### PR TITLE
Wiki lookup plugin

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/wikilookup/WikiLookupConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/wikilookup/WikiLookupConfig.java
@@ -40,7 +40,7 @@ public interface WikiLookupConfig extends Config
 	)
 	default boolean boundToShift()
 	{
-		return true;
+		return false;
 	}
 	
 	@ConfigItem(
@@ -51,14 +51,14 @@ public interface WikiLookupConfig extends Config
 	)
 	default boolean removeNonVital()
 	{
-		return false;
+		return true;
 	}
 	
 	@ConfigItem(
 			position = 2,
 			keyName = "permWiki",
 			name = "Make wiki option always visible",
-			description = "Makes the wiki option always visible but never the default regardless of options."
+			description = "Makes the wiki option always visible but never the default regardless of options. This will override the other options."
 	)
 	default boolean permWiki()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/wikilookup/WikiLookupConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/wikilookup/WikiLookupConfig.java
@@ -33,34 +33,11 @@ import net.runelite.client.config.ConfigItem;
 public interface WikiLookupConfig extends Config
 {
 	@ConfigItem(
-			position = 0,
-			keyName = "boundToShift",
-			name = "Shift bound lookup",
-			description = "Determines if wiki lookup will enable while shift is held."
+		keyName = "boundToShift",
+		name = "Shift bound lookup",
+		description = "Determines if wiki lookup will enable while shift is held."
 	)
 	default boolean boundToShift()
-	{
-		return false;
-	}
-	
-	@ConfigItem(
-			position = 1,
-			keyName = "removeNonVital",
-			name = "Make wiki option default",
-			description = "Determines whether wiki is the only option available during lookup."
-	)
-	default boolean removeNonVital()
-	{
-		return true;
-	}
-	
-	@ConfigItem(
-			position = 2,
-			keyName = "permWiki",
-			name = "Make wiki option always visible",
-			description = "Makes the wiki option always visible but never the default regardless of options. This will override the other options."
-	)
-	default boolean permWiki()
 	{
 		return false;
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/wikilookup/WikiLookupConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/wikilookup/WikiLookupConfig.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2018, Tanner Mjelde
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package net.runelite.client.plugins.wikilookup;
+
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+
+@ConfigGroup("wikilookup")
+public interface WikiLookupConfig extends Config
+{
+	@ConfigItem(
+			position = 0,
+			keyName = "boundToShift",
+			name = "Shift bound lookup",
+			description = "Determines if wiki lookup will enable while shift is held."
+	)
+	default boolean boundToShift()
+	{
+		return true;
+	}
+	
+	@ConfigItem(
+			position = 1,
+			keyName = "removeNonVital",
+			name = "Make wiki option default",
+			description = "Determines whether wiki is the only option available during lookup."
+	)
+	default boolean removeNonVital()
+	{
+		return false;
+	}
+	
+	@ConfigItem(
+			position = 2,
+			keyName = "permWiki",
+			name = "Make wiki option always visible",
+			description = "Makes the wiki option always visible but never the default regardless of options."
+	)
+	default boolean permWiki()
+	{
+		return false;
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/wikilookup/WikiLookupPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/wikilookup/WikiLookupPlugin.java
@@ -135,12 +135,11 @@ public class WikiLookupPlugin extends Plugin implements KeyListener
 	}
 
 	@Subscribe
-	public void onMenuObjectClicked(MenuOptionClicked event)
+	public void onMenuOptionClicked(MenuOptionClicked event)
 	{
-		wikiOrbInterface.setActive(false);
-
 		if (event.getMenuOption().equals(WIKI))
 		{
+			wikiOrbInterface.setActive(false);
 			LinkBrowser.browse("https://oldschool.runescape.wiki/w/" + Text.removeTags(event.getMenuTarget())
 				.replaceAll("\\(.*?\\)", "")
 				.replace(' ', '_'));
@@ -189,6 +188,7 @@ public class WikiLookupPlugin extends Plugin implements KeyListener
 
 		if (!hotkeyPressed && (
 			event.getTarget().length() >= 1
+				|| option.contains("walk here")
 				|| option.contains("guide")
 				|| option.contains("open")))
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/wikilookup/WikiLookupPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/wikilookup/WikiLookupPlugin.java
@@ -51,8 +51,7 @@ import javax.inject.Inject;
 import java.awt.event.KeyEvent;
 
 @PluginDescriptor(
-		name = "Wiki Lookup",
-		enabledByDefault = false
+		name = "Wiki Lookup"
 )
 public class WikiLookupPlugin extends Plugin implements KeyListener
 {
@@ -87,7 +86,8 @@ public class WikiLookupPlugin extends Plugin implements KeyListener
 		return configManager.getConfig(WikiLookupConfig.class);
 	}
 	
-	private boolean wikiLookupTrigger = false;
+	private boolean wikiLookupTriggerKey = false;
+	private boolean isWikiLookupTriggerButton = false;
 	
 	@Override
 	public void keyTyped(KeyEvent e)
@@ -98,21 +98,18 @@ public class WikiLookupPlugin extends Plugin implements KeyListener
 	@Override
 	public void keyPressed(KeyEvent e)
 	{
-		if (e.getKeyCode() == HOTKEY && config.boundToShift())
+		if (e.getKeyCode() == HOTKEY && config.boundToShift() && !isWikiLookupTriggerButton)
 		{
-			wikiLookupTrigger = true;
+			wikiLookupTriggerKey = true;
 		}
 	}
 	
 	@Override
 	public void keyReleased(KeyEvent e)
 	{
-		if (e.getKeyCode() == HOTKEY && config.boundToShift())
+		if (e.getKeyCode() == HOTKEY)
 		{
-			if (!wikiOrbInterface.getStatus())
-			{
-				wikiLookupTrigger = false;
-			}
+			wikiLookupTriggerKey = false;
 		}
 	}
 	
@@ -151,25 +148,28 @@ public class WikiLookupPlugin extends Plugin implements KeyListener
 			if (wikiOrbInterface.getStatus())
 			{
 				wikiOrbInterface.setStatus(false);
-				wikiLookupTrigger = false;
+				isWikiLookupTriggerButton = false;
 			}
 			else
 			{
-				wikiLookupTrigger = true;
+				System.out.println("We have clicked the button");
+				isWikiLookupTriggerButton = true;
 				wikiOrbInterface.setStatus(true);
 			}
 		}
 		else if (click.getMenuOption().equals(WIKI))
 		{
 			wikiOrbInterface.setStatus(false);
-			wikiLookupTrigger = false;
+			wikiLookupTriggerKey = false;
+			isWikiLookupTriggerButton = false;
 			LinkBrowser.browse("https://oldschool.runescape.wiki/w/" + Text.removeTags(click.getMenuTarget()).replaceAll("\\(.*?\\)", "").replace(' ', '_'));
 
 		}
 		else if (click.getMenuOption().equals("Cancel"))
 		{
 			wikiOrbInterface.setStatus(false);
-			wikiLookupTrigger = false;
+			wikiLookupTriggerKey = false;
+			isWikiLookupTriggerButton = false;
 		}
 	}
 	
@@ -178,9 +178,10 @@ public class WikiLookupPlugin extends Plugin implements KeyListener
 	{
 		if (config.permWiki())
 		{
-			wikiLookupTrigger = true;
+			wikiLookupTriggerKey = true;
+			isWikiLookupTriggerButton = true;
 		}
-		if (!wikiLookupTrigger)
+		if (!wikiLookupTriggerKey && !isWikiLookupTriggerButton)
 		{
 			return;
 		}
@@ -214,6 +215,7 @@ public class WikiLookupPlugin extends Plugin implements KeyListener
 		}
 		if (!config.permWiki() &&
 				(config.removeNonVital() &&
+						!wikiLookupTriggerKey &&
 						(event.getTarget().length() >= 1
 								|| option.equals("walk here")
 								|| option.contains("guide")
@@ -228,7 +230,9 @@ public class WikiLookupPlugin extends Plugin implements KeyListener
 	{
 		if (event.getGroup().equals("wikilookup"))
 		{
-			wikiLookupTrigger = false;
+			wikiLookupTriggerKey = false;
+			isWikiLookupTriggerButton = false;
+			wikiOrbInterface.setStatus(false);
 			if (event.getKey().equals("permWiki"))
 			{
 				if (config.permWiki())

--- a/runelite-client/src/main/java/net/runelite/client/plugins/wikilookup/WikiLookupPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/wikilookup/WikiLookupPlugin.java
@@ -185,14 +185,33 @@ public class WikiLookupPlugin extends Plugin implements KeyListener
 				addBlankOption(event.getOption().replaceFirst("View ", "").replaceFirst(" guide", ""));
 			}
 		}
-
-		if (!hotkeyPressed && (
-			event.getTarget().length() >= 1
-				|| option.contains("walk here")
-				|| option.contains("guide")
-				|| option.contains("open")))
+		//printEntries();
+		if (!hotkeyPressed)
 		{
-			removeOption(option);
+			removeWalk(option);
+			if ((event.getTarget().length() >= 1) || option.contains("guide") || option.contains("open"))
+			{
+				removeOption(option);
+			}
+		}
+	}
+
+	private void removeWalk(String option)
+	{
+		MenuEntry[] entries = client.getMenuEntries();
+
+		if (!option.equals("walk here") && entries.length >= 2 && entries[1].getOption().toLowerCase().equals("walk here"))
+		{
+			MenuEntry[] newEntries = new MenuEntry[entries.length - 1];
+			int j = 0;
+			for (int i = 0; i < entries.length; i++)
+			{
+				if (!entries[i].getOption().toLowerCase().equals("walk here"))
+				{
+					newEntries[j++] = entries[i];
+				}
+			}
+			client.setMenuEntries(newEntries);
 		}
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/wikilookup/WikiLookupPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/wikilookup/WikiLookupPlugin.java
@@ -1,0 +1,290 @@
+/*
+ * Copyright (c) 2018, Tanner <https://github.com/Reasel>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.wikilookup;
+
+import com.google.common.eventbus.Subscribe;
+import com.google.inject.Provides;
+import net.runelite.api.Client;
+import net.runelite.api.MenuAction;
+import net.runelite.api.MenuEntry;
+import net.runelite.api.events.ConfigChanged;
+import net.runelite.api.events.MenuEntryAdded;
+import net.runelite.api.events.MenuOptionClicked;
+import net.runelite.api.events.WidgetLoaded;
+import net.runelite.api.widgets.Widget;
+import net.runelite.api.widgets.WidgetID;
+import net.runelite.api.widgets.WidgetInfo;
+import net.runelite.client.callback.ClientThread;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.input.KeyListener;
+import net.runelite.client.input.KeyManager;
+import net.runelite.client.menus.MenuManager;
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.util.LinkBrowser;
+import net.runelite.client.util.Text;
+import org.apache.commons.lang3.ArrayUtils;
+
+import javax.inject.Inject;
+import java.awt.event.KeyEvent;
+
+@PluginDescriptor(
+		name = "Wiki Lookup",
+		enabledByDefault = false
+)
+public class WikiLookupPlugin extends Plugin implements KeyListener
+{
+	private static final String WIKI = "Wiki";
+	
+	private static final int HOTKEY = KeyEvent.VK_SHIFT;
+	
+	@Inject
+	private Client client;
+	
+	@Inject
+	private MenuManager menuManager;
+	
+	@Inject
+	private KeyManager keyManager;
+	
+	@Inject
+	private WikiLookupConfig config;
+	
+	@Inject
+	private ClientThread clientThread;
+	
+	@Inject
+	private WikiOrbInterface wikiOrbInterface;
+	
+	private Widget wikiOrb;
+	private Widget parent;
+	
+	@Provides
+	WikiLookupConfig provideConfig(ConfigManager configManager)
+	{
+		return configManager.getConfig(WikiLookupConfig.class);
+	}
+	
+	private boolean wikiLookupTrigger = false;
+	
+	@Override
+	public void keyTyped(KeyEvent e)
+	{
+	
+	}
+	
+	@Override
+	public void keyPressed(KeyEvent e)
+	{
+		if (e.getKeyCode() == HOTKEY && config.boundToShift())
+		{
+			wikiLookupTrigger = true;
+		}
+	}
+	
+	@Override
+	public void keyReleased(KeyEvent e)
+	{
+		if (e.getKeyCode() == HOTKEY && config.boundToShift())
+		{
+			if (!wikiOrbInterface.getStatus())
+			{
+				wikiLookupTrigger = false;
+			}
+		}
+	}
+	
+	@Override
+	protected void startUp() throws Exception
+	{
+		keyManager.registerKeyListener(this);
+		
+		if (client.getWidget(WidgetInfo.MINIMAP_ORBS) != null && !config.permWiki())
+		{
+			clientThread.invokeLater(() -> wikiOrbInterface.init());
+		}
+	}
+	
+	@Override
+	protected void shutDown() throws Exception
+	{
+		keyManager.unregisterKeyListener(this);
+		clientThread.invokeLater(() -> wikiOrbInterface.destroy());
+	}
+	
+	@Subscribe
+	public void onWidgetLoaded(WidgetLoaded event)
+	{
+		if (event.getGroupId() == WidgetID.MINIMAP_GROUP_ID && !wikiOrbInterface.getLoaded() && !config.permWiki())
+		{
+			wikiOrbInterface.init();
+		}
+	}
+	
+	@Subscribe
+	public void onMenuObjectClicked(MenuOptionClicked click)
+	{
+		if (click.getMenuOption().equals("Wiki Lookup"))
+		{
+			if (wikiOrbInterface.getStatus())
+			{
+				wikiOrbInterface.setStatus(false);
+				wikiLookupTrigger = false;
+			}
+			else
+			{
+				wikiLookupTrigger = true;
+				wikiOrbInterface.setStatus(true);
+			}
+		}
+		else if (click.getMenuOption().equals(WIKI))
+		{
+			wikiOrbInterface.setStatus(false);
+			wikiLookupTrigger = false;
+			LinkBrowser.browse("https://oldschool.runescape.wiki/w/" + Text.removeTags(click.getMenuTarget()).replaceAll("\\(.*?\\)", "").replace(' ', '_'));
+
+		}
+		else if (click.getMenuOption().equals("Cancel"))
+		{
+			wikiOrbInterface.setStatus(false);
+			wikiLookupTrigger = false;
+		}
+	}
+	
+	@Subscribe
+	public void onMenuEntryAdded(MenuEntryAdded event)
+	{
+		if (config.permWiki())
+		{
+			wikiLookupTrigger = true;
+		}
+		if (!wikiLookupTrigger)
+		{
+			return;
+		}
+		
+		String option = Text.removeTags(event.getOption()).toLowerCase();
+		
+		if (event.getType() == MenuAction.EXAMINE_ITEM_GROUND.getId()
+				|| event.getType() == MenuAction.EXAMINE_ITEM.getId()
+				|| event.getType() == MenuAction.EXAMINE_ITEM_BANK_EQ.getId()
+				|| event.getType() == MenuAction.EXAMINE_OBJECT.getId()
+				|| event.getType() == MenuAction.EXAMINE_NPC.getId()
+				|| event.getType() == MenuAction.WIDGET_DEFAULT.getId()
+				|| event.getType() == MenuAction.WIDGET_TYPE_2.getId())
+		{
+			if ((option.equals("read journal:")
+					|| option.equals("cast")
+					|| option.equals("activate"))
+					|| option.contains("play")
+					|| option.equals("examine"))
+			{
+				addBlankOption("cancel", WIKI, event.getTarget());
+			}
+			else if (option.contains("open"))
+			{
+				addBlankOption("cancel", WIKI, event.getOption().replaceFirst("Open ", "").replaceAll("Journal", "") + "Diary");
+			}
+			else if (option.contains("guide"))
+			{
+				addBlankOption("cancel", WIKI, event.getOption().replaceFirst("View ", "").replaceFirst(" guide", ""));
+			}
+		}
+		if (!config.permWiki() &&
+				(config.removeNonVital() &&
+						(event.getTarget().length() >= 1
+								|| option.equals("walk here")
+								|| option.contains("guide")
+								|| option.contains("open"))))
+		{
+			removeOption(option);
+		}
+	}
+	
+	@Subscribe
+	public void onConfigChanged(ConfigChanged event)
+	{
+		if (event.getGroup().equals("wikilookup"))
+		{
+			wikiLookupTrigger = false;
+			if (event.getKey().equals("permWiki"))
+			{
+				if (config.permWiki())
+				{
+					clientThread.invokeLater(() -> wikiOrbInterface.destroy());
+				}
+				else if (client.getWidget(WidgetInfo.MINIMAP_ORBS) != null)
+				{
+					clientThread.invokeLater(() -> wikiOrbInterface.init());
+				}
+			}
+		}
+	}
+	
+	private void removeOption(String option)
+	{
+		MenuEntry[] entries = client.getMenuEntries();
+		if (entries.length > 1)
+		{
+			MenuEntry[] newEntries = new MenuEntry[entries.length - 1];
+			for (int i = 0; i < entries.length; ++i)
+			{
+				if (!(Text.removeTags(entries[i].getOption()).toLowerCase().contains(option)))
+				{
+					newEntries[i] = entries[i];
+				}
+			}
+			client.setMenuEntries(newEntries);
+		}
+	}
+	
+	private void addBlankOption(String toCopy, String newOption, String newTarget)
+	{
+		MenuEntry[] entries = client.getMenuEntries();
+		MenuEntry[] newEntries = new MenuEntry[entries.length + 1];
+		for (int i = 0; i < entries.length; ++i)
+		{
+			if (Text.removeTags(entries[i].getOption()).toLowerCase().contains(toCopy))
+			{
+				final MenuEntry blankOption = new MenuEntry();
+				blankOption.setOption(newOption);
+				blankOption.setTarget(newTarget);
+				blankOption.setIdentifier(entries[i].getIdentifier());
+				blankOption.setParam1(entries[i].getParam1());
+				blankOption.setType(entries[i].getType());
+				client.setMenuEntries(ArrayUtils.addAll(entries, blankOption));
+				newEntries[newEntries.length - 1] = blankOption;
+				
+				//newEntries[newEntries.length - 1] = entries[i].toBuilder().option(newOption).target(newTarget).build();
+			}
+			newEntries[i] = entries[i];
+		}
+		newEntries[newEntries.length - 1].setOption(newOption);
+		MenuEntry holder = newEntries[newEntries.length - 1];
+		newEntries[newEntries.length - 1] = newEntries[newEntries.length - 2];
+		newEntries[newEntries.length - 2] = holder;
+		client.setMenuEntries(newEntries);
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/wikilookup/WikiLookupPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/wikilookup/WikiLookupPlugin.java
@@ -138,7 +138,6 @@ public class WikiLookupPlugin extends Plugin implements KeyListener
 	public void onMenuObjectClicked(MenuOptionClicked event)
 	{
 		wikiOrbInterface.setActive(false);
-		hotkeyPressed = false;
 
 		if (event.getMenuOption().equals(WIKI))
 		{
@@ -155,7 +154,7 @@ public class WikiLookupPlugin extends Plugin implements KeyListener
 	@Subscribe
 	public void onMenuEntryAdded(MenuEntryAdded event)
 	{
-		if (!hotkeyPressed || !wikiOrbInterface.isActive())
+		if (!hotkeyPressed && !wikiOrbInterface.isActive())
 		{
 			return;
 		}
@@ -190,7 +189,6 @@ public class WikiLookupPlugin extends Plugin implements KeyListener
 
 		if (!hotkeyPressed && (
 			event.getTarget().length() >= 1
-				|| option.equals("walk here")
 				|| option.contains("guide")
 				|| option.contains("open")))
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/wikilookup/WikiOrbInterface.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/wikilookup/WikiOrbInterface.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2018, Tanner Mjelde
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package net.runelite.client.plugins.wikilookup;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.Client;
+import net.runelite.api.ScriptID;
+import net.runelite.api.SpriteID;
+import net.runelite.api.WidgetType;
+import net.runelite.api.widgets.Widget;
+import net.runelite.api.widgets.WidgetInfo;
+import net.runelite.client.callback.ClientThread;
+import net.runelite.client.config.ConfigManager;
+
+@Slf4j
+@Singleton
+public class WikiOrbInterface
+{
+	private static final String WIKI_ORB = "Wiki Lookup";
+	private final Client client;
+	private final ClientThread clientThread;
+	private final ConfigManager configManager;
+	private final WikiLookupConfig config;
+	private boolean loaded = false;
+
+	private Widget wikiOrb;
+	private Widget orbSearch;
+	private Widget orbBackground;
+
+	@Getter
+	private Widget parent;
+	
+	@Inject
+	private WikiOrbInterface(
+			final Client client,
+			final ClientThread clientThread,
+			final ConfigManager configManager,
+			final WikiLookupConfig config)
+	{
+		this.client = client;
+		this.clientThread = clientThread;
+		this.configManager = configManager;
+		this.config = config;
+	}
+	
+	public void init()
+	{
+		if (isHidden())
+		{
+			return;
+		}
+		loaded = true;
+		parent = client.getWidget(WidgetInfo.MINIMAP_ORBS);
+		wikiOrb = createGraphic("", SpriteID.MINIMAP_ORB_WORLD_MAP_FRAME, -1, 30 , 30 , 170, 0, true);
+		orbBackground = createGraphic("", SpriteID.MINIMAP_ORB_RUN, -1, 25 , 25 , 173, 3, false);
+		orbSearch = createGraphic("", SpriteID.BANK_SEARCH, -1, 22, 20, 173, 5, false);
+		wikiOrb.setAction(0, WIKI_ORB);
+	}
+	
+	public void destroy()
+	{
+		wikiOrb.setHidden(true);
+		orbSearch.setHidden(true);
+		orbBackground.setHidden(true);
+	}
+	
+	public boolean getLoaded()
+	{
+		return loaded;
+	}
+	
+	private boolean isHidden()
+	{
+		Widget widget = client.getWidget(WidgetInfo.MINIMAP_ORBS);
+		return widget == null || widget.isHidden();
+	}
+
+	public boolean getStatus()
+	{
+		return orbBackground.getSpriteId() == SpriteID.MINIMAP_ORB_RUN_ACTIVATED;
+	}
+
+	public void setStatus(boolean status)
+	{
+		if (status)
+		{
+			orbBackground.setSpriteId(SpriteID.MINIMAP_ORB_RUN_ACTIVATED);
+		}
+		else
+		{
+			orbBackground.setSpriteId(SpriteID.MINIMAP_ORB_RUN);
+		}
+	}
+	
+	private Widget createGraphic(String name, int spriteId, int itemId, int width, int height, int x, int y, boolean hasListener)
+	{
+		Widget widget = parent.createChild(-1, WidgetType.GRAPHIC);
+		widget.setOriginalWidth(width);
+		widget.setOriginalHeight(height);
+		widget.setOriginalX(x);
+		widget.setOriginalY(y);
+		widget.setSpriteId(spriteId);
+		if (itemId > -1)
+		{
+			widget.setItemId(itemId);
+			widget.setItemQuantity(-1);
+			widget.setBorderType(1);
+		}
+		if (hasListener)
+		{
+			widget.setOnOpListener(ScriptID.NULL);
+			widget.setHasListener(true);
+		}
+		widget.setName(name);
+		widget.revalidate();
+		return widget;
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/wikilookup/WikiOrbInterface.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/wikilookup/WikiOrbInterface.java
@@ -67,7 +67,7 @@ public class WikiOrbInterface
 		parent = client.getWidget(WidgetInfo.MINIMAP_ORBS);
 		wikiOrb = createGraphic(SpriteID.MINIMAP_ORB_WORLD_MAP_FRAME, 30 , 30 , 170, 0, true);
 		orbBackground = createGraphic(SpriteID.MINIMAP_ORB_RUN, 25 , 25 , 173, 3, false);
-		orbSearch = createGraphic(SpriteID.BANK_SEARCH, 22, 20, 173, 5, false);
+		orbSearch = createGraphic(SpriteID.GE_SEARCH, 22, 20, 174, 6, false);
 		wikiOrb.setAction(0, WIKI_ORB);
 	}
 
@@ -108,6 +108,7 @@ public class WikiOrbInterface
 
 		if (event.getMenuOption().equals(WIKI_ORB))
 		{
+			event.consume();
 			setActive(!isActive());
 		}
 	}
@@ -126,13 +127,6 @@ public class WikiOrbInterface
 		widget.setOriginalX(x);
 		widget.setOriginalY(y);
 		widget.setSpriteId(spriteId);
-
-		if (-1 > -1)
-		{
-			widget.setItemId(-1);
-			widget.setItemQuantity(-1);
-			widget.setBorderType(1);
-		}
 
 		if (hasListener)
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/wikilookup/WikiOrbInterface.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/wikilookup/WikiOrbInterface.java
@@ -28,7 +28,6 @@ package net.runelite.client.plugins.wikilookup;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import lombok.Getter;
-import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.ScriptID;
 import net.runelite.api.SpriteID;
@@ -37,9 +36,8 @@ import net.runelite.api.events.MenuOptionClicked;
 import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetInfo;
 
-@Slf4j
 @Singleton
-public class WikiOrbInterface
+class WikiOrbInterface
 {
 	private static final String WIKI_ORB = "Wiki Lookup";
 
@@ -93,7 +91,7 @@ public class WikiOrbInterface
 	{
 		if (isHidden())
 		{
-            return;
+			return;
 		}
 
 		orbBackground.setSpriteId(active ? SpriteID.MINIMAP_ORB_RUN_ACTIVATED : SpriteID.MINIMAP_ORB_RUN);
@@ -110,6 +108,10 @@ public class WikiOrbInterface
 		{
 			event.consume();
 			setActive(!isActive());
+		}
+		else
+		{
+			setActive(false);
 		}
 	}
 


### PR DESCRIPTION
# Lookup Items, NPCs, Objects, Quests, Spells, Diaries, and more via menu option.

This plugin will allow you to add a new option to Lookup which when clicked will open the  **new** wiki page for that thing in your default browser.

It functions only when holding shift. It works in the bank, on the ground, in your inventory, and even your equipment.

Things you can wiki:

- Inventory Items
- Equipment
- Skills
- Spells
- Prayers
- Music
- Quests
- Diaries
- Objects

# Examples
This
![settings1](https://i.imgur.com/SBJaIVk.png)
Will produce this
![allOff](https://i.imgur.com/ISyuwJn.gif)

This
![settings2](https://i.imgur.com/5uXzcyj.png)
Will produce this. As long as the third option is select this will be the same behavior regardless of the other settings.
![alwaysOn](https://i.imgur.com/n3OWfAX.gif)


This
![settings3](https://i.imgur.com/jH8ptf9.png)
Will Produce this (Also to add here is that if you click cancel on anything it will turn off the wiki search)
![DefaultNoShift](https://i.imgur.com/NuIZLdE.gif)


This
![settings4](https://i.imgur.com/BuCVJ4H.png)
Will produce this
![shiftPlusOrbDeafault](https://i.imgur.com/QVcPiNr.gif)
