### PR TITLE
Add star to ground items

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/Varbits.java
+++ b/runelite-api/src/main/java/net/runelite/api/Varbits.java
@@ -249,7 +249,7 @@ public enum Varbits
 	BLAST_FURNACE_RUNITE_BAR(946),
 	BLAST_FURNACE_SILVER_BAR(948),
 	BLAST_FURNACE_GOLD_BAR(947),
-
+	
 	BLAST_FURNACE_COFFER(5357),
 
 	/**
@@ -261,7 +261,13 @@ public enum Varbits
 	/**
 	 * Multicombat area
 	 */
-	MULTICOMBAT_AREA(4605);
+	MULTICOMBAT_AREA(4605),
+
+	/**
+	 * Kingdom Management
+	 */
+	KINGDOM_FAVOR(72),
+	KINGDOM_COFFER(74);
 
 	/**
 	 * varbit id

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
@@ -265,6 +265,7 @@ public class GroundItemsOverlay extends Overlay
 					if (plugin.isHighlighted(item.getName()))
 					{
 						textColor = config.highlightedColor();
+						itemStringBuilder.insert(0, "★ ");
 					}
 
 					String itemString = itemStringBuilder.toString();
@@ -284,22 +285,22 @@ public class GroundItemsOverlay extends Overlay
 					{
 						// Hidden box
 						itemHiddenBox = new Rectangle
-						(
-							screenX + fm.stringWidth(itemString),
-							screenY - (fm.getHeight() / 2) - fm.getDescent(),
-							RECTANGLE_SIZE,
-							fm.getHeight() / 2
-						);
+							(
+								screenX + fm.stringWidth(itemString),
+								screenY - (fm.getHeight() / 2) - fm.getDescent(),
+								RECTANGLE_SIZE,
+								fm.getHeight() / 2
+							);
 						plugin.getHiddenBoxes().put(itemHiddenBox, item.getName());
 
 						// Highlight box
 						itemHighlightBox = new Rectangle
-						(
-							screenX + fm.stringWidth(itemString) + RECTANGLE_SIZE + 2,
-							screenY - (fm.getHeight() / 2) - fm.getDescent(),
-							RECTANGLE_SIZE,
-							fm.getHeight() / 2
-						);
+							(
+								screenX + fm.stringWidth(itemString) + RECTANGLE_SIZE + 2,
+								screenY - (fm.getHeight() / 2) - fm.getDescent(),
+								RECTANGLE_SIZE,
+								fm.getHeight() / 2
+							);
 						plugin.getHighlightBoxes().put(itemHighlightBox, item.getName());
 
 						Point mousePos = client.getMouseCanvasPosition();
@@ -360,23 +361,23 @@ public class GroundItemsOverlay extends Overlay
 		graphics.setColor(Color.WHITE);
 		// Minus symbol
 		graphics.drawLine
-		(
-			rect.x + 2,
-			rect.y + (RECTANGLE_SIZE / 2),
-			rect.x + RECTANGLE_SIZE - 2,
-			rect.y + (RECTANGLE_SIZE / 2)
-		);
+			(
+				rect.x + 2,
+				rect.y + (RECTANGLE_SIZE / 2),
+				rect.x + RECTANGLE_SIZE - 2,
+				rect.y + (RECTANGLE_SIZE / 2)
+			);
 
 		if (!hiddenBox)
 		{
 			// Plus symbol
 			graphics.drawLine
-			(
-				rect.x + (RECTANGLE_SIZE / 2),
-				rect.y + 2,
-				rect.x + (RECTANGLE_SIZE / 2),
-				rect.y + RECTANGLE_SIZE - 2
-			);
+				(
+					rect.x + (RECTANGLE_SIZE / 2),
+					rect.y + 2,
+					rect.x + (RECTANGLE_SIZE / 2),
+					rect.y + RECTANGLE_SIZE - 2
+				);
 		}
 
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
@@ -237,7 +237,7 @@ public class GroundItemsPlugin extends Plugin
 				String colTag = "<col=" + hexColor + ">";
 				if (config.highlightMenuOption())
 				{
-					lastEntry.setOption(colTag + "Take");
+					lastEntry.setOption(colTag + "<img=26> " + "Take");
 				}
 				if (config.highlightMenuItemName())
 				{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/kingdomofmiscellania/KingdomConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/kingdomofmiscellania/KingdomConfig.java
@@ -1,0 +1,57 @@
+package net.runelite.client.plugins.kingdomofmiscellania;
+
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+
+@ConfigGroup(
+	keyName = "kingdom",
+	name = "Kingdom of Miscellania",
+	description = "Configuration for Kingdom of Miscellania plugin"
+)
+public interface KingdomConfig extends Config
+{
+	@ConfigItem(
+		keyName = "showOnlyInKingdom",
+		name = "Show Only in Kingdom",
+		description = "Configures whether or not to display kingdom information only when in kingdom",
+		position = 1
+	)
+	default boolean showOnlyInKingdom()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		keyName = "showWhenLow",
+		name = "Show When Low Favor or Coffer",
+		description = "Configures whether or not to display kingdom information when favor or coffer is low",
+		position = 2
+	)
+	default boolean showWhenLow()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		keyName = "favorLessThanValue",
+		name = "Alert if favor % below",
+		description = "Configures display kingdom information when favor less than value",
+		position = 3
+	)
+	default int favorLessThanValue()
+	{
+		return 95;
+	}
+
+	@ConfigItem(
+		keyName = "cofferLessThanValue",
+		name = "Alert if coffer below",
+		description = "Configures display kingdom information when coffer less than value",
+		position = 4
+	)
+	default int cofferLessThanValue()
+	{
+		return 1000000;
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/kingdomofmiscellania/KingdomCounter.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/kingdomofmiscellania/KingdomCounter.java
@@ -12,13 +12,18 @@ public class KingdomCounter extends Counter
 	{
 		super(image, String.valueOf(plugin.getFavor()));
 		this.plugin = plugin;
-		setTooltip(String.format("Favor: " + plugin.getFavor() + "/127" + "</br>Coffer: " + NumberFormat.getInstance().format(plugin.getCoffer())));
 	}
 
 	@Override
 	public String getText()
 	{
 		return getFavorPercent(plugin.getFavor());
+	}
+
+	@Override
+	public String getTooltip()
+	{
+		return String.format("Favor: " + plugin.getFavor() + "/127" + "</br>Coffer: " + NumberFormat.getInstance().format(plugin.getCoffer()));
 	}
 
 	public static String getFavorPercent(int favor)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/kingdomofmiscellania/KingdomCounter.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/kingdomofmiscellania/KingdomCounter.java
@@ -1,0 +1,28 @@
+package net.runelite.client.plugins.kingdomofmiscellania;
+
+import java.awt.image.BufferedImage;
+import java.text.NumberFormat;
+import net.runelite.client.ui.overlay.infobox.Counter;
+
+public class KingdomCounter extends Counter
+{
+	private final KingdomPlugin plugin;
+
+	public KingdomCounter(BufferedImage image, KingdomPlugin plugin)
+	{
+		super(image, String.valueOf(plugin.getFavor()));
+		this.plugin = plugin;
+		setTooltip(String.format("Favor: " + plugin.getFavor() + "/127" + "</br>Coffer: " + NumberFormat.getInstance().format(plugin.getCoffer())));
+	}
+
+	@Override
+	public String getText()
+	{
+		return getFavorPercent(plugin.getFavor());
+	}
+
+	public static String getFavorPercent(int favor)
+	{
+		return (favor * 100) / 127 + "%";
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/kingdomofmiscellania/KingdomPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/kingdomofmiscellania/KingdomPlugin.java
@@ -1,0 +1,106 @@
+package net.runelite.client.plugins.kingdomofmiscellania;
+
+import com.google.common.eventbus.Subscribe;
+import com.google.common.primitives.Ints;
+import com.google.inject.Provides;
+import javax.inject.Inject;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.Client;
+import net.runelite.api.ItemID;
+import net.runelite.api.Varbits;
+import net.runelite.api.events.ConfigChanged;
+import net.runelite.api.events.MapRegionChanged;
+import net.runelite.api.events.VarbitChanged;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.game.ItemManager;
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.ui.overlay.infobox.InfoBoxManager;
+
+@PluginDescriptor(
+	name = "Kingdom of Miscellania"
+)
+@Slf4j
+public class KingdomPlugin extends Plugin
+{
+	@Inject
+	private Client client;
+
+	@Inject
+	private KingdomConfig config;
+
+	@Inject
+	ItemManager itemManager;
+
+	@Inject
+	private InfoBoxManager infoBoxManager;
+
+	private final int[] KINGDOM_REGION = {9787, 9788, 9789, 10043, 10044, 10045, 10299, 10300, 10301};
+
+	@Getter
+	private int favor = -1, coffer = -1;
+
+	@Provides
+	KingdomConfig provideConfig(ConfigManager configManager)
+	{
+		return configManager.getConfig(KingdomConfig.class);
+	}
+
+	@Subscribe
+	public void onConfigChanged(ConfigChanged event)
+	{
+		infoBoxManager.removeIf(t -> t instanceof KingdomCounter);
+		if (!config.showOnlyInKingdom())
+		{
+			addKingdomInfobox();
+		}
+		else if (config.showWhenLow() && (isFavorLow(config.favorLessThanValue()) || isCofferLow(config.cofferLessThanValue())))
+		{
+			addKingdomInfobox();
+		}
+	}
+
+	@Override
+	protected void shutDown() throws Exception
+	{
+		infoBoxManager.removeIf(t -> t instanceof KingdomCounter);
+	}
+
+	@Subscribe
+	public void onVarbitChanged(VarbitChanged event)
+	{
+		favor = client.getSetting(Varbits.KINGDOM_FAVOR);
+		coffer = client.getSetting(Varbits.KINGDOM_COFFER);
+	}
+
+	@Subscribe
+	public void onRegionChanged(MapRegionChanged event)
+	{
+		infoBoxManager.removeIf(t -> t instanceof KingdomCounter);
+		if (config.showOnlyInKingdom() && isInKingdom())
+		{
+			addKingdomInfobox();
+		}
+	}
+
+	public boolean isInKingdom()
+	{
+		return Ints.indexOf(client.getMapRegions(), KINGDOM_REGION) >= 0;
+	}
+
+	private void addKingdomInfobox()
+	{
+		infoBoxManager.addInfoBox(new KingdomCounter(itemManager.getImage(ItemID.TEAK_PRIZE_CHEST), this));
+	}
+
+	private boolean isFavorLow(int lessThanValue)
+	{
+		return Integer.parseInt(KingdomCounter.getFavorPercent(favor).replace("%", "")) < lessThanValue;
+	}
+
+	private boolean isCofferLow(int lessThanValue)
+	{
+		return coffer < lessThanValue;
+	}
+}


### PR DESCRIPTION
- Adds `★` to item name (GroundItemsOverlay)
- Adds a star sprite (from clan chat) to menu options (GroundItemsPlugin)

![Preview](https://i.imgur.com/m6VptM0.png)
