### PR TITLE
Fix logging inside info panel plugin

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/info/JRichTextPane.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/info/JRichTextPane.java
@@ -66,7 +66,6 @@ public class JRichTextPane extends JEditorPane
 			{
 				linkHandler = e ->
 				{
-					log.info(e.toString());
 					if (HyperlinkEvent.EventType.ACTIVATED.equals(e.getEventType()) && e.getURL() != null)
 					{
 						if (Desktop.isDesktopSupported())
@@ -77,7 +76,7 @@ public class JRichTextPane extends JEditorPane
 							}
 							catch (URISyntaxException | IOException ex)
 							{
-								log.info("Error opening link", ex);
+								log.warn("Error opening link", ex);
 							}
 						}
 					}


### PR DESCRIPTION
- Remove log.info on each hover of the JRichTextPane
- Change log.info to log.warn when browser cannot be opened in the
JRichTextPane

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>