### PR TITLE
XP tracker plugin - fix login experience drop not being ignored

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerPlugin.java
@@ -73,6 +73,10 @@ public class XpTrackerPlugin extends Plugin
 		if (event.getGameState() == GameState.LOGGED_IN)
 		{
 			xpPanel.resetAllSkillXpHr();
+			for (int i = 0; i < NUMBER_OF_SKILLS; i++)
+			{
+				xpInfos[i] = null;
+			}
 		}
 	}
 


### PR DESCRIPTION
Fix the xp array not being reset when changing characters without closing the client, resulting in massive xp gain/loss per hour being shown.