### PR TITLE
Infobox use panel component

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenmarkers/ScreenMarkerRenderable.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenmarkers/ScreenMarkerRenderable.java
@@ -27,6 +27,7 @@ package net.runelite.client.plugins.screenmarkers;
 import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Graphics2D;
+import java.awt.Point;
 import java.awt.Stroke;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -36,6 +37,10 @@ import net.runelite.client.ui.overlay.components.LayoutableRenderableEntity;
 public class ScreenMarkerRenderable implements LayoutableRenderableEntity
 {
 	@Getter(AccessLevel.PACKAGE)
+	@Setter
+	private Point preferredLocation;
+	@Getter(AccessLevel.PACKAGE)
+	@Setter
 	private Dimension preferredSize;
 	@Getter(AccessLevel.PACKAGE)
 	@Setter(AccessLevel.PACKAGE)
@@ -68,11 +73,5 @@ public class ScreenMarkerRenderable implements LayoutableRenderableEntity
 		graphics.setStroke(stroke);
 		graphics.drawRect(offset, offset, width - thickness, height - thickness);
 		return preferredSize;
-	}
-
-	@Override
-	public void setPreferredSize(Dimension preferredSize)
-	{
-		this.preferredSize = preferredSize;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesOverlay.java
@@ -231,7 +231,7 @@ public class XpGlobesOverlay extends Overlay
 		String skillCurrentXp = decimalFormat.format(mouseOverSkill.getCurrentXp());
 
 		xpTooltip.getChildren().clear();
-		graphics.translate(x, y);
+		xpTooltip.setPreferredLocation(new java.awt.Point(x, y));
 		xpTooltip.setPreferredSize(new Dimension(TOOLTIP_RECT_SIZE_X, 0));
 
 		xpTooltip.getChildren().add(LineComponent.builder()
@@ -280,6 +280,5 @@ public class XpGlobesOverlay extends Overlay
 		}
 
 		xpTooltip.render(graphics);
-		graphics.translate(-x, -y);
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/components/ImageComponent.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/components/ImageComponent.java
@@ -26,15 +26,17 @@ package net.runelite.client.ui.overlay.components;
 
 import java.awt.Dimension;
 import java.awt.Graphics2D;
+import java.awt.Point;
 import java.awt.image.BufferedImage;
-import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 
-@AllArgsConstructor
+@RequiredArgsConstructor
 @Setter
 public class ImageComponent implements LayoutableRenderableEntity
 {
-	private BufferedImage image;
+	private final BufferedImage image;
+	private Point preferredLocation = new Point();
 
 	@Override
 	public Dimension render(Graphics2D graphics)
@@ -44,7 +46,9 @@ public class ImageComponent implements LayoutableRenderableEntity
 			return null;
 		}
 
-		graphics.drawImage(image, 0, -graphics.getFontMetrics().getHeight(), null);
+		graphics.translate(preferredLocation.x, preferredLocation.y);
+		graphics.drawImage(image, 0, 0, null);
+		graphics.translate(-preferredLocation.x, -preferredLocation.y);
 		return new Dimension(image.getWidth(), image.getHeight());
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/components/InfoBoxComponent.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/components/InfoBoxComponent.java
@@ -32,26 +32,34 @@ import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.image.BufferedImage;
 import java.util.Objects;
+import lombok.Getter;
 import lombok.Setter;
-import net.runelite.client.ui.overlay.RenderableEntity;
 
 @Setter
-public class InfoBoxComponent implements RenderableEntity
+public class InfoBoxComponent implements LayoutableRenderableEntity
 {
 	private static final int BOX_SIZE = 35;
 	private static final int SEPARATOR = 2;
 
+	@Getter
+	private String tooltip;
+
+	@Getter
+	private Point preferredLocation = new Point();
+
 	private String text;
 	private Color color = Color.WHITE;
 	private Color backgroundColor = ComponentConstants.STANDARD_BACKGROUND_COLOR;
-	private Point position = new Point();
 	private BufferedImage image;
 
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
+		graphics.translate(preferredLocation.x, preferredLocation.y);
 		final FontMetrics metrics = graphics.getFontMetrics();
-		final Rectangle bounds = new Rectangle(position.x, position.y, BOX_SIZE, BOX_SIZE);
+		final int w = BOX_SIZE;
+		final int h = BOX_SIZE;
+		final Rectangle bounds = new Rectangle(w, h);
 		final BackgroundComponent backgroundComponent = new BackgroundComponent();
 		backgroundComponent.setBackgroundColor(backgroundColor);
 		backgroundComponent.setRectangle(bounds);
@@ -59,18 +67,30 @@ public class InfoBoxComponent implements RenderableEntity
 
 		if (Objects.nonNull(image))
 		{
-			graphics.drawImage(image,
-				position.x + (BOX_SIZE - image.getWidth()) / 2,
-				position.y + (BOX_SIZE - image.getHeight()) / 2, null);
+			graphics.drawImage(
+				image,
+				(w - image.getWidth()) / 2,
+				(h - image.getHeight()) / 2,
+				null);
 		}
 
 		final TextComponent textComponent = new TextComponent();
 		textComponent.setColor(color);
 		textComponent.setText(text);
-		textComponent.setPosition(new Point(
-			position.x + ((BOX_SIZE - metrics.stringWidth(text)) / 2),
-			position.y + BOX_SIZE - SEPARATOR));
+		textComponent.setPosition(new Point(((w - metrics.stringWidth(text)) / 2), h - SEPARATOR));
 		textComponent.render(graphics);
+		graphics.translate(-preferredLocation.x, -preferredLocation.y);
+		return bounds.getSize();
+	}
+
+	public Dimension getPreferredSize()
+	{
 		return new Dimension(BOX_SIZE, BOX_SIZE);
+	}
+
+	@Override
+	public void setPreferredSize(Dimension dimension)
+	{
+		// Just use infobox dimensions for now
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/components/LayoutableRenderableEntity.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/components/LayoutableRenderableEntity.java
@@ -25,9 +25,11 @@
 package net.runelite.client.ui.overlay.components;
 
 import java.awt.Dimension;
+import java.awt.Point;
 import net.runelite.client.ui.overlay.RenderableEntity;
 
 public interface LayoutableRenderableEntity extends RenderableEntity
 {
+	void setPreferredLocation(Point position);
 	void setPreferredSize(Dimension dimension);
 }

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/components/LineComponent.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/components/LineComponent.java
@@ -48,18 +48,22 @@ public class LineComponent implements LayoutableRenderableEntity
 	private Color rightColor = Color.WHITE;
 
 	@Builder.Default
+	private Point preferredLocation = new Point();
+
+	@Builder.Default
 	private Dimension preferredSize = new Dimension(ComponentConstants.STANDARD_WIDTH, 0);
 
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
+		graphics.translate(preferredLocation.x, preferredLocation.y);
 		// Prevent NPEs
 		final String left = MoreObjects.firstNonNull(this.left, "");
 		final String right = MoreObjects.firstNonNull(this.right, "");
 
 		final FontMetrics metrics = graphics.getFontMetrics();
 		int x = 0;
-		int y = 0;
+		int y = metrics.getHeight();
 		final int leftFullWidth = getLineWidth(left, metrics);
 		final int rightFullWidth = getLineWidth(right, metrics);
 
@@ -108,7 +112,8 @@ public class LineComponent implements LayoutableRenderableEntity
 				y += metrics.getHeight();
 			}
 
-			return new Dimension(preferredSize.width, y);
+			graphics.translate(-preferredLocation.x, -preferredLocation.y);
+			return new Dimension(preferredSize.width, y - metrics.getHeight());
 		}
 
 		final TextComponent leftLineComponent = new TextComponent();
@@ -124,7 +129,8 @@ public class LineComponent implements LayoutableRenderableEntity
 		rightLineComponent.render(graphics);
 		y += metrics.getHeight();
 
-		return new Dimension(preferredSize.width, y);
+		graphics.translate(-preferredLocation.x, -preferredLocation.y);
+		return new Dimension(preferredSize.width, y - metrics.getHeight());
 	}
 
 	private static int getLineWidth(final String line, final FontMetrics metrics)

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/components/PanelComponent.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/components/PanelComponent.java
@@ -56,6 +56,9 @@ public class PanelComponent implements LayoutableRenderableEntity
 	private Orientation orientation = Orientation.VERTICAL;
 
 	@Setter
+	private int wrapping = -1;
+
+	@Setter
 	private Rectangle border = new Rectangle(
 		ComponentConstants.STANDARD_BORDER,
 		ComponentConstants.STANDARD_BORDER,
@@ -100,9 +103,14 @@ public class PanelComponent implements LayoutableRenderableEntity
 			preferredSize.width - border.x - border.width,
 			preferredSize.height - border.y - border.height);
 
+		// This is needed to properly calculate total wrapped max w/h
+		int totalHeight = 0;
+		int totalWidth = 0;
+
 		// Render all children
-		for (final LayoutableRenderableEntity child : children)
+		for (int i = 0; i < children.size(); i ++)
 		{
+			final LayoutableRenderableEntity child = children.get(i);
 			child.setPreferredSize(childPreferredSize);
 			graphics.translate(x, y);
 			final Dimension childDimension = child.render(graphics);
@@ -121,14 +129,43 @@ public class PanelComponent implements LayoutableRenderableEntity
 					height = Math.max(height, childDimension.height);
 					break;
 			}
+
+			// Calculate total size
+			totalWidth = Math.max(totalWidth, width);
+			totalHeight = Math.max(totalHeight, height);
+
+			if (wrapping > 0 && i < children.size() - 1 && (i + 1)  % wrapping == 0)
+			{
+				switch (orientation)
+				{
+					case VERTICAL:
+					{
+						height = 0;
+						y = baseY;
+						int diff = childDimension.width + gap.x;
+						x += diff;
+						width += diff;
+						break;
+					}
+					case HORIZONTAL:
+					{
+						width = 0;
+						x = baseX;
+						int diff = childDimension.height + gap.y;
+						y += diff;
+						height += diff;
+						break;
+					}
+				}
+			}
 		}
 
 		// Remove last child gap
-		width -= gap.x;
-		height -= gap.y;
+		totalWidth -= gap.x;
+		totalHeight -= gap.y;
 
 		// Cache children bounds
-		childDimensions.setSize(width, height);
+		childDimensions.setSize(totalWidth, totalHeight);
 
 		return dimension;
 	}

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/components/PanelComponent.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/components/PanelComponent.java
@@ -26,12 +26,12 @@ package net.runelite.client.ui.overlay.components;
 
 import java.awt.Color;
 import java.awt.Dimension;
-import java.awt.FontMetrics;
 import java.awt.Graphics2D;
 import java.awt.Point;
 import java.awt.Rectangle;
 import java.util.ArrayList;
 import java.util.List;
+import javax.annotation.Nullable;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -44,7 +44,11 @@ public class PanelComponent implements LayoutableRenderableEntity
 	}
 
 	@Setter
+	@Nullable
 	private Color backgroundColor = ComponentConstants.STANDARD_BACKGROUND_COLOR;
+
+	@Setter
+	private Point preferredLocation = new Point();
 
 	@Setter
 	private Dimension preferredSize = new Dimension(ComponentConstants.STANDARD_WIDTH, 0);
@@ -78,21 +82,25 @@ public class PanelComponent implements LayoutableRenderableEntity
 			return null;
 		}
 
-		final FontMetrics metrics = graphics.getFontMetrics();
+		graphics.translate(preferredLocation.x, preferredLocation.y);
 
-		// Render background
+		// Calculate panel dimension
 		final Dimension dimension = new Dimension(
 			border.x + childDimensions.width + border.width,
 			border.y + childDimensions.height + border.height);
 
-		final BackgroundComponent backgroundComponent = new BackgroundComponent();
-		backgroundComponent.setRectangle(new Rectangle(dimension));
-		backgroundComponent.setBackgroundColor(backgroundColor);
-		backgroundComponent.render(graphics);
+		// Render background
+		if (backgroundColor != null)
+		{
+			final BackgroundComponent backgroundComponent = new BackgroundComponent();
+			backgroundComponent.setRectangle(new Rectangle(dimension));
+			backgroundComponent.setBackgroundColor(backgroundColor);
+			backgroundComponent.render(graphics);
+		}
 
 		// Offset children
 		final int baseX = border.x;
-		final int baseY = border.y + metrics.getHeight();
+		final int baseY = border.y;
 		int width = 0;
 		int height = 0;
 		int x = baseX;
@@ -111,10 +119,9 @@ public class PanelComponent implements LayoutableRenderableEntity
 		for (int i = 0; i < children.size(); i ++)
 		{
 			final LayoutableRenderableEntity child = children.get(i);
+			child.setPreferredLocation(new Point(x, y));
 			child.setPreferredSize(childPreferredSize);
-			graphics.translate(x, y);
 			final Dimension childDimension = child.render(graphics);
-			graphics.translate(-x, -y);
 
 			switch (orientation)
 			{
@@ -167,6 +174,7 @@ public class PanelComponent implements LayoutableRenderableEntity
 		// Cache children bounds
 		childDimensions.setSize(totalWidth, totalHeight);
 
+		graphics.translate(-preferredLocation.x, -preferredLocation.y);
 		return dimension;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/components/ProgressBarComponent.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/components/ProgressBarComponent.java
@@ -50,15 +50,17 @@ public class ProgressBarComponent implements LayoutableRenderableEntity
 	private Color foregroundColor = new Color(82, 161, 82);
 	private Color backgroundColor = new Color(255, 255, 255, 127);
 	private Color fontColor = Color.WHITE;
+	private Point preferredLocation = new Point();
 	private Dimension preferredSize = new Dimension(ComponentConstants.STANDARD_WIDTH, 16);
 
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
+		graphics.translate(preferredLocation.x, preferredLocation.y);
 		final FontMetrics metrics = graphics.getFontMetrics();
 
 		final int barX = 0;
-		final int barY = -metrics.getHeight();
+		final int barY = 0;
 
 		final long span = maximum - minimum;
 		final double currentValue = value - minimum;
@@ -92,6 +94,7 @@ public class ProgressBarComponent implements LayoutableRenderableEntity
 		textComponent.setText(textToWrite);
 		textComponent.render(graphics);
 
+		graphics.translate(-preferredLocation.x, -preferredLocation.y);
 		return new Dimension(width, height);
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/components/TitleComponent.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/components/TitleComponent.java
@@ -42,17 +42,22 @@ public class TitleComponent implements LayoutableRenderableEntity
 	private Color color = Color.WHITE;
 
 	@Builder.Default
+	private Point preferredLocation = new Point();
+
+	@Builder.Default
 	private Dimension preferredSize = new Dimension(ComponentConstants.STANDARD_WIDTH, 0);
 
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
+		graphics.translate(preferredLocation.x, preferredLocation.y);
 		final FontMetrics metrics = graphics.getFontMetrics();
 		final TextComponent titleComponent = new TextComponent();
 		titleComponent.setText(text);
 		titleComponent.setColor(color);
-		titleComponent.setPosition(new Point((preferredSize.width - metrics.stringWidth(text)) / 2, 0));
+		titleComponent.setPosition(new Point((preferredSize.width - metrics.stringWidth(text)) / 2, metrics.getHeight()));
 		final Dimension dimension = titleComponent.render(graphics);
+		graphics.translate(-preferredLocation.x, -preferredLocation.y);
 		return new Dimension(Math.min(preferredSize.width, dimension.width), dimension.height);
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/infobox/InfoBoxOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/infobox/InfoBoxOverlay.java
@@ -39,130 +39,93 @@ import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.OverlayUtil;
 import net.runelite.client.ui.overlay.components.InfoBoxComponent;
+import net.runelite.client.ui.overlay.components.LayoutableRenderableEntity;
+import net.runelite.client.ui.overlay.components.PanelComponent;
 import net.runelite.client.ui.overlay.tooltip.Tooltip;
 import net.runelite.client.ui.overlay.tooltip.TooltipManager;
 
 public class InfoBoxOverlay extends Overlay
 {
-	private static final int BOXSIZE = 35;
-	private static final int SEPARATOR = 2;
-	private static final int TOTAL_BOXSIZE = BOXSIZE + SEPARATOR;
-
+	private final PanelComponent panelComponent = new PanelComponent();
 	private final InfoBoxManager infoboxManager;
 	private final TooltipManager tooltipManager;
 	private final Provider<Client> clientProvider;
 	private final RuneLiteConfig config;
 
 	@Inject
-	public InfoBoxOverlay(InfoBoxManager infoboxManager, TooltipManager tooltipManager, Provider<Client> clientProvider, RuneLiteConfig config)
+	private InfoBoxOverlay(InfoBoxManager infoboxManager, TooltipManager tooltipManager, Provider<Client> clientProvider, RuneLiteConfig config)
 	{
 		setPosition(OverlayPosition.TOP_LEFT);
 		this.tooltipManager = tooltipManager;
 		this.infoboxManager = infoboxManager;
 		this.clientProvider = clientProvider;
 		this.config = config;
+
+		panelComponent.setBackgroundColor(null);
+		panelComponent.setBorder(new Rectangle());
+		panelComponent.setGap(new Point(2, 2));
 	}
 
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
-		List<InfoBox> infoBoxes = infoboxManager.getInfoBoxes();
+		final List<InfoBox> infoBoxes = infoboxManager.getInfoBoxes();
 
 		if (infoBoxes.isEmpty())
 		{
 			return null;
 		}
 
-		int wrap = config.infoBoxWrap();
-		int infoBoxCount = infoBoxes.size();
-		boolean vertical = config.infoBoxVertical();
+		panelComponent.getChildren().clear();
+		panelComponent.setWrapping(config.infoBoxWrap());
+		panelComponent.setOrientation(config.infoBoxVertical()
+			? PanelComponent.Orientation.VERTICAL
+			: PanelComponent.Orientation.HORIZONTAL);
 
-		int width, height;
-		if (!vertical)
+		infoBoxes.forEach(box ->
 		{
-			width = getWidth(infoBoxCount, wrap);
-			height = getHeight(infoBoxCount, wrap);
-		}
-		else
-		{
-			width = getHeight(infoBoxCount, wrap);
-			height = getWidth(infoBoxCount, wrap);
-		}
-
-		int x = 0;
-		int y = 0;
-
-		for (InfoBox box : infoBoxes)
-		{
-			if (!box.render())
-			{
-				continue;
-			}
-
-
 			final InfoBoxComponent infoBoxComponent = new InfoBoxComponent();
 			infoBoxComponent.setColor(box.getTextColor());
 			infoBoxComponent.setImage(box.getImage());
 			infoBoxComponent.setText(box.getText());
-			infoBoxComponent.setPosition(new Point(x, y));
-			final Dimension infoBoxBounds = infoBoxComponent.render(graphics);
+			infoBoxComponent.setTooltip(box.getTooltip());
+			panelComponent.getChildren().add(infoBoxComponent);
+		});
 
-			if (!Strings.isNullOrEmpty(box.getTooltip()))
+		final Dimension dimension = panelComponent.render(graphics);
+		final Client client = clientProvider.get();
+
+		// Handle tooltips
+		if (client != null)
+		{
+			final Point mouse = new Point(client.getMouseCanvasPosition().getX(), client.getMouseCanvasPosition().getY());
+
+			for (final LayoutableRenderableEntity child : panelComponent.getChildren())
 			{
-				final Rectangle intersectionRectangle = new Rectangle(infoBoxBounds);
-				intersectionRectangle.setLocation(getBounds().getLocation());
-				intersectionRectangle.translate(x, y);
-				final Point transformed = OverlayUtil.transformPosition(getPosition(), intersectionRectangle.getSize());
-				intersectionRectangle.translate(transformed.x, transformed.y);
+				if (child instanceof InfoBoxComponent)
+				{
+					final InfoBoxComponent component = (InfoBoxComponent) child;
 
-				final Client client = clientProvider.get();
+					if (!Strings.isNullOrEmpty(component.getTooltip()))
+					{
+						final Rectangle intersectionRectangle = new Rectangle(component.getPreferredLocation(), component.getPreferredSize());
 
-				if (client != null && intersectionRectangle.contains(new Point(client.getMouseCanvasPosition().getX(),
-					client.getMouseCanvasPosition().getY())))
-				{
-					tooltipManager.add(new Tooltip(box.getTooltip()));
-				}
-			}
+						// Move the intersection based on overlay position
+						intersectionRectangle.translate(getBounds().x, getBounds().y);
 
-			// Determine which axis to reset/increase
-			if (vertical)
-			{
-				// Reset y if newbox reaches height limit
-				if (y + TOTAL_BOXSIZE < height)
-				{
-					y += TOTAL_BOXSIZE;
-				}
-				else
-				{
-					y = 0;
-					x += TOTAL_BOXSIZE;
-				}
-			}
-			else
-			{
-				// Reset x if newbox reaches width limit
-				if (x + TOTAL_BOXSIZE < width)
-				{
-					x += TOTAL_BOXSIZE;
-				}
-				else
-				{
-					x = 0;
-					y += TOTAL_BOXSIZE;
+						// Move the intersection based on overlay "orientation"
+						final Point transformed = OverlayUtil.transformPosition(getPosition(), intersectionRectangle.getSize());
+						intersectionRectangle.translate(transformed.x, transformed.y);
+
+						if (intersectionRectangle.contains(mouse))
+						{
+							tooltipManager.add(new Tooltip(component.getTooltip()));
+						}
+					}
 				}
 			}
 		}
 
-		return new Dimension(width, height);
-	}
-
-	private static int getHeight(int infoBoxCount, int maxRow)
-	{
-		return maxRow == 0 ? TOTAL_BOXSIZE : (int) Math.ceil((double)infoBoxCount / maxRow) * TOTAL_BOXSIZE;
-	}
-
-	private static int getWidth(int infoBoxCount, int maxRow)
-	{
-		return maxRow == 0 ? infoBoxCount * TOTAL_BOXSIZE : (maxRow > infoBoxCount ? infoBoxCount : maxRow) * TOTAL_BOXSIZE;
+		return dimension;
 	}
 }


### PR DESCRIPTION
## Add support for wrapping to PanelComponent

Add support for wrapping at x elements to PanelComponent, depends on
panel component orientation.

## Add support for preferred position to Panel

- Add support for storing preferredPosition in PanelComponent and
translate children based on it.
- Offset children in PanelComponent by metrics.getHeight by default
- Add null check for background in PanelComponent to support panels
without background

## Change InfoBoxOverlay to use PanelComponent

Instead of doing layouting by itself, use PanelComponent and newly added
support for component wrapping and disabling of background.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>

Preview:
![peek 2018-05-13 13-41](https://user-images.githubusercontent.com/5115805/39966918-a490cd7c-56b3-11e8-9808-6b24edc0e2a4.gif)