### PR TITLE
Mark ground items dirty on region change

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
@@ -68,6 +68,7 @@ import net.runelite.api.events.ConfigChanged;
 import net.runelite.api.events.FocusChanged;
 import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.ItemLayerChanged;
+import net.runelite.api.events.MapRegionChanged;
 import net.runelite.api.events.MenuEntryAdded;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.game.ItemManager;
@@ -197,6 +198,12 @@ public class GroundItemsPlugin extends Plugin
 		{
 			dirty = true;
 		}
+	}
+
+	@Subscribe
+	public void onMapRegionChanged(final MapRegionChanged event)
+	{
+		dirty = true;
 	}
 
 	@Subscribe


### PR DESCRIPTION
When player's region changes and region was already loaded before, the
ground items on ground was not reloaded. Example: when you die
somewhere.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>