### PR TITLE
Fix MLM plugin overlay layer

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/motherlode/MotherlodeSackOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/motherlode/MotherlodeSackOverlay.java
@@ -34,7 +34,6 @@ import net.runelite.api.Varbits;
 import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.ui.overlay.Overlay;
-import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.components.PanelComponent;
 
@@ -48,7 +47,6 @@ class MotherlodeSackOverlay extends Overlay
 	MotherlodeSackOverlay(Client client, MotherlodeConfig config)
 	{
 		setPosition(OverlayPosition.TOP_LEFT);
-		setLayer(OverlayLayer.ABOVE_SCENE);
 		this.client = client;
 		this.config = config;
 	}


### PR DESCRIPTION
Currently MLM plugin sack overlay layer is set to ABOVE_SCENE, but it
needs to be set to UNDER_WIDGETS so overlay renderer can tile it
correctly with other overlays (and also to be rendered over overheads
and HP bars).

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>