### PR TITLE
Fix ArrayIndexOutOfBoundsException on getting vertices of certain gameobjects

### DIFF
--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSModelMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSModelMixin.java
@@ -45,7 +45,7 @@ public abstract class RSModelMixin implements RSModel
 
 		List<Vertex> vertices = new ArrayList<Vertex>();
 
-		for (int i = 0; i < verticesX.length; ++i)
+		for (int i = 0; i < getVerticesCount(); ++i)
 		{
 			Vertex v = new Vertex(
 				verticesX[i],
@@ -67,9 +67,9 @@ public abstract class RSModelMixin implements RSModel
 		int[] trianglesZ = getTrianglesZ();
 
 		List<Vertex> vertices = getVertices();
-		List<Triangle> triangles = new ArrayList<Triangle>(trianglesX.length);
+		List<Triangle> triangles = new ArrayList<Triangle>(getTrianglesCount());
 
-		for (int i = 0; i < trianglesX.length; ++i)
+		for (int i = 0; i < getTrianglesCount(); ++i)
 		{
 			int triangleX = trianglesX[i];
 			int triangleY = trianglesY[i];

--- a/runescape-api/src/main/java/net/runelite/rs/api/RSModel.java
+++ b/runescape-api/src/main/java/net/runelite/rs/api/RSModel.java
@@ -29,6 +29,9 @@ import net.runelite.mapping.Import;
 
 public interface RSModel extends RSRenderable, Model
 {
+	@Import("verticesCount")
+	int getVerticesCount();
+
 	@Import("verticesX")
 	int[] getVerticesX();
 
@@ -37,6 +40,9 @@ public interface RSModel extends RSRenderable, Model
 
 	@Import("verticesZ")
 	int[] getVerticesZ();
+
+	@Import("indicesCount")
+	int getTrianglesCount();
 
 	@Import("indices1")
 	int[] getTrianglesX();


### PR DESCRIPTION
verticesX.length doesn't always equal verticesY.length and verticesZ.length.
I changed it for triangles/indices too.