### PR TITLE
Implement Tile#getClickbox

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/Perspective.java
+++ b/runelite-api/src/main/java/net/runelite/api/Perspective.java
@@ -27,8 +27,16 @@ package net.runelite.api;
 import java.awt.FontMetrics;
 import java.awt.Graphics2D;
 import java.awt.Polygon;
+import java.awt.Rectangle;
+import java.awt.geom.Area;
 import java.awt.geom.Rectangle2D;
 import java.awt.image.BufferedImage;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import net.runelite.api.model.Jarvis;
+import net.runelite.api.model.Triangle;
+import net.runelite.api.model.Vertex;
 
 public class Perspective
 {
@@ -79,9 +87,54 @@ public class Perspective
 	 */
 	public static Point worldToCanvas(Client client, int x, int y, int plane, int zOffset)
 	{
+		return worldToCanvas(client, x, y, plane, x, y, zOffset);
+	}
+
+	/**
+	 * Translates two-dimensional ground coordinates within the 3D world to
+	 * their corresponding coordinates on the game screen. Calculating heights
+	 * based on the coordinates of the tile provided, rather than the world coordinates
+	 *
+	 * Using the position of each vertex, rather than the location of the object, to determine the
+	 * height of each vertex causes the mesh to be vertically warped, based on the terrain below
+	 *
+	 * @param client
+	 * @param x ground coordinate on the x axis
+	 * @param y ground coordinate on the y axis
+	 * @param plane ground plane on the z axis
+	 * @param tileX the X coordinate of the tile the object is on
+	 * @param tileY the Y coordinate of the tile the object is on
+	 * @return a {@link Point} on screen corresponding to the position in
+	 * 3D-space
+	 */
+	public static Point worldToCanvas(Client client, int x, int y, int plane, int tileX, int tileY)
+	{
+		return worldToCanvas(client, x, y, plane, tileX, tileY, 0);
+	}
+
+	/**
+	 * Translates two-dimensional ground coordinates within the 3D world to
+	 * their corresponding coordinates on the game screen. Calculating heights
+	 * based on the coordinates of the tile provided, rather than the world coordinates
+	 *
+	 * Using the position of each vertex, rather than the location of the object, to determine the
+	 * height of each vertex causes the mesh to be vertically warped, based on the terrain below
+	 *
+	 * @param client
+	 * @param x ground coordinate on the x axis
+	 * @param y ground coordinate on the y axis
+	 * @param plane ground plane on the z axis
+	 * @param tileX the X coordinate of the tile the object is on
+	 * @param tileY the Y coordinate of the tile the object is on
+	 * @param zOffset distance from ground on the z axis
+	 * @return a {@link Point} on screen corresponding to the position in
+	 * 3D-space
+	 */
+	public static Point worldToCanvas(Client client, int x, int y, int plane, int tileX, int tileY, int zOffset)
+	{
 		if (x >= 128 && y >= 128 && x <= 13056 && y <= 13056)
 		{
-			int z = getTileHeight(client, x, y, client.getPlane()) - plane;
+			int z = getTileHeight(client, tileX, tileY, client.getPlane()) - plane;
 			x -= client.getCameraX();
 			y -= client.getCameraY();
 			z -= client.getCameraZ();
@@ -377,6 +430,212 @@ public class Perspective
 		int yOffset = p.getY() - sprite.getHeight() / 2;
 
 		return new Point(xOffset, yOffset);
+	}
+
+	/**
+	 * You don't want this. Use {@link TileObject#getClickbox(Client)} instead
+	 *
+	 * Get the on-screen clickable area of {@code model} as though it's for the object on the tile at
+	 * 	({@code tileX}, {@code tileY}) and rotated to angle {@code orientation}
+	 *
+	 * @param client
+	 * @param model the model to calculate a clickbox for
+	 * @param orientation the orientation of the model (0-2048, where 0 is north)
+	 * @param tileX the X coordinate of the tile that the object using the model is on
+	 * @param tileY the Y coordinate of the tile that the object using the model is on
+	 * @return the clickable area of {@code model}, rotated to angle {@code orientation}, at the height of tile ({@code tileX}, {@code tileY})
+	 */
+	public static Area getClickbox(Client client, Model model, int orientation, int tileX, int tileY)
+	{
+		if (model == null)
+		{
+			return null;
+		}
+
+		List<Triangle> triangles = model.getTriangles().stream().map(triangle ->
+				new Triangle(
+						triangle.getA().rotate(orientation),
+						triangle.getB().rotate(orientation),
+						triangle.getC().rotate(orientation)
+				)).collect(Collectors.toList());
+
+		List<Vertex> vertices = model.getVertices().stream()
+				.map(v -> v.rotate(orientation))
+				.collect(Collectors.toList());
+
+		Area clickBox = get2DGeometry(client, triangles, orientation, tileX, tileY);
+		Area visibleAABB = getAABB(client, vertices, orientation, tileX, tileY);
+
+		if (visibleAABB == null || clickBox == null)
+		{
+			return null;
+		}
+
+		clickBox.intersect(visibleAABB);
+		return clickBox;
+	}
+
+	private static Area get2DGeometry(Client client, List<Triangle> triangles, int orientation, int tileX, int tileY)
+	{
+		int radius = 5;
+		Area geometry = new Area();
+
+		for (Triangle triangle : triangles)
+		{
+			Vertex _a = triangle.getA();
+			Point a = worldToCanvas(client,
+					tileX - _a.getX(),
+					tileY - _a.getZ(),
+					-_a.getY(), tileX, tileY);
+			if (a == null) continue;
+			Vertex _b = triangle.getB();
+			Point b = worldToCanvas(client,
+					tileX - _b.getX(),
+					tileY - _b.getZ(),
+					-_b.getY(), tileX, tileY);
+			if (b == null) continue;
+			Vertex _c = triangle.getC();
+			Point c = worldToCanvas(client,
+					tileX - _c.getX(),
+					tileY - _c.getZ(),
+					-_c.getY(), tileX, tileY);
+			if (c == null) continue;
+
+			int minX = Math.min(Math.min(a.getX(), b.getX()), c.getX());
+			int minY = Math.min(Math.min(a.getY(), b.getY()), c.getY());
+
+			// For some reason, this calculation is always 4 pixels short of the actual in-client one
+			int maxX = Math.max(Math.max(a.getX(), b.getX()), c.getX()) + 4;
+			int maxY = Math.max(Math.max(a.getY(), b.getY()), c.getY()) + 4;
+
+			// ...and the rectangles in the fixed client are shifted 4 pixels right and down
+			if (!client.isResized())
+			{
+				minX += 4;
+				minY += 4;
+				maxX += 4;
+				maxY += 4;
+			}
+
+			Rectangle clickableRect = new Rectangle(
+					minX - radius, minY - radius,
+					maxX - minX + radius, maxY - minY + radius
+			);
+			geometry.add(new Area(clickableRect));
+		}
+
+		return geometry;
+
+	}
+
+	private static Area getAABB(Client client, List<Vertex> vertices, int orientation, int tileX, int tileY)
+	{
+		int maxX = 0;
+		int minX = 0;
+		int maxY = 0;
+		int minY = 0;
+		int maxZ = 0;
+		int minZ = 0;
+
+		for (Vertex vertex : vertices)
+		{
+			int x = vertex.getX();
+			int y = vertex.getY();
+			int z = vertex.getZ();
+
+			if (x > maxX)
+			{
+				maxX = x;
+			}
+			if (x < minX)
+			{
+				minX = x;
+			}
+
+			if (y > maxY)
+			{
+				maxY = y;
+			}
+			if (y < minY)
+			{
+				minY = y;
+			}
+
+			if (z > maxZ)
+			{
+				maxZ = z;
+			}
+			if (z < minZ)
+			{
+				minZ = z;
+			}
+		}
+
+		int centerX = (minX + maxX) / 2;
+		int centerY = (minY + maxY) / 2;
+		int centerZ = (minZ + maxZ) / 2;
+
+		int extremeX = (maxX - minX + 1) / 2;
+		int extremeY = (maxY - minY + 1) / 2;
+		int extremeZ = (maxZ - minZ + 1) / 2;
+
+		if (extremeX < 32)
+		{
+			extremeX = 32;
+		}
+
+		if (extremeZ < 32)
+		{
+			extremeZ = 32;
+		}
+
+		int x1 = tileX - (centerX - extremeX);
+		int y1 = centerY - extremeY;
+		int z1 = tileY - (centerZ - extremeZ);
+
+		int x2 = tileX - (centerX + extremeX);
+		int y2 = centerY + extremeY;
+		int z2 = tileY - (centerZ + extremeZ);
+
+		Point p1 = worldToCanvas(client, x1, z1, -y1, tileX, tileY);
+		Point p2 = worldToCanvas(client, x1, z2, -y1, tileX, tileY);
+		Point p3 = worldToCanvas(client, x2, z2, -y1, tileX, tileY);
+
+		Point p4 = worldToCanvas(client, x2, z1, -y1, tileX, tileY);
+		Point p5 = worldToCanvas(client, x1, z1, -y2, tileX, tileY);
+		Point p6 = worldToCanvas(client, x1, z2, -y2, tileX, tileY);
+		Point p7 = worldToCanvas(client, x2, z2, -y2, tileX, tileY);
+		Point p8 = worldToCanvas(client, x2, z1, -y2, tileX, tileY);
+
+		List<Point> points = new ArrayList<>();
+		points.add(p1); points.add(p2); points.add(p3); points.add(p4);
+		points.add(p5); points.add(p6); points.add(p7); points.add(p8);
+
+		try
+		{
+			points = Jarvis.convexHull(points);
+		}
+		catch (NullPointerException e)
+		{
+			// No non-null screen points for this AABB e.g. for an way off-screen model
+			return null;
+		}
+
+		if (points == null)
+		{
+			return null;
+		}
+
+		Polygon hull = new Polygon();
+		for (Point p : points)
+		{
+			if (p != null)
+			{
+				hull.addPoint(p.getX(), p.getY());
+			}
+		}
+
+		return  new Area(hull);
 	}
 
 }

--- a/runelite-api/src/main/java/net/runelite/api/TileObject.java
+++ b/runelite-api/src/main/java/net/runelite/api/TileObject.java
@@ -26,6 +26,7 @@ package net.runelite.api;
 
 import java.awt.Graphics2D;
 import java.awt.Polygon;
+import java.awt.geom.Area;
 
 public interface TileObject
 {
@@ -54,4 +55,12 @@ public interface TileObject
 	Point getMinimapLocation();
 
 	Polygon getConvexHull(Model model, int orientation);
+
+	/**
+	 * Get the on-screen clickable area of {@code object}
+	 *
+	 * @param client
+	 * @return the clickable area of {@code object}
+	 */
+	Area getClickbox(Client client);
 }

--- a/runelite-api/src/main/java/net/runelite/api/model/Triangle.java
+++ b/runelite-api/src/main/java/net/runelite/api/model/Triangle.java
@@ -24,8 +24,9 @@
  */
 package net.runelite.api.model;
 
-import java.util.Objects;
+import lombok.Data;
 
+@Data
 public class Triangle
 {
 	private final Vertex a;
@@ -39,61 +40,4 @@ public class Triangle
 		this.c = c;
 	}
 
-	@Override
-	public String toString()
-	{
-		return "Triangle{" + "a=" + a + ", b=" + b + ", c=" + c + '}';
-	}
-
-	@Override
-	public int hashCode()
-	{
-		int hash = 7;
-		hash = 13 * hash + Objects.hashCode(this.a);
-		hash = 13 * hash + Objects.hashCode(this.b);
-		hash = 13 * hash + Objects.hashCode(this.c);
-		return hash;
-	}
-
-	@Override
-	public boolean equals(Object obj)
-	{
-		if (obj == null)
-		{
-			return false;
-		}
-		if (getClass() != obj.getClass())
-		{
-			return false;
-		}
-		final Triangle other = (Triangle) obj;
-		if (!Objects.equals(this.a, other.a))
-		{
-			return false;
-		}
-		if (!Objects.equals(this.b, other.b))
-		{
-			return false;
-		}
-		if (!Objects.equals(this.c, other.c))
-		{
-			return false;
-		}
-		return true;
-	}
-
-	public Vertex getA()
-	{
-		return a;
-	}
-
-	public Vertex getB()
-	{
-		return b;
-	}
-
-	public Vertex getC()
-	{
-		return c;
-	}
 }

--- a/runelite-api/src/main/java/net/runelite/api/model/Vertex.java
+++ b/runelite-api/src/main/java/net/runelite/api/model/Vertex.java
@@ -48,6 +48,14 @@ public class Vertex
 	 */
 	public Vertex rotate(int orientation)
 	{
+		// models are orientated north (1024) and there are 2048 angles total
+		orientation = (orientation + 1024) % 2048;
+
+		if (orientation == 0)
+		{
+			return this;
+		}
+
 		int sin = Perspective.SINE[orientation];
 		int cos = Perspective.COSINE[orientation];
 

--- a/runelite-api/src/main/java/net/runelite/api/model/Vertex.java
+++ b/runelite-api/src/main/java/net/runelite/api/model/Vertex.java
@@ -24,8 +24,10 @@
  */
 package net.runelite.api.model;
 
+import lombok.Data;
 import net.runelite.api.Perspective;
 
+@Data
 public class Vertex
 {
 	private final int x;
@@ -37,64 +39,6 @@ public class Vertex
 		this.x = x;
 		this.y = y;
 		this.z = z;
-	}
-
-	@Override
-	public String toString()
-	{
-		return "Vertex{" + "x=" + x + ", y=" + y + ", z=" + z + '}';
-	}
-
-	@Override
-	public int hashCode()
-	{
-		int hash = 7;
-		hash = 67 * hash + this.x;
-		hash = 67 * hash + this.y;
-		hash = 67 * hash + this.z;
-		return hash;
-	}
-
-	@Override
-	public boolean equals(Object obj)
-	{
-		if (obj == null)
-		{
-			return false;
-		}
-		if (getClass() != obj.getClass())
-		{
-			return false;
-		}
-		final Vertex other = (Vertex) obj;
-		if (this.x != other.x)
-		{
-			return false;
-		}
-		if (this.y != other.y)
-		{
-			return false;
-		}
-		if (this.z != other.z)
-		{
-			return false;
-		}
-		return true;
-	}
-
-	public int getX()
-	{
-		return x;
-	}
-
-	public int getY()
-	{
-		return y;
-	}
-
-	public int getZ()
-	{
-		return z;
 	}
 
 	/**

--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSGameObjectMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSGameObjectMixin.java
@@ -25,7 +25,10 @@
 package net.runelite.mixins;
 
 import java.awt.Polygon;
+import java.awt.geom.Area;
+import net.runelite.api.Client;
 import net.runelite.api.Model;
+import net.runelite.api.Perspective;
 import net.runelite.api.Point;
 import net.runelite.api.Renderable;
 import net.runelite.api.mixins.Inject;
@@ -50,8 +53,7 @@ public abstract class RSGameObjectMixin implements RSGameObject
 	}
 
 	@Inject
-	@Override
-	public Polygon getConvexHull()
+	private Model getModel()
 	{
 		Renderable renderable = getRenderable();
 		if (renderable == null)
@@ -59,16 +61,28 @@ public abstract class RSGameObjectMixin implements RSGameObject
 			return null;
 		}
 
-		Model model;
-
 		if (renderable instanceof Model)
 		{
-			model = (Model) renderable;
+			return (Model) renderable;
 		}
 		else
 		{
-			model = renderable.getModel();
+			return renderable.getModel();
 		}
+	}
+
+	@Inject
+	@Override
+	public Area getClickbox(Client client)
+	{
+		return Perspective.getClickbox(client, getModel(), getOrientation(), getX(), getY());
+	}
+
+	@Inject
+	@Override
+	public Polygon getConvexHull()
+	{
+		Model model = getModel();
 
 		if (model == null)
 		{

--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSGroundObjectMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSGroundObjectMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017, Adam <Adam@sigterm.info>
+ * Copyright (c) 2018, SomeoneWithAnInternetConnection
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -22,9 +22,9 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+
 package net.runelite.mixins;
 
-import java.awt.Polygon;
 import java.awt.geom.Area;
 import net.runelite.api.Client;
 import net.runelite.api.Model;
@@ -32,10 +32,10 @@ import net.runelite.api.Perspective;
 import net.runelite.api.Renderable;
 import net.runelite.api.mixins.Inject;
 import net.runelite.api.mixins.Mixin;
-import net.runelite.rs.api.RSDecorativeObject;
+import net.runelite.rs.api.RSGroundObject;
 
-@Mixin(RSDecorativeObject.class)
-public abstract class RSDecorativeObjectMixin implements RSDecorativeObject
+@Mixin(RSGroundObject.class)
+public abstract class RSGroundObjectMixin implements RSGroundObject
 {
 	@Inject
 	private Model getModel()
@@ -46,40 +46,20 @@ public abstract class RSDecorativeObjectMixin implements RSDecorativeObject
 			return null;
 		}
 
-		Model model;
-
 		if (renderable instanceof Model)
 		{
-			model = (Model) renderable;
+			return (Model) renderable;
 		}
 		else
 		{
-			model = renderable.getModel();
+			return renderable.getModel();
 		}
-
-		return model;
 	}
 
 	@Inject
 	@Override
 	public Area getClickbox(Client client)
 	{
-		return Perspective.getClickbox(client, getModel(), getOrientation(), getX(), getY());
-	}
-
-	@Inject
-	@Override
-	public Polygon getConvexHull()
-	{
-
-
-		Model model = getModel();
-
-		if (model == null)
-		{
-			return null;
-		}
-
-		return getConvexHull(model, getOrientation());
+		return Perspective.getClickbox(client, getModel(), 0, getX(), getY());
 	}
 }

--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSItemLayerMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSItemLayerMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017, Adam <Adam@sigterm.info>
+ * Copyright (c) 2018, SomeoneWithAnInternetConnection
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -24,62 +24,22 @@
  */
 package net.runelite.mixins;
 
-import java.awt.Polygon;
 import java.awt.geom.Area;
 import net.runelite.api.Client;
-import net.runelite.api.Model;
-import net.runelite.api.Perspective;
-import net.runelite.api.Renderable;
 import net.runelite.api.mixins.Inject;
 import net.runelite.api.mixins.Mixin;
-import net.runelite.rs.api.RSDecorativeObject;
+import net.runelite.rs.api.RSItemLayer;
+import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 
-@Mixin(RSDecorativeObject.class)
-public abstract class RSDecorativeObjectMixin implements RSDecorativeObject
+@Mixin(RSItemLayer.class)
+public abstract class RSItemLayerMixin implements RSItemLayer
 {
-	@Inject
-	private Model getModel()
-	{
-		Renderable renderable = getRenderable();
-		if (renderable == null)
-		{
-			return null;
-		}
-
-		Model model;
-
-		if (renderable instanceof Model)
-		{
-			model = (Model) renderable;
-		}
-		else
-		{
-			model = renderable.getModel();
-		}
-
-		return model;
-	}
 
 	@Inject
 	@Override
 	public Area getClickbox(Client client)
 	{
-		return Perspective.getClickbox(client, getModel(), getOrientation(), getX(), getY());
+		throw new NotImplementedException();
 	}
 
-	@Inject
-	@Override
-	public Polygon getConvexHull()
-	{
-
-
-		Model model = getModel();
-
-		if (model == null)
-		{
-			return null;
-		}
-
-		return getConvexHull(model, getOrientation());
-	}
 }

--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSPlayerMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSPlayerMixin.java
@@ -72,15 +72,11 @@ public abstract class RSPlayerMixin implements RSPlayer
 		int localX = getX();
 		int localY = getY();
 
-		// models are orientated north (1024) and there are 2048 angles total
-		int orientation = (getOrientation() + 1024) % 2048;
+		int orientation = getOrientation();
 
 		List<Triangle> triangles = model.getTriangles();
 
-		if (orientation != 0)
-		{
-			triangles = rotate(triangles, orientation);
-		}
+		triangles = rotate(triangles, orientation);
 
 		List<Polygon> polys = new ArrayList<Polygon>();
 		for (Triangle triangle : triangles)

--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSWallObjectMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSWallObjectMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017, Adam <Adam@sigterm.info>
+ * Copyright (c) 2018, SomeoneWithAnInternetConnection
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -22,9 +22,9 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+
 package net.runelite.mixins;
 
-import java.awt.Polygon;
 import java.awt.geom.Area;
 import net.runelite.api.Client;
 import net.runelite.api.Model;
@@ -32,54 +32,73 @@ import net.runelite.api.Perspective;
 import net.runelite.api.Renderable;
 import net.runelite.api.mixins.Inject;
 import net.runelite.api.mixins.Mixin;
-import net.runelite.rs.api.RSDecorativeObject;
+import net.runelite.rs.api.RSWallObject;
 
-@Mixin(RSDecorativeObject.class)
-public abstract class RSDecorativeObjectMixin implements RSDecorativeObject
+@Mixin(RSWallObject.class)
+public abstract class RSWallObjectMixin implements RSWallObject
 {
 	@Inject
-	private Model getModel()
+	private Model getModelA()
 	{
-		Renderable renderable = getRenderable();
+		Renderable renderable = getRenderable1();
 		if (renderable == null)
 		{
 			return null;
 		}
 
-		Model model;
-
 		if (renderable instanceof Model)
 		{
-			model = (Model) renderable;
+			return (Model) renderable;
 		}
 		else
 		{
-			model = renderable.getModel();
+			return renderable.getModel();
+		}
+	}
+
+	@Inject
+	private Model getModelB()
+	{
+		Renderable renderable = getRenderable2();
+		if (renderable == null)
+		{
+			return null;
 		}
 
-		return model;
+		if (renderable instanceof Model)
+		{
+			return (Model) renderable;
+		}
+		else
+		{
+			return renderable.getModel();
+		}
 	}
 
 	@Inject
 	@Override
 	public Area getClickbox(Client client)
 	{
-		return Perspective.getClickbox(client, getModel(), getOrientation(), getX(), getY());
-	}
+		Area clickbox = new Area();
 
-	@Inject
-	@Override
-	public Polygon getConvexHull()
-	{
+		Area clickboxA = Perspective.getClickbox(client, getModelA(), getOrientationA(), getX(), getY());
+		Area clickboxB = Perspective.getClickbox(client, getModelB(), getOrientationB(), getX(), getY());
 
-
-		Model model = getModel();
-
-		if (model == null)
+		if (clickboxA == null && clickboxB == null)
 		{
 			return null;
 		}
 
-		return getConvexHull(model, getOrientation());
+		if (clickboxA != null)
+		{
+			clickbox.add(clickboxA);
+		}
+
+		if (clickboxB != null)
+		{
+			clickbox.add(clickboxB);
+		}
+
+		return clickbox;
 	}
 }

--- a/runelite-mixins/src/main/java/net/runelite/mixins/TileObjectMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/TileObjectMixin.java
@@ -132,19 +132,13 @@ public abstract class TileObjectMixin implements TileObject
 		int localX = getX();
 		int localY = getY();
 
-		// models are orientated north (1024) and there are 2048 angles total
-		orientation = (orientation + 1024) % 2048;
-
 		List<Vertex> vertices = model.getVertices();
 
-		if (orientation != 0)
+		// rotate vertices
+		for (int i = 0; i < vertices.size(); ++i)
 		{
-			// rotate vertices
-			for (int i = 0; i < vertices.size(); ++i)
-			{
-				Vertex v = vertices.get(i);
-				vertices.set(i, v.rotate(orientation));
-			}
+			Vertex v = vertices.get(i);
+			vertices.set(i, v.rotate(orientation));
 		}
 
 		List<Point> points = new ArrayList<Point>();

--- a/runescape-api/src/main/java/net/runelite/rs/api/RSGroundObject.java
+++ b/runescape-api/src/main/java/net/runelite/rs/api/RSGroundObject.java
@@ -25,6 +25,7 @@
 package net.runelite.rs.api;
 
 import net.runelite.api.GroundObject;
+import net.runelite.api.Renderable;
 import net.runelite.mapping.Import;
 
 public interface RSGroundObject extends GroundObject
@@ -38,4 +39,7 @@ public interface RSGroundObject extends GroundObject
 
 	@Import("y")
 	int getY();
+
+	@Import("renderable")
+	Renderable getRenderable();
 }

--- a/runescape-api/src/main/java/net/runelite/rs/api/RSWallObject.java
+++ b/runescape-api/src/main/java/net/runelite/rs/api/RSWallObject.java
@@ -24,6 +24,7 @@
  */
 package net.runelite.rs.api;
 
+import net.runelite.api.Renderable;
 import net.runelite.api.WallObject;
 import net.runelite.mapping.Import;
 
@@ -48,6 +49,12 @@ public interface RSWallObject extends WallObject
 	@Import("orientationB")
 	@Override
 	int getOrientationB();
+
+	@Import("renderable1")
+	Renderable getRenderable1();
+
+	@Import("renderable2")
+	Renderable getRenderable2();
 
 	@Import("config")
 	@Override

--- a/runescape-client/src/main/java/BoundingBox3D.java
+++ b/runescape-client/src/main/java/BoundingBox3D.java
@@ -68,12 +68,12 @@ public final class BoundingBox3D extends BoundingBox {
       signature = "(Len;IIII)V"
    )
    public BoundingBox3D(Model var1, int var2, int var3, int var4, int var5) {
-      this.int1 = var2 + var1.field1843 - var1.field1834;
-      this.int2 = var3 + var1.field1832 - var1.field1803;
-      this.int3 = var4 + var1.field1833 - var1.field1836;
-      this.int4 = var2 + var1.field1834 + var1.field1843;
-      this.int5 = var3 + var1.field1803 + var1.field1832;
-      this.int6 = var4 + var1.field1836 + var1.field1833;
+      this.int1 = var2 + var1.centerX - var1.extremeX;
+      this.int2 = var3 + var1.centerY - var1.extremeY;
+      this.int3 = var4 + var1.centerZ - var1.extremeZ;
+      this.int4 = var2 + var1.extremeX + var1.centerX;
+      this.int5 = var3 + var1.extremeY + var1.centerY;
+      this.int6 = var4 + var1.extremeZ + var1.centerZ;
       this.color = var5;
    }
 

--- a/runescape-client/src/main/java/Model.java
+++ b/runescape-client/src/main/java/Model.java
@@ -149,17 +149,23 @@ public class Model extends Renderable {
    @Export("radius")
    int radius;
    @ObfuscatedName("ae")
-   public int field1843;
+   @Export("centerX")
+   public int centerX;
    @ObfuscatedName("ah")
-   public int field1832;
+   @Export("centerY")
+   public int centerY;
    @ObfuscatedName("ai")
-   public int field1833;
+   @Export("centerZ")
+   public int centerZ;
    @ObfuscatedName("au")
-   public int field1834;
+   @Export("extremeX")
+   public int extremeX;
    @ObfuscatedName("am")
-   public int field1803;
+   @Export("extremeY")
+   public int extremeY;
    @ObfuscatedName("af")
-   public int field1836;
+   @Export("extremeZ")
+   public int extremeZ;
 
    static {
       field1840 = new Model();
@@ -197,9 +203,9 @@ public class Model extends Renderable {
       this.field1811 = 0;
       this.field1819 = 0;
       this.field1825 = false;
-      this.field1834 = -1;
-      this.field1803 = -1;
-      this.field1836 = -1;
+      this.extremeX = -1;
+      this.extremeY = -1;
+      this.extremeZ = -1;
    }
 
    @ObfuscatedSignature(
@@ -211,9 +217,9 @@ public class Model extends Renderable {
       this.field1811 = 0;
       this.field1819 = 0;
       this.field1825 = false;
-      this.field1834 = -1;
-      this.field1803 = -1;
-      this.field1836 = -1;
+      this.extremeX = -1;
+      this.extremeY = -1;
+      this.extremeZ = -1;
       boolean var3 = false;
       boolean var4 = false;
       boolean var5 = false;
@@ -523,7 +529,7 @@ public class Model extends Renderable {
 
    @ObfuscatedName("j")
    void method2659(int var1) {
-      if(this.field1834 == -1) {
+      if(this.extremeX == -1) {
          int var2 = 0;
          int var3 = 0;
          int var4 = 0;
@@ -562,23 +568,23 @@ public class Model extends Renderable {
             }
          }
 
-         this.field1843 = (var5 + var2) / 2;
-         this.field1832 = (var6 + var3) / 2;
-         this.field1833 = (var7 + var4) / 2;
-         this.field1834 = (var5 - var2 + 1) / 2;
-         this.field1803 = (var6 - var3 + 1) / 2;
-         this.field1836 = (var7 - var4 + 1) / 2;
-         if(this.field1834 < 32) {
-            this.field1834 = 32;
+         this.centerX = (var5 + var2) / 2;
+         this.centerY = (var6 + var3) / 2;
+         this.centerZ = (var7 + var4) / 2;
+         this.extremeX = (var5 - var2 + 1) / 2;
+         this.extremeY = (var6 - var3 + 1) / 2;
+         this.extremeZ = (var7 - var4 + 1) / 2;
+         if(this.extremeX < 32) {
+            this.extremeX = 32;
          }
 
-         if(this.field1836 < 32) {
-            this.field1836 = 32;
+         if(this.extremeZ < 32) {
+            this.extremeZ = 32;
          }
 
          if(this.field1825) {
-            this.field1834 += 8;
-            this.field1836 += 8;
+            this.extremeX += 8;
+            this.extremeZ += 8;
          }
 
       }
@@ -649,7 +655,7 @@ public class Model extends Renderable {
    @Export("resetBounds")
    void resetBounds() {
       this.boundsType = 0;
-      this.field1834 = -1;
+      this.extremeX = -1;
    }
 
    @ObfuscatedName("o")

--- a/runescape-client/src/main/java/UnitPriceComparator.java
+++ b/runescape-client/src/main/java/UnitPriceComparator.java
@@ -80,12 +80,12 @@ final class UnitPriceComparator implements Comparator {
             GrandExchangeEvents.field264 = Math.abs(CombatInfoListHolder.field1254);
          }
 
-         var5 = var0.field1843 + var1;
-         var6 = var2 + var0.field1832;
-         var7 = var3 + var0.field1833;
-         var8 = var0.field1834;
-         var16 = var0.field1803;
-         var17 = var0.field1836;
+         var5 = var0.centerX + var1;
+         var6 = var2 + var0.centerY;
+         var7 = var3 + var0.centerZ;
+         var8 = var0.extremeX;
+         var16 = var0.extremeY;
+         var17 = var0.extremeZ;
          var11 = class131.field1873 - var5;
          var12 = class300.field3825 - var6;
          var13 = class63.field718 - var7;


### PR DESCRIPTION
This new method returns a `java.awt.geom.Area` corresponding to the clickable area of the tileobject. It's not currently implemented for ItemLayers

The two big issues I see with this change currently are that:
* It appears to be a bit frame hungry, it looks like get2DGeometry is the culprit. There's probably a better way to do the rectangle unioning that's going on in there, but I figured relying on existing APIs was better than writing my own.
* `getClickbox(Client client, Model model, int orientation, int tileX, int tileY)` doesn't need to be available to everything using runelite-api. I just couldn't see anywhere to actually put it.  Since TileObjects are something that's made up by `runelite-api`, and not something that the other fooObjects extend, the code can't go into the TileObjectMixin, and there doesn't seem to be anywhere to stick a utility class so that it would only be visible to the code in the mixins.
