### PR TITLE
Fix clue resetting

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/ClueScrollPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/ClueScrollPlugin.java
@@ -352,7 +352,16 @@ public class ClueScrollPlugin extends Plugin
 					return emoteClue;
 				}
 
-				return FairyRingClue.forText(text);
+				final FairyRingClue fairyRingClue = FairyRingClue.forText(text);
+
+				if (fairyRingClue != null)
+				{
+					return fairyRingClue;
+				}
+
+				// We have unknown clue, reset
+				resetClue();
+				return null;
 			}
 		}
 


### PR DESCRIPTION
- Save last item ID on either map clue or when reading regular clue
- If this item is removed from inventory reset clue
- If we opened clue but it is uknown simply reset clue overlay

Fixes #1966

Preview:
![peek 2018-04-23 21-52](https://user-images.githubusercontent.com/5115805/39149868-d3714766-4740-11e8-92c8-192e5d844261.gif)
