### PR TITLE
Color right click menu only in Player Indicators

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsConfig.java
@@ -180,7 +180,18 @@ public interface PlayerIndicatorsConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 13,
+			position = 13,
+			keyName = "onlyPlayerMenu",
+			name = "Only color player menu",
+			description = "Only right click menu will be colored"
+	)
+	default boolean onlyPlayerMenu()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		position = 14,
 		keyName = "clanMenuIcons",
 		name = "Show clan rank in menu",
 		description = "Add clan rank to right click menu for players"

--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsService.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsService.java
@@ -70,22 +70,26 @@ public class PlayerIndicatorsService
 					consumer.accept(player, config.getOwnNameColor());
 				}
 			}
-			else if (config.drawFriendNames() && player.isFriend())
+			if (!config.onlyPlayerMenu())
 			{
-				consumer.accept(player, config.getFriendNameColor());
+				if (config.drawFriendNames() && player.isFriend() && player != localPlayer)
+				{
+					consumer.accept(player, config.getFriendNameColor());
+				}
+				else if (config.drawClanMemberNames() && isClanMember && player != localPlayer)
+				{
+					consumer.accept(player, config.getClanMemberColor());
+				}
+				else if (config.drawTeamMemberNames() && localPlayer.getTeam() > 0 && localPlayer.getTeam() == player.getTeam() && player != localPlayer)
+				{
+					consumer.accept(player, config.getTeamMemberColor());
+				}
+				else if (config.drawNonClanMemberNames() && !isClanMember && player != localPlayer)
+				{
+					consumer.accept(player, config.getNonClanMemberColor());
+				}
 			}
-			else if (config.drawClanMemberNames() && isClanMember)
-			{
-				consumer.accept(player, config.getClanMemberColor());
-			}
-			else if (config.drawTeamMemberNames() && localPlayer.getTeam() > 0 && localPlayer.getTeam() == player.getTeam())
-			{
-				consumer.accept(player, config.getTeamMemberColor());
-			}
-			else if (config.drawNonClanMemberNames() && !isClanMember)
-			{
-				consumer.accept(player, config.getNonClanMemberColor());
-			}
+
 		}
 	}
 }


### PR DESCRIPTION
A toggle to only color in the right-click menu and not to have names drawn overhead

Toggle Off
![image](https://user-images.githubusercontent.com/38306979/38770095-af03daf2-4050-11e8-9c08-4986ff6ed06c.png)

Toggle On
![image](https://user-images.githubusercontent.com/38306979/38770072-701e1c12-4050-11e8-894d-83ca6b3f748d.png)
