### PR TITLE
Allow disabling of the skill icons on XP drops

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/experiencedrop/XpDropConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/experiencedrop/XpDropConfig.java
@@ -37,6 +37,16 @@ import net.runelite.client.config.ConfigItem;
 public interface XpDropConfig extends Config
 {
 	@ConfigItem(
+		keyName = "hideSkillIcons",
+		name = "Hide skill icons",
+		description = "Configure if XP drops will show their respective skill icons"
+	)
+	default boolean hideSkillIcons()
+	{
+		return false;
+	}
+
+	@ConfigItem(
 		keyName = "meleePrayerColor",
 		name = "Melee Prayer Color",
 		description = "XP drop color when a melee prayer is active"

--- a/runelite-client/src/main/java/net/runelite/client/plugins/experiencedrop/XpDropPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/experiencedrop/XpDropPlugin.java
@@ -66,12 +66,18 @@ public class XpDropPlugin extends Plugin
 			return;
 		}
 
-		PrayerType prayer = getActivePrayerType();
 		if (widget.isHidden())
 		{
 			return;
 		}
 
+		if (config.hideSkillIcons() && widget.getSpriteId() > 0)
+		{
+			widget.setHidden(true);
+			return;
+		}
+
+		PrayerType prayer = getActivePrayerType();
 		if (prayer == null)
 		{
 			resetTextColor(widget);


### PR DESCRIPTION
This allows the user to disable the skill icons on XP drops.

![image](https://user-images.githubusercontent.com/35824069/37016090-e26252e4-210a-11e8-87df-de023e19d228.png)

Fixes #801