### PR TITLE
Make groundItem highlighted items case-insensitive

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
@@ -151,7 +151,7 @@ public class GroundItemsOverlay extends Overlay
 		String configItems = config.getHiddenItems();
 		List<String> hiddenItems = Arrays.asList(configItems.split(DELIMITER_REGEX));
 		// note: both of these lists are immutable
-		configItems = config.getHighlightItems();
+		configItems = config.getHighlightItems().toLowerCase();
 		List<String> highlightedItems = Arrays.asList(configItems.split(DELIMITER_REGEX));
 
 		Region region = client.getRegion();
@@ -289,7 +289,7 @@ public class GroundItemsOverlay extends Overlay
 							.append(" gp)");
 					}
 
-					if (highlightedItems.contains(item.getName()))
+					if (highlightedItems.contains(item.getName().toLowerCase()))
 					{
 						textColor = PURPLE;
 					}


### PR DESCRIPTION
Current bug where "uncut sapphire" in highlight list does not match "Uncut sapphire" on ground