### PR TITLE
Open window frame right after session loads

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/RuneLite.java
+++ b/runelite-client/src/main/java/net/runelite/client/RuneLite.java
@@ -48,7 +48,6 @@ import net.runelite.client.game.ItemManager;
 import net.runelite.client.menus.MenuManager;
 import net.runelite.client.plugins.PluginManager;
 import net.runelite.client.ui.ClientUI;
-import net.runelite.client.ui.TitleToolbar;
 import net.runelite.client.ui.overlay.OverlayRenderer;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
@@ -95,9 +94,6 @@ public class RuneLite
 
 	@Inject
 	private ClientUI clientUI;
-
-	@Inject
-	private TitleToolbar titleToolbar;
 
 	@Inject
 	private ItemManager itemManager;
@@ -187,14 +183,11 @@ public class RuneLite
 		// Load the session, including saved configuration
 		sessionManager.loadSession();
 
-		// Start plugins
-		pluginManager.startCorePlugins();
-
-		// Refresh title toolbar
-		titleToolbar.refresh();
-
 		// Show UI after all plugins are loaded
 		clientUI.show();
+
+		// Start plugins
+		pluginManager.startCorePlugins();
 	}
 
 	public void shutdown()

--- a/runelite-client/src/main/java/net/runelite/client/ui/TitleToolbar.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/TitleToolbar.java
@@ -27,7 +27,6 @@ package net.runelite.client.ui;
 
 import com.google.common.eventbus.EventBus;
 import java.util.Comparator;
-import java.util.Iterator;
 import java.util.TreeSet;
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -80,23 +79,6 @@ public class TitleToolbar
 		if (buttons.remove(button))
 		{
 			eventBus.post(new TitleToolbarButtonRemoved(button, index));
-		}
-	}
-
-	/**
-	 * Refresh all buttons
-	 */
-	public void refresh()
-	{
-		final Iterator<NavigationButton> iterator = buttons.iterator();
-		int index = 0;
-
-		while (iterator.hasNext())
-		{
-			final NavigationButton button = iterator.next();
-			eventBus.post(new TitleToolbarButtonRemoved(button, index));
-			eventBus.post(new TitleToolbarButtonAdded(button, index));
-			index++;
 		}
 	}
 }


### PR DESCRIPTION
To reduce the delay between launching RuneLite and opening the main
window, show it right after session loads. This also removes the need
for refreshing title toolbar after plugin finish loading.

Depends on #1146