### PR TITLE
Slightly improve fps decrease from config panel scrolling

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ui/PluginPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/PluginPanel.java
@@ -29,6 +29,7 @@ import java.awt.Dimension;
 import java.awt.GridLayout;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
+import javax.swing.JViewport;
 import javax.swing.ScrollPaneConstants;
 import javax.swing.border.EmptyBorder;
 import lombok.AccessLevel;
@@ -68,6 +69,7 @@ public abstract class PluginPanel extends JPanel
 			northPanel.setBackground(ColorScheme.DARK_GRAY_COLOR);
 
 			scrollPane = new JScrollPane(northPanel);
+			scrollPane.getViewport().setScrollMode(JViewport.BACKINGSTORE_SCROLL_MODE);
 			scrollPane.setHorizontalScrollBarPolicy(ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
 
 			wrappedPanel = new JPanel();


### PR DESCRIPTION
Kind of addresses https://github.com/runelite/runelite/issues/3149.

I think the scrolling will always be bad, 'cos swing. But changing the scroll mode to backingstore seemed to provide a slight improvement for me when testing. Feel free to test it out yourself!