### PR TITLE
 Keep navigation toolbar location consistent

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
@@ -81,7 +81,7 @@ public class ClientUI extends JFrame
 	private final RuneLite runelite;
 	private final Applet client;
 	private final RuneLiteProperties properties;
-	private JPanel navContainer;
+	private JPanel innerNavContainer, outerNavContainer, activeNavContainer;
 	private PluginToolbar pluginToolbar;
 	private PluginPanel pluginPanel;
 	private Dimension clientSize;
@@ -355,14 +355,21 @@ public class ClientUI extends JFrame
 		container.setLayout(new BoxLayout(container, BoxLayout.X_AXIS));
 		container.add(new ClientPanel(client));
 
-		navContainer = new JPanel();
-		navContainer.setLayout(new BorderLayout(0, 0));
-		navContainer.setMinimumSize(new Dimension(0, 0));
-		navContainer.setMaximumSize(new Dimension(0, Integer.MAX_VALUE));
-		container.add(navContainer);
+		innerNavContainer = new JPanel();
+		innerNavContainer.setLayout(new BorderLayout(0, 0));
+		innerNavContainer.setMinimumSize(new Dimension(0, 0));
+		innerNavContainer.setMaximumSize(new Dimension(0, Integer.MAX_VALUE));
+		container.add(innerNavContainer);
 
 		pluginToolbar = new PluginToolbar(this);
 		container.add(pluginToolbar);
+
+		outerNavContainer = new JPanel();
+		outerNavContainer.setLayout(new BorderLayout(0, 0));
+		outerNavContainer.setMinimumSize(new Dimension(0, 0));
+		outerNavContainer.setMaximumSize(new Dimension(0, Integer.MAX_VALUE));
+		container.add(outerNavContainer);
+
 
 		titleToolbar = new TitleToolbar(properties);
 
@@ -379,24 +386,29 @@ public class ClientUI extends JFrame
 	{
 		if (pluginPanel != null)
 		{
-			navContainer.remove(0);
+			activeNavContainer.remove(0);
 		}
 		else
 		{
 			clientSize = this.getSize();
 			if (isInScreenBounds((int) getLocationOnScreen().getX() + getWidth() + PANEL_EXPANDED_WIDTH, (int) getLocationOnScreen().getY()))
 			{
+				activeNavContainer = outerNavContainer;
 				this.setSize(getWidth() + PANEL_EXPANDED_WIDTH, getHeight());
+			}
+			else
+			{
+				activeNavContainer = innerNavContainer;
 			}
 		}
 
 		pluginPanel = panel;
-		navContainer.setMinimumSize(new Dimension(PANEL_EXPANDED_WIDTH, 0));
-		navContainer.setMaximumSize(new Dimension(PANEL_EXPANDED_WIDTH, Integer.MAX_VALUE));
+		activeNavContainer.setMinimumSize(new Dimension(PANEL_EXPANDED_WIDTH, 0));
+		activeNavContainer.setMaximumSize(new Dimension(PANEL_EXPANDED_WIDTH, Integer.MAX_VALUE));
 
 		final JPanel wrappedPanel = panel.getWrappedPanel();
-		navContainer.add(wrappedPanel);
-		navContainer.revalidate();
+		activeNavContainer.add(wrappedPanel);
+		activeNavContainer.revalidate();
 
 		// panel.onActivate has to go after giveClientFocus so it can get focus if it needs.
 		giveClientFocus();
@@ -410,10 +422,10 @@ public class ClientUI extends JFrame
 	{
 		boolean wasMinimumWidth = this.getWidth() == (int) this.getMinimumSize().getWidth();
 		pluginPanel.onDeactivate();
-		navContainer.remove(0);
-		navContainer.setMinimumSize(new Dimension(0, 0));
-		navContainer.setMaximumSize(new Dimension(0, Integer.MAX_VALUE));
-		navContainer.revalidate();
+		activeNavContainer.remove(0);
+		activeNavContainer.setMinimumSize(new Dimension(0, 0));
+		activeNavContainer.setMaximumSize(new Dimension(0, Integer.MAX_VALUE));
+		activeNavContainer.revalidate();
 		giveClientFocus();
 		revalidateMinimumSize();
 		if (wasMinimumWidth)

--- a/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
@@ -84,7 +84,6 @@ public class ClientUI extends JFrame
 	private JPanel innerNavContainer, outerNavContainer, activeNavContainer;
 	private PluginToolbar pluginToolbar;
 	private PluginPanel pluginPanel;
-	private Dimension clientSize;
 
 	@Getter
 	private TitleToolbar titleToolbar;
@@ -390,7 +389,6 @@ public class ClientUI extends JFrame
 		}
 		else
 		{
-			clientSize = this.getSize();
 			if (isInScreenBounds((int) getLocationOnScreen().getX() + getWidth() + PANEL_EXPANDED_WIDTH, (int) getLocationOnScreen().getY()))
 			{
 				activeNavContainer = outerNavContainer;
@@ -432,9 +430,9 @@ public class ClientUI extends JFrame
 		{
 			this.setSize((int) this.getMinimumSize().getWidth(), getHeight());
 		}
-		else if (getWidth() < Toolkit.getDefaultToolkit().getScreenSize().getWidth())
+		else if (activeNavContainer == outerNavContainer)
 		{
-			this.setSize(clientSize);
+			this.setSize(getWidth() - PANEL_EXPANDED_WIDTH, getHeight());
 		}
 
 		pluginPanel = null;

--- a/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
@@ -73,6 +73,8 @@ import org.pushingpixels.substance.internal.utils.SubstanceTitlePaneUtilities;
 public class ClientUI extends JFrame
 {
 	private static final int PANEL_EXPANDED_WIDTH = PluginPanel.PANEL_WIDTH + PluginPanel.SCROLLBAR_WIDTH;
+	private static final Dimension PANEL_MINIMIZED_DIMENSION = new Dimension(0, 0);
+	private static final Dimension PANEL_EXPANDED_DIMENSION = new Dimension(PANEL_EXPANDED_WIDTH, Integer.MAX_VALUE);
 	private static final BufferedImage ICON;
 
 	@Getter
@@ -81,7 +83,9 @@ public class ClientUI extends JFrame
 	private final RuneLite runelite;
 	private final Applet client;
 	private final RuneLiteProperties properties;
-	private JPanel innerNavContainer, outerNavContainer, activeNavContainer;
+	private JPanel innerNavContainer;
+	private JPanel outerNavContainer;
+	private JPanel activeNavContainer;
 	private PluginToolbar pluginToolbar;
 	private PluginPanel pluginPanel;
 
@@ -356,8 +360,7 @@ public class ClientUI extends JFrame
 
 		innerNavContainer = new JPanel();
 		innerNavContainer.setLayout(new BorderLayout(0, 0));
-		innerNavContainer.setMinimumSize(new Dimension(0, 0));
-		innerNavContainer.setMaximumSize(new Dimension(0, Integer.MAX_VALUE));
+		innerNavContainer.setMaximumSize(PANEL_EXPANDED_DIMENSION);
 		container.add(innerNavContainer);
 
 		pluginToolbar = new PluginToolbar(this);
@@ -365,10 +368,8 @@ public class ClientUI extends JFrame
 
 		outerNavContainer = new JPanel();
 		outerNavContainer.setLayout(new BorderLayout(0, 0));
-		outerNavContainer.setMinimumSize(new Dimension(0, 0));
-		outerNavContainer.setMaximumSize(new Dimension(0, Integer.MAX_VALUE));
+		outerNavContainer.setMaximumSize(PANEL_EXPANDED_DIMENSION);
 		container.add(outerNavContainer);
-
 
 		titleToolbar = new TitleToolbar(properties);
 
@@ -385,7 +386,7 @@ public class ClientUI extends JFrame
 	{
 		if (pluginPanel != null)
 		{
-			activeNavContainer.remove(0);
+			activeNavContainer.remove(pluginPanel.getWrappedPanel());
 		}
 		else
 		{
@@ -401,10 +402,9 @@ public class ClientUI extends JFrame
 		}
 
 		pluginPanel = panel;
-		activeNavContainer.setMinimumSize(new Dimension(PANEL_EXPANDED_WIDTH, 0));
-		activeNavContainer.setMaximumSize(new Dimension(PANEL_EXPANDED_WIDTH, Integer.MAX_VALUE));
 
 		final JPanel wrappedPanel = panel.getWrappedPanel();
+		activeNavContainer.setMinimumSize(PANEL_EXPANDED_DIMENSION);
 		activeNavContainer.add(wrappedPanel);
 		activeNavContainer.revalidate();
 
@@ -420,9 +420,8 @@ public class ClientUI extends JFrame
 	{
 		boolean wasMinimumWidth = this.getWidth() == (int) this.getMinimumSize().getWidth();
 		pluginPanel.onDeactivate();
-		activeNavContainer.remove(0);
-		activeNavContainer.setMinimumSize(new Dimension(0, 0));
-		activeNavContainer.setMaximumSize(new Dimension(0, Integer.MAX_VALUE));
+		activeNavContainer.setMinimumSize(PANEL_MINIMIZED_DIMENSION);
+		activeNavContainer.remove(pluginPanel.getWrappedPanel());
 		activeNavContainer.revalidate();
 		giveClientFocus();
 		revalidateMinimumSize();
@@ -430,7 +429,7 @@ public class ClientUI extends JFrame
 		{
 			this.setSize((int) this.getMinimumSize().getWidth(), getHeight());
 		}
-		else if (activeNavContainer == outerNavContainer)
+		else if (activeNavContainer == outerNavContainer && getWidth() < Toolkit.getDefaultToolkit().getScreenSize().getWidth())
 		{
 			this.setSize(getWidth() - PANEL_EXPANDED_WIDTH, getHeight());
 		}


### PR DESCRIPTION
old: https://puu.sh/zwhy8/e05b6d0429.gif
new: https://puu.sh/zweQu/716d58a3ad.gif

Also fixes an issue with the client jumping back to an older size when you resize after opening a panel.