### PR TITLE
Default world

### DIFF
--- a/http-api/src/main/java/net/runelite/http/api/worlds/World.java
+++ b/http-api/src/main/java/net/runelite/http/api/worlds/World.java
@@ -25,7 +25,11 @@
 package net.runelite.http.api.worlds;
 
 import java.util.EnumSet;
+import lombok.Builder;
+import lombok.Value;
 
+@Value
+@Builder
 public class World
 {
 	private int id;
@@ -34,70 +38,4 @@ public class World
 	private String activity;
 	private int location;
 	private int players;
-
-	@Override
-	public String toString()
-	{
-		return "World{" + "id=" + id + ", types=" + types + ", address=" + address + ", activity=" + activity + ", location=" + location + ", players=" + players + '}';
-	}
-
-	public int getId()
-	{
-		return id;
-	}
-
-	public void setId(int id)
-	{
-		this.id = id;
-	}
-
-	public EnumSet<WorldType> getTypes()
-	{
-		return types;
-	}
-
-	public void setTypes(EnumSet<WorldType> types)
-	{
-		this.types = types;
-	}
-
-	public String getAddress()
-	{
-		return address;
-	}
-
-	public void setAddress(String address)
-	{
-		this.address = address;
-	}
-
-	public String getActivity()
-	{
-		return activity;
-	}
-
-	public void setActivity(String activity)
-	{
-		this.activity = activity;
-	}
-
-	public int getLocation()
-	{
-		return location;
-	}
-
-	public void setLocation(int location)
-	{
-		this.location = location;
-	}
-
-	public int getPlayers()
-	{
-		return players;
-	}
-
-	public void setPlayers(int players)
-	{
-		this.players = players;
-	}
 }

--- a/http-service/src/main/java/net/runelite/http/service/worlds/WorldsService.java
+++ b/http-service/src/main/java/net/runelite/http/service/worlds/WorldsService.java
@@ -71,15 +71,15 @@ public class WorldsService
 
 		for (int i = 0; i < num; ++i)
 		{
-			World world = new World();
-			world.setId(buf.getShort() & 0xFFFF);
-			world.setTypes(getTypes(buf.getInt()));
-			world.setAddress(readString(buf));
-			world.setActivity(readString(buf));
-			world.setLocation(buf.get() & 0xFF);
-			world.setPlayers(buf.getShort() & 0xFFFF);
+			final World.WorldBuilder worldBuilder = World.builder()
+				.id(buf.getShort() & 0xFFFF)
+				.types(getTypes(buf.getInt()))
+				.address(readString(buf))
+				.activity(readString(buf))
+				.location(buf.get() & 0xFF)
+				.players(buf.getShort() & 0xFFFF);
 
-			worlds.add(world);
+			worlds.add(worldBuilder.build());
 		}
 
 		WorldResult result = new WorldResult();

--- a/runelite-api/src/main/java/net/runelite/api/Client.java
+++ b/runelite-api/src/main/java/net/runelite/api/Client.java
@@ -114,6 +114,12 @@ public interface Client extends GameEngine
 
 	int[] getPlayerMenuTypes();
 
+	/**
+	 * Get list of all RuneScape worlds
+	 * @return world list
+	 */
+	World[] getWorldList();
+
 	MenuEntry[] getMenuEntries();
 
 	void setMenuEntries(MenuEntry[] entries);
@@ -308,4 +314,16 @@ public interface Client extends GameEngine
 	void setStretchedKeepAspectRatio(boolean state);
 
 	Dimension getStretchedDimensions();
+
+	/**
+	 * Changes world. Works only on login screen
+	 * @param world world
+	 */
+	void changeWorld(World world);
+
+	/**
+	 * Creates instance of new world
+	 * @return world
+	 */
+	World createWorld();
 }

--- a/runelite-api/src/main/java/net/runelite/api/World.java
+++ b/runelite-api/src/main/java/net/runelite/api/World.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017, Adam <Adam@sigterm.info>
+ * Copyright (c) 2018, Tomas Slusny <slusnucky@gmail.com>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -22,64 +22,111 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package net.runelite.rs.api;
+package net.runelite.api;
 
-import net.runelite.api.World;
-import net.runelite.mapping.Import;
 
-public interface RSWorld extends World
+import java.util.EnumSet;
+
+/**
+ * Holds data of RuneScape world.
+ */
+public interface World
 {
-	@Import("mask")
-	int getMask();
+	/**
+	 * Gets world types.
+	 *
+	 * @return the types
+	 */
+	EnumSet<WorldType> getTypes();
 
-	@Import("mask")
-	void setMask(int mask);
+	/**
+	 * Sets world types.
+	 *
+	 * @param types the types
+	 */
+	void setTypes(EnumSet<WorldType> types);
 
-	@Import("playerCount")
-	@Override
+	/**
+	 * Gets player count.
+	 *
+	 * @return the player count
+	 */
 	int getPlayerCount();
 
-	@Import("playerCount")
-	@Override
+	/**
+	 * Sets player count.
+	 *
+	 * @param playerCount the player count
+	 */
 	void setPlayerCount(int playerCount);
 
-	@Import("location")
-	@Override
+	/**
+	 * Gets location.
+	 *
+	 * @return the location
+	 */
 	int getLocation();
 
-	@Import("location")
-	@Override
+	/**
+	 * Sets location.
+	 *
+	 * @param location the location
+	 */
 	void setLocation(int location);
 
-	@Import("index")
-	@Override
+	/**
+	 * Gets index.
+	 *
+	 * @return the index
+	 */
 	int getIndex();
 
-	@Import("index")
-	@Override
+	/**
+	 * Sets index.
+	 *
+	 * @param index the index
+	 */
 	void setIndex(int index);
 
-	@Import("id")
-	@Override
+	/**
+	 * Gets id.
+	 *
+	 * @return the id
+	 */
 	int getId();
 
-	@Import("id")
-	@Override
+	/**
+	 * Sets id.
+	 *
+	 * @param id the id
+	 */
 	void setId(int id);
 
-	@Import("activity")
-	@Override
+	/**
+	 * Gets activity.
+	 *
+	 * @return the activity
+	 */
 	String getActivity();
 
-	@Import("activity")
-	@Override
+	/**
+	 * Sets activity.
+	 *
+	 * @param activity the activity
+	 */
 	void setActivity(String activity);
 
-	@Import("address")
-	@Override
+	/**
+	 * Gets address.
+	 *
+	 * @return the address
+	 */
 	String getAddress();
 
-	@Import("address")
-	@Override
+	/**
+	 * Sets address.
+	 *
+	 * @param address the address
+	 */
 	void setAddress(String address);
 }

--- a/runelite-api/src/main/java/net/runelite/api/WorldType.java
+++ b/runelite-api/src/main/java/net/runelite/api/WorldType.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2018, Tomas Slusny <slusnucky@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.api;
+
+import java.util.EnumSet;
+
+/**
+ * Enum representing world type.
+ */
+public enum WorldType
+{
+	/**
+	 * Members world type.
+	 */
+	MEMBERS(1),
+	/**
+	 * Pvp world type.
+	 */
+	PVP(1 << 2),
+	/**
+	 * Bounty world type.
+	 */
+	BOUNTY(1 << 5),
+	/**
+	 * Skill total world type.
+	 */
+	SKILL_TOTAL(1 << 7),
+	/**
+	 * Pvp high risk world type.
+	 */
+	PVP_HIGH_RISK(1 << 10),
+	/**
+	 * Last man standing world type.
+	 */
+	LAST_MAN_STANDING(1 << 14),
+	/**
+	 * Deadman world type.
+	 */
+	DEADMAN(1 << 29),
+	/**
+	 * Seasonal deadman world type.
+	 */
+	SEASONAL_DEADMAN(1 << 30);
+
+	private final int mask;
+
+	WorldType(int mask)
+	{
+		this.mask = mask;
+	}
+
+	/**
+	 * Create enum set of world types from mask.
+	 *
+	 * @param mask the mask
+	 * @return the enum set
+	 */
+	public static EnumSet<WorldType> fromMask(final int mask)
+	{
+		final EnumSet<WorldType> types = EnumSet.noneOf(WorldType.class);
+
+		for (WorldType type : WorldType.values())
+		{
+			if ((mask & type.mask) != 0)
+			{
+				types.add(type);
+			}
+		}
+
+		return types;
+	}
+
+	/**
+	 * Create mask from enum set of world types.
+	 *
+	 * @param types the types
+	 * @return the int
+	 */
+	public static int toMask(final EnumSet<WorldType> types)
+	{
+		int mask = 0;
+
+		for (WorldType type : types)
+		{
+			mask |= type.mask;
+		}
+
+		return mask;
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/defaultworld/DefaultWorldConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/defaultworld/DefaultWorldConfig.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2018, Tomas Slusny <slusnucky@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.defaultworld;
+
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+
+@ConfigGroup(
+	keyName = "defaultworld",
+	name = "Default World",
+	description = "Sets the default world and remembers it"
+)
+public interface DefaultWorldConfig extends Config
+{
+	@ConfigItem(
+		keyName = "defaultWorld",
+		name = "Default world",
+		description = "World to use as default one"
+	)
+	default int getWorld()
+	{
+		return 0;
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/defaultworld/DefaultWorldPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/defaultworld/DefaultWorldPlugin.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2018, Tomas Slusny <slusnucky@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.defaultworld;
+
+import com.google.common.eventbus.Subscribe;
+import com.google.inject.Provides;
+import java.io.IOException;
+import java.util.EnumSet;
+import javax.inject.Inject;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.Client;
+import net.runelite.api.GameState;
+import net.runelite.api.WorldType;
+import net.runelite.api.events.GameStateChanged;
+import net.runelite.api.events.SessionOpen;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.http.api.worlds.World;
+import net.runelite.http.api.worlds.WorldClient;
+import net.runelite.http.api.worlds.WorldResult;
+
+@PluginDescriptor(name = "Default World")
+@Slf4j
+public class DefaultWorldPlugin extends Plugin
+{
+	@Inject
+	private Client client;
+
+	@Inject
+	private DefaultWorldConfig config;
+
+	private final WorldClient worldClient = new WorldClient();
+	private int worldCache;
+	private boolean worldChangeRequired;
+
+	@Override
+	protected void startUp() throws Exception
+	{
+		worldChangeRequired = true;
+		applyWorld();
+	}
+
+	@Override
+	protected void shutDown() throws Exception
+	{
+		worldChangeRequired = true;
+		changeWorld(worldCache);
+	}
+
+	@Provides
+	DefaultWorldConfig getConfig(ConfigManager configManager)
+	{
+		return configManager.getConfig(DefaultWorldConfig.class);
+	}
+
+	@Subscribe
+	public void onSessionOpen(SessionOpen event)
+	{
+		worldChangeRequired = true;
+		applyWorld();
+	}
+
+	@Subscribe
+	public void onGameStateChange(GameStateChanged event)
+	{
+		applyWorld();
+	}
+
+	private void changeWorld(int newWorld)
+	{
+		if (!worldChangeRequired || client.getGameState() != GameState.LOGIN_SCREEN || client.getWorld() == newWorld)
+		{
+			return;
+		}
+
+		worldChangeRequired = false;
+
+		// Old School RuneScape worlds start for 301 so don't even bother trying to find lower id ones
+		if (client.getWorld() <= 300)
+		{
+			return;
+		}
+
+		try
+		{
+			final WorldResult worldResult = worldClient.lookupWorlds();
+			final World world = worldResult.findWorld(newWorld);
+
+			if (world != null)
+			{
+				final net.runelite.api.World rsWorld = client.createWorld();
+				rsWorld.setActivity(world.getActivity());
+				rsWorld.setAddress(world.getAddress());
+				rsWorld.setId(world.getId());
+				rsWorld.setPlayerCount(world.getPlayers());
+				rsWorld.setLocation(world.getLocation());
+				rsWorld.setTypes(toWorldTypes(world.getTypes()));
+
+				client.changeWorld(rsWorld);
+				log.debug("Applied new world {}", newWorld);
+			}
+			else
+			{
+				log.warn("World {} not found.", newWorld);
+			}
+		}
+		catch (IOException e)
+		{
+			log.warn("Error looking up world {}. Error: {}", newWorld, e);
+		}
+	}
+
+	private static EnumSet<WorldType> toWorldTypes(final EnumSet<net.runelite.http.api.worlds.WorldType> apiTypes)
+	{
+		final EnumSet<WorldType> types = EnumSet.noneOf(WorldType.class);
+
+		for (net.runelite.http.api.worlds.WorldType apiType : apiTypes)
+		{
+			types.add(WorldType.valueOf(apiType.name()));
+		}
+
+		return types;
+	}
+
+	private void applyWorld()
+	{
+		if (worldCache == 0)
+		{
+			worldCache = client.getWorld();
+			log.debug("Stored old world {}", worldCache);
+		}
+
+		final int newWorld = config.getWorld();
+		changeWorld(newWorld);
+	}
+}

--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSWorldMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSWorldMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017, Adam <Adam@sigterm.info>
+ * Copyright (c) 2018, Tomas Slusny <slusnucky@gmail.com>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -22,64 +22,28 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package net.runelite.rs.api;
+package net.runelite.mixins;
 
-import net.runelite.api.World;
-import net.runelite.mapping.Import;
+import java.util.EnumSet;
+import net.runelite.api.WorldType;
+import net.runelite.api.mixins.Inject;
+import net.runelite.api.mixins.Mixin;
+import net.runelite.rs.api.RSWorld;
 
-public interface RSWorld extends World
+@Mixin(RSWorld.class)
+public abstract class RSWorldMixin implements RSWorld
 {
-	@Import("mask")
-	int getMask();
-
-	@Import("mask")
-	void setMask(int mask);
-
-	@Import("playerCount")
+	@Inject
 	@Override
-	int getPlayerCount();
+	public EnumSet<WorldType> getTypes()
+	{
+		return WorldType.fromMask(getMask());
+	}
 
-	@Import("playerCount")
+	@Inject
 	@Override
-	void setPlayerCount(int playerCount);
-
-	@Import("location")
-	@Override
-	int getLocation();
-
-	@Import("location")
-	@Override
-	void setLocation(int location);
-
-	@Import("index")
-	@Override
-	int getIndex();
-
-	@Import("index")
-	@Override
-	void setIndex(int index);
-
-	@Import("id")
-	@Override
-	int getId();
-
-	@Import("id")
-	@Override
-	void setId(int id);
-
-	@Import("activity")
-	@Override
-	String getActivity();
-
-	@Import("activity")
-	@Override
-	void setActivity(String activity);
-
-	@Import("address")
-	@Override
-	String getAddress();
-
-	@Import("address")
-	@Override
-	void setAddress(String address);
+	public void setTypes(final EnumSet<WorldType> types)
+	{
+		setMask(WorldType.toMask(types));
+	}
 }

--- a/runescape-api/src/main/java/net/runelite/rs/api/RSClient.java
+++ b/runescape-api/src/main/java/net/runelite/rs/api/RSClient.java
@@ -27,6 +27,7 @@ package net.runelite.rs.api;
 import java.util.Map;
 import net.runelite.api.BufferProvider;
 import net.runelite.api.Client;
+import net.runelite.api.World;
 import net.runelite.mapping.Construct;
 import net.runelite.mapping.Import;
 
@@ -202,6 +203,7 @@ public interface RSClient extends RSGameEngine, Client
 	int[] getMenuActionParams1();
 
 	@Import("worldList")
+	@Override
 	RSWorld[] getWorldList();
 
 	@Import("addChatMessage")
@@ -495,4 +497,12 @@ public interface RSClient extends RSGameEngine, Client
 
 	@Import("renderOverview")
 	RSRenderOverview getRenderOverview();
+
+	@Import("changeWorld")
+	@Override
+	void changeWorld(World world);
+
+	@Construct
+	@Override
+	RSWorld createWorld();
 }

--- a/runescape-client/src/main/java/Client.java
+++ b/runescape-client/src/main/java/Client.java
@@ -4997,7 +4997,7 @@ public final class Client extends GameEngine implements class302 {
                Enum.setGameState(45);
                var2.vmethod3379();
                var2 = null;
-               TotalQuantityComparator.method99(var46);
+               TotalQuantityComparator.changeWorld(var46);
                var1.serverPacket = null;
                return false;
             }

--- a/runescape-client/src/main/java/TotalQuantityComparator.java
+++ b/runescape-client/src/main/java/TotalQuantityComparator.java
@@ -84,21 +84,22 @@ final class TotalQuantityComparator implements Comparator {
       signature = "(Lbq;B)V",
       garbageValue = "10"
    )
-   static void method99(World var0) {
-      if(var0.method1653() != Client.isMembers) {
-         Client.isMembers = var0.method1653();
-         boolean var1 = var0.method1653();
+   @Export("changeWorld")
+   static void changeWorld(World world) {
+      if(world.method1653() != Client.isMembers) {
+         Client.isMembers = world.method1653();
+         boolean var1 = world.method1653();
          if(var1 != ItemComposition.isMembersWorld) {
             class20.method152();
             ItemComposition.isMembersWorld = var1;
          }
       }
 
-      BoundingBox.host = var0.address;
-      Client.world = var0.id;
-      Client.flags = var0.mask;
-      class233.port1 = Client.socketType == 0?43594:var0.id + 40000;
-      class44.port2 = Client.socketType == 0?443:var0.id + 50000;
+      BoundingBox.host = world.address;
+      Client.world = world.id;
+      Client.flags = world.mask;
+      class233.port1 = Client.socketType == 0?43594:world.id + 40000;
+      class44.port2 = Client.socketType == 0?443:world.id + 50000;
       class247.myWorldPort = class233.port1;
    }
 }

--- a/runescape-client/src/main/java/UrlRequester.java
+++ b/runescape-client/src/main/java/UrlRequester.java
@@ -256,7 +256,7 @@ public class UrlRequester implements Runnable {
                         class90.logoSprite.method5899(class90.field1336 + 382 - class90.logoSprite.originalWidth / 2, 18);
                      } else if(class90.field1368 != -1) {
                         World var5 = World.worldList[class90.field1368];
-                        TotalQuantityComparator.method99(var5);
+                        TotalQuantityComparator.changeWorld(var5);
                         class90.worldSelectShown = false;
                         class90.field1338.method6003(class90.field1336, 0);
                         class90.field1340.method6003(class90.field1336 + 382, 0);


### PR DESCRIPTION
- Add default world plugin where user will be able to set his default
world. In case invalid world is set, the client default/selected one
will be used instead.
- Add setWorld to the RuneLite API
- Export World from RS client
- Export changeWorld method
- Create new method for creating RuneScape world
- Add support for mask and index fields to the WorldService.

Fixes #475 
Closes #749 
