### PR TITLE
Cleanup overlay logic after native-ui changes

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/config/RuneliteConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/RuneliteConfig.java
@@ -32,16 +32,6 @@ package net.runelite.client.config;
 public interface RuneliteConfig extends Config
 {
 	@ConfigItem(
-		keyName = "tooltipLeft",
-		name = "Tooltip left of mouse?",
-		description = "Places the tooltip on the left side of the mouse"
-	)
-	default boolean tooltipLeft()
-	{
-		return false;
-	}
-
-	@ConfigItem(
 		keyName = "chatCommandsRecolorEnabled",
 		name = "Enable chat commands recolor",
 		description = "Determines if recoloring of custom RuneLite chat commands is enabled"

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
@@ -48,6 +48,7 @@ import net.runelite.api.Region;
 import net.runelite.api.Tile;
 import net.runelite.api.widgets.Widget;
 import net.runelite.client.game.ItemManager;
+import net.runelite.client.ui.FontManager;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.http.api.item.ItemPrice;
@@ -139,6 +140,8 @@ public class GroundItemsOverlay extends Overlay
 		{
 			return null;
 		}
+
+		graphics.setFont(FontManager.getRunescapeSmallFont());
 
 		int z = client.getPlane();
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/jewellerycount/JewelleryCountOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/jewellerycount/JewelleryCountOverlay.java
@@ -24,10 +24,7 @@
  */
 package net.runelite.client.plugins.jewellerycount;
 
-import java.awt.Color;
 import java.awt.Dimension;
-import java.awt.Font;
-import java.awt.FontMetrics;
 import java.awt.Graphics2D;
 import java.awt.Point;
 import java.awt.Rectangle;
@@ -35,7 +32,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import javax.inject.Inject;
-import net.runelite.api.Client;
 import net.runelite.api.Query;
 import net.runelite.api.queries.EquipmentItemQuery;
 import net.runelite.api.queries.InventoryItemQuery;
@@ -45,20 +41,18 @@ import net.runelite.client.RuneLite;
 import net.runelite.client.ui.FontManager;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.components.TextComponent;
 
 class JewelleryCountOverlay extends Overlay
 {
 	private final RuneLite runelite;
-	private final Client client;
 	private final JewelleryCountConfig config;
-	private final Font font = FontManager.getRunescapeSmallFont().deriveFont(Font.PLAIN, 16);
 
 	@Inject
 	JewelleryCountOverlay(RuneLite runelite, JewelleryCountConfig config)
 	{
 		setPosition(OverlayPosition.DYNAMIC);
 		this.runelite = runelite;
-		this.client = runelite.getClient();
 		this.config = config;
 		this.setDrawOverBankScreen(true);
 	}
@@ -71,7 +65,7 @@ class JewelleryCountOverlay extends Overlay
 			return null;
 		}
 
-		graphics.setFont(font);
+		graphics.setFont(FontManager.getRunescapeSmallFont());
 
 		for (WidgetItem item : getJewelleryWidgetItems())
 		{
@@ -82,8 +76,11 @@ class JewelleryCountOverlay extends Overlay
 				continue;
 			}
 
-			renderWidgetText(graphics, item.getCanvasBounds(), charges.getCharges(), Color.white);
-
+			final Rectangle bounds = item.getCanvasBounds();
+			final TextComponent textComponent = new TextComponent();
+			textComponent.setPosition(new Point(bounds.x, bounds.y + 16));
+			textComponent.setText(String.valueOf(charges.getCharges()));
+			textComponent.render(graphics, parent);
 		}
 
 		return null;
@@ -106,20 +103,4 @@ class JewelleryCountOverlay extends Overlay
 		jewellery.addAll(Arrays.asList(equipmentWidgetItems));
 		return jewellery;
 	}
-
-	private void renderWidgetText(Graphics2D graphics, Rectangle bounds, int charges, Color color)
-	{
-		FontMetrics fm = graphics.getFontMetrics();
-
-		int textX = (int) bounds.getX();
-		int textY = (int) bounds.getY() + fm.getHeight();
-
-		//text shadow
-		graphics.setColor(Color.BLACK);
-		graphics.drawString(String.valueOf(charges), textX + 1, textY + 1);
-
-		graphics.setColor(color);
-		graphics.drawString(String.valueOf(charges), textX, textY);
-	}
-
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/runecraft/BindNeckOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/runecraft/BindNeckOverlay.java
@@ -28,8 +28,6 @@ package net.runelite.client.plugins.runecraft;
 import static net.runelite.api.ItemID.BINDING_NECKLACE;
 import java.awt.Color;
 import java.awt.Dimension;
-import java.awt.Font;
-import java.awt.FontMetrics;
 import java.awt.Graphics2D;
 import java.awt.Point;
 import java.awt.Rectangle;
@@ -37,7 +35,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import javax.inject.Inject;
-import net.runelite.api.Client;
 import net.runelite.api.Query;
 import net.runelite.api.queries.EquipmentItemQuery;
 import net.runelite.api.queries.InventoryItemQuery;
@@ -47,13 +44,12 @@ import net.runelite.client.RuneLite;
 import net.runelite.client.ui.FontManager;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.components.TextComponent;
 
 public class BindNeckOverlay extends Overlay
 {
 	private final RuneLite runelite;
-	private final Client client;
 	private final RunecraftConfig config;
-	private final Font font = FontManager.getRunescapeSmallFont().deriveFont(Font.PLAIN, 16);
 	int bindingCharges;
 
 	@Inject
@@ -61,7 +57,6 @@ public class BindNeckOverlay extends Overlay
 	{
 		setPosition(OverlayPosition.DYNAMIC);
 		this.runelite = runelite;
-		this.client = runelite.getClient();
 		this.config = config;
 		this.setDrawOverBankScreen(true);
 	}
@@ -74,12 +69,19 @@ public class BindNeckOverlay extends Overlay
 			return null;
 		}
 
-		graphics.setFont(font);
+		graphics.setFont(FontManager.getRunescapeSmallFont());
 
 		for (WidgetItem necklace : getNecklaceWidgetItems())
 		{
-			Color color = bindingCharges == 1 ? Color.RED : Color.WHITE;
-			renderBindNeck(graphics, necklace.getCanvasBounds(), bindingCharges, color);
+			final Color color = bindingCharges == 1 ? Color.RED : Color.WHITE;
+			final Rectangle bounds = necklace.getCanvasBounds();
+			final String text = bindingCharges <= 0 ? "?" : bindingCharges + "";
+
+			final TextComponent textComponent = new TextComponent();
+			textComponent.setPosition(new Point(bounds.x, bounds.y + 16));
+			textComponent.setText(text);
+			textComponent.setColor(color);
+			textComponent.render(graphics, parent);
 		}
 
 		return null;
@@ -100,21 +102,5 @@ public class BindNeckOverlay extends Overlay
 		necklaces.addAll(Arrays.asList(inventoryWidgetItems));
 		necklaces.addAll(Arrays.asList(equipmentWidgetItems));
 		return necklaces;
-	}
-
-	private void renderBindNeck(Graphics2D graphics, Rectangle bounds, int charges, Color color)
-	{
-		String text = charges <= 0 ? "?" : charges + "";
-		FontMetrics fm = graphics.getFontMetrics();
-
-		int textX = (int) bounds.getX();
-		int textY = (int) bounds.getY() + fm.getHeight();
-
-		//text shadow
-		graphics.setColor(Color.BLACK);
-		graphics.drawString(text, textX + 1, textY + 1);
-
-		graphics.setColor(color);
-		graphics.drawString(text, textX, textY);
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/runecraft/RunecraftOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/runecraft/RunecraftOverlay.java
@@ -24,10 +24,7 @@
  */
 package net.runelite.client.plugins.runecraft;
 
-import java.awt.Color;
 import java.awt.Dimension;
-import java.awt.Font;
-import java.awt.FontMetrics;
 import java.awt.Graphics2D;
 import java.awt.Point;
 import java.awt.Rectangle;
@@ -42,6 +39,7 @@ import net.runelite.client.RuneLite;
 import net.runelite.client.ui.FontManager;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.components.TextComponent;
 
 public class RunecraftOverlay extends Overlay
 {
@@ -51,7 +49,6 @@ public class RunecraftOverlay extends Overlay
 
 	private final RuneLite runelite;
 	private final Client client;
-	private final Font font = FontManager.getRunescapeSmallFont().deriveFont(Font.PLAIN, 16);
 
 	private final RunecraftConfig config;
 
@@ -73,10 +70,10 @@ public class RunecraftOverlay extends Overlay
 			return null;
 		}
 
-		graphics.setFont(font);
-
 		Query query = new InventoryItemQuery();
 		WidgetItem[] widgetItems = runelite.runQuery(query);
+		graphics.setFont(FontManager.getRunescapeSmallFont());
+
 		for (WidgetItem item : widgetItems)
 		{
 			Varbits varbits;
@@ -102,25 +99,13 @@ public class RunecraftOverlay extends Overlay
 					continue;
 			}
 
-			renderPouch(graphics, item.getCanvasBounds(), varbits, Color.WHITE);
+			final Rectangle bounds = item.getCanvasBounds();
+			final TextComponent textComponent = new TextComponent();
+			textComponent.setPosition(new Point(bounds.x, bounds.y + 16));
+			textComponent.setText(String.valueOf(client.getSetting(varbits)));
+			textComponent.render(graphics, parent);
 		}
+
 		return null;
-	}
-
-	private void renderPouch(Graphics2D graphics, Rectangle bounds, Varbits varbits, Color color)
-	{
-		FontMetrics fm = graphics.getFontMetrics();
-
-		int textX = (int) bounds.getX();
-		int textY = (int) bounds.getY() + fm.getHeight();
-
-		int contents = client.getSetting(varbits);
-
-		//text shadow
-		graphics.setColor(Color.BLACK);
-		graphics.drawString(String.valueOf(contents), textX + 1, textY + 1);
-
-		graphics.setColor(color);
-		graphics.drawString(String.valueOf(contents), textX, textY);
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerOverlay.java
@@ -27,17 +27,13 @@ package net.runelite.client.plugins.slayer;
 import static com.google.common.collect.ObjectArrays.concat;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Sets;
-import java.awt.Color;
 import java.awt.Dimension;
-import java.awt.Font;
-import java.awt.FontMetrics;
 import java.awt.Graphics2D;
 import java.awt.Point;
 import java.awt.Rectangle;
 import java.util.Collection;
 import java.util.Set;
 import javax.inject.Inject;
-import net.runelite.api.Client;
 import net.runelite.api.ItemID;
 import net.runelite.api.Query;
 import net.runelite.api.queries.EquipmentItemQuery;
@@ -48,14 +44,13 @@ import net.runelite.client.RuneLite;
 import net.runelite.client.ui.FontManager;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.components.TextComponent;
 
 class SlayerOverlay extends Overlay
 {
 	private final RuneLite runelite;
-	private final Client client;
 	private final SlayerConfig config;
 	private final SlayerPlugin plugin;
-	private final Font font = FontManager.getRunescapeSmallFont().deriveFont(Font.PLAIN, 16);
 
 	private final Set<Integer> slayerJewelry = Sets.newHashSet(
 		ItemID.SLAYER_RING_1,
@@ -89,7 +84,6 @@ class SlayerOverlay extends Overlay
 	{
 		setPosition(OverlayPosition.DYNAMIC);
 		this.runelite = runelite;
-		this.client = runelite.getClient();
 		this.plugin = plugin;
 		this.config = config;
 	}
@@ -113,7 +107,7 @@ class SlayerOverlay extends Overlay
 			return null;
 		}
 
-		graphics.setFont(font);
+		graphics.setFont(FontManager.getRunescapeSmallFont());
 
 		for (WidgetItem item : getSlayerWidgetItems())
 		{
@@ -124,7 +118,12 @@ class SlayerOverlay extends Overlay
 				continue;
 			}
 
-			renderWidgetText(graphics, itemId, item.getCanvasBounds(), amount, Color.white);
+			final Rectangle bounds = item.getCanvasBounds();
+			final TextComponent textComponent = new TextComponent();
+			textComponent.setText(String.valueOf(amount));
+			textComponent.setPosition(new Point(bounds.x, (slayerJewelry.contains(itemId)
+				? bounds.x
+				: 16 )));
 		}
 
 		return null;
@@ -140,20 +139,5 @@ class SlayerOverlay extends Overlay
 
 		WidgetItem[] items = concat(inventoryWidgetItems, equipmentWidgetItems, WidgetItem.class);
 		return ImmutableList.copyOf(items);
-	}
-
-	private void renderWidgetText(Graphics2D graphics, int itemId, Rectangle bounds, int amount, Color color)
-	{
-		FontMetrics fm = graphics.getFontMetrics();
-
-		int textX = (int) bounds.getX();
-		int textY = (int) bounds.getY() + (slayerJewelry.contains(itemId) ? (int) bounds.getHeight() : fm.getHeight());
-
-		//text shadow
-		graphics.setColor(Color.BLACK);
-		graphics.drawString(String.valueOf(amount), textX + 1, textY + 1);
-
-		graphics.setColor(color);
-		graphics.drawString(String.valueOf(amount), textX, textY);
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/volcanicmine/VolcanicMineOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/volcanicmine/VolcanicMineOverlay.java
@@ -27,7 +27,6 @@ package net.runelite.client.plugins.volcanicmine;
 
 import java.awt.Color;
 import java.awt.Dimension;
-import java.awt.Font;
 import java.awt.Graphics2D;
 import java.awt.Image;
 import java.awt.Polygon;
@@ -47,7 +46,6 @@ import net.runelite.api.Point;
 import net.runelite.api.Prayer;
 import net.runelite.api.Region;
 import net.runelite.api.Tile;
-import net.runelite.client.ui.FontManager;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.OverlayUtil;
@@ -86,11 +84,6 @@ public class VolcanicMineOverlay extends Overlay
 			return null;
 		}
 
-		Font font = FontManager.getRunescapeFont();
-		if (font != null)
-		{
-			graphics.setFont(font);
-		}
 		renderTileObjects(graphics);
 		renderRangePrayer(graphics);
 		return null;

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/Overlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/Overlay.java
@@ -27,7 +27,7 @@ package net.runelite.client.ui.overlay;
 import lombok.Data;
 
 @Data
-public abstract class Overlay extends RenderableEntity
+public abstract class Overlay implements RenderableEntity
 {
 	private OverlayPosition position = OverlayPosition.TOP_LEFT;
 	private OverlayPriority priority = OverlayPriority.NONE;

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/RenderableEntity.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/RenderableEntity.java
@@ -28,10 +28,7 @@ import java.awt.Dimension;
 import java.awt.Graphics2D;
 import java.awt.Point;
 
-public abstract class RenderableEntity
+public interface RenderableEntity
 {
-	public Dimension render(Graphics2D graphics, Point parent)
-	{
-		return null;
-	}
+	Dimension render(Graphics2D graphics, Point parent);
 }

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/components/BackgroundComponent.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/components/BackgroundComponent.java
@@ -36,7 +36,7 @@ import net.runelite.client.ui.overlay.RenderableEntity;
 
 @NoArgsConstructor
 @AllArgsConstructor
-public class BackgroundComponent extends RenderableEntity
+public class BackgroundComponent implements RenderableEntity
 {
 	private static final int BORDER_OFFSET = 2;
 	private static final Color BACKGROUND_COLOR = new Color(70, 61, 50, 156);

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/components/InfoBoxComponent.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/components/InfoBoxComponent.java
@@ -36,7 +36,7 @@ import javax.annotation.Nullable;
 import lombok.Setter;
 import net.runelite.client.ui.overlay.RenderableEntity;
 
-public class InfoBoxComponent extends RenderableEntity
+public class InfoBoxComponent implements RenderableEntity
 {
 	private static final int BOX_SIZE = 35;
 	private static final int SEPARATOR = 2;

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/components/PanelComponent.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/components/PanelComponent.java
@@ -41,7 +41,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import net.runelite.client.ui.overlay.RenderableEntity;
 
-public class PanelComponent extends RenderableEntity
+public class PanelComponent implements RenderableEntity
 {
 	private static final int TOP_BORDER = 3;
 	private static final int LEFT_BORDER = 6;

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/components/TextComponent.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/components/TextComponent.java
@@ -32,7 +32,7 @@ import java.awt.Point;
 import lombok.Setter;
 import net.runelite.client.ui.overlay.RenderableEntity;
 
-public class TextComponent extends RenderableEntity
+public class TextComponent implements RenderableEntity
 {
 	@Setter
 	private String text;

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/components/TooltipComponent.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/components/TooltipComponent.java
@@ -33,9 +33,10 @@ import java.awt.Rectangle;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import lombok.Setter;
+import net.runelite.client.ui.FontManager;
 import net.runelite.client.ui.overlay.RenderableEntity;
 
-public class TooltipComponent extends RenderableEntity
+public class TooltipComponent implements RenderableEntity
 {
 	private static final Pattern COLOR_SPLIT = Pattern.compile("<\\/?col=?([^>]+)?>");
 	private static final Pattern BR = Pattern.compile("</br>");
@@ -50,6 +51,8 @@ public class TooltipComponent extends RenderableEntity
 	@Override
 	public Dimension render(Graphics2D graphics, Point parent)
 	{
+		graphics.setFont(FontManager.getRunescapeSmallFont());
+
 		// Tooltip size
 		final FontMetrics metrics = graphics.getFontMetrics();
 		final int textDescent = metrics.getDescent();


### PR DESCRIPTION
- Remove unnecessary derivations of runescapeSmallFont
- Render overlays in "safe" environment (restore original font and
tranform after overlay rendering is done)
- Use TextComponent at more places
- Remove unnecessary setting of default font in VolcanicMineOverlay
- Change RenderableEntity from abstract class to interface
- Remove unused tooltip configuration from RuneliteConfig
- Use viewportWidget instead of chatbox widget for positioning the
overlay groups (thanks to Devin for tip)
- Use small font for tooltips and ground items