### PR TITLE
Add hide items under value to GroundItems plugin

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
@@ -85,4 +85,24 @@ public interface GroundItemsConfig extends Config
 	{
 		return "";
 	}
+
+	@ConfigItem(
+		keyName = "hideUnderGeValue",
+		name = "Hide < GE Value",
+		description = "Configures hidden ground items under GE value"
+	)
+	default int getHideUnderGeValue()
+	{
+		return 0;
+	}
+
+	@ConfigItem(
+		keyName = "hideUnderHaValue",
+		name = "Hide < HA Value",
+		description = "Configures hidden ground items under High Alch value"
+	)
+	default int getHideUnderHAValue()
+	{
+		return 0;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
@@ -205,13 +205,24 @@ public class GroundItemsOverlay extends Overlay
 					Integer currentQuantity = items.get(itemId);
 					if (!hiddenItems.contains(itemDefinition.getName().toLowerCase()))
 					{
-						if (currentQuantity == null)
+						if (itemDefinition.getNote() != -1)
 						{
-							items.put(itemId, itemQuantity);
+							itemId = itemDefinition.getLinkedNoteId();
 						}
-						else
+
+						int quantity = currentQuantity == null
+							? itemQuantity
+							: currentQuantity + itemQuantity;
+
+						ItemPrice itemPrice = itemManager.get(itemId);
+
+						int gePrice = itemPrice == null ? 0 : itemPrice.getPrice() * quantity;
+						int alchPrice = Math.round(itemDefinition.getPrice() * HIGH_ALCHEMY_CONSTANT);
+
+						if (gePrice == 0 || ((gePrice >= config.getHideUnderGeValue()) &&
+								(alchPrice >= config.getHideUnderHAValue())))
 						{
-							items.put(itemId, currentQuantity + itemQuantity);
+							items.put(itemId, quantity);
 						}
 					}
 


### PR DESCRIPTION
Add option to hide items under either Grand Exchange or High Alchemy
value to GroundItems plugin. Also ensure that items with 0 or no GE
price are shown anyway, as they are probably untradeables or inactive.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>