### PR TITLE
Decouple RuneLite class

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ClientLoader.java
+++ b/runelite-client/src/main/java/net/runelite/client/ClientLoader.java
@@ -28,10 +28,44 @@ import java.applet.Applet;
 import java.io.IOException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.http.api.updatecheck.UpdateCheckClient;
 
+@Slf4j
 public class ClientLoader
 {
-	public Applet loadRunelite() throws ClassNotFoundException, IOException, InstantiationException, IllegalAccessException
+	public Optional<Applet> loadRs()
+	{
+		final UpdateCheckClient updateCheck = new UpdateCheckClient();
+		boolean isOutdated = updateCheck.isOutdated();
+
+		try
+		{
+			if (isOutdated)
+			{
+				log.info("Runelite is outdated - fetching vanilla client");
+				return Optional.of(loadVanilla());
+			}
+
+			log.debug("Runelite is up to date");
+			return Optional.of(loadRunelite());
+		}
+		catch (IOException | ClassNotFoundException | InstantiationException | IllegalAccessException e)
+		{
+			if (e instanceof ClassNotFoundException)
+			{
+				log.error("Unable to load client - class not found. This means you"
+					+ " are not running RuneLite with Maven as the injected client"
+					+ " is not in your classpath.");
+			}
+
+			log.error("Error loading RS!", e);
+			return Optional.empty();
+		}
+	}
+
+	private Applet loadRunelite() throws ClassNotFoundException, IOException, InstantiationException, IllegalAccessException
 	{
 		ConfigLoader config = new ConfigLoader();
 
@@ -48,7 +82,7 @@ public class ClientLoader
 		return rs;
 	}
 
-	public Applet loadVanilla() throws IOException, ClassNotFoundException, InstantiationException, IllegalAccessException
+	private Applet loadVanilla() throws IOException, ClassNotFoundException, InstantiationException, IllegalAccessException
 	{
 		ConfigLoader config = new ConfigLoader();
 

--- a/runelite-client/src/main/java/net/runelite/client/Notifier.java
+++ b/runelite-client/src/main/java/net/runelite/client/Notifier.java
@@ -26,6 +26,7 @@ package net.runelite.client;
 
 import com.google.common.escape.Escaper;
 import com.google.common.escape.Escapers;
+import java.awt.Toolkit;
 import java.awt.TrayIcon;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -35,7 +36,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class Notifier
 {
-	private static enum OSType
+	private enum OSType
 	{
 		Windows, MacOS, Linux, Other
 	};
@@ -74,14 +75,28 @@ public class Notifier
 		log.debug("Detect OS: {}", DETECTED_OS);
 	}
 
+	private final String appName;
 	private final TrayIcon trayIcon;
 
-	public Notifier(final TrayIcon trayIcon)
+	Notifier(final String appName, final TrayIcon trayIcon)
 	{
+		this.appName = appName;
 		this.trayIcon = trayIcon;
 	}
 
-	public void sendNotification(
+
+	public void notify(String message)
+	{
+		notify(message, TrayIcon.MessageType.NONE);
+	}
+
+	public void notify(String message, TrayIcon.MessageType type)
+	{
+		sendNotification(appName, message, type, null);
+		Toolkit.getDefaultToolkit().beep();
+	}
+
+	private void sendNotification(
 		final String title,
 		final String message,
 		final TrayIcon.MessageType type,

--- a/runelite-client/src/main/java/net/runelite/client/RuneLite.java
+++ b/runelite-client/src/main/java/net/runelite/client/RuneLite.java
@@ -24,7 +24,6 @@
  */
 package net.runelite.client;
 
-import com.google.common.base.Strings;
 import com.google.common.eventbus.EventBus;
 import com.google.inject.Guice;
 import com.google.inject.Inject;
@@ -184,9 +183,7 @@ public class RuneLite
 				log.warn("unable to set look and feel", ex);
 			}
 
-			gui = new ClientUI(client);
-			setTitle(null);
-
+			gui = new ClientUI(properties, client);
 			setupTrayIcon();
 		});
 
@@ -218,18 +215,6 @@ public class RuneLite
 
 		// Begin watching for new plugins
 		pluginManager.watch();
-	}
-
-	public void setTitle(String extra)
-	{
-		if (!Strings.isNullOrEmpty(extra))
-		{
-			gui.setTitle(properties.getTitle() + " " + properties.getVersion() + " " + extra);
-		}
-		else
-		{
-			gui.setTitle(properties.getTitle() + " " + properties.getVersion());
-		}
 	}
 
 	private void setupTrayIcon()

--- a/runelite-client/src/main/java/net/runelite/client/RuneLite.java
+++ b/runelite-client/src/main/java/net/runelite/client/RuneLite.java
@@ -29,19 +29,9 @@ import com.google.inject.Guice;
 import com.google.inject.Inject;
 import com.google.inject.Injector;
 import java.applet.Applet;
-import java.awt.AWTException;
-import java.awt.Frame;
-import java.awt.Image;
-import java.awt.SystemTray;
-import java.awt.TrayIcon;
-import java.awt.event.MouseAdapter;
-import java.awt.event.MouseEvent;
 import java.io.File;
-import java.io.IOException;
-import java.net.URL;
 import java.util.Optional;
 import java.util.concurrent.ScheduledExecutorService;
-import javax.imageio.ImageIO;
 import javax.inject.Singleton;
 import javax.swing.JFrame;
 import javax.swing.JPopupMenu;
@@ -70,13 +60,10 @@ public class RuneLite
 	public static final File PROFILES_DIR = new File(RUNELITE_DIR, "profiles");
 	public static final File PLUGIN_DIR = new File(RUNELITE_DIR, "plugins");
 
-	public static Image ICON;
-
 	private static Injector injector;
 
 	private static OptionSet options;
 	private static RuneLite runelite;
-	private static TrayIcon trayIcon;
 
 	private ClientUI gui;
 
@@ -109,19 +96,6 @@ public class RuneLite
 
 	Client client;
 	Notifier notifier;
-
-	static
-	{
-		try
-		{
-			final URL icon = ClientUI.class.getResource("/runelite.png");
-			ICON = ImageIO.read(icon.openStream());
-		}
-		catch (IOException ex)
-		{
-			log.warn(null, ex);
-		}
-	}
 
 	public static void main(String[] args) throws Exception
 	{
@@ -184,7 +158,6 @@ public class RuneLite
 			}
 
 			gui = new ClientUI(properties, client);
-			setupTrayIcon();
 		});
 
 		configManager.load();
@@ -194,7 +167,7 @@ public class RuneLite
 		eventBus.register(chatMessageManager);
 
 		// Setup the notifier
-		notifier = new Notifier(properties.getTitle(), trayIcon);
+		notifier = new Notifier(properties.getTitle(), gui.getTrayIcon());
 
 		// Tell the plugin manager if client is outdated or not
 		pluginManager.setOutdated(isOutdated);
@@ -215,40 +188,6 @@ public class RuneLite
 
 		// Begin watching for new plugins
 		pluginManager.watch();
-	}
-
-	private void setupTrayIcon()
-	{
-		if (!SystemTray.isSupported())
-		{
-			return;
-		}
-
-		SystemTray systemTray = SystemTray.getSystemTray();
-
-		trayIcon = new TrayIcon(ICON, properties.getTitle());
-		trayIcon.setImageAutoSize(true);
-
-		try
-		{
-			systemTray.add(trayIcon);
-		}
-		catch (AWTException ex)
-		{
-			log.debug("Unable to add system tray icon", ex);
-			return;
-		}
-
-		// bring to front when tray icon is clicked
-		trayIcon.addMouseListener(new MouseAdapter()
-		{
-			@Override
-			public void mouseClicked(MouseEvent e)
-			{
-				gui.setVisible(true);
-				gui.setState(Frame.NORMAL); // unminimize
-			}
-		});
 	}
 
 	public ClientUI getGui()
@@ -280,10 +219,4 @@ public class RuneLite
 	{
 		RuneLite.options = options;
 	}
-
-	public static TrayIcon getTrayIcon()
-	{
-		return trayIcon;
-	}
-
 }

--- a/runelite-client/src/main/java/net/runelite/client/RuneLite.java
+++ b/runelite-client/src/main/java/net/runelite/client/RuneLite.java
@@ -33,12 +33,7 @@ import java.io.File;
 import java.util.Optional;
 import java.util.concurrent.ScheduledExecutorService;
 import javax.inject.Singleton;
-import javax.swing.JFrame;
-import javax.swing.JPopupMenu;
 import javax.swing.SwingUtilities;
-import javax.swing.ToolTipManager;
-import javax.swing.UIManager;
-import javax.swing.UnsupportedLookAndFeelException;
 import joptsimple.OptionParser;
 import joptsimple.OptionSet;
 import lombok.extern.slf4j.Slf4j;
@@ -50,7 +45,6 @@ import net.runelite.client.menus.MenuManager;
 import net.runelite.client.plugins.PluginManager;
 import net.runelite.client.ui.ClientUI;
 import net.runelite.client.ui.overlay.OverlayRenderer;
-import org.pushingpixels.substance.api.skin.SubstanceGraphiteLookAndFeel;
 
 @Singleton
 @Slf4j
@@ -96,15 +90,6 @@ public class RuneLite
 
 	public static void main(String[] args) throws Exception
 	{
-		// Force heavy-weight popups/tooltips.
-		// Prevents them from being obscured by the game applet.
-		ToolTipManager.sharedInstance().setLightWeightPopupEnabled(false);
-		// Do not render shadows under popups/tooltips.
-		// Fixes black boxes under popups that are above the game applet.
-		System.setProperty("jgoodies.popupDropShadowEnabled", "false");
-		// Do not fill in background on repaint. Reduces flickering when
-		// the applet is resized.
-		System.setProperty("sun.awt.noerasebackground", "true");
 
 		OptionParser parser = new OptionParser();
 		parser.accepts("developer-mode");
@@ -139,25 +124,13 @@ public class RuneLite
 			this.client = (Client) client;
 		}
 
-		SwingUtilities.invokeAndWait(() ->
-		{
-			JFrame.setDefaultLookAndFeelDecorated(true);
-			JPopupMenu.setDefaultLightWeightPopupEnabled(false);
+		// Load swing UI
+		SwingUtilities.invokeAndWait(() -> setGui(ClientUI.create(properties, client)));
 
-			try
-			{
-				UIManager.setLookAndFeel(new SubstanceGraphiteLookAndFeel());
-			}
-			catch (UnsupportedLookAndFeelException ex)
-			{
-				log.warn("unable to set look and feel", ex);
-			}
-
-			setGui(new ClientUI(properties, client));
-		});
-
+		// Load default configuration
 		configManager.load();
 
+		// Register event listeners
 		eventBus.register(overlayRenderer);
 		eventBus.register(menuManager);
 		eventBus.register(chatMessageManager);

--- a/runelite-client/src/main/java/net/runelite/client/RuneLite.java
+++ b/runelite-client/src/main/java/net/runelite/client/RuneLite.java
@@ -34,7 +34,6 @@ import java.awt.AWTException;
 import java.awt.Frame;
 import java.awt.Image;
 import java.awt.SystemTray;
-import java.awt.Toolkit;
 import java.awt.TrayIcon;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
@@ -118,7 +117,7 @@ public class RuneLite
 
 	private AccountSession accountSession;
 
-	private Notifier notifier;
+	Notifier notifier;
 
 	static
 	{
@@ -186,7 +185,7 @@ public class RuneLite
 		eventBus.register(chatMessageManager);
 
 		// Setup the notifier
-		notifier = new Notifier(trayIcon);
+		notifier = new Notifier(properties.getTitle(), trayIcon);
 
 		// Load the plugins, but does not start them yet.
 		// This will initialize configuration
@@ -407,17 +406,6 @@ public class RuneLite
 	public static TrayIcon getTrayIcon()
 	{
 		return trayIcon;
-	}
-
-	public void notify(String message)
-	{
-		notify(message, TrayIcon.MessageType.NONE);
-	}
-
-	public void notify(String message, TrayIcon.MessageType type)
-	{
-		notifier.sendNotification(properties.getTitle(), message, type, null);
-		Toolkit.getDefaultToolkit().beep();
 	}
 
 	public AccountSession getAccountSession()

--- a/runelite-client/src/main/java/net/runelite/client/RuneLite.java
+++ b/runelite-client/src/main/java/net/runelite/client/RuneLite.java
@@ -61,11 +61,7 @@ public class RuneLite
 	public static final File PLUGIN_DIR = new File(RUNELITE_DIR, "plugins");
 
 	private static Injector injector;
-
 	private static OptionSet options;
-	private static RuneLite runelite;
-
-	private ClientUI gui;
 
 	@Inject
 	private RuneliteProperties properties;
@@ -95,6 +91,7 @@ public class RuneLite
 	private SessionManager sessionManager;
 
 	Client client;
+	ClientUI gui;
 	Notifier notifier;
 
 	public static void main(String[] args) throws Exception
@@ -112,13 +109,12 @@ public class RuneLite
 		OptionParser parser = new OptionParser();
 		parser.accepts("developer-mode");
 		parser.accepts("no-rs");
-		options = parser.parse(args);
+		setOptions(parser.parse(args));
 
 		PROFILES_DIR.mkdirs();
 
-		injector = Guice.createInjector(new RuneliteModule());
-		runelite = injector.getInstance(RuneLite.class);
-		runelite.start();
+		setInjector(Guice.createInjector(new RuneliteModule()));
+		injector.getInstance(RuneLite.class).start();
 	}
 
 	public void start() throws Exception
@@ -157,7 +153,7 @@ public class RuneLite
 				log.warn("unable to set look and feel", ex);
 			}
 
-			gui = new ClientUI(properties, client);
+			setGui(new ClientUI(properties, client));
 		});
 
 		configManager.load();
@@ -188,11 +184,6 @@ public class RuneLite
 
 		// Begin watching for new plugins
 		pluginManager.watch();
-	}
-
-	public ClientUI getGui()
-	{
-		return gui;
 	}
 
 	public void setGui(ClientUI gui)

--- a/runelite-client/src/main/java/net/runelite/client/RuneLite.java
+++ b/runelite-client/src/main/java/net/runelite/client/RuneLite.java
@@ -287,8 +287,4 @@ public class RuneLite
 		return trayIcon;
 	}
 
-	public <T> T[] runQuery(Query query)
-	{
-		return (T[]) query.result(client);
-	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/RuneliteModule.java
+++ b/runelite-client/src/main/java/net/runelite/client/RuneliteModule.java
@@ -43,6 +43,7 @@ import net.runelite.client.plugins.PluginManager;
 import net.runelite.client.task.Scheduler;
 import net.runelite.client.ui.ClientUI;
 import net.runelite.client.ui.overlay.infobox.InfoBoxManager;
+import net.runelite.client.util.QueryRunner;
 
 @Slf4j
 public class RuneliteModule extends AbstractModule
@@ -51,6 +52,7 @@ public class RuneliteModule extends AbstractModule
 	protected void configure()
 	{
 		bind(ScheduledExecutorService.class).toInstance(Executors.newSingleThreadScheduledExecutor());
+		bind(QueryRunner.class);
 		bind(MenuManager.class);
 		bind(ChatMessageManager.class);
 		bind(ItemManager.class);

--- a/runelite-client/src/main/java/net/runelite/client/RuneliteModule.java
+++ b/runelite-client/src/main/java/net/runelite/client/RuneliteModule.java
@@ -72,6 +72,12 @@ public class RuneliteModule extends AbstractModule
 	}
 
 	@Provides
+	Notifier provideNotifier(RuneLite runeLite)
+	{
+		return runeLite.notifier;
+	}
+
+	@Provides
 	@Singleton
 	RuneliteConfig provideConfig(ConfigManager configManager)
 	{

--- a/runelite-client/src/main/java/net/runelite/client/RuneliteModule.java
+++ b/runelite-client/src/main/java/net/runelite/client/RuneliteModule.java
@@ -72,7 +72,7 @@ public class RuneliteModule extends AbstractModule
 	@Provides
 	ClientUI provideClientUi(RuneLite runelite)
 	{
-		return runelite.getGui();
+		return runelite.gui;
 	}
 
 	@Provides

--- a/runelite-client/src/main/java/net/runelite/client/RuneliteModule.java
+++ b/runelite-client/src/main/java/net/runelite/client/RuneliteModule.java
@@ -33,6 +33,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import javax.inject.Singleton;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
+import net.runelite.client.account.SessionManager;
 import net.runelite.client.chat.ChatMessageManager;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.config.RuneliteConfig;
@@ -57,6 +58,7 @@ public class RuneliteModule extends AbstractModule
 		bind(Scheduler.class);
 		bind(PluginManager.class);
 		bind(RuneliteProperties.class);
+		bind(SessionManager.class);
 	}
 
 	@Provides

--- a/runelite-client/src/main/java/net/runelite/client/RuneliteModule.java
+++ b/runelite-client/src/main/java/net/runelite/client/RuneliteModule.java
@@ -64,9 +64,9 @@ public class RuneliteModule extends AbstractModule
 	}
 
 	@Provides
-	Client provideClient(RuneLite runelite)
+	Client provideClient(RuneLite runeLite)
 	{
-		return runelite.getClient();
+		return runeLite.client;
 	}
 
 	@Provides

--- a/runelite-client/src/main/java/net/runelite/client/account/SessionManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/account/SessionManager.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) 2017, Adam <Adam@sigterm.info>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.account;
+
+import com.google.common.eventbus.EventBus;
+import com.google.gson.Gson;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.concurrent.ScheduledExecutorService;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.client.RuneLite;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.events.SessionClose;
+import net.runelite.client.events.SessionOpen;
+import net.runelite.http.api.account.AccountClient;
+
+@Singleton
+@Slf4j
+public class SessionManager
+{
+	private static final File SESSION_FILE = new File(RuneLite.RUNELITE_DIR, "session");
+	private WSClient wsclient;
+
+	@Getter
+	private AccountSession accountSession;
+
+	@Inject
+	private EventBus eventBus;
+
+	@Inject
+	private ConfigManager configManager;
+
+	@Inject
+	private ScheduledExecutorService executor;
+
+	public void loadSession()
+	{
+		if (!SESSION_FILE.exists())
+		{
+			log.info("No session file exists");
+			return;
+		}
+
+		AccountSession session;
+
+		try (FileInputStream in = new FileInputStream(SESSION_FILE))
+		{
+			session = new Gson().fromJson(new InputStreamReader(in), AccountSession.class);
+
+			log.debug("Loaded session for {}", session.getUsername());
+		}
+		catch (Exception ex)
+		{
+			log.warn("Unable to load session file", ex);
+			return;
+		}
+
+		// Check if session is still valid
+		AccountClient accountClient = new AccountClient(session.getUuid());
+		if (!accountClient.sesssionCheck())
+		{
+			log.debug("Loaded session {} is invalid", session.getUuid());
+			return;
+		}
+
+		openSession(session);
+	}
+
+	public void saveSession()
+	{
+		if (accountSession == null)
+		{
+			return;
+		}
+
+		try (FileWriter fw = new FileWriter(SESSION_FILE))
+		{
+			new Gson().toJson(accountSession, fw);
+
+			log.debug("Saved session to {}", SESSION_FILE);
+		}
+		catch (IOException ex)
+		{
+			log.warn("Unable to save session file", ex);
+		}
+	}
+
+	public void deleteSession()
+	{
+		SESSION_FILE.delete();
+	}
+
+	/**
+	 * Set the given session as the active session and open a socket to the
+	 * server with the given session
+	 *
+	 * @param session
+	 */
+	public void openSession(AccountSession session)
+	{
+		// If the ws session already exists, don't need to do anything
+		if (wsclient == null || !wsclient.getSession().equals(session))
+		{
+			if (wsclient != null)
+			{
+				wsclient.close();
+			}
+
+			wsclient = new WSClient(eventBus, executor, session);
+			wsclient.connect();
+		}
+
+		accountSession = session;
+
+		if (session.getUsername() != null)
+		{
+			// Initialize config for new session
+			// If the session isn't logged in yet, don't switch to the new config
+			configManager.switchSession(session);
+		}
+
+		eventBus.post(new SessionOpen());
+	}
+
+	public void closeSession()
+	{
+		if (wsclient != null)
+		{
+			wsclient.close();
+			wsclient = null;
+		}
+
+		if (accountSession == null)
+		{
+			return;
+		}
+
+		log.debug("Logging out of account {}", accountSession.getUsername());
+
+		accountSession = null; // No more account
+
+		// Restore config
+		configManager.switchSession(null);
+
+		eventBus.post(new SessionClose());
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/account/WSClient.java
+++ b/runelite-client/src/main/java/net/runelite/client/account/WSClient.java
@@ -22,7 +22,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package net.runelite.client;
+package net.runelite.client.account;
 
 import com.google.common.eventbus.EventBus;
 import com.google.gson.Gson;
@@ -32,12 +32,11 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import lombok.extern.slf4j.Slf4j;
-import net.runelite.client.account.AccountSession;
 import net.runelite.http.api.RuneliteAPI;
-import net.runelite.http.api.ws.messages.Handshake;
-import net.runelite.http.api.ws.messages.Ping;
 import net.runelite.http.api.ws.WebsocketGsonFactory;
 import net.runelite.http.api.ws.WebsocketMessage;
+import net.runelite.http.api.ws.messages.Handshake;
+import net.runelite.http.api.ws.messages.Ping;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/PluginDescriptor.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/PluginDescriptor.java
@@ -38,4 +38,6 @@ public @interface PluginDescriptor
 	String name();
 
 	boolean developerPlugin() default false;
+
+	boolean loadWhenOutdated() default false;
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/PluginManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/PluginManager.java
@@ -42,6 +42,7 @@ import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import javax.inject.Singleton;
 import javax.swing.SwingUtilities;
+import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.client.RuneLite;
 import net.runelite.client.events.PluginChanged;
@@ -66,6 +67,9 @@ public class PluginManager
 
 	@Inject
 	PluginWatcher pluginWatcher;
+
+	@Setter
+	boolean isOutdated;
 
 	private final List<Plugin> plugins = new CopyOnWriteArrayList<>();
 
@@ -124,6 +128,11 @@ public class PluginManager
 			{
 				log.warn("Class {} has plugin descriptor, but is not a plugin",
 					clazz);
+				continue;
+			}
+
+			if (!pluginDescriptor.loadWhenOutdated() && isOutdated)
+			{
 				continue;
 			}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/account/AccountPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/account/AccountPlugin.java
@@ -37,6 +37,7 @@ import javax.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.client.RuneLite;
 import net.runelite.client.account.AccountSession;
+import net.runelite.client.account.SessionManager;
 import net.runelite.client.events.SessionClose;
 import net.runelite.client.events.SessionOpen;
 import net.runelite.client.plugins.Plugin;
@@ -57,6 +58,9 @@ public class AccountPlugin extends Plugin
 {
 	@Inject
 	RuneLite runelite;
+
+	@Inject
+	SessionManager sessionManager;
 
 	@Inject
 	ClientUI ui;
@@ -87,7 +91,7 @@ public class AccountPlugin extends Plugin
 	private void logoutClick(ActionEvent ae)
 	{
 		// Destroy session
-		AccountSession session = runelite.getAccountSession();
+		AccountSession session = sessionManager.getAccountSession();
 		if (session != null)
 		{
 			AccountClient client = new AccountClient(session.getUuid());
@@ -101,8 +105,8 @@ public class AccountPlugin extends Plugin
 			}
 		}
 
-		runelite.closeSession(); // remove session from client
-		runelite.deleteSession(); // delete saved session file
+		sessionManager.closeSession(); // remove session from client
+		sessionManager.deleteSession(); // delete saved session file
 
 		// Replace logout nav button with login
 		PluginToolbar navigationPanel = ui.getPluginToolbar();
@@ -129,7 +133,7 @@ public class AccountPlugin extends Plugin
 		session.setUuid(login.getUid());
 		session.setCreated(Instant.now());
 
-		runelite.openSession(session);
+		sessionManager.openSession(session);
 
 		if (!Desktop.isDesktopSupported())
 		{
@@ -161,21 +165,21 @@ public class AccountPlugin extends Plugin
 	{
 		log.debug("Now logged in as {}", loginResponse.getUsername());
 
-		AccountSession session = runelite.getAccountSession();
+		AccountSession session = sessionManager.getAccountSession();
 		session.setUsername(loginResponse.getUsername());
 
 		// Open session, again, now that we have a username
 		// This triggers onSessionOpen
-		runelite.openSession(session);
+		sessionManager.openSession(session);
 
 		// Save session to disk
-		runelite.saveSession();
+		sessionManager.saveSession();
 	}
 
 	@Subscribe
 	public void onSessionOpen(SessionOpen sessionOpen)
 	{
-		AccountSession session = runelite.getAccountSession();
+		AccountSession session = sessionManager.getAccountSession();
 
 		if (session.getUsername() == null)
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/account/AccountPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/account/AccountPlugin.java
@@ -35,7 +35,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import javax.imageio.ImageIO;
 import javax.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
-import net.runelite.client.RuneLite;
 import net.runelite.client.account.AccountSession;
 import net.runelite.client.account.SessionManager;
 import net.runelite.client.events.SessionClose;
@@ -56,9 +55,6 @@ import net.runelite.http.api.ws.messages.LoginResponse;
 @Slf4j
 public class AccountPlugin extends Plugin
 {
-	@Inject
-	RuneLite runelite;
-
 	@Inject
 	SessionManager sessionManager;
 
@@ -188,7 +184,7 @@ public class AccountPlugin extends Plugin
 
 		log.debug("Session opened as {}", session.getUsername());
 
-		runelite.setTitle("(" + session.getUsername() + ")");
+		ui.setTitle("(" + session.getUsername() + ")");
 
 		replaceLoginWithLogout();
 	}
@@ -204,7 +200,7 @@ public class AccountPlugin extends Plugin
 	@Subscribe
 	public void onSessionClose(SessionClose sessionClose)
 	{
-		runelite.setTitle(null);
+		ui.setTitle(null);
 	}
 
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/attackindicator/AttackIndicatorPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/attackindicator/AttackIndicatorPlugin.java
@@ -24,6 +24,9 @@
  */
 package net.runelite.client.plugins.attackindicator;
 
+import static net.runelite.client.plugins.attackindicator.AttackStyle.CASTING;
+import static net.runelite.client.plugins.attackindicator.AttackStyle.DEFENSIVE_CASTING;
+import static net.runelite.client.plugins.attackindicator.AttackStyle.OTHER;
 import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.Table;
 import com.google.common.eventbus.Subscribe;
@@ -32,7 +35,6 @@ import com.google.inject.Provides;
 import java.time.temporal.ChronoUnit;
 import java.util.HashSet;
 import java.util.Set;
-import javax.annotation.Nullable;
 import javax.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
@@ -45,7 +47,6 @@ import net.runelite.client.events.ConfigChanged;
 import net.runelite.client.events.VarbitChanged;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
-import static net.runelite.client.plugins.attackindicator.AttackStyle.*;
 import net.runelite.client.task.Schedule;
 
 @PluginDescriptor(
@@ -63,7 +64,6 @@ public class AttackIndicatorPlugin extends Plugin
 	private final Table<WeaponType, WidgetInfo, Boolean> widgetsToHide = HashBasedTable.create();
 
 	@Inject
-	@Nullable
 	Client client;
 
 	@Inject

--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
@@ -31,7 +31,6 @@ import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
-import javax.annotation.Nullable;
 import javax.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.ChatMessageType;
@@ -69,7 +68,6 @@ public class ChatCommandsPlugin extends Plugin
 	private final HiscoreClient hiscoreClient = new HiscoreClient();
 
 	@Inject
-	@Nullable
 	Client client;
 
 	@Inject

--- a/runelite-client/src/main/java/net/runelite/client/plugins/clanchat/ClanChatPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/clanchat/ClanChatPlugin.java
@@ -39,7 +39,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
-import javax.annotation.Nullable;
 import javax.imageio.ImageIO;
 import javax.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
@@ -77,7 +76,6 @@ public class ClanChatPlugin extends Plugin
 	private int modIconsLength;
 
 	@Inject
-	@Nullable
 	Client client;
 
 	@Inject

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/ClueScrollPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/ClueScrollPlugin.java
@@ -30,7 +30,6 @@ import com.google.inject.Binder;
 import com.google.inject.Provides;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
-import javax.annotation.Nullable;
 import javax.inject.Inject;
 import net.runelite.api.Client;
 import net.runelite.api.GameState;
@@ -47,7 +46,6 @@ import net.runelite.client.task.Schedule;
 public class ClueScrollPlugin extends Plugin
 {
 	@Inject
-	@Nullable
 	Client client;
 
 	@Inject

--- a/runelite-client/src/main/java/net/runelite/client/plugins/combatlevel/CombatLevelPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/combatlevel/CombatLevelPlugin.java
@@ -27,7 +27,6 @@ package net.runelite.client.plugins.combatlevel;
 import com.google.inject.Provides;
 import java.text.DecimalFormat;
 import java.time.temporal.ChronoUnit;
-import javax.annotation.Nullable;
 import javax.inject.Inject;
 import net.runelite.api.Client;
 import net.runelite.api.Experience;
@@ -48,7 +47,6 @@ public class CombatLevelPlugin extends Plugin
 	private final DecimalFormat decimalFormat = new DecimalFormat("#.###");
 
 	@Inject
-	@Nullable
 	Client client;
 
 	@Inject
@@ -66,7 +64,7 @@ public class CombatLevelPlugin extends Plugin
 	)
 	public void updateCombatLevel()
 	{
-		if (client == null || client.getGameState() != GameState.LOGGED_IN)
+		if (client.getGameState() != GameState.LOGGED_IN)
 		{
 			return;
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/fightcave/FightCaveOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/fightcave/FightCaveOverlay.java
@@ -63,7 +63,7 @@ public class FightCaveOverlay extends Overlay
 	public Dimension render(Graphics2D graphics, Point parent)
 	{
 		JadAttack attack = plugin.getAttack();
-		if (attack == null || client == null || client.isPrayerActive(attack.getPrayer()))
+		if (attack == null || client.isPrayerActive(attack.getPrayer()))
 		{
 			return null;
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/fightcave/FightCavePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/fightcave/FightCavePlugin.java
@@ -27,7 +27,6 @@ package net.runelite.client.plugins.fightcave;
 import com.google.inject.Binder;
 import com.google.inject.Provides;
 import java.time.temporal.ChronoUnit;
-import javax.annotation.Nullable;
 import javax.inject.Inject;
 import net.runelite.api.Client;
 import net.runelite.api.GameState;
@@ -47,7 +46,6 @@ import net.runelite.client.util.QueryRunner;
 public class FightCavePlugin extends Plugin
 {
 	@Inject
-	@Nullable
 	Client client;
 
 	@Inject
@@ -85,7 +83,7 @@ public class FightCavePlugin extends Plugin
 	)
 	public void update()
 	{
-		if (!config.enabled() || client == null || client.getGameState() != GameState.LOGGED_IN)
+		if (!config.enabled() || client.getGameState() != GameState.LOGGED_IN)
 		{
 			return;
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/fightcave/FightCavePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/fightcave/FightCavePlugin.java
@@ -25,22 +25,21 @@
 package net.runelite.client.plugins.fightcave;
 
 import com.google.inject.Binder;
+import com.google.inject.Provides;
 import java.time.temporal.ChronoUnit;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
-
-import com.google.inject.Provides;
 import net.runelite.api.Client;
 import net.runelite.api.GameState;
 import net.runelite.api.NPC;
 import net.runelite.api.Query;
 import net.runelite.api.queries.NPCQuery;
-import net.runelite.client.RuneLite;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.task.Schedule;
 import net.runelite.client.ui.overlay.Overlay;
+import net.runelite.client.util.QueryRunner;
 
 @PluginDescriptor(
 	name = "Fight cave plugin"
@@ -52,7 +51,7 @@ public class FightCavePlugin extends Plugin
 	Client client;
 
 	@Inject
-	RuneLite runelite;
+	QueryRunner queryRunner;
 
 	@Inject
 	FightCaveConfig config;
@@ -112,7 +111,7 @@ public class FightCavePlugin extends Plugin
 	private NPC findJad()
 	{
 		Query query = new NPCQuery().nameContains("TzTok-Jad");
-		NPC[] result = runelite.runQuery(query);
+		NPC[] result = queryRunner.runQuery(query);
 		return result.length >= 1 ? result[0] : null;
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingSpotOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingSpotOverlay.java
@@ -32,34 +32,30 @@ import java.awt.Point;
 import java.awt.image.BufferedImage;
 import java.util.ArrayList;
 import java.util.List;
-import javax.annotation.Nullable;
 import javax.inject.Inject;
-import net.runelite.api.Client;
 import net.runelite.api.NPC;
 import net.runelite.api.queries.NPCQuery;
-import net.runelite.client.RuneLite;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.OverlayUtil;
+import net.runelite.client.util.QueryRunner;
 
 class FishingSpotOverlay extends Overlay
 {
 	private final List<Integer> ids = new ArrayList<>();
 
-	private final RuneLite runelite;
-	private final Client client;
+	private final QueryRunner queryRunner;
 	private final FishingConfig config;
 
 	@Inject
 	ItemManager itemManager;
 
 	@Inject
-	public FishingSpotOverlay(RuneLite runelite, @Nullable Client client, FishingConfig config)
+	public FishingSpotOverlay(QueryRunner queryRunner, FishingConfig config)
 	{
 		setPosition(OverlayPosition.DYNAMIC);
-		this.runelite = runelite;
-		this.client = client;
+		this.queryRunner = queryRunner;
 		this.config = config;
 	}
 
@@ -73,7 +69,7 @@ class FishingSpotOverlay extends Overlay
 
 		NPCQuery query = new NPCQuery()
 			.idEquals(Ints.toArray(ids));
-		NPC[] npcs = runelite.runQuery(query);
+		NPC[] npcs = queryRunner.runQuery(query);
 
 		for (NPC npc : npcs)
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/hiscore/HiscorePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/hiscore/HiscorePlugin.java
@@ -36,7 +36,8 @@ import net.runelite.client.ui.ClientUI;
 import net.runelite.client.ui.NavigationButton;
 
 @PluginDescriptor(
-	name = "Hiscore plugin"
+	name = "Hiscore plugin",
+	loadWhenOutdated = true
 )
 public class HiscorePlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/hunter/HunterPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/hunter/HunterPlugin.java
@@ -31,9 +31,9 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.List;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Set;
 import javax.inject.Inject;
 import lombok.Getter;
@@ -47,7 +47,6 @@ import net.runelite.api.Player;
 import net.runelite.api.Point;
 import net.runelite.api.queries.GameObjectQuery;
 import net.runelite.api.queries.PlayerQuery;
-import net.runelite.client.RuneLite;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.events.ConfigChanged;
 import net.runelite.client.events.GameObjectsChanged;
@@ -56,6 +55,7 @@ import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.task.Schedule;
 import net.runelite.client.ui.overlay.Overlay;
+import net.runelite.client.util.QueryRunner;
 
 @Slf4j
 @PluginDescriptor(
@@ -67,7 +67,7 @@ public class HunterPlugin extends Plugin
 	private Client client;
 
 	@Inject
-	private RuneLite runelite;
+	private QueryRunner queryRunner;
 
 	@Inject
 	private HunterConfig config;
@@ -139,7 +139,7 @@ public class HunterPlugin extends Plugin
 			case ObjectID.NET_TRAP_9002: //Net trap placed at black sallys
 				//Look for players that are on the same tile
 				PlayerQuery playerQuery = new PlayerQuery().atLocalLocation(gameObject.getLocalLocation());
-				List<Player> possiblePlayers = Arrays.asList(runelite.runQuery(playerQuery));
+				List<Player> possiblePlayers = Arrays.asList(queryRunner.runQuery(playerQuery));
 
 				/* If the player is on that tile, and it has the correct animation, assume he is the one that placed the trap
                                  * Special case: if you herb+tar, then move and place the trap, it does not detect laying the trap. It does work
@@ -294,7 +294,7 @@ public class HunterPlugin extends Plugin
 			GameObjectQuery goQuery = new GameObjectQuery()
 				.atWorldLocation(trap.getGameObject().getWorldLocation());
 			//This is for placeable traps like box traps. There are no gameobjects on that location if the trap collapsed
-			if (runelite.runQuery(goQuery).length == 0)
+			if (queryRunner.runQuery(goQuery).length == 0)
 			{
 				it.remove();
 				log.debug("Trap removed from personal trap collection, {} left", traps.size());
@@ -303,7 +303,7 @@ public class HunterPlugin extends Plugin
 			{
 				goQuery = goQuery
 					.idEquals(ObjectID.BOULDER_19215); //Deadfalls are the only ones (that i can test) that have this behaviour. I think maniacal monkeys have this too.
-				if (runelite.runQuery(goQuery).length != 0)
+				if (queryRunner.runQuery(goQuery).length != 0)
 				{
 					it.remove();
 					log.debug("Special trap removed from personal trap collection, {} left", traps.size());

--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
@@ -25,6 +25,69 @@
  */
 package net.runelite.client.plugins.idlenotifier;
 
+import static net.runelite.api.AnimationID.COOKING_FIRE;
+import static net.runelite.api.AnimationID.COOKING_RANGE;
+import static net.runelite.api.AnimationID.CRAFTING_GLASSBLOWING;
+import static net.runelite.api.AnimationID.FISHING_CAGE;
+import static net.runelite.api.AnimationID.FISHING_HARPOON;
+import static net.runelite.api.AnimationID.FISHING_KARAMBWAN;
+import static net.runelite.api.AnimationID.FISHING_NET;
+import static net.runelite.api.AnimationID.FISHING_POLE_CAST;
+import static net.runelite.api.AnimationID.FLETCHING_BOW_CUTTING;
+import static net.runelite.api.AnimationID.FLETCHING_STRING_MAGIC_LONGBOW;
+import static net.runelite.api.AnimationID.FLETCHING_STRING_MAGIC_SHORTBOW;
+import static net.runelite.api.AnimationID.FLETCHING_STRING_MAPLE_LONGBOW;
+import static net.runelite.api.AnimationID.FLETCHING_STRING_MAPLE_SHORTBOW;
+import static net.runelite.api.AnimationID.FLETCHING_STRING_NORMAL_LONGBOW;
+import static net.runelite.api.AnimationID.FLETCHING_STRING_NORMAL_SHORTBOW;
+import static net.runelite.api.AnimationID.FLETCHING_STRING_OAK_LONGBOW;
+import static net.runelite.api.AnimationID.FLETCHING_STRING_OAK_SHORTBOW;
+import static net.runelite.api.AnimationID.FLETCHING_STRING_WILLOW_LONGBOW;
+import static net.runelite.api.AnimationID.FLETCHING_STRING_WILLOW_SHORTBOW;
+import static net.runelite.api.AnimationID.FLETCHING_STRING_YEW_LONGBOW;
+import static net.runelite.api.AnimationID.FLETCHING_STRING_YEW_SHORTBOW;
+import static net.runelite.api.AnimationID.GEM_CUTTING_DIAMOND;
+import static net.runelite.api.AnimationID.GEM_CUTTING_EMERALD;
+import static net.runelite.api.AnimationID.GEM_CUTTING_JADE;
+import static net.runelite.api.AnimationID.GEM_CUTTING_OPAL;
+import static net.runelite.api.AnimationID.GEM_CUTTING_REDTOPAZ;
+import static net.runelite.api.AnimationID.GEM_CUTTING_RUBY;
+import static net.runelite.api.AnimationID.GEM_CUTTING_SAPPHIRE;
+import static net.runelite.api.AnimationID.HERBLORE_POTIONMAKING;
+import static net.runelite.api.AnimationID.IDLE;
+import static net.runelite.api.AnimationID.MAGIC_CHARGING_ORBS;
+import static net.runelite.api.AnimationID.MINING_ADAMANT_PICKAXE;
+import static net.runelite.api.AnimationID.MINING_BLACK_PICKAXE;
+import static net.runelite.api.AnimationID.MINING_BRONZE_PICKAXE;
+import static net.runelite.api.AnimationID.MINING_DRAGON_PICKAXE;
+import static net.runelite.api.AnimationID.MINING_DRAGON_PICKAXE_ORN;
+import static net.runelite.api.AnimationID.MINING_INFERNAL_PICKAXE;
+import static net.runelite.api.AnimationID.MINING_IRON_PICKAXE;
+import static net.runelite.api.AnimationID.MINING_MITHRIL_PICKAXE;
+import static net.runelite.api.AnimationID.MINING_MOTHERLODE_ADAMANT;
+import static net.runelite.api.AnimationID.MINING_MOTHERLODE_BLACK;
+import static net.runelite.api.AnimationID.MINING_MOTHERLODE_BRONZE;
+import static net.runelite.api.AnimationID.MINING_MOTHERLODE_DRAGON;
+import static net.runelite.api.AnimationID.MINING_MOTHERLODE_DRAGON_ORN;
+import static net.runelite.api.AnimationID.MINING_MOTHERLODE_INFERNAL;
+import static net.runelite.api.AnimationID.MINING_MOTHERLODE_IRON;
+import static net.runelite.api.AnimationID.MINING_MOTHERLODE_MITHRIL;
+import static net.runelite.api.AnimationID.MINING_MOTHERLODE_RUNE;
+import static net.runelite.api.AnimationID.MINING_MOTHERLODE_STEEL;
+import static net.runelite.api.AnimationID.MINING_RUNE_PICKAXE;
+import static net.runelite.api.AnimationID.MINING_STEEL_PICKAXE;
+import static net.runelite.api.AnimationID.SMITHING_ANVIL;
+import static net.runelite.api.AnimationID.SMITHING_CANNONBALL;
+import static net.runelite.api.AnimationID.SMITHING_SMELTING;
+import static net.runelite.api.AnimationID.WOODCUTTING_ADAMANT;
+import static net.runelite.api.AnimationID.WOODCUTTING_BLACK;
+import static net.runelite.api.AnimationID.WOODCUTTING_BRONZE;
+import static net.runelite.api.AnimationID.WOODCUTTING_DRAGON;
+import static net.runelite.api.AnimationID.WOODCUTTING_INFERNAL;
+import static net.runelite.api.AnimationID.WOODCUTTING_IRON;
+import static net.runelite.api.AnimationID.WOODCUTTING_MITHRIL;
+import static net.runelite.api.AnimationID.WOODCUTTING_RUNE;
+import static net.runelite.api.AnimationID.WOODCUTTING_STEEL;
 import com.google.common.eventbus.Subscribe;
 import com.google.inject.Provides;
 import java.time.Duration;
@@ -33,12 +96,11 @@ import java.time.temporal.ChronoUnit;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
 import net.runelite.api.Actor;
-import static net.runelite.api.AnimationID.*;
 import net.runelite.api.Client;
 import net.runelite.api.GameState;
 import net.runelite.api.Player;
 import net.runelite.api.Skill;
-import net.runelite.client.RuneLite;
+import net.runelite.client.Notifier;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.events.AnimationChanged;
 import net.runelite.client.events.GameStateChanged;
@@ -53,7 +115,7 @@ import net.runelite.client.ui.ClientUI;
 public class IdleNotifierPlugin extends Plugin
 {
 	@Inject
-	RuneLite runelite;
+	Notifier notifier;
 
 	@Inject
 	ClientUI gui;
@@ -260,7 +322,7 @@ public class IdleNotifierPlugin extends Plugin
 		}
 		if (config.sendTrayNotification())
 		{
-			runelite.notify(message);
+			notifier.notify(message);
 		}
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
@@ -93,7 +93,6 @@ import com.google.inject.Provides;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
-import javax.annotation.Nullable;
 import javax.inject.Inject;
 import net.runelite.api.Actor;
 import net.runelite.api.Client;
@@ -121,7 +120,6 @@ public class IdleNotifierPlugin extends Plugin
 	ClientUI gui;
 
 	@Inject
-	@Nullable
 	Client client;
 
 	@Inject

--- a/runelite-client/src/main/java/net/runelite/client/plugins/implings/ImplingsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/implings/ImplingsOverlay.java
@@ -32,17 +32,15 @@ import java.awt.Graphics2D;
 import java.awt.Polygon;
 import java.util.LinkedList;
 import java.util.List;
-import javax.annotation.Nullable;
 import javax.inject.Inject;
 import net.runelite.api.Actor;
-import net.runelite.api.Client;
 import net.runelite.api.NPC;
 import net.runelite.api.NpcID;
 import net.runelite.api.Point;
 import net.runelite.api.queries.NPCQuery;
-import net.runelite.client.RuneLite;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.util.QueryRunner;
 
 /**
  *
@@ -55,17 +53,15 @@ public class ImplingsOverlay extends Overlay
 	private static final int STATIC_SPAWN = 1618;
 	private static final int DYNAMIC_SPAWN = 1633;
 
-	private final RuneLite runelite;
-	private final Client client;
+	private final QueryRunner queryRunner;
 	private final ImplingsConfig config;
 	private final List<Integer> ids = new LinkedList<>();
 
 	@Inject
-	public ImplingsOverlay(RuneLite runelite, @Nullable Client client, ImplingsConfig config)
+	public ImplingsOverlay(QueryRunner queryRunner, ImplingsConfig config)
 	{
 		setPosition(OverlayPosition.DYNAMIC);
-		this.runelite = runelite;
-		this.client = client;
+		this.queryRunner = queryRunner;
 		this.config = config;
 	}
 
@@ -73,7 +69,7 @@ public class ImplingsOverlay extends Overlay
 	public Dimension render(Graphics2D graphics, java.awt.Point parent)
 	{
 		NPCQuery implingQuery = new NPCQuery().idEquals(Ints.toArray(ids));
-		NPC[] implings = runelite.runQuery(implingQuery);
+		NPC[] implings = queryRunner.runQuery(implingQuery);
 		for (NPC imp : implings)
 		{
 			//Spawns have the name "null", so they get changed to "Spawn"

--- a/runelite-client/src/main/java/net/runelite/client/plugins/jewellerycount/JewelleryCountOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/jewellerycount/JewelleryCountOverlay.java
@@ -37,22 +37,22 @@ import net.runelite.api.queries.EquipmentItemQuery;
 import net.runelite.api.queries.InventoryItemQuery;
 import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.api.widgets.WidgetItem;
-import net.runelite.client.RuneLite;
 import net.runelite.client.ui.FontManager;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.components.TextComponent;
+import net.runelite.client.util.QueryRunner;
 
 class JewelleryCountOverlay extends Overlay
 {
-	private final RuneLite runelite;
+	private final QueryRunner queryRunner;
 	private final JewelleryCountConfig config;
 
 	@Inject
-	JewelleryCountOverlay(RuneLite runelite, JewelleryCountConfig config)
+	JewelleryCountOverlay(QueryRunner queryRunner, JewelleryCountConfig config)
 	{
 		setPosition(OverlayPosition.DYNAMIC);
-		this.runelite = runelite;
+		this.queryRunner = queryRunner;
 		this.config = config;
 		this.setDrawOverBankScreen(true);
 	}
@@ -89,14 +89,14 @@ class JewelleryCountOverlay extends Overlay
 	private Collection<WidgetItem> getJewelleryWidgetItems()
 	{
 		Query inventoryQuery = new InventoryItemQuery();
-		WidgetItem[] inventoryWidgetItems = runelite.runQuery(inventoryQuery);
+		WidgetItem[] inventoryWidgetItems = queryRunner.runQuery(inventoryQuery);
 
 		Query equipmentQuery = new EquipmentItemQuery().slotEquals(
 			WidgetInfo.EQUIPMENT_AMULET,
 			WidgetInfo.EQUIPMENT_RING,
 			WidgetInfo.EQUIPMENT_GLOVES
 		);
-		WidgetItem[] equipmentWidgetItems = runelite.runQuery(equipmentQuery);
+		WidgetItem[] equipmentWidgetItems = queryRunner.runQuery(equipmentQuery);
 
 		Collection<WidgetItem> jewellery = new ArrayList<>();
 		jewellery.addAll(Arrays.asList(inventoryWidgetItems));

--- a/runelite-client/src/main/java/net/runelite/client/plugins/pestcontrol/PestControlOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/pestcontrol/PestControlOverlay.java
@@ -45,15 +45,15 @@ import net.runelite.api.Query;
 import net.runelite.api.queries.NPCQuery;
 import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetInfo;
-import net.runelite.client.RuneLite;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.OverlayUtil;
+import net.runelite.client.util.QueryRunner;
 
 @Slf4j
 public class PestControlOverlay extends Overlay
 {
-	private final RuneLite runelite;
+	private final QueryRunner queryRunner;
 	private final Client client;
 
 	private final PestControlPlugin plugin;
@@ -62,11 +62,11 @@ public class PestControlOverlay extends Overlay
 	private Game game;
 
 	@Inject
-	public PestControlOverlay(RuneLite runelite, PestControlPlugin plugin)
+	public PestControlOverlay(QueryRunner queryRunner, Client client, PestControlPlugin plugin)
 	{
 		setPosition(OverlayPosition.DYNAMIC);
-		this.runelite = runelite;
-		this.client = runelite.getClient();
+		this.queryRunner = queryRunner;
+		this.client = client;
 		this.plugin = plugin;
 	}
 
@@ -106,7 +106,7 @@ public class PestControlOverlay extends Overlay
 	private void renderSpinners(Graphics2D graphics)
 	{
 		Query query = new NPCQuery().nameEquals("Spinner");
-		NPC[] result = runelite.runQuery(query);
+		NPC[] result = queryRunner.runQuery(query);
 		Arrays.stream(result).forEach(npc -> OverlayUtil.renderActorOverlay(graphics, npc, npc.getName(), Color.CYAN));
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/rememberusername/RememberUsernamePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/rememberusername/RememberUsernamePlugin.java
@@ -26,7 +26,6 @@ package net.runelite.client.plugins.rememberusername;
 
 import com.google.common.eventbus.Subscribe;
 import com.google.inject.Provides;
-import javax.annotation.Nullable;
 import javax.inject.Inject;
 import net.runelite.api.Client;
 import net.runelite.api.GameState;
@@ -41,7 +40,6 @@ import net.runelite.client.plugins.PluginDescriptor;
 public class RememberUsernamePlugin extends Plugin
 {
 	@Inject
-	@Nullable
 	Client client;
 
 	@Inject

--- a/runelite-client/src/main/java/net/runelite/client/plugins/runecraft/BindNeckOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/runecraft/BindNeckOverlay.java
@@ -40,23 +40,23 @@ import net.runelite.api.queries.EquipmentItemQuery;
 import net.runelite.api.queries.InventoryItemQuery;
 import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.api.widgets.WidgetItem;
-import net.runelite.client.RuneLite;
 import net.runelite.client.ui.FontManager;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.components.TextComponent;
+import net.runelite.client.util.QueryRunner;
 
 public class BindNeckOverlay extends Overlay
 {
-	private final RuneLite runelite;
+	private final QueryRunner queryRunner;
 	private final RunecraftConfig config;
 	int bindingCharges;
 
 	@Inject
-	BindNeckOverlay(RuneLite runelite, RunecraftConfig config)
+	BindNeckOverlay(QueryRunner queryRunner, RunecraftConfig config)
 	{
 		setPosition(OverlayPosition.DYNAMIC);
-		this.runelite = runelite;
+		this.queryRunner = queryRunner;
 		this.config = config;
 		this.setDrawOverBankScreen(true);
 	}
@@ -91,12 +91,12 @@ public class BindNeckOverlay extends Overlay
 	{
 		Query inventoryQuery = new InventoryItemQuery()
 			.idEquals(BINDING_NECKLACE);
-		WidgetItem[] inventoryWidgetItems = runelite.runQuery(inventoryQuery);
+		WidgetItem[] inventoryWidgetItems = queryRunner.runQuery(inventoryQuery);
 
 		Query equipmentQuery = new EquipmentItemQuery()
 			.slotEquals(WidgetInfo.EQUIPMENT_AMULET)
 			.idEquals(BINDING_NECKLACE);
-		WidgetItem[] equipmentWidgetItems = runelite.runQuery(equipmentQuery);
+		WidgetItem[] equipmentWidgetItems = queryRunner.runQuery(equipmentQuery);
 
 		Collection<WidgetItem> necklaces = new ArrayList<>();
 		necklaces.addAll(Arrays.asList(inventoryWidgetItems));

--- a/runelite-client/src/main/java/net/runelite/client/plugins/runecraft/RunecraftOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/runecraft/RunecraftOverlay.java
@@ -35,11 +35,11 @@ import net.runelite.api.Query;
 import net.runelite.api.Varbits;
 import net.runelite.api.queries.InventoryItemQuery;
 import net.runelite.api.widgets.WidgetItem;
-import net.runelite.client.RuneLite;
 import net.runelite.client.ui.FontManager;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.components.TextComponent;
+import net.runelite.client.util.QueryRunner;
 
 public class RunecraftOverlay extends Overlay
 {
@@ -47,17 +47,17 @@ public class RunecraftOverlay extends Overlay
 	private static final int LARGE_POUCH_DAMAGED = ItemID.LARGE_POUCH_5513;
 	private static final int GIANT_POUCH_DAMAGED = ItemID.GIANT_POUCH_5515;
 
-	private final RuneLite runelite;
+	private final QueryRunner queryRunner;
 	private final Client client;
 
 	private final RunecraftConfig config;
 
 	@Inject
-	RunecraftOverlay(RuneLite runelite, RunecraftConfig config)
+	RunecraftOverlay(QueryRunner queryRunner, Client client, RunecraftConfig config)
 	{
 		setPosition(OverlayPosition.DYNAMIC);
-		this.runelite = runelite;
-		this.client = runelite.getClient();
+		this.queryRunner = queryRunner;
+		this.client = client;
 		this.config = config;
 		this.setDrawOverBankScreen(true);
 	}
@@ -71,7 +71,7 @@ public class RunecraftOverlay extends Overlay
 		}
 
 		Query query = new InventoryItemQuery();
-		WidgetItem[] widgetItems = runelite.runQuery(query);
+		WidgetItem[] widgetItems = queryRunner.runQuery(query);
 		graphics.setFont(FontManager.getRunescapeSmallFont());
 
 		for (WidgetItem item : widgetItems)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/runepouch/RunepouchOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/runepouch/RunepouchOverlay.java
@@ -36,13 +36,13 @@ import net.runelite.api.Query;
 import net.runelite.api.Varbits;
 import net.runelite.api.queries.InventoryItemQuery;
 import net.runelite.api.widgets.WidgetItem;
-import net.runelite.client.RuneLite;
 import net.runelite.client.ui.FontManager;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.OverlayUtil;
 import net.runelite.client.ui.overlay.tooltip.Tooltip;
 import net.runelite.client.ui.overlay.tooltip.TooltipManager;
+import net.runelite.client.util.QueryRunner;
 
 public class RunepouchOverlay extends Overlay
 {
@@ -57,18 +57,18 @@ public class RunepouchOverlay extends Overlay
 
 	private final RuneImageCache runeImageCache = new RuneImageCache();
 
-	private final RuneLite runelite;
+	private final QueryRunner queryRunner;
 	private final Client client;
 	private final RunepouchConfig config;
 	private final TooltipManager tooltipManager;
 
 	@Inject
-	RunepouchOverlay(RuneLite runelite, RunepouchConfig config, TooltipManager tooltipManager)
+	RunepouchOverlay(QueryRunner queryRunner, Client client, RunepouchConfig config, TooltipManager tooltipManager)
 	{
 		setPosition(OverlayPosition.DYNAMIC);
 		this.tooltipManager = tooltipManager;
-		this.runelite = runelite;
-		this.client = runelite.getClient();
+		this.queryRunner = queryRunner;
+		this.client = client;
 		this.config = config;
 		this.setDrawOverBankScreen(true);
 	}
@@ -82,7 +82,7 @@ public class RunepouchOverlay extends Overlay
 		}
 
 		Query query = new InventoryItemQuery().idEquals(ItemID.RUNE_POUCH);
-		WidgetItem[] items = runelite.runQuery(query);
+		WidgetItem[] items = queryRunner.runQuery(query);
 		if (items.length == 0)
 		{
 			return null;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerOverlay.java
@@ -40,15 +40,15 @@ import net.runelite.api.queries.EquipmentItemQuery;
 import net.runelite.api.queries.InventoryItemQuery;
 import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.api.widgets.WidgetItem;
-import net.runelite.client.RuneLite;
 import net.runelite.client.ui.FontManager;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.components.TextComponent;
+import net.runelite.client.util.QueryRunner;
 
 class SlayerOverlay extends Overlay
 {
-	private final RuneLite runelite;
+	private final QueryRunner queryRunner;
 	private final SlayerConfig config;
 	private final SlayerPlugin plugin;
 
@@ -80,10 +80,10 @@ class SlayerOverlay extends Overlay
 	);
 
 	@Inject
-	SlayerOverlay(RuneLite runelite, SlayerPlugin plugin, SlayerConfig config)
+	SlayerOverlay(QueryRunner queryRunner, SlayerPlugin plugin, SlayerConfig config)
 	{
 		setPosition(OverlayPosition.DYNAMIC);
-		this.runelite = runelite;
+		this.queryRunner = queryRunner;
 		this.plugin = plugin;
 		this.config = config;
 	}
@@ -132,10 +132,10 @@ class SlayerOverlay extends Overlay
 	private Collection<WidgetItem> getSlayerWidgetItems()
 	{
 		Query inventoryQuery = new InventoryItemQuery();
-		WidgetItem[] inventoryWidgetItems = runelite.runQuery(inventoryQuery);
+		WidgetItem[] inventoryWidgetItems = queryRunner.runQuery(inventoryQuery);
 
 		Query equipmentQuery = new EquipmentItemQuery().slotEquals(WidgetInfo.EQUIPMENT_HELMET, WidgetInfo.EQUIPMENT_RING);
-		WidgetItem[] equipmentWidgetItems = runelite.runQuery(equipmentQuery);
+		WidgetItem[] equipmentWidgetItems = queryRunner.runQuery(equipmentQuery);
 
 		WidgetItem[] items = concat(inventoryWidgetItems, equipmentWidgetItems, WidgetItem.class);
 		return ImmutableList.copyOf(items);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerPlugin.java
@@ -24,6 +24,7 @@
  */
 package net.runelite.client.plugins.slayer;
 
+import static net.runelite.api.Skill.SLAYER;
 import com.google.common.eventbus.Subscribe;
 import com.google.inject.Binder;
 import com.google.inject.Provides;
@@ -33,13 +34,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import javax.annotation.Nullable;
 import javax.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
 import net.runelite.api.ItemID;
-import static net.runelite.api.Skill.SLAYER;
 import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.config.ConfigManager;
@@ -73,7 +72,6 @@ public class SlayerPlugin extends Plugin
 	private static final Pattern REWARD_POINTS = Pattern.compile("Reward points: (\\d*)");
 
 	@Inject
-	@Nullable
 	Client client;
 
 	@Inject
@@ -146,7 +144,7 @@ public class SlayerPlugin extends Plugin
 	)
 	public void scheduledChecks()
 	{
-		if (!config.enabled() || client == null)
+		if (!config.enabled())
 		{
 			return;
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/teamcapes/TeamCapesPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/teamcapes/TeamCapesPlugin.java
@@ -26,6 +26,14 @@ package net.runelite.client.plugins.teamcapes;
 
 import com.google.inject.Binder;
 import com.google.inject.Provides;
+import java.time.temporal.ChronoUnit;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import javax.inject.Inject;
 import net.runelite.api.Client;
 import net.runelite.api.GameState;
 import net.runelite.api.Player;
@@ -35,23 +43,12 @@ import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.task.Schedule;
 import net.runelite.client.ui.overlay.Overlay;
 
-import javax.annotation.Nullable;
-import javax.inject.Inject;
-import java.time.temporal.ChronoUnit;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
-
 @PluginDescriptor(
 	name = "Team capes plugin"
 )
 public class TeamCapesPlugin extends Plugin
 {
 	@Inject
-	@Nullable
 	Client client;
 
 	@Inject
@@ -86,7 +83,7 @@ public class TeamCapesPlugin extends Plugin
 	)
 	public void update()
 	{
-		if (!config.enabled() || client == null || client.getGameState() != GameState.LOGGED_IN)
+		if (!config.enabled() || client.getGameState() != GameState.LOGGED_IN)
 		{
 			return;
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/volcanicmine/VolcanicMineOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/volcanicmine/VolcanicMineOverlay.java
@@ -79,7 +79,7 @@ public class VolcanicMineOverlay extends Overlay
 	@Override
 	public Dimension render(Graphics2D graphics, java.awt.Point point)
 	{
-		if (client == null || !plugin.getInside() || !config.enabled())
+		if (!plugin.getInside() || !config.enabled())
 		{
 			return null;
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/volcanicmine/VolcanicMinePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/volcanicmine/VolcanicMinePlugin.java
@@ -57,12 +57,12 @@ import net.runelite.api.queries.NPCQuery;
 import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.Notifier;
-import net.runelite.client.RuneLite;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.events.ConfigChanged;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.task.Schedule;
+import net.runelite.client.ui.ClientUI;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.util.QueryRunner;
 
@@ -87,7 +87,7 @@ public class VolcanicMinePlugin extends Plugin
 	Client client;
 
 	@Inject
-	RuneLite runeLite;
+	ClientUI clientUI;
 
 	@Inject
 	QueryRunner queryRunner;
@@ -300,13 +300,13 @@ public class VolcanicMinePlugin extends Plugin
 
 	private void sendNotification(String message)
 	{
-		if (!config.alertWhenFocused() && runeLite.getGui().isFocused())
+		if (!config.alertWhenFocused() && clientUI.isFocused())
 		{
 			return;
 		}
 		if (config.requestFocus())
 		{
-			runeLite.getGui().requestFocus();
+			clientUI.requestFocus();
 		}
 		if (config.sendTrayNotification())
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/volcanicmine/VolcanicMinePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/volcanicmine/VolcanicMinePlugin.java
@@ -64,6 +64,7 @@ import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.task.Schedule;
 import net.runelite.client.ui.overlay.Overlay;
+import net.runelite.client.util.QueryRunner;
 
 @PluginDescriptor(
 	name = "Volcanic mine helper"
@@ -87,6 +88,9 @@ public class VolcanicMinePlugin extends Plugin
 
 	@Inject
 	RuneLite runeLite;
+
+	@Inject
+	QueryRunner queryRunner;
 
 	@Inject
 	Notifier notifier;
@@ -278,7 +282,7 @@ public class VolcanicMinePlugin extends Plugin
 		Query query = new NPCQuery()
 			.nameEquals(LAVA_BEAST)
 			.isWithinArea(player.getLocalLocation(), LAVA_BEAST_ATTACK_RANGE);
-		NPC[] npcs = runeLite.runQuery(query);
+		NPC[] npcs = queryRunner.runQuery(query);
 		return npcs.length > 0;
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/volcanicmine/VolcanicMinePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/volcanicmine/VolcanicMinePlugin.java
@@ -25,31 +25,11 @@
  */
 package net.runelite.client.plugins.volcanicmine;
 
+import static java.lang.Math.abs;
 import com.google.common.eventbus.Subscribe;
 import com.google.inject.Binder;
 import com.google.inject.Provides;
 import java.awt.Color;
-import static java.lang.Math.abs;
-import net.runelite.api.ChatMessageType;
-import net.runelite.api.Client;
-import net.runelite.api.GameObject;
-import net.runelite.api.GameState;
-import net.runelite.api.NPC;
-import net.runelite.api.Player;
-import net.runelite.api.Point;
-import net.runelite.api.Region;
-import net.runelite.api.Tile;
-import net.runelite.api.widgets.Widget;
-import net.runelite.api.widgets.WidgetInfo;
-import net.runelite.client.RuneLite;
-import net.runelite.client.config.ConfigManager;
-import net.runelite.client.events.ConfigChanged;
-import net.runelite.client.plugins.Plugin;
-import net.runelite.client.plugins.PluginDescriptor;
-import net.runelite.client.task.Schedule;
-import net.runelite.client.ui.overlay.Overlay;
-import javax.annotation.Nullable;
-import javax.inject.Inject;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -59,10 +39,31 @@ import java.util.Map.Entry;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+import javax.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.ChatMessageType;
+import net.runelite.api.Client;
+import net.runelite.api.GameObject;
+import net.runelite.api.GameState;
+import net.runelite.api.NPC;
+import net.runelite.api.Player;
+import net.runelite.api.Point;
 import net.runelite.api.Prayer;
 import net.runelite.api.Query;
+import net.runelite.api.Region;
+import net.runelite.api.Tile;
 import net.runelite.api.queries.NPCQuery;
+import net.runelite.api.widgets.Widget;
+import net.runelite.api.widgets.WidgetInfo;
+import net.runelite.client.Notifier;
+import net.runelite.client.RuneLite;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.events.ConfigChanged;
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.task.Schedule;
+import net.runelite.client.ui.overlay.Overlay;
 
 @PluginDescriptor(
 	name = "Volcanic mine helper"
@@ -86,6 +87,9 @@ public class VolcanicMinePlugin extends Plugin
 
 	@Inject
 	RuneLite runeLite;
+
+	@Inject
+	Notifier notifier;
 
 	@Inject
 	VolcanicMineConfig config;
@@ -302,7 +306,7 @@ public class VolcanicMinePlugin extends Plugin
 		}
 		if (config.sendTrayNotification())
 		{
-			runeLite.notify(message);
+			notifier.notify(message);
 		}
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/volcanicmine/VolcanicMinePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/volcanicmine/VolcanicMinePlugin.java
@@ -39,7 +39,6 @@ import java.util.Map.Entry;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-import javax.annotation.Nullable;
 import javax.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.ChatMessageType;
@@ -83,7 +82,6 @@ public class VolcanicMinePlugin extends Plugin
 	private static final Pattern coltagPattern = Pattern.compile("((<col=([0-f]){6}>)|(<\\/col>))");
 
 	@Inject
-	@Nullable
 	Client client;
 
 	@Inject

--- a/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingPlugin.java
@@ -32,7 +32,7 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import javax.inject.Inject;
 import net.runelite.api.ChatMessageType;
-import net.runelite.client.RuneLite;
+import net.runelite.client.Notifier;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.events.ChatMessage;
 import net.runelite.client.plugins.Plugin;
@@ -46,7 +46,7 @@ import net.runelite.client.ui.overlay.Overlay;
 public class WoodcuttingPlugin extends Plugin
 {
 	@Inject
-	RuneLite runelite;
+	Notifier notifier;
 
 	@Inject
 	WoodcuttingOverlay overlay;
@@ -91,7 +91,7 @@ public class WoodcuttingPlugin extends Plugin
 
 			if (event.getMessage().contains("A bird's nest falls out of the tree") && config.showNestNotification())
 			{
-				runelite.notify("A bird nest has spawned!");
+				notifier.notify("A bird nest has spawned!");
 			}
 		}
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesPlugin.java
@@ -31,7 +31,6 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
-import javax.annotation.Nullable;
 import javax.inject.Inject;
 import net.runelite.api.Client;
 import net.runelite.api.Experience;
@@ -55,7 +54,6 @@ public class XpGlobesPlugin extends Plugin
 	private final List<XpGlobe> xpGlobes = new ArrayList<>();
 
 	@Inject
-	@Nullable
 	Client client;
 
 	@Inject

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpPanel.java
@@ -24,10 +24,6 @@
  */
 package net.runelite.client.plugins.xptracker;
 
-import net.runelite.api.Client;
-import net.runelite.api.Skill;
-import net.runelite.client.ui.PluginPanel;
-import javax.imageio.ImageIO;
 import java.awt.BorderLayout;
 import java.awt.Dimension;
 import java.io.IOException;
@@ -35,13 +31,16 @@ import java.text.NumberFormat;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ScheduledExecutorService;
-import javax.annotation.Nullable;
+import javax.imageio.ImageIO;
 import javax.inject.Inject;
 import javax.swing.ImageIcon;
 import javax.swing.JButton;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.Client;
+import net.runelite.api.Skill;
+import net.runelite.client.ui.PluginPanel;
 
 @Slf4j
 public class XpPanel extends PluginPanel
@@ -50,7 +49,6 @@ public class XpPanel extends PluginPanel
 	private final XpTrackerPlugin xpTracker;
 
 	@Inject
-	@Nullable
 	Client client;
 
 	@Inject

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerPlugin.java
@@ -35,7 +35,6 @@ import net.runelite.client.plugins.Plugin;
 import net.runelite.client.ui.ClientUI;
 import net.runelite.client.ui.NavigationButton;
 import java.time.temporal.ChronoUnit;
-import javax.annotation.Nullable;
 import javax.inject.Inject;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.task.Schedule;
@@ -51,7 +50,6 @@ public class XpTrackerPlugin extends Plugin
 	ClientUI ui;
 
 	@Inject
-	@Nullable
 	Client client;
 
 	private NavigationButton navButton;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xtea/XteaPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xtea/XteaPlugin.java
@@ -29,7 +29,6 @@ import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.ScheduledExecutorService;
-import javax.annotation.Nullable;
 import javax.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
@@ -50,7 +49,6 @@ public class XteaPlugin extends Plugin
 	private final Set<Integer> sentRegions = new HashSet<>();
 
 	@Inject
-	@Nullable
 	Client client;
 
 	@Inject

--- a/runelite-client/src/main/java/net/runelite/client/plugins/zulrah/ZulrahPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/zulrah/ZulrahPlugin.java
@@ -31,7 +31,6 @@ import com.google.inject.Provides;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.Collection;
-import javax.annotation.Nullable;
 import javax.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
@@ -66,7 +65,6 @@ public class ZulrahPlugin extends Plugin
 	QueryRunner queryRunner;
 
 	@Inject
-	@Nullable
 	Client client;
 
 	@Inject
@@ -118,7 +116,7 @@ public class ZulrahPlugin extends Plugin
 	)
 	public void update()
 	{
-		if (!config.enabled() || client == null || client.getGameState() != GameState.LOGGED_IN)
+		if (!config.enabled() || client.getGameState() != GameState.LOGGED_IN)
 		{
 			return;
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/zulrah/ZulrahPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/zulrah/ZulrahPlugin.java
@@ -39,7 +39,6 @@ import net.runelite.api.GameState;
 import net.runelite.api.NPC;
 import net.runelite.api.Query;
 import net.runelite.api.queries.NPCQuery;
-import net.runelite.client.RuneLite;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
@@ -55,6 +54,7 @@ import net.runelite.client.plugins.zulrah.patterns.ZulrahPatternD;
 import net.runelite.client.plugins.zulrah.phase.ZulrahPhase;
 import net.runelite.client.task.Schedule;
 import net.runelite.client.ui.overlay.Overlay;
+import net.runelite.client.util.QueryRunner;
 
 @PluginDescriptor(
 	name = "Zulrah plugin"
@@ -63,7 +63,7 @@ import net.runelite.client.ui.overlay.Overlay;
 public class ZulrahPlugin extends Plugin
 {
 	@Inject
-	RuneLite runelite;
+	QueryRunner queryRunner;
 
 	@Inject
 	@Nullable
@@ -187,7 +187,7 @@ public class ZulrahPlugin extends Plugin
 	private NPC findZulrah()
 	{
 		Query query = new NPCQuery().nameEquals("Zulrah");
-		NPC[] result = runelite.runQuery(query);
+		NPC[] result = queryRunner.runQuery(query);
 		return result.length == 1 ? result[0] : null;
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/zulrah/overlays/ZulrahPrayerOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/zulrah/overlays/ZulrahPrayerOverlay.java
@@ -60,7 +60,7 @@ public class ZulrahPrayerOverlay extends Overlay
 	{
 		ZulrahInstance instance = plugin.getInstance();
 
-		if (client == null || instance == null)
+		if (instance == null)
 		{
 			return null;
 		}

--- a/runelite-client/src/main/java/net/runelite/client/ui/ClientPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ClientPanel.java
@@ -25,89 +25,46 @@
 package net.runelite.client.ui;
 
 import java.applet.Applet;
+import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Dimension;
-import java.awt.BorderLayout;
-import java.io.IOException;
+import javax.annotation.Nullable;
 import javax.swing.JPanel;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
-import net.runelite.client.ClientLoader;
-import net.runelite.http.api.updatecheck.UpdateCheckClient;
 
 @Slf4j
 final class ClientPanel extends JPanel
 {
 	public static final int PANEL_WIDTH = 765, PANEL_HEIGHT = 503;
 
-	private final ClientUI ui;
-	private Applet rs;
-
-	public ClientPanel(ClientUI ui)
+	public ClientPanel(@Nullable Applet client)
 	{
-		this.ui = ui;
 		setSize(new Dimension(PANEL_WIDTH, PANEL_HEIGHT));
 		setMinimumSize(new Dimension(PANEL_WIDTH, PANEL_HEIGHT));
 		setPreferredSize(new Dimension(PANEL_WIDTH, PANEL_HEIGHT));
 		setLayout(new BorderLayout());
 		setBackground(Color.black);
-	}
 
-	public void loadRs() throws IOException, ClassNotFoundException, InstantiationException, IllegalAccessException
-	{
-		ClientLoader loader = new ClientLoader();
-
-		UpdateCheckClient updateCheck = new UpdateCheckClient();
-		boolean isOutdated = updateCheck.isOutdated();
-		if (isOutdated)
-		{
-			log.info("Runelite is outdated - fetching vanilla client");
-			rs = loader.loadVanilla();
-		}
-		else
-		{
-			log.debug("Runelite is up to date");
-
-			try
-			{
-				rs = loader.loadRunelite();
-			}
-			catch (ClassNotFoundException ex)
-			{
-				log.error("Unable to load client - class not found. This means you"
-					+ " are not running RuneLite with Maven as the injected client"
-					+ " is not in your classpath.");
-				throw new ClassNotFoundException("Unable to load injected client", ex);
-			}
-		}
-
-		rs.setLayout(null);
-		rs.setSize(PANEL_WIDTH, PANEL_HEIGHT);
-
-		rs.init();
-		rs.start();
-
-		add(rs, BorderLayout.CENTER);
-
-		if (isOutdated)
+		if (client == null)
 		{
 			return;
 		}
 
-		if (!(rs instanceof Client))
-		{
-			log.error("Injected client does not implement Client!");
-			return;
-		}
+		client.setLayout(null);
+		client.setSize(PANEL_WIDTH, PANEL_HEIGHT);
 
-		Client client = (Client) rs;
+		client.init();
+		client.start();
 
-		ui.getRunelite().setClient(client);
+		add(client, BorderLayout.CENTER);
 
 		// This causes the whole game frame to be redrawn each frame instead
 		// of only the viewport, so we can hook to MainBufferProvider#draw
 		// and draw anywhere without it leaving artifacts
-		client.setGameDrawingMode(2);
+		if (client instanceof Client)
+		{
+			((Client)client).setGameDrawingMode(2);
+		}
 	}
-
 }

--- a/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
@@ -25,6 +25,7 @@
 package net.runelite.client.ui;
 
 import java.applet.Applet;
+import com.google.common.base.Strings;
 import java.awt.BorderLayout;
 import java.awt.Dimension;
 import java.awt.event.WindowAdapter;
@@ -42,6 +43,7 @@ import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.GameState;
 import net.runelite.client.RuneLite;
+import net.runelite.client.RuneliteProperties;
 import org.pushingpixels.substance.internal.ui.SubstanceRootPaneUI;
 
 @Slf4j
@@ -52,21 +54,23 @@ public class ClientUI extends JFrame
 	private static final int EXPANDED_WIDTH = CLIENT_WIDTH + PluginPanel.PANEL_WIDTH + SCROLLBAR_WIDTH;
 
 	private final Applet client;
+	private final RuneliteProperties properties;
 	private JPanel container;
 	private JPanel navContainer;
 	private ClientPanel panel;
 	private PluginToolbar pluginToolbar;
 	private PluginPanel pluginPanel;
 
-	public ClientUI(Applet client)
+	public ClientUI(RuneliteProperties properties, Applet client)
 	{
+		this.properties = properties;
 		this.client = client;
 		setUIFont(new FontUIResource(FontManager.getRunescapeFont()));
 		init();
 		pack();
 		TitleBarPane titleBarPane = new TitleBarPane(this.getRootPane(), (SubstanceRootPaneUI)this.getRootPane().getUI());
 		titleBarPane.editTitleBar(this);
-		setTitle("RuneLite");
+		setTitle(null);
 		setIconImage(RuneLite.ICON);
 		setLocationRelativeTo(getOwner());
 		setResizable(true);
@@ -86,6 +90,20 @@ public class ClientUI extends JFrame
 			{
 				UIManager.put(key, f);
 			}
+		}
+	}
+
+
+	@Override
+	public void setTitle(String extra)
+	{
+		if (!Strings.isNullOrEmpty(extra))
+		{
+			super.setTitle(properties.getTitle() + " " + properties.getVersion() + " " + extra);
+		}
+		else
+		{
+			super.setTitle(properties.getTitle() + " " + properties.getVersion());
 		}
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
@@ -24,11 +24,11 @@
  */
 package net.runelite.client.ui;
 
+import java.applet.Applet;
 import java.awt.BorderLayout;
 import java.awt.Dimension;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
-import java.io.IOException;
 import java.util.Enumeration;
 import javax.swing.JFrame;
 import javax.swing.JOptionPane;
@@ -51,16 +51,16 @@ public class ClientUI extends JFrame
 	private static final int SCROLLBAR_WIDTH = 17;
 	private static final int EXPANDED_WIDTH = CLIENT_WIDTH + PluginPanel.PANEL_WIDTH + SCROLLBAR_WIDTH;
 
-	private final RuneLite runelite;
+	private final Applet client;
 	private JPanel container;
 	private JPanel navContainer;
 	private ClientPanel panel;
 	private PluginToolbar pluginToolbar;
 	private PluginPanel pluginPanel;
 
-	public ClientUI(RuneLite runelite)
+	public ClientUI(Applet client)
 	{
-		this.runelite = runelite;
+		this.client = client;
 		setUIFont(new FontUIResource(FontManager.getRunescapeFont()));
 		init();
 		pack();
@@ -107,19 +107,7 @@ public class ClientUI extends JFrame
 		container = new JPanel();
 		container.setLayout(new BorderLayout(0, 0));
 
-		panel = new ClientPanel(this);
-		if (!RuneLite.getOptions().has("no-rs"))
-		{
-			try
-			{
-				panel.loadRs();
-			}
-			catch (IOException | ClassNotFoundException | InstantiationException | IllegalAccessException ex)
-			{
-				log.error("Error loading RS!", ex);
-				System.exit(-1);
-			}
-		}
+		panel = new ClientPanel(client);
 		container.add(panel, BorderLayout.CENTER);
 
 		navContainer = new JPanel();
@@ -183,11 +171,10 @@ public class ClientUI extends JFrame
 
 	private void checkExit()
 	{
-		Client client = runelite.getClient();
 		int result = JOptionPane.OK_OPTION;
 
 		// only ask if not logged out
-		if (client != null && client.getGameState() != GameState.LOGIN_SCREEN)
+		if (client != null && client instanceof Client && ((Client)client).getGameState() != GameState.LOGIN_SCREEN)
 		{
 			result = JOptionPane.showConfirmDialog(this, "Are you sure you want to exit?", "Exit", JOptionPane.OK_CANCEL_OPTION, JOptionPane.QUESTION_MESSAGE);
 		}
@@ -206,10 +193,5 @@ public class ClientUI extends JFrame
 	public PluginPanel getPluginPanel()
 	{
 		return pluginPanel;
-	}
-
-	RuneLite getRunelite()
-	{
-		return runelite;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
@@ -24,8 +24,8 @@
  */
 package net.runelite.client.ui;
 
-import java.applet.Applet;
 import com.google.common.base.Strings;
+import java.applet.Applet;
 import java.awt.AWTException;
 import java.awt.BorderLayout;
 import java.awt.Dimension;
@@ -43,17 +43,20 @@ import javax.imageio.ImageIO;
 import javax.swing.JFrame;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
+import javax.swing.JPopupMenu;
 import javax.swing.JScrollPane;
 import javax.swing.ScrollPaneConstants;
 import javax.swing.SwingUtilities;
+import javax.swing.ToolTipManager;
 import javax.swing.UIManager;
+import javax.swing.UnsupportedLookAndFeelException;
 import javax.swing.plaf.FontUIResource;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.GameState;
-import net.runelite.client.RuneLite;
 import net.runelite.client.RuneliteProperties;
+import org.pushingpixels.substance.api.skin.SubstanceGraphiteLookAndFeel;
 import org.pushingpixels.substance.internal.ui.SubstanceRootPaneUI;
 
 @Slf4j
@@ -62,6 +65,7 @@ public class ClientUI extends JFrame
 	private static final int CLIENT_WIDTH = 809;
 	private static final int SCROLLBAR_WIDTH = 17;
 	private static final int EXPANDED_WIDTH = CLIENT_WIDTH + PluginPanel.PANEL_WIDTH + SCROLLBAR_WIDTH;
+	private static final BufferedImage ICON;
 
 	@Getter
 	private TrayIcon trayIcon;
@@ -70,23 +74,70 @@ public class ClientUI extends JFrame
 	private final RuneliteProperties properties;
 	private JPanel container;
 	private JPanel navContainer;
-	private ClientPanel panel;
 	private PluginToolbar pluginToolbar;
 	private PluginPanel pluginPanel;
-	private BufferedImage icon;
 
-	public ClientUI(RuneliteProperties properties, Applet client)
+	static
+	{
+		BufferedImage icon = null;
+
+		try
+		{
+			icon = ImageIO.read(ClientUI.class.getResourceAsStream("/runelite.png"));
+		}
+		catch (IOException e)
+		{
+			log.warn("Client icon failed to load", e);
+		}
+
+		ICON = icon;
+	}
+
+	public static ClientUI create(RuneliteProperties properties, Applet client)
+	{
+		// Force heavy-weight popups/tooltips.
+		// Prevents them from being obscured by the game applet.
+		ToolTipManager.sharedInstance().setLightWeightPopupEnabled(false);
+		JPopupMenu.setDefaultLightWeightPopupEnabled(false);
+
+		// Do not render shadows under popups/tooltips.
+		// Fixes black boxes under popups that are above the game applet.
+		System.setProperty("jgoodies.popupDropShadowEnabled", "false");
+
+		// Do not fill in background on repaint. Reduces flickering when
+		// the applet is resized.
+		System.setProperty("sun.awt.noerasebackground", "true");
+
+		// Use custom window decorations
+		JFrame.setDefaultLookAndFeelDecorated(true);
+
+		// Use substance look and feel
+		try
+		{
+			UIManager.setLookAndFeel(new SubstanceGraphiteLookAndFeel());
+		}
+		catch (UnsupportedLookAndFeelException ex)
+		{
+			log.warn("unable to set look and feel", ex);
+		}
+
+		// Use custom UI font
+		setUIFont(new FontUIResource(FontManager.getRunescapeFont()));
+
+		return new ClientUI(properties, client);
+	}
+
+	private ClientUI(RuneliteProperties properties, Applet client)
 	{
 		this.properties = properties;
 		this.client = client;
-		setUIFont(new FontUIResource(FontManager.getRunescapeFont()));
-		setupTrayIcon();
+		this.trayIcon = setupTrayIcon();
+
 		init();
 		pack();
-		TitleBarPane titleBarPane = new TitleBarPane(this.getRootPane(), (SubstanceRootPaneUI)this.getRootPane().getUI());
-		titleBarPane.editTitleBar(this);
+		new TitleBarPane(this.getRootPane(), (SubstanceRootPaneUI)this.getRootPane().getUI()).editTitleBar(this);
 		setTitle(null);
-		setIconImage(icon);
+		setIconImage(ICON);
 		setLocationRelativeTo(getOwner());
 		setResizable(true);
 		setVisible(true);
@@ -108,25 +159,15 @@ public class ClientUI extends JFrame
 		}
 	}
 
-	private void setupTrayIcon()
+	private TrayIcon setupTrayIcon()
 	{
 		if (!SystemTray.isSupported())
 		{
-			return;
+			return null;
 		}
 
 		SystemTray systemTray = SystemTray.getSystemTray();
-
-		try
-		{
-			icon = ImageIO.read(ClientUI.class.getResourceAsStream("/runelite.png"));
-		}
-		catch (IOException e)
-		{
-			log.warn("Client icon failed to load", e);
-		}
-
-		trayIcon = new TrayIcon(icon, properties.getTitle());
+		TrayIcon trayIcon = new TrayIcon(ICON, properties.getTitle());
 		trayIcon.setImageAutoSize(true);
 
 		try
@@ -136,7 +177,7 @@ public class ClientUI extends JFrame
 		catch (AWTException ex)
 		{
 			log.debug("Unable to add system tray icon", ex);
-			return;
+			return trayIcon;
 		}
 
 		// bring to front when tray icon is clicked
@@ -149,6 +190,8 @@ public class ClientUI extends JFrame
 				setState(Frame.NORMAL); // unminimize
 			}
 		});
+
+		return trayIcon;
 	}
 
 
@@ -182,9 +225,7 @@ public class ClientUI extends JFrame
 
 		container = new JPanel();
 		container.setLayout(new BorderLayout(0, 0));
-
-		panel = new ClientPanel(client);
-		container.add(panel, BorderLayout.CENTER);
+		container.add(new ClientPanel(client), BorderLayout.CENTER);
 
 		navContainer = new JPanel();
 		navContainer.setLayout(new BorderLayout(0, 0));
@@ -264,10 +305,5 @@ public class ClientUI extends JFrame
 	public PluginToolbar getPluginToolbar()
 	{
 		return pluginToolbar;
-	}
-
-	public PluginPanel getPluginPanel()
-	{
-		return pluginPanel;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/components/PanelComponent.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/components/PanelComponent.java
@@ -33,7 +33,6 @@ import java.awt.Point;
 import java.awt.Rectangle;
 import java.util.ArrayList;
 import java.util.List;
-import javax.annotation.Nullable;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.Getter;
@@ -61,7 +60,6 @@ public class PanelComponent implements RenderableEntity
 	}
 
 	@Setter
-	@Nullable
 	private String title;
 
 	@Setter

--- a/runelite-client/src/main/java/net/runelite/client/util/QueryRunner.java
+++ b/runelite-client/src/main/java/net/runelite/client/util/QueryRunner.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2017, Tomas Slusny <slusnucky@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.util;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import net.runelite.api.Client;
+import net.runelite.api.Query;
+
+@Singleton
+public class QueryRunner
+{
+	@Inject
+	private Client client;
+
+	@SuppressWarnings("unchecked")
+	public <T> T[] runQuery(Query query)
+	{
+		return (T[]) query.result(client);
+	}
+}

--- a/runelite-plugin-archetype/src/main/resources/archetype-resources/src/main/java/ExamplePlugin.java
+++ b/runelite-plugin-archetype/src/main/resources/archetype-resources/src/main/java/ExamplePlugin.java
@@ -27,7 +27,6 @@ public class ExamplePlugin extends Plugin
 	private static final Logger logger = LoggerFactory.getLogger(ExamplePlugin.class);
 
 	@Inject
-	@Nullable
 	Client client;
 
 	@Inject


### PR DESCRIPTION
- Extract specific functionality that could be decoupled to separate
modules
- Move UI-related logic to ClientUI class
- Remove usage of runelite.getClient and replace it with actual client
injection

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>