### PR TITLE
Skill calcs performance improvement

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/SkillCalculator.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/SkillCalculator.java
@@ -131,7 +131,7 @@ class SkillCalculator extends JPanel
 
 	private void updateCombinedAction()
 	{
-		int size = combinedActionSlots.size(); 
+		int size = combinedActionSlots.size();
 		if (size > 1)
 		{
 			combinedActionSlot.setTitle(size + " actions selected");

--- a/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/SkillCalculator.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/SkillCalculator.java
@@ -36,7 +36,6 @@ import java.util.ArrayList;
 import java.util.List;
 import javax.swing.BorderFactory;
 import javax.swing.Box;
-import javax.swing.BoxLayout;
 import javax.swing.JCheckBox;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
@@ -48,6 +47,7 @@ import net.runelite.client.plugins.skillcalculator.beans.SkillData;
 import net.runelite.client.plugins.skillcalculator.beans.SkillDataBonus;
 import net.runelite.client.plugins.skillcalculator.beans.SkillDataEntry;
 import net.runelite.client.ui.ColorScheme;
+import net.runelite.client.ui.DynamicGridLayout;
 import net.runelite.client.ui.FontManager;
 
 class SkillCalculator extends JPanel
@@ -80,7 +80,7 @@ class SkillCalculator extends JPanel
 		this.client = client;
 		this.uiInput = uiInput;
 
-		setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
+		setLayout(new DynamicGridLayout(0, 1, 0, 5));
 
 		// Register listeners on the input fields and then move on to the next related text field
 		uiInput.uiFieldCurrentLevel.addActionListener(e ->
@@ -125,15 +125,13 @@ class SkillCalculator extends JPanel
 		// Create action slots for the skill actions.
 		renderActionSlots();
 
-		add(Box.createRigidArea(new Dimension(0, 15)));
-
 		// Update the input fields.
 		updateInputFields();
 	}
 
 	private void updateCombinedAction()
 	{
-		int size = combinedActionSlots.size();
+		int size = combinedActionSlots.size(); 
 		if (size > 1)
 		{
 			combinedActionSlot.setTitle(size + " actions selected");
@@ -209,8 +207,6 @@ class SkillCalculator extends JPanel
 		{
 			UIActionSlot slot = new UIActionSlot(action);
 			uiActionSlots.add(slot); // Keep our own reference.
-
-			add(Box.createRigidArea(new Dimension(0, 5)));
 			add(slot); // Add component to the panel.
 
 			slot.addMouseListener(new MouseAdapter()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/SkillCalculatorPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/SkillCalculatorPanel.java
@@ -77,7 +77,7 @@ class SkillCalculatorPanel extends PluginPanel
 
 		this.iconManager = iconManager;
 
-		setBorder(new EmptyBorder(10, 10, 0, 10));
+		setBorder(new EmptyBorder(10, 10, 10, 10));
 		setLayout(new GridBagLayout());
 
 		GridBagConstraints c = new GridBagConstraints();


### PR DESCRIPTION
As the skilling calculator was taking a long time to switch to other
side panel tabs, I had to go in and improve performance to reduce the
delay (by a few seconds), **however to shave off the few hundred milliseconds that are left,
a lot more overall changes to the client have to be made, I will be
doing those in a separate PR.**


- Changed layout manager to DynamicGridLayout with a 5px hgap instead of
using rigid areas to add gaps.
- Removed useless bottom gap, and added bottom empty border