### PR TITLE
Add logback logger that will log to file

### DIFF
--- a/runelite-client/pom.xml
+++ b/runelite-client/pom.xml
@@ -38,6 +38,7 @@
 
 	<properties>
 		<slf4j.version>1.7.12</slf4j.version>
+		<logback.version>1.2.3</logback.version>
 		<guice.version>4.1.0</guice.version>
 
 		<jarsigner.skip>true</jarsigner.skip>
@@ -50,10 +51,9 @@
 			<version>${slf4j.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-simple</artifactId>
-			<version>${slf4j.version}</version>
-			<scope>runtime</scope>
+			<groupId>ch.qos.logback</groupId>
+			<artifactId>logback-classic</artifactId>
+			<version>${logback.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>net.sf.jopt-simple</groupId>
@@ -211,6 +211,12 @@
 								</filter>
 								<filter>
 									<artifact>com.google.guava:*</artifact>
+									<includes>
+										<include>**</include>
+									</includes>
+								</filter>
+								<filter>
+									<artifact>ch.qos.logback:*</artifact>
 									<includes>
 										<include>**</include>
 									</includes>

--- a/runelite-client/src/main/java/net/runelite/client/RuneLite.java
+++ b/runelite-client/src/main/java/net/runelite/client/RuneLite.java
@@ -24,6 +24,8 @@
  */
 package net.runelite.client;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.eventbus.EventBus;
 import com.google.inject.Guice;
@@ -48,6 +50,8 @@ import net.runelite.client.menus.MenuManager;
 import net.runelite.client.plugins.PluginManager;
 import net.runelite.client.ui.ClientUI;
 import net.runelite.client.ui.overlay.OverlayRenderer;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 
 @Singleton
 @Slf4j
@@ -56,6 +60,8 @@ public class RuneLite
 	public static final File RUNELITE_DIR = new File(System.getProperty("user.home"), ".runelite");
 	public static final File PROFILES_DIR = new File(RUNELITE_DIR, "profiles");
 	public static final File SCREENSHOT_DIR = new File(RUNELITE_DIR, "screenshots");
+	private static final File LOGS_DIR = new File(RUNELITE_DIR, "logs");
+	private static final File LOGS_FILE_NAME = new File(LOGS_DIR, "application");
 
 	private static Injector injector;
 	private static OptionSet options;
@@ -96,13 +102,22 @@ public class RuneLite
 
 	public static void main(String[] args) throws Exception
 	{
-
 		OptionParser parser = new OptionParser();
 		parser.accepts("developer-mode");
 		parser.accepts("no-rs");
+		parser.accepts("debug");
 		setOptions(parser.parse(args));
 
 		PROFILES_DIR.mkdirs();
+
+		// Setup logger
+		MDC.put("logFileName", LOGS_FILE_NAME.getAbsolutePath());
+
+		if (options.has("debug"))
+		{
+			final Logger logger = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
+			logger.setLevel(Level.DEBUG);
+		}
 
 		setInjector(Guice.createInjector(new RuneLiteModule()));
 		injector.getInstance(RuneLite.class).start();

--- a/runelite-client/src/main/resources/logback.xml
+++ b/runelite-client/src/main/resources/logback.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright (c) 2018, Adam <Adam@sigterm.info>
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice, this
+    list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-->
+<configuration scan="true">
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <Pattern>%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n</Pattern>
+        </encoder>
+    </appender>
+
+    <appender name="FILE" class="ch.qos.logback.classic.sift.SiftingAppender">
+        <!-- discriminator is used for setting up the log file from code -->
+        <discriminator>
+            <key>logFileName</key>
+            <defaultValue>${user.home}/.runelite/logs/application</defaultValue>
+        </discriminator>
+        <sift>
+            <appender name="FILE-${logFileName}" class="ch.qos.logback.core.rolling.RollingFileAppender">
+                <!-- default file to log to -->
+                <file>${logFileName}.log</file>
+
+                <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+                    <!-- daily rollover -->
+                    <fileNamePattern>${logFileName}_%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+
+                    <!-- when file size is larger than defined, roll to new file -->
+                    <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
+                        <maxFileSize>10MB</maxFileSize>
+                    </timeBasedFileNamingAndTriggeringPolicy>
+
+                    <!-- keep 30 days' worth of history -->
+                    <maxHistory>30</maxHistory>
+                </rollingPolicy>
+
+                <encoder>
+                    <Pattern>%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n</Pattern>
+                </encoder>
+            </appender>
+        </sift>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT" />
+        <appender-ref ref="FILE"/>
+    </root>
+</configuration>


### PR DESCRIPTION
Add dependency on logback and configure logger to log to
~/.runelite/logs/application.log with rolling file appender, that means
every 10MB file will be rolled and also every day file will be rolled
with maximum history of 30 days, to not flood user's system space.

Add new console parameter -debug, because logback properties cannot be
set from console like slf4j-simple ones, so it needs to be done in a bit
more complicated way.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>