### PR TITLE
Actually fix example plugin archetype, and add a test to make sure it stays that way

### DIFF
--- a/runelite-plugin-archetype/src/main/resources/archetype-resources/src/main/java/ExampleOverlay.java
+++ b/runelite-plugin-archetype/src/main/resources/archetype-resources/src/main/java/ExampleOverlay.java
@@ -5,7 +5,6 @@ package ${package};
 
 import java.awt.Dimension;
 import java.awt.Graphics2D;
-import java.awt.Point;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
 import net.runelite.api.Client;
@@ -29,7 +28,7 @@ public class ExampleOverlay extends Overlay
 	}
 
 	@Override
-	public Dimension render(Graphics2D graphics, Point parent)
+	public Dimension render(Graphics2D graphics, java.awt.Point parent)
 	{
 		if (client.getGameState() != GameState.LOGGED_IN || !config.enabled())
 		{

--- a/runelite-plugin-archetype/src/test/resources/projects/compilationtest/archetype.properties
+++ b/runelite-plugin-archetype/src/test/resources/projects/compilationtest/archetype.properties
@@ -1,0 +1,5 @@
+sourceEncoding=UTF-8
+groupId=org.example.runelite
+artifactId=exampleplugin
+version=1.0.0-SNAPSHOT
+package=org.example.runelite.exampleplugin

--- a/runelite-plugin-archetype/src/test/resources/projects/compilationtest/goal.txt
+++ b/runelite-plugin-archetype/src/test/resources/projects/compilationtest/goal.txt
@@ -1,0 +1,1 @@
+clean verify


### PR DESCRIPTION
This PR fixes the dependency conflict that was introduced in the last fix (#264), and adds a test to make sure that it at least builds.

The test is failing when I run it from IDEA, but works just fine if I run it from a regular shell. I'm pretty sure the issue is just IDEA/my configuration, but we'll see how travis likes it.