### PR TITLE
Change to allow the use of matching skill colors in XP Globes

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/SkillColor.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/SkillColor.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2018, Psikoi <https://github.com/psikoi>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.xpglobes;
+
+import java.awt.Color;
+
+public enum SkillColor
+{
+	ATTACK(105, 32, 7),
+	DEFENCE(98, 119, 190),
+	STRENGTH(4, 149, 90),
+	HITPOINTS(164, 162, 149),
+	RANGED(109, 144, 23),
+	PRAYER(240, 229, 46),
+	MAGIC(50, 80, 193),
+	COOKING(112, 35, 134),
+	WOODCUTTING(52, 140, 37),
+	FLETCHING(3, 121, 125),
+	FISHING(116, 142, 174),
+	FIREMAKING(209, 130, 18),
+	CRAFTING(151, 110, 77),
+	SMITHING(108, 107, 82),
+	MINING(82, 138, 161),
+	HERBLORE(2, 143, 7),
+	AGILITY(48, 50, 127),
+	THIEVING(108, 52, 87),
+	SLAYER(18, 18, 18),
+	FARMING(109, 170, 43),
+	RUNECRAFT(180, 151, 36),
+	HUNTER(92, 89, 65),
+	CONSTRUCTION(160, 146, 125);
+
+	private final Color color;
+
+	SkillColor(int red, int green, int blue)
+	{
+		this.color = new Color(red, green, blue);
+	}
+
+	public Color getColor()
+	{
+		return color;
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobe.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobe.java
@@ -24,6 +24,7 @@
  */
 package net.runelite.client.plugins.xpglobes;
 
+import java.awt.*;
 import java.time.Instant;
 import net.runelite.api.Skill;
 
@@ -31,6 +32,7 @@ public class XpGlobe
 {
 
 	private Skill skill;
+	private Color skillColor;
 	private int currentXp;
 	private int currentLevel;
 	private int goalXp;
@@ -40,9 +42,15 @@ public class XpGlobe
 	public XpGlobe(Skill skill, int currentXp, int currentLevel, int goalXp)
 	{
 		this.skill = skill;
+		this.skillColor = getColorFromSkill(skill);
 		this.currentXp = currentXp;
 		this.currentLevel = currentLevel;
 		this.goalXp = goalXp;
+	}
+
+	private Color getColorFromSkill(Skill skill)
+	{
+		return SkillColor.values()[skill.ordinal()].getColor();
 	}
 
 	public Skill getSkill()
@@ -53,6 +61,16 @@ public class XpGlobe
 	public void setSkill(Skill skill)
 	{
 		this.skill = skill;
+	}
+
+	public Color getSkillColor()
+	{
+		return skillColor;
+	}
+
+	public void setSkillColor(Color color)
+	{
+		this.skillColor = color;
 	}
 
 	public int getCurrentXp()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesConfig.java
@@ -48,32 +48,10 @@ public interface XpGlobesConfig extends Config
 	}
 
 	@ConfigItem(
-			keyName = "enableSkillColors",
-			name = "Enable skill colors",
-			description = "Use colors matching to the skill",
-			position = 1
-	)
-	default boolean enableSkillColors()
-	{
-		return true;
-	}
-
-	@ConfigItem(
-		keyName = "Progress arc color",
-		name = "Progress arc color",
-		description = "Change the color of the progress arc in the xp orb",
-		position = 2
-	)
-	default Color progressArcColor()
-	{
-		return Color.ORANGE;
-	}
-
-	@ConfigItem(
 		keyName = "Progress orb outline color",
 		name = "Progress orb outline color",
 		description = "Change the color of the progress orb outline",
-		position = 3
+		position = 1
 	)
 	default Color progressOrbOutLineColor()
 	{
@@ -84,7 +62,7 @@ public interface XpGlobesConfig extends Config
 		keyName = "Progress orb background color",
 		name = "Progress orb background color",
 		description = "Change the color of the progress orb background",
-		position = 4
+		position = 2
 	)
 	default Color progressOrbBackgroundColor()
 	{
@@ -95,7 +73,7 @@ public interface XpGlobesConfig extends Config
 		keyName = "Progress arc width",
 		name = "Progress arc width",
 		description = "Change the stroke width of the progress arc",
-		position = 5
+		position = 3
 	)
 	default int progressArcStrokeWidth()
 	{
@@ -106,7 +84,7 @@ public interface XpGlobesConfig extends Config
 		keyName = "Orb size",
 		name = "Size of orbs",
 		description = "Change the size of the xp orbs",
-		position = 6
+		position = 4
 	)
 	default int xpOrbSize()
 	{
@@ -117,7 +95,7 @@ public interface XpGlobesConfig extends Config
 		keyName = "Center orbs",
 		name = "Center orbs",
 		description = "Where to center the xp orbs around",
-		position = 7
+		position = 5
 	)
 	default OrbCentering centerOrbs()
 	{
@@ -128,7 +106,7 @@ public interface XpGlobesConfig extends Config
 		keyName = "Orb duration",
 		name = "Duration of orbs",
 		description = "Change the duration the xp orbs are visible",
-		position = 8
+		position = 6
 	)
 	default int xpOrbDuration()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesConfig.java
@@ -48,10 +48,21 @@ public interface XpGlobesConfig extends Config
 	}
 
 	@ConfigItem(
+			keyName = "enableSkillColors",
+			name = "Enable skill colors",
+			description = "Use colors matching to the skill",
+			position = 1
+	)
+	default boolean enableSkillColors()
+	{
+		return true;
+	}
+
+	@ConfigItem(
 		keyName = "Progress arc color",
 		name = "Progress arc color",
 		description = "Change the color of the progress arc in the xp orb",
-		position = 1
+		position = 2
 	)
 	default Color progressArcColor()
 	{
@@ -62,7 +73,7 @@ public interface XpGlobesConfig extends Config
 		keyName = "Progress orb outline color",
 		name = "Progress orb outline color",
 		description = "Change the color of the progress orb outline",
-		position = 2
+		position = 3
 	)
 	default Color progressOrbOutLineColor()
 	{
@@ -73,7 +84,7 @@ public interface XpGlobesConfig extends Config
 		keyName = "Progress orb background color",
 		name = "Progress orb background color",
 		description = "Change the color of the progress orb background",
-		position = 3
+		position = 4
 	)
 	default Color progressOrbBackgroundColor()
 	{
@@ -84,7 +95,7 @@ public interface XpGlobesConfig extends Config
 		keyName = "Progress arc width",
 		name = "Progress arc width",
 		description = "Change the stroke width of the progress arc",
-		position = 4
+		position = 5
 	)
 	default int progressArcStrokeWidth()
 	{
@@ -95,7 +106,7 @@ public interface XpGlobesConfig extends Config
 		keyName = "Orb size",
 		name = "Size of orbs",
 		description = "Change the size of the xp orbs",
-		position = 5
+		position = 6
 	)
 	default int xpOrbSize()
 	{
@@ -106,7 +117,7 @@ public interface XpGlobesConfig extends Config
 		keyName = "Center orbs",
 		name = "Center orbs",
 		description = "Where to center the xp orbs around",
-		position = 6
+		position = 7
 	)
 	default OrbCentering centerOrbs()
 	{
@@ -117,7 +128,7 @@ public interface XpGlobesConfig extends Config
 		keyName = "Orb duration",
 		name = "Duration of orbs",
 		description = "Change the duration the xp orbs are visible",
-		position = 7
+		position = 8
 	)
 	default int xpOrbDuration()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesOverlay.java
@@ -155,7 +155,8 @@ public class XpGlobesOverlay extends Overlay
 			config.xpOrbSize(), config.xpOrbSize(),
 			PROGRESS_RADIUS_START, radiusCurrentXp,
 			config.progressArcStrokeWidth(),
-			skillToDraw.getSkillColor());
+			skillToDraw.getSkillColor()
+		);
 
 		graphics.setRenderingHint(RenderingHints.KEY_STROKE_CONTROL, renderHint);
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesOverlay.java
@@ -149,20 +149,13 @@ public class XpGlobesOverlay extends Overlay
 			5,
 			config.progressOrbOutLineColor()
 		);
-
-		Color progressColor = config.progressArcColor();
-		if(config.enableSkillColors())
-		{
-			progressColor = skillToDraw.getSkillColor();
-		}
-		
 		drawProgressArc(
 			graphics,
 			x, y,
 			config.xpOrbSize(), config.xpOrbSize(),
 			PROGRESS_RADIUS_START, radiusCurrentXp,
 			config.progressArcStrokeWidth(),
-			progressColor);
+			skillToDraw.getSkillColor());
 
 		graphics.setRenderingHint(RenderingHints.KEY_STROKE_CONTROL, renderHint);
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesOverlay.java
@@ -149,13 +149,20 @@ public class XpGlobesOverlay extends Overlay
 			5,
 			config.progressOrbOutLineColor()
 		);
+
+		Color progressColor = config.progressArcColor();
+		if(config.enableSkillColors())
+		{
+			progressColor = skillToDraw.getSkillColor();
+		}
+		
 		drawProgressArc(
 			graphics,
 			x, y,
 			config.xpOrbSize(), config.xpOrbSize(),
 			PROGRESS_RADIUS_START, radiusCurrentXp,
 			config.progressArcStrokeWidth(),
-			config.progressArcColor());
+			progressColor);
 
 		graphics.setRenderingHint(RenderingHints.KEY_STROKE_CONTROL, renderHint);
 


### PR DESCRIPTION
Added an option to use colors matching to skills in the progressbar of the skill globes instead of one color to use for all the globes.