### PR TITLE
Add Menu Entry Swapper plugin

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) 2018, Adam <Adam@sigterm.info>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.menuentryswapper;
+
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+
+@ConfigGroup(
+	keyName = "menuentryswapper",
+	name = "Menu Entry Swapper",
+	description = "Swap menu entry options"
+)
+public interface MenuEntrySwapperConfig extends Config
+{
+	@ConfigItem(
+		position = 0,
+		keyName = "swapPickpocket",
+		name = "Pickpocket",
+		description = "Swap Talk-to with Pickpocket on NPC<br>Example: Man, Woman"
+	)
+	default boolean swapPickpocket()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		position = 1,
+		keyName = "swapBanker",
+		name = "Bank",
+		description = "Swap Talk-to with Bank on Bank NPC<br>Example: Banker"
+	)
+	default boolean swapBank()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		position = 2,
+		keyName = "swapExchange",
+		name = "Exchange",
+		description = "Swap Talk-to with Exchange on NPC<br>Example: Grand Exchange Clerk, Tool Leprechaun, Void Knight"
+	)
+	default boolean swapExchange()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		position = 3,
+		keyName = "swapHarpoon",
+		name = "Harpoon",
+		description = "Swap Cage, Net with Harpoon on Fishing spot"
+	)
+	default boolean swapHarpoon()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		position = 4,
+		keyName = "swapTrade",
+		name = "Trade",
+		description = "Swap Talk-to with Trade on NPC<br>Example: Shop keeper, Shop assistant"
+	)
+	default boolean swapTrade()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		position = 5,
+		keyName = "swapTravel",
+		name = "Travel",
+		description = "Swap Talk-to with Travel, Take-boat, Pay-fare, Charter on NPC<br>Example: Squire, Monk of Entrana, Customs officer, Trader Crewmember"
+	)
+	default boolean swapTravel()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		position = 6,
+		keyName = "swapPay",
+		name = "Pay",
+		description = "Swap Talk-to with Pay on NPC<br>Example: Elstan, Heskel, Fayeth"
+	)
+	default boolean swapPay()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		position = 7,
+		keyName = "swapHome",
+		name = "Home",
+		description = "Swap Enter with Home on Portal"
+	)
+	default boolean swapHome()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		position = 8,
+		keyName = "swapLastDestination",
+		name = "Last-destination (XXX)",
+		description = "Swap Zanaris with Last-destination on Fairy ring"
+	)
+	default boolean swapLastDestination()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		position = 9,
+		keyName = "swapBoxTrap",
+		name = "Reset",
+		description = "Swap Check with Reset on box trap"
+	)
+	default boolean swapBoxTrap()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		position = 10,
+		keyName = "swapCatacombEntrance",
+		name = "Catacomb entrance",
+		description = "Swap Read with Investigate on Catacombs of Kourend entrance"
+	)
+	default boolean swapCatacombEntrance()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		position = 11,
+		keyName = "swapTeleportItem",
+		name = "Teleport item",
+		description = "Swap Wear, Wield with Rub, Teleport on teleport item<br>Example: Amulet of glory, Ardougne cloak, Chronicle"
+	)
+	default boolean swapTeleportItem()
+	{
+		return true;
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) 2018, Adam <Adam@sigterm.info>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.menuentryswapper;
+
+import com.google.common.eventbus.Subscribe;
+import com.google.inject.Provides;
+import javax.inject.Inject;
+import net.runelite.api.Client;
+import net.runelite.api.GameState;
+import net.runelite.api.MenuEntry;
+import net.runelite.api.events.MenuEntryAdded;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginDescriptor;
+
+@PluginDescriptor(
+	name = "Menu entry swapper plugin",
+	enabledByDefault = false
+)
+public class MenuEntrySwapperPlugin extends Plugin
+{
+	@Inject
+	private Client client;
+
+	@Inject
+	private MenuEntrySwapperConfig config;
+
+	@Provides
+	MenuEntrySwapperConfig provideConfig(ConfigManager configManager)
+	{
+		return configManager.getConfig(MenuEntrySwapperConfig.class);
+	}
+
+	@Subscribe
+	public void onMenuEntryAdded(MenuEntryAdded event)
+	{
+		if (client.getGameState() != GameState.LOGGED_IN)
+		{
+			return;
+		}
+
+		String option = event.getOption().toLowerCase();
+		String target = event.getTarget();
+
+		if (option.equals("talk-to"))
+		{
+			if (config.swapPickpocket())
+			{
+				swap("pickpocket", option, target, true);
+			}
+
+			if (config.swapBank())
+			{
+				swap("bank", option, target, true);
+			}
+
+			if (config.swapExchange())
+			{
+				swap("exchange", option, target, true);
+			}
+
+			if (config.swapTrade())
+			{
+				swap("trade", option, target, true);
+			}
+
+			if (config.swapTravel())
+			{
+				swap("travel", option, target, true);
+				swap("pay-fare", option, target, true);
+				swap("charter", option, target, true);
+				swap("take-boat", option, target, true);
+			}
+
+			if (config.swapPay())
+			{
+				swap("pay", option, target, true);
+			}
+		}
+		else if (config.swapHarpoon() && option.equals("cage"))
+		{
+			swap("harpoon", option, target, true);
+		}
+		else if (config.swapHarpoon() && option.equals("net"))
+		{
+			swap("harpoon", option, target, true);
+		}
+		else if (config.swapHome() && option.equals("enter"))
+		{
+			swap("home", option, target, true);
+		}
+		else if (config.swapLastDestination() && option.equals("zanaris"))
+		{
+			swap("last-destination (", option, target, false);
+		}
+		else if (config.swapBoxTrap() && option.equals("check"))
+		{
+			swap("reset", option, target, true);
+		}
+		else if (config.swapCatacombEntrance() && option.equals("read"))
+		{
+			swap("investigate", option, target, true);
+		}
+		else if (config.swapTeleportItem() && option.equals("wear"))
+		{
+			swap("rub", option, target, true);
+			swap("teleport", option, target, true);
+		}
+		else if (config.swapTeleportItem() && option.equals("wield"))
+		{
+			swap("teleport", option, target, true);
+		}
+	}
+
+	private int searchIndex(MenuEntry[] entries, String option, String target, boolean strict)
+	{
+		for (int i = entries.length - 1; i >= 0; i--)
+		{
+			MenuEntry entry = entries[i];
+			if (strict)
+			{
+				if (entry.getOption().toLowerCase().equals(option) && entry.getTarget().equals(target))
+				{
+					return i;
+				}
+			}
+			else
+			{
+				if (entry.getOption().toLowerCase().contains(option) && entry.getTarget().equals(target))
+				{
+					return i;
+				}
+			}
+		}
+		return -1;
+	}
+
+	private void swap(String optionA, String optionB, String target, boolean strict)
+	{
+		MenuEntry[] entries = client.getMenuEntries();
+
+		int idxA = searchIndex(entries, optionA, target, strict);
+		int idxB = searchIndex(entries, optionB, target, strict);
+
+		if (idxA >= 0 && idxB >= 0)
+		{
+			MenuEntry entry = entries[idxA];
+			entries[idxA] = entries[idxB];
+			entries[idxB] = entry;
+
+			client.setMenuEntries(entries);
+		}
+	}
+}

--- a/runescape-client/src/main/java/class169.java
+++ b/runescape-client/src/main/java/class169.java
@@ -79,7 +79,7 @@ public abstract class class169 {
       garbageValue = "454714155"
    )
    @Export("addMenuEntry")
-   @Hook("addMenuEntry")
+   @Hook(value = "addMenuEntry", end = true)
    public static final void addMenuEntry(String var0, String var1, int var2, int var3, int var4, int var5) {
       Size.method193(var0, var1, var2, var3, var4, var5, false);
    }


### PR DESCRIPTION
The following menu entries will now be left-click:
- Pickpocket (on Man, Woman, etc. You still need attack option set to hidden)
- Bank (on bank NPC)
- Exchange (on Grand Exchange Clerk, Tool Leprechaun, Void Knight, etc.)
- Harpoon (on swordfish and shark Fishing spot)
- Trade (on Shop keeper, Shop assistant, etc.)
- Travel (includes Take-boat, Pay-fare and Charter. On Customs officer, Monk of Entrana, Trader Crewmember, Squire, etc.)
- Pay (on farmers like Elstan, Heskel, etc.)
- Home (on POH Portal)
- Last destination (XXX) (on Fairy ring)
- Reset (on box trap)
- Investigate (on Catacombs of Kourend entrance statue)
- Rub (on jewellery)
- Teleport (on equipable items)

This plugin will not bring the menu entry to the top of the menu if the menu entry it's swapped with wouldn't be at the top. E.g. big piles of people, npcs, etc. are still annoying. This can be implemented, but it will require a slightly different approach to menu entry swapping that also will require some weighting (e.g. should Travel or Pickpocket be at the top of the menu?)

This is not the best / most elegant way of implementing this plugin. Feel free to re-organize / improve it.