### PR TITLE
WIP - Add more discord information

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/discord/DiscordService.java
+++ b/runelite-client/src/main/java/net/runelite/client/discord/DiscordService.java
@@ -129,7 +129,7 @@ public class DiscordService implements AutoCloseable
 		discordRichPresence.largeImageText = discordPresence.getLargeImageText();
 		discordRichPresence.smallImageKey = Strings.isNullOrEmpty(discordPresence.getSmallImageKey())
 			? "default"
-			: discordPresence.getLargeImageKey();
+			: discordPresence.getSmallImageKey();
 		discordRichPresence.smallImageText = discordPresence.getSmallImageText();
 		discordRichPresence.partyId = discordPresence.getPartyId();
 		discordRichPresence.partySize = discordPresence.getPartySize();

--- a/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordGameEventType.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordGameEventType.java
@@ -29,7 +29,6 @@ import java.util.Set;
 import java.util.function.Function;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import net.runelite.api.Skill;
 import static net.runelite.api.Skill.AGILITY;
 import static net.runelite.api.Skill.ATTACK;
@@ -55,66 +54,85 @@ import static net.runelite.api.Skill.STRENGTH;
 import static net.runelite.api.Skill.THIEVING;
 import static net.runelite.api.Skill.WOODCUTTING;
 
-@RequiredArgsConstructor
 @AllArgsConstructor
 @Getter
 public enum DiscordGameEventType
 {
 	IN_GAME("In Game", false, true),
 	IN_MENU("In Menu", false, false),
-	TRAINING_ATTACK(training(ATTACK), DiscordGameEventType::combatSkillChanged),
-	TRAINING_DEFENCE(training(DEFENCE), DiscordGameEventType::combatSkillChanged),
-	TRAINING_STRENGTH(training(STRENGTH), DiscordGameEventType::combatSkillChanged),
-	TRAINING_HITPOINTS(training(HITPOINTS), DiscordGameEventType::combatSkillChanged),
-	TRAINING_SLAYER(training(SLAYER), 1, DiscordGameEventType::combatSkillChanged),
-	TRAINING_RANGED(training(RANGED), DiscordGameEventType::combatSkillChanged),
-	TRAINING_MAGIC(training(MAGIC), DiscordGameEventType::combatSkillChanged),
-	TRAINING_PRAYER(training(PRAYER)),
-	TRAINING_COOKING(training(COOKING)),
-	TRAINING_WOODCUTTING(training(WOODCUTTING)),
-	TRAINING_FLETCHING(training(FLETCHING)),
-	TRAINING_FISHING(training(FISHING)),
-	TRAINING_FIREMAKING(training(FIREMAKING)),
-	TRAINING_CRAFTING(training(CRAFTING)),
-	TRAINING_SMITHING(training(SMITHING)),
-	TRAINING_MINING(training(MINING)),
-	TRAINING_HERBLORE(training(HERBLORE)),
-	TRAINING_AGILITY(training(AGILITY)),
-	TRAINING_THIEVING(training(THIEVING)),
-	TRAINING_FARMING(training(FARMING)),
-	TRAINING_RUNECRAFT(training(RUNECRAFT)),
-	TRAINING_HUNTER(training(HUNTER)),
-	TRAINING_CONSTRUCTION(training(CONSTRUCTION));
+	TRAINING_ATTACK(ATTACK, DiscordGameEventType::combatSkillChanged),
+	TRAINING_DEFENCE(DEFENCE, DiscordGameEventType::combatSkillChanged),
+	TRAINING_STRENGTH(STRENGTH, DiscordGameEventType::combatSkillChanged),
+	TRAINING_HITPOINTS(HITPOINTS, DiscordGameEventType::combatSkillChanged),
+	TRAINING_SLAYER(SLAYER, 1, DiscordGameEventType::combatSkillChanged),
+	TRAINING_RANGED(RANGED, DiscordGameEventType::combatSkillChanged),
+	TRAINING_MAGIC(MAGIC, DiscordGameEventType::combatSkillChanged),
+	TRAINING_PRAYER(PRAYER),
+	TRAINING_COOKING(COOKING),
+	TRAINING_WOODCUTTING(WOODCUTTING),
+	TRAINING_FLETCHING(FLETCHING),
+	TRAINING_FISHING(FISHING),
+	TRAINING_FIREMAKING(FIREMAKING),
+	TRAINING_CRAFTING(CRAFTING),
+	TRAINING_SMITHING(SMITHING),
+	TRAINING_MINING(MINING),
+	TRAINING_HERBLORE(HERBLORE),
+	TRAINING_AGILITY(AGILITY),
+	TRAINING_THIEVING(THIEVING),
+	TRAINING_FARMING(FARMING),
+	TRAINING_RUNECRAFT(RUNECRAFT),
+	TRAINING_HUNTER(HUNTER),
+	TRAINING_CONSTRUCTION(CONSTRUCTION);
 
 	private static final Set<Skill> COMBAT_SKILLS = Sets.newHashSet(ATTACK, STRENGTH, DEFENCE, HITPOINTS, SLAYER, RANGED, MAGIC);
-	private final String state;
+	private Skill skill;
+	private String imageKey;
 	private String details;
 	private boolean trackTime = true;
 	private boolean considerDelay = true;
 	private Function<DiscordGameEventType, Boolean> isChanged = (l) -> true;
 	private int priority = 0;
 
-	DiscordGameEventType(String state, boolean considerDelay, boolean trackTime)
+	DiscordGameEventType(String details, boolean considerDelay, boolean trackTime)
 	{
-		this.state = state;
+		this.imageKey = "default";
+		this.details = details;
 		this.considerDelay = considerDelay;
 		this.trackTime = trackTime;
 	}
 
-	DiscordGameEventType(String state, int priority, Function<DiscordGameEventType, Boolean> isChanged)
+	DiscordGameEventType(Skill skill, int priority, Function<DiscordGameEventType, Boolean> isChanged)
 	{
-		this.state = state;
+		this.imageKey = getImageKey(skill);
+		this.details = training(skill);
 		this.priority = priority;
 		this.isChanged = isChanged;
 	}
 
-	DiscordGameEventType(String state, Function<DiscordGameEventType, Boolean> isChanged)
+	DiscordGameEventType(Skill skill, Function<DiscordGameEventType, Boolean> isChanged)
 	{
-		this.state = state;
+		this.imageKey = getImageKey(skill);
+		this.details = training(skill);
 		this.isChanged = isChanged;
 	}
 
-	private static String training(final Skill skill)
+	DiscordGameEventType(Skill skill)
+	{
+		this.imageKey = getImageKey(skill);
+		this.details = training(skill);
+	}
+
+	private static String getImageKey(final Skill skill)
+	{
+		return getImageKey(skill.getName().toLowerCase());
+	}
+
+	private static String getImageKey(final String what)
+	{
+		return "icon_" + what;
+	}
+
+	public static String training(final Skill skill)
 	{
 		return training(skill.getName());
 	}
@@ -128,7 +146,7 @@ public enum DiscordGameEventType
 	{
 		for (Skill skill : Skill.values())
 		{
-			if (l.getState().contains(skill.getName()))
+			if (l.getSkill() == skill)
 			{
 				return !COMBAT_SKILLS.contains(skill);
 			}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordGameEventType.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordGameEventType.java
@@ -29,6 +29,7 @@ import java.util.Set;
 import java.util.function.Function;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.Setter;
 import net.runelite.api.Skill;
 import static net.runelite.api.Skill.AGILITY;
 import static net.runelite.api.Skill.ATTACK;
@@ -60,7 +61,7 @@ public enum DiscordGameEventType
 {
 	IN_GAME("In Game", false, true),
 	IN_MENU("In Menu", false, false),
-	RAID("In Raid", "raids", false, true),
+	RAID("In Raid", "raids", 2, false, true),
 	TRAINING_ATTACK(ATTACK, DiscordGameEventType::combatSkillChanged),
 	TRAINING_DEFENCE(DEFENCE, DiscordGameEventType::combatSkillChanged),
 	TRAINING_STRENGTH(STRENGTH, DiscordGameEventType::combatSkillChanged),
@@ -72,7 +73,7 @@ public enum DiscordGameEventType
 	TRAINING_COOKING(COOKING),
 	TRAINING_WOODCUTTING(WOODCUTTING),
 	TRAINING_FLETCHING(FLETCHING),
-	TRAINING_FISHING(FISHING),
+	TRAINING_FISHING(FISHING, 1),
 	TRAINING_FIREMAKING(FIREMAKING),
 	TRAINING_CRAFTING(CRAFTING),
 	TRAINING_SMITHING(SMITHING),
@@ -89,15 +90,18 @@ public enum DiscordGameEventType
 	private Skill skill;
 	private String imageKey;
 	private String details;
+	@Setter
+	private String state;
 	private boolean trackTime = true;
 	private boolean considerDelay = true;
 	private Function<DiscordGameEventType, Boolean> isChanged = (l) -> true;
 	private int priority = 0;
 
-	DiscordGameEventType(String details, String minigame, boolean considerDelay, boolean trackTime)
+	DiscordGameEventType(String details, String minigame, int priority, boolean considerDelay, boolean trackTime)
 	{
 		this.imageKey = getImageKey(minigame);
 		this.details = details;
+		this.priority = priority;
 		this.considerDelay = considerDelay;
 		this.trackTime = trackTime;
 	}
@@ -129,6 +133,13 @@ public enum DiscordGameEventType
 	{
 		this.imageKey = getImageKey(skill);
 		this.details = training(skill);
+	}
+
+	DiscordGameEventType(Skill skill, int priority)
+	{
+		this.imageKey = getImageKey(skill);
+		this.details = training(skill);
+		this.priority = priority;
 	}
 
 	private static String getImageKey(final Skill skill)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordGameEventType.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordGameEventType.java
@@ -60,6 +60,7 @@ public enum DiscordGameEventType
 {
 	IN_GAME("In Game", false, true),
 	IN_MENU("In Menu", false, false),
+	RAID("In Raid", "raids", false, true),
 	TRAINING_ATTACK(ATTACK, DiscordGameEventType::combatSkillChanged),
 	TRAINING_DEFENCE(DEFENCE, DiscordGameEventType::combatSkillChanged),
 	TRAINING_STRENGTH(STRENGTH, DiscordGameEventType::combatSkillChanged),
@@ -92,6 +93,14 @@ public enum DiscordGameEventType
 	private boolean considerDelay = true;
 	private Function<DiscordGameEventType, Boolean> isChanged = (l) -> true;
 	private int priority = 0;
+
+	DiscordGameEventType(String details, String minigame, boolean considerDelay, boolean trackTime)
+	{
+		this.imageKey = getImageKey(minigame);
+		this.details = details;
+		this.considerDelay = considerDelay;
+		this.trackTime = trackTime;
+	}
 
 	DiscordGameEventType(String details, boolean considerDelay, boolean trackTime)
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordGameEventType.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordGameEventType.java
@@ -60,8 +60,8 @@ import static net.runelite.api.Skill.WOODCUTTING;
 @Getter
 public enum DiscordGameEventType
 {
-	IN_GAME("In Game", false),
-	IN_MENU("In Menu", false),
+	IN_GAME("In Game", false, true),
+	IN_MENU("In Menu", false, false),
 	TRAINING_ATTACK(training(ATTACK), DiscordGameEventType::combatSkillChanged),
 	TRAINING_DEFENCE(training(DEFENCE), DiscordGameEventType::combatSkillChanged),
 	TRAINING_STRENGTH(training(STRENGTH), DiscordGameEventType::combatSkillChanged),
@@ -89,14 +89,16 @@ public enum DiscordGameEventType
 	private static final Set<Skill> COMBAT_SKILLS = Sets.newHashSet(ATTACK, STRENGTH, DEFENCE, HITPOINTS, SLAYER, RANGED, MAGIC);
 	private final String state;
 	private String details;
+	private boolean trackTime = true;
 	private boolean considerDelay = true;
 	private Function<DiscordGameEventType, Boolean> isChanged = (l) -> true;
 	private int priority = 0;
 
-	DiscordGameEventType(String state, boolean considerDelay)
+	DiscordGameEventType(String state, boolean considerDelay, boolean trackTime)
 	{
 		this.state = state;
 		this.considerDelay = considerDelay;
+		this.trackTime = trackTime;
 	}
 
 	DiscordGameEventType(String state, int priority, Function<DiscordGameEventType, Boolean> isChanged)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordPlugin.java
@@ -30,16 +30,23 @@ import com.google.inject.Provides;
 import java.time.temporal.ChronoUnit;
 import java.util.HashMap;
 import java.util.Map;
+import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
+import net.runelite.api.Experience;
 import net.runelite.api.GameState;
 import net.runelite.api.Skill;
+import net.runelite.api.Varbits;
+import net.runelite.api.events.ChatMessage;
 import net.runelite.api.events.ExperienceChanged;
 import net.runelite.api.events.GameStateChanged;
+import net.runelite.api.events.GameTick;
+import net.runelite.api.events.VarbitChanged;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.discord.DiscordService;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.task.Schedule;
+import net.runelite.client.util.StackFormatter;
 
 @PluginDescriptor(
 	name = "Discord"
@@ -58,6 +65,9 @@ public class DiscordPlugin extends Plugin
 	private final DiscordState discordState = new DiscordState();
 	private Map<Skill, Integer> skillExp = new HashMap<>();
 	private boolean loggedIn = false;
+
+	private boolean raidInProgress = false;
+	private boolean inRaidChambers = false;
 
 	@Provides
 	private DiscordConfig provideConfig(ConfigManager configManager)
@@ -99,7 +109,44 @@ public class DiscordPlugin extends Plugin
 
 		if (discordGameEventType != null)
 		{
-			discordState.triggerEvent(discordGameEventType, config.actionDelay());
+			triggerEvent(discordGameEventType, config.actionDelay();
+		}
+	}
+
+	@Subscribe
+	public void onChatMessage(ChatMessage event)
+	{
+		// Raid
+		if (inRaidChambers && event.getType() == ChatMessageType.CLANCHAT_INFO)
+		{
+			String message = event.getMessage().replaceAll("<[^>]*>", "");
+
+			if (message.startsWith("The raid has begun!"))
+			{
+				raidInProgress = true;
+			}
+		}
+	}
+
+	@Subscribe
+	public void onVarbitChange(VarbitChanged event)
+	{
+		// Raid
+		boolean setting = client.getSetting(Varbits.IN_RAID) == 1;
+
+		if (inRaidChambers != setting)
+		{
+			inRaidChambers = setting;
+		}
+	}
+
+	@Subscribe
+	public void onGameTick(GameTick event)
+	{
+		// Raid
+		if (raidInProgress)
+		{
+			checkIfInRaid();
 		}
 	}
 
@@ -130,12 +177,40 @@ public class DiscordPlugin extends Plugin
 		{
 			skillExp.clear();
 			loggedIn = false;
-			discordState.triggerEvent(DiscordGameEventType.IN_MENU, config.actionDelay());
+			triggerEvent(DiscordGameEventType.IN_MENU, config.actionDelay());
 		}
 		else if (client.getGameState() == GameState.LOGGED_IN && (force || !loggedIn))
 		{
 			loggedIn = true;
-			discordState.triggerEvent(DiscordGameEventType.IN_GAME, config.actionDelay());
+			triggerEvent(DiscordGameEventType.IN_GAME, config.actionDelay());
+		}
+	}
+
+	private void triggerEvent(DiscordGameEventType type, int delay)
+	{
+		triggerEvent(type, delay, "");
+	}
+
+	private void triggerEvent(DiscordGameEventType type, int delay, String state)
+	{
+		discordState.triggerEvent(type, delay, state);
+	}
+
+	private void checkIfInRaid()
+	{
+		if (inRaidChambers)
+		{
+			// Raid has started, triggering raid event
+			int totalPoints = client.getSetting(Varbits.TOTAL_POINTS);
+			int personalPoints = client.getSetting(Varbits.PERSONAL_POINTS);
+
+			triggerEvent(DiscordGameEventType.RAID, config.actionDelay(), "Points: " + totalPoints + " (" + personalPoints + ")");
+		}
+		else
+		{
+			// No longer in raid
+			raidInProgress = false;
+			updateGameStatus(client.getGameState(), true);
 		}
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordPlugin.java
@@ -109,7 +109,10 @@ public class DiscordPlugin extends Plugin
 
 		if (discordGameEventType != null)
 		{
-			triggerEvent(discordGameEventType, config.actionDelay();
+			int level = client.getRealSkillLevel(event.getSkill());
+			int xpToLevel = Experience.getXpForLevel(level + 1) - client.getSkillExperience(event.getSkill());
+
+			triggerEvent(discordGameEventType, config.actionDelay(), "Level: " + level + " (" + StackFormatter.quantityToStackSize(xpToLevel) + " till " + (level + 1) + ")");
 		}
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordState.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordState.java
@@ -35,7 +35,7 @@ import net.runelite.client.discord.DiscordService;
 public class DiscordState
 {
 	private final List<DiscordGameEventType> lastQueue = new ArrayList<>();
-	private DiscordGameEventType lastEvent;
+	private DiscordGameEventType event;
 	private Instant startOfAction;
 	private Instant lastAction;
 	private DiscordPresence lastPresence;
@@ -44,7 +44,7 @@ public class DiscordState
 	void reset()
 	{
 		lastQueue.clear();
-		lastEvent = null;
+		event = null;
 		startOfAction = null;
 		lastAction = null;
 		lastPresence = null;
@@ -63,7 +63,7 @@ public class DiscordState
 	void triggerEvent(final DiscordGameEventType eventType, int delay)
 	{
 		final boolean first = startOfAction == null;
-		final boolean changed = eventType != lastEvent && eventType.getIsChanged().apply(lastEvent);
+		final boolean changed = eventType != event && eventType.getIsChanged().apply(event);
 		boolean reset = false;
 
 		if (first)
@@ -103,15 +103,17 @@ public class DiscordState
 		lastAction = Instant.now();
 		final DiscordGameEventType newEvent = lastQueue.get(lastQueue.size() - 1);
 
-		if (lastEvent != newEvent)
+		if (event != newEvent)
 		{
-			lastEvent = newEvent;
+			event = newEvent;
 
-			lastPresence = DiscordPresence.builder()
-				.state(lastEvent.getState())
-				.details(lastEvent.getDetails())
-				.startTimestamp(startOfAction)
-				.build();
+			final DiscordPresence.DiscordPresenceBuilder discordPresenceBuilder = DiscordPresence.builder()
+				.state(event.getState())
+				.details(event.getDetails());
+
+			lastPresence = eventType.isTrackTime()
+				? discordPresenceBuilder.startTimestamp(startOfAction).build()
+				: discordPresenceBuilder.build();
 
 			needsFlush = true;
 		}
@@ -126,11 +128,7 @@ public class DiscordState
 
 		final Duration actionTimeout = Duration.ofMinutes(timeout);
 
-		if (Instant.now().compareTo(lastAction.plus(actionTimeout)) >= 0)
-		{
-			return true;
-		}
+		return Instant.now().compareTo(lastAction.plus(actionTimeout)) >= 0;
 
-		return false;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordState.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordState.java
@@ -60,7 +60,7 @@ public class DiscordState
 		}
 	}
 
-	void triggerEvent(final DiscordGameEventType eventType, int delay)
+	void triggerEvent(final DiscordGameEventType eventType, int delay, String state)
 	{
 		final boolean first = startOfAction == null;
 		final boolean changed = eventType != event && eventType.getIsChanged().apply(event);
@@ -101,22 +101,18 @@ public class DiscordState
 		}
 
 		lastAction = Instant.now();
-		final DiscordGameEventType newEvent = lastQueue.get(lastQueue.size() - 1);
+		event = lastQueue.get(lastQueue.size() - 1);
 
-		if (event != newEvent)
-		{
-			event = newEvent;
+		final DiscordPresence.DiscordPresenceBuilder discordPresenceBuilder = DiscordPresence.builder()
+			.details(event.getDetails())
+			.state(state)
+			.smallImageKey(event.getImageKey());
 
-			final DiscordPresence.DiscordPresenceBuilder discordPresenceBuilder = DiscordPresence.builder()
-				.details(event.getDetails())
-				.smallImageKey(event.getImageKey());
+		lastPresence = eventType.isTrackTime()
+			? discordPresenceBuilder.startTimestamp(startOfAction).build()
+			: discordPresenceBuilder.build();
 
-			lastPresence = eventType.isTrackTime()
-				? discordPresenceBuilder.startTimestamp(startOfAction).build()
-				: discordPresenceBuilder.build();
-
-			needsFlush = true;
-		}
+		needsFlush = true;
 	}
 
 	boolean checkForTimeout(final int timeout)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordState.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordState.java
@@ -66,6 +66,9 @@ public class DiscordState
 		final boolean changed = eventType != event && eventType.getIsChanged().apply(event);
 		boolean reset = false;
 
+		// Set the state of the event
+		eventType.setState(state);
+
 		if (first)
 		{
 			reset = true;
@@ -105,7 +108,7 @@ public class DiscordState
 
 		final DiscordPresence.DiscordPresenceBuilder discordPresenceBuilder = DiscordPresence.builder()
 			.details(event.getDetails())
-			.state(state)
+			.state(event.getState())
 			.smallImageKey(event.getImageKey());
 
 		lastPresence = eventType.isTrackTime()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordState.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordState.java
@@ -108,8 +108,8 @@ public class DiscordState
 			event = newEvent;
 
 			final DiscordPresence.DiscordPresenceBuilder discordPresenceBuilder = DiscordPresence.builder()
-				.state(event.getState())
-				.details(event.getDetails());
+				.details(event.getDetails())
+				.smallImageKey(event.getImageKey());
 
 			lastPresence = eventType.isTrackTime()
 				? discordPresenceBuilder.startTimestamp(startOfAction).build()


### PR DESCRIPTION
### Detailed level information
- Replaces the double logo in discord with actual skilling icons
- Adds additional support for adding very detailed information such as Level/Exp till level

![skilling](https://user-images.githubusercontent.com/5454364/37247417-2d3c3ba4-2480-11e8-957d-937217d6e753.png)

### Raid support
- Adds support for when you start a raid
- Will display Total points as well as personal points

![raid](https://user-images.githubusercontent.com/5454364/37247416-2c3a188e-2480-11e8-9cdc-21d9d899970d.png)

[_Why I swapped details with state_](https://i.imgur.com/3Ifb0CD.png)

depends on #702 
