### PR TITLE
 runelite-client: Don't fail on invalid config values

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/Actor.java
+++ b/runelite-api/src/main/java/net/runelite/api/Actor.java
@@ -85,8 +85,8 @@ public interface Actor extends Renderable
 	/**
 	 * Gets the server-side location of the actor.
 	 * <p>
-	 * This value is typically ahead of where the client renders and may
-	 * be affected by things such as animations.
+	 * This value is typically ahead of where the client renders and is not
+	 * affected by things such as animations.
 	 *
 	 * @return the server location
 	 */

--- a/runelite-client/src/main/java/net/runelite/client/config/ConfigInvocationHandler.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/ConfigInvocationHandler.java
@@ -78,16 +78,20 @@ class ConfigInvocationHandler implements InvocationHandler
 
 			// Convert value to return type
 			Class<?> returnType = method.getReturnType();
-			Object objectValue = ConfigManager.stringToObject(value, returnType);
-
-			// objectValue automatically gets unboxed
-//			if (!objectValue.getClass().equals(returnType))
-//			{
-//				log.warn("Unable to convert return type for configuration item {}.{}: {}", group.keyName(), item.keyName(), returnType);
-//				return null;
-//			}
-
-			return objectValue;
+			
+			try
+			{
+				return ConfigManager.stringToObject(value, returnType);
+			}
+			catch (Exception e)
+			{
+				log.warn("Unable to unmarshal {}.{} ", group.keyName(), item.keyName(), e);
+				if (method.isDefault())
+				{
+					return callDefaultMethod(proxy, method, args);
+				}
+				return null;
+			}
 		}
 		else
 		{

--- a/runelite-client/src/main/java/net/runelite/client/config/ConfigManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/ConfigManager.java
@@ -254,7 +254,14 @@ public class ConfigManager
 		String value = getConfiguration(groupName, key);
 		if (!Strings.isNullOrEmpty(value))
 		{
-			return (T) stringToObject(value, clazz);
+			try
+			{
+				return (T) stringToObject(value, clazz);
+			}
+			catch (Exception e)
+			{
+				log.warn("Unable to unmarshal {}.{} ", groupName, key, e);
+			}
 		}
 		return null;
 	}


### PR DESCRIPTION
As it is now, any plugin with an invalid config value fails to load. This makes it load with the default value instead.