### PR TITLE
runelite-client: Allow developer-tools to run from the launcher

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/RuneLite.java
+++ b/runelite-client/src/main/java/net/runelite/client/RuneLite.java
@@ -153,7 +153,7 @@ public class RuneLite
 			System.exit(0);
 		}
 
-		if (RuneLite.getOptions().has("developer-mode"))
+		if (RuneLite.getOptions().has("developer-mode") && RuneLiteProperties.getLauncherVersion() == null)
 		{
 			boolean assertions = false;
 			assert assertions = true;

--- a/runelite-client/src/main/java/net/runelite/client/RuneLiteProperties.java
+++ b/runelite-client/src/main/java/net/runelite/client/RuneLiteProperties.java
@@ -27,6 +27,7 @@ package net.runelite.client;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Properties;
+import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import lombok.extern.slf4j.Slf4j;
@@ -96,7 +97,8 @@ public class RuneLiteProperties
 		return properties.getProperty(PATREON_LINK);
 	}
 
-	public String getLauncherVersion()
+	@Nullable
+	public static String getLauncherVersion()
 	{
 		return System.getProperty(LAUNCHER_VERSION_PROPERTY);
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/info/InfoPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/info/InfoPanel.java
@@ -135,7 +135,7 @@ public class InfoPanel extends PluginPanel
 		revision.setText(htmlLabel("Oldschool revision: ", engineVer));
 
 		JLabel launcher = new JLabel(htmlLabel("Launcher version: ", MoreObjects
-			.firstNonNull(runeLiteProperties.getLauncherVersion(), "Unknown")));
+			.firstNonNull(RuneLiteProperties.getLauncherVersion(), "Unknown")));
 		launcher.setFont(smallFont);
 
 		loggedLabel.setForeground(ColorScheme.LIGHT_GRAY_COLOR);


### PR DESCRIPTION
Packr doesn't let us add jvm arguments from the command line, so this disables the assertion check if the launcher version is present