### PR TITLE
Allow drawing of screen markers in every direction

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenmarkers/ScreenMarkerMouseListener.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenmarkers/ScreenMarkerMouseListener.java
@@ -24,10 +24,7 @@
  */
 package net.runelite.client.plugins.screenmarkers;
 
-import java.awt.Point;
 import java.awt.event.MouseEvent;
-import static java.lang.Math.max;
-import static java.lang.Math.min;
 import javax.swing.SwingUtilities;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.client.input.MouseListener;
@@ -36,7 +33,6 @@ import net.runelite.client.input.MouseListener;
 public class ScreenMarkerMouseListener extends MouseListener
 {
 	private final ScreenMarkerPlugin plugin;
-	private Point lastMousePoint = null;
 
 	ScreenMarkerMouseListener(ScreenMarkerPlugin plugin)
 	{
@@ -65,13 +61,11 @@ public class ScreenMarkerMouseListener extends MouseListener
 
 		if (SwingUtilities.isLeftMouseButton(event))
 		{
-			lastMousePoint = event.getPoint();
 			plugin.startCreation(event.getPoint());
 		}
 		else if (plugin.isCreatingScreenMarker())
 		{
 			plugin.finishCreation(true);
-			lastMousePoint = null;
 		}
 
 		event.consume();
@@ -106,29 +100,7 @@ public class ScreenMarkerMouseListener extends MouseListener
 
 		if (SwingUtilities.isLeftMouseButton(event))
 		{
-			Point currentPoint = event.getPoint();
-			int dx = currentPoint.x - lastMousePoint.x;
-			int dy = currentPoint.y - lastMousePoint.y;
-
-			//if shift is down, constrain proportions
-			if (event.isShiftDown() && dx != dy)
-			{
-				int x = dx;
-
-				if (dx > 0 || dy > 0)
-				{
-					dx = max(dx, dy);
-					dy = max(dy, x);
-				}
-				else
-				{
-					dx = min(dx, dy);
-					dy = min(dy, x);
-				}
-			}
-
-			plugin.resizeMarker(dx, dy);
-			lastMousePoint = currentPoint;
+			plugin.resizeMarker(event.getPoint());
 		}
 
 		return event;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenmarkers/ScreenMarkerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenmarkers/ScreenMarkerPlugin.java
@@ -32,6 +32,7 @@ import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import java.awt.Dimension;
 import java.awt.Point;
+import java.awt.Rectangle;
 import java.awt.image.BufferedImage;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -95,6 +96,7 @@ public class ScreenMarkerPlugin extends Plugin
 
 	@Getter
 	private boolean creatingScreenMarker = false;
+	private Point startLocation = null;
 
 	@Override
 	public Collection<Overlay> getOverlays()
@@ -180,6 +182,7 @@ public class ScreenMarkerPlugin extends Plugin
 		);
 
 		// Set overlay creator bounds to current position and default size
+		startLocation = location;
 		overlay.setPreferredLocation(location);
 		overlay.setPreferredSize(DEFAULT_SIZE);
 		creatingScreenMarker = true;
@@ -201,6 +204,7 @@ public class ScreenMarkerPlugin extends Plugin
 		}
 
 		creatingScreenMarker = false;
+		startLocation = null;
 		currentMarker = null;
 		setMouseListenerEnabled(false);
 
@@ -222,11 +226,12 @@ public class ScreenMarkerPlugin extends Plugin
 		overlayRenderer.rebuildOverlays();
 	}
 
-	public void resizeMarker(int dx, int dy)
+	void resizeMarker(Point point)
 	{
-		// TODO: Allow resizing below base point
-		Dimension currentSize = overlay.getPreferredSize();
-		overlay.setPreferredSize(new Dimension(currentSize.width + dx, currentSize.height + dy));
+		Rectangle bounds = new Rectangle(startLocation);
+		bounds.add(point);
+		overlay.setPreferredLocation(bounds.getLocation());
+		overlay.setPreferredSize(bounds.getSize());
 	}
 
 	public void updateConfig()


### PR DESCRIPTION
This will allow drawing screen markers in every direction.
I had to remove the support for constraining proportions because it was causing some issues. If it is desired to return this behavior I will take another look at it.

Fixes #3524