### PR TITLE
farmingtracker - Change tickrate for giant seaweed from 10 to 5

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/farmingtracker/Produce.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/farmingtracker/Produce.java
@@ -104,7 +104,7 @@ public enum Produce
 	PALM("Palm", ItemID.COCONUT, 160, 7, 45, 7),
 
 	// Special crops
-	SEAWEED("Seaweed", ItemID.GIANT_SEAWEED, 10, 8, 0, 4),
+	SEAWEED("Seaweed", ItemID.GIANT_SEAWEED, 5, 8, 0, 4),
 	TEAK("Teak", ItemID.TEAK_LOGS, 560, 9),
 	GRAPE("Grape", ItemID.GRAPES, 5, 8, 0, 5),
 	MUSHROOM("Mushroom", ItemID.MUSHROOM, 40, 7, 0, 7),


### PR DESCRIPTION
As described in #3552, the tickrate should be 5 rather than 10 as it only takes 35 minutes to grow rather than 70. I have not tested whether this is true or not.

Fixes #3552