### PR TITLE
Clip overlays on the above scene layer to the viewport

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/Client.java
+++ b/runelite-api/src/main/java/net/runelite/api/Client.java
@@ -76,6 +76,10 @@ public interface Client extends GameEngine
 
 	int getViewportWidth();
 
+	int getViewportXOffset();
+
+	int getViewportYOffset();
+
 	int getScale();
 
 	Point getMouseCanvasPosition();

--- a/runelite-api/src/main/java/net/runelite/api/Perspective.java
+++ b/runelite-api/src/main/java/net/runelite/api/Perspective.java
@@ -508,8 +508,8 @@ public class Perspective
 			int minY = Math.min(Math.min(a.getY(), b.getY()), c.getY());
 
 			// For some reason, this calculation is always 4 pixels short of the actual in-client one
-			int maxX = Math.max(Math.max(a.getX(), b.getX()), c.getX()) + 4;
-			int maxY = Math.max(Math.max(a.getY(), b.getY()), c.getY()) + 4;
+			int maxX = Math.max(Math.max(a.getX(), b.getX()), c.getX()) + client.getViewportXOffset();
+			int maxY = Math.max(Math.max(a.getY(), b.getY()), c.getY()) + client.getViewportYOffset();
 
 			// ...and the rectangles in the fixed client are shifted 4 pixels right and down
 			if (!client.isResized())

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayRenderer.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayRenderer.java
@@ -34,7 +34,6 @@ import java.awt.Rectangle;
 import java.awt.event.KeyEvent;
 import java.awt.event.MouseEvent;
 import java.awt.image.BufferedImage;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -225,7 +224,7 @@ public class OverlayRenderer extends MouseListener implements KeyListener
 			{
 				if (value == null)
 				{
-					value = new ArrayList<>();
+					value = new CopyOnWriteArrayList<>();
 				}
 
 				value.add(overlay);

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayRenderer.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayRenderer.java
@@ -317,7 +317,7 @@ public class OverlayRenderer extends MouseListener implements KeyListener
 
 			if (overlayPosition == OverlayPosition.DYNAMIC || overlayPosition == OverlayPosition.TOOLTIP)
 			{
-				safeRender(overlay, graphics, new Point());
+				safeRender(client, overlay, layer, graphics, new Point());
 			}
 			else
 			{
@@ -338,7 +338,7 @@ public class OverlayRenderer extends MouseListener implements KeyListener
 					location.setLocation(overlay.getPreferredLocation());
 				}
 
-				safeRender(overlay, graphics, location);
+				safeRender(client, overlay, layer, graphics, location);
 				dimension.setSize(overlay.getBounds().getSize());
 
 				if (dimension.width == 0 && dimension.height == 0)
@@ -488,9 +488,16 @@ public class OverlayRenderer extends MouseListener implements KeyListener
 		}
 	}
 
-	private void safeRender(Overlay overlay, Graphics2D graphics, Point point)
+	private void safeRender(Client client, Overlay overlay, OverlayLayer layer, Graphics2D graphics, Point point)
 	{
 		final Graphics2D subGraphics = (Graphics2D) graphics.create();
+		if (!isResizeable && (layer == OverlayLayer.ABOVE_SCENE || layer == OverlayLayer.UNDER_WIDGETS))
+		{
+			subGraphics.setClip(client.getViewportXOffset(),
+				client.getViewportYOffset(),
+				client.getViewportWidth(),
+				client.getViewportHeight());
+		}
 		subGraphics.translate(point.x, point.y);
 		final Dimension dimension = MoreObjects.firstNonNull(overlay.render(subGraphics), new Dimension());
 		subGraphics.dispose();

--- a/runescape-api/src/main/java/net/runelite/rs/api/RSClient.java
+++ b/runescape-api/src/main/java/net/runelite/rs/api/RSClient.java
@@ -251,6 +251,14 @@ public interface RSClient extends RSGameEngine, Client
 	@Override
 	int getViewportWidth();
 
+	@Import("Viewport_xOffset")
+	@Override
+	int getViewportXOffset();
+
+	@Import("Viewport_yOffset")
+	@Override
+	int getViewportYOffset();
+
 	@Import("isResized")
 	@Override
 	boolean isResized();


### PR DESCRIPTION
Clips overlays on the above scene layer to the size and position of the viewport so the text doesn't draw over the minimap

Before:
![image](https://user-images.githubusercontent.com/11643842/38150494-64570bfc-345f-11e8-891c-843e9fceb150.png)

After:
![image](https://user-images.githubusercontent.com/11643842/38150462-4384f060-345f-11e8-8777-76bf5f3ded27.png)
