### PR TITLE
Add raids items overlay WIP

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidRoom.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidRoom.java
@@ -125,6 +125,14 @@ public class RaidRoom
 
 	@Getter
 	@Setter
+	private String itemType;
+
+	@Getter
+	@Setter
+	private int[] itemIds;
+
+	@Getter
+	@Setter
 	private Type type;
 
 	@Getter

--- a/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsConfig.java
@@ -29,17 +29,17 @@ import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
 
 @ConfigGroup(
-	keyName = "raids",
-	name = "Chambers Of Xeric",
-	description = "Configuration for the raids plugin"
+		keyName = "raids",
+		name = "Chambers Of Xeric",
+		description = "Configuration for the raids plugin"
 )
 public interface RaidsConfig extends Config
 {
 	@ConfigItem(
-		position = 0,
-		keyName = "raidsTimer",
-		name = "Display elapsed raid time",
-		description = "Display elapsed raid time"
+			position = 0,
+			keyName = "raidsTimer",
+			name = "Display elapsed raid time",
+			description = "Display elapsed raid time"
 	)
 	default boolean raidsTimer()
 	{
@@ -47,10 +47,10 @@ public interface RaidsConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 1,
-		keyName = "pointsMessage",
-		name = "Display points in chatbox after raid",
-		description = "Display a message with total points, individual points and percentage at the end of a raid"
+			position = 1,
+			keyName = "pointsMessage",
+			name = "Display points in chatbox after raid",
+			description = "Display a message with total points, individual points and percentage at the end of a raid"
 	)
 	default boolean pointsMessage()
 	{
@@ -58,10 +58,10 @@ public interface RaidsConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 2,
-		keyName = "scoutOverlay",
-		name = "Show scout overlay",
-		description = "Display an overlay that shows the current raid layout (when entering lobby)"
+			position = 2,
+			keyName = "scoutOverlay",
+			name = "Show scout overlay",
+			description = "Display an overlay that shows the current raid layout (when entering lobby)"
 	)
 	default boolean scoutOverlay()
 	{
@@ -69,10 +69,10 @@ public interface RaidsConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 3,
-		keyName = "scoutOverlayAtBank",
-		name = "Show scout overlay outside lobby",
-		description = "Keep the overlay active while at the raids area"
+			position = 3,
+			keyName = "scoutOverlayAtBank",
+			name = "Show scout overlay outside lobby",
+			description = "Keep the overlay active while at the raids area"
 	)
 	default boolean scoutOverlayAtBank()
 	{
@@ -80,10 +80,10 @@ public interface RaidsConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 4,
-		keyName = "whitelistedRooms",
-		name = "Whitelisted rooms",
-		description = "Display whitelisted rooms in green on the overlay. Separate with comma (full name)"
+			position = 4,
+			keyName = "whitelistedRooms",
+			name = "Whitelisted rooms",
+			description = "Display whitelisted rooms in green on the overlay. Separate with comma (full name)"
 	)
 	default String whitelistedRooms()
 	{
@@ -91,10 +91,10 @@ public interface RaidsConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 5,
-		keyName = "blacklistedRooms",
-		name = "Blacklisted rooms",
-		description = "Display blacklisted rooms in red on the overlay. Separate with comma (full name)"
+			position = 5,
+			keyName = "blacklistedRooms",
+			name = "Blacklisted rooms",
+			description = "Display blacklisted rooms in red on the overlay. Separate with comma (full name)"
 	)
 	default String blacklistedRooms()
 	{
@@ -102,10 +102,10 @@ public interface RaidsConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 6,
-		keyName = "enableRotationWhitelist",
-		name = "Enable rotation whitelist",
-		description = "Enable the rotation whitelist"
+			position = 6,
+			keyName = "enableRotationWhitelist",
+			name = "Enable rotation whitelist",
+			description = "Enable the rotation whitelist"
 	)
 	default boolean enableRotationWhitelist()
 	{
@@ -113,10 +113,10 @@ public interface RaidsConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 7,
-		keyName = "whitelistedRotations",
-		name = "Whitelisted rotations",
-		description = "Warn when boss rotation doesn't match a whitelisted one. Add rotations like [tekton, muttadile, guardians]"
+			position = 7,
+			keyName = "whitelistedRotations",
+			name = "Whitelisted rotations",
+			description = "Warn when boss rotation doesn't match a whitelisted one. Add rotations like [tekton, muttadile, guardians]"
 	)
 	default String whitelistedRotations()
 	{
@@ -124,10 +124,10 @@ public interface RaidsConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 8,
-		keyName = "enableLayoutWhitelist",
-		name = "Enable layout whitelist",
-		description = "Enable the layout whitelist"
+			position = 8,
+			keyName = "enableLayoutWhitelist",
+			name = "Enable layout whitelist",
+			description = "Enable the layout whitelist"
 	)
 	default boolean enableLayoutWhitelist()
 	{
@@ -135,13 +135,24 @@ public interface RaidsConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 9,
-		keyName = "whitelistedLayouts",
-		name = "Whitelisted layouts",
-		description = "Warn when layout doesn't match a whitelisted one. Add layouts like CFSCPPCSCF separated with comma"
+			position = 9,
+			keyName = "whitelistedLayouts",
+			name = "Whitelisted layouts",
+			description = "Warn when layout doesn't match a whitelisted one. Add layouts like CFSCPPCSCF separated with comma"
 	)
 	default String whitelistedLayouts()
 	{
 		return "";
+	}
+
+	@ConfigItem(
+			position = 10,
+			keyName = "itemsOverlay",
+			name = "Show items overlay",
+			description = "Display an overlay that shows the required items for the current raid layout (when entering the lobby)"
+	)
+	default boolean itemsOverlay()
+	{
+		return false;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsConfig.java
@@ -29,17 +29,17 @@ import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
 
 @ConfigGroup(
-		keyName = "raids",
-		name = "Chambers Of Xeric",
-		description = "Configuration for the raids plugin"
+	keyName = "raids",
+	name = "Chambers Of Xeric",
+	description = "Configuration for the raids plugin"
 )
 public interface RaidsConfig extends Config
 {
 	@ConfigItem(
-			position = 0,
-			keyName = "raidsTimer",
-			name = "Display elapsed raid time",
-			description = "Display elapsed raid time"
+		position = 0,
+		keyName = "raidsTimer",
+		name = "Display elapsed raid time",
+		description = "Display elapsed raid time"
 	)
 	default boolean raidsTimer()
 	{
@@ -47,10 +47,10 @@ public interface RaidsConfig extends Config
 	}
 
 	@ConfigItem(
-			position = 1,
-			keyName = "pointsMessage",
-			name = "Display points in chatbox after raid",
-			description = "Display a message with total points, individual points and percentage at the end of a raid"
+		position = 1,
+		keyName = "pointsMessage",
+		name = "Display points in chatbox after raid",
+		description = "Display a message with total points, individual points and percentage at the end of a raid"
 	)
 	default boolean pointsMessage()
 	{
@@ -58,10 +58,10 @@ public interface RaidsConfig extends Config
 	}
 
 	@ConfigItem(
-			position = 2,
-			keyName = "scoutOverlay",
-			name = "Show scout overlay",
-			description = "Display an overlay that shows the current raid layout (when entering lobby)"
+		position = 2,
+		keyName = "scoutOverlay",
+		name = "Show scout overlay",
+		description = "Display an overlay that shows the current raid layout (when entering lobby)"
 	)
 	default boolean scoutOverlay()
 	{
@@ -69,10 +69,10 @@ public interface RaidsConfig extends Config
 	}
 
 	@ConfigItem(
-			position = 3,
-			keyName = "scoutOverlayAtBank",
-			name = "Show scout overlay outside lobby",
-			description = "Keep the overlay active while at the raids area"
+		position = 3,
+		keyName = "scoutOverlayAtBank",
+		name = "Show scout overlay outside lobby",
+		description = "Keep the overlay active while at the raids area"
 	)
 	default boolean scoutOverlayAtBank()
 	{
@@ -80,10 +80,10 @@ public interface RaidsConfig extends Config
 	}
 
 	@ConfigItem(
-			position = 4,
-			keyName = "whitelistedRooms",
-			name = "Whitelisted rooms",
-			description = "Display whitelisted rooms in green on the overlay. Separate with comma (full name)"
+		position = 4,
+		keyName = "whitelistedRooms",
+		name = "Whitelisted rooms",
+		description = "Display whitelisted rooms in green on the overlay. Separate with comma (full name)"
 	)
 	default String whitelistedRooms()
 	{
@@ -91,10 +91,10 @@ public interface RaidsConfig extends Config
 	}
 
 	@ConfigItem(
-			position = 5,
-			keyName = "blacklistedRooms",
-			name = "Blacklisted rooms",
-			description = "Display blacklisted rooms in red on the overlay. Separate with comma (full name)"
+		position = 5,
+		keyName = "blacklistedRooms",
+		name = "Blacklisted rooms",
+		description = "Display blacklisted rooms in red on the overlay. Separate with comma (full name)"
 	)
 	default String blacklistedRooms()
 	{
@@ -102,10 +102,10 @@ public interface RaidsConfig extends Config
 	}
 
 	@ConfigItem(
-			position = 6,
-			keyName = "enableRotationWhitelist",
-			name = "Enable rotation whitelist",
-			description = "Enable the rotation whitelist"
+		position = 6,
+		keyName = "enableRotationWhitelist",
+		name = "Enable rotation whitelist",
+		description = "Enable the rotation whitelist"
 	)
 	default boolean enableRotationWhitelist()
 	{
@@ -113,10 +113,10 @@ public interface RaidsConfig extends Config
 	}
 
 	@ConfigItem(
-			position = 7,
-			keyName = "whitelistedRotations",
-			name = "Whitelisted rotations",
-			description = "Warn when boss rotation doesn't match a whitelisted one. Add rotations like [tekton, muttadile, guardians]"
+		position = 7,
+		keyName = "whitelistedRotations",
+		name = "Whitelisted rotations",
+		description = "Warn when boss rotation doesn't match a whitelisted one. Add rotations like [tekton, muttadile, guardians]"
 	)
 	default String whitelistedRotations()
 	{
@@ -124,10 +124,10 @@ public interface RaidsConfig extends Config
 	}
 
 	@ConfigItem(
-			position = 8,
-			keyName = "enableLayoutWhitelist",
-			name = "Enable layout whitelist",
-			description = "Enable the layout whitelist"
+		position = 8,
+		keyName = "enableLayoutWhitelist",
+		name = "Enable layout whitelist",
+		description = "Enable the layout whitelist"
 	)
 	default boolean enableLayoutWhitelist()
 	{
@@ -135,10 +135,10 @@ public interface RaidsConfig extends Config
 	}
 
 	@ConfigItem(
-			position = 9,
-			keyName = "whitelistedLayouts",
-			name = "Whitelisted layouts",
-			description = "Warn when layout doesn't match a whitelisted one. Add layouts like CFSCPPCSCF separated with comma"
+		position = 9,
+		keyName = "whitelistedLayouts",
+		name = "Whitelisted layouts",
+		description = "Warn when layout doesn't match a whitelisted one. Add layouts like CFSCPPCSCF separated with comma"
 	)
 	default String whitelistedLayouts()
 	{
@@ -146,10 +146,10 @@ public interface RaidsConfig extends Config
 	}
 
 	@ConfigItem(
-			position = 10,
-			keyName = "itemsOverlay",
-			name = "Show items overlay",
-			description = "Display an overlay that shows the required items for the current raid layout (when entering the lobby)"
+		position = 10,
+		keyName = "itemsOverlay",
+		name = "Show items overlay",
+		description = "Display an overlay that shows the required items for the current raid layout (when entering the lobby)"
 	)
 	default boolean itemsOverlay()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsItemsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsItemsOverlay.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2018, bheisenberg
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.raids;
+
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Graphics2D;
+import java.util.Arrays;
+import java.util.stream.IntStream;
+import javax.inject.Inject;
+import lombok.Getter;
+import lombok.Setter;
+import net.runelite.api.ItemContainer;
+import net.runelite.client.game.ItemManager;
+import net.runelite.client.plugins.raids.solver.Room;
+import net.runelite.client.ui.overlay.Overlay;
+import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.OverlayPriority;
+import net.runelite.client.ui.overlay.components.LineComponent;
+import net.runelite.client.ui.overlay.components.PanelComponent;
+import net.runelite.client.ui.overlay.components.TitleComponent;
+import net.runelite.api.Client;
+import net.runelite.api.InventoryID;
+import net.runelite.api.Item;
+
+public class RaidsItemsOverlay extends Overlay
+{
+    private RaidsPlugin plugin;
+    private RaidsConfig config;
+    private final PanelComponent panelComponent = new PanelComponent();
+
+    @Setter
+    private boolean itemsOverlayShown = false;
+
+    @Getter
+    private Item[] inventoryItems;
+
+    @Inject
+    private Client client;
+
+    @Inject
+    private ItemManager itemManager;
+
+    @Inject
+    public RaidsItemsOverlay(RaidsPlugin plugin, RaidsConfig config)
+    {
+        setPosition(OverlayPosition.TOP_LEFT);
+        setPriority(OverlayPriority.LOW);
+        this.plugin = plugin;
+        this.config = config;
+    }
+
+    @Override
+    public Dimension render(Graphics2D graphics)
+    {
+        if (!config.itemsOverlay() || !itemsOverlayShown)
+        {
+            return null;
+        }
+
+        panelComponent.getChildren().clear();
+        inventoryItems = client.getItemContainer(InventoryID.INVENTORY).getItems();
+
+        if (plugin.getRaid() == null || plugin.getRaid().getLayout() == null)
+        {
+            panelComponent.getChildren().add(TitleComponent.builder()
+                    .text("No items found for this raid")
+                    .color(Color.RED)
+                    .build());
+
+            return panelComponent.render(graphics);
+        }
+
+
+        panelComponent.getChildren().add(TitleComponent.builder()
+                .text("Raid items")
+                .build());
+
+
+
+        for (Room layoutRoom : plugin.getRaid().getLayout().getRooms())
+        {
+            int position = layoutRoom.getPosition();
+            RaidRoom room = plugin.getRaid().getRoom(position);
+
+
+            if (room == null)
+            {
+                continue;
+            }
+
+            if (room.getItemType() != null)
+            {
+                Color color = Color.white;
+                String itemName = room.getItemType();
+                String[] roomItemsInInventory = getRaidItems(room);
+                if(roomItemsInInventory.length > 0) {
+                    color = Color.green;
+                    itemName = roomItemsInInventory[0];
+                } else {
+                    color = Color.red;
+                }
+                panelComponent.getChildren().add(LineComponent.builder()
+                        .left(itemName)
+                        .leftColor(color)
+                        .build());
+            }
+
+        }
+        return panelComponent.render(graphics);
+    }
+
+    private String[] getRaidItems(RaidRoom room) {
+        int[] inventoryIds = Arrays.stream(inventoryItems).mapToInt(Item::getId).toArray();
+        return IntStream.of(inventoryIds).filter(x -> IntStream.of(room.getItemIds()).anyMatch(y -> y == x)).mapToObj(z -> itemManager.getItemComposition(z).getName()).toArray(String[]::new);
+    }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsItemsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsItemsOverlay.java
@@ -32,7 +32,6 @@ import java.util.stream.IntStream;
 import javax.inject.Inject;
 import lombok.Getter;
 import lombok.Setter;
-import net.runelite.api.ItemContainer;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.plugins.raids.solver.Room;
 import net.runelite.client.ui.overlay.Overlay;
@@ -47,93 +46,96 @@ import net.runelite.api.Item;
 
 public class RaidsItemsOverlay extends Overlay
 {
-    private RaidsPlugin plugin;
-    private RaidsConfig config;
-    private final PanelComponent panelComponent = new PanelComponent();
+	private RaidsPlugin plugin;
+	private RaidsConfig config;
+	private final PanelComponent panelComponent = new PanelComponent();
 
-    @Setter
-    private boolean itemsOverlayShown = false;
+	@Setter
+	private boolean itemsOverlayShown = false;
 
-    @Getter
-    private Item[] inventoryItems;
+	@Getter
+	private Item[] inventoryItems;
 
-    @Inject
-    private Client client;
+	@Inject
+	private Client client;
 
-    @Inject
-    private ItemManager itemManager;
+	@Inject
+	private ItemManager itemManager;
 
-    @Inject
-    public RaidsItemsOverlay(RaidsPlugin plugin, RaidsConfig config)
-    {
-        setPosition(OverlayPosition.TOP_LEFT);
-        setPriority(OverlayPriority.LOW);
-        this.plugin = plugin;
-        this.config = config;
-    }
+	@Inject
+	public RaidsItemsOverlay(RaidsPlugin plugin, RaidsConfig config)
+	{
+		setPosition(OverlayPosition.TOP_LEFT);
+		setPriority(OverlayPriority.LOW);
+		this.plugin = plugin;
+		this.config = config;
+	}
 
-    @Override
-    public Dimension render(Graphics2D graphics)
-    {
-        if (!config.itemsOverlay() || !itemsOverlayShown)
-        {
-            return null;
-        }
+	@Override
+	public Dimension render(Graphics2D graphics)
+	{
+		if (!config.itemsOverlay() || !itemsOverlayShown)
+		{
+			return null;
+		}
 
-        panelComponent.getChildren().clear();
-        inventoryItems = client.getItemContainer(InventoryID.INVENTORY).getItems();
+		panelComponent.getChildren().clear();
+		inventoryItems = client.getItemContainer(InventoryID.INVENTORY).getItems();
 
-        if (plugin.getRaid() == null || plugin.getRaid().getLayout() == null)
-        {
-            panelComponent.getChildren().add(TitleComponent.builder()
-                    .text("No items found for this raid")
-                    .color(Color.RED)
-                    .build());
+		if (plugin.getRaid() == null || plugin.getRaid().getLayout() == null)
+		{
+			panelComponent.getChildren().add(TitleComponent.builder()
+				.text("No items found for this raid")
+				.color(Color.RED)
+				.build());
 
-            return panelComponent.render(graphics);
-        }
-
-
-        panelComponent.getChildren().add(TitleComponent.builder()
-                .text("Raid items")
-                .build());
+			return panelComponent.render(graphics);
+		}
 
 
-
-        for (Room layoutRoom : plugin.getRaid().getLayout().getRooms())
-        {
-            int position = layoutRoom.getPosition();
-            RaidRoom room = plugin.getRaid().getRoom(position);
+		panelComponent.getChildren().add(TitleComponent.builder()
+			.text("Raid items")
+			.build());
 
 
-            if (room == null)
-            {
-                continue;
-            }
+		for (Room layoutRoom : plugin.getRaid().getLayout().getRooms())
+		{
+			int position = layoutRoom.getPosition();
+			RaidRoom room = plugin.getRaid().getRoom(position);
 
-            if (room.getItemType() != null)
-            {
-                Color color = Color.white;
-                String itemName = room.getItemType();
-                String[] roomItemsInInventory = getRaidItems(room);
-                if(roomItemsInInventory.length > 0) {
-                    color = Color.green;
-                    itemName = roomItemsInInventory[0];
-                } else {
-                    color = Color.red;
-                }
-                panelComponent.getChildren().add(LineComponent.builder()
-                        .left(itemName)
-                        .leftColor(color)
-                        .build());
-            }
 
-        }
-        return panelComponent.render(graphics);
-    }
+			if (room == null)
+			{
+				continue;
+			}
 
-    private String[] getRaidItems(RaidRoom room) {
-        int[] inventoryIds = Arrays.stream(inventoryItems).mapToInt(Item::getId).toArray();
-        return IntStream.of(inventoryIds).filter(x -> IntStream.of(room.getItemIds()).anyMatch(y -> y == x)).mapToObj(z -> itemManager.getItemComposition(z).getName()).toArray(String[]::new);
-    }
+			if (room.getItemType() != null)
+			{
+				Color color = Color.white;
+				String itemName = room.getItemType();
+				String[] roomItemsInInventory = getRaidItems(room);
+				if (roomItemsInInventory.length > 0)
+				{
+					color = Color.green;
+					itemName = roomItemsInInventory[0];
+				}
+				else
+				{
+					color = Color.red;
+				}
+				panelComponent.getChildren().add(LineComponent.builder()
+					.left(itemName)
+					.leftColor(color)
+					.build());
+			}
+
+		}
+		return panelComponent.render(graphics);
+	}
+
+	private String[] getRaidItems(RaidRoom room)
+	{
+		int[] inventoryIds = Arrays.stream(inventoryItems).mapToInt(Item::getId).toArray();
+		return IntStream.of(inventoryIds).filter(x -> IntStream.of(room.getItemIds()).anyMatch(y -> y == x)).mapToObj(z -> itemManager.getItemComposition(z).getName()).toArray(String[]::new);
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsPlugin.java
@@ -73,7 +73,7 @@ import net.runelite.client.ui.overlay.infobox.InfoBoxManager;
 import net.runelite.client.util.Text;
 
 @PluginDescriptor(
-		name = "Chambers Of Xeric"
+	name = "Chambers Of Xeric"
 )
 @Slf4j
 public class RaidsPlugin extends Plugin
@@ -261,7 +261,8 @@ public class RaidsPlugin extends Plugin
 			}
 			else
 			{
-				if(!config.scoutOverlayAtBank()) {
+				if (!config.scoutOverlayAtBank())
+				{
 					scoutOverlay.setScoutOverlayShown(false);
 				}
 				itemsOverlay.setItemsOverlayShown(false);
@@ -311,26 +312,26 @@ public class RaidsPlugin extends Plugin
 					double percentage = personalPoints / (totalPoints / 100.0);
 
 					String chatMessage = new ChatMessageBuilder()
-							.append(ChatColorType.NORMAL)
-							.append("Total points: ")
-							.append(ChatColorType.HIGHLIGHT)
-							.append(POINTS_FORMAT.format(totalPoints))
-							.append(ChatColorType.NORMAL)
-							.append(", Personal points: ")
-							.append(ChatColorType.HIGHLIGHT)
-							.append(POINTS_FORMAT.format(personalPoints))
-							.append(ChatColorType.NORMAL)
-							.append(" (")
-							.append(ChatColorType.HIGHLIGHT)
-							.append(DECIMAL_FORMAT.format(percentage))
-							.append(ChatColorType.NORMAL)
-							.append("%)")
-							.build();
+						.append(ChatColorType.NORMAL)
+						.append("Total points: ")
+						.append(ChatColorType.HIGHLIGHT)
+						.append(POINTS_FORMAT.format(totalPoints))
+						.append(ChatColorType.NORMAL)
+						.append(", Personal points: ")
+						.append(ChatColorType.HIGHLIGHT)
+						.append(POINTS_FORMAT.format(personalPoints))
+						.append(ChatColorType.NORMAL)
+						.append(" (")
+						.append(ChatColorType.HIGHLIGHT)
+						.append(DECIMAL_FORMAT.format(percentage))
+						.append(ChatColorType.NORMAL)
+						.append("%)")
+						.build();
 
 					chatMessageManager.queue(QueuedMessage.builder()
-							.type(ChatMessageType.CLANCHAT_INFO)
-							.runeLiteFormattedMessage(chatMessage)
-							.build());
+						.type(ChatMessageType.CLANCHAT_INFO)
+						.runeLiteFormattedMessage(chatMessage)
+						.build());
 				}
 			}
 		}
@@ -390,10 +391,10 @@ public class RaidsPlugin extends Plugin
 	private void cacheColors()
 	{
 		chatMessageManager.cacheColor(new ChatColor(ChatColorType.NORMAL, Color.BLACK, false), ChatMessageType.CLANCHAT_INFO)
-				.cacheColor(new ChatColor(ChatColorType.HIGHLIGHT, Color.RED, false), ChatMessageType.CLANCHAT_INFO)
-				.cacheColor(new ChatColor(ChatColorType.NORMAL, Color.WHITE, true), ChatMessageType.CLANCHAT_INFO)
-				.cacheColor(new ChatColor(ChatColorType.HIGHLIGHT, Color.RED, true), ChatMessageType.CLANCHAT_INFO)
-				.refreshAll();
+			.cacheColor(new ChatColor(ChatColorType.HIGHLIGHT, Color.RED, false), ChatMessageType.CLANCHAT_INFO)
+			.cacheColor(new ChatColor(ChatColorType.NORMAL, Color.WHITE, true), ChatMessageType.CLANCHAT_INFO)
+			.cacheColor(new ChatColor(ChatColorType.HIGHLIGHT, Color.RED, true), ChatMessageType.CLANCHAT_INFO)
+			.refreshAll();
 	}
 
 	public int getRotationMatches()
@@ -563,7 +564,7 @@ public class RaidsPlugin extends Plugin
 				room.setType(RaidRoom.Type.COMBAT);
 				room.setBoss(RaidRoom.Boss.SHAMANS);
 				room.setItemType("Antipoison");
-				room.setItemIds(new int[] {5943, 4945, 5947, 5949, 5952, 5954, 5956, 5958, 10925, 10927, 10929, 10931, 175, 177, 179, 181, 183, 185, 2446, 2448, 11433, 11435, 11501, 11503});
+				room.setItemIds(new int[]{5943, 4945, 5947, 5949, 5952, 5954, 5956, 5958, 10925, 10927, 10929, 10931, 175, 177, 179, 181, 183, 185, 2446, 2448, 11433, 11435, 11501, 11503});
 				break;
 
 			case RAIDS_VASA:
@@ -615,7 +616,7 @@ public class RaidsPlugin extends Plugin
 				room.setType(RaidRoom.Type.COMBAT);
 				room.setBoss(RaidRoom.Boss.GUARDIANS);
 				room.setItemType("Pickaxe");
-				room.setItemIds(new int[] {1265, 1267, 1269, 1271, 1273, 1275, 11920, 12297, 12797, 13243, 13244, 20014});
+				room.setItemIds(new int[]{1265, 1267, 1269, 1271, 1273, 1275, 11920, 12297, 12797, 13243, 13244, 20014});
 				break;
 
 			case RAIDS_CRABS:

--- a/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsPlugin.java
@@ -73,7 +73,7 @@ import net.runelite.client.ui.overlay.infobox.InfoBoxManager;
 import net.runelite.client.util.Text;
 
 @PluginDescriptor(
-	name = "Chambers Of Xeric"
+		name = "Chambers Of Xeric"
 )
 @Slf4j
 public class RaidsPlugin extends Plugin
@@ -106,10 +106,13 @@ public class RaidsPlugin extends Plugin
 	private RaidsConfig config;
 
 	@Inject
-	private RaidsOverlay overlay;
+	private RaidsOverlay scoutOverlay;
 
 	@Inject
 	private RaidsPointsOverlay pointsOverlay;
+
+	@Inject
+	private RaidsItemsOverlay itemsOverlay;
 
 	@Inject
 	private LayoutSolver layoutSolver;
@@ -144,7 +147,7 @@ public class RaidsPlugin extends Plugin
 	@Override
 	public List<Overlay> getOverlays()
 	{
-		return Arrays.asList(overlay, pointsOverlay);
+		return Arrays.asList(scoutOverlay, pointsOverlay, itemsOverlay);
 	}
 
 	@Override
@@ -253,18 +256,23 @@ public class RaidsPlugin extends Plugin
 
 				raid.updateLayout(layout);
 				RotationSolver.solve(raid.getCombatRooms());
-				overlay.setScoutOverlayShown(true);
+				scoutOverlay.setScoutOverlayShown(true);
+				itemsOverlay.setItemsOverlayShown(true);
 			}
-			else if (!config.scoutOverlayAtBank())
+			else
 			{
-				overlay.setScoutOverlayShown(false);
+				if(!config.scoutOverlayAtBank()) {
+					scoutOverlay.setScoutOverlayShown(false);
+				}
+				itemsOverlay.setItemsOverlayShown(false);
 				raid = null;
 			}
 		}
 
 		if (client.getVar(VarPlayer.IN_RAID_PARTY) == -1)
 		{
-			overlay.setScoutOverlayShown(false);
+			scoutOverlay.setScoutOverlayShown(false);
+			itemsOverlay.setItemsOverlayShown(false);
 			raid = null;
 		}
 	}
@@ -320,9 +328,9 @@ public class RaidsPlugin extends Plugin
 							.build();
 
 					chatMessageManager.queue(QueuedMessage.builder()
-						.type(ChatMessageType.CLANCHAT_INFO)
-						.runeLiteFormattedMessage(chatMessage)
-						.build());
+							.type(ChatMessageType.CLANCHAT_INFO)
+							.runeLiteFormattedMessage(chatMessage)
+							.build());
 				}
 			}
 		}
@@ -554,6 +562,8 @@ public class RaidsPlugin extends Plugin
 			case RAIDS_SHAMANS:
 				room.setType(RaidRoom.Type.COMBAT);
 				room.setBoss(RaidRoom.Boss.SHAMANS);
+				room.setItemType("Antipoison");
+				room.setItemIds(new int[] {5943, 4945, 5947, 5949, 5952, 5954, 5956, 5958, 10925, 10927, 10929, 10931, 175, 177, 179, 181, 183, 185, 2446, 2448, 11433, 11435, 11501, 11503});
 				break;
 
 			case RAIDS_VASA:
@@ -604,6 +614,8 @@ public class RaidsPlugin extends Plugin
 			case RAIDS_GUARDIANS:
 				room.setType(RaidRoom.Type.COMBAT);
 				room.setBoss(RaidRoom.Boss.GUARDIANS);
+				room.setItemType("Pickaxe");
+				room.setItemIds(new int[] {1265, 1267, 1269, 1271, 1273, 1275, 11920, 12297, 12797, 13243, 13244, 20014});
 				break;
 
 			case RAIDS_CRABS:


### PR DESCRIPTION
**Overview**
The raids items overlay assists raiders by displaying the items required to complete the raid.

**Current State**
The interface is populated based on the rooms that are scouted. Each room that requires has an item type (ex: "Pickaxe" for Guardians or "Antipoison" for Lizardman Shamans) and a list of items that fulfill the requirement (ex: any pickaxe bronze-rune for Guardians). If the player has the item, the first matching item found in their inventory will display on the interface in green. If the player does not have the item, the item "type" will show in the interface in red.

![2018-05-23_15-25-01](https://user-images.githubusercontent.com/15053687/40451876-0f926e80-5eae-11e8-8ca0-fb9a575fab3f.png)

**Future State**
Future releases will add recommended items and potentially a list of custom items that the player can enter in a text field. This will allow a more robust and customized user experience based on the player's preferred loadout.
