### PR TITLE
Add Lay/take option for MenuEntrySwap

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -188,4 +188,15 @@ public interface MenuEntrySwapperConfig extends Config
 	{
 		return true;
 	}
+
+	@ConfigItem(
+			position = 14,
+			keyName = "swapHunterTrap",
+			name = "Lay hunter trap",
+			description = "Swap take with lay on hunter traps"
+	)
+	default boolean swapHunterTrap()
+	{
+		return true;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -144,6 +144,10 @@ public class MenuEntrySwapperPlugin extends Plugin
 		{
 			swap("use", option, target, true);
 		}
+		else if (config.swapHunterTrap() && option.equals("take"))
+		{
+			swap("lay", option, target, true);
+		}
 	}
 
 	private int searchIndex(MenuEntry[] entries, String option, String target, boolean strict)


### PR DESCRIPTION
at least this part swaps the lay/take if a trap is unset on the ground. there is no relay as stated in the issue.

partly addresses issue #1085