### PR TITLE
HTTP Service - Number of sessions in-game

### DIFF
--- a/http-api/src/main/java/net/runelite/http/api/session/SessionClient.java
+++ b/http-api/src/main/java/net/runelite/http/api/session/SessionClient.java
@@ -32,7 +32,9 @@ import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.http.api.RuneLiteAPI;
 import okhttp3.HttpUrl;
+import okhttp3.MultipartBody;
 import okhttp3.Request;
+import okhttp3.RequestBody;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
 
@@ -62,16 +64,22 @@ public class SessionClient
 		}
 	}
 
-	public void ping(UUID uuid) throws IOException
+	public void ping(UUID uuid, boolean inGame) throws IOException
 	{
 		HttpUrl url = RuneLiteAPI.getApiBase().newBuilder()
 			.addPathSegment("session")
 			.addPathSegment("ping")
-			.addQueryParameter("session", uuid.toString())
+			.build();
+
+		RequestBody requestBody = new MultipartBody.Builder()
+			.setType(MultipartBody.FORM)
+			.addFormDataPart("session", uuid.toString())
+			.addFormDataPart("ingame", inGame ? "1" : "0")
 			.build();
 
 		Request request = new Request.Builder()
 			.url(url)
+			.post(requestBody)
 			.build();
 
 		try (Response response = RuneLiteAPI.CLIENT.newCall(request).execute())

--- a/http-service/src/main/java/net/runelite/http/service/session/SessionController.java
+++ b/http-service/src/main/java/net/runelite/http/service/session/SessionController.java
@@ -30,6 +30,7 @@ import javax.servlet.http.HttpServletRequest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -55,14 +56,15 @@ public class SessionController
 		SessionEntry sessionEntry = new SessionEntry();
 		sessionEntry.setUuid(uuid);
 		sessionEntry.setIp(addr);
+		sessionEntry.setIngame(false);
 		sessionEntry.setStart(now);
 		sessionEntry.setLast(now);
 		sessionService.createSession(sessionEntry);
 		return uuid;
 	}
 
-	@RequestMapping("/ping")
-	public ResponseEntity ping(@RequestParam("session") UUID uuid)
+	@PostMapping("/ping")
+	public ResponseEntity ping(@RequestParam("session") UUID uuid, @RequestParam("ingame") Boolean inGame)
 	{
 		SessionEntry sessionEntry = sessionService.findSessionByUUID(uuid);
 		if (sessionEntry == null)
@@ -70,7 +72,7 @@ public class SessionController
 			return ResponseEntity.notFound().build();
 		}
 
-		sessionService.updateLast(uuid);
+		sessionService.updateLast(uuid, inGame);
 		return ResponseEntity.ok().build();
 	}
 
@@ -91,5 +93,11 @@ public class SessionController
 	public int count()
 	{
 		return sessionService.getCount();
+	}
+
+	@RequestMapping("/statistics")
+	public String statistics()
+	{
+		return sessionService.getStatistics();
 	}
 }

--- a/http-service/src/main/java/net/runelite/http/service/session/SessionService.java
+++ b/http-service/src/main/java/net/runelite/http/service/session/SessionService.java
@@ -24,8 +24,10 @@
  */
 package net.runelite.http.service.session;
 
+import com.google.gson.Gson;
 import java.time.Instant;
 import java.util.UUID;
+import net.runelite.http.api.RuneLiteAPI;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -36,6 +38,7 @@ import org.sql2o.Sql2o;
 @Service
 public class SessionService
 {
+	private final Gson gson = RuneLiteAPI.GSON;
 	private final Sql2o sql2o;
 
 	@Autowired
@@ -50,10 +53,11 @@ public class SessionService
 	{
 		try (Connection con = sql2o.open())
 		{
-			con.createQuery("insert into session (uuid, ip, start, last) "
-				+ "values (:uuid, :ip, :start, :last)")
+			con.createQuery("insert into session (uuid, ip, ingame, start, last) "
+				+ "values (:uuid, :ip, :ingame, :start, :last)")
 				.addParameter("uuid", session.getUuid().toString())
 				.addParameter("ip", session.getIp())
+				.addParameter("ingame", session.getIngame())
 				.addParameter("start", session.getStart())
 				.addParameter("last", session.getLast())
 				.executeUpdate();
@@ -64,7 +68,7 @@ public class SessionService
 	{
 		try (Connection con = sql2o.open())
 		{
-			return con.createQuery("select uuid, ip, start, last from session where uuid = :uuid")
+			return con.createQuery("select uuid, ip, ingame, start, last from session where uuid = :uuid")
 				.addParameter("uuid", id.toString())
 				.executeAndFetchFirst(SessionEntry.class);
 		}
@@ -80,13 +84,14 @@ public class SessionService
 		}
 	}
 
-	public void updateLast(UUID session)
+	public void updateLast(UUID session, Boolean inGame)
 	{
 		try (Connection con = sql2o.open())
 		{
 			Instant last = Instant.now();
-			con.createQuery("update session set last = :last where uuid = :uuid")
+			con.createQuery("update session set last = :last, ingame = :ingame where uuid = :uuid")
 				.addParameter("last", last)
+				.addParameter("ingame", inGame)
 				.addParameter("uuid", session.toString())
 				.executeUpdate();
 		}
@@ -98,6 +103,22 @@ public class SessionService
 		{
 			con.createQuery("delete from session where last + interval 5 minute < current_timestamp()")
 				.executeUpdate();
+		}
+	}
+
+	public String getStatistics()
+	{
+		try (Connection con = sql2o.open())
+		{
+			int clientCount = con.createQuery("select count(*) from session")
+				.executeScalar(Integer.class);
+
+			int inGameCount = con.createQuery("SELECT count(*) from session WHERE ingame IS NOT FALSE;")
+				.executeScalar(Integer.class);
+
+			StatisticsInfo statistics = new StatisticsInfo(inGameCount, clientCount);
+
+			return gson.toJson(statistics);
 		}
 	}
 

--- a/http-service/src/main/java/net/runelite/http/service/session/StatisticsInfo.java
+++ b/http-service/src/main/java/net/runelite/http/service/session/StatisticsInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Adam <Adam@sigterm.info>
+ * Copyright (c) 2018, Lars <lars.oernlo@gmail.com>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -22,19 +22,17 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+
 package net.runelite.http.service.session;
 
-import java.time.Instant;
-import java.util.UUID;
-import lombok.Data;
-
-@Data
-public class SessionEntry
+class StatisticsInfo
 {
-	private int id;
-	private UUID uuid;
-	private String ip;
-	private Boolean ingame;
-	private Instant start;
-	private Instant last;
+	private int ingame;
+	private int clients;
+
+	StatisticsInfo(int ingameCount, int clientCount)
+	{
+		this.ingame = ingameCount;
+		this.clients = clientCount;
+	}
 }

--- a/http-service/src/main/resources/net/runelite/http/service/session/session.sql
+++ b/http-service/src/main/resources/net/runelite/http/service/session/session.sql
@@ -26,6 +26,7 @@ CREATE TABLE `session` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `uuid` varchar(36) NOT NULL,
   `ip` varchar(39) NOT NULL,
+  `ingame` BOOL DEFAULT FALSE,
   `start` timestamp NOT NULL DEFAULT '0000-00-00 00:00:00',
   `last` timestamp NOT NULL DEFAULT '0000-00-00 00:00:00',
   PRIMARY KEY (`id`),

--- a/runelite-client/src/main/java/net/runelite/client/ClientSessionManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/ClientSessionManager.java
@@ -107,7 +107,7 @@ public class ClientSessionManager
 			log.warn(null, ex);
 		}
 
-		boolean inGame = client.getGameState() != GameState.LOGIN_SCREEN;
+		boolean inGame = client.getGameState().compareTo(GameState.LOGIN_SCREEN) > 0;
 
 		try
 		{


### PR DESCRIPTION
Extends session system to also check for players currently in-game.

```
curl http://127.0.0.1/runelite-1.3.9-SNAPSHOT/session/statistics
{"ingame":1,"clients":1}
```

(Client is logged out and next ping runs)

```
curl http://127.0.0.1/runelite-1.3.9-SNAPSHOT/session/statistics
{"ingame":0,"clients":1}
```