### PR TITLE
Redo XP Tracking data structures

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpInfoBox.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpInfoBox.java
@@ -49,10 +49,9 @@ import javax.swing.SwingUtilities;
 import javax.swing.border.CompoundBorder;
 import javax.swing.border.EmptyBorder;
 import javax.swing.border.LineBorder;
-import lombok.AccessLevel;
-import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
+import net.runelite.api.Skill;
 import net.runelite.client.game.SkillIconManager;
 import net.runelite.client.ui.JShadowedLabel;
 import net.runelite.client.util.LinkBrowser;
@@ -65,8 +64,7 @@ class XpInfoBox extends JPanel
 
 	private final Client client;
 	private final JPanel panel;
-	@Getter(AccessLevel.PACKAGE)
-	private final SkillXPInfo xpInfo;
+	private final Skill skill;
 
 	private final JPanel container = new JPanel();
 	private final JPanel statsPanel = new JPanel();
@@ -77,11 +75,11 @@ class XpInfoBox extends JPanel
 	private final JLabel actionsLeft = new JLabel();
 	private final JLabel levelLabel = new JShadowedLabel();
 
-	XpInfoBox(Client client, JPanel panel, SkillXPInfo xpInfo, SkillIconManager iconManager) throws IOException
+	XpInfoBox(XpTrackerPlugin xpTrackerPlugin, Client client, JPanel panel, Skill skill, SkillIconManager iconManager) throws IOException
 	{
 		this.client = client;
 		this.panel = panel;
-		this.xpInfo = xpInfo;
+		this.skill = skill;
 
 		setLayout(new BorderLayout());
 		setBorder(new CompoundBorder
@@ -121,7 +119,7 @@ class XpInfoBox extends JPanel
 
 		// Create open xp tracker menu
 		final JMenuItem openXpTracker = new JMenuItem("Open XP tracker");
-		openXpTracker.addActionListener(e -> LinkBrowser.browse(XpPanel.buildXpTrackerUrl(client.getLocalPlayer(), xpInfo.getSkill())));
+		openXpTracker.addActionListener(e -> LinkBrowser.browse(XpPanel.buildXpTrackerUrl(client.getLocalPlayer(), skill)));
 
 		// Create popup menu
 		final JPopupMenu popupMenu = new JPopupMenu();
@@ -134,14 +132,16 @@ class XpInfoBox extends JPanel
 		iconBarPanel.setOpaque(false);
 
 		// Create skill/reset icon
-		final BufferedImage skillImage = iconManager.getSkillImage(xpInfo.getSkill());
+		final BufferedImage skillImage = iconManager.getSkillImage(skill);
 		final JButton skillIcon = new JButton();
+
 		skillIcon.putClientProperty(SubstanceSynapse.FLAT_LOOK, Boolean.TRUE);
 		skillIcon.putClientProperty(SubstanceSynapse.BUTTON_NEVER_PAINT_BACKGROUND, Boolean.TRUE);
 		skillIcon.setIcon(new ImageIcon(skillImage));
 		skillIcon.setRolloverIcon(new ImageIcon(createHoverImage(skillImage)));
-		skillIcon.setToolTipText("Reset " + xpInfo.getSkill().getName() + " tracker");
-		skillIcon.addActionListener(e -> reset());
+
+		skillIcon.setToolTipText("Reset " + skill.getName() + " tracker");
+		skillIcon.addActionListener(e -> xpTrackerPlugin.resetSkillState(skill));
 		skillIcon.setBounds(ICON_BOUNDS);
 		skillIcon.setOpaque(false);
 		skillIcon.setFocusPainted(false);
@@ -201,63 +201,47 @@ class XpInfoBox extends JPanel
 
 	void reset()
 	{
-		xpInfo.reset(client.getSkillExperience(xpInfo.getSkill()));
 		container.remove(statsPanel);
 		panel.remove(this);
 		panel.revalidate();
 	}
 
-	void init()
+	void update(boolean updated, XpSnapshotSingle xpSnapshotSingle)
 	{
-		if (xpInfo.getStartXp() != -1)
-		{
-			return;
-		}
-
-		xpInfo.setStartXp(client.getSkillExperience(xpInfo.getSkill()));
+		SwingUtilities.invokeLater(() -> rebuildAsync(updated, xpSnapshotSingle));
 	}
 
-	void update()
+	private void rebuildAsync(boolean updated, XpSnapshotSingle xpSnapshotSingle)
 	{
-		if (xpInfo.getStartXp() == -1)
+		if (updated)
 		{
-			return;
-		}
-
-		boolean updated = xpInfo.update(client.getSkillExperience(xpInfo.getSkill()));
-
-		SwingUtilities.invokeLater(() ->
-		{
-			if (updated)
+			if (getParent() != panel)
 			{
-				if (getParent() != panel)
-				{
-					panel.add(this);
-					panel.revalidate();
-				}
-
-				levelLabel.setText(String.valueOf(xpInfo.getLevel()));
-				xpGained.setText(XpPanel.formatLine(xpInfo.getXpGained(), "xp gained"));
-				xpLeft.setText(XpPanel.formatLine(xpInfo.getXpRemaining(), "xp left"));
-				actionsLeft.setText(XpPanel.formatLine(xpInfo.getActionsRemaining(), "actions left"));
-
-				final int progress = xpInfo.getSkillProgress();
-
-				progressBar.setValue(progress);
-				progressBar.setBackground(Color.getHSBColor((progress / 100.f) * (120.f / 360.f), 1, 1));
-
-				progressBar.setToolTipText("<html>"
-					+ XpPanel.formatLine(xpInfo.getActions(), "actions")
-					+ "<br/>"
-					+ XpPanel.formatLine(xpInfo.getActionsHr(), "actions/hr")
-					+ "<br/>"
-					+ xpInfo.getTimeTillLevel() + " till next lvl"
-					+ "</html>");
+				panel.add(this);
+				panel.revalidate();
 			}
 
-			// Always update xp/hr as time always changes
-			xpHr.setText(XpPanel.formatLine(xpInfo.getXpHr(), "xp/hr"));
-		});
+			levelLabel.setText(String.valueOf(xpSnapshotSingle.getCurrentLevel()));
+			xpGained.setText(XpPanel.formatLine(xpSnapshotSingle.getXpGainedInSession(), "xp gained"));
+			xpLeft.setText(XpPanel.formatLine(xpSnapshotSingle.getXpRemainingToGoal(), "xp left"));
+			actionsLeft.setText(XpPanel.formatLine(xpSnapshotSingle.getActionsRemainingToGoal(), "actions left"));
+
+			final int progress = xpSnapshotSingle.getSkillProgressToGoal();
+
+			progressBar.setValue(progress);
+			progressBar.setBackground(Color.getHSBColor((progress / 100.f) * (120.f / 360.f), 1, 1));
+
+			progressBar.setToolTipText("<html>"
+				+ XpPanel.formatLine(xpSnapshotSingle.getActionsInSession(), "actions")
+				+ "<br/>"
+				+ XpPanel.formatLine(xpSnapshotSingle.getActionsPerHour(), "actions/hr")
+				+ "<br/>"
+				+ xpSnapshotSingle.getTimeTillGoal() + " till next lvl"
+				+ "</html>");
+		}
+
+		// Always update xp/hr as time always changes
+		xpHr.setText(XpPanel.formatLine(xpSnapshotSingle.getXpPerHour(), "xp/hr"));
 	}
 
 	private static BufferedImage createHoverImage(BufferedImage image)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpSnapshotSingle.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpSnapshotSingle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Adam <Adam@sigterm.info>
+ * Copyright (c) 2018, Levi <me@levischuck.com>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -24,36 +24,20 @@
  */
 package net.runelite.client.plugins.xptracker;
 
-import javax.inject.Inject;
-import javax.inject.Singleton;
-import net.runelite.api.Skill;
+import lombok.Builder;
+import lombok.Value;
 
-@Singleton
-class XpTrackerServiceImpl implements XpTrackerService
+@Builder
+@Value
+class XpSnapshotSingle
 {
-	private final XpTrackerPlugin plugin;
-
-	@Inject
-	XpTrackerServiceImpl(XpTrackerPlugin plugin)
-	{
-		this.plugin = plugin;
-	}
-
-	@Override
-	public int getActions(Skill skill)
-	{
-		return plugin.getSkillSnapshot(skill).getActionsInSession();
-	}
-
-	@Override
-	public int getActionsHr(Skill skill)
-	{
-		return plugin.getSkillSnapshot(skill).getActionsPerHour();
-	}
-
-	@Override
-	public int getActionsLeft(Skill skill)
-	{
-		return plugin.getSkillSnapshot(skill).getActionsRemainingToGoal();
-	}
+	private int currentLevel;
+	private int xpGainedInSession;
+	private int xpRemainingToGoal;
+	private int xpPerHour;
+	private int skillProgressToGoal;
+	private int actionsInSession;
+	private int actionsRemainingToGoal;
+	private int actionsPerHour;
+	private String timeTillGoal;
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpSnapshotTotal.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpSnapshotTotal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Adam <Adam@sigterm.info>
+ * Copyright (c) 2018, Levi <me@levischuck.com>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -24,36 +24,16 @@
  */
 package net.runelite.client.plugins.xptracker;
 
-import javax.inject.Inject;
-import javax.inject.Singleton;
-import net.runelite.api.Skill;
+import lombok.Value;
 
-@Singleton
-class XpTrackerServiceImpl implements XpTrackerService
+@Value
+class XpSnapshotTotal
 {
-	private final XpTrackerPlugin plugin;
+	private final int xpGainedInSession;
+	private final int xpPerHour;
 
-	@Inject
-	XpTrackerServiceImpl(XpTrackerPlugin plugin)
+	public static XpSnapshotTotal zero()
 	{
-		this.plugin = plugin;
-	}
-
-	@Override
-	public int getActions(Skill skill)
-	{
-		return plugin.getSkillSnapshot(skill).getActionsInSession();
-	}
-
-	@Override
-	public int getActionsHr(Skill skill)
-	{
-		return plugin.getSkillSnapshot(skill).getActionsPerHour();
-	}
-
-	@Override
-	public int getActionsLeft(Skill skill)
-	{
-		return plugin.getSkillSnapshot(skill).getActionsRemainingToGoal();
+		return new XpSnapshotTotal(0, 0);
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpState.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpState.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2018, Levi <me@levischuck.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.xptracker;
+
+import java.util.EnumMap;
+import java.util.Map;
+import lombok.NonNull;
+import net.runelite.api.Skill;
+
+/**
+ * Internal state for the XpTrackerPlugin
+ *
+ * Note: This class's operations are not currently synchronized.
+ * It is intended to be called by the XpTrackerPlugin on the client thread.
+ */
+class XpState
+{
+	private final XpStateTotal xpTotal = new XpStateTotal();
+	private final Map<Skill, XpStateSingle> xpSkills = new EnumMap<>(Skill.class);
+
+	/**
+	 * Destroys all internal state, however any XpSnapshotSingle or XpSnapshotTotal remain unaffected.
+	 */
+	void reset()
+	{
+		xpTotal.reset();
+		xpSkills.clear();
+	}
+
+	/**
+	 * Resets a single skill
+	 * @param skill Skill to reset
+	 * @param currentXp Current XP to set to, if unknown set to -1
+	 */
+	void resetSkill(Skill skill, int currentXp)
+	{
+		xpSkills.remove(skill);
+		xpSkills.put(skill, new XpStateSingle(skill, currentXp));
+		recalculateTotal();
+	}
+
+	/**
+	 * Calculates the total skill changes observed in this session or since the last reset
+	 */
+	void recalculateTotal()
+	{
+		xpTotal.reset();
+
+		for (XpStateSingle state : xpSkills.values())
+		{
+			xpTotal.addXpGainedInSession(state.getXpGained());
+			xpTotal.addXpPerHour(state.getXpHr());
+		}
+	}
+
+	/**
+	 * Updates a skill with the current known XP.
+	 * When the result of this operation is XpUpdateResult.UPDATED, the UI should be updated accordingly.
+	 * This is to distinguish events that reload all the skill's current values (such as world hopping)
+	 * and also first-login when the skills are not initialized (the start XP will be -1 in this case).
+	 * @param skill Skill to update
+	 * @param currentXp Current known XP for this skill
+	 * @return Whether or not the skill has been initialized, there was no change, or it has been updated
+	 */
+	XpUpdateResult updateSkill(Skill skill, int currentXp)
+	{
+		XpStateSingle state = getSkill(skill);
+
+		if (state.getStartXp() == -1)
+		{
+			if (currentXp > 0)
+			{
+				initializeSkill(skill, currentXp);
+				return XpUpdateResult.INITIALIZED;
+			}
+			else
+			{
+				return XpUpdateResult.NO_CHANGE;
+			}
+		}
+		else
+		{
+			int startXp = state.getStartXp();
+			int gainedXp = state.getXpGained();
+
+			if (startXp + gainedXp > currentXp)
+			{
+				// Reinitialize with lesser currentXp, this can happen with negative xp lamps
+				initializeSkill(skill, currentXp);
+				return XpUpdateResult.INITIALIZED;
+			}
+			else
+			{
+				return state.update(currentXp) ? XpUpdateResult.UPDATED : XpUpdateResult.NO_CHANGE;
+			}
+		}
+	}
+
+	/**
+	 * Forcefully initialize a skill with a known start XP from the current XP.
+	 * This is used in resetAndInitState by the plugin. It should not result in showing the XP in the UI.
+	 * @param skill Skill to initialize
+	 * @param currentXp Current known XP for the skill
+	 */
+	void initializeSkill(Skill skill, int currentXp)
+	{
+		xpSkills.put(skill, new XpStateSingle(skill, currentXp));
+	}
+
+	@NonNull
+	private XpStateSingle getSkill(Skill skill)
+	{
+		return xpSkills.computeIfAbsent(skill, (s) -> new XpStateSingle(s, -1));
+	}
+
+	/**
+	 * Obtain an immutable snapshot of the provided skill
+	 * intended for use with the UI which operates on another thread
+	 * @param skill Skill to obtain the snapshot for
+	 * @return An immutable snapshot of the specified skill for this session since first login or last reset
+	 */
+	@NonNull
+	XpSnapshotSingle getSkillSnapshot(Skill skill)
+	{
+		return getSkill(skill).snapshot();
+	}
+
+	/**
+	 * Obtain an immutable snapshot of the provided skill
+	 * intended for use with the UI which operates on another thread
+	 * @return An immutable snapshot of total information for this session since first login or last reset
+	 */
+	@NonNull
+	XpSnapshotTotal getTotalSnapshot()
+	{
+		return xpTotal.snapshot();
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpStateTotal.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpStateTotal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Adam <Adam@sigterm.info>
+ * Copyright (c) 2018, Levi <me@levischuck.com>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -24,36 +24,32 @@
  */
 package net.runelite.client.plugins.xptracker;
 
-import javax.inject.Inject;
-import javax.inject.Singleton;
-import net.runelite.api.Skill;
+import lombok.Data;
 
-@Singleton
-class XpTrackerServiceImpl implements XpTrackerService
+@Data
+class XpStateTotal
 {
-	private final XpTrackerPlugin plugin;
+	private int xpGainedInSession = 0;
+	private int xpPerHour = 0;
 
-	@Inject
-	XpTrackerServiceImpl(XpTrackerPlugin plugin)
+	void reset()
 	{
-		this.plugin = plugin;
+		xpGainedInSession = 0;
+		xpPerHour = 0;
 	}
 
-	@Override
-	public int getActions(Skill skill)
+	void addXpGainedInSession(int skillXpGainedInSession)
 	{
-		return plugin.getSkillSnapshot(skill).getActionsInSession();
+		xpGainedInSession += skillXpGainedInSession;
 	}
 
-	@Override
-	public int getActionsHr(Skill skill)
+	void addXpPerHour(int skillXpGainedPerHour)
 	{
-		return plugin.getSkillSnapshot(skill).getActionsPerHour();
+		xpPerHour += skillXpGainedPerHour;
 	}
 
-	@Override
-	public int getActionsLeft(Skill skill)
+	XpSnapshotTotal snapshot()
 	{
-		return plugin.getSkillSnapshot(skill).getActionsRemainingToGoal();
+		return new XpSnapshotTotal(xpGainedInSession, xpPerHour);
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpUpdateResult.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpUpdateResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Adam <Adam@sigterm.info>
+ * Copyright (c) 2018, Levi <me@levischuck.com>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -24,36 +24,9 @@
  */
 package net.runelite.client.plugins.xptracker;
 
-import javax.inject.Inject;
-import javax.inject.Singleton;
-import net.runelite.api.Skill;
-
-@Singleton
-class XpTrackerServiceImpl implements XpTrackerService
+enum XpUpdateResult
 {
-	private final XpTrackerPlugin plugin;
-
-	@Inject
-	XpTrackerServiceImpl(XpTrackerPlugin plugin)
-	{
-		this.plugin = plugin;
-	}
-
-	@Override
-	public int getActions(Skill skill)
-	{
-		return plugin.getSkillSnapshot(skill).getActionsInSession();
-	}
-
-	@Override
-	public int getActionsHr(Skill skill)
-	{
-		return plugin.getSkillSnapshot(skill).getActionsPerHour();
-	}
-
-	@Override
-	public int getActionsLeft(Skill skill)
-	{
-		return plugin.getSkillSnapshot(skill).getActionsRemainingToGoal();
-	}
+	NO_CHANGE,
+	INITIALIZED,
+	UPDATED,
 }


### PR DESCRIPTION
Fixes #1273 

Root cause: copying the current skill XPs on game tick is a bad idea. Only use it to recalculate dynamic values like xp/hr.

Game tick happens AFTER login, but BEFORE current XP loads for the current user and then gets
broadcasted as an event. Therefore, the first login gets 0's. Subsequent logins get the last logged in user's skills! In the previous code, if the current XP was less than the starting XP, it would ignore it and drop the update. Thus, the user would not see any updates.

I attempted to fix it by dropping the data on hard reset (logged in as **different user** or **different world type**) in #1351. However, due to coupling in the view (`XpInfoBox` and `XpPanel`), that was DOA as we lost references to what the UI used to display! Gah! As such, I have redone how the view interacts with the plugin, and how the plugin manages state. Now the view  does not modify its own local state and the state is only passed around with immutable data structures (I noticed there was code for atomic integers and the like.. because concurrency..) so asynchronous JSwing updates are also no longer a concern.

I have also renamed `XpSkillInfo` to `XpStateSingle`, as there's both single skill and total skill structures involved.

This should not impact any styling or expected user observed behavior.
I have thoroughly tested this by:
1. Switching between accounts while training the same skill
2. Training, switching worlds by logging out and then in on the same user on the same world, training more
3. Training, switching worlds with logged in world-switcher, continuing to train
4. Training, resetting all skills with the panel button, more training

