### PR TITLE
Weapon Charges - Iban's Staff

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/AnimationID.java
+++ b/runelite-api/src/main/java/net/runelite/api/AnimationID.java
@@ -112,6 +112,7 @@ public final class AnimationID
 	public static final int MINING_MOTHERLODE_3A = 7282;
 	public static final int HERBLORE_POTIONMAKING = 363; //used for both herb and secondary
 	public static final int MAGIC_CHARGING_ORBS = 726;
+	public static final int MAGIC_IBANS_BLAST = 708;
 	public static final int BURYING_BONES = 827;
 	public static final int LOOKING_INTO = 832;
 	public static final int DIG = 830;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/weaponcharges/ChargedWeapon.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/weaponcharges/ChargedWeapon.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2018, JerwuQu <marcus@ramse.se>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package net.runelite.client.plugins.weaponcharges;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import net.runelite.api.ItemID;
+
+@RequiredArgsConstructor
+@Getter
+public enum ChargedWeapon
+{
+	IBANS_STAFF("Iban's staff", ItemID.IBANS_STAFF, 120),
+	IBANS_STAFF_U("Iban's staff (u)", ItemID.IBANS_STAFF_U, 2500);
+
+
+	private final String itemName;
+	private final Integer itemId;
+	private final Integer rechargeAmount;
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/weaponcharges/WeaponChargesConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/weaponcharges/WeaponChargesConfig.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2018, JerwuQu <marcus@ramse.se>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package net.runelite.client.plugins.weaponcharges;
+
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+
+@ConfigGroup(
+	keyName = "weaponCharges",
+	name = "Weapon Charges",
+	description = "Configuration for the Weapon Charges plugin"
+)
+public interface WeaponChargesConfig extends Config
+{
+	@ConfigItem(
+		keyName = "showChargesOverlay",
+		name = "Show charges overlay",
+		description = "Displays amount of charges on top of the item in your inventory"
+	)
+	default boolean showChargesOverlay()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		keyName = "showChargesInfoBox",
+		name = "Show charges InfoBox",
+		description = "Displays amount of charges in an InfoBox when equipped"
+	)
+	default boolean showChargesInfoBox()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		keyName = "ibansCharges",
+		name = "",
+		description = "",
+		hidden = true
+	)
+	default int ibansCharges()
+	{
+		return -1;
+	}
+
+	@ConfigItem(
+		keyName = "ibansCharges",
+		name = "",
+		description = ""
+	)
+	void ibansCharges(int ibansCharges);
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/weaponcharges/WeaponChargesCounter.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/weaponcharges/WeaponChargesCounter.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2018, JerwuQu <marcus@ramse.se>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package net.runelite.client.plugins.weaponcharges;
+
+import java.awt.Color;
+import java.awt.image.BufferedImage;
+import lombok.Getter;
+import net.runelite.client.ui.overlay.infobox.Counter;
+
+public class WeaponChargesCounter extends Counter
+{
+	private final WeaponChargesPlugin plugin;
+
+	@Getter
+	private final ChargedWeapon chargedWeapon;
+
+	WeaponChargesCounter(BufferedImage image, WeaponChargesPlugin plugin, final ChargedWeapon chargedWeapon)
+	{
+		super(image, plugin, String.valueOf(plugin.getCharges(chargedWeapon)));
+		this.plugin = plugin;
+		this.chargedWeapon = chargedWeapon;
+	}
+
+	@Override
+	public String getText()
+	{
+		Integer charges = plugin.getCharges(chargedWeapon);
+		return charges == null ? "?" : String.valueOf(charges);
+	}
+
+	@Override
+	public Color getTextColor()
+	{
+		return plugin.getChargesColor(plugin.getCharges(chargedWeapon));
+	}
+
+	@Override
+	public String getTooltip()
+	{
+		if (plugin.getCharges(chargedWeapon) == null)
+		{
+			return "<col=ff0000>Please Check charges on your weapon";
+		}
+		else
+		{
+			return "Weapon Charges";
+		}
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/weaponcharges/WeaponChargesOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/weaponcharges/WeaponChargesOverlay.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2018, JerwuQu <marcus@ramse.se>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package net.runelite.client.plugins.weaponcharges;
+
+import java.awt.Dimension;
+import java.awt.Graphics2D;
+import java.awt.Point;
+import java.awt.Rectangle;
+import javax.inject.Inject;
+import net.runelite.api.Query;
+import net.runelite.api.queries.EquipmentItemQuery;
+import net.runelite.api.queries.InventoryWidgetItemQuery;
+import net.runelite.api.widgets.WidgetInfo;
+import net.runelite.api.widgets.WidgetItem;
+import net.runelite.client.ui.FontManager;
+import net.runelite.client.ui.overlay.Overlay;
+import net.runelite.client.ui.overlay.OverlayLayer;
+import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.components.TextComponent;
+import net.runelite.client.util.QueryRunner;
+import org.apache.commons.lang3.ArrayUtils;
+
+public class WeaponChargesOverlay extends Overlay
+{
+	private final WeaponChargesPlugin plugin;
+	private final WeaponChargesConfig config;
+	private final QueryRunner queryRunner;
+
+	private final TextComponent textComponent = new TextComponent();
+
+	@Inject
+	private WeaponChargesOverlay(WeaponChargesPlugin plugin, WeaponChargesConfig config, QueryRunner queryRunner)
+	{
+		setPosition(OverlayPosition.DYNAMIC);
+		setLayer(OverlayLayer.ABOVE_WIDGETS);
+		this.plugin = plugin;
+		this.config = config;
+		this.queryRunner = queryRunner;
+	}
+
+	@Override
+	public Dimension render(Graphics2D graphics)
+	{
+		if (!config.showChargesOverlay())
+		{
+			return null;
+		}
+
+		graphics.setFont(FontManager.getRunescapeSmallFont());
+
+		final Query inventoryQuery = new InventoryWidgetItemQuery();
+		final Query equipmentQuery = new EquipmentItemQuery().slotEquals(WidgetInfo.EQUIPMENT_WEAPON);
+		final WidgetItem[] itemSlots = ArrayUtils.addAll(queryRunner.runQuery(inventoryQuery),
+				queryRunner.runQuery(equipmentQuery));
+		for (WidgetItem item : itemSlots)
+		{
+			final ChargedWeapon chargedWeapon = plugin.getChargedWeaponFromId(item.getId());
+			if (chargedWeapon != null)
+			{
+				final Integer charges = plugin.getCharges(chargedWeapon);
+				if (charges != null)
+				{
+					final String chargesString = String.valueOf(charges);
+					int chargesStringWidth = graphics.getFontMetrics().stringWidth(chargesString);
+
+					final Rectangle bounds = item.getCanvasBounds();
+					textComponent.setPosition(new Point(bounds.x + 16 - chargesStringWidth / 2, bounds.y + 24));
+					textComponent.setText(chargesString);
+					textComponent.setColor(plugin.getChargesColor(charges));
+					textComponent.render(graphics);
+				}
+			}
+		}
+
+		return null;
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/weaponcharges/WeaponChargesPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/weaponcharges/WeaponChargesPlugin.java
@@ -1,0 +1,280 @@
+/*
+ * Copyright (c) 2018, JerwuQu <marcus@ramse.se>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package net.runelite.client.plugins.weaponcharges;
+
+import com.google.common.eventbus.Subscribe;
+import com.google.inject.Provides;
+import java.awt.Color;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import javax.inject.Inject;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.Actor;
+import net.runelite.api.AnimationID;
+import net.runelite.api.ChatMessageType;
+import net.runelite.api.Client;
+import net.runelite.api.EquipmentInventorySlot;
+import net.runelite.api.InventoryID;
+import net.runelite.api.Item;
+import net.runelite.api.ItemContainer;
+import net.runelite.api.events.AnimationChanged;
+import net.runelite.api.events.ChatMessage;
+import net.runelite.api.events.ConfigChanged;
+import net.runelite.api.events.ItemContainerChanged;
+import net.runelite.api.events.MenuOptionClicked;
+import net.runelite.client.callback.ClientThread;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.game.ItemManager;
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.ui.overlay.Overlay;
+import net.runelite.client.ui.overlay.infobox.InfoBoxManager;
+
+@PluginDescriptor(
+	name = "Weapon Charges"
+)
+@Slf4j
+public class WeaponChargesPlugin extends Plugin
+{
+	private static final int WEAPON_SLOT = EquipmentInventorySlot.WEAPON.getSlotIdx();
+	private static final Pattern ibansCheckString = Pattern.compile("You have ([0-9]+) charges left on the staff.");
+	private static final String ibansRechargeString = "You hold the staff above the well...";
+
+	private WeaponChargesCounter counter;
+
+	private ChargedWeapon rechargedWeapon;
+
+	@Inject
+	private Client client;
+
+	@Inject
+	private WeaponChargesOverlay overlay;
+
+	@Inject
+	private ItemManager itemManager;
+
+	@Inject
+	private WeaponChargesConfig config;
+
+	@Inject
+	private InfoBoxManager infoBoxManager;
+
+	@Inject
+	private ClientThread clientThread;
+
+	@Provides
+	WeaponChargesConfig getConfig(ConfigManager configManager)
+	{
+		return configManager.getConfig(WeaponChargesConfig.class);
+	}
+
+	@Override
+	protected void startUp() throws Exception
+	{
+		processChargesCounter();
+	}
+
+	@Override
+	protected void shutDown() throws Exception
+	{
+		removeChargesCounter();
+	}
+
+	@Override
+	public Overlay getOverlay()
+	{
+		return overlay;
+	}
+
+	Integer getCharges(ChargedWeapon weapon)
+	{
+		if ((weapon == ChargedWeapon.IBANS_STAFF ||
+				weapon == ChargedWeapon.IBANS_STAFF_U) &&
+				config.ibansCharges() >= 0)
+		{
+			return config.ibansCharges();
+		}
+		else
+		{
+			return null;
+		}
+	}
+
+	Color getChargesColor(Integer charges)
+	{
+		if (charges == null)
+		{
+			return Color.MAGENTA;
+		}
+		else if (charges > 100)
+		{
+			return Color.WHITE;
+		}
+		else
+		{
+			return Color.RED;
+		}
+	}
+
+	private void addChargesCounter(ChargedWeapon weapon)
+	{
+		if (counter != null)
+		{
+			if (counter.getChargedWeapon() == weapon)
+			{
+				return;
+			}
+
+			removeChargesCounter();
+		}
+
+		counter = new WeaponChargesCounter(itemManager.getImage(weapon.getItemId()), this, weapon);
+		infoBoxManager.addInfoBox(counter);
+		log.debug("Added Weapon Charges Counter");
+	}
+
+	private void removeChargesCounter()
+	{
+		if (counter != null)
+		{
+			infoBoxManager.removeInfoBox(counter);
+			counter = null;
+			log.debug("Removed Weapon Charges Counter");
+		}
+	}
+
+	private void processChargesCounter(final ItemContainer equipmentContainer)
+	{
+		final ChargedWeapon equippedWeapon = getEquippedWeapon(equipmentContainer);
+		if (config.showChargesInfoBox() && equippedWeapon != null)
+		{
+			clientThread.invokeLater(() -> addChargesCounter(equippedWeapon));
+		}
+		else
+		{
+			removeChargesCounter();
+		}
+	}
+
+	private void processChargesCounter()
+	{
+		processChargesCounter(client.getItemContainer(InventoryID.EQUIPMENT));
+	}
+
+	ChargedWeapon getChargedWeaponFromId(int itemId)
+	{
+		for (ChargedWeapon weapon : ChargedWeapon.values())
+		{
+			if (itemId == weapon.getItemId())
+			{
+				return weapon;
+			}
+		}
+
+		return null;
+	}
+
+	private ChargedWeapon getEquippedWeapon(final ItemContainer equipmentContainer)
+	{
+		if (equipmentContainer != null)
+		{
+			Item[] equippedItems = equipmentContainer.getItems();
+			if (equippedItems.length >= WEAPON_SLOT)
+			{
+				return getChargedWeaponFromId(equippedItems[WEAPON_SLOT].getId());
+			}
+		}
+
+		return null;
+	}
+
+	@Subscribe
+	private void onConfigChanged(ConfigChanged event)
+	{
+		processChargesCounter();
+	}
+
+	@Subscribe
+	public void onItemContainerChanged(final ItemContainerChanged event)
+	{
+		final ItemContainer itemContainer = event.getItemContainer();
+		if (itemContainer == client.getItemContainer(InventoryID.EQUIPMENT))
+		{
+			processChargesCounter(itemContainer);
+		}
+	}
+
+	@Subscribe
+	public void onMenuOptionClicked(MenuOptionClicked event)
+	{
+		final String menuTarget = event.getMenuTarget();
+		for (ChargedWeapon weapon : ChargedWeapon.values())
+		{
+			if (menuTarget.contains(">" + weapon.getItemName() + "<"))
+			{
+				rechargedWeapon = weapon;
+				return;
+			}
+		}
+	}
+
+	@Subscribe
+	public void onChatMessage(ChatMessage event)
+	{
+		if (event.getType() != ChatMessageType.SERVER)
+		{
+			return;
+		}
+
+		final String message = event.getMessage();
+
+		// Recharge
+		if (message.equals(ibansRechargeString))
+		{
+			config.ibansCharges(rechargedWeapon.getRechargeAmount());
+		}
+
+		// Check charges
+		final Matcher match = ibansCheckString.matcher(message);
+		if (match.find())
+		{
+			config.ibansCharges(Integer.parseInt(match.group(1)));
+		}
+	}
+
+	@Subscribe
+	public void onAnimationChanged(AnimationChanged event)
+	{
+		final Actor actor = event.getActor();
+		if (actor == client.getLocalPlayer())
+		{
+			if (actor.getAnimation() == AnimationID.MAGIC_IBANS_BLAST)
+			{
+				config.ibansCharges(config.ibansCharges() - 1);
+			}
+		}
+	}
+}


### PR DESCRIPTION
## This is a recreation of #1494 for the May 16 changes
Please see that PR for discussion

---

As suggested in #1408

Shows the remaining charges for Iban's Staff.

This is what it looks like in inventory:
![image](https://user-images.githubusercontent.com/3710677/38773684-2ac97f6e-4053-11e8-9317-5dc4f5b2a04d.png)

InfoBox counter when equipped:
![image](https://user-images.githubusercontent.com/3710677/38773694-55046d02-4053-11e8-9f34-b442d5ea0174.png)

There are settings for disabling both inventory overlay and the infobox.

The charges are counted using the cast animation and are reset upon using the staff on the well.

Heavily tested with Iban's Staff (u) and works well.

