### PR TITLE
Update Screenshot plugin to have option to automatically take screenshot for PvP kills

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotConfig.java
@@ -133,4 +133,15 @@ public interface ScreenshotConfig extends Config
 	{
 		return false;
 	}
+
+	@ConfigItem(
+		keyName = "kills",
+		name = "Screenshot PvP Kills",
+		description = "Configures whether or not screenshots are automatically taken of PvP kills",
+		position = 9
+	)
+	default boolean screenshotKills()
+	{
+		return false;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
@@ -111,6 +111,11 @@ public class ScreenshotPlugin extends Plugin
 		"You feel something weird sneaking into your backpack",
 		"You have a funny feeling like you would have been followed");
 
+	private static final ImmutableList<String> KILL_MESSAGES = ImmutableList.of("into tiny pieces and sat on them", "you have obliterated",
+		"falls before your might", "A humiliating defeat for", "With a crushing blow you", "thinking challenging you",
+		"Can anyone defeat you? Certainly", "was no match for you", "You were clearly a better fighter than", "RIP",
+		"You have defeated", "What an embarrassing performance by", "was no match for your awesomeness");
+
 	private String clueType;
 	private Integer clueNumber;
 
@@ -256,6 +261,12 @@ public class ScreenshotPlugin extends Plugin
 		if (config.screenshotPet() && PET_MESSAGES.stream().anyMatch(chatMessage::contains))
 		{
 			String fileName = "Pet " + TIME_FORMAT.format(new Date());
+			takeScreenshot(fileName);
+		}
+
+		if (config.screenshotKills() && KILL_MESSAGES.stream().anyMatch(chatMessage::contains))
+		{
+			String fileName = "Kill " + " " + LocalDate.now();
 			takeScreenshot(fileName);
 		}
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
@@ -107,7 +107,7 @@ public class ScreenshotPlugin extends Plugin
 	private static final Pattern NUMBER_PATTERN = Pattern.compile("([0-9]+)");
 	private static final Pattern LEVEL_UP_PATTERN = Pattern.compile("Your ([a-zA-Z]+) (?:level is|are)? now (\\d+)\\.");
 
-	private static final ImmutableList<String> petMessages = ImmutableList.of("You have a funny feeling like you're being followed",
+	private static final ImmutableList<String> PET_MESSAGES = ImmutableList.of("You have a funny feeling like you're being followed",
 		"You feel something weird sneaking into your backpack",
 		"You have a funny feeling like you would have been followed");
 
@@ -252,8 +252,8 @@ public class ScreenshotPlugin extends Plugin
 				return;
 			}
 		}
-		
-		if (config.screenshotPet() && petMessages.stream().anyMatch(chatMessage::contains))
+
+		if (config.screenshotPet() && PET_MESSAGES.stream().anyMatch(chatMessage::contains))
 		{
 			String fileName = "Pet " + TIME_FORMAT.format(new Date());
 			takeScreenshot(fileName);


### PR DESCRIPTION
This just takes a screenshot whenever a PvP kill message is received. 