### PR TITLE
Fix soft-crash for GE and highscore plugin on bad character input

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangeSearchPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangeSearchPanel.java
@@ -36,6 +36,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.regex.Pattern;
 import javax.imageio.ImageIO;
 import javax.swing.ImageIcon;
 import javax.swing.JPanel;
@@ -67,6 +68,8 @@ class GrandExchangeSearchPanel extends JPanel
 	private static final ImageIcon SEARCH_ICON;
 	private static final ImageIcon LOADING_ICON;
 	private static final ImageIcon ERROR_ICON;
+
+	private static final Pattern PATTERN = Pattern.compile("^[A-Za-z0-9_\\s'()\"-]*$");
 
 	private final GridBagConstraints constraints = new GridBagConstraints();
 	private final CardLayout cardLayout = new CardLayout();
@@ -188,6 +191,17 @@ class GrandExchangeSearchPanel extends JPanel
 			return;
 		}
 
+		// If the input contains characters not part of the pattern
+		// then show an error. This is to prevent bad lookups that can
+		// cause an npe and therefore soft-crash the plugin
+		if (!PATTERN.matcher(lookup).matches())
+		{
+			searchBox.setIcon(ERROR_ICON);
+			errorPanel.setContent("No results found.", "No items were found with that name, please try again.");
+			cardLayout.show(centerPanel, ERROR_PANEL);
+			return;
+		}
+
 		// Input is not empty, add searching label
 		searchItemsPanel.removeAll();
 		searchBox.setBackground(ColorScheme.MEDIUM_GRAY_COLOR);
@@ -205,7 +219,7 @@ class GrandExchangeSearchPanel extends JPanel
 			log.warn("Unable to search for item {}", lookup, ex);
 			searchBox.setIcon(ERROR_ICON);
 			searchBox.setEditable(true);
-			errorPanel.setContent("Error fetching results", "An error occured why trying to fetch item data, please try again later.");
+			errorPanel.setContent("Error fetching results", "An error occurred why trying to fetch item data, please try again later.");
 			cardLayout.show(centerPanel, ERROR_PANEL);
 			return;
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/hiscore/HiscorePanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/hiscore/HiscorePanel.java
@@ -40,6 +40,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.regex.Pattern;
 import javax.annotation.Nullable;
 import javax.imageio.ImageIO;
 import javax.inject.Inject;
@@ -101,6 +102,8 @@ public class HiscorePanel extends PluginPanel
 	private static final ImageIcon SEARCH_ICON;
 	private static final ImageIcon LOADING_ICON;
 	private static final ImageIcon ERROR_ICON;
+
+	private static final Pattern PATTERN = Pattern.compile("^[A-Za-z0-9_\\s-]*$");
 
 	/**
 	 * Real skills, ordered in the way they should be displayed in the panel.
@@ -394,8 +397,10 @@ public class HiscorePanel extends PluginPanel
 			return;
 		}
 
-		/* Runescape usernames can't be longer than 12 characters long */
-		if (lookup.length() > MAX_USERNAME_LENGTH)
+		// Runescape usernames can't be longer than 12 characters long and
+		// only lookup if input is a set of valid characters to prevent bad character lookups,
+		// as this can cause a soft-crash.
+		if (lookup.length() > MAX_USERNAME_LENGTH || !PATTERN.matcher(lookup).matches())
 		{
 			input.setIcon(ERROR_ICON);
 			loading = false;


### PR DESCRIPTION
Addresses https://github.com/runelite/runelite/issues/3093.

If some special characters are entered as a lookup for the highscores or the GE search plugin, then the plugin can "soft-crash", requiring a client restart to get the plugin to work again.
This aims to fix this by checking the input using regex. If the input doesn't match the allowed characters then just stop the look-up (and _show_ some error).

I'm definitely open to any feedback on the regex patterns! 