### PR TITLE
Add support for colored HP xp drops if XP drops are splitted and a combat prayer is active

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/experiencedrop/XpDropPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/experiencedrop/XpDropPlugin.java
@@ -100,7 +100,7 @@ public class XpDropPlugin extends Plugin
 				case MELEE:
 					if (spriteIDs.anyMatch(id ->
                             id == SpriteID.SKILL_ATTACK || id == SpriteID.SKILL_STRENGTH || id == SpriteID.SKILL_DEFENCE
-                                    || id == SpriteID.SKILL_HITPOINTS))
+                            || id == SpriteID.SKILL_HITPOINTS))
 					{
 						color = config.getMeleePrayerColor().getRGB();
 					}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/experiencedrop/XpDropPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/experiencedrop/XpDropPlugin.java
@@ -99,8 +99,8 @@ public class XpDropPlugin extends Plugin
 			{
 				case MELEE:
 					if (spriteIDs.anyMatch(id ->
-                            (id == SpriteID.SKILL_ATTACK) || (id == SpriteID.SKILL_STRENGTH) || (id == SpriteID.SKILL_DEFENCE)
-                                    || (id == SpriteID.SKILL_HITPOINTS)))
+                            id == SpriteID.SKILL_ATTACK || id == SpriteID.SKILL_STRENGTH || id == SpriteID.SKILL_DEFENCE
+                                    || id == SpriteID.SKILL_HITPOINTS))
 					{
 						color = config.getMeleePrayerColor().getRGB();
 					}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/experiencedrop/XpDropPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/experiencedrop/XpDropPlugin.java
@@ -99,19 +99,20 @@ public class XpDropPlugin extends Plugin
 			{
 				case MELEE:
 					if (spriteIDs.anyMatch(id ->
-						id == SpriteID.SKILL_ATTACK || id == SpriteID.SKILL_STRENGTH || id == SpriteID.SKILL_DEFENCE))
+                            (id == SpriteID.SKILL_ATTACK) || (id == SpriteID.SKILL_STRENGTH) || (id == SpriteID.SKILL_DEFENCE)
+                                    || (id == SpriteID.SKILL_HITPOINTS)))
 					{
 						color = config.getMeleePrayerColor().getRGB();
 					}
 					break;
 				case RANGE:
-					if (spriteIDs.anyMatch(id -> id == SpriteID.SKILL_RANGED))
+					if (spriteIDs.anyMatch(id -> id == SpriteID.SKILL_RANGED || id == SpriteID.SKILL_HITPOINTS))
 					{
 						color = config.getRangePrayerColor().getRGB();
 					}
 					break;
 				case MAGIC:
-					if (spriteIDs.anyMatch(id -> id == SpriteID.SKILL_MAGIC))
+					if (spriteIDs.anyMatch(id -> id == SpriteID.SKILL_MAGIC || id == SpriteID.SKILL_HITPOINTS))
 					{
 						color = config.getMagePrayerColor().getRGB();
 					}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/experiencedrop/XpDropPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/experiencedrop/XpDropPlugin.java
@@ -99,12 +99,13 @@ public class XpDropPlugin extends Plugin
 			{
 				case MELEE:
 					if (spriteIDs.anyMatch(id ->
-                            id == SpriteID.SKILL_ATTACK || id == SpriteID.SKILL_STRENGTH || id == SpriteID.SKILL_DEFENCE
-                            || id == SpriteID.SKILL_HITPOINTS))
+							id == SpriteID.SKILL_ATTACK || id == SpriteID.SKILL_STRENGTH || id == SpriteID.SKILL_DEFENCE
+								|| id == SpriteID.SKILL_HITPOINTS))
 					{
 						color = config.getMeleePrayerColor().getRGB();
 					}
 					break;
+
 				case RANGE:
 					if (spriteIDs.anyMatch(id -> id == SpriteID.SKILL_RANGED || id == SpriteID.SKILL_HITPOINTS))
 					{


### PR DESCRIPTION
Fix for ref #1751 , works exactly as described in the feature request.