### PR TITLE
Add tooltip font type dropdown

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/config/RuneLiteConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/RuneLiteConfig.java
@@ -190,10 +190,21 @@ public interface RuneLiteConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "tooltipFontType",
+		name = "Tooltip Font",
+		description = "Configures what font type is used for in-game tooltips such as food stats, NPC names, etc.",
+		position = 31
+	)
+	default FontType tooltipFontType()
+	{
+		return FontType.SMALL;
+	}
+
+	@ConfigItem(
 		keyName = "infoBoxVertical",
 		name = "Display infoboxes vertically",
 		description = "Toggles the infoboxes to display vertically",
-		position = 31
+		position = 32
 	)
 	default boolean infoBoxVertical()
 	{
@@ -204,7 +215,7 @@ public interface RuneLiteConfig extends Config
 		keyName = "infoBoxWrap",
 		name = "Infobox wrap count",
 		description = "Configures the amount of infoboxes shown before wrapping",
-		position = 32
+		position = 33
 	)
 	default int infoBoxWrap()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayRenderer.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayRenderer.java
@@ -517,7 +517,7 @@ public class OverlayRenderer extends MouseListener implements KeyListener
 		}
 		else if (position == OverlayPosition.TOOLTIP)
 		{
-			subGraphics.setFont(FontManager.getRunescapeSmallFont());
+			subGraphics.setFont(runeLiteConfig.tooltipFontType().getFont());
 		}
 		else
 		{

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/components/TooltipComponent.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/components/TooltipComponent.java
@@ -53,7 +53,7 @@ public class TooltipComponent implements RenderableEntity
 		// Tooltip size
 		final FontMetrics metrics = graphics.getFontMetrics();
 		final int textDescent = metrics.getDescent();
-		final int textHeight = graphics.getFontMetrics().getHeight();
+		final int textHeight = metrics.getHeight();
 		int tooltipWidth = 0;
 		int tooltipHeight = 0;
 		String[] lines = BR.split(text);


### PR DESCRIPTION
This dropdown is similar to to #1651 but for tooltips. Other PR is inactive and having issues. 

Dropdown:
![java_2018-04-26_11-23-10](https://user-images.githubusercontent.com/1210740/39324394-3bb89cb6-4944-11e8-9f00-f107df75bdf8.png)

Small:
![java_2018-04-26_11-20-03](https://user-images.githubusercontent.com/1210740/39324289-001c82da-4944-11e8-9264-ebbad76da263.png)

Regular:
![java_2018-04-26_11-19-55](https://user-images.githubusercontent.com/1210740/39324295-0045b7ea-4944-11e8-93ee-113e55198fd4.png)


Bold:
![java_2018-04-26_11-20-10](https://user-images.githubusercontent.com/1210740/39324292-003240b6-4944-11e8-99d3-f0c58a7b5eb6.png)


