### PR TITLE
Add a toggle to only show player indicators in the wilderness.

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/Varbits.java
+++ b/runelite-api/src/main/java/net/runelite/api/Varbits.java
@@ -305,6 +305,11 @@ public enum Varbits
 	MULTICOMBAT_AREA(4605),
 
 	/**
+	 * In the Wilderness
+	 */
+	IN_THE_WILDERNESS(5963),
+
+	/**
 	 * Kingdom Management
 	 */
 	KINGDOM_FAVOR(72),

--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsConfig.java
@@ -200,4 +200,15 @@ public interface PlayerIndicatorsConfig extends Config
 	{
 		return true;
 	}
+
+	@ConfigItem(
+		position = 15,
+		keyName = "wildernessOnly",
+		name = "Show only in wilderness",
+		description = "Toggle whether or not to only show player indicators in the wilderness"
+	)
+	default boolean showInWildernessOnly()
+	{
+		return false;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsPlugin.java
@@ -47,6 +47,7 @@ import static net.runelite.api.MenuAction.SPELL_CAST_ON_PLAYER;
 import static net.runelite.api.MenuAction.TRADE;
 import net.runelite.api.MenuEntry;
 import net.runelite.api.Player;
+import net.runelite.api.Varbits;
 import net.runelite.api.events.MenuEntryAdded;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.game.ClanManager;
@@ -89,6 +90,11 @@ public class PlayerIndicatorsPlugin extends Plugin
 	@Subscribe
 	public void onMenuEntryAdd(MenuEntryAdded menuEntryAdded)
 	{
+		if (config.showInWildernessOnly() && client.getVar(Varbits.IN_THE_WILDERNESS) != 1)
+		{
+			return;
+		}
+
 		int type = menuEntryAdded.getType();
 
 		if (type >= 2000)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsService.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsService.java
@@ -30,6 +30,7 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 import net.runelite.api.Client;
 import net.runelite.api.Player;
+import net.runelite.api.Varbits;
 
 @Singleton
 public class PlayerIndicatorsService
@@ -46,6 +47,11 @@ public class PlayerIndicatorsService
 
 	public void forEachPlayer(final BiConsumer<Player, Color> consumer)
 	{
+		if (config.showInWildernessOnly() && client.getVar(Varbits.IN_THE_WILDERNESS) != 1)
+		{
+			return;
+		}
+
 		if (!config.highlightOwnPlayer() && !config.drawClanMemberNames()
 			&& !config.highlightFriends() && !config.highlightNonClanMembers())
 		{


### PR DESCRIPTION
Implements the requested feature in Issue #3684. 

_Demo of this added toggle_
https://puu.sh/ABd9I.gif 