### PR TITLE
Fix SlayerPlugin crashing the game

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerPlugin.java
@@ -283,7 +283,7 @@ public class SlayerPlugin extends Plugin
 		}
 
 		infoBoxManager.removeIf(t -> t instanceof TaskCounter);
-		if (config.enabled() && config.showInfobox())
+		if (config.enabled() && config.showInfobox() && counter != null)
 		{
 			infoBoxManager.addInfoBox(counter);
 		}


### PR DESCRIPTION
If you don't have a task and change the Slayer plugin settings, the game will crash:

```
Error: bd.ag() | InfoBoxManager:70 Hooks:97 client.ax bd.ag bd.run Thread:748 | java.lang.NullPointerException
error_game_crash
```

This is because "counter" is null when you don't have a task, and the null is registered as an info box.