### PR TITLE
XP tracker plugin - Allow hopping/logging out/other GameState changes, Fix login experience drop not being ignored

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/Client.java
+++ b/runelite-api/src/main/java/net/runelite/api/Client.java
@@ -62,6 +62,8 @@ public interface Client extends GameEngine
 
 	int getCameraYaw();
 
+	int getWorld();
+
 	int getViewportHeight();
 
 	int getViewportWidth();

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpWorldType.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpWorldType.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2018, Adam <Adam@sigterm.info>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.xptracker;
+
+import net.runelite.http.api.worlds.WorldType;
+
+enum XpWorldType
+{
+	NORMAL,
+	DMM,
+	SDMM;
+
+	public static XpWorldType of(WorldType type)
+	{
+		switch (type)
+		{
+			case DEADMAN:
+				return DMM;
+			case SEASONAL_DEADMAN:
+				return SDMM;
+			default:
+				return NORMAL;
+		}
+	}
+}


### PR DESCRIPTION
Allow hopping/logging out/other GameState changes without resetting XP tracker. Tracker automatically resets when changing characters.