### PR TITLE
Add more features to raids plugin

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/Varbits.java
+++ b/runelite-api/src/main/java/net/runelite/api/Varbits.java
@@ -179,6 +179,8 @@ public enum Varbits
 	 * Raids
 	 */
 	IN_RAID(5432),
+	TOTAL_POINTS(5431),
+	PERSONAL_POINTS(5422),
 
 	/**
 	 * Nightmare Zone

--- a/runelite-client/src/main/java/net/runelite/client/plugins/raids/Raid.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/raids/Raid.java
@@ -24,7 +24,9 @@
  */
 package net.runelite.client.plugins.raids;
 
+import com.google.common.base.Joiner;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import lombok.Getter;
 import net.runelite.client.plugins.raids.solver.Layout;
@@ -107,6 +109,11 @@ public class Raid
 		}
 
 		return combatRooms.toArray(new RaidRoom[combatRooms.size()]);
+	}
+
+	public String getRotationString()
+	{
+		return Joiner.on(",").join(Arrays.stream(getCombatRooms()).map(r -> r.getBoss().getName()).toArray());
 	}
 
 	public String toCode()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsConfig.java
@@ -103,6 +103,28 @@ public interface RaidsConfig extends Config
 
 	@ConfigItem(
 		position = 6,
+		keyName = "enableRotationWhitelist",
+		name = "Enable rotation whitelist",
+		description = "Enable the rotation whitelist"
+	)
+	default boolean enableRotationWhitelist()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		position = 7,
+		keyName = "whitelistedRotations",
+		name = "Whitelisted rotations",
+		description = "Warn when boss rotation doesn't match a whitelisted one. Add rotations like [tekton, muttadile, guardians]"
+	)
+	default String whitelistedRotations()
+	{
+		return "";
+	}
+
+	@ConfigItem(
+		position = 8,
 		keyName = "enableLayoutWhitelist",
 		name = "Enable layout whitelist",
 		description = "Enable the layout whitelist"
@@ -113,7 +135,7 @@ public interface RaidsConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 7,
+		position = 9,
 		keyName = "whitelistedLayouts",
 		name = "Whitelisted layouts",
 		description = "Warn when layout doesn't match a whitelisted one. Add layouts like CFSCPPCSCF separated with comma"

--- a/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsConfig.java
@@ -36,6 +36,7 @@ import net.runelite.client.config.ConfigItem;
 public interface RaidsConfig extends Config
 {
 	@ConfigItem(
+		position = 0,
 		keyName = "raidsTimer",
 		name = "Display elapsed raid time",
 		description = "Display elapsed raid time"
@@ -46,6 +47,7 @@ public interface RaidsConfig extends Config
 	}
 
 	@ConfigItem(
+		position = 1,
 		keyName = "pointsMessage",
 		name = "Display points in chatbox after raid",
 		description = "Display a message with total points, individual points and percentage at the end of a raid"
@@ -56,6 +58,7 @@ public interface RaidsConfig extends Config
 	}
 
 	@ConfigItem(
+		position = 2,
 		keyName = "scoutOverlay",
 		name = "Show scout overlay",
 		description = "Display an overlay that shows the current raid layout (when entering lobby)"
@@ -66,6 +69,7 @@ public interface RaidsConfig extends Config
 	}
 
 	@ConfigItem(
+		position = 3,
 		keyName = "scoutOverlayAtBank",
 		name = "Show scout overlay outside lobby",
 		description = "Keep the overlay active while at the raids area"
@@ -76,11 +80,34 @@ public interface RaidsConfig extends Config
 	}
 
 	@ConfigItem(
+		position = 4,
 		keyName = "blacklistedRooms",
 		name = "Blacklisted rooms",
 		description = "Display blacklisted rooms in red on the overlay. Separate with comma (full name)"
 	)
 	default String blacklistedRooms()
+	{
+		return "";
+	}
+
+	@ConfigItem(
+		position = 5,
+		keyName = "enableLayoutWhitelist",
+		name = "Enable layout whitelist",
+		description = "Enable the layout whitelist"
+	)
+	default boolean enableLayoutWhitelist()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		position = 6,
+		keyName = "whitelistedLayouts",
+		name = "Whitelisted layouts",
+		description = "Warn when layout doesn't match a whitelisted one. Add layouts like CFSCPPCSCF separated with comma"
+	)
+	default String whitelistedLayouts()
 	{
 		return "";
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsConfig.java
@@ -81,6 +81,17 @@ public interface RaidsConfig extends Config
 
 	@ConfigItem(
 		position = 4,
+		keyName = "whitelistedRooms",
+		name = "Whitelisted rooms",
+		description = "Display whitelisted rooms in green on the overlay. Separate with comma (full name)"
+	)
+	default String whitelistedRooms()
+	{
+		return "";
+	}
+
+	@ConfigItem(
+		position = 5,
 		keyName = "blacklistedRooms",
 		name = "Blacklisted rooms",
 		description = "Display blacklisted rooms in red on the overlay. Separate with comma (full name)"
@@ -91,7 +102,7 @@ public interface RaidsConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 5,
+		position = 6,
 		keyName = "enableLayoutWhitelist",
 		name = "Enable layout whitelist",
 		description = "Enable the layout whitelist"
@@ -102,7 +113,7 @@ public interface RaidsConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 6,
+		position = 7,
 		keyName = "whitelistedLayouts",
 		name = "Whitelisted layouts",
 		description = "Warn when layout doesn't match a whitelisted one. Add layouts like CFSCPPCSCF separated with comma"

--- a/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsOverlay.java
@@ -101,7 +101,11 @@ public class RaidsOverlay extends Overlay
 			switch (room.getType())
 			{
 				case COMBAT:
-					if (plugin.getBlacklist().contains(room.getBoss().getName().toLowerCase()))
+					if (plugin.getRoomWhitelist().contains(room.getBoss().getName().toLowerCase()))
+					{
+						color = Color.GREEN;
+					}
+					else if (plugin.getRoomBlacklist().contains(room.getBoss().getName().toLowerCase()))
 					{
 						color = Color.RED;
 					}
@@ -112,7 +116,11 @@ public class RaidsOverlay extends Overlay
 					break;
 
 				case PUZZLE:
-					if (plugin.getBlacklist().contains(room.getPuzzle().getName().toLowerCase()))
+					if (plugin.getRoomWhitelist().contains(room.getPuzzle().getName().toLowerCase()))
+					{
+						color = Color.GREEN;
+					}
+					else if (plugin.getRoomBlacklist().contains(room.getPuzzle().getName().toLowerCase()))
 					{
 						color = Color.RED;
 					}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsOverlay.java
@@ -86,6 +86,14 @@ public class RaidsOverlay extends Overlay
 				"Layout", Color.WHITE, layout, color
 		));
 
+		int bossMatches = 0;
+		int bossCount = 0;
+
+		if (config.enableRotationWhitelist())
+		{
+			bossMatches = plugin.getRotationMatches();
+		}
+
 		for (Room layoutRoom : plugin.getRaid().getLayout().getRooms())
 		{
 			int position = layoutRoom.getPosition();
@@ -101,11 +109,13 @@ public class RaidsOverlay extends Overlay
 			switch (room.getType())
 			{
 				case COMBAT:
+					bossCount++;
 					if (plugin.getRoomWhitelist().contains(room.getBoss().getName().toLowerCase()))
 					{
 						color = Color.GREEN;
 					}
-					else if (plugin.getRoomBlacklist().contains(room.getBoss().getName().toLowerCase()))
+					else if (plugin.getRoomBlacklist().contains(room.getBoss().getName().toLowerCase())
+							|| config.enableRotationWhitelist() && bossCount > bossMatches)
 					{
 						color = Color.RED;
 					}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsOverlay.java
@@ -74,6 +74,18 @@ public class RaidsOverlay extends Overlay
 		panelComponent.setTitleColor(Color.WHITE);
 		panelComponent.setTitle("Raid scouter");
 
+		Color color = Color.WHITE;
+		String layout = plugin.getRaid().getLayout().toCode().replaceAll("#", "").replaceAll("¤", "");
+
+		if (config.enableLayoutWhitelist() && !plugin.getLayoutWhitelist().contains(layout.toLowerCase()))
+		{
+			color = Color.RED;
+		}
+
+		panelComponent.getLines().add(new PanelComponent.Line(
+				"Layout", Color.WHITE, layout, color
+		));
+
 		for (Room layoutRoom : plugin.getRaid().getLayout().getRooms())
 		{
 			int position = layoutRoom.getPosition();
@@ -84,7 +96,7 @@ public class RaidsOverlay extends Overlay
 				continue;
 			}
 
-			Color color = Color.WHITE;
+			color = Color.WHITE;
 
 			switch (room.getType())
 			{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsPlugin.java
@@ -78,6 +78,7 @@ public class RaidsPlugin extends Plugin
 {
 	private static final int LOBBY_PLANE = 3;
 	private static final String RAID_START_MESSAGE = "The raid has begun!";
+	private static final String LEVEL_COMPLETE_MESSAGE = "level complete!";
 	private static final String RAID_COMPLETE_MESSAGE = "Congratulations - your raid is complete!";
 	private static final int TOTAL_POINTS = 0, PERSONAL_POINTS = 1, TEXT_CHILD = 4;
 	private static final DecimalFormat DECIMAL_FORMAT = new DecimalFormat("###.##");
@@ -258,10 +259,16 @@ public class RaidsPlugin extends Plugin
 				infoBoxManager.addInfoBox(timer);
 			}
 
+			if (timer != null && message.contains(LEVEL_COMPLETE_MESSAGE))
+			{
+				timer.timeFloor();
+			}
+
 			if (message.startsWith(RAID_COMPLETE_MESSAGE))
 			{
 				if (timer != null)
 				{
+					timer.timeFloor();
 					timer.setStopped(true);
 				}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsPlugin.java
@@ -71,6 +71,7 @@ public class RaidsPlugin extends Plugin
 	private static final String RAID_COMPLETE_MESSAGE = "Congratulations - your raid is complete!";
 	private static final int TOTAL_POINTS = 0, PERSONAL_POINTS = 1, TEXT_CHILD = 4;
 	private static final DecimalFormat DECIMAL_FORMAT = new DecimalFormat("###.##");
+	private static final String SPLIT_REGEX = "\\s*,\\s*";
 
 	private BufferedImage raidsIcon;
 	private RaidsTimer timer;
@@ -99,6 +100,9 @@ public class RaidsPlugin extends Plugin
 
 	@Getter
 	private ArrayList<String> blacklist = new ArrayList<>();
+
+	@Getter
+	private ArrayList<String> layoutWhitelist = new ArrayList<>();
 
 	@Provides
 	RaidsConfig provideConfig(ConfigManager configManager)
@@ -132,7 +136,7 @@ public class RaidsPlugin extends Plugin
 			cacheColors();
 		}
 
-		updateBlacklist();
+		updateLists();
 	}
 
 	@Override
@@ -159,7 +163,12 @@ public class RaidsPlugin extends Plugin
 
 		if (event.getKey().equals("blacklistedRooms"))
 		{
-			updateBlacklist();
+			updateList(blacklist, config.blacklistedRooms());
+		}
+
+		if (event.getKey().equals("whitelistedLayouts"))
+		{
+			updateList(layoutWhitelist, config.whitelistedLayouts());
 		}
 	}
 
@@ -284,10 +293,16 @@ public class RaidsPlugin extends Plugin
 		}
 	}
 
-	private void updateBlacklist()
+	private void updateLists()
 	{
-		blacklist.clear();
-		blacklist.addAll(Arrays.asList(config.blacklistedRooms().toLowerCase().split("\\s*,\\s*")));
+		updateList(blacklist, config.blacklistedRooms());
+		updateList(layoutWhitelist, config.whitelistedLayouts());
+	}
+
+	private void updateList(ArrayList<String> list, String input)
+	{
+		list.clear();
+		list.addAll(Arrays.asList(input.toLowerCase().split(SPLIT_REGEX)));
 	}
 
 	private void cacheColors()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsPlugin.java
@@ -54,8 +54,6 @@ import static net.runelite.api.Perspective.SCENE_SIZE;
 import net.runelite.api.events.ChatMessage;
 import net.runelite.api.events.ConfigChanged;
 import net.runelite.api.events.VarbitChanged;
-import net.runelite.api.widgets.Widget;
-import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.chat.ChatColor;
 import net.runelite.client.chat.ChatColorType;
 import net.runelite.client.chat.ChatMessageBuilder;
@@ -80,8 +78,8 @@ public class RaidsPlugin extends Plugin
 	private static final String RAID_START_MESSAGE = "The raid has begun!";
 	private static final String LEVEL_COMPLETE_MESSAGE = "level complete!";
 	private static final String RAID_COMPLETE_MESSAGE = "Congratulations - your raid is complete!";
-	private static final int TOTAL_POINTS = 0, PERSONAL_POINTS = 1, TEXT_CHILD = 4;
 	private static final DecimalFormat DECIMAL_FORMAT = new DecimalFormat("###.##");
+	private static final DecimalFormat POINTS_FORMAT = new DecimalFormat("#,###");
 	private static final String SPLIT_REGEX = "\\s*,\\s*";
 	private static final Pattern ROTATION_REGEX = Pattern.compile("\\[(.*?)\\]");
 
@@ -274,10 +272,8 @@ public class RaidsPlugin extends Plugin
 
 				if (config.pointsMessage())
 				{
-					Widget raidsWidget = client.getWidget(WidgetInfo.RAIDS_POINTS_INFOBOX).getChild(TEXT_CHILD);
-					String[] raidPoints = raidsWidget.getText().split("<br>");
-					int totalPoints = Integer.parseInt(raidPoints[TOTAL_POINTS].replace(",", ""));
-					int personalPoints = Integer.parseInt(raidPoints[PERSONAL_POINTS].replace(",", ""));
+					int totalPoints = client.getSetting(Varbits.TOTAL_POINTS);
+					int personalPoints = client.getSetting(Varbits.PERSONAL_POINTS);
 
 					double percentage = personalPoints / (totalPoints / 100.0);
 
@@ -285,11 +281,11 @@ public class RaidsPlugin extends Plugin
 							.append(ChatColorType.NORMAL)
 							.append("Total points: ")
 							.append(ChatColorType.HIGHLIGHT)
-							.append(raidPoints[TOTAL_POINTS])
+							.append(POINTS_FORMAT.format(totalPoints))
 							.append(ChatColorType.NORMAL)
 							.append(", Personal points: ")
 							.append(ChatColorType.HIGHLIGHT)
-							.append(raidPoints[PERSONAL_POINTS])
+							.append(POINTS_FORMAT.format(personalPoints))
 							.append(ChatColorType.NORMAL)
 							.append(" (")
 							.append(ChatColorType.HIGHLIGHT)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsPlugin.java
@@ -99,7 +99,10 @@ public class RaidsPlugin extends Plugin
 	private Raid raid;
 
 	@Getter
-	private ArrayList<String> blacklist = new ArrayList<>();
+	private ArrayList<String> roomWhitelist = new ArrayList<>();
+
+	@Getter
+	private ArrayList<String> roomBlacklist = new ArrayList<>();
 
 	@Getter
 	private ArrayList<String> layoutWhitelist = new ArrayList<>();
@@ -161,9 +164,14 @@ public class RaidsPlugin extends Plugin
 			updateInfoBoxState();
 		}
 
+		if (event.getKey().equals("whitelistedRooms"))
+		{
+			updateList(roomWhitelist, config.whitelistedRooms());
+		}
+
 		if (event.getKey().equals("blacklistedRooms"))
 		{
-			updateList(blacklist, config.blacklistedRooms());
+			updateList(roomBlacklist, config.blacklistedRooms());
 		}
 
 		if (event.getKey().equals("whitelistedLayouts"))
@@ -295,7 +303,8 @@ public class RaidsPlugin extends Plugin
 
 	private void updateLists()
 	{
-		updateList(blacklist, config.blacklistedRooms());
+		updateList(roomWhitelist, config.blacklistedRooms());
+		updateList(roomBlacklist, config.blacklistedRooms());
 		updateList(layoutWhitelist, config.whitelistedLayouts());
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsTimer.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsTimer.java
@@ -36,7 +36,11 @@ import net.runelite.client.ui.overlay.infobox.InfoBox;
 public class RaidsTimer extends InfoBox
 {
 	private final Instant startTime;
+	private Instant floorTime;
 	private LocalTime time;
+	private LocalTime firstFloorTime;
+	private LocalTime secondFloorTime;
+	private LocalTime olmTime;
 
 	@Setter
 	private boolean stopped;
@@ -45,7 +49,28 @@ public class RaidsTimer extends InfoBox
 	{
 		super(image);
 		this.startTime = startTime;
+		floorTime = startTime;
 		stopped = false;
+	}
+
+	public void timeFloor()
+	{
+		Duration elapsed = Duration.between(floorTime, Instant.now());
+
+		if (firstFloorTime == null)
+		{
+			firstFloorTime = LocalTime.ofSecondOfDay(elapsed.getSeconds());
+		}
+		else if (secondFloorTime == null)
+		{
+			secondFloorTime = LocalTime.ofSecondOfDay(elapsed.getSeconds());
+		}
+		else if (olmTime == null)
+		{
+			olmTime = LocalTime.ofSecondOfDay(elapsed.getSeconds());
+		}
+
+		floorTime = Instant.now();
 	}
 
 	@Override
@@ -84,6 +109,28 @@ public class RaidsTimer extends InfoBox
 	@Override
 	public String getTooltip()
 	{
-		return "Elapsed raid time: " + time.format(DateTimeFormatter.ofPattern("HH:mm:ss"));
+		StringBuilder builder = new StringBuilder();
+		builder.append("Elapsed raid time: ");
+		builder.append(time.format(DateTimeFormatter.ofPattern("HH:mm:ss")));
+
+		if (firstFloorTime != null)
+		{
+			builder.append("</br>First floor: ");
+			builder.append(firstFloorTime.format(DateTimeFormatter.ofPattern("mm:ss")));
+		}
+
+		if (secondFloorTime != null)
+		{
+			builder.append("</br>Second floor: ");
+			builder.append(secondFloorTime.format(DateTimeFormatter.ofPattern("mm:ss")));
+		}
+
+		if (olmTime != null)
+		{
+			builder.append("</br>Olm: ");
+			builder.append(olmTime.format(DateTimeFormatter.ofPattern("mm:ss")));
+		}
+
+		return builder.toString();
 	}
 }


### PR DESCRIPTION
- Now shows raid layout code on the overlay
- Ability to whitelist/highlight rooms
- Ability to whitelist boss rotations
- Ability to whitelist layouts
- Timer now shows floor completion times on hover

![image](https://user-images.githubusercontent.com/35824069/36713836-c378264a-1b8f-11e8-868d-21d5e9d49526.png)
![image](https://user-images.githubusercontent.com/35824069/36763808-e93a2cb2-1c29-11e8-9182-e2ae15be0808.png)


Current behaviour:
Whitelisted rooms will ALWAYS show up in green (highlight)
Blacklisted rooms and rotations that aren't whitelisted will show up in red
Any boss rotations that partially match a whitelisted one will show the extra boss in red (shown in first picture)

The ideal raid after setting up your settings would show everything in white/green on the overlay.

Input for layout whitelist is `SCSPFCCSPF`, add more separating them with a comma.

Input for boss rotation whitelist is `[vespula, shamans, vasa]` being one rotation. (example used in the first picture)

Fixes #710