### PR TITLE
Make the Clue Scroll World Map icon stay inside the bounds of the map

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/worldmap/WorldMapOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/worldmap/WorldMapOverlay.java
@@ -176,8 +176,24 @@ public class WorldMapOverlay extends Overlay
 
 				if (worldPoint.getImagePoint() == null)
 				{
-					drawX -= image.getWidth() / 2;
-					drawY -= image.getHeight() / 2;
+					if (worldPoint.isCurrentlyEdgeSnapped())
+					{
+						switch (worldPoint.getSnappedEdge())
+						{
+							case BOTTOM:
+							case BOTTOM_LEFT:
+								drawY -= image.getHeight();
+								break;
+							case RIGHT:
+							case TOP_RIGHT:
+								drawX -= image.getWidth();
+								break;
+							case BOTTOM_RIGHT:
+								drawX -= image.getWidth();
+								drawY -= image.getHeight();
+								break;
+						}
+					}
 				}
 				else
 				{

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/worldmap/WorldMapOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/worldmap/WorldMapOverlay.java
@@ -126,11 +126,44 @@ public class WorldMapOverlay extends Overlay
 					else
 					{
 						drawPoint = clipToRectangle(drawPoint, worldMapRectangle);
-						if (!worldPoint.isCurrentlyEdgeSnapped())
+						WorldMapSnapEdge[] edges = new WorldMapSnapEdge[]{WorldMapSnapEdge.NONE, WorldMapSnapEdge.NONE};
+						if (drawPoint.getX() <= worldMapRectangle.x)
+						{
+							edges[0] = WorldMapSnapEdge.LEFT;
+						}
+						else if (drawPoint.getX() + image.getWidth() / 2 >= worldMapRectangle.width)
+						{
+							edges[0] = WorldMapSnapEdge.RIGHT;
+						}
+
+						if (drawPoint.getY() <= worldMapRectangle.y)
+						{
+							edges[1] = WorldMapSnapEdge.TOP;
+						}
+						else if (drawPoint.getY() + image.getHeight() / 2 >= worldMapRectangle.height)
+						{
+							edges[1] = WorldMapSnapEdge.BOTTOM;
+						}
+
+						WorldMapSnapEdge newEdge = WorldMapSnapEdge.combineEdges(edges[1], edges[0]);
+
+						if (worldPoint.isCurrentlyEdgeSnapped())
+						{
+							WorldMapSnapEdge oldEdge = worldPoint.getSnappedEdge();
+							worldPoint.setSnappedEdge(newEdge);
+
+							if (oldEdge != newEdge)
+							{
+								worldPoint.onSnapEdgeChanged(newEdge);
+							}
+						}
+						else
 						{
 							worldPoint.setCurrentlyEdgeSnapped(true);
+							worldPoint.onSnapEdgeChanged(newEdge);
 							worldPoint.onEdgeSnap();
 						}
+						worldPoint.setSnappedEdge(newEdge);
 					}
 				}
 				else

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/worldmap/WorldMapOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/worldmap/WorldMapOverlay.java
@@ -126,26 +126,27 @@ public class WorldMapOverlay extends Overlay
 					else
 					{
 						drawPoint = clipToRectangle(drawPoint, worldMapRectangle);
-						WorldMapSnapEdge[] edges = new WorldMapSnapEdge[]{WorldMapSnapEdge.NONE, WorldMapSnapEdge.NONE};
+						WorldMapSnapEdge horizontalEdge = WorldMapSnapEdge.NONE;
+						WorldMapSnapEdge verticalEdge = WorldMapSnapEdge.NONE;
 						if (drawPoint.getX() <= worldMapRectangle.x)
 						{
-							edges[0] = WorldMapSnapEdge.LEFT;
+							horizontalEdge = WorldMapSnapEdge.LEFT;
 						}
 						else if (drawPoint.getX() + image.getWidth() / 2 >= worldMapRectangle.width)
 						{
-							edges[0] = WorldMapSnapEdge.RIGHT;
+							horizontalEdge = WorldMapSnapEdge.RIGHT;
 						}
 
 						if (drawPoint.getY() <= worldMapRectangle.y)
 						{
-							edges[1] = WorldMapSnapEdge.TOP;
+							verticalEdge = WorldMapSnapEdge.TOP;
 						}
 						else if (drawPoint.getY() + image.getHeight() / 2 >= worldMapRectangle.height)
 						{
-							edges[1] = WorldMapSnapEdge.BOTTOM;
+							verticalEdge = WorldMapSnapEdge.BOTTOM;
 						}
 
-						WorldMapSnapEdge newEdge = WorldMapSnapEdge.combineEdges(edges[1], edges[0]);
+						WorldMapSnapEdge newEdge = WorldMapSnapEdge.combineEdges(verticalEdge, horizontalEdge);
 
 						if (worldPoint.isCurrentlyEdgeSnapped())
 						{

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/worldmap/WorldMapPoint.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/worldmap/WorldMapPoint.java
@@ -50,6 +50,8 @@ public class WorldMapPoint
 
 	private boolean currentlyEdgeSnapped;
 
+	private WorldMapSnapEdge snappedEdge;
+
 	/**
 	 * Whether or not the map jumps to worldPoint when the overlay is clicked
 	 */
@@ -75,6 +77,10 @@ public class WorldMapPoint
 	}
 
 	public void onEdgeUnsnap()
+	{
+	}
+
+	public void onSnapEdgeChanged(WorldMapSnapEdge newEdge)
 	{
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/worldmap/WorldMapSnapEdge.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/worldmap/WorldMapSnapEdge.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2018, Hydrox6 <ikada@protonmail.ch>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.ui.overlay.worldmap;
+
+public enum WorldMapSnapEdge
+{
+	NONE,
+	LEFT,
+	RIGHT,
+	TOP,
+	TOP_LEFT,
+	TOP_RIGHT,
+	BOTTOM,
+	BOTTOM_LEFT,
+	BOTTOM_RIGHT;
+
+	public WorldMapSnapEdge increment(int x)
+	{
+		return values()[ordinal() + x];
+	}
+
+	public static WorldMapSnapEdge combineEdges(WorldMapSnapEdge old, WorldMapSnapEdge addition)
+	{
+		if (old == NONE)
+		{
+			return addition;
+		}
+		if (addition == NONE)
+		{
+			return old;
+		}
+
+		return old.increment(addition.ordinal());
+	}
+}


### PR DESCRIPTION
Doing this increases visibility, as currently the clue is hanging off the edge.

To do this, I've also made it so `WorldMapPoint`s know what edge they are snapped to at the current moment, with a relevant function that is called when it changes, `onSnapEdgeChanged`

Before:
![runelite_2018-05-22_15-36-13](https://user-images.githubusercontent.com/2979691/40369592-32cf644e-5dd6-11e8-8a65-4a7370d0e7f0.png)

After:
![java_2018-05-22_15-39-53](https://user-images.githubusercontent.com/2979691/40369662-64189cf0-5dd6-11e8-9671-6a84b39c3bd5.png)

Gif of the change in action ([click here for a higher resolution](https://gfycat.com/LinedEminentIndochinesetiger)):
![](https://thumbs.gfycat.com/LinedEminentIndochinesetiger-size_restricted.gif)

I know it's a little glitchy, but for the life of me I can't figure out exactly what's causing those jumps. However, it does the job of keeping the clue scroll icon on the screen