### PR TITLE
Fix demonic gorilla overlay position on fixed screen

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/demonicgorilla/DemonicGorillaOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/demonicgorilla/DemonicGorillaOverlay.java
@@ -97,6 +97,10 @@ public class DemonicGorillaOverlay extends Overlay
 					gorilla.getNpc().getLogicalHeight() + 16);
 				if (point != null)
 				{
+					point = new Point(
+						client.getViewportXOffset() + point.getX(),
+						client.getViewportYOffset() + point.getY());
+
 					List<DemonicGorilla.AttackStyle> attackStyles = gorilla.getNextPosibleAttackStyles();
 					List<BufferedImage> icons = new ArrayList<>();
 					int totalWidth = (attackStyles.size() - 1) * OVERLAY_ICON_MARGIN;


### PR DESCRIPTION
The overlay was off by a few pixels when using fixed screen size

![image](https://user-images.githubusercontent.com/26200523/41080663-d4a8a534-6a27-11e8-8b6a-081b7cdf5ed2.png)
