### PR TITLE
runelite-client: Cleanup cli arguments

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ClientLoader.java
+++ b/runelite-client/src/main/java/net/runelite/client/ClientLoader.java
@@ -28,33 +28,34 @@ import java.applet.Applet;
 import java.io.IOException;
 import java.net.URL;
 import java.net.URLClassLoader;
-import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.http.api.updatecheck.UpdateCheckClient;
 
 @Slf4j
 public class ClientLoader
 {
-	public Optional<Applet> loadRs(boolean disableUpdateCheck)
+	public Applet loadRs(UpdateCheckMode updateMode)
 	{
-		boolean isOutdated = false;
-
-		if (!disableUpdateCheck)
+		if (updateMode == UpdateCheckMode.AUTO)
 		{
 			final UpdateCheckClient updateCheck = new UpdateCheckClient();
-			isOutdated = updateCheck.isOutdated();
+			updateMode = updateCheck.isOutdated() ?
+				UpdateCheckMode.VANILLA :
+				UpdateCheckMode.RUNELITE;
 		}
 
 		try
 		{
-			if (isOutdated)
+			switch (updateMode)
 			{
-				log.info("RuneLite is outdated - fetching vanilla client");
-				return Optional.of(loadVanilla());
+				case RUNELITE:
+					return loadRuneLite();
+				default:
+				case VANILLA:
+					return loadVanilla();
+				case NONE:
+					return null;
 			}
-
-			log.debug("RuneLite is up to date");
-			return Optional.of(loadRuneLite());
 		}
 		catch (IOException | ClassNotFoundException | InstantiationException | IllegalAccessException e)
 		{
@@ -66,7 +67,8 @@ public class ClientLoader
 			}
 
 			log.error("Error loading RS!", e);
-			return Optional.empty();
+			System.exit(-1);
+			return null;
 		}
 	}
 
@@ -102,9 +104,9 @@ public class ClientLoader
 		// Must set parent classloader to null, or it will pull from
 		// this class's classloader first
 		URLClassLoader classloader = new URLClassLoader(new URL[]
-		{
-			url
-		}, null);
+			{
+				url
+			}, null);
 
 		Class<?> clientClass = classloader.loadClass(initialClass);
 		Applet rs = (Applet) clientClass.newInstance();

--- a/runelite-client/src/main/java/net/runelite/client/UpdateCheckMode.java
+++ b/runelite-client/src/main/java/net/runelite/client/UpdateCheckMode.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2018 Abex
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client;
+
+public enum UpdateCheckMode
+{
+	AUTO,
+	NONE,
+	VANILLA,
+	RUNELITE
+}


### PR DESCRIPTION
Adds `--help` and replaces `--no-rs` and `--disable-update-check` with `--rs`. This also removes use of Optional from ClientLoader because it just called `orElse(null)`.

```
Option                               Description                       
------                               -----------                       
--debug                              Show extra debugging output       
--developer-mode                     Enable developer tools            
--help                               Show this text                    
--rs <[AUTO,NONE,VANILLA,RUNELITE]>  Select client type (default: AUTO)
```