### PR TITLE
Widget Inspector Revamp: Searching + Widget Picker

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/devtools/WidgetInspector.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/devtools/WidgetInspector.java
@@ -139,7 +139,6 @@ class WidgetInspector extends JFrame
 				plugin.itemIndex = node.getWidgetItem().getIndex();
 				log.debug("Set item index to {}", plugin.itemIndex);
 			}
-
 		});
 
 		final JScrollPane treeScrollPane = new JScrollPane(widgetTree);
@@ -236,7 +235,6 @@ class WidgetInspector extends JFrame
 				searchNodes.clear();
 				widgetResults.clear();
 			}
-
 			searchIndex = 0;
 			mousePos = client.getMouseCanvasPosition();
 			event.consume();

--- a/runelite-client/src/main/java/net/runelite/client/plugins/devtools/WidgetInspector.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/devtools/WidgetInspector.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2018 Abex
+ * Copyright (c) 2018, Damien <https://github.com/ADHDDamien>
+ * Copyright (c) 2018, Abex
  * Copyright (c) 2017, Kronos <https://github.com/KronosDesign>
  * Copyright (c) 2017, Adam <Adam@sigterm.info>
  * All rights reserved.
@@ -29,28 +30,40 @@ package net.runelite.client.plugins.devtools;
 import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
 import com.google.inject.Inject;
+
 import java.awt.BorderLayout;
+import java.awt.Color;
 import java.awt.Dimension;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.concurrent.ExecutionException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
 import javax.swing.JFrame;
+import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JSplitPane;
 import javax.swing.JTable;
+import javax.swing.JTextField;
 import javax.swing.JTree;
 import javax.swing.SwingWorker;
 import javax.swing.tree.DefaultMutableTreeNode;
 import javax.swing.tree.DefaultTreeModel;
+import javax.swing.tree.TreePath;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.events.ConfigChanged;
+import net.runelite.api.events.MenuOptionClicked;
+import net.runelite.api.GameState;
+import net.runelite.api.Point;
 import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.api.widgets.WidgetItem;
@@ -60,14 +73,23 @@ import net.runelite.client.ui.ClientUI;
 class WidgetInspector extends JFrame
 {
 	private final Client client;
-	private final DevToolsPlugin plugin;
 	private final DevToolsConfig config;
-
-	private final JTree widgetTree;
+	private final DevToolsPlugin plugin;
 	private final WidgetInfoTableModel infoTableModel;
-	private final JCheckBox alwaysOnTop;
 
+	private final JButton nextResultBtn;
+	private final JCheckBox alwaysOnTop;
+	private final JTree widgetTree;
+
+	private List<DefaultMutableTreeNode> searchNodes = new ArrayList<>();
+	private List<Widget> widgetResults = new ArrayList<>();
+	private WidgetSearch widgetSearch = new WidgetSearch();
 	private static final Map<Integer, WidgetInfo> widgetIdMap = new HashMap<>();
+
+	private boolean readyToSelectWidget;
+	private boolean searchIsActive;
+	private int searchIndex;
+	private Point mousePos;
 
 	@Inject
 	WidgetInspector(DevToolsPlugin plugin, Client client, WidgetInfoTableModel infoTableModel, DevToolsConfig config, EventBus eventBus)
@@ -101,6 +123,7 @@ class WidgetInspector extends JFrame
 		widgetTree.getSelectionModel().addTreeSelectionListener(e ->
 		{
 			Object selected = widgetTree.getLastSelectedPathComponent();
+
 			if (selected instanceof WidgetTreeNode)
 			{
 				WidgetTreeNode node = (WidgetTreeNode) selected;
@@ -116,34 +139,82 @@ class WidgetInspector extends JFrame
 				plugin.itemIndex = node.getWidgetItem().getIndex();
 				log.debug("Set item index to {}", plugin.itemIndex);
 			}
+
 		});
 
 		final JScrollPane treeScrollPane = new JScrollPane(widgetTree);
 		treeScrollPane.setPreferredSize(new Dimension(200, 400));
 
-
 		final JTable widgetInfo = new JTable(infoTableModel);
 
-		final JScrollPane infoScrollPane = new JScrollPane(widgetInfo);
-		infoScrollPane.setPreferredSize(new Dimension(400, 400));
-
+		final JScrollPane searchFieldPane = new JScrollPane(widgetInfo);
+		searchFieldPane.setPreferredSize(new Dimension(400, 400));
 
 		final JPanel bottomPanel = new JPanel();
 		add(bottomPanel, BorderLayout.SOUTH);
 
-		final JButton refreshWidgetsBtn = new JButton("Refresh");
-		refreshWidgetsBtn.addActionListener(e -> refreshWidgets());
+		final JButton refreshWidgetsBtn = new JButton("Load Widgets");
+		refreshWidgetsBtn.addActionListener(e ->
+		{
+			if (loggedIn())
+			{
+				refreshWidgets(client.getWidgetRoots());
+			}
+			else
+			{
+				JOptionPane.showMessageDialog(null, "Please log in to the game before trying to load widgets.");
+			}
+		});
 		bottomPanel.add(refreshWidgetsBtn);
+
+		final JButton widgetSelectorBtn = new JButton("Select in-game Widgets");
+		widgetSelectorBtn.addActionListener(e ->
+		{
+			if (loggedIn())
+			{
+				readyToSelectWidget = true;
+			}
+			else
+			{
+				JOptionPane.showMessageDialog(null, "Please log in to the game before trying to select widgets.");
+			}
+		});
+		bottomPanel.add(widgetSelectorBtn);
+
+		final JButton searchHelpBtn = new JButton("Search Help");
+		searchHelpBtn.addActionListener(e -> JOptionPane.showMessageDialog(null, "Search examples: \nId:10747904 where 10747904 is the Widget ID you are searching for\n\nCanvasLocation:0,0 with 0,0 being the X & Y in the Point\n\nText:Bank Of Runescape (Partial text searches work as well)\n\nHidden=true where true is the boolean result you are searching for, etc.\n\nAll fields are searchable.\n\nMultiple searches:\nChain searches with a pipe separating each search term to get more exact results, for example Width:1642|Height:1057 or Text:Bank Of Runescape|Hidden:false\n\nThe enter key submits your search.\n\nSelecting on-screen widgets:\nClick \"Select in-game Widgets\" and then click the widget in game you wish to find in the list."));
+		bottomPanel.add(searchHelpBtn);
+
+		nextResultBtn = new JButton("Next Result");
+		nextResultBtn.addActionListener(e -> nextResult());
+		nextResultBtn.setEnabled(false);
+		bottomPanel.add(nextResultBtn);
 
 		alwaysOnTop = new JCheckBox("Always on top");
 		alwaysOnTop.addItemListener(ev -> config.inspectorAlwaysOnTop(alwaysOnTop.isSelected()));
 		onConfigChanged(null);
 		bottomPanel.add(alwaysOnTop);
 
+		final JTextField searchField = new JTextField("Search");
+		searchField.setBackground(Color.GRAY);
+		searchField.setText("Enter search here...");
+		searchField.addActionListener(e -> startSearch(searchField.getText()));
+		searchField.addMouseListener(new MouseAdapter()
+		{
+			@Override
+			public void mouseReleased(MouseEvent e)
+			{
+				if (searchField.getText().equals("Enter search here..."))
+				{
+					searchField.setText("");
+				}
+			}
+		});
 
-		final JSplitPane split = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT, treeScrollPane, infoScrollPane);
+		JScrollPane scrollPane = new JScrollPane(searchField);
+		add(scrollPane, BorderLayout.NORTH);
+		final JSplitPane split = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT, treeScrollPane, searchFieldPane);
 		add(split, BorderLayout.CENTER);
-
 		pack();
 	}
 
@@ -155,25 +226,93 @@ class WidgetInspector extends JFrame
 		alwaysOnTop.setSelected(onTop);
 	}
 
-	private void refreshWidgets()
+	@Subscribe
+	private void MenuOptionClicked(MenuOptionClicked event)
+	{
+		if (readyToSelectWidget)
+		{
+			if (searchNodes.size() > 0 && widgetResults.size() > 0)
+			{
+				searchNodes.clear();
+				widgetResults.clear();
+			}
+
+			searchIndex = 0;
+			mousePos = client.getMouseCanvasPosition();
+			event.consume();
+			refreshWidgets(client.getWidgetRoots());
+		}
+	}
+
+	private void startSearch(String search)
+	{
+		if (loggedIn())
+		{
+			if (searchNodes.size() > 0 && widgetResults.size() > 0)
+			{
+				searchNodes.clear();
+				widgetResults.clear();
+			}
+
+			searchIndex = 0;
+			searchIsActive = true;
+			widgetSearch.searchRequest(search);
+			refreshWidgets(client.getWidgetRoots());
+		}
+		else
+		{
+			JOptionPane.showMessageDialog(null, "Please log in to the game before trying to search widgets.");
+		}
+	}
+
+	private void nextResult()
+	{
+		searchIndex++;
+
+		if (searchIndex >= searchNodes.size())
+		{
+			searchIndex = 0;
+		}
+
+		updateResults();
+	}
+
+	private void updateResults()
+	{
+		plugin.currentWidget = widgetResults.get(searchIndex);
+		plugin.itemIndex = -1;
+		refreshInfo();
+		widgetTree.expandPath(new TreePath(searchNodes.get(searchIndex).getPath()));
+		widgetTree.setSelectionPath(new TreePath(searchNodes.get(searchIndex).getPath()));
+		nextResultBtn.setText("Next Result: " + String.valueOf(searchIndex + 1) + "/" + searchNodes.size());
+		pack();
+	}
+
+	private Boolean loggedIn()
+	{
+		return client.getGameState().equals(GameState.LOGGED_IN);
+	}
+
+	private void refreshWidgets(Widget[] widgets )
 	{
 		new SwingWorker<DefaultMutableTreeNode, Void>()
 		{
 			@Override
 			protected DefaultMutableTreeNode doInBackground() throws Exception
 			{
-				Widget[] rootWidgets = client.getWidgetRoots();
 				DefaultMutableTreeNode root = new DefaultMutableTreeNode();
 
-				plugin.currentWidget = null;
-				plugin.itemIndex = -1;
-
-				for (Widget widget : rootWidgets)
+				for (Widget widget : widgets)
 				{
 					DefaultMutableTreeNode childNode = addWidget("R", widget);
 					if (childNode != null)
 					{
 						root.add(childNode);
+						if (searchIsActive && widgetSearch.isMatch(widget) || readyToSelectWidget && widgetSearch.matchesMousePosition(widget.getBounds(), mousePos))
+						{
+							searchNodes.add(childNode);
+							widgetResults.add(widget);
+						}
 					}
 				}
 
@@ -189,6 +328,23 @@ class WidgetInspector extends JFrame
 					plugin.itemIndex = -1;
 					refreshInfo();
 					widgetTree.setModel(new DefaultTreeModel(get()));
+
+					if (searchIsActive || readyToSelectWidget)
+					{
+						searchIndex = 0;
+						updateResults();
+						nextResultBtn.setEnabled(true);
+						readyToSelectWidget = false;
+						searchIsActive = false;
+					}
+					else
+					{
+						//reset search iterator button incase you are loading widgets after a search
+						searchIndex = 0;
+						nextResultBtn.setText("Next Result");
+						nextResultBtn.setEnabled(false);
+					}
+
 				}
 				catch (InterruptedException | ExecutionException ex)
 				{
@@ -196,7 +352,7 @@ class WidgetInspector extends JFrame
 				}
 			}
 		}.execute();
-	}
+		}
 
 	private DefaultMutableTreeNode addWidget(String type, Widget widget)
 	{
@@ -206,8 +362,8 @@ class WidgetInspector extends JFrame
 		}
 
 		DefaultMutableTreeNode node = new WidgetTreeNode(type, widget);
-
 		Widget[] childComponents = widget.getDynamicChildren();
+
 		if (childComponents != null)
 		{
 			for (Widget component : childComponents)
@@ -216,6 +372,11 @@ class WidgetInspector extends JFrame
 				if (childNode != null)
 				{
 					node.add(childNode);
+					if (searchIsActive && widgetSearch.isMatch(component) || readyToSelectWidget && widgetSearch.matchesMousePosition(component.getBounds(), mousePos))
+					{
+						searchNodes.add(childNode);
+						widgetResults.add(component);
+					}
 				}
 			}
 		}
@@ -229,6 +390,11 @@ class WidgetInspector extends JFrame
 				if (childNode != null)
 				{
 					node.add(childNode);
+					if (searchIsActive && widgetSearch.isMatch(component) || readyToSelectWidget && widgetSearch.matchesMousePosition(component.getBounds(), mousePos))
+					{
+						searchNodes.add(childNode);
+						widgetResults.add(component);
+					}
 				}
 			}
 		}
@@ -242,6 +408,11 @@ class WidgetInspector extends JFrame
 				if (childNode != null)
 				{
 					node.add(childNode);
+					if (searchIsActive && widgetSearch.isMatch(component) || readyToSelectWidget && widgetSearch.matchesMousePosition(component.getBounds(), mousePos))
+					{
+						searchNodes.add(childNode);
+						widgetResults.add(component);
+					}
 				}
 			}
 		}
@@ -255,7 +426,6 @@ class WidgetInspector extends JFrame
 				{
 					continue;
 				}
-
 				node.add(new WidgetItemNode(item));
 			}
 		}
@@ -280,7 +450,6 @@ class WidgetInspector extends JFrame
 				widgetIdMap.put(w.getPackedId(), w);
 			}
 		}
-
 		return widgetIdMap.get(packedId);
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/devtools/WidgetSearch.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/devtools/WidgetSearch.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright (c) 2018, Damien <https://github.com/ADHDDamien>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.devtools;
+
+import java.awt.Rectangle;
+import java.util.HashMap;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.Point;
+import net.runelite.api.widgets.Widget;
+
+@Slf4j
+public class WidgetSearch
+{
+	private HashMap<String, Object> searchTerms = new HashMap<>();
+
+	public void searchRequest(String search)
+	{
+		searchTerms.clear();
+		search = search.toLowerCase();
+		String segments[] = search.split("[:|]");
+
+		for (int i = 0; i < segments.length; i++)
+		{
+			switch (segments[i])
+			{
+				case "id":
+					searchTerms.put("Id", Integer.parseInt(segments[i + 1]));
+					break;
+				case "type":
+					searchTerms.put("Type", Integer.parseInt(segments[i + 1]));
+					break;
+				case "contenttype":
+					searchTerms.put("ContentType", Integer.parseInt(segments[i + 1]));
+					break;
+				case "parentid":
+					searchTerms.put("ParentId", Integer.parseInt(segments[i + 1]));
+					break;
+				case "selfhidden":
+					if (segments[i + 1].equals("true"))
+					{
+						searchTerms.put("SelfHidden", true);
+					}
+					else
+					{
+						searchTerms.put("SelfHidden", false);
+					}
+					break;
+				case "hidden":
+					if (segments[i + 1].equals("true"))
+					{
+						searchTerms.put("Hidden", true);
+					}
+					else
+					{
+						searchTerms.put("Hidden", false);
+					}
+					break;
+				case "text":
+					searchTerms.put("Text", segments[i + 1]);
+					break;
+				case "textcolor":
+					searchTerms.put("TextColor", segments[i + 1]);
+					break;
+				case "name":
+					searchTerms.put("Name", segments[i + 1]);
+					break;
+				case "itemid":
+					searchTerms.put("ItemId", Integer.parseInt(segments[i + 1]));
+					break;
+				case "itemquantity":
+					searchTerms.put("ItemQuantity", Integer.parseInt(segments[i + 1]));
+					break;
+				case "modelid":
+					searchTerms.put("ModelId", Integer.parseInt(segments[i + 1]));
+					break;
+				case "spriteid":
+					searchTerms.put("SpriteId", Integer.parseInt(segments[i + 1]));
+					break;
+				case "width":
+					searchTerms.put("Width", Integer.parseInt(segments[i + 1]));
+					break;
+				case "height":
+					searchTerms.put("Height", Integer.parseInt(segments[i + 1]));
+					break;
+				case "relativex":
+					searchTerms.put("RelativeX", Integer.parseInt(segments[i + 1]));
+					break;
+				case "relativey":
+					searchTerms.put("RelativeY", Integer.parseInt(segments[i + 1]));
+					break;
+				case "canvaslocation":
+					String canvasSegments[] = segments[i + 1].split("[,]");
+					searchTerms.put("CanvasLocation", new Point(Integer.parseInt(canvasSegments[0]), Integer.parseInt(canvasSegments[1])));
+					break;
+				case "bounds":
+					String boundsSegments[] = segments[i + 1].split("[,]");
+					searchTerms.put("Bounds", new Rectangle(Integer.parseInt(boundsSegments[0]), Integer.parseInt(boundsSegments[1]), Integer.parseInt(boundsSegments[2]), Integer.parseInt(boundsSegments[3])));
+					break;
+				case "scrollx":
+					searchTerms.put("ScrollX", Integer.parseInt(segments[i + 1]));
+					break;
+				case "scrolly":
+					searchTerms.put("ScrollY", Integer.parseInt(segments[i + 1]));
+					break;
+				case "originalx":
+					searchTerms.put("OriginalX", Integer.parseInt(segments[i + 1]));
+					break;
+				case "originaly":
+					searchTerms.put("OriginalY", Integer.parseInt(segments[i + 1]));
+					break;
+				case "paddingx":
+					searchTerms.put("PaddingX", Integer.parseInt(segments[i + 1]));
+					break;
+				case "paddingy":
+					searchTerms.put("PaddingY", Integer.parseInt(segments[i + 1]));
+					break;
+			}
+		}
+	}
+
+	public boolean isMatch(Widget widget)
+	{
+		int counter = 0;
+
+		for (Object key : searchTerms.keySet())
+		{
+			switch ((String) key)
+			{
+				case "Id":
+					counter += ((widget.getId() == (Integer) searchTerms.get("Id")) ? 1 : -100);
+					break;
+				case "Type":
+					counter += ((widget.getType() == (Integer) searchTerms.get("Type")) ? 1 : -100);
+					break;
+				case "ContentType":
+					counter += ((widget.getContentType() == (Integer) searchTerms.get("ContentType")) ? 1 : -100);
+					break;
+				case "ParentId":
+					counter += ((widget.getParentId() == (Integer) searchTerms.get("ParentId")) ? 1 : -100);
+					break;
+				case "SelfHidden":
+					counter += ((widget.isSelfHidden() == (Boolean) searchTerms.get("SelfHidden")) ? 1 : -100);
+					break;
+				case "Hidden":
+					counter += ((widget.isHidden() == (Boolean) searchTerms.get("Hidden")) ? 1 : -100);
+					break;
+				case "Text":
+					counter += ((widget.getText().toLowerCase().contains((String) searchTerms.get("Text"))) ? 1 : -100);
+					break;
+				case "TextColor":
+					counter += ((Integer.toString(widget.getTextColor(), 16).equals((searchTerms.get("TextColor"))) ? 1 : -100));
+					break;
+				case "Name":
+					counter += ((widget.getName().toLowerCase().contains((String) searchTerms.get("Name"))) ? 1 : -100);
+					break;
+				case "ItemId":
+					counter += ((widget.getItemId() == (Integer) searchTerms.get("ItemId")) ? 1 : -100);
+					break;
+				case "ItemQuantity":
+					counter += ((widget.getItemQuantity() == (Integer) searchTerms.get("ItemQuantity")) ? 1 : -100);
+					break;
+				case "ModelId":
+					counter += ((widget.getModelId() == (Integer) searchTerms.get("ModelId")) ? 1 : -100);
+					break;
+				case "SpriteId":
+					counter += ((widget.getSpriteId() == (Integer) searchTerms.get("SpriteId")) ? 1 : -100);
+					break;
+				case "Width":
+					counter += ((widget.getWidth() == (Integer) searchTerms.get("Width")) ? 1 : -100);
+					break;
+				case "Height":
+					counter += ((widget.getHeight() == (Integer) searchTerms.get("Height")) ? 1 : -100);
+					break;
+				case "RelativeX":
+					counter += ((widget.getRelativeX() == (Integer) searchTerms.get("RelativeX")) ? 1 : -100);
+					break;
+				case "RelativeY":
+					counter += ((widget.getRelativeY() == (Integer) searchTerms.get("RelativeY")) ? 1 : -100);
+					break;
+				case "CanvasLocation":
+					counter += ((widget.getCanvasLocation().equals((searchTerms.get("CanvasLocation"))) ? 1 : -100));
+					break;
+				case "Bounds":
+					counter += ((widget.getBounds().equals(searchTerms.get("Bounds"))) ? 1 : -100);
+					break;
+				case "ScrollX":
+					counter += ((widget.getScrollX() == (Integer) searchTerms.get("ScrollX")) ? 1 : -100);
+					break;
+				case "ScrollY":
+					counter += ((widget.getScrollY() == (Integer) searchTerms.get("ScrollY")) ? 1 : -100);
+					break;
+				case "OriginalX":
+					counter += ((widget.getOriginalX() == (Integer) searchTerms.get("OriginalX")) ? 1 : -100);
+					break;
+				case "OriginalY":
+					counter += ((widget.getOriginalY() == (Integer) searchTerms.get("OriginalY")) ? 1 : -100);
+					break;
+				case "PaddingX":
+					counter += ((widget.getPaddingX() == (Integer) searchTerms.get("PaddingX")) ? 1 : -100);
+					break;
+				case "PaddingY":
+					counter += ((widget.getPaddingY() == (Integer) searchTerms.get("PaddingY")) ? 1 : -100);
+					break;
+			}
+		}
+
+		//If any case is entered and doesn't match it sets the value to -100 this way all search terms have to match a widgetIDs fields or it's impossible to return true
+		if (counter < 1)
+		{
+			return false;
+		}
+		else
+		{
+			return true;
+		}
+
+	}
+
+	public boolean matchesMousePosition(Rectangle bounds, Point mousePos)
+	{
+		return ((mousePos.getX() >= bounds.x) && (mousePos.getY() >= bounds.y) && (mousePos.getX() < bounds.x + bounds.width) && (mousePos.getY() < bounds.y + bounds.height));
+	}
+}


### PR DESCRIPTION
## Widget Inspector Revamp

The Widget Inspector has been revamped to include searching throughout all Widget fields including multiple at once as well as on-screen widget selection to give developers ease of use when trying to find a specific widget among the thousands that clutter the main list.

It utilizes the main Widget Inspector Refresh function so searching is just as fast as loading the normal set of widgets normally.

Default state: ![](https://i.imgur.com/WFU2laW.png)

### New Features: 

**Searching**:
You can now search every widget field available via the new search bar: 
![](https://i.imgur.com/KM5JjAv.png)

**Multiple Field Searches**: to get more precise results combine and customize as many fields as you want (Includes partial text search as well):
![](https://i.imgur.com/0Rz0WWm.png)

**Widget Selector**:
If you don't know the field you are looking for you can now just select in-game widgets and get back the results of all widgets in the area you defined and check out the results to locate obscure widgets:
![](https://i.imgur.com/RHohAwi.gif)

--


### Other changes:
- Fixed some NPEs being sent when the inspector was attempting to populate Widget fields when the user wasn't logged into the game
- Nifty Search Help box that gives instructions and examples of how to use all the new filtering features.

Important mention:
@Alexsuperfly was an incredible help in getting the WidgetSearch.java into a MUCH cleaner state, it would be unrecognizable to it's current version if not for his advice on ways I could fix various issues in it which would eventually knock around 200 lines of codes off it in the end.