### PR TITLE
Update game tick event to run after packets have been processed

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/callback/Hooks.java
+++ b/runelite-client/src/main/java/net/runelite/client/callback/Hooks.java
@@ -95,9 +95,16 @@ public class Hooks
 	private static Graphics2D stretchedGraphics;
 
 	private static long lastCheck;
+	private static boolean shouldProcessGameTick;
 
 	public static void clientMainLoop(Client client, boolean arg1)
 	{
+		if (shouldProcessGameTick)
+		{
+			shouldProcessGameTick = false;
+			eventBus.post(tick);
+		}
+
 		clientThread.invoke();
 
 		long now = System.currentTimeMillis();
@@ -403,7 +410,10 @@ public class Hooks
 
 	public static void onNpcUpdate(boolean var0, PacketBuffer var1)
 	{
-		eventBus.post(tick);
+		// The NPC update event seem to run every server tick,
+		// but having the game tick event after all packets
+		// have been processed is typically more useful.
+		shouldProcessGameTick = true;
 	}
 
 	public static void onSetCombatInfo(Actor actor, int combatInfoId, int gameCycle, int var3, int var4, int healthRatio, int health)


### PR DESCRIPTION
It makes more sense to have the game tick event run after npcs, players, game object etc have all been updated. This fixes a few issues like [#1276](https://github.com/runelite/runelite/issues/1276).

The fix for the hunter plugin also depends on pull [#1325](https://github.com/runelite/runelite/pull/1325).