### PR TITLE
Support both highlight over GE and HA value

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
@@ -127,10 +127,32 @@ public interface GroundItemsConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "highlightOverGeValue",
+		name = "Highlight > GE Value",
+		description = "Configures highlighted ground items over GE value",
+		position = 9
+	)
+	default int getHighlightOverGeValue()
+	{
+		return 20000;
+	}
+
+	@ConfigItem(
+		keyName = "highlightOverHaValue",
+		name = "Highlight > HA Value",
+		description = "Configures highlighted ground items over High Alch value",
+		position = 10
+	)
+	default int getHighlightOverHAValue()
+	{
+		return 20000;
+	}
+
+	@ConfigItem(
 		keyName = "highlightedItems",
 		name = "Highlighted Items",
 		description = "Configures specifically highlighted ground items. Format: (item), (item)",
-		position = 9
+		position = 11
 	)
 	default String getHighlightItems()
 	{
@@ -148,7 +170,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "hiddenItems",
 		name = "Hidden Items",
 		description = "Configures hidden ground items. Format: (item), (item)",
-		position = 10
+		position = 12
 	)
 	default String getHiddenItems()
 	{
@@ -166,7 +188,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "defaultColor",
 		name = "Default items color",
 		description = "Configures the color for default, non-highlighted items",
-		position = 11
+		position = 13
 	)
 	default Color defaultColor()
 	{
@@ -177,7 +199,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "highlightedColor",
 		name = "Highlighted items color",
 		description = "Configures the color for highlighted items",
-		position = 12
+		position = 14
 	)
 	default Color highlightedColor()
 	{
@@ -185,43 +207,10 @@ public interface GroundItemsConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "lowValueColor",
-		name = "Low value items color",
-		description = "Configures the color for low value items",
-		position = 13
-	)
-	default Color lowValueColor()
-	{
-		return Color.decode("#66B2FF");
-	}
-
-	@ConfigItem(
-		keyName = "lowValuePrice",
-		name = "Low value price",
-		description = "Configures the start price for low value items",
-		position = 14
-	)
-	default int lowValuePrice()
-	{
-		return 20000;
-	}
-
-	@ConfigItem(
-		keyName = "mediumValueColor",
-		name = "Medium value items color",
-		description = "Configures the color for medium value items",
-		position = 15
-	)
-	default Color mediumValueColor()
-	{
-		return Color.decode("#99FF99");
-	}
-
-	@ConfigItem(
 		keyName = "mediumValuePrice",
-		name = "Medium value price",
-		description = "Configures the start price for medium value items",
-		position = 16
+		name = "Medium value price offset",
+		description = "Configures the offset price for medium value items (base is highlight > value)",
+		position = 15
 	)
 	default int mediumValuePrice()
 	{
@@ -229,21 +218,21 @@ public interface GroundItemsConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "highValueColor",
-		name = "High value items color",
-		description = "Configures the color for high value items",
-		position = 17
+		keyName = "mediumValueColor",
+		name = "Medium value items color",
+		description = "Configures the color for medium value items",
+		position = 16
 	)
-	default Color highValueColor()
+	default Color mediumValueColor()
 	{
-		return Color.decode("#FF9600");
+		return Color.decode("#99FF99");
 	}
 
 	@ConfigItem(
 		keyName = "highValuePrice",
-		name = "High value price",
-		description = "Configures the start price for high value items",
-		position = 18
+		name = "High value price offset",
+		description = "Configures the offset price for high value items (base is highlight > value)",
+		position = 17
 	)
 	default int highValuePrice()
 	{
@@ -251,24 +240,35 @@ public interface GroundItemsConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "insaneValueColor",
-		name = "Insane value items color",
-		description = "Configures the color for insane value items",
-		position = 19
+		keyName = "highValueColor",
+		name = "High value items color",
+		description = "Configures the color for high value items",
+		position = 18
 	)
-	default Color insaneValueColor()
+	default Color highValueColor()
 	{
-		return Color.decode("#FF66B2");
+		return Color.decode("#FF9600");
 	}
 
 	@ConfigItem(
 		keyName = "insaneValuePrice",
-		name = "Insane value price",
-		description = "Configures the start price for insane value items",
-		position = 20
+		name = "Insane value price offset",
+		description = "Configures the offset price for insane value items (base is highlight > value)",
+		position = 19
 	)
 	default int insaneValuePrice()
 	{
 		return 10000000;
+	}
+
+	@ConfigItem(
+		keyName = "insaneValueColor",
+		name = "Insane value items color",
+		description = "Configures the color for insane value items",
+		position = 20
+	)
+	default Color insaneValueColor()
+	{
+		return Color.decode("#FF66B2");
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
@@ -118,7 +118,7 @@ public class GroundItemsOverlay extends Overlay
 			final boolean highlighted = plugin.isHighlighted(item.getName(), item.getHaPrice(), item.getGePrice());
 			final boolean hidden = plugin.isHidden(item.getName(), item.getHaPrice(), item.getGePrice());
 
-			if (!plugin.isHotKeyPressed())
+			if (!plugin.isHotKeyPressed() && !highlighted)
 			{
 				// Do not display hidden items
 				if (hidden)
@@ -127,7 +127,7 @@ public class GroundItemsOverlay extends Overlay
 				}
 
 				// Do not display non-highlighted items when only highlighted items should be shown
-				if (config.showHighlightedOnly() && !highlighted)
+				if (config.showHighlightedOnly())
 				{
 					continue;
 				}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
@@ -105,8 +105,18 @@ public class GroundItemsOverlay extends Overlay
 				continue;
 			}
 
-			final boolean highlighted = plugin.isHighlighted(item.getName());
-			final boolean hidden = plugin.isHidden(item.getName());
+
+			// Update GE price for item
+			final ItemPrice itemPrice = itemManager.getItemPriceAsync(item.getItemId());
+
+			if (itemPrice != null && itemPrice.getPrice() > 0)
+			{
+				item.setGePrice(itemPrice.getPrice() * item.getQuantity());
+			}
+
+			// Determine if item is highlighted or hidden
+			final boolean highlighted = plugin.isHighlighted(item.getName(), item.getHaPrice(), item.getGePrice());
+			final boolean hidden = plugin.isHidden(item.getName(), item.getHaPrice(), item.getGePrice());
 
 			if (!plugin.isHotKeyPressed())
 			{
@@ -123,24 +133,7 @@ public class GroundItemsOverlay extends Overlay
 				}
 			}
 
-			// Update GE price for item
-			final ItemPrice itemPrice = itemManager.getItemPriceAsync(item.getItemId());
-
-			if (itemPrice != null && itemPrice.getPrice() > 0)
-			{
-				item.setGePrice(itemPrice.getPrice() * item.getQuantity());
-			}
-
-			// Do not display items that are under HA or GE price and are not highlighted
-			if (!plugin.isHotKeyPressed() && !highlighted
-				&& ((item.getGePrice() > 0 && item.getGePrice() < config.getHideUnderGeValue())
-				|| item.getHaPrice() < config.getHideUnderHAValue()))
-			{
-				continue;
-			}
-
-			final Color color = getCostColor(item.getGePrice() > 0 ? item.getGePrice() : item.getHaPrice(),
-				highlighted, hidden);
+			final Color color = plugin.getCostColor(highlighted, hidden, item.getHaPrice(), item.getGePrice());
 			itemStringBuilder.append(item.getName());
 
 			if (item.getQuantity() > 1)
@@ -227,42 +220,6 @@ public class GroundItemsOverlay extends Overlay
 		}
 
 		return null;
-	}
-
-	Color getCostColor(int cost, boolean highlighted, boolean hidden)
-	{
-		if (hidden)
-		{
-			return Color.GRAY;
-		}
-
-		if (highlighted)
-		{
-			return config.highlightedColor();
-		}
-
-		// set the color according to rarity, if possible
-		if (cost >= config.insaneValuePrice())
-		{
-			return config.insaneValueColor();
-		}
-
-		if (cost >= config.highValuePrice())
-		{
-			return config.highValueColor();
-		}
-
-		if (cost >= config.mediumValuePrice())
-		{
-			return config.mediumValueColor();
-		}
-
-		if (cost >= config.lowValuePrice())
-		{
-			return config.lowValueColor();
-		}
-
-		return config.defaultColor();
 	}
 
 	private void drawRectangle(Graphics2D graphics, Rectangle rect, Color color, boolean inList, boolean hiddenBox)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
@@ -342,13 +342,6 @@ public class GroundItemsPlugin extends Plugin
 			&& event.getType() == MenuAction.GROUND_ITEM_THIRD_OPTION.getId())
 		{
 			int itemId = event.getIdentifier();
-			ItemComposition itemComposition = client.getItemDefinition(itemId);
-
-			if (isHidden(itemComposition.getName()))
-			{
-				return;
-			}
-
 			Region region = client.getRegion();
 			Tile tile = region.getTiles()[client.getPlane()][event.getActionParam0()][event.getActionParam1()];
 			ItemLayer itemLayer = tile.getItemLayer();
@@ -372,20 +365,25 @@ public class GroundItemsPlugin extends Plugin
 				current = current.getNext();
 			}
 
-			ItemPrice itemPrice = getItemPrice(itemComposition);
-			int price = itemPrice == null ? itemComposition.getPrice() : itemPrice.getPrice();
-			int cost = quantity * price;
-			Color color = overlay.getCostColor(cost, isHighlighted(itemComposition.getName()),
-				isHidden(itemComposition.getName()));
+			final ItemComposition itemComposition = client.getItemDefinition(itemId);
+			final ItemPrice itemPrice = getItemPrice(itemComposition);
+			final int price = itemPrice == null ? itemComposition.getPrice() : itemPrice.getPrice();
+			final int haPrice = Math.round(itemComposition.getPrice() * HIGH_ALCHEMY_CONSTANT) * quantity;
+			final int gePrice = quantity * price;
+			final boolean hidden = isHidden(itemComposition.getName(), haPrice, gePrice);
+			final boolean highlighted = isHighlighted(itemComposition.getName(), haPrice, gePrice);
+			final Color color = getCostColor(highlighted, hidden, haPrice, gePrice);
 
 			if (!color.equals(config.defaultColor()))
 			{
 				String hexColor = Integer.toHexString(color.getRGB() & 0xFFFFFF);
 				String colTag = "<col=" + hexColor + ">";
+
 				if (config.highlightMenuOption())
 				{
 					lastEntry.setOption(colTag + "Take");
 				}
+
 				if (config.highlightMenuItemName())
 				{
 					String target = lastEntry.getTarget().substring(lastEntry.getTarget().indexOf(">") + 1);
@@ -424,14 +422,52 @@ public class GroundItemsPlugin extends Plugin
 		}
 	}
 
-	public boolean isHighlighted(String item)
+	Color getCostColor(boolean highlighted, boolean hidden, int haPrice, int gePrice)
 	{
-		return TRUE.equals(highlightedItems.getUnchecked(item));
+		if (hidden)
+		{
+			return Color.GRAY;
+		}
+
+		if (highlighted)
+		{
+			final boolean geBased = gePrice > haPrice;
+			final int cost = geBased ? gePrice : haPrice;
+			final int base = geBased ? config.getHighlightOverGeValue() : config.getHighlightOverHAValue();
+
+			if (cost >= base + config.insaneValuePrice())
+			{
+				return config.insaneValueColor();
+			}
+
+			if (cost >= base + config.highValuePrice())
+			{
+				return config.highValueColor();
+			}
+
+			if (cost >= base + config.mediumValuePrice())
+			{
+				return config.mediumValueColor();
+			}
+
+			return config.highlightedColor();
+		}
+
+		return config.defaultColor();
 	}
 
-	public boolean isHidden(String item)
+	boolean isHighlighted(String item, int haPrice, int gePrice)
 	{
-		return TRUE.equals(hiddenItems.getUnchecked(item));
+		return TRUE.equals(highlightedItems.getUnchecked(item))
+			|| (config.getHighlightOverGeValue() > 0 && gePrice >= config.getHighlightOverGeValue())
+			|| (config.getHighlightOverHAValue() > 0 && haPrice >= config.getHighlightOverHAValue());
+	}
+
+	boolean isHidden(String item, int haPrice, int gePrice)
+	{
+		return TRUE.equals(hiddenItems.getUnchecked(item))
+			|| (gePrice > 0 && gePrice < config.getHideUnderGeValue())
+			|| haPrice < config.getHideUnderHAValue();
 	}
 
 	@Subscribe

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
@@ -424,11 +424,6 @@ public class GroundItemsPlugin extends Plugin
 
 	Color getCostColor(boolean highlighted, boolean hidden, int haPrice, int gePrice)
 	{
-		if (hidden)
-		{
-			return Color.GRAY;
-		}
-
 		if (highlighted)
 		{
 			final boolean geBased = gePrice > haPrice;
@@ -451,6 +446,11 @@ public class GroundItemsPlugin extends Plugin
 			}
 
 			return config.highlightedColor();
+		}
+
+		if (hidden)
+		{
+			return Color.GRAY;
 		}
 
 		return config.defaultColor();


### PR DESCRIPTION
- Add option to highlight item over GE value using the highlight color
- Add option to highlight item over HA value using the highlight color
- Mark highlighted and hidden items properly based on the hide/highlight
properties
- Use highlight > GE and > HA value as base for the item color
thresholds (so for example when the highlight > GE value is 20k, the medium item highlight is 20k + medium threshold, so 100k, and that is 120k threshold)
- Highlighted items should be prioritized over hidden items, so switch
this behaviour.

Fixes #1563 and closes #1841 

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>

Preview:
![screenshot 2018-04-22 16 55 56](https://user-images.githubusercontent.com/5115805/39096293-2eaf4ea0-464e-11e8-8187-bec6df7847e5.png)

![screenie](https://user-images.githubusercontent.com/5115805/38622446-7eaaeb98-3da3-11e8-8dfb-c3ab03566cad.png)