### PR TITLE
Fix Netty resource leak

### DIFF
--- a/protocol/src/main/java/net/runelite/protocol/update/encoders/ArchiveResponseEncoder.java
+++ b/protocol/src/main/java/net/runelite/protocol/update/encoders/ArchiveResponseEncoder.java
@@ -55,20 +55,28 @@ public class ArchiveResponseEncoder extends MessageToByteEncoder<ArchiveResponse
 		// - 3 for the header
 		int chunkSize = Math.min(file.readableBytes(), CHUNK_SIZE - 3);
 
-		out.writeBytes(file.readBytes(chunkSize));
+		writeChunk(file.readBytes(chunkSize), out);
 
 		while (file.isReadable())
 		{
 			out.writeByte(0xff);
 
 			chunkSize = Math.min(file.readableBytes(), CHUNK_SIZE - 1);
-			out.writeBytes(file.readBytes(chunkSize));
+			writeChunk(file.readBytes(chunkSize), out);
 		}
 
 		int size = out.readableBytes() - pos;
 		logger.debug("Wrote index {} archive {} (size {}) in {} bytes",
 			archiveResponse.getIndex(), archiveResponse.getArchive(),
 			archiveResponse.getData().length, size);
+	}
+
+	private void writeChunk(ByteBuf chunk, ByteBuf out) {
+		try {
+			out.writeBytes(chunk);
+		} finally {
+			chunk.release();
+		}
 	}
 
 }

--- a/protocol/src/main/java/net/runelite/protocol/update/encoders/ArchiveResponseEncoder.java
+++ b/protocol/src/main/java/net/runelite/protocol/update/encoders/ArchiveResponseEncoder.java
@@ -71,10 +71,14 @@ public class ArchiveResponseEncoder extends MessageToByteEncoder<ArchiveResponse
 			archiveResponse.getData().length, size);
 	}
 
-	private void writeChunk(ByteBuf chunk, ByteBuf out) {
-		try {
+	private void writeChunk(ByteBuf chunk, ByteBuf out)
+	{
+		try
+		{
 			out.writeBytes(chunk);
-		} finally {
+		}
+		finally
+		{
 			chunk.release();
 		}
 	}


### PR DESCRIPTION
from: http://netty.io/wiki/reference-counted-objects.html#derived-buffers
> In contrast, `ByteBuf.copy()` and `ByteBuf.readBytes(int)` are not derived buffers. The returned ByteBuf is allocated will need to be released.

This means we need to release the `ByteBuf` that is created when calling `file.readByte(CHUNK_SIZE)`.