### PR TITLE
xp globe: add a toggle for the orb background

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesConfig.java
@@ -81,10 +81,21 @@ public interface XpGlobesConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "enableOrbBackground",
+		name = "Show orb background",
+		description = "Display the globe background",
+		position = 4
+	)
+	default boolean showOrbBackground()
+	{
+		return true;
+	}
+
+	@ConfigItem(
 		keyName = "Progress arc width",
 		name = "Progress arc width",
 		description = "Change the stroke width of the progress arc",
-		position = 4
+		position = 5
 	)
 	default int progressArcStrokeWidth()
 	{
@@ -95,7 +106,7 @@ public interface XpGlobesConfig extends Config
 		keyName = "Orb size",
 		name = "Size of orbs",
 		description = "Change the size of the xp orbs",
-		position = 5
+		position = 6
 	)
 	default int xpOrbSize()
 	{
@@ -106,7 +117,7 @@ public interface XpGlobesConfig extends Config
 		keyName = "Center orbs",
 		name = "Center orbs",
 		description = "Where to center the xp orbs around",
-		position = 6
+		position = 7
 	)
 	default OrbCentering centerOrbs()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesOverlay.java
@@ -179,8 +179,12 @@ public class XpGlobesOverlay extends Overlay
 	{
 		graphics.setColor(config.progressOrbBackgroundColor());
 		Ellipse2D ellipse = new Ellipse2D.Double(x, y, config.xpOrbSize(), config.xpOrbSize());
-		graphics.fill(ellipse);
-		graphics.draw(ellipse);
+		if (config.showOrbBackground())
+		{
+			graphics.fill(ellipse);
+			graphics.draw(ellipse);
+		}
+
 		return ellipse;
 	}
 


### PR DESCRIPTION
add a config option to disable/enable the orb background color

![animation 5](https://user-images.githubusercontent.com/5454364/37057292-80c29502-214c-11e8-9d25-2961a7d038ed.gif)
