### PR TITLE
Reset XP on log-in of another character / mode

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerPlugin.java
@@ -153,6 +153,7 @@ public class XpTrackerPlugin extends Plugin
 				lastUsername = client.getUsername();
 				lastWorldType = type;
 				xpPanel.resetAllInfoBoxes();
+				xpInfos.clear();
 			}
 		}
 		else if (event.getGameState() == GameState.LOGIN_SCREEN)


### PR DESCRIPTION
Fix #1273

Upon logging into a new character or world mode (which has different XPs) we clear the info boxes in the panel.
Yet we forget to clear the data that powers those boxes. 

Simple, clear the data AND the ui.