### PR TITLE
BossTimerPlugin: Start timer on despawn

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/bosstimer/Boss.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/bosstimer/Boss.java
@@ -51,11 +51,11 @@ enum Boss
 	DAGANNOTH_REX("Dagannoth Rex", 90, ChronoUnit.SECONDS, ItemID.PET_DAGANNOTH_REX),
 	DAGANNOTH_SUPREME("Dagannoth Supreme", 90, ChronoUnit.SECONDS, ItemID.PET_DAGANNOTH_SUPREME),
 	CORPOREAL_BEAST("Corporeal Beast", 30, ChronoUnit.SECONDS, ItemID.PET_DARK_CORE),
-	GIANT_MOLE("Giant Mole", 10, ChronoUnit.SECONDS, ItemID.BABY_MOLE),
-	DERANGED_ARCHAEOLOGIST("Deranged archaeologist", 30, ChronoUnit.SECONDS, ItemID.UNIDENTIFIED_LARGE_FOSSIL),
-	CERBERUS("Cerberus", 10800, ChronoUnit.MILLIS, ItemID.HELLPUPPY),
-	THERMONUCLEAR_SMOKE_DEVIL("Thermonuclear smoke devil", 12, ChronoUnit.SECONDS, ItemID.PET_SMOKE_DEVIL),
-	KRAKEN("Kraken", 10800, ChronoUnit.MILLIS, ItemID.PET_KRAKEN);
+	GIANT_MOLE("Giant Mole", 9000, ChronoUnit.MILLIS, ItemID.BABY_MOLE),
+	DERANGED_ARCHAEOLOGIST("Deranged archaeologist", 29400, ChronoUnit.MILLIS, ItemID.UNIDENTIFIED_LARGE_FOSSIL),
+	CERBERUS("Cerberus", 8400, ChronoUnit.MILLIS, ItemID.HELLPUPPY),
+	THERMONUCLEAR_SMOKE_DEVIL("Thermonuclear smoke devil", 8400, ChronoUnit.MILLIS, ItemID.PET_SMOKE_DEVIL),
+	KRAKEN("Kraken", 8400, ChronoUnit.MILLIS, ItemID.PET_KRAKEN);
 
 	private static final Map<String, Boss> bosses = new HashMap<>();
 


### PR DESCRIPTION
The current implementation starts the timer when a boss' hp reaches 0, meaning the reaches 0 before the boss respawns. Some bosses might be a tick or two off, but it's now way more accurate