### PR TITLE
Fix OkHttp connection leaks on connection error

### DIFF
--- a/http-api/src/main/java/net/runelite/http/api/account/AccountClient.java
+++ b/http-api/src/main/java/net/runelite/http/api/account/AccountClient.java
@@ -33,7 +33,6 @@ import net.runelite.http.api.RuneliteAPI;
 import okhttp3.HttpUrl;
 import okhttp3.Request;
 import okhttp3.Response;
-import okhttp3.ResponseBody;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -65,11 +64,9 @@ public class AccountClient
 			.url(url)
 			.build();
 
-		Response response = RuneliteAPI.CLIENT.newCall(request).execute();
-
-		try (ResponseBody body = response.body())
+		try (Response response = RuneliteAPI.CLIENT.newCall(request).execute())
 		{
-			InputStream in = body.byteStream();
+			InputStream in = response.body().byteStream();
 			return RuneliteAPI.GSON.fromJson(new InputStreamReader(in), OAuthResponse.class);
 		}
 		catch (JsonParseException ex)
@@ -92,9 +89,7 @@ public class AccountClient
 			.url(url)
 			.build();
 
-		Response response = RuneliteAPI.CLIENT.newCall(request).execute();
-
-		try (ResponseBody body = response.body())
+		try (Response response = RuneliteAPI.CLIENT.newCall(request).execute())
 		{
 			logger.debug("Sent logout request");
 		}

--- a/http-api/src/main/java/net/runelite/http/api/config/ConfigClient.java
+++ b/http-api/src/main/java/net/runelite/http/api/config/ConfigClient.java
@@ -35,7 +35,6 @@ import okhttp3.MediaType;
 import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
-import okhttp3.ResponseBody;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -65,11 +64,9 @@ public class ConfigClient
 			.url(url)
 			.build();
 
-		Response response = RuneliteAPI.CLIENT.newCall(request).execute();
-
-		try (ResponseBody body = response.body())
+		try (Response response = RuneliteAPI.CLIENT.newCall(request).execute())
 		{
-			InputStream in = body.byteStream();
+			InputStream in = response.body().byteStream();
 			return RuneliteAPI.GSON.fromJson(new InputStreamReader(in), Configuration.class);
 		}
 		catch (JsonParseException ex)

--- a/http-api/src/main/java/net/runelite/http/api/hiscore/HiscoreClient.java
+++ b/http-api/src/main/java/net/runelite/http/api/hiscore/HiscoreClient.java
@@ -32,7 +32,6 @@ import net.runelite.http.api.RuneliteAPI;
 import okhttp3.HttpUrl;
 import okhttp3.Request;
 import okhttp3.Response;
-import okhttp3.ResponseBody;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -55,11 +54,9 @@ public class HiscoreClient
 			.url(url)
 			.build();
 
-		Response response = RuneliteAPI.CLIENT.newCall(request).execute();
-
-		try (ResponseBody body = response.body())
+		try (Response response = RuneliteAPI.CLIENT.newCall(request).execute())
 		{
-			InputStream in = body.byteStream();
+			InputStream in = response.body().byteStream();
 			return RuneliteAPI.GSON.fromJson(new InputStreamReader(in), HiscoreResult.class);
 		}
 		catch (JsonParseException ex)
@@ -76,24 +73,22 @@ public class HiscoreClient
 	public SingleHiscoreSkillResult lookup(String username, HiscoreSkill skill, HiscoreEndpoint endpoint) throws IOException
 	{
 		HttpUrl.Builder builder = RuneliteAPI.getApiBase().newBuilder()
-				.addPathSegment("hiscore")
-				.addPathSegment(endpoint.name())
-				.addPathSegment(skill.toString().toLowerCase())
-				.addQueryParameter("username", username);
+			.addPathSegment("hiscore")
+			.addPathSegment(endpoint.name())
+			.addPathSegment(skill.toString().toLowerCase())
+			.addQueryParameter("username", username);
 
 		HttpUrl url = builder.build();
 
 		logger.debug("Built URI: {}", url);
 
 		Request request = new Request.Builder()
-				.url(url)
-				.build();
+			.url(url)
+			.build();
 
-		Response response = RuneliteAPI.CLIENT.newCall(request).execute();
-
-		try (ResponseBody body = response.body())
+		try (Response response = RuneliteAPI.CLIENT.newCall(request).execute())
 		{
-			InputStream in = body.byteStream();
+			InputStream in = response.body().byteStream();
 			return RuneliteAPI.GSON.fromJson(new InputStreamReader(in), SingleHiscoreSkillResult.class);
 		}
 		catch (JsonParseException ex)

--- a/http-api/src/main/java/net/runelite/http/api/item/ItemClient.java
+++ b/http-api/src/main/java/net/runelite/http/api/item/ItemClient.java
@@ -32,7 +32,6 @@ import net.runelite.http.api.RuneliteAPI;
 import okhttp3.HttpUrl;
 import okhttp3.Request;
 import okhttp3.Response;
-import okhttp3.ResponseBody;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -54,17 +53,15 @@ public class ItemClient
 			.url(url)
 			.build();
 
-		Response response = RuneliteAPI.CLIENT.newCall(request).execute();
-
-		if (!response.isSuccessful())
+		try (Response response = RuneliteAPI.CLIENT.newCall(request).execute())
 		{
-			logger.debug("Error looking up item {}: {}", itemId, response.message());
-			return null;
-		}
+			if (!response.isSuccessful())
+			{
+				logger.debug("Error looking up item {}: {}", itemId, response.message());
+				return null;
+			}
 
-		try (ResponseBody body = response.body())
-		{
-			InputStream in = body.byteStream();
+			InputStream in = response.body().byteStream();
 			return RuneliteAPI.GSON.fromJson(new InputStreamReader(in), ItemPrice.class);
 		}
 		catch (JsonParseException ex)
@@ -76,28 +73,26 @@ public class ItemClient
 	public SearchResult search(String itemName) throws IOException
 	{
 		HttpUrl url = RuneliteAPI.getApiBase().newBuilder()
-				.addPathSegment("item")
-				.addPathSegment("search")
-				.addQueryParameter("query", itemName)
-				.build();
+			.addPathSegment("item")
+			.addPathSegment("search")
+			.addQueryParameter("query", itemName)
+			.build();
 
 		logger.debug("Built URI: {}", url);
 
 		Request request = new Request.Builder()
-				.url(url)
-				.build();
+			.url(url)
+			.build();
 
-		Response response = RuneliteAPI.CLIENT.newCall(request).execute();
-
-		if (!response.isSuccessful())
+		try (Response response = RuneliteAPI.CLIENT.newCall(request).execute())
 		{
-			logger.debug("Error looking up item {}: {}", itemName, response.message());
-			return null;
-		}
+			if (!response.isSuccessful())
+			{
+				logger.debug("Error looking up item {}: {}", itemName, response.message());
+				return null;
+			}
 
-		try (ResponseBody body = response.body())
-		{
-			InputStream in = body.byteStream();
+			InputStream in = response.body().byteStream();
 			return RuneliteAPI.GSON.fromJson(new InputStreamReader(in), SearchResult.class);
 		}
 		catch (JsonParseException ex)

--- a/http-api/src/main/java/net/runelite/http/api/xtea/XteaClient.java
+++ b/http-api/src/main/java/net/runelite/http/api/xtea/XteaClient.java
@@ -36,7 +36,6 @@ import okhttp3.MediaType;
 import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
-import okhttp3.ResponseBody;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -83,11 +82,9 @@ public class XteaClient
 			.url(url)
 			.build();
 
-		Response response = RuneliteAPI.CLIENT.newCall(request).execute();
-
-		try (ResponseBody body = response.body())
+		try (Response response = RuneliteAPI.CLIENT.newCall(request).execute())
 		{
-			InputStream in = body.byteStream();
+			InputStream in = response.body().byteStream();
 			// CHECKSTYLE:OFF
 			return RuneliteAPI.GSON.fromJson(new InputStreamReader(in), new TypeToken<List<XteaKey>>() { }.getType());
 			// CHECKSTYLE:ON
@@ -109,11 +106,9 @@ public class XteaClient
 			.url(url)
 			.build();
 
-		Response response = RuneliteAPI.CLIENT.newCall(request).execute();
-
-		try (ResponseBody body = response.body())
+		try (Response response = RuneliteAPI.CLIENT.newCall(request).execute())
 		{
-			InputStream in = body.byteStream();
+			InputStream in = response.body().byteStream();
 			return RuneliteAPI.GSON.fromJson(new InputStreamReader(in), XteaKey.class);
 		}
 		catch (JsonParseException ex)

--- a/http-service/src/main/java/net/runelite/http/service/item/ItemService.java
+++ b/http-service/src/main/java/net/runelite/http/service/item/ItemService.java
@@ -45,7 +45,6 @@ import net.runelite.http.api.item.SearchResult;
 import okhttp3.HttpUrl;
 import okhttp3.Request;
 import okhttp3.Response;
-import okhttp3.ResponseBody;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -487,16 +486,14 @@ public class ItemService
 
 	private <T> T fetchJson(Request request, Class<T> clazz) throws IOException
 	{
-		Response response = RuneliteAPI.CLIENT.newCall(request).execute();
-
-		if (!response.isSuccessful())
+		try (Response response = RuneliteAPI.CLIENT.newCall(request).execute())
 		{
-			throw new IOException("Unsuccessful http response: " + response.message());
-		}
+			if (!response.isSuccessful())
+			{
+				throw new IOException("Unsuccessful http response: " + response.message());
+			}
 
-		try (ResponseBody body = response.body())
-		{
-			InputStream in = body.byteStream();
+			InputStream in = response.body().byteStream();
 			return RuneliteAPI.GSON.fromJson(new InputStreamReader(in), clazz);
 		}
 		catch (JsonParseException ex)
@@ -513,16 +510,14 @@ public class ItemService
 			.url(httpUrl)
 			.build();
 
-		Response response = RuneliteAPI.CLIENT.newCall(request).execute();
-
-		if (!response.isSuccessful())
+		try (Response response = RuneliteAPI.CLIENT.newCall(request).execute())
 		{
-			throw new IOException("Unsuccessful http response: " + response.message());
-		}
+			if (!response.isSuccessful())
+			{
+				throw new IOException("Unsuccessful http response: " + response.message());
+			}
 
-		try (ResponseBody body = response.body())
-		{
-			return body.bytes();
+			return response.body().bytes();
 		}
 	}
 }

--- a/http-service/src/main/java/net/runelite/http/service/worlds/WorldsService.java
+++ b/http-service/src/main/java/net/runelite/http/service/worlds/WorldsService.java
@@ -34,7 +34,6 @@ import net.runelite.http.api.worlds.WorldResult;
 import okhttp3.HttpUrl;
 import okhttp3.Request;
 import okhttp3.Response;
-import okhttp3.ResponseBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -53,12 +52,11 @@ public class WorldsService
 			.url(url)
 			.build();
 
-		Response okresponse = RuneliteAPI.CLIENT.newCall(okrequest).execute();
 		byte[] b;
 
-		try (ResponseBody body = okresponse.body())
+		try (Response okresponse = RuneliteAPI.CLIENT.newCall(okrequest).execute())
 		{
-			b = body.bytes();
+			b = okresponse.body().bytes();
 		}
 
 		List<World> worlds = new ArrayList<>();

--- a/runelite-client/src/main/java/net/runelite/client/ConfigLoader.java
+++ b/runelite-client/src/main/java/net/runelite/client/ConfigLoader.java
@@ -31,13 +31,11 @@ import java.util.HashMap;
 import java.util.Map;
 import net.runelite.http.api.RuneliteAPI;
 import okhttp3.HttpUrl;
-import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
 
 public class ConfigLoader
 {
-	private static final OkHttpClient CLIENT = RuneliteAPI.CLIENT;
 	private static final HttpUrl CONFIG_URL = HttpUrl.parse("http://oldschool.runescape.com/jav_config.ws"); // https redirects us to rs3
 
 	public static final String CODEBASE = "codebase";
@@ -53,7 +51,7 @@ public class ConfigLoader
 			.url(CONFIG_URL)
 			.build();
 
-		try (Response response = CLIENT.newCall(request).execute();
+		try (Response response = RuneliteAPI.CLIENT.newCall(request).execute();
 			BufferedReader in = new BufferedReader(new InputStreamReader(response.body().byteStream())))
 		{
 			String str;


### PR DESCRIPTION
When request fails, entire response needs to be wrapped in try with
resources in order to close the connection properly and not only
response body.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>