### PR TITLE
Do not track main menu time

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordGameEventType.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordGameEventType.java
@@ -60,8 +60,8 @@ import static net.runelite.api.Skill.WOODCUTTING;
 @Getter
 public enum DiscordGameEventType
 {
-	IN_GAME("In Game", false),
-	IN_MENU("In Menu", false),
+	IN_GAME("In Game", false, true),
+	IN_MENU("In Menu", false, false),
 	TRAINING_ATTACK(training(ATTACK), DiscordGameEventType::combatSkillChanged),
 	TRAINING_DEFENCE(training(DEFENCE), DiscordGameEventType::combatSkillChanged),
 	TRAINING_STRENGTH(training(STRENGTH), DiscordGameEventType::combatSkillChanged),
@@ -89,14 +89,16 @@ public enum DiscordGameEventType
 	private static final Set<Skill> COMBAT_SKILLS = Sets.newHashSet(ATTACK, STRENGTH, DEFENCE, HITPOINTS, SLAYER, RANGED, MAGIC);
 	private final String state;
 	private String details;
+	private boolean trackTime = true;
 	private boolean considerDelay = true;
 	private Function<DiscordGameEventType, Boolean> isChanged = (l) -> true;
 	private int priority = 0;
 
-	DiscordGameEventType(String state, boolean considerDelay)
+	DiscordGameEventType(String state, boolean considerDelay, boolean trackTime)
 	{
 		this.state = state;
 		this.considerDelay = considerDelay;
+		this.trackTime = trackTime;
 	}
 
 	DiscordGameEventType(String state, int priority, Function<DiscordGameEventType, Boolean> isChanged)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordState.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordState.java
@@ -35,7 +35,7 @@ import net.runelite.client.discord.DiscordService;
 public class DiscordState
 {
 	private final List<DiscordGameEventType> lastQueue = new ArrayList<>();
-	private DiscordGameEventType lastEvent;
+	private DiscordGameEventType event;
 	private Instant startOfAction;
 	private Instant lastAction;
 	private DiscordPresence lastPresence;
@@ -44,7 +44,7 @@ public class DiscordState
 	void reset()
 	{
 		lastQueue.clear();
-		lastEvent = null;
+		event = null;
 		startOfAction = null;
 		lastAction = null;
 		lastPresence = null;
@@ -63,7 +63,7 @@ public class DiscordState
 	void triggerEvent(final DiscordGameEventType eventType, int delay)
 	{
 		final boolean first = startOfAction == null;
-		final boolean changed = eventType != lastEvent && eventType.getIsChanged().apply(lastEvent);
+		final boolean changed = eventType != event && eventType.getIsChanged().apply(event);
 		boolean reset = false;
 
 		if (first)
@@ -103,15 +103,17 @@ public class DiscordState
 		lastAction = Instant.now();
 		final DiscordGameEventType newEvent = lastQueue.get(lastQueue.size() - 1);
 
-		if (lastEvent != newEvent)
+		if (event != newEvent)
 		{
-			lastEvent = newEvent;
+			event = newEvent;
 
-			lastPresence = DiscordPresence.builder()
-				.state(lastEvent.getState())
-				.details(lastEvent.getDetails())
-				.startTimestamp(startOfAction)
-				.build();
+			final DiscordPresence.DiscordPresenceBuilder discordPresenceBuilder = DiscordPresence.builder()
+				.state(event.getState())
+				.details(event.getDetails());
+
+			lastPresence = eventType.isTrackTime()
+				? discordPresenceBuilder.startTimestamp(startOfAction).build()
+				: discordPresenceBuilder.build();
 
 			needsFlush = true;
 		}
@@ -126,11 +128,7 @@ public class DiscordState
 
 		final Duration actionTimeout = Duration.ofMinutes(timeout);
 
-		if (Instant.now().compareTo(lastAction.plus(actionTimeout)) >= 0)
-		{
-			return true;
-		}
+		return Instant.now().compareTo(lastAction.plus(actionTimeout)) >= 0;
 
-		return false;
 	}
 }


### PR DESCRIPTION
Do not track time spent in main menu (in case someone forgots to close
RuneLite or just leaves it running overnight, this information can be a
bit misleading). Also it is not really useful to know/see for how long
is someone in menu.

Closes #667

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>