### PR TITLE
fix jumpy arcs on xp globes, fixes #384

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesOverlay.java
@@ -24,11 +24,7 @@
  */
 package net.runelite.client.plugins.xpglobes;
 
-import java.awt.BasicStroke;
-import java.awt.Color;
-import java.awt.Dimension;
-import java.awt.Graphics2D;
-import java.awt.Stroke;
+import java.awt.*;
 import java.awt.geom.Arc2D;
 import java.awt.geom.Ellipse2D;
 import java.awt.image.BufferedImage;
@@ -140,7 +136,10 @@ public class XpGlobesOverlay extends Overlay
 
 	private void drawProgressArc(Graphics2D graphics, int x, int y, int w, int h, double radiusStart, double radiusEnd, int strokeWidth, Color color)
 	{
+		Object renderHint = graphics.getRenderingHint(RenderingHints.KEY_STROKE_CONTROL);
 		Stroke stroke = graphics.getStroke();
+
+		graphics.setRenderingHint(RenderingHints.KEY_STROKE_CONTROL, RenderingHints.VALUE_STROKE_PURE);
 		graphics.setStroke(new BasicStroke(strokeWidth));
 		graphics.setColor(color);
 		graphics.draw(new Arc2D.Double(
@@ -148,6 +147,8 @@ public class XpGlobesOverlay extends Overlay
 			w, h,
 			radiusStart, radiusEnd,
 			Arc2D.OPEN));
+
+		graphics.setRenderingHint(RenderingHints.KEY_STROKE_CONTROL, renderHint);
 		graphics.setStroke(stroke);
 	}
 


### PR DESCRIPTION
Fixes the arcs on the XP globes being jumpy by using a rendering hint to increase the quality of the stroke drawn and restoring the original quality after draw.

edit: Animation of after (left) and before (right), not in game but you get the idea.
https://gfycat.com/SphericalScaryLaughingthrush