### PR TITLE
Hp and prayer notification fix

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierConfig.java
@@ -76,7 +76,7 @@ public interface IdleNotifierConfig extends Config
 	)
 	default int getHitpointsThreshold()
 	{
-		return 15;
+		return 0;
 	}
 
 	@ConfigItem(
@@ -87,6 +87,6 @@ public interface IdleNotifierConfig extends Config
 	)
 	default int getPrayerThreshold()
 	{
-		return 15;
+		return 0;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierConfig.java
@@ -71,7 +71,7 @@ public interface IdleNotifierConfig extends Config
 	@ConfigItem(
 		keyName = "hitpoints",
 		name = "Hitpoints Notification Threshold",
-		description = "The amount of hitpoints to send a notification at",
+		description = "The amount of hitpoints to send a notification at. A value of 0 will disable notification.",
 		position = 4
 	)
 	default int getHitpointsThreshold()
@@ -82,7 +82,7 @@ public interface IdleNotifierConfig extends Config
 	@ConfigItem(
 		keyName = "prayer",
 		name = "Prayer Notification Threshold",
-		description = "The amount of prayer points to send a notification at",
+		description = "The amount of prayer points to send a notification at. A value of 0 will disable notification.",
 		position = 5
 	)
 	default int getPrayerThreshold()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
@@ -251,6 +251,10 @@ public class IdleNotifierPlugin extends Plugin
 
 	private boolean checkLowHitpoints()
 	{
+		if (config.getHitpointsThreshold() == 0)
+		{
+			return false;
+		}
 		if (client.getRealSkillLevel(Skill.HITPOINTS) > config.getHitpointsThreshold())
 		{
 			if (client.getBoostedSkillLevel(Skill.HITPOINTS) <= config.getHitpointsThreshold())
@@ -272,6 +276,10 @@ public class IdleNotifierPlugin extends Plugin
 
 	private boolean checkLowPrayer()
 	{
+		if (config.getPrayerThreshold() == 0)
+		{
+			return false;
+		}
 		if (client.getRealSkillLevel(Skill.PRAYER) > config.getPrayerThreshold())
 		{
 			if (client.getBoostedSkillLevel(Skill.PRAYER) <= config.getPrayerThreshold())


### PR DESCRIPTION
This change will make the default option for notification on low HP/Prayer to off by setting it to 0. Also changes logic so that a value of 0 disables the notification.