### PR TITLE
Remove unneeded drawRegionTile calls

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/tileindicators/TileIndicatorsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/tileindicators/TileIndicatorsOverlay.java
@@ -54,8 +54,8 @@ public class TileIndicatorsOverlay extends Overlay
 	@Override
 	public Dimension render(Graphics2D graphics, java.awt.Point parent)
 	{
-		if (client.getSceneDestinationLocation().getX() >= 0
-			&& client.getSceneDestinationLocation().getY() >= 0)
+		if (client.getSceneDestinationLocation().getX() > 0
+			&& client.getSceneDestinationLocation().getY() > 0)
 		{
 			drawRegionTile(graphics, client.getSceneDestinationLocation(), config.highlightDestinationColor());
 		}


### PR DESCRIPTION
Stops the tile indicator plugin from always calculating the tile indicator even though it is not going to be drawn.