### PR TITLE
Opponent info panel improvements

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/opponentinfo/OpponentInfoOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/opponentinfo/OpponentInfoOverlay.java
@@ -26,11 +26,9 @@ package net.runelite.client.plugins.opponentinfo;
 
 import java.awt.Color;
 import java.awt.Dimension;
-import java.awt.FontMetrics;
 import java.awt.Graphics2D;
 import java.awt.Point;
 import java.awt.Rectangle;
-import java.text.DecimalFormat;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Map;
@@ -43,42 +41,39 @@ import net.runelite.api.Varbits;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.OverlayPriority;
-import net.runelite.client.ui.overlay.components.BackgroundComponent;
-import net.runelite.client.ui.overlay.components.TextComponent;
+import net.runelite.client.ui.overlay.components.PanelComponent;
+import net.runelite.client.ui.overlay.components.ProgressBarComponent;
+import net.runelite.client.ui.overlay.components.TitleComponent;
 import net.runelite.client.util.Text;
 
 class OpponentInfoOverlay extends Overlay
 {
-	private static final int WIDTH = 129;
-
-	private static final int TOP_BORDER = 2;
-
-	private static final int BAR_WIDTH = WIDTH - 4;
-	private static final int BAR_HEIGHT = 16;
-
 	private static final Color HP_GREEN = new Color(0, 146, 54, 230);
 	private static final Color HP_RED = new Color(102, 15, 16, 230);
 	private static final Duration WAIT = Duration.ofSeconds(3);
 
 	private final Client client;
 	private final NPC[] clientNpcs;
+	private final PanelComponent panelComponent = new PanelComponent();
+	private final Map<String, Integer> oppInfoHealth = OpponentInfoPlugin.loadNpcHealth();
 
 	private Integer lastMaxHealth;
-	private DecimalFormat df = new DecimalFormat("0.0");
 	private float lastRatio = 0;
 	private Instant lastTime = Instant.now();
 	private String opponentName;
 	private String opponentsOpponentName;
-	private Map<String, Integer> oppInfoHealth = OpponentInfoPlugin.loadNpcHealth();
 	private NPC lastOpponent;
 
 	@Inject
-	OpponentInfoOverlay(Client client)
+	private OpponentInfoOverlay(Client client)
 	{
-		setPosition(OverlayPosition.TOP_LEFT);
-		setPriority(OverlayPriority.HIGH);
 		this.client = client;
 		this.clientNpcs = client.getCachedNPCs();
+		setPosition(OverlayPosition.TOP_LEFT);
+		setPriority(OverlayPriority.HIGH);
+
+		panelComponent.setBorder(new Rectangle(2, 2, 2, 2));
+		panelComponent.setGap(new Point(0, 2));
 	}
 
 	private Actor getOpponent()
@@ -140,77 +135,42 @@ class OpponentInfoOverlay extends Overlay
 			return null; //don't draw anything.
 		}
 
-		FontMetrics fm = graphics.getFontMetrics();
+		panelComponent.getChildren().clear();
 
-		int height = TOP_BORDER + fm.getHeight(); // opponent name
+		// Opponent name
+		panelComponent.getChildren().add(TitleComponent.builder()
+			.text(opponentName)
+			.build());
+
+		// Health bar
 		if (lastRatio >= 0)
 		{
-			height += BAR_HEIGHT + 5;
-		}
-		if (opponentsOpponentName != null)
-		{
-			height += fm.getHeight() + 5;
-		}
-
-		final BackgroundComponent backgroundComponent = new BackgroundComponent();
-		backgroundComponent.setRectangle(new Rectangle(0, 0, WIDTH, height));
-		backgroundComponent.render(graphics);
-
-		int y = TOP_BORDER + fm.getHeight();
-
-		{
-			int x = (WIDTH - fm.stringWidth(opponentName)) / 2;
-			final TextComponent textComponent = new TextComponent();
-			textComponent.setPosition(new Point(x, y));
-			textComponent.setText(opponentName);
-			textComponent.render(graphics);
-
-			y += 3;
-		}
-
-		if (lastRatio >= 0)
-		{
-			int barWidth = (int) (lastRatio * (float) BAR_WIDTH);
-
-			graphics.setColor(HP_GREEN);
-			graphics.fillRect((WIDTH - BAR_WIDTH) / 2, y, barWidth, BAR_HEIGHT);
-
-			graphics.setColor(HP_RED);
-			graphics.fillRect(((WIDTH - BAR_WIDTH) / 2) + barWidth, y, BAR_WIDTH - barWidth, BAR_HEIGHT);
-
-			String str;
+			final ProgressBarComponent progressBarComponent = new ProgressBarComponent();
+			progressBarComponent.setBackgroundColor(HP_RED);
+			progressBarComponent.setForegroundColor(HP_GREEN);
 
 			if (lastMaxHealth != null)
 			{
-				int currHealth = (int) (lastRatio * lastMaxHealth);
-				str = currHealth + "/" + lastMaxHealth;
+				progressBarComponent.setLabelDisplayMode(ProgressBarComponent.LabelDisplayMode.FULL);
+				progressBarComponent.setMaximum(lastMaxHealth);
+				progressBarComponent.setValue(lastRatio * lastMaxHealth);
 			}
 			else
 			{
-				str = df.format(lastRatio * 100) + "%";
+				progressBarComponent.setValue(lastRatio * 100d);
 			}
 
-			y += BAR_HEIGHT;
-
-			final TextComponent textComponent1 = new TextComponent();
-			textComponent1.setText(str);
-			textComponent1.setPosition(new Point((WIDTH - fm.stringWidth(str)) / 2, y));
-			textComponent1.render(graphics);
-
-			y += 3;
+			panelComponent.getChildren().add(progressBarComponent);
 		}
 
+		// Opponents opponent
 		if (opponentsOpponentName != null)
 		{
-			y += fm.getHeight();
-
-			int x = (WIDTH - fm.stringWidth(opponentsOpponentName)) / 2;
-			final TextComponent textComponent = new TextComponent();
-			textComponent.setPosition(new Point(x, y));
-			textComponent.setText(opponentsOpponentName);
-			textComponent.render(graphics);
+			panelComponent.getChildren().add(TitleComponent.builder()
+				.text(opponentsOpponentName)
+				.build());
 		}
 
-		return new Dimension(WIDTH, height);
+		return panelComponent.render(graphics);
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesOverlay.java
@@ -275,8 +275,7 @@ public class XpGlobesOverlay extends Overlay
 			ProgressBarComponent progressBar = new ProgressBarComponent();
 			double progress = mouseOverSkill.getSkillProgress(Experience.getXpForLevel(mouseOverSkill.getCurrentLevel()),
 				mouseOverSkill.getCurrentXp(), mouseOverSkill.getGoalXp());
-			progressBar.setProgress(progress);
-
+			progressBar.setValue(progress);
 			xpTooltip.getChildren().add(progressBar);
 		}
 

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/components/ProgressBarComponent.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/components/ProgressBarComponent.java
@@ -24,7 +24,6 @@
  */
 package net.runelite.client.ui.overlay.components;
 
-import com.google.common.base.Strings;
 import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.FontMetrics;
@@ -36,9 +35,18 @@ import lombok.Setter;
 @Setter
 public class ProgressBarComponent implements LayoutableRenderableEntity
 {
-	private String text;
-	private double progress;
-	private Point position = new Point();
+	public enum LabelDisplayMode
+	{
+		PERCENTAGE,
+		FULL
+	}
+
+	private static final DecimalFormat DECIMAL_FORMAT = new DecimalFormat("0.0");
+	private static final DecimalFormat DECIMAL_FORMAT2 = new DecimalFormat("#0");
+	private long minimum;
+	private long maximum = 100;
+	private double value;
+	private LabelDisplayMode labelDisplayMode = LabelDisplayMode.PERCENTAGE;
 	private Color foregroundColor = new Color(82, 161, 82);
 	private Color backgroundColor = new Color(255, 255, 255, 127);
 	private Color fontColor = Color.WHITE;
@@ -47,29 +55,30 @@ public class ProgressBarComponent implements LayoutableRenderableEntity
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
-		FontMetrics metrics = graphics.getFontMetrics();
+		final FontMetrics metrics = graphics.getFontMetrics();
 
-		int barX = position.x;
-		int barY = position.y - metrics.getHeight();
-		String textToWrite;
+		final int barX = 0;
+		final int barY = -metrics.getHeight();
 
-		if (Strings.isNullOrEmpty(text))
+		final long span = maximum - minimum;
+		final double currentValue = value - minimum;
+		final double pc = currentValue / span;
+		final String textToWrite;
+
+		switch (labelDisplayMode)
 		{
-			DecimalFormat df = new DecimalFormat("#0");
-			textToWrite = df.format(Math.floor(progress)) + "%";
+			case PERCENTAGE:
+				textToWrite = DECIMAL_FORMAT.format(Math.floor(pc)) + "%";
+				break;
+			default:
+				textToWrite = DECIMAL_FORMAT2.format(Math.floor(currentValue)) + "/" + maximum;
 		}
-		else
-		{
-			textToWrite = text;
-		}
 
-		int width = preferredSize.width;
-		int height = Math.max(preferredSize.height, 16);
-
-		int progressTextX = barX + (width - metrics.stringWidth(textToWrite)) / 2;
-		int progressTextY = barY + ((height - metrics.getHeight()) / 2) + metrics.getAscent();
-
-		int progressFill = (int) ((width / 100F) * progress);
+		final int width = preferredSize.width;
+		final int height = Math.max(preferredSize.height, 16);
+		final int progressTextX = barX + (width - metrics.stringWidth(textToWrite)) / 2;
+		final int progressTextY = barY + ((height - metrics.getHeight()) / 2) + metrics.getHeight();
+		final int progressFill = (int) (width * pc);
 
 		//Draw bar
 		graphics.setColor(backgroundColor);
@@ -77,7 +86,7 @@ public class ProgressBarComponent implements LayoutableRenderableEntity
 		graphics.setColor(foregroundColor);
 		graphics.fillRect(barX, barY, progressFill, height);
 
-		TextComponent textComponent = new TextComponent();
+		final TextComponent textComponent = new TextComponent();
 		textComponent.setPosition(new Point(progressTextX, progressTextY));
 		textComponent.setColor(fontColor);
 		textComponent.setText(textToWrite);


### PR DESCRIPTION
##  Improve ProgressBarComponent to support %/FULL

- Add minimum, maximum and value properties to ProgressBarComponent
- Add label display mode that will differentiate between percentage and
current/maximum display modes
- Properly center the text in progress bar

## Update opponent info to use PanelComponent

- Use panel component with custom paddings for opponent info
- For opponent/opponents opponent names use TitleComponent that is
horizontally centered
- Use new progress bar with full display mode when needed

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>

Preview:
![screenie](https://user-images.githubusercontent.com/5115805/39761741-2a0cb90e-52d9-11e8-9409-ca39fc3839b1.png)

