### PR TITLE
Preserve prayer tracking in boost timer

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/boosts/BoostsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/boosts/BoostsPlugin.java
@@ -221,7 +221,7 @@ public class BoostsPlugin extends Plugin
 		}
 
 		preserveBeenActive = false;
-		return (timeSinceChange > 60) ? 75-timeSinceChange : 60-timeSinceChange;
+		return (timeSinceChange > 60) ? 75 - timeSinceChange : 60 - timeSinceChange;
 	}
 
 	private int timeSinceLastChange()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/boosts/BoostsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/boosts/BoostsPlugin.java
@@ -220,14 +220,9 @@ public class BoostsPlugin extends Plugin
 			return 90 - timeSinceChange;
 		}
 
-		if (timeSinceChange > 60)
-		{
-			preserveBeenActive = false;
-			return 75 - timeSinceChange;
-		}
-
 		preserveBeenActive = false;
-		return 60 - timeSinceChange;
+		return (timeSinceChange > 60) ? 75-timeSinceChange : 60-timeSinceChange;
+
 	}
 
 	private int timeSinceLastChange()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/boosts/BoostsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/boosts/BoostsPlugin.java
@@ -36,6 +36,7 @@ import javax.inject.Inject;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
+import net.runelite.api.Prayer;
 import net.runelite.api.Skill;
 import net.runelite.api.events.BoostedLevelChanged;
 import net.runelite.api.events.ConfigChanged;
@@ -89,6 +90,10 @@ public class BoostsPlugin extends Plugin
 	private StatChangeIndicator statChangeIndicator;
 
 	private BufferedImage overallIcon;
+
+	private boolean preserveBeenActive = false;
+
+	private int timeSinceChange;
 
 	@Provides
 	BoostsConfig provideConfig(ConfigManager configManager)
@@ -191,8 +196,54 @@ public class BoostsPlugin extends Plugin
 		}
 	}
 
+	/**
+	 * Calculates the amount of time until boosted stats decay,
+	 * accounting for the effect of preserve prayer.
+	 * Preserve extends the time of boosted stats by 50% while active.
+	 * The length of a boost is split into 4 sections of 15 seconds each.
+	 * If the preserve prayer is active for the entire duration of the final
+	 * section it will "activate" adding an additional 15 second section
+	 * to the boost timing. If again the preserve prayer is active for that
+	 * entire section a second 15 second section will be added.
+	 *
+	 * Preserve is only required to be on for the 4th and 5th sections of the boost timer
+	 * to gain full effect (seconds 45-75).
+	 *
+	 * @return integer value in seconds until next boost change
+	 */
 	public int getChangeTime()
 	{
-		return 60 - (int) Duration.between(lastChange, Instant.now()).getSeconds();
+		timeSinceChange = timeSinceLastChange();
+
+		if (client.isPrayerActive(Prayer.PRESERVE) && timeSinceChange < 45)
+		{
+			preserveBeenActive = true;
+			return 90 - timeSinceChange;
+		}
+
+		if (client.isPrayerActive(Prayer.PRESERVE) && preserveBeenActive)
+		{
+			return 90 - timeSinceChange;
+		}
+
+		if (timeSinceChange > 60 && timeSinceChange <= 75)
+		{
+			preserveBeenActive = false;
+			return 75 - timeSinceChange;
+		}
+
+		if (timeSinceChange > 75)
+		{
+			return 90 - timeSinceChange;
+		}
+
+		preserveBeenActive = false;
+		return 60 - timeSinceChange;
 	}
+
+	public int timeSinceLastChange()
+	{
+		return (int) Duration.between(lastChange, Instant.now()).getSeconds();
+	}
+
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/boosts/BoostsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/boosts/BoostsPlugin.java
@@ -222,7 +222,6 @@ public class BoostsPlugin extends Plugin
 
 		preserveBeenActive = false;
 		return (timeSinceChange > 60) ? 75-timeSinceChange : 60-timeSinceChange;
-
 	}
 
 	private int timeSinceLastChange()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/boosts/BoostsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/boosts/BoostsPlugin.java
@@ -212,27 +212,18 @@ public class BoostsPlugin extends Plugin
 	public int getChangeTime()
 	{
 		int timeSinceChange = timeSinceLastChange();
+		boolean isPreserveActive = client.isPrayerActive(Prayer.PRESERVE);
 
-		if (client.isPrayerActive(Prayer.PRESERVE) && timeSinceChange < 45)
+		if ((isPreserveActive && (timeSinceChange < 45 || preserveBeenActive)) || timeSinceChange > 75)
 		{
 			preserveBeenActive = true;
 			return 90 - timeSinceChange;
 		}
 
-		if (client.isPrayerActive(Prayer.PRESERVE) && preserveBeenActive)
-		{
-			return 90 - timeSinceChange;
-		}
-
-		if (timeSinceChange > 60 && timeSinceChange <= 75)
+		if (timeSinceChange > 60)
 		{
 			preserveBeenActive = false;
 			return 75 - timeSinceChange;
-		}
-
-		if (timeSinceChange > 75)
-		{
-			return 90 - timeSinceChange;
 		}
 
 		preserveBeenActive = false;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/boosts/BoostsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/boosts/BoostsPlugin.java
@@ -93,8 +93,6 @@ public class BoostsPlugin extends Plugin
 
 	private boolean preserveBeenActive = false;
 
-	private int timeSinceChange;
-
 	@Provides
 	BoostsConfig provideConfig(ConfigManager configManager)
 	{
@@ -213,7 +211,7 @@ public class BoostsPlugin extends Plugin
 	 */
 	public int getChangeTime()
 	{
-		timeSinceChange = timeSinceLastChange();
+		int timeSinceChange = timeSinceLastChange();
 
 		if (client.isPrayerActive(Prayer.PRESERVE) && timeSinceChange < 45)
 		{
@@ -241,7 +239,7 @@ public class BoostsPlugin extends Plugin
 		return 60 - timeSinceChange;
 	}
 
-	public int timeSinceLastChange()
+	private int timeSinceLastChange()
 	{
 		return (int) Duration.between(lastChange, Instant.now()).getSeconds();
 	}


### PR DESCRIPTION
From what i have been able to test there are 4 "sections" of 15 seconds each until your stats drain.
Preserve only needs to be on for the entirety of the last one for it to activate, once it does so you get 30 seconds extra even if you turn off preserve.

This will display the new decay timing while you have preserve on, if you don't turn it on soon enough or take it off too early it will catch that and display correctly.

This fulfills request #1059 