### PR TITLE
InfoBox tooltip fixes

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/infobox/InfoBoxOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/infobox/InfoBoxOverlay.java
@@ -121,14 +121,14 @@ public class InfoBoxOverlay extends Overlay
 				continue;
 			}
 
-			Rectangle bounds = new Rectangle((int) overlayBounds.getX() + x, (int) overlayBounds.getY(), BOXSIZE, BOXSIZE);
-			if (bounds.contains(mouse.getX(), mouse.getY()))
+			Rectangle infoboxBounds = new Rectangle((int) overlayBounds.getX() + x, (int) overlayBounds.getY(), BOXSIZE, BOXSIZE);
+			if (infoboxBounds.contains(mouseX, mouseY))
 			{
 				int tooltipWidth = metrics.stringWidth(tooltip);
 				int height = metrics.getHeight();
 
-				int tooltipX = mouseX - (int) bounds.getX();
-				int tooltipY = mouseY - (int) bounds.getY();
+				int tooltipX = mouseX - (int) infoboxBounds.getX();
+				int tooltipY = mouseY - (int) infoboxBounds.getY();
 				if (tooltipY - height < 0)
 					tooltipY = height;
 

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/infobox/InfoBoxOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/infobox/InfoBoxOverlay.java
@@ -127,7 +127,6 @@ public class InfoBoxOverlay extends Overlay
 				int tooltipWidth = metrics.stringWidth(tooltip);
 				int height = metrics.getHeight();
 
-				int tooltipX = mouseX;
 				int tooltipY = mouseY - (int) infoboxBounds.getY();
 				if (tooltipY - height < 0)
 					tooltipY = height;
@@ -136,15 +135,15 @@ public class InfoBoxOverlay extends Overlay
 				graphics.setColor(gray);
 
 				// Draws the background rect
-				graphics.fillRect(tooltipX, tooltipY - height, tooltipWidth + 6, height);
+				graphics.fillRect(mouseX, tooltipY - height, tooltipWidth + 6, height);
 
 				// Draws the outline of the rect
 				graphics.setColor(Color.yellow);
-				graphics.drawRect(tooltipX, tooltipY - height, tooltipWidth + 6, height);
+				graphics.drawRect(mouseX, tooltipY - height, tooltipWidth + 6, height);
 
 				// Tooltip text
 				graphics.setColor(Color.WHITE);
-				graphics.drawString(tooltip, tooltipX + 3, tooltipY - height / 2 + 5);
+				graphics.drawString(tooltip, mouseX + 3, tooltipY - height / 2 + 5);
 			}
 
 			x += BOXSIZE + SEPARATOR;

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/infobox/InfoBoxOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/infobox/InfoBoxOverlay.java
@@ -125,19 +125,24 @@ public class InfoBoxOverlay extends Overlay
 				int tooltipWidth = metrics.stringWidth(tooltip);
 				int height = metrics.getHeight();
 
+				int tooltipX = mouseX - (int) bounds.getX();
+				int tooltipY = mouseY - (int) bounds.getY();
+				if (tooltipY - height < 0)
+					tooltipY = height;
+
 				Color gray = new Color(Color.darkGray.getRed(), Color.darkGray.getGreen(), Color.darkGray.getBlue(), 190);
 				graphics.setColor(gray);
 
 				// Draws the background rect
-				graphics.fillRect(mouseX, mouseY - (height / 2), tooltipWidth + 6, height);
+				graphics.fillRect(tooltipX, tooltipY - height, tooltipWidth + 6, height);
 
 				// Draws the outline of the rect
-				graphics.setColor(Color.BLACK);
-				graphics.drawRect(mouseX, mouseY - (height / 2), tooltipWidth + 6, height);
+				graphics.setColor(Color.yellow);
+				graphics.drawRect(tooltipX, tooltipY - height, tooltipWidth + 6, height);
 
 				// Tooltip text
 				graphics.setColor(Color.WHITE);
-				graphics.drawString(tooltip, mouseX + 3, mouseY + 5);
+				graphics.drawString(tooltip, tooltipX + 3, tooltipY - height / 2 + 5);
 			}
 
 			x += BOXSIZE + SEPARATOR;

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/infobox/InfoBoxOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/infobox/InfoBoxOverlay.java
@@ -108,6 +108,8 @@ public class InfoBoxOverlay extends Overlay
 			graphics.setColor(color);
 			graphics.drawString(str, x + ((BOXSIZE - metrics.stringWidth(str)) / 2), BOXSIZE - SEPARATOR);
 
+			x += BOXSIZE + SEPARATOR;
+
 			if (overlayBounds == null)
 			{
 				continue;
@@ -144,8 +146,6 @@ public class InfoBoxOverlay extends Overlay
 				graphics.setColor(Color.WHITE);
 				graphics.drawString(tooltip, tooltipX + 3, tooltipY - height / 2 + 5);
 			}
-
-			x += BOXSIZE + SEPARATOR;
 		}
 
 		return new Dimension(width, BOXSIZE);

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/infobox/InfoBoxOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/infobox/InfoBoxOverlay.java
@@ -108,16 +108,16 @@ public class InfoBoxOverlay extends Overlay
 			graphics.setColor(color);
 			graphics.drawString(str, x + ((BOXSIZE - metrics.stringWidth(str)) / 2), BOXSIZE - SEPARATOR);
 
-			x += BOXSIZE + SEPARATOR;
-
 			if (overlayBounds == null)
 			{
+				x += BOXSIZE + SEPARATOR;
 				continue;
 			}
 
 			String tooltip = box.getTooltip();
 			if (tooltip == null || tooltip.isEmpty())
 			{
+				x += BOXSIZE + SEPARATOR;
 				continue;
 			}
 
@@ -127,7 +127,7 @@ public class InfoBoxOverlay extends Overlay
 				int tooltipWidth = metrics.stringWidth(tooltip);
 				int height = metrics.getHeight();
 
-				int tooltipX = mouseX - (int) infoboxBounds.getX();
+				int tooltipX = mouseX;
 				int tooltipY = mouseY - (int) infoboxBounds.getY();
 				if (tooltipY - height < 0)
 					tooltipY = height;
@@ -146,6 +146,8 @@ public class InfoBoxOverlay extends Overlay
 				graphics.setColor(Color.WHITE);
 				graphics.drawString(tooltip, tooltipX + 3, tooltipY - height / 2 + 5);
 			}
+
+			x += BOXSIZE + SEPARATOR;
 		}
 
 		return new Dimension(width, BOXSIZE);


### PR DESCRIPTION
Tooltips now display properly with other left rendered overlays present
InfoBoxes no longer stack when they don't have tooltips (Timers plugin)