### PR TITLE
Party average combat lvl

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsPointsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsPointsOverlay.java
@@ -82,23 +82,26 @@ public class RaidsPointsOverlay extends Overlay
 			.right(String.valueOf(client.getVar(Varbits.RAID_PARTY_SIZE)))
 			.build());
 
-		if(totalPoints==0) //Calculates average combat level of the party before the raid has begun
-		{
-			int sumOfCombatLvls = 0;
+		if (totalPoints == 0) // Calculates average combat level of the party before the raid has begun
+        {
+            panel.getChildren().add(LineComponent.builder()
+                    .left("Average combat:")
+                    .right(String.valueOf(averageCombat()))
+                    .build());
 
-			for(Player currPlayer :client.getPlayers())
-			{
-				sumOfCombatLvls += currPlayer.getCombatLevel();
-			}
-			int averageCombat = sumOfCombatLvls/client.getPlayers().size();
-
-			panel.getChildren().add(LineComponent.builder()
-					.left("Average combat:")
-					.right(String.valueOf(averageCombat))
-					.build());
-
-		}
+        }
 
 		return panel.render(graphics);
+	}
+
+	private int averageCombat()
+	{
+		int sumOfCombatLvls = 0;
+
+		for (Player currPlayer :client.getPlayers())
+		{
+			sumOfCombatLvls += currPlayer.getCombatLevel();
+		}
+		return sumOfCombatLvls/client.getPlayers().size();
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsPointsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsPointsOverlay.java
@@ -28,6 +28,7 @@ import java.awt.Dimension;
 import java.awt.Graphics2D;
 import javax.inject.Inject;
 import net.runelite.api.Client;
+import net.runelite.api.Player;
 import net.runelite.api.Varbits;
 import static net.runelite.client.plugins.raids.RaidsPlugin.POINTS_FORMAT;
 import net.runelite.client.ui.overlay.Overlay;
@@ -64,6 +65,7 @@ public class RaidsPointsOverlay extends Overlay
 		int totalPoints = client.getVar(Varbits.TOTAL_POINTS);
 		int personalPoints = client.getVar(Varbits.PERSONAL_POINTS);
 
+
 		panel.getChildren().clear();
 		panel.getChildren().add(LineComponent.builder()
 			.left("Total:")
@@ -79,6 +81,23 @@ public class RaidsPointsOverlay extends Overlay
 			.left("Party size:")
 			.right(String.valueOf(client.getVar(Varbits.RAID_PARTY_SIZE)))
 			.build());
+
+		if(totalPoints==0) //Calculates average combat level of the party before the raid has begun
+		{
+			int sumOfCombatLvls = 0;
+
+			for(Player currPlayer :client.getPlayers())
+			{
+				sumOfCombatLvls += currPlayer.getCombatLevel();
+			}
+			int averageCombat = sumOfCombatLvls/client.getPlayers().size();
+
+			panel.getChildren().add(LineComponent.builder()
+					.left("Average combat:")
+					.right(String.valueOf(averageCombat))
+					.build());
+
+		}
 
 		return panel.render(graphics);
 	}


### PR DESCRIPTION
Displays average combat level before raid has begun. This is helpful in large parties with many alts and people going in and out