### PR TITLE
assembler: allow lines with no instructions

### DIFF
--- a/cache/src/main/antlr4/net/runelite/cache/script/assembler/rs2asm.g4
+++ b/cache/src/main/antlr4/net/runelite/cache/script/assembler/rs2asm.g4
@@ -24,7 +24,7 @@
  */
 grammar rs2asm;
 
-prog: (header NEWLINE)* (line NEWLINE)+ ;
+prog: (header NEWLINE+)* (line NEWLINE+)+ ;
 
 header: id | int_stack_count | string_stack_count | int_var_count | string_var_count ;
 


### PR DESCRIPTION
This allow the assembler to not complain when it sees a line with no code. Sometimes maven interprets this complaining as a build failure. I do not know why, because the assembler produces correct code.