### PR TITLE
runelite-client: Require assertions when developer mode is on

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/RuneLite.java
+++ b/runelite-client/src/main/java/net/runelite/client/RuneLite.java
@@ -146,6 +146,16 @@ public class RuneLite
 			System.exit(0);
 		}
 
+		if (RuneLite.getOptions().has("developer-mode"))
+		{
+			boolean assertions = false;
+			assert assertions = true;
+			if (!assertions)
+			{
+				throw new RuntimeException("Developers should enable assertions; Add `-ea` to your JVM arguments`");
+			}
+		}
+
 		PROFILES_DIR.mkdirs();
 
 		// Setup logger


### PR DESCRIPTION
Because we now have several thread checks that use assertions, but not many people have assertions on, so we keep getting code with threading problems that no one notices.

If for some reason you need developer mode with assertions disabled you can add `-ea:net.runelite.client.RuneLite` to your JVM params