### PR TITLE
Disabled kingdom plugin by default, and it's options

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/kingdomofmiscellania/KingdomConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/kingdomofmiscellania/KingdomConfig.java
@@ -43,7 +43,7 @@ public interface KingdomConfig extends Config
 	)
 	default boolean showOnlyInKingdom()
 	{
-		return true;
+		return false;
 	}
 
 	@ConfigItem(
@@ -54,7 +54,7 @@ public interface KingdomConfig extends Config
 	)
 	default boolean showWhenLow()
 	{
-		return true;
+		return false;
 	}
 
 	@ConfigItem(

--- a/runelite-client/src/main/java/net/runelite/client/plugins/kingdomofmiscellania/KingdomPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/kingdomofmiscellania/KingdomPlugin.java
@@ -44,7 +44,8 @@ import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.infobox.InfoBoxManager;
 
 @PluginDescriptor(
-	name = "Kingdom of Miscellania"
+	name = "Kingdom of Miscellania",
+	enabledByDefault = false
 )
 @Slf4j
 public class KingdomPlugin extends Plugin


### PR DESCRIPTION
To help mitigate complaints on the infobox appearing when they never asked.