### PR TITLE
Small Fixes

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/ClueScrollPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/ClueScrollPlugin.java
@@ -28,20 +28,15 @@ package net.runelite.client.plugins.cluescrolls;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
-import java.util.HashSet;
-import java.util.Set;
 
 import javax.inject.Inject;
 import net.runelite.api.Client;
 import net.runelite.api.GameState;
-import net.runelite.api.ItemID;
 import net.runelite.api.Query;
 import net.runelite.api.queries.InventoryWidgetItemQuery;
 import net.runelite.api.widgets.Widget;
-import net.runelite.api.widgets.WidgetID;
 import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.api.widgets.WidgetItem;
-import net.runelite.client.game.ItemManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.task.Schedule;
@@ -86,9 +81,9 @@ public class ClueScrollPlugin extends Plugin
 			WidgetItem[] inventoryWidgetItems = queryRunner.runQuery(inventoryQuery);
 			for (WidgetItem item : inventoryWidgetItems)
 			{
-			    if (client.getItemDefinition(item.getId()).getName().startsWith("Clue scroll"))
-			    {
-			    	return;
+				if (client.getItemDefinition(item.getId()).getName().startsWith("Clue scroll"))
+				{
+					return;
 				}
 			}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/ClueScrollPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/ClueScrollPlugin.java
@@ -84,8 +84,10 @@ public class ClueScrollPlugin extends Plugin
 		{
 			Query inventoryQuery = new InventoryWidgetItemQuery();
 			WidgetItem[] inventoryWidgetItems = queryRunner.runQuery(inventoryQuery);
-			for (WidgetItem item : inventoryWidgetItems) {
-			    if (client.getItemDefinition(item.getId()).getName().startsWith("Clue scroll")) {
+			for (WidgetItem item : inventoryWidgetItems)
+			{
+			    if (client.getItemDefinition(item.getId()).getName().startsWith("Clue scroll"))
+			    {
 			    	return;
 				}
 			}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/ClueScrollPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/ClueScrollPlugin.java
@@ -28,14 +28,24 @@ package net.runelite.client.plugins.cluescrolls;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.HashSet;
+import java.util.Set;
+
 import javax.inject.Inject;
 import net.runelite.api.Client;
 import net.runelite.api.GameState;
+import net.runelite.api.ItemID;
+import net.runelite.api.Query;
+import net.runelite.api.queries.InventoryWidgetItemQuery;
 import net.runelite.api.widgets.Widget;
+import net.runelite.api.widgets.WidgetID;
 import net.runelite.api.widgets.WidgetInfo;
+import net.runelite.api.widgets.WidgetItem;
+import net.runelite.client.game.ItemManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.task.Schedule;
+import net.runelite.client.util.QueryRunner;
 
 @PluginDescriptor(
 	name = "Clue scroll"
@@ -44,6 +54,9 @@ public class ClueScrollPlugin extends Plugin
 {
 	@Inject
 	private Client client;
+
+	@Inject
+	private QueryRunner queryRunner;
 
 	@Inject
 	private ClueScrollOverlay clueScrollOverlay;
@@ -69,6 +82,15 @@ public class ClueScrollPlugin extends Plugin
 
 		if (clueScroll == null)
 		{
+			Query inventoryQuery = new InventoryWidgetItemQuery();
+			WidgetItem[] inventoryWidgetItems = queryRunner.runQuery(inventoryQuery);
+			for (WidgetItem item : inventoryWidgetItems) {
+			    if (client.getItemDefinition(item.getId()).getName().startsWith("Clue scroll")) {
+			    	return;
+				}
+			}
+
+			clueScrollOverlay.clue = null;
 			return;
 		}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
@@ -121,7 +121,7 @@ public interface GroundItemsConfig extends Config
 			description = "Configures the color for default, non-highlighted items",
 			position = 8
 	)
-    default Color defaultColor()
+	default Color defaultColor()
 	{
 		return Color.WHITE;
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
@@ -116,10 +116,21 @@ public interface GroundItemsConfig extends Config
 	}
 
 	@ConfigItem(
+			keyName = "defaultColor",
+			name = "Default items color",
+			description = "Configures the color for default, non-highlighted items",
+			position = 8
+	)
+    default Color defaultColor()
+	{
+		return Color.WHITE;
+	}
+
+	@ConfigItem(
 		keyName = "highlightedColor",
 		name = "Highlighted items color",
 		description = "Configures the color for highlighted items",
-		position = 8
+		position = 9
 	)
 	default Color highlightedColor()
 	{
@@ -130,7 +141,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "lowValueColor",
 		name = "Low value items color",
 		description = "Configures the color for low value items",
-		position = 9
+		position = 10
 	)
 	default Color lowValueColor()
 	{
@@ -141,7 +152,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "mediumValueColor",
 		name = "Medium value items color",
 		description = "Configures the color for medium value items",
-		position = 10
+		position = 11
 	)
 	default Color mediumValueColor()
 	{
@@ -152,7 +163,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "highValueColor",
 		name = "High value items color",
 		description = "Configures the color for high value items",
-		position = 11
+		position = 12
 	)
 	default Color highValueColor()
 	{
@@ -163,7 +174,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "insaneValueColor",
 		name = "Insane value items color",
 		description = "Configures the color for insane value items",
-		position = 12
+		position = 13
 	)
 	default Color insaneValueColor()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
@@ -235,7 +235,7 @@ public class GroundItemsOverlay extends Overlay
 						itemId = item.getLinkedNoteId();
 					}
 
-					Color textColor = Color.WHITE; // Color to use when drawing the ground item
+					Color textColor = config.defaultColor(); // Color to use when drawing the ground item
 					ItemPrice itemPrice = itemManager.getItemPriceAsync(itemId);
 					if (itemPrice != null && config.showGEPrice())
 					{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/hiscore/HiscorePanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/hiscore/HiscorePanel.java
@@ -434,7 +434,7 @@ public class HiscorePanel extends PluginPanel
 
 		// Clear details panel
 		details.setFont(UIManager.getFont("Label.font").deriveFont(Font.ITALIC));
-		details.setText("Click a skill for details");
+		details.setText("Hover over a skill for details");
 	}
 
 	private static String sanitize(String lookup)


### PR DESCRIPTION
Made the following fixes/changes:
- Renamed text in the hiscores panel from 'Click a skill for details' to 'Hover over a skill for details'.
- Clue scrolls overlay no longer shows while one isn't in the player's inventory.
- The color for default, non-highlighted items is now configurable.

Everything changed has been tested and works.