### PR TITLE
NPCQuery - Add idEquals

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/queries/NPCQuery.java
+++ b/runelite-api/src/main/java/net/runelite/api/queries/NPCQuery.java
@@ -40,4 +40,21 @@ public class NPCQuery extends ActorQuery<NPC, NPCQuery>
 				.filter(predicate)
 				.toArray(NPC[]::new);
 	}
+	
+	@SuppressWarnings("unchecked")
+	public NPCQuery idEquals(int... ids)
+	{
+		predicate = and(object ->
+		{
+			for (int id : ids)
+			{
+				if (object.getId() == id)
+				{
+					return true;
+				}
+			}
+			return false;
+		});
+		return (NPCQuery) this;
+	}
 }


### PR DESCRIPTION
code is reused from the TileObjectQuery class