### PR TITLE
Fix drawing of player names on minimap

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsMinimapOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsMinimapOverlay.java
@@ -28,22 +28,23 @@ import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Graphics2D;
 import java.awt.Point;
-import java.awt.Polygon;
 import net.runelite.api.Player;
 import net.runelite.client.ui.overlay.Overlay;
+import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.OverlayPriority;
 import net.runelite.client.ui.overlay.OverlayUtil;
 
-public class PlayerIndicatorsOverlay extends Overlay
+public class PlayerIndicatorsMinimapOverlay extends Overlay
 {
 	private final PlayerIndicatorsService playerIndicatorsService;
 	private final PlayerIndicatorsConfig config;
 
-	PlayerIndicatorsOverlay(PlayerIndicatorsConfig config, PlayerIndicatorsService playerIndicatorsService)
+	PlayerIndicatorsMinimapOverlay(PlayerIndicatorsConfig config, PlayerIndicatorsService playerIndicatorsService)
 	{
 		this.config = config;
 		this.playerIndicatorsService = playerIndicatorsService;
+		setLayer(OverlayLayer.ABOVE_WIDGETS);
 		setPosition(OverlayPosition.DYNAMIC);
 		setPriority(OverlayPriority.HIGH);
 	}
@@ -57,22 +58,16 @@ public class PlayerIndicatorsOverlay extends Overlay
 
 	private void renderPlayerOverlay(Graphics2D graphics, Player actor, Color color)
 	{
-		if (config.drawTiles())
-		{
-			Polygon poly = actor.getCanvasTilePoly();
-			if (poly != null)
-			{
-				OverlayUtil.renderPolygon(graphics, poly, color);
-			}
-		}
-
 		final String name = actor.getName().replace('\u00A0', ' ');
-		net.runelite.api.Point textLocation = actor
-			.getCanvasTextLocation(graphics, name, actor.getLogicalHeight() + 40);
 
-		if (textLocation != null)
+		if (config.drawMinimapNames())
 		{
-			OverlayUtil.renderTextLocation(graphics, textLocation, name, color);
+			final net.runelite.api.Point minimapLocation = actor.getMinimapLocation();
+
+			if (minimapLocation != null)
+			{
+				OverlayUtil.renderTextLocation(graphics, minimapLocation, name, color);
+			}
 		}
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsPlugin.java
@@ -24,7 +24,9 @@
  */
 package net.runelite.client.plugins.playerindicators;
 
+import com.google.common.collect.Sets;
 import com.google.inject.Provides;
+import java.util.Collection;
 import javax.inject.Inject;
 import net.runelite.api.Client;
 import net.runelite.client.config.ConfigManager;
@@ -43,7 +45,7 @@ public class PlayerIndicatorsPlugin extends Plugin
 	@Inject
 	private PlayerIndicatorsConfig config;
 
-	PlayerIndicatorsOverlay playerIndicatorsOverlay;
+	private Collection<Overlay> overlays;
 
 	@Provides
 	PlayerIndicatorsConfig provideConfig(ConfigManager configManager)
@@ -54,12 +56,19 @@ public class PlayerIndicatorsPlugin extends Plugin
 	@Override
 	protected void startUp() throws Exception
 	{
-		playerIndicatorsOverlay = new PlayerIndicatorsOverlay(client, config);
+		final PlayerIndicatorsService playerIndicatorsService =
+			new PlayerIndicatorsService(client, config);
+		final PlayerIndicatorsOverlay playerIndicatorsOverlay =
+			new PlayerIndicatorsOverlay(config, playerIndicatorsService);
+		final PlayerIndicatorsMinimapOverlay playerIndicatorsMinimapOverlay =
+			new PlayerIndicatorsMinimapOverlay(config, playerIndicatorsService);
+
+		overlays = Sets.newHashSet(playerIndicatorsOverlay, playerIndicatorsMinimapOverlay);
 	}
 
 	@Override
-	public Overlay getOverlay()
+	public Collection<Overlay> getOverlays()
 	{
-		return playerIndicatorsOverlay;
+		return overlays;
 	}
 }


### PR DESCRIPTION
Move drawing player names on minimap to separate overlay, so the minimap
names can be rendered over minimap in resizeable mode.

Fixes #940

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>