### PR TITLE
Add support for native notifications

### DIFF
--- a/runelite-client/pom.xml
+++ b/runelite-client/pom.xml
@@ -76,6 +76,17 @@
 			<version>2.4</version>
 		</dependency>
 		<dependency>
+			<groupId>fr.jcgay.send-notification</groupId>
+			<artifactId>send-notification</artifactId>
+			<version>0.14.0</version>
+			<exclusions>
+				<exclusion>
+					<groupId>com.squareup.okhttp</groupId>
+					<artifactId>okhttp</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
 			<groupId>org.pushingpixels</groupId>
 			<artifactId>substance</artifactId>
 			<version>7.1.00-rc</version>
@@ -92,7 +103,7 @@
 			<version>1.16.18</version>
 			<scope>provided</scope>
 		</dependency>
-		
+
 		<dependency>
 			<groupId>net.runelite</groupId>
 			<artifactId>api</artifactId>
@@ -115,7 +126,7 @@
 			<artifactId>http-api</artifactId>
 			<version>${project.version}</version>
 		</dependency>
-		
+
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>


### PR DESCRIPTION
Replace current TrayIcon notifications with system-native notifications.
Supports most of the operating systems (the important ones are Windows,
Linux and OS X).

Resolves: #230

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>