### PR TITLE
Fix runelite-plugin-archetype

### DIFF
--- a/runelite-plugin-archetype/src/test/resources/projects/compilationtest/goal.txt
+++ b/runelite-plugin-archetype/src/test/resources/projects/compilationtest/goal.txt
@@ -1,1 +1,1 @@
-clean verify
+verify

--- a/travis/build.sh
+++ b/travis/build.sh
@@ -8,5 +8,5 @@ PROJECT_VERSION=`mvn -q -Dexec.executable="echo" -Dexec.args='${project.version}
 if [[ "${TRAVIS_PULL_REQUEST}" == "false" && $PROJECT_VERSION == *"-SNAPSHOT" && "$TRAVIS_BRANCH" == "master" ]]; then
 	mvn clean deploy --settings travis/settings.xml
 else
-	mvn clean verify --settings travis/settings.xml
+	mvn clean install --settings travis/settings.xml
 fi


### PR DESCRIPTION
- Use "install" instead of "verify" so archetype test can pick up the
latest RuneLite version
- Remove "clean" from goals.txt

Fixes #364

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>