### PR TITLE
sidebar: fix minimum size when restoring window

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ui/ContainableFrame.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ContainableFrame.java
@@ -39,6 +39,21 @@ public class ContainableFrame extends JFrame
 	private boolean containedInScreen;
 	private boolean expandedClientOppositeDirection;
 
+	ContainableFrame()
+	{
+		addWindowStateListener(windowEvent ->
+		{
+			if (windowEvent.getNewState() == Frame.NORMAL)
+			{
+				// When the sidebar is contracted while the frame is normal and the frame is as small as possible,
+				// then the sidebar is expanded while the frame is maximized, then restoring the frame, the frame will
+				// restore back to the smaller original contracted size instead of the new larger expanded minimum size.
+				// This will revalidate the size when restored.
+				revalidateMinimumSize();
+			}
+		});
+	}
+
 	public void setContainedInScreen(boolean value)
 	{
 		this.containedInScreen = value;


### PR DESCRIPTION
Fixes #2612

This fix seems like a hack, but I'm not sure of a better way around it since it seems like a Swing problem. 

While the client is as small as possible and the sidebar gets contracted, the minimum size gets updated. Now maximize the client, then expand the sidebar. Based on the existing `expandby` code, the minimum size does not get updated. However, adding a `revalidateminimumsize` while fullscreen "does" update the minimum size, restoring the window does not actually resize the frame. It will only resize the frame when the window is moved or manually resized. This is why I think it's a Swing problem. While technically correct to call `revalidateminimumsize` in the `expandby` code, I decided to only call it during the restoring window event, instead of having both calls, where it wouldn't make much of a difference.