### PR TITLE
regen plugin: don't show regen if the minimap orb is hidden

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/regenmeter/RegenMeterOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/regenmeter/RegenMeterOverlay.java
@@ -88,7 +88,7 @@ public class RegenMeterOverlay extends Overlay
 	private void renderRegen(Graphics2D g, WidgetInfo widgetInfo, double percent, Color color)
 	{
 		Widget widget = client.getWidget(widgetInfo);
-		if (widget == null)
+		if (widget == null || widget.isHidden())
 		{
 			return;
 		}


### PR DESCRIPTION
If the minimap orb is hidden, don't render the regen meter. This is mostly noticeable during cutscenes and if the minimap is hidden in general.