### PR TITLE
Sanitize player indicators options

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsConfig.java
@@ -39,10 +39,10 @@ public interface PlayerIndicatorsConfig extends Config
 	@ConfigItem(
 		position = 0,
 		keyName = "drawOwnName",
-		name = "Draw own name",
-		description = "Configures whether or not own name should be drawn"
+		name = "Highlight own player",
+		description = "Configures whether or not your own player should be highlighted"
 	)
-	default boolean drawOwnName()
+	default boolean highlightOwnPlayer()
 	{
 		return false;
 	}
@@ -50,10 +50,10 @@ public interface PlayerIndicatorsConfig extends Config
 	@ConfigItem(
 		position = 1,
 		keyName = "ownNameColor",
-		name = "Own name color",
-		description = "Color of your own name"
+		name = "Own player color",
+		description = "Color of your own player"
 	)
-	default Color getOwnNameColor()
+	default Color getOwnPlayerColor()
 	{
 		return new Color(0, 184, 212);
 	}
@@ -61,10 +61,10 @@ public interface PlayerIndicatorsConfig extends Config
 	@ConfigItem(
 		position = 2,
 		keyName = "drawFriendNames",
-		name = "Draw friend names",
-		description = "Configures whether or not names of player friends should be drawn"
+		name = "Highlight friends",
+		description = "Configures whether or not friends should be highlighted"
 	)
-	default boolean drawFriendNames()
+	default boolean highlightFriends()
 	{
 		return true;
 	}
@@ -72,10 +72,10 @@ public interface PlayerIndicatorsConfig extends Config
 	@ConfigItem(
 		position = 3,
 		keyName = "friendNameColor",
-		name = "Friend name color",
+		name = "Friend color",
 		description = "Color of friend names"
 	)
-	default Color getFriendNameColor()
+	default Color getFriendColor()
 	{
 		return new Color(0, 200, 83);
 	}
@@ -83,8 +83,8 @@ public interface PlayerIndicatorsConfig extends Config
 	@ConfigItem(
 		position = 4,
 		keyName = "drawClanMemberNames",
-		name = "Draw clan member names",
-		description = "Configures whether or not names of player's clan members should be drawn"
+		name = "Highlight clan members",
+		description = "Configures whether or clan members should be highlighted"
 	)
 	default boolean drawClanMemberNames()
 	{
@@ -95,7 +95,7 @@ public interface PlayerIndicatorsConfig extends Config
 		position = 5,
 		keyName = "clanMemberColor",
 		name = "Clan member color",
-		description = "Color of clan member names"
+		description = "Color of clan members"
 	)
 	default Color getClanMemberColor()
 	{
@@ -105,10 +105,10 @@ public interface PlayerIndicatorsConfig extends Config
 	@ConfigItem(
 		position = 6,
 		keyName = "drawTeamMemberNames",
-		name = "Draw team member names",
-		description = "Configures whether or not names of player's team members should be drawn"
+		name = "Highlight team members",
+		description = "Configures whether or not team members should be highlighted"
 	)
-	default boolean drawTeamMemberNames()
+	default boolean highlightTeamMembers()
 	{
 		return true;
 	}
@@ -117,7 +117,7 @@ public interface PlayerIndicatorsConfig extends Config
 		position = 7,
 		keyName = "teamMemberColor",
 		name = "Team member color",
-		description = "Color of team member names"
+		description = "Color of team members"
 	)
 	default Color getTeamMemberColor()
 	{
@@ -127,10 +127,10 @@ public interface PlayerIndicatorsConfig extends Config
 	@ConfigItem(
 		position = 8,
 		keyName = "drawNonClanMemberNames",
-		name = "Draw non-clan member names",
-		description = "Configures whether or not names of non-clan members should be drawn"
+		name = "Highlight non-clan members",
+		description = "Configures whether or not non-clan members should be highlighted"
 	)
-	default boolean drawNonClanMemberNames()
+	default boolean highlightNonClanMembers()
 	{
 		return false;
 	}
@@ -149,8 +149,8 @@ public interface PlayerIndicatorsConfig extends Config
 	@ConfigItem(
 		position = 10,
 		keyName = "drawPlayerTiles",
-		name = "Draw tiles",
-		description = "Configures whether or not tiles under players with rendered names should be drawn"
+		name = "Draw tiles under players",
+		description = "Configures whether or not tiles under highlighted players should be drawn"
 	)
 	default boolean drawTiles()
 	{
@@ -182,7 +182,7 @@ public interface PlayerIndicatorsConfig extends Config
 	@ConfigItem(
 		position = 13,
 		keyName = "colorPlayerMenu",
-		name = "Color player menu",
+		name = "Colorize player menu",
 		description = "Color right click menu for players"
 	)
 	default boolean colorPlayerMenu()
@@ -193,10 +193,10 @@ public interface PlayerIndicatorsConfig extends Config
 	@ConfigItem(
 		position = 14,
 		keyName = "clanMenuIcons",
-		name = "Show clan rank in menu",
-		description = "Add clan rank to right click menu for players"
+		name = "Show clan ranks",
+		description = "Add clan rank to right click menu and next to player names"
 	)
-	default boolean clanMenuIcons()
+	default boolean showClanRanks()
 	{
 		return true;
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsOverlay.java
@@ -87,12 +87,14 @@ public class PlayerIndicatorsOverlay extends Overlay
 
 		if (textLocation != null)
 		{
-			if (actor.isClanMember())
+			if (config.showClanRanks() && actor.isClanMember())
 			{
 				ClanMemberRank rank = clanManager.getRank(name);
+
 				if (rank != ClanMemberRank.UNRANKED)
 				{
 					BufferedImage clanchatImage = clanManager.getClanImage(rank);
+
 					if (clanchatImage != null)
 					{
 						int width = clanchatImage.getWidth();
@@ -105,6 +107,7 @@ public class PlayerIndicatorsOverlay extends Overlay
 					}
 				}
 			}
+
 			OverlayUtil.renderTextLocation(graphics, textLocation, name, color);
 		}
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsPlugin.java
@@ -125,9 +125,9 @@ public class PlayerIndicatorsPlugin extends Plugin
 			int image = -1;
 			Color color = null;
 
-			if (config.drawFriendNames() && player.isFriend())
+			if (config.highlightFriends() && player.isFriend())
 			{
-				color = config.getFriendNameColor();
+				color = config.getFriendColor();
 			}
 			else if (config.drawClanMemberNames() && player.isClanMember())
 			{
@@ -139,11 +139,11 @@ public class PlayerIndicatorsPlugin extends Plugin
 					image = clanManager.getIconNumber(rank);
 				}
 			}
-			else if (config.drawTeamMemberNames() && player.getTeam() > 0 && localPlayer.getTeam() == player.getTeam())
+			else if (config.highlightTeamMembers() && player.getTeam() > 0 && localPlayer.getTeam() == player.getTeam())
 			{
 				color = config.getTeamMemberColor();
 			}
-			else if (config.drawNonClanMemberNames() && !player.isClanMember())
+			else if (config.highlightNonClanMembers() && !player.isClanMember())
 			{
 				color = config.getNonClanMemberColor();
 			}
@@ -166,7 +166,7 @@ public class PlayerIndicatorsPlugin extends Plugin
 					lastEntry.setTarget("<col=" + Integer.toHexString(color.getRGB() & 0xFFFFFF) + ">" + target);
 				}
 
-				if (image != -1 && config.clanMenuIcons())
+				if (image != -1 && config.showClanRanks())
 				{
 					lastEntry.setTarget("<img=" + image + ">" + lastEntry.getTarget());
 				}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsService.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsService.java
@@ -46,8 +46,8 @@ public class PlayerIndicatorsService
 
 	public void forEachPlayer(final BiConsumer<Player, Color> consumer)
 	{
-		if (!config.drawOwnName() && !config.drawClanMemberNames()
-			&& !config.drawFriendNames() && !config.drawNonClanMemberNames())
+		if (!config.highlightOwnPlayer() && !config.drawClanMemberNames()
+			&& !config.highlightFriends() && !config.highlightNonClanMembers())
 		{
 			return;
 		}
@@ -65,24 +65,24 @@ public class PlayerIndicatorsService
 
 			if (player == localPlayer)
 			{
-				if (config.drawOwnName())
+				if (config.highlightOwnPlayer())
 				{
-					consumer.accept(player, config.getOwnNameColor());
+					consumer.accept(player, config.getOwnPlayerColor());
 				}
 			}
-			else if (config.drawFriendNames() && player.isFriend())
+			else if (config.highlightFriends() && player.isFriend())
 			{
-				consumer.accept(player, config.getFriendNameColor());
+				consumer.accept(player, config.getFriendColor());
 			}
 			else if (config.drawClanMemberNames() && isClanMember)
 			{
 				consumer.accept(player, config.getClanMemberColor());
 			}
-			else if (config.drawTeamMemberNames() && localPlayer.getTeam() > 0 && localPlayer.getTeam() == player.getTeam())
+			else if (config.highlightTeamMembers() && localPlayer.getTeam() > 0 && localPlayer.getTeam() == player.getTeam())
 			{
 				consumer.accept(player, config.getTeamMemberColor());
 			}
-			else if (config.drawNonClanMemberNames() && !isClanMember)
+			else if (config.highlightNonClanMembers() && !isClanMember)
 			{
 				consumer.accept(player, config.getNonClanMemberColor());
 			}


### PR DESCRIPTION
- Name the player indicators options properly
- Extend the clan ranks icon setting to support also overhead names

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>

Preview:
![screenie](https://user-images.githubusercontent.com/5115805/39678630-70d11550-5190-11e8-9178-e8e7749c659a.png)