### PR TITLE
entityhider: don't hide npcs by default

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/entityhider/EntityHiderConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/entityhider/EntityHiderConfig.java
@@ -110,7 +110,7 @@ public interface EntityHiderConfig extends Config
 	)
 	default boolean hideNPCs()
 	{
-		return true;
+		return false;
 	}
 
 	@ConfigItem(
@@ -121,7 +121,7 @@ public interface EntityHiderConfig extends Config
 	)
 	default boolean hideNPCs2D()
 	{
-		return true;
+		return false;
 	}
 
 	@ConfigItem(


### PR DESCRIPTION
I think the entity hider should only hide players by default, since this is the main usage of the plugin.
Users have also gone into the Discord asking why they can't see NPCs, so this would alleviate that a little.