### PR TITLE
Add support for mapping parameter names

### DIFF
--- a/deobfuscator/src/main/java/net/runelite/asm/Method.java
+++ b/deobfuscator/src/main/java/net/runelite/asm/Method.java
@@ -31,9 +31,12 @@ import net.runelite.asm.attributes.Code;
 import net.runelite.asm.attributes.Exceptions;
 import net.runelite.asm.attributes.annotation.Annotation;
 import net.runelite.asm.attributes.code.Instruction;
+import net.runelite.asm.attributes.code.LocalVariable;
+import net.runelite.asm.attributes.code.Parameter;
 import net.runelite.asm.attributes.code.instruction.types.LVTInstruction;
 import net.runelite.asm.signature.Signature;
 import org.objectweb.asm.AnnotationVisitor;
+import org.objectweb.asm.Label;
 import org.objectweb.asm.MethodVisitor;
 import static org.objectweb.asm.Opcodes.ACC_FINAL;
 import static org.objectweb.asm.Opcodes.ACC_NATIVE;
@@ -54,6 +57,7 @@ public class Method
 	private Signature arguments;
 	private Exceptions exceptions;
 	private Annotations annotations;
+	private List<Parameter> parameters;
 	private Code code;
 
 	public Method(ClassFile classFile, String name, Signature signature)
@@ -63,6 +67,7 @@ public class Method
 		this.arguments = signature;
 		exceptions = new Exceptions();
 		annotations = new Annotations();
+		parameters = new ArrayList<>();
 	}
 
 	public ClassFile getClassFile()
@@ -78,6 +83,12 @@ public class Method
 
 	public void accept(MethodVisitor visitor)
 	{
+		//This is required to name unused parameters
+		for (Parameter p : parameters)
+		{
+			visitor.visitParameter(p.getName(), p.getAccess());
+		}
+
 		for (Annotation annotation : annotations.getAnnotations())
 		{
 			AnnotationVisitor av = visitor.visitAnnotation(annotation.getType().toString(), true);
@@ -117,6 +128,33 @@ public class Method
 			for (Instruction i : code.getInstructions().getInstructions())
 			{
 				i.accept(visitor);
+			}
+
+			//Find first and last label for this method
+			if (parameters.size() > 0)
+			{
+				Label startLabel = null;
+				Label endLabel = null;
+				for (Instruction i : code.getInstructions().getInstructions())
+				{
+					if (i instanceof net.runelite.asm.attributes.code.Label)
+					{
+						if (startLabel == null)
+						{
+							startLabel = ((net.runelite.asm.attributes.code.Label) i).getLabel();
+						}
+						endLabel = ((net.runelite.asm.attributes.code.Label) i).getLabel();
+					}
+				}
+
+				for (Parameter p : parameters)
+				{
+					LocalVariable lv = p.getLocalVariable();
+					if (lv != null)
+					{
+						visitor.visitLocalVariable(lv.getName(), lv.getDesc(), lv.getSignature(), startLabel, endLabel, lv.getIndex());
+					}
+				}
 			}
 
 			visitor.visitMaxs(code.getMaxStack(), code.getMaxLocals());
@@ -262,5 +300,15 @@ public class Method
 			name,
 			arguments
 		);
+	}
+
+	public List<Parameter> getParameters()
+	{
+		return parameters;
+	}
+
+	public void setParameters(List<Parameter> parameters)
+	{
+		this.parameters = parameters;
 	}
 }

--- a/deobfuscator/src/main/java/net/runelite/asm/attributes/code/LocalVariable.java
+++ b/deobfuscator/src/main/java/net/runelite/asm/attributes/code/LocalVariable.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2018 Morgan Lewis <http://github.com/MESLewis>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.asm.attributes.code;
+
+import org.objectweb.asm.Label;
+
+public class LocalVariable
+{
+	private final String name;
+	private final String desc;
+	private final String signature;
+	private final Label start;
+	private final Label end;
+	private final int index;
+
+	public LocalVariable(String name, String desc, String signature, Label start, Label end, int index)
+	{
+		this.name = name;
+		this.desc = desc;
+		this.signature = signature;
+		this.start = start;
+		this.end = end;
+		this.index = index;
+	}
+
+	public String getName()
+	{
+		return name;
+	}
+
+	public String getDesc()
+	{
+		return desc;
+	}
+
+	public String getSignature()
+	{
+		return signature;
+	}
+
+	public Label getStart()
+	{
+		return start;
+	}
+
+	public Label getEnd()
+	{
+		return end;
+	}
+
+	public int getIndex()
+	{
+		return index;
+	}
+}

--- a/deobfuscator/src/main/java/net/runelite/asm/attributes/code/Parameter.java
+++ b/deobfuscator/src/main/java/net/runelite/asm/attributes/code/Parameter.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2018 Morgan Lewis <http://github.com/MESLewis>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.asm.attributes.code;
+
+public class Parameter
+{
+	private final String name;
+	private final int access;
+	private LocalVariable localVariable;
+
+	public Parameter(String name, int access)
+	{
+		this.name = name;
+		this.access = access;
+	}
+
+	public String getName()
+	{
+		return name;
+	}
+
+	public int getAccess()
+	{
+		return access;
+	}
+
+	public LocalVariable getLocalVariable()
+	{
+		return localVariable;
+	}
+
+	public void setLocalVariable(LocalVariable localVariable)
+	{
+		this.localVariable = localVariable;
+	}
+}

--- a/deobfuscator/src/main/java/net/runelite/asm/visitors/CodeVisitor.java
+++ b/deobfuscator/src/main/java/net/runelite/asm/visitors/CodeVisitor.java
@@ -36,6 +36,8 @@ import net.runelite.asm.attributes.code.Exceptions;
 import net.runelite.asm.attributes.code.Instruction;
 import net.runelite.asm.attributes.code.InstructionType;
 import net.runelite.asm.attributes.code.Instructions;
+import net.runelite.asm.attributes.code.LocalVariable;
+import net.runelite.asm.attributes.code.Parameter;
 import net.runelite.asm.attributes.code.instruction.types.FieldInstruction;
 import net.runelite.asm.attributes.code.instruction.types.IntInstruction;
 import net.runelite.asm.attributes.code.instruction.types.InvokeInstruction;
@@ -111,6 +113,12 @@ public class CodeVisitor extends MethodVisitor
 	{
 		Type type = new Type(desc);
 		return new MethodAnnotationVisitor(method, type);
+	}
+
+	@Override
+	public void visitParameter(String name, int access)
+	{
+		method.getParameters().add(new Parameter(name, access));
 	}
 
 	private Instruction createInstructionFromOpcode(int opcode)
@@ -300,6 +308,21 @@ public class CodeVisitor extends MethodVisitor
 	{
 		Instruction i = code.getInstructions().findOrCreateLabel(label);
 		code.getInstructions().addInstruction(i);
+	}
+
+	@Override
+	public void visitLocalVariable(String name, String desc, String signature, Label start, Label end, int index)
+	{
+		LocalVariable lv = new LocalVariable(name, desc, signature, start, end, index);
+
+		for (Parameter p : method.getParameters())
+		{
+			if (p.getName().equals(name))
+			{
+				p.setLocalVariable(lv);
+				break;
+			}
+		}
 	}
 
 	@Override

--- a/deobfuscator/src/main/java/net/runelite/deob/updater/ParameterRenamer.java
+++ b/deobfuscator/src/main/java/net/runelite/deob/updater/ParameterRenamer.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2018, Morgan Lewis <http://github.com/MESLewis>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.deob.updater;
+
+import net.runelite.asm.ClassFile;
+import net.runelite.asm.ClassGroup;
+import net.runelite.asm.Method;
+import net.runelite.deob.deobfuscators.mapping.ParallelExecutorMapping;
+
+public class ParameterRenamer
+{
+	private final ClassGroup source;
+	private final ClassGroup dest;
+	private final ParallelExecutorMapping mapping;
+
+	public ParameterRenamer(ClassGroup source, ClassGroup dest, ParallelExecutorMapping mapping)
+	{
+		this.source = source;
+		this.dest = dest;
+		this.mapping = mapping;
+	}
+
+	public void run()
+	{
+		for (ClassFile sourceCF : source.getClasses())
+		{
+			for (Method sourceM : sourceCF.getMethods())
+			{
+				Method destM = (Method) mapping.get(sourceM);
+				if (destM != null)
+				{
+					destM.setParameters(sourceM.getParameters());
+				}
+			}
+		}
+	}
+}

--- a/deobfuscator/src/main/java/net/runelite/deob/updater/UpdateMappings.java
+++ b/deobfuscator/src/main/java/net/runelite/deob/updater/UpdateMappings.java
@@ -69,6 +69,9 @@ public class UpdateMappings
 
 		AnnotationRenamer an = new AnnotationRenamer(group2);
 		an.run();
+
+		ParameterRenamer pr = new ParameterRenamer(group1, group2, mapping);
+		pr.run();
 	}
 
 	public void save(File out) throws IOException

--- a/http-service/pom.xml
+++ b/http-service/pom.xml
@@ -138,7 +138,6 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.5.1</version>
 				<configuration>
 					<annotationProcessorPaths>
 						<path>

--- a/pom.xml
+++ b/pom.xml
@@ -223,6 +223,11 @@
 					<artifactId>maven-jar-plugin</artifactId>
 					<version>3.0.2</version>
 				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-compiler-plugin</artifactId>
+					<version>3.6.1</version>
+				</plugin>
 			</plugins>
 		</pluginManagement>
 		<extensions>

--- a/runelite-mixins/pom.xml
+++ b/runelite-mixins/pom.xml
@@ -60,7 +60,6 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.6.1</version>
 				<configuration>
 					<!-- RuneScape classes do not verify
 					 under Java 7+ due to the obfuscation

--- a/runescape-client/pom.xml
+++ b/runescape-client/pom.xml
@@ -73,6 +73,15 @@
 					<skip>true</skip>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<compilerArgs>
+						<arg>-parameters</arg>
+					</compilerArgs>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 </project>


### PR DESCRIPTION
Allow the mapper to transfer method parameter names between versions

This was tested by renaming a parameter in runescape-client and running the actions from runelite/updater shell script.

I am going to keep doing further testing, including running this on the next game update.