### PR TITLE
Motherlode Mine - Region check on plugin startup

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/motherlode/MotherlodePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/motherlode/MotherlodePlugin.java
@@ -138,6 +138,12 @@ public class MotherlodePlugin extends Plugin
 	}
 
 	@Override
+	protected void startUp()
+	{
+		inMlm = checkInMlm();
+	}
+
+	@Override
 	protected void shutDown() throws Exception
 	{
 		veins.clear();


### PR DESCRIPTION
When enabling Motherlode Mine plugin within MLM, the region check fails because it will not be run until the gamestate / region changes.