### PR TITLE
XpTracker: xp/h reset

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpInfoBox.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpInfoBox.java
@@ -94,11 +94,16 @@ class XpInfoBox extends JPanel
 		final JMenuItem reset = new JMenuItem("Reset");
 		reset.addActionListener(e -> xpTrackerPlugin.resetSkillState(skill));
 
+		// Create reset menu
+		final JMenuItem resetXpPerHour = new JMenuItem("Reset xp/h");
+		resetXpPerHour.addActionListener(e -> xpTrackerPlugin.resetXpPerHourForSkill(skill));
+
 		// Create popup menu
 		final JPopupMenu popupMenu = new JPopupMenu();
 		popupMenu.setBorder(new EmptyBorder(5, 5, 5, 5));
 		popupMenu.add(openXpTracker);
 		popupMenu.add(reset);
+		popupMenu.add(resetXpPerHour);
 
 		JLabel skillIcon = new JLabel(new ImageIcon(iconManager.getSkillImage(skill)));
 		skillIcon.setHorizontalAlignment(SwingConstants.CENTER);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpState.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpState.java
@@ -54,22 +54,32 @@ class XpState
 	 * @param skill Skill to reset
 	 * @param currentXp Current XP to set to, if unknown set to -1
 	 */
-	void resetSkill(Skill skill, int currentXp)
+	void resetSkill(Skill skill, int currentXp, XpTrackerConfig config)
 	{
 		xpSkills.remove(skill);
 		xpSkills.put(skill, new XpStateSingle(skill, currentXp));
-		recalculateTotal();
+		recalculateTotal(config);
+	}
+
+	void resetSkillXpPerHour(Skill skill)
+	{
+		xpSkills.get(skill).resetXpPerHour();
 	}
 
 	/**
 	 * Calculates the total skill changes observed in this session or since the last reset
 	 */
-	void recalculateTotal()
+	void recalculateTotal(XpTrackerConfig config)
 	{
 		xpTotal.reset();
 
 		for (XpStateSingle state : xpSkills.values())
 		{
+			if (state.getSkillTimeLastGained() >= config.skillTimeOut())
+			{
+				resetSkillXpPerHour(state.getSkill());
+			}
+
 			xpTotal.addXpGainedInSession(state.getXpGained());
 			xpTotal.addXpPerHour(state.getXpHr());
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerConfig.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2018, Yoav Ram <https://github.com/yoyo421>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.xptracker;
+
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+
+@ConfigGroup(
+		keyName = "xpTracker",
+		name = "Xp Tracker",
+		description = "Configuration for the xp tracker plugin"
+)
+public interface XpTrackerConfig extends Config
+{
+	@ConfigItem(
+		keyName = "skillTimeOut",
+		name = "Skill TimeOut",
+		description = "Set how long the skill will track the Xp / H after the last gained"
+	)
+	default int skillTimeOut()
+	{
+		return 600;
+	}
+}


### PR DESCRIPTION
The xp/h will reset after X seconds from the last xp gained (can be configure).
And new right click option for each skill to reset the xp/h manually.