### PR TITLE
Move loading of session before starting plugins

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/RuneLite.java
+++ b/runelite-client/src/main/java/net/runelite/client/RuneLite.java
@@ -87,7 +87,7 @@ public class RuneLite
 
 	@Inject
 	private DiscordService discordService;
-	
+
 	@Inject
 	private ClientSessionManager clientSessionManager;
 
@@ -171,14 +171,14 @@ public class RuneLite
 		// to main settings
 		pluginManager.loadDefaultPluginConfiguration();
 
-		// Start plugins
-		pluginManager.startCorePlugins();
-		
 		// Start client session
 		clientSessionManager.start();
 
 		// Load the session, including saved configuration
 		sessionManager.loadSession();
+
+		// Start plugins
+		pluginManager.startCorePlugins();
 
 		// Refresh title toolbar
 		titleToolbar.refresh();


### PR DESCRIPTION
To remove the need for restarting plugins or reloading configurations
when plugins are loaded and then their confifguration changes, load
session configuration in advance.

Closes: #1121

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>