### PR TITLE
More options for fairy rings in the menu entry swap plugin

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/FairyRingSwap.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/FairyRingSwap.java
@@ -1,3 +1,28 @@
+/*
+ * Copyright (c) 2018, Adam <Adam@sigterm.info>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package net.runelite.client.plugins.menuentryswapper;
 
 public enum FairyRingSwap

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/FairyRingSwap.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/FairyRingSwap.java
@@ -1,0 +1,8 @@
+package net.runelite.client.plugins.menuentryswapper;
+
+public enum FairyRingSwap
+{
+	ZANARIS,
+	CONFIGURE,
+	LAST_DESTINATION
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -125,13 +125,13 @@ public interface MenuEntrySwapperConfig extends Config
 
 	@ConfigItem(
 		position = 8,
-		keyName = "swapLastDestination",
-		name = "Last-destination (XXX)",
-		description = "Swap Zanaris with Last-destination on Fairy ring"
+		keyName = "swapFairyRing",
+		name = "Swap Fairy Ring",
+		description = "Swap Zanaris with Configure or Last-Destination on Fairy ring"
 	)
-	default boolean swapLastDestination()
+	default FairyRingSwap swapFairyRing()
 	{
-		return true;
+		return FairyRingSwap.ZANARIS;
 	}
 
 	@ConfigItem(

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -125,17 +125,6 @@ public interface MenuEntrySwapperConfig extends Config
 
 	@ConfigItem(
 		position = 8,
-		keyName = "swapFairyRing",
-		name = "Swap Fairy Ring",
-		description = "Swap Zanaris with Configure or Last-Destination on Fairy ring"
-	)
-	default FairyRingSwap swapFairyRing()
-	{
-		return FairyRingSwap.ZANARIS;
-	}
-
-	@ConfigItem(
-		position = 9,
 		keyName = "swapBoxTrap",
 		name = "Reset",
 		description = "Swap Check with Reset on box trap"
@@ -146,7 +135,7 @@ public interface MenuEntrySwapperConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 10,
+		position = 9,
 		keyName = "swapCatacombEntrance",
 		name = "Catacomb entrance",
 		description = "Swap Read with Investigate on Catacombs of Kourend entrance"
@@ -157,7 +146,7 @@ public interface MenuEntrySwapperConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 11,
+		position = 10,
 		keyName = "swapTeleportItem",
 		name = "Teleport item",
 		description = "Swap Wear, Wield with Rub, Teleport on teleport item<br>Example: Amulet of glory, Ardougne cloak, Chronicle"
@@ -165,5 +154,16 @@ public interface MenuEntrySwapperConfig extends Config
 	default boolean swapTeleportItem()
 	{
 		return true;
+	}
+
+	@ConfigItem(
+		position = 11,
+		keyName = "swapFairyRing",
+		name = "Fairy Rings",
+		description = "Swap Zanaris with Configure or Last-Destination on Fairy rings"
+	)
+	default FairyRingSwap swapFairyRing()
+	{
+		return FairyRingSwap.ZANARIS;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -111,10 +111,6 @@ public class MenuEntrySwapperPlugin extends Plugin
 		{
 			swap("home", option, target, true);
 		}
-		else if (config.swapLastDestination() && option.equals("zanaris"))
-		{
-			swap("last-destination (", option, target, false);
-		}
 		else if (config.swapBoxTrap() && option.equals("check"))
 		{
 			swap("reset", option, target, true);
@@ -131,6 +127,20 @@ public class MenuEntrySwapperPlugin extends Plugin
 		else if (config.swapTeleportItem() && option.equals("wield"))
 		{
 			swap("teleport", option, target, true);
+		}
+		else if (option.equals("zanaris") || option.equals("configure"))
+		{
+			switch (config.swapFairyRing())
+			{
+				case LAST_DESTINATION:
+					swap("last-destination (", option, target, false);
+				case CONFIGURE:
+					swap("configure", option, target, false);
+				case ZANARIS:
+					swap("zanaris", option, target, false);
+				default:
+					break;
+			}
 		}
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -134,10 +134,13 @@ public class MenuEntrySwapperPlugin extends Plugin
 			{
 				case LAST_DESTINATION:
 					swap("last-destination (", option, target, false);
+					break;
 				case CONFIGURE:
 					swap("configure", option, target, false);
+					break;
 				case ZANARIS:
 					swap("zanaris", option, target, false);
+					break;
 				default:
 					break;
 			}


### PR DESCRIPTION
Allows the user to select between the options for fairy rings beyond last-destination. This mirrors functionality in other clients.