### PR TITLE
Change Anti-Drag plugin to work only with SHIFT

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/antidrag/AntiDragConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/antidrag/AntiDragConfig.java
@@ -29,9 +29,9 @@ import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
 
 @ConfigGroup(
-	keyName = AntiDragPlugin.CONFIG_GROUP,
+	keyName = "antiDrag",
 	name = "Anti Drag",
-	description = "Configuration for the anti drag plugin"
+	description = "Configuration for the anti drag plugin (shift only)"
 )
 public interface AntiDragConfig extends Config
 {
@@ -52,15 +52,4 @@ public interface AntiDragConfig extends Config
 		description = ""
 	)
 	void dragDelay(int delay);
-
-	@ConfigItem(
-		keyName = "onShiftOnly",
-		name = "On Shift Only",
-		description = "Configures whether to only adjust the delay while holding shift",
-		position = 2
-	)
-	default boolean onShiftOnly()
-	{
-		return true;
-	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/antidrag/AntiDragPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/antidrag/AntiDragPlugin.java
@@ -24,27 +24,20 @@
  */
 package net.runelite.client.plugins.antidrag;
 
-import com.google.common.eventbus.Subscribe;
 import com.google.inject.Provides;
+import java.awt.event.KeyEvent;
+import javax.inject.Inject;
 import net.runelite.api.Client;
-import net.runelite.api.events.ConfigChanged;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.input.KeyListener;
 import net.runelite.client.input.KeyManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
-import javax.inject.Inject;
-import java.awt.event.KeyEvent;
 
-@PluginDescriptor(
-	name = "Anti Drag",
-	enabledByDefault = false
-)
+@PluginDescriptor(name = "Shift Anti Drag")
 public class AntiDragPlugin extends Plugin implements KeyListener
 {
-	static final String CONFIG_GROUP = "antiDrag";
-
-	static final int DEFAULT_DELAY = 5;
+	private static final int DEFAULT_DELAY = 5;
 
 	@Inject
 	private Client client;
@@ -64,10 +57,6 @@ public class AntiDragPlugin extends Plugin implements KeyListener
 	@Override
 	protected void startUp() throws Exception
 	{
-		if (!config.onShiftOnly())
-		{
-			client.setInventoryDragDelay(config.dragDelay());
-		}
 		keyManager.registerKeyListener(this);
 	}
 
@@ -87,7 +76,7 @@ public class AntiDragPlugin extends Plugin implements KeyListener
 	@Override
 	public void keyPressed(KeyEvent e)
 	{
-		if (config.onShiftOnly() && e.getKeyCode() == KeyEvent.VK_SHIFT)
+		if (e.getKeyCode() == KeyEvent.VK_SHIFT)
 		{
 			client.setInventoryDragDelay(config.dragDelay());
 		}
@@ -96,25 +85,9 @@ public class AntiDragPlugin extends Plugin implements KeyListener
 	@Override
 	public void keyReleased(KeyEvent e)
 	{
-		if (config.onShiftOnly() && e.getKeyCode() == KeyEvent.VK_SHIFT)
+		if (e.getKeyCode() == KeyEvent.VK_SHIFT)
 		{
 			client.setInventoryDragDelay(DEFAULT_DELAY);
-		}
-	}
-
-	@Subscribe
-	public void onConfigChanged(ConfigChanged event)
-	{
-		if (event.getGroup().equals(CONFIG_GROUP))
-		{
-			if (config.onShiftOnly())
-			{
-				client.setInventoryDragDelay(DEFAULT_DELAY);
-			}
-			else
-			{
-				client.setInventoryDragDelay(config.dragDelay());
-			}
 		}
 	}
 }


### PR DESCRIPTION
Due to complains in PKing community, nerf this feature to work exactly
like its counterpart in other clients and make it work only when SHIFT
key is pressed.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>