### PR TITLE
ground item overlay: Fix boxes appearing very small with small font

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
@@ -167,23 +167,22 @@ public class GroundItemsOverlay extends Overlay
 			{
 				final int stringWidth = fm.stringWidth(itemString);
 				final int stringHeight = fm.getHeight();
-				final int descent = fm.getDescent();
 
 				// Hidden box
 				final Rectangle itemHiddenBox = new Rectangle(
 					textX + stringWidth,
-					textY - (stringHeight / 2) - descent,
+					textY - (RECTANGLE_SIZE + stringHeight) / 2,
 					RECTANGLE_SIZE,
-					stringHeight / 2);
+					RECTANGLE_SIZE);
 
 				plugin.getHiddenBoxes().put(itemHiddenBox, item.getName());
 
 				// Highlight box
 				final Rectangle itemHighlightBox = new Rectangle(
 					textX + stringWidth + RECTANGLE_SIZE + 2,
-					textY - (stringHeight / 2) - descent,
+					textY - (RECTANGLE_SIZE + stringHeight) / 2,
 					RECTANGLE_SIZE,
-					stringHeight / 2);
+					RECTANGLE_SIZE);
 
 				plugin.getHighlightBoxes().put(itemHighlightBox, item.getName());
 


### PR DESCRIPTION
The box was based off the width of the font, which made the box super small when using the small RS font. This will provide a fixed rectangle size on any font.

before
![1](https://user-images.githubusercontent.com/5454364/38278812-33442e12-3763-11e8-8eff-f605f3027c94.png)

after
![2](https://user-images.githubusercontent.com/5454364/38278814-3472b7ea-3763-11e8-861f-4254b7feffa8.png)
