### PR TITLE
Add a null check to Runecrafting Plugin.

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/runecraft/RunecraftPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/runecraft/RunecraftPlugin.java
@@ -192,7 +192,7 @@ public class RunecraftPlugin extends Plugin
 		);
 
 		Item[] items = queryRunner.runQuery(inventoryQuery);
-		degradedPouchInInventory = items.length > 0;
+		degradedPouchInInventory = items != null && items.length > 0;
 
 		if (degradedPouchInInventory)
 		{


### PR DESCRIPTION
The client was throwing a null pointer exception on the runecrafting plugin and I wasn't even runecrafting, a small null check was added to prevent this.