### PR TITLE
Fix Lizardmen cannon spot plane

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonSpots.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonSpots.java
@@ -47,7 +47,7 @@ public enum CannonSpots
 	DUST_DEVIL(new WorldPoint(3218, 9366, 0)),
 	KALPHITE(new WorldPoint(3307, 9528, 0)),
 	LESSER_DEMON(new WorldPoint(2838, 9559, 0)),
-	LIZARDMEN(new WorldPoint(1500, 3703, 1)),
+	LIZARDMEN(new WorldPoint(1500, 3703, 0)),
 	MINIONS_OF_SCARABAS(new WorldPoint(3297, 9252, 0)),
 	SMOKE_DEVIL(new WorldPoint(2398, 9444, 0));
 


### PR DESCRIPTION
The plane is 0 not 1.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>