### PR TITLE
Remove "teleport" and "cast bloom" swapping

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -169,28 +169,17 @@ public interface MenuEntrySwapperConfig extends Config
 
 	@ConfigItem(
 		position = 12,
-		keyName = "swapSilverSickle",
-		name = "Silver sickle(b)",
-		description = "Swap Wield with Cast Bloom on Silver sickle(b)"
-	)
-	default boolean swapSilverSickle()
-	{
-		return true;
-	}
-
-	@ConfigItem(
-		position = 13,
 		keyName = "swapTeleportItem",
 		name = "Teleport item",
 		description = "Swap Wear, Wield with Rub, Teleport on teleport item<br>Example: Amulet of glory, Ardougne cloak, Chronicle"
 	)
 	default boolean swapTeleportItem()
 	{
-		return true;
+		return false;
 	}
 
 	@ConfigItem(
-		position = 14,
+		position = 13,
 		keyName = "swapTrade",
 		name = "Trade",
 		description = "Swap Talk-to with Trade on NPC<br>Example: Shop keeper, Shop assistant"
@@ -201,7 +190,7 @@ public interface MenuEntrySwapperConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 15,
+		position = 14,
 		keyName = "swapTravel",
 		name = "Travel",
 		description = "Swap Talk-to with Travel, Take-boat, Pay-fare, Charter on NPC<br>Example: Squire, Monk of Entrana, Customs officer, Trader Crewmember"

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -392,6 +392,20 @@ public class MenuEntrySwapperPlugin extends Plugin
 		{
 			swap("investigate", option, target, true);
 		}
+		else if (config.swapBones() && option.equals("bury"))
+		{
+			swap("chase", option, target, true);
+		}
+		else if (config.shiftClickCustomization() && shiftModifier && !option.equals("use"))
+		{
+			Integer customOption = getSwapConfig(itemId);
+
+			if (customOption != null && customOption == -1)
+			{
+				swap("use", option, target, true);
+			}
+		}
+		// Put all item-related swapping after shift-click
 		else if (config.swapTeleportItem() && option.equals("wear"))
 		{
 			swap("rub", option, target, true);
@@ -407,19 +421,6 @@ public class MenuEntrySwapperPlugin extends Plugin
 		else if (config.swapBones() && option.equals("bury"))
 		{
 			swap("use", option, target, true);
-		}
-		else if (config.shiftClickCustomization() && shiftModifier && !option.equals("use"))
-		{
-			Integer customOption = getSwapConfig(itemId);
-
-			if (customOption != null && customOption == -1)
-			{
-				swap("use", option, target, true);
-			}
-		}
-		else if (config.swapChase() && option.equals("pick-up"))
-		{
-			swap("chase", option, target, true);
 		}
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -403,11 +403,6 @@ public class MenuEntrySwapperPlugin extends Plugin
 			{
 				swap("teleport", option, target, true);
 			}
-
-			if (config.swapSilverSickle())
-			{
-				swap("cast bloom", option, target, true);
-			}
 		}
 		else if (config.swapBones() && option.equals("bury"))
 		{


### PR DESCRIPTION
Remove both "teleport" and "cast bloom" menu entry swapping from menu
entry swapper plugin as they both can be done with shift-click
customization, and usually the teleport and wear option is not wanted to
be swapped.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>