### PR TITLE
Add ability to disable Left Click to bank inventory, equipment, and looting bag options

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/events/MenuShouldLeftClick.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/MenuShouldLeftClick.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2019, Adam <Adam@sigterm.info>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.api.events;
+
+import lombok.Data;
+
+/**
+ * Event called when the client is checking if the menu should be
+ * opened on left click.
+ */
+@Data
+public class MenuShouldLeftClick
+{
+	/**
+	 * If set to true, the menu will open on left click.
+	 */
+	private boolean forceRightClick;
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/bank/BankCalculation.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/bank/BankCalculation.java
@@ -22,7 +22,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package net.runelite.client.plugins.bankvalue;
+package net.runelite.client.plugins.bank;
 
 import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
@@ -60,7 +60,7 @@ class BankCalculation
 		Varbits.BANK_TAB_NINE_COUNT
 	);
 
-	private final BankValueConfig config;
+	private final BankConfig config;
 	private final ItemManager itemManager;
 	private final Client client;
 
@@ -74,7 +74,7 @@ class BankCalculation
 	private long haPrice;
 
 	@Inject
-	BankCalculation(ItemManager itemManager, BankValueConfig config, Client client)
+	BankCalculation(ItemManager itemManager, BankConfig config, Client client)
 	{
 		this.itemManager = itemManager;
 		this.config = config;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/bank/BankConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/bank/BankConfig.java
@@ -64,4 +64,37 @@ public interface BankConfig extends Config
 	{
 		return false;
 	}
+
+	@ConfigItem(
+		keyName = "rightClickBankInventory",
+		name = "Disable left click bank inventory",
+		description = "Configures whether the bank inventory button will bank your inventory on left click",
+		position = 4
+	)
+	default boolean rightClickBankInventory()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		keyName = "rightClickBankEquip",
+		name = "Disable left click bank equipment",
+		description = "Configures whether the bank equipment button will bank your equipment on left click",
+		position = 5
+	)
+	default boolean rightClickBankEquip()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		keyName = "rightClickBankLoot",
+		name = "Disable left click bank looting bag",
+		description = "Configures whether the bank looting bag button will bank your looting bag contents on left click",
+		position = 6
+	)
+	default boolean rightClickBankLoot()
+	{
+		return false;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/bank/BankConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/bank/BankConfig.java
@@ -23,14 +23,14 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package net.runelite.client.plugins.bankvalue;
+package net.runelite.client.plugins.bank;
 
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
 
-@ConfigGroup("bankvalue")
-public interface BankValueConfig extends Config
+@ConfigGroup("bank")
+public interface BankConfig extends Config
 {
 	@ConfigItem(
 		keyName = "showGE",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/bank/BankPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/bank/BankPlugin.java
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2018, TheLonelyDev <https://github.com/TheLonelyDev>
  * Copyright (c) 2018, Jeremy Plsek <https://github.com/jplsek>
+ * Copyright (c) 2019, Hydrox6 <ikada@protonmail.ch>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -28,6 +29,9 @@ package net.runelite.client.plugins.bank;
 import com.google.inject.Provides;
 import javax.inject.Inject;
 import net.runelite.api.Client;
+import net.runelite.api.MenuEntry;
+import net.runelite.api.events.MenuEntryAdded;
+import net.runelite.api.events.MenuShouldLeftClick;
 import net.runelite.api.events.ScriptCallbackEvent;
 import net.runelite.client.callback.ClientThread;
 import net.runelite.client.config.ConfigManager;
@@ -44,6 +48,10 @@ import net.runelite.client.util.StackFormatter;
 )
 public class BankPlugin extends Plugin
 {
+	private static final String DEPOSIT_WORN = "Deposit worn items";
+	private static final String DEPOSIT_INVENTORY = "Deposit inventory";
+	private static final String DEPOSIT_LOOT = "Deposit loot";
+
 	@Inject
 	private Client client;
 
@@ -59,6 +67,8 @@ public class BankPlugin extends Plugin
 	@Inject
 	private BankSearch bankSearch;
 
+	private boolean forceRightClickFlag;
+
 	@Provides
 	BankConfig getConfig(ConfigManager configManager)
 	{
@@ -69,6 +79,40 @@ public class BankPlugin extends Plugin
 	protected void shutDown()
 	{
 		clientThread.invokeLater(() -> bankSearch.reset(false));
+		forceRightClickFlag = false;
+	}
+
+	@Subscribe
+	public void onMenuShouldLeftClick(MenuShouldLeftClick event)
+	{
+		if (!forceRightClickFlag)
+		{
+			return;
+		}
+
+		forceRightClickFlag = false;
+		MenuEntry[] menuEntries = client.getMenuEntries();
+		for (MenuEntry entry : menuEntries)
+		{
+			if ((entry.getOption().equals(DEPOSIT_WORN) && config.rightClickBankEquip())
+				|| (entry.getOption().equals(DEPOSIT_INVENTORY) && config.rightClickBankInventory())
+				|| (entry.getOption().equals(DEPOSIT_LOOT) && config.rightClickBankLoot()))
+			{
+				event.setForceRightClick(true);
+				return;
+			}
+		}
+	}
+
+	@Subscribe
+	public void onMenuEntryAdded(MenuEntryAdded event)
+	{
+		if ((event.getOption().equals(DEPOSIT_WORN) && config.rightClickBankEquip())
+			|| (event.getOption().equals(DEPOSIT_INVENTORY) && config.rightClickBankInventory())
+			|| (event.getOption().equals(DEPOSIT_LOOT) && config.rightClickBankLoot()))
+		{
+			forceRightClickFlag = true;
+		}
 	}
 
 	@Subscribe

--- a/runelite-client/src/main/java/net/runelite/client/plugins/bank/BankPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/bank/BankPlugin.java
@@ -23,7 +23,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package net.runelite.client.plugins.bankvalue;
+package net.runelite.client.plugins.bank;
 
 import com.google.inject.Provides;
 import javax.inject.Inject;
@@ -38,11 +38,11 @@ import net.runelite.client.plugins.banktags.tabs.BankSearch;
 import net.runelite.client.util.StackFormatter;
 
 @PluginDescriptor(
-	name = "Bank Value",
-	description = "Show the value of your bank and/or current tab",
-	tags = {"grand", "exchange", "high", "alchemy", "prices"}
+	name = "Bank",
+	description = "Modifications to the banking interface",
+	tags = {"grand", "exchange", "high", "alchemy", "prices", "deposit"}
 )
-public class BankValuePlugin extends Plugin
+public class BankPlugin extends Plugin
 {
 	@Inject
 	private Client client;
@@ -54,15 +54,15 @@ public class BankValuePlugin extends Plugin
 	private BankCalculation bankCalculation;
 
 	@Inject
-	private BankValueConfig config;
+	private BankConfig config;
 
 	@Inject
 	private BankSearch bankSearch;
 
 	@Provides
-	BankValueConfig getConfig(ConfigManager configManager)
+	BankConfig getConfig(ConfigManager configManager)
 	{
-		return configManager.getConfig(BankValueConfig.class);
+		return configManager.getConfig(BankConfig.class);
 	}
 
 	@Override

--- a/runelite-client/src/test/java/net/runelite/client/plugins/bank/BankCalculationTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/bank/BankCalculationTest.java
@@ -22,7 +22,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package net.runelite.client.plugins.bankvalue;
+package net.runelite.client.plugins.bank;
 
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Guice;
@@ -58,7 +58,7 @@ public class BankCalculationTest
 
 	@Mock
 	@Bind
-	private BankValueConfig bankValueConfig;
+	private BankConfig bankConfig;
 
 	@Inject
 	private BankCalculation bankCalculation;
@@ -72,7 +72,7 @@ public class BankCalculationTest
 	@Test
 	public void testCalculate()
 	{
-		when(bankValueConfig.showHA())
+		when(bankConfig.showHA())
 			.thenReturn(true);
 
 		Item coins = mock(Item.class);

--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSClientMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSClientMixin.java
@@ -85,6 +85,7 @@ import net.runelite.api.events.GrandExchangeOfferChanged;
 import net.runelite.api.events.MenuEntryAdded;
 import net.runelite.api.events.MenuOpened;
 import net.runelite.api.events.MenuOptionClicked;
+import net.runelite.api.events.MenuShouldLeftClick;
 import net.runelite.api.events.NpcSpawned;
 import net.runelite.api.events.PlayerDespawned;
 import net.runelite.api.events.PlayerMenuOptionsChanged;
@@ -1465,6 +1466,14 @@ public abstract class RSClientMixin implements RSClient
 	boolean rl$shouldLeftClickOpenMenu()
 	{
 		if (rs$shouldLeftClickOpenMenu())
+		{
+			return true;
+		}
+
+		MenuShouldLeftClick menuShouldLeftClick = new MenuShouldLeftClick();
+		client.getCallbacks().post(menuShouldLeftClick);
+
+		if (menuShouldLeftClick.isForceRightClick())
 		{
 			return true;
 		}


### PR DESCRIPTION
Closes #2867

When the options are enabled, the relevant Deposit options are set to open the right click menu, like the Bank Fillers currently do.

In Action:
![](https://thumbs.gfycat.com/CircularPresentFanworms-max-14mb.gif)

This is in it's own plugin due to not really being a Menu Entry swap, and I'm tempted to merge the other bank plugins into it (Bank Value, Bank Tags), though I'm not sure if merging Bank Tags would be a good idea. Open to ideas on that front.