### PR TITLE
Use newer Substance API for modifying titlebar

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/info/InfoPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/info/InfoPanel.java
@@ -133,7 +133,7 @@ public class InfoPanel extends PluginPanel
 
 		layout.setVerticalGroup(layout.createSequentialGroup()
 			.addComponent(toolbarPanelPlaceholder)
-			.addGap(3)
+			.addGap(12)
 			.addGroup(layout.createParallelGroup()
 				.addComponent(runeliteVersionHeader)
 				.addComponent(runescapeVersionHeader)
@@ -150,10 +150,8 @@ public class InfoPanel extends PluginPanel
 		);
 
 		layout.setHorizontalGroup(layout.createParallelGroup()
+			.addComponent(toolbarPanelPlaceholder)
 			.addGroup(layout.createSequentialGroup()
-				.addPreferredGap(LayoutStyle.ComponentPlacement.RELATED, GroupLayout.PREFERRED_SIZE, Short.MAX_VALUE)
-				.addComponent(toolbarPanelPlaceholder)
-			).addGroup(layout.createSequentialGroup()
 				.addComponent(runeliteVersionHeader)
 				.addPreferredGap(LayoutStyle.ComponentPlacement.UNRELATED, GroupLayout.PREFERRED_SIZE, Short.MAX_VALUE)
 				.addComponent(runescapeVersionHeader)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
@@ -173,7 +173,7 @@ public class ScreenshotPlugin extends Plugin
 	{
 		SwingUtilities.invokeLater(() ->
 		{
-			clientUi.getTitleToolbar().remove(titleBarButton);
+			clientUi.getTitleToolbar().removeButton(titleBarButton);
 		});
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
@@ -24,6 +24,7 @@
  */
 package net.runelite.client.ui;
 
+import com.google.common.eventbus.Subscribe;
 import java.applet.Applet;
 import java.awt.AWTException;
 import java.awt.BorderLayout;
@@ -31,10 +32,9 @@ import java.awt.Canvas;
 import java.awt.Cursor;
 import java.awt.Dimension;
 import java.awt.Frame;
+import java.awt.Insets;
 import java.awt.SystemTray;
 import java.awt.TrayIcon;
-import java.awt.event.ComponentAdapter;
-import java.awt.event.ComponentEvent;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.awt.event.WindowAdapter;
@@ -44,7 +44,6 @@ import java.io.IOException;
 import java.util.Enumeration;
 import javax.imageio.ImageIO;
 import javax.swing.BoxLayout;
-import javax.swing.JComponent;
 import javax.swing.JFrame;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
@@ -54,17 +53,17 @@ import javax.swing.SwingUtilities;
 import javax.swing.ToolTipManager;
 import javax.swing.UIManager;
 import javax.swing.UnsupportedLookAndFeelException;
+import javax.swing.border.EmptyBorder;
 import javax.swing.plaf.FontUIResource;
-import com.google.common.eventbus.Subscribe;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.GameState;
 import net.runelite.api.events.ConfigChanged;
 import net.runelite.client.RuneLiteProperties;
+import org.pushingpixels.substance.api.SubstanceCortex;
+import org.pushingpixels.substance.api.SubstanceSlices;
 import org.pushingpixels.substance.api.skin.SubstanceGraphiteLookAndFeel;
-import org.pushingpixels.substance.internal.utils.SubstanceCoreUtilities;
-import org.pushingpixels.substance.internal.utils.SubstanceTitlePaneUtilities;
 
 @Slf4j
 public class ClientUI extends JFrame
@@ -153,23 +152,16 @@ public class ClientUI extends JFrame
 		if (customChrome)
 		{
 			getRootPane().setWindowDecorationStyle(JRootPane.FRAME);
+			SubstanceCortex.WindowScope.extendContentIntoTitlePane(
+				this,
+				SubstanceSlices.HorizontalGravity.TRAILING,
+				SubstanceSlices.VerticalGravity.CENTERED);
 
-			JComponent titleBar = SubstanceCoreUtilities.getTitlePaneComponent(this);
-			titleToolbar.putClientProperty(SubstanceTitlePaneUtilities.EXTRA_COMPONENT_KIND, SubstanceTitlePaneUtilities.ExtraComponentKind.TRAILING);
-			titleBar.add(titleToolbar);
-
-			// The title bar doesn't have a real layout manager, so we have to do it manually
-			titleBar.addComponentListener(new ComponentAdapter()
-			{
-				@Override
-				public void componentResized(ComponentEvent e)
-				{
-					super.componentResized(e);
-					final int width = titleToolbar.getPreferredSize().width;
-					titleToolbar.setBounds(titleBar.getWidth() - 75 - width, 0, width, titleBar.getHeight());
-					titleToolbar.revalidate();
-				}
-			});
+			SubstanceCortex.ComponentScope.setDecorationType(titleToolbar,
+				SubstanceSlices.DecorationAreaType.PRIMARY_TITLE_PANE);
+			final Insets insets = SubstanceCortex.WindowScope.getTitlePaneControlInsets(this);
+			titleToolbar.setBorder(new EmptyBorder(0, insets.left + 6, 0, insets.right + 6));
+			getContentPane().add(titleToolbar, BorderLayout.NORTH);
 		}
 
 		pack();
@@ -322,7 +314,7 @@ public class ClientUI extends JFrame
 		pluginToolbar = new PluginToolbar(this);
 		container.add(pluginToolbar);
 
-		titleToolbar = new TitleToolbar(properties);
+		titleToolbar = new TitleToolbar(ICON, properties);
 
 		add(container);
 	}

--- a/runelite-client/src/main/java/net/runelite/client/ui/TitleToolbar.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/TitleToolbar.java
@@ -24,7 +24,10 @@
  */
 package net.runelite.client.ui;
 
+import java.awt.BorderLayout;
 import java.awt.Desktop;
+import java.awt.FlowLayout;
+import java.awt.Font;
 import java.awt.Image;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
@@ -33,12 +36,10 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
 import javax.imageio.ImageIO;
-import javax.swing.BorderFactory;
-import javax.swing.GroupLayout;
 import javax.swing.ImageIcon;
 import javax.swing.JButton;
+import javax.swing.JLabel;
 import javax.swing.JPanel;
-import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.client.RuneLiteProperties;
 import org.pushingpixels.substance.internal.SubstanceSynapse;
@@ -47,25 +48,21 @@ import org.pushingpixels.substance.internal.SubstanceSynapse;
 public class TitleToolbar extends JPanel
 {
 	private static final int TITLEBAR_SIZE = 23;
+	private static final int ICON_SIZE = TITLEBAR_SIZE - 6;
 
-	@Getter
-	private final GroupLayout.SequentialGroup horizontal;
+	private final JPanel buttonPanel = new JPanel();
 
-	@Getter
-	private final GroupLayout.ParallelGroup vertical;
-
-	public TitleToolbar(RuneLiteProperties properties)
+	TitleToolbar(BufferedImage icon, RuneLiteProperties properties)
 	{
-		GroupLayout layout = new GroupLayout(this);
-		setLayout(layout);
+		setLayout(new BorderLayout(6, 0));
+		buttonPanel.setLayout(new FlowLayout(FlowLayout.TRAILING, 1, 0));
+		final JLabel iconLabel = new JLabel(new ImageIcon(icon.getScaledInstance(ICON_SIZE, ICON_SIZE, Image.SCALE_SMOOTH)));
+		final JLabel titleLabel = new JLabel(properties.getTitle());
+		titleLabel.setFont(FontManager.getRunescapeFont().deriveFont(Font.BOLD, 16));
 
-		setBorder(BorderFactory.createEmptyBorder(0, 0, 0, 0));
-
-		horizontal = layout.createSequentialGroup();
-		layout.setHorizontalGroup(horizontal);
-
-		vertical = layout.createParallelGroup();
-		layout.setVerticalGroup(vertical);
+		add(iconLabel, BorderLayout.WEST);
+		add(titleLabel, BorderLayout.CENTER);
+		add(buttonPanel, BorderLayout.EAST);
 
 		try
 		{
@@ -101,18 +98,20 @@ public class TitleToolbar extends JPanel
 
 	public void addButton(JButton button, Image iconImage, Image invertedIconImage)
 	{
-		final int iconSize = TITLEBAR_SIZE - 6;
-		ImageIcon icon = new ImageIcon(iconImage.getScaledInstance(iconSize, iconSize, Image.SCALE_SMOOTH));
-		ImageIcon invertedIcon = new ImageIcon(invertedIconImage.getScaledInstance(iconSize, iconSize, Image.SCALE_SMOOTH));
+		ImageIcon icon = new ImageIcon(iconImage.getScaledInstance(ICON_SIZE, ICON_SIZE, Image.SCALE_SMOOTH));
+		ImageIcon invertedIcon = new ImageIcon(invertedIconImage.getScaledInstance(ICON_SIZE, ICON_SIZE, Image.SCALE_SMOOTH));
 
 		button.setIcon(icon);
 		button.setRolloverIcon(invertedIcon);
 		button.putClientProperty(SubstanceSynapse.FLAT_LOOK, Boolean.TRUE);
 		button.setFocusable(false);
+		buttonPanel.add(button);
+		buttonPanel.revalidate();
+	}
 
-		horizontal.addGap(6);
-		horizontal.addComponent(button, 0, TITLEBAR_SIZE, TITLEBAR_SIZE);
-		vertical.addComponent(button, 0, TITLEBAR_SIZE, TITLEBAR_SIZE);
-		revalidate();
+	public void removeButton(JButton button)
+	{
+		buttonPanel.remove(button);
+		buttonPanel.revalidate();
 	}
 }


### PR DESCRIPTION
Use SubstanceCortex.WindowScope.extendContentIntoTitlePane to modify
(create our own titlebar) instead of injecting new panels into existing
titlebar, because that do not works correctly (buttons not being
removed, need to use custom layout managers because of problems with
layouting).

This makes PR #564 not needed. Also, same as with PR #564, this is required for PR #351.

Preview of changes, this basically also auto-includes title and icon in the moving titlebar:

![screenie](https://user-images.githubusercontent.com/5115805/36069427-b1334346-0ee9-11e8-9479-dc3ac6cd66ff.png)
