### PR TITLE
Fix herbiboar plugin NPE on startup

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/herbiboars/Herbiboars.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/herbiboars/Herbiboars.java
@@ -327,7 +327,7 @@ public class Herbiboars extends Plugin
 
 	private boolean checkArea()
 	{
-		return Arrays.stream(client.getMapRegions())
+		return client.getMapRegions() != null && Arrays.stream(client.getMapRegions())
 				.filter(x -> Arrays.stream(HERBIBOAR_REGIONS).anyMatch(y -> y == x))
 				.toArray().length > 0;
 	}


### PR DESCRIPTION
Add null check for client.getMapRegions because during plugin startup
when game is loading, they are null.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>