### PR TITLE
Additons to MenuEntrySwapper Fixes #1459

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -210,4 +210,47 @@ public interface MenuEntrySwapperConfig extends Config
 	{
 		return true;
 	}
+	@ConfigItem(
+			position = 16,
+			keyName = "swapAbyss",
+			name = "Abyss Teleport",
+			description = "Swap Talk-to with teleport on the Mage of Zamorak"
+	)
+	default boolean swapAbyss()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+			position = 17,
+			keyName = "swapPass",
+			name = "Quick Pass",
+			description = "Swap Pass with Quick Pass at Cerberus and Olm"
+	)
+	default boolean swapCerberus()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+			position = 18,
+			keyName = "swapBellRing",
+			name = "Bell Ring",
+			description = "Swap Ring with Quick-start at Grotesque Guardians"
+	)
+	default boolean swapBellRing()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+			position = 19,
+			keyName = "swapPyramid",
+			name = "Pyramid Plunder",
+			description = "Swap Talk-to with Start-minigame at Pyramid Plunder"
+	)
+	default boolean swapPyramid()
+	{
+		return true;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -336,6 +336,11 @@ public class MenuEntrySwapperPlugin extends Plugin
 				swap("pickpocket", option, target, true);
 			}
 
+			if (config.swapAbyss() && target.contains("mage of zamorak"))
+			{
+				swap("teleport", option, target, true);
+			}
+
 			if (config.swapBank())
 			{
 				swap("bank", option, target, true);
@@ -367,6 +372,12 @@ public class MenuEntrySwapperPlugin extends Plugin
 			{
 				swap("pay", option, target, true);
 			}
+
+			if (config.swapPyramid())
+			{
+				swap("start-minigame", option, target, true);
+			}
+
 		}
 		else if (config.swapHarpoon() && option.equals("cage"))
 		{
@@ -425,6 +436,16 @@ public class MenuEntrySwapperPlugin extends Plugin
 		else if (config.swapChase() && option.equals("pick-up"))
 		{
 			swap("chase", option, target, true);
+		}
+
+		else if (config.swapAbyss())
+		{
+			swap("quick pass", option, target, true);
+		}
+
+		else if (config.swapBellRing())
+		{
+			swap("quick-pass", option, target, true);
 		}
 	}
 


### PR DESCRIPTION
Added left click options to Abyss teleport to Mage of zamorak, Quick pass to cerberus flame and to door of the Olm, Quick-start to grotesque guardians and start minigame to mummy at pyramid plunder. Fixes #1459 