### PR TITLE
Fixed flickering bug.

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
@@ -36,7 +36,7 @@ import javax.swing.SwingUtilities;
 import javax.swing.UIManager;
 import javax.swing.UnsupportedLookAndFeelException;
 
-public final class ClientUI extends JFrame implements ComponentListener
+public final class ClientUI extends JFrame
 {
 	private ClientPanel panel;
 
@@ -48,7 +48,6 @@ public final class ClientUI extends JFrame implements ComponentListener
 		setLocationRelativeTo(getOwner());
 		setMinimumSize(getSize());
 		setResizable(true);
-		this.addComponentListener(this);
 	}
 	
 	private void init() throws Exception
@@ -85,25 +84,5 @@ public final class ClientUI extends JFrame implements ComponentListener
 		{
 			System.exit(0);
 		}
-	}
-
-	@Override
-	public void componentResized(ComponentEvent e)
-	{
-	}
-
-	@Override
-	public void componentMoved(ComponentEvent e)
-	{
-	}
-
-	@Override
-	public void componentShown(ComponentEvent e)
-	{
-	}
-
-	@Override
-	public void componentHidden(ComponentEvent e)
-	{
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
@@ -90,7 +90,8 @@ public final class ClientUI extends JFrame implements ComponentListener
 	@Override
 	public void componentResized(ComponentEvent e)
 	{
-		SwingUtilities.invokeLater(() -> pack()); // is this right?
+		//Causes flickering when smaller than min size.
+		//SwingUtilities.invokeLater(() -> pack());
 	}
 
 	@Override

--- a/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
@@ -90,8 +90,6 @@ public final class ClientUI extends JFrame implements ComponentListener
 	@Override
 	public void componentResized(ComponentEvent e)
 	{
-		//Causes flickering when smaller than min size.
-		//SwingUtilities.invokeLater(() -> pack());
 	}
 
 	@Override


### PR DESCRIPTION
When the Client was smaller than the minimum size it would flicker on redraw, commenting this line out fixes that, but introduces a new bug that makes the RS Load screen not centered on first load, but as soon as you resize it, it gets centered.