### PR TITLE
Fix for minimum client size

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
@@ -63,6 +63,7 @@ public final class ClientUI extends JFrame
 	private void init() throws Exception
 	{
 		setDefaultCloseOperation(DO_NOTHING_ON_CLOSE);
+		setMinimumSize(new Dimension(PANEL_WIDTH, PANEL_HEIGHT));
 
 		addWindowListener(new WindowAdapter()
 		{


### PR DESCRIPTION
-The minimum size isn't set until sidebar is expanded allowing you to minimize client until game crashes.