### PR TITLE
Fix NPEs on startup from PlayerIndicators

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsMinimapOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsMinimapOverlay.java
@@ -28,6 +28,8 @@ import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Graphics2D;
 import java.awt.Point;
+import javax.inject.Inject;
+import javax.inject.Singleton;
 import net.runelite.api.Player;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
@@ -35,12 +37,14 @@ import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.OverlayPriority;
 import net.runelite.client.ui.overlay.OverlayUtil;
 
+@Singleton
 public class PlayerIndicatorsMinimapOverlay extends Overlay
 {
 	private final PlayerIndicatorsService playerIndicatorsService;
 	private final PlayerIndicatorsConfig config;
 
-	PlayerIndicatorsMinimapOverlay(PlayerIndicatorsConfig config, PlayerIndicatorsService playerIndicatorsService)
+	@Inject
+	private PlayerIndicatorsMinimapOverlay(PlayerIndicatorsConfig config, PlayerIndicatorsService playerIndicatorsService)
 	{
 		this.config = config;
 		this.playerIndicatorsService = playerIndicatorsService;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsOverlay.java
@@ -29,18 +29,22 @@ import java.awt.Dimension;
 import java.awt.Graphics2D;
 import java.awt.Point;
 import java.awt.Polygon;
+import javax.inject.Inject;
+import javax.inject.Singleton;
 import net.runelite.api.Player;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.OverlayPriority;
 import net.runelite.client.ui.overlay.OverlayUtil;
 
+@Singleton
 public class PlayerIndicatorsOverlay extends Overlay
 {
 	private final PlayerIndicatorsService playerIndicatorsService;
 	private final PlayerIndicatorsConfig config;
 
-	PlayerIndicatorsOverlay(PlayerIndicatorsConfig config, PlayerIndicatorsService playerIndicatorsService)
+	@Inject
+	private PlayerIndicatorsOverlay(PlayerIndicatorsConfig config, PlayerIndicatorsService playerIndicatorsService)
 	{
 		this.config = config;
 		this.playerIndicatorsService = playerIndicatorsService;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsPlugin.java
@@ -28,7 +28,6 @@ import com.google.common.collect.Sets;
 import com.google.inject.Provides;
 import java.util.Collection;
 import javax.inject.Inject;
-import net.runelite.api.Client;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
@@ -40,12 +39,10 @@ import net.runelite.client.ui.overlay.Overlay;
 public class PlayerIndicatorsPlugin extends Plugin
 {
 	@Inject
-	private Client client;
+	private PlayerIndicatorsOverlay playerIndicatorsOverlay;
 
 	@Inject
-	private PlayerIndicatorsConfig config;
-
-	private Collection<Overlay> overlays;
+	private PlayerIndicatorsMinimapOverlay playerIndicatorsMinimapOverlay;
 
 	@Provides
 	PlayerIndicatorsConfig provideConfig(ConfigManager configManager)
@@ -54,21 +51,8 @@ public class PlayerIndicatorsPlugin extends Plugin
 	}
 
 	@Override
-	protected void startUp() throws Exception
-	{
-		final PlayerIndicatorsService playerIndicatorsService =
-			new PlayerIndicatorsService(client, config);
-		final PlayerIndicatorsOverlay playerIndicatorsOverlay =
-			new PlayerIndicatorsOverlay(config, playerIndicatorsService);
-		final PlayerIndicatorsMinimapOverlay playerIndicatorsMinimapOverlay =
-			new PlayerIndicatorsMinimapOverlay(config, playerIndicatorsService);
-
-		overlays = Sets.newHashSet(playerIndicatorsOverlay, playerIndicatorsMinimapOverlay);
-	}
-
-	@Override
 	public Collection<Overlay> getOverlays()
 	{
-		return overlays;
+		return Sets.newHashSet(playerIndicatorsOverlay, playerIndicatorsMinimapOverlay);
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsService.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsService.java
@@ -26,15 +26,19 @@ package net.runelite.client.plugins.playerindicators;
 
 import java.awt.Color;
 import java.util.function.BiConsumer;
+import javax.inject.Inject;
+import javax.inject.Singleton;
 import net.runelite.api.Client;
 import net.runelite.api.Player;
 
+@Singleton
 public class PlayerIndicatorsService
 {
 	private final Client client;
 	private final PlayerIndicatorsConfig config;
 
-	PlayerIndicatorsService(Client client, PlayerIndicatorsConfig config)
+	@Inject
+	private PlayerIndicatorsService(Client client, PlayerIndicatorsConfig config)
 	{
 		this.config = config;
 		this.client = client;

--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSPlayerMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSPlayerMixin.java
@@ -36,6 +36,7 @@ import net.runelite.api.mixins.Inject;
 import net.runelite.api.mixins.Mixin;
 import net.runelite.api.mixins.Shadow;
 import net.runelite.rs.api.RSClient;
+import net.runelite.rs.api.RSName;
 import net.runelite.rs.api.RSPlayer;
 
 @Mixin(RSPlayer.class)
@@ -48,7 +49,14 @@ public abstract class RSPlayerMixin implements RSPlayer
 	@Override
 	public String getName()
 	{
-		String name = getRsName().getName();
+		final RSName rsName = getRsName();
+
+		if (rsName == null)
+		{
+			return null;
+		}
+
+		String name = rsName.getName();
 
 		if (name == null)
 		{


### PR DESCRIPTION
- Add null check for getRsName, because when logging to game, sometimes it
is null, and throws NPE.
- Change the PlayerIndicators model to use injection
- Create new set from overlays when getOverlays is called

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>