### PR TITLE
Show also full item name clickboxes in GroundItems

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItem.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItem.java
@@ -40,6 +40,7 @@ class GroundItem
 	private WorldPoint location;
 	private int haPrice;
 	private int gePrice;
+	private int offset;
 
 	@Value
 	static class GroundItemKey

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemInputListener.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemInputListener.java
@@ -25,12 +25,8 @@
 package net.runelite.client.plugins.grounditems;
 
 import java.awt.Point;
-import java.awt.Rectangle;
 import java.awt.event.KeyEvent;
 import java.awt.event.MouseEvent;
-import java.util.Iterator;
-import java.util.Map;
-import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.swing.SwingUtilities;
 import net.runelite.client.input.KeyListener;
@@ -64,77 +60,56 @@ public class GroundItemInputListener extends MouseListener implements KeyListene
 		if (e.getKeyCode() == HOTKEY)
 		{
 			plugin.setHotKeyPressed(false);
-			plugin.getBoxes().clear();
-			plugin.getHiddenBoxes().clear();
-			plugin.getHighlightBoxes().clear();
+			plugin.setTextBoxBounds(null);
+			plugin.setHiddenBoxBounds(null);
+			plugin.setHighlightBoxBounds(null);
 		}
 	}
 
 	@Override
 	public MouseEvent mousePressed(MouseEvent e)
 	{
+		final Point mousePos = e.getPoint();
+
 		if (plugin.isHotKeyPressed())
 		{
 			if (SwingUtilities.isLeftMouseButton(e))
 			{
 				// Process both click boxes for hidden and highlighted items
-				final Iterator<Map.Entry<Rectangle, String>> highlightIterator = plugin
-					.getHighlightBoxes().entrySet().iterator();
-
-				if (findMatchAndProcess(e, highlightIterator, false) != null)
+				if (plugin.getHiddenBoxBounds() != null && plugin.getHiddenBoxBounds().getKey().contains(mousePos))
 				{
+					plugin.updateList(plugin.getHiddenBoxBounds().getValue().getName(), true);
+					e.consume();
 					return e;
 				}
 
-				final Iterator<Map.Entry<Rectangle, String>> hiddenIterator = plugin
-					.getHiddenBoxes().entrySet().iterator();
-
-				if (findMatchAndProcess(e, hiddenIterator, true) != null)
+				if (plugin.getHighlightBoxBounds() != null && plugin.getHighlightBoxBounds().getKey().contains(mousePos))
 				{
+					plugin.updateList(plugin.getHighlightBoxBounds().getValue().getName(), false);
+					e.consume();
 					return e;
 				}
 
 				// There is one name click box for left click and one for right click
-				final Iterator<Map.Entry<Rectangle, String>> iterator = plugin.getBoxes().entrySet().iterator();
-				if (findMatchAndProcess(e, iterator, false) != null)
+				if (plugin.getTextBoxBounds() != null && plugin.getTextBoxBounds().getKey().contains(mousePos))
 				{
+					plugin.updateList(plugin.getTextBoxBounds().getValue().getName(), false);
+					e.consume();
 					return e;
 				}
 			}
 			else if (SwingUtilities.isRightMouseButton(e))
 			{
-				final Iterator<Map.Entry<Rectangle, String>> iterator = plugin.getBoxes().entrySet().iterator();
-				if (findMatchAndProcess(e, iterator, true) != null)
+				if (plugin.getTextBoxBounds() != null && plugin.getTextBoxBounds().getKey().contains(mousePos))
 				{
+					plugin.updateList(plugin.getTextBoxBounds().getValue().getName(), true);
+					e.consume();
 					return e;
 				}
 			}
 		}
 
 		return e;
-	}
-
-	@Nullable
-	private MouseEvent findMatchAndProcess(
-		final MouseEvent mouseEvent,
-		final Iterator<Map.Entry<Rectangle, String>> iterator,
-		final boolean hiddenList)
-	{
-		final Point mousePos = mouseEvent.getPoint();
-
-		while (iterator.hasNext())
-		{
-			final Map.Entry<Rectangle, String> next = iterator.next();
-
-			if (next.getKey().contains(mousePos))
-			{
-				plugin.updateList(next.getValue(), hiddenList);
-				mouseEvent.consume();
-				return mouseEvent;
-			}
-		}
-
-		return null;
 	}
 }
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
@@ -30,7 +30,10 @@ import java.awt.Dimension;
 import java.awt.FontMetrics;
 import java.awt.Graphics2D;
 import java.awt.Rectangle;
+import java.util.AbstractMap.SimpleEntry;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import javax.inject.Inject;
 import net.runelite.api.Client;
@@ -59,6 +62,8 @@ public class GroundItemsOverlay extends Overlay
 	private static final int MAX_QUANTITY = 65535;
 	// The 15 pixel gap between each drawn ground item.
 	private static final int STRING_GAP = OFFSET_Z;
+	// Size of the hidden/highlight boxes
+	private static final int RECTANGLE_SIZE = 8;
 
 	private final Client client;
 	private final GroundItemsPlugin plugin;
@@ -96,8 +101,60 @@ public class GroundItemsOverlay extends Overlay
 		offsetMap.clear();
 		final LocalPoint localLocation = player.getLocalLocation();
 		final Point mousePos = client.getMouseCanvasPosition();
+		final List<GroundItem> groundItemList = new ArrayList<>(plugin.getCollectedGroundItems().values());
+		GroundItem topGroundItem = null;
 
-		for (GroundItem item : plugin.getCollectedGroundItems().values())
+		if (plugin.isHotKeyPressed())
+		{
+			final java.awt.Point awtMousePos = new java.awt.Point(mousePos.getX(), mousePos.getY());
+			GroundItem groundItem = null;
+
+			for (GroundItem item : groundItemList)
+			{
+				item.setOffset(offsetMap.compute(item.getLocation(), (k, v) -> v != null ? v + 1 : 0));
+
+				if (groundItem != null)
+				{
+					continue;
+				}
+
+				if (plugin.getTextBoxBounds() != null
+					&& item.equals(plugin.getTextBoxBounds().getValue())
+					&& plugin.getTextBoxBounds().getKey().contains(awtMousePos))
+				{
+					groundItem = item;
+					continue;
+				}
+
+				if (plugin.getHiddenBoxBounds() != null
+					&& item.equals(plugin.getHiddenBoxBounds().getValue())
+					&& plugin.getHiddenBoxBounds().getKey().contains(awtMousePos))
+				{
+					groundItem = item;
+					continue;
+				}
+
+				if (plugin.getHighlightBoxBounds() != null
+					&& item.equals(plugin.getHighlightBoxBounds().getValue())
+					&& plugin.getHighlightBoxBounds().getKey().contains(awtMousePos))
+				{
+					groundItem = item;
+				}
+			}
+
+			if (groundItem != null)
+			{
+				groundItemList.remove(groundItem);
+				groundItemList.add(groundItem);
+				topGroundItem = groundItem;
+			}
+		}
+
+		plugin.setTextBoxBounds(null);
+		plugin.setHiddenBoxBounds(null);
+		plugin.setHighlightBoxBounds(null);
+
+		for (GroundItem item : groundItemList)
 		{
 			final LocalPoint groundPoint = LocalPoint.fromWorld(client, item.getLocation());
 
@@ -183,7 +240,10 @@ public class GroundItemsOverlay extends Overlay
 				continue;
 			}
 
-			final int offset = offsetMap.compute(item.getLocation(), (k, v) -> v != null ? v + 1 : 0);
+			final int offset = plugin.isHotKeyPressed()
+				? item.getOffset()
+				: offsetMap.compute(item.getLocation(), (k, v) -> v != null ? v + 1 : 0);
+
 			final int textX = textPoint.getX();
 			final int textY = textPoint.getY() - (STRING_GAP * offset);
 
@@ -199,38 +259,48 @@ public class GroundItemsOverlay extends Overlay
 				int height = stringHeight + 4;
 				final Rectangle itemBounds = new Rectangle(x, y, width, height);
 
-				plugin.getBoxes().put(itemBounds, item.getName());
-
 				// Hidden box
 				x += width + 2;
-				y += 4;
-				width = height = stringHeight - 2;
+				y = textY - (RECTANGLE_SIZE + stringHeight) / 2;
+				width = height = RECTANGLE_SIZE - 2;
 				final Rectangle itemHiddenBox = new Rectangle(x, y, width, height);
-
-				plugin.getHiddenBoxes().put(itemHiddenBox, item.getName());
 
 				// Highlight box
 				x += width + 2;
 				final Rectangle itemHighlightBox = new Rectangle(x, y, width, height);
 
-				plugin.getHighlightBoxes().put(itemHighlightBox, item.getName());
-
 				boolean mouseInBox = itemBounds.contains(mousePos.getX(), mousePos.getY());
 				boolean mouseInHiddenBox = itemHiddenBox.contains(mousePos.getX(), mousePos.getY());
 				boolean mouseInHighlightBox = itemHighlightBox.contains(mousePos.getX(), mousePos.getY());
 
+				if (mouseInBox)
+				{
+					plugin.setTextBoxBounds(new SimpleEntry<>(itemBounds, item));
+				}
+				else if (mouseInHiddenBox)
+				{
+					plugin.setHiddenBoxBounds(new SimpleEntry<>(itemHiddenBox, item));
+
+				}
+				else if (mouseInHighlightBox)
+				{
+					plugin.setHighlightBoxBounds(new SimpleEntry<>(itemHighlightBox, item));
+				}
+
+				boolean topItem = topGroundItem == item;
+
 				// Draw background if hovering
-				if (mouseInBox || mouseInHiddenBox || mouseInHighlightBox)
+				if (topItem && (mouseInBox || mouseInHiddenBox || mouseInHighlightBox))
 				{
 					backgroundComponent.setRectangle(itemBounds);
 					backgroundComponent.render(graphics);
 				}
 
 				// Draw hidden box
-				drawRectangle(graphics, itemHiddenBox, mouseInHiddenBox ? Color.RED : color, hidden, true);
+				drawRectangle(graphics, itemHiddenBox, topItem && mouseInHiddenBox ? Color.RED : color, hidden, true);
 
 				// Draw highlight box
-				drawRectangle(graphics, itemHighlightBox, mouseInHighlightBox ? Color.GREEN : color, highlighted, false);
+				drawRectangle(graphics, itemHighlightBox, topItem && mouseInHighlightBox ? Color.GREEN : color, highlighted, false);
 			}
 
 			textComponent.setText(itemString);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
@@ -43,6 +43,7 @@ import net.runelite.client.game.ItemManager;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.components.BackgroundComponent;
 import net.runelite.client.ui.overlay.components.TextComponent;
 import net.runelite.client.util.StackFormatter;
 import net.runelite.http.api.item.ItemPrice;
@@ -57,14 +58,13 @@ public class GroundItemsOverlay extends Overlay
 	// so we replace any item quantity higher with "Lots" instead.
 	private static final int MAX_QUANTITY = 65535;
 	// The 15 pixel gap between each drawn ground item.
-	private static final int STRING_GAP = 15;
-	// Size of the hidden/highlight boxes
-	private static final int RECTANGLE_SIZE = 8;
+	private static final int STRING_GAP = OFFSET_Z;
 
 	private final Client client;
 	private final GroundItemsPlugin plugin;
 	private final GroundItemsConfig config;
 	private final StringBuilder itemStringBuilder = new StringBuilder();
+	private final BackgroundComponent backgroundComponent = new BackgroundComponent();
 	private final TextComponent textComponent = new TextComponent();
 	private final Map<WorldPoint, Integer> offsetMap = new HashMap<>();
 	private final ItemManager itemManager;
@@ -95,6 +95,7 @@ public class GroundItemsOverlay extends Overlay
 
 		offsetMap.clear();
 		final LocalPoint localLocation = player.getLocalLocation();
+		final Point mousePos = client.getMouseCanvasPosition();
 
 		for (GroundItem item : plugin.getCollectedGroundItems().values())
 		{
@@ -186,37 +187,44 @@ public class GroundItemsOverlay extends Overlay
 			final int textX = textPoint.getX();
 			final int textY = textPoint.getY() - (STRING_GAP * offset);
 
-			textComponent.setText(itemString);
-			textComponent.setColor(color);
-			textComponent.setPosition(new java.awt.Point(textX, textY));
-			textComponent.render(graphics);
-
 			if (plugin.isHotKeyPressed())
 			{
 				final int stringWidth = fm.stringWidth(itemString);
 				final int stringHeight = fm.getHeight();
 
+				// Item bounds
+				int x = textX - 2;
+				int y = textY - stringHeight - 2;
+				int width = stringWidth + 4;
+				int height = stringHeight + 4;
+				final Rectangle itemBounds = new Rectangle(x, y, width, height);
+
+				plugin.getBoxes().put(itemBounds, item.getName());
+
 				// Hidden box
-				final Rectangle itemHiddenBox = new Rectangle(
-					textX + stringWidth,
-					textY - (RECTANGLE_SIZE + stringHeight) / 2,
-					RECTANGLE_SIZE,
-					RECTANGLE_SIZE);
+				x += width + 2;
+				y += 4;
+				width = height = stringHeight - 2;
+				final Rectangle itemHiddenBox = new Rectangle(x, y, width, height);
 
 				plugin.getHiddenBoxes().put(itemHiddenBox, item.getName());
 
 				// Highlight box
-				final Rectangle itemHighlightBox = new Rectangle(
-					textX + stringWidth + RECTANGLE_SIZE + 2,
-					textY - (RECTANGLE_SIZE + stringHeight) / 2,
-					RECTANGLE_SIZE,
-					RECTANGLE_SIZE);
+				x += width + 2;
+				final Rectangle itemHighlightBox = new Rectangle(x, y, width, height);
 
 				plugin.getHighlightBoxes().put(itemHighlightBox, item.getName());
 
-				final Point mousePos = client.getMouseCanvasPosition();
+				boolean mouseInBox = itemBounds.contains(mousePos.getX(), mousePos.getY());
 				boolean mouseInHiddenBox = itemHiddenBox.contains(mousePos.getX(), mousePos.getY());
 				boolean mouseInHighlightBox = itemHighlightBox.contains(mousePos.getX(), mousePos.getY());
+
+				// Draw background if hovering
+				if (mouseInBox || mouseInHiddenBox || mouseInHighlightBox)
+				{
+					backgroundComponent.setRectangle(itemBounds);
+					backgroundComponent.render(graphics);
+				}
 
 				// Draw hidden box
 				drawRectangle(graphics, itemHiddenBox, mouseInHiddenBox ? Color.RED : color, hidden, true);
@@ -224,6 +232,11 @@ public class GroundItemsOverlay extends Overlay
 				// Draw highlight box
 				drawRectangle(graphics, itemHighlightBox, mouseInHighlightBox ? Color.GREEN : color, highlighted, false);
 			}
+
+			textComponent.setText(itemString);
+			textComponent.setColor(color);
+			textComponent.setPosition(new java.awt.Point(textX, textY));
+			textComponent.render(graphics);
 		}
 
 		return null;
@@ -283,9 +296,9 @@ public class GroundItemsOverlay extends Overlay
 		graphics.drawLine
 			(
 				rect.x + 2,
-				rect.y + (RECTANGLE_SIZE / 2),
-				rect.x + RECTANGLE_SIZE - 2,
-				rect.y + (RECTANGLE_SIZE / 2)
+				rect.y + (rect.height / 2),
+				rect.x + rect.width - 2,
+				rect.y + (rect.height / 2)
 			);
 
 		if (!hiddenBox)
@@ -293,10 +306,10 @@ public class GroundItemsOverlay extends Overlay
 			// Plus symbol
 			graphics.drawLine
 				(
-					rect.x + (RECTANGLE_SIZE / 2),
+					rect.x + (rect.width / 2),
 					rect.y + 2,
-					rect.x + (RECTANGLE_SIZE / 2),
-					rect.y + RECTANGLE_SIZE - 2
+					rect.x + (rect.width / 2),
+					rect.y + rect.height - 2
 				);
 		}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
@@ -41,7 +41,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
@@ -102,13 +101,16 @@ public class GroundItemsPlugin extends Plugin
 	private static final int COINS = ItemID.COINS_995;
 
 	@Getter(AccessLevel.PACKAGE)
-	private final Map<Rectangle, String> boxes = new ConcurrentHashMap<>();
+	@Setter(AccessLevel.PACKAGE)
+	private Map.Entry<Rectangle, GroundItem> textBoxBounds;
 
 	@Getter(AccessLevel.PACKAGE)
-	private final Map<Rectangle, String> hiddenBoxes = new ConcurrentHashMap<>();
+	@Setter(AccessLevel.PACKAGE)
+	private Map.Entry<Rectangle, GroundItem> hiddenBoxBounds;
 
 	@Getter(AccessLevel.PACKAGE)
-	private final Map<Rectangle, String> highlightBoxes = new ConcurrentHashMap<>();
+	@Setter(AccessLevel.PACKAGE)
+	private Map.Entry<Rectangle, GroundItem> highlightBoxBounds;
 
 	@Getter(AccessLevel.PACKAGE)
 	@Setter(AccessLevel.PACKAGE)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
@@ -102,6 +102,9 @@ public class GroundItemsPlugin extends Plugin
 	private static final int COINS = ItemID.COINS_995;
 
 	@Getter(AccessLevel.PACKAGE)
+	private final Map<Rectangle, String> boxes = new ConcurrentHashMap<>();
+
+	@Getter(AccessLevel.PACKAGE)
 	private final Map<Rectangle, String> hiddenBoxes = new ConcurrentHashMap<>();
 
 	@Getter(AccessLevel.PACKAGE)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
@@ -36,13 +36,15 @@ import java.awt.Color;
 import java.awt.Rectangle;
 import static java.lang.Boolean.TRUE;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
-import java.util.regex.Pattern;
 import java.util.stream.Collector;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
@@ -84,6 +86,12 @@ import net.runelite.http.api.item.ItemPrice;
 @Slf4j
 public class GroundItemsPlugin extends Plugin
 {
+	private static final Splitter COMMA_SPLITTER = Splitter
+		.on(",")
+		.omitEmptyStrings()
+		.trimResults();
+
+	private static final Joiner COMMA_JOINER = Joiner.on(",").skipNulls();
 	//Size of one region
 	private static final int REGION_SIZE = 104;
 	// The max distance in tiles between the player and the item.
@@ -94,17 +102,17 @@ public class GroundItemsPlugin extends Plugin
 	private static final int COINS = ItemID.COINS_995;
 
 	@Getter(AccessLevel.PACKAGE)
-	private final Map<Rectangle, String> hiddenBoxes = new HashMap<>();
+	private final Map<Rectangle, String> hiddenBoxes = new ConcurrentHashMap<>();
 
 	@Getter(AccessLevel.PACKAGE)
-	private final Map<Rectangle, String> highlightBoxes = new HashMap<>();
+	private final Map<Rectangle, String> highlightBoxes = new ConcurrentHashMap<>();
 
 	@Getter(AccessLevel.PACKAGE)
 	@Setter(AccessLevel.PACKAGE)
 	private boolean hotKeyPressed;
 
-	private List<String> hiddenItemList = new ArrayList<>();
-	private List<String> highlightedItemsList = new ArrayList<>();
+	private List<String> hiddenItemList = new CopyOnWriteArrayList<>();
+	private List<String> highlightedItemsList = new CopyOnWriteArrayList<>();
 	private boolean dirty;
 
 	@Inject
@@ -302,13 +310,11 @@ public class GroundItemsPlugin extends Plugin
 
 	private void reset()
 	{
-		Splitter COMMA_SPLITTER = Splitter.on(Pattern.compile("\\s*,\\s*"));
-
 		// gets the hidden items from the text box in the config
-		hiddenItemList = COMMA_SPLITTER.splitToList(config.getHiddenItems().trim());
+		hiddenItemList = COMMA_SPLITTER.splitToList(config.getHiddenItems());
 
 		// gets the highlighted items from the text box in the config
-		highlightedItemsList = COMMA_SPLITTER.splitToList(config.getHighlightItems().trim());
+		highlightedItemsList = COMMA_SPLITTER.splitToList(config.getHighlightItems());
 
 		highlightedItems = CacheBuilder.newBuilder()
 			.maximumSize(512L)
@@ -404,24 +410,27 @@ public class GroundItemsPlugin extends Plugin
 
 	void updateList(String item, boolean hiddenList)
 	{
-		List<String> items = new ArrayList<>((hiddenList) ? hiddenItemList : highlightedItemsList);
+		final Set<String> hiddenItemSet = new HashSet<>(hiddenItemList);
+		final Set<String> highlightedItemSet = new HashSet<>(highlightedItemsList);
 
-		items.removeIf(s -> s.isEmpty());
-		if (!items.removeIf(s -> s.equalsIgnoreCase(item)))
+		if (hiddenList)
+		{
+			highlightedItemSet.removeIf(item::equalsIgnoreCase);
+		}
+		else
+		{
+			hiddenItemSet.removeIf(item::equalsIgnoreCase);
+		}
+
+		final Set<String> items = hiddenList ? hiddenItemSet : highlightedItemSet;
+
+		if (!items.removeIf(item::equalsIgnoreCase))
 		{
 			items.add(item);
 		}
 
-		String newList = Joiner.on(", ").join(items);
-		// This triggers the config update which updates the list
-		if (hiddenList)
-		{
-			config.setHiddenItems(newList);
-		}
-		else
-		{
-			config.setHighlightedItem(newList);
-		}
+		config.setHiddenItems(COMMA_JOINER.join(hiddenItemSet));
+		config.setHighlightedItem(COMMA_JOINER.join(highlightedItemSet));
 	}
 
 	public boolean isHighlighted(String item)


### PR DESCRIPTION
- Remove the possibility of having the item both highlighted and hidden
when using the highlight/hidden boxes.
- Expand the clickbox for highlighting/hiding item to it's entire name
- Left click name highlights item, right click hides item
- Highlight background when in highlighting mode of the background item
that is hovered
- In order to help in cluttered environments, bring currently hovered item name to front

Depends on: #1236

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>

Preview of new features:
![peek 2018-03-20 19-12](https://user-images.githubusercontent.com/5115805/37674391-16e955c6-2c73-11e8-8cd8-8123bde22b25.gif)

Preview of bringing the ground item to front:
![peek 2018-03-22 10-12](https://user-images.githubusercontent.com/5115805/37762627-264c3c18-2dbd-11e8-9dee-dfc8f1f0e4c3.gif)
