### PR TITLE
Item price tooltip: use linebreak instead of comma

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemprices/ItemPricesOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemprices/ItemPricesOverlay.java
@@ -231,8 +231,12 @@ class ItemPricesOverlay extends Overlay
 		}
 		if (haValue > 0)
 		{
-			itemStringBuilder.append(gePrice > 0 ? ", " : "")
-				.append("HA: ")
+			if (gePrice > 0)
+			{
+				itemStringBuilder.append("</br>");
+			}
+
+			itemStringBuilder.append("HA: ")
 				.append(StackFormatter.quantityToStackSize(haValue * qty))
 				.append(" gp");
 			if (config.showEA() && qty > 1)


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/35824069/37834679-912bb68e-2eae-11e8-952a-840e3c8bcc79.png)

After:
![image](https://user-images.githubusercontent.com/35824069/37834613-65db48aa-2eae-11e8-835d-401ccffd661b.png)
