### PR TITLE
fix: Hide vanilla raid points box when inside chambers of xeric

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsPlugin.java
@@ -210,7 +210,7 @@ public class RaidsPlugin extends Plugin
 	@Subscribe
 	public void onWidgetHiddenChanged(WidgetHiddenChanged event)
 	{
-		if (!inRaidChambers || event.isHidden())
+		if (event.isHidden())
 		{
 			return;
 		}


### PR DESCRIPTION
Since commit 08c816e, the varbit change event is fired after this widget is shown and inRaidChambers is always false at that point. This would prevent the vanilla point box from being hidden.

Fixes #2621 