### PR TITLE
Swap Quick-Travel option for Barge Guard

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -364,6 +364,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 			if (config.swapTravel())
 			{
 				swap("travel", option, target, true);
+				swap("quick-travel", option, target, true);
 				swap("pay-fare", option, target, true);
 				swap("charter", option, target, true);
 				swap("take-boat", option, target, true);


### PR DESCRIPTION
In the same vein as all of the other quick-travel right-click NPCs, I believe that the Barge Guard (the guy who takes you to Fossil Island) should be included. My change is very minor, and simply includes him in this list.