### PR TITLE
Fix "You are fishing" in fishing plugin

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingOverlay.java
@@ -78,7 +78,8 @@ class FishingOverlay extends Overlay
 		}
 
 		panelComponent.getLines().clear();
-		if (client.getLocalPlayer().getInteracting() != null && client.getLocalPlayer().getInteracting().getName().equals(FISHING_SPOT))
+		if (client.getLocalPlayer().getInteracting() != null && client.getLocalPlayer().getInteracting().getName()
+			.contains(FISHING_SPOT))
 		{
 			panelComponent.setTitle("You are fishing");
 			panelComponent.setTitleColor(Color.GREEN);


### PR DESCRIPTION
Replace equality check with contains check due to recent renaming of
some fishing spots from OSRS side.

Fixes: #755

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>