### PR TITLE
Use single GridLayout for XPTracker stats

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpInfoBox.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpInfoBox.java
@@ -81,7 +81,7 @@ class XpInfoBox extends JPanel
 		this.skill = skill;
 
 		setLayout(new BorderLayout());
-		setBorder(new EmptyBorder(10, 0, 0, 0));
+		setBorder(new EmptyBorder(5, 0, 0, 0));
 
 		container.setLayout(new BorderLayout());
 		container.setBackground(ColorScheme.DARKER_GRAY_COLOR);
@@ -110,7 +110,7 @@ class XpInfoBox extends JPanel
 
 		statsPanel.setLayout(new DynamicGridLayout(2, 2));
 		statsPanel.setBackground(ColorScheme.DARKER_GRAY_COLOR);
-		statsPanel.setBorder(new EmptyBorder(9, 5, 9, 5));
+		statsPanel.setBorder(new EmptyBorder(9, 2, 9, 2));
 
 		expGained.setFont(FontManager.getRunescapeSmallFont());
 		expHour.setFont(FontManager.getRunescapeSmallFont());

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpInfoBox.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpInfoBox.java
@@ -108,32 +108,19 @@ class XpInfoBox extends JPanel
 		headerPanel.setBackground(ColorScheme.DARKER_GRAY_COLOR);
 		headerPanel.setLayout(new BorderLayout());
 
-		statsPanel.setLayout(new BorderLayout());
+		statsPanel.setLayout(new GridLayout(2, 2, 15, 0));
 		statsPanel.setBackground(ColorScheme.DARKER_GRAY_COLOR);
-		statsPanel.setBorder(new EmptyBorder(9, 5, 9, 10));
-
-		JPanel leftPanel = new JPanel();
-		leftPanel.setBackground(ColorScheme.DARKER_GRAY_COLOR);
-		leftPanel.setLayout(new GridLayout(2, 1));
+		statsPanel.setBorder(new EmptyBorder(9, 5, 9, 5));
 
 		expGained.setFont(FontManager.getRunescapeSmallFont());
 		expHour.setFont(FontManager.getRunescapeSmallFont());
-
-		leftPanel.add(expGained);
-		leftPanel.add(expHour);
-
-		JPanel rightPanel = new JPanel();
-		rightPanel.setBackground(ColorScheme.DARKER_GRAY_COLOR);
-		rightPanel.setLayout(new GridLayout(2, 1));
-
 		expLeft.setFont(FontManager.getRunescapeSmallFont());
 		actionsLeft.setFont(FontManager.getRunescapeSmallFont());
 
-		rightPanel.add(expLeft);
-		rightPanel.add(actionsLeft);
-
-		statsPanel.add(leftPanel, BorderLayout.WEST);
-		statsPanel.add(rightPanel, BorderLayout.EAST);
+		statsPanel.add(expGained);
+		statsPanel.add(expLeft);
+		statsPanel.add(expHour);
+		statsPanel.add(actionsLeft);
 
 		headerPanel.add(skillIcon, BorderLayout.WEST);
 		headerPanel.add(statsPanel, BorderLayout.CENTER);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpInfoBox.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpInfoBox.java
@@ -28,7 +28,6 @@ package net.runelite.client.plugins.xptracker;
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Dimension;
-import java.awt.GridLayout;
 import java.io.IOException;
 import javax.swing.ImageIcon;
 import javax.swing.JLabel;
@@ -45,6 +44,7 @@ import net.runelite.api.Client;
 import net.runelite.api.Skill;
 import net.runelite.client.game.SkillIconManager;
 import net.runelite.client.ui.ColorScheme;
+import net.runelite.client.ui.DynamicGridLayout;
 import net.runelite.client.ui.FontManager;
 import net.runelite.client.ui.components.ProgressBar;
 import net.runelite.client.util.LinkBrowser;
@@ -108,7 +108,7 @@ class XpInfoBox extends JPanel
 		headerPanel.setBackground(ColorScheme.DARKER_GRAY_COLOR);
 		headerPanel.setLayout(new BorderLayout());
 
-		statsPanel.setLayout(new GridLayout(2, 2, 15, 0));
+		statsPanel.setLayout(new DynamicGridLayout(2, 2, 15, 0));
 		statsPanel.setBackground(ColorScheme.DARKER_GRAY_COLOR);
 		statsPanel.setBorder(new EmptyBorder(9, 5, 9, 5));
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpInfoBox.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpInfoBox.java
@@ -108,7 +108,7 @@ class XpInfoBox extends JPanel
 		headerPanel.setBackground(ColorScheme.DARKER_GRAY_COLOR);
 		headerPanel.setLayout(new BorderLayout());
 
-		statsPanel.setLayout(new DynamicGridLayout(2, 2, 15, 0));
+		statsPanel.setLayout(new DynamicGridLayout(2, 2));
 		statsPanel.setBackground(ColorScheme.DARKER_GRAY_COLOR);
 		statsPanel.setBorder(new EmptyBorder(9, 5, 9, 5));
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpPanel.java
@@ -67,12 +67,14 @@ class XpPanel extends PluginPanel
 	{
 		super();
 
-		setBorder(new EmptyBorder(10, 10, 10, 10));
+		setBorder(new EmptyBorder(10, 6, 10, 6));
 		setBackground(ColorScheme.DARK_GRAY_COLOR);
+		setLayout(new BorderLayout());
 
 		final JPanel layoutPanel = new JPanel();
-		layoutPanel.setLayout(new BorderLayout());
-		add(layoutPanel);
+		BoxLayout boxLayout = new BoxLayout(layoutPanel, BoxLayout.Y_AXIS);
+		layoutPanel.setLayout(boxLayout);
+		add(layoutPanel, BorderLayout.NORTH);
 
 		overallPanel.setBorder(new EmptyBorder(10, 10, 10, 10));
 		overallPanel.setBackground(ColorScheme.DARKER_GRAY_COLOR);
@@ -113,8 +115,8 @@ class XpPanel extends PluginPanel
 
 		final JPanel infoBoxPanel = new JPanel();
 		infoBoxPanel.setLayout(new BoxLayout(infoBoxPanel, BoxLayout.Y_AXIS));
-		layoutPanel.add(infoBoxPanel, BorderLayout.CENTER);
-		layoutPanel.add(overallPanel, BorderLayout.NORTH);
+		layoutPanel.add(overallPanel);
+		layoutPanel.add(infoBoxPanel);
 
 		try
 		{


### PR DESCRIPTION
This should help keep columns aligned across different boxes.
Also avoids constant resizing of info box when 'XP/Hour' text is longer than 'XP Gained' text and is changing.