### PR TITLE
Report button plugin: Fix the skipping seconds digits

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/reportbutton/ReportButtonPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/reportbutton/ReportButtonPlugin.java
@@ -117,8 +117,8 @@ public class ReportButtonPlugin extends Plugin
 	}
 
 	@Schedule(
-		period = 1,
-		unit = ChronoUnit.SECONDS
+		period = 500,
+		unit = ChronoUnit.MILLIS
 	)
 	public void updateSchedule()
 	{


### PR DESCRIPTION
Right now, the timer and clock modes of this plugin frequently jump ahead by 2 seconds instead of 1, due to the `@Schedule` callback being imperfectly in sync with the system seconds. Doubling the frequency of the time updates to 500ms fixes the problem.

Note that there's still some visible jerkiness in the seconds timing, which doesn't improve even when using faster time updates like 100ms, but I'm not aware of a way to fix this.