### PR TITLE
Chat colour configuration changes

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/chat/ChatMessageManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/chat/ChatMessageManager.java
@@ -256,6 +256,11 @@ public class ChatMessageManager
 			cacheColor(new ChatColor(ChatColorType.NORMAL, chatColorConfig.opaqueClanChatInfo(), false),
 				ChatMessageType.CLANCHAT_INFO);
 		}
+		if (chatColorConfig.opaqueClanChatInfoHighlight() != null)
+		{
+			cacheColor(new ChatColor(ChatColorType.HIGHLIGHT, chatColorConfig.opaqueClanChatInfoHighlight(), false),
+				ChatMessageType.CLANCHAT_INFO);
+		}
 		if (chatColorConfig.opaqueClanChatMessage() != null)
 		{
 			cacheColor(new ChatColor(ChatColorType.NORMAL, chatColorConfig.opaqueClanChatMessage(), false),
@@ -381,6 +386,11 @@ public class ChatMessageManager
 		if (chatColorConfig.transparentClanChatInfo() != null)
 		{
 			cacheColor(new ChatColor(ChatColorType.NORMAL, chatColorConfig.transparentClanChatInfo(), true),
+				ChatMessageType.CLANCHAT_INFO);
+		}
+		if (chatColorConfig.transparentClanChatInfoHighlight() != null)
+		{
+			cacheColor(new ChatColor(ChatColorType.HIGHLIGHT, chatColorConfig.transparentClanChatInfoHighlight(), true),
 				ChatMessageType.CLANCHAT_INFO);
 		}
 		if (chatColorConfig.transparentClanChatMessage() != null)

--- a/runelite-client/src/main/java/net/runelite/client/config/ChatColorConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/ChatColorConfig.java
@@ -34,6 +34,13 @@ import java.awt.Color;
 public interface ChatColorConfig extends Config
 {
 	@ConfigItem(
+		position = 30,
+		name = "Opaque Chatbox",
+		description = "All the settings for Opaque Chatboxes"
+	)
+	void opaqueHeading();
+
+	@ConfigItem(
 		position = 31,
 		keyName = "opaquePublicChat",
 		name = "Public chat",
@@ -249,9 +256,16 @@ public interface ChatColorConfig extends Config
 	Color opaqueClanUsernames();
 
 	@ConfigItem(
+		position = 60,
+		name = "Transparent Chatbox",
+		description = "All the settings for Transparent Chatboxes"
+	)
+	void transparentHeading();
+
+	@ConfigItem(
 		position = 61,
 		keyName = "transparentPublicChat",
-		name = "Public chat (transparent)",
+		name = "Public chat",
 		description = "Color of Public chat (transparent)"
 	)
 	Color transparentPublicChat();
@@ -259,7 +273,7 @@ public interface ChatColorConfig extends Config
 	@ConfigItem(
 		position = 62,
 		keyName = "transparentPublicChatHighlight",
-		name = "Public chat highlight (transparent)",
+		name = "Public chat highlight",
 		description = "Color of highlights in Public chat (transparent)"
 	)
 	default Color transparentPublicChatHighlight()
@@ -270,7 +284,7 @@ public interface ChatColorConfig extends Config
 	@ConfigItem(
 		position = 63,
 		keyName = "transparentPrivateMessageSent",
-		name = "Sent private messages (transparent)",
+		name = "Sent private messages",
 		description = "Color of Private messages you've sent (transparent)"
 	)
 	Color transparentPrivateMessageSent();
@@ -278,7 +292,7 @@ public interface ChatColorConfig extends Config
 	@ConfigItem(
 		position = 64,
 		keyName = "transparentPrivateMessageSentHighlight",
-		name = "Sent private messages highlight (transparent)",
+		name = "Sent private messages highlight",
 		description = "Color of highlights in Private messages you've sent (transparent)"
 	)
 	default Color transparentPrivateMessageSentHighlight()
@@ -289,7 +303,7 @@ public interface ChatColorConfig extends Config
 	@ConfigItem(
 		position = 65,
 		keyName = "transparentPrivateMessageReceived",
-		name = "Received private messages (transparent)",
+		name = "Received private messages",
 		description = "Color of Private messages you've received (transparent)"
 	)
 	Color transparentPrivateMessageReceived();
@@ -297,7 +311,7 @@ public interface ChatColorConfig extends Config
 	@ConfigItem(
 		position = 66,
 		keyName = "transparentPrivateMessageReceivedHighlight",
-		name = "Received private messages highlight (transparent)",
+		name = "Received private messages highlight",
 		description = "Color of highlights in Private messages you've received (transparent)"
 	)
 	default Color transparentPrivateMessageReceivedHighlight()
@@ -308,7 +322,7 @@ public interface ChatColorConfig extends Config
 	@ConfigItem(
 		position = 67,
 		keyName = "transparentClanChatInfo",
-		name = "Clan chat info (transparent)",
+		name = "Clan chat info",
 		description = "Clan Chat Information (eg. when joining a channel) (transparent)"
 	)
 	Color transparentClanChatInfo();
@@ -316,7 +330,7 @@ public interface ChatColorConfig extends Config
 	@ConfigItem(
 		position = 68,
 		keyName = "transparentClanChatMessage",
-		name = "Clan chat message (transparent)",
+		name = "Clan chat message",
 		description = "Color of Clan Chat Messages (transparent)"
 	)
 	Color transparentClanChatMessage();
@@ -324,7 +338,7 @@ public interface ChatColorConfig extends Config
 	@ConfigItem(
 		position = 69,
 		keyName = "transparentClanChatMessageHighlight",
-		name = "Clan chat message highlight (transparent)",
+		name = "Clan chat message highlight",
 		description = "Color of highlights in Clan Chat Messages (transparent)"
 	)
 	default Color transparentClanChatMessageHighlight()
@@ -335,7 +349,7 @@ public interface ChatColorConfig extends Config
 	@ConfigItem(
 		position = 70,
 		keyName = "transparentAutochatMessage",
-		name = "Autochat (transparent)",
+		name = "Autochat",
 		description = "Color of Autochat messages (transparent)"
 	)
 	Color transparentAutochatMessage();
@@ -343,7 +357,7 @@ public interface ChatColorConfig extends Config
 	@ConfigItem(
 		position = 71,
 		keyName = "transparentAutochatMessageHighlight",
-		name = "Autochat highlight (transparent)",
+		name = "Autochat highlight",
 		description = "Color of highlights in Autochat messages (transparent)"
 	)
 	Color transparentAutochatMessageHighlight();
@@ -351,7 +365,7 @@ public interface ChatColorConfig extends Config
 	@ConfigItem(
 		position = 72,
 		keyName = "transparentTradeChatMessage",
-		name = "Trade chat (transparent)",
+		name = "Trade chat",
 		description = "Color of Trade Chat Messages (transparent)"
 	)
 	Color transparentTradeChatMessage();
@@ -359,7 +373,7 @@ public interface ChatColorConfig extends Config
 	@ConfigItem(
 		position = 73,
 		keyName = "transparentTradeChatMessageHighlight",
-		name = "Trade chat highlight (transparent)",
+		name = "Trade chat highlight",
 		description = "Color of highlights in Trade Chat Messages (transparent)"
 	)
 	Color transparentTradeChatMessageHighlight();
@@ -367,7 +381,7 @@ public interface ChatColorConfig extends Config
 	@ConfigItem(
 		position = 74,
 		keyName = "transparentServerMessage",
-		name = "Server message (transparent)",
+		name = "Server message",
 		description = "Color of Server Messages (eg. 'Welcome to Runescape') (transparent)"
 	)
 	Color transparentServerMessage();
@@ -375,7 +389,7 @@ public interface ChatColorConfig extends Config
 	@ConfigItem(
 		position = 75,
 		keyName = "transparentServerMessageHighlight",
-		name = "Server message highlight (transparent)",
+		name = "Server message highlight",
 		description = "Color of highlights in Server Messages (transparent)"
 	)
 	Color transparentServerMessageHighlight();
@@ -383,7 +397,7 @@ public interface ChatColorConfig extends Config
 	@ConfigItem(
 		position = 76,
 		keyName = "transparentGameMessage",
-		name = "Game message (transparent)",
+		name = "Game message",
 		description = "Color of Game Messages (transparent)"
 	)
 	Color transparentGameMessage();
@@ -391,7 +405,7 @@ public interface ChatColorConfig extends Config
 	@ConfigItem(
 		position = 77,
 		keyName = "transparentGameMessageHighlight",
-		name = "Game message highlight (transparent)",
+		name = "Game message highlight",
 		description = "Color of highlights in Game Messages (transparent)"
 	)
 	Color transparentGameMessageHighlight();
@@ -399,7 +413,7 @@ public interface ChatColorConfig extends Config
 	@ConfigItem(
 		position = 78,
 		keyName = "transparentExamine",
-		name = "Examine (transparent)",
+		name = "Examine",
 		description = "Color of Examine Text (transparent)"
 	)
 	Color transparentExamine();
@@ -407,7 +421,7 @@ public interface ChatColorConfig extends Config
 	@ConfigItem(
 		position = 79,
 		keyName = "transparentExamineHighlight",
-		name = "Examine Highlight (transparent)",
+		name = "Examine Highlight",
 		description = "Color of highlights in Examine Text (transparent)"
 	)
 	default Color transparentExamineHighlight()
@@ -418,7 +432,7 @@ public interface ChatColorConfig extends Config
 	@ConfigItem(
 		position = 80,
 		keyName = "transparentFiltered",
-		name = "Filtered (transparent)",
+		name = "Filtered",
 		description = "Color of Filtered Text (messages that aren't shown when Game messages are filtered) (transparent)"
 	)
 	Color transparentFiltered();
@@ -426,7 +440,7 @@ public interface ChatColorConfig extends Config
 	@ConfigItem(
 		position = 81,
 		keyName = "transparentFilteredHighlight",
-		name = "Filtered Highlight (transparent)",
+		name = "Filtered Highlight",
 		description = "Color of highlights in Filtered Text (transparent)"
 	)
 	Color transparentFilteredHighlight();
@@ -434,7 +448,7 @@ public interface ChatColorConfig extends Config
 	@ConfigItem(
 		position = 82,
 		keyName = "transparentUsername",
-		name = "Usernames (transparent)",
+		name = "Usernames",
 		description = "Color of Usernames (transparent)"
 	)
 	Color transparentUsername();
@@ -442,7 +456,7 @@ public interface ChatColorConfig extends Config
 	@ConfigItem(
 		position = 83,
 		keyName = "transparentPrivateUsernames",
-		name = "Private chat usernames (transparent)",
+		name = "Private chat usernames",
 		description = "Color of Usernames in Private Chat (transparent)"
 	)
 	Color transparentPrivateUsernames();
@@ -450,7 +464,7 @@ public interface ChatColorConfig extends Config
 	@ConfigItem(
 		position = 84,
 		keyName = "transparentClanChannelName",
-		name = "Chan channel Name (transparent)",
+		name = "Chan channel Name",
 		description = "Color of Clan Channel Name (transparent)"
 	)
 	Color transparentClanChannelName();
@@ -458,7 +472,7 @@ public interface ChatColorConfig extends Config
 	@ConfigItem(
 		position = 85,
 		keyName = "transparentClanUsernames",
-		name = "Clan usernames (transparent)",
+		name = "Clan usernames",
 		description = "Color of Usernames in Clan Chat (transparent)"
 	)
 	Color transparentClanUsernames();

--- a/runelite-client/src/main/java/net/runelite/client/config/ChatColorConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/ChatColorConfig.java
@@ -107,6 +107,17 @@ public interface ChatColorConfig extends Config
 
 	@ConfigItem(
 		position = 38,
+		keyName = "opaqueClanChatInfoHighlight",
+		name = "Clan chat info highlight",
+		description = "Clan Chat Information highlight (used for the Raids plugin)"
+	)
+	default Color opaqueClanChatInfoHighlight()
+	{
+		return Color.decode("#EF20FF");
+	}
+
+	@ConfigItem(
+		position = 39,
 		keyName = "opaqueClanChatMessage",
 		name = "Clan chat message",
 		description = "Color of Clan Chat Messages"
@@ -114,7 +125,7 @@ public interface ChatColorConfig extends Config
 	Color opaqueClanChatMessage();
 
 	@ConfigItem(
-		position = 39,
+		position = 40,
 		keyName = "opaqueClanChatMessageHighlight",
 		name = "Clan chat message highlight",
 		description = "Color of highlights in Clan Chat Messages"
@@ -125,7 +136,7 @@ public interface ChatColorConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 40,
+		position = 41,
 		keyName = "opaqueAutochatMessage",
 		name = "Autochat",
 		description = "Color of Autochat messages"
@@ -133,7 +144,7 @@ public interface ChatColorConfig extends Config
 	Color opaqueAutochatMessage();
 
 	@ConfigItem(
-		position = 41,
+		position = 42,
 		keyName = "opaqueAutochatMessageHighlight",
 		name = "Autochat highlight",
 		description = "Color of highlights in Autochat messages"
@@ -141,7 +152,7 @@ public interface ChatColorConfig extends Config
 	Color opaqueAutochatMessageHighlight();
 
 	@ConfigItem(
-		position = 42,
+		position = 43,
 		keyName = "opaqueTradeChatMessage",
 		name = "Trade chat",
 		description = "Color of Trade Chat Messages"
@@ -149,7 +160,7 @@ public interface ChatColorConfig extends Config
 	Color opaqueTradeChatMessage();
 
 	@ConfigItem(
-		position = 43,
+		position = 44,
 		keyName = "opaqueTradeChatMessageHighlight",
 		name = "Trade chat highlight",
 		description = "Color of highlights in Trade Chat Messages"
@@ -157,7 +168,7 @@ public interface ChatColorConfig extends Config
 	Color opaqueTradeChatMessageHighlight();
 
 	@ConfigItem(
-		position = 44,
+		position = 45,
 		keyName = "opaqueServerMessage",
 		name = "Server message",
 		description = "Color of Server Messages (eg. 'Welcome to Runescape')"
@@ -165,7 +176,7 @@ public interface ChatColorConfig extends Config
 	Color opaqueServerMessage();
 
 	@ConfigItem(
-		position = 45,
+		position = 46,
 		keyName = "opaqueServerMessageHighlight",
 		name = "Server message highlight",
 		description = "Color of highlights in Server Messages"
@@ -173,7 +184,7 @@ public interface ChatColorConfig extends Config
 	Color opaqueServerMessageHighlight();
 
 	@ConfigItem(
-		position = 46,
+		position = 47,
 		keyName = "opaqueGameMessage",
 		name = "Game message",
 		description = "Color of Game Messages"
@@ -181,7 +192,7 @@ public interface ChatColorConfig extends Config
 	Color opaqueGameMessage();
 
 	@ConfigItem(
-		position = 47,
+		position = 48,
 		keyName = "opaqueGameMessageHighlight",
 		name = "Game message highlight",
 		description = "Color of highlights in Game Messages"
@@ -189,7 +200,7 @@ public interface ChatColorConfig extends Config
 	Color opaqueGameMessageHighlight();
 
 	@ConfigItem(
-		position = 48,
+		position = 49,
 		keyName = "opaqueExamine",
 		name = "Examine",
 		description = "Color of Examine Text"
@@ -197,7 +208,7 @@ public interface ChatColorConfig extends Config
 	Color opaqueExamine();
 
 	@ConfigItem(
-		position = 49,
+		position = 50,
 		keyName = "opaqueExamineHighlight",
 		name = "Examine Highlight",
 		description = "Color of highlights in Examine Text"
@@ -208,7 +219,7 @@ public interface ChatColorConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 50,
+		position = 51,
 		keyName = "opaqueFiltered",
 		name = "Filtered",
 		description = "Color of Filtered Text (messages that aren't shown when Game messages are filtered)"
@@ -216,7 +227,7 @@ public interface ChatColorConfig extends Config
 	Color opaqueFiltered();
 
 	@ConfigItem(
-		position = 51,
+		position = 52,
 		keyName = "opaqueFilteredHighlight",
 		name = "Filtered Highlight",
 		description = "Color of highlights in Filtered Text"
@@ -224,7 +235,7 @@ public interface ChatColorConfig extends Config
 	Color opaqueFilteredHighlight();
 
 	@ConfigItem(
-		position = 52,
+		position = 53,
 		keyName = "opaqueUsername",
 		name = "Usernames",
 		description = "Color of Usernames"
@@ -232,7 +243,7 @@ public interface ChatColorConfig extends Config
 	Color opaqueUsername();
 
 	@ConfigItem(
-		position = 53,
+		position = 54,
 		keyName = "opaquePrivateUsernames",
 		name = "Private chat usernames",
 		description = "Color of Usernames in Private Chat"
@@ -240,7 +251,7 @@ public interface ChatColorConfig extends Config
 	Color opaquePrivateUsernames();
 
 	@ConfigItem(
-		position = 54,
+		position = 55,
 		keyName = "opaqueClanChannelName",
 		name = "Chan channel Name",
 		description = "Color of Clan Channel Name"
@@ -248,7 +259,7 @@ public interface ChatColorConfig extends Config
 	Color opaqueClanChannelName();
 
 	@ConfigItem(
-		position = 55,
+		position = 56,
 		keyName = "opaqueClanUsernames",
 		name = "Clan usernames",
 		description = "Color of Usernames in Clan Chat"
@@ -329,6 +340,17 @@ public interface ChatColorConfig extends Config
 
 	@ConfigItem(
 		position = 68,
+		keyName = "transparentClanChatInfoHighlight",
+		name = "Clan chat info highlight (transparent)",
+		description = "Clan Chat Information highlight (used for the Raids plugin) (transparent)"
+	)
+	default Color transparentClanChatInfoHighlight()
+	{
+		return Color.decode("#EF20FF");
+	}
+
+	@ConfigItem(
+		position = 69,
 		keyName = "transparentClanChatMessage",
 		name = "Clan chat message",
 		description = "Color of Clan Chat Messages (transparent)"
@@ -336,7 +358,7 @@ public interface ChatColorConfig extends Config
 	Color transparentClanChatMessage();
 
 	@ConfigItem(
-		position = 69,
+		position = 70,
 		keyName = "transparentClanChatMessageHighlight",
 		name = "Clan chat message highlight",
 		description = "Color of highlights in Clan Chat Messages (transparent)"
@@ -347,7 +369,7 @@ public interface ChatColorConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 70,
+		position = 71,
 		keyName = "transparentAutochatMessage",
 		name = "Autochat",
 		description = "Color of Autochat messages (transparent)"
@@ -355,7 +377,7 @@ public interface ChatColorConfig extends Config
 	Color transparentAutochatMessage();
 
 	@ConfigItem(
-		position = 71,
+		position = 72,
 		keyName = "transparentAutochatMessageHighlight",
 		name = "Autochat highlight",
 		description = "Color of highlights in Autochat messages (transparent)"
@@ -363,7 +385,7 @@ public interface ChatColorConfig extends Config
 	Color transparentAutochatMessageHighlight();
 
 	@ConfigItem(
-		position = 72,
+		position = 73,
 		keyName = "transparentTradeChatMessage",
 		name = "Trade chat",
 		description = "Color of Trade Chat Messages (transparent)"
@@ -371,7 +393,7 @@ public interface ChatColorConfig extends Config
 	Color transparentTradeChatMessage();
 
 	@ConfigItem(
-		position = 73,
+		position = 74,
 		keyName = "transparentTradeChatMessageHighlight",
 		name = "Trade chat highlight",
 		description = "Color of highlights in Trade Chat Messages (transparent)"
@@ -379,7 +401,7 @@ public interface ChatColorConfig extends Config
 	Color transparentTradeChatMessageHighlight();
 
 	@ConfigItem(
-		position = 74,
+		position = 75,
 		keyName = "transparentServerMessage",
 		name = "Server message",
 		description = "Color of Server Messages (eg. 'Welcome to Runescape') (transparent)"
@@ -387,7 +409,7 @@ public interface ChatColorConfig extends Config
 	Color transparentServerMessage();
 
 	@ConfigItem(
-		position = 75,
+		position = 76,
 		keyName = "transparentServerMessageHighlight",
 		name = "Server message highlight",
 		description = "Color of highlights in Server Messages (transparent)"
@@ -395,7 +417,7 @@ public interface ChatColorConfig extends Config
 	Color transparentServerMessageHighlight();
 
 	@ConfigItem(
-		position = 76,
+		position = 77,
 		keyName = "transparentGameMessage",
 		name = "Game message",
 		description = "Color of Game Messages (transparent)"
@@ -403,7 +425,7 @@ public interface ChatColorConfig extends Config
 	Color transparentGameMessage();
 
 	@ConfigItem(
-		position = 77,
+		position = 78,
 		keyName = "transparentGameMessageHighlight",
 		name = "Game message highlight",
 		description = "Color of highlights in Game Messages (transparent)"
@@ -411,7 +433,7 @@ public interface ChatColorConfig extends Config
 	Color transparentGameMessageHighlight();
 
 	@ConfigItem(
-		position = 78,
+		position = 79,
 		keyName = "transparentExamine",
 		name = "Examine",
 		description = "Color of Examine Text (transparent)"
@@ -419,7 +441,7 @@ public interface ChatColorConfig extends Config
 	Color transparentExamine();
 
 	@ConfigItem(
-		position = 79,
+		position = 80,
 		keyName = "transparentExamineHighlight",
 		name = "Examine Highlight",
 		description = "Color of highlights in Examine Text (transparent)"
@@ -430,7 +452,7 @@ public interface ChatColorConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 80,
+		position = 81,
 		keyName = "transparentFiltered",
 		name = "Filtered",
 		description = "Color of Filtered Text (messages that aren't shown when Game messages are filtered) (transparent)"
@@ -438,7 +460,7 @@ public interface ChatColorConfig extends Config
 	Color transparentFiltered();
 
 	@ConfigItem(
-		position = 81,
+		position = 82,
 		keyName = "transparentFilteredHighlight",
 		name = "Filtered Highlight",
 		description = "Color of highlights in Filtered Text (transparent)"
@@ -446,7 +468,7 @@ public interface ChatColorConfig extends Config
 	Color transparentFilteredHighlight();
 
 	@ConfigItem(
-		position = 82,
+		position = 83,
 		keyName = "transparentUsername",
 		name = "Usernames",
 		description = "Color of Usernames (transparent)"
@@ -454,7 +476,7 @@ public interface ChatColorConfig extends Config
 	Color transparentUsername();
 
 	@ConfigItem(
-		position = 83,
+		position = 84,
 		keyName = "transparentPrivateUsernames",
 		name = "Private chat usernames",
 		description = "Color of Usernames in Private Chat (transparent)"
@@ -462,7 +484,7 @@ public interface ChatColorConfig extends Config
 	Color transparentPrivateUsernames();
 
 	@ConfigItem(
-		position = 84,
+		position = 85,
 		keyName = "transparentClanChannelName",
 		name = "Chan channel Name",
 		description = "Color of Clan Channel Name (transparent)"
@@ -470,7 +492,7 @@ public interface ChatColorConfig extends Config
 	Color transparentClanChannelName();
 
 	@ConfigItem(
-		position = 85,
+		position = 86,
 		keyName = "transparentClanUsernames",
 		name = "Clan usernames",
 		description = "Color of Usernames in Clan Chat (transparent)"

--- a/runelite-client/src/main/java/net/runelite/client/config/ChatColorConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/ChatColorConfig.java
@@ -197,7 +197,10 @@ public interface ChatColorConfig extends Config
 		name = "Game message highlight",
 		description = "Color of highlights in Game Messages"
 	)
-	Color opaqueGameMessageHighlight();
+	default Color opaqueGameMessageHighlight()
+	{
+		return Color.decode("#EF1020");
+	}
 
 	@ConfigItem(
 		position = 49,
@@ -430,7 +433,10 @@ public interface ChatColorConfig extends Config
 		name = "Game message highlight",
 		description = "Color of highlights in Game Messages (transparent)"
 	)
-	Color transparentGameMessageHighlight();
+	default Color transparentGameMessageHighlight()
+	{
+		return Color.decode("#EF1020");
+	}
 
 	@ConfigItem(
 		position = 79,

--- a/runelite-client/src/main/java/net/runelite/client/config/ConfigItem.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/ConfigItem.java
@@ -35,7 +35,7 @@ public @interface ConfigItem
 {
 	int position() default -1;
 
-	String keyName();
+	String keyName() default "";
 
 	String name();
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
@@ -454,6 +454,12 @@ public class ConfigPanel extends PluginPanel
 			JLabel configEntryName = new JLabel(name);
 			configEntryName.setForeground(Color.WHITE);
 			configEntryName.setToolTipText("<html>" + name + ":<br>" + cid.getItem().description() + "</html>");
+
+			if (cid.getType() == void.class)
+			{
+				configEntryName.setText("<html><u>" + name + "</u></html>");
+			}
+
 			item.add(configEntryName, BorderLayout.CENTER);
 
 			if (cid.getType() == boolean.class)


### PR DESCRIPTION
* Added heading support to @ConfigItem. 

Gave keyName a default value of "" (which doesn't seem to save a value in the settings), and made options with the type `void` render with a nice underline and no input box


* Added headings to the Chat Color plugin settings, and removed the (transparent) from the transparent options

The text was getting cut off either way, requiring users to use the tooltip to tell. As a result, I've left the (transparent) tag in the tooltip itself.

* Added an option for Clan Chat Info Highlights, as the Raids plugin used them

If there's anything I should add, please let me know