### PR TITLE
Continue to update opponent info while on screen

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/Client.java
+++ b/runelite-api/src/main/java/net/runelite/api/Client.java
@@ -39,6 +39,8 @@ public interface Client extends GameEngine
 
 	List<NPC> getNpcs();
 
+	NPC[] getCachedNPCs();
+
 	int getBoostedSkillLevel(Skill skill);
 
 	int getRealSkillLevel(Skill skill);

--- a/runelite-api/src/main/java/net/runelite/api/NPC.java
+++ b/runelite-api/src/main/java/net/runelite/api/NPC.java
@@ -34,4 +34,5 @@ public interface NPC extends Actor
 	@Override
 	int getCombatLevel();
 
+	int getIndex();
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/opponentinfo/OpponentInfoOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/opponentinfo/OpponentInfoOverlay.java
@@ -37,6 +37,7 @@ import java.util.Map;
 import javax.inject.Inject;
 import net.runelite.api.Actor;
 import net.runelite.api.Client;
+import net.runelite.api.NPC;
 import net.runelite.api.Player;
 import net.runelite.api.Varbits;
 import net.runelite.client.ui.overlay.Overlay;
@@ -60,6 +61,8 @@ class OpponentInfoOverlay extends Overlay
 	private static final Duration WAIT = Duration.ofSeconds(3);
 
 	private final Client client;
+	private final NPC[] clientNpcs;
+
 	private Integer lastMaxHealth;
 	private DecimalFormat df = new DecimalFormat("0.0");
 	private float lastRatio = 0;
@@ -67,6 +70,7 @@ class OpponentInfoOverlay extends Overlay
 	private String opponentName;
 	private String opponentsOpponentName;
 	private Map<String, Integer> oppInfoHealth = OpponentInfoPlugin.loadNpcHealth();
+	private NPC lastOpponent;
 
 	@Inject
 	OpponentInfoOverlay(Client client)
@@ -74,6 +78,7 @@ class OpponentInfoOverlay extends Overlay
 		setPosition(OverlayPosition.TOP_LEFT);
 		setPriority(OverlayPriority.HIGH);
 		this.client = client;
+		this.clientNpcs = client.getCachedNPCs();
 	}
 
 	private Actor getOpponent()
@@ -91,6 +96,25 @@ class OpponentInfoOverlay extends Overlay
 	public Dimension render(Graphics2D graphics, Point parent)
 	{
 		Actor opponent = getOpponent();
+
+		// If opponent is null, try to use last opponent
+		if (opponent == null)
+		{
+			if (lastOpponent != null && clientNpcs[lastOpponent.getIndex()] != lastOpponent)
+			{
+				// lastOpponent is no longer valid
+				lastOpponent = null;
+			}
+			else
+			{
+				opponent = lastOpponent;
+			}
+		}
+		else
+		{
+			// Update last opponent
+			lastOpponent = opponent instanceof NPC ? (NPC) opponent : null;
+		}
 
 		if (opponent != null && opponent.getHealth() > 0)
 		{

--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSClientMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSClientMixin.java
@@ -65,6 +65,7 @@ import net.runelite.rs.api.RSDeque;
 import net.runelite.rs.api.RSHashTable;
 import net.runelite.rs.api.RSIndexedSprite;
 import net.runelite.rs.api.RSItemContainer;
+import net.runelite.rs.api.RSNPC;
 import net.runelite.rs.api.RSName;
 import net.runelite.rs.api.RSWidget;
 
@@ -492,6 +493,24 @@ public abstract class RSClientMixin implements RSClient
 		GameStateChanged gameStateChange = new GameStateChanged();
 		gameStateChange.setGameState(client.getGameState());
 		eventBus.post(gameStateChange);
+	}
+
+
+	@FieldHook("cachedNPCs")
+	@Inject
+	public static void cachedNPCsChanged(int idx)
+	{
+		RSNPC[] cachedNPCs = client.getCachedNPCs();
+		if (idx < 0 || idx >= cachedNPCs.length)
+		{
+			return;
+		}
+
+		RSNPC npc = cachedNPCs[idx];
+		if (npc != null)
+		{
+			npc.setIndex(idx);
+		}
 	}
 
 	@Inject

--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSNPCMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSNPCMixin.java
@@ -33,6 +33,9 @@ import net.runelite.rs.api.RSNPCComposition;
 public abstract class RSNPCMixin implements RSNPC
 {
 	@Inject
+	private int npcIndex;
+
+	@Inject
 	@Override
 	public int getId()
 	{
@@ -54,5 +57,19 @@ public abstract class RSNPCMixin implements RSNPC
 	{
 		RSNPCComposition composition = getComposition();
 		return composition == null ? -1 : composition.getCombatLevel();
+	}
+
+	@Inject
+	@Override
+	public int getIndex()
+	{
+		return npcIndex;
+	}
+
+	@Inject
+	@Override
+	public void setIndex(int id)
+	{
+		npcIndex = id;
 	}
 }

--- a/runescape-api/src/main/java/net/runelite/rs/api/RSClient.java
+++ b/runescape-api/src/main/java/net/runelite/rs/api/RSClient.java
@@ -129,6 +129,7 @@ public interface RSClient extends RSGameEngine, Client
 	int[] getNpcIndices();
 
 	@Import("cachedNPCs")
+	@Override
 	RSNPC[] getCachedNPCs();
 
 	@Import("collisionMaps")

--- a/runescape-api/src/main/java/net/runelite/rs/api/RSNPC.java
+++ b/runescape-api/src/main/java/net/runelite/rs/api/RSNPC.java
@@ -31,4 +31,9 @@ public interface RSNPC extends RSActor, NPC
 {
 	@Import("composition")
 	RSNPCComposition getComposition();
+
+	@Override
+	int getIndex();
+
+	void setIndex(int id);
 }


### PR DESCRIPTION
If you fire a ranged weapon and stop interacting with an enemy, it's opponent info will still be on screen but it won't update once it's taken damage which can be annoying. Now it will update until the info panel disapears.