### PR TITLE
SetOpaque UI performance fix

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
@@ -180,7 +180,6 @@ public class ConfigPanel extends PluginPanel
 				groupPanel.add(name, BorderLayout.CENTER);
 
 				final JPanel buttonPanel = new JPanel();
-				buttonPanel.setOpaque(false);
 				buttonPanel.setLayout(new GridLayout(1, 2));
 				groupPanel.add(buttonPanel, BorderLayout.LINE_END);
 
@@ -202,7 +201,6 @@ public class ConfigPanel extends PluginPanel
 		groupPanel.add(name, BorderLayout.CENTER);
 
 		final JPanel buttonPanel = new JPanel();
-		buttonPanel.setOpaque(false);
 		buttonPanel.setLayout(new GridLayout(1, 2));
 		groupPanel.add(buttonPanel, BorderLayout.LINE_END);
 
@@ -225,7 +223,6 @@ public class ConfigPanel extends PluginPanel
 		final JPanel groupPanel = new JPanel();
 		groupPanel.setLayout(new BorderLayout(3, 0));
 		groupPanel.setPreferredSize(new Dimension(PluginPanel.PANEL_WIDTH, 20));
-		groupPanel.setOpaque(false);
 		return groupPanel;
 	}
 
@@ -378,7 +375,6 @@ public class ConfigPanel extends PluginPanel
 		if (component instanceof JCheckBox)
 		{
 			JCheckBox checkbox = (JCheckBox) component;
-			checkbox.setOpaque(false);
 			configManager.setConfiguration(cd.getGroup().keyName(), cid.getItem().keyName(), "" + checkbox.isSelected());
 		}
 
@@ -426,7 +422,6 @@ public class ConfigPanel extends PluginPanel
 			}
 
 			JPanel item = new JPanel();
-			item.setOpaque(false);
 			item.setLayout(new BorderLayout());
 			name = cid.getItem().name();
 			JLabel configEntryName = new JLabel(name);
@@ -436,7 +431,6 @@ public class ConfigPanel extends PluginPanel
 			if (cid.getType() == boolean.class)
 			{
 				JCheckBox checkbox = new JCheckBox();
-				checkbox.setOpaque(false);
 				checkbox.setBackground(ColorScheme.LIGHT_GRAY_COLOR);
 				checkbox.setSelected(Boolean.parseBoolean(configManager.getConfiguration(cd.getGroup().keyName(), cid.getItem().keyName())));
 				checkbox.addActionListener(ae -> changeConfiguration(config, checkbox, cd, cid));
@@ -515,7 +509,6 @@ public class ConfigPanel extends PluginPanel
 			if (cid.getType() == Dimension.class)
 			{
 				JPanel dimensionPanel = new JPanel();
-				dimensionPanel.setOpaque(false);
 				dimensionPanel.setLayout(new BorderLayout());
 
 				String str = configManager.getConfiguration(cd.getGroup().keyName(), cid.getItem().keyName());

--- a/runelite-client/src/main/java/net/runelite/client/plugins/farmingtracker/FarmingPatchPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/farmingtracker/FarmingPatchPanel.java
@@ -52,7 +52,6 @@ class FarmingPatchPanel extends JPanel
 		this.patch = patch;
 
 		setLayout(new BorderLayout());
-		setOpaque(false);
 		setBorder(new EmptyBorder(7, 0, 0, 0));
 
 		JPanel topContainer = new JPanel();
@@ -63,7 +62,7 @@ class FarmingPatchPanel extends JPanel
 		icon.setMinimumSize(new Dimension(36, 32));
 
 		JPanel infoPanel = new JPanel();
-		infoPanel.setOpaque(false);
+		infoPanel.setBackground(ColorScheme.DARKER_GRAY_COLOR);
 		infoPanel.setLayout(new GridLayout(2, 1));
 		infoPanel.setBorder(new EmptyBorder(4, 4, 4, 0));
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/farmingtracker/FarmingTrackerPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/farmingtracker/FarmingTrackerPanel.java
@@ -91,7 +91,6 @@ class FarmingTrackerPanel extends PluginPanel
 		setLayout(new BorderLayout());
 		setBackground(ColorScheme.DARK_GRAY_COLOR);
 
-		display.setOpaque(false);
 		display.setBorder(new EmptyBorder(10, 10, 8, 10));
 
 		tabGroup.setBorder(new EmptyBorder(10, 1, 0, 0));

--- a/runelite-client/src/main/java/net/runelite/client/plugins/feed/FeedPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/feed/FeedPanel.java
@@ -135,13 +135,13 @@ class FeedPanel extends PluginPanel
 		setLayout(new BorderLayout());
 
 		feedContainer.setLayout(new GridLayout(0, 1, 0, 4));
-		feedContainer.setOpaque(false);
+		feedContainer.setBackground(ColorScheme.DARK_GRAY_COLOR);
 
 		/**
 		 * This header contains the "News Feed" title and a refresh icon button.
 		 */
 		JPanel header = new JPanel();
-		header.setOpaque(false);
+		header.setBackground(ColorScheme.DARK_GRAY_COLOR);
 		header.setLayout(new BorderLayout());
 		header.setBorder(new EmptyBorder(0, 0, 9, 0));
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangeItemPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangeItemPanel.java
@@ -94,7 +94,7 @@ class GrandExchangeItemPanel extends JPanel
 
 		// Item details panel
 		JPanel rightPanel = new JPanel(new GridLayout(3, 1));
-		rightPanel.setOpaque(false);
+		rightPanel.setBackground(ColorScheme.MEDIUM_GRAY_COLOR);
 
 		// Item name
 		JLabel itemName = new JLabel();

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangeOfferSlot.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangeOfferSlot.java
@@ -140,7 +140,7 @@ public class GrandExchangeOfferSlot extends JPanel
 		container.setBackground(ColorScheme.MEDIUM_GRAY_COLOR);
 
 		JPanel faceCard = new JPanel();
-		faceCard.setOpaque(false);
+		faceCard.setBackground(ColorScheme.MEDIUM_GRAY_COLOR);
 		faceCard.setLayout(new BorderLayout());
 		faceCard.addMouseListener(ml);
 
@@ -162,7 +162,7 @@ public class GrandExchangeOfferSlot extends JPanel
 		switchFaceViewIcon.setPreferredSize(new Dimension(30, 45));
 
 		JPanel offerFaceDetails = new JPanel();
-		offerFaceDetails.setOpaque(false);
+		offerFaceDetails.setBackground(ColorScheme.MEDIUM_GRAY_COLOR);
 		offerFaceDetails.setLayout(new GridLayout(2, 1, 0, 2));
 
 		offerFaceDetails.add(itemName);
@@ -173,7 +173,7 @@ public class GrandExchangeOfferSlot extends JPanel
 		faceCard.add(switchFaceViewIcon, BorderLayout.EAST);
 
 		JPanel detailsCard = new JPanel();
-		detailsCard.setOpaque(false);
+		detailsCard.setBackground(ColorScheme.MEDIUM_GRAY_COLOR);
 		detailsCard.setLayout(new BorderLayout());
 		detailsCard.setBorder(new EmptyBorder(0, 15, 0, 0));
 		detailsCard.addMouseListener(ml);
@@ -192,7 +192,7 @@ public class GrandExchangeOfferSlot extends JPanel
 		switchDetailsViewIcon.setPreferredSize(new Dimension(30, 45));
 
 		JPanel offerDetails = new JPanel();
-		offerDetails.setOpaque(false);
+		offerDetails.setBackground(ColorScheme.MEDIUM_GRAY_COLOR);
 		offerDetails.setLayout(new GridLayout(2, 1));
 
 		offerDetails.add(itemPrice);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/hiscore/HiscorePanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/hiscore/HiscorePanel.java
@@ -216,7 +216,6 @@ public class HiscorePanel extends PluginPanel
 
 		/* The container for all the endpoint selectors */
 		JPanel endpointPanel = new JPanel();
-		endpointPanel.setOpaque(false);
 		endpointPanel.setLayout(new GridLayout(1, 5, 7, 1));
 
 		for (HiscoreEndpoint endpoint : HiscoreEndpoint.values())
@@ -281,7 +280,6 @@ public class HiscorePanel extends PluginPanel
 		for (HiscoreSkill skill : SKILLS)
 		{
 			JPanel panel = makeSkillPanel(skill);
-			panel.setOpaque(false);
 			statsPanel.add(panel);
 		}
 
@@ -354,7 +352,7 @@ public class HiscorePanel extends PluginPanel
 		label.setIconTextGap(totalLabel ? 10 : 4);
 
 		JPanel skillPanel = new JPanel();
-		skillPanel.setOpaque(false);
+		skillPanel.setBackground(ColorScheme.DARKER_GRAY_COLOR);
 		skillPanel.setBorder(new EmptyBorder(2, 0, 2, 0));
 		skillLabels.add(label);
 		skillPanel.add(skillLabels.get(skillLabels.size() - 1));

--- a/runelite-client/src/main/java/net/runelite/client/plugins/info/InfoPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/info/InfoPanel.java
@@ -159,7 +159,6 @@ public class InfoPanel extends PluginPanel
 
 		JPanel actionsContainer = new JPanel();
 		actionsContainer.setBorder(new EmptyBorder(10, 0, 0, 0));
-		actionsContainer.setOpaque(false);
 		actionsContainer.setLayout(new GridLayout(3, 1, 0, 10));
 
 		actionsContainer.add(buildLinkPanel(GITHUB_ICON, "Report an issue or", "make a suggestion", runeLiteProperties.getGithubLink()));
@@ -194,7 +193,7 @@ public class InfoPanel extends PluginPanel
 		container.add(iconLabel, BorderLayout.WEST);
 
 		JPanel textContainer = new JPanel();
-		textContainer.setOpaque(false);
+		textContainer.setBackground(ColorScheme.DARKER_GRAY_COLOR);
 		textContainer.setLayout(new GridLayout(2, 1));
 		textContainer.setBorder(new EmptyBorder(5, 10, 5, 10));
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/kourendlibrary/BookPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/kourendlibrary/BookPanel.java
@@ -29,6 +29,7 @@ import javax.swing.GroupLayout;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.border.EmptyBorder;
+import net.runelite.client.ui.ColorScheme;
 import net.runelite.client.ui.FontManager;
 
 class BookPanel extends JPanel
@@ -38,7 +39,7 @@ class BookPanel extends JPanel
 	BookPanel(Book b)
 	{
 		setBorder(new EmptyBorder(3, 3, 3, 3));
-		setOpaque(false);
+		setBackground(ColorScheme.DARK_GRAY_COLOR);
 
 		GroupLayout layout = new GroupLayout(this);
 		this.setLayout(layout);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/kourendlibrary/KourendLibraryPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/kourendlibrary/KourendLibraryPanel.java
@@ -90,7 +90,6 @@ public class KourendLibraryPanel extends PluginPanel
 		setBackground(ColorScheme.DARK_GRAY_COLOR);
 
 		JPanel books = new JPanel(new GridBagLayout());
-		books.setOpaque(false);
 		GridBagConstraints c = new GridBagConstraints();
 		c.fill = GridBagConstraints.HORIZONTAL;
 		c.weightx = 1;
@@ -126,7 +125,6 @@ public class KourendLibraryPanel extends PluginPanel
 		});
 
 		JPanel header = new JPanel();
-		header.setOpaque(false);
 		header.setLayout(new BorderLayout());
 		header.setBorder(new CompoundBorder(
 			BorderFactory.createMatteBorder(0, 0, 1, 0, new Color(58, 58, 58)),

--- a/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/UIActionSlot.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/UIActionSlot.java
@@ -41,6 +41,7 @@ class UIActionSlot extends JPanel
 	SkillDataEntry action;
 	private JShadowedLabel uiLabelActions;
 	private static final Dimension ICON_SIZE = new Dimension(32, 32);
+	private final JPanel uiInfo;
 
 	boolean isAvailable = false;
 	boolean isSelected = false;
@@ -70,8 +71,7 @@ class UIActionSlot extends JPanel
 		uiIcon.setHorizontalAlignment(JLabel.CENTER);
 		add(uiIcon, BorderLayout.LINE_START);
 
-		JPanel uiInfo = new JPanel(new GridLayout(2, 1));
-		uiInfo.setOpaque(false);
+		uiInfo = new JPanel(new GridLayout(2, 1));
 
 		JShadowedLabel uiLabelName = new JShadowedLabel(action.name);
 		uiInfo.add(uiLabelName);
@@ -106,5 +106,7 @@ class UIActionSlot extends JPanel
 			this.setBackground(isAvailable ? Color.GREEN : Color.RED);
 		else
 			this.setBackground(isAvailable ? Color.GREEN.darker() : Color.RED.darker());
+
+		uiInfo.setBackground(getBackground());
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/UICombinedActionSlot.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/UICombinedActionSlot.java
@@ -60,7 +60,7 @@ class UICombinedActionSlot extends JPanel
 		add(uiIcon, BorderLayout.LINE_START);
 
 		JPanel uiInfo = new JPanel(new GridLayout(2, 1));
-		uiInfo.setOpaque(false);
+		uiInfo.setBackground(Color.ORANGE);
 
 		uiLabelTitle = new JShadowedLabel("No Action Selected");
 		uiInfo.add(uiLabelTitle);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpInfoBox.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpInfoBox.java
@@ -84,10 +84,8 @@ class XpInfoBox extends JPanel
 
 		setLayout(new BorderLayout());
 		setBorder(new EmptyBorder(10, 0, 0, 0));
-		setOpaque(false);
 
 		container.setLayout(new BorderLayout());
-		container.setOpaque(true);
 		container.setBackground(ColorScheme.DARKER_GRAY_COLOR);
 
 		// Create open xp tracker menu
@@ -110,15 +108,15 @@ class XpInfoBox extends JPanel
 		skillIcon.setVerticalAlignment(SwingConstants.CENTER);
 		skillIcon.setPreferredSize(new Dimension(35, 35));
 
-		headerPanel.setOpaque(false);
+		headerPanel.setBackground(ColorScheme.DARKER_GRAY_COLOR);
 		headerPanel.setLayout(new BorderLayout());
 
 		statsPanel.setLayout(new BorderLayout());
+		statsPanel.setBackground(ColorScheme.DARKER_GRAY_COLOR);
 		statsPanel.setBorder(new EmptyBorder(9, 5, 9, 10));
-		statsPanel.setOpaque(false);
 
 		JPanel leftPanel = new JPanel();
-		leftPanel.setOpaque(false);
+		leftPanel.setBackground(ColorScheme.DARKER_GRAY_COLOR);
 		leftPanel.setLayout(new GridLayout(2, 1));
 
 		expGained.setFont(FontManager.getRunescapeSmallFont());
@@ -128,7 +126,7 @@ class XpInfoBox extends JPanel
 		leftPanel.add(expHour);
 
 		JPanel rightPanel = new JPanel();
-		rightPanel.setOpaque(false);
+		rightPanel.setBackground(ColorScheme.DARKER_GRAY_COLOR);
 		rightPanel.setLayout(new GridLayout(2, 1));
 
 		expLeft.setFont(FontManager.getRunescapeSmallFont());
@@ -144,7 +142,7 @@ class XpInfoBox extends JPanel
 		headerPanel.add(statsPanel, BorderLayout.CENTER);
 
 		JPanel progressWrapper = new JPanel();
-		progressWrapper.setOpaque(false);
+		progressWrapper.setBackground(ColorScheme.DARKER_GRAY_COLOR);
 		progressWrapper.setLayout(new BorderLayout());
 		progressWrapper.setBorder(new EmptyBorder(0, 7, 7, 7));
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpPanel.java
@@ -71,7 +71,6 @@ class XpPanel extends PluginPanel
 		setBackground(ColorScheme.DARK_GRAY_COLOR);
 
 		final JPanel layoutPanel = new JPanel();
-		layoutPanel.setOpaque(false);
 		layoutPanel.setLayout(new BorderLayout());
 		add(layoutPanel);
 
@@ -98,7 +97,7 @@ class XpPanel extends PluginPanel
 		final JLabel overallIcon = new JLabel(new ImageIcon(iconManager.getSkillImage(Skill.OVERALL)));
 
 		final JPanel overallInfo = new JPanel();
-		overallInfo.setOpaque(false);
+		overallInfo.setBackground(ColorScheme.DARKER_GRAY_COLOR);
 		overallInfo.setLayout(new GridLayout(2, 1));
 		overallInfo.setBorder(new EmptyBorder(0, 10, 0, 0));
 
@@ -113,7 +112,6 @@ class XpPanel extends PluginPanel
 
 
 		final JPanel infoBoxPanel = new JPanel();
-		infoBoxPanel.setOpaque(false);
 		infoBoxPanel.setLayout(new BoxLayout(infoBoxPanel, BoxLayout.Y_AXIS));
 		layoutPanel.add(infoBoxPanel, BorderLayout.CENTER);
 		layoutPanel.add(overallPanel, BorderLayout.NORTH);

--- a/runelite-client/src/main/java/net/runelite/client/util/SwingUtil.java
+++ b/runelite-client/src/main/java/net/runelite/client/util/SwingUtil.java
@@ -62,6 +62,7 @@ import javax.swing.UnsupportedLookAndFeelException;
 import static javax.swing.WindowConstants.DO_NOTHING_ON_CLOSE;
 import javax.swing.plaf.FontUIResource;
 import lombok.extern.slf4j.Slf4j;
+import net.runelite.client.ui.ColorScheme;
 import net.runelite.client.ui.NavigationButton;
 import net.runelite.client.ui.components.CustomScrollBarUI;
 import org.pushingpixels.substance.internal.SubstanceSynapse;
@@ -87,6 +88,7 @@ public class SwingUtil
 
 		UIManager.put("Button.foreground", Color.WHITE);
 		UIManager.put("MenuItem.foreground", Color.WHITE);
+		UIManager.put("Panel.background", ColorScheme.DARK_GRAY_COLOR);
 		UIManager.put("ScrollBarUI", CustomScrollBarUI.class.getName());
 
 		// Do not render shadows under popups/tooltips.


### PR DESCRIPTION
Apparently, the setOpaque method on JPanels was causing some performance
issues on the client, the original reason I had these was so that the
base panel would have a color defined, and every container or wrapper
panel on top would just be transparent.

To fix this I have set a default JPanel background color and replaced
calls to setOpaque with calls to
setBackground with the appropriate colors.