### PR TITLE
UI element mouse hover improvements

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
@@ -37,6 +37,7 @@ import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
+import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.util.Comparator;
 import java.util.Map;
@@ -80,6 +81,7 @@ import net.runelite.client.ui.DynamicGridLayout;
 import net.runelite.client.ui.PluginPanel;
 import net.runelite.client.ui.components.ComboBoxListRenderer;
 import net.runelite.client.ui.components.IconTextField;
+import net.runelite.client.util.SwingUtil;
 
 @Slf4j
 public class ConfigPanel extends PluginPanel
@@ -88,6 +90,7 @@ public class ConfigPanel extends PluginPanel
 	private static final int SPINNER_FIELD_WIDTH = 6;
 
 	private static final ImageIcon CONFIG_ICON;
+	private static final ImageIcon CONFIG_ICON_HOVER;
 	private static final ImageIcon ON_SWITCHER;
 	private static final ImageIcon OFF_SWITCHER;
 	private static final ImageIcon SEARCH;
@@ -98,7 +101,9 @@ public class ConfigPanel extends PluginPanel
 		{
 			synchronized (ImageIO.class)
 			{
-				CONFIG_ICON = new ImageIcon(ImageIO.read(ConfigPanel.class.getResourceAsStream("config_edit_icon.png")));
+				BufferedImage configIcon = ImageIO.read(ConfigPanel.class.getResourceAsStream("config_edit_icon.png"));
+				CONFIG_ICON = new ImageIcon(configIcon);
+				CONFIG_ICON_HOVER = new ImageIcon(SwingUtil.grayscaleOffset(configIcon, -100));
 				ON_SWITCHER = new ImageIcon(ImageIO.read(ConfigPanel.class.getResourceAsStream("switchers/on.png")));
 				OFF_SWITCHER = new ImageIcon(ImageIO.read(ConfigPanel.class.getResourceAsStream("switchers/off.png")));
 				SEARCH = new ImageIcon(ImageIO.read(IconTextField.class.getResourceAsStream("search.png")));
@@ -246,7 +251,20 @@ public class ConfigPanel extends PluginPanel
 					@Override
 					public void mousePressed(MouseEvent mouseEvent)
 					{
+						editConfigButton.setIcon(CONFIG_ICON);
 						openGroupConfigPanel(config, configDescriptor, configManager);
+					}
+
+					@Override
+					public void mouseEntered(MouseEvent e)
+					{
+						editConfigButton.setIcon(CONFIG_ICON_HOVER);
+					}
+
+					@Override
+					public void mouseExited(MouseEvent e)
+					{
+						editConfigButton.setIcon(CONFIG_ICON);
 					}
 				});
 				editConfigButton.setVisible(true);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/farmingtracker/FarmingTrackerPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/farmingtracker/FarmingTrackerPanel.java
@@ -31,6 +31,8 @@ import java.awt.Dimension;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Image;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
 import java.awt.image.BufferedImage;
 import java.time.Instant;
 import java.time.LocalDateTime;
@@ -185,6 +187,20 @@ class FarmingTrackerPanel extends PluginPanel
 			resize.run();
 
 			materialTab.setOnSelectEvent(() -> config.setPatch(tab));
+			materialTab.addMouseListener(new MouseAdapter()
+			{
+				@Override
+				public void mouseEntered(MouseEvent e)
+				{
+					materialTab.setBackground(ColorScheme.DARKER_GRAY_HOVER_COLOR);
+				}
+
+				@Override
+				public void mouseExited(MouseEvent e)
+				{
+					materialTab.setBackground(ColorScheme.DARKER_GRAY_COLOR);
+				}
+			});
 
 			tabGroup.addTab(materialTab);
 			if (config.patch() == tab)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/feed/FeedPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/feed/FeedPanel.java
@@ -27,6 +27,7 @@ package net.runelite.client.plugins.feed;
 
 import java.awt.BorderLayout;
 import java.awt.Color;
+import java.awt.Cursor;
 import java.awt.Dimension;
 import java.awt.Font;
 import java.awt.GridLayout;
@@ -328,12 +329,14 @@ class FeedPanel extends PluginPanel
 			public void mouseEntered(MouseEvent e)
 			{
 				avatarAndRight.setBackground(hoverColor);
+				avatarAndRight.setCursor(new Cursor(Cursor.HAND_CURSOR));
 			}
 
 			@Override
 			public void mouseExited(MouseEvent e)
 			{
 				avatarAndRight.setBackground(backgroundColor);
+				avatarAndRight.setCursor(new Cursor(Cursor.DEFAULT_CURSOR));
 			}
 
 			@Override

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangeItemPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangeItemPanel.java
@@ -27,6 +27,8 @@ package net.runelite.client.plugins.grandexchange;
 
 import java.awt.BorderLayout;
 import java.awt.Color;
+import java.awt.Component;
+import java.awt.Cursor;
 import java.awt.Dimension;
 import java.awt.GridLayout;
 import java.awt.event.MouseAdapter;
@@ -65,13 +67,23 @@ class GrandExchangeItemPanel extends JPanel
 			@Override
 			public void mouseEntered(MouseEvent e)
 			{
-				setBackground(getBackground().brighter());
+				setBackground(background.brighter());
+				for (Component component : getComponents())
+				{
+					component.setBackground(component.getBackground().brighter());
+				}
+				setCursor(new Cursor(Cursor.HAND_CURSOR));
 			}
 
 			@Override
 			public void mouseExited(MouseEvent e)
 			{
 				setBackground(background);
+				for (Component component : getComponents())
+				{
+					component.setBackground(background);
+				}
+				setCursor(new Cursor(Cursor.DEFAULT_CURSOR));
 			}
 
 			@Override

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangePanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangePanel.java
@@ -27,6 +27,9 @@
 package net.runelite.client.plugins.grandexchange;
 
 import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
 import java.util.concurrent.ScheduledExecutorService;
 import javax.inject.Inject;
 import javax.swing.JPanel;
@@ -71,6 +74,29 @@ class GrandExchangePanel extends PluginPanel
 
 		MaterialTab offersTab = new MaterialTab("Offers", tabGroup, offersPanel);
 		searchTab = new MaterialTab("Search", tabGroup, searchPanel);
+
+		MouseAdapter materialTabMouseAdapter = new MouseAdapter()
+		{
+			@Override
+			public void mouseEntered(MouseEvent e)
+			{
+				MaterialTab tab = (MaterialTab)e.getSource();
+				tab.setForeground(Color.WHITE);
+			}
+
+			@Override
+			public void mouseExited(MouseEvent e)
+			{
+				MaterialTab tab = (MaterialTab)e.getSource();
+				if (!tab.isSelected())
+				{
+					tab.setForeground(Color.GRAY);
+				}
+			}
+		};
+
+		searchTab.addMouseListener(materialTabMouseAdapter);
+		offersTab.addMouseListener(materialTabMouseAdapter);
 
 		tabGroup.setBorder(new EmptyBorder(5, 0, 0, 0));
 		tabGroup.addTab(offersTab);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/hiscore/HiscorePanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/hiscore/HiscorePanel.java
@@ -251,6 +251,18 @@ public class HiscorePanel extends PluginPanel
 						selectedEndPoint = endpoint;
 						updateButtons();
 					}
+
+					@Override
+					public void mouseEntered(MouseEvent e)
+					{
+						panel.setBackground(ColorScheme.DARKER_GRAY_HOVER_COLOR);
+					}
+
+					@Override
+					public void mouseExited(MouseEvent e)
+					{
+						panel.setBackground(ColorScheme.DARKER_GRAY_COLOR);
+					}
 				});
 
 				endPoints.add(panel);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/info/InfoPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/info/InfoPanel.java
@@ -30,6 +30,7 @@ import com.google.common.eventbus.Subscribe;
 import com.google.inject.Inject;
 import java.awt.BorderLayout;
 import java.awt.Color;
+import java.awt.Cursor;
 import java.awt.Font;
 import java.awt.GridLayout;
 import java.awt.event.MouseAdapter;
@@ -180,14 +181,9 @@ public class InfoPanel extends PluginPanel
 		container.setBackground(ColorScheme.DARKER_GRAY_COLOR);
 		container.setLayout(new BorderLayout());
 		container.setBorder(new EmptyBorder(10, 10, 10, 10));
-		container.addMouseListener(new MouseAdapter()
-		{
-			@Override
-			public void mousePressed(MouseEvent mouseEvent)
-			{
-				LinkBrowser.browse(url);
-			}
-		});
+
+		final Color hoverColor = ColorScheme.DARKER_GRAY_HOVER_COLOR;
+		final Color pressedColor = ColorScheme.DARKER_GRAY_COLOR.brighter();
 
 		JLabel iconLabel = new JLabel(icon);
 		container.add(iconLabel, BorderLayout.WEST);
@@ -196,6 +192,40 @@ public class InfoPanel extends PluginPanel
 		textContainer.setBackground(ColorScheme.DARKER_GRAY_COLOR);
 		textContainer.setLayout(new GridLayout(2, 1));
 		textContainer.setBorder(new EmptyBorder(5, 10, 5, 10));
+
+		container.addMouseListener(new MouseAdapter()
+		{
+			@Override
+			public void mousePressed(MouseEvent mouseEvent)
+			{
+				LinkBrowser.browse(url);
+				container.setBackground(pressedColor);
+				textContainer.setBackground(pressedColor);
+			}
+
+			@Override
+			public void mouseReleased(MouseEvent e)
+			{
+				container.setBackground(hoverColor);
+				textContainer.setBackground(hoverColor);
+			}
+
+			@Override
+			public void mouseEntered(MouseEvent e)
+			{
+				container.setBackground(hoverColor);
+				textContainer.setBackground(hoverColor);
+				container.setCursor(new Cursor(Cursor.HAND_CURSOR));
+			}
+
+			@Override
+			public void mouseExited(MouseEvent e)
+			{
+				container.setBackground(ColorScheme.DARKER_GRAY_COLOR);
+				textContainer.setBackground(ColorScheme.DARKER_GRAY_COLOR);
+				container.setCursor(new Cursor(Cursor.DEFAULT_CURSOR));
+			}
+		});
 
 		JLabel topLine = new JLabel(topText);
 		topLine.setForeground(Color.WHITE);

--- a/runelite-client/src/main/java/net/runelite/client/util/SwingUtil.java
+++ b/runelite-client/src/main/java/net/runelite/client/util/SwingUtil.java
@@ -288,6 +288,14 @@ public class SwingUtil
 		});
 	}
 
+	/**
+	 * Re-size a BufferedImage to the given dimensions.
+	 *
+	 * @param image the BufferedImage.
+	 * @param newWidth The width to set the BufferedImage to.
+	 * @param newHeight The height to set the BufferedImage to.
+	 * @return The BufferedImage with the specified dimensions
+	 */
 	private static BufferedImage resizeImage(BufferedImage image, int newWidth, int newHeight)
 	{
 		final Image tmp = image.getScaledInstance(newWidth, newHeight, Image.SCALE_SMOOTH);


### PR DESCRIPTION
The aim of this pull request is to improve the ui experience by providing visual feedback when certain ui elements are hovered by the mouse. Some elements did this but others didn't!

The info plugin panel containers now behave more like buttons:
(ignore the pointer going transparent, that's a gyazo issue)
<img src="https://i.gyazo.com/31ec173f3000c0fda9d1a3619707758e.gif" />

Changes the mouse to a pointer to help indicate the news items are hyperlinks:
(ignore the pointer going transparent, that's a gyazo issue)
<img src="https://i.gyazo.com/68e796f4e84ebd6c0ae957f2b6759836.gif" />

The highscore panel buttons highlight on hover to help indicate they are hovered and clickable:
<img src="https://i.gyazo.com/e471d18b2cb8a2e4ce112c1dbe20c2b9.gif" />

Same with the farming panel buttons:
<img src="https://i.gyazo.com/154aac41ae6c6929779e2b5724a63afa.gif" />

Same with the GE panel:
<img src="https://i.gyazo.com/370f571ad96503ea183263e824918832.gif" />

Changes the cogs in the config panel to change when hovered to help indicate that they are hovered and clickable:
<img src="https://i.gyazo.com/35980e82da6c75f11bd83b94d673e5e1.gif" />

@psikoi 
