### PR TITLE
runescape-api: remove RSCacheableNode::getNext() and getPrevious().

### DIFF
--- a/runescape-api/src/main/java/net/runelite/rs/api/RSCacheableNode.java
+++ b/runescape-api/src/main/java/net/runelite/rs/api/RSCacheableNode.java
@@ -28,9 +28,4 @@ import net.runelite.mapping.Import;
 
 public interface RSCacheableNode extends RSNode
 {
-	@Import("next")
-	RSCacheableNode getNext();
-
-	@Import("previous")
-	RSCacheableNode getPrevious();
 }


### PR DESCRIPTION
They are different than RSNode's next and previous, but have the same signature so they can get called instead. This caused the ground overlay to only show 1 item because it was iterating the cache, not the item list.