### PR TITLE
Notify before 5 minute idle and 6h logout

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/Client.java
+++ b/runelite-api/src/main/java/net/runelite/api/Client.java
@@ -176,4 +176,8 @@ public interface Client
 
 
 	BufferProvider getBufferProvider();
+
+	int getMouseIdleTicks();
+
+	int getKeyboardIdleTicks();
 }

--- a/runescape-api/src/main/java/net/runelite/rs/api/RSClient.java
+++ b/runescape-api/src/main/java/net/runelite/rs/api/RSClient.java
@@ -355,4 +355,12 @@ public interface RSClient extends RSGameEngine, Client
 	@Import("rasterProvider")
 	@Override
 	BufferProvider getBufferProvider();
+
+	@Import("mouseIdleTicks")
+	@Override
+	int getMouseIdleTicks();
+
+	@Import("keyboardIdleTicks")
+	@Override
+	int getKeyboardIdleTicks();
 }


### PR DESCRIPTION
Extends the idle notifier plugin to notify you after 4 minutes and 40 seconds of being idle and 5h 40min of being logged in.