### PR TITLE
Add item drop notification

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
@@ -271,4 +271,15 @@ public interface GroundItemsConfig extends Config
 	{
 		return 10000000;
 	}
+
+	@ConfigItem(
+		keyName = "notifyDrop",
+		name = "Notification on Drop",
+		description = "Configures whether to notify the player of an item from highlighted items list being dropped.",
+		position = 21
+	)
+	default boolean notifyDrop()
+	{
+		return false;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
@@ -39,7 +39,6 @@ import net.runelite.api.Player;
 import net.runelite.api.Point;
 import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.coords.WorldPoint;
-import net.runelite.client.Notifier;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
@@ -71,9 +70,6 @@ public class GroundItemsOverlay extends Overlay
 	private final ItemManager itemManager;
 
 	@Inject
-	private Notifier notifier;
-
-	@Inject
 	public GroundItemsOverlay(Client client, GroundItemsPlugin plugin, GroundItemsConfig config, ItemManager itemManager)
 	{
 		setPosition(OverlayPosition.DYNAMIC);
@@ -99,7 +95,6 @@ public class GroundItemsOverlay extends Overlay
 
 		offsetMap.clear();
 		final LocalPoint localLocation = player.getLocalLocation();
-		final boolean shouldNotify = plugin.shouldNotify();
 
 		for (GroundItem item : plugin.getCollectedGroundItems().values())
 		{
@@ -112,9 +107,9 @@ public class GroundItemsOverlay extends Overlay
 
 			final boolean highlighted = plugin.isHighlighted(item.getName());
 			final boolean hidden = plugin.isHidden(item.getName());
-			if (highlighted && shouldNotify)
+			if (highlighted)
 			{
-				notifier.notify("[" + client.getLocalPlayer().getName() + "] just received a drop of " + item.getName() + "!");
+				plugin.setNotify(true);
 			}
 
 			if (!plugin.isHotKeyPressed())
@@ -310,5 +305,4 @@ public class GroundItemsOverlay extends Overlay
 		}
 
 	}
-
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
@@ -39,6 +39,7 @@ import net.runelite.api.Player;
 import net.runelite.api.Point;
 import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.coords.WorldPoint;
+import net.runelite.client.Notifier;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
@@ -70,6 +71,9 @@ public class GroundItemsOverlay extends Overlay
 	private final ItemManager itemManager;
 
 	@Inject
+	private Notifier notifier;
+
+	@Inject
 	public GroundItemsOverlay(Client client, GroundItemsPlugin plugin, GroundItemsConfig config, ItemManager itemManager)
 	{
 		setPosition(OverlayPosition.DYNAMIC);
@@ -95,6 +99,7 @@ public class GroundItemsOverlay extends Overlay
 
 		offsetMap.clear();
 		final LocalPoint localLocation = player.getLocalLocation();
+		final boolean shouldNotify = plugin.shouldNotify();
 
 		for (GroundItem item : plugin.getCollectedGroundItems().values())
 		{
@@ -107,6 +112,10 @@ public class GroundItemsOverlay extends Overlay
 
 			final boolean highlighted = plugin.isHighlighted(item.getName());
 			final boolean hidden = plugin.isHidden(item.getName());
+			if (highlighted && shouldNotify)
+			{
+				notifier.notify("[" + client.getLocalPlayer().getName() + "] just received a drop of " + item.getName() + "!");
+			}
 
 			if (!plugin.isHotKeyPressed())
 			{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
@@ -35,8 +35,6 @@ import com.google.inject.Provides;
 import java.awt.Color;
 import java.awt.Rectangle;
 import static java.lang.Boolean.TRUE;
-
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
@@ -429,6 +429,11 @@ public class GroundItemsPlugin extends Plugin
 		return TRUE.equals(highlightedItems.getUnchecked(item));
 	}
 
+	public boolean shouldNotify()
+	{
+		return config.notifyDrop();
+	}
+
 	public boolean isHidden(String item)
 	{
 		return TRUE.equals(hiddenItems.getUnchecked(item));

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
@@ -35,6 +35,8 @@ import com.google.inject.Provides;
 import java.awt.Color;
 import java.awt.Rectangle;
 import static java.lang.Boolean.TRUE;
+
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -64,11 +66,8 @@ import net.runelite.api.Player;
 import net.runelite.api.Region;
 import net.runelite.api.Tile;
 import net.runelite.api.coords.LocalPoint;
-import net.runelite.api.events.ConfigChanged;
-import net.runelite.api.events.FocusChanged;
-import net.runelite.api.events.GameStateChanged;
-import net.runelite.api.events.ItemLayerChanged;
-import net.runelite.api.events.MenuEntryAdded;
+import net.runelite.api.events.*;
+import net.runelite.client.Notifier;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.input.KeyManager;
@@ -105,10 +104,15 @@ public class GroundItemsPlugin extends Plugin
 
 	private List<String> hiddenItemList = new ArrayList<>();
 	private List<String> highlightedItemsList = new ArrayList<>();
+	private boolean needToNotify = false;
+	private Integer timeSinceLastNotification = 0;
 	private boolean dirty;
 
 	@Inject
 	private GroundItemInputListener inputListener;
+
+	@Inject
+	private Notifier notifier;
 
 	@Inject
 	private MouseManager mouseManager;
@@ -133,6 +137,7 @@ public class GroundItemsPlugin extends Plugin
 	private final List<GroundItem> groundItems = new ArrayList<>();
 	private LoadingCache<String, Boolean> highlightedItems;
 	private LoadingCache<String, Boolean> hiddenItems;
+	private Integer ticksSinceLastNotification = 0;
 
 	// Collects similar ground items
 	private final Collector<GroundItem, ?, Map<GroundItem.GroundItemKey, GroundItem>> groundItemMapCollector = Collectors
@@ -429,9 +434,9 @@ public class GroundItemsPlugin extends Plugin
 		return TRUE.equals(highlightedItems.getUnchecked(item));
 	}
 
-	public boolean shouldNotify()
+	public void setNotify(boolean shouldNotify)
 	{
-		return config.notifyDrop();
+		needToNotify = shouldNotify;
 	}
 
 	public boolean isHidden(String item)
@@ -445,6 +450,18 @@ public class GroundItemsPlugin extends Plugin
 		if (!focusChanged.isFocused())
 		{
 			setHotKeyPressed(false);
+		}
+	}
+
+
+	@Subscribe
+	public void onGameTick(GameTick event)
+	{
+		if (config.notifyDrop() && needToNotify && ticksSinceLastNotification-- == 0)
+		{
+			ticksSinceLastNotification = 50;
+			needToNotify = false;
+			notifier.notify("[" + client.getLocalPlayer().getName() + "] just received a highlighted drop!");
 		}
 	}
 }


### PR DESCRIPTION
This adds a toggle that will send a windows notification to the user whenever a highlighted item is visible. Once triggered it will not trigger again for 30 seconds.