### PR TITLE
Barrows enhancments

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/barrows/BarrowsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/barrows/BarrowsConfig.java
@@ -90,4 +90,26 @@ public interface BarrowsConfig extends Config
 	{
 		return Color.RED;
 	}
+
+	@ConfigItem(
+		keyName = "showLadderTile",
+		name = "Show Ladder tile",
+		description = "Configures whether or not to label ladder tiles in the catacombs",
+		position = 5
+	)
+	default boolean showLadderTile()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		keyName = "ladderTileColor",
+		name = "Ladder Tile Color",
+		description = "Change the color of the ladder tile",
+		position = 6
+	)
+	default Color ladderTileColor()
+	{
+		return Color.ORANGE;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/barrows/BarrowsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/barrows/BarrowsConfig.java
@@ -92,10 +92,21 @@ public interface BarrowsConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "doorColor",
+		name = "Catacombs door color",
+		description = "Change the color doors that can be opened in the catcombs",
+		position = 5
+	)
+	default Color doorColor()
+	{
+		return Color.GREEN;
+	}
+
+	@ConfigItem(
 		keyName = "showLadderTile",
 		name = "Show Ladder tile",
 		description = "Configures whether or not to label ladder tiles in the catacombs",
-		position = 5
+		position = 6
 	)
 	default boolean showLadderTile()
 	{
@@ -106,7 +117,7 @@ public interface BarrowsConfig extends Config
 		keyName = "ladderTileColor",
 		name = "Ladder Tile Color",
 		description = "Change the color of the ladder tile",
-		position = 6
+		position = 7
 	)
 	default Color ladderTileColor()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/barrows/BarrowsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/barrows/BarrowsOverlay.java
@@ -131,7 +131,7 @@ class BarrowsOverlay extends Overlay
 
 		if (impostor != null && impostor.getActions()[0] != null)
 		{
-			graphics.setColor(Color.green);
+			graphics.setColor(config.doorColor());
 		}
 		else
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/barrows/BarrowsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/barrows/BarrowsOverlay.java
@@ -24,11 +24,10 @@
  */
 package net.runelite.client.plugins.barrows;
 
-import java.awt.Color;
-import java.awt.Dimension;
-import java.awt.Graphics2D;
+import java.awt.*;
 import java.util.List;
 import javax.inject.Inject;
+
 import net.runelite.api.Client;
 import net.runelite.api.GameObject;
 import net.runelite.api.NPC;
@@ -37,9 +36,11 @@ import net.runelite.api.Perspective;
 import net.runelite.api.Player;
 import net.runelite.api.WallObject;
 import net.runelite.api.coords.LocalPoint;
+import net.runelite.api.coords.WorldPoint;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.OverlayUtil;
 
 class BarrowsOverlay extends Overlay
 {
@@ -155,7 +156,35 @@ class BarrowsOverlay extends Overlay
 		{
 			graphics.setColor(Color.orange);
 			graphics.fillRect(minimapLocation.getX(), minimapLocation.getY(), 6, 6);
+			if (config.showLadderTile())
+			{
+				drawTile(graphics, ladder.getWorldLocation());
+			}
 		}
+	}
+
+	private void drawTile(Graphics2D graphics, WorldPoint point)
+	{
+		WorldPoint playerLocation = client.getLocalPlayer().getWorldLocation();
+
+		if (point.distanceTo(playerLocation) >= 32)
+		{
+			return;
+		}
+
+		LocalPoint lp = LocalPoint.fromWorld(client, point);
+		if (lp == null)
+		{
+			return;
+		}
+
+		Polygon poly = Perspective.getCanvasTilePoly(client, lp);
+		if (poly == null)
+		{
+			return;
+		}
+
+		OverlayUtil.renderPolygon(graphics, poly, config.ladderTileColor());
 	}
 
 	private void renderBarrowsBrothers(Graphics2D graphics)


### PR DESCRIPTION
This will add a toggle to highlight the ladder tiles even when they are not visible.

Also adds a config for changing the color of the operable doors in the catacombs to support color blind users.


Note: I have not tested this yet. I will test when I am able. If someone wants to give it a go and let me know that would be awesome.

Suggested in issue: [#3385](https://github.com/runelite/runelite/issues/3385)
Fixes issue: [#3268](https://github.com/runelite/runelite/issues/3268)