### PR TITLE
Fix IllegalArgumentExceptions from XPGlobes' tooltips for level 1 stats

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/Experience.java
+++ b/runelite-api/src/main/java/net/runelite/api/Experience.java
@@ -39,29 +39,29 @@ public class Experience
 
 		for (int level = 1; level <= MAX_VIRT_LEVEL; ++level)
 		{
+			XP_FOR_LEVEL[level - 1] = xp / 4;
+
 			int difference = (int) ((double) level + 300.0 * Math.pow(2.0, (double) level / 7.0));
 			xp += difference;
-
-			XP_FOR_LEVEL[level - 1] = xp / 4;
 		}
 	}
 
 	public static int getXpForLevel(int level)
 	{
-		if (level < 2 || level > MAX_VIRT_LEVEL)
+		if (level < 1 || level > MAX_VIRT_LEVEL)
 		{
-			throw new IllegalArgumentException();
+			throw new IllegalArgumentException(level + " is not a valid level");
 		}
 
-		// XP_FOR_LEVEL[0] is XP for level 2
-		return XP_FOR_LEVEL[level - 2];
+		// XP_FOR_LEVEL[0] is XP for level 1
+		return XP_FOR_LEVEL[level - 1];
 	}
 
 	public static int getLevelForXp(int xp)
 	{
 		if (xp < 0)
 		{
-			throw new IllegalArgumentException();
+			throw new IllegalArgumentException("XP must not be negative");
 		}
 
 		int low = 0;
@@ -82,11 +82,11 @@ public class Experience
 			}
 			else
 			{
-				break;
+				return mid + 1;
 			}
 		}
 
-		return high + 2;
+		return high + 1;
 	}
 
 	public static double getCombatLevelPrecise(int attackLevel, int strengthLevel,

--- a/runelite-api/src/test/java/net/runelite/api/ExperienceTest.java
+++ b/runelite-api/src/test/java/net/runelite/api/ExperienceTest.java
@@ -36,6 +36,21 @@ public class ExperienceTest
 	{
 		int xp = Experience.getXpForLevel(99);
 		Assert.assertEquals(XP_FOR_99, xp);
+
+		xp = Experience.getXpForLevel(1);
+		Assert.assertEquals(0, xp);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testGetXpForHighLevel()
+	{
+		int xp = Experience.getXpForLevel(Integer.MAX_VALUE);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testGetXpForLowLevel()
+	{
+		int xp = Experience.getXpForLevel(0);
 	}
 
 	@Test


### PR DESCRIPTION
To draw the progress bar, `XPGlobesOverlay.drawTooltipIfMouseover()` uses `Experience.getXPForLevel()`, which threw an `IllegalArgumentException` when asked about level 1. This change shifts the `XP_FOR_LEVEL` array over by one, so that `XP_FOR_LEVEL[0]` is the XP required to reach level 1 (i.e. 0), rather than the XP required for level 2.