### PR TITLE
Replace perThreadQueue EventBus with immediate one

### DIFF
--- a/runelite-client/src/main/java/com/google/common/eventbus/ImmediateEventBus.java
+++ b/runelite-client/src/main/java/com/google/common/eventbus/ImmediateEventBus.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2018 Tomas Slusny <slusnucky@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.google.common.eventbus;
+
+import com.google.common.util.concurrent.MoreExecutors;
+
+/**
+ * An {@link EventBus} dispatches events to subscribers immediately as they're posted without using an
+ * intermediate queue to change the dispatch order.
+ */
+public class ImmediateEventBus extends EventBus
+{
+	/**
+	 * Creates a new ImmediateEventBus with the given {@code identifier}.
+	 */
+	public ImmediateEventBus()
+	{
+		super("default", MoreExecutors.directExecutor(), Dispatcher.immediate(), LoggingHandler.INSTANCE);
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/RuneLiteModule.java
+++ b/runelite-client/src/main/java/net/runelite/client/RuneLiteModule.java
@@ -25,7 +25,7 @@
 package net.runelite.client;
 
 import com.google.common.eventbus.EventBus;
-import com.google.common.eventbus.SubscriberExceptionContext;
+import com.google.common.eventbus.ImmediateEventBus;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import com.google.inject.name.Names;
@@ -57,6 +57,7 @@ public class RuneLiteModule extends AbstractModule
 	protected void configure()
 	{
 		bind(ScheduledExecutorService.class).toInstance(Executors.newSingleThreadScheduledExecutor());
+		bind(EventBus.class).toInstance(new ImmediateEventBus());
 		bind(QueryRunner.class);
 		bind(MenuManager.class);
 		bind(ChatMessageManager.class);
@@ -95,17 +96,5 @@ public class RuneLiteModule extends AbstractModule
 	ChatColorConfig provideChatColorConfig(ConfigManager configManager)
 	{
 		return configManager.getConfig(ChatColorConfig.class);
-	}
-
-	@Provides
-	@Singleton
-	EventBus provideEventBus()
-	{
-		return new EventBus(RuneLiteModule::eventExceptionHandler);
-	}
-
-	private static void eventExceptionHandler(Throwable exception, SubscriberExceptionContext context)
-	{
-		log.warn("uncaught exception in event subscriber", exception);
 	}
 }

--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSItemCompositionMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSItemCompositionMixin.java
@@ -87,6 +87,6 @@ public abstract class RSItemCompositionMixin implements RSItemComposition
 	{
 		final PostItemComposition event = new PostItemComposition();
 		event.setItemComposition(this);
-		client.getCallbacks().post(event);
+		client.getCallbacks().postDeferred(event);
 	}
 }


### PR DESCRIPTION
- Add ImmediateEventBus implementation to replace current perThreadQueue
implementation to reduce EventBus call overhead to minimum.
- Because PostItemComposition is hooked to inside of getItemComposition,
prevent event being posted from inside as it is dangerous to call
getItemComposition when inside of it, and instead defer the event.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>