### PR TITLE
runescape-client: Fix broken glyphs

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
@@ -30,7 +30,6 @@ import java.awt.AWTException;
 import java.awt.BorderLayout;
 import java.awt.Cursor;
 import java.awt.Dimension;
-import java.awt.Font;
 import java.awt.Frame;
 import java.awt.SystemTray;
 import java.awt.TrayIcon;
@@ -55,7 +54,6 @@ import javax.swing.ToolTipManager;
 import javax.swing.UIManager;
 import javax.swing.UnsupportedLookAndFeelException;
 import javax.swing.plaf.FontUIResource;
-import javax.swing.text.StyleContext;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
@@ -123,8 +121,7 @@ public class ClientUI extends JFrame
 		}
 
 		// Use custom UI font
-		setUIFont(new FontUIResource(StyleContext.getDefaultStyleContext()
-				.getFont(FontManager.getRunescapeFont().getName(), Font.PLAIN, 16)));
+		setUIFont(new FontUIResource(FontManager.getRunescapeFont()));
 
 		return new ClientUI(properties, client);
 	}

--- a/runelite-client/src/main/java/net/runelite/client/ui/FontManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/FontManager.java
@@ -24,6 +24,7 @@
  */
 package net.runelite.client.ui;
 
+import javax.swing.text.StyleContext;
 import java.awt.Font;
 import java.awt.FontFormatException;
 import java.awt.GraphicsEnvironment;
@@ -40,14 +41,22 @@ public class FontManager
 
 		try
 		{
-			runescapeFont = Font.createFont(Font.TRUETYPE_FONT,
+			Font font = Font.createFont(Font.TRUETYPE_FONT,
 				FontManager.class.getResourceAsStream("runescape.ttf"))
 				.deriveFont(Font.PLAIN, 16);
+			ge.registerFont(font);
+
+			runescapeFont = StyleContext.getDefaultStyleContext()
+					.getFont(font.getName(), Font.PLAIN, 16);
 			ge.registerFont(runescapeFont);
 
-			runescapeSmallFont = Font.createFont(Font.TRUETYPE_FONT,
+			Font smallFont = Font.createFont(Font.TRUETYPE_FONT,
 				FontManager.class.getResourceAsStream("runescape_small.ttf"))
 				.deriveFont(Font.PLAIN, 16);
+			ge.registerFont(smallFont);
+
+			runescapeSmallFont = StyleContext.getDefaultStyleContext()
+					.getFont(smallFont.getName(), Font.PLAIN, 16);
 			ge.registerFont(runescapeSmallFont);
 		}
 		catch (FontFormatException ex)


### PR DESCRIPTION
Fix broken glyphs once and for all (hopefully).

The last pull request that was supposed to fix this (#312) only fixed it for the Swing UI, this fixes it for in-game overlays too.

**Before:**

![](https://i.imgur.com/qwcvr5f.png)

**After:**

![](https://i.imgur.com/2wj26Ry.png)