### PR TITLE
Unify Highlight and Tag colors for NPC indicators, cleanup code

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcClickboxOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcClickboxOverlay.java
@@ -60,7 +60,7 @@ public class NpcClickboxOverlay extends Overlay
 	{
 		for (NPC npc : plugin.getHighlightedNpcs())
 		{
-			renderNpcOverlay(graphics, npc, npc.getName(), config.getNpcColor());
+			renderNpcOverlay(graphics, npc, npc.getName(), config.getHighlightColor());
 		}
 
 		NPC[] npcs = client.getCachedNPCs();
@@ -69,7 +69,7 @@ public class NpcClickboxOverlay extends Overlay
 			NPC npc = npcs[npcId];
 			if (npc != null && npc.getName() != null)
 			{
-				renderNpcOverlay(graphics, npc, npc.getName(), config.getTagColor());
+				renderNpcOverlay(graphics, npc, npc.getName(), config.getHighlightColor());
 			}
 		}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcClickboxOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcClickboxOverlay.java
@@ -63,16 +63,6 @@ public class NpcClickboxOverlay extends Overlay
 			renderNpcOverlay(graphics, npc, npc.getName(), config.getHighlightColor());
 		}
 
-		NPC[] npcs = client.getCachedNPCs();
-		for (int npcId : plugin.getNpcTags())
-		{
-			NPC npc = npcs[npcId];
-			if (npc != null && npc.getName() != null)
-			{
-				renderNpcOverlay(graphics, npc, npc.getName(), config.getHighlightColor());
-			}
-		}
-
 		return null;
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsConfig.java
@@ -64,7 +64,7 @@ public interface NpcIndicatorsConfig extends Config
 		name = "Highlight Color",
 		description = "Color of the NPC highlight"
 	)
-	default Color getNpcColor()
+	default Color getHighlightColor()
 	{
 		return Color.CYAN;
 	}
@@ -82,17 +82,6 @@ public interface NpcIndicatorsConfig extends Config
 
 	@ConfigItem(
 		position = 4,
-		keyName = "tagColor",
-		name = "Tag Color",
-		description = "Color of the NPC tag highlight"
-	)
-	default Color getTagColor()
-	{
-		return Color.CYAN;
-	}
-
-	@ConfigItem(
-		position = 5,
 		keyName = "drawNames",
 		name = "Draw names above NPC",
 		description = "Configures whether or not NPC names should be drawn above the NPC"
@@ -103,7 +92,7 @@ public interface NpcIndicatorsConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 6,
+		position = 5,
 		keyName = "drawMinimapNames",
 		name = "Draw names on minimap",
 		description = "Configures whether or not NPC names should be drawn on the minimap"

--- a/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsPlugin.java
@@ -25,6 +25,7 @@
  */
 package net.runelite.client.plugins.npchighlight;
 
+import com.google.common.base.Splitter;
 import com.google.common.eventbus.Subscribe;
 import com.google.inject.Provides;
 import java.util.ArrayList;
@@ -34,6 +35,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.regex.Pattern;
 import javax.inject.Inject;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -59,7 +61,7 @@ public class NpcIndicatorsPlugin extends Plugin
 	private static final String TAG = "Tag";
 
 	// Regex for splitting the hidden items in the config.
-	private static final String DELIMITER_REGEX = "\\s*,\\s*";
+	private static final Splitter COMMA_SPLITTER = Splitter.on(Pattern.compile("\\s*,\\s*")).trimResults();
 
 	@Inject
 	private Client client;
@@ -83,13 +85,7 @@ public class NpcIndicatorsPlugin extends Plugin
 	private KeyManager keyManager;
 
 	/**
-	 * NPCs tagged with the Tag option
-	 */
-	@Getter(AccessLevel.PACKAGE)
-	private final Set<Integer> npcTags = new HashSet<>();
-
-	/**
-	 * NPCs tagged due to highlight in the config
+	 * NPCs to highlight
 	 */
 	@Getter(AccessLevel.PACKAGE)
 	private final Set<NPC> highlightedNpcs = new HashSet<>();
@@ -99,14 +95,12 @@ public class NpcIndicatorsPlugin extends Plugin
 	 */
 	private List<String> highlights = new ArrayList<>();
 
-	private boolean hotKeyPressed = false;
+	/**
+	 * NPC ids marked with the Tag option
+	 */
+	private final Set<Integer> npcTags = new HashSet<>();
 
-	private void toggleTag(int npcId)
-	{
-		boolean removed = npcTags.remove(npcId);
-		if (!removed)
-			npcTags.add(npcId);
-	}
+	private boolean hotKeyPressed = false;
 
 	@Provides
 	NpcIndicatorsConfig provideConfig(ConfigManager configManager)
@@ -144,12 +138,14 @@ public class NpcIndicatorsPlugin extends Plugin
 
 	private List<String> getHighlights()
 	{
-		String configNpcs = config.getNpcToHighlight().toLowerCase();
-		if (configNpcs.isEmpty())
-			return Collections.emptyList();
+		final String configNpcs = config.getNpcToHighlight().toLowerCase();
 
-		List<String> highlightedNpcs = Arrays.asList(configNpcs.split(DELIMITER_REGEX));
-		return highlightedNpcs;
+		if (configNpcs.isEmpty())
+		{
+			return Collections.emptyList();
+		}
+
+		return COMMA_SPLITTER.splitToList(configNpcs);
 	}
 
 	/**
@@ -165,6 +161,12 @@ public class NpcIndicatorsPlugin extends Plugin
 
 			if (npcName == null)
 			{
+				continue;
+			}
+
+			if (npcTags.contains(npc.getIndex()))
+			{
+				highlightedNpcs.add(npc);
 				continue;
 			}
 
@@ -193,16 +195,41 @@ public class NpcIndicatorsPlugin extends Plugin
 	public void onMenuObjectClicked(MenuOptionClicked click)
 	{
 		if (click.getMenuOption().equals(TAG))
-			toggleTag(click.getId());
+		{
+			final int id = click.getId();
+			final boolean removed = npcTags.remove(id);
+			final NPC[] cachedNPCs = client.getCachedNPCs();
+			final NPC npc = cachedNPCs[id];
+
+			if (npc != null && npc.getName() != null)
+			{
+				if (removed)
+				{
+					highlightedNpcs.remove(npc);
+				}
+				else
+				{
+					npcTags.add(id);
+					highlightedNpcs.add(npc);
+				}
+			}
+		}
 	}
 
 	@Subscribe
 	public void onNpcSpawned(NpcSpawned npcSpawned)
 	{
-		NPC npc = npcSpawned.getNpc();
-		String npcName = npc.getName();
+		final NPC npc = npcSpawned.getNpc();
+		final String npcName = npc.getName();
+
 		if (npcName != null)
 		{
+			if (npcTags.contains(npc.getIndex()))
+			{
+				highlightedNpcs.add(npc);
+				return;
+			}
+
 			for (String highlight : highlights)
 			{
 				if (WildcardMatcher.matches(highlight, npcName))
@@ -217,8 +244,7 @@ public class NpcIndicatorsPlugin extends Plugin
 	@Subscribe
 	public void onNpcDespawned(NpcDespawned npcDespawned)
 	{
-		NPC npc = npcDespawned.getNpc();
-		highlightedNpcs.remove(npc);
+		highlightedNpcs.remove(npcDespawned.getNpc());
 	}
 
 	@Override

--- a/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsPlugin.java
@@ -113,7 +113,7 @@ public class NpcIndicatorsPlugin extends Plugin
 	{
 		keyManager.registerKeyListener(inputListener);
 		highlights = getHighlights();
-		rebuildNpcs();
+		rebuildAllNpcs();
 	}
 
 	@Override
@@ -133,52 +133,7 @@ public class NpcIndicatorsPlugin extends Plugin
 		}
 
 		highlights = getHighlights();
-		rebuildNpcs();
-	}
-
-	private List<String> getHighlights()
-	{
-		final String configNpcs = config.getNpcToHighlight().toLowerCase();
-
-		if (configNpcs.isEmpty())
-		{
-			return Collections.emptyList();
-		}
-
-		return COMMA_SPLITTER.splitToList(configNpcs);
-	}
-
-	/**
-	 * Rebuild highlighted npcs
-	 */
-	private void rebuildNpcs()
-	{
-		highlightedNpcs.clear();
-
-		for (NPC npc : client.getNpcs())
-		{
-			String npcName = npc.getName();
-
-			if (npcName == null)
-			{
-				continue;
-			}
-
-			if (npcTags.contains(npc.getIndex()))
-			{
-				highlightedNpcs.add(npc);
-				continue;
-			}
-
-			for (String highlight : highlights)
-			{
-				if (WildcardMatcher.matches(highlight, npcName))
-				{
-					highlightedNpcs.add(npc);
-					break;
-				}
-			}
-		}
+		rebuildAllNpcs();
 	}
 
 	@Subscribe
@@ -271,4 +226,47 @@ public class NpcIndicatorsPlugin extends Plugin
 
 		hotKeyPressed = pressed;
 	}
+
+	private List<String> getHighlights()
+	{
+		final String configNpcs = config.getNpcToHighlight().toLowerCase();
+
+		if (configNpcs.isEmpty())
+		{
+			return Collections.emptyList();
+		}
+
+		return COMMA_SPLITTER.splitToList(configNpcs);
+	}
+
+	private void rebuildAllNpcs()
+	{
+		highlightedNpcs.clear();
+
+		for (NPC npc : client.getNpcs())
+		{
+			String npcName = npc.getName();
+
+			if (npcName == null)
+			{
+				continue;
+			}
+
+			if (npcTags.contains(npc.getIndex()))
+			{
+				highlightedNpcs.add(npc);
+				continue;
+			}
+
+			for (String highlight : highlights)
+			{
+				if (WildcardMatcher.matches(highlight, npcName))
+				{
+					highlightedNpcs.add(npc);
+					break;
+				}
+			}
+		}
+	}
+
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcMinimapOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcMinimapOverlay.java
@@ -58,7 +58,7 @@ public class NpcMinimapOverlay extends Overlay
 	{
 		for (NPC npc : plugin.getHighlightedNpcs())
 		{
-			renderNpcOverlay(graphics, npc, npc.getName(), config.getNpcColor());
+			renderNpcOverlay(graphics, npc, npc.getName(), config.getHighlightColor());
 		}
 
 		NPC[] npcs = client.getCachedNPCs();
@@ -67,7 +67,7 @@ public class NpcMinimapOverlay extends Overlay
 			NPC npc = npcs[npcId];
 			if (npc != null && npc.getName() != null)
 			{
-				renderNpcOverlay(graphics, npc, npc.getName(), config.getTagColor());
+				renderNpcOverlay(graphics, npc, npc.getName(), config.getHighlightColor());
 			}
 		}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcMinimapOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcMinimapOverlay.java
@@ -61,16 +61,6 @@ public class NpcMinimapOverlay extends Overlay
 			renderNpcOverlay(graphics, npc, npc.getName(), config.getHighlightColor());
 		}
 
-		NPC[] npcs = client.getCachedNPCs();
-		for (int npcId : plugin.getNpcTags())
-		{
-			NPC npc = npcs[npcId];
-			if (npc != null && npc.getName() != null)
-			{
-				renderNpcOverlay(graphics, npc, npc.getName(), config.getHighlightColor());
-			}
-		}
-
 		return null;
 	}
 


### PR DESCRIPTION
- Unify the logic and coloring of NPC tagging and highlighting
- Merge highlightedNpcs and npc tags to one list
- Compare npc index with list of tags on NPC spawn and add to
highlighted NPCs list instead of getting NPC from client.getCachedNPCs
- Add brackets to single line ifs, remove redundant code
- Cleanup code

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>