### PR TITLE
Maintain Agility plugin state on plugin state change

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/agility/AgilityPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/agility/AgilityPlugin.java
@@ -103,14 +103,6 @@ public class AgilityPlugin extends Plugin
 		return Arrays.asList(overlay, lapOverlay);
 	}
 
-	@Override
-	protected void shutDown() throws Exception
-	{
-		markOfGrace = null;
-		obstacles.clear();
-		session = null;
-	}
-
 	@Subscribe
 	public void onGameStateChange(GameStateChanged event)
 	{


### PR DESCRIPTION
Clearing the state caused the plugin to lose information about already spawned objects which are necessary to display the overlays correctly.
Since the overlays are not used when the plugin is disabled anyway, we simply maintain the state as well.

Note that this still loses information about any spawned objects while the plugin was disabled, however fixing that would require a far more drastic rewrite of this plugin.

For #2480 