### PR TITLE
Fix mixins producing broken code

### DIFF
--- a/runescape-client-injector-plugin/src/main/java/net/runelite/injector/MixinInjector.java
+++ b/runescape-client-injector-plugin/src/main/java/net/runelite/injector/MixinInjector.java
@@ -341,6 +341,11 @@ public class MixinInjector
 				throw new InjectionException("Failed to find the ob method " + obMethodName + " for mixin " + mixinCf);
 			}
 
+			if (method.getDescriptor().size() > obMethod.getDescriptor().size())
+			{
+				throw new InjectionException("Mixin methods cannot have more parameters than their corresponding ob method");
+			}
+
 			Method copy = new Method(cf, "copy$" + deobMethodName, obMethodSignature);
 			moveCode(copy, obMethod.getCode());
 			copy.setAccessFlags(obMethod.getAccessFlags());
@@ -412,6 +417,12 @@ public class MixinInjector
 
 				Method obMethod = obCf.findMethod(obMethodName, obMethodSignature);
 				assert obMethod != null : "obfuscated method " + obMethodName + obMethodSignature + " does not exist";
+
+				if (method.getDescriptor().size() > obMethod.getDescriptor().size())
+				{
+					throw new InjectionException("Mixin methods cannot have more parameters than their corresponding ob method");
+				}
+
 				moveCode(obMethod, method.getCode());
 
 				setOwnersToTargetClass(mixinCf, cf, obMethod, shadowFields, copiedMethods);

--- a/runescape-client-injector-plugin/src/main/java/net/runelite/injector/MixinInjector.java
+++ b/runescape-client-injector-plugin/src/main/java/net/runelite/injector/MixinInjector.java
@@ -41,8 +41,10 @@ import net.runelite.asm.Type;
 import net.runelite.asm.attributes.Code;
 import net.runelite.asm.attributes.annotation.Annotation;
 import net.runelite.asm.attributes.code.Instruction;
+import net.runelite.asm.attributes.code.Instructions;
 import net.runelite.asm.attributes.code.instruction.types.FieldInstruction;
 import net.runelite.asm.attributes.code.instruction.types.InvokeInstruction;
+import net.runelite.asm.attributes.code.instruction.types.LVTInstruction;
 import net.runelite.asm.attributes.code.instructions.GetField;
 import net.runelite.asm.attributes.code.instructions.ILoad;
 import net.runelite.asm.attributes.code.instructions.InvokeDynamic;
@@ -347,7 +349,13 @@ public class MixinInjector
 			copy.getAnnotations().getAnnotations().addAll(obMethod.getAnnotations().getAnnotations());
 			cf.addMethod(copy);
 
-			boolean hasGarbageValue = deobMethod.getDescriptor().size() < obMethodSignature.size();
+			/*
+				If the desc for the mixin method and the desc for the ob method
+				are the same in length, assume that the mixin method is taking
+				care of the garbage parameter itself.
+			 */
+			boolean hasGarbageValue = method.getDescriptor().size() != obMethod.getDescriptor().size()
+					&& deobMethod.getDescriptor().size() < obMethodSignature.size();
 			copiedMethods.put(method.getPoolMethod(), new CopiedMethod(copy, hasGarbageValue));
 
 			logger.debug("Injected copy of {} to {}", obMethod, copy);
@@ -454,6 +462,15 @@ public class MixinInjector
 							? copiedMethod.obMethod.getDescriptor().size() - 1
 							: copiedMethod.obMethod.getDescriptor().size();
 
+						/*
+							If the mixin method doesn't have the garbage parameter,
+							the compiler will have produced code that uses the garbage
+							parameter's local variable index for other things,
+							so we'll have to add 1 to all loads/stores to indices
+							that are >= garbageIndex.
+						 */
+						shiftLocalIndices(method.getCode().getInstructions(), garbageIndex);
+
 						iterator.previous();
 						iterator.add(new ILoad(method.getCode().getInstructions(), garbageIndex));
 						iterator.next();
@@ -488,6 +505,22 @@ public class MixinInjector
 			}
 
 			verify(mixinCf, i);
+		}
+	}
+
+	private void shiftLocalIndices(Instructions instructions, int startIdx)
+	{
+		for (Instruction i : instructions.getInstructions())
+		{
+			if (i instanceof LVTInstruction)
+			{
+				LVTInstruction lvti = (LVTInstruction) i;
+
+				if (lvti.getVariableIndex() >= startIdx)
+				{
+					lvti.setVariableIndex(lvti.getVariableIndex() + 1);
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes the injector producing broken code when doing this:

isFriended has a garbage/dummy parameter, so an ``iload 2`` will be injected before the rs$isFriended call to pass the garbage parameter down the line, but "foo" has already taken the lvar slot 2.

```java
@Copy("isFriended")
private static boolean rs$isFriended(String name, boolean mustBeLoggedIn)
{ return false; }

@Replace("isFriended")
private static boolean rl$isFriended(String name, boolean mustBeLoggedIn)
{
	boolean foo = ....; // <-- foo has taken local var slot 2
	return foo || rs$isFriended(name, false); // iload 2 will be injected for the method call
}
```

This pull request makes it so "foo" uses lvar slot 3, fixing the broken code.
 
It also prevents injected @Replace-annotated methods from using lvar slots that are > the garbage parameter index, by preventing mixin method descriptor length from exceeding their corresponding obfuscated method's descriptor length. Doing this is necessary because the obfuscated method that the mixin method's code will be placed in would otherwise have less parameters than the mixin method.