### PR TITLE
Rename widgetSettings and settings

### DIFF
--- a/cache/src/main/java/net/runelite/cache/script/Instructions.java
+++ b/cache/src/main/java/net/runelite/cache/script/Instructions.java
@@ -36,8 +36,8 @@ public class Instructions
 	public void init()
 	{
 		add(LOAD_INT, "load_int", 0, 1);
-		add(GET_SETTINGS, "get_settings", 0, 1);
-		add(PUT_SETTINGS, "put_settings", 0, 1);
+		add(GET_VARP, "get_varp", 0, 1);
+		add(PUT_VARP, "put_varp", 0, 1);
 		add(LOAD_STRING, "load_string", 0, 0, 0, 1);
 		add(JUMP, "jump", 0, 0);
 		add(IF_ICMPNE, "if_icmpne", 2, 0);

--- a/cache/src/main/java/net/runelite/cache/script/Opcodes.java
+++ b/cache/src/main/java/net/runelite/cache/script/Opcodes.java
@@ -27,8 +27,8 @@ package net.runelite.cache.script;
 public class Opcodes
 {
 	public static final int LOAD_INT = 0;
-	public static final int GET_SETTINGS = 1;
-	public static final int PUT_SETTINGS = 2;
+	public static final int GET_VARP = 1;
+	public static final int PUT_VARP = 2;
 	public static final int LOAD_STRING = 3;
 	public static final int JUMP = 6;
 	public static final int IF_ICMPNE = 7;

--- a/runelite-api/src/main/java/net/runelite/api/Client.java
+++ b/runelite-api/src/main/java/net/runelite/api/Client.java
@@ -152,8 +152,6 @@ public interface Client extends GameEngine
 
 	int[][] getXteaKeys();
 
-	int[] getSettings();
-
 	int[] getVarps();
 
 	int getSetting(Setting setting);

--- a/runelite-api/src/main/java/net/runelite/api/Client.java
+++ b/runelite-api/src/main/java/net/runelite/api/Client.java
@@ -154,7 +154,7 @@ public interface Client extends GameEngine
 
 	int[] getSettings();
 
-	int[] getWidgetSettings();
+	int[] getVarps();
 
 	int getSetting(Setting setting);
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/devtools/SettingsTracker.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/devtools/SettingsTracker.java
@@ -47,14 +47,14 @@ public class SettingsTracker
 		if (clientSettings == null || widgetSettings == null)
 		{
 			clientSettings = copy(client.getSettings());
-			widgetSettings = copy(client.getWidgetSettings());
+			widgetSettings = copy(client.getVarps());
 
 			log.info("Snapshotted client and widget settings");
 			return;
 		}
 
 		int[] newClientSettings = client.getSettings();
-		int[] newWidgetSettings = client.getWidgetSettings();
+		int[] newWidgetSettings = client.getVarps();
 
 		for (int i = 0; i < Math.min(clientSettings.length, newClientSettings.length); ++i)
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/devtools/SettingsTracker.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/devtools/SettingsTracker.java
@@ -34,7 +34,6 @@ public class SettingsTracker
 {
 	private final Client client;
 
-	private int[] clientSettings;
 	private int[] widgetSettings;
 
 	public SettingsTracker(Client client)
@@ -44,31 +43,15 @@ public class SettingsTracker
 
 	public void snapshot(ActionEvent e)
 	{
-		if (clientSettings == null || widgetSettings == null)
+		if (widgetSettings == null)
 		{
-			clientSettings = copy(client.getSettings());
 			widgetSettings = copy(client.getVarps());
 
 			log.info("Snapshotted client and widget settings");
 			return;
 		}
 
-		int[] newClientSettings = client.getSettings();
 		int[] newWidgetSettings = client.getVarps();
-
-		for (int i = 0; i < Math.min(clientSettings.length, newClientSettings.length); ++i)
-		{
-			int before = clientSettings[i];
-			int after = newClientSettings[i];
-
-			if (before == after)
-			{
-				continue;
-			}
-
-			log.info("Client setting index {} has changed from {} to {}: {} -> {}",
-				i, before, after, prettyPrintInt(before), prettyPrintInt(after));
-		}
 
 		for (int i = 0; i < Math.min(widgetSettings.length, newWidgetSettings.length); ++i)
 		{
@@ -84,13 +67,12 @@ public class SettingsTracker
 				i, before, after, prettyPrintInt(before), prettyPrintInt(after));
 		}
 
-		clientSettings = copy(newClientSettings);
 		widgetSettings = copy(newWidgetSettings);
 	}
 
 	public void clear(ActionEvent e)
 	{
-		clientSettings = widgetSettings = null;
+		widgetSettings = null;
 	}
 
 	private static int[] copy(int[] array)

--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSClientMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSClientMixin.java
@@ -233,8 +233,8 @@ public abstract class RSClientMixin implements RSClient
 	@Override
 	public int getSetting(Setting setting)
 	{
-		int[] settings = getSettings();
-		return settings[setting.getId()];
+		int[] varps = getVarps();
+		return varps[setting.getId()];
 	}
 
 	@Inject

--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSClientMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSClientMixin.java
@@ -634,7 +634,7 @@ public abstract class RSClientMixin implements RSClient
 		eventBus.post(offerChangedEvent);
 	}
 
-	@FieldHook("settings")
+	@FieldHook("clientVarps")
 	@Inject
 	public static void settingsChanged(int idx)
 	{

--- a/runelite-mixins/src/main/java/net/runelite/mixins/VarbitMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/VarbitMixin.java
@@ -64,8 +64,8 @@ public abstract class VarbitMixin implements RSClient
 			varbitCache.put(varbitId, v);
 		}
 
-		int[] settings = getSettings();
-		int value = settings[v.getIndex()];
+		int[] varps = getVarps();
+		int value = varps[v.getIndex()];
 		int lsb = v.getLeastSignificantBit();
 		int msb = v.getMostSignificantBit();
 		int mask = (1 << ((msb - lsb) + 1)) - 1;

--- a/runescape-api/src/main/java/net/runelite/rs/api/RSClient.java
+++ b/runescape-api/src/main/java/net/runelite/rs/api/RSClient.java
@@ -77,10 +77,6 @@ public interface RSClient extends RSGameEngine, Client
 	@Override
 	byte[][][] getTileSettings();
 
-	@Import("serverVarps")
-	@Override
-	int[] getSettings();
-
 	@Import("clientVarps")
 	@Override
 	int[] getVarps();

--- a/runescape-api/src/main/java/net/runelite/rs/api/RSClient.java
+++ b/runescape-api/src/main/java/net/runelite/rs/api/RSClient.java
@@ -77,7 +77,7 @@ public interface RSClient extends RSGameEngine, Client
 	@Override
 	byte[][][] getTileSettings();
 
-	@Import("settings")
+	@Import("serverVarps")
 	@Override
 	int[] getSettings();
 

--- a/runescape-api/src/main/java/net/runelite/rs/api/RSClient.java
+++ b/runescape-api/src/main/java/net/runelite/rs/api/RSClient.java
@@ -81,9 +81,9 @@ public interface RSClient extends RSGameEngine, Client
 	@Override
 	int[] getSettings();
 
-	@Import("widgetSettings")
+	@Import("clientVarps")
 	@Override
-	int[] getWidgetSettings();
+	int[] getVarps();
 
 	@Import("energy")
 	@Override

--- a/runescape-client/src/main/java/Client.java
+++ b/runescape-client/src/main/java/Client.java
@@ -2736,7 +2736,7 @@ public final class Client extends GameEngine implements class302 {
                      VarPlayerType var23 = method1275(var28);
                      if(var23 != null) {
                         class237.settings[var28] = 0;
-                        class237.widgetSettings[var28] = 0;
+                        class237.clientVarps[var28] = 0;
                      }
                   }
 
@@ -4029,9 +4029,9 @@ public final class Client extends GameEngine implements class302 {
             }
 
             if(ServerPacket.field2305 == var1.serverPacket) {
-               for(var20 = 0; var20 < class237.widgetSettings.length; ++var20) {
-                  if(class237.settings[var20] != class237.widgetSettings[var20]) {
-                     class237.widgetSettings[var20] = class237.settings[var20];
+               for(var20 = 0; var20 < class237.clientVarps.length; ++var20) {
+                  if(class237.settings[var20] != class237.clientVarps[var20]) {
+                     class237.clientVarps[var20] = class237.settings[var20];
                      class5.method14(var20);
                      field1032[++field1033 - 1 & 31] = var20;
                   }
@@ -4553,7 +4553,7 @@ public final class Client extends GameEngine implements class302 {
                   VarPlayerType var67 = method1275(var20);
                   if(var67 != null) {
                      class237.settings[var20] = 0;
-                     class237.widgetSettings[var20] = 0;
+                     class237.clientVarps[var20] = 0;
                   }
                }
 
@@ -4998,8 +4998,8 @@ public final class Client extends GameEngine implements class302 {
                var20 = var3.method3585();
                var21 = var3.method3576();
                class237.settings[var21] = var20;
-               if(class237.widgetSettings[var21] != var20) {
-                  class237.widgetSettings[var21] = var20;
+               if(class237.clientVarps[var21] != var20) {
+                  class237.clientVarps[var21] = var20;
                }
 
                class5.method14(var21);
@@ -5374,8 +5374,8 @@ public final class Client extends GameEngine implements class302 {
                byte var85 = var3.method3613();
                var21 = var3.method3574();
                class237.settings[var21] = var85;
-               if(class237.widgetSettings[var21] != var85) {
-                  class237.widgetSettings[var21] = var85;
+               if(class237.clientVarps[var21] != var85) {
+                  class237.clientVarps[var21] = var85;
                }
 
                class5.method14(var21);

--- a/runescape-client/src/main/java/Client.java
+++ b/runescape-client/src/main/java/Client.java
@@ -2735,7 +2735,7 @@ public final class Client extends GameEngine implements class302 {
                   for(var28 = 0; var28 < VarPlayerType.field3448; ++var28) {
                      VarPlayerType var23 = method1275(var28);
                      if(var23 != null) {
-                        class237.settings[var28] = 0;
+                        class237.serverVarps[var28] = 0;
                         class237.clientVarps[var28] = 0;
                      }
                   }
@@ -4030,8 +4030,8 @@ public final class Client extends GameEngine implements class302 {
 
             if(ServerPacket.field2305 == var1.serverPacket) {
                for(var20 = 0; var20 < class237.clientVarps.length; ++var20) {
-                  if(class237.settings[var20] != class237.clientVarps[var20]) {
-                     class237.clientVarps[var20] = class237.settings[var20];
+                  if(class237.serverVarps[var20] != class237.clientVarps[var20]) {
+                     class237.clientVarps[var20] = class237.serverVarps[var20];
                      class5.method14(var20);
                      field1032[++field1033 - 1 & 31] = var20;
                   }
@@ -4552,7 +4552,7 @@ public final class Client extends GameEngine implements class302 {
                for(var20 = 0; var20 < VarPlayerType.field3448; ++var20) {
                   VarPlayerType var67 = method1275(var20);
                   if(var67 != null) {
-                     class237.settings[var20] = 0;
+                     class237.serverVarps[var20] = 0;
                      class237.clientVarps[var20] = 0;
                   }
                }
@@ -4997,7 +4997,7 @@ public final class Client extends GameEngine implements class302 {
             if(ServerPacket.field2324 == var1.serverPacket) {
                var20 = var3.method3585();
                var21 = var3.method3576();
-               class237.settings[var21] = var20;
+               class237.serverVarps[var21] = var20;
                if(class237.clientVarps[var21] != var20) {
                   class237.clientVarps[var21] = var20;
                }
@@ -5373,7 +5373,7 @@ public final class Client extends GameEngine implements class302 {
             if(ServerPacket.field2296 == var1.serverPacket) {
                byte var85 = var3.method3613();
                var21 = var3.method3574();
-               class237.settings[var21] = var85;
+               class237.serverVarps[var21] = var85;
                if(class237.clientVarps[var21] != var85) {
                   class237.clientVarps[var21] = var85;
                }

--- a/runescape-client/src/main/java/NPCComposition.java
+++ b/runescape-client/src/main/java/NPCComposition.java
@@ -492,7 +492,7 @@ public class NPCComposition extends CacheableNode {
       if(this.varpIndex != -1) {
          var1 = World.getVarbit(this.varpIndex);
       } else if(this.varp32Index != -1) {
-         var1 = class237.widgetSettings[this.varp32Index];
+         var1 = class237.clientVarps[this.varp32Index];
       }
 
       int var2;
@@ -518,7 +518,7 @@ public class NPCComposition extends CacheableNode {
          if(this.varpIndex != -1) {
             var1 = World.getVarbit(this.varpIndex);
          } else if(this.varp32Index != -1) {
-            var1 = class237.widgetSettings[this.varp32Index];
+            var1 = class237.clientVarps[this.varp32Index];
          }
 
          return var1 >= 0 && var1 < this.configs.length?this.configs[var1] != -1:this.configs[this.configs.length - 1] != -1;

--- a/runescape-client/src/main/java/ObjectComposition.java
+++ b/runescape-client/src/main/java/ObjectComposition.java
@@ -832,7 +832,7 @@ public class ObjectComposition extends CacheableNode {
       if(this.varpId != -1) {
          var1 = World.getVarbit(this.varpId);
       } else if(this.configId != -1) {
-         var1 = class237.widgetSettings[this.configId];
+         var1 = class237.clientVarps[this.configId];
       }
 
       int var2;

--- a/runescape-client/src/main/java/Timer.java
+++ b/runescape-client/src/main/java/Timer.java
@@ -52,7 +52,7 @@ public abstract class Timer {
       }
 
       var6 <<= var4;
-      class237.widgetSettings[var3] = class237.widgetSettings[var3] & ~var6 | var1 << var4 & var6;
+      class237.clientVarps[var3] = class237.clientVarps[var3] & ~var6 | var1 << var4 & var6;
    }
 
    @ObfuscatedName("c")

--- a/runescape-client/src/main/java/World.java
+++ b/runescape-client/src/main/java/World.java
@@ -150,7 +150,7 @@ public class World {
       int var3 = var1.leastSignificantBit;
       int var4 = var1.mostSignificantBit;
       int var5 = class237.varpsMasks[var4 - var3];
-      return class237.widgetSettings[var2] >> var3 & var5;
+      return class237.clientVarps[var2] >> var3 & var5;
    }
 
    @ObfuscatedName("ae")

--- a/runescape-client/src/main/java/class110.java
+++ b/runescape-client/src/main/java/class110.java
@@ -192,7 +192,7 @@ public class class110 {
                }
 
                if(var6 == 5) {
-                  var7 = class237.widgetSettings[var2[var4++]];
+                  var7 = class237.clientVarps[var2[var4++]];
                }
 
                if(var6 == 6) {
@@ -200,7 +200,7 @@ public class class110 {
                }
 
                if(var6 == 7) {
-                  var7 = class237.widgetSettings[var2[var4++]] * 100 / 46875;
+                  var7 = class237.clientVarps[var2[var4++]] * 100 / 46875;
                }
 
                if(var6 == 8) {
@@ -239,7 +239,7 @@ public class class110 {
                }
 
                if(var6 == 13) {
-                  var9 = class237.widgetSettings[var2[var4++]];
+                  var9 = class237.clientVarps[var2[var4++]];
                   int var13 = var2[var4++];
                   var7 = (var9 & 1 << var13) != 0?1:0;
                }

--- a/runescape-client/src/main/java/class237.java
+++ b/runescape-client/src/main/java/class237.java
@@ -11,8 +11,8 @@ public class class237 {
    @Export("settings")
    public static int[] settings;
    @ObfuscatedName("i")
-   @Export("widgetSettings")
-   public static int[] widgetSettings;
+   @Export("clientVarps")
+   public static int[] clientVarps;
    @ObfuscatedName("e")
    @ObfuscatedSignature(
       signature = "Lla;"
@@ -29,6 +29,6 @@ public class class237 {
       }
 
       settings = new int[2000];
-      widgetSettings = new int[2000];
+      clientVarps = new int[2000];
    }
 }

--- a/runescape-client/src/main/java/class237.java
+++ b/runescape-client/src/main/java/class237.java
@@ -8,8 +8,8 @@ public class class237 {
    @Export("varpsMasks")
    static int[] varpsMasks;
    @ObfuscatedName("q")
-   @Export("settings")
-   public static int[] settings;
+   @Export("serverVarps")
+   public static int[] serverVarps;
    @ObfuscatedName("i")
    @Export("clientVarps")
    public static int[] clientVarps;
@@ -28,7 +28,7 @@ public class class237 {
          var0 += var0;
       }
 
-      settings = new int[2000];
+      serverVarps = new int[2000];
       clientVarps = new int[2000];
    }
 }

--- a/runescape-client/src/main/java/class25.java
+++ b/runescape-client/src/main/java/class25.java
@@ -470,12 +470,12 @@ public class class25 {
                                                                                                       }
                                                                                                    } else {
                                                                                                       var21 = var30[var19];
-                                                                                                      class237.widgetSettings[var21] = class81.intStack[--class5.intStackSize];
+                                                                                                      class237.clientVarps[var21] = class81.intStack[--class5.intStackSize];
                                                                                                       class5.method14(var21);
                                                                                                    }
                                                                                                 } else {
                                                                                                    var21 = var30[var19];
-                                                                                                   class81.intStack[++class5.intStackSize - 1] = class237.widgetSettings[var21];
+                                                                                                   class81.intStack[++class5.intStackSize - 1] = class237.clientVarps[var21];
                                                                                                 }
                                                                                              } else {
                                                                                                 class81.intStack[++class5.intStackSize - 1] = var30[var19];

--- a/runescape-client/src/main/java/class281.java
+++ b/runescape-client/src/main/java/class281.java
@@ -227,7 +227,7 @@ public class class281 extends CacheableNode {
       if(this.field3592 != -1) {
          var1 = World.getVarbit(this.field3592);
       } else if(this.field3593 != -1) {
-         var1 = class237.widgetSettings[this.field3593];
+         var1 = class237.clientVarps[this.field3593];
       }
 
       int var2;

--- a/runescape-client/src/main/java/class3.java
+++ b/runescape-client/src/main/java/class3.java
@@ -456,7 +456,7 @@ final class class3 implements class0 {
                         var22 = GZipDecompressor.getWidget(var1);
                         if(var22.dynamicValues != null && var22.dynamicValues[0][0] == 5) {
                            var10 = var22.dynamicValues[0][1];
-                           class237.widgetSettings[var10] = 1 - class237.widgetSettings[var10];
+                           class237.clientVarps[var10] = 1 - class237.clientVarps[var10];
                            class5.method14(var10);
                         }
                      } else if(var2 == 29) {
@@ -466,8 +466,8 @@ final class class3 implements class0 {
                         var22 = GZipDecompressor.getWidget(var1);
                         if(var22.dynamicValues != null && var22.dynamicValues[0][0] == 5) {
                            var10 = var22.dynamicValues[0][1];
-                           if(class237.widgetSettings[var10] != var22.field2931[0]) {
-                              class237.widgetSettings[var10] = var22.field2931[0];
+                           if(class237.clientVarps[var10] != var22.field2931[0]) {
+                              class237.clientVarps[var10] = var22.field2931[0];
                               class5.method14(var10);
                            }
                         }

--- a/runescape-client/src/main/java/class5.java
+++ b/runescape-client/src/main/java/class5.java
@@ -64,7 +64,7 @@ final class class5 implements class0 {
 
       int var4 = Client.method1275(var0).configType;
       if(var4 != 0) {
-         int var2 = class237.widgetSettings[var0];
+         int var2 = class237.clientVarps[var0];
          if(var4 == 1) {
             if(var2 == 1) {
                Graphics3D.setBrightness(0.9D);


### PR DESCRIPTION
This changes the internal naming for `widgetSettings` and `settings` to `clientVarps` and `serverVarps` respectively.

Also removes `Client#getSettings()` since `Client#getVarps()` will essentially return the same values.