### PR TITLE
Fix of NullPointerException

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
@@ -468,7 +468,7 @@ public class ScreenshotPlugin extends Plugin
 			}
 
 			File playerFolder;
-			if (client.getLocalPlayer() != null)
+			if (client.getLocalPlayer() != null && client.getLocalPlayer().getName() != null)
 			{
 				playerFolder = new File(SCREENSHOT_DIR, client.getLocalPlayer().getName());
 			}


### PR DESCRIPTION
Fix of NullPointerException you get when you spam the screenshot button as you login. During development, I noticed getLocalPlayer().getName() is longer null than the getLocalPlayer() method and this causes the error.