### PR TITLE
add CrystalMathLabs plugin.

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/crystalmathlabs/CrystalMathLabs.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/crystalmathlabs/CrystalMathLabs.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2018, Adam <Adam@sigterm.info>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.crystalmathlabs;
+
+import com.google.common.eventbus.Subscribe;
+import java.io.IOException;
+import lombok.extern.slf4j.Slf4j;
+import javax.inject.Inject;
+import net.runelite.api.Player;
+import net.runelite.http.api.RuneLiteAPI;
+import okhttp3.Call;
+import okhttp3.Callback;
+import okhttp3.HttpUrl;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import net.runelite.api.Client;
+import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.api.GameState;
+import net.runelite.api.events.GameStateChanged;
+import net.runelite.client.plugins.Plugin;
+import okhttp3.Response;
+
+@PluginDescriptor(
+	name = "Crystal Math Labs",
+	enabledByDefault = false
+)
+@Slf4j
+public class CrystalMathLabs extends Plugin
+{
+	@Inject
+	private Client client;
+
+	@Subscribe
+	public void onGameStateChanged(GameStateChanged gameStateChanged)
+	{
+		GameState state = gameStateChanged.getGameState();
+		if (state == GameState.LOGIN_SCREEN)
+		{
+			Player local = client.getLocalPlayer();
+			if (local != null)
+			{
+				log.debug("Submitting update for {}", local.getName());
+				sendUpdateRequest(local.getName());
+			}
+		}
+	}
+
+	private void sendUpdateRequest(String username)
+	{
+		String reformedUsername = username.replace(" ", "_");
+		OkHttpClient httpClient = RuneLiteAPI.CLIENT;
+
+		HttpUrl httpUrl = new HttpUrl.Builder()
+			.scheme("https")
+			.host("crystalmathlabs.com")
+			.addPathSegment("tracker")
+			.addPathSegment("api.php")
+			.addQueryParameter("type", "update")
+			.addQueryParameter("player", reformedUsername)
+			.build();
+
+		Request request = new Request.Builder()
+			.url(httpUrl)
+			.build();
+
+		httpClient.newCall(request).enqueue(new Callback()
+		{
+			@Override
+			public void onFailure(Call call, IOException e)
+			{
+				log.warn("error submitting CML update", e);
+			}
+
+			@Override
+			public void onResponse(Call call, Response response) throws IOException
+			{
+				response.close();
+			}
+		});
+	}
+}


### PR DESCRIPTION
# Crystal Math Labs plugin
## What does it do? 
This plugin is an opt-in plugin. When activated, the plugin will try and make a request to the CrystalMathLabs API when the user logs in and logs out. 

That would mean that a user does not have to manually track when logging in and out on CML.

I've spoken to both Adam and the owner of CML and they are both ok with it.
Adam is ok with it as long as it's not going through the RuneLite API.
![adam](https://user-images.githubusercontent.com/14212955/40726875-f0f4fb86-6426-11e8-8f46-2bcf8c47d3b0.jpg)
