### PR TITLE
Skill Calculator: Orange indicator for actions that will become available before target.

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/SkillCalculator.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/SkillCalculator.java
@@ -246,6 +246,7 @@ class SkillCalculator extends JPanel
 
 			slot.setText("Lvl. " + action.getLevel() + " (" + formatXPActionString(xp, actionCount, "exp) - "));
 			slot.setAvailable(currentLevel >= action.getLevel());
+			slot.setOverlapping(action.getLevel() < targetLevel);
 			slot.setValue((int) xp);
 		}
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/SkillCalculator.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/SkillCalculator.java
@@ -52,15 +52,18 @@ import net.runelite.client.ui.FontManager;
 
 class SkillCalculator extends JPanel
 {
+	private static final int MAX_XP = 200_000_000;
+	private static final DecimalFormat XP_FORMAT = new DecimalFormat("#.#");
+
+	static SpriteManager spriteManager;
+	static ItemManager itemManager;
+
 	private Client client;
 	private SkillData skillData;
 	private List<UIActionSlot> uiActionSlots = new ArrayList<>();
 	private UICalculatorInputArea uiInput;
 
 	private CacheSkillData cacheSkillData = new CacheSkillData();
-
-	static SpriteManager spriteManager;
-	static ItemManager itemManager;
 
 	private UICombinedActionSlot combinedActionSlot = new UICombinedActionSlot();
 	private ArrayList<UIActionSlot> combinedActionSlots = new ArrayList<>();
@@ -70,10 +73,6 @@ class SkillCalculator extends JPanel
 	private int targetLevel = currentLevel + 1;
 	private int targetXP = Experience.getXpForLevel(targetLevel);
 	private float xpFactor = 1.0f;
-
-	private static int MAX_XP = Experience.getXpForLevel(Experience.MAX_VIRT_LEVEL);
-
-	private static DecimalFormat XP_FORMAT = new DecimalFormat("#.#");
 
 	SkillCalculator(Client client, UICalculatorInputArea uiInput)
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/SkillCalculator.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/SkillCalculator.java
@@ -151,7 +151,7 @@ class SkillCalculator extends JPanel
 		double xp = 0;
 
 		for (UIActionSlot slot : combinedActionSlots)
-			xp += slot.value;
+			xp += slot.getValue();
 
 		if (neededXP > 0)
 			actionCount = (int) Math.ceil(neededXP / xp);
@@ -216,12 +216,12 @@ class SkillCalculator extends JPanel
 					if (!e.isShiftDown())
 						clearCombinedSlots();
 
-					if (slot.isSelected)
+					if (slot.isSelected())
 						combinedActionSlots.remove(slot);
 					else
 						combinedActionSlots.add(slot);
 
-					slot.setSelected(!slot.isSelected);
+					slot.setSelected(!slot.isSelected());
 					updateCombinedAction();
 				}
 			});
@@ -238,14 +238,15 @@ class SkillCalculator extends JPanel
 		{
 			int actionCount = 0;
 			int neededXP = targetXP - currentXP;
-			double xp = (slot.action.isIgnoreBonus()) ? slot.action.getXp() : slot.action.getXp() * xpFactor;
+			SkillDataEntry action = slot.getAction();
+			double xp = (action.isIgnoreBonus()) ? action.getXp() : action.getXp() * xpFactor;
 
 			if (neededXP > 0)
 				actionCount = (int) Math.ceil(neededXP / xp);
 
-			slot.setText("Lvl. " + slot.action.getLevel() + " (" + formatXPActionString(xp, actionCount, "exp) - "));
-			slot.setAvailable(currentLevel >= slot.action.getLevel());
-			slot.value = xp;
+			slot.setText("Lvl. " + action.getLevel() + " (" + formatXPActionString(xp, actionCount, "exp) - "));
+			slot.setAvailable(currentLevel >= action.getLevel());
+			slot.setValue((int) xp);
 		}
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/UIActionSlot.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/UIActionSlot.java
@@ -39,6 +39,9 @@ import javax.swing.JPanel;
 import javax.swing.border.Border;
 import javax.swing.border.CompoundBorder;
 import javax.swing.border.EmptyBorder;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.Setter;
 import net.runelite.client.plugins.skillcalculator.beans.SkillDataEntry;
 import net.runelite.client.ui.ColorScheme;
 import net.runelite.client.ui.FontManager;
@@ -54,15 +57,27 @@ class UIActionSlot extends JPanel
 		BorderFactory.createMatteBorder(0, 4, 0, 0, (ColorScheme.PROGRESS_ERROR_COLOR).darker()),
 		BorderFactory.createEmptyBorder(7, 12, 7, 7));
 
-	SkillDataEntry action;
-	private JShadowedLabel uiLabelActions;
+	private static final Border ORANGE_BORDER = new CompoundBorder(
+		BorderFactory.createMatteBorder(0, 4, 0, 0, (ColorScheme.PROGRESS_INPROGRESS_COLOR).darker()),
+		BorderFactory.createEmptyBorder(7, 12, 7, 7));
+
 	private static final Dimension ICON_SIZE = new Dimension(32, 32);
+
+	@Getter(AccessLevel.PACKAGE)
+	private final SkillDataEntry action;
+	private final JShadowedLabel uiLabelActions;
+
 	private final JPanel uiInfo;
 
-	boolean isAvailable = false;
-	boolean isSelected = false;
+	@Getter(AccessLevel.PACKAGE)
+	private boolean isAvailable;
 
-	double value = 0;
+	@Getter(AccessLevel.PACKAGE)
+	private boolean isSelected;
+
+	@Getter(AccessLevel.PACKAGE)
+	@Setter(AccessLevel.PACKAGE)
+	private int value = 0;
 
 	UIActionSlot(SkillDataEntry action)
 	{
@@ -128,13 +143,13 @@ class UIActionSlot extends JPanel
 	void setSelected(boolean selected)
 	{
 		isSelected = selected;
-		updateBackground();
+		this.updateBackground();
 	}
 
 	void setAvailable(boolean available)
 	{
 		isAvailable = available;
-		updateBackground();
+		this.updateBackground();
 	}
 
 	void setText(String text)
@@ -144,8 +159,16 @@ class UIActionSlot extends JPanel
 
 	private void updateBackground()
 	{
-		setBorder(isAvailable ? GREEN_BORDER : RED_BORDER);
-		setBackground(isSelected ? ColorScheme.DARKER_GRAY_HOVER_COLOR.brighter() : ColorScheme.DARKER_GRAY_COLOR);
+		if (isAvailable)
+		{
+			this.setBorder(GREEN_BORDER);
+		}
+		else
+		{
+			this.setBorder(RED_BORDER);
+		}
+
+		setBackground(this.isSelected() ? ColorScheme.DARKER_GRAY_HOVER_COLOR.brighter() : ColorScheme.DARKER_GRAY_COLOR);
 	}
 
 	@Override

--- a/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/UIActionSlot.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/UIActionSlot.java
@@ -76,6 +76,9 @@ class UIActionSlot extends JPanel
 	private boolean isSelected;
 
 	@Getter(AccessLevel.PACKAGE)
+	private boolean isOverlapping;
+
+	@Getter(AccessLevel.PACKAGE)
 	@Setter(AccessLevel.PACKAGE)
 	private int value = 0;
 
@@ -152,6 +155,12 @@ class UIActionSlot extends JPanel
 		this.updateBackground();
 	}
 
+	void setOverlapping(boolean overlapping)
+	{
+		isOverlapping = overlapping;
+		this.updateBackground();
+	}
+
 	void setText(String text)
 	{
 		uiLabelActions.setText(text);
@@ -162,6 +171,10 @@ class UIActionSlot extends JPanel
 		if (isAvailable)
 		{
 			this.setBorder(GREEN_BORDER);
+		}
+		else if (isOverlapping)
+		{
+			this.setBorder(ORANGE_BORDER);
 		}
 		else
 		{


### PR DESCRIPTION
This PR updates the skill calculator to show an orange indicator on actions that will become available before the target level has been reached.

![runelite_2018-05-25_21-59-22](https://user-images.githubusercontent.com/682348/40566587-5271c8d8-6069-11e8-8a80-99cd6effc95f.png)

As well as the addition of an orange indicator, the PR also includes some basic clean-up that was supposed to be included as part of a closed PR before the apocalypse.