### PR TITLE
Move the notification options to Notifier

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/RuneLite.java
+++ b/runelite-client/src/main/java/net/runelite/client/RuneLite.java
@@ -98,7 +98,6 @@ public class RuneLite
 
 	Client client;
 	ClientUI gui;
-	Notifier notifier;
 
 	public static void main(String[] args) throws Exception
 	{
@@ -161,9 +160,6 @@ public class RuneLite
 		eventBus.register(gui);
 		eventBus.register(pluginManager);
 
-		// Setup the notifier
-		notifier = new Notifier(properties.getTitle(), gui.getTrayIcon(), runeliteConfig);
-
 		// Tell the plugin manager if client is outdated or not
 		pluginManager.setOutdated(isOutdated);
 
@@ -217,12 +213,6 @@ public class RuneLite
 	public void setClient(Client client)
 	{
 		this.client = client;
-	}
-
-	@VisibleForTesting
-	public void setNotifier(Notifier notifier)
-	{
-		this.notifier = notifier;
 	}
 
 	public static Injector getInjector()

--- a/runelite-client/src/main/java/net/runelite/client/RuneLiteModule.java
+++ b/runelite-client/src/main/java/net/runelite/client/RuneLiteModule.java
@@ -74,12 +74,6 @@ public class RuneLiteModule extends AbstractModule
 	}
 
 	@Provides
-	Notifier provideNotifier(RuneLite runeLite)
-	{
-		return runeLite.notifier;
-	}
-
-	@Provides
 	@Singleton
 	RuneLiteConfig provideConfig(ConfigManager configManager)
 	{

--- a/runelite-client/src/main/java/net/runelite/client/config/RuneLiteConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/RuneLiteConfig.java
@@ -77,11 +77,41 @@ public interface RuneLiteConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "notificationTray",
+		name = "Enable tray notifications",
+		description = "Enables tray notifications"
+	)
+	default boolean enableTrayNotifications()
+	{
+		return true;
+	}
+
+	@ConfigItem(
 		keyName = "notificationSound",
 		name = "Enable sound on notifications",
 		description = "Enables the playing of a beep sound when notifications are displayed"
 	)
 	default boolean enableNotificationSound()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		keyName = "notificationFocused",
+		name = "Send notifications when focused",
+		description = "Toggles idle notifications for when the client is focused"
+	)
+	default boolean sendNotificationsWhenFocused()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		keyName = "notificationRequestFocus",
+		name = "Request focus on notification",
+		description = "Toggles window focus request"
+	)
+	default boolean requestFocusOnNotification()
 	{
 		return true;
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierConfig.java
@@ -36,39 +36,6 @@ import net.runelite.client.config.ConfigItem;
 public interface IdleNotifierConfig extends Config
 {
 	@ConfigItem(
-		keyName = "tray",
-		name = "Send Tray Notification",
-		description = "Toggles tray notifications",
-		position = 2
-	)
-	default boolean sendTrayNotification()
-	{
-		return true;
-	}
-
-	@ConfigItem(
-		keyName = "focused",
-		name = "Notify When Focused",
-		description = "Toggles idle notifications for when the client is focused",
-		position = 3
-	)
-	default boolean alertWhenFocused()
-	{
-		return false;
-	}
-
-	@ConfigItem(
-		keyName = "request",
-		name = "Request Window Focus",
-		description = "Toggles window focus request",
-		position = 4
-	)
-	default boolean requestFocus()
-	{
-		return true;
-	}
-
-	@ConfigItem(
 		keyName = "timeout",
 		name = "Idle Timeout (ms)",
 		description = "The notification delay after the player is idle",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
@@ -25,6 +25,12 @@
  */
 package net.runelite.client.plugins.idlenotifier;
 
+import com.google.common.eventbus.Subscribe;
+import com.google.inject.Provides;
+import java.time.Duration;
+import java.time.Instant;
+import javax.inject.Inject;
+import net.runelite.api.Actor;
 import static net.runelite.api.AnimationID.COOKING_FIRE;
 import static net.runelite.api.AnimationID.COOKING_RANGE;
 import static net.runelite.api.AnimationID.CRAFTING_GLASSBLOWING;
@@ -90,12 +96,6 @@ import static net.runelite.api.AnimationID.WOODCUTTING_IRON;
 import static net.runelite.api.AnimationID.WOODCUTTING_MITHRIL;
 import static net.runelite.api.AnimationID.WOODCUTTING_RUNE;
 import static net.runelite.api.AnimationID.WOODCUTTING_STEEL;
-import com.google.common.eventbus.Subscribe;
-import com.google.inject.Provides;
-import java.time.Duration;
-import java.time.Instant;
-import javax.inject.Inject;
-import net.runelite.api.Actor;
 import net.runelite.api.Client;
 import net.runelite.api.GameState;
 import net.runelite.api.Player;
@@ -107,7 +107,6 @@ import net.runelite.client.Notifier;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
-import net.runelite.client.ui.ClientUI;
 
 @PluginDescriptor(
 	name = "Idle notifier"
@@ -119,9 +118,6 @@ public class IdleNotifierPlugin extends Plugin
 
 	@Inject
 	private Notifier notifier;
-
-	@Inject
-	private ClientUI gui;
 
 	@Inject
 	private Client client;
@@ -283,32 +279,32 @@ public class IdleNotifierPlugin extends Plugin
 
 		if (checkIdleLogout())
 		{
-			sendNotification("[" + local.getName() + "] is about to log out from idling too long!");
+			notifier.notify("[" + local.getName() + "] is about to log out from idling too long!");
 		}
 
 		if (check6hrLogout())
 		{
-			sendNotification("[" + local.getName() + "] is about to log out from being online for 6 hours!");
+			notifier.notify("[" + local.getName() + "] is about to log out from being online for 6 hours!");
 		}
 
 		if (checkAnimationIdle(waitDuration, local))
 		{
-			sendNotification("[" + local.getName() + "] is now idle!");
+			notifier.notify("[" + local.getName() + "] is now idle!");
 		}
 
 		if (checkOutOfCombat(waitDuration, local))
 		{
-			sendNotification("[" + local.getName() + "] is now out of combat!");
+			notifier.notify("[" + local.getName() + "] is now out of combat!");
 		}
 
 		if (checkLowHitpoints(waitDuration))
 		{
-			sendNotification("[" + local.getName() + "] has low hitpoints!");
+			notifier.notify("[" + local.getName() + "] has low hitpoints!");
 		}
 
 		if (checkLowPrayer(waitDuration))
 		{
-			sendNotification("[" + local.getName() + "] has low prayer!");
+			notifier.notify("[" + local.getName() + "] has low prayer!");
 		}
 	}
 
@@ -450,22 +446,6 @@ public class IdleNotifierPlugin extends Plugin
 		}
 
 		return false;
-	}
-
-	private void sendNotification(String message)
-	{
-		if (!config.alertWhenFocused() && gui.isFocused())
-		{
-			return;
-		}
-		if (config.requestFocus())
-		{
-			gui.requestFocus();
-		}
-		if (config.sendTrayNotification())
-		{
-			notifier.notify(message);
-		}
 	}
 
 	private void resetTimers()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/nightmarezone/NightmareZoneConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/nightmarezone/NightmareZoneConfig.java
@@ -37,23 +37,12 @@ import net.runelite.client.config.ConfigItem;
 public interface NightmareZoneConfig extends Config
 {
 	@ConfigItem(
-		keyName = "tray",
-		name = "Send Tray Notification",
-		description = "Toggles tray notifications",
+		keyName = "moveoverlay",
+		name = "Override NMZ overlay",
+		description = "Overrides the overlay so it doesn't conflict with other RuneLite plugins",
 		position = 1
 	)
-	default boolean sendTrayNotification()
-	{
-		return true;
-	}
-
-	@ConfigItem(
-		keyName = "request",
-		name = "Request Window Focus",
-		description = "Toggles window focus request",
-		position = 2
-	)
-	default boolean requestFocus()
+	default boolean moveOverlay()
 	{
 		return true;
 	}
@@ -62,20 +51,9 @@ public interface NightmareZoneConfig extends Config
 		keyName = "overloadnotification",
 		name = "Overload notification",
 		description = "Toggles notifications when your overload runs out",
-		position = 3
+		position = 2
 	)
 	default boolean overloadNotification()
-	{
-		return true;
-	}
-
-	@ConfigItem(
-		keyName = "moveoverlay",
-		name = "Override NMZ overlay",
-		description = "Overrides the overlay so it doesn't conflict with other RuneLite plugins",
-		position = 4
-	)
-	default boolean moveOverlay()
 	{
 		return true;
 	}
@@ -84,7 +62,7 @@ public interface NightmareZoneConfig extends Config
 		keyName = "absorptionnotification",
 		name = "Absorption notification",
 		description = "Toggles notifications when your absorption points gets below your threshold",
-		position = 5
+		position = 3
 	)
 	default boolean absorptionNotification()
 	{
@@ -95,7 +73,7 @@ public interface NightmareZoneConfig extends Config
 		keyName = "absorptionthreshold",
 		name = "Absorption Threshold",
 		description = "The amount of absorption points to send a notification at",
-		position = 6
+		position = 4
 	)
 	default int absorptionThreshold()
 	{
@@ -106,7 +84,7 @@ public interface NightmareZoneConfig extends Config
 		keyName = "absorptioncoloroverthreshold",
 		name = "Color above threshold",
 		description = "Configures the color for the absorption widget when above the threshold",
-		position = 7
+		position = 5
 	)
 	default Color absorptionColorAboveThreshold()
 	{
@@ -117,7 +95,7 @@ public interface NightmareZoneConfig extends Config
 		keyName = "absorptioncolorbelowthreshold",
 		name = "Color below threshold",
 		description = "Configures the color for the absorption widget when below the threshold",
-		position = 8
+		position = 6
 	)
 	default Color absorptionColorBelowThreshold()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/nightmarezone/NightmareZonePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/nightmarezone/NightmareZonePlugin.java
@@ -38,7 +38,6 @@ import net.runelite.client.Notifier;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
-import net.runelite.client.ui.ClientUI;
 import net.runelite.client.ui.overlay.Overlay;
 
 @PluginDescriptor(
@@ -50,9 +49,6 @@ public class NightmareZonePlugin extends Plugin
 
 	@Inject
 	private Notifier notifier;
-
-	@Inject
-	private ClientUI gui;
 
 	@Inject
 	private Client client;
@@ -117,7 +113,7 @@ public class NightmareZonePlugin extends Plugin
 		String msg = event.getMessage().replaceAll("<[^>]*>", " "); //remove color and linebreaks
 		if (msg.contains("The effects of overload have worn off, and you feel normal again."))
 		{
-			sendNotification("Your overload has worn off");
+			notifier.notify("Your overload has worn off");
 		}
 	}
 
@@ -129,7 +125,7 @@ public class NightmareZonePlugin extends Plugin
 		{
 			if (absorptionPoints < config.absorptionThreshold())
 			{
-				sendNotification("Absorption points below: " + config.absorptionThreshold());
+				notifier.notify("Absorption points below: " + config.absorptionThreshold());
 				absorptionNotificationSend = true;
 			}
 		}
@@ -145,17 +141,5 @@ public class NightmareZonePlugin extends Plugin
 	public boolean isInNightmareZone()
 	{
 		return Arrays.equals(client.getMapRegions(), NMZ_MAP_REGION);
-	}
-
-	private void sendNotification(String message)
-	{
-		if (!gui.isFocused() && config.requestFocus())
-		{
-			gui.requestFocus();
-		}
-		if (config.sendTrayNotification())
-		{
-			notifier.notify(message);
-		}
 	}
 }

--- a/runelite-client/src/test/java/net/runelite/client/plugins/PluginManagerTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/PluginManagerTest.java
@@ -43,7 +43,6 @@ import java.util.Objects;
 import java.util.Set;
 import joptsimple.OptionSet;
 import net.runelite.api.Client;
-import net.runelite.client.Notifier;
 import net.runelite.client.RuneLite;
 import net.runelite.client.RuneLiteModule;
 import net.runelite.client.ui.ClientUI;
@@ -74,9 +73,6 @@ public class PluginManagerTest
 	@Mock
 	Client client;
 
-	@Mock
-	Notifier notifier;
-
 	@Before
 	public void before() throws IOException
 	{
@@ -88,7 +84,6 @@ public class PluginManagerTest
 
 		runelite = injector.getInstance(RuneLite.class);
 		runelite.setGui(clientUi);
-		runelite.setNotifier(notifier);
 
 		// Find plugins we expect to have
 		pluginClasses = new HashSet<>();


### PR DESCRIPTION
- Move enabling of tray notifications to RuneLiteConfig
- Move request when focused notification option to RuneLiteConfig and
use it in notifier
- Move request window focus to RuneLiteConfig and use it in notifier
- Change Notifier to use Guice for creation
- Remove notification settings from NMZ that are now contained in
RuneLiteConfig.
- Remove options that are now contained in RuneLiteConfig from idle
notifier.