### PR TITLE
Add a way to determine instanced areas

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/Client.java
+++ b/runelite-api/src/main/java/net/runelite/api/Client.java
@@ -124,6 +124,8 @@ public interface Client extends GameEngine
 
 	int[] getMapRegions();
 
+	int[][][] getInstanceTemplateChunks();
+
 	int[][] getXteaKeys();
 
 	int[] getSettings();

--- a/runelite-api/src/main/java/net/runelite/api/InstanceTemplates.java
+++ b/runelite-api/src/main/java/net/runelite/api/InstanceTemplates.java
@@ -47,7 +47,7 @@ public enum InstanceTemplates
 	@Getter
 	private final int height;
 
-	public InstanceTemplates findMatch(int chunkData)
+	public static InstanceTemplates findMatch(int chunkData)
 	{
 		int rotation = chunkData >> 1 & 0x3; //unused, but shows us the rotation of the chunk
 		int y = (chunkData >> 3 & 0x7FF) * 8;

--- a/runelite-api/src/main/java/net/runelite/api/InstanceTemplates.java
+++ b/runelite-api/src/main/java/net/runelite/api/InstanceTemplates.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2018, Kamiel
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.api;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+public enum InstanceTemplates
+{
+	;
+
+	@Getter
+	private final int baseX;
+
+	@Getter
+	private final int baseY;
+
+	@Getter
+	private final int plane;
+
+	@Getter
+	private final int width;
+
+	@Getter
+	private final int height;
+
+	public InstanceTemplates findMatch(int chunkData)
+	{
+		int rotation = chunkData >> 1 & 0x3; //unused, but shows us the rotation of the chunk
+		int y = (chunkData >> 3 & 0x7FF) * 8;
+		int x = (chunkData >> 14 & 0x3FF) * 8;
+		int plane = chunkData >> 24 & 0x3;
+
+		for (InstanceTemplates template : InstanceTemplates.values())
+		{
+			if (plane == template.getPlane()
+					&& x >= template.getBaseX() && x < template.getBaseX() + template.getWidth()
+					&& y >= template.getBaseY() && y < template.getBaseY() + template.getHeight())
+			{
+				return template;
+			}
+		}
+
+		return null;
+	}
+}

--- a/runescape-api/src/main/java/net/runelite/rs/api/RSClient.java
+++ b/runescape-api/src/main/java/net/runelite/rs/api/RSClient.java
@@ -276,6 +276,10 @@ public interface RSClient extends RSGameEngine, Client
 	@Override
 	int[] getMapRegions();
 
+	@Import("instanceTemplateChunks")
+	@Override
+	int[][][] getInstanceTemplateChunks();
+
 	@Import("xteaKeys")
 	@Override
 	int[][] getXteaKeys();

--- a/runescape-client/src/main/java/Client.java
+++ b/runescape-client/src/main/java/Client.java
@@ -651,7 +651,8 @@ public final class Client extends GameEngine implements class277 {
    @Export("isDynamicRegion")
    static boolean isDynamicRegion;
    @ObfuscatedName("fu")
-   static int[][][] field897;
+   @Export("instanceTemplateChunks")
+   static int[][][] instanceTemplateChunks;
    @ObfuscatedName("fg")
    static final int[] field898;
    @ObfuscatedName("fj")
@@ -1191,7 +1192,7 @@ public final class Client extends GameEngine implements class277 {
       field894 = 0;
       collisionMaps = new CollisionData[4];
       isDynamicRegion = false;
-      field897 = new int[4][13][13];
+      instanceTemplateChunks = new int[4][13][13];
       field898 = new int[]{0, 0, 0, 0, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 3};
       field1091 = 0;
       field901 = 2301979;
@@ -1781,7 +1782,7 @@ public final class Client extends GameEngine implements class277 {
                         if(var41 >= 4) {
                            for(var41 = 0; var41 < 13; ++var41) {
                               for(var40 = 0; var40 < 13; ++var40) {
-                                 var5 = field897[0][var41][var40];
+                                 var5 = instanceTemplateChunks[0][var41][var40];
                                  if(var5 == -1) {
                                     class43.method592(var41 * 8, var40 * 8, 8, 8);
                                  }
@@ -1800,7 +1801,7 @@ public final class Client extends GameEngine implements class277 {
 
                               for(var40 = 0; var40 < 13; ++var40) {
                                  for(var5 = 0; var5 < 13; ++var5) {
-                                    var6 = field897[var41][var40][var5];
+                                    var6 = instanceTemplateChunks[var41][var40][var5];
                                     if(var6 != -1) {
                                        var7 = var6 >> 24 & 3;
                                        var57 = var6 >> 1 & 3;
@@ -1827,7 +1828,7 @@ public final class Client extends GameEngine implements class277 {
                         for(var40 = 0; var40 < 13; ++var40) {
                            for(var5 = 0; var5 < 13; ++var5) {
                               boolean var56 = false;
-                              var7 = field897[var41][var40][var5];
+                              var7 = instanceTemplateChunks[var41][var40][var5];
                               if(var7 != -1) {
                                  var57 = var7 >> 24 & 3;
                                  var46 = var7 >> 1 & 3;

--- a/runescape-client/src/main/java/class23.java
+++ b/runescape-client/src/main/java/class23.java
@@ -79,9 +79,9 @@ public class class23 {
                for(var8 = 0; var8 < 13; ++var8) {
                   var9 = var1.getBits(1);
                   if(var9 == 1) {
-                     Client.field897[var6][var7][var8] = var1.getBits(26);
+                     Client.instanceTemplateChunks[var6][var7][var8] = var1.getBits(26);
                   } else {
-                     Client.field897[var6][var7][var8] = -1;
+                     Client.instanceTemplateChunks[var6][var7][var8] = -1;
                   }
                }
             }
@@ -106,7 +106,7 @@ public class class23 {
          for(var6 = 0; var6 < 4; ++var6) {
             for(var7 = 0; var7 < 13; ++var7) {
                for(var8 = 0; var8 < 13; ++var8) {
-                  var9 = Client.field897[var6][var7][var8];
+                  var9 = Client.instanceTemplateChunks[var6][var7][var8];
                   if(var9 != -1) {
                      int var10 = var9 >> 14 & 1023;
                      int var11 = var9 >> 3 & 2047;


### PR DESCRIPTION
This allows us to determine what instance a player is in if we know the coordinates of the original location.
The client uses the 'template' to construct an instanced region at another location.

Each chunk is 8*8 tiles, so to get the correct data you have to divide the region x and y of the tile you're checking by 8
`int chunkData = client.getInstanceTemplateChunks()[plane][x / 8][y / 8]`

Big thanks to Hexagon#0001 on discord for the correct masks.
