### PR TITLE
Fix issue where hiding local player would not hide you when in clan

### DIFF
--- a/runelite-mixins/src/main/java/net/runelite/mixins/EntityHiderMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/EntityHiderMixin.java
@@ -112,8 +112,9 @@ public abstract class EntityHiderMixin implements RSRegion
 		{
 			boolean local = drawingUI ? hideLocalPlayer2D : hideLocalPlayer;
 			boolean other = drawingUI ? hidePlayers2D : hidePlayers;
+			boolean isLocalPlayer = renderable == client.getLocalPlayer();
 
-			if (renderable == client.getLocalPlayer() ? local : other)
+			if (isLocalPlayer ? local : other)
 			{
 				RSPlayer player = (RSPlayer) renderable;
 
@@ -125,7 +126,7 @@ public abstract class EntityHiderMixin implements RSRegion
 					}
 				}
 
-				return (!hideFriends && player.isFriend()) || (!hideClanMates && player.isClanMember());
+				return (!hideFriends && player.isFriend()) || (!isLocalPlayer && !hideClanMates && player.isClanMember());
 			}
 		}
 		else if (renderable instanceof RSNPC)


### PR DESCRIPTION
This fixes an issue where the entity hider would not hide the local player when this option was enabled. The cause of this was the player is seen as a clan member and thus it was affected by the isClanMember check.