### PR TITLE
Cleanup sidebar expanding/closing

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/util/SwingUtil.java
+++ b/runelite-client/src/main/java/net/runelite/client/util/SwingUtil.java
@@ -228,17 +228,6 @@ public class SwingUtil
 		});
 	}
 
-	/**
-	 * Revalidate minimum frame size.
-	 *
-	 * @param frame the frame
-	 */
-	public static void revalidateMinimumSize(final JFrame frame)
-	{
-		// The JFrame only respects minimumSize if it was set by setMinimumSize, for some reason. (atleast on windows/native)
-		frame.setMinimumSize(frame.getLayout().minimumLayoutSize(frame));
-	}
-
 	private static BufferedImage resizeImage(BufferedImage image, int newWidth, int newHeight)
 	{
 		final Image tmp = image.getScaledInstance(newWidth, newHeight, Image.SCALE_SMOOTH);


### PR DESCRIPTION
- Instead of changing the frame width, just revalidate the width to match
minumum size in case the size is smaller than it
- On restoration from maximize, revalidate frame size to not end up in
having small window with opened sidebar

Closes #1795 and closes #1300

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>