### PR TITLE
Add simple clue scroll instance map

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,6 +120,8 @@
 		<module>runelite-api</module>
 		<module>runelite-client</module>
 		<module>runelite-mixins</module>
+		<module>runelite-map-assembler-plugin</module>
+		<module>runelite-map</module>
 		<module>runelite-script-assembler-plugin</module>
 		<module>runelite-scripts</module>
 		<module>runescape-api</module>

--- a/runelite-client/pom.xml
+++ b/runelite-client/pom.xml
@@ -121,6 +121,11 @@
 		</dependency>
 		<dependency>
 			<groupId>net.runelite</groupId>
+			<artifactId>map</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>net.runelite</groupId>
 			<artifactId>http-api</artifactId>
 			<version>${project.version}</version>
 		</dependency>

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/ClueScrollConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/ClueScrollConfig.java
@@ -44,4 +44,14 @@ public interface ClueScrollConfig extends Config
 	{
 		return true;
 	}
+
+	@ConfigItem(
+		keyName = "showMapOnFirstRead",
+		name = "Show instance map on first read",
+		description = "Configures whether or not the instance map is auto-shown on first read"
+	)
+	default boolean showOnFirstRead()
+	{
+		return false;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/instancemap/InstanceMapInputListener.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/instancemap/InstanceMapInputListener.java
@@ -29,10 +29,12 @@ import java.awt.event.KeyEvent;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseWheelEvent;
 import javax.inject.Inject;
+import javax.inject.Singleton;
 import net.runelite.client.input.KeyListener;
 import net.runelite.client.input.MouseListener;
 import net.runelite.client.input.MouseWheelListener;
 
+@Singleton
 public class InstanceMapInputListener extends MouseListener implements KeyListener, MouseWheelListener
 {
 	@Inject
@@ -57,7 +59,8 @@ public class InstanceMapInputListener extends MouseListener implements KeyListen
 
 		if (event.getKeyCode() == KeyEvent.VK_ESCAPE)
 		{
-			plugin.closeMap();
+			overlay.setShowMap(false);
+			plugin.setMenuState(false);
 			event.consume();
 		}
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/instancemap/InstanceMapInputListener.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/instancemap/InstanceMapInputListener.java
@@ -52,16 +52,20 @@ public class InstanceMapInputListener extends MouseListener implements KeyListen
 	@Override
 	public void keyPressed(KeyEvent event)
 	{
-		if (!overlay.isMapShown())
-		{
-			return;
-		}
-
 		if (event.getKeyCode() == KeyEvent.VK_ESCAPE)
 		{
-			overlay.setShowMap(false);
-			plugin.setMenuState(false);
-			event.consume();
+			if (overlay.isMapShown())
+			{
+				overlay.setShowMap(false);
+				plugin.setMenuState(false);
+				event.consume();
+			}
+			else if (event.isShiftDown())
+			{
+				overlay.setShowMap(true);
+				plugin.setMenuState(true);
+				event.consume();
+			}
 		}
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/instancemap/InstanceMapOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/instancemap/InstanceMapOverlay.java
@@ -27,6 +27,7 @@ package net.runelite.client.plugins.instancemap;
 import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Graphics2D;
+import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.image.BufferedImage;
 import javax.inject.Inject;
@@ -36,6 +37,7 @@ import net.runelite.api.Player;
 import net.runelite.api.SpritePixels;
 import net.runelite.api.Tile;
 import net.runelite.api.coords.LocalPoint;
+import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.MapRegionChanged;
 import net.runelite.client.ui.overlay.Overlay;
@@ -43,6 +45,7 @@ import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.OverlayPriority;
 import net.runelite.client.ui.overlay.components.BackgroundComponent;
+import net.runelite.client.util.WorldMapView;
 
 @Singleton
 class InstanceMapOverlay extends Overlay
@@ -52,12 +55,12 @@ class InstanceMapOverlay extends Overlay
 	 * this value to be 4. Changing this will break the method for rendering
 	 * complex tiles
 	 */
-	static final int TILE_SIZE = 4;
+	private static final int TILE_SIZE = 4;
 
 	/**
 	 * The size of the player's position marker on the map
 	 */
-	private static final int PLAYER_MARKER_SIZE = 4;
+	private static final int DOT_SIZE = 4;
 
 	private static final int MAX_PLANE = 3;
 	private static final int MIN_PLANE = 0;
@@ -71,6 +74,7 @@ class InstanceMapOverlay extends Overlay
 	private int viewedPlane = 0;
 
 	private final Client client;
+	private final WorldMapView worldMapView;
 
 	/**
 	 * Saved image of the region, no reason to draw the whole thing every
@@ -78,16 +82,18 @@ class InstanceMapOverlay extends Overlay
 	 */
 	private volatile BufferedImage mapImage;
 	private volatile boolean showMap = false;
+	private volatile WorldPoint mapLocation;
 	private final BackgroundComponent backgroundComponent = new BackgroundComponent();
 
 	@Inject
-	InstanceMapOverlay(Client client)
+	private InstanceMapOverlay(final Client client, final WorldMapView worldMapView)
 	{
 		this.client = client;
+		this.worldMapView = worldMapView;
+		backgroundComponent.setFill(false);
 		setPriority(OverlayPriority.HIGH);
 		setPosition(OverlayPosition.TOP_LEFT);
 		setLayer(OverlayLayer.ABOVE_WIDGETS);
-		backgroundComponent.setFill(false);
 	}
 
 	public boolean isMapShown()
@@ -110,6 +116,7 @@ class InstanceMapOverlay extends Overlay
 			viewedPlane = client.getPlane();
 		}
 		mapImage = null;
+		mapLocation = null;
 	}
 
 	/**
@@ -140,6 +147,25 @@ class InstanceMapOverlay extends Overlay
 		mapImage = null;
 	}
 
+	/**
+	 * Open the instance map at specified location
+	 * @param mapLocation map location
+	 */
+	public void openAt(final WorldPoint mapLocation)
+	{
+		if (this.mapLocation != mapLocation)
+		{
+			setShowMap(mapLocation != null);
+			this.mapLocation = mapLocation;
+			mapImage = null;
+
+			if (mapLocation != null)
+			{
+				viewedPlane = mapLocation.getPlane();
+			}
+		}
+	}
+
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
@@ -153,8 +179,20 @@ class InstanceMapOverlay extends Overlay
 
 		if (image == null)
 		{
-			SpritePixels map = client.drawInstanceMap(viewedPlane);
-			image = minimapToBufferedImage(map);
+			if (mapLocation == null)
+			{
+				SpritePixels map = client.drawInstanceMap(viewedPlane);
+				image = minimapToBufferedImage(map);
+			}
+			else
+			{
+				worldMapView.setZoom(1);
+				worldMapView.setCenter(new WorldPoint(mapLocation.getX(), mapLocation.getY(), viewedPlane));
+				worldMapView.setGraphicsWidth(TILE_SIZE * 104);
+				worldMapView.setGraphicsHeight(TILE_SIZE * 104);
+				image = worldMapView.buildMapImage();
+			}
+
 			synchronized (this)
 			{
 				if (showMap)
@@ -168,14 +206,14 @@ class InstanceMapOverlay extends Overlay
 		backgroundComponent.setRectangle(new Rectangle(0, 0, image.getWidth(), image.getHeight()));
 		backgroundComponent.render(graphics);
 
-		if (client.getPlane() == viewedPlane)//If we are not viewing the plane we are on, don't show player's position
+		if (mapLocation != null)
+		{
+			final Point point = worldMapView.worldPointToGraphicsPoint(mapLocation);
+			drawDot(graphics, point.x, point.y, Color.white, Color.black);
+		}
+		else if (client.getPlane() == viewedPlane) //If we are not viewing the plane we are on, don't show player's position
 		{
 			drawPlayerDot(graphics, client.getLocalPlayer(), Color.white, Color.black);
-		}
-
-		if (image == null)
-		{
-			return null;
 		}
 
 		return new Dimension(image.getWidth(), image.getHeight());
@@ -205,13 +243,17 @@ class InstanceMapOverlay extends Overlay
 		Tile[][] tiles = getTiles();
 		int tileX = playerLoc.getRegionX();
 		int tileY = (tiles[0].length - 1) - playerLoc.getRegionY(); // flip the y value
+		int x = tileX * TILE_SIZE;
+		int y = tileY * TILE_SIZE;
+		drawDot(graphics, x, y, dotColor, outlineColor);
+	}
 
-		int x = (int) (tileX * TILE_SIZE);
-		int y = (int) (tileY * TILE_SIZE);
+	private void drawDot(Graphics2D graphics, int x, int y, Color dotColor, Color outlineColor)
+	{
 		graphics.setColor(dotColor);
-		graphics.fillRect(x, y, PLAYER_MARKER_SIZE, PLAYER_MARKER_SIZE);//draw the players point on the map
+		graphics.fillRect(x, y, DOT_SIZE, DOT_SIZE);//draw the point on the map
 		graphics.setColor(outlineColor);
-		graphics.drawRect(x, y, PLAYER_MARKER_SIZE, PLAYER_MARKER_SIZE);//outline
+		graphics.drawRect(x, y, DOT_SIZE, DOT_SIZE);//outline
 	}
 
 	/**

--- a/runelite-client/src/main/java/net/runelite/client/plugins/instancemap/InstanceMapPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/instancemap/InstanceMapPlugin.java
@@ -27,6 +27,8 @@ package net.runelite.client.plugins.instancemap;
 import com.google.common.eventbus.Subscribe;
 import com.google.inject.Binder;
 import javax.inject.Inject;
+import javax.inject.Singleton;
+import lombok.Getter;
 import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.MapRegionChanged;
 import net.runelite.api.events.WidgetMenuOptionClicked;
@@ -38,11 +40,11 @@ import net.runelite.client.menus.MenuManager;
 import net.runelite.client.menus.WidgetMenuOption;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
-import net.runelite.client.ui.overlay.Overlay;
 
 @PluginDescriptor(
 	name = "Instance Map"
 )
+@Singleton
 public class InstanceMapPlugin extends Plugin
 {
 	private final WidgetMenuOption openMapOption = new WidgetMenuOption("Show", "Instance Map", WidgetInfo.WORLD_MAP_OPTION);
@@ -51,6 +53,7 @@ public class InstanceMapPlugin extends Plugin
 	private InstanceMapInputListener inputListener;
 
 	@Inject
+	@Getter
 	private InstanceMapOverlay overlay;
 
 	@Inject
@@ -63,25 +66,15 @@ public class InstanceMapPlugin extends Plugin
 	private MouseManager mouseManager;
 
 	@Override
-	public void configure(Binder binder)
+	public void configure(final Binder binder)
 	{
-		binder.bind(InstanceMapInputListener.class);
-	}
-
-	private void addCustomOptions()
-	{
-		menuManager.addManagedCustomMenu(openMapOption);
-	}
-
-	private void removeCustomOptions()
-	{
-		menuManager.removeManagedCustomMenu(openMapOption);
+		binder.bind(InstanceMapService.class).to(InstanceMapServiceImpl.class);
 	}
 
 	@Override
 	protected void startUp() throws Exception
 	{
-		addCustomOptions();
+		menuManager.addManagedCustomMenu(openMapOption);
 		keyManager.registerKeyListener(inputListener);
 		mouseManager.registerMouseListener(inputListener);
 		mouseManager.registerMouseWheelListener(inputListener);
@@ -90,7 +83,7 @@ public class InstanceMapPlugin extends Plugin
 	@Override
 	protected void shutDown() throws Exception
 	{
-		removeCustomOptions();
+		menuManager.removeManagedCustomMenu(openMapOption);
 		keyManager.unregisterKeyListener(inputListener);
 		mouseManager.registerMouseListener(inputListener);
 		mouseManager.unregisterMouseWheelListener(inputListener);
@@ -123,33 +116,14 @@ public class InstanceMapPlugin extends Plugin
 
 		if (clickedOptionEquals(event, openMapOption))
 		{
-			if (overlay.isMapShown())
-			{
-				closeMap();
-			}
-			else
-			{
-				showMap();
-			}
+			setMenuState(!overlay.isMapShown());
+			overlay.setShowMap(!overlay.isMapShown());
 		}
 	}
 
-	@Override
-	public Overlay getOverlay()
+	public void setMenuState(boolean shown)
 	{
-		return overlay;
-	}
-
-	public void showMap()
-	{
-		overlay.setShowMap(true);
-		openMapOption.setMenuOption("Hide");
-	}
-
-	public void closeMap()
-	{
-		overlay.setShowMap(false);
-		openMapOption.setMenuOption("Show");
+		openMapOption.setMenuOption(shown ? "Hide" : "Show");
 	}
 
 	public void ascendMap()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/instancemap/InstanceMapService.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/instancemap/InstanceMapService.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2018, Tomas Slusny <slusnucky@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.instancemap;
+
+import net.runelite.api.coords.WorldPoint;
+
+/**
+ * Instance map service to be used for manipulation with the map.
+ */
+public interface InstanceMapService extends AutoCloseable
+{
+	/**
+	 * Open instance map at specified world point.
+	 *
+	 * @param point the point
+	 */
+	void openAt(final WorldPoint point);
+
+	/**
+	 * Checks if instance map is already open
+	 * @return true if map is open
+	 */
+	boolean isOpen();
+
+	@Override
+	void close();
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/instancemap/InstanceMapServiceImpl.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/instancemap/InstanceMapServiceImpl.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2018, Tomas Slusny <slusnucky@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.instancemap;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import net.runelite.api.coords.WorldPoint;
+
+@Singleton
+class InstanceMapServiceImpl implements InstanceMapService
+{
+	private final InstanceMapPlugin instanceMapPlugin;
+	private final InstanceMapOverlay instanceMapOverlay;
+
+	@Inject
+	private InstanceMapServiceImpl(final InstanceMapPlugin instanceMapPlugin, final InstanceMapOverlay instanceMapOverlay)
+	{
+		this.instanceMapPlugin = instanceMapPlugin;
+		this.instanceMapOverlay = instanceMapOverlay;
+	}
+
+	@Override
+	public void openAt(WorldPoint point)
+	{
+		if (point != null)
+		{
+			instanceMapOverlay.openAt(point);
+			instanceMapPlugin.setMenuState(instanceMapOverlay.isMapShown());
+		}
+	}
+
+	@Override
+	public void close()
+	{
+		instanceMapOverlay.openAt(null);
+		instanceMapPlugin.setMenuState(instanceMapOverlay.isMapShown());
+	}
+
+	@Override
+	public boolean isOpen()
+	{
+		return instanceMapOverlay.isMapShown();
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/mapTest/MapTestConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/mapTest/MapTestConfig.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2018 Morgan Lewis <http://github.com/MESLewis>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.mapTest;
+
+import java.awt.Dimension;
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+
+@ConfigGroup(
+	keyName = "devtoolsmap",
+	name = "Dev Tools Map",
+	description = "Configuration for developer tools map test"
+)
+public interface MapTestConfig extends Config
+{
+	@ConfigItem(
+		keyName = "mapTestCoords",
+		name = "Coordinates",
+		description = "Coordinates to display",
+		position = 2
+	)
+	default Dimension mapTestCoords()
+	{
+		return new Dimension(3222, 3217);
+	}
+
+	@ConfigItem(
+		keyName = "mapTestSize",
+		name = "Display Size",
+		description = "",
+		position = 3
+	)
+	default Dimension mapTestDisplay()
+	{
+		return new Dimension(100, 100);
+	}
+
+	@ConfigItem(
+		keyName = "mapTestZoom",
+		name = "Zoom",
+		description = "",
+		position = 4
+	)
+	default int mapTestZoom()
+	{
+		return 100;
+	}
+
+	@ConfigItem(
+		keyName = "mapTestMarkerCoords",
+		name = "Map Marker",
+		description = "Coordinates to display a mark on the map",
+		position = 5
+	)
+	default Dimension mapTestMarkerCoords()
+	{
+		return new Dimension(3225, 3217);
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/mapTest/MapTestPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/mapTest/MapTestPlugin.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2018, Morgan Lewis <https://github.com/MESLewis>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.mapTest;
+
+import com.google.common.eventbus.Subscribe;
+import com.google.inject.Provides;
+import java.awt.image.BufferedImage;
+import javax.inject.Inject;
+import lombok.Getter;
+import net.runelite.api.coords.WorldPoint;
+import net.runelite.api.events.ConfigChanged;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.util.WorldMapView;
+
+@PluginDescriptor(
+	name = "Map Test",
+	developerPlugin = true
+)
+public class MapTestPlugin extends Plugin
+{
+	@Inject
+	private MapViewOverlay overlay;
+
+	@Inject
+	private MapTestConfig config;
+
+	@Inject
+	@Getter
+	private WorldMapView mapView;
+
+	@Provides
+	MapTestConfig provideConfig(ConfigManager configManager)
+	{
+		return configManager.getConfig(MapTestConfig.class);
+	}
+
+	@Subscribe
+	public void onConfigChanged(ConfigChanged event)
+	{
+		if (!event.getGroup().equals("devtoolsmap"))
+		{
+			return;
+		}
+
+		WorldPoint center = new WorldPoint(config.mapTestCoords().width, config.mapTestCoords().height, 0);
+		mapView.setCenter(center);
+		mapView.setZoom(config.mapTestZoom() / 100f);
+		mapView.setGraphicsHeight(config.mapTestDisplay().height);
+		mapView.setGraphicsWidth(config.mapTestDisplay().width);
+
+		BufferedImage image = mapView.buildMapImage();
+		overlay.setImage(image);
+	}
+
+	@Override
+	protected void startUp()
+	{
+		WorldPoint center = new WorldPoint(config.mapTestCoords().width, config.mapTestCoords().height, 0);
+		mapView.setCenter(center);
+		mapView.setZoom(config.mapTestZoom() / 100f);
+		mapView.setGraphicsHeight(config.mapTestDisplay().height);
+		mapView.setGraphicsWidth(config.mapTestDisplay().width);
+
+		BufferedImage image = mapView.buildMapImage();
+		overlay.setImage(image);
+	}
+
+	@Override
+	public MapViewOverlay getOverlay()
+	{
+		return overlay;
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/mapTest/MapViewOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/mapTest/MapViewOverlay.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2018, Morgan Lewis <https://github.com/MESLewis>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.mapTest;
+
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Graphics2D;
+import java.awt.Point;
+import java.awt.image.BufferedImage;
+import javax.inject.Inject;
+import net.runelite.api.coords.WorldPoint;
+import net.runelite.client.ui.overlay.Overlay;
+
+public class MapViewOverlay extends Overlay
+{
+	private final MapTestPlugin plugin;
+
+	@Inject
+	private MapTestConfig config;
+
+	private BufferedImage image = null;
+
+	@Inject
+	MapViewOverlay(MapTestPlugin plugin, MapTestConfig config)
+	{
+		this.plugin = plugin;
+		this.config = config;
+	}
+
+
+	void setImage(BufferedImage image)
+	{
+		this.image = image;
+	}
+
+
+	@Override
+	public Dimension render(Graphics2D graphics)
+	{
+		graphics.drawImage(image, 0, 0, null);
+		graphics.setColor(Color.WHITE);
+		int pixelsPerTile = (int) plugin.getMapView().getPixelsPerTile();
+		graphics.fillRect(image.getWidth() / 2, image.getHeight() / 2, pixelsPerTile, pixelsPerTile);
+
+		Point mapMarker = plugin.getMapView().worldPointToGraphicsPoint(new WorldPoint(config.mapTestMarkerCoords().width, config.mapTestMarkerCoords().height, 0));
+		graphics.setColor(Color.CYAN);
+		graphics.fillOval(mapMarker.x, mapMarker.y, pixelsPerTile, pixelsPerTile);
+
+		return config.mapTestDisplay();
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/util/WorldMapView.java
+++ b/runelite-client/src/main/java/net/runelite/client/util/WorldMapView.java
@@ -1,0 +1,226 @@
+/*
+ * Copyright (c) 2018 Morgan Lewis <https://github.com/MESLewis>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.util;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import java.awt.Graphics2D;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.RenderingHints;
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Nonnull;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.Value;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.coords.WorldPoint;
+import net.runelite.map.MapLoader;
+
+@Slf4j
+public class WorldMapView
+{
+	private static final int REGION_GRAPHIC_SIZE = 256;
+	private static final int REGION_TILE_SIZE = 64;
+
+	@Value
+	public static class WorldMapKey
+	{
+		private int plane;
+		private int regionId;
+	}
+
+	private static final LoadingCache<WorldMapKey, BufferedImage> regions = CacheBuilder.newBuilder()
+		.maximumSize(9)
+		.expireAfterAccess(1, TimeUnit.MINUTES)
+		.build(
+			new CacheLoader<WorldMapKey, BufferedImage>()
+			{
+				public BufferedImage load(@Nonnull final WorldMapKey key) throws IOException
+				{
+					try
+					{
+						return MapLoader.readMapRegionImage(key.getPlane(), key.getRegionId());
+					}
+					catch (IllegalArgumentException | IOException e)
+					{
+						throw new IOException("No map image found");
+					}
+				}
+			});
+
+
+	@Getter
+	@Setter
+	private WorldPoint center;
+
+	@Getter
+	@Setter
+	private float zoom;
+
+	@Getter
+	@Setter
+	private int graphicsWidth;
+
+	@Getter
+	@Setter
+	private int graphicsHeight;
+
+	@Getter
+	@Setter
+	private float pixelsPerTile;
+
+	private int regionSizeScaled;
+	private Point tileOffset;
+	private Point graphicalOffset;
+	private Point graphicalCenter;
+
+	/**
+	 * Loads a map image for a single map region from disk
+	 * @param worldPoint The Point (in world coordinates) of the region to load
+	 * @return the BufferedImage from disk if it exists, otherwise null
+	 */
+	private static BufferedImage loadMapRegion(final WorldPoint worldPoint)
+	{
+		try
+		{
+			int x = worldPoint.getX();
+			int y = worldPoint.getY();
+			int regionX = x >> 6;
+			int regionY = y >> 6;
+			int regionId = regionX << 8 | regionY;
+			return regions.get(new WorldMapKey(worldPoint.getPlane(), regionId));
+		}
+		catch (ExecutionException e)
+		{
+			return null;
+		}
+	}
+
+	/**
+	 * Updates a few simple calculations used by various methods.
+	 * Functions that use these variables are responsible for calling
+	 * this function to ensure they are up to date.
+	 */
+	private void updateCalculations()
+	{
+		//Calculate region graphical size.
+		regionSizeScaled = (int) (REGION_GRAPHIC_SIZE * zoom);
+		//How far from top left of region this tile is
+		tileOffset = new Point(center.getX() % REGION_TILE_SIZE, center.getY() % REGION_TILE_SIZE);
+		//Graphical size of tileOffset
+		pixelsPerTile = regionSizeScaled / (float)REGION_TILE_SIZE;
+		graphicalOffset = new Point((int)(tileOffset.x * pixelsPerTile), (int)(tileOffset.y * pixelsPerTile));
+		graphicalCenter = new Point(graphicsWidth / 2, graphicsHeight / 2);
+	}
+
+
+	public Point[] worldPointsToGraphicsPoint(WorldPoint... worldPoints)
+	{
+		updateCalculations();
+		Point[] retPoints = new Point[worldPoints.length];
+		for (int i = 0; i < worldPoints.length; i++)
+		{
+			retPoints[i] = worldPointToGraphicsPointNoCalculations(worldPoints[i]);
+		}
+		return  retPoints;
+	}
+
+	/**
+	 * Convert a WorldPoint to a graphical position on the currently displayed map.
+	 * This will return the correct Point even if it is not visible on the current map.
+	 * @param worldPoint A WorldPoint to calculate the graphical position for
+	 * @return the graphical coordinates of the specified point.
+	 */
+	public Point worldPointToGraphicsPoint(WorldPoint worldPoint)
+	{
+		updateCalculations();
+		return worldPointToGraphicsPointNoCalculations(worldPoint);
+	}
+
+	/**
+	 * Convert points without updatingCalculations.
+	 * This method is only to be called when the calculations are already known
+	 * to be correct
+	 * @param worldPoint A WorldPoint to calculate the graphical position for
+	 * @return the graphical coordinates of the specified point.
+	 */
+	private Point worldPointToGraphicsPointNoCalculations(WorldPoint worldPoint)
+	{
+		Point difference = new Point((int) ((worldPoint.getX() - center.getX()) * pixelsPerTile), (int) ((center.getY() - worldPoint.getY()) * pixelsPerTile));
+		difference.translate(graphicalCenter.x, graphicalCenter.y);
+		return difference;
+	}
+
+	public BufferedImage buildMapImage()
+	{
+		updateCalculations();
+
+		BufferedImage mapImage = new BufferedImage(graphicsWidth, graphicsHeight, BufferedImage.TYPE_INT_RGB);
+		Graphics2D graphics = mapImage.createGraphics();
+
+		//Get top left corner of where center region would be drawn.
+		Point drawingWorldPoint = new Point(center.getX(), center.getY());
+		Rectangle drawingDestionation = new Rectangle(graphicalCenter.x - graphicalOffset.x, graphicalCenter.y - (regionSizeScaled - graphicalOffset.y), regionSizeScaled, regionSizeScaled);
+
+		while (drawingDestionation.x > 0)
+		{
+			//Go as far left as needed
+			drawingDestionation.x -= regionSizeScaled;
+			drawingWorldPoint.x -= REGION_TILE_SIZE;
+		}
+
+		while (drawingDestionation.y > 0)
+		{
+			//Go as far up as needed
+			drawingDestionation.y -= regionSizeScaled;
+			drawingWorldPoint.y += REGION_TILE_SIZE;
+		}
+
+		int yGraphicalBound = drawingDestionation.y;
+		int yWorldBound = drawingWorldPoint.y;
+		graphics.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BILINEAR);
+		while (drawingDestionation.x < graphicsWidth)
+		{
+
+			while (drawingDestionation.y < graphicsHeight)
+			{
+				BufferedImage image = loadMapRegion(new WorldPoint(drawingWorldPoint.x, drawingWorldPoint.y, center.getPlane()));
+				graphics.drawImage(image, drawingDestionation.x, drawingDestionation.y, drawingDestionation.width, drawingDestionation.height, null);
+
+				drawingDestionation.translate(0, regionSizeScaled);
+				drawingWorldPoint.translate(0, -REGION_TILE_SIZE);
+			}
+			drawingDestionation.setLocation(drawingDestionation.x + regionSizeScaled, yGraphicalBound);
+			drawingWorldPoint.setLocation(drawingWorldPoint.x + REGION_TILE_SIZE, yWorldBound);
+		}
+
+		return mapImage;
+	}
+}

--- a/runelite-map-assembler-plugin/pom.xml
+++ b/runelite-map-assembler-plugin/pom.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright (c) 2018, Adam <Adam@sigterm.info>
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice, this
+    list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>net.runelite</groupId>
+		<artifactId>runelite-parent</artifactId>
+		<version>1.4.1-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>map-assembler-plugin</artifactId>
+	<name>Map Assembler Plugin</name>
+	<packaging>maven-plugin</packaging>
+
+	<properties>
+		<cache.version>165</cache.version>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>net.runelite.rs</groupId>
+			<artifactId>cache</artifactId>
+			<version>${cache.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>net.runelite</groupId>
+			<artifactId>cache</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.maven</groupId>
+			<artifactId>maven-plugin-api</artifactId>
+			<version>3.0.5</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.maven.plugin-tools</groupId>
+			<artifactId>maven-plugin-annotations</artifactId>
+			<version>3.4</version>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<resources>
+			<resource>
+				<directory>src/main/resources</directory>
+				<filtering>true</filtering>
+			</resource>
+		</resources>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-plugin-plugin</artifactId>
+				<version>3.4</version>
+				<executions>
+					<execution>
+						<id>default-descriptor</id>
+						<phase>process-classes</phase>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/runelite-map-assembler-plugin/src/main/java/net/runelite/map/AssembleMojo.java
+++ b/runelite-map-assembler-plugin/src/main/java/net/runelite/map/AssembleMojo.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright (c) 2018, Tomas Slusny <slusnucky@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.map;
+
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.util.Collection;
+import java.util.Properties;
+import javax.imageio.ImageIO;
+import net.runelite.cache.MapImageDumper;
+import net.runelite.cache.fs.Store;
+import net.runelite.cache.region.Region;
+import net.runelite.cache.region.RegionLoader;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+
+@Mojo(name = "assemble", defaultPhase = LifecyclePhase.GENERATE_RESOURCES)
+public class AssembleMojo extends AbstractMojo
+{
+	private static final int MIN_PLANE = 0;
+	private static final int MAX_PLANE = 3;
+	private static final int NUM_INDEXES = 16;
+
+	@Parameter(required = true)
+	private File outputDirectory;
+
+	@Override
+	public void execute() throws MojoExecutionException
+	{
+		outputDirectory.mkdirs();
+		final File location;
+
+		try
+		{
+			location = setupCacheDir();
+		}
+		catch (IOException e)
+		{
+			throw new MojoExecutionException(e.getMessage());
+		}
+
+		try (final Store store = new Store(location))
+		{
+			getLog().info("Loading store");
+			store.load();
+
+			getLog().info("Loading regions");
+			final RegionLoader regionLoader = new RegionLoader(store);
+			regionLoader.loadRegions();
+
+			getLog().info("Loading map image dumper");
+			final MapImageDumper dumper = new MapImageDumper(store);
+			dumper.load();
+
+			final Collection<Region> regions = regionLoader.getRegions();
+
+			for (Region region : regions)
+			{
+				getLog().info("Assembling " + region.getRegionID() + " region");
+
+				for (int z = MIN_PLANE; z <= MAX_PLANE; z++)
+				{
+					final String regionId = z + "-" + region.getRegionID();
+					final BufferedImage image = dumper.drawRegion(region, z);
+
+					if (!isFullyBlack(image))
+					{
+						final File imageFile = new File(outputDirectory, "map-" + regionId + ".png");
+						ImageIO.write(image, "png", imageFile);
+					}
+				}
+			}
+
+			getLog().info("Assembled " + regions.size() + " map regions");
+		}
+		catch (IOException | NullPointerException e)
+		{
+			throw new MojoExecutionException(e.getMessage());
+		}
+	}
+
+	/**
+	 * Extract cache contents to temporary directory and return path to the directory. If directory already exists
+	 * reuse it.
+	 * @return path to cache directory
+	 * @throws IOException exception when file is not found
+	 */
+	private File setupCacheDir() throws IOException
+	{
+		File file = new File(System.getProperty("java.io.tmpdir"), "cache-" + getCacheVersion());
+
+		if (file.exists())
+		{
+			getLog().info("Using preexisting cache working directory " + file.getPath());
+			return file;
+		}
+
+		file.mkdir();
+
+		// Copy over files
+		InputStream in = getClass().getResourceAsStream("/main_file_cache.dat2");
+		Files.copy(in, new File(file, "main_file_cache.dat2").toPath());
+
+		in = getClass().getResourceAsStream("/main_file_cache.idx255");
+		Files.copy(in, new File(file, "main_file_cache.idx255").toPath());
+
+		for (int i = 0; i <= NUM_INDEXES; ++i)
+		{
+			in = getClass().getResourceAsStream("/main_file_cache.idx" + i);
+			Files.copy(in, new File(file, "main_file_cache.idx" + i).toPath());
+		}
+
+		getLog().info("Set up cache working directory to " + file.getPath());
+		return file;
+	}
+
+	/**
+	 * Check if image contains only black pixels
+	 * @param image image to check
+	 * @return true if image is fully black
+	 */
+	private static boolean isFullyBlack(final BufferedImage image)
+	{
+		final int xmin = image.getMinX();
+		final int ymin = image.getMinY();
+		final int ymax = ymin + image.getHeight();
+		final int xmax = xmin + image.getWidth();
+
+		for (int i = xmin; i < xmax;i++)
+		{
+			for (int j = ymin; j < ymax; j++)
+			{
+				int pixel = image.getRGB(i, j);
+
+				if (((pixel & 0x00FFFFFF) != 0))
+				{
+					return false;
+				}
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Get RuneScape cache version from properties
+	 * @return cache version
+	 * @throws IOException exception when file is not found
+	 */
+	private static int getCacheVersion() throws IOException
+	{
+		final Properties properties = new Properties();
+		InputStream resourceAsStream = AssembleMojo.class.getResourceAsStream("/cache.properties");
+		properties.load(resourceAsStream);
+		return Integer.parseInt(properties.getProperty("cache.version"));
+	}
+}

--- a/runelite-map-assembler-plugin/src/main/resources/cache.properties
+++ b/runelite-map-assembler-plugin/src/main/resources/cache.properties
@@ -1,0 +1,1 @@
+cache.version=${cache.version}

--- a/runelite-map/pom.xml
+++ b/runelite-map/pom.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright (c) 2018, Adam <Adam@sigterm.info>
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice, this
+    list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>net.runelite</groupId>
+		<artifactId>runelite-parent</artifactId>
+		<version>1.4.1-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>map</artifactId>
+	<name>RuneLite Map</name>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>net.runelite</groupId>
+				<artifactId>map-assembler-plugin</artifactId>
+				<version>${project.version}</version>
+				<executions>
+					<execution>
+						<id>assemble</id>
+						<goals>
+							<goal>assemble</goal>
+						</goals>
+						<configuration>
+							<outputDirectory>${project.build.outputDirectory}/net/runelite/map</outputDirectory>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/runelite-map/src/main/java/net/runelite/map/MapLoader.java
+++ b/runelite-map/src/main/java/net/runelite/map/MapLoader.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2018, Tomas Slusny <slusnucky@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.map;
+
+import java.awt.Color;
+import java.awt.Graphics;
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+import java.net.URL;
+import javax.imageio.ImageIO;
+
+public class MapLoader
+{
+	private static final int REGION_IMAGE_SIZE = 256;
+	private static final BufferedImage EMPTY_REGION;
+
+	static
+	{
+		EMPTY_REGION = new BufferedImage(REGION_IMAGE_SIZE, REGION_IMAGE_SIZE, BufferedImage.TYPE_INT_RGB);
+		final Graphics graphics = EMPTY_REGION.getGraphics();
+		graphics.setColor(Color.BLACK);
+		graphics.fillRect(0, 0, REGION_IMAGE_SIZE, REGION_IMAGE_SIZE);
+		graphics.dispose();
+	}
+
+	/**
+	 * Reads map region image
+	 * @param plane plane on map
+	 * @param regionId region id
+	 * @return map region image
+	 * @throws IOException exception when image is not found
+	 */
+	public static BufferedImage readMapRegionImage(final int plane, final int regionId) throws IOException
+	{
+		final URL resource = MapLoader.class.getResource(String.format("map-%d-%d.png", plane, regionId));
+		return resource != null ? ImageIO.read(resource) : EMPTY_REGION;
+	}
+}


### PR DESCRIPTION
## Add instance map service to open map at location

- Add service to instance map plugin that will open map at specified
location
- Use new world map drawer in instance map to draw different regions

## Add support for opening map with location clues

Open world map from location clue:
1. Automatically when clue is first read
2. When "Preview location" on clue is called

Closes #3416
Signed-off-by: Tomas Slusny <slusnucky@gmail.com>

Preview:
![peek 2018-05-28 15-13](https://user-images.githubusercontent.com/5115805/40616096-ec805314-6289-11e8-9dab-5c11c37d7896.gif)