### PR TITLE
Disable team capes plugin by default

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/teamcapes/TeamCapesPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/teamcapes/TeamCapesPlugin.java
@@ -41,7 +41,8 @@ import net.runelite.client.task.Schedule;
 import net.runelite.client.ui.overlay.Overlay;
 
 @PluginDescriptor(
-	name = "Team capes"
+	name = "Team capes",
+	enabledByDefault = false
 )
 public class TeamCapesPlugin extends Plugin
 {


### PR DESCRIPTION
For most of people this plugin is not relevant so it should be disabled
by default as it adds unnecessary clutter in populated areas.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>