### PR TITLE
XpGlobeTooltip now sets width of itself to prevent overlap; fixes #405

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesOverlay.java
@@ -70,7 +70,7 @@ public class XpGlobesOverlay extends Overlay
 
 	private final BufferedImage[] imgCache = new BufferedImage[Skill.values().length - 1];
 
-	private static final int TOOLTIP_RECT_SIZE_X = 140;
+	private static final int TOOLTIP_RECT_SIZE_X = 150;
 
 	@Inject
 	public XpGlobesOverlay(@Nullable Client client, XpGlobesPlugin plugin, XpGlobesConfig config)
@@ -232,6 +232,7 @@ public class XpGlobesOverlay extends Overlay
 
 		PanelComponent xpTooltip = new PanelComponent();
 		xpTooltip.setPosition(new java.awt.Point(x, y));
+		xpTooltip.setWidth(TOOLTIP_RECT_SIZE_X);
 
 		List<PanelComponent.Line> lines = xpTooltip.getLines();
 		lines.add(new PanelComponent.Line(skillName, Color.WHITE, skillLevel, Color.WHITE));
@@ -239,7 +240,7 @@ public class XpGlobesOverlay extends Overlay
 		if (mouseOverSkill.getGoalXp() != -1)
 		{
 			String skillXpToLvl = decimalFormat.format(mouseOverSkill.getGoalXp() - mouseOverSkill.getCurrentXp());
-			lines.add(new PanelComponent.Line("Xp to level: ", Color.ORANGE, skillXpToLvl, Color.WHITE));
+			lines.add(new PanelComponent.Line("Xp to level:", Color.ORANGE, skillXpToLvl, Color.WHITE));
 
 			//Create progress bar for skill.
 			ProgressBarComponent progressBar = new ProgressBarComponent();


### PR DESCRIPTION
The widest part of the tooltip would be 146 pixels with "Current Xp: 888,888,888", so I rounded up to 150 for other locales. Fixes #405 

![deepinscreenshot_select-area_20180122114810](https://user-images.githubusercontent.com/5100085/35235560-2226d660-ff6a-11e7-8a64-796695581dc5.png)
