### PR TITLE
Enqueue most post/put/delete requests

### DIFF
--- a/http-api/src/main/java/net/runelite/http/api/xp/XpClient.java
+++ b/http-api/src/main/java/net/runelite/http/api/xp/XpClient.java
@@ -26,12 +26,19 @@ package net.runelite.http.api.xp;
 
 import java.io.IOException;
 import net.runelite.http.api.RuneLiteAPI;
+import okhttp3.Call;
+import okhttp3.Callback;
 import okhttp3.HttpUrl;
 import okhttp3.Request;
+import okhttp3.Response;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class XpClient
 {
-	public void update(String username) throws IOException
+	private static final Logger logger = LoggerFactory.getLogger(XpClient.class);
+
+	public void update(String username)
 	{
 		HttpUrl url = RuneLiteAPI.getApiBase().newBuilder()
 			.addPathSegment("xp")
@@ -43,6 +50,20 @@ public class XpClient
 			.url(url)
 			.build();
 
-		RuneLiteAPI.CLIENT.newCall(request).execute().close();
+		RuneLiteAPI.CLIENT.newCall(request).enqueue(new Callback()
+		{
+			@Override
+			public void onFailure(Call call, IOException e)
+			{
+				logger.warn("Error submitting xp track", e);
+			}
+
+			@Override
+			public void onResponse(Call call, Response response)
+			{
+				response.close();
+				logger.debug("Submitted xp track for {}", username);
+			}
+		});
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/config/ConfigManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/ConfigManager.java
@@ -265,19 +265,7 @@ public class ConfigManager
 
 		if (client != null)
 		{
-			Runnable task = () ->
-			{
-				try
-				{
-					client.set(groupName + "." + key, value);
-				}
-				catch (IOException ex)
-				{
-					log.warn("unable to set configuration item", ex);
-				}
-			};
-			executor.execute(task);
-
+			client.set(groupName + "." + key, value);
 		}
 
 		Runnable task = () ->
@@ -315,19 +303,7 @@ public class ConfigManager
 
 		if (client != null)
 		{
-			final Runnable task = () ->
-			{
-				try
-				{
-					client.unset(groupName + "." + key);
-				}
-				catch (IOException ex)
-				{
-					log.warn("unable to set configuration item", ex);
-				}
-			};
-
-			executor.execute(task);
+			client.unset(groupName + "." + key);
 		}
 
 		Runnable task = () ->

--- a/runelite-client/src/main/java/net/runelite/client/plugins/examine/ExaminePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/examine/ExaminePlugin.java
@@ -231,7 +231,7 @@ public class ExaminePlugin extends Plugin
 		}
 
 		cache.put(key, Boolean.TRUE);
-		executor.submit(() -> submitExamine(pendingExamine, event.getMessage()));
+		submitExamine(pendingExamine, event.getMessage());
 	}
 
 	private void findExamineItem(PendingExamine pendingExamine)
@@ -404,24 +404,17 @@ public class ExaminePlugin extends Plugin
 	{
 		int id = examine.getId();
 
-		try
+		switch (examine.getType())
 		{
-			switch (examine.getType())
-			{
-				case ITEM:
-					examineClient.submitItem(id, text);
-					break;
-				case OBJECT:
-					examineClient.submitObject(id, text);
-					break;
-				case NPC:
-					examineClient.submitNpc(id, text);
-					break;
-			}
-		}
-		catch (IOException ex)
-		{
-			log.warn("Error submitting examine", ex);
+			case ITEM:
+				examineClient.submitItem(id, text);
+				break;
+			case OBJECT:
+				examineClient.submitObject(id, text);
+				break;
+			case NPC:
+				examineClient.submitNpc(id, text);
+				break;
 		}
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerPlugin.java
@@ -32,7 +32,6 @@ import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.util.EnumSet;
 import java.util.Objects;
-import java.util.concurrent.ScheduledExecutorService;
 import javax.imageio.ImageIO;
 import javax.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
@@ -70,9 +69,6 @@ public class XpTrackerPlugin extends Plugin
 
 	@Inject
 	private SkillIconManager skillIconManager;
-
-	@Inject
-	private ScheduledExecutorService executor;
 
 	private NavigationButton navButton;
 	private XpPanel xpPanel;
@@ -164,19 +160,7 @@ public class XpTrackerPlugin extends Plugin
 			String username = local != null ? local.getName() : null;
 			if (username != null)
 			{
-				log.debug("Submitting xp track for {}", username);
-
-				executor.submit(() ->
-				{
-					try
-					{
-						xpClient.update(username);
-					}
-					catch (IOException ex)
-					{
-						log.warn("error submitting xp track", ex);
-					}
-				});
+				xpClient.update(username);
 			}
 		}
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xtea/XteaPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xtea/XteaPlugin.java
@@ -25,10 +25,8 @@
 package net.runelite.client.plugins.xtea;
 
 import com.google.common.eventbus.Subscribe;
-import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.concurrent.ScheduledExecutorService;
 import javax.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
@@ -36,7 +34,6 @@ import net.runelite.api.events.MapRegionChanged;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.http.api.xtea.XteaClient;
-import okhttp3.Response;
 
 @PluginDescriptor(
 	name = "Xtea",
@@ -51,9 +48,6 @@ public class XteaPlugin extends Plugin
 
 	@Inject
 	private Client client;
-
-	@Inject
-	private ScheduledExecutorService executor;
 
 	@Subscribe
 	public void onMapRegionChanged(MapRegionChanged event)
@@ -82,19 +76,6 @@ public class XteaPlugin extends Plugin
 
 		sentRegions.add(region);
 
-		executor.execute(() ->
-		{
-			try (Response response = xteaClient.submit(revision, region, keys))
-			{
-				if (!response.isSuccessful())
-				{
-					log.debug("unsuccessful xtea response");
-				}
-			}
-			catch (IOException ex)
-			{
-				log.debug("unable to submit xtea keys", ex);
-			}
-		});
+		xteaClient.submit(revision, region, keys);
 	}
 }


### PR DESCRIPTION
Change most post/put/delete http requests to enqueue() instead of execute().

This allows the UI to not block when the api is acting slow or when it's down, since the calls now run on okhttp's thread pool instead of using RuneLite's thread pool.

Tested by simulating a slow connection and disabling/enabling a plugin with: `sudo tc qdisc add dev INTERFACE root netem delay 2000ms`

This won't "fix" all problems in case the API is down, but this should mitigate most of the annoying ones.

Closes the main issue of #2666