### PR TITLE
Replace default raids points widget with our own overlay

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/Varbits.java
+++ b/runelite-api/src/main/java/net/runelite/api/Varbits.java
@@ -228,6 +228,7 @@ public enum Varbits
 	IN_RAID(5432),
 	TOTAL_POINTS(5431),
 	PERSONAL_POINTS(5422),
+	RAID_PARTY_SIZE(5424),
 
 	/**
 	 * Nightmare Zone

--- a/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsOverlay.java
@@ -56,11 +56,6 @@ public class RaidsOverlay extends Overlay
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
-		if (plugin.isInRaidChambers())
-		{
-			plugin.repositionPointsBox();
-		}
-
 		if (!config.scoutOverlay() || !scoutOverlayShown)
 		{
 			return null;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsPlugin.java
@@ -34,6 +34,7 @@ import java.text.DecimalFormat;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.imageio.ImageIO;
@@ -53,6 +54,7 @@ import static net.runelite.api.Perspective.SCENE_SIZE;
 import net.runelite.api.events.ChatMessage;
 import net.runelite.api.events.ConfigChanged;
 import net.runelite.api.events.VarbitChanged;
+import net.runelite.api.events.WidgetHiddenChanged;
 import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.chat.ChatColor;
@@ -81,7 +83,7 @@ public class RaidsPlugin extends Plugin
 	private static final String LEVEL_COMPLETE_MESSAGE = "level complete!";
 	private static final String RAID_COMPLETE_MESSAGE = "Congratulations - your raid is complete!";
 	private static final DecimalFormat DECIMAL_FORMAT = new DecimalFormat("###.##");
-	private static final DecimalFormat POINTS_FORMAT = new DecimalFormat("#,###");
+	public static final DecimalFormat POINTS_FORMAT = new DecimalFormat("#,###");
 	private static final String SPLIT_REGEX = "\\s*,\\s*";
 	private static final Pattern ROTATION_REGEX = Pattern.compile("\\[(.*?)\\]");
 
@@ -105,6 +107,9 @@ public class RaidsPlugin extends Plugin
 
 	@Inject
 	private RaidsOverlay overlay;
+
+	@Inject
+	private RaidsPointsOverlay pointsOverlay;
 
 	@Inject
 	private LayoutSolver layoutSolver;
@@ -137,9 +142,9 @@ public class RaidsPlugin extends Plugin
 	}
 
 	@Override
-	public Overlay getOverlay()
+	public List<Overlay> getOverlays()
 	{
-		return overlay;
+		return Arrays.asList(overlay, pointsOverlay);
 	}
 
 	@Override
@@ -199,6 +204,22 @@ public class RaidsPlugin extends Plugin
 		if (event.getKey().equals("whitelistedLayouts"))
 		{
 			updateList(layoutWhitelist, config.whitelistedLayouts());
+		}
+	}
+
+	@Subscribe
+	public void onWidgetHiddenChanged(WidgetHiddenChanged event)
+	{
+		if (!inRaidChambers || event.isHidden())
+		{
+			return;
+		}
+
+		Widget widget = event.getWidget();
+
+		if (widget == client.getWidget(WidgetInfo.RAIDS_POINTS_INFOBOX))
+		{
+			widget.setHidden(true);
 		}
 	}
 
@@ -305,27 +326,6 @@ public class RaidsPlugin extends Plugin
 				}
 			}
 		}
-	}
-
-	public void repositionPointsBox()
-	{
-		Widget widget = client.getWidget(WidgetInfo.RAIDS_POINTS_INFOBOX);
-		int x = widget.getParent().getWidth() - widget.getWidth() - 2;
-		int y = widget.getOriginalY();
-
-		if (client.getSetting(Varbits.EXPERIENCE_TRACKER_POSITION) == 0)
-		{
-			Widget area = client.getWidget(WidgetInfo.EXPERIENCE_TRACKER_BOTTOM_BAR);
-
-			if (area != null)
-			{
-				y = area.getOriginalY() + 2;
-				area.setRelativeY(y + widget.getHeight());
-			}
-		}
-
-		widget.setRelativeX(x);
-		widget.setRelativeY(y);
 	}
 
 	private void updateInfoBoxState()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsPointsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsPointsOverlay.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2018, Kamiel
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.raids;
+
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Graphics2D;
+import javax.inject.Inject;
+import net.runelite.api.Client;
+import net.runelite.api.Varbits;
+import static net.runelite.client.plugins.raids.RaidsPlugin.POINTS_FORMAT;
+import net.runelite.client.ui.overlay.Overlay;
+import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.OverlayPriority;
+import net.runelite.client.ui.overlay.components.PanelComponent;
+
+public class RaidsPointsOverlay extends Overlay
+{
+	@Inject
+	private Client client;
+
+	@Inject
+	private RaidsPlugin plugin;
+
+	private final PanelComponent panel = new PanelComponent();
+
+	@Inject
+	public RaidsPointsOverlay()
+	{
+		setPosition(OverlayPosition.TOP_RIGHT);
+		setPriority(OverlayPriority.HIGH);
+	}
+
+	@Override
+	public Dimension render(Graphics2D graphics)
+	{
+		if (!plugin.isInRaidChambers())
+		{
+			return null;
+		}
+
+		int totalPoints = client.getSetting(Varbits.TOTAL_POINTS);
+		int personalPoints = client.getSetting(Varbits.PERSONAL_POINTS);
+
+		panel.getLines().clear();
+		panel.getLines().add(new PanelComponent.Line(
+			"Total:", Color.WHITE, POINTS_FORMAT.format(totalPoints), Color.WHITE
+		));
+		panel.getLines().add(new PanelComponent.Line(
+			client.getLocalPlayer().getName() + ":", Color.WHITE, POINTS_FORMAT.format(personalPoints), Color.WHITE
+		));
+		panel.getLines().add(new PanelComponent.Line(
+			"Party size:", Color.WHITE, String.valueOf(client.getSetting(Varbits.RAID_PARTY_SIZE)), Color.WHITE
+		));
+
+		return panel.render(graphics);
+	}
+}


### PR DESCRIPTION
Replaces the default client's point box with our own overlay. This will also allow the user to move it around freely.

![image](https://user-images.githubusercontent.com/35824069/37843269-bde6f5ce-2ec4-11e8-8e1c-986f1e644c1c.png)

Also shows raid party size.