### PR TITLE
Use SplitPane for ClientUI

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ui/ClientPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ClientPanel.java
@@ -36,9 +36,9 @@ import net.runelite.api.Client;
 @Slf4j
 final class ClientPanel extends JPanel
 {
-	public static final int PANEL_WIDTH = 765, PANEL_HEIGHT = 503;
+	private static final int PANEL_WIDTH = 765, PANEL_HEIGHT = 503;
 
-	public ClientPanel(@Nullable Applet client)
+	ClientPanel(@Nullable Applet client)
 	{
 		setSize(new Dimension(PANEL_WIDTH, PANEL_HEIGHT));
 		setMinimumSize(new Dimension(PANEL_WIDTH, PANEL_HEIGHT));

--- a/runelite-client/src/main/java/net/runelite/client/ui/PluginToolbar.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/PluginToolbar.java
@@ -35,23 +35,22 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class PluginToolbar extends JToolBar
 {
-	public static final int TOOLBAR_WIDTH = 36, TOOLBAR_HEIGHT = 503;
+	private static final int TOOLBAR_WIDTH = 36, TOOLBAR_HEIGHT = 503;
 
 	private final ClientUI ui;
 	private final TreeSet<NavigationButton> buttons = new TreeSet<>(Comparator.comparing(Component::getName));
 
 	private NavigationButton current;
 
-	public PluginToolbar(ClientUI ui)
+	PluginToolbar(ClientUI ui)
 	{
 		super(JToolBar.VERTICAL);
+		setFloatable(false);
+		setSize(new Dimension(TOOLBAR_WIDTH, TOOLBAR_HEIGHT));
+		setMinimumSize(new Dimension(TOOLBAR_WIDTH, TOOLBAR_HEIGHT));
+		setPreferredSize(new Dimension(TOOLBAR_WIDTH, TOOLBAR_HEIGHT));
+		setMaximumSize(new Dimension(TOOLBAR_WIDTH, Integer.MAX_VALUE));
 		this.ui = ui;
-
-		super.setFloatable(false);
-		super.setSize(new Dimension(TOOLBAR_WIDTH, TOOLBAR_HEIGHT));
-		super.setMinimumSize(new Dimension(TOOLBAR_WIDTH, TOOLBAR_HEIGHT));
-		super.setPreferredSize(new Dimension(TOOLBAR_WIDTH, TOOLBAR_HEIGHT));
-		super.setMaximumSize(new Dimension(TOOLBAR_WIDTH, Integer.MAX_VALUE));
 	}
 
 	public void addNavigation(NavigationButton button)
@@ -93,17 +92,17 @@ public class PluginToolbar extends JToolBar
 			current.setSelected(false);
 		}
 
+		final PluginPanel pluginPanel = panelSupplier.get();
+
 		if (current == button)
 		{
-			ui.contract();
+			ui.contract(pluginPanel);
 			current = null;
 		}
 		else
 		{
 			current = button;
 			current.setSelected(true);
-
-			PluginPanel pluginPanel = panelSupplier.get();
 			ui.expand(pluginPanel);
 		}
 	}

--- a/runelite-client/src/main/java/net/runelite/client/ui/TitleToolbar.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/TitleToolbar.java
@@ -50,7 +50,7 @@ public class TitleToolbar extends JPanel
 	private static final int TITLEBAR_SIZE = 23;
 	private static final int ITEM_PADDING = 4;
 
-	public TitleToolbar(RuneLiteProperties properties)
+	TitleToolbar(RuneLiteProperties properties)
 	{
 		// The only other layout manager that would manage it's preferred size without padding
 		// was the GroupLayout manager, which doesn't work with dynamic layouts like this one.


### PR DESCRIPTION
- As with plugin toolbar, only purpose of having the wrapper components
there is to split pane to 2 parts, replace this overly complicated
solution with simply using SplitPane.
- Remove automatic window expanding - just move applet in case the
sidebar do not fits on the screen, in cases like this, resizing of the
window should be handled by user and not by us, prevents future issues
and removes need of us knowing anything about screen bounds

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>