### PR TITLE
Add ground marker plugin

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/Client.java
+++ b/runelite-api/src/main/java/net/runelite/api/Client.java
@@ -381,4 +381,6 @@ public interface Client extends GameEngine
 	boolean isInterpolateObjectAnimations();
 
 	void setInterpolateObjectAnimations(boolean interpolate);
+
+	boolean isInInstancedRegion();
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/groundmarkers/GroundMarkerConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/groundmarkers/GroundMarkerConfig.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2018, TheLonelyDev <https://github.com/TheLonelyDev>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package net.runelite.client.plugins.groundmarkers;
+
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+
+import java.awt.Color;
+
+@ConfigGroup(
+	keyName = "groundMarker",
+	name = "Ground arker",
+	description = "Mark ground tiles"
+)
+public interface GroundMarkerConfig extends Config
+{
+	@ConfigItem(
+		keyName = "markerColor",
+		name = "Color of the tile",
+		description = "Configures the color of marked tile"
+	)
+	default Color markerColor()
+	{
+		return Color.YELLOW;
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/groundmarkers/GroundMarkerInputListener.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/groundmarkers/GroundMarkerInputListener.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2018, TheLonelyDev <https://github.com/TheLonelyDev>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package net.runelite.client.plugins.groundmarkers;
+
+import java.awt.event.KeyEvent;
+import java.awt.event.MouseEvent;
+import javax.inject.Inject;
+import net.runelite.api.Client;
+import net.runelite.client.input.KeyListener;
+import net.runelite.client.input.MouseListener;
+
+public class GroundMarkerInputListener extends MouseListener implements KeyListener
+{
+	private static final int HOTKEY = KeyEvent.VK_ALT;
+	private static final int HOTKEYR = KeyEvent.VK_SHIFT;
+
+	private Client client;
+	private GroundMarkerPlugin plugin;
+
+	@Inject
+	private GroundMarkerInputListener(Client client, GroundMarkerPlugin plugin)
+	{
+		this.client = client;
+		this.plugin = plugin;
+	}
+
+	@Override
+	public void keyTyped(KeyEvent e)
+	{
+
+	}
+
+	@Override
+	public void keyPressed(KeyEvent e)
+	{
+		if (e.getKeyCode() == HOTKEY)
+		{
+			plugin.setHotKeyPressed(true);
+		}
+		else if (e.getKeyCode() == HOTKEYR)
+		{
+			plugin.setResetHotkeyPressed(true);
+		}
+	}
+
+	@Override
+	public void keyReleased(KeyEvent e)
+	{
+		if (e.getKeyCode() == HOTKEY)
+		{
+			plugin.setHotKeyPressed(false);
+		}
+		else if (e.getKeyCode() == HOTKEYR)
+		{
+			plugin.setResetHotkeyPressed(false);
+		}
+	}
+
+	@Override
+	public MouseEvent mousePressed(MouseEvent e)
+	{
+		if (plugin.isHotKeyPressed())
+		{
+			if (e.getButton() == MouseEvent.BUTTON3)
+			{
+				if (plugin.isResetHotkeyPressed())
+				{
+					plugin.clearPoints();
+				}
+				else
+				{
+					plugin.markTile(client.getMouseCanvasPosition());
+				}
+			}
+		}
+
+		return e;
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/groundmarkers/GroundMarkerOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/groundmarkers/GroundMarkerOverlay.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2018, TheLonelyDev <https://github.com/TheLonelyDev>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package net.runelite.client.plugins.groundmarkers;
+
+import java.awt.Dimension;
+import java.awt.Graphics2D;
+import java.awt.Polygon;
+import java.util.ArrayList;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.Client;
+import net.runelite.api.Perspective;
+import net.runelite.client.ui.overlay.Overlay;
+import net.runelite.client.ui.overlay.OverlayLayer;
+import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.OverlayPriority;
+import net.runelite.client.ui.overlay.OverlayUtil;
+import javax.inject.Inject;
+import java.util.Iterator;
+
+@Slf4j
+public class GroundMarkerOverlay extends Overlay
+{
+	private Client client;
+	private GroundMarkerConfig config;
+	private GroundMarkerPlugin plugin;
+
+	@Getter(AccessLevel.PACKAGE)
+	@Setter(AccessLevel.PACKAGE)
+	private java.util.List<GroundMarkerPoint> lstPoints = new ArrayList<GroundMarkerPoint>();
+
+	@Inject
+	private GroundMarkerOverlay(Client client, GroundMarkerConfig config, GroundMarkerPlugin plugin)
+	{
+		this.client = client;
+		this.config = config;
+		this.plugin = plugin;
+		setPosition(OverlayPosition.DYNAMIC);
+		setPriority(OverlayPriority.HIGH);
+		setLayer(OverlayLayer.UNDER_WIDGETS);
+	}
+
+	@Override
+	public Dimension render(Graphics2D graphics)
+	{
+		Iterator<GroundMarkerPoint> it = this.lstPoints.iterator();
+
+		while (it.hasNext())
+		{
+			drawTile(graphics, it.next(), it);
+		}
+
+		return null;
+	}
+
+	private void drawTile(Graphics2D graphics, GroundMarkerPoint pt, Iterator<GroundMarkerPoint> it)
+	{
+		if (pt.getPoint().distanceTo(client.getLocalPlayer().getWorldLocation()) >= 32)
+		{
+			return;
+		}
+
+		Polygon poly = Perspective.getCanvasTilePoly(client, pt.toLocal(client));
+
+		if (poly == null)
+		{
+			return;
+		}
+
+		OverlayUtil.renderPolygon(graphics, poly, config.markerColor());
+
+		return;
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/groundmarkers/GroundMarkerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/groundmarkers/GroundMarkerPlugin.java
@@ -1,0 +1,338 @@
+/*
+ * Copyright (c) 2018, TheLonelyDev <https://github.com/TheLonelyDev>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package net.runelite.client.plugins.groundmarkers;
+
+import com.google.common.eventbus.Subscribe;
+import com.google.gson.Gson;
+import java.util.concurrent.ScheduledExecutorService;
+import javax.inject.Inject;
+import com.google.inject.Provides;
+import java.awt.Polygon;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.Client;
+import net.runelite.api.Point;
+import net.runelite.api.coords.WorldPoint;
+import net.runelite.api.events.FocusChanged;
+import net.runelite.api.events.MenuOptionClicked;
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.input.KeyManager;
+import net.runelite.client.input.MouseManager;
+import net.runelite.api.Region ;
+import net.runelite.api.Tile ;
+import net.runelite.api.coords.LocalPoint ;
+import net.runelite.api.Perspective ;
+import org.apache.commons.lang3.ArrayUtils;
+import net.runelite.api.events.MenuEntryAdded;
+import java.util.Arrays;
+import net.runelite.api.MenuEntry;
+import net.runelite.api.MenuAction;
+
+@Slf4j
+@PluginDescriptor(
+	name = "Ground Markers"
+)
+public class GroundMarkerPlugin extends Plugin
+{
+	private static final String CONFIG_GROUP = "groundMarker";
+	private static final String PREFIX = "markers";
+	private static final int REGION_SIZE = 104;
+	private static final String MARK = "Mark tile";
+
+	@Inject
+	Client client;
+
+	@Getter(AccessLevel.PACKAGE)
+	@Setter(AccessLevel.PACKAGE)
+	private boolean hotKeyPressed;
+
+	@Getter(AccessLevel.PACKAGE)
+	@Setter(AccessLevel.PACKAGE)
+	private boolean resetHotkeyPressed;
+
+	@Inject
+	private GroundMarkerInputListener inputListener;
+
+	@Inject
+	private ConfigManager configManager;
+
+	@Inject
+	private GroundMarkerConfig config;
+
+	@Inject
+	private GroundMarkerOverlay overlay ;
+
+	@Inject
+	private MouseManager mouseManager;
+
+	@Inject
+	private KeyManager keyManager;
+
+	@Inject
+	ScheduledExecutorService executor;
+
+	@Provides
+	GroundMarkerConfig provideConfig(ConfigManager configManager)
+	{
+		return configManager.getConfig(GroundMarkerConfig.class);
+	}
+
+	@Subscribe
+	public void onFocusChanged(FocusChanged focusChanged)
+	{
+		if (!focusChanged.isFocused() && (hotKeyPressed || resetHotkeyPressed))
+		{
+			setHotKeyPressed(false);
+			setResetHotkeyPressed(false);
+		}
+	}
+
+	@Subscribe
+	public void onMenuEntryAdded(MenuEntryAdded event)
+	{
+		if (event.getOption().equals("Walk here"))
+		{
+			MenuEntry[] menuEntries = client.getMenuEntries();
+			menuEntries = Arrays.copyOf(menuEntries, menuEntries.length + 1);
+
+			MenuEntry menuEntry = menuEntries[menuEntries.length - 1] = new MenuEntry();
+
+			menuEntry.setOption(MARK);
+			menuEntry.setTarget(event.getTarget());
+			menuEntry.setType(MenuAction.CANCEL.getId());
+
+			client.setMenuEntries(menuEntries);
+		}
+
+		return;
+	}
+
+	@Subscribe
+	public void onMenuOptionClicked(MenuOptionClicked event)
+	{
+		if (!event.getMenuOption().equals(MARK))
+		{
+			return;
+		}
+
+		MenuEntry[] menuEntries = client.getMenuEntries();
+
+		for (int i = 0; i < menuEntries.length; i++)
+		{
+			if (menuEntries[i].getOption().equals("Walk here"))
+			{
+				Point target = new Point(menuEntries[i].getParam0(), menuEntries[i].getParam1());
+				executor.execute(() -> markTile(target));
+
+				return ;
+			}
+		}
+	}
+
+	private int getPointIndex(WorldPoint ptWorld)
+	{
+		for (GroundMarkerPoint pt : overlay.getLstPoints())
+		{
+			if (pt.getPoint().equals(ptWorld))
+			{
+				return overlay.getLstPoints().indexOf(pt);
+			}
+		}
+
+		return -1 ;
+	}
+
+	public void addPoint(WorldPoint ptWorld)
+	{
+		overlay.getLstPoints().add(new GroundMarkerPoint(ptWorld, client));
+		savePoints();
+	}
+
+	private void addPoint(int[] intPoint)
+	{
+		overlay.getLstPoints().add(new GroundMarkerPoint(intPoint));
+	}
+
+	public void removePoint(WorldPoint ptWorld)
+	{
+		int intIndex = this.getPointIndex(ptWorld);
+
+		if (intIndex < 0)
+		{
+			return;
+		}
+
+		overlay.getLstPoints().remove(intIndex);
+
+		savePoints();
+	}
+
+	public boolean hasPoint(WorldPoint ptWorld)
+	{
+		return this.getPointIndex(ptWorld) >= 0;
+	}
+
+	public void clearPoints()
+	{
+		overlay.getLstPoints().clear();
+		savePoints();
+	}
+
+	protected void togglePoint(WorldPoint ptWorld)
+	{
+		if (this.hasPoint(ptWorld))
+		{
+			this.removePoint(ptWorld);
+		}
+		else
+		{
+			this.addPoint(ptWorld);
+		}
+	}
+
+	private int[][] listToRaw()
+	{
+		int[][] intOut = {};
+
+		for (GroundMarkerPoint point : overlay.getLstPoints())
+		{
+			if (!point.isInstanced())
+			{
+				intOut = ArrayUtils.add(intOut, point.toRaw());
+			}
+		}
+
+		return intOut ;
+	}
+
+	private final Gson gson = new Gson();
+
+	public void loadPoints()
+	{
+		String config = configManager.getConfiguration(CONFIG_GROUP, PREFIX);
+
+		if (config == null || config.isEmpty())
+		{
+			return;
+		}
+
+		int[][] intIn = gson.fromJson(config, int[][].class);
+
+		for (int[] intPoint : intIn)
+		{
+			addPoint(intPoint);
+		}
+	}
+
+	public void savePoints()
+	{
+		configManager.setConfiguration(CONFIG_GROUP, PREFIX, gson.toJson(listToRaw()));
+	}
+
+	@Override
+	protected void startUp()
+	{
+		loadPoints();
+
+		mouseManager.registerMouseListener(inputListener);
+		keyManager.registerKeyListener(inputListener);
+	}
+
+	@Override
+	protected void shutDown()
+	{
+		savePoints();
+
+		mouseManager.unregisterMouseListener(inputListener);
+		keyManager.unregisterKeyListener(inputListener);
+	}
+
+	@Override
+	public GroundMarkerOverlay getOverlay()
+	{
+		return overlay;
+	}
+
+	protected void markTile(Point ptMouse)
+	{
+		WorldPoint ptWorld = getTile(ptMouse);
+
+		if (ptWorld == null)
+		{
+			return;
+		}
+
+		this.togglePoint(ptWorld);
+	}
+
+	public WorldPoint getTile(Point mouse)
+	{
+		try
+		{
+			Region region = client.getRegion();
+			Tile[][][] tiles = region.getTiles();
+			int z = client.getPlane();
+
+			java.awt.Point gameMouse = new java.awt.Point(mouse.getX(), mouse.getY());
+
+			for (int x = 0; x < REGION_SIZE; ++x)
+			{
+				for (int y = 0; y < REGION_SIZE; ++y)
+				{
+					Tile tile = tiles[z][x][y];
+
+					if (tile == null)
+					{
+						continue;
+					}
+
+					LocalPoint local = (tile.getLocalLocation());
+					Polygon poly = Perspective.getCanvasTilePoly(client, local);
+
+					if ( poly == null )
+					{
+						continue;
+					}
+
+					if (Perspective.getCanvasTilePoly(client, local).contains(gameMouse))
+					{
+						return new WorldPoint(0, 0, 0).fromLocal(client, local);
+					}
+				}
+			}
+		}
+		catch (Exception e)
+		{
+			log.debug(e.toString());
+		}
+
+		return null;
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/groundmarkers/GroundMarkerPoint.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/groundmarkers/GroundMarkerPoint.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2018, TheLonelyDev <https://github.com/TheLonelyDev>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package net.runelite.client.plugins.groundmarkers;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import net.runelite.api.Client;
+import net.runelite.api.coords.LocalPoint;
+import net.runelite.api.coords.WorldPoint;
+
+public class GroundMarkerPoint
+{
+	@Getter(AccessLevel.PACKAGE)
+	private WorldPoint point;
+
+	@Getter(AccessLevel.PACKAGE)
+	private boolean isInstanced = false;
+
+	GroundMarkerPoint(WorldPoint point, Client client)
+	{
+		this.isInstanced = client.isInInstancedRegion();
+		this.point = point;
+	}
+
+	GroundMarkerPoint(int[] intRaw)
+	{
+		fromRaw(intRaw);
+	}
+
+	public int[] toRaw()
+	{
+		return new int[] {point.getX(), point.getY(), point.getPlane()};
+	}
+
+	private void fromRaw(int[] intRaw)
+	{
+		this.point = new WorldPoint(intRaw[0], intRaw[1], intRaw[2]);
+	}
+
+	public LocalPoint toLocal(Client client)
+	{
+		return new LocalPoint(0, 0).fromWorld(client, this.point);
+	}
+}

--- a/runescape-api/src/main/java/net/runelite/rs/api/RSClient.java
+++ b/runescape-api/src/main/java/net/runelite/rs/api/RSClient.java
@@ -612,4 +612,8 @@ public interface RSClient extends RSGameEngine, Client
 
 	@Import("hintArrowPlayerTargetIdx")
 	int getHintArrowPlayerTargetIdx();
+
+	@Import("isDynamicRegion")
+	@Override
+	boolean isInInstancedRegion();
 }


### PR DESCRIPTION
Adds a plugin that allows the user to mark tiles around the world. The marking happens with alt + right click or trough the right click menu and "mark tile". Alt + shift + right click removes all current markers. To remove a certain tile just alt + right click it again (or use the mark tile option again).

The markers are automaticallty saved and loaded (except when in instances) so marked tiles are "rembered" when your client restarts.

![image](https://user-images.githubusercontent.com/8240706/38455946-10bd235c-3a7f-11e8-94ae-a550f56cfb98.png)

![image](https://user-images.githubusercontent.com/8240706/38455966-45314d34-3a7f-11e8-8ed2-06462f096683.png)


Addresses https://github.com/runelite/runelite/issues/949