### PR TITLE
Extend Metronome Plugin with configurable sound and tick delay

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/metronome/MetronomePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/metronome/MetronomePlugin.java
@@ -46,25 +46,34 @@ public class MetronomePlugin extends Plugin
 	@Inject
 	MetronomePluginConfiguration config;
 
+	private int tickCounter = 0;
+	private boolean shouldTock = false;
+
 	@Provides
 	MetronomePluginConfiguration provideConfig(ConfigManager configManager)
 	{
 		return configManager.getConfig(MetronomePluginConfiguration.class);
 	}
 
-	private int tickCounter = 0;
-
 	@Subscribe
 	void onTick(GameTick tick)
 	{
-		if (!config.enabled())
+		if (!config.enabled() || config.tickCount() == 0)
 		{
 			return;
 		}
 
 		if (++tickCounter % config.tickCount() == 0)
 		{
-			client.playSoundEffect(config.tickSound());
+			if (config.enableTock() && shouldTock)
+			{
+				client.playSoundEffect(config.tockSound());
+			}
+			else
+			{
+				client.playSoundEffect(config.tickSound());
+			}
+			shouldTock = !shouldTock;
 		}
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/metronome/MetronomePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/metronome/MetronomePlugin.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018, SomeoneWithAnInternetConnection
+ * Copyright (c) 2018, oplosthee <https://github.com/oplosthee>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,13 +28,10 @@ package net.runelite.client.plugins.metronome;
 import com.google.common.eventbus.Subscribe;
 import com.google.inject.Provides;
 import net.runelite.api.Client;
-import net.runelite.api.SoundEffectID;
 import net.runelite.api.events.GameTick;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 
@@ -42,15 +40,19 @@ import javax.inject.Inject;
 )
 public class MetronomePlugin extends Plugin
 {
-	private static final Logger logger = LoggerFactory.getLogger(MetronomePlugin.class);
-
 	@Inject
 	Client client;
 
 	@Inject
 	MetronomePluginConfiguration config;
 
-	private boolean tock = false;
+	@Provides
+	MetronomePluginConfiguration provideConfig(ConfigManager configManager)
+	{
+		return configManager.getConfig(MetronomePluginConfiguration.class);
+	}
+
+	private int tickCounter = 0;
 
 	@Subscribe
 	void onTick(GameTick tick)
@@ -59,22 +61,10 @@ public class MetronomePlugin extends Plugin
 		{
 			return;
 		}
-		if (tock)
+
+		if (++tickCounter % config.tickCount() == 0)
 		{
-			client.playSoundEffect(SoundEffectID.GE_DECREMENT_PLOP);
+			client.playSoundEffect(config.tickSound());
 		}
-		else // tick
-		{
-			client.playSoundEffect(SoundEffectID.GE_INCREMENT_PLOP);
-		}
-
-		tock = !tock;
 	}
-
-	@Provides
-	MetronomePluginConfiguration provideConfig(ConfigManager configManager)
-	{
-		return configManager.getConfig(MetronomePluginConfiguration.class);
-	}
-
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/metronome/MetronomePluginConfiguration.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/metronome/MetronomePluginConfiguration.java
@@ -25,12 +25,13 @@
  */
 package net.runelite.client.plugins.metronome;
 
+import net.runelite.api.SoundEffectID;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
 
 @ConfigGroup(
-	keyName = "metronomeplugin",
+	keyName = "metronome",
 	name = "Metronome",
 	description = "Plays a sound on the specified tick to aid in efficient skilling"
 )
@@ -39,7 +40,8 @@ public interface MetronomePluginConfiguration extends Config
 	@ConfigItem(
 		keyName = "enabled",
 		name = "Enable metronome",
-		description = "Toggles tick metronome"
+		description = "Toggles tick metronome",
+		position = 1
 	)
 	default boolean enabled()
 	{
@@ -47,9 +49,10 @@ public interface MetronomePluginConfiguration extends Config
 	}
 
 	@ConfigItem(
-			keyName = "tickCount",
-			name = "Tick count",
-			description = "Configures the tick on which a sound will be played"
+		keyName = "tickCount",
+		name = "Tick count",
+		description = "Configures the tick on which a sound will be played",
+		position = 2
 	)
 	default int tickCount()
 	{
@@ -57,12 +60,35 @@ public interface MetronomePluginConfiguration extends Config
 	}
 
 	@ConfigItem(
-			keyName = "tickSound",
-			name = "Tick sound",
-			description = "Configures which sound to play on the specified tick"
+		keyName = "tickSound",
+		name = "Tick sound ID",
+		description = "Configures which sound to play on the specified tick",
+		position = 3
 	)
 	default int tickSound()
 	{
-		return 3929;
+		return SoundEffectID.GE_INCREMENT_PLOP;
+	}
+
+	@ConfigItem(
+		keyName = "enableTock",
+		name = "Enable tock (alternating) sound",
+		description = "Toggles whether to play two alternating sounds",
+		position = 4
+	)
+	default boolean enableTock()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		keyName = "tockSound",
+		name = "Tock sound ID",
+		description = "Configures which sound to alternate between",
+		position = 5
+	)
+	default int tockSound()
+	{
+		return SoundEffectID.GE_DECREMENT_PLOP;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/metronome/MetronomePluginConfiguration.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/metronome/MetronomePluginConfiguration.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018, SomeoneWithAnInternetConnection
+ * Copyright (c) 2018, oplosthee <https://github.com/oplosthee>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -30,8 +31,8 @@ import net.runelite.client.config.ConfigItem;
 
 @ConfigGroup(
 	keyName = "metronomeplugin",
-	name = "Metronome plugin",
-	description = "Configuration for the metronome plugin"
+	name = "Metronome",
+	description = "Plays a sound on the specified tick to aid in efficient skilling"
 )
 public interface MetronomePluginConfiguration extends Config
 {
@@ -43,5 +44,25 @@ public interface MetronomePluginConfiguration extends Config
 	default boolean enabled()
 	{
 		return false;
+	}
+
+	@ConfigItem(
+			keyName = "tickCount",
+			name = "Tick count",
+			description = "Configures the tick on which a sound will be played"
+	)
+	default int tickCount()
+	{
+		return 1;
+	}
+
+	@ConfigItem(
+			keyName = "tickSound",
+			name = "Tick sound",
+			description = "Configures which sound to play on the specified tick"
+	)
+	default int tickSound()
+	{
+		return 3929;
 	}
 }


### PR DESCRIPTION
Adds support to the Metronome Plugin to make a (now configurable) sound every n-ticks instead of every tick.