### PR TITLE
Add null-check for overlays in OverlayRenderer

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayRenderer.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayRenderer.java
@@ -262,6 +262,7 @@ public class OverlayRenderer extends MouseListener implements KeyListener
 		final List<Overlay> overlays = overlayLayerOverlayMap.get(layer);
 
 		if (client == null
+			|| overlays == null
 			|| overlays.isEmpty()
 			|| client.getViewportWidget() == null
 			|| client.getGameState() != GameState.LOGGED_IN


### PR DESCRIPTION
Sometimes right after login overlays can be null instead of empty list.
Add null check to prevent ending on NPE.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>