### PR TITLE
 Add indicators to boosts plugin

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/boosts/BoostIndicator.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/boosts/BoostIndicator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Seth <Sethtroll3@gmail.com>
+ * Copyright (c) 2018 Kamiel
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -24,54 +24,56 @@
  */
 package net.runelite.client.plugins.boosts;
 
-import net.runelite.client.config.ConfigGroup;
-import net.runelite.client.config.ConfigItem;
-import net.runelite.client.config.Config;
+import java.awt.Color;
+import java.awt.image.BufferedImage;
+import net.runelite.api.Client;
+import net.runelite.api.Skill;
+import net.runelite.client.ui.overlay.infobox.InfoBox;
 
-@ConfigGroup(
-	keyName = "boosts",
-	name = "Boosts Info",
-	description = "Configuration for the Boosts plugin"
-)
-public interface BoostsConfig extends Config
+public class BoostIndicator extends InfoBox
 {
-	@ConfigItem(
-		keyName = "enabled",
-		name = "Enabled",
-		description = "Configures whether or not boost info is displayed"
-	)
-	default boolean enabled()
+	private final BoostsConfig config;
+	private final Client client;
+	private final Skill skill;
+
+	public BoostIndicator(Skill skill, BufferedImage image, Client client, BoostsConfig config)
 	{
-		return true;
+		super(image);
+		this.config = config;
+		this.client = client;
+		this.skill = skill;
+		setTooltip(skill.getName() + " boost");
 	}
 
-	@ConfigItem(
-		keyName = "enableSkill",
-		name = "Enable Skill Boosts",
-		description = "Configures whether or not to display skill boost information"
-	)
-	default boolean enableSkill()
+	@Override
+	public String getText()
 	{
-		return true;
+		if (!config.useRelativeBoost())
+		{
+			return String.valueOf(client.getBoostedSkillLevel(skill));
+		}
+
+		int boost = client.getBoostedSkillLevel(skill) - client.getRealSkillLevel(skill);
+		String text = String.valueOf(boost);
+		if (boost > 0)
+		{
+			text = "+" + text;
+		}
+
+		return text;
 	}
 
-	@ConfigItem(
-		keyName = "relativeBoost",
-		name = "Use Relative Boosts",
-		description = "Configures whether or not relative boost is used"
-	)
-	default boolean useRelativeBoost()
+	@Override
+	public Color getTextColor()
 	{
-		return false;
-	}
+		int boosted = client.getBoostedSkillLevel(skill),
+			base = client.getRealSkillLevel(skill);
 
-	@ConfigItem(
-		keyName = "displayIndicators",
-		name = "Display as indicators",
-		description = "Configures whether or not to display the boost as indicators"
-	)
-	default boolean displayIndicators()
-	{
-		return false;
+		if (boosted > base)
+		{
+			return Color.GREEN;
+		}
+
+		return new Color(238, 51, 51);
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/boosts/BoostsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/boosts/BoostsPlugin.java
@@ -24,21 +24,47 @@
  */
 package net.runelite.client.plugins.boosts;
 
+import com.google.common.collect.ObjectArrays;
+import com.google.common.eventbus.Subscribe;
 import com.google.inject.Binder;
 import com.google.inject.Provides;
 import javax.inject.Inject;
+import lombok.Getter;
+import net.runelite.api.Skill;
+import net.runelite.api.events.ConfigChanged;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.Overlay;
+import net.runelite.client.ui.overlay.infobox.InfoBoxManager;
 
 @PluginDescriptor(
 	name = "Boosts plugin"
 )
 public class BoostsPlugin extends Plugin
 {
+	private static final Skill[] COMBAT = new Skill[]
+	{
+		Skill.ATTACK, Skill.STRENGTH, Skill.DEFENCE, Skill.RANGED, Skill.MAGIC
+	};
+	private static final Skill[] SKILLING = new Skill[]
+	{
+		Skill.MINING, Skill.AGILITY, Skill.SMITHING, Skill.HERBLORE, Skill.FISHING, Skill.THIEVING,
+		Skill.COOKING, Skill.CRAFTING, Skill.FIREMAKING, Skill.FLETCHING, Skill.WOODCUTTING, Skill.RUNECRAFT,
+		Skill.SLAYER, Skill.FARMING, Skill.CONSTRUCTION, Skill.HUNTER
+	};
+
+	@Inject
+	InfoBoxManager infoBoxManager;
+
 	@Inject
 	BoostsOverlay boostsOverlay;
+
+	@Inject
+	BoostsConfig config;
+
+	@Getter
+	private Skill[] shownSkills;
 
 	@Override
 	public void configure(Binder binder)
@@ -56,5 +82,43 @@ public class BoostsPlugin extends Plugin
 	public Overlay getOverlay()
 	{
 		return boostsOverlay;
+	}
+
+	@Subscribe
+	public void onConfigChanged(ConfigChanged event)
+	{
+		if (!config.enabled())
+		{
+			return;
+		}
+
+		if (config.enableSkill())
+		{
+			shownSkills = ObjectArrays.concat(COMBAT, SKILLING, Skill.class);
+		}
+		else
+		{
+			shownSkills = COMBAT;
+		}
+
+		if (event.getKey().equals("displayIndicators"))
+		{
+			for (BoostIndicator indicator : boostsOverlay.getIndicators())
+			{
+				if (indicator == null)
+				{
+					continue;
+				}
+
+				if (config.displayIndicators())
+				{
+					infoBoxManager.addInfoBox(indicator);
+				}
+				else
+				{
+					infoBoxManager.removeInfoBox(indicator);
+				}
+			}
+		}
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/components/InfoBoxComponent.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/components/InfoBoxComponent.java
@@ -71,7 +71,7 @@ public class InfoBoxComponent implements RenderableEntity
 		{
 			graphics.drawImage(image,
 				position.x + (BOX_SIZE - image.getWidth()) / 2,
-				SEPARATOR, null);
+				(BOX_SIZE - image.getHeight()) / 2, null);
 		}
 
 		final TextComponent textComponent = new TextComponent();


### PR DESCRIPTION
Add the option to show boosts as indicators
![image](https://user-images.githubusercontent.com/35824069/35468860-e029a604-0327-11e8-9759-16b343532877.png)
![image](https://user-images.githubusercontent.com/35824069/35468862-f8cd9382-0327-11e8-9293-220fa32ed898.png)
