### PR TITLE
Use a fieldhook for MenuEntryAdded events

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/callback/Hooks.java
+++ b/runelite-client/src/main/java/net/runelite/client/callback/Hooks.java
@@ -48,7 +48,6 @@ import net.runelite.api.WorldMapManager;
 import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.events.ChatMessage;
 import net.runelite.api.events.GameTick;
-import net.runelite.api.events.MenuEntryAdded;
 import net.runelite.api.events.MenuOptionClicked;
 import net.runelite.api.events.ProjectileMoved;
 import net.runelite.api.events.SetMessage;
@@ -332,18 +331,6 @@ public class Hooks
 		log.debug("Menu action clicked: {}", menuOptionClicked);
 
 		eventBus.post(menuOptionClicked);
-	}
-
-	public static void addMenuEntry(String option, String target, int type, int identifier, int param0, int param1)
-	{
-		if (log.isTraceEnabled())
-		{
-			log.trace("Menu entry added {} {}", option, target);
-		}
-
-		MenuEntryAdded menuEntry = new MenuEntryAdded(option, target, type, identifier, param0, param1);
-
-		eventBus.post(menuEntry);
 	}
 
 	public static void addChatMessage(int type, String name, String message, String sender)

--- a/runelite-mixins/src/main/java/net/runelite/mixins/MenuEntryEventMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/MenuEntryEventMixin.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2018, SomeoneWithAnInternetConnection
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package net.runelite.mixins;
+
+import net.runelite.api.events.MenuEntryAdded;
+import net.runelite.api.mixins.FieldHook;
+import net.runelite.api.mixins.Inject;
+import net.runelite.api.mixins.Mixin;
+import net.runelite.api.mixins.Shadow;
+import static net.runelite.client.callback.Hooks.eventBus;
+import net.runelite.rs.api.RSClient;
+
+
+@Mixin(RSClient.class)
+public abstract class MenuEntryEventMixin implements RSClient
+{
+	@Shadow("clientInstance")
+	private static RSClient client;
+
+	@Inject
+	private static int oldMenuEntryCount;
+
+	@FieldHook("menuOptionCount")
+	@Inject
+	public static void onMenuOptionsChanged(int idx)
+	{
+		int newCount = client.getMenuOptionCount();
+
+		if (newCount == oldMenuEntryCount + 1)
+		{
+			MenuEntryAdded event = new MenuEntryAdded(
+					client.getMenuOptions()[newCount - 1],
+					client.getMenuTargets()[newCount - 1],
+					client.getMenuTypes()[newCount - 1],
+					client.getMenuIdentifiers()[newCount - 1],
+					client.getMenuActionParams0()[newCount - 1],
+					client.getMenuActionParams1()[newCount - 1]
+			);
+
+			eventBus.post(event);
+		}
+
+		oldMenuEntryCount = newCount;
+	}
+}

--- a/runescape-client/src/main/java/class169.java
+++ b/runescape-client/src/main/java/class169.java
@@ -79,7 +79,6 @@ public abstract class class169 {
       garbageValue = "454714155"
    )
    @Export("addMenuEntry")
-   @Hook(value = "addMenuEntry", end = true)
    public static final void addMenuEntry(String var0, String var1, int var2, int var3, int var4, int var5) {
       Size.method193(var0, var1, var2, var3, var4, var5, false);
    }


### PR DESCRIPTION
The previously-hooked addMenuEntry method in runescape-client is one that occasionally gets inlined which can cause weird breakages like MenuEntryAdded not getting fired for menu entries defined in
ItemDefinitions. Hooking the menuOptionCount field should be more reliable.

Fixes #936