### PR TITLE
Fix XP Drop plugin recolouring ALL drops whenever a combat prayer is enabled

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/SpriteID.java
+++ b/runelite-api/src/main/java/net/runelite/api/SpriteID.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Lotto <https://github.com/devLotto>
+ * Copyright (c) 2018, Lotto <https://github.com/devLotto>, SoyChai <https://github.com/SoyChai>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -28,6 +28,32 @@ package net.runelite.api;
 // through the cache and widget inspector. Please add sprites as you happen to use them.
 public final class SpriteID
 {
+	public static final int SKILL_ATTACK = 197;
+	public static final int SKILL_STRENGTH = 198;
+	public static final int SKILL_DEFENCE = 199;
+	public static final int SKILL_RANGED = 200;
+	public static final int SKILL_PRAYER = 201;
+	public static final int SKILL_MAGIC = 202;
+	public static final int SKILL_HITPOINTS = 203;
+	public static final int SKILL_AGILITY = 204;
+	public static final int SKILL_HERBLORE = 205;
+	public static final int SKILL_THIEVING = 206;
+	public static final int SKILL_CRAFTING = 207;
+	public static final int SKILL_FLETCHING = 208;
+	public static final int SKILL_MINING = 209;
+	public static final int SKILL_SMITHING = 210;
+	public static final int SKILL_FISHING = 211;
+	public static final int SKILL_COOKING = 212;
+	public static final int SKILL_FIREMAKING = 213;
+	public static final int SKILL_WOODCUTTING = 214;
+	public static final int SKILL_RUNECRAFT = 215;
+	public static final int SKILL_SLAYER = 216;
+	public static final int SKILL_FARMING = 217;
+	public static final int UNKNOWN_SHOVEL = 218;
+	public static final int UNKNOWN_RAT = 219;
+	public static final int SKILL_HUNTER = 220;
+	public static final int SKILL_CONSTRUCTION = 221;
+	public static final int SKILL_TOTAL_XP = 222;
 	public static final int EMOTE_YES = 700;
 	public static final int EMOTE_NO = 701;
 	public static final int EMOTE_THINK = 702;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/experiencedrop/XpDropPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/experiencedrop/XpDropPlugin.java
@@ -26,6 +26,8 @@ package net.runelite.client.plugins.experiencedrop;
 
 import com.google.common.eventbus.Subscribe;
 import com.google.inject.Provides;
+import java.util.Arrays;
+import java.util.stream.IntStream;
 import javax.inject.Inject;
 import net.runelite.api.Client;
 import net.runelite.api.SpriteID;
@@ -37,11 +39,6 @@ import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
-
-import java.util.Arrays;
-import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 @PluginDescriptor(
 	name = "XP Drop"
@@ -91,8 +88,8 @@ public class XpDropPlugin extends Plugin
 		}
 
 		String text = widget.getText();
-		final Stream<Widget> siblingWidgets = Arrays.stream(widget.getParent().getDynamicChildren());
-		final List<Integer> spriteIDs = siblingWidgets.map(Widget::getSpriteId).collect(Collectors.toList());
+		final IntStream spriteIDs =
+			Arrays.stream(widget.getParent().getDynamicChildren()).mapToInt(Widget::getSpriteId);
 
 		if (text != null)
 		{
@@ -101,21 +98,20 @@ public class XpDropPlugin extends Plugin
 			switch (prayer)
 			{
 				case MELEE:
-					if (spriteIDs.contains(SpriteID.SKILL_ATTACK)
-						|| spriteIDs.contains(SpriteID.SKILL_STRENGTH)
-						|| spriteIDs.contains(SpriteID.SKILL_DEFENCE))
+					if (spriteIDs.anyMatch(id ->
+						id == SpriteID.SKILL_ATTACK || id == SpriteID.SKILL_STRENGTH || id == SpriteID.SKILL_DEFENCE))
 					{
 						color = config.getMeleePrayerColor().getRGB();
 					}
 					break;
 				case RANGE:
-					if (spriteIDs.contains(SpriteID.SKILL_RANGED))
+					if (spriteIDs.anyMatch(id -> id == SpriteID.SKILL_RANGED))
 					{
 						color = config.getRangePrayerColor().getRGB();
 					}
 					break;
 				case MAGIC:
-					if (spriteIDs.contains(SpriteID.SKILL_MAGIC))
+					if (spriteIDs.anyMatch(id -> id == SpriteID.SKILL_MAGIC))
 					{
 						color = config.getMagePrayerColor().getRGB();
 					}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/experiencedrop/XpDropPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/experiencedrop/XpDropPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Cameron <https://github.com/noremac201>
+ * Copyright (c) 2018, Cameron <https://github.com/noremac201>, SoyChai <https://github.com/SoyChai>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -28,6 +28,7 @@ import com.google.common.eventbus.Subscribe;
 import com.google.inject.Provides;
 import javax.inject.Inject;
 import net.runelite.api.Client;
+import net.runelite.api.SpriteID;
 import net.runelite.api.Varbits;
 import net.runelite.api.events.WidgetHiddenChanged;
 import net.runelite.api.widgets.Widget;
@@ -36,6 +37,11 @@ import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @PluginDescriptor(
 	name = "XP Drop"
@@ -85,20 +91,38 @@ public class XpDropPlugin extends Plugin
 		}
 
 		String text = widget.getText();
+		final Stream<Widget> siblingWidgets = Arrays.stream(widget.getParent().getDynamicChildren());
+		final List<Integer> spriteIDs = siblingWidgets.map(Widget::getSpriteId).collect(Collectors.toList());
+
 		if (text != null)
 		{
+			int color = widget.getTextColor();
+
 			switch (prayer)
 			{
 				case MELEE:
-					widget.setTextColor(config.getMeleePrayerColor().getRGB());
+					if (spriteIDs.contains(SpriteID.SKILL_ATTACK)
+						|| spriteIDs.contains(SpriteID.SKILL_STRENGTH)
+						|| spriteIDs.contains(SpriteID.SKILL_DEFENCE))
+					{
+						color = config.getMeleePrayerColor().getRGB();
+					}
 					break;
 				case RANGE:
-					widget.setTextColor(config.getRangePrayerColor().getRGB());
+					if (spriteIDs.contains(SpriteID.SKILL_RANGED))
+					{
+						color = config.getRangePrayerColor().getRGB();
+					}
 					break;
 				case MAGIC:
-					widget.setTextColor(config.getMagePrayerColor().getRGB());
+					if (spriteIDs.contains(SpriteID.SKILL_MAGIC))
+					{
+						color = config.getMagePrayerColor().getRGB();
+					}
 					break;
 			}
+
+			widget.setTextColor(color);
 		}
 	}
 


### PR DESCRIPTION
This fixes #555.

Plugin wasn't actually checking whether the XP drop widgets were for the relevant combat skill before recolouring them, so I've added their SpriteIDs to verify the skill icons as they appear.

Both grouped and ungrouped XP drops work as expected now.