### PR TITLE
Invalidate ground items and item composition cache

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/RuneLite.java
+++ b/runelite-client/src/main/java/net/runelite/client/RuneLite.java
@@ -43,6 +43,7 @@ import net.runelite.client.account.SessionManager;
 import net.runelite.client.chat.ChatMessageManager;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.discord.DiscordService;
+import net.runelite.client.game.ItemManager;
 import net.runelite.client.menus.MenuManager;
 import net.runelite.client.plugins.PluginManager;
 import net.runelite.client.ui.ClientUI;
@@ -96,6 +97,9 @@ public class RuneLite
 
 	@Inject
 	private TitleToolbar titleToolbar;
+
+	@Inject
+	private ItemManager itemManager;
 
 	Client client;
 
@@ -156,6 +160,7 @@ public class RuneLite
 		eventBus.register(menuManager);
 		eventBus.register(chatMessageManager);
 		eventBus.register(pluginManager);
+		eventBus.register(itemManager);
 
 		// Load user configuration
 		configManager.load();

--- a/runelite-client/src/main/java/net/runelite/client/game/ItemManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/game/ItemManager.java
@@ -27,6 +27,7 @@ package net.runelite.client.game;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
+import com.google.common.eventbus.Subscribe;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -43,8 +44,10 @@ import lombok.Value;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import static net.runelite.api.Constants.CLIENT_DEFAULT_ZOOM;
+import net.runelite.api.GameState;
 import net.runelite.api.ItemComposition;
 import net.runelite.api.SpritePixels;
+import net.runelite.api.events.GameStateChanged;
 import net.runelite.http.api.item.ItemClient;
 import net.runelite.http.api.item.ItemPrice;
 import net.runelite.http.api.item.SearchResult;
@@ -126,6 +129,15 @@ public class ItemManager
 					return client.getItemDefinition(key);
 				}
 			});
+	}
+
+	@Subscribe
+	public void onGameStateChanged(final GameStateChanged event)
+	{
+		if (event.getGameState() == GameState.HOPPING || event.getGameState() == GameState.LOGIN_SCREEN)
+		{
+			itemCompositions.invalidateAll();
+		}
 	}
 
 	/**

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
@@ -195,8 +195,7 @@ public class GroundItemsPlugin extends Plugin
 	{
 		if (event.getGameState() == GameState.LOGGED_IN)
 		{
-			groundItems.clear();
-			collectedGroundItems.clear();
+			dirty = true;
 		}
 	}
 


### PR DESCRIPTION
- Invalidate item manager composition cache when person is hopping or goes
to login screen to prevent issues with changing from p2p to f2p worlds.
- Instead of clearing ground items after game state change, just mark the
ground items dirty.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>