### PR TITLE
Fixed % on opponent health

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/components/ProgressBarComponent.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/components/ProgressBarComponent.java
@@ -68,7 +68,7 @@ public class ProgressBarComponent implements LayoutableRenderableEntity
 		switch (labelDisplayMode)
 		{
 			case PERCENTAGE:
-				textToWrite = DECIMAL_FORMAT.format(Math.floor(pc)) + "%";
+				textToWrite = DECIMAL_FORMAT.format(Math.floor(pc * 100d)) + "%";
 				break;
 			default:
 				textToWrite = DECIMAL_FORMAT2.format(Math.floor(currentValue)) + "/" + maximum;


### PR DESCRIPTION
Added *100 to correctly display the opponent's health on the Opponent info overlay.