### PR TITLE
attackstyles-adjustment

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/attackstyles/AttackStylesOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/attackstyles/AttackStylesOverlay.java
@@ -64,7 +64,7 @@ public class AttackStylesOverlay extends Overlay
 
 			panelComponent.setPreferredSize(new Dimension(
 				graphics.getFontMetrics().stringWidth(attackStyleString) + 10,
-				0));
+				28));
 
 			return panelComponent.render(graphics);
 		}


### PR DESCRIPTION
Adjust the height of the attackstyle panelComponent to make the text not hug the bottom of the panel.

(i.e. Aggressive touches the bottom of the panel currently. Commit adjusts the height to eliminate this issue.)