### PR TITLE
client: Add option to disable custom window chrome/style

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/RuneLite.java
+++ b/runelite-client/src/main/java/net/runelite/client/RuneLite.java
@@ -41,7 +41,7 @@ import net.runelite.api.Client;
 import net.runelite.client.account.SessionManager;
 import net.runelite.client.chat.ChatMessageManager;
 import net.runelite.client.config.ConfigManager;
-import net.runelite.client.config.RuneliteConfig;
+import net.runelite.client.config.RuneLiteConfig;
 import net.runelite.client.menus.MenuManager;
 import net.runelite.client.plugins.PluginManager;
 import net.runelite.client.ui.ClientUI;
@@ -84,6 +84,9 @@ public class RuneLite
 
 	@Inject
 	private SessionManager sessionManager;
+	
+	@Inject
+	private RuneLiteConfig runeliteConfig;
 
 	Client client;
 	ClientUI gui;
@@ -158,9 +161,8 @@ public class RuneLite
 
 		// Begin watching for new plugins
 		pluginManager.watch();
-
-		boolean customChrome = configManager.getConfig(RuneliteConfig.class).enableCustomChrome();
-		SwingUtilities.invokeAndWait(() -> gui.showWithChrome(customChrome));
+		
+		SwingUtilities.invokeAndWait(() -> gui.showWithChrome(runeliteConfig.enableCustomChrome()));
 	}
 
 	public void setGui(ClientUI gui)

--- a/runelite-client/src/main/java/net/runelite/client/RuneLite.java
+++ b/runelite-client/src/main/java/net/runelite/client/RuneLite.java
@@ -84,7 +84,7 @@ public class RuneLite
 
 	@Inject
 	private SessionManager sessionManager;
-	
+
 	@Inject
 	private RuneLiteConfig runeliteConfig;
 
@@ -161,7 +161,7 @@ public class RuneLite
 
 		// Begin watching for new plugins
 		pluginManager.watch();
-		
+
 		SwingUtilities.invokeAndWait(() -> gui.showWithChrome(runeliteConfig.enableCustomChrome()));
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/RuneLite.java
+++ b/runelite-client/src/main/java/net/runelite/client/RuneLite.java
@@ -41,6 +41,7 @@ import net.runelite.api.Client;
 import net.runelite.client.account.SessionManager;
 import net.runelite.client.chat.ChatMessageManager;
 import net.runelite.client.config.ConfigManager;
+import net.runelite.client.config.RuneliteConfig;
 import net.runelite.client.menus.MenuManager;
 import net.runelite.client.plugins.PluginManager;
 import net.runelite.client.ui.ClientUI;
@@ -157,6 +158,9 @@ public class RuneLite
 
 		// Begin watching for new plugins
 		pluginManager.watch();
+
+		boolean customChrome = configManager.getConfig(RuneliteConfig.class).enableCustomChrome();
+		SwingUtilities.invokeAndWait(() -> gui.showWithChrome(customChrome));
 	}
 
 	public void setGui(ClientUI gui)

--- a/runelite-client/src/main/java/net/runelite/client/config/RuneLiteConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/RuneLiteConfig.java
@@ -40,7 +40,7 @@ public interface RuneLiteConfig extends Config
 	{
 		return true;
 	}
-	
+
 	@ConfigItem(
 		keyName = "uiEnableCustomChrome",
 		name = "Enable custom window chrome",

--- a/runelite-client/src/main/java/net/runelite/client/config/RuneLiteConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/RuneLiteConfig.java
@@ -40,6 +40,17 @@ public interface RuneLiteConfig extends Config
 	{
 		return true;
 	}
+	
+	@ConfigItem(
+		keyName = "uiEnableCustomChrome",
+		name = "Enable custom window chrome",
+		description = "Use Runelite's custom window title and borders.",
+		confirmationWarining = "Please restart your client after changing this setting"
+	)
+	default boolean enableCustomChrome()
+	{
+		return true;
+	}
 
 	@ConfigItem(
 		keyName = "enablePlugins",

--- a/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
@@ -143,7 +143,7 @@ public class ClientUI extends JFrame
 		setLocationRelativeTo(getOwner());
 		setResizable(true);
 	}
-	
+
 	public void showWithChrome(boolean customChrome)
 	{
 		setUndecorated(customChrome);
@@ -158,7 +158,7 @@ public class ClientUI extends JFrame
 		{
 			new TitleBarPane(this.getRootPane(), (SubstanceRootPaneUI) this.getRootPane().getUI()).editTitleBar(this);
 		}
-		
+
 		setVisible(true);
 		toFront();
 	}
@@ -258,7 +258,7 @@ public class ClientUI extends JFrame
 		add(container);
 	}
 
-	void revalidateMinimumSize()
+	private void revalidateMinimumSize()
 	{
 		// The JFrame only respects minimumSize if it was set by setMinimumSize, for some reason. (atleast on windows/native)
 		this.setMinimumSize(this.getLayout().minimumLayoutSize(this));
@@ -272,8 +272,8 @@ public class ClientUI extends JFrame
 		}
 
 		pluginPanel = panel;
-		navContainer.setMinimumSize(new Dimension(PANEL_EXPANDED_WIDTH,0));
-		navContainer.setMaximumSize(new Dimension(PANEL_EXPANDED_WIDTH,Integer.MAX_VALUE));
+		navContainer.setMinimumSize(new Dimension(PANEL_EXPANDED_WIDTH, 0));
+		navContainer.setMaximumSize(new Dimension(PANEL_EXPANDED_WIDTH, Integer.MAX_VALUE));
 		navContainer.add(wrapPanel(pluginPanel));
 		navContainer.revalidate();
 		revalidateMinimumSize();
@@ -281,15 +281,15 @@ public class ClientUI extends JFrame
 
 	void contract()
 	{
-		boolean wasMinimumWidth = this.getWidth() == (int)this.getMinimumSize().getWidth();
+		boolean wasMinimumWidth = this.getWidth() == (int) this.getMinimumSize().getWidth();
 		navContainer.remove(0);
-		navContainer.setMinimumSize(new Dimension(0,0));
-		navContainer.setMaximumSize(new Dimension(0,Integer.MAX_VALUE));
+		navContainer.setMinimumSize(new Dimension(0, 0));
+		navContainer.setMaximumSize(new Dimension(0, Integer.MAX_VALUE));
 		navContainer.revalidate();
 		revalidateMinimumSize();
 		if (wasMinimumWidth)
 		{
-			this.setSize((int)this.getMinimumSize().getWidth(), getHeight());
+			this.setSize((int) this.getMinimumSize().getWidth(), getHeight());
 		}
 		pluginPanel = null;
 	}

--- a/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
@@ -47,6 +47,7 @@ import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JPopupMenu;
 import javax.swing.JScrollPane;
+import javax.swing.JRootPane;
 import javax.swing.ScrollPaneConstants;
 import javax.swing.SwingUtilities;
 import javax.swing.ToolTipManager;
@@ -111,9 +112,6 @@ public class ClientUI extends JFrame
 		// the applet is resized.
 		System.setProperty("sun.awt.noerasebackground", "true");
 
-		// Use custom window decorations
-		JFrame.setDefaultLookAndFeelDecorated(true);
-
 		// Use substance look and feel
 		try
 		{
@@ -138,14 +136,27 @@ public class ClientUI extends JFrame
 		this.trayIcon = setupTrayIcon();
 
 		init();
-		pack();
-		new TitleBarPane(this.getRootPane(), (SubstanceRootPaneUI)this.getRootPane().getUI()).editTitleBar(this);
 		setTitle(null);
 		setIconImage(ICON);
 		// Prevent substance from using a resize cursor for pointing
 		getLayeredPane().setCursor(Cursor.getDefaultCursor());
 		setLocationRelativeTo(getOwner());
 		setResizable(true);
+	}
+	
+	public void showWithChrome(boolean customChrome)
+	{
+		setUndecorated(customChrome);
+		if (customChrome)
+		{
+			getRootPane().setWindowDecorationStyle(JRootPane.FRAME);
+		}
+		pack();
+		if (customChrome)
+		{
+			new TitleBarPane(this.getRootPane(), (SubstanceRootPaneUI) this.getRootPane().getUI()).editTitleBar(this);
+		}
+		
 		setVisible(true);
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
@@ -152,6 +152,7 @@ public class ClientUI extends JFrame
 			getRootPane().setWindowDecorationStyle(JRootPane.FRAME);
 		}
 		pack();
+		setLocationRelativeTo(getOwner());
 		if (customChrome)
 		{
 			new TitleBarPane(this.getRootPane(), (SubstanceRootPaneUI) this.getRootPane().getUI()).editTitleBar(this);

--- a/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
@@ -42,6 +42,7 @@ import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.util.Enumeration;
 import javax.imageio.ImageIO;
+import javax.swing.BoxLayout;
 import javax.swing.JFrame;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
@@ -66,9 +67,8 @@ import org.pushingpixels.substance.internal.ui.SubstanceRootPaneUI;
 @Slf4j
 public class ClientUI extends JFrame
 {
-	private static final int CLIENT_WIDTH = 809;
 	private static final int SCROLLBAR_WIDTH = 17;
-	private static final int EXPANDED_WIDTH = CLIENT_WIDTH + PluginPanel.PANEL_WIDTH + SCROLLBAR_WIDTH;
+	private static final int PANEL_EXPANDED_WIDTH = PluginPanel.PANEL_WIDTH + SCROLLBAR_WIDTH;
 	private static final BufferedImage ICON;
 
 	@Getter
@@ -152,6 +152,7 @@ public class ClientUI extends JFrame
 			getRootPane().setWindowDecorationStyle(JRootPane.FRAME);
 		}
 		pack();
+		revalidateMinimumSize();
 		setLocationRelativeTo(getOwner());
 		if (customChrome)
 		{
@@ -159,6 +160,7 @@ public class ClientUI extends JFrame
 		}
 		
 		setVisible(true);
+		toFront();
 	}
 
 	private static void setUIFont(FontUIResource f)
@@ -231,7 +233,6 @@ public class ClientUI extends JFrame
 		assert SwingUtilities.isEventDispatchThread();
 
 		setDefaultCloseOperation(DO_NOTHING_ON_CLOSE);
-		setMinimumSize(new Dimension(CLIENT_WIDTH, 0));
 		addWindowListener(new WindowAdapter()
 		{
 			@Override
@@ -242,41 +243,53 @@ public class ClientUI extends JFrame
 		});
 
 		container = new JPanel();
-		container.setLayout(new BorderLayout(0, 0));
-		container.add(new ClientPanel(client), BorderLayout.CENTER);
+		container.setLayout(new BoxLayout(container, BoxLayout.X_AXIS));
+		container.add(new ClientPanel(client));
 
 		navContainer = new JPanel();
-		navContainer.setLayout(new BorderLayout(0, 0));
-		container.add(navContainer, BorderLayout.EAST);
+		navContainer.setLayout(new BorderLayout(0,0));
+		navContainer.setMinimumSize(new Dimension(0,0));
+		navContainer.setMaximumSize(new Dimension(0,Integer.MAX_VALUE));
+		container.add(navContainer);
 
 		pluginToolbar = new PluginToolbar(this);
-		navContainer.add(pluginToolbar, BorderLayout.EAST);
+		container.add(pluginToolbar);
 
 		add(container);
+	}
+
+	void revalidateMinimumSize()
+	{
+		// The JFrame only respects minimumSize if it was set by setMinimumSize, for some reason. (atleast on windows/native)
+		this.setMinimumSize(this.getLayout().minimumLayoutSize(this));
 	}
 
 	void expand(PluginPanel panel)
 	{
 		if (pluginPanel != null)
 		{
-			navContainer.remove(1);
-			container.validate();
+			navContainer.remove(0);
 		}
 
 		pluginPanel = panel;
-		navContainer.add(wrapPanel(pluginPanel), BorderLayout.WEST);
-		container.validate();
-		this.setMinimumSize(new Dimension(EXPANDED_WIDTH, 0));
+		navContainer.setMinimumSize(new Dimension(PANEL_EXPANDED_WIDTH,0));
+		navContainer.setMaximumSize(new Dimension(PANEL_EXPANDED_WIDTH,Integer.MAX_VALUE));
+		navContainer.add(wrapPanel(pluginPanel));
+		navContainer.revalidate();
+		revalidateMinimumSize();
 	}
 
 	void contract()
 	{
-		navContainer.remove(1);
-		container.validate();
-		this.setMinimumSize(new Dimension(CLIENT_WIDTH, 0));
-		if (this.getWidth() == EXPANDED_WIDTH)
+		boolean wasMinimumWidth = this.getWidth() == (int)this.getMinimumSize().getWidth();
+		navContainer.remove(0);
+		navContainer.setMinimumSize(new Dimension(0,0));
+		navContainer.setMaximumSize(new Dimension(0,Integer.MAX_VALUE));
+		navContainer.revalidate();
+		revalidateMinimumSize();
+		if (wasMinimumWidth)
 		{
-			this.setSize(CLIENT_WIDTH, getHeight());
+			this.setSize((int)this.getMinimumSize().getWidth(), getHeight());
 		}
 		pluginPanel = null;
 	}

--- a/runelite-client/src/main/java/net/runelite/client/ui/PluginToolbar.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/PluginToolbar.java
@@ -48,6 +48,7 @@ public class PluginToolbar extends JToolBar
 		super.setSize(new Dimension(TOOLBAR_WIDTH, TOOLBAR_HEIGHT));
 		super.setMinimumSize(new Dimension(TOOLBAR_WIDTH, TOOLBAR_HEIGHT));
 		super.setPreferredSize(new Dimension(TOOLBAR_WIDTH, TOOLBAR_HEIGHT));
+		super.setMaximumSize(new Dimension(TOOLBAR_WIDTH, Integer.MAX_VALUE));
 	}
 
 	public void addNavigation(NavigationButton button)


### PR DESCRIPTION
This is similar to #240 but it adds it as a config option.

Because it is a config option it waits for the config to be loaded before showing the window. This has the positive side affect of not having the contents of the window jump around as plugins are loaded, but makes it take even longer to show the window. It may be a good idea to add a splash screen or loading bar.