### PR TITLE
 Add a config setting for the game's size

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/RuneLite.java
+++ b/runelite-client/src/main/java/net/runelite/client/RuneLite.java
@@ -140,6 +140,7 @@ public class RuneLite
 		eventBus.register(overlayRenderer);
 		eventBus.register(menuManager);
 		eventBus.register(chatMessageManager);
+		eventBus.register(gui);
 
 		// Setup the notifier
 		notifier = new Notifier(properties.getTitle(), gui.getTrayIcon());
@@ -161,7 +162,19 @@ public class RuneLite
 		// Load the session, including saved configuration
 		sessionManager.loadSession();
 
-		SwingUtilities.invokeAndWait(() -> gui.showWithChrome(runeliteConfig.enableCustomChrome()));
+		SwingUtilities.invokeAndWait(() ->
+		{
+			if (client != null)
+			{
+				client.setSize(runeliteConfig.gameSize());
+				client.setPreferredSize(runeliteConfig.gameSize());
+
+				client.getParent().setPreferredSize(runeliteConfig.gameSize());
+				client.getParent().setSize(runeliteConfig.gameSize());
+			}
+
+			gui.showWithChrome(runeliteConfig.enableCustomChrome());
+		});
 
 		eventBus.post(new ClientUILoaded());
 	}

--- a/runelite-client/src/main/java/net/runelite/client/config/ConfigManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/ConfigManager.java
@@ -28,6 +28,7 @@ import com.google.common.eventbus.EventBus;
 import com.google.inject.Injector;
 import com.google.inject.Key;
 import java.awt.Color;
+import java.awt.Dimension;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -409,6 +410,13 @@ public class ConfigManager
 		{
 			return Color.decode(str);
 		}
+		if (type == Dimension.class)
+		{
+			String[] splitStr = str.split("x");
+			int width = Integer.parseInt(splitStr[0]);
+			int height = Integer.parseInt(splitStr[1]);
+			return new Dimension(width, height);
+		}
 		if (type.isEnum())
 		{
 			return Enum.valueOf((Class<? extends Enum>) type, str);
@@ -425,6 +433,11 @@ public class ConfigManager
 		if (object instanceof Enum)
 		{
 			return ((Enum) object).name();
+		}
+		if (object instanceof Dimension)
+		{
+			Dimension d = (Dimension) object;
+			return d.width + "x" + d.height;
 		}
 		return object.toString();
 	}

--- a/runelite-client/src/main/java/net/runelite/client/config/RuneLiteConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/RuneLiteConfig.java
@@ -24,6 +24,8 @@
  */
 package net.runelite.client.config;
 
+import java.awt.Dimension;
+
 @ConfigGroup(
 	keyName = "runelite",
 	name = "RuneLite",
@@ -31,6 +33,16 @@ package net.runelite.client.config;
 )
 public interface RuneLiteConfig extends Config
 {
+	@ConfigItem(
+		keyName = "gameSize",
+		name = "Game size",
+		description = "The game will resize to this resolution upon starting the client"
+	)
+	default Dimension gameSize()
+	{
+		return new Dimension(765, 503);
+	}
+
 	@ConfigItem(
 		keyName = "chatCommandsRecolorEnabled",
 		name = "Enable chat commands recolor",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
@@ -28,7 +28,6 @@ import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Component;
 import java.awt.Dimension;
-import java.awt.event.ActionEvent;
 import java.awt.event.FocusEvent;
 import java.awt.event.FocusListener;
 import java.awt.event.ItemEvent;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
@@ -27,6 +27,8 @@ package net.runelite.client.plugins.config;
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.event.ActionEvent;
 import java.awt.event.FocusEvent;
 import java.awt.event.FocusListener;
 import java.awt.event.ItemEvent;
@@ -55,6 +57,7 @@ import javax.swing.JTextField;
 import javax.swing.SpinnerModel;
 import javax.swing.SpinnerNumberModel;
 import javax.swing.SwingConstants;
+import javax.swing.event.ChangeListener;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
 import lombok.extern.slf4j.Slf4j;
@@ -318,6 +321,41 @@ public class ConfigPanel extends PluginPanel
 					}
 				});
 				item.add(colorPicker, BorderLayout.EAST);
+			}
+
+			if (cid.getType() == Dimension.class)
+			{
+				JPanel dimensionPanel = new JPanel();
+				dimensionPanel.setLayout(new BorderLayout());
+
+				String str = configManager.getConfiguration(cd.getGroup().keyName(), cid.getItem().keyName());
+				String[] splitStr = str.split("x");
+				int width = Integer.parseInt(splitStr[0]);
+				int height = Integer.parseInt(splitStr[1]);
+
+				SpinnerModel widthModel = new SpinnerNumberModel(width, 0, Integer.MAX_VALUE, 1);
+				JSpinner widthSpinner = new JSpinner(widthModel);
+				Component widthEditor = widthSpinner.getEditor();
+				JFormattedTextField widthSpinnerTextField = ((JSpinner.DefaultEditor) widthEditor).getTextField();
+				widthSpinnerTextField.setColumns(4);
+
+				SpinnerModel heightModel = new SpinnerNumberModel(height, 0, Integer.MAX_VALUE, 1);
+				JSpinner heightSpinner = new JSpinner(heightModel);
+				Component heightEditor = heightSpinner.getEditor();
+				JFormattedTextField heightSpinnerTextField = ((JSpinner.DefaultEditor) heightEditor).getTextField();
+				heightSpinnerTextField.setColumns(4);
+
+				ChangeListener listener = e ->
+						configManager.setConfiguration(cd.getGroup().keyName(), cid.getItem().keyName(), widthSpinner.getValue() + "x" + heightSpinner.getValue());
+
+				widthSpinner.addChangeListener(listener);
+				heightSpinner.addChangeListener(listener);
+
+				dimensionPanel.add(widthSpinner, BorderLayout.WEST);
+				dimensionPanel.add(new JLabel(" x "), BorderLayout.CENTER);
+				dimensionPanel.add(heightSpinner, BorderLayout.EAST);
+
+				item.add(dimensionPanel, BorderLayout.EAST);
 			}
 
 			if (cid.getType().isEnum())

--- a/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
@@ -61,10 +61,12 @@ import javax.swing.ToolTipManager;
 import javax.swing.UIManager;
 import javax.swing.UnsupportedLookAndFeelException;
 import javax.swing.plaf.FontUIResource;
+import com.google.common.eventbus.Subscribe;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.GameState;
+import net.runelite.api.events.ConfigChanged;
 import net.runelite.client.RuneLiteProperties;
 import org.pushingpixels.substance.api.skin.SubstanceGraphiteLookAndFeel;
 import org.pushingpixels.substance.internal.SubstanceSynapse;
@@ -248,6 +250,52 @@ public class ClientUI extends JFrame
 
 		revalidate();
 		repaint();
+	}
+
+	@Subscribe
+	public void onConfigChanged(ConfigChanged event)
+	{
+		if (!event.getGroup().equals("runelite"))
+		{
+			return;
+		}
+
+		if (!event.getKey().equals("gameSize"))
+		{
+			return;
+		}
+
+		if (client == null)
+		{
+			return;
+		}
+
+		String[] splitStr = event.getNewValue().split("x");
+		int width = Integer.parseInt(splitStr[0]);
+		int height = Integer.parseInt(splitStr[1]);
+
+		// The upper bounds are defined by the applet's max size
+		// The lower bounds are taken care of by ClientPanel's setMinimumSize
+
+		if (width > 7680)
+		{
+			width = 7680;
+		}
+
+		if (height > 2160)
+		{
+			height = 2160;
+		}
+
+		Dimension size = new Dimension(width, height);
+
+		client.setSize(size);
+		client.setPreferredSize(size);
+
+		client.getParent().setPreferredSize(size);
+		client.getParent().setSize(size);
+
+		pack();
 	}
 
 	private static void setUIFont(FontUIResource f)


### PR DESCRIPTION
Adds a "game size" setting to the client's own config panel. I didn't want to split it up into a standalone plugin because it feels more like a completely client feature.

Unfortunately the input fields are not reset to their minimum/maximum when you go outside the bounds, because of missing functionality in the config system that I don't feel like adding because it can probably get a bit big.

Solves #390 