### PR TITLE
Fix equipItemQuery to remove number after unequip

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/queries/EquipmentItemQuery.java
+++ b/runelite-api/src/main/java/net/runelite/api/queries/EquipmentItemQuery.java
@@ -87,11 +87,13 @@ public class EquipmentItemQuery extends WidgetItemQuery
 			for (WidgetInfo slot : slots)
 			{
 				Widget widget = client.getWidget(slot).getChild(1);
+				// Check if background icon is hidden. if hidden, item is equipped.
+				boolean equipped = client.getWidget(slot).getChild(2).isHidden();
 				// set bounds to same size as default inventory
 				Rectangle bounds = widget.getBounds();
 				bounds.setBounds(bounds.x - 1, bounds.y - 1, 32, 32);
 				// Index is set to 0 because there is no set in stone order of equipment slots
-				widgetItems.add(new WidgetItem(widget.getItemId(), widget.getItemQuantity(), 0, bounds));
+				widgetItems.add(new WidgetItem(equipped ? widget.getItemId() : -1, widget.getItemQuantity(), 0, bounds));
 			}
 		}
 		return widgetItems;

--- a/runelite-api/src/main/java/net/runelite/api/queries/EquipmentItemQuery.java
+++ b/runelite-api/src/main/java/net/runelite/api/queries/EquipmentItemQuery.java
@@ -86,14 +86,15 @@ public class EquipmentItemQuery extends WidgetItemQuery
 			}
 			for (WidgetInfo slot : slots)
 			{
-				Widget widget = client.getWidget(slot).getChild(1);
+				Widget parentWidget = client.getWidget(slot);
+				Widget itemWidget = parentWidget.getChild(1);
 				// Check if background icon is hidden. if hidden, item is equipped.
-				boolean equipped = client.getWidget(slot).getChild(2).isHidden();
+				boolean equipped = parentWidget.getChild(2).isHidden();
 				// set bounds to same size as default inventory
-				Rectangle bounds = widget.getBounds();
+				Rectangle bounds = itemWidget.getBounds();
 				bounds.setBounds(bounds.x - 1, bounds.y - 1, 32, 32);
 				// Index is set to 0 because there is no set in stone order of equipment slots
-				widgetItems.add(new WidgetItem(equipped ? widget.getItemId() : -1, widget.getItemQuantity(), 0, bounds));
+				widgetItems.add(new WidgetItem(equipped ? itemWidget.getItemId() : -1, itemWidget.getItemQuantity(), 0, bounds));
 			}
 		}
 		return widgetItems;


### PR DESCRIPTION
Fixed equipped item queries to return -1 (default value for no item in slot) for itemIds that remain in Widgets after removing them:
![equipquerychg](https://user-images.githubusercontent.com/17709869/32087814-10b73416-baa4-11e7-82fa-60b78eabd7ba.gif)
