### PR TITLE
Fix items with no Grand Exchange Price using Store Price for the right click menu instead of High Alchemy value

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
@@ -380,7 +380,7 @@ public class GroundItemsPlugin extends Plugin
 			}
 
 			ItemPrice itemPrice = getItemPrice(itemComposition);
-			int price = itemPrice == null ? itemComposition.getPrice() : itemPrice.getPrice();
+			int price = itemPrice == null ? (int)Math.floor(itemComposition.getPrice() * HIGH_ALCHEMY_CONSTANT) : itemPrice.getPrice();
 			int cost = quantity * price;
 			Color color = overlay.getCostColor(cost, isHighlighted(itemComposition.getName()),
 				isHidden(itemComposition.getName()));


### PR DESCRIPTION
Before this fix, if an item did not have a grand exchange value, the overlay would use its High Alchemy value, but the right click menu would use the full store price value.

For Example, I have Green set to >20k and Blue set to >100k 
![runelite_2018-05-28_10-26-21](https://user-images.githubusercontent.com/2979691/40609828-d22568a0-6267-11e8-8d46-38e0f172975d.png)
This happens because, to get that 61.5k alch value, the Ecu key's Store Price is ~102k.