### PR TITLE
WidgetHiddenChanged event

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/events/WidgetHiddenChanged.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/WidgetHiddenChanged.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2018, Adam <Adam@sigterm.info>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.api.events;
+
+import lombok.Data;
+import net.runelite.api.widgets.Widget;
+
+@Data
+public class WidgetHiddenChanged
+{
+	private Widget widget;
+	private boolean hidden;
+}

--- a/runelite-api/src/main/java/net/runelite/api/widgets/WidgetID.java
+++ b/runelite-api/src/main/java/net/runelite/api/widgets/WidgetID.java
@@ -24,32 +24,32 @@
  */
 package net.runelite.api.widgets;
 
-class WidgetID
+public class WidgetID
 {
-	static final int LOGOUT_PANEL_ID = 182;
-	static final int BANK_GROUP_ID = 12;
-	static final int BANK_INVENTORY_GROUP_ID = 15;
-	static final int DEPOSIT_BOX_GROUP_ID = 192;
-	static final int INVENTORY_GROUP_ID = 149;
-	static final int EQUIPMENT_GROUP_ID = 387;
-	static final int PESTRCONTROL_GROUP_ID = 408;
-	static final int CLAN_CHAT_GROUP_ID = 7;
-	static final int MINIMAP_GROUP_ID = 160;
-	static final int LOGIN_CLICK_TO_PLAY_GROUP_ID = 378;
-	static final int CLUE_SCROLL_GROUP_ID = 203;
-	static final int FIXED_VIEWPORT_GROUP_ID = 548;
-	static final int RESIZABLE_VIEWPORT_OLD_SCHOOL_BOX_GROUP_ID = 161;
-	static final int RESIZABLE_VIEWPORT_BOTTOM_LINE_GROUP_ID = 164;
-	static final int PRAYER_GROUP_ID = 541;
-	static final int SHOP_GROUP_ID = 300;
-	static final int SHOP_INVENTORY_GROUP_ID = 301;
-	static final int COMBAT_GROUP_ID = 593;
-	static final int DIALOG_NPC_GROUP_ID = 231;
-	static final int SLAYER_REWARDS_GROUP_ID = 426;
-	static final int PRIVATE_CHAT = 163;
-	static final int CHATBOX_GROUP_ID = 162;
-	static final int WORLD_MAP_MENU_GROUP_ID = 160;
-	static final int VOLCANIC_MINE_GROUP_ID = 611;
+	public static final int LOGOUT_PANEL_ID = 182;
+	public static final int BANK_GROUP_ID = 12;
+	public static final int BANK_INVENTORY_GROUP_ID = 15;
+	public static final int DEPOSIT_BOX_GROUP_ID = 192;
+	public static final int INVENTORY_GROUP_ID = 149;
+	public static final int EQUIPMENT_GROUP_ID = 387;
+	public static final int PESTRCONTROL_GROUP_ID = 408;
+	public static final int CLAN_CHAT_GROUP_ID = 7;
+	public static final int MINIMAP_GROUP_ID = 160;
+	public static final int LOGIN_CLICK_TO_PLAY_GROUP_ID = 378;
+	public static final int CLUE_SCROLL_GROUP_ID = 203;
+	public static final int FIXED_VIEWPORT_GROUP_ID = 548;
+	public static final int RESIZABLE_VIEWPORT_OLD_SCHOOL_BOX_GROUP_ID = 161;
+	public static final int RESIZABLE_VIEWPORT_BOTTOM_LINE_GROUP_ID = 164;
+	public static final int PRAYER_GROUP_ID = 541;
+	public static final int SHOP_GROUP_ID = 300;
+	public static final int SHOP_INVENTORY_GROUP_ID = 301;
+	public static final int COMBAT_GROUP_ID = 593;
+	public static final int DIALOG_NPC_GROUP_ID = 231;
+	public static final int SLAYER_REWARDS_GROUP_ID = 426;
+	public static final int PRIVATE_CHAT = 163;
+	public static final int CHATBOX_GROUP_ID = 162;
+	public static final int WORLD_MAP_MENU_GROUP_ID = 160;
+	public static final int VOLCANIC_MINE_GROUP_ID = 611;
 
 	static class WorldMap
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/attackindicator/AttackIndicatorPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/attackindicator/AttackIndicatorPlugin.java
@@ -24,15 +24,11 @@
  */
 package net.runelite.client.plugins.attackindicator;
 
-import static net.runelite.client.plugins.attackindicator.AttackStyle.CASTING;
-import static net.runelite.client.plugins.attackindicator.AttackStyle.DEFENSIVE_CASTING;
-import static net.runelite.client.plugins.attackindicator.AttackStyle.OTHER;
 import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.Table;
 import com.google.common.eventbus.Subscribe;
 import com.google.inject.Binder;
 import com.google.inject.Provides;
-import java.time.temporal.ChronoUnit;
 import java.util.HashSet;
 import java.util.Set;
 import javax.inject.Inject;
@@ -41,15 +37,18 @@ import net.runelite.api.Client;
 import net.runelite.api.GameState;
 import net.runelite.api.Skill;
 import net.runelite.api.Varbits;
-import net.runelite.api.widgets.Widget;
-import net.runelite.api.widgets.WidgetInfo;
-import net.runelite.client.config.ConfigManager;
 import net.runelite.api.events.ConfigChanged;
 import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.VarbitChanged;
+import net.runelite.api.events.WidgetHiddenChanged;
+import net.runelite.api.widgets.Widget;
+import static net.runelite.api.widgets.WidgetID.COMBAT_GROUP_ID;
+import net.runelite.api.widgets.WidgetInfo;
+import static net.runelite.api.widgets.WidgetInfo.TO_GROUP;
+import net.runelite.client.config.ConfigManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
-import net.runelite.client.task.Schedule;
+import static net.runelite.client.plugins.attackindicator.AttackStyle.*;
 
 @PluginDescriptor(
 	name = "Attack indicator plugin"
@@ -102,12 +101,14 @@ public class AttackIndicatorPlugin extends Plugin
 		return warnedSkillSelected;
 	}
 
-	@Schedule(
-		period = 600,
-		unit = ChronoUnit.MILLIS
-	)
-	public void hideWidgets()
+	@Subscribe
+	public void hideWidgets(WidgetHiddenChanged event)
 	{
+		if (event.getWidget().isHidden() || TO_GROUP(event.getWidget().getId()) != COMBAT_GROUP_ID)
+		{
+			return;
+		}
+
 		if (widgetsToHide == null)
 		{
 			return;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/combatlevel/CombatLevelPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/combatlevel/CombatLevelPlugin.java
@@ -24,20 +24,20 @@
  */
 package net.runelite.client.plugins.combatlevel;
 
+import com.google.common.eventbus.Subscribe;
 import com.google.inject.Provides;
 import java.text.DecimalFormat;
-import java.time.temporal.ChronoUnit;
 import javax.inject.Inject;
 import net.runelite.api.Client;
 import net.runelite.api.Experience;
 import net.runelite.api.GameState;
 import net.runelite.api.Skill;
+import net.runelite.api.events.GameTick;
 import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
-import net.runelite.client.task.Schedule;
 
 @PluginDescriptor(
 	name = "Combat level plugin"
@@ -58,11 +58,8 @@ public class CombatLevelPlugin extends Plugin
 		return configManager.getConfig(CombatLevelConfig.class);
 	}
 
-	@Schedule(
-		period = 600,
-		unit = ChronoUnit.MILLIS
-	)
-	public void updateCombatLevel()
+	@Subscribe
+	public void updateCombatLevel(GameTick event)
 	{
 		if (client.getGameState() != GameState.LOGGED_IN)
 		{

--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSWidgetMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSWidgetMixin.java
@@ -31,13 +31,16 @@ import java.util.List;
 import net.runelite.api.Node;
 import net.runelite.api.Point;
 import net.runelite.api.WidgetNode;
+import net.runelite.api.events.WidgetHiddenChanged;
+import net.runelite.api.mixins.FieldHook;
+import net.runelite.api.mixins.Inject;
+import net.runelite.api.mixins.Mixin;
+import net.runelite.api.mixins.Shadow;
 import net.runelite.api.widgets.Widget;
 import static net.runelite.api.widgets.WidgetInfo.TO_CHILD;
 import static net.runelite.api.widgets.WidgetInfo.TO_GROUP;
 import net.runelite.api.widgets.WidgetItem;
-import net.runelite.api.mixins.Inject;
-import net.runelite.api.mixins.Mixin;
-import net.runelite.api.mixins.Shadow;
+import static net.runelite.client.callback.Hooks.eventBus;
 import net.runelite.rs.api.RSClient;
 import net.runelite.rs.api.RSHashTable;
 import net.runelite.rs.api.RSWidget;
@@ -313,5 +316,25 @@ public abstract class RSWidgetMixin implements RSWidget
 	{
 		Rectangle bounds = getBounds();
 		return bounds != null && bounds.contains(new java.awt.Point(point.getX(), point.getY()));
+	}
+
+	@FieldHook("isHidden")
+	@Inject
+	public void onHiddenChanged(int idx)
+	{
+		int id = getId();
+
+		if (id == -1)
+		{
+			return;
+		}
+
+		boolean hidden = isHidden();
+
+		WidgetHiddenChanged event = new WidgetHiddenChanged();
+		event.setWidget(this);
+		event.setHidden(hidden);
+
+		eventBus.post(event);
 	}
 }


### PR DESCRIPTION
An event gets fired as soon as a Widget is created from the GraphicsObject.loadWidget (cj.k) function.
This makes manipulation of widgets much smoother without having to rely on polling.

For example: 
![2018-01-07_16-17-32](https://user-images.githubusercontent.com/503776/34651081-746ddcd4-f3cb-11e7-8455-b185f89fcc55.gif)

The first combat style is hidden as soon as the weapon is changed where it usually would've been redrawn. The old polling method can be seen with the delayed update of the decimal in the Combat Lvl.
