### PR TITLE
Save overlay data after resetting position

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayRenderer.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayRenderer.java
@@ -377,6 +377,8 @@ public class OverlayRenderer extends MouseListener implements KeyListener
 				{
 					overlay.setPreferredLocation(null);
 					overlay.setPreferredPosition(null);
+					saveOverlayPosition(overlay);
+					saveOverlayLocation(overlay);
 					rebuildOverlayLayers();
 				}
 				else


### PR DESCRIPTION
Due to flaw in logic, the save event in mouseReleased was never
triggered when overlay position was reset. It is not possible anymore to
go through the logic again/not worth and so save the overlay data
immediately.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>