### PR TITLE
Add ItemLayer height to GroundItems overlay

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItem.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItem.java
@@ -38,6 +38,7 @@ class GroundItem
 	private String name;
 	private int quantity;
 	private WorldPoint location;
+	private int height;
 	private int haPrice;
 	private int gePrice;
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
@@ -181,7 +181,8 @@ public class GroundItemsOverlay extends Overlay
 			final Point textPoint = Perspective.getCanvasTextLocation(client,
 				graphics,
 				groundPoint,
-				itemString, OFFSET_Z);
+				itemString,
+				item.getHeight() + OFFSET_Z);
 
 			if (textPoint == null)
 			{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
@@ -265,6 +265,7 @@ public class GroundItemsPlugin extends Plugin
 
 					if (groundItem != null)
 					{
+						groundItem.setHeight(itemLayer.getHeight());
 						groundItems.add(groundItem);
 					}
 				}


### PR DESCRIPTION
Add back ItemLayer#getHeight consideration when drawing ground items.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>