### PR TITLE
Add plugin for displaying player names

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsConfig.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2018, Tomas Slusny <slusnucky@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.playerindicators;
+
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+
+@ConfigGroup(
+	keyName = "playerindicators",
+	name = "Player Indicators",
+	description = "Configuration for the player indicators plugin"
+)
+public interface PlayerIndicatorsConfig extends Config
+{
+	@ConfigItem(
+		keyName = "drawOwnName",
+		name = "Draw own name",
+		description = "Configures whether or not own name should be drawn"
+	)
+	default boolean drawOwnName()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		keyName = "drawFriendNames",
+		name = "Draw friend names",
+		description = "Configures whether or not names of player friends should be drawn"
+	)
+	default boolean drawFriendNames()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		keyName = "drawClanMemberNames",
+		name = "Draw clan member names",
+		description = "Configures whether or not names of player's clan members should be drawn"
+	)
+	default boolean drawClanMemberNames()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		keyName = "drawPlayerTiles",
+		name = "Draw tiles",
+		description = "Configures whether or not tiles under players with rendered names should be drawn"
+	)
+	default boolean drawTiles()
+	{
+		return false;
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsOverlay.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2018, Tomas Slusny <slusnucky@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.playerindicators;
+
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Graphics2D;
+import java.awt.Point;
+import java.awt.Polygon;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.Client;
+import net.runelite.api.Player;
+import net.runelite.client.ui.overlay.Overlay;
+import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.OverlayUtil;
+
+@Slf4j
+public class PlayerIndicatorsOverlay extends Overlay
+{
+	private static final Color CYAN = new Color(0, 184, 212);
+	private static final Color GREEN = new Color(0, 200, 83);
+	private static final Color PURPLE = new Color(170, 0, 255);
+	private final Client client;
+	private final PlayerIndicatorsConfig config;
+
+	PlayerIndicatorsOverlay(Client client, PlayerIndicatorsConfig config)
+	{
+		this.config = config;
+		this.client = client;
+		setPosition(OverlayPosition.DYNAMIC);
+	}
+
+	@Override
+	public Dimension render(Graphics2D graphics, Point parent)
+	{
+		if (!config.drawOwnName() && !config.drawClanMemberNames() && !config.drawFriendNames())
+		{
+			return null;
+		}
+
+		for (Player player : client.getPlayers())
+		{
+			if (player == null || player.getName() == null)
+			{
+				continue;
+			}
+
+			final String name = player.getName();
+
+			if (player == client.getLocalPlayer())
+			{
+				if (config.drawOwnName())
+				{
+					renderPlayerOverlay(graphics, player, CYAN);
+				}
+			}
+			else if (config.drawFriendNames() && client.isFriend(name, false))
+			{
+				renderPlayerOverlay(graphics, player, GREEN);
+			}
+			else if (config.drawClanMemberNames() && client.isClanMember(name))
+			{
+				renderPlayerOverlay(graphics, player, PURPLE);
+			}
+		}
+
+		return null;
+	}
+
+	private void renderPlayerOverlay(Graphics2D graphics, Player actor, Color color)
+	{
+		if (config.drawTiles())
+		{
+			Polygon poly = actor.getCanvasTilePoly();
+			if (poly != null)
+			{
+				OverlayUtil.renderPolygon(graphics, poly, color);
+			}
+		}
+
+		final String name = actor.getName().replace('\u00A0', ' ');
+		net.runelite.api.Point textLocation = actor
+			.getCanvasTextLocation(graphics, name, actor.getModelHeight() + 40);
+
+		if (textLocation != null)
+		{
+			OverlayUtil.renderTextLocation(graphics, textLocation, name, color);
+		}
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsPlugin.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2018, Tomas Slusny <slusnucky@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.playerindicators;
+
+import com.google.inject.Provides;
+import javax.inject.Inject;
+import net.runelite.api.Client;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.ui.overlay.Overlay;
+
+@PluginDescriptor(
+	name = "Player names plugin"
+)
+public class PlayerIndicatorsPlugin extends Plugin
+{
+	@Inject
+	Client client;
+
+	@Inject
+	PlayerIndicatorsConfig config;
+
+	PlayerIndicatorsOverlay playerIndicatorsOverlay;
+
+	@Provides
+	PlayerIndicatorsConfig provideConfig(ConfigManager configManager)
+	{
+		return configManager.getConfig(PlayerIndicatorsConfig.class);
+	}
+
+	@Override
+	protected void startUp() throws Exception
+	{
+		playerIndicatorsOverlay = new PlayerIndicatorsOverlay(client, config);
+	}
+
+	@Override
+	public Overlay getOverlay()
+	{
+		return playerIndicatorsOverlay;
+	}
+}


### PR DESCRIPTION
Plugin will be able to display own name (disabled by default), friend
player names and clan member names. Also, to optionally render highlighted tile under players with rendered names. Each of the options is configurable.

Fixes #324

Preview:
![clan-names](https://user-images.githubusercontent.com/5115805/34666819-77558de8-f466-11e7-8301-6c6ba55fcaf0.png)

  