### PR TITLE
Fixes !price chat history not staying between world hops

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
@@ -208,6 +208,9 @@ public class ChatCommandsPlugin extends Plugin
 	{
 		SearchResult result;
 
+		if (search.contains("\u00A0"))
+			search = search.replaceAll("\u00A0", " ");
+
 		try
 		{
 			result = itemManager.searchForItem(search);


### PR DESCRIPTION
Due to ChatHistoryPlugin's addition of nbsp characters, the item price lookup would fail to find a matching item in the api's JSON response. Adding a little sanitation to the search variable to replace those nbsp characters before it gets sent of fixes this.