### PR TITLE
Add stream progress overlay for Tears of Guthix minigame

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/tearsofguthix/TearsOfGuthixOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/tearsofguthix/TearsOfGuthixOverlay.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2018, Infinitay <https://github.com/Infinitay>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.tearsofguthix;
+
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Graphics2D;
+import java.time.Duration;
+import java.time.Instant;
+import javax.inject.Inject;
+import net.runelite.client.ui.overlay.Overlay;
+import net.runelite.client.ui.overlay.OverlayLayer;
+import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.components.ProgressPieComponent;
+
+class TearsOfGuthixOverlay extends Overlay
+{
+	private static final Color CYAN_ALPHA = new Color(Color.CYAN.getRed(), Color.CYAN.getGreen(), Color.CYAN.getBlue(), 100);
+	private static final Duration MAX_TIME = Duration.ofSeconds(9);
+	private final TearsOfGuthixPlugin plugin;
+
+	@Inject
+	private TearsOfGuthixOverlay(TearsOfGuthixPlugin plugin)
+	{
+		this.plugin = plugin;
+		setPosition(OverlayPosition.DYNAMIC);
+		setLayer(OverlayLayer.ABOVE_SCENE);
+	}
+
+	@Override
+	public Dimension render(Graphics2D graphics)
+	{
+		plugin.getStreams().forEach((object, timer) ->
+		{
+			final ProgressPieComponent progressPie = new ProgressPieComponent();
+			progressPie.setDiameter(15);
+			progressPie.setFill(CYAN_ALPHA);
+			progressPie.setBorderColor(Color.CYAN);
+			progressPie.setPosition(object.getCanvasLocation(100));
+
+			final Duration duration = Duration.between(timer, Instant.now());
+			progressPie.setProgress(1 - (duration.compareTo(MAX_TIME) < 0
+				? (double) duration.toMillis() / MAX_TIME.toMillis()
+				: 1));
+
+			progressPie.render(graphics);
+		});
+
+		return null;
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/tearsofguthix/TearsOfGuthixPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/tearsofguthix/TearsOfGuthixPlugin.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2018, Infinitay <https://github.com/Infinitay>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.tearsofguthix;
+
+import com.google.common.eventbus.Subscribe;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import javax.inject.Inject;
+import lombok.Getter;
+import net.runelite.api.Client;
+import net.runelite.api.DecorativeObject;
+import net.runelite.api.ObjectID;
+import net.runelite.api.events.DecorativeObjectDespawned;
+import net.runelite.api.events.DecorativeObjectSpawned;
+import net.runelite.api.events.GameStateChanged;
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.ui.overlay.OverlayManager;
+
+@PluginDescriptor(
+	name = "Tears Of Guthix",
+	description = "Show timers for the Tears Of Guthix streams",
+	tags = {"minigame", "overlay", "skilling", "timers", "tog"}
+)
+public class TearsOfGuthixPlugin extends Plugin
+{
+	private static final int TOG_REGION = 12948;
+
+	@Inject
+	private Client client;
+
+	@Inject
+	private OverlayManager overlayManager;
+
+	@Inject
+	private TearsOfGuthixOverlay overlay;
+
+	@Getter
+	private final Map<DecorativeObject, Instant> streams = new HashMap<>();
+
+	@Override
+	protected void startUp()
+	{
+		overlayManager.add(overlay);
+	}
+
+	@Override
+	protected void shutDown()
+	{
+		overlayManager.remove(overlay);
+		streams.clear();
+	}
+
+	@Subscribe
+	public void onGameStateChanged(GameStateChanged event)
+	{
+		switch (event.getGameState())
+		{
+			case LOADING:
+			case LOGIN_SCREEN:
+			case HOPPING:
+				streams.clear();
+		}
+	}
+
+	@Subscribe
+	public void onDecorativeObjectSpawned(DecorativeObjectSpawned event)
+	{
+		DecorativeObject object = event.getDecorativeObject();
+
+		if (event.getDecorativeObject().getId() == ObjectID.BLUE_TEARS ||
+			event.getDecorativeObject().getId() == ObjectID.BLUE_TEARS_6665)
+		{
+			if (client.getLocalPlayer().getWorldLocation().getRegionID() == TOG_REGION)
+			{
+				streams.put(event.getDecorativeObject(), Instant.now());
+			}
+		}
+	}
+
+	@Subscribe
+	public void onDecorativeObjectDespawned(DecorativeObjectDespawned event)
+	{
+		if (streams.isEmpty())
+		{
+			return;
+		}
+
+		DecorativeObject object = event.getDecorativeObject();
+		streams.remove(object);
+	}
+}


### PR DESCRIPTION
![Preview](https://i.imgur.com/orGPPsk.gif)

Adds a `ProgressPieComponent` overlay to the blue tear streams that spawn in the Tears of Guthix minigame. Each tear stays for 9 seconds, the overlay displays the time remaining before the stream disappears.

Closes #3180 