### PR TITLE
Fix Hiscore auto-complete

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/hiscore/HiscorePanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/hiscore/HiscorePanel.java
@@ -493,12 +493,12 @@ public class HiscorePanel extends PluginPanel
 
 	void addInputKeyListener(KeyListener l)
 	{
-		this.input.addInputKeyListener(l);
+		this.input.addKeyListener(l);
 	}
 
 	void removeInputKeyListener(KeyListener l)
 	{
-		this.input.removeInputKeyListener(l);
+		this.input.removeKeyListener(l);
 	}
 
 	/*

--- a/runelite-client/src/main/java/net/runelite/client/ui/components/FlatTextField.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/components/FlatTextField.java
@@ -110,14 +110,16 @@ public class FlatTextField extends JPanel
 		textField.setText(text);
 	}
 
-	public void addInputKeyListener(KeyListener l)
+	@Override
+	public void addKeyListener(KeyListener keyListener)
 	{
-		textField.addKeyListener(l);
+		textField.addKeyListener(keyListener);
 	}
 
-	public void removeInputKeyListener(KeyListener l)
+	@Override
+	public void removeKeyListener(KeyListener keyListener)
 	{
-		textField.removeKeyListener(l);
+		textField.removeKeyListener(keyListener);
 	}
 
 	@Override
@@ -134,7 +136,7 @@ public class FlatTextField extends JPanel
 		}
 
 		super.setBackground(color);
-		
+
 		if (saveColor)
 		{
 			this.backgroundColor = color;

--- a/runelite-client/src/main/java/net/runelite/client/ui/components/IconTextField.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/components/IconTextField.java
@@ -145,14 +145,16 @@ public class IconTextField extends JPanel
 		this.textField.setHoverBackgroundColor(hoverBackgroundColor);
 	}
 
-	public void addInputKeyListener(KeyListener l)
+	@Override
+	public void addKeyListener(KeyListener keyListener)
 	{
-		textField.addKeyListener(l);
+		textField.addKeyListener(keyListener);
 	}
 
-	public void removeInputKeyListener(KeyListener l)
+	@Override
+	public void removeKeyListener(KeyListener keyListener)
 	{
-		textField.removeKeyListener(l);
+		textField.removeKeyListener(keyListener);
 	}
 
 	public void setEditable(boolean editable)


### PR DESCRIPTION
When I refactored the IconTextField to include a new component called
FlatTextField, I forgot to change the methods to add/remove key
listeners.

All I had to do is override de addKeyListener/removeKeyListener
methods on both the IconTextField and FlatTextField instead of some
useless no-sense-making similar methods I had.

Easy fix.

Fixes #3202