### PR TITLE
Add HP bar & Pray bar for inventory

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/hpandprayeroverlay/hpAndPrayerConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/hpandprayeroverlay/hpAndPrayerConfig.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2018, Jos <Malevolentdev@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.hpandprayeroverlay;
+
+import com.google.inject.Provides;
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.plugins.metronome.MetronomePluginConfiguration;
+
+@ConfigGroup(
+        keyName = "hpandprayeroverlay",
+        name = "HP & Prayer overlay",
+        description = "Configuration for the HP & Prayer overlay plugin"
+)
+public interface hpAndPrayerConfig extends Config
+{
+
+    @ConfigItem(
+            keyName = "enableHP",
+            name = "Enable HP bar",
+            description = "Toggles a HP bar in the inventory left side",
+            position = 2
+    )
+    default boolean enableHP()
+    {
+        return true;
+    }
+
+    @ConfigItem(
+            keyName = "enablePray",
+            name = "Enable Pray bar",
+            description = "Toggles a Prayer bar in the inventory right side",
+            position = 3
+    )
+    default boolean enablePray()
+    {
+        return true;
+    }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/hpandprayeroverlay/hpAndPrayerConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/hpandprayeroverlay/hpAndPrayerConfig.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018, Jos <Malevolentdev@gmail.com>
+ * Creation date : 26-5-2018
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -24,12 +25,10 @@
  */
 package net.runelite.client.plugins.hpandprayeroverlay;
 
-import com.google.inject.Provides;
+
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
-import net.runelite.client.config.ConfigManager;
-import net.runelite.client.plugins.metronome.MetronomePluginConfiguration;
 
 @ConfigGroup(
         keyName = "hpandprayeroverlay",
@@ -38,7 +37,6 @@ import net.runelite.client.plugins.metronome.MetronomePluginConfiguration;
 )
 public interface hpAndPrayerConfig extends Config
 {
-
     @ConfigItem(
             keyName = "enableHP",
             name = "Enable HP bar",
@@ -49,6 +47,7 @@ public interface hpAndPrayerConfig extends Config
     {
         return true;
     }
+
 
     @ConfigItem(
             keyName = "enablePray",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/hpandprayeroverlay/hpAndPrayerOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/hpandprayeroverlay/hpAndPrayerOverlay.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2018, Jos <Malevolentdev@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.hpandprayeroverlay;
+
+import java.awt.BasicStroke;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Graphics2D;
+import java.awt.Rectangle;
+import java.awt.RenderingHints;
+import java.awt.Stroke;
+import java.awt.geom.Arc2D;
+import javax.inject.Inject;
+
+import com.google.common.eventbus.Subscribe;
+import com.sun.javafx.scene.web.Debugger;
+import net.runelite.api.Client;
+import net.runelite.api.Prayer;
+import net.runelite.api.Skill;
+import net.runelite.api.events.BoostedLevelChanged;
+import net.runelite.api.events.GameStateChanged;
+import net.runelite.api.events.ResizeableChanged;
+import net.runelite.api.widgets.Widget;
+import net.runelite.api.widgets.WidgetInfo;
+import net.runelite.client.game.SkillIconManager;
+import net.runelite.client.ui.overlay.Overlay;
+import net.runelite.client.ui.overlay.OverlayLayer;
+import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.components.PanelComponent;
+import sun.security.ssl.Debug;
+
+class hpAndPrayerOverlay extends Overlay
+{
+
+    private final Client client;
+    private hpAndPrayerPlugin plugin;
+    private hpAndPrayerConfig config;
+
+    @Inject
+    public hpAndPrayerOverlay(Client client, hpAndPrayerPlugin plugin, hpAndPrayerConfig config)
+    {
+
+        setPosition(OverlayPosition.DYNAMIC);
+        setLayer(OverlayLayer.ABOVE_WIDGETS);
+
+        this.client = client;
+        this.plugin = plugin;
+        this.config = config;
+    }
+
+    @Inject
+    private SkillIconManager iconManager;
+
+
+    @Override
+    public Dimension render(Graphics2D g) {
+
+
+        int realHpLevel = client.getRealSkillLevel(Skill.HITPOINTS);
+        int realPrayerLevel = client.getRealSkillLevel(Skill.PRAYER);
+        int boostedHpLevel = client.getBoostedSkillLevel(Skill.HITPOINTS);
+        int boostedPrayerLevel = client.getBoostedSkillLevel(Skill.PRAYER);
+        int healthBarheight = (boostedHpLevel * 224) / realHpLevel;
+        int prayerBarheight = (boostedPrayerLevel * 224) / realPrayerLevel;
+        int healthBarPosition = 455 - healthBarheight;
+        int prayerBarPosition = 453 - prayerBarheight;
+
+
+
+        if (config.enableHP()){
+
+            // Fixed bars for fixed client
+            g.setColor(Color.BLACK);
+            g.fillRect(530, 229,13,228);
+            g.setColor(Color.red);
+            g.fillRect(532, 231,9,224);
+            g.drawImage(iconManager.getSkillImage(Skill.HITPOINTS),527,209,20,18,null);
+
+            // dynamic bar
+            g.setColor(Color.GREEN);
+            g.fillRect(532, healthBarPosition,9, healthBarheight);
+        }
+
+        if (config.enablePray()){
+
+            // Fixed bars for fixed client
+            g.setColor(Color.BLACK);
+            g.fillRect(741, 227,13,228);
+            g.setColor(Color.BLUE);
+            g.fillRect(743, 229,9,224);
+            g.drawImage(iconManager.getSkillImage(Skill.PRAYER),736,204,23,23,null);
+
+            //dynamic bar
+            g.setColor(Color.CYAN);
+            g.fillRect(743, prayerBarPosition,9,prayerBarheight);
+
+        }
+
+        if (client.isResized()){
+            setPosition(OverlayPosition.BOTTOM_RIGHT);
+
+            Color c=new Color(90,91,94,127 );
+            g.setColor(c);
+            g.fillRect(-43, -133,53,258);
+
+            if (config.enableHP()){
+
+                // Fixed bars for fixed client
+                g.setColor(Color.BLACK);
+                g.fillRect(-34, -106,13,228);
+                g.setColor(Color.red);
+                g.fillRect(-32, -104,9,224);
+                g.drawImage(iconManager.getSkillImage(Skill.HITPOINTS),-37,-125,20,18,null);
+
+                // dynamic bar
+                g.setColor(Color.GREEN);
+                g.fillRect(-32, 120 - healthBarheight,9, healthBarheight);
+            }
+
+            if (config.enablePray()){
+                // Fixed bars for fixed client
+                g.setColor(Color.BLACK);
+                g.fillRect(-10, -106,13,228);
+                g.setColor(Color.BLUE);
+                g.fillRect(-8, -104,9,224);
+                g.drawImage(iconManager.getSkillImage(Skill.PRAYER),-15,-130,23,23,null);
+
+                //dynamic bar
+                g.setColor(Color.CYAN);
+                g.fillRect(0 - 8,  120 - prayerBarheight,9,prayerBarheight);
+            }
+        }
+        else
+            setPosition(OverlayPosition.DYNAMIC);
+        return null;
+    }
+}
+

--- a/runelite-client/src/main/java/net/runelite/client/plugins/hpandprayeroverlay/hpAndPrayerOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/hpandprayeroverlay/hpAndPrayerOverlay.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018, Jos <Malevolentdev@gmail.com>
+ * Creation date : 26-5-2018
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -24,36 +25,19 @@
  */
 package net.runelite.client.plugins.hpandprayeroverlay;
 
-import java.awt.BasicStroke;
 import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Graphics2D;
-import java.awt.Rectangle;
-import java.awt.RenderingHints;
-import java.awt.Stroke;
-import java.awt.geom.Arc2D;
 import javax.inject.Inject;
-
-import com.google.common.eventbus.Subscribe;
-import com.sun.javafx.scene.web.Debugger;
 import net.runelite.api.Client;
-import net.runelite.api.Prayer;
 import net.runelite.api.Skill;
-import net.runelite.api.events.BoostedLevelChanged;
-import net.runelite.api.events.GameStateChanged;
-import net.runelite.api.events.ResizeableChanged;
-import net.runelite.api.widgets.Widget;
-import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.game.SkillIconManager;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
-import net.runelite.client.ui.overlay.components.PanelComponent;
-import sun.security.ssl.Debug;
 
 class hpAndPrayerOverlay extends Overlay
 {
-
     private final Client client;
     private hpAndPrayerPlugin plugin;
     private hpAndPrayerConfig config;
@@ -61,22 +45,18 @@ class hpAndPrayerOverlay extends Overlay
     @Inject
     public hpAndPrayerOverlay(Client client, hpAndPrayerPlugin plugin, hpAndPrayerConfig config)
     {
-
         setPosition(OverlayPosition.DYNAMIC);
         setLayer(OverlayLayer.ABOVE_WIDGETS);
-
         this.client = client;
         this.plugin = plugin;
         this.config = config;
     }
-
     @Inject
     private SkillIconManager iconManager;
 
 
     @Override
     public Dimension render(Graphics2D g) {
-
 
         int realHpLevel = client.getRealSkillLevel(Skill.HITPOINTS);
         int realPrayerLevel = client.getRealSkillLevel(Skill.PRAYER);
@@ -86,8 +66,6 @@ class hpAndPrayerOverlay extends Overlay
         int prayerBarheight = (boostedPrayerLevel * 224) / realPrayerLevel;
         int healthBarPosition = 455 - healthBarheight;
         int prayerBarPosition = 453 - prayerBarheight;
-
-
 
         if (config.enableHP()){
 
@@ -118,6 +96,7 @@ class hpAndPrayerOverlay extends Overlay
 
         }
 
+        // Resizable position settings are changed here
         if (client.isResized()){
             setPosition(OverlayPosition.BOTTOM_RIGHT);
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/hpandprayeroverlay/hpAndPrayerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/hpandprayeroverlay/hpAndPrayerPlugin.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2018, Jos <Malevolentdev@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.hpandprayeroverlay;
+
+import com.google.common.eventbus.Subscribe;
+import com.google.inject.Provides;
+import javax.inject.Inject;
+import lombok.Getter;
+import net.runelite.api.Client;
+import net.runelite.api.GameState;
+import net.runelite.api.Prayer;
+import net.runelite.api.VarPlayer;
+import net.runelite.api.Skill;
+import net.runelite.api.events.GameStateChanged;
+import net.runelite.api.events.GameTick;
+import net.runelite.api.events.ResizeableChanged;
+import net.runelite.api.events.VarbitChanged;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.ui.overlay.Overlay;
+import org.omg.PortableServer.POAPackage.ObjectNotActive;
+
+
+@PluginDescriptor(
+        name = "HP & Prayer overlay",
+        enabledByDefault = false
+)
+
+public class hpAndPrayerPlugin extends Plugin
+{
+    @Inject
+    private Client client;
+    @Inject
+    private hpAndPrayerConfig config;
+    @Inject
+    private hpAndPrayerOverlay overlay;
+
+    @Override
+    public Overlay getOverlay() {return overlay;}
+
+    @Provides
+    hpAndPrayerConfig provideConfig(ConfigManager configManager) {return configManager.getConfig(hpAndPrayerConfig.class);}
+
+
+
+
+
+
+
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/hpandprayeroverlay/hpAndPrayerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/hpandprayeroverlay/hpAndPrayerPlugin.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018, Jos <Malevolentdev@gmail.com>
+ * Creation date : 26-5-2018
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
I wanted to try and managed to create my first plugin for runelite after creating the feature request :
- HP bar & Pray bar feature request. #2943

The plugin adds a HP & Prayer bar into your inventory UI, which makes it easier on the eyes so you dont
have to look at the right top corner of your screen to check your hp or prayer.
You can also selectively turn on or off the HP or Prayer bar via the config.

https://gyazo.com/90105e908ee047a8e47651549e38cca6

This also works for the resizeable mode:

https://gyazo.com/168d4b0cd71eff764fe5b5f52c63e3c8

I am only not sure about my code, i'm not that experienced yet but it works.




