### PR TITLE
Fix coloring of warned attack styles

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/attackindicator/AttackIndicatorOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/attackindicator/AttackIndicatorOverlay.java
@@ -24,6 +24,7 @@
  */
 package net.runelite.client.plugins.attackindicator;
 
+import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Graphics2D;
 import java.awt.Point;
@@ -57,6 +58,8 @@ public class AttackIndicatorOverlay extends Overlay
 		}
 
 		final String attackStyleString = plugin.getAttackStyle().getName();
+
+		panelComponent.setTitleColor(plugin.isWarnedSkillSelected() ? Color.RED : Color.WHITE);
 		panelComponent.setTitle(attackStyleString);
 		panelComponent.setWidth(COMPONENT_WIDTH);
 


### PR DESCRIPTION
Fix coloring of warned attack styles for attack indicator plugin. This
was in before, but probably got lost during the changes to use new UI
comoponents.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>

Preview:
![screenie](https://user-images.githubusercontent.com/5115805/35437221-c5bb449e-0291-11e8-855c-c810c0b6d5b2.png)
