### PR TITLE
Menu Entry Swapper: Add 'Reset' on dismanteled traps and 'Lay' on expired traps as first value.

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -384,9 +384,13 @@ public class MenuEntrySwapperPlugin extends Plugin
 		{
 			swap("last-destination (", option, target, false);
 		}
-		else if (config.swapBoxTrap() && option.equals("check"))
+		else if (config.swapBoxTrap() && (option.equals("check") || option.equals("dismantle")))
 		{
 			swap("reset", option, target, true);
+		}
+		else if (config.swapBoxTrap() && option.equals("take"))
+		{
+			swap("lay", option, target, true);
 		}
 		else if (config.swapCatacombEntrance() && option.equals("read"))
 		{


### PR DESCRIPTION
Currently it doesn't swap Dismantle and Reset for failed traps.