### PR TITLE
Raw injector for script VM

### DIFF
--- a/deobfuscator/src/main/java/net/runelite/asm/attributes/code/instructions/IfNe.java
+++ b/deobfuscator/src/main/java/net/runelite/asm/attributes/code/instructions/IfNe.java
@@ -27,6 +27,7 @@ package net.runelite.asm.attributes.code.instructions;
 
 import net.runelite.asm.attributes.code.InstructionType;
 import net.runelite.asm.attributes.code.Instructions;
+import net.runelite.asm.attributes.code.Label;
 import static net.runelite.asm.attributes.code.instructions.IfICmpEq.isOne;
 import static net.runelite.asm.attributes.code.instructions.IfICmpEq.isZero;
 import net.runelite.asm.execution.InstructionContext;
@@ -35,6 +36,11 @@ import net.runelite.deob.deobfuscators.mapping.ParallelExecutorMapping;
 
 public class IfNe extends If0
 {
+	public IfNe(Instructions instructions, Label to)
+	{
+		super(instructions, InstructionType.IFNE, to);
+	}
+
 	public IfNe(Instructions instructions, InstructionType type)
 	{
 		super(instructions, type);

--- a/runelite-client/src/main/java/net/runelite/client/callback/Hooks.java
+++ b/runelite-client/src/main/java/net/runelite/client/callback/Hooks.java
@@ -45,8 +45,6 @@ import net.runelite.api.PacketBuffer;
 import net.runelite.api.Point;
 import net.runelite.api.Projectile;
 import net.runelite.api.Region;
-import net.runelite.api.Script;
-import net.runelite.api.events.ScriptEvent;
 import net.runelite.client.RuneLite;
 import net.runelite.client.chat.ChatMessageManager;
 import net.runelite.client.game.DeathChecker;
@@ -168,28 +166,6 @@ public class Hooks
 		{
 			log.warn("Error during overlay rendering", ex);
 		}
-	}
-
-	/**
-	 *
-	 * @param opcode
-	 * @param script
-	 * @param isOne
-	 * @return 0 halts, 1 continues, 2 throws
-	 */
-	public static int runeliteExecute(int opcode, Script script, boolean isOne)
-	{
-		String[] stringStack = client.getStringStack();
-		int stackSize = client.getStringStackSize();
-		String eventName = stringStack[--stackSize];
-		client.setStringStackSize(stackSize);
-
-		ScriptEvent event = new ScriptEvent();
-		event.setScript(script);
-		event.setEventName(eventName);
-		eventBus.post(event);
-
-		return 1;
 	}
 
 	public static void menuActionHook(int actionParam, int widgetId, int menuAction, int id, String menuOption, String menuTarget, int var6, int var7)

--- a/runelite-mixins/src/main/java/net/runelite/client/callback/Hooks.java
+++ b/runelite-mixins/src/main/java/net/runelite/client/callback/Hooks.java
@@ -25,7 +25,6 @@
 package net.runelite.client.callback;
 
 import com.google.common.eventbus.EventBus;
-import net.runelite.api.Script;
 import org.slf4j.Logger;
 
 /**
@@ -38,9 +37,4 @@ public class Hooks
 	public static Logger log;
 
 	public static EventBus eventBus;
-
-	public static int runeliteExecute(int opcode, Script script, boolean isOne)
-	{
-		throw new RuntimeException();
-	}
 }

--- a/runelite-mixins/src/main/java/net/runelite/mixins/ScriptVMMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/ScriptVMMixin.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2018 Abex
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.mixins;
+
+import net.runelite.api.Client;
+import net.runelite.api.events.ScriptEvent;
+import net.runelite.api.mixins.Copy;
+import net.runelite.api.mixins.Inject;
+import net.runelite.api.mixins.Mixin;
+import net.runelite.api.mixins.Replace;
+import net.runelite.api.mixins.Shadow;
+import net.runelite.client.callback.Hooks;
+import net.runelite.rs.api.RSClient;
+import net.runelite.rs.api.RSScript;
+import net.runelite.rs.api.RSScriptEvent;
+
+import static net.runelite.api.Opcodes.RUNELITE_EXECUTE;
+
+@Mixin(RSClient.class)
+public abstract class ScriptVMMixin implements RSClient
+{
+	@Shadow("clientInstance")
+	private static Client client;
+
+	// This field is set by the ScriptVM raw injector
+	@Inject
+	private static RSScript currentScript;
+
+	// This field is set by the ScriptVM raw injector
+	@Inject
+	private static int currentScriptPC;
+
+	// Call is injected into runScript by the ScriptVM raw injector
+	@Inject
+	static boolean vmExecuteOpcode(int opcode)
+	{
+		if (opcode == RUNELITE_EXECUTE)
+		{
+			if (currentScript.getInstructions()[currentScriptPC] != RUNELITE_EXECUTE)
+			{
+				throw new AssertionError("currentScriptPC is wrong");
+			}
+
+			int stringStackSize = client.getStringStackSize();
+			String stringOp = client.getStringStack()[--stringStackSize];
+			client.setStringStackSize(stringStackSize);
+
+			ScriptEvent event = new ScriptEvent();
+			event.setScript(currentScript);
+			event.setEventName(stringOp);
+			Hooks.eventBus.post(event);
+			return true;
+		}
+		return false;
+	}
+
+	@Copy("runScript")
+	static void rs$runScript(RSScriptEvent event, int maxExecutionTime)
+	{
+		throw new RuntimeException();
+	}
+
+	@Replace("runScript")
+	static void rl$runScript(RSScriptEvent event, int maxExecutionTime)
+	{
+		try
+		{
+			rs$runScript(event, maxExecutionTime);
+		}
+		finally
+		{
+			currentScript = null;
+		}
+	}
+}

--- a/runelite-scripts/scripts/OptionsPanelRebuilder.rs2asm
+++ b/runelite-scripts/scripts/OptionsPanelRebuilder.rs2asm
@@ -230,8 +230,8 @@ LABEL198:
    6202                  
    get_varc               73
    load_int               195
-   ;load_string            "fixedOuterZoomLimit"
-   ;runelite_callback
+   load_string            "fixedOuterZoomLimit"
+   runelite_callback
    if_icmpge              LABEL210
    jump                   LABEL226
 LABEL210:
@@ -242,8 +242,8 @@ LABEL210:
 LABEL214:
    get_varc               74
    load_int               175
-   ;load_string            "resizableOuterZoomLimit"
-   ;runelite_callback
+   load_string            "resizableOuterZoomLimit"
+   runelite_callback
    if_icmpge              LABEL218
    jump                   LABEL226
 LABEL218:

--- a/runelite-scripts/scripts/OptionsPanelZoomMouseListener.rs2asm
+++ b/runelite-scripts/scripts/OptionsPanelZoomMouseListener.rs2asm
@@ -34,14 +34,14 @@ LABEL5:
    istore                 2
    load_int               715
    load_int               175
-   ;load_string            "resizableOuterZoomLimit"
-   ;runelite_callback
+   load_string            "resizableOuterZoomLimit"
+   runelite_callback
    isub                  
    istore                 6
    load_int               700
    load_int               195
-   ;load_string            "fixedOuterZoomLimit"
-   ;runelite_callback
+   load_string            "fixedOuterZoomLimit"
+   runelite_callback
    isub                  
    istore                 7
    iload                  2
@@ -50,8 +50,8 @@ LABEL5:
    iload                  5
    idiv                  
    load_int               175
-   ;load_string            "resizableOuterZoomLimit"
-   ;runelite_callback
+   load_string            "resizableOuterZoomLimit"
+   runelite_callback
    iadd                  
    istore                 3
    iload                  2
@@ -60,8 +60,8 @@ LABEL5:
    iload                  5
    idiv                  
    load_int               195
-   ;load_string            "fixedOuterZoomLimit"
-   ;runelite_callback
+   load_string            "fixedOuterZoomLimit"
+   runelite_callback
    iadd                  
    istore                 4
    iload                  4

--- a/runelite-scripts/scripts/OptionsPanelZoomUpdater.rs2asm
+++ b/runelite-scripts/scripts/OptionsPanelZoomUpdater.rs2asm
@@ -5,14 +5,14 @@
 .string_var_count   0
    load_int               715
    load_int               175
-   ;load_string            "resizableOuterZoomLimit"
-   ;runelite_callback
+   load_string            "resizableOuterZoomLimit"
+   runelite_callback
    isub                  
    istore                 0
    load_int               700
    load_int               195
-   ;load_string            "fixedOuterZoomLimit"
-   ;runelite_callback
+   load_string            "fixedOuterZoomLimit"
+   runelite_callback
    isub                  
    istore                 1
    load_int               17104904
@@ -37,8 +37,8 @@
 LABEL27:
    get_varc               74
    load_int               175
-   ;load_string            "resizableOuterZoomLimit"
-   ;runelite_callback
+   load_string            "resizableOuterZoomLimit"
+   runelite_callback
    isub                  
    iload                  2
    imul                  
@@ -49,8 +49,8 @@ LABEL27:
 LABEL36:
    get_varc               73
    load_int               195
-   ;load_string            "fixedOuterZoomLimit"
-   ;runelite_callback
+   load_string            "fixedOuterZoomLimit"
+   runelite_callback
    isub                  
    iload                  2
    imul                  

--- a/runelite-scripts/scripts/ScrollWheelZoomHandler.rs2asm
+++ b/runelite-scripts/scripts/ScrollWheelZoomHandler.rs2asm
@@ -15,8 +15,8 @@ LABEL5:
    invoke                 1046
    istore                 0
    load_int               195
-   ;load_string            "fixedOuterZoomLimit"
-   ;runelite_callback
+   load_string            "fixedOuterZoomLimit"
+   runelite_callback
    iload                  0
    invoke                 1045
    istore                 0
@@ -25,8 +25,8 @@ LABEL5:
    invoke                 1046
    istore                 1
    load_int               175
-   ;load_string            "resizableOuterZoomLimit"
-   ;runelite_callback
+   load_string            "resizableOuterZoomLimit"
+   runelite_callback
    iload                  1
    invoke                 1045
    istore                 1

--- a/runescape-api/src/main/java/net/runelite/rs/api/RSScriptEvent.java
+++ b/runescape-api/src/main/java/net/runelite/rs/api/RSScriptEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Adam <Adam@sigterm.info>
+ * Copyright (c) 2018 Abex
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -22,30 +22,8 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package net.runelite.mixins;
+package net.runelite.rs.api;
 
-import static net.runelite.api.Opcodes.RUNELITE_EXECUTE;
-import net.runelite.api.Script;
-import net.runelite.api.mixins.Copy;
-import net.runelite.api.mixins.Replace;
-import net.runelite.client.callback.Hooks;
-
-//@Mixin(RSClient.class)
-public abstract class VmMixin
+public interface RSScriptEvent
 {
-	@Copy("execute6500")
-	static int rs$execute6500(int opcode, Script script, boolean isOne)
-	{
-		throw new RuntimeException();
-	}
-
-	@Replace("execute6500")
-	static int rl$execute6500(int opcode, Script script, boolean isOne)
-	{
-		if (opcode == RUNELITE_EXECUTE)
-		{
-			return Hooks.runeliteExecute(opcode, script, isOne);
-		}
-		return rs$execute6500(opcode, script, isOne);
-	}
 }

--- a/runescape-client-injector-plugin/src/main/java/net/runelite/injector/Inject.java
+++ b/runescape-client-injector-plugin/src/main/java/net/runelite/injector/Inject.java
@@ -46,6 +46,7 @@ import net.runelite.asm.pool.Class;
 import net.runelite.asm.signature.Signature;
 import net.runelite.deob.DeobAnnotations;
 import net.runelite.deob.deobfuscators.arithmetic.DMath;
+import net.runelite.injector.raw.ScriptVM;
 import net.runelite.mapping.Import;
 import net.runelite.rs.api.RSClient;
 import org.slf4j.Logger;
@@ -69,6 +70,7 @@ public class Inject
 
 	private final MixinInjector mixinInjector = new MixinInjector(this);
 	private final DrawAfterWidgets drawAfterWidgets = new DrawAfterWidgets(this);
+	private final ScriptVM scriptVM = new ScriptVM(this);
 
 	// deobfuscated contains exports etc to apply to vanilla
 	private final ClassGroup deobfuscated, vanilla;
@@ -318,6 +320,7 @@ public class Inject
 			setters.getInjectedSetters(), invokes.getInjectedInvokers());
 
 		drawAfterWidgets.inject();
+		scriptVM.inject();
 	}
 
 	private java.lang.Class injectInterface(ClassFile cf, ClassFile other)

--- a/runescape-client-injector-plugin/src/main/java/net/runelite/injector/MixinInjector.java
+++ b/runescape-client-injector-plugin/src/main/java/net/runelite/injector/MixinInjector.java
@@ -475,6 +475,11 @@ public class MixinInjector
 		{
 			i.setInstructions(newCode.getInstructions());
 		}
+		newCode.getExceptions().getExceptions().addAll(code.getExceptions().getExceptions());
+		for (net.runelite.asm.attributes.code.Exception e : newCode.getExceptions().getExceptions())
+		{
+			e.setExceptions(newCode.getExceptions());
+		}
 		method.setCode(newCode);
 	}
 

--- a/runescape-client-injector-plugin/src/main/java/net/runelite/injector/raw/ScriptVM.java
+++ b/runescape-client-injector-plugin/src/main/java/net/runelite/injector/raw/ScriptVM.java
@@ -1,0 +1,340 @@
+/*
+ * Copyright (c) 2018 Abex
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.injector.raw;
+
+import java.util.HashSet;
+import java.util.ListIterator;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+import net.runelite.asm.ClassFile;
+import net.runelite.asm.Field;
+import net.runelite.asm.Method;
+import net.runelite.asm.Type;
+import net.runelite.asm.attributes.code.Instruction;
+import net.runelite.asm.attributes.code.Instructions;
+import net.runelite.asm.attributes.code.Label;
+import net.runelite.asm.attributes.code.instructions.ALoad;
+import net.runelite.asm.attributes.code.instructions.AStore;
+import net.runelite.asm.attributes.code.instructions.Dup;
+import net.runelite.asm.attributes.code.instructions.GetField;
+import net.runelite.asm.attributes.code.instructions.IALoad;
+import net.runelite.asm.attributes.code.instructions.IInc;
+import net.runelite.asm.attributes.code.instructions.ILoad;
+import net.runelite.asm.attributes.code.instructions.IMul;
+import net.runelite.asm.attributes.code.instructions.IStore;
+import net.runelite.asm.attributes.code.instructions.IfNe;
+import net.runelite.asm.attributes.code.instructions.InvokeStatic;
+import net.runelite.asm.attributes.code.instructions.PutField;
+import net.runelite.asm.attributes.code.instructions.PutStatic;
+import net.runelite.asm.execution.Execution;
+import net.runelite.asm.execution.InstructionContext;
+import net.runelite.asm.execution.MethodContext;
+import net.runelite.asm.execution.StackContext;
+import net.runelite.deob.DeobAnnotations;
+import net.runelite.injector.Inject;
+import net.runelite.injector.InjectionException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ScriptVM
+{
+	private static final Logger log = LoggerFactory.getLogger(ScriptVM.class);
+
+	private final Inject inject;
+
+	public ScriptVM(Inject inject)
+	{
+		this.inject = inject;
+	}
+
+	public void inject() throws InjectionException
+	{
+		injectScriptVMHooks();
+	}
+
+	private void injectScriptVMHooks() throws InjectionException
+	{
+		/*
+			This hooks local variable assignments in the copied version of runScript:
+			 - The currently executing script > client.currentScript
+			 - The currently executing script's program counter > client.currentScriptPC
+			 - The currently executing opcode > client.vmExecuteOpcode(I)Z
+
+			The currently executing script variable is located as the outermost Script local
+
+			The PC is located by its use in PutField ScriptState::invokedFromPC
+
+			The currently executing opcode is found by searching for iaload with the script's instruction array
+
+			The script's instruction array is identified by looking for the getfield from script.instructions
+
+			bn.g @ rev 163 :
+			// Jump back to here if vmExecuteOpcode returns true
+			aload6 // Script.instructions
+			iinc 5 1 // ++PC
+			iload5 // PC
+			iaload
+			istore8
+			// <- Inject here
+			iload8
+			bipush 100
+			if_icmpge L52
+
+		 */
+		String scriptObName = DeobAnnotations.getObfuscatedName(inject.getDeobfuscated().findClass("Script").getAnnotations());
+		Method runScript = findObMethod("copy$runScript");
+		Method vmExecuteOpcode = findObMethod("vmExecuteOpcode");
+		Field scriptInstructions = findDeobField("instructions");
+		Field scriptStatePC = findDeobField("invokedFromPc");
+		Field currentScriptField = findObField("currentScript");
+		Field currentScriptPCField = findObField("currentScriptPC");
+
+		Execution e = new Execution(inject.getVanilla());
+		e.addMethod(runScript);
+		e.noInvoke = true;
+
+		AtomicReference<MethodContext> pcontext = new AtomicReference<>(null);
+
+		e.addMethodContextVisitor(pcontext::set);
+		e.run();
+
+		Set<AStore> scriptStores = new HashSet<>();
+		Integer pcLocalVar = null;
+		Integer instructionArrayLocalVar = null;
+		IStore currentOpcodeStore = null;
+		ALoad localInstructionLoad = null;
+
+		MethodContext methodContext = pcontext.get();
+		for (InstructionContext instrCtx : methodContext.getInstructionContexts())
+		{
+			Instruction instr = instrCtx.getInstruction();
+
+			if (instr instanceof AStore)
+			{
+				AStore store = (AStore) instr;
+				StackContext storedVarCtx = instrCtx.getPops().get(0);
+
+				// Find AStores that store a Script
+				if (storedVarCtx.getType().getInternalName().equals(scriptObName))
+				{
+					scriptStores.add(store);
+				}
+
+				// Find AStores that store the instructions
+				InstructionContext pusherCtx = storedVarCtx.getPushed();
+				if (pusherCtx.getInstruction() instanceof GetField)
+				{
+					GetField getField = (GetField) pusherCtx.getInstruction();
+					if (getField.getMyField().equals(scriptInstructions))
+					{
+						instructionArrayLocalVar = store.getVariableIndex();
+					}
+				}
+			}
+
+			// Find the local that invokedFromPc is set from
+			if (instr instanceof PutField)
+			{
+				PutField put = (PutField) instr;
+				if (put.getMyField() == scriptStatePC)
+				{
+					StackContext pc = instrCtx.getPops().get(0);
+					assert Type.INT.equals(pc.getType()) : pc.getType();
+
+					InstructionContext mulctx = pc.pushed;
+					assert mulctx.getInstruction() instanceof IMul;
+
+					pcLocalVar = mulctx.getPops().stream()
+						.map(StackContext::getPushed)
+						.filter(i -> i.getInstruction() instanceof ILoad)
+						.map(i -> ((ILoad) i.getInstruction()).getVariableIndex())
+						.findFirst()
+						.orElse(null);
+				}
+			}
+		}
+
+		// Find opcode load
+		// This has to run after the first loop because it relies on instructionArrayLocalVar being set
+		if (instructionArrayLocalVar == null)
+		{
+			throw new InjectionException("Unable to find local instruction array");
+		}
+		for (InstructionContext instrCtx : methodContext.getInstructionContexts())
+		{
+			Instruction instr = instrCtx.getInstruction();
+
+			if (instr instanceof IALoad)
+			{
+				StackContext array = instrCtx.getPops().get(1);
+
+				// Check where the array came from (looking for a getField scriptInstructions
+				InstructionContext pushedCtx = array.getPushed();
+				Instruction pushed = pushedCtx.getInstruction();
+				if (pushed instanceof ALoad)
+				{
+					ALoad arrayLoad = (ALoad) pushed;
+					if (arrayLoad.getVariableIndex() == instructionArrayLocalVar)
+					{
+						//Find the istore
+						IStore istore = (IStore) instrCtx.getPushes().get(0).getPopped().stream()
+							.map(InstructionContext::getInstruction)
+							.filter(i -> i instanceof IStore)
+							.findFirst()
+							.orElse(null);
+						if (istore != null)
+						{
+							currentOpcodeStore = istore;
+							localInstructionLoad = arrayLoad;
+						}
+					}
+				}
+			}
+		}
+
+		// Add PutStatics to all Script AStores
+		int outerSciptIdx = scriptStores.stream()
+			.mapToInt(AStore::getVariableIndex)
+			.reduce(Math::min)
+			.orElseThrow(() -> new InjectionException("Unable to find any Script AStores in runScript"));
+		log.debug("Found script index {}", outerSciptIdx);
+
+		scriptStores.stream()
+			.filter(s -> s.getVariableIndex() == outerSciptIdx)
+			.forEach(store ->
+			{
+				Instructions instrs = store.getInstructions();
+				int idx = instrs.getInstructions().indexOf(store);
+				instrs.addInstruction(idx, new Dup(instrs));
+				instrs.addInstruction(idx + 1, new PutStatic(instrs, currentScriptField));
+			});
+
+		// Add PutStatics to all PC IStores and IIncs
+		if (pcLocalVar == null)
+		{
+			throw new InjectionException("Unable to find ILoad for invokedFromPc IStore");
+		}
+		log.debug("Found pc index {}", pcLocalVar);
+
+		Instructions instrs = runScript.getCode().getInstructions();
+		ListIterator<Instruction> instrIter = instrs.getInstructions().listIterator();
+		while (instrIter.hasNext())
+		{
+			Instruction instr = instrIter.next();
+
+			if (instr instanceof IStore)
+			{
+				IStore il = (IStore) instr;
+				if (il.getVariableIndex() == pcLocalVar)
+				{
+					instrIter.previous();
+					instrIter.add(new Dup(instrs));
+					instrIter.add(new PutStatic(instrs, currentScriptPCField));
+					instrIter.next();
+				}
+			}
+
+			if (instr instanceof IInc)
+			{
+				IInc iinc = (IInc) instr;
+				if (iinc.getVariableIndex() == pcLocalVar)
+				{
+					instrIter.add(new ILoad(instrs, pcLocalVar));
+					instrIter.add(new PutStatic(instrs, currentScriptPCField));
+				}
+			}
+		}
+
+		// Inject call to vmExecuteOpcode
+		log.debug("Found instruction array index {}", instructionArrayLocalVar);
+		if (currentOpcodeStore == null)
+		{
+			throw new InjectionException("Unable to find IStore for current opcode");
+		}
+
+		int istorepc = instrs.getInstructions().indexOf(currentOpcodeStore);
+		assert istorepc >= 0;
+
+		Label nextIteration = instrs.createLabelFor(localInstructionLoad);
+		instrs.addInstruction(istorepc + 1, new ILoad(instrs, currentOpcodeStore.getVariableIndex()));
+		instrs.addInstruction(istorepc + 2, new InvokeStatic(instrs, vmExecuteOpcode.getPoolMethod()));
+		instrs.addInstruction(istorepc + 3, new IfNe(instrs, nextIteration));
+	}
+
+	private Method findObMethod(String name) throws InjectionException
+	{
+		for (ClassFile c : inject.getVanilla().getClasses())
+		{
+			for (Method m : c.getMethods())
+			{
+				if (!m.getName().equals(name))
+				{
+					continue;
+				}
+				return m;
+			}
+		}
+
+		throw new InjectionException(String.format("Method \"%s\" could not be found.", name));
+	}
+
+	private Field findObField(String name) throws InjectionException
+	{
+		for (ClassFile c : inject.getVanilla().getClasses())
+		{
+			for (Field f : c.getFields())
+			{
+				if (!f.getName().equals(name))
+				{
+					continue;
+				}
+				return f;
+			}
+		}
+
+		throw new InjectionException(String.format("Field \"%s\" could not be found.", name));
+	}
+
+	private Field findDeobField(String name) throws InjectionException
+	{
+		for (ClassFile c : inject.getDeobfuscated().getClasses())
+		{
+			for (Field f : c.getFields())
+			{
+				if (!f.getName().equals(name))
+				{
+					continue;
+				}
+
+				String obfuscatedName = DeobAnnotations.getObfuscatedName(f.getAnnotations());
+
+				ClassFile c2 = inject.toObClass(c);
+				return c2.findField(obfuscatedName);
+			}
+		}
+
+		throw new InjectionException(String.format("Mapped field \"%s\" could not be found.", name));
+	}
+}

--- a/runescape-client/src/main/java/FrameMap.java
+++ b/runescape-client/src/main/java/FrameMap.java
@@ -85,7 +85,7 @@ public class FrameMap extends Node {
                   ScriptEvent var4 = new ScriptEvent();
                   var4.widget = var3;
                   var4.objs = var3.field2743;
-                  ScriptState.method984(var4, 2000000);
+                  ScriptState.runScript(var4, 2000000);
                }
             }
 

--- a/runescape-client/src/main/java/ScriptState.java
+++ b/runescape-client/src/main/java/ScriptState.java
@@ -53,7 +53,8 @@ public class ScriptState {
       signature = "(Lbc;II)V",
       garbageValue = "1690409976"
    )
-   static void method984(ScriptEvent var0, int var1) {
+   @Export("runScript")
+   static void runScript(ScriptEvent var0, int var1) {
       Object[] var2 = var0.objs;
       Script var3;
       Script var5;

--- a/runescape-client/src/main/java/class84.java
+++ b/runescape-client/src/main/java/class84.java
@@ -35,7 +35,7 @@ public class class84 {
       garbageValue = "101"
    )
    public static void method1868(ScriptEvent var0) {
-      ScriptState.method984(var0, 200000);
+      ScriptState.runScript(var0, 200000);
    }
 
    @ObfuscatedName("w")


### PR DESCRIPTION
Fixes #550 
Fixes the zoom plugin

This exports some other fields because I thought I could use a string operand, but the script loader doesn't support that. They are left here for ease of adding a script stack trace generator.