### PR TITLE
Add setting to keep the scouter active during raid

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsConfig.java
@@ -80,7 +80,15 @@ public interface RaidsConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 4,
+			position = 4,
+			keyName = "keepScouterActiveDuringRaid",
+			name = "Keep scout overlay active during raid",
+			description = "Keeps the scout overlay active whilst inside the raid"
+	)
+	default boolean keepScouterActiveDuringRaid() {return false;}
+
+	@ConfigItem(
+		position = 5,
 		keyName = "whitelistedRooms",
 		name = "Whitelisted rooms",
 		description = "Display whitelisted rooms in green on the overlay. Separate with comma (full name)"
@@ -91,7 +99,7 @@ public interface RaidsConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 5,
+		position = 6,
 		keyName = "blacklistedRooms",
 		name = "Blacklisted rooms",
 		description = "Display blacklisted rooms in red on the overlay. Separate with comma (full name)"
@@ -102,7 +110,7 @@ public interface RaidsConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 6,
+		position = 7,
 		keyName = "enableRotationWhitelist",
 		name = "Enable rotation whitelist",
 		description = "Enable the rotation whitelist"
@@ -113,7 +121,7 @@ public interface RaidsConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 7,
+		position = 8,
 		keyName = "whitelistedRotations",
 		name = "Whitelisted rotations",
 		description = "Warn when boss rotation doesn't match a whitelisted one. Add rotations like [tekton, muttadile, guardians]"
@@ -124,7 +132,7 @@ public interface RaidsConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 8,
+		position = 9,
 		keyName = "enableLayoutWhitelist",
 		name = "Enable layout whitelist",
 		description = "Enable the layout whitelist"
@@ -135,7 +143,7 @@ public interface RaidsConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 9,
+		position = 10,
 		keyName = "whitelistedLayouts",
 		name = "Whitelisted layouts",
 		description = "Warn when layout doesn't match a whitelisted one. Add layouts like CFSCPPCSCF separated with comma"

--- a/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsPlugin.java
@@ -264,8 +264,11 @@ public class RaidsPlugin extends Plugin
 
 		if (client.getSetting(Setting.IN_RAID_PARTY) == -1)
 		{
-			overlay.setScoutOverlayShown(false);
-			raid = null;
+			if(!(this.isInRaidChambers() && config.keepScouterActiveDuringRaid()))
+			{
+				overlay.setScoutOverlayShown(false);
+				raid = null;
+			}
 		}
 	}
 


### PR DESCRIPTION
Simple change that makes the raids scouter appear during the raid, complete with settings toggle.