### PR TITLE
configmanager: Allow multiple delimiters

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/config/ConfigManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/ConfigManager.java
@@ -193,7 +193,7 @@ public class ConfigManager
 			Map<String, String> copy = (Map) ImmutableMap.copyOf(properties);
 			copy.forEach((groupAndKey, value) ->
 			{
-				final String[] split = ((String) groupAndKey).split("\\.");
+				final String[] split = ((String) groupAndKey).split("\\.", 2);
 				if (split.length != 2)
 				{
 					log.debug("Properties key malformed!: {}", groupAndKey);


### PR DESCRIPTION
When loading from a local config the config manager would complain if there were multiple `.` chars in the key.