### PR TITLE
runelite-api: fix worldToMiniMap not working correctly in stretched mode

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/Perspective.java
+++ b/runelite-api/src/main/java/net/runelite/api/Perspective.java
@@ -230,7 +230,9 @@ public class Perspective
 			int xx = y * sin + cos * x >> 16;
 			int yy = sin * x - y * cos >> 16;
 
-			int miniMapX = client.getCanvas().getWidth() - (!client.isResized() ? 208 : 167);
+			int miniMapX = client.isResized()
+				? client.getCanvas().getWidth() - 167
+				: Constants.GAME_FIXED_WIDTH - 208;
 
 			x = (miniMapX + 167 / 2) + xx;
 			y = (167 / 2 - 1) + yy;


### PR DESCRIPTION
Fixes Perspective#worldToMinimap not returning correct values if in fixed mode and using the stretched fixed mode plugin.

I looked for other usages of Canvas width/size and couldn't find any that would be affected by the same behaviour.

Fixes #846 