### PR TITLE
Change hot/cold overlay to only show outline of dig area

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/HotColdClue.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/HotColdClue.java
@@ -25,13 +25,11 @@
 package net.runelite.client.plugins.cluescrolls.clues;
 
 import com.google.common.collect.Lists;
-import java.awt.BasicStroke;
 import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Graphics2D;
 import java.awt.Point;
 import java.awt.Rectangle;
-import java.awt.geom.GeneralPath;
 import java.awt.geom.Rectangle2D;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -43,7 +41,6 @@ import java.util.regex.Pattern;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import net.runelite.api.NPC;
-import net.runelite.api.Perspective;
 import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.coords.WorldPoint;
 import static net.runelite.client.plugins.cluescrolls.ClueScrollOverlay.TITLED_CONTENT_COLOR;
@@ -218,127 +215,21 @@ public class HotColdClue extends ClueScroll implements LocationClueScroll, Locat
 			}
 		}
 
-		// once the number of possible dig locations is below 10, outline their ground areas
+		// once the number of possible dig locations is below 10, show the dig spots
 		if (digLocations.size() < 10)
 		{
 			// Mark potential dig locations
 			for (HotColdLocation hotColdLocation : digLocations)
 			{
 				WorldPoint wp = hotColdLocation.getWorldPoint();
+				LocalPoint localLocation = LocalPoint.fromWorld(plugin.getClient(), wp.getX(), wp.getY());
 
-				// outlines a 9x9 area around the central point
-				int startX = (wp.getX() - 4);
-				int startY = (wp.getY() - 4);
-				int endX = (wp.getX() + 5);
-				int endY = (wp.getY() + 5);
-
-				graphics.setStroke(new BasicStroke(3));
-				graphics.setColor(Color.BLUE);
-				GeneralPath path = new GeneralPath();
-
-				LocalPoint lowerLeft = LocalPoint.fromWorld(plugin.getClient(), startX, startY);
-				LocalPoint upperLeft = LocalPoint.fromWorld(plugin.getClient(), startX, endY);
-				LocalPoint upperRight = LocalPoint.fromWorld(plugin.getClient(), endX, endY);
-				LocalPoint lowerRight = LocalPoint.fromWorld(plugin.getClient(), endX, startY);
-
-				if (lowerLeft == null || upperLeft == null || upperRight == null || lowerRight == null)
+				if (localLocation == null)
 				{
-					continue;
+					return;
 				}
 
-				boolean first = true;
-
-				for (int y = lowerLeft.getY(); y <= upperLeft.getY(); y += Perspective.LOCAL_TILE_SIZE)
-				{
-					net.runelite.api.Point p = Perspective.worldToCanvas(plugin.getClient(),
-						lowerLeft.getX() - Perspective.LOCAL_TILE_SIZE / 2,
-						y - Perspective.LOCAL_TILE_SIZE / 2,
-						plugin.getClient().getPlane());
-
-					if (p != null)
-					{
-						if (first)
-						{
-							path.moveTo(p.getX(), p.getY());
-							first = false;
-						}
-						else
-						{
-							path.lineTo(p.getX(), p.getY());
-						}
-					}
-				}
-
-				first = true;
-
-				for (int x = upperLeft.getX(); x <= upperRight.getX(); x += Perspective.LOCAL_TILE_SIZE)
-				{
-					net.runelite.api.Point p = Perspective.worldToCanvas(plugin.getClient(),
-						x - Perspective.LOCAL_TILE_SIZE / 2,
-						upperLeft.getY() - Perspective.LOCAL_TILE_SIZE / 2,
-						plugin.getClient().getPlane());
-
-					if (p != null)
-					{
-						if (first)
-						{
-							path.moveTo(p.getX(), p.getY());
-							first = false;
-						}
-						else
-						{
-							path.lineTo(p.getX(), p.getY());
-						}
-					}
-				}
-
-				first = true;
-
-				for (int y = upperRight.getY(); y >= lowerRight.getY(); y -= Perspective.LOCAL_TILE_SIZE)
-				{
-					net.runelite.api.Point p = Perspective.worldToCanvas(plugin.getClient(),
-						lowerRight.getX() - Perspective.LOCAL_TILE_SIZE / 2,
-						y - Perspective.LOCAL_TILE_SIZE / 2,
-						plugin.getClient().getPlane());
-
-					if (p != null)
-					{
-						if (first)
-						{
-							path.moveTo(p.getX(), p.getY());
-							first = false;
-						}
-						else
-						{
-							path.lineTo(p.getX(), p.getY());
-						}
-					}
-				}
-
-				first = true;
-
-				for (int x = lowerRight.getX(); x >= lowerLeft.getX(); x -= Perspective.LOCAL_TILE_SIZE)
-				{
-					net.runelite.api.Point p = Perspective.worldToCanvas(plugin.getClient(),
-						x - Perspective.LOCAL_TILE_SIZE / 2,
-						lowerLeft.getY() - Perspective.LOCAL_TILE_SIZE / 2,
-						plugin.getClient().getPlane());
-
-					if (p != null)
-					{
-						if (first)
-						{
-							path.moveTo(p.getX(), p.getY());
-							first = false;
-						}
-						else
-						{
-							path.lineTo(p.getX(), p.getY());
-						}
-					}
-				}
-
-				graphics.draw(path);
+				OverlayUtil.renderTileOverlay(plugin.getClient(), graphics, localLocation, SPADE_IMAGE, Color.ORANGE);
 			}
 		}
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java
@@ -90,7 +90,7 @@ public enum HotColdLocation
 	FREMENNIK_PROVINCE_PIRATES_COVE(new WorldPoint(2210, 3814, 0), FREMENNIK_PROVINCE, "Pirates' Cove"),
 	FREMENNIK_PROVINCE_ASTRAL_ALTER(new WorldPoint(2147, 3862, 0), FREMENNIK_PROVINCE, "Astral altar"),
 	FREMENNIK_PROVINCE_LUNAR_VILLAGE(new WorldPoint(2087, 3915, 0), FREMENNIK_PROVINCE, "Lunar Isle, inside the village."),
-	FREMENNIK_PROVINCE_LUNAR_NORTH(new WorldPoint(2101, 3949, 0), FREMENNIK_PROVINCE, "Lunar Isle, north of the village."),
+	FREMENNIK_PROVINCE_LUNAR_NORTH(new WorldPoint(2106, 3949, 0), FREMENNIK_PROVINCE, "Lunar Isle, north of the village."),
 	KANDARIN_SINCLAR_MANSION(new WorldPoint(2726, 3588, 0), KANDARIN, "North-west of the Sinclair Mansion, near the log balance shortcut."),
 	KANDARIN_CATHERBY(new WorldPoint(2774, 3433, 0), KANDARIN, "Catherby, between the bank and the beehives, near small rock formation."),
 	KANDARIN_GRAND_TREE(new WorldPoint(2449, 3509, 0), KANDARIN, "Grand Tree, just east of the terrorchick gnome enclosure."),


### PR DESCRIPTION
This change offers slight fps improvement compared to the original solid dig area overlay. Discussed in issue #3123. 

Note: The square that is marked as the dig location may be inaccurate. The marked square is supposed to be the center of the true 9x9 final area, but because the central coordinates were collected manually from pictures on the wiki, many of them are slightly off center. If the center points we have for an area are 5 or more squares away from their true center, then the dig location will not work. Getting the true centers will improve the calculations used to find the areas, so if anyone gets an inaccurate clue its center should be updated in plugins/cluescrolls/clues/hotcold/HotColdLocation.java.

New:

![java_2018-05-23_14-21-18](https://user-images.githubusercontent.com/38920911/40446498-0d4f8496-5e95-11e8-8c26-b7ca0b3319f3.png)

Old:

![java_2018-05-23_13-09-41](https://user-images.githubusercontent.com/38920911/40444672-906232da-5e8f-11e8-8150-16dd58417f93.png)
