### PR TITLE
Inventory Highlight While Dragging Plugin (Somewhat WIP)

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/inventoryhighlight/InventoryHighlightConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/inventoryhighlight/InventoryHighlightConfig.java
@@ -1,0 +1,39 @@
+package net.runelite.client.plugins.inventoryhighlight;
+
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+
+@ConfigGroup("inventoryHighlight")
+public interface InventoryHighlightConfig extends Config
+{
+	@ConfigItem(
+		keyName = "showItem",
+		name = "Show the item",
+		description = "Show a preview of the item in the new slot"
+	)
+	default boolean showItem()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		keyName = "showGrid",
+		name = "Show a grid",
+		description = "Show a grid on the inventory while dragging"
+	)
+	default boolean showGrid()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		keyName = "showHighlight",
+		name = "Show background highlight",
+		description = "Show a green background highlight in the new slot"
+	)
+	default boolean showHighlight()
+	{
+		return false;
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/inventoryhighlight/InventoryHighlightInputListener.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/inventoryhighlight/InventoryHighlightInputListener.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2018, Jeremy Plsek <https://github.com/jplsek>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.inventoryhighlight;
+
+import com.google.inject.Inject;
+import java.awt.event.MouseEvent;
+import net.runelite.api.Client;
+import net.runelite.api.GameState;
+import net.runelite.api.Point;
+import net.runelite.api.widgets.Widget;
+import net.runelite.api.widgets.WidgetInfo;
+import net.runelite.api.widgets.WidgetItem;
+import net.runelite.client.input.MouseListener;
+
+public class InventoryHighlightInputListener extends MouseListener
+{
+	private final InventoryHighlightPlugin plugin;
+	private final Client client;
+
+	@Inject
+	public InventoryHighlightInputListener(InventoryHighlightPlugin plugin, Client client)
+	{
+		this.plugin = plugin;
+		this.client = client;
+	}
+
+	@Override
+	public MouseEvent mouseDragged(MouseEvent mouseEvent)
+	{
+		plugin.setDragging(true);
+		return super.mouseDragged(mouseEvent);
+	}
+
+	@Override
+	public MouseEvent mousePressed(MouseEvent mouseEvent)
+	{
+		if (client.getGameState() != GameState.LOGGED_IN)
+		{
+			return super.mousePressed(mouseEvent);
+		}
+
+		final Widget inventoryWidget = client.getWidget(WidgetInfo.INVENTORY);
+		final Widget bankInventoryWidget = client.getWidget(WidgetInfo.BANK_INVENTORY_ITEMS_CONTAINER);
+
+		if ((inventoryWidget == null || inventoryWidget.isSelfHidden()) &&
+			(inventoryWidget == null || bankInventoryWidget == null || bankInventoryWidget.isSelfHidden()))
+		{
+			return super.mousePressed(mouseEvent);
+		}
+
+		final Point mouse = client.getMouseCanvasPosition();
+
+		for (WidgetItem item : inventoryWidget.getWidgetItems())
+		{
+			if (item.getCanvasBounds().contains(mouse.getX(), mouse.getY()))
+			{
+				plugin.setDraggingItem(item.getId());
+				break;
+			}
+		}
+
+		return super.mousePressed(mouseEvent);
+	}
+
+	@Override
+	public MouseEvent mouseReleased(MouseEvent mouseEvent)
+	{
+		plugin.setDragging(false);
+		plugin.setDraggingItem(-1);
+		return super.mouseReleased(mouseEvent);
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/inventoryhighlight/InventoryHighlightOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/inventoryhighlight/InventoryHighlightOverlay.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2018, Jeremy Plsek <https://github.com/jplsek>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.inventoryhighlight;
+
+import com.google.inject.Inject;
+import java.awt.AlphaComposite;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Graphics2D;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.image.BufferedImage;
+import net.runelite.api.Client;
+import net.runelite.api.widgets.Widget;
+import net.runelite.api.widgets.WidgetInfo;
+import net.runelite.client.game.ItemManager;
+import net.runelite.client.ui.overlay.Overlay;
+import net.runelite.client.ui.overlay.OverlayLayer;
+
+public class InventoryHighlightOverlay extends Overlay
+{
+	private final InventoryHighlightPlugin plugin;
+	private final InventoryHighlightConfig config;
+	private final Client client;
+	private final ItemManager itemManager;
+
+	// the inventory widget location is slightly off
+	private static final int FIXED_MARGIN_X = -10;
+	private static final int FIXED_MARGIN_Y = -25;
+	private static final int RESIZEABLE_MARGIN_X = -6;
+	private static final int RESIZEABLE_MARGIN_Y = -21;
+
+	private static final int ITEM_WIDTH = 32;
+	private static final int ITEM_HEIGHT = 32;
+	private static final int ITEM_MARGIN_X = 10;
+	private static final int ITEM_MARGIN_Y = 4;
+
+	private static final Color HIGHLIGHT = new Color(0, 255, 0, 45);
+	private static final Color GRID = new Color(255, 255, 255, 45);
+
+	@Inject
+	public InventoryHighlightOverlay(InventoryHighlightPlugin plugin, InventoryHighlightConfig config, Client client, ItemManager itemManager)
+	{
+		this.plugin = plugin;
+		this.itemManager = itemManager;
+		this.client = client;
+		this.config = config;
+
+		setLayer(OverlayLayer.ABOVE_WIDGETS);
+	}
+
+	@Override
+	public Dimension render(Graphics2D graphics)
+	{
+		if (plugin.getDraggingItem() == -1 || !plugin.isDragging())
+		{
+			return null;
+		}
+
+		int marginX, marginY;
+		if (client.isResized())
+		{
+			marginX = RESIZEABLE_MARGIN_X;
+			marginY = RESIZEABLE_MARGIN_Y;
+		}
+		else
+		{
+			marginX = FIXED_MARGIN_X;
+			marginY = FIXED_MARGIN_Y;
+		}
+
+		final net.runelite.api.Point mouse = client.getMouseCanvasPosition();
+		final Point updatedMouse = new Point(mouse.getX() + marginX, mouse.getY() + marginY);
+
+		// null checks for inventory are checked during dragging events
+		final Widget inventoryWidget = client.getWidget(WidgetInfo.INVENTORY);
+
+		final int inventoryX = inventoryWidget.getCanvasLocation().getX() + marginX;
+		final int inventoryY = inventoryWidget.getCanvasLocation().getY() + marginY;
+
+		final BufferedImage draggedItemImage = itemManager.getImage(plugin.getDraggingItem());
+
+		for (int i = 0; i < 4; i++)
+		{
+			for (int j = 0; j < 7; j++)
+			{
+				final int x = (ITEM_WIDTH + ITEM_MARGIN_X) * i + inventoryX;
+				final int y = (ITEM_HEIGHT + ITEM_MARGIN_Y) * j + inventoryY;
+				final Rectangle bounds = new Rectangle(x, y, ITEM_WIDTH, ITEM_HEIGHT);
+
+				if (config.showItem() && bounds.contains(updatedMouse))
+				{
+					graphics.setComposite(AlphaComposite.SrcOver.derive(0.3f));
+					graphics.drawImage(draggedItemImage, x, y, null);
+					graphics.setComposite(AlphaComposite.SrcOver);
+				}
+
+				if (config.showHighlight() && bounds.contains(updatedMouse))
+				{
+					graphics.setColor(HIGHLIGHT);
+					graphics.fill(bounds);
+				}
+
+				if (config.showGrid())
+				{
+					// don't set color on highlighted slot
+					if (!config.showHighlight() || !(config.showHighlight() && bounds.contains(updatedMouse)))
+					{
+						graphics.setColor(GRID);
+						graphics.fill(bounds);
+					}
+				}
+			}
+		}
+
+		return null;
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/inventoryhighlight/InventoryHighlightPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/inventoryhighlight/InventoryHighlightPlugin.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2018, Jeremy Plsek <https://github.com/jplsek>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.inventoryhighlight;
+
+import com.google.common.eventbus.Subscribe;
+import com.google.inject.Inject;
+import com.google.inject.Provides;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.Setter;
+import net.runelite.api.events.FocusChanged;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.input.MouseManager;
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.ui.overlay.OverlayManager;
+
+@PluginDescriptor(
+	name = "Inventory Highlight",
+	description = "Shows a preview of where items will be dragged",
+	tags = {"items", "overlay"},
+	enabledByDefault = false
+)
+public class InventoryHighlightPlugin extends Plugin
+{
+	@Inject
+	private InventoryHighlightOverlay overlay;
+
+	@Inject
+	private InventoryHighlightConfig config;
+
+	@Inject
+	private InventoryHighlightInputListener inputListener;
+
+	@Inject
+	private MouseManager mouseManager;
+
+	@Inject
+	private OverlayManager overlayManager;
+
+	@Getter(AccessLevel.PACKAGE)
+	@Setter(AccessLevel.PACKAGE)
+	private int draggingItem = -1;
+
+	@Getter(AccessLevel.PACKAGE)
+	@Setter(AccessLevel.PACKAGE)
+	private boolean dragging = false;
+
+	@Override
+	public void startUp()
+	{
+		overlayManager.add(overlay);
+		mouseManager.registerMouseListener(inputListener);
+	}
+
+	@Override
+	public void shutDown()
+	{
+		mouseManager.unregisterMouseListener(inputListener);
+		overlayManager.remove(overlay);
+	}
+
+	@Provides
+	InventoryHighlightConfig getConfig(ConfigManager configManager)
+	{
+		return configManager.getConfig(InventoryHighlightConfig.class);
+	}
+
+	@Subscribe
+	public void onFocusChanged(FocusChanged focusChanged)
+	{
+		if (!focusChanged.isFocused())
+		{
+			dragging = false;
+			draggingItem = -1;
+		}
+	}
+}


### PR DESCRIPTION
This is somewhat a work in progress. Although it works and is mostly feature complete, the way dragging is detected can be improved. I have a feeling that there is a way to detect when an item is being dragged in the runescape client (similar to widget dragged, but that doesn't work for items). Figuring out the render layer would also be nice so the overlays don't draw on top of the item.

Closes #1333 

Examples of different options:
From left to right: The default option (renders an item underneath), highlight option, highlight and grid option.
![ezgif-5-7f125a901c](https://user-images.githubusercontent.com/2388657/39088339-eb9cb9b6-457d-11e8-9443-7aa1d220da84.gif)

Suggestions welcome.

I chose to make the plugin is disabled by default just so players are not surprised or get distracted.