### PR TITLE
Rename "Attack Indicators" plugin to "Attack Styles"

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/attackstyles/AttackStyle.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/attackstyles/AttackStyle.java
@@ -22,39 +22,38 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package net.runelite.client.plugins.attackindicator;
+package net.runelite.client.plugins.attackstyles;
 
-import java.awt.Color;
-import java.awt.Dimension;
-import java.awt.Graphics2D;
-import javax.inject.Inject;
-import net.runelite.client.ui.overlay.Overlay;
-import net.runelite.client.ui.overlay.OverlayPosition;
-import net.runelite.client.ui.overlay.components.PanelComponent;
+import net.runelite.api.Skill;
 
-public class AttackIndicatorOverlay extends Overlay
+public enum AttackStyle
 {
-	private static final int COMPONENT_WIDTH = 80;
+	ACCURATE("Accurate", Skill.ATTACK),
+	AGGRESSIVE("Aggressive", Skill.STRENGTH),
+	DEFENSIVE("Defensive", Skill.DEFENCE),
+	CONTROLLED("Controlled", Skill.ATTACK, Skill.STRENGTH, Skill.DEFENCE),
+	RANGING("Ranging", Skill.RANGED),
+	LONGRANGE("Longrange", Skill.RANGED, Skill.DEFENCE),
+	CASTING("Casting", Skill.MAGIC),
+	DEFENSIVE_CASTING("Defensive Casting", Skill.MAGIC, Skill.DEFENCE),
+	OTHER("Other");
 
-	private final AttackIndicatorPlugin plugin;
-	private final PanelComponent panelComponent = new PanelComponent();
+	private final String name;
+	private final Skill[] skills;
 
-	@Inject
-	public AttackIndicatorOverlay(AttackIndicatorPlugin plugin)
+	AttackStyle(String name, Skill... skills)
 	{
-		setPosition(OverlayPosition.ABOVE_CHATBOX_RIGHT);
-		this.plugin = plugin;
+		this.name = name;
+		this.skills = skills;
 	}
 
-	@Override
-	public Dimension render(Graphics2D graphics)
+	public String getName()
 	{
-		final String attackStyleString = plugin.getAttackStyle().getName();
+		return name;
+	}
 
-		panelComponent.setTitleColor(plugin.isWarnedSkillSelected() ? Color.RED : Color.WHITE);
-		panelComponent.setTitle(attackStyleString);
-		panelComponent.setWidth(COMPONENT_WIDTH);
-
-		return panelComponent.render(graphics);
+	public Skill[] getSkills()
+	{
+		return skills;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/attackstyles/AttackStylesConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/attackstyles/AttackStylesConfig.java
@@ -48,11 +48,11 @@ public interface AttackStylesConfig extends Config
 
 	@ConfigItem(
 		keyName = "warnForDefensive",
-		name = "Warn for defensive",
-		description = "Configures whether or not users are warned for selecting a defensive combat option",
+		name = "Warn for defence",
+		description = "Show warning when a Defence skill combat option is selected",
 		position = 2
 	)
-	default boolean warnForDefensive()
+	default boolean warnForDefence()
 	{
 		return false;
 	}
@@ -60,7 +60,7 @@ public interface AttackStylesConfig extends Config
 	@ConfigItem(
 		keyName = "warnForAttack",
 		name = "Warn for attack",
-		description = "Configures whether or not users are warned for selecting an attack combat option",
+		description = "Show warning when an Attack skill combat option is selected",
 		position = 3
 	)
 	default boolean warnForAttack()
@@ -71,7 +71,7 @@ public interface AttackStylesConfig extends Config
 	@ConfigItem(
 		keyName = "warnForStrength",
 		name = "Warn for strength",
-		description = "Configures whether or not users are warned for selecting a strength combat option",
+		description = "Show warning when a Strength skill combat option is selected",
 		position = 4
 	)
 	default boolean warnForStrength()
@@ -82,7 +82,7 @@ public interface AttackStylesConfig extends Config
 	@ConfigItem(
 		keyName = "warnForRanged",
 		name = "Warn for ranged",
-		description = "Configures whether or not users are warned for selecting a ranged combat option",
+		description = "Show warning when a Ranged skill combat option is selected",
 		position = 5
 	)
 	default boolean warnForRanged()
@@ -93,7 +93,7 @@ public interface AttackStylesConfig extends Config
 	@ConfigItem(
 		keyName = "warnForMagic",
 		name = "Warn for magic",
-		description = "Configures whether or not users are warned for selecting a magic combat option",
+		description = "Show warning when a Magic skill combat option is selected",
 		position = 6
 	)
 	default boolean warnForMagic()
@@ -104,7 +104,7 @@ public interface AttackStylesConfig extends Config
 	@ConfigItem(
 		keyName = "removeWarnedStyles",
 		name = "Remove warned styles",
-		description = "Configures whether or not warned styles are removed from the combat options tab",
+		description = "Remove warned styles from the combat options tab",
 		position = 7
 	)
 	default boolean removeWarnedStyles()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/attackstyles/AttackStylesConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/attackstyles/AttackStylesConfig.java
@@ -36,6 +36,17 @@ import net.runelite.client.config.ConfigItem;
 public interface AttackStylesConfig extends Config
 {
 	@ConfigItem(
+		keyName = "alwaysShowStyle",
+		name = "Always show style",
+		description = "Show attack style indicator at all times",
+		position = 1
+	)
+	default boolean alwaysShowStyle()
+	{
+		return true;
+	}
+
+	@ConfigItem(
 		keyName = "warnForDefensive",
 		name = "Warn for defensive",
 		description = "Configures whether or not users are warned for selecting a defensive combat option",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/attackstyles/AttackStylesConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/attackstyles/AttackStylesConfig.java
@@ -22,7 +22,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package net.runelite.client.plugins.attackindicator;
+package net.runelite.client.plugins.attackstyles;
 
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
@@ -30,10 +30,10 @@ import net.runelite.client.config.ConfigItem;
 
 @ConfigGroup(
 	keyName = "attackIndicator",
-	name = "Attack Indicators",
-	description = "Configuration for the attack indicator plugin"
+	name = "Attack Styles",
+	description = "Configuration for the attack styles plugin"
 )
-public interface AttackIndicatorConfig extends Config
+public interface AttackStylesConfig extends Config
 {
 	@ConfigItem(
 		keyName = "warnForDefensive",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/attackstyles/AttackStylesOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/attackstyles/AttackStylesOverlay.java
@@ -37,24 +37,33 @@ public class AttackStylesOverlay extends Overlay
 	private static final int COMPONENT_WIDTH = 80;
 
 	private final AttackStylesPlugin plugin;
+	private final AttackStylesConfig config;
 	private final PanelComponent panelComponent = new PanelComponent();
 
 	@Inject
-	public AttackStylesOverlay(AttackStylesPlugin plugin)
+	public AttackStylesOverlay(AttackStylesPlugin plugin, AttackStylesConfig config)
 	{
 		setPosition(OverlayPosition.ABOVE_CHATBOX_RIGHT);
 		this.plugin = plugin;
+		this.config = config;
 	}
 
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
-		final String attackStyleString = plugin.getAttackStyle().getName();
+		boolean warnedSkillSelected = plugin.isWarnedSkillSelected();
 
-		panelComponent.setTitleColor(plugin.isWarnedSkillSelected() ? Color.RED : Color.WHITE);
-		panelComponent.setTitle(attackStyleString);
-		panelComponent.setWidth(COMPONENT_WIDTH);
+		if (warnedSkillSelected || config.alwaysShowStyle())
+		{
+			final String attackStyleString = plugin.getAttackStyle().getName();
 
-		return panelComponent.render(graphics);
+			panelComponent.setTitleColor(warnedSkillSelected ? Color.RED : Color.WHITE);
+			panelComponent.setTitle(attackStyleString);
+			panelComponent.setWidth(COMPONENT_WIDTH);
+
+			return panelComponent.render(graphics);
+		}
+
+		return null;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/attackstyles/AttackStylesOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/attackstyles/AttackStylesOverlay.java
@@ -22,38 +22,39 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package net.runelite.client.plugins.attackindicator;
+package net.runelite.client.plugins.attackstyles;
 
-import net.runelite.api.Skill;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Graphics2D;
+import javax.inject.Inject;
+import net.runelite.client.ui.overlay.Overlay;
+import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.components.PanelComponent;
 
-public enum AttackStyle
+public class AttackStylesOverlay extends Overlay
 {
-	ACCURATE("Accurate", Skill.ATTACK),
-	AGGRESSIVE("Aggressive", Skill.STRENGTH),
-	DEFENSIVE("Defensive", Skill.DEFENCE),
-	CONTROLLED("Controlled", Skill.ATTACK, Skill.STRENGTH, Skill.DEFENCE),
-	RANGING("Ranging", Skill.RANGED),
-	LONGRANGE("Longrange", Skill.RANGED, Skill.DEFENCE),
-	CASTING("Casting", Skill.MAGIC),
-	DEFENSIVE_CASTING("Defensive Casting", Skill.MAGIC, Skill.DEFENCE),
-	OTHER("Other");
+	private static final int COMPONENT_WIDTH = 80;
 
-	private final String name;
-	private final Skill[] skills;
+	private final AttackStylesPlugin plugin;
+	private final PanelComponent panelComponent = new PanelComponent();
 
-	AttackStyle(String name, Skill... skills)
+	@Inject
+	public AttackStylesOverlay(AttackStylesPlugin plugin)
 	{
-		this.name = name;
-		this.skills = skills;
+		setPosition(OverlayPosition.ABOVE_CHATBOX_RIGHT);
+		this.plugin = plugin;
 	}
 
-	public String getName()
+	@Override
+	public Dimension render(Graphics2D graphics)
 	{
-		return name;
-	}
+		final String attackStyleString = plugin.getAttackStyle().getName();
 
-	public Skill[] getSkills()
-	{
-		return skills;
+		panelComponent.setTitleColor(plugin.isWarnedSkillSelected() ? Color.RED : Color.WHITE);
+		panelComponent.setTitle(attackStyleString);
+		panelComponent.setWidth(COMPONENT_WIDTH);
+
+		return panelComponent.render(graphics);
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/attackstyles/AttackStylesPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/attackstyles/AttackStylesPlugin.java
@@ -22,7 +22,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package net.runelite.client.plugins.attackindicator;
+package net.runelite.client.plugins.attackstyles;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.HashBasedTable;
@@ -49,15 +49,15 @@ import static net.runelite.api.widgets.WidgetInfo.TO_GROUP;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
-import static net.runelite.client.plugins.attackindicator.AttackStyle.CASTING;
-import static net.runelite.client.plugins.attackindicator.AttackStyle.DEFENSIVE_CASTING;
-import static net.runelite.client.plugins.attackindicator.AttackStyle.OTHER;
+import static net.runelite.client.plugins.attackstyles.AttackStyle.CASTING;
+import static net.runelite.client.plugins.attackstyles.AttackStyle.DEFENSIVE_CASTING;
+import static net.runelite.client.plugins.attackstyles.AttackStyle.OTHER;
 
 @PluginDescriptor(
-	name = "Attack Indicators"
+	name = "Attack Styles"
 )
 @Slf4j
-public class AttackIndicatorPlugin extends Plugin
+public class AttackStylesPlugin extends Plugin
 {
 	private int attackStyleVarbit = -1;
 	private int equippedWeaponTypeVarbit = -1;
@@ -71,19 +71,19 @@ public class AttackIndicatorPlugin extends Plugin
 	private Client client;
 
 	@Inject
-	private AttackIndicatorConfig config;
+	private AttackStylesConfig config;
 
 	@Inject
-	private AttackIndicatorOverlay overlay;
+	private AttackStylesOverlay overlay;
 
 	@Provides
-	AttackIndicatorConfig provideConfig(ConfigManager configManager)
+	AttackStylesConfig provideConfig(ConfigManager configManager)
 	{
-		return configManager.getConfig(AttackIndicatorConfig.class);
+		return configManager.getConfig(AttackStylesConfig.class);
 	}
 
 	@Override
-	public AttackIndicatorOverlay getOverlay()
+	public AttackStylesOverlay getOverlay()
 	{
 		return overlay;
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/attackstyles/AttackStylesPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/attackstyles/AttackStylesPlugin.java
@@ -96,7 +96,7 @@ public class AttackStylesPlugin extends Plugin
 		{
 			updateWarnedSkills(config.warnForAttack(), Skill.ATTACK);
 			updateWarnedSkills(config.warnForStrength(), Skill.STRENGTH);
-			updateWarnedSkills(config.warnForDefensive(), Skill.DEFENCE);
+			updateWarnedSkills(config.warnForDefence(), Skill.DEFENCE);
 			updateWarnedSkills(config.warnForRanged(), Skill.RANGED);
 			updateWarnedSkills(config.warnForMagic(), Skill.MAGIC);
 			updateAttackStyle(
@@ -164,7 +164,7 @@ public class AttackStylesPlugin extends Plugin
 		{
 			updateWarnedSkills(config.warnForAttack(), Skill.ATTACK);
 			updateWarnedSkills(config.warnForStrength(), Skill.STRENGTH);
-			updateWarnedSkills(config.warnForDefensive(), Skill.DEFENCE);
+			updateWarnedSkills(config.warnForDefence(), Skill.DEFENCE);
 			updateWarnedSkills(config.warnForRanged(), Skill.RANGED);
 			updateWarnedSkills(config.warnForMagic(), Skill.MAGIC);
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/attackstyles/WeaponType.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/attackstyles/WeaponType.java
@@ -22,11 +22,11 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package net.runelite.client.plugins.attackindicator;
+package net.runelite.client.plugins.attackstyles;
 
 import java.util.HashMap;
 import java.util.Map;
-import static net.runelite.client.plugins.attackindicator.AttackStyle.*;
+import static net.runelite.client.plugins.attackstyles.AttackStyle.*;
 
 public enum WeaponType
 {

--- a/runelite-client/src/test/java/net/runelite/client/plugins/attackstyles/AttackStylesPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/attackstyles/AttackStylesPluginTest.java
@@ -22,7 +22,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package net.runelite.client.plugins.attackindicator;
+package net.runelite.client.plugins.attackstyles;
 
 import com.google.inject.Guice;
 import com.google.inject.testing.fieldbinder.Bind;
@@ -48,7 +48,7 @@ import static org.mockito.Mockito.when;
 import org.mockito.runners.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
-public class AttackIndicatorPluginTest
+public class AttackStylesPluginTest
 {
 	@Mock
 	@Bind
@@ -56,10 +56,10 @@ public class AttackIndicatorPluginTest
 
 	@Mock
 	@Bind
-	AttackIndicatorConfig attackConfig;
+	AttackStylesConfig attackConfig;
 
 	@Inject
-	AttackIndicatorPlugin attackPlugin;
+	AttackStylesPlugin attackPlugin;
 
 	@Before
 	public void before()
@@ -102,7 +102,7 @@ public class AttackIndicatorPluginTest
 	}
 
 	/*
-	 * Verify that attack style widgets are hidden when filtered with the AttackIndicatorPlugin.
+	 * Verify that attack style widgets are hidden when filtered with the AttackStylesPlugin.
 	 */
 	@Test
 	public void testHiddenWidget()


### PR DESCRIPTION
Motivated by a visitor on Discord who didn't realise this was the plugin he was looking for when he asked us to add it. The label needs to describe the plugin's scope more clearly.

This pr also renames code references for clarity, although not the `keyName` of course.