### PR TITLE
Remove viewport contains from cannon/hunter plugin

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonOverlay.java
@@ -27,13 +27,12 @@ package net.runelite.client.plugins.cannon;
 import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Graphics2D;
-import java.awt.Point;
 import java.awt.Polygon;
 import javax.inject.Inject;
 import net.runelite.api.Client;
 import net.runelite.api.Perspective;
 import static net.runelite.api.Perspective.LOCAL_TILE_SIZE;
-import net.runelite.api.widgets.Widget;
+import net.runelite.api.Point;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.OverlayPriority;
@@ -42,6 +41,8 @@ import net.runelite.client.ui.overlay.components.TextComponent;
 
 class CannonOverlay extends Overlay
 {
+	private static final int MAX_DISTANCE = 2500;
+
 	private final Client client;
 	private final CannonConfig config;
 	private final CannonPlugin plugin;
@@ -58,7 +59,7 @@ class CannonOverlay extends Overlay
 	}
 
 	@Override
-	public Dimension render(Graphics2D graphics, Point parent)
+	public Dimension render(Graphics2D graphics, java.awt.Point parent)
 	{
 		if (!plugin.isCannonPlaced() || plugin.getCannonPosition() == null)
 		{
@@ -70,37 +71,35 @@ class CannonOverlay extends Overlay
 			return null;
 		}
 
-		net.runelite.api.Point cannonPoint = Perspective.worldToLocal(client, plugin.getCannonPosition());
+		Point cannonPoint = Perspective.worldToLocal(client, plugin.getCannonPosition());
 
 		if (cannonPoint == null)
 		{
 			return null;
 		}
 
-		net.runelite.api.Point cannonLoc = Perspective.getCanvasTextLocation(client,
-			graphics,
-			cannonPoint,
-			String.valueOf(plugin.getCballsLeft()), 200);
+		Point localLocation = client.getLocalPlayer().getLocalLocation();
 
-		Widget viewport = client.getViewportWidget();
-
-		if (viewport == null)
+		if (localLocation.distanceTo(cannonPoint) <= MAX_DISTANCE)
 		{
-			return null;
-		}
+			Point cannonLoc = Perspective.getCanvasTextLocation(client,
+				graphics,
+				cannonPoint,
+				String.valueOf(plugin.getCballsLeft()), 200);
 
-		if (cannonLoc != null && viewport.contains(cannonLoc))
-		{
-			textComponent.setText(String.valueOf(plugin.getCballsLeft()));
-			textComponent.setPosition(new Point(cannonLoc.getX(), cannonLoc.getY()));
-			textComponent.setColor(plugin.getStateColor());
-			textComponent.render(graphics, parent);
-		}
+			if (cannonLoc != null)
+			{
+				textComponent.setText(String.valueOf(plugin.getCballsLeft()));
+				textComponent.setPosition(new java.awt.Point(cannonLoc.getX(), cannonLoc.getY()));
+				textComponent.setColor(plugin.getStateColor());
+				textComponent.render(graphics, parent);
+			}
 
-		if (config.showDoubleHitSpot())
-		{
-			Color color = config.highlightDoubleHitColor();
-			drawDoubleHitSpots(graphics, cannonPoint, color);
+			if (config.showDoubleHitSpot())
+			{
+				Color color = config.highlightDoubleHitColor();
+				drawDoubleHitSpots(graphics, cannonPoint, color);
+			}
 		}
 
 		return null;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/hunter/TrapOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/hunter/TrapOverlay.java
@@ -32,7 +32,6 @@ import java.awt.Point;
 import java.awt.geom.Arc2D;
 import javax.inject.Inject;
 import net.runelite.api.Client;
-import net.runelite.api.widgets.Widget;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
@@ -43,6 +42,8 @@ import net.runelite.client.ui.overlay.OverlayPosition;
  */
 public class TrapOverlay extends Overlay
 {
+	private static final int MAX_DISTANCE = 2500;
+
 	/**
 	 * Size of the trap timer.
 	 */
@@ -107,11 +108,11 @@ public class TrapOverlay extends Overlay
 	 */
 	private void drawTraps(Graphics2D graphics)
 	{
-		Widget viewport = client.getViewportWidget();
+		net.runelite.api.Point localLocation = client.getLocalPlayer().getLocalLocation();
 		for (HunterTrap trap : plugin.getTraps())
 		{
-			net.runelite.api.Point trapLoc = trap.getGameObject().getCanvasLocation();
-			if (viewport != null && trapLoc != null && viewport.contains(trapLoc))
+			net.runelite.api.Point trapLocation = trap.getGameObject().getLocalLocation();
+			if (trapLocation != null && localLocation.distanceTo(trapLocation) <= MAX_DISTANCE)
 			{
 				switch (trap.getState())
 				{


### PR DESCRIPTION
Since we have the ability to render behind widgets now, the "check if viewport contains" is not necessary anymore. Instead replace it with distance check to remove it if ran off screen.