### PR TITLE
Add Low Energy Notification

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierConfig.java
@@ -89,4 +89,15 @@ public interface IdleNotifierConfig extends Config
 	{
 		return 0;
 	}
+
+	@ConfigItem(
+		keyName = "energy",
+		name = "Energy Notification Threshold",
+		description = "The amount of energy points to send a notification at. A value of 0 will disable notification.",
+		position = 6
+	)
+	default int getEnergyThreshold()
+	{
+		return 0;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
@@ -68,6 +68,7 @@ public class IdleNotifierPlugin extends Plugin
 	private boolean notifyIdle = false;
 	private boolean notifyHitpoints = true;
 	private boolean notifyPrayer = true;
+	private boolean notifyEnergy = true;
 	private boolean notifyIdleLogout = true;
 	private boolean notify6HourLogout = true;
 
@@ -251,6 +252,11 @@ public class IdleNotifierPlugin extends Plugin
 		{
 			notifier.notify("[" + local.getName() + "] has low prayer!");
 		}
+
+		if (checkLowEnergy())
+		{
+			notifier.notify("[" + local.getName() + "] has low run energy!");
+		}
 	}
 
 	private boolean checkLowHitpoints()
@@ -298,6 +304,29 @@ public class IdleNotifierPlugin extends Plugin
 			{
 				notifyPrayer = false;
 			}
+		}
+
+		return false;
+	}
+
+	private boolean checkLowEnergy()
+	{
+		if (config.getEnergyThreshold() == 0)
+		{
+			return false;
+		}
+
+		if (client.getEnergy() <= config.getEnergyThreshold())
+		{
+			if (!notifyEnergy)
+			{
+				notifyEnergy = true;
+				return true;
+			}
+		}
+		else
+		{
+			notifyEnergy = false;
 		}
 
 		return false;


### PR DESCRIPTION
As requested in issue: [#3057](https://github.com/runelite/runelite/issues/3057)

This will allow the user to set a threshold for run energy to be notified of.