### PR TITLE
Fix worldToMiniMap for locations outside of range - fixes #1385

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/Perspective.java
+++ b/runelite-api/src/main/java/net/runelite/api/Perspective.java
@@ -221,7 +221,7 @@ public class Perspective
 			return new Point(x, y);
 		}
 
-		return new Point(-1, -1);
+		return null;
 	}
 
 	/**


### PR DESCRIPTION
All uses of `worldToMiniMap` seem to expect it to be null if something fails, when it actuality it returns a Point(-1, -1).

This caused weird behavior for some drawing on the minimap. Tested and it solved #1385. 

My first PR on here and though it might be a very small one, please tell me if I did something incorrectly.