### PR TITLE
runelite-client: fix Use tooltip arrow not being displayed

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/components/TooltipComponent.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/components/TooltipComponent.java
@@ -155,6 +155,17 @@ public class TooltipComponent implements RenderableEntity
 							lineX += modIcon.getWidth();
 						}
 					}
+					else
+					{
+						TextComponent textComponent = new TextComponent();
+						textComponent.setColor(nextColor);
+						String text = line.substring(begin, j + 1);
+						textComponent.setText(text);
+						textComponent.setPosition(new Point(lineX, textY + (i + 1) * textHeight - textDescent));
+						textComponent.render(graphics, parent);
+
+						lineX += metrics.stringWidth(text);
+					}
 
 					begin = j + 1;
 				}
@@ -192,6 +203,10 @@ public class TooltipComponent implements RenderableEntity
 				if (subLine.startsWith("img="))
 				{
 					textWidth += MOD_ICON_WIDTH;
+				}
+				else if (!subLine.startsWith("col=") && !subLine.startsWith("/col"))
+				{
+					textWidth += metrics.stringWidth(line.substring(begin, j + 1));
 				}
 
 				begin = j + 1;


### PR DESCRIPTION
Fixes #866 

Ideally we should probably have some parser util that can do a better job of parsing their markup language, one that gives some iterateable collection containing elements such as color change, regular text, modicons, and replace TooltipComponent's parser with that.. But this is a quick fix to get arrows to work.