### PR TITLE
Exclude Ironmen accounts from herb box notifications

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/dailytaskindicators/DailyTasksPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/dailytaskindicators/DailyTasksPlugin.java
@@ -36,6 +36,7 @@ import net.runelite.api.Varbits;
 import net.runelite.api.events.ConfigChanged;
 import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.GameTick;
+import net.runelite.api.vars.AccountType;
 import net.runelite.client.chat.ChatColor;
 import net.runelite.client.chat.ChatColorType;
 import net.runelite.client.chat.ChatMessageBuilder;
@@ -147,7 +148,7 @@ public class DailyTasksPlugin extends Plugin
 	private boolean checkCanCollectHerbBox()
 	{
 		int value = client.getVar(Varbits.DAILY_HERB_BOX);
-		return value < 15; // < 15 can claim
+		return  client.getAccountType() == AccountType.NORMAL && value < 15; // < 15 can claim
 	}
 
 	private boolean checkCanCollectStaves()


### PR DESCRIPTION
This will do as the title states.

Fixes issue: [#3307](https://github.com/runelite/runelite/pull/3307)