### PR TITLE
grandexchange: Format 'Price each' value for items

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangeOfferSlot.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangeOfferSlot.java
@@ -233,7 +233,7 @@ public class GrandExchangeOfferSlot extends JPanel
 
 			offerInfo.setText(offerState);
 
-			itemPrice.setText(htmlLabel("Price each: ", newOffer.getPrice() + ""));
+			itemPrice.setText(htmlLabel("Price each: ", StackFormatter.formatNumber(newOffer.getPrice())));
 
 			String action = buying ? "Spent: " : "Received: ";
 


### PR DESCRIPTION
Adds proper formatting for large values in the 'Price each' line of additional information of a grand exchange offer. For example, "19000000" gets formatted as "19,000,000".