### PR TITLE
farmingtracker: Prevent saving when teleporting

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/farmingtracker/FarmingTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/farmingtracker/FarmingTrackerPlugin.java
@@ -128,7 +128,7 @@ public class FarmingTrackerPlugin extends Plugin
 
 		WorldPoint loc = lastTickLoc;
 		lastTickLoc = client.getLocalPlayer().getWorldLocation();
-		if (loc == null)
+		if (loc == null || loc.getRegionID() != lastTickLoc.getRegionID())
 		{
 			return;
 		}


### PR DESCRIPTION
When teleporting to a updating region (ardy teleport), it would save the new region's varbits to the old region's config.

As reported by `@Littens#3548` on discord.