### PR TITLE
Fix camera pitch

### DIFF
--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSRegionMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSRegionMixin.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2018 Abex
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.mixins;
+
+import net.runelite.api.mixins.Copy;
+import net.runelite.api.mixins.Inject;
+import net.runelite.api.mixins.Mixin;
+import net.runelite.api.mixins.Replace;
+import net.runelite.rs.api.RSRegion;
+
+@Mixin(RSRegion.class)
+public abstract class RSRegionMixin implements RSRegion
+{
+	@Inject
+	static boolean isDrawingRegion;
+
+	@Copy("drawRegion")
+	abstract void rs$drawRegion(int cameraX, int cameraY, int cameraZ, int cameraPitch, int cameraYaw, int plane);
+
+	@Replace("drawRegion")
+	void rl$drawRegion(int cameraX, int cameraY, int cameraZ, int cameraPitch, int cameraYaw, int plane)
+	{
+		try
+		{
+			isDrawingRegion = true;
+			rs$drawRegion(cameraX, cameraY, cameraZ, cameraPitch, cameraYaw, plane);
+		}
+		finally
+		{
+			isDrawingRegion = false;
+		}
+	}
+}

--- a/runescape-api/src/main/java/net/runelite/rs/api/RSClient.java
+++ b/runescape-api/src/main/java/net/runelite/rs/api/RSClient.java
@@ -487,6 +487,12 @@ public interface RSClient extends RSGameEngine, Client
 	@Import("cameraPitchTarget")
 	void setCameraPitchTarget(int pitch);
 
+	@Import("pitchSin")
+	void setPitchSin(int v);
+
+	@Import("pitchCos")
+	void setPitchCos(int v);
+
 	@Import("renderOverview")
 	RSRenderOverview getRenderOverview();
 }

--- a/runescape-client/src/main/java/AudioInstrument.java
+++ b/runescape-client/src/main/java/AudioInstrument.java
@@ -14,8 +14,8 @@ public class AudioInstrument {
    @Export("NOISE")
    static int[] NOISE;
    @ObfuscatedName("c")
-   @Export("SINE")
-   static int[] SINE;
+   @Export("AUDIO_SINE")
+   static int[] AUDIO_SINE;
    @ObfuscatedName("l")
    @Export("phases")
    static int[] phases;
@@ -121,10 +121,10 @@ public class AudioInstrument {
          NOISE[var1] = (var0.nextInt() & 2) - 1;
       }
 
-      SINE = new int['耀'];
+      AUDIO_SINE = new int['耀'];
 
       for(var1 = 0; var1 < 32768; ++var1) {
-         SINE[var1] = (int)(Math.sin((double)var1 / 5215.1903D) * 16384.0D);
+         AUDIO_SINE[var1] = (int)(Math.sin((double)var1 / 5215.1903D) * 16384.0D);
       }
 
       samples = new int[220500];
@@ -351,7 +351,7 @@ public class AudioInstrument {
    @ObfuscatedName("z")
    @Export("evaluateWave")
    final int evaluateWave(int var1, int var2, int var3) {
-      return var3 == 1?((var1 & 32767) < 16384?var2:-var2):(var3 == 2?SINE[var1 & 32767] * var2 >> 14:(var3 == 3?(var2 * (var1 & 32767) >> 14) - var2:(var3 == 4?var2 * NOISE[var1 / 2607 & 32767]:0)));
+      return var3 == 1?((var1 & 32767) < 16384?var2:-var2):(var3 == 2? AUDIO_SINE[var1 & 32767] * var2 >> 14:(var3 == 3?(var2 * (var1 & 32767) >> 14) - var2:(var3 == 4?var2 * NOISE[var1 / 2607 & 32767]:0)));
    }
 
    @ObfuscatedName("n")

--- a/runescape-client/src/main/java/Region.java
+++ b/runescape-client/src/main/java/Region.java
@@ -1043,12 +1043,12 @@ public class Region {
    }
 
    @ObfuscatedName("ab")
-   @Export("draw")
+   @Export("drawRegion")
    @Hook(
       value = "drawRegion",
       end = true
    )
-   public void draw(int var1, int var2, int var3, int var4, int var5, int var6) {
+   public void drawRegion(int var1, int var2, int var3, int var4, int var5, int var6) {
       if(var1 < 0) {
          var1 = 0;
       } else if(var1 >= this.maxX * 128) {

--- a/runescape-client/src/main/java/WorldComparator.java
+++ b/runescape-client/src/main/java/WorldComparator.java
@@ -389,7 +389,7 @@ final class WorldComparator implements Comparator {
                         Huffman.method3510();
                         var31 = Graphics3D.Rasterizer3D_zoom;
                         Graphics3D.Rasterizer3D_zoom = Client.scale;
-                        class86.region.draw(Resampler.cameraX, class49.cameraZ, class31.cameraY, GameCanvas.cameraPitch, IndexDataBase.cameraYaw, var23);
+                        class86.region.drawRegion(Resampler.cameraX, class49.cameraZ, class31.cameraY, GameCanvas.cameraPitch, IndexDataBase.cameraYaw, var23);
 
                         while(true) {
                            BoundingBox var54 = (BoundingBox)class7.boundingBoxes.removeLast();


### PR DESCRIPTION
In rev 165 a extra check for pitch was added in Region.drawRegion which caused tiles to be rendered at a different pitch than 2D extras. Because the new limit is only a local variable I couldn't use the same trick. Instead, this just recomputes the pitchCos and pitchSin with the unlimited values when they are changed. Additionally, the visibilityMap code is removed because it no longer crashes without it, due to the new limit.