### PR TITLE
Remove "RS" prefixes from runescape-client classes

### DIFF
--- a/runescape-api/src/main/java/net/runelite/rs/api/RSGameCanvas.java
+++ b/runescape-api/src/main/java/net/runelite/rs/api/RSGameCanvas.java
@@ -24,6 +24,6 @@
  */
 package net.runelite.rs.api;
 
-public interface RSCanvas
+public interface RSGameCanvas
 {
 }

--- a/runescape-client/src/main/java/Client.java
+++ b/runescape-client/src/main/java/Client.java
@@ -3879,7 +3879,7 @@ public final class Client extends GameEngine {
                         TotalQuantityComparator.clientInstance.method884(var43);
                      } else {
                         field1051[field1049] = FileRequest.field3304;
-                        field1085[field1049] = RSSocket.field2186;
+                        field1085[field1049] = GameSocket.field2186;
                         ++field1049;
                      }
                   }

--- a/runescape-client/src/main/java/GameCanvas.java
+++ b/runescape-client/src/main/java/GameCanvas.java
@@ -7,13 +7,13 @@ import net.runelite.mapping.ObfuscatedName;
 import net.runelite.mapping.ObfuscatedSignature;
 
 @ObfuscatedName("bc")
-@Implements("RSCanvas")
-public final class RSCanvas extends Canvas {
+@Implements("GameCanvas")
+public final class GameCanvas extends Canvas {
    @ObfuscatedName("a")
    @Export("component")
    Component component;
 
-   RSCanvas(Component var1) {
+   GameCanvas(Component var1) {
       this.component = var1;
    }
 

--- a/runescape-client/src/main/java/GameEngine.java
+++ b/runescape-client/src/main/java/GameEngine.java
@@ -502,7 +502,7 @@ public abstract class GameEngine extends Applet implements Runnable, FocusListen
          VertexNormal.canvasHeight -= var2.top + var2.bottom;
       }
 
-      this.canvas = new RSCanvas(this);
+      this.canvas = new GameCanvas(this);
       var1.add(this.canvas);
       this.canvas.setSize(Huffman.canvasWidth, VertexNormal.canvasHeight);
       this.canvas.setVisible(true);

--- a/runescape-client/src/main/java/GameSocket.java
+++ b/runescape-client/src/main/java/GameSocket.java
@@ -7,8 +7,8 @@ import net.runelite.mapping.ObfuscatedName;
 import net.runelite.mapping.ObfuscatedSignature;
 
 @ObfuscatedName("fr")
-@Implements("RSSocket")
-public class RSSocket implements Runnable {
+@Implements("GameSocket")
+public class GameSocket implements Runnable {
    @ObfuscatedName("cu")
    public static char field2186;
    @ObfuscatedName("a")
@@ -37,7 +37,7 @@ public class RSSocket implements Runnable {
    @ObfuscatedName("f")
    boolean field2189;
 
-   RSSocket(OutputStream var1, int var2) {
+   GameSocket(OutputStream var1, int var2) {
       this.field2187 = 0;
       this.field2184 = 0;
       this.field2183 = var1;

--- a/runescape-client/src/main/java/TextureProvider.java
+++ b/runescape-client/src/main/java/TextureProvider.java
@@ -282,7 +282,7 @@ public class TextureProvider implements ITextureLoader {
             var4 += var0.readUnsignedByte() << 8;
          }
 
-         RSCanvas.method764(var0, var2, var3, var4);
+         GameCanvas.method764(var0, var2, var3, var4);
       }
 
    }

--- a/runescape-client/src/main/java/class161.java
+++ b/runescape-client/src/main/java/class161.java
@@ -23,7 +23,7 @@ public class class161 extends class159 {
    @ObfuscatedSignature(
       signature = "Lfr;"
    )
-   RSSocket field2155;
+   GameSocket field2155;
 
    class161(Socket var1, int var2, int var3) throws IOException {
       this.field2156 = var1;
@@ -32,7 +32,7 @@ public class class161 extends class159 {
       this.field2156.setReceiveBufferSize(65536);
       this.field2156.setSendBufferSize(65536);
       this.field2157 = new class153(this.field2156.getInputStream(), var2);
-      this.field2155 = new RSSocket(this.field2156.getOutputStream(), var3);
+      this.field2155 = new GameSocket(this.field2156.getOutputStream(), var3);
    }
 
    @ObfuscatedName("w")

--- a/runescape-client/src/main/java/class192.java
+++ b/runescape-client/src/main/java/class192.java
@@ -248,7 +248,7 @@ public class class192 {
                               boolean var10 = false;
 
                               for(int var11 = 0; var11 < "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!\"£$%^&*()-_=+[{]};:\'@#~,<.>/?\\| ".length(); ++var11) {
-                                 if(RSSocket.field2186 == "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!\"£$%^&*()-_=+[{]};:\'@#~,<.>/?\\| ".charAt(var11)) {
+                                 if(GameSocket.field2186 == "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!\"£$%^&*()-_=+[{]};:\'@#~,<.>/?\\| ".charAt(var11)) {
                                     var10 = true;
                                     break;
                                  }
@@ -271,7 +271,7 @@ public class class192 {
                                  }
 
                                  if(var10 && class91.username.length() < 320) {
-                                    class91.username = class91.username + RSSocket.field2186;
+                                    class91.username = class91.username + GameSocket.field2186;
                                  }
                               } else if(class91.field1345 == 1) {
                                  if(FileRequest.field3304 == 85 && class91.password.length() > 0) {
@@ -301,7 +301,7 @@ public class class192 {
                                  }
 
                                  if(var10 && class91.password.length() < 20) {
-                                    class91.password = class91.password + RSSocket.field2186;
+                                    class91.password = class91.password + GameSocket.field2186;
                                  }
                               }
                            }
@@ -382,7 +382,7 @@ public class class192 {
                               var21 = false;
 
                               for(var22 = 0; var22 < "1234567890".length(); ++var22) {
-                                 if(RSSocket.field2186 == "1234567890".charAt(var22)) {
+                                 if(GameSocket.field2186 == "1234567890".charAt(var22)) {
                                     var21 = true;
                                     break;
                                  }
@@ -415,7 +415,7 @@ public class class192 {
                                  }
 
                                  if(var21 && class237.field3245.length() < 6) {
-                                    class237.field3245 = class237.field3245 + RSSocket.field2186;
+                                    class237.field3245 = class237.field3245 + GameSocket.field2186;
                                  }
                               }
                            }
@@ -436,7 +436,7 @@ public class class192 {
                               var21 = false;
 
                               for(var22 = 0; var22 < "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!\"£$%^&*()-_=+[{]};:\'@#~,<.>/?\\| ".length(); ++var22) {
-                                 if(RSSocket.field2186 == "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!\"£$%^&*()-_=+[{]};:\'@#~,<.>/?\\| ".charAt(var22)) {
+                                 if(GameSocket.field2186 == "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!\"£$%^&*()-_=+[{]};:\'@#~,<.>/?\\| ".charAt(var22)) {
                                     var21 = true;
                                     break;
                                  }
@@ -455,7 +455,7 @@ public class class192 {
                                  }
 
                                  if(var21 && class91.username.length() < 320) {
-                                    class91.username = class91.username + RSSocket.field2186;
+                                    class91.username = class91.username + GameSocket.field2186;
                                  }
                               }
                            }

--- a/runescape-client/src/main/java/class230.java
+++ b/runescape-client/src/main/java/class230.java
@@ -116,7 +116,7 @@ public class class230 implements class229 {
             return false;
          } else {
             FileRequest.field3304 = KeyFocusListener.field599[KeyFocusListener.field602];
-            RSSocket.field2186 = KeyFocusListener.field598[KeyFocusListener.field602];
+            GameSocket.field2186 = KeyFocusListener.field598[KeyFocusListener.field602];
             KeyFocusListener.field602 = KeyFocusListener.field602 + 1 & 127;
             return true;
          }


### PR DESCRIPTION
This makes mixins that perform actions on those classes work again.

For example:
 ```
[INFO] Class RSCanvas implements nonexistent interface net.runelite.rs.api.RSRSCanvas, skipping interface injection
```
would show up when trying to build with a mixin on the class ``net.runelite.rs.api.RSCanvas``.