### PR TITLE
Set correct offsets to overlays, smaller panels

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingOverlay.java
@@ -81,12 +81,12 @@ class FishingOverlay extends Overlay
 		if (client.getLocalPlayer().getInteracting() != null && client.getLocalPlayer().getInteracting().getName()
 			.contains(FISHING_SPOT))
 		{
-			panelComponent.setTitle("You are fishing");
+			panelComponent.setTitle("Fishing");
 			panelComponent.setTitleColor(Color.GREEN);
 		}
 		else
 		{
-			panelComponent.setTitle("You are NOT fishing");
+			panelComponent.setTitle("NOT fishing");
 			panelComponent.setTitleColor(Color.RED);
 		}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/instancemap/InstanceMapInputListener.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/instancemap/InstanceMapInputListener.java
@@ -29,10 +29,10 @@ import java.awt.event.KeyEvent;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseWheelEvent;
 import javax.inject.Inject;
+import net.runelite.api.Point;
 import net.runelite.client.input.KeyListener;
 import net.runelite.client.input.MouseListener;
 import net.runelite.client.input.MouseWheelListener;
-import static net.runelite.client.plugins.instancemap.InstanceMapOverlay.OVERLAY_POSITION;
 
 public class InstanceMapInputListener extends MouseListener implements KeyListener, MouseWheelListener
 {
@@ -116,11 +116,14 @@ public class InstanceMapInputListener extends MouseListener implements KeyListen
 	private boolean isWithinOverlay(int x, int y)
 	{
 		Dimension dimm = plugin.getOverlaySize();
+
 		if (dimm == null)
 		{
 			return false;
 		}
-		return (x >= OVERLAY_POSITION.getX() && x <= OVERLAY_POSITION.getX() + dimm.width &&
-			y >= OVERLAY_POSITION.getY() && y <= OVERLAY_POSITION.getY() + dimm.height);
+
+		final Point offset =  plugin.getMapOffset();
+		return (x >= offset.getX() && x <= offset.getX() + dimm.width &&
+				y >= offset.getY() && y <= offset.getY() + dimm.height);
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/instancemap/InstanceMapOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/instancemap/InstanceMapOverlay.java
@@ -27,6 +27,7 @@ package net.runelite.client.plugins.instancemap;
 import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Graphics2D;
+import java.awt.Rectangle;
 import java.awt.image.BufferedImage;
 import javax.inject.Inject;
 import net.runelite.api.Client;
@@ -68,6 +69,7 @@ import static net.runelite.client.plugins.instancemap.WallOffset.TOP_RIGHT;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.components.BackgroundComponent;
 
 class InstanceMapOverlay extends Overlay
 {
@@ -109,6 +111,7 @@ class InstanceMapOverlay extends Overlay
 	 */
 	private volatile BufferedImage mapImage;
 	private volatile boolean showMap = false;
+	private final BackgroundComponent backgroundComponent = new BackgroundComponent();
 
 	@Inject
 	InstanceMapOverlay(Client client, InstanceMapPlugin plugin)
@@ -297,10 +300,9 @@ class InstanceMapOverlay extends Overlay
 
 		Dimension mapOverlaySize = new Dimension(tiles.length * TILE_SIZE, tiles[0].length * TILE_SIZE);
 
-		graphics.setColor(Color.black);
-		graphics.fillRect(0, 0, mapOverlaySize.width, mapOverlaySize.height);//draw background
-		graphics.setColor(Color.white);
-		graphics.drawRect(0, 0, mapOverlaySize.width - 1, mapOverlaySize.height - 1);//draw outline
+		backgroundComponent.setFill(false);
+		backgroundComponent.setRectangle(new Rectangle(0, 0, mapOverlaySize.width, mapOverlaySize.height));
+		backgroundComponent.render(graphics, new java.awt.Point());
 
 		//These loops are seperated on purpose to prevent layering issues. This is how it's written in the client
 		//Draw the base colors first

--- a/runelite-client/src/main/java/net/runelite/client/plugins/instancemap/InstanceMapOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/instancemap/InstanceMapOverlay.java
@@ -71,8 +71,6 @@ import net.runelite.client.ui.overlay.OverlayPosition;
 
 class InstanceMapOverlay extends Overlay
 {
-	public static final Point OVERLAY_POSITION = new Point(10, 25);
-
 	/**
 	 * The size of tiles on the map. The way the client renders requires
 	 * this value to be 4. Changing this will break the method for rendering
@@ -93,6 +91,7 @@ class InstanceMapOverlay extends Overlay
 
 	private static final int MAX_PLANE = 3;
 	private static final int MIN_PLANE = 0;
+	private final InstanceMapPlugin plugin;
 
 	/**
 	 * The plane to render on the instance map. When the map is opened this
@@ -112,11 +111,12 @@ class InstanceMapOverlay extends Overlay
 	private volatile boolean showMap = false;
 
 	@Inject
-	InstanceMapOverlay(Client client)
+	InstanceMapOverlay(Client client, InstanceMapPlugin plugin)
 	{
+		this.plugin = plugin;
+		this.client = client;
 		setPosition(OverlayPosition.DYNAMIC);
 		setLayer(OverlayLayer.ALWAYS_ON_TOP);
-		this.client = client;
 	}
 
 	public Dimension getInstanceMapDimension()
@@ -204,11 +204,13 @@ class InstanceMapOverlay extends Overlay
 			}
 		}
 
-		graphics.drawImage(image, OVERLAY_POSITION.getX(), OVERLAY_POSITION.getY(), null);
+		final Point offset = plugin.getMapOffset();
+
+		graphics.drawImage(image, offset.getX(), offset.getY(), null);
 
 		if (client.getPlane() == viewedPlane)//If we are not viewing the plane we are on, don't show player's position
 		{
-			drawPlayerDot(graphics, client.getLocalPlayer(), Color.white, Color.black);
+			drawPlayerDot(graphics, offset.getX(), offset.getY(), client.getLocalPlayer(), Color.white, Color.black);
 		}
 
 		return getInstanceMapDimension();
@@ -219,7 +221,8 @@ class InstanceMapOverlay extends Overlay
 	 *
 	 * @param graphics graphics to be drawn to
 	 */
-	private void drawPlayerDot(Graphics2D graphics, Player player, Color dotColor, Color outlineColor)
+	private void drawPlayerDot(Graphics2D graphics, int baseX, int baseY, Player player,
+		Color dotColor, Color outlineColor)
 	{
 		LocalPoint playerLoc = player.getLocalLocation();
 
@@ -227,8 +230,8 @@ class InstanceMapOverlay extends Overlay
 		int tileX = playerLoc.getRegionX();
 		int tileY = (tiles[0].length - 1) - playerLoc.getRegionY(); // flip the y value
 
-		int x = OVERLAY_POSITION.getX() + (int) (tileX * TILE_SIZE * MAP_SCALING);
-		int y = OVERLAY_POSITION.getY() + (int) (tileY * TILE_SIZE * MAP_SCALING);
+		int x = baseX + (int) (tileX * TILE_SIZE * MAP_SCALING);
+		int y = baseY + (int) (tileY * TILE_SIZE * MAP_SCALING);
 		graphics.setColor(dotColor);
 		graphics.fillRect(x, y, PLAYER_MARKER_SIZE, PLAYER_MARKER_SIZE);//draw the players point on the map
 		graphics.setColor(outlineColor);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/instancemap/InstanceMapPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/instancemap/InstanceMapPlugin.java
@@ -29,6 +29,7 @@ import com.google.inject.Binder;
 import java.awt.Dimension;
 import javax.inject.Inject;
 import net.runelite.api.Client;
+import net.runelite.api.Point;
 import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.MapRegionChanged;
 import net.runelite.api.events.WidgetMenuOptionClicked;
@@ -47,6 +48,10 @@ import net.runelite.client.ui.overlay.Overlay;
 )
 public class InstanceMapPlugin extends Plugin
 {
+	private static final int OVERLAY_POSITION_X = 5;
+	private static final int OVERLAY_POSITION_Y = 20;
+	private static final int FRAME_OFFSET = 4;
+
 	private final WidgetMenuOption openMapOption = new WidgetMenuOption("Show", "Instance Map", WidgetInfo.WORLD_MAP);
 
 	@Inject
@@ -148,6 +153,13 @@ public class InstanceMapPlugin extends Plugin
 	public boolean isMapShown()
 	{
 		return overlay.isMapShown();
+	}
+
+	public Point getMapOffset()
+	{
+		return new Point(
+			OVERLAY_POSITION_X + (client.isResized() ? 0 : FRAME_OFFSET),
+			OVERLAY_POSITION_Y + (client.isResized() ? 0 : FRAME_OFFSET));
 	}
 
 	public void showMap()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/opponentinfo/OpponentInfoOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/opponentinfo/OpponentInfoOverlay.java
@@ -49,12 +49,12 @@ import net.runelite.client.util.Text;
 
 class OpponentInfoOverlay extends Overlay
 {
-	private static final int WIDTH = 140;
+	private static final int WIDTH = 129;
 
-	private static final int TOP_BORDER = 3;
-	private static final int BOTTOM_BORDER = 3;
+	private static final int TOP_BORDER = 4;
+	private static final int BOTTOM_BORDER = 4;
 
-	private static final int BAR_WIDTH = 124;
+	private static final int BAR_WIDTH = WIDTH - 10;
 	private static final int BAR_HEIGHT = 16;
 
 	private static final Color HP_GREEN = new Color(0, 146, 54, 230);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingOverlay.java
@@ -95,12 +95,12 @@ class WoodcuttingOverlay extends Overlay
 
 		if (IntStream.of(animationIds).anyMatch(x -> x == client.getLocalPlayer().getAnimation()))
 		{
-			panelComponent.setTitle("You are woodcutting");
+			panelComponent.setTitle("Woodcutting");
 			panelComponent.setTitleColor(Color.GREEN);
 		}
 		else
 		{
-			panelComponent.setTitle("You are NOT woodcutting");
+			panelComponent.setTitle("NOT woodcutting");
 			panelComponent.setTitleColor(Color.RED);
 		}
 

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayRenderer.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayRenderer.java
@@ -58,8 +58,11 @@ import net.runelite.client.ui.overlay.tooltip.TooltipOverlay;
 @Slf4j
 public class OverlayRenderer
 {
-	private static final int BORDER_TOP = 25;
-	private static final int BORDER_LEFT = 5;
+	private static final int BORDER_LEFT_RESIZABLE = 5;
+	private static final int BORDER_TOP_RESIZABLE = 20;
+	private static final int FRAME_OFFSET = 4;
+	private static final int BORDER_LEFT_FIXED = BORDER_LEFT_RESIZABLE + FRAME_OFFSET;
+	private static final int BORDER_TOP_FIXED = BORDER_TOP_RESIZABLE + FRAME_OFFSET;
 	private static final int BORDER_RIGHT = 2;
 	private static final int BORDER_BOTTOM = 2;
 	private static final int PADDING = 2;
@@ -192,6 +195,7 @@ public class OverlayRenderer
 			return;
 		}
 
+		final boolean isResizeable = client.isResized();
 		final Widget viewport = client.getViewportWidget();
 		final Rectangle bounds = viewport != null
 			? new Rectangle(viewport.getBounds())
@@ -203,18 +207,20 @@ public class OverlayRenderer
 
 		OverlayUtil.setGraphicProperties(graphics);
 		final Point topLeftPoint = new Point();
-		topLeftPoint.move(BORDER_LEFT, BORDER_TOP);
+		topLeftPoint.move(
+			isResizeable ? BORDER_LEFT_RESIZABLE : BORDER_LEFT_FIXED,
+			isResizeable ? BORDER_TOP_RESIZABLE : BORDER_TOP_FIXED);
 		final Point topRightPoint = new Point();
-		topRightPoint.move(bounds.x + bounds.width - BORDER_RIGHT, BORDER_TOP);
+		topRightPoint.move(bounds.x + bounds.width - BORDER_RIGHT, BORDER_TOP_FIXED);
 		final Point bottomLeftPoint = new Point();
-		bottomLeftPoint.move(BORDER_LEFT, bounds.y + bounds.height - BORDER_BOTTOM);
+		bottomLeftPoint.move(isResizeable ? BORDER_LEFT_RESIZABLE : BORDER_LEFT_FIXED, bounds.y + bounds.height - BORDER_BOTTOM);
 		final Point bottomRightPoint = new Point();
 		bottomRightPoint.move(bounds.x + bounds.width - BORDER_RIGHT, bounds.y + bounds.height - BORDER_BOTTOM);
 		final Point rightChatboxPoint = new Point();
 		rightChatboxPoint.move(bounds.x + chatboxBounds.width - BORDER_RIGHT, bounds.y + bounds.height - BORDER_BOTTOM);
 
 		//check to see if Chatbox is minimized
-		if (chatbox != null && client.isResized() && chatbox.isHidden())
+		if (chatbox != null && isResizeable && chatbox.isHidden())
 		{
 			rightChatboxPoint.y += chatboxBounds.height;
 			bottomLeftPoint.y += chatboxBounds.height;

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/components/BackgroundComponent.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/components/BackgroundComponent.java
@@ -58,6 +58,9 @@ public class BackgroundComponent implements RenderableEntity
 	@Setter
 	private Rectangle rectangle = new Rectangle();
 
+	@Setter
+	private boolean fill = true;
+
 	@Override
 	public Dimension render(Graphics2D graphics, Point parent)
 	{
@@ -76,8 +79,11 @@ public class BackgroundComponent implements RenderableEntity
 		);
 
 		// Render background
-		graphics.setColor(backgroundColor);
-		graphics.fill(rectangle);
+		if (fill)
+		{
+			graphics.setColor(backgroundColor);
+			graphics.fill(rectangle);
+		}
 
 		// Render outside stroke
 		final Rectangle outsideStroke = new Rectangle();

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/components/ImagePanelComponent.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/components/ImagePanelComponent.java
@@ -41,10 +41,10 @@ import net.runelite.client.ui.overlay.RenderableEntity;
 
 public class ImagePanelComponent implements RenderableEntity
 {
-	private static final int TOP_BORDER = 3;
-	private static final int SIDE_BORDER = 6;
-	private static final int BOTTOM_BORDER = 6;
-	private static final int SEPARATOR = 4;
+	private static final int TOP_BORDER = 4;
+	private static final int SIDE_BORDER = 4;
+	private static final int BOTTOM_BORDER = 4;
+	private static final int SEPARATOR = 1;
 
 	@Setter
 	@Nullable

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/components/PanelComponent.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/components/PanelComponent.java
@@ -43,11 +43,11 @@ import net.runelite.client.ui.overlay.RenderableEntity;
 
 public class PanelComponent implements RenderableEntity
 {
-	private static final int TOP_BORDER = 3;
-	private static final int LEFT_BORDER = 6;
-	private static final int RIGHT_BORDER = 6;
-	private static final int BOTTOM_BORDER = 6;
-	private static final int SEPARATOR = 2;
+	private static final int TOP_BORDER = 4;
+	private static final int LEFT_BORDER = 4;
+	private static final int RIGHT_BORDER = 4;
+	private static final int BOTTOM_BORDER = 4;
+	private static final int SEPARATOR = 1;
 
 	@Data
 	@AllArgsConstructor

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/components/PanelComponent.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/components/PanelComponent.java
@@ -79,7 +79,7 @@ public class PanelComponent implements RenderableEntity
 	private ProgressBarComponent progressBar;
 
 	@Setter
-	private int width = 140;
+	private int width = 129;
 
 	@Override
 	public Dimension render(Graphics2D graphics, Point parent)


### PR DESCRIPTION
- Set correct offsets for overlays based on resizable or fixed mode
- Change PanelComponent inside padding to be slighly smaller
- Set correct offset to instance map
- Change instance map to use BackgroundComponent border

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>

Before:
![before-instance](https://user-images.githubusercontent.com/5115805/37462663-0a498922-2853-11e8-9bb4-59b2a05e4ed8.png)

![before-panels](https://user-images.githubusercontent.com/5115805/37462662-09f7a8fa-2853-11e8-95e2-d62741f5cbba.png)

After:
![after-instance](https://user-images.githubusercontent.com/5115805/37242277-e6548868-2466-11e8-807e-81633d15eb11.png)

![after-panels](https://user-images.githubusercontent.com/5115805/37149552-b77fa11a-22ce-11e8-8725-6469a473e595.png)
