### PR TITLE
Add Chat Highlighting and Chat Notifications

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatnotifications/ChatNotificationsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatnotifications/ChatNotificationsConfig.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2018, Hydrox6 <ikada@protonmail.ch>
+ * Copyright (c) 2018, Adam <Adam@sigterm.info>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.chatnotifications;
+
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+
+@ConfigGroup(
+	keyName = "chatnotification",
+	name = "Chat Notifications",
+	description = "Highlights and notifies you of chat messages"
+)
+public interface ChatNotificationsConfig extends Config
+{
+	@ConfigItem(
+		position = 0,
+		keyName = "highlightOwnName",
+		name = "Highlight own name",
+		description = "Highlights any instance of your username in chat"
+	)
+	default boolean highlightOwnName()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		position = 1,
+		keyName = "highlightWordsString",
+		name = "Highlight words",
+		description = "Highlights the following words in chat"
+	)
+	default String highlightWordsString()
+	{
+		return "";
+	}
+
+	@ConfigItem(
+		position = 2,
+		keyName = "notifyOnTrade",
+		name = "Notify on trade",
+		description = "Notifies you whenever you are traded"
+	)
+	default boolean notifyOnTrade() { return false; }
+
+	@ConfigItem(
+		position = 3,
+		keyName = "notifyOnDuel",
+		name = "Notify on duel",
+		description = "Notifies you whenever you are challenged to a duel"
+	)
+	default boolean notifyOnDuel() { return false; }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatnotifications/ChatNotificationsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatnotifications/ChatNotificationsConfig.java
@@ -60,17 +60,45 @@ public interface ChatNotificationsConfig extends Config
 
 	@ConfigItem(
 		position = 2,
+		keyName = "notifyOnOwnName",
+		name = "Notify on own name",
+		description = "Notifies you whenever your name is mentioned"
+	)
+	default boolean notifyOnOwnName()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		position = 3,
+		keyName = "notifyOnHighlight",
+		name = "Notify on hightlight",
+		description = "Notifies you whenever a word is above is highlighted"
+	)
+	default boolean notifyOnHighlight()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		position = 4,
 		keyName = "notifyOnTrade",
 		name = "Notify on trade",
 		description = "Notifies you whenever you are traded"
 	)
-	default boolean notifyOnTrade() { return false; }
+	default boolean notifyOnTrade()
+	{
+		return false;
+	}
 
 	@ConfigItem(
-		position = 3,
+		position = 5,
 		keyName = "notifyOnDuel",
 		name = "Notify on duel",
 		description = "Notifies you whenever you are challenged to a duel"
 	)
-	default boolean notifyOnDuel() { return false; }
+	default boolean notifyOnDuel()
+	{
+		return false;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatnotifications/ChatNotificationsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatnotifications/ChatNotificationsPlugin.java
@@ -113,13 +113,13 @@ public class ChatNotificationsPlugin extends Plugin
 		switch (event.getType())
 		{
 			case TRADE:
-				if (event.getValue().contains("wishes to trade with you."))
+				if (event.getValue().contains("wishes to trade with you.") && config.notifyOnTrade())
 				{
 					notifier.notify(event.getValue());
 				}
 				break;
 			case DUEL:
-				if (event.getValue().contains("wishes to duel with you."))
+				if (event.getValue().contains("wishes to duel with you.") && config.notifyOnDuel())
 				{
 					notifier.notify(event.getValue());
 				}
@@ -133,7 +133,7 @@ public class ChatNotificationsPlugin extends Plugin
 			usernameReplacer = "<col" + ChatColorType.HIGHLIGHT.name() + "><u>" + username + "</u><col" + ChatColorType.NORMAL.name() + ">";
 		}
 
-		if (usernameMatcher != null)
+		if (config.highlightOwnName() && usernameMatcher != null)
 		{
 			Matcher matcher = usernameMatcher.matcher(messageNode.getValue());
 			if (matcher.find())
@@ -145,7 +145,7 @@ public class ChatNotificationsPlugin extends Plugin
 			}
 		}
 
-		if (highlightMatcher != null)
+		if (config.notifyOnHighlight() && highlightMatcher != null)
 		{
 			Matcher matcher = highlightMatcher.matcher(messageNode.getValue());
 			if (matcher.find())

--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatnotifications/ChatNotificationsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatnotifications/ChatNotificationsPlugin.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) 2018, Hydrox6 <ikada@protonmail.ch>
+ * Copyright (c) 2018, Adam <Adam@sigterm.info>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.chatnotifications;
+
+import com.google.common.eventbus.Subscribe;
+import com.google.inject.Inject;
+import com.google.inject.Provides;
+import java.util.Arrays;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import static java.util.regex.Pattern.quote;
+import java.util.stream.Collectors;
+import net.runelite.api.Client;
+import net.runelite.api.MessageNode;
+import net.runelite.api.events.ConfigChanged;
+import net.runelite.api.events.GameStateChanged;
+import net.runelite.api.events.SetMessage;
+import net.runelite.client.Notifier;
+import net.runelite.client.chat.ChatColorType;
+import net.runelite.client.chat.ChatMessageManager;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginDescriptor;
+
+@PluginDescriptor(
+	name = "Chat Notifications"
+)
+public class ChatNotificationsPlugin extends Plugin
+{
+	@Inject
+	private Client client;
+
+	@Inject
+	private ChatNotificationsConfig config;
+
+	@Inject
+	private ChatMessageManager chatMessageManager;
+
+	@Inject
+	private Notifier notifier;
+
+	//Custom Highlights
+	private Pattern usernameMatcher = null;
+	private String usernameReplacer = "";
+	private Pattern highlightMatcher = null;
+
+	@Provides
+	ChatNotificationsConfig provideConfig(ConfigManager configManager)
+	{
+		return configManager.getConfig(ChatNotificationsConfig.class);
+	}
+
+	@Subscribe
+	public void onGameStateChanged(GameStateChanged event)
+	{
+		switch (event.getGameState())
+		{
+			case LOGIN_SCREEN:
+			case HOPPING:
+				usernameMatcher = null;
+				break;
+			case LOGGED_IN:
+				// update username matcher on login
+				if (usernameMatcher == null && client.getLocalPlayer() != null && client.getLocalPlayer().getName() != null)
+				{
+					String username = client.getLocalPlayer().getName();
+					usernameMatcher = Pattern.compile("\\b(" + quote(username) + ")\\b", Pattern.CASE_INSENSITIVE);
+					usernameReplacer = "<col" + ChatColorType.HIGHLIGHT.name() + "><u>" + username + "</u><col" + ChatColorType.NORMAL.name() + ">";
+				}
+		}
+	}
+
+	@Subscribe
+	public void onConfigChanged(ConfigChanged event)
+	{
+		if (event.getGroup().equals("chatnotification"))
+		{
+			highlightMatcher = null;
+
+			if (!config.highlightWordsString().trim().equals(""))
+			{
+				String[] items = config.highlightWordsString().trim().split(", ");
+				String joined = Arrays.stream(items)
+					.map(item -> quote(item))
+					.collect(Collectors.joining("|"));
+				highlightMatcher = Pattern.compile("\\b(" + joined + ")\\b", Pattern.CASE_INSENSITIVE);
+			}
+		}
+	}
+
+	@Subscribe
+	public void onSetMessage(SetMessage event)
+	{
+		MessageNode messageNode = event.getMessageNode();
+		boolean update = false;
+
+		switch (event.getType())
+		{
+			case TRADE:
+				if (event.getValue().contains("wishes to trade with you."))
+				{
+					notifier.notify(event.getValue());
+				}
+				break;
+			case DUEL:
+				if (event.getValue().contains("wishes to duel with you."))
+				{
+					notifier.notify(event.getValue());
+				}
+				break;
+		}
+
+		if (usernameMatcher != null)
+		{
+			Matcher matcher = usernameMatcher.matcher(messageNode.getValue());
+			if (matcher.find())
+			{
+				messageNode.setValue(matcher.replaceAll(usernameReplacer));
+				update = true;
+			}
+		}
+
+		if (highlightMatcher != null)
+		{
+			Matcher matcher = highlightMatcher.matcher(messageNode.getValue());
+			while (matcher.find())
+			{
+				String value = matcher.group();
+				messageNode.setValue(matcher.replaceFirst("<col" + ChatColorType.HIGHLIGHT + ">" + value + "<col" + ChatColorType.NORMAL + ">"));
+				update = true;
+			}
+		}
+
+		if (update)
+		{
+			messageNode.setRuneLiteFormatMessage(messageNode.getValue());
+			chatMessageManager.update(messageNode);
+		}
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatnotifications/ChatNotificationsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatnotifications/ChatNotificationsPlugin.java
@@ -25,6 +25,7 @@
  */
 package net.runelite.client.plugins.chatnotifications;
 
+import com.google.common.base.Strings;
 import com.google.common.eventbus.Subscribe;
 import com.google.inject.Inject;
 import com.google.inject.Provides;
@@ -170,17 +171,21 @@ public class ChatNotificationsPlugin extends Plugin
 
 	private void sendNotification(SetMessage message)
 	{
-		String notificationMessage = message.getValue();
-		if (message.getName() != null && !message.getName().equals(""))
-		{
-			notificationMessage = String.format("%s: %s", message.getName().substring(message.getName().indexOf(">") + 1), notificationMessage);
-		}
+		String name = message.getName();
+		String sender = message.getSender();
+		StringBuilder stringBuilder = new StringBuilder();
 
-		if (message.getSender() != null && !message.getSender().equals(""))
+		if (!Strings.isNullOrEmpty(sender))
 		{
-			notificationMessage = String.format("[%s] %s", message.getSender(), notificationMessage);
+			stringBuilder.append('[').append(sender).append("] ");
 		}
+		if (!Strings.isNullOrEmpty(name))
+		{
+			stringBuilder.append(name).append(' ');
+		}
+		stringBuilder.append(message.getValue());
 
-		notifier.notify(notificationMessage);
+		String notification = stringBuilder.toString();
+		notifier.notify(notification);
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatnotifications/ChatNotificationsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatnotifications/ChatNotificationsPlugin.java
@@ -97,7 +97,7 @@ public class ChatNotificationsPlugin extends Plugin
 			{
 				String[] items = config.highlightWordsString().trim().split(", ");
 				String joined = Arrays.stream(items)
-					.map(item -> quote(item))
+					.map(Pattern::quote)
 					.collect(Collectors.joining("|"));
 				highlightMatcher = Pattern.compile("\\b(" + joined + ")\\b", Pattern.CASE_INSENSITIVE);
 			}
@@ -133,32 +133,37 @@ public class ChatNotificationsPlugin extends Plugin
 			usernameReplacer = "<col" + ChatColorType.HIGHLIGHT.name() + "><u>" + username + "</u><col" + ChatColorType.NORMAL.name() + ">";
 		}
 
-		if (config.highlightOwnName() && usernameMatcher != null)
+		if (usernameMatcher != null)
 		{
 			Matcher matcher = usernameMatcher.matcher(messageNode.getValue());
 			if (matcher.find())
 			{
-				//notifier.notify(event.getValue());
-				sendNotification(event);
 				messageNode.setValue(matcher.replaceAll(usernameReplacer));
 				update = true;
+
+				if (config.highlightOwnName())
+				{
+					sendNotification(event);
+				}
 			}
 		}
 
-		if (config.notifyOnHighlight() && highlightMatcher != null)
+		if (highlightMatcher != null)
 		{
 			Matcher matcher = highlightMatcher.matcher(messageNode.getValue());
-			if (matcher.find())
-			{
-				//notifier.notify(event.getValue());
-				sendNotification(event);
-				matcher.reset();
-			}
+			boolean found = false;
+
 			while (matcher.find())
 			{
 				String value = matcher.group();
 				messageNode.setValue(matcher.replaceFirst("<col" + ChatColorType.HIGHLIGHT + ">" + value + "<col" + ChatColorType.NORMAL + ">"));
 				update = true;
+				found = true;
+			}
+
+			if (found && config.notifyOnHighlight())
+			{
+				sendNotification(event);
 			}
 		}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatnotifications/ChatNotificationsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatnotifications/ChatNotificationsPlugin.java
@@ -82,14 +82,6 @@ public class ChatNotificationsPlugin extends Plugin
 			case HOPPING:
 				usernameMatcher = null;
 				break;
-			case LOGGED_IN:
-				// update username matcher on login
-				if (usernameMatcher == null && client.getLocalPlayer() != null && client.getLocalPlayer().getName() != null)
-				{
-					String username = client.getLocalPlayer().getName();
-					usernameMatcher = Pattern.compile("\\b(" + quote(username) + ")\\b", Pattern.CASE_INSENSITIVE);
-					usernameReplacer = "<col" + ChatColorType.HIGHLIGHT.name() + "><u>" + username + "</u><col" + ChatColorType.NORMAL.name() + ">";
-				}
 		}
 	}
 
@@ -131,6 +123,13 @@ public class ChatNotificationsPlugin extends Plugin
 					notifier.notify(event.getValue());
 				}
 				break;
+		}
+
+		if (usernameMatcher == null && client.getLocalPlayer() != null && client.getLocalPlayer().getName() != null)
+		{
+			String username = client.getLocalPlayer().getName();
+			usernameMatcher = Pattern.compile("\\b(" + quote(username) + ")\\b", Pattern.CASE_INSENSITIVE);
+			usernameReplacer = "<col" + ChatColorType.HIGHLIGHT.name() + "><u>" + username + "</u><col" + ChatColorType.NORMAL.name() + ">";
 		}
 
 		if (usernameMatcher != null)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatnotifications/ChatNotificationsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatnotifications/ChatNotificationsPlugin.java
@@ -138,6 +138,8 @@ public class ChatNotificationsPlugin extends Plugin
 			Matcher matcher = usernameMatcher.matcher(messageNode.getValue());
 			if (matcher.find())
 			{
+				//notifier.notify(event.getValue());
+				sendNotification(event);
 				messageNode.setValue(matcher.replaceAll(usernameReplacer));
 				update = true;
 			}
@@ -146,6 +148,12 @@ public class ChatNotificationsPlugin extends Plugin
 		if (highlightMatcher != null)
 		{
 			Matcher matcher = highlightMatcher.matcher(messageNode.getValue());
+			if (matcher.find())
+			{
+				//notifier.notify(event.getValue());
+				sendNotification(event);
+				matcher.reset();
+			}
 			while (matcher.find())
 			{
 				String value = matcher.group();
@@ -159,5 +167,21 @@ public class ChatNotificationsPlugin extends Plugin
 			messageNode.setRuneLiteFormatMessage(messageNode.getValue());
 			chatMessageManager.update(messageNode);
 		}
+	}
+
+	private void sendNotification(SetMessage message)
+	{
+		String notificationMessage = message.getValue();
+		if (message.getName() != null && !message.getName().equals(""))
+		{
+			notificationMessage = String.format("%s: %s", message.getName().substring(message.getName().indexOf(">") + 1), notificationMessage);
+		}
+
+		if (message.getSender() != null && !message.getSender().equals(""))
+		{
+			notificationMessage = String.format("[%s] %s", message.getSender(), notificationMessage);
+		}
+
+		notifier.notify(notificationMessage);
 	}
 }


### PR DESCRIPTION
Highlight own username example:
![java_2018-05-07_21-02-17](https://user-images.githubusercontent.com/2979691/40986121-524fd260-68dd-11e8-9c81-bd642a99b502.png)

Highlight arbitrary words example (Highlighted words were "Abyssal Whip" and "Doughnut")
![java_2018-05-07_21-42-42](https://user-images.githubusercontent.com/2979691/40986110-4f9faad6-68dd-11e8-932b-7f4a356ec8fa.png)

The highlights work with all types of chat, and the highlight colour is controlled by that chat's highlight option in Chat Color.

Oh yeah, and there are chat notifications now.