### PR TITLE
Allow PluginPanels to keep state

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/Client.java
+++ b/runelite-api/src/main/java/net/runelite/api/Client.java
@@ -30,7 +30,7 @@ import java.util.Map;
 import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetInfo;
 
-public interface Client
+public interface Client extends GameEngine
 {
 	List<Player> getPlayers();
 

--- a/runelite-api/src/main/java/net/runelite/api/GameEngine.java
+++ b/runelite-api/src/main/java/net/runelite/api/GameEngine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Adam <Adam@sigterm.info>
+ * Copyright (c) 2018 Abex
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -22,40 +22,11 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package net.runelite.client.plugins.config;
+package net.runelite.api;
 
-import javax.imageio.ImageIO;
-import javax.inject.Inject;
-import net.runelite.client.config.ConfigManager;
-import net.runelite.client.plugins.Plugin;
-import net.runelite.client.plugins.PluginDescriptor;
-import net.runelite.client.ui.ClientUI;
-import net.runelite.client.ui.NavigationButton;
+import java.awt.Canvas;
 
-@PluginDescriptor(
-	name = "Configuration plugin",
-	loadWhenOutdated = true
-)
-public class ConfigPlugin extends Plugin
+public interface GameEngine
 {
-	@Inject
-	ClientUI ui;
-
-	@Inject
-	ConfigManager configManager;
-
-	private NavigationButton navButton;
-
-	@Override
-	protected void startUp() throws Exception
-	{
-		ConfigPanel configPanel = new ConfigPanel(configManager);
-
-		navButton = new NavigationButton(
-			"Configuration",
-			ImageIO.read(getClass().getResourceAsStream("config_icon.png")),
-			() -> configPanel);
-
-		ui.getPluginToolbar().addNavigation(navButton);
-	}
+	Canvas getCanvas();
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
@@ -31,7 +31,6 @@ import static javax.swing.JOptionPane.YES_OPTION;
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Component;
-import java.awt.event.ActionEvent;
 import java.awt.event.FocusEvent;
 import java.awt.event.FocusListener;
 import java.awt.event.ItemEvent;
@@ -114,7 +113,7 @@ public class ConfigPanel extends PluginPanel
 			}
 		});
 
-		populateConfig();
+		openConfigList();
 	}
 
 	private void onSearchBarChanged()
@@ -147,7 +146,7 @@ public class ConfigPanel extends PluginPanel
 		}
 	}
 
-	private void populateConfig()
+	private void openConfigList()
 	{
 		removeAll();
 		add(new JLabel("Plugin Configuration", SwingConstants.CENTER));
@@ -336,15 +335,9 @@ public class ConfigPanel extends PluginPanel
 		}
 
 		JButton backButton = new JButton("Back");
-		backButton.addActionListener(this::getBackButtonListener);
+		backButton.addActionListener(e -> openConfigList());
 		add(backButton);
 		revalidate();
 		scrollPane.getVerticalScrollBar().setValue(0);
 	}
-
-	public void getBackButtonListener(ActionEvent e)
-	{
-		populateConfig();
-	}
-
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
@@ -27,6 +27,7 @@ package net.runelite.client.plugins.config;
 import static javax.swing.JOptionPane.WARNING_MESSAGE;
 import static javax.swing.JOptionPane.YES_NO_OPTION;
 import static javax.swing.JOptionPane.YES_OPTION;
+
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Component;
@@ -34,13 +35,10 @@ import java.awt.event.ActionEvent;
 import java.awt.event.FocusEvent;
 import java.awt.event.FocusListener;
 import java.awt.event.ItemEvent;
-import java.awt.event.KeyAdapter;
-import java.awt.event.KeyEvent;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
-import java.util.Comparator;
 import java.util.Map;
 import java.util.TreeMap;
 import javax.swing.JButton;
@@ -58,6 +56,8 @@ import javax.swing.JTextField;
 import javax.swing.SpinnerModel;
 import javax.swing.SpinnerNumberModel;
 import javax.swing.SwingConstants;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.client.config.ConfigDescriptor;
 import net.runelite.client.config.ConfigItem;
@@ -72,21 +72,76 @@ public class ConfigPanel extends PluginPanel
 	private static final int SPINNER_FIELD_WIDTH = 6;
 
 	private final ConfigManager configManager;
-	private JTextField searchBar;
+	private JTextField searchBar = new JTextField();
+	private Map<String, JPanel> children = new TreeMap<>();
+	private int scrollBarPosition = 0;
 
 	public ConfigPanel(ConfigManager configManager)
 	{
 		super();
 		this.configManager = configManager;
+
+		configManager.getConfigProxies().stream()
+			.map(configManager::getConfigDescriptor)
+			.forEach(cd ->
+			{
+				JPanel groupPanel = new JPanel();
+				groupPanel.setLayout(new BorderLayout());
+				JButton viewGroupItemsButton = new JButton(cd.getGroup().name());
+				viewGroupItemsButton.addActionListener(ae -> openGroupConfigPanel(cd, configManager));
+				groupPanel.add(viewGroupItemsButton);
+				children.put(cd.getGroup().name(), groupPanel);
+			});
+
+		searchBar.getDocument().addDocumentListener(new DocumentListener()
+		{
+			@Override
+			public void insertUpdate(DocumentEvent e)
+			{
+				onSearchBarChanged();
+			}
+
+			@Override
+			public void removeUpdate(DocumentEvent e)
+			{
+				onSearchBarChanged();
+			}
+
+			@Override
+			public void changedUpdate(DocumentEvent e)
+			{
+				onSearchBarChanged();
+			}
+		});
+
 		populateConfig();
 	}
 
-	@Override
-	public void invalidate()
+	private void onSearchBarChanged()
 	{
-		super.invalidate();
+		children.forEach((key, value) ->
+		{
+			final String text = searchBar.getText().toLowerCase();
+			final String labelToSearch = key.toLowerCase();
 
-		if (searchBar != null)
+			if (text.isEmpty() || labelToSearch.contains(text))
+			{
+				add(value);
+			}
+			else
+			{
+				remove(value);
+			}
+		});
+
+		revalidate();
+	}
+
+	@Override
+	public void onActivate()
+	{
+		super.onActivate();
+		if (searchBar.getParent() != null)
 		{
 			searchBar.requestFocusInWindow();
 		}
@@ -96,49 +151,12 @@ public class ConfigPanel extends PluginPanel
 	{
 		removeAll();
 		add(new JLabel("Plugin Configuration", SwingConstants.CENTER));
-		searchBar = new JTextField();
 		add(searchBar);
-		final Map<String, JPanel> children = new TreeMap<>();
 
-		configManager.getConfigProxies().stream()
-			.map(configManager::getConfigDescriptor)
-			.sorted(Comparator.comparing(left -> left.getGroup().name()))
-			.forEach(cd ->
-			{
-				JPanel groupPanel = new JPanel();
-				groupPanel.setLayout(new BorderLayout());
-				JButton viewGroupItemsButton = new JButton(cd.getGroup().name());
-				viewGroupItemsButton.addActionListener(ae -> openGroupConfigPanel(cd, configManager));
-				groupPanel.add(viewGroupItemsButton);
-				children.put(cd.getGroup().name(), groupPanel);
-				add(groupPanel);
-			});
-
-		searchBar.addKeyListener(new KeyAdapter()
-		{
-			@Override
-			public void keyTyped(KeyEvent e)
-			{
-				children.forEach((key, value) ->
-				{
-					final String text = searchBar.getText().toLowerCase();
-					final String labelToSearch = key.toLowerCase();
-
-					if (text.isEmpty() || labelToSearch.contains(text))
-					{
-						add(value);
-					}
-					else
-					{
-						remove(value);
-					}
-				});
-
-				revalidate();
-			}
-		});
-
-		revalidate();
+		onSearchBarChanged();
+		searchBar.requestFocusInWindow();
+		scrollPane.validate();
+		scrollPane.getVerticalScrollBar().setValue(scrollBarPosition);
 	}
 
 	private void changeConfiguration(JComponent component, ConfigDescriptor cd, ConfigItemDescriptor cid)
@@ -154,7 +172,7 @@ public class ConfigPanel extends PluginPanel
 			{
 				int value = JOptionPane.showOptionDialog(component, configItem.confirmationWarining(),
 					"Are you sure?", YES_NO_OPTION, WARNING_MESSAGE,
-					null, new String[] { "Yes", "No" }, "No");
+					null, new String[]{"Yes", "No"}, "No");
 				if (value != YES_OPTION)
 				{
 					checkbox.setSelected(originalState);
@@ -192,6 +210,7 @@ public class ConfigPanel extends PluginPanel
 
 	private void openGroupConfigPanel(ConfigDescriptor cd, ConfigManager configManager)
 	{
+		scrollBarPosition = scrollPane.getVerticalScrollBar().getValue();
 		removeAll();
 		String name = cd.getGroup().name() + " Configuration";
 		JLabel title = new JLabel(name);
@@ -320,11 +339,11 @@ public class ConfigPanel extends PluginPanel
 		backButton.addActionListener(this::getBackButtonListener);
 		add(backButton);
 		revalidate();
+		scrollPane.getVerticalScrollBar().setValue(0);
 	}
 
 	public void getBackButtonListener(ActionEvent e)
 	{
-
 		populateConfig();
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
@@ -80,18 +80,6 @@ public class ConfigPanel extends PluginPanel
 		super();
 		this.configManager = configManager;
 
-		configManager.getConfigProxies().stream()
-			.map(configManager::getConfigDescriptor)
-			.forEach(cd ->
-			{
-				JPanel groupPanel = new JPanel();
-				groupPanel.setLayout(new BorderLayout());
-				JButton viewGroupItemsButton = new JButton(cd.getGroup().name());
-				viewGroupItemsButton.addActionListener(ae -> openGroupConfigPanel(cd, configManager));
-				groupPanel.add(viewGroupItemsButton);
-				children.put(cd.getGroup().name(), groupPanel);
-			});
-
 		searchBar.getDocument().addDocumentListener(new DocumentListener()
 		{
 			@Override
@@ -113,6 +101,31 @@ public class ConfigPanel extends PluginPanel
 			}
 		});
 
+		rebuildPluginList();
+		openConfigList();
+	}
+
+	void rebuildPluginList()
+	{
+		Map<String, JPanel> oldChildren = children;
+		children = new TreeMap<String, JPanel>();
+		configManager.getConfigProxies().stream()
+			.map(configManager::getConfigDescriptor)
+			.forEach(cd ->
+			{
+				String groupName = cd.getGroup().name();
+				if (oldChildren.containsKey(groupName))
+				{
+					children.put(groupName, oldChildren.get(groupName));
+					return;
+				}
+				JPanel groupPanel = new JPanel();
+				groupPanel.setLayout(new BorderLayout());
+				JButton viewGroupItemsButton = new JButton(groupName);
+				viewGroupItemsButton.addActionListener(ae -> openGroupConfigPanel(cd, configManager));
+				groupPanel.add(viewGroupItemsButton);
+				children.put(groupName, groupPanel);
+			});
 		openConfigList();
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPlugin.java
@@ -24,9 +24,12 @@
  */
 package net.runelite.client.plugins.config;
 
+import com.google.common.eventbus.Subscribe;
 import javax.imageio.ImageIO;
 import javax.inject.Inject;
+import javax.swing.SwingUtilities;
 import net.runelite.client.config.ConfigManager;
+import net.runelite.client.events.PluginChanged;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.ClientUI;
@@ -44,12 +47,13 @@ public class ConfigPlugin extends Plugin
 	@Inject
 	ConfigManager configManager;
 
+	private ConfigPanel configPanel;
 	private NavigationButton navButton;
 
 	@Override
 	protected void startUp() throws Exception
 	{
-		ConfigPanel configPanel = new ConfigPanel(configManager);
+		configPanel = new ConfigPanel(configManager);
 
 		navButton = new NavigationButton(
 			"Configuration",
@@ -57,5 +61,14 @@ public class ConfigPlugin extends Plugin
 			() -> configPanel);
 
 		ui.getPluginToolbar().addNavigation(navButton);
+	}
+
+	@Subscribe
+	public void onPluginChanged(PluginChanged event)
+	{
+		if (configManager != null)
+		{
+			SwingUtilities.invokeLater(configPanel::rebuildPluginList);
+		}
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/hiscore/HiscorePanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/hiscore/HiscorePanel.java
@@ -326,6 +326,13 @@ public class HiscorePanel extends PluginPanel
 		details.setText(text);
 	}
 
+	@Override
+	public void onActivate()
+	{
+		super.onActivate();
+		input.requestFocusInWindow();
+	}
+
 	private JPanel makeSkillPanel(String skillName, HiscoreSkill skill)
 	{
 		JLabel label = new JLabel();

--- a/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
@@ -78,7 +78,6 @@ public class ClientUI extends JFrame
 	private JPanel navContainer;
 	private PluginToolbar pluginToolbar;
 	private PluginPanel pluginPanel;
-	private boolean gameClientHasFocus = true;
 
 	static
 	{
@@ -166,7 +165,6 @@ public class ClientUI extends JFrame
 
 	private void giveClientFocus()
 	{
-		gameClientHasFocus = true;
 		if (client instanceof Client)
 		{
 			Canvas c = ((Client) client).getCanvas();
@@ -293,6 +291,7 @@ public class ClientUI extends JFrame
 		navContainer.add(wrappedPanel);
 		navContainer.revalidate();
 
+		// panel.onActivate has to go after giveClientFocus so it can get focus if it needs.
 		giveClientFocus();
 		panel.onActivate();
 

--- a/runelite-client/src/main/java/net/runelite/client/ui/PluginPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/PluginPanel.java
@@ -24,27 +24,62 @@
  */
 package net.runelite.client.ui;
 
+import java.awt.BorderLayout;
 import java.awt.Dimension;
 import java.awt.GridLayout;
 import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.ScrollPaneConstants;
 import javax.swing.border.EmptyBorder;
 
 public abstract class PluginPanel extends JPanel
 {
-	public static final int PANEL_WIDTH = 225;
+	static final int PANEL_WIDTH = 225;
+	static final int SCROLLBAR_WIDTH = 17;
 	private static final int OFFSET = 6;
 	private static final EmptyBorder BORDER_PADDING = new EmptyBorder(OFFSET, OFFSET, OFFSET, OFFSET);
+	protected final JScrollPane scrollPane;
+	protected final JPanel wrappedPanel;
 
 	public PluginPanel()
 	{
 		super();
 		setBorder(BORDER_PADDING);
 		setLayout(new GridLayout(0, 1, 0, 3));
+
+		final JPanel northPanel = new JPanel();
+		northPanel.setLayout(new BorderLayout());
+		northPanel.add(this, BorderLayout.NORTH);
+
+		scrollPane = new JScrollPane(northPanel);
+		scrollPane.getVerticalScrollBar().setUnitIncrement(16); //Otherwise scrollspeed is really slow
+		scrollPane.setHorizontalScrollBarPolicy(ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
+
+		wrappedPanel = new JPanel();
+
+		// Adjust the preferred size to expand to width of scrollbar to
+		// to preven scrollbar overlapping over contents
+		wrappedPanel.setPreferredSize(new Dimension(PluginPanel.PANEL_WIDTH + SCROLLBAR_WIDTH, 0));
+		wrappedPanel.setLayout(new BorderLayout());
+		wrappedPanel.add(scrollPane, BorderLayout.CENTER);
 	}
 
 	@Override
 	public Dimension getPreferredSize()
 	{
 		return new Dimension(PANEL_WIDTH, super.getPreferredSize().height);
+	}
+
+	protected JPanel getWrappedPanel()
+	{
+		return wrappedPanel;
+	}
+
+	public void onActivate()
+	{
+	}
+
+	public void onDeactivate()
+	{
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/ui/PluginToolbar.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/PluginToolbar.java
@@ -88,12 +88,11 @@ public class PluginToolbar extends JToolBar
 		}
 		else
 		{
+			current = button;
+			current.setSelected(true);
 
 			PluginPanel pluginPanel = panelSupplier.get();
 			ui.expand(pluginPanel);
-
-			current = button;
-			current.setSelected(true);
 		}
 	}
 }

--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSGameCanvasMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSGameCanvasMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Adam <Adam@sigterm.info>
+ * Copyright (c) 2018 Abex
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -22,40 +22,26 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package net.runelite.client.plugins.config;
+package net.runelite.mixins;
 
-import javax.imageio.ImageIO;
-import javax.inject.Inject;
-import net.runelite.client.config.ConfigManager;
-import net.runelite.client.plugins.Plugin;
-import net.runelite.client.plugins.PluginDescriptor;
-import net.runelite.client.ui.ClientUI;
-import net.runelite.client.ui.NavigationButton;
+import java.awt.Canvas;
+import net.runelite.api.mixins.Inject;
+import net.runelite.api.mixins.Mixin;
+import net.runelite.rs.api.RSGameCanvas;
+import net.runelite.rs.api.RSGameEngine;
 
-@PluginDescriptor(
-	name = "Configuration plugin",
-	loadWhenOutdated = true
-)
-public class ConfigPlugin extends Plugin
+@Mixin(RSGameCanvas.class)
+public abstract class RSGameCanvasMixin implements RSGameCanvas
 {
 	@Inject
-	ClientUI ui;
-
-	@Inject
-	ConfigManager configManager;
-
-	private NavigationButton navButton;
-
-	@Override
-	protected void startUp() throws Exception
+	public void requestFocus()
 	{
-		ConfigPanel configPanel = new ConfigPanel(configManager);
-
-		navButton = new NavigationButton(
-			"Configuration",
-			ImageIO.read(getClass().getResourceAsStream("config_icon.png")),
-			() -> configPanel);
-
-		ui.getPluginToolbar().addNavigation(navButton);
+		// Runescape requests focus whenever the window is resized. This makes it so PluginPanels cannot have focus
+		// if they cause the sidebar to expand. This prevents Runescape from requesting focus whenever it wants
+		RSGameEngine engine = (RSGameEngine)getComponent();
+		if (engine.getShouldGetFocus())
+		{
+			((Canvas) (Object) this).requestFocusInWindow();
+		}
 	}
 }

--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSGameCanvasMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSGameCanvasMixin.java
@@ -31,7 +31,7 @@ import net.runelite.rs.api.RSGameCanvas;
 import net.runelite.rs.api.RSGameEngine;
 
 @Mixin(RSGameCanvas.class)
-public abstract class RSGameCanvasMixin implements RSGameCanvas
+public abstract class RSGameCanvasMixin extends Canvas implements RSGameCanvas
 {
 	@Inject
 	public void requestFocus()
@@ -41,7 +41,7 @@ public abstract class RSGameCanvasMixin implements RSGameCanvas
 		RSGameEngine engine = (RSGameEngine)getComponent();
 		if (engine.getShouldGetFocus())
 		{
-			((Canvas) (Object) this).requestFocusInWindow();
+			this.requestFocusInWindow();
 		}
 	}
 }

--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSGameEngineMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSGameEngineMixin.java
@@ -44,9 +44,11 @@ public abstract class RSGameEngineMixin implements RSGameEngine
 		return shouldGetFocus;
 	}
 
-	// If this is put in rl$replaceCanavs it generates a bad stack map in be::<init> (GameEngines ctor)
-	@Inject
-	private void setShouldGetFocus()
+	@Copy("replaceCanvas")
+	abstract void replaceCanvas();
+
+	@Replace("replaceCanvas")
+	public void rl$replaceCanvas()
 	{
 		Canvas c = getCanvas();
 		if (c == null)
@@ -57,15 +59,6 @@ public abstract class RSGameEngineMixin implements RSGameEngine
 		{
 			shouldGetFocus = c.hasFocus();
 		}
-	}
-
-	@Copy("replaceCanvas")
-	abstract void replaceCanvas();
-
-	@Replace("replaceCanvas")
-	public void rl$replaceCanvas()
-	{
-		setShouldGetFocus();
 		replaceCanvas();
 		shouldGetFocus = true;
 	}

--- a/runescape-api/src/main/java/net/runelite/rs/api/RSGameCanvas.java
+++ b/runescape-api/src/main/java/net/runelite/rs/api/RSGameCanvas.java
@@ -24,6 +24,11 @@
  */
 package net.runelite.rs.api;
 
+import java.awt.Component;
+import net.runelite.mapping.Import;
+
 public interface RSGameCanvas
 {
+	@Import("component")
+	Component getComponent();
 }

--- a/runescape-api/src/main/java/net/runelite/rs/api/RSGameEngine.java
+++ b/runescape-api/src/main/java/net/runelite/rs/api/RSGameEngine.java
@@ -25,10 +25,13 @@
 package net.runelite.rs.api;
 
 import java.awt.Canvas;
+import net.runelite.api.GameEngine;
 import net.runelite.mapping.Import;
 
-public interface RSGameEngine
+public interface RSGameEngine extends GameEngine
 {
 	@Import("canvas")
 	Canvas getCanvas();
+
+	boolean getShouldGetFocus();
 }


### PR DESCRIPTION
This allow PluginPanels to keep state, primarily so that their scrollbars do not get reset when changing panels. It also allows the ConfigPanel to keep it's scroll and search state when entering and exiting it's sub-pages. This introduced a bug where the GameEngine would steal focus when being resized. This was fixed by checking that the old GameCanvas had focus before giving the new GameCanvas focus.

This PR supersedes #367