### PR TITLE
Change warning for not found task to debug

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerPlugin.java
@@ -283,7 +283,7 @@ public class SlayerPlugin extends Plugin
 		int itemSpriteId = ItemID.ENCHANTED_GEM;
 		if (task == null)
 		{
-			log.warn("No slayer task for {} in the Task database", taskName);
+			log.debug("No slayer task for {} in the Task database", taskName);
 		}
 		else
 		{


### PR DESCRIPTION
As this is not really issue, as in this case the icon just falls back to
the default gem icon, this should not really be a warning message and
spam console logs.

Fixes #292

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>