### PR TITLE
Skill Calculator Cleanup

### DIFF
--- a/runelite-client/src/main/resources/net/runelite/client/plugins/skillcalculator/skill_construction.json
+++ b/runelite-client/src/main/resources/net/runelite/client/plugins/skillcalculator/skill_construction.json
@@ -2,33 +2,9 @@
   "actions": [
     {
       "level": 1,
-      "icon": 8168,
-      "name": "Exit Portal",
-      "xp": 100
-    },
-    {
-      "level": 1,
       "icon": 960,
       "name": "Plank",
       "xp": 29
-    },
-    {
-      "level": 1,
-      "icon": 8780,
-      "name": "Teak Plank",
-      "xp": 90
-    },
-    {
-      "level": 1,
-      "icon": 8180,
-      "name": "Plant",
-      "xp": 31
-    },
-    {
-      "level": 1,
-      "icon": 8782,
-      "name": "Mahogany Plank",
-      "xp": 140
     },
     {
       "level": 1,
@@ -38,9 +14,15 @@
     },
     {
       "level": 1,
-      "icon": 8186,
-      "name": "Fern",
-      "xp": 31
+      "icon": 8780,
+      "name": "Teak Plank",
+      "xp": 90
+    },
+    {
+      "level": 1,
+      "icon": 8782,
+      "name": "Mahogany Plank",
+      "xp": 140
     },
     {
       "level": 1,
@@ -50,105 +32,9 @@
     },
     {
       "level": 1,
-      "icon": 8183,
-      "name": "Dock Leaf",
-      "xp": 31
-    },
-    {
-      "level": 1,
       "icon": 8309,
       "name": "Crude Wooden Chair",
       "xp": 58
-    },
-    {
-      "level": 2,
-      "icon": 8316,
-      "name": "Brown Rug",
-      "xp": 30
-    },
-    {
-      "level": 2,
-      "icon": 8322,
-      "name": "Torn Curtains",
-      "xp": 132
-    },
-    {
-      "level": 3,
-      "icon": 8325,
-      "name": "Clay Fireplace",
-      "xp": 30
-    },
-    {
-      "level": 4,
-      "icon": 8319,
-      "name": "Wooden Bookcase",
-      "xp": 115
-    },
-    {
-      "level": 5,
-      "icon": 8216,
-      "name": "Firepit",
-      "xp": 40
-    },
-    {
-      "level": 5,
-      "icon": 8236,
-      "name": "Cat Blanket",
-      "xp": 15
-    },
-    {
-      "level": 5,
-      "icon": 8169,
-      "name": "Decorative Rock",
-      "xp": 100
-    },
-    {
-      "level": 5,
-      "icon": 8173,
-      "name": "Tree",
-      "xp": 31
-    },
-    {
-      "level": 6,
-      "icon": 8181,
-      "name": "Small Fern",
-      "xp": 70
-    },
-    {
-      "level": 6,
-      "icon": 8184,
-      "name": "Thistle",
-      "xp": 70
-    },
-    {
-      "level": 6,
-      "icon": 8187,
-      "name": "Bush",
-      "xp": 70
-    },
-    {
-      "level": 6,
-      "icon": 8187,
-      "name": "Large Leaf Bush",
-      "xp": 70
-    },
-    {
-      "level": 6,
-      "icon": 8223,
-      "name": "Wooden Shelves 1",
-      "xp": 87
-    },
-    {
-      "level": 7,
-      "icon": 8230,
-      "name": "Pump and Drain",
-      "xp": 100
-    },
-    {
-      "level": 7,
-      "icon": 8239,
-      "name": "Beer Barrel",
-      "xp": 87
     },
     {
       "level": 8,
@@ -170,123 +56,15 @@
     },
     {
       "level": 10,
-      "icon": 8170,
-      "name": "Pond",
-      "xp": 100
-    },
-    {
-      "level": 10,
-      "icon": 8174,
-      "name": "Nice Tree",
-      "xp": 44
-    },
-    {
-      "level": 10,
       "icon": 8108,
       "name": "Wooden Bench",
       "xp": 115
-    },
-    {
-      "level": 11,
-      "icon": 8217,
-      "name": "Firepit with Hook",
-      "xp": 60
-    },
-    {
-      "level": 12,
-      "icon": 8185,
-      "name": "Reeds",
-      "xp": 100
-    },
-    {
-      "level": 12,
-      "icon": 8186,
-      "name": "Fern",
-      "xp": 70
-    },
-    {
-      "level": 12,
-      "icon": 8240,
-      "name": "Cider Barrel",
-      "xp": 91
-    },
-    {
-      "level": 12,
-      "icon": 8224,
-      "name": "Wooden Shelves 2",
-      "xp": 147
     },
     {
       "level": 12,
       "icon": 8115,
       "name": "Wood Table",
       "xp": 87
-    },
-    {
-      "level": 12,
-      "icon": 8191,
-      "name": "Huge Plant",
-      "xp": 100
-    },
-    {
-      "level": 12,
-      "icon": 8188,
-      "name": "Tall Plant",
-      "xp": 100
-    },
-    {
-      "level": 13,
-      "icon": 8317,
-      "name": "Rug",
-      "xp": 60
-    },
-    {
-      "level": 14,
-      "icon": 8311,
-      "name": "Rocking Chair",
-      "xp": 87
-    },
-    {
-      "level": 15,
-      "icon": 8171,
-      "name": "Imp Statue",
-      "xp": 150
-    },
-    {
-      "level": 15,
-      "icon": 8175,
-      "name": "Oak Tree",
-      "xp": 70
-    },
-    {
-      "level": 16,
-      "icon": 8102,
-      "name": "Oak Decoration",
-      "xp": 120
-    },
-    {
-      "level": 17,
-      "icon": 8218,
-      "name": "Firepit with Pot",
-      "xp": 80
-    },
-    {
-      "level": 18,
-      "icon": 8323,
-      "name": "Curtains",
-      "xp": 225
-    },
-    {
-      "level": 18,
-      "icon": 1905,
-      "name": "Asgarnian Ale",
-      "xp": 184
-    },
-    {
-      "level": 19,
-      "icon": 8237,
-      "name": "Cat Basket",
-      "xp": 58
     },
     {
       "level": 19,
@@ -299,18 +77,6 @@
       "icon": 8031,
       "name": "Wooden Bed",
       "xp": 117
-    },
-    {
-      "level": 20,
-      "icon": 8038,
-      "name": "Shoe Box",
-      "xp": 58
-    },
-    {
-      "level": 21,
-      "icon": 8045,
-      "name": "Shaving Stand",
-      "xp": 30
     },
     {
       "level": 22,
@@ -326,93 +92,9 @@
     },
     {
       "level": 23,
-      "icon": 8225,
-      "name": "Wooden Shelves 3",
-      "xp": 147
-    },
-    {
-      "level": 23,
       "icon": 8313,
       "name": "Oak Armchair",
       "xp": 180
-    },
-    {
-      "level": 24,
-      "icon": 8219,
-      "name": "Small Oven",
-      "xp": 80
-    },
-    {
-      "level": 25,
-      "icon": 8052,
-      "name": "Oak Clock",
-      "xp": 142
-    },
-    {
-      "level": 26,
-      "icon": 1909,
-      "name": "Greenman's Ale",
-      "xp": 184
-    },
-    {
-      "level": 26,
-      "icon": 8099,
-      "name": "Rope Bell-Pull",
-      "xp": 64
-    },
-    {
-      "level": 27,
-      "icon": 8231,
-      "name": "Pump and Tub",
-      "xp": 200
-    },
-    {
-      "level": 27,
-      "icon": 8039,
-      "name": "Oak Drawers",
-      "xp": 120
-    },
-    {
-      "level": 29,
-      "icon": 8320,
-      "name": "Oak Bookcase",
-      "xp": 180
-    },
-    {
-      "level": 29,
-      "icon": 8220,
-      "name": "Large Oven",
-      "xp": 100
-    },
-    {
-      "level": 29,
-      "icon": 8046,
-      "name": "Oak Shaving Stand",
-      "xp": 61
-    },
-    {
-      "level": 30,
-      "icon": 8176,
-      "name": "Willow Tree",
-      "xp": 100
-    },
-    {
-      "level": 30,
-      "icon": 8032,
-      "name": "Oak Bed",
-      "xp": 210
-    },
-    {
-      "level": 31,
-      "icon": 8110,
-      "name": "Carved Oak Bench",
-      "xp": 240
-    },
-    {
-      "level": 31,
-      "icon": 8117,
-      "name": "Carved Oak Table",
-      "xp": 360
     },
     {
       "level": 32,
@@ -421,82 +103,16 @@
       "xp": 180
     },
     {
-      "level": 32,
-      "icon": 8023,
-      "name": "Boxing Ring",
-      "xp": 420
-    },
-    {
       "level": 33,
       "icon": 8234,
       "name": "Oak Larder",
       "xp": 480
     },
     {
-      "level": 33,
-      "icon": 8238,
-      "name": "Cushioned Basket",
-      "xp": 58
-    },
-    {
-      "level": 33,
-      "icon": 8326,
-      "name": "Stone Fireplace",
-      "xp": 40
-    },
-    {
-      "level": 34,
-      "icon": 8221,
-      "name": "Steel Range",
-      "xp": 120
-    },
-    {
-      "level": 34,
-      "icon": 8226,
-      "name": "Oak Shelves 1",
-      "xp": 240
-    },
-    {
-      "level": 34,
-      "icon": 8028,
-      "name": "Glove Rack",
-      "xp": 120
-    },
-    {
-      "level": 34,
-      "icon": 8033,
-      "name": "Large Oak Bed",
-      "xp": 330
-    },
-    {
       "level": 35,
       "icon": 8314,
       "name": "Teak Armchair",
       "xp": 180
-    },
-    {
-      "level": 36,
-      "icon": 1911,
-      "name": "Dragon Bitter",
-      "xp": 224
-    },
-    {
-      "level": 36,
-      "icon": 8103,
-      "name": "Teak Decoration",
-      "xp": 180
-    },
-    {
-      "level": 37,
-      "icon": 8100,
-      "name": "Bell-Pull",
-      "xp": 120
-    },
-    {
-      "level": 37,
-      "icon": 8047,
-      "name": "Oak Dresser",
-      "xp": 121
     },
     {
       "level": 38,
@@ -511,106 +127,10 @@
       "xp": 360
     },
     {
-      "level": 39,
-      "icon": 8040,
-      "name": "Oak Wardrobe",
-      "xp": 180
-    },
-    {
-      "level": 40,
-      "icon": 8034,
-      "name": "Teak Bed",
-      "xp": 300
-    },
-    {
-      "level": 40,
-      "icon": 8321,
-      "name": "Mahogany Bookcase",
-      "xp": 420
-    },
-    {
-      "level": 40,
-      "icon": 8334,
-      "name": "Oak Lectern",
-      "xp": 60
-    },
-    {
-      "level": 40,
-      "icon": 8324,
-      "name": "Opulent Curtains",
-      "xp": 315
-    },
-    {
-      "level": 41,
-      "icon": 8024,
-      "name": "Fencing Ring",
-      "xp": 570
-    },
-    {
-      "level": 41,
-      "icon": 8341,
-      "name": "Globe",
-      "xp": 180
-    },
-    {
-      "level": 42,
-      "icon": 8222,
-      "name": "Fancy Range",
-      "xp": 160
-    },
-    {
-      "level": 42,
-      "icon": 8351,
-      "name": "Crystal Ball",
-      "xp": 280
-    },
-    {
-      "level": 43,
-      "icon": 8354,
-      "name": "Alchemical Chart",
-      "xp": 30
-    },
-    {
       "level": 43,
       "icon": 8235,
       "name": "Teak larder",
       "xp": 750
-    },
-    {
-      "level": 44,
-      "icon": 8348,
-      "name": "Wooden Telescope",
-      "xp": 121
-    },
-    {
-      "level": 44,
-      "icon": 8029,
-      "name": "Weapons Rack",
-      "xp": 180
-    },
-    {
-      "level": 44,
-      "icon": 8112,
-      "name": "Carved Teak Bench",
-      "xp": 360
-    },
-    {
-      "level": 45,
-      "icon": 8227,
-      "name": "Oak Shelves 2",
-      "xp": 240
-    },
-    {
-      "level": 45,
-      "icon": 8119,
-      "name": "Carved Teak Table",
-      "xp": 600
-    },
-    {
-      "level": 45,
-      "icon": 8035,
-      "name": "Large Teak Bed",
-      "xp": 480
     },
     {
       "level": 45,
@@ -619,70 +139,10 @@
       "xp": 122
     },
     {
-      "level": 46,
-      "icon": 8048,
-      "name": "Teak Dresser",
-      "xp": 181
-    },
-    {
-      "level": 47,
-      "icon": 8232,
-      "name": "Sink",
-      "xp": 300
-    },
-    {
-      "level": 47,
-      "icon": 8335,
-      "name": "Eagle Lectern",
-      "xp": 120
-    },
-    {
-      "level": 47,
-      "icon": 8336,
-      "name": "Demon Lectern",
-      "xp": 120
-    },
-    {
-      "level": 48,
-      "icon": 5755,
-      "name": "Chef's Delight",
-      "xp": 224
-    },
-    {
-      "level": 50,
-      "icon": 8328,
-      "name": "Teak Portal",
-      "xp": 270
-    },
-    {
       "level": 50,
       "icon": 8315,
       "name": "Mahogany Armchair",
       "xp": 280
-    },
-    {
-      "level": 50,
-      "icon": 8342,
-      "name": "Ornamental Globe",
-      "xp": 270
-    },
-    {
-      "level": 50,
-      "icon": 8331,
-      "name": "Teleport Focus",
-      "xp": 40
-    },
-    {
-      "level": 51,
-      "icon": 8041,
-      "name": "Teak Drawers",
-      "xp": 180
-    },
-    {
-      "level": 51,
-      "icon": 8025,
-      "name": "Combat Ring",
-      "xp": 630
     },
     {
       "level": 52,
@@ -703,274 +163,10 @@
       "xp": 840
     },
     {
-      "level": 53,
-      "icon": 8036,
-      "name": "4-Poster Bed",
-      "xp": 450
-    },
-    {
-      "level": 54,
-      "icon": 8030,
-      "name": "Extra Weapons Rack",
-      "xp": 440
-    },
-    {
-      "level": 54,
-      "icon": 8352,
-      "name": "Elemental Sphere",
-      "xp": 580
-    },
-    {
-      "level": 55,
-      "icon": 8053,
-      "name": "Teak Clock",
-      "xp": 202
-    },
-    {
-      "level": 56,
-      "icon": 8104,
-      "name": "Gilded Decoration",
-      "xp": 1020
-    },
-    {
-      "level": 56,
-      "icon": 8049,
-      "name": "Fancy Teak Dresser",
-      "xp": 182
-    },
-    {
-      "level": 56,
-      "icon": 8228,
-      "name": "Teak Shelves 1",
-      "xp": 330
-    },
-    {
-      "level": 57,
-      "icon": 8337,
-      "name": "Teak Eagle Lectern",
-      "xp": 180
-    },
-    {
-      "level": 57,
-      "icon": 8338,
-      "name": "Teak Demon Lectern",
-      "xp": 180
-    },
-    {
-      "level": 59,
-      "icon": 8343,
-      "name": "Lunar Globe",
-      "xp": 570
-    },
-    {
-      "level": 60,
-      "icon": 8037,
-      "name": "Gilded 4-Poster Bed",
-      "xp": 1330
-    },
-    {
-      "level": 60,
-      "icon": 8101,
-      "name": "Posh Bell-Pull",
-      "xp": 420
-    },
-    {
-      "level": 60,
-      "icon": 8178,
-      "name": "Yew Tree",
-      "xp": 141
-    },
-    {
-      "level": 61,
-      "icon": 8114,
-      "name": "Gilded Bench",
-      "xp": 1760
-    },
-    {
-      "level": 63,
-      "icon": 8042,
-      "name": "Teak Wardrobe",
-      "xp": 270
-    },
-    {
-      "level": 63,
-      "icon": 8327,
-      "name": "Marble Fireplace",
-      "xp": 500
-    },
-    {
-      "level": 63,
-      "icon": 8355,
-      "name": "Astronomical Chart",
-      "xp": 45
-    },
-    {
-      "level": 64,
-      "icon": 8349,
-      "name": "Teak Telescope",
-      "xp": 181
-    },
-    {
-      "level": 64,
-      "icon": 8050,
-      "name": "Mahogany Dresser",
-      "xp": 281
-    },
-    {
-      "level": 65,
-      "icon": 8329,
-      "name": "Mahogany Portal",
-      "xp": 420
-    },
-    {
-      "level": 65,
-      "icon": 8332,
-      "name": "Greater Focus",
-      "xp": 500
-    },
-    {
-      "level": 65,
-      "icon": 8318,
-      "name": "Opulent Rug",
-      "xp": 360
-    },
-    {
-      "level": 66,
-      "icon": 20649,
-      "name": "Teak Garden Bench",
-      "xp": 540
-    },
-    {
-      "level": 66,
-      "icon": 8353,
-      "name": "Crystal of Power",
-      "xp": 890
-    },
-    {
-      "level": 67,
-      "icon": 8229,
-      "name": "Teak Shelves 2",
-      "xp": 930
-    },
-    {
-      "level": 67,
-      "icon": 8338,
-      "name": "Mahogany Demon Lectern",
-      "xp": 580
-    },
-    {
-      "level": 67,
-      "icon": 8338,
-      "name": "Mahogany Eagle Lectern",
-      "xp": 580
-    },
-    {
-      "level": 68,
-      "icon": 8344,
-      "name": "Celestial Globe",
-      "xp": 570
-    },
-    {
-      "level": 70,
-      "icon": 8172,
-      "name": "Dungeon Entrance",
-      "xp": 500
-    },
-    {
-      "level": 71,
-      "icon": 8026,
-      "name": "Ranging Pedestals",
-      "xp": 720
-    },
-    {
-      "level": 72,
-      "icon": 8121,
-      "name": "Opulent Table",
-      "xp": 3100
-    },
-    {
       "level": 74,
       "icon": 8122,
       "name": "Oak Door",
       "xp": 600
-    },
-    {
-      "level": 74,
-      "icon": 8051,
-      "name": "Gilded Dresser",
-      "xp": 582
-    },
-    {
-      "level": 75,
-      "icon": 8043,
-      "name": "Mahogany Wardrobe",
-      "xp": 420
-    },
-    {
-      "level": 75,
-      "icon": 8179,
-      "name": "Magic Tree",
-      "xp": 223
-    },
-    {
-      "level": 77,
-      "icon": 8341,
-      "name": "Armillary Globe",
-      "xp": 960
-    },
-    {
-      "level": 80,
-      "icon": 8330,
-      "name": "Marble Portal",
-      "xp": 1500
-    },
-    {
-      "level": 80,
-      "icon": 8333,
-      "name": "Scrying Pool",
-      "xp": 2000
-    },
-    {
-      "level": 81,
-      "icon": 8027,
-      "name": "Balance Beam",
-      "xp": 1000
-    },
-    {
-      "level": 83,
-      "icon": 8356,
-      "name": "Infernal Chart",
-      "xp": 60
-    },
-    {
-      "level": 84,
-      "icon": 8350,
-      "name": "Mahogany Telescope",
-      "xp": 281
-    },
-    {
-      "level": 85,
-      "icon": 8054,
-      "name": "Gilded Clock",
-      "xp": 602
-    },
-    {
-      "level": 86,
-      "icon": 8346,
-      "name": "Small Orrery",
-      "xp": 1320
-    },
-    {
-      "level": 87,
-      "icon": 8044,
-      "name": "Gilded Wardrobe",
-      "xp": 720
-    },
-    {
-      "level": 95,
-      "icon": 8347,
-      "name": "Large Orrery",
-      "xp": 1420
     }
   ]
 }

--- a/runelite-client/src/main/resources/net/runelite/client/plugins/skillcalculator/skill_cooking.json
+++ b/runelite-client/src/main/resources/net/runelite/client/plugins/skillcalculator/skill_cooking.json
@@ -20,12 +20,6 @@
     },
     {
       "level": 1,
-      "icon": 3228,
-      "name": "Cooked Rabbit",
-      "xp": 30
-    },
-    {
-      "level": 1,
       "icon": 325,
       "name": "Sardine",
       "xp": 40
@@ -37,21 +31,9 @@
       "xp": 40
     },
     {
-      "level": 3,
-      "icon": 9436,
-      "name": "Sinew",
-      "xp": 3
-    },
-    {
       "level": 5,
       "icon": 347,
       "name": "Herring",
-      "xp": 50
-    },
-    {
-      "level": 6,
-      "icon": 2084,
-      "name": "Fruit Blast",
       "xp": 50
     },
     {
@@ -59,18 +41,6 @@
       "icon": 6701,
       "name": "Baked Potato",
       "xp": 15
-    },
-    {
-      "level": 8,
-      "icon": 2048,
-      "name": "Pineapple Punch",
-      "xp": 70
-    },
-    {
-      "level": 9,
-      "icon": 7072,
-      "name": "Spicy Sauce",
-      "xp": 24
     },
     {
       "level": 10,
@@ -85,46 +55,10 @@
       "xp": 78
     },
     {
-      "level": 10,
-      "icon": 2217,
-      "name": "Toad Crunchies",
-      "xp": 100
-    },
-    {
-      "level": 11,
-      "icon": 7062,
-      "name": "Chilli Con Carne",
-      "xp": 55
-    },
-    {
       "level": 11,
       "icon": 9980,
       "name": "Roast Bird Meat",
       "xp": 62.5
-    },
-    {
-      "level": 12,
-      "icon": 3369,
-      "name": "Thin Snail Meat",
-      "xp": 70
-    },
-    {
-      "level": 13,
-      "icon": 7078,
-      "name": "Scrambled Egg",
-      "xp": 50
-    },
-    {
-      "level": 14,
-      "icon": 5763,
-      "name": "Cider",
-      "xp": 182
-    },
-    {
-      "level": 14,
-      "icon": 2205,
-      "name": "Worm Crunchies",
-      "xp": 104
     },
     {
       "level": 15,
@@ -145,34 +79,10 @@
       "xp": 72.5
     },
     {
-      "level": 17,
-      "icon": 3371,
-      "name": "Lean Snail Meat",
-      "xp": 80
-    },
-    {
       "level": 18,
       "icon": 339,
       "name": "Cod",
       "xp": 75
-    },
-    {
-      "level": 18,
-      "icon": 2054,
-      "name": "Wizard Blizzard",
-      "xp": 110
-    },
-    {
-      "level": 19,
-      "icon": 1913,
-      "name": "Dwarven Stout",
-      "xp": 215
-    },
-    {
-      "level": 20,
-      "icon": 2080,
-      "name": "Short Green Guy",
-      "xp": 120
     },
     {
       "level": 20,
@@ -187,30 +97,6 @@
       "xp": 80
     },
     {
-      "level": 21,
-      "icon": 9988,
-      "name": "Roast Beast Meat",
-      "xp": 82.5
-    },
-    {
-      "level": 22,
-      "icon": 3373,
-      "name": "Fat Snail Meat",
-      "xp": 95
-    },
-    {
-      "level": 23,
-      "icon": 7064,
-      "name": "Egg And Tomato",
-      "xp": 50
-    },
-    {
-      "level": 24,
-      "icon": 1905,
-      "name": "Asgarnian Ale",
-      "xp": 248
-    },
-    {
       "level": 25,
       "icon": 329,
       "name": "Salmon",
@@ -223,40 +109,10 @@
       "xp": 117
     },
     {
-      "level": 25,
-      "icon": 2277,
-      "name": "Fruit Batta",
-      "xp": 150
-    },
-    {
-      "level": 26,
-      "icon": 2255,
-      "name": "Toad Batta",
-      "xp": 152
-    },
-    {
-      "level": 27,
-      "icon": 2253,
-      "name": "Worm Batta",
-      "xp": 154
-    },
-    {
-      "level": 28,
-      "icon": 2281,
-      "name": "Vegetable Batta",
-      "xp": 156
-    },
-    {
       "level": 28,
       "icon": 5988,
       "name": "Sweetcorn",
       "xp": 104
-    },
-    {
-      "level": 28,
-      "icon": 3381,
-      "name": "Cooked Slimy Eel",
-      "xp": 95
     },
     {
       "level": 29,
@@ -278,21 +134,9 @@
     },
     {
       "level": 30,
-      "icon": 2191,
-      "name": "Worm Hole",
-      "xp": 170
-    },
-    {
-      "level": 30,
       "icon": 3144,
       "name": "Cooked Karambwan",
       "xp": 190
-    },
-    {
-      "level": 32,
-      "icon": 2092,
-      "name": "Drunk Dragon",
-      "xp": 160
     },
     {
       "level": 34,
@@ -319,24 +163,6 @@
       "xp": 110
     },
     {
-      "level": 37,
-      "icon": 2064,
-      "name": "Blurberry Special",
-      "xp": 180
-    },
-    {
-      "level": 38,
-      "icon": 5003,
-      "name": "Cave Eel",
-      "xp": 115
-    },
-    {
-      "level": 39,
-      "icon": 1911,
-      "name": "Dragon Bitter",
-      "xp": 347
-    },
-    {
       "level": 40,
       "icon": 379,
       "name": "Lobster",
@@ -349,28 +175,10 @@
       "xp": 180
     },
     {
-      "level": 41,
-      "icon": 7054,
-      "name": "Chilli Potato",
-      "xp": 165.5
-    },
-    {
-      "level": 42,
-      "icon": 2185,
-      "name": "Chocolate Bomb",
-      "xp": 190
-    },
-    {
       "level": 43,
       "icon": 365,
       "name": "Bass",
       "xp": 130
-    },
-    {
-      "level": 44,
-      "icon": 2955,
-      "name": "Moonlight Mead",
-      "xp": 380
     },
     {
       "level": 45,
@@ -392,33 +200,15 @@
     },
     {
       "level": 50,
-      "icon": 2343,
-      "name": "Cooked Oomlie Wrap",
-      "xp": 30
-    },
-    {
-      "level": 50,
       "icon": 1897,
       "name": "Chocolate Cake",
       "xp": 210
-    },
-    {
-      "level": 51,
-      "icon": 7056,
-      "name": "Egg Potato",
-      "xp": 195.5
     },
     {
       "level": 55,
       "icon": 2297,
       "name": "Anchovy Pizza",
       "xp": 182
-    },
-    {
-      "level": 58,
-      "icon": 1883,
-      "name": "Ugthanki Kebab (Fresh)",
-      "xp": 80
     },
     {
       "level": 60,
@@ -443,12 +233,6 @@
       "icon": 2301,
       "name": "Pineapple Pizza",
       "xp": 188
-    },
-    {
-      "level": 67,
-      "icon": 7068,
-      "name": "Tuna And Corn",
-      "xp": 204
     },
     {
       "level": 68,

--- a/runelite-client/src/main/resources/net/runelite/client/plugins/skillcalculator/skill_crafting.json
+++ b/runelite-client/src/main/resources/net/runelite/client/plugins/skillcalculator/skill_crafting.json
@@ -380,7 +380,7 @@
     },
     {
       "level": 67,
-      "icon": 6564,
+      "icon": 6575,
       "name": "Onyx Ring",
       "xp": 115
     },
@@ -500,7 +500,7 @@
     },
     {
       "level": 89,
-      "icon": 19499,
+      "icon": 19538,
       "name": "Zenyte Ring",
       "xp": 150
     },
@@ -518,7 +518,7 @@
     },
     {
       "level": 92,
-      "icon": 19500,
+      "icon": 19535,
       "name": "Zenyte Necklace",
       "xp": 165
     },

--- a/runelite-client/src/main/resources/net/runelite/client/plugins/skillcalculator/skill_herblore.json
+++ b/runelite-client/src/main/resources/net/runelite/client/plugins/skillcalculator/skill_herblore.json
@@ -243,8 +243,8 @@
     {
       "level": 77,
       "icon": 12627,
-      "name": "Stamina Potion (3)",
-      "xp": 76.5
+      "name": "Stamina Potion (4)",
+      "xp": 102
     },
     {
       "level": 78,
@@ -279,8 +279,8 @@
     {
       "level": 87,
       "icon": 12907,
-      "name": "Anti-venom(3)",
-      "xp": 90
+      "name": "Anti-venom(4)",
+      "xp": 120
     },
     {
       "level": 90,
@@ -293,12 +293,6 @@
       "icon": 12915,
       "name": "Anti-venom+(3)",
       "xp": 125
-    },
-    {
-      "level": 98,
-      "icon": 21981,
-      "name": "Extended Super Antifire (3)",
-      "xp": 120
     },
     {
       "level": 98,

--- a/runelite-client/src/main/resources/net/runelite/client/plugins/skillcalculator/skill_prayer.json
+++ b/runelite-client/src/main/resources/net/runelite/client/plugins/skillcalculator/skill_prayer.json
@@ -172,12 +172,6 @@
     },
     {
       "level": 1,
-      "icon": 2859,
-      "name": "Wolf Bones",
-      "xp": 4.5
-    },
-    {
-      "level": 1,
       "icon": 3396,
       "name": "Loar Remains",
       "xp": 33,
@@ -185,45 +179,9 @@
     },
     {
       "level": 1,
-      "icon": 528,
-      "name": "Burnt Bones",
-      "xp": 4.5
-    },
-    {
-      "level": 1,
-      "icon": 3179,
-      "name": "Monkey Bones",
-      "xp": 5
-    },
-    {
-      "level": 1,
-      "icon": 530,
-      "name": "Bat Bones",
-      "xp": 5.3
-    },
-    {
-      "level": 1,
-      "icon": 3125,
-      "name": "Jogre Bones",
-      "xp": 15
-    },
-    {
-      "level": 1,
       "icon": 532,
       "name": "Big Bones",
       "xp": 15
-    },
-    {
-      "level": 1,
-      "icon": 4812,
-      "name": "Zogre Bones",
-      "xp": 22.5
-    },
-    {
-      "level": 1,
-      "icon": 3123,
-      "name": "Shaikahan Bones",
-      "xp": 25
     },
     {
       "level": 1,
@@ -237,12 +195,6 @@
       "name": "Phrin Remains",
       "xp": 46.5,
       "ignoreBonus": true
-    },
-    {
-      "level": 1,
-      "icon": 4834,
-      "name": "Ourg Bones",
-      "xp": 140
     },
     {
       "level": 1,
@@ -272,12 +224,6 @@
     },
     {
       "level": 1,
-      "icon": 4830,
-      "name": "Fayrg Bones",
-      "xp": 84
-    },
-    {
-      "level": 1,
       "icon": 3404,
       "name": "Fiyr Remains",
       "xp": 84,
@@ -288,12 +234,6 @@
       "icon": 11943,
       "name": "Lava Dragon Bones",
       "xp": 85
-    },
-    {
-      "level": 1,
-      "icon": 4832,
-      "name": "Raurg Bones",
-      "xp": 96
     },
     {
       "level": 1,

--- a/runelite-client/src/main/resources/net/runelite/client/plugins/skillcalculator/skill_smithing.json
+++ b/runelite-client/src/main/resources/net/runelite/client/plugins/skillcalculator/skill_smithing.json
@@ -8,140 +8,20 @@
     },
     {
       "level": 1,
-      "icon": 1351,
-      "name": "Bronze Axe",
-      "xp": 12.5
-    },
-    {
-      "level": 1,
       "icon": 1205,
-      "name": "Bronze Dagger",
-      "xp": 12.5
-    },
-    {
-      "level": 2,
-      "icon": 1422,
-      "name": "Bronze Mace",
-      "xp": 12.5
-    },
-    {
-      "level": 3,
-      "icon": 1139,
-      "name": "Bronze Med Helm",
-      "xp": 12.5
-    },
-    {
-      "level": 3,
-      "icon": 9375,
-      "name": "Bronze Bolts (Unf)",
-      "xp": 12.5
-    },
-    {
-      "level": 4,
-      "icon": 4819,
-      "name": "Bronze Nails",
-      "xp": 12.5
-    },
-    {
-      "level": 4,
-      "icon": 1277,
-      "name": "Bronze Sword",
-      "xp": 12.5
-    },
-    {
-      "level": 4,
-      "icon": 1794,
-      "name": "Bronze Wire",
-      "xp": 12.5
-    },
-    {
-      "level": 4,
-      "icon": 819,
-      "name": "Bronze Dart Tip",
-      "xp": 12.5
-    },
-    {
-      "level": 5,
-      "icon": 39,
-      "name": "Bronze Arrowtips",
+      "name": "1 Bar Bronze Items",
       "xp": 12.5
     },
     {
       "level": 5,
       "icon": 1321,
-      "name": "Bronze Scimitar",
-      "xp": 25
-    },
-    {
-      "level": 6,
-      "icon": 19570,
-      "name": "Bronze Javelin Heads",
-      "xp": 12.5
-    },
-    {
-      "level": 6,
-      "icon": 1291,
-      "name": "Bronze Longsword",
-      "xp": 25
-    },
-    {
-      "level": 6,
-      "icon": 9420,
-      "name": "Bronze Limbs",
-      "xp": 12.5
-    },
-    {
-      "level": 7,
-      "icon": 864,
-      "name": "Bronze Knife",
-      "xp": 12.5
-    },
-    {
-      "level": 7,
-      "icon": 1155,
-      "name": "Bronze Full Helm",
-      "xp": 25
-    },
-    {
-      "level": 8,
-      "icon": 1173,
-      "name": "Bronze Sq Shield",
+      "name": "2 Bar Bronze Items",
       "xp": 25
     },
     {
       "level": 9,
       "icon": 1337,
-      "name": "Bronze Warhammer",
-      "xp": 37.5
-    },
-    {
-      "level": 10,
-      "icon": 1375,
-      "name": "Bronze Battleaxe",
-      "xp": 37.5
-    },
-    {
-      "level": 11,
-      "icon": 1103,
-      "name": "Bronze Chainbody",
-      "xp": 37.5
-    },
-    {
-      "level": 12,
-      "icon": 1189,
-      "name": "Bronze Kiteshield",
-      "xp": 37.5
-    },
-    {
-      "level": 13,
-      "icon": 3095,
-      "name": "Bronze Claws",
-      "xp": 25
-    },
-    {
-      "level": 14,
-      "icon": 1307,
-      "name": "Bronze 2h Sword",
+      "name": "3 Bar Bronze Items",
       "xp": 37.5
     },
     {
@@ -153,74 +33,14 @@
     {
       "level": 15,
       "icon": 1203,
-      "name": "Iron Dagger",
-      "xp": 25
-    },
-    {
-      "level": 16,
-      "icon": 1349,
-      "name": "Iron Axe",
-      "xp": 25
-    },
-    {
-      "level": 16,
-      "icon": 1075,
-      "name": "Bronze Platelegs",
-      "xp": 37.5
-    },
-    {
-      "level": 16,
-      "icon": 1087,
-      "name": "Bronze Plateskirt",
-      "xp": 37.5
-    },
-    {
-      "level": 17,
-      "icon": 7225,
-      "name": "Iron Spit",
-      "xp": 25
-    },
-    {
-      "level": 17,
-      "icon": 1420,
-      "name": "Iron Mace",
-      "xp": 25
-    },
-    {
-      "level": 18,
-      "icon": 9377,
-      "name": "Iron Bolts (Unf)",
+      "name": "1 Bar Iron Items",
       "xp": 25
     },
     {
       "level": 18,
       "icon": 1117,
-      "name": "Bronze Platebody",
+      "name": "5 Bar Bronze Items",
       "xp": 62.5
-    },
-    {
-      "level": 18,
-      "icon": 1137,
-      "name": "Iron Med Helm",
-      "xp": 25
-    },
-    {
-      "level": 19,
-      "icon": 4820,
-      "name": "Iron Nails",
-      "xp": 25
-    },
-    {
-      "level": 19,
-      "icon": 820,
-      "name": "Iron Dart Tip",
-      "xp": 25
-    },
-    {
-      "level": 19,
-      "icon": 1279,
-      "name": "Iron Sword",
-      "xp": 25
     },
     {
       "level": 20,
@@ -230,105 +50,21 @@
     },
     {
       "level": 20,
-      "icon": 40,
-      "name": "Iron Arrowtips",
-      "xp": 25
-    },
-    {
-      "level": 20,
       "icon": 1323,
-      "name": "Iron Scimitar",
-      "xp": 50
-    },
-    {
-      "level": 21,
-      "icon": 1293,
-      "name": "Iron Longsword",
-      "xp": 50
-    },
-    {
-      "level": 21,
-      "icon": 19572,
-      "name": "Iron Javelin Heads",
-      "xp": 25
-    },
-    {
-      "level": 22,
-      "icon": 1153,
-      "name": "Iron Full Helm",
-      "xp": 50
-    },
-    {
-      "level": 22,
-      "icon": 863,
-      "name": "Iron Knife",
-      "xp": 25
-    },
-    {
-      "level": 23,
-      "icon": 9423,
-      "name": "Iron Limbs",
-      "xp": 25
-    },
-    {
-      "level": 23,
-      "icon": 1175,
-      "name": "Iron Sq Shield",
+      "name": "2 Bar Iron Items",
       "xp": 50
     },
     {
       "level": 24,
       "icon": 1335,
-      "name": "Iron Warhammer",
+      "name": "3 Bar Iron Items",
       "xp": 75
     },
     {
       "level": 25,
       "icon": 1363,
-      "name": "Iron Battleaxe",
+      "name": "3 Bar Iron Items",
       "xp": 75
-    },
-    {
-      "level": 26,
-      "icon": 4540,
-      "name": "Oil Lantern Frame",
-      "xp": 25
-    },
-    {
-      "level": 26,
-      "icon": 1101,
-      "name": "Iron Chainbody",
-      "xp": 75
-    },
-    {
-      "level": 27,
-      "icon": 1191,
-      "name": "Iron Kiteshield",
-      "xp": 75
-    },
-    {
-      "level": 28,
-      "icon": 3096,
-      "name": "Iron Claws",
-      "xp": 50
-    },
-    {
-      "level": 29,
-      "icon": 1309,
-      "name": "Iron 2h Sword",
-      "xp": 75
-    },
-    {
-      "level": 30,
-      "icon": 2353,
-      "name": "Steel Bar (Blast Furnace)",
-      "xp": 17.5
-    },
-    {
-      "level": 30,
-      "icon": 1207,
-      "name": "Steel Dagger",
-      "xp": 27
     },
     {
       "level": 30,
@@ -337,64 +73,16 @@
       "xp": 17.5
     },
     {
-      "level": 31,
-      "icon": 1081,
-      "name": "Iron Plateskirt",
-      "xp": 75
-    },
-    {
-      "level": 31,
-      "icon": 1067,
-      "name": "Iron Platelegs",
-      "xp": 75
-    },
-    {
-      "level": 31,
-      "icon": 1353,
-      "name": "Steel Axe",
-      "xp": 37
-    },
-    {
-      "level": 32,
-      "icon": 1424,
-      "name": "Steel Mace",
-      "xp": 37
+      "level": 30,
+      "icon": 1207,
+      "name": "1 Bar Steel Items",
+      "xp": 27
     },
     {
       "level": 33,
       "icon": 1115,
-      "name": "Iron Platebody",
+      "name": "5 Bar Iron Items",
       "xp": 125
-    },
-    {
-      "level": 33,
-      "icon": 1141,
-      "name": "Steel Med Helm",
-      "xp": 37
-    },
-    {
-      "level": 33,
-      "icon": 9378,
-      "name": "Steel Bolts (Unf)",
-      "xp": 37
-    },
-    {
-      "level": 34,
-      "icon": 821,
-      "name": "Steel Dart Tip",
-      "xp": 37
-    },
-    {
-      "level": 34,
-      "icon": 1539,
-      "name": "Steel Nails",
-      "xp": 37
-    },
-    {
-      "level": 34,
-      "icon": 1281,
-      "name": "Steel Sword",
-      "xp": 37
     },
     {
       "level": 35,
@@ -405,68 +93,8 @@
     {
       "level": 35,
       "icon": 1325,
-      "name": "Steel Scimitar",
+      "name": "2 Bar Steel Items",
       "xp": 75
-    },
-    {
-      "level": 35,
-      "icon": 41,
-      "name": "Steel Arrowtips",
-      "xp": 37
-    },
-    {
-      "level": 36,
-      "icon": 9425,
-      "name": "Steel Limbs",
-      "xp": 37
-    },
-    {
-      "level": 36,
-      "icon": 2370,
-      "name": "Steel Studs",
-      "xp": 37
-    },
-    {
-      "level": 36,
-      "icon": 1295,
-      "name": "Steel Longsword",
-      "xp": 75
-    },
-    {
-      "level": 36,
-      "icon": 19574,
-      "name": "Steel Javelin Heads",
-      "xp": 37.5
-    },
-    {
-      "level": 37,
-      "icon": 865,
-      "name": "Steel Knife",
-      "xp": 37.5
-    },
-    {
-      "level": 37,
-      "icon": 1157,
-      "name": "Steel Full Helm",
-      "xp": 75
-    },
-    {
-      "level": 38,
-      "icon": 1177,
-      "name": "Steel Sq Shield",
-      "xp": 75
-    },
-    {
-      "level": 39,
-      "icon": 1339,
-      "name": "Steel Warhammer",
-      "xp": 112
-    },
-    {
-      "level": 40,
-      "icon": 1365,
-      "name": "Steel Battleaxe",
-      "xp": 112
     },
     {
       "level": 40,
@@ -483,62 +111,14 @@
     {
       "level": 41,
       "icon": 1105,
-      "name": "Steel Chainbody",
-      "xp": 112
-    },
-    {
-      "level": 42,
-      "icon": 1193,
-      "name": "Steel Kiteshield",
-      "xp": 112
-    },
-    {
-      "level": 43,
-      "icon": 3097,
-      "name": "Steel Claws",
-      "xp": 75
-    },
-    {
-      "level": 44,
-      "icon": 1311,
-      "name": "Steel 2h Sword",
-      "xp": 112
-    },
-    {
-      "level": 46,
-      "icon": 1069,
-      "name": "Steel Platelegs",
-      "xp": 112
-    },
-    {
-      "level": 46,
-      "icon": 1083,
-      "name": "Steel Plateskirt",
+      "name": "3 Bar Steel Items",
       "xp": 112
     },
     {
       "level": 48,
       "icon": 1119,
-      "name": "Steel Platebody",
+      "name": "5 Bar Steel Items",
       "xp": 187.5
-    },
-    {
-      "level": 49,
-      "icon": 4544,
-      "name": "Bullseye Lantern (Unf)",
-      "xp": 37
-    },
-    {
-      "level": 50,
-      "icon": 1209,
-      "name": "Mithril Dagger",
-      "xp": 50
-    },
-    {
-      "level": 50,
-      "icon": 2359,
-      "name": "Mithril Bar (Blast Furnace)",
-      "xp": 30
     },
     {
       "level": 50,
@@ -547,105 +127,21 @@
       "xp": 30
     },
     {
-      "level": 51,
-      "icon": 1355,
-      "name": "Mithril Axe",
-      "xp": 50
-    },
-    {
-      "level": 52,
-      "icon": 1428,
-      "name": "Mithril Mace",
-      "xp": 50
-    },
-    {
-      "level": 53,
-      "icon": 1143,
-      "name": "Mithril Med Helm",
-      "xp": 50
-    },
-    {
-      "level": 53,
-      "icon": 9379,
-      "name": "Mithril Bolts (Unf)",
-      "xp": 50
-    },
-    {
-      "level": 54,
-      "icon": 1285,
-      "name": "Mithril Sword",
-      "xp": 50
-    },
-    {
-      "level": 54,
-      "icon": 822,
-      "name": "Mithril Dart Tip",
-      "xp": 50
-    },
-    {
-      "level": 54,
-      "icon": 4822,
-      "name": "Mithril Nails",
-      "xp": 50
-    },
-    {
-      "level": 55,
-      "icon": 42,
-      "name": "Mithril Arrowtips",
+      "level": 50,
+      "icon": 1209,
+      "name": "1 Bar Mithril Items",
       "xp": 50
     },
     {
       "level": 55,
       "icon": 1329,
-      "name": "Mithril Scimitar",
+      "name": "2 Bar Mithril Items",
       "xp": 100
-    },
-    {
-      "level": 56,
-      "icon": 1299,
-      "name": "Mithril Longsword",
-      "xp": 100
-    },
-    {
-      "level": 56,
-      "icon": 19576,
-      "name": "Mithril Javelin Heads",
-      "xp": 50
-    },
-    {
-      "level": 56,
-      "icon": 9427,
-      "name": "Mithril Limbs",
-      "xp": 50
-    },
-    {
-      "level": 57,
-      "icon": 1159,
-      "name": "Mithril Full Helm",
-      "xp": 100
-    },
-    {
-      "level": 57,
-      "icon": 866,
-      "name": "Mithril Knife",
-      "xp": 50
-    },
-    {
-      "level": 58,
-      "icon": 1181,
-      "name": "Mithril Sq Shield",
-      "xp": 100
-    },
-    {
-      "level": 59,
-      "icon": 9416,
-      "name": "Mith Grapple Tip",
-      "xp": 50
     },
     {
       "level": 59,
       "icon": 1343,
-      "name": "Mithril Warhammer",
+      "name": "3 Bar Mithril Items",
       "xp": 150
     },
     {
@@ -655,64 +151,10 @@
       "xp": 75
     },
     {
-      "level": 60,
-      "icon": 1369,
-      "name": "Mithril Battleaxe",
-      "xp": 150
-    },
-    {
-      "level": 61,
-      "icon": 1109,
-      "name": "Mithril Chainbody",
-      "xp": 150
-    },
-    {
-      "level": 62,
-      "icon": 1197,
-      "name": "Mithril Kiteshield",
-      "xp": 150
-    },
-    {
-      "level": 63,
-      "icon": 3099,
-      "name": "Mithril Claws",
-      "xp": 100
-    },
-    {
-      "level": 64,
-      "icon": 1315,
-      "name": "Mithril 2h Sword",
-      "xp": 150
-    },
-    {
-      "level": 66,
-      "icon": 1085,
-      "name": "Mithril Plateskirt",
-      "xp": 150
-    },
-    {
-      "level": 66,
-      "icon": 1071,
-      "name": "Mithril Platelegs",
-      "xp": 150
-    },
-    {
       "level": 68,
       "icon": 1121,
-      "name": "Mithril Platebody",
+      "name": "5 Bar Mithril Items",
       "xp": 250
-    },
-    {
-      "level": 70,
-      "icon": 2361,
-      "name": "Adamantite Bar (Blast Furnace)",
-      "xp": 37.5
-    },
-    {
-      "level": 70,
-      "icon": 1211,
-      "name": "Adamant Dagger",
-      "xp": 62.5
     },
     {
       "level": 70,
@@ -721,129 +163,21 @@
       "xp": 37.5
     },
     {
-      "level": 71,
-      "icon": 1357,
-      "name": "Adamant Axe",
-      "xp": 62.5
-    },
-    {
-      "level": 72,
-      "icon": 1430,
-      "name": "Adamant Mace",
-      "xp": 62.5
-    },
-    {
-      "level": 73,
-      "icon": 9380,
-      "name": "Adamant Bolts (Unf)",
-      "xp": 62.5
-    },
-    {
-      "level": 73,
-      "icon": 1145,
-      "name": "Adamant Med Helm",
-      "xp": 62.5
-    },
-    {
-      "level": 74,
-      "icon": 823,
-      "name": "Adamant Dart Tip",
-      "xp": 62.5
-    },
-    {
-      "level": 74,
-      "icon": 1287,
-      "name": "Adamant Sword",
-      "xp": 62.5
-    },
-    {
-      "level": 74,
-      "icon": 4823,
-      "name": "Adamantite Nails",
-      "xp": 62.5
-    },
-    {
-      "level": 75,
-      "icon": 43,
-      "name": "Adamant Arrowtips",
+      "level": 70,
+      "icon": 1211,
+      "name": "1 Bar Adamant Items",
       "xp": 62.5
     },
     {
       "level": 75,
       "icon": 1331,
-      "name": "Adamant Scimitar",
-      "xp": 125
-    },
-    {
-      "level": 76,
-      "icon": 9429,
-      "name": "Adamantite Limbs",
-      "xp": 62.5
-    },
-    {
-      "level": 76,
-      "icon": 1301,
-      "name": "Adamant Longsword",
-      "xp": 125
-    },
-    {
-      "level": 76,
-      "icon": 19578,
-      "name": "Adamant Javelin Heads",
-      "xp": 62.5
-    },
-    {
-      "level": 77,
-      "icon": 1161,
-      "name": "Adamant Full Helm",
-      "xp": 125
-    },
-    {
-      "level": 77,
-      "icon": 867,
-      "name": "Adamant Knife",
-      "xp": 62.5
-    },
-    {
-      "level": 78,
-      "icon": 1183,
-      "name": "Adamant Sq Shield",
+      "name": "2 Bar Adamant Items",
       "xp": 125
     },
     {
       "level": 79,
       "icon": 1345,
-      "name": "Adamant Warhammer",
-      "xp": 187.5
-    },
-    {
-      "level": 80,
-      "icon": 1371,
-      "name": "Adamant Battleaxe",
-      "xp": 187.5
-    },
-    {
-      "level": 81,
-      "icon": 1111,
-      "name": "Adamant Chainbody",
-      "xp": 187.5
-    },
-    {
-      "level": 82,
-      "icon": 1199,
-      "name": "Adamant Kiteshield",
-      "xp": 187.5
-    },
-    {
-      "level": 83,
-      "icon": 3100,
-      "name": "Adamant Claws",
-      "xp": 125
-    },
-    {
-      "level": 84,
-      "icon": 1317,
-      "name": "Adamant 2h Sword",
+      "name": "3 Bar Adamant Items",
       "xp": 187.5
     },
     {
@@ -854,86 +188,20 @@
     },
     {
       "level": 85,
-      "icon": 2363,
-      "name": "Runite Bar (Blast Furnace)",
-      "xp": 50
-    },
-    {
-      "level": 85,
       "icon": 1213,
-      "name": "Rune Dagger",
-      "xp": 75
-    },
-    {
-      "level": 86,
-      "icon": 1359,
-      "name": "Rune Axe",
-      "xp": 75
-    },
-    {
-      "level": 86,
-      "icon": 1091,
-      "name": "Adamant Plateskirt",
-      "xp": 187.5
-    },
-    {
-      "level": 86,
-      "icon": 1073,
-      "name": "Adamant Platelegs",
-      "xp": 187.5
-    },
-    {
-      "level": 87,
-      "icon": 1432,
-      "name": "Rune Mace",
-      "xp": 75
-    },
-    {
-      "level": 88,
-      "icon": 9381,
-      "name": "Runite Bolts (Unf)",
-      "xp": 75
-    },
-    {
-      "level": 88,
-      "icon": 1147,
-      "name": "Rune Med Helm",
+      "name": "1 Bar Rune Items",
       "xp": 75
     },
     {
       "level": 88,
       "icon": 1123,
-      "name": "Adamant Platebody",
+      "name": "5 Bar Adamant Items",
       "xp": 312
-    },
-    {
-      "level": 89,
-      "icon": 1289,
-      "name": "Rune Sword",
-      "xp": 75
-    },
-    {
-      "level": 89,
-      "icon": 4824,
-      "name": "Rune Nails",
-      "xp": 75
-    },
-    {
-      "level": 89,
-      "icon": 824,
-      "name": "Rune Dart Tip",
-      "xp": 75
-    },
-    {
-      "level": 90,
-      "icon": 44,
-      "name": "Rune Arrowtips",
-      "xp": 75
     },
     {
       "level": 90,
       "icon": 1333,
-      "name": "Rune Scimitar",
+      "name": "2 Bar Rune Items",
       "xp": 150
     },
     {
@@ -943,94 +211,16 @@
       "xp": 2000
     },
     {
-      "level": 91,
-      "icon": 1303,
-      "name": "Rune Longsword",
-      "xp": 150
-    },
-    {
-      "level": 91,
-      "icon": 19580,
-      "name": "Rune Javelin Heads",
-      "xp": 75
-    },
-    {
-      "level": 91,
-      "icon": 9431,
-      "name": "Runite Limbs",
-      "xp": 75
-    },
-    {
-      "level": 92,
-      "icon": 868,
-      "name": "Rune Knife",
-      "xp": 75
-    },
-    {
-      "level": 92,
-      "icon": 1163,
-      "name": "Rune Full Helm",
-      "xp": 150
-    },
-    {
-      "level": 93,
-      "icon": 1185,
-      "name": "Rune Sq Shield",
-      "xp": 150
-    },
-    {
       "level": 94,
       "icon": 1347,
-      "name": "Rune Warhammer",
+      "name": "3 Bar Rune Items",
       "xp": 225
-    },
-    {
-      "level": 95,
-      "icon": 1373,
-      "name": "Rune Battleaxe",
-      "xp": 225
-    },
-    {
-      "level": 96,
-      "icon": 1113,
-      "name": "Rune Chainbody",
-      "xp": 225
-    },
-    {
-      "level": 97,
-      "icon": 1201,
-      "name": "Rune Kiteshield",
-      "xp": 225
-    },
-    {
-      "level": 98,
-      "icon": 3101,
-      "name": "Rune Claws",
-      "xp": 150
     },
     {
       "level": 99,
       "icon": 1127,
-      "name": "Rune Platebody",
+      "name": "5 Bar Rune Items",
       "xp": 375
-    },
-    {
-      "level": 99,
-      "icon": 1093,
-      "name": "Rune Plateskirt",
-      "xp": 225
-    },
-    {
-      "level": 99,
-      "icon": 1079,
-      "name": "Rune Platelegs",
-      "xp": 225
-    },
-    {
-      "level": 99,
-      "icon": 1319,
-      "name": "Rune 2h Sword",
-      "xp": 225
     }
   ]
 }


### PR DESCRIPTION
Removes a bunch of training methods nobody would ever use to make it easier to find the right training methods, fixed some icons in crafting, removed individual items from smithing since items requiring the same amount of bars give the same amount of xp, and changed some herblore potions to 4 dose since you would never not make 4 dose