### PR TITLE
examineplugin: only capture menuactions with the option "Examine"

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/examine/ExaminePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/examine/ExaminePlugin.java
@@ -144,6 +144,11 @@ public class ExaminePlugin extends Plugin
 	@Subscribe
 	public void onMenuOptionClicked(MenuOptionClicked event)
 	{
+		if (!event.getMenuOption().equals("Examine"))
+		{
+			return;
+		}
+
 		ExamineType type;
 		int id;
 		switch (event.getMenuAction())


### PR DESCRIPTION
Makes it so it doesn't print out the price of items you interact with like it did below:

![](https://i.gyazo.com/192f0794df2dabe2edb6fe3d84ad062c.png)