### PR TITLE
Motherlode Mine - Startup / shutdown bugs

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/motherlode/MotherlodePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/motherlode/MotherlodePlugin.java
@@ -67,6 +67,8 @@ import net.runelite.api.events.VarbitChanged;
 import net.runelite.api.events.WallObjectChanged;
 import net.runelite.api.events.WallObjectDespawned;
 import net.runelite.api.events.WallObjectSpawned;
+import net.runelite.api.widgets.Widget;
+import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
@@ -137,10 +139,22 @@ public class MotherlodePlugin extends Plugin
 		return Arrays.asList(overlay, rocksOverlay, motherlodeSackOverlay, motherlodeGemOverlay);
 	}
 
+	private void refreshSackValues()
+	{
+		curSackSize = client.getVar(Varbits.SACK_NUMBER);
+		boolean sackUpgraded = client.getVar(Varbits.SACK_UPGRADED) == 1;
+		maxSackSize = sackUpgraded ? SACK_LARGE_SIZE : SACK_SIZE;
+	}
+
 	@Override
 	protected void startUp()
 	{
 		inMlm = checkInMlm();
+
+		if (inMlm)
+		{
+			refreshSackValues();
+		}
 	}
 
 	@Override
@@ -148,6 +162,13 @@ public class MotherlodePlugin extends Plugin
 	{
 		veins.clear();
 		rocks.clear();
+
+		Widget sack = client.getWidget(WidgetInfo.MOTHERLODE_MINE);
+
+		if (sack != null && sack.isHidden())
+		{
+			sack.setHidden(false);
+		}
 	}
 
 	public MotherlodeSession getSession()
@@ -160,9 +181,7 @@ public class MotherlodePlugin extends Plugin
 	{
 		if (inMlm)
 		{
-			curSackSize = client.getVar(Varbits.SACK_NUMBER);
-			boolean sackUpgraded = client.getVar(Varbits.SACK_UPGRADED) == 1;
-			maxSackSize = sackUpgraded ? SACK_LARGE_SIZE : SACK_SIZE;
+			refreshSackValues();
 		}
 	}
 


### PR DESCRIPTION
This commit fixes two small bugs in the Motherlode Mine plugin.

1. When starting the Motherlode Mine plugin for the first time inside
MLM, the sack overlay will be colored red because the sack values are
set to 0. Changed so the plugin refreshes the sack values on startup.

2. When stopping the plugin, the sack widget will stay hidden. This
calls sack.setHidden(false) on plugin shutdown.