### PR TITLE
Fix NPE in ScreenShotPlugin

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
@@ -169,10 +169,13 @@ public class ScreenshotPlugin extends Plugin
 		SwingUtilities.invokeLater(() ->
 		{
 			JComponent titleBar = SubstanceCoreUtilities.getTitlePaneComponent(clientUi);
-			titleBar.remove(titleBarButton);
 
-			clientUi.revalidate();
-			clientUi.repaint();
+			if (titleBar != null)
+			{
+				titleBar.remove(titleBarButton);
+				clientUi.revalidate();
+				clientUi.repaint();
+			}
 		});
 	}
 


### PR DESCRIPTION
Fix NPE that happens when titlebar is not present (not using the custom
window decorations) and plugin is trying to remove the screenshot
button from titlebar.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>