### PR TITLE
Add Tile location tooltip option to dev tools

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/devtools/DevToolsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/devtools/DevToolsOverlay.java
@@ -61,6 +61,8 @@ import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.OverlayUtil;
+import net.runelite.client.ui.overlay.tooltip.Tooltip;
+import net.runelite.client.ui.overlay.tooltip.TooltipManager;
 
 public class DevToolsOverlay extends Overlay
 {
@@ -82,14 +84,16 @@ public class DevToolsOverlay extends Overlay
 
 	private final Client client;
 	private final DevToolsPlugin plugin;
+	private final TooltipManager toolTipManager;
 
 	@Inject
-	public DevToolsOverlay(Client client, DevToolsPlugin plugin)
+	public DevToolsOverlay(Client client, DevToolsPlugin plugin, TooltipManager toolTipManager)
 	{
 		setPosition(OverlayPosition.DYNAMIC);
 		setLayer(OverlayLayer.ALWAYS_ON_TOP);
 		this.client = client;
 		this.plugin = plugin;
+		this.toolTipManager = toolTipManager;
 	}
 
 	@Override
@@ -111,7 +115,7 @@ public class DevToolsOverlay extends Overlay
 			renderNpcs(graphics);
 		}
 
-		if (plugin.isToggleGroundItems() || plugin.isToggleGroundObjects() || plugin.isToggleGameObjects() || plugin.isToggleWalls() || plugin.isToggleDecor())
+		if (plugin.isToggleGroundItems() || plugin.isToggleGroundObjects() || plugin.isToggleGameObjects() || plugin.isToggleWalls() || plugin.isToggleDecor() || plugin.isToggleTileLocation())
 		{
 			renderTileObjects(graphics);
 		}
@@ -233,7 +237,22 @@ public class DevToolsOverlay extends Overlay
 				{
 					renderDecorObject(graphics, tile, player);
 				}
+
+				if (plugin.isToggleTileLocation())
+				{
+					renderTileTooltip(graphics, tile);
+				}
 			}
+		}
+	}
+
+	private void renderTileTooltip(Graphics2D graphics, Tile tile)
+	{
+		Polygon poly = Perspective.getCanvasTilePoly(client, tile.getLocalLocation());
+		if (poly != null && poly.contains(client.getMouseCanvasPosition().getX(), client.getMouseCanvasPosition().getY()))
+		{
+			toolTipManager.add(new Tooltip("World Location: " + tile.getWorldLocation().getX() + ", " + tile.getWorldLocation().getY() + ", " + client.getPlane()));
+			OverlayUtil.renderPolygon(graphics, poly, GREEN);
 		}
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/devtools/DevToolsPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/devtools/DevToolsPanel.java
@@ -216,6 +216,14 @@ public class DevToolsPanel extends PluginPanel
 		});
 		container.add(worldMapBtn);
 
+		final JButton tileLocationBtn = new JButton("Tile Location Tooltip");
+		tileLocationBtn.addActionListener(e ->
+		{
+			highlightButton(tileLocationBtn);
+			plugin.toggleTileLocation();
+		});
+		container.add(tileLocationBtn);
+
 		return container;
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/devtools/DevToolsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/devtools/DevToolsPlugin.java
@@ -103,6 +103,7 @@ public class DevToolsPlugin extends Plugin
 	private boolean toggleGraphicsObjects;
 	private boolean toggleCamera;
 	private boolean toggleWorldMapLocation;
+	private boolean toggleTileLocation;
 
 	Widget currentWidget;
 	int itemIndex = -1;
@@ -326,6 +327,11 @@ public class DevToolsPlugin extends Plugin
 		toggleWorldMapLocation = !toggleWorldMapLocation;
 	}
 
+	void toggleTileLocation()
+	{
+		toggleTileLocation = !toggleTileLocation;
+	}
+
 	boolean isTogglePlayers()
 	{
 		return togglePlayers;
@@ -409,5 +415,10 @@ public class DevToolsPlugin extends Plugin
 	boolean isToggleWorldMapLocation()
 	{
 		return toggleWorldMapLocation;
+	}
+
+	boolean isToggleTileLocation()
+	{
+		return toggleTileLocation;
 	}
 }


### PR DESCRIPTION
This toggle will turn on highlighting the current tile under the mouse as well as show a tooltip containing the world location of that tile.

![admirablealtruisticindianpangolin-max-14mb](https://user-images.githubusercontent.com/1210740/39538967-4a0f7880-4df3-11e8-9e2c-0e4bbedefb89.gif)

