### PR TITLE
Fix Actor.getWorldLocation to use pathX/pathY instead of getX/getY

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/Actor.java
+++ b/runelite-api/src/main/java/net/runelite/api/Actor.java
@@ -42,6 +42,11 @@ public interface Actor extends Renderable
 
 	int getHealth();
 
+	/**
+	 * Retrieve the server location of the actor. Note that this is typically
+	 * a couple steps ahead of where the client renders the actor.
+	 * @return Returns the server location of the actor.
+	 */
 	WorldPoint getWorldLocation();
 
 	LocalPoint getLocalLocation();

--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSActorMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSActorMixin.java
@@ -127,7 +127,10 @@ public abstract class RSActorMixin implements RSActor
 	@Inject
 	public WorldPoint getWorldLocation()
 	{
-		return WorldPoint.fromLocal(client, getX(), getY(), client.getPlane());
+		return WorldPoint.fromLocal(client,
+			this.getPathX()[0] * Perspective.LOCAL_TILE_SIZE + Perspective.LOCAL_TILE_SIZE / 2,
+			this.getPathY()[0] * Perspective.LOCAL_TILE_SIZE + Perspective.LOCAL_TILE_SIZE / 2,
+			client.getPlane());
 	}
 
 	@Inject

--- a/runescape-api/src/main/java/net/runelite/rs/api/RSActor.java
+++ b/runescape-api/src/main/java/net/runelite/rs/api/RSActor.java
@@ -41,6 +41,12 @@ public interface RSActor extends RSRenderable, Actor
 	@Import("y")
 	int getY();
 
+	@Import("pathX")
+	int[] getPathX();
+
+	@Import("pathY")
+	int[] getPathY();
+
 	@Import("animation")
 	@Override
 	int getAnimation();


### PR DESCRIPTION
Actor.getWorldLocation is currently based on getX/getY which is the current position of the actor in the client. We should instead base it on pathX[0]/pathY[0] which is the location of the actor on the server.