### PR TITLE
Add timer to hide Slayer infobox

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerConfig.java
@@ -65,6 +65,16 @@ public interface SlayerConfig extends Config
 		return true;
 	}
 
+	@ConfigItem(
+		keyName = "statTimeout",
+		name = "InfoBox Expiry (minutes)",
+		description = "Set the time until the InfoBox expires"
+	)
+	default int statTimeout()
+	{
+		return 5;
+	}
+
 	// Stored data
 	@ConfigItem(
 		keyName = "taskName",


### PR DESCRIPTION
Add an option in plugin config to set a time for the infobox to expire
Change setTask to only fire on initial login (to stop infobox appearing on every map change)
Infobox reappears on getting task, checking task, killing slayer monster, and initial log in

First contribution to a project of this nature so please let me know if there is anything that should be changed

Closes #526 