### PR TITLE
Apply small font option only to dynamic overlays

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/config/RuneLiteConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/RuneLiteConfig.java
@@ -119,11 +119,11 @@ public interface RuneLiteConfig extends Config
 
 	@ConfigItem(
 		keyName = "useSmallFont",
-		name = "Use smaller font for in-game overlays",
+		name = "Small font in dynamic overlays",
 		description = "Toggles between small and regular RuneScape font for in-game overlays"
 	)
 	default boolean useSmallFont()
 	{
-		return false;
+		return true;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayRenderer.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayRenderer.java
@@ -281,12 +281,6 @@ public class OverlayRenderer extends MouseListener implements KeyListener
 
 		// Create copy of snap corners because overlays will modify them
 		OverlayBounds snapCorners = new OverlayBounds(this.snapCorners);
-
-		// Set font based on configuration
-		graphics.setFont(runeLiteConfig.useSmallFont()
-			? FontManager.getRunescapeSmallFont()
-			: FontManager.getRunescapeFont());
-
 		OverlayUtil.setGraphicProperties(graphics);
 
 		// Draw snap corners
@@ -500,6 +494,7 @@ public class OverlayRenderer extends MouseListener implements KeyListener
 	private void safeRender(Client client, Overlay overlay, OverlayLayer layer, Graphics2D graphics, Point point)
 	{
 		final Graphics2D subGraphics = (Graphics2D) graphics.create();
+
 		if (!isResizeable && (layer == OverlayLayer.ABOVE_SCENE || layer == OverlayLayer.UNDER_WIDGETS))
 		{
 			subGraphics.setClip(client.getViewportXOffset(),
@@ -507,6 +502,16 @@ public class OverlayRenderer extends MouseListener implements KeyListener
 				client.getViewportWidth(),
 				client.getViewportHeight());
 		}
+
+		final OverlayPosition position = overlay.getPosition();
+
+		// Set font based on configuration
+		subGraphics.setFont((position == OverlayPosition.DYNAMIC
+			|| position == OverlayPosition.TOOLTIP)
+			&& runeLiteConfig.useSmallFont()
+			? FontManager.getRunescapeSmallFont()
+			: FontManager.getRunescapeFont());
+
 		subGraphics.translate(point.x, point.y);
 		final Dimension dimension = MoreObjects.firstNonNull(overlay.render(subGraphics), new Dimension());
 		subGraphics.dispose();


### PR DESCRIPTION
Instead of applying this configuration option to both layouted overlays
that are supposed to follow XP tracker layout 1 to 1, apply this setting
only for dynamic overlays and tooltsip (e.g mouse highlighting, ground
items, player names).

Closes: #1288

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>