### PR TITLE
AntiDragPlugin: Fix crash on pressing reset

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/antidrag/AntiDragConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/antidrag/AntiDragConfig.java
@@ -45,11 +45,4 @@ public interface AntiDragConfig extends Config
 	{
 		return 600 / 20; // one game tick
 	}
-
-	@ConfigItem(
-		keyName = "dragDelay",
-		name = "",
-		description = ""
-	)
-	void dragDelay(int delay);
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/antidrag/AntiDragConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/antidrag/AntiDragConfig.java
@@ -38,11 +38,11 @@ public interface AntiDragConfig extends Config
 	@ConfigItem(
 		keyName = "dragDelay",
 		name = "Drag Delay",
-		description = "Configures the inventory drag delay in client ticks (20ms)",
+		description = "Configures the inventory drag delay in milliseconds",
 		position = 1
 	)
 	default int dragDelay()
 	{
-		return 600 / 20; // one game tick
+		return 600; // one game tick
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/antidrag/AntiDragPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/antidrag/AntiDragPlugin.java
@@ -78,9 +78,11 @@ public class AntiDragPlugin extends Plugin implements KeyListener
 	@Override
 	public void keyPressed(KeyEvent e)
 	{
+		int dragDelay = (int) Math.floor(config.dragDelay() / 20);
+
 		if (e.getKeyCode() == KeyEvent.VK_SHIFT)
 		{
-			client.setInventoryDragDelay(config.dragDelay());
+			client.setInventoryDragDelay(dragDelay);
 		}
 	}
 


### PR DESCRIPTION
Fix crash when pressing reset and change drag delay to milliseconds to match other plugins