### PR TITLE
Add support for fullscreen mode

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/config/RuneLiteConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/RuneLiteConfig.java
@@ -113,6 +113,18 @@ public interface RuneLiteConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "fullscreen",
+		name = "Fullscreen mode",
+		description = "Switch window to fullscreen mode.",
+		warning = "Please restart your client after changing this setting",
+		position = 17
+	)
+	default boolean enableFullscreen()
+	{
+		return false;
+	}
+
+	@ConfigItem(
 		keyName = "notificationTray",
 		name = "Enable tray notifications",
 		description = "Enables tray notifications",

--- a/runelite-client/src/main/java/net/runelite/client/util/OSXUtil.java
+++ b/runelite-client/src/main/java/net/runelite/client/util/OSXUtil.java
@@ -26,6 +26,7 @@ package net.runelite.client.util;
 
 import com.apple.eawt.Application;
 import com.apple.eawt.FullScreenUtilities;
+import java.awt.Window;
 import javax.swing.JFrame;
 import lombok.extern.slf4j.Slf4j;
 
@@ -60,5 +61,21 @@ public class OSXUtil
 			app.requestForeground(true);
 			log.debug("Requested focus on macOS");
 		}
+	}
+
+	/**
+	 * Requests the fullscreen in a macOS friendly way
+	 */
+	public static boolean toggleFullscreen(final Window window)
+	{
+		if (OSType.getOSType() == OSType.MacOS)
+		{
+			Application app = Application.getApplication();
+			app.requestToggleFullScreen(window);
+			log.debug("Requested fullscreen on macOS");
+			return true;
+		}
+
+		return false;
 	}
 }


### PR DESCRIPTION
Add support for toggle in "RuneLite" settings to go into fullscreen
mode, that will make RuneLite window fully fullscreen without any weird
hacks.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>

Preview (ignore my WM top bar):
![screenie](https://user-images.githubusercontent.com/5115805/40493367-e21980f4-5f72-11e8-896c-5fc63b103dbc.png)
