### PR TITLE
Add currently hovered tile to TileIndicators

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/Client.java
+++ b/runelite-api/src/main/java/net/runelite/api/Client.java
@@ -369,6 +369,23 @@ public interface Client extends GameEngine
 	int getMouseCurrentButton();
 
 	/**
+	 * Schedules checking of current region tile for next frame, so ${@link Client#getSelectedSceneTile()} ()} will
+	 * return actual value.
+	 *
+	 * @param checkClick when true next frame selected region tile will be updated
+	 */
+	void setCheckClick(boolean checkClick);
+
+	/**
+	 * Sets current mouse hover position. This value is automatically updated only when right-clicking in game.
+	 * Setting this value together with ${@link Client#setCheckClick(boolean)} will update ${@link Client#getSelectedSceneTile()} ()}
+	 * for next frame.
+	 *
+	 * @param position current mouse hover position
+	 */
+	void setMouseCanvasHoverPosition(Point position);
+
+	/**
 	 * Gets the currently selected tile (ie. last right clicked tile).
 	 *
 	 * @return the selected tile

--- a/runelite-client/src/main/java/net/runelite/client/plugins/tileindicators/TileIndicatorsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/tileindicators/TileIndicatorsConfig.java
@@ -41,4 +41,24 @@ public interface TileIndicatorsConfig extends Config
 	{
 		return Color.GRAY;
 	}
+
+	@ConfigItem(
+		keyName = "highlightDestinationTile",
+		name = "Highlight destination tile",
+		description = "Highlights tile player is walking to"
+	)
+	default boolean highlightDestinationTile()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		keyName = "highlightHoveredTile",
+		name = "Highlight hovered tile",
+		description = "Highlights tile player is hovering with mouse"
+	)
+	default boolean highlightHoveredTile()
+	{
+		return false;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/tileindicators/TileIndicatorsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/tileindicators/TileIndicatorsOverlay.java
@@ -24,6 +24,7 @@
  */
 package net.runelite.client.plugins.tileindicators;
 
+import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Graphics2D;
 import java.awt.Polygon;
@@ -39,6 +40,7 @@ import net.runelite.client.ui.overlay.OverlayUtil;
 
 public class TileIndicatorsOverlay extends Overlay
 {
+	private static final Color EMPTY = new Color(0, 0, 0, 0);
 	private final Client client;
 	private final TileIndicatorsConfig config;
 
@@ -55,20 +57,44 @@ public class TileIndicatorsOverlay extends Overlay
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
-		LocalPoint dest = client.getLocalDestinationLocation();
-		if (dest == null)
+		if (config.highlightHoveredTile())
 		{
-			return null;
+			// Update selected scene tile
+			if (!client.isMenuOpen())
+			{
+				client.setCheckClick(true);
+				client.setMouseCanvasHoverPosition(client.getMouseCanvasPosition());
+			}
+
+			// If we have tile "selected" render it
+			if (client.getSelectedSceneTile() != null)
+			{
+				renderTile(graphics, client.getSelectedSceneTile().getLocalLocation(), EMPTY);
+			}
 		}
 
-		Polygon poly = Perspective.getCanvasTilePoly(client, dest);
-		if (poly == null)
+		if (config.highlightDestinationTile())
 		{
-			return null;
+			renderTile(graphics, client.getLocalDestinationLocation(), config.highlightDestinationColor());
 		}
-		
-		OverlayUtil.renderPolygon(graphics, poly, config.highlightDestinationColor());
 
 		return null;
+	}
+
+	private void renderTile(final Graphics2D graphics, final LocalPoint dest, final Color color)
+	{
+		if (dest == null)
+		{
+			return;
+		}
+
+		final Polygon poly = Perspective.getCanvasTilePoly(client, dest);
+
+		if (poly == null)
+		{
+			return;
+		}
+
+		OverlayUtil.renderPolygon(graphics, poly, color);
 	}
 }

--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSClientMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSClientMixin.java
@@ -239,6 +239,14 @@ public abstract class RSClientMixin implements RSClient
 
 	@Inject
 	@Override
+	public void setMouseCanvasHoverPosition(final Point position)
+	{
+		setMouseCanvasHoverPositionX(position.getX());
+		setMouseCanvasHoverPositionY(position.getY());
+	}
+
+	@Inject
+	@Override
 	public Tile getSelectedSceneTile()
 	{
 		int tileX = getSelectedSceneTileX();

--- a/runescape-api/src/main/java/net/runelite/rs/api/RSClient.java
+++ b/runescape-api/src/main/java/net/runelite/rs/api/RSClient.java
@@ -129,6 +129,16 @@ public interface RSClient extends RSGameEngine, Client
 	@Import("gameState")
 	int getRSGameState();
 
+	@Import("checkClick")
+	@Override
+	void setCheckClick(boolean checkClick);
+
+	@Import("mouseX2")
+	void setMouseCanvasHoverPositionX(int x);
+
+	@Import("mouseY2")
+	void setMouseCanvasHoverPositionY(int y);
+
 	@Import("mouseCurrentButton")
 	@Override
 	int getMouseCurrentButton();


### PR DESCRIPTION
Add tile that is currently being hovered to tile indicators.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>

Preview:
![peek 2018-06-05 17-11](https://user-images.githubusercontent.com/5115805/40985761-14eca454-68e5-11e8-89bf-10410c837d63.gif)
