### PR TITLE
Revert #2530 "Make VarbitChanged only fire once..."

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/Client.java
+++ b/runelite-api/src/main/java/net/runelite/api/Client.java
@@ -192,8 +192,6 @@ public interface Client extends GameEngine
 	@VisibleForDevtools
 	void setVarbitValue(int varbit, int value);
 
-	boolean shouldPostVarbitEvent();
-
 	HashTable getWidgetFlags();
 
 	HashTable getComponentTable();

--- a/runelite-client/src/main/java/net/runelite/client/callback/Hooks.java
+++ b/runelite-client/src/main/java/net/runelite/client/callback/Hooks.java
@@ -64,7 +64,6 @@ import net.runelite.api.events.MenuOptionClicked;
 import net.runelite.api.events.PostItemComposition;
 import net.runelite.api.events.ProjectileMoved;
 import net.runelite.api.events.SetMessage;
-import net.runelite.api.events.VarbitChanged;
 import net.runelite.api.widgets.Widget;
 import static net.runelite.api.widgets.WidgetInfo.WORLD_MAP_VIEW;
 import net.runelite.client.Notifier;
@@ -103,7 +102,6 @@ public class Hooks
 	private static final GameTick tick = new GameTick();
 	private static final DrawManager renderHooks = injector.getInstance(DrawManager.class);
 	private static final Notifier notifier = injector.getInstance(Notifier.class);
-	private static final VarbitChanged varbitChanged = new VarbitChanged();
 
 	private static Dimension lastStretchedDimensions;
 	private static BufferedImage stretchedImage;
@@ -117,11 +115,6 @@ public class Hooks
 		if (shouldProcessGameTick)
 		{
 			shouldProcessGameTick = false;
-
-			if (client.shouldPostVarbitEvent())
-			{
-				eventBus.post(varbitChanged);
-			}
 
 			_deferredEventBus.replay();
 

--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSClientMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSClientMixin.java
@@ -78,6 +78,7 @@ import net.runelite.api.events.PlayerMenuOptionsChanged;
 import net.runelite.api.events.PlayerSpawned;
 import net.runelite.api.events.ResizeableChanged;
 import net.runelite.api.events.UsernameChanged;
+import net.runelite.api.events.VarbitChanged;
 import net.runelite.api.events.WidgetLoaded;
 import net.runelite.api.mixins.Copy;
 import net.runelite.api.mixins.FieldHook;
@@ -134,9 +135,6 @@ public abstract class RSClientMixin implements RSClient
 
 	@Inject
 	private static int inventoryDragDelay;
-
-	@Inject
-	private static boolean hasVarbitChanged;
 
 	@Inject
 	private static int oldMenuEntryCount;
@@ -872,16 +870,8 @@ public abstract class RSClientMixin implements RSClient
 	@Inject
 	public static void settingsChanged(int idx)
 	{
-		hasVarbitChanged = true;
-	}
-
-	@Inject
-	@Override
-	public boolean shouldPostVarbitEvent()
-	{
-		boolean ret = hasVarbitChanged;
-		hasVarbitChanged = false;
-		return ret;
+		VarbitChanged varbitChanged = new VarbitChanged();
+		eventBus.post(varbitChanged);
 	}
 
 	@FieldHook("isResized")


### PR DESCRIPTION
This broke the speccounter plugin, and is moderately incorrect because client scripts can update varbits before a tick has happened, and the event should reflect that.