### PR TITLE
stretched mode: pass extended modifiers on click

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/stretchedfixedmode/TranslateMouseListener.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/stretchedfixedmode/TranslateMouseListener.java
@@ -94,8 +94,8 @@ public class TranslateMouseListener extends MouseListener
 			int newX = (int) (e.getX() / (stretchedDimensions.width / (double) Constants.GAME_FIXED_WIDTH));
 			int newY = (int) (e.getY() / (stretchedDimensions.height / (double) Constants.GAME_FIXED_HEIGHT));
 
-			return new MouseEvent((Component) e.getSource(), e.getID(), e.getWhen(), e.getModifiers(),
-					newX, newY, e.getClickCount(), e.isPopupTrigger());
+			return new MouseEvent((Component) e.getSource(), e.getID(), e.getWhen(), e.getModifiersEx(),
+					newX, newY, e.getClickCount(), e.isPopupTrigger(), e.getButton());
 		}
 
 		return e;


### PR DESCRIPTION
The MouseEvent constructor says in its documentation to pass the extended modifiers. This contains alt, ctrl, meta, etc. Doing this also requires passing down the button pressed in the constructor.

Fixes #1618