### PR TITLE
Ground items: Only consume mouse clicks when a checkbox has been clicked

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemInputListener.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemInputListener.java
@@ -78,8 +78,6 @@ public class GroundItemInputListener extends MouseListener implements KeyListene
 			// Check if left click
 			if (e.getButton() == MouseEvent.BUTTON1)
 			{
-				e.consume();
-
 				Point mousePos = client.getMouseCanvasPosition();
 
 				for (Map.Entry<Rectangle, String> entry : plugin.getHiddenBoxes().entrySet())
@@ -87,6 +85,7 @@ public class GroundItemInputListener extends MouseListener implements KeyListene
 					if (entry.getKey().contains(mousePos.getX(), mousePos.getY()))
 					{
 						plugin.updateList(entry.getValue(), true);
+						e.consume();
 						return e;
 					}
 				}
@@ -96,6 +95,7 @@ public class GroundItemInputListener extends MouseListener implements KeyListene
 					if (entry.getKey().contains(mousePos.getX(), mousePos.getY()))
 					{
 						plugin.updateList(entry.getValue(), false);
+						e.consume();
 						return e;
 					}
 				}


### PR DESCRIPTION
This will allow the default behaviour of dragging the screen camera whilst holding alt again, previously it would consume the event completely while alt was held.