### PR TITLE
farming panel: reset progress bar background

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/farmingtracker/FarmingTrackerPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/farmingtracker/FarmingTrackerPanel.java
@@ -183,6 +183,7 @@ class FarmingTrackerPanel extends PluginPanel
 				panel.getProgress().setMaximum(0);
 				panel.getProgress().setValue(0);
 				panel.getEstimate().setText("Unknown");
+				panel.getProgress().setBackground(null);
 			}
 			else
 			{


### PR DESCRIPTION
fixes progress bar background not resetting when state = null
![this 1](https://user-images.githubusercontent.com/5454364/39409723-b602b564-4bb1-11e8-8ded-1691a642540d.gif)
