### PR TITLE
Motherlode Mine - Ore overlay

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/motherlode/MotherlodeConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/motherlode/MotherlodeConfig.java
@@ -105,4 +105,14 @@ public interface MotherlodeConfig extends Config
 	{
 		return true;
 	}
+
+	@ConfigItem(
+		keyName = "showOresCollected",
+		name = "Show ores collected",
+		description = "Shows ores collected during current mining session"
+	)
+	default boolean showOresCollected()
+	{
+		return true;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/motherlode/MotherlodeOreType.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/motherlode/MotherlodeOreType.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2018, Lars <lars.oernlo@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package net.runelite.client.plugins.motherlode;
+
+import net.runelite.api.ItemID;
+
+public enum MotherlodeOreType
+{
+	RUNITE_ORE("Runite", ItemID.RUNITE_ORE),
+	ADAMANTITE_ORE("Adamant", ItemID.ADAMANTITE_ORE),
+	MITHRIL_ORE("Mithril", ItemID.MITHRIL_ORE),
+	GOLD_ORE("Gold", ItemID.GOLD_ORE),
+	COAL("Coal", ItemID.COAL),
+	GOLDEN_NUGGET("Nugget", ItemID.GOLDEN_NUGGET);
+
+	public final String oreName;
+	public final int oreId;
+
+	MotherlodeOreType(String oreName, int oreId)
+	{
+		this.oreName = oreName;
+		this.oreId = oreId;
+	}
+
+	public static boolean containsOreId(int oreId)
+	{
+
+		for (MotherlodeOreType oreType : MotherlodeOreType.values())
+		{
+			if (oreType.oreId == oreId)
+			{
+				return true;
+			}
+		}
+
+		return false;
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/motherlode/MotherlodeSession.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/motherlode/MotherlodeSession.java
@@ -45,9 +45,6 @@ public class MotherlodeSession
 	private int recentMined;
 
 	@Getter(AccessLevel.PACKAGE)
-	private Instant lastGemFound;
-
-	@Getter(AccessLevel.PACKAGE)
 	private int diamondsFound;
 
 	@Getter(AccessLevel.PACKAGE)
@@ -59,10 +56,80 @@ public class MotherlodeSession
 	@Getter(AccessLevel.PACKAGE)
 	private int sapphiresFound;
 
+	private int runiteCollected;
+
+	private int adamantCollected;
+
+	private int mithrilCollected;
+
+	private int goldCollected;
+
+	private int coalCollected;
+
+	private int nuggetsCollected;
+
+	Integer getCollected(int oreId)
+	{
+		switch (oreId)
+		{
+			case ItemID.RUNITE_ORE:
+				return runiteCollected;
+
+			case ItemID.ADAMANTITE_ORE:
+				return adamantCollected;
+
+			case ItemID.MITHRIL_ORE:
+				return mithrilCollected;
+
+			case ItemID.GOLD_ORE:
+				return goldCollected;
+
+			case ItemID.COAL:
+				return coalCollected;
+
+			case ItemID.GOLDEN_NUGGET:
+				return nuggetsCollected;
+
+			default:
+				return null;
+		}
+	}
+
+	public void incrementCollected(int oreId, int... quantity)
+	{
+		switch (oreId)
+		{
+			case ItemID.RUNITE_ORE:
+				runiteCollected++;
+				break;
+
+			case ItemID.ADAMANTITE_ORE:
+				adamantCollected++;
+				break;
+
+			case ItemID.MITHRIL_ORE:
+				mithrilCollected++;
+				break;
+
+			case ItemID.GOLD_ORE:
+				goldCollected++;
+				break;
+
+			case ItemID.COAL:
+				coalCollected++;
+				break;
+
+			case ItemID.GOLDEN_NUGGET:
+				nuggetsCollected += quantity[0];
+				break;
+
+			default:
+				log.error("Invalid item id specified. The value for the specified item will not be incremented.");
+		}
+	}
+
 	public void incrementGemFound(int gemID)
 	{
-		lastGemFound = Instant.now();
-
 		switch (gemID)
 		{
 			case ItemID.UNCUT_DIAMOND:


### PR DESCRIPTION
Implements an ore counter to the Motherlode Mine Plugin.

Other small changes:

* Make gem overlay inactivity depend on last pay-dirt mined rather than
lastGemFound. Reason for this is because the overlay disappears rather
quick.
* Move inventory item id -1 to constant

Screenshot:
![image](https://user-images.githubusercontent.com/4660715/39893541-5bb78bce-54a4-11e8-9ec1-a9cf0690e0d1.png)
