### PR TITLE
Expose Xp Tracker info

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingOverlay.java
@@ -33,6 +33,8 @@ import java.time.Instant;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
 import net.runelite.api.Client;
+import net.runelite.api.Skill;
+import net.runelite.client.plugins.xptracker.XpTrackerPlugin;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.components.PanelComponent;
@@ -84,6 +86,14 @@ class FishingOverlay extends Overlay
 			panelComponent.setTitle("You are NOT fishing");
 			panelComponent.setTitleColor(Color.RED);
 		}
+
+		panelComponent.getLines().add(new PanelComponent.Line(
+				"", XpTrackerPlugin.getSkillXpInfo(Skill.FISHING).getActions()
+		));
+
+		panelComponent.getLines().add(new PanelComponent.Line(
+				"", XpTrackerPlugin.getSkillXpInfo(Skill.FISHING).getActionsHr()
+		));
 
 		return panelComponent.render(graphics, parent);
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingOverlay.java
@@ -43,6 +43,8 @@ import java.util.stream.IntStream;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
 import net.runelite.api.Client;
+import net.runelite.api.Skill;
+import net.runelite.client.plugins.xptracker.XpTrackerPlugin;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.components.PanelComponent;
@@ -100,6 +102,14 @@ class WoodcuttingOverlay extends Overlay
 			panelComponent.setTitle("You are NOT woodcutting");
 			panelComponent.setTitleColor(Color.RED);
 		}
+
+		panelComponent.getLines().add(new PanelComponent.Line(
+				"", XpTrackerPlugin.getSkillXpInfo(Skill.WOODCUTTING).getActions()
+		));
+
+		panelComponent.getLines().add(new PanelComponent.Line(
+				"", XpTrackerPlugin.getSkillXpInfo(Skill.WOODCUTTING).getActionsHr()
+		));
 
 		return panelComponent.render(graphics, parent);
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpInfoBox.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpInfoBox.java
@@ -43,7 +43,7 @@ import net.runelite.api.Client;
 import net.runelite.client.game.SkillIconManager;
 
 @Slf4j
-class XpInfoBox extends JPanel
+public class XpInfoBox extends JPanel
 {
 
 	private static final Color[] PROGRESS_COLORS = new Color[]
@@ -198,5 +198,13 @@ class XpInfoBox extends JPanel
 		}
 
 		return new Color((int) r, (int) g, (int) b);
+	}
+
+	public String getActions() {
+		return actions.getText();
+	}
+
+	public String getActionsHr() {
+		return actionsHr.getText();
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpPanel.java
@@ -137,10 +137,6 @@ class XpPanel extends PluginPanel
 		});
 	}
 
-	public Map<Skill, XpInfoBox> getInfoBoxes(){
-		return infoBoxes;
-	}
-
 	static String formatLine(double number, String description)
 	{
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpPanel.java
@@ -137,6 +137,10 @@ class XpPanel extends PluginPanel
 		});
 	}
 
+	public Map<Skill, XpInfoBox> getInfoBoxes(){
+		return infoBoxes;
+	}
+
 	static String formatLine(double number, String description)
 	{
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerPlugin.java
@@ -36,6 +36,7 @@ import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.GameState;
 import net.runelite.api.Player;
+import net.runelite.api.Skill;
 import net.runelite.api.events.ExperienceChanged;
 import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.GameTick;
@@ -69,7 +70,7 @@ public class XpTrackerPlugin extends Plugin
 	private ScheduledExecutorService executor;
 
 	private NavigationButton navButton;
-	private XpPanel xpPanel;
+	private static XpPanel xpPanel;
 	private WorldResult worlds;
 	private XpWorldType lastWorldType;
 	private String lastUsername;
@@ -168,6 +169,10 @@ public class XpTrackerPlugin extends Plugin
 			}
 		}
 		return xpType;
+	}
+
+	public static XpInfoBox getSkillXpInfo (Skill skill) {
+		return xpPanel.getInfoBoxes().get(skill);
 	}
 
 	@Subscribe


### PR DESCRIPTION
Gives access to Xp Tracker info via:

XpTrackerPlugin.getSkillXpInfo(Skill)

Also re-added Fishing / Woodcutting action counts to overlay via the XpTracker. You can reset the overlay now as well.

Rather rudimentary but it had a simple task. Maybe add some kind of enabled check for the Xp Tracker and some kind of warning for when disabling a plugin that is relied upon.