### PR TITLE
Display ground items unless GE & HA are below config

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
@@ -134,7 +134,7 @@ public class GroundItemsOverlay extends Overlay
 			// Do not display items that are under HA or GE price and are not highlighted
 			if (!plugin.isHotKeyPressed() && !highlighted
 				&& ((item.getGePrice() > 0 && item.getGePrice() < config.getHideUnderGeValue())
-				|| item.getHaPrice() < config.getHideUnderHAValue()))
+				&& item.getHaPrice() < config.getHideUnderHAValue()))
 			{
 				continue;
 			}


### PR DESCRIPTION
Previously, items would be hidden unless their Grand Exchange and High
Alchemy values were both above the configured values, meaning many items
would not be highlighted due to low alchemy values. (potions, runes,
etc.)