### PR TITLE
runelite-client: Make notification options not mutually excusive

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/Notifier.java
+++ b/runelite-client/src/main/java/net/runelite/client/Notifier.java
@@ -43,8 +43,6 @@ import java.util.Optional;
 import java.util.concurrent.ScheduledExecutorService;
 import javax.inject.Provider;
 import javax.inject.Singleton;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
@@ -57,25 +55,6 @@ import net.runelite.client.util.OSType;
 @Slf4j
 public class Notifier
 {
-	@Getter
-	@RequiredArgsConstructor
-	public enum NotificationMode
-	{
-		TRAY("System tray"),
-		BEEP("System beep"),
-		MESSAGE("Game message"),
-		FLASH("Screen flash"),
-		OFF("Off");
-
-		private final String name;
-
-		@Override
-		public String toString()
-		{
-			return name;
-		}
-	}
-
 	// Default timeout of notification in milliseconds
 	private static final int DEFAULT_TIMEOUT = 10000;
 	private static final String DOUBLE_QUOTE = "\"";
@@ -137,27 +116,30 @@ public class Notifier
 			clientUI.requestFocus();
 		}
 
-		switch (runeLiteConfig.notificationMode())
+		if (runeLiteConfig.enableTrayNotifications())
 		{
-			case TRAY:
-				sendNotification(appName, message, type);
-				break;
-			case BEEP:
-				Toolkit.getDefaultToolkit().beep();
-				break;
-			case MESSAGE:
-				final Client client = this.client.get();
+			sendNotification(appName, message, type);
+		}
 
-				if (client != null && client.getGameState() == GameState.LOGGED_IN)
-				{
-					client.addChatMessage(ChatMessageType.GAME, appName,
-						"<col=" + MESSAGE_COLOR + ">" + message + "</col>", "");
-				}
+		if (runeLiteConfig.enableNotificationSound())
+		{
+			Toolkit.getDefaultToolkit().beep();
+		}
 
-				break;
-			case FLASH:
-				flashStart = Instant.now();
-				break;
+		if (runeLiteConfig.enableGameMessageNotification())
+		{
+			final Client client = this.client.get();
+
+			if (client != null && client.getGameState() == GameState.LOGGED_IN)
+			{
+				client.addChatMessage(ChatMessageType.GAME, appName,
+					"<col=" + MESSAGE_COLOR + ">" + message + "</col>", "");
+			}
+		}
+
+		if (runeLiteConfig.enableFlashNotification())
+		{
+			flashStart = Instant.now();
 		}
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/config/RuneLiteConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/RuneLiteConfig.java
@@ -26,7 +26,6 @@ package net.runelite.client.config;
 
 import java.awt.Dimension;
 import net.runelite.api.Constants;
-import net.runelite.client.Notifier;
 
 @ConfigGroup(
 	keyName = "runelite",
@@ -39,7 +38,7 @@ public interface RuneLiteConfig extends Config
 		keyName = "gameSize",
 		name = "Game size",
 		description = "The game will resize to this resolution upon starting the client",
-		position = 1
+		position = 10
 	)
 	default Dimension gameSize()
 	{
@@ -50,7 +49,7 @@ public interface RuneLiteConfig extends Config
 		keyName = "automaticResizeType",
 		name = "Resize type",
 		description = "Choose how the window should resize when opening and closing panels",
-		position = 2
+		position = 11
 	)
 	default ExpandResizeType automaticResizeType()
 	{
@@ -61,7 +60,7 @@ public interface RuneLiteConfig extends Config
 		keyName = "lockWindowSize",
 		name = "Lock window size",
 		description = "Determines if the window resizing is allowed or not",
-		position = 3
+		position = 12
 	)
 	default boolean lockWindowSize()
 	{
@@ -69,99 +68,10 @@ public interface RuneLiteConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "uiEnableCustomChrome",
-		name = "Enable custom window chrome",
-		description = "Use Runelite's custom window title and borders.",
-		warning = "Please restart your client after changing this setting",
-		position = 4
-	)
-	default boolean enableCustomChrome()
-	{
-		return true;
-	}
-
-	@ConfigItem(
-		keyName = "gameAlwaysOnTop",
-		name = "Enable client always on top",
-		description = "The game will always be on the top of the screen",
-		position = 5
-	)
-	default boolean gameAlwaysOnTop()
-	{
-		return false;
-	}
-
-	@ConfigItem(
-		keyName = "notificationMode",
-		name = "Notification mode",
-		description = "Determines mode of notifications",
-		position = 6
-	)
-	default Notifier.NotificationMode notificationMode()
-	{
-		return Notifier.NotificationMode.TRAY;
-	}
-
-	@ConfigItem(
-		keyName = "notificationFocused",
-		name = "Send notifications when focused",
-		description = "Toggles idle notifications for when the client is focused",
-		position = 7
-	)
-	default boolean sendNotificationsWhenFocused()
-	{
-		return false;
-	}
-
-	@ConfigItem(
-		keyName = "notificationRequestFocus",
-		name = "Request focus on notification",
-		description = "Toggles window focus request",
-		position = 8
-	)
-	default boolean requestFocusOnNotification()
-	{
-		return true;
-	}
-
-	@ConfigItem(
-		keyName = "fontType",
-		name = "Dynamic Overlay Font",
-		description = "Configures what font type is used for in-game overlays such as player name, ground items, etc.",
-		position = 9
-	)
-	default FontType fontType()
-	{
-		return FontType.SMALL;
-	}
-
-	@ConfigItem(
-		keyName = "infoBoxVertical",
-		name = "Display infoboxes vertically",
-		description = "Toggles the infoboxes to display vertically",
-		position = 10
-	)
-	default boolean infoBoxVertical()
-	{
-		return false;
-	}
-
-	@ConfigItem(
-		keyName = "infoBoxWrap",
-		name = "Infobox wrap count",
-		description = "Configures the amount of infoboxes shown before wrapping",
-		position = 11
-	)
-	default int infoBoxWrap()
-	{
-		return 4;
-	}
-
-	@ConfigItem(
 		keyName = "containInScreen",
 		name = "Contain in screen",
 		description = "Makes the client stay contained in the screen when attempted to move out of it.<br>Note: Only works if custom chrome is enabled.",
-		position = 12
+		position = 13
 	)
 	default boolean containInScreen()
 	{
@@ -172,10 +82,132 @@ public interface RuneLiteConfig extends Config
 		keyName = "rememberScreenBounds",
 		name = "Remember client position",
 		description = "Save the position and size of the client after exiting",
-		position = 13
+		position = 14
 	)
 	default boolean rememberScreenBounds()
 	{
 		return true;
+	}
+
+	@ConfigItem(
+		keyName = "uiEnableCustomChrome",
+		name = "Enable custom window chrome",
+		description = "Use Runelite's custom window title and borders.",
+		warning = "Please restart your client after changing this setting",
+		position = 15
+	)
+	default boolean enableCustomChrome()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		keyName = "gameAlwaysOnTop",
+		name = "Enable client always on top",
+		description = "The game will always be on the top of the screen",
+		position = 16
+	)
+	default boolean gameAlwaysOnTop()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		keyName = "notificationTray",
+		name = "Enable tray notifications",
+		description = "Enables tray notifications",
+		position = 20
+	)
+	default boolean enableTrayNotifications()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		keyName = "notificationRequestFocus",
+		name = "Request focus on notification",
+		description = "Toggles window focus request",
+		position = 21
+	)
+	default boolean requestFocusOnNotification()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		keyName = "notificationSound",
+		name = "Enable sound on notifications",
+		description = "Enables the playing of a beep sound when notifications are displayed",
+		position = 22
+	)
+	default boolean enableNotificationSound()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		keyName = "notificationGameMessage",
+		name = "Enable game message notifications",
+		description = "Puts a notification message in the chatbox",
+		position = 23
+	)
+	default boolean enableGameMessageNotification()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		keyName = "notificationFlash",
+		name = "Enable flash notification",
+		description = "Flashes the game frame as a notification",
+		position = 24
+	)
+	default boolean enableFlashNotification()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		keyName = "notificationFocused",
+		name = "Send notifications when focused",
+		description = "Toggles idle notifications for when the client is focused",
+		position = 25
+	)
+	default boolean sendNotificationsWhenFocused()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		keyName = "fontType",
+		name = "Dynamic Overlay Font",
+		description = "Configures what font type is used for in-game overlays such as player name, ground items, etc.",
+		position = 30
+	)
+	default FontType fontType()
+	{
+		return FontType.SMALL;
+	}
+
+	@ConfigItem(
+		keyName = "infoBoxVertical",
+		name = "Display infoboxes vertically",
+		description = "Toggles the infoboxes to display vertically",
+		position = 31
+	)
+	default boolean infoBoxVertical()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		keyName = "infoBoxWrap",
+		name = "Infobox wrap count",
+		description = "Configures the amount of infoboxes shown before wrapping",
+		position = 32
+	)
+	default int infoBoxWrap()
+	{
+		return 4;
 	}
 }


### PR DESCRIPTION
#2180 made it so Windows users could not have sound and a tray notification at the same time. This splits the enum into separate booleans

Cherry-picked from: #2230