### PR TITLE
Fix for confirm dialog appearing behind main UI window

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenmarkers/ui/ScreenMarkerPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenmarkers/ui/ScreenMarkerPanel.java
@@ -276,7 +276,7 @@ class ScreenMarkerPanel extends JPanel
 			@Override
 			public void mousePressed(MouseEvent mouseEvent)
 			{
-				int confirm = JOptionPane.showConfirmDialog(null,
+				int confirm = JOptionPane.showConfirmDialog(ScreenMarkerPanel.this,
 					"Are you sure you want to permanenely delete this screen marker?",
 					"Warning", JOptionPane.OK_CANCEL_OPTION);
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenmarkers/ui/ScreenMarkerPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenmarkers/ui/ScreenMarkerPanel.java
@@ -277,7 +277,7 @@ class ScreenMarkerPanel extends JPanel
 			public void mousePressed(MouseEvent mouseEvent)
 			{
 				int confirm = JOptionPane.showConfirmDialog(ScreenMarkerPanel.this,
-					"Are you sure you want to permanenely delete this screen marker?",
+					"Are you sure you want to permanently delete this screen marker?",
 					"Warning", JOptionPane.OK_CANCEL_OPTION);
 
 				if (confirm == 0)


### PR DESCRIPTION
If you have the 'always on top' option on and showing a confirm dialog with `null` as the `parentComponent`, it would show behind the main window, making it impossible to click and basically freezing the program, with the only way out being to kill the process (on Windows 10 atleast).

There are two other instances of `null` being passed to the same method but there is no way (that I know of) to access the parent component at this time. These are in LinkBrowser.java and AccountPlugin.java.

Also fixes a typo.