### PR TITLE
Fix running Maven install on JDK9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -149,7 +149,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>2.10.4</version>
+				<version>3.0.0-M1</version>
 				<executions>
 					<execution>
 						<id>attach-javadocs</id>


### PR DESCRIPTION
Gets rid of the fatal error explained in https://issues.apache.org/jira/browse/MJAVADOC-488 by updating maven-javadoc-plugin to the latest version.