### PR TITLE
Show account and config plugins when outdated

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/account/AccountPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/account/AccountPlugin.java
@@ -50,7 +50,8 @@ import net.runelite.http.api.account.OAuthResponse;
 import net.runelite.http.api.ws.messages.LoginResponse;
 
 @PluginDescriptor(
-	name = "Account plugin"
+	name = "Account plugin",
+	loadWhenOutdated = true
 )
 @Slf4j
 public class AccountPlugin extends Plugin

--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPlugin.java
@@ -33,7 +33,8 @@ import net.runelite.client.ui.ClientUI;
 import net.runelite.client.ui.NavigationButton;
 
 @PluginDescriptor(
-	name = "Configuration plugin"
+	name = "Configuration plugin",
+	loadWhenOutdated = true
 )
 public class ConfigPlugin extends Plugin
 {


### PR DESCRIPTION
Add property to load when outdated to both account and config plugins to
make them visible even when native client is loaded.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>