### PR TITLE
Do not draw text on top of Mark Of Grace

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/agilityplugin/AgilityOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/agilityplugin/AgilityOverlay.java
@@ -29,6 +29,7 @@ import java.awt.Color;
 import static java.awt.Color.RED;
 import java.awt.Dimension;
 import java.awt.Graphics2D;
+import java.awt.Polygon;
 import java.awt.geom.Area;
 import javax.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
@@ -75,6 +76,7 @@ public class AgilityOverlay extends Overlay
 				if (objectClickbox != null)
 				{
 					Color configColor = markOfGrace != null ? RED : config.getOverlayColor();
+
 					if (objectClickbox.contains(mousePosition.getX(), mousePosition.getY()))
 					{
 						graphics.setColor(configColor.darker());
@@ -83,6 +85,7 @@ public class AgilityOverlay extends Overlay
 					{
 						graphics.setColor(configColor);
 					}
+
 					graphics.draw(objectClickbox);
 					graphics.setColor(new Color(configColor.getRed(), configColor.getGreen(), configColor.getBlue(), 50));
 					graphics.fill(objectClickbox);
@@ -96,7 +99,14 @@ public class AgilityOverlay extends Overlay
 			if (markOfGrace.getPlane() == client.getPlane() && markOfGrace.getItemLayer() != null
 				&& markOfGrace.getLocalLocation().distanceTo(playerLocation) < MAX_DISTANCE)
 			{
-				OverlayUtil.renderTileOverlay(graphics, markOfGrace.getItemLayer(), "Mark of Grace", config.getMarkColor());
+				final Polygon poly = markOfGrace.getItemLayer().getCanvasTilePoly();
+
+				if (poly == null)
+				{
+					return null;
+				}
+
+				OverlayUtil.renderPolygon(graphics, poly, config.getMarkColor());
 			}
 		}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/agilityplugin/AgilityPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/agilityplugin/AgilityPlugin.java
@@ -165,11 +165,13 @@ public class AgilityPlugin extends Plugin
 	public void onItemLayerChanged(ItemLayerChanged event)
 	{
 		if (obstacles.isEmpty())
+		{
 			return;
+		}
 
-		Tile tile = event.getTile();
-		ItemLayer itemLayer = tile.getItemLayer();
-		boolean hasMark = tileHasMark(itemLayer);
+		final Tile tile = event.getTile();
+		final ItemLayer itemLayer = tile.getItemLayer();
+		final boolean hasMark = tileHasMark(itemLayer);
 
 		if (markOfGrace != null && tile.getWorldLocation().equals(markOfGrace.getWorldLocation()) && !hasMark)
 		{
@@ -203,8 +205,6 @@ public class AgilityPlugin extends Plugin
 		return false;
 	}
 
-	// This code, brought to you, in part, by the letters C and V
-	// ... and the words "search" and "replace"
 	@Subscribe
 	public void onGameObjectSpawned(GameObjectSpawned event)
 	{


### PR DESCRIPTION
Do not draw text on top of Mark Of Grace
- This is GroundItemsPlugin's job.

Agility plugin small code cleanup
- Do not use 1 line ifs
- Mark fields final properly
- Remove confusing comments
