### PR TITLE
Fix crash in ClienUI configChanged event

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
@@ -269,16 +269,19 @@ public class ClientUI extends JFrame
 
 		Dimension size = new Dimension(width, height);
 
-		client.setSize(size);
-		client.setPreferredSize(size);
-
-		client.getParent().setPreferredSize(size);
-		client.getParent().setSize(size);
-
-		if (isVisible())
+		SwingUtilities.invokeLater(() ->
 		{
-			pack();
-		}
+			client.setSize(size);
+			client.setPreferredSize(size);
+
+			client.getParent().setPreferredSize(size);
+			client.getParent().setSize(size);
+
+			if (isVisible())
+			{
+				pack();
+			}
+		});
 	}
 
 	private static void setUIFont(FontUIResource f)


### PR DESCRIPTION
Fix crash that can happen when ConfigChanged event arrives to ClientUI
and pack method is called in the event thread. Move swing/awt related
calls to swing thread to avoid this issue.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>