### PR TITLE
Clear plugin skill tracking on reset

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpInfoBox.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpInfoBox.java
@@ -54,7 +54,6 @@ import net.runelite.client.util.SwingUtil;
 @Slf4j
 class XpInfoBox extends JPanel
 {
-	private final Client client;
 	private final JPanel panel;
 
 	@Getter(AccessLevel.PACKAGE)
@@ -78,7 +77,6 @@ class XpInfoBox extends JPanel
 
 	XpInfoBox(XpTrackerPlugin xpTrackerPlugin, Client client, JPanel panel, Skill skill, SkillIconManager iconManager) throws IOException
 	{
-		this.client = client;
 		this.panel = panel;
 		this.skill = skill;
 
@@ -96,7 +94,7 @@ class XpInfoBox extends JPanel
 
 		// Create reset menu
 		final JMenuItem reset = new JMenuItem("Reset");
-		reset.addActionListener(e -> reset());
+		reset.addActionListener(e -> xpTrackerPlugin.resetSkillState(skill));
 
 		// Create popup menu
 		final JPopupMenu popupMenu = new JPopupMenu();


### PR DESCRIPTION
Instead of calling `reset`, which just clears the skill info box from the UI.

Also removed an unused `client` field as a fly-by.