### PR TITLE
XP Tracker: Add skill display options

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/SkillOrderType.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/SkillOrderType.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2018, Grant <grant.dellar@live.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.xptracker;
+
+public enum SkillOrderType
+{
+	LEAST_RECENT("Least Recent"),
+	MOST_RECENT("Most Recent"),
+	ALPHABETICAL("Alphabetical");
+
+	private final String name;
+
+	SkillOrderType(String name)
+	{
+		this.name = name;
+	}
+
+	@Override
+	public String toString()
+	{
+		return name;
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpInfoBox.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpInfoBox.java
@@ -55,6 +55,7 @@ import net.runelite.client.util.SwingUtil;
 class XpInfoBox extends JPanel
 {
 	private final JPanel panel;
+	private final XpPanel xpPanel;
 
 	@Getter(AccessLevel.PACKAGE)
 	private final Skill skill;
@@ -75,10 +76,14 @@ class XpInfoBox extends JPanel
 	private final JLabel expLeft = new JLabel();
 	private final JLabel actionsLeft = new JLabel();
 
-	XpInfoBox(XpTrackerPlugin xpTrackerPlugin, Client client, JPanel panel, Skill skill, SkillIconManager iconManager) throws IOException
+	@Getter
+	private int addedOrder = -1;
+
+	XpInfoBox(XpTrackerPlugin xpTrackerPlugin, Client client, JPanel panel, XpPanel xpPanel, Skill skill, SkillIconManager iconManager) throws IOException
 	{
 		this.panel = panel;
 		this.skill = skill;
+		this.xpPanel = xpPanel;
 
 		setLayout(new BorderLayout());
 		setBorder(new EmptyBorder(10, 0, 0, 0));
@@ -158,6 +163,22 @@ class XpInfoBox extends JPanel
 		add(container, BorderLayout.NORTH);
 	}
 
+	public static String htmlLabel(String key, int value)
+	{
+		String valueStr = value + "";
+
+		if (value > 9999999 || value < -9999999)
+		{
+			valueStr = "Lots!";
+		}
+		else
+		{
+			valueStr = StackFormatter.quantityToRSDecimalStack(value);
+		}
+
+		return "<html><body style = 'color:" + SwingUtil.toHexColor(ColorScheme.LIGHT_GRAY_COLOR) + "'>" + key + "<span style = 'color:white'>" + valueStr + "</span></body></html>";
+	}
+
 	void reset()
 	{
 		container.remove(statsPanel);
@@ -178,7 +199,10 @@ class XpInfoBox extends JPanel
 			{
 				panel.add(this);
 				panel.revalidate();
+				addedOrder = panel.getComponentCount() + 1;
 			}
+
+			xpPanel.setInfoBoxOrder(this);
 
 			// Update information labels
 			expGained.setText(htmlLabel("XP Gained: ", xpSnapshotSingle.getXpGainedInSession()));
@@ -205,21 +229,4 @@ class XpInfoBox extends JPanel
 		// Update exp per hour seperately, everytime (not only when there's an update)
 		expHour.setText(htmlLabel("XP/Hour: ", xpSnapshotSingle.getXpPerHour()));
 	}
-
-	public static String htmlLabel(String key, int value)
-	{
-		String valueStr = value + "";
-
-		if (value > 9999999 || value < -9999999)
-		{
-			valueStr = "Lots!";
-		}
-		else
-		{
-			valueStr = StackFormatter.quantityToRSDecimalStack(value);
-		}
-
-		return "<html><body style = 'color:" + SwingUtil.toHexColor(ColorScheme.LIGHT_GRAY_COLOR) + "'>" + key + "<span style = 'color:white'>" + valueStr + "</span></body></html>";
-	}
-
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpInfoBoxOrderState.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpInfoBoxOrderState.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2018, Grant <grant.dellar@live.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.xptracker;
+
+import java.awt.Component;
+import java.util.Comparator;
+import java.util.LinkedList;
+import java.util.List;
+import lombok.Getter;
+
+class XpInfoBoxOrderState
+{
+	private XpTrackerConfig config;
+	@Getter
+	private List<XpInfoBox> infoBoxes;
+	private XpInfoBox previousXpBox;
+
+	XpInfoBoxOrderState(XpTrackerConfig config)
+	{
+		this.config = config;
+	}
+
+	void reorderInfoBoxOrderState()
+	{
+		if (infoBoxes == null || previousXpBox == null)
+		{
+			return;
+		}
+
+		SkillOrderType skillOrderType = config.skillOrder();
+
+		switch (skillOrderType)
+		{
+			case LEAST_RECENT:
+				infoBoxes.sort(Comparator.comparing(XpInfoBox::getAddedOrder));
+				break;
+
+			case MOST_RECENT:
+				int newTopBoxIndex = infoBoxes.indexOf(previousXpBox);
+
+				if (newTopBoxIndex > 0)
+				{
+					XpInfoBox box = infoBoxes.remove(newTopBoxIndex);
+					infoBoxes.add(0, box);
+				}
+				break;
+
+			case ALPHABETICAL:
+				infoBoxes.sort(Comparator.comparing(box -> box.getSkill().getName()));
+				break;
+		}
+	}
+
+	void setInfoBoxOrderState(XpInfoBox infoBox, Component[] oldBoxOrder)
+	{
+		List<XpInfoBox> boxes = new LinkedList<>();
+
+		for (Component component : oldBoxOrder)
+		{
+			boxes.add((XpInfoBox) component);
+		}
+
+		infoBoxes = boxes;
+		previousXpBox = infoBox;
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpPanel.java
@@ -29,6 +29,7 @@ import java.awt.BorderLayout;
 import java.awt.GridLayout;
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import javax.swing.BoxLayout;
 import javax.swing.ImageIcon;
@@ -53,6 +54,7 @@ import okhttp3.HttpUrl;
 @Slf4j
 class XpPanel extends PluginPanel
 {
+	private final JPanel infoBoxPanel = new JPanel();
 	private final Map<Skill, XpInfoBox> infoBoxes = new HashMap<>();
 
 	private final JLabel overallExpGained = new JLabel(XpInfoBox.htmlLabel("Gained: ", 0));
@@ -63,9 +65,13 @@ class XpPanel extends PluginPanel
 	/* This displays the "No exp gained" text */
 	private final PluginErrorPanel errorPanel = new PluginErrorPanel();
 
-	XpPanel(XpTrackerPlugin xpTrackerPlugin, Client client, SkillIconManager iconManager)
+	private XpInfoBoxOrderState xpInfoBoxOrderState;
+
+	XpPanel(XpTrackerPlugin xpTrackerPlugin, Client client, SkillIconManager iconManager, XpInfoBoxOrderState xpInfoBoxOrderState)
 	{
 		super();
+
+		this.xpInfoBoxOrderState = xpInfoBoxOrderState;
 
 		setBorder(new EmptyBorder(10, 10, 10, 10));
 		setBackground(ColorScheme.DARK_GRAY_COLOR);
@@ -111,7 +117,7 @@ class XpPanel extends PluginPanel
 		overallPanel.add(overallInfo, BorderLayout.CENTER);
 
 
-		final JPanel infoBoxPanel = new JPanel();
+		infoBoxPanel.setOpaque(false);
 		infoBoxPanel.setLayout(new BoxLayout(infoBoxPanel, BoxLayout.Y_AXIS));
 		layoutPanel.add(infoBoxPanel, BorderLayout.CENTER);
 		layoutPanel.add(overallPanel, BorderLayout.NORTH);
@@ -124,7 +130,7 @@ class XpPanel extends PluginPanel
 				{
 					break;
 				}
-				infoBoxes.put(skill, new XpInfoBox(xpTrackerPlugin, client, infoBoxPanel, skill, iconManager));
+				infoBoxes.put(skill, new XpInfoBox(xpTrackerPlugin, client, infoBoxPanel, this, skill, iconManager));
 			}
 		}
 		catch (IOException e)
@@ -181,6 +187,27 @@ class XpPanel extends PluginPanel
 		}
 	}
 
+	void renderInfoBoxOrder()
+	{
+		List<XpInfoBox> xpInfoBoxes = xpInfoBoxOrderState.getInfoBoxes();
+
+		if (xpInfoBoxes == null || infoBoxPanel.getComponentCount() < 1)
+		{
+			return;
+		}
+
+		xpInfoBoxes.forEach(infoBoxPanel::add);
+
+		infoBoxPanel.revalidate();
+		infoBoxPanel.repaint();
+	}
+
+	void setInfoBoxOrder(XpInfoBox infoBox)
+	{
+		xpInfoBoxOrderState.setInfoBoxOrderState(infoBox, infoBoxPanel.getComponents());
+		xpInfoBoxOrderState.reorderInfoBoxOrderState();
+		renderInfoBoxOrder();
+	}
 
 	public void updateTotal(XpSnapshotTotal xpSnapshotTotal)
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerConfig.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2018, Grant <grant.dellar@live.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.xptracker;
+
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+
+@ConfigGroup(
+	keyName = "xpTracker",
+	name = "XP Tracker",
+	description = "Configuration for the XP Tracker plugin"
+)
+public interface XpTrackerConfig extends Config
+{
+	@ConfigItem(
+		keyName = "skillOrderType",
+		name = "Display order",
+		description = "Configures how to display the order of the skills in the XP Tracker",
+		position = 0
+	)
+	default SkillOrderType skillOrder()
+	{
+		return SkillOrderType.LEAST_RECENT;
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerPlugin.java
@@ -28,6 +28,7 @@ package net.runelite.client.plugins.xptracker;
 import static com.google.common.base.MoreObjects.firstNonNull;
 import com.google.common.eventbus.Subscribe;
 import com.google.inject.Binder;
+import com.google.inject.Provides;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.util.EnumSet;
@@ -41,9 +42,11 @@ import net.runelite.api.GameState;
 import net.runelite.api.Player;
 import net.runelite.api.Skill;
 import net.runelite.api.VarPlayer;
+import net.runelite.api.events.ConfigChanged;
 import net.runelite.api.events.ExperienceChanged;
 import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.GameTick;
+import net.runelite.client.config.ConfigManager;
 import net.runelite.client.game.SkillIconManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
@@ -62,6 +65,8 @@ import net.runelite.http.api.xp.XpClient;
 @Slf4j
 public class XpTrackerPlugin extends Plugin
 {
+	private final XpState xpState = new XpState();
+	private final XpClient xpClient = new XpClient();
 	@Inject
 	private PluginToolbar pluginToolbar;
 
@@ -76,14 +81,19 @@ public class XpTrackerPlugin extends Plugin
 
 	private NavigationButton navButton;
 	private XpPanel xpPanel;
-
-	private final XpState xpState = new XpState();
-
+	private XpInfoBoxOrderState xpInfoBoxOrderState;
 	private WorldResult worlds;
 	private XpWorldType lastWorldType;
 	private String lastUsername;
 
-	private final XpClient xpClient = new XpClient();
+	@Inject
+	private XpTrackerConfig config;
+
+	@Provides
+	XpTrackerConfig getConfig(ConfigManager configManager)
+	{
+		return configManager.getConfig(XpTrackerConfig.class);
+	}
 
 	@Override
 	public void configure(Binder binder)
@@ -112,7 +122,8 @@ public class XpTrackerPlugin extends Plugin
 			log.warn("Error looking up worlds list", e);
 		}
 
-		xpPanel = new XpPanel(this, client, skillIconManager);
+		xpInfoBoxOrderState = new XpInfoBoxOrderState(config);
+		xpPanel = new XpPanel(this, client, skillIconManager, xpInfoBoxOrderState);
 
 		BufferedImage icon;
 		synchronized (ImageIO.class)
@@ -285,6 +296,18 @@ public class XpTrackerPlugin extends Plugin
 
 		xpState.recalculateTotal();
 		xpPanel.updateTotal(xpState.getTotalSnapshot());
+	}
+
+	@Subscribe
+	public void onConfigChanged(ConfigChanged event)
+	{
+		if (!event.getGroup().equals("xpTracker"))
+		{
+			return;
+		}
+
+		xpInfoBoxOrderState.reorderInfoBoxOrderState();
+		xpPanel.renderInfoBoxOrder();
 	}
 
 	public XpSnapshotSingle getSkillSnapshot(Skill skill)


### PR DESCRIPTION
This lets the user select from three skill display order options in the XP Tracker.

- Least recent - current behaviour
- Most recent - most recent skill to gain exp goes to the top.
- Alphabetically - in case there is a preference for this.

![2018-05-20_20-44-56](https://user-images.githubusercontent.com/21123949/40277330-4994b8b6-5c71-11e8-8e2a-a00b8129d354.gif)