### PR TITLE
Add support for Ctrl-V pasting to Login Screen

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/Client.java
+++ b/runelite-api/src/main/java/net/runelite/api/Client.java
@@ -145,6 +145,20 @@ public interface Client extends GameEngine
 	void setUsername(String name);
 
 	/**
+	 * Sets the password on login screen.
+	 *
+	 * @param password the login screen password
+	 */
+	void setPassword(String password);
+
+	/**
+	 * Gets currently selected login field. 0 is username, and 1 is password.
+	 *
+	 * @return currently selected login field
+	 */
+	int getCurrentLoginField();
+
+	/**
 	 * Gets the account type of the logged in player.
 	 *
 	 * @return the account type

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loginscreen/LoginScreenConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loginscreen/LoginScreenConfig.java
@@ -22,15 +22,35 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package net.runelite.client.plugins.usernamesyncer;
+package net.runelite.client.plugins.loginscreen;
 
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
 
-@ConfigGroup("rememberusername")
-public interface UsernameSyncerConfig extends Config
+@ConfigGroup("loginscreen")
+public interface LoginScreenConfig extends Config
 {
+	@ConfigItem(
+		keyName = "syncusername",
+		name = "Sync username",
+		description = "Syncs the username that is currently remembered between computers"
+	)
+	default boolean syncUsername()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		keyName = "pasteenabled",
+		name = "Ctrl-V paste",
+		description = "Enables Ctrl+V pasting on the login screen"
+	)
+	default boolean pasteEnabled()
+	{
+		return false;
+	}
+
 	@ConfigItem(
 		keyName = "username",
 		name = "",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loginscreen/LoginScreenPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loginscreen/LoginScreenPlugin.java
@@ -22,11 +22,16 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package net.runelite.client.plugins.usernamesyncer;
+package net.runelite.client.plugins.loginscreen;
 
 import com.google.common.base.Strings;
 import com.google.common.eventbus.Subscribe;
 import com.google.inject.Provides;
+import java.awt.Toolkit;
+import java.awt.datatransfer.DataFlavor;
+import java.awt.datatransfer.UnsupportedFlavorException;
+import java.awt.event.KeyEvent;
+import java.io.IOException;
 import javax.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
@@ -34,21 +39,26 @@ import net.runelite.api.GameState;
 import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.SessionOpen;
 import net.runelite.client.config.ConfigManager;
+import net.runelite.client.input.KeyListener;
+import net.runelite.client.input.KeyManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 
 @PluginDescriptor(
-	name = "Username Syncer",
-	description = "Save your username to the config, allowing it to be synced"
+	name = "Login Screen",
+	description = "Provides various enhancements for login screen"
 )
 @Slf4j
-public class UsernameSyncerPlugin extends Plugin
+public class LoginScreenPlugin extends Plugin implements KeyListener
 {
 	@Inject
 	private Client client;
 
 	@Inject
-	private UsernameSyncerConfig config;
+	private LoginScreenConfig config;
+
+	@Inject
+	private KeyManager keyManager;
 
 	private String usernameCache;
 
@@ -56,23 +66,34 @@ public class UsernameSyncerPlugin extends Plugin
 	protected void startUp() throws Exception
 	{
 		applyUsername();
+		keyManager.registerKeyListener(this);
 	}
 
 	@Override
 	protected void shutDown() throws Exception
 	{
-		client.getPreferences().setRememberedUsername(usernameCache);
+		if (config.syncUsername())
+		{
+			client.getPreferences().setRememberedUsername(usernameCache);
+		}
+
+		keyManager.unregisterKeyListener(this);
 	}
 
 	@Provides
-	UsernameSyncerConfig getConfig(ConfigManager configManager)
+	LoginScreenConfig getConfig(ConfigManager configManager)
 	{
-		return configManager.getConfig(UsernameSyncerConfig.class);
+		return configManager.getConfig(LoginScreenConfig.class);
 	}
 
 	@Subscribe
 	public void onGameStateChanged(GameStateChanged event)
 	{
+		if (!config.syncUsername())
+		{
+			return;
+		}
+
 		if (event.getGameState() == GameState.LOGIN_SCREEN)
 		{
 			applyUsername();
@@ -105,6 +126,11 @@ public class UsernameSyncerPlugin extends Plugin
 
 	private void applyUsername()
 	{
+		if (!config.syncUsername())
+		{
+			return;
+		}
+
 		GameState gameState = client.getGameState();
 		if (gameState == GameState.LOGIN_SCREEN)
 		{
@@ -123,5 +149,52 @@ public class UsernameSyncerPlugin extends Plugin
 
 			client.getPreferences().setRememberedUsername(username);
 		}
+	}
+
+	@Override
+	public void keyTyped(KeyEvent e)
+	{
+	}
+
+	@Override
+	public void keyPressed(KeyEvent e)
+	{
+		if (!config.pasteEnabled() || client.getGameState() != GameState.LOGIN_SCREEN)
+		{
+			return;
+		}
+
+		if (e.getKeyCode() == KeyEvent.VK_V && e.isControlDown())
+		{
+			try
+			{
+				final String data = Toolkit
+					.getDefaultToolkit()
+					.getSystemClipboard()
+					.getData(DataFlavor.stringFlavor)
+					.toString()
+					.trim();
+
+				// 0 is username, 1 is password
+				if (client.getCurrentLoginField() == 0)
+				{
+					client.setUsername(data);
+				}
+				else
+				{
+					client.setPassword(data);
+				}
+			}
+			catch (UnsupportedFlavorException | IOException ex)
+			{
+				log.warn("failed to fetch clipboard data", ex);
+			}
+		}
+	}
+
+	@Override
+	public void keyReleased(KeyEvent e)
+	{
+
 	}
 }

--- a/runescape-api/src/main/java/net/runelite/rs/api/RSClient.java
+++ b/runescape-api/src/main/java/net/runelite/rs/api/RSClient.java
@@ -246,6 +246,14 @@ public interface RSClient extends RSGameEngine, Client
 	@Override
 	void setUsername(String username);
 
+	@Import("password")
+	@Override
+	void setPassword(String password);
+
+	@Import("currentLoginField")
+	@Override
+	int getCurrentLoginField();
+
 	@Import("playerOptions")
 	@Override
 	String[] getPlayerOptions();


### PR DESCRIPTION
- Based on what field is currently selected, add support for pasting to that field with standard Ctrl-V keybinding (disabled by default)
- Add export for login screen password
- Add mappings for current login screen field selected

As OSB added this feature recently, and it is very useful one, also do not provides any security risks, there is no reason to not implement it.

Closes #3793