### PR TITLE
Add support for examining bank and eq items price

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/MenuAction.java
+++ b/runelite-api/src/main/java/net/runelite/api/MenuAction.java
@@ -28,7 +28,19 @@ public enum MenuAction
 {
 	EXAMINE_OBJECT(1002),
 	EXAMINE_NPC(1003),
+	/**
+	 * Menu action triggered by examining item on ground
+	 */
+	EXAMINE_ITEM_GROUND(1004),
+	/**
+	 * Menu action triggered by examining item in inventory
+	 */
 	EXAMINE_ITEM(1005),
+	/**
+	 * Menu action triggered by either examining item in bank, examining item
+	 * in inventory while having bank open, or examining equipped item
+	 */
+	EXAMINE_ITEM_BANK_EQ(1007),
 	/**
 	 * Menu action injected by runelite for its menu items
 	 */

--- a/runelite-client/src/main/java/net/runelite/client/plugins/examine/ExaminePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/examine/ExaminePlugin.java
@@ -266,13 +266,15 @@ public class ExaminePlugin extends Plugin
 			}
 
 			message
-				.append(itemComposition.getName());
+				.append(itemComposition.getName())
+				.append(ChatColorType.NORMAL)
+				.append(":");
 
 			if (gePrice > 0)
 			{
 				message
 					.append(ChatColorType.NORMAL)
-					.append(": GE average ")
+					.append(" GE average ")
 					.append(ChatColorType.HIGHLIGHT)
 					.append(String.format("%,d", gePrice));
 			}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/examine/ExamineType.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/examine/ExamineType.java
@@ -27,6 +27,7 @@ package net.runelite.client.plugins.examine;
 public enum ExamineType
 {
 	ITEM,
+	ITEM_BANK_EQ,
 	NPC,
 	OBJECT;
 }


### PR DESCRIPTION
Add support for showing bank, bank inventory and equipment item prices
when examined.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>