### PR TITLE
Move class members to their original classes (runescape-client)

### DIFF
--- a/deobfuscator/src/main/java/net/runelite/asm/Field.java
+++ b/deobfuscator/src/main/java/net/runelite/asm/Field.java
@@ -38,7 +38,7 @@ public class Field
 {
 	public static final int ACCESS_MODIFIERS = ACC_PUBLIC | ACC_PRIVATE | ACC_PROTECTED;
 
-	private final ClassFile classFile;
+	private ClassFile classFile;
 
 	private int accessFlags;
 	private String name;
@@ -69,6 +69,11 @@ public class Field
 	public ClassFile getClassFile()
 	{
 		return classFile;
+	}
+
+	public void setClassFile(ClassFile classFile)
+	{
+		this.classFile = classFile;
 	}
 
 	public int getAccessFlags()

--- a/deobfuscator/src/main/java/net/runelite/asm/Method.java
+++ b/deobfuscator/src/main/java/net/runelite/asm/Method.java
@@ -48,7 +48,7 @@ public class Method
 {
 	public static final int ACCESS_MODIFIERS = ACC_PUBLIC | ACC_PRIVATE | ACC_PROTECTED;
 
-	private final ClassFile classFile;
+	private ClassFile classFile;
 
 	private int accessFlags;
 	private String name;
@@ -71,6 +71,11 @@ public class Method
 	public ClassFile getClassFile()
 	{
 		return classFile;
+	}
+
+	public void setClassFile(ClassFile classFile)
+	{
+		this.classFile = classFile;
 	}
 
 	@Override

--- a/deobfuscator/src/main/java/net/runelite/asm/Method.java
+++ b/deobfuscator/src/main/java/net/runelite/asm/Method.java
@@ -29,6 +29,7 @@ import java.util.List;
 import net.runelite.asm.attributes.Annotations;
 import net.runelite.asm.attributes.Code;
 import net.runelite.asm.attributes.Exceptions;
+import net.runelite.asm.attributes.LineNumbers;
 import net.runelite.asm.attributes.annotation.Annotation;
 import net.runelite.asm.attributes.code.Instruction;
 import net.runelite.asm.attributes.code.instruction.types.LVTInstruction;
@@ -54,6 +55,7 @@ public class Method
 	private Signature arguments;
 	private Exceptions exceptions;
 	private Annotations annotations;
+	private LineNumbers lineNumbers;
 	private Code code;
 
 	public Method(ClassFile classFile, String name, Signature signature)
@@ -63,6 +65,7 @@ public class Method
 		this.arguments = signature;
 		exceptions = new Exceptions();
 		annotations = new Annotations();
+		lineNumbers = new LineNumbers();
 	}
 
 	public ClassFile getClassFile()
@@ -225,6 +228,11 @@ public class Method
 	public Annotations getAnnotations()
 	{
 		return annotations;
+	}
+
+	public LineNumbers getLineNumbers()
+	{
+		return lineNumbers;
 	}
 
 	@SuppressWarnings("unchecked")

--- a/deobfuscator/src/main/java/net/runelite/asm/attributes/Annotations.java
+++ b/deobfuscator/src/main/java/net/runelite/asm/attributes/Annotations.java
@@ -43,7 +43,12 @@ public class Annotations
 	
 	public void addAnnotation(Annotation annotation)
 	{
-		annotations.add(annotation);
+		addAnnotation(annotations.size(), annotation);
+	}
+
+	public void addAnnotation(int idx, Annotation annotation)
+	{
+		annotations.add(idx, annotation);
 	}
 
 	public void removeAnnotation(Annotation annotation)
@@ -68,12 +73,17 @@ public class Annotations
 	{
 		return annotations.size();
 	}
-	
+
 	public Annotation addAnnotation(Type type, String name, Object value)
+	{
+		return addAnnotation(annotations.size(), type, name, value);
+	}
+	
+	public Annotation addAnnotation(int idx, Type type, String name, Object value)
 	{
 		Annotation annotation = new Annotation(this);
 		annotation.setType(type);
-		addAnnotation(annotation);
+		addAnnotation(idx, annotation);
 		
 		Element element = new Element(annotation);
 		element.setName(name);

--- a/deobfuscator/src/main/java/net/runelite/asm/attributes/LineNumbers.java
+++ b/deobfuscator/src/main/java/net/runelite/asm/attributes/LineNumbers.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2017, UniquePassive <https://github.com/uniquepassive>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.asm.attributes;
+
+import net.runelite.asm.attributes.code.Label;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class LineNumbers
+{
+	private final Map<Label, Integer> lineNumbers = new HashMap<>();
+
+	public Map<Label, Integer> getLineNumbers()
+	{
+		return lineNumbers;
+	}
+
+	public void setLineNumber(Label label, int line)
+	{
+		lineNumbers.put(label, line);
+	}
+
+	public int size()
+	{
+		return lineNumbers.size();
+	}
+}

--- a/deobfuscator/src/main/java/net/runelite/asm/attributes/code/Label.java
+++ b/deobfuscator/src/main/java/net/runelite/asm/attributes/code/Label.java
@@ -93,6 +93,11 @@ public class Label extends NOP
 		Instruction next;
 		do
 		{
+			if (i + 1 >= ins.getInstructions().size())
+			{
+				return null;
+			}
+
 			next = ins.getInstructions().get(i + 1);
 			++i;
 		}

--- a/deobfuscator/src/main/java/net/runelite/asm/visitors/CodeVisitor.java
+++ b/deobfuscator/src/main/java/net/runelite/asm/visitors/CodeVisitor.java
@@ -365,6 +365,12 @@ public class CodeVisitor extends MethodVisitor
 	}
 
 	@Override
+	public void visitLineNumber(int line, Label start)
+	{
+		method.getLineNumbers().setLineNumber(code.getInstructions().findOrCreateLabel(start), line);
+	}
+
+	@Override
 	public void visitTryCatchBlock(Label start, Label end, Label handler, String type)
 	{
 		Exceptions exceptions = code.getExceptions();

--- a/deobfuscator/src/main/java/net/runelite/deob/Deob.java
+++ b/deobfuscator/src/main/java/net/runelite/deob/Deob.java
@@ -41,6 +41,7 @@ import net.runelite.deob.deobfuscators.PacketHandlerOrder;
 import net.runelite.deob.deobfuscators.RenameUnique;
 import net.runelite.deob.deobfuscators.RuntimeExceptions;
 import net.runelite.deob.deobfuscators.UnreachedCode;
+import net.runelite.deob.deobfuscators.MoveBackMethods;
 import net.runelite.deob.deobfuscators.UnusedClass;
 import net.runelite.deob.deobfuscators.UnusedFields;
 import net.runelite.deob.deobfuscators.UnusedMethods;
@@ -93,6 +94,7 @@ public class Deob
 		// remove unused methods - this leaves Code with no instructions,
 		// which is not valid, so unused methods is run after
 		run(group, new UnreachedCode());
+		run(group, new MoveBackMethods());
 		run(group, new UnusedMethods());
 
 		// remove illegal state exceptions, frees up some parameters

--- a/deobfuscator/src/main/java/net/runelite/deob/Deob.java
+++ b/deobfuscator/src/main/java/net/runelite/deob/Deob.java
@@ -95,7 +95,7 @@ public class Deob
 		run(group, new IllegalStateExceptions());
 
 		// moves static members to either their original classes or the Static class
-		// this also removes unused instructions in reached methods
+		// this must be run before unreached code is removed
 		run(group, new MemberMover());
 
 		// remove unused methods - this leaves Code with no instructions,

--- a/deobfuscator/src/main/java/net/runelite/deob/Deob.java
+++ b/deobfuscator/src/main/java/net/runelite/deob/Deob.java
@@ -29,6 +29,7 @@ import java.io.File;
 import java.io.IOException;
 import net.runelite.asm.ClassGroup;
 import net.runelite.asm.execution.Execution;
+import net.runelite.deob.deobfuscators.membermover.MemberMover;
 import net.runelite.deob.deobfuscators.transformers.GetPathTransformer;
 import net.runelite.deob.deobfuscators.CastNull;
 import net.runelite.deob.deobfuscators.constparam.ConstantParameter;
@@ -41,7 +42,6 @@ import net.runelite.deob.deobfuscators.PacketHandlerOrder;
 import net.runelite.deob.deobfuscators.RenameUnique;
 import net.runelite.deob.deobfuscators.RuntimeExceptions;
 import net.runelite.deob.deobfuscators.UnreachedCode;
-import net.runelite.deob.deobfuscators.MoveBackMethods;
 import net.runelite.deob.deobfuscators.UnusedClass;
 import net.runelite.deob.deobfuscators.UnusedFields;
 import net.runelite.deob.deobfuscators.UnusedMethods;
@@ -94,9 +94,9 @@ public class Deob
 		// remove illegal state exceptions, frees up some parameters
 		run(group, new IllegalStateExceptions());
 
-		// moves back static methods to their original classes
+		// moves static members to either their original classes or the Static class
 		// this also removes unused instructions in reached methods
-		run(group, new MoveBackMethods());
+		run(group, new MemberMover());
 
 		// remove unused methods - this leaves Code with no instructions,
 		// which is not valid, so unused methods is run after

--- a/deobfuscator/src/main/java/net/runelite/deob/Deob.java
+++ b/deobfuscator/src/main/java/net/runelite/deob/Deob.java
@@ -91,14 +91,17 @@ public class Deob
 		// remove except RuntimeException
 		run(group, new RuntimeExceptions());
 
+		// remove illegal state exceptions, frees up some parameters
+		run(group, new IllegalStateExceptions());
+
+		// moves back static methods to their original classes
+		// this also removes unused instructions in reached methods
+		run(group, new MoveBackMethods());
+
 		// remove unused methods - this leaves Code with no instructions,
 		// which is not valid, so unused methods is run after
 		run(group, new UnreachedCode());
-		run(group, new MoveBackMethods());
 		run(group, new UnusedMethods());
-
-		// remove illegal state exceptions, frees up some parameters
-		run(group, new IllegalStateExceptions());
 
 		// remove constant logically dead parameters
 		run(group, new ConstantParameter());

--- a/deobfuscator/src/main/java/net/runelite/deob/DeobAnnotations.java
+++ b/deobfuscator/src/main/java/net/runelite/deob/DeobAnnotations.java
@@ -37,6 +37,7 @@ import java.util.List;
 
 public class DeobAnnotations
 {
+	public static final Type OBFUSCATED_OWNER = new Type("Lnet/runelite/mapping/ObfuscatedOwner;");
 	public static final Type OBFUSCATED_NAME = new Type("Lnet/runelite/mapping/ObfuscatedName;");
 	public static final Type EXPORT = new Type("Lnet/runelite/mapping/Export;");
 	public static final Type IMPLEMENTS = new Type("Lnet/runelite/mapping/Implements;");

--- a/deobfuscator/src/main/java/net/runelite/deob/DeobAnnotations.java
+++ b/deobfuscator/src/main/java/net/runelite/deob/DeobAnnotations.java
@@ -69,6 +69,11 @@ public class DeobAnnotations
 		return new Type(str);
 	}
 
+	public static String getObfuscatedOwner(Annotations an)
+	{
+		return getAnnotationValue(an, OBFUSCATED_OWNER);
+	}
+
 	public static String getObfuscatedName(Annotations an)
 	{
 		return getAnnotationValue(an, OBFUSCATED_NAME);

--- a/deobfuscator/src/main/java/net/runelite/deob/deobfuscators/MoveBackMethods.java
+++ b/deobfuscator/src/main/java/net/runelite/deob/deobfuscators/MoveBackMethods.java
@@ -1,0 +1,239 @@
+/*
+ * Copyright (c) 2016-2017, Adam <Adam@sigterm.info>
+ * Copyright (c) 2017, UniquePassive <https://github.com/uniquepassive>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.deob.deobfuscators;
+
+import net.runelite.asm.ClassFile;
+import net.runelite.asm.ClassGroup;
+import net.runelite.asm.Method;
+import net.runelite.asm.attributes.Code;
+import net.runelite.asm.attributes.code.Instruction;
+import net.runelite.asm.attributes.code.instruction.types.InvokeInstruction;
+import net.runelite.deob.Deob;
+import net.runelite.deob.Deobfuscator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+public class MoveBackMethods implements Deobfuscator
+{
+	private static final Logger logger = LoggerFactory.getLogger(MoveBackMethods.class);
+
+	private final Set<Method> methods = new HashSet<>();
+
+	private final Set<Method> unusedMethods = new HashSet<>();
+	private final Set<Method> usedMethods = new HashSet<>();
+
+	@Override
+	public void run(ClassGroup group)
+	{
+		group.buildClassGraph();
+		group.lookup();
+
+		for (ClassFile cf : group.getClasses())
+		{
+			for (Method method : cf.getMethods())
+			{
+				findMethods(method);
+			}
+		}
+
+		for (ClassFile cf : group.getClasses())
+		{
+			findUnusedMethods(cf);
+		}
+
+		findUsedMethods();
+
+		Map<Method, List<Method>> realMethodDummies = new HashMap<>();
+
+		for (Method m : usedMethods)
+		{
+			List<Integer> lineNumbers = getLineNumbers(m);
+
+			for (Method m2 : unusedMethods)
+			{
+				if (!m.getDescriptor().getReturnValue().equals(m2.getDescriptor().getReturnValue()))
+				{
+					continue;
+				}
+
+				// Used methods can have an extra parameter (the opaque predicate)
+				// Dummy methods cannot
+				if (m.getDescriptor().size() + 1 < m2.getDescriptor().size()
+						|| m.getDescriptor().size() - 1 > m2.getDescriptor().size())
+				{
+					continue;
+				}
+
+				List<Integer> lineNumbers2 = getLineNumbers(m2);
+
+				if (lineNumbers.size() != lineNumbers2.size()
+						|| !lineNumbers.containsAll(lineNumbers2))
+				{
+					continue;
+				}
+
+				realMethodDummies
+						.computeIfAbsent(m, k -> new ArrayList<>())
+						.add(m2);
+			}
+		}
+
+		AtomicInteger count = new AtomicInteger();
+
+		realMethodDummies.forEach((m, ml) ->
+		{
+			ClassFile cf = ml.get(0).getClassFile();
+
+			if (cf.getName().equals(m.getClassFile().getName()))
+			{
+				return;
+			}
+
+			boolean singleTarget = ml
+					.stream()
+					.map(m2 -> m2.getClassFile().getName())
+					.distinct()
+					.count() == 1;
+
+			if (!singleTarget)
+			{
+				return;
+			}
+
+			ClassFile oldOwner = m.getClassFile();
+
+			m.getClassFile().removeMethod(m);
+			cf.addMethod(m);
+			m.setClassFile(cf);
+
+			logger.info("Moved {}.{}{} to {}",
+					oldOwner.getName(), m.getName(), m.getDescriptor(), cf.getName());
+
+			count.incrementAndGet();
+		});
+
+		logger.info("Moved {}/{} static methods back to their original classes", count, usedMethods.size());
+
+		this.regeneratePool(group);
+	}
+
+	private void findMethods(Method method)
+	{
+		Code code = method.getCode();
+
+		if (code == null)
+		{
+			return;
+		}
+
+		for (Instruction i : code.getInstructions().getInstructions())
+		{
+			if (!(i instanceof InvokeInstruction))
+			{
+				continue;
+			}
+
+			InvokeInstruction ii = (InvokeInstruction) i;
+
+			methods.addAll(ii.getMethods());
+		}
+	}
+
+	private void findUnusedMethods(ClassFile cf)
+	{
+		boolean extendsApplet = extendsApplet(cf);
+
+		for (Method method : new ArrayList<>(cf.getMethods()))
+		{
+			if (!method.isStatic())
+			{
+				continue;
+			}
+
+			// constructors can't be renamed, but are obfuscated
+			if (!Deob.isObfuscated(method.getName()) && !method.getName().equals("<init>"))
+			{
+				continue;
+			}
+
+			if (extendsApplet && method.getName().equals("<init>"))
+			{
+				continue;
+			}
+
+			if (!methods.contains(method))
+			{
+				unusedMethods.add(method);
+			}
+		}
+	}
+
+	private static boolean extendsApplet(ClassFile cf)
+	{
+		if (cf.getParent() != null)
+		{
+			return extendsApplet(cf.getParent());
+		}
+		return cf.getSuperName().equals("java/applet/Applet");
+	}
+
+	private void findUsedMethods()
+	{
+		Set<Method> usedMethods = methods
+				.stream()
+				.filter(Method::isStatic)
+				.filter(m -> !unusedMethods.contains(m))
+				.collect(Collectors.toSet());
+
+		this.usedMethods.addAll(usedMethods);
+	}
+
+	private List<Integer> getLineNumbers(Method method)
+	{
+		return new ArrayList<>(method.getLineNumbers().getLineNumbers().values());
+	}
+
+	private void regeneratePool(ClassGroup group)
+	{
+		for (ClassFile cf : group.getClasses())
+		{
+			for (Method m : cf.getMethods())
+			{
+				Code c = m.getCode();
+				if (c == null)
+				{
+					continue;
+				}
+
+				c.getInstructions().regeneratePool();
+			}
+		}
+	}
+}

--- a/deobfuscator/src/main/java/net/runelite/deob/deobfuscators/MoveBackMethods.java
+++ b/deobfuscator/src/main/java/net/runelite/deob/deobfuscators/MoveBackMethods.java
@@ -29,9 +29,11 @@ import net.runelite.asm.ClassFile;
 import net.runelite.asm.ClassGroup;
 import net.runelite.asm.Method;
 import net.runelite.asm.attributes.Code;
+import net.runelite.asm.attributes.annotation.Annotation;
 import net.runelite.asm.attributes.code.Instruction;
 import net.runelite.asm.attributes.code.instruction.types.InvokeInstruction;
 import net.runelite.deob.Deob;
+import net.runelite.deob.DeobAnnotations;
 import net.runelite.deob.Deobfuscator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -132,6 +134,18 @@ public class MoveBackMethods implements Deobfuscator
 			m.getClassFile().removeMethod(m);
 			cf.addMethod(m);
 			m.setClassFile(cf);
+
+			if (m.getAnnotations().find(DeobAnnotations.OBFUSCATED_OWNER) == null)
+			{
+				String oldOwnerName = DeobAnnotations.getObfuscatedName(oldOwner.getAnnotations());
+
+				if (oldOwnerName == null) {
+					oldOwnerName = oldOwner.getName();
+				}
+
+				// Put the annotation first in the list to get owner, name, signature order
+				m.getAnnotations().addAnnotation(0, DeobAnnotations.OBFUSCATED_OWNER, "value", oldOwnerName);
+			}
 
 			logger.info("Moved {}.{}{} to {}",
 					oldOwner.getName(), m.getName(), m.getDescriptor(), cf.getName());

--- a/deobfuscator/src/main/java/net/runelite/deob/deobfuscators/MoveBackMethods.java
+++ b/deobfuscator/src/main/java/net/runelite/deob/deobfuscators/MoveBackMethods.java
@@ -29,7 +29,6 @@ import net.runelite.asm.ClassFile;
 import net.runelite.asm.ClassGroup;
 import net.runelite.asm.Method;
 import net.runelite.asm.attributes.Code;
-import net.runelite.asm.attributes.annotation.Annotation;
 import net.runelite.asm.attributes.code.Instruction;
 import net.runelite.asm.attributes.code.instruction.types.InvokeInstruction;
 import net.runelite.deob.Deob;
@@ -139,7 +138,8 @@ public class MoveBackMethods implements Deobfuscator
 			{
 				String oldOwnerName = DeobAnnotations.getObfuscatedName(oldOwner.getAnnotations());
 
-				if (oldOwnerName == null) {
+				if (oldOwnerName == null)
+				{
 					oldOwnerName = oldOwner.getName();
 				}
 

--- a/deobfuscator/src/main/java/net/runelite/deob/deobfuscators/membermover/MemberMover.java
+++ b/deobfuscator/src/main/java/net/runelite/deob/deobfuscators/membermover/MemberMover.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2016-2017, Adam <Adam@sigterm.info>
+ * Copyright (c) 2017, UniquePassive <https://github.com/uniquepassive>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.deob.deobfuscators.membermover;
+
+import net.runelite.asm.ClassFile;
+import net.runelite.asm.ClassGroup;
+import net.runelite.asm.Field;
+import net.runelite.asm.Method;
+import net.runelite.asm.attributes.Code;
+import net.runelite.asm.attributes.code.Instruction;
+import net.runelite.asm.attributes.code.instruction.types.SetFieldInstruction;
+import net.runelite.deob.Deobfuscator;
+import net.runelite.deob.deobfuscators.Renamer;
+import net.runelite.deob.util.OwnerMappings;
+import org.objectweb.asm.Opcodes;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class MemberMover implements Deobfuscator
+{
+	private static final Logger logger = LoggerFactory.getLogger(MemberMover.class);
+
+	private MoveBackMethods moveBackMethods = new MoveBackMethods();
+
+	private ClassFile staticClass;
+
+	@Override
+	public void run(ClassGroup group)
+	{
+		group.buildClassGraph();
+		group.lookup();
+
+		moveBackMethods = new MoveBackMethods();
+		moveBackMethods.run(group);
+
+		findOrCreateStaticClass(group);
+
+		moveStaticMethods(group);
+		moveStaticFields(group);
+
+		this.regeneratePool(group);
+	}
+
+	private void findOrCreateStaticClass(ClassGroup group)
+	{
+		staticClass = group.findClass("Static");
+
+		if (staticClass == null)
+		{
+			staticClass = new ClassFile(group);
+
+			staticClass.setName("Static");
+			staticClass.setSuperName("java/lang/Object");
+			staticClass.setVersion(Opcodes.V1_6);
+			staticClass.setAccess(Opcodes.ACC_PUBLIC);
+
+			group.addClass(staticClass);
+		}
+	}
+
+	private void moveStaticMethods(ClassGroup group)
+	{
+		OwnerMappings ownerMappings = new OwnerMappings();
+
+		for (Method m : moveBackMethods.getUsedMethods())
+		{
+			if (moveBackMethods.getMovedMethods().contains(m))
+			{
+				continue;
+			}
+
+			ownerMappings.map(m.getPoolMethod(), staticClass.getName());
+		}
+
+		Renamer renamer = new Renamer(ownerMappings);
+		renamer.run(group);
+
+		logger.info("Moved {} static methods to Static", ownerMappings.getMap().size());
+	}
+
+	private void moveStaticFields(ClassGroup group)
+	{
+		OwnerMappings ownerMappings = new OwnerMappings();
+
+		for (ClassFile cf : group.getClasses())
+		{
+			Set<String> initializedFields = new HashSet<>();
+
+			Method clinit = cf.findMethod("<clinit>");
+
+			if (clinit != null)
+			{
+				for (Instruction i : clinit.getCode().getInstructions().getInstructions())
+				{
+					if (i instanceof SetFieldInstruction)
+					{
+						SetFieldInstruction sfi = (SetFieldInstruction) i;
+
+						if (!sfi.getMyField().isStatic())
+						{
+							continue;
+						}
+
+						initializedFields.add(sfi.getMyField().getName());
+					}
+				}
+			}
+
+			cf.getFields()
+					.stream()
+					.filter(Field::isStatic)
+					.filter(f -> !initializedFields.contains(f.getName()))
+					.forEach(f -> ownerMappings.map(f.getPoolField(), staticClass.getName()));
+		}
+
+		Renamer renamer = new Renamer(ownerMappings);
+		renamer.run(group);
+
+		logger.info("Moved {} static fields to Static", ownerMappings.getMap().size());
+	}
+
+	private void regeneratePool(ClassGroup group)
+	{
+		for (ClassFile cf : group.getClasses())
+		{
+			for (Method m : cf.getMethods())
+			{
+				Code c = m.getCode();
+				if (c == null)
+				{
+					continue;
+				}
+
+				c.getInstructions().regeneratePool();
+			}
+		}
+	}
+}

--- a/deobfuscator/src/main/java/net/runelite/deob/deobfuscators/membermover/MoveBackMethods.java
+++ b/deobfuscator/src/main/java/net/runelite/deob/deobfuscators/membermover/MoveBackMethods.java
@@ -31,8 +31,6 @@ import net.runelite.asm.Method;
 import net.runelite.asm.Type;
 import net.runelite.asm.attributes.Code;
 import net.runelite.asm.attributes.code.Instruction;
-import net.runelite.asm.attributes.code.Instructions;
-import net.runelite.asm.attributes.code.Label;
 import net.runelite.asm.execution.Execution;
 import net.runelite.asm.signature.Signature;
 import net.runelite.deob.Deobfuscator;
@@ -69,11 +67,6 @@ public class MoveBackMethods implements Deobfuscator
 
 		findUnusedMethods(group);
 		findUsedMethods(group);
-
-		for (Method m : usedMethods)
-		{
-			removeUnusedInstructions(m);
-		}
 
 		for (Method m : usedMethods)
 		{
@@ -146,45 +139,6 @@ public class MoveBackMethods implements Deobfuscator
 				}
 
 				usedMethods.add(m);
-			}
-		}
-	}
-
-	private void removeUnusedInstructions(Method m)
-	{
-		Instructions ins = m.getCode().getInstructions();
-
-		List<Instruction> insCopy = new ArrayList<>(ins.getInstructions());
-
-		for (int j = 0; j < insCopy.size(); ++j)
-		{
-			Instruction i = insCopy.get(j);
-
-			if (!execution.executed.contains(i))
-			{
-				// if this is an exception handler, the exception handler is never used...
-				for (net.runelite.asm.attributes.code.Exception e : new ArrayList<>(m.getCode().getExceptions().getExceptions()))
-				{
-					if (e.getStart().next() == i)
-					{
-						e.setStart(ins.createLabelFor(insCopy.get(j + 1)));
-
-						if (e.getStart().next() == e.getEnd().next())
-						{
-							m.getCode().getExceptions().remove(e);
-							continue;
-						}
-					}
-					if (e.getHandler().next() == i)
-					{
-						m.getCode().getExceptions().remove(e);
-					}
-				}
-
-				if (i instanceof Label)
-					continue;
-
-				ins.remove(i);
 			}
 		}
 	}

--- a/deobfuscator/src/main/java/net/runelite/deob/deobfuscators/packetwrite/PacketWriteDeobfuscator.java
+++ b/deobfuscator/src/main/java/net/runelite/deob/deobfuscators/packetwrite/PacketWriteDeobfuscator.java
@@ -184,6 +184,7 @@ public class PacketWriteDeobfuscator implements Deobfuscator
 		opcodeReplacer.run(group, writes.values());
 
 		int count = 0;
+		int writesCount = 0;
 
 		for (PacketWrite write : writes.values())
 		{
@@ -194,9 +195,10 @@ public class PacketWriteDeobfuscator implements Deobfuscator
 
 			insert(group, write);
 			++count;
+			writesCount += write.writes.size();
 		}
 
-		logger.info("Converted buffer write methods for {} opcodes", count);
+		logger.info("Converted buffer write methods for {} opcodes ({} writes)", count, writesCount);
 	}
 
 	private void insert(ClassGroup group, PacketWrite write)
@@ -314,7 +316,7 @@ public class PacketWriteDeobfuscator implements Deobfuscator
 		}
 		else
 		{
-			throw new IllegalStateException("Unknown type " + ii.getMethod().getType().getReturnValue());
+			throw new IllegalStateException("Unknown type " + argumentType);
 		}
 
 		return new InvokeVirtual(i.getInstructions(), invokeMethod);

--- a/deobfuscator/src/main/java/net/runelite/deob/deobfuscators/packetwrite/PacketWriteDeobfuscator.java
+++ b/deobfuscator/src/main/java/net/runelite/deob/deobfuscators/packetwrite/PacketWriteDeobfuscator.java
@@ -304,6 +304,14 @@ public class PacketWriteDeobfuscator implements Deobfuscator
 				new Signature("(J)V")
 			);
 		}
+		else if (argumentType.equals(Type.STRING))
+		{
+			invokeMethod = new Method(
+					ii.getMethod().getClazz(),
+					"runeliteWriteString",
+					new Signature("(Ljava/lang/String;)V")
+			);
+		}
 		else
 		{
 			throw new IllegalStateException("Unknown type " + ii.getMethod().getType().getReturnValue());

--- a/deobfuscator/src/main/java/net/runelite/deob/deobfuscators/packetwrite/PacketWriteDeobfuscator.java
+++ b/deobfuscator/src/main/java/net/runelite/deob/deobfuscators/packetwrite/PacketWriteDeobfuscator.java
@@ -96,6 +96,16 @@ public class PacketWriteDeobfuscator implements Deobfuscator
 			return;
 		}
 
+		if (!(ctx.getInstruction() instanceof InvokeVirtual))
+		{
+			return;
+		}
+
+		if (!ii.getMethod().getClazz().getName().equals(rw.getWriteOpcode().getClassFile().getSuperName()))
+		{
+			return;
+		}
+
 		write.writes.add(ctx);
 	}
 

--- a/deobfuscator/src/main/java/net/runelite/deob/deobfuscators/transformers/ReflectionTransformer.java
+++ b/deobfuscator/src/main/java/net/runelite/deob/deobfuscators/transformers/ReflectionTransformer.java
@@ -71,6 +71,7 @@ public class ReflectionTransformer implements Transformer
 			transformMethodName(ins, i);
 			transformGetParameterTypes(ins, i);
 			transformGetDeclaredField(ins, i);
+			transformGetDeclaredMethods(ins, i);
 			transformSetInt(ins, i);
 			transformGetInt(ins, i);
 			transformInvokeVirtual(ins, i);
@@ -177,6 +178,32 @@ public class ReflectionTransformer implements Transformer
 			instructions.replace(iv, is);
 
 			logger.info("Transformed Class.getDeclaredField call");
+		}
+	}
+
+	// invokevirtual         java/lang/Class/getDeclaredMethods(;)[Ljava/lang/reflect/Method;
+	// to
+	// invokestatic          net/runelite/rs/Reflection/findMethods
+	private void transformGetDeclaredMethods(Instructions instructions, Instruction i)
+	{
+		if (!(i instanceof InvokeVirtual))
+		{
+			return;
+		}
+
+		InvokeVirtual iv = (InvokeVirtual) i;
+
+		if (iv.getMethod().getClazz().getName().equals("java/lang/Class")
+				&& iv.getMethod().getName().equals("getDeclaredMethods"))
+		{
+			InvokeStatic is = new InvokeStatic(instructions,
+					new net.runelite.asm.pool.Method(
+							new net.runelite.asm.pool.Class("net/runelite/rs/Reflection"), "findMethods", new Signature("(Ljava/lang/Class;)[Ljava/lang/reflect/Method;")
+					)
+			);
+			instructions.replace(iv, is);
+
+			logger.info("Transformed Class.getDeclaredMethods call");
 		}
 	}
 

--- a/deobfuscator/src/main/java/net/runelite/deob/util/OwnerMappings.java
+++ b/deobfuscator/src/main/java/net/runelite/deob/util/OwnerMappings.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2016-2017, Adam <Adam@sigterm.info>
+ * Copyright (c) 2017, UniquePassive <https://github.com/uniquepassive>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package net.runelite.deob.util;
+
+import net.runelite.asm.pool.Field;
+import net.runelite.asm.pool.Method;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class OwnerMappings
+{
+	private final Map<Object, String> map = new HashMap<>();
+
+	public void map(Field field, String name)
+	{
+		map.put(field, name);
+	}
+	
+	public void map(Method method, String name)
+	{
+		map.put(method, name);
+	}
+	
+	public String get(Object object)
+	{
+		return map.get(object);
+	}
+
+	public Map<Object, String> getMap()
+	{
+		return map;
+	}
+}

--- a/deobfuscator/src/test/java/net/runelite/deob/deobfuscators/membermover/MemberMoverTest.java
+++ b/deobfuscator/src/test/java/net/runelite/deob/deobfuscators/membermover/MemberMoverTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2017, UniquePassive <https://github.com/uniquepassive>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.deob.deobfuscators.membermover;
+
+import net.runelite.asm.ClassGroup;
+import net.runelite.deob.DeobTestProperties;
+import net.runelite.deob.TemporyFolderLocation;
+import net.runelite.deob.util.JarUtil;
+import org.junit.*;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+
+public class MemberMoverTest
+{
+    @Rule
+    public DeobTestProperties properties = new DeobTestProperties();
+
+    @Rule
+    public TemporaryFolder folder = TemporyFolderLocation.getTemporaryFolder();
+
+    private ClassGroup group;
+
+    @Before
+    public void before() throws IOException
+    {
+        group = JarUtil.loadJar(new File(properties.getVanillaClient()));
+    }
+
+    @After
+    public void after() throws IOException
+    {
+        JarUtil.saveJar(group, folder.newFile());
+    }
+
+    @Test
+    @Ignore
+    public void testRun()
+    {
+        MemberMover memberMover = new MemberMover();
+        memberMover.run(group);
+    }
+}

--- a/runescape-api/src/main/java/net/runelite/mapping/ObfuscatedOwner.java
+++ b/runescape-api/src/main/java/net/runelite/mapping/ObfuscatedOwner.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2016-2017, Adam <Adam@sigterm.info>
+ * Copyright (c) 2017, UniquePassive <https://github.com/uniquepassive>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.mapping;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(
+	{
+		ElementType.FIELD, ElementType.METHOD
+	})
+public @interface ObfuscatedOwner
+{
+	String value();
+}

--- a/runescape-client-injector-plugin/src/main/java/net/runelite/injector/Inject.java
+++ b/runescape-client-injector-plugin/src/main/java/net/runelite/injector/Inject.java
@@ -313,7 +313,17 @@ public class Inject
 			for (Method m : cf.getMethods())
 			{
 				hookMethod.process(m);
-				invokes.process(m, other, implementingClass);
+
+				String obfuscatedOwner = DeobAnnotations.getObfuscatedOwner(m.getAnnotations());
+
+				if (obfuscatedOwner != null)
+				{
+					invokes.process(m, vanilla.findClass(obfuscatedOwner), implementingClass);
+				}
+				else
+				{
+					invokes.process(m, other, implementingClass);
+				}
 			}
 		}
 		

--- a/runescape-client-injector-plugin/src/main/java/net/runelite/injector/InjectHookMethod.java
+++ b/runescape-client-injector-plugin/src/main/java/net/runelite/injector/InjectHookMethod.java
@@ -63,9 +63,13 @@ public class InjectHookMethod
 		String hookName = DeobAnnotations.getHookName(an); // hook name
 
 		// Find equivalent method in vanilla, and insert callback at the beginning
-		ClassFile cf = method.getClassFile();
-		String obfuscatedMethodName = DeobAnnotations.getObfuscatedName(an),
+		String obfuscatedClassName = DeobAnnotations.getObfuscatedOwner(an);
+		if (obfuscatedClassName == null)
+		{
+			ClassFile cf = method.getClassFile();
 			obfuscatedClassName = DeobAnnotations.getObfuscatedName(cf.getAnnotations());
+		}
+		String obfuscatedMethodName = DeobAnnotations.getObfuscatedName(an);
 
 		// might be a constructor
 		if (obfuscatedMethodName == null && method.getName().equals("<init>"))

--- a/runescape-client-injector-plugin/src/main/java/net/runelite/injector/MixinInjector.java
+++ b/runescape-client-injector-plugin/src/main/java/net/runelite/injector/MixinInjector.java
@@ -322,7 +322,11 @@ public class MixinInjector
 			}
 
 			// Find the vanilla class where the method to copy is in
-			String obClassName = DeobAnnotations.getObfuscatedName(deobMethod.getClassFile().getAnnotations());
+			String obClassName = DeobAnnotations.getObfuscatedOwner(deobMethod.getAnnotations());
+			if (obClassName == null)
+			{
+				obClassName = DeobAnnotations.getObfuscatedName(deobMethod.getClassFile().getAnnotations());
+			}
 			ClassFile obCf = inject.getVanilla().findClass(obClassName);
 			assert obCf != null : "unable to find vanilla class from obfuscated name " + obClassName;
 
@@ -400,7 +404,11 @@ public class MixinInjector
 				}
 
 				// Find the vanilla class where the method to copy is in
-				String obClassName = DeobAnnotations.getObfuscatedName(deobMethod.getClassFile().getAnnotations());
+				String obClassName = DeobAnnotations.getObfuscatedOwner(deobMethod.getAnnotations());
+				if (obClassName == null)
+				{
+					obClassName = DeobAnnotations.getObfuscatedName(deobMethod.getClassFile().getAnnotations());
+				}
 				ClassFile obCf = inject.getVanilla().findClass(obClassName);
 
 				Method obMethod = obCf.findMethod(obMethodName, obMethodSignature);


### PR DESCRIPTION
+ **Ability to change the owner of fields and methods through Renamer**
+ New ObfuscatedOwner annotation that is applied when a member's owner is changed
+ **Move back static methods to their original classes at Jagex**
+ **Move static methods whose original class couldn't be determined to the new "Static" static member container class**
+ **Move static fields whose original class couldn't be determined to "Static"**
+ Record line numbers in visited methods
+ Ability to add annotations at any index in the annotation list (e.g. at the start)
+ Don't crash when calling next() on a label that is the last insn
+ Only record actual write methods in PacketWriteDeobfuscator (MoveBackMethods errors if this is not done)