### PR TITLE
Add high hitpoints notification

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierConfig.java
@@ -70,8 +70,8 @@ public interface IdleNotifierConfig extends Config
 
 	@ConfigItem(
 		keyName = "hitpoints",
-		name = "Hitpoints Notification Threshold",
-		description = "The amount of hitpoints to send a notification at. A value of 0 will disable notification.",
+		name = "Low Hitpoints Threshold",
+		description = "Send a notification when you fall below this amount of hitpoints. A value of 0 will disable notification.",
 		position = 4
 	)
 	default int getHitpointsThreshold()
@@ -80,10 +80,21 @@ public interface IdleNotifierConfig extends Config
 	}
 
 	@ConfigItem(
+			keyName = "hp",
+			name = "High Hitpoints Threshold",
+			description = "Send a notification when you are above this amount of hitpoints. A value of 0 will disable notification.",
+			position = 5
+	)
+	default int getHPThreshold()
+	{
+		return 0;
+	}
+
+	@ConfigItem(
 		keyName = "prayer",
 		name = "Prayer Notification Threshold",
 		description = "The amount of prayer points to send a notification at. A value of 0 will disable notification.",
-		position = 5
+		position = 6
 	)
 	default int getPrayerThreshold()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
@@ -67,6 +67,7 @@ public class IdleNotifierPlugin extends Plugin
 	private Instant lastInteracting;
 	private boolean notifyIdle = false;
 	private boolean notifyHitpoints = true;
+	private boolean notifyHP = true;
 	private boolean notifyPrayer = true;
 	private boolean notifyIdleLogout = true;
 	private boolean notify6HourLogout = true;
@@ -247,6 +248,11 @@ public class IdleNotifierPlugin extends Plugin
 			notifier.notify("[" + local.getName() + "] has low hitpoints!");
 		}
 
+		if (checkHighHitpoints())
+		{
+			notifier.notify("[" + local.getName() + "] has high hitpoints!");
+		}
+
 		if (checkLowPrayer())
 		{
 			notifier.notify("[" + local.getName() + "] has low prayer!");
@@ -272,6 +278,31 @@ public class IdleNotifierPlugin extends Plugin
 			else
 			{
 				notifyHitpoints = false;
+			}
+		}
+
+		return false;
+	}
+
+	private boolean checkHighHitpoints()
+	{
+		if (config.getHPThreshold() <= 0)
+		{
+			return false;
+		}
+		if (client.getRealSkillLevel(Skill.HITPOINTS) > config.getHPThreshold())
+		{
+			if (client.getBoostedSkillLevel(Skill.HITPOINTS) >= config.getHPThreshold())
+			{
+				if (!notifyHP)
+				{
+					notifyHP = true;
+					return true;
+				}
+			}
+			else
+			{
+				notifyHP = false;
 			}
 		}
 


### PR DESCRIPTION
Adds a notification for when your health goes above a certain threshold. Setting the threshold to 0 disables the notification. Puts it into the "Idle Notifier" plugin. Also changes the current name and description of the low hitpoints threshold to remove ambiguity. Can be useful for AFKing Dharok's or saving absorption points at nightmare zone.