### PR TITLE
Add tile highlighting for current position and mouse pointer location

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/tileindicators/TileIndicatorsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/tileindicators/TileIndicatorsConfig.java
@@ -37,11 +37,67 @@ import net.runelite.client.config.ConfigItem;
 public interface TileIndicatorsConfig extends Config
 {
 	@ConfigItem(
+		keyName = "highlightCurrentLocation",
+		name = "Highlight current tile",
+		description = "Enable/disable current location highlighting",
+		position = 1
+	)
+	default boolean highlightCurrentLocation()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		keyName = "highlightCurrentLocationColor",
+		name = "Color of current tile highlighting",
+		description = "Configures the highlight color of current location",
+		position = 2
+	)
+	default Color highlightCurrentLocationColor()
+	{
+		return Color.GRAY;
+	}
+
+	@ConfigItem(
+		keyName = "highlightDestination",
+		name = "Highlight destination tile",
+		description = "Enable/disable destination highlighting",
+		position = 3
+	)
+	default boolean highlightDestination()
+	{
+		return true;
+	}
+
+	@ConfigItem(
 		keyName = "highlightDestinationColor",
 		name = "Color of current destination highlighting",
-		description = "Configures the highlight color of current destination"
+		description = "Configures the highlight color of current destination",
+		position = 4
 	)
 	default Color highlightDestinationColor()
+	{
+		return Color.GRAY;
+	}
+
+	@ConfigItem(
+		keyName = "highlightMousePosition",
+		name = "Highlight tile under mouse cursor",
+		description = "Enable/disable highlighting destination highlighting",
+		position = 5
+	)
+	default boolean highlightMousePosition()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		keyName = "highlightMousePositionColor",
+		name = "Color of mouse cursor tile highlighting",
+		description = "Configures the highlight color of tile under mouse cursor",
+		position = 6
+	)
+	default Color highlightMousePositionColor()
 	{
 		return Color.GRAY;
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/tileindicators/TileIndicatorsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/tileindicators/TileIndicatorsOverlay.java
@@ -58,7 +58,8 @@ public class TileIndicatorsOverlay extends Overlay
 	{
 		if (config.highlightCurrentLocation())
 		{
-			highlightTile(graphics, client.getLocalPlayer().getLocalLocation(), config.highlightCurrentLocationColor());
+			LocalPoint position = LocalPoint.fromWorld(client, client.getLocalPlayer().getWorldLocation());
+			highlightTile(graphics, position, config.highlightCurrentLocationColor());
 		}
 
 		if (config.highlightDestination())

--- a/runelite-client/src/main/java/net/runelite/client/plugins/tileindicators/TileIndicatorsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/tileindicators/TileIndicatorsOverlay.java
@@ -58,7 +58,7 @@ public class TileIndicatorsOverlay extends Overlay
 	{
 		if (config.highlightCurrentLocation())
 		{
-			LocalPoint position = LocalPoint.fromWorld(client, client.getLocalPlayer().getWorldLocation());
+			final LocalPoint position = LocalPoint.fromWorld(client, client.getLocalPlayer().getWorldLocation());
 			highlightTile(graphics, position, config.highlightCurrentLocationColor());
 		}
 
@@ -69,7 +69,7 @@ public class TileIndicatorsOverlay extends Overlay
 
 		if (config.highlightMousePosition())
 		{
-			Tile[][][] tiles = client.getRegion().getTiles();
+			final Tile[][][] tiles = client.getRegion().getTiles();
 			int z = client.getPlane();
 
 			for (int x = 0; x < Constants.REGION_SIZE; x++)
@@ -90,6 +90,7 @@ public class TileIndicatorsOverlay extends Overlay
 				}
 			}
 		}
+
 		return null;
 	}
 
@@ -107,6 +108,5 @@ public class TileIndicatorsOverlay extends Overlay
 		}
 
 		OverlayUtil.renderPolygon(graphics, poly, color);
-
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/tileindicators/TileIndicatorsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/tileindicators/TileIndicatorsOverlay.java
@@ -24,11 +24,14 @@
  */
 package net.runelite.client.plugins.tileindicators;
 
+import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Graphics2D;
 import java.awt.Polygon;
 import net.runelite.api.Client;
+import net.runelite.api.Constants;
 import net.runelite.api.Perspective;
+import net.runelite.api.Tile;
 import net.runelite.api.coords.LocalPoint;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
@@ -53,20 +56,56 @@ public class TileIndicatorsOverlay extends Overlay
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
-		LocalPoint dest = client.getLocalDestinationLocation();
+		if (config.highlightCurrentLocation())
+		{
+			highlightTile(graphics, client.getLocalPlayer().getLocalLocation(), config.highlightCurrentLocationColor());
+		}
+
+		if (config.highlightDestination())
+		{
+			highlightTile(graphics, client.getLocalDestinationLocation(), config.highlightDestinationColor());
+		}
+
+		if (config.highlightMousePosition())
+		{
+			Tile[][][] tiles = client.getRegion().getTiles();
+			int z = client.getPlane();
+
+			for (int x = 0; x < Constants.REGION_SIZE; x++)
+			{
+				for (int y = 0; y < Constants.REGION_SIZE; ++y)
+				{
+					Tile tile = tiles[z][x][y];
+
+					if (tile != null)
+					{
+						Polygon poly = Perspective.getCanvasTilePoly(client, tile.getLocalLocation());
+
+						if (poly != null && poly.contains(client.getMouseCanvasPosition().getX(), client.getMouseCanvasPosition().getY()))
+						{
+							highlightTile(graphics, tile.getLocalLocation(), config.highlightMousePositionColor());
+						}
+					}
+				}
+			}
+		}
+		return null;
+	}
+
+	private void highlightTile(Graphics2D graphics, LocalPoint dest, Color color)
+	{
 		if (dest == null)
 		{
-			return null;
+			return;
 		}
 
 		Polygon poly = Perspective.getCanvasTilePoly(client, dest);
 		if (poly == null)
 		{
-			return null;
+			return;
 		}
-		
-		OverlayUtil.renderPolygon(graphics, poly, config.highlightDestinationColor());
 
-		return null;
+		OverlayUtil.renderPolygon(graphics, poly, color);
+
 	}
 }


### PR DESCRIPTION
Adds 2 new configuration options to the tile indicators plugin allowing users to highlight current player position as well as the tile that the cursor is under.

![capture](https://user-images.githubusercontent.com/9153518/40075093-664fa212-5849-11e8-9012-a3b64e21cea1.PNG)

Thanks to @Reasel for code in PR #1928 

Fixes #2430 and #2676