### PR TITLE
Initial implementation of screen markers.

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenmarkers/ScreenMarker.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenmarkers/ScreenMarker.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2018, Kruithne <kruithne@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package net.runelite.client.plugins.screenmarkers;
+
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.awt.*;
+
+public class ScreenMarker
+{
+	@Getter(AccessLevel.PACKAGE)
+	private int positionX;
+
+	@Getter(AccessLevel.PACKAGE)
+	private int positionY;
+
+	@Getter(AccessLevel.PACKAGE)
+	private int width;
+
+	@Getter(AccessLevel.PACKAGE)
+	private int height;
+
+	@Getter(AccessLevel.PACKAGE)
+	private BasicStroke stroke;
+	private int thickness;
+
+	@Getter(AccessLevel.PACKAGE)
+	@Setter(AccessLevel.PACKAGE)
+	private Color color;
+
+	@Getter(AccessLevel.PACKAGE)
+	@Setter(AccessLevel.PACKAGE)
+	private boolean isVisible;
+
+	ScreenMarker(int x, int y, int width, int height, int stroke, Color color)
+	{
+		this.setPosition(x, y);
+		this.setSize(width, height);
+		this.setStrokeSize(stroke);
+		this.color = color;
+		this.isVisible = false;
+	}
+
+	void setStrokeSize(int thickness)
+	{
+		this.stroke = new BasicStroke(thickness);
+		this.thickness = thickness;
+	}
+
+	void setSize(int width, int height)
+	{
+		this.width = width;
+		this.height = height;
+	}
+
+	void setPosition(int x, int y)
+	{
+		this.positionX = x;
+		this.positionY = y;
+	}
+
+	ScreenMarker duplicateMarker()
+	{
+		return new ScreenMarker(this.positionX, this.positionY, this.width, this.height, this.thickness, this.color);
+	}
+
+	@Override
+	public String toString()
+	{
+		return String.format("%d,%d,%d,%d,%d,%d", this.positionX, this.positionY, this.width, this.height, this.thickness, this.color.getRGB());
+	}
+
+	static ScreenMarker fromString(String input)
+	{
+		String[] parts = input.split(",");
+		if (parts.length != 6)
+			return null;
+
+		return new ScreenMarker(
+			Integer.parseInt(parts[0]),
+			Integer.parseInt(parts[1]),
+			Integer.parseInt(parts[2]),
+			Integer.parseInt(parts[3]),
+			Integer.parseInt(parts[4]),
+			new Color(Integer.parseInt(parts[5]))
+		);
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenmarkers/ScreenMarkerConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenmarkers/ScreenMarkerConfig.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2018, Kruithne <kruithne@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.screenmarkers;
+
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+
+import java.awt.*;
+
+@ConfigGroup(
+		name = "Screen Markers",
+		keyName = "screenmarkers",
+		description = "Configuration for the screen markers plugin"
+)
+public interface ScreenMarkerConfig extends Config
+{
+	@ConfigItem(
+			keyName = "displayMarkers",
+			name = "Display markers",
+			description = "Configures whether or not to display markers",
+			position = 1
+	)
+	default boolean displayMarkers() { return true; }
+
+	@ConfigItem(
+			keyName = "markerThickness",
+			name = "Border Thickness",
+			description = "Thickness of the border for new markers",
+			position = 2
+	)
+	default int markerThickness()
+	{
+		return 3;
+	}
+
+	@ConfigItem(
+			keyName = "markerColor",
+			name = "Marker Color",
+			description = "Configures the color to use for new markers",
+			position = 3
+	)
+	default Color markerColor()
+	{
+		return Color.RED.darker();
+	}
+
+	@ConfigItem(
+			keyName = "addMarkers",
+			name = "Marker Creation Mode",
+			description = "Allows markers to be added to the screen",
+			position = 4
+	)
+	default boolean addMarkers() { return false; }
+
+	@ConfigItem(
+			keyName = "addMarkers",
+			name = "",
+			description = ""
+	)
+	void addMarkers(boolean addMarkers);
+
+	@ConfigItem(
+			keyName = "markerData",
+			name = "Screen Marker Data",
+			description = "Contains serialized marker data",
+			hidden = true
+	)
+	default String markerData() { return ""; }
+
+	@ConfigItem(
+			keyName = "markerData",
+			name = "",
+			description = ""
+	)
+	void markerData(String markerData);
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenmarkers/ScreenMarkerConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenmarkers/ScreenMarkerConfig.java
@@ -43,7 +43,10 @@ public interface ScreenMarkerConfig extends Config
 			description = "Configures whether or not to display markers",
 			position = 1
 	)
-	default boolean displayMarkers() { return true; }
+	default boolean displayMarkers()
+	{
+		return true;
+	}
 
 	@ConfigItem(
 			keyName = "markerThickness",
@@ -73,7 +76,10 @@ public interface ScreenMarkerConfig extends Config
 			description = "Allows markers to be added to the screen",
 			position = 4
 	)
-	default boolean addMarkers() { return false; }
+	default boolean addMarkers()
+	{
+		return false;
+	}
 
 	@ConfigItem(
 			keyName = "addMarkers",
@@ -88,7 +94,10 @@ public interface ScreenMarkerConfig extends Config
 			description = "Contains serialized marker data",
 			hidden = true
 	)
-	default String markerData() { return ""; }
+	default String markerData()
+	{
+		return "";
+	}
 
 	@ConfigItem(
 			keyName = "markerData",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenmarkers/ScreenMarkerMouseListener.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenmarkers/ScreenMarkerMouseListener.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2018, Kruithne <kruithne@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package net.runelite.client.plugins.screenmarkers;
+
+import com.google.inject.Inject;
+import net.runelite.client.input.MouseListener;
+
+import java.awt.event.MouseEvent;
+
+public class ScreenMarkerMouseListener extends MouseListener
+{
+	private final ScreenMarkerPlugin plugin;
+	private final ScreenMarker drawingMarker;
+
+	private int anchorX;
+	private int anchorY;
+
+	@Inject
+	public ScreenMarkerMouseListener(ScreenMarkerPlugin plugin)
+	{
+		this.plugin = plugin;
+		this.drawingMarker = this.plugin.getDrawingMarker();
+	}
+
+	@Override
+	public MouseEvent mousePressed(MouseEvent e)
+	{
+		if (this.plugin.isPlacingMarker())
+		{
+			this.anchorX = e.getX();
+			this.anchorY = e.getY();
+
+			this.drawingMarker.setPosition(this.anchorX, this.anchorY);
+			this.drawingMarker.setSize(0, 0);
+			this.drawingMarker.setVisible(true);
+
+			e.consume();
+		}
+
+		return e;
+	}
+
+	@Override
+	public MouseEvent mouseDragged(MouseEvent e)
+	{
+		if (this.plugin.isPlacingMarker() && this.drawingMarker.isVisible())
+		{
+			int posX = this.anchorX;
+			int posY = this.anchorY;
+
+			int diffX = e.getX() - this.anchorX;
+			int diffY = e.getY() - this.anchorY;
+
+			int width = diffX;
+			int height = diffY;
+
+			if (diffX < 0) {
+				width = Math.abs(diffX);
+				posX -= width;
+			}
+
+			if (diffY < 0) {
+				height = Math.abs(diffY);
+				posY -= height;
+			}
+
+			this.drawingMarker.setSize(width, height);
+			this.drawingMarker.setPosition(posX, posY);
+		}
+
+		return e;
+	}
+
+	@Override
+	public MouseEvent mouseReleased(MouseEvent e)
+	{
+		if (this.plugin.isPlacingMarker() && this.drawingMarker.isVisible())
+		{
+			ScreenMarker clone = this.drawingMarker.duplicateMarker();
+			this.plugin.addMarker(clone);
+
+			clone.setVisible(this.plugin.getConfig().displayMarkers());
+			this.drawingMarker.setVisible(false);
+			this.plugin.updateMarkerConfig();
+
+			e.consume();
+		}
+
+		return e;
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenmarkers/ScreenMarkerOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenmarkers/ScreenMarkerOverlay.java
@@ -26,6 +26,8 @@
 package net.runelite.client.plugins.screenmarkers;
 
 import net.runelite.client.ui.overlay.Overlay;
+import net.runelite.client.ui.overlay.OverlayLayer;
+import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.OverlayPriority;
 
 import javax.inject.Inject;
@@ -40,6 +42,7 @@ public class ScreenMarkerOverlay extends Overlay
 	{
 		this.plugin = plugin;
 		setPriority(OverlayPriority.HIGH);
+		setLayer(OverlayLayer.ALWAYS_ON_TOP);
 	}
 
 	@Override

--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenmarkers/ScreenMarkerOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenmarkers/ScreenMarkerOverlay.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2018, Kruithne <kruithne@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package net.runelite.client.plugins.screenmarkers;
+
+import net.runelite.client.ui.overlay.Overlay;
+import net.runelite.client.ui.overlay.OverlayPriority;
+
+import javax.inject.Inject;
+import java.awt.*;
+
+public class ScreenMarkerOverlay extends Overlay
+{
+	private final ScreenMarkerPlugin plugin;
+
+	@Inject
+	public ScreenMarkerOverlay(ScreenMarkerPlugin plugin)
+	{
+		this.plugin = plugin;
+		setPriority(OverlayPriority.HIGH);
+	}
+
+	@Override
+	public Dimension render(Graphics2D graphics)
+	{
+		Stroke stroke = graphics.getStroke();
+
+		for (ScreenMarker marker : this.plugin.getMarkers())
+		{
+			if (!marker.isVisible())
+				continue;
+
+			graphics.setColor(marker.getColor());
+			graphics.setStroke(marker.getStroke());
+			graphics.drawRect(marker.getPositionX(), marker.getPositionY(), marker.getWidth(), marker.getHeight());
+		}
+
+		graphics.setStroke(stroke);
+		return null;
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenmarkers/ScreenMarkerOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenmarkers/ScreenMarkerOverlay.java
@@ -43,6 +43,7 @@ public class ScreenMarkerOverlay extends Overlay
 		this.plugin = plugin;
 		setPriority(OverlayPriority.HIGH);
 		setLayer(OverlayLayer.ALWAYS_ON_TOP);
+		setPosition(OverlayPosition.DYNAMIC);
 	}
 
 	@Override

--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenmarkers/ScreenMarkerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenmarkers/ScreenMarkerPlugin.java
@@ -114,7 +114,8 @@ public class ScreenMarkerPlugin extends Plugin
 	void updateMarkerConfig()
 	{
 		ArrayList<String> parts = new ArrayList<>(this.markers.size() - 1);
-		for (ScreenMarker marker : this.markers) {
+		for (ScreenMarker marker : this.markers)
+		{
 			if (marker.equals(this.drawingMarker))
 				continue;
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenmarkers/ScreenMarkerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenmarkers/ScreenMarkerPlugin.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright (c) 2018, Kruithne <kruithne@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package net.runelite.client.plugins.screenmarkers;
+
+import com.google.common.eventbus.Subscribe;
+import com.google.inject.Provides;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.Setter;
+import net.runelite.api.events.ConfigChanged;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.input.MouseManager;
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.ui.overlay.Overlay;
+
+import javax.inject.Inject;
+import java.awt.*;
+import java.util.ArrayList;
+
+@PluginDescriptor(name = "Screen Markers")
+
+public class ScreenMarkerPlugin extends Plugin
+{
+	@Inject
+	private ScreenMarkerOverlay overlay;
+
+	@Inject
+	private ScreenMarkerMouseListener mouseListener;
+
+	@Inject
+	private MouseManager mouseManager;
+
+	@Inject
+	@Getter(AccessLevel.PACKAGE)
+	private ScreenMarkerConfig config;
+
+	@Getter(AccessLevel.PACKAGE)
+	private final ArrayList<ScreenMarker> markers;
+
+	@Getter(AccessLevel.PACKAGE)
+	private final ScreenMarker drawingMarker;
+
+	@Getter(AccessLevel.PACKAGE)
+	@Setter(AccessLevel.PACKAGE)
+	private boolean isPlacingMarker = false;
+
+	public ScreenMarkerPlugin()
+	{
+		this.markers = new ArrayList<>();
+		this.drawingMarker = new ScreenMarker(200, 200, 20, 20, 3, Color.red.darker());
+		this.addMarker(this.drawingMarker);
+	}
+
+	void addMarker(ScreenMarker marker)
+	{
+		this.markers.add(marker);
+	}
+
+	private void removeAllMarkers()
+	{
+		this.markers.clear();
+		this.addMarker(this.drawingMarker);
+	}
+
+	private void updateMarkerVisibility()
+	{
+		boolean showDrawingMarker = this.drawingMarker.isVisible();
+		for (ScreenMarker marker : this.markers)
+			marker.setVisible(config.displayMarkers());
+
+		this.drawingMarker.setVisible(showDrawingMarker);
+	}
+
+	private void loadMarkersFromConfig()
+	{
+		this.removeAllMarkers();
+
+		String[] parts = this.config.markerData().split(";");
+		for (String part : parts)
+		{
+			ScreenMarker marker = ScreenMarker.fromString(part);
+			if (marker != null)
+			{
+				marker.setVisible(this.config.displayMarkers());
+				this.addMarker(marker);
+			}
+		}
+	}
+
+	void updateMarkerConfig()
+	{
+		ArrayList<String> parts = new ArrayList<>(this.markers.size() - 1);
+		for (ScreenMarker marker : this.markers) {
+			if (marker.equals(this.drawingMarker))
+				continue;
+
+			parts.add(marker.toString());
+		}
+
+		this.config.markerData(String.join(";", parts));
+	}
+
+	@Subscribe
+	public void onConfigChanged(ConfigChanged event)
+	{
+		if (event.getGroup().equals("screenmarkers"))
+		{
+			switch (event.getKey())
+			{
+				case "displayMarkers":
+					this.updateMarkerVisibility();
+					break;
+				case "markerData":
+					this.loadMarkersFromConfig();
+					break;
+				case "markerColor":
+					this.drawingMarker.setColor(this.config.markerColor());
+					break;
+				case "markerThickness":
+					this.drawingMarker.setStrokeSize(this.config.markerThickness());
+					break;
+				case "addMarkers":
+					this.setPlacingMarker(this.config.addMarkers());
+					break;
+			}
+		}
+	}
+
+	@Override
+	protected void startUp()
+	{
+		mouseManager.registerMouseListener(mouseListener);
+		this.updateMarkerVisibility();
+		this.loadMarkersFromConfig();
+
+		this.drawingMarker.setColor(this.config.markerColor());
+		this.drawingMarker.setStrokeSize(this.config.markerThickness());
+		this.config.addMarkers(false);
+	}
+
+	@Override
+	protected void shutDown() throws Exception
+	{
+		mouseManager.unregisterMouseListener(mouseListener);
+	}
+
+	@Override
+	public Overlay getOverlay()
+	{
+		return overlay;
+	}
+
+	@Provides
+	ScreenMarkerConfig getConfig(ConfigManager configManager)
+	{
+		return configManager.getConfig(ScreenMarkerConfig.class);
+	}
+}


### PR DESCRIPTION
This PR adds rudimentary screen markers that can be configured in both colour and thickness.

To add a screen marker, the user opens the "Screen Markers" configuration section and selects "Marker Creation Mode". With this mode enabled, rectangular markers can be drawn on the screen, and will persist until the configuration is reset.

Preview: https://i.imgur.com/OjGbQbg.mp4

The thickness and colour of the markers can be defined in the configuration **before** a marker is drawn. Currently nothing has been added to allow existing markers to be edited, moved or individually removed.

This PR seeks to resolve issue #722