### PR TITLE
Display tooltips for widget actions

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/mousehighlight/MouseHighlightOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/mousehighlight/MouseHighlightOverlay.java
@@ -24,6 +24,7 @@
  */
 package net.runelite.client.plugins.mousehighlight;
 
+import com.google.common.base.Strings;
 import java.awt.Dimension;
 import java.awt.Graphics2D;
 import java.awt.Point;
@@ -69,7 +70,7 @@ class MouseHighlightOverlay extends Overlay
 		String target = menuEntry.getTarget();
 		String option = menuEntry.getOption();
 
-		if (target.isEmpty())
+		if (Strings.isNullOrEmpty(option))
 		{
 			return null;
 		}
@@ -89,7 +90,7 @@ class MouseHighlightOverlay extends Overlay
 				}
 		}
 
-		tooltipManager.add(new Tooltip(option + " " + target));
+		tooltipManager.add(new Tooltip(option + (Strings.isNullOrEmpty(target) ? "" : " " + target)));
 		return null;
 	}
 }


### PR DESCRIPTION
Check for option instead of target presence when renderingt the mouse
highlighting overlay.

Fixes: #490

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>

Preview: 
![screenie](https://user-images.githubusercontent.com/5115805/36307844-52dd96dc-131e-11e8-8f07-7b4c69386e09.png)

![screenie](https://user-images.githubusercontent.com/5115805/36307864-6ce9d68a-131e-11e8-8afa-af2f8c2d4feb.png)
