### PR TITLE
Normalize plugin names

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/attackindicator/AttackIndicatorPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/attackindicator/AttackIndicatorPlugin.java
@@ -53,7 +53,7 @@ import static net.runelite.client.plugins.attackindicator.AttackStyle.DEFENSIVE_
 import static net.runelite.client.plugins.attackindicator.AttackStyle.OTHER;
 
 @PluginDescriptor(
-	name = "Attack indicator"
+	name = "Attack Indicators"
 )
 @Slf4j
 public class AttackIndicatorPlugin extends Plugin

--- a/runelite-client/src/main/java/net/runelite/client/plugins/barrows/BarrowsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/barrows/BarrowsConfig.java
@@ -30,7 +30,7 @@ import net.runelite.client.config.ConfigItem;
 
 @ConfigGroup(
 	keyName = "barrows",
-	name = "Barrows Plugin",
+	name = "Barrows Brothers",
 	description = "Configuration for the Barrows plugin"
 )
 public interface BarrowsConfig extends Config

--- a/runelite-client/src/main/java/net/runelite/client/plugins/barrows/BarrowsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/barrows/BarrowsPlugin.java
@@ -49,7 +49,7 @@ import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.Overlay;
 
 @PluginDescriptor(
-	name = "Barrows plugin"
+	name = "Barrows Brothers"
 )
 public class BarrowsPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/boosts/BoostsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/boosts/BoostsConfig.java
@@ -30,7 +30,7 @@ import net.runelite.client.config.Config;
 
 @ConfigGroup(
 	keyName = "boosts",
-	name = "Boosts Info",
+	name = "Boosts Information",
 	description = "Configuration for the Boosts plugin"
 )
 public interface BoostsConfig extends Config

--- a/runelite-client/src/main/java/net/runelite/client/plugins/boosts/BoostsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/boosts/BoostsPlugin.java
@@ -39,7 +39,7 @@ import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.infobox.InfoBoxManager;
 
 @PluginDescriptor(
-	name = "Boosts"
+	name = "Boosts Information"
 )
 public class BoostsPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/bosstimer/BossTimersPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/bosstimer/BossTimersPlugin.java
@@ -36,7 +36,7 @@ import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.infobox.InfoBoxManager;
 
 @PluginDescriptor(
-	name = "Boss timers"
+	name = "Boss Timers"
 )
 @Slf4j
 public class BossTimersPlugin extends Plugin

--- a/runelite-client/src/main/java/net/runelite/client/plugins/chathistory/ChatHistoryPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chathistory/ChatHistoryPlugin.java
@@ -38,7 +38,7 @@ import net.runelite.client.chat.QueuedMessage;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 
-@PluginDescriptor(name = "Chat history")
+@PluginDescriptor(name = "Chat History")
 public class ChatHistoryPlugin extends Plugin
 {
 	private static final String WELCOME_MESSAGE = "Welcome to RuneScape.";

--- a/runelite-client/src/main/java/net/runelite/client/plugins/clanchat/ClanChatPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/clanchat/ClanChatPlugin.java
@@ -56,7 +56,7 @@ import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.task.Schedule;
 
 @PluginDescriptor(
-	name = "Clan chat"
+	name = "Clan Chat"
 )
 @Slf4j
 public class ClanChatPlugin extends Plugin

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/ClueScrollPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/ClueScrollPlugin.java
@@ -38,7 +38,7 @@ import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.task.Schedule;
 
 @PluginDescriptor(
-	name = "Clue scroll"
+	name = "Clue Scroll"
 )
 public class ClueScrollPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/combatlevel/CombatLevelPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/combatlevel/CombatLevelPlugin.java
@@ -38,7 +38,7 @@ import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 
 @PluginDescriptor(
-	name = "Combat level"
+	name = "Combat Level"
 )
 public class CombatLevelPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/devtools/DevToolsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/devtools/DevToolsPlugin.java
@@ -36,7 +36,7 @@ import net.runelite.client.ui.NavigationButton;
 import net.runelite.client.ui.overlay.Overlay;
 
 @PluginDescriptor(
-	name = "Developer tools",
+	name = "Developer Tools",
 	developerPlugin = true
 )
 public class DevToolsPlugin extends Plugin

--- a/runelite-client/src/main/java/net/runelite/client/plugins/fightcave/FightCavePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/fightcave/FightCavePlugin.java
@@ -38,7 +38,7 @@ import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.util.QueryRunner;
 
 @PluginDescriptor(
-	name = "Fight cave"
+	name = "Fight Cave"
 )
 public class FightCavePlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangePlugin.java
@@ -52,7 +52,7 @@ import net.runelite.client.ui.ClientUI;
 import net.runelite.client.ui.NavigationButton;
 
 @PluginDescriptor(
-	name = "Grand Exchange offers"
+	name = "Grand Exchange"
 )
 public class GrandExchangePlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
@@ -32,7 +32,7 @@ import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.Overlay;
 
 @PluginDescriptor(
-	name = "Ground items"
+	name = "Ground Items"
 )
 public class GroundItemsPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/hiscore/HiscoreConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/hiscore/HiscoreConfig.java
@@ -30,7 +30,7 @@ import net.runelite.client.config.ConfigItem;
 
 @ConfigGroup(
 	keyName = "hiscore",
-	name = "Hiscore",
+	name = "HiScore",
 	description = "Configuration for the hiscore plugin"
 )
 public interface HiscoreConfig extends Config

--- a/runelite-client/src/main/java/net/runelite/client/plugins/hiscore/HiscorePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/hiscore/HiscorePlugin.java
@@ -41,7 +41,7 @@ import net.runelite.client.ui.ClientUI;
 import net.runelite.client.ui.NavigationButton;
 
 @PluginDescriptor(
-	name = "Hiscore",
+	name = "HiScore",
 	loadWhenOutdated = true
 )
 public class HiscorePlugin extends Plugin

--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
@@ -112,7 +112,7 @@ import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 
 @PluginDescriptor(
-	name = "Idle notifier"
+	name = "Idle Notifier"
 )
 public class IdleNotifierPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/info/InfoPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/info/InfoPlugin.java
@@ -32,7 +32,7 @@ import net.runelite.client.ui.ClientUI;
 import net.runelite.client.ui.NavigationButton;
 
 @PluginDescriptor(
-	name = "Info panel",
+	name = "Info Panel",
 	loadWhenOutdated = true
 )
 public class InfoPlugin extends Plugin

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatPlugin.java
@@ -32,7 +32,7 @@ import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.Overlay;
 
 @PluginDescriptor(
-	name = "Item stat"
+	name = "Item Stats"
 )
 public class ItemStatPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/jewellerycount/JewelleryCountPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/jewellerycount/JewelleryCountPlugin.java
@@ -30,7 +30,7 @@ import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.Overlay;
 
 @PluginDescriptor(
-	name = "Jewellery count"
+	name = "Jewellery Count"
 )
 public class JewelleryCountPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/lowmemory/LowMemoryPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/lowmemory/LowMemoryPlugin.java
@@ -33,7 +33,7 @@ import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 
 @PluginDescriptor(
-	name = "Low detail",
+	name = "Low Detail",
 	enabledByDefault = false
 )
 public class LowMemoryPlugin extends Plugin

--- a/runelite-client/src/main/java/net/runelite/client/plugins/motherlode/MotherlodeConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/motherlode/MotherlodeConfig.java
@@ -30,7 +30,7 @@ import net.runelite.client.config.ConfigItem;
 
 @ConfigGroup(
 	keyName = "motherlode",
-	name = "Motherlode",
+	name = "Motherlode Mine",
 	description = "Configuration for the motherlode plugin"
 )
 public interface MotherlodeConfig extends Config

--- a/runelite-client/src/main/java/net/runelite/client/plugins/motherlode/MotherlodePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/motherlode/MotherlodePlugin.java
@@ -63,7 +63,7 @@ import net.runelite.client.task.Schedule;
 import net.runelite.client.ui.overlay.Overlay;
 
 @PluginDescriptor(
-	name = "Motherlode",
+	name = "Motherlode Mine",
 	enabledByDefault = false
 )
 public class MotherlodePlugin extends Plugin

--- a/runelite-client/src/main/java/net/runelite/client/plugins/mousehighlight/MouseHighlightPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/mousehighlight/MouseHighlightPlugin.java
@@ -30,7 +30,7 @@ import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.Overlay;
 
 @PluginDescriptor(
-	name = "Mouse highlight"
+	name = "Mouse Tooltips"
 )
 public class MouseHighlightPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/opponentinfo/OpponentInfoPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/opponentinfo/OpponentInfoPlugin.java
@@ -36,7 +36,7 @@ import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.Overlay;
 
 @PluginDescriptor(
-	name = "Opponent information"
+	name = "Opponent Information"
 )
 public class OpponentInfoPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/pestcontrol/PestControlPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/pestcontrol/PestControlPlugin.java
@@ -32,7 +32,7 @@ import net.runelite.client.ui.FontManager;
 import net.runelite.client.ui.overlay.Overlay;
 
 @PluginDescriptor(
-	name = "Pest control"
+	name = "Pest Control"
 )
 public class PestControlPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsPlugin.java
@@ -33,7 +33,7 @@ import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.Overlay;
 
 @PluginDescriptor(
-	name = "Player names"
+	name = "Player Indicators"
 )
 public class PlayerIndicatorsPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/poh/PohConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/poh/PohConfig.java
@@ -30,7 +30,7 @@ import net.runelite.client.config.ConfigItem;
 
 @ConfigGroup(
 	keyName = "poh",
-	name = "Poh",
+	name = "Player-owned House",
 	description = "Configuration for the POH plugin"
 )
 public interface PohConfig extends Config

--- a/runelite-client/src/main/java/net/runelite/client/plugins/poh/PohPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/poh/PohPlugin.java
@@ -54,7 +54,7 @@ import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.Overlay;
 
 @PluginDescriptor(
-	name = "Poh"
+	name = "Player-owned House"
 )
 public class PohPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/prayflick/PrayerFlickPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/prayflick/PrayerFlickPlugin.java
@@ -32,7 +32,7 @@ import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.Overlay;
 
 @PluginDescriptor(
-	name = "Prayer flicking"
+	name = "Prayer Flicking"
 )
 public class PrayerFlickPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/puzzlesolver/PuzzleSolverPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/puzzlesolver/PuzzleSolverPlugin.java
@@ -33,7 +33,7 @@ import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 
 @PluginDescriptor(
-	name = "Puzzle solver"
+	name = "Puzzle Solver"
 )
 public class PuzzleSolverPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsConfig.java
@@ -30,7 +30,7 @@ import net.runelite.client.config.ConfigItem;
 
 @ConfigGroup(
 	keyName = "raids",
-	name = "Raids",
+	name = "Chambers Of Xeric",
 	description = "Configuration for the raids plugin"
 )
 public interface RaidsConfig extends Config

--- a/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsPlugin.java
@@ -69,7 +69,7 @@ import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.infobox.InfoBoxManager;
 
 @PluginDescriptor(
-	name = "Raids"
+	name = "Chambers Of Xeric"
 )
 @Slf4j
 public class RaidsPlugin extends Plugin

--- a/runelite-client/src/main/java/net/runelite/client/plugins/reportbutton/ReportButtonConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/reportbutton/ReportButtonConfig.java
@@ -30,7 +30,7 @@ import net.runelite.client.config.ConfigItem;
 
 @ConfigGroup(
 	keyName = "reportButton",
-	name = "Report Button Utils",
+	name = "Report Button",
 	description = "Configuration for report button"
 )
 public interface ReportButtonConfig extends Config

--- a/runelite-client/src/main/java/net/runelite/client/plugins/reportbutton/ReportButtonPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/reportbutton/ReportButtonPlugin.java
@@ -46,7 +46,7 @@ import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.task.Schedule;
 
 @PluginDescriptor(
-	name = "Report Button Utilities"
+	name = "Report Button"
 )
 @Slf4j
 public class ReportButtonPlugin extends Plugin

--- a/runelite-client/src/main/java/net/runelite/client/plugins/runepouch/RunepouchConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/runepouch/RunepouchConfig.java
@@ -31,7 +31,7 @@ import net.runelite.client.config.ConfigItem;
 
 @ConfigGroup(
 	keyName = "runepouch",
-	name = "Runepouch",
+	name = "Rune Pouch",
 	description = "Configuration for the Runepouch plugin"
 )
 public interface RunepouchConfig extends Config

--- a/runelite-client/src/main/java/net/runelite/client/plugins/runepouch/RunepouchPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/runepouch/RunepouchPlugin.java
@@ -32,7 +32,7 @@ import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.Overlay;
 
 @PluginDescriptor(
-	name = "Runepouch"
+	name = "Rune Pouch"
 )
 public class RunepouchPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/teamcapes/TeamCapesPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/teamcapes/TeamCapesPlugin.java
@@ -41,7 +41,7 @@ import net.runelite.client.task.Schedule;
 import net.runelite.client.ui.overlay.Overlay;
 
 @PluginDescriptor(
-	name = "Team capes",
+	name = "Team Capes",
 	enabledByDefault = false
 )
 public class TeamCapesPlugin extends Plugin

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesPlugin.java
@@ -42,7 +42,7 @@ import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.Overlay;
 
 @PluginDescriptor(
-	name = "XP globes"
+	name = "XP Globes"
 )
 public class XpGlobesPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerPlugin.java
@@ -55,7 +55,7 @@ import net.runelite.http.api.worlds.WorldType;
 import net.runelite.http.api.xp.XpClient;
 
 @PluginDescriptor(
-	name = "XP tracker"
+	name = "XP Tracker"
 )
 @Slf4j
 public class XpTrackerPlugin extends Plugin

--- a/runelite-client/src/main/java/net/runelite/client/plugins/zoom/ZoomConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/zoom/ZoomConfig.java
@@ -30,7 +30,7 @@ import net.runelite.client.config.ConfigItem;
 
 @ConfigGroup(
 	keyName = "zoom",
-	name = "Zoom Unlimiter",
+	name = "Camera Zoom",
 	description = "Configuration for the camera zoom limit"
 )
 public interface ZoomConfig extends Config

--- a/runelite-client/src/main/java/net/runelite/client/plugins/zoom/ZoomPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/zoom/ZoomPlugin.java
@@ -37,7 +37,7 @@ import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 
 @PluginDescriptor(
-	name = "Camera zoom unlimiter"
+	name = "Camera Zoom"
 )
 @Slf4j
 public class ZoomPlugin extends Plugin


### PR DESCRIPTION
- Replace abbreviations with full names
- Make casing in plugins consistent (title case)

These changes are needed in order to achieve better navigation in config
panel and also to improve search results in the panel (and to reduce the
mess with current naming).

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>