### PR TITLE
injector: Allow injection of <init> and <clinit>

### DIFF
--- a/runelite-mixins/src/main/java/net/runelite/api/mixins/Inject.java
+++ b/runelite-mixins/src/main/java/net/runelite/api/mixins/Inject.java
@@ -30,7 +30,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.METHOD, ElementType.FIELD})
+@Target({ElementType.METHOD, ElementType.FIELD, ElementType.CONSTRUCTOR})
 public @interface Inject
 {
 


### PR DESCRIPTION
Mixins with static initialized variables and static blocks will now be injected
Mixins can now create constructors annotated with `@Inject` which will be run after the base class's constructor.