### PR TITLE
Fix color of text in the NMZ absorption infobox

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/nightmarezone/AbsorptionCounter.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/nightmarezone/AbsorptionCounter.java
@@ -24,18 +24,51 @@
  */
 package net.runelite.client.plugins.nightmarezone;
 
+import java.awt.Color;
 import java.awt.image.BufferedImage;
+import lombok.Getter;
+import lombok.Setter;
 import net.runelite.client.ui.overlay.infobox.Counter;
 
 public class AbsorptionCounter extends Counter
 {
-	public AbsorptionCounter(BufferedImage image, String text)
+	private int absorption;
+
+	@Getter
+	@Setter
+	private int threshold;
+
+	@Getter
+	@Setter
+	private Color aboveThresholdColor = Color.GREEN;
+
+	@Getter
+	@Setter
+	private Color belowThresholdColor = Color.RED;
+
+	public AbsorptionCounter(BufferedImage image, int absorption, int threshold)
 	{
-		super(image, text);
+		super(image, "");
+		this.threshold = threshold;
+		setAbsorption(absorption);
 	}
 
-	public void setAbsorption(int value)
+	public void setAbsorption(int absorption)
 	{
-		setText(String.valueOf(value));
+		this.absorption = absorption;
+		setText(String.valueOf(absorption));
+	}
+
+	@Override
+	public Color getTextColor()
+	{
+		if (absorption >= threshold)
+		{
+			return aboveThresholdColor;
+		}
+		else
+		{
+			return belowThresholdColor;
+		}
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/nightmarezone/NightmareZoneConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/nightmarezone/NightmareZoneConfig.java
@@ -29,17 +29,17 @@ import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
 
 @ConfigGroup(
-		keyName = "nightmareZone",
-		name = "Nightmare Zone",
-		description = "Configuration for the nightmare zone plugin"
+	keyName = "nightmareZone",
+	name = "Nightmare Zone",
+	description = "Configuration for the nightmare zone plugin"
 )
 public interface NightmareZoneConfig extends Config
 {
 	@ConfigItem(
-			keyName = "tray",
-			name = "Send Tray Notification",
-			description = "Toggles tray notifications",
-			position = 2
+		keyName = "tray",
+		name = "Send Tray Notification",
+		description = "Toggles tray notifications",
+		position = 1
 	)
 	default boolean sendTrayNotification()
 	{
@@ -47,10 +47,10 @@ public interface NightmareZoneConfig extends Config
 	}
 
 	@ConfigItem(
-			keyName = "request",
-			name = "Request Window Focus",
-			description = "Toggles window focus request",
-			position = 3
+		keyName = "request",
+		name = "Request Window Focus",
+		description = "Toggles window focus request",
+		position = 2
 	)
 	default boolean requestFocus()
 	{
@@ -58,10 +58,10 @@ public interface NightmareZoneConfig extends Config
 	}
 
 	@ConfigItem(
-			keyName = "overloadnotification",
-			name = "Overload notification",
-			description = "Toggles notifications when your overload runs out",
-			position = 4
+		keyName = "overloadnotification",
+		name = "Overload notification",
+		description = "Toggles notifications when your overload runs out",
+		position = 3
 	)
 	default boolean overloadNotification()
 	{
@@ -69,10 +69,10 @@ public interface NightmareZoneConfig extends Config
 	}
 
 	@ConfigItem(
-			keyName = "absorptionnotification",
-			name = "Absorption notification",
-			description = "Toggles notifications when your absorption points gets below your threshold",
-			position = 5
+		keyName = "absorptionnotification",
+		name = "Absorption notification",
+		description = "Toggles notifications when your absorption points gets below your threshold",
+		position = 4
 	)
 	default boolean absorptionNotification()
 	{
@@ -80,10 +80,10 @@ public interface NightmareZoneConfig extends Config
 	}
 
 	@ConfigItem(
-			keyName = "absorptionthreshold",
-			name = "Absorption Threshold",
-			description = "The amount of absorption points to send a notification at",
-			position = 6
+		keyName = "absorptionthreshold",
+		name = "Absorption Threshold",
+		description = "The amount of absorption points to send a notification at",
+		position = 5
 	)
 	default int absorptionThreshold()
 	{
@@ -91,10 +91,10 @@ public interface NightmareZoneConfig extends Config
 	}
 
 	@ConfigItem(
-			keyName = "moveoverlay",
-			name = "Override NMZ overlay",
-			description = "Overrides the overlay so it doesn't conflict with other RuneLite plugins",
-			position = 7
+		keyName = "moveoverlay",
+		name = "Override NMZ overlay",
+		description = "Overrides the overlay so it doesn't conflict with other RuneLite plugins",
+		position = 6
 	)
 	default boolean moveOverlay()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/nightmarezone/NightmareZoneConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/nightmarezone/NightmareZoneConfig.java
@@ -24,6 +24,7 @@
  */
 package net.runelite.client.plugins.nightmarezone;
 
+import java.awt.Color;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
@@ -69,10 +70,21 @@ public interface NightmareZoneConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "moveoverlay",
+		name = "Override NMZ overlay",
+		description = "Overrides the overlay so it doesn't conflict with other RuneLite plugins",
+		position = 4
+	)
+	default boolean moveOverlay()
+	{
+		return true;
+	}
+
+	@ConfigItem(
 		keyName = "absorptionnotification",
 		name = "Absorption notification",
 		description = "Toggles notifications when your absorption points gets below your threshold",
-		position = 4
+		position = 5
 	)
 	default boolean absorptionNotification()
 	{
@@ -83,7 +95,7 @@ public interface NightmareZoneConfig extends Config
 		keyName = "absorptionthreshold",
 		name = "Absorption Threshold",
 		description = "The amount of absorption points to send a notification at",
-		position = 5
+		position = 6
 	)
 	default int absorptionThreshold()
 	{
@@ -91,13 +103,25 @@ public interface NightmareZoneConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "moveoverlay",
-		name = "Override NMZ overlay",
-		description = "Overrides the overlay so it doesn't conflict with other RuneLite plugins",
-		position = 6
+		keyName = "absorptioncoloroverthreshold",
+		name = "Color above threshold",
+		description = "Configures the color for the absorption widget when above the threshold",
+		position = 7
 	)
-	default boolean moveOverlay()
+	default Color absorptionColorAboveThreshold()
 	{
-		return true;
+		return Color.YELLOW;
 	}
+
+	@ConfigItem(
+		keyName = "absorptioncolorbelowthreshold",
+		name = "Color below threshold",
+		description = "Configures the color for the absorption widget when below the threshold",
+		position = 8
+	)
+	default Color absorptionColorBelowThreshold()
+	{
+		return Color.RED;
+	}
+
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/nightmarezone/NightmareZoneOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/nightmarezone/NightmareZoneOverlay.java
@@ -133,15 +133,25 @@ class NightmareZoneOverlay extends Overlay
 
 	private void addAbsorptionCounter(int startValue)
 	{
-		absorptionCounter = new AbsorptionCounter(itemManager.getImage(ItemID.ABSORPTION_4), "0");
-		absorptionCounter.setAbsorption(startValue);
+		absorptionCounter = new AbsorptionCounter(itemManager.getImage(ItemID.ABSORPTION_4), startValue, config.absorptionThreshold());
+		absorptionCounter.setAboveThresholdColor(config.absorptionColorAboveThreshold());
+		absorptionCounter.setBelowThresholdColor(config.absorptionColorBelowThreshold());
 		infoBoxManager.addInfoBox(absorptionCounter);
 	}
 
-	private void removeAbsorptionCounter()
+	public void removeAbsorptionCounter()
 	{
 		infoBoxManager.removeInfoBox(absorptionCounter);
 		absorptionCounter = null;
 	}
 
+	public void updateConfig()
+	{
+		if (absorptionCounter != null)
+		{
+			absorptionCounter.setAboveThresholdColor(config.absorptionColorAboveThreshold());
+			absorptionCounter.setBelowThresholdColor(config.absorptionColorBelowThreshold());
+			absorptionCounter.setThreshold(config.absorptionThreshold());
+		}
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/nightmarezone/NightmareZonePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/nightmarezone/NightmareZonePlugin.java
@@ -32,6 +32,7 @@ import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
 import net.runelite.api.Varbits;
 import net.runelite.api.events.ChatMessage;
+import net.runelite.api.events.ConfigChanged;
 import net.runelite.api.events.GameTick;
 import net.runelite.client.Notifier;
 import net.runelite.client.config.ConfigManager;
@@ -65,6 +66,18 @@ public class NightmareZonePlugin extends Plugin
 	// This starts as true since you need to get
 	// above the threshold before sending notifications
 	private boolean absorptionNotificationSend = true;
+
+	@Override
+	protected void shutDown()
+	{
+		overlay.removeAbsorptionCounter();
+	}
+
+	@Subscribe
+	public void updateConfig(ConfigChanged event)
+	{
+		overlay.updateConfig();
+	}
 
 	@Provides
 	NightmareZoneConfig getConfig(ConfigManager configManager)


### PR DESCRIPTION
* Changed the default text color to green
* If the absorption points goes below the threshold, the text becomes red
* Added config fields to change the color if needed

Fixes #606