### PR TITLE
Change default overlay position to UNDER_WIDGETS

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/TextureProvider.java
+++ b/runelite-api/src/main/java/net/runelite/api/TextureProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, UniquePassive <https://github.com/uniquepassive>
+ * Copyright (c) 2018, Tomas Slusny <slusnucky@gmail.com>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -22,27 +22,9 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package net.runelite.client.ui.overlay;
+package net.runelite.api;
 
-public enum OverlayLayer
+public interface TextureProvider
 {
-	/**
-	 * Render right above the scene (that contains actors and the surface)
-	 */
-	ABOVE_SCENE,
-
-	/**
-	 * Render under all interfaces, but above overheads
-	 */
-	UNDER_WIDGETS,
-
-	/**
-	 * Render under the right-click menu
-	 */
-	ABOVE_WIDGETS,
-
-	/**
-	 * Render overlay above all game elements
-	 */
-	ALWAYS_ON_TOP,
+	void checkTextures(int var1);
 }

--- a/runelite-client/src/main/java/net/runelite/client/callback/Hooks.java
+++ b/runelite-client/src/main/java/net/runelite/client/callback/Hooks.java
@@ -24,6 +24,7 @@
  */
 package net.runelite.client.callback;
 
+import net.runelite.api.TextureProvider;
 import net.runelite.api.events.GameTick;
 import net.runelite.api.events.ProjectileMoved;
 import net.runelite.api.events.MenuEntryAdded;
@@ -122,6 +123,22 @@ public class Hooks
 	}
 
 	public static void drawRegion(Region region, int var1, int var2, int var3, int var4, int var5, int var6)
+	{
+		MainBufferProvider bufferProvider = (MainBufferProvider) client.getBufferProvider();
+		BufferedImage image = (BufferedImage) bufferProvider.getImage();
+		Graphics2D graphics2d = (Graphics2D) image.getGraphics();
+
+		try
+		{
+			renderer.render(graphics2d, OverlayLayer.ABOVE_SCENE);
+		}
+		catch (Exception ex)
+		{
+			log.warn("Error during overlay rendering", ex);
+		}
+	}
+
+	public static void drawAboveOverheads(TextureProvider textureProvider, int var1)
 	{
 		MainBufferProvider bufferProvider = (MainBufferProvider) client.getBufferProvider();
 		BufferedImage image = (BufferedImage) bufferProvider.getImage();

--- a/runelite-client/src/main/java/net/runelite/client/plugins/agilityplugin/AgilityOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/agilityplugin/AgilityOverlay.java
@@ -50,7 +50,7 @@ public class AgilityOverlay extends Overlay
 	public AgilityOverlay(@Nullable Client client, AgilityPlugin plugin, AgilityPluginConfiguration config)
 	{
 		setPosition(OverlayPosition.DYNAMIC);
-		setLayer(OverlayLayer.UNDER_WIDGETS);
+		setLayer(OverlayLayer.ABOVE_SCENE);
 		this.client = client;
 		this.plugin = plugin;
 		this.config = config;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/barbarianassault/BarbarianAssaultOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/barbarianassault/BarbarianAssaultOverlay.java
@@ -35,6 +35,7 @@ import net.runelite.api.Client;
 import net.runelite.api.GameState;
 import net.runelite.api.widgets.Widget;
 import net.runelite.client.ui.overlay.Overlay;
+import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
 
 public class BarbarianAssaultOverlay extends Overlay
@@ -52,6 +53,7 @@ public class BarbarianAssaultOverlay extends Overlay
 	BarbarianAssaultOverlay(Client client, BarbarianAssaultPlugin plugin, BarbarianAssaultConfig config)
 	{
 		setPosition(OverlayPosition.DYNAMIC);
+		setLayer(OverlayLayer.ABOVE_WIDGETS);
 		this.client = client;
 		this.plugin = plugin;
 		this.config = config;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonOverlay.java
@@ -36,6 +36,7 @@ import net.runelite.api.Perspective;
 import net.runelite.api.widgets.Widget;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.OverlayPriority;
 import net.runelite.client.ui.overlay.components.TextComponent;
 
 class CannonOverlay extends Overlay
@@ -49,6 +50,7 @@ class CannonOverlay extends Overlay
 	CannonOverlay(Client client, CannonConfig config, CannonPlugin plugin)
 	{
 		setPosition(OverlayPosition.DYNAMIC);
+		setPriority(OverlayPriority.MED);
 		this.client = client;
 		this.config = config;
 		this.plugin = plugin;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonOverlay.java
@@ -35,7 +35,6 @@ import net.runelite.api.Client;
 import net.runelite.api.Perspective;
 import net.runelite.api.widgets.Widget;
 import net.runelite.client.ui.overlay.Overlay;
-import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.components.TextComponent;
 
@@ -50,7 +49,6 @@ class CannonOverlay extends Overlay
 	CannonOverlay(Client client, CannonConfig config, CannonPlugin plugin)
 	{
 		setPosition(OverlayPosition.DYNAMIC);
-		setLayer(OverlayLayer.UNDER_WIDGETS);
 		this.client = client;
 		this.config = config;
 		this.plugin = plugin;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingSpotOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingSpotOverlay.java
@@ -37,6 +37,7 @@ import net.runelite.api.NPC;
 import net.runelite.api.queries.NPCQuery;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.ui.overlay.Overlay;
+import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.OverlayUtil;
 import net.runelite.client.util.QueryRunner;
@@ -55,6 +56,7 @@ class FishingSpotOverlay extends Overlay
 	public FishingSpotOverlay(QueryRunner queryRunner, FishingConfig config)
 	{
 		setPosition(OverlayPosition.DYNAMIC);
+		setLayer(OverlayLayer.ABOVE_SCENE);
 		this.queryRunner = queryRunner;
 		this.config = config;
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingSpotOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingSpotOverlay.java
@@ -37,7 +37,6 @@ import net.runelite.api.NPC;
 import net.runelite.api.queries.NPCQuery;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.ui.overlay.Overlay;
-import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.OverlayUtil;
 import net.runelite.client.util.QueryRunner;
@@ -56,7 +55,6 @@ class FishingSpotOverlay extends Overlay
 	public FishingSpotOverlay(QueryRunner queryRunner, FishingConfig config)
 	{
 		setPosition(OverlayPosition.DYNAMIC);
-		setLayer(OverlayLayer.UNDER_WIDGETS);
 		this.queryRunner = queryRunner;
 		this.config = config;
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
@@ -52,8 +52,8 @@ import net.runelite.api.widgets.Widget;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.ui.FontManager;
 import net.runelite.client.ui.overlay.Overlay;
-import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.OverlayPriority;
 import net.runelite.http.api.item.ItemPrice;
 
 public class GroundItemsOverlay extends Overlay
@@ -92,7 +92,7 @@ public class GroundItemsOverlay extends Overlay
 	public GroundItemsOverlay(@Nullable Client client, GroundItemsConfig config)
 	{
 		setPosition(OverlayPosition.DYNAMIC);
-		setLayer(OverlayLayer.UNDER_WIDGETS);
+		setPriority(OverlayPriority.LOW);
 		this.client = client;
 		this.config = config;
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
@@ -24,12 +24,12 @@
  */
 package net.runelite.client.plugins.grounditems;
 
+import static java.lang.Math.max;
+import static java.lang.Math.min;
 import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.FontMetrics;
 import java.awt.Graphics2D;
-import static java.lang.Math.max;
-import static java.lang.Math.min;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -52,8 +52,8 @@ import net.runelite.api.widgets.Widget;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.ui.FontManager;
 import net.runelite.client.ui.overlay.Overlay;
+import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
-import net.runelite.client.ui.overlay.OverlayPriority;
 import net.runelite.http.api.item.ItemPrice;
 
 public class GroundItemsOverlay extends Overlay
@@ -92,7 +92,7 @@ public class GroundItemsOverlay extends Overlay
 	public GroundItemsOverlay(@Nullable Client client, GroundItemsConfig config)
 	{
 		setPosition(OverlayPosition.DYNAMIC);
-		setPriority(OverlayPriority.LOW);
+		setLayer(OverlayLayer.ABOVE_SCENE);
 		this.client = client;
 		this.config = config;
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/hunter/TrapOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/hunter/TrapOverlay.java
@@ -35,7 +35,6 @@ import javax.inject.Inject;
 import net.runelite.api.Client;
 import net.runelite.api.widgets.Widget;
 import net.runelite.client.ui.overlay.Overlay;
-import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
 
 /**
@@ -72,7 +71,6 @@ public class TrapOverlay extends Overlay
 	TrapOverlay(@Nullable Client client, HunterPlugin plugin, HunterConfig config)
 	{
 		setPosition(OverlayPosition.DYNAMIC);
-		setLayer(OverlayLayer.UNDER_WIDGETS);
 		this.plugin = plugin;
 		this.config = config;
 		this.client = client;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/hunter/TrapOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/hunter/TrapOverlay.java
@@ -35,6 +35,7 @@ import javax.inject.Inject;
 import net.runelite.api.Client;
 import net.runelite.api.widgets.Widget;
 import net.runelite.client.ui.overlay.Overlay;
+import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
 
 /**
@@ -71,6 +72,7 @@ public class TrapOverlay extends Overlay
 	TrapOverlay(@Nullable Client client, HunterPlugin plugin, HunterConfig config)
 	{
 		setPosition(OverlayPosition.DYNAMIC);
+		setLayer(OverlayLayer.ABOVE_SCENE);
 		this.plugin = plugin;
 		this.config = config;
 		this.client = client;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/implings/ImplingsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/implings/ImplingsOverlay.java
@@ -40,7 +40,6 @@ import net.runelite.api.NpcID;
 import net.runelite.api.Point;
 import net.runelite.api.queries.NPCQuery;
 import net.runelite.client.ui.overlay.Overlay;
-import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.util.QueryRunner;
 
@@ -65,7 +64,6 @@ public class ImplingsOverlay extends Overlay
 	public ImplingsOverlay(QueryRunner queryRunner, ImplingsConfig config)
 	{
 		setPosition(OverlayPosition.DYNAMIC);
-		setLayer(OverlayLayer.UNDER_WIDGETS);
 		this.queryRunner = queryRunner;
 		this.config = config;
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/implings/ImplingsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/implings/ImplingsOverlay.java
@@ -40,6 +40,7 @@ import net.runelite.api.NpcID;
 import net.runelite.api.Point;
 import net.runelite.api.queries.NPCQuery;
 import net.runelite.client.ui.overlay.Overlay;
+import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.util.QueryRunner;
 
@@ -64,6 +65,7 @@ public class ImplingsOverlay extends Overlay
 	public ImplingsOverlay(QueryRunner queryRunner, ImplingsConfig config)
 	{
 		setPosition(OverlayPosition.DYNAMIC);
+		setLayer(OverlayLayer.ABOVE_SCENE);
 		this.queryRunner = queryRunner;
 		this.config = config;
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/jewellerycount/JewelleryCountOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/jewellerycount/JewelleryCountOverlay.java
@@ -39,6 +39,7 @@ import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.api.widgets.WidgetItem;
 import net.runelite.client.ui.FontManager;
 import net.runelite.client.ui.overlay.Overlay;
+import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.components.TextComponent;
 import net.runelite.client.util.QueryRunner;
@@ -52,6 +53,7 @@ class JewelleryCountOverlay extends Overlay
 	JewelleryCountOverlay(QueryRunner queryRunner, JewelleryCountConfig config)
 	{
 		setPosition(OverlayPosition.DYNAMIC);
+		setLayer(OverlayLayer.ABOVE_WIDGETS);
 		this.queryRunner = queryRunner;
 		this.config = config;
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/motherlode/MotherlodeRocksOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/motherlode/MotherlodeRocksOverlay.java
@@ -53,7 +53,7 @@ class MotherlodeRocksOverlay extends Overlay
 	MotherlodeRocksOverlay(Client client, MotherlodePlugin plugin, MotherlodeConfig config)
 	{
 		setPosition(OverlayPosition.DYNAMIC);
-		setLayer(OverlayLayer.UNDER_WIDGETS);
+		setLayer(OverlayLayer.ABOVE_SCENE);
 		this.client = client;
 		this.plugin = plugin;
 		this.config = config;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/motherlode/MotherlodeSackOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/motherlode/MotherlodeSackOverlay.java
@@ -34,6 +34,7 @@ import net.runelite.api.Varbits;
 import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.ui.overlay.Overlay;
+import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.components.PanelComponent;
 
@@ -47,6 +48,7 @@ class MotherlodeSackOverlay extends Overlay
 	MotherlodeSackOverlay(Client client, MotherlodeConfig config)
 	{
 		setPosition(OverlayPosition.TOP_LEFT);
+		setLayer(OverlayLayer.ABOVE_SCENE);
 		this.client = client;
 		this.config = config;
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsOverlay.java
@@ -34,6 +34,7 @@ import net.runelite.api.Client;
 import net.runelite.api.Player;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.OverlayPriority;
 import net.runelite.client.ui.overlay.OverlayUtil;
 
 @Slf4j
@@ -50,6 +51,7 @@ public class PlayerIndicatorsOverlay extends Overlay
 		this.config = config;
 		this.client = client;
 		setPosition(OverlayPosition.DYNAMIC);
+		setPriority(OverlayPriority.HIGH);
 	}
 
 	@Override

--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsOverlay.java
@@ -33,7 +33,6 @@ import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.Player;
 import net.runelite.client.ui.overlay.Overlay;
-import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.OverlayUtil;
 
@@ -51,7 +50,6 @@ public class PlayerIndicatorsOverlay extends Overlay
 		this.config = config;
 		this.client = client;
 		setPosition(OverlayPosition.DYNAMIC);
-		setLayer(OverlayLayer.UNDER_WIDGETS);
 	}
 
 	@Override

--- a/runelite-client/src/main/java/net/runelite/client/plugins/prayflick/PrayerFlickOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/prayflick/PrayerFlickOverlay.java
@@ -38,6 +38,7 @@ import net.runelite.api.Prayer;
 import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.ui.overlay.Overlay;
+import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
 
 public class PrayerFlickOverlay extends Overlay
@@ -51,6 +52,7 @@ public class PrayerFlickOverlay extends Overlay
 	public PrayerFlickOverlay(@Nullable Client client, PrayerFlickConfig config)
 	{
 		setPosition(OverlayPosition.DYNAMIC);
+		setLayer(OverlayLayer.ABOVE_WIDGETS);
 		this.client = client;
 		this.config = config;
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/runecraft/AbyssOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/runecraft/AbyssOverlay.java
@@ -24,19 +24,6 @@
  */
 package net.runelite.client.plugins.runecraft;
 
-import com.google.inject.Inject;
-import java.awt.Dimension;
-import java.awt.Graphics2D;
-import java.awt.image.BufferedImage;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
-import net.runelite.api.Client;
-import net.runelite.api.DecorativeObject;
-import net.runelite.api.Perspective;
-import net.runelite.api.Point;
-import net.runelite.client.game.ItemManager;
 import static net.runelite.client.plugins.runecraft.AbyssRifts.AIR_RIFT;
 import static net.runelite.client.plugins.runecraft.AbyssRifts.BLOOD_RIFT;
 import static net.runelite.client.plugins.runecraft.AbyssRifts.BODY_RIFT;
@@ -50,7 +37,21 @@ import static net.runelite.client.plugins.runecraft.AbyssRifts.MIND_RIFT;
 import static net.runelite.client.plugins.runecraft.AbyssRifts.NATURE_RIFT;
 import static net.runelite.client.plugins.runecraft.AbyssRifts.SOUL_RIFT;
 import static net.runelite.client.plugins.runecraft.AbyssRifts.WATER_RIFT;
+import com.google.inject.Inject;
+import java.awt.Dimension;
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import net.runelite.api.Client;
+import net.runelite.api.DecorativeObject;
+import net.runelite.api.Perspective;
+import net.runelite.api.Point;
+import net.runelite.client.game.ItemManager;
 import net.runelite.client.ui.overlay.Overlay;
+import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
 
 class AbyssOverlay extends Overlay
@@ -72,6 +73,7 @@ class AbyssOverlay extends Overlay
 	AbyssOverlay(Client client, RunecraftPlugin plugin, RunecraftConfig config)
 	{
 		setPosition(OverlayPosition.DYNAMIC);
+		setLayer(OverlayLayer.ABOVE_WIDGETS);
 		this.client = client;
 		this.plugin = plugin;
 		this.config = config;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/runecraft/BindNeckOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/runecraft/BindNeckOverlay.java
@@ -42,6 +42,7 @@ import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.api.widgets.WidgetItem;
 import net.runelite.client.ui.FontManager;
 import net.runelite.client.ui.overlay.Overlay;
+import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.components.TextComponent;
 import net.runelite.client.util.QueryRunner;
@@ -56,6 +57,7 @@ public class BindNeckOverlay extends Overlay
 	BindNeckOverlay(QueryRunner queryRunner, RunecraftConfig config)
 	{
 		setPosition(OverlayPosition.DYNAMIC);
+		setLayer(OverlayLayer.ABOVE_WIDGETS);
 		this.queryRunner = queryRunner;
 		this.config = config;
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/runecraft/RunecraftOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/runecraft/RunecraftOverlay.java
@@ -37,6 +37,7 @@ import net.runelite.api.queries.InventoryWidgetItemQuery;
 import net.runelite.api.widgets.WidgetItem;
 import net.runelite.client.ui.FontManager;
 import net.runelite.client.ui.overlay.Overlay;
+import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.components.TextComponent;
 import net.runelite.client.util.QueryRunner;
@@ -56,6 +57,7 @@ public class RunecraftOverlay extends Overlay
 	RunecraftOverlay(QueryRunner queryRunner, Client client, RunecraftConfig config)
 	{
 		setPosition(OverlayPosition.DYNAMIC);
+		setLayer(OverlayLayer.ABOVE_WIDGETS);
 		this.queryRunner = queryRunner;
 		this.client = client;
 		this.config = config;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/runepouch/RunepouchOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/runepouch/RunepouchOverlay.java
@@ -38,6 +38,7 @@ import net.runelite.api.queries.InventoryWidgetItemQuery;
 import net.runelite.api.widgets.WidgetItem;
 import net.runelite.client.ui.FontManager;
 import net.runelite.client.ui.overlay.Overlay;
+import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.OverlayUtil;
 import net.runelite.client.ui.overlay.tooltip.Tooltip;
@@ -66,6 +67,7 @@ public class RunepouchOverlay extends Overlay
 	RunepouchOverlay(QueryRunner queryRunner, Client client, RunepouchConfig config, TooltipManager tooltipManager)
 	{
 		setPosition(OverlayPosition.DYNAMIC);
+		setLayer(OverlayLayer.ABOVE_WIDGETS);
 		this.tooltipManager = tooltipManager;
 		this.queryRunner = queryRunner;
 		this.client = client;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerOverlay.java
@@ -42,6 +42,7 @@ import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.api.widgets.WidgetItem;
 import net.runelite.client.ui.FontManager;
 import net.runelite.client.ui.overlay.Overlay;
+import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.components.TextComponent;
 import net.runelite.client.util.QueryRunner;
@@ -83,6 +84,7 @@ class SlayerOverlay extends Overlay
 	SlayerOverlay(QueryRunner queryRunner, SlayerPlugin plugin, SlayerConfig config)
 	{
 		setPosition(OverlayPosition.DYNAMIC);
+		setLayer(OverlayLayer.ABOVE_WIDGETS);
 		this.queryRunner = queryRunner;
 		this.plugin = plugin;
 		this.config = config;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/specorb/SpecOrbOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/specorb/SpecOrbOverlay.java
@@ -32,11 +32,12 @@ import javax.inject.Inject;
 import net.runelite.api.Client;
 import net.runelite.api.Point;
 import net.runelite.api.Varbits;
-import net.runelite.api.widgets.Widget;
-import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.api.events.GameTick;
 import net.runelite.api.events.VarbitChanged;
+import net.runelite.api.widgets.Widget;
+import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.ui.overlay.Overlay;
+import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.OverlayUtil;
 
@@ -69,6 +70,7 @@ public class SpecOrbOverlay extends Overlay
 	public SpecOrbOverlay(@Nullable Client client, SpecOrbConfig config, SpecOrbPlugin plugin)
 	{
 		setPosition(OverlayPosition.DYNAMIC);
+		setLayer(OverlayLayer.ABOVE_WIDGETS);
 		this.client = client;
 		this.config = config;
 		this.plugin = plugin;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/tileindicators/TileIndicatorsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/tileindicators/TileIndicatorsOverlay.java
@@ -32,6 +32,7 @@ import net.runelite.api.Client;
 import net.runelite.api.Perspective;
 import net.runelite.api.Point;
 import net.runelite.client.ui.overlay.Overlay;
+import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.OverlayPriority;
 import net.runelite.client.ui.overlay.OverlayUtil;
@@ -46,6 +47,7 @@ public class TileIndicatorsOverlay extends Overlay
 		this.client = client;
 		this.config = config;
 		setPosition(OverlayPosition.DYNAMIC);
+		setLayer(OverlayLayer.ABOVE_SCENE);
 		setPriority(OverlayPriority.LOW);
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/tileindicators/TileIndicatorsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/tileindicators/TileIndicatorsOverlay.java
@@ -32,7 +32,6 @@ import net.runelite.api.Client;
 import net.runelite.api.Perspective;
 import net.runelite.api.Point;
 import net.runelite.client.ui.overlay.Overlay;
-import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.OverlayPriority;
 import net.runelite.client.ui.overlay.OverlayUtil;
@@ -48,7 +47,6 @@ public class TileIndicatorsOverlay extends Overlay
 		this.config = config;
 		setPosition(OverlayPosition.DYNAMIC);
 		setPriority(OverlayPriority.LOW);
-		setLayer(OverlayLayer.UNDER_WIDGETS);
 	}
 
 	@Override

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesOverlay.java
@@ -45,6 +45,7 @@ import net.runelite.api.Point;
 import net.runelite.api.Skill;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.OverlayPriority;
 import net.runelite.client.ui.overlay.components.PanelComponent;
 import net.runelite.client.ui.overlay.components.ProgressBarComponent;
 
@@ -76,6 +77,7 @@ public class XpGlobesOverlay extends Overlay
 	public XpGlobesOverlay(@Nullable Client client, XpGlobesPlugin plugin, XpGlobesConfig config)
 	{
 		setPosition(OverlayPosition.DYNAMIC);
+		setPriority(OverlayPriority.HIGH);
 		this.client = client;
 		this.plugin = plugin;
 		this.config = config;

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/Overlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/Overlay.java
@@ -31,5 +31,5 @@ public abstract class Overlay implements RenderableEntity
 {
 	private OverlayPosition position = OverlayPosition.TOP_LEFT;
 	private OverlayPriority priority = OverlayPriority.NONE;
-	private OverlayLayer layer = OverlayLayer.ABOVE_WIDGETS;
+	private OverlayLayer layer = OverlayLayer.UNDER_WIDGETS;
 }

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/tooltip/TooltipOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/tooltip/TooltipOverlay.java
@@ -33,6 +33,7 @@ import javax.inject.Inject;
 import javax.inject.Provider;
 import net.runelite.api.Client;
 import net.runelite.client.ui.overlay.Overlay;
+import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.OverlayPriority;
 import net.runelite.client.ui.overlay.components.TooltipComponent;
@@ -48,6 +49,7 @@ public class TooltipOverlay extends Overlay
 	{
 		setPosition(OverlayPosition.TOOLTIP);
 		setPriority(OverlayPriority.HIGH);
+		setLayer(OverlayLayer.ALWAYS_ON_TOP);
 		this.tooltipManager = tooltipManager;
 		this.clientProvider = clientProvider;
 	}

--- a/runescape-api/src/main/java/net/runelite/rs/api/RSTextureProvider.java
+++ b/runescape-api/src/main/java/net/runelite/rs/api/RSTextureProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, UniquePassive <https://github.com/uniquepassive>
+ * Copyright (c) 2018, Tomas Slusny <slusnucky@gmail.com>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -22,27 +22,14 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package net.runelite.client.ui.overlay;
+package net.runelite.rs.api;
 
-public enum OverlayLayer
+import net.runelite.api.TextureProvider;
+import net.runelite.mapping.Import;
+
+public interface RSTextureProvider extends TextureProvider
 {
-	/**
-	 * Render right above the scene (that contains actors and the surface)
-	 */
-	ABOVE_SCENE,
-
-	/**
-	 * Render under all interfaces, but above overheads
-	 */
-	UNDER_WIDGETS,
-
-	/**
-	 * Render under the right-click menu
-	 */
-	ABOVE_WIDGETS,
-
-	/**
-	 * Render overlay above all game elements
-	 */
-	ALWAYS_ON_TOP,
+	@Override
+	@Import("checkTextures")
+	void checkTextures(int var1);
 }

--- a/runescape-client/src/main/java/TextureProvider.java
+++ b/runescape-client/src/main/java/TextureProvider.java
@@ -1,4 +1,5 @@
 import net.runelite.mapping.Export;
+import net.runelite.mapping.Hook;
 import net.runelite.mapping.Implements;
 import net.runelite.mapping.ObfuscatedGetter;
 import net.runelite.mapping.ObfuscatedName;
@@ -198,7 +199,12 @@ public class TextureProvider implements ITextureLoader {
       signature = "(II)V",
       garbageValue = "1136074177"
    )
-   public void method2539(int var1) {
+   @Hook(
+	   value = "drawAboveOverheads",
+	   end = true
+   )
+   @Export("checkTextures")
+   public void checkTextures(int var1) {
       for(int var2 = 0; var2 < this.textures.length; ++var2) {
          Texture var3 = this.textures[var2];
          if(var3 != null && var3.field1758 != 0 && var3.loaded) {

--- a/runescape-client/src/main/java/class3.java
+++ b/runescape-client/src/main/java/class3.java
@@ -375,7 +375,7 @@ final class class3 implements class0 {
       }
 
       class2.method5(var0, var1);
-      ((TextureProvider)Graphics3D.textureLoader).method2539(Client.field882);
+      ((TextureProvider)Graphics3D.textureLoader).checkTextures(Client.field882);
       if(Client.cursorState == 1) {
          class39.crossSprites[Client.field871 / 100].drawAt(Client.lastLeftClickX - 8, Client.lastLeftClickY - 8);
       }


### PR DESCRIPTION
In order to not draw UI overlays over bank interfaces (and similar popup
interfaces), change default overlay position to UNDER_WIDGETS.

Fixes #451

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>

Preview:
![screenie](https://user-images.githubusercontent.com/5115805/35440229-c3a40c56-029e-11e8-9d26-7d90996d0800.png)

![screenie2](https://user-images.githubusercontent.com/5115805/35640207-d20cc8ba-06bc-11e8-89c7-c16a5ebcd1c0.png)

![screenie](https://user-images.githubusercontent.com/5115805/35640217-d4ec2ab2-06bc-11e8-9cc0-626e4b0dcec7.png)
