### PR TITLE
Move login/interface check to overlay

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/aoewarnings/AoeWarningOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/aoewarnings/AoeWarningOverlay.java
@@ -34,7 +34,6 @@ import java.util.Map;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
 import net.runelite.api.Client;
-import net.runelite.api.GameState;
 import net.runelite.api.Perspective;
 import net.runelite.api.Projectile;
 import net.runelite.client.ui.overlay.Overlay;
@@ -56,12 +55,13 @@ public class AoeWarningOverlay extends Overlay
 		this.client = client;
 		this.plugin = plugin;
 		this.config = config;
+		this.setDrawOverLoginScreen(false);
 	}
 
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
-		if (client.getGameState() != GameState.LOGGED_IN || !config.enabled())
+		if (!config.enabled())
 		{
 			return null;
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/aoewarnings/AoeWarningOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/aoewarnings/AoeWarningOverlay.java
@@ -55,7 +55,6 @@ public class AoeWarningOverlay extends Overlay
 		this.client = client;
 		this.plugin = plugin;
 		this.config = config;
-		this.setDrawOverLoginScreen(false);
 	}
 
 	@Override

--- a/runelite-client/src/main/java/net/runelite/client/plugins/attackindicator/AttackIndicatorOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/attackindicator/AttackIndicatorOverlay.java
@@ -33,7 +33,6 @@ import java.awt.Rectangle;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
 import net.runelite.api.Client;
-import net.runelite.api.GameState;
 import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.ui.FontManager;
@@ -62,12 +61,13 @@ public class AttackIndicatorOverlay extends Overlay
 		super(OverlayPosition.DYNAMIC);
 		this.plugin = plugin;
 		this.config = config;
+		this.setDrawOverLoginScreen(false);
 	}
 
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
-		if (!config.enabled() || client.getGameState() != GameState.LOGGED_IN)
+		if (!config.enabled())
 		{
 			return null;
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/attackindicator/AttackIndicatorOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/attackindicator/AttackIndicatorOverlay.java
@@ -61,7 +61,6 @@ public class AttackIndicatorOverlay extends Overlay
 		super(OverlayPosition.DYNAMIC);
 		this.plugin = plugin;
 		this.config = config;
-		this.setDrawOverLoginScreen(false);
 	}
 
 	@Override

--- a/runelite-client/src/main/java/net/runelite/client/plugins/boosts/BoostsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/boosts/BoostsOverlay.java
@@ -70,9 +70,6 @@ class BoostsOverlay extends Overlay
 		super(OverlayPosition.TOP_LEFT, OverlayPriority.MED);
 		this.client = client;
 		this.config = config;
-		this.setDrawOverLoginScreen(false);
-		this.setDrawOverClickToPlayScreen(false);
-		this.setDrawOverBankScreen(false);
 	}
 
 	@Override

--- a/runelite-client/src/main/java/net/runelite/client/plugins/boosts/BoostsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/boosts/BoostsOverlay.java
@@ -32,7 +32,6 @@ import java.awt.Graphics2D;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
 import net.runelite.api.Client;
-import net.runelite.api.GameState;
 import net.runelite.api.Skill;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayPosition;
@@ -71,12 +70,15 @@ class BoostsOverlay extends Overlay
 		super(OverlayPosition.TOP_LEFT, OverlayPriority.MED);
 		this.client = client;
 		this.config = config;
+		this.setDrawOverLoginScreen(false);
+		this.setDrawOverClickToPlayScreen(false);
+		this.setDrawOverBankScreen(false);
 	}
 
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
-		if (client.getGameState() != GameState.LOGGED_IN || !config.enabled())
+		if (!config.enabled())
 		{
 			return null;
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/ClueScrollOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/ClueScrollOverlay.java
@@ -35,7 +35,6 @@ import java.time.Instant;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
 import net.runelite.api.Client;
-import net.runelite.api.GameState;
 import net.runelite.api.ItemComposition;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayPosition;
@@ -65,12 +64,13 @@ public class ClueScrollOverlay extends Overlay
 		super(OverlayPosition.TOP_LEFT, OverlayPriority.LOW);
 		this.client = client;
 		this.config = config;
+		this.setDrawOverLoginScreen(false);
 	}
 
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
-		if (client.getGameState() != GameState.LOGGED_IN || !config.enabled())
+		if (!config.enabled())
 		{
 			return null;
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/ClueScrollOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/ClueScrollOverlay.java
@@ -64,7 +64,6 @@ public class ClueScrollOverlay extends Overlay
 		super(OverlayPosition.TOP_LEFT, OverlayPriority.LOW);
 		this.client = client;
 		this.config = config;
-		this.setDrawOverLoginScreen(false);
 	}
 
 	@Override

--- a/runelite-client/src/main/java/net/runelite/client/plugins/devtools/DevToolsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/devtools/DevToolsOverlay.java
@@ -39,7 +39,6 @@ import javax.inject.Inject;
 import net.runelite.api.Client;
 import net.runelite.api.DecorativeObject;
 import net.runelite.api.GameObject;
-import net.runelite.api.GameState;
 import net.runelite.api.GroundObject;
 import net.runelite.api.Item;
 import net.runelite.api.ItemLayer;
@@ -83,16 +82,12 @@ public class DevToolsOverlay extends Overlay
 		super(OverlayPosition.DYNAMIC);
 		this.client = client;
 		this.plugin = plugin;
+		this.setDrawOverLoginScreen(false);
 	}
 
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
-		if (client.getGameState() != GameState.LOGGED_IN)
-		{
-			return null;
-		}
-
 		Font font = plugin.getFont();
 		if (font != null)
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/devtools/DevToolsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/devtools/DevToolsOverlay.java
@@ -82,7 +82,6 @@ public class DevToolsOverlay extends Overlay
 		super(OverlayPosition.DYNAMIC);
 		this.client = client;
 		this.plugin = plugin;
-		this.setDrawOverLoginScreen(false);
 	}
 
 	@Override

--- a/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingOverlay.java
@@ -61,7 +61,6 @@ class FishingOverlay extends Overlay
 		this.client = client;
 		this.plugin = plugin;
 		this.config = config;
-		this.setDrawOverLoginScreen(false);
 	}
 
 	@Override

--- a/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingOverlay.java
@@ -33,7 +33,6 @@ import java.time.Instant;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
 import net.runelite.api.Client;
-import net.runelite.api.GameState;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.OverlayPriority;
@@ -62,12 +61,13 @@ class FishingOverlay extends Overlay
 		this.client = client;
 		this.plugin = plugin;
 		this.config = config;
+		this.setDrawOverLoginScreen(false);
 	}
 
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
-		if (client.getGameState() != GameState.LOGGED_IN || !config.enabled())
+		if (!config.enabled())
 		{
 			return null;
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingSpotOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingSpotOverlay.java
@@ -64,7 +64,6 @@ class FishingSpotOverlay extends Overlay
 		this.runelite = runelite;
 		this.client = client;
 		this.config = config;
-		this.setDrawOverLoginScreen(false);
 	}
 
 	@Override

--- a/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingSpotOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingSpotOverlay.java
@@ -34,7 +34,6 @@ import java.util.List;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
 import net.runelite.api.Client;
-import net.runelite.api.GameState;
 import net.runelite.api.NPC;
 import net.runelite.api.queries.NPCQuery;
 import net.runelite.client.RuneLite;
@@ -65,12 +64,13 @@ class FishingSpotOverlay extends Overlay
 		this.runelite = runelite;
 		this.client = client;
 		this.config = config;
+		this.setDrawOverLoginScreen(false);
 	}
 
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
-		if (client.getGameState() != GameState.LOGGED_IN || !config.enabled())
+		if (!config.enabled())
 		{
 			return null;
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/fpsinfo/FPSOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/fpsinfo/FPSOverlay.java
@@ -33,7 +33,6 @@ import java.awt.geom.Rectangle2D;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
 import net.runelite.api.Client;
-import net.runelite.api.GameState;
 import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.ui.overlay.Overlay;
@@ -51,16 +50,12 @@ public class FPSOverlay extends Overlay
 		super(OverlayPosition.DYNAMIC, OverlayPriority.HIGH);
 		this.client = client;
 		this.plugin = plugin;
+		this.setDrawOverLoginScreen(false);
 	}
 
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
-		if (client.getGameState() != GameState.LOGGED_IN)
-		{
-			return null;
-		}
-
 		Font font = plugin.getFont();
 		if (font != null)
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/fpsinfo/FPSOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/fpsinfo/FPSOverlay.java
@@ -50,7 +50,6 @@ public class FPSOverlay extends Overlay
 		super(OverlayPosition.DYNAMIC, OverlayPriority.HIGH);
 		this.client = client;
 		this.plugin = plugin;
-		this.setDrawOverLoginScreen(false);
 	}
 
 	@Override

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
@@ -109,9 +109,6 @@ public class GroundItemsOverlay extends Overlay
 		super(OverlayPosition.DYNAMIC);
 		this.client = client;
 		this.config = config;
-		this.setDrawOverLoginScreen(false);
-		this.setDrawOverClickToPlayScreen(false);
-		this.setDrawOverBankScreen(false);
 	}
 
 	@Override

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
@@ -42,7 +42,6 @@ import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
 import net.runelite.api.Client;
-import net.runelite.api.GameState;
 import net.runelite.api.Item;
 import net.runelite.api.ItemComposition;
 import net.runelite.api.ItemLayer;
@@ -52,7 +51,6 @@ import net.runelite.api.Point;
 import net.runelite.api.Region;
 import net.runelite.api.Tile;
 import net.runelite.api.widgets.Widget;
-import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayPosition;
@@ -111,23 +109,14 @@ public class GroundItemsOverlay extends Overlay
 		super(OverlayPosition.DYNAMIC);
 		this.client = client;
 		this.config = config;
+		this.setDrawOverLoginScreen(false);
+		this.setDrawOverClickToPlayScreen(false);
+		this.setDrawOverBankScreen(false);
 	}
 
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
-		// won't draw if not logged in
-		if (client.getGameState() != GameState.LOGGED_IN || !config.enabled())
-		{
-			return null;
-		}
-
-		//if the player is logged in but viewing the click to play screen exit
-		if (client.getWidget(WidgetInfo.LOGIN_CLICK_TO_PLAY_SCREEN) != null)
-		{
-			return null;
-		}
-
 		Widget viewport = client.getViewportWidget();
 
 		if (viewport != null)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/implings/ImplingsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/implings/ImplingsOverlay.java
@@ -67,7 +67,6 @@ public class ImplingsOverlay extends Overlay
 		this.runelite = runelite;
 		this.client = client;
 		this.config = config;
-		this.setDrawOverLoginScreen(false);
 	}
 
 	@Override

--- a/runelite-client/src/main/java/net/runelite/client/plugins/implings/ImplingsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/implings/ImplingsOverlay.java
@@ -36,7 +36,6 @@ import javax.annotation.Nullable;
 import javax.inject.Inject;
 import net.runelite.api.Actor;
 import net.runelite.api.Client;
-import net.runelite.api.GameState;
 import net.runelite.api.NPC;
 import net.runelite.api.NpcID;
 import net.runelite.api.Point;
@@ -68,16 +67,12 @@ public class ImplingsOverlay extends Overlay
 		this.runelite = runelite;
 		this.client = client;
 		this.config = config;
+		this.setDrawOverLoginScreen(false);
 	}
 
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
-		if (client.getGameState() != GameState.LOGGED_IN)
-		{
-			return null;
-		}
-
 		NPCQuery implingQuery = new NPCQuery().idEquals(Ints.toArray(ids));
 		NPC[] implings = runelite.runQuery(implingQuery);
 		for (NPC imp : implings)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/instancemap/InstanceMapOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/instancemap/InstanceMapOverlay.java
@@ -32,7 +32,6 @@ import javax.annotation.Nullable;
 import javax.inject.Inject;
 import net.runelite.api.Client;
 import net.runelite.api.GameObject;
-import net.runelite.api.GameState;
 import net.runelite.api.GroundObject;
 import net.runelite.api.IndexedSprite;
 import net.runelite.api.ObjectComposition;
@@ -118,6 +117,7 @@ class InstanceMapOverlay extends Overlay
 		this.client = client;
 		this.config = config;
 		this.plugin = plugin;
+		this.setDrawOverLoginScreen(false);
 	}
 
 	public boolean isMapShown()
@@ -172,7 +172,7 @@ class InstanceMapOverlay extends Overlay
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
-		if (client.getGameState() != GameState.LOGGED_IN || !config.enabled() || !showMap)
+		if (!config.enabled() || !showMap)
 		{
 			return null;
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/instancemap/InstanceMapOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/instancemap/InstanceMapOverlay.java
@@ -117,7 +117,6 @@ class InstanceMapOverlay extends Overlay
 		this.client = client;
 		this.config = config;
 		this.plugin = plugin;
-		this.setDrawOverLoginScreen(false);
 	}
 
 	public boolean isMapShown()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/jewellerycount/JewelleryCountOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/jewellerycount/JewelleryCountOverlay.java
@@ -35,7 +35,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import javax.inject.Inject;
 import net.runelite.api.Client;
-import net.runelite.api.GameState;
 import net.runelite.api.Query;
 import net.runelite.api.queries.EquipmentItemQuery;
 import net.runelite.api.queries.InventoryItemQuery;
@@ -60,14 +59,14 @@ class JewelleryCountOverlay extends Overlay
 		this.runelite = runelite;
 		this.client = runelite.getClient();
 		this.config = config;
+		this.setDrawOverLoginScreen(false);
+		this.setDrawOverClickToPlayScreen(false);
 	}
 
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
-		if (client.getGameState() != GameState.LOGGED_IN
-			|| !config.enabled()
-			|| client.getWidget(WidgetInfo.LOGIN_CLICK_TO_PLAY_SCREEN) != null)
+		if (!config.enabled())
 		{
 			return null;
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/jewellerycount/JewelleryCountOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/jewellerycount/JewelleryCountOverlay.java
@@ -59,8 +59,7 @@ class JewelleryCountOverlay extends Overlay
 		this.runelite = runelite;
 		this.client = runelite.getClient();
 		this.config = config;
-		this.setDrawOverLoginScreen(false);
-		this.setDrawOverClickToPlayScreen(false);
+		this.setDrawOverBankScreen(true);
 	}
 
 	@Override

--- a/runelite-client/src/main/java/net/runelite/client/plugins/mousehighlight/MouseHighlightOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/mousehighlight/MouseHighlightOverlay.java
@@ -29,7 +29,6 @@ import java.awt.Graphics2D;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
 import net.runelite.api.Client;
-import net.runelite.api.GameState;
 import net.runelite.api.MenuEntry;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayPosition;
@@ -53,12 +52,13 @@ class MouseHighlightOverlay extends Overlay
 		this.client = client;
 		this.config = config;
 		this.tooltipRenderer = overlayRenderer.getTooltipRenderer();
+		this.setDrawOverLoginScreen(false);
 	}
 
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
-		if (client.getGameState() != GameState.LOGGED_IN || !config.enabled())
+		if (!config.enabled())
 		{
 			return null;
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/mousehighlight/MouseHighlightOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/mousehighlight/MouseHighlightOverlay.java
@@ -52,7 +52,7 @@ class MouseHighlightOverlay extends Overlay
 		this.client = client;
 		this.config = config;
 		this.tooltipRenderer = overlayRenderer.getTooltipRenderer();
-		this.setDrawOverLoginScreen(false);
+		this.setDrawOverBankScreen(true);
 	}
 
 	@Override

--- a/runelite-client/src/main/java/net/runelite/client/plugins/opponentinfo/OpponentInfoOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/opponentinfo/OpponentInfoOverlay.java
@@ -72,7 +72,6 @@ class OpponentInfoOverlay extends Overlay
 		super(OverlayPosition.TOP_LEFT, OverlayPriority.HIGH);
 		this.client = client;
 		this.config = config;
-		this.setDrawOverLoginScreen(false);
 	}
 
 	private Actor getOpponent()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/opponentinfo/OpponentInfoOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/opponentinfo/OpponentInfoOverlay.java
@@ -30,7 +30,6 @@ import java.awt.FontMetrics;
 import java.awt.Graphics2D;
 import net.runelite.api.Actor;
 import net.runelite.api.Client;
-import net.runelite.api.GameState;
 import net.runelite.api.Player;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayPosition;
@@ -73,6 +72,7 @@ class OpponentInfoOverlay extends Overlay
 		super(OverlayPosition.TOP_LEFT, OverlayPriority.HIGH);
 		this.client = client;
 		this.config = config;
+		this.setDrawOverLoginScreen(false);
 	}
 
 	private Actor getOpponent()
@@ -89,7 +89,7 @@ class OpponentInfoOverlay extends Overlay
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
-		if (client.getGameState() != GameState.LOGGED_IN || config.enabled() == false)
+		if (config.enabled() == false)
 		{
 			return null;
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/pestcontrol/PestControlOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/pestcontrol/PestControlOverlay.java
@@ -69,7 +69,6 @@ public class PestControlOverlay extends Overlay
 		this.runelite = runelite;
 		this.client = runelite.getClient();
 		this.plugin = plugin;
-		this.setDrawOverLoginScreen(false);
 	}
 
 	@Override

--- a/runelite-client/src/main/java/net/runelite/client/plugins/pestcontrol/PestControlOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/pestcontrol/PestControlOverlay.java
@@ -34,7 +34,6 @@ import java.awt.geom.Rectangle2D;
 import java.util.Arrays;
 import javax.inject.Inject;
 import net.runelite.api.Client;
-import net.runelite.api.GameState;
 import net.runelite.api.NPC;
 import net.runelite.api.Query;
 import net.runelite.api.queries.NPCQuery;
@@ -70,16 +69,12 @@ public class PestControlOverlay extends Overlay
 		this.runelite = runelite;
 		this.client = runelite.getClient();
 		this.plugin = plugin;
+		this.setDrawOverLoginScreen(false);
 	}
 
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
-		if (client.getGameState() != GameState.LOGGED_IN)
-		{
-			return null;
-		}
-
 		// See if we are in a game or not
 		if (client.getWidget(WidgetInfo.PESTCONTROL_BLUE_SHIELD) == null)
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/prayflick/PrayerFlickOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/prayflick/PrayerFlickOverlay.java
@@ -52,8 +52,6 @@ public class PrayerFlickOverlay extends Overlay
 		super(OverlayPosition.DYNAMIC);
 		this.client = client;
 		this.config = config;
-		this.setDrawOverLoginScreen(false);
-		this.setDrawOverClickToPlayScreen(false);
 	}
 
 	public void onTick()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/prayflick/PrayerFlickOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/prayflick/PrayerFlickOverlay.java
@@ -33,7 +33,6 @@ import java.time.Instant;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
 import net.runelite.api.Client;
-import net.runelite.api.GameState;
 import net.runelite.api.Prayer;
 import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetInfo;
@@ -53,6 +52,8 @@ public class PrayerFlickOverlay extends Overlay
 		super(OverlayPosition.DYNAMIC);
 		this.client = client;
 		this.config = config;
+		this.setDrawOverLoginScreen(false);
+		this.setDrawOverClickToPlayScreen(false);
 	}
 
 	public void onTick()
@@ -64,7 +65,7 @@ public class PrayerFlickOverlay extends Overlay
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
-		if (client.getGameState() != GameState.LOGGED_IN || !config.enabled() || !prayersActive)//If there are no prayers active we don't need to be flicking
+		if (!config.enabled() || !prayersActive)//If there are no prayers active we don't need to be flicking
 		{
 			return null;
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/runecraft/BindNeckOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/runecraft/BindNeckOverlay.java
@@ -62,8 +62,7 @@ public class BindNeckOverlay extends Overlay
 		this.runelite = runelite;
 		this.client = runelite.getClient();
 		this.config = config;
-		this.setDrawOverLoginScreen(false);
-		this.setDrawOverClickToPlayScreen(false);
+		this.setDrawOverBankScreen(true);
 	}
 
 	@Override

--- a/runelite-client/src/main/java/net/runelite/client/plugins/runecraft/BindNeckOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/runecraft/BindNeckOverlay.java
@@ -36,7 +36,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import javax.inject.Inject;
 import net.runelite.api.Client;
-import net.runelite.api.GameState;
 import static net.runelite.api.ItemID.BINDING_NECKLACE;
 import net.runelite.api.Query;
 import net.runelite.api.queries.EquipmentItemQuery;
@@ -63,14 +62,14 @@ public class BindNeckOverlay extends Overlay
 		this.runelite = runelite;
 		this.client = runelite.getClient();
 		this.config = config;
+		this.setDrawOverLoginScreen(false);
+		this.setDrawOverClickToPlayScreen(false);
 	}
 
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
-		if (client.getGameState() != GameState.LOGGED_IN
-			|| !config.showBindNeck()
-			|| client.getWidget(WidgetInfo.LOGIN_CLICK_TO_PLAY_SCREEN) != null)
+		if (!config.showBindNeck())
 		{
 			return null;
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/runecraft/RunecraftOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/runecraft/RunecraftOverlay.java
@@ -32,12 +32,10 @@ import java.awt.Graphics2D;
 import java.awt.Rectangle;
 import javax.inject.Inject;
 import net.runelite.api.Client;
-import net.runelite.api.GameState;
 import net.runelite.api.ItemID;
 import net.runelite.api.Query;
 import net.runelite.api.Varbits;
 import net.runelite.api.queries.InventoryItemQuery;
-import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.api.widgets.WidgetItem;
 import net.runelite.client.RuneLite;
 import net.runelite.client.ui.FontManager;
@@ -63,14 +61,14 @@ public class RunecraftOverlay extends Overlay
 		this.runelite = runelite;
 		this.client = runelite.getClient();
 		this.config = config;
+		this.setDrawOverLoginScreen(false);
+		this.setDrawOverClickToPlayScreen(false);
 	}
 
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
-		if (client.getGameState() != GameState.LOGGED_IN
-			|| !config.showPouch()
-			|| client.getWidget(WidgetInfo.LOGIN_CLICK_TO_PLAY_SCREEN) != null)
+		if (!config.showPouch())
 		{
 			return null;
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/runecraft/RunecraftOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/runecraft/RunecraftOverlay.java
@@ -61,8 +61,7 @@ public class RunecraftOverlay extends Overlay
 		this.runelite = runelite;
 		this.client = runelite.getClient();
 		this.config = config;
-		this.setDrawOverLoginScreen(false);
-		this.setDrawOverClickToPlayScreen(false);
+		this.setDrawOverBankScreen(true);
 	}
 
 	@Override

--- a/runelite-client/src/main/java/net/runelite/client/plugins/runepouch/RunepouchOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/runepouch/RunepouchOverlay.java
@@ -72,8 +72,7 @@ public class RunepouchOverlay extends Overlay
 		this.client = runelite.getClient();
 		this.config = config;
 		this.tooltipRenderer = overlayRenderer.getTooltipRenderer();
-		this.setDrawOverLoginScreen(false);
-		this.setDrawOverClickToPlayScreen(false);
+		this.setDrawOverBankScreen(true);
 	}
 
 	@Override

--- a/runelite-client/src/main/java/net/runelite/client/plugins/runepouch/RunepouchOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/runepouch/RunepouchOverlay.java
@@ -30,13 +30,11 @@ import java.awt.Graphics2D;
 import java.awt.image.BufferedImage;
 import javax.inject.Inject;
 import net.runelite.api.Client;
-import net.runelite.api.GameState;
 import net.runelite.api.ItemID;
 import net.runelite.api.Point;
 import net.runelite.api.Query;
 import net.runelite.api.Varbits;
 import net.runelite.api.queries.InventoryItemQuery;
-import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.api.widgets.WidgetItem;
 import net.runelite.client.RuneLite;
 import net.runelite.client.ui.FontManager;
@@ -74,14 +72,14 @@ public class RunepouchOverlay extends Overlay
 		this.client = runelite.getClient();
 		this.config = config;
 		this.tooltipRenderer = overlayRenderer.getTooltipRenderer();
+		this.setDrawOverLoginScreen(false);
+		this.setDrawOverClickToPlayScreen(false);
 	}
 
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
-		if (!config.enabled()
-			|| client.getGameState() != GameState.LOGGED_IN
-			|| client.getWidget(WidgetInfo.LOGIN_CLICK_TO_PLAY_SCREEN) != null)
+		if (!config.enabled())
 		{
 			return null;
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerOverlay.java
@@ -37,7 +37,6 @@ import java.util.Collection;
 import java.util.Set;
 import javax.inject.Inject;
 import net.runelite.api.Client;
-import net.runelite.api.GameState;
 import net.runelite.api.ItemID;
 import net.runelite.api.Query;
 import net.runelite.api.queries.EquipmentItemQuery;
@@ -92,14 +91,14 @@ class SlayerOverlay extends Overlay
 		this.client = runelite.getClient();
 		this.plugin = plugin;
 		this.config = config;
+		this.setDrawOverLoginScreen(false);
+		this.setDrawOverClickToPlayScreen(false);
 	}
 
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
-		if (client.getGameState() != GameState.LOGGED_IN
-			|| !config.enabled()
-			|| client.getWidget(WidgetInfo.LOGIN_CLICK_TO_PLAY_SCREEN) != null)
+		if (!config.enabled())
 		{
 			return null;
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerOverlay.java
@@ -91,8 +91,6 @@ class SlayerOverlay extends Overlay
 		this.client = runelite.getClient();
 		this.plugin = plugin;
 		this.config = config;
-		this.setDrawOverLoginScreen(false);
-		this.setDrawOverClickToPlayScreen(false);
 	}
 
 	@Override

--- a/runelite-client/src/main/java/net/runelite/client/plugins/specorb/SpecOrbOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/specorb/SpecOrbOverlay.java
@@ -30,7 +30,6 @@ import java.awt.Graphics2D;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
 import net.runelite.api.Client;
-import net.runelite.api.GameState;
 import net.runelite.api.Point;
 import net.runelite.api.Varbits;
 import net.runelite.api.widgets.Widget;
@@ -63,12 +62,14 @@ public class SpecOrbOverlay extends Overlay
 		this.client = client;
 		this.config = config;
 		this.plugin = plugin;
+		this.setDrawOverClickToPlayScreen(false);
+		this.setDrawOverLoginScreen(false);
 	}
 
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
-		if (client.getGameState() != GameState.LOGGED_IN || !config.enabled())
+		if (!config.enabled())
 		{
 			return null;
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/specorb/SpecOrbOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/specorb/SpecOrbOverlay.java
@@ -62,8 +62,6 @@ public class SpecOrbOverlay extends Overlay
 		this.client = client;
 		this.config = config;
 		this.plugin = plugin;
-		this.setDrawOverClickToPlayScreen(false);
-		this.setDrawOverLoginScreen(false);
 	}
 
 	@Override

--- a/runelite-client/src/main/java/net/runelite/client/plugins/volcanicmine/VolcanicMineOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/volcanicmine/VolcanicMineOverlay.java
@@ -41,7 +41,6 @@ import javax.imageio.ImageIO;
 import javax.inject.Inject;
 import net.runelite.api.Client;
 import net.runelite.api.GameObject;
-import net.runelite.api.GameState;
 import net.runelite.api.Perspective;
 import net.runelite.api.Point;
 import net.runelite.api.Prayer;
@@ -79,12 +78,13 @@ public class VolcanicMineOverlay extends Overlay
 		this.client = client;
 		this.plugin = plugin;
 		this.config = config;
+		this.setDrawOverLoginScreen(false);
 	}
 
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
-		if (client == null || client.getGameState() != GameState.LOGGED_IN || !plugin.getInside() || !config.enabled())
+		if (client == null || !plugin.getInside() || !config.enabled())
 		{
 			return null;
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/volcanicmine/VolcanicMineOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/volcanicmine/VolcanicMineOverlay.java
@@ -78,7 +78,6 @@ public class VolcanicMineOverlay extends Overlay
 		this.client = client;
 		this.plugin = plugin;
 		this.config = config;
-		this.setDrawOverLoginScreen(false);
 	}
 
 	@Override

--- a/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingOverlay.java
@@ -35,7 +35,6 @@ import javax.annotation.Nullable;
 import javax.inject.Inject;
 import static net.runelite.api.AnimationID.*;
 import net.runelite.api.Client;
-import net.runelite.api.GameState;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.OverlayPriority;
@@ -70,12 +69,13 @@ class WoodcuttingOverlay extends Overlay
 		this.client = client;
 		this.plugin = plugin;
 		this.config = config;
+		this.setDrawOverLoginScreen(false);
 	}
 
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
-		if (client.getGameState() != GameState.LOGGED_IN || !config.enabled())
+		if (!config.enabled())
 		{
 			return null;
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingOverlay.java
@@ -69,7 +69,6 @@ class WoodcuttingOverlay extends Overlay
 		this.client = client;
 		this.plugin = plugin;
 		this.config = config;
-		this.setDrawOverLoginScreen(false);
 	}
 
 	@Override

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesOverlay.java
@@ -40,7 +40,6 @@ import javax.imageio.ImageIO;
 import javax.inject.Inject;
 import net.runelite.api.Client;
 import net.runelite.api.Experience;
-import net.runelite.api.GameState;
 import net.runelite.api.Point;
 import net.runelite.api.Skill;
 import net.runelite.client.ui.overlay.Overlay;
@@ -82,6 +81,7 @@ public class XpGlobesOverlay extends Overlay
 		this.client = client;
 		this.plugin = plugin;
 		this.config = config;
+		this.setDrawOverLoginScreen(false);
 	}
 
 	@Override
@@ -89,7 +89,7 @@ public class XpGlobesOverlay extends Overlay
 	{
 
 		// won't draw if not logged in or not enabled
-		if (client.getGameState() != GameState.LOGGED_IN || !config.enabled())
+		if (!config.enabled())
 		{
 			return null;
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesOverlay.java
@@ -81,7 +81,6 @@ public class XpGlobesOverlay extends Overlay
 		this.client = client;
 		this.plugin = plugin;
 		this.config = config;
-		this.setDrawOverLoginScreen(false);
 	}
 
 	@Override

--- a/runelite-client/src/main/java/net/runelite/client/plugins/zulrah/ZulrahOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/zulrah/ZulrahOverlay.java
@@ -79,7 +79,6 @@ public class ZulrahOverlay extends Overlay
 		super(OverlayPosition.DYNAMIC);
 		this.client = client;
 		this.plugin = plugin;
-		this.setDrawOverLoginScreen(false);
 	}
 
 	@Override

--- a/runelite-client/src/main/java/net/runelite/client/plugins/zulrah/ZulrahOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/zulrah/ZulrahOverlay.java
@@ -40,7 +40,6 @@ import javax.annotation.Nullable;
 import javax.imageio.ImageIO;
 import javax.inject.Inject;
 import net.runelite.api.Client;
-import net.runelite.api.GameState;
 import net.runelite.api.Perspective;
 import net.runelite.api.Point;
 import net.runelite.api.Prayer;
@@ -80,6 +79,7 @@ public class ZulrahOverlay extends Overlay
 		super(OverlayPosition.DYNAMIC);
 		this.client = client;
 		this.plugin = plugin;
+		this.setDrawOverLoginScreen(false);
 	}
 
 	@Override
@@ -87,7 +87,7 @@ public class ZulrahOverlay extends Overlay
 	{
 		ZulrahInstance instance = plugin.getInstance();
 
-		if (instance == null || client.getGameState() != GameState.LOGGED_IN)
+		if (instance == null)
 		{
 			return null;
 		}

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/DynamicRenderer.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/DynamicRenderer.java
@@ -43,6 +43,9 @@ public class DynamicRenderer implements Renderer
 	{
 		for (Overlay overlay : overlays)
 		{
+			if (!overlay.isDrawn())
+				continue;
+
 			Graphics2D graphics = clientBuffer.createGraphics();
 			Renderer.setAntiAliasing(graphics);
 			overlay.render(graphics);

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/Overlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/Overlay.java
@@ -25,6 +25,11 @@
 
 package net.runelite.client.ui.overlay;
 
+import net.runelite.api.Client;
+import net.runelite.api.GameState;
+import net.runelite.api.widgets.WidgetInfo;
+
+import javax.inject.Inject;
 import java.awt.Dimension;
 import java.awt.Graphics2D;
 import java.awt.Rectangle;
@@ -34,6 +39,12 @@ public abstract class Overlay
 	private OverlayPosition position; // where to draw it
 	private OverlayPriority priority; // if multiple overlays exist in the same position, who wins
 	private Rectangle bounds; //screen bounds of overlay after OverlayRenderer decides location
+	private boolean drawOverLoginScreen = true;
+	private boolean drawOverBankScreen = true;
+	private boolean drawOverClickToPlayScreen = true;
+
+	@Inject
+	Client client;
 
 	public Overlay(OverlayPosition position)
 	{
@@ -76,5 +87,39 @@ public abstract class Overlay
 	public void storeBounds(Rectangle bounds)
 	{
 		this.bounds = bounds;
+	}
+
+	public boolean isDrawn()
+	{
+		if(client == null)
+			return false;
+		if (!drawOverLoginScreen && client.getGameState() != GameState.LOGGED_IN)
+		{
+			return false;
+		}
+		if (!drawOverClickToPlayScreen && client.getWidget(WidgetInfo.LOGIN_CLICK_TO_PLAY_SCREEN) != null)
+		{
+			return false;
+		}
+		if (!drawOverBankScreen && client.getWidget(WidgetInfo.BANK_INVENTORY_ITEMS_CONTAINER) != null)
+		{
+			return false;
+		}
+		return true;
+	}
+
+	public void setDrawOverLoginScreen(boolean drawOverLoginScreen)
+	{
+		this.drawOverLoginScreen = drawOverLoginScreen;
+	}
+
+	public void setDrawOverBankScreen(boolean drawOverBankScreen)
+	{
+		this.drawOverBankScreen = drawOverBankScreen;
+	}
+
+	public void setDrawOverClickToPlayScreen(boolean drawOverClickToPlayScreen)
+	{
+		this.drawOverClickToPlayScreen = drawOverClickToPlayScreen;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/Overlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/Overlay.java
@@ -39,9 +39,9 @@ public abstract class Overlay
 	private OverlayPosition position; // where to draw it
 	private OverlayPriority priority; // if multiple overlays exist in the same position, who wins
 	private Rectangle bounds; //screen bounds of overlay after OverlayRenderer decides location
-	private boolean drawOverLoginScreen = true;
-	private boolean drawOverBankScreen = true;
-	private boolean drawOverClickToPlayScreen = true;
+	private boolean drawOverLoginScreen = false;
+	private boolean drawOverBankScreen = false;
+	private boolean drawOverClickToPlayScreen = false;
 
 	@Inject
 	Client client;
@@ -91,7 +91,7 @@ public abstract class Overlay
 
 	public boolean isDrawn()
 	{
-		if(client == null)
+		if (client == null)
 			return false;
 		if (!drawOverLoginScreen && client.getGameState() != GameState.LOGGED_IN)
 		{

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/TopDownRendererLeft.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/TopDownRendererLeft.java
@@ -52,6 +52,9 @@ public class TopDownRendererLeft implements Renderer
 
 		for (Overlay overlay : overlays)
 		{
+			if (!overlay.isDrawn())
+				continue;
+
 			BufferedImage image = clientBuffer.getSubimage(BORDER_LEFT, y, clientBuffer.getWidth() - BORDER_LEFT, clientBuffer.getHeight() - y);
 			Graphics2D graphics = image.createGraphics();
 			Renderer.setAntiAliasing(graphics);

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/TopDownRendererRight.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/TopDownRendererRight.java
@@ -30,6 +30,7 @@ import java.awt.Rectangle;
 import java.awt.image.BufferedImage;
 import java.util.ArrayList;
 import java.util.List;
+
 import net.runelite.api.Client;
 
 public class TopDownRendererRight implements Renderer
@@ -62,6 +63,9 @@ public class TopDownRendererRight implements Renderer
 
 		for (Overlay overlay : overlays)
 		{
+			if (!overlay.isDrawn())
+				continue;
+
 			BufferedImage image = new BufferedImage(clientWidth, clientHeight, BufferedImage.TYPE_INT_ARGB);
 			Graphics2D graphics = image.createGraphics();
 			Renderer.setAntiAliasing(graphics);

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/infobox/InfoBoxOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/infobox/InfoBoxOverlay.java
@@ -33,7 +33,6 @@ import java.awt.Rectangle;
 import java.awt.image.BufferedImage;
 import java.util.List;
 import net.runelite.api.Client;
-import net.runelite.api.GameState;
 import net.runelite.api.Point;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayPosition;
@@ -58,16 +57,12 @@ public class InfoBoxOverlay extends Overlay
 		this.client = client;
 		this.tooltipRenderer = tooltipRenderer;
 		this.infoboxManager = infoboxManager;
+		this.setDrawOverLoginScreen(false);
 	}
 
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
-		if (client.getGameState() != GameState.LOGGED_IN)
-		{
-			return null;
-		}
-
 		List<InfoBox> infoBoxes = infoboxManager.getInfoBoxes();
 
 		if (infoBoxes.isEmpty())

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/infobox/InfoBoxOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/infobox/InfoBoxOverlay.java
@@ -57,7 +57,6 @@ public class InfoBoxOverlay extends Overlay
 		this.client = client;
 		this.tooltipRenderer = tooltipRenderer;
 		this.infoboxManager = infoboxManager;
-		this.setDrawOverLoginScreen(false);
 	}
 
 	@Override


### PR DESCRIPTION
Instead of checking the login state, click to play screen, and bank interface inside a plugin's overlay render method, the check is now inside of their super class Overlay.

This means that checks in a plugin's overlay like this:
```
if(client.getGameState() != GameState.LOGGED_IN || client.getWidget(WidgetInfo.LOGIN_CLICK_TO_PLAY_SCREEN) != null)
{
    return null
}
```

Now become

```
this.setDrawOverClickToPlayScreen(false);
this.setDrawOverLoginScreen(false);
```
Inside the plugin overlay constructor.

There is also a flag for drawing over the bank interface, which avoids having things like ground items drawing while the bank screen is open.

```
this.setDrawOverBankScreen(false);
```