### PR TITLE
Decrease the injector plugin's verbosity

### DIFF
--- a/runescape-client-injector-plugin/src/main/java/net/runelite/injector/Inject.java
+++ b/runescape-client-injector-plugin/src/main/java/net/runelite/injector/Inject.java
@@ -271,7 +271,7 @@ public class Inject
 					assert !f.isStatic();
 
 					// non static field exported on non exported interface
-					logger.warn("Non static exported field {} on non exported interface", exportedName);
+					logger.debug("Non static exported field {} on non exported interface", exportedName);
 					continue;
 				}
 
@@ -290,7 +290,7 @@ public class Inject
 				apiMethod = findImportMethodOnApi(targetApiClass, exportedName, false);
 				if (apiMethod == null)
 				{
-					logger.info("Unable to find import method on api class {} with imported name {}, not injecting getter", targetApiClass, exportedName);
+					logger.debug("Unable to find import method on api class {} with imported name {}, not injecting getter", targetApiClass, exportedName);
 					continue;
 				}
 
@@ -343,7 +343,7 @@ public class Inject
 		}
 		catch (ClassNotFoundException ex)
 		{
-			logger.info("Class {} implements nonexistent interface {}, skipping interface injection",
+			logger.trace("Class {} implements nonexistent interface {}, skipping interface injection",
 				cf.getName(),
 				ifaceName);
 			return null;

--- a/runescape-client-injector-plugin/src/main/java/net/runelite/injector/InjectHook.java
+++ b/runescape-client-injector-plugin/src/main/java/net/runelite/injector/InjectHook.java
@@ -128,7 +128,7 @@ public class InjectHook
 			String hookName = hookInfo.fieldName;
 			assert hookName != null;
 
-			logger.info("Found injection location for hook {} at instruction {}", hookName, sfi);
+			logger.trace("Found injection location for hook {} at instruction {}", hookName, sfi);
 			++injectedHooks;
 
 			Instruction objectInstruction = new AConstNull(ins);

--- a/runescape-client-injector-plugin/src/main/java/net/runelite/injector/InjectInvoker.java
+++ b/runescape-client-injector-plugin/src/main/java/net/runelite/injector/InjectInvoker.java
@@ -104,14 +104,14 @@ public class InjectInvoker
 			assert !m.isStatic();
 
 			// non static exported method on non exported interface, weird.
-			logger.warn("Non static exported method {} on non exported interface", exportedName);
+			logger.debug("Non static exported method {} on non exported interface", exportedName);
 			return;
 		}
 
 		java.lang.reflect.Method apiMethod = inject.findImportMethodOnApi(targetClassJava, exportedName, null); // api method to invoke 'otherm'
 		if (apiMethod == null)
 		{
-			logger.info("Unable to find api method on {} with imported name {}, not injecting invoker", targetClassJava, exportedName);
+			logger.debug("Unable to find api method on {} with imported name {}, not injecting invoker", targetClassJava, exportedName);
 			return;
 		}
 


### PR DESCRIPTION
These were the most populous, and least helpful, lines in my build log, as I was trying to figure out how I'd managed to upset the injector. As far as I can tell, this information isn't actually important to have at hand for every single build ever.