### PR TITLE
Enable recolouring skill boost text for all options

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/boosts/BoostIndicator.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/boosts/BoostIndicator.java
@@ -69,6 +69,9 @@ public class BoostIndicator extends InfoBox
 	@Override
 	public Color getTextColor()
 	{
+		if (!config.colorText())
+			return Color.WHITE;
+
 		int boosted = client.getBoostedSkillLevel(skill),
 			base = client.getRealSkillLevel(skill);
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/boosts/BoostsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/boosts/BoostsConfig.java
@@ -52,7 +52,7 @@ public interface BoostsConfig extends Config
 	)
 	default boolean colorText()
 	{
-		return false;
+		return true;
 	}
 
 	@ConfigItem(

--- a/runelite-client/src/main/java/net/runelite/client/plugins/boosts/BoostsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/boosts/BoostsConfig.java
@@ -46,6 +46,16 @@ public interface BoostsConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "colorText",
+		name = "Recolour text",
+		description = "Recolour the boosted text to green/red for positive/negative"
+	)
+	default boolean colorText()
+	{
+		return false;
+	}
+
+	@ConfigItem(
 		keyName = "relativeBoost",
 		name = "Use Relative Boosts",
 		description = "Configures whether or not relative boost is used"

--- a/runelite-client/src/main/java/net/runelite/client/plugins/boosts/BoostsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/boosts/BoostsOverlay.java
@@ -111,16 +111,14 @@ class BoostsOverlay extends Overlay
 				}
 
 				String str;
-				Color strColor = Color.WHITE;
+				int boost = boosted - base;
 				if (!config.useRelativeBoost())
 				{
 					str = boosted + "/" + base;
 				}
 				else
 				{
-					int boost = boosted - base;
 					str = String.valueOf(boost);
-					strColor = getTextColor(boost);
 					if (boost > 0)
 					{
 						str = "+" + str;
@@ -131,7 +129,7 @@ class BoostsOverlay extends Overlay
 					skill.getName(),
 					Color.WHITE,
 					str,
-					strColor
+					getTextColor(boost)
 				));
 			}
 		}
@@ -141,6 +139,9 @@ class BoostsOverlay extends Overlay
 
 	private Color getTextColor(int boost)
 	{
+		if (!config.colorText())
+			return Color.WHITE;
+
 		if (boost > 0)
 		{
 			return Color.GREEN;


### PR DESCRIPTION
Fixes #657

![image](https://user-images.githubusercontent.com/35824069/36554339-4d6ab9c4-17ff-11e8-8cad-4f137a5f9348.png)

Allows user to enable colouring of stats for all options (default, relative, indicators)