### PR TITLE
Type safe coordinates

### DIFF
--- a/runelite-api/pom.xml
+++ b/runelite-api/pom.xml
@@ -47,6 +47,11 @@
 			<artifactId>lombok</artifactId>
 			<scope>provided</scope>
 		</dependency>
+		<dependency>
+			<groupId>com.google.code.findbugs</groupId>
+			<artifactId>jsr305</artifactId>
+			<version>1.3.9</version>
+		</dependency>
 
 		<dependency>
 			<groupId>junit</groupId>

--- a/runelite-api/src/main/java/net/runelite/api/Actor.java
+++ b/runelite-api/src/main/java/net/runelite/api/Actor.java
@@ -27,6 +27,8 @@ package net.runelite.api;
 import java.awt.Graphics2D;
 import java.awt.Polygon;
 import java.awt.image.BufferedImage;
+import net.runelite.api.coords.LocalPoint;
+import net.runelite.api.coords.WorldPoint;
 
 public interface Actor extends Renderable
 {
@@ -40,9 +42,9 @@ public interface Actor extends Renderable
 
 	int getHealth();
 
-	Point getWorldLocation();
+	WorldPoint getWorldLocation();
 
-	Point getLocalLocation();
+	LocalPoint getLocalLocation();
 
 	int getOrientation();
 
@@ -61,8 +63,6 @@ public interface Actor extends Renderable
 	Point getCanvasSpriteLocation(Graphics2D graphics, SpritePixels sprite, int zOffset);
 
 	Point getMinimapLocation();
-
-	Point getRegionLocation();
 
 	/**
 	 * Returns the logical height of the actor's model. This is roughly where the health bar is drawn.

--- a/runelite-api/src/main/java/net/runelite/api/Client.java
+++ b/runelite-api/src/main/java/net/runelite/api/Client.java
@@ -28,6 +28,8 @@ import java.awt.Canvas;
 import java.awt.Dimension;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
+import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetInfo;
 
@@ -184,7 +186,8 @@ public interface Client extends GameEngine
 
 	SpritePixels createSpritePixels(int[] pixels, int width, int height);
 
-	Point getSceneDestinationLocation();
+	@Nullable
+	LocalPoint getLocalDestinationLocation();
 
 	List<Projectile> getProjectiles();
 

--- a/runelite-api/src/main/java/net/runelite/api/Perspective.java
+++ b/runelite-api/src/main/java/net/runelite/api/Perspective.java
@@ -34,6 +34,7 @@ import java.awt.image.BufferedImage;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
+import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.model.Jarvis;
 import net.runelite.api.model.Triangle;
 import net.runelite.api.model.Vertex;
@@ -218,7 +219,7 @@ public class Perspective
 	{
 		int angle = client.getMapAngle() & 0x7FF;
 
-		Point localLocation = client.getLocalPlayer().getLocalLocation();
+		LocalPoint localLocation = client.getLocalPlayer().getLocalLocation();
 		x = x / 32 - localLocation.getX() / 32;
 		y = y / 32 - localLocation.getY() / 32;
 
@@ -328,7 +329,7 @@ public class Perspective
 	 * @return a {@link Polygon} on screen corresponding to the given
 	 * localLocation.
 	 */
-	public static Polygon getCanvasTilePoly(Client client, Point localLocation)
+	public static Polygon getCanvasTilePoly(Client client, LocalPoint localLocation)
 	{
 		return getCanvasTileAreaPoly(client, localLocation, 1);
 	}
@@ -342,7 +343,7 @@ public class Perspective
 	 * size = 3
 	 * @return a polygon representing the tiles in the area
 	 */
-	public static Polygon getCanvasTileAreaPoly(Client client, Point localLocation, int size)
+	public static Polygon getCanvasTileAreaPoly(Client client, LocalPoint localLocation, int size)
 	{
 		int plane = client.getPlane();
 		int halfTile = LOCAL_TILE_SIZE / 2;
@@ -391,7 +392,7 @@ public class Perspective
 	 * @return a {@link Point} on screen corresponding to the given
 	 * localLocation.
 	 */
-	public static Point getCanvasTextLocation(Client client, Graphics2D graphics, Point localLocation, String text, int zOffset)
+	public static Point getCanvasTextLocation(Client client, Graphics2D graphics, LocalPoint localLocation, String text, int zOffset)
 	{
 		int plane = client.getPlane();
 
@@ -420,7 +421,7 @@ public class Perspective
 	 * @return a {@link Point} on screen corresponding to the given
 	 * localLocation.
 	 */
-	public static Point getCanvasImageLocation(Client client, Graphics2D graphics, Point localLocation, BufferedImage image, int zOffset)
+	public static Point getCanvasImageLocation(Client client, Graphics2D graphics, LocalPoint localLocation, BufferedImage image, int zOffset)
 	{
 		int plane = client.getPlane();
 
@@ -446,7 +447,7 @@ public class Perspective
 	 * @return a {@link Point} on screen corresponding to the given
 	 * localLocation.
 	 */
-	public static Point getMiniMapImageLocation(Client client, Point localLocation, BufferedImage image)
+	public static Point getMiniMapImageLocation(Client client, LocalPoint localLocation, BufferedImage image)
 	{
 		Point p = Perspective.worldToMiniMap(client, localLocation.getX(), localLocation.getY());
 
@@ -472,7 +473,7 @@ public class Perspective
 	 * @return a {@link Point} on screen corresponding to the given
 	 * localLocation.
 	 */
-	public static Point getCanvasSpriteLocation(Client client, Graphics2D graphics, Point localLocation, SpritePixels sprite, int zOffset)
+	public static Point getCanvasSpriteLocation(Client client, Graphics2D graphics, LocalPoint localLocation, SpritePixels sprite, int zOffset)
 	{
 		int plane = client.getPlane();
 
@@ -718,7 +719,7 @@ public class Perspective
 	 * @return a {@link Point} on screen corresponding to the given
 	 * localLocation.
 	 */
-	public static Point getCanvasTextMiniMapLocation(Client client, Graphics2D graphics, Point localLocation, String text)
+	public static Point getCanvasTextMiniMapLocation(Client client, Graphics2D graphics, LocalPoint localLocation, String text)
 	{
 		Point p = Perspective.worldToMiniMap(client, localLocation.getX(), localLocation.getY());
 

--- a/runelite-api/src/main/java/net/runelite/api/Perspective.java
+++ b/runelite-api/src/main/java/net/runelite/api/Perspective.java
@@ -64,6 +64,7 @@ public class Perspective
 	 * @param point world location
 	 * @return
 	 */
+	@Deprecated
 	public static boolean isWorldInScene(Client client, Point point)
 	{
 		int x = point.getX();
@@ -276,6 +277,7 @@ public class Perspective
 		return 0;
 	}
 
+	@Deprecated
 	public static Point worldToLocal(Client client, Point point)
 	{
 		if (!isWorldInScene(client, point))
@@ -292,6 +294,7 @@ public class Perspective
 		return new Point(x, y);
 	}
 
+	@Deprecated
 	public static Point localToWorld(Client client, Point point)
 	{
 		int x = (point.getX() >>> LOCAL_COORD_BITS) + client.getBaseX();
@@ -299,6 +302,7 @@ public class Perspective
 		return new Point(x, y);
 	}
 
+	@Deprecated
 	public static Point regionToWorld(Client client, Point point)
 	{
 		int baseX = client.getBaseX();
@@ -308,6 +312,7 @@ public class Perspective
 		return new Point(x, y);
 	}
 
+	@Deprecated
 	public static Point regionToLocal(Client client, Point point)
 	{
 		int x = point.getX() << LOCAL_COORD_BITS;

--- a/runelite-api/src/main/java/net/runelite/api/Perspective.java
+++ b/runelite-api/src/main/java/net/runelite/api/Perspective.java
@@ -61,26 +61,6 @@ public class Perspective
 	}
 
 	/**
-	 * Check if a world location is in the scene
-	 * @param point world location
-	 * @return
-	 */
-	@Deprecated
-	public static boolean isWorldInScene(Client client, Point point)
-	{
-		int x = point.getX();
-		int y = point.getY();
-
-		int baseX = client.getBaseX();
-		int baseY = client.getBaseY();
-
-		int maxX = baseX + SCENE_SIZE;
-		int maxY = baseY + SCENE_SIZE;
-
-		return x >= baseX && x < maxX && y >= baseY && y < maxY;
-	}
-
-	/**
 	 * Translates two-dimensional ground coordinates within the 3D world to
 	 * their corresponding coordinates on the game screen.
 	 *
@@ -276,49 +256,6 @@ public class Perspective
 		}
 
 		return 0;
-	}
-
-	@Deprecated
-	public static Point worldToLocal(Client client, Point point)
-	{
-		if (!isWorldInScene(client, point))
-		{
-			return null;
-		}
-
-		int baseX = client.getBaseX();
-		int baseY = client.getBaseY();
-
-		int x = ((point.getX() - baseX) << LOCAL_COORD_BITS) + (1 << LOCAL_COORD_BITS - 1) - 1;
-		int y = ((point.getY() - baseY) << LOCAL_COORD_BITS) + (1 << LOCAL_COORD_BITS - 1) - 1;
-
-		return new Point(x, y);
-	}
-
-	@Deprecated
-	public static Point localToWorld(Client client, Point point)
-	{
-		int x = (point.getX() >>> LOCAL_COORD_BITS) + client.getBaseX();
-		int y = (point.getY() >>> LOCAL_COORD_BITS) + client.getBaseY();
-		return new Point(x, y);
-	}
-
-	@Deprecated
-	public static Point regionToWorld(Client client, Point point)
-	{
-		int baseX = client.getBaseX();
-		int baseY = client.getBaseY();
-		int x = point.getX() + baseX;
-		int y = point.getY() + baseY;
-		return new Point(x, y);
-	}
-
-	@Deprecated
-	public static Point regionToLocal(Client client, Point point)
-	{
-		int x = point.getX() << LOCAL_COORD_BITS;
-		int y = point.getY() << LOCAL_COORD_BITS;
-		return new Point(x, y);
 	}
 
 	/**

--- a/runelite-api/src/main/java/net/runelite/api/Tile.java
+++ b/runelite-api/src/main/java/net/runelite/api/Tile.java
@@ -24,6 +24,9 @@
  */
 package net.runelite.api;
 
+import net.runelite.api.coords.LocalPoint;
+import net.runelite.api.coords.WorldPoint;
+
 public interface Tile
 {
 	/**
@@ -45,11 +48,11 @@ public interface Tile
 
 	SceneTileModel getSceneTileModel();
 
-	Point getWorldLocation();
+	WorldPoint getWorldLocation();
 
 	Point getRegionLocation();
 
-	Point getLocalLocation();
+	LocalPoint getLocalLocation();
 
 	int getPlane();
 }

--- a/runelite-api/src/main/java/net/runelite/api/TileObject.java
+++ b/runelite-api/src/main/java/net/runelite/api/TileObject.java
@@ -27,6 +27,8 @@ package net.runelite.api;
 import java.awt.Graphics2D;
 import java.awt.Polygon;
 import java.awt.geom.Area;
+import net.runelite.api.coords.LocalPoint;
+import net.runelite.api.coords.WorldPoint;
 
 public interface TileObject
 {
@@ -38,11 +40,9 @@ public interface TileObject
 
 	int getId();
 
-	Point getWorldLocation();
+	WorldPoint getWorldLocation();
 
-	Point getLocalLocation();
-
-	Point getRegionLocation();
+	LocalPoint getLocalLocation();
 
 	Point getCanvasLocation();
 

--- a/runelite-api/src/main/java/net/runelite/api/TileObject.java
+++ b/runelite-api/src/main/java/net/runelite/api/TileObject.java
@@ -38,6 +38,8 @@ public interface TileObject
 
 	int getY();
 
+	int getPlane();
+
 	int getId();
 
 	WorldPoint getWorldLocation();

--- a/runelite-api/src/main/java/net/runelite/api/coords/LocalPoint.java
+++ b/runelite-api/src/main/java/net/runelite/api/coords/LocalPoint.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2018 Abex
+ * Copyright (c) 2017, Adam <Adam@sigterm.info>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.api.coords;
+
+import javax.annotation.Nullable;
+import lombok.Value;
+import net.runelite.api.Client;
+import net.runelite.api.Perspective;
+
+/**
+ * A LocolPoint is a Two-Dimensional point in the local coordinate space. Because the local coordinate space moves,
+ * it is not safe to keep a LocalPoint after a loading zone. The unit is 1/128th of a Tile
+ */
+@Value
+public class LocalPoint
+{
+	private final int x, y;
+
+	/**
+	 * Returns a LocalPoint of the center of the passed tile
+	 *
+	 * @return LocalPoint if in scene, otherwise null
+	 */
+	@Nullable
+	public static LocalPoint fromWorld(Client client, WorldPoint world)
+	{
+		if (client.getPlane() != world.getPlane())
+		{
+			return null;
+		}
+		return fromWorld(client, world.getX(), world.getY());
+	}
+
+	/**
+	 * Returns a LocalPoint of the center of the passed tile
+	 *
+	 * @return LocalPoint if in scene, otherwise null
+	 */
+	public static LocalPoint fromWorld(Client client, int x, int y)
+	{
+		if (!WorldPoint.isInScene(client, x, y))
+		{
+			return null;
+		}
+
+		int baseX = client.getBaseX();
+		int baseY = client.getBaseY();
+
+		return fromRegion(x - baseX, y - baseY);
+	}
+
+	/**
+	 * Find the distance from this point to another point
+	 *
+	 * @param other
+	 * @return
+	 */
+	public int distanceTo(LocalPoint other)
+	{
+		return (int) Math.hypot(getX() - other.getX(), getY() - other.getY());
+	}
+
+	/**
+	 * Returns a LocalPoint of the center of the passed tile
+	 */
+	public static LocalPoint fromRegion(int x, int y)
+	{
+		return new LocalPoint(
+			(x << Perspective.LOCAL_COORD_BITS) + (1 << Perspective.LOCAL_COORD_BITS - 1) - 1,
+			(y << Perspective.LOCAL_COORD_BITS) + (1 << Perspective.LOCAL_COORD_BITS - 1) - 1
+		);
+	}
+
+	/**
+	 * Returns the X coordinate in Region space (tiles)
+	 */
+	public int getRegionX()
+	{
+		return x >>> Perspective.LOCAL_COORD_BITS;
+	}
+
+
+	/**
+	 * Returns the Y coordinate in Region space (tiles)
+	 */
+	public int getRegionY()
+	{
+		return y >>> Perspective.LOCAL_COORD_BITS;
+	}
+}

--- a/runelite-api/src/main/java/net/runelite/api/coords/WorldPoint.java
+++ b/runelite-api/src/main/java/net/runelite/api/coords/WorldPoint.java
@@ -22,15 +22,30 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package net.runelite.api;
+package net.runelite.api.coords;
 
 import lombok.Value;
 import net.runelite.api.Point;
 
 @Value
-public class Point3D
+public class WorldPoint
 {
-	private final int X, Y, Z;
+	/**
+	 * The X coordinate of the Point.
+	 * Units are in tiles
+	 */
+	private final int X;
+
+	/**
+	 * The Y coordinate of the Point.
+	 * Units are in tiles
+	 */
+	private final int Y;
+
+	/**
+	 * The plane coordinate of the Point.
+	 */
+	private final int plane;
 
 	public Point toPoint()
 	{

--- a/runelite-api/src/main/java/net/runelite/api/events/ProjectileMoved.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/ProjectileMoved.java
@@ -25,13 +25,13 @@
 package net.runelite.api.events;
 
 import lombok.Data;
-import net.runelite.api.Point;
 import net.runelite.api.Projectile;
+import net.runelite.api.coords.LocalPoint;
 
 @Data
 public class ProjectileMoved
 {
 	private Projectile projectile;
-	private Point position;
-	private int plane;
+	private LocalPoint position;
+	private int z;
 }

--- a/runelite-api/src/main/java/net/runelite/api/queries/ActorQuery.java
+++ b/runelite-api/src/main/java/net/runelite/api/queries/ActorQuery.java
@@ -26,8 +26,8 @@ package net.runelite.api.queries;
 
 import static java.lang.Math.abs;
 import net.runelite.api.Actor;
-import net.runelite.api.Point;
 import net.runelite.api.Query;
+import net.runelite.api.coords.LocalPoint;
 
 public abstract class ActorQuery<EntityType extends Actor, QueryType> extends Query<EntityType, QueryType>
 {
@@ -68,7 +68,7 @@ public abstract class ActorQuery<EntityType extends Actor, QueryType> extends Qu
 	}
 
 	@SuppressWarnings("unchecked")
-	public QueryType atLocalLocation(Point location)
+	public QueryType atLocalLocation(LocalPoint location)
 	{
 		predicate = and(actor -> actor.getLocalLocation().equals(location));
 		return (QueryType) this;
@@ -96,18 +96,18 @@ public abstract class ActorQuery<EntityType extends Actor, QueryType> extends Qu
 	}
 
 	@SuppressWarnings("unchecked")
-	public QueryType isWithinDistance(Point to, int distance)
+	public QueryType isWithinDistance(LocalPoint to, int distance)
 	{
 		predicate = and(a -> a.getLocalLocation().distanceTo(to) <= distance);
 		return (QueryType) this;
 	}
 
 	@SuppressWarnings("unchecked")
-	public QueryType isWithinArea(Point from, int area)
+	public QueryType isWithinArea(LocalPoint from, int area)
 	{
 		predicate = and(a ->
 		{
-			Point localLocation = a.getLocalLocation();
+			LocalPoint localLocation = a.getLocalLocation();
 			return abs(localLocation.getX() - from.getX()) < area
 				&& abs(localLocation.getY() - from.getY()) < area;
 		});

--- a/runelite-api/src/main/java/net/runelite/api/queries/TileObjectQuery.java
+++ b/runelite-api/src/main/java/net/runelite/api/queries/TileObjectQuery.java
@@ -26,7 +26,6 @@ package net.runelite.api.queries;
 
 import static java.lang.Math.abs;
 import net.runelite.api.Client;
-import net.runelite.api.Point;
 import net.runelite.api.Query;
 import net.runelite.api.Region;
 import net.runelite.api.Tile;
@@ -34,6 +33,8 @@ import net.runelite.api.TileObject;
 
 import java.util.ArrayList;
 import java.util.List;
+import net.runelite.api.coords.LocalPoint;
+import net.runelite.api.coords.WorldPoint;
 
 public abstract class TileObjectQuery<EntityType extends TileObject, QueryType> extends Query<EntityType, QueryType>
 {
@@ -78,32 +79,32 @@ public abstract class TileObjectQuery<EntityType extends TileObject, QueryType> 
 	}
 
 	@SuppressWarnings("unchecked")
-	public QueryType atWorldLocation(Point location)
+	public QueryType atWorldLocation(WorldPoint location)
 	{
 		predicate = and(object -> object.getWorldLocation().equals(location));
 		return (QueryType) this;
 	}
 
 	@SuppressWarnings("unchecked")
-	public QueryType atLocalLocation(Point location)
+	public QueryType atLocalLocation(LocalPoint location)
 	{
 		predicate = and(object -> object.getLocalLocation().equals(location));
 		return (QueryType) this;
 	}
 
 	@SuppressWarnings("unchecked")
-	public QueryType isWithinDistance(Point to, int distance)
+	public QueryType isWithinDistance(LocalPoint to, int distance)
 	{
 		predicate = and(a -> a.getLocalLocation().distanceTo(to) <= distance);
 		return (QueryType) this;
 	}
 
 	@SuppressWarnings("unchecked")
-	public QueryType isWithinArea(Point from, int area)
+	public QueryType isWithinArea(LocalPoint from, int area)
 	{
 		predicate = and(a ->
 		{
-			Point localLocation = a.getLocalLocation();
+			LocalPoint localLocation = a.getLocalLocation();
 			return abs(localLocation.getX() - from.getX()) < area
 				&& abs(localLocation.getY() - from.getY()) < area;
 		});

--- a/runelite-client/src/main/java/net/runelite/client/callback/Hooks.java
+++ b/runelite-client/src/main/java/net/runelite/client/callback/Hooks.java
@@ -40,12 +40,12 @@ import net.runelite.api.MainBufferProvider;
 import net.runelite.api.MenuAction;
 import net.runelite.api.MessageNode;
 import net.runelite.api.PacketBuffer;
-import net.runelite.api.Point;
 import net.runelite.api.Projectile;
 import net.runelite.api.Region;
 import net.runelite.api.RenderOverview;
 import net.runelite.api.TextureProvider;
 import net.runelite.api.WorldMapManager;
+import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.events.ChatMessage;
 import net.runelite.api.events.GameTick;
 import net.runelite.api.events.MenuEntryAdded;
@@ -372,11 +372,11 @@ public class Hooks
 	 */
 	public static void projectileMoved(Projectile projectile, int targetX, int targetY, int targetZ, int cycle)
 	{
-		Point position = new Point(targetX, targetY);
+		LocalPoint position = new LocalPoint(targetX, targetY);
 		ProjectileMoved projectileMoved = new ProjectileMoved();
 		projectileMoved.setProjectile(projectile);
 		projectileMoved.setPosition(position);
-		projectileMoved.setPlane(targetZ);
+		projectileMoved.setZ(targetZ);
 		eventBus.post(projectileMoved);
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/agilityplugin/AgilityOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/agilityplugin/AgilityOverlay.java
@@ -32,6 +32,7 @@ import javax.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.Point;
+import net.runelite.api.coords.LocalPoint;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
@@ -56,7 +57,7 @@ public class AgilityOverlay extends Overlay
 	@Override
 	public Dimension render(Graphics2D graphics, java.awt.Point parent)
 	{
-		Point playerLocation = client.getLocalPlayer().getLocalLocation();
+		LocalPoint playerLocation = client.getLocalPlayer().getLocalLocation();
 		Point mousePosition = client.getMouseCanvasPosition();
 		plugin.getObstacles().forEach((object, tile) ->
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/barrows/BarrowsBrothers.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/barrows/BarrowsBrothers.java
@@ -25,25 +25,21 @@
 package net.runelite.client.plugins.barrows;
 
 import lombok.Getter;
-import net.runelite.api.Point;
+import lombok.RequiredArgsConstructor;
+import net.runelite.api.coords.WorldPoint;
 
+@RequiredArgsConstructor
 public enum BarrowsBrothers
 {
-	VERAC("V", new Point(3557, 3298)),
-	DHAROK("D", new Point(3575, 3298)),
-	AHRIM("A", new Point(3566, 3289)),
-	TORAG("T", new Point(3553, 3283)),
-	KARIL("K", new Point(3566, 3275)),
-	GUTHAN("G", new Point(3577, 3283));
+	VERAC("V", new WorldPoint(3557, 3298, 0)),
+	DHAROK("D", new WorldPoint(3575, 3298, 0)),
+	AHRIM("A", new WorldPoint(3566, 3289, 0)),
+	TORAG("T", new WorldPoint(3553, 3283, 0)),
+	KARIL("K", new WorldPoint(3566, 3275, 0)),
+	GUTHAN("G", new WorldPoint(3577, 3283, 0));
 
 	@Getter
 	private final String name;
 	@Getter
-	private final Point location;
-
-	BarrowsBrothers(String name, net.runelite.api.Point location)
-	{
-		this.name = name;
-		this.location = location;
-	}
+	private final WorldPoint location;
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/barrows/BarrowsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/barrows/BarrowsOverlay.java
@@ -37,6 +37,7 @@ import net.runelite.api.ObjectComposition;
 import net.runelite.api.Perspective;
 import net.runelite.api.Player;
 import net.runelite.api.WallObject;
+import net.runelite.api.coords.LocalPoint;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
@@ -94,12 +95,12 @@ class BarrowsOverlay extends Overlay
 		return null;
 	}
 
-	private void renderObjects(Graphics2D graphics, Player local)
+	private void renderObjects(Graphics2D graphics, Player localPlayer)
 	{
-		net.runelite.api.Point localLocation = local.getLocalLocation();
+		LocalPoint localLocation = localPlayer.getLocalLocation();
 		for (WallObject wall : plugin.getWalls())
 		{
-			net.runelite.api.Point location = wall.getLocalLocation();
+			LocalPoint location = wall.getLocalLocation();
 			if (localLocation.distanceTo(location) <= MAX_DISTANCE)
 			{
 				renderWalls(graphics, wall);
@@ -108,7 +109,7 @@ class BarrowsOverlay extends Overlay
 
 		for (GameObject ladder : plugin.getLadders())
 		{
-			net.runelite.api.Point location = ladder.getLocalLocation();
+			LocalPoint location = ladder.getLocalLocation();
 			if (localLocation.distanceTo(location) <= MAX_DISTANCE)
 			{
 				renderLadders(graphics, ladder);
@@ -162,15 +163,15 @@ class BarrowsOverlay extends Overlay
 	{
 		for (BarrowsBrothers brother : BarrowsBrothers.values())
 		{
-			net.runelite.api.Point location = brother.getLocation();
+			LocalPoint localLocation = LocalPoint.fromWorld(client, brother.getLocation());
 
-			if (!Perspective.isWorldInScene(client, location))
+			if (localLocation == null)
 			{
 				continue;
 			}
 
 			net.runelite.api.Point minimapText = Perspective.getCanvasTextMiniMapLocation(client, graphics,
-				Perspective.worldToLocal(client, brother.getLocation()), brother.getName());
+				localLocation, brother.getName());
 
 			if (minimapText != null)
 			{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/blastfurnace/ConveyorBeltOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/blastfurnace/ConveyorBeltOverlay.java
@@ -32,6 +32,7 @@ import javax.inject.Inject;
 import net.runelite.api.Client;
 import net.runelite.api.GameObject;
 import net.runelite.api.Point;
+import net.runelite.api.coords.LocalPoint;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayPosition;
 
@@ -60,12 +61,12 @@ class ConveyorBeltOverlay extends Overlay
 			return null;
 		}
 
-		Point localLocation = client.getLocalPlayer().getLocalLocation();
+		LocalPoint localLocation = client.getLocalPlayer().getLocalLocation();
 		Point mousePosition = client.getMouseCanvasPosition();
 
 		GameObject object = plugin.getConveyorBelt();
 
-		Point location = object.getLocalLocation();
+		LocalPoint location = object.getLocalLocation();
 		if (localLocation.distanceTo(location) <= MAX_DISTANCE)
 		{
 			Area objectClickbox = object.getClickbox();

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonOverlay.java
@@ -33,6 +33,7 @@ import net.runelite.api.Client;
 import net.runelite.api.Perspective;
 import static net.runelite.api.Perspective.LOCAL_TILE_SIZE;
 import net.runelite.api.Point;
+import net.runelite.api.coords.LocalPoint;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.OverlayPriority;
@@ -66,19 +67,14 @@ class CannonOverlay extends Overlay
 			return null;
 		}
 
-		if (!Perspective.isWorldInScene(client, plugin.getCannonPosition()))
-		{
-			return null;
-		}
-
-		Point cannonPoint = Perspective.worldToLocal(client, plugin.getCannonPosition());
+		LocalPoint cannonPoint = LocalPoint.fromWorld(client, plugin.getCannonPosition());
 
 		if (cannonPoint == null)
 		{
 			return null;
 		}
 
-		Point localLocation = client.getLocalPlayer().getLocalLocation();
+		LocalPoint localLocation = client.getLocalPlayer().getLocalLocation();
 
 		if (localLocation.distanceTo(cannonPoint) <= MAX_DISTANCE)
 		{
@@ -110,7 +106,7 @@ class CannonOverlay extends Overlay
 	 * Draw the double hit spots on a 6 by 6 grid around the cannon
 	 * @param startTile The position of the cannon
 	 */
-	private void drawDoubleHitSpots(Graphics2D graphics, net.runelite.api.Point startTile, Color color)
+	private void drawDoubleHitSpots(Graphics2D graphics, LocalPoint startTile, Color color)
 	{
 		for (int x = -3; x <= 3; x++)
 		{
@@ -130,7 +126,7 @@ class CannonOverlay extends Overlay
 				int xPos = startTile.getX() - (x * LOCAL_TILE_SIZE);
 				int yPos = startTile.getY() - (y * LOCAL_TILE_SIZE);
 
-				net.runelite.api.Point marker = new net.runelite.api.Point(xPos, yPos);
+				LocalPoint marker = new LocalPoint(xPos, yPos);
 				Polygon poly = Perspective.getCanvasTilePoly(client, marker);
 
 				if (poly == null)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonPlugin.java
@@ -37,11 +37,11 @@ import net.runelite.api.Client;
 import net.runelite.api.GameObject;
 import net.runelite.api.ItemID;
 import static net.runelite.api.ObjectID.CANNON_BASE;
-import net.runelite.api.Perspective;
 import net.runelite.api.Player;
 import net.runelite.api.Projectile;
 import static net.runelite.api.ProjectileID.CANNONBALL;
 import static net.runelite.api.ProjectileID.GRANITE_CANNONBALL;
+import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.ChatMessage;
 import net.runelite.api.events.ConfigChanged;
 import net.runelite.api.events.GameObjectSpawned;
@@ -71,7 +71,7 @@ public class CannonPlugin extends Plugin
 	private boolean cannonPlaced;
 
 	@Getter
-	private net.runelite.api.Point cannonPosition;
+	private WorldPoint cannonPosition;
 
 	@Getter
 	private GameObject cannon;
@@ -159,7 +159,7 @@ public class CannonPlugin extends Plugin
 
 		if ((projectile.getId() == CANNONBALL || projectile.getId() == GRANITE_CANNONBALL) && cannonPosition != null)
 		{
-			net.runelite.api.Point projectileLoc = Perspective.localToWorld(client, new net.runelite.api.Point(projectile.getX1(), projectile.getY1()));
+			WorldPoint projectileLoc = WorldPoint.fromLocal(client, projectile.getX1(), projectile.getY1(), client.getPlane());
 
 			//Check to see if projectile x,y is 0 else it will continuously decrease while ball is flying.
 			if (projectileLoc.equals(cannonPosition) && projectile.getX() == 0 && projectile.getY() == 0)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/devtools/DevToolsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/devtools/DevToolsOverlay.java
@@ -25,7 +25,6 @@
  */
 package net.runelite.client.plugins.devtools;
 
-import java.awt.BasicStroke;
 import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Font;
@@ -52,6 +51,7 @@ import net.runelite.api.Projectile;
 import net.runelite.api.Region;
 import net.runelite.api.Tile;
 import net.runelite.api.WallObject;
+import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.api.widgets.WidgetItem;
@@ -341,7 +341,7 @@ public class DevToolsOverlay extends Overlay
 			int originX = projectile.getX1();
 			int originY = projectile.getY1();
 
-			net.runelite.api.Point tilePoint = new net.runelite.api.Point(originX, originY);
+			LocalPoint tilePoint = new LocalPoint(originX, originY);
 			Polygon poly = Perspective.getCanvasTilePoly(client, tilePoint);
 
 			if (poly != null)
@@ -370,17 +370,6 @@ public class DevToolsOverlay extends Overlay
 				OverlayUtil.renderActorOverlay(graphics, projectile.getInteracting(), infoString, Color.RED);
 			}
 		}
-	}
-
-	public void renderProjectileOrigin(Graphics2D graphics, Projectile projectile, int floor, net.runelite.api.Point origin)
-	{
-		Polygon poly = Perspective.getCanvasTilePoly(client, origin);
-
-		graphics.setColor(Color.RED);
-		graphics.setStroke(new BasicStroke(2));
-		graphics.drawPolygon(poly);
-		graphics.setColor(Color.RED);
-		graphics.fillPolygon(poly);
 	}
 
 	public void renderWidgets(Graphics2D graphics)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/devtools/LocationOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/devtools/LocationOverlay.java
@@ -28,7 +28,7 @@ import java.awt.Dimension;
 import java.awt.Graphics2D;
 import javax.inject.Inject;
 import net.runelite.api.Client;
-import net.runelite.api.Point;
+import net.runelite.api.coords.WorldPoint;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.components.PanelComponent;
@@ -58,7 +58,7 @@ public class LocationOverlay extends Overlay
 
 		panelComponent = new PanelComponent();
 
-		Point localWorld = client.getLocalPlayer().getWorldLocation();
+		WorldPoint localWorld = client.getLocalPlayer().getWorldLocation();
 
 		panelComponent.getLines().add(new PanelComponent.Line(
 			"Tile",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
@@ -47,6 +47,7 @@ import net.runelite.api.Player;
 import net.runelite.api.Point;
 import net.runelite.api.Region;
 import net.runelite.api.Tile;
+import net.runelite.api.coords.LocalPoint;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.ui.FontManager;
 import net.runelite.client.ui.overlay.Overlay;
@@ -122,13 +123,13 @@ public class GroundItemsOverlay extends Overlay
 		graphics.setFont(FontManager.getRunescapeSmallFont());
 
 		int z = client.getPlane();
-		Point from = player.getRegionLocation();
+		LocalPoint from = player.getLocalLocation();
 
-		int lowerX = max(0, from.getX() - MAX_RANGE);
-		int lowerY = max(0, from.getY() - MAX_RANGE);
+		int lowerX = max(0, from.getRegionX() - MAX_RANGE);
+		int lowerY = max(0, from.getRegionY() - MAX_RANGE);
 
-		int upperX = min(from.getX() + MAX_RANGE, REGION_SIZE - 1);
-		int upperY = min(from.getY() + MAX_RANGE, REGION_SIZE - 1);
+		int upperX = min(from.getRegionX() + MAX_RANGE, REGION_SIZE - 1);
+		int upperY = min(from.getRegionY() + MAX_RANGE, REGION_SIZE - 1);
 
 		for (int x = lowerX; x <= upperX; ++x)
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/hunter/HunterPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/hunter/HunterPlugin.java
@@ -39,7 +39,7 @@ import net.runelite.api.Client;
 import net.runelite.api.GameObject;
 import net.runelite.api.ObjectID;
 import net.runelite.api.Player;
-import net.runelite.api.Point;
+import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.ConfigChanged;
 import net.runelite.api.events.GameObjectSpawned;
 import net.runelite.api.events.GameTick;
@@ -321,7 +321,7 @@ public class HunterPlugin extends Plugin
 	 */
 	private HunterTrap getTrapFromCollection(GameObject gameObject)
 	{
-		final Point gameObjectLocation = gameObject.getWorldLocation();
+		final WorldPoint gameObjectLocation = gameObject.getWorldLocation();
 
 		for (HunterTrap trap : traps)
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/hunter/TrapOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/hunter/TrapOverlay.java
@@ -32,6 +32,7 @@ import java.awt.Point;
 import java.awt.geom.Arc2D;
 import javax.inject.Inject;
 import net.runelite.api.Client;
+import net.runelite.api.coords.LocalPoint;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
@@ -108,10 +109,10 @@ public class TrapOverlay extends Overlay
 	 */
 	private void drawTraps(Graphics2D graphics)
 	{
-		net.runelite.api.Point localLocation = client.getLocalPlayer().getLocalLocation();
+		LocalPoint localLocation = client.getLocalPlayer().getLocalLocation();
 		for (HunterTrap trap : plugin.getTraps())
 		{
-			net.runelite.api.Point trapLocation = trap.getGameObject().getLocalLocation();
+			LocalPoint trapLocation = trap.getGameObject().getLocalLocation();
 			if (trapLocation != null && localLocation.distanceTo(trapLocation) <= MAX_DISTANCE)
 			{
 				switch (trap.getState())

--- a/runelite-client/src/main/java/net/runelite/client/plugins/instancemap/InstanceMapOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/instancemap/InstanceMapOverlay.java
@@ -42,6 +42,7 @@ import net.runelite.api.SceneTilePaint;
 import net.runelite.api.SpritePixels;
 import net.runelite.api.Tile;
 import net.runelite.api.WallObject;
+import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.MapRegionChanged;
 import static net.runelite.client.plugins.instancemap.PixelMaps.ALL;
@@ -220,13 +221,14 @@ class InstanceMapOverlay extends Overlay
 	 */
 	private void drawPlayerDot(Graphics2D graphics, Player player, Color dotColor, Color outlineColor)
 	{
-		Point playerLocation = player.getRegionLocation();
+		LocalPoint playerLoc = player.getLocalLocation();
 
 		Tile[][] tiles = getTiles();
-		Point localPlayerPoint = new Point(playerLocation.getX(), (tiles[0].length - 1) - playerLocation.getY()); // flip the y value
+		int tileX = playerLoc.getRegionX();
+		int tileY = (tiles[0].length - 1) - playerLoc.getRegionY(); // flip the y value
 
-		int x = OVERLAY_POSITION.getX() + (int) (localPlayerPoint.getX() * TILE_SIZE * MAP_SCALING);
-		int y = OVERLAY_POSITION.getY() + (int) (localPlayerPoint.getY() * TILE_SIZE * MAP_SCALING);
+		int x = OVERLAY_POSITION.getX() + (int) (tileX * TILE_SIZE * MAP_SCALING);
+		int y = OVERLAY_POSITION.getY() + (int) (tileY * TILE_SIZE * MAP_SCALING);
 		graphics.setColor(dotColor);
 		graphics.fillRect(x, y, PLAYER_MARKER_SIZE, PLAYER_MARKER_SIZE);//draw the players point on the map
 		graphics.setColor(outlineColor);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/kourendlibrary/Bookcase.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/kourendlibrary/Bookcase.java
@@ -30,18 +30,18 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.Getter;
-import net.runelite.api.Point3D;
+import net.runelite.api.coords.WorldPoint;
 
 class Bookcase
 {
-	public Bookcase(Point3D location)
+	public Bookcase(WorldPoint location)
 	{
 		this.location = location;
 		this.index = new ArrayList<>();
 	}
 
 	@Getter
-	private final Point3D location;
+	private final WorldPoint location;
 
 	@Getter
 	private final List<Integer> index;
@@ -99,7 +99,7 @@ class Bookcase
 
 		b.append(" ");
 
-		switch (location.getZ())
+		switch (location.getPlane())
 		{
 			case 0:
 				b.append("ground floor");

--- a/runelite-client/src/main/java/net/runelite/client/plugins/kourendlibrary/KourendLibraryOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/kourendlibrary/KourendLibraryOverlay.java
@@ -40,6 +40,7 @@ import net.runelite.api.Client;
 import net.runelite.api.Perspective;
 import net.runelite.api.Player;
 import net.runelite.api.Point;
+import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
@@ -50,7 +51,7 @@ import static net.runelite.api.Perspective.getCanvasTilePoly;
 
 public class KourendLibraryOverlay extends Overlay
 {
-	private final static Point LIBRARY_CENTER = new Point(1632, 3807);
+	private final static WorldPoint LIBRARY_CENTER = new WorldPoint(1632, 3807, 1);
 	private final static int MAXIMUM_DISTANCE = 24;
 	private final static int ROUGH_ENABLE_DISTANCE = 45;
 
@@ -76,9 +77,9 @@ public class KourendLibraryOverlay extends Overlay
 			return null;
 		}
 
-		Point playerLoc = player.getWorldLocation();
+		WorldPoint playerLoc = player.getWorldLocation();
 
-		if (playerLoc.distanceTo(LIBRARY_CENTER) > ROUGH_ENABLE_DISTANCE)
+		if (playerLoc.distanceTo2D(LIBRARY_CENTER) > ROUGH_ENABLE_DISTANCE)
 		{
 			return null;
 		}
@@ -100,7 +101,7 @@ public class KourendLibraryOverlay extends Overlay
 				continue;
 			}
 
-			Point localBookcase = Perspective.worldToLocal(client, caseLoc.toPoint());
+			LocalPoint localBookcase = LocalPoint.fromWorld(client, caseLoc);
 			Point screenBookcase = Perspective.worldToCanvas(client, localBookcase.getX(), localBookcase.getY(), caseLoc.getPlane(), 25);
 
 			if (screenBookcase != null)
@@ -211,7 +212,7 @@ public class KourendLibraryOverlay extends Overlay
 				.forEach(n ->
 				{
 					Book b = library.getCustomerBook();
-					Point local = n.getLocalLocation();
+					LocalPoint local = n.getLocalLocation();
 					Polygon poly = getCanvasTilePoly(client, local);
 					OverlayUtil.renderPolygon(g, poly, Color.WHITE);
 					Point screen = Perspective.worldToCanvas(client, local.getX(), local.getY(), client.getPlane(), n.getLogicalHeight());

--- a/runelite-client/src/main/java/net/runelite/client/plugins/kourendlibrary/KourendLibraryOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/kourendlibrary/KourendLibraryOverlay.java
@@ -40,7 +40,7 @@ import net.runelite.api.Client;
 import net.runelite.api.Perspective;
 import net.runelite.api.Player;
 import net.runelite.api.Point;
-import net.runelite.api.Point3D;
+import net.runelite.api.coords.WorldPoint;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
@@ -93,7 +93,7 @@ public class KourendLibraryOverlay extends Overlay
 		for (Bookcase bookcase : allBookcases)
 		{
 			// AABB
-			Point3D caseLoc = bookcase.getLocation();
+			WorldPoint caseLoc = bookcase.getLocation();
 			if (Math.abs(playerLoc.getX() - caseLoc.getX()) > MAXIMUM_DISTANCE
 				|| Math.abs(playerLoc.getY() - caseLoc.getY()) > MAXIMUM_DISTANCE)
 			{
@@ -101,7 +101,7 @@ public class KourendLibraryOverlay extends Overlay
 			}
 
 			Point localBookcase = Perspective.worldToLocal(client, caseLoc.toPoint());
-			Point screenBookcase = Perspective.worldToCanvas(client, localBookcase.getX(), localBookcase.getY(), caseLoc.getZ(), 25);
+			Point screenBookcase = Perspective.worldToCanvas(client, localBookcase.getX(), localBookcase.getY(), caseLoc.getPlane(), 25);
 
 			if (screenBookcase != null)
 			{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/kourendlibrary/KourendLibraryPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/kourendlibrary/KourendLibraryPlugin.java
@@ -37,7 +37,7 @@ import net.runelite.api.Client;
 import net.runelite.api.MenuAction;
 import net.runelite.api.Perspective;
 import net.runelite.api.Point;
-import net.runelite.api.Point3D;
+import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.AnimationChanged;
 import net.runelite.api.events.ChatMessage;
 import net.runelite.api.events.GameTick;
@@ -73,8 +73,8 @@ public class KourendLibraryPlugin extends Plugin
 	private KourendLibraryPanel panel;
 	private NavigationButton navButton;
 
-	private Point3D lastBookcaseClick = null;
-	private Point3D lastBookcaseAnimatedOn = null;
+	private WorldPoint lastBookcaseClick = null;
+	private WorldPoint lastBookcaseAnimatedOn = null;
 
 	@Override
 	protected void startUp() throws Exception
@@ -115,7 +115,7 @@ public class KourendLibraryPlugin extends Plugin
 		if (MenuAction.GAME_OBJECT_FIRST_OPTION == menuOpt.getMenuAction() && menuOpt.getMenuTarget().contains("Bookshelf"))
 		{
 			Point worldPoint = Perspective.regionToWorld(client, new Point(menuOpt.getId() & 127, menuOpt.getId() >> 7 & 127));
-			lastBookcaseClick = new Point3D(worldPoint.getX(), worldPoint.getY(), client.getPlane());
+			lastBookcaseClick = new WorldPoint(worldPoint.getX(), worldPoint.getY(), client.getPlane());
 		}
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/kourendlibrary/KourendLibraryPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/kourendlibrary/KourendLibraryPlugin.java
@@ -35,8 +35,6 @@ import net.runelite.api.AnimationID;
 import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
 import net.runelite.api.MenuAction;
-import net.runelite.api.Perspective;
-import net.runelite.api.Point;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.AnimationChanged;
 import net.runelite.api.events.ChatMessage;
@@ -114,8 +112,7 @@ public class KourendLibraryPlugin extends Plugin
 	{
 		if (MenuAction.GAME_OBJECT_FIRST_OPTION == menuOpt.getMenuAction() && menuOpt.getMenuTarget().contains("Bookshelf"))
 		{
-			Point worldPoint = Perspective.regionToWorld(client, new Point(menuOpt.getId() & 127, menuOpt.getId() >> 7 & 127));
-			lastBookcaseClick = new WorldPoint(worldPoint.getX(), worldPoint.getY(), client.getPlane());
+			lastBookcaseClick = WorldPoint.fromLocal(client, menuOpt.getId() & 127, menuOpt.getId() >> 7 & 127, client.getPlane());
 		}
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/kourendlibrary/Library.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/kourendlibrary/Library.java
@@ -35,7 +35,7 @@ import java.util.stream.IntStream;
 import javax.inject.Singleton;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
-import net.runelite.api.Point3D;
+import net.runelite.api.coords.WorldPoint;
 
 import static net.runelite.client.plugins.kourendlibrary.Book.*;
 
@@ -59,7 +59,7 @@ import static net.runelite.client.plugins.kourendlibrary.Book.*;
 @Slf4j
 public class Library
 {
-	private final Map<Point3D, Bookcase> byPoint = new HashMap<>();
+	private final Map<WorldPoint, Bookcase> byPoint = new HashMap<>();
 	private final Map<Integer, ArrayList<Bookcase>> byLevel = new HashMap<>();
 	private final List<Bookcase> byIndex = new ArrayList<>();
 
@@ -110,7 +110,7 @@ public class Library
 		log.info("Library is now reset");
 	}
 
-	public synchronized void mark(Point3D loc, Book book)
+	public synchronized void mark(WorldPoint loc, Book book)
 	{
 		Bookcase bookcase = byPoint.get(loc);
 		if (bookcase == null)
@@ -428,7 +428,7 @@ public class Library
 	private void add(int x, int y, int z, int i)
 	{
 		// 'i' is added as a parameter for readability
-		Point3D p = new Point3D(x, y, z);
+		WorldPoint p = new WorldPoint(x, y, z);
 		Bookcase b = byPoint.get(p);
 		if (b == null)
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/motherlode/MotherlodeRocksOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/motherlode/MotherlodeRocksOverlay.java
@@ -38,6 +38,7 @@ import net.runelite.api.Player;
 import net.runelite.api.Point;
 import net.runelite.api.Skill;
 import net.runelite.api.WallObject;
+import net.runelite.api.coords.LocalPoint;
 import net.runelite.client.game.SkillIconManager;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
@@ -83,10 +84,10 @@ class MotherlodeRocksOverlay extends Overlay
 
 	private void renderTiles(Graphics2D graphics, Player local)
 	{
-		Point localLocation = local.getLocalLocation();
+		LocalPoint localLocation = local.getLocalLocation();
 		for (WallObject vein : plugin.getVeins())
 		{
-			Point location = vein.getLocalLocation();
+			LocalPoint location = vein.getLocalLocation();
 			if (localLocation.distanceTo(location) <= MAX_DISTANCE)
 			{
 				renderVein(graphics, vein);
@@ -95,7 +96,7 @@ class MotherlodeRocksOverlay extends Overlay
 
 		for (GameObject rock : plugin.getRocks())
 		{
-			Point location = rock.getLocalLocation();
+			LocalPoint location = rock.getLocalLocation();
 			if (localLocation.distanceTo(location) <= MAX_DISTANCE)
 			{
 				renderRock(graphics, rock);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/poh/PohOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/poh/PohOverlay.java
@@ -33,7 +33,7 @@ import javax.inject.Inject;
 import lombok.Getter;
 import net.runelite.api.Client;
 import net.runelite.api.Perspective;
-import net.runelite.api.Point;
+import net.runelite.api.coords.LocalPoint;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
@@ -69,10 +69,10 @@ public class PohOverlay extends Overlay
 	@Override
 	public Dimension render(Graphics2D graphics, java.awt.Point parent)
 	{
-		Point localLocation = client.getLocalPlayer().getLocalLocation();
+		LocalPoint localLocation = client.getLocalPlayer().getLocalLocation();
 		plugin.getPohObjects().forEach((object, tile) ->
 		{
-			Point location = object.getLocalLocation();
+			LocalPoint location = object.getLocalLocation();
 			if (tile.getPlane() == client.getPlane() && localLocation.distanceTo(location) <= MAX_DISTANCE)
 			{
 				PohIcons icon = PohIcons.getIcon(object.getId());

--- a/runelite-client/src/main/java/net/runelite/client/plugins/roguesden/RoguesDenOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/roguesden/RoguesDenOverlay.java
@@ -31,7 +31,7 @@ import java.awt.Polygon;
 import javax.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
-import net.runelite.api.Point;
+import net.runelite.api.coords.LocalPoint;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
@@ -61,7 +61,7 @@ public class RoguesDenOverlay extends Overlay
 			return null;
 		}
 
-		Point playerLocation = client.getLocalPlayer().getLocalLocation();
+		LocalPoint playerLocation = client.getLocalPlayer().getLocalLocation();
 
 		plugin.getObstaclesHull().forEach((obstacle, tile) ->
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/runecraft/AbyssOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/runecraft/AbyssOverlay.java
@@ -51,6 +51,7 @@ import net.runelite.api.Client;
 import net.runelite.api.DecorativeObject;
 import net.runelite.api.Perspective;
 import net.runelite.api.Point;
+import net.runelite.api.coords.LocalPoint;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
@@ -89,10 +90,10 @@ class AbyssOverlay extends Overlay
 			return null;
 		}
 
-		Point localLocation = client.getLocalPlayer().getLocalLocation();
+		LocalPoint localLocation = client.getLocalPlayer().getLocalLocation();
 		for (DecorativeObject object : plugin.getAbyssObjects())
 		{
-			Point location = object.getLocalLocation();
+			LocalPoint location = object.getLocalLocation();
 			if (localLocation.distanceTo(location) <= MAX_DISTANCE)
 			{
 				renderRifts(graphics, object);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/tileindicators/TileIndicatorsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/tileindicators/TileIndicatorsOverlay.java
@@ -24,13 +24,12 @@
  */
 package net.runelite.client.plugins.tileindicators;
 
-import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Graphics2D;
 import java.awt.Polygon;
 import net.runelite.api.Client;
 import net.runelite.api.Perspective;
-import net.runelite.api.Point;
+import net.runelite.api.coords.LocalPoint;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
@@ -54,24 +53,20 @@ public class TileIndicatorsOverlay extends Overlay
 	@Override
 	public Dimension render(Graphics2D graphics, java.awt.Point parent)
 	{
-		if (client.getSceneDestinationLocation().getX() > 0
-			&& client.getSceneDestinationLocation().getY() > 0)
+		LocalPoint dest = client.getLocalDestinationLocation();
+		if (dest == null)
 		{
-			drawRegionTile(graphics, client.getSceneDestinationLocation(), config.highlightDestinationColor());
+			return null;
 		}
+
+		Polygon poly = Perspective.getCanvasTilePoly(client, dest);
+		if (poly == null)
+		{
+			return null;
+		}
+		
+		OverlayUtil.renderPolygon(graphics, poly, config.highlightDestinationColor());
 
 		return null;
-	}
-
-	private void drawRegionTile(Graphics2D graphics, Point tile, Color color)
-	{
-		Point localTile = Perspective.regionToLocal(client, tile);
-		localTile = new Point(localTile.getX() + Perspective.LOCAL_TILE_SIZE / 2, localTile.getY() + Perspective.LOCAL_TILE_SIZE / 2);
-		Polygon poly = Perspective.getCanvasTilePoly(client, localTile);
-
-		if (poly != null)
-		{
-			OverlayUtil.renderPolygon(graphics, poly, color);
-		}
 	}
 }

--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSActorMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSActorMixin.java
@@ -30,10 +30,11 @@ import java.awt.image.BufferedImage;
 import net.runelite.api.Actor;
 import net.runelite.api.NPC;
 import net.runelite.api.Perspective;
-import static net.runelite.api.Perspective.LOCAL_COORD_BITS;
 import net.runelite.api.Player;
 import net.runelite.api.Point;
 import net.runelite.api.SpritePixels;
+import net.runelite.api.coords.LocalPoint;
+import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.GraphicChanged;
 import net.runelite.api.mixins.FieldHook;
 import net.runelite.api.mixins.Inject;
@@ -123,24 +124,16 @@ public abstract class RSActorMixin implements RSActor
 
 	@Override
 	@Inject
-	public Point getWorldLocation()
+	public WorldPoint getWorldLocation()
 	{
-		Point localLocation = getLocalLocation();
-		return Perspective.localToWorld(client, localLocation);
+		return WorldPoint.fromLocal(client, getX(), getY(), client.getPlane());
 	}
 
 	@Inject
 	@Override
-	public Point getRegionLocation()
+	public LocalPoint getLocalLocation()
 	{
-		return new Point(getX() >>> LOCAL_COORD_BITS, getY() >>> LOCAL_COORD_BITS);// divided by 128
-	}
-
-	@Inject
-	@Override
-	public Point getLocalLocation()
-	{
-		return new Point(getX(), getY());
+		return new LocalPoint(getX(), getY());
 	}
 
 	@Inject

--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSClientMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSClientMixin.java
@@ -26,6 +26,7 @@ package net.runelite.mixins;
 
 import java.util.ArrayList;
 import java.util.List;
+import javax.annotation.Nullable;
 import net.runelite.api.ChatMessageType;
 import net.runelite.api.ClanMember;
 import net.runelite.api.GameState;
@@ -43,6 +44,7 @@ import net.runelite.api.Projectile;
 import net.runelite.api.Setting;
 import net.runelite.api.Skill;
 import net.runelite.api.Varbits;
+import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.events.ExperienceChanged;
 import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.GrandExchangeOfferChanged;
@@ -366,9 +368,16 @@ public abstract class RSClientMixin implements RSClient
 
 	@Inject
 	@Override
-	public Point getSceneDestinationLocation()
+	@Nullable
+	public LocalPoint getLocalDestinationLocation()
 	{
-		return new Point(getDestinationX(), getDestinationY());
+		int regionX = getDestinationX();
+		int regionY = getDestinationY();
+		if (regionX != 0 && regionY != 0)
+		{
+			return LocalPoint.fromRegion(regionX, regionY);
+		}
+		return null;
 	}
 
 	@Inject

--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSDecorativeObjectMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSDecorativeObjectMixin.java
@@ -42,6 +42,23 @@ public abstract class RSDecorativeObjectMixin implements RSDecorativeObject
 	private static RSClient client;
 
 	@Inject
+	private int decorativeObjectPlane;
+
+	@Inject
+	@Override
+	public int getPlane()
+	{
+		return decorativeObjectPlane;
+	}
+
+	@Inject
+	@Override
+	public void setPlane(int plane)
+	{
+		this.decorativeObjectPlane = plane;
+	}
+
+	@Inject
 	private Model getModel()
 	{
 		Renderable renderable = getRenderable();

--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSGroundObjectMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSGroundObjectMixin.java
@@ -41,6 +41,23 @@ public abstract class RSGroundObjectMixin implements RSGroundObject
 	private static RSClient client;
 
 	@Inject
+	private int groundObjectPlane;
+
+	@Inject
+	@Override
+	public int getPlane()
+	{
+		return groundObjectPlane;
+	}
+
+	@Inject
+	@Override
+	public void setPlane(int plane)
+	{
+		this.groundObjectPlane = plane;
+	}
+
+	@Inject
 	private Model getModel()
 	{
 		Renderable renderable = getRenderable();

--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSItemLayerMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSItemLayerMixin.java
@@ -33,10 +33,26 @@ import net.runelite.rs.api.RSItemLayer;
 public abstract class RSItemLayerMixin implements RSItemLayer
 {
 	@Inject
+	private int itemLayerPlane;
+
+	@Inject
+	@Override
+	public int getPlane()
+	{
+		return itemLayerPlane;
+	}
+
+	@Inject
+	@Override
+	public void setPlane(int plane)
+	{
+		this.itemLayerPlane = plane;
+	}
+
+	@Inject
 	@Override
 	public Area getClickbox()
 	{
 		throw new UnsupportedOperationException();
 	}
-
 }

--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSRegionMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSRegionMixin.java
@@ -24,11 +24,16 @@
  */
 package net.runelite.mixins;
 
+import net.runelite.api.Renderable;
 import net.runelite.api.mixins.Copy;
 import net.runelite.api.mixins.Inject;
 import net.runelite.api.mixins.Mixin;
 import net.runelite.api.mixins.Replace;
+import net.runelite.rs.api.RSDecorativeObject;
+import net.runelite.rs.api.RSGroundObject;
+import net.runelite.rs.api.RSItemLayer;
 import net.runelite.rs.api.RSRegion;
+import net.runelite.rs.api.RSWallObject;
 
 @Mixin(RSRegion.class)
 public abstract class RSRegionMixin implements RSRegion
@@ -51,5 +56,45 @@ public abstract class RSRegionMixin implements RSRegion
 		{
 			isDrawingRegion = false;
 		}
+	}
+
+	@Copy("addBoundaryDecoration")
+	abstract public void rs$addBoundaryDecoration(int plane, int x, int y, int hash, Renderable var5, Renderable var6, int var7, int var8, int var9, int var10, int var11, int var12);
+
+	@Replace("addBoundaryDecoration")
+	public void rl$addBoundaryDecoration(int plane, int x, int y, int hash, Renderable var5, Renderable var6, int var7, int var8, int var9, int var10, int var11, int var12)
+	{
+		rs$addBoundaryDecoration(plane, x, y, hash, var5, var6, var7, var8, var9, var10, var11, var12);
+		((RSDecorativeObject) getTiles()[plane][x][y].getDecorativeObject()).setPlane(plane);
+	}
+
+	@Copy("addItemPile")
+	abstract public void rs$addItemPile(int plane, int x, int y, int hash, Renderable var5, int var6, Renderable var7, Renderable var8);
+
+	@Replace("addItemPile")
+	public void rl$addItemPile(int plane, int x, int y, int hash, Renderable var5, int var6, Renderable var7, Renderable var8)
+	{
+		rs$addItemPile(plane, x, y, hash, var5, var6, var7, var8);
+		((RSItemLayer) getTiles()[plane][x][y].getItemLayer()).setPlane(plane);
+	}
+
+	@Copy("groundObjectSpawned")
+	abstract public void rs$groundObjectSpawned(int plane, int x, int y, int hash, Renderable var5, int var6, int var7);
+
+	@Replace("groundObjectSpawned")
+	public void rl$groundObjectSpawned(int plane, int x, int y, int hash, Renderable var5, int var6, int var7)
+	{
+		rs$groundObjectSpawned(plane, x, y, hash, var5, var6, var7);
+		((RSGroundObject) getTiles()[plane][x][y].getGroundObject()).setPlane(plane);
+	}
+
+	@Copy("addBoundary")
+	abstract public void rs$addBoundary(int plane, int x, int y, int hash, Renderable var5, Renderable var6, int var7, int var8, int var9, int var10);
+
+	@Replace("addBoundary")
+	public void rl$addBoundary(int plane, int x, int y, int hash, Renderable var5, Renderable var6, int var7, int var8, int var9, int var10)
+	{
+		rs$addBoundary(plane, x, y, hash, var5, var6, var7, var8, var9, var10);
+		((RSWallObject) getTiles()[plane][x][y].getWallObject()).setPlane(plane);
 	}
 }

--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSTileMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSTileMixin.java
@@ -28,9 +28,10 @@ import net.runelite.api.Actor;
 import net.runelite.api.DecorativeObject;
 import net.runelite.api.GameObject;
 import net.runelite.api.GroundObject;
-import net.runelite.api.Perspective;
 import net.runelite.api.Point;
 import net.runelite.api.WallObject;
+import net.runelite.api.coords.LocalPoint;
+import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.DecorativeObjectChanged;
 import net.runelite.api.events.DecorativeObjectDespawned;
 import net.runelite.api.events.DecorativeObjectSpawned;
@@ -75,10 +76,9 @@ public abstract class RSTileMixin implements RSTile
 
 	@Inject
 	@Override
-	public Point getWorldLocation()
+	public WorldPoint getWorldLocation()
 	{
-		Point regionLocation = getRegionLocation();
-		return Perspective.regionToWorld(client, regionLocation);
+		return WorldPoint.fromRegion(client, getX(), getY(), getPlane());
 	}
 
 	@Inject
@@ -90,10 +90,9 @@ public abstract class RSTileMixin implements RSTile
 
 	@Inject
 	@Override
-	public Point getLocalLocation()
+	public LocalPoint getLocalLocation()
 	{
-		Point regionLocation = getRegionLocation();
-		return Perspective.regionToLocal(client, regionLocation);
+		return LocalPoint.fromRegion(getX(), getY());
 	}
 
 	@FieldHook("wallObject")

--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSWallObjectMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSWallObjectMixin.java
@@ -41,6 +41,23 @@ public abstract class RSWallObjectMixin implements RSWallObject
 	private static RSClient client;
 
 	@Inject
+	private int wallPlane;
+
+	@Inject
+	@Override
+	public int getPlane()
+	{
+		return wallPlane;
+	}
+
+	@Inject
+	@Override
+	public void setPlane(int plane)
+	{
+		this.wallPlane = plane;
+	}
+
+	@Inject
 	private Model getModelA()
 	{
 		Renderable renderable = getRenderable1();

--- a/runelite-mixins/src/main/java/net/runelite/mixins/TileObjectMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/TileObjectMixin.java
@@ -71,7 +71,7 @@ public abstract class TileObjectMixin implements TileObject
 	@Inject
 	public WorldPoint getWorldLocation()
 	{
-		return WorldPoint.fromLocal(client, getX(), getY(), client.getPlane()); //TODO: use the correct plane
+		return WorldPoint.fromLocal(client, getX(), getY(), getPlane());
 	}
 
 	@Override

--- a/runelite-mixins/src/main/java/net/runelite/mixins/TileObjectMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/TileObjectMixin.java
@@ -30,9 +30,10 @@ import java.util.ArrayList;
 import java.util.List;
 import net.runelite.api.Model;
 import net.runelite.api.Perspective;
-import static net.runelite.api.Perspective.LOCAL_COORD_BITS;
 import net.runelite.api.Point;
 import net.runelite.api.TileObject;
+import net.runelite.api.coords.LocalPoint;
+import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.mixins.Inject;
 import net.runelite.api.mixins.Mixin;
 import net.runelite.api.mixins.Mixins;
@@ -68,25 +69,16 @@ public abstract class TileObjectMixin implements TileObject
 
 	@Override
 	@Inject
-	public Point getWorldLocation()
+	public WorldPoint getWorldLocation()
 	{
-		Point localLocation = getLocalLocation();
-		return Perspective.localToWorld(client, localLocation);
+		return WorldPoint.fromLocal(client, getX(), getY(), client.getPlane()); //TODO: use the correct plane
 	}
 
 	@Override
 	@Inject
-	public Point getLocalLocation()
+	public LocalPoint getLocalLocation()
 	{
-		return new Point(getX(), getY());
-	}
-
-	@Override
-	@Inject
-	public Point getRegionLocation()
-	{
-		Point localLocation = getLocalLocation();
-		return new Point(localLocation.getX() >>> LOCAL_COORD_BITS, localLocation.getY() >>> LOCAL_COORD_BITS);
+		return new LocalPoint(getX(), getY());
 	}
 
 	@Override
@@ -100,8 +92,7 @@ public abstract class TileObjectMixin implements TileObject
 	@Inject
 	public Point getCanvasLocation(int zOffset)
 	{
-		Point localLocation = getLocalLocation();
-		return Perspective.worldToCanvas(client, localLocation.getX(), localLocation.getY(), 0, zOffset);
+		return Perspective.worldToCanvas(client, getX(), getY(), 0, zOffset);
 	}
 
 	@Override

--- a/runescape-api/src/main/java/net/runelite/rs/api/RSDecorativeObject.java
+++ b/runescape-api/src/main/java/net/runelite/rs/api/RSDecorativeObject.java
@@ -45,4 +45,6 @@ public interface RSDecorativeObject extends DecorativeObject
 
 	@Import("renderable1")
 	Renderable getRenderable();
+
+	void setPlane(int plane);
 }

--- a/runescape-api/src/main/java/net/runelite/rs/api/RSGroundObject.java
+++ b/runescape-api/src/main/java/net/runelite/rs/api/RSGroundObject.java
@@ -42,4 +42,6 @@ public interface RSGroundObject extends GroundObject
 
 	@Import("renderable")
 	Renderable getRenderable();
+
+	void setPlane(int plane);
 }

--- a/runescape-api/src/main/java/net/runelite/rs/api/RSItemLayer.java
+++ b/runescape-api/src/main/java/net/runelite/rs/api/RSItemLayer.java
@@ -56,4 +56,6 @@ public interface RSItemLayer extends ItemLayer
 	@Import("top")
 	@Override
 	RSRenderable getTop();
+
+	void setPlane(int plane);
 }

--- a/runescape-api/src/main/java/net/runelite/rs/api/RSWallObject.java
+++ b/runescape-api/src/main/java/net/runelite/rs/api/RSWallObject.java
@@ -59,4 +59,6 @@ public interface RSWallObject extends WallObject
 	@Import("config")
 	@Override
 	int getConfig();
+
+	void setPlane(int plane);
 }


### PR DESCRIPTION
This changes all usages of the local and world coordinate systems to use a new `WorldPoint` and `LocalPoint` type. Region coords, due to their low use, are primarily left as is.