### PR TITLE
ge search: remove null check from item icon

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangeItemPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangeItemPanel.java
@@ -26,6 +26,7 @@ package net.runelite.client.plugins.grandexchange;
 
 import java.awt.BorderLayout;
 import java.awt.Color;
+import java.awt.Dimension;
 import java.awt.GridLayout;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
@@ -44,6 +45,8 @@ import net.runelite.client.util.LinkBrowser;
 class GrandExchangeItemPanel extends JPanel
 {
 	private static final NumberFormat NUMBER_FORMATTER = NumberFormat.getInstance();
+
+	private static final Dimension ICON_SIZE = new Dimension(32, 32);
 
 	GrandExchangeItemPanel(LinkBrowser linkBrowser, BufferedImage icon, String name, int itemID, int gePrice, Double
 		haPrice)
@@ -84,7 +87,11 @@ class GrandExchangeItemPanel extends JPanel
 
 		// Icon
 		JLabel itemIcon = new JLabel();
-		itemIcon.setIcon(new ImageIcon(icon));
+		itemIcon.setPreferredSize(ICON_SIZE);
+		if (icon != null)
+		{
+			itemIcon.setIcon(new ImageIcon(icon));
+		}
 		add(itemIcon, BorderLayout.LINE_START);
 
 		// Item details panel
@@ -98,7 +105,14 @@ class GrandExchangeItemPanel extends JPanel
 
 		// Ge price
 		JLabel gePriceLabel = new JLabel();
-		gePriceLabel.setText(NUMBER_FORMATTER.format(gePrice) + " gp");
+		if (gePrice > 0)
+		{
+			gePriceLabel.setText(NUMBER_FORMATTER.format(gePrice) + " gp");
+		}
+		else
+		{
+			gePriceLabel.setText("N/A");
+		}
 		gePriceLabel.setForeground(Color.GREEN);
 		rightPanel.add(gePriceLabel);
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangeSearchPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangeSearchPanel.java
@@ -69,7 +69,7 @@ class GrandExchangeSearchPanel extends JPanel
 	private IconTextField searchBox = new IconTextField();
 	private JPanel container = new JPanel();
 	private JPanel searchItemsPanel = new JPanel();
-	private JLabel searchingLabel = new JLabel("Searching...");
+	private JLabel searchingLabel = new JLabel();
 
 	GrandExchangeSearchPanel(Client client, ItemManager itemManager, ScheduledExecutorService executor, LinkBrowser linkBrowser)
 	{
@@ -129,7 +129,7 @@ class GrandExchangeSearchPanel extends JPanel
 
 		// Input is not empty, add searching label
 		searchItemsPanel.removeAll();
-		showSearchString(true);
+		showSearchString("Searching...");
 
 		SearchResult result;
 
@@ -140,7 +140,7 @@ class GrandExchangeSearchPanel extends JPanel
 		catch (ExecutionException ex)
 		{
 			log.warn("Unable to search for item {}", lookup, ex);
-			showSearchString(false);
+			showSearchString("Error performing search");
 			return;
 		}
 
@@ -159,7 +159,7 @@ class GrandExchangeSearchPanel extends JPanel
 					continue;
 				}
 
-				ItemPrice itemPrice;
+				ItemPrice itemPrice = null;
 				try
 				{
 					itemPrice = itemManager.getItemPrice(itemId);
@@ -167,11 +167,9 @@ class GrandExchangeSearchPanel extends JPanel
 				catch (IOException ex)
 				{
 					log.warn("Unable to fetch item price for {}", itemId, ex);
-					showSearchString(false);
-					return;
 				}
 
-				BufferedImage itemImage;
+				BufferedImage itemImage = null;
 				try
 				{
 					itemImage = itemClient.getIcon(itemId);
@@ -179,18 +177,14 @@ class GrandExchangeSearchPanel extends JPanel
 				catch (IOException ex)
 				{
 					log.warn("Unable to fetch item icon for {}", itemId, ex);
-					showSearchString(false);
-					return;
 				}
 
 				if (itemImage == null)
 				{
 					log.warn("Unable to fetch item icon for {}", itemId);
-					showSearchString(false);
-					return;
 				}
 
-				ITEMS_LIST.add(new GrandExchangeItems(itemImage, item.getName(), itemId, itemPrice.getPrice(), itemComp.getPrice() * 0.6));
+				ITEMS_LIST.add(new GrandExchangeItems(itemImage, item.getName(), itemId, itemPrice != null ? itemPrice.getPrice() : 0, itemComp.getPrice() * 0.6));
 
 				// If using hotkey to lookup item, stop after finding match.
 				if (exactMatch && item.getName().equalsIgnoreCase(lookup))
@@ -213,14 +207,16 @@ class GrandExchangeSearchPanel extends JPanel
 			ITEMS_LIST.clear();
 
 			// Remove searching label after search is complete
-			showSearchString(false);
+			showSearchString(null);
 		});
 	}
 
-	private void showSearchString(boolean shown)
+	private void showSearchString(String str)
 	{
-		if (shown)
+		if (str != null)
 		{
+			remove(searchingLabel);
+			searchingLabel.setText(str);
 			add(searchingLabel, BorderLayout.CENTER);
 		}
 		else


### PR DESCRIPTION
before it was just returning if the image icon was not found, now it should still display the item, just with no icon if it is null