### PR TITLE
Zoom plugin: Relax inner zoom constraint

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/zoom/ZoomConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/zoom/ZoomConfig.java
@@ -37,10 +37,20 @@ public interface ZoomConfig extends Config
 {
 	@ConfigItem(
 		keyName = "enabled",
-		name = "Enabled",
-		description = "Configures whether or not the zoom limit is reduced"
+		name = "Expand outer zoom limit",
+		description = "Configures whether or not the outer zoom limit is reduced"
 	)
-	default boolean enabled()
+	default boolean outerLimit()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		keyName = "inner",
+		name = "Expand inner zoom limit",
+		description = "Configures whether or not the inner zoom limit is reduced"
+	)
+	default boolean innerLimit()
 	{
 		return false;
 	}

--- a/runelite-scripts/scripts/OptionsPanelRebuilder.rs2asm
+++ b/runelite-scripts/scripts/OptionsPanelRebuilder.rs2asm
@@ -237,6 +237,8 @@ LABEL198:
 LABEL210:
    get_varc               73
    load_int               700
+   load_string            "fixedInnerZoomLimit"
+   runelite_callback
    if_icmple              LABEL214
    jump                   LABEL226
 LABEL214:
@@ -249,6 +251,8 @@ LABEL214:
 LABEL218:
    get_varc               74
    load_int               715
+   load_string            "resizableInnerZoomLimit"
+   runelite_callback
    if_icmple              LABEL222
    jump                   LABEL226
 LABEL222:

--- a/runelite-scripts/scripts/OptionsPanelZoomMouseListener.rs2asm
+++ b/runelite-scripts/scripts/OptionsPanelZoomMouseListener.rs2asm
@@ -3,6 +3,8 @@
 .string_stack_count 0
 .int_var_count      8
 .string_var_count   0
+; locals
+; 2 bar size
    get_varbit             4606
    load_int               0
    if_icmpne              LABEL4
@@ -33,22 +35,30 @@ LABEL5:
    invoke                 1046
    istore                 2
    load_int               715
+   load_string            "resizableInnerZoomLimit"
+   runelite_callback
    load_int               175
    load_string            "resizableOuterZoomLimit"
    runelite_callback
    isub                  
-   istore                 6
+   istore                 6 ; resizable delta
    load_int               700
+   load_string            "fixedInnerZoomLimit"
+   runelite_callback
    load_int               195
    load_string            "fixedOuterZoomLimit"
    runelite_callback
    isub                  
-   istore                 7
+   istore                 7 ; fixed delta
    iload                  2
    iload                  6
    imul                  
    iload                  5
-   idiv                  
+   idiv
+   iload                  6
+   load_string            "zoomLinToExp"
+   runelite_callback
+   pop_int
    load_int               175
    load_string            "resizableOuterZoomLimit"
    runelite_callback
@@ -58,7 +68,11 @@ LABEL5:
    iload                  7
    imul                  
    iload                  5
-   idiv                  
+   idiv
+   iload                  7
+   load_string            "zoomLinToExp"
+   runelite_callback
+   pop_int
    load_int               195
    load_string            "fixedOuterZoomLimit"
    runelite_callback

--- a/runelite-scripts/scripts/OptionsPanelZoomUpdater.rs2asm
+++ b/runelite-scripts/scripts/OptionsPanelZoomUpdater.rs2asm
@@ -3,13 +3,21 @@
 .string_stack_count 0
 .int_var_count      6
 .string_var_count   0
+; locals
+; 0 resizableZoomRange
+; 1 fixedZoomRange
+; 2 bar size
    load_int               715
+   load_string            "resizableInnerZoomLimit"
+   runelite_callback
    load_int               175
    load_string            "resizableOuterZoomLimit"
    runelite_callback
    isub                  
    istore                 0
    load_int               700
+   load_string            "fixedInnerZoomLimit"
+   runelite_callback
    load_int               195
    load_string            "fixedOuterZoomLimit"
    runelite_callback
@@ -39,7 +47,11 @@ LABEL27:
    load_int               175
    load_string            "resizableOuterZoomLimit"
    runelite_callback
-   isub                  
+   isub
+   iload                  0
+   load_string            "zoomExpToLin"
+   runelite_callback
+   pop_int
    iload                  2
    imul                  
    iload                  0
@@ -51,7 +63,11 @@ LABEL36:
    load_int               195
    load_string            "fixedOuterZoomLimit"
    runelite_callback
-   isub                  
+   isub
+   iload                  1
+   load_string            "zoomExpToLin"
+   runelite_callback
+   pop_int
    iload                  2
    imul                  
    iload                  1

--- a/runelite-scripts/scripts/ScrollWheelZoomHandler.rs2asm
+++ b/runelite-scripts/scripts/ScrollWheelZoomHandler.rs2asm
@@ -11,6 +11,8 @@ LABEL4:
    return                
 LABEL5:
    load_int               700
+   load_string            "fixedInnerZoomLimit"
+   runelite_callback
    iload                  0
    invoke                 1046
    istore                 0
@@ -21,6 +23,8 @@ LABEL5:
    invoke                 1045
    istore                 0
    load_int               715
+   load_string            "resizableInnerZoomLimit"
+   runelite_callback
    iload                  1
    invoke                 1046
    istore                 1


### PR DESCRIPTION
This adds an option to the zoom plugin to expand your inner zoom limit.
It also changes the options panel's zoom scrollbar to be exponential so it is actually usable with the limit increased. 