### PR TITLE
Add top margin to the error panel

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpPanel.java
@@ -133,7 +133,6 @@ class XpPanel extends PluginPanel
 		}
 
 		errorPanel.setContent("Exp trackers", "You have not gained experience yet.");
-		errorPanel.setBorder(new EmptyBorder(0, 0, 0, 0));
 		add(errorPanel);
 	}
 


### PR DESCRIPTION
This was somehow removed in the latest PluginPanel updates, all other
panels were unaffected, by this was. Simple fix, a 50px empty border
should do the job.