### PR TITLE
Add category system to plugin configuration UI. Fixes #2411

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/PluginCategory.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/PluginCategory.java
@@ -2,7 +2,6 @@ package net.runelite.client.plugins;
 
 public enum PluginCategory
 {
-	ALL("All"),
 	COMBAT("Combat"),
 	SKILLS("Skills"),
 	ITEM("Item"),

--- a/runelite-client/src/main/java/net/runelite/client/plugins/PluginCategory.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/PluginCategory.java
@@ -5,6 +5,9 @@ public enum PluginCategory
 	ALL("All"),
 	COMBAT("Combat"),
 	SKILLS("Skills"),
+	ITEM("Item"),
+	ACTIVITY("Activity"),
+	MINIGAME("Minigame"),
 	UTILITY("Utility"),
 	CLIENT("Client");
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/PluginCategory.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/PluginCategory.java
@@ -1,0 +1,23 @@
+package net.runelite.client.plugins;
+
+public enum PluginCategory
+{
+	ALL("All"),
+	COMBAT("Combat"),
+	SKILLS("Skills"),
+	UTILITY("Utility"),
+	CLIENT("Client");
+
+	private final String category;
+
+	PluginCategory(final String category)
+	{
+		this.category = category;
+	}
+
+	@Override
+	public String toString()
+	{
+		return category;
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/PluginDescriptor.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/PluginDescriptor.java
@@ -37,6 +37,8 @@ public @interface PluginDescriptor
 {
 	String name();
 
+	PluginCategory category();
+
 	boolean enabledByDefault() default true;
 
 	/**

--- a/runelite-client/src/main/java/net/runelite/client/plugins/account/AccountPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/account/AccountPlugin.java
@@ -37,6 +37,7 @@ import net.runelite.api.events.SessionOpen;
 import net.runelite.client.account.AccountSession;
 import net.runelite.client.account.SessionManager;
 import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginCategory;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.NavigationButton;
 import net.runelite.client.ui.TitleToolbar;
@@ -44,7 +45,8 @@ import net.runelite.client.util.RunnableExceptionLogger;
 
 @PluginDescriptor(
 	name = "Account",
-	loadWhenOutdated = true
+	loadWhenOutdated = true,
+	category = PluginCategory.CLIENT
 )
 @Slf4j
 public class AccountPlugin extends Plugin

--- a/runelite-client/src/main/java/net/runelite/client/plugins/agility/AgilityPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/agility/AgilityPlugin.java
@@ -58,11 +58,13 @@ import net.runelite.api.events.WallObjectDespawned;
 import net.runelite.api.events.WallObjectSpawned;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginCategory;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.Overlay;
 
 @PluginDescriptor(
-	name = "Agility"
+	name = "Agility",
+	category = PluginCategory.SKILLING
 )
 @Slf4j
 public class AgilityPlugin extends Plugin

--- a/runelite-client/src/main/java/net/runelite/client/plugins/agility/AgilityPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/agility/AgilityPlugin.java
@@ -64,7 +64,7 @@ import net.runelite.client.ui.overlay.Overlay;
 
 @PluginDescriptor(
 	name = "Agility",
-	category = PluginCategory.SKILLING
+	category = PluginCategory.SKILLS
 )
 @Slf4j
 public class AgilityPlugin extends Plugin

--- a/runelite-client/src/main/java/net/runelite/client/plugins/animsmoothing/AnimationSmoothingPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/animsmoothing/AnimationSmoothingPlugin.java
@@ -30,12 +30,14 @@ import net.runelite.api.Client;
 import net.runelite.api.events.ConfigChanged;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginCategory;
 import net.runelite.client.plugins.PluginDescriptor;
 import javax.inject.Inject;
 
 @PluginDescriptor(
 	name = "Animation Smoothing",
-	enabledByDefault = false
+	enabledByDefault = false,
+	category = PluginCategory.OTHER
 )
 public class AnimationSmoothingPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/animsmoothing/AnimationSmoothingPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/animsmoothing/AnimationSmoothingPlugin.java
@@ -37,7 +37,7 @@ import javax.inject.Inject;
 @PluginDescriptor(
 	name = "Animation Smoothing",
 	enabledByDefault = false,
-	category = PluginCategory.OTHER
+	category = PluginCategory.CLIENT
 )
 public class AnimationSmoothingPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/antidrag/AntiDragPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/antidrag/AntiDragPlugin.java
@@ -32,13 +32,15 @@ import net.runelite.client.config.ConfigManager;
 import net.runelite.client.input.KeyListener;
 import net.runelite.client.input.KeyManager;
 import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginCategory;
 import net.runelite.client.plugins.PluginDescriptor;
 import javax.inject.Inject;
 import java.awt.event.KeyEvent;
 
 @PluginDescriptor(
 	name = "Anti Drag",
-	enabledByDefault = false
+	enabledByDefault = false,
+	category = PluginCategory.CLIENT
 )
 public class AntiDragPlugin extends Plugin implements KeyListener
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/attackstyles/AttackStylesPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/attackstyles/AttackStylesPlugin.java
@@ -56,7 +56,7 @@ import static net.runelite.client.plugins.attackstyles.AttackStyle.OTHER;
 
 @PluginDescriptor(
 	name = "Attack Styles",
-	category = PluginCategory.UTILITY
+	category = PluginCategory.COMBAT
 )
 @Slf4j
 public class AttackStylesPlugin extends Plugin

--- a/runelite-client/src/main/java/net/runelite/client/plugins/attackstyles/AttackStylesPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/attackstyles/AttackStylesPlugin.java
@@ -48,13 +48,15 @@ import net.runelite.api.widgets.WidgetInfo;
 import static net.runelite.api.widgets.WidgetInfo.TO_GROUP;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginCategory;
 import net.runelite.client.plugins.PluginDescriptor;
 import static net.runelite.client.plugins.attackstyles.AttackStyle.CASTING;
 import static net.runelite.client.plugins.attackstyles.AttackStyle.DEFENSIVE_CASTING;
 import static net.runelite.client.plugins.attackstyles.AttackStyle.OTHER;
 
 @PluginDescriptor(
-	name = "Attack Styles"
+	name = "Attack Styles",
+	category = PluginCategory.UTILITY
 )
 @Slf4j
 public class AttackStylesPlugin extends Plugin

--- a/runelite-client/src/main/java/net/runelite/client/plugins/banktags/BankTagsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/banktags/BankTagsPlugin.java
@@ -45,10 +45,12 @@ import net.runelite.client.config.ConfigManager;
 import net.runelite.client.game.ChatboxInputManager;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginCategory;
 import net.runelite.client.plugins.PluginDescriptor;
 
 @PluginDescriptor(
-	name = "Bank Tags"
+	name = "Bank Tags",
+	category = PluginCategory.UTILITY
 )
 @Slf4j
 public class BankTagsPlugin extends Plugin

--- a/runelite-client/src/main/java/net/runelite/client/plugins/bankvalue/BankValuePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/bankvalue/BankValuePlugin.java
@@ -34,9 +34,13 @@ import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginCategory;
 import net.runelite.client.plugins.PluginDescriptor;
 
-@PluginDescriptor(name = "Bank Value")
+@PluginDescriptor(
+	name = "Bank Value",
+	category = PluginCategory.UTILITY
+)
 public class BankValuePlugin extends Plugin
 {
 	@Inject

--- a/runelite-client/src/main/java/net/runelite/client/plugins/barbarianassault/BarbarianAssaultPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/barbarianassault/BarbarianAssaultPlugin.java
@@ -43,12 +43,14 @@ import net.runelite.api.events.VarbitChanged;
 import net.runelite.api.kit.KitType;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginCategory;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.FontManager;
 import net.runelite.client.ui.overlay.Overlay;
 
 @PluginDescriptor(
-	name = "Barbarian Assault"
+	name = "Barbarian Assault",
+	category = PluginCategory.COMBAT
 )
 public class BarbarianAssaultPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/barbarianassault/BarbarianAssaultPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/barbarianassault/BarbarianAssaultPlugin.java
@@ -50,7 +50,7 @@ import net.runelite.client.ui.overlay.Overlay;
 
 @PluginDescriptor(
 	name = "Barbarian Assault",
-	category = PluginCategory.COMBAT
+	category = PluginCategory.MINIGAME
 )
 public class BarbarianAssaultPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/barrows/BarrowsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/barrows/BarrowsPlugin.java
@@ -64,13 +64,15 @@ import net.runelite.client.chat.QueuedMessage;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginCategory;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.util.StackFormatter;
 import net.runelite.http.api.item.ItemPrice;
 
 @PluginDescriptor(
-	name = "Barrows Brothers"
+	name = "Barrows Brothers",
+	category = PluginCategory.COMBAT
 )
 @Slf4j
 public class BarrowsPlugin extends Plugin

--- a/runelite-client/src/main/java/net/runelite/client/plugins/barrows/BarrowsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/barrows/BarrowsPlugin.java
@@ -72,7 +72,7 @@ import net.runelite.http.api.item.ItemPrice;
 
 @PluginDescriptor(
 	name = "Barrows Brothers",
-	category = PluginCategory.COMBAT
+	category = PluginCategory.MINIGAME
 )
 @Slf4j
 public class BarrowsPlugin extends Plugin

--- a/runelite-client/src/main/java/net/runelite/client/plugins/blastfurnace/BlastFurnacePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/blastfurnace/BlastFurnacePlugin.java
@@ -45,7 +45,7 @@ import net.runelite.client.ui.overlay.Overlay;
 
 @PluginDescriptor(
 	name = "Blast Furnace",
-	category = PluginCategory.SKILLS
+	category = PluginCategory.MINIGAME
 )
 public class BlastFurnacePlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/blastfurnace/BlastFurnacePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/blastfurnace/BlastFurnacePlugin.java
@@ -39,11 +39,13 @@ import net.runelite.api.events.GameObjectSpawned;
 import net.runelite.api.events.GameStateChanged;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginCategory;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.Overlay;
 
 @PluginDescriptor(
-	name = "Blast Furnace"
+	name = "Blast Furnace",
+	category = PluginCategory.SKILLING
 )
 public class BlastFurnacePlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/blastfurnace/BlastFurnacePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/blastfurnace/BlastFurnacePlugin.java
@@ -45,7 +45,7 @@ import net.runelite.client.ui.overlay.Overlay;
 
 @PluginDescriptor(
 	name = "Blast Furnace",
-	category = PluginCategory.SKILLING
+	category = PluginCategory.SKILLS
 )
 public class BlastFurnacePlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/boosts/BoostsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/boosts/BoostsPlugin.java
@@ -42,12 +42,14 @@ import net.runelite.api.events.ConfigChanged;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.game.SkillIconManager;
 import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginCategory;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.infobox.InfoBoxManager;
 
 @PluginDescriptor(
-	name = "Boosts Information"
+	name = "Boosts Information",
+	category = PluginCategory.UTILITY
 )
 @Slf4j
 public class BoostsPlugin extends Plugin

--- a/runelite-client/src/main/java/net/runelite/client/plugins/bosstimer/BossTimersPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/bosstimer/BossTimersPlugin.java
@@ -32,11 +32,13 @@ import net.runelite.api.Actor;
 import net.runelite.api.events.ActorDeath;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginCategory;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.infobox.InfoBoxManager;
 
 @PluginDescriptor(
-	name = "Boss Timers"
+	name = "Boss Timers",
+	category = PluginCategory.UTILITY
 )
 @Slf4j
 public class BossTimersPlugin extends Plugin

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonPlugin.java
@@ -57,13 +57,15 @@ import net.runelite.client.callback.ClientThread;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginCategory;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.task.Schedule;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.infobox.InfoBoxManager;
 
 @PluginDescriptor(
-	name = "Cannon"
+	name = "Cannon",
+	category = PluginCategory.UTILITY
 )
 public class CannonPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonPlugin.java
@@ -65,7 +65,7 @@ import net.runelite.client.ui.overlay.infobox.InfoBoxManager;
 
 @PluginDescriptor(
 	name = "Cannon",
-	category = PluginCategory.UTILITY
+	category = PluginCategory.COMBAT
 )
 public class CannonPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cerberus/CerberusPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cerberus/CerberusPlugin.java
@@ -40,10 +40,14 @@ import net.runelite.api.events.GameTick;
 import net.runelite.api.events.NpcDespawned;
 import net.runelite.api.events.NpcSpawned;
 import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginCategory;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.Overlay;
 
-@PluginDescriptor(name = "Cerberus")
+@PluginDescriptor(
+	name = "Cerberus",
+	category = PluginCategory.COMBAT
+)
 @Singleton
 public class CerberusPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
@@ -61,7 +61,7 @@ import net.runelite.http.api.item.SearchResult;
 
 @PluginDescriptor(
 	name = "Chat Commands",
-	category = PluginCategory.OTHER
+	category = PluginCategory.CLIENT
 )
 @Slf4j
 public class ChatCommandsPlugin extends Plugin

--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
@@ -48,6 +48,7 @@ import net.runelite.client.chat.ChatMessageManager;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginCategory;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.util.StackFormatter;
 import net.runelite.http.api.hiscore.HiscoreClient;
@@ -59,7 +60,8 @@ import net.runelite.http.api.item.ItemPrice;
 import net.runelite.http.api.item.SearchResult;
 
 @PluginDescriptor(
-	name = "Chat Commands"
+	name = "Chat Commands",
+	category = PluginCategory.OTHER
 )
 @Slf4j
 public class ChatCommandsPlugin extends Plugin

--- a/runelite-client/src/main/java/net/runelite/client/plugins/chathistory/ChatHistoryPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chathistory/ChatHistoryPlugin.java
@@ -36,9 +36,13 @@ import net.runelite.api.events.SetMessage;
 import net.runelite.client.chat.ChatMessageManager;
 import net.runelite.client.chat.QueuedMessage;
 import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginCategory;
 import net.runelite.client.plugins.PluginDescriptor;
 
-@PluginDescriptor(name = "Chat History")
+@PluginDescriptor(
+	name = "Chat History",
+	category = PluginCategory.OTHER
+)
 public class ChatHistoryPlugin extends Plugin
 {
 	private static final String WELCOME_MESSAGE = "Welcome to RuneScape.";

--- a/runelite-client/src/main/java/net/runelite/client/plugins/chathistory/ChatHistoryPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chathistory/ChatHistoryPlugin.java
@@ -41,7 +41,7 @@ import net.runelite.client.plugins.PluginDescriptor;
 
 @PluginDescriptor(
 	name = "Chat History",
-	category = PluginCategory.OTHER
+	category = PluginCategory.CLIENT
 )
 public class ChatHistoryPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/clanchat/ClanChatPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/clanchat/ClanChatPlugin.java
@@ -43,7 +43,7 @@ import net.runelite.client.task.Schedule;
 
 @PluginDescriptor(
 	name = "Clan Chat",
-	category = PluginCategory.OTHER
+	category = PluginCategory.UTILITY
 )
 @Slf4j
 public class ClanChatPlugin extends Plugin

--- a/runelite-client/src/main/java/net/runelite/client/plugins/clanchat/ClanChatPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/clanchat/ClanChatPlugin.java
@@ -37,11 +37,13 @@ import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.game.ClanManager;
 import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginCategory;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.task.Schedule;
 
 @PluginDescriptor(
-	name = "Clan Chat"
+	name = "Clan Chat",
+	category = PluginCategory.OTHER
 )
 @Slf4j
 public class ClanChatPlugin extends Plugin

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/ClueScrollPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/ClueScrollPlugin.java
@@ -90,7 +90,7 @@ import net.runelite.client.util.Text;
 
 @PluginDescriptor(
 	name = "Clue Scroll",
-	category = PluginCategory.ACTIVITY
+	category = PluginCategory.MINIGAME
 )
 @Slf4j
 public class ClueScrollPlugin extends Plugin

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/ClueScrollPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/ClueScrollPlugin.java
@@ -67,6 +67,7 @@ import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginCategory;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.plugins.cluescrolls.clues.AnagramClue;
 import net.runelite.client.plugins.cluescrolls.clues.CipherClue;
@@ -88,7 +89,8 @@ import net.runelite.client.util.QueryRunner;
 import net.runelite.client.util.Text;
 
 @PluginDescriptor(
-	name = "Clue Scroll"
+	name = "Clue Scroll",
+	category = PluginCategory.UTILITY
 )
 @Slf4j
 public class ClueScrollPlugin extends Plugin

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/ClueScrollPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/ClueScrollPlugin.java
@@ -90,7 +90,7 @@ import net.runelite.client.util.Text;
 
 @PluginDescriptor(
 	name = "Clue Scroll",
-	category = PluginCategory.UTILITY
+	category = PluginCategory.ACTIVITY
 )
 @Slf4j
 public class ClueScrollPlugin extends Plugin

--- a/runelite-client/src/main/java/net/runelite/client/plugins/combatlevel/CombatLevelPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/combatlevel/CombatLevelPlugin.java
@@ -40,7 +40,7 @@ import net.runelite.client.plugins.PluginDescriptor;
 
 @PluginDescriptor(
 	name = "Combat Level",
-	category = PluginCategory.UTILITY
+	category = PluginCategory.COMBAT
 )
 public class CombatLevelPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/combatlevel/CombatLevelPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/combatlevel/CombatLevelPlugin.java
@@ -35,10 +35,12 @@ import net.runelite.api.events.GameTick;
 import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginCategory;
 import net.runelite.client.plugins.PluginDescriptor;
 
 @PluginDescriptor(
-	name = "Combat Level"
+	name = "Combat Level",
+	category = PluginCategory.UTILITY
 )
 public class CombatLevelPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
@@ -45,6 +45,7 @@ import java.util.Map;
 import java.util.TreeMap;
 import java.util.concurrent.ScheduledExecutorService;
 import javax.imageio.ImageIO;
+import javax.swing.BorderFactory;
 import javax.swing.ImageIcon;
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
@@ -249,8 +250,12 @@ public class ConfigPanel extends PluginPanel
 
 		for (PluginCategory c: PluginCategory.values())
 		{
-			final JLabel categoryLabel = new JLabel(c.toString(), SwingConstants.CENTER);
-			categoryLabel.setFont(FontManager.getRunescapeBoldFont());
+			final JLabel categoryLabel = new JLabel(c.toString(), SwingConstants.LEFT);
+			categoryLabel.setBorder(BorderFactory.createCompoundBorder(
+					BorderFactory.createEmptyBorder(c == PluginCategory.COMBAT ? 8 : 18, 0, 6, 0),
+					BorderFactory.createMatteBorder(0, 0, 2, 0, ColorScheme.BRAND_ORANGE_TRANSPARENT)));
+			categoryLabel.setFont(FontManager.getRunescapeBoldFont().deriveFont(32f));
+			categoryLabel.setForeground(ColorScheme.LIGHT_GRAY_COLOR);
 			map.put(c, categoryLabel);
 		}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
@@ -38,7 +38,9 @@ import java.awt.event.MouseEvent;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.concurrent.ScheduledExecutorService;
@@ -72,11 +74,13 @@ import net.runelite.client.config.ConfigItemDescriptor;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.config.RuneLiteConfig;
 import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginCategory;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.plugins.PluginInstantiationException;
 import net.runelite.client.plugins.PluginManager;
 import net.runelite.client.ui.ColorScheme;
 import net.runelite.client.ui.DynamicGridLayout;
+import net.runelite.client.ui.FontManager;
 import net.runelite.client.ui.PluginPanel;
 import net.runelite.client.ui.components.ComboBoxListRenderer;
 import net.runelite.client.ui.components.IconTextField;
@@ -116,6 +120,8 @@ public class ConfigPanel extends PluginPanel
 	private final RuneLiteConfig runeLiteConfig;
 	private final IconTextField searchBar = new IconTextField();
 	private Map<String, JPanel> children = new TreeMap<>();
+	private Map<PluginCategory, List<JPanel>> pluginMap = new TreeMap<>();
+	private Map<PluginCategory, JLabel> categoryLabels = new TreeMap<>();
 	private int scrollBarPosition = 0;
 
 	public ConfigPanel(PluginManager pluginManager, ConfigManager configManager, ScheduledExecutorService executorService, RuneLiteConfig runeLiteConfig)
@@ -164,34 +170,41 @@ public class ConfigPanel extends PluginPanel
 		scrollBarPosition = getScrollPane().getVerticalScrollBar().getValue();
 		Map<String, JPanel> newChildren = new TreeMap<>();
 
+		pluginMap = initPluginMap();
+		categoryLabels = initCategoryLabels();
+
 		pluginManager.getPlugins().stream()
-			.filter(plugin -> !plugin.getClass().getAnnotation(PluginDescriptor.class).hidden())
-			.sorted(Comparator.comparing(left -> left.getClass().getAnnotation(PluginDescriptor.class).name()))
-			.forEach(plugin ->
-			{
-				final Config pluginConfigProxy = pluginManager.getPluginConfigProxy(plugin);
-				final String pluginName = plugin.getClass().getAnnotation(PluginDescriptor.class).name();
+				.filter(plugin -> !plugin.getClass().getAnnotation(PluginDescriptor.class).hidden())
+				.sorted(Comparator.comparing(left -> left.getClass().getAnnotation(PluginDescriptor.class).name()))
+				.forEach(plugin ->
+				{
+					final PluginDescriptor pluginDescriptor = plugin.getClass().getAnnotation(PluginDescriptor.class);
+					final PluginCategory pluginCategory = pluginDescriptor.category();
 
-				final JPanel groupPanel = buildGroupPanel();
+					final Config pluginConfigProxy = pluginManager.getPluginConfigProxy(plugin);
+					final String pluginName = pluginDescriptor.name();
 
-				JLabel name = new JLabel(pluginName);
-				name.setForeground(Color.WHITE);
+					final JPanel groupPanel = buildGroupPanel();
 
-				groupPanel.add(name, BorderLayout.CENTER);
+					JLabel name = new JLabel(pluginName);
+					name.setForeground(Color.WHITE);
 
-				final JPanel buttonPanel = new JPanel();
-				buttonPanel.setLayout(new GridLayout(1, 2));
-				groupPanel.add(buttonPanel, BorderLayout.LINE_END);
+					groupPanel.add(name, BorderLayout.CENTER);
 
-				final JLabel editConfigButton = buildConfigButton(pluginConfigProxy);
-				buttonPanel.add(editConfigButton);
+					final JPanel buttonPanel = new JPanel();
+					buttonPanel.setLayout(new GridLayout(1, 2));
+					groupPanel.add(buttonPanel, BorderLayout.LINE_END);
 
-				final JLabel toggleButton = buildToggleButton(plugin);
-				toggleButton.setHorizontalAlignment(SwingConstants.RIGHT);
-				buttonPanel.add(toggleButton);
+					final JLabel editConfigButton = buildConfigButton(pluginConfigProxy);
+					buttonPanel.add(editConfigButton);
 
-				newChildren.put(pluginName, groupPanel);
-			});
+					final JLabel toggleButton = buildToggleButton(plugin);
+					toggleButton.setHorizontalAlignment(SwingConstants.RIGHT);
+					buttonPanel.add(toggleButton);
+
+					newChildren.put(pluginName, groupPanel);
+					pluginMap.get(pluginCategory).add(groupPanel);
+				});
 
 		final JPanel groupPanel = buildGroupPanel();
 
@@ -212,9 +225,36 @@ public class ConfigPanel extends PluginPanel
 		buttonPanel.add(toggleButton);
 
 		newChildren.put("RuneLite", groupPanel);
+		pluginMap.get(PluginCategory.CLIENT).add(groupPanel);
 
 		children = newChildren;
 		openConfigList();
+	}
+
+	private Map<PluginCategory, List<JPanel>> initPluginMap()
+	{
+		final Map<PluginCategory, List<JPanel>> map = new TreeMap<>();
+
+		for (PluginCategory c: PluginCategory.values())
+		{
+			map.put(c, new ArrayList<>());
+		}
+
+		return map;
+	}
+
+	private Map<PluginCategory, JLabel> initCategoryLabels()
+	{
+		final Map<PluginCategory, JLabel> map = new TreeMap<>();
+
+		for (PluginCategory c: PluginCategory.values())
+		{
+			final JLabel categoryLabel = new JLabel(c.toString(), SwingConstants.CENTER);
+			categoryLabel.setFont(FontManager.getRunescapeBoldFont());
+			map.put(c, categoryLabel);
+		}
+
+		return map;
 	}
 
 	private JPanel buildGroupPanel()
@@ -315,17 +355,48 @@ public class ConfigPanel extends PluginPanel
 	{
 		final String text = searchBar.getText();
 
-		children.values().forEach(this::remove);
+		pluginMap.values().forEach(l -> l.forEach(this::remove));
+		categoryLabels.values().forEach(this::remove);
 
 		if (text.isEmpty())
 		{
-			children.values().forEach(this::add);
+			addPluginsToPanel(pluginMap);
 			revalidate();
 			return;
 		}
 
-		FuzzySearch.findAndProcess(text, children.keySet(), (k) -> add(children.get(k)));
+		Map<PluginCategory, List<JPanel>> plugins = new TreeMap<>();
+
+		FuzzySearch.findAndProcess(text, children.keySet(), (k) ->
+		{
+			final JPanel pluginPanel = children.get(k);
+			final PluginCategory category = getPluginCategory(pluginPanel);
+
+			if (!plugins.keySet().contains(category))
+			{
+				plugins.put(category, new ArrayList<>());
+			}
+
+			plugins.get(category).add(pluginPanel);
+		});
+
+		addPluginsToPanel(plugins);
 		revalidate();
+	}
+
+	private void addPluginsToPanel(Map<PluginCategory, List<JPanel>> plugins)
+	{
+		plugins.keySet().forEach(category ->
+		{
+			add(categoryLabels.get(category));
+			plugins.get(category).forEach(this::add);
+		});
+	}
+
+	private PluginCategory getPluginCategory(JPanel pluginPanel)
+	{
+		return pluginMap.keySet().stream().filter(category ->
+				pluginMap.get(category).contains(pluginPanel)).findFirst().orElse(null);
 	}
 
 	@Override

--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPlugin.java
@@ -34,6 +34,7 @@ import net.runelite.client.config.ConfigManager;
 import net.runelite.client.config.RuneLiteConfig;
 import net.runelite.client.events.PluginChanged;
 import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginCategory;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.plugins.PluginManager;
 import net.runelite.client.ui.NavigationButton;
@@ -42,7 +43,8 @@ import net.runelite.client.ui.PluginToolbar;
 @PluginDescriptor(
 	name = "Configuration",
 	loadWhenOutdated = true,
-	hidden = true // prevent users from disabling
+	hidden = true, // prevent users from disabling
+	category = PluginCategory.CLIENT
 )
 public class ConfigPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/dailytaskindicators/DailyTasksPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/dailytaskindicators/DailyTasksPlugin.java
@@ -49,7 +49,7 @@ import net.runelite.client.plugins.PluginDescriptor;
 @PluginDescriptor(
 	name = "Daily Task Indicator",
 	enabledByDefault = false,
-	category = PluginCategory.UTILITY
+	category = PluginCategory.ACTIVITY
 )
 @Slf4j
 public class DailyTasksPlugin extends Plugin

--- a/runelite-client/src/main/java/net/runelite/client/plugins/dailytaskindicators/DailyTasksPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/dailytaskindicators/DailyTasksPlugin.java
@@ -43,11 +43,13 @@ import net.runelite.client.chat.ChatMessageManager;
 import net.runelite.client.chat.QueuedMessage;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginCategory;
 import net.runelite.client.plugins.PluginDescriptor;
 
 @PluginDescriptor(
 	name = "Daily Task Indicator",
-	enabledByDefault = false
+	enabledByDefault = false,
+	category = PluginCategory.UTILITY
 )
 @Slf4j
 public class DailyTasksPlugin extends Plugin

--- a/runelite-client/src/main/java/net/runelite/client/plugins/defaultworld/DefaultWorldPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/defaultworld/DefaultWorldPlugin.java
@@ -37,12 +37,16 @@ import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.SessionOpen;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginCategory;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.http.api.worlds.World;
 import net.runelite.http.api.worlds.WorldClient;
 import net.runelite.http.api.worlds.WorldResult;
 
-@PluginDescriptor(name = "Default World")
+@PluginDescriptor(
+	name = "Default World",
+	category = PluginCategory.OTHER
+)
 @Slf4j
 public class DefaultWorldPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/defaultworld/DefaultWorldPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/defaultworld/DefaultWorldPlugin.java
@@ -45,7 +45,7 @@ import net.runelite.http.api.worlds.WorldResult;
 
 @PluginDescriptor(
 	name = "Default World",
-	category = PluginCategory.OTHER
+	category = PluginCategory.CLIENT
 )
 @Slf4j
 public class DefaultWorldPlugin extends Plugin

--- a/runelite-client/src/main/java/net/runelite/client/plugins/demonicgorilla/DemonicGorillaPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/demonicgorilla/DemonicGorillaPlugin.java
@@ -56,11 +56,13 @@ import net.runelite.api.events.PlayerDespawned;
 import net.runelite.api.events.PlayerSpawned;
 import net.runelite.api.events.ProjectileMoved;
 import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginCategory;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.Overlay;
 
 @PluginDescriptor(
-	name = "Demonic Gorillas"
+	name = "Demonic Gorillas",
+	category = PluginCategory.COMBAT
 )
 @Slf4j
 public class DemonicGorillaPlugin extends Plugin

--- a/runelite-client/src/main/java/net/runelite/client/plugins/devtools/DevToolsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/devtools/DevToolsPlugin.java
@@ -48,6 +48,7 @@ import net.runelite.api.events.VarbitChanged;
 import net.runelite.api.widgets.Widget;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginCategory;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.FontManager;
 import net.runelite.client.ui.NavigationButton;
@@ -57,7 +58,8 @@ import org.slf4j.LoggerFactory;
 
 @PluginDescriptor(
 	name = "Developer Tools",
-	developerPlugin = true
+	developerPlugin = true,
+	category = PluginCategory.OTHER
 )
 @Slf4j
 public class DevToolsPlugin extends Plugin

--- a/runelite-client/src/main/java/net/runelite/client/plugins/devtools/DevToolsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/devtools/DevToolsPlugin.java
@@ -59,7 +59,7 @@ import org.slf4j.LoggerFactory;
 @PluginDescriptor(
 	name = "Developer Tools",
 	developerPlugin = true,
-	category = PluginCategory.OTHER
+	category = PluginCategory.CLIENT
 )
 @Slf4j
 public class DevToolsPlugin extends Plugin

--- a/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordPlugin.java
@@ -41,6 +41,7 @@ import net.runelite.client.RuneLiteProperties;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.discord.DiscordService;
 import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginCategory;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.task.Schedule;
 import net.runelite.client.ui.NavigationButton;
@@ -48,7 +49,8 @@ import net.runelite.client.ui.TitleToolbar;
 import net.runelite.client.util.LinkBrowser;
 
 @PluginDescriptor(
-	name = "Discord"
+	name = "Discord",
+	category = PluginCategory.OTHER
 )
 public class DiscordPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordPlugin.java
@@ -50,7 +50,7 @@ import net.runelite.client.util.LinkBrowser;
 
 @PluginDescriptor(
 	name = "Discord",
-	category = PluginCategory.OTHER
+	category = PluginCategory.CLIENT
 )
 public class DiscordPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/entityhider/EntityHiderPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/entityhider/EntityHiderPlugin.java
@@ -38,7 +38,7 @@ import net.runelite.client.plugins.PluginDescriptor;
 @PluginDescriptor(
 	name = "Entity Hider",
 	enabledByDefault = false,
-	category = PluginCategory.OTHER
+	category = PluginCategory.CLIENT
 )
 public class EntityHiderPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/entityhider/EntityHiderPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/entityhider/EntityHiderPlugin.java
@@ -32,11 +32,13 @@ import net.runelite.api.Client;
 import net.runelite.api.events.ConfigChanged;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginCategory;
 import net.runelite.client.plugins.PluginDescriptor;
 
 @PluginDescriptor(
 	name = "Entity Hider",
-	enabledByDefault = false
+	enabledByDefault = false,
+	category = PluginCategory.OTHER
 )
 public class EntityHiderPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/examine/ExaminePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/examine/ExaminePlugin.java
@@ -56,6 +56,7 @@ import net.runelite.client.chat.QueuedMessage;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginCategory;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.util.StackFormatter;
 import net.runelite.http.api.examine.ExamineClient;
@@ -67,7 +68,8 @@ import net.runelite.http.api.item.ItemPrice;
  * @author Adam
  */
 @PluginDescriptor(
-	name = "Examine"
+	name = "Examine",
+	category = PluginCategory.OTHER
 )
 @Slf4j
 public class ExaminePlugin extends Plugin

--- a/runelite-client/src/main/java/net/runelite/client/plugins/examine/ExaminePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/examine/ExaminePlugin.java
@@ -69,7 +69,7 @@ import net.runelite.http.api.item.ItemPrice;
  */
 @PluginDescriptor(
 	name = "Examine",
-	category = PluginCategory.OTHER
+	category = PluginCategory.UTILITY
 )
 @Slf4j
 public class ExaminePlugin extends Plugin

--- a/runelite-client/src/main/java/net/runelite/client/plugins/examine/ExaminePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/examine/ExaminePlugin.java
@@ -69,7 +69,7 @@ import net.runelite.http.api.item.ItemPrice;
  */
 @PluginDescriptor(
 	name = "Examine",
-	category = PluginCategory.UTILITY
+	category = PluginCategory.ITEM
 )
 @Slf4j
 public class ExaminePlugin extends Plugin

--- a/runelite-client/src/main/java/net/runelite/client/plugins/experiencedrop/XpDropPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/experiencedrop/XpDropPlugin.java
@@ -38,10 +38,12 @@ import net.runelite.api.widgets.WidgetID;
 import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginCategory;
 import net.runelite.client.plugins.PluginDescriptor;
 
 @PluginDescriptor(
-	name = "XP Drop"
+	name = "XP Drop",
+	category = PluginCategory.UTILITY
 )
 public class XpDropPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/fairyring/FairyRingPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/fairyring/FairyRingPlugin.java
@@ -36,10 +36,12 @@ import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetID;
 import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginCategory;
 import net.runelite.client.plugins.PluginDescriptor;
 
 @PluginDescriptor(
-	name = "Fairy Ring Helper"
+	name = "Fairy Ring Helper",
+	category = PluginCategory.UTILITY
 )
 public class FairyRingPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/farmingtracker/FarmingTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/farmingtracker/FarmingTrackerPlugin.java
@@ -42,13 +42,15 @@ import net.runelite.api.events.UsernameChanged;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginCategory;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.task.Schedule;
 import net.runelite.client.ui.NavigationButton;
 import net.runelite.client.ui.PluginToolbar;
 
 @PluginDescriptor(
-	name = "Farming Tracker"
+	name = "Farming Tracker",
+	category = PluginCategory.SKILLING
 )
 @Slf4j
 public class FarmingTrackerPlugin extends Plugin

--- a/runelite-client/src/main/java/net/runelite/client/plugins/farmingtracker/FarmingTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/farmingtracker/FarmingTrackerPlugin.java
@@ -50,7 +50,7 @@ import net.runelite.client.ui.PluginToolbar;
 
 @PluginDescriptor(
 	name = "Farming Tracker",
-	category = PluginCategory.SKILLING
+	category = PluginCategory.SKILLS
 )
 @Slf4j
 public class FarmingTrackerPlugin extends Plugin

--- a/runelite-client/src/main/java/net/runelite/client/plugins/feed/FeedPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/feed/FeedPlugin.java
@@ -39,6 +39,7 @@ import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.events.ConfigChanged;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginCategory;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.task.Schedule;
 import net.runelite.client.ui.NavigationButton;
@@ -48,7 +49,8 @@ import net.runelite.http.api.feed.FeedResult;
 
 @PluginDescriptor(
 	name = "News Feed",
-	loadWhenOutdated = true
+	loadWhenOutdated = true,
+	category = PluginCategory.OTHER
 )
 @Slf4j
 public class FeedPlugin extends Plugin

--- a/runelite-client/src/main/java/net/runelite/client/plugins/feed/FeedPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/feed/FeedPlugin.java
@@ -50,7 +50,7 @@ import net.runelite.http.api.feed.FeedResult;
 @PluginDescriptor(
 	name = "News Feed",
 	loadWhenOutdated = true,
-	category = PluginCategory.OTHER
+	category = PluginCategory.CLIENT
 )
 @Slf4j
 public class FeedPlugin extends Plugin

--- a/runelite-client/src/main/java/net/runelite/client/plugins/fightcave/FightCavePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/fightcave/FightCavePlugin.java
@@ -40,7 +40,7 @@ import net.runelite.client.util.QueryRunner;
 
 @PluginDescriptor(
 	name = "Fight Cave",
-	category = PluginCategory.COMBAT
+	category = PluginCategory.MINIGAME
 )
 public class FightCavePlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/fightcave/FightCavePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/fightcave/FightCavePlugin.java
@@ -32,13 +32,15 @@ import net.runelite.api.NPC;
 import net.runelite.api.Query;
 import net.runelite.api.queries.NPCQuery;
 import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginCategory;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.task.Schedule;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.util.QueryRunner;
 
 @PluginDescriptor(
-	name = "Fight Cave"
+	name = "Fight Cave",
+	category = PluginCategory.COMBAT
 )
 public class FightCavePlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingPlugin.java
@@ -47,6 +47,7 @@ import net.runelite.api.events.GameTick;
 import net.runelite.api.queries.NPCQuery;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginCategory;
 import net.runelite.client.plugins.PluginDependency;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.plugins.xptracker.XpTrackerPlugin;
@@ -54,7 +55,8 @@ import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.util.QueryRunner;
 
 @PluginDescriptor(
-	name = "Fishing"
+	name = "Fishing",
+	category = PluginCategory.SKILLING
 )
 @PluginDependency(XpTrackerPlugin.class)
 @Singleton

--- a/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingPlugin.java
@@ -56,7 +56,7 @@ import net.runelite.client.util.QueryRunner;
 
 @PluginDescriptor(
 	name = "Fishing",
-	category = PluginCategory.SKILLING
+	category = PluginCategory.SKILLS
 )
 @PluginDependency(XpTrackerPlugin.class)
 @Singleton

--- a/runelite-client/src/main/java/net/runelite/client/plugins/fps/FpsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/fps/FpsPlugin.java
@@ -49,7 +49,7 @@ import net.runelite.client.ui.overlay.Overlay;
 @PluginDescriptor(
 	name = "FPS Control",
 	enabledByDefault = false,
-	category = PluginCategory.OTHER
+	category = PluginCategory.CLIENT
 )
 public class FpsPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/fps/FpsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/fps/FpsPlugin.java
@@ -31,6 +31,7 @@ import net.runelite.api.events.ConfigChanged;
 import net.runelite.api.events.FocusChanged;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginCategory;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.DrawManager;
 import net.runelite.client.ui.overlay.Overlay;
@@ -47,7 +48,8 @@ import net.runelite.client.ui.overlay.Overlay;
  */
 @PluginDescriptor(
 	name = "FPS Control",
-	enabledByDefault = false
+	enabledByDefault = false,
+	category = PluginCategory.OTHER
 )
 public class FpsPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/friendnotes/FriendNotesPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/friendnotes/FriendNotesPlugin.java
@@ -47,12 +47,16 @@ import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.game.ChatboxInputManager;
 import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginCategory;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.util.Text;
 
 @Slf4j
-@PluginDescriptor(name = "Friend Notes")
+@PluginDescriptor(
+	name = "Friend Notes",
+	category = PluginCategory.UTILITY
+)
 public class FriendNotesPlugin extends Plugin
 {
 	private static final String CONFIG_GROUP = "friendNotes";

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangePlugin.java
@@ -61,7 +61,7 @@ import net.runelite.client.ui.PluginToolbar;
 
 @PluginDescriptor(
 	name = "Grand Exchange",
-	category = PluginCategory.UTILITY
+	category = PluginCategory.CLIENT
 )
 public class GrandExchangePlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangePlugin.java
@@ -54,12 +54,14 @@ import net.runelite.client.game.ItemManager;
 import net.runelite.client.input.KeyManager;
 import net.runelite.client.input.MouseManager;
 import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginCategory;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.NavigationButton;
 import net.runelite.client.ui.PluginToolbar;
 
 @PluginDescriptor(
-	name = "Grand Exchange"
+	name = "Grand Exchange",
+	category = PluginCategory.UTILITY
 )
 public class GrandExchangePlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
@@ -74,6 +74,7 @@ import net.runelite.client.game.ItemManager;
 import net.runelite.client.input.KeyManager;
 import net.runelite.client.input.MouseManager;
 import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginCategory;
 import net.runelite.client.plugins.PluginDescriptor;
 import static net.runelite.client.plugins.grounditems.config.ItemHighlightMode.OVERLAY;
 import net.runelite.client.plugins.grounditems.config.MenuHighlightMode;
@@ -84,7 +85,8 @@ import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.http.api.item.ItemPrice;
 
 @PluginDescriptor(
-	name = "Ground Items"
+	name = "Ground Items",
+	category = PluginCategory.UTILITY
 )
 @Slf4j
 public class GroundItemsPlugin extends Plugin

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
@@ -86,7 +86,7 @@ import net.runelite.http.api.item.ItemPrice;
 
 @PluginDescriptor(
 	name = "Ground Items",
-	category = PluginCategory.UTILITY
+	category = PluginCategory.ITEM
 )
 @Slf4j
 public class GroundItemsPlugin extends Plugin

--- a/runelite-client/src/main/java/net/runelite/client/plugins/groundmarkers/GroundMarkerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/groundmarkers/GroundMarkerPlugin.java
@@ -55,11 +55,13 @@ import net.runelite.api.events.MenuOptionClicked;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.input.KeyManager;
 import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginCategory;
 import net.runelite.client.plugins.PluginDescriptor;
 
 @Slf4j
 @PluginDescriptor(
-	name = "Ground Markers"
+	name = "Ground Markers",
+	category = PluginCategory.UTILITY
 )
 public class GroundMarkerPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/herbiboars/HerbiboarPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/herbiboars/HerbiboarPlugin.java
@@ -64,7 +64,7 @@ import net.runelite.client.ui.overlay.Overlay;
 @Slf4j
 @PluginDescriptor(
 	name = "Herbiboar",
-	category = PluginCategory.SKILLING
+	category = PluginCategory.SKILLS
 )
 public class HerbiboarPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/herbiboars/HerbiboarPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/herbiboars/HerbiboarPlugin.java
@@ -57,12 +57,14 @@ import net.runelite.api.events.GroundObjectSpawned;
 import net.runelite.api.events.VarbitChanged;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginCategory;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.Overlay;
 
 @Slf4j
 @PluginDescriptor(
-	name = "Herbiboar"
+	name = "Herbiboar",
+	category = PluginCategory.SKILLING
 )
 public class HerbiboarPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/hiscore/HiscorePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/hiscore/HiscorePlugin.java
@@ -55,7 +55,7 @@ import org.apache.commons.lang3.ArrayUtils;
 @PluginDescriptor(
 	name = "HiScore",
 	loadWhenOutdated = true,
-	category = PluginCategory.OTHER
+	category = PluginCategory.CLIENT
 )
 public class HiscorePlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/hiscore/HiscorePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/hiscore/HiscorePlugin.java
@@ -45,6 +45,7 @@ import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.menus.MenuManager;
 import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginCategory;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.NavigationButton;
 import net.runelite.client.ui.PluginToolbar;
@@ -53,7 +54,8 @@ import org.apache.commons.lang3.ArrayUtils;
 
 @PluginDescriptor(
 	name = "HiScore",
-	loadWhenOutdated = true
+	loadWhenOutdated = true,
+	category = PluginCategory.OTHER
 )
 public class HiscorePlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/hunter/HunterPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/hunter/HunterPlugin.java
@@ -54,7 +54,7 @@ import net.runelite.client.util.QueryRunner;
 @Slf4j
 @PluginDescriptor(
 	name = "Hunter",
-	category = PluginCategory.SKILLING
+	category = PluginCategory.SKILLS
 )
 public class HunterPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/hunter/HunterPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/hunter/HunterPlugin.java
@@ -47,12 +47,14 @@ import net.runelite.api.events.GameTick;
 import net.runelite.client.Notifier;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginCategory;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.util.QueryRunner;
 
 @Slf4j
 @PluginDescriptor(
-	name = "Hunter"
+	name = "Hunter",
+	category = PluginCategory.SKILLING
 )
 public class HunterPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
@@ -48,7 +48,7 @@ import net.runelite.client.plugins.PluginDescriptor;
 
 @PluginDescriptor(
 	name = "Idle Notifier",
-	category = PluginCategory.UTILITY
+	category = PluginCategory.CLIENT
 )
 public class IdleNotifierPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
@@ -43,10 +43,12 @@ import net.runelite.api.events.GameTick;
 import net.runelite.client.Notifier;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginCategory;
 import net.runelite.client.plugins.PluginDescriptor;
 
 @PluginDescriptor(
-	name = "Idle Notifier"
+	name = "Idle Notifier",
+	category = PluginCategory.UTILITY
 )
 public class IdleNotifierPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/implings/ImplingsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/implings/ImplingsPlugin.java
@@ -51,7 +51,7 @@ import net.runelite.client.util.QueryRunner;
  */
 @PluginDescriptor(
 	name = "Implings",
-	category = PluginCategory.UTILITY
+	category = PluginCategory.ACTIVITY
 )
 public class ImplingsPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/implings/ImplingsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/implings/ImplingsPlugin.java
@@ -51,7 +51,7 @@ import net.runelite.client.util.QueryRunner;
  */
 @PluginDescriptor(
 	name = "Implings",
-	category = PluginCategory.ACTIVITY
+	category = PluginCategory.MINIGAME
 )
 public class ImplingsPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/implings/ImplingsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/implings/ImplingsPlugin.java
@@ -41,6 +41,7 @@ import net.runelite.api.events.NpcDespawned;
 import net.runelite.api.events.NpcSpawned;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginCategory;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.util.QueryRunner;
@@ -49,7 +50,8 @@ import net.runelite.client.util.QueryRunner;
  * @author robin
  */
 @PluginDescriptor(
-	name = "Implings"
+	name = "Implings",
+	category = PluginCategory.UTILITY
 )
 public class ImplingsPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/info/InfoPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/info/InfoPlugin.java
@@ -28,13 +28,15 @@ import java.awt.image.BufferedImage;
 import javax.imageio.ImageIO;
 import javax.inject.Inject;
 import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginCategory;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.NavigationButton;
 import net.runelite.client.ui.PluginToolbar;
 
 @PluginDescriptor(
 	name = "Info Panel",
-	loadWhenOutdated = true
+	loadWhenOutdated = true,
+	category = PluginCategory.OTHER
 )
 public class InfoPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/info/InfoPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/info/InfoPlugin.java
@@ -36,7 +36,7 @@ import net.runelite.client.ui.PluginToolbar;
 @PluginDescriptor(
 	name = "Info Panel",
 	loadWhenOutdated = true,
-	category = PluginCategory.OTHER
+	category = PluginCategory.CLIENT
 )
 public class InfoPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/instancemap/InstanceMapPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/instancemap/InstanceMapPlugin.java
@@ -43,7 +43,7 @@ import net.runelite.client.ui.overlay.Overlay;
 
 @PluginDescriptor(
 	name = "Instance Map",
-	category = PluginCategory.OTHER
+	category = PluginCategory.CLIENT
 )
 public class InstanceMapPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/instancemap/InstanceMapPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/instancemap/InstanceMapPlugin.java
@@ -37,11 +37,13 @@ import net.runelite.client.input.MouseManager;
 import net.runelite.client.menus.MenuManager;
 import net.runelite.client.menus.WidgetMenuOption;
 import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginCategory;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.Overlay;
 
 @PluginDescriptor(
-	name = "Instance Map"
+	name = "Instance Map",
+	category = PluginCategory.OTHER
 )
 public class InstanceMapPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/interfacestyles/InterfaceStylesPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/interfacestyles/InterfaceStylesPlugin.java
@@ -47,12 +47,14 @@ import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.game.SpriteManager;
 import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginCategory;
 import net.runelite.client.plugins.PluginDescriptor;
 
 @Slf4j
 @PluginDescriptor(
 	name = "Interface Styles",
-	enabledByDefault = false
+	enabledByDefault = false,
+	category = PluginCategory.CLIENT
 )
 public class InterfaceStylesPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemprices/ItemPricesPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemprices/ItemPricesPlugin.java
@@ -28,12 +28,14 @@ import com.google.inject.Provides;
 import javax.inject.Inject;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginCategory;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.Overlay;
 
 @PluginDescriptor(
 	name = "Item Prices",
-	enabledByDefault = false
+	enabledByDefault = false,
+	category = PluginCategory.UTILITY
 )
 public class ItemPricesPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemprices/ItemPricesPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemprices/ItemPricesPlugin.java
@@ -35,7 +35,7 @@ import net.runelite.client.ui.overlay.Overlay;
 @PluginDescriptor(
 	name = "Item Prices",
 	enabledByDefault = false,
-	category = PluginCategory.UTILITY
+	category = PluginCategory.ITEM
 )
 public class ItemPricesPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatPlugin.java
@@ -34,7 +34,7 @@ import net.runelite.client.ui.overlay.Overlay;
 
 @PluginDescriptor(
 	name = "Item Stats",
-	category = PluginCategory.UTILITY
+	category = PluginCategory.ITEM
 )
 public class ItemStatPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatPlugin.java
@@ -28,11 +28,13 @@ import com.google.inject.Inject;
 import com.google.inject.Provides;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginCategory;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.Overlay;
 
 @PluginDescriptor(
-	name = "Item Stats"
+	name = "Item Stats",
+	category = PluginCategory.UTILITY
 )
 public class ItemStatPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/jewellerycount/JewelleryCountPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/jewellerycount/JewelleryCountPlugin.java
@@ -31,7 +31,6 @@ import net.runelite.client.plugins.PluginCategory;
 import net.runelite.client.ui.overlay.Overlay;
 import com.google.common.eventbus.Subscribe;
 import com.google.inject.Provides;
-import javax.inject.Inject;
 import net.runelite.api.events.ChatMessage;
 import net.runelite.client.Notifier;
 import net.runelite.client.config.ConfigManager;
@@ -39,7 +38,7 @@ import net.runelite.client.plugins.PluginDescriptor;
 
 @PluginDescriptor(
 	name = "Jewellery Count",
-	category = PluginCategory.UTILITY
+	category = PluginCategory.ITEM
 )
 public class JewelleryCountPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/jewellerycount/JewelleryCountPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/jewellerycount/JewelleryCountPlugin.java
@@ -27,6 +27,7 @@ package net.runelite.client.plugins.jewellerycount;
 import javax.inject.Inject;
 import net.runelite.api.ChatMessageType;
 import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginCategory;
 import net.runelite.client.ui.overlay.Overlay;
 import com.google.common.eventbus.Subscribe;
 import com.google.inject.Provides;
@@ -37,7 +38,8 @@ import net.runelite.client.config.ConfigManager;
 import net.runelite.client.plugins.PluginDescriptor;
 
 @PluginDescriptor(
-	name = "Jewellery Count"
+	name = "Jewellery Count",
+	category = PluginCategory.UTILITY
 )
 public class JewelleryCountPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/kingdomofmiscellania/KingdomPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/kingdomofmiscellania/KingdomPlugin.java
@@ -44,7 +44,7 @@ import net.runelite.client.ui.overlay.infobox.InfoBoxManager;
 @PluginDescriptor(
 	name = "Kingdom of Miscellania",
 	enabledByDefault = false,
-	category = PluginCategory.UTILITY
+	category = PluginCategory.ACTIVITY
 )
 @Slf4j
 public class KingdomPlugin extends Plugin

--- a/runelite-client/src/main/java/net/runelite/client/plugins/kingdomofmiscellania/KingdomPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/kingdomofmiscellania/KingdomPlugin.java
@@ -37,12 +37,14 @@ import net.runelite.api.Varbits;
 import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.VarbitChanged;
 import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginCategory;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.infobox.InfoBoxManager;
 
 @PluginDescriptor(
 	name = "Kingdom of Miscellania",
-	enabledByDefault = false
+	enabledByDefault = false,
+	category = PluginCategory.UTILITY
 )
 @Slf4j
 public class KingdomPlugin extends Plugin

--- a/runelite-client/src/main/java/net/runelite/client/plugins/kourendlibrary/KourendLibraryPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/kourendlibrary/KourendLibraryPlugin.java
@@ -52,7 +52,7 @@ import net.runelite.client.ui.overlay.Overlay;
 
 @PluginDescriptor(
 	name = "Kourend Library",
-	category = PluginCategory.ACTIVITY
+	category = PluginCategory.MINIGAME
 )
 @Slf4j
 public class KourendLibraryPlugin extends Plugin

--- a/runelite-client/src/main/java/net/runelite/client/plugins/kourendlibrary/KourendLibraryPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/kourendlibrary/KourendLibraryPlugin.java
@@ -52,7 +52,7 @@ import net.runelite.client.ui.overlay.Overlay;
 
 @PluginDescriptor(
 	name = "Kourend Library",
-	category = PluginCategory.UTILITY
+	category = PluginCategory.ACTIVITY
 )
 @Slf4j
 public class KourendLibraryPlugin extends Plugin

--- a/runelite-client/src/main/java/net/runelite/client/plugins/kourendlibrary/KourendLibraryPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/kourendlibrary/KourendLibraryPlugin.java
@@ -44,13 +44,15 @@ import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginCategory;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.NavigationButton;
 import net.runelite.client.ui.PluginToolbar;
 import net.runelite.client.ui.overlay.Overlay;
 
 @PluginDescriptor(
-	name = "Kourend Library"
+	name = "Kourend Library",
+	category = PluginCategory.UTILITY
 )
 @Slf4j
 public class KourendLibraryPlugin extends Plugin

--- a/runelite-client/src/main/java/net/runelite/client/plugins/lowmemory/LowMemoryPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/lowmemory/LowMemoryPlugin.java
@@ -30,11 +30,13 @@ import net.runelite.api.Client;
 import net.runelite.api.GameState;
 import net.runelite.api.events.GameStateChanged;
 import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginCategory;
 import net.runelite.client.plugins.PluginDescriptor;
 
 @PluginDescriptor(
 	name = "Low Detail",
-	enabledByDefault = false
+	enabledByDefault = false,
+	category = PluginCategory.OTHER
 )
 public class LowMemoryPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/lowmemory/LowMemoryPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/lowmemory/LowMemoryPlugin.java
@@ -36,7 +36,7 @@ import net.runelite.client.plugins.PluginDescriptor;
 @PluginDescriptor(
 	name = "Low Detail",
 	enabledByDefault = false,
-	category = PluginCategory.OTHER
+	category = PluginCategory.CLIENT
 )
 public class LowMemoryPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -59,7 +59,7 @@ import org.apache.commons.lang3.ArrayUtils;
 @PluginDescriptor(
 	name = "Menu Entry Swapper",
 	enabledByDefault = false,
-	category = PluginCategory.UTILITY
+	category = PluginCategory.CLIENT
 )
 public class MenuEntrySwapperPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -51,13 +51,15 @@ import net.runelite.client.input.KeyManager;
 import net.runelite.client.menus.MenuManager;
 import net.runelite.client.menus.WidgetMenuOption;
 import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginCategory;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.util.Text;
 import org.apache.commons.lang3.ArrayUtils;
 
 @PluginDescriptor(
 	name = "Menu Entry Swapper",
-	enabledByDefault = false
+	enabledByDefault = false,
+	category = PluginCategory.UTILITY
 )
 public class MenuEntrySwapperPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -59,7 +59,7 @@ import org.apache.commons.lang3.ArrayUtils;
 @PluginDescriptor(
 	name = "Menu Entry Swapper",
 	enabledByDefault = false,
-	category = PluginCategory.CLIENT
+	category = PluginCategory.UTILITY
 )
 public class MenuEntrySwapperPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/metronome/MetronomePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/metronome/MetronomePlugin.java
@@ -33,11 +33,13 @@ import net.runelite.api.SoundEffectID;
 import net.runelite.api.events.GameTick;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginCategory;
 import net.runelite.client.plugins.PluginDescriptor;
 
 @PluginDescriptor(
 	name = "Metronome",
-	enabledByDefault = false
+	enabledByDefault = false,
+	category = PluginCategory.UTILITY
 )
 public class MetronomePlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/minimap/MinimapPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/minimap/MinimapPlugin.java
@@ -44,7 +44,7 @@ import net.runelite.client.plugins.PluginDescriptor;
 
 @PluginDescriptor(
 	name = "Minimap",
-	category = PluginCategory.OTHER
+	category = PluginCategory.UTILITY
 )
 public class MinimapPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/minimap/MinimapPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/minimap/MinimapPlugin.java
@@ -39,10 +39,12 @@ import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginCategory;
 import net.runelite.client.plugins.PluginDescriptor;
 
 @PluginDescriptor(
-	name = "Minimap"
+	name = "Minimap",
+	category = PluginCategory.OTHER
 )
 public class MinimapPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/motherlode/MotherlodePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/motherlode/MotherlodePlugin.java
@@ -69,13 +69,15 @@ import net.runelite.api.events.WallObjectDespawned;
 import net.runelite.api.events.WallObjectSpawned;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginCategory;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.task.Schedule;
 import net.runelite.client.ui.overlay.Overlay;
 
 @PluginDescriptor(
 	name = "Motherlode Mine",
-	enabledByDefault = false
+	enabledByDefault = false,
+	category = PluginCategory.SKILLING
 )
 public class MotherlodePlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/motherlode/MotherlodePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/motherlode/MotherlodePlugin.java
@@ -77,7 +77,7 @@ import net.runelite.client.ui.overlay.Overlay;
 @PluginDescriptor(
 	name = "Motherlode Mine",
 	enabledByDefault = false,
-	category = PluginCategory.SKILLING
+	category = PluginCategory.SKILLS
 )
 public class MotherlodePlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/mousehighlight/MouseHighlightPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/mousehighlight/MouseHighlightPlugin.java
@@ -34,7 +34,7 @@ import net.runelite.client.ui.overlay.Overlay;
 
 @PluginDescriptor(
 	name = "Mouse Tooltips",
-	category = PluginCategory.UTILITY
+	category = PluginCategory.CLIENT
 )
 public class MouseHighlightPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/mousehighlight/MouseHighlightPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/mousehighlight/MouseHighlightPlugin.java
@@ -28,11 +28,13 @@ import com.google.inject.Provides;
 import javax.inject.Inject;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginCategory;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.Overlay;
 
 @PluginDescriptor(
-	name = "Mouse Tooltips"
+	name = "Mouse Tooltips",
+	category = PluginCategory.UTILITY
 )
 public class MouseHighlightPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/nightmarezone/NightmareZonePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/nightmarezone/NightmareZonePlugin.java
@@ -37,12 +37,14 @@ import net.runelite.api.events.GameTick;
 import net.runelite.client.Notifier;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginCategory;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.util.Text;
 
 @PluginDescriptor(
-	name = "Nightmare Zone"
+	name = "Nightmare Zone",
+	category = PluginCategory.COMBAT
 )
 public class NightmareZonePlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/nightmarezone/NightmareZonePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/nightmarezone/NightmareZonePlugin.java
@@ -44,7 +44,7 @@ import net.runelite.client.util.Text;
 
 @PluginDescriptor(
 	name = "Nightmare Zone",
-	category = PluginCategory.COMBAT
+	category = PluginCategory.MINIGAME
 )
 public class NightmareZonePlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/notes/NotesPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/notes/NotesPlugin.java
@@ -33,13 +33,15 @@ import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.events.SessionOpen;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginCategory;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.NavigationButton;
 import net.runelite.client.ui.PluginToolbar;
 
 @PluginDescriptor(
 	name = "Notes",
-	loadWhenOutdated = true
+	loadWhenOutdated = true,
+	category = PluginCategory.OTHER
 )
 @Slf4j
 public class NotesPlugin extends Plugin

--- a/runelite-client/src/main/java/net/runelite/client/plugins/notes/NotesPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/notes/NotesPlugin.java
@@ -41,7 +41,7 @@ import net.runelite.client.ui.PluginToolbar;
 @PluginDescriptor(
 	name = "Notes",
 	loadWhenOutdated = true,
-	category = PluginCategory.OTHER
+	category = PluginCategory.CLIENT
 )
 @Slf4j
 public class NotesPlugin extends Plugin

--- a/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsPlugin.java
@@ -50,11 +50,15 @@ import net.runelite.client.config.ConfigManager;
 import net.runelite.client.input.KeyManager;
 import net.runelite.client.menus.MenuManager;
 import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginCategory;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.util.WildcardMatcher;
 
-@PluginDescriptor(name = "NPC Indicators")
+@PluginDescriptor(
+	name = "NPC Indicators",
+	category = PluginCategory.UTILITY
+)
 public class NpcIndicatorsPlugin extends Plugin
 {
 	// Option added to NPC menu

--- a/runelite-client/src/main/java/net/runelite/client/plugins/opponentinfo/OpponentInfoPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/opponentinfo/OpponentInfoPlugin.java
@@ -47,7 +47,7 @@ import net.runelite.http.api.hiscore.HiscoreEndpoint;
 
 @PluginDescriptor(
 	name = "Opponent Information",
-	category = PluginCategory.UTILITY
+	category = PluginCategory.COMBAT
 )
 public class OpponentInfoPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/opponentinfo/OpponentInfoPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/opponentinfo/OpponentInfoPlugin.java
@@ -40,12 +40,14 @@ import net.runelite.api.GameState;
 import net.runelite.api.WorldType;
 import net.runelite.api.events.GameStateChanged;
 import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginCategory;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.http.api.hiscore.HiscoreEndpoint;
 
 @PluginDescriptor(
-	name = "Opponent Information"
+	name = "Opponent Information",
+	category = PluginCategory.UTILITY
 )
 public class OpponentInfoPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/pestcontrol/PestControlPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/pestcontrol/PestControlPlugin.java
@@ -32,7 +32,7 @@ import net.runelite.client.ui.overlay.Overlay;
 
 @PluginDescriptor(
 	name = "Pest Control",
-	category = PluginCategory.COMBAT
+	category = PluginCategory.MINIGAME
 )
 public class PestControlPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/pestcontrol/PestControlPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/pestcontrol/PestControlPlugin.java
@@ -26,11 +26,13 @@ package net.runelite.client.plugins.pestcontrol;
 
 import javax.inject.Inject;
 import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginCategory;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.Overlay;
 
 @PluginDescriptor(
-	name = "Pest Control"
+	name = "Pest Control",
+	category = PluginCategory.COMBAT
 )
 public class PestControlPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsPlugin.java
@@ -51,11 +51,13 @@ import net.runelite.api.events.MenuEntryAdded;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.game.ClanManager;
 import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginCategory;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.Overlay;
 
 @PluginDescriptor(
-	name = "Player Indicators"
+	name = "Player Indicators",
+	category = PluginCategory.OTHER
 )
 public class PlayerIndicatorsPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsPlugin.java
@@ -57,7 +57,7 @@ import net.runelite.client.ui.overlay.Overlay;
 
 @PluginDescriptor(
 	name = "Player Indicators",
-	category = PluginCategory.OTHER
+	category = PluginCategory.UTILITY
 )
 public class PlayerIndicatorsPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/poh/PohPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/poh/PohPlugin.java
@@ -54,11 +54,13 @@ import net.runelite.api.events.GameObjectSpawned;
 import net.runelite.api.events.GameStateChanged;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginCategory;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.Overlay;
 
 @PluginDescriptor(
-	name = "Player-owned House"
+	name = "Player-owned House",
+	category = PluginCategory.UTILITY
 )
 public class PohPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/prayflick/PrayerFlickPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/prayflick/PrayerFlickPlugin.java
@@ -28,11 +28,13 @@ import com.google.common.eventbus.Subscribe;
 import javax.inject.Inject;
 import net.runelite.api.events.GameTick;
 import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginCategory;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.Overlay;
 
 @PluginDescriptor(
-	name = "Prayer Flicking"
+	name = "Prayer Flicking",
+	category = PluginCategory.COMBAT
 )
 public class PrayerFlickPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/puzzlesolver/PuzzleSolverPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/puzzlesolver/PuzzleSolverPlugin.java
@@ -30,10 +30,12 @@ import java.util.concurrent.ScheduledExecutorService;
 import javax.inject.Inject;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginCategory;
 import net.runelite.client.plugins.PluginDescriptor;
 
 @PluginDescriptor(
-	name = "Puzzle Solver"
+	name = "Puzzle Solver",
+	category = PluginCategory.UTILITY
 )
 public class PuzzleSolverPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/puzzlesolver/PuzzleSolverPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/puzzlesolver/PuzzleSolverPlugin.java
@@ -35,7 +35,7 @@ import net.runelite.client.plugins.PluginDescriptor;
 
 @PluginDescriptor(
 	name = "Puzzle Solver",
-	category = PluginCategory.UTILITY
+	category = PluginCategory.ACTIVITY
 )
 public class PuzzleSolverPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsPlugin.java
@@ -64,6 +64,7 @@ import net.runelite.client.chat.ChatMessageManager;
 import net.runelite.client.chat.QueuedMessage;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginCategory;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.plugins.raids.solver.Layout;
 import net.runelite.client.plugins.raids.solver.LayoutSolver;
@@ -73,7 +74,8 @@ import net.runelite.client.ui.overlay.infobox.InfoBoxManager;
 import net.runelite.client.util.Text;
 
 @PluginDescriptor(
-	name = "Chambers Of Xeric"
+	name = "Chambers Of Xeric",
+	category = PluginCategory.COMBAT
 )
 @Slf4j
 public class RaidsPlugin extends Plugin

--- a/runelite-client/src/main/java/net/runelite/client/plugins/regenmeter/RegenMeterPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/regenmeter/RegenMeterPlugin.java
@@ -40,10 +40,14 @@ import net.runelite.api.events.GameTick;
 import net.runelite.api.events.VarbitChanged;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginCategory;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.Overlay;
 
-@PluginDescriptor(name = "Regeneration Meter")
+@PluginDescriptor(
+	name = "Regeneration Meter",
+	category = PluginCategory.UTILITY
+)
 public class RegenMeterPlugin extends Plugin
 {
 	private static final int SPEC_REGEN_TICKS = 50;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/reorderprayers/ReorderPrayersPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/reorderprayers/ReorderPrayersPlugin.java
@@ -53,10 +53,14 @@ import net.runelite.client.config.ConfigManager;
 import net.runelite.client.menus.MenuManager;
 import net.runelite.client.menus.WidgetMenuOption;
 import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginCategory;
 import net.runelite.client.plugins.PluginDescriptor;
 
 @Slf4j
-@PluginDescriptor(name = "Reorder Prayers")
+@PluginDescriptor(
+	name = "Reorder Prayers",
+	category = PluginCategory.UTILITY
+)
 public class ReorderPrayersPlugin extends Plugin
 {
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/reportbutton/ReportButtonPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/reportbutton/ReportButtonPlugin.java
@@ -43,11 +43,13 @@ import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.callback.ClientThread;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginCategory;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.task.Schedule;
 
 @PluginDescriptor(
-	name = "Report Button"
+	name = "Report Button",
+	category = PluginCategory.OTHER
 )
 @Slf4j
 public class ReportButtonPlugin extends Plugin

--- a/runelite-client/src/main/java/net/runelite/client/plugins/reportbutton/ReportButtonPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/reportbutton/ReportButtonPlugin.java
@@ -49,7 +49,7 @@ import net.runelite.client.task.Schedule;
 
 @PluginDescriptor(
 	name = "Report Button",
-	category = PluginCategory.OTHER
+	category = PluginCategory.CLIENT
 )
 @Slf4j
 public class ReportButtonPlugin extends Plugin

--- a/runelite-client/src/main/java/net/runelite/client/plugins/roguesden/RoguesDenPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/roguesden/RoguesDenPlugin.java
@@ -47,11 +47,13 @@ import net.runelite.api.events.GroundObjectChanged;
 import net.runelite.api.events.GroundObjectDespawned;
 import net.runelite.api.events.GroundObjectSpawned;
 import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginCategory;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.task.Schedule;
 
 @PluginDescriptor(
-	name = "Rogues' Den"
+	name = "Rogues' Den",
+	category = PluginCategory.SKILLING
 )
 @Slf4j
 public class RoguesDenPlugin extends Plugin

--- a/runelite-client/src/main/java/net/runelite/client/plugins/roguesden/RoguesDenPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/roguesden/RoguesDenPlugin.java
@@ -53,7 +53,7 @@ import net.runelite.client.task.Schedule;
 
 @PluginDescriptor(
 	name = "Rogues' Den",
-	category = PluginCategory.SKILLING
+	category = PluginCategory.SKILLS
 )
 @Slf4j
 public class RoguesDenPlugin extends Plugin

--- a/runelite-client/src/main/java/net/runelite/client/plugins/roguesden/RoguesDenPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/roguesden/RoguesDenPlugin.java
@@ -53,7 +53,7 @@ import net.runelite.client.task.Schedule;
 
 @PluginDescriptor(
 	name = "Rogues' Den",
-	category = PluginCategory.SKILLS
+	category = PluginCategory.MINIGAME
 )
 @Slf4j
 public class RoguesDenPlugin extends Plugin

--- a/runelite-client/src/main/java/net/runelite/client/plugins/runecraft/RunecraftPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/runecraft/RunecraftPlugin.java
@@ -53,7 +53,7 @@ import net.runelite.client.util.QueryRunner;
 
 @PluginDescriptor(
 	name = "Runecraft",
-	category = PluginCategory.SKILLING
+	category = PluginCategory.SKILLS
 )
 public class RunecraftPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/runecraft/RunecraftPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/runecraft/RunecraftPlugin.java
@@ -46,12 +46,14 @@ import net.runelite.api.queries.InventoryItemQuery;
 import net.runelite.api.queries.NPCQuery;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginCategory;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.util.QueryRunner;
 
 @PluginDescriptor(
-	name = "Runecraft"
+	name = "Runecraft",
+	category = PluginCategory.SKILLING
 )
 public class RunecraftPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/runepouch/RunepouchPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/runepouch/RunepouchPlugin.java
@@ -34,7 +34,7 @@ import net.runelite.client.ui.overlay.Overlay;
 
 @PluginDescriptor(
 	name = "Rune Pouch",
-	category = PluginCategory.UTILITY
+	category = PluginCategory.SKILLS
 )
 public class RunepouchPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/runepouch/RunepouchPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/runepouch/RunepouchPlugin.java
@@ -28,11 +28,13 @@ import com.google.inject.Provides;
 import javax.inject.Inject;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginCategory;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.Overlay;
 
 @PluginDescriptor(
-	name = "Rune Pouch"
+	name = "Rune Pouch",
+	category = PluginCategory.UTILITY
 )
 public class RunepouchPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
@@ -70,6 +70,7 @@ import net.runelite.api.widgets.WidgetInfo;
 import static net.runelite.api.widgets.WidgetInfo.TO_GROUP;
 import net.runelite.client.Notifier;
 import static net.runelite.client.RuneLite.SCREENSHOT_DIR;
+import net.runelite.client.plugins.PluginCategory;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.input.KeyManager;
 import net.runelite.client.plugins.Plugin;
@@ -92,7 +93,8 @@ import okhttp3.RequestBody;
 import okhttp3.Response;
 
 @PluginDescriptor(
-	name = "Screenshot"
+	name = "Screenshot",
+	category = PluginCategory.OTHER
 )
 @Slf4j
 public class ScreenshotPlugin extends Plugin

--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
@@ -94,7 +94,7 @@ import okhttp3.Response;
 
 @PluginDescriptor(
 	name = "Screenshot",
-	category = PluginCategory.OTHER
+	category = PluginCategory.CLIENT
 )
 @Slf4j
 public class ScreenshotPlugin extends Plugin

--- a/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/SkillCalculatorPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/SkillCalculatorPlugin.java
@@ -33,12 +33,16 @@ import net.runelite.client.game.ItemManager;
 import net.runelite.client.game.SkillIconManager;
 import net.runelite.client.game.SpriteManager;
 import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginCategory;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.ClientUI;
 import net.runelite.client.ui.NavigationButton;
 import net.runelite.client.ui.PluginToolbar;
 
-@PluginDescriptor(name = "Skill Calculator")
+@PluginDescriptor(
+	name = "Skill Calculator",
+	category = PluginCategory.CLIENT
+)
 public class SkillCalculatorPlugin extends Plugin
 {
 	@Inject

--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerPlugin.java
@@ -68,6 +68,7 @@ import net.runelite.client.callback.ClientThread;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginCategory;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.infobox.InfoBoxManager;
@@ -75,7 +76,8 @@ import net.runelite.client.util.QueryRunner;
 import net.runelite.client.util.Text;
 
 @PluginDescriptor(
-	name = "Slayer"
+	name = "Slayer",
+	category = PluginCategory.UTILITY
 )
 @Slf4j
 public class SlayerPlugin extends Plugin

--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerPlugin.java
@@ -77,7 +77,7 @@ import net.runelite.client.util.Text;
 
 @PluginDescriptor(
 	name = "Slayer",
-	category = PluginCategory.UTILITY
+	category = PluginCategory.COMBAT
 )
 @Slf4j
 public class SlayerPlugin extends Plugin

--- a/runelite-client/src/main/java/net/runelite/client/plugins/specialcounter/SpecialCounterPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/specialcounter/SpecialCounterPlugin.java
@@ -43,12 +43,14 @@ import net.runelite.api.events.GameTick;
 import net.runelite.api.events.VarbitChanged;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginCategory;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.infobox.InfoBoxManager;
 
 @PluginDescriptor(
 	name = "Special Attack Counter",
-	enabledByDefault = false
+	enabledByDefault = false,
+	category = PluginCategory.UTILITY
 )
 public class SpecialCounterPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/stretchedfixedmode/StretchedFixedModePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/stretchedfixedmode/StretchedFixedModePlugin.java
@@ -33,11 +33,13 @@ import net.runelite.api.events.ConfigChanged;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.input.MouseManager;
 import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginCategory;
 import net.runelite.client.plugins.PluginDescriptor;
 
 @PluginDescriptor(
 	name = "Stretched Fixed Mode",
-	enabledByDefault = false
+	enabledByDefault = false,
+	category = PluginCategory.OTHER
 )
 public class StretchedFixedModePlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/stretchedfixedmode/StretchedFixedModePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/stretchedfixedmode/StretchedFixedModePlugin.java
@@ -39,7 +39,7 @@ import net.runelite.client.plugins.PluginDescriptor;
 @PluginDescriptor(
 	name = "Stretched Fixed Mode",
 	enabledByDefault = false,
-	category = PluginCategory.OTHER
+	category = PluginCategory.CLIENT
 )
 public class StretchedFixedModePlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/teamcapes/TeamCapesPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/teamcapes/TeamCapesPlugin.java
@@ -46,7 +46,7 @@ import net.runelite.client.ui.overlay.Overlay;
 @PluginDescriptor(
 	name = "Team Capes",
 	enabledByDefault = false,
-	category = PluginCategory.OTHER
+	category = PluginCategory.UTILITY
 )
 public class TeamCapesPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/teamcapes/TeamCapesPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/teamcapes/TeamCapesPlugin.java
@@ -38,13 +38,15 @@ import net.runelite.api.GameState;
 import net.runelite.api.Player;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginCategory;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.task.Schedule;
 import net.runelite.client.ui.overlay.Overlay;
 
 @PluginDescriptor(
 	name = "Team Capes",
-	enabledByDefault = false
+	enabledByDefault = false,
+	category = PluginCategory.OTHER
 )
 public class TeamCapesPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/tileindicators/TileIndicatorsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/tileindicators/TileIndicatorsPlugin.java
@@ -36,7 +36,7 @@ import net.runelite.client.ui.overlay.Overlay;
 @PluginDescriptor(
 	name = "Tile Indicators",
 	enabledByDefault = false,
-	category = PluginCategory.OTHER
+	category = PluginCategory.UTILITY
 )
 public class TileIndicatorsPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/tileindicators/TileIndicatorsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/tileindicators/TileIndicatorsPlugin.java
@@ -29,12 +29,14 @@ import javax.inject.Inject;
 import net.runelite.api.Client;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginCategory;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.Overlay;
 
 @PluginDescriptor(
 	name = "Tile Indicators",
-	enabledByDefault = false
+	enabledByDefault = false,
+	category = PluginCategory.OTHER
 )
 public class TileIndicatorsPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersPlugin.java
@@ -42,6 +42,7 @@ import net.runelite.api.events.MenuOptionClicked;
 import net.runelite.api.events.VarbitChanged;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginCategory;
 import net.runelite.client.plugins.PluginDescriptor;
 import static net.runelite.client.plugins.timers.GameTimer.ANTIDOTEPLUS;
 import static net.runelite.client.plugins.timers.GameTimer.ANTIDOTEPLUSPLUS;
@@ -79,7 +80,8 @@ import static net.runelite.client.plugins.timers.GameTimer.VENGEANCEOTHER;
 import net.runelite.client.ui.overlay.infobox.InfoBoxManager;
 
 @PluginDescriptor(
-	name = "Timers"
+	name = "Timers",
+	category = PluginCategory.UTILITY
 )
 public class TimersPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/tithefarm/TitheFarmPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/tithefarm/TitheFarmPlugin.java
@@ -47,7 +47,7 @@ import net.runelite.client.ui.overlay.Overlay;
 @Slf4j
 @PluginDescriptor(
 	name = "Tithe Farm",
-	category = PluginCategory.SKILLING
+	category = PluginCategory.SKILLS
 )
 public class TitheFarmPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/tithefarm/TitheFarmPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/tithefarm/TitheFarmPlugin.java
@@ -39,13 +39,15 @@ import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.GameObjectSpawned;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginCategory;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.task.Schedule;
 import net.runelite.client.ui.overlay.Overlay;
 
 @Slf4j
 @PluginDescriptor(
-	name = "Tithe Farm"
+	name = "Tithe Farm",
+	category = PluginCategory.SKILLING
 )
 public class TitheFarmPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/tithefarm/TitheFarmPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/tithefarm/TitheFarmPlugin.java
@@ -47,7 +47,7 @@ import net.runelite.client.ui.overlay.Overlay;
 @Slf4j
 @PluginDescriptor(
 	name = "Tithe Farm",
-	category = PluginCategory.SKILLS
+	category = PluginCategory.MINIGAME
 )
 public class TitheFarmPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/usernamesyncer/UsernameSyncerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/usernamesyncer/UsernameSyncerPlugin.java
@@ -40,7 +40,7 @@ import net.runelite.client.plugins.PluginDescriptor;
 
 @PluginDescriptor(
 	name = "Username Syncer",
-	category = PluginCategory.OTHER
+	category = PluginCategory.CLIENT
 )
 @Slf4j
 public class UsernameSyncerPlugin extends Plugin

--- a/runelite-client/src/main/java/net/runelite/client/plugins/usernamesyncer/UsernameSyncerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/usernamesyncer/UsernameSyncerPlugin.java
@@ -35,10 +35,12 @@ import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.SessionOpen;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginCategory;
 import net.runelite.client.plugins.PluginDescriptor;
 
 @PluginDescriptor(
-	name = "Username Syncer"
+	name = "Username Syncer",
+	category = PluginCategory.OTHER
 )
 @Slf4j
 public class UsernameSyncerPlugin extends Plugin

--- a/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingPlugin.java
@@ -32,13 +32,15 @@ import net.runelite.api.events.ChatMessage;
 import net.runelite.client.Notifier;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginCategory;
 import net.runelite.client.plugins.PluginDependency;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.plugins.xptracker.XpTrackerPlugin;
 import net.runelite.client.ui.overlay.Overlay;
 
 @PluginDescriptor(
-	name = "Woodcutting"
+	name = "Woodcutting",
+	category = PluginCategory.SKILLING
 )
 @PluginDependency(XpTrackerPlugin.class)
 public class WoodcuttingPlugin extends Plugin

--- a/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingPlugin.java
@@ -40,7 +40,7 @@ import net.runelite.client.ui.overlay.Overlay;
 
 @PluginDescriptor(
 	name = "Woodcutting",
-	category = PluginCategory.SKILLING
+	category = PluginCategory.SKILLS
 )
 @PluginDependency(XpTrackerPlugin.class)
 public class WoodcuttingPlugin extends Plugin

--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldmap/WorldMapPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldmap/WorldMapPlugin.java
@@ -35,11 +35,13 @@ import javax.imageio.ImageIO;
 import net.runelite.api.events.ConfigChanged;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginCategory;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.worldmap.WorldMapPointManager;
 
 @PluginDescriptor(
-	name = "World Map"
+	name = "World Map",
+	category = PluginCategory.CLIENT
 )
 public class WorldMapPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldmaptest/WorldMapOverlayTestPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldmaptest/WorldMapOverlayTestPlugin.java
@@ -45,7 +45,7 @@ import net.runelite.client.ui.overlay.worldmap.WorldMapPointManager;
 	name = "WorldMapOverlayTest",
 	developerPlugin = true,
 	enabledByDefault = false,
-	category = PluginCategory.OTHER
+	category = PluginCategory.CLIENT
 )
 public class WorldMapOverlayTestPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldmaptest/WorldMapOverlayTestPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldmaptest/WorldMapOverlayTestPlugin.java
@@ -36,6 +36,7 @@ import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.CommandExecuted;
 import net.runelite.api.events.GameTick;
 import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginCategory;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.worldmap.WorldMapPoint;
 import net.runelite.client.ui.overlay.worldmap.WorldMapPointManager;
@@ -43,7 +44,8 @@ import net.runelite.client.ui.overlay.worldmap.WorldMapPointManager;
 @PluginDescriptor(
 	name = "WorldMapOverlayTest",
 	developerPlugin = true,
-	enabledByDefault = false
+	enabledByDefault = false,
+	category = PluginCategory.OTHER
 )
 public class WorldMapOverlayTestPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesPlugin.java
@@ -39,6 +39,7 @@ import net.runelite.api.events.ExperienceChanged;
 import net.runelite.api.events.GameStateChanged;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginCategory;
 import net.runelite.client.plugins.PluginDependency;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.plugins.xptracker.XpTrackerPlugin;
@@ -46,7 +47,8 @@ import net.runelite.client.task.Schedule;
 import net.runelite.client.ui.overlay.Overlay;
 
 @PluginDescriptor(
-	name = "XP Globes"
+	name = "XP Globes",
+	category = PluginCategory.UTILITY
 )
 @PluginDependency(XpTrackerPlugin.class)
 public class XpGlobesPlugin extends Plugin

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerPlugin.java
@@ -45,6 +45,7 @@ import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.GameTick;
 import net.runelite.client.game.SkillIconManager;
 import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginCategory;
 import net.runelite.client.plugins.PluginDescriptor;
 import static net.runelite.client.plugins.xptracker.XpWorldType.NORMAL;
 import net.runelite.client.ui.NavigationButton;
@@ -56,7 +57,8 @@ import net.runelite.http.api.worlds.WorldType;
 import net.runelite.http.api.xp.XpClient;
 
 @PluginDescriptor(
-	name = "XP Tracker"
+	name = "XP Tracker",
+	category = PluginCategory.UTILITY
 )
 @Slf4j
 public class XpTrackerPlugin extends Plugin

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xtea/XteaPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xtea/XteaPlugin.java
@@ -34,13 +34,15 @@ import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.events.MapRegionChanged;
 import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginCategory;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.http.api.xtea.XteaClient;
 import okhttp3.Response;
 
 @PluginDescriptor(
 	name = "Xtea",
-	hidden = true
+	hidden = true,
+	category = PluginCategory.CLIENT
 )
 @Slf4j
 public class XteaPlugin extends Plugin

--- a/runelite-client/src/main/java/net/runelite/client/plugins/zoom/ZoomPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/zoom/ZoomPlugin.java
@@ -34,10 +34,12 @@ import net.runelite.api.events.ConfigChanged;
 import net.runelite.api.events.ScriptCallbackEvent;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginCategory;
 import net.runelite.client.plugins.PluginDescriptor;
 
 @PluginDescriptor(
-	name = "Camera Zoom"
+	name = "Camera Zoom",
+	category = PluginCategory.UTILITY
 )
 @Slf4j
 public class ZoomPlugin extends Plugin

--- a/runelite-client/src/main/java/net/runelite/client/plugins/zoom/ZoomPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/zoom/ZoomPlugin.java
@@ -39,7 +39,7 @@ import net.runelite.client.plugins.PluginDescriptor;
 
 @PluginDescriptor(
 	name = "Camera Zoom",
-	category = PluginCategory.UTILITY
+	category = PluginCategory.CLIENT
 )
 @Slf4j
 public class ZoomPlugin extends Plugin


### PR DESCRIPTION

![001447b626d2d6324d0fbc55c2c883f5](https://user-images.githubusercontent.com/5104566/39702442-ba9d674e-51fc-11e8-9225-7f41d70705f4.gif)
Adds category field to PluginDescriptor annotation.
New categories can be added in the PluginCategory enum.
New categories are automatically added to the config UI.