### PR TITLE
Add toggle for drawing overhead player names to PlayerIndicators plugin

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsConfig.java
@@ -159,6 +159,17 @@ public interface PlayerIndicatorsConfig extends Config
 
 	@ConfigItem(
 		position = 11,
+		keyName = "drawOverheadPlayerNames",
+		name = "Draw names above players",
+		description = "Configures whether or not player names should be drawn above players"
+	)
+	default boolean drawOverheadPlayerNames()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		position = 12,
 		keyName = "drawMinimapNames",
 		name = "Draw names on minimap",
 		description = "Configures whether or not minimap names for players with rendered names should be drawn"
@@ -169,7 +180,7 @@ public interface PlayerIndicatorsConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 12,
+		position = 13,
 		keyName = "colorPlayerMenu",
 		name = "Color player menu",
 		description = "Color right click menu for players"
@@ -180,7 +191,7 @@ public interface PlayerIndicatorsConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 13,
+		position = 14,
 		keyName = "clanMenuIcons",
 		name = "Show clan rank in menu",
 		description = "Add clan rank to right click menu for players"

--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsOverlay.java
@@ -76,6 +76,11 @@ public class PlayerIndicatorsOverlay extends Overlay
 			}
 		}
 
+		if (!config.drawOverheadPlayerNames())
+		{
+			return;
+		}
+
 		String name = actor.getName().replace('\u00A0', ' ');
 		int offset = actor.getLogicalHeight() + 40;
 		Point textLocation = actor.getCanvasTextLocation(graphics, name, offset);


### PR DESCRIPTION
This PR adds a toggle to the Player Indicators plugin to allow the user to disable drawing names above players in-game. With this toggle players can reduce the amount of clutter on their screen by limiting the indicators to the minimap only.

![In action](https://thumbs.gfycat.com/TatteredUnacceptableEyas-size_restricted.gif)

(Requested on Discord)