### PR TITLE
Prevent cursor icon from getting stuck as the wrong shape

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
@@ -28,6 +28,7 @@ import com.google.common.base.Strings;
 import java.applet.Applet;
 import java.awt.AWTException;
 import java.awt.BorderLayout;
+import java.awt.Cursor;
 import java.awt.Dimension;
 import java.awt.Font;
 import java.awt.Frame;
@@ -141,6 +142,8 @@ public class ClientUI extends JFrame
 		new TitleBarPane(this.getRootPane(), (SubstanceRootPaneUI)this.getRootPane().getUI()).editTitleBar(this);
 		setTitle(null);
 		setIconImage(ICON);
+		// Prevent substance from using a resize cursor for pointing
+		getLayeredPane().setCursor(Cursor.getDefaultCursor());
 		setLocationRelativeTo(getOwner());
 		setResizable(true);
 		setVisible(true);


### PR DESCRIPTION
Since it sounds like this isn't just an issue for me and my weird linux+hipster tiling wm setup, here's a PR to fix the cursor weirdness.

Once its gotten close to the edge of the window, my cursor will usually get stuck as one of the resize arrows rather than change back to a normal cursor.  It looks like Substance gets confused about what the last cursor was, and starts "restoring" one of the resize cursors, instead of the pointer, when the cursor moves back away from the edge of the window. Setting the cursor for the frame's LayeredPane fixes the problem.