### PR TITLE
Anti-venom+ now have two timers

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/timers/GameTimer.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timers/GameTimer.java
@@ -45,7 +45,8 @@ public enum GameTimer
 	MAGICIMBUE("magicimbue", "Magic imbue", 12, ChronoUnit.SECONDS),
 	FULLTB("teleblock", "Full Teleblock", 5, ChronoUnit.MINUTES),
 	HALFTB("teleblock", "Half Teleblock", 150, ChronoUnit.SECONDS),
-	ANTIVENOMPLUS("antivenomplus", "Anti-venom+", 3, ChronoUnit.MINUTES),
+	ANTIVENOMPLUSVENOM("antivenomplus", "Anti-venom+ (Venom immunity)", 3, ChronoUnit.MINUTES),
+	ANTIVENOMPLUSPOISON("antidoteplusplus", "Anti-venom+ (Poison immunity)", 12, ChronoUnit.MINUTES), //uses antidoteplusplus's image to differentiate between the venom and poison timer
 	SUPERANTIFIRE("superantifire", "Super antifire", 3, ChronoUnit.MINUTES),
 	ANTIDOTEPLUSPLUS("antidoteplusplus", "Antidote++", 12, ChronoUnit.MINUTES),
 	BIND("bind", "Bind", GraphicID.BIND, 5, ChronoUnit.SECONDS),

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersPlugin.java
@@ -43,9 +43,41 @@ import net.runelite.api.events.VarbitChanged;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
+import static net.runelite.client.plugins.timers.GameTimer.ANTIDOTEPLUS;
+import static net.runelite.client.plugins.timers.GameTimer.ANTIDOTEPLUSPLUS;
+import static net.runelite.client.plugins.timers.GameTimer.ANTIFIRE;
+import static net.runelite.client.plugins.timers.GameTimer.ANTIPOISON;
+import static net.runelite.client.plugins.timers.GameTimer.ANTIVENOM;
+import static net.runelite.client.plugins.timers.GameTimer.ANTIVENOMPLUSPOISON;
+import static net.runelite.client.plugins.timers.GameTimer.ANTIVENOMPLUSVENOM;
+import static net.runelite.client.plugins.timers.GameTimer.BIND;
+import static net.runelite.client.plugins.timers.GameTimer.CANNON;
+import static net.runelite.client.plugins.timers.GameTimer.ENTANGLE;
+import static net.runelite.client.plugins.timers.GameTimer.EXANTIFIRE;
+import static net.runelite.client.plugins.timers.GameTimer.EXSUPERANTIFIRE;
+import static net.runelite.client.plugins.timers.GameTimer.FULLTB;
+import static net.runelite.client.plugins.timers.GameTimer.GOD_WARS_ALTAR;
+import static net.runelite.client.plugins.timers.GameTimer.HALFBIND;
+import static net.runelite.client.plugins.timers.GameTimer.HALFENTANGLE;
+import static net.runelite.client.plugins.timers.GameTimer.HALFSNARE;
+import static net.runelite.client.plugins.timers.GameTimer.HALFTB;
+import static net.runelite.client.plugins.timers.GameTimer.ICEBARRAGE;
+import static net.runelite.client.plugins.timers.GameTimer.ICEBLITZ;
+import static net.runelite.client.plugins.timers.GameTimer.ICEBURST;
+import static net.runelite.client.plugins.timers.GameTimer.ICERUSH;
+import static net.runelite.client.plugins.timers.GameTimer.IMBUEDHEART;
+import static net.runelite.client.plugins.timers.GameTimer.MAGICIMBUE;
+import static net.runelite.client.plugins.timers.GameTimer.OVERLOAD;
+import static net.runelite.client.plugins.timers.GameTimer.OVERLOAD_RAID;
+import static net.runelite.client.plugins.timers.GameTimer.PRAYER_ENHANCE;
+import static net.runelite.client.plugins.timers.GameTimer.SANFEW;
+import static net.runelite.client.plugins.timers.GameTimer.SNARE;
+import static net.runelite.client.plugins.timers.GameTimer.STAMINA;
+import static net.runelite.client.plugins.timers.GameTimer.SUPERANTIFIRE;
+import static net.runelite.client.plugins.timers.GameTimer.SUPERANTIPOISON;
+import static net.runelite.client.plugins.timers.GameTimer.VENGEANCE;
+import static net.runelite.client.plugins.timers.GameTimer.VENGEANCEOTHER;
 import net.runelite.client.ui.overlay.infobox.InfoBoxManager;
-
-import static net.runelite.client.plugins.timers.GameTimer.*;
 
 @PluginDescriptor(
 	name = "Timers"

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersPlugin.java
@@ -43,40 +43,9 @@ import net.runelite.api.events.VarbitChanged;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
-import static net.runelite.client.plugins.timers.GameTimer.ANTIDOTEPLUS;
-import static net.runelite.client.plugins.timers.GameTimer.ANTIDOTEPLUSPLUS;
-import static net.runelite.client.plugins.timers.GameTimer.ANTIFIRE;
-import static net.runelite.client.plugins.timers.GameTimer.ANTIPOISON;
-import static net.runelite.client.plugins.timers.GameTimer.ANTIVENOM;
-import static net.runelite.client.plugins.timers.GameTimer.ANTIVENOMPLUS;
-import static net.runelite.client.plugins.timers.GameTimer.BIND;
-import static net.runelite.client.plugins.timers.GameTimer.CANNON;
-import static net.runelite.client.plugins.timers.GameTimer.ENTANGLE;
-import static net.runelite.client.plugins.timers.GameTimer.EXANTIFIRE;
-import static net.runelite.client.plugins.timers.GameTimer.EXSUPERANTIFIRE;
-import static net.runelite.client.plugins.timers.GameTimer.FULLTB;
-import static net.runelite.client.plugins.timers.GameTimer.GOD_WARS_ALTAR;
-import static net.runelite.client.plugins.timers.GameTimer.HALFBIND;
-import static net.runelite.client.plugins.timers.GameTimer.HALFENTANGLE;
-import static net.runelite.client.plugins.timers.GameTimer.HALFSNARE;
-import static net.runelite.client.plugins.timers.GameTimer.HALFTB;
-import static net.runelite.client.plugins.timers.GameTimer.ICEBARRAGE;
-import static net.runelite.client.plugins.timers.GameTimer.ICEBLITZ;
-import static net.runelite.client.plugins.timers.GameTimer.ICEBURST;
-import static net.runelite.client.plugins.timers.GameTimer.ICERUSH;
-import static net.runelite.client.plugins.timers.GameTimer.IMBUEDHEART;
-import static net.runelite.client.plugins.timers.GameTimer.MAGICIMBUE;
-import static net.runelite.client.plugins.timers.GameTimer.OVERLOAD;
-import static net.runelite.client.plugins.timers.GameTimer.OVERLOAD_RAID;
-import static net.runelite.client.plugins.timers.GameTimer.PRAYER_ENHANCE;
-import static net.runelite.client.plugins.timers.GameTimer.SANFEW;
-import static net.runelite.client.plugins.timers.GameTimer.SNARE;
-import static net.runelite.client.plugins.timers.GameTimer.STAMINA;
-import static net.runelite.client.plugins.timers.GameTimer.SUPERANTIFIRE;
-import static net.runelite.client.plugins.timers.GameTimer.SUPERANTIPOISON;
-import static net.runelite.client.plugins.timers.GameTimer.VENGEANCE;
-import static net.runelite.client.plugins.timers.GameTimer.VENGEANCEOTHER;
 import net.runelite.client.ui.overlay.infobox.InfoBoxManager;
+
+import static net.runelite.client.plugins.timers.GameTimer.*;
 
 @PluginDescriptor(
 	name = "Timers"
@@ -180,7 +149,8 @@ public class TimersPlugin extends Plugin
 
 		if (!config.showAntiVenomPlus())
 		{
-			removeGameTimer(ANTIVENOMPLUS);
+			removeGameTimer(ANTIVENOMPLUSVENOM);
+			removeGameTimer(ANTIVENOMPLUSPOISON);
 		}
 
 		if (!config.showSanfew())
@@ -344,7 +314,8 @@ public class TimersPlugin extends Plugin
 
 		if (config.showAntiVenomPlus() && event.getMessage().contains("You drink some of your super antivenom potion"))
 		{
-			createGameTimer(ANTIVENOMPLUS);
+			createGameTimer(ANTIVENOMPLUSVENOM);
+			createGameTimer(ANTIVENOMPLUSPOISON);
 		}
 
 		if (config.showMagicImbue() && event.getMessage().equals("You are charged to combine runes!"))


### PR DESCRIPTION
Decided to split ANTIVENOMPLUS into two different entries as requested by #2369 . The reason I don't just use ANTIDOTEPLUSPLUS is so that it does not interfere when you call removeGameTimer but this could be changed back if requested and just use ANTIDOTEPLUSPLUS.

ANTIVENOMPLUSPOISON uses the image of antidote++ to not confuse it with the anti-venom effect.