### PR TITLE
Fix widget loaded event for prayer reordering

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/events/WidgetLoaded.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/WidgetLoaded.java
@@ -27,7 +27,7 @@ package net.runelite.api.events;
 import lombok.Data;
 
 @Data
-public class WidgetOpened
+public class WidgetLoaded
 {
 	private int groupId;
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/reorderprayers/ReorderPrayersPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/reorderprayers/ReorderPrayersPlugin.java
@@ -43,7 +43,7 @@ import net.runelite.api.events.ConfigChanged;
 import net.runelite.api.events.DraggingWidgetChanged;
 import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.WidgetMenuOptionClicked;
-import net.runelite.api.events.WidgetOpened;
+import net.runelite.api.events.WidgetLoaded;
 import net.runelite.api.widgets.Widget;
 import static net.runelite.api.widgets.WidgetConfig.DRAG;
 import static net.runelite.api.widgets.WidgetConfig.DRAG_ON;
@@ -259,7 +259,7 @@ public class ReorderPrayersPlugin extends Plugin
 	}
 
 	@Subscribe
-	public void onWidgetOpened(WidgetOpened event)
+	public void onWidgetLoaded(WidgetLoaded event)
 	{
 		if (event.getGroupId() == WidgetID.PRAYER_GROUP_ID || event.getGroupId() == WidgetID.QUICK_PRAYERS_GROUP_ID)
 		{

--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSClientMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSClientMixin.java
@@ -64,7 +64,7 @@ import net.runelite.api.events.MapRegionChanged;
 import net.runelite.api.events.PlayerMenuOptionsChanged;
 import net.runelite.api.events.ResizeableChanged;
 import net.runelite.api.events.VarbitChanged;
-import net.runelite.api.events.WidgetOpened;
+import net.runelite.api.events.WidgetLoaded;
 import net.runelite.api.mixins.Copy;
 import net.runelite.api.mixins.FieldHook;
 import net.runelite.api.mixins.Inject;
@@ -507,28 +507,26 @@ public abstract class RSClientMixin implements RSClient
 		client.setMenuEntries(entries);
 	}
 
-	@Copy("loadWidget")
-	public static boolean rs$loadWidget(int widgetId)
+	@Copy("runWidgetOnLoadListener")
+	public static void rs$runWidgetOnLoadListener(int groupId)
 	{
 		throw new RuntimeException();
 	}
 
-	@Replace("loadWidget")
-	public static boolean rl$loadWidget(int widgetId)
+	@Replace("runWidgetOnLoadListener")
+	public static void rl$runWidgetOnLoadListener(int groupId)
 	{
+		rs$runWidgetOnLoadListener(groupId);
+
 		RSWidget[][] widgets = client.getWidgets();
-		boolean loadedBefore = widgets != null && widgets[widgetId] != null;
+		boolean loaded = widgets != null && widgets[groupId] != null;
 
-		boolean loaded = rs$loadWidget(widgetId);
-
-		if (!loadedBefore && loaded)
+		if (loaded)
 		{
-			WidgetOpened event = new WidgetOpened();
-			event.setGroupId(widgetId);
+			WidgetLoaded event = new WidgetLoaded();
+			event.setGroupId(groupId);
 			eventBus.post(event);
 		}
-
-		return loaded;
 	}
 
 	@FieldHook("skillExperiences")

--- a/runescape-client/src/main/java/Client.java
+++ b/runescape-client/src/main/java/Client.java
@@ -4914,7 +4914,7 @@ public final class Client extends GameEngine implements class302 {
                widgetRoot = var23;
                this.method1347(false);
                class251.method4520(var23);
-               FriendManager.method1721(widgetRoot);
+               FriendManager.runWidgetOnLoadListener(widgetRoot);
 
                for(var5 = 0; var5 < 100; ++var5) {
                   field1060[var5] = true;
@@ -5273,7 +5273,7 @@ public final class Client extends GameEngine implements class302 {
                   widgetRoot = var5;
                   this.method1347(false);
                   class251.method4520(widgetRoot);
-                  FriendManager.method1721(widgetRoot);
+                  FriendManager.runWidgetOnLoadListener(widgetRoot);
 
                   for(var31 = 0; var31 < 100; ++var31) {
                      field1060[var31] = true;
@@ -5306,7 +5306,7 @@ public final class Client extends GameEngine implements class302 {
 
                      BoundingBox3D.method62();
                      MapIcon.method578(class189.widgets[var31 >> 16], var70, false);
-                     FriendManager.method1721(var8);
+                     FriendManager.runWidgetOnLoadListener(var8);
                      if(widgetRoot != -1) {
                         DState.method3500(widgetRoot, 1);
                      }
@@ -5921,7 +5921,7 @@ public final class Client extends GameEngine implements class302 {
 
                BoundingBox3D.method62();
                MapIcon.method578(class189.widgets[var23 >> 16], var33, false);
-               FriendManager.method1721(var5);
+               FriendManager.runWidgetOnLoadListener(var5);
                if(widgetRoot != -1) {
                   DState.method3500(widgetRoot, 1);
                }

--- a/runescape-client/src/main/java/FriendManager.java
+++ b/runescape-client/src/main/java/FriendManager.java
@@ -282,7 +282,8 @@ public class FriendManager {
       signature = "(II)V",
       garbageValue = "-472965224"
    )
-   static void method1721(int var0) {
+   @Export("runWidgetOnLoadListener")
+   static void runWidgetOnLoadListener(int var0) {
       if(var0 != -1) {
          if(Name.loadWidget(var0)) {
             Widget[] var1 = class189.widgets[var0];


### PR DESCRIPTION
- Fixes widget loaded event

runWidgetOnLoadListener has not been inlined since atleast release 1.2.2 so it should be stable