### PR TITLE
Add native window switch

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/RuneLite.java
+++ b/runelite-client/src/main/java/net/runelite/client/RuneLite.java
@@ -94,6 +94,7 @@ public class RuneLite
 		OptionParser parser = new OptionParser();
 		parser.accepts("developer-mode");
 		parser.accepts("no-rs");
+		parser.accepts("native-window");
 		setOptions(parser.parse(args));
 
 		PROFILES_DIR.mkdirs();

--- a/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
@@ -57,6 +57,7 @@ import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.GameState;
+import net.runelite.client.RuneLite;
 import net.runelite.client.RuneliteProperties;
 import org.pushingpixels.substance.api.skin.SubstanceGraphiteLookAndFeel;
 import org.pushingpixels.substance.internal.ui.SubstanceRootPaneUI;
@@ -110,8 +111,11 @@ public class ClientUI extends JFrame
 		// the applet is resized.
 		System.setProperty("sun.awt.noerasebackground", "true");
 
+		// Determine if we should use native look
+		boolean nativeLook = RuneLite.getOptions().has("native-window");
+
 		// Use custom window decorations
-		JFrame.setDefaultLookAndFeelDecorated(true);
+		JFrame.setDefaultLookAndFeelDecorated(!nativeLook);
 
 		// Use substance look and feel
 		try
@@ -127,7 +131,15 @@ public class ClientUI extends JFrame
 		setUIFont(new FontUIResource(StyleContext.getDefaultStyleContext()
 				.getFont(FontManager.getRunescapeFont().getName(), Font.PLAIN, 16)));
 
-		return new ClientUI(properties, client);
+		final ClientUI ui = new ClientUI(properties, client);
+
+		// Edit title bar if we are not using native look
+		if (!nativeLook)
+		{
+			new TitleBarPane(ui.getRootPane(), (SubstanceRootPaneUI)ui.getRootPane().getUI()).editTitleBar(ui);
+		}
+
+		return ui;
 	}
 
 	private ClientUI(RuneliteProperties properties, Applet client)
@@ -138,7 +150,6 @@ public class ClientUI extends JFrame
 
 		init();
 		pack();
-		new TitleBarPane(this.getRootPane(), (SubstanceRootPaneUI)this.getRootPane().getUI()).editTitleBar(this);
 		setTitle(null);
 		setIconImage(ICON);
 		setLocationRelativeTo(getOwner());


### PR DESCRIPTION
Add command line option -native-window to use native window instead of
window with custom decorations in order to let system properly handle
and decorate window. Changing this option on the fly is not supported
by Swing, so at least having it as command-line parameter is good
solution.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>