### PR TITLE
Improve stretched fixed mode performance

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/fps/FpsDrawListener.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/fps/FpsDrawListener.java
@@ -24,7 +24,7 @@
  */
 package net.runelite.client.plugins.fps;
 
-import java.awt.image.BufferedImage;
+import java.awt.Image;
 import java.util.function.Consumer;
 import javax.inject.Inject;
 import net.runelite.api.events.FocusChanged;
@@ -42,7 +42,7 @@ import net.runelite.api.events.FocusChanged;
  * Enforcing FPS in the draw code does not impact the client engine's ability to run including its audio,
  * even when forced to 1 FPS with this plugin.
  */
-public class FpsDrawListener implements Consumer<BufferedImage>
+public class FpsDrawListener implements Consumer<Image>
 {
 	private static final int SAMPLE_SIZE = 4;
 
@@ -90,7 +90,7 @@ public class FpsDrawListener implements Consumer<BufferedImage>
 	}
 
 	@Override
-	public void accept(BufferedImage bufferedImage)
+	public void accept(Image image)
 	{
 
 		if (!isEnforced())

--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotOverlay.java
@@ -29,6 +29,7 @@ import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.FontMetrics;
 import java.awt.Graphics2D;
+import java.awt.Image;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.text.DateFormat;
@@ -74,7 +75,7 @@ public class ScreenshotOverlay extends Overlay
 	private final Client client;
 	private final DrawManager drawManager;
 
-	private final Queue<Consumer<BufferedImage>> consumers = new ConcurrentLinkedQueue<>();
+	private final Queue<Consumer<Image>> consumers = new ConcurrentLinkedQueue<>();
 
 	@Inject
 	public ScreenshotOverlay(Client client, DrawManager drawManager)
@@ -118,7 +119,7 @@ public class ScreenshotOverlay extends Overlay
 
 		// Request the queued screenshots to be taken,
 		// now that the timestamp is visible.
-		Consumer<BufferedImage> consumer;
+		Consumer<Image> consumer;
 		while ((consumer = consumers.poll()) != null)
 		{
 			drawManager.requestNextFrameListener(consumer);
@@ -127,7 +128,7 @@ public class ScreenshotOverlay extends Overlay
 		return null;
 	}
 
-	public void queueForTimestamp(Consumer<BufferedImage> screenshotConsumer)
+	public void queueForTimestamp(Consumer<Image> screenshotConsumer)
 	{
 		if (REPORT_BUTTON == null)
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
@@ -30,6 +30,7 @@ import com.google.common.eventbus.Subscribe;
 import com.google.inject.Provides;
 import java.awt.Desktop;
 import java.awt.Graphics;
+import java.awt.Image;
 import java.awt.Toolkit;
 import java.awt.TrayIcon;
 import java.awt.datatransfer.Clipboard;
@@ -409,11 +410,11 @@ public class ScreenshotPlugin extends Plugin
 			return;
 		}
 
-		Consumer<BufferedImage> screenshotConsumer = image ->
+		Consumer<Image> screenshotConsumer = image ->
 		{
 			BufferedImage screenshot = config.includeFrame()
 				? new BufferedImage(clientUi.getWidth(), clientUi.getHeight(), BufferedImage.TYPE_INT_ARGB)
-				: new BufferedImage(image.getWidth(), image.getHeight(), BufferedImage.TYPE_INT_ARGB);
+				: new BufferedImage(image.getWidth(null), image.getHeight(null), BufferedImage.TYPE_INT_ARGB);
 
 			Graphics graphics = screenshot.getGraphics();
 

--- a/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
@@ -34,6 +34,7 @@ import java.awt.Container;
 import java.awt.Cursor;
 import java.awt.Dimension;
 import java.awt.Graphics;
+import java.awt.GraphicsConfiguration;
 import java.awt.LayoutManager;
 import java.awt.Rectangle;
 import java.awt.TrayIcon;
@@ -580,6 +581,11 @@ public class ClientUI
 		}
 
 		return new Point(0, 0);
+	}
+
+	public GraphicsConfiguration getGraphicsConfiguration()
+	{
+		return frame.getGraphicsConfiguration();
 	}
 
 	void toggleSidebar()

--- a/runelite-client/src/main/java/net/runelite/client/ui/DrawManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/DrawManager.java
@@ -24,7 +24,7 @@
  */
 package net.runelite.client.ui;
 
-import java.awt.image.BufferedImage;
+import java.awt.Image;
 import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -37,10 +37,10 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class DrawManager
 {
-	private final List<Consumer<BufferedImage>> everyFrame = new CopyOnWriteArrayList<>();
-	private final Queue<Consumer<BufferedImage>> nextFrame = new ConcurrentLinkedQueue<>();
+	private final List<Consumer<Image>> everyFrame = new CopyOnWriteArrayList<>();
+	private final Queue<Consumer<Image>> nextFrame = new ConcurrentLinkedQueue<>();
 
-	public void registerEveryFrameListener(Consumer<BufferedImage> everyFrameListener)
+	public void registerEveryFrameListener(Consumer<Image> everyFrameListener)
 	{
 		if (!everyFrame.contains(everyFrameListener))
 		{
@@ -48,19 +48,19 @@ public class DrawManager
 		}
 	}
 
-	public void unregisterEveryFrameListener(Consumer<BufferedImage> everyFrameListener)
+	public void unregisterEveryFrameListener(Consumer<Image> everyFrameListener)
 	{
 		everyFrame.remove(everyFrameListener);
 	}
 
-	public void requestNextFrameListener(Consumer<BufferedImage> nextFrameListener)
+	public void requestNextFrameListener(Consumer<Image> nextFrameListener)
 	{
 		nextFrame.add(nextFrameListener);
 	}
 
-	public void processDrawComplete(BufferedImage image)
+	public void processDrawComplete(Image image)
 	{
-		for (Consumer<BufferedImage> everyFrameListener : everyFrame)
+		for (Consumer<Image> everyFrameListener : everyFrame)
 		{
 			try
 			{
@@ -72,7 +72,7 @@ public class DrawManager
 			}
 		}
 
-		Consumer<BufferedImage> nextFrameListener = nextFrame.poll();
+		Consumer<Image> nextFrameListener = nextFrame.poll();
 		while (nextFrameListener != null)
 		{
 			try


### PR DESCRIPTION
This improves the plugin's performance significantly, by making it use your GPU instead of CPU when stretching.

**Before:**

28 fps in fullscreen

![](https://i.imgur.com/cRgcGUq.jpg)

**After:**

50 fps in fullscreen

![](https://i.imgur.com/Z6vAw9T.jpg)