### PR TITLE
boosts plugin: Add stat change indicator

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/boosts/BoostsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/boosts/BoostsOverlay.java
@@ -57,6 +57,8 @@ class BoostsOverlay extends Overlay
 
 	private PanelComponent panelComponent;
 
+	private boolean overlayActive;
+
 	@Inject
 	BoostsOverlay(Client client, BoostsConfig config, InfoBoxManager infoBoxManager)
 	{
@@ -71,7 +73,23 @@ class BoostsOverlay extends Overlay
 	public Dimension render(Graphics2D graphics)
 	{
 		panelComponent = new PanelComponent();
-		boolean overlayActive = false;
+
+		Instant lastChange = plugin.getLastChange();
+		if (config.displayNextChange() && lastChange != null && overlayActive)
+		{
+			int nextChange = 60 - (int)Duration.between(lastChange, Instant.now()).getSeconds();
+			if (nextChange > 0)
+			{
+				panelComponent.getLines().add(new PanelComponent.Line(
+					"Next change in",
+					Color.WHITE,
+					String.valueOf(nextChange),
+					Color.WHITE
+				));
+			}
+		}
+
+		overlayActive = false;
 
 		for (Skill skill : plugin.getShownSkills())
 		{
@@ -133,21 +151,6 @@ class BoostsOverlay extends Overlay
 					Color.WHITE,
 					str,
 					strColor
-				));
-			}
-		}
-
-		Instant lastChange = plugin.getLastChange();
-		if (config.displayNextChange() && lastChange != null && overlayActive)
-		{
-			int nextChange = 60 - (int)Duration.between(lastChange, Instant.now()).getSeconds();
-			if (nextChange > 0)
-			{
-				panelComponent.getLines().add(new PanelComponent.Line(
-					"Next change in",
-					Color.WHITE,
-					String.valueOf(nextChange),
-					Color.WHITE
 				));
 			}
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/boosts/BoostsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/boosts/BoostsOverlay.java
@@ -27,7 +27,6 @@ package net.runelite.client.plugins.boosts;
 import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Graphics2D;
-import java.time.Duration;
 import java.time.Instant;
 import javax.inject.Inject;
 import lombok.Getter;
@@ -75,9 +74,12 @@ class BoostsOverlay extends Overlay
 		panelComponent = new PanelComponent();
 
 		Instant lastChange = plugin.getLastChange();
-		if (config.displayNextChange() && lastChange != null && overlayActive)
+		if (!config.displayIndicators()
+			&& config.displayNextChange()
+			&& lastChange != null
+			&& overlayActive)
 		{
-			int nextChange = 60 - (int)Duration.between(lastChange, Instant.now()).getSeconds();
+			int nextChange = plugin.getChangeTime();
 			if (nextChange > 0)
 			{
 				panelComponent.getLines().add(new PanelComponent.Line(

--- a/runelite-client/src/main/java/net/runelite/client/plugins/boosts/StatChangeIndicator.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/boosts/StatChangeIndicator.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2018, Seth <http://github.com/sethtroll>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.boosts;
+
+import java.awt.image.BufferedImage;
+import java.time.temporal.ChronoUnit;
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.ui.overlay.infobox.InfoBoxPriority;
+import net.runelite.client.ui.overlay.infobox.Timer;
+
+public class StatChangeIndicator extends Timer
+{
+	public StatChangeIndicator(long period, ChronoUnit unit, BufferedImage image, Plugin plugin)
+	{
+		super(period, unit, image, plugin);
+		setPriority(InfoBoxPriority.MED);
+		setTooltip("Next stat change");
+	}
+}


### PR DESCRIPTION
- Move the next stat change text to the top
![top](https://user-images.githubusercontent.com/5454364/38165630-2d74ef32-34dc-11e8-942e-613cc7609c36.png)

- Add stat change indicator when indicators are selected
![indicators](https://user-images.githubusercontent.com/5454364/38165631-2e9df8ae-34dc-11e8-9a9c-328823da3f45.png)
