### PR TITLE
Revert "Reset XP on log-in of another character / mode"

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerPlugin.java
@@ -153,7 +153,6 @@ public class XpTrackerPlugin extends Plugin
 				lastUsername = client.getUsername();
 				lastWorldType = type;
 				xpPanel.resetAllInfoBoxes();
-				xpInfos.clear();
 			}
 		}
 		else if (event.getGameState() == GameState.LOGIN_SCREEN)


### PR DESCRIPTION
This PR created bug that prevents XP tracker from tracking anything. Unless the bug will be solved, the PR should be reverted. @LeviSchuck 