### PR TITLE
client ui: Add top bar when custom chrome is disabled

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/info/InfoPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/info/InfoPanel.java
@@ -33,10 +33,8 @@ import javax.annotation.Nullable;
 import javax.inject.Singleton;
 import javax.swing.BorderFactory;
 import javax.swing.GroupLayout;
-import javax.swing.JButton;
 import javax.swing.JLabel;
 import javax.swing.LayoutStyle;
-import javax.swing.SwingUtilities;
 import javax.swing.event.HyperlinkEvent;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
@@ -45,20 +43,14 @@ import net.runelite.api.events.SessionOpen;
 import net.runelite.client.RuneLiteProperties;
 import net.runelite.client.account.SessionManager;
 import net.runelite.client.config.RuneLiteConfig;
-import net.runelite.client.events.ClientUILoaded;
-import net.runelite.client.events.TitleToolbarButtonAdded;
-import net.runelite.client.events.TitleToolbarButtonRemoved;
-import net.runelite.client.ui.ClientTitleToolbar;
 import net.runelite.client.ui.FontManager;
 import net.runelite.client.ui.PluginPanel;
 import net.runelite.client.util.RunnableExceptionLogger;
-import net.runelite.client.util.SwingUtil;
 
 @Slf4j
 @Singleton
 public class InfoPanel extends PluginPanel
 {
-	private static final int TITLEBAR_SIZE = 23;
 	private static final String RUNELITE_LOGIN = "https://runelite_login/";
 
 	@Inject
@@ -81,7 +73,6 @@ public class InfoPanel extends PluginPanel
 	private ScheduledExecutorService executor;
 
 	private final GroupLayout layout = new GroupLayout(this);
-	private final ClientTitleToolbar titleBar = new ClientTitleToolbar();
 	private final JLabel usernameHeader = new JLabel();
 	private final JRichTextPane username = new JRichTextPane();
 
@@ -90,7 +81,6 @@ public class InfoPanel extends PluginPanel
 		setLayout(layout);
 
 		final Font smallFont = FontManager.getRunescapeSmallFont();
-		updateTitleBar();
 
 		final JLabel runeliteVersionHeader = new JLabel("RuneLite version");
 		runeliteVersionHeader.setFont(smallFont);
@@ -132,8 +122,6 @@ public class InfoPanel extends PluginPanel
 		setBorder(BorderFactory.createEmptyBorder(2, 6, 6, 6));
 
 		layout.setVerticalGroup(layout.createSequentialGroup()
-			.addComponent(titleBar)
-			.addGap(3)
 			.addGroup(layout.createParallelGroup()
 				.addComponent(runeliteVersionHeader)
 				.addComponent(runescapeVersionHeader)
@@ -150,9 +138,6 @@ public class InfoPanel extends PluginPanel
 		);
 
 		layout.setHorizontalGroup(layout.createParallelGroup()
-			.addGroup(layout.createSequentialGroup()
-				.addPreferredGap(LayoutStyle.ComponentPlacement.RELATED, GroupLayout.PREFERRED_SIZE, Short.MAX_VALUE)
-				.addComponent(titleBar))
 			.addGroup(layout.createSequentialGroup()
 				.addComponent(runeliteVersionHeader)
 				.addPreferredGap(LayoutStyle.ComponentPlacement.UNRELATED, GroupLayout.PREFERRED_SIZE, Short.MAX_VALUE)
@@ -189,18 +174,6 @@ public class InfoPanel extends PluginPanel
 		}
 	}
 
-	private void updateTitleBar()
-	{
-		titleBar.setVisible(!runeliteConfig.enableCustomChrome());
-	}
-
-	@Subscribe
-	public void onClientUILoaded(ClientUILoaded e)
-	{
-		// Add the title toolbar to the infopanel if the custom chrome is disabled
-		updateTitleBar();
-	}
-
 	@Subscribe
 	public void onSessionOpen(SessionOpen sessionOpen)
 	{
@@ -211,39 +184,5 @@ public class InfoPanel extends PluginPanel
 	public void onSessionClose(SessionClose e)
 	{
 		updateLoggedIn();
-	}
-
-	@Subscribe
-	public void onTitleToolbarButtonAdded(TitleToolbarButtonAdded event)
-	{
-		if (runeliteConfig.enableCustomChrome())
-		{
-			return;
-		}
-
-		SwingUtilities.invokeLater(() ->
-		{
-			final int iconSize = TITLEBAR_SIZE - 6;
-			final JButton button = SwingUtil.createSwingButton(event.getButton(), iconSize, null);
-			titleBar.addComponent(event.getButton(), button);
-			titleBar.revalidate();
-			titleBar.repaint();
-		});
-	}
-
-	@Subscribe
-	public void onTitleToolbarButtonRemoved(TitleToolbarButtonRemoved event)
-	{
-		if (runeliteConfig.enableCustomChrome())
-		{
-			return;
-		}
-
-		SwingUtilities.invokeLater(() ->
-		{
-			titleBar.removeComponent(event.getButton());
-			titleBar.revalidate();
-			titleBar.repaint();
-		});
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/info/InfoPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/info/InfoPlugin.java
@@ -32,7 +32,6 @@ import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.NavigationButton;
 import net.runelite.client.ui.PluginToolbar;
-import net.runelite.client.ui.TitleToolbar;
 
 @PluginDescriptor(
 	name = "Info Panel",
@@ -42,9 +41,6 @@ public class InfoPlugin extends Plugin
 {
 	@Inject
 	private PluginToolbar pluginToolbar;
-
-	@Inject
-	private TitleToolbar titleToolbar;
 
 	@Inject
 	private RuneLiteConfig runeLiteConfig;
@@ -70,11 +66,6 @@ public class InfoPlugin extends Plugin
 			.build();
 
 		pluginToolbar.addNavigation(navButton);
-
-		if (!runeLiteConfig.enableCustomChrome())
-		{
-			titleToolbar.refresh();
-		}
 	}
 
 	@Override

--- a/runelite-client/src/main/java/net/runelite/client/ui/ClientTitleToolbar.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ClientTitleToolbar.java
@@ -35,7 +35,7 @@ import javax.swing.JPanel;
 /**
  * Client title toolbar component.
  */
-public class ClientTitleToolbar extends JPanel
+class ClientTitleToolbar extends JPanel
 {
 	public static final int TITLEBAR_SIZE = 23;
 	private static final int ITEM_PADDING = 4;
@@ -45,7 +45,7 @@ public class ClientTitleToolbar extends JPanel
 	/**
 	 * Instantiates a new Client title toolbar.
 	 */
-	public ClientTitleToolbar()
+	ClientTitleToolbar()
 	{
 		// The only other layout manager that would manage it's preferred size without padding
 		// was the GroupLayout manager, which doesn't work with dynamic layouts like this one.
@@ -122,7 +122,7 @@ public class ClientTitleToolbar extends JPanel
 		});
 	}
 
-	public void addComponent(NavigationButton button, Component c)
+	void addComponent(NavigationButton button, Component c)
 	{
 		if (componentMap.put(button, c) == null)
 		{
@@ -132,7 +132,7 @@ public class ClientTitleToolbar extends JPanel
 		}
 	}
 
-	public void removeComponent(NavigationButton button)
+	void removeComponent(NavigationButton button)
 	{
 		final Component component = componentMap.remove(button);
 		if (component != null)

--- a/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
@@ -50,6 +50,7 @@ import javax.swing.JFrame;
 import javax.swing.JPanel;
 import javax.swing.JRootPane;
 import javax.swing.SwingUtilities;
+import javax.swing.border.EmptyBorder;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
@@ -250,11 +251,6 @@ public class ClientUI
 	@Subscribe
 	public void onTitleToolbarButtonAdded(final TitleToolbarButtonAdded event)
 	{
-		if (!config.enableCustomChrome() && !SwingUtil.isCustomTitlePanePresent(frame))
-		{
-			return;
-		}
-
 		SwingUtilities.invokeLater(() ->
 		{
 			final int iconSize = ClientTitleToolbar.TITLEBAR_SIZE - 6;
@@ -266,11 +262,6 @@ public class ClientUI
 	@Subscribe
 	public void onTitleToolbarButtonRemoved(final TitleToolbarButtonRemoved event)
 	{
-		if (!config.enableCustomChrome() && !SwingUtil.isCustomTitlePanePresent(frame))
-		{
-			return;
-		}
-
 		SwingUtilities.invokeLater(() -> titleToolbar.removeComponent(event.getButton()));
 	}
 
@@ -297,6 +288,7 @@ public class ClientUI
 
 			// Create main window
 			frame = new JFrame();
+			frame.setLayout(new BorderLayout());
 
 			// Try to enable fullscreen on OSX
 			OSXUtil.tryEnableFullscreen(frame);
@@ -328,7 +320,7 @@ public class ClientUI
 			container.add(pluginToolbar);
 
 			titleToolbar = new ClientTitleToolbar();
-			frame.add(container);
+			frame.add(container, BorderLayout.CENTER);
 		});
 	}
 
@@ -390,6 +382,14 @@ public class ClientUI
 						titleToolbar.setBounds(titleBar.getWidth() - 75 - width, 0, width, titleBar.getHeight());
 					}
 				});
+			}
+			else
+			{
+				JPanel topBar = new JPanel(new BorderLayout());
+				topBar.setBorder(new EmptyBorder(2, 2, 2, 5));
+				topBar.add(titleToolbar, BorderLayout.EAST);
+
+				frame.add(topBar, BorderLayout.NORTH);
 			}
 
 			frame.pack();


### PR DESCRIPTION
Adds a topbar with the titletoolbar buttons as opposed to just not displaying it. This will also remove the need to add the buttons to the info panel.

![titlebar](https://user-images.githubusercontent.com/5454364/37877374-e2672fac-301f-11e8-8131-99b4a8150a23.png)

Fixes #912
Fixes #956 