### PR TITLE
Reduce player indicators overlay priority to MED

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsOverlay.java
@@ -55,7 +55,7 @@ public class PlayerIndicatorsOverlay extends Overlay
 		this.playerIndicatorsService = playerIndicatorsService;
 		this.clanManager = clanManager;
 		setPosition(OverlayPosition.DYNAMIC);
-		setPriority(OverlayPriority.HIGH);
+		setPriority(OverlayPriority.MED);
 	}
 
 	@Override


### PR DESCRIPTION
Prevents player names from drawing over certain overlays.

example: XP Globe tooltip

before:
![before](https://user-images.githubusercontent.com/2943260/38774572-3cc2bf96-403a-11e8-8422-27e816cf0b86.png)

after:
![after](https://user-images.githubusercontent.com/2943260/38774574-43831e84-403a-11e8-9625-2d7d83a9c6fa.png)


