### PR TITLE
Sort Fishing spots by distance from camera

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingPlugin.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2017, Seth <Sethtroll3@gmail.com>
+ * Copyright (c) 2018, Levi <me@levischuck.com>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -30,13 +31,16 @@ import com.google.inject.Provides;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.List;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import lombok.AccessLevel;
 import lombok.Getter;
 import net.runelite.api.ChatMessageType;
+import net.runelite.api.Client;
 import net.runelite.api.NPC;
+import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.events.ChatMessage;
 import net.runelite.api.events.ConfigChanged;
 import net.runelite.api.events.GameTick;
@@ -60,6 +64,9 @@ public class FishingPlugin extends Plugin
 
 	@Getter(AccessLevel.PACKAGE)
 	private NPC[] fishingSpots;
+
+	@Inject
+	private Client client;
 
 	@Inject
 	private QueryRunner queryRunner;
@@ -174,8 +181,13 @@ public class FishingPlugin extends Plugin
 	@Subscribe
 	public void checkSpots(GameTick event)
 	{
-		NPCQuery query = new NPCQuery()
+		final LocalPoint cameraPoint = new LocalPoint(client.getCameraX(), client.getCameraY());
+
+		final NPCQuery query = new NPCQuery()
 			.idEquals(Ints.toArray(spotIds));
-		fishingSpots = queryRunner.runQuery(query);
+		NPC[] spots = queryRunner.runQuery(query);
+		// -1 to make closer things draw last (on top of farther things)
+		Arrays.sort(spots, Comparator.comparing(npc -> -1 * npc.getLocalLocation().distanceTo(cameraPoint)));
+		fishingSpots = spots;
 	}
 }


### PR DESCRIPTION
The default sort of fishing spots ends up drawing further things on top of closer things, as it has no relation to the camera.

To solve this, convert the camera point to a `LocalPoint` and then sort by comparing local points from the NPC to the camera's point. However, the sort is inverted by `-1 *` so that further things are drawn first, and closer things are drawn last--this way closer things are always on top.

Fixes #1737

![screenshot from 2018-04-21 15 03 42](https://user-images.githubusercontent.com/245911/39088382-7ef9b694-4576-11e8-8e7b-9944fae8863e.png)
![screenshot from 2018-04-21 15 03 58](https://user-images.githubusercontent.com/245911/39088383-80e5536e-4576-11e8-9d23-0d72dc04c185.png)

