### PR TITLE
configmanager: Synchronize disk access

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/config/ConfigManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/ConfigManager.java
@@ -170,7 +170,7 @@ public class ConfigManager
 		}
 	}
 
-	private void loadFromFile()
+	private synchronized void loadFromFile()
 	{
 		properties.clear();
 
@@ -216,7 +216,7 @@ public class ConfigManager
 		}
 	}
 
-	private void saveToFile() throws IOException
+	private synchronized void saveToFile() throws IOException
 	{
 		propertiesFile.getParentFile().mkdirs();
 


### PR DESCRIPTION
I'm not 100% sure this is what is causing our config corruption problem, but this can be called from multiple threads and is not locked at all.