### PR TITLE
WorldMapOverlay: Add check for current plane

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/WorldMapData.java
+++ b/runelite-api/src/main/java/net/runelite/api/WorldMapData.java
@@ -26,4 +26,5 @@ package net.runelite.api;
 
 public interface WorldMapData
 {
+	boolean surfaceContainsPosition(int x, int y);
 }

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/worldmap/WorldMapOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/worldmap/WorldMapOverlay.java
@@ -104,6 +104,12 @@ public class WorldMapOverlay extends Overlay
 			{
 				Point drawPoint = mapWorldPointToGraphicsPoint(point);
 
+				if (drawPoint == null)
+				{
+					worldPoint.setClickbox(null);
+					continue;
+				}
+
 				if (worldPoint.isSnapToEdge())
 				{
 					Canvas canvas = client.getCanvas();
@@ -168,6 +174,12 @@ public class WorldMapOverlay extends Overlay
 	private Point mapWorldPointToGraphicsPoint(WorldPoint worldPoint)
 	{
 		RenderOverview ro = clientProvider.get().getRenderOverview();
+
+		if (!ro.getWorldMapData().surfaceContainsPosition(worldPoint.getX(), worldPoint.getY()))
+		{
+			return null;
+		}
+
 		Float pixelsPerTile = ro.getWorldMapZoom();
 
 		Point worldMapPosition = ro.getWorldMapPosition();
@@ -184,18 +196,18 @@ public class WorldMapOverlay extends Overlay
 
 			return new Point(xGraphDiff, yGraphDiff);
 		}
-		return new Point(0, 0);
+		return null;
 	}
 
 	private void drawTooltip(Graphics2D graphics, WorldMapPoint worldPoint)
 	{
 		String tooltip = worldPoint.getTooltip();
-		if (tooltip == null || tooltip.length() <= 0)
+		Point drawPoint = mapWorldPointToGraphicsPoint(worldPoint.getWorldPoint());
+		if (tooltip == null || tooltip.length() <= 0 || drawPoint == null)
 		{
 			return;
 		}
 
-		Point drawPoint = mapWorldPointToGraphicsPoint(worldPoint.getWorldPoint());
 		drawPoint = new Point(drawPoint.getX() + TOOLTIP_OFFSET_WIDTH, drawPoint.getY() + TOOLTIP_OFFSET_HEIGHT);
 
 		graphics.setClip(0, 0, clientProvider.get().getCanvas().getWidth(), clientProvider.get().getCanvas().getHeight());

--- a/runescape-api/src/main/java/net/runelite/rs/api/RSWorldMapData.java
+++ b/runescape-api/src/main/java/net/runelite/rs/api/RSWorldMapData.java
@@ -25,7 +25,10 @@
 package net.runelite.rs.api;
 
 import net.runelite.api.WorldMapData;
+import net.runelite.mapping.Import;
 
 public interface RSWorldMapData extends WorldMapData
 {
+	@Import("surfaceContainsPosition")
+	boolean surfaceContainsPosition(int x, int y);
 }


### PR DESCRIPTION
Adds plane check to WorldMapOverlay rendering
![6f47ee12f42e1ba919832ad3204c4045](https://user-images.githubusercontent.com/597053/39638727-605b58ba-4f84-11e8-8042-77b433dcdd83.gif)
