### PR TITLE
Swap also dismantle/reset on box traps

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -384,7 +384,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 		{
 			swap("last-destination (", option, target, false);
 		}
-		else if (config.swapBoxTrap() && option.equals("check"))
+		else if (config.swapBoxTrap() && (option.equals("check") || option.equals("dismantle")))
 		{
 			swap("reset", option, target, true);
 		}


### PR DESCRIPTION
Currently the menu entry swapper swaps only check and reset on box traps
what is not that useful without also swapping dismantle and reset.

See also: #1085

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>