### PR TITLE
Add Mark of Grace highlighting to Agility plugin

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/agilityplugin/AgilityConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/agilityplugin/AgilityConfig.java
@@ -68,4 +68,27 @@ public interface AgilityConfig extends Config
 	{
 		return Color.GREEN;
 	}
+
+	@ConfigItem(
+		keyName = "highlightMarks",
+		name = "Highlight Marks of Grace",
+		description = "Enable/disable the highlighting of retrievable Marks of Grace",
+		position = 4
+	)
+	default boolean highlightMarks()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		keyName = "markHighlight",
+		name = "Mark highlight Color",
+		description = "Color of highlighted Marks of Grace",
+		position = 5
+	)
+	default Color getMarkColor()
+	{
+		return Color.ORANGE;
+	}
+
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/agilityplugin/AgilityOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/agilityplugin/AgilityOverlay.java
@@ -26,6 +26,7 @@
 package net.runelite.client.plugins.agilityplugin;
 
 import java.awt.Color;
+import static java.awt.Color.RED;
 import java.awt.Dimension;
 import java.awt.Graphics2D;
 import java.awt.geom.Area;
@@ -33,10 +34,12 @@ import javax.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.Point;
+import net.runelite.api.Tile;
 import net.runelite.api.coords.LocalPoint;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.OverlayUtil;
 
 @Slf4j
 public class AgilityOverlay extends Overlay
@@ -62,6 +65,7 @@ public class AgilityOverlay extends Overlay
 	{
 		LocalPoint playerLocation = client.getLocalPlayer().getLocalLocation();
 		Point mousePosition = client.getMouseCanvasPosition();
+		final Tile markOfGrace = plugin.getMarkOfGrace();
 		plugin.getObstacles().forEach((object, tile) ->
 		{
 			if (tile.getPlane() == client.getPlane()
@@ -70,7 +74,7 @@ public class AgilityOverlay extends Overlay
 				Area objectClickbox = object.getClickbox();
 				if (objectClickbox != null)
 				{
-					Color configColor = config.getOverlayColor();
+					Color configColor = markOfGrace != null ? RED : config.getOverlayColor();
 					if (objectClickbox.contains(mousePosition.getX(), mousePosition.getY()))
 					{
 						graphics.setColor(configColor.darker());
@@ -86,6 +90,15 @@ public class AgilityOverlay extends Overlay
 			}
 
 		});
+
+		if (markOfGrace != null && config.highlightMarks())
+		{
+			if (markOfGrace.getPlane() == client.getPlane() && markOfGrace.getItemLayer() != null
+				&& markOfGrace.getLocalLocation().distanceTo(playerLocation) < MAX_DISTANCE)
+			{
+				OverlayUtil.renderTileOverlay(graphics, markOfGrace.getItemLayer(), "Mark of Grace", config.getMarkColor());
+			}
+		}
 
 		return null;
 	}


### PR DESCRIPTION
Wouldn't mind seeing this in the client, something I enjoyed in OSB, useful if you aren't really paying attention to the game while training but don't want to miss those marks.

- Added optional highlighting for marks of grace.
- Added two new configuration options to agility settings.

Uses single tile location as only one mark seems to be able to spawn. From my testing there wasn't a need to use a list and store/highlight multiple tiles.

Like so
![java_2018-04-23_19-49-21](https://user-images.githubusercontent.com/38576432/39129601-1183036a-474a-11e8-8892-650224cd7e41.png)
