### PR TITLE
Improve ground items

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/ItemComposition.java
+++ b/runelite-api/src/main/java/net/runelite/api/ItemComposition.java
@@ -105,6 +105,13 @@ public interface ItemComposition
 	boolean isStackable();
 
 	/**
+	 * Returns whether or not the item can be traded to other players.
+	 *
+	 * @return true if tradeable, false otherwise
+	 */
+	boolean isTradeable();
+
+	/**
 	 * Gets an array of possible right-click menu actions the item
 	 * has in a player inventory.
 	 *

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItem.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItem.java
@@ -41,6 +41,7 @@ class GroundItem
 	private int height;
 	private int haPrice;
 	private int gePrice;
+	private int offset;
 	private boolean tradeable;
 
 	@Value

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItem.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItem.java
@@ -41,6 +41,7 @@ class GroundItem
 	private int height;
 	private int haPrice;
 	private int gePrice;
+	private boolean tradeable;
 
 	@Value
 	static class GroundItemKey

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemInputListener.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemInputListener.java
@@ -24,22 +24,17 @@
  */
 package net.runelite.client.plugins.grounditems;
 
-import java.awt.Rectangle;
+import java.awt.Point;
 import java.awt.event.KeyEvent;
 import java.awt.event.MouseEvent;
-import java.util.Map;
 import javax.inject.Inject;
-import net.runelite.api.Client;
-import net.runelite.api.Point;
+import javax.swing.SwingUtilities;
 import net.runelite.client.input.KeyListener;
 import net.runelite.client.input.MouseListener;
 
 public class GroundItemInputListener extends MouseListener implements KeyListener
 {
 	private static final int HOTKEY = KeyEvent.VK_ALT;
-
-	@Inject
-	private Client client;
 
 	@Inject
 	private GroundItemsPlugin plugin;
@@ -65,39 +60,51 @@ public class GroundItemInputListener extends MouseListener implements KeyListene
 		if (e.getKeyCode() == HOTKEY)
 		{
 			plugin.setHotKeyPressed(false);
-			plugin.getHighlightBoxes().clear();
-			plugin.getHiddenBoxes().clear();
+			plugin.setTextBoxBounds(null);
+			plugin.setHiddenBoxBounds(null);
+			plugin.setHighlightBoxBounds(null);
 		}
 	}
 
 	@Override
 	public MouseEvent mousePressed(MouseEvent e)
 	{
+		final Point mousePos = e.getPoint();
+
 		if (plugin.isHotKeyPressed())
 		{
-			// Check if left click
-			if (e.getButton() == MouseEvent.BUTTON1)
+			if (SwingUtilities.isLeftMouseButton(e))
 			{
-				Point mousePos = client.getMouseCanvasPosition();
-
-				for (Map.Entry<Rectangle, String> entry : plugin.getHiddenBoxes().entrySet())
+				// Process both click boxes for hidden and highlighted items
+				if (plugin.getHiddenBoxBounds() != null && plugin.getHiddenBoxBounds().getKey().contains(mousePos))
 				{
-					if (entry.getKey().contains(mousePos.getX(), mousePos.getY()))
-					{
-						plugin.updateList(entry.getValue(), true);
-						e.consume();
-						return e;
-					}
+					plugin.updateList(plugin.getHiddenBoxBounds().getValue().getName(), true);
+					e.consume();
+					return e;
 				}
 
-				for (Map.Entry<Rectangle, String> entry : plugin.getHighlightBoxes().entrySet())
+				if (plugin.getHighlightBoxBounds() != null && plugin.getHighlightBoxBounds().getKey().contains(mousePos))
 				{
-					if (entry.getKey().contains(mousePos.getX(), mousePos.getY()))
-					{
-						plugin.updateList(entry.getValue(), false);
-						e.consume();
-						return e;
-					}
+					plugin.updateList(plugin.getHighlightBoxBounds().getValue().getName(), false);
+					e.consume();
+					return e;
+				}
+
+				// There is one name click box for left click and one for right click
+				if (plugin.getTextBoxBounds() != null && plugin.getTextBoxBounds().getKey().contains(mousePos))
+				{
+					plugin.updateList(plugin.getTextBoxBounds().getValue().getName(), false);
+					e.consume();
+					return e;
+				}
+			}
+			else if (SwingUtilities.isRightMouseButton(e))
+			{
+				if (plugin.getTextBoxBounds() != null && plugin.getTextBoxBounds().getKey().contains(mousePos))
+				{
+					plugin.updateList(plugin.getTextBoxBounds().getValue().getName(), true);
+					e.consume();
+					return e;
 				}
 			}
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
@@ -25,13 +25,13 @@
 
 package net.runelite.client.plugins.grounditems;
 
+import java.awt.Color;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
-
-import java.awt.Color;
 import net.runelite.client.plugins.grounditems.config.ItemHighlightMode;
 import net.runelite.client.plugins.grounditems.config.MenuHighlightMode;
+import net.runelite.client.plugins.grounditems.config.PriceDisplayMode;
 
 @ConfigGroup(
 	keyName = "grounditems",
@@ -44,7 +44,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "highlightedItems",
 		name = "Highlighted Items",
 		description = "Configures specifically highlighted ground items. Format: (item), (item)",
-		position = 1
+		position = 0
 	)
 	default String getHighlightItems()
 	{
@@ -62,7 +62,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "hiddenItems",
 		name = "Hidden Items",
 		description = "Configures hidden ground items. Format: (item), (item)",
-		position = 2
+		position = 1
 	)
 	default String getHiddenItems()
 	{
@@ -80,31 +80,9 @@ public interface GroundItemsConfig extends Config
 		keyName = "showHighlightedOnly",
 		name = "Show Highlighted items only",
 		description = "Configures whether or not to draw items only on your highlighted list",
-		position = 3
+		position = 2
 	)
 	default boolean showHighlightedOnly()
-	{
-		return false;
-	}
-
-	@ConfigItem(
-		keyName = "showGEPrice",
-		name = "Show Grand Exchange Prices",
-		description = "Configures whether or not to draw GE prices alongside ground items",
-		position = 4
-	)
-	default boolean showGEPrice()
-	{
-		return true;
-	}
-
-	@ConfigItem(
-		keyName = "showHAValue",
-		name = "Show High Alchemy Values",
-		description = "Configures whether or not to draw High Alchemy values alongside ground items",
-		position = 5
-	)
-	default boolean showHAValue()
 	{
 		return false;
 	}
@@ -113,7 +91,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "showMenuItemQuantities",
 		name = "Show Menu Item Quantities",
 		description = "Configures whether or not to show the item quantities in the menu",
-		position = 6
+		position = 3
 	)
 	default boolean showMenuItemQuantities()
 	{
@@ -121,10 +99,21 @@ public interface GroundItemsConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "priceDisplayMode",
+		name = "Price Display Mode",
+		description = "Configures what price types are shown alongside of ground item name",
+		position = 4
+	)
+	default PriceDisplayMode priceDisplayMode()
+	{
+		return PriceDisplayMode.BOTH;
+	}
+
+	@ConfigItem(
 		keyName = "itemHighlightMode",
 		name = "Item Highlight Mode",
 		description = "Configures how ground items will be highlighted",
-		position = 7
+		position = 5
 	)
 	default ItemHighlightMode itemHighlightMode()
 	{
@@ -135,7 +124,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "menuHighlightMode",
 		name = "Menu Highlight Mode",
 		description = "Configures what to highlight in right-click menu",
-		position = 8
+		position = 6
 	)
 	default MenuHighlightMode menuHighlightMode()
 	{
@@ -146,7 +135,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "hideUnderGeValue",
 		name = "Hide < GE Value",
 		description = "Configures hidden ground items under GE value",
-		position = 9
+		position = 7
 	)
 	default int getHideUnderGeValue()
 	{
@@ -157,7 +146,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "hideUnderHaValue",
 		name = "Hide < HA Value",
 		description = "Configures hidden ground items under High Alch value",
-		position = 10
+		position = 8
 	)
 	default int getHideUnderHAValue()
 	{
@@ -168,7 +157,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "defaultColor",
 		name = "Default items color",
 		description = "Configures the color for default, non-highlighted items",
-		position = 11
+		position = 9
 	)
 	default Color defaultColor()
 	{
@@ -179,7 +168,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "highlightedColor",
 		name = "Highlighted items color",
 		description = "Configures the color for highlighted items",
-		position = 12
+		position = 10
 	)
 	default Color highlightedColor()
 	{
@@ -190,7 +179,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "lowValueColor",
 		name = "Low value items color",
 		description = "Configures the color for low value items",
-		position = 13
+		position = 11
 	)
 	default Color lowValueColor()
 	{
@@ -201,7 +190,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "lowValuePrice",
 		name = "Low value price",
 		description = "Configures the start price for low value items",
-		position = 14
+		position = 12
 	)
 	default int lowValuePrice()
 	{
@@ -212,7 +201,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "mediumValueColor",
 		name = "Medium value items color",
 		description = "Configures the color for medium value items",
-		position = 15
+		position = 13
 	)
 	default Color mediumValueColor()
 	{
@@ -223,7 +212,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "mediumValuePrice",
 		name = "Medium value price",
 		description = "Configures the start price for medium value items",
-		position = 16
+		position = 14
 	)
 	default int mediumValuePrice()
 	{
@@ -234,7 +223,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "highValueColor",
 		name = "High value items color",
 		description = "Configures the color for high value items",
-		position = 17
+		position = 15
 	)
 	default Color highValueColor()
 	{
@@ -245,7 +234,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "highValuePrice",
 		name = "High value price",
 		description = "Configures the start price for high value items",
-		position = 18
+		position = 16
 	)
 	default int highValuePrice()
 	{
@@ -256,7 +245,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "insaneValueColor",
 		name = "Insane value items color",
 		description = "Configures the color for insane value items",
-		position = 19
+		position = 17
 	)
 	default Color insaneValueColor()
 	{
@@ -267,7 +256,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "insaneValuePrice",
 		name = "Insane value price",
 		description = "Configures the start price for insane value items",
-		position = 20
+		position = 18
 	)
 	default int insaneValuePrice()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
@@ -88,10 +88,21 @@ public interface GroundItemsConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "dontHideUntradeables",
+		name = "Do not hide untradeables",
+		description = "Configures whether or not untradeable items ignore hiding under settings",
+		position = 3
+	)
+	default boolean dontHideUntradeables()
+	{
+		return true;
+	}
+
+	@ConfigItem(
 		keyName = "showMenuItemQuantities",
 		name = "Show Menu Item Quantities",
 		description = "Configures whether or not to show the item quantities in the menu",
-		position = 3
+		position = 4
 	)
 	default boolean showMenuItemQuantities()
 	{
@@ -102,7 +113,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "priceDisplayMode",
 		name = "Price Display Mode",
 		description = "Configures what price types are shown alongside of ground item name",
-		position = 4
+		position = 5
 	)
 	default PriceDisplayMode priceDisplayMode()
 	{
@@ -113,7 +124,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "itemHighlightMode",
 		name = "Item Highlight Mode",
 		description = "Configures how ground items will be highlighted",
-		position = 5
+		position = 6
 	)
 	default ItemHighlightMode itemHighlightMode()
 	{
@@ -124,7 +135,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "menuHighlightMode",
 		name = "Menu Highlight Mode",
 		description = "Configures what to highlight in right-click menu",
-		position = 6
+		position = 7
 	)
 	default MenuHighlightMode menuHighlightMode()
 	{
@@ -135,7 +146,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "hideUnderGeValue",
 		name = "Hide < GE Value",
 		description = "Configures hidden ground items under GE value",
-		position = 7
+		position = 8
 	)
 	default int getHideUnderGeValue()
 	{
@@ -146,7 +157,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "hideUnderHaValue",
 		name = "Hide < HA Value",
 		description = "Configures hidden ground items under High Alch value",
-		position = 8
+		position = 9
 	)
 	default int getHideUnderHAValue()
 	{
@@ -157,7 +168,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "defaultColor",
 		name = "Default items color",
 		description = "Configures the color for default, non-highlighted items",
-		position = 9
+		position = 10
 	)
 	default Color defaultColor()
 	{
@@ -168,7 +179,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "highlightedColor",
 		name = "Highlighted items color",
 		description = "Configures the color for highlighted items",
-		position = 10
+		position = 11
 	)
 	default Color highlightedColor()
 	{
@@ -179,7 +190,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "lowValueColor",
 		name = "Low value items color",
 		description = "Configures the color for low value items",
-		position = 11
+		position = 12
 	)
 	default Color lowValueColor()
 	{
@@ -190,7 +201,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "lowValuePrice",
 		name = "Low value price",
 		description = "Configures the start price for low value items",
-		position = 12
+		position = 13
 	)
 	default int lowValuePrice()
 	{
@@ -201,7 +212,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "mediumValueColor",
 		name = "Medium value items color",
 		description = "Configures the color for medium value items",
-		position = 13
+		position = 14
 	)
 	default Color mediumValueColor()
 	{
@@ -212,7 +223,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "mediumValuePrice",
 		name = "Medium value price",
 		description = "Configures the start price for medium value items",
-		position = 14
+		position = 15
 	)
 	default int mediumValuePrice()
 	{
@@ -223,7 +234,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "highValueColor",
 		name = "High value items color",
 		description = "Configures the color for high value items",
-		position = 15
+		position = 16
 	)
 	default Color highValueColor()
 	{
@@ -234,7 +245,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "highValuePrice",
 		name = "High value price",
 		description = "Configures the start price for high value items",
-		position = 16
+		position = 17
 	)
 	default int highValuePrice()
 	{
@@ -245,7 +256,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "insaneValueColor",
 		name = "Insane value items color",
 		description = "Configures the color for insane value items",
-		position = 17
+		position = 18
 	)
 	default Color insaneValueColor()
 	{
@@ -256,7 +267,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "insaneValuePrice",
 		name = "Insane value price",
 		description = "Configures the start price for insane value items",
-		position = 18
+		position = 19
 	)
 	default int insaneValuePrice()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
@@ -143,23 +143,23 @@ public interface GroundItemsConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "hideUnderGeValue",
-		name = "Hide < GE Value",
-		description = "Configures hidden ground items under GE value",
+		keyName = "highlightOverValue",
+		name = "Highlight > Value",
+		description = "Configures highlighted ground items over either GE or HA value",
 		position = 8
 	)
-	default int getHideUnderGeValue()
+	default int getHighlightOverValue()
 	{
-		return 0;
+		return 10000;
 	}
 
 	@ConfigItem(
-		keyName = "hideUnderHaValue",
-		name = "Hide < HA Value",
-		description = "Configures hidden ground items under High Alch value",
+		keyName = "hideUnderValue",
+		name = "Hide < Value",
+		description = "Configures hidden ground items under both GE and HA value",
 		position = 9
 	)
-	default int getHideUnderHAValue()
+	default int getHideUnderValue()
 	{
 		return 0;
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
@@ -138,12 +138,18 @@ public class GroundItemsOverlay extends Overlay
 				item.setGePrice(itemPrice.getPrice() * item.getQuantity());
 			}
 
-			// Do not display items that are under HA or GE price and are not highlighted
-			if (!plugin.isHotKeyPressed() && !highlighted
-				&& ((item.getGePrice() > 0 && item.getGePrice() < config.getHideUnderGeValue())
-				|| item.getHaPrice() < config.getHideUnderHAValue()))
+			if (!plugin.isHotKeyPressed() && !highlighted)
 			{
-				continue;
+				// Check if item is under config threshold
+				final boolean underThreshold = item.getGePrice() < config.getHideUnderGeValue()
+					|| item.getHaPrice() < config.getHideUnderHAValue();
+
+				// If item is under threshold an we are either not always showing untradeables or item is tradeable
+				// do not display item
+				if (underThreshold && (!config.dontHideUntradeables() || item.isTradeable()))
+				{
+					continue;
+				}
 			}
 
 			final Color color = getCostColor(item.getGePrice() > 0 ? item.getGePrice() : item.getHaPrice(),

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
@@ -41,6 +41,7 @@ import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.client.game.ItemManager;
 import static net.runelite.client.plugins.grounditems.config.ItemHighlightMode.MENU;
+import net.runelite.client.plugins.grounditems.config.PriceDisplayMode;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
@@ -163,18 +164,35 @@ public class GroundItemsOverlay extends Overlay
 				}
 			}
 
-			if (config.showGEPrice() && item.getGePrice() > 0)
+			if (config.priceDisplayMode() == PriceDisplayMode.BOTH)
 			{
-				itemStringBuilder.append(" (EX: ")
-					.append(StackFormatter.quantityToStackSize(item.getGePrice()))
-					.append(" gp)");
-			}
+				if (item.getGePrice() > 0)
+				{
+					itemStringBuilder.append(" (EX: ")
+						.append(StackFormatter.quantityToStackSize(item.getGePrice()))
+						.append(" gp)");
+				}
 
-			if (config.showHAValue() && item.getHaPrice() > 0)
+				if (item.getHaPrice() > 0)
+				{
+					itemStringBuilder.append(" (HA: ")
+						.append(StackFormatter.quantityToStackSize(item.getHaPrice()))
+						.append(" gp)");
+				}
+			}
+			else if (config.priceDisplayMode() != PriceDisplayMode.OFF)
 			{
-				itemStringBuilder.append(" (HA: ")
-					.append(StackFormatter.quantityToStackSize(item.getHaPrice()))
-					.append(" gp)");
+				final int price = config.priceDisplayMode() == PriceDisplayMode.GE
+					? item.getGePrice()
+					: item.getHaPrice();
+
+				if (price > 0)
+				{
+					itemStringBuilder
+						.append(" (")
+						.append(StackFormatter.quantityToStackSize(price))
+						.append(" gp)");
+				}
 			}
 
 			final String itemString = itemStringBuilder.toString();

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
@@ -170,24 +170,6 @@ public class GroundItemsOverlay extends Overlay
 				continue;
 			}
 
-			final boolean highlighted = plugin.isHighlighted(item.getName());
-			final boolean hidden = plugin.isHidden(item.getName());
-
-			if (!plugin.isHotKeyPressed())
-			{
-				// Do not display hidden items
-				if (hidden)
-				{
-					continue;
-				}
-
-				// Do not display non-highlighted items when only highlighted items should be shown
-				if (config.showHighlightedOnly() && !highlighted)
-				{
-					continue;
-				}
-			}
-
 			// Update GE price for item
 			final ItemPrice itemPrice = itemManager.getItemPriceAsync(item.getItemId());
 
@@ -196,22 +178,25 @@ public class GroundItemsOverlay extends Overlay
 				item.setGePrice(itemPrice.getPrice() * item.getQuantity());
 			}
 
-			if (!plugin.isHotKeyPressed() && !highlighted)
-			{
-				// Check if item is under config threshold
-				final boolean underThreshold = item.getGePrice() < config.getHideUnderGeValue()
-					|| item.getHaPrice() < config.getHideUnderHAValue();
+			final Color highlighted = plugin.getHighlighted(item.getName(), item.getGePrice(), item.getHaPrice());
+			final Color hidden = plugin.getHidden(item.getName(), item.getGePrice(), item.getHaPrice(), item.isTradeable());
 
-				// If item is under threshold an we are either not always showing untradeables or item is tradeable
-				// do not display item
-				if (underThreshold && (!config.dontHideUntradeables() || item.isTradeable()))
+			if (highlighted == null && !plugin.isHotKeyPressed())
+			{
+				// Do not display hidden items
+				if (hidden != null)
+				{
+					continue;
+				}
+
+				// Do not display non-highlighted items
+				if (config.showHighlightedOnly())
 				{
 					continue;
 				}
 			}
 
-			final Color color = getCostColor(item.getGePrice() > 0 ? item.getGePrice() : item.getHaPrice(),
-				highlighted, hidden);
+			final Color color = plugin.getItemColor(highlighted, hidden);
 			itemStringBuilder.append(item.getName());
 
 			if (item.getQuantity() > 1)
@@ -330,10 +315,10 @@ public class GroundItemsOverlay extends Overlay
 				}
 
 				// Draw hidden box
-				drawRectangle(graphics, itemHiddenBox, topItem && mouseInHiddenBox ? Color.RED : color, hidden, true);
+				drawRectangle(graphics, itemHiddenBox, topItem && mouseInHiddenBox ? Color.RED : color, hidden != null, true);
 
 				// Draw highlight box
-				drawRectangle(graphics, itemHighlightBox, topItem && mouseInHighlightBox ? Color.GREEN : color, highlighted, false);
+				drawRectangle(graphics, itemHighlightBox, topItem && mouseInHighlightBox ? Color.GREEN : color, highlighted != null, false);
 			}
 
 			textComponent.setText(itemString);
@@ -343,42 +328,6 @@ public class GroundItemsOverlay extends Overlay
 		}
 
 		return null;
-	}
-
-	Color getCostColor(int cost, boolean highlighted, boolean hidden)
-	{
-		if (hidden)
-		{
-			return Color.GRAY;
-		}
-
-		if (highlighted)
-		{
-			return config.highlightedColor();
-		}
-
-		// set the color according to rarity, if possible
-		if (cost >= config.insaneValuePrice())
-		{
-			return config.insaneValueColor();
-		}
-
-		if (cost >= config.highValuePrice())
-		{
-			return config.highValueColor();
-		}
-
-		if (cost >= config.mediumValuePrice())
-		{
-			return config.mediumValueColor();
-		}
-
-		if (cost >= config.lowValuePrice())
-		{
-			return config.lowValueColor();
-		}
-
-		return config.defaultColor();
 	}
 
 	private void drawRectangle(Graphics2D graphics, Rectangle rect, Color color, boolean inList, boolean hiddenBox)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
@@ -293,6 +293,7 @@ public class GroundItemsPlugin extends Plugin
 			.quantity(item.getQuantity())
 			.name(itemComposition.getName())
 			.haPrice(alchPrice * item.getQuantity())
+			.tradeable(itemComposition.isTradeable())
 			.build();
 
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
@@ -41,7 +41,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
@@ -107,10 +106,16 @@ public class GroundItemsPlugin extends Plugin
 	private static final int COINS = ItemID.COINS_995;
 
 	@Getter(AccessLevel.PACKAGE)
-	private final Map<Rectangle, String> hiddenBoxes = new ConcurrentHashMap<>();
+	@Setter(AccessLevel.PACKAGE)
+	private Map.Entry<Rectangle, GroundItem> textBoxBounds;
 
 	@Getter(AccessLevel.PACKAGE)
-	private final Map<Rectangle, String> highlightBoxes = new ConcurrentHashMap<>();
+	@Setter(AccessLevel.PACKAGE)
+	private Map.Entry<Rectangle, GroundItem> hiddenBoxBounds;
+
+	@Getter(AccessLevel.PACKAGE)
+	@Setter(AccessLevel.PACKAGE)
+	private Map.Entry<Rectangle, GroundItem> highlightBoxBounds;
 
 	@Getter(AccessLevel.PACKAGE)
 	@Setter(AccessLevel.PACKAGE)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/config/PriceDisplayMode.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/config/PriceDisplayMode.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2018, Tomas Slusny <slusnucky@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.grounditems.config;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum PriceDisplayMode
+{
+	HA("High Alchemy"),
+	GE("Grand Exchange"),
+	BOTH("Both"),
+	OFF("Off");
+
+	private final String name;
+
+	@Override
+	public String toString()
+	{
+		return name;
+	}
+}

--- a/runescape-api/src/main/java/net/runelite/rs/api/RSItemComposition.java
+++ b/runescape-api/src/main/java/net/runelite/rs/api/RSItemComposition.java
@@ -66,6 +66,10 @@ public interface RSItemComposition extends ItemComposition
 	@Override
 	boolean isMembers();
 
+	@Import("isTradable")
+	@Override
+	boolean isTradeable();
+
 	/**
 	 * You probably want {@link #isStackable}
 	 * <p>


### PR DESCRIPTION
## Show GE and HA only when showing both prices

- Change the price displaying to dropdown menu
- Show (GE:, (HA: only when showing both prices at once, otherwise do
not add label at all

## Add option to always draw untradeable items

Instead of checking for GE price being above 0, use isTradeable boolean
to determine if the price checks should apply or not and add
configuration value to disable this behaviour.

## Remove 4th invalid state from ground boxes

Remove the possibility of having the item both highlighted and hidden
when using the highlight/hidden boxes.

## Add full item name clickboxes

- Expand the clickbox for highlighting/hiding item to it's entire name
- Left click on name highlights item, right click hides item
- Highlight background when in highlighting mode of the background item
that is hovered
- In order to help in cluttered environment, bring ground item that is
hovered to front.

These changes makes easy to see what item are you trying to
highlight/hide in cluttered areas.

## Add highlight > value, merge hide < ge and ha

- Add highlight > value setting
- Merge hide < GE and hide < HA value and always check for both
- Change the color getting logic to use simple methods instead of checks
spread around the code

Fixes #1841 
Closes #1731 
Fixes #1563 
See also #1479 
Closes #1074
Closes #2695 
Closes #3415

Previews:
 
![peek 2018-05-03 12-05](https://user-images.githubusercontent.com/5115805/39571214-12ee2e18-4ecb-11e8-95dd-448713bdf2f8.gif)

![screenie](https://user-images.githubusercontent.com/5115805/39593412-f2232906-4f09-11e8-9c8f-ec219ca59790.png)

![screenie1](https://user-images.githubusercontent.com/5115805/39571940-8aa0905c-4ecd-11e8-9563-7a0e2730e597.png)