### PR TITLE
Do not reuse HttpUrl.builder for building xp urls

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpPanel.java
@@ -49,12 +49,6 @@ import okhttp3.HttpUrl;
 @Slf4j
 class XpPanel extends PluginPanel
 {
-	private static final HttpUrl.Builder XP_TRACKER_FORMAT = new HttpUrl.Builder()
-		.scheme("https")
-		.host("runelite.net")
-		.addPathSegment("xp")
-		.addPathSegment("show");
-
 	private final Map<Skill, XpInfoBox> infoBoxes = new HashMap<>();
 	private final JLabel totalXpGained = new JLabel();
 	private final JLabel totalXpHr = new JLabel();
@@ -120,7 +114,11 @@ class XpPanel extends PluginPanel
 			return "";
 		}
 
-		return XP_TRACKER_FORMAT
+		return new HttpUrl.Builder()
+			.scheme("https")
+			.host("runelite.net")
+			.addPathSegment("xp")
+			.addPathSegment("show")
 			.addPathSegment(skill.getName().toLowerCase())
 			.addPathSegment(player.getName())
 			.addPathSegment("1week")


### PR DESCRIPTION
Due to HttpUrl.Builder being mutable, this causes duplicate URL path
segments when tracking more than 1 skill at a time.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>