### PR TITLE
Consistent plugin naming

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/agilityplugin/AgilityConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/agilityplugin/AgilityConfig.java
@@ -32,7 +32,7 @@ import net.runelite.client.config.ConfigItem;
 @ConfigGroup(
 	keyName = "agility",
 	name = "Agility",
-	description = "Placeholder"
+	description = "Configuration for the Agility plugin"
 )
 public interface AgilityConfig extends Config
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
@@ -59,7 +59,7 @@ import net.runelite.http.api.item.ItemPrice;
 import net.runelite.http.api.item.SearchResult;
 
 @PluginDescriptor(
-	name = "Chat commands"
+	name = "Chat Commands"
 )
 @Slf4j
 public class ChatCommandsPlugin extends Plugin

--- a/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcClickboxOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcClickboxOverlay.java
@@ -44,11 +44,11 @@ import net.runelite.client.ui.overlay.OverlayUtil;
 public class NpcClickboxOverlay extends Overlay
 {
 	private final Client client;
-	private final NpcHighlightConfig config;
-	private final NpcHighlightPlugin plugin;
+	private final NpcIndicatorsConfig config;
+	private final NpcIndicatorsPlugin plugin;
 
 	@Inject
-	NpcClickboxOverlay(Client client, NpcHighlightConfig config, NpcHighlightPlugin plugin)
+	NpcClickboxOverlay(Client client, NpcIndicatorsConfig config, NpcIndicatorsPlugin plugin)
 	{
 		this.client = client;
 		this.config = config;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsConfig.java
@@ -30,11 +30,11 @@ import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
 
 @ConfigGroup(
-	keyName = "npchighlight",
-	name = "NPC Highlight",
-	description = "Configuration for the NPC highlight plugin"
+	keyName = "npcindicators",
+	name = "NPC Indicators",
+	description = "Configuration for the NPC indicators plugin"
 )
-public interface NpcHighlightConfig extends Config
+public interface NpcIndicatorsConfig extends Config
 {
 	@ConfigItem(
 		position = 0,

--- a/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsPlugin.java
@@ -52,8 +52,8 @@ import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.util.WildcardMatcher;
 
-@PluginDescriptor(name = "NPC Highlight")
-public class NpcHighlightPlugin extends Plugin
+@PluginDescriptor(name = "NPC Indicators")
+public class NpcIndicatorsPlugin extends Plugin
 {
 	// Option added to NPC menu
 	private static final String TAG = "Tag";
@@ -68,7 +68,7 @@ public class NpcHighlightPlugin extends Plugin
 	private MenuManager menuManager;
 
 	@Inject
-	private NpcHighlightConfig config;
+	private NpcIndicatorsConfig config;
 
 	@Inject
 	private NpcClickboxOverlay npcClickboxOverlay;
@@ -93,9 +93,9 @@ public class NpcHighlightPlugin extends Plugin
 	}
 
 	@Provides
-	NpcHighlightConfig provideConfig(ConfigManager configManager)
+	NpcIndicatorsConfig provideConfig(ConfigManager configManager)
 	{
-		return configManager.getConfig(NpcHighlightConfig.class);
+		return configManager.getConfig(NpcIndicatorsConfig.class);
 	}
 
 	@Override
@@ -116,7 +116,7 @@ public class NpcHighlightPlugin extends Plugin
 	@Subscribe
 	public void updateConfig(ConfigChanged event)
 	{
-		if (!event.getGroup().equals("npchighlight"))
+		if (!event.getGroup().equals("npcindicators"))
 			return;
 
 		if (config.isTagEnabled())

--- a/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcMinimapOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcMinimapOverlay.java
@@ -39,11 +39,11 @@ import net.runelite.client.ui.overlay.OverlayUtil;
 
 public class NpcMinimapOverlay extends Overlay
 {
-	private final NpcHighlightConfig config;
-	private final NpcHighlightPlugin plugin;
+	private final NpcIndicatorsConfig config;
+	private final NpcIndicatorsPlugin plugin;
 
 	@Inject
-	NpcMinimapOverlay(NpcHighlightConfig config, NpcHighlightPlugin plugin)
+	NpcMinimapOverlay(NpcIndicatorsConfig config, NpcIndicatorsPlugin plugin)
 	{
 		this.config = config;
 		this.plugin = plugin;


### PR DESCRIPTION
- Remove "Placeholder" description of Agility plugin and replace it with real description
- For consistent plugin naming "NPC Highlighting" plugin should be named NPC Indicators
to follow the naming of Tile Indicators and Player Indicators.
- Title-case chat commands plugin name