### PR TITLE
dev-tools: Add camera position overlay

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/devtools/CameraOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/devtools/CameraOverlay.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2018, Seth <https://github.com/sethtroll>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.devtools;
+
+import java.awt.Dimension;
+import java.awt.Graphics2D;
+import javax.inject.Inject;
+import net.runelite.api.Client;
+import net.runelite.client.ui.overlay.Overlay;
+import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.components.LineComponent;
+import net.runelite.client.ui.overlay.components.PanelComponent;
+import net.runelite.client.ui.overlay.components.TitleComponent;
+
+public class CameraOverlay extends Overlay
+{
+	private final Client client;
+	private final DevToolsPlugin plugin;
+	private final PanelComponent panelComponent = new PanelComponent();
+
+	@Inject
+	CameraOverlay(Client client, DevToolsPlugin plugin)
+	{
+		this.client = client;
+		this.plugin = plugin;
+		panelComponent.setPreferredSize(new Dimension(150, 0));
+		setPosition(OverlayPosition.TOP_LEFT);
+	}
+
+	@Override
+	public Dimension render(Graphics2D graphics)
+	{
+		if (!plugin.isToggleCamera())
+		{
+			return null;
+		}
+
+		panelComponent.getChildren().clear();
+
+		panelComponent.getChildren().add(TitleComponent.builder()
+				.text("Camera")
+				.build());
+
+		panelComponent.getChildren().add(LineComponent.builder()
+				.left("X")
+				.right("" + client.getCameraX())
+				.build());
+
+		panelComponent.getChildren().add(LineComponent.builder()
+				.left("Y")
+				.right("" + client.getCameraY())
+				.build());
+
+		panelComponent.getChildren().add(LineComponent.builder()
+				.left("Z")
+				.right("" + client.getCameraZ())
+				.build());
+
+		panelComponent.getChildren().add(LineComponent.builder()
+				.left("Pitch")
+				.right("" + client.getCameraPitch())
+				.build());
+
+		panelComponent.getChildren().add(LineComponent.builder()
+				.left("Yaw")
+				.right("" + client.getCameraYaw())
+				.build());
+
+		panelComponent.getChildren().add(LineComponent.builder()
+				.left("Scale")
+				.right("" + client.getScale())
+				.build());
+
+		return panelComponent.render(graphics);
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/devtools/DevToolsPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/devtools/DevToolsPanel.java
@@ -198,6 +198,14 @@ public class DevToolsPanel extends PluginPanel
 		});
 		container.add(graphicsObjectsBtn);
 
+		final JButton cameraPositionBtn = new JButton("Camera Position");
+		cameraPositionBtn.addActionListener(e ->
+		{
+			highlightButton(cameraPositionBtn);
+			plugin.toggleCamera();
+		});
+		container.add(cameraPositionBtn);
+
 		return container;
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/devtools/DevToolsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/devtools/DevToolsPlugin.java
@@ -78,6 +78,9 @@ public class DevToolsPlugin extends Plugin
 	private SceneOverlay sceneOverlay;
 
 	@Inject
+	private CameraOverlay cameraOverlay;
+
+	@Inject
 	private EventBus eventBus;
 
 	private boolean togglePlayers;
@@ -95,6 +98,7 @@ public class DevToolsPlugin extends Plugin
 	private boolean toggleValidMovement;
 	private boolean toggleLineOfSight;
 	private boolean toggleGraphicsObjects;
+	private boolean toggleCamera;
 
 	Widget currentWidget;
 	int itemIndex = -1;
@@ -140,7 +144,7 @@ public class DevToolsPlugin extends Plugin
 	@Override
 	public Collection<Overlay> getOverlays()
 	{
-		return Arrays.asList(overlay, locationOverlay, sceneOverlay);
+		return Arrays.asList(overlay, locationOverlay, sceneOverlay, cameraOverlay);
 	}
 
 	@Subscribe
@@ -307,6 +311,11 @@ public class DevToolsPlugin extends Plugin
 		toggleGraphicsObjects = !toggleGraphicsObjects;
 	}
 
+	void toggleCamera()
+	{
+		toggleCamera = !toggleCamera;
+	}
+
 	boolean isTogglePlayers()
 	{
 		return togglePlayers;
@@ -380,5 +389,10 @@ public class DevToolsPlugin extends Plugin
 	boolean isToggleGraphicsObjects()
 	{
 		return toggleGraphicsObjects;
+	}
+
+	boolean isToggleCamera()
+	{
+		return toggleCamera;
 	}
 }


### PR DESCRIPTION
Adds an overlay for Developer Tools displaying relevant camera position information such as X, Y, Z co-ordinates.

![capture2](https://user-images.githubusercontent.com/9153518/40076158-2d67906a-584c-11e8-8d12-6ae5f53025b9.PNG)
