### PR TITLE
Hide clue scroll interface when no clue is present

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/ClueScrollPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/ClueScrollPlugin.java
@@ -29,7 +29,6 @@ package net.runelite.client.plugins.cluescrolls;
 import com.google.common.eventbus.Subscribe;
 import java.time.Duration;
 import java.time.Instant;
-import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
@@ -43,15 +42,20 @@ import net.runelite.api.GameObject;
 import net.runelite.api.GameState;
 import net.runelite.api.InventoryID;
 import net.runelite.api.Item;
+import net.runelite.api.ItemComposition;
 import net.runelite.api.NPC;
 import net.runelite.api.Query;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.ChatMessage;
+import net.runelite.api.events.GameStateChanged;
+import net.runelite.api.events.GameTick;
+import net.runelite.api.events.ItemContainerChanged;
 import net.runelite.api.queries.GameObjectQuery;
 import net.runelite.api.queries.InventoryItemQuery;
 import net.runelite.api.queries.NPCQuery;
 import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetInfo;
+import net.runelite.client.game.ItemManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.plugins.cluescrolls.clues.AnagramClue;
@@ -65,7 +69,6 @@ import net.runelite.client.plugins.cluescrolls.clues.MapClue;
 import net.runelite.client.plugins.cluescrolls.clues.NpcClueScroll;
 import net.runelite.client.plugins.cluescrolls.clues.ObjectClueScroll;
 import net.runelite.client.plugins.cluescrolls.clues.TextClueScroll;
-import net.runelite.client.task.Schedule;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.util.QueryRunner;
 
@@ -95,6 +98,9 @@ public class ClueScrollPlugin extends Plugin
 	@Inject
 	@Getter
 	private Client client;
+
+	@Inject
+	private ItemManager itemManager;
 
 	@Inject
 	private QueryRunner queryRunner;
@@ -131,19 +137,47 @@ public class ClueScrollPlugin extends Plugin
 		clue = null;
 	}
 
-	@Schedule(
-		period = 600,
-		unit = ChronoUnit.MILLIS
-	)
-	public void checkForClues()
+	@Subscribe
+	public void onItemContainerChanged(final ItemContainerChanged event)
 	{
-		if (client.getGameState() == GameState.LOGIN_SCREEN)
+		// Check if item was removed from inventory
+		if (clue != null && event.getItemContainer() == client.getItemContainer(InventoryID.INVENTORY))
 		{
-			client.clearHintArrow();
-			clue = null;
-			return;
-		}
+			final Item[] items = event.getItemContainer().getItems();
+			boolean found = false;
 
+			// Clue was maybe removed from inventory, check if there is any clue scrolls left
+			for (Item item : items)
+			{
+				final ItemComposition itemContainerDefinition = itemManager.getItemComposition(item.getId());
+
+				// Check if we have any clue scrolls left
+				if (itemContainerDefinition.getName().startsWith("Clue scroll"))
+				{
+					found = true;
+					break;
+				}
+			}
+
+			if (!found)
+			{
+				resetClue();
+			}
+		}
+	}
+
+	@Subscribe
+	public void onGameStateChanged(final GameStateChanged event)
+	{
+		if (event.getGameState() == GameState.LOGIN_SCREEN)
+		{
+			resetClue();
+		}
+	}
+
+	@Subscribe
+	public void onGameTick(final GameTick event)
+	{
 		npcsToMark = null;
 		objectsToMark = null;
 		equippedItems = null;
@@ -202,10 +236,20 @@ public class ClueScrollPlugin extends Plugin
 		// so the clue window doesn't have to be open.
 		if (clue != null)
 		{
-			client.clearHintArrow();
+			if (clue != this.clue)
+			{
+				resetClue();
+			}
+
 			this.clue = clue;
 			this.clueTimeout = Instant.now();
 		}
+	}
+
+	private void resetClue()
+	{
+		clue = null;
+		client.clearHintArrow();
 	}
 
 	private ClueScroll findClueScroll()


### PR DESCRIPTION
When user does not have any more clues left in inventory, hide clue
scroll interface.

Depends on: #1569 

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>

