### PR TITLE
Set oculus speed to 36 (x3) in DevTools

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/Client.java
+++ b/runelite-api/src/main/java/net/runelite/api/Client.java
@@ -1395,4 +1395,11 @@ public interface Client extends GameEngine
 	 * @param state boolean enabled value
 	 */
 	void setOculusOrbState(int state);
+
+	/**
+	 * Sets the normal moving speed when using oculus orb (default value is 12)
+	 *
+	 * @param speed speed
+	 */
+	void setOculusOrbNormalSpeed(int speed);
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/devtools/DevToolsPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/devtools/DevToolsPanel.java
@@ -228,7 +228,9 @@ public class DevToolsPanel extends PluginPanel
 		oculusOrbBtn.addActionListener(e ->
 		{
 			highlightButton(oculusOrbBtn);
-			client.setOculusOrbState(oculusOrbBtn.getBackground().equals(Color.GREEN) ? 1 : 0);
+			boolean enabled = oculusOrbBtn.getBackground().equals(Color.GREEN);
+			client.setOculusOrbState(enabled ? 1 : 0);
+			client.setOculusOrbNormalSpeed(enabled ? 36 : 12);
 		});
 		container.add(oculusOrbBtn);
 

--- a/runescape-api/src/main/java/net/runelite/rs/api/RSClient.java
+++ b/runescape-api/src/main/java/net/runelite/rs/api/RSClient.java
@@ -640,4 +640,8 @@ public interface RSClient extends RSGameEngine, Client
 	@Import("oculusOrbState")
 	@Override
 	void setOculusOrbState(int state);
+
+	@Import("oculusOrbNormalSpeed")
+	@Override
+	void setOculusOrbNormalSpeed(int state);
 }


### PR DESCRIPTION
Default oculus orb speed is hardly useable when trying to explore
something so this will set it to more reasonable default.

Depends on !9

Preview:
![peek 2018-06-09 03-40](https://user-images.githubusercontent.com/5115805/41186551-83819eaa-6b98-11e8-976d-7ddcf479323e.gif)
