### PR TITLE
Remove left click calling from BA plugin

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/barbarianassault/BarbarianAssaultConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/barbarianassault/BarbarianAssaultConfig.java
@@ -36,16 +36,6 @@ import net.runelite.client.config.ConfigItem;
 public interface BarbarianAssaultConfig extends Config
 {
 	@ConfigItem(
-		keyName = "removeUnused",
-		name = "Remove incorrect calls",
-		description = "Removes incorrect calls for Role horn"
-	)
-	default boolean removeWrong()
-	{
-		return true;
-	}
-
-	@ConfigItem(
 		keyName = "showTimer",
 		name = "Show call change timer",
 		description = "Show time to next call change"

--- a/runelite-client/src/main/java/net/runelite/client/plugins/barbarianassault/BarbarianAssaultPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/barbarianassault/BarbarianAssaultPlugin.java
@@ -39,11 +39,8 @@ import net.runelite.api.MenuEntry;
 import net.runelite.api.Varbits;
 import net.runelite.api.events.ChatMessage;
 import net.runelite.api.events.GameTick;
-import net.runelite.api.events.MenuEntryAdded;
 import net.runelite.api.events.VarbitChanged;
 import net.runelite.api.kit.KitType;
-import net.runelite.api.widgets.Widget;
-import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
@@ -107,39 +104,6 @@ public class BarbarianAssaultPlugin extends Plugin
 				case ItemID.HEALER_ICON:
 					overlay.setCurrentRound(new Round(Role.HEALER));
 					break;
-			}
-		}
-	}
-
-	@Subscribe
-	public void onMenuOpen(MenuEntryAdded event)
-	{
-		if (config.removeWrong() && overlay.getCurrentRound() != null && event.getTarget().endsWith("horn"))
-		{
-			MenuEntry[] menuEntries = client.getMenuEntries();
-			WidgetInfo callInfo = overlay.getCurrentRound().getRoundRole().getCall();
-			Widget callWidget = client.getWidget(callInfo);
-			String call = Calls.getOption(callWidget.getText());
-			MenuEntry correctCall = null;
-
-			entries.clear();
-			for (MenuEntry entry : menuEntries)
-			{
-				String option = entry.getOption();
-				if (option.equals(call))
-				{
-					correctCall = entry;
-				}
-				else if (!option.startsWith("Tell-"))
-				{
-					entries.add(entry);
-				}
-			}
-
-			if (correctCall != null)
-			{
-				entries.add(correctCall);
-				client.setMenuEntries(entries.toArray(new MenuEntry[entries.size()]));
 			}
 		}
 	}


### PR DESCRIPTION
Being able to spam left click without paying attention to what actually needs to be called is overpowered. Until we come up with something better (like binding the different calls to Ctrl, Alt, Ctrl+Alt) we shouldn't offer this particular feature.