### PR TITLE
Hunter Plugin: Fix salamander net display (Fixed)

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/coords/Angle.java
+++ b/runelite-api/src/main/java/net/runelite/api/coords/Angle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Adam <Adam@sigterm.info>
+ * Copyright (c) 2018, Adam <Adam@sigterm.info>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -22,33 +22,48 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package net.runelite.api;
+package net.runelite.api.coords;
 
-import java.awt.Polygon;
-import net.runelite.api.coords.Angle;
+import lombok.Value;
+import static net.runelite.api.coords.Direction.EAST;
+import static net.runelite.api.coords.Direction.NORTH;
+import static net.runelite.api.coords.Direction.SOUTH;
+import static net.runelite.api.coords.Direction.WEST;
 
-/**
- *
- * @author Adam
- */
-public interface GameObject extends TileObject
+@Value
+public class Angle
 {
 	/**
-	 * Returns the min x,y for this game object
-	 *
-	 * @return
+	 * angle, 0-2047.
+	 * 0 is south, west is 512, south is 1024, east is 1536s
 	 */
-	Point getRegionMinLocation();
+	private final int angle;
 
 	/**
-	 * Returns the max x,y for this game object. This is different from
-	 * {@link #getRegionMinLocation()} for objects larger than 1 tile.
-	 *
+	 * Get the nearest N/S/E/W direction for this angle
 	 * @return
 	 */
-	Point getRegionMaxLocation();
-
-	Polygon getConvexHull();
-
-	Angle getOrientation();
+	public Direction getNearestDirection()
+	{
+		int round = angle >>> 9;
+		int up = angle & 256;
+		if (up != 0)
+		{
+			// round up
+			++round;
+		}
+		switch (round & 3)
+		{
+			case 0:
+				return SOUTH;
+			case 1:
+				return WEST;
+			case 2:
+				return NORTH;
+			case 3:
+				return EAST;
+			default:
+				throw new IllegalStateException();
+		}
+	}
 }

--- a/runelite-api/src/main/java/net/runelite/api/coords/Direction.java
+++ b/runelite-api/src/main/java/net/runelite/api/coords/Direction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Adam <Adam@sigterm.info>
+ * Copyright (c) 2018, Adam <Adam@sigterm.info>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -22,33 +22,12 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package net.runelite.api;
+package net.runelite.api.coords;
 
-import java.awt.Polygon;
-import net.runelite.api.coords.Angle;
-
-/**
- *
- * @author Adam
- */
-public interface GameObject extends TileObject
+public enum Direction
 {
-	/**
-	 * Returns the min x,y for this game object
-	 *
-	 * @return
-	 */
-	Point getRegionMinLocation();
-
-	/**
-	 * Returns the max x,y for this game object. This is different from
-	 * {@link #getRegionMinLocation()} for objects larger than 1 tile.
-	 *
-	 * @return
-	 */
-	Point getRegionMaxLocation();
-
-	Polygon getConvexHull();
-
-	Angle getOrientation();
+	NORTH,
+	SOUTH,
+	EAST,
+	WEST;
 }

--- a/runelite-api/src/main/java/net/runelite/api/coords/WorldPoint.java
+++ b/runelite-api/src/main/java/net/runelite/api/coords/WorldPoint.java
@@ -53,6 +53,36 @@ public class WorldPoint
 	 */
 	private final int plane;
 
+	/**
+	 * Returns a WorldPoint offset on x from this point
+	 * @param dx offset
+	 * @return
+	 */
+	public WorldPoint dx(int dx)
+	{
+		return new WorldPoint(x + dx, y, plane);
+	}
+
+	/**
+	 * Returns a WorldPoint offset on y from this point
+	 * @param dy offset
+	 * @return
+	 */
+	public WorldPoint dy(int dy)
+	{
+		return new WorldPoint(x, y + dy, plane);
+	}
+
+	/**
+	 * Returns a WorldPoint offset on z from this point
+	 * @param dz offset
+	 * @return
+	 */
+	public WorldPoint dz(int dz)
+	{
+		return new WorldPoint(x, y, plane + dz);
+	}
+
 	public static boolean isInScene(Client client, int x, int y)
 	{
 		int baseX = client.getBaseX();

--- a/runelite-api/src/test/java/net/runelite/api/coords/AngleTest.java
+++ b/runelite-api/src/test/java/net/runelite/api/coords/AngleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Adam <Adam@sigterm.info>
+ * Copyright (c) 2018, Adam <Adam@sigterm.info>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -22,33 +22,23 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package net.runelite.api;
+package net.runelite.api.coords;
 
-import java.awt.Polygon;
-import net.runelite.api.coords.Angle;
+import static net.runelite.api.coords.Direction.NORTH;
+import static net.runelite.api.coords.Direction.WEST;
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
 
-/**
- *
- * @author Adam
- */
-public interface GameObject extends TileObject
+public class AngleTest
 {
-	/**
-	 * Returns the min x,y for this game object
-	 *
-	 * @return
-	 */
-	Point getRegionMinLocation();
 
-	/**
-	 * Returns the max x,y for this game object. This is different from
-	 * {@link #getRegionMinLocation()} for objects larger than 1 tile.
-	 *
-	 * @return
-	 */
-	Point getRegionMaxLocation();
+	@Test
+	public void getNearestDirection()
+	{
+		Angle angle = new Angle(512 + 10);
+		assertEquals(WEST, angle.getNearestDirection());
 
-	Polygon getConvexHull();
-
-	Angle getOrientation();
+		angle = new Angle(512 + 256 + 1);
+		assertEquals(NORTH, angle.getNearestDirection());
+	}
 }

--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSGameObjectMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSGameObjectMixin.java
@@ -28,6 +28,7 @@ import java.awt.Polygon;
 import java.awt.geom.Area;
 import net.runelite.api.Perspective;
 import net.runelite.api.Point;
+import net.runelite.api.coords.Angle;
 import net.runelite.api.mixins.Inject;
 import net.runelite.api.mixins.Mixin;
 import net.runelite.api.mixins.Shadow;
@@ -79,7 +80,7 @@ public abstract class RSGameObjectMixin implements RSGameObject
 	@Override
 	public Area getClickbox()
 	{
-		return Perspective.getClickbox(client, getModel(), getOrientation(), getX(), getY());
+		return Perspective.getClickbox(client, getModel(), getRsOrientation(), getX(), getY());
 	}
 
 	@Inject
@@ -93,6 +94,15 @@ public abstract class RSGameObjectMixin implements RSGameObject
 			return null;
 		}
 
-		return model.getConvexHull(getX(), getY(), getOrientation());
+		return model.getConvexHull(getX(), getY(), getRsOrientation());
+	}
+
+	@Override
+	@Inject
+	public Angle getOrientation()
+	{
+		int orientation = getRsOrientation();
+		int rotation = (getFlags() >> 6) & 3;
+		return new Angle(rotation * 512 + orientation);
 	}
 }

--- a/runescape-api/src/main/java/net/runelite/rs/api/RSGameObject.java
+++ b/runescape-api/src/main/java/net/runelite/rs/api/RSGameObject.java
@@ -59,13 +59,12 @@ public interface RSGameObject extends GameObject
 	int getHeight();
 
 	@Import("orientation")
-	int getOrientation();
+	int getRsOrientation();
 
 	@Import("hash")
 	@Override
 	int getHash();
 
-	@Override
 	@Import("flags")
 	int getFlags();
 }


### PR DESCRIPTION
This is a bugfix for the problems described in #1169 and #1553.

**Problem**:  The hunter plugin stores the incorrect trap tile depending on the angle of the small tree. 

**Solution**: Whenever a trap change is detected that is not in our hash map (and thus null), we cannot assume it is our trap blindly. For each of these traps, we look up adjacent tiles in the hash map. If a tile is one of our keys, we have identified our trap. The changes also separate salamander handling to its own case body, in order to reduce the scope of these scans to salamanders only.

**Considerations**: While I could have shortened the code that was added, I wanted to ensure that there were no unnecessary calculations that could impact performance even in the smallest degree. That's why there are several if-statements and redundant code in each block. 

![after2](https://user-images.githubusercontent.com/25905465/38783826-df138de8-40d5-11e8-85cb-815d343f2dbf.png)

If the changes here could be improved in any way, let me know. I can add comments throughout the code if that would be useful.
**Note**: This was _only_ tested at green salamanders. If you have issues outside of green salamanders, leave a comment. 