### PR TITLE
Move title toolbar buttons to sidebar in native

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/info/InfoPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/info/InfoPanel.java
@@ -33,10 +33,8 @@ import javax.annotation.Nullable;
 import javax.inject.Singleton;
 import javax.swing.BorderFactory;
 import javax.swing.GroupLayout;
-import javax.swing.JButton;
 import javax.swing.JLabel;
 import javax.swing.LayoutStyle;
-import javax.swing.SwingUtilities;
 import javax.swing.event.HyperlinkEvent;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
@@ -44,29 +42,19 @@ import net.runelite.api.events.SessionClose;
 import net.runelite.api.events.SessionOpen;
 import net.runelite.client.RuneLiteProperties;
 import net.runelite.client.account.SessionManager;
-import net.runelite.client.config.RuneLiteConfig;
-import net.runelite.client.events.ClientUILoaded;
-import net.runelite.client.events.TitleToolbarButtonAdded;
-import net.runelite.client.events.TitleToolbarButtonRemoved;
-import net.runelite.client.ui.ClientTitleToolbar;
 import net.runelite.client.ui.FontManager;
 import net.runelite.client.ui.PluginPanel;
 import net.runelite.client.util.RunnableExceptionLogger;
-import net.runelite.client.util.SwingUtil;
 
 @Slf4j
 @Singleton
 public class InfoPanel extends PluginPanel
 {
-	private static final int TITLEBAR_SIZE = 23;
 	private static final String RUNELITE_LOGIN = "https://runelite_login/";
 
 	@Inject
 	@Nullable
 	private Client client;
-
-	@Inject
-	private RuneLiteConfig runeliteConfig;
 
 	@Inject
 	private RuneLiteProperties runeLiteProperties;
@@ -81,7 +69,6 @@ public class InfoPanel extends PluginPanel
 	private ScheduledExecutorService executor;
 
 	private final GroupLayout layout = new GroupLayout(this);
-	private final ClientTitleToolbar titleBar = new ClientTitleToolbar();
 	private final JLabel usernameHeader = new JLabel();
 	private final JRichTextPane username = new JRichTextPane();
 
@@ -90,7 +77,6 @@ public class InfoPanel extends PluginPanel
 		setLayout(layout);
 
 		final Font smallFont = FontManager.getRunescapeSmallFont();
-		updateTitleBar();
 
 		final JLabel runeliteVersionHeader = new JLabel("RuneLite version");
 		runeliteVersionHeader.setFont(smallFont);
@@ -132,8 +118,6 @@ public class InfoPanel extends PluginPanel
 		setBorder(BorderFactory.createEmptyBorder(2, 6, 6, 6));
 
 		layout.setVerticalGroup(layout.createSequentialGroup()
-			.addComponent(titleBar)
-			.addGap(3)
 			.addGroup(layout.createParallelGroup()
 				.addComponent(runeliteVersionHeader)
 				.addComponent(runescapeVersionHeader)
@@ -150,9 +134,6 @@ public class InfoPanel extends PluginPanel
 		);
 
 		layout.setHorizontalGroup(layout.createParallelGroup()
-			.addGroup(layout.createSequentialGroup()
-				.addPreferredGap(LayoutStyle.ComponentPlacement.RELATED, GroupLayout.PREFERRED_SIZE, Short.MAX_VALUE)
-				.addComponent(titleBar))
 			.addGroup(layout.createSequentialGroup()
 				.addComponent(runeliteVersionHeader)
 				.addPreferredGap(LayoutStyle.ComponentPlacement.UNRELATED, GroupLayout.PREFERRED_SIZE, Short.MAX_VALUE)
@@ -189,18 +170,6 @@ public class InfoPanel extends PluginPanel
 		}
 	}
 
-	private void updateTitleBar()
-	{
-		titleBar.setVisible(!runeliteConfig.enableCustomChrome());
-	}
-
-	@Subscribe
-	public void onClientUILoaded(ClientUILoaded e)
-	{
-		// Add the title toolbar to the infopanel if the custom chrome is disabled
-		updateTitleBar();
-	}
-
 	@Subscribe
 	public void onSessionOpen(SessionOpen sessionOpen)
 	{
@@ -211,39 +180,5 @@ public class InfoPanel extends PluginPanel
 	public void onSessionClose(SessionClose e)
 	{
 		updateLoggedIn();
-	}
-
-	@Subscribe
-	public void onTitleToolbarButtonAdded(TitleToolbarButtonAdded event)
-	{
-		if (runeliteConfig.enableCustomChrome())
-		{
-			return;
-		}
-
-		SwingUtilities.invokeLater(() ->
-		{
-			final int iconSize = TITLEBAR_SIZE - 6;
-			final JButton button = SwingUtil.createSwingButton(event.getButton(), iconSize, null);
-			titleBar.addComponent(event.getButton(), button);
-			titleBar.revalidate();
-			titleBar.repaint();
-		});
-	}
-
-	@Subscribe
-	public void onTitleToolbarButtonRemoved(TitleToolbarButtonRemoved event)
-	{
-		if (runeliteConfig.enableCustomChrome())
-		{
-			return;
-		}
-
-		SwingUtilities.invokeLater(() ->
-		{
-			titleBar.removeComponent(event.getButton());
-			titleBar.revalidate();
-			titleBar.repaint();
-		});
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/info/InfoPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/info/InfoPlugin.java
@@ -27,12 +27,10 @@ package net.runelite.client.plugins.info;
 import java.awt.image.BufferedImage;
 import javax.imageio.ImageIO;
 import javax.inject.Inject;
-import net.runelite.client.config.RuneLiteConfig;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.NavigationButton;
 import net.runelite.client.ui.PluginToolbar;
-import net.runelite.client.ui.TitleToolbar;
 
 @PluginDescriptor(
 	name = "Info Panel",
@@ -42,12 +40,6 @@ public class InfoPlugin extends Plugin
 {
 	@Inject
 	private PluginToolbar pluginToolbar;
-
-	@Inject
-	private TitleToolbar titleToolbar;
-
-	@Inject
-	private RuneLiteConfig runeLiteConfig;
 
 	private NavigationButton navButton;
 
@@ -70,11 +62,6 @@ public class InfoPlugin extends Plugin
 			.build();
 
 		pluginToolbar.addNavigation(navButton);
-
-		if (!runeLiteConfig.enableCustomChrome())
-		{
-			titleToolbar.refresh();
-		}
 	}
 
 	@Override

--- a/runelite-client/src/main/java/net/runelite/client/ui/ClientPluginToolbar.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ClientPluginToolbar.java
@@ -50,13 +50,22 @@ public class ClientPluginToolbar extends JToolBar
 		setMinimumSize(new Dimension(TOOLBAR_WIDTH, TOOLBAR_HEIGHT));
 		setPreferredSize(new Dimension(TOOLBAR_WIDTH, TOOLBAR_HEIGHT));
 		setMaximumSize(new Dimension(TOOLBAR_WIDTH, Integer.MAX_VALUE));
+		addSeparator();
 	}
 
 	public void addComponent(final int index, final NavigationButton button, final Component component)
 	{
 		if (componentMap.put(button, component) == null)
 		{
-			add(component, index);
+			if (index < 0)
+			{
+				add(component);
+			}
+			else
+			{
+				add(component, index);
+			}
+
 			revalidate();
 			repaint();
 		}

--- a/runelite-client/src/main/java/net/runelite/client/ui/ClientTitleToolbar.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ClientTitleToolbar.java
@@ -35,9 +35,9 @@ import javax.swing.JPanel;
 /**
  * Client title toolbar component.
  */
-public class ClientTitleToolbar extends JPanel
+class ClientTitleToolbar extends JPanel
 {
-	public static final int TITLEBAR_SIZE = 23;
+	static final int TITLEBAR_SIZE = 23;
 	private static final int ITEM_PADDING = 4;
 
 	private final Map<NavigationButton, Component> componentMap = new HashMap<>();
@@ -45,7 +45,7 @@ public class ClientTitleToolbar extends JPanel
 	/**
 	 * Instantiates a new Client title toolbar.
 	 */
-	public ClientTitleToolbar()
+	ClientTitleToolbar()
 	{
 		// The only other layout manager that would manage it's preferred size without padding
 		// was the GroupLayout manager, which doesn't work with dynamic layouts like this one.

--- a/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
@@ -250,28 +250,34 @@ public class ClientUI
 	@Subscribe
 	public void onTitleToolbarButtonAdded(final TitleToolbarButtonAdded event)
 	{
-		if (!config.enableCustomChrome() && !SwingUtil.isCustomTitlePanePresent(frame))
-		{
-			return;
-		}
-
 		SwingUtilities.invokeLater(() ->
 		{
 			final int iconSize = ClientTitleToolbar.TITLEBAR_SIZE - 6;
 			final JButton button = SwingUtil.createSwingButton(event.getButton(), iconSize, null);
-			titleToolbar.addComponent(event.getButton(), button);
+
+			if (config.enableCustomChrome() || SwingUtil.isCustomTitlePanePresent(frame))
+			{
+				titleToolbar.addComponent(event.getButton(), button);
+				return;
+			}
+
+			pluginToolbar.addComponent(-1, event.getButton(), button);
 		});
 	}
 
 	@Subscribe
 	public void onTitleToolbarButtonRemoved(final TitleToolbarButtonRemoved event)
 	{
-		if (!config.enableCustomChrome() && !SwingUtil.isCustomTitlePanePresent(frame))
+		SwingUtilities.invokeLater(() ->
 		{
-			return;
-		}
+			if (config.enableCustomChrome() || SwingUtil.isCustomTitlePanePresent(frame))
+			{
+				titleToolbar.removeComponent(event.getButton());
+				return;
+			}
 
-		SwingUtilities.invokeLater(() -> titleToolbar.removeComponent(event.getButton()));
+			pluginToolbar.removeComponent(event.getButton());
+		});
 	}
 
 	/**


### PR DESCRIPTION
When native window decorations are enabled (e.g when custom window
chrome is disabled), to reduce code complexity, but to maintain current
usability (e.g prevent adding new UI elements in order to position the
icons somewhere) move the title toolbar icons to sidebar.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>

Preview:
![peek 2018-03-27 12-41](https://user-images.githubusercontent.com/5115805/37962687-2f8e08f8-31bc-11e8-959f-39dd89a5d47c.gif)
