### PR TITLE
Add getCanvasOffset to clientUI, fix screenshots

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
@@ -54,6 +54,7 @@ import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
 import net.runelite.api.GameState;
+import net.runelite.api.Point;
 import net.runelite.api.events.ChatMessage;
 import net.runelite.api.events.WidgetHiddenChanged;
 import net.runelite.api.widgets.Widget;
@@ -380,8 +381,9 @@ public class ScreenshotPlugin extends Plugin
 				clientUi.paint(graphics);
 
 				// Evaluate the position of the game inside the frame
-				gameOffsetX = 6;
-				gameOffsetY = 0;
+				final Point canvasOffset = clientUi.getCanvasOffset();
+				gameOffsetX = canvasOffset.getX();
+				gameOffsetY = canvasOffset.getY();
 			}
 
 			// Draw the game onto the screenshot

--- a/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
@@ -54,6 +54,7 @@ import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.GameState;
+import net.runelite.api.Point;
 import net.runelite.api.events.ConfigChanged;
 import net.runelite.client.RuneLite;
 import net.runelite.client.RuneLiteProperties;
@@ -446,6 +447,21 @@ public class ClientUI
 
 		frame.requestFocus();
 		giveClientFocus();
+	}
+
+	/**
+	 * Get offset of game canvas in game window
+	 * @return game canvas offset
+	 */
+	public Point getCanvasOffset()
+	{
+		if (client instanceof Client)
+		{
+			final java.awt.Point point = SwingUtilities.convertPoint(((Client) client).getCanvas(), 0, 0, frame);
+			return new Point(point.x, point.y);
+		}
+
+		return new Point(0, 0);
 	}
 
 	private void expand(PluginPanel panel)


### PR DESCRIPTION
Fix screenshot offset by exposing getCanvasOffset from ClientUI and
using it when taking screenshots with game frame enabled.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>