### PR TITLE
deobfuscator: fix aic failing to determine if a field is imported

### DIFF
--- a/deobfuscator/src/main/java/net/runelite/deob/deobfuscators/mapping/AnnotationIntegrityChecker.java
+++ b/deobfuscator/src/main/java/net/runelite/deob/deobfuscators/mapping/AnnotationIntegrityChecker.java
@@ -44,7 +44,7 @@ public class AnnotationIntegrityChecker
 
 	public static final java.lang.Class<?> CLIENT_CLASS = RSClient.class;
 
-	public static final String API_PACKAGE_BASE = "net.runelite.rs.api.";
+	public static final String API_PACKAGE_BASE = "net.runelite.rs.api.RS";
 
 	private final ClassGroup one;
 	private final ClassGroup two;


### PR DESCRIPTION
RS API classes have the prefix "RS", and the Implements annotation does not have that.