### PR TITLE
Fix bank placeholder release option

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/banktags/BankTagsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/banktags/BankTagsPlugin.java
@@ -201,7 +201,8 @@ public class BankTagsPlugin extends Plugin
 	{
 		if (event.getWidgetId() == WidgetInfo.BANK_ITEM_CONTAINER.getId()
 			&& event.getMenuAction() == MenuAction.EXAMINE_ITEM_BANK_EQ
-			&& event.getId() == EDIT_TAGS_MENU_INDEX)
+			&& event.getId() == EDIT_TAGS_MENU_INDEX
+			&& event.getMenuOption().startsWith(EDIT_TAGS_MENU_OPTION))
 		{
 			event.consume();
 			int inventoryIndex = event.getActionParam();


### PR DESCRIPTION
Fixes the placeholder release option by only consuming the event when the edit tags is clicked