### PR TITLE
Fix notes plugin loading notes from account

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/notes/NotesPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/notes/NotesPanel.java
@@ -91,4 +91,9 @@ public class NotesPanel extends PluginPanel
 		});
 		add(notesEditor, BorderLayout.CENTER);
 	}
+
+	void setNotes(String data)
+	{
+		notesEditor.setText(data);
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/notes/NotesPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/notes/NotesPlugin.java
@@ -27,7 +27,9 @@ package net.runelite.client.plugins.notes;
 import javax.imageio.ImageIO;
 import javax.inject.Inject;
 
+import com.google.common.eventbus.Subscribe;
 import com.google.inject.Provides;
+import net.runelite.api.events.SessionOpen;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
@@ -76,5 +78,13 @@ public class NotesPlugin extends Plugin
 	protected void shutDown()
 	{
 		ui.getPluginToolbar().removeNavigation(navButton);
+	}
+
+	@Subscribe
+	public void onSessionOpen(SessionOpen event)
+	{
+		// update notes
+		String data = config.notesData();
+		panel.setNotes(data);
 	}
 }


### PR DESCRIPTION
When logged into a sync account, the notes plugin was loading notes before the ConfigClient updated config. Add an event to update notes when the config changes.