### PR TITLE
Properly determine if item is untradeable and add option to disable always showing of untradeables

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/ItemComposition.java
+++ b/runelite-api/src/main/java/net/runelite/api/ItemComposition.java
@@ -100,6 +100,12 @@ public interface ItemComposition
 	boolean isStackable();
 
 	/**
+	 * Returns whether or not the item can be traded to other players.
+	 * @return true if tradeable, false otherwise
+	 */
+	boolean isTradeable();
+
+	/**
 	 * Returns the menu actions the item has in a players' inventory
 	 *
 	 * @return the inventory menu actions

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItem.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItem.java
@@ -40,6 +40,7 @@ class GroundItem
 	private WorldPoint location;
 	private int haPrice;
 	private int gePrice;
+	private boolean tradeable;
 
 	@Value
 	static class GroundItemKey

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
@@ -50,6 +50,17 @@ public interface GroundItemsConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "alwaysShowUntradeable",
+		name = "Always show untradeable items",
+		description = "Configures whether or not untradeable items ignore hiding under settings",
+		position = 1
+	)
+	default boolean alwaysShowUntradeable()
+	{
+		return true;
+	}
+
+	@ConfigItem(
 		keyName = "showGEPrice",
 		name = "Show Grand Exchange Prices",
 		description = "Configures whether or not to draw GE prices alongside ground items",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
@@ -131,12 +131,18 @@ public class GroundItemsOverlay extends Overlay
 				item.setGePrice(itemPrice.getPrice() * item.getQuantity());
 			}
 
-			// Do not display items that are under HA or GE price and are not highlighted
-			if (!plugin.isHotKeyPressed() && !highlighted
-				&& ((item.getGePrice() > 0 && item.getGePrice() < config.getHideUnderGeValue())
-				|| item.getHaPrice() < config.getHideUnderHAValue()))
+			if (!plugin.isHotKeyPressed() && !highlighted)
 			{
-				continue;
+				// Check if item is under config threshold
+				final boolean underThreshold = item.getGePrice() < config.getHideUnderGeValue()
+					|| item.getHaPrice() < config.getHideUnderHAValue();
+
+				// If item is under threshold an we are either not always showing untradeables or item is tradeable
+				// do not display item
+				if (underThreshold && (!config.alwaysShowUntradeable() || item.isTradeable()))
+				{
+					continue;
+				}
 			}
 
 			final Color color = getCostColor(item.getGePrice() > 0 ? item.getGePrice() : item.getHaPrice(),

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
@@ -287,6 +287,7 @@ public class GroundItemsPlugin extends Plugin
 			.quantity(item.getQuantity())
 			.name(itemComposition.getName())
 			.haPrice(alchPrice * item.getQuantity())
+			.tradeable(itemComposition.isTradeable())
 			.build();
 
 

--- a/runescape-api/src/main/java/net/runelite/rs/api/RSItemComposition.java
+++ b/runescape-api/src/main/java/net/runelite/rs/api/RSItemComposition.java
@@ -66,6 +66,10 @@ public interface RSItemComposition extends ItemComposition
 	@Override
 	boolean isMembers();
 
+	@Import("isTradable")
+	@Override
+	boolean isTradeable();
+
 	/**
 	 * You probably want {@link #isStackable}
 	 * <p>


### PR DESCRIPTION
- Add mappings for isTradeable to ItemComposition
- Instead of checking for GE price being above 0, use isTradeable boolean
to determine if the price checks should apply or not and add
configuration value to disable this behaviour.
