### PR TITLE
Fix null names for quest objects in cryptic clues

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java
@@ -356,7 +356,12 @@ public class CrypticClue extends ClueScroll implements TextClueScroll, NpcClueSc
 
 		if (objectId != -1)
 		{
-			ObjectComposition object = plugin.getClient().getObjectDefinition(getObjectId());
+			ObjectComposition object = plugin.getClient().getObjectDefinition(objectId);
+
+			if (object != null && object.getImpostorIds() != null)
+			{
+				object = object.getImpostor();
+			}
 
 			if (object != null)
 			{


### PR DESCRIPTION
Example: Spirit Tree NULL_1293.

Fixes #1926
Closes #3480

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>