### PR TITLE
Fix updating of Hot/Cold clue

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/ClueScrollPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/ClueScrollPlugin.java
@@ -190,7 +190,10 @@ public class ClueScrollPlugin extends Plugin
 
 		if (clue instanceof LocationsClueScroll)
 		{
-			((LocationsClueScroll)clue).update(event.getMessage(), this);
+			if (((LocationsClueScroll)clue).update(event.getMessage(), this))
+			{
+				worldMapPointsSet = false;
+			}
 		}
 
 		if (!event.getMessage().equals("The strange device cools as you find your treasure.")
@@ -261,7 +264,11 @@ public class ClueScrollPlugin extends Plugin
 		if (clue instanceof LocationsClueScroll)
 		{
 			final List<WorldPoint> locations = ((LocationsClueScroll) clue).getLocations();
-			addMapPoints(locations.toArray(new WorldPoint[locations.size()]));
+
+			if (!locations.isEmpty())
+			{
+				addMapPoints(locations.toArray(new WorldPoint[locations.size()]));
+			}
 		}
 
 		// If we have location clue, set world location before all other types of clues
@@ -270,12 +277,15 @@ public class ClueScrollPlugin extends Plugin
 		{
 			final WorldPoint location = ((LocationClueScroll) clue).getLocation();
 
-			if (config.displayHintArrows() && location != null)
+			if (location != null)
 			{
-				client.setHintArrow(location);
-			}
+				if (config.displayHintArrows())
+				{
+					client.setHintArrow(location);
+				}
 
-			addMapPoints(location);
+				addMapPoints(location);
+			}
 		}
 
 		if (clue instanceof NpcClueScroll)
@@ -395,7 +405,7 @@ public class ClueScrollPlugin extends Plugin
 
 		clueItemChanged = false;
 		clue = null;
-		worldMapPointManager.removeIf(point -> point instanceof ClueScrollWorldMapPoint);
+		worldMapPointManager.removeIf(ClueScrollWorldMapPoint.class::isInstance);
 		worldMapPointsSet = false;
 
 		if (config.displayHintArrows())
@@ -560,6 +570,7 @@ public class ClueScrollPlugin extends Plugin
 		}
 
 		worldMapPointsSet = true;
+		worldMapPointManager.removeIf(ClueScrollWorldMapPoint.class::isInstance);
 
 		for (final WorldPoint point : points)
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/HotColdClue.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/HotColdClue.java
@@ -248,11 +248,11 @@ public class HotColdClue extends ClueScroll implements LocationClueScroll, Locat
 	}
 
 	@Override
-	public void update(final String message, final ClueScrollPlugin plugin)
+	public boolean update(final String message, final ClueScrollPlugin plugin)
 	{
 		if (!message.startsWith("The device is"))
 		{
-			return;
+			return false;
 		}
 
 		Matcher m1 = FINAL_STRANGE_DEVICE_MESSAGE.matcher(message);
@@ -268,6 +268,7 @@ public class HotColdClue extends ClueScroll implements LocationClueScroll, Locat
 			if (localWorld != null)
 			{
 				markFinalSpot(localWorld);
+				return true;
 			}
 		}
 		else if (m2.find())
@@ -279,6 +280,7 @@ public class HotColdClue extends ClueScroll implements LocationClueScroll, Locat
 			if (localWorld != null)
 			{
 				updatePossibleArea(localWorld, temperature, difference);
+				return true;
 			}
 		}
 		else if (m3.find())
@@ -289,8 +291,11 @@ public class HotColdClue extends ClueScroll implements LocationClueScroll, Locat
 			if (localWorld != null)
 			{
 				updatePossibleArea(localWorld, temperature, "");
+				return true;
 			}
 		}
+
+		return false;
 	}
 
 	@Override

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/LocationsClueScroll.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/LocationsClueScroll.java
@@ -30,7 +30,7 @@ import net.runelite.client.plugins.cluescrolls.ClueScrollPlugin;
 
 public interface LocationsClueScroll
 {
-	void update(String message, ClueScrollPlugin plugin);
+	boolean update(String message, ClueScrollPlugin plugin);
 
 	void reset();
 


### PR DESCRIPTION
Properly reset the WorldMapPoints when Hot/Cold clue updates.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>