### PR TITLE
Add a shortcut key to take screenshots

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotConfig.java
@@ -111,4 +111,15 @@ public interface ScreenshotConfig extends Config
 	{
 		return false;
 	}
+
+	@ConfigItem(
+		keyName = "enableShortcut",
+		name = "Screenshot with [Insert]",
+		description = "Configures whether or not screenshots can be taken with the Insert key",
+		position = 7
+	)
+	default boolean isScreenshotEnabled()
+	{
+		return false;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotInput.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotInput.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2018, Seth <http://github.com/sethtroll>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.screenshot;
+
+import java.awt.event.KeyEvent;
+import java.util.Date;
+import javax.inject.Inject;
+import net.runelite.client.input.KeyListener;
+import static net.runelite.client.plugins.screenshot.ScreenshotPlugin.TIME_FORMAT;
+
+public class ScreenshotInput implements KeyListener
+{
+	private final ScreenshotConfig config;
+	private final ScreenshotPlugin plugin;
+
+	@Inject
+	ScreenshotInput(ScreenshotConfig config, ScreenshotPlugin plugin)
+	{
+		this.config = config;
+		this.plugin = plugin;
+	}
+
+	@Override
+	public void keyPressed(KeyEvent event)
+	{
+	}
+
+	@Override
+	public void keyTyped(KeyEvent event)
+	{
+	}
+
+	@Override
+	public void keyReleased(KeyEvent event)
+	{
+		if (!config.isScreenshotEnabled())
+			return;
+
+		if (event.getKeyCode() == KeyEvent.VK_INSERT)
+		{
+			plugin.takeScreenshot(TIME_FORMAT.format(new Date()), config.displayDate());
+		}
+	}
+
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
@@ -72,6 +72,7 @@ import static net.runelite.api.widgets.WidgetInfo.TO_GROUP;
 import net.runelite.client.Notifier;
 import static net.runelite.client.RuneLite.SCREENSHOT_DIR;
 import net.runelite.client.config.ConfigManager;
+import net.runelite.client.input.KeyManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.plugins.screenshot.imgur.ImageUploadRequest;
@@ -102,7 +103,7 @@ public class ScreenshotPlugin extends Plugin
 	private static final MediaType JSON = MediaType.parse("application/json");
 
 	private static final DateFormat DATE_FORMAT = new SimpleDateFormat("MMM. dd, yyyy", Locale.US);
-	private static final DateFormat TIME_FORMAT = new SimpleDateFormat("yyyy-MM-dd_HH-mm-ss", Locale.US);
+	static final DateFormat TIME_FORMAT = new SimpleDateFormat("yyyy-MM-dd_HH-mm-ss", Locale.US);
 
 	private static final Pattern NUMBER_PATTERN = Pattern.compile("([0-9]+)");
 	private static final Pattern LEVEL_UP_PATTERN = Pattern.compile("Your ([a-zA-Z]+) (?:level is|are)? now (\\d+)\\.");
@@ -133,7 +134,13 @@ public class ScreenshotPlugin extends Plugin
 	private OverlayRenderer overlayRenderer;
 
 	@Inject
+	private ScreenshotInput inputListener;
+
+	@Inject
 	private ScheduledExecutorService executor;
+
+	@Inject
+	private KeyManager keyManager;
 
 	private NavigationButton titleBarButton;
 
@@ -147,6 +154,7 @@ public class ScreenshotPlugin extends Plugin
 	protected void startUp() throws Exception
 	{
 		SCREENSHOT_DIR.mkdirs();
+		keyManager.registerKeyListener(inputListener);
 
 		try
 		{
@@ -191,6 +199,7 @@ public class ScreenshotPlugin extends Plugin
 	protected void shutDown() throws Exception
 	{
 		titleToolbar.removeNavigation(titleBarButton);
+		keyManager.unregisterKeyListener(inputListener);
 	}
 
 	@Subscribe
@@ -387,7 +396,7 @@ public class ScreenshotPlugin extends Plugin
 	 * @param fileName    Filename to use, without file extension.
 	 * @param displayDate Whether to show today's date on the report button as the screenshot is taken.
 	 */
-	private void takeScreenshot(String fileName, boolean displayDate)
+	void takeScreenshot(String fileName, boolean displayDate)
 	{
 		if (client.getGameState() == GameState.LOGIN_SCREEN)
 		{


### PR DESCRIPTION
As it says on the tin. A config option to enable/disable taking screenshots with the INSERT key. The suggestion mentioned F11 as a possible default, but it is already used by many (me included) in the vanilla client, so I decided to go with INSERT (which as also the OSBuddy default).

I'm a bit unsure about the wording in the config panel and I'd be happy to change it (or other aspects of the code) if you have any other suggestions.

Would fix issues #1013  and #1501 