### PR TITLE
Add link to web XP tracker to XP panel

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpInfoBox.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpInfoBox.java
@@ -40,7 +40,9 @@ import javax.swing.ImageIcon;
 import javax.swing.JButton;
 import javax.swing.JLabel;
 import javax.swing.JLayeredPane;
+import javax.swing.JMenuItem;
 import javax.swing.JPanel;
+import javax.swing.JPopupMenu;
 import javax.swing.JProgressBar;
 import javax.swing.SwingConstants;
 import javax.swing.SwingUtilities;
@@ -53,6 +55,7 @@ import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.client.game.SkillIconManager;
 import net.runelite.client.ui.JShadowedLabel;
+import net.runelite.client.util.LinkBrowser;
 import org.pushingpixels.substance.internal.SubstanceSynapse;
 
 @Slf4j
@@ -66,17 +69,13 @@ class XpInfoBox extends JPanel
 	private final SkillXPInfo xpInfo;
 
 	private final JPanel container = new JPanel();
-
-	private final JPanel iconBarPanel = new JPanel();
 	private final JPanel statsPanel = new JPanel();
-
 	private final JProgressBar progressBar = new JProgressBar();
 	private final JLabel xpHr = new JLabel();
 	private final JLabel xpGained = new JLabel();
 	private final JLabel xpLeft = new JLabel();
 	private final JLabel actionsLeft = new JLabel();
 	private final JLabel levelLabel = new JShadowedLabel();
-	private final JButton skillIcon = new JButton();
 
 	XpInfoBox(Client client, JPanel panel, SkillXPInfo xpInfo, SkillIconManager iconManager) throws IOException
 	{
@@ -109,7 +108,10 @@ class XpInfoBox extends JPanel
 			@Override
 			public void mouseReleased(MouseEvent e)
 			{
-				showStatsPanel();
+				if (SwingUtilities.isLeftMouseButton(e))
+				{
+					showStatsPanel();
+				}
 			}
 		};
 
@@ -117,11 +119,23 @@ class XpInfoBox extends JPanel
 		container.setBorder(new EmptyBorder(5, 5, 5, 5));
 		container.addMouseListener(panelMouseListener);
 
+		// Create open xp tracker menu
+		final JMenuItem openXpTracker = new JMenuItem("Open XP tracker");
+		openXpTracker.addActionListener(e -> LinkBrowser.browse(XpPanel.buildXpTrackerUrl(client.getLocalPlayer(), xpInfo.getSkill())));
+
+		// Create popup menu
+		final JPopupMenu popupMenu = new JPopupMenu();
+		popupMenu.add(openXpTracker);
+		container.setComponentPopupMenu(popupMenu);
+
+		// Create icon panel
+		final JPanel iconBarPanel = new JPanel();
 		iconBarPanel.setLayout(new BorderLayout(5, 0));
 		iconBarPanel.setOpaque(false);
 
 		// Create skill/reset icon
 		final BufferedImage skillImage = iconManager.getSkillImage(xpInfo.getSkill());
+		final JButton skillIcon = new JButton();
 		skillIcon.putClientProperty(SubstanceSynapse.FLAT_LOOK, Boolean.TRUE);
 		skillIcon.putClientProperty(SubstanceSynapse.BUTTON_NEVER_PAINT_BACKGROUND, Boolean.TRUE);
 		skillIcon.setIcon(new ImageIcon(skillImage));

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpPanel.java
@@ -37,15 +37,24 @@ import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.SwingUtilities;
 import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.Actor;
 import net.runelite.api.Client;
 import net.runelite.api.Skill;
 import net.runelite.client.game.SkillIconManager;
 import net.runelite.client.ui.PluginPanel;
+import net.runelite.client.util.LinkBrowser;
 import net.runelite.client.util.StackFormatter;
+import okhttp3.HttpUrl;
 
 @Slf4j
 class XpPanel extends PluginPanel
 {
+	private static final HttpUrl.Builder XP_TRACKER_FORMAT = new HttpUrl.Builder()
+		.scheme("https")
+		.host("runelite.net")
+		.addPathSegment("xp")
+		.addPathSegment("show");
+
 	private final Map<Skill, XpInfoBox> infoBoxes = new HashMap<>();
 	private final JLabel totalXpGained = new JLabel();
 	private final JLabel totalXpHr = new JLabel();
@@ -63,11 +72,14 @@ class XpPanel extends PluginPanel
 		totalPanel.setBorder(BorderFactory.createLineBorder(getBackground().brighter(), 1, true));
 
 		final JPanel infoPanel = new JPanel();
-		infoPanel.setLayout(new GridLayout(3, 1));
+		infoPanel.setLayout(new GridLayout(4, 1));
 		infoPanel.setBorder(BorderFactory.createEmptyBorder(3, 3, 3, 3));
 
 		final JButton resetButton = new JButton("Reset All");
 		resetButton.addActionListener(e -> resetAllInfoBoxes());
+
+		final JButton openTrackerButton = new JButton("Open XP tracker");
+		openTrackerButton.addActionListener(e -> LinkBrowser.browse(buildXpTrackerUrl(client.getLocalPlayer(), Skill.OVERALL)));
 
 		totalXpGained.setText(formatLine(0, "total xp gained"));
 		totalXpHr.setText(formatLine(0, "total xp/hr"));
@@ -75,6 +87,7 @@ class XpPanel extends PluginPanel
 		infoPanel.add(totalXpGained);
 		infoPanel.add(totalXpHr);
 		infoPanel.add(resetButton);
+		infoPanel.add(openTrackerButton);
 		totalPanel.add(infoPanel, BorderLayout.CENTER);
 		layoutPanel.add(totalPanel, BorderLayout.NORTH);
 
@@ -98,6 +111,22 @@ class XpPanel extends PluginPanel
 		{
 			log.warn(null, e);
 		}
+	}
+
+	static String buildXpTrackerUrl(final Actor player, final Skill skill)
+	{
+		if (player == null)
+		{
+			return "";
+		}
+
+		return XP_TRACKER_FORMAT
+			.addPathSegment(skill.getName().toLowerCase())
+			.addPathSegment(player.getName())
+			.addPathSegment("1week")
+			.addPathSegment("now")
+			.build()
+			.toString();
 	}
 
 	void resetAllInfoBoxes()

--- a/runelite-client/src/main/java/net/runelite/client/util/LinkBrowser.java
+++ b/runelite-client/src/main/java/net/runelite/client/util/LinkBrowser.java
@@ -24,6 +24,7 @@
  */
 package net.runelite.client.util;
 
+import com.google.common.base.Strings;
 import java.awt.Desktop;
 import java.awt.Toolkit;
 import java.awt.datatransfer.StringSelection;
@@ -50,6 +51,11 @@ public class LinkBrowser
 	 */
 	public static boolean browse(final String url)
 	{
+		if (Strings.isNullOrEmpty(url))
+		{
+			return false;
+		}
+
 		if (!Desktop.isDesktopSupported())
 		{
 			showMessageBox("Desktop is not supported. Press 'OK' and link will be copied to your clipboard.", url);


### PR DESCRIPTION
- Add "overall" link to the top of the XP panel that will link logged in
user to the website XP tracker showing his overall gains in 1 week
- Add right click menu to open XP tracker for each skill, same rules as
in "overall"

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>

Preview:
![peek 2018-04-09 14-51](https://user-images.githubusercontent.com/5115805/38498829-f2bfd39e-3c05-11e8-9b24-8deca06d3ffb.gif)