### PR TITLE
Add notifications to Grand Exchange plugin

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangeNotification.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangeNotification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Seth <https://github.com/sethtroll>
+ * Copyright (c) 2018, Ethan <https://github.com/shmeeps>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -24,47 +24,40 @@
  */
 package net.runelite.client.plugins.grandexchange;
 
-import net.runelite.client.config.Config;
-import net.runelite.client.config.ConfigGroup;
-import net.runelite.client.config.ConfigItem;
+import java.time.Instant;
+import lombok.Value;
+import net.runelite.api.GrandExchangeOfferState;
 
-@ConfigGroup(
-	keyName = "grandexchange",
-	name = "Grand Exchange",
-	description = "Configuration for the Grand Exchange"
-)
-public interface GrandExchangeConfig extends Config
+@Value
+class GrandExchangeNotification
 {
-	@ConfigItem(
-		position = 1,
-		keyName = "quickLookup",
-		name = "Hotkey lookup (Alt + Left click)",
-		description = "Configures whether to enable the hotkey lookup for ge searches"
-	)
-	default boolean quickLookup()
-	{
-		return true;
-	}
+	private final int slot;
+	private final int quantitySold;
+	private final int totalQuantity;
+	private final String itemName;
+	private final GrandExchangeOfferState state;
+	private final Instant insertedOn = Instant.now();
 
-	@ConfigItem(
-		position = 2,
-		keyName = "enableNotifications",
-		name = "Enable Notifications",
-		description = "Configures whether to enable notifications when an offer updates"
-	)
-	default boolean enableNotifications()
+	String getNotificationMessage()
 	{
-		return true;
-	}
+		// Send complete or X/Y notification
+		switch (this.state)
+		{
+			case BUYING:
+				return String.format("Grand Exchange: Bought %d / %d x %s", quantitySold, totalQuantity, itemName);
 
-	@ConfigItem(
-		position = 3,
-		keyName = "notificationDelay",
-		name = "Notification Delay",
-		description = "Number of seconds between notifications on offer updates"
-	)
-	default int notificationDelay()
-	{
-		return 5;
+			case SELLING:
+				return String.format("Grand Exchange: Sold %d / %d x %s", quantitySold, totalQuantity, itemName);
+
+			case BOUGHT:
+				return String.format("Grand Exchange: Finished buying %d x %s", totalQuantity, itemName);
+
+			case SOLD:
+				return String.format("Grand Exchange: Finished selling %d x %s", totalQuantity, itemName);
+
+			default:
+				// Not possible
+				return null;
+		}
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangeNotificationHandler.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangeNotificationHandler.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2018, Ethan <https://github.com/shmeeps>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.grandexchange;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.LinkedList;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import net.runelite.api.GrandExchangeOffer;
+import net.runelite.api.GrandExchangeOfferState;
+import net.runelite.api.ItemComposition;
+
+@Singleton
+class GrandExchangeNotificationHandler
+{
+	@Inject
+	private GrandExchangeConfig config;
+
+	private final LinkedList<GrandExchangeNotification> notificationQueue = new LinkedList<>();
+
+	private Instant lastNotificationSent = Instant.now();
+
+	void queueNotification(int slot, ItemComposition offerItem, GrandExchangeOffer newOffer)
+	{
+		// Get offer data
+		int itemId = offerItem.getId();
+		int quantitySold = newOffer.getQuantitySold();
+		int totalQuantity = newOffer.getTotalQuantity();
+		String itemName = offerItem.getName();
+
+		// Ignore empty/cancelled offers, or those with invalid data
+		if (newOffer.getState() == GrandExchangeOfferState.EMPTY ||
+			newOffer.getState() == GrandExchangeOfferState.CANCELLED_BUY ||
+			newOffer.getState() == GrandExchangeOfferState.CANCELLED_SELL ||
+			quantitySold == 0 || itemId == 0 || itemId == -1)
+		{
+			return;
+		}
+
+		// Inspect the queue for an existing notification from the same offer slot
+		for (GrandExchangeNotification existingNotification : notificationQueue)
+		{
+			if (existingNotification.getSlot() == slot)
+			{
+				// Don't replace a "finished" notification with a "in-progress" one
+				if (existingNotification.getState() == GrandExchangeOfferState.BOUGHT ||
+					existingNotification.getState() == GrandExchangeOfferState.SOLD)
+				{
+					return;
+				}
+
+				// Remove the "in-progress" notification so we can replace it with a "finished" one
+				notificationQueue.remove(existingNotification);
+				break;
+			}
+		}
+
+		// If not, just add a new notification to the queue
+		notificationQueue.add(new GrandExchangeNotification(slot, quantitySold, totalQuantity, itemName, newOffer.getState()));
+	}
+
+	boolean canSendNotification()
+	{
+		// Can't send a notification if none are in the queue
+		if (notificationQueue.isEmpty())
+		{
+			return false;
+		}
+
+		// Make sure we aren't sending notifications too quickly
+		long timeSinceLastNotification = Duration.between(this.lastNotificationSent, Instant.now()).toMillis();
+		boolean canSendNotification = timeSinceLastNotification > (this.config.notificationDelay() * 1000);
+
+		// Make sure the next notification has been given time to update to a complete status if it instantly bought/sold
+		boolean notificationAvailable = Duration.between(notificationQueue.peek().getInsertedOn(), Instant.now()).toMillis() > 600;
+		return canSendNotification && notificationAvailable;
+	}
+
+	String getNextNotification()
+	{
+		// Reset the notification timer
+		this.lastNotificationSent = Instant.now();
+
+		// Get the next notification, remove it from the queue
+		GrandExchangeNotification nextNotification = notificationQueue.pop();
+
+		// Return the notification
+		return nextNotification.getNotificationMessage();
+	}
+}


### PR DESCRIPTION
Adds notifications to Grand Exchange offers.

* Toggleable notifications
* Delays notifications by a configurable amount of seconds so notifications don't immediately overwrite each other
* Delays notifications in a slot by a tick so any quick partial buy/sell to complete buy/sell events will coalesce into just the "Finished buying/selling" notifications
* Only sends notifications on buying/selling/bought/sold events. Cancelled offers don't cause any notifications

Tested with basic offers, as well as partial orders that complete non-quickly by buying over the buy limit of an item, and then selling the amount that were partially-bought with the original offer still in place. This correctly shows a partial buy notification, then a finished notification for the original offer. Also, as this causes two offers to complete on the same tick, it does correctly display one offer notification, and then the other after the delay. Not sure if there are any more advanced scenarios that need to be covered.

Currently will give updates on pending offers when you first log in. I didn't see anything in the event data to filter these out, but if anyone knows of a way I can add that in as a configurable option as well.

Probably needs testing on Mac / Linux to make sure everything works fine with their notification types, probably worth testing on Windows 7/Vista as well, as they do the "tray-style" pop up notifications.

Refs #3168