### PR TITLE
Add config option that enables/disables mouse tooltip on rune pouch hover

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/runepouch/RunepouchOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/runepouch/RunepouchOverlay.java
@@ -37,6 +37,8 @@ import net.runelite.api.Varbits;
 import net.runelite.api.queries.InventoryWidgetItemQuery;
 import net.runelite.api.widgets.WidgetItem;
 import net.runelite.client.game.ItemManager;
+import static net.runelite.client.plugins.runepouch.config.RunePouchOverlayMode.BOTH;
+import static net.runelite.client.plugins.runepouch.config.RunePouchOverlayMode.MOUSE_HOVER;
 import net.runelite.client.ui.FontManager;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
@@ -125,7 +127,7 @@ public class RunepouchOverlay extends Overlay
 				.append(rune.getName())
 				.append("</col></br>");
 
-			if (config.showOnlyOnHover())
+			if (config.runePouchOverlayMode() == MOUSE_HOVER)
 			{
 				continue;
 			}
@@ -154,7 +156,9 @@ public class RunepouchOverlay extends Overlay
 
 		String tooltip = tooltipBuilder.toString();
 
-		if (!tooltip.isEmpty() && runePouch.getCanvasBounds().contains(client.getMouseCanvasPosition().getX(), client.getMouseCanvasPosition().getY()))
+		if (!tooltip.isEmpty()
+			&& runePouch.getCanvasBounds().contains(client.getMouseCanvasPosition().getX(), client.getMouseCanvasPosition().getY())
+			&& (config.runePouchOverlayMode() == MOUSE_HOVER || config.runePouchOverlayMode() == BOTH))
 		{
 			tooltipManager.add(new Tooltip(tooltip));
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/runepouch/config/RunePouchOverlayMode.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/runepouch/config/RunePouchOverlayMode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Tyler <https://github.com/tylerthardy>
+ * Copyright (c) 2018, Lars <lars.oernlo@gmail.com>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -22,51 +22,24 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package net.runelite.client.plugins.runepouch;
+package net.runelite.client.plugins.runepouch.config;
 
-import java.awt.Color;
-import net.runelite.client.config.Config;
-import net.runelite.client.config.ConfigGroup;
-import net.runelite.client.config.ConfigItem;
-import net.runelite.client.plugins.runepouch.config.RunePouchOverlayMode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
-@ConfigGroup(
-	keyName = "runepouch",
-	name = "Rune Pouch",
-	description = "Configuration for the Runepouch plugin"
-)
-public interface RunepouchConfig extends Config
+@Getter
+@RequiredArgsConstructor
+public enum RunePouchOverlayMode
 {
-	@ConfigItem(
-		keyName = "fontcolor",
-		name = "Font Color",
-		description = "Color of the font for the number of runes in pouch",
-		position = 1
-	)
-	default Color fontColor()
-	{
-		return Color.yellow;
-	}
+	INVENTORY("Inventory"),
+	MOUSE_HOVER("Mouse hover"),
+	BOTH("Both");
 
-	@ConfigItem(
-		keyName = "runeicons",
-		name = "Show Rune Icons",
-		description = "Show the rune icons next to the number of runes in pouch",
-		position = 2
-	)
-	default boolean showIcons()
-	{
-		return true;
-	}
+	private final String name;
 
-	@ConfigItem(
-		keyName = "runePouchOverlayMode",
-		name = "Display mode",
-		description = "Configures where rune pouch overlay is displayed",
-		position = 3
-	)
-	default RunePouchOverlayMode runePouchOverlayMode()
+	@Override
+	public String toString()
 	{
-		return RunePouchOverlayMode.BOTH;
+		return name;
 	}
 }


### PR DESCRIPTION
Showing a tooltip on mouseover when the same information is already visible on screen seems unnecessary.