### PR TITLE
Add entity hider plugin

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/Client.java
+++ b/runelite-api/src/main/java/net/runelite/api/Client.java
@@ -389,4 +389,24 @@ public interface Client extends GameEngine
 	void setInterpolateObjectAnimations(boolean interpolate);
 
 	boolean isInInstancedRegion();
+
+	void setPlayersHidden(boolean state);
+
+	void setPlayersHidden2D(boolean state);
+
+	void setFriendsHidden(boolean state);
+
+	void setClanMatesHidden(boolean state);
+
+	void setLocalPlayerHidden(boolean state);
+
+	void setLocalPlayerHidden2D(boolean state);
+
+	void setNPCsHidden(boolean state);
+
+	void setNPCsHidden2D(boolean state);
+
+	void setAttackersHidden(boolean state);
+
+	void setProjectilesHidden(boolean state);
 }

--- a/runelite-api/src/main/java/net/runelite/api/Client.java
+++ b/runelite-api/src/main/java/net/runelite/api/Client.java
@@ -390,6 +390,8 @@ public interface Client extends GameEngine
 
 	boolean isInInstancedRegion();
 
+	void setIsHidingEntities(boolean state);
+
 	void setPlayersHidden(boolean state);
 
 	void setPlayersHidden2D(boolean state);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/entityhider/EntityHiderConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/entityhider/EntityHiderConfig.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2018, Lotto <https://github.com/devLotto>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.entityhider;
+
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+
+@ConfigGroup(
+	keyName = "entityhider",
+	name = "Entity Hider",
+	description = "Hides various entities such as players and NPCs"
+)
+public interface EntityHiderConfig extends Config
+{
+	@ConfigItem(
+		position = 1,
+		keyName = "hidePlayers",
+		name = "Hide Players",
+		description = "Configures whether or not players are hidden"
+	)
+	default boolean hidePlayers()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		position = 2,
+		keyName = "hidePlayers2D",
+		name = "Hide Players 2D",
+		description = "Configures whether or not players 2D elements are hidden"
+	)
+	default boolean hidePlayers2D()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		position = 3,
+		keyName = "hideFriends",
+		name = "Hide Friends",
+		description = "Configures whether or not friends are hidden"
+	)
+	default boolean hideFriends()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		position = 4,
+		keyName = "hideClanMates",
+		name = "Hide Clan Mates",
+		description = "Configures whether or not clan mates are hidden"
+	)
+	default boolean hideClanMates()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		position = 5,
+		keyName = "hideLocalPlayer",
+		name = "Hide Local Player",
+		description = "Configures whether or not the local player is hidden"
+	)
+	default boolean hideLocalPlayer()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		position = 6,
+		keyName = "hideLocalPlayer2D",
+		name = "Hide Local Player 2D",
+		description = "Configures whether or not the local player's 2D elements are hidden"
+	)
+	default boolean hideLocalPlayer2D()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		position = 7,
+		keyName = "hideNPCs",
+		name = "Hide NPCs",
+		description = "Configures whether or not NPCs are hidden"
+	)
+	default boolean hideNPCs()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		position = 8,
+		keyName = "hideNPCs2D",
+		name = "Hide NPCs 2D",
+		description = "Configures whether or not NPCs 2D elements are hidden"
+	)
+	default boolean hideNPCs2D()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		position = 9,
+		keyName = "hideAttackers",
+		name = "Hide Attackers",
+		description = "Configures whether or not NPCs/players attacking you are hidden"
+	)
+	default boolean hideAttackers()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		position = 10,
+		keyName = "hideProjectiles",
+		name = "Hide Projectiles",
+		description = "Configures whether or not projectiles are hidden"
+	)
+	default boolean hideProjectiles()
+	{
+		return false;
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/entityhider/EntityHiderPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/entityhider/EntityHiderPlugin.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2018, Lotto <https://github.com/devLotto>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.entityhider;
+
+import com.google.common.eventbus.Subscribe;
+import com.google.inject.Provides;
+import javax.inject.Inject;
+import net.runelite.api.Client;
+import net.runelite.api.events.ConfigChanged;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginDescriptor;
+
+@PluginDescriptor(
+	name = "Entity Hider",
+	enabledByDefault = false
+)
+public class EntityHiderPlugin extends Plugin
+{
+	@Inject
+	private Client client;
+
+	@Inject
+	private EntityHiderConfig config;
+
+	@Provides
+	EntityHiderConfig provideConfig(ConfigManager configManager)
+	{
+		return configManager.getConfig(EntityHiderConfig.class);
+	}
+
+	@Override
+	protected void startUp()
+	{
+		updateConfig();
+	}
+
+	@Subscribe
+	public void onConfigChanged(ConfigChanged e)
+	{
+		updateConfig();
+	}
+
+	private void updateConfig()
+	{
+		client.setPlayersHidden(config.hidePlayers());
+		client.setPlayersHidden2D(config.hidePlayers2D());
+
+		client.setFriendsHidden(config.hideFriends());
+		client.setClanMatesHidden(config.hideClanMates());
+
+		client.setLocalPlayerHidden(config.hideLocalPlayer());
+		client.setLocalPlayerHidden2D(config.hideLocalPlayer2D());
+
+		client.setNPCsHidden(config.hideNPCs());
+		client.setNPCsHidden2D(config.hideNPCs2D());
+
+		client.setAttackersHidden(config.hideAttackers());
+
+		client.setProjectilesHidden(config.hideProjectiles());
+	}
+
+	@Override
+	protected void shutDown() throws Exception
+	{
+		client.setPlayersHidden(false);
+		client.setPlayersHidden2D(false);
+
+		client.setFriendsHidden(false);
+		client.setClanMatesHidden(false);
+
+		client.setLocalPlayerHidden(false);
+		client.setLocalPlayerHidden2D(false);
+
+		client.setNPCsHidden(false);
+		client.setNPCsHidden2D(false);
+
+		client.setAttackersHidden(false);
+
+		client.setProjectilesHidden(false);
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/entityhider/EntityHiderPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/entityhider/EntityHiderPlugin.java
@@ -66,6 +66,8 @@ public class EntityHiderPlugin extends Plugin
 
 	private void updateConfig()
 	{
+		client.setIsHidingEntities(true);
+
 		client.setPlayersHidden(config.hidePlayers());
 		client.setPlayersHidden2D(config.hidePlayers2D());
 
@@ -86,6 +88,8 @@ public class EntityHiderPlugin extends Plugin
 	@Override
 	protected void shutDown() throws Exception
 	{
+		client.setIsHidingEntities(false);
+
 		client.setPlayersHidden(false);
 		client.setPlayersHidden2D(false);
 

--- a/runelite-mixins/src/main/java/net/runelite/mixins/EntityHiderBridgeMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/EntityHiderBridgeMixin.java
@@ -35,14 +35,38 @@ public abstract class EntityHiderBridgeMixin implements RSClient
 	public static boolean hidePlayers;
 
 	@Inject
+	public static boolean hidePlayers2D;
+
+	@Inject
+	public static boolean hideFriends;
+
+	@Inject
+	public static boolean hideClanMates;
+
+	@Inject
+	public static boolean hideLocalPlayer;
+
+	@Inject
+	public static boolean hideLocalPlayer2D;
+
+	@Inject
+	public static boolean hideNPCs;
+
+	@Inject
+	public static boolean hideNPCs2D;
+
+	@Inject
+	public static boolean hideAttackers;
+
+	@Inject
+	public static boolean hideProjectiles;
+
+	@Inject
 	@Override
 	public void setPlayersHidden(boolean state)
 	{
 		hidePlayers = state;
 	}
-
-	@Inject
-	public static boolean hidePlayers2D;
 
 	@Inject
 	@Override
@@ -52,17 +76,11 @@ public abstract class EntityHiderBridgeMixin implements RSClient
 	}
 
 	@Inject
-	public static boolean hideFriends;
-
-	@Inject
 	@Override
 	public void setFriendsHidden(boolean state)
 	{
 		hideFriends = state;
 	}
-
-	@Inject
-	public static boolean hideClanMates;
 
 	@Inject
 	@Override
@@ -72,17 +90,11 @@ public abstract class EntityHiderBridgeMixin implements RSClient
 	}
 
 	@Inject
-	public static boolean hideLocalPlayer;
-
-	@Inject
 	@Override
 	public void setLocalPlayerHidden(boolean state)
 	{
 		hideLocalPlayer = state;
 	}
-
-	@Inject
-	public static boolean hideLocalPlayer2D;
 
 	@Inject
 	@Override
@@ -92,17 +104,11 @@ public abstract class EntityHiderBridgeMixin implements RSClient
 	}
 
 	@Inject
-	public static boolean hideNPCs;
-
-	@Inject
 	@Override
 	public void setNPCsHidden(boolean state)
 	{
 		hideNPCs = state;
 	}
-
-	@Inject
-	public static boolean hideNPCs2D;
 
 	@Inject
 	@Override
@@ -112,17 +118,11 @@ public abstract class EntityHiderBridgeMixin implements RSClient
 	}
 
 	@Inject
-	public static boolean hideAttackers;
-
-	@Inject
 	@Override
 	public void setAttackersHidden(boolean state)
 	{
 		hideAttackers = state;
 	}
-
-	@Inject
-	public static boolean hideProjectiles;
 
 	@Inject
 	@Override

--- a/runelite-mixins/src/main/java/net/runelite/mixins/EntityHiderBridgeMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/EntityHiderBridgeMixin.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2018, Lotto <https://github.com/devLotto>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.mixins;
+
+import net.runelite.api.mixins.Inject;
+import net.runelite.api.mixins.Mixin;
+import net.runelite.rs.api.RSClient;
+
+@Mixin(RSClient.class)
+public abstract class EntityHiderBridgeMixin implements RSClient
+{
+	@Inject
+	public static boolean hidePlayers;
+
+	@Inject
+	@Override
+	public void setPlayersHidden(boolean state)
+	{
+		hidePlayers = state;
+	}
+
+	@Inject
+	public static boolean hidePlayers2D;
+
+	@Inject
+	@Override
+	public void setPlayersHidden2D(boolean state)
+	{
+		hidePlayers2D = state;
+	}
+
+	@Inject
+	public static boolean hideFriends;
+
+	@Inject
+	@Override
+	public void setFriendsHidden(boolean state)
+	{
+		hideFriends = state;
+	}
+
+	@Inject
+	public static boolean hideClanMates;
+
+	@Inject
+	@Override
+	public void setClanMatesHidden(boolean state)
+	{
+		hideClanMates = state;
+	}
+
+	@Inject
+	public static boolean hideLocalPlayer;
+
+	@Inject
+	@Override
+	public void setLocalPlayerHidden(boolean state)
+	{
+		hideLocalPlayer = state;
+	}
+
+	@Inject
+	public static boolean hideLocalPlayer2D;
+
+	@Inject
+	@Override
+	public void setLocalPlayerHidden2D(boolean state)
+	{
+		hideLocalPlayer2D = state;
+	}
+
+	@Inject
+	public static boolean hideNPCs;
+
+	@Inject
+	@Override
+	public void setNPCsHidden(boolean state)
+	{
+		hideNPCs = state;
+	}
+
+	@Inject
+	public static boolean hideNPCs2D;
+
+	@Inject
+	@Override
+	public void setNPCsHidden2D(boolean state)
+	{
+		hideNPCs2D = state;
+	}
+
+	@Inject
+	public static boolean hideAttackers;
+
+	@Inject
+	@Override
+	public void setAttackersHidden(boolean state)
+	{
+		hideAttackers = state;
+	}
+
+	@Inject
+	public static boolean hideProjectiles;
+
+	@Inject
+	@Override
+	public void setProjectilesHidden(boolean state)
+	{
+		hideProjectiles = state;
+	}
+}

--- a/runelite-mixins/src/main/java/net/runelite/mixins/EntityHiderBridgeMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/EntityHiderBridgeMixin.java
@@ -32,6 +32,9 @@ import net.runelite.rs.api.RSClient;
 public abstract class EntityHiderBridgeMixin implements RSClient
 {
 	@Inject
+	public static boolean isHidingEntities;
+
+	@Inject
 	public static boolean hidePlayers;
 
 	@Inject
@@ -60,6 +63,13 @@ public abstract class EntityHiderBridgeMixin implements RSClient
 
 	@Inject
 	public static boolean hideProjectiles;
+
+	@Inject
+	@Override
+	public void setIsHidingEntities(boolean state)
+	{
+		isHidingEntities = state;
+	}
 
 	@Inject
 	@Override

--- a/runelite-mixins/src/main/java/net/runelite/mixins/EntityHiderMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/EntityHiderMixin.java
@@ -43,6 +43,9 @@ public abstract class EntityHiderMixin implements RSRegion
 	@Shadow("clientInstance")
 	private static RSClient client;
 
+	@Shadow("isHidingEntities")
+	private static boolean isHidingEntities;
+
 	@Shadow("hidePlayers")
 	private static boolean hidePlayers;
 
@@ -100,6 +103,11 @@ public abstract class EntityHiderMixin implements RSRegion
 	@Inject
 	private static boolean shouldDraw(Object renderable, boolean drawingUI)
 	{
+		if (!isHidingEntities)
+		{
+			return true;
+		}
+
 		if (renderable instanceof RSPlayer)
 		{
 			boolean local = drawingUI ? hideLocalPlayer2D : hideLocalPlayer;

--- a/runelite-mixins/src/main/java/net/runelite/mixins/EntityHiderMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/EntityHiderMixin.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2018, Lotto <https://github.com/devLotto>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.mixins;
+
+import net.runelite.api.mixins.Copy;
+import net.runelite.api.mixins.Inject;
+import net.runelite.api.mixins.Mixin;
+import net.runelite.api.mixins.Replace;
+import net.runelite.api.mixins.Shadow;
+import net.runelite.rs.api.RSActor;
+import net.runelite.rs.api.RSClient;
+import net.runelite.rs.api.RSNPC;
+import net.runelite.rs.api.RSPlayer;
+import net.runelite.rs.api.RSProjectile;
+import net.runelite.rs.api.RSRegion;
+import net.runelite.rs.api.RSRenderable;
+
+@Mixin(RSRegion.class)
+public abstract class EntityHiderMixin implements RSRegion
+{
+	@Shadow("clientInstance")
+	private static RSClient client;
+
+	@Shadow("hidePlayers")
+	private static boolean hidePlayers;
+
+	@Shadow("hidePlayers2D")
+	private static boolean hidePlayers2D;
+
+	@Shadow("hideFriends")
+	private static boolean hideFriends;
+
+	@Shadow("hideClanMates")
+	private static boolean hideClanMates;
+
+	@Shadow("hideLocalPlayer")
+	private static boolean hideLocalPlayer;
+
+	@Shadow("hideLocalPlayer2D")
+	private static boolean hideLocalPlayer2D;
+
+	@Shadow("hideNPCs")
+	private static boolean hideNPCs;
+
+	@Shadow("hideNPCs2D")
+	private static boolean hideNPCs2D;
+
+	@Shadow("hideAttackers")
+	private static boolean hideAttackers;
+
+	@Shadow("hideProjectiles")
+	private static boolean hideProjectiles;
+
+	@Copy("addEntityMarker")
+	abstract boolean addEntityMarker(int var1, int var2, int var3, int var4, int var5, int var6, int var7, int var8, RSRenderable renderable, int var10, boolean var11, int var12, int var13);
+
+	@Replace("addEntityMarker")
+	boolean rl$addEntityMarker(int var1, int var2, int var3, int var4, int var5, int var6, int var7, int var8, RSRenderable renderable, int var10, boolean var11, int var12, int var13)
+	{
+		return shouldDraw(renderable, false) && addEntityMarker(var1, var2, var3, var4, var5, var6, var7, var8, renderable, var10, var11, var12, var13);
+	}
+
+	@Copy("draw2DExtras")
+	private static void draw2DExtras(RSActor actor, int var1, int var2, int var3, int var4, int var5)
+	{ throw new RuntimeException(); }
+
+	@Replace("draw2DExtras")
+	private static void rl$draw2DExtras(RSActor actor, int var1, int var2, int var3, int var4, int var5)
+	{
+		if (shouldDraw(actor, true))
+		{
+			draw2DExtras(actor, var1, var2, var3, var4, var5);
+		}
+	}
+
+	@Inject
+	private static boolean shouldDraw(Object renderable, boolean drawingUI)
+	{
+		if (renderable != null)
+		{
+			if (renderable instanceof RSPlayer)
+			{
+				boolean local = drawingUI ? hideLocalPlayer2D : hideLocalPlayer;
+				boolean other = drawingUI ? hidePlayers2D : hidePlayers;
+
+				if ((local && renderable == client.getLocalPlayer())
+						|| (other && renderable != client.getLocalPlayer()))
+				{
+					RSPlayer player = (RSPlayer) renderable;
+
+					if (!hideAttackers)
+					{
+						if (player.getInteracting() == client.getLocalPlayer())
+						{
+							return true;
+						}
+					}
+
+					return (!hideFriends && player.isFriend()) || (!hideClanMates && player.isClanMember());
+				}
+			}
+			else if (renderable instanceof RSNPC)
+			{
+				RSNPC npc = (RSNPC) renderable;
+
+				if (!hideAttackers)
+				{
+					if (npc.getInteracting() == client.getLocalPlayer())
+					{
+						return true;
+					}
+				}
+
+				return drawingUI ? !hideNPCs2D : !hideNPCs;
+			}
+			else if (renderable instanceof RSProjectile)
+			{
+				return !hideProjectiles;
+			}
+		}
+
+		return true;
+	}
+}

--- a/runelite-mixins/src/main/java/net/runelite/mixins/EntityHiderMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/EntityHiderMixin.java
@@ -84,7 +84,9 @@ public abstract class EntityHiderMixin implements RSRegion
 
 	@Copy("draw2DExtras")
 	private static void draw2DExtras(RSActor actor, int var1, int var2, int var3, int var4, int var5)
-	{ throw new RuntimeException(); }
+	{
+		throw new RuntimeException();
+	}
 
 	@Replace("draw2DExtras")
 	private static void rl$draw2DExtras(RSActor actor, int var1, int var2, int var3, int var4, int var5)
@@ -98,47 +100,43 @@ public abstract class EntityHiderMixin implements RSRegion
 	@Inject
 	private static boolean shouldDraw(Object renderable, boolean drawingUI)
 	{
-		if (renderable != null)
+		if (renderable instanceof RSPlayer)
 		{
-			if (renderable instanceof RSPlayer)
+			boolean local = drawingUI ? hideLocalPlayer2D : hideLocalPlayer;
+			boolean other = drawingUI ? hidePlayers2D : hidePlayers;
+
+			if (renderable == client.getLocalPlayer() ? local : other)
 			{
-				boolean local = drawingUI ? hideLocalPlayer2D : hideLocalPlayer;
-				boolean other = drawingUI ? hidePlayers2D : hidePlayers;
-
-				if ((local && renderable == client.getLocalPlayer())
-						|| (other && renderable != client.getLocalPlayer()))
-				{
-					RSPlayer player = (RSPlayer) renderable;
-
-					if (!hideAttackers)
-					{
-						if (player.getInteracting() == client.getLocalPlayer())
-						{
-							return true;
-						}
-					}
-
-					return (!hideFriends && player.isFriend()) || (!hideClanMates && player.isClanMember());
-				}
-			}
-			else if (renderable instanceof RSNPC)
-			{
-				RSNPC npc = (RSNPC) renderable;
+				RSPlayer player = (RSPlayer) renderable;
 
 				if (!hideAttackers)
 				{
-					if (npc.getInteracting() == client.getLocalPlayer())
+					if (player.getInteracting() == client.getLocalPlayer())
 					{
 						return true;
 					}
 				}
 
-				return drawingUI ? !hideNPCs2D : !hideNPCs;
+				return (!hideFriends && player.isFriend()) || (!hideClanMates && player.isClanMember());
 			}
-			else if (renderable instanceof RSProjectile)
+		}
+		else if (renderable instanceof RSNPC)
+		{
+			RSNPC npc = (RSNPC) renderable;
+
+			if (!hideAttackers)
 			{
-				return !hideProjectiles;
+				if (npc.getInteracting() == client.getLocalPlayer())
+				{
+					return true;
+				}
 			}
+
+			return drawingUI ? !hideNPCs2D : !hideNPCs;
+		}
+		else if (renderable instanceof RSProjectile)
+		{
+			return !hideProjectiles;
 		}
 
 		return true;


### PR DESCRIPTION
Allows the user to hide players, npcs and projectiles. The plugin is disabled by default, and when enabled, friends, clan mates and attackers are by default always visible.

It does not support hiding any objects, because I don't think we should hide elements that cannot be walked through, as you cannot walk through these even though they are hidden, which might look like a bug to some users.

It does not remove minimap dots because this turned out to be not that easy to do. Player#hidden and NPCComposition#isMinimapVisible do indeed remove the dots when set to their hidden state, but they also hide the 3D part of the player/npc at the same time, making it so you can't easily separate minimap hiding and game hiding.

Closes #636 

![](https://i.imgur.com/KvhvsEJ.png)

