### PR TITLE
Fix tray icon crash when clicked quickly on start

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
@@ -301,8 +301,6 @@ public class ClientUI
 			// Try to enable fullscreen on OSX
 			OSXUtil.tryEnableFullscreen(frame);
 
-			trayIcon = SwingUtil.createTrayIcon(ICON, properties.getTitle(), frame);
-
 			frame.setTitle(properties.getTitle());
 			frame.setIconImage(ICON);
 			frame.getLayeredPane().setCursor(Cursor.getDefaultCursor()); // Prevent substance from using a resize cursor for pointing
@@ -399,6 +397,8 @@ public class ClientUI
 			frame.toFront();
 			requestFocus();
 			giveClientFocus();
+
+			trayIcon = SwingUtil.createTrayIcon(ICON, properties.getTitle(), frame);
 		});
 
 		eventBus.post(new ClientUILoaded());


### PR DESCRIPTION
`SwingUtil` adds a click event to focus the frame, but the frame isn't fully built when the icon is created. Clicking after the icon was made and before the frame was built caused a crash. Moved the icon creation to after the frame is built, should resolve the problem. Fixes #1130.