### PR TITLE
Improve Material Tabs Code

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/farmingtracker/FarmingTrackerPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/farmingtracker/FarmingTrackerPanel.java
@@ -31,8 +31,6 @@ import java.awt.Dimension;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Image;
-import java.awt.event.MouseAdapter;
-import java.awt.event.MouseEvent;
 import java.awt.image.BufferedImage;
 import java.time.Instant;
 import java.time.LocalDateTime;
@@ -45,7 +43,6 @@ import javax.swing.ImageIcon;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
-import javax.swing.SwingConstants;
 import javax.swing.border.EmptyBorder;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
@@ -139,7 +136,7 @@ class FarmingTrackerPanel extends PluginPanel
 					{
 						groupLabel.setBorder(new EmptyBorder(15, 0, 0, 0));
 					}
-					
+
 					groupLabel.setFont(FontManager.getRunescapeSmallFont());
 
 					container.add(groupLabel, c);
@@ -169,7 +166,9 @@ class FarmingTrackerPanel extends PluginPanel
 			scroller.getVerticalScrollBar().setBorder(new EmptyBorder(0, 9, 0, 0));
 			scroller.setBackground(ColorScheme.DARK_GRAY_COLOR);
 
-			MaterialTab materialTab = new MaterialTab("", tabGroup, scroller);
+			//Use a placeholder icon until the async image gets loaded
+			MaterialTab materialTab = new MaterialTab(new ImageIcon(), tabGroup, scroller);
+			materialTab.setPreferredSize(new Dimension(30, 27));
 			materialTab.setName(tab.getName());
 
 			AsyncBufferedImage icon = itemManager.getImage(tab.getItemID());
@@ -177,30 +176,11 @@ class FarmingTrackerPanel extends PluginPanel
 			{
 				BufferedImage subIcon = icon.getSubimage(0, 0, 32, 32);
 				materialTab.setIcon(new ImageIcon(subIcon.getScaledInstance(24, 24, Image.SCALE_SMOOTH)));
-				materialTab.setHorizontalAlignment(SwingConstants.CENTER);
-				materialTab.setVerticalAlignment(SwingConstants.CENTER);
-				materialTab.setOpaque(true);
-				materialTab.setBackground(ColorScheme.DARKER_GRAY_COLOR);
-				materialTab.setPreferredSize(new Dimension(30, 27));
 			};
 			icon.onChanged(resize);
 			resize.run();
 
 			materialTab.setOnSelectEvent(() -> config.setPatch(tab));
-			materialTab.addMouseListener(new MouseAdapter()
-			{
-				@Override
-				public void mouseEntered(MouseEvent e)
-				{
-					materialTab.setBackground(ColorScheme.DARKER_GRAY_HOVER_COLOR);
-				}
-
-				@Override
-				public void mouseExited(MouseEvent e)
-				{
-					materialTab.setBackground(ColorScheme.DARKER_GRAY_COLOR);
-				}
-			});
 
 			tabGroup.addTab(materialTab);
 			if (config.patch() == tab)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangePanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangePanel.java
@@ -27,9 +27,6 @@
 package net.runelite.client.plugins.grandexchange;
 
 import java.awt.BorderLayout;
-import java.awt.Color;
-import java.awt.event.MouseAdapter;
-import java.awt.event.MouseEvent;
 import java.util.concurrent.ScheduledExecutorService;
 import javax.inject.Inject;
 import javax.swing.JPanel;
@@ -74,29 +71,6 @@ class GrandExchangePanel extends PluginPanel
 
 		MaterialTab offersTab = new MaterialTab("Offers", tabGroup, offersPanel);
 		searchTab = new MaterialTab("Search", tabGroup, searchPanel);
-
-		MouseAdapter materialTabMouseAdapter = new MouseAdapter()
-		{
-			@Override
-			public void mouseEntered(MouseEvent e)
-			{
-				MaterialTab tab = (MaterialTab)e.getSource();
-				tab.setForeground(Color.WHITE);
-			}
-
-			@Override
-			public void mouseExited(MouseEvent e)
-			{
-				MaterialTab tab = (MaterialTab)e.getSource();
-				if (!tab.isSelected())
-				{
-					tab.setForeground(Color.GRAY);
-				}
-			}
-		};
-
-		searchTab.addMouseListener(materialTabMouseAdapter);
-		offersTab.addMouseListener(materialTabMouseAdapter);
 
 		tabGroup.setBorder(new EmptyBorder(5, 0, 0, 0));
 		tabGroup.addTab(offersTab);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/SkillCalculatorPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/SkillCalculatorPanel.java
@@ -36,7 +36,6 @@ import java.awt.event.MouseListener;
 import javax.swing.ImageIcon;
 import javax.swing.JLabel;
 import javax.swing.JScrollPane;
-import javax.swing.SwingConstants;
 import javax.swing.border.EmptyBorder;
 import net.runelite.api.Client;
 import net.runelite.client.game.SkillIconManager;
@@ -118,15 +117,9 @@ class SkillCalculatorPanel extends PluginPanel
 	{
 		for (CalculatorType calculatorType : CalculatorType.values())
 		{
-			MaterialTab tab = new MaterialTab("", tabGroup, null);
-			tab.setOpaque(true);
-			tab.setVerticalAlignment(SwingConstants.CENTER);
-			tab.setHorizontalAlignment(SwingConstants.CENTER);
-			tab.setBackground(ColorScheme.DARKER_GRAY_COLOR);
-			tab.setIcon(new ImageIcon(iconManager.getSkillImage(calculatorType.getSkill(), true)));
+			ImageIcon icon = new ImageIcon(iconManager.getSkillImage(calculatorType.getSkill(), true));
+			MaterialTab tab = new MaterialTab(icon, tabGroup, null);
 			tab.setOnSelectEvent(() -> uiCalculator.openCalculator(calculatorType));
-			tab.addMouseListener(tabHoverListener);
-
 			tabGroup.addTab(tab);
 		}
 	}

--- a/runelite-client/src/main/java/net/runelite/client/ui/components/materialtabs/MaterialTab.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/components/materialtabs/MaterialTab.java
@@ -24,12 +24,15 @@
  */
 package net.runelite.client.ui.components.materialtabs;
 
+import com.google.common.base.Strings;
 import java.awt.Color;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import javax.swing.BorderFactory;
+import javax.swing.ImageIcon;
 import javax.swing.JComponent;
 import javax.swing.JLabel;
+import javax.swing.SwingConstants;
 import javax.swing.border.Border;
 import javax.swing.border.CompoundBorder;
 import lombok.Getter;
@@ -91,6 +94,57 @@ public class MaterialTab extends JLabel
 				group.select(MaterialTab.this);
 			}
 		});
+
+		if (!Strings.isNullOrEmpty(string))
+		{
+			addMouseListener(new MouseAdapter()
+			{
+				@Override
+				public void mouseEntered(MouseEvent e)
+				{
+					MaterialTab tab = (MaterialTab) e.getSource();
+					tab.setForeground(Color.WHITE);
+				}
+
+				@Override
+				public void mouseExited(MouseEvent e)
+				{
+					MaterialTab tab = (MaterialTab) e.getSource();
+					if (!tab.isSelected())
+					{
+						tab.setForeground(Color.GRAY);
+					}
+				}
+			});
+		}
+	}
+
+	public MaterialTab(ImageIcon icon, MaterialTabGroup group, JComponent content)
+	{
+		this("", group, content);
+		setIcon(icon);
+		setOpaque(true);
+		setVerticalAlignment(SwingConstants.CENTER);
+		setHorizontalAlignment(SwingConstants.CENTER);
+		setBackground(ColorScheme.DARKER_GRAY_COLOR);
+
+		addMouseListener(new MouseAdapter()
+		{
+			@Override
+			public void mouseEntered(MouseEvent e)
+			{
+				MaterialTab tab = (MaterialTab) e.getSource();
+				tab.setBackground(ColorScheme.DARKER_GRAY_HOVER_COLOR);
+			}
+
+			@Override
+			public void mouseExited(MouseEvent e)
+			{
+				MaterialTab tab = (MaterialTab) e.getSource();
+				tab.setBackground(ColorScheme.DARKER_GRAY_COLOR);
+			}
+		});
+
 	}
 
 	public void select()


### PR DESCRIPTION
As material tabs started being used in different ways than planned, the code
around them started being a little inconsistent. With this change I created a new constructor for Icon Tabs (skill calculator, farm timer) and also add hover effects to them. These hover effects were previously added on each plugin that used them.

I also refactored the plugins that included these tabs to use the new constructor.

**These tabs will look and behave exactly like they do currently in master, it's just a code improvement.**