### PR TITLE
 Fix NMZ points overlay appearing in the KBD instance lair

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/nightmarezone/NightmareZonePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/nightmarezone/NightmareZonePlugin.java
@@ -26,7 +26,6 @@ package net.runelite.client.plugins.nightmarezone;
 
 import com.google.common.eventbus.Subscribe;
 import com.google.inject.Provides;
-import java.util.Arrays;
 import javax.inject.Inject;
 import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
@@ -34,6 +33,8 @@ import net.runelite.api.Varbits;
 import net.runelite.api.events.ChatMessage;
 import net.runelite.api.events.ConfigChanged;
 import net.runelite.api.events.GameTick;
+import net.runelite.api.widgets.Widget;
+import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.Notifier;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.plugins.Plugin;
@@ -46,8 +47,6 @@ import net.runelite.client.util.Text;
 )
 public class NightmareZonePlugin extends Plugin
 {
-	private static final int[] NMZ_MAP_REGION = {9033};
-
 	@Inject
 	private Notifier notifier;
 
@@ -172,6 +171,7 @@ public class NightmareZonePlugin extends Plugin
 
 	public boolean isInNightmareZone()
 	{
-		return Arrays.equals(client.getMapRegions(), NMZ_MAP_REGION);
+		Widget nmz = client.getWidget(WidgetInfo.NIGHTMARE_ZONE);
+		return nmz != null && !nmz.isSelfHidden();
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/nightmarezone/NightmareZonePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/nightmarezone/NightmareZonePlugin.java
@@ -171,25 +171,6 @@ public class NightmareZonePlugin extends Plugin
 
 	boolean isInNightmareZone()
 	{
-		/*
-		This check works because each frame RuneScape unhides the widget every frame. As a result, we can use the state
-		of this widget to check whether we are in the Nightmare Zone. We can't check if the widget exists as it doesn't
-		get removed as soon as we leave, just hidden. If the widget is hidden at this stage in the code execution, this
-		means RuneScape has hidden it, so we have left NMZ.	The widget is not shown because, after this check is done,
-		the NightmareZoneOverlay hides it to show the custom one.
-
-		In short:
-
-		RuneScape unhides it
-		Is it hidden?
-		-yes? We're not in NMZ
-		-no? We're in NMZ, so hide it and show our overlay
-
-
-		The old check asked if the only region loaded was the KBD lair (9033), as the normal KBD lair has a few valid
-		(but mostly empty) regions around it that would be loaded at the same time. However, since there an instanced
-		version of the KBD lair, it also thought that was NMZ since that also only loads 9033.
-		 */
 		Widget nmz = client.getWidget(WidgetInfo.NIGHTMARE_ZONE);
 		return nmz != null && !nmz.isSelfHidden();
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/nightmarezone/NightmareZonePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/nightmarezone/NightmareZonePlugin.java
@@ -169,7 +169,7 @@ public class NightmareZonePlugin extends Plugin
 		}
 	}
 
-	public boolean isInNightmareZone()
+	boolean isInNightmareZone()
 	{
 		Widget nmz = client.getWidget(WidgetInfo.NIGHTMARE_ZONE);
 		return nmz != null && !nmz.isSelfHidden();

--- a/runelite-client/src/main/java/net/runelite/client/plugins/nightmarezone/NightmareZonePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/nightmarezone/NightmareZonePlugin.java
@@ -171,6 +171,25 @@ public class NightmareZonePlugin extends Plugin
 
 	boolean isInNightmareZone()
 	{
+		/*
+		This check works because each frame RuneScape unhides the widget every frame. As a result, we can use the state
+		of this widget to check whether we are in the Nightmare Zone. We can't check if the widget exists as it doesn't
+		get removed as soon as we leave, just hidden. If the widget is hidden at this stage in the code execution, this
+		means RuneScape has hidden it, so we have left NMZ.	The widget is not shown because, after this check is done,
+		the NightmareZoneOverlay hides it to show the custom one.
+
+		In short:
+
+		RuneScape unhides it
+		Is it hidden?
+		-yes? We're not in NMZ
+		-no? We're in NMZ, so hide it and show our overlay
+
+
+		The old check asked if the only region loaded was the KBD lair (9033), as the normal KBD lair has a few valid
+		(but mostly empty) regions around it that would be loaded at the same time. However, since there an instanced
+		version of the KBD lair, it also thought that was NMZ since that also only loads 9033.
+		 */
 		Widget nmz = client.getWidget(WidgetInfo.NIGHTMARE_ZONE);
 		return nmz != null && !nmz.isSelfHidden();
 	}


### PR DESCRIPTION
This was due to the old method checking to see if the only map tile loaded is 9033, which is both the KBD lair and NMZ (early OSRS reuses a lot). 
This doesn't cause issues with the normal KBD lair, as there are (mostly) empty but valid regions around the KBD lair ([See this map](https://i.imgur.com/JuUZE2S.png)).

Fixes #3692 