### PR TITLE
Instance map: Add support for user input

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/instancemap/InstanceMapInputListener.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/instancemap/InstanceMapInputListener.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2018, Kamiel
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.instancemap;
+
+import java.awt.event.KeyEvent;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseWheelEvent;
+import javax.inject.Inject;
+import net.runelite.client.input.KeyListener;
+import net.runelite.client.input.MouseListener;
+import net.runelite.client.input.MouseWheelListener;
+import static net.runelite.client.plugins.instancemap.InstanceMapOverlay.OVERLAY_POSITION;
+
+public class InstanceMapInputListener extends MouseListener implements KeyListener, MouseWheelListener
+{
+	@Inject
+	private InstanceMapPlugin plugin;
+
+	@Override
+	public void keyTyped(KeyEvent event)
+	{
+
+	}
+
+	@Override
+	public void keyPressed(KeyEvent event)
+	{
+		if (!plugin.isMapShown())
+		{
+			return;
+		}
+
+		if (event.getKeyCode() == KeyEvent.VK_ESCAPE)
+		{
+			plugin.closeMap();
+			event.consume();
+		}
+	}
+
+	@Override
+	public void keyReleased(KeyEvent event)
+	{
+
+	}
+
+	@Override
+	public void mouseWheelMoved(MouseWheelEvent event)
+	{
+		if (!plugin.isMapShown())
+		{
+			return;
+		}
+
+		int direction = event.getWheelRotation();
+
+		if (direction > 0)
+		{
+			plugin.ascendMap();
+		}
+		else
+		{
+			plugin.descendMap();
+		}
+
+		event.consume();
+	}
+
+	@Override
+	public MouseEvent mouseClicked(MouseEvent event)
+	{
+		if (!plugin.isMapShown() || !isWithinOverlay(event.getX(), event.getY()))
+		{
+			return event;
+		}
+
+		event.consume();
+		return event;
+	}
+
+	@Override
+	public MouseEvent mousePressed(MouseEvent event)
+	{
+		if (!plugin.isMapShown() || !isWithinOverlay(event.getX(), event.getY()))
+		{
+			return event;
+		}
+
+		event.consume();
+		return event;
+	}
+
+	private boolean isWithinOverlay(int x, int y)
+	{
+		return (x >= OVERLAY_POSITION.getX() && x <= OVERLAY_POSITION.getX() + plugin.getOverlaySize().width &&
+				y >= OVERLAY_POSITION.getY() && y <= OVERLAY_POSITION.getY() + plugin.getOverlaySize().height);
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/instancemap/InstanceMapOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/instancemap/InstanceMapOverlay.java
@@ -71,6 +71,8 @@ import net.runelite.client.ui.overlay.OverlayPosition;
 
 class InstanceMapOverlay extends Overlay
 {
+	public static final Point OVERLAY_POSITION = new Point(10, 25);
+
 	/**
 	 * The size of tiles on the map. The way the client renders requires
 	 * this value to be 4. Changing this will break the method for rendering
@@ -115,6 +117,16 @@ class InstanceMapOverlay extends Overlay
 		setPosition(OverlayPosition.DYNAMIC);
 		setLayer(OverlayLayer.ALWAYS_ON_TOP);
 		this.client = client;
+	}
+
+	public Dimension getInstanceMapDimension()
+	{
+		if (mapImage == null)
+		{
+			return null;
+		}
+
+		return new Dimension(mapImage.getWidth(), mapImage.getHeight());
 	}
 
 	public boolean isMapShown()
@@ -179,18 +191,14 @@ class InstanceMapOverlay extends Overlay
 			mapImage = drawMapImage(getTiles());
 		}
 
-		//Scale mapImage by the mapScaling to display a larger map.
-		graphics.drawImage(mapImage, 0, 0, (int) (mapImage.getWidth() * MAP_SCALING), (int) (mapImage.getHeight() * MAP_SCALING), 0, 0, mapImage.getWidth(), mapImage.getHeight(), null);
+		graphics.drawImage(mapImage, OVERLAY_POSITION.getX(), OVERLAY_POSITION.getY(), null);
 
 		if (client.getPlane() == viewedPlane)//If we are not viewing the plane we are on, don't show player's position
 		{
 			drawPlayerDot(graphics, client.getLocalPlayer(), Color.white, Color.black);
 		}
 
-		Tile[][] tiles = getTiles();
-		Dimension mapOverlaySize = new Dimension(tiles.length * TILE_SIZE, tiles[0].length * TILE_SIZE);
-
-		return mapOverlaySize;
+		return getInstanceMapDimension();
 	}
 
 	/**
@@ -205,10 +213,12 @@ class InstanceMapOverlay extends Overlay
 		Tile[][] tiles = getTiles();
 		Point localPlayerPoint = new Point(playerLocation.getX(), (tiles[0].length - 1) - playerLocation.getY()); // flip the y value
 
+		int x = OVERLAY_POSITION.getX() + (int) (localPlayerPoint.getX() * TILE_SIZE * MAP_SCALING);
+		int y = OVERLAY_POSITION.getY() + (int) (localPlayerPoint.getY() * TILE_SIZE * MAP_SCALING);
 		graphics.setColor(dotColor);
-		graphics.fillRect((int) (localPlayerPoint.getX() * TILE_SIZE * MAP_SCALING), (int) (localPlayerPoint.getY() * TILE_SIZE * MAP_SCALING), PLAYER_MARKER_SIZE, PLAYER_MARKER_SIZE);//draw the players point on the map
+		graphics.fillRect(x, y, PLAYER_MARKER_SIZE, PLAYER_MARKER_SIZE);//draw the players point on the map
 		graphics.setColor(outlineColor);
-		graphics.drawRect((int) (localPlayerPoint.getX() * TILE_SIZE * MAP_SCALING), (int) (localPlayerPoint.getY() * TILE_SIZE * MAP_SCALING), PLAYER_MARKER_SIZE, PLAYER_MARKER_SIZE);//outline
+		graphics.drawRect(x, y, PLAYER_MARKER_SIZE, PLAYER_MARKER_SIZE);//outline
 	}
 
 	/**

--- a/runelite-client/src/main/java/net/runelite/client/plugins/instancemap/InstanceMapPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/instancemap/InstanceMapPlugin.java
@@ -25,12 +25,17 @@
 package net.runelite.client.plugins.instancemap;
 
 import com.google.common.eventbus.Subscribe;
+import com.google.inject.Binder;
+import java.awt.Dimension;
 import javax.inject.Inject;
+import net.runelite.api.Client;
 import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.MapRegionChanged;
 import net.runelite.api.events.WidgetMenuOptionClicked;
 import net.runelite.api.widgets.WidgetInfo;
 import static net.runelite.api.widgets.WidgetInfo.WORLD_MAP;
+import net.runelite.client.input.KeyManager;
+import net.runelite.client.input.MouseManager;
 import net.runelite.client.menus.MenuManager;
 import net.runelite.client.menus.WidgetMenuOption;
 import net.runelite.client.plugins.Plugin;
@@ -43,8 +48,12 @@ import net.runelite.client.ui.overlay.Overlay;
 public class InstanceMapPlugin extends Plugin
 {
 	private final WidgetMenuOption openMapOption = new WidgetMenuOption("Show", "Instance Map", WidgetInfo.WORLD_MAP);
-	private final WidgetMenuOption ascendOption = new WidgetMenuOption("Ascend", "Instance Map", WidgetInfo.WORLD_MAP);
-	private final WidgetMenuOption descendOption = new WidgetMenuOption("Descend", "Instance Map", WidgetInfo.WORLD_MAP);
+
+	@Inject
+	private Client client;
+
+	@Inject
+	private InstanceMapInputListener inputListener;
 
 	@Inject
 	private InstanceMapOverlay overlay;
@@ -52,30 +61,44 @@ public class InstanceMapPlugin extends Plugin
 	@Inject
 	private MenuManager menuManager;
 
+	@Inject
+	private KeyManager keyManager;
+
+	@Inject
+	private MouseManager mouseManager;
+
+	@Override
+	public void configure(Binder binder)
+	{
+		binder.bind(InstanceMapInputListener.class);
+	}
+
 	private void addCustomOptions()
 	{
 		menuManager.addManagedCustomMenu(openMapOption);
-		menuManager.addManagedCustomMenu(descendOption);
-		menuManager.addManagedCustomMenu(ascendOption);
 	}
 
 	private void removeCustomOptions()
 	{
 		menuManager.removeManagedCustomMenu(openMapOption);
-		menuManager.removeManagedCustomMenu(descendOption);
-		menuManager.removeManagedCustomMenu(ascendOption);
 	}
 
 	@Override
 	protected void startUp() throws Exception
 	{
 		addCustomOptions();
+		keyManager.registerKeyListener(inputListener);
+		mouseManager.registerMouseListener(inputListener);
+		mouseManager.registerMouseWheelListener(inputListener);
 	}
 
 	@Override
 	protected void shutDown() throws Exception
 	{
 		removeCustomOptions();
+		keyManager.unregisterKeyListener(inputListener);
+		mouseManager.registerMouseListener(inputListener);
+		mouseManager.unregisterMouseWheelListener(inputListener);
 	}
 
 	@Subscribe
@@ -105,24 +128,14 @@ public class InstanceMapPlugin extends Plugin
 
 		if (clickedOptionEquals(event, openMapOption))
 		{
-			overlay.setShowMap(!overlay.isMapShown());
-
 			if (overlay.isMapShown())
 			{
-				openMapOption.setMenuOption("Hide");
+				closeMap();
 			}
 			else
 			{
-				openMapOption.setMenuOption("Show");
+				showMap();
 			}
-		}
-		else if (clickedOptionEquals(event, ascendOption))
-		{
-			overlay.onAscend();
-		}
-		else if (clickedOptionEquals(event, descendOption))
-		{
-			overlay.onDescend();
 		}
 	}
 
@@ -130,5 +143,37 @@ public class InstanceMapPlugin extends Plugin
 	public Overlay getOverlay()
 	{
 		return overlay;
+	}
+
+	public boolean isMapShown()
+	{
+		return overlay.isMapShown();
+	}
+
+	public void showMap()
+	{
+		overlay.setShowMap(true);
+		openMapOption.setMenuOption("Hide");
+	}
+
+	public void closeMap()
+	{
+		overlay.setShowMap(false);
+		openMapOption.setMenuOption("Show");
+	}
+
+	public void ascendMap()
+	{
+		overlay.onAscend();
+	}
+
+	public void descendMap()
+	{
+		overlay.onDescend();
+	}
+
+	public Dimension getOverlaySize()
+	{
+		return overlay.getInstanceMapDimension();
 	}
 }


### PR DESCRIPTION
- Can now scroll to traverse trough planes
- Closes on ESC

Removed the "ascend" and "descend" options from the right click menu since scrolling now performs these actions.

I also moved the map a bit so it kinda matches the positioning of the other widgets