### PR TITLE
Show Logout of RuneLite on-top

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/account/AccountPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/account/AccountPlugin.java
@@ -38,6 +38,7 @@ import net.runelite.client.account.AccountSession;
 import net.runelite.client.account.SessionManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.ui.ClientUI;
 import net.runelite.client.ui.NavigationButton;
 import net.runelite.client.ui.TitleToolbar;
 import net.runelite.client.util.RunnableExceptionLogger;
@@ -57,6 +58,9 @@ public class AccountPlugin extends Plugin
 
 	@Inject
 	private ScheduledExecutorService executor;
+
+	@Inject
+	private ClientUI ui;
 
 	private NavigationButton loginButton;
 	private NavigationButton logoutButton;
@@ -120,7 +124,7 @@ public class AccountPlugin extends Plugin
 
 	private void logoutClick()
 	{
-		if (JOptionPane.YES_OPTION == JOptionPane.showConfirmDialog(null,
+		if (JOptionPane.YES_OPTION == JOptionPane.showConfirmDialog(ui.getContainer(),
 				"Are you sure you want to logout from RuneLite?", "Logout Confirmation",
 				JOptionPane.YES_NO_OPTION))
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/account/AccountPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/account/AccountPlugin.java
@@ -124,7 +124,7 @@ public class AccountPlugin extends Plugin
 
 	private void logoutClick()
 	{
-		if (JOptionPane.YES_OPTION == JOptionPane.showConfirmDialog(ui.getContainer(),
+		if (JOptionPane.YES_OPTION == JOptionPane.showConfirmDialog(ui.getFrame(),
 				"Are you sure you want to logout from RuneLite?", "Logout Confirmation",
 				JOptionPane.YES_NO_OPTION))
 		{

--- a/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
@@ -135,7 +135,10 @@ public class ClientUI
 	private JButton currentButton;
 	private NavigationButton currentNavButton;
 	private boolean sidebarOpen;
+
+	@Getter
 	private JPanel container;
+
 	private PluginPanel lastPluginPanel;
 	private NavigationButton sidebarNavigationButton;
 	private JButton sidebarNavigationJButton;

--- a/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
@@ -127,7 +127,10 @@ public class ClientUI
 	private final EventBus eventBus;
 	private final KeyManager keyManager;
 	private Applet client;
+
+	@Getter
 	private ContainableFrame frame;
+
 	private JPanel navContainer;
 	private PluginPanel pluginPanel;
 	private ClientPluginToolbar pluginToolbar;
@@ -135,10 +138,7 @@ public class ClientUI
 	private JButton currentButton;
 	private NavigationButton currentNavButton;
 	private boolean sidebarOpen;
-
-	@Getter
 	private JPanel container;
-
 	private PluginPanel lastPluginPanel;
 	private NavigationButton sidebarNavigationButton;
 	private JButton sidebarNavigationJButton;


### PR DESCRIPTION
Fixes #2690

[Previously, this PR fixed the issue](https://github.com/runelite/runelite/commit/be7d00c7224526d519d24583c50d64ab63bc0c7e#diff-7cbc9d32b3dd2afedc636b6e7abef3e1)
[I believe when this PR passed, it reverted the changes](https://github.com/runelite/runelite/commit/025211b9195cf6d82b8e1612104e36b573ef1783#diff-7cbc9d32b3dd2afedc636b6e7abef3e1)

So I added `@Getter` to `container` and injected `ClientUI` to `AccountPlugin`. Now whenever the user is logged into RuneLite and attempt to logout, the confirmation dialog will show on-top and centered relative to the client.