### PR TITLE
Make idle notifier work for splashing/missing

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
@@ -357,8 +357,7 @@ public class IdleNotifierPlugin extends Plugin
 
 		if (opponent != null
 			&& !isPlayer
-			&& opponent.getCombatLevel() > 0
-			&& opponent.getHealth() != -1)
+			&& opponent.getCombatLevel() > 0)
 		{
 			resetTimers();
 			lastOpponent = opponent;


### PR DESCRIPTION
When you splash or miss too many times client
thinks that NPC have -1 HP and then idle notifier ignores that action, that means
- It do not register start of action, so never throws notification
- Or it will not register continuation of action, so it will throw false notification
=> do not registers start of the action

After some testing, seems like that health check is not necessary and checking for combat level is enough.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>