### PR TITLE
added approximate pvp hitpoints functionality 

### DIFF
--- a/http-service/src/main/java/net/runelite/http/service/item/ItemService.java
+++ b/http-service/src/main/java/net/runelite/http/service/item/ItemService.java
@@ -369,7 +369,7 @@ public class ItemService
 		}
 		else
 		{
-			log.warn("Dropping pending price lookup for {}", itemId);
+			log.debug("Dropping pending price lookup for {}", itemId);
 		}
 	}
 
@@ -381,7 +381,7 @@ public class ItemService
 		}
 		else
 		{
-			log.warn("Dropping pending search for {}", search);
+			log.debug("Dropping pending search for {}", search);
 		}
 	}
 
@@ -393,7 +393,7 @@ public class ItemService
 		}
 		else
 		{
-			log.warn("Dropping pending item lookup for {}", itemId);
+			log.debug("Dropping pending item lookup for {}", itemId);
 		}
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/game/HiscoreLoader.java
+++ b/runelite-client/src/main/java/net/runelite/client/game/HiscoreLoader.java
@@ -1,0 +1,102 @@
+package net.runelite.client.game;
+
+import com.google.common.cache.CacheLoader;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListeningExecutorService;
+import com.google.common.util.concurrent.MoreExecutors;
+import java.io.IOException;
+import java.util.concurrent.ScheduledExecutorService;
+import lombok.extern.slf4j.Slf4j;
+import static net.runelite.client.game.HiscoreManager.EMPTY;
+import static net.runelite.client.game.HiscoreManager.NONE;
+
+import net.runelite.api.Client;
+import net.runelite.client.plugins.xptracker.XpTrackerPlugin;
+import net.runelite.client.plugins.xptracker.XpWorldType;
+import net.runelite.http.api.hiscore.HiscoreClient;
+import net.runelite.http.api.hiscore.HiscoreResult;
+import net.runelite.http.api.hiscore.HiscoreEndpoint;
+
+@Slf4j
+public class HiscoreLoader extends CacheLoader<String, HiscoreResult>
+{
+	private final Client client;
+	private final ListeningExecutorService executorService;
+	private final HiscoreClient hiscoreClient;
+	private final XpTrackerPlugin xpTrackerPlugin = new XpTrackerPlugin();
+
+	HiscoreLoader(Client client, ScheduledExecutorService executor, HiscoreClient hiscoreClient)
+	{
+		this.executorService = MoreExecutors.listeningDecorator(executor);
+		this.client = client;
+		this.hiscoreClient = hiscoreClient;
+
+		try
+		{
+			xpTrackerPlugin.startUp_backend();
+		}
+		catch (Exception ex)
+		{
+			log.debug("could not start up plugin");
+		}
+	}
+
+	@Override
+	public HiscoreResult load(String username) throws Exception
+	{
+		// guava's Cache doesn't support null values
+		return EMPTY;
+	}
+
+	@Override
+	public ListenableFuture<HiscoreResult> reload(String username, HiscoreResult oldValue)
+	{
+		log.debug("Submitting lookup for item {}", username);
+
+		return executorService.submit(() -> fetch(username));
+	}
+
+	private HiscoreResult fetch(String username)
+	{
+		HiscoreEndpoint hiscoreEndpoint;
+		try
+		{
+			int worldNum = client.getWorld();
+			XpWorldType worldType = xpTrackerPlugin.getWorldType(worldNum);
+
+			switch (worldType)
+			{
+				case NORMAL:  hiscoreEndpoint = HiscoreEndpoint.NORMAL;
+					break;
+				case DMM:  hiscoreEndpoint = HiscoreEndpoint.DEADMAN;
+					break;
+				case SDMM:  hiscoreEndpoint = HiscoreEndpoint.SEASONAL_DEADMAN;
+					break;
+				default: hiscoreEndpoint = HiscoreEndpoint.NORMAL;
+					break;
+			}
+
+			log.debug("Hiscore endpoint " + hiscoreEndpoint.name() + " selected");
+		}
+		catch (Exception ex)
+		{
+			hiscoreEndpoint = HiscoreEndpoint.NORMAL;
+			log.debug("could not start up plugin");
+		}
+
+		try
+		{
+			HiscoreResult hiscoreResult = hiscoreClient.lookup(username, hiscoreEndpoint);
+			if (hiscoreResult == null)
+			{
+				return NONE;
+			}
+			return hiscoreResult;
+		}
+		catch (IOException ex)
+		{
+			log.warn("unable to look up item!", ex);
+			return NONE;
+		}
+	}
+};

--- a/runelite-client/src/main/java/net/runelite/client/game/HiscoreManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/game/HiscoreManager.java
@@ -1,20 +1,17 @@
 package net.runelite.client.game;
 
 import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.CacheLoader;
+//import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.client.callback.ClientThread;
-import net.runelite.client.plugins.xptracker.XpTrackerPlugin;
-import net.runelite.client.plugins.xptracker.XpWorldType;
 import net.runelite.http.api.hiscore.HiscoreClient;
-import net.runelite.http.api.hiscore.HiscoreEndpoint;
 import net.runelite.http.api.hiscore.HiscoreResult;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import java.io.IOException;
+//import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -30,13 +27,17 @@ public class HiscoreManager
 	private final ClientThread clientThread;
 
 	/**
+	 * not yet looked up
+	 */
+	static final HiscoreResult EMPTY = new HiscoreResult();
+
+	/**
 	 * has no hiscore
 	 */
 	static final HiscoreResult NONE = new HiscoreResult();
 
 	private final HiscoreClient hiscoreClient = new HiscoreClient();
 	private final LoadingCache<String, HiscoreResult> hiscoreLookupCache;
-	private final XpTrackerPlugin xpTrackerPlugin = new XpTrackerPlugin();
 
 	@Inject
 	public HiscoreManager(Client client, ScheduledExecutorService executor, ClientThread clientThread)
@@ -45,53 +46,13 @@ public class HiscoreManager
 		this.scheduledExecutorService = executor;
 		this.clientThread = clientThread;
 
-		try
-		{
-			xpTrackerPlugin.startUp_backend();
-		}
-		catch (Exception ex)
-		{
-			log.debug("could not start up plugin");
-		}
+
 
 
 		hiscoreLookupCache = CacheBuilder.newBuilder()
 				.maximumSize(128L)
 				.expireAfterAccess(1, TimeUnit.HOURS)
-				.build(new CacheLoader<String, HiscoreResult>()
-				{
-					@Override
-					public HiscoreResult load(String username) throws Exception
-					{
-						try
-						{
-							int worldNum = client.getWorld();
-							XpWorldType worldType = xpTrackerPlugin.getWorldType(worldNum);
-
-							HiscoreEndpoint endpoint;
-							switch (worldType)
-							{
-								case NORMAL:  endpoint = HiscoreEndpoint.NORMAL;
-									break;
-								case DMM:  endpoint = HiscoreEndpoint.DEADMAN;
-									break;
-								case SDMM:  endpoint = HiscoreEndpoint.SEASONAL_DEADMAN;
-									break;
-								default: endpoint = HiscoreEndpoint.NORMAL;
-									break;
-							}
-
-							log.debug("Hiscore endpoint " + endpoint.name() + " selected");
-							HiscoreResult result = hiscoreClient.lookup(username, endpoint);
-							return result;
-						}
-						catch (IOException ex)
-						{
-							log.warn("Error fetching Hiscore data " + ex.getMessage());
-							return NONE;
-						}
-					}
-				});
+				.build(new HiscoreLoader(client, executor, hiscoreClient));
 	}
 
 	public HiscoreResult lookupUsername(String username) throws ExecutionException
@@ -103,9 +64,9 @@ public class HiscoreManager
 	{
 		HiscoreResult hiscore = hiscoreLookupCache.getIfPresent(username);
 
-		if (hiscore != null && hiscore != NONE)
+		if (hiscore != null && hiscore != EMPTY)
 		{
-			return hiscore;
+			return hiscore == NONE ? null : hiscore;
 		}
 		hiscoreLookupCache.refresh(username);
 		return null;

--- a/runelite-client/src/main/java/net/runelite/client/game/HiscoreManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/game/HiscoreManager.java
@@ -1,0 +1,57 @@
+package net.runelite.client.game;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.Client;
+import net.runelite.client.callback.ClientThread;
+import net.runelite.http.api.hiscore.HiscoreClient;
+import net.runelite.http.api.hiscore.HiscoreResult;
+
+//import java.io.IOException;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+
+@Singleton
+@Slf4j
+public class HiscoreManager {
+
+    private final Client client;
+    private final ScheduledExecutorService scheduledExecutorService;
+    private final ClientThread clientThread;
+
+    private final HiscoreClient hiscoreClient = new HiscoreClient();
+    private final LoadingCache<String, HiscoreResult> hiscoreLookups;
+
+    @Inject
+    public HiscoreManager(Client client, ScheduledExecutorService executor, ClientThread clientThread)
+    {
+        this.client = client;
+        this.scheduledExecutorService = executor;
+        this.clientThread = clientThread;
+
+        hiscoreLookups = CacheBuilder.newBuilder()
+                .maximumSize(128L)
+                .expireAfterAccess(1, TimeUnit.HOURS)
+                .build(new CacheLoader<String, HiscoreResult>()
+                {
+                    @Override
+                    public HiscoreResult load(String username) throws Exception
+                    {
+                        return hiscoreClient.lookup(username);
+                    }
+                });
+    }
+
+    public HiscoreResult lookupUsername(String username) throws ExecutionException//, IOException
+    {
+        return hiscoreLookups.get(username);
+    }
+
+}

--- a/runelite-client/src/main/java/net/runelite/client/game/HiscoreManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/game/HiscoreManager.java
@@ -6,13 +6,15 @@ import com.google.common.cache.LoadingCache;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.client.callback.ClientThread;
+import net.runelite.client.plugins.xptracker.XpTrackerPlugin;
+import net.runelite.client.plugins.xptracker.XpWorldType;
 import net.runelite.http.api.hiscore.HiscoreClient;
+import net.runelite.http.api.hiscore.HiscoreEndpoint;
 import net.runelite.http.api.hiscore.HiscoreResult;
-
-//import java.io.IOException;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
+import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -20,38 +22,92 @@ import java.util.concurrent.TimeUnit;
 
 @Singleton
 @Slf4j
-public class HiscoreManager {
+public class HiscoreManager
+{
 
-    private final Client client;
-    private final ScheduledExecutorService scheduledExecutorService;
-    private final ClientThread clientThread;
+	private final Client client;
+	private final ScheduledExecutorService scheduledExecutorService;
+	private final ClientThread clientThread;
 
-    private final HiscoreClient hiscoreClient = new HiscoreClient();
-    private final LoadingCache<String, HiscoreResult> hiscoreLookups;
+	/**
+	 * has no hiscore
+	 */
+	static final HiscoreResult NONE = new HiscoreResult();
 
-    @Inject
-    public HiscoreManager(Client client, ScheduledExecutorService executor, ClientThread clientThread)
-    {
-        this.client = client;
-        this.scheduledExecutorService = executor;
-        this.clientThread = clientThread;
+	private final HiscoreClient hiscoreClient = new HiscoreClient();
+	private final LoadingCache<String, HiscoreResult> hiscoreLookupCache;
+	private final XpTrackerPlugin xpTrackerPlugin = new XpTrackerPlugin();
 
-        hiscoreLookups = CacheBuilder.newBuilder()
-                .maximumSize(128L)
-                .expireAfterAccess(1, TimeUnit.HOURS)
-                .build(new CacheLoader<String, HiscoreResult>()
-                {
-                    @Override
-                    public HiscoreResult load(String username) throws Exception
-                    {
-                        return hiscoreClient.lookup(username);
-                    }
-                });
-    }
+	@Inject
+	public HiscoreManager(Client client, ScheduledExecutorService executor, ClientThread clientThread)
+	{
+		this.client = client;
+		this.scheduledExecutorService = executor;
+		this.clientThread = clientThread;
 
-    public HiscoreResult lookupUsername(String username) throws ExecutionException//, IOException
-    {
-        return hiscoreLookups.get(username);
-    }
+		try
+		{
+			xpTrackerPlugin.startUp_backend();
+		}
+		catch (Exception ex)
+		{
+			log.debug("could not start up plugin");
+		}
 
+
+		hiscoreLookupCache = CacheBuilder.newBuilder()
+				.maximumSize(128L)
+				.expireAfterAccess(1, TimeUnit.HOURS)
+				.build(new CacheLoader<String, HiscoreResult>()
+				{
+					@Override
+					public HiscoreResult load(String username) throws Exception
+					{
+						try
+						{
+							int worldNum = client.getWorld();
+							XpWorldType worldType = xpTrackerPlugin.getWorldType(worldNum);
+
+							HiscoreEndpoint endpoint;
+							switch (worldType)
+							{
+								case NORMAL:  endpoint = HiscoreEndpoint.NORMAL;
+									break;
+								case DMM:  endpoint = HiscoreEndpoint.DEADMAN;
+									break;
+								case SDMM:  endpoint = HiscoreEndpoint.SEASONAL_DEADMAN;
+									break;
+								default: endpoint = HiscoreEndpoint.NORMAL;
+									break;
+							}
+
+							log.debug("Hiscore endpoint " + endpoint.name() + " selected");
+							HiscoreResult result = hiscoreClient.lookup(username, endpoint);
+							return result;
+						}
+						catch (IOException ex)
+						{
+							log.warn("Error fetching Hiscore data " + ex.getMessage());
+							return NONE;
+						}
+					}
+				});
+	}
+
+	public HiscoreResult lookupUsername(String username) throws ExecutionException
+	{
+		return hiscoreLookupCache.get(username);
+	}
+
+	public HiscoreResult lookupUsernameAsync(String username)
+	{
+		HiscoreResult hiscore = hiscoreLookupCache.getIfPresent(username);
+
+		if (hiscore != null && hiscore != NONE)
+		{
+			return hiscore;
+		}
+		hiscoreLookupCache.refresh(username);
+		return null;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/opponentinfo/OpponentInfoOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/opponentinfo/OpponentInfoOverlay.java
@@ -30,7 +30,6 @@ import java.awt.FontMetrics;
 import java.awt.Graphics2D;
 import java.awt.Point;
 import java.awt.Rectangle;
-import java.io.IOException;
 import java.text.DecimalFormat;
 import java.time.Duration;
 import java.time.Instant;
@@ -42,13 +41,13 @@ import net.runelite.api.NPC;
 import net.runelite.api.Player;
 import net.runelite.api.Varbits;
 import net.runelite.client.game.HiscoreManager;
+import net.runelite.http.api.hiscore.HiscoreResult;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.OverlayPriority;
 import net.runelite.client.ui.overlay.components.BackgroundComponent;
 import net.runelite.client.ui.overlay.components.TextComponent;
 import net.runelite.client.util.Text;
-import java.util.concurrent.ExecutionException;
 
 class OpponentInfoOverlay extends Overlay
 {
@@ -193,16 +192,16 @@ class OpponentInfoOverlay extends Overlay
 			// PVP Hitpoints
 			if (lastMaxHealth == null)
 			{
-				// If found
-				try
+				HiscoreResult opponentHiscore = hiscoreManager.lookupUsernameAsync(opponentName);
+				if (opponentHiscore != null)
 				{
+					int hitpointLevel = opponentHiscore.getHitpoints().getLevel();
 					// Rounding b/c in pvp its better to overestimate than underestimate
-					lastMaxHealth = hiscoreManager.lookupUsername(opponentName).getHitpoints().getLevel();
-					int currHealth = Math.round((lastRatio * lastMaxHealth));
-					str = currHealth + "/" + lastMaxHealth;
+					int currHealth = Math.round((lastRatio * hitpointLevel));
+					str = currHealth + "/" + hitpointLevel;
 				}
-				// If not found
-				catch (ExecutionException ex)
+
+				else
 				{
 					str = df.format(lastRatio * 100) + "%";
 				}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerPlugin.java
@@ -180,7 +180,28 @@ public class XpTrackerPlugin extends Plugin
 		}
 	}
 
-	private XpWorldType getWorldType(int worldNum)
+	public void startUp_backend() throws Exception
+	{
+		WorldClient worldClient = new WorldClient();
+		try
+		{
+			worlds = worldClient.lookupWorlds();
+			if (worlds != null)
+			{
+				log.debug("Worlds list contains {} worlds", worlds.getWorlds().size());
+			}
+			else
+			{
+				log.warn("Unable to look up worlds");
+			}
+		}
+		catch (IOException e)
+		{
+			log.warn("Error looking up worlds list", e);
+		}
+	}
+
+	public XpWorldType getWorldType(int worldNum)
 	{
 		if (worlds == null)
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpWorldType.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpWorldType.java
@@ -26,7 +26,7 @@ package net.runelite.client.plugins.xptracker;
 
 import net.runelite.http.api.worlds.WorldType;
 
-enum XpWorldType
+public enum XpWorldType
 {
 	NORMAL,
 	DMM,


### PR DESCRIPTION
Added approximate pvp hitpoints functionality  with cached highscores to avoid flooding highscore request flooding. Using traditional rounding (0.5 threshold) as a better estimator. Id rather overestimate hp by one than go in for a spec/ko when hp is underestimated.