### PR TITLE
Synchronize usages of ImageIO.read(...)

### DIFF
--- a/http-api/src/main/java/net/runelite/http/api/item/ItemClient.java
+++ b/http-api/src/main/java/net/runelite/http/api/item/ItemClient.java
@@ -95,8 +95,10 @@ public class ItemClient
 			}
 
 			InputStream in = response.body().byteStream();
-			BufferedImage imageIcon = ImageIO.read(in);
-			return imageIcon;
+			synchronized (ImageIO.class)
+			{
+				return ImageIO.read(in);
+			}
 		}
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/game/SkillIconManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/game/SkillIconManager.java
@@ -51,7 +51,10 @@ public class SkillIconManager
 		{
 			String skillIconPath = "/skill_icons/" + skill.getName().toLowerCase() + ".png";
 			log.debug("Loading skill icon from {}", skillIconPath);
-			skillImage = ImageIO.read(SkillIconManager.class.getResourceAsStream(skillIconPath));
+			synchronized (ImageIO.class)
+			{
+				skillImage = ImageIO.read(SkillIconManager.class.getResourceAsStream(skillIconPath));
+			}
 			imgCache[skillIdx] = skillImage;
 		}
 		catch (IOException e)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/account/AccountPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/account/AccountPlugin.java
@@ -68,8 +68,11 @@ public class AccountPlugin extends Plugin
 	{
 		try
 		{
-			LOGIN_IMAGE = ImageIO.read(AccountPlugin.class.getResourceAsStream("login_icon.png"));
-			LOGOUT_IMAGE = ImageIO.read(AccountPlugin.class.getResourceAsStream("logout_icon.png"));
+			synchronized (ImageIO.class)
+			{
+				LOGIN_IMAGE = ImageIO.read(AccountPlugin.class.getResourceAsStream("login_icon.png"));
+				LOGOUT_IMAGE = ImageIO.read(AccountPlugin.class.getResourceAsStream("logout_icon.png"));
+			}
 		}
 		catch (IOException e)
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/barbarianassault/BarbarianAssaultPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/barbarianassault/BarbarianAssaultPlugin.java
@@ -80,7 +80,11 @@ public class BarbarianAssaultPlugin extends Plugin
 	{
 		font = FontManager.getRunescapeFont()
 			.deriveFont(Font.BOLD, 24);
-		clockImage = ImageIO.read(getClass().getResourceAsStream("clock.png"));
+
+		synchronized (ImageIO.class)
+		{
+			clockImage = ImageIO.read(getClass().getResourceAsStream("clock.png"));
+		}
 	}
 
 	@Subscribe

--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
@@ -92,9 +92,12 @@ public class ConfigPanel extends PluginPanel
 	{
 		try
 		{
-			CONFIG_ICON = ImageIO.read(ConfigPanel.class.getResourceAsStream("config_icon.png"));
-			UNCHECK_ICON = ImageIO.read(ConfigPanel.class.getResourceAsStream("disabled.png"));
-			CHECK_ICON = ImageIO.read(ConfigPanel.class.getResourceAsStream("enabled.png"));
+			synchronized (ImageIO.class)
+			{
+				CONFIG_ICON = ImageIO.read(ConfigPanel.class.getResourceAsStream("config_icon.png"));
+				UNCHECK_ICON = ImageIO.read(ConfigPanel.class.getResourceAsStream("disabled.png"));
+				CHECK_ICON = ImageIO.read(ConfigPanel.class.getResourceAsStream("enabled.png"));
+			}
 		}
 		catch (IOException e)
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPlugin.java
@@ -25,6 +25,7 @@
 package net.runelite.client.plugins.config;
 
 import com.google.common.eventbus.Subscribe;
+import java.awt.image.BufferedImage;
 import java.util.concurrent.ScheduledExecutorService;
 import javax.imageio.ImageIO;
 import javax.inject.Inject;
@@ -68,9 +69,15 @@ public class ConfigPlugin extends Plugin
 	{
 		configPanel = new ConfigPanel(pluginManager, configManager, executorService, runeLiteConfig);
 
+		BufferedImage icon;
+		synchronized (ImageIO.class)
+		{
+			icon = ImageIO.read(getClass().getResourceAsStream("config_icon.png"));
+		}
+
 		navButton = new NavigationButton(
 			"Configuration",
-			ImageIO.read(getClass().getResourceAsStream("config_icon.png")),
+			icon,
 			() -> configPanel);
 
 		ui.getPluginToolbar().addNavigation(navButton);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/devtools/DevToolsPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/devtools/DevToolsPanel.java
@@ -200,10 +200,13 @@ public class DevToolsPanel extends PluginPanel
 
 		try
 		{
-			bBox2DIcon = new ImageIcon(ImageIO.read(DevToolsPlugin.class.getResourceAsStream("2D_bounding_box.png")));
-			bBox3DIcon = new ImageIcon(ImageIO.read(DevToolsPlugin.class.getResourceAsStream("3D_bounding_box.png")));
-			clickBoxIcon = new ImageIcon(ImageIO.read(DevToolsPlugin.class.getResourceAsStream("2D_clickbox_geometry.png")));
-			bBox3DMousoverIcon = new ImageIcon(ImageIO.read(DevToolsPlugin.class.getResourceAsStream("mouseover_3D_bounding_box.png")));
+			synchronized (ImageIO.class)
+			{
+				bBox2DIcon = new ImageIcon(ImageIO.read(DevToolsPlugin.class.getResourceAsStream("2D_bounding_box.png")));
+				bBox3DIcon = new ImageIcon(ImageIO.read(DevToolsPlugin.class.getResourceAsStream("3D_bounding_box.png")));
+				clickBoxIcon = new ImageIcon(ImageIO.read(DevToolsPlugin.class.getResourceAsStream("2D_clickbox_geometry.png")));
+				bBox3DMousoverIcon = new ImageIcon(ImageIO.read(DevToolsPlugin.class.getResourceAsStream("mouseover_3D_bounding_box.png")));
+			}
 		}
 		catch (IOException ex)
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/devtools/DevToolsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/devtools/DevToolsPlugin.java
@@ -25,6 +25,7 @@
 package net.runelite.client.plugins.devtools;
 
 import java.awt.Font;
+import java.awt.image.BufferedImage;
 import javax.imageio.ImageIO;
 import javax.inject.Inject;
 import net.runelite.api.widgets.Widget;
@@ -67,9 +68,16 @@ public class DevToolsPlugin extends Plugin
 	protected void startUp() throws Exception
 	{
 		final DevToolsPanel panel = injector.getInstance(DevToolsPanel.class);
+
+		BufferedImage icon;
+		synchronized (ImageIO.class)
+		{
+			icon = ImageIO.read(getClass().getResourceAsStream("devtools_icon.png"));
+		}
+
 		navButton = new NavigationButton(
 			"Developer Tools",
-			ImageIO.read(getClass().getResourceAsStream("devtools_icon.png")),
+			icon,
 			() -> panel);
 
 		ui.getPluginToolbar().addNavigation(navButton);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/feed/FeedPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/feed/FeedPanel.java
@@ -95,7 +95,10 @@ class FeedPanel extends PluginPanel
 	{
 		try
 		{
-			RUNELITE_ICON = ImageIO.read(FeedPanel.class.getResourceAsStream("runelite.png"));
+			synchronized (ImageIO.class)
+			{
+				RUNELITE_ICON = ImageIO.read(FeedPanel.class.getResourceAsStream("runelite.png"));
+			}
 		}
 		catch (IOException e)
 		{
@@ -104,7 +107,10 @@ class FeedPanel extends PluginPanel
 
 		try
 		{
-			OSRS_ICON = ImageIO.read(FeedPanel.class.getResourceAsStream("osrs.png"));
+			synchronized (ImageIO.class)
+			{
+				OSRS_ICON = ImageIO.read(FeedPanel.class.getResourceAsStream("osrs.png"));
+			}
 		}
 		catch (IOException e)
 		{
@@ -184,7 +190,12 @@ class FeedPanel extends PluginPanel
 									return;
 								}
 
-								avatar.setIcon(new ImageIcon(ImageIO.read(responseBody.byteStream())));
+								BufferedImage icon;
+								synchronized (ImageIO.class)
+								{
+									icon = ImageIO.read(responseBody.byteStream());
+								}
+								avatar.setIcon(new ImageIcon(icon));
 							}
 						}
 					});

--- a/runelite-client/src/main/java/net/runelite/client/plugins/feed/FeedPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/feed/FeedPlugin.java
@@ -27,6 +27,7 @@ package net.runelite.client.plugins.feed;
 import com.google.common.base.Suppliers;
 import com.google.common.eventbus.Subscribe;
 import com.google.inject.Provides;
+import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.time.temporal.ChronoUnit;
 import java.util.concurrent.ScheduledExecutorService;
@@ -87,9 +88,15 @@ public class FeedPlugin extends Plugin
 	{
 		feedPanel = new FeedPanel(config, feedSupplier, linkBrowser);
 
+		BufferedImage icon;
+		synchronized (ImageIO.class)
+		{
+			icon = ImageIO.read(getClass().getResourceAsStream("icon.png"));
+		}
+
 		navButton = new NavigationButton(
 			"News Feed",
-			ImageIO.read(getClass().getResourceAsStream("icon.png")),
+			icon,
 			() -> feedPanel);
 
 		ui.getPluginToolbar().addNavigation(navButton);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/fightcave/FightCaveOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/fightcave/FightCaveOverlay.java
@@ -39,7 +39,6 @@ import java.awt.Graphics2D;
 import java.awt.Point;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
-import java.io.InputStream;
 
 @Slf4j
 public class FightCaveOverlay extends Overlay
@@ -110,8 +109,10 @@ public class FightCaveOverlay extends Overlay
 		BufferedImage image = null;
 		try
 		{
-			InputStream in = FightCaveOverlay.class.getResourceAsStream(path);
-			image = ImageIO.read(in);
+			synchronized (ImageIO.class)
+			{
+				image = ImageIO.read(FightCaveOverlay.class.getResourceAsStream(path));
+			}
 		}
 		catch (IOException e)
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangePlugin.java
@@ -84,7 +84,11 @@ public class GrandExchangePlugin extends Plugin
 	protected void startUp() throws IOException
 	{
 		panel = injector.getInstance(GrandExchangePanel.class);
-		BufferedImage icon = ImageIO.read(getClass().getResourceAsStream("ge_icon.png"));
+		BufferedImage icon;
+		synchronized (ImageIO.class)
+		{
+			icon = ImageIO.read(getClass().getResourceAsStream("ge_icon.png"));
+		}
 		button = new NavigationButton("GE Offers", icon, () -> panel);
 		ui.getPluginToolbar().addNavigation(button);
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangeSearchPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangeSearchPanel.java
@@ -88,7 +88,12 @@ class GrandExchangeSearchPanel extends JPanel
 		// Search Box
 		try
 		{
-			search = new ImageIcon(ImageIO.read(GrandExchangePlugin.class.getResourceAsStream("search.png")));
+			BufferedImage icon;
+			synchronized (ImageIO.class)
+			{
+				icon = ImageIO.read(GrandExchangePlugin.class.getResourceAsStream("search.png"));
+			}
+			search = new ImageIcon(icon);
 		}
 		catch (IOException e)
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/hiscore/HiscorePanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/hiscore/HiscorePanel.java
@@ -35,6 +35,7 @@ import java.awt.GridBagLayout;
 import java.awt.GridLayout;
 import java.awt.Insets;
 import java.awt.event.MouseEvent;
+import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.text.NumberFormat;
 import java.util.ArrayList;
@@ -118,10 +119,15 @@ public class HiscorePanel extends PluginPanel
 		inputPanel.setLayout(new BorderLayout(7, 7));
 		inputPanel.setBorder(subPanelBorder);
 
-		Icon search = null;
+		Icon search;
 		try
 		{
-			search = new ImageIcon(ImageIO.read(HiscorePanel.class.getResourceAsStream("search.png")));
+			BufferedImage icon;
+			synchronized (ImageIO.class)
+			{
+				icon = ImageIO.read(HiscorePanel.class.getResourceAsStream("search.png"));
+			}
+			search = new ImageIcon(icon);
 		}
 		catch (IOException ex)
 		{
@@ -217,13 +223,18 @@ public class HiscorePanel extends PluginPanel
 		{
 			try
 			{
-				Icon icon = new ImageIcon(ImageIO.read(HiscorePanel.class.getResourceAsStream(
-					endpoint.name().toLowerCase() + ".png")));
-				Icon selected = new ImageIcon(ImageIO.read(HiscorePanel.class.getResourceAsStream(
-					endpoint.name().toLowerCase() + "_selected.png")));
+				BufferedImage iconImage;
+				BufferedImage selectedImage;
+				synchronized (ImageIO.class)
+				{
+					iconImage = ImageIO.read(HiscorePanel.class.getResourceAsStream(
+						endpoint.name().toLowerCase() + ".png"));
+					selectedImage = ImageIO.read(HiscorePanel.class.getResourceAsStream(
+						endpoint.name().toLowerCase() + "_selected.png"));
+				}
 				JToggleButton button = new JToggleButton();
-				button.setIcon(icon);
-				button.setSelectedIcon(selected);
+				button.setIcon(new ImageIcon(iconImage));
+				button.setSelectedIcon(new ImageIcon(selectedImage));
 				button.setPreferredSize(new Dimension(24, 24));
 				button.setBackground(Color.WHITE);
 				button.setFocusPainted(false);
@@ -344,7 +355,12 @@ public class HiscorePanel extends PluginPanel
 
 		try
 		{
-			label.setIcon(new ImageIcon(ImageIO.read(HiscorePanel.class.getResourceAsStream(skillIcon))));
+			BufferedImage icon;
+			synchronized (ImageIO.class)
+			{
+				icon = ImageIO.read(HiscorePanel.class.getResourceAsStream(skillIcon));
+			}
+			label.setIcon(new ImageIcon(icon));
 		}
 		catch (IOException ex)
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/hiscore/HiscorePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/hiscore/HiscorePlugin.java
@@ -26,6 +26,7 @@ package net.runelite.client.plugins.hiscore;
 
 import com.google.common.eventbus.Subscribe;
 import com.google.inject.Provides;
+import java.awt.image.BufferedImage;
 import java.lang.reflect.InvocationTargetException;
 import java.util.concurrent.ScheduledExecutorService;
 import javax.imageio.ImageIO;
@@ -73,9 +74,16 @@ public class HiscorePlugin extends Plugin
 	protected void startUp() throws Exception
 	{
 		hiscorePanel = injector.getInstance(HiscorePanel.class);
+
+		BufferedImage icon;
+		synchronized (ImageIO.class)
+		{
+			icon = ImageIO.read(getClass().getResourceAsStream("hiscore.gif"));
+		}
+
 		navButton = new NavigationButton(
 			"Hiscore",
-			ImageIO.read(getClass().getResourceAsStream("hiscore.gif")),
+			icon,
 			() -> hiscorePanel);
 
 		ui.getPluginToolbar().addNavigation(navButton);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/info/InfoPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/info/InfoPlugin.java
@@ -24,6 +24,7 @@
  */
 package net.runelite.client.plugins.info;
 
+import java.awt.image.BufferedImage;
 import javax.imageio.ImageIO;
 import javax.inject.Inject;
 import net.runelite.client.plugins.Plugin;
@@ -48,9 +49,15 @@ public class InfoPlugin extends Plugin
 		final InfoPanel panel = injector.getInstance(InfoPanel.class);
 		panel.init();
 
+		BufferedImage icon;
+		synchronized (ImageIO.class)
+		{
+			icon = ImageIO.read(getClass().getResourceAsStream("info_icon.png"));
+		}
+
 		navButton = new NavigationButton(
 			"Info",
-			ImageIO.read(getClass().getResourceAsStream("info_icon.png")),
+			icon,
 			() -> panel
 		);
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/kourendlibrary/Book.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/kourendlibrary/Book.java
@@ -137,7 +137,10 @@ public enum Book
 	{
 		try
 		{
-			return ImageIO.read(Book.class.getResourceAsStream("items/" + name + ".png"));
+			synchronized (ImageIO.class)
+			{
+				return ImageIO.read(Book.class.getResourceAsStream("items/" + name + ".png"));
+			}
 		}
 		catch (IOException | IllegalArgumentException e)
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/kourendlibrary/KourendLibraryPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/kourendlibrary/KourendLibraryPlugin.java
@@ -25,6 +25,7 @@
 package net.runelite.client.plugins.kourendlibrary;
 
 import com.google.common.eventbus.Subscribe;
+import java.awt.image.BufferedImage;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.imageio.ImageIO;
@@ -81,9 +82,15 @@ public class KourendLibraryPlugin extends Plugin
 		panel = injector.getInstance(KourendLibraryPanel.class);
 		panel.init();
 
+		BufferedImage icon;
+		synchronized (ImageIO.class)
+		{
+			icon = ImageIO.read(Book.class.getResourceAsStream("panel_icon.png"));
+		}
+
 		navButton = new NavigationButton(
 			"Kourend Library",
-			ImageIO.read(Book.class.getResourceAsStream("panel_icon.png")),
+			icon,
 			() -> panel
 		);
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/notes/NotesPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/notes/NotesPlugin.java
@@ -24,6 +24,7 @@
  */
 package net.runelite.client.plugins.notes;
 
+import java.awt.image.BufferedImage;
 import javax.imageio.ImageIO;
 import javax.inject.Inject;
 
@@ -65,9 +66,15 @@ public class NotesPlugin extends Plugin
 		panel = injector.getInstance(NotesPanel.class);
 		panel.init(config);
 
+		BufferedImage icon;
+		synchronized (ImageIO.class)
+		{
+			icon = ImageIO.read(getClass().getResourceAsStream("notes_icon.png"));
+		}
+
 		navButton = new NavigationButton(
 			"Notes",
-			ImageIO.read(getClass().getResourceAsStream("notes_icon.png")),
+			icon,
 			() -> panel
 		);
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/poh/PohIcons.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/poh/PohIcons.java
@@ -26,7 +26,6 @@ package net.runelite.client.plugins.poh;
 
 import java.awt.image.BufferedImage;
 import java.io.IOException;
-import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
 import javax.imageio.ImageIO;
@@ -101,10 +100,12 @@ public enum PohIcons
 			return image;
 		}
 
-		InputStream in = PohIcons.class.getResourceAsStream(getImageResource() + ".png");
 		try
 		{
-			image = ImageIO.read(in);
+			synchronized (ImageIO.class)
+			{
+				image = ImageIO.read(PohIcons.class.getResourceAsStream(getImageResource() + ".png"));
+			}
 		}
 		catch (IOException ex)
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/puzzlesolver/PuzzleSolverOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/puzzlesolver/PuzzleSolverOverlay.java
@@ -36,7 +36,6 @@ import java.awt.geom.AffineTransform;
 import java.awt.image.AffineTransformOp;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
-import java.io.InputStream;
 import java.util.Arrays;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
@@ -432,8 +431,10 @@ public class PuzzleSolverOverlay extends Overlay
 		{
 			try
 			{
-				InputStream in = PuzzleSolverOverlay.class.getResourceAsStream("arrow.png");
-				downArrow = ImageIO.read(in);
+				synchronized (ImageIO.class)
+				{
+					downArrow = ImageIO.read(PuzzleSolverOverlay.class.getResourceAsStream("arrow.png"));
+				}
 			}
 			catch (IOException e)
 			{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsPlugin.java
@@ -30,7 +30,6 @@ import com.google.inject.Provides;
 import java.awt.Color;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
-import java.io.InputStream;
 import java.text.DecimalFormat;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -601,12 +600,12 @@ public class RaidsPlugin extends Plugin
 		{
 			return raidsIcon;
 		}
-
-		InputStream in = RaidsPlugin.class.getResourceAsStream("raids_icon.png");
-
 		try
 		{
-			raidsIcon = ImageIO.read(in);
+			synchronized (ImageIO.class)
+			{
+				raidsIcon = ImageIO.read(RaidsPlugin.class.getResourceAsStream("raids_icon.png"));
+			}
 		}
 		catch (IOException ex)
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
@@ -151,8 +151,13 @@ public class ScreenshotPlugin extends Plugin
 	{
 		try
 		{
-			BufferedImage iconImage = ImageIO.read(ScreenshotPlugin.class.getResourceAsStream("screenshot.png"));
-			BufferedImage invertedIconImage = ImageIO.read(ScreenshotPlugin.class.getResourceAsStream("screenshot_inverted.png"));
+			BufferedImage iconImage;
+			BufferedImage invertedIconImage;
+			synchronized (ImageIO.class)
+			{
+				iconImage = ImageIO.read(ScreenshotPlugin.class.getResourceAsStream("screenshot.png"));
+				invertedIconImage = ImageIO.read(ScreenshotPlugin.class.getResourceAsStream("screenshot_inverted.png"));
+			}
 
 			SwingUtilities.invokeLater(() ->
 			{
@@ -391,7 +396,11 @@ public class ScreenshotPlugin extends Plugin
 			{
 				try (InputStream reportButton = ScreenshotPlugin.class.getResourceAsStream("report_button.png"))
 				{
-					BufferedImage reportButtonImage = ImageIO.read(reportButton);
+					BufferedImage reportButtonImage;
+					synchronized (ImageIO.class)
+					{
+						reportButtonImage = ImageIO.read(reportButton);
+					}
 
 					int x = gameOffsetX + 403;
 					int y = gameOffsetY + image.getHeight() - reportButtonImage.getHeight() - 1;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/specorb/SpecOrbOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/specorb/SpecOrbOverlay.java
@@ -76,7 +76,11 @@ public class SpecOrbOverlay extends Overlay
 		this.client = client;
 		try
 		{
-			BufferedImage icon = ImageIO.read(getClass().getResourceAsStream("special_orb_icon.png"));
+			BufferedImage icon;
+			synchronized (ImageIO.class)
+			{
+				icon = ImageIO.read(getClass().getResourceAsStream("special_orb_icon.png"));
+			}
 			orb = new MinimapOrb(SPECIAL_ORB_BACKGROUND_COLOR, SPECIAL_ORB_BACKGROUND_COLOR, icon);
 		}
 		catch (IOException e)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timers/GameTimer.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timers/GameTimer.java
@@ -27,7 +27,6 @@ package net.runelite.client.plugins.timers;
 
 import java.awt.image.BufferedImage;
 import java.io.IOException;
-import java.io.InputStream;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import javax.imageio.ImageIO;
@@ -99,10 +98,12 @@ public enum GameTimer
 			return image;
 		}
 
-		InputStream in = GameTimer.class.getResourceAsStream(imageResource + ".png");
 		try
 		{
-			image = ImageIO.read(in);
+			synchronized (ImageIO.class)
+			{
+				image = ImageIO.read(GameTimer.class.getResourceAsStream(imageResource + ".png"));
+			}
 		}
 		catch (IOException ex)
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerPlugin.java
@@ -26,6 +26,7 @@ package net.runelite.client.plugins.xptracker;
 
 import com.google.common.eventbus.Subscribe;
 import com.google.inject.Binder;
+import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.util.EnumSet;
 import java.util.HashMap;
@@ -103,10 +104,16 @@ public class XpTrackerPlugin extends Plugin
 			log.warn("Error looking up worlds list", e);
 		}
 
+		BufferedImage icon;
+		synchronized (ImageIO.class)
+		{
+			icon = ImageIO.read(getClass().getResourceAsStream("xp.png"));
+		}
+
 		xpPanel = new XpPanel(this, client, skillIconManager);
 		navButton = new NavigationButton(
 			"XP Tracker",
-			ImageIO.read(getClass().getResourceAsStream("xp.png")),
+			icon,
 			() -> xpPanel);
 
 		ui.getPluginToolbar().addNavigation(navButton);

--- a/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
@@ -96,7 +96,10 @@ public class ClientUI extends JFrame
 
 		try
 		{
-			icon = ImageIO.read(ClientUI.class.getResourceAsStream("/runelite.png"));
+			synchronized (ImageIO.class)
+			{
+				icon = ImageIO.read(ClientUI.class.getResourceAsStream("/runelite.png"));
+			}
 		}
 		catch (IOException e)
 		{

--- a/runelite-client/src/main/java/net/runelite/client/ui/TitleToolbar.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/TitleToolbar.java
@@ -128,8 +128,13 @@ public class TitleToolbar extends JPanel
 
 		try
 		{
-			BufferedImage discordIcon = ImageIO.read(ClientUI.class.getResourceAsStream("discord.png"));
-			BufferedImage invertedIcon = ImageIO.read(ClientUI.class.getResourceAsStream("discord_inverted.png"));
+			BufferedImage discordIcon;
+			BufferedImage invertedIcon;
+			synchronized (ImageIO.class)
+			{
+				discordIcon = ImageIO.read(ClientUI.class.getResourceAsStream("discord.png"));
+				invertedIcon = ImageIO.read(ClientUI.class.getResourceAsStream("discord_inverted.png"));
+			}
 
 			JButton discordButton = new JButton();
 			discordButton.setToolTipText("Join Discord");

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/components/MinimapOrb.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/components/MinimapOrb.java
@@ -58,7 +58,10 @@ public class MinimapOrb implements RenderableEntity
 	{
 		try
 		{
-			FRAME = ImageIO.read(MinimapOrb.class.getResourceAsStream("minimap_orb_background.png"));
+			synchronized (ImageIO.class)
+			{
+				FRAME = ImageIO.read(MinimapOrb.class.getResourceAsStream("minimap_orb_background.png"));
+			}
 		}
 		catch (IOException e)
 		{


### PR DESCRIPTION
ImageIO.read(...) is not really thread-safe, as calling it on several threads at the same time can cause NullPointerExceptions and ConcurrentModificationExceptions, as reported in https://bugs.openjdk.java.net/browse/JDK-8058973 and https://bugs.openjdk.java.net/browse/JDK-6986863.

This commit changes all usages of this method to synchronize on ImageIO.class, so the method is never run asynchronously.

This fixes the feed plugin throwing these exceptions at times.