### PR TITLE
Add hot-cold clue scroll plugin

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/coords/WorldPoint.java
+++ b/runelite-api/src/main/java/net/runelite/api/coords/WorldPoint.java
@@ -144,7 +144,7 @@ public class WorldPoint
 			return Integer.MAX_VALUE;
 		}
 
-		return (int) Math.hypot(getX() - other.getX(), getY() - other.getY());
+		return distanceTo2D(other);
 	}
 
 
@@ -156,7 +156,7 @@ public class WorldPoint
 	 */
 	public int distanceTo2D(WorldPoint other)
 	{
-		return (int) Math.hypot(getX() - other.getX(), getY() - other.getY());
+		return Math.max(Math.abs(getX() - other.getX()), Math.abs(getY() - other.getY()));
 	}
 
 	/**

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java
@@ -126,7 +126,6 @@ public class CrypticClue extends ClueScroll implements TextClueScroll, NpcClueSc
 		new CrypticClue("Search the crates in the Barbarian Village helmet shop.", CRATES_11600, new WorldPoint(3073, 3430, 0), "Peska's Helmet Shop in Barbarian Village."),
 		new CrypticClue("Search the boxes of Falador's general store.", CRATES_24088, new WorldPoint(2955, 3390, 0), "Falador general store."),
 		new CrypticClue("In a village made of bamboo, look for some crates under one of the houses.", CRATE_356, new WorldPoint(2800, 3074, 0), "Search the crate by the house at the northern point of the broken jungle fence in Tai Bwo Wannai."),
-		new CrypticClue("Buried beneath the ground, who knows where it's found. Lucky for you, A man called Jorral may have a clue.", "Jorral", new WorldPoint(2437, 3347, 0), "Speak to Jorral to receive a strange device."),
 		new CrypticClue("This crate is mine, all mine, even if it is in the middle of the desert.", CRATE_18889, new WorldPoint(3289, 3022, 0), "Center of desert Mining Camp. Search the crates. Requires the metal key from Tourist Trap to enter."),
 		new CrypticClue("Dig where 4 siblings and I all live with our evil overlord.", new WorldPoint(3195, 3357, 0), "Dig in the chicken pen inside the Champion's Guild"),
 		new CrypticClue("In a town where the guards are armed with maces, search the upstairs rooms of the Public House.", "Guard dog", 348, new WorldPoint(2574, 3326, 1), "Search the drawers upstairs in the pub north of Ardougne Castle. Kill a Guard dog at Handelmort Mansion to obtain the key."),

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/HotColdClue.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/HotColdClue.java
@@ -1,0 +1,364 @@
+/*
+ * Copyright (c) 2018, Eadgars Ruse <https://github.com/Eadgars-Ruse>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.cluescrolls.clues;
+
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Graphics2D;
+import java.awt.Point;
+import java.awt.Polygon;
+import java.awt.Rectangle;
+import java.awt.geom.Rectangle2D;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import net.runelite.api.NPC;
+import net.runelite.api.Perspective;
+import net.runelite.api.coords.LocalPoint;
+import net.runelite.api.coords.WorldPoint;
+import static net.runelite.client.plugins.cluescrolls.ClueScrollOverlay.TITLED_CONTENT_COLOR;
+import net.runelite.client.plugins.cluescrolls.ClueScrollPlugin;
+import static net.runelite.client.plugins.cluescrolls.ClueScrollPlugin.CLUE_SCROLL_IMAGE;
+import static net.runelite.client.plugins.cluescrolls.ClueScrollPlugin.SPADE_IMAGE;
+import static net.runelite.client.plugins.cluescrolls.ClueScrollWorldOverlay.IMAGE_Z_OFFSET;
+import net.runelite.client.plugins.cluescrolls.clues.hotcold.HotColdArea;
+import net.runelite.client.plugins.cluescrolls.clues.hotcold.HotColdLocation;
+import net.runelite.client.ui.overlay.OverlayUtil;
+import net.runelite.client.ui.overlay.components.LineComponent;
+import net.runelite.client.ui.overlay.components.PanelComponent;
+import net.runelite.client.ui.overlay.components.TitleComponent;
+
+@Getter
+@RequiredArgsConstructor
+public class HotColdClue extends ClueScroll implements TextClueScroll, NpcClueScroll
+{
+	private static final HotColdClue CLUE =
+		new HotColdClue("Buried beneath the ground, who knows where it's found. Lucky for you, A man called Jorral may have a clue.",
+			"Jorral",
+			"Speak to Jorral to receive a strange device.");
+
+	// list of potential places to dig
+	private List<HotColdLocation> digLocations = new ArrayList<>();
+	private final String text;
+	private final String npc;
+	private final String solution;
+	private WorldPoint location;
+	private WorldPoint lastWorldPoint;
+
+	@Override
+	public void makeOverlayHint(PanelComponent panelComponent, ClueScrollPlugin plugin)
+	{
+		panelComponent.getChildren().add(TitleComponent.builder()
+			.text("Hot/Cold Clue")
+			.build());
+		panelComponent.setPreferredSize(new Dimension(200, 0));
+
+		// strange device has not been tested yet, show how to get it
+		if (lastWorldPoint == null && location == null)
+		{
+			panelComponent.getChildren().add(LineComponent.builder()
+				.left("Clue:")
+				.build());
+			panelComponent.getChildren().add(LineComponent.builder()
+				.left(getText())
+				.leftColor(TITLED_CONTENT_COLOR)
+				.build());
+
+			if (getNpc() != null)
+			{
+				panelComponent.getChildren().add(LineComponent.builder()
+					.left("NPC:")
+					.build());
+				panelComponent.getChildren().add(LineComponent.builder()
+					.left(getNpc())
+					.leftColor(TITLED_CONTENT_COLOR)
+					.build());
+			}
+
+			panelComponent.getChildren().add(LineComponent.builder()
+				.left("Solution:")
+				.build());
+			panelComponent.getChildren().add(LineComponent.builder()
+				.left(getSolution())
+				.leftColor(TITLED_CONTENT_COLOR)
+				.build());
+		}
+		// strange device has been tested, show possible locations for final dig spot
+		else
+		{
+			panelComponent.getChildren().add(LineComponent.builder()
+				.left("Possible areas:")
+				.build());
+			Map<HotColdArea, Integer> locationCounts = new HashMap<>();
+
+			for (HotColdLocation hotColdLocation : digLocations)
+			{
+				Rectangle2D r = hotColdLocation.getRect();
+				HotColdArea hotColdArea = hotColdLocation.getHotColdArea();
+
+				if (locationCounts.containsKey(hotColdArea))
+				{
+					locationCounts.put(hotColdArea, locationCounts.get(hotColdArea) + 1);
+				}
+				else
+				{
+					locationCounts.put(hotColdArea, 1);
+				}
+			}
+
+			if (digLocations.size() > 10)
+			{
+				for (HotColdArea area : locationCounts.keySet())
+				{
+					panelComponent.getChildren().add(LineComponent.builder()
+						.left(area.getName())
+						.right(Integer.toString(locationCounts.get(area)))
+						.build());
+				}
+			}
+			else
+			{
+				for (HotColdArea s : locationCounts.keySet())
+				{
+					panelComponent.getChildren().add(LineComponent.builder()
+						.left(s.getName() + ":")
+						.build());
+
+					for (HotColdLocation hotColdLocation : digLocations)
+					{
+						if (hotColdLocation.getHotColdArea() == s)
+						{
+							Rectangle2D r = hotColdLocation.getRect();
+							panelComponent.getChildren().add(LineComponent.builder()
+								.left("- " + hotColdLocation.getArea())
+								.leftColor(Color.LIGHT_GRAY)
+								.build());
+						}
+					}
+				}
+			}
+		}
+	}
+
+	@Override
+	public void makeWorldOverlayHint(Graphics2D graphics, ClueScrollPlugin plugin)
+	{
+		// when final location has been found
+		if (this.location != null)
+		{
+			LocalPoint localLocation = LocalPoint.fromWorld(plugin.getClient(), getLocation());
+
+			if (localLocation != null)
+			{
+				OverlayUtil.renderTileOverlay(plugin.getClient(), graphics, localLocation, SPADE_IMAGE, Color.ORANGE);
+			}
+
+			return;
+		}
+
+		// when strange device hasn't been activated yet, show Jorral
+		if (lastWorldPoint == null)
+		{
+			// Mark NPC
+			if (plugin.getNpcsToMark() != null)
+			{
+				for (NPC npc : plugin.getNpcsToMark())
+				{
+					OverlayUtil.renderActorOverlayImage(graphics, npc, CLUE_SCROLL_IMAGE, Color.ORANGE, IMAGE_Z_OFFSET);
+				}
+			}
+		}
+
+		// once the number of possible dig locations is below 10, highlight their ground areas
+		if (digLocations.size() < 10)
+		{
+			// Mark potential dig locations
+			for (HotColdLocation hotColdLocation : digLocations)
+			{
+				Rectangle2D r = hotColdLocation.getRect();
+
+				for (int i = (int) r.getMinX(); i <= r.getMaxX(); i++)
+				{
+					for (int j = (int) r.getMinY(); j <= r.getMaxY(); j++)
+					{
+						LocalPoint localLocation = LocalPoint.fromWorld(plugin.getClient(), new WorldPoint(i, j, 0));
+
+						if (localLocation != null)
+						{
+							Polygon poly = Perspective.getCanvasTilePoly(plugin.getClient(), localLocation);
+							graphics.setColor(new Color(Color.BLUE.getRed(), Color.BLUE.getGreen(), Color.BLUE.getBlue(), 50));
+
+							if (poly != null)
+							{
+								graphics.fillPolygon(poly);
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	public static HotColdClue forText(String text)
+	{
+		if (CLUE.text.equalsIgnoreCase(text))
+		{
+			return CLUE;
+		}
+
+		return null;
+	}
+
+	public void updatePossibleArea(WorldPoint wp, String temperature, String difference)
+	{
+		this.location = null;
+
+		if (digLocations.size() == 0)
+		{
+			digLocations.addAll(Arrays.asList(HotColdLocation.values()));
+		}
+
+		int maxSquaresAway = 5000;
+		int minSquaresAway = 0;
+
+		switch (temperature)
+		{
+			// when the strange device reads a temperature, that means that the center of the final dig location
+			// is a range of squares away from the player's current location (Chebyshev AKA Chess-board distance)
+			case "ice cold":
+				maxSquaresAway = 5000;
+				minSquaresAway = 500;
+				break;
+			case "very cold":
+				maxSquaresAway = 499;
+				minSquaresAway = 200;
+				break;
+			case "cold":
+				maxSquaresAway = 199;
+				minSquaresAway = 150;
+				break;
+			case "warm":
+				maxSquaresAway = 149;
+				minSquaresAway = 100;
+				break;
+			case "hot":
+				maxSquaresAway = 99;
+				minSquaresAway = 70;
+				break;
+			case "very hot":
+				maxSquaresAway = 69;
+				minSquaresAway = 30;
+				break;
+			case "incredibly hot":
+				maxSquaresAway = 29;
+				minSquaresAway = 5;
+				break;
+		}
+
+		// rectangle r1 encompasses all of the points that are within the max possible distance from the player
+		Point p1 = new Point(wp.getX() - maxSquaresAway, wp.getY() - maxSquaresAway);
+		Rectangle r1 = new Rectangle((int) p1.getX(), (int) p1.getY(), 2 * maxSquaresAway + 1, 2 * maxSquaresAway + 1);
+		// rectangle r2 encompasses all of the points that are within the min possible distance from the player
+		Point p2 = new Point(wp.getX() - minSquaresAway, wp.getY() - minSquaresAway);
+		Rectangle r2 = new Rectangle((int) p2.getX(), (int) p2.getY(), 2 * minSquaresAway + 1, 2 * minSquaresAway + 1);
+
+		// eliminate from consideration dig spots that lie entirely within the min range or entirely outside of the max range
+		digLocations.removeIf(entry -> r2.contains(entry.getRect()) || !r1.intersects(entry.getRect()));
+
+		// if a previous world point has been recorded, we can consider the warmer/colder result from the strange device
+		if (lastWorldPoint != null)
+		{
+			switch (difference)
+			{
+				case "but colder than":
+					// eliminate spots that are absolutely warmer
+					digLocations.removeIf(entry -> isCurrentPointCloser(wp, lastWorldPoint, entry.getRect()));
+					break;
+				case "and warmer than":
+					// eliminate spots that are absolutely colder
+					digLocations.removeIf(entry -> !isCurrentPointCloser(wp, lastWorldPoint, entry.getRect()));
+					break;
+				case "and the same temperature as":
+					// I couldn't figure out a clean implementation for this case
+					// not necessary for quickly determining final location
+			}
+		}
+
+		lastWorldPoint = wp;
+	}
+
+	private boolean isCurrentPointCloser(WorldPoint currentWp, WorldPoint lastWp, Rectangle2D r)
+	{
+		int lastDistance;
+		int currentDistance;
+		WorldPoint p1 = new WorldPoint((int) r.getMaxX(), (int) r.getMaxY(), 0);
+		lastDistance = lastWp.distanceTo2D(p1);
+		currentDistance = currentWp.distanceTo2D(p1);
+
+		if (lastDistance < currentDistance)
+		{
+			return false;
+		}
+
+		WorldPoint p2 = new WorldPoint((int) r.getMaxX(), (int) r.getMinY(), 0);
+		lastDistance = lastWp.distanceTo2D(p2);
+		currentDistance = currentWp.distanceTo(p2);
+
+		if (lastDistance < currentDistance)
+		{
+			return false;
+		}
+
+		WorldPoint p3 = new WorldPoint((int) r.getMinX(), (int)r.getMaxY(), 0);
+		lastDistance = lastWp.distanceTo2D(p3);
+		currentDistance = currentWp.distanceTo2D(p3);
+
+		if (lastDistance < currentDistance)
+		{
+			return false;
+		}
+
+		WorldPoint p4 = new WorldPoint((int) r.getMinX(), (int) r.getMinY(), 0);
+		lastDistance = lastWp.distanceTo2D(p4);
+		currentDistance = currentWp.distanceTo2D(p4);
+		return (lastDistance >= currentDistance);
+	}
+
+	public void markFinalSpot(WorldPoint wp)
+	{
+		this.location = wp;
+		resetHotCold();
+	}
+
+	public void resetHotCold()
+	{
+		this.lastWorldPoint = null;
+		digLocations.clear();
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdArea.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdArea.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2018, Adam <Adam@sigterm.info>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.cluescrolls.clues.hotcold;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public enum HotColdArea
+{
+	ASGARNIA("Asgarnia"),
+	DESERT("Desert"),
+	FELDIP_HILLS("Feldip Hills"),
+	FREMENNIK_PROVINCE("Fremennik Province"),
+	KANDARIN("Kandarin"),
+	KARAMJA("Karamja"),
+	MISTHALIN("Misthalin"),
+	MORYTANIA("Morytania"),
+	WESTERN_PROVINCE("Western Province"),
+	WILDERNESS("Wilderness"),
+	ZEAH("Zeah");
+
+	private final String name;
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright (c) 2018, Eadgars Ruse <https://github.com/Eadgars-Ruse>
+ * Copyright (c) 2018, Adam <Adam@sigterm.info>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.cluescrolls.clues.hotcold;
+
+import java.awt.Rectangle;
+import java.awt.geom.Rectangle2D;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import net.runelite.api.coords.WorldPoint;
+import static net.runelite.client.plugins.cluescrolls.clues.hotcold.HotColdArea.ASGARNIA;
+import static net.runelite.client.plugins.cluescrolls.clues.hotcold.HotColdArea.DESERT;
+import static net.runelite.client.plugins.cluescrolls.clues.hotcold.HotColdArea.FELDIP_HILLS;
+import static net.runelite.client.plugins.cluescrolls.clues.hotcold.HotColdArea.FREMENNIK_PROVINCE;
+import static net.runelite.client.plugins.cluescrolls.clues.hotcold.HotColdArea.KANDARIN;
+import static net.runelite.client.plugins.cluescrolls.clues.hotcold.HotColdArea.KARAMJA;
+import static net.runelite.client.plugins.cluescrolls.clues.hotcold.HotColdArea.MISTHALIN;
+import static net.runelite.client.plugins.cluescrolls.clues.hotcold.HotColdArea.MORYTANIA;
+import static net.runelite.client.plugins.cluescrolls.clues.hotcold.HotColdArea.WESTERN_PROVINCE;
+import static net.runelite.client.plugins.cluescrolls.clues.hotcold.HotColdArea.WILDERNESS;
+import static net.runelite.client.plugins.cluescrolls.clues.hotcold.HotColdArea.ZEAH;
+
+// The locations contains all hot/cold points and their descriptions according to the wiki
+// these central points were obtained by checking wiki location pictures against a coordinate map
+// some central points points may be slightly off-center
+// calculations are done considering the 9x9 grid around the central point where the strange device shakes
+// because the calculations consider the 9x9 grid, slightly off-center points should still be found by the calculations
+@AllArgsConstructor
+@Getter
+public enum HotColdLocation
+{
+	ASGARNIA_WARRIORS(new WorldPoint(2854, 3558, 0), ASGARNIA, "North of the Warriors' Guild in Burthorpe."),
+	ASGARNIA_JATIX(new WorldPoint(2914, 3429, 0), ASGARNIA, "East of Jatix's Herblore Shop in Taverley."),
+	ASGARNIA_BARB(new WorldPoint(3038, 3438, 0), ASGARNIA, "West of Barbarian Village."),
+	ASGARNIA_MIAZRQA(new WorldPoint(2972, 3489, 0), ASGARNIA, "North of Miazrqa's tower, outside Goblin Village."),
+	ASGARNIA_COW(new WorldPoint(3033, 3311, 0), ASGARNIA, "In the cow pen north of Sarah's Farming Shop."),
+	ASGARNIA_PARTY_ROOM(new WorldPoint(3034, 3368, 0), ASGARNIA, "Outside the Falador Party Room."),
+	ASGARNIA_CRAFT_GUILD(new WorldPoint(2917, 3295, 0), ASGARNIA, "Outside the Crafting Guild cow pen."),
+	ASGARNIA_RIMMINGTON(new WorldPoint(2978, 3241, 0), ASGARNIA, "In the centre of the Rimmington mine."),
+	ASGARNIA_MUDSKIPPER(new WorldPoint(2984, 3109, 0), ASGARNIA, "Mudskipper Point, on the starfish in the south-west corner."),
+	ASGARNIA_TROLL(new WorldPoint(2910, 3616, 0), ASGARNIA, "The Troll arena, where the player fights Dadduring the Troll Stronghold quest. Bring climbing boots."),
+	DESERT_GENIE(new WorldPoint(3363, 2905, 0), DESERT, "West of Nardah genie cave."),
+	DESERT_ALKHARID_MINE(new WorldPoint(3280, 3271, 0), DESERT, "West of Al Kharid mine."),
+	DESERT_MENAPHOS_GATE(new WorldPoint(3224, 2816, 0), DESERT, "North of Menaphos gate."),
+	DESERT_BEDABIN_CAMP(new WorldPoint(3164, 3050, 0), DESERT, "Bedabin Camp, dig around the north tent."),
+	DESERT_UZER(new WorldPoint(3431, 3106, 0), DESERT, "West of Uzer."),
+	DESERT_POLLNIVNEACH(new WorldPoint(3287, 2975, 0), DESERT, "West of Pollnivneach."),
+	DESERT_MTA(new WorldPoint(3350, 3293, 0), DESERT, "Next to Mage Training Arena."),
+	DESERT_SHANTY(new WorldPoint(3294, 3106, 0), DESERT, "South-west of Shantay Pass."),
+	FELDIP_HILLS_JIGGIG(new WorldPoint(2414, 3047, 0), FELDIP_HILLS, "West of Jiggig, east of the fairy ring bkp."),
+	FELDIP_HILLS_SW(new WorldPoint(2582, 2895, 0), FELDIP_HILLS, "West of the southeasternmost lake in Feldip Hills."),
+	FELDIP_HILLS_GNOME_GLITER(new WorldPoint(2553, 2972, 0), FELDIP_HILLS, "East of the gnome glider (Lemantolly Undri)."),
+	FELDIP_HILLS_RANTZ(new WorldPoint(2611, 2946, 0), FELDIP_HILLS, "South of Rantz, six steps west of the empty glass bottles."),
+	FELDIP_HILLS_SOUTH(new WorldPoint(2487, 3001, 0), FELDIP_HILLS, "South of Jiggig."),
+	FELDIP_HILLS_RED_CHIN(new WorldPoint(2532, 2900, 0), FELDIP_HILLS, "Outside the red chinchompa hunting groundentrance, south of the Hunting expert's hut."),
+	FELDIP_HILLS_SE(new WorldPoint(2567, 2916, 0), FELDIP_HILLS, "South-east of the ∩-shaped lake, near the icon."),
+	FELDIP_HILLS_CW_BALLOON(new WorldPoint(2452, 3108, 0), FELDIP_HILLS, "Directly west of the Castle Wars balloon."),
+	FREMENNIK_PROVINCE_MTN_CAMP(new WorldPoint(2804, 3672, 0), FREMENNIK_PROVINCE, "At the Mountain Camp."),
+	FREMENNIK_PROVINCE_RELLEKKA_HUNTER(new WorldPoint(2724, 3783, 0), FREMENNIK_PROVINCE, "At the Rellekka Hunter area, near the icon."),
+	FREMENNIK_PROVINCE_KELGADRIM_ENTRANCE(new WorldPoint(2719, 3688, 0), FREMENNIK_PROVINCE, "West of the Keldagrim entrance mine."),
+	FREMENNIK_PROVINCE_SW(new WorldPoint(2605, 3648, 0), FREMENNIK_PROVINCE, "Outside the fence in the south-western corner of Rellekka."),
+	FREMENNIK_PROVINCE_LIGHTHOUSE(new WorldPoint(2589, 3598, 0), FREMENNIK_PROVINCE, "South-east of the Lighthouse."),
+	FREMENNIK_PROVINCE_ETCETERIA_CASTLE(new WorldPoint(2614, 3867, 0), FREMENNIK_PROVINCE, "Inside Etceteria's castle, in the southern staircase."),
+	FREMENNIK_PROVINCE_MISC_COURTYARD(new WorldPoint(2529, 3867, 0), FREMENNIK_PROVINCE, "Outside Miscellania's courtyard."),
+	FREMENNIK_PROVINCE_FREMMY_ISLES_MINE(new WorldPoint(2378, 3849, 0), FREMENNIK_PROVINCE, "Central Fremennik Isles mine."),
+	FREMENNIK_PROVINCE_WEST_ISLES_MINE(new WorldPoint(2313, 3854, 0), FREMENNIK_PROVINCE, "West Fremennik Isles mine."),
+	FREMENNIK_PROVINCE_WEST_JATIZSO_ENTRANCE(new WorldPoint(2391, 3813, 0), FREMENNIK_PROVINCE, "West of the Jatizso mine entrance."),
+	FREMENNIK_PROVINCE_PIRATES_COVE(new WorldPoint(2210, 3814, 0), FREMENNIK_PROVINCE, "Pirates' Cove"),
+	FREMENNIK_PROVINCE_ASTRAL_ALTER(new WorldPoint(2147, 3862, 0), FREMENNIK_PROVINCE, "Astral altar"),
+	FREMENNIK_PROVINCE_LUNAR_VILLAGE(new WorldPoint(2087, 3915, 0), FREMENNIK_PROVINCE, "Lunar Isle, inside the village."),
+	FREMENNIK_PROVINCE_LUNAR_NORTH(new WorldPoint(2101, 3949, 0), FREMENNIK_PROVINCE, "Lunar Isle, north of the village."),
+	KANDARIN_SINCLAR_MANSION(new WorldPoint(2726, 3588, 0), KANDARIN, "North-west of the Sinclair Mansion, near the log balance shortcut."),
+	KANDARIN_CATHERBY(new WorldPoint(2774, 3433, 0), KANDARIN, "Catherby, between the bank and the beehives, near small rock formation."),
+	KANDARIN_GRAND_TREE(new WorldPoint(2449, 3509, 0), KANDARIN, "Grand Tree, just east of the terrorchick gnome enclosure."),
+	KANDARIN_SEERS(new WorldPoint(2735, 3486, 0), KANDARIN, "Between the Seers' Village bank and Camelot."),
+	KANDARIN_MCGRUBORS_WOOD(new WorldPoint(2658, 3487, 0), KANDARIN, "McGrubor's Wood"),
+	KANDARIN_FISHING_BUILD(new WorldPoint(2586, 3372, 0), KANDARIN, "South of Fishing Guild"),
+	KANDARIN_WITCHHAVEN(new WorldPoint(2708, 3304, 0), KANDARIN, "Outside Witchaven, west of Jeb, Holgart, and Caroline."),
+	KANDARIN_NECRO_TOWER(new WorldPoint(2669, 3242, 0), KANDARIN, "Ground floor inside the Necromancer Tower. Easily accessed by using fairy ring code djp."),
+	KANDARIN_FIGHT_ARENA(new WorldPoint(2587, 3134, 0), KANDARIN, "South of the Fight Arena, north-west of the Nightmare Zone."),
+	KANDARIN_TREE_GNOME_VILLAGE(new WorldPoint(2526, 3160, 0), KANDARIN, "Tree Gnome Village, near the icon."),
+	KANDARIN_GRAVE_OF_SCORPIUS(new WorldPoint(2464, 3228, 0), KANDARIN, "Grave of Scorpius"),
+	KANDARIN_KHAZARD_BATTLEFIELD(new WorldPoint(2518, 3249, 0), KANDARIN, "Khazard Battlefield, in the small ruins south of tracker gnome 2."),
+	KANDARIN_WEST_ARDY(new WorldPoint(2533, 3320, 0), KANDARIN, "West Ardougne, near the staircase outside the Civic Office."),
+	KANDARIN_SW_TREE_GNOME_STRONGHOLD(new WorldPoint(2411, 3431, 0), KANDARIN, "South-west Tree Gnome Stronghold"),
+	KANDARIN_OUTPOST(new WorldPoint(3458, 3364, 0), KANDARIN, "South of the Tree Gnome Stronghold, north-east of the Outpost."),
+	KANDARIN_BAXTORIAN_FALLS(new WorldPoint(2534, 3479, 0), KANDARIN, "South-east of Almera's house on Baxtorian Falls."),
+	KANDARIN_BA_AGILITY_COURSE(new WorldPoint(2536, 3546, 0), KANDARIN, "Inside the Barbarian Agility Course. Completion of Alfred Grimhand's Barcrawl is required."),
+	KARAMJA_MUSA_POINT(new WorldPoint(2914, 3168, 0), KARAMJA, "Musa Point, banana plantation."),
+	KARAMJA_BRIMHAVEN_FRUIT_TREE(new WorldPoint(2783, 3210, 0), KARAMJA, "Brimhaven, east of the fruit tree patch."),
+	KARAMJA_WEST_BRIMHAVEN(new WorldPoint(2715, 3161, 0), KARAMJA, "West of Brimhaven."),
+	KARAMJA_GLIDER(new WorldPoint(2966, 2975, 0), KARAMJA, "West of the gnome glider."),
+	KARAMJA_KHARAZI_NE(new WorldPoint(2909, 2926, 0), KARAMJA, "North-eastern part of Kharazi Jungle."),
+	KARAMJA_KHARAZI_SW(new WorldPoint(2783, 2898, 0), KARAMJA, "South-western part of Kharazi Jungle."),
+	KARAMJA_CRASH_ISLAND(new WorldPoint(2910, 2737, 0), KARAMJA, "Northern part of Crash Island."),
+	MISTHALIN_VARROCK_STONE_CIRCLE(new WorldPoint(3225, 3355, 0), MISTHALIN, "South of the stone circle near Varrock's entrance."),
+	MISTHALIN_LUMBRIDGE(new WorldPoint(3240, 3163, 0), MISTHALIN, "Just north-west of the Lumbridge Fishing tutor."),
+	MISTHALIN_LUMBRIDGE_2(new WorldPoint(3170, 3278, 0), MISTHALIN, "North of the pond between Lumbridge and Draynor Village."),
+	MISTHALIN_GERTUDES(new WorldPoint(3158, 3421, 0), MISTHALIN, "Nort-east of Gertrude's house west of Varrock."),
+	MISTHALIN_DRAYNOR_BANK(new WorldPoint(3096, 3235, 0), MISTHALIN, "South of Draynor Village bank."),
+	MISTHALIN_LUMBER_YARD(new WorldPoint(3303, 3483, 0), MISTHALIN, "South of Lumber Yard, east of Assistant Serf."),
+	MORYTANIA_BURGH_DE_ROTT(new WorldPoint(3545, 3253, 0), MORYTANIA, "In the north-east area of Burgh de Rott, by the reverse-L-shaped ruins."),
+	MORYTANIA_PORT_PHASMATYS(new WorldPoint(3613, 3485, 0), MORYTANIA, "West of Port Phasmatys, south-east of fairy ring."),
+	MORYTANIA_HOLLOWS(new WorldPoint(3500, 3423, 0), MORYTANIA, "Inside The Hollows, south of the bridge which was repaired in a quest."),
+	MORYTANIA_SWAMP(new WorldPoint(3422, 3374, 0), MORYTANIA, "Inside the Mort Myre Swamp, north-west of the Nature Grotto."),
+	MORYTANIA_HAUNTED_MINE(new WorldPoint(3441, 3259, 0), MORYTANIA, "At Haunted Mine quest start."),
+	MORYTANIA_MAUSOLEUM(new WorldPoint(3502, 3537, 0), MORYTANIA, "South of the Mausoleum."),
+	MORYTANIA_MOS_LES_HARMLESS(new WorldPoint(3744, 3041, 0), MORYTANIA, "Northern area of Mos Le'Harmless, between the lakes."),
+	MORYTANIA_MOS_LES_HARMLESS_BAR(new WorldPoint(3670, 2974, 0), MORYTANIA, "Near Mos Le'Harmless southern bar."),
+	MORYTANIA_DRAGONTOOTH_NORTH(new WorldPoint(3813, 3567, 0), MORYTANIA, "Northern part of Dragontooth Island."),
+	MORYTANIA_DRAGONTOOTH_SOUTH(new WorldPoint(3803, 3532, 0), MORYTANIA, "Southern part of Dragontooth Island."),
+	WESTERN_PROVINCE_EAGLES_PEAK(new WorldPoint(2297, 3530, 0), WESTERN_PROVINCE, "North-west of Eagles' Peak."),
+	WESTERN_PROVINCE_PISCATORIS(new WorldPoint(2337, 3689, 0), WESTERN_PROVINCE, "Piscatoris Fishing Colony"),
+	WESTERN_PROVINCE_PISCATORIS_HUNTER_AREA(new WorldPoint(2361, 3566, 0), WESTERN_PROVINCE, "Eastern part of Piscatoris Hunter area, south-west of the Falconry."),
+	WESTERN_PROVINCE_ARANDAR(new WorldPoint(2366, 3318, 0), WESTERN_PROVINCE, "South-west of the crystal gate to Arandar."),
+	WESTERN_PROVINCE_ELF_CAMP_EAST(new WorldPoint(2270, 3244, 0), WESTERN_PROVINCE, "East of Elf Camp."),
+	WESTERN_PROVINCE_ELF_CAMP_NW(new WorldPoint(2171, 3280, 0), WESTERN_PROVINCE, "North-west of Elf Camp."),
+	WESTERN_PROVINCE_LLETYA(new WorldPoint(2335, 3166, 0), WESTERN_PROVINCE, "In Lletya."),
+	WESTERN_PROVINCE_TYRAS(new WorldPoint(2204, 3157, 0), WESTERN_PROVINCE, "Near Tyras Camp."),
+	WESTERN_PROVINCE_ZULANDRA(new WorldPoint(2196, 3057, 0), WESTERN_PROVINCE, "The northern house at Zul-Andra."),
+	WILDERNESS_5(new WorldPoint(3169, 3558, 0), WILDERNESS, "North of the Grand Exchange, level 5 Wilderness."),
+	WILDERNESS_12(new WorldPoint(3038, 3612, 0), WILDERNESS, "South-east of the Dark Warriors' Fortress, level 12 Wilderness."),
+	WILDERNESS_20(new WorldPoint(3225, 3676, 0), WILDERNESS, "East of the Corporeal Beast's lair, level 20 Wilderness."),
+	WILDERNESS_28(new WorldPoint(3369, 3664, 0), WILDERNESS, "East of Venenatis' nest, level 28 Wilderness."),
+	WILDERNESS_35(new WorldPoint(3153, 3795, 0), WILDERNESS, "East of the Wilderness canoe exit, level 35 Wilderness."),
+	WILDERNESS_37(new WorldPoint(2975, 3809, 0), WILDERNESS, "South-east of the Chaos Temple, level 37 Wilderness."),
+	WILDERNESS_38(new WorldPoint(3294, 3817, 0), WILDERNESS, "South of Callisto, level 38 Wilderness."),
+	WILDERNESS_49(new WorldPoint(3139, 3909, 0), WILDERNESS, "South-west of the Deserted Keep, level 49 Wilderness."),
+	WILDERNESS_54(new WorldPoint(2983, 3946, 0), WILDERNESS, "West of the Wilderness Agility Course, level 54 Wilderness."),
+	ZEAH_BLASTMINE_BANK(new WorldPoint(1507, 3856, 0), ZEAH, "Next to the bank in the Lovakengj Houseblast mine."),
+	ZEAH_BLASTMINE_NORTH(new WorldPoint(1490, 3883, 0), ZEAH, "Northern part of the Lovakengj House blast mine."),
+	ZEAH_LOVAKITE_FURNACE(new WorldPoint(1505, 3814, 0), ZEAH, "Next to the lovakite furnace in the Lovakengj House."),
+	ZEAH_LOVAKENGJ_MINE(new WorldPoint(1477, 3779, 0), ZEAH, "Next to mithril rock in the Lovakengj mine."),
+	ZEAH_SULPHR_MINE(new WorldPoint(1428, 3864, 0), ZEAH, "Western entrance in the Lovakengj House's sulphur mine."),
+	ZEAH_SHAYZIEN_BANK(new WorldPoint(1517, 3603, 0), ZEAH, "South-east of the bank in the Shayzien House."),
+	ZEAH_OVERPASS(new WorldPoint(1467, 3714, 0), ZEAH, "Overpass between the Lovakengj and Shayzien House."),
+	ZEAH_LIZARDMAN(new WorldPoint(1493, 3694, 0), ZEAH, "Within Lizardman Canyon, east of the ladder. Requires 5% favour with the Shayzien House."),
+	ZEAH_COMBAT_RING(new WorldPoint(1557, 3580, 0), ZEAH, "Shayzien, south-east of the Combat Ring."),
+	ZEAH_SHAYZIEN_BANK_2(new WorldPoint(1494, 3622, 0), ZEAH, "North-west of the bank in the Shayzien House."),
+	ZEAH_LIBRARY(new WorldPoint(1601, 3842, 0), ZEAH, "North-west of the Arceuus House Library."),
+	ZEAH_HOUSECHURCH(new WorldPoint(1682, 3792, 0), ZEAH, "By the entrance to the Arceuus Housechurch."),
+	ZEAH_DARK_ALTAR(new WorldPoint(1699, 3879, 0), ZEAH, "West of the Dark Altar."),
+	ZEAH_ARCEUUS_HOUSE(new WorldPoint(1708, 3701, 0), ZEAH, "By the southern entrance to the Arceuus House."),
+	ZEAH_ESSENCE_MINE(new WorldPoint(1762, 3852, 0), ZEAH, "By the Arceuus essence mine."),
+	ZEAH_ESSENCE_MINE_NE(new WorldPoint(1772, 3866, 0), ZEAH, "North-east of the Arceuus essence mine."),
+	ZEAH_PISCARILUS_MINE(new WorldPoint(1768, 3705, 0), ZEAH, "South of the Piscarilius mine."),
+	ZEAH_GOLDEN_FIELD_TAVERN(new WorldPoint(1718, 3647, 0), ZEAH, "South of The Golden Field tavern in the northern area of Great Kourend's Hosidius House."),
+	ZEAH_MESS_HALL(new WorldPoint(1658, 3621, 0), ZEAH, "East of Mess hall."),
+	ZEAH_WATSONS_HOUSE(new WorldPoint(1653, 3577, 0), ZEAH, "East of Watson's house."),
+	ZEAH_VANNAHS_FARM_STORE(new WorldPoint(1806, 3521, 0), ZEAH, "North of Vannah's Farm Store, between the chicken coop and willow trees.");
+
+	private final WorldPoint worldPoint;
+	private final HotColdArea hotColdArea;
+	private final String area;
+
+	public Rectangle2D getRect()
+	{
+		return new Rectangle(worldPoint.getX() - 4, worldPoint.getY() - 4, 9, 9);
+	}
+}


### PR DESCRIPTION
https://streamable.com/vfbie

The hot-cold clue scroll plugin is an extension of the existing clue scroll plugins. When a hot-cold clue is opened, instructions for obtaining the strange device will be displayed. Once the user attempts to use the strange device, the panel component will switch to showing names of world areas and how many possible final locations are in each world area. Once the user checks in a different spot, the list of world areas and number of possible final locations will be updated to reflect the temperature obtained from the strange device. From the second check onward the warmer/colder result of the strange device will also be considered (same temperature is not considered at this time because I couldn't figure out a good way to implement it, but the process is still quick without it).

Once the number of possible final dig spots is reduced to 10, the panel component will switch to showing the descriptions of the remaining dig spots. The user can continue testing locations to further narrow the number of remaining spots. The remaining spots will have a blue ground highlight, showing approximately where the final 9x9 dig spot area will be. When the user receives a message that their device is shaking, a dig icon will be placed on that square signaling that a valid final dig location has been found.

The logic behind the hot-cold plugin is based on the precise range of squares that a player is away from the final location when checking the temperature of the strange device (measured in Chebyshev or Chess-board distance). All calculations are based off of the world map coordinate system, and strange device checks can be done anywhere on the world map. The centers of the final locations were manually approximated by comparing wiki location pictures to a coordinate map. So some final locations may be slightly off-center, but since the final areas are 9x9 this leaves room in the calculations for any slightly off-centered points.