### PR TITLE
tooltips: hug edge of screen instead of jumping

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/tooltip/TooltipOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/tooltip/TooltipOverlay.java
@@ -90,7 +90,7 @@ public class TooltipOverlay extends Overlay
 
 			if (boundsX > clientX)
 			{
-				graphics.translate(-bounds.width, 0);
+				graphics.translate(-bounds.width + clientCanvasBounds.width - bounds.x, 0);
 			}
 		}
 


### PR DESCRIPTION
This is more noticeable for larger tooltips, but changing this feels more natural in general.
Before:
![ezgif-5-c6dca4e7ac](https://user-images.githubusercontent.com/2388657/38471033-895397dc-3b39-11e8-801d-5c00f9d43312.gif)

After:
![ezgif-5-a5f48e238e](https://user-images.githubusercontent.com/2388657/38471034-900942a2-3b39-11e8-8d98-c3c618b14479.gif)
