### PR TITLE
Rename agilityplugin package to agility

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/agility/AgilityConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/agility/AgilityConfig.java
@@ -22,7 +22,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package net.runelite.client.plugins.agilityplugin;
+package net.runelite.client.plugins.agility;
 
 import java.awt.Color;
 import net.runelite.client.config.Config;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/agility/AgilityOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/agility/AgilityOverlay.java
@@ -23,7 +23,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package net.runelite.client.plugins.agilityplugin;
+package net.runelite.client.plugins.agility;
 
 import java.awt.Color;
 import static java.awt.Color.RED;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/agility/AgilityPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/agility/AgilityPlugin.java
@@ -22,7 +22,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package net.runelite.client.plugins.agilityplugin;
+package net.runelite.client.plugins.agility;
 
 import com.google.common.eventbus.Subscribe;
 import com.google.common.primitives.Ints;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/agility/AgilitySession.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/agility/AgilitySession.java
@@ -22,7 +22,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package net.runelite.client.plugins.agilityplugin;
+package net.runelite.client.plugins.agility;
 
 import java.time.Instant;
 import lombok.Getter;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/agility/Courses.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/agility/Courses.java
@@ -22,7 +22,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package net.runelite.client.plugins.agilityplugin;
+package net.runelite.client.plugins.agility;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/agility/LapCounterOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/agility/LapCounterOverlay.java
@@ -22,7 +22,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package net.runelite.client.plugins.agilityplugin;
+package net.runelite.client.plugins.agility;
 
 import java.awt.Dimension;
 import java.awt.Graphics2D;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/agility/Obstacles.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/agility/Obstacles.java
@@ -22,7 +22,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package net.runelite.client.plugins.agilityplugin;
+package net.runelite.client.plugins.agility;
 
 import com.google.common.collect.Sets;
 import java.util.Set;


### PR DESCRIPTION
Agility is the only plugin which has the word "plugin" in its package name, which probably would've been corrected if it was PR'd today. This brings it in line with other plugin packages like `plugins.hunter` and `plugins.woodcutting`.