### PR TITLE
Expand panels based on click event not isSelected

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangePlugin.java
@@ -131,7 +131,6 @@ public class GrandExchangePlugin extends Plugin
 
 										if (!button.isSelected())
 										{
-											button.setSelected(true);
 											button.getOnSelect().run();
 										}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/hiscore/HiscorePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/hiscore/HiscorePlugin.java
@@ -129,7 +129,6 @@ public class HiscorePlugin extends Plugin
 					{
 						if (!navButton.isSelected())
 						{
-							navButton.setSelected(true);
 							navButton.getOnSelect().run();
 						}
 					});

--- a/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
@@ -113,6 +113,7 @@ public class ClientUI
 	private ClientPluginToolbar pluginToolbar;
 	private ClientTitleToolbar titleToolbar;
 	private JButton currentButton;
+	private NavigationButton currentNavButton;
 
 	@Inject
 	private ClientUI(
@@ -200,9 +201,9 @@ public class ClientUI
 	{
 		SwingUtilities.invokeLater(() ->
 		{
-			final JButton button = SwingUtil.createSwingButton(event.getButton(), 0, (jButton) ->
+			final JButton button = SwingUtil.createSwingButton(event.getButton(), 0, (navButton, jButton) ->
 			{
-				final PluginPanel panel = event.getButton().getPanel();
+				final PluginPanel panel = navButton.getPanel();
 
 				if (panel == null)
 				{
@@ -214,15 +215,23 @@ public class ClientUI
 					currentButton.setSelected(false);
 				}
 
-				if (currentButton == jButton)
+				if (currentNavButton != null)
+				{
+					currentNavButton.setSelected(false);
+				}
+
+				if (currentButton == jButton && currentNavButton == navButton)
 				{
 					contract();
 					currentButton = null;
+					currentNavButton = null;
 				}
 				else
 				{
 					currentButton = jButton;
+					currentNavButton = navButton;
 					currentButton.setSelected(true);
+					currentNavButton.setSelected(true);
 					expand(panel);
 				}
 			});

--- a/runelite-client/src/main/java/net/runelite/client/ui/NavigationButton.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/NavigationButton.java
@@ -60,14 +60,14 @@ public class NavigationButton
 	private boolean selected;
 
 	/**
-	 * On select action of the button.
-	 */
-	private Runnable onSelect;
-
-	/**
 	 * On click action of the button.
 	 */
 	private Runnable onClick;
+
+	/**
+	 * On select action of the button.
+	 */
+	private Runnable onSelect;
 
 	/**
 	 * Plugin panel, used when expanding and contracting sidebar.

--- a/runelite-client/src/main/java/net/runelite/client/util/SwingUtil.java
+++ b/runelite-client/src/main/java/net/runelite/client/util/SwingUtil.java
@@ -42,7 +42,7 @@ import java.awt.event.WindowEvent;
 import java.awt.image.BufferedImage;
 import java.util.Enumeration;
 import java.util.concurrent.Callable;
-import java.util.function.Consumer;
+import java.util.function.BiConsumer;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.swing.ImageIcon;
@@ -261,7 +261,7 @@ public class SwingUtil
 	public static JButton createSwingButton(
 		@Nonnull final NavigationButton navigationButton,
 		int iconSize,
-		@Nullable final Consumer<JButton> specialCallback)
+		@Nullable final BiConsumer<NavigationButton, JButton> specialCallback)
 	{
 
 		final BufferedImage scaledImage = iconSize > 0
@@ -278,7 +278,7 @@ public class SwingUtil
 		{
 			if (specialCallback != null)
 			{
-				specialCallback.accept(button);
+				specialCallback.accept(navigationButton, button);
 			}
 
 			if (navigationButton.getOnClick() != null)
@@ -301,16 +301,7 @@ public class SwingUtil
 			button.setComponentPopupMenu(popupMenu);
 		}
 
-		navigationButton.setOnSelect(() ->
-		{
-			button.setSelected(navigationButton.isSelected());
-
-			if (navigationButton.isSelected())
-			{
-				button.doClick();
-			}
-		});
-
+		navigationButton.setOnSelect(button::doClick);
 		return button;
 	}
 


### PR DESCRIPTION
- Remove changing of isSelected property on navigation button in order
to open it
- Change navigation button handling to always "click" the wrapped button
no matter if button is selected or not and let the special callback
handle it

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>