### PR TITLE
Fix overlay system sizing

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/ClueScrollOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/ClueScrollOverlay.java
@@ -33,6 +33,7 @@ import javax.inject.Inject;
 import net.runelite.client.plugins.cluescrolls.clues.ClueScroll;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayPriority;
+import net.runelite.client.ui.overlay.components.ComponentConstants;
 import net.runelite.client.ui.overlay.components.PanelComponent;
 
 public class ClueScrollOverlay extends Overlay
@@ -60,6 +61,7 @@ public class ClueScrollOverlay extends Overlay
 		}
 
 		panelComponent.getChildren().clear();
+		panelComponent.setPreferredSize(new Dimension(ComponentConstants.STANDARD_WIDTH, 0));
 
 		clue.makeOverlayHint(panelComponent, plugin);
 

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/components/PanelComponent.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/components/PanelComponent.java
@@ -100,6 +100,22 @@ public class PanelComponent implements LayoutableRenderableEntity
 			preferredSize.width - border.x - border.width,
 			preferredSize.height - border.y - border.height);
 
+		// Adjust preferred size of children based on orientation and children
+		// sizes exceeding the parent size
+		switch (orientation)
+		{
+			case VERTICAL:
+				childPreferredSize.setSize(
+					Math.max(childDimensions.width, childPreferredSize.width),
+					childPreferredSize.height);
+				break;
+			case HORIZONTAL:
+				childPreferredSize.setSize(
+					childPreferredSize.width,
+					Math.max(childDimensions.height, childPreferredSize.height));
+				break;
+		}
+
 		// Render all children
 		for (final LayoutableRenderableEntity child : children)
 		{


### PR DESCRIPTION
- If panel component child exceeds the preferred size, correctly send this
new max size to other children, so they can resize/reposition themselves
correctly.
- To prevent affecting other clue types, reset the preferred size of the
clue scroll panel component to default value each render cycle, as the
clues can modify it.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>

Preview:
![screenie](https://cdn.discordapp.com/attachments/359016743802503178/444976532490944512/screenie.png)