### PR TITLE
runelite-api: Add missing documentation

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/Actor.java
+++ b/runelite-api/src/main/java/net/runelite/api/Actor.java
@@ -32,37 +32,112 @@ import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.coords.WorldArea;
 import net.runelite.api.coords.WorldPoint;
 
+/**
+ * Represents a RuneScape actor/entity.
+ */
 public interface Actor extends Renderable
 {
+	/**
+	 * Gets the combat level of the actor.
+	 *
+	 * @return the combat level
+	 */
 	int getCombatLevel();
 
+	/**
+	 * Gets the name of the actor.
+	 *
+	 * @return the name
+	 */
 	String getName();
 
+	/**
+	 * Gets the actor being interacted with.
+	 * <p>
+	 * Examples of interaction include:
+	 * <ul>
+	 *     <li>A monster focusing an Actor to attack</li>
+	 *     <li>Targetting a player to trade</li>
+	 *     <li>Following a player</li>
+	 * </ul>
+	 *
+	 * @return the actor, null if no interaction is occurring
+	 */
 	Actor getInteracting();
 
+	/**
+	 * Gets the health ratio of the actor.
+	 * <p>
+	 * The ratio is the number of green bars in the overhead
+	 * HP display.
+	 *
+	 * @return the health ratio
+	 */
 	int getHealthRatio();
 
+	/**
+	 * Gets the health of the actor.
+	 *
+	 * @return the health
+	 */
 	int getHealth();
 
 	/**
-	 * Retrieve the server location of the actor. Note that this is typically
-	 * a couple steps ahead of where the client renders the actor.
-	 * @return Returns the server location of the actor.
+	 * Gets the server-side location of the actor.
+	 * <p>
+	 * This value is typically ahead of where the client renders and may
+	 * be affected by things such as animations.
+	 *
+	 * @return the server location
 	 */
 	WorldPoint getWorldLocation();
 
+	/**
+	 * Gets the client-side location of the actor.
+	 *
+	 * @return the client location
+	 */
 	LocalPoint getLocalLocation();
 
+	/**
+	 * Gets the orientation of the actor.
+	 *
+	 * @return the orientation
+	 * @see net.runelite.api.coords.Angle
+	 */
 	int getOrientation();
 
+	/**
+	 * Gets the current animation the actor is performing.
+	 *
+	 * @return the animation ID
+	 * @see AnimationID
+	 */
 	int getAnimation();
 
+	/**
+	 * Sets an animation for the actor to perform.
+	 *
+	 * @param animation the animation ID
+	 * @see AnimationID
+	 */
 	@VisibleForDevtools
 	void setAnimation(int animation);
 
+	/**
+	 * Sets the frame of the animation the actor is performing.
+	 *
+	 * @param actionFrame the animation frame
+	 */
 	@VisibleForDevtools
 	void setActionFrame(int actionFrame);
 
+	/**
+	 * Gets the graphic that is currently on the player.
+	 *
+	 * @return the graphic of the actor
+	 * @see GraphicID
+	 */
 	int getGraphic();
 
 	@VisibleForDevtools
@@ -71,24 +146,84 @@ public interface Actor extends Renderable
 	@VisibleForDevtools
 	void setSpotAnimFrame(int spotAnimFrame);
 
+	/**
+	 * Gets the height of the actors model.
+	 *
+	 * @return the height
+	 */
 	int getModelHeight();
 
+	/**
+	 * Gets the canvas area of the current tile the actor is standing on.
+	 *
+	 * @return the current tile canvas area
+	 */
 	Polygon getCanvasTilePoly();
 
+	/**
+	 * Gets the point at which text should be drawn, relative to the
+	 * current location with the given z-axis offset.
+	 *
+	 * @param graphics engine graphics
+	 * @param text the text to draw
+	 * @param zOffset the z-axis offset
+	 * @return the text drawing location
+	 */
 	Point getCanvasTextLocation(Graphics2D graphics, String text, int zOffset);
 
+	/**
+	 * Gets the point at which an image should be drawn, relative to the
+	 * current location with the given z-axis offset.
+	 *
+	 * @param graphics engine graphics
+	 * @param image the image to draw
+	 * @param zOffset the z-axis offset
+	 * @return the image drawing location
+	 */
 	Point getCanvasImageLocation(Graphics2D graphics, BufferedImage image, int zOffset);
 
+
+	/**
+	 * Gets the point at which a sprite should be drawn, relative to the
+	 * current location with the given z-axis offset.
+	 *
+	 * @param graphics engine graphics
+	 * @param sprite the sprite to draw
+	 * @param zOffset the z-axis offset
+	 * @return the sprite drawing location
+	 */
 	Point getCanvasSpriteLocation(Graphics2D graphics, SpritePixels sprite, int zOffset);
 
+	/**
+	 * Gets a point on the canvas of where this actors mini-map indicator
+	 * should appear.
+	 *
+	 * @return mini-map location on canvas
+	 */
 	Point getMinimapLocation();
 
 	/**
-	 * Returns the logical height of the actor's model. This is roughly where the health bar is drawn.
+	 * Gets the logical height of the actors model.
+	 * <p>
+	 * This z-axis offset is roughly where the health bar of the actor
+	 * is drawn.
+	 *
+	 * @return the logical height
 	 */
 	int getLogicalHeight();
 
+	/**
+	 * Gets the convex hull of the actors model.
+	 *
+	 * @return the convex hull
+	 * @see net.runelite.api.model.Jarvis
+	 */
 	Polygon getConvexHull();
 
+	/**
+	 * Gets the world area that the actor occupies.
+	 *
+	 * @return the world area
+	 */
 	WorldArea getWorldArea();
 }

--- a/runelite-api/src/main/java/net/runelite/api/AnimationID.java
+++ b/runelite-api/src/main/java/net/runelite/api/AnimationID.java
@@ -24,8 +24,12 @@
  */
 package net.runelite.api;
 
-// Note: This class is not complete: these animations were manually gathered
-// through getAnimation(). Please add animations as you happen to use them.
+/**
+ * Utility class used for mapping animation IDs.
+ * <p>
+ * Note: This class is not complete and may not contain a specific animation
+ * required.
+ */
 public final class AnimationID
 {
 	public static final int IDLE = -1;

--- a/runelite-api/src/main/java/net/runelite/api/Area.java
+++ b/runelite-api/src/main/java/net/runelite/api/Area.java
@@ -24,7 +24,16 @@
  */
 package net.runelite.api;
 
+/**
+ * Represents an area in the world.
+ */
 public interface Area
 {
-	SpritePixels getMapIcon(boolean var1);
+	/**
+	 * Gets the sprite icon to display on the world map.
+	 *
+	 * @param unused unused value
+	 * @return the sprite icon to display on the world map
+	 */
+	SpritePixels getMapIcon(boolean unused);
 }

--- a/runelite-api/src/main/java/net/runelite/api/BufferProvider.java
+++ b/runelite-api/src/main/java/net/runelite/api/BufferProvider.java
@@ -24,6 +24,9 @@
  */
 package net.runelite.api;
 
+/**
+ * Represents an engine graphic buffer.
+ */
 public interface BufferProvider
 {
 }

--- a/runelite-api/src/main/java/net/runelite/api/ChatLineBuffer.java
+++ b/runelite-api/src/main/java/net/runelite/api/ChatLineBuffer.java
@@ -26,15 +26,22 @@
 
 package net.runelite.api;
 
+/**
+ * Represents the buffer containing all messages in the chatbox.
+ */
 public interface ChatLineBuffer
 {
 	/**
-	 * @return the MessageNode arrays which contain the messages in the chatbox
+	 * Gets an array of message nodes currently in the chatbox.
+	 *
+	 * @return messages in the chatbox
 	 */
 	MessageNode[] getLines();
 
 	/**
-	 * @return the length of the MessageNode array getLines()
+	 * Gets the length of the {@link #getLines()} array.
+	 *
+	 * @return the length
 	 */
 	int getLength();
 }

--- a/runelite-api/src/main/java/net/runelite/api/ChatMessageType.java
+++ b/runelite-api/src/main/java/net/runelite/api/ChatMessageType.java
@@ -24,30 +24,102 @@
  */
 package net.runelite.api;
 
+/**
+ * Enumeration of message types that can be received in the chat.
+ */
 public enum ChatMessageType
 {
+	/**
+	 * A message received from the server.
+	 */
 	SERVER(0),
+	/**
+	 * A message in the public chat.
+	 */
 	PUBLIC(2),
+	/**
+	 * A private message from another player.
+	 */
 	PRIVATE_MESSAGE_RECEIVED(3),
+	/**
+	 * A trade request received.
+	 */
 	TRADE_RECEIVED(4),
+	/**
+	 * A message received when a friend logs in or out.
+	 */
 	PRIVATE_MESSAGE_INFO(5),
+	/**
+	 * A private message sent to another player.
+	 */
 	PRIVATE_MESSAGE_SENT(6),
+	/**
+	 * A private message received from a moderator.
+	 */
 	PRIVATE_MESSAGE_RECEIVED_MOD(7),
+	/**
+	 * A message received in clan chat.
+	 */
 	CLANCHAT(9),
+	/**
+	 * A message received with information about the current clan chat.
+	 */
 	CLANCHAT_INFO(11),
+	/**
+	 * A trade request being sent.
+	 */
 	TRADE_SENT(12),
+	/**
+	 * An abuse report submitted.
+	 */
 	ABUSE_REPORT(26),
+	/**
+	 * Examine item description.
+	 */
 	EXAMINE_ITEM(27),
+	/**
+	 * Examine NPC description.
+	 */
 	EXAMINE_NPC(28),
+	/**
+	 * Examine object description.
+	 */
 	EXAMINE_OBJECT(29),
+	/**
+	 * Adding player to friend list.
+	 */
 	FRIENDS_LIST_ADD(30),
+	/**
+	 * Adding player to ignore list.
+	 */
 	IGNORE_LIST_ADD(31),
+	/**
+	 * An autochat message from a player.
+	 */
 	AUTOCHAT(90),
+	/**
+	 * A game message (ie. when a setting is changed).
+	 */
 	GAME(99),
+	/**
+	 * A message received when somebody sends a trade offer.
+	 */
 	TRADE(101),
+	/**
+	 * A message received when somebody sends a duel offer.
+	 */
 	DUEL(103),
+	/**
+	 * A message that was filtered.
+	 */
 	FILTERED(105),
+	/**
+	 * A message about an action.
+	 */
 	ACTION(109),
+	/**
+	 * An unknown message type.
+	 */
 	UNKNOWN(-1);
 
 	private final int type;
@@ -57,6 +129,13 @@ public enum ChatMessageType
 		this.type = type;
 	}
 
+	/**
+	 * Utility method that maps the type value to its respective
+	 * {@link ChatMessageType} value.
+	 *
+	 * @param type the raw type
+	 * @return appropriate message type, or {@link #UNKNOWN}
+	 */
 	public static ChatMessageType of(int type)
 	{
 		for (ChatMessageType ct : ChatMessageType.values())
@@ -69,6 +148,11 @@ public enum ChatMessageType
 		return UNKNOWN;
 	}
 
+	/**
+	 * Gets the raw type value of the message type.
+	 *
+	 * @return the raw type
+	 */
 	public int getType()
 	{
 		return type;

--- a/runelite-api/src/main/java/net/runelite/api/ChatPlayer.java
+++ b/runelite-api/src/main/java/net/runelite/api/ChatPlayer.java
@@ -24,6 +24,9 @@
  */
 package net.runelite.api;
 
+/**
+ * Represents a player in the chat.
+ */
 public interface ChatPlayer extends Nameable
 {
 }

--- a/runelite-api/src/main/java/net/runelite/api/ClanMember.java
+++ b/runelite-api/src/main/java/net/runelite/api/ClanMember.java
@@ -24,11 +24,29 @@
  */
 package net.runelite.api;
 
+/**
+ * Represents a clan member.
+ */
 public interface ClanMember
 {
+	/**
+	 * Gets the username of the member.
+	 *
+	 * @return the username
+	 */
 	String getUsername();
 
+	/**
+	 * Gets the world the member is in.
+	 *
+	 * @return the world
+	 */
 	int getWorld();
 
+	/**
+	 * Gets the rank of the clan member.
+	 *
+	 * @return the rank
+	 */
 	ClanMemberRank getRank();
 }

--- a/runelite-api/src/main/java/net/runelite/api/ClanMemberRank.java
+++ b/runelite-api/src/main/java/net/runelite/api/ClanMemberRank.java
@@ -29,18 +29,48 @@ import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+/**
+ * An enumeration of ranks of clan members.
+ */
 @AllArgsConstructor
 @Getter
 public enum ClanMemberRank
 {
+	/**
+	 * Not in a clan.
+	 */
 	UNRANKED(-1),
+	/**
+	 * Friend rank.
+	 */
 	FRIEND(0),
+	/**
+	 * Recruit rank.
+	 */
 	RECRUIT(1),
+	/**
+	 * Corporal rank.
+	 */
 	CORPORAL(2),
+	/**
+	 * Sergeant rank.
+	 */
 	SERGEANT(3),
+	/**
+	 * Lieutenant rank.
+	 */
 	LIEUTENANT(4),
+	/**
+	 * Captain rank.
+	 */
 	CAPTAIN(5),
+	/**
+	 * General rank.
+	 */
 	GENERAL(6),
+	/**
+	 * Channel owner rank.
+	 */
 	OWNER(7);
 
 	private static final Map<Integer, ClanMemberRank> RANKS = new HashMap<>();
@@ -53,10 +83,20 @@ public enum ClanMemberRank
 		}
 	}
 
+	/**
+	 * Utility method that maps the rank value to its respective
+	 * {@link ClanMemberRank} value.
+	 *
+	 * @param rank the rank value
+	 * @return rank type
+	 */
 	public static ClanMemberRank valueOf(int rank)
 	{
 		return RANKS.get(rank);
 	}
 
+	/**
+	 * The value of the clan rank.
+	 */
 	private final int value;
 }

--- a/runelite-api/src/main/java/net/runelite/api/Client.java
+++ b/runelite-api/src/main/java/net/runelite/api/Client.java
@@ -37,221 +37,812 @@ import net.runelite.api.vars.AccountType;
 import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetInfo;
 
+/**
+ * Represents the RuneScape client.
+ */
 public interface Client extends GameEngine
 {
+	/**
+	 * Gets a list of all valid players from the player cache.
+	 *
+	 * @return a list of all players
+	 */
 	List<Player> getPlayers();
 
+	/**
+	 * Gets a list of all valid NPCs from the NPC cache.
+	 *
+	 * @return a list of all NPCs
+	 */
 	List<NPC> getNpcs();
 
+	/**
+	 * Gets an array of all cached NPCs.
+	 *
+	 * @return cached NPCs
+	 */
 	NPC[] getCachedNPCs();
 
+	/**
+	 * Gets an array of all cached players.
+	 *
+	 * @return cached players
+	 */
 	Player[] getCachedPlayers();
 
+	/**
+	 * Gets the current modified level of a skill.
+	 *
+	 * @param skill the skill
+	 * @return the modified skill level
+	 */
 	int getBoostedSkillLevel(Skill skill);
 
+	/**
+	 * Gets the real level of a skill.
+	 *
+	 * @param skill the skill
+	 * @return the skill level
+	 */
 	int getRealSkillLevel(Skill skill);
 
+	/**
+	 * Adds a new chat message to the chatbox.
+	 *
+	 * @param type the type of message
+	 * @param name the name of the player that sent the message
+	 * @param message the message contents
+	 * @param sender the sender/channel name
+	 */
 	void addChatMessage(ChatMessageType type, String name, String message, String sender);
 
+	/**
+	 * Gets the current game state.
+	 *
+	 * @return the game state
+	 */
 	GameState getGameState();
 
+	/**
+	 * Gets the current logged in username.
+	 *
+	 * @return the logged in username
+	 */
 	String getUsername();
 
+	/**
+	 * Sets the current logged in username.
+	 *
+	 * @param name the logged in username
+	 */
 	void setUsername(String name);
 
 	/**
-	 * Gets the account type for the logged in player.
+	 * Gets the account type of the logged in player.
+	 *
+	 * @return the account type
 	 */
 	AccountType getAccountType();
 
+	@Override
 	Canvas getCanvas();
 
+	/**
+	 * Gets the current FPS (frames per second).
+	 *
+	 * @return the FPS
+	 */
 	int getFPS();
 
+	/**
+	 * Gets the x-axis coordinate of the camera.
+	 * <p>
+	 * This value is a local coordinate value similar to
+	 * {@link #getLocalDestinationLocation()}.
+	 *
+	 * @return the camera x coordinate
+	 */
 	int getCameraX();
 
+	/**
+	 * Gets the y-axis coordinate of the camera.
+	 * <p>
+	 * This value is a local coordinate value similar to
+	 * {@link #getLocalDestinationLocation()}.
+	 *
+	 * @return the camera y coordinate
+	 */
 	int getCameraY();
 
+	/**
+	 * Gets the z-axis coordinate of the camera.
+	 * <p>
+	 * This value is a local coordinate value similar to
+	 * {@link #getLocalDestinationLocation()}.
+	 *
+	 * @return the camera z coordinate
+	 */
 	int getCameraZ();
 
 	/**
-	 * This returns the actual pitch of the camera in JAUs
+	 * Gets the actual pitch of the camera.
+	 * <p>
+	 * The value returned by this method is measured in JAU, or Jagex
+	 * Angle Unit, which is 1/1024 of a revolution.
+	 *
+	 * @return the camera pitch
 	 */
 	int getCameraPitch();
 
+	/**
+	 * Gets the yaw of the camera.
+	 *
+	 * @return the camera yaw
+	 */
 	int getCameraYaw();
 
+	/**
+	 * Gets the current world number of the logged in player.
+	 *
+	 * @return the logged in world number
+	 */
 	int getWorld();
 
+	/**
+	 * Gets the height of the viewport.
+	 *
+	 * @return the viewport height
+	 */
 	int getViewportHeight();
 
+	/**
+	 * Gets the width of the viewport.
+	 *
+	 * @return the viewport width
+	 */
 	int getViewportWidth();
 
+	/**
+	 * Gets the x-axis offset of the viewport.
+	 *
+	 * @return the x-axis offset
+	 */
 	int getViewportXOffset();
 
+	/**
+	 * Gets the y-axis offset of the viewport.
+	 *
+	 * @return the y-axis offset
+	 */
 	int getViewportYOffset();
 
+	/**
+	 * Gets the scale of the world (zoom value).
+	 *
+	 * @return the world scale
+	 */
 	int getScale();
 
+	/**
+	 * Gets the current position of the mouse on the canvas.
+	 *
+	 * @return the mouse canvas position
+	 */
 	Point getMouseCanvasPosition();
 
+	/**
+	 * Gets a 3D array containing the heights of tiles in the
+	 * current scene.
+	 *
+	 * @return the tile heights
+	 */
 	int[][][] getTileHeights();
 
+	/**
+	 * Gets a 3D array containing the settings of tiles in the
+	 * current scene.
+	 *
+	 * @return the tile settings
+	 */
 	byte[][][] getTileSettings();
 
+	/**
+	 * Gets the current plane the player is on.
+	 * <p>
+	 * This value indicates the current map level above ground level, where
+	 * ground level is 0. For example, going up a ladder in Lumbridge castle
+	 * will put the player on plane 1.
+	 * <p>
+	 * Note: This value will never be below 0. Basements and caves below ground
+	 * level use a tile offset and are still considered plane 0 by the game.
+	 *
+	 * @return the plane
+	 */
 	int getPlane();
 
+	/**
+	 * Gets the current region the local player is in.
+	 *
+	 * @return the region
+	 */
 	Region getRegion();
 
+	/**
+	 * Gets the logged in player instance.
+	 *
+	 * @return the logged in player
+	 */
 	Player getLocalPlayer();
 
+	/**
+	 * Gets the item composition corresponding to an items ID.
+	 *
+	 * @param id the item ID
+	 * @return the corresponding item composition
+	 * @see ItemID
+	 */
 	ItemComposition getItemDefinition(int id);
 
+	/**
+	 * Creates an item icon sprite with passed variables.
+	 *
+	 * @param itemId the item ID
+	 * @param quantity the item quantity
+	 * @param border whether to draw a border
+	 * @param shadowColor the shadow color
+	 * @param stackable whether the item is stackable
+	 * @param noted whether the item is noted
+	 * @param scale the scale of the sprite
+	 * @return the created sprite
+	 */
 	SpritePixels createItemSprite(int itemId, int quantity, int border, int shadowColor, int stackable, boolean noted, int scale);
 
+	/**
+	 * Loads and creates the sprite image of the passed archive and file IDs.
+	 *
+	 * @param source the sprite database
+	 * @param archiveId the sprites archive ID
+	 * @param fileId the sprites file ID
+	 * @return the sprite image of the file
+	 */
 	SpritePixels getSprite(IndexDataBase source, int archiveId, int fileId);
 
+	/**
+	 * Gets the sprite index database.
+	 *
+	 * @return the sprite database
+	 */
 	IndexDataBase getIndexSprites();
 
+	/**
+	 * Returns the x-axis base coordinate.
+	 * <p>
+	 * This value is the x-axis world coordinate of tile (0, 0) in
+	 * the current scene (ie. the bottom-left most coordinates in
+	 * the rendered region).
+	 *
+	 * @return the base x-axis coordinate
+	 */
 	int getBaseX();
 
+	/**
+	 * Returns the y-axis base coordinate.
+	 * <p>
+	 * This value is the y-axis world coordinate of tile (0, 0) in
+	 * the current scene (ie. the bottom-left most coordinates in
+	 * the rendered region).
+	 *
+	 * @return the base y-axis coordinate
+	 */
 	int getBaseY();
 
+	/**
+	 * Gets the current mouse button that is pressed.
+	 *
+	 * @return the pressed mouse button
+	 */
 	int getMouseCurrentButton();
 
+	/**
+	 * Gets the currently selected region tile (ie. last right clicked
+	 * tile).
+	 *
+	 * @return the selected region tile
+	 */
 	Tile getSelectedRegionTile();
 
+	/**
+	 * Checks whether a widget is currently being dragged.
+	 *
+	 * @return true if dragging a widget, false otherwise
+	 */
 	boolean isDraggingWidget();
 
+	/**
+	 * Gets the widget currently being dragged.
+	 *
+	 * @return the dragged widget, null if not dragging any widget
+	 */
 	Widget getDraggedWidget();
 
+	/**
+	 * Gets the widget that is being dragged on.
+	 * <p>
+	 * The widget being dragged has the {@link net.runelite.api.widgets.WidgetConfig#DRAG_ON}
+	 * flag set, and is the widget currently under the dragged widget.
+	 *
+	 * @return the dragged on widget, null if not dragging any widget
+	 */
 	Widget getDraggedOnWidget();
 
+	/**
+	 * Sets the widget that is being dragged on.
+	 *
+	 * @param widget the new dragged on widget
+	 */
 	void setDraggedOnWidget(Widget widget);
 
+	/**
+	 * Gets the root widgets.
+	 *
+	 * @return the root widgets
+	 */
 	Widget[] getWidgetRoots();
 
+	/**
+	 * Gets a widget corresponding to the passed widget info.
+	 *
+	 * @param widget the widget info
+	 * @return the widget
+	 */
 	Widget getWidget(WidgetInfo widget);
 
+	/**
+	 * Gets an array of widgets that correspond to the passed group ID.
+	 *
+	 * @param groupId the group ID
+	 * @return the widget group
+	 * @see net.runelite.api.widgets.WidgetID
+	 */
 	Widget[] getGroup(int groupId);
 
+	/**
+	 * Gets a widget by its raw group ID and child ID.
+	 * <p>
+	 * Note: Use {@link #getWidget(WidgetInfo)} for a more human-readable
+	 * version of this method.
+	 *
+	 * @param groupId the group ID
+	 * @param childId the child widget ID
+	 * @return the widget corresponding to the group and child pair
+	 */
 	Widget getWidget(int groupId, int childId);
 
+	/**
+	 * Gets an array containing the x-axis canvas positions
+	 * of all widgets.
+	 *
+	 * @return array of x-axis widget coordinates
+	 */
 	int[] getWidgetPositionsX();
 
+	/**
+	 * Gets an array containing the y-axis canvas positions
+	 * of all widgets.
+	 *
+	 * @return array of y-axis widget coordinates
+	 */
 	int[] getWidgetPositionsY();
 
+	/**
+	 * Gets the current run energy of the logged in player.
+	 *
+	 * @return the run energy
+	 */
 	int getEnergy();
 
+	/**
+	 * Gets an array of options that can currently be used on other players.
+	 * <p>
+	 * For example, if the player is in a PVP area the "Attack" option
+	 * will become available in the array. Otherwise, it won't be there.
+	 *
+	 * @return an array of options
+	 */
 	String[] getPlayerOptions();
 
+	/**
+	 * Gets an array of whether an option is enabled or not.
+	 *
+	 * @return the option priorities
+	 */
 	boolean[] getPlayerOptionsPriorities();
 
+	/**
+	 * Gets an array of player menu types.
+	 *
+	 * @return the player menu types
+	 */
 	int[] getPlayerMenuTypes();
 
 	/**
-	 * Get list of all RuneScape worlds
+	 * Gets a list of all RuneScape worlds.
+	 *
 	 * @return world list
 	 */
 	World[] getWorldList();
 
+	/**
+	 * Gets an array of currently open right-click menu entries that can be
+	 * clicked and activated.
+	 *
+	 * @return array of open menu entries
+	 */
 	MenuEntry[] getMenuEntries();
 
+	/**
+	 * Sets the array of open menu entries.
+	 * <p>
+	 * This method should typically be used in the context of the {@link net.runelite.api.events.MenuOpened}
+	 * event, since setting the menu entries will be overwritten the next
+	 * time the menu entries are calculated.
+	 *
+	 * @param entries new array of open menu entries
+	 */
 	void setMenuEntries(MenuEntry[] entries);
 
+	/**
+	 * Checks whether a right-click menu is currently open.
+	 *
+	 * @return true if a menu is open, false otherwise
+	 */
 	boolean isMenuOpen();
 
+	/**
+	 * Gets the angle of the map, or camera yaw.
+	 *
+	 * @return the map angle
+	 */
 	int getMapAngle();
 
+	/**
+	 * Checks whether the client window is currently resized.
+	 *
+	 * @return true if resized, false otherwise
+	 */
 	boolean isResized();
 
+	/**
+	 * Gets the client revision number.
+	 *
+	 * @return the revision
+	 */
 	int getRevision();
 
+	/**
+	 * Gets an array of map region IDs that are currently loaded.
+	 *
+	 * @return the map regions
+	 */
 	int[] getMapRegions();
 
+	/**
+	 * Contains a 3D array of template chunks for instanced areas.
+	 * <p>
+	 * The array returned is of format [z][x][y], where z is the
+	 * plane, x and y the x-axis and y-axis coordinates of a tile
+	 * divided by the size of a chunk.
+	 * <p>
+	 * The bits of the int value held by the coordinates are structured
+	 * with the following format:
+	 * <ul>
+	 *     <li>Bits 7 and 8 correspond to the plane</li>
+	 *     <li>Bits 9 to 18 correspond to the x-axis coordinate of the chunk</li>
+	 *     <li>Bits 19 to 29 correspond to the y-axis coordinate of the chunk</li>
+	 *     <li>Bits 30 and 31 correspond to the chunks rotation</li>
+	 * </ul>
+	 * Note: The above positions assume that the left-most bit of an integer
+	 * is bit position 1, and the right-most bit 32.
+	 * ie.
+	 * 0000 0000 0000 0000 0000 0000 0000 0000
+	 *        PP XXXX XXXX XXYY YYYY YYYY YRR
+	 * Where P is the plane, X and Y the x/y axis coordinates, and R the chunks
+	 * rotation.
+	 *
+	 * @return the array of instance template chunks
+	 * @see Constants#CHUNK_SIZE
+	 * @see InstanceTemplates
+	 */
 	int[][][] getInstanceTemplateChunks();
 
+	/**
+	 * Returns a 2D array containing XTEA encryption keys used to decrypt
+	 * map region files.
+	 * <p>
+	 * The array maps the region keys at index {@code n} to the region
+	 * ID held in {@link #getMapRegions()} at {@code n}.
+	 * <p>
+	 * The array of keys for the region make up a 128-bit encryption key
+	 * spread across 4 integers.
+	 *
+	 * @return the XTEA encryption keys
+	 */
 	int[][] getXteaKeys();
 
+	/**
+	 * Gets an array of all client variables.
+	 *
+	 * @return local player variables
+	 */
 	@VisibleForDevtools
 	int[] getVarps();
 
+	/**
+	 * Gets an array of all integer client variables.
+	 *
+	 * @return local variables
+	 */
 	@VisibleForDevtools
 	int[] getIntVarcs();
 
+	/**
+	 * Gets an array of all string client variables.
+	 *
+	 * @return local variables
+	 */
 	@VisibleForDevtools
 	String[] getStrVarcs();
 
+	/**
+	 * Gets the value corresponding to the passed player variable.
+	 *
+	 * @param varPlayer the player variable
+	 * @return the value
+	 */
 	int getVar(VarPlayer varPlayer);
 
+	/**
+	 * Gets a value corresponding to the passed variable.
+	 *
+	 * @param varbit the variable
+	 * @return the value
+	 */
 	int getVar(Varbits varbit);
 
+	/**
+	 * Gets an int value corresponding to the passed variable.
+	 *
+	 * @param varClientInt the variable
+	 * @return the value
+	 */
 	int getVar(VarClientInt varClientInt);
 
+	/**
+	 * Gets a String value corresponding to the passed variable.
+	 *
+	 * @param varClientStr the variable
+	 * @return the value
+	 */
 	String getVar(VarClientStr varClientStr);
 
+	/**
+	 * Sets the value of a given variable.
+	 *
+	 * @param varbit the variable
+	 * @param value the new value
+	 */
 	@VisibleForDevtools
 	void setSetting(Varbits varbit, int value);
 
+	/**
+	 * Gets the value of a given variable.
+	 *
+	 * @param varps passed varbits
+	 * @param varbitId the variable ID
+	 * @return the value
+	 * @see Varbits#id
+	 */
 	@VisibleForDevtools
 	int getVarbitValue(int[] varps, int varbitId);
 
+	/**
+	 * Sets the value of a given variable.
+	 *
+	 * @param varps passed varbits
+	 * @param varbit the variable
+	 * @param value the value
+	 * @see Varbits#id
+	 */
 	@VisibleForDevtools
 	void setVarbitValue(int[] varps, int varbit, int value);
 
+	/**
+	 * Gets the widget flags table.
+	 *
+	 * @return the widget flags table
+	 */
 	HashTable getWidgetFlags();
 
+	/**
+	 * Gets the widget node component table.
+	 *
+	 * @return the widget node component table
+	 * @see WidgetNode
+	 */
 	HashTable getComponentTable();
 
+	/**
+	 * Gets an array of current grand exchange offers.
+	 *
+	 * @return all grand exchange offers
+	 */
 	GrandExchangeOffer[] getGrandExchangeOffers();
 
+	/**
+	 * Checks whether or not a prayer is currently active.
+	 *
+	 * @param prayer the prayer
+	 * @return true if the prayer is active, false otherwise
+	 */
 	boolean isPrayerActive(Prayer prayer);
 
+	/**
+	 * Gets the current experience towards a skill.
+	 *
+	 * @param skill the skill
+	 * @return the experience
+	 */
 	int getSkillExperience(Skill skill);
 
+	/**
+	 * Gets the game drawing mode.
+	 *
+	 * @return the game drawing mode
+	 */
 	int getGameDrawingMode();
 
+	/**
+	 * Sets the games drawing mode.
+	 *
+	 * @param gameDrawingMode the new drawing mode
+	 */
 	void setGameDrawingMode(int gameDrawingMode);
 
+	/**
+	 * Refreshes the chat.
+	 */
 	void refreshChat();
 
+	/**
+	 * Gets the map of chat buffers.
+	 *
+	 * @return the chat buffers
+	 */
 	Map<Integer, ChatLineBuffer> getChatLineMap();
 
+	/**
+	 * Gets the viewport widget.
+	 * <p>
+	 * The viewport is the area of the game above the chatbox
+	 * and to the left of the mini-map.
+	 *
+	 * @return the viewport widget
+	 */
 	Widget getViewportWidget();
 
+	/**
+	 * Gets the object composition corresponding to an objects ID.
+	 *
+	 * @param objectId the object ID
+	 * @return the corresponding object composition
+	 * @see ObjectID
+	 */
 	ObjectComposition getObjectDefinition(int objectId);
 
+	/**
+	 * Gets the NPC composition corresponding to an NPCs ID.
+	 *
+	 * @param npcId the npc ID
+	 * @return the corresponding NPC composition
+	 * @see NpcID
+	 */
 	NPCComposition getNpcDefinition(int npcId);
 
+	/**
+	 * Gets an array of all world areas
+	 *
+	 * @return the world areas
+	 */
 	Area[] getMapAreas();
 
+	/**
+	 * Gets a sprite of the map scene
+	 *
+	 * @return the sprite
+	 */
 	IndexedSprite[] getMapScene();
-	
+
+	/**
+	 * Gets an array of currently drawn mini-map dots.
+	 *
+	 * @return all mini-map dots
+	 */
 	SpritePixels[] getMapDots();
 
+	/**
+	 * Gets the local clients game cycle.
+	 * <p>
+	 * Note: This value is incremented every 20ms.
+	 *
+	 * @return the game cycle
+	 */
 	int getGameCycle();
 
+	/**
+	 * Gets an array of current map icon sprites.
+	 *
+	 * @return the map icons
+	 */
 	SpritePixels[] getMapIcons();
 
+	/**
+	 * Gets an array of mod icon sprites.
+	 *
+	 * @return the mod icons
+	 */
 	IndexedSprite[] getModIcons();
 
+	/**
+	 * Replaces the current mod icons with a new array.
+	 *
+	 * @param modIcons the new mod icons
+	 */
 	void setModIcons(IndexedSprite[] modIcons);
 
+	/**
+	 * Creates an empty indexed sprite.
+	 *
+	 * @return the sprite
+	 */
 	IndexedSprite createIndexedSprite();
 
+	/**
+	 * Creates a sprite image with given width and height containing the
+	 * pixels.
+	 *
+	 * @param pixels the pixels
+	 * @param width the width
+	 * @param height the height
+	 * @return the sprite image
+	 */
 	SpritePixels createSpritePixels(int[] pixels, int width, int height);
 
+	/**
+	 * Gets the location of the local player.
+	 *
+	 * @return the local player location
+	 */
 	@Nullable
 	LocalPoint getLocalDestinationLocation();
 
+	/**
+	 * Gets a list of all projectiles currently spawned.
+	 *
+	 * @return all projectiles
+	 */
 	List<Projectile> getProjectiles();
 
+	/**
+	 * Gets a list of all graphics objects currently drawn.
+	 *
+	 * @return all graphics objects
+	 */
 	List<GraphicsObject> getGraphicsObjects();
 
 	/**
 	 * Play a sound effect at the player's current location. This is how UI,
 	 * and player-generated (e.g. mining, woodcutting) sound effects are
-	 * normally played
+	 * normally played.
 	 *
 	 * @param id the ID of the sound to play. Any int is allowed, but see
 	 * {@link SoundEffectID} for some common ones
@@ -270,10 +861,25 @@ public interface Client extends GameEngine
 	 */
 	void playSoundEffect(int id, int x, int y, int range);
 
+	/**
+	 * Gets the clients graphic buffer provider.
+	 *
+	 * @return the buffer provider
+	 */
 	BufferProvider getBufferProvider();
 
+	/**
+	 * Gets the amount of ticks since the last mouse movement occurred.
+	 *
+	 * @return amount of idle mouse ticks
+	 */
 	int getMouseIdleTicks();
 
+	/**
+	 * Gets the amount of ticks since the last keyboard press occurred.
+	 *
+	 * @return amount of idle keyboard ticks
+	 */
 	int getKeyboardIdleTicks();
 
 	/**
@@ -285,128 +891,415 @@ public interface Client extends GameEngine
 	void changeMemoryMode(boolean lowMemory);
 
 	/**
-	 * Get the item container for an inventory
+	 * Get the item container for an inventory.
 	 *
-	 * @param inventory
-	 * @return
+	 * @param inventory the inventory type
+	 * @return the item container
 	 */
 	@Nullable
 	ItemContainer getItemContainer(InventoryID inventory);
 
+	/**
+	 * Gets the index of the last integer added to the
+	 * {@link #getIntStack()} array.
+	 *
+	 * @return the array index
+	 */
 	int getIntStackSize();
 
+	/**
+	 * Sets the index of the last integer added to the
+	 * {@link #getIntStack()} array.
+	 *
+	 * @param stackSize the array index
+	 */
 	void setIntStackSize(int stackSize);
 
+	/**
+	 * Gets the integer stack
+	 *
+	 * @return the array
+	 */
 	int[] getIntStack();
 
+	/**
+	 * Gets the index of the last string added to the
+	 * {@link #getStringStack()} array.
+	 *
+	 * @return the array index
+	 */
 	int getStringStackSize();
 
+	/**
+	 * Sets the index of the last string added to the
+	 * {@link #getStringStack()} array.
+	 *
+	 * @param stackSize the array index
+	 */
 	void setStringStackSize(int stackSize);
 
+	/**
+	 * Gets the string stack
+	 *
+	 * @return the string stack
+	 */
 	String[] getStringStack();
 
+	/**
+	 * Checks whether a player is on the friends list.
+	 *
+	 * @param name the name of the player
+	 * @param mustBeLoggedIn if they player is online
+	 * @return true if the player is friends
+	 */
 	boolean isFriended(String name, boolean mustBeLoggedIn);
 
+	/**
+	 * Gets the number of players in the clan chat.
+	 *
+	 * @return the number of clan chat members
+	 */
 	int getClanChatCount();
 
+	/**
+	 * Gets an array of players in the clan chat.
+	 *
+	 * @return the clan chat members, null if not in a clan
+	 */
 	ClanMember[] getClanMembers();
 
+	/**
+	 * Gets an array of players in the friends list.
+	 *
+	 * @return the friends list
+	 */
 	Friend[] getFriends();
 
+	/**
+	 * Checks whether a player is in the same clan chat.
+	 *
+	 * @param name the name of the player
+	 * @return true if the player is in clan chat
+	 */
 	boolean isClanMember(String name);
 
+	/**
+	 * Gets the clients saved preferences.
+	 *
+	 * @return the client preferences
+	 */
 	Preferences getPreferences();
 
+	/**
+	 * Sets whether the camera pitch can exceed the normal limits set
+	 * by the RuneScape client.
+	 *
+	 * @param enabled new camera pitch relaxer value
+	 */
 	void setCameraPitchRelaxerEnabled(boolean enabled);
 
+	/**
+	 * Gets the world map overview.
+	 *
+	 * @return the world map overview
+	 */
 	RenderOverview getRenderOverview();
 
+	/**
+	 * Checked whether the client is in stretched mode.
+	 *
+	 * @return true if the client is in stretched, false otherwise
+	 */
 	boolean isStretchedEnabled();
 
+	/**
+	 * Sets the client stretched mode state.
+	 *
+	 * @param state new stretched mode state
+	 */
 	void setStretchedEnabled(boolean state);
 
+	/**
+	 * Checks whether the client is using fast rendering techniques when
+	 * stretching the client in fixed mode.
+	 *
+	 * @return true if client is fast rendering, false otherwise
+	 */
 	boolean isStretchedFast();
 
+	/**
+	 * Sets whether to use fast rendering techniques when in stretch
+	 * fixed mode.
+	 *
+	 * @param state new fast rendering state
+	 */
 	void setStretchedFast(boolean state);
 
+	/**
+	 * Sets whether to force integer scale factor by rounding scale
+	 * factors towards {@code zero} when stretching fixed mode.
+	 *
+	 * @param state new integer scaling state
+	*/
 	void setStretchedIntegerScaling(boolean state);
 
+	/**
+	 * Sets whether to keep aspect ratio when stretching fixed mode.
+	 *
+	 * @param state new keep aspect ratio state
+	 */
 	void setStretchedKeepAspectRatio(boolean state);
 
+	/**
+	 * Gets the current stretched dimensions of the client.
+	 *
+	 * @return the stretched dimensions
+	 */
 	Dimension getStretchedDimensions();
 
+	/**
+	 * Gets the real dimensions of the client before being stretched.
+	 *
+	 * @return the real dimensions
+	 */
 	Dimension getRealDimensions();
 
 	/**
-	 * Changes world. Works only on login screen
-	 * @param world world
+	 * Changes the selected world to log in to.
+	 * <p>
+	 * Note: this method will have no effect unless {@link GameState}
+	 * is {@link GameState#LOGIN_SCREEN}.
+	 *
+	 * @param world the world to switch to
 	 */
 	void changeWorld(World world);
 
 	/**
-	 * Creates instance of new world
-	 * @return world
+	 * Creates a new instance of a world.
+	 *
+	 * @return the created world
 	 */
 	World createWorld();
 
+	/**
+	 * Draws an instance map for the current viewed plane.
+	 *
+	 * @param z the plane
+	 * @return the map sprite
+	 */
 	SpritePixels drawInstanceMap(int z);
 
+	/**
+	 * Runs a RuneLite script.
+	 *
+	 * @param id the script ID
+	 * @param args additional arguments to execute the script with
+	 * @see ScriptID
+	 */
 	void runScript(int id, Object... args);
 
+	/**
+	 * Checks whether or not there is any active hint arrow.
+	 *
+	 * @return true if there is a hint arrow, false otherwise
+	 */
 	boolean hasHintArrow();
 
+	/**
+	 * Gets the type of hint arrow currently displayed.
+	 *
+	 * @return the hint arrow type
+	 */
 	HintArrowType getHintArrowType();
 
+	/**
+	 * Clears the current hint arrow.
+	 */
 	void clearHintArrow();
 
+	/**
+	 * Sets a hint arrow to point to the passed location.
+	 *
+	 * @param point the location
+	 */
 	void setHintArrow(WorldPoint point);
 
+	/**
+	 * Sets a hint arrow to point to the passed player.
+	 *
+	 * @param player the player
+	 */
 	void setHintArrow(Player player);
 
+	/**
+	 * Sets a hint arrow to point to the passed NPC.
+	 *
+	 * @param npc the NPC
+	 */
 	void setHintArrow(NPC npc);
 
+	/**
+	 * Gets the world point that the hint arrow is directed at.
+	 *
+	 * @return hint arrow target
+	 */
 	WorldPoint getHintArrowPoint();
 
+	/**
+	 * Gets the player that the hint arrow is directed at.
+	 *
+	 * @return hint arrow target
+	 */
 	Player getHintArrowPlayer();
 
+	/**
+	 * Gets the NPC that the hint arrow is directed at.
+	 *
+	 * @return hint arrow target
+	 */
 	NPC getHintArrowNpc();
 
+	/**
+	 * Checks whether animation smoothing is enabled for players.
+	 *
+	 * @return true if player animation smoothing is enabled, false otherwise
+	 */
 	boolean isInterpolatePlayerAnimations();
 
+	/**
+	 * Sets the animation smoothing state for players.
+	 *
+	 * @param interpolate the new smoothing state
+	 */
 	void setInterpolatePlayerAnimations(boolean interpolate);
 
+	/**
+	 * Checks whether animation smoothing is enabled for NPC.
+	 *
+	 * @return true if NPC animation smoothing is enabled, false otherwise
+	 */
 	boolean isInterpolateNpcAnimations();
 
+	/**
+	 * Sets the animation smoothing state for NPCs.
+	 *
+	 * @param interpolate the new smoothing state
+	 */
 	void setInterpolateNpcAnimations(boolean interpolate);
 
+	/**
+	 * Checks whether animation smoothing is enabled for objects.
+	 *
+	 * @return true if object animation smoothing is enabled, false otherwise
+	 */
 	boolean isInterpolateObjectAnimations();
 
+	/**
+	 * Sets the animation smoothing state for objects.
+	 *
+	 * @param interpolate the new smoothing state
+	 */
 	void setInterpolateObjectAnimations(boolean interpolate);
 
+	/**
+	 * Checks whether the logged in player is in an instanced region.
+	 *
+	 * @return true if the player is in instanced region, false otherwise
+	 */
 	boolean isInInstancedRegion();
 
+	/**
+	 * Sets whether the client is hiding entities.
+	 * <p>
+	 * This method does not itself hide any entities. It behaves as a master
+	 * switch for whether or not any of the related entities are hidden or
+	 * shown. If this method is set to false, changing the configurations for
+	 * specific entities will have no effect.
+	 *
+	 * @param state new entity hiding state
+	 */
 	void setIsHidingEntities(boolean state);
 
+	/**
+	 * Sets whether or not other players are hidden.
+	 *
+	 * @param state the new player hidden state
+	 */
 	void setPlayersHidden(boolean state);
 
+	/**
+	 * Sets whether 2D sprites (ie. overhead prayers, PK skull) related to
+	 * the other players are hidden.
+	 *
+	 * @param state the new player 2D hidden state
+	 */
 	void setPlayersHidden2D(boolean state);
 
+	/**
+	 * Sets whether or not friends are hidden.
+	 *
+	 * @param state the new friends hidden state
+	 */
 	void setFriendsHidden(boolean state);
 
+	/**
+	 * Sets whether or not clan mates are hidden.
+	 *
+	 * @param state the new clan mates hidden state
+	 */
 	void setClanMatesHidden(boolean state);
 
+	/**
+	 * Sets whether the local player is hidden.
+	 *
+	 * @param state new local player hidden state
+	 */
 	void setLocalPlayerHidden(boolean state);
 
+	/**
+	 * Sets whether 2D sprites (ie. overhead prayers, PK skull) related to
+	 * the local player are hidden.
+	 *
+	 * @param state new local player 2D hidden state
+	 */
 	void setLocalPlayerHidden2D(boolean state);
 
+	/**
+	 * Sets whether NPCs are hidden.
+	 *
+	 * @param state new NPC hidden state
+	 */
 	void setNPCsHidden(boolean state);
 
+	/**
+	 * Sets whether 2D sprites (ie. overhead prayers) related to
+	 * the NPCs are hidden.
+	 *
+	 * @param state new NPC 2D hidden state
+	 */
 	void setNPCsHidden2D(boolean state);
 
+	/**
+	 * Sets whether attacking players or NPCs are hidden.
+	 *
+	 * @param state new attacker hidden state
+	 */
 	void setAttackersHidden(boolean state);
 
+	/**
+	 * Sets whether projectiles are hidden.
+	 *
+	 * @param state new projectile hidden state
+	 */
 	void setProjectilesHidden(boolean state);
 
+	/**
+	 * Gets an array of tile collision data.
+	 * <p>
+	 * The index into the array is the plane/z-axis coordinate.
+	 *
+	 * @return the collision data
+	 */
 	CollisionData[] getCollisionMaps();
 
 	@VisibleForDevtools
@@ -427,17 +1320,58 @@ public interface Client extends GameEngine
 	@VisibleForDevtools
 	void setChangedSkillsCount(int i);
 
+	/**
+	 * Sets a mapping of sprites to override.
+	 * <p>
+	 * The key value in the map corresponds to the ID of the sprite,
+	 * and the value the sprite to replace it with.
+	 *
+	 * @param overrides the sprites to override
+	 */
 	void setSpriteOverrides(Map<Integer, SpritePixels> overrides);
 
+	/**
+	 * Sets a mapping of widget sprites to override.
+	 * <p>
+	 * The key value in the map corresponds to the packed widget ID,
+	 * and the value the sprite to replace the widgets sprite with.
+	 *
+	 * @param overrides the sprites to override
+	 */
 	void setWidgetSpriteOverrides(Map<Integer, SpritePixels> overrides);
 
+	/**
+	 * Sets the compass sprite.
+	 *
+	 * @param spritePixels the new sprite
+	 */
 	void setCompass(SpritePixels spritePixels);
 
+	/**
+	 * Gets the current server tick count.
+	 *
+	 * @return the tick count
+	 */
 	int getTickCount();
 
+	/**
+	 * Sets the current server tick count.
+	 *
+	 * @param tickCount the new tick count
+	 */
 	void setTickCount(int tickCount);
 
+	/**
+	 * Sets the inventory drag delay in client game cycles (20ms).
+	 *
+	 * @param delay the number of game cycles to delay dragging
+	 */
 	void setInventoryDragDelay(int delay);
 
+	/**
+	 * Gets a set of current world types that apply to the logged in world.
+	 *
+	 * @return the types for current world
+	 */
 	EnumSet<WorldType> getWorldType();
 }

--- a/runelite-api/src/main/java/net/runelite/api/CollisionData.java
+++ b/runelite-api/src/main/java/net/runelite/api/CollisionData.java
@@ -24,7 +24,23 @@
  */
 package net.runelite.api;
 
+/**
+ * Represents tile collision data for a world region.
+ */
 public interface CollisionData
 {
+	/**
+	 * Gets a 2D array of tile collision flags.
+	 * <p>
+	 * The array covers all tiles in a region (104x104), and the index into
+	 * the array is of format [x][y] where x and y are the tiles region
+	 * coordinates, respectively.
+	 * <p>
+	 * Collision flags are checked using the bitwise and (&amp;) operator. Flag
+	 * values can be obtained and used with the {@link CollisionDataFlag} class.
+	 *
+	 * @return all collision flags for the tiles in the region
+	 * @see Constants#REGION_SIZE
+	 */
 	int[][] getFlags();
 }

--- a/runelite-api/src/main/java/net/runelite/api/CollisionDataFlag.java
+++ b/runelite-api/src/main/java/net/runelite/api/CollisionDataFlag.java
@@ -24,8 +24,14 @@
  */
 package net.runelite.api;
 
+/**
+ * A utility class containing collision data flags for tiles.
+ */
 public final class CollisionDataFlag
 {
+	/**
+	 * Directional movement blocking flags.
+	 */
 	public static final int BLOCK_MOVEMENT_NORTH_WEST = 0x1;
 	public static final int BLOCK_MOVEMENT_NORTH = 0x2;
 	public static final int BLOCK_MOVEMENT_NORTH_EAST = 0x4;
@@ -35,6 +41,9 @@ public final class CollisionDataFlag
 	public static final int BLOCK_MOVEMENT_SOUTH_WEST = 0x40;
 	public static final int BLOCK_MOVEMENT_WEST = 0x80;
 
+	/**
+	 * Movement blocking type flags.
+	 */
 	public static final int BLOCK_MOVEMENT_OBJECT = 0x100;
 	public static final int BLOCK_MOVEMENT_FLOOR_DECORATION = 0x40000;
 	public static final int BLOCK_MOVEMENT_FLOOR = 0x200000; // Eg. water
@@ -43,6 +52,9 @@ public final class CollisionDataFlag
 			BLOCK_MOVEMENT_FLOOR_DECORATION |
 			BLOCK_MOVEMENT_FLOOR;
 
+	/**
+	 * Directional line of sight blocking flags.
+	 */
 	public static final int BLOCK_LINE_OF_SIGHT_NORTH = BLOCK_MOVEMENT_NORTH << 9; // 0x400
 	public static final int BLOCK_LINE_OF_SIGHT_EAST = BLOCK_MOVEMENT_EAST << 9; // 0x1000
 	public static final int BLOCK_LINE_OF_SIGHT_SOUTH = BLOCK_MOVEMENT_SOUTH << 9; // 0x4000

--- a/runelite-api/src/main/java/net/runelite/api/Constants.java
+++ b/runelite-api/src/main/java/net/runelite/api/Constants.java
@@ -27,14 +27,44 @@ package net.runelite.api;
 
 import java.awt.Dimension;
 
+/**
+ * A utility class containing constant values.
+ */
 public class Constants
 {
+	/**
+	 * The original width of the game when running in fixed mode.
+	 */
 	public static final int GAME_FIXED_WIDTH = 765;
+	/**
+	 * The original height of the game when running in fixed mode.
+	 */
 	public static final int GAME_FIXED_HEIGHT = 503;
+	/**
+	 * Dimension representation of the width and height of the game in fixed mode.
+	 */
 	public static final Dimension GAME_FIXED_SIZE = new Dimension(GAME_FIXED_WIDTH, GAME_FIXED_HEIGHT);
+	/**
+	 * The aspect ratio of the game when running in fixed mode.
+	 */
 	public static final double GAME_FIXED_ASPECT_RATIO = (double) GAME_FIXED_WIDTH / (double) GAME_FIXED_HEIGHT;
+	/**
+	 * The default camera zoom value.
+	 */
 	public static final int CLIENT_DEFAULT_ZOOM = 512;
+	/**
+	 * The width and length of a chunk (8x8 tiles).
+	 */
 	public static final int CHUNK_SIZE = 8;
+	/**
+	 * The width and length of a region (13 chunks x 8 tiles).
+	 */
 	public static final int REGION_SIZE = 104;
+	/**
+	 * The max allowed plane by the game.
+	 * <p>
+	 * This value is exclusive. The plane is set by 2 bits which restricts
+	 * the plane value to 0-3.
+	 */
 	public static final int MAX_Z = 4;
 }

--- a/runelite-api/src/main/java/net/runelite/api/DecorativeObject.java
+++ b/runelite-api/src/main/java/net/runelite/api/DecorativeObject.java
@@ -27,11 +27,15 @@ package net.runelite.api;
 import java.awt.Polygon;
 
 /**
- * Decorative object, such as objects on walls
- *
- * @author Adam
+ * Represents a decorative object, such as an object on a wall.
  */
 public interface DecorativeObject extends TileObject
 {
+	/**
+	 * Gets the convex hull of the objects model.
+	 *
+	 * @return the convex hull
+	 * @see net.runelite.api.model.Jarvis
+	 */
 	Polygon getConvexHull();
 }

--- a/runelite-api/src/main/java/net/runelite/api/EquipmentInventorySlot.java
+++ b/runelite-api/src/main/java/net/runelite/api/EquipmentInventorySlot.java
@@ -24,6 +24,16 @@
  */
 package net.runelite.api;
 
+/**
+ * An enumeration of equipment slots in the inventory {@link ItemContainer}.
+ * <p>
+ * These values are intended for use with the local players equipment
+ * {@link ItemContainer} corresponding. For obtaining information about equipment
+ * in the {@link PlayerComposition}, use {@link net.runelite.api.kit.KitType}.
+ *
+ * @see Client#getItemContainer(InventoryID)
+ * @see InventoryID#EQUIPMENT
+ */
 public enum EquipmentInventorySlot
 {
 	HEAD(0),
@@ -44,6 +54,12 @@ public enum EquipmentInventorySlot
 		this.slotIdx = slotIdx;
 	}
 
+	/**
+	 * Gets the index into the item array obtained from
+	 * {@link ItemContainer#getItems()}.
+	 *
+	 * @return the raw index
+	 */
 	public int getSlotIdx()
 	{
 		return slotIdx;

--- a/runelite-api/src/main/java/net/runelite/api/Experience.java
+++ b/runelite-api/src/main/java/net/runelite/api/Experience.java
@@ -27,15 +27,22 @@ package net.runelite.api;
 import static java.lang.Math.floor;
 import static java.lang.Math.max;
 
+/**
+ * A utility class used for calculating experience related values.
+ * <p>
+ * Skill levels calculated and handled by this class are within (inclusive)
+ * the range 1-126 rather than 1-99 to account for virtual levels obtained
+ * when reaching the 200M experience limit.
+ */
 public class Experience
 {
 	/**
-	 * Maximum virtual skill level at 200m xp
+	 * The maximum virtual skill level for any skill (200M experience).
 	 */
 	public static final int MAX_VIRT_LEVEL = 126;
 
 	/**
-	 * Total xp requirements of each skill level
+	 * The total experience required for each skill level.
 	 */
 	private static final int[] XP_FOR_LEVEL = new int[MAX_VIRT_LEVEL];
 
@@ -53,10 +60,12 @@ public class Experience
 	}
 
 	/**
-	 * Gets the total quantity of xp required to hit a skill level.
+	 * Gets the total experience required to obtain the passed skill
+	 * level.
 	 *
-	 * @param level Level between 1 and 126 (inclusive).
-	 * @return Positive quantity of xp.
+	 * @param level the skill level
+	 * @return the required experience for the level
+	 * @throws IllegalArgumentException if skill level is invalid
 	 */
 	public static int getXpForLevel(int level)
 	{
@@ -70,10 +79,10 @@ public class Experience
 	}
 
 	/**
-	 * Gets the skill level reached with a total quantity of xp.
+	 * Gets the skill level for the passed total experience.
 	 *
-	 * @param xp Positive quantity of xp.
-	 * @return Level between 1 and 126 (inclusive).
+	 * @param xp the passed experience (non-negative)
+	 * @return the skill level
 	 */
 	public static int getLevelForXp(int xp)
 	{
@@ -108,9 +117,19 @@ public class Experience
 	}
 
 	/**
-	 * Calculates a high-precision combat level without integer rounding.
+	 * Calculates a non-virtual high-precision combat level without integer
+	 * rounding.
+	 * <p>
+	 * Combat levels range between 1.15 and ~126.1.
 	 *
-	 * @return Combat level between 1.15 and ~126.1 (assuming non-virtual levels).
+	 * @param attackLevel the attack level
+	 * @param strengthLevel the strength level
+	 * @param defenceLevel the defence level
+	 * @param hitpointsLevel the hitpoints level
+	 * @param magicLevel the magic level
+	 * @param rangeLevel the range level
+	 * @param prayerLevel the prayer level
+	 * @return the non-virtual combat level
 	 */
 	public static double getCombatLevelPrecise(int attackLevel, int strengthLevel,
 		int defenceLevel, int hitpointsLevel, int magicLevel,
@@ -128,7 +147,14 @@ public class Experience
 	/**
 	 * Calculates a regular combat level.
 	 *
-	 * @return Combat level between 1 and 126 (assuming non-virtual levels).
+	 * @param attackLevel the attack level
+	 * @param strengthLevel the strength level
+	 * @param defenceLevel the defence level
+	 * @param hitpointsLevel the hitpoints level
+	 * @param magicLevel the magic level
+	 * @param rangeLevel the range level
+	 * @param prayerLevel the prayer level
+	 * @return the combat level, rounded down
 	 */
 	public static int getCombatLevel(int attackLevel, int strengthLevel,
 		int defenceLevel, int hitpointsLevel, int magicLevel,

--- a/runelite-api/src/main/java/net/runelite/api/Friend.java
+++ b/runelite-api/src/main/java/net/runelite/api/Friend.java
@@ -24,9 +24,22 @@
  */
 package net.runelite.api;
 
+/**
+ * Represents a player in the friends list.
+ */
 public interface Friend extends ChatPlayer
 {
+	/**
+	 * The name of the player.
+	 *
+	 * @return the name
+	 */
 	String getName();
 
+	/**
+	 * The previous name the player had.
+	 *
+	 * @return the previous name
+	 */
 	String getPrevName();
 }

--- a/runelite-api/src/main/java/net/runelite/api/FriendManager.java
+++ b/runelite-api/src/main/java/net/runelite/api/FriendManager.java
@@ -24,6 +24,9 @@
  */
 package net.runelite.api;
 
+/**
+ * Represents the friend and ignore list manager.
+ */
 public interface FriendManager
 {
 }

--- a/runelite-api/src/main/java/net/runelite/api/GameEngine.java
+++ b/runelite-api/src/main/java/net/runelite/api/GameEngine.java
@@ -26,11 +26,29 @@ package net.runelite.api;
 
 import java.awt.Canvas;
 
+/**
+ * Represents the client game engine.
+ */
 public interface GameEngine
 {
+	/**
+	 * Gets the canvas that contains everything.
+	 *
+	 * @return the game canvas
+	 */
 	Canvas getCanvas();
 
+	/**
+	 * Gets the client main thread.
+	 *
+	 * @return the main thread
+	 */
 	Thread getClientThread();
 
+	/**
+	 * Checks whether this code is executing on the client main thread.
+	 *
+	 * @return true if on the main thread, false otherwise
+	 */
 	boolean isClientThread();
 }

--- a/runelite-api/src/main/java/net/runelite/api/GameObject.java
+++ b/runelite-api/src/main/java/net/runelite/api/GameObject.java
@@ -28,27 +28,43 @@ import java.awt.Polygon;
 import net.runelite.api.coords.Angle;
 
 /**
- *
- * @author Adam
+ * Represents a game object.
+ * <p>
+ * Most object in the RuneScape world are considered as game objects. Things
+ * such as trees, anvils, boxes, etc are all game objects.
  */
 public interface GameObject extends TileObject
 {
+
 	/**
-	 * Returns the min x,y for this game object
+	 * Gets the minimum x and y region coordinate pair for this game object.
 	 *
-	 * @return
+	 * @return the minimum region coordinate
 	 */
 	Point getRegionMinLocation();
 
 	/**
-	 * Returns the max x,y for this game object. This is different from
-	 * {@link #getRegionMinLocation()} for objects larger than 1 tile.
+	 * Gets the maximum x and y region coordinate pair for this game object.
+	 * <p>
+	 * This value differs from {@link #getRegionMinLocation()} when the size
+	 * of the object is more than 1 tile.
 	 *
-	 * @return
+	 * @return the minimum region coordinate
 	 */
 	Point getRegionMaxLocation();
 
+	/**
+	 * Gets the convex hull of the actors model.
+	 *
+	 * @return the convex hull
+	 * @see net.runelite.api.model.Jarvis
+	 */
 	Polygon getConvexHull();
 
+	/**
+	 * Gets the orientation of the object.
+	 *
+	 * @return the orientation
+	 */
 	Angle getOrientation();
 }

--- a/runelite-api/src/main/java/net/runelite/api/GameState.java
+++ b/runelite-api/src/main/java/net/runelite/api/GameState.java
@@ -24,17 +24,47 @@
  */
 package net.runelite.api;
 
+/**
+ * An enumeration of game states the client is in.
+ */
 public enum GameState
 {
+	/**
+	 * Unknown game state.
+	 */
 	UNKNOWN(-1),
+	/**
+	 * The client is starting.
+	 */
 	STARTING(0),
+	/**
+	 * The client is at the login screen.
+	 */
 	LOGIN_SCREEN(10),
+	/**
+	 * There is a player logging in.
+	 */
 	LOGGING_IN(20),
+	/**
+	 * The game is being loaded.
+	 */
 	LOADING(25),
+	/**
+	 * The user has successfully logged in.
+	 */
 	LOGGED_IN(30),
+	/**
+	 * Connection to the server was lost.
+	 */
 	CONNECTION_LOST(40),
+	/**
+	 * A world hop is taking place.
+	 */
 	HOPPING(45);
 
+	/**
+	 * The raw state value.
+	 */
 	private final int state;
 
 	GameState(int state)
@@ -42,6 +72,13 @@ public enum GameState
 		this.state = state;
 	}
 
+	/**
+	 * Utility method that maps the rank value to its respective
+	 * {@link GameState} value.
+	 *
+	 * @param state the raw state value
+	 * @return the gamestate
+	 */
 	public static GameState of(int state)
 	{
 		for (GameState gs : GameState.values())

--- a/runelite-api/src/main/java/net/runelite/api/GrandExchangeOffer.java
+++ b/runelite-api/src/main/java/net/runelite/api/GrandExchangeOffer.java
@@ -24,17 +24,51 @@
  */
 package net.runelite.api;
 
+/**
+ * Represents an offer in a grand exchange slot.
+ */
 public interface GrandExchangeOffer
 {
+	/**
+	 * Gets the quantity of bought or sold items.
+	 *
+	 * @return the quantity bought or sold
+	 */
 	int getQuantitySold();
 
+	/**
+	 * Gets the ID of the item being bought or sold.
+	 *
+	 * @return item ID
+	 * @see ItemID
+	 */
 	int getItemId();
 
+	/**
+	 * Gets the total quantity being bought or sold.
+	 *
+	 * @return the total quantity
+	 */
 	int getTotalQuantity();
 
+	/**
+	 * Gets the offer or sell price per item.
+	 *
+	 * @return the offer price
+	 */
 	int getPrice();
 
+	/**
+	 * Gets the total amount of money spent so far.
+	 *
+	 * @return the amount spent
+	 */
 	int getSpent();
 
+	/**
+	 * Gets the current state of the offer.
+	 *
+	 * @return the offers state
+	 */
 	GrandExchangeOfferState getState();
 }

--- a/runelite-api/src/main/java/net/runelite/api/GrandExchangeOfferState.java
+++ b/runelite-api/src/main/java/net/runelite/api/GrandExchangeOfferState.java
@@ -26,7 +26,7 @@
 package net.runelite.api;
 
 /**
- * Describes the state of a Grand Exchange offer
+ * Describes the state of a Grand Exchange offer.
  */
 public enum GrandExchangeOfferState
 {
@@ -35,11 +35,11 @@ public enum GrandExchangeOfferState
 	 */
 	EMPTY,
 	/**
-	 * A cancelled buy offer
+	 * A cancelled buy offer.
 	 */
 	CANCELLED_BUY,
 	/**
-	 * A cancelled sell offer
+	 * A cancelled sell offer.
 	 */
 	CANCELLED_SELL,
 	/**

--- a/runelite-api/src/main/java/net/runelite/api/GraphicsObject.java
+++ b/runelite-api/src/main/java/net/runelite/api/GraphicsObject.java
@@ -26,15 +26,33 @@ package net.runelite.api;
 
 import net.runelite.api.coords.LocalPoint;
 
+/**
+ * Represents a graphics object.
+ */
 public interface GraphicsObject extends Renderable
 {
+	/**
+	 * The graphics object ID.
+	 *
+	 * @return the ID
+	 */
 	int getId();
 
+	/**
+	 * The location of the object.
+	 *
+	 * @return the location
+	 */
 	LocalPoint getLocation();
 
 	int getStartCycle();
 
 	int getLevel();
 
+	/**
+	 * Gets the height of the graphic.
+	 *
+	 * @return the height
+	 */
 	int getHeight();
 }

--- a/runelite-api/src/main/java/net/runelite/api/GroundObject.java
+++ b/runelite-api/src/main/java/net/runelite/api/GroundObject.java
@@ -24,6 +24,9 @@
  */
 package net.runelite.api;
 
+/**
+ * Represents an object on the ground of a tile.
+ */
 public interface GroundObject extends TileObject
 {
 }

--- a/runelite-api/src/main/java/net/runelite/api/HashTable.java
+++ b/runelite-api/src/main/java/net/runelite/api/HashTable.java
@@ -26,9 +26,24 @@ package net.runelite.api;
 
 import java.util.Collection;
 
+/**
+ * A data structure that uses a hash function to compute an index into an
+ * array of buckets from which node objects can be quickly obtained.
+ */
 public interface HashTable
 {
+	/**
+	 * Gets a node by its hash value.
+	 *
+	 * @param value the node value
+	 * @return the associated node
+	 */
 	Node get(long value);
 
+	/**
+	 * Gets a collection of all nodes stored in this table.
+	 *
+	 * @return the nodes stored
+	 */
 	Collection<Node> getNodes();
 }

--- a/runelite-api/src/main/java/net/runelite/api/HeadIcon.java
+++ b/runelite-api/src/main/java/net/runelite/api/HeadIcon.java
@@ -24,13 +24,37 @@
  */
 package net.runelite.api;
 
+/**
+ * An enumeration of prayer icons above the head.
+ */
 public enum HeadIcon
 {
+	/**
+	 * Protect from melee.
+	 */
 	MELEE,
+	/**
+	 * Protect from ranged.
+	 */
 	RANGED,
+	/**
+	 * Protect from magic.
+	 */
 	MAGIC,
+	/**
+	 * Retribution prayer.
+	 */
 	RETRIBUTION,
+	/**
+	 * Smite prayer.
+	 */
 	SMITE,
+	/**
+	 * Redemption prayer.
+	 */
 	REDEMPTION,
-	RANGE_MAGE; //used by Kalphite Queen
+	/**
+	 * Protect from range and mage (ie. used by Kalphite Queen).
+	 */
+	RANGE_MAGE
 }

--- a/runelite-api/src/main/java/net/runelite/api/HintArrowType.java
+++ b/runelite-api/src/main/java/net/runelite/api/HintArrowType.java
@@ -27,14 +27,32 @@ package net.runelite.api;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+/**
+ * An enumeration of hint arrow types.
+ */
 @AllArgsConstructor
 public enum HintArrowType
 {
+	/**
+	 * No hint arrow present.
+	 */
 	NONE(0),
+	/**
+	 * Hint arrow is pointing to a player.
+	 */
 	PLAYER(10),
+	/**
+	 * Hint arrow is pointing to an NPC.
+	 */
 	NPC(1),
+	/**
+	 * Hint arrow is pointing at a position in the world.
+	 */
 	WORLD_POSITION(2);
 
+	/**
+	 * The raw type value.
+	 */
 	@Getter
 	private final int value;
 }

--- a/runelite-api/src/main/java/net/runelite/api/Hitsplat.java
+++ b/runelite-api/src/main/java/net/runelite/api/Hitsplat.java
@@ -26,17 +26,48 @@ package net.runelite.api;
 
 import lombok.Getter;
 
+/**
+ * A hitsplat that has been applied to an {@link Actor}.
+ */
 public class Hitsplat
 {
+	/**
+	 * An enumeration of hitsplat types.
+	 */
 	public enum HitsplatType
 	{
-		BLOCK, // Blue
-		DAMAGE, // Red
-		POISON, // Green
-		VENOM, // Darkgreen
-		DISEASE, // Yellow
-		HEAL; // Purple
+		/**
+		 * Blocking damage (blue).
+		 */
+		BLOCK,
+		/**
+		 * Taking damage (red).
+		 */
+		DAMAGE,
+		/**
+		 * Damage from poison (green).
+		 */
+		POISON,
+		/**
+		 * Damage from venom (dark green).
+		 */
+		VENOM,
+		/**
+		 * Damage from disease (yellow).
+		 */
+		DISEASE,
+		/**
+		 * Healing (purple).
+		 */
+		HEAL;
 
+		/**
+		 * Utility method that maps the type value to its respective
+		 * {@link Hitsplat} value.
+		 *
+		 * @param type the type value
+		 * @return hitsplat type
+		 */
 		public static HitsplatType fromInteger(int type)
 		{
 			switch (type)
@@ -52,12 +83,21 @@ public class Hitsplat
 		}
 	}
 
+	/**
+	 * The type of hitsplat.
+	 */
 	@Getter
 	private HitsplatType hitsplatType;
 
+	/**
+	 * The value displayed by the hitsplat.
+	 */
 	@Getter
 	private int amount;
 
+	/**
+	 * When the hitsplat will disappear.
+	 */
 	@Getter
 	private int disappearsOnGameCycle;
 

--- a/runelite-api/src/main/java/net/runelite/api/IndexDataBase.java
+++ b/runelite-api/src/main/java/net/runelite/api/IndexDataBase.java
@@ -24,6 +24,9 @@
  */
 package net.runelite.api;
 
+/**
+ * Represents an indexed database, typically used for sprites.
+ */
 public interface IndexDataBase
 {
 }

--- a/runelite-api/src/main/java/net/runelite/api/IndexedSprite.java
+++ b/runelite-api/src/main/java/net/runelite/api/IndexedSprite.java
@@ -24,37 +24,120 @@
  */
 package net.runelite.api;
 
+/**
+ * Represents an indexed sprite.
+ */
 public interface IndexedSprite
 {
+	/**
+	 * Gets the pixels contained by the sprite.
+	 *
+	 * @return the sprite pixels
+	 */
 	byte[] getPixels();
 
+	/**
+	 * Sets the pixels contained by the sprite.
+	 *
+	 * @param pixels the new sprite pixels
+	 */
 	void setPixels(byte[] pixels);
 
+	/**
+	 * Gets the color palette for the sprites pixels.
+	 *
+	 * @return the color palette
+	 */
 	int[] getPalette();
 
+	/**
+	 * Sets the color palette for the sprites pixels.
+	 *
+	 * @param palette the new color palette
+	 */
 	void setPalette(int[] palette);
 
+	/**
+	 * Gets the offset of the sprite along the x-axis.
+	 *
+	 * @return the x-axis offset
+	 */
 	int getOffsetX();
 
+	/**
+	 * Sets the offset of the sprite along the x-axis.
+	 *
+	 * @param offsetX new x-axis offset
+	 */
 	void setOffsetX(int offsetX);
 
+	/**
+	 * Gets the offset of the sprite along the y-axis.
+	 *
+	 * @return the y-axis offset
+	 */
 	int getOffsetY();
 
+	/**
+	 * Sets the offset of the sprite along the y-axis.
+	 *
+	 * @param offsetY new y-axis offset
+	 */
 	void setOffsetY(int offsetY);
 
+	/**
+	 * Gets the width of the sprite.
+	 *
+	 * @return the width
+	 */
 	int getWidth();
 
+	/**
+	 * Sets the width of the sprite.
+	 *
+	 * @param width the new width
+	 */
 	void setWidth(int width);
 
+	/**
+	 * Gets the original width of the sprite.
+	 *
+	 * @return the width
+	 */
 	int getOriginalWidth();
 
+	/**
+	 * Sets the original width of the sprite.
+	 *
+	 * @param originalWidth the width
+	 */
 	void setOriginalWidth(int originalWidth);
 
+	/**
+	 * Gets the height of the sprite.
+	 *
+	 * @return the height
+	 */
 	int getHeight();
 
+	/**
+	 * Sets the height of the sprite.
+	 *
+	 * @param height the height
+	 */
 	void setHeight(int height);
 
+	/**
+	 * Gets the original height of the sprite.
+	 *
+	 * @return the height
+	 */
 	int getOriginalHeight();
 
+	/**
+	 * Sets the original height of the sprite.
+	 *
+	 * @param originalHeight the height
+	 */
 	void setOriginalHeight(int originalHeight);
 }

--- a/runelite-api/src/main/java/net/runelite/api/InstanceTemplates.java
+++ b/runelite-api/src/main/java/net/runelite/api/InstanceTemplates.java
@@ -27,6 +27,9 @@ package net.runelite.api;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+/**
+ * An enumeration of possible instance templates and the area they occupy.
+ */
 @AllArgsConstructor
 public enum InstanceTemplates
 {
@@ -50,21 +53,42 @@ public enum InstanceTemplates
 	RAIDS_VESPULA(3264, 5280, 2, 96, 32),
 	RAIDS_CRABS(3264, 5344, 2, 96, 32);
 
+	/**
+	 * The base x-axis coordinate of the instance area.
+	 */
 	@Getter
 	private final int baseX;
 
+	/**
+	 * The base y-axis coordinate of the instance area.
+	 */
 	@Getter
 	private final int baseY;
 
+	/**
+	 * The plane the instance is on.
+	 */
 	@Getter
 	private final int plane;
 
+	/**
+	 * The width of the instance area.
+	 */
 	@Getter
 	private final int width;
 
+	/**
+	 * The height of the instance area.
+	 */
 	@Getter
 	private final int height;
 
+	/**
+	 * Matches chunk data of an instance to the instance it belongs.
+	 *
+	 * @param chunkData the chunk data
+	 * @return the instance the chunk is in
+	 */
 	public static InstanceTemplates findMatch(int chunkData)
 	{
 		int rotation = chunkData >> 1 & 0x3; //unused, but shows us the rotation of the chunk

--- a/runelite-api/src/main/java/net/runelite/api/IntegerNode.java
+++ b/runelite-api/src/main/java/net/runelite/api/IntegerNode.java
@@ -24,9 +24,22 @@
  */
 package net.runelite.api;
 
+/**
+ * Represents an integer typically in a {@link HashTable}.
+ */
 public interface IntegerNode extends Node
 {
+	/**
+	 * Gets the value of the node.
+	 *
+	 * @return the int value
+	 */
 	int getValue();
 
+	/**
+	 * Sets the value of the node.
+	 *
+	 * @param value the new int value
+	 */
 	void setValue(int value);
 }

--- a/runelite-api/src/main/java/net/runelite/api/InventoryID.java
+++ b/runelite-api/src/main/java/net/runelite/api/InventoryID.java
@@ -24,12 +24,30 @@
  */
 package net.runelite.api;
 
+/**
+ * An enumeration of possible inventory types.
+ */
 public enum InventoryID
 {
+	/**
+	 * Standard player inventory.
+	 */
 	INVENTORY(93),
+	/**
+	 * Equipment inventory.
+	 */
 	EQUIPMENT(94),
+	/**
+	 * Bank inventory.
+	 */
 	BANK(95),
+	/**
+	 * A puzzle box inventory.
+	 */
 	PUZZLE_BOX(140),
+	/**
+	 * Barrows reward chest inventory.
+	 */
 	BARROWS_REWARD(141);
 
 	private final int id;
@@ -39,6 +57,11 @@ public enum InventoryID
 		this.id = id;
 	}
 
+	/**
+	 * Gets the raw inventory type ID.
+	 *
+	 * @return inventory type
+	 */
 	public int getId()
 	{
 		return id;

--- a/runelite-api/src/main/java/net/runelite/api/Item.java
+++ b/runelite-api/src/main/java/net/runelite/api/Item.java
@@ -24,9 +24,23 @@
  */
 package net.runelite.api;
 
+/**
+ * Represents an item inside an {@link ItemContainer}.
+ */
 public interface Item extends Renderable
 {
+	/**
+	 * Gets the items ID.
+	 *
+	 * @return the ID of the item
+	 * @see ItemID
+	 */
 	int getId();
 
+	/**
+	 * Gets the items quantity.
+	 *
+	 * @return the items quantity
+	 */
 	int getQuantity();
 }

--- a/runelite-api/src/main/java/net/runelite/api/ItemComposition.java
+++ b/runelite-api/src/main/java/net/runelite/api/ItemComposition.java
@@ -24,96 +24,111 @@
  */
 package net.runelite.api;
 
+/**
+ * Represents the template of a specific item type.
+ */
 public interface ItemComposition
 {
 	/**
-	 * Returns the item's name as a string.
+	 * Gets the items name.
 	 *
 	 * @return the name of the item
 	 */
 	String getName();
 
 	/**
-	 * Returns the item's ID. A list of item IDs can be found in
-	 * ItemID.
+	 * Gets the items ID.
 	 *
-	 * @return the item's ID as an integer
+	 * @return the items ID
+	 * @see ItemID
 	 */
 	int getId();
 
 	/**
-	 * Returns a result that depends on whether the item is in noted form or
-	 * not.
+	 * Gets a value specifying whether the item is noted.
 	 *
-	 * @return 799 if noted, -1 if unnoted
+	 * @return 799 if noted, -1 otherwise
 	 */
 	int getNote();
 
 	/**
-	 * Returns the item ID of the noted/unnoted counterpart. For example, if
-	 * you call this on an unnoted monkfish(ID 7946), this method will
-	 * return the ID of a noted monkfish(ID 7947), and vice versa.
+	 * Gets the item ID of the noted or unnoted variant of this item.
+	 * <p>
+	 * Calling this method on a noted item will result in the ID of itself
+	 * in unnoted form, and on an unnoted item its noted variant.
 	 *
-	 * @return the ID that is linked to this item in noted/unnoted form.
+	 * @return the noted or unnoted variant of this item
 	 */
 	int getLinkedNoteId();
 
 	/**
-	 * Returns the item ID of the normal/placeholder counterpart. For example, if
-	 * you call this on a monkfish(ID 7946), this method will
-	 * return the ID of a placeholder monkfish(ID 17065), and vice versa.
+	 * Gets the item ID of the normal or placeholder variant of this item.
+	 * <p>
+	 * Calling this method on a normal item will result in the ID of itself
+	 * in placeholder form, and on a placeholder item its normal variant.
 	 *
-	 * @return the ID that is linked to this item in normal/placeholder form.
+	 * @return the normal or placeholder variant of this item
 	 */
 	int getPlaceholderId();
 
 	/**
-	 * Returns a result that depends on whether the item is in placeholder form or
-	 * not.
+	 * Gets a value specifying whether the item is a placeholder.
 	 *
-	 * @return 14401 if placeholder, -1 if normal
+	 * @return 14401 if placeholder, -1 otherwise
 	 */
 	int getPlaceholderTemplateId();
 
 	/**
-	 * Returns the store price of the item. Even if the item cannot be found
-	 * in a store, all items have a store price from which the High and Low
-	 * Alchemy values are calculated. Multiply the price by 0.6 to get the
-	 * High Alchemy value, or 0.4 to get the Low Alchemy value.
+	 * Gets the store price of the item.
+	 * <p>
+	 * Although not all items can be found in a store, they have a store price
+	 * which can be used to calculate high and low alchemy values. Multiplying
+	 * the price by {@code 0.6} and {@code 0.4} gives these high and low
+	 * alchemy values, respectively.
 	 *
 	 * @return the general store value of the item
 	 */
 	int getPrice();
 
 	/**
-	 * Returns whether or not the item is members-only.
+	 * Checks whether the item is members only.
 	 *
-	 * @return true if members-only, false otherwise.
+	 * @return true if members only, false otherwise.
 	 */
 	boolean isMembers();
 
 	/**
-	 * Returns whether or not the item stacks in the players' inventories
+	 * Checks whether the item is able to stack in a players inventory.
 	 *
 	 * @return true if stackable, false otherwise
 	 */
 	boolean isStackable();
 
 	/**
-	 * Returns the menu actions the item has in a players' inventory
+	 * Gets an array of possible right-click menu actions the item
+	 * has in a player inventory.
 	 *
 	 * @return the inventory menu actions
 	 */
 	String[] getInventoryActions();
 
 	/**
-	 * Returns the menu action index of the shift-click action
+	 * Gets the menu action index of the shift-click action.
 	 *
-	 * @return menu index of the shift-click action
+	 * @return the index of the shift-click action
 	 */
 	int getShiftClickActionIndex();
 
+	/**
+	 * Sets the menu action index of the shift-click action.
+	 *
+	 * @param shiftclickActionIndex the new index of the shift-click action
+	 */
 	void setShiftClickActionIndex(int shiftclickActionIndex);
 
+	/**
+	 * Resets the menu action index of the shift-click action to its
+	 * default value.
+	 */
 	void resetShiftClickActionIndex();
 }

--- a/runelite-api/src/main/java/net/runelite/api/ItemContainer.java
+++ b/runelite-api/src/main/java/net/runelite/api/ItemContainer.java
@@ -24,11 +24,15 @@
  */
 package net.runelite.api;
 
+/**
+ * Represents an inventory that contains items.
+ */
 public interface ItemContainer extends Node
 {
 	/**
-	 * Get the items from the container
-	 * @return items
+	 * Gets an array of all items in the container.
+	 *
+	 * @return the items held
 	 */
 	Item[] getItems();
 }

--- a/runelite-api/src/main/java/net/runelite/api/ItemLayer.java
+++ b/runelite-api/src/main/java/net/runelite/api/ItemLayer.java
@@ -24,13 +24,36 @@
  */
 package net.runelite.api;
 
+/**
+ * Represents a pile of items held by a tile.
+ */
 public interface ItemLayer extends TileObject
 {
+	/**
+	 * Gets the height of the layer.
+	 *
+	 * @return the height
+	 */
 	int getHeight();
 
+	/**
+	 * Gets the item at the bottom of the pile.
+	 *
+	 * @return the bottom item
+	 */
 	Renderable getBottom();
 
+	/**
+	 * Gets the item at the middle of the pile.
+	 *
+	 * @return the middle item
+	 */
 	Renderable getMiddle();
 
+	/**
+	 * Gets the item at the top of the pile.
+	 *
+	 * @return the top item
+	 */
 	Renderable getTop();
 }

--- a/runelite-api/src/main/java/net/runelite/api/KeyFocusListener.java
+++ b/runelite-api/src/main/java/net/runelite/api/KeyFocusListener.java
@@ -24,6 +24,9 @@
  */
 package net.runelite.api;
 
+/**
+ * Detects when the window is focused or unfocused.
+ */
 public interface KeyFocusListener
 {
 }

--- a/runelite-api/src/main/java/net/runelite/api/MainBufferProvider.java
+++ b/runelite-api/src/main/java/net/runelite/api/MainBufferProvider.java
@@ -26,7 +26,15 @@ package net.runelite.api;
 
 import java.awt.Image;
 
+/**
+ * Represents the clients primary image buffer.
+ */
 public interface MainBufferProvider
 {
+	/**
+	 * Gets the image currently loaded in the buffer.
+	 *
+	 * @return the loaded image
+	 */
 	Image getImage();
 }

--- a/runelite-api/src/main/java/net/runelite/api/MenuAction.java
+++ b/runelite-api/src/main/java/net/runelite/api/MenuAction.java
@@ -27,6 +27,9 @@ package net.runelite.api;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * An enumeration of right-click menu actions.
+ */
 public enum MenuAction
 {
 	/**

--- a/runelite-api/src/main/java/net/runelite/api/MenuEntry.java
+++ b/runelite-api/src/main/java/net/runelite/api/MenuEntry.java
@@ -26,14 +26,38 @@ package net.runelite.api;
 
 import lombok.Data;
 
+/**
+ * A menu entry in a right-click menu.
+ */
 @Data
 public class MenuEntry
 {
+	/**
+	 * The option text added to the menu (ie. "Walk here", "Use").
+	 */
 	private String option;
+	/**
+	 * The target of the action (ie. Item or Actor name).
+	 * <p>
+	 * If the option does not apply to any target, this field
+	 * will be set to empty string.
+	 */
 	private String target;
+	/**
+	 * An identifier value for the target of the action.
+	 */
 	private int identifier;
+	/**
+	 * The action the entry will trigger.
+	 */
 	private int type;
+	/**
+	 * An additional parameter for the action.
+	 */
 	private int param0;
+	/**
+	 * A second additional parameter for the action.
+	 */
 	private int param1;
 
 	@Override

--- a/runelite-api/src/main/java/net/runelite/api/MessageNode.java
+++ b/runelite-api/src/main/java/net/runelite/api/MessageNode.java
@@ -24,23 +24,75 @@
  */
 package net.runelite.api;
 
+/**
+ * Represents a message in the chatbox.
+ */
 public interface MessageNode
 {
+	/**
+	 * Gets the type of message.
+	 *
+	 * @return the message type
+	 */
 	ChatMessageType getType();
 
+	/**
+	 * Gets the name of the player that sent the message.
+	 *
+	 * @return the player name
+	 */
 	String getName();
 
+	/**
+	 * Sets the name of the player that sent the message.
+	 *
+	 * @param name the new player name
+	 */
 	void setName(String name);
 
+	/**
+	 * Gets the sender of the message (ie. clan name).
+	 *
+	 * @return the message sender
+	 */
 	String getSender();
 
+	/**
+	 * Sets the sender of the message.
+	 *
+	 * @param sender the new message sender
+	 */
 	void setSender(String sender);
 
+	/**
+	 * Gets the message contents.
+	 *
+	 * @return the message contents
+	 */
 	String getValue();
 
+	/**
+	 * Sets the message contents.
+	 *
+	 * @param value the new message contents
+	 */
 	void setValue(String value);
 
+	/**
+	 * Gets the overriden message format.
+	 *
+	 * @return the message format
+	 */
 	String getRuneLiteFormatMessage();
 
+	/**
+	 * Sets the overriden message format.
+	 * <p>
+	 * If this value is not null, the message contents as returned by
+	 * {@link #getValue()} will be replaced with the format set here
+	 * when a message is processed.
+	 *
+	 * @param runeLiteFormatMessage the new message format
+	 */
 	void setRuneLiteFormatMessage(String runeLiteFormatMessage);
 }

--- a/runelite-api/src/main/java/net/runelite/api/Model.java
+++ b/runelite-api/src/main/java/net/runelite/api/Model.java
@@ -28,9 +28,22 @@ import java.util.List;
 import net.runelite.api.model.Triangle;
 import net.runelite.api.model.Vertex;
 
+/**
+ * Represents the model of an object.
+ */
 public interface Model extends Renderable
 {
+	/**
+	 * Gets a list of all vertices of the model.
+	 *
+	 * @return the vertices
+	 */
 	List<Vertex> getVertices();
 
+	/**
+	 * Gets a list of all triangles of the model.
+	 *
+	 * @return the triangle
+	 */
 	List<Triangle> getTriangles();
 }

--- a/runelite-api/src/main/java/net/runelite/api/NPC.java
+++ b/runelite-api/src/main/java/net/runelite/api/NPC.java
@@ -24,8 +24,17 @@
  */
 package net.runelite.api;
 
+/**
+ * Represents a non-player character in the game.
+ */
 public interface NPC extends Actor
 {
+	/**
+	 * Gets the ID of the NPC.
+	 *
+	 * @return the ID of the NPC
+	 * @see NpcID
+	 */
 	int getId();
 
 	@Override
@@ -34,14 +43,26 @@ public interface NPC extends Actor
 	@Override
 	int getCombatLevel();
 
+	/**
+	 * Gets the index position of this NPC in the clients cached
+	 * NPC array.
+	 *
+	 * @return the NPC index
+	 * @see Client#getCachedNPCs()
+	 */
 	int getIndex();
 
+	/**
+	 * Gets the composition of this NPC.
+	 *
+	 * @return the composition
+	 */
 	NPCComposition getComposition();
 
 	/**
 	 * Get the composition for this NPC and transform it if required
 	 *
-	 * @return
+	 * @return the transformed NPC
 	 */
 	NPCComposition getTransformedComposition();
 }

--- a/runelite-api/src/main/java/net/runelite/api/NPCComposition.java
+++ b/runelite-api/src/main/java/net/runelite/api/NPCComposition.java
@@ -24,29 +24,94 @@
  */
 package net.runelite.api;
 
+/**
+ * Represents the template of a specific NPC type.
+ */
 public interface NPCComposition
 {
+	/**
+	 * Gets the name of the NPC.
+	 *
+	 * @return the name
+	 */
 	String getName();
 
+	/**
+	 * Gets the model IDs that compose this NPC.
+	 *
+	 * @return the NPCs model IDs
+	 */
 	int[] getModels();
 
+	/**
+	 * Gets an array of possible right-click menu actions that can be
+	 * performed on the NPC.
+	 *
+	 * @return the menu actions
+	 */
 	String[] getActions();
 
+	/**
+	 * Gets whether the NPC can be clicked.
+	 *
+	 * @return true if the NPC can be clicked, false otherwise
+	 */
 	boolean isClickable();
 
+	/**
+	 * Gets whether the NPC is visible on the mini-map.
+	 *
+	 * @return the mini-map visible state
+	 */
 	boolean isMinimapVisable();
 
+	/**
+	 * Gets whether the NPC is visible.
+	 *
+	 * @return the visible state
+	 */
 	boolean isVisable();
 
+	/**
+	 * Gets the ID of the NPC.
+	 *
+	 * @return the ID of the NPC
+	 * @see NpcID
+	 */
 	int getId();
 
+	/**
+	 * Gets the combat level of the NPC.
+	 *
+	 * @return the combat level, -1 if none
+	 */
 	int getCombatLevel();
 
+	/**
+	 * Gets the configuration data for the NPC.
+	 *
+	 * @return the configuration data
+	 */
 	int[] getConfigs();
-	
+
+	/**
+	 * Transforms this NPC into a new state, which may have a different ID.
+	 *
+	 * @return the transformed composition
+	 */
 	NPCComposition transform();
 
+	/**
+	 * Gets the size of the NPC.
+	 *
+	 * @return the NPCs size
+	 */
 	int getSize();
 
+	/**
+	 * Gets the displayed overhead icon of the NPC.
+	 *
+	 * @return the overhead icon
+	 */
 	HeadIcon getOverheadIcon();
 }

--- a/runelite-api/src/main/java/net/runelite/api/Nameable.java
+++ b/runelite-api/src/main/java/net/runelite/api/Nameable.java
@@ -24,6 +24,9 @@
  */
 package net.runelite.api;
 
+/**
+ * Represents a chat entity that has a name.
+ */
 public interface Nameable extends Comparable
 {
 }

--- a/runelite-api/src/main/java/net/runelite/api/Node.java
+++ b/runelite-api/src/main/java/net/runelite/api/Node.java
@@ -24,11 +24,29 @@
  */
 package net.runelite.api;
 
+/**
+ * Represents a doubly linked node.
+ */
 public interface Node
 {
+	/**
+	 * Gets the next node.
+	 *
+	 * @return the next node
+	 */
 	Node getNext();
 
+	/**
+	 * Gets the previous node.
+	 *
+	 * @return the previous node
+	 */
 	Node getPrevious();
 
+	/**
+	 * Gets the hash value of the node.
+	 *
+	 * @return the hash value
+	 */
 	long getHash();
 }

--- a/runelite-api/src/main/java/net/runelite/api/ObjectComposition.java
+++ b/runelite-api/src/main/java/net/runelite/api/ObjectComposition.java
@@ -24,17 +24,52 @@
  */
 package net.runelite.api;
 
+/**
+ * Represents the template of a specific object.
+ */
 public interface ObjectComposition
 {
+	/**
+	 * Gets the name of the object.
+	 *
+	 * @return the object name
+	 */
 	String getName();
 
+	/**
+	 * Gets an array of possible right-click menu actions that can be
+	 * performed on the object.
+	 *
+	 * @return the menu actions
+	 */
 	String[] getActions();
 
+	/**
+	 * Gets the map scene ID for the object.
+	 *
+	 * @return the scene ID
+	 */
 	int getMapSceneId();
 
+	/**
+	 * Gets the map icon ID for the object.
+	 *
+	 * @return the map icon ID
+	 */
 	int getMapIconId();
 
+	/**
+	 * Gets IDs for objects that are considered fakes of this object,
+	 * such as barrows walls.
+	 *
+	 * @return the impostor IDs
+	 */
 	int[] getImpostorIds();
 
+	/**
+	 * Gets the impostor composition for this object.
+	 *
+	 * @return the impostor
+	 */
 	ObjectComposition getImpostor();
 }

--- a/runelite-api/src/main/java/net/runelite/api/Opcodes.java
+++ b/runelite-api/src/main/java/net/runelite/api/Opcodes.java
@@ -24,7 +24,13 @@
  */
 package net.runelite.api;
 
+/**
+ * Utility class containing ASM opcodes used by the RuneLite client.
+ */
 public class Opcodes
 {
+	/**
+	 * RuneLite execution opcode used to inject scripts.
+	 */
 	public static final int RUNELITE_EXECUTE = 6599;
 }

--- a/runelite-api/src/main/java/net/runelite/api/Perspective.java
+++ b/runelite-api/src/main/java/net/runelite/api/Perspective.java
@@ -40,6 +40,10 @@ import net.runelite.api.model.Jarvis;
 import net.runelite.api.model.Triangle;
 import net.runelite.api.model.Vertex;
 
+/**
+ * A utility class containing methods to help with conversion between
+ * in-game features to canvas areas.
+ */
 public class Perspective
 {
 	private static final double UNIT = Math.PI / 1024d; // How much of the circle each unit of SINE/COSINE is
@@ -65,7 +69,7 @@ public class Perspective
 	 * Translates two-dimensional ground coordinates within the 3D world to
 	 * their corresponding coordinates on the game screen.
 	 *
-	 * @param client
+	 * @param client the game client
 	 * @param x ground coordinate on the x axis
 	 * @param y ground coordinate on the y axis
 	 * @param plane ground plane on the z axis
@@ -81,7 +85,7 @@ public class Perspective
 	 * Translates two-dimensional ground coordinates within the 3D world to
 	 * their corresponding coordinates on the game screen.
 	 *
-	 * @param client
+	 * @param client the game client
 	 * @param x ground coordinate on the x axis
 	 * @param y ground coordinate on the y axis
 	 * @param plane ground plane on the z axis
@@ -97,12 +101,14 @@ public class Perspective
 	/**
 	 * Translates two-dimensional ground coordinates within the 3D world to
 	 * their corresponding coordinates on the game screen. Calculating heights
-	 * based on the coordinates of the tile provided, rather than the world coordinates
+	 * based on the coordinates of the tile provided, rather than the world
+	 * coordinates.
+	 * <p>
+	 * Using the position of each vertex, rather than the location of the
+	 * object, to determine the height of each vertex causes the mesh to be
+	 * vertically warped, based on the terrain below.
 	 *
-	 * Using the position of each vertex, rather than the location of the object, to determine the
-	 * height of each vertex causes the mesh to be vertically warped, based on the terrain below
-	 *
-	 * @param client
+	 * @param client the game client
 	 * @param x ground coordinate on the x axis
 	 * @param y ground coordinate on the y axis
 	 * @param plane ground plane on the z axis
@@ -119,12 +125,14 @@ public class Perspective
 	/**
 	 * Translates two-dimensional ground coordinates within the 3D world to
 	 * their corresponding coordinates on the game screen. Calculating heights
-	 * based on the coordinates of the tile provided, rather than the world coordinates
+	 * based on the coordinates of the tile provided, rather than the world
+	 * coordinates.
+	 * <p>
+	 * Using the position of each vertex, rather than the location of the
+	 * object, to determine the height of each vertex causes the mesh to be
+	 * vertically warped, based on the terrain below.
 	 *
-	 * Using the position of each vertex, rather than the location of the object, to determine the
-	 * height of each vertex causes the mesh to be vertically warped, based on the terrain below
-	 *
-	 * @param client
+	 * @param client the game client
 	 * @param x ground coordinate on the x axis
 	 * @param y ground coordinate on the y axis
 	 * @param plane ground plane on the z axis
@@ -174,7 +182,7 @@ public class Perspective
 	 * Translates two-dimensional ground coordinates within the 3D world to
 	 * their corresponding coordinates on the Minimap.
 	 *
-	 * @param client
+	 * @param client the game client
 	 * @param x ground coordinate on the x axis
 	 * @param y ground coordinate on the y axis
 	 * @return a {@link Point} on screen corresponding to the position in
@@ -189,7 +197,7 @@ public class Perspective
 	 * Translates two-dimensional ground coordinates within the 3D world to
 	 * their corresponding coordinates on the Minimap.
 	 *
-	 * @param client
+	 * @param client the game client
 	 * @param x ground coordinate on the x axis
 	 * @param y ground coordinate on the y axis
 	 * @param distance max distance from local player to minimap point
@@ -228,7 +236,7 @@ public class Perspective
 	/**
 	 * Calculates the above ground height of a tile point.
 	 *
-	 * @param client
+	 * @param client the game client
 	 * @param localX the ground coordinate on the x axis
 	 * @param localY the ground coordinate on the y axis
 	 * @param plane the client plane/ground level
@@ -262,7 +270,7 @@ public class Perspective
 	/**
 	 * Calculates a tile polygon from offset worldToScreen() points.
 	 *
-	 * @param client
+	 * @param client the game client
 	 * @param localLocation local location of the tile
 	 * @return a {@link Polygon} on screen corresponding to the given
 	 * localLocation.
@@ -275,10 +283,9 @@ public class Perspective
 	/**
 	 * Returns a polygon representing an area.
 	 *
-	 * @param client
-	 * @param localLocation Center location of the AoE
-	 * @param size size of the area. Ex. Lizardman Shaman AoE is a 3x3, so
-	 * size = 3
+	 * @param client the game client
+	 * @param localLocation the center location of the AoE
+	 * @param size the size of the area (ie. 3x3 AoE evaluates to size 3)
 	 * @return a polygon representing the tiles in the area
 	 */
 	public static Polygon getCanvasTileAreaPoly(@Nonnull Client client, @Nonnull LocalPoint localLocation, int size)
@@ -322,8 +329,8 @@ public class Perspective
 	/**
 	 * Calculates text position and centers depending on string length.
 	 *
-	 * @param client
-	 * @param graphics
+	 * @param client the game client
+	 * @param graphics the game graphics
 	 * @param localLocation local location of the tile
 	 * @param text string for width measurement
 	 * @param zOffset offset from ground plane
@@ -357,8 +364,8 @@ public class Perspective
 	/**
 	 * Calculates image position and centers depending on image size.
 	 *
-	 * @param client
-	 * @param graphics
+	 * @param client the game client
+	 * @param graphics the game graphics
 	 * @param localLocation local location of the tile
 	 * @param image image for size measurement
 	 * @param zOffset offset from ground plane
@@ -390,7 +397,7 @@ public class Perspective
 	/**
 	 * Calculates image position and centers depending on image size.
 	 *
-	 * @param client
+	 * @param client the game client
 	 * @param localLocation local location of the tile
 	 * @param image image for size measurement
 	 * @return a {@link Point} on screen corresponding to the given
@@ -399,8 +406,7 @@ public class Perspective
 	public static Point getMiniMapImageLocation(
 		@Nonnull Client client,
 		@Nonnull LocalPoint localLocation,
-		@Nonnull BufferedImage image
-	)
+		@Nonnull BufferedImage image)
 	{
 		Point p = Perspective.worldToMiniMap(client, localLocation.getX(), localLocation.getY());
 
@@ -418,21 +424,19 @@ public class Perspective
 	/**
 	 * Calculates sprite position and centers depending on sprite size.
 	 *
-	 * @param client
-	 * @param graphics
+	 * @param client the game client
+	 * @param graphics the game graphics
 	 * @param localLocation local location of the tile
 	 * @param sprite SpritePixel for size measurement
 	 * @param zOffset offset from ground plane
-	 * @return a {@link Point} on screen corresponding to the given
-	 * localLocation.
+	 * @return a {@link Point} on screen corresponding to the given localLocation.
 	 */
 	public static Point getCanvasSpriteLocation(
 		@Nonnull Client client,
 		@Nonnull Graphics2D graphics,
 		@Nonnull LocalPoint localLocation,
 		@Nonnull SpritePixels sprite,
-		int zOffset
-	)
+		int zOffset)
 	{
 		int plane = client.getPlane();
 
@@ -450,17 +454,18 @@ public class Perspective
 	}
 
 	/**
-	 * You don't want this. Use {@link TileObject#getClickbox()} instead
+	 * You don't want this. Use {@link TileObject#getClickbox()} instead.
+	 * <p>
+	 * Get the on-screen clickable area of {@code model} as though it's for the
+	 * object on the tile at ({@code tileX}, {@code tileY}) and rotated to
+	 * angle {@code orientation}.
 	 *
-	 * Get the on-screen clickable area of {@code model} as though it's for the object on the tile at
-	 * 	({@code tileX}, {@code tileY}) and rotated to angle {@code orientation}
-	 *
-	 * @param client
+	 * @param client the game client
 	 * @param model the model to calculate a clickbox for
 	 * @param orientation the orientation of the model (0-2048, where 0 is north)
-	 * @param tileX the X coordinate of the tile that the object using the model is on
-	 * @param tileY the Y coordinate of the tile that the object using the model is on
-	 * @return the clickable area of {@code model}, rotated to angle {@code orientation}, at the height of tile ({@code tileX}, {@code tileY})
+	 * @param tileX the x-axis coordinate of the tile
+	 * @param tileY the y-axis coordinate of the tile
+	 * @return the clickable area of the model
 	 */
 	public static Area getClickbox(@Nonnull Client client, Model model, int orientation, int tileX, int tileY)
 	{
@@ -683,8 +688,8 @@ public class Perspective
 	/**
 	 * Calculates text position and centers on minimap depending on string length.
 	 *
-	 * @param client
-	 * @param graphics
+	 * @param client the game client
+	 * @param graphics the game graphics
 	 * @param localLocation local location of the tile
 	 * @param text string for width measurement
 	 * @return a {@link Point} on screen corresponding to the given
@@ -694,8 +699,7 @@ public class Perspective
 		@Nonnull Client client,
 		@Nonnull Graphics2D graphics,
 		@Nonnull LocalPoint localLocation,
-		@Nonnull String text
-	)
+		@Nonnull String text)
 	{
 		Point p = Perspective.worldToMiniMap(client, localLocation.getX(), localLocation.getY());
 

--- a/runelite-api/src/main/java/net/runelite/api/Player.java
+++ b/runelite-api/src/main/java/net/runelite/api/Player.java
@@ -26,20 +26,54 @@ package net.runelite.api;
 
 import java.awt.Polygon;
 
+/**
+ * Represents a player entity in the game.
+ */
 public interface Player extends Actor
 {
 	@Override
 	int getCombatLevel();
 
+	/**
+	 * Gets the composition of this player.
+	 *
+	 * @return the composition
+	 */
 	PlayerComposition getPlayerComposition();
 
+	/**
+	 * Gets the polygons that make up the players model.
+	 *
+	 * @return the model polygons
+	 */
 	Polygon[] getPolygons();
 
+	/**
+	 * Gets the current team cape team number the player is on.
+	 *
+	 * @return team number, or 0 if not on any team
+	 */
 	int getTeam();
 
+	/**
+	 * Checks whether this player is a member of the same clan as
+	 * the local player.
+	 *
+	 * @return true if the player is a clan member, false otherwise
+	 */
 	boolean isClanMember();
 
+	/**
+	 * Checks whether this player is a friend of the local player.
+	 *
+	 * @return true if the player is a friend, false otherwise
+	 */
 	boolean isFriend();
 
+	/**
+	 * Gets the displayed overhead icon of the player.
+	 *
+	 * @return the overhead icon
+	 */
 	HeadIcon getOverheadIcon();
 }

--- a/runelite-api/src/main/java/net/runelite/api/PlayerComposition.java
+++ b/runelite-api/src/main/java/net/runelite/api/PlayerComposition.java
@@ -26,18 +26,35 @@ package net.runelite.api;
 
 import net.runelite.api.kit.KitType;
 
+/**
+ * Represents the template of a player.
+ */
 public interface PlayerComposition
 {
 	/**
-	 * Get equipment ids. If id is &ge; 256 &amp;&amp; &lt; 512 then
-	 * subtract 256 and the id is a kit definition. If the id is &ge; 512
-	 * then subtract 512 and the id is an item id.
+	 * Gets an array of IDs related to equipment slots.
+	 * <p>
+	 * If the ID for a specific slot is between 256 and 512, subtracting
+	 * 256 will result in the kit ID. Values above 512 indicate an item
+	 * and can be converted to the item ID by subtracting 512.
 	 *
-	 * @return
+	 * @return the equipment IDs
 	 */
 	int[] getEquipmentIds();
 
+	/**
+	 * Gets the equipment ID of a particular slot.
+	 *
+	 * @param type equipment slot
+	 * @return the equipment ID
+	 */
 	int getEquipmentId(KitType type);
 
+	/**
+	 * Gets the kit ID of a particular slot.
+	 *
+	 * @param type equipment slot
+	 * @return the kit ID
+	 */
 	int getKitId(KitType type);
 }

--- a/runelite-api/src/main/java/net/runelite/api/Point.java
+++ b/runelite-api/src/main/java/net/runelite/api/Point.java
@@ -24,6 +24,9 @@
  */
 package net.runelite.api;
 
+/**
+ * A two-dimensional coordinate on the canvas.
+ */
 public class Point
 {
 	private final int x;
@@ -41,21 +44,31 @@ public class Point
 		return "Point{" + "x=" + x + ", y=" + y + '}';
 	}
 
+	/**
+	 * Gets the x-axis coordinate of the point.
+	 *
+	 * @return the x-axis coordinate
+	 */
 	public int getX()
 	{
 		return x;
 	}
 
+	/**
+	 * Gets the y-axis coordinate of the point.
+	 *
+	 * @return the y-axis coordinate
+	 */
 	public int getY()
 	{
 		return y;
 	}
 
 	/**
-	 * Find the distance from this point to another point
+	 * Gets the distance between this point and another.
 	 *
-	 * @param other
-	 * @return
+	 * @param other other point
+	 * @return the distance
 	 */
 	public int distanceTo(Point other)
 	{

--- a/runelite-api/src/main/java/net/runelite/api/Prayer.java
+++ b/runelite-api/src/main/java/net/runelite/api/Prayer.java
@@ -24,45 +24,140 @@
  */
 package net.runelite.api;
 
+/**
+ * An enumeration of different prayer spells.
+ */
 public enum Prayer
 {
+	/**
+	 * Thick Skin (Level 1, Defence).
+	 */
 	THICK_SKIN(Varbits.PRAYER_THICK_SKIN),
+	/**
+	 * Burst of Strength (Level 4, Strength).
+	 */
 	BURST_OF_STRENGTH(Varbits.PRAYER_BURST_OF_STRENGTH),
+	/**
+	 * Clarity of Thought (Level 7, Attack).
+	 */
 	CLARITY_OF_THOUGHT(Varbits.PRAYER_CLARITY_OF_THOUGHT),
+	/**
+	 * Sharp Eye (Level 8, Ranging).
+	 */
 	SHARP_EYE(Varbits.PRAYER_SHARP_EYE),
+	/**
+	 * Mystic Will (Level 9, Magic).
+	 */
 	MYSTIC_WILL(Varbits.PRAYER_MYSTIC_WILL),
+	/**
+	 * Rock Skin (Level 10, Defence).
+	 */
 	ROCK_SKIN(Varbits.PRAYER_ROCK_SKIN),
+	/**
+	 * Superhuman Strength (Level 13, Strength).
+	 */
 	SUPERHUMAN_STRENGTH(Varbits.PRAYER_SUPERHUMAN_STRENGTH),
+	/**
+	 * Improved Reflexes (Level 16, Attack).
+	 */
 	IMPROVED_REFLEXES(Varbits.PRAYER_IMPROVED_REFLEXES),
+	/**
+	 * Rapid Restore (Level 19, Stats).
+	 */
 	RAPID_RESTORE(Varbits.PRAYER_RAPID_RESTORE),
+	/**
+	 * Rapid Heal (Level 22, Hitpoints).
+	 */
 	RAPID_HEAL(Varbits.PRAYER_RAPID_HEAL),
+	/**
+	 * Protect Item (Level 25).
+	 */
 	PROTECT_ITEM(Varbits.PRAYER_PROTECT_ITEM),
+	/**
+	 * Hawk Eye (Level 26, Ranging).
+	 */
 	HAWK_EYE(Varbits.PRAYER_HAWK_EYE),
+	/**
+	 * Mystic Lore (Level 27, Magic).
+	 */
 	MYSTIC_LORE(Varbits.PRAYER_MYSTIC_LORE),
+	/**
+	 * Steel Skin (Level 28, Defence).
+	 */
 	STEEL_SKIN(Varbits.PRAYER_STEEL_SKIN),
+	/**
+	 * Ultimate Strength (Level 31, Strength).
+	 */
 	ULTIMATE_STRENGTH(Varbits.PRAYER_ULTIMATE_STRENGTH),
+	/**
+	 * Incredible Reflexes (Level 34, Attack).
+	 */
 	INCREDIBLE_REFLEXES(Varbits.PRAYER_INCREDIBLE_REFLEXES),
+	/**
+	 * Protect from Magic (Level 37).
+	 */
 	PROTECT_FROM_MAGIC(Varbits.PRAYER_PROTECT_FROM_MAGIC),
+	/**
+	 * Protect from Missiles (Level 40).
+	 */
 	PROTECT_FROM_MISSILES(Varbits.PRAYER_PROTECT_FROM_MISSILES),
+	/**
+	 * Protect from Melee (Level 43).
+	 */
 	PROTECT_FROM_MELEE(Varbits.PRAYER_PROTECT_FROM_MELEE),
+	/**
+	 * Eagle Eye (Level 44, Ranging).
+	 */
 	EAGLE_EYE(Varbits.PRAYER_EAGLE_EYE),
+	/**
+	 * Mystic Might (Level 45, Magic).
+	 */
 	MYSTIC_MIGHT(Varbits.PRAYER_MYSTIC_MIGHT),
+	/**
+	 * Retribution (Level 46).
+	 */
 	RETRIBUTION(Varbits.PRAYER_RETRIBUTION),
+	/**
+	 * Redemption (Level 49).
+	 */
 	REDEMPTION(Varbits.PRAYER_REDEMPTION),
+	/**
+	 * Smite (Level 52).
+	 */
 	SMITE(Varbits.PRAYER_SMITE),
-	CHIVALRY(Varbits.PRAYER_CHIVALRY),
-	PIETY(Varbits.PRAYER_PIETY),
+	/**
+	 * Preserve (Level 55).
+	 */
 	PRESERVE(Varbits.PRAYER_PRESERVE),
+	/**
+	 * Chivalry (Level 60, Defence/Strength/Attack).
+	 */
+	CHIVALRY(Varbits.PRAYER_CHIVALRY),
+	/**
+	 * Piety (Level 70, Defence/Strength/Attack).
+	 */
+	PIETY(Varbits.PRAYER_PIETY),
+	/**
+	 * Rigour (Level 74, Ranging/Damage/Defence).
+	 */
 	RIGOUR(Varbits.PRAYER_RIGOUR),
+	/**
+	 * Augury (Level 77, Magic/Magic Def./Defence).
+	 */
 	AUGURY(Varbits.PRAYER_AUGURY);
-	
+
 	private final Varbits varbit;
 
-	private Prayer(Varbits varbit)
+	Prayer(Varbits varbit)
 	{
 		this.varbit = varbit;
 	}
 
+	/**
+	 * Gets the varbit that stores whether the prayer is active or not.
+	 *
+	 * @return the prayer active varbit
+	 */
 	public Varbits getVarbit()
 	{
 		return varbit;

--- a/runelite-api/src/main/java/net/runelite/api/Preferences.java
+++ b/runelite-api/src/main/java/net/runelite/api/Preferences.java
@@ -24,9 +24,22 @@
  */
 package net.runelite.api;
 
+/**
+ * Stores the clients persisting preferences.
+ */
 public interface Preferences
 {
+	/**
+	 * Gets the remembered login username.
+	 *
+	 * @return the remembered username
+	 */
 	String getRememberedUsername();
 
+	/**
+	 * Sets the remembered login username.
+	 *
+	 * @param username the new remembered username
+	 */
 	void setRememberedUsername(String username);
 }

--- a/runelite-api/src/main/java/net/runelite/api/Projectile.java
+++ b/runelite-api/src/main/java/net/runelite/api/Projectile.java
@@ -24,43 +24,146 @@
  */
 package net.runelite.api;
 
+/**
+ * Represents a projectile entity (ie. cannonball, arrow).
+ */
 public interface Projectile extends Renderable
 {
+	/**
+	 * Gets the ID of the projectile.
+	 *
+	 * @return the projectile ID
+	 * @see ProjectileID
+	 */
 	int getId();
 
+	/**
+	 * Gets the actor that is targeted by this projectile.
+	 *
+	 * @return the target actor, or null if this projectile is an AoE attack
+	 */
 	Actor getInteracting();
 
+	/**
+	 * Gets the original x-axis coordinate that this projectile started from.
+	 *
+	 * @return the original coordinate
+	 */
 	int getX1();
 
+	/**
+	 * Gets the original y-axis coordinate that this projectile started from.
+	 *
+	 * @return the original coordinate
+	 */
 	int getY1();
 
+	/**
+	 * Gets the plane that the projectile is on.
+	 *
+	 * @return the plane
+	 */
 	int getFloor();
 
+	/**
+	 * Gets the height of the projectile.
+	 *
+	 * @return the height
+	 */
 	int getHeight();
 
+	/**
+	 * Gets the ending height of the projectile.
+	 *
+	 * @return the ending height
+	 */
 	int getEndHeight();
 
+	/**
+	 * Gets the game cycle that the projectile begun movement at.
+	 *
+	 * @return the start game cycle
+	 */
 	int getStartMovementCycle();
 
+	/**
+	 * Gets the game cycle that the projectile will reach its target at.
+	 *
+	 * @return the end game cycle
+	 */
 	int getEndCycle();
 
+	/**
+	 * Gets the remaining game cycles until the projectile reaches its
+	 * target and despawns.
+	 *
+	 * @return the remaining game cycles
+	 */
 	int getRemainingCycles();
 
+	/**
+	 * Gets the slope of the projectile.
+	 * <p>
+	 * This value indicates how much arc the projectile can have. Projectiles
+	 * with larger slopes have a more noticeable arc when thrown.
+	 *
+	 * @return the slope of the projectile
+	 */
 	int getSlope();
 
+	/**
+	 * Gets the starting height of the projectile.
+	 *
+	 * @return the starting height
+	 */
 	int getStartHeight();
 
+	/**
+	 * Gets the current x-axis coordinate of the projectile.
+	 *
+	 * @return the x-axis coordinate
+	 */
 	double getX();
 
+	/**
+	 * Gets the current y-axis coordinate of the projectile.
+	 *
+	 * @return the y-axis coordinate
+	 */
 	double getY();
 
+	/**
+	 * Gets the current z-axis coordinate of the projectile.
+	 *
+	 * @return the z-axis coordinate
+	 */
 	double getZ();
 
+	/**
+	 * Gets the scalar quantity (speed) at which the projectile is travelling.
+	 *
+	 * @return the scalar quantity
+	 */
 	double getScalar();
 
+	/**
+	 * Gets the x-axis velocity of the projectile.
+	 *
+	 * @return the x-axis velocity
+	 */
 	double getVelocityX();
 
+	/**
+	 * Gets the y-axis velocity of the projectile.
+	 *
+	 * @return the y-axis velocity
+	 */
 	double getVelocityY();
 
+	/**
+	 * Gets the z-axis velocity of the projectile.
+	 *
+	 * @return the z-axis velocity
+	 */
 	double getVelocityZ();
 }

--- a/runelite-api/src/main/java/net/runelite/api/ProjectileID.java
+++ b/runelite-api/src/main/java/net/runelite/api/ProjectileID.java
@@ -24,6 +24,11 @@
  */
 package net.runelite.api;
 
+/**
+ * Utility class used for mapping projectile IDs.
+ * <p>
+ * Note: This class is not complete and may be missing mapped IDs.
+ */
 public class ProjectileID
 {
 	public static final int CANNONBALL = 53;

--- a/runelite-api/src/main/java/net/runelite/api/Query.java
+++ b/runelite-api/src/main/java/net/runelite/api/Query.java
@@ -26,6 +26,12 @@ package net.runelite.api;
 
 import java.util.function.Predicate;
 
+/**
+ * A query to search the game for objects that match.
+ *
+ * @param <EntityType> the returned object type
+ * @param <QueryType> the query type
+ */
 public abstract class Query<EntityType, QueryType>
 {
 	protected Predicate<EntityType> predicate = x -> true;
@@ -34,8 +40,22 @@ public abstract class Query<EntityType, QueryType>
 	{
 	}
 
+	/**
+	 * Executes the query and filters through possible objects, returning only
+	 * those who evaluate true using {@link #predicate}.
+	 *
+	 * @param client the game client
+	 * @return the matching objects
+	 */
 	public abstract EntityType[] result(Client client);
 
+	/**
+	 * Constructs and returns a predicate that will evaluate {@link #predicate}
+	 * and the passed value.
+	 *
+	 * @param other the passed predicate
+	 * @return the combined predicate
+	 */
 	protected Predicate<EntityType> and(Predicate<EntityType> other)
 	{
 		if (predicate == null)

--- a/runelite-api/src/main/java/net/runelite/api/Region.java
+++ b/runelite-api/src/main/java/net/runelite/api/Region.java
@@ -24,7 +24,17 @@
  */
 package net.runelite.api;
 
+/**
+ * Represents a region of chunks.
+ * <p>
+ * A region is an area that contains 8x8 chunks on the map.
+ */
 public interface Region
 {
+	/**
+	 * Gets the tiles in this region.
+	 *
+	 * @return the regions tile
+	 */
 	Tile[][][] getTiles();
 }

--- a/runelite-api/src/main/java/net/runelite/api/RenderOverview.java
+++ b/runelite-api/src/main/java/net/runelite/api/RenderOverview.java
@@ -26,17 +26,50 @@ package net.runelite.api;
 
 import net.runelite.api.coords.WorldPoint;
 
+/**
+ * Represents an overview of the currently rendered world map.
+ */
 public interface RenderOverview
 {
+	/**
+	 * Gets the current position of the local player on the world map.
+	 *
+	 * @return the world map position
+	 */
 	Point getWorldMapPosition();
 
+	/**
+	 * Gets the current zoom level of the world map.
+	 *
+	 * @return the world map zoon
+	 */
 	float getWorldMapZoom();
 
+	/**
+	 * Sets the target position of the world map.
+	 *
+	 * @param worldPoint the new target position
+	 */
 	void setWorldMapPositionTarget(WorldPoint worldPoint);
 
+	/**
+	 * Gets the world map manager.
+	 *
+	 * @return the world map manager
+	 */
 	WorldMapManager getWorldMapManager();
 
+	/**
+	 * Initializes the world map with the provided data.
+	 *
+	 * @param var1 the new map data
+	 */
 	void initializeWorldMap(WorldMapData var1);
 
+	/**
+	 * The data represented by the render.
+	 *
+	 * @return the map data
+	 */
 	WorldMapData getWorldMapData();
 }

--- a/runelite-api/src/main/java/net/runelite/api/Renderable.java
+++ b/runelite-api/src/main/java/net/runelite/api/Renderable.java
@@ -24,7 +24,15 @@
  */
 package net.runelite.api;
 
+/**
+ * Represents an object that can be rendered.
+ */
 public interface Renderable extends Node
 {
+	/**
+	 * Gets the model of the object.
+	 *
+	 * @return the model
+	 */
 	Model getModel();
 }

--- a/runelite-api/src/main/java/net/runelite/api/SceneTileModel.java
+++ b/runelite-api/src/main/java/net/runelite/api/SceneTileModel.java
@@ -24,13 +24,36 @@
  */
 package net.runelite.api;
 
+/**
+ * Represents the model of a tile in the current scene.
+ */
 public interface SceneTileModel
 {
+	/**
+	 * Gets the underlay color of the tile.
+	 *
+	 * @return the underlay color
+	 */
 	int getModelUnderlay();
 
+	/**
+	 * Gets the overlay color of the tile.
+	 *
+	 * @return the overlay color
+	 */
 	int getModelOverlay();
 
+	/**
+	 * Gets the shape mask type.
+	 *
+	 * @return the shape mask
+	 */
 	int getShape();
 
+	/**
+	 * Gets the rotation of the tile.
+	 *
+	 * @return the rotation
+	 */
 	int getRotation();
 }

--- a/runelite-api/src/main/java/net/runelite/api/SceneTilePaint.java
+++ b/runelite-api/src/main/java/net/runelite/api/SceneTilePaint.java
@@ -24,7 +24,15 @@
  */
 package net.runelite.api;
 
+/**
+ * Represents the paint of a tile in the current scene.
+ */
 public interface SceneTilePaint
 {
+	/**
+	 * Gets the RGB value of the paint.
+	 *
+	 * @return the paint RGB
+	 */
 	int getRBG();
 }

--- a/runelite-api/src/main/java/net/runelite/api/Skill.java
+++ b/runelite-api/src/main/java/net/runelite/api/Skill.java
@@ -25,6 +25,9 @@
 
 package net.runelite.api;
 
+/**
+ * An enumeration of skills that a player can level.
+ */
 public enum Skill
 {
 	ATTACK("Attack"),
@@ -50,6 +53,9 @@ public enum Skill
 	RUNECRAFT("Runecraft"),
 	HUNTER("Hunter"),
 	CONSTRUCTION("Construction"),
+	/**
+	 * The level of all skills added together.
+	 */
 	OVERALL("Overall");
 
 	private final String name;
@@ -59,6 +65,11 @@ public enum Skill
 		this.name = name;
 	}
 
+	/**
+	 * Gets the name of the skill.
+	 *
+	 * @return the skill name
+	 */
 	public String getName()
 	{
 		return name;

--- a/runelite-api/src/main/java/net/runelite/api/SoundEffectID.java
+++ b/runelite-api/src/main/java/net/runelite/api/SoundEffectID.java
@@ -24,6 +24,9 @@
  */
 package net.runelite.api;
 
+/**
+ * Utility class used for mapping sound effect IDs.
+ */
 public final class SoundEffectID
 {
 	public final static int UI_BOOP = 2266;
@@ -51,7 +54,7 @@ public final class SoundEffectID
 	public final static int SMITH_ANVIL_TONK = 3791;
 
 	/**
-	 * Used for random event NPCs spawning, and the imp teleport
+	 * Used for random event NPCs spawning, and the imp teleport.
 	 */
 	public final static int NPC_TELEPORT_WOOSH = 1930;
 

--- a/runelite-api/src/main/java/net/runelite/api/SpritePixels.java
+++ b/runelite-api/src/main/java/net/runelite/api/SpritePixels.java
@@ -26,29 +26,54 @@ package net.runelite.api;
 
 import java.awt.image.BufferedImage;
 
+/**
+ * Represents data about the pixels of a sprite image.
+ */
 public interface SpritePixels
 {
 	int DEFAULT_SHADOW_COLOR = 3153952;
 
+	/**
+	 * Draws the pixels at the given coordinates on the canvas.
+	 *
+	 * @param x the x-axis coordinate
+	 * @param y the y-axis coordinate
+	 */
 	void drawAt(int x, int y);
 
+	/**
+	 * Gets the width of the sprite image in pixels.
+	 *
+	 * @return the width
+	 */
 	int getWidth();
 
+	/**
+	 * Gets the height of the sprite image in pixels.
+	 *
+	 * @return the height
+	 */
 	int getHeight();
 
+	/**
+	 * Gets an array of all pixels data in the sprite.
+	 *
+	 * @return the pixel data
+	 */
 	int[] getPixels();
 
 	/**
-	 * Covert the SpritePixels to a BufferedImage
+	 * Converts the sprite into a BufferedImage.
 	 *
-	 * @return
+	 * @return the resulting BufferedImage
 	 */
 	BufferedImage toBufferedImage();
 
-
 	/**
-	 * Writes the contents of the SpritePixels to the BufferedImage.
-	 * Width and Height must match
+	 * Writes the contents of the sprite to the given BufferedImage.
+	 *
+	 * @param img the passsed buffered image
+	 * @throws IllegalArgumentException if the width or height do not match
  	 */
-	void toBufferedImage(BufferedImage img);
+	void toBufferedImage(BufferedImage img) throws IllegalArgumentException;
 }

--- a/runelite-api/src/main/java/net/runelite/api/Tile.java
+++ b/runelite-api/src/main/java/net/runelite/api/Tile.java
@@ -28,41 +28,101 @@ import java.util.List;
 import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.coords.WorldPoint;
 
+/**
+ * Represents a tile in the game.
+ */
 public interface Tile
 {
 	/**
-	 * Get the decorative object for this tile.
+	 * Gets the decoration on the tile.
 	 *
-	 * @return
+	 * @return the tile decoration
 	 */
 	DecorativeObject getDecorativeObject();
 
+	/**
+	 * Gets all game objects on the tile.
+	 *
+	 * @return the game objects
+	 */
 	GameObject[] getGameObjects();
 
+	/**
+	 * Gets the items held on this tile.
+	 *
+	 * @return the item
+	 */
 	ItemLayer getItemLayer();
 
+	/**
+	 * Gets the object on the ground layer of the tile.
+	 *
+	 * @return the ground object
+	 */
 	GroundObject getGroundObject();
 
+	/**
+	 * Gets the wall of the tile.
+	 *
+	 * @return the wall object
+	 */
 	WallObject getWallObject();
 
+	/**
+	 * Gets the scene paint of the tile.
+	 *
+	 * @return the paint
+	 */
 	SceneTilePaint getSceneTilePaint();
 
+	/**
+	 * Gets the model of the tile in the scene.
+	 *
+	 * @return the tile model
+	 */
 	SceneTileModel getSceneTileModel();
 
+	/**
+	 * Gets the location coordinate of the tile in the world.
+	 *
+	 * @return the world location
+	 */
 	WorldPoint getWorldLocation();
 
+	/**
+	 * Gets the location coordinate of the tile relative to the current
+	 * region start point.
+	 *
+	 * @return the region location
+	 */
 	Point getRegionLocation();
 
+	/**
+	 * Gets the local coordinate of the tile.
+	 *
+	 * @return the local location
+	 */
 	LocalPoint getLocalLocation();
 
+	/**
+	 * Gets the plane that this tile is on.
+	 *
+	 * @return the plane
+	 */
 	int getPlane();
 
+	/**
+	 * Computes and returns whether this tile has line of sight to another.
+	 *
+	 * @param other the other tile
+	 * @return true if there is no sight obstruction, false otherwise
+	 */
 	boolean hasLineOfSightTo(Tile other);
 
 	/**
 	 * Get all the ground items for this tile
 	 *
-	 * @return
+	 * @return the ground items
 	 */
 	List<Item> getGroundItems();
 }

--- a/runelite-api/src/main/java/net/runelite/api/TileObject.java
+++ b/runelite-api/src/main/java/net/runelite/api/TileObject.java
@@ -30,36 +30,105 @@ import java.awt.geom.Area;
 import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.coords.WorldPoint;
 
+/**
+ * Represents an object that a tile holds.
+ */
 public interface TileObject
 {
+	/**
+	 * Gets the hashed value of this object.
+	 *
+	 * @return the object hash
+	 */
 	long getHash();
 
+	/**
+	 * Gets the x-axis coordinate of the object in local context.
+	 *
+	 * @return the x-axis coordinate
+	 */
 	int getX();
 
+	/**
+	 * Gets the y-axis coordinate of the object in local context.
+	 *
+	 * @return the y-axis coordinate
+	 */
 	int getY();
 
+	/**
+	 * Gets the plane of the tile that the object is on.
+	 *
+	 * @return the tile plane
+	 */
 	int getPlane();
 
+	/**
+	 * Gets the ID of the object.
+	 *
+	 * @return the object ID
+	 */
 	int getId();
 
+	/**
+	 * Gets the location coordinate of the object in the world.
+	 *
+	 * @return the world location
+	 */
 	WorldPoint getWorldLocation();
 
+	/**
+	 * Gets the local location of the object.
+	 *
+	 * @return the local location
+	 */
 	LocalPoint getLocalLocation();
 
+	/**
+	 * Gets the upper-left canvas point where this object is drawn.
+	 *
+	 * @return the canvas location
+	 */
 	Point getCanvasLocation();
 
+	/**
+	 * Gets the upper-left canvas point where this object is drawn,
+	 * offset by the passed value.
+	 *
+	 * @param zOffset the z-axis offset
+	 * @return the canvas location
+	 */
 	Point getCanvasLocation(int zOffset);
 
+	/**
+	 * Gets the polygon of the objects model as drawn on the canvas.
+	 *
+	 * @return the canvas polygon
+	 */
 	Polygon getCanvasTilePoly();
 
+	/**
+	 * Gets the text position on the canvas.
+	 *
+	 * @param graphics the client graphics
+	 * @param text the text to draw
+	 * @param zOffset the offset from ground plane
+	 * @return the canvas point to draw the text at
+	 */
 	Point getCanvasTextLocation(Graphics2D graphics, String text, int zOffset);
 
+	/**
+	 * Gets a point on the canvas of where this objects mini-map indicator
+	 * should appear.
+	 *
+	 * @return mini-map location on canvas
+	 */
 	Point getMinimapLocation();
 
 	/**
-	 * Get the on-screen clickable area of {@code object}
+	 * Get the on-screen clickable area of the object.
 	 *
-	 * @return the clickable area of {@code object}
+	 * @return the clickable area
 	 */
 	Area getClickbox();
 }

--- a/runelite-api/src/main/java/net/runelite/api/VarClientInt.java
+++ b/runelite-api/src/main/java/net/runelite/api/VarClientInt.java
@@ -27,6 +27,9 @@ package net.runelite.api;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+/**
+ * An enumeration of integer local variables.
+ */
 @AllArgsConstructor
 @Getter
 public enum VarClientInt

--- a/runelite-api/src/main/java/net/runelite/api/VarClientStr.java
+++ b/runelite-api/src/main/java/net/runelite/api/VarClientStr.java
@@ -27,6 +27,9 @@ package net.runelite.api;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+/**
+ * An enumeration of string local variables.
+ */
 @AllArgsConstructor
 @Getter
 public enum VarClientStr

--- a/runelite-api/src/main/java/net/runelite/api/VarPlayer.java
+++ b/runelite-api/src/main/java/net/runelite/api/VarPlayer.java
@@ -27,6 +27,9 @@ package net.runelite.api;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+/**
+ * An enumeration of local player variables.
+ */
 @AllArgsConstructor
 @Getter
 public enum VarPlayer
@@ -41,7 +44,7 @@ public enum VarPlayer
 	IN_RAID_PARTY(1427),
 
 	/**
-	 * Experience tracker goal start
+	 * Experience tracker goal start.
 	 */
 	ATTACK_GOAL_START(1229),
 	STRENGTH_GOAL_START(1230),
@@ -68,7 +71,7 @@ public enum VarPlayer
 	HUNTER_GOAL_START(1251),
 
 	/**
-	 * Experience tracker goal end
+	 * Experience tracker goal end.
 	 */
 	ATTACK_GOAL_END(1253),
 	STRENGTH_GOAL_END(1254),

--- a/runelite-api/src/main/java/net/runelite/api/Varbits.java
+++ b/runelite-api/src/main/java/net/runelite/api/Varbits.java
@@ -27,6 +27,9 @@ package net.runelite.api;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+/**
+ * An enumeration of local client variables.
+ */
 @AllArgsConstructor
 @Getter
 public enum Varbits
@@ -347,7 +350,7 @@ public enum Varbits
 	ACCOUNT_TYPE(1777);
 
 	/**
-	 * varbit id
+	 * The raw varbit ID.
 	 */
 	private final int id;
 }

--- a/runelite-api/src/main/java/net/runelite/api/WallObject.java
+++ b/runelite-api/src/main/java/net/runelite/api/WallObject.java
@@ -25,15 +25,28 @@
 package net.runelite.api;
 
 /**
- * A wall object, which is a boundary you can't walk through.
- *
- * @author Adam
+ * Represents the wall of a tile, which is an un-passable boundary.
  */
 public interface WallObject extends TileObject
 {
+	/**
+	 * Gets the first orientation of the wall.
+	 *
+	 * @return the first orientation, 0-2048 where 0 is north
+	 */
 	int getOrientationA();
 
+	/**
+	 * Gets the second orientation value of the wall.
+	 *
+	 * @return the second orientation, 0-2048 where 0 is north
+	 */
 	int getOrientationB();
 
+	/**
+	 * Gets the boundary configuration of the wall.
+	 *
+	 * @return the boundary configuration
+	 */
 	int getConfig();
 }

--- a/runelite-api/src/main/java/net/runelite/api/WidgetNode.java
+++ b/runelite-api/src/main/java/net/runelite/api/WidgetNode.java
@@ -24,7 +24,16 @@
  */
 package net.runelite.api;
 
+/**
+ * Represents a widget as an iterable node.
+ */
 public interface WidgetNode extends Node
 {
+	/**
+	 * The ID of the widget.
+	 *
+	 * @return the ID of the widget
+	 * @see net.runelite.api.widgets.Widget
+	 */
 	int getId();
 }

--- a/runelite-api/src/main/java/net/runelite/api/World.java
+++ b/runelite-api/src/main/java/net/runelite/api/World.java
@@ -24,18 +24,17 @@
  */
 package net.runelite.api;
 
-
 import java.util.EnumSet;
 
 /**
- * Holds data of RuneScape world.
+ * Holds data of a RuneScape world.
  */
 public interface World
 {
 	/**
-	 * Gets world types.
+	 * Gets all applicable world types for this world.
 	 *
-	 * @return the types
+	 * @return the world types
 	 */
 	EnumSet<WorldType> getTypes();
 
@@ -47,84 +46,86 @@ public interface World
 	void setTypes(EnumSet<WorldType> types);
 
 	/**
-	 * Gets player count.
+	 * Gets the current number of players logged in the world.
 	 *
 	 * @return the player count
 	 */
 	int getPlayerCount();
 
 	/**
-	 * Sets player count.
+	 * Sets the player count of the world.
 	 *
-	 * @param playerCount the player count
+	 * @param playerCount the new player count
 	 */
 	void setPlayerCount(int playerCount);
 
 	/**
-	 * Gets location.
+	 * Gets the world location value.
 	 *
-	 * @return the location
+	 * @return the world location
 	 */
 	int getLocation();
 
 	/**
-	 * Sets location.
+	 * Sets the world location value.
 	 *
 	 * @param location the location
 	 */
 	void setLocation(int location);
 
 	/**
-	 * Gets index.
+	 * Gets the worlds index.
 	 *
 	 * @return the index
 	 */
 	int getIndex();
 
 	/**
-	 * Sets index.
+	 *  Sets the worlds index.
 	 *
 	 * @param index the index
 	 */
 	void setIndex(int index);
 
 	/**
-	 * Gets id.
+	 * Gets the world number.
 	 *
-	 * @return the id
+	 * @return the world number
 	 */
 	int getId();
 
 	/**
-	 * Sets id.
+	 * Sets the world number.
 	 *
-	 * @param id the id
+	 * @param id the world number
 	 */
 	void setId(int id);
 
 	/**
-	 * Gets activity.
+	 * Gets the world activity description.
+	 * <p>
+	 * For example, world 2 would return "Trade - Members".
 	 *
-	 * @return the activity
+	 * @return the world activity
 	 */
 	String getActivity();
 
 	/**
-	 * Sets activity.
+	 * Sets the world activity description.
 	 *
 	 * @param activity the activity
 	 */
 	void setActivity(String activity);
 
 	/**
-	 * Gets address.
+	 * Gets the address of the world.
 	 *
-	 * @return the address
+	 * @return the world address
 	 */
 	String getAddress();
 
 	/**
-	 * Sets address.
+	 * Sets the address of the world.
 	 *
 	 * @param address the address
 	 */

--- a/runelite-api/src/main/java/net/runelite/api/WorldMapData.java
+++ b/runelite-api/src/main/java/net/runelite/api/WorldMapData.java
@@ -24,7 +24,18 @@
  */
 package net.runelite.api;
 
+/**
+ * Represents data on the world map.
+ */
 public interface WorldMapData
 {
+	/**
+	 * Checks whether the passed coordinates are on the surface of the
+	 * world map.
+	 *
+	 * @param x x-axis coordinate
+	 * @param y y-axis coordinate
+	 * @return true if the coordinate is on the surface, false otherwise
+	 */
 	boolean surfaceContainsPosition(int x, int y);
 }

--- a/runelite-api/src/main/java/net/runelite/api/WorldMapManager.java
+++ b/runelite-api/src/main/java/net/runelite/api/WorldMapManager.java
@@ -24,7 +24,15 @@
  */
 package net.runelite.api;
 
+/**
+ * Manages the world map.
+ */
 public interface WorldMapManager
 {
+	/**
+	 * Checks whether the world map is currently loaded.
+	 *
+	 * @return true if the map is loaded, false otherwise
+	 */
 	boolean isLoaded();
 }

--- a/runelite-api/src/main/java/net/runelite/api/WorldType.java
+++ b/runelite-api/src/main/java/net/runelite/api/WorldType.java
@@ -27,7 +27,7 @@ package net.runelite.api;
 import java.util.EnumSet;
 
 /**
- * Enum representing world type.
+ * An enumeration of possible world types.
  */
 public enum WorldType
 {
@@ -96,7 +96,7 @@ public enum WorldType
 	 * Create mask from enum set of world types.
 	 *
 	 * @param types the types
-	 * @return the int
+	 * @return the int containing all mask
 	 */
 	public static int toMask(final EnumSet<WorldType> types)
 	{

--- a/runelite-api/src/main/java/net/runelite/api/coords/Angle.java
+++ b/runelite-api/src/main/java/net/runelite/api/coords/Angle.java
@@ -30,18 +30,34 @@ import static net.runelite.api.coords.Direction.NORTH;
 import static net.runelite.api.coords.Direction.SOUTH;
 import static net.runelite.api.coords.Direction.WEST;
 
+/**
+ * Represents an in-game orientation that uses fixed point arithmetic.
+ * <p>
+ * Angles are represented as an int value ranging from 0-2047, where the
+ * following is true:
+ * <ul>
+ *     <li>0 is true South</li>
+ *     <li>512 is true West</li>
+ *     <li>1024 is true North</li>
+ *     <li>1536 is true East</li>
+ * </ul>
+ */
 @Value
 public class Angle
 {
 	/**
-	 * angle, 0-2047.
-	 * 0 is south, west is 512, south is 1024, east is 1536s
+	 * The raw angle value.
 	 */
 	private final int angle;
 
 	/**
-	 * Get the nearest N/S/E/W direction for this angle
-	 * @return
+	 * Converts the angle value to the nearest cardinal direction.
+	 * <p>
+	 * Each cardinal direction contains 512 angles, ranging between
+	 * -256 and +256 of it's true value. Negative values and values
+	 * above 2047 are wrapped accordingly.
+	 *
+	 * @return Nearest cardinal direction to the angle
 	 */
 	public Direction getNearestDirection()
 	{

--- a/runelite-api/src/main/java/net/runelite/api/coords/Direction.java
+++ b/runelite-api/src/main/java/net/runelite/api/coords/Direction.java
@@ -24,10 +24,28 @@
  */
 package net.runelite.api.coords;
 
+/**
+ * Represents the four main cardinal points.
+ */
 public enum Direction
 {
+	/**
+	 * Angles ranging from 768 - 1279.
+	 */
 	NORTH,
+
+	/**
+	 * Angles ranging from 1792 - 2047 and 0 - 255.
+	 */
 	SOUTH,
+
+	/**
+	 * Angles ranging from 1280 - 1791.
+	 */
 	EAST,
-	WEST;
+
+	/**
+	 * Angles ranging from 256 - 767.
+	 */
+	WEST
 }

--- a/runelite-api/src/main/java/net/runelite/api/coords/LocalPoint.java
+++ b/runelite-api/src/main/java/net/runelite/api/coords/LocalPoint.java
@@ -31,18 +31,27 @@ import net.runelite.api.Client;
 import net.runelite.api.Perspective;
 
 /**
- * A LocolPoint is a Two-Dimensional point in the local coordinate space. Because the local coordinate space moves,
- * it is not safe to keep a LocalPoint after a loading zone. The unit is 1/128th of a Tile
+ * A two-dimensional point in the local coordinate space.
+ * <p>
+ * Local points are immutable, however since the local coordinate space moves,
+ * it is not safe to keep a LocalPoint after a loading zone.
+ * <p>
+ * The unit of a LocalPoint is 1/128th of a tile.
  */
 @Value
 public class LocalPoint
 {
+	/**
+	 * X and Y axis coordinates.
+	 */
 	private final int x, y;
 
 	/**
-	 * Returns a LocalPoint of the center of the passed tile
+	 * Gets the local coordinate at the center of the passed tile.
 	 *
-	 * @return LocalPoint if in scene, otherwise null
+	 * @param client the client
+	 * @param world  the passed tile
+	 * @return coordinate if the tile is in the current scene, otherwise null
 	 */
 	@Nullable
 	public static LocalPoint fromWorld(Client client, WorldPoint world)
@@ -55,9 +64,12 @@ public class LocalPoint
 	}
 
 	/**
-	 * Returns a LocalPoint of the center of the passed tile
+	 * Gets the local coordinate at the center of the passed tile.
 	 *
-	 * @return LocalPoint if in scene, otherwise null
+	 * @param client the client
+	 * @param x      x-axis coordinate of the tile
+	 * @param y      y-axis coordinate of the tile
+	 * @return coordinate if the tile is in the current scene, otherwise null
 	 */
 	public static LocalPoint fromWorld(Client client, int x, int y)
 	{
@@ -73,10 +85,10 @@ public class LocalPoint
 	}
 
 	/**
-	 * Find the distance from this point to another point
+	 * Gets the distance between this point and another.
 	 *
-	 * @param other
-	 * @return
+	 * @param other other point
+	 * @return the distance
 	 */
 	public int distanceTo(LocalPoint other)
 	{
@@ -84,7 +96,17 @@ public class LocalPoint
 	}
 
 	/**
-	 * Returns a LocalPoint of the center of the passed tile
+	 * Gets the coordinate at the center of the passed tile.
+	 * <p>
+	 * The coordinate returned by this method is the true tile location,
+	 * in LocalPoint units, relative to tile (0, 0).
+	 * <p>
+	 * e.g. If the local player is standing on tile 3170, the method returns
+	 * 405823, or 3170 * 128 + 64.
+	 *
+	 * @param x      x-axis coordinate of the tile
+	 * @param y      y-axis coordinate of the tile
+	 * @return true coordinate of the tile
 	 */
 	public static LocalPoint fromRegion(int x, int y)
 	{
@@ -95,16 +117,19 @@ public class LocalPoint
 	}
 
 	/**
-	 * Returns the X coordinate in Scene space (tiles)
+	 * Gets the x-axis coordinate in scene space (tiles).
+	 *
+	 * @return x-axis coordinate
 	 */
 	public int getRegionX()
 	{
 		return x >>> Perspective.LOCAL_COORD_BITS;
 	}
 
-
 	/**
-	 * Returns the Y coordinate in Scene space (tiles)
+	 * Gets the y-axis coordinate in scene space (tiles).
+	 *
+	 * @return y-axis coordinate
 	 */
 	public int getRegionY()
 	{

--- a/runelite-api/src/main/java/net/runelite/api/coords/WorldArea.java
+++ b/runelite-api/src/main/java/net/runelite/api/coords/WorldArea.java
@@ -33,34 +33,37 @@ import net.runelite.api.Constants;
 import net.runelite.api.Point;
 import net.runelite.api.Tile;
 
+/**
+ * Represents an area on the world.
+ */
 public class WorldArea
 {
 	/**
-	 * The western most point of the area
+	 * The western most point of the area.
 	 */
 	@Getter
 	private int x;
 
 	/**
-	 * The southern most point of the area
+	 * The southern most point of the area.
 	 */
 	@Getter
 	private int y;
 
 	/**
-	 * The width of the area
+	 * The width of the area.
 	 */
 	@Getter
 	private int width;
 
 	/**
-	 * The height of the area
+	 * The height of the area.
 	 */
 	@Getter
 	private int height;
 
 	/**
-	 * The plane the area is on
+	 * The plane the area is on.
 	 */
 	@Getter
 	private int plane;
@@ -84,9 +87,10 @@ public class WorldArea
 	}
 
 	/**
-	 * Get the shortest distance to another WorldArea for both x and y axis
-	 * @param other The WorldArea to get the distance to
-	 * @return Returns a Point with the shortest distance
+	 * Computes the shortest distance to another area.
+	 *
+	 * @param other the passed area
+	 * @return the distance along both x and y axis
 	 */
 	private Point getAxisDistances(WorldArea other)
 	{
@@ -96,10 +100,10 @@ public class WorldArea
 	}
 
 	/**
-	 * Get the shortest distance to another WorldArea
+	 * Computes the shortest distance to another area.
 	 *
-	 * @param other The other area
-	 * @return Returns the distance
+	 * @param other the passed area
+	 * @return the distance, or {@link Integer#MAX_VALUE} if the planes differ
 	 */
 	public int distanceTo(WorldArea other)
 	{
@@ -113,10 +117,10 @@ public class WorldArea
 	}
 
 	/**
-	 * Get the shortest distance to another WorldPoint
+	 * Computes the shortest distance to a world coordinate.
 	 *
-	 * @param other The other worldpoint
-	 * @return Returns the distance
+	 * @param other the passed coordinate
+	 * @return the distance, or {@link Integer#MAX_VALUE} if the planes differ
 	 */
 	public int distanceTo(WorldPoint other)
 	{
@@ -124,10 +128,14 @@ public class WorldArea
 	}
 
 	/**
-	 * Determines if this WorldArea is within melee distance of another WorldArea
+	 * Checks whether this area is within melee distance of another.
+	 * <p>
+	 * Melee distance is exactly 1 tile, so this method computes and returns
+	 * whether the shortest distance to the passed area is directly
+	 * on the outside of this areas edge.
 	 *
-	 * @param other The other world area to compare with
-	 * @return Returns true if it is in melee distance
+	 * @param other the other area
+	 * @return true if in melee distance, false otherwise
 	 */
 	public boolean isInMeleeDistance(WorldArea other)
 	{
@@ -141,10 +149,11 @@ public class WorldArea
 	}
 
 	/**
-	 * Determines if this WorldArea is within melee distance of another WorldPoint
+	 * Checks whether a coordinate is within melee distance of this area.
 	 *
-	 * @param other The world pint to compare with
-	 * @return Returns true if it is in melee distance
+	 * @param other the coordinate
+	 * @return true if in melee distance, false otherwise
+	 * @see #isInMeleeDistance(WorldArea)
 	 */
 	public boolean isInMeleeDistance(WorldPoint other)
 	{
@@ -152,10 +161,10 @@ public class WorldArea
 	}
 
 	/**
-	 * Determines if a WorldArea intersects with another WorldArea
+	 * Checks whether this area intersects with another.
 	 *
-	 * @param other The other WorldArea to compare with
-	 * @return Returns true if the areas intersect
+	 * @param other the other area
+	 * @return true if the areas intersect, false otherwise
 	 */
 	public boolean intersectsWith(WorldArea other)
 	{
@@ -169,16 +178,18 @@ public class WorldArea
 	}
 
 	/**
-	 * Determines if the area can travel in one of the 8 directions
+	 * Determines if the area can travel in one of the 9 directions
 	 * by using the standard collision detection algorithm.
+	 * <p>
 	 * Note that this method does not consider other actors as
 	 * a collision, but most non-boss NPCs do check for collision
-	 * with some actors.
+	 * with some actors. For actor collision checking, use the
+	 * {@link #canTravelInDirection(Client, int, int, Predicate)} method.
 	 *
-	 * @param client The client to test in
-	 * @param dx The x direction to test against
-	 * @param dy The y direction to test against
-	 * @return Returns true if it's possible to travel in specified direction
+	 * @param client the client to test in
+	 * @param dx the x-axis direction to travel (-1, 0, or 1)
+	 * @param dy the y-axis direction to travel (-1, 0, or 1)
+	 * @return true if the area can travel in the specified direction
 	 */
 	public boolean canTravelInDirection(Client client, int dx, int dy)
 	{
@@ -186,18 +197,23 @@ public class WorldArea
 	}
 
 	/**
-	 * Determines if the area can travel in one of the 8 directions
+	 * Determines if the area can travel in one of the 9 directions
 	 * by using the standard collision detection algorithm.
-	 * Note that this method does not consider other actors as
-	 * a collision, but most non-boss NPCs do check for collision
-	 * with some actors.
+	 * <p>
+	 * The passed x and y axis directions indicate the direction to
+	 * travel in.
+	 * <p>
+	 * Note that this method does not normally consider other actors
+	 * as a collision, but most non-boss NPCs do check for collision
+	 * with some actors. However, using the {@code extraCondition} param
+	 * it is possible to implement this check manually.
 	 *
-	 * @param client The client to test in
-	 * @param dx The x direction to test against
-	 * @param dy The y direction to test against
-	 * @param extraCondition Additional check for if movement is allowed through specific
-	 * tiles, which may be used if movement should be disabled through other actors
-	 * @return Returns true if it's possible to travel in specified direction
+	 * @param client the client to test in
+	 * @param dx the x-axis direction to travel (-1, 0, or 1)
+	 * @param dy the y-axis direction to travel (-1, 0, or 1)
+	 * @param extraCondition an additional condition to perform when checking valid tiles,
+	 *                       such as performing a check for un-passable actors
+	 * @return true if the area can travel in the specified direction
 	 */
 	public boolean canTravelInDirection(Client client, int dx, int dy,
 										Predicate<? super WorldPoint> extraCondition)
@@ -375,10 +391,10 @@ public class WorldArea
 	}
 
 	/**
-	 * Retrieves the Point within this WorldArea which is the closest to another WorldArea
+	 * Gets the point within this area that is closest to another.
 	 *
-	 * @param other The other WorldArea to compare to
-	 * @return Returns the closest Point
+	 * @param other the other area
+	 * @return the closest point to the passed area
 	 */
 	private Point getComparisonPoint(WorldArea other)
 	{
@@ -411,14 +427,13 @@ public class WorldArea
 	}
 
 	/**
-	 * Calculates the next area that will be occupied if this area
-	 * attempts to move toward it by using the normal NPC travelling
-	 * pattern.
+	 * Calculates the next area that will be occupied if this area attempts
+	 * to move toward it by using the normal NPC travelling pattern.
 	 *
-	 * @param client The client to calculate with
-	 * @param target The target area
-	 * @param stopAtMeleeDistance Determine if it should stop at melee distance to the target
-	 * @return Returns the next occupied area
+	 * @param client the client to calculate with
+	 * @param target the target area
+	 * @param stopAtMeleeDistance whether to stop at melee distance to the target
+	 * @return the next occupied area
 	 */
 	public WorldArea calculateNextTravellingPoint(Client client, WorldArea target,
 		boolean stopAtMeleeDistance)
@@ -427,16 +442,15 @@ public class WorldArea
 	}
 
 	/**
-	 * Calculates the next area that will be occupied if this area
-	 * attempts to move toward it by using the normal NPC travelling
-	 * pattern.
+	 * Calculates the next area that will be occupied if this area attempts
+	 * to move toward it by using the normal NPC travelling pattern.
 	 *
-	 * @param client The client to calculate with
-	 * @param target The target area
-	 * @param stopAtMeleeDistance Determine if it should stop at melee distance to the target
-	 * @param extraCondition Additional check for if movement is allowed through specific
-	 * tiles, which may be used if movement should be disabled through other actors
-	 * @return Returns the next occupied area
+	 * @param client the client to calculate with
+	 * @param target the target area
+	 * @param stopAtMeleeDistance whether to stop at melee distance to the target
+	 * @param extraCondition an additional condition to perform when checking valid tiles,
+	 * 	                     such as performing a check for un-passable actors
+	 * @return the next occupied area
 	 */
 	public WorldArea calculateNextTravellingPoint(Client client, WorldArea target,
 		boolean stopAtMeleeDistance, Predicate<? super WorldPoint> extraCondition)
@@ -514,6 +528,7 @@ public class WorldArea
 
 	/**
 	 * Determine if this WorldArea has line of sight to another WorldArea.
+	 * <p>
 	 * Note that the reverse isn't necessarily true, meaning this can return true
 	 * while the other WorldArea does not have line of sight to this WorldArea.
 	 *
@@ -606,6 +621,7 @@ public class WorldArea
 
 	/**
 	 * Determine if this WorldArea has line of sight to another WorldArea.
+	 * <p>
 	 * Note that the reverse isn't necessarily true, meaning this can return true
 	 * while the other WorldArea does not have line of sight to this WorldArea.
 	 *
@@ -619,7 +635,7 @@ public class WorldArea
 	}
 
 	/**
-	 * Retrieves the southwestern most point of this WorldArea
+	 * Retrieves the southwestern most point of this WorldArea.
 	 *
 	 * @return Returns the southwestern most WorldPoint in the area
 	 */

--- a/runelite-api/src/main/java/net/runelite/api/coords/WorldPoint.java
+++ b/runelite-api/src/main/java/net/runelite/api/coords/WorldPoint.java
@@ -31,32 +31,36 @@ import net.runelite.api.Perspective;
 import net.runelite.api.Point;
 
 /**
- * WorldPoint is a Three-Dimensional point representing the location of a Tile
+ * A three-dimensional point representing the coordinate of a Tile.
+ * <p>
+ * WorldPoints are immutable. Methods that modify the properties create a new
+ * instance.
  */
 @Value
 public class WorldPoint
 {
 	/**
-	 * The X coordinate of the Point.
-	 * Units are in tiles
+	 * X-axis coordinate.
 	 */
 	private final int x;
 
 	/**
-	 * The Y coordinate of the Point.
-	 * Units are in tiles
+	 * Y-axis coordinate.
 	 */
 	private final int y;
 
 	/**
-	 * The plane coordinate of the Point.
+	 * The plane level of the Tile, also referred as z-axis coordinate.
+	 *
+	 * @see Client#getPlane()
 	 */
 	private final int plane;
 
 	/**
-	 * Returns a WorldPoint offset on x from this point
-	 * @param dx offset
-	 * @return
+	 * Offsets the x-axis coordinate by the passed value.
+	 *
+	 * @param dx the offset
+	 * @return new instance
 	 */
 	public WorldPoint dx(int dx)
 	{
@@ -64,9 +68,10 @@ public class WorldPoint
 	}
 
 	/**
-	 * Returns a WorldPoint offset on y from this point
-	 * @param dy offset
-	 * @return
+	 * Offsets the y-axis coordinate by the passed value.
+	 *
+	 * @param dy the offset
+	 * @return new instance
 	 */
 	public WorldPoint dy(int dy)
 	{
@@ -74,15 +79,24 @@ public class WorldPoint
 	}
 
 	/**
-	 * Returns a WorldPoint offset on z from this point
-	 * @param dz offset
-	 * @return
+	 * Offsets the plane by the passed value.
+	 *
+	 * @param dz the offset
+	 * @return new instance
 	 */
 	public WorldPoint dz(int dz)
 	{
 		return new WorldPoint(x, y, plane + dz);
 	}
 
+	/**
+	 * Checks whether a tile is located in the current scene.
+	 *
+	 * @param client the client
+	 * @param x the tiles x coordinate
+	 * @param y the tiles y coordinate
+	 * @return true if the tile is in the scene, false otherwise
+	 */
 	public static boolean isInScene(Client client, int x, int y)
 	{
 		int baseX = client.getBaseX();
@@ -94,13 +108,23 @@ public class WorldPoint
 		return x >= baseX && x < maxX && y >= baseY && y < maxY;
 	}
 
+	/**
+	 * Checks whether this tile is located in the current scene.
+	 *
+	 * @param client the client
+	 * @return true if this tile is in the scene, false otherwise
+	 */
 	public boolean isInScene(Client client)
 	{
 		return client.getPlane() == plane && isInScene(client, x, y);
 	}
 
 	/**
-	 * Returns a WorldPoint containing the passed LocalPoint
+	 * Gets the coordinate of the tile that contains the passed local point.
+	 *
+	 * @param client the client
+	 * @param local the local coordinate
+	 * @return the tile coordinate containing the local point
 	 */
 	public static WorldPoint fromLocal(Client client, LocalPoint local)
 	{
@@ -108,7 +132,13 @@ public class WorldPoint
 	}
 
 	/**
-	 * Returns a WorldPoint containing the passed local coordinates
+	 * Gets the coordinate of the tile that contains the passed local point.
+	 *
+	 * @param client the client
+	 * @param x the local x-axis coordinate
+	 * @param y the local x-axis coordinate
+	 * @param plane the plane
+	 * @return the tile coordinate containing the local point
 	 */
 	public static WorldPoint fromLocal(Client client, int x, int y, int plane)
 	{
@@ -120,10 +150,10 @@ public class WorldPoint
 	}
 
 	/**
-	 * Find the shortest distance from this point to a WorldArea
+	 * Gets the shortest distance from this point to a WorldArea.
 	 *
-	 * @param other The WorldArea to find the distance to
-	 * @return Returns the shortest distance
+	 * @param other the world area
+	 * @return the shortest distance
 	 */
 	public int distanceTo(WorldArea other)
 	{
@@ -131,11 +161,14 @@ public class WorldPoint
 	}
 
 	/**
-	 * Find the distance from this point to another point. Returns Integer.MAX_VALUE if other is on
-	 * a different plane.
+	 * Gets the distance between this point and another.
+	 * <p>
+	 * If the other point is not on the same plane, this method will return
+	 * {@link Integer#MAX_VALUE}. If ignoring the plane is wanted, use the
+	 * {@link #distanceTo2D(WorldPoint)} method.
 	 *
-	 * @param other
-	 * @return
+	 * @param other other point
+	 * @return the distance
 	 */
 	public int distanceTo(WorldPoint other)
 	{
@@ -147,12 +180,14 @@ public class WorldPoint
 		return distanceTo2D(other);
 	}
 
-
 	/**
 	 * Find the distance from this point to another point.
+	 * <p>
+	 * This method disregards the plane value of the two tiles and returns
+	 * the simple distance between the X-Z coordinate pairs.
 	 *
-	 * @param other
-	 * @return
+	 * @param other other point
+	 * @return the distance
 	 */
 	public int distanceTo2D(WorldPoint other)
 	{
@@ -160,7 +195,13 @@ public class WorldPoint
 	}
 
 	/**
-	 * Returns a WorldPoint from the passed region coords
+	 * Gets the coordinate of the tile that contains the passed local point.
+	 *
+	 * @param client the client
+	 * @param x the local x-axis coordinate
+	 * @param y the local x-axis coordinate
+	 * @param plane the plane
+	 * @return the tile coordinate containing the local point
 	 */
 	public static WorldPoint fromRegion(Client client, int x, int y, int plane)
 	{
@@ -177,6 +218,11 @@ public class WorldPoint
 		return new Point(x, y);
 	}
 
+	/**
+	 * Gets the ID of the region containing this tile.
+	 *
+	 * @return the region ID
+	 */
 	public int getRegionID()
 	{
 		return ((x >> 6) << 8) | (y >> 6);

--- a/runelite-api/src/main/java/net/runelite/api/events/ActorDeath.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/ActorDeath.java
@@ -27,8 +27,14 @@ package net.runelite.api.events;
 import lombok.Data;
 import net.runelite.api.Actor;
 
+/**
+ * An event where the {@link Actor} has died.
+ */
 @Data
 public class ActorDeath
 {
+	/**
+	 * The player or NPC who died.
+	 */
 	private Actor actor;
 }

--- a/runelite-api/src/main/java/net/runelite/api/events/ActorDespawned.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/ActorDespawned.java
@@ -26,7 +26,31 @@ package net.runelite.api.events;
 
 import net.runelite.api.Actor;
 
+/**
+ * Represents the base event where an {@link Actor} has despawned.
+ * <p>
+ * To hook into a more focused actor type, see the {@link PlayerDespawned}
+ * or {@link NpcDespawned} events.
+ * <p>
+ * Examples of when this event may trigger include:
+ * <ul>
+ *     <li>An actor moving out of render distance</li>
+ *     <li>An actor despawning after death</li>
+ *     <li>Moving out of or away from a region with Actor entities in it</li>
+ * </ul>
+ * <p>
+ * During a world change, the event is only called for Players,
+ * ie. {@link PlayerDespawned} will trigger but {@link NpcDespawned}
+ * will not.
+ * <p>
+ * The client logging out does not trigger this event.
+ */
 public interface ActorDespawned
 {
+	/**
+	 * Gets the despawned player or NPC.
+	 *
+	 * @return despawned entity
+	 */
 	Actor getActor();
 }

--- a/runelite-api/src/main/java/net/runelite/api/events/ActorSpawned.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/ActorSpawned.java
@@ -26,7 +26,25 @@ package net.runelite.api.events;
 
 import net.runelite.api.Actor;
 
+/**
+ * Represents the base event where an {@link Actor} has spawned.
+ * <p>
+ * To hook into a more focused actor type, see the {@link PlayerSpawned}
+ * or {@link NpcSpawned} events.
+ * <p>
+ * Examples of when this event may trigger include:
+ * <ul>
+ *     <li>Entering a new region or area with actors inside</li>
+ *     <li>A player logging in nearby</li>
+ *     <li>An actor moving into render distance</li>
+ * </ul>
+ */
 public interface ActorSpawned
 {
+	/**
+	 * Gets the spawned player or NPC.
+	 *
+	 * @return spawned entity
+	 */
 	Actor getActor();
 }

--- a/runelite-api/src/main/java/net/runelite/api/events/AnimationChanged.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/AnimationChanged.java
@@ -27,8 +27,24 @@ package net.runelite.api.events;
 import lombok.Data;
 import net.runelite.api.Actor;
 
+/**
+ * An event where the {@link Actor} has changed animations.
+ * <p>
+ * In order to get the new animation ID, use {@link Actor#getAnimation()}.
+ * <p>
+ * Examples of when this event may trigger include:
+ * <ul>
+ *     <li>A player starts or stops gathering a resource (ie. woodcut, fishing)</li>
+ *     <li>A player starts or stops dancing</li>
+ * </ul>
+ *
+ * @see net.runelite.api.AnimationID
+ */
 @Data
 public class AnimationChanged
 {
+	/**
+	 * The actor that has entered a new animation.
+	 */
 	private Actor actor;
 }

--- a/runelite-api/src/main/java/net/runelite/api/events/BoostedLevelChanged.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/BoostedLevelChanged.java
@@ -27,8 +27,25 @@ package net.runelite.api.events;
 import lombok.Data;
 import net.runelite.api.Skill;
 
+/**
+ * An event where a players skill level has been temporarily modified.
+ * <p>
+ * Examples of when this event may trigger include:
+ * <ul>
+ *     <li>Prayer points draining or being restored at an altar or restoration pool</li>
+ *     <li>Positive and negative effects gained from potions (ie. Saradomin brew)</li>
+ *     <li>Earning skill points towards a skill</li>
+ *     <li>Levelling up a skill</li>
+ * </ul>
+ * <p>
+ * Use {@link net.runelite.api.Client#getBoostedSkillLevel(Skill)} in order to
+ * retrieve the newly boosted skill level.
+ */
 @Data
 public class BoostedLevelChanged
 {
+	/**
+	 * The skill that has had its level modified.
+	 */
 	private Skill skill;
 }

--- a/runelite-api/src/main/java/net/runelite/api/events/ChatMessage.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/ChatMessage.java
@@ -28,12 +28,35 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import net.runelite.api.ChatMessageType;
 
+/**
+ * An event where a new chat message is received.
+ * <p>
+ * See {@link ChatMessageType} for different message types that can be
+ * received.
+ * <p>
+ * Note: This event will not trigger for NPC dialogues.
+ */
 @Data
 @AllArgsConstructor
 public class ChatMessage
 {
+	/**
+	 * The type of message received.
+	 */
 	private ChatMessageType type;
+	/**
+	 * The name of the player that sent the message.
+	 */
 	private String name;
+	/**
+	 * The contents of the message.
+	 */
 	private String message;
+	/**
+	 * The sender of the message.
+	 * <p>
+	 * This field is only used for clan messages and refers to the
+	 * current name of the clan chat the client is in.
+	 */
 	private String sender;
 }

--- a/runelite-api/src/main/java/net/runelite/api/events/ClanChanged.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/ClanChanged.java
@@ -26,8 +26,14 @@ package net.runelite.api.events;
 
 import lombok.Value;
 
+/**
+ * An event where the client has joined or left a clan chat.
+ */
 @Value
 public class ClanChanged
 {
+	/**
+	 * Whether or not the client is now in a clan chat.
+	 */
 	private boolean joined;
 }

--- a/runelite-api/src/main/java/net/runelite/api/events/CommandExecuted.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/CommandExecuted.java
@@ -26,9 +26,30 @@ package net.runelite.api.events;
 
 import lombok.Value;
 
+/**
+ * An event where a command has been used in the chat.
+ * <p>
+ * Commands are triggered by using the "::" prefix before a chat message. The
+ * structure of a command is "::[name] [args..]" where "[name]" is the name
+ * of the command that is set in the command field, and args are (optional)
+ * words entered that are separated by spaces.
+ * <p>
+ * Typing in "::" with no additional characters will treat the message as normal
+ * and pass it along to the public chat.
+ * <p>
+ * Note that having a space as the first character after the command trigger will
+ * set the command field to an empty string. For example, the message ":: hello world!"
+ * will set command to "" and arguments to ["hello", "world!"].
+ */
 @Value
 public class CommandExecuted
 {
+	/**
+	 * The name of the command entered.
+	 */
 	private String command;
+	/**
+	 * The command arguments that have been entered.
+	 */
 	private String[] arguments;
 }

--- a/runelite-api/src/main/java/net/runelite/api/events/ConfigChanged.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/ConfigChanged.java
@@ -26,11 +26,29 @@ package net.runelite.api.events;
 
 import lombok.Data;
 
+/**
+ * An event where a configuration entry has been modified.
+ */
 @Data
 public class ConfigChanged
 {
+	/**
+	 * The parent group for the key.
+	 * <p>
+	 * Typically set to the name of a plugin to prevent potential collisions
+	 * between other key values that may have the same name.
+	 */
 	private String group;
+	/**
+	 * The configuration key that has been modified.
+	 */
 	private String key;
+	/**
+	 * The previous value of the entry.
+	 */
 	private String oldValue;
+	/**
+	 * The new value of the entry, null if the entry has been unset.
+	 */
 	private String newValue;
 }

--- a/runelite-api/src/main/java/net/runelite/api/events/DecorativeObjectChanged.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/DecorativeObjectChanged.java
@@ -28,10 +28,23 @@ import lombok.Data;
 import net.runelite.api.DecorativeObject;
 import net.runelite.api.Tile;
 
+/**
+ * An event where the {@link DecorativeObject} attached to a {@link Tile}
+ * has been modified.
+ */
 @Data
 public class DecorativeObjectChanged
 {
+	/**
+	 * The affected tile.
+	 */
 	private Tile tile;
+	/**
+	 * The decorative object that has been replaced.
+	 */
 	private DecorativeObject previous;
+	/**
+	 * The new decoration for the tile.
+	 */
 	private DecorativeObject decorativeObject;
 }

--- a/runelite-api/src/main/java/net/runelite/api/events/DecorativeObjectDespawned.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/DecorativeObjectDespawned.java
@@ -28,9 +28,19 @@ import lombok.Data;
 import net.runelite.api.DecorativeObject;
 import net.runelite.api.Tile;
 
+/**
+ * An event where the {@link DecorativeObject} attached to a {@link Tile}
+ * is removed.
+ */
 @Data
 public class DecorativeObjectDespawned
 {
+	/**
+	 * The affected tile.
+	 */
 	private Tile tile;
+	/**
+	 * The removed decorative object.
+	 */
 	private DecorativeObject decorativeObject;
 }

--- a/runelite-api/src/main/java/net/runelite/api/events/DecorativeObjectSpawned.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/DecorativeObjectSpawned.java
@@ -28,9 +28,18 @@ import lombok.Data;
 import net.runelite.api.DecorativeObject;
 import net.runelite.api.Tile;
 
+/**
+ * An event where a {@link DecorativeObject} is attached to a {@link Tile}.
+ */
 @Data
 public class DecorativeObjectSpawned
 {
+	/**
+	 * The affected tile.
+	 */
 	private Tile tile;
+	/**
+	 * The newly spawned decorative object.
+	 */
 	private DecorativeObject decorativeObject;
 }

--- a/runelite-api/src/main/java/net/runelite/api/events/DraggingWidgetChanged.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/DraggingWidgetChanged.java
@@ -26,8 +26,15 @@ package net.runelite.api.events;
 
 import lombok.Data;
 
+/**
+ * Called every game cycle the client is dragging a widget on
+ * the cursor.
+ */
 @Data
 public class DraggingWidgetChanged
 {
+	/**
+	 * Whether a widget is currently being dragged.
+	 */
 	private boolean draggingWidget;
 }

--- a/runelite-api/src/main/java/net/runelite/api/events/ExperienceChanged.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/ExperienceChanged.java
@@ -28,11 +28,14 @@ package net.runelite.api.events;
 import lombok.Data;
 import net.runelite.api.Skill;
 
+/**
+ * An event where the experience level of a {@link Skill} has been modified.
+ */
 @Data
 public class ExperienceChanged
 {
 	/**
-	 * The {@link Skill} that had its experience changed.
+	 * The modified skill.
 	 */
 	private Skill skill;
 }

--- a/runelite-api/src/main/java/net/runelite/api/events/FocusChanged.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/FocusChanged.java
@@ -26,8 +26,21 @@ package net.runelite.api.events;
 
 import lombok.Data;
 
+/**
+ * An event where the focus state of the client changes.
+ * <p>
+ * Examples of when this event may trigger include:
+ * <ul>
+ *     <li>Alt-tabbing to a different window</li>
+ *     <li>Clicking outside the client window</li>
+ *     <li>Clicking the client window from a different focused window</li>
+ * </ul>
+ */
 @Data
 public class FocusChanged
 {
+	/**
+	 * The new focus state.
+	 */
 	private boolean focused;
 }

--- a/runelite-api/src/main/java/net/runelite/api/events/GameObjectChanged.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/GameObjectChanged.java
@@ -28,10 +28,22 @@ import lombok.Data;
 import net.runelite.api.GameObject;
 import net.runelite.api.Tile;
 
+/**
+ * An event where a {@link GameObject} on a {@link Tile} has been replaced.
+ */
 @Data
 public class GameObjectChanged
 {
+	/**
+	 * The affected tile.
+	 */
 	private Tile tile;
+	/**
+	 * The game object that has been replaced.
+	 */
 	private GameObject previous;
+	/**
+	 * The new game object on the tile.
+	 */
 	private GameObject gameObject;
 }

--- a/runelite-api/src/main/java/net/runelite/api/events/GameObjectDespawned.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/GameObjectDespawned.java
@@ -28,9 +28,18 @@ import lombok.Data;
 import net.runelite.api.GameObject;
 import net.runelite.api.Tile;
 
+/**
+ * An event where a {@link GameObject} on a {@link Tile} is removed.
+ */
 @Data
 public class GameObjectDespawned
 {
+	/**
+	 * The affected tile.
+	 */
 	private Tile tile;
+	/**
+	 * The removed game object.
+	 */
 	private GameObject gameObject;
 }

--- a/runelite-api/src/main/java/net/runelite/api/events/GameObjectSpawned.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/GameObjectSpawned.java
@@ -28,9 +28,18 @@ import lombok.Data;
 import net.runelite.api.GameObject;
 import net.runelite.api.Tile;
 
+/**
+ * An event where a {@link GameObject} is added to a {@link Tile}.
+ */
 @Data
 public class GameObjectSpawned
 {
+	/**
+	 * The affected tile.
+	 */
 	private Tile tile;
+	/**
+	 * The newly spawned game object.
+	 */
 	private GameObject gameObject;
 }

--- a/runelite-api/src/main/java/net/runelite/api/events/GameStateChanged.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/GameStateChanged.java
@@ -27,8 +27,14 @@ package net.runelite.api.events;
 import lombok.Data;
 import net.runelite.api.GameState;
 
+/**
+ * An event where the clients game state has changed.
+ */
 @Data
 public class GameStateChanged
 {
+	/**
+	 * The new game state.
+	 */
 	private GameState gameState;
 }

--- a/runelite-api/src/main/java/net/runelite/api/events/GameTick.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/GameTick.java
@@ -26,10 +26,22 @@ package net.runelite.api.events;
 
 import lombok.Data;
 
+// The NPC update event seem to run every server tick,
+// but having the game tick event after all packets
+// have been processed is typically more useful.
+
 /**
- * Event called once per tick.
- *
- * @author Adam
+ * An event called once every game tick, after all packets have processed.
+ * <p>
+ * A game tick is a unit of time used by the RuneScape server that refers to
+ * the time-frame of all actions performed. Each game tick is approximately
+ * 0.6 seconds. All actions are a multiple of this time-frame and include
+ * instances such as when messages appear in the chat interface, experience
+ * being gained, monster spawns and more. All actions registered by the client
+ * within a single tick will begin to occur by the beginning of the next tick.
+ * <p>
+ * Note that occurrences that take place purely on the client, such as right
+ * click menus, are independent of the game tick.
  */
 @Data
 public class GameTick

--- a/runelite-api/src/main/java/net/runelite/api/events/GrandExchangeOfferChanged.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/GrandExchangeOfferChanged.java
@@ -26,10 +26,30 @@ package net.runelite.api.events;
 
 import lombok.Data;
 import net.runelite.api.GrandExchangeOffer;
+import net.runelite.api.GrandExchangeOfferState;
 
+/**
+ * An event where a {@link GrandExchangeOffer} has been updated with
+ * new information.
+ * <p>
+ * When the client initially logs in, this event is called for all grand
+ * exchange slots with the {@link GrandExchangeOfferState#EMPTY} state,
+ * regardless of whether any slots have offers. Once the exchange is
+ * initialized, the client then updates any offers with items as it
+ * receives information from the server.
+ * <p>
+ * See {@link GrandExchangeOfferState} for potential states an offer
+ * can change into.
+ */
 @Data
 public class GrandExchangeOfferChanged
 {
+	/**
+	 * The offer that has been modified.
+	 */
 	private GrandExchangeOffer offer;
+	/**
+	 * The index value of the slot.
+	 */
 	private int slot;
 }

--- a/runelite-api/src/main/java/net/runelite/api/events/GraphicChanged.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/GraphicChanged.java
@@ -27,8 +27,26 @@ package net.runelite.api.events;
 import lombok.Data;
 import net.runelite.api.Actor;
 
+/**
+ * An event where the graphic of an {@link Actor} has changed.
+ * <p>
+ * The graphic the player has changed to can be obtained using
+ * {@link Actor#getGraphic()}.
+ * <p>
+ * Examples of when this event may trigger include:
+ * <ul>
+ *     <li>Casting a magic spell</li>
+ *     <li>Using a fairy ring</li>
+ *     <li>Breaking a teleport tab</li>
+ * </ul>
+ *
+ * @see net.runelite.api.GraphicID
+ */
 @Data
 public class GraphicChanged
 {
+	/**
+	 * The actor that has had their graphic changed.
+	 */
 	private Actor actor;
 }

--- a/runelite-api/src/main/java/net/runelite/api/events/GraphicsObjectCreated.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/GraphicsObjectCreated.java
@@ -27,8 +27,14 @@ package net.runelite.api.events;
 import lombok.Value;
 import net.runelite.api.GraphicsObject;
 
+/**
+ * An event where a new {@link GraphicsObject} has been created.
+ */
 @Value
 public class GraphicsObjectCreated
 {
+	/**
+	 * The newly created graphics object.
+	 */
 	private final GraphicsObject graphicsObject;
 }

--- a/runelite-api/src/main/java/net/runelite/api/events/GroundObjectChanged.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/GroundObjectChanged.java
@@ -28,10 +28,22 @@ import lombok.Data;
 import net.runelite.api.GroundObject;
 import net.runelite.api.Tile;
 
+/**
+ * An event where the {@link GroundObject} on a {@link Tile} has been changed.
+ */
 @Data
 public class GroundObjectChanged
 {
+	/**
+	 * The affected tile.
+	 */
 	private Tile tile;
+	/**
+	 * The ground object that has been replaced.
+	 */
 	private GroundObject previous;
+	/**
+	 * The new ground object on the tile.
+	 */
 	private GroundObject groundObject;
 }

--- a/runelite-api/src/main/java/net/runelite/api/events/GroundObjectDespawned.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/GroundObjectDespawned.java
@@ -28,9 +28,18 @@ import lombok.Data;
 import net.runelite.api.GroundObject;
 import net.runelite.api.Tile;
 
+/**
+ * An event where a {@link GroundObject} on a {@link Tile} has been removed.
+ */
 @Data
 public class GroundObjectDespawned
 {
+	/**
+	 * The affected tile.
+	 */
 	private Tile tile;
+	/**
+	 * The removed ground object.
+	 */
 	private GroundObject groundObject;
 }

--- a/runelite-api/src/main/java/net/runelite/api/events/GroundObjectSpawned.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/GroundObjectSpawned.java
@@ -28,9 +28,18 @@ import lombok.Data;
 import net.runelite.api.GroundObject;
 import net.runelite.api.Tile;
 
+/**
+ * An event where a {@link GroundObject} is added to a {@link Tile}.
+ */
 @Data
 public class GroundObjectSpawned
 {
+	/**
+	 * The affected tile.
+	 */
 	private Tile tile;
+	/**
+	 * The newly spawned ground object.
+	 */
 	private GroundObject groundObject;
 }

--- a/runelite-api/src/main/java/net/runelite/api/events/HitsplatApplied.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/HitsplatApplied.java
@@ -28,9 +28,22 @@ import lombok.Data;
 import net.runelite.api.Actor;
 import net.runelite.api.Hitsplat;
 
+/**
+ * An event called when a {@link Hitsplat} is processed on an {@link Actor}.
+ * <p>
+ * This event is called regardless of whether or not the hitsplat was
+ * rendered. An example of this occuring would be if the actor has 4
+ * visible hitsplats.
+ */
 @Data
 public class HitsplatApplied
 {
+	/**
+	 * The actor the hitsplat was applied to.
+	 */
 	private Actor actor;
+	/**
+	 * The applied hitsplat.
+	 */
 	private Hitsplat hitsplat;
 }

--- a/runelite-api/src/main/java/net/runelite/api/events/ItemContainerChanged.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/ItemContainerChanged.java
@@ -27,8 +27,22 @@ package net.runelite.api.events;
 import lombok.Value;
 import net.runelite.api.ItemContainer;
 
+/**
+ * An event called whenever the stack size of an {@link net.runelite.api.Item}
+ * in an {@link ItemContainer} is modified.
+ * <p>
+ * Examples of when this event may trigger include:
+ * <ul>
+ *     <li>Withdrawing an item from bank (triggers for both bank and player inv)
+ *     <li>Picking up an item</li>
+ *     <li>Dropping an item</li>
+ * </ul>
+ */
 @Value
 public class ItemContainerChanged
 {
+	/**
+	 * The modified item container.
+	 */
 	private final ItemContainer itemContainer;
 }

--- a/runelite-api/src/main/java/net/runelite/api/events/ItemLayerChanged.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/ItemLayerChanged.java
@@ -27,8 +27,22 @@ package net.runelite.api.events;
 import lombok.Value;
 import net.runelite.api.Tile;
 
+/**
+ * An event called when an item pile on a {@link Tile} is modified.
+ * <p>
+ * Examples of when this event may trigger include:
+ * <ul>
+ *     <li>Dropping an item</li>
+ *     <li>Picking up an item</li>
+ *     <li>A dropped item spawning</li>
+ *     <li>Loading a region with dropped items</li>
+ * </ul>
+ */
 @Value
 public class ItemLayerChanged
 {
+	/**
+	 * The affected tile.
+	 */
 	private Tile tile;
 }

--- a/runelite-api/src/main/java/net/runelite/api/events/MapRegionChanged.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/MapRegionChanged.java
@@ -25,11 +25,20 @@
 package net.runelite.api.events;
 
 import lombok.Data;
+import net.runelite.api.Client;
 
+/**
+ * An event where a map region has been modified.
+ * <p>
+ * This event exposes the index into the map that is changing,
+ * the value of which can be obtained by using the index with
+ * the {@link Client#getMapRegions()} array.
+ */
 @Data
 public class MapRegionChanged
 {
-	/** index into the region map that is changing
+	/**
+	 * The map region index.
 	 */
 	private int index;
 }

--- a/runelite-api/src/main/java/net/runelite/api/events/MenuEntryAdded.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/MenuEntryAdded.java
@@ -27,14 +27,38 @@ package net.runelite.api.events;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
+/**
+ * An event when a new entry is added to a right-click menu.
+ */
 @Data
 @AllArgsConstructor
 public class MenuEntryAdded
 {
-	private String option;
-	private String target;
-	private int type;
-	private int identifier;
-	private int actionParam0;
-	private int actionParam1;
+	/**
+	 * The option text added to the menu (ie. "Walk here", "Use").
+	 */
+	private final String option;
+	/**
+	 * The target of the action (ie. Item or Actor name).
+	 * <p>
+	 * If the option does not apply to any target, this field
+	 * will be set to empty string.
+	 */
+	private final String target;
+	/**
+	 * The action type that will be triggered.
+	 */
+	private final int type;
+	/**
+	 * An identifier value for the target of the action
+	 */
+	private final int identifier;
+	/**
+	 * An additional parameter for the action.
+	 */
+	private final int actionParam0;
+	/**
+	 * A second additional parameter for the action.
+	 */
+	private final int actionParam1;
 }

--- a/runelite-api/src/main/java/net/runelite/api/events/MenuOpened.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/MenuOpened.java
@@ -27,11 +27,25 @@ package net.runelite.api.events;
 import lombok.Data;
 import net.runelite.api.MenuEntry;
 
+/**
+ * An event where a menu has been opened.
+ */
 @Data
 public class MenuOpened
 {
+	/**
+	 * The menu entries in the newly opened menu.
+	 * <p>
+	 * The entries in this menu are reversed, the last entry in the
+	 * array will appear first (at the top) in the opened menu.
+	 */
 	private MenuEntry[] menuEntries;
 
+	/**
+	 * Gets the entry that will be displayed first in the menu.
+	 *
+	 * @return the first entry
+	 */
 	public MenuEntry getFirstEntry()
 	{
 		if (menuEntries.length > 0)

--- a/runelite-api/src/main/java/net/runelite/api/events/MenuOptionClicked.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/MenuOptionClicked.java
@@ -27,17 +27,58 @@ package net.runelite.api.events;
 import lombok.Data;
 import net.runelite.api.MenuAction;
 
+/**
+ * An event where a menu option has been clicked.
+ * <p>
+ * This event does not only trigger when clicking an option in a
+ * right-clicked menu. The event will trigger for any left click
+ * action performed (ie. clicking an item, walking to a tile, etc) as
+ * well as any right-click menu option.
+ * <p>
+ * By default, when there is no action performed when left-clicking,
+ * it seems that this event still triggers with the "Cancel" action.
+ */
 @Data
 public class MenuOptionClicked
 {
+	/**
+	 * The action parameter used in the click.
+	 */
 	private int actionParam;
+	/**
+	 * The option text added to the menu.
+	 */
 	private String menuOption;
+	/**
+	 * The target of the action.
+	 */
 	private String menuTarget;
+	/**
+	 * The action performed.
+	 */
 	private MenuAction menuAction;
+	/**
+	 * The ID of the object, actor, or item that the interaction targets.
+	 */
 	private int id;
+	/**
+	 * The ID of the widget where the menu was clicked.
+	 *
+	 * @see net.runelite.api.widgets.WidgetID
+	 */
 	private int widgetId;
+	/**
+	 * Whether or not the event has been consumed by a subscriber.
+	 */
 	private boolean consumed;
 
+	/**
+	 * Marks the event as having been consumed.
+	 * <p>
+	 * Setting this state indicates that a plugin has processed the menu
+	 * option being clicked and that the event will not be passed on
+	 * for handling by vanilla client code.
+	 */
 	public void consume()
 	{
 		this.consumed = true;

--- a/runelite-api/src/main/java/net/runelite/api/events/NameableNameChanged.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/NameableNameChanged.java
@@ -28,10 +28,13 @@ import lombok.Value;
 import net.runelite.api.Nameable;
 
 /**
- * Event called when a nameable name changes
+ * An event where a {@link Nameable} has had their name changed.
  */
 @Value
 public class NameableNameChanged
 {
+	/**
+	 * The nameable that changed names.
+	 */
 	private final Nameable nameable;
 }

--- a/runelite-api/src/main/java/net/runelite/api/events/NpcActionChanged.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/NpcActionChanged.java
@@ -27,9 +27,18 @@ package net.runelite.api.events;
 import lombok.Data;
 import net.runelite.api.NPCComposition;
 
+/**
+ * An event where an action of an {@link NPCComposition} has changed.
+ */
 @Data
 public class NpcActionChanged
 {
+	/**
+	 * The NPC composition that has been changed.
+	 */
 	private NPCComposition npcComposition;
+	/**
+	 * The raw index of the modified action.
+	 */
 	private int idx;
 }

--- a/runelite-api/src/main/java/net/runelite/api/events/NpcDespawned.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/NpcDespawned.java
@@ -28,9 +28,15 @@ import lombok.Value;
 import net.runelite.api.Actor;
 import net.runelite.api.NPC;
 
+/**
+ * An event where an {@link NPC} has despawned.
+ */
 @Value
 public class NpcDespawned implements ActorDespawned
 {
+	/**
+	 * The despawned NPC.
+	 */
 	private final NPC npc;
 
 	@Override

--- a/runelite-api/src/main/java/net/runelite/api/events/NpcSpawned.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/NpcSpawned.java
@@ -28,9 +28,15 @@ import lombok.Value;
 import net.runelite.api.Actor;
 import net.runelite.api.NPC;
 
+/**
+ * An event where an {@link NPC} has spawned.
+ */
 @Value
 public class NpcSpawned implements ActorSpawned
 {
+	/**
+	 * The spawned NPC.
+	 */
 	private final NPC npc;
 
 	@Override

--- a/runelite-api/src/main/java/net/runelite/api/events/PlayerDespawned.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/PlayerDespawned.java
@@ -28,9 +28,15 @@ import lombok.Value;
 import net.runelite.api.Actor;
 import net.runelite.api.Player;
 
+/**
+ * An event where a {@link Player} has despawned.
+ */
 @Value
 public class PlayerDespawned implements ActorDespawned
 {
+	/**
+	 * The despawned player.
+	 */
 	private final Player player;
 
 	@Override

--- a/runelite-api/src/main/java/net/runelite/api/events/PlayerMenuOptionClicked.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/PlayerMenuOptionClicked.java
@@ -26,9 +26,19 @@ package net.runelite.api.events;
 
 import lombok.Data;
 
+/**
+ * An event where a player menu option that was added by RuneLite has
+ * been clicked (ie. HiScore Lookup).
+ */
 @Data
 public class PlayerMenuOptionClicked
 {
+	/**
+	 * The menu option clicked.
+	 */
 	private String menuOption;
+	/**
+	 * The target player.
+	 */
 	private String menuTarget;
 }

--- a/runelite-api/src/main/java/net/runelite/api/events/PlayerMenuOptionsChanged.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/PlayerMenuOptionsChanged.java
@@ -30,7 +30,7 @@ import lombok.Data;
 public class PlayerMenuOptionsChanged
 {
 	/**
-	 * Index in playerOptions which changed
+	 * Index in playerOptions which changed.
 	 */
 	private int index;
 }

--- a/runelite-api/src/main/java/net/runelite/api/events/PlayerSpawned.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/PlayerSpawned.java
@@ -28,9 +28,15 @@ import lombok.Value;
 import net.runelite.api.Actor;
 import net.runelite.api.Player;
 
+/**
+ * An event where a {@link Player} has spawned.
+ */
 @Value
 public class PlayerSpawned implements ActorSpawned
 {
+	/**
+	 * The spawned player.
+	 */
 	private final Player player;
 
 	@Override

--- a/runelite-api/src/main/java/net/runelite/api/events/PostItemComposition.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/PostItemComposition.java
@@ -27,8 +27,15 @@ package net.runelite.api.events;
 import lombok.Data;
 import net.runelite.api.ItemComposition;
 
+/**
+ * An event called after a new {@link ItemComposition} is created and
+ * its data is initialized.
+ */
 @Data
 public class PostItemComposition
 {
+	/**
+	 * The newly created item.
+	 */
 	private ItemComposition itemComposition;
 }

--- a/runelite-api/src/main/java/net/runelite/api/events/ProjectileMoved.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/ProjectileMoved.java
@@ -28,10 +28,25 @@ import lombok.Data;
 import net.runelite.api.Projectile;
 import net.runelite.api.coords.LocalPoint;
 
+/**
+ * An event called whenever a {@link Projectile} has moved towards a point.
+ * <p>
+ * For projectiles that target the ground, this event is only triggered
+ * once (ie. AoE from Lizardman Shaman).
+ */
 @Data
 public class ProjectileMoved
 {
+	/**
+	 * The projectile being moved.
+	 */
 	private Projectile projectile;
+	/**
+	 * The target location of the projectile.
+	 */
 	private LocalPoint position;
+	/**
+	 * The z-axis target location of the projectile.
+	 */
 	private int z;
 }

--- a/runelite-api/src/main/java/net/runelite/api/events/RemovedFriend.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/RemovedFriend.java
@@ -27,10 +27,13 @@ package net.runelite.api.events;
 import lombok.Value;
 
 /**
- * Called when a request to remove a friend is sent to the server
+ * An event where a request to remove a friend is sent to the server.
  */
 @Value
 public class RemovedFriend
 {
+	/**
+	 * The name of the removed friend.
+	 */
 	private final String name;
 }

--- a/runelite-api/src/main/java/net/runelite/api/events/ResizeableChanged.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/ResizeableChanged.java
@@ -28,8 +28,14 @@ package net.runelite.api.events;
 
 import lombok.Data;
 
+/**
+ * An event where the client window has been resized.
+ */
 @Data
 public class ResizeableChanged
 {
+	/**
+	 * Whether the window is resized.
+	 */
 	private boolean isResized;
 }

--- a/runelite-api/src/main/java/net/runelite/api/events/ScriptCallbackEvent.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/ScriptCallbackEvent.java
@@ -27,9 +27,18 @@ package net.runelite.api.events;
 import lombok.Data;
 import net.runelite.api.Script;
 
+/**
+ * An event where a Runelite ASM script is called.
+ */
 @Data
 public class ScriptCallbackEvent
 {
+	/**
+	 * The script being called.
+	 */
 	private Script script;
+	/**
+	 * The name of the event that triggered script execution.
+	 */
 	private String eventName;
 }

--- a/runelite-api/src/main/java/net/runelite/api/events/SessionClose.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/SessionClose.java
@@ -26,6 +26,13 @@ package net.runelite.api.events;
 
 import lombok.Data;
 
+/**
+ * An event where a new RuneLite account session has been closed,
+ * typically when logging out of the account.
+ * <p>
+ * Note: This event is not to be confused with a RuneScape session,
+ * it has nothing to do with whether an account is being logged out.
+ */
 @Data
 public class SessionClose
 {

--- a/runelite-api/src/main/java/net/runelite/api/events/SessionOpen.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/SessionOpen.java
@@ -27,8 +27,11 @@ package net.runelite.api.events;
 import lombok.Data;
 
 /**
- * Called when a session has been opened with the server
- * @author Adam
+ * An event where a new RuneLite account session has been opened
+ * with the server.
+ * <p>
+ * Note: This event is not to be confused with a RuneScape session,
+ * it has nothing to do with whether an account is being logged in.
  */
 @Data
 public class SessionOpen

--- a/runelite-api/src/main/java/net/runelite/api/events/SetMessage.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/SetMessage.java
@@ -5,16 +5,35 @@ import net.runelite.api.ChatMessageType;
 import net.runelite.api.MessageNode;
 
 /**
- * called when a message node's message is set
- *
- * @author Adam
+ * An event where a {@link MessageNode} has had its message set.
+ * <p>
+ * Called whenever a message is received in the chat box.
+ * <p>
+ * Editing the {@link #messageNode} properties will reflect the change when
+ * the message in the chat is rendered. The original values of the message
+ * are held by the other fields of this event.
  */
 @Data
 public class SetMessage
 {
+	/**
+	 * The updated message node.
+	 */
 	private MessageNode messageNode;
+	/**
+	 * The set message type.
+	 */
 	private ChatMessageType type;
+	/**
+	 * The name of the player that sent the message.
+	 */
 	private String name;
+	/**
+	 * The sender of the message (ie. clan name).
+	 */
 	private String sender;
+	/**
+	 * The new message value.
+	 */
 	private String value;
 }

--- a/runelite-api/src/main/java/net/runelite/api/events/UsernameChanged.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/UsernameChanged.java
@@ -24,6 +24,12 @@
  */
 package net.runelite.api.events;
 
+/**
+ * An event where the username the client will log in with has changed.
+ * <p>
+ * This event triggers for every character change to the username
+ * in the login screen.
+ */
 public class UsernameChanged
 {
 }

--- a/runelite-api/src/main/java/net/runelite/api/events/VarClientIntChanged.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/VarClientIntChanged.java
@@ -27,6 +27,9 @@ package net.runelite.api.events;
 
 import lombok.Value;
 
+/**
+ * An event where a varbit integer has changed.
+ */
 @Value
 public class VarClientIntChanged
 {

--- a/runelite-api/src/main/java/net/runelite/api/events/VarClientStrChanged.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/VarClientStrChanged.java
@@ -27,6 +27,9 @@ package net.runelite.api.events;
 
 import lombok.Value;
 
+/**
+ * An event where a varbit string has changed.
+ */
 @Value
 public class VarClientStrChanged
 {

--- a/runelite-api/src/main/java/net/runelite/api/events/VarbitChanged.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/VarbitChanged.java
@@ -28,6 +28,9 @@ package net.runelite.api.events;
 
 import lombok.Data;
 
+/**
+ * An event where a varbit has changed.
+ */
 @Data
 public class VarbitChanged
 {

--- a/runelite-api/src/main/java/net/runelite/api/events/WallObjectChanged.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/WallObjectChanged.java
@@ -28,10 +28,22 @@ import lombok.Data;
 import net.runelite.api.Tile;
 import net.runelite.api.WallObject;
 
+/**
+ * An event where the {@link WallObject} of a {@link Tile} has been changed.
+ */
 @Data
 public class WallObjectChanged
 {
+	/**
+	 * The affected tile.
+	 */
 	private Tile tile;
+	/**
+	 * The wall object that has been replaced.
+	 */
 	private WallObject previous;
+	/**
+	 * The new wall object on the tile.
+	 */
 	private WallObject wallObject;
 }

--- a/runelite-api/src/main/java/net/runelite/api/events/WallObjectDespawned.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/WallObjectDespawned.java
@@ -28,9 +28,18 @@ import lombok.Data;
 import net.runelite.api.Tile;
 import net.runelite.api.WallObject;
 
+/**
+ * An event where a {@link WallObject} on a {@link Tile} has been removed.
+ */
 @Data
 public class WallObjectDespawned
 {
+	/**
+	 * The affected tile.
+	 */
 	private Tile tile;
+	/**
+	 * The removed wall object.
+	 */
 	private WallObject wallObject;
 }

--- a/runelite-api/src/main/java/net/runelite/api/events/WallObjectSpawned.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/WallObjectSpawned.java
@@ -28,9 +28,18 @@ import lombok.Data;
 import net.runelite.api.Tile;
 import net.runelite.api.WallObject;
 
+/**
+ * An event where a {@link WallObject} is added to a {@link Tile}.
+ */
 @Data
 public class WallObjectSpawned
 {
+	/**
+	 * The affected tile.
+	 */
 	private Tile tile;
+	/**
+	 * The newly spawned wall object.
+	 */
 	private WallObject wallObject;
 }

--- a/runelite-api/src/main/java/net/runelite/api/events/WidgetHiddenChanged.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/WidgetHiddenChanged.java
@@ -27,9 +27,18 @@ package net.runelite.api.events;
 import lombok.Data;
 import net.runelite.api.widgets.Widget;
 
+/**
+ * An event where the hidden state of a {@link Widget} has been modified.
+ */
 @Data
 public class WidgetHiddenChanged
 {
+	/**
+	 * The affected widget.
+	 */
 	private Widget widget;
+	/**
+	 * The new hidden state of the widget.
+	 */
 	private boolean hidden;
 }

--- a/runelite-api/src/main/java/net/runelite/api/events/WidgetLoaded.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/WidgetLoaded.java
@@ -26,8 +26,14 @@ package net.runelite.api.events;
 
 import lombok.Data;
 
+/**
+ * An event where a {@link net.runelite.api.widgets.Widget} has been loaded.
+ */
 @Data
 public class WidgetLoaded
 {
+	/**
+	 * The group ID of the loaded widget.
+	 */
 	private int groupId;
 }

--- a/runelite-api/src/main/java/net/runelite/api/events/WidgetMenuOptionClicked.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/WidgetMenuOptionClicked.java
@@ -27,10 +27,22 @@ package net.runelite.api.events;
 import lombok.Data;
 import net.runelite.api.widgets.WidgetInfo;
 
+/**
+ * An event where an option has been clicked in a {@link net.runelite.api.widgets.Widget}s menu.
+ */
 @Data
 public class WidgetMenuOptionClicked
 {
+	/**
+	 * The clicked menu option.
+	 */
 	private String menuOption;
+	/**
+	 * The clicked menu target.
+	 */
 	private String menuTarget;
+	/**
+	 * The type of widget that was clicked.
+	 */
 	private WidgetInfo widget;
 }

--- a/runelite-api/src/main/java/net/runelite/api/events/WidgetPositioned.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/WidgetPositioned.java
@@ -26,6 +26,10 @@ package net.runelite.api.events;
 
 import lombok.Value;
 
+/**
+ * An event where the position of a {@link net.runelite.api.widgets.Widget}
+ * relative to its parent has changed.
+ */
 @Value
 public class WidgetPositioned
 {

--- a/runelite-api/src/main/java/net/runelite/api/kit/KitType.java
+++ b/runelite-api/src/main/java/net/runelite/api/kit/KitType.java
@@ -24,6 +24,16 @@
  */
 package net.runelite.api.kit;
 
+import net.runelite.api.PlayerComposition;
+
+/**
+ * Represents an equipment slot in a players composition.
+ * <p>
+ * These values are intended for use with {@link PlayerComposition} equipment
+ * slots. For obtaining information about equipment in the local players
+ * equipment {@link net.runelite.api.ItemContainer}, use
+ * {@link net.runelite.api.EquipmentInventorySlot}.
+ */
 public enum KitType
 {
 	CAPE(1),
@@ -37,15 +47,21 @@ public enum KitType
 	BOOTS(10),
 	JAW(11);
 
-	/** index into player composition equipment ids
+	/**
+	 * Raw equipment index.
 	 */
 	private final int index;
 
-	private KitType(int index)
+	KitType(int index)
 	{
 		this.index = index;
 	}
 
+	/**
+	 * Gets the raw equipment index for use in {@link PlayerComposition#getEquipmentIds()}.
+	 *
+	 * @return raw equipment index
+	 */
 	public int getIndex()
 	{
 		return index;

--- a/runelite-api/src/main/java/net/runelite/api/model/Jarvis.java
+++ b/runelite-api/src/main/java/net/runelite/api/model/Jarvis.java
@@ -29,17 +29,23 @@ import java.util.List;
 import net.runelite.api.Point;
 
 /**
- * Implementation of the Jarvis march algorithm
- * https://en.wikipedia.org/wiki/Gift_wrapping_algorithm
- * @author adam
+ * Provides utility methods for computing the convex hull of a list of
+ * <em>n</em> points.
+ * <p>
+ * The implementation uses the Jarvis march algorithm and runs in O(nh)
+ * time in the worst case, where n is the number of points and h the
+ * number of points on the convex hull.
  */
 public class Jarvis
 {
 	/**
-	 * compute the convex hull of a given set of points
+	 * Computes and returns the convex hull of the passed points.
+	 * <p>
+	 * The size of the list must be at least 4, otherwise this method will
+	 * return null.
 	 *
-	 * @param points
-	 * @return
+	 * @param points list of points
+	 * @return list containing the points part of the convex hull
 	 */
 	public static List<Point> convexHull(List<Point> points)
 	{

--- a/runelite-api/src/main/java/net/runelite/api/model/Triangle.java
+++ b/runelite-api/src/main/java/net/runelite/api/model/Triangle.java
@@ -26,6 +26,9 @@ package net.runelite.api.model;
 
 import lombok.Value;
 
+/**
+ * Represents 3 vertices as a three-dimensional Triangle.
+ */
 @Value
 public class Triangle
 {
@@ -40,6 +43,12 @@ public class Triangle
 		this.c = c;
 	}
 
+	/**
+	 * Rotates the triangle by the given orientation.
+	 *
+	 * @param orientation passed orientation
+	 * @return new instance
+	 */
 	public Triangle rotate(int orientation)
 	{
 		return new Triangle(

--- a/runelite-api/src/main/java/net/runelite/api/model/Vertex.java
+++ b/runelite-api/src/main/java/net/runelite/api/model/Vertex.java
@@ -27,6 +27,9 @@ package net.runelite.api.model;
 import lombok.Value;
 import net.runelite.api.Perspective;
 
+/**
+ * Represents a point in a three-dimensional space.
+ */
 @Value
 public class Vertex
 {
@@ -42,9 +45,10 @@ public class Vertex
 	}
 
 	/**
-	 * Rotate the vertex by the given orientation
-	 * @param orientation
-	 * @return the newly rotated vertex
+	 * Rotates the triangle by the given orientation.
+	 *
+	 * @param orientation passed orientation
+	 * @return new instance
 	 */
 	public Vertex rotate(int orientation)
 	{

--- a/runelite-api/src/main/java/net/runelite/api/vars/AccountType.java
+++ b/runelite-api/src/main/java/net/runelite/api/vars/AccountType.java
@@ -29,13 +29,25 @@ package net.runelite.api.vars;
  */
 public enum AccountType
 {
+	/**
+	 * Normal account type.
+	 */
 	NORMAL,
+	/**
+	 * Ironman account type.
+	 */
 	IRONMAN,
+	/**
+	 * Ultimate ironman account type.
+	 */
 	ULTIMATE_IRONMAN,
+	/**
+	 * Hardcore ironman account type.
+	 */
 	HARDCORE_IRONMAN;
 
 	/**
-	 * Check if the {@code AccountType} is any of the possible ironman types.
+	 * Checks whether this type is an ironman.
 	 *
 	 * @return {@code true} if the type is any of the ironman types.
 	 */

--- a/runelite-api/src/main/java/net/runelite/api/vars/Autoweed.java
+++ b/runelite-api/src/main/java/net/runelite/api/vars/Autoweed.java
@@ -24,9 +24,21 @@
  */
 package net.runelite.api.vars;
 
+/**
+ * An enumeration of possible autoweed settings.
+ */
 public enum Autoweed
 {
+	/**
+	 * Access to autoweed has not been unlocked.
+	 */
 	UNOWNED,
+	/**
+	 * Autoweed is disabled.
+	 */
 	OFF,
+	/**
+	 * Autoweed is enabled.
+	 */
 	ON
 }

--- a/runelite-api/src/main/java/net/runelite/api/widgets/Widget.java
+++ b/runelite-api/src/main/java/net/runelite/api/widgets/Widget.java
@@ -28,97 +28,330 @@ import java.awt.Rectangle;
 import java.util.Collection;
 import net.runelite.api.Point;
 
+/**
+ * Represents an on-screen UI element that is drawn on the canvas.
+ * <p>
+ * It should be noted that unique RuneLite elements are note widgets
+ * themselves, and that Widgets are primarily RuneScape elements.
+ * <p>
+ * Examples of Widgets include:
+ * <ul>
+ *     <li>The fairy ring configuration selector</li>
+ *     <li>The mini-map</li>
+ *     <li>The bank inventory</li>
+ * </ul>
+ * <p>
+ * For a more complete idea of what is classified as a widget, see {@link WidgetID}.
+ */
 public interface Widget
 {
+	/**
+	 * Gets the widgets ID.
+	 *
+	 * @return the widget ID
+	 * @see WidgetID
+	 */
 	int getId();
 
+	/**
+	 * Gets the type of the widget.
+	 *
+	 * @return the widget type
+	 */
 	int getType();
 
+	/**
+	 * Sets the type of the widget.
+	 *
+	 * @param type the new widget type
+	 */
 	void setType(int type);
 
+	/**
+	 * Gets the type of content displayed by the widget.
+	 *
+	 * @return the content type
+	 */
 	int getContentType();
 
+	/**
+	 * Sets the type of content displayed by the widget.
+	 *
+	 * @param contentType the new content type
+	 */
 	void setContentType(int contentType);
 
+	/**
+	 * Gets the current click configuration of the widget.
+	 *
+	 * @return the click configuration
+	 */
 	int getClickMask();
 
+	/**
+	 * Sets the click configuration of the widget.
+	 *
+	 * @param mask the new configuration
+	 */
 	void setClickMask(int mask);
 
+	/**
+	 * Gets the parent widget, if this widget is a child.
+	 *
+	 * @return the parent widget, or null
+	 */
 	Widget getParent();
 
+	/**
+	 * Gets the ID of the parent widget.
+	 *
+	 * @return the parent ID, or -1 if this widget is not a child
+	 */
 	int getParentId();
 
+	/**
+	 * Safely gets a child widget at a specific index from {@link #getChildren}.
+	 *
+	 * @param index the raw index into the array
+	 * @return child widget, or null if the index does not exist
+	 */
 	Widget getChild(int index);
 
+	/**
+	 * Gets all children of this widget.
+	 *
+	 * @return the widgets children
+	 */
 	Widget[] getChildren();
 
+	/**
+	 * Gets all dynamic children.
+	 *
+	 * @return the dynamic children
+	 */
 	Widget[] getDynamicChildren();
 
+	/**
+	 * Gets all static children.
+	 *
+	 * @return the static children
+	 */
 	Widget[] getStaticChildren();
 
+	/**
+	 * Gets all nested children.
+	 *
+	 * @return the nested children
+	 */
 	Widget[] getNestedChildren();
 
+	/**
+	 * Gets the relative x-axis coordinate to the widgets parent.
+	 *
+	 * @return the relative x-axis coordinate
+	 */
 	int getRelativeX();
 
+	/**
+	 * Sets the relative x-axis coordinate to the widgets parent.
+	 *
+	 * @param x the new relative coordinate
+	 */
 	void setRelativeX(int x);
 
+	/**
+	 * Gets the relative y-axis coordinate to the widgets parent.
+	 *
+	 * @return the relative coordinate
+	 */
 	int getRelativeY();
 
+	/**
+	 * Sets the relative y-axis coordinate to the widgets parent.
+	 *
+	 * @param y the new relative coordinate
+	 */
 	void setRelativeY(int y);
 
+	/**
+	 * Gets the text displayed on this widget.
+	 *
+	 * @return the displayed text
+	 */
 	String getText();
 
+	/**
+	 * Sets the text displayed on this widget.
+	 *
+	 * @param text the text to display
+	 */
 	void setText(String text);
 
+	/**
+	 * Gets the text color as an RGB value.
+	 *
+	 * @return the text color
+	 * @see java.awt.Color#getRGB()
+	 */
 	int getTextColor();
 
+	/**
+	 * Sets the RGB color of the displayed text.
+	 *
+	 * @param textColor the new text color
+	 * @see java.awt.Color#getRGB()
+	 */
 	void setTextColor(int textColor);
 
+	/**
+	 * Gets the name of the widget.
+	 * <p>
+	 * The name of the widget is used in the tooltip when an action is
+	 * available. For example, the widget that activates quick prayers
+	 * has the name "Quick-prayers" so when hovering there is a tooltip
+	 * that says "Activate Quick-prayers".
+	 *
+	 * @return the name
+	 */
 	String getName();
 
+	/**
+	 * Sets the name of the widget.
+	 *
+	 * @param name the new name
+	 */
 	void setName(String name);
 
+	/**
+	 * Gets the model ID displayed in the widget.
+	 *
+	 * @return the model ID
+	 */
 	int getModelId();
 
+	/**
+	 * Gets the sprite ID displayed in the widget.
+	 *
+	 * @return the sprite ID
+	 * @see net.runelite.api.SpriteID
+	 */
 	int getSpriteId();
 
+	/**
+	 * Sets the sprite ID displayed in the widget.
+	 *
+	 * @param spriteId the sprite ID
+	 * @see net.runelite.api.SpriteID
+	 */
 	void setSpriteId(int spriteId);
 
 	/**
-	 * @return True if this widget or any of it's parents are hidden
+	 * Checks whether this widget or any of its parents are hidden.
+	 *
+	 * @return true if this widget or any parent is hidden, false otherwise
 	 */
 	boolean isHidden();
 
 	/**
-	 * @return True if this widget, regardless of it's parent's state
+	 * Checks whether this widget is hidden, not taking into account
+	 * any parent hidden states.
+	 *
+	 * @return true if this widget is hidden, false otherwise
 	 */
 	boolean isSelfHidden();
 
 	/**
-	 * Sets if this element is hidden as returned by isSelfHidden()
+	 * Sets the hidden state of this widget.
+	 *
+	 * @param hidden new hidden state
 	 */
 	void setHidden(boolean hidden);
 
+	/**
+	 * Gets the location the widget is being drawn on the canvas.
+	 * <p>
+	 * This method accounts for the relative coordinates and bounds
+	 * of any parent widgets.
+	 *
+	 * @return the upper-left coordinate of where this widget is drawn
+	 */
 	Point getCanvasLocation();
 
+	/**
+	 * Gets the width of the widget.
+	 * <p>
+	 * If this widget is storing any {@link WidgetItem}s, this value is
+	 * used to store the number of item slot columns.
+	 *
+	 * @return the width
+	 */
 	int getWidth();
 
+	/**
+	 * Sets the width of the widget.
+	 *
+	 * @param width the new width
+	 */
 	void setWidth(int width);
 
+	/**
+	 * Gets the height of the widget.
+	 *
+	 * @return the height
+	 */
 	int getHeight();
 
+	/**
+	 * Sets the height of the widget.
+	 *
+	 * @param height the new height
+	 */
 	void setHeight(int height);
 
+	/**
+	 * Gets the area where the widget is drawn on the canvas.
+	 *
+	 * @return the occupied area of the widget
+	 */
 	Rectangle getBounds();
 
+	/**
+	 * Gets any items that are being displayed in the widget.
+	 *
+	 * @return any items displayed, or null if there are no items
+	 */
 	Collection<WidgetItem> getWidgetItems();
 
+	/**
+	 * Gets a widget item at a specific index.
+	 *
+	 * @param index index of the item
+	 * @return the widget item at index, or null if an item at index
+	 * 		   does not exist
+	 */
 	WidgetItem getWidgetItem(int index);
 
+	/**
+	 * Gets the item ID displayed by the widget.
+	 *
+	 * @return the item ID
+	 */
 	int getItemId();
 
+	/**
+	 * Gets the quantity of the item displayed by the widget.
+	 *
+	 * @return the item quantity
+	 */
 	int getItemQuantity();
-	
+
+	/**
+	 * Checks whether or not the drawn area of this widget contains
+	 * a point on the canvas.
+	 *
+	 * @param point the canvas point
+	 * @return true if this widget contains the point, false otherwise
+	 */
 	boolean contains(Point point);
 
 	int getScrollX();
@@ -129,29 +362,94 @@ public interface Widget
 
 	void setScrollY(int scrollY);
 
+	/**
+	 * Gets the original x-axis coordinate.
+	 *
+	 * @return the original coordinate
+	 */
 	int getOriginalX();
 
+	/**
+	 * Sets the original x-axis coordinate.
+	 *
+	 * @param originalX the new coordinate
+	 */
 	void setOriginalX(int originalX);
 
+	/**
+	 * Gets the original y-axis coordinate.
+	 *
+	 * @return the original coordinate
+	 */
 	int getOriginalY();
 
+	/**
+	 * Sets the original y-axis coordinate.
+	 *
+	 * @param originalY the new coordinate
+	 */
 	void setOriginalY(int originalY);
 
+	/**
+	 * Gets the original height of the widget.
+	 *
+	 * @return the original height
+	 */
 	int getOriginalHeight();
 
+	/**
+	 * Sets the original height of the widget.
+	 *
+	 * @param originalHeight the original height
+	 */
 	void setOriginalHeight(int originalHeight);
 
+	/**
+	 * Gets the original width of the widget.
+	 *
+	 * @return the original width
+	 */
 	int getOriginalWidth();
 
+	/**
+	 * Sets the original width of the widget.
+	 *
+	 * @param originalWidth the original width
+	 */
 	void setOriginalWidth(int originalWidth);
 
+	/**
+	 * Gets the additional x-axis padding.
+	 *
+	 * @return the x-axis padding
+	 */
 	int getPaddingX();
 
+	/**
+	 * Sets the x-axis padding.
+	 *
+	 * @param paddingX the new padding
+	 */
 	void setPaddingX(int paddingX);
 
+	/**
+	 * Gets the additional y-axis padding.
+	 *
+	 * @return the y-axis padding
+	 */
 	int getPaddingY();
 
+	/**
+	 * Sets the y-axis padding.
+	 *
+	 * @param paddingY the new padding
+	 */
 	void setPaddingY(int paddingY);
 
+	/**
+	 * Gets the actions available on the widget.
+	 *
+	 * @return the actions
+	 */
 	String[] getActions();
 }

--- a/runelite-api/src/main/java/net/runelite/api/widgets/WidgetConfig.java
+++ b/runelite-api/src/main/java/net/runelite/api/widgets/WidgetConfig.java
@@ -24,9 +24,24 @@
  */
 package net.runelite.api.widgets;
 
+/**
+ * Utility class used for defining options to be used on the click mask
+ * of a {@link Widget}.
+ *
+ * @see Widget#getClickMask()
+ */
 public class WidgetConfig
 {
+	/**
+	 * Enables displaying a ninth option on a menu.
+	 */
 	public static final int SHOW_MENU_OPTION_NINE = 1 << 9;
+	/**
+	 * Controls whether or not a widget can have another dragged onto it.
+	 */
 	public static final int DRAG_ON = 1 << 17;
+	/**
+	 * Controls whether or not a widget can be dragged around.
+	 */
 	public static final int DRAG = 1 << 20;
 }

--- a/runelite-api/src/main/java/net/runelite/api/widgets/WidgetID.java
+++ b/runelite-api/src/main/java/net/runelite/api/widgets/WidgetID.java
@@ -24,6 +24,16 @@
  */
 package net.runelite.api.widgets;
 
+/**
+ * Utility class mapping widget IDs to global constants.
+ * <p>
+ * The constants defined directly under the {@link WidgetID} class are
+ * Widget group IDs. All child IDs are defined in sub-classes relating
+ * to their group.
+ * <p>
+ * For a more direct group-child widget mapping, use the
+ * {@link WidgetInfo} enum class.
+ */
 public class WidgetID
 {
 	public static final int FAIRY_RING_CODE_GROUP_ID = 381;

--- a/runelite-api/src/main/java/net/runelite/api/widgets/WidgetInfo.java
+++ b/runelite-api/src/main/java/net/runelite/api/widgets/WidgetInfo.java
@@ -24,6 +24,11 @@
  */
 package net.runelite.api.widgets;
 
+/**
+ * Represents a group-child {@link Widget} relationship.
+ * <p>
+ * For getting a specific widget from the client, see {@link net.runelite.api.Client#getWidget(WidgetInfo)}.
+ */
 public enum WidgetInfo
 {
 	FAIRY_QUEEN_HIDEOUT_CODE(WidgetID.FAIRY_RING_CODE_GROUP_ID, WidgetID.FairyRingCode.FAIRY_QUEEN_HIDEOUT),
@@ -327,36 +332,77 @@ public enum WidgetInfo
 		this.childId = childId;
 	}
 
+	/**
+	 * Gets the ID of the group-child pairing.
+	 *
+	 * @return the ID
+	 */
 	public int getId()
 	{
 		return groupId << 16 | childId;
 	}
 
+	/**
+	 * Gets the group ID of the pair.
+	 *
+	 * @return the group ID
+	 */
 	public int getGroupId()
 	{
 		return groupId;
 	}
 
+	/**
+	 * Gets the ID of the child in the group.
+	 *
+	 * @return the child ID
+	 */
 	public int getChildId()
 	{
 		return childId;
 	}
 
+	/**
+	 * Gets the packed widget ID.
+	 *
+	 * @return the packed ID
+	 */
 	public int getPackedId()
 	{
 		return groupId << 16 | childId;
 	}
 
+	/**
+	 * Utility method that converts an ID returned by {@link #getId()} back
+	 * to its group ID.
+	 *
+	 * @param id passed group-child ID
+	 * @return the group ID
+	 */
 	public static int TO_GROUP(int id)
 	{
 		return id >>> 16;
 	}
 
+	/**
+	 * Utility method that converts an ID returned by {@link #getId()} back
+	 * to its child ID.
+	 *
+	 * @param id passed group-child ID
+	 * @return the child ID
+	 */
 	public static int TO_CHILD(int id)
 	{
 		return id & 0xFFFF;
 	}
 
+	/**
+	 * Packs the group and child IDs into a single integer.
+	 *
+	 * @param groupId the group ID
+	 * @param childId the child ID
+	 * @return the packed ID
+	 */
 	public static int PACK(int groupId, int childId)
 	{
 		return groupId << 16 | childId;

--- a/runelite-api/src/main/java/net/runelite/api/widgets/WidgetItem.java
+++ b/runelite-api/src/main/java/net/runelite/api/widgets/WidgetItem.java
@@ -27,6 +27,9 @@ package net.runelite.api.widgets;
 import java.awt.Rectangle;
 import net.runelite.api.Point;
 
+/**
+ * An item that is being represented in a {@link Widget}.
+ */
 public class WidgetItem
 {
 	private final int id;
@@ -48,26 +51,55 @@ public class WidgetItem
 		return "WidgetItem{" + "id=" + id + ", quantity=" + quantity + ", index=" + index + ", canvasBounds=" + canvasBounds + '}';
 	}
 
+	/**
+	 * Gets the ID of the item represented.
+	 *
+	 * @return the items ID
+	 * @see net.runelite.api.ItemID
+	 */
 	public int getId()
 	{
 		return id;
 	}
 
+	/**
+	 * Gets the quantity of the represented item.
+	 *
+	 * @return the items quantity
+	 */
 	public int getQuantity()
 	{
 		return quantity;
 	}
 
+	/**
+	 * Gets the index position of this WidgetItem inside its parents
+	 * WidgetItem array.
+	 *
+	 * @return the index in the parent widget
+	 * @see Widget#getWidgetItems()
+	 */
 	public int getIndex()
 	{
 		return index;
 	}
 
+	/**
+	 * Gets the area where the widget is drawn on the canvas.
+	 *
+	 * @return the occupied area of the widget
+	 */
 	public Rectangle getCanvasBounds()
 	{
 		return canvasBounds;
 	}
 
+	/**
+	 * Gets the upper-left coordinate of where the widget is being drawn
+	 * on the canvas.
+	 *
+	 * @return the upper-left coordinate of where this widget is drawn
+	 */
 	public Point getCanvasLocation()
 	{
 		return new Point((int) canvasBounds.getX(), (int) canvasBounds.getY());


### PR DESCRIPTION
Adds much needed javadoc documentation comments to methods in the API and resolves #500.

Although the diff is very large and might need to be split up, I thought it would be a good start to have everything centralized for review in one place. If there are any additions, changes, or feedbacks about the proposed documentation please leave comments.

Current incomplete classes are:
- Script
- TextureProvider
- PacketBuffer
- OverlayIndex