### PR TITLE
Add examine info to dev tools

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/devtools/DevToolsPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/devtools/DevToolsPanel.java
@@ -240,6 +240,14 @@ public class DevToolsPanel extends PluginPanel
 		});
 		container.add(interactingBtn);
 
+		final JButton examineInfoBtn = new JButton("Examine Info");
+		examineInfoBtn.addActionListener(e ->
+		{
+			highlightButton(examineInfoBtn);
+			plugin.toggleExamineInfo();
+		});
+		container.add(examineInfoBtn);
+
 		return container;
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/devtools/DevToolsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/devtools/DevToolsPlugin.java
@@ -26,20 +26,28 @@ package net.runelite.client.plugins.devtools;
 
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
+import com.google.common.collect.ImmutableList;
 import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
 import com.google.inject.Provides;
+import java.awt.Color;
 import java.awt.Font;
 import java.awt.image.BufferedImage;
 import static java.lang.Math.min;
+import java.util.List;
 import javax.inject.Inject;
 import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
 import net.runelite.api.Experience;
+import net.runelite.api.MenuAction;
+import net.runelite.api.MenuEntry;
+import net.runelite.api.NPC;
 import net.runelite.api.Player;
 import net.runelite.api.Skill;
+import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.CommandExecuted;
 import net.runelite.api.events.ExperienceChanged;
+import net.runelite.api.events.MenuEntryAdded;
 import net.runelite.api.events.VarbitChanged;
 import net.runelite.api.widgets.Widget;
 import net.runelite.client.config.ConfigManager;
@@ -49,6 +57,7 @@ import net.runelite.client.ui.FontManager;
 import net.runelite.client.ui.NavigationButton;
 import net.runelite.client.ui.ClientToolbar;
 import net.runelite.client.ui.overlay.OverlayManager;
+import net.runelite.client.util.ColorUtil;
 import net.runelite.client.util.ImageUtil;
 import org.slf4j.LoggerFactory;
 
@@ -59,6 +68,10 @@ import org.slf4j.LoggerFactory;
 )
 public class DevToolsPlugin extends Plugin
 {
+	private static final List<MenuAction> EXAMINE_MENU_ACTIONS = ImmutableList.of(MenuAction.EXAMINE_ITEM,
+			MenuAction.EXAMINE_ITEM_GROUND, MenuAction.EXAMINE_NPC, MenuAction.EXAMINE_OBJECT);
+	private static final Color COLOR_ORANGE = new Color(255, 144, 64);
+
 	@Inject
 	private Client client;
 
@@ -105,6 +118,7 @@ public class DevToolsPlugin extends Plugin
 	private boolean toggleWorldMapLocation;
 	private boolean toggleTileLocation;
 	private boolean toggleInteracting;
+	private boolean toggleExamineInfo;
 
 	Widget currentWidget;
 	int itemIndex = -1;
@@ -261,6 +275,45 @@ public class DevToolsPlugin extends Plugin
 		}
 	}
 
+	@Subscribe
+	public void onMenuEntryAdded(MenuEntryAdded event)
+	{
+		if (!toggleExamineInfo)
+		{
+			return;
+		}
+
+		MenuAction action = MenuAction.of(event.getType());
+
+		if (EXAMINE_MENU_ACTIONS.contains(action))
+		{
+			MenuEntry[] entries = client.getMenuEntries();
+			MenuEntry entry = entries[entries.length - 1];
+
+			final int identifier = event.getIdentifier();
+			String info = "ID: ";
+
+			if (action == MenuAction.EXAMINE_NPC)
+			{
+				NPC npc = client.getCachedNPCs()[identifier];
+				info += npc.getId();
+			}
+			else
+			{
+				info += identifier;
+
+				if (action == MenuAction.EXAMINE_OBJECT)
+				{
+					WorldPoint point = WorldPoint.fromScene(client, entry.getParam0(), entry.getParam1(), client.getPlane());
+					info += " X: " + point.getX() + " Y: " + point.getY();
+				}
+			}
+
+			entry.setTarget(entry.getTarget() + " " + ColorUtil.prependColorTag("(" + info + ")", COLOR_ORANGE));
+			client.setMenuEntries(entries);
+		}
+	}
+
 	Font getFont()
 	{
 		return font;
@@ -359,6 +412,11 @@ public class DevToolsPlugin extends Plugin
 	void toggleInteracting()
 	{
 		toggleInteracting = !toggleInteracting;
+	}
+
+	void toggleExamineInfo()
+	{
+		toggleExamineInfo = !toggleExamineInfo;
 	}
 
 	boolean isTogglePlayers()


### PR DESCRIPTION
Adds a new option to the dev tools to show more info of the currently hovered NPC, object or item. The ID and, if applicable, the world coords are added after the examine target in the right click menu.

![image](https://puu.sh/BLUJm/979a6caf73.gif)


