### PR TITLE
Add SpriteManager to get sprites from the cache

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/Client.java
+++ b/runelite-api/src/main/java/net/runelite/api/Client.java
@@ -108,6 +108,10 @@ public interface Client extends GameEngine
 
 	SpritePixels createItemSprite(int itemId, int quantity, int border, int shadowColor, int stackable, boolean noted, int scale);
 
+	SpritePixels getSprite(IndexDataBase source, int archiveId, int fileId);
+
+	IndexDataBase getIndexSprites();
+
 	int getBaseX();
 
 	int getBaseY();

--- a/runelite-api/src/main/java/net/runelite/api/IndexDataBase.java
+++ b/runelite-api/src/main/java/net/runelite/api/IndexDataBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Adam <Adam@sigterm.info>
+ * Copyright (c) 2018 Abex
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -22,13 +22,8 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package net.runelite.rs.api;
+package net.runelite.api;
 
-import net.runelite.api.IndexDataBase;
-import net.runelite.mapping.Import;
-
-public interface RSIndexDataBase extends IndexDataBase
+public interface IndexDataBase
 {
-	@Import("getConfigData")
-	byte[] getConfigData(int archiveId, int fileId);
 }

--- a/runelite-client/src/main/java/net/runelite/client/game/SpriteManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/game/SpriteManager.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2018 Abex
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.game;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import com.google.inject.Inject;
+import java.awt.image.BufferedImage;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import javax.annotation.Nullable;
+import javax.inject.Singleton;
+import javax.swing.ImageIcon;
+import javax.swing.JButton;
+import javax.swing.JLabel;
+import javax.swing.SwingUtilities;
+import net.runelite.api.Client;
+import net.runelite.api.GameState;
+import net.runelite.api.SpritePixels;
+import net.runelite.client.callback.ClientThread;
+
+@Singleton
+public class SpriteManager
+{
+	@Inject
+	private Client client;
+
+	@Inject
+	private ClientThread clientThread;
+
+	public Cache<Long, BufferedImage> cache = CacheBuilder.newBuilder()
+		.maximumSize(128L)
+		.expireAfterAccess(1, TimeUnit.HOURS)
+		.build();
+
+	@Nullable
+	public BufferedImage getSprite(int archive, int file)
+	{
+		assert client.isClientThread();
+		if (client.getGameState().ordinal() < GameState.LOGIN_SCREEN.ordinal())
+		{
+			return null;
+		}
+
+		Long key = (long) archive << 32 | file;
+		BufferedImage cached = cache.getIfPresent(key);
+		if (cached != null)
+		{
+			return cached;
+		}
+
+		SpritePixels sp = client.getSprite(client.getIndexSprites(), archive, file);
+		BufferedImage img = sp.toBufferedImage();
+
+		cache.put(key, img);
+		return img;
+	}
+
+	public void getSpriteAsync(int archive, int file, Consumer<BufferedImage> user)
+	{
+		BufferedImage cached = cache.getIfPresent((long) archive << 32 | file);
+		if (cached != null)
+		{
+			user.accept(cached);
+			return;
+		}
+
+		clientThread.invokeLater(() ->
+		{
+			BufferedImage img = getSprite(archive, file);
+			if (img == null)
+			{
+				// Cache isn't loaded yet
+				return false;
+			}
+			user.accept(img);
+			return true;
+		});
+	}
+
+	/**
+	 * Calls setIcon on c, ensuring it is repainted when this changes
+	 */
+	public void addSpriteTo(JButton c, int archive, int file)
+	{
+		getSpriteAsync(archive, file, img ->
+		{
+			SwingUtilities.invokeLater(() ->
+			{
+				c.setIcon(new ImageIcon(img));
+			});
+		});
+	}
+
+	/**
+	 * Calls setIcon on c, ensuring it is repainted when this changes
+	 */
+	public void addSpriteTo(JLabel c, int archive, int file)
+	{
+		getSpriteAsync(archive, file, img ->
+		{
+			SwingUtilities.invokeLater(() ->
+			{
+				c.setIcon(new ImageIcon(img));
+			});
+		});
+	}
+}

--- a/runescape-api/src/main/java/net/runelite/rs/api/RSClient.java
+++ b/runescape-api/src/main/java/net/runelite/rs/api/RSClient.java
@@ -26,6 +26,7 @@ package net.runelite.rs.api;
 
 import java.util.Map;
 import net.runelite.api.Client;
+import net.runelite.api.IndexDataBase;
 import net.runelite.api.SpritePixels;
 import net.runelite.api.World;
 import net.runelite.api.widgets.Widget;
@@ -304,6 +305,14 @@ public interface RSClient extends RSGameEngine, Client
 
 	@Import("createSprite")
 	RSSpritePixels createItemSprite(int itemId, int quantity, int thickness, int borderColor, int stackable, boolean noted);
+
+	@Import("getSpriteAsSpritePixels")
+	@Override
+	RSSpritePixels getSprite(IndexDataBase source, int archiveId, int fileId);
+
+	@Import("indexSprites")
+	@Override
+	RSIndexDataBase getIndexSprites();
 
 	@Import("widgetFlags")
 	@Override

--- a/runescape-client/src/main/java/AbstractByteBuffer.java
+++ b/runescape-client/src/main/java/AbstractByteBuffer.java
@@ -38,7 +38,8 @@ public abstract class AbstractByteBuffer {
       signature = "(Ljr;IIB)Llv;",
       garbageValue = "-11"
    )
-   public static SpritePixels method3836(IndexDataBase var0, int var1, int var2) {
+   @Export("getSpriteAsSpritePixels")
+   public static SpritePixels getSpriteAsSpritePixels(IndexDataBase var0, int var1, int var2) {
       if(!class326.method5792(var0, var1, var2)) {
          return null;
       } else {

--- a/runescape-client/src/main/java/Area.java
+++ b/runescape-client/src/main/java/Area.java
@@ -273,7 +273,7 @@ public class Area extends CacheableNode {
          if(var2 != null) {
             return var2;
          } else {
-            var2 = AbstractByteBuffer.method3836(field3462, var1, 0);
+            var2 = AbstractByteBuffer.getSpriteAsSpritePixels(field3462, var1, 0);
             if(var2 != null) {
                areaSpriteCache.put(var2, (long)var1);
             }

--- a/runescape-client/src/main/java/AttackOption.java
+++ b/runescape-client/src/main/java/AttackOption.java
@@ -299,7 +299,7 @@ public enum AttackOption implements Enumerated {
                      var10 = UnitPriceComparator.indexSprites;
                      var3 = var10.getFile("compass");
                      var4 = var10.getChild(var3, "");
-                     var12 = AbstractByteBuffer.method3836(var10, var3, var4);
+                     var12 = AbstractByteBuffer.getSpriteAsSpritePixels(var10, var3, var4);
                      WorldMapManager.compass = var12;
                   } else {
                      ++var0;
@@ -309,7 +309,7 @@ public enum AttackOption implements Enumerated {
                      var10 = UnitPriceComparator.indexSprites;
                      var3 = var10.getFile("mapedge");
                      var4 = var10.getChild(var3, "");
-                     var12 = AbstractByteBuffer.method3836(var10, var3, var4);
+                     var12 = AbstractByteBuffer.getSpriteAsSpritePixels(var10, var3, var4);
                      class230.mapedge = var12;
                   } else {
                      ++var0;

--- a/runescape-client/src/main/java/CombatInfo2.java
+++ b/runescape-client/src/main/java/CombatInfo2.java
@@ -159,7 +159,7 @@ public class CombatInfo2 extends CacheableNode {
          if(var1 != null) {
             return var1;
          } else {
-            var1 = AbstractByteBuffer.method3836(field3523, this.field3533, 0);
+            var1 = AbstractByteBuffer.getSpriteAsSpritePixels(field3523, this.field3533, 0);
             if(var1 != null) {
                field3525.put(var1, (long)this.field3533);
             }
@@ -182,7 +182,7 @@ public class CombatInfo2 extends CacheableNode {
          if(var1 != null) {
             return var1;
          } else {
-            var1 = AbstractByteBuffer.method3836(field3523, this.field3531, 0);
+            var1 = AbstractByteBuffer.getSpriteAsSpritePixels(field3523, this.field3531, 0);
             if(var1 != null) {
                field3525.put(var1, (long)this.field3531);
             }

--- a/runescape-client/src/main/java/Widget.java
+++ b/runescape-client/src/main/java/Widget.java
@@ -1225,7 +1225,7 @@ public class Widget extends Node {
          if(var5 != null) {
             return var5;
          } else {
-            var5 = AbstractByteBuffer.method3836(class18.field319, var2, 0);
+            var5 = AbstractByteBuffer.getSpriteAsSpritePixels(class18.field319, var2, 0);
             if(var5 == null) {
                field2934 = true;
                return null;
@@ -1313,7 +1313,7 @@ public class Widget extends Node {
             if(var3 != null) {
                return var3;
             } else {
-               var3 = AbstractByteBuffer.method3836(class18.field319, var2, 0);
+               var3 = AbstractByteBuffer.getSpriteAsSpritePixels(class18.field319, var2, 0);
                if(var3 != null) {
                   field2842.put(var3, (long)var2);
                } else {

--- a/runescape-client/src/main/java/class281.java
+++ b/runescape-client/src/main/java/class281.java
@@ -273,7 +273,7 @@ public class class281 extends CacheableNode {
          if(var1 != null) {
             return var1;
          } else {
-            var1 = AbstractByteBuffer.method3836(field3573, this.field3577, 0);
+            var1 = AbstractByteBuffer.getSpriteAsSpritePixels(field3573, this.field3577, 0);
             if(var1 != null) {
                field3584.put(var1, (long)this.field3577);
             }
@@ -296,7 +296,7 @@ public class class281 extends CacheableNode {
          if(var1 != null) {
             return var1;
          } else {
-            var1 = AbstractByteBuffer.method3836(field3573, this.field3578, 0);
+            var1 = AbstractByteBuffer.getSpriteAsSpritePixels(field3573, this.field3578, 0);
             if(var1 != null) {
                field3584.put(var1, (long)this.field3578);
             }
@@ -319,7 +319,7 @@ public class class281 extends CacheableNode {
          if(var1 != null) {
             return var1;
          } else {
-            var1 = AbstractByteBuffer.method3836(field3573, this.field3579, 0);
+            var1 = AbstractByteBuffer.getSpriteAsSpritePixels(field3573, this.field3579, 0);
             if(var1 != null) {
                field3584.put(var1, (long)this.field3579);
             }
@@ -342,7 +342,7 @@ public class class281 extends CacheableNode {
          if(var1 != null) {
             return var1;
          } else {
-            var1 = AbstractByteBuffer.method3836(field3573, this.field3565, 0);
+            var1 = AbstractByteBuffer.getSpriteAsSpritePixels(field3573, this.field3565, 0);
             if(var1 != null) {
                field3584.put(var1, (long)this.field3565);
             }


### PR DESCRIPTION
Adds a SpriteManager class, similar to the ItemManager, to load sprites from the cache.

Required for #947

I want to convert most usage of resource-sprites to use this, probably in a separate PR