### PR TITLE
Add support for map for hot/cold clues

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/ClueScrollPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/ClueScrollPlugin.java
@@ -34,8 +34,6 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import java.util.stream.Stream;
 import javax.imageio.ImageIO;
 import javax.inject.Inject;
@@ -94,10 +92,6 @@ import net.runelite.client.util.Text;
 public class ClueScrollPlugin extends Plugin
 {
 	private static final Duration WAIT_DURATION = Duration.ofMinutes(4);
-
-	private static final Pattern INITIAL_STRANGE_DEVICE_MESSAGE = Pattern.compile("The device is (.*)");
-	private static final Pattern STRANGE_DEVICE_MESSAGE = Pattern.compile("The device is (.*), (.*) last time\\.");
-	private static final Pattern FINAL_STRANGE_DEVICE_MESSAGE = Pattern.compile("The device is visibly shaking.*");
 
 	public static final BufferedImage CLUE_SCROLL_IMAGE;
 	public static final BufferedImage MAP_ARROW;
@@ -193,46 +187,9 @@ public class ClueScrollPlugin extends Plugin
 			return;
 		}
 
-		if (clue instanceof HotColdClue && event.getMessage().startsWith("The device is"))
+		if (clue instanceof HotColdClue)
 		{
-			HotColdClue hotColdClue = (HotColdClue) clue;
-			String message = event.getMessage();
-			Matcher m1 = FINAL_STRANGE_DEVICE_MESSAGE.matcher(message);
-			Matcher m2 = STRANGE_DEVICE_MESSAGE.matcher(message);
-			Matcher m3 = INITIAL_STRANGE_DEVICE_MESSAGE.matcher(message);
-
-			// the order that these pattern matchers are checked is important
-			if (m1.find())
-			{
-				// final location for hot cold clue has been found
-				WorldPoint localWorld = client.getLocalPlayer().getWorldLocation();
-
-				if (localWorld != null)
-				{
-					hotColdClue.markFinalSpot(localWorld);
-				}
-			}
-			else if (m2.find())
-			{
-				String temperature = m2.group(1);
-				String difference = m2.group(2);
-				WorldPoint localWorld = client.getLocalPlayer().getWorldLocation();
-
-				if (localWorld != null)
-				{
-					hotColdClue.updatePossibleArea(localWorld, temperature, difference);
-				}
-			}
-			else if (m3.find())
-			{
-				String temperature = m3.group(1);
-				WorldPoint localWorld = client.getLocalPlayer().getWorldLocation();
-
-				if (localWorld != null)
-				{
-					hotColdClue.updatePossibleArea(localWorld, temperature, "");
-				}
-			}
+			((HotColdClue)clue).update(event.getMessage(), this);
 		}
 
 		if (!event.getMessage().equals("The strange device cools as you find your treasure.")

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/ClueScrollPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/ClueScrollPlugin.java
@@ -174,14 +174,9 @@ public class ClueScrollPlugin extends Plugin
 	}
 
 	@Override
-	protected void startUp() throws Exception
-	{
-	}
-
-	@Override
 	protected void shutDown() throws Exception
 	{
-		clearMapPoint();
+		resetClue();
 	}
 
 	@Override
@@ -437,7 +432,11 @@ public class ClueScrollPlugin extends Plugin
 		clueItemChanged = false;
 		clue = null;
 
-		clearMapPoint();
+		if (worldMapPoint != null)
+		{
+			worldMapPointManager.remove(worldMapPoint);
+			worldMapPoint = null;
+		}
 
 		if (config.displayHintArrows())
 		{
@@ -601,14 +600,5 @@ public class ClueScrollPlugin extends Plugin
 			worldMapPointManager.add(worldMapPoint);
 		}
 		worldMapPoint.setWorldPoint(point);
-	}
-
-	private void clearMapPoint()
-	{
-		if (worldMapPoint != null)
-		{
-			worldMapPointManager.remove(worldMapPoint);
-			worldMapPoint = null;
-		}
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/ClueScrollPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/ClueScrollPlugin.java
@@ -596,9 +596,8 @@ public class ClueScrollPlugin extends Plugin
 	{
 		if (worldMapPoint == null)
 		{
-			worldMapPoint = new ClueScrollWorldMapPoint();
+			worldMapPoint = new ClueScrollWorldMapPoint(point);
 			worldMapPointManager.add(worldMapPoint);
 		}
-		worldMapPoint.setWorldPoint(point);
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/ClueScrollWorldMapPoint.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/ClueScrollWorldMapPoint.java
@@ -27,44 +27,46 @@ package net.runelite.client.plugins.cluescrolls;
 import java.awt.Graphics;
 import java.awt.image.BufferedImage;
 import net.runelite.api.Point;
+import net.runelite.api.coords.WorldPoint;
 import net.runelite.client.ui.overlay.worldmap.WorldMapPoint;
 
 class ClueScrollWorldMapPoint extends WorldMapPoint
 {
-	private final BufferedImage worldMapImage;
-	private final Point imagePoint;
-	private final BufferedImage edgeSnapImage;
+	private static final BufferedImage CLUE_SCROLL_WORLD_IMAGE;
+	private static final Point CLUE_SCROLL_WORLD_IMAGE_POINT;
 
-	ClueScrollWorldMapPoint()
+	static
 	{
-		super(null, null);
+		CLUE_SCROLL_WORLD_IMAGE = new BufferedImage(ClueScrollPlugin.MAP_ARROW.getWidth(), ClueScrollPlugin.MAP_ARROW.getHeight(), BufferedImage.TYPE_INT_ARGB);
+		Graphics graphics = CLUE_SCROLL_WORLD_IMAGE.getGraphics();
+		graphics.drawImage(ClueScrollPlugin.MAP_ARROW, 0, 0, null);
+		graphics.drawImage(ClueScrollPlugin.CLUE_SCROLL_IMAGE, 0, 2, null);
+		CLUE_SCROLL_WORLD_IMAGE_POINT = new Point(
+			CLUE_SCROLL_WORLD_IMAGE.getWidth() / 2,
+			CLUE_SCROLL_WORLD_IMAGE.getHeight());
+	}
+
+	ClueScrollWorldMapPoint(final WorldPoint worldPoint)
+	{
+		super(worldPoint, null);
 
 		this.setSnapToEdge(true);
 		this.setJumpOnClick(true);
-
-		worldMapImage = new BufferedImage(ClueScrollPlugin.MAP_ARROW.getWidth(), ClueScrollPlugin.MAP_ARROW.getHeight(), BufferedImage.TYPE_INT_ARGB);
-		Graphics graphics = worldMapImage.getGraphics();
-		graphics.drawImage(ClueScrollPlugin.MAP_ARROW, 0, 0, null);
-		graphics.drawImage(ClueScrollPlugin.CLUE_SCROLL_IMAGE, 0,  2, null);
-
-		imagePoint = new Point(worldMapImage.getWidth() / 2, worldMapImage.getHeight());
-		this.setImage(worldMapImage);
-		this.setImagePoint(imagePoint);
-
-		edgeSnapImage = ClueScrollPlugin.CLUE_SCROLL_IMAGE;
+		this.setImage(CLUE_SCROLL_WORLD_IMAGE);
+		this.setImagePoint(CLUE_SCROLL_WORLD_IMAGE_POINT);
 	}
 
 	@Override
 	public void onEdgeSnap()
 	{
-		this.setImage(edgeSnapImage);
+		this.setImage(ClueScrollPlugin.CLUE_SCROLL_IMAGE);
 		this.setImagePoint(null);
 	}
 
 	@Override
 	public void onEdgeUnsnap()
 	{
-		this.setImage(worldMapImage);
-		this.setImagePoint(imagePoint);
+		this.setImage(CLUE_SCROLL_WORLD_IMAGE);
+		this.setImagePoint(CLUE_SCROLL_WORLD_IMAGE_POINT);
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/HotColdClue.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/HotColdClue.java
@@ -24,6 +24,7 @@
  */
 package net.runelite.client.plugins.cluescrolls.clues;
 
+import com.google.common.collect.Lists;
 import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Graphics2D;
@@ -58,7 +59,7 @@ import net.runelite.client.ui.overlay.components.TitleComponent;
 
 @Getter
 @RequiredArgsConstructor
-public class HotColdClue extends ClueScroll implements TextClueScroll, NpcClueScroll
+public class HotColdClue extends ClueScroll implements LocationClueScroll, LocationsClueScroll, TextClueScroll, NpcClueScroll
 {
 	private static final Pattern INITIAL_STRANGE_DEVICE_MESSAGE = Pattern.compile("The device is (.*)");
 	private static final Pattern STRANGE_DEVICE_MESSAGE = Pattern.compile("The device is (.*), (.*) last time\\.");
@@ -75,6 +76,22 @@ public class HotColdClue extends ClueScroll implements TextClueScroll, NpcClueSc
 	private final String solution;
 	private WorldPoint location;
 	private WorldPoint lastWorldPoint;
+
+	public static HotColdClue forText(String text)
+	{
+		if (CLUE.text.equalsIgnoreCase(text))
+		{
+			return CLUE;
+		}
+
+		return null;
+	}
+
+	@Override
+	public List<WorldPoint> getLocations()
+	{
+		return Lists.transform(digLocations, HotColdLocation::getWorldPoint);
+	}
 
 	@Override
 	public void makeOverlayHint(PanelComponent panelComponent, ClueScrollPlugin plugin)
@@ -230,16 +247,7 @@ public class HotColdClue extends ClueScroll implements TextClueScroll, NpcClueSc
 		}
 	}
 
-	public static HotColdClue forText(String text)
-	{
-		if (CLUE.text.equalsIgnoreCase(text))
-		{
-			return CLUE;
-		}
-
-		return null;
-	}
-
+	@Override
 	public void update(final String message, final ClueScrollPlugin plugin)
 	{
 		if (!message.startsWith("The device is"))
@@ -283,6 +291,13 @@ public class HotColdClue extends ClueScroll implements TextClueScroll, NpcClueSc
 				updatePossibleArea(localWorld, temperature, "");
 			}
 		}
+	}
+
+	@Override
+	public void reset()
+	{
+		this.lastWorldPoint = null;
+		digLocations.clear();
 	}
 
 	private void updatePossibleArea(WorldPoint currentWp, String temperature, String difference)
@@ -400,12 +415,6 @@ public class HotColdClue extends ClueScroll implements TextClueScroll, NpcClueSc
 	private void markFinalSpot(WorldPoint wp)
 	{
 		this.location = wp;
-		resetHotCold();
-	}
-
-	public void resetHotCold()
-	{
-		this.lastWorldPoint = null;
-		digLocations.clear();
+		reset();
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/LocationsClueScroll.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/LocationsClueScroll.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Morgan Lewis <https://github.com/MESLewis>
+ * Copyright (c) 2018, Tomas Slusny <slusnucky@gmail.com>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -22,33 +22,17 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package net.runelite.client.ui.overlay.worldmap;
+package net.runelite.client.plugins.cluescrolls.clues;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.function.Predicate;
-import javax.inject.Singleton;
-import lombok.AccessLevel;
-import lombok.Getter;
+import net.runelite.api.coords.WorldPoint;
+import net.runelite.client.plugins.cluescrolls.ClueScrollPlugin;
 
-@Singleton
-public class WorldMapPointManager
+public interface LocationsClueScroll
 {
-	@Getter(AccessLevel.PACKAGE)
-	private final List<WorldMapPoint> worldMapPoints = new ArrayList<>();
+	void update(String message, ClueScrollPlugin plugin);
 
-	public void add(WorldMapPoint worldMapPoint)
-	{
-		worldMapPoints.add(worldMapPoint);
-	}
+	void reset();
 
-	public void remove(WorldMapPoint worldMapPoint)
-	{
-		worldMapPoints.remove(worldMapPoint);
-	}
-
-	public void removeIf(Predicate<WorldMapPoint> filter)
-	{
-		worldMapPoints.removeIf(filter);
-	}
+	List<WorldPoint> getLocations();
 }

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/worldmap/WorldMapOverlayMouseListener.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/worldmap/WorldMapOverlayMouseListener.java
@@ -56,7 +56,8 @@ public class WorldMapOverlayMouseListener extends MouseListener
 	@Override
 	public MouseEvent mousePressed(MouseEvent e)
 	{
-		List<WorldMapPoint> worldMapPoints = worldMapPointManager.getWorldMapPoints();
+		final List<WorldMapPoint> worldMapPoints = worldMapPointManager.getWorldMapPoints();
+
 		if (SwingUtilities.isLeftMouseButton(e) && !worldMapPoints.isEmpty())
 		{
 			Point mousePos = clientProvider.get().getMouseCanvasPosition();
@@ -84,7 +85,8 @@ public class WorldMapOverlayMouseListener extends MouseListener
 	@Override
 	public MouseEvent mouseMoved(MouseEvent mouseEvent)
 	{
-		List<WorldMapPoint> worldMapPoints = worldMapPointManager.getWorldMapPoints();
+		final List<WorldMapPoint> worldMapPoints = worldMapPointManager.getWorldMapPoints();
+
 		if (worldMapPoints.isEmpty())
 		{
 			return mouseEvent;


### PR DESCRIPTION
- Improve the WorldMapPointManager to handle multiple world points
better
- Create new interface for clues that will return multiple locations,
have update and reset methods for clues with undetermined location
- Implement new LocationsClueScroll and LocationClueScroll to
HotColdClue to add support for displaying all the points on world map
- Handle the LocationsClueScroll to add each WorldPoint to the world map
when found
- Move part of the HotCold logic to the HotColdClue
- Improve the ClueScrollWorldMapPoint to not create BufferedImage for each of it's instance

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>