### PR TITLE
Fix agility laps left counter

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/agility/AgilityPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/agility/AgilityPlugin.java
@@ -25,7 +25,6 @@
 package net.runelite.client.plugins.agility;
 
 import com.google.common.eventbus.Subscribe;
-import com.google.common.primitives.Ints;
 import com.google.inject.Provides;
 import java.util.Arrays;
 import java.util.Collection;
@@ -142,8 +141,8 @@ public class AgilityPlugin extends Plugin
 		lastAgilityXp = agilityXp;
 
 		// Get course
-		Courses course = Courses.getCourse(skillGained);
-		if (course == null || !Ints.contains(client.getMapRegions(), course.getRegionId()))
+		Courses course = Courses.getCourse(client.getLocalPlayer().getWorldLocation().getRegionID());
+		if (course == null || Math.abs(course.getLastObstacleXp() - skillGained) > 1)
 		{
 			return;
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/agility/AgilitySession.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/agility/AgilitySession.java
@@ -54,7 +54,13 @@ public class AgilitySession
 
 		int currentExp = client.getSkillExperience(Skill.AGILITY);
 		int nextLevel = client.getRealSkillLevel(Skill.AGILITY) + 1;
-		int remainingXp = nextLevel <= Experience.MAX_VIRT_LEVEL ? Experience.getXpForLevel(nextLevel) - currentExp : 0;
+
+		int remainingXp;
+		do
+		{
+			remainingXp = nextLevel <= Experience.MAX_VIRT_LEVEL ? Experience.getXpForLevel(nextLevel) - currentExp : 0;
+			nextLevel++;
+		} while (remainingXp < 0);
 
 		lapsTillLevel = remainingXp > 0 ? (int) Math.ceil(remainingXp / course.getTotalXp()) : 0;
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/agility/Courses.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/agility/Courses.java
@@ -48,11 +48,12 @@ public enum Courses
 	RELLEKA(780.0, 475, 10553),
 	ARDOUGNE(793.0, 529, 10547);
 
-	private final static Map<Integer, Courses> courseXps = new HashMap<>();
+	private final static Map<Integer, Courses> coursesByRegion = new HashMap<>();
 
 	@Getter
 	private final double totalXp;
 
+	@Getter
 	private final int lastObstacleXp;
 
 	@Getter
@@ -62,12 +63,12 @@ public enum Courses
 	{
 		for (Courses course : values())
 		{
-			courseXps.put(course.lastObstacleXp, course);
+			coursesByRegion.put(course.regionId, course);
 		}
 	}
 
-	public static Courses getCourse(int exp)
+	public static Courses getCourse(int regionId)
 	{
-		return courseXps.get(exp);
+		return coursesByRegion.get(regionId);
 	}
 }


### PR DESCRIPTION
Stop the laps remaining overlay from disappearing on level up at end of course (Fixes #2282 )
Make the laps remaining counter count the laps remaining to the next level if the previous next level was reached with the exp gained.
Select the active course based on regionId as the results from selecting by exp are unreliable because there are courses that give uneven amounts of exp/lap