### PR TITLE
tagging: Add toggle keyword to tagging

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/groundmarkers/GroundMarkerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/groundmarkers/GroundMarkerPlugin.java
@@ -64,7 +64,7 @@ import net.runelite.client.plugins.PluginDescriptor;
 public class GroundMarkerPlugin extends Plugin
 {
 	private static final String CONFIG_GROUP = "groundMarker";
-	private static final String MARK = "Mark tile";
+	private static final String MARK = "Toggle mark tile";
 	private static final String WALK_HERE = "Walk here";
 
 	private static final Gson gson = new Gson();

--- a/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsPlugin.java
@@ -56,7 +56,7 @@ import net.runelite.client.util.WildcardMatcher;
 public class NpcIndicatorsPlugin extends Plugin
 {
 	// Option added to NPC menu
-	private static final String TAG = "Tag";
+	private static final String TAG = "Toggle tag";
 
 	// Regex for splitting the hidden items in the config.
 	private static final String DELIMITER_REGEX = "\\s*,\\s*";


### PR DESCRIPTION
- Ground markers: "Toggle mark tile" instead of "Mark tile"
- NPC Indicators: "Toggle tag" instead of "Tag"

This is a *super lazy* enhancement to make the tagging text slightly more intuitive until #2184 is implemented.