### PR TITLE
Incorrect idle notifications

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
@@ -264,7 +264,12 @@ public class IdleNotifierPlugin extends Plugin
 		}
 
 		Actor opponent = local.getInteracting();
-		if (opponent != null && opponent.getCombatLevel() > 0)
+		boolean isPlayer = opponent instanceof Player;
+
+		if (opponent != null
+			&& !isPlayer
+			&& opponent.getCombatLevel() > 0
+			&& opponent.getHealth() != -1)
 		{
 			lastInteracting = Instant.now();
 		}


### PR DESCRIPTION
Fixes idle notifications (claiming to have just dropped combat) from happening when interacting with another player (following/trading) and banking using an NPC instead of a booth. See #282 