### PR TITLE
Add a font type dropdown for tooltips

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/config/RuneLiteConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/RuneLiteConfig.java
@@ -124,12 +124,23 @@ public interface RuneLiteConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "fontType",
+		keyName = "dynamicfontType",
 		name = "Dynamic Overlay Font",
 		description = "Configures what font type is used for in-game overlays such as player name, ground items, etc.",
 		position = 9
 	)
-	default FontType fontType()
+	default FontType dynamicfontType()
+	{
+		return FontType.SMALL;
+	}
+
+	@ConfigItem(
+		keyName = "tooltipFontType",
+		name = "Tooltip Font",
+		description = "Configures what font type is used for in-game tooltips such as food stats, NPC names, etc.",
+		position = 10
+	)
+	default FontType tooltipFontType()
 	{
 		return FontType.SMALL;
 	}
@@ -138,7 +149,7 @@ public interface RuneLiteConfig extends Config
 		keyName = "infoBoxVertical",
 		name = "Display infoboxes vertically",
 		description = "Toggles the infoboxes to display vertically",
-		position = 10
+		position = 11
 	)
 	default boolean infoBoxVertical()
 	{
@@ -149,7 +160,7 @@ public interface RuneLiteConfig extends Config
 		keyName = "infoBoxWrap",
 		name = "Infobox wrap count",
 		description = "Configures the amount of infoboxes shown before wrapping",
-		position = 11
+		position = 12
 	)
 	default int infoBoxWrap()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayRenderer.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayRenderer.java
@@ -513,11 +513,11 @@ public class OverlayRenderer extends MouseListener implements KeyListener
 		// Set font based on configuration
 		if (position == OverlayPosition.DYNAMIC)
 		{
-			subGraphics.setFont(runeLiteConfig.fontType().getFont());
+			subGraphics.setFont(runeLiteConfig.dynamicfontType().getFont());
 		}
 		else if (position == OverlayPosition.TOOLTIP)
 		{
-			subGraphics.setFont(FontManager.getRunescapeSmallFont());
+			subGraphics.setFont(runeLiteConfig.tooltipFontType().getFont());
 		}
 		else
 		{


### PR DESCRIPTION
This dropdown is similar to to #1651 but for tooltips.

Dropdown:
![java_2018-04-26_11-23-10](https://user-images.githubusercontent.com/1210740/39324394-3bb89cb6-4944-11e8-9f00-f107df75bdf8.png)

Small:
![java_2018-04-26_11-20-03](https://user-images.githubusercontent.com/1210740/39324289-001c82da-4944-11e8-9264-ebbad76da263.png)

Regular:
![java_2018-04-26_11-19-55](https://user-images.githubusercontent.com/1210740/39324295-0045b7ea-4944-11e8-93ee-113e55198fd4.png)


Bold:
![java_2018-04-26_11-20-10](https://user-images.githubusercontent.com/1210740/39324292-003240b6-4944-11e8-99d3-f0c58a7b5eb6.png)


