### PR TITLE
Disable configuration button when all items hidden

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
@@ -210,9 +210,14 @@ public class ConfigPanel extends PluginPanel
 		if (config != null)
 		{
 			final ConfigDescriptor configDescriptor = configManager.getConfigDescriptor(config);
-			editConfigButton.addActionListener(ae -> openGroupConfigPanel(config, configDescriptor, configManager));
-			editConfigButton.setEnabled(true);
-			editConfigButton.setToolTipText("Edit plugin configuration");
+			final boolean configEmpty = configDescriptor.getItems().stream().allMatch(item -> item.getItem().hidden());
+
+			if (!configEmpty)
+			{
+				editConfigButton.addActionListener(ae -> openGroupConfigPanel(config, configDescriptor, configManager));
+				editConfigButton.setEnabled(true);
+				editConfigButton.setToolTipText("Edit plugin configuration");
+			}
 		}
 
 		return editConfigButton;


### PR DESCRIPTION
Disable configuration button in ConfigPanel when all configuration items
of the plugin are hidden.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>