### PR TITLE
prayer flick overlay: remove background arc

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/prayflick/PrayerFlickOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/prayflick/PrayerFlickOverlay.java
@@ -99,9 +99,6 @@ public class PrayerFlickOverlay extends Overlay
 
 		int yOffset = (orbInnerHeight / 2) - (indicatorHeight / 2);
 
-		graphics.setColor(new Color(255, 255, 255, 100));
-		graphics.fillArc(orbInnerX, orbInnerY, orbInnerWidth, orbInnerHeight, 0, 360);
-
 		graphics.setColor(Color.cyan);
 		graphics.fillRect(orbInnerX + xOffset, orbInnerY + yOffset, 1, indicatorHeight);
 


### PR DESCRIPTION
Removed the white background on the the prayer orb when overlay was on which made it hard to tell if quick prayers were on

Fixes #972 