### PR TITLE
POC - Add custom orange-dark RuneLite color scheme

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
@@ -64,10 +64,10 @@ import net.runelite.client.events.PluginToolbarButtonAdded;
 import net.runelite.client.events.PluginToolbarButtonRemoved;
 import net.runelite.client.events.TitleToolbarButtonAdded;
 import net.runelite.client.events.TitleToolbarButtonRemoved;
+import net.runelite.client.ui.skin.SubstanceRuneLiteLookAndFeel;
 import net.runelite.client.util.OSType;
 import net.runelite.client.util.OSXUtil;
 import net.runelite.client.util.SwingUtil;
-import org.pushingpixels.substance.api.skin.SubstanceGraphiteLookAndFeel;
 import org.pushingpixels.substance.internal.utils.SubstanceCoreUtilities;
 import org.pushingpixels.substance.internal.utils.SubstanceTitlePaneUtilities;
 
@@ -296,7 +296,7 @@ public class ClientUI
 			SwingUtil.setupDefaults();
 
 			// Use substance look and feel
-			SwingUtil.setTheme(new SubstanceGraphiteLookAndFeel());
+			SwingUtil.setTheme(new SubstanceRuneLiteLookAndFeel());
 
 			// Use custom UI font
 			SwingUtil.setFont(FontManager.getRunescapeFont());

--- a/runelite-client/src/main/java/net/runelite/client/ui/skin/RuneLiteSkin.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/skin/RuneLiteSkin.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright (c) 2018, Tomas Slusny <slusnucky@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.ui.skin;
+
+import javax.swing.AbstractButton;
+import org.pushingpixels.substance.api.ComponentState;
+import org.pushingpixels.substance.api.SubstanceColorSchemeBundle;
+import org.pushingpixels.substance.api.SubstanceSkin;
+import org.pushingpixels.substance.api.SubstanceSlices.ColorSchemeAssociationKind;
+import org.pushingpixels.substance.api.SubstanceSlices.DecorationAreaType;
+import org.pushingpixels.substance.api.colorscheme.ColorSchemeSingleColorQuery;
+import org.pushingpixels.substance.api.colorscheme.SubstanceColorScheme;
+import org.pushingpixels.substance.api.painter.border.ClassicBorderPainter;
+import org.pushingpixels.substance.api.painter.border.CompositeBorderPainter;
+import org.pushingpixels.substance.api.painter.border.DelegateBorderPainter;
+import org.pushingpixels.substance.api.painter.decoration.MatteDecorationPainter;
+import org.pushingpixels.substance.api.painter.fill.FractionBasedFillPainter;
+import org.pushingpixels.substance.api.painter.highlight.ClassicHighlightPainter;
+import org.pushingpixels.substance.api.painter.overlay.BottomLineOverlayPainter;
+import org.pushingpixels.substance.api.painter.overlay.BottomShadowOverlayPainter;
+import org.pushingpixels.substance.api.painter.overlay.TopBezelOverlayPainter;
+import org.pushingpixels.substance.api.painter.overlay.TopLineOverlayPainter;
+import org.pushingpixels.substance.api.shaper.ClassicButtonShaper;
+import org.pushingpixels.substance.internal.utils.SubstanceColorUtilities;
+
+public class RuneLiteSkin extends SubstanceSkin
+{
+	/**
+	 * Display name for <code>this</code> skin.
+	 */
+	private static final String NAME = "RuneLite";
+
+	/**
+	 * Creates a new <code>RuneLite</code> skin.
+	 */
+	RuneLiteSkin()
+	{
+		final SubstanceSkin.ColorSchemes schemes = SubstanceSkin
+			.getColorSchemes(getClass().getResource(NAME + ".colorschemes"));
+		final SubstanceColorScheme activeScheme = schemes.get("RuneLite Active");
+		final SubstanceColorScheme enabledScheme = schemes.get("RuneLite Enabled");
+
+		final SubstanceColorSchemeBundle defaultSchemeBundle = new SubstanceColorSchemeBundle(
+			activeScheme, enabledScheme, enabledScheme);
+		defaultSchemeBundle.registerColorScheme(enabledScheme, 0.6f,
+			ComponentState.DISABLED_UNSELECTED);
+		defaultSchemeBundle.registerColorScheme(activeScheme, 0.6f,
+			ComponentState.DISABLED_SELECTED);
+
+		// borders
+		final SubstanceColorScheme borderDisabledSelectedScheme = schemes
+			.get("RuneLite Selected Disabled Border");
+		final SubstanceColorScheme borderScheme = schemes.get("RuneLite Border");
+		defaultSchemeBundle.registerColorScheme(borderDisabledSelectedScheme,
+			ColorSchemeAssociationKind.BORDER, ComponentState.DISABLED_SELECTED);
+		defaultSchemeBundle.registerColorScheme(borderScheme, ColorSchemeAssociationKind.BORDER);
+
+		// marks
+		final SubstanceColorScheme markActiveScheme = schemes.get("RuneLite Mark Active");
+		defaultSchemeBundle.registerColorScheme(markActiveScheme, ColorSchemeAssociationKind.MARK,
+			ComponentState.getActiveStates());
+		defaultSchemeBundle.registerColorScheme(markActiveScheme, 0.6f,
+			ColorSchemeAssociationKind.MARK, ComponentState.DISABLED_SELECTED,
+			ComponentState.DISABLED_UNSELECTED);
+
+		// separators
+		final SubstanceColorScheme separatorScheme = schemes.get("RuneLite Separator");
+		defaultSchemeBundle.registerColorScheme(separatorScheme,
+			ColorSchemeAssociationKind.SEPARATOR);
+
+		// tab borders
+		defaultSchemeBundle.registerColorScheme(schemes.get("RuneLite Tab Border"),
+			ColorSchemeAssociationKind.TAB_BORDER, ComponentState.getActiveStates());
+
+		final SubstanceColorScheme watermarkScheme = schemes.get("RuneLite Watermark");
+
+		this.registerDecorationAreaSchemeBundle(defaultSchemeBundle, watermarkScheme,
+			DecorationAreaType.NONE);
+
+		final SubstanceColorSchemeBundle decorationsSchemeBundle = new SubstanceColorSchemeBundle(
+			activeScheme, enabledScheme, enabledScheme);
+		decorationsSchemeBundle.registerColorScheme(enabledScheme, 0.5f,
+			ComponentState.DISABLED_UNSELECTED);
+
+		// borders
+		decorationsSchemeBundle.registerColorScheme(borderDisabledSelectedScheme,
+			ColorSchemeAssociationKind.BORDER, ComponentState.DISABLED_SELECTED);
+		decorationsSchemeBundle.registerColorScheme(borderScheme,
+			ColorSchemeAssociationKind.BORDER);
+
+		// marks
+		decorationsSchemeBundle.registerColorScheme(markActiveScheme,
+			ColorSchemeAssociationKind.MARK, ComponentState.getActiveStates());
+
+		// separators
+		final SubstanceColorScheme separatorDecorationsScheme = schemes
+			.get("RuneLite Decorations Separator");
+		decorationsSchemeBundle.registerColorScheme(separatorDecorationsScheme,
+			ColorSchemeAssociationKind.SEPARATOR);
+
+		final SubstanceColorScheme decorationsWatermarkScheme = schemes
+			.get("RuneLite Decorations Watermark");
+
+		this.registerDecorationAreaSchemeBundle(decorationsSchemeBundle, decorationsWatermarkScheme,
+			DecorationAreaType.TOOLBAR, DecorationAreaType.GENERAL, DecorationAreaType.FOOTER);
+
+		final SubstanceColorSchemeBundle headerSchemeBundle = new SubstanceColorSchemeBundle(activeScheme,
+			enabledScheme, enabledScheme);
+		headerSchemeBundle.registerColorScheme(enabledScheme, 0.5f,
+			ComponentState.DISABLED_UNSELECTED);
+
+		// borders
+		final SubstanceColorScheme headerBorderScheme = schemes.get("RuneLite Header Border");
+		headerSchemeBundle.registerColorScheme(borderDisabledSelectedScheme,
+			ColorSchemeAssociationKind.BORDER, ComponentState.DISABLED_SELECTED);
+		headerSchemeBundle.registerColorScheme(headerBorderScheme,
+			ColorSchemeAssociationKind.BORDER);
+		// marks
+		headerSchemeBundle.registerColorScheme(markActiveScheme, ColorSchemeAssociationKind.MARK,
+			ComponentState.getActiveStates());
+
+		headerSchemeBundle.registerHighlightColorScheme(activeScheme, 0.7f,
+			ComponentState.ROLLOVER_UNSELECTED, ComponentState.ROLLOVER_ARMED,
+			ComponentState.ARMED);
+		headerSchemeBundle.registerHighlightColorScheme(activeScheme, 0.8f,
+			ComponentState.SELECTED);
+		headerSchemeBundle.registerHighlightColorScheme(activeScheme, 1.0f,
+			ComponentState.ROLLOVER_SELECTED);
+
+		final SubstanceColorScheme headerWatermarkScheme = schemes.get("RuneLite Header Watermark");
+
+		this.registerDecorationAreaSchemeBundle(headerSchemeBundle, headerWatermarkScheme,
+			DecorationAreaType.PRIMARY_TITLE_PANE, DecorationAreaType.SECONDARY_TITLE_PANE,
+			DecorationAreaType.HEADER);
+
+		setTabFadeStart(0.2);
+		setTabFadeEnd(0.9);
+
+		// Add overlay painters to paint drop shadows along the bottom
+		// edges of toolbars and footers
+		this.addOverlayPainter(BottomShadowOverlayPainter.getInstance(),
+			DecorationAreaType.TOOLBAR);
+		this.addOverlayPainter(BottomShadowOverlayPainter.getInstance(), DecorationAreaType.FOOTER);
+
+		// add an overlay painter to paint a dark line along the bottom
+		// edge of toolbars
+		final BottomLineOverlayPainter toolbarBottomLineOverlayPainter = new BottomLineOverlayPainter(
+			(SubstanceColorScheme scheme) -> scheme.getUltraDarkColor().darker());
+		this.addOverlayPainter(toolbarBottomLineOverlayPainter, DecorationAreaType.TOOLBAR);
+
+		// add an overlay painter to paint a dark line along the bottom
+		// edge of toolbars
+		final TopLineOverlayPainter toolbarTopLineOverlayPainter = new TopLineOverlayPainter(
+			(SubstanceColorScheme scheme) -> SubstanceColorUtilities
+				.getAlphaColor(scheme.getForegroundColor(), 32));
+		this.addOverlayPainter(toolbarTopLineOverlayPainter, DecorationAreaType.TOOLBAR);
+
+		// add an overlay painter to paint a bezel line along the top
+		// edge of footer
+		final TopBezelOverlayPainter footerTopBezelOverlayPainter = new TopBezelOverlayPainter(
+			(SubstanceColorScheme scheme) -> scheme.getUltraDarkColor().darker(),
+			(SubstanceColorScheme scheme) -> SubstanceColorUtilities
+				.getAlphaColor(scheme.getForegroundColor(), 32));
+		this.addOverlayPainter(footerTopBezelOverlayPainter, DecorationAreaType.FOOTER);
+
+		this.setTabFadeStart(0.18);
+		this.setTabFadeEnd(0.18);
+
+		// Set button shaper to use "flat" design
+		this.buttonShaper = new ClassicButtonShaper()
+		{
+			@Override
+			public float getCornerRadius(AbstractButton button, float insets)
+			{
+				return 0;
+			}
+		};
+
+		this.watermark = null;
+		this.fillPainter = new FractionBasedFillPainter("RuneLite",
+			new float[]{0.0f, 0.5f, 1.0f},
+			new ColorSchemeSingleColorQuery[]{ColorSchemeSingleColorQuery.ULTRALIGHT,
+				ColorSchemeSingleColorQuery.LIGHT, ColorSchemeSingleColorQuery.LIGHT});
+		this.decorationPainter = new MatteDecorationPainter();
+		this.highlightPainter = new ClassicHighlightPainter();
+		this.borderPainter = new CompositeBorderPainter("RuneLite", new ClassicBorderPainter(),
+			new DelegateBorderPainter("RuneLite Inner", new ClassicBorderPainter(), 0x40FFFFFF,
+				0x20FFFFFF, 0x00FFFFFF,
+				(SubstanceColorScheme scheme) -> scheme.tint(0.2f)));
+	}
+
+	@Override
+	public String getDisplayName()
+	{
+		return NAME;
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/ui/skin/SubstanceRuneLiteLookAndFeel.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/skin/SubstanceRuneLiteLookAndFeel.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2018, Tomas Slusny <slusnucky@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.ui.skin;
+
+import org.pushingpixels.substance.api.SubstanceLookAndFeel;
+
+public class SubstanceRuneLiteLookAndFeel extends SubstanceLookAndFeel
+{
+	public SubstanceRuneLiteLookAndFeel()
+	{
+		super(new RuneLiteSkin());
+	}
+}

--- a/runelite-client/src/main/resources/net/runelite/client/ui/skin/RuneLite.colorschemes
+++ b/runelite-client/src/main/resources/net/runelite/client/ui/skin/RuneLite.colorschemes
@@ -1,0 +1,142 @@
+RuneLite Enabled {
+    kind=Dark
+    colorUltraLight=#232323
+    colorExtraLight=#232323
+    colorLight=#232323
+    colorMid=#232323
+    colorDark=#232323
+    colorUltraDark=#232323
+    colorForeground=#C6C6C6
+}
+
+RuneLite Active {
+    kind=Light
+    colorUltraLight=#DC8A00
+    colorExtraLight=#DC8A00
+    colorLight=#DC8A00
+    colorMid=#232323
+    colorDark=#232323
+    colorUltraDark=#232323
+    colorForeground=#000000
+}
+
+RuneLite Selected Disabled Border {
+	kind=Dark
+	colorUltraLight=#191919
+	colorExtraLight=#191919
+	colorLight=#191919
+	colorMid=#191919
+	colorDark=#191919
+	colorUltraDark=#191919
+	colorForeground=#C6C6C6
+}
+
+RuneLite Border {
+    kind=Dark
+    colorUltraLight=#191919
+    colorExtraLight=#191919
+    colorLight=#191919
+    colorMid=#191919
+    colorDark=#191919
+    colorUltraDark=#191919
+    colorForeground=#C6C6C6
+}
+
+RuneLite Tab Border {
+    kind=Light
+    colorUltraLight=#232323
+    colorExtraLight=#232323
+    colorLight=#232323
+    colorMid=#232323
+    colorDark=#232323
+    colorUltraDark=#232323
+    colorForeground=#232323
+}
+
+RuneLite Mark Active {
+    kind=Dark
+    colorUltraLight=#191919
+    colorExtraLight=#191919
+    colorLight=#191919
+    colorMid=#191919
+    colorDark=#191919
+    colorUltraDark=#191919
+    colorForeground=#191919
+}
+
+RuneLite Highlight {
+    kind=Light
+    colorUltraLight=#C6C6C6
+    colorExtraLight=#C6C6C6
+    colorLight=#C6C6C6
+    colorMid=#C6C6C6
+    colorDark=#C6C6C6
+    colorUltraDark=#C6C6C6
+    colorForeground=#191919
+}
+
+RuneLite Watermark {
+    kind=Light
+    colorUltraLight=#232323
+    colorExtraLight=#232323
+    colorLight=#232323
+    colorMid=#232323
+    colorDark=#232323
+    colorUltraDark=#232323
+    colorForeground=#C6C6C6
+}
+
+RuneLite Decorations Watermark {
+    kind=Light
+    colorUltraLight=#191919
+    colorExtraLight=#191919
+    colorLight=#191919
+    colorMid=#191919
+    colorDark=#191919
+    colorUltraDark=#191919
+    colorForeground=#C6C6C6
+}
+
+RuneLite Separator {
+    kind=Dark
+    colorUltraLight=#232323
+    colorExtraLight=#232323
+    colorLight=#232323
+    colorMid=#232323
+    colorDark=#232323
+    colorUltraDark=#232323
+    colorForeground=#232323
+}
+
+RuneLite Decorations Separator {
+    kind=Dark
+    colorUltraLight=#232323
+    colorExtraLight=#232323
+    colorLight=#232323
+    colorMid=#232323
+    colorDark=#232323
+    colorUltraDark=#232323
+    colorForeground=#232323
+}
+
+RuneLite Header Watermark {
+    kind=Dark
+    colorUltraLight=#000000
+    colorExtraLight=#000000
+    colorLight=#000000
+    colorMid=#000000
+    colorDark=#000000
+    colorUltraDark=#000000
+    colorForeground=#C6C6C6
+}
+
+RuneLite Header Border {
+    kind=Dark
+    colorUltraLight=#000000
+    colorExtraLight=#000000
+    colorLight=#000000
+    colorMid=#000000
+    colorDark=#000000
+    colorUltraDark=#000000
+    colorForeground=#C6C6C6
+}


### PR DESCRIPTION
Add new Substance Twillight-based color scheme with dark color as main
and orange as highlight color. The color scheme is based on
https://github.com/runelite/runelite.net/issues/44.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>

Preview:
![2018-04-08_17-45-18](https://user-images.githubusercontent.com/5115805/38469542-b6e7f446-3b56-11e8-918b-b9f872f7efae.png)

![2018-04-08_17-46-05](https://user-images.githubusercontent.com/5115805/38469543-b71aaee0-3b56-11e8-9fac-59d1b1641178.png)

