### PR TITLE
Remove ip address storing

### DIFF
--- a/http-service/src/main/java/net/runelite/http/service/session/SessionController.java
+++ b/http-service/src/main/java/net/runelite/http/service/session/SessionController.java
@@ -50,11 +50,9 @@ public class SessionController
 	public UUID get(HttpServletRequest request)
 	{
 		UUID uuid = UUID.randomUUID();
-		String addr = request.getRemoteAddr();
 		Instant now = Instant.now();
 		SessionEntry sessionEntry = new SessionEntry();
 		sessionEntry.setUuid(uuid);
-		sessionEntry.setIp(addr);
 		sessionEntry.setStart(now);
 		sessionEntry.setLast(now);
 		sessionService.createSession(sessionEntry);

--- a/http-service/src/main/java/net/runelite/http/service/session/SessionEntry.java
+++ b/http-service/src/main/java/net/runelite/http/service/session/SessionEntry.java
@@ -33,7 +33,6 @@ public class SessionEntry
 {
 	private int id;
 	private UUID uuid;
-	private String ip;
 	private Instant start;
 	private Instant last;
 }

--- a/http-service/src/main/java/net/runelite/http/service/session/SessionService.java
+++ b/http-service/src/main/java/net/runelite/http/service/session/SessionService.java
@@ -50,10 +50,9 @@ public class SessionService
 	{
 		try (Connection con = sql2o.open())
 		{
-			con.createQuery("insert into session (uuid, ip, start, last) "
-				+ "values (:uuid, :ip, :start, :last)")
+			con.createQuery("insert into session (uuid, start, last) "
+				+ "values (:uuid, :start, :last)")
 				.addParameter("uuid", session.getUuid().toString())
-				.addParameter("ip", session.getIp())
 				.addParameter("start", session.getStart())
 				.addParameter("last", session.getLast())
 				.executeUpdate();


### PR DESCRIPTION
This change removes IP address storing in session table. 

Another thing to is remove IP row all together from table. I didn't do that in this commit as was not sure if it would mean whole table recreation.

I would still suggest to go over all logs and check that user IP address is not showed in any place that might lead back to sessionId or Username.