### PR TITLE
Highlight dark mage NPC in the center of the abyss when inventory contains a degraded pouch

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/queries/InventoryItemQuery.java
+++ b/runelite-api/src/main/java/net/runelite/api/queries/InventoryItemQuery.java
@@ -24,6 +24,8 @@
  */
 package net.runelite.api.queries;
 
+import java.util.Arrays;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import net.runelite.api.Client;
 import net.runelite.api.InventoryID;
@@ -44,7 +46,26 @@ public class InventoryItemQuery extends Query<Item, InventoryItemQuery>
 		{
 			return null;
 		}
-		return container.getItems();
+		return Arrays.stream(container.getItems())
+				.filter(Objects::nonNull)
+				.filter(predicate)
+				.toArray(Item[]::new);
+	}
+
+	public InventoryItemQuery idEquals(int... ids)
+	{
+		predicate = and(item ->
+		{
+			for (int id : ids)
+			{
+				if (item.getId() == id)
+				{
+					return true;
+				}
+			}
+			return false;
+		});
+		return this;
 	}
 
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/runecraft/AbyssOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/runecraft/AbyssOverlay.java
@@ -25,6 +25,7 @@
 package net.runelite.client.plugins.runecraft;
 
 import java.awt.Color;
+import java.awt.Polygon;
 import java.awt.geom.Area;
 import static net.runelite.client.plugins.runecraft.AbyssRifts.AIR_RIFT;
 import static net.runelite.client.plugins.runecraft.AbyssRifts.BLOOD_RIFT;
@@ -49,6 +50,7 @@ import java.util.Map;
 import java.util.Set;
 import net.runelite.api.Client;
 import net.runelite.api.DecorativeObject;
+import net.runelite.api.NPC;
 import net.runelite.api.Perspective;
 import net.runelite.api.Point;
 import net.runelite.api.coords.LocalPoint;
@@ -56,6 +58,7 @@ import net.runelite.client.game.ItemManager;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.OverlayUtil;
 
 class AbyssOverlay extends Overlay
 {
@@ -85,22 +88,47 @@ class AbyssOverlay extends Overlay
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
-		if (!config.showRifts())
+		if (config.showRifts())
 		{
-			return null;
-		}
-
-		LocalPoint localLocation = client.getLocalPlayer().getLocalLocation();
-		for (DecorativeObject object : plugin.getAbyssObjects())
-		{
-			LocalPoint location = object.getLocalLocation();
-			if (localLocation.distanceTo(location) <= MAX_DISTANCE)
+			LocalPoint localLocation = client.getLocalPlayer().getLocalLocation();
+			for (DecorativeObject object : plugin.getAbyssObjects())
 			{
-				renderRifts(graphics, object);
+				LocalPoint location = object.getLocalLocation();
+				if (localLocation.distanceTo(location) <= MAX_DISTANCE)
+				{
+					renderRifts(graphics, object);
+				}
 			}
 		}
 
+		if (config.hightlightDarkMage())
+		{
+			highlightDarkMage(graphics);
+		}
+
 		return null;
+	}
+
+	private void highlightDarkMage(Graphics2D graphics)
+	{
+		if (!plugin.isDegradedPouchInInventory())
+		{
+			return;
+		}
+
+		NPC darkMage = plugin.getDarkMage();
+		if (darkMage == null)
+		{
+			return;
+		}
+
+		Polygon tilePoly = darkMage.getCanvasTilePoly();
+		if (tilePoly == null)
+		{
+			return;
+		}
+
+		OverlayUtil.renderPolygon(graphics, tilePoly, Color.green);
 	}
 
 	private void renderRifts(Graphics2D graphics, DecorativeObject object)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/runecraft/RunecraftConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/runecraft/RunecraftConfig.java
@@ -205,4 +205,14 @@ public interface RunecraftConfig extends Config
 	{
 		return true;
 	}
+
+	@ConfigItem(
+		keyName = "hightlightDarkMage",
+		name = "Highlight Dark Mage NPC",
+		description = "Configures whether to highlight the Dark Mage when pouches are degraded"
+	)
+	default boolean hightlightDarkMage()
+	{
+		return true;
+	}
 }


### PR DESCRIPTION
Highlights the Dark mage NPC tile in the abyss when there is a degraded pouch in your inventory. The goal is to help players (like myself) who constantly forget to repair degraded pouches.

This is my first contribution attempt so any feedback / tips very welcome!

![image](https://user-images.githubusercontent.com/2659651/38175168-d4462c76-358c-11e8-9214-ac05c12fde55.png)
