### PR TITLE
Fix dead fun weapon action clicks on player

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/MenuAction.java
+++ b/runelite-api/src/main/java/net/runelite/api/MenuAction.java
@@ -209,7 +209,10 @@ public enum MenuAction
 	 * Fifth menu action for a widget.
 	 */
 	WIDGET_FIFTH_OPTION(43),
-
+	/**
+	 * Menu action triggered by whacking, pelting or slashing a player.
+	 */
+	FUN_WEAPON(48),
 	/**
 	 * Default menu action for a widget.
 	 */


### PR DESCRIPTION
This will add a menu action for fun weapon actions like whacking with rubber chicken, pelting with snowballs and slashing with hunting knife.
Fixes #928 where the fun weapon menu entry on a player is a dead click, caused by the lookup menu entry from the hiscore plugin.