### PR TITLE
Xp orb fixes

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/OrbCentering.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/OrbCentering.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2018, l2-
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *     list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.xpglobes;
+
+public enum OrbCentering
+{
+	MIDDLE_CANVAS,
+	MIDDLE_VIEWPORT,
+	DYNAMIC
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesConfig.java
@@ -24,6 +24,7 @@
  */
 package net.runelite.client.plugins.xpglobes;
 
+import java.awt.Color;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
@@ -38,10 +39,77 @@ public interface XpGlobesConfig extends Config
 	@ConfigItem(
 		keyName = "enableTooltips",
 		name = "Enable Tooltips",
-		description = "Configures whether or not to show tooltips"
+		description = "Configures whether or not to show tooltips",
+		position = 0
 	)
 	default boolean enableTooltips()
 	{
 		return true;
+	}
+
+	@ConfigItem(
+		keyName = "Progress arc color",
+		name = "Progress arc color",
+		description = "Change the color of the progress arc in the xp orb",
+		position = 1
+	)
+	default Color progressArcColor()
+	{
+		return Color.ORANGE;
+	}
+
+	@ConfigItem(
+		keyName = "Progress orb outline color",
+		name = "Progress orb outline color",
+		description = "Change the color of the progress orb outline",
+		position = 2
+	)
+	default Color progressOrbOutLineColor()
+	{
+		return Color.BLACK;
+	}
+
+	@ConfigItem(
+		keyName = "Progress orb background color",
+		name = "Progress orb background color",
+		description = "Change the color of the progress orb background",
+		position = 3
+	)
+	default Color progressOrbBackgroundColor()
+	{
+		return new Color(Color.gray.getRed(), Color.gray.getGreen(), Color.gray.getBlue(), 127);
+	}
+
+	@ConfigItem(
+		keyName = "Progress arc width",
+		name = "Progress arc width",
+		description = "Change the stroke width of the progress arc",
+		position = 4
+	)
+	default int progressArcStrokeWidth()
+	{
+		return 4;
+	}
+
+	@ConfigItem(
+		keyName = "Orb size",
+		name = "Size of orbs",
+		description = "Change the size of the xp orbs",
+		position = 5
+	)
+	default int xpOrbSize()
+	{
+		return 40;
+	}
+
+	@ConfigItem(
+		keyName = "Center orbs",
+		name = "Center orbs",
+		description = "Where to center the xp orbs around",
+		position = 6
+	)
+	default XpGlobesOverlay.CENTER_ORBS centerOrbs()
+	{
+		return XpGlobesOverlay.CENTER_ORBS.DYNAMIC;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesConfig.java
@@ -77,7 +77,7 @@ public interface XpGlobesConfig extends Config
 	)
 	default Color progressOrbBackgroundColor()
 	{
-		return new Color(Color.gray.getRed(), Color.gray.getGreen(), Color.gray.getBlue(), 127);
+		return new Color(128, 128, 128, 127);
 	}
 
 	@ConfigItem(
@@ -88,7 +88,7 @@ public interface XpGlobesConfig extends Config
 	)
 	default int progressArcStrokeWidth()
 	{
-		return 4;
+		return 2;
 	}
 
 	@ConfigItem(
@@ -108,8 +108,8 @@ public interface XpGlobesConfig extends Config
 		description = "Where to center the xp orbs around",
 		position = 6
 	)
-	default XpGlobesOverlay.CENTER_ORBS centerOrbs()
+	default OrbCentering centerOrbs()
 	{
-		return XpGlobesOverlay.CENTER_ORBS.DYNAMIC;
+		return OrbCentering.DYNAMIC;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesOverlay.java
@@ -55,13 +55,6 @@ public class XpGlobesOverlay extends Overlay
 	private final XpGlobesPlugin plugin;
 	private final XpGlobesConfig config;
 
-	public enum CENTER_ORBS
-	{
-		MIDDLE_CANVAS,
-		MIDDLE_VIEWPORT,
-		DYNAMIC
-	}
-
 	@Inject
 	private SkillIconManager iconManager;
 
@@ -115,6 +108,7 @@ public class XpGlobesOverlay extends Overlay
 		{
 			return null;
 		}
+		
 		int queueSize = plugin.getXpGlobesSize();
 		if (queueSize > 0)
 		{
@@ -138,6 +132,10 @@ public class XpGlobesOverlay extends Overlay
 		double radiusToGoalXp = 360; //draw a circle
 
 		Ellipse2D backgroundCircle = drawEllipse(graphics, x, y);
+
+		Object renderHint = graphics.getRenderingHint(RenderingHints.KEY_STROKE_CONTROL);
+		graphics.setRenderingHint(RenderingHints.KEY_STROKE_CONTROL, RenderingHints.VALUE_STROKE_PURE);
+
 		drawProgressArc(
 			graphics,
 			x, y,
@@ -153,6 +151,9 @@ public class XpGlobesOverlay extends Overlay
 			PROGRESS_RADIUS_START, radiusCurrentXp,
 			config.progressArcStrokeWidth(),
 			config.progressArcColor());
+
+		graphics.setRenderingHint(RenderingHints.KEY_STROKE_CONTROL, renderHint);
+
 		drawSkillImage(graphics, skillToDraw, x, y);
 
 		if (config.enableTooltips())
@@ -163,16 +164,14 @@ public class XpGlobesOverlay extends Overlay
 
 	private void drawProgressArc(Graphics2D graphics, int x, int y, int w, int h, double radiusStart, double radiusEnd, int strokeWidth, Color color)
 	{
-		graphics.setRenderingHint(RenderingHints.  KEY_STROKE_CONTROL, RenderingHints.VALUE_STROKE_PURE);
 		Stroke stroke = graphics.getStroke();
 		graphics.setStroke(new BasicStroke(strokeWidth, BasicStroke.CAP_BUTT, BasicStroke.JOIN_BEVEL));
 		graphics.setColor(color);
-		Arc2D arc = new Arc2D.Double(
+		graphics.draw(new Arc2D.Double(
 			x, y,
 			w, h,
 			radiusStart, radiusEnd,
-			Arc2D.OPEN);
-		graphics.draw(arc);
+			Arc2D.OPEN));
 		graphics.setStroke(stroke);
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesOverlay.java
@@ -165,7 +165,7 @@ public class XpGlobesOverlay extends Overlay
 	{
 		graphics.setRenderingHint(RenderingHints.  KEY_STROKE_CONTROL, RenderingHints.VALUE_STROKE_PURE);
 		Stroke stroke = graphics.getStroke();
-		graphics.setStroke(new BasicStroke(strokeWidth));
+		graphics.setStroke(new BasicStroke(strokeWidth, BasicStroke.CAP_BUTT, BasicStroke.JOIN_BEVEL));
 		graphics.setColor(color);
 		Arc2D arc = new Arc2D.Double(
 			x, y,

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesOverlay.java
@@ -28,6 +28,7 @@ import java.awt.BasicStroke;
 import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Graphics2D;
+import java.awt.RenderingHints;
 import java.awt.Stroke;
 import java.awt.geom.Arc2D;
 import java.awt.geom.Ellipse2D;
@@ -39,6 +40,7 @@ import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.Experience;
 import net.runelite.api.Point;
+import net.runelite.api.widgets.Widget;
 import net.runelite.client.game.SkillIconManager;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayPosition;
@@ -53,19 +55,20 @@ public class XpGlobesOverlay extends Overlay
 	private final XpGlobesPlugin plugin;
 	private final XpGlobesConfig config;
 
+	public enum CENTER_ORBS
+	{
+		MIDDLE_CANVAS,
+		MIDDLE_VIEWPORT,
+		DYNAMIC
+	}
+
 	@Inject
 	private SkillIconManager iconManager;
 
-	private static final int DEFAULT_CIRCLE_WIDTH = 40;
-	private static final int DEFAULT_CIRCLE_HEIGHT = 40;
-	private static final int MINIMUM_STEP_WIDTH = DEFAULT_CIRCLE_WIDTH + 10;
+	private static final int MINIMUM_STEP = 10;
 
-	private static final int PROGRESS_RADIUS_START = 270;
+	private static final int PROGRESS_RADIUS_START = 90;
 	private static final int PROGRESS_RADIUS_REMAINDER = 0;
-
-	private static final Color DEFAULT_XPGLOBE_BACKGROUND_COLOR = new Color(Color.gray.getRed(), Color.gray.getGreen(), Color.gray.getBlue(), 127);
-	private static final Color DEFAULT_PROGRESS_ARC_COLOR = Color.ORANGE;
-	private static final Color DEFAULT_PROGRESS_REMAINDER_ARC_COLOR = Color.BLACK;
 
 	private static final int DEFAULT_START_Y = 10;
 
@@ -84,31 +87,51 @@ public class XpGlobesOverlay extends Overlay
 	@Override
 	public Dimension render(Graphics2D graphics, java.awt.Point point)
 	{
-		//check the width of the client if we can draw properly
-		int clientWidth = client.isResized() ? client.getCanvas().getWidth() : client.getViewportWidth();
-		if (clientWidth <= 0)
+		//if this is null there is no reason to draw e.g. switching between resizable and fixed
+		Widget viewportWidget = client.getViewportWidget();
+		if (viewportWidget == null)
 		{
 			return null;
 		}
 
+		//check the width of the client if we can draw properly
+		int clientWidth;
+		switch (config.centerOrbs())
+		{
+			case MIDDLE_CANVAS:
+				clientWidth = client.getViewportWidth();
+				break;
+			case MIDDLE_VIEWPORT:
+				clientWidth = viewportWidget.getWidth();
+				break;
+			case DYNAMIC:
+				clientWidth = (viewportWidget.getWidth() + client.getViewportWidth()) / 2;
+				break;
+			default:
+				clientWidth = client.getViewportWidth();
+				break;
+		}
+		if (clientWidth <= 0)
+		{
+			return null;
+		}
 		int queueSize = plugin.getXpGlobesSize();
 		if (queueSize > 0)
 		{
 			List<XpGlobe> xpChangedQueue = plugin.getXpGlobes();
-			int markersLength = (queueSize * (DEFAULT_CIRCLE_WIDTH)) + ((MINIMUM_STEP_WIDTH - DEFAULT_CIRCLE_WIDTH) * (queueSize - 1));
+			int markersLength = (queueSize * (config.xpOrbSize())) + ((MINIMUM_STEP) * (queueSize - 1));
 			int startDrawX = (clientWidth - markersLength) / 2;
 
 			for (XpGlobe xpGlobe : xpChangedQueue)
 			{
 				renderProgressCircle(graphics, point, xpGlobe, startDrawX, DEFAULT_START_Y);
-				startDrawX += MINIMUM_STEP_WIDTH;
+				startDrawX += MINIMUM_STEP + config.xpOrbSize();
 			}
 			plugin.removeExpiredXpGlobes();
 		}
 
 		return null;
 	}
-
 	private void renderProgressCircle(Graphics2D graphics, java.awt.Point parent, XpGlobe skillToDraw, int x, int y)
 	{
 		double radiusCurrentXp = skillToDraw.getSkillProgressRadius();
@@ -118,18 +141,18 @@ public class XpGlobesOverlay extends Overlay
 		drawProgressArc(
 			graphics,
 			x, y,
-			DEFAULT_CIRCLE_WIDTH, DEFAULT_CIRCLE_HEIGHT,
+			config.xpOrbSize(), config.xpOrbSize(),
 			PROGRESS_RADIUS_REMAINDER, radiusToGoalXp,
 			5,
-			DEFAULT_PROGRESS_REMAINDER_ARC_COLOR
+			config.progressOrbOutLineColor()
 		);
 		drawProgressArc(
 			graphics,
 			x, y,
-			DEFAULT_CIRCLE_WIDTH, DEFAULT_CIRCLE_HEIGHT,
+			config.xpOrbSize(), config.xpOrbSize(),
 			PROGRESS_RADIUS_START, radiusCurrentXp,
-			2,
-			DEFAULT_PROGRESS_ARC_COLOR);
+			config.progressArcStrokeWidth(),
+			config.progressArcColor());
 		drawSkillImage(graphics, skillToDraw, x, y);
 
 		if (config.enableTooltips())
@@ -140,21 +163,23 @@ public class XpGlobesOverlay extends Overlay
 
 	private void drawProgressArc(Graphics2D graphics, int x, int y, int w, int h, double radiusStart, double radiusEnd, int strokeWidth, Color color)
 	{
+		graphics.setRenderingHint(RenderingHints.  KEY_STROKE_CONTROL, RenderingHints.VALUE_STROKE_PURE);
 		Stroke stroke = graphics.getStroke();
 		graphics.setStroke(new BasicStroke(strokeWidth));
 		graphics.setColor(color);
-		graphics.draw(new Arc2D.Double(
+		Arc2D arc = new Arc2D.Double(
 			x, y,
 			w, h,
 			radiusStart, radiusEnd,
-			Arc2D.OPEN));
+			Arc2D.OPEN);
+		graphics.draw(arc);
 		graphics.setStroke(stroke);
 	}
 
 	private Ellipse2D drawEllipse(Graphics2D graphics, int x, int y)
 	{
-		graphics.setColor(DEFAULT_XPGLOBE_BACKGROUND_COLOR);
-		Ellipse2D ellipse = new Ellipse2D.Double(x, y, DEFAULT_CIRCLE_WIDTH, DEFAULT_CIRCLE_HEIGHT);
+		graphics.setColor(config.progressOrbBackgroundColor());
+		Ellipse2D ellipse = new Ellipse2D.Double(x, y, config.xpOrbSize(), config.xpOrbSize());
 		graphics.fill(ellipse);
 		graphics.draw(ellipse);
 		return ellipse;
@@ -171,8 +196,8 @@ public class XpGlobesOverlay extends Overlay
 
 		graphics.drawImage(
 			skillImage,
-			x + (DEFAULT_CIRCLE_WIDTH / 2) - (skillImage.getWidth() / 2),
-			y + (DEFAULT_CIRCLE_HEIGHT / 2) - (skillImage.getHeight() / 2),
+			x + (config.xpOrbSize() / 2) - (skillImage.getWidth() / 2),
+			y + (config.xpOrbSize() / 2) - (skillImage.getHeight() / 2),
 			null
 		);
 	}
@@ -189,8 +214,8 @@ public class XpGlobesOverlay extends Overlay
 		}
 
 		//draw tooltip under the globe of the mouse location
-		int x = (int) drawnGlobe.getX() - (TOOLTIP_RECT_SIZE_X / 2) + (DEFAULT_CIRCLE_WIDTH / 2);
-		int y = (int) drawnGlobe.getY() + DEFAULT_CIRCLE_HEIGHT + 10;
+		int x = (int) drawnGlobe.getX() - (TOOLTIP_RECT_SIZE_X / 2) + (config.xpOrbSize() / 2);
+		int y = (int) drawnGlobe.getY() + config.xpOrbSize() + 10;
 
 		String skillName = mouseOverSkill.getSkillName();
 		String skillLevel = Integer.toString(mouseOverSkill.getCurrentLevel());


### PR DESCRIPTION
xp progress arcs now render correctly and are neat circles at 99.9% progress. Slightly changed position of the xp orbs and the stroke width of the progress arc. also added customization to change the position and stroke width and more. The progress arc now also starts from the top.

old : https://i.imgur.com/1UgpxLy.png
new : https://i.imgur.com/hQhlMLd.png

The old settings were a stroke width of 2 and positioned in the middle of the canvas. you can now set this in settings.