### PR TITLE
Add Anti Drag Plugin

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/Client.java
+++ b/runelite-api/src/main/java/net/runelite/api/Client.java
@@ -410,4 +410,6 @@ public interface Client extends GameEngine
 	int getTickCount();
 
 	void setTickCount(int tickCount);
+
+	void setInventoryDragDelay(int delay);
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/antidrag/AntiDragConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/antidrag/AntiDragConfig.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2018, DennisDeV <https://github.com/DevDennis>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.antidrag;
+
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+
+@ConfigGroup(
+	keyName = AntiDragPlugin.CONFIG_GROUP,
+	name = "Anti Drag",
+	description = "Configuration for the anti drag plugin"
+)
+public interface AntiDragConfig extends Config
+{
+	@ConfigItem(
+		keyName = "dragDelay",
+		name = "Drag Delay",
+		description = "Configures the inventory drag delay in client ticks (20ms)",
+		position = 1
+	)
+	default int dragDelay()
+	{
+		return 600 / 20; // one game tick
+	}
+
+	@ConfigItem(
+		keyName = "dragDelay",
+		name = "",
+		description = ""
+	)
+	void dragDelay(int delay);
+
+	@ConfigItem(
+		keyName = "onShiftOnly",
+		name = "On Shift Only",
+		description = "Configures whether to only adjust the delay while holding shift",
+		position = 2
+	)
+	default boolean onShiftOnly()
+	{
+		return true;
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/antidrag/AntiDragPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/antidrag/AntiDragPlugin.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2018, DennisDeV <https://github.com/DevDennis>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.antidrag;
+
+import com.google.common.eventbus.Subscribe;
+import com.google.inject.Provides;
+import net.runelite.api.Client;
+import net.runelite.api.events.ConfigChanged;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.input.KeyListener;
+import net.runelite.client.input.KeyManager;
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginDescriptor;
+import javax.inject.Inject;
+import java.awt.event.KeyEvent;
+
+@PluginDescriptor(
+	name = "Anti Drag",
+	enabledByDefault = false
+)
+public class AntiDragPlugin extends Plugin implements KeyListener
+{
+	static final String CONFIG_GROUP = "antiDrag";
+
+	static final int DEFAULT_DELAY = 5;
+
+	@Inject
+	private Client client;
+
+	@Inject
+	private AntiDragConfig config;
+
+	@Inject
+	private KeyManager keyManager;
+
+	@Provides
+	AntiDragConfig getConfig(ConfigManager configManager)
+	{
+		return configManager.getConfig(AntiDragConfig.class);
+	}
+
+	@Override
+	protected void startUp() throws Exception
+	{
+		if (!config.onShiftOnly())
+		{
+			client.setInventoryDragDelay(config.dragDelay());
+		}
+		keyManager.registerKeyListener(this);
+	}
+
+	@Override
+	protected void shutDown() throws Exception
+	{
+		client.setInventoryDragDelay(DEFAULT_DELAY);
+		keyManager.unregisterKeyListener(this);
+	}
+
+	@Override
+	public void keyTyped(KeyEvent e)
+	{
+
+	}
+
+	@Override
+	public void keyPressed(KeyEvent e)
+	{
+		if (config.onShiftOnly() && e.getKeyCode() == KeyEvent.VK_SHIFT)
+		{
+			client.setInventoryDragDelay(config.dragDelay());
+		}
+	}
+
+	@Override
+	public void keyReleased(KeyEvent e)
+	{
+		if (config.onShiftOnly() && e.getKeyCode() == KeyEvent.VK_SHIFT)
+		{
+			client.setInventoryDragDelay(DEFAULT_DELAY);
+		}
+	}
+
+	@Subscribe
+	public void onConfigChanged(ConfigChanged event)
+	{
+		if (event.getGroup().equals(CONFIG_GROUP))
+		{
+			if (config.onShiftOnly())
+			{
+				client.setInventoryDragDelay(DEFAULT_DELAY);
+			}
+			else
+			{
+				client.setInventoryDragDelay(config.dragDelay());
+			}
+		}
+	}
+}

--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSClientMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSClientMixin.java
@@ -124,6 +124,12 @@ public abstract class RSClientMixin implements RSClient
 	private static RSNPC[] oldNpcs = new RSNPC[32768];
 
 	@Inject
+	private static int itemPressedDurationBuffer;
+
+	@Inject
+	private static int inventoryDragDelay;
+
+	@Inject
 	@Override
 	public boolean isInterpolatePlayerAnimations()
 	{
@@ -163,6 +169,13 @@ public abstract class RSClientMixin implements RSClient
 	public void setInterpolateObjectAnimations(boolean interpolate)
 	{
 		interpolateObjectAnimations = interpolate;
+	}
+
+	@Inject
+	@Override
+	public void setInventoryDragDelay(int delay)
+	{
+		inventoryDragDelay = delay;
 	}
 
 	@Inject
@@ -630,6 +643,28 @@ public abstract class RSClientMixin implements RSClient
 			WidgetLoaded event = new WidgetLoaded();
 			event.setGroupId(groupId);
 			eventBus.post(event);
+		}
+	}
+
+	@FieldHook("itemPressedDuration")
+	@Inject
+	public static void itemPressedDurationChanged(int idx)
+	{
+		if (client.getItemPressedDuration() > 0)
+		{
+			itemPressedDurationBuffer++;
+			if (itemPressedDurationBuffer >= inventoryDragDelay)
+			{
+				client.setItemPressedDuration(itemPressedDurationBuffer);
+			}
+			else
+			{
+				client.setItemPressedDuration(0);
+			}
+		}
+		else
+		{
+			itemPressedDurationBuffer = 0;
 		}
 	}
 

--- a/runescape-api/src/main/java/net/runelite/rs/api/RSClient.java
+++ b/runescape-api/src/main/java/net/runelite/rs/api/RSClient.java
@@ -612,4 +612,10 @@ public interface RSClient extends RSGameEngine, Client
 	@Import("isDynamicRegion")
 	@Override
 	boolean isInInstancedRegion();
+
+	@Import("itemPressedDuration")
+	int getItemPressedDuration();
+
+	@Import("itemPressedDuration")
+	void setItemPressedDuration(int duration);
 }


### PR DESCRIPTION
- Allows you to configure the delay before you start dragging an item in your inventory in client ticks (20ms)
- Choose whether you want the delay while holding shift only

Adds https://github.com/runelite/runelite/issues/1062, https://github.com/runelite/runelite/issues/1669, https://github.com/runelite/runelite/issues/2299

![2018-05-08_23-15-34](https://user-images.githubusercontent.com/11643842/39783630-f8647e9a-5315-11e8-9433-5f792139da34.gif)
