### PR TITLE
Add support for launcher version

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/RuneLite.java
+++ b/runelite-client/src/main/java/net/runelite/client/RuneLite.java
@@ -40,6 +40,7 @@ import joptsimple.ArgumentAcceptingOptionSpec;
 import joptsimple.OptionParser;
 import joptsimple.OptionSet;
 import joptsimple.util.EnumConverter;
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.client.account.SessionManager;
@@ -68,7 +69,10 @@ public class RuneLite
 	private static final File LOGS_DIR = new File(RUNELITE_DIR, "logs");
 	private static final File LOGS_FILE_NAME = new File(LOGS_DIR, "application");
 
+	@Getter
 	private static Injector injector;
+
+	@Getter
 	private static OptionSet options;
 
 	@Inject
@@ -122,10 +126,12 @@ public class RuneLite
 	{
 		Locale.setDefault(Locale.ENGLISH);
 
-		OptionParser parser = new OptionParser();
+		final OptionParser parser = new OptionParser();
 		parser.accepts("developer-mode", "Enable developer tools");
 		parser.accepts("debug", "Show extra debugging output");
-		ArgumentAcceptingOptionSpec<UpdateCheckMode> updateMode = parser.accepts("rs", "Select client type")
+
+		final ArgumentAcceptingOptionSpec<UpdateCheckMode> updateMode = parser
+			.accepts("rs", "Select client type")
 			.withRequiredArg()
 			.ofType(UpdateCheckMode.class)
 			.defaultsTo(UpdateCheckMode.AUTO)
@@ -137,8 +143,9 @@ public class RuneLite
 					return super.convert(v.toUpperCase());
 				}
 			});
+
 		parser.accepts("help", "Show this text").forHelp();
-		setOptions(parser.parse(args));
+		options = parser.parse(args);
 
 		if (getOptions().has("help"))
 		{
@@ -176,7 +183,7 @@ public class RuneLite
 			}
 		});
 
-		setInjector(Guice.createInjector(new RuneLiteModule()));
+		injector = Guice.createInjector(new RuneLiteModule());
 		injector.getInstance(RuneLite.class).start(getOptions().valueOf(updateMode));
 	}
 
@@ -207,6 +214,7 @@ public class RuneLite
 		eventBus.register(commandManager);
 		eventBus.register(pluginManager);
 		eventBus.register(clanManager);
+
 		if (this.client != null)
 		{
 			eventBus.register(itemManager.get());
@@ -249,28 +257,20 @@ public class RuneLite
 	}
 
 	@VisibleForTesting
-	public void setClient(Client client)
-	{
-		this.client = client;
-	}
-
-	public static Injector getInjector()
-	{
-		return injector;
-	}
-
 	public static void setInjector(Injector injector)
 	{
 		RuneLite.injector = injector;
 	}
 
-	public static OptionSet getOptions()
-	{
-		return options;
-	}
-
+	@VisibleForTesting
 	public static void setOptions(OptionSet options)
 	{
 		RuneLite.options = options;
+	}
+
+	@VisibleForTesting
+	public void setClient(Client client)
+	{
+		this.client = client;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/RuneLiteProperties.java
+++ b/runelite-client/src/main/java/net/runelite/client/RuneLiteProperties.java
@@ -27,10 +27,9 @@ package net.runelite.client;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Properties;
-import lombok.extern.slf4j.Slf4j;
-
 import javax.inject.Inject;
 import javax.inject.Singleton;
+import lombok.extern.slf4j.Slf4j;
 
 @Singleton
 @Slf4j
@@ -43,13 +42,15 @@ public class RuneLiteProperties
 	private static final String DISCORD_INVITE = "runelite.discord.invite";
 	private static final String GITHUB_LINK = "runelite.github.link";
 	private static final String PATREON_LINK = "runelite.patreon.link";
+	private static final String LAUNCHER_VERSION_PROPERTY = "runelite.launcher.version";
 
 	private final Properties properties = new Properties();
 
 	@Inject
 	public RuneLiteProperties()
 	{
-		InputStream in = getClass().getResourceAsStream("runelite.properties");
+		final InputStream in = getClass().getResourceAsStream("runelite.properties");
+
 		try
 		{
 			properties.load(in);
@@ -93,5 +94,10 @@ public class RuneLiteProperties
 	public String getPatreonLink()
 	{
 		return properties.getProperty(PATREON_LINK);
+	}
+
+	public String getLauncherVersion()
+	{
+		return System.getProperty(LAUNCHER_VERSION_PROPERTY);
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/info/InfoPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/info/InfoPanel.java
@@ -25,6 +25,7 @@
  */
 package net.runelite.client.plugins.info;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
 import com.google.inject.Inject;
@@ -133,6 +134,10 @@ public class InfoPanel extends PluginPanel
 
 		revision.setText(htmlLabel("Oldschool revision: ", engineVer));
 
+		JLabel launcher = new JLabel(htmlLabel("Launcher version: ", MoreObjects
+			.firstNonNull(runeLiteProperties.getLauncherVersion(), "Unknown")));
+		launcher.setFont(smallFont);
+
 		loggedLabel.setForeground(ColorScheme.LIGHT_GRAY_COLOR);
 		loggedLabel.setFont(smallFont);
 
@@ -152,6 +157,7 @@ public class InfoPanel extends PluginPanel
 
 		versionPanel.add(version);
 		versionPanel.add(revision);
+		versionPanel.add(launcher);
 		versionPanel.add(Box.createGlue());
 		versionPanel.add(loggedLabel);
 		versionPanel.add(emailLabel);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/info/InfoPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/info/InfoPanel.java
@@ -129,7 +129,7 @@ public class InfoPanel extends PluginPanel
 		String engineVer = "Unknown";
 		if (client != null)
 		{
-			engineVer = String.format("Rev %s", runeLiteProperties.getRunescapeVersion());
+			engineVer = String.format("Rev %d", client.getRevision());
 		}
 
 		revision.setText(htmlLabel("Oldschool revision: ", engineVer));


### PR DESCRIPTION
## Cleanup RuneLite class (use Lombok)

- Use Lombok for creating setters and getters for variables in RuneLite
- Use correct spacing and final modifiers

## Show RuneLite launcher version in info panel

- Propagate RuneLite launcher version to client via system property and
add this property to RuneLite properties file.
- Show this version in info panel

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>

This also requires changes in https://github.com/runelite/launcher to propagate this system property.

Preview:
![screenie](https://user-images.githubusercontent.com/5115805/40578314-2f86e69c-6112-11e8-9840-35af00623230.png)