### PR TITLE
Fix ArrayIndexOutOfBoundsException when an empty command is typed

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/chat/CommandManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/chat/CommandManager.java
@@ -67,6 +67,12 @@ public class CommandManager
 
 		String[] split = typedText.split(" ");
 
+		// Fixes ArrayIndexOutOfBounds when typing ":: "
+		if (split.length == 0)
+		{
+			return;
+		}
+
 		String command = split[0];
 		String[] args = Arrays.copyOfRange(split, 1, split.length);
 


### PR DESCRIPTION
Fixes the following exception:
```2018-05-19 15:25:19 [Thread-5] WARN  net.runelite.client.RuneLiteModule - uncaught exception in event subscriber
java.lang.ArrayIndexOutOfBoundsException: 0
	at net.runelite.client.chat.CommandManager.scriptEvent(CommandManager.java:70)
	at sun.reflect.GeneratedMethodAccessor110.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at com.google.common.eventbus.Subscriber.invokeSubscriberMethod(Subscriber.java:91)
	at com.google.common.eventbus.Subscriber$SynchronizedSubscriber.invokeSubscriberMethod(Subscriber.java:150)
	at com.google.common.eventbus.Subscriber$1.run(Subscriber.java:76)
	at com.google.common.util.concurrent.MoreExecutors$DirectExecutor.execute(MoreExecutors.java:399)
	at com.google.common.eventbus.Subscriber.dispatchEvent(Subscriber.java:71)
	at com.google.common.eventbus.Dispatcher$PerThreadQueuedDispatcher.dispatch(Dispatcher.java:116)
	at com.google.common.eventbus.EventBus.post(EventBus.java:217)
	at client.vmExecuteOpcode(client.java:104)
	at client.copy$runScript(client.java:146)
	at bk.m(bk.java:121)
	at bm.w(bm.java:90)
	at client.fe(client.java:3072)
	at client.ao(client.java:1382)
	at aa.at(aa.java:402)
	at aa.copy$run(aa.java:381)
	at aa.run(aa.java:60)
	at java.lang.Thread.run(Thread.java:748) 
```
when typing ":: " (space included)