### PR TITLE
Fix bank widget IDs due to container changes

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/widgets/WidgetID.java
+++ b/runelite-api/src/main/java/net/runelite/api/widgets/WidgetID.java
@@ -134,10 +134,10 @@ public class WidgetID
 
 	static class Bank
 	{
-		static final int ITEM_CONTAINER = 12;
+		static final int ITEM_CONTAINER = 23;
 		static final int INVENTORY_ITEM_CONTAINER = 3;
-		static final int BANK_TITLE_BAR = 4;
-		static final int BANK_ITEM_COUNT = 5;
+		static final int BANK_TITLE_BAR = 15;
+		static final int BANK_ITEM_COUNT = 16;
 	}
 
 	static class GrandExchange


### PR DESCRIPTION
Fix bank title bar, item count and item container widget ids due to
changes in widget IDs (possibly caused by new container).

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>