### PR TITLE
injector: Allow use of assert

### DIFF
--- a/deobfuscator/src/main/java/net/runelite/asm/attributes/code/instructions/LDC.java
+++ b/deobfuscator/src/main/java/net/runelite/asm/attributes/code/instructions/LDC.java
@@ -68,7 +68,7 @@ public class LDC extends Instruction implements PushConstantInstruction
 		if (object instanceof net.runelite.asm.pool.Class)
 		{
 			net.runelite.asm.pool.Class cl = (net.runelite.asm.pool.Class) object;
-			org.objectweb.asm.Type type = org.objectweb.asm.Type.getType("L" + cl.getName().replace('.', '/') + ";");
+			org.objectweb.asm.Type type = org.objectweb.asm.Type.getType("L" + cl.getName() + ";");
 			visitor.visitLdcInsn(type);
 		}
 		else if (object.equals(0d))

--- a/deobfuscator/src/main/java/net/runelite/asm/pool/Class.java
+++ b/deobfuscator/src/main/java/net/runelite/asm/pool/Class.java
@@ -31,12 +31,13 @@ public class Class
 	public Class(String name)
 	{
 		assert !name.startsWith("L") || !name.endsWith(";");
-		this.name = name;
+		this.name = name.replace('.', '/');
 	}
 
 	public Class(String name, int dimms)
 	{
 		assert !name.startsWith("L") && !name.endsWith(";");
+		name = name.replace('.', '/');
 
 		while (dimms-- > 0)
 		{

--- a/runelite-mixins/src/main/java/net/runelite/mixins/ScriptVMMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/ScriptVMMixin.java
@@ -58,10 +58,7 @@ public abstract class ScriptVMMixin implements RSClient
 	{
 		if (opcode == RUNELITE_EXECUTE)
 		{
-			if (currentScript.getInstructions()[currentScriptPC] != RUNELITE_EXECUTE)
-			{
-				throw new AssertionError("currentScriptPC is wrong");
-			}
+			assert currentScript.getInstructions()[currentScriptPC] == RUNELITE_EXECUTE;
 
 			int stringStackSize = client.getStringStackSize();
 			String stringOp = client.getStringStack()[--stringStackSize];

--- a/runescape-client-injector-plugin/src/main/java/net/runelite/injector/Inject.java
+++ b/runescape-client-injector-plugin/src/main/java/net/runelite/injector/Inject.java
@@ -484,7 +484,7 @@ public class Inject
 		java.lang.Class<?> rsApiType;
 		try
 		{
-			rsApiType = java.lang.Class.forName(API_PACKAGE_BASE + cf.getName());
+			rsApiType = java.lang.Class.forName(API_PACKAGE_BASE + cf.getName().replace("/", "."));
 		}
 		catch (ClassNotFoundException ex)
 		{
@@ -527,11 +527,12 @@ public class Inject
 	
 	ClassFile findVanillaForInterface(java.lang.Class<?> clazz)
 	{
+		String className = clazz.getName().replace('.', '/');
 		for (ClassFile cf : getVanilla().getClasses())
 		{
 			for (net.runelite.asm.pool.Class cl : cf.getInterfaces().getInterfaces())
 			{
-				if (cl.getName().equals(clazz.getName().replace('.', '/')))
+				if (cl.getName().equals(className))
 				{
 					return cf;
 				}

--- a/runescape-client-injector-plugin/src/main/java/net/runelite/injector/MixinInjector.java
+++ b/runescape-client-injector-plugin/src/main/java/net/runelite/injector/MixinInjector.java
@@ -400,6 +400,11 @@ public class MixinInjector
 				{
 					name = "rl$$" + (isInit ? "init" : "clinit");
 				}
+				String numberlessName = name;
+				for (int i = 1; cf.findMethod(name, method.getDescriptor()) != null; i++)
+				{
+					name = numberlessName + i;
+				}
 
 				Method copy = new Method(cf, name, method.getDescriptor());
 				moveCode(copy, method.getCode());


### PR DESCRIPTION
This makes the injector transform `XXMixin.class` into the name of the class being injected into, and forcibly injects `$assertionsDisabled` if it doesn't exist already in the target. This also fixes multiple mixins on the same class not being able to use `<init>` and `<clinit>`.