### PR TITLE
Swap pickpocket only on H.A.M. members

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -49,8 +49,8 @@ public interface MenuEntrySwapperConfig extends Config
 	@ConfigItem(
 		position = 1,
 		keyName = "swapPickpocket",
-		name = "Pickpocket",
-		description = "Swap Talk-to with Pickpocket on NPC<br>Example: Man, Woman"
+		name = "Pickpocket on H.A.M.",
+		description = "Swap Talk-to with Pickpocket on H.A.M members"
 	)
 	default boolean swapPickpocket()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -331,7 +331,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 
 		if (option.equals("talk-to"))
 		{
-			if (config.swapPickpocket())
+			if (config.swapPickpocket() && target.contains("H.A.M."))
 			{
 				swap("pickpocket", option, target, true);
 			}


### PR DESCRIPTION
This was oversight and swaps pickpocket options when black-jacking what
is something that other clients don't do.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>