### PR TITLE
Check for "Attack" option for NPC in idle notifier

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
@@ -29,6 +29,8 @@ import com.google.common.eventbus.Subscribe;
 import com.google.inject.Provides;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Arrays;
+import java.util.List;
 import javax.inject.Inject;
 import net.runelite.api.Actor;
 import static net.runelite.api.AnimationID.COOKING_FIRE;
@@ -101,6 +103,8 @@ import static net.runelite.api.AnimationID.WOODCUTTING_RUNE;
 import static net.runelite.api.AnimationID.WOODCUTTING_STEEL;
 import net.runelite.api.Client;
 import net.runelite.api.GameState;
+import net.runelite.api.NPC;
+import net.runelite.api.NPCComposition;
 import net.runelite.api.Player;
 import net.runelite.api.Skill;
 import net.runelite.api.events.AnimationChanged;
@@ -128,7 +132,6 @@ public class IdleNotifierPlugin extends Plugin
 	@Inject
 	private IdleNotifierConfig config;
 
-	private Actor lastOpponent;
 	private Instant lastAnimating;
 	private Instant lastInteracting;
 	private boolean notifyIdle = false;
@@ -356,24 +359,28 @@ public class IdleNotifierPlugin extends Plugin
 
 	private boolean checkOutOfCombat(Duration waitDuration, Player local)
 	{
-		Actor opponent = local.getInteracting();
-		boolean isPlayer = opponent instanceof Player;
+		final Actor opponent = local.getInteracting();
 
-		if (opponent != null
-			&& !isPlayer
-			&& opponent.getCombatLevel() > 0)
+		if (opponent != null)
 		{
-			resetTimers();
-			lastOpponent = opponent;
-		}
-		else if (opponent == null)
-		{
-			lastOpponent = null;
-		}
+			// Reset last interaction time
+			lastInteracting = null;
 
-		if (lastOpponent != null && opponent == lastOpponent)
-		{
-			lastInteracting = Instant.now();
+			final boolean isNpc = opponent instanceof NPC;
+
+			if (isNpc)
+			{
+				final NPC npc = (NPC) opponent;
+				final NPCComposition npcComposition = npc.getComposition();
+				final List<String> npcMenuActions = Arrays.asList(npcComposition.getActions());
+
+				if (npcMenuActions.contains("Attack"))
+				{
+					// Player is most likely in combat with attack-able NPC
+					resetTimers();
+					lastInteracting = Instant.now();
+				}
+			}
 		}
 
 		if (lastInteracting != null && Instant.now().compareTo(lastInteracting.plus(waitDuration)) >= 0)
@@ -456,7 +463,6 @@ public class IdleNotifierPlugin extends Plugin
 		lastAnimating = null;
 
 		// Reset combat idle timer
-		lastOpponent = null;
 		lastInteracting = null;
 	}
 }


### PR DESCRIPTION
- Instead of checking for combat level, check if NPC has attack option
to prevent issues with idle notifier falsely counting talking to NPCs as
combat action
- Do not compare last and current opponent. Instead just reset
lastInteracting every time player has opponent and set it to new value
in case it is attackable opponent. This ensures that idle notification
will be reset when player starts talking to non-attackable NPC after
fight, but also ensures that notification will not be thrown during the
actual fight and only after it ends (e.g opponent changes to null and
action will not be reset)

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>