### PR TITLE
Fix SuperRestore and friends

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/potions/SuperRestore.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/potions/SuperRestore.java
@@ -63,10 +63,9 @@ public class SuperRestore implements Effect
 				.map(stat ->
 				{
 					calc.setStat(stat);
-					return calc.calculate(client);
+					return calc.effect(client);
 				})
-		)
-			.toArray(StatChange[]::new));
+			).toArray(StatChange[]::new));
 		changes.setPositivity(Stream.of(changes.getStatChanges()).map(sc -> sc.getPositivity()).max(Comparator.comparing(Enum::ordinal)).get());
 		return changes;
 	}


### PR DESCRIPTION
Hovering over a SuperRestore throws an Exception because java has a good type system.