### PR TITLE
 Slayer Plugin: use varbit for retrieving slayer reward points

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/Varbits.java
+++ b/runelite-api/src/main/java/net/runelite/api/Varbits.java
@@ -358,7 +358,12 @@ public enum Varbits
 	/**
 	 * The varbit that stores the players {@code AccountType}.
 	 */
-	ACCOUNT_TYPE(1777);
+	ACCOUNT_TYPE(1777),
+
+	/**
+	 * Varbit used for Slayer reward points
+	 */
+	SLAYER_REWARD_POINTS(4068);
 
 	/**
 	 * The raw varbit ID.

--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerConfig.java
@@ -159,24 +159,6 @@ public interface SlayerConfig extends Config
 	void streak(int streak);
 
 	@ConfigItem(
-		keyName = "points",
-		name = "",
-		description = "",
-		hidden = true
-	)
-	default int points()
-	{
-		return -1;
-	}
-
-	@ConfigItem(
-		keyName = "points",
-		name = "",
-		description = ""
-	)
-	void points(int points);
-
-	@ConfigItem(
 		keyName = "expeditious",
 		name = "",
 		description = "",

--- a/runelite-client/src/test/java/net/runelite/client/plugins/slayer/SlayerPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/slayer/SlayerPluginTest.java
@@ -30,8 +30,10 @@ import com.google.inject.testing.fieldbinder.BoundFieldModule;
 import javax.inject.Inject;
 import static net.runelite.api.ChatMessageType.SERVER;
 import net.runelite.api.Client;
+import net.runelite.api.Varbits;
 import net.runelite.api.events.ChatMessage;
 import net.runelite.api.events.GameTick;
+import net.runelite.api.events.VarbitChanged;
 import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.Notifier;
@@ -178,8 +180,12 @@ public class SlayerPluginTest
 	@Test
 	public void testPoints()
 	{
+		when(client.getVar(Varbits.SLAYER_REWARD_POINTS)).thenReturn(18_000);
+
 		ChatMessage chatMessageEvent = new ChatMessage(SERVER, "Perterter", TASK_POINTS, null);
 		slayerPlugin.onChatMessage(chatMessageEvent);
+		VarbitChanged varbitChanged = new VarbitChanged();
+		slayerPlugin.onVarbitChanged(varbitChanged);
 
 		assertEquals(9, slayerPlugin.getStreak());
 		assertEquals("", slayerPlugin.getTaskName());


### PR DESCRIPTION
Currently slayer plugin uses widgets to retrieve the slayer reward points, this PR makes that process utilise varbits. The updateTick variable method isn't nice, but it's the easiest way for me to delay the update process by just enough to give varbits enough time to initialize, I'm up for any suggestions how make it nicer.