### PR TITLE
Fix Charge timer showing with every teleport

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/GraphicID.java
+++ b/runelite-api/src/main/java/net/runelite/api/GraphicID.java
@@ -26,7 +26,7 @@ package net.runelite.api;
 
 public class GraphicID
 {
-	public static final int CHARGE = 111;
+	public static final int TELEPORT = 111;
 	public static final int ENTANGLE = 179;
 	public static final int SNARE = 180;
 	public static final int BIND = 181;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timers/GameTimer.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timers/GameTimer.java
@@ -70,7 +70,7 @@ public enum GameTimer
 	GOD_WARS_ALTAR("altar", "God wars altar", 10, ChronoUnit.MINUTES),
 	ANTIPOISON("antipoison", "Antipoison", 90, ChronoUnit.SECONDS),
 	SUPERANTIPOISON("superantipoison", "Superantipoison", 346, ChronoUnit.SECONDS),
-	CHARGE("charge", "Charge", GraphicID.CHARGE, 6, ChronoUnit.MINUTES);
+	CHARGE("charge", "Charge", 6, ChronoUnit.MINUTES);
 
 	@Getter
 	private final String imageResource;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersPlugin.java
@@ -407,6 +407,11 @@ public class TimersPlugin extends Plugin
 		{
 			createGameTimer(CHARGE);
 		}
+
+		if (event.getMessage().equals("<col=ef1020>Your magical charge fades away.</col>"))
+		{
+			removeGameTimer(CHARGE);
+		}
 	}
 
 	@Subscribe

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersPlugin.java
@@ -402,6 +402,11 @@ public class TimersPlugin extends Plugin
 		{
 			createGameTimer(PRAYER_ENHANCE);
 		}
+
+		if (config.showCharge() && event.getMessage().equals("<col=ef1020>You feel charged with magic power.</col>"))
+		{
+			createGameTimer(CHARGE);
+		}
 	}
 
 	@Subscribe
@@ -429,11 +434,6 @@ public class TimersPlugin extends Plugin
 		if (actor != client.getLocalPlayer())
 		{
 			return;
-		}
-
-		if (config.showCharge() && actor.getGraphic() == CHARGE.getGraphicId())
-		{
-			createGameTimer(CHARGE);
 		}
 
 		if (config.showImbuedHeart() && actor.getGraphic() == IMBUEDHEART.getGraphicId())


### PR DESCRIPTION
Turns out a lot of things reuse that animation. Apparently the AnimationID is reused by the God Spells as well, so the chat message is the only option.

Thanks to @josharoo for reporting this issue and @Kamielvf for suggesting this fix.