### PR TITLE
Fix runelite-client shading

### DIFF
--- a/runelite-client/pom.xml
+++ b/runelite-client/pom.xml
@@ -208,13 +208,13 @@
 									</includes>
 								</filter>
 								<filter>
-									<artifact>net.runelite.rs:api</artifact>
+									<artifact>net.runelite.rs:runescape-api</artifact>
 									<includes>
 										<include>**</include>
 									</includes>
 								</filter>
 								<filter>
-									<artifact>org.pushingpixels:*</artifact>
+									<artifact>net.runelite.pushingpixels:*</artifact>
 									<includes>
 										<include>**</include>
 									</includes>


### PR DESCRIPTION
After changes to artifacts names, fix shading of runelite-client to make
it keep everything that is required.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>