### PR TITLE
overlayutil: reset stroke for renderpolygon

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayUtil.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayUtil.java
@@ -30,6 +30,7 @@ import java.awt.Dimension;
 import java.awt.Graphics2D;
 import java.awt.Polygon;
 import java.awt.RenderingHints;
+import java.awt.Stroke;
 import java.awt.geom.Area;
 import java.awt.image.BufferedImage;
 import net.runelite.api.Actor;
@@ -48,10 +49,12 @@ public class OverlayUtil
 	public static void renderPolygon(Graphics2D graphics, Polygon poly, Color color)
 	{
 		graphics.setColor(color);
+		final Stroke originalStroke = graphics.getStroke();
 		graphics.setStroke(new BasicStroke(2));
 		graphics.drawPolygon(poly);
 		graphics.setColor(new Color(0, 0, 0, 50));
 		graphics.fillPolygon(poly);
+		graphics.setStroke(originalStroke);
 	}
 
 	public static void renderMinimapLocation(Graphics2D graphics, Point mini, Color color)


### PR DESCRIPTION
If a plugin used a combination of renderPolygon and either used other util methods or draw on their own using the same graphics object, the stroke would get applied as well.

Before:
![capture](https://user-images.githubusercontent.com/2388657/39968126-1067d108-5696-11e8-9964-9f00346801c6.PNG)


After:
![ss 2018-05-13 09 57 38](https://user-images.githubusercontent.com/2388657/39968114-ec12554e-5695-11e8-8416-ee65e7fc710d.png)
