### PR TITLE
Fix WorldMapOverlay to draw pixel perfect on the WorldMap

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/worldmap/WorldMapOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/worldmap/WorldMapOverlay.java
@@ -182,17 +182,31 @@ public class WorldMapOverlay extends Overlay
 
 		Float pixelsPerTile = ro.getWorldMapZoom();
 
-		Point worldMapPosition = ro.getWorldMapPosition();
-		int xWorldDiff = worldPoint.getX() - worldMapPosition.getX();
-		int yWorldDiff = worldPoint.getY() - worldMapPosition.getY();
-		yWorldDiff = -yWorldDiff;
-
 		Widget map = clientProvider.get().getWidget(WidgetInfo.WORLD_MAP_VIEW);
 		if (map != null)
 		{
 			Rectangle worldMapRect = map.getBounds();
-			int xGraphDiff = (int) (xWorldDiff * pixelsPerTile + worldMapRect.getWidth() / 2 + worldMapRect.getX());
-			int yGraphDiff = (int) (yWorldDiff * pixelsPerTile + worldMapRect.getHeight() / 2 + worldMapRect.getY());
+
+			int widthInTiles = (int) Math.ceil(worldMapRect.getWidth() / pixelsPerTile);
+			int heightInTiles = (int) Math.ceil(worldMapRect.getHeight() / pixelsPerTile);
+
+			Point worldMapPosition = ro.getWorldMapPosition();
+
+			//Offset in tiles from anchor sides
+			int yTileMax = worldMapPosition.getY() - heightInTiles / 2;
+			int yTileOffset = (yTileMax - worldPoint.getY() - 1) * -1;
+			int xTileOffset = worldPoint.getX() + widthInTiles / 2 - worldMapPosition.getX();
+
+			int xGraphDiff = ((int) (xTileOffset * pixelsPerTile));
+			int yGraphDiff = (int) (yTileOffset * pixelsPerTile);
+
+			//Center on tile.
+			yGraphDiff -= pixelsPerTile - (pixelsPerTile / 2);
+			xGraphDiff += pixelsPerTile - (pixelsPerTile / 2);
+
+			yGraphDiff = worldMapRect.height - yGraphDiff;
+			yGraphDiff += (int) worldMapRect.getY();
+			xGraphDiff += (int) worldMapRect.getX();
 
 			return new Point(xGraphDiff, yGraphDiff);
 		}

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/worldmap/WorldMapPointManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/worldmap/WorldMapPointManager.java
@@ -25,6 +25,7 @@
 package net.runelite.client.ui.overlay.worldmap;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import javax.inject.Singleton;
 import lombok.AccessLevel;
@@ -41,8 +42,18 @@ public class WorldMapPointManager
 		worldMapPoints.add(worldMapPoint);
 	}
 
+	public void addAll(Collection<? extends WorldMapPoint> collection)
+	{
+		worldMapPoints.addAll(collection);
+	}
+
 	public void remove(WorldMapPoint worldMapPoint)
 	{
 		worldMapPoints.remove(worldMapPoint);
+	}
+
+	public void removeAll(Collection<? extends WorldMapPoint> collection)
+	{
+		worldMapPoints.removeAll(collection);
 	}
 }

--- a/runelite-mixins/src/main/java/net/runelite/mixins/WorldMapManagerMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/WorldMapManagerMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Adam <Adam@sigterm.info>
+ * Copyright (c) 2018, Morgan Lewis <https://github.com/MESLewis>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -22,23 +22,37 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package net.runelite.rs.api;
+package net.runelite.mixins;
 
-import net.runelite.api.WorldMapManager;
-import net.runelite.mapping.Import;
+import net.runelite.api.mixins.Mixin;
+import net.runelite.api.mixins.Replace;
+import net.runelite.api.mixins.Shadow;
+import net.runelite.rs.api.RSClient;
+import net.runelite.rs.api.RSWorldMapManager;
 
-public interface RSWorldMapManager extends WorldMapManager
+@Mixin(RSWorldMapManager.class)
+public abstract class WorldMapManagerMixin implements RSWorldMapManager
 {
-	@Import("loaded")
+	@Shadow("clientInstance")
+	static RSClient client;
+
+	/*
+	 The worldMapZoom is essentially pixels per tile. In most instances
+	 getPixelsPerTile returns the same as worldMapZoom.
+
+	 At some map widths when 100% zoomed in the Jagex version of this function
+	 returns 7.89 instead of 8.0 (the worldMapZoom at this level).
+	 This would cause both the x and y positions of the map to shift
+	 slightly when the map was certain widths.
+
+	 This mixin function replaces Jagex calculation with getWorldMapZoom.
+	 This small change makes the world map tile sizing predictable.
+	 */
+	@Replace("getPixelsPerTile")
 	@Override
-	boolean isLoaded();
+	public float getPixelsPerTile(int graphicsDiff, int worldDiff)
+	{
+		return client.getRenderOverview().getWorldMapZoom();
+	}
 
-	@Import("mapSurfaceBaseOffsetX")
-	int getSurfaceOffsetX();
-
-	@Import("mapSurfaceBaseOffsetY")
-	int getSurfaceOffsetY();
-
-	@Import("getPixelsPerTile")
-	float getPixelsPerTile(int graphicsDiff, int worldDiff);
 }

--- a/runelite-mixins/src/main/java/net/runelite/mixins/WorldMapMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/WorldMapMixin.java
@@ -49,5 +49,4 @@ public abstract class WorldMapMixin implements RSRenderOverview
 	{
 		setWorldMapPositionTarget(worldPoint.getX(), worldPoint.getY());
 	}
-
 }

--- a/runescape-client/src/main/java/RenderOverview.java
+++ b/runescape-client/src/main/java/RenderOverview.java
@@ -723,9 +723,9 @@ public class RenderOverview {
             }
          }
 
-         int var8 = (int)Math.ceil((double)((float)width / this.worldMapZoom));
-         int var9 = (int)Math.ceil((double)((float)height / this.worldMapZoom));
-         this.worldMapManager.drawMapRegion(this.worldMapX - var8 / 2, this.worldMapY - var9 / 2, var8 / 2 + this.worldMapX, var9 / 2 + this.worldMapY, graphicsX, graphicsY, width + graphicsX, graphicsY + height);
+         int widthInTiles = (int)Math.ceil((double)((float)width / this.worldMapZoom));
+         int heightInTiles = (int)Math.ceil((double)((float)height / this.worldMapZoom));
+         this.worldMapManager.drawMapRegion(this.worldMapX - widthInTiles / 2, this.worldMapY - heightInTiles / 2, widthInTiles / 2 + this.worldMapX, heightInTiles / 2 + this.worldMapY, graphicsX, graphicsY, width + graphicsX, graphicsY + height);
          boolean var10;
          if(!this.field4065) {
             var10 = false;
@@ -734,17 +734,17 @@ public class RenderOverview {
                var10 = true;
             }
 
-            this.worldMapManager.drawMapIcons(this.worldMapX - var8 / 2, this.worldMapY - var9 / 2, var8 / 2 + this.worldMapX, var9 / 2 + this.worldMapY, graphicsX, graphicsY, width + graphicsX, graphicsY + height, this.field4052, this.field4038, this.field4060, this.field4036, var10);
+            this.worldMapManager.drawMapIcons(this.worldMapX - widthInTiles / 2, this.worldMapY - heightInTiles / 2, widthInTiles / 2 + this.worldMapX, heightInTiles / 2 + this.worldMapY, graphicsX, graphicsY, width + graphicsX, graphicsY + height, this.field4052, this.field4038, this.field4060, this.field4036, var10);
          }
 
-         this.method6087(graphicsX, graphicsY, width, height, var8, var9);
+         this.method6087(graphicsX, graphicsY, width, height, widthInTiles, heightInTiles);
          var10 = Client.rights >= 2;
          if(var10 && this.field4011 && this.field4059 != null) {
             this.field4055.method5630("Coord: " + this.field4059, Rasterizer2D.draw_region_x + 10, Rasterizer2D.drawingAreaTop + 20, 16776960, -1);
          }
 
-         this.worldMapDisplayWidth = var8;
-         this.worldMapDisplayHeight = var9;
+         this.worldMapDisplayWidth = widthInTiles;
+         this.worldMapDisplayHeight = heightInTiles;
          this.worldMapDisplayX = graphicsX;
          this.worldMapDisplayY = graphicsY;
          Rasterizer2D.setDrawRegion(var6);

--- a/runescape-client/src/main/java/WorldMapManager.java
+++ b/runescape-client/src/main/java/WorldMapManager.java
@@ -192,7 +192,7 @@ public final class WorldMapManager {
       int[] var12 = new int[4];
       Rasterizer2D.copyDrawRegion(var12);
       WorldMapRectangle var13 = this.getRegionRectForViewport(var1, var2, var3, var4);
-      float var14 = this.method602(x2 - x1, var3 - var1);
+      float var14 = this.getPixelsPerTile(x2 - x1, var3 - var1);
       int var15 = (int)Math.ceil((double)var14);
       this.field557 = var15;
       if(!this.field550.containsKey(Integer.valueOf(var15))) {
@@ -232,29 +232,29 @@ public final class WorldMapManager {
       garbageValue = "-1997582972"
    )
    @Export("drawMapIcons")
-   public final void drawMapIcons(int x1, int y1, int x2, int y2, int graphicsX1, int var6, int graphicsX2, int var8, HashSet var9, HashSet var10, int var11, int var12, boolean var13) {
+   public final void drawMapIcons(int x1, int y1, int x2, int y2, int graphicsX1, int graphicsY1, int graphicsX2, int graphicsY2, HashSet var9, HashSet var10, int var11, int var12, boolean var13) {
       WorldMapRectangle worldMapRectangle = this.getRegionRectForViewport(x1, y1, x2, y2);
-      float var15 = this.method602(graphicsX2 - graphicsX1, x2 - x1);
-      int var16 = (int)(64.0F * var15);
+      float pixelsPerTile = this.getPixelsPerTile(graphicsX2 - graphicsX1, x2 - x1);
+      int regionWidthPixels = (int)(64.0F * pixelsPerTile);
       int xCoordinate = x1 + this.mapSurfaceBaseOffsetX;
       int yCoordinate = y1 + this.mapSurfaceBaseOffsetY;
 
-      int var19;
-      int var20;
-      for(var19 = worldMapRectangle.worldMapRegionX; var19 < worldMapRectangle.worldMapRegionWidth + worldMapRectangle.worldMapRegionX; ++var19) {
-         for(var20 = worldMapRectangle.worldMapRegionY; var20 < worldMapRectangle.worldMapRegionHeight + worldMapRectangle.worldMapRegionY; ++var20) {
+      int curRegionX;
+      int curRegionY;
+      for(curRegionX = worldMapRectangle.worldMapRegionX; curRegionX < worldMapRectangle.worldMapRegionWidth + worldMapRectangle.worldMapRegionX; ++curRegionX) {
+         for(curRegionY = worldMapRectangle.worldMapRegionY; curRegionY < worldMapRectangle.worldMapRegionHeight + worldMapRectangle.worldMapRegionY; ++curRegionY) {
             if(var13) {
-               this.mapRegions[var19][var20].method405();
+               this.mapRegions[curRegionX][curRegionY].method405();
             }
 
-            this.mapRegions[var19][var20].method499(graphicsX1 + var16 * (this.mapRegions[var19][var20].field481 * 64 - xCoordinate) / 64, var8 - var16 * (this.mapRegions[var19][var20].field488 * 64 - yCoordinate + 64) / 64, var16, var9);
+            this.mapRegions[curRegionX][curRegionY].method499(graphicsX1 + regionWidthPixels * (this.mapRegions[curRegionX][curRegionY].field481 * 64 - xCoordinate) / 64, graphicsY2 - regionWidthPixels * (this.mapRegions[curRegionX][curRegionY].field488 * 64 - yCoordinate + 64) / 64, regionWidthPixels, var9);
          }
       }
 
       if(var10 != null && var11 > 0) {
-         for(var19 = worldMapRectangle.worldMapRegionX; var19 < worldMapRectangle.worldMapRegionWidth + worldMapRectangle.worldMapRegionX; ++var19) {
-            for(var20 = worldMapRectangle.worldMapRegionY; var20 < worldMapRectangle.worldMapRegionHeight + worldMapRectangle.worldMapRegionY; ++var20) {
-               this.mapRegions[var19][var20].drawFlashingMapIcons(var10, var11, var12);
+         for(curRegionX = worldMapRectangle.worldMapRegionX; curRegionX < worldMapRectangle.worldMapRegionWidth + worldMapRectangle.worldMapRegionX; ++curRegionX) {
+            for(curRegionY = worldMapRectangle.worldMapRegionY; curRegionY < worldMapRectangle.worldMapRegionHeight + worldMapRectangle.worldMapRegionY; ++curRegionY) {
+               this.mapRegions[curRegionX][curRegionY].drawFlashingMapIcons(var10, var11, var12);
             }
          }
       }
@@ -336,7 +336,7 @@ public final class WorldMapManager {
          return var11;
       } else {
          WorldMapRectangle var12 = this.getRegionRectForViewport(var1, var2, var3, var4);
-         float var13 = this.method602(var7, var3 - var1);
+         float var13 = this.getPixelsPerTile(var7, var3 - var1);
          int var14 = (int)(64.0F * var13);
          int var15 = this.mapSurfaceBaseOffsetX + var1;
          int var16 = var2 + this.mapSurfaceBaseOffsetY;
@@ -455,7 +455,8 @@ public final class WorldMapManager {
       signature = "(III)F",
       garbageValue = "-782152666"
    )
-   float method602(int graphicsDiff, int worldDiff) {
+   @Export("getPixelsPerTile")
+   float getPixelsPerTile(int graphicsDiff, int worldDiff) {
       float var3 = (float)graphicsDiff / (float)worldDiff;
       if(var3 > 8.0F) {
          return 8.0F;

--- a/runescape-client/src/main/java/WorldMapRegion.java
+++ b/runescape-client/src/main/java/WorldMapRegion.java
@@ -220,13 +220,13 @@ public class WorldMapRegion {
       signature = "(IIILjava/util/HashSet;I)V",
       garbageValue = "1923609767"
    )
-   void method499(int var1, int var2, int var3, HashSet var4) {
+   void method499(int displayX, int displayY, int pixelsPerRegion, HashSet var4) {
       if(var4 == null) {
          var4 = new HashSet();
       }
 
-      this.drawNonLinkMapIcons(var1, var2, var4, var3);
-      this.drawMapLinks(var1, var2, var4, var3);
+      this.drawNonLinkMapIcons(displayX, displayY, var4, pixelsPerRegion);
+      this.drawMapLinks(displayX, displayY, var4, pixelsPerRegion);
    }
 
    @ObfuscatedName("q")
@@ -617,23 +617,23 @@ public class WorldMapRegion {
       garbageValue = "50"
    )
    @Export("drawNonLinkMapIcons")
-   void drawNonLinkMapIcons(int var1, int var2, HashSet var3, int var4) {
-      float var5 = (float)var4 / 64.0F;
-      float var6 = var5 / 2.0F;
+   void drawNonLinkMapIcons(int regionBaseDisplayX, int regionBaseDisplayY, HashSet var3, int pixelsPerRegion) {
+      float pixelsPerTile = (float)pixelsPerRegion / 64.0F;
+      float halfPixelsPerTile = pixelsPerTile / 2.0F;
       Iterator var7 = this.field474.entrySet().iterator();
 
       while(var7.hasNext()) {
          Entry var8 = (Entry)var7.next();
          Coordinates var9 = (Coordinates)var8.getKey();
-         int var10 = (int)((float)var9.worldX * var5 + (float)var1 - var6);
-         int var11 = (int)((float)(var2 + var4) - (float)var9.worldY * var5 - var6);
+         int screenX = (int)((float)var9.worldX * pixelsPerTile + (float)regionBaseDisplayX - halfPixelsPerTile);
+         int screenY = (int)((float)(regionBaseDisplayY + pixelsPerRegion) - (float)var9.worldY * pixelsPerTile - halfPixelsPerTile);
          MapIcon var12 = (MapIcon)var8.getValue();
          if(var12 != null) {
-            var12.screenX = var10;
-            var12.screenY = var11;
+            var12.screenX = screenX;
+            var12.screenY = screenY;
             Area var13 = class190.mapAreaType[var12.areaId];
             if(!var3.contains(Integer.valueOf(var13.method4865()))) {
-               this.method381(var12, var10, var11, var5);
+               this.method381(var12, screenX, screenY, pixelsPerTile);
             }
          }
       }
@@ -680,10 +680,10 @@ public class WorldMapRegion {
       signature = "(Lal;IIFI)V",
       garbageValue = "-2042579438"
    )
-   void method381(MapIcon var1, int var2, int var3, float var4) {
+   void method381(MapIcon var1, int screenX, int screenY, float var4) {
       Area var5 = class190.mapAreaType[var1.areaId];
-      this.method409(var5, var2, var3);
-      this.method497(var1, var5, var2, var3, var4);
+      this.method409(var5, screenX, screenY);
+      this.method497(var1, var5, screenX, screenY, var4);
    }
 
    @ObfuscatedName("ak")


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/597053/39667223-389d7386-506e-11e8-8342-336bc171579a.png)

Fixes a poorly implemented getPixelsPerTile to make the WorldMap tile sizing more predictable. (In practice it is not a noticeable change unless you are drawing overlays)