### PR TITLE
NMZ QoL: Adds points per hour & duration to overlay

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/nightmarezone/NightmareZoneConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/nightmarezone/NightmareZoneConfig.java
@@ -48,10 +48,33 @@ public interface NightmareZoneConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "staticPointsPerHourUpdate",
+		name = "Update P/H once per kill",
+		description = "Configures whether to update [Points/Hour] only when total points changes",
+		position = 2
+	)
+	default boolean staticPointsPerHourUpdate()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		keyName = "hourlyUpdateInterval",
+		name = "P/H update interval (s)",
+		description = "The amount of time in seconds before visually updating [Points/Hour]. " +
+			"Only applies if [Update P/H once per kill] is unchecked",
+		position = 3
+	)
+	default int hourlyUpdateInterval()
+	{
+		return 1;
+	}
+
+	@ConfigItem(
 		keyName = "powersurgenotification",
 		name = "Power surge notification",
 		description = "Toggles notifications when a power surge power-up appears",
-		position = 2
+		position = 4
 	)
 	default boolean powerSurgeNotification()
 	{
@@ -62,7 +85,7 @@ public interface NightmareZoneConfig extends Config
 		keyName = "recurrentdamagenotification",
 		name = "Recurrent damage notification",
 		description = "Toggles notifications when a recurrent damage power-up appears",
-		position = 3
+		position = 5
 	)
 	default boolean recurrentDamageNotification()
 	{
@@ -73,7 +96,7 @@ public interface NightmareZoneConfig extends Config
 		keyName = "zappernotification",
 		name = "Zapper notification",
 		description = "Toggles notifications when a zapper power-up appears",
-		position = 4
+		position = 6
 	)
 	default boolean zapperNotification()
 	{
@@ -84,7 +107,7 @@ public interface NightmareZoneConfig extends Config
 		keyName = "overloadnotification",
 		name = "Overload notification",
 		description = "Toggles notifications when your overload runs out",
-		position = 5
+		position = 7
 	)
 	default boolean overloadNotification()
 	{
@@ -95,7 +118,7 @@ public interface NightmareZoneConfig extends Config
 		keyName = "absorptionnotification",
 		name = "Absorption notification",
 		description = "Toggles notifications when your absorption points gets below your threshold",
-		position = 6
+		position = 8
 	)
 	default boolean absorptionNotification()
 	{
@@ -106,7 +129,7 @@ public interface NightmareZoneConfig extends Config
 		keyName = "absorptionthreshold",
 		name = "Absorption Threshold",
 		description = "The amount of absorption points to send a notification at",
-		position = 7
+		position = 9
 	)
 	default int absorptionThreshold()
 	{
@@ -117,7 +140,7 @@ public interface NightmareZoneConfig extends Config
 		keyName = "absorptioncoloroverthreshold",
 		name = "Color above threshold",
 		description = "Configures the color for the absorption widget when above the threshold",
-		position = 8
+		position = 10
 	)
 	default Color absorptionColorAboveThreshold()
 	{
@@ -128,7 +151,7 @@ public interface NightmareZoneConfig extends Config
 		keyName = "absorptioncolorbelowthreshold",
 		name = "Color below threshold",
 		description = "Configures the color for the absorption widget when below the threshold",
-		position = 9
+		position = 11
 	)
 	default Color absorptionColorBelowThreshold()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/nightmarezone/NightmareZoneInfoModel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/nightmarezone/NightmareZoneInfoModel.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2018, Grant <grant.dellar@live.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.nightmarezone;
+
+import java.sql.Timestamp;
+import javax.inject.Inject;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.Setter;
+import net.runelite.api.Client;
+import net.runelite.api.Varbits;
+
+/**
+ * Represents a model of the current Nightmare Zone dream points, points per hour, elapsed time/
+ * elapsed formatted time.
+ */
+public class NightmareZoneInfoModel
+{
+	private final NightmareZoneConfig config;
+	private final Client client;
+
+	/**
+	 * A Timestamp signifying the start time a Nightmare Zone Dream
+	 */
+	private Timestamp dreamStartTime;
+
+	/**
+	 * Seconds that has elapsed since entering a Nightmare Zone Dream.
+	 */
+	private int elapsedTimeSeconds;
+
+	/**
+	 * A Timestamp signifying the last time Points/Hour was updated after a set interval
+	 */
+	private Timestamp lastIntervalUpdate;
+
+	/**
+	 * Points currently earned in a Nightmare Zone dream
+	 */
+	@Getter
+	@Setter(AccessLevel.PRIVATE)
+	private int points;
+
+	/**
+	 * Expected hourly Nightmare Zone dream points rate
+	 */
+	@Getter
+	private int pointsPerHour;
+
+	/**
+	 * Nightmare Zone dream duration time formatted into a user-friendly string. hh/mm/ss.
+	 */
+	@Getter
+	private String formattedElapsedTime;
+
+
+	@Inject
+	NightmareZoneInfoModel(Client client, NightmareZoneConfig config)
+	{
+		this.client = client;
+		this.config = config;
+		lastIntervalUpdate = new Timestamp(0);
+		dreamStartTime = new Timestamp(System.currentTimeMillis());
+	}
+
+	/**
+	 * Retrieves the most up to date dream points and sets the model points, point per hour and
+	 * elapsed time/ formatted time accordingly
+	 */
+	public void update()
+	{
+		int points = client.getVar(Varbits.NMZ_POINTS);
+
+		long currentTimeMillis = System.currentTimeMillis();
+		elapsedTimeSeconds = (int) (System.currentTimeMillis() - dreamStartTime.getTime()) / 1000;
+		long intervalTimeDifference = currentTimeMillis - lastIntervalUpdate.getTime();
+
+		setFormattedElapsedTime();
+
+		if (config.staticPointsPerHourUpdate())
+		{
+			if (this.points != points)
+			{
+				setPointsPerHour(points);
+				setPoints(points);
+			}
+		}
+		else if (intervalTimeDifference >= config.hourlyUpdateInterval() * 1000
+			|| lastIntervalUpdate.getTime() == 0)
+		{
+			setPointsPerHour(points);
+			setPoints(points);
+			lastIntervalUpdate.setTime(System.currentTimeMillis());
+		}
+	}
+
+	private void setPointsPerHour(int points)
+	{
+		pointsPerHour = (int) (3600.0 / (elapsedTimeSeconds) * points);
+	}
+
+	private void setFormattedElapsedTime()
+	{
+		int durationHours = (elapsedTimeSeconds % (24 * 60 * 60)) / (60 * 60);
+		int durationMinutes = (elapsedTimeSeconds % (60 * 60)) / 60;
+		int durationSeconds = elapsedTimeSeconds % 60;
+
+		if (durationHours > 0)
+		{
+			formattedElapsedTime = String.format("%02d:%02d:%02d", durationHours, durationMinutes, durationSeconds);
+		}
+		else if (durationSeconds >= 0)
+		{
+			formattedElapsedTime = String.format("%02d:%02d", durationMinutes, durationSeconds);
+		}
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/nightmarezone/NightmareZoneOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/nightmarezone/NightmareZoneOverlay.java
@@ -48,17 +48,17 @@ class NightmareZoneOverlay extends Overlay
 	private final NightmareZonePlugin plugin;
 	private final InfoBoxManager infoBoxManager;
 	private final ItemManager itemManager;
-
-	private AbsorptionCounter absorptionCounter;
 	private final PanelComponent panelComponent = new PanelComponent();
+	private AbsorptionCounter absorptionCounter;
+
 
 	@Inject
 	NightmareZoneOverlay(
-			Client client,
-			NightmareZoneConfig config,
-			NightmareZonePlugin plugin,
-			InfoBoxManager infoBoxManager,
-			ItemManager itemManager)
+		Client client,
+		NightmareZoneConfig config,
+		NightmareZonePlugin plugin,
+		InfoBoxManager infoBoxManager,
+		ItemManager itemManager)
 	{
 		setPosition(OverlayPosition.TOP_LEFT);
 		setPriority(OverlayPriority.LOW);
@@ -67,6 +67,8 @@ class NightmareZoneOverlay extends Overlay
 		this.plugin = plugin;
 		this.infoBoxManager = infoBoxManager;
 		this.itemManager = itemManager;
+
+		panelComponent.setPreferredSize(new Dimension(150, 0));
 	}
 
 	@Override
@@ -95,11 +97,20 @@ class NightmareZoneOverlay extends Overlay
 		}
 
 		renderAbsorptionCounter();
+		plugin.getNMZInfoModel().update();
 
 		panelComponent.getChildren().clear();
 		panelComponent.getChildren().add(LineComponent.builder()
-			.left("Points: ")
-			.right(StackFormatter.formatNumber(client.getVar(Varbits.NMZ_POINTS)))
+			.left("Total Points: ")
+			.right(StackFormatter.formatNumber(plugin.getNMZInfoModel().getPoints()))
+			.build());
+		panelComponent.getChildren().add(LineComponent.builder()
+			.left("Points/Hour: ")
+			.right(StackFormatter.formatNumber(plugin.getNMZInfoModel().getPointsPerHour()))
+			.build());
+		panelComponent.getChildren().add(LineComponent.builder()
+			.left("Duration: ")
+			.right(plugin.getNMZInfoModel().getFormattedElapsedTime())
 			.build());
 
 		return panelComponent.render(graphics);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/nightmarezone/NightmareZonePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/nightmarezone/NightmareZonePlugin.java
@@ -28,6 +28,7 @@ import com.google.common.eventbus.Subscribe;
 import com.google.inject.Provides;
 import java.util.Arrays;
 import javax.inject.Inject;
+import lombok.Getter;
 import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
 import net.runelite.api.Varbits;
@@ -64,6 +65,9 @@ public class NightmareZonePlugin extends Plugin
 	// above the threshold before sending notifications
 	private boolean absorptionNotificationSend = true;
 
+	@Getter
+	private NightmareZoneInfoModel NMZInfoModel;
+
 	@Override
 	protected void shutDown()
 	{
@@ -98,8 +102,16 @@ public class NightmareZonePlugin extends Plugin
 				absorptionNotificationSend = true;
 			}
 
+			NMZInfoModel = null;
+
 			return;
 		}
+
+		if (NMZInfoModel == null)
+		{
+			NMZInfoModel = new NightmareZoneInfoModel(client, config);
+		}
+
 		if (config.absorptionNotification())
 		{
 			checkAbsorption();


### PR DESCRIPTION
This also adds two new configs items.

1.  **Update P/H once per kill** - Configures whether to update [Points/Hour] only when total points changes.
2. **P/H update interval (s)** - The amount of time in seconds before visually updating [Points/Hour]. Only applies if [Update P/H once per kill] is unchecked.

![ezgif-5-c8a2641a18](https://user-images.githubusercontent.com/21123949/40542352-fbb0962c-6073-11e8-8b35-71422076280a.gif)

Let me know if I went a bit overboard with the documentation.