### PR TITLE
Make farming tracker use english for dates by default

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/farmingtracker/FarmingTrackerConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/farmingtracker/FarmingTrackerConfig.java
@@ -49,6 +49,16 @@ public interface FarmingTrackerConfig extends Config
 	}
 
 	@ConfigItem(
+			keyName = "useLocalDates",
+			name = "Use local language in dates",
+			description = "The language used for displaying dates"
+	)
+	default boolean useLocalDates()
+	{
+		return false;
+	}
+
+	@ConfigItem(
 		keyName = "patch",
 		name = "Default patch",
 		description = "Default patch on opening the panel",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/farmingtracker/FarmingTrackerConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/farmingtracker/FarmingTrackerConfig.java
@@ -49,16 +49,6 @@ public interface FarmingTrackerConfig extends Config
 	}
 
 	@ConfigItem(
-			keyName = "useLocalDates",
-			name = "Use local language in dates",
-			description = "The language used for displaying dates"
-	)
-	default boolean useLocalDates()
-	{
-		return false;
-	}
-
-	@ConfigItem(
 		keyName = "patch",
 		name = "Default patch",
 		description = "Default patch on opening the panel",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/farmingtracker/FarmingTrackerPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/farmingtracker/FarmingTrackerPanel.java
@@ -266,7 +266,7 @@ class FarmingTrackerPanel extends PluginPanel
 						f.append("Done ");
 						if (ldtTime.getDayOfWeek() != ldtNow.getDayOfWeek())
 						{
-							f.append(ldtTime.getDayOfWeek().getDisplayName(TextStyle.FULL, Locale.getDefault())).append(" ");
+                            f.append(ldtTime.getDayOfWeek().getDisplayName(TextStyle.FULL, config.useLocalDates() ? Locale.getDefault() : Locale.ENGLISH)).append(" ");
 						}
 						f.append(String.format("at %d:%02d", ldtTime.getHour(), ldtTime.getMinute()));
 						panel.getEstimate().setText(f.toString());

--- a/runelite-client/src/main/java/net/runelite/client/plugins/farmingtracker/FarmingTrackerPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/farmingtracker/FarmingTrackerPanel.java
@@ -266,7 +266,7 @@ class FarmingTrackerPanel extends PluginPanel
 						f.append("Done ");
 						if (ldtTime.getDayOfWeek() != ldtNow.getDayOfWeek())
 						{
-                            f.append(ldtTime.getDayOfWeek().getDisplayName(TextStyle.FULL, config.useLocalDates() ? Locale.getDefault() : Locale.ENGLISH)).append(" ");
+							f.append(ldtTime.getDayOfWeek().getDisplayName(TextStyle.FULL, config.useLocalDates() ? Locale.getDefault() : Locale.ENGLISH)).append(" ");
 						}
 						f.append(String.format("at %d:%02d", ldtTime.getHour(), ldtTime.getMinute()));
 						panel.getEstimate().setText(f.toString());

--- a/runelite-client/src/main/java/net/runelite/client/plugins/farmingtracker/FarmingTrackerPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/farmingtracker/FarmingTrackerPanel.java
@@ -266,7 +266,7 @@ class FarmingTrackerPanel extends PluginPanel
 						f.append("Done ");
 						if (ldtTime.getDayOfWeek() != ldtNow.getDayOfWeek())
 						{
-							f.append(ldtTime.getDayOfWeek().getDisplayName(TextStyle.FULL, config.useLocalDates() ? Locale.getDefault() : Locale.ENGLISH)).append(" ");
+							f.append(ldtTime.getDayOfWeek().getDisplayName(TextStyle.FULL, Locale.ENGLISH)).append(" ");
 						}
 						f.append(String.format("at %d:%02d", ldtTime.getHour(), ldtTime.getMinute()));
 						panel.getEstimate().setText(f.toString());


### PR DESCRIPTION
Make farming tracker use english for dates by default and allow swapping between system default and English, Fix #2268