### PR TITLE
Do not use object world locations for clues

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/ClueScrollPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/ClueScrollPlugin.java
@@ -215,34 +215,32 @@ public class ClueScrollPlugin extends Plugin
 
 		if (clue instanceof ObjectClueScroll)
 		{
-			int objectId = ((ObjectClueScroll) clue).getObjectId();
+			final ObjectClueScroll objectClueScroll = (ObjectClueScroll) clue;
+			int objectId = objectClueScroll.getObjectId();
 
 			if (objectId != -1)
 			{
-				if (clue instanceof LocationClueScroll)
+				// Match object with location every time
+				final WorldPoint location = objectClueScroll.getLocation();
+
+				if (location != null)
 				{
-					// Match object with location every time
-					final WorldPoint location = ((LocationClueScroll) clue).getLocation();
+					final LocalPoint localLocation = LocalPoint.fromWorld(client, location);
 
-					if (location != null)
+					if (localLocation != null)
 					{
-						final LocalPoint localLocation = LocalPoint.fromWorld(client, location);
+						final Region region = client.getRegion();
+						final Tile[][][] tiles = region.getTiles();
+						final Tile tile = tiles[client.getPlane()][localLocation.getRegionX()][localLocation.getRegionY()];
 
-						if (localLocation != null)
+						objectsToMark = Arrays.stream(tile.getGameObjects())
+							.filter(object -> object != null && object.getId() == objectId)
+							.toArray(GameObject[]::new);
+
+						// Set hint arrow to first object found as there can only be 1 hint arrow
+						if (objectsToMark.length >= 1)
 						{
-							final Region region = client.getRegion();
-							final Tile[][][] tiles = region.getTiles();
-							final Tile tile = tiles[client.getPlane()][localLocation.getRegionX()][localLocation.getRegionY()];
-
-							objectsToMark = Arrays.stream(tile.getGameObjects())
-								.filter(object -> object != null && object.getId() == objectId)
-								.toArray(GameObject[]::new);
-
-							// Set hint arrow to first object found as there can only be 1 hint arrow
-							if (objectsToMark.length >= 1)
-							{
-								client.setHintArrow(objectsToMark[0].getWorldLocation());
-							}
+							client.setHintArrow(objectsToMark[0].getWorldLocation());
 						}
 					}
 				}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/ClueScrollPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/ClueScrollPlugin.java
@@ -45,12 +45,14 @@ import net.runelite.api.Item;
 import net.runelite.api.ItemComposition;
 import net.runelite.api.NPC;
 import net.runelite.api.Query;
+import net.runelite.api.Region;
+import net.runelite.api.Tile;
+import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.ChatMessage;
 import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.GameTick;
 import net.runelite.api.events.ItemContainerChanged;
-import net.runelite.api.queries.GameObjectQuery;
 import net.runelite.api.queries.InventoryItemQuery;
 import net.runelite.api.queries.NPCQuery;
 import net.runelite.api.widgets.Widget;
@@ -217,13 +219,32 @@ public class ClueScrollPlugin extends Plugin
 
 			if (objectId != -1)
 			{
-				GameObjectQuery query = new GameObjectQuery().idEquals(objectId);
-				objectsToMark = queryRunner.runQuery(query);
-
-				// Set hint arrow to first object found as there can only be 1 hint arrow
-				if (objectsToMark.length >= 1)
+				if (clue instanceof LocationClueScroll)
 				{
-					client.setHintArrow(objectsToMark[0].getWorldLocation());
+					// Match object with location every time
+					final WorldPoint location = ((LocationClueScroll) clue).getLocation();
+
+					if (location != null)
+					{
+						final LocalPoint localLocation = LocalPoint.fromWorld(client, location);
+
+						if (localLocation != null)
+						{
+							final Region region = client.getRegion();
+							final Tile[][][] tiles = region.getTiles();
+							final Tile tile = tiles[client.getPlane()][localLocation.getRegionX()][localLocation.getRegionY()];
+
+							objectsToMark = Arrays.stream(tile.getGameObjects())
+								.filter(object -> object != null && object.getId() == objectId)
+								.toArray(GameObject[]::new);
+
+							// Set hint arrow to first object found as there can only be 1 hint arrow
+							if (objectsToMark.length >= 1)
+							{
+								client.setHintArrow(objectsToMark[0].getWorldLocation());
+							}
+						}
+					}
 				}
 			}
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java
@@ -57,7 +57,7 @@ public class CrypticClue extends ClueScroll implements TextClueScroll, NpcClueSc
 		new CrypticClue("Search for a crate in a building in Hemenster.", CRATE_357, new WorldPoint(2636, 3454, 0), "House north of the Fishing Contest quest area. West of Grandpa Jack."),
 		new CrypticClue("A reck you say Let's pray there aren't any ghosts.", "Father Aereck", new WorldPoint(3242, 3207, 0), "Speak to Father Aereck in Lumbridge."),
 		new CrypticClue("Search the bucket in the Port Sarim jail.", BUCKET_9568, new WorldPoint(3013, 3181, 0), "Talk to Shantay & identify yourself as an outlaw, refuse to pay the 5gp fine twice and you will be sent to the Port Sarim jail."),
-		new CrypticClue("Search the crates in a bank in Varrock.", NULL_336, new WorldPoint(3187, 9824, 0), "Search in the basement of the West Varrock bank."),
+		new CrypticClue("Search the crates in a bank in Varrock.", CRATE_5107, new WorldPoint(3187, 9825, 0), "Search in the basement of the West Varrock bank."),
 		new CrypticClue("Falo the bard wants to see you.", "Falo the Bard", new WorldPoint(2689, 3550, 0), "Speak to Falo the Bard"),
 		new CrypticClue("Search a bookcase in the Wizards tower.", BOOKCASE_12539, new WorldPoint(3113, 3159, 0), "The bookcase located on the ground floor."),
 		new CrypticClue("Come have a cip with this great soot covered denizen.", "Miner Magnus", new WorldPoint(2527, 3891, 0), "Talk to Miner Magnus east of the fairy ring CIP. Answer: 8"),

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java
@@ -47,7 +47,7 @@ import static net.runelite.client.plugins.cluescrolls.ClueScrollWorldOverlay.IMA
 import static net.runelite.client.plugins.cluescrolls.ClueScrollWorldOverlay.SPADE_IMAGE;
 
 @Getter
-public class CrypticClue extends ClueScroll implements TextClueScroll, NpcClueScroll, ObjectClueScroll, LocationClueScroll
+public class CrypticClue extends ClueScroll implements TextClueScroll, NpcClueScroll, ObjectClueScroll
 {
 	private static final Set<CrypticClue> CLUES = ImmutableSet.of(
 		new CrypticClue("Show this to Sherlock.", "Sherlock", new WorldPoint(2733, 3415, 0), "Sherlock is located to the east of the Sorcerer's tower in Seers' Village."),

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/MapClue.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/MapClue.java
@@ -46,7 +46,7 @@ import net.runelite.client.ui.overlay.OverlayUtil;
 import net.runelite.client.ui.overlay.components.PanelComponent;
 
 @Getter
-public class MapClue extends ClueScroll implements ObjectClueScroll, LocationClueScroll
+public class MapClue extends ClueScroll implements ObjectClueScroll
 {
 	private static final Set<MapClue> CLUES = ImmutableSet.of(
 		new MapClue(CLUE_SCROLL_EASY_12179, new WorldPoint(3300, 3291, 0)),

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/MapClue.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/MapClue.java
@@ -30,22 +30,20 @@ import java.awt.Graphics2D;
 import java.util.Set;
 import lombok.Getter;
 import net.runelite.api.GameObject;
+import static net.runelite.api.ItemID.*;
 import net.runelite.api.ObjectComposition;
-import net.runelite.api.Region;
-import net.runelite.api.Tile;
+import static net.runelite.api.ObjectID.*;
 import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.client.plugins.cluescrolls.ClueScrollPlugin;
-import net.runelite.client.ui.overlay.OverlayUtil;
-import net.runelite.client.ui.overlay.components.PanelComponent;
-import static net.runelite.api.ItemID.*;
-import static net.runelite.api.ObjectID.*;
 import static net.runelite.client.plugins.cluescrolls.ClueScrollWorldOverlay.CLICKBOX_BORDER_COLOR;
 import static net.runelite.client.plugins.cluescrolls.ClueScrollWorldOverlay.CLICKBOX_FILL_COLOR;
 import static net.runelite.client.plugins.cluescrolls.ClueScrollWorldOverlay.CLICKBOX_HOVER_BORDER_COLOR;
 import static net.runelite.client.plugins.cluescrolls.ClueScrollWorldOverlay.CLUE_SCROLL_IMAGE;
 import static net.runelite.client.plugins.cluescrolls.ClueScrollWorldOverlay.IMAGE_Z_OFFSET;
 import static net.runelite.client.plugins.cluescrolls.ClueScrollWorldOverlay.SPADE_IMAGE;
+import net.runelite.client.ui.overlay.OverlayUtil;
+import net.runelite.client.ui.overlay.components.PanelComponent;
 
 @Getter
 public class MapClue extends ClueScroll implements ObjectClueScroll, LocationClueScroll
@@ -136,24 +134,20 @@ public class MapClue extends ClueScroll implements ObjectClueScroll, LocationClu
 		// Mark game object
 		if (objectId != -1)
 		{
-			Region region = plugin.getClient().getRegion();
-			Tile[][][] tiles = region.getTiles();
-
-			Tile tile = tiles[plugin.getClient().getPlane()][localLocation.getRegionX()][localLocation.getRegionY()];
-
 			net.runelite.api.Point mousePosition = plugin.getClient().getMouseCanvasPosition();
 
-			for (GameObject gameObject : tile.getGameObjects())
+			if (plugin.getObjectsToMark() != null)
 			{
-				if (gameObject != null)
+				for (GameObject gameObject : plugin.getObjectsToMark())
 				{
 					OverlayUtil.renderHoverableArea(graphics, gameObject.getClickbox(), mousePosition,
-							CLICKBOX_FILL_COLOR, CLICKBOX_BORDER_COLOR, CLICKBOX_HOVER_BORDER_COLOR);
+						CLICKBOX_FILL_COLOR, CLICKBOX_BORDER_COLOR, CLICKBOX_HOVER_BORDER_COLOR);
 
-					OverlayUtil.renderImageLocation(plugin.getClient(), graphics, localLocation, CLUE_SCROLL_IMAGE, IMAGE_Z_OFFSET);
+					OverlayUtil.renderImageLocation(plugin.getClient(), graphics, gameObject.getLocalLocation(), CLUE_SCROLL_IMAGE, IMAGE_Z_OFFSET);
 				}
 			}
 		}
+		// Mark tile
 		else
 		{
 			OverlayUtil.renderTileOverlay(plugin.getClient(), graphics, localLocation, SPADE_IMAGE, Color.ORANGE);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/ObjectClueScroll.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/ObjectClueScroll.java
@@ -24,7 +24,7 @@
  */
 package net.runelite.client.plugins.cluescrolls.clues;
 
-public interface ObjectClueScroll
+public interface ObjectClueScroll extends LocationClueScroll
 {
 	int getObjectId();
 }


### PR DESCRIPTION
- Instead of using object world locations and using query to find
objects, if object clue also has location, just find all objects on tile
on that clue's location and check if ID is matching
- Fix varrock west bank cryptic clue (what was used also during testing)

Fixes #1692 and fixes #1314 and fixes #1732 

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>