### PR TITLE
Update Project Lombok version to 1.16.20

### DIFF
--- a/cache/pom.xml
+++ b/cache/pom.xml
@@ -86,7 +86,6 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
-			<version>1.16.18</version>
 			<scope>provided</scope>
 		</dependency>
 		

--- a/http-api/pom.xml
+++ b/http-api/pom.xml
@@ -53,7 +53,6 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
-			<version>1.16.18</version>
 			<scope>provided</scope>
 		</dependency>
 

--- a/http-service/pom.xml
+++ b/http-service/pom.xml
@@ -37,7 +37,6 @@
 
 	<properties>
 		<spring.boot.version>1.5.6.RELEASE</spring.boot.version>
-		<lombok.version>1.16.18</lombok.version>
 		<mapstruct.version>1.2.0.Final</mapstruct.version>
 	</properties>
 
@@ -73,7 +72,6 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
-			<version>${lombok.version}</version>
 			<scope>provided</scope>
 		</dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,7 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<java.version>1.8</java.version>
+		<lombok.version>1.16.20</lombok.version>
 
 		<maven.javadoc.skip>true</maven.javadoc.skip>
 		<checkstyle.skip>true</checkstyle.skip>
@@ -61,7 +62,7 @@
 		<developerConnection>scm:git:git@github.com:runelite/runelite</developerConnection>
 		<tag>HEAD</tag>
 	</scm>
-	
+
 	<developers>
 		<developer>
 			<id>Adam-</id>
@@ -128,6 +129,12 @@
 				<groupId>com.google.guava</groupId>
 				<artifactId>guava</artifactId>
 				<version>23.2-jre</version>
+			</dependency>
+			<dependency>
+				<groupId>org.projectlombok</groupId>
+				<artifactId>lombok</artifactId>
+				<version>${lombok.version}</version>
+				<scope>provided</scope>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>

--- a/protocol-api/pom.xml
+++ b/protocol-api/pom.xml
@@ -54,7 +54,6 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
-			<version>1.16.18</version>
 			<scope>provided</scope>
 		</dependency>
 

--- a/protocol/pom.xml
+++ b/protocol/pom.xml
@@ -60,7 +60,6 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
-			<version>1.16.18</version>
 			<scope>provided</scope>
 		</dependency>
 

--- a/runelite-api/pom.xml
+++ b/runelite-api/pom.xml
@@ -40,7 +40,6 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
-			<version>1.16.18</version>
 			<scope>provided</scope>
 		</dependency>
 

--- a/runelite-client/pom.xml
+++ b/runelite-client/pom.xml
@@ -89,7 +89,6 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
-			<version>1.16.18</version>
 			<scope>provided</scope>
 		</dependency>
 


### PR DESCRIPTION
Update Project Lombok version to 1.16.20 (from 1.16.18) and specify this
version in runelite-parent instead of having it specified all around the
maven projects.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>