### PR TITLE
UI: Add a clear button (×) to IconTextField

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ui/components/IconTextField.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/components/IconTextField.java
@@ -26,6 +26,8 @@
  */
 package net.runelite.client.ui.components;
 
+import net.runelite.client.ui.ColorScheme;
+import net.runelite.client.ui.FontManager;
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Dimension;
@@ -35,13 +37,16 @@ import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
 import javax.swing.ImageIcon;
+import javax.swing.JButton;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
 import javax.swing.text.Document;
 
 /**
- * This component is a FlatTextField with an icon on its left side.
+ * This component is a FlatTextField with an icon on its left side, and a clear button (×) on its right side.
  */
 public class IconTextField extends JPanel
 {
@@ -49,6 +54,8 @@ public class IconTextField extends JPanel
 
 	//to support gifs, the icon needs to be wrapped in a JLabel
 	private final JLabel iconWrapperLabel;
+
+	private final JButton clearButton;
 
 	public IconTextField()
 	{
@@ -95,8 +102,40 @@ public class IconTextField extends JPanel
 		textField.addMouseListener(hoverEffect);
 		innerTxt.addMouseListener(hoverEffect);
 
+		clearButton = new JButton();
+		clearButton.setPreferredSize(new Dimension(30, 0));
+		clearButton.setText("×");
+		clearButton.setFont(FontManager.getRunescapeBoldFont());
+		clearButton.setForeground(ColorScheme.PROGRESS_ERROR_COLOR);
+		clearButton.setBorder(null);
+		clearButton.setBorderPainted(false);
+		clearButton.setVisible(false);
+		clearButton.addActionListener(e -> setText(null));
+
+		// Show the clear button when text is present, and hide again when empty
+		getDocument().addDocumentListener(new DocumentListener()
+		{
+			@Override
+			public void insertUpdate(DocumentEvent e)
+			{
+				clearButton.setVisible(true);
+			}
+
+			@Override
+			public void removeUpdate(DocumentEvent e)
+			{
+				clearButton.setVisible(!getText().isEmpty());
+			}
+
+			@Override
+			public void changedUpdate(DocumentEvent e)
+			{
+			}
+		});
+
 		add(iconWrapperLabel, BorderLayout.WEST);
 		add(textField, BorderLayout.CENTER);
+		add(clearButton, BorderLayout.EAST);
 	}
 
 	public void addActionListener(ActionListener actionListener)

--- a/runelite-client/src/main/java/net/runelite/client/ui/components/IconTextField.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/components/IconTextField.java
@@ -102,15 +102,41 @@ public class IconTextField extends JPanel
 		textField.addMouseListener(hoverEffect);
 		innerTxt.addMouseListener(hoverEffect);
 
-		clearButton = new JButton();
+		clearButton = new JButton("×");
 		clearButton.setPreferredSize(new Dimension(30, 0));
-		clearButton.setText("×");
 		clearButton.setFont(FontManager.getRunescapeBoldFont());
 		clearButton.setForeground(ColorScheme.PROGRESS_ERROR_COLOR);
 		clearButton.setBorder(null);
 		clearButton.setBorderPainted(false);
+		clearButton.setContentAreaFilled(false);
 		clearButton.setVisible(false);
-		clearButton.addActionListener(e -> setText(null));
+
+		// ActionListener for keyboard use (via Tab -> Space)
+		clearButton.addActionListener((l) -> setText(null));
+
+		// MouseListener for hover and click events
+		clearButton.addMouseListener(new MouseAdapter()
+		{
+			@Override
+			public void mousePressed(MouseEvent mouseEvent)
+			{
+				setText(null);
+			}
+
+			@Override
+			public void mouseEntered(MouseEvent mouseEvent)
+			{
+				clearButton.setForeground(Color.PINK);
+				textField.dispatchEvent(mouseEvent);
+			}
+
+			@Override
+			public void mouseExited(MouseEvent mouseEvent)
+			{
+				clearButton.setForeground(ColorScheme.PROGRESS_ERROR_COLOR);
+				textField.dispatchEvent(mouseEvent);
+			}
+		});
 
 		// Show the clear button when text is present, and hide again when empty
 		getDocument().addDocumentListener(new DocumentListener()

--- a/runelite-client/src/main/java/net/runelite/client/ui/components/IconTextField.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/components/IconTextField.java
@@ -50,10 +50,10 @@ import javax.swing.text.Document;
  */
 public class IconTextField extends JPanel
 {
-	private final FlatTextField textField;
-
-	//to support gifs, the icon needs to be wrapped in a JLabel
+	// To support gifs, the icon needs to be wrapped in a JLabel
 	private final JLabel iconWrapperLabel;
+
+	private final FlatTextField textField;
 
 	private final JButton clearButton;
 
@@ -61,18 +61,18 @@ public class IconTextField extends JPanel
 	{
 		setLayout(new BorderLayout());
 
-		this.iconWrapperLabel = new JLabel();
-		this.iconWrapperLabel.setPreferredSize(new Dimension(30, 0));
-		this.iconWrapperLabel.setVerticalAlignment(JLabel.CENTER);
-		this.iconWrapperLabel.setHorizontalAlignment(JLabel.CENTER);
+		iconWrapperLabel = new JLabel();
+		iconWrapperLabel.setPreferredSize(new Dimension(30, 0));
+		iconWrapperLabel.setVerticalAlignment(JLabel.CENTER);
+		iconWrapperLabel.setHorizontalAlignment(JLabel.CENTER);
 
 		textField = new FlatTextField();
 		textField.setBorder(null);
 
-		JTextField innerTxt = textField.getTextField();
+		final JTextField innerTxt = textField.getTextField();
 		innerTxt.removeMouseListener(innerTxt.getMouseListeners()[innerTxt.getMouseListeners().length - 1]);
 
-		MouseListener hoverEffect = new MouseAdapter()
+		final MouseListener hoverEffect = new MouseAdapter()
 		{
 			@Override
 			public void mouseEntered(MouseEvent mouseEvent)
@@ -82,7 +82,7 @@ public class IconTextField extends JPanel
 					return;
 				}
 
-				Color hoverColor = textField.getHoverBackgroundColor();
+				final Color hoverColor = textField.getHoverBackgroundColor();
 
 				if (hoverColor != null)
 				{


### PR DESCRIPTION
Simple little addition to all searchbars. If anyone wants to style it better, just ask for push access.

Updated:

![image](https://user-images.githubusercontent.com/37604308/40705211-9a8ced06-642d-11e8-9594-46011fed067f.png)

The PR originally looked like this:

![image](https://user-images.githubusercontent.com/37604308/40705367-152422e6-642e-11e8-96b1-04de3150db1b.png)
