### PR TITLE
mixins: Fix invoking copied methods multiple times producing broken code

### DIFF
--- a/runescape-client-injector-plugin/src/main/java/net/runelite/injector/MixinInjector.java
+++ b/runescape-client-injector-plugin/src/main/java/net/runelite/injector/MixinInjector.java
@@ -371,6 +371,20 @@ public class MixinInjector
 		{
 			if (method.getAnnotations().find(INJECT) != null)
 			{
+				// Make sure the method doesn't invoke copied methods
+				for (Instruction i : method.getCode().getInstructions().getInstructions())
+				{
+					if (i instanceof InvokeInstruction)
+					{
+						InvokeInstruction ii = (InvokeInstruction) i;
+
+						if (copiedMethods.containsKey(ii.getMethod()))
+						{
+							throw new InjectionException("Injected methods cannot invoke copied methods");
+						}
+					}
+				}
+
 				Method copy = new Method(cf, method.getName(), method.getDescriptor());
 				moveCode(copy, method.getCode());
 				copy.setAccessFlags(method.getAccessFlags());


### PR DESCRIPTION
```java
@Copy("isFriended")
private static boolean rs$isFriended(String name, boolean mustBeLoggedIn)
{
	throw new IllegalStateException();
}

@Replace("isFriended")
private static boolean rl$isFriended(String name, boolean mustBeLoggedIn)
{
	// invoking these twice or more would produce broken code (or if you'd invoke another copied method)
	rs$isFriended(name, mustBeLoggedIn);
	rs$isFriended(name, mustBeLoggedIn); 
	.....
}
```

Also disallows invoking copied methods from injected methods.