### PR TITLE
Fix bounds for west bookcases in Kourend Library

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/kourendlibrary/Bookcase.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/kourendlibrary/Bookcase.java
@@ -79,7 +79,7 @@ class Bookcase
 		StringBuilder b = new StringBuilder();
 
 		boolean north = location.getY() > 3815;
-		boolean west = location.getX() < 1625;
+		boolean west = location.getX() < 1627;
 		if (north && west)
 		{
 			b.append("Northwest");


### PR DESCRIPTION
Bookcases on the eastern side of western rooms on the ground floor were classified incorrectly. 