### PR TITLE
agility plugin: Add region check to lap counter

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/agilityplugin/AgilityPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/agilityplugin/AgilityPlugin.java
@@ -25,6 +25,7 @@
 package net.runelite.client.plugins.agilityplugin;
 
 import com.google.common.eventbus.Subscribe;
+import com.google.common.primitives.Ints;
 import com.google.inject.Provides;
 import java.util.Arrays;
 import java.util.Collection;
@@ -129,7 +130,7 @@ public class AgilityPlugin extends Plugin
 
 		// Get course
 		Courses course = Courses.getCourse(skillGained);
-		if (course == null)
+		if (course == null || !Ints.contains(client.getMapRegions(), course.getRegionId()))
 		{
 			return;
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/agilityplugin/Courses.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/agilityplugin/Courses.java
@@ -26,25 +26,27 @@ package net.runelite.client.plugins.agilityplugin;
 
 import java.util.HashMap;
 import java.util.Map;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+@AllArgsConstructor
 public enum Courses
 {
-	GNOME(86.5, 46),
-	DRAYNOR(120.0, 79),
-	AL_KARID(180.0, 30),
-	PYRAMID(722.0, 300),
-	VARROCK(238.0, 125),
-	PENGUIN(540.0, 65),
-	BARBARIAN(139.5, 60),
-	CANIFIS(240.0, 175),
-	APE_ATOLL(580.0, 300),
-	FALADOR(440, 180),
-	WILDERNESS(571.0, 499),
-	SEERS(570.0, 435),
-	POLLNIVEACH(890.0, 540),
-	RELLEKA(780.0, 475),
-	ARDOUGNE(793.0, 529);
+	GNOME(86.5, 46, 9781),
+	DRAYNOR(120.0, 79, 12338),
+	AL_KARID(180.0, 30, 13105),
+	PYRAMID(722.0, 300, 13356),
+	VARROCK(238.0, 125, 12853),
+	PENGUIN(540.0, 65, 10559),
+	BARBARIAN(139.5, 60, 10039),
+	CANIFIS(240.0, 175, 13878),
+	APE_ATOLL(580.0, 300, 11050),
+	FALADOR(440, 180, 12084),
+	WILDERNESS(571.0, 499, 11837),
+	SEERS(570.0, 435, 10806),
+	POLLNIVEACH(890.0, 540, 13358),
+	RELLEKA(780.0, 475, 10553),
+	ARDOUGNE(793.0, 529, 10547);
 
 	private final static Map<Integer, Courses> courseXps = new HashMap<>();
 
@@ -53,18 +55,15 @@ public enum Courses
 
 	private final int lastObstacleXp;
 
+	@Getter
+	private final int regionId;
+
 	static
 	{
 		for (Courses course : values())
 		{
 			courseXps.put(course.lastObstacleXp, course);
 		}
-	}
-
-	Courses(double totalXp, int lastObstacleXp)
-	{
-		this.totalXp = totalXp;
-		this.lastObstacleXp = lastObstacleXp;
 	}
 
 	public static Courses getCourse(int exp)


### PR DESCRIPTION
Some courses have obstacles that have XP equal to another courses last obstacle making it trigger a new course. This adds a region check to make sure you are in the correct region before setting a new course