### PR TITLE
Add disable for level 99 XP Orbs

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesConfig.java
@@ -30,17 +30,17 @@ import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
 
 @ConfigGroup(
-		keyName = "xpglobes",
-		name = "XP Globes",
-		description = "Configuration for the XP globes plugin"
+	keyName = "xpglobes",
+	name = "XP Globes",
+	description = "Configuration for the XP globes plugin"
 )
 public interface XpGlobesConfig extends Config
 {
 	@ConfigItem(
-			keyName = "enableTooltips",
-			name = "Enable Tooltips",
-			description = "Configures whether or not to show tooltips",
-			position = 0
+		keyName = "enableTooltips",
+		name = "Enable Tooltips",
+		description = "Configures whether or not to show tooltips",
+		position = 0
 	)
 	default boolean enableTooltips()
 	{
@@ -48,10 +48,10 @@ public interface XpGlobesConfig extends Config
 	}
 
 	@ConfigItem(
-			keyName = "Progress arc color",
-			name = "Progress arc color",
-			description = "Change the color of the progress arc in the xp orb",
-			position = 1
+		keyName = "Progress arc color",
+		name = "Progress arc color",
+		description = "Change the color of the progress arc in the xp orb",
+		position = 1
 	)
 	default Color progressArcColor()
 	{
@@ -59,10 +59,10 @@ public interface XpGlobesConfig extends Config
 	}
 
 	@ConfigItem(
-			keyName = "Progress orb outline color",
-			name = "Progress orb outline color",
-			description = "Change the color of the progress orb outline",
-			position = 2
+		keyName = "Progress orb outline color",
+		name = "Progress orb outline color",
+		description = "Change the color of the progress orb outline",
+		position = 2
 	)
 	default Color progressOrbOutLineColor()
 	{
@@ -70,10 +70,10 @@ public interface XpGlobesConfig extends Config
 	}
 
 	@ConfigItem(
-			keyName = "Progress orb background color",
-			name = "Progress orb background color",
-			description = "Change the color of the progress orb background",
-			position = 3
+		keyName = "Progress orb background color",
+		name = "Progress orb background color",
+		description = "Change the color of the progress orb background",
+		position = 3
 	)
 	default Color progressOrbBackgroundColor()
 	{
@@ -81,10 +81,10 @@ public interface XpGlobesConfig extends Config
 	}
 
 	@ConfigItem(
-			keyName = "Progress arc width",
-			name = "Progress arc width",
-			description = "Change the stroke width of the progress arc",
-			position = 4
+		keyName = "Progress arc width",
+		name = "Progress arc width",
+		description = "Change the stroke width of the progress arc",
+		position = 4
 	)
 	default int progressArcStrokeWidth()
 	{
@@ -92,10 +92,10 @@ public interface XpGlobesConfig extends Config
 	}
 
 	@ConfigItem(
-			keyName = "Orb size",
-			name = "Size of orbs",
-			description = "Change the size of the xp orbs",
-			position = 5
+		keyName = "Orb size",
+		name = "Size of orbs",
+		description = "Change the size of the xp orbs",
+		position = 5
 	)
 	default int xpOrbSize()
 	{
@@ -103,10 +103,10 @@ public interface XpGlobesConfig extends Config
 	}
 
 	@ConfigItem(
-			keyName = "Center orbs",
-			name = "Center orbs",
-			description = "Where to center the xp orbs around",
-			position = 6
+		keyName = "Center orbs",
+		name = "Center orbs",
+		description = "Where to center the xp orbs around",
+		position = 6
 	)
 	default OrbCentering centerOrbs()
 	{
@@ -114,10 +114,10 @@ public interface XpGlobesConfig extends Config
 	}
 
 	@ConfigItem(
-			keyName = "disable99s",
-			name = "Disable lvl99 Orbs",
-			description = "Disables all Orbs for skills leveled to 99",
-			position = 7
+		keyName = "disable99s",
+		name = "Disable lvl99 Orbs",
+		description = "Disables all Orbs for skills leveled to 99",
+		position = 7
 	)
 	default boolean disable99s()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesConfig.java
@@ -30,17 +30,17 @@ import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
 
 @ConfigGroup(
-	keyName = "xpglobes",
-	name = "XP Globes",
-	description = "Configuration for the XP globes plugin"
+		keyName = "xpglobes",
+		name = "XP Globes",
+		description = "Configuration for the XP globes plugin"
 )
 public interface XpGlobesConfig extends Config
 {
 	@ConfigItem(
-		keyName = "enableTooltips",
-		name = "Enable Tooltips",
-		description = "Configures whether or not to show tooltips",
-		position = 0
+			keyName = "enableTooltips",
+			name = "Enable Tooltips",
+			description = "Configures whether or not to show tooltips",
+			position = 0
 	)
 	default boolean enableTooltips()
 	{
@@ -48,10 +48,10 @@ public interface XpGlobesConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "Progress arc color",
-		name = "Progress arc color",
-		description = "Change the color of the progress arc in the xp orb",
-		position = 1
+			keyName = "Progress arc color",
+			name = "Progress arc color",
+			description = "Change the color of the progress arc in the xp orb",
+			position = 1
 	)
 	default Color progressArcColor()
 	{
@@ -59,10 +59,10 @@ public interface XpGlobesConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "Progress orb outline color",
-		name = "Progress orb outline color",
-		description = "Change the color of the progress orb outline",
-		position = 2
+			keyName = "Progress orb outline color",
+			name = "Progress orb outline color",
+			description = "Change the color of the progress orb outline",
+			position = 2
 	)
 	default Color progressOrbOutLineColor()
 	{
@@ -70,10 +70,10 @@ public interface XpGlobesConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "Progress orb background color",
-		name = "Progress orb background color",
-		description = "Change the color of the progress orb background",
-		position = 3
+			keyName = "Progress orb background color",
+			name = "Progress orb background color",
+			description = "Change the color of the progress orb background",
+			position = 3
 	)
 	default Color progressOrbBackgroundColor()
 	{
@@ -81,10 +81,10 @@ public interface XpGlobesConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "Progress arc width",
-		name = "Progress arc width",
-		description = "Change the stroke width of the progress arc",
-		position = 4
+			keyName = "Progress arc width",
+			name = "Progress arc width",
+			description = "Change the stroke width of the progress arc",
+			position = 4
 	)
 	default int progressArcStrokeWidth()
 	{
@@ -92,10 +92,10 @@ public interface XpGlobesConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "Orb size",
-		name = "Size of orbs",
-		description = "Change the size of the xp orbs",
-		position = 5
+			keyName = "Orb size",
+			name = "Size of orbs",
+			description = "Change the size of the xp orbs",
+			position = 5
 	)
 	default int xpOrbSize()
 	{
@@ -103,13 +103,24 @@ public interface XpGlobesConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "Center orbs",
-		name = "Center orbs",
-		description = "Where to center the xp orbs around",
-		position = 6
+			keyName = "Center orbs",
+			name = "Center orbs",
+			description = "Where to center the xp orbs around",
+			position = 6
 	)
 	default OrbCentering centerOrbs()
 	{
 		return OrbCentering.DYNAMIC;
+	}
+
+	@ConfigItem(
+			keyName = "disable99s",
+			name = "Disable lvl99 Orbs",
+			description = "Disables all Orbs for skills leveled to 99",
+			position = 7
+	)
+	default boolean disable99s()
+	{
+		return false;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesOverlay.java
@@ -118,10 +118,6 @@ public class XpGlobesOverlay extends Overlay
 
 			for (XpGlobe xpGlobe : xpChangedQueue)
 			{
-				if (config.disable99s() && xpGlobe.getCurrentLevel() == 99)
-				{
-					continue;
-				}
 				renderProgressCircle(graphics, xpGlobe, startDrawX, DEFAULT_START_Y);
 				startDrawX += MINIMUM_STEP + config.xpOrbSize();
 			}
@@ -142,20 +138,20 @@ public class XpGlobesOverlay extends Overlay
 		graphics.setRenderingHint(RenderingHints.KEY_STROKE_CONTROL, RenderingHints.VALUE_STROKE_PURE);
 
 		drawProgressArc(
-				graphics,
-				x, y,
-				config.xpOrbSize(), config.xpOrbSize(),
-				PROGRESS_RADIUS_REMAINDER, radiusToGoalXp,
-				5,
-				config.progressOrbOutLineColor()
+			graphics,
+			x, y,
+			config.xpOrbSize(), config.xpOrbSize(),
+			PROGRESS_RADIUS_REMAINDER, radiusToGoalXp,
+			5,
+			config.progressOrbOutLineColor()
 		);
 		drawProgressArc(
-				graphics,
-				x, y,
-				config.xpOrbSize(), config.xpOrbSize(),
-				PROGRESS_RADIUS_START, radiusCurrentXp,
-				config.progressArcStrokeWidth(),
-				config.progressArcColor());
+			graphics,
+			x, y,
+			config.xpOrbSize(), config.xpOrbSize(),
+			PROGRESS_RADIUS_START, radiusCurrentXp,
+			config.progressArcStrokeWidth(),
+			config.progressArcColor());
 
 		graphics.setRenderingHint(RenderingHints.KEY_STROKE_CONTROL, renderHint);
 
@@ -173,10 +169,10 @@ public class XpGlobesOverlay extends Overlay
 		graphics.setStroke(new BasicStroke(strokeWidth, BasicStroke.CAP_BUTT, BasicStroke.JOIN_BEVEL));
 		graphics.setColor(color);
 		graphics.draw(new Arc2D.Double(
-				x, y,
-				w, h,
-				radiusStart, radiusEnd,
-				Arc2D.OPEN));
+			x, y,
+			w, h,
+			radiusStart, radiusEnd,
+			Arc2D.OPEN));
 		graphics.setStroke(stroke);
 	}
 
@@ -199,10 +195,10 @@ public class XpGlobesOverlay extends Overlay
 		}
 
 		graphics.drawImage(
-				skillImage,
-				x + (config.xpOrbSize() / 2) - (skillImage.getWidth() / 2),
-				y + (config.xpOrbSize() / 2) - (skillImage.getHeight() / 2),
-				null
+			skillImage,
+			x + (config.xpOrbSize() / 2) - (skillImage.getWidth() / 2),
+			y + (config.xpOrbSize() / 2) - (skillImage.getHeight() / 2),
+			null
 		);
 	}
 
@@ -242,7 +238,7 @@ public class XpGlobesOverlay extends Overlay
 			//Create progress bar for skill.
 			ProgressBarComponent progressBar = new ProgressBarComponent();
 			double progress = mouseOverSkill.getSkillProgress(Experience.getXpForLevel(mouseOverSkill.getCurrentLevel()),
-					mouseOverSkill.getCurrentXp(), mouseOverSkill.getGoalXp());
+				mouseOverSkill.getCurrentXp(), mouseOverSkill.getGoalXp());
 			progressBar.setProgress(progress);
 
 			xpTooltip.setProgressBar(progressBar);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesOverlay.java
@@ -108,7 +108,7 @@ public class XpGlobesOverlay extends Overlay
 		{
 			return null;
 		}
-		
+
 		int queueSize = plugin.getXpGlobesSize();
 		if (queueSize > 0)
 		{
@@ -118,6 +118,10 @@ public class XpGlobesOverlay extends Overlay
 
 			for (XpGlobe xpGlobe : xpChangedQueue)
 			{
+				if (config.disable99s() && xpGlobe.getCurrentLevel() == 99)
+				{
+					continue;
+				}
 				renderProgressCircle(graphics, xpGlobe, startDrawX, DEFAULT_START_Y);
 				startDrawX += MINIMUM_STEP + config.xpOrbSize();
 			}
@@ -126,6 +130,7 @@ public class XpGlobesOverlay extends Overlay
 
 		return null;
 	}
+
 	private void renderProgressCircle(Graphics2D graphics, XpGlobe skillToDraw, int x, int y)
 	{
 		double radiusCurrentXp = skillToDraw.getSkillProgressRadius();
@@ -137,20 +142,20 @@ public class XpGlobesOverlay extends Overlay
 		graphics.setRenderingHint(RenderingHints.KEY_STROKE_CONTROL, RenderingHints.VALUE_STROKE_PURE);
 
 		drawProgressArc(
-			graphics,
-			x, y,
-			config.xpOrbSize(), config.xpOrbSize(),
-			PROGRESS_RADIUS_REMAINDER, radiusToGoalXp,
-			5,
-			config.progressOrbOutLineColor()
+				graphics,
+				x, y,
+				config.xpOrbSize(), config.xpOrbSize(),
+				PROGRESS_RADIUS_REMAINDER, radiusToGoalXp,
+				5,
+				config.progressOrbOutLineColor()
 		);
 		drawProgressArc(
-			graphics,
-			x, y,
-			config.xpOrbSize(), config.xpOrbSize(),
-			PROGRESS_RADIUS_START, radiusCurrentXp,
-			config.progressArcStrokeWidth(),
-			config.progressArcColor());
+				graphics,
+				x, y,
+				config.xpOrbSize(), config.xpOrbSize(),
+				PROGRESS_RADIUS_START, radiusCurrentXp,
+				config.progressArcStrokeWidth(),
+				config.progressArcColor());
 
 		graphics.setRenderingHint(RenderingHints.KEY_STROKE_CONTROL, renderHint);
 
@@ -168,10 +173,10 @@ public class XpGlobesOverlay extends Overlay
 		graphics.setStroke(new BasicStroke(strokeWidth, BasicStroke.CAP_BUTT, BasicStroke.JOIN_BEVEL));
 		graphics.setColor(color);
 		graphics.draw(new Arc2D.Double(
-			x, y,
-			w, h,
-			radiusStart, radiusEnd,
-			Arc2D.OPEN));
+				x, y,
+				w, h,
+				radiusStart, radiusEnd,
+				Arc2D.OPEN));
 		graphics.setStroke(stroke);
 	}
 
@@ -194,10 +199,10 @@ public class XpGlobesOverlay extends Overlay
 		}
 
 		graphics.drawImage(
-			skillImage,
-			x + (config.xpOrbSize() / 2) - (skillImage.getWidth() / 2),
-			y + (config.xpOrbSize() / 2) - (skillImage.getHeight() / 2),
-			null
+				skillImage,
+				x + (config.xpOrbSize() / 2) - (skillImage.getWidth() / 2),
+				y + (config.xpOrbSize() / 2) - (skillImage.getHeight() / 2),
+				null
 		);
 	}
 
@@ -237,7 +242,7 @@ public class XpGlobesOverlay extends Overlay
 			//Create progress bar for skill.
 			ProgressBarComponent progressBar = new ProgressBarComponent();
 			double progress = mouseOverSkill.getSkillProgress(Experience.getXpForLevel(mouseOverSkill.getCurrentLevel()),
-				mouseOverSkill.getCurrentXp(), mouseOverSkill.getGoalXp());
+					mouseOverSkill.getCurrentXp(), mouseOverSkill.getGoalXp());
 			progressBar.setProgress(progress);
 
 			xpTooltip.setProgressBar(progressBar);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesPlugin.java
@@ -125,7 +125,15 @@ public class XpGlobesPlugin extends Plugin
 		{
 			xpGlobes.remove(0);
 		}
-		xpGlobes.add(xpGlobe);
+		if (xpGlobe.getCurrentLevel() == 99 && config.disable99s())
+		{
+
+		} else
+		{
+			xpGlobes.add(xpGlobe);
+		}
+
+
 	}
 
 	public int getXpGlobesSize()
@@ -138,7 +146,7 @@ public class XpGlobesPlugin extends Plugin
 		if (!xpGlobes.isEmpty())
 		{
 			Instant currentTime = Instant.now();
-			for (Iterator<XpGlobe> it = xpGlobes.iterator(); it.hasNext();)
+			for (Iterator<XpGlobe> it = xpGlobes.iterator(); it.hasNext(); )
 			{
 				XpGlobe globe = it.next();
 				Instant globeCreationTime = globe.getTime();

--- a/runelite-client/src/test/java/net/runelite/client/plugins/xpglobes/XPGlobePluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/xpglobes/XPGlobePluginTest.java
@@ -1,9 +1,34 @@
+/*
+ *
+ *  * Copyright (c) 2017, Steve <steve.rs.dev@gmail.com>
+ *  * All rights reserved.
+ *  *
+ *  * Redistribution and use in source and binary forms, with or without
+ *  * modification, are permitted provided that the following conditions are met:
+ *  *
+ *  * 1. Redistributions of source code must retain the above copyright notice, this
+ *  *    list of conditions and the following disclaimer.
+ *  * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *  *    this list of conditions and the following disclaimer in the documentation
+ *  *    and/or other materials provided with the distribution.
+ *  *
+ *  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ *  * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
 package net.runelite.client.plugins.xpglobes;
 
 import com.google.inject.Guice;
 import com.google.inject.testing.fieldbinder.Bind;
 import com.google.inject.testing.fieldbinder.BoundFieldModule;
-import java.util.ArrayList;
 import java.util.List;
 import javax.inject.Inject;
 import net.runelite.api.Client;

--- a/runelite-client/src/test/java/net/runelite/client/plugins/xpglobes/XPGlobePluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/xpglobes/XPGlobePluginTest.java
@@ -1,0 +1,71 @@
+package net.runelite.client.plugins.xpglobes;
+
+import com.google.inject.Guice;
+import com.google.inject.testing.fieldbinder.Bind;
+import com.google.inject.testing.fieldbinder.BoundFieldModule;
+import java.util.ArrayList;
+import java.util.List;
+import javax.inject.Inject;
+import net.runelite.api.Client;
+import net.runelite.api.Skill;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import static org.mockito.Mockito.when;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class XPGlobePluginTest
+{
+	@Inject
+	private XpGlobesPlugin plugin;
+
+	@Mock
+	@Bind
+	private Client client;
+
+	@Mock
+	@Bind
+	private XpGlobesConfig config;
+
+
+	private XpGlobe globe;
+	private XpGlobe globeTwo;
+	private XpGlobe globeThree;
+	private List<XpGlobe> list;
+	private Skill skill;
+
+	private int MAX_LENGTH = 5;
+
+	@Before
+	public void before()
+	{
+		Guice.createInjector(BoundFieldModule.of(this)).injectMembers(this);
+		skill = Skill.MINING;
+		when(config.disable99s()).thenReturn(true);
+		globe = new XpGlobe(skill,13034431,99,14000000 );
+		globeTwo = new XpGlobe(skill,5346332,90,13034431);
+		globeThree = new XpGlobe(skill,0,1,13034431);
+	}
+
+	@Test
+	public void testAddXpGlobe99()
+	{
+		plugin.addXpGlobe(globe ,MAX_LENGTH);
+		list = plugin.getXpGlobes();
+		Assert.assertFalse(list.contains(globe));
+	}
+
+	@Test
+	public void testAddXpGlobeNot99()
+	{
+		plugin.addXpGlobe(globeTwo ,MAX_LENGTH);
+		plugin.addXpGlobe(globeThree ,MAX_LENGTH);
+		list = plugin.getXpGlobes();
+		Assert.assertTrue(list.contains(globeTwo));
+		Assert.assertTrue(list.contains(globeThree));
+	}
+
+}


### PR DESCRIPTION
Figured this seemed like an easy first contribution. Adds a simple toggle to disable all 99 XP Orbs from showing up in the Render list for the Overlay.