### PR TITLE
Cache enum values

### DIFF
--- a/deobfuscator/src/main/java/net/runelite/asm/attributes/code/InstructionType.java
+++ b/deobfuscator/src/main/java/net/runelite/asm/attributes/code/InstructionType.java
@@ -308,6 +308,8 @@ public enum InstructionType
 	IFNONNULL(0xc7, "ifnonnull", IfNonNull.class),
 	GOTO_W(0xc8, "goto_w", GotoW.class);
 
+	public static final InstructionType[] VALUES = values();
+
 	private final int code;
 	private final String name;
 	private final Class<? extends Instruction> clazz;
@@ -336,7 +338,7 @@ public enum InstructionType
 
 	public static InstructionType findInstructionFromCode(int code)
 	{
-		for (InstructionType t : InstructionType.values())
+		for (InstructionType t : InstructionType.VALUES)
 		{
 			if (t.getCode() == code)
 			{

--- a/http-api/src/main/java/net/runelite/http/api/hiscore/HiscoreEndpoint.java
+++ b/http-api/src/main/java/net/runelite/http/api/hiscore/HiscoreEndpoint.java
@@ -37,6 +37,8 @@ public enum HiscoreEndpoint
 	DEADMAN("Deadman", "http://services.runescape.com/m=hiscore_oldschool_deadman/index_lite.ws"),
 	SEASONAL_DEADMAN("Seasonal Deadman", "http://services.runescape.com/m=hiscore_oldschool_seasonal/index_lite.ws");
 
+	public static final HiscoreEndpoint[] VALUES = values();
+
 	private final String name;
 	private final HttpUrl hiscoreURL;
 

--- a/http-api/src/main/java/net/runelite/http/api/hiscore/HiscoreSkill.java
+++ b/http-api/src/main/java/net/runelite/http/api/hiscore/HiscoreSkill.java
@@ -60,6 +60,8 @@ public enum HiscoreSkill
 	CLUE_SCROLL_ELITE("Clue Scrolls (elite)"),
 	CLUE_SCROLL_MASTER("Clue Scrolls (master)");
 
+	public static final HiscoreSkill[] VALUES = values();
+
 	private final String name;
 
 	HiscoreSkill(String name)

--- a/http-service/src/main/java/net/runelite/http/service/hiscore/HiscoreService.java
+++ b/http-service/src/main/java/net/runelite/http/service/hiscore/HiscoreService.java
@@ -89,7 +89,7 @@ public class HiscoreService
 
 		for (CSVRecord record : parser.getRecords())
 		{
-			if (count++ >= HiscoreSkill.values().length)
+			if (count++ >= HiscoreSkill.VALUES.length)
 			{
 				log.warn("Jagex Hiscore API returned unexpected data");
 				break; // rest is other things?

--- a/http-service/src/main/java/net/runelite/http/service/worlds/ServiceWorldType.java
+++ b/http-service/src/main/java/net/runelite/http/service/worlds/ServiceWorldType.java
@@ -37,6 +37,8 @@ enum ServiceWorldType
 	DEADMAN(WorldType.DEADMAN, 1 << 29),
 	SEASONAL_DEADMAN(WorldType.SEASONAL_DEADMAN, 1 << 30);
 
+	public static final ServiceWorldType[] VALUES = values();
+
 	private final WorldType apiType;
 	private final int mask;
 

--- a/http-service/src/main/java/net/runelite/http/service/worlds/WorldsService.java
+++ b/http-service/src/main/java/net/runelite/http/service/worlds/WorldsService.java
@@ -91,7 +91,7 @@ public class WorldsService
 	{
 		EnumSet<WorldType> types = EnumSet.noneOf(WorldType.class);
 
-		for (ServiceWorldType type : ServiceWorldType.values())
+		for (ServiceWorldType type : ServiceWorldType.VALUES)
 		{
 			if ((mask & type.getMask()) != 0)
 			{

--- a/runelite-api/src/main/java/net/runelite/api/ChatMessageType.java
+++ b/runelite-api/src/main/java/net/runelite/api/ChatMessageType.java
@@ -50,6 +50,8 @@ public enum ChatMessageType
 	ACTION(109),
 	UNKNOWN(-1);
 
+	public static final ChatMessageType[] VALUES = values();
+
 	private final int type;
 
 	ChatMessageType(int type)
@@ -59,7 +61,7 @@ public enum ChatMessageType
 
 	public static ChatMessageType of(int type)
 	{
-		for (ChatMessageType ct : ChatMessageType.values())
+		for (ChatMessageType ct : ChatMessageType.VALUES)
 		{
 			if (ct.type == type)
 			{

--- a/runelite-api/src/main/java/net/runelite/api/ClanMemberRank.java
+++ b/runelite-api/src/main/java/net/runelite/api/ClanMemberRank.java
@@ -39,11 +39,13 @@ public enum ClanMemberRank
 	GENERAL((byte) 6),
 	OWNER((byte) 7);
 
+	public static final ClanMemberRank[] VALUES = values();
+
 	private static final Map<Byte, ClanMemberRank> BYTE_TO_RANK = new HashMap<>();
 
 	static
 	{
-		for (final ClanMemberRank clanMemberRank : ClanMemberRank.values())
+		for (final ClanMemberRank clanMemberRank : ClanMemberRank.VALUES)
 		{
 			BYTE_TO_RANK.put(clanMemberRank.value, clanMemberRank);
 		}

--- a/runelite-api/src/main/java/net/runelite/api/GameState.java
+++ b/runelite-api/src/main/java/net/runelite/api/GameState.java
@@ -35,6 +35,8 @@ public enum GameState
 	CONNECTION_LOST(40),
 	HOPPING(45);
 
+	public static final GameState[] VALUES = values();
+
 	private final int state;
 
 	GameState(int state)
@@ -44,7 +46,7 @@ public enum GameState
 
 	public static GameState of(int state)
 	{
-		for (GameState gs : GameState.values())
+		for (GameState gs : GameState.VALUES)
 		{
 			if (gs.state == state)
 			{

--- a/runelite-api/src/main/java/net/runelite/api/Prayer.java
+++ b/runelite-api/src/main/java/net/runelite/api/Prayer.java
@@ -55,7 +55,9 @@ public enum Prayer
 	PRESERVE(Varbits.PRAYER_PRESERVE),
 	RIGOUR(Varbits.PRAYER_RIGOUR),
 	AUGURY(Varbits.PRAYER_AUGURY);
-	
+
+	public static final Prayer[] VALUES = values();
+
 	private final Varbits varbit;
 
 	private Prayer(Varbits varbit)

--- a/runelite-api/src/main/java/net/runelite/api/Skill.java
+++ b/runelite-api/src/main/java/net/runelite/api/Skill.java
@@ -52,6 +52,8 @@ public enum Skill
 	CONSTRUCTION("Construction"),
 	OVERALL("Overall");
 
+	public static final Skill[] VALUES = values();
+
 	private final String name;
 
 	Skill(String name)

--- a/runelite-client/src/main/java/net/runelite/client/game/SkillIconManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/game/SkillIconManager.java
@@ -35,7 +35,7 @@ import net.runelite.api.Skill;
 @Slf4j
 public class SkillIconManager
 {
-	private final BufferedImage[] imgCache = new BufferedImage[Skill.values().length];
+	private final BufferedImage[] imgCache = new BufferedImage[Skill.VALUES.length];
 
 	public BufferedImage getSkillImage(Skill skill)
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/barrows/BarrowsBrothers.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/barrows/BarrowsBrothers.java
@@ -36,6 +36,8 @@ public enum BarrowsBrothers
 	KARIL("K", new Point(3566, 3275)),
 	GUTHAN("G", new Point(3577, 3283));
 
+	public static final BarrowsBrothers[] VALUES = values();
+
 	@Getter
 	private final String name;
 	@Getter

--- a/runelite-client/src/main/java/net/runelite/client/plugins/barrows/BarrowsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/barrows/BarrowsOverlay.java
@@ -160,7 +160,7 @@ class BarrowsOverlay extends Overlay
 
 	private void renderBarrowsBrothers(Graphics2D graphics)
 	{
-		for (BarrowsBrothers brother : BarrowsBrothers.values())
+		for (BarrowsBrothers brother : BarrowsBrothers.VALUES)
 		{
 			net.runelite.api.Point location = brother.getLocation();
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/blastfurnace/BarsOres.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/blastfurnace/BarsOres.java
@@ -50,6 +50,8 @@ public enum BarsOres
 	SILVER_BAR(Varbits.BLAST_FURNACE_SILVER_BAR, ItemID.SILVER_BAR),
 	GOLD_BAR(Varbits.BLAST_FURNACE_GOLD_BAR, ItemID.GOLD_BAR);
 
+	public static final BarsOres[] VALUES = values();
+
 	private static final Map<Varbits, BarsOres> VARBIT = new HashMap<>();
 
 	static

--- a/runelite-client/src/main/java/net/runelite/client/plugins/blastfurnace/BlastFurnaceOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/blastfurnace/BlastFurnaceOverlay.java
@@ -62,7 +62,7 @@ class BlastFurnaceOverlay extends Overlay
 
 		imagePanelComponent.getImages().clear();
 
-		for (BarsOres varbit : BarsOres.values())
+		for (BarsOres varbit : BarsOres.VALUES)
 		{
 			int amount = client.getSetting(varbit.getVarbit());
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/boosts/BoostsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/boosts/BoostsOverlay.java
@@ -45,7 +45,7 @@ import net.runelite.client.ui.overlay.infobox.InfoBoxManager;
 class BoostsOverlay extends Overlay
 {
 	@Getter
-	private final BoostIndicator[] indicators = new BoostIndicator[Skill.values().length - 1];
+	private final BoostIndicator[] indicators = new BoostIndicator[Skill.VALUES.length - 1];
 
 	private final Client client;
 	private final BoostsConfig config;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/diaryprogress/DiaryEntry.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/diaryprogress/DiaryEntry.java
@@ -40,6 +40,8 @@ public enum DiaryEntry
 	WESTERN(10, "Western Provinces", Varbits.DIARY_WESTERN_EASY, Varbits.DIARY_WESTERN_MEDIUM, Varbits.DIARY_WESTERN_HARD, Varbits.DIARY_WESTERN_ELITE),
 	WILDERNESS(9, "Wilderness", Varbits.DIARY_WILDERNESS_EASY, Varbits.DIARY_WILDERNESS_MEDIUM, Varbits.DIARY_WILDERNESS_HARD, Varbits.DIARY_WILDERNESS_ELITE);
 
+	public static final DiaryEntry[] VALUES = values();
+
 	private final int index;
 	private final String name;
 	private final Varbits[] varbits;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/diaryprogress/DiaryProgressPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/diaryprogress/DiaryProgressPlugin.java
@@ -56,7 +56,7 @@ public class DiaryProgressPlugin extends Plugin
 			return;
 		}
 
-		for (DiaryEntry entry : DiaryEntry.values())
+		for (DiaryEntry entry : DiaryEntry.VALUES)
 		{
 			Widget child = diaryWidget.getChild(entry.getIndex());
 			child.setText(entry.getName());
@@ -73,7 +73,7 @@ public class DiaryProgressPlugin extends Plugin
 			return;
 		}
 
-		for (DiaryEntry entry : DiaryEntry.values())
+		for (DiaryEntry entry : DiaryEntry.VALUES)
 		{
 			Widget child = diaryWidget.getChild(entry.getIndex());
 			StringBuilder progress = new StringBuilder();

--- a/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordGameEventType.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordGameEventType.java
@@ -124,7 +124,7 @@ public enum DiscordGameEventType
 
 	static boolean combatSkillChanged(final DiscordGameEventType l)
 	{
-		for (Skill skill : Skill.values())
+		for (Skill skill : Skill.VALUES)
 		{
 			if (l.getState().contains(skill.getName()))
 			{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/experiencedrop/DefaultColors.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/experiencedrop/DefaultColors.java
@@ -40,6 +40,8 @@ enum DefaultColors
 	ORANGE(new Color(0xFF, 0x98, 0x1F)),
 	PINK(new Color(0xFF, 0xC8, 0xC8));
 
+	public static final DefaultColors[] VALUES = values();
+
 	@Getter
 	private final Color color;
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/experiencedrop/ExperienceDropPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/experiencedrop/ExperienceDropPlugin.java
@@ -99,7 +99,7 @@ public class ExperienceDropPlugin extends Plugin
 	private void resetTextColor(Widget widget)
 	{
 		int defaultColorIdx = client.getSetting(Varbits.EXPERIENCE_DROP_COLOR);
-		int defaultColor = DefaultColors.values()[defaultColorIdx].getColor().getRGB();
+		int defaultColor = DefaultColors.VALUES[defaultColorIdx].getColor().getRGB();
 		widget.setTextColor(defaultColor);
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/experiencedrop/ExperienceDropPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/experiencedrop/ExperienceDropPlugin.java
@@ -105,7 +105,7 @@ public class ExperienceDropPlugin extends Plugin
 
 	private PrayerType getActivePrayerType()
 	{
-		for (XpPrayer prayer : XpPrayer.values())
+		for (XpPrayer prayer : XpPrayer.VALUES)
 		{
 			if (client.isPrayerActive(prayer.getPrayer()))
 			{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/experiencedrop/XpPrayer.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/experiencedrop/XpPrayer.java
@@ -50,6 +50,8 @@ enum XpPrayer
 	XP_RIGOUR(RIGOUR, RANGE),
 	XP_AUGURY(AUGURY, MAGIC);
 
+	public static final XpPrayer[] VALUES = values();
+
 	@Getter
 	private final Prayer prayer;
 	@Getter

--- a/runelite-client/src/main/java/net/runelite/client/plugins/hiscore/HiscorePanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/hiscore/HiscorePanel.java
@@ -214,7 +214,7 @@ public class HiscorePanel extends PluginPanel
 
 		List<JToggleButton> endpointButtons = new ArrayList<>();
 
-		for (HiscoreEndpoint endpoint : HiscoreEndpoint.values())
+		for (HiscoreEndpoint endpoint : HiscoreEndpoint.VALUES)
 		{
 			try
 			{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/pestcontrol/Game.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/pestcontrol/Game.java
@@ -37,7 +37,7 @@ import static net.runelite.client.plugins.pestcontrol.Portal.YELLOW;
 public class Game
 {
 	// Game starts with all possible rotations
-	private Rotation[] possibleRotations = Rotation.values();
+	private Rotation[] possibleRotations = Rotation.VALUES;
 	// Number of shields dropped
 	private int shieldsDropped;
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/pestcontrol/Rotation.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/pestcontrol/Rotation.java
@@ -38,6 +38,8 @@ public enum Rotation
 	YRPB(YELLOW, RED, PURPLE, BLUE),
 	YPRB(YELLOW, PURPLE, RED, BLUE);
 
+	public static final Rotation[] VALUES = values();
+
 	private final Portal[] portals;
 
 	private Rotation(Portal first, Portal second, Portal third, Portal fourth)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/prayflick/PrayerFlickOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/prayflick/PrayerFlickOverlay.java
@@ -111,7 +111,7 @@ public class PrayerFlickOverlay extends Overlay
 
 	boolean isAnyPrayerActive()
 	{
-		for (Prayer pray : Prayer.values())//Check if any prayers are active
+		for (Prayer pray : Prayer.VALUES)//Check if any prayers are active
 		{
 			if (client.isPrayerActive(pray))
 			{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesPlugin.java
@@ -162,7 +162,7 @@ public class XpGlobesPlugin extends Plugin
 	public void resetGlobeState()
 	{
 		xpGlobes.clear();
-		globeCache = new XpGlobe[Skill.values().length - 1];
+		globeCache = new XpGlobe[Skill.VALUES.length - 1];
 	}
 
 	@Subscribe

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesPlugin.java
@@ -50,7 +50,7 @@ public class XpGlobesPlugin extends Plugin
 	private static final int SECONDS_TO_SHOW_GLOBE = 10;
 	private static final int MAXIMUM_SHOWN_GLOBES = 5;
 
-	private XpGlobe[] globeCache = new XpGlobe[Skill.values().length - 1]; //overall does not trigger xp change event
+	private XpGlobe[] globeCache = new XpGlobe[Skill.VALUES.length - 1]; //overall does not trigger xp change event
 	private final List<XpGlobe> xpGlobes = new ArrayList<>();
 
 	@Inject

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpPanel.java
@@ -83,7 +83,7 @@ class XpPanel extends PluginPanel
 
 		try
 		{
-			for (Skill skill : Skill.values())
+			for (Skill skill : Skill.VALUES)
 			{
 				if (skill == Skill.OVERALL)
 				{

--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSClientMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSClientMixin.java
@@ -445,7 +445,7 @@ public abstract class RSClientMixin implements RSClient
 	public static void experiencedChanged(int idx)
 	{
 		ExperienceChanged experienceChanged = new ExperienceChanged();
-		Skill[] possibleSkills = Skill.values();
+		Skill[] possibleSkills = Skill.VALUES;
 
 		// We subtract one here because 'Overall' isn't considered a skill that's updated.
 		if (idx < possibleSkills.length - 1)


### PR DESCRIPTION
Calls to `#values()` creates a new array every time it is invoked so it's better to cache them. This should help out with GC and even CPU performance since it doesn't have to copy an array every time.

With this being merged it should also be enforced to do the same thing for all future plugins (and core related things) that make use of enums.