### PR TITLE
Add option for Minimap Orbs to be left aligned

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/minimap/AlignmentMode.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/minimap/AlignmentMode.java
@@ -1,0 +1,22 @@
+package net.runelite.client.plugins.minimap;
+
+public enum AlignmentMode
+{
+	OFF("Off"),
+	FIXED("Fixed"),
+	RESIZEABLE("Resizeable"),
+	BOTH("Both");
+
+	private final String name;
+
+	AlignmentMode(String name)
+	{
+		this.name = name;
+	}
+
+	@Override
+	public String toString()
+	{
+		return name;
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/minimap/MinimapConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/minimap/MinimapConfig.java
@@ -110,8 +110,8 @@ public interface MinimapConfig extends Config
 		name = "Left Align Orbs",
 		description = "Align the Health, Prayer, Run and Special Attack orbs to the left."
 	)
-	default boolean leftAlignOrbs()
+	default AlignmentMode leftAlignOrbs()
 	{
-		return false;
+		return AlignmentMode.OFF;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/minimap/MinimapConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/minimap/MinimapConfig.java
@@ -104,4 +104,14 @@ public interface MinimapConfig extends Config
 	{
 		return false;
 	}
+
+	@ConfigItem(
+		keyName = "leftAlignOrbs",
+		name = "Left Align Orbs",
+		description = "Align the Health, Prayer, Run and Special Attack orbs to the left."
+	)
+	default boolean leftAlignOrbs()
+	{
+		return false;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/minimap/MinimapPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/minimap/MinimapPlugin.java
@@ -35,7 +35,9 @@ import net.runelite.api.SpritePixels;
 import net.runelite.api.events.ConfigChanged;
 import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.WidgetHiddenChanged;
+import net.runelite.api.events.WidgetLoaded;
 import net.runelite.api.widgets.Widget;
+import net.runelite.api.widgets.WidgetID;
 import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.plugins.Plugin;
@@ -154,6 +156,18 @@ public class MinimapPlugin extends Plugin
 			return;
 		}
 
+		if (event.getKey().equals("leftAlignOrbs"))
+		{
+			if (config.leftAlignOrbs())
+			{
+				moveOrbs();
+			}
+			else
+			{
+				resetOrbs();
+			}
+		}
+
 		replaceMapDots();
 	}
 
@@ -184,4 +198,87 @@ public class MinimapPlugin extends Plugin
 		}
 	}
 
+	@Subscribe
+	public void onWidgetLoaded(WidgetLoaded event)
+	{
+		if (event.getGroupId() == WidgetID.MINIMAP_GROUP_ID)
+		{
+			if (config.leftAlignOrbs())
+			{
+				moveOrbs();
+			}
+		}
+	}
+
+	private void moveOrbs()
+	{
+		Widget healthOrb = client.getWidget(WidgetInfo.MINIMAP_HEALTH_ORB);
+		Widget prayerOrb = client.getWidget(WidgetInfo.MINIMAP_PRAYER_ORB);
+		Widget runOrb = client.getWidget(WidgetInfo.MINIMAP_RUN_ORB);
+		Widget specOrb = client.getWidget(WidgetInfo.MINIMAP_SPEC_ORB);
+
+		if (healthOrb != null)
+		{
+			healthOrb.setRelativeY(33);
+			healthOrb.setOriginalY(33);
+		}
+
+		if (prayerOrb != null)
+		{
+			prayerOrb.setRelativeY(65);
+			prayerOrb.setOriginalY(65);
+		}
+
+		if (runOrb != null)
+		{
+			runOrb.setRelativeX(0);
+			runOrb.setRelativeY(97);
+			runOrb.setOriginalX(0);
+			runOrb.setOriginalY(97);
+		}
+
+		if (specOrb != null)
+		{
+			specOrb.setRelativeX(0);
+			specOrb.setRelativeY(129);
+			specOrb.setOriginalX(0);
+			specOrb.setOriginalY(129);
+		}
+	}
+
+	private void resetOrbs()
+	{
+		Widget healthOrb = client.getWidget(WidgetInfo.MINIMAP_HEALTH_ORB);
+		Widget prayerOrb = client.getWidget(WidgetInfo.MINIMAP_PRAYER_ORB);
+		Widget runOrb = client.getWidget(WidgetInfo.MINIMAP_RUN_ORB);
+		Widget specOrb = client.getWidget(WidgetInfo.MINIMAP_SPEC_ORB);
+
+		if (healthOrb != null)
+		{
+			healthOrb.setRelativeY(37);
+			healthOrb.setOriginalY(37);
+		}
+
+		if (prayerOrb != null)
+		{
+			prayerOrb.setRelativeY(71);
+			prayerOrb.setOriginalY(71);
+		}
+
+		if (runOrb != null)
+		{
+			runOrb.setRelativeX(10);
+			runOrb.setRelativeY(103);
+			runOrb.setOriginalX(10);
+			runOrb.setOriginalY(103);
+		}
+
+		if (specOrb != null)
+		{
+			specOrb.setRelativeX(32);
+			specOrb.setRelativeY(128);
+			specOrb.setOriginalX(32);
+			specOrb.setOriginalY(128);
+		}
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/minimap/MinimapPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/minimap/MinimapPlugin.java
@@ -34,6 +34,7 @@ import net.runelite.api.GameState;
 import net.runelite.api.SpritePixels;
 import net.runelite.api.events.ConfigChanged;
 import net.runelite.api.events.GameStateChanged;
+import net.runelite.api.events.ResizeableChanged;
 import net.runelite.api.events.WidgetHiddenChanged;
 import net.runelite.api.events.WidgetLoaded;
 import net.runelite.api.widgets.Widget;
@@ -158,9 +159,24 @@ public class MinimapPlugin extends Plugin
 
 		if (event.getKey().equals("leftAlignOrbs"))
 		{
-			if (config.leftAlignOrbs())
+			if (config.leftAlignOrbs() != AlignmentMode.OFF)
 			{
-				moveOrbs();
+				if (config.leftAlignOrbs() == AlignmentMode.BOTH)
+				{
+					moveOrbs();
+				}
+				else if (!client.isResized() && config.leftAlignOrbs() == AlignmentMode.FIXED)
+				{
+					moveOrbs();
+				}
+				else if (client.isResized() && config.leftAlignOrbs() == AlignmentMode.RESIZEABLE)
+				{
+					moveOrbs();
+				}
+				else
+				{
+					resetOrbs();
+				}
 			}
 			else
 			{
@@ -169,6 +185,27 @@ public class MinimapPlugin extends Plugin
 		}
 
 		replaceMapDots();
+	}
+
+	@Subscribe
+	public void onResizeableChanged(ResizeableChanged event)
+	{
+		if (config.leftAlignOrbs() == AlignmentMode.BOTH)
+		{
+			moveOrbs();
+		}
+		else if (!client.isResized() && config.leftAlignOrbs() == AlignmentMode.FIXED)
+		{
+			moveOrbs();
+		}
+		else if (client.isResized() && config.leftAlignOrbs() == AlignmentMode.RESIZEABLE)
+		{
+			moveOrbs();
+		}
+		else
+		{
+			resetOrbs();
+		}
 	}
 
 	@Subscribe
@@ -203,9 +240,20 @@ public class MinimapPlugin extends Plugin
 	{
 		if (event.getGroupId() == WidgetID.MINIMAP_GROUP_ID)
 		{
-			if (config.leftAlignOrbs())
+			if (config.leftAlignOrbs() != AlignmentMode.OFF)
 			{
-				moveOrbs();
+				if (config.leftAlignOrbs() == AlignmentMode.BOTH)
+				{
+					moveOrbs();
+				}
+				else if (!client.isResized() && config.leftAlignOrbs() == AlignmentMode.FIXED)
+				{
+					moveOrbs();
+				}
+				else if (client.isResized() && config.leftAlignOrbs() == AlignmentMode.RESIZEABLE)
+				{
+					moveOrbs();
+				}
 			}
 		}
 	}


### PR DESCRIPTION
![idea64_2018-05-11_04-08-28](https://user-images.githubusercontent.com/2979691/39904663-fba56346-54d0-11e8-9649-e0035a5760c3.png)

Simply aligns the orbs to the left. Allows Streamers who cover their minimap to still have their orbs showing without much effort.

Works in Fixed, Stretched Fixed, and Resizeable Modes.