### PR TITLE
Fix cannon cannonball count

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonPlugin.java
@@ -67,7 +67,6 @@ import net.runelite.client.ui.overlay.infobox.InfoBoxManager;
 public class CannonPlugin extends Plugin
 {
 	private static final Pattern NUMBER_PATTERN = Pattern.compile("([0-9]+)");
-	private static final int MAX_CBALLS = 30;
 
 	private CannonCounter counter;
 
@@ -236,16 +235,7 @@ public class CannonPlugin extends Plugin
 			if (m.find())
 			{
 				int amt = Integer.valueOf(m.group());
-
-				// make sure cballs doesn't go above MAX_CBALLS
-				if (amt + cballsLeft > MAX_CBALLS)
-				{
-					cballsLeft = MAX_CBALLS;
-				}
-				else
-				{
-					cballsLeft += amt;
-				}
+				cballsLeft += amt;
 			}
 		}
 
@@ -256,8 +246,6 @@ public class CannonPlugin extends Plugin
 
 		if (event.getMessage().contains("Your cannon is out of ammo!"))
 		{
-			cballsLeft = 0;
-
 			if (config.showEmptyCannonNotification())
 			{
 				notifier.notify("Your cannon is out of ammo!");


### PR DESCRIPTION
The ChatMessage event runs before the ProjectileMoved event but the server seems to process them in the opposite order. The cannonballs left counter would go to 31, which was reduced to 30 by a check, but the projectile event (if fired in the same game tick) would then reduce it to 29 when it should really have been 30, so the counter would always show 1 less cannonball than the cannon actually had, and eventually it'd go to -1. This pull removes the check which fixes the issue.