### PR TITLE
Fix agility plugin and herbiboar plugin codestyle

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/agilityplugin/AgilityPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/agilityplugin/AgilityPlugin.java
@@ -70,73 +70,73 @@ public class AgilityPlugin extends Plugin
 	// This code, brought to you, in part, by the letters C and V
 	// ... and the words "search" and "replace"
 	@Subscribe
-	public void GameObjectSpawned(GameObjectSpawned event)
+	public void onGameObjectSpawned(GameObjectSpawned event)
 	{
 		onTileObject(event.getTile(), null, event.getGameObject());
 	}
 
 	@Subscribe
-	public void GameObjectChanged(GameObjectChanged event)
+	public void onGameObjectChanged(GameObjectChanged event)
 	{
 		onTileObject(event.getTile(), event.getPrevious(), event.getGameObject());
 	}
 
 	@Subscribe
-	public void GameObjectDeSpawned(GameObjectDespawned event)
+	public void onGameObjectDeSpawned(GameObjectDespawned event)
 	{
 		onTileObject(event.getTile(), event.getGameObject(), null);
 	}
 
 	@Subscribe
-	public void GroundObjectSpawned(GroundObjectSpawned event)
+	public void onGroundObjectSpawned(GroundObjectSpawned event)
 	{
 		onTileObject(event.getTile(), null, event.getGroundObject());
 	}
 
 	@Subscribe
-	public void GroundObjectChanged(GroundObjectChanged event)
+	public void onGroundObjectChanged(GroundObjectChanged event)
 	{
 		onTileObject(event.getTile(), event.getPrevious(), event.getGroundObject());
 	}
 
 	@Subscribe
-	public void GroundObjectDeSpawned(GroundObjectDespawned event)
+	public void onGroundObjectDeSpawned(GroundObjectDespawned event)
 	{
 		onTileObject(event.getTile(), event.getGroundObject(), null);
 	}
 
 	@Subscribe
-	public void WallObjectSpawned(WallObjectSpawned event)
+	public void onWallObjectSpawned(WallObjectSpawned event)
 	{
 		onTileObject(event.getTile(), null, event.getWallObject());
 	}
 
 	@Subscribe
-	public void WallObjectChanged(WallObjectChanged event)
+	public void onWallObjectChanged(WallObjectChanged event)
 	{
 		onTileObject(event.getTile(), event.getPrevious(), event.getWallObject());
 	}
 
 	@Subscribe
-	public void WallObjectDeSpawned(WallObjectDespawned event)
+	public void onWallObjectDeSpawned(WallObjectDespawned event)
 	{
 		onTileObject(event.getTile(), event.getWallObject(), null);
 	}
 
 	@Subscribe
-	public void DecorativeObjectSpawned(DecorativeObjectSpawned event)
+	public void onDecorativeObjectSpawned(DecorativeObjectSpawned event)
 	{
 		onTileObject(event.getTile(), null, event.getDecorativeObject());
 	}
 
 	@Subscribe
-	public void DecorativeObjectChanged(DecorativeObjectChanged event)
+	public void onDecorativeObjectChanged(DecorativeObjectChanged event)
 	{
 		onTileObject(event.getTile(), event.getPrevious(), event.getDecorativeObject());
 	}
 
 	@Subscribe
-	public void DecorativeObjectDeSpawned(DecorativeObjectDespawned event)
+	public void onDecorativeObjectDeSpawned(DecorativeObjectDespawned event)
 	{
 		onTileObject(event.getTile(), event.getDecorativeObject(), null);
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/herbiboars/HerbiboarOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/herbiboars/HerbiboarOverlay.java
@@ -31,7 +31,6 @@ import java.awt.Graphics2D;
 import java.awt.geom.Area;
 import java.util.Map;
 import java.util.Set;
-import net.runelite.api.Client;
 import net.runelite.api.Tile;
 import net.runelite.api.TileObject;
 import net.runelite.api.coords.WorldPoint;
@@ -42,16 +41,14 @@ import net.runelite.client.ui.overlay.OverlayUtil;
 
 class HerbiboarOverlay extends Overlay
 {
-	private final Client client;
 	private final HerbiboarPlugin plugin;
 	private final HerbiboarConfig config;
 
 	@Inject
-	public HerbiboarOverlay(Client client, HerbiboarPlugin plugin, HerbiboarConfig config)
+	public HerbiboarOverlay(HerbiboarPlugin plugin, HerbiboarConfig config)
 	{
 		setPosition(OverlayPosition.DYNAMIC);
 		setLayer(OverlayLayer.ABOVE_WIDGETS);
-		this.client = client;
 		this.plugin = plugin;
 		this.config = config;
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/herbiboars/HerbiboarOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/herbiboars/HerbiboarOverlay.java
@@ -40,14 +40,14 @@ import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.OverlayUtil;
 
-class HerbiboarsOverlay extends Overlay
+class HerbiboarOverlay extends Overlay
 {
 	private final Client client;
-	private final Herbiboars plugin;
+	private final HerbiboarPlugin plugin;
 	private final HerbiboarConfig config;
 
 	@Inject
-	public HerbiboarsOverlay(Client client, Herbiboars plugin, HerbiboarConfig config)
+	public HerbiboarOverlay(Client client, HerbiboarPlugin plugin, HerbiboarConfig config)
 	{
 		setPosition(OverlayPosition.DYNAMIC);
 		setLayer(OverlayLayer.ABOVE_WIDGETS);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/herbiboars/HerbiboarPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/herbiboars/HerbiboarPlugin.java
@@ -98,9 +98,6 @@ public class HerbiboarPlugin extends Plugin
 	@Inject
 	private HerbiboarOverlay overlay;
 
-	@Inject
-	private HerbiboarConfig config;;
-
 	@Override
 	public Overlay getOverlay()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/herbiboars/HerbiboarPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/herbiboars/HerbiboarPlugin.java
@@ -61,9 +61,9 @@ import net.runelite.client.ui.overlay.Overlay;
 
 @Slf4j
 @PluginDescriptor(
-	name = "Herbiboars"
+	name = "Herbiboar"
 )
-public class Herbiboars extends Plugin
+public class HerbiboarPlugin extends Plugin
 {
 	private static final List<WorldPoint> END_LOCATIONS = Arrays.asList(
 		new WorldPoint(3693, 3798, 0),
@@ -96,7 +96,7 @@ public class Herbiboars extends Plugin
 	private Client client;
 
 	@Inject
-	private HerbiboarsOverlay overlay;
+	private HerbiboarOverlay overlay;
 
 	@Inject
 	private HerbiboarConfig config;;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/herbiboars/Herbiboars.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/herbiboars/Herbiboars.java
@@ -232,37 +232,37 @@ public class Herbiboars extends Plugin
 	}
 
 	@Subscribe
-	public void GameObjectSpawned(GameObjectSpawned event)
+	public void onGameObjectSpawned(GameObjectSpawned event)
 	{
 		onGameObject(event.getTile(), null, event.getGameObject());
 	}
 
 	@Subscribe
-	public void GameObjectChanged(GameObjectChanged event)
+	public void onGameObjectChanged(GameObjectChanged event)
 	{
 		onGameObject(event.getTile(), event.getPrevious(), event.getGameObject());
 	}
 
 	@Subscribe
-	public void GameObjectDeSpawned(GameObjectDespawned event)
+	public void onGameObjectDeSpawned(GameObjectDespawned event)
 	{
 		onGameObject(event.getTile(), event.getGameObject(), null);
 	}
 
 	@Subscribe
-	public void GroundObjectSpawned(GroundObjectSpawned event)
+	public void onGroundObjectSpawned(GroundObjectSpawned event)
 	{
 		onGroundObject(event.getTile(), null, event.getGroundObject());
 	}
 
 	@Subscribe
-	public void GroundObjectChanged(GroundObjectChanged event)
+	public void onGroundObjectChanged(GroundObjectChanged event)
 	{
 		onGroundObject(event.getTile(), event.getPrevious(), event.getGroundObject());
 	}
 
 	@Subscribe
-	public void GroundObjectDeSpawned(GroundObjectDespawned event)
+	public void onGroundObjectDeSpawned(GroundObjectDespawned event)
 	{
 		onGroundObject(event.getTile(), event.getGroundObject(), null);
 	}


### PR DESCRIPTION
- Remove unused variables in Herbiboar plugin
- Rename Herbiboars to HerbiboarPlugin
- Rename HerbiboarsOverlay to HerbiboarOverlay
- Rename "Herbiboars" to "Herbiboar" plugin name
- Fix Herbiboar plugin naming conventions
- Fix AgilityPlugin naming conventions