### PR TITLE
Extend TooltipManager to support multiple types of tooltip

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatOverlay.java
@@ -32,7 +32,7 @@ import net.runelite.api.Client;
 import net.runelite.api.queries.InventoryWidgetItemQuery;
 import net.runelite.api.widgets.WidgetItem;
 import net.runelite.client.ui.overlay.Overlay;
-import net.runelite.client.ui.overlay.tooltip.Tooltip;
+import net.runelite.client.ui.overlay.tooltip.TextTooltip;
 import net.runelite.client.ui.overlay.tooltip.TooltipManager;
 import net.runelite.client.util.QueryRunner;
 
@@ -76,7 +76,7 @@ public class ItemStatOverlay extends Overlay
 					{
 						b.append(buildStatChangeString(c));
 					}
-					tooltipManager.add(new Tooltip(b.toString()));
+					tooltipManager.add(new TextTooltip(b.toString()));
 				}
 			}
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/mousehighlight/MouseHighlightOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/mousehighlight/MouseHighlightOverlay.java
@@ -33,7 +33,7 @@ import net.runelite.api.Client;
 import net.runelite.api.MenuEntry;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayPosition;
-import net.runelite.client.ui.overlay.tooltip.Tooltip;
+import net.runelite.client.ui.overlay.tooltip.TextTooltip;
 import net.runelite.client.ui.overlay.tooltip.TooltipManager;
 
 class MouseHighlightOverlay extends Overlay
@@ -89,7 +89,7 @@ class MouseHighlightOverlay extends Overlay
 				}
 		}
 
-		tooltipManager.add(new Tooltip(option + (Strings.isNullOrEmpty(target) ? "" : " " + target)));
+		tooltipManager.add(new TextTooltip(option + (Strings.isNullOrEmpty(target) ? "" : " " + target)));
 		return null;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/runepouch/RunepouchOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/runepouch/RunepouchOverlay.java
@@ -42,7 +42,7 @@ import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.OverlayUtil;
-import net.runelite.client.ui.overlay.tooltip.Tooltip;
+import net.runelite.client.ui.overlay.tooltip.TextTooltip;
 import net.runelite.client.ui.overlay.tooltip.TooltipManager;
 import net.runelite.client.util.QueryRunner;
 
@@ -156,7 +156,7 @@ public class RunepouchOverlay extends Overlay
 
 		if (!tooltip.isEmpty() && runePouch.getCanvasBounds().contains(client.getMouseCanvasPosition().getX(), client.getMouseCanvasPosition().getY()))
 		{
-			tooltipManager.add(new Tooltip(tooltip));
+			tooltipManager.add(new TextTooltip(tooltip));
 		}
 		return null;
 	}

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/components/TextBoxComponent.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/components/TextBoxComponent.java
@@ -35,8 +35,15 @@ import lombok.Setter;
 import net.runelite.api.IndexedSprite;
 import net.runelite.client.ui.FontManager;
 import net.runelite.client.ui.overlay.RenderableEntity;
+import net.runelite.client.ui.overlay.tooltip.ModIconReceiver;
+import net.runelite.client.ui.overlay.tooltip.TooltipComponent;
 
-public class TooltipComponent implements RenderableEntity
+import static java.lang.Math.max;
+
+/**
+ * Renders a string with a background panel.
+ */
+public class TextBoxComponent implements TooltipComponent, ModIconReceiver, RenderableEntity
 {
 	private static final Pattern BR = Pattern.compile("</br>");
 	private static final int OFFSET = 4;
@@ -53,6 +60,9 @@ public class TooltipComponent implements RenderableEntity
 
 	@Setter
 	private IndexedSprite[] modIcons;
+
+	@Setter
+	private boolean anchorBottomRight;
 
 	@Override
 	public Dimension render(Graphics2D graphics, Point parent)
@@ -80,19 +90,14 @@ public class TooltipComponent implements RenderableEntity
 			tooltipHeight += textHeight;
 		}
 
-		// Tooltip position
 		int x = position.x;
 		int y = position.y;
-		x = x - tooltipWidth - OFFSET * 2;
-		if (x < 0)
-		{
-			x = 0;
-		}
 
-		y = y - tooltipHeight - OFFSET * 2;
-		if (y < 0)
+		// if anchoring bottom right, subtract dimensions but don't render outside screen
+		if (anchorBottomRight)
 		{
-			y = 0;
+			x = max(x - tooltipWidth - OFFSET * 2, 0);
+			y = max(y - tooltipHeight - OFFSET * 2, 0);
 		}
 
 		// Render tooltip - background

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/infobox/InfoBoxOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/infobox/InfoBoxOverlay.java
@@ -38,7 +38,7 @@ import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.OverlayUtil;
 import net.runelite.client.ui.overlay.components.InfoBoxComponent;
-import net.runelite.client.ui.overlay.tooltip.Tooltip;
+import net.runelite.client.ui.overlay.tooltip.TextTooltip;
 import net.runelite.client.ui.overlay.tooltip.TooltipManager;
 
 public class InfoBoxOverlay extends Overlay
@@ -100,7 +100,7 @@ public class InfoBoxOverlay extends Overlay
 				if (client != null && intersectionRectangle.contains(new Point(client.getMouseCanvasPosition().getX(),
 					client.getMouseCanvasPosition().getY())))
 				{
-					tooltipManager.add(new Tooltip(box.getTooltip()));
+					tooltipManager.add(new TextTooltip(box.getTooltip()));
 				}
 			}
 

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/tooltip/ModIconReceiver.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/tooltip/ModIconReceiver.java
@@ -1,0 +1,12 @@
+package net.runelite.client.ui.overlay.tooltip;
+
+import net.runelite.api.IndexedSprite;
+
+/**
+ * Used in conjunction with the TooltipManager
+ * to signify that the component uses mod icons.
+ */
+public interface ModIconReceiver
+{
+	public void setModIcons(IndexedSprite[] icons);
+}

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/tooltip/PanelTooltip.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/tooltip/PanelTooltip.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2018, arlyon <https://github.com/arlyon>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.ui.overlay.tooltip;
+
+import lombok.Getter;
+import lombok.Setter;
+import net.runelite.client.ui.overlay.components.PanelComponent;
+
+import java.awt.Color;
+import java.awt.Point;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A tooltip that displays key value data.
+ *
+ * @see PanelComponent The component the tooltip uses.
+ */
+public class PanelTooltip implements Tooltip
+{
+	@Setter
+	private String title;
+
+	@Setter
+	private Color titleColor;
+
+	@Getter
+	private List<PanelComponent.Line> lines = new ArrayList<>();
+
+	@Getter
+	@Setter
+	private boolean followMouse = true;
+
+	@Setter
+	@Getter
+	private Point position = new Point();
+
+	/**
+	 * Creates the TooltipComponent for the tooltip.
+	 *
+	 * @return The TooltipComponent
+	 */
+	@Override
+	public TooltipComponent createTooltipComponent()
+	{
+		PanelComponent component = new PanelComponent();
+		component.getLines().addAll(this.lines);
+		component.setTitle(title);
+		component.setTitleColor(titleColor);
+		return component;
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/tooltip/TextTooltip.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/tooltip/TextTooltip.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, arlyon <https://github.com/arlyon>
+ * Copyright (c) 2017, Tyler <https://github.com/tylerthardy>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -24,34 +24,33 @@
  */
 package net.runelite.client.ui.overlay.tooltip;
 
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+import net.runelite.client.ui.overlay.components.TextBoxComponent;
+
 import java.awt.Point;
 
 /**
- * The interface for a tooltip. Tooltips can return
- * any TooltipComponent which is an extension of the
- * RenderableEntity with a few additional methods.
+ * A simple tooltip for displaying lines of text. Also
+ * supports runescape's text markup.
+ *
+ * @see TextBoxComponent The component the TextTooltip uses.
  */
-public interface Tooltip
+@Data
+@AllArgsConstructor
+@RequiredArgsConstructor
+public class TextTooltip implements Tooltip
 {
-	/**
-	 * Creates the TooltipComponent for the tooltip.
-	 *
-	 * @return The TooltipComponent
-	 */
-	TooltipComponent createTooltipComponent();
+	private final String text;
+	private boolean followMouse = true;
+	private Point position = new Point();
 
-	/**
-	 * Whether the tooltip should follow the mouse.
-	 *
-	 * @return True if the tooltip should follow the mouse.
-	 */
-	boolean isFollowMouse();
-
-	/**
-	 * In the case that the Tooltip is not intended to
-	 * follow the mouse, this position is used instead.
-	 *
-	 * @return The desired mouse position.
-	 */
-	Point getPosition();
+	@Override
+	public TooltipComponent createTooltipComponent()
+	{
+		TextBoxComponent component = new TextBoxComponent();
+		component.setText(this.getText());
+		return component;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/tooltip/TooltipComponent.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/tooltip/TooltipComponent.java
@@ -24,34 +24,30 @@
  */
 package net.runelite.client.ui.overlay.tooltip;
 
+import net.runelite.api.Client;
+import net.runelite.api.IndexedSprite;
+import net.runelite.client.ui.overlay.RenderableEntity;
+
 import java.awt.Point;
 
 /**
- * The interface for a tooltip. Tooltips can return
- * any TooltipComponent which is an extension of the
- * RenderableEntity with a few additional methods.
+ * An extension of RenderableEntity that adds some
+ * useful methods for tooltips.
  */
-public interface Tooltip
+public interface TooltipComponent extends RenderableEntity
 {
 	/**
-	 * Creates the TooltipComponent for the tooltip.
+	 * Sets the position of the RenderableEntity to the given Point.
 	 *
-	 * @return The TooltipComponent
+	 * @param position The desired position.
 	 */
-	TooltipComponent createTooltipComponent();
+	void setPosition(Point position);
 
 	/**
-	 * Whether the tooltip should follow the mouse.
+	 * Sets whether the component should anchor itself to the
+	 * top left (default) or bottom right (tooltip).
 	 *
-	 * @return True if the tooltip should follow the mouse.
+	 * @param value True for bottom right.
 	 */
-	boolean isFollowMouse();
-
-	/**
-	 * In the case that the Tooltip is not intended to
-	 * follow the mouse, this position is used instead.
-	 *
-	 * @return The desired mouse position.
-	 */
-	Point getPosition();
+	void setAnchorBottomRight(boolean value);
 }

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/tooltip/TooltipManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/tooltip/TooltipManager.java
@@ -30,10 +30,18 @@ import javax.inject.Singleton;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
+/**
+ * A singleton class to handle displaying tooltips on the screen.
+ */
 @Singleton
 @Slf4j
 public class TooltipManager
 {
+	/**
+	 * The list of tooltips to display on the screen.
+	 * It is cleared each frame, and so the tooltip must
+	 * be added each frame it is drawn.
+	 */
 	@Getter
 	private final List<Tooltip> tooltips = new ArrayList<>();
 


### PR DESCRIPTION
This PR extends the tooltip manager so that many implementations can be used.

- Creates the `Tooltip` interface for multiple tooltip types in the `TooltipManager`
- Creates a `TooltipComponent` interface that must be implemented by any tooltip-compatible component.
- Creates a new `PanelTooltip` that uses the `PanelComponent` (to be used in #725).