### PR TITLE
Add support for wildcards in grounditem plugin

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
@@ -292,13 +292,11 @@ public class GroundItemsOverlay extends Overlay
 
 	private boolean listContains(List<String> list, String itemName)
 	{
-		int wildcardIndex;
-		String matchString;
 		itemName = itemName.toLowerCase();
 
 		for (String item : list)
 		{
-			wildcardIndex = item.indexOf("*");
+			int wildcardIndex = item.indexOf("*");
 
 			if (wildcardIndex == -1)
 			{
@@ -308,7 +306,7 @@ public class GroundItemsOverlay extends Overlay
 					continue;
 			}
 
-			matchString = item.replaceAll("\\*", "").toLowerCase();
+			String matchString = item.replaceAll("\\*", "").toLowerCase();
 
 			if (wildcardIndex == 0 && itemName.endsWith(matchString) || itemName.startsWith(matchString))
 				return true;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
@@ -36,7 +36,6 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 import javax.inject.Inject;
 import net.runelite.api.Client;
 import net.runelite.api.Item;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
@@ -36,6 +36,7 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import javax.inject.Inject;
 import net.runelite.api.Client;
 import net.runelite.api.Item;
@@ -154,8 +155,8 @@ public class GroundItemsOverlay extends Overlay
 
 					Integer currentQuantity = items.get(itemId);
 
-					String itemName = itemDefinition.getName().toLowerCase();
-					if (config.showHighlightedOnly() ? highlightedItems.contains(itemName) : !hiddenItems.contains(itemName))
+					String itemName = itemDefinition.getName();
+					if (config.showHighlightedOnly() ? listContains(highlightedItems, itemName) : !listContains(hiddenItems, itemName))
 					{
 						if (itemDefinition.getNote() != -1)
 						{
@@ -180,7 +181,7 @@ public class GroundItemsOverlay extends Overlay
 							gePrice = itemPrice == null ? 0 : itemPrice.getPrice() * quantity;
 							alchPrice = Math.round(itemDefinition.getPrice() * HIGH_ALCHEMY_CONSTANT) * quantity;
 						}
-						if (highlightedItems.contains(itemDefinition.getName().toLowerCase()) ||
+						if (listContains(highlightedItems, itemName) ||
 							gePrice == 0 || ((gePrice >= config.getHideUnderGeValue()) &&
 							(alchPrice >= config.getHideUnderHAValue())))
 						{
@@ -267,7 +268,7 @@ public class GroundItemsOverlay extends Overlay
 							.append(" gp)");
 					}
 
-					if (highlightedItems.contains(item.getName().toLowerCase()))
+					if (listContains(highlightedItems, item.getName()))
 					{
 						textColor = config.highlightedColor();
 					}
@@ -288,5 +289,32 @@ public class GroundItemsOverlay extends Overlay
 		}
 
 		return null;
+	}
+
+	private boolean listContains(List<String> list, String itemName)
+	{
+		int wildcardIndex;
+		String matchString;
+		itemName = itemName.toLowerCase();
+
+		for (String item : list)
+		{
+			wildcardIndex = item.indexOf("*");
+
+			if (wildcardIndex == -1)
+			{
+				if (itemName.equalsIgnoreCase(item))
+					return true;
+				else
+					continue;
+			}
+
+			matchString = item.replaceAll("\\*", "").toLowerCase();
+
+			if (wildcardIndex == 0 && itemName.endsWith(matchString) || itemName.startsWith(matchString))
+				return true;
+		}
+
+		return false;
 	}
 }


### PR DESCRIPTION
Allows the use of wildcards (*) in the highlighted and hidden items. Works for both`*itemname` and `itemname*` and ofcourse `itemname`

Fixes #658