### PR TITLE
Fix runelite-client when running on Java 9

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/config/ConfigInvocationHandler.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/ConfigInvocationHandler.java
@@ -126,7 +126,7 @@ class ConfigInvocationHandler implements InvocationHandler
 		constructor.setAccessible(true);
 
 		Class<?> declaringClass = method.getDeclaringClass();
-		return constructor.newInstance(declaringClass, MethodHandles.Lookup.PRIVATE)
+		return constructor.newInstance(declaringClass, MethodHandles.Lookup.PUBLIC | MethodHandles.Lookup.PRIVATE)
 			.unreflectSpecial(method, declaringClass)
 			.bindTo(proxy)
 			.invokeWithArguments(args);


### PR DESCRIPTION
Gets rid of the extreme "access to public member failed" spam in the console along with settings not being loaded, when running the client on Java 9.