### PR TITLE
Clarify ground items configs to include * explanation.

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
@@ -34,53 +34,17 @@ import net.runelite.client.plugins.grounditems.config.ItemHighlightMode;
 import net.runelite.client.plugins.grounditems.config.MenuHighlightMode;
 
 @ConfigGroup(
-	keyName = "grounditems",
-	name = "Ground Items",
-	description = "Configuration for the ground items plugin"
+		keyName = "grounditems",
+		name = "Ground Items",
+		description = "Configuration for the ground items plugin"
 )
 public interface GroundItemsConfig extends Config
 {
 	@ConfigItem(
-		keyName = "highlightedItems",
-		name = "Highlighted Items",
-		description = "Configures specifically highlighted ground items. Format: (item), (item)",
-		position = 1
-	)
-	default String getHighlightItems()
-	{
-		return "";
-	}
-
-	@ConfigItem(
-		keyName = "highlightedItems",
-		name = "",
-		description = ""
-	)
-	void setHighlightedItem(String key);
-
-	@ConfigItem(
-		keyName = "hiddenItems",
-		name = "Hidden Items",
-		description = "Configures hidden ground items. Format: (item), (item)",
-		position = 2
-	)
-	default String getHiddenItems()
-	{
-		return "";
-	}
-
-	@ConfigItem(
-		keyName = "hiddenItems",
-		name = "",
-		description = ""
-	)
-	void setHiddenItems(String key);
-
-	@ConfigItem(
-		keyName = "showHighlightedOnly",
-		name = "Show Highlighted items only",
-		description = "Configures whether or not to draw items only on your highlighted list",
-		position = 3
+			keyName = "showHighlightedOnly",
+			name = "Show Highlighted items only",
+			description = "Configures whether or not to draw items only on your highlighted list.",
+			position = 1
 	)
 	default boolean showHighlightedOnly()
 	{
@@ -88,10 +52,10 @@ public interface GroundItemsConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "showGEPrice",
-		name = "Show Grand Exchange Prices",
-		description = "Configures whether or not to draw GE prices alongside ground items",
-		position = 4
+			keyName = "showGEPrice",
+			name = "Show Grand Exchange Prices",
+			description = "Configures whether or not to draw GE prices alongside ground items",
+			position = 2
 	)
 	default boolean showGEPrice()
 	{
@@ -99,10 +63,10 @@ public interface GroundItemsConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "showHAValue",
-		name = "Show High Alchemy Values",
-		description = "Configures whether or not to draw High Alchemy values alongside ground items",
-		position = 5
+			keyName = "showHAValue",
+			name = "Show High Alchemy Values",
+			description = "Configures whether or not to draw High Alchemy values alongside ground items",
+			position = 3
 	)
 	default boolean showHAValue()
 	{
@@ -110,10 +74,10 @@ public interface GroundItemsConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "showMenuItemQuantities",
-		name = "Show Menu Item Quantities",
-		description = "Configures whether or not to show the item quantities in the menu",
-		position = 6
+			keyName = "showMenuItemQuantities",
+			name = "Show Menu Item Quantities",
+			description = "Configures whether or not to show the item quantities in the menu",
+			position = 4
 	)
 	default boolean showMenuItemQuantities()
 	{
@@ -121,10 +85,10 @@ public interface GroundItemsConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "itemHighlightMode",
-		name = "Item Highlight Mode",
-		description = "Configures how ground items will be highlighted",
-		position = 7
+			keyName = "itemHighlightMode",
+			name = "Item Highlight Mode",
+			description = "Configures how ground items will be highlighted",
+			position = 5
 	)
 	default ItemHighlightMode itemHighlightMode()
 	{
@@ -132,10 +96,10 @@ public interface GroundItemsConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "menuHighlightMode",
-		name = "Menu Highlight Mode",
-		description = "Configures what to highlight in right-click menu",
-		position = 8
+			keyName = "menuHighlightMode",
+			name = "Menu Highlight Mode",
+			description = "Configures what to highlight in right-click menu",
+			position = 6
 	)
 	default MenuHighlightMode menuHighlightMode()
 	{
@@ -143,10 +107,10 @@ public interface GroundItemsConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "hideUnderGeValue",
-		name = "Hide < GE Value",
-		description = "Configures hidden ground items under GE value",
-		position = 9
+			keyName = "hideUnderGeValue",
+			name = "Hide < GE Value",
+			description = "Configures hidden ground items under GE value",
+			position = 7
 	)
 	default int getHideUnderGeValue()
 	{
@@ -154,10 +118,10 @@ public interface GroundItemsConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "hideUnderHaValue",
-		name = "Hide < HA Value",
-		description = "Configures hidden ground items under High Alch value",
-		position = 10
+			keyName = "hideUnderHaValue",
+			name = "Hide < HA Value",
+			description = "Configures hidden ground items under High Alch value",
+			position = 8
 	)
 	default int getHideUnderHAValue()
 	{
@@ -165,10 +129,46 @@ public interface GroundItemsConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "defaultColor",
-		name = "Default items color",
-		description = "Configures the color for default, non-highlighted items",
-		position = 11
+			keyName = "highlightedItems",
+			name = "Highlighted Items",
+			description = "Configures specifically highlighted ground items. Can use * to denote any character any number of times. Such as Rune* for Rune sword and Rune med helm. Format: (item), (item)",
+			position = 9
+	)
+	default String getHighlightItems()
+	{
+		return "";
+	}
+
+	@ConfigItem(
+			keyName = "highlightedItems",
+			name = "",
+			description = ""
+	)
+	void setHighlightedItem(String key);
+
+	@ConfigItem(
+			keyName = "hiddenItems",
+			name = "Hidden Items",
+			description = "Configures hidden ground items. Can use * to denote any character any number of times. Such as Rune* for Rune sword and Rune med helm. Format: (item), (item)",
+			position = 10
+	)
+	default String getHiddenItems()
+	{
+		return "";
+	}
+
+	@ConfigItem(
+			keyName = "hiddenItems",
+			name = "",
+			description = ""
+	)
+	void setHiddenItems(String key);
+
+	@ConfigItem(
+			keyName = "defaultColor",
+			name = "Default items color",
+			description = "Configures the color for default, non-highlighted items",
+			position = 11
 	)
 	default Color defaultColor()
 	{
@@ -176,10 +176,10 @@ public interface GroundItemsConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "highlightedColor",
-		name = "Highlighted items color",
-		description = "Configures the color for highlighted items",
-		position = 12
+			keyName = "highlightedColor",
+			name = "Highlighted items color",
+			description = "Configures the color for highlighted items",
+			position = 12
 	)
 	default Color highlightedColor()
 	{
@@ -187,10 +187,10 @@ public interface GroundItemsConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "lowValueColor",
-		name = "Low value items color",
-		description = "Configures the color for low value items",
-		position = 13
+			keyName = "lowValueColor",
+			name = "Low value items color",
+			description = "Configures the color for low value items",
+			position = 13
 	)
 	default Color lowValueColor()
 	{
@@ -198,10 +198,10 @@ public interface GroundItemsConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "lowValuePrice",
-		name = "Low value price",
-		description = "Configures the start price for low value items",
-		position = 14
+			keyName = "lowValuePrice",
+			name = "Low value price",
+			description = "Configures the start price for low value items",
+			position = 14
 	)
 	default int lowValuePrice()
 	{
@@ -209,10 +209,10 @@ public interface GroundItemsConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "mediumValueColor",
-		name = "Medium value items color",
-		description = "Configures the color for medium value items",
-		position = 15
+			keyName = "mediumValueColor",
+			name = "Medium value items color",
+			description = "Configures the color for medium value items",
+			position = 15
 	)
 	default Color mediumValueColor()
 	{
@@ -220,10 +220,10 @@ public interface GroundItemsConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "mediumValuePrice",
-		name = "Medium value price",
-		description = "Configures the start price for medium value items",
-		position = 16
+			keyName = "mediumValuePrice",
+			name = "Medium value price",
+			description = "Configures the start price for medium value items",
+			position = 16
 	)
 	default int mediumValuePrice()
 	{
@@ -231,10 +231,10 @@ public interface GroundItemsConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "highValueColor",
-		name = "High value items color",
-		description = "Configures the color for high value items",
-		position = 17
+			keyName = "highValueColor",
+			name = "High value items color",
+			description = "Configures the color for high value items",
+			position = 17
 	)
 	default Color highValueColor()
 	{
@@ -242,10 +242,10 @@ public interface GroundItemsConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "highValuePrice",
-		name = "High value price",
-		description = "Configures the start price for high value items",
-		position = 18
+			keyName = "highValuePrice",
+			name = "High value price",
+			description = "Configures the start price for high value items",
+			position = 18
 	)
 	default int highValuePrice()
 	{
@@ -253,10 +253,10 @@ public interface GroundItemsConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "insaneValueColor",
-		name = "Insane value items color",
-		description = "Configures the color for insane value items",
-		position = 19
+			keyName = "insaneValueColor",
+			name = "Insane value items color",
+			description = "Configures the color for insane value items",
+			position = 19
 	)
 	default Color insaneValueColor()
 	{
@@ -264,10 +264,10 @@ public interface GroundItemsConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "insaneValuePrice",
-		name = "Insane value price",
-		description = "Configures the start price for insane value items",
-		position = 20
+			keyName = "insaneValuePrice",
+			name = "Insane value price",
+			description = "Configures the start price for insane value items",
+			position = 20
 	)
 	default int insaneValuePrice()
 	{


### PR DESCRIPTION
Would partially fix [#3302](https://github.com/runelite/runelite/issues/3302).

Changed from:

> Configures hidden ground items. Format: (item), (item)

to 

> Configures hidden ground items. Can use * to denote any character any number of times. Such as Rune* for Rune sword and Rune med helm. Format: (item), (item)

Thanks to @Tehterokkar for the suggestion.