### PR TITLE
Do not display mouse tooltips over RS tooltips

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/Client.java
+++ b/runelite-api/src/main/java/net/runelite/api/Client.java
@@ -154,6 +154,8 @@ public interface Client extends GameEngine
 
 	int[] getVarps();
 
+	Varcs getVarcs();
+
 	int getSetting(Setting setting);
 
 	int getSetting(Varbits varbit);

--- a/runelite-api/src/main/java/net/runelite/api/VarClient.java
+++ b/runelite-api/src/main/java/net/runelite/api/VarClient.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2018, Adam <Adam@sigterm.info>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.api;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public enum VarClient
+{
+	TOOLTIP_TIMEOUT(1);
+
+	private final int index;
+}

--- a/runelite-api/src/main/java/net/runelite/api/Varcs.java
+++ b/runelite-api/src/main/java/net/runelite/api/Varcs.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2018, Tomas Slusny <slusnucky@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.api;
+
+public interface Varcs
+{
+	int getIntVar(VarClient var);
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/mousehighlight/MouseHighlightOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/mousehighlight/MouseHighlightOverlay.java
@@ -30,6 +30,10 @@ import java.awt.Graphics2D;
 import javax.inject.Inject;
 import net.runelite.api.Client;
 import net.runelite.api.MenuEntry;
+import net.runelite.api.VarClient;
+import net.runelite.api.Varcs;
+import net.runelite.api.widgets.Widget;
+import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.tooltip.Tooltip;
@@ -86,6 +90,22 @@ class MouseHighlightOverlay extends Overlay
 				{
 					return null;
 				}
+		}
+
+		final int widgetId = menuEntry.getParam1();
+		final int groupId = WidgetInfo.TO_GROUP(widgetId);
+		final int childId = WidgetInfo.TO_CHILD(widgetId);
+		final Widget widget = client.getWidget(groupId, childId);
+
+		if (widget != null)
+		{
+			// If this varc is set, some CS is showing tooltip
+			Varcs varcs = client.getVarcs();
+			int tooltipTimeout = varcs.getIntVar(VarClient.TOOLTIP_TIMEOUT);
+			if (tooltipTimeout > client.getGameCycle())
+			{
+				return null;
+			}
 		}
 
 		tooltipManager.addFront(new Tooltip(option + (Strings.isNullOrEmpty(target) ? "" : " " + target)));

--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSVarcsMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSVarcsMixin.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2018, Adam <Adam@sigterm.info>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.mixins;
+
+import net.runelite.api.VarClient;
+import net.runelite.api.mixins.Inject;
+import net.runelite.api.mixins.Mixin;
+import net.runelite.rs.api.RSVarcs;
+
+@Mixin(RSVarcs.class)
+public abstract class RSVarcsMixin implements RSVarcs
+{
+	@Inject
+	@Override
+	public int getIntVar(VarClient var)
+	{
+		int[] varcs = getVarcs();
+		return varcs[var.getIndex()];
+	}
+}

--- a/runescape-api/src/main/java/net/runelite/rs/api/RSClient.java
+++ b/runescape-api/src/main/java/net/runelite/rs/api/RSClient.java
@@ -81,6 +81,10 @@ public interface RSClient extends RSGameEngine, Client
 	@Override
 	int[] getVarps();
 
+	@Import("varcs")
+	@Override
+	RSVarcs getVarcs();
+
 	@Import("energy")
 	@Override
 	int getEnergy();

--- a/runescape-api/src/main/java/net/runelite/rs/api/RSVarcs.java
+++ b/runescape-api/src/main/java/net/runelite/rs/api/RSVarcs.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2018, Tomas Slusny <slusnucky@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.rs.api;
+
+import net.runelite.api.Varcs;
+import net.runelite.mapping.Import;
+
+public interface RSVarcs extends Varcs
+{
+	@Import("varcs")
+	int[] getVarcs();
+}

--- a/runescape-client/src/main/java/BoundingBox.java
+++ b/runescape-client/src/main/java/BoundingBox.java
@@ -10,8 +10,8 @@ public abstract class BoundingBox extends Node {
    @ObfuscatedSignature(
       signature = "Lcy;"
    )
-   @Export("chatMessages")
-   static Varcs chatMessages;
+   @Export("varcs")
+   static Varcs varcs;
    @ObfuscatedName("g")
    @Export("floorHues")
    static int[] floorHues;

--- a/runescape-client/src/main/java/Client.java
+++ b/runescape-client/src/main/java/Client.java
@@ -1696,8 +1696,8 @@ public final class Client extends GameEngine implements class302 {
       garbageValue = "52"
    )
    protected final void vmethod1535() {
-      if(BoundingBox.chatMessages.changed()) {
-         BoundingBox.chatMessages.serialize();
+      if(BoundingBox.varcs.changed()) {
+         BoundingBox.varcs.serialize();
       }
 
       if(WidgetNode.mouseRecorder != null) {
@@ -2740,7 +2740,7 @@ public final class Client extends GameEngine implements class302 {
                      }
                   }
 
-                  BoundingBox.chatMessages.reset();
+                  BoundingBox.varcs.reset();
                   field1016 = -1;
                   if(widgetRoot != -1) {
                      var28 = widgetRoot;
@@ -3635,7 +3635,7 @@ public final class Client extends GameEngine implements class302 {
                                                 ++field1096[var4];
                                              }
 
-                                             BoundingBox.chatMessages.process();
+                                             BoundingBox.varcs.process();
                                              var4 = ++MouseInput.mouseIdleTicks - 1;
                                              var6 = class153.method3139();
                                              PacketNode var28;

--- a/runescape-client/src/main/java/FileRequest.java
+++ b/runescape-client/src/main/java/FileRequest.java
@@ -435,7 +435,7 @@ public class FileRequest extends CacheableNode {
                                  var26 = var10.itemIds[var30] - 1;
                                  if(var22 + 32 > var2 && var22 < var4 && var23 + 32 > var3 && var23 < var5 || var10 == MapIconReference.field574 && var30 == Client.field998) {
                                     SpritePixels var36;
-                                    if(Client.itemSelectionState == 1 && var30 == class271.selectedItemIndex && var10.id == SoundTaskDataProvider.field619) {
+                                    if(Client.itemSelectionState == 1 && var30 == VarCString.selectedItemIndex && var10.id == SoundTaskDataProvider.field619) {
                                        var36 = class25.createSprite(var26, var10.itemQuantities[var30], 2, 0, 2, false);
                                     } else {
                                        var36 = class25.createSprite(var26, var10.itemQuantities[var30], 1, 3153952, 2, false);

--- a/runescape-client/src/main/java/FontName.java
+++ b/runescape-client/src/main/java/FontName.java
@@ -93,17 +93,17 @@ public class FontName {
                }
             }
 
-            if(class270.field3481 == null) {
-               class270.field3481 = new class110(class229.field2675, class243.field2953);
+            if(VarCInt.field3481 == null) {
+               VarCInt.field3481 = new class110(class229.field2675, class243.field2953);
             }
 
-            if(class229.field2673.method4286(class178.field2258, WorldComparator.field258, class270.field3481, 22050)) {
+            if(class229.field2673.method4286(class178.field2258, WorldComparator.field258, VarCInt.field3481, 22050)) {
                class229.field2673.method4169();
                class229.field2673.method4220(class229.field2677);
                class229.field2673.method4171(class178.field2258, class85.field1294);
                class229.field2674 = 0;
                class178.field2258 = null;
-               class270.field3481 = null;
+               VarCInt.field3481 = null;
                class229.field2672 = null;
                return true;
             }
@@ -113,7 +113,7 @@ public class FontName {
          class229.field2673.method4172();
          class229.field2674 = 0;
          class178.field2258 = null;
-         class270.field3481 = null;
+         VarCInt.field3481 = null;
          class229.field2672 = null;
       }
 

--- a/runescape-client/src/main/java/GZipDecompressor.java
+++ b/runescape-client/src/main/java/GZipDecompressor.java
@@ -223,7 +223,7 @@ public class GZipDecompressor {
 
             return 1;
          } else if(var0 == 1121) {
-            class270.method4793(var3.id, var3.index);
+            VarCInt.method4793(var3.id, var3.index);
             Client.field1012 = var3;
             GameEngine.method1053(var3);
             return 1;

--- a/runescape-client/src/main/java/GameObject.java
+++ b/runescape-client/src/main/java/GameObject.java
@@ -205,7 +205,7 @@ public final class GameObject {
          var3.field2926 = var8;
       }
 
-      var3.field2878 = true;
+      var3.mouseActionsPresent = true;
       return 1;
    }
 }

--- a/runescape-client/src/main/java/VarCInt.java
+++ b/runescape-client/src/main/java/VarCInt.java
@@ -1,8 +1,10 @@
+import net.runelite.mapping.Implements;
 import net.runelite.mapping.ObfuscatedName;
 import net.runelite.mapping.ObfuscatedSignature;
 
 @ObfuscatedName("jq")
-public class class270 extends CacheableNode {
+@Implements("VarCInt")
+public class VarCInt extends CacheableNode {
    @ObfuscatedName("t")
    @ObfuscatedSignature(
       signature = "Ljc;"
@@ -25,7 +27,7 @@ public class class270 extends CacheableNode {
       field3478 = new NodeCache(64);
    }
 
-   public class270() {
+   public VarCInt() {
       this.field3477 = false;
    }
 

--- a/runescape-client/src/main/java/VarCString.java
+++ b/runescape-client/src/main/java/VarCString.java
@@ -1,10 +1,12 @@
 import net.runelite.mapping.Export;
+import net.runelite.mapping.Implements;
 import net.runelite.mapping.ObfuscatedGetter;
 import net.runelite.mapping.ObfuscatedName;
 import net.runelite.mapping.ObfuscatedSignature;
 
 @ObfuscatedName("jz")
-public class class271 extends CacheableNode {
+@Implements("VarCString")
+public class VarCString extends CacheableNode {
    @ObfuscatedName("t")
    @ObfuscatedSignature(
       signature = "Ljc;"
@@ -28,7 +30,7 @@ public class class271 extends CacheableNode {
       field3482 = new NodeCache(64);
    }
 
-   public class271() {
+   public VarCString() {
       this.field3484 = false;
    }
 

--- a/runescape-client/src/main/java/Varcs.java
+++ b/runescape-client/src/main/java/Varcs.java
@@ -49,18 +49,18 @@ public class Varcs {
       int var1;
       byte[] var4;
       for(var1 = 0; var1 < this.varcs.length; ++var1) {
-         class270 var3 = (class270)class270.field3478.get((long)var1);
-         class270 var2;
+         VarCInt var3 = (VarCInt) VarCInt.field3478.get((long)var1);
+         VarCInt var2;
          if(var3 != null) {
             var2 = var3;
          } else {
-            var4 = class270.field3480.getConfigData(19, var1);
-            var3 = new class270();
+            var4 = VarCInt.field3480.getConfigData(19, var1);
+            var3 = new VarCInt();
             if(var4 != null) {
                var3.method4790(new Buffer(var4));
             }
 
-            class270.field3478.put(var3, (long)var1);
+            VarCInt.field3478.put(var3, (long)var1);
             var2 = var3;
          }
 
@@ -70,18 +70,18 @@ public class Varcs {
       this.varcstringSerials = new boolean[this.varcstrings.length];
 
       for(var1 = 0; var1 < this.varcstrings.length; ++var1) {
-         class271 var6 = (class271)class271.field3482.get((long)var1);
-         class271 var5;
+         VarCString var6 = (VarCString) VarCString.field3482.get((long)var1);
+         VarCString var5;
          if(var6 != null) {
             var5 = var6;
          } else {
-            var4 = class271.field3485.getConfigData(15, var1);
-            var6 = new class271();
+            var4 = VarCString.field3485.getConfigData(15, var1);
+            var6 = new VarCString();
             if(var4 != null) {
                var6.method4797(new Buffer(var4));
             }
 
-            class271.field3482.put(var6, (long)var1);
+            VarCString.field3482.put(var6, (long)var1);
             var5 = var6;
          }
 

--- a/runescape-client/src/main/java/Widget.java
+++ b/runescape-client/src/main/java/Widget.java
@@ -445,7 +445,8 @@ public class Widget extends Node {
    @Export("selectedAction")
    public String selectedAction;
    @ObfuscatedName("ca")
-   public boolean field2878;
+   @Export("mouseActionsPresent")
+   public boolean mouseActionsPresent;
    @ObfuscatedName("cf")
    public Object[] field2898;
    @ObfuscatedName("cp")
@@ -696,7 +697,7 @@ public class Widget extends Node {
       this.field2894 = 0;
       this.field2895 = false;
       this.selectedAction = "";
-      this.field2878 = false;
+      this.mouseActionsPresent = false;
       this.field2932 = -1;
       this.spellName = "";
       this.tooltip = "Ok";
@@ -1136,7 +1137,7 @@ public class Widget extends Node {
             }
          }
 
-         this.field2878 = true;
+         this.mouseActionsPresent = true;
          return var3;
       }
    }

--- a/runescape-client/src/main/java/class132.java
+++ b/runescape-client/src/main/java/class132.java
@@ -71,7 +71,7 @@ public class class132 {
       ObjectComposition.field3597.reset();
       ObjectComposition.cachedModels.reset();
       ObjectComposition.field3599.reset();
-      class271.method4800();
+      VarCString.method4800();
       ItemComposition.items.reset();
       ItemComposition.itemModelCache.reset();
       ItemComposition.itemSpriteCache.reset();

--- a/runescape-client/src/main/java/class153.java
+++ b/runescape-client/src/main/java/class153.java
@@ -76,14 +76,14 @@ public class class153 extends class297 {
             }
 
             class178.field2258 = null;
-            class270.field3481 = null;
+            VarCInt.field3481 = null;
          }
       } catch (Exception var2) {
          var2.printStackTrace();
          class229.field2673.method4172();
          class229.field2674 = 0;
          class178.field2258 = null;
-         class270.field3481 = null;
+         VarCInt.field3481 = null;
          class229.field2672 = null;
       }
 

--- a/runescape-client/src/main/java/class190.java
+++ b/runescape-client/src/main/java/class190.java
@@ -164,7 +164,7 @@ public class class190 {
    static final void method3504(Widget[] var0, int var1, int var2, int var3, int var4, int var5, int var6, int var7) {
       for(int var8 = 0; var8 < var0.length; ++var8) {
          Widget var9 = var0[var8];
-         if(var9 != null && (!var9.hasScript || var9.type == 0 || var9.field2878 || GrandExchangeEvent.getWidgetConfig(var9) != 0 || var9 == Client.field1020 || var9.contentType == 1338) && var9.parentId == var1) {
+         if(var9 != null && (!var9.hasScript || var9.type == 0 || var9.mouseActionsPresent || GrandExchangeEvent.getWidgetConfig(var9) != 0 || var9 == Client.field1020 || var9.contentType == 1338) && var9.parentId == var1) {
             if(var9.hasScript) {
                boolean var10 = var9.isHidden;
                if(var10) {
@@ -551,7 +551,7 @@ public class class190 {
                         Client.field1098 = var11;
                      }
 
-                     if(var9.field2878) {
+                     if(var9.mouseActionsPresent) {
                         ScriptEvent var35;
                         if(var44 && Client.mouseWheelRotation != 0 && var9.scrollListener != null) {
                            var35 = new ScriptEvent();

--- a/runescape-client/src/main/java/class25.java
+++ b/runescape-client/src/main/java/class25.java
@@ -313,14 +313,14 @@ public class class25 {
 
                                                                                                                                                                         class81.SHAPE_VERTICES[var21][var23] = class81.intStack[class5.intStackSize + 1];
                                                                                                                                                                      } else if(var7 == 47) {
-                                                                                                                                                                        var34 = BoundingBox.chatMessages.getVarcString(var30[var19]);
+                                                                                                                                                                        var34 = BoundingBox.varcs.getVarcString(var30[var19]);
                                                                                                                                                                         if(var34 == null) {
                                                                                                                                                                            var34 = "null";
                                                                                                                                                                         }
 
                                                                                                                                                                         class81.scriptStringStack[++class316.scriptStringStackSize - 1] = var34;
                                                                                                                                                                      } else if(var7 == 48) {
-                                                                                                                                                                        BoundingBox.chatMessages.putVarcString(var30[var19], class81.scriptStringStack[--class316.scriptStringStackSize]);
+                                                                                                                                                                        BoundingBox.varcs.putVarcString(var30[var19], class81.scriptStringStack[--class316.scriptStringStackSize]);
                                                                                                                                                                      } else {
                                                                                                                                                                         if(var7 != 60) {
                                                                                                                                                                            throw new IllegalStateException();
@@ -333,10 +333,10 @@ public class class25 {
                                                                                                                                                                         }
                                                                                                                                                                      }
                                                                                                                                                                   } else {
-                                                                                                                                                                     BoundingBox.chatMessages.putVarc(var30[var19], class81.intStack[--class5.intStackSize]);
+                                                                                                                                                                     BoundingBox.varcs.putVarc(var30[var19], class81.intStack[--class5.intStackSize]);
                                                                                                                                                                   }
                                                                                                                                                                } else {
-                                                                                                                                                                  class81.intStack[++class5.intStackSize - 1] = BoundingBox.chatMessages.getVarc(var30[var19]);
+                                                                                                                                                                  class81.intStack[++class5.intStackSize - 1] = BoundingBox.varcs.getVarc(var30[var19]);
                                                                                                                                                                }
                                                                                                                                                             } else {
                                                                                                                                                                var21 = var30[var19];

--- a/runescape-client/src/main/java/class3.java
+++ b/runescape-client/src/main/java/class3.java
@@ -65,7 +65,7 @@ final class class3 implements class0 {
          var8.packetBuffer.method3582(SoundTaskDataProvider.field619);
          var8.packetBuffer.putShort(BaseVarType.field26);
          var8.packetBuffer.method3619(KeyFocusListener.keyPressed[82]?1:0);
-         var8.packetBuffer.method3573(class271.selectedItemIndex);
+         var8.packetBuffer.method3573(VarCString.selectedItemIndex);
          var8.packetBuffer.method3573(PlayerComposition.baseY + var1);
          Client.field1072.method2073(var8);
       } else if(var2 == 2) {
@@ -152,7 +152,7 @@ final class class3 implements class0 {
                var9.packetBuffer.method3573(var3);
                var9.packetBuffer.method3519(BaseVarType.field26);
                var9.packetBuffer.putByte(KeyFocusListener.keyPressed[82]?1:0);
-               var9.packetBuffer.method3570(class271.selectedItemIndex);
+               var9.packetBuffer.method3570(VarCString.selectedItemIndex);
                Client.field1072.method2073(var9);
             }
          } else if(var2 == 8) {
@@ -254,7 +254,7 @@ final class class3 implements class0 {
                   Client.destinationY = var1;
                   var9 = class33.method382(ClientPacket.field2357, Client.field1072.field1456);
                   var9.packetBuffer.putShortLE(KeyFocusListener.keyPressed[82]?1:0);
-                  var9.packetBuffer.putShort(class271.selectedItemIndex);
+                  var9.packetBuffer.putShort(VarCString.selectedItemIndex);
                   var9.packetBuffer.method3519(BaseVarType.field26);
                   var9.packetBuffer.method3584(SoundTaskDataProvider.field619);
                   var9.packetBuffer.method3519(var3);
@@ -284,7 +284,7 @@ final class class3 implements class0 {
                Client.destinationX = var0;
                Client.destinationY = var1;
                var8 = class33.method382(ClientPacket.field2377, Client.field1072.field1456);
-               var8.packetBuffer.method3573(class271.selectedItemIndex);
+               var8.packetBuffer.method3573(VarCString.selectedItemIndex);
                var8.packetBuffer.method3570(PlayerComposition.baseY + var1);
                var8.packetBuffer.putInt(SoundTaskDataProvider.field619);
                var8.packetBuffer.putShortLE(KeyFocusListener.keyPressed[82]?1:0);
@@ -473,7 +473,7 @@ final class class3 implements class0 {
                         }
                      } else if(var2 == 30) {
                         if(Client.field1012 == null) {
-                           class270.method4793(var1, var0);
+                           VarCInt.method4793(var1, var0);
                            Client.field1012 = CollisionData.getWidgetChild(var1, var0);
                            GameEngine.method1053(Client.field1012);
                         }
@@ -481,7 +481,7 @@ final class class3 implements class0 {
                         var8 = class33.method382(ClientPacket.field2407, Client.field1072.field1456);
                         var8.packetBuffer.method3584(var1);
                         var8.packetBuffer.putShort(BaseVarType.field26);
-                        var8.packetBuffer.putShort(class271.selectedItemIndex);
+                        var8.packetBuffer.putShort(VarCString.selectedItemIndex);
                         var8.packetBuffer.method3713(SoundTaskDataProvider.field619);
                         var8.packetBuffer.putShort(var0);
                         var8.packetBuffer.putShort(var3);
@@ -550,7 +550,7 @@ final class class3 implements class0 {
                            Fonts.method5482();
                            var23 = GZipDecompressor.getWidget(var1);
                            Client.itemSelectionState = 1;
-                           class271.selectedItemIndex = var0;
+                           VarCString.selectedItemIndex = var0;
                            SoundTaskDataProvider.field619 = var1;
                            BaseVarType.field26 = var3;
                            GameEngine.method1053(var23);

--- a/runescape-client/src/main/java/class47.java
+++ b/runescape-client/src/main/java/class47.java
@@ -622,7 +622,7 @@ public class class47 {
       garbageValue = "1642824812"
    )
    public static void method756(IndexDataBase var0) {
-      class271.field3485 = var0;
+      VarCString.field3485 = var0;
    }
 
    @ObfuscatedName("b")

--- a/runescape-client/src/main/java/class88.java
+++ b/runescape-client/src/main/java/class88.java
@@ -265,11 +265,11 @@ public class class88 {
                   class199.method3797(Client.configsIndex);
                   PendingSpawn.method1647(Client.configsIndex);
                   IndexData var17 = Client.configsIndex;
-                  class270.field3480 = var17;
+                  VarCInt.field3480 = var17;
                   class47.method756(Client.configsIndex);
                   IndexData var18 = Client.configsIndex;
                   class278.field3551 = var18;
-                  BoundingBox.chatMessages = new Varcs();
+                  BoundingBox.varcs = new Varcs();
                   IndexData var19 = Client.configsIndex;
                   IndexData var20 = WorldMapRegion.indexSprites;
                   IndexData var21 = Client.indexCache13;

--- a/runescape-client/src/main/java/class95.java
+++ b/runescape-client/src/main/java/class95.java
@@ -98,7 +98,7 @@ public class class95 {
                   if(var0.itemIds[var13] > 0) {
                      ItemComposition var8 = class81.getItemDefinition(var0.itemIds[var13] - 1);
                      if(Client.itemSelectionState == 1 && method2041(GrandExchangeEvent.getWidgetConfig(var0))) {
-                        if(var0.id != SoundTaskDataProvider.field619 || var13 != class271.selectedItemIndex) {
+                        if(var0.id != SoundTaskDataProvider.field619 || var13 != VarCString.selectedItemIndex) {
                            class169.addMenuEntry("Use", Client.lastSelectedItemName + " " + "->" + " " + class37.getColTags(16748608) + var8.name, 31, var8.id, var13, var0.id);
                         }
                      } else if(Client.spellSelected && method2041(GrandExchangeEvent.getWidgetConfig(var0))) {


### PR DESCRIPTION
- Add mappings for Varc class and varc field in it
- Update mappings that reference to Varc field
- Update widget mappings for boolean that determines if widget have
mouse action
- When rs tooltips are visible, don't display our tooltips in Mouse
Highlighting plugin

Preview:
![peek 2018-03-25 00-27](https://user-images.githubusercontent.com/5115805/37870030-464c0634-2fc4-11e8-95bb-da125384822b.gif)
