### PR TITLE
Client always on top

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/RuneLite.java
+++ b/runelite-client/src/main/java/net/runelite/client/RuneLite.java
@@ -192,6 +192,11 @@ public class RuneLite
 			}
 
 			gui.showWithChrome(runeliteConfig.enableCustomChrome());
+
+			if (gui.isAlwaysOnTopSupported())
+			{
+				gui.setAlwaysOnTop(runeliteConfig.gameAlwaysOnTop());
+			}
 		});
 
 		eventBus.post(new ClientUILoaded());

--- a/runelite-client/src/main/java/net/runelite/client/config/RuneLiteConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/RuneLiteConfig.java
@@ -65,4 +65,14 @@ public interface RuneLiteConfig extends Config
 	{
 		return true;
 	}
+
+	@ConfigItem(
+			keyName = "gameAlwaysOnTop",
+			name = "Enable client always on top",
+			description = "The game will always be on the top of the screen"
+	)
+	default boolean gameAlwaysOnTop()
+	{
+		return false;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/config/RuneLiteConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/RuneLiteConfig.java
@@ -67,9 +67,9 @@ public interface RuneLiteConfig extends Config
 	}
 
 	@ConfigItem(
-			keyName = "gameAlwaysOnTop",
-			name = "Enable client always on top",
-			description = "The game will always be on the top of the screen"
+		keyName = "gameAlwaysOnTop",
+		name = "Enable client always on top",
+		description = "The game will always be on the top of the screen"
 	)
 	default boolean gameAlwaysOnTop()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
@@ -206,6 +206,14 @@ public class ClientUI extends JFrame
 			return;
 		}
 
+		if (event.getKey().equals("gameAlwaysOnTop"))
+		{
+			if (this.isAlwaysOnTopSupported())
+			{
+				this.setAlwaysOnTop(Boolean.valueOf(event.getNewValue()));
+			}
+		}
+
 		if (!event.getKey().equals("gameSize"))
 		{
 			return;


### PR DESCRIPTION
Feature request made in #537.

This adds a new options to the RuneLite config section, which allows the user to set the client always on top. This option is disabled by default.