### PR TITLE
Fix ArrayIndexOutOfBounds errors in screenshot plugin

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
@@ -342,7 +342,7 @@ public class ScreenshotPlugin extends Plugin
 	 *                     with the format "Your Skill (level is/are) now 99."
 	 * @return Shortened string in the format "Skill(99)"
 	 */
-	public String parseLevelUpWidget(WidgetInfo levelUpLevel)
+	String parseLevelUpWidget(WidgetInfo levelUpLevel)
 	{
 		Widget levelChild = client.getWidget(levelUpLevel);
 		if (levelChild == null)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
@@ -102,6 +102,7 @@ public class ScreenshotPlugin extends Plugin
 	private static final DateFormat TIME_FORMAT = new SimpleDateFormat("yyyy-MM-dd_HH-mm-ss", Locale.US);
 
 	private static final Pattern NUMBER_PATTERN = Pattern.compile("([0-9]+)");
+	private static final Pattern LEVEL_UP_PATTERN = Pattern.compile("Your ([a-zA-Z]+) (?:level is|are)? now (\\d+)\\.");
 
 	private String clueType;
 	private Integer clueNumber;
@@ -264,12 +265,12 @@ public class ScreenshotPlugin extends Plugin
 		{
 			case LEVEL_UP_GROUP_ID:
 			{
-				fileName = parseLevelUpWidget(WidgetInfo.LEVEL_UP_SKILL, WidgetInfo.LEVEL_UP_LEVEL);
+				fileName = parseLevelUpWidget(WidgetInfo.LEVEL_UP_LEVEL);
 				break;
 			}
 			case DIALOG_SPRITE_GROUP_ID:
 			{
-				fileName = parseLevelUpWidget(WidgetInfo.DIALOG_SPRITE_SPRITE, WidgetInfo.DIALOG_SPRITE_TEXT);
+				fileName = parseLevelUpWidget(WidgetInfo.DIALOG_SPRITE_TEXT);
 				break;
 			}
 			case QUEST_COMPLETED_GROUP_ID:
@@ -333,25 +334,22 @@ public class ScreenshotPlugin extends Plugin
 		takeScreenshot(fileName, config.displayDate());
 	}
 
-	public String parseLevelUpWidget(WidgetInfo levelUpSkill, WidgetInfo levelUpLevel)
+	public String parseLevelUpWidget(WidgetInfo levelUpLevel)
 	{
-		Widget skillChild = client.getWidget(levelUpSkill);
 		Widget levelChild = client.getWidget(levelUpLevel);
-
-		if (skillChild == null || levelChild == null)
+		if (levelChild == null)
 		{
 			return null;
 		}
 
-		// "Congratulations, you just advanced a Firemaking level."
-		String skillText = skillChild.getText();
-		// "Your Firemaking level is now 9."
-		String levelText = levelChild.getText();
+		Matcher m = LEVEL_UP_PATTERN.matcher(levelChild.getText());
+		if (!m.matches())
+		{
+			return null;
+		}
 
-		String[] splitSkillName = skillText.split(" ");
-		String skillName = splitSkillName[splitSkillName.length - 2];
-		String skillLevel = levelText.substring(levelText.lastIndexOf(" ") + 1, levelText.length() - 1);
-
+		String skillName = m.group(1);
+		String skillLevel = m.group(2);
 		return skillName + "(" + skillLevel + ")";
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
@@ -334,6 +334,14 @@ public class ScreenshotPlugin extends Plugin
 		takeScreenshot(fileName, config.displayDate());
 	}
 
+	/**
+	 * Receives a WidgetInfo pointing to the middle widget of the level-up dialog,
+	 * and parses it into a shortened string for filename usage.
+	 *
+	 * @param levelUpLevel WidgetInfo pointing to the required text widget,
+	 *                     with the format "Your Skill (level is/are) now 99."
+	 * @return Shortened string in the format "Skill(99)"
+	 */
 	public String parseLevelUpWidget(WidgetInfo levelUpLevel)
 	{
 		Widget levelChild = client.getWidget(levelUpLevel);
@@ -353,6 +361,13 @@ public class ScreenshotPlugin extends Plugin
 		return skillName + "(" + skillLevel + ")";
 	}
 
+	/**
+	 * Saves a screenshot of the client window to the screenshot folder as a PNG,
+	 * and optionally uploads it to an image-hosting service.
+	 *
+	 * @param fileName    Filename to use, without file extension.
+	 * @param displayDate Whether to show today's date on the report button as the screenshot is taken.
+	 */
 	private void takeScreenshot(String fileName, boolean displayDate)
 	{
 		if (client.getGameState() == GameState.LOGIN_SCREEN)
@@ -461,6 +476,13 @@ public class ScreenshotPlugin extends Plugin
 		});
 	}
 
+	/**
+	 * Uploads a screenshot to the Imgur image-hosting service,
+	 * and copies the image link to the clipboard.
+	 *
+	 * @param screenshotFile Image file to upload.
+	 * @throws IOException Thrown if the file cannot be read.
+	 */
 	private void uploadScreenshot(File screenshotFile) throws IOException
 	{
 		String json = RuneLiteAPI.GSON.toJson(new ImageUploadRequest(screenshotFile));

--- a/runelite-client/src/test/java/net/runelite/client/plugins/screenshot/ScreenshotPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/screenshot/ScreenshotPluginTest.java
@@ -64,14 +64,14 @@ public class ScreenshotPluginTest
 
 	@Mock
 	@Bind
-	Client client;
+	private Client client;
 
 	@Inject
-	ScreenshotPlugin screenshotPlugin;
+	private ScreenshotPlugin screenshotPlugin;
 
 	@Mock
 	@Bind
-	ScreenshotConfig screenshotConfig;
+	private ScreenshotConfig screenshotConfig;
 
 	@Mock
 	@Bind
@@ -83,7 +83,7 @@ public class ScreenshotPluginTest
 
 	@Mock
 	@Bind
-	OverlayRenderer overlayRenderer;
+	private OverlayRenderer overlayRenderer;
 
 	@Mock
 	@Bind
@@ -102,7 +102,7 @@ public class ScreenshotPluginTest
 	}
 
 	@Test
-	public void testcluescroll()
+	public void testClueScroll()
 	{
 		ChatMessage chatMessageEvent = new ChatMessage(SERVER, "Seth", CLUE_SCROLL, null);
 		screenshotPlugin.onChatMessage(chatMessageEvent);
@@ -112,7 +112,7 @@ public class ScreenshotPluginTest
 	}
 
 	@Test
-	public void testbarrowschest()
+	public void testBarrowsChest()
 	{
 		ChatMessage chatMessageEvent = new ChatMessage(SERVER, "Seth", BARROWS_CHEST, null);
 		screenshotPlugin.onChatMessage(chatMessageEvent);
@@ -121,7 +121,7 @@ public class ScreenshotPluginTest
 	}
 
 	@Test
-	public void testraidschest()
+	public void testRaidsChest()
 	{
 		ChatMessage chatMessageEvent = new ChatMessage(SERVER, "Seth", RAIDS_CHEST, null);
 		screenshotPlugin.onChatMessage(chatMessageEvent);
@@ -130,7 +130,7 @@ public class ScreenshotPluginTest
 	}
 
 	@Test
-	public void testHitpoints()
+	public void testHitpointsLevel99()
 	{
 		Widget widget = mock(Widget.class);
 		when(widget.getId()).thenReturn(PACK(LEVEL_UP_GROUP_ID, 0));
@@ -150,7 +150,7 @@ public class ScreenshotPluginTest
 	}
 
 	@Test
-	public void testFiremaking()
+	public void testFiremakingLevel9()
 	{
 		Widget widget = mock(Widget.class);
 		when(widget.getId()).thenReturn(PACK(LEVEL_UP_GROUP_ID, 0));
@@ -170,7 +170,7 @@ public class ScreenshotPluginTest
 	}
 
 	@Test
-	public void testAttack()
+	public void testAttackLevel70()
 	{
 		Widget widget = mock(Widget.class);
 		when(widget.getId()).thenReturn(PACK(LEVEL_UP_GROUP_ID, 0));
@@ -190,7 +190,7 @@ public class ScreenshotPluginTest
 	}
 
 	@Test
-	public void testHunter()
+	public void testHunterLevel2()
 	{
 		Widget widget = mock(Widget.class);
 		when(widget.getId()).thenReturn(PACK(DIALOG_SPRITE_GROUP_ID, 0));

--- a/runelite-client/src/test/java/net/runelite/client/plugins/screenshot/ScreenshotPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/screenshot/ScreenshotPluginTest.java
@@ -37,10 +37,8 @@ import net.runelite.api.events.WidgetHiddenChanged;
 import net.runelite.api.widgets.Widget;
 import static net.runelite.api.widgets.WidgetID.DIALOG_SPRITE_GROUP_ID;
 import static net.runelite.api.widgets.WidgetID.LEVEL_UP_GROUP_ID;
-import static net.runelite.api.widgets.WidgetInfo.DIALOG_SPRITE_SPRITE;
 import static net.runelite.api.widgets.WidgetInfo.DIALOG_SPRITE_TEXT;
 import static net.runelite.api.widgets.WidgetInfo.LEVEL_UP_LEVEL;
-import static net.runelite.api.widgets.WidgetInfo.LEVEL_UP_SKILL;
 import static net.runelite.api.widgets.WidgetInfo.PACK;
 import net.runelite.client.Notifier;
 import net.runelite.client.config.RuneLiteConfig;
@@ -137,16 +135,12 @@ public class ScreenshotPluginTest
 		Widget widget = mock(Widget.class);
 		when(widget.getId()).thenReturn(PACK(LEVEL_UP_GROUP_ID, 0));
 
-		Widget skillChild = mock(Widget.class);
-		when(client.getWidget(Matchers.eq(LEVEL_UP_SKILL))).thenReturn(skillChild);
-
 		Widget levelChild = mock(Widget.class);
 		when(client.getWidget(Matchers.eq(LEVEL_UP_LEVEL))).thenReturn(levelChild);
 
-		when(skillChild.getText()).thenReturn("Congratulations, you just advanced a Hitpoints level.");
 		when(levelChild.getText()).thenReturn("Your Hitpoints are now 99.");
 
-		assertEquals("Hitpoints(99)", screenshotPlugin.parseLevelUpWidget(LEVEL_UP_SKILL, LEVEL_UP_LEVEL));
+		assertEquals("Hitpoints(99)", screenshotPlugin.parseLevelUpWidget(LEVEL_UP_LEVEL));
 
 		WidgetHiddenChanged event = new WidgetHiddenChanged();
 		event.setWidget(widget);
@@ -161,16 +155,12 @@ public class ScreenshotPluginTest
 		Widget widget = mock(Widget.class);
 		when(widget.getId()).thenReturn(PACK(LEVEL_UP_GROUP_ID, 0));
 
-		Widget skillChild = mock(Widget.class);
-		when(client.getWidget(Matchers.eq(LEVEL_UP_SKILL))).thenReturn(skillChild);
-
 		Widget levelChild = mock(Widget.class);
 		when(client.getWidget(Matchers.eq(LEVEL_UP_LEVEL))).thenReturn(levelChild);
 
-		when(skillChild.getText()).thenReturn("Congratulations, you just advanced a Firemaking level.");
 		when(levelChild.getText()).thenReturn("Your Firemaking level is now 9.");
 
-		assertEquals("Firemaking(9)", screenshotPlugin.parseLevelUpWidget(LEVEL_UP_SKILL, LEVEL_UP_LEVEL));
+		assertEquals("Firemaking(9)", screenshotPlugin.parseLevelUpWidget(LEVEL_UP_LEVEL));
 
 		WidgetHiddenChanged event = new WidgetHiddenChanged();
 		event.setWidget(widget);
@@ -185,16 +175,12 @@ public class ScreenshotPluginTest
 		Widget widget = mock(Widget.class);
 		when(widget.getId()).thenReturn(PACK(LEVEL_UP_GROUP_ID, 0));
 
-		Widget skillChild = mock(Widget.class);
-		when(client.getWidget(Matchers.eq(LEVEL_UP_SKILL))).thenReturn(skillChild);
-
 		Widget levelChild = mock(Widget.class);
 		when(client.getWidget(Matchers.eq(LEVEL_UP_LEVEL))).thenReturn(levelChild);
 
-		when(skillChild.getText()).thenReturn("Congratulations, you just advanced an Attack level.");
 		when(levelChild.getText()).thenReturn("Your Attack level is now 70.");
 
-		assertEquals("Attack(70)", screenshotPlugin.parseLevelUpWidget(LEVEL_UP_SKILL, LEVEL_UP_LEVEL));
+		assertEquals("Attack(70)", screenshotPlugin.parseLevelUpWidget(LEVEL_UP_LEVEL));
 
 		WidgetHiddenChanged event = new WidgetHiddenChanged();
 		event.setWidget(widget);
@@ -209,16 +195,12 @@ public class ScreenshotPluginTest
 		Widget widget = mock(Widget.class);
 		when(widget.getId()).thenReturn(PACK(DIALOG_SPRITE_GROUP_ID, 0));
 
-		Widget skillChild = mock(Widget.class);
-		when(client.getWidget(Matchers.eq(DIALOG_SPRITE_SPRITE))).thenReturn(skillChild);
-
 		Widget levelChild = mock(Widget.class);
 		when(client.getWidget(Matchers.eq(DIALOG_SPRITE_TEXT))).thenReturn(levelChild);
 
-		when(skillChild.getText()).thenReturn("Congratulations, you just advanced a Hunter level.");
 		when(levelChild.getText()).thenReturn("Your Hunter level is now 2.");
 
-		assertEquals("Hunter(2)", screenshotPlugin.parseLevelUpWidget(DIALOG_SPRITE_SPRITE, DIALOG_SPRITE_TEXT));
+		assertEquals("Hunter(2)", screenshotPlugin.parseLevelUpWidget(DIALOG_SPRITE_TEXT));
 
 		WidgetHiddenChanged event = new WidgetHiddenChanged();
 		event.setWidget(widget);


### PR DESCRIPTION
Fixes #1060.

Plugin now uses a regex for validation of text in the level-up widget, because that widget is sometimes re-used for other game dialogs. Those dialogs will now be safely ignored.