### PR TITLE
Add editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+[*.java]
+indent_style = tab
+indent_size = 4


### PR DESCRIPTION
Add editorconfig configuration to use tabs in .java files.

[Editorconfig](http://editorconfig.org/) is widely adapted configuration format for IDEs to determine what indentation and whitespace rules to use when editing files. It is built in in editor like IntelliJ Idea and Visual Studio and have plugins for f.e. Eclipse and Vim. When using non-standard rules, like tabs instead of spaces in Java files, it is very convenient to have a way to automatically tell most of the editors to honor that, so having .editorconfig file with that rule is very nice.