### PR TITLE
Add Wave Info To Fight Cave Plugin

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/fightcave/FightCaveOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/fightcave/FightCaveOverlay.java
@@ -30,6 +30,8 @@ import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.OverlayPriority;
 import net.runelite.client.ui.overlay.components.ImagePanelComponent;
+import net.runelite.client.ui.overlay.components.PanelComponent;
+
 
 import javax.imageio.ImageIO;
 import javax.inject.Inject;
@@ -38,6 +40,9 @@ import java.awt.Dimension;
 import java.awt.Graphics2D;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 @Slf4j
 public class FightCaveOverlay extends Overlay
@@ -65,17 +70,68 @@ public class FightCaveOverlay extends Overlay
 		JadAttack attack = plugin.getAttack();
 		if (attack == null)
 		{
-			return null;
+			int wave = plugin.getWave();
+			if(wave == 0)
+			{
+				return null;
+			}
+			int[] enemies = plugin.getEnemies(wave);
+			if(enemies.length > 0)
+			{
+				Map<Integer, Integer> numberOfEnemies = new HashMap<>();
+				for(int i=0; i<enemies.length; i++){
+					if(numberOfEnemies.containsKey(enemies[i]))
+					{
+						numberOfEnemies.put(enemies[i], numberOfEnemies.get(enemies[i]) + 1);
+					}
+					else
+					{
+						numberOfEnemies.put(enemies[i], 1);
+					}
+				}
+				PanelComponent waveInfo = new PanelComponent();
+				waveInfo.setTitle("Current Wave: " + Integer.toString(wave));
+				List<PanelComponent.Line> lines = waveInfo.getLines();
+
+				if(numberOfEnemies.containsKey(360))
+				{
+					lines.add(new PanelComponent.Line("360 Mage: ", Integer.toString(numberOfEnemies.get(360))));
+				}
+				if(numberOfEnemies.containsKey(180))
+				{
+					lines.add(new PanelComponent.Line("180 Melee: ", Integer.toString(numberOfEnemies.get(180))));
+				}
+				if(numberOfEnemies.containsKey(90))
+				{
+					lines.add(new PanelComponent.Line("90 Ranger: ", Integer.toString(numberOfEnemies.get(90))));
+				}
+				if(numberOfEnemies.containsKey(45))
+				{
+					lines.add(new PanelComponent.Line("45 Melee: ", Integer.toString(numberOfEnemies.get(45))));
+				}
+				if(numberOfEnemies.containsKey(22))
+				{
+					lines.add(new PanelComponent.Line("22 Melee: ", Integer.toString(numberOfEnemies.get(22))));
+				}
+
+				return waveInfo.render(graphics);
+			}
+			else
+			{
+				return null;
+			}
 		}
-		BufferedImage prayerImage = getPrayerImage(attack);
-		ImagePanelComponent imagePanelComponent = new ImagePanelComponent();
-		imagePanelComponent.setTitle("TzTok-Jad");
-		imagePanelComponent.getImages().add(prayerImage);
-		if (!client.isPrayerActive(attack.getPrayer()))
+		else
 		{
-			imagePanelComponent.setBackgroundColor(NOT_ACTIVATED_BACKGROUND_COLOR);
+			BufferedImage prayerImage = getPrayerImage(attack);
+			ImagePanelComponent imagePanelComponent = new ImagePanelComponent();
+			imagePanelComponent.setTitle("TzTok-Jad");
+			imagePanelComponent.getImages().add(prayerImage);
+			if (!client.isPrayerActive(attack.getPrayer())) {
+				imagePanelComponent.setBackgroundColor(NOT_ACTIVATED_BACKGROUND_COLOR);
+			}
+			return imagePanelComponent.render(graphics);
 		}
-		return imagePanelComponent.render(graphics);
 	}
 
 	private BufferedImage getPrayerImage(JadAttack attack)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/fightcave/FightCavePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/fightcave/FightCavePlugin.java
@@ -25,17 +25,20 @@
 package net.runelite.client.plugins.fightcave;
 
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Arrays;
 import javax.inject.Inject;
-import net.runelite.api.Client;
-import net.runelite.api.GameState;
-import net.runelite.api.NPC;
-import net.runelite.api.Query;
+
+import com.google.common.eventbus.Subscribe;
+import net.runelite.api.*;
+import net.runelite.api.events.ChatMessage;
 import net.runelite.api.queries.NPCQuery;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.task.Schedule;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.util.QueryRunner;
+import net.runelite.client.util.Text;
 
 @PluginDescriptor(
 	name = "Fight Cave"
@@ -53,6 +56,74 @@ public class FightCavePlugin extends Plugin
 
 	private JadAttack attack;
 
+	private static final ArrayList<Integer> FIGHT_CAVE_REGIONS = new ArrayList<Integer>(Arrays.asList(9294, 9295, 9296, 9550, 9551, 9552, 9806, 9807, 9808));
+
+	private static final int[][] WAVE_ENEMIES = {//I could have just written a function, but this is faster to write :shrug:
+			{22},
+			{22, 22},
+			{45},
+			{45, 22},
+			{45, 22, 22},
+			{45, 45},
+			{90},
+			{90, 22},
+			{90, 22, 22},
+			{90, 45},
+			{90, 45, 22},
+			{90, 45, 22, 22},
+			{90, 45, 45},
+			{90, 90},
+			{180},
+			{180, 22},
+			{180, 22, 22},
+			{180, 45},
+			{180, 45, 22},
+			{180, 45, 22, 22},
+			{180, 45, 45},
+			{180, 90},
+			{180, 90, 22},
+			{180, 90, 22, 22},
+			{180, 90, 45},
+			{180, 90, 45, 22},
+			{180, 90, 45, 22, 22},
+			{180, 90, 45, 45},
+			{180, 90, 90},
+			{180, 180},
+			{360},
+			{360, 22},
+			{360, 22, 22},
+			{360, 45},
+			{360, 45, 22},
+			{360, 45, 22, 22},
+			{360, 45 ,45},
+			{360, 90},
+			{360, 90, 22},
+			{360, 90, 22, 22},
+			{360, 90, 45},
+			{360, 90, 45, 22},
+			{360, 90, 45, 22, 22},
+			{360, 90, 45, 45},
+			{360, 90, 90},
+			{360, 180},
+			{360, 180, 22},
+			{360, 180, 22, 22},
+			{360, 180, 45},
+			{360, 180, 45, 22},
+			{360, 180, 45, 22, 22},
+			{360, 180, 45, 45},
+			{360, 180, 90},
+			{360, 180, 90, 22},
+			{360, 180, 90, 22, 22},
+			{360, 180, 90, 45},
+			{360, 180, 90, 45 ,22},
+			{360, 180, 90, 45, 22, 22},
+			{360, 180, 90, 45, 45},
+			{360, 180, 90, 90},
+			{360, 180, 180},
+			{360, 360}
+	};
+
+	private int wave = 0;
 	@Override
 	public Overlay getOverlay()
 	{
@@ -88,11 +159,56 @@ public class FightCavePlugin extends Plugin
 		}
 	}
 
+	@Subscribe
+	public void onChatMessage(ChatMessage event)
+	{
+		if (event.getType() == ChatMessageType.SERVER && isInFightCaves())
+		{
+			String msg = Text.removeTags(event.getMessage());//.substring(6);
+			if(msg.contains("Wave:"))
+			{
+				this.wave = Integer.parseInt(msg.substring(6));
+				return;
+			}
+		}
+	}
+
+	private boolean isInFightCaves()
+	{//more like is in city or fight caves, but close enough
+		int[] regions = client.getMapRegions();
+		for(int i=0; i<regions.length; i++)
+		{
+			if(FIGHT_CAVE_REGIONS.contains(regions[i]))
+			{
+				return true;
+			}
+		}
+		return false;
+	}
+
 	private NPC findJad()
 	{
 		Query query = new NPCQuery().nameContains("TzTok-Jad");
 		NPC[] result = queryRunner.runQuery(query);
 		return result.length >= 1 ? result[0] : null;
+	}
+
+	public int[] getEnemies(int wave)
+	{
+		int index = wave-1;
+		if(index >= 0 && index <= 61)
+		{
+			return WAVE_ENEMIES[index];
+		}
+		return new int[]{};
+	}
+
+	public int getWave()
+	{
+		if(!isInFightCaves()){
+			this.wave = 0;
+		}
+		return this.wave;
 	}
 
 	JadAttack getAttack()


### PR DESCRIPTION
The fight cave plugin now shows what type of enemies to expect, and how many to expect for that wave.

See bottom right corner

![image](https://user-images.githubusercontent.com/9359529/39658999-ebbfd59e-4fec-11e8-8c28-85be27fff1d6.png)
