### PR TITLE
Change menuOpened from FieldHook to Hook

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/callback/Hooks.java
+++ b/runelite-client/src/main/java/net/runelite/client/callback/Hooks.java
@@ -54,6 +54,7 @@ import net.runelite.api.events.ActorDeath;
 import net.runelite.api.events.ChatMessage;
 import net.runelite.api.events.FocusChanged;
 import net.runelite.api.events.GameTick;
+import net.runelite.api.events.MenuOpened;
 import net.runelite.api.events.MenuOptionClicked;
 import net.runelite.api.events.PostItemComposition;
 import net.runelite.api.events.ProjectileMoved;
@@ -438,6 +439,13 @@ public class Hooks
 	{
 		PostItemComposition event = new PostItemComposition();
 		event.setItemComposition(itemComposition);
+		eventBus.post(event);
+	}
+
+	public static void menuOpened(Client client, int var1, int var2)
+	{
+		MenuOpened event = new MenuOpened();
+		event.setMenuEntries(client.getMenuEntries());
 		eventBus.post(event);
 	}
 }

--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSClientMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSClientMixin.java
@@ -65,7 +65,6 @@ import net.runelite.api.events.ExperienceChanged;
 import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.GrandExchangeOfferChanged;
 import net.runelite.api.events.MapRegionChanged;
-import net.runelite.api.events.MenuOpened;
 import net.runelite.api.events.NpcDespawned;
 import net.runelite.api.events.NpcSpawned;
 import net.runelite.api.events.PlayerDespawned;
@@ -764,20 +763,6 @@ public abstract class RSClientMixin implements RSClient
 	public static void clanMemberManagerChanged(int idx)
 	{
 		eventBus.post(new ClanChanged(client.getClanMemberManager() != null));
-	}
-
-	@FieldHook("isMenuOpen")
-	@Inject
-	public static void menuOpened(int opened)
-	{
-		if (!client.isMenuOpen())
-		{
-			return;
-		}
-
-		MenuOpened event = new MenuOpened();
-		event.setMenuEntries(client.getMenuEntries());
-		eventBus.post(event);
 	}
 
 	@Inject

--- a/runescape-client/src/main/java/Client.java
+++ b/runescape-client/src/main/java/Client.java
@@ -6069,6 +6069,7 @@ public final class Client extends GameEngine implements class302 {
       garbageValue = "-1938426547"
    )
    @Export("openMenu")
+   @Hook("menuOpened")
    final void openMenu(int var1, int var2) {
       int var3 = MessageNode.fontBold12.getTextWidth("Choose Option");
 


### PR DESCRIPTION
This fixes the issue with the menu going "off screen" and text overflowing the menu background when the menu entries have been changed on MenuOpened.

Before:
![image](https://user-images.githubusercontent.com/35824069/38776510-37878440-4098-11e8-8ba1-5da36f01b346.png)

After:
![image](https://user-images.githubusercontent.com/35824069/38776528-8c73ac54-4098-11e8-8df1-96a758fd5e82.png)
