### PR TITLE
NPE 

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsPlugin.java
@@ -176,7 +176,7 @@ public class NpcIndicatorsPlugin extends Plugin
 
 			for (String highlight : highlightedNpcs)
 			{
-				if (WildcardMatcher.matches(highlight, npcName))
+				if (npc.getName() != null && WildcardMatcher.matches(highlight, npcName))
 				{
 					npcMap.put(npc, npcName);
 				}

--- a/runelite-client/src/main/java/net/runelite/client/util/WildcardMatcher.java
+++ b/runelite-client/src/main/java/net/runelite/client/util/WildcardMatcher.java
@@ -33,6 +33,11 @@ public class WildcardMatcher
 
 	public static boolean matches(String pattern, String text)
 	{
+		if (pattern == null || text == null)
+		{
+			return false;
+		}
+
 		final Matcher matcher = WILDCARD_PATTERN.matcher(pattern);
 		final StringBuffer buffer = new StringBuffer();
 


### PR DESCRIPTION
Was getting NPE on a fresh pull and rebase from the repo. Occured after [cff46bb](https://github.com/runelite/runelite/commit/cff46bb3d891eb0109882f80d22f2bcfe72da08f)

Changed two lines, null checks in both the affected plugin and the ```matches()``` method

<details><summary>Stacktrace</summary><p>

```
java.lang.NullPointerException: null
	at net.runelite.client.util.WildcardMatcher.matches(WildcardMatcher.java:55)
	at net.runelite.client.plugins.npchighlight.NpcIndicatorsPlugin.buildNpcsToHighlight(NpcIndicatorsPlugin.java:179)
	at net.runelite.client.plugins.npchighlight.NpcIndicatorsPlugin.onGameTick(NpcIndicatorsPlugin.java:143)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:564)
	at com.google.common.eventbus.Subscriber.invokeSubscriberMethod(Subscriber.java:91)
	at com.google.common.eventbus.Subscriber$SynchronizedSubscriber.invokeSubscriberMethod(Subscriber.java:150)
	at com.google.common.eventbus.Subscriber$1.run(Subscriber.java:76)
	at com.google.common.util.concurrent.MoreExecutors$DirectExecutor.execute(MoreExecutors.java:399)
	at com.google.common.eventbus.Subscriber.dispatchEvent(Subscriber.java:71)
	at com.google.common.eventbus.Dispatcher$PerThreadQueuedDispatcher.dispatch(Dispatcher.java:116)
	at com.google.common.eventbus.EventBus.post(EventBus.java:217)
	at net.runelite.client.callback.Hooks.clientMainLoop(Hooks.java:113)
	at client.ac(client.java)
	at br.f(br.java:408)
	at br.copy$run(br.java:362)
	at br.run(br.java:60)
	at java.base/java.lang.Thread.run(Thread.java:844)```

</p></details>
