### PR TITLE
Remove the black line below the game applet

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
@@ -44,8 +44,8 @@ public final class ClientUI extends JFrame
 {
 	private static final Logger logger = LoggerFactory.getLogger(ClientUI.class);
 
-	private static final int PANEL_WIDTH = 805;
-	private static final int PANEL_HEIGHT = 541;
+	private static final int PANEL_WIDTH = 809;
+	private static final int PANEL_HEIGHT = 536;
 	private static final int EXPANDED_WIDTH = PANEL_WIDTH + PluginPanel.PANEL_WIDTH;
 
 	private JPanel container;


### PR DESCRIPTION
Removes this black line:

![image](https://i.imgur.com/ubANjgV.png)
(image taken by Xrio)

Also fixes a minor error with the panel width where resizing the frame horizontally would make the plugin bar overlap a bit over the game.