### PR TITLE
Low memory mode audio fix

### DIFF
--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSClientMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSClientMixin.java
@@ -396,7 +396,7 @@ public abstract class RSClientMixin implements RSClient
 	{
 		setLowMemory(lowMemory);
 		setRegionLowMemory(lowMemory);
-		setHighMemory(!lowMemory);
+		setHighMemory(true);
 		setOcLowDetail(lowMemory);
 	}
 

--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSClientMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSClientMixin.java
@@ -396,7 +396,7 @@ public abstract class RSClientMixin implements RSClient
 	{
 		setLowMemory(lowMemory);
 		setRegionLowMemory(lowMemory);
-		setHighMemory(true);
+		setAudioHighMemory(true);
 		setOcLowDetail(lowMemory);
 	}
 

--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSClientMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSClientMixin.java
@@ -397,7 +397,7 @@ public abstract class RSClientMixin implements RSClient
 		setLowMemory(lowMemory);
 		setRegionLowMemory(lowMemory);
 		setAudioHighMemory(true);
-		setOcLowDetail(lowMemory);
+		setObjectCompositionLowDetail(lowMemory);
 	}
 
 	@Inject

--- a/runescape-api/src/main/java/net/runelite/rs/api/RSClient.java
+++ b/runescape-api/src/main/java/net/runelite/rs/api/RSClient.java
@@ -407,8 +407,8 @@ public interface RSClient extends RSGameEngine, Client
 	@Import("regionLowMemory")
 	void setRegionLowMemory(boolean lowMemory);
 
-	@Import("highMemory")
-	void setHighMemory(boolean highMemory);
+	@Import("audioHighMemory")
+	void setAudioHighMemory(boolean highMemory);
 
 	@Import("ocLowDetail")
 	void setOcLowDetail(boolean lowDetail);

--- a/runescape-api/src/main/java/net/runelite/rs/api/RSClient.java
+++ b/runescape-api/src/main/java/net/runelite/rs/api/RSClient.java
@@ -410,8 +410,8 @@ public interface RSClient extends RSGameEngine, Client
 	@Import("audioHighMemory")
 	void setAudioHighMemory(boolean highMemory);
 
-	@Import("ocLowDetail")
-	void setOcLowDetail(boolean lowDetail);
+	@Import("objectCompositionLowDetail")
+	void setObjectCompositionLowDetail(boolean lowDetail);
 
 	@Construct
 	RSItem createItem();

--- a/runescape-client/src/main/java/AbstractSoundSystem.java
+++ b/runescape-client/src/main/java/AbstractSoundSystem.java
@@ -329,7 +329,7 @@ public class AbstractSoundSystem {
    @ObfuscatedName("ar")
    final void method2188(int[] var1, int var2) {
       int var3 = var2;
-      if(BoundingBox3DDrawMode.highMemory) {
+      if(BoundingBox3DDrawMode.audioHighMemory) {
          var3 = var2 << 1;
       }
 

--- a/runescape-client/src/main/java/BoundingBox3DDrawMode.java
+++ b/runescape-client/src/main/java/BoundingBox3DDrawMode.java
@@ -21,8 +21,8 @@ public class BoundingBox3DDrawMode {
    @Export("ALWAYS")
    public static final BoundingBox3DDrawMode ALWAYS;
    @ObfuscatedName("a")
-   @Export("highMemory")
-   protected static boolean highMemory;
+   @Export("audioHighMemory")
+   protected static boolean audioHighMemory;
    @ObfuscatedName("aj")
    @ObfuscatedGetter(
       intValue = -1534439537

--- a/runescape-client/src/main/java/Client.java
+++ b/runescape-client/src/main/java/Client.java
@@ -6194,7 +6194,7 @@ public final class Client extends GameEngine implements class277 {
 
          try {
             AbstractSoundSystem var3 = DecorativeObject.soundTaskDataProvider.taskData();
-            var3.samples = new int[(BoundingBox3DDrawMode.highMemory?2:1) * 256];
+            var3.samples = new int[(BoundingBox3DDrawMode.audioHighMemory ?2:1) * 256];
             var3.field1531 = var2;
             var3.vmethod2190();
             var3.offset = (var2 & -1024) + 1024;

--- a/runescape-client/src/main/java/MouseRecorder.java
+++ b/runescape-client/src/main/java/MouseRecorder.java
@@ -217,7 +217,7 @@ public class MouseRecorder implements Runnable {
                      boolean var24 = Client.lowMemory;
                      SoundTask.objects_ref = var22;
                      ObjectComposition.field3496 = var23;
-                     ObjectComposition.ocLowDetail = var24;
+                     ObjectComposition.objectCompositionLowDetail = var24;
                      RunException.method3090(class293.configsIndex, indexModels);
                      GameObject.method3020(class293.configsIndex);
                      IndexData var5 = class293.configsIndex;

--- a/runescape-client/src/main/java/ObjectComposition.java
+++ b/runescape-client/src/main/java/ObjectComposition.java
@@ -8,8 +8,8 @@ import net.runelite.mapping.ObfuscatedSignature;
 @Implements("ObjectComposition")
 public class ObjectComposition extends CacheableNode {
    @ObfuscatedName("p")
-   @Export("ocLowDetail")
-   public static boolean ocLowDetail;
+   @Export("objectCompositionLowDetail")
+   public static boolean objectCompositionLowDetail;
    @ObfuscatedName("w")
    @ObfuscatedSignature(
       signature = "Lik;"
@@ -250,7 +250,7 @@ public class ObjectComposition extends CacheableNode {
    IterableHashTable params;
 
    static {
-      ocLowDetail = false;
+      objectCompositionLowDetail = false;
       objects = new NodeCache(4096);
       field3498 = new NodeCache(500);
       cachedModels = new NodeCache(30);
@@ -349,7 +349,7 @@ public class ObjectComposition extends CacheableNode {
       if(var2 == 1) {
          var3 = var1.readUnsignedByte();
          if(var3 > 0) {
-            if(this.objectModels != null && !ocLowDetail) {
+            if(this.objectModels != null && !objectCompositionLowDetail) {
                var1.offset += var3 * 3;
             } else {
                this.objectTypes = new int[var3];
@@ -366,7 +366,7 @@ public class ObjectComposition extends CacheableNode {
       } else if(var2 == 5) {
          var3 = var1.readUnsignedByte();
          if(var3 > 0) {
-            if(this.objectModels != null && !ocLowDetail) {
+            if(this.objectModels != null && !objectCompositionLowDetail) {
                var1.offset += var3 * 2;
             } else {
                this.objectTypes = null;

--- a/runescape-client/src/main/java/SourceDataSoundSystem.java
+++ b/runescape-client/src/main/java/SourceDataSoundSystem.java
@@ -34,8 +34,8 @@ public class SourceDataSoundSystem extends AbstractSoundSystem {
       garbageValue = "-1683722552"
    )
    protected void vmethod2190() {
-      this.audioFormat = new AudioFormat((float)class20.sampleRate, 16, BoundingBox3DDrawMode.highMemory?2:1, true, false);
-      this.bytes = new byte[256 << (BoundingBox3DDrawMode.highMemory?2:1)];
+      this.audioFormat = new AudioFormat((float)class20.sampleRate, 16, BoundingBox3DDrawMode.audioHighMemory ?2:1, true, false);
+      this.bytes = new byte[256 << (BoundingBox3DDrawMode.audioHighMemory ?2:1)];
    }
 
    @ObfuscatedName("i")
@@ -46,7 +46,7 @@ public class SourceDataSoundSystem extends AbstractSoundSystem {
    @Export("create")
    protected void create(int var1) throws LineUnavailableException {
       try {
-         Info var2 = new Info(SourceDataLine.class, this.audioFormat, var1 << (BoundingBox3DDrawMode.highMemory?2:1));
+         Info var2 = new Info(SourceDataLine.class, this.audioFormat, var1 << (BoundingBox3DDrawMode.audioHighMemory ?2:1));
          this.source = (SourceDataLine)AudioSystem.getLine(var2);
          this.source.open();
          this.source.start();
@@ -74,14 +74,14 @@ public class SourceDataSoundSystem extends AbstractSoundSystem {
    )
    @Export("size")
    protected int size() {
-      return this.size - (this.source.available() >> (BoundingBox3DDrawMode.highMemory?2:1));
+      return this.size - (this.source.available() >> (BoundingBox3DDrawMode.audioHighMemory ?2:1));
    }
 
    @ObfuscatedName("s")
    @Export("write")
    protected void write() {
       int var1 = 256;
-      if(BoundingBox3DDrawMode.highMemory) {
+      if(BoundingBox3DDrawMode.audioHighMemory) {
          var1 <<= 1;
       }
 

--- a/runescape-client/src/main/java/WidgetNode.java
+++ b/runescape-client/src/main/java/WidgetNode.java
@@ -34,7 +34,7 @@ public class WidgetNode extends Node {
    public static final void method1074(int var0, boolean var1, int var2) {
       if(var0 >= 8000 && var0 <= 48000) {
          class20.sampleRate = var0;
-         BoundingBox3DDrawMode.highMemory = var1;
+         BoundingBox3DDrawMode.audioHighMemory = var1;
          AbstractSoundSystem.priority = var2;
       } else {
          throw new IllegalArgumentException();

--- a/runescape-client/src/main/java/class114.java
+++ b/runescape-client/src/main/java/class114.java
@@ -655,12 +655,12 @@ public class class114 extends TaskDataNode {
 
             this.field1582 += var2;
             if(this.field1581 == 256 && (this.field1572 & 255) == 0) {
-               if(BoundingBox3DDrawMode.highMemory) {
+               if(BoundingBox3DDrawMode.audioHighMemory) {
                   var2 = method2321(0, ((RawAudioNode)super.data).audioBuffer, var1, this.field1572, var2, this.field1576, this.field1577, this.field1584, this.field1585, 0, var6, var3, this);
                } else {
                   var2 = method2320(((RawAudioNode)super.data).audioBuffer, var1, this.field1572, var2, this.field1575, this.field1583, 0, var6, var3, this);
                }
-            } else if(BoundingBox3DDrawMode.highMemory) {
+            } else if(BoundingBox3DDrawMode.audioHighMemory) {
                var2 = method2325(0, 0, ((RawAudioNode)super.data).audioBuffer, var1, this.field1572, var2, this.field1576, this.field1577, this.field1584, this.field1585, 0, var6, var3, this, this.field1581, var5);
             } else {
                var2 = method2324(0, 0, ((RawAudioNode)super.data).audioBuffer, var1, this.field1572, var2, this.field1575, this.field1583, 0, var6, var3, this, this.field1581, var5);
@@ -679,14 +679,14 @@ public class class114 extends TaskDataNode {
          }
 
          if(this.field1581 == 256 && (this.field1572 & 255) == 0) {
-            if(BoundingBox3DDrawMode.highMemory) {
+            if(BoundingBox3DDrawMode.audioHighMemory) {
                return method2358(0, ((RawAudioNode)super.data).audioBuffer, var1, this.field1572, var2, this.field1576, this.field1577, 0, var4, var3, this);
             }
 
             return method2383(((RawAudioNode)super.data).audioBuffer, var1, this.field1572, var2, this.field1575, 0, var4, var3, this);
          }
 
-         if(BoundingBox3DDrawMode.highMemory) {
+         if(BoundingBox3DDrawMode.audioHighMemory) {
             return method2334(0, 0, ((RawAudioNode)super.data).audioBuffer, var1, this.field1572, var2, this.field1576, this.field1577, 0, var4, var3, this, this.field1581, var5);
          }
 
@@ -705,12 +705,12 @@ public class class114 extends TaskDataNode {
 
             this.field1582 += var2;
             if(this.field1581 == -256 && (this.field1572 & 255) == 0) {
-               if(BoundingBox3DDrawMode.highMemory) {
+               if(BoundingBox3DDrawMode.audioHighMemory) {
                   var2 = method2323(0, ((RawAudioNode)super.data).audioBuffer, var1, this.field1572, var2, this.field1576, this.field1577, this.field1584, this.field1585, 0, var6, var3, this);
                } else {
                   var2 = method2322(((RawAudioNode)super.data).audioBuffer, var1, this.field1572, var2, this.field1575, this.field1583, 0, var6, var3, this);
                }
-            } else if(BoundingBox3DDrawMode.highMemory) {
+            } else if(BoundingBox3DDrawMode.audioHighMemory) {
                var2 = method2384(0, 0, ((RawAudioNode)super.data).audioBuffer, var1, this.field1572, var2, this.field1576, this.field1577, this.field1584, this.field1585, 0, var6, var3, this, this.field1581, var5);
             } else {
                var2 = method2326(0, 0, ((RawAudioNode)super.data).audioBuffer, var1, this.field1572, var2, this.field1575, this.field1583, 0, var6, var3, this, this.field1581, var5);
@@ -729,14 +729,14 @@ public class class114 extends TaskDataNode {
          }
 
          if(this.field1581 == -256 && (this.field1572 & 255) == 0) {
-            if(BoundingBox3DDrawMode.highMemory) {
+            if(BoundingBox3DDrawMode.audioHighMemory) {
                return method2340(0, ((RawAudioNode)super.data).audioBuffer, var1, this.field1572, var2, this.field1576, this.field1577, 0, var4, var3, this);
             }
 
             return method2314(((RawAudioNode)super.data).audioBuffer, var1, this.field1572, var2, this.field1575, 0, var4, var3, this);
          }
 
-         if(BoundingBox3DDrawMode.highMemory) {
+         if(BoundingBox3DDrawMode.audioHighMemory) {
             return method2359(0, 0, ((RawAudioNode)super.data).audioBuffer, var1, this.field1572, var2, this.field1576, this.field1577, 0, var4, var3, this, this.field1581, var5);
          }
 


### PR DESCRIPTION
Fixes the audio in low memory mode being sped up, by making the audio always use the "high memory" mode.

Also renames highMemory to audioHighMemory and ocLowDetail to objectCompositionLowDetail. 
I shouldn't have to go into the engine code to see what "oc" in ocLowDetail means.