### PR TITLE
Field mixins

### DIFF
--- a/runelite-mixins/src/main/java/net/runelite/api/mixins/Inject.java
+++ b/runelite-mixins/src/main/java/net/runelite/api/mixins/Inject.java
@@ -30,7 +30,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 @Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.METHOD)
+@Target({ElementType.METHOD, ElementType.FIELD})
 public @interface Inject
 {
 

--- a/runescape-client-injector-plugin/src/main/java/net/runelite/injector/MixinInjector.java
+++ b/runescape-client-injector-plugin/src/main/java/net/runelite/injector/MixinInjector.java
@@ -213,7 +213,8 @@ public class MixinInjector
 					}
 
 					Field injected = injectedFields.get(field);
-					if (injected != null) {
+					if (injected != null)
+					{
 						gfi.setField(injected.getPoolField());
 					}
 				}
@@ -223,7 +224,8 @@ public class MixinInjector
 					Field field = gfi.getMyField();
 
 					Field injected = injectedFields.get(field);
-					if (injected != null) {
+					if (injected != null)
+					{
 						gfi.setField(injected.getPoolField());
 					}
 				}


### PR DESCRIPTION
Adds support for injecting fields into game classes through mixins.

Example usage:
```java
@Mixin(RSActor.class)
public abstract class RSActorMixin implements RSActor
{
        // inject "foo" into RSActor
	@Inject
	public int foo; 

        // inject "bar()" into RSActor
        @Inject
	@Override
	public Actor bar()
	{
                // references will be modified to RSActor.foo from RSActorMixin.foo
		foo = 1; 
		System.out.println(foo);
        }
}