### PR TITLE
Make Color config options show their colour instead of "Pick a color"

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
@@ -507,7 +507,7 @@ public class ConfigPanel extends PluginPanel
 				String existing = configManager.getConfiguration(cd.getGroup().keyName(), cid.getItem().keyName());
 				Color existingColor = existing == null ? Color.BLACK : Color.decode(existing);
 
-				JButton colorPicker = new JButton("Pick a color");
+				JButton colorPicker = new JButton("#" + Integer.toHexString(existingColor.getRGB()).substring(2).toUpperCase());
 				colorPicker.setFocusable(false);
 				colorPicker.setBackground(existingColor);
 				colorPicker.addMouseListener(new MouseAdapter()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
@@ -505,9 +505,21 @@ public class ConfigPanel extends PluginPanel
 			if (cid.getType() == Color.class)
 			{
 				String existing = configManager.getConfiguration(cd.getGroup().keyName(), cid.getItem().keyName());
-				Color existingColor = existing == null ? Color.BLACK : Color.decode(existing);
 
-				JButton colorPicker = new JButton("#" + Integer.toHexString(existingColor.getRGB()).substring(2).toUpperCase());
+				Color existingColor;
+				JButton colorPicker;
+
+				if (existing == null)
+				{
+					existingColor = Color.BLACK;
+					colorPicker = new JButton("Pick a color");
+				}
+				else
+				{
+					existingColor = Color.decode(existing);
+					colorPicker = new JButton("#" + Integer.toHexString(existingColor.getRGB()).substring(2).toUpperCase());
+				}
+
 				colorPicker.setFocusable(false);
 				colorPicker.setBackground(existingColor);
 				colorPicker.addMouseListener(new MouseAdapter()


### PR DESCRIPTION
Allows for seeing the colours you have set at a glance. Very nice for figuring out exactly what your Chat colours are set to.

Before:
![runelite_2018-06-02_19-34-48](https://user-images.githubusercontent.com/2979691/40879727-19f25eb2-669c-11e8-89f8-74ed3ead222f.png)

After:
![vivaldi_2018-06-02_19-35-18](https://user-images.githubusercontent.com/2979691/40879728-1ac4df22-669c-11e8-8e38-766f5cbccbea.png)
