### PR TITLE
Add option to overlay non-clanmate players with Player Indicator Overlay

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsConfig.java
@@ -66,6 +66,16 @@ public interface PlayerIndicatorsConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "drawNonClanMemberNames",
+		name = "Draw non-clan member names",
+		description = "Configures whether or not names of non-clan members should be drawn"
+	)
+	default boolean drawNonClanMemberNames()
+	{
+		return false;
+	}
+
+	@ConfigItem(
 		keyName = "drawPlayerTiles",
 		name = "Draw tiles",
 		description = "Configures whether or not tiles under players with rendered names should be drawn"

--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsOverlay.java
@@ -43,6 +43,8 @@ public class PlayerIndicatorsOverlay extends Overlay
 	private static final Color CYAN = new Color(0, 184, 212);
 	private static final Color GREEN = new Color(0, 200, 83);
 	private static final Color PURPLE = new Color(170, 0, 255);
+	private static final Color RED = new Color(255, 0, 0);
+
 	private final Client client;
 	private final PlayerIndicatorsConfig config;
 
@@ -57,7 +59,8 @@ public class PlayerIndicatorsOverlay extends Overlay
 	@Override
 	public Dimension render(Graphics2D graphics, Point parent)
 	{
-		if (!config.drawOwnName() && !config.drawClanMemberNames() && !config.drawFriendNames())
+		if (!config.drawOwnName() && !config.drawClanMemberNames() &&
+			!config.drawFriendNames() && !config.drawNonClanMemberNames())
 		{
 			return null;
 		}
@@ -85,6 +88,10 @@ public class PlayerIndicatorsOverlay extends Overlay
 			else if (config.drawClanMemberNames() && client.isClanMember(name))
 			{
 				renderPlayerOverlay(graphics, player, PURPLE);
+			}
+			else if (config.drawNonClanMemberNames() && !client.isClanMember(name))
+			{
+				renderPlayerOverlay(graphics, player, RED);
 			}
 		}
 


### PR DESCRIPTION
Addresses top feature request made in #512.

The issue requests the ability to overlay RSNs for players outside of the user's clan chat. Instead of making a blanket option to overlay all players with specific exceptions, this PR adds an option to highlight non-clan members specifically. If the user wants to see all clan and non-clan members, they can enable both options.