### PR TITLE
dev tools: add location to dev tools plugin

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/devtools/DevToolsPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/devtools/DevToolsPanel.java
@@ -65,6 +65,7 @@ public class DevToolsPanel extends PluginPanel
 	private JButton renderInventoryBtn = new JButton();
 	private JButton renderProjectilesBtn = new JButton();
 	private JPanel boundsDebugPanel = new JPanel();
+	private JButton renderLocationBtn = new JButton();
 
 	private JLabel textLbl = new JLabel();
 	private JLabel textColorLbl = new JLabel();
@@ -103,7 +104,7 @@ public class DevToolsPanel extends PluginPanel
 	private JPanel createOptionsPanel()
 	{
 		JPanel container = new JPanel();
-		container.setLayout(new GridLayout(6, 2, 3, 3));
+		container.setLayout(new GridLayout(7, 2, 3, 3));
 
 		renderPlayersBtn = new JButton("Players");
 		renderPlayersBtn.addActionListener(e ->
@@ -187,6 +188,14 @@ public class DevToolsPanel extends PluginPanel
 		JButton settingsClearBtn = new JButton("Clear Settings");
 		settingsClearBtn.addActionListener(settingsTracker::clear);
 		container.add(settingsClearBtn);
+
+		renderLocationBtn = new JButton("Location");
+		renderLocationBtn.addActionListener(e ->
+		{
+			highlightButton(renderLocationBtn);
+			plugin.toggleLocation();
+		});
+		container.add(renderLocationBtn);
 
 		return container;
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/devtools/DevToolsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/devtools/DevToolsPlugin.java
@@ -26,6 +26,8 @@ package net.runelite.client.plugins.devtools;
 
 import java.awt.Font;
 import java.awt.image.BufferedImage;
+import java.util.Arrays;
+import java.util.Collection;
 import javax.imageio.ImageIO;
 import javax.inject.Inject;
 import net.runelite.api.widgets.Widget;
@@ -48,6 +50,9 @@ public class DevToolsPlugin extends Plugin
 	@Inject
 	private DevToolsOverlay overlay;
 
+	@Inject
+	private LocationOverlay locationOverlay;
+
 	private boolean togglePlayers;
 	private boolean toggleNpcs;
 	private boolean toggleGroundItems;
@@ -57,6 +62,7 @@ public class DevToolsPlugin extends Plugin
 	private boolean toggleDecor;
 	private boolean toggleInventory;
 	private boolean toggleProjectiles;
+	private boolean toggleLocation;
 
 	Widget currentWidget;
 	int itemIndex = -1;
@@ -93,9 +99,9 @@ public class DevToolsPlugin extends Plugin
 	}
 
 	@Override
-	public Overlay getOverlay()
+	public Collection<Overlay> getOverlays()
 	{
-		return overlay;
+		return Arrays.asList(overlay, locationOverlay);
 	}
 
 	Font getFont()
@@ -148,6 +154,11 @@ public class DevToolsPlugin extends Plugin
 		toggleProjectiles = !toggleProjectiles;
 	}
 
+	void toggleLocation()
+	{
+		toggleLocation = !toggleLocation;
+	}
+
 	boolean isTogglePlayers()
 	{
 		return togglePlayers;
@@ -191,5 +202,10 @@ public class DevToolsPlugin extends Plugin
 	boolean isToggleProjectiles()
 	{
 		return toggleProjectiles;
+	}
+
+	boolean isToggleLocation()
+	{
+		return toggleLocation;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/devtools/LocationOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/devtools/LocationOverlay.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2018, Seth <https://github.com/sethtroll>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.devtools;
+
+import java.awt.Dimension;
+import java.awt.Graphics2D;
+import javax.inject.Inject;
+import net.runelite.api.Client;
+import net.runelite.api.Point;
+import net.runelite.client.ui.overlay.Overlay;
+import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.components.PanelComponent;
+
+public class LocationOverlay extends Overlay
+{
+	private final Client client;
+	private final DevToolsPlugin plugin;
+
+	private PanelComponent panelComponent;
+
+	@Inject
+	LocationOverlay(Client client, DevToolsPlugin plugin)
+	{
+		setPosition(OverlayPosition.TOP_LEFT);
+		this.client = client;
+		this.plugin = plugin;
+	}
+
+	@Override
+	public Dimension render(Graphics2D graphics, java.awt.Point parent)
+	{
+		if (!plugin.isToggleLocation())
+		{
+			return null;
+		}
+
+		panelComponent = new PanelComponent();
+
+		Point localWorld = client.getLocalPlayer().getWorldLocation();
+
+		panelComponent.getLines().add(new PanelComponent.Line(
+			"Tile",
+			localWorld.getX() + ", " + localWorld.getY() + ", " + client.getPlane()
+		));
+
+		for (int i = 0; i < client.getMapRegions().length; i++)
+		{
+			int region = client.getMapRegions()[i];
+
+			panelComponent.getLines().add(new PanelComponent.Line(
+				(i == 0) ? "Map region" : " ",
+				String.valueOf(region)
+			));
+		}
+
+
+		return panelComponent.render(graphics, parent);
+	}
+}


### PR DESCRIPTION
Adds a panel which will display current tile in relation to world location as well as display the current map regions

![location](https://user-images.githubusercontent.com/5454364/37075477-857a0dd2-2197-11e8-952c-63f7f2c64485.png)
