### PR TITLE
Improve boss respawn timer (revision)

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/bosstimer/Boss.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/bosstimer/Boss.java
@@ -46,7 +46,7 @@ enum Boss
 	KING_BLACK_DRAGON("King Black Dragon", 10, ChronoUnit.SECONDS, ItemID.PRINCE_BLACK_DRAGON),
 	SCORPIA("Scorpia", 10, ChronoUnit.SECONDS, ItemID.SCORPIAS_OFFSPRING),
 	VENENATIS("Venenatis", 30, ChronoUnit.SECONDS, ItemID.VENENATIS_SPIDERLING),
-	VETION("Vet'ion", 30, ChronoUnit.SECONDS, ItemID.VETION_JR),
+	VETION("Vet'ion Reborn", 30, ChronoUnit.SECONDS, ItemID.VETION_JR),
 	DAGANNOTH_PRIME("Dagannoth Prime", 90, ChronoUnit.SECONDS, ItemID.PET_DAGANNOTH_PRIME),
 	DAGANNOTH_REX("Dagannoth Rex", 90, ChronoUnit.SECONDS, ItemID.PET_DAGANNOTH_REX),
 	DAGANNOTH_SUPREME("Dagannoth Supreme", 90, ChronoUnit.SECONDS, ItemID.PET_DAGANNOTH_SUPREME),

--- a/runelite-client/src/main/java/net/runelite/client/plugins/bosstimer/Boss.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/bosstimer/Boss.java
@@ -55,7 +55,8 @@ enum Boss
 	DERANGED_ARCHAEOLOGIST("Deranged archaeologist", 30, ChronoUnit.SECONDS, ItemID.UNIDENTIFIED_LARGE_FOSSIL),
 	CERBERUS("Cerberus", 10800, ChronoUnit.MILLIS, ItemID.HELLPUPPY),
 	THERMONUCLEAR_SMOKE_DEVIL("Thermonuclear smoke devil", 12, ChronoUnit.SECONDS, ItemID.PET_SMOKE_DEVIL),
-	KRAKEN("Kraken", 10800, ChronoUnit.MILLIS, ItemID.PET_KRAKEN);
+	KRAKEN("Kraken", 10800, ChronoUnit.MILLIS, ItemID.PET_KRAKEN),
+	KALPHITE_QUEEN("Kalphite Queen", 30, ChronoUnit.SECONDS, ItemID.KALPHITE_PRINCESS);
 
 	private static final Map<String, Boss> bosses = new HashMap<>();
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/bosstimer/BossTimersPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/bosstimer/BossTimersPlugin.java
@@ -29,7 +29,7 @@ import com.google.common.eventbus.Subscribe;
 import javax.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Actor;
-import net.runelite.api.events.ActorDeath;
+import net.runelite.api.events.ActorDespawned;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
@@ -54,9 +54,9 @@ public class BossTimersPlugin extends Plugin
 	}
 
 	@Subscribe
-	public void onActorDeath(ActorDeath death)
+	public void onActorDespawned(ActorDespawned despawned)
 	{
-		Actor actor = death.getActor();
+		Actor actor = despawned.getActor();
 
 		Boss boss = Boss.find(actor.getName());
 		if (boss == null)


### PR DESCRIPTION
Improve the accuracy of the boss respawn timer by starting it when the boss despawns.
Add KQ to boss list per request #2630 
Fix Vet'ion timer to start after 2nd phase death instead of first per request #3017