### PR TITLE
runelite-client: Log uncaught exceptions

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/RuneLite.java
+++ b/runelite-client/src/main/java/net/runelite/client/RuneLite.java
@@ -154,6 +154,15 @@ public class RuneLite
 			logger.setLevel(Level.DEBUG);
 		}
 
+		Thread.setDefaultUncaughtExceptionHandler((thread, throwable) ->
+		{
+			log.error("Uncaught exception:", throwable);
+			if (throwable instanceof AbstractMethodError)
+			{
+				log.error("Classes are out of date; Build with maven again.");
+			}
+		});
+
 		setInjector(Guice.createInjector(new RuneLiteModule()));
 		injector.getInstance(RuneLite.class).start(getOptions().valueOf(updateMode));
 	}


### PR DESCRIPTION
Previously exceptions would be printed to stderr, and not show in log files.

This also adds a case for AbstractMethodError because it almost always means the injector needs to be re-ran.