### PR TITLE
Fix capitalization of 'Black demon' in npc_health.json

### DIFF
--- a/runelite-client/src/main/resources/npc_health.json
+++ b/runelite-client/src/main/resources/npc_health.json
@@ -816,7 +816,7 @@
   "Scorpion_14": 17,
   "Scorpion_37": 37,
   "Scorpion_59": 55,
-  "Black Demon_172": 157,
+  "Black demon_172": 157,
   "Black demon_178": 160,
   "Black demon_184": 170,
   "Crab_21": 18,


### PR DESCRIPTION
Fixes level 172 Black demons not having hp numbers in the opponent info plugin.