### PR TITLE
Fix the frame is displayable exception

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
@@ -154,13 +154,16 @@ public class ClientUI extends JFrame
 	public void showWithChrome(boolean customChrome)
 	{
 		setUndecorated(customChrome);
+
 		if (customChrome)
 		{
 			getRootPane().setWindowDecorationStyle(JRootPane.FRAME);
 		}
+
 		pack();
 		revalidateMinimumSize();
 		setLocationRelativeTo(getOwner());
+
 		if (customChrome)
 		{
 			try
@@ -295,7 +298,10 @@ public class ClientUI extends JFrame
 		client.getParent().setPreferredSize(size);
 		client.getParent().setSize(size);
 
-		pack();
+		if (isVisible())
+		{
+			pack();
+		}
 	}
 
 	private static void setUIFont(FontUIResource f)


### PR DESCRIPTION
Fix java.awt.IllegalComponentStateException: The frame is displayable
that is caused by window being packed before showWithChrome method is
called.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>