### PR TITLE
Add tooltips when pressing ALT for searching the GE

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangeInputListener.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangeInputListener.java
@@ -24,6 +24,7 @@
  */
 package net.runelite.client.plugins.grandexchange;
 
+import java.awt.event.KeyEvent;
 import java.awt.event.MouseEvent;
 import javax.inject.Inject;
 import javax.swing.SwingUtilities;
@@ -35,9 +36,10 @@ import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.api.widgets.WidgetItem;
 import net.runelite.client.game.ItemManager;
+import net.runelite.client.input.KeyListener;
 import net.runelite.client.input.MouseListener;
 
-public class GrandExchangeInputListener extends MouseListener
+public class GrandExchangeInputListener extends MouseListener implements KeyListener
 {
 	private final Client client;
 	private final GrandExchangePlugin plugin;
@@ -141,5 +143,29 @@ public class GrandExchangeInputListener extends MouseListener
 
 			plugin.getPanel().getSearchPanel().priceLookup(itemComposition.getName());
 		});
+	}
+
+	@Override
+	public void keyTyped(KeyEvent e)
+	{
+
+	}
+
+	@Override
+	public void keyPressed(KeyEvent e)
+	{
+		if (e.isAltDown())
+		{
+			plugin.setHotKeyPressed(true);
+		}
+	}
+
+	@Override
+	public void keyReleased(KeyEvent e)
+	{
+		if (!e.isAltDown())
+		{
+			plugin.setHotKeyPressed(false);
+		}
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangeInputListener.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangeInputListener.java
@@ -38,19 +38,23 @@ import net.runelite.api.widgets.WidgetItem;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.input.KeyListener;
 import net.runelite.client.input.MouseListener;
+import net.runelite.client.util.QueryRunner;
 
 public class GrandExchangeInputListener extends MouseListener implements KeyListener
 {
 	private final Client client;
 	private final GrandExchangePlugin plugin;
 	private final ItemManager itemManager;
+	private final QueryRunner queryRunner;
 
 	@Inject
-	GrandExchangeInputListener(Client client, GrandExchangePlugin plugin, ItemManager itemManager)
+	GrandExchangeInputListener(Client client, GrandExchangePlugin plugin, ItemManager itemManager,
+		QueryRunner queryRunner)
 	{
 		this.client = client;
 		this.plugin = plugin;
 		this.itemManager = itemManager;
+		this.queryRunner = queryRunner;
 	}
 
 	@Override
@@ -84,7 +88,8 @@ public class GrandExchangeInputListener extends MouseListener implements KeyList
 			if (bankWidget != null && !bankWidget.isHidden())
 			{
 				// Use bank item query for only checking the active tab
-				if (findAndSearch(new BankItemQuery().result(client)))
+				WidgetItem[] items = queryRunner.runQuery(new BankItemQuery());
+				if (findAndSearch(items))
 				{
 					e.consume();
 					return super.mouseClicked(e);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangeInputListener.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangeInputListener.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2018, Jeremy Plsek <https://github.com/jplsek>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *	list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *	this list of conditions and the following disclaimer in the documentation
+ *	and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.grandexchange;
+
+import java.awt.event.MouseEvent;
+import javax.inject.Inject;
+import javax.swing.SwingUtilities;
+import net.runelite.api.Client;
+import net.runelite.api.ItemComposition;
+import net.runelite.api.Point;
+import net.runelite.api.queries.BankItemQuery;
+import net.runelite.api.widgets.Widget;
+import net.runelite.api.widgets.WidgetInfo;
+import net.runelite.api.widgets.WidgetItem;
+import net.runelite.client.game.ItemManager;
+import net.runelite.client.input.MouseListener;
+
+public class GrandExchangeInputListener extends MouseListener
+{
+	private final Client client;
+	private final GrandExchangePlugin plugin;
+	private final ItemManager itemManager;
+
+	@Inject
+	GrandExchangeInputListener(Client client, GrandExchangePlugin plugin, ItemManager itemManager)
+	{
+		this.client = client;
+		this.plugin = plugin;
+		this.itemManager = itemManager;
+	}
+
+	@Override
+	public MouseEvent mouseClicked(MouseEvent e)
+	{
+		// Check if left click + alt
+		if (e.getButton() == MouseEvent.BUTTON1 && e.isAltDown())
+		{
+			Widget inventoryWidget = client.getWidget(WidgetInfo.INVENTORY);
+			if (inventoryWidget != null && !inventoryWidget.isHidden())
+			{
+				if (findAndSearch(inventoryWidget.getWidgetItems().toArray(new WidgetItem[0])))
+				{
+					e.consume();
+					return super.mouseClicked(e);
+				}
+			}
+
+			// Check the inventory when the bank is open aswell
+			Widget bankInventoryWidget = client.getWidget(WidgetInfo.BANK_INVENTORY_ITEMS_CONTAINER);
+			if (bankInventoryWidget != null && !bankInventoryWidget.isHidden())
+			{
+				if (findAndSearch(bankInventoryWidget.getDynamicChildren()))
+				{
+					e.consume();
+					return super.mouseClicked(e);
+				}
+			}
+
+			Widget bankWidget = client.getWidget(WidgetInfo.BANK_ITEM_CONTAINER);
+			if (bankWidget != null && !bankWidget.isHidden())
+			{
+				// Use bank item query for only checking the active tab
+				if (findAndSearch(new BankItemQuery().result(client)))
+				{
+					e.consume();
+					return super.mouseClicked(e);
+				}
+			}
+		}
+
+		return super.mouseClicked(e);
+	}
+
+	private boolean findAndSearch(Widget[] widgets)
+	{
+		Point mousePosition = client.getMouseCanvasPosition();
+		for (Widget widget : widgets)
+		{
+			if (widget.getBounds().contains(mousePosition.getX(), mousePosition.getY()))
+			{
+				ItemComposition itemComposition = itemManager.getItemComposition(widget.getItemId());
+				search(itemComposition);
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Finds the item clicked based on the mouse location
+	 * @param items
+	 * @return true if an item is found, false otherwise
+	 */
+	private boolean findAndSearch(WidgetItem[] items)
+	{
+		Point mousePosition = client.getMouseCanvasPosition();
+		for (WidgetItem item : items)
+		{
+			if (item.getCanvasBounds().contains(mousePosition.getX(), mousePosition.getY()))
+			{
+				ItemComposition itemComposition = itemManager.getItemComposition(item.getId());
+				search(itemComposition);
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private void search(ItemComposition itemComposition)
+	{
+		SwingUtilities.invokeLater(() ->
+		{
+			plugin.getPanel().showSearch();
+
+			if (!plugin.getButton().isSelected())
+			{
+				plugin.getButton().getOnSelect().run();
+			}
+
+			plugin.getPanel().getSearchPanel().priceLookup(itemComposition.getName());
+		});
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangePlugin.java
@@ -29,25 +29,20 @@ package net.runelite.client.plugins.grandexchange;
 
 import com.google.common.eventbus.Subscribe;
 import com.google.inject.Provides;
-import java.awt.event.MouseEvent;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
 import javax.imageio.ImageIO;
 import javax.inject.Inject;
 import javax.swing.SwingUtilities;
+import lombok.AccessLevel;
+import lombok.Getter;
 import net.runelite.api.Client;
 import net.runelite.api.GrandExchangeOffer;
 import net.runelite.api.ItemComposition;
-import net.runelite.api.Point;
 import net.runelite.api.events.ConfigChanged;
 import net.runelite.api.events.GrandExchangeOfferChanged;
-import net.runelite.api.queries.BankItemQuery;
-import net.runelite.api.widgets.Widget;
-import net.runelite.api.widgets.WidgetInfo;
-import net.runelite.api.widgets.WidgetItem;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.game.ItemManager;
-import net.runelite.client.input.MouseListener;
 import net.runelite.client.input.MouseManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
@@ -59,11 +54,14 @@ import net.runelite.client.ui.PluginToolbar;
 )
 public class GrandExchangePlugin extends Plugin
 {
+	@Getter(AccessLevel.PACKAGE)
 	private NavigationButton button;
 
+	@Getter(AccessLevel.PACKAGE)
 	private GrandExchangePanel panel;
 
-	private MouseListener itemClick;
+	@Inject
+	private GrandExchangeInputListener inputListener;
 
 	@Inject
 	private ItemManager itemManager;
@@ -105,104 +103,9 @@ public class GrandExchangePlugin extends Plugin
 
 		pluginToolbar.addNavigation(button);
 
-		itemClick = new MouseListener()
-		{
-			@Override
-			public MouseEvent mouseClicked(MouseEvent e)
-			{
-				// Check if left click + alt
-				if (e.getButton() == MouseEvent.BUTTON1 && e.isAltDown())
-				{
-					Widget inventoryWidget = client.getWidget(WidgetInfo.INVENTORY);
-					if (inventoryWidget != null && !inventoryWidget.isHidden())
-					{
-						if (findAndSearch(inventoryWidget.getWidgetItems().toArray(new WidgetItem[0])))
-						{
-							e.consume();
-							return super.mouseClicked(e);
-						}
-					}
-
-					// Check the inventory when the bank is open aswell
-					Widget bankInventoryWidget = client.getWidget(WidgetInfo.BANK_INVENTORY_ITEMS_CONTAINER);
-					if (bankInventoryWidget != null && !bankInventoryWidget.isHidden())
-					{
-						if (findAndSearch(bankInventoryWidget.getDynamicChildren()))
-						{
-							e.consume();
-							return super.mouseClicked(e);
-						}
-					}
-
-					Widget bankWidget = client.getWidget(WidgetInfo.BANK_ITEM_CONTAINER);
-					if (bankWidget != null && !bankWidget.isHidden())
-					{
-						// Use bank item query for only checking the active tab
-						if (findAndSearch(new BankItemQuery().result(client)))
-						{
-							e.consume();
-							return super.mouseClicked(e);
-						}
-					}
-				}
-
-				return super.mouseClicked(e);
-			}
-
-			private boolean findAndSearch(Widget[] widgets)
-			{
-				Point mousePosition = client.getMouseCanvasPosition();
-				for (Widget widget : widgets)
-				{
-					if (widget.getBounds().contains(mousePosition.getX(), mousePosition.getY()))
-					{
-						ItemComposition itemComposition = itemManager.getItemComposition(widget.getItemId());
-						search(itemComposition);
-						return true;
-					}
-				}
-				return false;
-			}
-
-			/**
-			 * Finds the item clicked based on the mouse location
-			 * @param items
-			 * @return true if an item is found, false otherwise
-			 */
-			private boolean findAndSearch(WidgetItem[] items)
-			{
-				Point mousePosition = client.getMouseCanvasPosition();
-				for (WidgetItem item : items)
-				{
-					if (item.getCanvasBounds().contains(mousePosition.getX(), mousePosition.getY()))
-					{
-						ItemComposition itemComposition = itemManager.getItemComposition(item.getId());
-						search(itemComposition);
-						return true;
-					}
-				}
-				return false;
-			}
-
-			private void search(ItemComposition itemComposition)
-			{
-				SwingUtilities.invokeLater(() ->
-				{
-					panel.showSearch();
-
-					if (!button.isSelected())
-					{
-						button.getOnSelect().run();
-					}
-
-					panel.getSearchPanel().priceLookup(itemComposition.getName());
-				});
-			}
-		};
-
 		if (config.quickLookup())
 		{
-			mouseManager.registerMouseListener(itemClick);
+			mouseManager.registerMouseListener(inputListener);
 		}
 	}
 
@@ -210,7 +113,7 @@ public class GrandExchangePlugin extends Plugin
 	protected void shutDown()
 	{
 		pluginToolbar.removeNavigation(button);
-		mouseManager.unregisterMouseListener(itemClick);
+		mouseManager.unregisterMouseListener(inputListener);
 	}
 
 	@Subscribe
@@ -222,11 +125,11 @@ public class GrandExchangePlugin extends Plugin
 			{
 				if (config.quickLookup())
 				{
-					mouseManager.registerMouseListener(itemClick);
+					mouseManager.registerMouseListener(inputListener);
 				}
 				else
 				{
-					mouseManager.unregisterMouseListener(itemClick);
+					mouseManager.unregisterMouseListener(inputListener);
 				}
 			}
 		}


### PR DESCRIPTION
Note: This does not "add" a tooltip, but instead replaces the default action.

Since clicking while holding ALT searches the GE, update the default action so the player can discover that the functionality exists.

Example:
![ezgif-5-a863b71cb7](https://user-images.githubusercontent.com/2388657/38589121-4882369a-3cf7-11e8-83d9-8b5c9f3019b8.gif)

Depends on #1319.

I'll probably rebase if PR #1319 gets merged.
