### PR TITLE
Added yellow check mark to clue scroll emote overlay for when a set

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java
@@ -639,8 +639,11 @@ public class EmoteClue extends ClueScroll implements TextClueScroll, LocationClu
 				boolean equipmentFulfilled = requirement.fulfilledBy(equipment);
 				boolean inventoryFulfilled = requirement.fulfilledBy(inventory);
 				boolean combinedFulfilled = false;
-				if(!equipmentFulfilled && !inventoryFulfilled)
+
+				if (!equipmentFulfilled && !inventoryFulfilled)
+				{
 					combinedFulfilled = requirement.fulfilledBy(combined);
+				}
 
 				panelComponent.getChildren().add(LineComponent.builder()
 					.left(requirement.getCollectiveName(plugin.getClient()))

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java
@@ -617,6 +617,9 @@ public class EmoteClue extends ClueScroll implements TextClueScroll, LocationClu
 
 			Item[] equipment = plugin.getEquippedItems();
 			Item[] inventory = plugin.getInventoryItems();
+			Item[] combined = new Item[equipment.length + inventory.length];
+			System.arraycopy(equipment, 0, combined, 0, equipment.length);
+			System.arraycopy(inventory, 0, combined, equipment.length, inventory.length);
 
 			// If equipment is null, the player is wearing nothing
 			if (equipment == null)
@@ -634,12 +637,13 @@ public class EmoteClue extends ClueScroll implements TextClueScroll, LocationClu
 			{
 				boolean equipmentFulfilled = requirement.fulfilledBy(equipment);
 				boolean inventoryFulfilled = requirement.fulfilledBy(inventory);
+				boolean combinedFulfilled = requirement.fulfilledBy(combined);
 
 				panelComponent.getChildren().add(LineComponent.builder()
 					.left(requirement.getCollectiveName(plugin.getClient()))
 					.leftColor(TITLED_CONTENT_COLOR)
-					.right(equipmentFulfilled || inventoryFulfilled ? "\u2713" : "\u2717")
-					.rightColor(equipmentFulfilled ? Color.GREEN : (inventoryFulfilled ? Color.ORANGE : Color.RED))
+					.right(equipmentFulfilled || inventoryFulfilled || combinedFulfilled ? "\u2713" : "\u2717")
+					.rightColor(equipmentFulfilled ? Color.GREEN : (inventoryFulfilled ? Color.ORANGE : (combinedFulfilled ? Color.YELLOW : Color.RED)))
 					.build());
 			}
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java
@@ -643,7 +643,7 @@ public class EmoteClue extends ClueScroll implements TextClueScroll, LocationClu
 					.left(requirement.getCollectiveName(plugin.getClient()))
 					.leftColor(TITLED_CONTENT_COLOR)
 					.right(equipmentFulfilled || inventoryFulfilled || combinedFulfilled ? "\u2713" : "\u2717")
-					.rightColor(equipmentFulfilled ? Color.GREEN : (inventoryFulfilled ? Color.ORANGE : (combinedFulfilled ? Color.YELLOW : Color.RED)))
+					.rightColor(equipmentFulfilled ? Color.GREEN : ((inventoryFulfilled || combinedFulfilled) ? Color.ORANGE  : Color.RED))
 					.build());
 			}
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java
@@ -617,9 +617,6 @@ public class EmoteClue extends ClueScroll implements TextClueScroll, LocationClu
 
 			Item[] equipment = plugin.getEquippedItems();
 			Item[] inventory = plugin.getInventoryItems();
-			Item[] combined = new Item[equipment.length + inventory.length];
-			System.arraycopy(equipment, 0, combined, 0, equipment.length);
-			System.arraycopy(inventory, 0, combined, equipment.length, inventory.length);
 
 			// If equipment is null, the player is wearing nothing
 			if (equipment == null)
@@ -633,11 +630,17 @@ public class EmoteClue extends ClueScroll implements TextClueScroll, LocationClu
 				inventory = new Item[0];
 			}
 
+			Item[] combined = new Item[equipment.length + inventory.length];
+			System.arraycopy(equipment, 0, combined, 0, equipment.length);
+			System.arraycopy(inventory, 0, combined, equipment.length, inventory.length);
+
 			for (ItemRequirement requirement : getItemRequirements())
 			{
 				boolean equipmentFulfilled = requirement.fulfilledBy(equipment);
 				boolean inventoryFulfilled = requirement.fulfilledBy(inventory);
-				boolean combinedFulfilled = requirement.fulfilledBy(combined);
+				boolean combinedFulfilled = false;
+				if(!equipmentFulfilled && !inventoryFulfilled)
+					combinedFulfilled = requirement.fulfilledBy(combined);
 
 				panelComponent.getChildren().add(LineComponent.builder()
 					.left(requirement.getCollectiveName(plugin.getClient()))


### PR DESCRIPTION
is not fully equipped. This prevents the red X from showing when you actually do have the entire set.
Issue #3271 