### PR TITLE
Material Tabs in Hiscores + OnTabSelected event

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/farmingtracker/FarmingTrackerPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/farmingtracker/FarmingTrackerPanel.java
@@ -180,7 +180,11 @@ class FarmingTrackerPanel extends PluginPanel
 			icon.onChanged(resize);
 			resize.run();
 
-			materialTab.setOnSelectEvent(() -> config.setPatch(tab));
+			materialTab.setOnSelectEvent(() ->
+			{
+				config.setPatch(tab);
+				return true;
+			});
 
 			tabGroup.addTab(materialTab);
 			if (config.patch() == tab)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/SkillCalculatorPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/SkillCalculatorPanel.java
@@ -119,7 +119,12 @@ class SkillCalculatorPanel extends PluginPanel
 		{
 			ImageIcon icon = new ImageIcon(iconManager.getSkillImage(calculatorType.getSkill(), true));
 			MaterialTab tab = new MaterialTab(icon, tabGroup, null);
-			tab.setOnSelectEvent(() -> uiCalculator.openCalculator(calculatorType));
+			tab.setOnSelectEvent(() ->
+			{
+				uiCalculator.openCalculator(calculatorType);
+				return true;
+			});
+
 			tabGroup.addTab(tab);
 		}
 	}

--- a/runelite-client/src/main/java/net/runelite/client/ui/components/materialtabs/MaterialTab.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/components/materialtabs/MaterialTab.java
@@ -28,6 +28,7 @@ import com.google.common.base.Strings;
 import java.awt.Color;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
+import java.util.function.BooleanSupplier;
 import javax.swing.BorderFactory;
 import javax.swing.ImageIcon;
 import javax.swing.JComponent;
@@ -37,6 +38,7 @@ import javax.swing.border.Border;
 import javax.swing.border.CompoundBorder;
 import lombok.Getter;
 import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
 import net.runelite.client.ui.ColorScheme;
 
 /**
@@ -47,6 +49,7 @@ import net.runelite.client.ui.ColorScheme;
  *
  * @author Psikoi
  */
+@Slf4j
 public class MaterialTab extends JLabel
 {
 	private static final Border SELECTED_BORDER = new CompoundBorder(
@@ -65,7 +68,7 @@ public class MaterialTab extends JLabel
 
 	/* To be execuded when the tab is selected */
 	@Setter
-	private Runnable onSelectEvent;
+	private BooleanSupplier onSelectEvent;
 
 	@Getter
 	private boolean selected;
@@ -147,15 +150,19 @@ public class MaterialTab extends JLabel
 
 	}
 
-	public void select()
+	public boolean select()
 	{
-		setBorder(SELECTED_BORDER);
-		setForeground(Color.WHITE);
-		selected = true;
 		if (onSelectEvent != null)
 		{
-			onSelectEvent.run();
+			if (!onSelectEvent.getAsBoolean())
+			{
+				return false;
+			}
 		}
+
+		setBorder(SELECTED_BORDER);
+		setForeground(Color.WHITE);
+		return selected = true;
 	}
 
 	public void unselect()

--- a/runelite-client/src/main/java/net/runelite/client/ui/components/materialtabs/MaterialTabGroup.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/components/materialtabs/MaterialTabGroup.java
@@ -101,24 +101,25 @@ public class MaterialTabGroup extends JPanel
 			return false;
 		}
 
+		// If the OnTabSelected returned false, exit the method to prevent tab switching
+		if (!selectedTab.select())
+		{
+			return false;
+		}
+
+		// If the display is available, switch from the old to the new display
 		if (display != null)
 		{
 			display.removeAll();
+			display.add(selectedTab.getContent());
+			display.revalidate();
+			display.repaint();
 		}
 
+		// Unselected all other tabs
 		for (MaterialTab tab : tabs)
 		{
-			if (tab.equals(selectedTab))
-			{
-				tab.select();
-				if (display != null)
-				{
-					display.add(tab.getContent());
-					display.revalidate();
-					display.repaint();
-				}
-			}
-			else
+			if (!tab.equals(selectedTab))
 			{
 				tab.unselect();
 			}


### PR DESCRIPTION
In an attempt to clean-up and re-use UI elements, I am applying the material tabs to the hiscores plugin (previously it was jpanels that looked exactly like tabs because at the time this panel was made, there were no icon material tabs yet).

With this, I expanded the functionality on the Material Tabs by adding a new event instead of Runnable.
From the commit message:

This new functionality allows a tab to not be selected depending on the
value of onTabSelected.

For example, for the hiscores, I want to block tab switching when the
plugin is already loading someone's hiscores, and in this scenario, I
have to return false to make sure the tabs don't switch.

**Small visual improvements were done to the hiscores search bar (it broke because of the new tabs, just had to readjust some heights).**

