### PR TITLE
infobox overlay: Configure the amount of info boxes per row

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/config/RuneLiteConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/RuneLiteConfig.java
@@ -133,4 +133,26 @@ public interface RuneLiteConfig extends Config
 	{
 		return FontType.SMALL;
 	}
+
+	@ConfigItem(
+		keyName = "infoBoxVertical",
+		name = "Display infoboxes vertically",
+		description = "Toggles the infoboxes to display vertically",
+		position = 10
+	)
+	default boolean infoBoxVertical()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		keyName = "infoBoxWrap",
+		name = "Infobox wrap count",
+		description = "Configures the amount of infoboxes shown before wrapping",
+		position = 11
+	)
+	default int infoBoxWrap()
+	{
+		return 4;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/components/InfoBoxComponent.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/components/InfoBoxComponent.java
@@ -71,7 +71,7 @@ public class InfoBoxComponent implements RenderableEntity
 		{
 			graphics.drawImage(image,
 				position.x + (BOX_SIZE - image.getWidth()) / 2,
-				(BOX_SIZE - image.getHeight()) / 2, null);
+				position.y + (BOX_SIZE - image.getHeight()) / 2, null);
 		}
 
 		final TextComponent textComponent = new TextComponent();
@@ -79,7 +79,7 @@ public class InfoBoxComponent implements RenderableEntity
 		textComponent.setText(text);
 		textComponent.setPosition(new Point(
 			position.x + ((BOX_SIZE - metrics.stringWidth(text)) / 2),
-			BOX_SIZE - SEPARATOR));
+			position.y + BOX_SIZE - SEPARATOR));
 		textComponent.render(graphics);
 		return new Dimension(BOX_SIZE, BOX_SIZE);
 	}


### PR DESCRIPTION
allow the user to set the amount of info boxes per row. setting this value to 1 will make the boxes appear vertically. setting it to 0 will default to normal horizontal behavior

I wasn't sure if this config option should be added to the runelite settings, or made an entirely separate "InfoBox" config options. I opted for the first choice, but can easily be changed.

![infobox](https://user-images.githubusercontent.com/5454364/38227421-b71f874a-36c3-11e8-9c2d-6f76c9519e54.png)

> [9:01 PM] Adam: I would be ok with some stopgap settings on the infobox overlay renderer for max row/column/verticle etc
