### PR TITLE
Remove auto-expanding from PanelComponent

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/opponentinfo/OpponentInfoOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/opponentinfo/OpponentInfoOverlay.java
@@ -26,6 +26,7 @@ package net.runelite.client.plugins.opponentinfo;
 
 import java.awt.Color;
 import java.awt.Dimension;
+import java.awt.FontMetrics;
 import java.awt.Graphics2D;
 import java.awt.Point;
 import java.awt.Rectangle;
@@ -42,6 +43,7 @@ import net.runelite.client.game.HiscoreManager;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.OverlayPriority;
+import net.runelite.client.ui.overlay.components.ComponentConstants;
 import net.runelite.client.ui.overlay.components.PanelComponent;
 import net.runelite.client.ui.overlay.components.ProgressBarComponent;
 import net.runelite.client.ui.overlay.components.TitleComponent;
@@ -160,9 +162,13 @@ class OpponentInfoOverlay extends Overlay
 			return null; //don't draw anything.
 		}
 
+		final FontMetrics fontMetrics = graphics.getFontMetrics();
+
 		panelComponent.getChildren().clear();
 
 		// Opponent name
+		int textWidth = Math.max(ComponentConstants.STANDARD_WIDTH, fontMetrics.stringWidth(opponentName));
+		panelComponent.setPreferredSize(new Dimension(textWidth, 0));
 		panelComponent.getChildren().add(TitleComponent.builder()
 			.text(opponentName)
 			.build());
@@ -191,6 +197,8 @@ class OpponentInfoOverlay extends Overlay
 		// Opponents opponent
 		if (opponentsOpponentName != null)
 		{
+			textWidth = Math.max(textWidth, fontMetrics.stringWidth(opponentsOpponentName));
+			panelComponent.setPreferredSize(new Dimension(textWidth, 0));
 			panelComponent.getChildren().add(TitleComponent.builder()
 				.text(opponentsOpponentName)
 				.build());

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/components/PanelComponent.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/components/PanelComponent.java
@@ -100,22 +100,6 @@ public class PanelComponent implements LayoutableRenderableEntity
 			preferredSize.width - border.x - border.width,
 			preferredSize.height - border.y - border.height);
 
-		// Adjust preferred size of children based on orientation and children
-		// sizes exceeding the parent size
-		switch (orientation)
-		{
-			case VERTICAL:
-				childPreferredSize.setSize(
-					Math.max(childDimensions.width, childPreferredSize.width),
-					childPreferredSize.height);
-				break;
-			case HORIZONTAL:
-				childPreferredSize.setSize(
-					childPreferredSize.width,
-					Math.max(childDimensions.height, childPreferredSize.height));
-				break;
-		}
-
 		// Render all children
 		for (final LayoutableRenderableEntity child : children)
 		{

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/components/TitleComponent.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/components/TitleComponent.java
@@ -53,6 +53,6 @@ public class TitleComponent implements LayoutableRenderableEntity
 		titleComponent.setColor(color);
 		titleComponent.setPosition(new Point((preferredSize.width - metrics.stringWidth(text)) / 2, 0));
 		final Dimension dimension = titleComponent.render(graphics);
-		return new Dimension(Math.max(preferredSize.width, dimension.width), Math.max(preferredSize.height, dimension.height));
+		return new Dimension(Math.min(preferredSize.width, dimension.width), dimension.height);
 	}
 }


### PR DESCRIPTION
- Remove the auto-expanding of PanelComponent based on children size
because then the size cannot be ever reduced
- Make TitleComponent return preferredSize if it is smaller than string
width
- Make opponentInfo assign the preferred size to panel based on input
strings

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>