### PR TITLE
Allow PluginPanels to keep state

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/Client.java
+++ b/runelite-api/src/main/java/net/runelite/api/Client.java
@@ -30,7 +30,7 @@ import java.util.Map;
 import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetInfo;
 
-public interface Client
+public interface Client extends GameEngine
 {
 	List<Player> getPlayers();
 

--- a/runelite-api/src/main/java/net/runelite/api/GameEngine.java
+++ b/runelite-api/src/main/java/net/runelite/api/GameEngine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Adam <Adam@sigterm.info>
+ * Copyright (c) 2018 Abex
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -22,56 +22,11 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package net.runelite.client.plugins.config;
+package net.runelite.api;
 
-import com.google.common.eventbus.Subscribe;
-import javax.imageio.ImageIO;
-import javax.inject.Inject;
-import javax.swing.SwingUtilities;
-import net.runelite.client.config.ConfigManager;
-import net.runelite.client.events.PluginChanged;
-import net.runelite.client.plugins.Plugin;
-import net.runelite.client.plugins.PluginDescriptor;
-import net.runelite.client.ui.ClientUI;
-import net.runelite.client.ui.NavigationButton;
+import java.awt.Canvas;
 
-@PluginDescriptor(
-	name = "Configuration plugin",
-	loadWhenOutdated = true
-)
-public class ConfigPlugin extends Plugin
+public interface GameEngine
 {
-	@Inject
-	ClientUI ui;
-
-	@Inject
-	ConfigManager configManager;
-
-	private ConfigPanel configPanel;
-	private NavigationButton navButton;
-
-	@Override
-	protected void startUp() throws Exception
-	{
-		configPanel = new ConfigPanel(configManager);
-
-		navButton = new NavigationButton(
-			"Configuration",
-			ImageIO.read(getClass().getResourceAsStream("config_icon.png")),
-			() -> configPanel);
-
-		ui.getPluginToolbar().addNavigation(navButton);
-	}
-
-	@Override
-	protected void shutDown() throws Exception
-	{
-		ui.getPluginToolbar().removeNavigation(navButton);
-	}
-
-	@Subscribe
-	public void onPluginChanged(PluginChanged event)
-	{
-		SwingUtilities.invokeLater(configPanel::rebuildPluginList);
-	}
+	Canvas getCanvas();
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/hiscore/HiscorePanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/hiscore/HiscorePanel.java
@@ -326,6 +326,13 @@ public class HiscorePanel extends PluginPanel
 		details.setText(text);
 	}
 
+	@Override
+	public void onActivate()
+	{
+		super.onActivate();
+		input.requestFocusInWindow();
+	}
+
 	private JPanel makeSkillPanel(String skillName, HiscoreSkill skill)
 	{
 		JLabel label = new JLabel();

--- a/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
@@ -28,6 +28,7 @@ import com.google.common.base.Strings;
 import java.applet.Applet;
 import java.awt.AWTException;
 import java.awt.BorderLayout;
+import java.awt.Canvas;
 import java.awt.Cursor;
 import java.awt.Dimension;
 import java.awt.Frame;
@@ -46,9 +47,7 @@ import javax.swing.JFrame;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JPopupMenu;
-import javax.swing.JScrollPane;
 import javax.swing.JRootPane;
-import javax.swing.ScrollPaneConstants;
 import javax.swing.SwingUtilities;
 import javax.swing.ToolTipManager;
 import javax.swing.UIManager;
@@ -65,8 +64,7 @@ import org.pushingpixels.substance.internal.ui.SubstanceRootPaneUI;
 @Slf4j
 public class ClientUI extends JFrame
 {
-	private static final int SCROLLBAR_WIDTH = 17;
-	private static final int PANEL_EXPANDED_WIDTH = PluginPanel.PANEL_WIDTH + SCROLLBAR_WIDTH;
+	private static final int PANEL_EXPANDED_WIDTH = PluginPanel.PANEL_WIDTH + PluginPanel.SCROLLBAR_WIDTH;
 	private static final BufferedImage ICON;
 
 	@Getter
@@ -74,7 +72,6 @@ public class ClientUI extends JFrame
 
 	private final Applet client;
 	private final RuneLiteProperties properties;
-	private JPanel container;
 	private JPanel navContainer;
 	private PluginToolbar pluginToolbar;
 	private PluginPanel pluginPanel;
@@ -158,6 +155,21 @@ public class ClientUI extends JFrame
 
 		setVisible(true);
 		toFront();
+		requestFocus();
+		giveClientFocus();
+	}
+
+	private void giveClientFocus()
+	{
+		if (client instanceof Client)
+		{
+			final Canvas c = ((Client) client).getCanvas();
+			c.requestFocusInWindow();
+		}
+		else
+		{
+			client.requestFocusInWindow();
+		}
 	}
 
 	private static void setUIFont(FontUIResource f)
@@ -211,7 +223,6 @@ public class ClientUI extends JFrame
 		return trayIcon;
 	}
 
-
 	@Override
 	public void setTitle(String extra)
 	{
@@ -239,14 +250,14 @@ public class ClientUI extends JFrame
 			}
 		});
 
-		container = new JPanel();
+		final JPanel container = new JPanel();
 		container.setLayout(new BoxLayout(container, BoxLayout.X_AXIS));
 		container.add(new ClientPanel(client));
 
 		navContainer = new JPanel();
-		navContainer.setLayout(new BorderLayout(0,0));
-		navContainer.setMinimumSize(new Dimension(0,0));
-		navContainer.setMaximumSize(new Dimension(0,Integer.MAX_VALUE));
+		navContainer.setLayout(new BorderLayout(0, 0));
+		navContainer.setMinimumSize(new Dimension(0, 0));
+		navContainer.setMaximumSize(new Dimension(0, Integer.MAX_VALUE));
 		container.add(navContainer);
 
 		pluginToolbar = new PluginToolbar(this);
@@ -271,18 +282,28 @@ public class ClientUI extends JFrame
 		pluginPanel = panel;
 		navContainer.setMinimumSize(new Dimension(PANEL_EXPANDED_WIDTH, 0));
 		navContainer.setMaximumSize(new Dimension(PANEL_EXPANDED_WIDTH, Integer.MAX_VALUE));
-		navContainer.add(wrapPanel(pluginPanel));
+
+		final JPanel wrappedPanel = panel.getWrappedPanel();
+		navContainer.add(wrappedPanel);
 		navContainer.revalidate();
+
+		// panel.onActivate has to go after giveClientFocus so it can get focus if it needs.
+		giveClientFocus();
+		panel.onActivate();
+
+		wrappedPanel.repaint();
 		revalidateMinimumSize();
 	}
 
 	void contract()
 	{
 		boolean wasMinimumWidth = this.getWidth() == (int) this.getMinimumSize().getWidth();
+		pluginPanel.onDeactivate();
 		navContainer.remove(0);
 		navContainer.setMinimumSize(new Dimension(0, 0));
 		navContainer.setMaximumSize(new Dimension(0, Integer.MAX_VALUE));
 		navContainer.revalidate();
+		giveClientFocus();
 		revalidateMinimumSize();
 		if (wasMinimumWidth)
 		{
@@ -291,35 +312,12 @@ public class ClientUI extends JFrame
 		pluginPanel = null;
 	}
 
-	private JPanel wrapPanel(PluginPanel panel)
-	{
-		final JPanel northPanel = new JPanel();
-		northPanel.setLayout(new BorderLayout());
-		northPanel.add(panel, BorderLayout.NORTH);
-
-		final JScrollPane scrollPane = new JScrollPane(northPanel);
-		scrollPane.getVerticalScrollBar().setUnitIncrement(16); //Otherwise scrollspeed is really slow
-		scrollPane.setHorizontalScrollBarPolicy(ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
-
-		final JPanel panelWrap = new JPanel();
-
-		// Adjust the preferred size to expand to width of scrollbar to
-		// to preven scrollbar overlapping over contents
-		panelWrap.setPreferredSize(new Dimension(
-					PluginPanel.PANEL_WIDTH + SCROLLBAR_WIDTH,
-					0));
-
-		panelWrap.setLayout(new BorderLayout());
-		panelWrap.add(scrollPane, BorderLayout.CENTER);
-		return panelWrap;
-	}
-
 	private void checkExit()
 	{
 		int result = JOptionPane.OK_OPTION;
 
 		// only ask if not logged out
-		if (client != null && client instanceof Client && ((Client)client).getGameState() != GameState.LOGIN_SCREEN)
+		if (client != null && client instanceof Client && ((Client) client).getGameState() != GameState.LOGIN_SCREEN)
 		{
 			result = JOptionPane.showConfirmDialog(this, "Are you sure you want to exit?", "Exit", JOptionPane.OK_CANCEL_OPTION, JOptionPane.QUESTION_MESSAGE);
 		}

--- a/runelite-client/src/main/java/net/runelite/client/ui/PluginPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/PluginPanel.java
@@ -24,27 +24,63 @@
  */
 package net.runelite.client.ui;
 
+import java.awt.BorderLayout;
 import java.awt.Dimension;
 import java.awt.GridLayout;
 import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.ScrollPaneConstants;
 import javax.swing.border.EmptyBorder;
+import lombok.AccessLevel;
+import lombok.Getter;
 
 public abstract class PluginPanel extends JPanel
 {
-	public static final int PANEL_WIDTH = 225;
+	static final int PANEL_WIDTH = 225;
+	static final int SCROLLBAR_WIDTH = 17;
 	private static final int OFFSET = 6;
 	private static final EmptyBorder BORDER_PADDING = new EmptyBorder(OFFSET, OFFSET, OFFSET, OFFSET);
+
+	@Getter(AccessLevel.PROTECTED)
+	private final JScrollPane scrollPane;
+
+	@Getter(AccessLevel.PACKAGE)
+	private final JPanel wrappedPanel;
 
 	public PluginPanel()
 	{
 		super();
 		setBorder(BORDER_PADDING);
 		setLayout(new GridLayout(0, 1, 0, 3));
+
+		final JPanel northPanel = new JPanel();
+		northPanel.setLayout(new BorderLayout());
+		northPanel.add(this, BorderLayout.NORTH);
+
+		scrollPane = new JScrollPane(northPanel);
+		scrollPane.getVerticalScrollBar().setUnitIncrement(16); //Otherwise scrollspeed is really slow
+		scrollPane.setHorizontalScrollBarPolicy(ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
+
+		wrappedPanel = new JPanel();
+
+		// Adjust the preferred size to expand to width of scrollbar to
+		// to preven scrollbar overlapping over contents
+		wrappedPanel.setPreferredSize(new Dimension(PluginPanel.PANEL_WIDTH + SCROLLBAR_WIDTH, 0));
+		wrappedPanel.setLayout(new BorderLayout());
+		wrappedPanel.add(scrollPane, BorderLayout.CENTER);
 	}
 
 	@Override
 	public Dimension getPreferredSize()
 	{
 		return new Dimension(PANEL_WIDTH, super.getPreferredSize().height);
+	}
+
+	public void onActivate()
+	{
+	}
+
+	public void onDeactivate()
+	{
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/ui/PluginToolbar.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/PluginToolbar.java
@@ -88,12 +88,11 @@ public class PluginToolbar extends JToolBar
 		}
 		else
 		{
+			current = button;
+			current.setSelected(true);
 
 			PluginPanel pluginPanel = panelSupplier.get();
 			ui.expand(pluginPanel);
-
-			current = button;
-			current.setSelected(true);
 		}
 	}
 }


### PR DESCRIPTION
This allow PluginPanels to keep state, primarily so that their scrollbars do not get reset when changing panels. It also allows the ConfigPanel to keep it's scroll and search state when entering and exiting it's sub-pages.

This PR supersedes #371