### PR TITLE
Fix spec orb regen timing

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/regenmeter/RegenMeterPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/regenmeter/RegenMeterPlugin.java
@@ -46,7 +46,7 @@ import net.runelite.client.ui.overlay.Overlay;
 @PluginDescriptor(name = "Regeneration Meter")
 public class RegenMeterPlugin extends Plugin
 {
-	private static final int SPEC_REGEN_TICKS = 51;
+	private static final int SPEC_REGEN_TICKS = 50;
 	private static final int NORMAL_HP_REGEN_TICKS = 100;
 
 	@Inject


### PR DESCRIPTION
Spec orb regen was off by 1 tick, which made it get more and more off as the regen went on

![old vs new](https://thumbs.gfycat.com/NecessaryIlliterateKiskadee-size_restricted.gif)


After regening from 0 to 100 the regen progress bar was off by almost 1/4 of the bar