### PR TITLE
Add configuration options for ground item plugin

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
@@ -196,10 +196,21 @@ public interface GroundItemsConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "lowValuePrice",
+		name = "Low value price",
+		description = "Configures the start price for low value items",
+		position = 14
+	)
+	default int lowValuePrice()
+	{
+		return 20000;
+	}
+
+	@ConfigItem(
 		keyName = "mediumValueColor",
 		name = "Medium value items color",
 		description = "Configures the color for medium value items",
-		position = 14
+		position = 15
 	)
 	default Color mediumValueColor()
 	{
@@ -207,10 +218,21 @@ public interface GroundItemsConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "mediumValuePrice",
+		name = "Medium value price",
+		description = "Configures the start price for medium value items",
+		position = 16
+	)
+	default int mediumValuePrice()
+	{
+		return 100000;
+	}
+
+	@ConfigItem(
 		keyName = "highValueColor",
 		name = "High value items color",
 		description = "Configures the color for high value items",
-		position = 15
+		position = 17
 	)
 	default Color highValueColor()
 	{
@@ -218,13 +240,35 @@ public interface GroundItemsConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "highValuePrice",
+		name = "High value price",
+		description = "Configures the start price for high value items",
+		position = 18
+	)
+	default int highValuePrice()
+	{
+		return 1000000;
+	}
+
+	@ConfigItem(
 		keyName = "insaneValueColor",
 		name = "Insane value items color",
 		description = "Configures the color for insane value items",
-		position = 16
+		position = 19
 	)
 	default Color insaneValueColor()
 	{
 		return Color.decode("#FF66B2");
+	}
+
+	@ConfigItem(
+		keyName = "insaneValuePrice",
+		name = "Insane value price",
+		description = "Configures the start price for insane value items",
+		position = 20
+	)
+	default int insaneValuePrice()
+	{
+		return 10000000;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
@@ -57,14 +57,6 @@ public class GroundItemsOverlay extends Overlay
 	private static final int MAX_QUANTITY = 65535;
 	// The 15 pixel gap between each drawn ground item.
 	private static final int STRING_GAP = 15;
-	// Threshold for highlighting items as blue.
-	private static final int LOW_VALUE = 20_000;
-	// Threshold for highlighting items as green.
-	private static final int MEDIUM_VALUE = 100_000;
-	// Threshold for highlighting items as amber.
-	private static final int HIGH_VALUE = 1_000_000;
-	// Threshold for highlighting items as pink.
-	private static final int INSANE_VALUE = 10_000_000;
 	// Size of the hidden/highlight boxes
 	private static final int RECTANGLE_SIZE = 8;
 
@@ -225,22 +217,22 @@ public class GroundItemsOverlay extends Overlay
 		}
 
 		// set the color according to rarity, if possible
-		if (cost >= INSANE_VALUE) // 10,000,000 gp
+		if (cost >= config.insaneValuePrice())
 		{
 			return config.insaneValueColor();
 		}
 
-		if (cost >= HIGH_VALUE) // 1,000,000 gp
+		if (cost >= config.highValuePrice())
 		{
 			return config.highValueColor();
 		}
 
-		if (cost >= MEDIUM_VALUE) // 100,000 gp
+		if (cost >= config.mediumValuePrice())
 		{
 			return config.mediumValueColor();
 		}
 
-		if (cost >= LOW_VALUE) // 20,000 gp
+		if (cost >= config.lowValuePrice())
 		{
 			return config.lowValueColor();
 		}


### PR DESCRIPTION
Adds simple number input for the ground item plugin.

![image](https://user-images.githubusercontent.com/597053/38168225-d8999f08-3503-11e8-9abf-d579558e6694.png)

Fixes #1126 
