### PR TITLE
Fix NPE in minimap plugin

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/minimap/MinimapPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/minimap/MinimapPlugin.java
@@ -106,9 +106,15 @@ public class MinimapPlugin extends Plugin
 		originalDotSprites = Arrays.copyOf(originalDots, originalDots.length);
 	}
 
-	public void restoreOriginalDots()
+	private void restoreOriginalDots()
 	{
 		SpritePixels[] mapDots = client.getMapDots();
+
+		if (originalDotSprites == null || mapDots == null)
+		{
+			return;
+		}
+
 		System.arraycopy(originalDotSprites, 0, mapDots, 0, mapDots.length);
 	}
 


### PR DESCRIPTION
If shutdown was called but startup was not, this would throw NPE.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>

NPE example:
```
net.runelite.client.plugins.PluginInstantiationException: java.lang.reflect.InvocationTargetException
        at net.runelite.client.plugins.PluginManager.stopPlugin(PluginManager.java:376)
        at net.runelite.client.plugins.PluginManager.lambda$null$0(PluginManager.java:126)
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:180)
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:293)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:748)
Caused by: java.lang.reflect.InvocationTargetException: null
        at java.awt.EventQueue.invokeAndWait(EventQueue.java:1321)
        at java.awt.EventQueue.invokeAndWait(EventQueue.java:1296)
        at javax.swing.SwingUtilities.invokeAndWait(SwingUtilities.java:1348)
        at net.runelite.client.plugins.PluginManager.stopPlugin(PluginManager.java:358)
        ... 8 common frames omitted
Caused by: java.lang.RuntimeException: java.lang.NullPointerException
        at net.runelite.client.plugins.PluginManager.lambda$stopPlugin$4(PluginManager.java:366)
        at java.awt.event.InvocationEvent.dispatch(InvocationEvent.java:301)
        at java.awt.EventQueue.dispatchEventImpl(EventQueue.java:756)
        at java.awt.EventQueue.access$500(EventQueue.java:97)
        at java.awt.EventQueue$3.run(EventQueue.java:709)
        at java.awt.EventQueue$3.run(EventQueue.java:703)
        at java.security.AccessController.doPrivileged(Native Method)
        at java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:80)
        at java.awt.EventQueue.dispatchEvent(EventQueue.java:726)
        at java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:201)
        at java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:116)
        at java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:105)
        at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:101)
        at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:93)
        at java.awt.EventDispatchThread.run(EventDispatchThread.java:82)
Caused by: java.lang.NullPointerException: null
        at net.runelite.client.plugins.minimap.MinimapPlugin.restoreOriginalDots(MinimapPlugin.java:112)
        at net.runelite.client.plugins.minimap.MinimapPlugin.shutDown(MinimapPlugin.java:72)
        at net.runelite.client.plugins.PluginManager.lambda$stopPlugin$4(PluginManager.java:362)
        ... 14 common frames omitted
2018-02-27 11:37:33 [pool-2-thread-1] INFO  n.r.client.discord.DiscordService - Discord RPC service is ready.
```