### PR TITLE
Add notifications for NMZ power-up spawns

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/nightmarezone/NightmareZoneConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/nightmarezone/NightmareZoneConfig.java
@@ -70,21 +70,10 @@ public interface NightmareZoneConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "ultimateforcenotification",
-		name = "Ultimate force notification",
-		description = "Toggles notifications when a ultimate force power-up appears",
-		position = 4
-	)
-	default boolean ultimateForceNotification()
-	{
-		return false;
-	}
-
-	@ConfigItem(
 		keyName = "zappernotification",
 		name = "Zapper notification",
 		description = "Toggles notifications when a zapper power-up appears",
-		position = 5
+		position = 4
 	)
 	default boolean zapperNotification()
 	{
@@ -95,7 +84,7 @@ public interface NightmareZoneConfig extends Config
 		keyName = "overloadnotification",
 		name = "Overload notification",
 		description = "Toggles notifications when your overload runs out",
-		position = 6
+		position = 5
 	)
 	default boolean overloadNotification()
 	{
@@ -106,7 +95,7 @@ public interface NightmareZoneConfig extends Config
 		keyName = "absorptionnotification",
 		name = "Absorption notification",
 		description = "Toggles notifications when your absorption points gets below your threshold",
-		position = 7
+		position = 6
 	)
 	default boolean absorptionNotification()
 	{
@@ -117,7 +106,7 @@ public interface NightmareZoneConfig extends Config
 		keyName = "absorptionthreshold",
 		name = "Absorption Threshold",
 		description = "The amount of absorption points to send a notification at",
-		position = 8
+		position = 7
 	)
 	default int absorptionThreshold()
 	{
@@ -128,7 +117,7 @@ public interface NightmareZoneConfig extends Config
 		keyName = "absorptioncoloroverthreshold",
 		name = "Color above threshold",
 		description = "Configures the color for the absorption widget when above the threshold",
-		position = 9
+		position = 8
 	)
 	default Color absorptionColorAboveThreshold()
 	{
@@ -139,7 +128,7 @@ public interface NightmareZoneConfig extends Config
 		keyName = "absorptioncolorbelowthreshold",
 		name = "Color below threshold",
 		description = "Configures the color for the absorption widget when below the threshold",
-		position = 10
+		position = 9
 	)
 	default Color absorptionColorBelowThreshold()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/nightmarezone/NightmareZoneConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/nightmarezone/NightmareZoneConfig.java
@@ -48,10 +48,54 @@ public interface NightmareZoneConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "powersurgenotification",
+		name = "Power surge notification",
+		description = "Toggles notifications when a power surge power-up appears",
+		position = 2
+	)
+	default boolean powerSurgeNotification()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		keyName = "recurrentdamagenotification",
+		name = "Recurrent damage notification",
+		description = "Toggles notifications when a recurrent damge power-up appears",
+		position = 3
+	)
+	default boolean recurrentDamageNotification()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		keyName = "ultimateforcenotification",
+		name = "Ultimate force notification",
+		description = "Toggles notifications when a ultimate force power-up appears",
+		position = 4
+	)
+	default boolean ultimateForceNotification()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		keyName = "zappernotification",
+		name = "Zapper notification",
+		description = "Toggles notifications when a zapper power-up appears",
+		position = 5
+	)
+	default boolean zapperNotification()
+	{
+		return false;
+	}
+
+	@ConfigItem(
 		keyName = "overloadnotification",
 		name = "Overload notification",
 		description = "Toggles notifications when your overload runs out",
-		position = 2
+		position = 6
 	)
 	default boolean overloadNotification()
 	{
@@ -62,7 +106,7 @@ public interface NightmareZoneConfig extends Config
 		keyName = "absorptionnotification",
 		name = "Absorption notification",
 		description = "Toggles notifications when your absorption points gets below your threshold",
-		position = 3
+		position = 7
 	)
 	default boolean absorptionNotification()
 	{
@@ -73,7 +117,7 @@ public interface NightmareZoneConfig extends Config
 		keyName = "absorptionthreshold",
 		name = "Absorption Threshold",
 		description = "The amount of absorption points to send a notification at",
-		position = 4
+		position = 8
 	)
 	default int absorptionThreshold()
 	{
@@ -84,7 +128,7 @@ public interface NightmareZoneConfig extends Config
 		keyName = "absorptioncoloroverthreshold",
 		name = "Color above threshold",
 		description = "Configures the color for the absorption widget when above the threshold",
-		position = 5
+		position = 9
 	)
 	default Color absorptionColorAboveThreshold()
 	{
@@ -95,7 +139,7 @@ public interface NightmareZoneConfig extends Config
 		keyName = "absorptioncolorbelowthreshold",
 		name = "Color below threshold",
 		description = "Configures the color for the absorption widget when below the threshold",
-		position = 6
+		position = 10
 	)
 	default Color absorptionColorBelowThreshold()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/nightmarezone/NightmareZoneConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/nightmarezone/NightmareZoneConfig.java
@@ -61,7 +61,7 @@ public interface NightmareZoneConfig extends Config
 	@ConfigItem(
 		keyName = "recurrentdamagenotification",
 		name = "Recurrent damage notification",
-		description = "Toggles notifications when a recurrent damge power-up appears",
+		description = "Toggles notifications when a recurrent damage power-up appears",
 		position = 3
 	)
 	default boolean recurrentDamageNotification()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/nightmarezone/NightmareZonePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/nightmarezone/NightmareZonePlugin.java
@@ -110,7 +110,7 @@ public class NightmareZonePlugin extends Plugin
 			return;
 		}
 
-		String msg = Text.removeTags(event.getMessage()); //remove color and linebreaks
+		String msg = Text.removeTags(event.getMessage()); //remove color
 		if (msg.contains("The effects of overload have worn off, and you feel normal again."))
 		{
 			if (config.overloadNotification())
@@ -118,30 +118,30 @@ public class NightmareZonePlugin extends Plugin
 				notifier.notify("Your overload has worn off");
 			}
 		}
-		else if (msg.startsWith("A power-up has spawned:"))
+		else if (msg.contains("A power-up has spawned:"))
 		{
-			if (msg.endsWith("Power surge"))
+			if (msg.contains("Power surge"))
 			{
 				if (config.powerSurgeNotification())
 				{
 					notifier.notify(msg);
 				}
 			}
-			else if (msg.endsWith("Recurrent damage"))
+			else if (msg.contains("Recurrent damage"))
 			{
 				if (config.recurrentDamageNotification())
 				{
 					notifier.notify(msg);
 				}
 			}
-			else if (msg.endsWith("Ultimate force"))
+			else if (msg.contains("Ultimate force"))
 			{
 				if (config.ultimateForceNotification())
 				{
 					notifier.notify(msg);
 				}
 			}
-			else if (msg.endsWith("Zapper"))
+			else if (msg.contains("Zapper"))
 			{
 				if (config.zapperNotification())
 				{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/nightmarezone/NightmareZonePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/nightmarezone/NightmareZonePlugin.java
@@ -134,13 +134,6 @@ public class NightmareZonePlugin extends Plugin
 					notifier.notify(msg);
 				}
 			}
-			else if (msg.contains("Ultimate force"))
-			{
-				if (config.ultimateForceNotification())
-				{
-					notifier.notify(msg);
-				}
-			}
 			else if (msg.contains("Zapper"))
 			{
 				if (config.zapperNotification())

--- a/runelite-client/src/main/java/net/runelite/client/plugins/nightmarezone/NightmareZonePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/nightmarezone/NightmareZonePlugin.java
@@ -105,8 +105,7 @@ public class NightmareZonePlugin extends Plugin
 	public void onChatMessage(ChatMessage event)
 	{
 		if (event.getType() != ChatMessageType.SERVER
-				|| !isInNightmareZone()
-				|| !config.overloadNotification())
+				|| !isInNightmareZone())
 		{
 			return;
 		}
@@ -114,7 +113,41 @@ public class NightmareZonePlugin extends Plugin
 		String msg = Text.removeTags(event.getMessage()); //remove color and linebreaks
 		if (msg.contains("The effects of overload have worn off, and you feel normal again."))
 		{
-			notifier.notify("Your overload has worn off");
+			if (config.overloadNotification())
+			{
+				notifier.notify("Your overload has worn off");
+			}
+		}
+		else if (msg.startsWith("A power-up has spawned:"))
+		{
+			if (msg.endsWith("Power surge"))
+			{
+				if (config.powerSurgeNotification())
+				{
+					notifier.notify(msg);
+				}
+			}
+			else if (msg.endsWith("Recurrent damage"))
+			{
+				if (config.recurrentDamageNotification())
+				{
+					notifier.notify(msg);
+				}
+			}
+			else if (msg.endsWith("Ultimate force"))
+			{
+				if (config.ultimateForceNotification())
+				{
+					notifier.notify(msg);
+				}
+			}
+			else if (msg.endsWith("Zapper"))
+			{
+				if (config.zapperNotification())
+				{
+					notifier.notify(msg);
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
A pretty simple change, just scans the chat like the overload notification. This makes afk NMZ completely notification driven if you, like me, want to collect zappers or power surges for extra points/prayer.