### PR TITLE
Add ability to retrieve cache index for npcs and players

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/NPC.java
+++ b/runelite-api/src/main/java/net/runelite/api/NPC.java
@@ -34,5 +34,12 @@ public interface NPC extends Actor
 	@Override
 	int getCombatLevel();
 
+	/**
+	 * This returns the index of the NPC in the client cache.
+	 * This cache usually persists throughout the game session and is the preferred
+	 * method for tracking NPCs.
+	 * Additionaly for NPCs this index also persists through respawns.
+	 * @return the cache id of the NPC
+	 */
 	int getCacheIndex();
 }

--- a/runelite-api/src/main/java/net/runelite/api/NPC.java
+++ b/runelite-api/src/main/java/net/runelite/api/NPC.java
@@ -34,4 +34,5 @@ public interface NPC extends Actor
 	@Override
 	int getCombatLevel();
 
+	int getCacheIndex();
 }

--- a/runelite-api/src/main/java/net/runelite/api/Player.java
+++ b/runelite-api/src/main/java/net/runelite/api/Player.java
@@ -40,4 +40,6 @@ public interface Player extends Actor
 	boolean isClanMember();
 
 	boolean isFriend();
+
+	int getCacheIndex();
 }

--- a/runelite-api/src/main/java/net/runelite/api/Player.java
+++ b/runelite-api/src/main/java/net/runelite/api/Player.java
@@ -41,5 +41,11 @@ public interface Player extends Actor
 
 	boolean isFriend();
 
+	/**
+	 * This returns the index of the Player in the client cache.
+	 * This cache usually persists throughout the game session and is the preferred
+	 * method for tracking players
+	 * @return the cache id of the player
+	 */
 	int getCacheIndex();
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/devtools/DevToolsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/devtools/DevToolsOverlay.java
@@ -139,12 +139,12 @@ public class DevToolsOverlay extends Overlay
 		{
 			if (p != local)
 			{
-				String text = p.getName() + " (A: " + p.getAnimation() + ") (G: " + p.getGraphic() + ")";
+				String text = p.getName() + " (A: " + p.getAnimation() + ") (G: " + p.getGraphic() + ") (IDX: " + p.getCacheIndex() + ")";
 				OverlayUtil.renderActorOverlay(graphics, p, text, BLUE);
 			}
 		}
 
-		String text = local.getName() + " (A: " + local.getAnimation() + ") (G: " + local.getGraphic() + ")";
+		String text = local.getName() + " (A: " + local.getAnimation() + ") (G: " + local.getGraphic() + ") (IDX: " + local.getCacheIndex() + ")";
 		OverlayUtil.renderActorOverlay(graphics, local, text, CYAN);
 		renderPlayerWireframe(graphics, local, CYAN);
 	}
@@ -154,7 +154,7 @@ public class DevToolsOverlay extends Overlay
 		List<NPC> npcs = client.getNpcs();
 		for (NPC npc : npcs)
 		{
-			String text = npc.getName() + " (ID: " + npc.getId() + ") (A: " + npc.getAnimation() + ") (G: " + npc.getGraphic() + ")";
+			String text = npc.getName() + " (ID: " + npc.getId() + ") (A: " + npc.getAnimation() + ") (G: " + npc.getGraphic() + ") (IDX: " + npc.getCacheIndex() + ")";
 			if (npc.getCombatLevel() > 1)
 			{
 				OverlayUtil.renderActorOverlay(graphics, npc, text, YELLOW);

--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSNPCMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSNPCMixin.java
@@ -26,11 +26,16 @@ package net.runelite.mixins;
 
 import net.runelite.api.mixins.Inject;
 import net.runelite.api.mixins.Mixin;
+import net.runelite.api.mixins.Shadow;
+import net.runelite.rs.api.RSClient;
 import net.runelite.rs.api.RSNPC;
 
 @Mixin(RSNPC.class)
 public abstract class RSNPCMixin implements RSNPC
 {
+	@Shadow("clientInstance")
+	private static RSClient client;
+
 	@Inject
 	@Override
 	public int getId()
@@ -50,5 +55,22 @@ public abstract class RSNPCMixin implements RSNPC
 	public int getCombatLevel()
 	{
 		return getComposition().getCombatLevel();
+	}
+
+	@Inject
+	@Override
+	public int getCacheIndex()
+	{
+		RSNPC[] npcs = client.getCachedNPCs();
+
+		for (int i = 0; i < npcs.length; ++i)
+		{
+			RSNPC npc = npcs[i];
+
+			if (npc == this)
+				return i;
+		}
+
+		return -1;
 	}
 }

--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSPlayerMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSPlayerMixin.java
@@ -133,4 +133,21 @@ public abstract class RSPlayerMixin implements RSPlayer
 		}
 		return rotatedTriangles;
 	}
+
+	@Inject
+	@Override
+	public int getCacheIndex()
+	{
+		RSPlayer[] players = client.getCachedPlayers();
+
+		for (int i = 0; i < players.length; ++i)
+		{
+			RSPlayer cachedPlayer = players[i];
+
+			if (cachedPlayer == this)
+				return i;
+		}
+
+		return -1;
+	}
 }


### PR DESCRIPTION
Adds the getCacheIndex methods to Player and NPC objects.


![java_2018-02-06_18-35-23](https://user-images.githubusercontent.com/503776/35874332-84c83fe4-0b6c-11e8-8e4e-e9fd982f89e3.png)

This is necessary to properly support tagging in the future.