### PR TITLE
Remove duplicate anti-venom+ config check

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersPlugin.java
@@ -146,11 +146,6 @@ public class TimersPlugin extends Plugin
 			removeGameTimer(MAGICIMBUE);
 		}
 
-		if (!config.showAntiVenomPlus())
-		{
-			removeGameTimer(ANTIVENOMPLUS);
-		}
-
 		if (!config.showTeleblock())
 		{
 			removeGameTimer(FULLTB);


### PR DESCRIPTION
Remove the first duplicate config check for Anti-venom+ in TimersPlugin (other one begins line 175, left this one so that all antivenom are grouped)