### PR TITLE
Daily Task Indicators: delay the varbit check to allow them to initialize

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/dailytaskindicators/DailyTasksPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/dailytaskindicators/DailyTasksPlugin.java
@@ -33,8 +33,8 @@ import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
 import net.runelite.api.Varbits;
-import net.runelite.api.events.ChatMessage;
 import net.runelite.api.events.ConfigChanged;
+import net.runelite.api.events.PlayerSpawned;
 import net.runelite.client.chat.ChatColor;
 import net.runelite.client.chat.ChatColorType;
 import net.runelite.client.chat.ChatMessageBuilder;
@@ -102,9 +102,9 @@ public class DailyTasksPlugin extends Plugin
 	}
 
 	@Subscribe
-	public void onChatMessage(ChatMessage event)
+	public void onPlayerSpawned(PlayerSpawned event)
 	{
-		if (event.getType() != ChatMessageType.SERVER || !event.getMessage().equals("Welcome to RuneScape."))
+		if (event.getPlayer() != client.getLocalPlayer())
 		{
 			return;
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/dailytaskindicators/DailyTasksPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/dailytaskindicators/DailyTasksPlugin.java
@@ -61,8 +61,7 @@ public class DailyTasksPlugin extends Plugin
 	@Inject
 	private ChatMessageManager chatMessageManager;
 
-	private boolean hasSentHerbMsg, hasSentStavesMsg, hasSentEssenceMsg;
-	private int updateTick;
+	private boolean hasSentHerbMsg, hasSentStavesMsg, hasSentEssenceMsg, check;
 
 	@Provides
 	DailyTasksConfig provideConfig(ConfigManager configManager)
@@ -111,17 +110,19 @@ public class DailyTasksPlugin extends Plugin
 			return;
 		}
 
-		//load the varbits one tick after spawning
-		updateTick = client.getTickCount() + 1;
+		//load the varbits on first available tick
+		check = true;
 	}
 
 	@Subscribe
 	public void onGameTick(GameTick event)
 	{
-		if (client.getTickCount() != updateTick)
+		if (!check)
 		{
 			return;
 		}
+		
+		check = false;
 
 		if (config.showHerbBoxes() && !hasSentHerbMsg && checkCanCollectHerbBox())
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/dailytaskindicators/DailyTasksPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/dailytaskindicators/DailyTasksPlugin.java
@@ -34,6 +34,7 @@ import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
 import net.runelite.api.Varbits;
 import net.runelite.api.events.ConfigChanged;
+import net.runelite.api.events.GameTick;
 import net.runelite.api.events.PlayerSpawned;
 import net.runelite.client.chat.ChatColor;
 import net.runelite.client.chat.ChatColorType;
@@ -61,6 +62,7 @@ public class DailyTasksPlugin extends Plugin
 	private ChatMessageManager chatMessageManager;
 
 	private boolean hasSentHerbMsg, hasSentStavesMsg, hasSentEssenceMsg;
+	private int updateTick;
 
 	@Provides
 	DailyTasksConfig provideConfig(ConfigManager configManager)
@@ -105,6 +107,18 @@ public class DailyTasksPlugin extends Plugin
 	public void onPlayerSpawned(PlayerSpawned event)
 	{
 		if (event.getPlayer() != client.getLocalPlayer())
+		{
+			return;
+		}
+
+		//load the varbits one tick after spawning
+		updateTick = client.getTickCount() + 1;
+	}
+
+	@Subscribe
+	public void onGameTick(GameTick event)
+	{
+		if (client.getTickCount() != updateTick)
 		{
 			return;
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/dailytaskindicators/DailyTasksPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/dailytaskindicators/DailyTasksPlugin.java
@@ -32,11 +32,9 @@ import javax.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
-import net.runelite.api.GameState;
 import net.runelite.api.Varbits;
+import net.runelite.api.events.ChatMessage;
 import net.runelite.api.events.ConfigChanged;
-import net.runelite.api.events.GameStateChanged;
-import net.runelite.api.events.GameTick;
 import net.runelite.client.chat.ChatColor;
 import net.runelite.client.chat.ChatColorType;
 import net.runelite.client.chat.ChatMessageBuilder;
@@ -63,7 +61,6 @@ public class DailyTasksPlugin extends Plugin
 	private ChatMessageManager chatMessageManager;
 
 	private boolean hasSentHerbMsg, hasSentStavesMsg, hasSentEssenceMsg;
-	private int sendOnTick;
 
 	@Provides
 	DailyTasksConfig provideConfig(ConfigManager configManager)
@@ -105,34 +102,29 @@ public class DailyTasksPlugin extends Plugin
 	}
 
 	@Subscribe
-	public void onGameStateChanged(GameStateChanged event)
+	public void onChatMessage(ChatMessage event)
 	{
-		if (event.getGameState().equals(GameState.LOGGED_IN))
+		if (event.getType() != ChatMessageType.SERVER || !event.getMessage().equals("Welcome to RuneScape."))
 		{
-			sendOnTick = client.getTickCount();
+			return;
 		}
-	}
 
-	@Subscribe
-	public void onGameTick(GameTick event)
-	{
-		if (sendOnTick == client.getTickCount())
+		if (config.showHerbBoxes() && !hasSentHerbMsg && checkCanCollectHerbBox())
 		{
-			if (config.showHerbBoxes() && !hasSentHerbMsg && checkCanCollectHerbBox())
-			{
-				sendChatMessage("You have herb boxes waiting to be collected at NMZ.");
-				hasSentHerbMsg = true;
-			}
-			if (config.showStaves() && !hasSentStavesMsg && checkCanCollectStaves())
-			{
-				sendChatMessage("You have staves waiting to be collected from Zaff.");
-				hasSentStavesMsg = true;
-			}
-			if (config.showEssence() && !hasSentEssenceMsg && checkCanCollectEssence())
-			{
-				sendChatMessage("You have pure essence waiting to be collected from Wizard Cromperty.");
-				hasSentEssenceMsg = true;
-			}
+			sendChatMessage("You have herb boxes waiting to be collected at NMZ.");
+			hasSentHerbMsg = true;
+		}
+
+		if (config.showStaves() && !hasSentStavesMsg && checkCanCollectStaves())
+		{
+			sendChatMessage("You have staves waiting to be collected from Zaff.");
+			hasSentStavesMsg = true;
+		}
+
+		if (config.showEssence() && !hasSentEssenceMsg && checkCanCollectEssence())
+		{
+			sendChatMessage("You have pure essence waiting to be collected from Wizard Cromperty.");
+			hasSentEssenceMsg = true;
 		}
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/dailytaskindicators/DailyTasksPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/dailytaskindicators/DailyTasksPlugin.java
@@ -36,6 +36,7 @@ import net.runelite.api.GameState;
 import net.runelite.api.Varbits;
 import net.runelite.api.events.ConfigChanged;
 import net.runelite.api.events.GameStateChanged;
+import net.runelite.api.events.GameTick;
 import net.runelite.client.chat.ChatColor;
 import net.runelite.client.chat.ChatColorType;
 import net.runelite.client.chat.ChatMessageBuilder;
@@ -62,6 +63,7 @@ public class DailyTasksPlugin extends Plugin
 	private ChatMessageManager chatMessageManager;
 
 	private boolean hasSentHerbMsg, hasSentStavesMsg, hasSentEssenceMsg;
+	private int sendOnTick;
 
 	@Provides
 	DailyTasksConfig provideConfig(ConfigManager configManager)
@@ -106,6 +108,15 @@ public class DailyTasksPlugin extends Plugin
 	public void onGameStateChanged(GameStateChanged event)
 	{
 		if (event.getGameState().equals(GameState.LOGGED_IN))
+		{
+			sendOnTick = client.getTickCount();
+		}
+	}
+
+	@Subscribe
+	public void onGameTick(GameTick event)
+	{
+		if (sendOnTick == client.getTickCount())
 		{
 			if (config.showHerbBoxes() && !hasSentHerbMsg && checkCanCollectHerbBox())
 			{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/dailytaskindicators/DailyTasksPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/dailytaskindicators/DailyTasksPlugin.java
@@ -34,8 +34,8 @@ import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
 import net.runelite.api.Varbits;
 import net.runelite.api.events.ConfigChanged;
+import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.GameTick;
-import net.runelite.api.events.PlayerSpawned;
 import net.runelite.client.chat.ChatColor;
 import net.runelite.client.chat.ChatColorType;
 import net.runelite.client.chat.ChatMessageBuilder;
@@ -103,15 +103,16 @@ public class DailyTasksPlugin extends Plugin
 	}
 
 	@Subscribe
-	public void onPlayerSpawned(PlayerSpawned event)
+	public void onGameStateChanged(GameStateChanged event)
 	{
-		if (event.getPlayer() != client.getLocalPlayer())
+		switch (event.getGameState())
 		{
-			return;
+			case HOPPING:
+			case LOGGED_IN:
+				//load the varbits on first available tick
+				check = true;
+				break;
 		}
-
-		//load the varbits on first available tick
-		check = true;
 	}
 
 	@Subscribe


### PR DESCRIPTION
Currently the plugin reads varbits right on GameStateChanged event, but varbits are not yet initialized to the correct values, which means the dailies will always be available. This delays this check until next game tick.