### PR TITLE
Clue Scroll Plugin: Add wording to direct users to world map

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java
@@ -54,7 +54,7 @@ public class CoordinateClue extends ClueScroll implements TextClueScroll, Locati
 		panelComponent.getChildren().add(TitleComponent.builder().text("Coordinate Clue").build());
 
 		panelComponent.getChildren().add(LineComponent.builder()
-			.left("Travel to the marked out destination to see a marker for where you should dig.")
+			.left("Click the clue scroll along the edge of your world map to see where you should dig.")
 			.build());
 
 		if (plugin.getEquippedItems() != null)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/MapClue.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/MapClue.java
@@ -108,6 +108,10 @@ public class MapClue extends ClueScroll implements ObjectClueScroll
 	{
 		panelComponent.getChildren().add(TitleComponent.builder().text("Map Clue").build());
 
+		panelComponent.getChildren().add(LineComponent.builder()
+				.left("Click the clue scroll along the edge of your world map to see your destination.")
+				.build());
+
 		if (objectId != -1)
 		{
 			ObjectComposition objectToClick = plugin.getClient().getObjectDefinition(getObjectId());


### PR DESCRIPTION
People have been confused by how the clue scroll overlay works on the world map.
This PR updates the text on Map and Coordinate clues to be more clear on how the overlay functions.