### PR TITLE
runelite-api: Add check for tile being null before creating wrapper

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/Region.java
+++ b/runelite-api/src/main/java/net/runelite/api/Region.java
@@ -42,7 +42,7 @@ public class Region
 		return Arrays.stream(region.getTiles())
 			.map(tile1 -> Arrays.stream(tile1)
 				.map(tile2 -> Arrays.stream(tile2)
-					.map(tile3 -> new Tile(client, tile3))
+					.map(tile3 -> tile3 != null ? new Tile(client, tile3) : null)
 					.toArray(Tile[]::new)
 				).toArray(Tile[][]::new)
 			).toArray(Tile[][][]::new);


### PR DESCRIPTION
I noticed that when the Ground Items debug is enabled in devtools that there are a lot of NullPointerExceptions being thrown if you are not on the ground floor in the game world. After looking at the stack trace I can see that `net.runelite.api.Region#getTiles` hydrates a 3d array of Tiles where the tile could be null.

I'm using `isEmpty` as a stub for a method name to check if the underlying `net.runelite.rs.api.Tile` is `null` to avoid NPEs being thrown. This check should probably be in place for all other methods in `net.runelite.api.Tile`, or the constructor should require the `net.runelite.rs.api.Tile` object to be non-null.