### PR TITLE
Fix NullPointerExceptions from Boosts Plugin

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/boosts/BoostsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/boosts/BoostsOverlay.java
@@ -47,6 +47,7 @@ import net.runelite.client.ui.overlay.infobox.InfoBoxManager;
 class BoostsOverlay extends Overlay
 {
 	private final BufferedImage[] imgCache = new BufferedImage[Skill.values().length - 1];
+
 	@Getter
 	private final BoostIndicator[] indicators = new BoostIndicator[Skill.values().length - 1];
 
@@ -56,6 +57,7 @@ class BoostsOverlay extends Overlay
 
 	@Inject
 	private BoostsPlugin plugin;
+
 	private PanelComponent panelComponent;
 
 	@Inject

--- a/runelite-client/src/main/java/net/runelite/client/plugins/boosts/BoostsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/boosts/BoostsPlugin.java
@@ -84,6 +84,15 @@ public class BoostsPlugin extends Plugin
 		return boostsOverlay;
 	}
 
+	@Override
+	protected void startUp()
+	{
+		if (config.enabled())
+		{
+			updateShownSkills(config.enableSkill());
+		}
+	}
+
 	@Subscribe
 	public void onConfigChanged(ConfigChanged event)
 	{
@@ -92,14 +101,7 @@ public class BoostsPlugin extends Plugin
 			return;
 		}
 
-		if (config.enableSkill())
-		{
-			shownSkills = ObjectArrays.concat(COMBAT, SKILLING, Skill.class);
-		}
-		else
-		{
-			shownSkills = COMBAT;
-		}
+		updateShownSkills(config.enableSkill());
 
 		if (event.getKey().equals("displayIndicators"))
 		{
@@ -119,6 +121,18 @@ public class BoostsPlugin extends Plugin
 					infoBoxManager.removeInfoBox(indicator);
 				}
 			}
+		}
+	}
+
+	private void updateShownSkills(boolean showSkillingSkills)
+	{
+		if (showSkillingSkills)
+		{
+			shownSkills = ObjectArrays.concat(COMBAT, SKILLING, Skill.class);
+		}
+		else
+		{
+			shownSkills = COMBAT;
 		}
 	}
 }


### PR DESCRIPTION
`shownSkills` wasn't being initialized until it received `ConfigChanged` event, causing a `NullPointerException` when the overlay tried to iterate over `shownSkills`