### PR TITLE
Add check for chatbox minimized

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayRenderer.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayRenderer.java
@@ -187,7 +187,7 @@ public class OverlayRenderer
 			? new Rectangle(viewport.getBounds())
 			: new Rectangle(0, 0, surface.getWidth(), surface.getHeight());
 
-		final Widget chatbox = client.getWidget(WidgetInfo.CHATBOX);
+		final Widget chatbox = client.getWidget(WidgetInfo.CHATBOX_MESSAGES);
 		final Rectangle chatboxBounds = chatbox != null
 				? chatbox.getBounds() : new Rectangle(0, bounds.height, 519, 165);
 
@@ -202,6 +202,14 @@ public class OverlayRenderer
 		bottomRightPoint.move(bounds.x + bounds.width - BORDER_RIGHT, bounds.y + bounds.height - BORDER_BOTTOM);
 		final Point rightChatboxPoint = new Point();
 		rightChatboxPoint.move(bounds.x + chatboxBounds.width - BORDER_RIGHT,bounds.y + bounds.height - BORDER_BOTTOM);
+
+		//check to see if Chatbox is minimized
+		if (chatbox != null && client.isResized() && chatbox.isHidden())
+		{
+			rightChatboxPoint.y += chatboxBounds.height;
+			bottomLeftPoint.y += chatboxBounds.height;
+		}
+
 
 		overlays.stream()
 			.filter(overlay -> shouldDrawOverlay(client, overlay))

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayRenderer.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayRenderer.java
@@ -210,7 +210,6 @@ public class OverlayRenderer
 			bottomLeftPoint.y += chatboxBounds.height;
 		}
 
-
 		overlays.stream()
 			.filter(overlay -> shouldDrawOverlay(client, overlay))
 			.forEach(overlay ->


### PR DESCRIPTION
Currently the bottomleft and rightChatBox are unchanged regardless if chatbox is minimized or not.

Currently:
![chatboxbug](https://user-images.githubusercontent.com/5454364/34920178-2d374e86-f934-11e7-82c6-d91e4852110f.png)

After:
![chatboxfixed](https://user-images.githubusercontent.com/5454364/34920180-33f12aa8-f934-11e7-9327-46a82810fedf.png)

