### PR TITLE
RSPlayerMixin: Don't NPE when Player name is null

### DIFF
--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSPlayerMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSPlayerMixin.java
@@ -48,7 +48,14 @@ public abstract class RSPlayerMixin implements RSPlayer
 	@Override
 	public String getName()
 	{
-		return getRSName().replace('\u00A0', ' ');
+		String name = getRSName();
+
+		if (name == null)
+		{
+			return null;
+		}
+
+		return name.replace('\u00A0', ' ');
 	}
 
 	@Inject


### PR DESCRIPTION
Player name is null when the player's appearance hasn't been decoded/set.

For the local player I at one instance measured 160ms between having initialized the Player object and having decoded the appearance, which provides a window in which the name field can be null.