### PR TITLE
Do not display stack in price tooltips

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemprices/ItemPricesOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemprices/ItemPricesOverlay.java
@@ -217,10 +217,6 @@ class ItemPricesOverlay extends Overlay
 
 	private String stackValueText(int qty, int gePrice, int haValue)
 	{
-		if (qty > 1)
-		{
-			itemStringBuilder.append("(").append(qty).append(") ");
-		}
 		if (gePrice > 0)
 		{
 			itemStringBuilder.append("EX: ")


### PR DESCRIPTION
Displaying amount of items in stack is unnecessary because the
information is shown on item itself, so it is just making the tooltip
unnecessary big.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>