### PR TITLE
Add kills left to xp tracker and globe

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/interfacestyles/InterfaceStylesPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/interfacestyles/InterfaceStylesPlugin.java
@@ -44,6 +44,7 @@ import net.runelite.api.events.ConfigChanged;
 import net.runelite.api.events.WidgetPositioned;
 import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetInfo;
+import net.runelite.client.callback.ClientThread;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.game.SpriteManager;
 import net.runelite.client.plugins.Plugin;
@@ -60,6 +61,9 @@ public class InterfaceStylesPlugin extends Plugin
 	private Client client;
 
 	@Inject
+	private ClientThread clientThread;
+
+	@Inject
 	private InterfaceStylesConfig config;
 
 	@Inject
@@ -74,17 +78,23 @@ public class InterfaceStylesPlugin extends Plugin
 	@Override
 	protected void startUp() throws Exception
 	{
-		overrideSprites();
-		overrideWidgetSprites();
-		restoreWidgetDimensions();
-		adjustWidgetDimensions();
+		clientThread.invokeLater(() ->
+		{
+			overrideSprites();
+			overrideWidgetSprites();
+			restoreWidgetDimensions();
+			adjustWidgetDimensions();
+		});
 	}
 
 	@Override
 	protected void shutDown() throws Exception
 	{
-		restoreWidgetDimensions();
-		removeGameframe();
+		clientThread.invokeLater(() ->
+		{
+			restoreWidgetDimensions();
+			removeGameframe();
+		});
 	}
 
 	@Subscribe
@@ -92,11 +102,14 @@ public class InterfaceStylesPlugin extends Plugin
 	{
 		if (config.getGroup().equals("interfaceStyles"))
 		{
-			removeGameframe();
-			overrideSprites();
-			overrideWidgetSprites();
-			restoreWidgetDimensions();
-			adjustWidgetDimensions();
+			clientThread.invokeLater(() ->
+			{
+				removeGameframe();
+				overrideSprites();
+				overrideWidgetSprites();
+				restoreWidgetDimensions();
+				adjustWidgetDimensions();
+			});
 		}
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesOverlay.java
@@ -35,6 +35,7 @@ import java.awt.geom.Ellipse2D;
 import java.awt.image.BufferedImage;
 import java.text.DecimalFormat;
 import java.time.Instant;
+import java.util.Arrays;
 import java.util.List;
 import javax.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
@@ -226,10 +227,8 @@ public class XpGlobesOverlay extends Overlay
 
 		String skillName = mouseOverSkill.getSkillName();
 		String skillLevel = Integer.toString(mouseOverSkill.getCurrentLevel());
-
 		DecimalFormat decimalFormat = new DecimalFormat("###,###,###");
 		String skillCurrentXp = decimalFormat.format(mouseOverSkill.getCurrentXp());
-
 		xpTooltip.getChildren().clear();
 		graphics.translate(x, y);
 		xpTooltip.setPreferredSize(new Dimension(TOOLTIP_RECT_SIZE_X, 0));
@@ -250,7 +249,7 @@ public class XpGlobesOverlay extends Overlay
 			int actionsLeft = xpTrackerService.getActionsLeft(mouseOverSkill.getSkill());
 			String actionsLeftString = decimalFormat.format(actionsLeft);
 			xpTooltip.getChildren().add(LineComponent.builder()
-				.left("Actions left:")
+				.left(getActionKillsText(skillName))
 				.leftColor(Color.ORANGE)
 				.right(actionsLeftString)
 				.build());
@@ -282,4 +281,11 @@ public class XpGlobesOverlay extends Overlay
 		xpTooltip.render(graphics);
 		graphics.translate(-x, -y);
 	}
+
+	private String getActionKillsText(String skillName)
+	{
+		String[] combatSkills = new String[]{"Attack", "Defence", "Hitpoints", "Ranged", "Strength"};
+		return Arrays.asList(combatSkills).contains(skillName) ? "Kills left:" : "Actions left:";
+	}
+
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesOverlay.java
@@ -42,6 +42,7 @@ import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.Experience;
 import net.runelite.api.Point;
+import net.runelite.api.Skill;
 import net.runelite.api.widgets.Widget;
 import net.runelite.client.game.SkillIconManager;
 import net.runelite.client.plugins.xptracker.XpTrackerService;
@@ -209,6 +210,7 @@ public class XpGlobesOverlay extends Overlay
 
 	private void drawTooltipIfMouseover(Graphics2D graphics, XpGlobe mouseOverSkill, Ellipse2D drawnGlobe)
 	{
+		List<Skill> combat = Arrays.asList(Skill.ATTACK, Skill.STRENGTH, Skill.DEFENCE, Skill.RANGED, Skill.HITPOINTS);
 		Point mouse = client.getMouseCanvasPosition();
 		int mouseX = mouse.getX();
 		int mouseY = mouse.getY();
@@ -246,7 +248,9 @@ public class XpGlobesOverlay extends Overlay
 
 		if (mouseOverSkill.getGoalXp() != -1)
 		{
-			int actionsLeft = xpTrackerService.getActionsLeft(mouseOverSkill.getSkill());
+			int actionsLeft = combat.contains(mouseOverSkill.getSkill())
+					? xpTrackerService.getKillsLeft(mouseOverSkill.getSkill())
+					: xpTrackerService.getActionsLeft(mouseOverSkill.getSkill());
 			String actionsLeftString = decimalFormat.format(actionsLeft);
 			xpTooltip.getChildren().add(LineComponent.builder()
 				.left(getActionKillsText(skillName))
@@ -284,8 +288,11 @@ public class XpGlobesOverlay extends Overlay
 
 	private String getActionKillsText(String skillName)
 	{
-		String[] combatSkills = new String[]{"Attack", "Defence", "Hitpoints", "Ranged", "Strength"};
-		return Arrays.asList(combatSkills).contains(skillName) ? "Kills left:" : "Actions left:";
+		List<Skill> COMBAT = Arrays.asList(Skill.ATTACK, Skill.STRENGTH, Skill.DEFENCE, Skill.RANGED, Skill.HITPOINTS);
+		return COMBAT.stream()
+				.anyMatch(s -> s.getName().equals(skillName))
+				? "Kills left:"
+				: "Actions left:";
 	}
 
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpInfoBox.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpInfoBox.java
@@ -84,8 +84,10 @@ class XpInfoBox extends JPanel
 	private final JLabel expLeft = new JLabel();
 	private final JLabel actionsLeft = new JLabel();
 	private final Map<String, Integer> oppInfoHealth = OpponentInfoPlugin.loadNpcHealth();
+	@Getter(AccessLevel.PACKAGE)
 	private static final List<Skill> COMBAT = Arrays.asList(Skill.ATTACK, Skill.STRENGTH, Skill.DEFENCE, Skill.RANGED, Skill.HITPOINTS);
 
+	@Getter
 	private int killsRemaining = Integer.MAX_VALUE;
 
 	XpInfoBox(XpTrackerPlugin xpTrackerPlugin, Client client, JPanel panel, Skill skill, SkillIconManager iconManager) throws IOException
@@ -251,6 +253,7 @@ class XpInfoBox extends JPanel
 
 		int styleIndex = client.getVar(VarPlayer.ATTACK_STYLE);
 		WeaponType weaponType = WeaponType.getWeaponType(client.getVar(Varbits.EQUIPPED_WEAPON_TYPE));
+
 		return weaponType.getAttackStyles()[styleIndex].equals(AttackStyle.CONTROLLED)
 				? sharedXPModifier
 				: weaponType.getAttackStyles()[styleIndex].equals(AttackStyle.LONGRANGE)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpInfoBox.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpInfoBox.java
@@ -83,10 +83,13 @@ class XpInfoBox extends JPanel
 	private final JLabel expLeft = new JLabel();
 	private final JLabel actionsLeft = new JLabel();
 	private Map<String, Integer> oppInfoHealth = OpponentInfoPlugin.loadNpcHealth();
+	@Getter(AccessLevel.PACKAGE)
 	private static final Skill[] COMBAT = new Skill[]
 					{
 							Skill.ATTACK, Skill.STRENGTH, Skill.DEFENCE, Skill.RANGED, Skill.HITPOINTS
 					};
+	private int killsRemaining;
+
 	XpInfoBox(XpTrackerPlugin xpTrackerPlugin, Client client, JPanel panel, Skill skill, SkillIconManager iconManager) throws IOException
 	{
 		this.client = client;
@@ -169,6 +172,8 @@ class XpInfoBox extends JPanel
 		progressBar.setComponentPopupMenu(popupMenu);
 
 		add(container, BorderLayout.NORTH);
+
+		killsRemaining = Integer.MAX_VALUE;
 	}
 
 	void reset()
@@ -226,9 +231,8 @@ class XpInfoBox extends JPanel
 		expHour.setText(htmlLabel("XP/Hour: ", xpSnapshotSingle.getXpPerHour()));
 	}
 
-	private int getKillsRemaining(XpSnapshotSingle xpSnapshotSingle)
+	int getKillsRemaining(XpSnapshotSingle xpSnapshotSingle)
 	{
-		int killsRemaining = Integer.MAX_VALUE;
 		Actor opponent = client.getLocalPlayer().getInteracting();
 		if (opponent != null)
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpInfoBox.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpInfoBox.java
@@ -30,6 +30,8 @@ import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.GridLayout;
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.Map;
 import javax.swing.ImageIcon;
 import javax.swing.JLabel;
 import javax.swing.JMenuItem;
@@ -41,9 +43,15 @@ import javax.swing.border.EmptyBorder;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.Actor;
 import net.runelite.api.Client;
 import net.runelite.api.Skill;
+import net.runelite.api.VarPlayer;
+import net.runelite.api.Varbits;
 import net.runelite.client.game.SkillIconManager;
+import net.runelite.client.plugins.attackstyles.AttackStyle;
+import net.runelite.client.plugins.attackstyles.WeaponType;
+import net.runelite.client.plugins.opponentinfo.OpponentInfoPlugin;
 import net.runelite.client.ui.ColorScheme;
 import net.runelite.client.ui.FontManager;
 import net.runelite.client.ui.components.ProgressBar;
@@ -58,7 +66,7 @@ class XpInfoBox extends JPanel
 
 	@Getter(AccessLevel.PACKAGE)
 	private final Skill skill;
-
+	private final Client client;
 	/* The tracker's wrapping container */
 	private final JPanel container = new JPanel();
 
@@ -74,9 +82,14 @@ class XpInfoBox extends JPanel
 	private final JLabel expHour = new JLabel();
 	private final JLabel expLeft = new JLabel();
 	private final JLabel actionsLeft = new JLabel();
-
+	private Map<String, Integer> oppInfoHealth = OpponentInfoPlugin.loadNpcHealth();
+	private static final Skill[] COMBAT = new Skill[]
+					{
+							Skill.ATTACK, Skill.STRENGTH, Skill.DEFENCE, Skill.RANGED, Skill.HITPOINTS
+					};
 	XpInfoBox(XpTrackerPlugin xpTrackerPlugin, Client client, JPanel panel, Skill skill, SkillIconManager iconManager) throws IOException
 	{
+		this.client = client;
 		this.panel = panel;
 		this.skill = skill;
 
@@ -183,7 +196,14 @@ class XpInfoBox extends JPanel
 			// Update information labels
 			expGained.setText(htmlLabel("XP Gained: ", xpSnapshotSingle.getXpGainedInSession()));
 			expLeft.setText(htmlLabel("XP Left: ", xpSnapshotSingle.getXpRemainingToGoal()));
-			actionsLeft.setText(htmlLabel("Actions: ", xpSnapshotSingle.getActionsRemainingToGoal()));
+			if (Arrays.asList(COMBAT).contains(skill))
+			{
+				actionsLeft.setText(htmlLabel("Kills: ", getKillsRemaining(xpSnapshotSingle)));
+			}
+			else
+			{
+				actionsLeft.setText(htmlLabel("Actions: ", xpSnapshotSingle.getActionsRemainingToGoal()));
+			}
 
 			// Update progress bar
 			progressBar.setValue(xpSnapshotSingle.getSkillProgressToGoal());
@@ -204,6 +224,35 @@ class XpInfoBox extends JPanel
 
 		// Update exp per hour seperately, everytime (not only when there's an update)
 		expHour.setText(htmlLabel("XP/Hour: ", xpSnapshotSingle.getXpPerHour()));
+	}
+
+	private int getKillsRemaining(XpSnapshotSingle xpSnapshotSingle)
+	{
+		int killsRemaining = Integer.MAX_VALUE;
+		Actor opponent = client.getLocalPlayer().getInteracting();
+		if (opponent != null)
+		{
+			int opponentHealth = oppInfoHealth.get(opponent.getName() + "_" + opponent.getCombatLevel());
+			double modifier = getCombatXPModifier(skill);
+			double actionExp = (opponentHealth * modifier);
+			killsRemaining = (int) Math.ceil(xpSnapshotSingle.getXpRemainingToGoal() / actionExp);
+		}
+		return killsRemaining;
+	}
+
+	private double getCombatXPModifier(Skill skill)
+	{
+		final double sharedXPModifier = 4.0 / 3.0;
+		final double longRangedXPModifier = 2.0;
+		final double defaultModifier = 4;
+		if (skill.equals(Skill.HITPOINTS))
+		{
+			return sharedXPModifier;
+		}
+		int styleIndex = client.getVar(VarPlayer.ATTACK_STYLE);
+		WeaponType weaponType = WeaponType.getWeaponType(client.getVar(Varbits.EQUIPPED_WEAPON_TYPE));
+		return weaponType.getAttackStyles()[styleIndex].equals(AttackStyle.CONTROLLED) ? sharedXPModifier :
+				weaponType.getAttackStyles()[styleIndex].equals(AttackStyle.LONGRANGE) ? longRangedXPModifier : defaultModifier;
 	}
 
 	public static String htmlLabel(String key, int value)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpPanel.java
@@ -38,7 +38,6 @@ import javax.swing.JPanel;
 import javax.swing.JPopupMenu;
 import javax.swing.SwingUtilities;
 import javax.swing.border.EmptyBorder;
-import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Actor;
@@ -55,7 +54,7 @@ import okhttp3.HttpUrl;
 @Slf4j
 class XpPanel extends PluginPanel
 {
-	@Getter(AccessLevel.PACKAGE)
+	@Getter
 	private final Map<Skill, XpInfoBox> infoBoxes = new HashMap<>();
 
 	private final JLabel overallExpGained = new JLabel(XpInfoBox.htmlLabel("Gained: ", 0));

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpPanel.java
@@ -38,6 +38,8 @@ import javax.swing.JPanel;
 import javax.swing.JPopupMenu;
 import javax.swing.SwingUtilities;
 import javax.swing.border.EmptyBorder;
+import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Actor;
 import net.runelite.api.Client;
@@ -53,6 +55,7 @@ import okhttp3.HttpUrl;
 @Slf4j
 class XpPanel extends PluginPanel
 {
+	@Getter(AccessLevel.PACKAGE)
 	private final Map<Skill, XpInfoBox> infoBoxes = new HashMap<>();
 
 	private final JLabel overallExpGained = new JLabel(XpInfoBox.htmlLabel("Gained: ", 0));

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerPlugin.java
@@ -77,7 +77,7 @@ public class XpTrackerPlugin extends Plugin
 	private ScheduledExecutorService executor;
 
 	private NavigationButton navButton;
-	@Getter(AccessLevel.PACKAGE)
+	@Getter
 	private XpPanel xpPanel;
 
 	private final XpState xpState = new XpState();

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerPlugin.java
@@ -35,6 +35,8 @@ import java.util.Objects;
 import java.util.concurrent.ScheduledExecutorService;
 import javax.imageio.ImageIO;
 import javax.inject.Inject;
+import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.GameState;
@@ -75,6 +77,7 @@ public class XpTrackerPlugin extends Plugin
 	private ScheduledExecutorService executor;
 
 	private NavigationButton navButton;
+	@Getter(AccessLevel.PACKAGE)
 	private XpPanel xpPanel;
 
 	private final XpState xpState = new XpState();

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerPlugin.java
@@ -35,7 +35,6 @@ import java.util.Objects;
 import java.util.concurrent.ScheduledExecutorService;
 import javax.imageio.ImageIO;
 import javax.inject.Inject;
-import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerService.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerService.java
@@ -50,6 +50,10 @@ public interface XpTrackerService
 	int getActionsLeft(Skill skill);
 
 	/**
+	 *
+	 */
+	int getKillsLeft(Skill skill);
+	/**
 	 * Get the amount of xp per hour
 	 * @param skill
 	 * @return

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerServiceImpl.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerServiceImpl.java
@@ -28,6 +28,8 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 import net.runelite.api.Skill;
 
+import java.util.Arrays;
+
 @Singleton
 class XpTrackerServiceImpl implements XpTrackerService
 {
@@ -54,6 +56,15 @@ class XpTrackerServiceImpl implements XpTrackerService
 	@Override
 	public int getActionsLeft(Skill skill)
 	{
+		Skill[] COMBAT = XpInfoBox.getCOMBAT();
+		if (Arrays.asList(COMBAT).contains(skill))
+		{
+			XpSnapshotSingle snapShot = plugin.getSkillSnapshot(skill);
+			return plugin.getXpPanel()
+							.getInfoBoxes()
+							.get(skill)
+							.getKillsRemaining(snapShot);
+		}
 		return plugin.getSkillSnapshot(skill).getActionsRemainingToGoal();
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerServiceImpl.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerServiceImpl.java
@@ -28,8 +28,6 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 import net.runelite.api.Skill;
 
-import java.util.Arrays;
-
 @Singleton
 class XpTrackerServiceImpl implements XpTrackerService
 {
@@ -56,16 +54,13 @@ class XpTrackerServiceImpl implements XpTrackerService
 	@Override
 	public int getActionsLeft(Skill skill)
 	{
-		Skill[] COMBAT = XpInfoBox.getCOMBAT();
-		if (Arrays.asList(COMBAT).contains(skill))
-		{
-			XpSnapshotSingle snapShot = plugin.getSkillSnapshot(skill);
-			return plugin.getXpPanel()
-							.getInfoBoxes()
-							.get(skill)
-							.getKillsRemaining(snapShot);
-		}
 		return plugin.getSkillSnapshot(skill).getActionsRemainingToGoal();
+	}
+
+	@Override
+	public int getKillsLeft(Skill skill)
+	{
+		return plugin.getXpPanel().getInfoBoxes().get(skill).getKillsRemaining(plugin.getSkillSnapshot(skill));
 	}
 
 	@Override


### PR DESCRIPTION
I closed #1645 and implemented the feature after a few changes were made in the xp tracker code. Also added the kills left to the xp globe now.

![screenshot](https://i.imgur.com/Vkn0zuu.png)
closes #1594