### PR TITLE
Motherlode Mine - Gem overlay

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/motherlode/MotherlodeConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/motherlode/MotherlodeConfig.java
@@ -95,4 +95,14 @@ public interface MotherlodeConfig extends Config
 	{
 		return true;
 	}
+
+	@ConfigItem(
+		keyName = "showGemsFound",
+		name = "Show gems found",
+		description = "Shows gems found during current mining session"
+	)
+	default boolean showGemsFound()
+	{
+		return true;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/motherlode/MotherlodeGemOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/motherlode/MotherlodeGemOverlay.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2018, Lars <lars.oernlo@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.motherlode;
+
+import java.awt.Dimension;
+import java.awt.Graphics2D;
+import java.time.Duration;
+import java.time.Instant;
+import javax.inject.Inject;
+import net.runelite.client.ui.overlay.Overlay;
+import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.components.PanelComponent;
+
+public class MotherlodeGemOverlay extends Overlay
+{
+	private final MotherlodePlugin plugin;
+	private final MotherlodeConfig config;
+	private final PanelComponent panelComponent = new PanelComponent();
+
+	@Inject
+	MotherlodeGemOverlay(MotherlodePlugin plugin, MotherlodeConfig config)
+	{
+		setPosition(OverlayPosition.TOP_LEFT);
+		this.plugin = plugin;
+		this.config = config;
+	}
+
+	@Override
+	public Dimension render(Graphics2D graphics)
+	{
+		MotherlodeSession session = plugin.getSession();
+
+		if (session.getLastGemFound() == null || !plugin.isInMlm() || !config.showGemsFound())
+		{
+			return null;
+		}
+
+		Duration statTimeout = Duration.ofMinutes(config.statTimeout());
+		Duration sinceCut = Duration.between(session.getLastGemFound(), Instant.now());
+
+		if (sinceCut.compareTo(statTimeout) >= 0)
+		{
+			return null;
+		}
+
+		int diamondsFound = session.getDiamondsFound();
+		int rubiesFound = session.getRubiesFound();
+		int emeraldsFound = session.getEmeraldsFound();
+		int sapphiresFound = session.getSapphiresFound();
+
+		panelComponent.getLines().clear();
+
+		panelComponent.setTitle("Gems found");
+
+		if (diamondsFound > 0)
+		{
+			panelComponent.getLines().add(new PanelComponent.Line(
+					"Diamonds:",
+					Integer.toString(diamondsFound)
+			));
+		}
+
+		if (rubiesFound > 0)
+		{
+			panelComponent.getLines().add(new PanelComponent.Line(
+					"Rubies:",
+					Integer.toString(rubiesFound)
+			));
+		}
+
+		if (emeraldsFound > 0)
+		{
+			panelComponent.getLines().add(new PanelComponent.Line(
+					"Emeralds:",
+					Integer.toString(emeraldsFound)
+			));
+		}
+
+		if (sapphiresFound > 0)
+		{
+			panelComponent.getLines().add(new PanelComponent.Line(
+					"Sapphires:",
+					Integer.toString(sapphiresFound)
+			));
+		}
+		return panelComponent.render(graphics);
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/motherlode/MotherlodePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/motherlode/MotherlodePlugin.java
@@ -96,6 +96,9 @@ public class MotherlodePlugin extends Plugin
 	private MotherlodeSackOverlay motherlodeSackOverlay;
 
 	@Inject
+	private MotherlodeGemOverlay motherlodeGemOverlay;
+
+	@Inject
 	private MotherlodeConfig config;
 
 	@Inject
@@ -127,7 +130,7 @@ public class MotherlodePlugin extends Plugin
 	@Override
 	public Collection<Overlay> getOverlays()
 	{
-		return Arrays.asList(overlay, rocksOverlay, motherlodeSackOverlay);
+		return Arrays.asList(overlay, rocksOverlay, motherlodeSackOverlay, motherlodeGemOverlay);
 	}
 
 	@Override
@@ -156,17 +159,34 @@ public class MotherlodePlugin extends Plugin
 	@Subscribe
 	public void onChatMessage(ChatMessage event)
 	{
-		if (!inMlm)
+		if (!inMlm || event.getType() != ChatMessageType.FILTERED)
 		{
 			return;
 		}
 
-		if (event.getType() == ChatMessageType.FILTERED)
+		String chatMessage = event.getMessage();
+
+		switch (chatMessage)
 		{
-			if (event.getMessage().equals("You manage to mine some pay-dirt."))
-			{
+			case "You manage to mine some pay-dirt.":
 				session.incrementPayDirtMined();
-			}
+				break;
+
+			case "You just found a Diamond!":
+				session.incrementGemFound(ItemID.UNCUT_DIAMOND);
+				break;
+
+			case "You just found a Ruby!":
+				session.incrementGemFound(ItemID.UNCUT_RUBY);
+				break;
+
+			case "You just found an Emerald!":
+				session.incrementGemFound(ItemID.UNCUT_EMERALD);
+				break;
+
+			case "You just found a Sapphire!":
+				session.incrementGemFound(ItemID.UNCUT_SAPPHIRE);
+				break;
 		}
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/motherlode/MotherlodeSession.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/motherlode/MotherlodeSession.java
@@ -24,9 +24,14 @@
  */
 package net.runelite.client.plugins.motherlode;
 
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.ItemID;
 import java.time.Duration;
 import java.time.Instant;
 
+@Slf4j
 public class MotherlodeSession
 {
 	private static final Duration HOUR = Duration.ofHours(1);
@@ -38,6 +43,48 @@ public class MotherlodeSession
 
 	private Instant recentPayDirtMined;
 	private int recentMined;
+
+	@Getter(AccessLevel.PACKAGE)
+	private Instant lastGemFound;
+
+	@Getter(AccessLevel.PACKAGE)
+	private int diamondsFound;
+
+	@Getter(AccessLevel.PACKAGE)
+	private int rubiesFound;
+
+	@Getter(AccessLevel.PACKAGE)
+	private int emeraldsFound;
+
+	@Getter(AccessLevel.PACKAGE)
+	private int sapphiresFound;
+
+	public void incrementGemFound(int gemID)
+	{
+		lastGemFound = Instant.now();
+
+		switch (gemID)
+		{
+			case ItemID.UNCUT_DIAMOND:
+				diamondsFound++;
+				break;
+
+			case ItemID.UNCUT_RUBY:
+				rubiesFound++;
+				break;
+
+			case ItemID.UNCUT_EMERALD:
+				emeraldsFound++;
+				break;
+
+			case ItemID.UNCUT_SAPPHIRE:
+				sapphiresFound++;
+				break;
+
+			default:
+				log.error("Invalid gem type specified. The gem count will not be incremented.");
+		}
+	}
 
 	public void incrementPayDirtMined()
 	{


### PR DESCRIPTION
When mining with an alumet of glory the chance of receiving uncut gems increases significantly.

This introduces an overlay to the Motherlode Mine Plugin which shows the numer of gems found during the current mining session.

Screenshot:
![image](https://user-images.githubusercontent.com/4660715/38778111-18d889e2-40b4-11e8-9c24-3695c0b50766.png)
