### PR TITLE
Fix Jad overlay plugin with multiple prayer indicators

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/fightcave/FightCaveOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/fightcave/FightCaveOverlay.java
@@ -69,6 +69,7 @@ public class FightCaveOverlay extends Overlay
 			return null;
 		}
 		BufferedImage prayerImage = getPrayerImage(attack);
+		imagePanelComponent.getChildren().clear();
 		imagePanelComponent.getChildren().add(new ImageComponent(prayerImage));
 
 		if (!client.isPrayerActive(attack.getPrayer()))


### PR DESCRIPTION
Clear children of the Panel Component before adding another child so only 1 exists at a time. Fixes #2556