### PR TITLE
cache: Add mapping for opcode 1301

### DIFF
--- a/cache/src/main/java/net/runelite/cache/script/Instructions.java
+++ b/cache/src/main/java/net/runelite/cache/script/Instructions.java
@@ -113,7 +113,7 @@ public class Instructions
 		add(1212, 2, 0);
 		// and 1300-1400 and 2300-2400
 		add(1300, 1, 0, 1, 0);
-		add(1301, 2, 0);
+		add(Opcodes.WIDGET_PUT_DRAG_PARENT, "widget_put_drag_parent", 2, 0);
 		add(1302, 1, 0);
 		add(1303, 1, 0);
 		add(1304, 1, 0);
@@ -193,7 +193,7 @@ public class Instructions
 		add(2212, 3, 0);
 		// 2300-2400
 		add(2300, 2, 0, 1, 0);
-		add(2301, 3, 0);
+		add(Opcodes.WIDGET_PUT_DRAG_PARENT_WIDGET, "widget_put_drag_parent_widget", 3, 0);
 		add(2302, 2, 0);
 		add(2303, 2, 0);
 		add(2304, 2, 0);

--- a/cache/src/main/java/net/runelite/cache/script/Opcodes.java
+++ b/cache/src/main/java/net/runelite/cache/script/Opcodes.java
@@ -54,6 +54,7 @@ public class Opcodes
 	public static final int WIDGET_PUT_SCROLLWIDTHHEIGHT = 1120;
 	public static final int WIDGET_PUT_MODELID_2 = 1201;
 	public static final int WIDGET_PUT_MODELID_3 = 1202;
+	public static final int WIDGET_PUT_DRAG_PARENT = 1301;
 	public static final int WIDGET_PUT_NAME = 1305;
 	public static final int WIDGET_PUT_ACTIONS_NULL = 1307;
 	public static final int WIDGET_GET_RELATIVEX = 1500;
@@ -88,6 +89,7 @@ public class Opcodes
 	public static final int WIDGET_PUT_SCROLLWIDTHHEIGHT_WIDGET = WIDGET_PUT_SCROLLWIDTHHEIGHT + 1000;
 	public static final int WIDGET_PUT_MODELID_2_WIDGET = WIDGET_PUT_MODELID_2 + 1000;
 	public static final int WIDGET_PUT_MODELID_3_WIDGET = WIDGET_PUT_MODELID_3 + 1000;
+	public static final int WIDGET_PUT_DRAG_PARENT_WIDGET = WIDGET_PUT_DRAG_PARENT + 1000;
 	public static final int WIDGET_PUT_NAME_WIDGET = WIDGET_PUT_NAME + 1000;
 	public static final int WIDGET_PUT_ACTIONS_NULL_WIDGET = WIDGET_PUT_ACTIONS_NULL + 1000;
 	public static final int WIDGET_GET_RELATIVEX_WIDGET = WIDGET_GET_RELATIVEX + 1000;


### PR DESCRIPTION
This adds a mapping for opcode 1301 for setting the `dragParent` on a `Widget`.