### PR TITLE
Fix WorldMapOverlay to draw pixel perfect on the WorldMap

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldmaptest/WorldMapDebugOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldmaptest/WorldMapDebugOverlay.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2018, Morgan Lewis <https://github.com/MESLewis>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.worldmaptest;
+
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.FontMetrics;
+import java.awt.Graphics2D;
+import java.awt.Rectangle;
+import javax.inject.Inject;
+import net.runelite.api.Client;
+import net.runelite.api.Point;
+import net.runelite.api.RenderOverview;
+import net.runelite.api.coords.WorldPoint;
+import net.runelite.api.widgets.Widget;
+import net.runelite.api.widgets.WidgetInfo;
+import net.runelite.client.ui.overlay.Overlay;
+import net.runelite.client.ui.overlay.OverlayLayer;
+import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.OverlayPriority;
+import net.runelite.client.ui.overlay.worldmap.WorldMapOverlay;
+
+public class WorldMapDebugOverlay extends Overlay
+{
+	private final Client client;
+	private final WorldMapOverlay worldMapOverlay;
+
+	@Inject
+	private WorldMapDebugOverlay(Client client, WorldMapOverlay worldMapOverlay)
+	{
+		this.client = client;
+		this.worldMapOverlay = worldMapOverlay;
+		setPosition(OverlayPosition.DYNAMIC);
+		setPriority(OverlayPriority.HIGH);
+		setLayer(OverlayLayer.ALWAYS_ON_TOP);
+	}
+
+	@Override
+	public Dimension render(Graphics2D graphics)
+	{
+		RenderOverview ro = client.getRenderOverview();
+		Widget worldMapWidget = client.getWidget(WidgetInfo.WORLD_MAP_VIEW);
+
+		if (ro == null || worldMapWidget == null)
+		{
+			return null;
+		}
+
+		Rectangle worldMapRectangle = worldMapWidget.getBounds();
+
+		graphics.setClip(worldMapRectangle);
+		graphics.setColor(Color.CYAN);
+
+		WorldPoint mapCenterPoint = new WorldPoint(ro.getWorldMapPosition().getX(), ro.getWorldMapPosition().getY(), 0);
+		Point middle = worldMapOverlay.mapWorldPointToGraphicsPoint(mapCenterPoint);
+
+		if (middle == null)
+		{
+			return null;
+		}
+
+		graphics.drawLine(middle.getX(), worldMapRectangle.y, middle.getX(), worldMapRectangle.y + worldMapRectangle.height);
+		graphics.drawLine(worldMapRectangle.x, middle.getY(), worldMapRectangle.x + worldMapRectangle.width, middle.getY());
+
+		String output = "Center: " + mapCenterPoint.getX() + ", " + mapCenterPoint.getY();
+		graphics.setColor(Color.white);
+		FontMetrics fm = graphics.getFontMetrics();
+		int height = fm.getHeight();
+		int width = fm.stringWidth(output);
+		graphics.fillRect((int)worldMapRectangle.getX(), (int)worldMapRectangle.getY() + worldMapRectangle.height - height, (int)worldMapRectangle.getX() + width, (int)worldMapRectangle.getY() + worldMapRectangle.height);
+
+		graphics.setColor(Color.BLACK);
+		graphics.drawString(output, (int) worldMapRectangle.getX(), (int) worldMapRectangle.getY() + worldMapRectangle.height);
+
+		return null;
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldmaptest/WorldMapOverlayTestPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldmaptest/WorldMapOverlayTestPlugin.java
@@ -37,11 +37,12 @@ import net.runelite.api.events.CommandExecuted;
 import net.runelite.api.events.GameTick;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.worldmap.WorldMapPoint;
 import net.runelite.client.ui.overlay.worldmap.WorldMapPointManager;
 
 @PluginDescriptor(
-	name = "WorldMapOverlayTest",
+	name = "World Map Debug Tools",
 	developerPlugin = true,
 	enabledByDefault = false
 )
@@ -57,6 +58,15 @@ public class WorldMapOverlayTestPlugin extends Plugin
 
 	private WorldMapPoint playerDot;
 
+	@Inject
+	private WorldMapDebugOverlay worldMapDebugOverlay;
+
+	@Override
+	public Overlay getOverlay()
+	{
+		return worldMapDebugOverlay;
+	}
+
 	@Override
 	protected void startUp() throws Exception
 	{
@@ -65,9 +75,9 @@ public class WorldMapOverlayTestPlugin extends Plugin
 		markGraphics.setColor(Color.ORANGE);
 		markGraphics.fillOval(0, 0, 10, 10);
 
-		BufferedImage playerImage = new BufferedImage(5, 5, BufferedImage.TYPE_INT_ARGB);
+		BufferedImage playerImage = new BufferedImage(8, 8, BufferedImage.TYPE_INT_ARGB);
 		playerImage.getGraphics().setColor(Color.WHITE);
-		playerImage.getGraphics().fillRect(0, 0, 5, 5);
+		playerImage.getGraphics().fillRect(0, 0, 8, 8);
 		playerDot = new WorldMapPoint(null, playerImage);
 
 		worldMapPointManager.add(playerDot);

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/worldmap/WorldMapOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/worldmap/WorldMapOverlay.java
@@ -171,7 +171,7 @@ public class WorldMapOverlay extends Overlay
 		return null;
 	}
 
-	private Point mapWorldPointToGraphicsPoint(WorldPoint worldPoint)
+	public Point mapWorldPointToGraphicsPoint(WorldPoint worldPoint)
 	{
 		RenderOverview ro = clientProvider.get().getRenderOverview();
 
@@ -182,17 +182,31 @@ public class WorldMapOverlay extends Overlay
 
 		Float pixelsPerTile = ro.getWorldMapZoom();
 
-		Point worldMapPosition = ro.getWorldMapPosition();
-		int xWorldDiff = worldPoint.getX() - worldMapPosition.getX();
-		int yWorldDiff = worldPoint.getY() - worldMapPosition.getY();
-		yWorldDiff = -yWorldDiff;
-
 		Widget map = clientProvider.get().getWidget(WidgetInfo.WORLD_MAP_VIEW);
 		if (map != null)
 		{
 			Rectangle worldMapRect = map.getBounds();
-			int xGraphDiff = (int) (xWorldDiff * pixelsPerTile + worldMapRect.getWidth() / 2 + worldMapRect.getX());
-			int yGraphDiff = (int) (yWorldDiff * pixelsPerTile + worldMapRect.getHeight() / 2 + worldMapRect.getY());
+
+			int widthInTiles = (int) Math.ceil(worldMapRect.getWidth() / pixelsPerTile);
+			int heightInTiles = (int) Math.ceil(worldMapRect.getHeight() / pixelsPerTile);
+
+			Point worldMapPosition = ro.getWorldMapPosition();
+
+			//Offset in tiles from anchor sides
+			int yTileMax = worldMapPosition.getY() - heightInTiles / 2;
+			int yTileOffset = (yTileMax - worldPoint.getY() - 1) * -1;
+			int xTileOffset = worldPoint.getX() + widthInTiles / 2 - worldMapPosition.getX();
+
+			int xGraphDiff = ((int) (xTileOffset * pixelsPerTile));
+			int yGraphDiff = (int) (yTileOffset * pixelsPerTile);
+
+			//Center on tile.
+			yGraphDiff -= pixelsPerTile - Math.ceil(pixelsPerTile / 2);
+			xGraphDiff += pixelsPerTile - Math.ceil(pixelsPerTile / 2);
+
+			yGraphDiff = worldMapRect.height - yGraphDiff;
+			yGraphDiff += (int) worldMapRect.getY();
+			xGraphDiff += (int) worldMapRect.getX();
 
 			return new Point(xGraphDiff, yGraphDiff);
 		}

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/worldmap/WorldMapPoint.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/worldmap/WorldMapPoint.java
@@ -28,10 +28,12 @@ import java.awt.Rectangle;
 import java.awt.event.MouseEvent;
 import java.awt.image.BufferedImage;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import net.runelite.api.Point;
 import net.runelite.api.coords.WorldPoint;
 
 @Data
+@EqualsAndHashCode(exclude = {"clickbox", "currentlyEdgeSnapped", "tooltipVisible", "imagePoint"})
 public class WorldMapPoint
 {
 	private BufferedImage image;

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/worldmap/WorldMapPointManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/worldmap/WorldMapPointManager.java
@@ -25,6 +25,7 @@
 package net.runelite.client.ui.overlay.worldmap;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.function.Predicate;
 import javax.inject.Singleton;
@@ -37,18 +38,28 @@ public class WorldMapPointManager
 	@Getter(AccessLevel.PACKAGE)
 	private final List<WorldMapPoint> worldMapPoints = new ArrayList<>();
 
-	public void add(WorldMapPoint worldMapPoint)
+	public boolean add(WorldMapPoint worldMapPoint)
 	{
-		worldMapPoints.add(worldMapPoint);
+		return worldMapPoints.add(worldMapPoint);
 	}
 
-	public void remove(WorldMapPoint worldMapPoint)
+	public boolean addAll(Collection<WorldMapPoint> collection)
 	{
-		worldMapPoints.remove(worldMapPoint);
+		return worldMapPoints.addAll(collection);
 	}
 
 	public void removeIf(Predicate<WorldMapPoint> filter)
 	{
 		worldMapPoints.removeIf(filter);
+	}
+
+	public boolean remove(WorldMapPoint worldMapPoint)
+	{
+		return worldMapPoints.remove(worldMapPoint);
+	}
+
+	public boolean removeAll(Collection<WorldMapPoint> collection)
+	{
+		return worldMapPoints.removeAll(collection);
 	}
 }

--- a/runelite-mixins/src/main/java/net/runelite/mixins/WorldMapManagerMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/WorldMapManagerMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Adam <Adam@sigterm.info>
+ * Copyright (c) 2018, Morgan Lewis <https://github.com/MESLewis>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -22,23 +22,37 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package net.runelite.rs.api;
+package net.runelite.mixins;
 
-import net.runelite.api.WorldMapManager;
-import net.runelite.mapping.Import;
+import net.runelite.api.mixins.Mixin;
+import net.runelite.api.mixins.Replace;
+import net.runelite.api.mixins.Shadow;
+import net.runelite.rs.api.RSClient;
+import net.runelite.rs.api.RSWorldMapManager;
 
-public interface RSWorldMapManager extends WorldMapManager
+@Mixin(RSWorldMapManager.class)
+public abstract class WorldMapManagerMixin implements RSWorldMapManager
 {
-	@Import("loaded")
+	@Shadow("clientInstance")
+	static RSClient client;
+
+	/*
+	 The worldMapZoom is essentially pixels per tile. In most instances
+	 getPixelsPerTile returns the same as worldMapZoom.
+
+	 At some map widths when 100% zoomed in the Jagex version of this function
+	 returns 7.89 instead of 8.0 (the worldMapZoom at this level).
+	 This would cause both the x and y positions of the map to shift
+	 slightly when the map was certain widths.
+
+	 This mixin function replaces Jagex calculation with getWorldMapZoom.
+	 This small change makes the world map tile sizing predictable.
+	 */
+	@Replace("getPixelsPerTile")
 	@Override
-	boolean isLoaded();
+	public float getPixelsPerTile(int graphicsDiff, int worldDiff)
+	{
+		return client.getRenderOverview().getWorldMapZoom();
+	}
 
-	@Import("mapSurfaceBaseOffsetX")
-	int getSurfaceOffsetX();
-
-	@Import("mapSurfaceBaseOffsetY")
-	int getSurfaceOffsetY();
-
-	@Import("getPixelsPerTile")
-	float getPixelsPerTile(int graphicsDiff, int worldDiff);
 }

--- a/runelite-mixins/src/main/java/net/runelite/mixins/WorldMapMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/WorldMapMixin.java
@@ -49,5 +49,4 @@ public abstract class WorldMapMixin implements RSRenderOverview
 	{
 		setWorldMapPositionTarget(worldPoint.getX(), worldPoint.getY());
 	}
-
 }

--- a/runescape-client/src/main/java/WorldMapManager.java
+++ b/runescape-client/src/main/java/WorldMapManager.java
@@ -188,7 +188,7 @@ public final class WorldMapManager {
       int[] var12 = new int[4];
       Rasterizer2D.copyDrawRegion(var12);
       WorldMapRectangle var13 = this.getRegionRectForViewport(var1, var2, var3, var4);
-      float var14 = this.method522(x2 - x1, var3 - var1);
+      float var14 = this.getPixelsPerTile(x2 - x1, var3 - var1);
       int var15 = (int)Math.ceil((double)var14);
       this.field269 = var15;
       if(!this.field270.containsKey(Integer.valueOf(var15))) {
@@ -230,7 +230,7 @@ public final class WorldMapManager {
    @Export("drawMapIcons")
    public final void drawMapIcons(int x1, int y1, int x2, int y2, int graphicsX1, int var6, int graphicsX2, int var8, HashSet var9, HashSet var10, int var11, int var12, boolean var13) {
       WorldMapRectangle var14 = this.getRegionRectForViewport(x1, y1, x2, y2);
-      float var15 = this.method522(graphicsX2 - graphicsX1, x2 - x1);
+      float var15 = this.getPixelsPerTile(graphicsX2 - graphicsX1, x2 - x1);
       int var16 = (int)(var15 * 64.0F);
       int var17 = this.mapSurfaceBaseOffsetX + x1;
       int var18 = y1 + this.mapSurfaceBaseOffsetY;
@@ -332,7 +332,7 @@ public final class WorldMapManager {
          return var11;
       } else {
          WorldMapRectangle var12 = this.getRegionRectForViewport(var1, var2, var3, var4);
-         float var13 = this.method522(var7, var3 - var1);
+         float var13 = this.getPixelsPerTile(var7, var3 - var1);
          int var14 = (int)(64.0F * var13);
          int var15 = this.mapSurfaceBaseOffsetX + var1;
          int var16 = var2 + this.mapSurfaceBaseOffsetY;
@@ -451,7 +451,8 @@ public final class WorldMapManager {
       signature = "(III)F",
       garbageValue = "1789202139"
    )
-   float method522(int graphicsDiff, int worldDiff) {
+   @Export("getPixelsPerTile")
+   float getPixelsPerTile(int graphicsDiff, int worldDiff) {
       float var3 = (float)graphicsDiff / (float)worldDiff;
       if(var3 > 8.0F) {
          return 8.0F;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/597053/39710013-cd3ba768-51d8-11e8-8469-114409ec441b.png)

Fixes a poorly implemented getPixelsPerTile to make the WorldMap tile sizing more predictable. (In practice it is not a noticeable change unless you are drawing overlays)