### PR TITLE
Swapped viewport width and height fields.

### DIFF
--- a/runescape-client/src/main/java/BaseVarType.java
+++ b/runescape-client/src/main/java/BaseVarType.java
@@ -1933,8 +1933,8 @@ public enum BaseVarType implements Enumerated {
                                                                                                                   } else if(var9 == 6203) {
                                                                                                                      if(Client.field980 != null) {
                                                                                                                         Player.method1159(0, 0, Client.field980.width, Client.field980.height, false);
-                                                                                                                        class82.intStack[++class82.intStackSize - 1] = Client.viewportHeight;
                                                                                                                         class82.intStack[++class82.intStackSize - 1] = Client.viewportWidth;
+                                                                                                                        class82.intStack[++class82.intStackSize - 1] = Client.viewportHeight;
                                                                                                                      } else {
                                                                                                                         class82.intStack[++class82.intStackSize - 1] = -1;
                                                                                                                         class82.intStack[++class82.intStackSize - 1] = -1;

--- a/runescape-client/src/main/java/BoundingBox3DDrawMode.java
+++ b/runescape-client/src/main/java/BoundingBox3DDrawMode.java
@@ -312,8 +312,8 @@ public class BoundingBox3DDrawMode {
                         Player.method1159(var12, var13, var21, var22, true);
                         var19 = Client.Viewport_xOffset;
                         var20 = Client.Viewport_yOffset;
-                        var21 = Client.viewportHeight;
-                        var22 = Client.viewportWidth;
+                        var21 = Client.viewportWidth;
+                        var22 = Client.viewportHeight;
                         Rasterizer2D.setDrawRegion(var19, var20, var19 + var21, var20 + var22);
                         Graphics3D.Rasterizer3D_method1();
                         if(!Client.field1101) {

--- a/runescape-client/src/main/java/Client.java
+++ b/runescape-client/src/main/java/Client.java
@@ -328,14 +328,14 @@ public final class Client extends GameEngine {
    @ObfuscatedGetter(
       intValue = 81711465
    )
-   @Export("viewportHeight")
-   static int viewportHeight;
+   @Export("viewportWidth")
+   static int viewportWidth;
    @ObfuscatedName("pz")
    @ObfuscatedGetter(
       intValue = -1291048227
    )
-   @Export("viewportWidth")
-   static int viewportWidth;
+   @Export("viewportHeight")
+   static int viewportHeight;
    @ObfuscatedName("pq")
    static short field1113;
    @ObfuscatedName("pf")
@@ -1400,8 +1400,8 @@ public final class Client extends GameEngine {
       field948 = 32767;
       Viewport_xOffset = 0;
       Viewport_yOffset = 0;
-      viewportHeight = 0;
       viewportWidth = 0;
+      viewportHeight = 0;
       scale = 0;
       friendCount = 0;
       field1077 = 0;

--- a/runescape-client/src/main/java/Player.java
+++ b/runescape-client/src/main/java/Player.java
@@ -597,7 +597,7 @@ public final class Player extends Actor {
 
       var8 = (Client.field1110 - Client.field1046) * var5 / 100 + Client.field1046;
       Client.scale = var3 * var6 * var8 / 85504 << 1;
-      if(var2 != Client.viewportHeight || var3 != Client.viewportWidth) {
+      if(var2 != Client.viewportWidth || var3 != Client.viewportHeight) {
          int[] var14 = new int[9];
 
          for(int var10 = 0; var10 < 9; ++var10) {
@@ -612,7 +612,7 @@ public final class Player extends Actor {
 
       Client.Viewport_xOffset = var0;
       Client.Viewport_yOffset = var1;
-      Client.viewportHeight = var2;
-      Client.viewportWidth = var3;
+      Client.viewportWidth = var2;
+      Client.viewportHeight = var3;
    }
 }

--- a/runescape-client/src/main/java/class61.java
+++ b/runescape-client/src/main/java/class61.java
@@ -120,8 +120,8 @@ public final class class61 {
          var8 = var5 * var3 - var4 * var1 >> 16;
          var1 = var4 * var3 + var5 * var1 >> 16;
          if(var1 >= 50) {
-            Client.screenX = var0 * Client.scale / var1 + Client.viewportHeight / 2;
-            Client.screenY = var8 * Client.scale / var1 + Client.viewportWidth / 2;
+            Client.screenX = var0 * Client.scale / var1 + Client.viewportWidth / 2;
+            Client.screenY = var8 * Client.scale / var1 + Client.viewportHeight / 2;
          } else {
             Client.screenX = -1;
             Client.screenY = -1;


### PR DESCRIPTION
These fields were previously swapped.

Evidence:
- On fixed-screen, printing the viewport width and height outputs roughly 300 and 500 respectively (swapped dimensions).
- Numerous instances in the client code where the viewport height is read or set __first__, even though generally the dimension tuple goes like _(width, height)_.
- For example,
```
Client.screenX = var0 * Client.scale / var1 + Client.viewportHeight / 2;
Client.screenX = var0 * Client.scale / var1 + Client.viewportWidth / 2;
```