### PR TITLE
Add formatNumber methods to StackFormatter

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
@@ -28,7 +28,6 @@ package net.runelite.client.plugins.chatcommands;
 import com.google.common.eventbus.Subscribe;
 import com.google.inject.Provides;
 import java.io.IOException;
-import java.text.NumberFormat;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
@@ -50,6 +49,7 @@ import net.runelite.client.config.ConfigManager;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.util.StackFormatter;
 import net.runelite.http.api.hiscore.HiscoreClient;
 import net.runelite.http.api.hiscore.HiscoreSkill;
 import net.runelite.http.api.hiscore.SingleHiscoreSkillResult;
@@ -65,7 +65,6 @@ import net.runelite.http.api.item.SearchResult;
 public class ChatCommandsPlugin extends Plugin
 {
 	private static final float HIGH_ALCHEMY_CONSTANT = 0.6f;
-	private static final NumberFormat NUMBER_FORMATTER = NumberFormat.getInstance();
 
 	private final HiscoreClient hiscoreClient = new HiscoreClient();
 
@@ -249,7 +248,7 @@ public class ChatCommandsPlugin extends Plugin
 				.append(ChatColorType.NORMAL)
 				.append(": GE average ")
 				.append(ChatColorType.HIGHLIGHT)
-				.append(NUMBER_FORMATTER.format(itemPrice.getPrice()));
+				.append(StackFormatter.formatNumber(itemPrice.getPrice()));
 
 			ItemComposition itemComposition = itemManager.getItemComposition(itemId);
 			if (itemComposition != null)
@@ -259,7 +258,7 @@ public class ChatCommandsPlugin extends Plugin
 					.append(ChatColorType.NORMAL)
 					.append(" HA value ")
 					.append(ChatColorType.HIGHLIGHT)
-					.append(NUMBER_FORMATTER.format(alchPrice));
+					.append(StackFormatter.formatNumber(alchPrice));
 			}
 
 			String response = builder.build();

--- a/runelite-client/src/main/java/net/runelite/client/plugins/examine/ExaminePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/examine/ExaminePlugin.java
@@ -24,14 +24,11 @@
  */
 package net.runelite.client.plugins.examine;
 
-import static net.runelite.api.widgets.WidgetInfo.TO_CHILD;
-import static net.runelite.api.widgets.WidgetInfo.TO_GROUP;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.eventbus.Subscribe;
 import com.google.inject.Provides;
 import java.io.IOException;
-import java.text.NumberFormat;
 import java.time.Instant;
 import java.util.ArrayDeque;
 import java.util.Deque;
@@ -48,6 +45,8 @@ import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.MenuOptionClicked;
 import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetInfo;
+import static net.runelite.api.widgets.WidgetInfo.TO_CHILD;
+import static net.runelite.api.widgets.WidgetInfo.TO_GROUP;
 import net.runelite.api.widgets.WidgetItem;
 import net.runelite.client.chat.ChatColor;
 import net.runelite.client.chat.ChatColorType;
@@ -58,6 +57,7 @@ import net.runelite.client.config.ConfigManager;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.util.StackFormatter;
 import net.runelite.http.api.examine.ExamineClient;
 import net.runelite.http.api.item.ItemPrice;
 
@@ -73,7 +73,6 @@ import net.runelite.http.api.item.ItemPrice;
 public class ExaminePlugin extends Plugin
 {
 	private static final float HIGH_ALCHEMY_CONSTANT = 0.6f;
-	private static final NumberFormat NUMBER_FORMATTER = NumberFormat.getInstance();
 
 	private final ExamineClient examineClient = new ExamineClient();
 	private final Deque<PendingExamine> pending = new ArrayDeque<>();
@@ -335,7 +334,7 @@ public class ExaminePlugin extends Plugin
 			if (quantity > 1)
 			{
 				message
-					.append(NUMBER_FORMATTER.format(quantity))
+					.append(StackFormatter.formatNumber(quantity))
 					.append(" x ");
 			}
 
@@ -350,7 +349,7 @@ public class ExaminePlugin extends Plugin
 					.append(ChatColorType.NORMAL)
 					.append(" GE average ")
 					.append(ChatColorType.HIGHLIGHT)
-					.append(NUMBER_FORMATTER.format(gePrice * quantity));
+					.append(StackFormatter.formatNumber(gePrice * quantity));
 			}
 
 			if (quantity > 1)
@@ -359,7 +358,7 @@ public class ExaminePlugin extends Plugin
 					.append(ChatColorType.NORMAL)
 					.append(" (")
 					.append(ChatColorType.HIGHLIGHT)
-					.append(NUMBER_FORMATTER.format(gePrice))
+					.append(StackFormatter.formatNumber(gePrice))
 					.append(ChatColorType.NORMAL)
 					.append("ea)");
 			}
@@ -370,7 +369,7 @@ public class ExaminePlugin extends Plugin
 					.append(ChatColorType.NORMAL)
 					.append(" HA value ")
 					.append(ChatColorType.HIGHLIGHT)
-					.append(NUMBER_FORMATTER.format(alchPrice * quantity));
+					.append(StackFormatter.formatNumber(alchPrice * quantity));
 			}
 
 			if (quantity > 1)
@@ -379,7 +378,7 @@ public class ExaminePlugin extends Plugin
 					.append(ChatColorType.NORMAL)
 					.append(" (")
 					.append(ChatColorType.HIGHLIGHT)
-					.append(NUMBER_FORMATTER.format(alchPrice))
+					.append(StackFormatter.formatNumber(alchPrice))
 					.append(ChatColorType.NORMAL)
 					.append("ea)");
 			}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangeItemPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangeItemPanel.java
@@ -31,7 +31,6 @@ import java.awt.GridLayout;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.awt.image.BufferedImage;
-import java.text.NumberFormat;
 import javax.swing.ImageIcon;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
@@ -40,11 +39,11 @@ import javax.swing.border.EmptyBorder;
 import javax.swing.border.LineBorder;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.client.util.LinkBrowser;
+import net.runelite.client.util.StackFormatter;
 
 @Slf4j
 class GrandExchangeItemPanel extends JPanel
 {
-	private static final NumberFormat NUMBER_FORMATTER = NumberFormat.getInstance();
 	private static final Dimension ICON_SIZE = new Dimension(32, 32);
 
 	GrandExchangeItemPanel(BufferedImage icon, String name, int itemID, int gePrice, Double
@@ -106,7 +105,7 @@ class GrandExchangeItemPanel extends JPanel
 		JLabel gePriceLabel = new JLabel();
 		if (gePrice > 0)
 		{
-			gePriceLabel.setText(NUMBER_FORMATTER.format(gePrice) + " gp");
+			gePriceLabel.setText(StackFormatter.formatNumber(gePrice) + " gp");
 		}
 		else
 		{
@@ -117,7 +116,7 @@ class GrandExchangeItemPanel extends JPanel
 
 		// Alch price
 		JLabel haPriceLabel = new JLabel();
-		haPriceLabel.setText(NUMBER_FORMATTER.format(haPrice.intValue()) + " alch");
+		haPriceLabel.setText(StackFormatter.formatNumber(haPrice.intValue()) + " alch");
 		haPriceLabel.setForeground(Color.orange);
 		rightPanel.add(haPriceLabel);
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangeOfferSlot.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangeOfferSlot.java
@@ -29,7 +29,6 @@ import java.awt.BorderLayout;
 import java.awt.CardLayout;
 import java.awt.Color;
 import java.awt.image.BufferedImage;
-import java.text.NumberFormat;
 import javax.annotation.Nullable;
 import javax.swing.BorderFactory;
 import javax.swing.Box;
@@ -44,12 +43,11 @@ import net.runelite.api.GrandExchangeOffer;
 import net.runelite.api.GrandExchangeOfferState;
 import static net.runelite.api.GrandExchangeOfferState.EMPTY;
 import net.runelite.api.ItemComposition;
+import net.runelite.client.util.StackFormatter;
 
 @Slf4j
 public class GrandExchangeOfferSlot extends JPanel
 {
-	private static final NumberFormat NUMBER_FORMATTER = NumberFormat.getInstance();
-
 	private static final Color GE_INPROGRESS_ORANGE = new Color(0xd8, 0x80, 0x20).brighter();
 	private static final Color GE_FINISHED_GREEN = new Color(0, 0x5f, 0);
 	private static final Color GE_CANCELLED_RED = new Color(0x8f, 0, 0);
@@ -136,7 +134,8 @@ public class GrandExchangeOfferSlot extends JPanel
 			ImageIcon newItemIcon = new ImageIcon(itemImage);
 			itemIcon.setIcon(newItemIcon);
 
-			offerState.setText(getNameForState(newOffer.getState()) + " at " + NUMBER_FORMATTER.format(newOffer.getPrice()) + (newOffer.getTotalQuantity() > 1 ? "gp ea" : "gp"));
+			offerState.setText(getNameForState(newOffer.getState()) + " at " + StackFormatter.formatNumber(newOffer.getPrice()) +
+				(newOffer.getTotalQuantity() > 1 ? "gp ea" : "gp"));
 
 			progressBar.setMaximum(newOffer.getTotalQuantity());
 			progressBar.setValue(newOffer.getQuantitySold());

--- a/runelite-client/src/main/java/net/runelite/client/plugins/hiscore/HiscorePanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/hiscore/HiscorePanel.java
@@ -24,8 +24,6 @@
  */
 package net.runelite.client.plugins.hiscore;
 
-import java.awt.event.MouseAdapter;
-import static net.runelite.http.api.hiscore.HiscoreSkill.*;
 import com.google.common.base.Strings;
 import java.awt.BorderLayout;
 import java.awt.Color;
@@ -35,10 +33,10 @@ import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.GridLayout;
 import java.awt.Insets;
+import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
-import java.text.NumberFormat;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ScheduledExecutorService;
@@ -58,10 +56,39 @@ import javax.swing.event.MouseInputAdapter;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Experience;
 import net.runelite.client.ui.PluginPanel;
+import net.runelite.client.util.StackFormatter;
 import net.runelite.http.api.hiscore.HiscoreClient;
 import net.runelite.http.api.hiscore.HiscoreEndpoint;
 import net.runelite.http.api.hiscore.HiscoreResult;
 import net.runelite.http.api.hiscore.HiscoreSkill;
+import static net.runelite.http.api.hiscore.HiscoreSkill.AGILITY;
+import static net.runelite.http.api.hiscore.HiscoreSkill.ATTACK;
+import static net.runelite.http.api.hiscore.HiscoreSkill.BOUNTY_HUNTER_HUNTER;
+import static net.runelite.http.api.hiscore.HiscoreSkill.BOUNTY_HUNTER_ROGUE;
+import static net.runelite.http.api.hiscore.HiscoreSkill.CLUE_SCROLL_ALL;
+import static net.runelite.http.api.hiscore.HiscoreSkill.CONSTRUCTION;
+import static net.runelite.http.api.hiscore.HiscoreSkill.COOKING;
+import static net.runelite.http.api.hiscore.HiscoreSkill.CRAFTING;
+import static net.runelite.http.api.hiscore.HiscoreSkill.DEFENCE;
+import static net.runelite.http.api.hiscore.HiscoreSkill.FARMING;
+import static net.runelite.http.api.hiscore.HiscoreSkill.FIREMAKING;
+import static net.runelite.http.api.hiscore.HiscoreSkill.FISHING;
+import static net.runelite.http.api.hiscore.HiscoreSkill.FLETCHING;
+import static net.runelite.http.api.hiscore.HiscoreSkill.HERBLORE;
+import static net.runelite.http.api.hiscore.HiscoreSkill.HITPOINTS;
+import static net.runelite.http.api.hiscore.HiscoreSkill.HUNTER;
+import static net.runelite.http.api.hiscore.HiscoreSkill.LAST_MAN_STANDING;
+import static net.runelite.http.api.hiscore.HiscoreSkill.MAGIC;
+import static net.runelite.http.api.hiscore.HiscoreSkill.MINING;
+import static net.runelite.http.api.hiscore.HiscoreSkill.OVERALL;
+import static net.runelite.http.api.hiscore.HiscoreSkill.PRAYER;
+import static net.runelite.http.api.hiscore.HiscoreSkill.RANGED;
+import static net.runelite.http.api.hiscore.HiscoreSkill.RUNECRAFT;
+import static net.runelite.http.api.hiscore.HiscoreSkill.SLAYER;
+import static net.runelite.http.api.hiscore.HiscoreSkill.SMITHING;
+import static net.runelite.http.api.hiscore.HiscoreSkill.STRENGTH;
+import static net.runelite.http.api.hiscore.HiscoreSkill.THIEVING;
+import static net.runelite.http.api.hiscore.HiscoreSkill.WOODCUTTING;
 import net.runelite.http.api.hiscore.Skill;
 
 @Slf4j
@@ -69,8 +96,6 @@ public class HiscorePanel extends PluginPanel
 {
 	private static final String SKILL_NAME = "SKILL_NAME";
 	private static final String SKILL = "SKILL";
-
-	private static final NumberFormat NUMBER_FORMATTER = NumberFormat.getInstance();
 
 	private static final HiscoreSkill[] SKILL_PANEL_ORDER = new HiscoreSkill[]
 	{
@@ -290,8 +315,8 @@ public class HiscorePanel extends PluginPanel
 					result.getPrayer().getLevel()
 				);
 				text = "Skill: Combat" + System.lineSeparator()
-					+ "Exact Combat Level: " + NUMBER_FORMATTER.format(combatLevel) + System.lineSeparator()
-					+ "Experience: " + NUMBER_FORMATTER.format(result.getAttack().getExperience()
+					+ "Exact Combat Level: " + StackFormatter.formatNumber(combatLevel) + System.lineSeparator()
+					+ "Experience: " + StackFormatter.formatNumber(result.getAttack().getExperience()
 					+ result.getStrength().getExperience() + result.getDefence().getExperience()
 					+ result.getHitpoints().getExperience() + result.getMagic().getExperience()
 					+ result.getRanged().getExperience() + result.getPrayer().getExperience());
@@ -299,28 +324,28 @@ public class HiscorePanel extends PluginPanel
 			}
 			case "Clue Scrolls (all)":
 			{
-				String rank = (result.getClueScrollAll().getRank() == -1) ? "Unranked" : NUMBER_FORMATTER.format(result.getClueScrollAll().getRank());
+				String rank = (result.getClueScrollAll().getRank() == -1) ? "Unranked" : StackFormatter.formatNumber(result.getClueScrollAll().getRank());
 				text = "Total Clue Scrolls Completed" + System.lineSeparator()
 					+ "Rank: " + rank;
 				break;
 			}
 			case "Bounty Hunter - Rogue":
 			{
-				String rank = (result.getBountyHunterRogue().getRank() == -1) ? "Unranked" : NUMBER_FORMATTER.format(result.getBountyHunterRogue().getRank());
+				String rank = (result.getBountyHunterRogue().getRank() == -1) ? "Unranked" : StackFormatter.formatNumber(result.getBountyHunterRogue().getRank());
 				text = "Bounty Hunter - Rogue Kills" + System.lineSeparator()
 					+ "Rank: " + rank;
 				break;
 			}
 			case "Bounty Hunter - Hunter":
 			{
-				String rank = (result.getBountyHunterHunter().getRank() == -1) ? "Unranked" : NUMBER_FORMATTER.format(result.getBountyHunterHunter().getRank());
+				String rank = (result.getBountyHunterHunter().getRank() == -1) ? "Unranked" : StackFormatter.formatNumber(result.getBountyHunterHunter().getRank());
 				text = "Bounty Hunter - Hunter Kills" + System.lineSeparator()
 						+ "Rank: " + rank;
 				break;
 			}
 			case "Last Man Standing":
 			{
-				String rank = (result.getLastManStanding().getRank() == -1) ? "Unranked" : NUMBER_FORMATTER.format(result.getLastManStanding().getRank());
+				String rank = (result.getLastManStanding().getRank() == -1) ? "Unranked" : StackFormatter.formatNumber(result.getLastManStanding().getRank());
 				text = "Last Man Standing" + System.lineSeparator()
 						+ "Rank: " + rank;
 				break;
@@ -328,8 +353,8 @@ public class HiscorePanel extends PluginPanel
 			case "Overall":
 			{
 				Skill requestedSkill = result.getSkill(skill);
-				String rank = (requestedSkill.getRank() == -1) ? "Unranked" : NUMBER_FORMATTER.format(requestedSkill.getRank());
-				String exp = (requestedSkill.getRank() == -1) ? "Unranked" : NUMBER_FORMATTER.format(requestedSkill.getExperience());
+				String rank = (requestedSkill.getRank() == -1) ? "Unranked" : StackFormatter.formatNumber(requestedSkill.getRank());
+				String exp = (requestedSkill.getRank() == -1) ? "Unranked" : StackFormatter.formatNumber(requestedSkill.getExperience());
 				text = "Skill: " + skillName + System.lineSeparator()
 					+ "Rank: " + rank + System.lineSeparator()
 					+ "Experience: " + exp;
@@ -338,8 +363,8 @@ public class HiscorePanel extends PluginPanel
 			default:
 			{
 				Skill requestedSkill = result.getSkill(skill);
-				String rank = (requestedSkill.getRank() == -1) ? "Unranked" : NUMBER_FORMATTER.format(requestedSkill.getRank());
-				String exp = (requestedSkill.getRank() == -1) ? "Unranked" : NUMBER_FORMATTER.format(requestedSkill.getExperience());
+				String rank = (requestedSkill.getRank() == -1) ? "Unranked" : StackFormatter.formatNumber(requestedSkill.getRank());
+				String exp = (requestedSkill.getRank() == -1) ? "Unranked" : StackFormatter.formatNumber(requestedSkill.getExperience());
 				String remainingXp;
 				if (requestedSkill.getRank() == -1)
 				{
@@ -348,7 +373,7 @@ public class HiscorePanel extends PluginPanel
 				else
 				{
 					int currentLevel = Experience.getLevelForXp((int) requestedSkill.getExperience());
-					remainingXp = (currentLevel + 1 <= Experience.MAX_VIRT_LEVEL) ? NUMBER_FORMATTER.format(Experience.getXpForLevel(currentLevel + 1) - requestedSkill.getExperience()) : "0";
+					remainingXp = (currentLevel + 1 <= Experience.MAX_VIRT_LEVEL) ? StackFormatter.formatNumber(Experience.getXpForLevel(currentLevel + 1) - requestedSkill.getExperience()) : "0";
 				}
 				text = "Skill: " + skillName + System.lineSeparator()
 					+ "Rank: " + rank + System.lineSeparator()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemprices/ItemPricesOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemprices/ItemPricesOverlay.java
@@ -26,7 +26,6 @@ package net.runelite.client.plugins.itemprices;
 
 import java.awt.Dimension;
 import java.awt.Graphics2D;
-import java.text.NumberFormat;
 import javax.inject.Inject;
 import net.runelite.api.Client;
 import net.runelite.api.InventoryID;
@@ -50,8 +49,6 @@ class ItemPricesOverlay extends Overlay
 {
 	// Used when getting High Alchemy value - multiplied by general store price.
 	private static final float HIGH_ALCHEMY_CONSTANT = 0.6f;
-
-	private static final NumberFormat NUMBER_FORMATTER = NumberFormat.getInstance();
 
 	private static final int INVENTORY_ITEM_WIDGETID = WidgetInfo.INVENTORY.getPackedId();
 	private static final int BANK_INVENTORY_ITEM_WIDGETID = WidgetInfo.BANK_INVENTORY_ITEMS_CONTAINER.getPackedId();
@@ -176,11 +173,11 @@ class ItemPricesOverlay extends Overlay
 		// Special case for coins and platinum tokens
 		if (id == ItemID.COINS_995)
 		{
-			return NUMBER_FORMATTER.format(qty) + " gp";
+			return StackFormatter.formatNumber(qty) + " gp";
 		}
 		else if (id == ItemID.PLATINUM_TOKEN)
 		{
-			return NUMBER_FORMATTER.format(qty * 1000) + " gp";
+			return StackFormatter.formatNumber(qty * 1000) + " gp";
 		}
 
 		final ItemComposition itemDef = itemManager.getItemComposition(id);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/nightmarezone/NightmareZoneOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/nightmarezone/NightmareZoneOverlay.java
@@ -39,6 +39,7 @@ import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.OverlayPriority;
 import net.runelite.client.ui.overlay.components.PanelComponent;
 import net.runelite.client.ui.overlay.infobox.InfoBoxManager;
+import net.runelite.client.util.StackFormatter;
 
 class NightmareZoneOverlay extends Overlay
 {
@@ -99,7 +100,7 @@ class NightmareZoneOverlay extends Overlay
 		panelComponent.getLines().add(new PanelComponent.Line(
 				"Points: ",
 				Color.WHITE,
-				Integer.toString(client.getSetting(Varbits.NMZ_POINTS)),
+				StackFormatter.formatNumber(client.getSetting(Varbits.NMZ_POINTS)),
 				Color.WHITE
 		));
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpPanel.java
@@ -27,7 +27,6 @@ package net.runelite.client.plugins.xptracker;
 import java.awt.BorderLayout;
 import java.awt.GridLayout;
 import java.io.IOException;
-import java.text.NumberFormat;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -42,12 +41,11 @@ import net.runelite.api.Client;
 import net.runelite.api.Skill;
 import net.runelite.client.game.SkillIconManager;
 import net.runelite.client.ui.PluginPanel;
+import net.runelite.client.util.StackFormatter;
 
 @Slf4j
 class XpPanel extends PluginPanel
 {
-	private static final NumberFormat NUMBER_FORMATTER = NumberFormat.getInstance();
-
 	private final Map<Skill, XpInfoBox> infoBoxes = new HashMap<>();
 	private final JLabel totalXpGained = new JLabel();
 	private final JLabel totalXpHr = new JLabel();
@@ -145,7 +143,7 @@ class XpPanel extends PluginPanel
 		String numberStr;
 		if (number < 100000)
 		{
-			numberStr = NUMBER_FORMATTER.format(number);
+			numberStr = StackFormatter.formatNumber(number);
 		}
 		else
 		{

--- a/runelite-client/src/main/java/net/runelite/client/util/StackFormatter.java
+++ b/runelite-client/src/main/java/net/runelite/client/util/StackFormatter.java
@@ -143,6 +143,34 @@ public class StackFormatter
 	}
 
 	/**
+	 * Specialization of format.
+	 *
+	 * @param number the long number to format
+	 * @return the formatted String
+	 * @exception        ArithmeticException if rounding is needed with rounding
+	 *                   mode being set to RoundingMode.UNNECESSARY
+	 * @see java.text.Format#format
+	 */
+	public static String formatNumber(final long number)
+	{
+		return NUMBER_FORMATTER.format(number);
+	}
+
+	/**
+	 * Specialization of format.
+	 *
+	 * @param number the double number to format
+	 * @return the formatted String
+	 * @exception        ArithmeticException if rounding is needed with rounding
+	 *                   mode being set to RoundingMode.UNNECESSARY
+	 * @see java.text.Format#format
+	 */
+	public static String formatNumber(double number)
+	{
+		return NUMBER_FORMATTER.format(number);
+	}
+
+	/**
 	 * Calculates, given a string with a value denominator (ex. 20K)
 	 * the multiplier that the denominator represents (in this case 1000).
 	 *


### PR DESCRIPTION
- Add formatNumber methods to StackFormatter that reuse the NumberFormat
instance
- Use new methods instead of using created NumberFormats on other places
- Use new formatter in NightmareZonePlugin

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>