### PR TITLE
http-service: don't apply auto increment on sessions table

### DIFF
--- a/http-service/src/main/java/net/runelite/http/service/account/AccountService.java
+++ b/http-service/src/main/java/net/runelite/http/service/account/AccountService.java
@@ -63,7 +63,7 @@ public class AccountService
 	private static final Logger logger = LoggerFactory.getLogger(AccountService.class);
 
 	private static final String CREATE_SESSIONS = "CREATE TABLE IF NOT EXISTS `sessions` (\n"
-		+ "  `user` int(11) NOT NULL PRIMARY KEY AUTO_INCREMENT,\n"
+		+ "  `user` int(11) NOT NULL PRIMARY KEY,\n"
 		+ "  `uuid` varchar(36) NOT NULL,\n"
 		+ "  `created` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,\n"
 		+ "  `last_used` timestamp NOT NULL,\n"


### PR DESCRIPTION
This seems to have been an oversight in https://github.com/runelite/runelite/commit/82ffa4457c9b63794ce820c02a888f0de655a8db, and made it so inserting into the sessions table resulted in an error:
 ```
Error in executeUpdate, Cannot add or update a child row: a foreign key constraint fails 
(runelite.sessions, CONSTRAINT id FOREIGN KEY (user) REFERENCES users (id) 
ON DELETE CASCADE ON UPDATE CASCADE)
```