### PR TITLE
Fix configuration name for other players, add option to disable chat recolour

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsConfig.java
@@ -178,4 +178,15 @@ public interface PlayerIndicatorsConfig extends Config
 	{
 		return true;
 	}
+
+	@ConfigItem(
+		position = 13,
+		keyName = "recolourChatNames",
+		name = "Recolour chat names",
+		description = "Configures whether recolouring of chat names based on previous options is enabled or not"
+	)
+	default boolean recolourChatNames()
+	{
+		return true;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsConfig.java
@@ -137,9 +137,9 @@ public interface PlayerIndicatorsConfig extends Config
 
 	@ConfigItem(
 		position = 9,
-		keyName = "nonClanMemberColor",
-		name = "Non-clan member color",
-		description = "Color of non-clan member names"
+		keyName = "othersColor",
+		name = "Others color",
+		description = "Color of other player's names"
 	)
 	default Color getNonOwnColor()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsPlugin.java
@@ -62,6 +62,9 @@ public class PlayerIndicatorsPlugin extends Plugin
 	@Inject
 	private PlayerIndicatorsService playerIndicatorsService;
 
+	@Inject
+	private PlayerIndicatorsConfig playerIndicatorsConfig;
+
 	@Provides
 	PlayerIndicatorsConfig provideConfig(ConfigManager configManager)
 	{
@@ -120,6 +123,11 @@ public class PlayerIndicatorsPlugin extends Plugin
 		if (client.getGameState() != GameState.LOADING && client.getGameState() != GameState.LOGGED_IN)
 		{
 			return;
+		}
+
+		if (!playerIndicatorsConfig.recolourChatNames() && setMessage.getType() == ChatMessageType.PUBLIC)
+		{
+			setMessage.getMessageNode().setName((setMessage.getName().replaceAll("<col=[^>]+>", "")));
 		}
 
 		if (setMessage.getType() == ChatMessageType.CLANCHAT && client.getClanChatCount() > 0)


### PR DESCRIPTION
- Add option to disable recolouring of player names in chat based on
player indicators configuration
- Fix name of confifugration property to configure colors of other
players.

Preview:
![image](https://cdn.discordapp.com/attachments/419891709883973642/430040805760040991/screenie.png)