### PR TITLE
http-api: Print a more helpful error message when maven has not worked

### DIFF
--- a/http-api/src/main/java/net/runelite/http/api/RuneLiteAPI.java
+++ b/http-api/src/main/java/net/runelite/http/api/RuneLiteAPI.java
@@ -58,6 +58,10 @@ public class RuneLiteAPI
 			version = properties.getProperty("runelite.version");
 			rsVersion = Integer.parseInt(properties.getProperty("rs.version"));
 		}
+		catch (NumberFormatException e)
+		{
+			throw new RuntimeException("Version string has not been substituted; Re-run maven");
+		}
 		catch (IOException ex)
 		{
 			logger.error(null, ex);


### PR DESCRIPTION
We get a minimum of one person a day having this error because maven can't build correctly on first run. This makes throws a more useful exception when this happens.