### PR TITLE
Incorporate height into the GroundItems overlay

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/ItemLayer.java
+++ b/runelite-api/src/main/java/net/runelite/api/ItemLayer.java
@@ -26,6 +26,8 @@ package net.runelite.api;
 
 public interface ItemLayer extends TileObject
 {
+	int getHeight();
+
 	Renderable getBottom();
 
 	Renderable getMiddle();

--- a/runelite-api/src/main/java/net/runelite/api/TileObject.java
+++ b/runelite-api/src/main/java/net/runelite/api/TileObject.java
@@ -45,6 +45,8 @@ public interface TileObject
 
 	Point getCanvasLocation();
 
+	Point getCanvasLocation(int zOffset);
+
 	Polygon getCanvasTilePoly();
 
 	Point getCanvasTextLocation(Graphics2D graphics, String text, int zOffset);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
@@ -228,7 +228,7 @@ public class GroundItemsOverlay extends Overlay
 
 				for (int i = 0; i < itemIds.size(); ++i)
 				{
-					Point point = itemLayer.getCanvasLocation();
+					Point point = itemLayer.getCanvasLocation(itemLayer.getHeight());
 					// if the item is offscreen, don't bother drawing it
 					if (point == null || (viewport != null && !viewport.contains(point)))
 					{

--- a/runelite-mixins/src/main/java/net/runelite/mixins/TileObjectMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/TileObjectMixin.java
@@ -85,16 +85,23 @@ public abstract class TileObjectMixin implements TileObject
 	@Inject
 	public Point getRegionLocation()
 	{
-		Point locaLocation = getLocalLocation();
-		return new Point(locaLocation.getX() >>> LOCAL_COORD_BITS, locaLocation.getY() >>> LOCAL_COORD_BITS);
+		Point localLocation = getLocalLocation();
+		return new Point(localLocation.getX() >>> LOCAL_COORD_BITS, localLocation.getY() >>> LOCAL_COORD_BITS);
 	}
 
 	@Override
 	@Inject
 	public Point getCanvasLocation()
 	{
-		Point locaLocation = getLocalLocation();
-		return Perspective.worldToCanvas(client, locaLocation.getX(), locaLocation.getY(), 0);
+		return getCanvasLocation(0);
+	}
+
+	@Override
+	@Inject
+	public Point getCanvasLocation(int zOffset)
+	{
+		Point localLocation = getLocalLocation();
+		return Perspective.worldToCanvas(client, localLocation.getX(), localLocation.getY(), 0, zOffset);
 	}
 
 	@Override


### PR DESCRIPTION
Takes into account the height of the ItemLayer for drawing the text for the GroundItems plugin.

Before:
![](https://i.imgur.com/NOXz1Fy.png)

After:
![](https://i.imgur.com/MtmsPxL.png)