### PR TITLE
Fix bank value overflow

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/bankvalue/BankCalculation.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/bankvalue/BankCalculation.java
@@ -32,15 +32,13 @@ import java.util.concurrent.CompletableFuture;
 import javax.inject.Inject;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
-import net.runelite.api.Client;
 import net.runelite.api.ItemComposition;
 import static net.runelite.api.ItemID.COINS_995;
 import static net.runelite.api.ItemID.PLATINUM_TOKEN;
 import net.runelite.api.queries.BankItemQuery;
-import net.runelite.api.widgets.Widget;
-import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.api.widgets.WidgetItem;
 import net.runelite.client.game.ItemManager;
+import net.runelite.client.util.QueryRunner;
 import net.runelite.http.api.item.ItemPrice;
 
 @Slf4j
@@ -48,7 +46,7 @@ class BankCalculation
 {
 	private static final float HIGH_ALCHEMY_CONSTANT = 0.6f;
 
-	private final Client client;
+	private final QueryRunner queryRunner;
 	private final BankValueConfig config;
 	private final ItemManager itemManager;
 
@@ -65,9 +63,9 @@ class BankCalculation
 	private boolean finished;
 
 	@Inject
-	BankCalculation(Client client, ItemManager itemManager, BankValueConfig config)
+	BankCalculation(QueryRunner queryRunner, ItemManager itemManager, BankValueConfig config)
 	{
-		this.client = client;
+		this.queryRunner = queryRunner;
 		this.itemManager = itemManager;
 		this.config = config;
 	}
@@ -77,17 +75,7 @@ class BankCalculation
 	 */
 	void calculate()
 	{
-		Widget widgetBankTitleBar = client.getWidget(WidgetInfo.BANK_TITLE_BAR);
-
-		// Don't update on a search because rs seems to constantly update the title
-		if (widgetBankTitleBar == null ||
-			widgetBankTitleBar.isHidden() ||
-			widgetBankTitleBar.getText().contains("Showing"))
-		{
-			return;
-		}
-
-		WidgetItem[] widgetItems = new BankItemQuery().result(client);
+		WidgetItem[] widgetItems = queryRunner.runQuery(new BankItemQuery());
 
 		if (widgetItems.length == 0 || !isBankDifferent(widgetItems))
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/bankvalue/BankCalculation.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/bankvalue/BankCalculation.java
@@ -108,12 +108,12 @@ class BankCalculation
 
 			if (widgetItem.getId() == PLATINUM_TOKEN)
 			{
-				gePrice += widgetItem.getQuantity() * 1000;
-				haPrice += widgetItem.getQuantity() * 1000;
+				gePrice += widgetItem.getQuantity() * 1000L;
+				haPrice += widgetItem.getQuantity() * 1000L;
 				continue;
 			}
 
-			ItemComposition itemComposition = itemManager.getItemComposition(widgetItem.getId());
+			final ItemComposition itemComposition = itemManager.getItemComposition(widgetItem.getId());
 			itemCompositions.add(itemComposition);
 			itemMap.put(widgetItem.getId(), widgetItem);
 
@@ -152,7 +152,7 @@ class BankCalculation
 							continue; // cached no price
 						}
 
-						gePrice += itemPrice.getPrice() * itemMap.get(itemPrice.getItem().getId()).getQuantity();
+						gePrice += (long) itemPrice.getPrice() * (long) itemMap.get(itemPrice.getItem().getId()).getQuantity();
 					}
 				}
 				catch (Exception ex2)
@@ -178,8 +178,8 @@ class BankCalculation
 
 				if (price > 0)
 				{
-					haPrice += Math.round(price * HIGH_ALCHEMY_CONSTANT) *
-						itemMap.get(itemComposition.getId()).getQuantity();
+					haPrice += (long) Math.round(price * HIGH_ALCHEMY_CONSTANT) *
+						(long) itemMap.get(itemComposition.getId()).getQuantity();
 				}
 			}
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/bankvalue/BankValuePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/bankvalue/BankValuePlugin.java
@@ -71,10 +71,23 @@ public class BankValuePlugin extends Plugin
 		}
 
 		bankTitle.save();
-		bankCalculation.calculate();
+		calculate(widgetBankTitleBar);
 		if (bankCalculation.isFinished())
 		{
 			bankTitle.update(bankCalculation.getGePrice(), bankCalculation.getHaPrice());
 		}
+	}
+
+	private void calculate(Widget bankTitleBar)
+	{
+		// Don't update on a search because rs seems to constantly update the title
+		if (bankTitleBar == null ||
+			bankTitleBar.isHidden() ||
+			bankTitleBar.getText().contains("Showing"))
+		{
+			return;
+		}
+
+		bankCalculation.calculate();
 	}
 }

--- a/runelite-client/src/test/java/net/runelite/client/plugins/bankvalue/BankCalculationTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/bankvalue/BankCalculationTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2018, Adam <Adam@sigterm.info>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.bankvalue;
+
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Guice;
+import com.google.inject.testing.fieldbinder.Bind;
+import com.google.inject.testing.fieldbinder.BoundFieldModule;
+import javax.inject.Inject;
+import net.runelite.api.Client;
+import net.runelite.api.ItemComposition;
+import net.runelite.api.ItemID;
+import net.runelite.api.queries.BankItemQuery;
+import net.runelite.api.widgets.WidgetItem;
+import net.runelite.client.game.ItemManager;
+import net.runelite.client.util.QueryRunner;
+import static org.junit.Assert.*;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import static org.mockito.Matchers.any;
+import org.mockito.Mock;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class BankCalculationTest
+{
+	@Mock
+	@Bind
+	private Client client;
+
+	@Mock
+	@Bind
+	private QueryRunner queryRunner;
+
+	@Mock
+	@Bind
+	private ItemManager itemManager;
+
+	@Mock
+	@Bind
+	private BankValueConfig bankValueConfig;
+
+	@Inject
+	private BankCalculation bankCalculation;
+
+	@Before
+	public void before()
+	{
+		Guice.createInjector(BoundFieldModule.of(this)).injectMembers(this);
+	}
+
+	@Test
+	public void testCalculate()
+	{
+		when(bankValueConfig.showHA())
+			.thenReturn(true);
+
+		WidgetItem[] widgetItems = ImmutableList.of(
+			new WidgetItem(ItemID.COINS_995, Integer.MAX_VALUE, -1, null),
+			new WidgetItem(ItemID.ABYSSAL_WHIP, 1_000_000_000, -1, null)
+		).toArray(new WidgetItem[0]);
+
+		when(queryRunner.runQuery(any(BankItemQuery.class)))
+			.thenReturn(widgetItems);
+
+		ItemComposition whip = mock(ItemComposition.class);
+		when(whip.getId())
+			.thenReturn(ItemID.ABYSSAL_WHIP);
+		when(whip.getPrice())
+			.thenReturn(7); // 7 * .6 = 4, 4 * 1m overflows
+		when(itemManager.getItemComposition(ItemID.ABYSSAL_WHIP))
+			.thenReturn(whip);
+
+		bankCalculation.calculate();
+
+		long value = bankCalculation.getHaPrice();
+		assertTrue(value > Integer.MAX_VALUE);
+	}
+}


### PR DESCRIPTION
Use longs instead of ints for per-item price calculations to avoid int
overflows.

Fixes: #1460

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>