### PR TITLE
ScreenshotPlugin: Stop overwrite

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
@@ -266,7 +266,7 @@ public class ScreenshotPlugin extends Plugin
 
 		if (config.screenshotKills() && KILL_MESSAGES.stream().anyMatch(chatMessage::contains))
 		{
-			String fileName = "Kill " + " " + LocalDate.now();
+			String fileName = "Kill " + TIME_FORMAT.format(new Date());
 			takeScreenshot(fileName);
 		}
 	}


### PR DESCRIPTION
Stops screenshots taken on kills from overwriting screenshots taken same day, and remove double spacing