### PR TITLE
Fix for the WidgetHiddenChanged event

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/widgets/Widget.java
+++ b/runelite-api/src/main/java/net/runelite/api/widgets/Widget.java
@@ -78,7 +78,17 @@ public interface Widget
 
 	void setSpriteId(int spriteId);
 
+	/**
+	 * whether the widget is hidden on the screen returns
+	 * @return hidden if any of its parents or itself are hidden
+	 */
 	boolean isHidden();
+
+	/**
+	 * whether the widget is hidden on a local level, not including its parents hidden value
+	 * @return hidden if this widget is set to hidden, parents don't affect this.
+	 */
+	boolean isLocalHidden();
 
 	void setHidden(boolean hidden);
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/attackindicator/AttackIndicatorPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/attackindicator/AttackIndicatorPlugin.java
@@ -119,7 +119,7 @@ public class AttackIndicatorPlugin extends Plugin
 	@Subscribe
 	public void hideWidgets(WidgetHiddenChanged event)
 	{
-		if (event.getWidget().isHidden() || TO_GROUP(event.getWidget().getId()) != COMBAT_GROUP_ID)
+		if (event.getWidget().isLocalHidden() || TO_GROUP(event.getWidget().getId()) != COMBAT_GROUP_ID)
 		{
 			return;
 		}

--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSWidgetMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSWidgetMixin.java
@@ -122,6 +122,13 @@ public abstract class RSWidgetMixin implements RSWidget
 
 	@Inject
 	@Override
+	public boolean isLocalHidden()
+	{
+		return isRSHidden();
+	}
+
+	@Inject
+	@Override
 	public Point getCanvasLocation()
 	{
 		int x = 0;
@@ -336,7 +343,7 @@ public abstract class RSWidgetMixin implements RSWidget
 			return;
 		}
 
-		boolean hidden = isHidden();
+		boolean hidden = isLocalHidden();
 
 		WidgetHiddenChanged event = new WidgetHiddenChanged();
 		event.setWidget(this);


### PR DESCRIPTION
Previously the WidgetHiddenChanged event would use the isHidden method to determine whether it is visible and which hidden value to send in the event, however this is incorrect as isHidden also takes into account the hidden status of all its parent widgets. This has led to WidgetHiddenChanged to be fired with a wrong hidden value.

This PR introduces an isLocalHidden() method to determine the hidden status for the widget without taking into account its parents. Feel free to rename it if there's a more intuitive name for this method.