### PR TITLE
Add Runepouch bank overlay

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/runepouch/RunepouchConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/runepouch/RunepouchConfig.java
@@ -92,6 +92,4 @@ public interface RunepouchConfig extends Config
 	{
 		return Color.yellow;
 	}
-
-
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/runepouch/RunepouchConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/runepouch/RunepouchConfig.java
@@ -25,6 +25,7 @@
 package net.runelite.client.plugins.runepouch;
 
 import java.awt.Color;
+
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
@@ -36,20 +37,34 @@ import net.runelite.client.config.ConfigItem;
 )
 public interface RunepouchConfig extends Config
 {
+
 	@ConfigItem(
-		keyName = "fontcolor",
-		name = "Font Color",
-		description = "Color of the font for the number of runes in pouch"
+		keyName = "showinbank",
+		name = "Show in bank",
+		description = "Show the contents of the Rune Pouch in the bank",
+		position = 0
 	)
-	default Color fontColor()
+	default boolean showInBank()
 	{
-		return Color.yellow;
+		return true;
+	}
+
+	@ConfigItem(
+		keyName = "showininventory",
+		name = "Show in inventory",
+		description = "Show the contents of the Rune Pouch in the inventory",
+		position = 1
+	)
+	default boolean showInInventory()
+	{
+		return true;
 	}
 
 	@ConfigItem(
 		keyName = "runeicons",
 		name = "Show Rune Icons",
-		description = "Show the rune icons next to the number of runes in pouch"
+		description = "Show the rune icons next to the number of runes in pouch",
+		position = 2
 	)
 	default boolean showIcons()
 	{
@@ -59,10 +74,24 @@ public interface RunepouchConfig extends Config
 	@ConfigItem(
 		keyName = "showOnlyOnHover",
 		name = "Show only on hover",
-		description = "Show the runes only when hovered"
+		description = "Show the runes only when hovered",
+		position = 3
 	)
 	default boolean showOnlyOnHover()
 	{
 		return false;
 	}
+
+	@ConfigItem(
+		keyName = "fontcolor",
+		name = "Font Color",
+		description = "Color of the font for the number of runes in pouch",
+		position = 4
+	)
+	default Color fontColor()
+	{
+		return Color.yellow;
+	}
+
+
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/runepouch/RunepouchOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/runepouch/RunepouchOverlay.java
@@ -29,11 +29,13 @@ import java.awt.Dimension;
 import java.awt.Graphics2D;
 import java.awt.image.BufferedImage;
 import javax.inject.Inject;
+
 import net.runelite.api.Client;
 import net.runelite.api.ItemID;
 import net.runelite.api.Point;
 import net.runelite.api.Query;
 import net.runelite.api.Varbits;
+import net.runelite.api.queries.BankItemQuery;
 import net.runelite.api.queries.InventoryWidgetItemQuery;
 import net.runelite.api.widgets.WidgetItem;
 import net.runelite.client.game.ItemManager;
@@ -49,13 +51,13 @@ import net.runelite.client.util.QueryRunner;
 public class RunepouchOverlay extends Overlay
 {
 	private static final Varbits[] AMOUNT_VARBITS =
-	{
-		Varbits.RUNE_POUCH_AMOUNT1, Varbits.RUNE_POUCH_AMOUNT2, Varbits.RUNE_POUCH_AMOUNT3
-	};
+		{
+			Varbits.RUNE_POUCH_AMOUNT1, Varbits.RUNE_POUCH_AMOUNT2, Varbits.RUNE_POUCH_AMOUNT3
+		};
 	private static final Varbits[] RUNE_VARBITS =
-	{
-		Varbits.RUNE_POUCH_RUNE1, Varbits.RUNE_POUCH_RUNE2, Varbits.RUNE_POUCH_RUNE3
-	};
+		{
+			Varbits.RUNE_POUCH_RUNE1, Varbits.RUNE_POUCH_RUNE2, Varbits.RUNE_POUCH_RUNE3
+		};
 	private static final Dimension IMAGE_SIZE = new Dimension(11, 11);
 
 
@@ -81,8 +83,22 @@ public class RunepouchOverlay extends Overlay
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
-		Query query = new InventoryWidgetItemQuery().idEquals(ItemID.RUNE_POUCH);
-		WidgetItem[] items = queryRunner.runQuery(query);
+		WidgetItem[] items = new WidgetItem[]{};
+
+		// Check if RUNE_POUCH is in inventory
+		if (config.showInInventory())
+		{
+			Query inventoryQuery = new InventoryWidgetItemQuery().idEquals(ItemID.RUNE_POUCH);
+			items = queryRunner.runQuery(inventoryQuery);
+		}
+
+		// Check if RUNE_POUCH is in bank, only if it is not already found in the inventory
+		if (config.showInBank() && items.length == 0)
+		{
+			Query bankQuery = new BankItemQuery().idEquals(ItemID.RUNE_POUCH);
+			items = queryRunner.runQuery(bankQuery);
+		}
+
 		if (items.length == 0)
 		{
 			return null;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/runepouch/RunepouchPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/runepouch/RunepouchPlugin.java
@@ -39,9 +39,6 @@ import net.runelite.client.ui.overlay.Overlay;
 public class RunepouchPlugin extends Plugin
 {
 	@Inject
-	private ConfigManager configManager;
-
-	@Inject
 	private RunepouchOverlay overlay;
 
 	@Provides

--- a/runelite-client/src/main/java/net/runelite/client/plugins/runepouch/RunepouchPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/runepouch/RunepouchPlugin.java
@@ -25,7 +25,9 @@
 package net.runelite.client.plugins.runepouch;
 
 import com.google.inject.Provides;
+
 import javax.inject.Inject;
+
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;


### PR DESCRIPTION
Extended the existing Rune Pouch plugin to also offer an overlay in the bank. The inventory overlay takes priority over the bank (only shows one at a time in the case of multiple rune pouches) and either options are now also on a toggle.