### PR TITLE
Change the initial tooltip delay to 300ms

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/util/SwingUtil.java
+++ b/runelite-client/src/main/java/net/runelite/client/util/SwingUtil.java
@@ -74,10 +74,15 @@ public class SwingUtil
 	 */
 	public static void setupDefaults()
 	{
+		final ToolTipManager toolTipManager = ToolTipManager.sharedInstance();
+
 		// Force heavy-weight popups/tooltips.
 		// Prevents them from being obscured by the game applet.
-		ToolTipManager.sharedInstance().setLightWeightPopupEnabled(false);
+		toolTipManager.setLightWeightPopupEnabled(false);
 		JPopupMenu.setDefaultLightWeightPopupEnabled(false);
+
+		// Set tooltip delay to something useful
+		toolTipManager.setInitialDelay(300);
 
 		// Do not render shadows under popups/tooltips.
 		// Fixes black boxes under popups that are above the game applet.


### PR DESCRIPTION
Currently, it takes ages before the tooltip will show, so change it to
something more useful.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>

Preview:
![peek 2018-04-10 23-09](https://user-images.githubusercontent.com/5115805/38583814-81145f5c-3d14-11e8-9985-d3b084d74558.gif)