### PR TITLE
Fix layer of MotherlodeOverlay

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/motherlode/MotherlodeOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/motherlode/MotherlodeOverlay.java
@@ -44,7 +44,6 @@ import static net.runelite.api.AnimationID.MINING_MOTHERLODE_RUNE;
 import static net.runelite.api.AnimationID.MINING_MOTHERLODE_STEEL;
 import net.runelite.api.Client;
 import net.runelite.client.ui.overlay.Overlay;
-import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.components.PanelComponent;
 
@@ -66,7 +65,6 @@ class MotherlodeOverlay extends Overlay
 	MotherlodeOverlay(Client client, MotherlodePlugin plugin, MotherlodeConfig config)
 	{
 		setPosition(OverlayPosition.TOP_LEFT);
-		setLayer(OverlayLayer.ABOVE_SCENE);
 		this.client = client;
 		this.plugin = plugin;
 		this.config = config;


### PR DESCRIPTION
To correctly layour motherlode overlay, change it's layer from
ABOVE_WIDGETS to BELOW_WIDGETS (what should be the correct layer for it
anyway).

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>