### PR TITLE
Use preferred size if it is larger than minimum

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
@@ -722,7 +722,11 @@ public class ClientUI
 	{
 		revalidateMinimumSize();
 		final int result = frame.getWidth() + value;
-		return result <= frame.getMinimumSize().width ? result : -1;
+		final int minWidth = frame.getMinimumSize().width > config.gameSize().width
+			? frame.getMinimumSize().width
+			: config.gameSize().width;
+
+		return result <= minWidth ? result : -1;
 	}
 
 	private void revalidateMinimumSize()


### PR DESCRIPTION
If user's preferred size is larger than minimum size, prefer that size
when validating contraction of frame.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>