### PR TITLE
Make condition for H.A.M. pickpockets lowercase

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -331,7 +331,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 
 		if (option.equals("talk-to"))
 		{
-			if (config.swapPickpocket() && target.contains("H.A.M."))
+			if (config.swapPickpocket() && target.contains("h.a.m."))
 			{
 				swap("pickpocket", option, target, true);
 			}


### PR DESCRIPTION
As target is lowercased, make the condition lowercased too so it can be
properly matched.

Fixes: #1478

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>