### PR TITLE
FPS plugin: fix startup not applying limits

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/fps/FpsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/fps/FpsPlugin.java
@@ -94,6 +94,7 @@ public class FpsPlugin extends Plugin
 	protected void startUp() throws Exception
 	{
 		drawManager.registerEveryFrameListener(drawListener);
+		drawListener.reloadConfig();
 	}
 
 	@Override


### PR DESCRIPTION
Issue:
@deathbeam reported that the limits were not applying immediately after start up
and this required dirtying the config manually to get it to apply.

Problem:
The draw listener expects `reloadConfig` to be called prior to its active use, so it is also an initalizing method.
`reloadConfig` was only being called if the config changed, and not when the plugin was activated.

Solution:
Call `reloadConfig` when the plugin is activated so it has been initialized.