### PR TITLE
Change the default color scheme of the swing UI

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
@@ -29,6 +29,7 @@ import com.google.common.eventbus.Subscribe;
 import java.applet.Applet;
 import java.awt.BorderLayout;
 import java.awt.Canvas;
+import java.awt.Color;
 import java.awt.Component;
 import java.awt.Container;
 import java.awt.Cursor;
@@ -67,7 +68,8 @@ import net.runelite.client.events.TitleToolbarButtonRemoved;
 import net.runelite.client.util.OSType;
 import net.runelite.client.util.OSXUtil;
 import net.runelite.client.util.SwingUtil;
-import org.pushingpixels.substance.api.skin.SubstanceGraphiteLookAndFeel;
+import org.pushingpixels.substance.api.SubstanceCortex;
+import org.pushingpixels.substance.api.skin.GraphiteSkin;
 import org.pushingpixels.substance.internal.utils.SubstanceCoreUtilities;
 import org.pushingpixels.substance.internal.utils.SubstanceTitlePaneUtilities;
 
@@ -290,7 +292,8 @@ public class ClientUI
 			SwingUtil.setupDefaults();
 
 			// Use substance look and feel
-			SwingUtil.setTheme(new SubstanceGraphiteLookAndFeel());
+			SubstanceCortex.GlobalScope.setSkin(new GraphiteSkin().transform(substanceColorScheme -> substanceColorScheme
+				.shiftBackground(new Color(61, 52, 41, 255), 1), "OSRS"));
 
 			// Use custom UI font
 			SwingUtil.setFont(FontManager.getRunescapeFont());

--- a/runelite-client/src/main/java/net/runelite/client/util/SwingUtil.java
+++ b/runelite-client/src/main/java/net/runelite/client/util/SwingUtil.java
@@ -51,10 +51,8 @@ import javax.swing.JFrame;
 import javax.swing.JMenuItem;
 import javax.swing.JOptionPane;
 import javax.swing.JPopupMenu;
-import javax.swing.LookAndFeel;
 import javax.swing.ToolTipManager;
 import javax.swing.UIManager;
-import javax.swing.UnsupportedLookAndFeelException;
 import static javax.swing.WindowConstants.DO_NOTHING_ON_CLOSE;
 import javax.swing.plaf.FontUIResource;
 import lombok.extern.slf4j.Slf4j;
@@ -86,23 +84,6 @@ public class SwingUtil
 		// Do not fill in background on repaint. Reduces flickering when
 		// the applet is resized.
 		System.setProperty("sun.awt.noerasebackground", "true");
-	}
-
-	/**
-	 * Safely sets Swing theme
-	 *
-	 * @param laf the swing look and feel
-	 */
-	public static void setTheme(@Nonnull final LookAndFeel laf)
-	{
-		try
-		{
-			UIManager.setLookAndFeel(laf);
-		}
-		catch (UnsupportedLookAndFeelException ex)
-		{
-			log.warn("Unable to set look and feel", ex);
-		}
 	}
 
 	/**


### PR DESCRIPTION
Change the default color scheme of the swing UI from Graphite/gray to
OSRS/brown to match the in-game UI and also to feel more "warm".

Preview of the OSRS-themed UI:
![screenie](https://user-images.githubusercontent.com/5115805/34134769-0a7a7ce2-e45d-11e7-8f6c-be40a6da5823.png)

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>