### PR TITLE
Added config option to not factor Prayer level to calculate combat level

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/Experience.java
+++ b/runelite-api/src/main/java/net/runelite/api/Experience.java
@@ -124,6 +124,22 @@ public class Experience
 
 		return base + max(melee, max(range, magic));
 	}
+	/**
+	 * Calculates a high-precision combat level without integer rounding and without factoring in prayer.
+	 *
+	 * @return Combat level between 1.15 and ~126.1 (assuming non-virtual levels).
+	 * */
+	public static double getCombatLevelPreciseNoPrayer(int attackLevel, int strengthLevel,
+		int defenceLevel, int hitpointsLevel, int magicLevel, int rangeLevel)
+	{
+		double base = 0.25 * (defenceLevel + hitpointsLevel);
+
+		double melee = 0.325 * (attackLevel + strengthLevel);
+		double range = 0.325 * (floor(rangeLevel / 2) + rangeLevel);
+		double magic = 0.325 * (floor(magicLevel / 2) + magicLevel);
+
+		return base + max(melee, max(range, magic));
+	}
 
 	/**
 	 * Calculates a regular combat level.
@@ -131,9 +147,20 @@ public class Experience
 	 * @return Combat level between 1 and 126 (assuming non-virtual levels).
 	 */
 	public static int getCombatLevel(int attackLevel, int strengthLevel,
-		int defenceLevel, int hitpointsLevel, int magicLevel,
-		int rangeLevel, int prayerLevel)
+		int defenceLevel, int hitpointsLevel,
+		int magicLevel, int rangeLevel, int prayerLevel)
 	{
 		return (int) getCombatLevelPrecise(attackLevel, strengthLevel, defenceLevel, hitpointsLevel, magicLevel, rangeLevel, prayerLevel);
+	}
+	/**
+	 * Calculates a regular combat level without factoring in prayer.
+	 *
+	 * @return Combat level between 1 and 126 (assuming non-virtual levels).
+	 */
+	public static int getCombatLevelNoPrayer(int attackLevel, int strengthLevel,
+		int defenceLevel, int hitpointsLevel,
+		int magicLevel, int rangeLevel)
+	{
+		return (int) getCombatLevelPreciseNoPrayer(attackLevel, strengthLevel, defenceLevel, hitpointsLevel, magicLevel, rangeLevel);
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/combatlevel/CombatLevelConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/combatlevel/CombatLevelConfig.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2018, Fat Rat <http://github.com/capSAR273>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.combatlevel;
+
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+
+@ConfigGroup(name = "Combat Level",
+	keyName = "combatlevel",
+	description = "Configuration for the combat level plugin"
+)
+
+
+public interface CombatLevelConfig extends Config
+{
+	@ConfigItem(
+			keyName = "factorPrayerLevel",
+			name = "Includes Prayer Level",
+			description = "Configures whether or not to factor in Prayer level for the combat level calculation"
+	)
+	default boolean includePrayerLevel()
+	{
+		return true;
+	}
+
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/combatlevel/CombatLevelPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/combatlevel/CombatLevelPlugin.java
@@ -27,6 +27,7 @@ package net.runelite.client.plugins.combatlevel;
 import com.google.common.eventbus.Subscribe;
 import java.text.DecimalFormat;
 import javax.inject.Inject;
+import com.google.inject.Provides;
 import net.runelite.api.Client;
 import net.runelite.api.Experience;
 import net.runelite.api.GameState;
@@ -34,6 +35,7 @@ import net.runelite.api.Skill;
 import net.runelite.api.events.GameTick;
 import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetInfo;
+import net.runelite.client.config.ConfigManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 
@@ -46,6 +48,15 @@ public class CombatLevelPlugin extends Plugin
 
 	@Inject
 	Client client;
+
+	@Inject
+	private CombatLevelConfig config;
+
+	@Provides
+	CombatLevelConfig getConfig(ConfigManager configManager)
+	{
+		return configManager.getConfig(CombatLevelConfig.class);
+	}
 
 	@Override
 	protected void shutDown() throws Exception
@@ -76,17 +87,32 @@ public class CombatLevelPlugin extends Plugin
 		{
 			return;
 		}
+		if (config.includePrayerLevel())
+		{
+			double combatLevelPrecise = Experience.getCombatLevelPrecise(
+					client.getRealSkillLevel(Skill.ATTACK),
+					client.getRealSkillLevel(Skill.STRENGTH),
+					client.getRealSkillLevel(Skill.DEFENCE),
+					client.getRealSkillLevel(Skill.HITPOINTS),
+					client.getRealSkillLevel(Skill.MAGIC),
+					client.getRealSkillLevel(Skill.RANGED),
+					client.getRealSkillLevel(Skill.PRAYER)
+			);
+			combatLevelWidget.setText("Combat Lvl: " + decimalFormat.format(combatLevelPrecise));
+		}
+		else if (!config.includePrayerLevel())
+		{
+			double combatLevelPreciseNoPrayer = Experience.getCombatLevelPreciseNoPrayer(
+					client.getRealSkillLevel(Skill.ATTACK),
+					client.getRealSkillLevel(Skill.STRENGTH),
+					client.getRealSkillLevel(Skill.DEFENCE),
+					client.getRealSkillLevel(Skill.HITPOINTS),
+					client.getRealSkillLevel(Skill.MAGIC),
+					client.getRealSkillLevel(Skill.RANGED)
+			);
+			combatLevelWidget.setText("Combat Lvl: " + decimalFormat.format(combatLevelPreciseNoPrayer));
+		}
 
-		double combatLevelPrecise = Experience.getCombatLevelPrecise(
-				client.getRealSkillLevel(Skill.ATTACK),
-				client.getRealSkillLevel(Skill.STRENGTH),
-				client.getRealSkillLevel(Skill.DEFENCE),
-				client.getRealSkillLevel(Skill.HITPOINTS),
-				client.getRealSkillLevel(Skill.MAGIC),
-				client.getRealSkillLevel(Skill.RANGED),
-				client.getRealSkillLevel(Skill.PRAYER)
-		);
 
-		combatLevelWidget.setText("Combat Lvl: " + decimalFormat.format(combatLevelPrecise));
 	}
 }


### PR DESCRIPTION
A user requested this feature, and then they removed their account so I can't attach this to an issue at the moment. It simply excludes prayer level from the base combat level calculation.