### PR TITLE
Change NPC name check to nameEquals

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/ClueScrollPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/ClueScrollPlugin.java
@@ -209,7 +209,7 @@ public class ClueScrollPlugin extends Plugin
 
 			if (npc != null)
 			{
-				Query query = new NPCQuery().nameContains(npc);
+				Query query = new NPCQuery().nameEquals(npc);
 				npcsToMark = queryRunner.runQuery(query);
 
 				// Set hint arrow to first NPC found as there can only be 1 hint arrow


### PR DESCRIPTION
The NPCQuery inside of the clue scroll plugin used `nameContains` to check which NPCs to highlight. This lead to a case where the wrong NPCs could be highlighted.

I looked over ciphers and cryptics and didn't see any clue that looked like it was relying on a partial name, so I don't believe this is a breaking change.

Fixes #2077 