### PR TITLE
Slayer plugin: update infobox counter whenever bracelet triggers

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerPlugin.java
@@ -505,6 +505,7 @@ public class SlayerPlugin extends Plugin
 
 		addCounter();
 		counter.setText(String.valueOf(amount));
+		infoTimer = Instant.now();
 	}
 
 	private List<NPC> buildTargetsToHighlight()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerPlugin.java
@@ -317,6 +317,7 @@ public class SlayerPlugin extends Plugin
 		if (chatMsg.startsWith(CHAT_BRACELET_SLAUGHTER))
 		{
 			amount++;
+			addCounter();
 			counter.setText(String.valueOf(amount));
 			slaughterChargeCount = --slaughterChargeCount <= 0 ? SLAUGHTER_CHARGE : slaughterChargeCount;
 			config.slaughter(slaughterChargeCount);
@@ -325,6 +326,7 @@ public class SlayerPlugin extends Plugin
 		if (chatMsg.startsWith(CHAT_BRACELET_EXPEDITIOUS))
 		{
 			amount--;
+			addCounter();
 			counter.setText(String.valueOf(amount));
 			expeditiousChargeCount = --expeditiousChargeCount <= 0 ? EXPEDITIOUS_CHARGE : expeditiousChargeCount;
 			config.expeditious(expeditiousChargeCount);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerPlugin.java
@@ -317,19 +317,27 @@ public class SlayerPlugin extends Plugin
 		if (chatMsg.startsWith(CHAT_BRACELET_SLAUGHTER))
 		{
 			amount++;
-			addCounter();
-			counter.setText(String.valueOf(amount));
 			slaughterChargeCount = --slaughterChargeCount <= 0 ? SLAUGHTER_CHARGE : slaughterChargeCount;
 			config.slaughter(slaughterChargeCount);
+			if (!config.showInfobox())
+			{
+				return;
+			}
+			addCounter();
+			counter.setText(String.valueOf(amount));
 		}
 
 		if (chatMsg.startsWith(CHAT_BRACELET_EXPEDITIOUS))
 		{
 			amount--;
-			addCounter();
-			counter.setText(String.valueOf(amount));
 			expeditiousChargeCount = --expeditiousChargeCount <= 0 ? EXPEDITIOUS_CHARGE : expeditiousChargeCount;
 			config.expeditious(expeditiousChargeCount);
+			if (!config.showInfobox())
+			{
+				return;
+			}
+			addCounter();
+			counter.setText(String.valueOf(amount));
 		}
 
 		if (chatMsg.startsWith(CHAT_BRACELET_EXPEDITIOUS_CHARGE))

--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerPlugin.java
@@ -317,6 +317,7 @@ public class SlayerPlugin extends Plugin
 		if (chatMsg.startsWith(CHAT_BRACELET_SLAUGHTER))
 		{
 			amount++;
+			counter.setText(String.valueOf(amount));
 			slaughterChargeCount = --slaughterChargeCount <= 0 ? SLAUGHTER_CHARGE : slaughterChargeCount;
 			config.slaughter(slaughterChargeCount);
 		}
@@ -324,6 +325,7 @@ public class SlayerPlugin extends Plugin
 		if (chatMsg.startsWith(CHAT_BRACELET_EXPEDITIOUS))
 		{
 			amount--;
+			counter.setText(String.valueOf(amount));
 			expeditiousChargeCount = --expeditiousChargeCount <= 0 ? EXPEDITIOUS_CHARGE : expeditiousChargeCount;
 			config.expeditious(expeditiousChargeCount);
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerPlugin.java
@@ -319,12 +319,7 @@ public class SlayerPlugin extends Plugin
 			amount++;
 			slaughterChargeCount = --slaughterChargeCount <= 0 ? SLAUGHTER_CHARGE : slaughterChargeCount;
 			config.slaughter(slaughterChargeCount);
-			if (!config.showInfobox())
-			{
-				return;
-			}
-			addCounter();
-			counter.setText(String.valueOf(amount));
+			updateCounter();
 		}
 
 		if (chatMsg.startsWith(CHAT_BRACELET_EXPEDITIOUS))
@@ -332,12 +327,7 @@ public class SlayerPlugin extends Plugin
 			amount--;
 			expeditiousChargeCount = --expeditiousChargeCount <= 0 ? EXPEDITIOUS_CHARGE : expeditiousChargeCount;
 			config.expeditious(expeditiousChargeCount);
-			if (!config.showInfobox())
-			{
-				return;
-			}
-			addCounter();
-			counter.setText(String.valueOf(amount));
+			updateCounter();
 		}
 
 		if (chatMsg.startsWith(CHAT_BRACELET_EXPEDITIOUS_CHARGE))
@@ -460,16 +450,7 @@ public class SlayerPlugin extends Plugin
 
 		amount--;
 		config.amount(amount); // save changed value
-
-		if (!config.showInfobox())
-		{
-			return;
-		}
-
-		// add and update counter, set timer
-		addCounter();
-		counter.setText(String.valueOf(amount));
-		infoTimer = Instant.now();
+		updateCounter();
 	}
 
 	private void setTask(String name, int amt)
@@ -513,6 +494,17 @@ public class SlayerPlugin extends Plugin
 
 		infoBoxManager.removeInfoBox(counter);
 		counter = null;
+	}
+
+	private void updateCounter()
+	{
+		if (!config.showInfobox())
+		{
+			return;
+		}
+
+		addCounter();
+		counter.setText(String.valueOf(amount));
 	}
 
 	private List<NPC> buildTargetsToHighlight()


### PR DESCRIPTION
Currently infobox only updates whenever the killedOne() is triggered, this fixes that.