### PR TITLE
Change TextField to TextArea that can span multiple lines

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
@@ -44,6 +44,7 @@ import java.util.Map;
 import java.util.TreeMap;
 import java.util.concurrent.ScheduledExecutorService;
 import javax.imageio.ImageIO;
+import javax.swing.BorderFactory;
 import javax.swing.ImageIcon;
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
@@ -57,7 +58,7 @@ import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JSpinner;
-import javax.swing.JTextField;
+import javax.swing.JTextArea;
 import javax.swing.SpinnerModel;
 import javax.swing.SpinnerNumberModel;
 import javax.swing.SwingConstants;
@@ -86,7 +87,6 @@ import net.runelite.client.util.SwingUtil;
 @Slf4j
 public class ConfigPanel extends PluginPanel
 {
-	private static final int TEXT_FIELD_WIDTH = 7;
 	private static final int SPINNER_FIELD_WIDTH = 6;
 
 	private static final ImageIcon CONFIG_ICON;
@@ -402,9 +402,9 @@ public class ConfigPanel extends PluginPanel
 			configManager.setConfiguration(cd.getGroup().keyName(), cid.getItem().keyName(), "" + spinner.getValue());
 		}
 
-		if (component instanceof JTextField)
+		if (component instanceof JTextArea)
 		{
-			JTextField textField = (JTextField) component;
+			JTextArea textField = (JTextArea) component;
 			configManager.setConfiguration(cd.getGroup().keyName(), cid.getItem().keyName(), textField.getText());
 		}
 
@@ -426,10 +426,10 @@ public class ConfigPanel extends PluginPanel
 		scrollBarPosition = getScrollPane().getVerticalScrollBar().getValue();
 		removeAll();
 		String name = cd.getGroup().name() + " Configuration";
-		JLabel title = new JLabel(name);
+		JLabel title = new JLabel(name, SwingConstants.CENTER);
 		title.setForeground(Color.WHITE);
 		title.setToolTipText(cd.getGroup().description());
-		add(title, SwingConstants.CENTER);
+		add(title);
 
 		for (ConfigItemDescriptor cid : cd.getItems())
 		{
@@ -472,7 +472,10 @@ public class ConfigPanel extends PluginPanel
 
 			if (cid.getType() == String.class)
 			{
-				JTextField textField = new JTextField("", TEXT_FIELD_WIDTH);
+				JTextArea textField = new JTextArea();
+				textField.setLineWrap(true);
+				textField.setWrapStyleWord(true);
+				textField.setBorder(BorderFactory.createEmptyBorder(5, 5, 5, 5));
 				textField.setText(configManager.getConfiguration(cd.getGroup().keyName(), cid.getItem().keyName()));
 
 				textField.addFocusListener(new FocusAdapter()
@@ -485,14 +488,8 @@ public class ConfigPanel extends PluginPanel
 					}
 				});
 
-				textField.addActionListener(e ->
-				{
-					changeConfiguration(config, textField, cd, cid);
-					textField.setToolTipText(textField.getText());
-				});
-
 				textField.setToolTipText(textField.getText());
-				item.add(textField, BorderLayout.EAST);
+				item.add(textField, BorderLayout.SOUTH);
 			}
 
 			if (cid.getType() == Color.class)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
@@ -41,98 +41,10 @@ import net.runelite.client.plugins.grounditems.config.MenuHighlightMode;
 public interface GroundItemsConfig extends Config
 {
 	@ConfigItem(
-		keyName = "showHighlightedOnly",
-		name = "Show Highlighted items only",
-		description = "Configures whether or not to draw items only on your highlighted list",
-		position = 1
-	)
-	default boolean showHighlightedOnly()
-	{
-		return false;
-	}
-
-	@ConfigItem(
-		keyName = "showGEPrice",
-		name = "Show Grand Exchange Prices",
-		description = "Configures whether or not to draw GE prices alongside ground items",
-		position = 2
-	)
-	default boolean showGEPrice()
-	{
-		return true;
-	}
-
-	@ConfigItem(
-		keyName = "showHAValue",
-		name = "Show High Alchemy Values",
-		description = "Configures whether or not to draw High Alchemy values alongside ground items",
-		position = 3
-	)
-	default boolean showHAValue()
-	{
-		return false;
-	}
-
-	@ConfigItem(
-		keyName = "showMenuItemQuantities",
-		name = "Show Menu Item Quantities",
-		description = "Configures whether or not to show the item quantities in the menu",
-		position = 4
-	)
-	default boolean showMenuItemQuantities()
-	{
-		return true;
-	}
-
-	@ConfigItem(
-		keyName = "itemHighlightMode",
-		name = "Item Highlight Mode",
-		description = "Configures how ground items will be highlighted",
-		position = 5
-	)
-	default ItemHighlightMode itemHighlightMode()
-	{
-		return ItemHighlightMode.BOTH;
-	}
-
-	@ConfigItem(
-		keyName = "menuHighlightMode",
-		name = "Menu Highlight Mode",
-		description = "Configures what to highlight in right-click menu",
-		position = 6
-	)
-	default MenuHighlightMode menuHighlightMode()
-	{
-		return MenuHighlightMode.NAME;
-	}
-
-	@ConfigItem(
-		keyName = "hideUnderGeValue",
-		name = "Hide < GE Value",
-		description = "Configures hidden ground items under GE value",
-		position = 7
-	)
-	default int getHideUnderGeValue()
-	{
-		return 0;
-	}
-
-	@ConfigItem(
-		keyName = "hideUnderHaValue",
-		name = "Hide < HA Value",
-		description = "Configures hidden ground items under High Alch value",
-		position = 8
-	)
-	default int getHideUnderHAValue()
-	{
-		return 0;
-	}
-
-	@ConfigItem(
 		keyName = "highlightedItems",
 		name = "Highlighted Items",
 		description = "Configures specifically highlighted ground items. Format: (item), (item)",
-		position = 9
+		position = 1
 	)
 	default String getHighlightItems()
 	{
@@ -150,7 +62,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "hiddenItems",
 		name = "Hidden Items",
 		description = "Configures hidden ground items. Format: (item), (item)",
-		position = 10
+		position = 2
 	)
 	default String getHiddenItems()
 	{
@@ -163,6 +75,94 @@ public interface GroundItemsConfig extends Config
 		description = ""
 	)
 	void setHiddenItems(String key);
+
+	@ConfigItem(
+		keyName = "showHighlightedOnly",
+		name = "Show Highlighted items only",
+		description = "Configures whether or not to draw items only on your highlighted list",
+		position = 3
+	)
+	default boolean showHighlightedOnly()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		keyName = "showGEPrice",
+		name = "Show Grand Exchange Prices",
+		description = "Configures whether or not to draw GE prices alongside ground items",
+		position = 4
+	)
+	default boolean showGEPrice()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		keyName = "showHAValue",
+		name = "Show High Alchemy Values",
+		description = "Configures whether or not to draw High Alchemy values alongside ground items",
+		position = 5
+	)
+	default boolean showHAValue()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		keyName = "showMenuItemQuantities",
+		name = "Show Menu Item Quantities",
+		description = "Configures whether or not to show the item quantities in the menu",
+		position = 6
+	)
+	default boolean showMenuItemQuantities()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		keyName = "itemHighlightMode",
+		name = "Item Highlight Mode",
+		description = "Configures how ground items will be highlighted",
+		position = 7
+	)
+	default ItemHighlightMode itemHighlightMode()
+	{
+		return ItemHighlightMode.BOTH;
+	}
+
+	@ConfigItem(
+		keyName = "menuHighlightMode",
+		name = "Menu Highlight Mode",
+		description = "Configures what to highlight in right-click menu",
+		position = 8
+	)
+	default MenuHighlightMode menuHighlightMode()
+	{
+		return MenuHighlightMode.NAME;
+	}
+
+	@ConfigItem(
+		keyName = "hideUnderGeValue",
+		name = "Hide < GE Value",
+		description = "Configures hidden ground items under GE value",
+		position = 9
+	)
+	default int getHideUnderGeValue()
+	{
+		return 0;
+	}
+
+	@ConfigItem(
+		keyName = "hideUnderHaValue",
+		name = "Hide < HA Value",
+		description = "Configures hidden ground items under High Alch value",
+		position = 10
+	)
+	default int getHideUnderHAValue()
+	{
+		return 0;
+	}
 
 	@ConfigItem(
 		keyName = "defaultColor",

--- a/runelite-client/src/main/java/net/runelite/client/ui/PluginPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/PluginPanel.java
@@ -26,7 +26,6 @@ package net.runelite.client.ui;
 
 import java.awt.BorderLayout;
 import java.awt.Dimension;
-import java.awt.GridLayout;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.ScrollPaneConstants;
@@ -59,7 +58,7 @@ public abstract class PluginPanel extends JPanel
 		if (wrap)
 		{
 			setBorder(BORDER_PADDING);
-			setLayout(new GridLayout(0, 1, 0, 3));
+			setLayout(new DynamicGridLayout(0, 1, 0, 3));
 			setBackground(ColorScheme.DARK_GRAY_COLOR);
 
 			final JPanel northPanel = new JPanel();


### PR DESCRIPTION
- Add layout manager that supports grid of components with variable sizes.
- For better readability of text configurations, change TextField to
TextArea that can span multiple lines.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>

Preview:
![peek 2018-05-12 12-26](https://user-images.githubusercontent.com/5115805/39956582-f58c8ffc-55e3-11e8-8d88-da86273d6230.gif)