### PR TITLE
Add trap overlay for agility plugin

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/agility/AgilityConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/agility/AgilityConfig.java
@@ -82,7 +82,7 @@ public interface AgilityConfig extends Config
 
 	@ConfigItem(
 		keyName = "markHighlight",
-		name = "Mark highlight Color",
+		name = "Mark Highlight Color",
 		description = "Color of highlighted Marks of Grace",
 		position = 5
 	)
@@ -100,5 +100,27 @@ public interface AgilityConfig extends Config
 	default boolean highlightShortcuts()
 	{
 		return true;
+	}
+
+	@ConfigItem(
+		keyName = "trapOverlay",
+		name = "Show Trap Overlay",
+		description = "Enable/disable the highlighting of traps on Agility courses",
+		position = 7
+	)
+	default boolean showTrapOverlay()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		keyName = "trapHighlight",
+		name = "Trap Overlay Color",
+		description = "Color of Agility trap overlay",
+		position = 8
+	)
+	default Color getTrapColor()
+	{
+		return Color.RED;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/agility/AgilityOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/agility/AgilityOverlay.java
@@ -69,7 +69,8 @@ public class AgilityOverlay extends Overlay
 		final Tile markOfGrace = plugin.getMarkOfGrace();
 		plugin.getObstacles().forEach((object, tile) ->
 		{
-			if (Obstacles.SHORTCUT_OBSTACLE_IDS.contains(object.getId()) && !config.highlightShortcuts())
+			if (Obstacles.SHORTCUT_OBSTACLE_IDS.contains(object.getId()) && !config.highlightShortcuts() ||
+					Obstacles.TRAP_OBSTACLE_IDS.contains(object.getId()) && !config.showTrapOverlay())
 			{
 				return;
 			}
@@ -77,6 +78,13 @@ public class AgilityOverlay extends Overlay
 			if (tile.getPlane() == client.getPlane()
 				&& object.getLocalLocation().distanceTo(playerLocation) < MAX_DISTANCE)
 			{
+				// This assumes that the obstacle is not clickable.
+				if (Obstacles.TRAP_OBSTACLE_IDS.contains(object.getId()))
+				{
+					OverlayUtil.renderPolygon(graphics, object.getCanvasTilePoly(), config.getTrapColor());
+					return;
+				}
+
 				Area objectClickbox = object.getClickbox();
 				if (objectClickbox != null)
 				{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/agility/AgilityPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/agility/AgilityPlugin.java
@@ -286,7 +286,8 @@ public class AgilityPlugin extends Plugin
 		}
 
 		if (Obstacles.COURSE_OBSTACLE_IDS.contains(newObject.getId()) ||
-			Obstacles.SHORTCUT_OBSTACLE_IDS.contains(newObject.getId()))
+				Obstacles.SHORTCUT_OBSTACLE_IDS.contains(newObject.getId()) ||
+				Obstacles.TRAP_OBSTACLE_IDS.contains(newObject.getId()))
 		{
 			obstacles.put(newObject, tile);
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/agility/Obstacles.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/agility/Obstacles.java
@@ -24,13 +24,13 @@
  */
 package net.runelite.client.plugins.agility;
 
-import com.google.common.collect.Sets;
+import com.google.common.collect.ImmutableSet;
 import java.util.Set;
 import static net.runelite.api.ObjectID.*;
 
 public class Obstacles
 {
-	public static final Set<Integer> COURSE_OBSTACLE_IDS = Sets.newHashSet(
+	public static final Set<Integer> COURSE_OBSTACLE_IDS = ImmutableSet.of(
 		// Gnome
 		OBSTACLE_NET_23134, TREE_BRANCH_23559, TREE_BRANCH_23560, OBSTACLE_NET_23135, OBSTACLE_PIPE_23138,
 		OBSTACLE_PIPE_23139, LOG_BALANCE_23145, BALANCING_ROPE_23557,
@@ -76,7 +76,7 @@ public class Obstacles
 		GAP_11406, GAP_11429, GAP_11430, STEEP_ROOF, GAP_11630, PLANK_11631, WOODEN_BEAMS
 	);
 
-	public static final Set<Integer> SHORTCUT_OBSTACLE_IDS = Sets.newHashSet(
+	public static final Set<Integer> SHORTCUT_OBSTACLE_IDS = ImmutableSet.of(
 		// Grand Exchange
 		UNDERWALL_TUNNEL_16529, UNDERWALL_TUNNEL_16530,
 		// South Varrock
@@ -178,7 +178,7 @@ public class Obstacles
 		PILLAR_31561
 	);
 
-	public static final Set<Integer> TRAP_OBSTACLE_IDS = Sets.newHashSet(
+	public static final Set<Integer> TRAP_OBSTACLE_IDS = ImmutableSet.of(
 		// Agility pyramid
 		NULL_3550, NULL_10872, NULL_10873
 	);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/agility/Obstacles.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/agility/Obstacles.java
@@ -177,4 +177,9 @@ public class Obstacles
 		// Revenant Caves
 		PILLAR_31561
 	);
+
+	public static final Set<Integer> TRAP_OBSTACLE_IDS = Sets.newHashSet(
+		// Agility pyramid
+		NULL_3550, NULL_10872, NULL_10873
+	);
 }


### PR DESCRIPTION
Add an option to show an overlay over traps in agility courses.

This only shows traps on the Agility Pyramid. I am not sure of other locations that this should include.

Closes #1184

![ss 2018-05-07 21 15 24](https://user-images.githubusercontent.com/2388657/39732952-36f22dde-523e-11e8-96aa-b6e01876b3e5.png)

I would like to draw a hull overlay of those traps, but I'm not sure if there is a way to do that for non-clickable objects. This may be good enough.