### PR TITLE
Inventory ItemStats Toggle Option While Viewing Banking

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatConfig.java
@@ -70,9 +70,9 @@ public interface ItemStatConfig extends Config
 	}
 
 	@ConfigItem(
-			keyName = "bankToggle",
-			name = "Show While Banking",
-			description = "Show inventory tooltip while viewing bank"
+		keyName = "bankToggle",
+		name = "Show While Banking",
+		description = "Show inventory tooltip while viewing bank"
 	)
 
 	default boolean bankToggle()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatConfig.java
@@ -70,6 +70,17 @@ public interface ItemStatConfig extends Config
 	}
 
 	@ConfigItem(
+			keyName = "bankToggle",
+			name = "Show While Banking",
+			description = "Show inventory tooltip while viewing bank"
+	)
+
+	default boolean bankToggle()
+	{
+		return true;
+	}
+
+	@ConfigItem(
 		keyName = "colorBetterUncapped",
 		name = "Better (Uncapped)",
 		description = "Color to show when the stat change is fully consumed",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatOverlay.java
@@ -30,6 +30,8 @@ import java.awt.Graphics2D;
 import java.awt.Point;
 import net.runelite.api.Client;
 import net.runelite.api.queries.InventoryWidgetItemQuery;
+import net.runelite.api.widgets.Widget;
+import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.api.widgets.WidgetItem;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.tooltip.Tooltip;
@@ -57,6 +59,11 @@ public class ItemStatOverlay extends Overlay
 	public Dimension render(Graphics2D graphics)
 	{
 		if (client.isMenuOpen() || (!config.relative() && !config.absolute() && !config.theoretical()))
+		{
+			return null;
+		}
+
+		if (client.getWidget(WidgetInfo.BANK_ITEM_CONTAINER) != null && !config.bankToggle())
 		{
 			return null;
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatOverlay.java
@@ -30,7 +30,6 @@ import java.awt.Graphics2D;
 import java.awt.Point;
 import net.runelite.api.Client;
 import net.runelite.api.queries.InventoryWidgetItemQuery;
-import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.api.widgets.WidgetItem;
 import net.runelite.client.ui.overlay.Overlay;


### PR DESCRIPTION
Adds the option to enable/disable the plugin while banking.

Clarification: This only adds the option to disable the INVENTORY side WHILE banking. If enabled, you can walk around and have item stats, though, the moment you open a bank, the inventory-side of item stats is disabled.