### PR TITLE
Add Tree indicator

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/Axe.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/Axe.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Seth <Sethtroll3@gmail.com>
+ * Copyright (c) 2018, Mantautas Jurksa <https://github.com/Juzzed>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -22,60 +22,56 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+
 package net.runelite.client.plugins.woodcutting;
 
-import net.runelite.client.config.Config;
-import net.runelite.client.config.ConfigGroup;
-import net.runelite.client.config.ConfigItem;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import static net.runelite.api.AnimationID.*;
+import static net.runelite.api.ItemID.*;
 
-@ConfigGroup(
-	keyName = "woodcutting",
-	name = "Woodcutting",
-	description = "Configuration for the woodcutting plugin"
-)
-public interface WoodcuttingConfig extends Config
+@AllArgsConstructor
+enum Axe
 {
-	@ConfigItem(
-		position = 1,
-		keyName = "statTimeout",
-		name = "Reset stats (minutes)",
-		description = "Configures the time until statistic is reset. Also configures when tree indicator is hidden"
-	)
-	default int statTimeout()
+	BRONZE(WOODCUTTING_BRONZE, BRONZE_AXE),
+	IRON(WOODCUTTING_IRON, IRON_AXE),
+	STEEL(WOODCUTTING_STEEL, STEEL_AXE),
+	BLACK(WOODCUTTING_BLACK, BLACK_AXE),
+	MITHRIL(WOODCUTTING_MITHRIL, MITHRIL_AXE),
+	ADAMANT(WOODCUTTING_ADAMANT, ADAMANT_AXE),
+	RUNE(WOODCUTTING_RUNE, RUNE_AXE),
+	DRAGON(WOODCUTTING_DRAGON, DRAGON_AXE),
+	INFERNAL(WOODCUTTING_INFERNAL, INFERNAL_AXE),
+	THIRDAGE(WOODCUTTING_3A_AXE, _3RD_AGE_AXE);
+
+	private static final List<Integer> AXE_ANIM_IDS = new ArrayList<>();
+	private final Integer animID;
+	private final Integer itemID;
+
+	static
 	{
-		return 5;
+		for (Axe axe : values())
+		{
+			AXE_ANIM_IDS.add(axe.animID);
+		}
 	}
 
-	@ConfigItem(
-		position = 2,
-		keyName = "showNestNotification",
-		name = "Bird nest notification",
-		description = "Configures whether to notify you of a bird nest spawn"
-	)
-	default boolean showNestNotification()
+	public static List<Integer> getAxeAnimIds()
 	{
-		return true;
+		return AXE_ANIM_IDS;
 	}
 
-	@ConfigItem(
-		position = 3,
-		keyName = "showWoodcuttingStats",
-		name = "Show session stats",
-		description = "Configures whether to display woodcutting session stats"
-	)
-	default boolean showWoodcuttingStats()
+	public static Integer getItemID(int animID)
 	{
-		return true;
-	}
+		for (Axe axe : Axe.values())
+		{
+			if (axe.animID == animID)
+			{
+				return axe.itemID;
+			}
+		}
 
-	@ConfigItem(
-		position = 4,
-		keyName = "showAvailableTrees",
-		name = "Show available trees",
-		description = "Configures whether to show a indicator for available trees. Shows you recent Trees"
-	)
-	default boolean showAvailableTrees()
-	{
-		return true;
+		return null;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/Tree.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/Tree.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Seth <Sethtroll3@gmail.com>
+ * Copyright (c) 2018, Mantautas Jurksa <https://github.com/Juzzed>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -24,58 +24,48 @@
  */
 package net.runelite.client.plugins.woodcutting;
 
-import net.runelite.client.config.Config;
-import net.runelite.client.config.ConfigGroup;
-import net.runelite.client.config.ConfigItem;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import lombok.Getter;
+import static net.runelite.api.ObjectID.*;
 
-@ConfigGroup(
-	keyName = "woodcutting",
-	name = "Woodcutting",
-	description = "Configuration for the woodcutting plugin"
-)
-public interface WoodcuttingConfig extends Config
+@Getter
+enum Tree
 {
-	@ConfigItem(
-		position = 1,
-		keyName = "statTimeout",
-		name = "Reset stats (minutes)",
-		description = "Configures the time until statistic is reset. Also configures when tree indicator is hidden"
-	)
-	default int statTimeout()
+	NORMAL_TREE_SPAWN (TREE, TREE_1277, TREE_1278, TREE_1279, TREE_1280, DEAD_TREE, DEAD_TREE_1283, DEAD_TREE_1284, DEAD_TREE_1285, DEAD_TREE_1286, DEAD_TREE_1287, DEAD_TREE_1288, DEAD_TREE_1289, DEAD_TREE_1290,
+	DEAD_TREE_1291, DEAD_TREE_1333, DEAD_TREE_1365, DEAD_TREE_1383, DEAD_TREE_1384, EVERGREEN_2091, EVERGREEN_2092),
+	ACHEY_TREE_SPAWN (ACHEY_TREE),
+	OAK_TREE_SPAWN (OAK),
+	WILLOW_TREE_SPAWN (WILLOW, WILLOW_1756, WILLOW_1758, WILLOW_1760),
+	TEAK_TREE_SPAWN (TEAK),
+	JUNIPER_TREE_SPAWN (MATURE_JUNIPER_TREE),
+	MAPLE_TREE_SPAWN (MAPLE_TREE),
+	HALLOW_TREE_SPAWN (HOLLOW_TREE_1752, HOLLOW_TREE_1757),
+	MAHOGANY_TREE_SPAWN (MAHOGANY),
+	ARCTIC_PINE_TREE_SPAWN (ARCTIC_PINE),
+	YEW_TREE_SPAWN (YEW, NULL_1754),
+	MAGIC_TREE_SPAWN (MAGIC_TREE),
+	REDWOOD_TREE_SPAWN (REDWOOD, REDWOOD_29669, REDWOOD_29670, REDWOOD_29671);
+
+	private static final List<Integer> TREES = new ArrayList<>();
+	private final List<Integer> treeIds;
+
+	Tree(Integer... treeIds)
 	{
-		return 5;
+		this.treeIds = Arrays.asList(treeIds);
 	}
 
-	@ConfigItem(
-		position = 2,
-		keyName = "showNestNotification",
-		name = "Bird nest notification",
-		description = "Configures whether to notify you of a bird nest spawn"
-	)
-	default boolean showNestNotification()
+	static
 	{
-		return true;
+		for (Tree tree : values())
+		{
+			TREES.addAll(tree.getTreeIds());
+		}
 	}
 
-	@ConfigItem(
-		position = 3,
-		keyName = "showWoodcuttingStats",
-		name = "Show session stats",
-		description = "Configures whether to display woodcutting session stats"
-	)
-	default boolean showWoodcuttingStats()
+	public static List<Integer> getTrees ()
 	{
-		return true;
-	}
-
-	@ConfigItem(
-		position = 4,
-		keyName = "showAvailableTrees",
-		name = "Show available trees",
-		description = "Configures whether to show a indicator for available trees. Shows you recent Trees"
-	)
-	default boolean showAvailableTrees()
-	{
-		return true;
+		return TREES;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingOverlay.java
@@ -29,17 +29,7 @@ import java.awt.Dimension;
 import java.awt.Graphics2D;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.stream.IntStream;
 import javax.inject.Inject;
-import static net.runelite.api.AnimationID.WOODCUTTING_ADAMANT;
-import static net.runelite.api.AnimationID.WOODCUTTING_BLACK;
-import static net.runelite.api.AnimationID.WOODCUTTING_BRONZE;
-import static net.runelite.api.AnimationID.WOODCUTTING_DRAGON;
-import static net.runelite.api.AnimationID.WOODCUTTING_INFERNAL;
-import static net.runelite.api.AnimationID.WOODCUTTING_IRON;
-import static net.runelite.api.AnimationID.WOODCUTTING_MITHRIL;
-import static net.runelite.api.AnimationID.WOODCUTTING_RUNE;
-import static net.runelite.api.AnimationID.WOODCUTTING_STEEL;
 import net.runelite.api.Client;
 import net.runelite.api.Skill;
 import net.runelite.client.plugins.xptracker.XpTrackerService;
@@ -51,13 +41,6 @@ import net.runelite.client.ui.overlay.components.TitleComponent;
 
 class WoodcuttingOverlay extends Overlay
 {
-	private static final int[] animationIds =
-	{
-		WOODCUTTING_BRONZE, WOODCUTTING_IRON, WOODCUTTING_STEEL, WOODCUTTING_BLACK,
-		WOODCUTTING_MITHRIL, WOODCUTTING_ADAMANT, WOODCUTTING_RUNE, WOODCUTTING_DRAGON,
-		WOODCUTTING_INFERNAL
-	};
-
 	private final Client client;
 	private final WoodcuttingPlugin plugin;
 	private final WoodcuttingConfig config;
@@ -65,7 +48,7 @@ class WoodcuttingOverlay extends Overlay
 	private final PanelComponent panelComponent = new PanelComponent();
 
 	@Inject
-	public WoodcuttingOverlay(Client client, WoodcuttingPlugin plugin, WoodcuttingConfig config, XpTrackerService xpTrackerService)
+	private WoodcuttingOverlay(Client client, WoodcuttingPlugin plugin, WoodcuttingConfig config, XpTrackerService xpTrackerService)
 	{
 		setPosition(OverlayPosition.TOP_LEFT);
 		this.client = client;
@@ -99,7 +82,7 @@ class WoodcuttingOverlay extends Overlay
 
 		panelComponent.getChildren().clear();
 
-		if (IntStream.of(animationIds).anyMatch(x -> x == client.getLocalPlayer().getAnimation()))
+		if (Axe.getAxeAnimIds().contains(client.getLocalPlayer().getAnimation()))
 		{
 			panelComponent.getChildren().add(TitleComponent.builder()
 				.text("Woodcutting")
@@ -133,4 +116,5 @@ class WoodcuttingOverlay extends Overlay
 
 		return panelComponent.render(graphics);
 	}
+
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingTreesOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingTreesOverlay.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Seth <Sethtroll3@gmail.com>
+ * Copyright (c) 2018, Tomas Slusny <slusnucky@gmail.com>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -24,58 +24,48 @@
  */
 package net.runelite.client.plugins.woodcutting;
 
-import net.runelite.client.config.Config;
-import net.runelite.client.config.ConfigGroup;
-import net.runelite.client.config.ConfigItem;
+import java.awt.Dimension;
+import java.awt.Graphics2D;
+import javax.inject.Inject;
+import net.runelite.api.Client;
+import net.runelite.api.GameObject;
+import net.runelite.client.game.ItemManager;
+import net.runelite.client.ui.overlay.Overlay;
+import net.runelite.client.ui.overlay.OverlayLayer;
+import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.OverlayUtil;
 
-@ConfigGroup(
-	keyName = "woodcutting",
-	name = "Woodcutting",
-	description = "Configuration for the woodcutting plugin"
-)
-public interface WoodcuttingConfig extends Config
+class WoodcuttingTreesOverlay extends Overlay
 {
-	@ConfigItem(
-		position = 1,
-		keyName = "statTimeout",
-		name = "Reset stats (minutes)",
-		description = "Configures the time until statistic is reset. Also configures when tree indicator is hidden"
-	)
-	default int statTimeout()
+	private final Client client;
+	private final ItemManager itemManager;
+	private final WoodcuttingPlugin plugin;
+
+	@Inject
+	private WoodcuttingTreesOverlay(final Client client, final ItemManager itemManager, final WoodcuttingPlugin plugin)
 	{
-		return 5;
+		this.client = client;
+		this.itemManager = itemManager;
+		this.plugin = plugin;
+		setLayer(OverlayLayer.ABOVE_SCENE);
+		setPosition(OverlayPosition.DYNAMIC);
 	}
 
-	@ConfigItem(
-		position = 2,
-		keyName = "showNestNotification",
-		name = "Bird nest notification",
-		description = "Configures whether to notify you of a bird nest spawn"
-	)
-	default boolean showNestNotification()
+	@Override
+	public Dimension render(Graphics2D graphics)
 	{
-		return true;
-	}
+		if (!plugin.getTreesToDraw().isEmpty())
+		{
+			for (final GameObject tree : plugin.getTreeObjects())
+			{
+				if (plugin.getTreesToDraw().contains(tree.getId())
+					&& tree.getWorldLocation().distanceTo(client.getLocalPlayer().getWorldLocation()) <= 12)
+				{
+					OverlayUtil.renderImageLocation(client, graphics, tree.getLocalLocation(), itemManager.getImage(plugin.getAxeID()), 120);
+				}
+			}
+		}
 
-	@ConfigItem(
-		position = 3,
-		keyName = "showWoodcuttingStats",
-		name = "Show session stats",
-		description = "Configures whether to display woodcutting session stats"
-	)
-	default boolean showWoodcuttingStats()
-	{
-		return true;
-	}
-
-	@ConfigItem(
-		position = 4,
-		keyName = "showAvailableTrees",
-		name = "Show available trees",
-		description = "Configures whether to show a indicator for available trees. Shows you recent Trees"
-	)
-	default boolean showAvailableTrees()
-	{
-		return true;
+		return null;
 	}
 }


### PR DESCRIPTION
Adds a tree indicator. 

The indicator shows the current axe the player is using. It works with both equipped and unequipped axes because it is based on the animation.
The indicator is shown when the player starts an animation and is hidden within certain time (default 5mins) when no woodcutting animation was performed.

Settings:
![image](https://user-images.githubusercontent.com/25037124/40270001-3bf1863a-5b86-11e8-95d2-75c521e839b5.png)

Indicator:
![image](https://user-images.githubusercontent.com/25037124/40272231-93caacf0-5baa-11e8-81cb-26f3f0a61932.png)


Switching Trees:
![ezgif-1-67e5cea60f](https://user-images.githubusercontent.com/25037124/40268126-4e7a6128-5b68-11e8-9cf7-ac9d3ce0a43d.gif)

Switching Axes:
![ezgif-1-78ff95e2f6](https://user-images.githubusercontent.com/25037124/40268057-092c558c-5b67-11e8-9701-f8ef4f7798e4.gif)

Fixes: #1053 