### PR TITLE
Move viewport check below gamestate and CTP

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayRenderer.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayRenderer.java
@@ -264,9 +264,9 @@ public class OverlayRenderer extends MouseListener implements KeyListener
 		if (client == null
 			|| overlays == null
 			|| overlays.isEmpty()
-			|| client.getViewportWidget() == null
 			|| client.getGameState() != GameState.LOGGED_IN
-			|| client.getWidget(WidgetInfo.LOGIN_CLICK_TO_PLAY_SCREEN) != null)
+			|| client.getWidget(WidgetInfo.LOGIN_CLICK_TO_PLAY_SCREEN) != null
+			|| client.getViewportWidget() == null)
 		{
 			return;
 		}


### PR DESCRIPTION
Move viewport widget check below logged in check and click to play
screen check.

Fixes: #1190

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>