### PR TITLE
Add Twitch plugin

### DIFF
--- a/runelite-client/pom.xml
+++ b/runelite-client/pom.xml
@@ -159,6 +159,11 @@
 			<version>${guice.version}</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.kitteh.irc</groupId>
+			<artifactId>client-lib</artifactId>
+			<version>4.0.2</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/runelite-client/src/main/java/net/runelite/client/config/ConfigItem.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/ConfigItem.java
@@ -44,4 +44,6 @@ public @interface ConfigItem
 	boolean hidden() default false;
 
 	String warning() default "";
+
+	boolean secret() default false;
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
@@ -56,6 +56,7 @@ import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
+import javax.swing.JPasswordField;
 import javax.swing.JScrollPane;
 import javax.swing.JSpinner;
 import javax.swing.JTextArea;
@@ -482,22 +483,32 @@ public class ConfigPanel extends PluginPanel
 
 			if (cid.getType() == String.class)
 			{
-				JTextArea textField = new JTextArea();
-				textField.setLineWrap(true);
-				textField.setWrapStyleWord(true);
-				textField.setBorder(BorderFactory.createEmptyBorder(5, 5, 5, 5));
-				textField.setText(configManager.getConfiguration(cd.getGroup().keyName(), cid.getItem().keyName()));
-
-				textField.addFocusListener(new FocusAdapter()
+				if (!cid.getItem().secret())
 				{
-					@Override
-					public void focusLost(FocusEvent e)
-					{
-						changeConfiguration(config, textField, cd, cid);
-					}
-				});
+					JTextArea textField = new JTextArea();
+					textField.setLineWrap(true);
+					textField.setWrapStyleWord(true);
+					textField.setBorder(BorderFactory.createEmptyBorder(5, 5, 5, 5));
+					textField.setText(configManager.getConfiguration(cd.getGroup().keyName(), cid.getItem().keyName()));
 
-				item.add(textField, BorderLayout.SOUTH);
+					textField.addFocusListener(new FocusAdapter()
+					{
+						@Override
+						public void focusLost(FocusEvent e)
+						{
+							changeConfiguration(config, textField, cd, cid);
+						}
+					});
+
+					item.add(textField, BorderLayout.SOUTH);
+				}
+				else
+				{
+					JPasswordField passwordField = new JPasswordField();
+					passwordField.setBorder(BorderFactory.createEmptyBorder(5, 5, 5, 5));
+
+					item.add(passwordField, BorderLayout.SOUTH);
+				}
 			}
 
 			if (cid.getType() == Color.class)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/mousehighlight/MouseHighlightOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/mousehighlight/MouseHighlightOverlay.java
@@ -83,6 +83,14 @@ class MouseHighlightOverlay extends Overlay
 		{
 			case "Walk here":
 			case "Cancel":
+			case "Accept trade":
+				//This case is used for the twitch chat plugin
+				//Normal trade messages will be <col=ffffff>NAME</col> but the twitch chat plugin does not have a name to it
+				final String twitchPluginMessage = "<col=ffffff></col>";
+				if (target.equals(twitchPluginMessage))
+				{
+					return null;
+				}
 			case "Continue":
 				return null;
 			case "Move":

--- a/runelite-client/src/main/java/net/runelite/client/plugins/twitch/TwitchConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/twitch/TwitchConfig.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2018, William Gray <wgray5093@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package net.runelite.client.plugins.twitch;
+
+import java.awt.Color;
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+
+@ConfigGroup(
+	keyName = "twitch",
+	name = "Twitch",
+	description = "Used to see Twitch chat in game"
+)
+public interface TwitchConfig extends Config
+{
+	@ConfigItem(
+		keyName = "channel",
+		name = "Channel",
+		description = "Enter the channel you wish to view the chat of",
+		position = 0
+	)
+	default String nickName()
+	{
+		return "";
+	}
+
+	@ConfigItem(
+		keyName = "oauth",
+		name = "OAuth Token",
+		description = "Enter your OAuth token here. This can be found at http://www.twitchapps.com/tmi/",
+		position = 1,
+		secret = true
+	)
+	default String oauthToken()
+	{
+		return "";
+	}
+
+	@ConfigItem(
+		keyName = "nick",
+		name = "Twitch Username",
+		description = "Your twitch username",
+		position = 2
+	)
+	default String channelName()
+	{
+		return "";
+	}
+
+	@ConfigItem(
+		keyName = "chattcolor",
+		name = "Transparent chat color",
+		description = "The color of chat in game",
+		position = 3
+	)
+	default Color chatTColor()
+	{
+		return Color.decode("#7C00A6");
+	}
+
+	@ConfigItem(
+		keyName = "chatocolor",
+		name = "Opaque chat color",
+		description = "The color of chat in game",
+		position = 4
+	)
+	default Color chatOColor()
+	{
+		return Color.decode("#7C00A6");
+	}
+
+	@ConfigItem(
+		keyName = "subnotifications",
+		name = "Sub notifications",
+		description = "Toggles sub notifications",
+		position = 5
+	)
+	default boolean subNotifs()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		keyName = "subocolor",
+		name = "Subscriber notification opaque color",
+		description = "Color of the sub notifications in chat when using opaque chat",
+		position = 6
+	)
+	default Color subsOColor()
+	{
+		return Color.decode("#000000");
+	}
+
+	@ConfigItem(
+		keyName = "subtcolor",
+		name = "Subscriber notification transparent color",
+		description = "Color of the sub notifications in chat when using transparent chat",
+		position = 7
+	)
+	default Color subsTColor()
+	{
+		return Color.decode("#FFFFFF");
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/twitch/TwitchPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/twitch/TwitchPlugin.java
@@ -1,0 +1,411 @@
+/*
+ * Copyright (c) 2018, William Gray <wgray5093@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package net.runelite.client.plugins.twitch;
+
+import com.google.common.eventbus.Subscribe;
+import com.google.inject.Provides;
+import javax.inject.Inject;
+import net.engio.mbassy.listener.Handler;
+import net.runelite.api.ChatMessageType;
+import net.runelite.api.GameState;
+import net.runelite.api.Varbits;
+import net.runelite.api.events.CommandExecuted;
+import net.runelite.api.events.ConfigChanged;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginDescriptor;
+import org.apache.commons.lang3.StringUtils;
+import org.kitteh.irc.client.library.Client;
+import org.kitteh.irc.client.library.element.User;
+import org.kitteh.irc.client.library.event.abstractbase.ActorChannelMessageEventBase;
+import org.kitteh.irc.client.library.event.channel.ChannelCtcpEvent;
+import org.kitteh.irc.client.library.event.channel.ChannelMessageEvent;
+import org.kitteh.irc.client.library.feature.twitch.TwitchDelaySender;
+import org.kitteh.irc.client.library.feature.twitch.TwitchListener;
+import org.kitteh.irc.client.library.feature.twitch.event.RoomStateEvent;
+import org.kitteh.irc.client.library.feature.twitch.event.UserNoticeEvent;
+import org.kitteh.irc.client.library.feature.twitch.event.UserStateEvent;
+
+@PluginDescriptor(
+	name = "Twitch",
+	enabledByDefault = false
+)
+public class TwitchPlugin extends Plugin
+{
+	@Inject
+	private net.runelite.api.Client client;
+
+	@Inject
+	private TwitchConfig config;
+
+	private Client irc;
+	private boolean subscribed;
+	private boolean mod;
+	private boolean broadcaster;
+	private boolean subsOnly;
+	private boolean emoteOnly;
+	private String badges = "";
+	private String oColor;
+	private String tColor;
+
+	@Provides
+	TwitchConfig provideConfig(ConfigManager configManager)
+	{
+		return configManager.getConfig(TwitchConfig.class);
+	}
+
+	@Override
+	protected void startUp()
+	{
+		twitchShutdown(irc);
+		irc = twitchSetup(config.oauthToken(), config.channelName(), config.nickName());
+		oColor = Integer.toHexString(config.chatOColor().getRGB() & 0xFFFFFF);
+		tColor = Integer.toHexString(config.chatTColor().getRGB() & 0xFFFFFF);
+	}
+
+	@Override
+	protected void shutDown()
+	{
+		twitchShutdown(irc);
+	}
+
+	@Subscribe
+	public void onConfigChanged(ConfigChanged event)
+	{
+		if (!event.getGroup().equals("twitch"))
+		{
+			return;
+		}
+
+		oColor = Integer.toHexString(config.chatOColor().getRGB() & 0xFFFFFF);
+		tColor = Integer.toHexString(config.chatTColor().getRGB() & 0xFFFFFF);
+
+		if (event.getKey().equals("channel") || event.getKey().equals("oauth") || event.getKey().equals("nick"))
+		{
+			twitchShutdown(irc);
+			irc = twitchSetup(config.oauthToken(), config.channelName(), config.nickName());
+		}
+	}
+
+	private boolean isChatboxTransparent()
+	{
+		return client.isResized() && client.getVar(Varbits.TRANSPARENT_CHATBOX) == 1;
+	}
+
+	private Client twitchSetup(String oauth, String nick, String name)
+	{
+		Client ircClient = Client.builder()
+				.serverHost("irc.chat.twitch.tv").serverPort(443)
+				.serverPassword(oauth)
+				.nick(nick)
+				.messageSendingQueueSupplier(TwitchDelaySender.getSupplier(false))
+				.build();
+		TwitchListener listener = new TwitchListener(ircClient);
+		ircClient.getEventManager().registerEventListener(listener);
+		ircClient.getEventManager().registerEventListener(this);
+		ircClient.connect();
+		ircClient.addChannel("#" + name);
+		return ircClient;
+	}
+
+	//Send messages to twitch chat using command "t"
+	@Subscribe
+	private void onCommand(CommandExecuted executed)
+	{
+		if (!client.getGameState().equals(GameState.LOGGED_IN))
+		{
+			return;
+		}
+
+		String[] args = executed.getArguments();
+		StringBuilder sb = new StringBuilder();
+		String command = executed.getCommand();
+
+		if (command.equalsIgnoreCase("t"))
+		{
+			for (String arg : args)
+			{
+				sb.append(arg + " ");
+			}
+
+			String message = sb.toString();
+			irc.sendMessage("#" + config.nickName(), message);
+			//Echos the message back in in-game chat
+			if (irc.getChannels().toString().contains("#" + config.nickName()))
+			{
+				//If the chat is in sub only mode and they are not a subscriber
+				if (!subscribed && subsOnly)
+				{
+					final String subsOnlyMessage = "<col=FF0000>This channel is in Subscriber only mode!</col>";
+					sendMessage(subsOnlyMessage, "Notification");
+				}
+				//If chat is in emote only mode
+				else if (emoteOnly && !broadcaster && !mod)
+				{
+					final String emoteOnlyMessage = "<col=FF0000>This channel is in emote only mode!</col><br><col=FF0000>Function coming soon to a Runelite client near you.</col>";
+					sendMessage(emoteOnlyMessage, "Notification");
+				}
+				else
+				{
+					sendMessage(message, badges + config.channelName());
+				}
+			}
+		}
+	}
+
+	private void sendMessage(String message, String name)
+	{
+		if (isChatboxTransparent())
+		{
+			final String transparentMessage = "<col=ffffff></col>[<col=9070ff>Twitch</col>] " +  name + ": <col=" + tColor + ">" + message + "</col>";
+			client.addChatMessage(ChatMessageType.TRADE, "", transparentMessage, "");
+		}
+		else
+		{
+			final String opaqueMessage = "<col=000000></col>[<col=0000FF>Twitch</col>] " +  name + ": <col=" + oColor + ">" + message + "</col>";
+			client.addChatMessage(ChatMessageType.TRADE, "", opaqueMessage, "");
+		}
+	}
+
+	/**
+	 * Shut off current running irc client
+	 * @param client
+	 */
+	private void twitchShutdown(Client client)
+	{
+		if (client != null)
+		{
+			client.shutdown();
+		}
+	}
+
+	/**
+	 * Triggers when a message is sent to twitch chat
+	 * @param event
+	 */
+	@Handler
+	private void onMessage(ChannelMessageEvent event)
+	{
+		if (!client.getGameState().equals(GameState.LOGGED_IN))
+		{
+			return;
+		}
+
+		String message = event.getMessage();
+		messageBuilder(event, message);
+	}
+
+	/**
+	 * Triggers when a /me message is sent in twitch chat
+	 * Works the same as the onMessage method
+	 * @param event
+	 */
+	@Handler
+	private void onMe(ChannelCtcpEvent event)
+	{
+		if (!client.getGameState().equals(GameState.LOGGED_IN))
+		{
+			return;
+		}
+
+		String message = event.getMessage().replace("ACTION ", "");
+		messageBuilder(event, message);
+	}
+
+	private void messageBuilder(ActorChannelMessageEventBase<User> event, String message)
+	{
+		String username = event.getActor().getUserString();
+		String badge = event.getOriginalMessages().get(0).getTag("badges").toString();
+
+		//Sub length badges
+		//0 months
+		if (badge.contains("subscriber/0"))
+		{
+			username = "<img=9>" + username;
+		}
+		//3 months
+		else if (badge.contains("subscriber/3"))
+		{
+			username = "<img=8>" + username;
+		}
+		//6 months
+		else if (badge.contains("subscriber/6"))
+		{
+			username = "<img=7>" + username;
+		}
+		//12 months
+		else if (badge.contains("subscriber/12"))
+		{
+			username = "<img=6>" + username;
+		}
+		//24 months
+		else if (badge.contains("subscriber/24"))
+		{
+			username = "<img=5>" + username;
+		}
+		//48 months
+		else if (badge.contains("subscriber/48"))
+		{
+			username = "<img=4>" + username;
+		}
+
+		//Moderator badge
+		if (badge.contains("moderator/1"))
+		{
+			username = "<img=26>" + username;
+		}
+
+		//Streamer badge
+		if (badge.contains("broadcaster/1"))
+		{
+			username = "<img=27>" + username;
+		}
+		sendMessage(message, username);
+	}
+
+	/**
+	 * User and room information update events
+	 * Triggers whenever the user's state is updated or they join a room
+	 * @param event
+	 */
+	@Handler
+	private void onUserStateEvent(UserStateEvent event)
+	{
+		String originalMessage = event.getOriginalMessage().toString();
+		badges = "";
+		//Finding if the user is a subscriber
+		if ((originalMessage.contains("subscriber=1") || originalMessage.contains("mod=1") || originalMessage.contains("value=broadcaster/1")) && StringUtils.containsIgnoreCase(originalMessage, "display-name=" + config.channelName()))
+		{
+			subscribed = true;
+			if (originalMessage.contains("subscriber=1"))
+			{
+				if (originalMessage.contains("subscriber/0"))
+				{
+					badges = "<img=9>";
+				}
+				else if (originalMessage.contains("subscriber/3"))
+				{
+					badges = "<img=8>";
+				}
+				else if (originalMessage.contains("subscriber/6"))
+				{
+					badges = "<img=7>";
+				}
+				else if (originalMessage.contains("subscriber/12"))
+				{
+					badges = "<img=6>";
+				}
+				else if (originalMessage.contains("subscriber/24"))
+				{
+					badges = "<img=5>";
+				}
+				else if (originalMessage.contains("subscriber/48"))
+				{
+					badges = "<img=4>";
+				}
+			}
+		}
+		else
+		{
+			subscribed = false;
+		}
+
+		//Finding if the user is a moderator or broadcaster which allows them to talk during emote-only and sub-only while not actually subscribed
+		if (originalMessage.contains("mod=1") && originalMessage.toLowerCase().contains("display-name=" + config.channelName()))
+		{
+			mod = true;
+			badges = "<img=26>" + badges;
+		}
+		else
+		{
+			mod = false;
+		}
+
+		if (originalMessage.contains("value=broadcaster/1") && originalMessage.toLowerCase().contains("display-name=" + config.channelName()))
+		{
+			broadcaster = true;
+			badges = "<img=27>" + badges;
+		}
+		else
+		{
+			broadcaster = false;
+		}
+	}
+
+	/**
+	 * Triggers when the room state changes. I.E. Sub mode, slow mode, etc.
+	 * @param event
+	 */
+	@Handler
+	private void onRoomStateEvent(RoomStateEvent event)
+	{
+		String originalMessage = event.getOriginalMessage().toString();
+		//Checking if the subs-only state has changed
+		subsOnly = originalMessage.contains("subs-only=1");
+
+		//Checking if the emote-only state has changed
+		emoteOnly = originalMessage.contains("emote-only=1");
+	}
+
+	/**
+	 * Triggers when a user subscribes/re-subscribes
+	 * @param event
+	 */
+	@Handler
+	private void onUserNoticeEvent(UserNoticeEvent event)
+	{
+		if (!client.getGameState().equals(GameState.LOGGED_IN) || !config.subNotifs())
+		{
+			return;
+		}
+
+		String newSubMessage;
+		String originalMessage = event.getOriginalMessage().toString();
+		String[] subMessage = originalMessage.split(";");
+
+		//Fixes and issue where gifted subs say "Notification: msg-param-sub-plan-name=1000" instead of the proper sub message
+		if (subMessage[13].contains("msg-param-sub-plan-name="))
+		{
+			newSubMessage = subMessage[17].replace("\\s", " ").replace("system-msg=", "");
+		}
+		else
+		{
+			newSubMessage = subMessage[13].replace("\\s", " ").replace("system-msg=", "");
+		}
+
+		//Sends the sub notification
+		if (isChatboxTransparent())
+		{
+			final String transparentMessage = "<col=ffffff></col>[<col=9070ff>Twitch</col>] <col=" + tColor + ">" + newSubMessage + "</col>";
+			client.addChatMessage(ChatMessageType.TRADE, "", transparentMessage, "");
+		}
+		else
+		{
+			final String opaqueMessage = "<col=000000></col>[<col=0000FF>Twitch</col>] <col=" + oColor + ">" + newSubMessage + "</col>";
+			client.addChatMessage(ChatMessageType.TRADE, "", opaqueMessage, "");
+		}
+	}
+}


### PR DESCRIPTION
This plugin allows users to see Twitch chats in the in-game chat window.
Fixes #762
Fixes #3584

Features:

- View one Twitch chat in the in-game chat window, using the trade/all tabs
- Change color of chat text in transparent and opaque chat modes
- Subscriber messages with the option to disable them and change their color
- Subscriber badges using deadman skull icons 

![image](https://user-images.githubusercontent.com/39203754/39953894-71602bec-558b-11e8-8272-4b2f863f9fc9.png)

- Send messages to chat using ::t [Message]

![helpfulblandhochstettersfrog-size_restricted](https://user-images.githubusercontent.com/39203754/39954177-2dc424aa-5591-11e8-94ea-77b9ab13b278.gif)

- OAuth tokens can be found at [twitchapps](http://www.twitchapps.com/tmi/)

![image](https://user-images.githubusercontent.com/39203754/41512133-7b0b2df4-725a-11e8-8a03-b8f930635348.png)

