### PR TITLE
Alphabetize the config entries of the menu entry swapper plugin.

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -37,28 +37,6 @@ public interface MenuEntrySwapperConfig extends Config
 {
 	@ConfigItem(
 		position = 0,
-		keyName = "shiftClickCustomization",
-		name = "Customizable shift-click",
-		description = "Allows customization of shift-clicks on items"
-	)
-	default boolean shiftClickCustomization()
-	{
-		return true;
-	}
-
-	@ConfigItem(
-		position = 1,
-		keyName = "swapPickpocket",
-		name = "Pickpocket on H.A.M.",
-		description = "Swap Talk-to with Pickpocket on H.A.M members"
-	)
-	default boolean swapPickpocket()
-	{
-		return true;
-	}
-
-	@ConfigItem(
-		position = 2,
 		keyName = "swapBanker",
 		name = "Bank",
 		description = "Swap Talk-to with Bank on Bank NPC<br>Example: Banker"
@@ -69,128 +47,7 @@ public interface MenuEntrySwapperConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 3,
-		keyName = "swapExchange",
-		name = "Exchange",
-		description = "Swap Talk-to with Exchange on NPC<br>Example: Grand Exchange Clerk, Tool Leprechaun, Void Knight"
-	)
-	default boolean swapExchange()
-	{
-		return true;
-	}
-
-	@ConfigItem(
-		position = 4,
-		keyName = "swapHarpoon",
-		name = "Harpoon",
-		description = "Swap Cage, Big Net with Harpoon on Fishing spot"
-	)
-	default boolean swapHarpoon()
-	{
-		return true;
-	}
-
-	@ConfigItem(
-		position = 5,
-		keyName = "swapTrade",
-		name = "Trade",
-		description = "Swap Talk-to with Trade on NPC<br>Example: Shop keeper, Shop assistant"
-	)
-	default boolean swapTrade()
-	{
-		return true;
-	}
-
-	@ConfigItem(
-		position = 6,
-		keyName = "swapTravel",
-		name = "Travel",
-		description = "Swap Talk-to with Travel, Take-boat, Pay-fare, Charter on NPC<br>Example: Squire, Monk of Entrana, Customs officer, Trader Crewmember"
-	)
-	default boolean swapTravel()
-	{
-		return true;
-	}
-
-	@ConfigItem(
-		position = 7,
-		keyName = "swapPay",
-		name = "Pay",
-		description = "Swap Talk-to with Pay on NPC<br>Example: Elstan, Heskel, Fayeth"
-	)
-	default boolean swapPay()
-	{
-		return true;
-	}
-
-	@ConfigItem(
-		position = 8,
-		keyName = "swapHome",
-		name = "Home",
-		description = "Swap Enter with Home on Portal"
-	)
-	default boolean swapHome()
-	{
-		return true;
-	}
-
-	@ConfigItem(
-		position = 9,
-		keyName = "swapLastDestination",
-		name = "Last-destination (XXX)",
-		description = "Swap Zanaris with Last-destination on Fairy ring"
-	)
-	default boolean swapLastDestination()
-	{
-		return true;
-	}
-
-	@ConfigItem(
-		position = 10,
-		keyName = "swapBoxTrap",
-		name = "Reset",
-		description = "Swap Check with Reset on box trap"
-	)
-	default boolean swapBoxTrap()
-	{
-		return true;
-	}
-
-	@ConfigItem(
-		position = 11,
-		keyName = "swapCatacombEntrance",
-		name = "Catacomb entrance",
-		description = "Swap Read with Investigate on Catacombs of Kourend entrance"
-	)
-	default boolean swapCatacombEntrance()
-	{
-		return true;
-	}
-
-	@ConfigItem(
-		position = 12,
-		keyName = "swapTeleportItem",
-		name = "Teleport item",
-		description = "Swap Wear, Wield with Rub, Teleport on teleport item<br>Example: Amulet of glory, Ardougne cloak, Chronicle"
-	)
-	default boolean swapTeleportItem()
-	{
-		return true;
-	}
-
-	@ConfigItem(
-		position = 13,
-		keyName = "swapSilverSickle",
-		name = "Silver sickle(b)",
-		description = "Swap Wield with Cast Bloom on Silver sickle(b)"
-	)
-	default boolean swapSilverSickle()
-	{
-		return true;
-	}
-
-	@ConfigItem(
-		position = 14,
+		position = 1,
 		keyName = "swapBones",
 		name = "Bury",
 		description = "Swap Bury with Use on Bones"
@@ -201,12 +58,155 @@ public interface MenuEntrySwapperConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 15,
+		position = 2,
+		keyName = "swapCatacombEntrance",
+		name = "Catacomb entrance",
+		description = "Swap Read with Investigate on Catacombs of Kourend entrance"
+	)
+	default boolean swapCatacombEntrance()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		position = 3,
 		keyName = "swapChase",
 		name = "Chase",
 		description = "Allows to left click your cat to chase"
 	)
 	default boolean swapChase()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		position = 4,
+		keyName = "shiftClickCustomization",
+		name = "Customizable shift-click",
+		description = "Allows customization of shift-clicks on items"
+	)
+	default boolean shiftClickCustomization()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		position = 5,
+		keyName = "swapExchange",
+		name = "Exchange",
+		description = "Swap Talk-to with Exchange on NPC<br>Example: Grand Exchange Clerk, Tool Leprechaun, Void Knight"
+	)
+	default boolean swapExchange()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		position = 6,
+		keyName = "swapHarpoon",
+		name = "Harpoon",
+		description = "Swap Cage, Big Net with Harpoon on Fishing spot"
+	)
+	default boolean swapHarpoon()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		position = 7,
+		keyName = "swapHome",
+		name = "Home",
+		description = "Swap Enter with Home on Portal"
+	)
+	default boolean swapHome()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		position = 8,
+		keyName = "swapLastDestination",
+		name = "Last-destination (XXX)",
+		description = "Swap Zanaris with Last-destination on Fairy ring"
+	)
+	default boolean swapLastDestination()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		position = 9,
+		keyName = "swapPickpocket",
+		name = "Pickpocket on H.A.M.",
+		description = "Swap Talk-to with Pickpocket on H.A.M members"
+	)
+	default boolean swapPickpocket()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		position = 10,
+		keyName = "swapPay",
+		name = "Pay",
+		description = "Swap Talk-to with Pay on NPC<br>Example: Elstan, Heskel, Fayeth"
+	)
+	default boolean swapPay()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		position = 11,
+		keyName = "swapBoxTrap",
+		name = "Reset",
+		description = "Swap Check with Reset on box trap"
+	)
+	default boolean swapBoxTrap()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		position = 12,
+		keyName = "swapSilverSickle",
+		name = "Silver sickle(b)",
+		description = "Swap Wield with Cast Bloom on Silver sickle(b)"
+	)
+	default boolean swapSilverSickle()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		position = 13,
+		keyName = "swapTeleportItem",
+		name = "Teleport item",
+		description = "Swap Wear, Wield with Rub, Teleport on teleport item<br>Example: Amulet of glory, Ardougne cloak, Chronicle"
+	)
+	default boolean swapTeleportItem()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		position = 14,
+		keyName = "swapTrade",
+		name = "Trade",
+		description = "Swap Talk-to with Trade on NPC<br>Example: Shop keeper, Shop assistant"
+	)
+	default boolean swapTrade()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		position = 15,
+		keyName = "swapTravel",
+		name = "Travel",
+		description = "Swap Talk-to with Travel, Take-boat, Pay-fare, Charter on NPC<br>Example: Squire, Monk of Entrana, Customs officer, Trader Crewmember"
+	)
+	default boolean swapTravel()
 	{
 		return true;
 	}


### PR DESCRIPTION
The current menu is in no particular order as far as I know.
I alphabetized all the config entries.
Unsure if "Customizable shift-click" should be the first entry, as it has more specific functionality. 

