### PR TITLE
Add low memory mode flag

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/Client.java
+++ b/runelite-api/src/main/java/net/runelite/api/Client.java
@@ -239,4 +239,11 @@ public interface Client extends GameEngine
 	int getMouseIdleTicks();
 
 	int getKeyboardIdleTicks();
+
+	/**
+	 * Changes how game behaves based on memory mode. Low memory mode skips drawing of all floors and renders ground
+	 * textures in low quality.
+	 * @param lowMemory if we are running in low memory mode or not
+	 */
+	void changeMemoryMode(boolean lowMemory);
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/lowmemory/LowMemoryConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/lowmemory/LowMemoryConfig.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2018, Tomas Slusny <slusnucky@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.lowmemory;
+
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+
+@ConfigGroup(
+	keyName = "lowmemory",
+	name = "Low Memory Mode",
+	description = "Configuration for the plugin for enabling and disabling RuneScape low memory mode"
+)
+public interface LowMemoryConfig extends Config
+{
+	@ConfigItem(
+		keyName = "enabled",
+		name = "Enabled",
+		description = "Configures whether or not low memory mode is enabled"
+	)
+	default boolean enabled()
+	{
+		return false;
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/lowmemory/LowMemoryPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/lowmemory/LowMemoryPlugin.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2018, Tomas Slusny <slusnucky@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.lowmemory;
+
+import com.google.common.eventbus.Subscribe;
+import com.google.inject.Provides;
+import javax.inject.Inject;
+import net.runelite.api.Client;
+import net.runelite.api.GameState;
+import net.runelite.api.events.ConfigChanged;
+import net.runelite.api.events.GameStateChanged;
+import net.runelite.api.events.SessionClose;
+import net.runelite.api.events.SessionOpen;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginDescriptor;
+
+@PluginDescriptor(name = "Low memory plugin")
+public class LowMemoryPlugin extends Plugin
+{
+	@Inject
+	Client client;
+
+	@Inject
+	LowMemoryConfig config;
+
+	@Provides
+	LowMemoryConfig provideConfig(ConfigManager configManager)
+	{
+		return configManager.getConfig(LowMemoryConfig.class);
+	}
+
+	@Override
+	protected void startUp() throws Exception
+	{
+		client.changeMemoryMode(config.enabled());
+	}
+
+	@Override
+	protected void shutDown() throws Exception
+	{
+		client.changeMemoryMode(false);
+	}
+
+	@Subscribe
+	private void onConfigChanged(ConfigChanged event)
+	{
+		if (event.getGroup().equals("lowmemory"))
+		{
+			client.changeMemoryMode(config.enabled());
+		}
+	}
+
+	@Subscribe
+	private void onSessionOpen(SessionOpen event)
+	{
+		client.changeMemoryMode(config.enabled());
+	}
+
+	@Subscribe
+	private void onSessionClose(SessionClose event)
+	{
+		client.changeMemoryMode(config.enabled());
+	}
+
+	@Subscribe
+	private void onGameStateChanged(GameStateChanged event)
+	{
+		if (event.getGameState() == GameState.LOGIN_SCREEN)
+		{
+			client.changeMemoryMode(config.enabled());
+		}
+	}
+}

--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSClientMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSClientMixin.java
@@ -396,6 +396,16 @@ public abstract class RSClientMixin implements RSClient
 		}
 	}
 
+	@Inject
+	@Override
+	public void changeMemoryMode(boolean lowMemory)
+	{
+		setLowMemory(lowMemory);
+		setRegionLowMemory(lowMemory);
+		setHighMemory(!lowMemory);
+		setOcLowDetail(lowMemory);
+	}
+
 	@FieldHook("skillExperiences")
 	@Inject
 	public static void experiencedChanged(int idx)

--- a/runescape-api/src/main/java/net/runelite/rs/api/RSClient.java
+++ b/runescape-api/src/main/java/net/runelite/rs/api/RSClient.java
@@ -420,4 +420,16 @@ public interface RSClient extends RSGameEngine, Client
 	@Import("keyboardIdleTicks")
 	@Override
 	int getKeyboardIdleTicks();
+
+	@Import("lowMemory")
+	void setLowMemory(boolean lowMemory);
+
+	@Import("regionLowMemory")
+	void setRegionLowMemory(boolean lowMemory);
+
+	@Import("highMemory")
+	void setHighMemory(boolean highMemory);
+
+	@Import("ocLowDetail")
+	void setOcLowDetail(boolean lowDetail);
 }

--- a/runescape-client/src/main/java/Client.java
+++ b/runescape-client/src/main/java/Client.java
@@ -1824,7 +1824,7 @@ public final class Client extends GameEngine {
             }
          }
 
-         Region.lowMemory = false;
+         Region.regionLowMemory = false;
          lowMemory = false;
          class161.host = this.getCodeBase().getHost();
          String var11 = field875.identifier;

--- a/runescape-client/src/main/java/MouseRecorder.java
+++ b/runescape-client/src/main/java/MouseRecorder.java
@@ -66,7 +66,7 @@ public class MouseRecorder implements Runnable {
    public static void method1119(IndexDataBase var0, IndexDataBase var1, boolean var2) {
       ObjectComposition.objects_ref = var0;
       ObjectComposition.field3522 = var1;
-      ObjectComposition.ObjectDefinition_isLowDetail = var2;
+      ObjectComposition.ocLowDetail = var2;
    }
 
    @ObfuscatedName("n")

--- a/runescape-client/src/main/java/ObjectComposition.java
+++ b/runescape-client/src/main/java/ObjectComposition.java
@@ -8,8 +8,8 @@ import net.runelite.mapping.ObfuscatedSignature;
 @Implements("ObjectComposition")
 public class ObjectComposition extends CacheableNode {
    @ObfuscatedName("n")
-   @Export("ObjectDefinition_isLowDetail")
-   static boolean ObjectDefinition_isLowDetail;
+   @Export("ocLowDetail")
+   static boolean ocLowDetail;
    @ObfuscatedName("v")
    @ObfuscatedSignature(
       signature = "Lil;"
@@ -256,7 +256,7 @@ public class ObjectComposition extends CacheableNode {
    IterableHashTable params;
 
    static {
-      ObjectDefinition_isLowDetail = false;
+      ocLowDetail = false;
       objects = new NodeCache(4096);
       field3524 = new NodeCache(500);
       cachedModels = new NodeCache(30);
@@ -355,7 +355,7 @@ public class ObjectComposition extends CacheableNode {
       if(var2 == 1) {
          var3 = var1.readUnsignedByte();
          if(var3 > 0) {
-            if(this.objectModels != null && !ObjectDefinition_isLowDetail) {
+            if(this.objectModels != null && !ocLowDetail) {
                var1.offset += var3 * 3;
             } else {
                this.objectTypes = new int[var3];
@@ -372,7 +372,7 @@ public class ObjectComposition extends CacheableNode {
       } else if(var2 == 5) {
          var3 = var1.readUnsignedByte();
          if(var3 > 0) {
-            if(this.objectModels != null && !ObjectDefinition_isLowDetail) {
+            if(this.objectModels != null && !ocLowDetail) {
                var1.offset += var3 * 2;
             } else {
                this.objectTypes = null;

--- a/runescape-client/src/main/java/Region.java
+++ b/runescape-client/src/main/java/Region.java
@@ -8,8 +8,8 @@ import net.runelite.mapping.ObfuscatedSignature;
 @Implements("Region")
 public class Region {
    @ObfuscatedName("n")
-   @Export("lowMemory")
-   public static boolean lowMemory;
+   @Export("regionLowMemory")
+   public static boolean regionLowMemory;
    @ObfuscatedName("t")
    @Export("tileUpdateCount")
    static int tileUpdateCount;
@@ -187,7 +187,7 @@ public class Region {
    int[][] TILE_ROTATION_2D;
 
    static {
-      lowMemory = true;
+      regionLowMemory = true;
       tileUpdateCount = 0;
       Scene_plane = 0;
       entityBuffer = new GameObject[100];
@@ -1837,7 +1837,7 @@ public class Region {
                         if(var1.neColor != 12345678) {
                            Graphics3D.rasterGouraud(var27, var29, var25, var26, var28, var24, var1.neColor, var1.nwColor, var1.seColor);
                         }
-                     } else if(!lowMemory) {
+                     } else if(!regionLowMemory) {
                         if(var1.flatShade) {
                            Graphics3D.rasterTexture(var27, var29, var25, var26, var28, var24, var1.neColor, var1.nwColor, var1.seColor, var10, var14, var9, var17, var18, var21, var12, var11, var15, var1.texture);
                         } else {
@@ -1864,7 +1864,7 @@ public class Region {
                         if(var1.swColor != 12345678) {
                            Graphics3D.rasterGouraud(var23, var25, var29, var22, var24, var28, var1.swColor, var1.seColor, var1.nwColor);
                         }
-                     } else if(!lowMemory) {
+                     } else if(!regionLowMemory) {
                         Graphics3D.rasterTexture(var23, var25, var29, var22, var24, var28, var1.swColor, var1.seColor, var1.nwColor, var10, var14, var9, var17, var18, var21, var12, var11, var15, var1.texture);
                      } else {
                         var30 = Graphics3D.textureLoader.getAverageTextureRGB(var1.texture);
@@ -1939,7 +1939,7 @@ public class Region {
             }
 
             if(var1.triangleTextureId != null && var1.triangleTextureId[var9] != -1) {
-               if(!lowMemory) {
+               if(!regionLowMemory) {
                   if(var1.flatShade) {
                      Graphics3D.rasterTexture(var16, var17, var18, var13, var14, var15, var1.triangleColorA[var9], var1.triangleColorB[var9], var1.triangleColorC[var9], SceneTileModel.vertexSceneX[0], SceneTileModel.vertexSceneX[1], SceneTileModel.vertexSceneX[3], SceneTileModel.vertexSceneY[0], SceneTileModel.vertexSceneY[1], SceneTileModel.vertexSceneY[3], SceneTileModel.vertexSceneZ[0], SceneTileModel.vertexSceneZ[1], SceneTileModel.vertexSceneZ[3], var1.triangleTextureId[var9]);
                   } else {


### PR DESCRIPTION
Add configurable flag for RuneScape low memory mode that disables ground
textures and drawing of multiple floors to RuneLiteConfig.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>

Preview:
![screenie](https://user-images.githubusercontent.com/5115805/35296683-1d747c6c-007d-11e8-9b66-ae18e63ab974.png)
