### PR TITLE
Limit the amount of stat boosts that can be shown at a time.

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/boosts/BoostsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/boosts/BoostsConfig.java
@@ -78,4 +78,26 @@ public interface BoostsConfig extends Config
 	{
 		return true;
 	}
+
+	@ConfigItem(
+		keyName = "limitBoostAmount",
+		name = "Limit boosts shown",
+		description = "Configures whether or not to limit the amount of boosts shown",
+		position = 5
+	)
+	default boolean limitBoostAmount()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		keyName = "limitBoostsTo",
+		name = "Amount to show",
+		description = "Configures how many boosts can be shown at a time",
+		position = 6
+	)
+	default int limitBoostsTo()
+	{
+		return 5;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/boosts/BoostsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/boosts/BoostsOverlay.java
@@ -90,6 +90,8 @@ class BoostsOverlay extends Overlay
 		}
 
 		overlayActive = false;
+		int displayedBoosts = 0;
+		int displayedLimit = config.limitBoostsTo();
 
 		for (Skill skill : plugin.getShownSkills())
 		{
@@ -121,6 +123,14 @@ class BoostsOverlay extends Overlay
 				if (!infoBoxManager.getInfoBoxes().contains(indicator))
 				{
 					infoBoxManager.addInfoBox(indicator);
+					if(config.limitBoostAmount())
+					{
+						displayedBoosts++;
+						if(displayedBoosts == displayedLimit)
+						{
+							break;
+						}
+					}
 				}
 			}
 			else
@@ -151,6 +161,14 @@ class BoostsOverlay extends Overlay
 					.right(str)
 					.rightColor(strColor)
 					.build());
+				if(config.limitBoostAmount())
+				{
+					displayedBoosts++;
+					if(displayedBoosts == displayedLimit)
+					{
+						break;
+					}
+				}
 			}
 		}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/boosts/BoostsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/boosts/BoostsOverlay.java
@@ -123,10 +123,10 @@ class BoostsOverlay extends Overlay
 				if (!infoBoxManager.getInfoBoxes().contains(indicator))
 				{
 					infoBoxManager.addInfoBox(indicator);
-					if(config.limitBoostAmount())
+					if (config.limitBoostAmount())
 					{
 						displayedBoosts++;
-						if(displayedBoosts == displayedLimit)
+						if (displayedBoosts == displayedLimit)
 						{
 							break;
 						}
@@ -161,10 +161,10 @@ class BoostsOverlay extends Overlay
 					.right(str)
 					.rightColor(strColor)
 					.build());
-				if(config.limitBoostAmount())
+				if (config.limitBoostAmount())
 				{
 					displayedBoosts++;
-					if(displayedBoosts == displayedLimit)
+					if (displayedBoosts == displayedLimit)
 					{
 						break;
 					}


### PR DESCRIPTION
![GIF of the feature](https://user-images.githubusercontent.com/29176781/40000644-41ff25c4-5784-11e8-9471-1b9387f6c15d.gif)