### PR TITLE
Preserve guava classes in the shaded jar

### DIFF
--- a/runelite-client/pom.xml
+++ b/runelite-client/pom.xml
@@ -204,6 +204,12 @@
 										<include>**</include>
 									</includes>
 								</filter>
+								<filter>
+									<artifact>com.google.guava:*</artifact>
+									<includes>
+										<include>**</include>
+									</includes>
+								</filter>
 							</filters>
 							<transformers>
 								<transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">


### PR DESCRIPTION
Because currently Hashing.java is using only in mixins, it gets removed
by maven-shade-plugin from the shaded jar. So tell the plugin to keep
these classes.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>