### PR TITLE
Screen Markers - Fix for screenmarker display name

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenmarkers/ui/ScreenMarkerPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenmarkers/ui/ScreenMarkerPanel.java
@@ -253,7 +253,7 @@ class ScreenMarkerPanel extends JPanel
 		nameActions.add(cancel, BorderLayout.WEST);
 		nameActions.add(rename, BorderLayout.CENTER);
 
-		nameInput.setText(marker.getName());
+		nameInput.setText(marker.getMarker().getName());
 		nameInput.setBorder(null);
 		nameInput.setEditable(false);
 		nameInput.setBackground(ColorScheme.DARKER_GRAY_COLOR);


### PR DESCRIPTION
Implements getDisplayName() so the screen marker name is correct in the panel.