### PR TITLE
Fix clanchat messages not showing rank icons during region loading

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/clanchat/ClanChatPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/clanchat/ClanChatPlugin.java
@@ -146,7 +146,7 @@ public class ClanChatPlugin extends Plugin
 	@Subscribe
 	public void onSetMessage(SetMessage setMessage)
 	{
-		if (client.getGameState() != GameState.LOGGED_IN)
+		if (client.getGameState() != GameState.LOADING && client.getGameState() != GameState.LOGGED_IN)
 		{
 			return;
 		}


### PR DESCRIPTION
Fixes #583 
There was honestly no need for this check here since messages with the type `CLANCHAT` would always require the clan chat to have at least 1 member (aside from when we set them e.g. trough chat history). Unless there's something I don't know of, this should work just fine.