### PR TITLE
Changes/upgrades to GroundItems

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
@@ -40,9 +40,28 @@ public interface GroundItemsConfig
 		name = "Enabled",
 		description = "Configures whether or not item names/quantities are displayed"
 	)
-
 	default boolean enabled()
 	{
 		return true;
+	}
+
+	@ConfigItem(
+		keyName = "showGEPrice",
+		name = "Show Grand Exchange Prices",
+		description = "Configures whether or not to draw GE prices alongside ground items"
+	)
+	default boolean showGEPrice()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		keyName = "showHAValue",
+		name = "Show High Alchemy Values",
+		description = "Configure whether or not to draw High Alchemy values alongside ground items"
+	)
+	default boolean showHAValue()
+	{
+		return false;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
@@ -183,6 +183,12 @@ public class GroundItemsOverlay extends Overlay
 						}
 					}
 
+					// sets item ID to unnoted version, if noted
+					if (item.getNote() != -1)
+					{
+						itemId = item.getLinkedNoteId();
+					}
+
 					Color textColor = Color.WHITE; // Color to use when drawing the ground item
 					ItemPrice itemPrice = itemManager.get(itemId);
 					if (itemPrice != null)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
@@ -73,6 +73,8 @@ public class GroundItemsOverlay extends Overlay
 	// Threshold for highlighting items as pink.
 	private static final int INSANE_VALUE = 10_000_000;
 	private static final Color FADED_PINK = new Color(255, 102, 178);
+	// Used when getting High Alchemy value - multiplied by general store price.
+	private static final float HIGH_ALCHEMY_CONSTANT = 0.6f;
 
 	private final Client client = RuneLite.getClient();
 	private final GroundItemsConfig config;
@@ -191,7 +193,7 @@ public class GroundItemsOverlay extends Overlay
 
 					Color textColor = Color.WHITE; // Color to use when drawing the ground item
 					ItemPrice itemPrice = itemManager.get(itemId);
-					if (itemPrice != null)
+					if (itemPrice != null && config.showGEPrice())
 					{
 						int cost = itemPrice.getPrice() * quantity;
 						// set the color according to rarity, if possible
@@ -214,6 +216,13 @@ public class GroundItemsOverlay extends Overlay
 
 						itemStringBuilder.append(" (EX: ")
 							.append(ItemManager.quantityToStackSize(cost))
+							.append(" gp)");
+					}
+
+					if (config.showHAValue())
+					{
+						itemStringBuilder.append(" (HA: ")
+							.append(Math.round(item.getPrice() * HIGH_ALCHEMY_CONSTANT))
 							.append(" gp)");
 					}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
@@ -94,11 +94,11 @@ public class GroundItemsOverlay extends Overlay
 			return null;
 		}
 
-		Widget bank = client.getWidget(WidgetInfo.BANK_ITEM_CONTAINER);
-		if (bank != null && !bank.isHidden())
-		{
-			return null;
-		}
+		//Widget bank = client.getWidget(WidgetInfo.BANK_ITEM_CONTAINER);
+		//if (bank != null && !bank.isHidden())
+		//{
+		//	return null;
+		//}
 
 		Region region = client.getRegion();
 		Tile[][][] tiles = region.getTiles();

--- a/runescape-api/src/main/java/net/runelite/rs/api/ItemComposition.java
+++ b/runescape-api/src/main/java/net/runelite/rs/api/ItemComposition.java
@@ -27,11 +27,61 @@ package net.runelite.rs.api;
 
 import net.runelite.mapping.Import;
 
+/**
+ * ItemComposition is an interface that represents the various properties
+ * of an item. Imports several values from rs-client/ItemComposition,
+ * and allows direct access to them by calling these methods.
+ */
 public interface ItemComposition
 {
+	/**
+	 * Returns the item's name as a string.
+	 * @return the name of the item
+	 */
 	@Import("name")
 	String getName();
 
+	/**
+	 * Returns the item's ID. A list of item IDs can be
+	 * found in net.runelite.api.ItemID.
+	 * @return the item's ID as an integer
+	 */
+	@Import("id")
+	int getId();
+
+	/**
+	 * Returns a result that depends on whether the item
+	 * is in noted form or not.
+	 * @return 799 if noted, -1 if unnoted
+	 */
+	@Import("notedTemplate")
+	int getNote();
+
+	/**
+	 * Returns the item ID of the noted/unnoted counterpart.
+	 * For example, if you call this on an unnoted monkfish(ID 7946),
+	 * this method will return the ID of a noted monkfish(ID 7947),
+	 * and vice versa.
+	 * @return the ID that is linked to this item in noted/unnoted form.
+	 */
+	@Import("note")
+	int getLinkedNoteId();
+
+	/**
+	 * Returns the store price of the item. Even if the item cannot
+	 * be found in a store, all items have a store price from which the
+	 * High and Low Alchemy values are calculated. Multiply the price by
+	 * 0.6 to get the High Alchemy value, or 0.4 to get the Low Alchemy
+	 * value.
+	 * @return the general store value of the item
+	 */
+	@Import("price")
+	int getPrice();
+
+	/**
+	 * Returns whether or not the item is members-only.
+	 * @return true if members-only, false otherwise.
+	 */
 	@Import("isMembers")
 	boolean isMembers();
 


### PR DESCRIPTION
++ Added support for High Alchemy values, if enabled. Disabled by default.

++ Fixed issue where noted items would not have their GE values calculated.

++ Added configuration key for GE values, can be enabled or disabled by itself. Enabled by default.

-- Removed/commented out the code that hides the overlay when the bank is opened. I'm still trying to find the source of the bug that causes the overlay to permanantly disappear(requiring a client restart) after opening the bank interface in certain banks.