### PR TITLE
Skill Calc - Fix combined action slot not updating when an input field was changed

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/SkillCalculator.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/SkillCalculator.java
@@ -227,6 +227,8 @@ class SkillCalculator extends JPanel
 			slot.setAvailable(currentLevel >= slot.action.level);
 			slot.value = xp;
 		}
+
+		updateCombinedAction();
 	}
 
 	private String formatXPActionString(double xp, int actionCount)


### PR DESCRIPTION
The top action (Combined action slot) was not being updated when you changed a target level or exp. This fixes that.