### PR TITLE
Fix "request focus on notification" on OSX

### DIFF
--- a/runelite-client/pom.xml
+++ b/runelite-client/pom.xml
@@ -130,6 +130,12 @@
 			<artifactId>discord</artifactId>
 			<version>1.0</version>
 		</dependency>
+		<dependency>
+			<groupId>net.runelite</groupId>
+			<artifactId>orange-extensions</artifactId>
+			<version>1.0</version>
+			<scope>provided</scope>
+		</dependency>
 
 		<dependency>
 			<groupId>junit</groupId>

--- a/runelite-client/src/main/java/net/runelite/client/Notifier.java
+++ b/runelite-client/src/main/java/net/runelite/client/Notifier.java
@@ -43,6 +43,7 @@ import lombok.extern.slf4j.Slf4j;
 import net.runelite.client.config.RuneLiteConfig;
 import net.runelite.client.ui.ClientUI;
 import net.runelite.client.util.OSType;
+import net.runelite.client.util.OSXUtil;
 
 @Singleton
 @Slf4j
@@ -98,7 +99,14 @@ public class Notifier
 
 		if (runeLiteConfig.requestFocusOnNotification())
 		{
-			clientUI.requestFocus();
+			if (OSType.getOSType() == OSType.MacOS)
+			{
+				OSXUtil.requestFocus();
+			}
+			else
+			{
+				clientUI.requestFocus();
+			}
 		}
 
 		if (runeLiteConfig.enableTrayNotifications())

--- a/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
@@ -37,14 +37,12 @@ import java.awt.LayoutManager;
 import java.awt.SystemTray;
 import java.awt.Toolkit;
 import java.awt.TrayIcon;
-import java.awt.Window;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
-import java.lang.reflect.InvocationTargetException;
 import java.util.Enumeration;
 import javax.imageio.ImageIO;
 import javax.swing.BoxLayout;
@@ -67,7 +65,7 @@ import net.runelite.api.GameState;
 import net.runelite.api.events.ConfigChanged;
 import net.runelite.client.RuneLite;
 import net.runelite.client.RuneLiteProperties;
-import net.runelite.client.util.OSType;
+import net.runelite.client.util.OSXUtil;
 import org.pushingpixels.substance.api.skin.SubstanceGraphiteLookAndFeel;
 import org.pushingpixels.substance.internal.utils.SubstanceCoreUtilities;
 import org.pushingpixels.substance.internal.utils.SubstanceTitlePaneUtilities;
@@ -136,7 +134,7 @@ public class ClientUI extends JFrame
 		setUIFont(new FontUIResource(FontManager.getRunescapeFont()));
 
 		ClientUI gui = new ClientUI(runelite, properties, client);
-		tryEnableOSXFullscreen(gui);
+		OSXUtil.tryEnableFullscreen(gui);
 		return gui;
 	}
 
@@ -459,26 +457,4 @@ public class ClientUI extends JFrame
 		return pluginToolbar;
 	}
 
-	/**
-	 * Enables the osx native fullscreen if running on a mac.
-	 *
-	 * @param gui The gui to enable the fullscreen on.
-	 */
-	private static void tryEnableOSXFullscreen(ClientUI gui)
-	{
-		if (OSType.getOSType() == OSType.MacOS)
-		{
-			try
-			{
-				Class.forName("com.apple.eawt.FullScreenUtilities")
-					.getMethod("setWindowCanFullScreen", Window.class, boolean.class)
-					.invoke(null, gui, true);
-				log.debug("macOS fullscreen enabled");
-			}
-			catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException | InvocationTargetException ignored)
-			{
-				// not running macOS, ignore
-			}
-		}
-	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/util/OSXUtil.java
+++ b/runelite-client/src/main/java/net/runelite/client/util/OSXUtil.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2018, Adam <Adam@sigterm.info>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.util;
+
+import com.apple.eawt.Application;
+import com.apple.eawt.FullScreenUtilities;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.client.ui.ClientUI;
+
+/**
+ * A class with OSX-specific functions to improve integration.
+ */
+@Slf4j
+public class OSXUtil
+{
+	/**
+	 * Enables the osx native fullscreen if running on a mac.
+	 *
+	 * @param gui The gui to enable the fullscreen on.
+	 */
+	public static void tryEnableFullscreen(ClientUI gui)
+	{
+		if (OSType.getOSType() == OSType.MacOS)
+		{
+			FullScreenUtilities.setWindowCanFullScreen(gui, true);
+			log.debug("Enabled fullscreen on macOS");
+		}
+	}
+
+	/**
+	 * Requests the foreground in a macOS friendly way.
+	 */
+	public static void requestFocus()
+	{
+		if (OSType.getOSType() == OSType.MacOS)
+		{
+			Application app = Application.getApplication();
+			app.requestForeground(true);
+			log.debug("Requested focus on macOS");
+		}
+	}
+}


### PR DESCRIPTION
I also extracted the OSX-specific tools into a new util class so that all the apple-related reflection is done in one place.

Now focus will correctly switch to the RuneLite window when the setting is enabled on OSX.