### PR TITLE
Hide cannon spot overlay if player lacks the cannon.

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonConfig.java
@@ -39,7 +39,8 @@ public interface CannonConfig extends Config
 	@ConfigItem(
 		keyName = "showEmptyCannonNotification",
 		name = "Empty cannon notification",
-		description = "Configures whether to notify you that the cannon is empty"
+		description = "Configures whether to notify you that the cannon is empty",
+		position = 0
 	)
 	default boolean showEmptyCannonNotification()
 	{
@@ -47,19 +48,10 @@ public interface CannonConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "showInfobox",
-		name = "Show Cannonball infobox",
-		description = "Configures whether to show the cannonballs in an infobox"
-	)
-	default boolean showInfobox()
-	{
-		return false;
-	}
-
-	@ConfigItem(
 		keyName = "showDoubleHitSpot",
 		name = "Show double hit spots",
-		description = "Configures whether to show the NPC double hit spot"
+		description = "Configures whether to show the NPC double hit spot",
+		position = 1
 	)
 	default boolean showDoubleHitSpot()
 	{
@@ -67,22 +59,36 @@ public interface CannonConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "showInfobox",
+		name = "Show cannonball infobox",
+		description = "Configures whether to show the cannonballs in an infobox",
+		position = 2
+	)
+	default boolean showInfobox()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		keyName = "showCannonSpotsPermissions",
+		name = "Show cannon spots",
+		description = "Configures whether to show common cannon spots or not",
+		position = 3
+	)
+	default CannonSpotPermission showCannonSpotsPermissions()
+	{
+		return CannonSpotPermission.HOLDING_CANNON;
+	}
+
+	@ConfigItem(
 		keyName = "highlightDoubleHitColor",
-		name = "Color of double hit spots",
-		description = "Configures the highlight color of double hit spots"
+		name = "Double hit spots color",
+		description = "Configures the highlight color of double hit spots",
+		position = 4
 	)
 	default Color highlightDoubleHitColor()
 	{
 		return Color.RED;
 	}
 
-	@ConfigItem(
-		keyName = "showCannonSpots",
-		name = "Show common cannon spots",
-		description = "Configures whether to show common cannon spots or not"
-	)
-	default boolean showCannonSpots()
-	{
-		return true;
-	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonPlugin.java
@@ -37,6 +37,7 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.inject.Inject;
+import lombok.AccessLevel;
 import lombok.Getter;
 import net.runelite.api.AnimationID;
 import net.runelite.api.ChatMessageType;
@@ -53,6 +54,7 @@ import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.ChatMessage;
 import net.runelite.api.events.ConfigChanged;
 import net.runelite.api.events.GameObjectSpawned;
+import net.runelite.api.events.GameTick;
 import net.runelite.api.events.ProjectileMoved;
 import net.runelite.api.queries.InventoryWidgetItemQuery;
 import net.runelite.api.widgets.WidgetItem;
@@ -126,6 +128,9 @@ public class CannonPlugin extends Plugin
 	@Inject
 	private ClientThread clientThread;
 
+	@Getter(AccessLevel.PACKAGE)
+	private boolean hasCannon;
+
 	@Provides
 	CannonConfig provideConfig(ConfigManager configManager)
 	{
@@ -138,7 +143,7 @@ public class CannonPlugin extends Plugin
 		return Arrays.asList(cannonOverlay, cannonSpotOverlay);
 	}
 
-	boolean hasCannon()
+	private boolean hasCannon()
 	{
 
 		Query inventoryQuery = new InventoryWidgetItemQuery();
@@ -192,7 +197,7 @@ public class CannonPlugin extends Plugin
 	)
 	public void checkSpots()
 	{
-		if (!config.showCannonSpots())
+		if (config.showCannonSpotsPermissions() == CannonSpotPermission.NEVER)
 		{
 			return;
 		}
@@ -224,6 +229,12 @@ public class CannonPlugin extends Plugin
 				cannon = gameObject;
 			}
 		}
+	}
+
+	@Subscribe
+	public void onGameTick(GameTick event)
+	{
+		hasCannon = hasCannon();
 	}
 
 	@Subscribe

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonSpotOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonSpotOverlay.java
@@ -65,12 +65,12 @@ public class CannonSpotOverlay extends Overlay
 	public Dimension render(Graphics2D graphics)
 	{
 
-		if (!plugin.hasCannon())
+		if (!plugin.isHasCannon() && config.showCannonSpotsPermissions() == CannonSpotPermission.HOLDING_CANNON)
 		{
 			return null;
 		}
 
-		if (!config.showCannonSpots() || plugin.isCannonPlaced())
+		if (config.showCannonSpotsPermissions() == CannonSpotPermission.NEVER || plugin.isCannonPlaced())
 		{
 			return null;
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonSpotOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonSpotOverlay.java
@@ -64,6 +64,12 @@ public class CannonSpotOverlay extends Overlay
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
+
+		if (!plugin.hasCannon())
+		{
+			return null;
+		}
+
 		if (!config.showCannonSpots() || plugin.isCannonPlaced())
 		{
 			return null;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonSpotPermission.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonSpotPermission.java
@@ -1,0 +1,22 @@
+package net.runelite.client.plugins.cannon;
+
+public enum CannonSpotPermission
+{
+
+	ALWAYS("Always"),
+	HOLDING_CANNON("Holding cannon"),
+	NEVER("Never");
+
+	private final String name;
+
+	CannonSpotPermission(String name)
+	{
+		this.name = name;
+	}
+
+	@Override
+	public String toString()
+	{
+		return name;
+	}
+}


### PR DESCRIPTION
**CannonPlugin**
- Added `hasCannon()` that returns true if the player has 4 cannon pieces on their inventory. 
- Added a int set `cannonParts` containing the item ids for the cannon parts.
- Added a `QueryRunner` attribute for checking inventory items.

**CannonSpotOverlay**
- Added a check (using `hasCannon()`) to prevent the plugin from displaying the cannon spot if the player lacks the cannon pieces.