### PR TITLE
add runecrafting profit tracking plugin

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/AnimationID.java
+++ b/runelite-api/src/main/java/net/runelite/api/AnimationID.java
@@ -132,6 +132,7 @@ public final class AnimationID
 	public static final int DEMONIC_GORILLA_PRAYER_SWITCH = 7228;
 	public static final int DEMONIC_GORILLA_DEFEND = 7224;
 	public static final int IMP_DEATH = 172;
+	public static final int RUNECRAFTING_ANIMATION = 791;
 
 	// NPC animations
 	public static final int TZTOK_JAD_MAGIC_ATTACK = 2656;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/runecraftingprofit/RunecraftingProfitConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/runecraftingprofit/RunecraftingProfitConfig.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2018, Adam <Adam@sigterm.info>
+ * Copyright (c) 2018, Dalton <delps1001@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.runecraftingprofit;
+
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+
+@ConfigGroup(
+		keyName = "runecrafting",
+		name = "Runecrafting Profit",
+		description = "Configuration for the Runecrafting Profit Plugin"
+)
+public interface RunecraftingProfitConfig extends Config
+{
+
+	@ConfigItem(
+			keyName = "profit per hour",
+			name = "Display profit per hour",
+			description = "Show profit per hour"
+	)
+	default boolean displayProfitPerHour()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+			keyName = "overlay timeout",
+			name = "Overlay timeout",
+			description = "How long to wait before hiding the overlay after last runecrafting at an altar"
+	)
+	default int overlayTimeout()
+	{
+		return 3;
+	}
+
+	@ConfigItem(
+			keyName = "individual rune type",
+			name = "Display individual rune",
+			description = "Toggle displaying individual rune count and profit."
+	)
+	default boolean displayIndividualRuneTypes()
+	{
+		return true;
+	}
+
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/runecraftingprofit/RunecraftingProfitOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/runecraftingprofit/RunecraftingProfitOverlay.java
@@ -70,7 +70,6 @@ public class RunecraftingProfitOverlay extends Overlay
 
 	public static String format(long value)
 	{
-		//Long.MIN_VALUE == -Long.MIN_VALUE so we need an adjustment here
 		if (value == Long.MIN_VALUE) return format(Long.MIN_VALUE + 1);
 		if (value < 0) return "-" + format(-value);
 		if (value < 1000) return Long.toString(value); //deal with easy case

--- a/runelite-client/src/main/java/net/runelite/client/plugins/runecraftingprofit/RunecraftingProfitOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/runecraftingprofit/RunecraftingProfitOverlay.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2018, Adam <Adam@sigterm.info>
+ * Copyright (c) 2018, Dalton <delps1001@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.runecraftingprofit;
+
+import net.runelite.api.Client;
+import net.runelite.client.ui.overlay.Overlay;
+import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.components.LineComponent;
+import net.runelite.client.ui.overlay.components.PanelComponent;
+import javax.inject.Inject;
+import java.awt.Dimension;
+import java.awt.Graphics2D;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.TreeMap;
+
+
+public class RunecraftingProfitOverlay extends Overlay
+{
+	private static final NavigableMap<Long, String> suffixes = new TreeMap<>();
+
+	static
+	{
+		suffixes.put(1_000L, "k");
+		suffixes.put(1_000_000L, "M");
+		suffixes.put(1_000_000_000L, "G");
+		suffixes.put(1_000_000_000_000L, "T");
+		suffixes.put(1_000_000_000_000_000L, "P");
+		suffixes.put(1_000_000_000_000_000_000L, "E");
+	}
+
+	private final Client client;
+	private final RunecraftingProfitPlugin plugin;
+	private final RunecraftingProfitConfig config;
+	private final PanelComponent panelComponent = new PanelComponent();
+	RunecraftingProfitSession session;
+
+	@Inject
+	RunecraftingProfitOverlay(Client client, RunecraftingProfitPlugin plugin, RunecraftingProfitConfig config)
+	{
+		setPosition(OverlayPosition.TOP_LEFT);
+		this.client = client;
+		this.plugin = plugin;
+		this.config = config;
+		this.session = plugin.getSession();
+	}
+
+	public static String format(long value)
+	{
+		//Long.MIN_VALUE == -Long.MIN_VALUE so we need an adjustment here
+		if (value == Long.MIN_VALUE) return format(Long.MIN_VALUE + 1);
+		if (value < 0) return "-" + format(-value);
+		if (value < 1000) return Long.toString(value); //deal with easy case
+
+		Map.Entry<Long, String> e = suffixes.floorEntry(value);
+		Long divideBy = e.getKey();
+		String suffix = e.getValue();
+
+		long truncated = value / (divideBy / 10); //the number part of the output times 10
+		boolean hasDecimal = truncated < 100 && (truncated / 10d) != (truncated / 10);
+		return hasDecimal ? (truncated / 10d) + suffix : (truncated / 10) + suffix;
+	}
+
+	@Override
+	public Dimension render(Graphics2D graphics)
+	{
+
+		//only display the overlay after the first RC animation occurs...
+		if (!plugin.isFirstRunecraft())
+		{
+			return null;
+		}
+
+		//only display the UI if the player has done the RC animation in the last TIMEOUT_INTERVAL minutes
+		if (!plugin.displayOverlay)
+		{
+			return null;
+		}
+
+		panelComponent.getChildren().clear();
+
+
+		if (plugin.displayProfit)
+		{
+			if (config.displayIndividualRuneTypes())
+			{
+				for (Runes rune : Runes.values())
+				{
+					int profitForRuneType = session.getProfitPerRuneType().get(rune);
+					if (profitForRuneType > 0)
+					{
+						panelComponent.getChildren().add(LineComponent.builder()
+								.left(rune.getName() + ":")
+								.right(format(profitForRuneType) + " gp")
+								.build());
+					}
+				}
+			}
+
+			panelComponent.getChildren().add(LineComponent.builder()
+					.left("Total: ")
+					.right(format(session.getTotalProfit()) + " gp")
+					.build());
+		}
+		else
+		{
+			if (config.displayIndividualRuneTypes())
+			{
+				for (Runes rune : Runes.values())
+				{
+					int totalForRuneType = session.getNumberOfTotalRunesCrafted().get(rune.getItemId());
+					if (totalForRuneType > 0)
+					{
+						panelComponent.getChildren().add(LineComponent.builder()
+								.left(rune.getName() + ":")
+								.right(Integer.toString(totalForRuneType))
+								.build());
+					}
+
+				}
+			}
+
+			panelComponent.getChildren().add(LineComponent.builder()
+					.left("Total: ")
+					.right(Integer.toString(session.getTotalRunesCrafted()))
+					.build());
+		}
+
+		//display profit per hour if enabled
+		if (config.displayProfitPerHour())
+		{
+			panelComponent.getChildren().add(LineComponent.builder()
+					.left("Profit/hr: ")
+					.right(format((long) session.getTotalProfitPerHour()))
+					.build());
+		}
+
+
+		return panelComponent.render(graphics);
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/runecraftingprofit/RunecraftingProfitPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/runecraftingprofit/RunecraftingProfitPlugin.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright (c) 2018, Adam <Adam@sigterm.info>
+ * Copyright (c) 2018, Dalton <delps1001@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.runecraftingprofit;
+
+import com.google.common.eventbus.Subscribe;
+import com.google.inject.Provides;
+import net.runelite.api.AnimationID;
+import net.runelite.api.Client;
+import net.runelite.api.InventoryID;
+import net.runelite.api.Item;
+import net.runelite.api.ItemContainer;
+import net.runelite.api.Player;
+import net.runelite.api.events.AnimationChanged;
+import net.runelite.api.events.GameTick;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.task.Schedule;
+import net.runelite.client.ui.overlay.Overlay;
+import javax.inject.Inject;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+
+import static net.runelite.client.callback.Hooks.log;
+
+@PluginDescriptor(
+		name = "Runecrafting Profit",
+		enabledByDefault = false
+)
+public class RunecraftingProfitPlugin extends Plugin
+{
+
+	boolean displayProfit = false;
+	boolean displayOverlay = false;
+	private boolean lastTickAnimationWasRunecrafting = false;
+	private boolean firstRunecraft = false;
+	private Instant lastRunecraftingAnimation;
+	private Instant startTime;
+
+	@Inject
+	private Client client;
+
+	@Inject
+	private RunecraftingProfitSession session;
+
+	@Inject
+	private RunecraftingProfitOverlay overlay;
+
+	@Inject
+	private RunecraftingProfitConfig config;
+
+	@Provides
+	RunecraftingProfitConfig getConfig(ConfigManager configManager)
+	{
+		return configManager.getConfig(RunecraftingProfitConfig.class);
+	}
+
+	@Override
+	protected void startUp()
+	{
+		lastRunecraftingAnimation = Instant.now();
+	}
+
+	@Override
+	protected void shutDown()
+	{
+		session.clearSession();
+		this.firstRunecraft = false;
+		this.displayOverlay = false;
+	}
+
+	@Override
+	public Collection<Overlay> getOverlays()
+	{
+		return Arrays.asList(overlay);
+	}
+
+	@Subscribe
+	public void onGameTick(GameTick event)
+	{
+		if (ChronoUnit.MINUTES.between(this.lastRunecraftingAnimation, Instant.now()) >= config.overlayTimeout())
+		{
+			displayOverlay = false;
+			return;
+		}
+		else
+		{
+			displayOverlay = true;
+		}
+		Player localPlayer = client.getLocalPlayer();
+		lastTickAnimationWasRunecrafting = localPlayer.getAnimation() == AnimationID.RUNECRAFTING_ANIMATION;
+	}
+
+
+	@Subscribe
+	private void onAnimationChanged(AnimationChanged anim)
+	{
+		if (anim.getActor() == client.getLocalPlayer() && anim.getActor().getAnimation() == AnimationID.RUNECRAFTING_ANIMATION)
+		{
+			this.lastRunecraftingAnimation = Instant.now();
+			if (!this.firstRunecraft)
+			{
+				startTime = Instant.now();
+				this.firstRunecraft = true;
+			}
+			try
+			{
+				ArrayList<Item> items = getInventoryContents();
+				session.updatePreviousRunesInInventory(items);
+			} catch (NullPointerException e)
+			{
+				log.debug("inventory is empty...");
+			}
+
+		}
+		else if (anim.getActor() == client.getLocalPlayer() && (anim.getActor().getAnimation() != AnimationID.RUNECRAFTING_ANIMATION) && lastTickAnimationWasRunecrafting)
+		{
+			session.updateTotalCraftedRunes(getInventoryContents());
+		}
+	}
+
+	private ArrayList<Item> getInventoryContents() throws NullPointerException
+	{
+		ItemContainer inventory = client.getItemContainer(InventoryID.INVENTORY);
+		Item[] itemsArray = inventory.getItems();
+		if (itemsArray != null)
+		{
+			return new ArrayList<>(Arrays.asList(itemsArray));
+		}
+		else
+		{
+			return null;
+		}
+	}
+
+	@Schedule(
+			period = 5,
+			unit = ChronoUnit.SECONDS
+	)
+	public void alternateProfitAndRunesCrafted()
+	{
+		this.displayProfit = !this.displayProfit;
+	}
+
+	public Instant getStartTime()
+	{
+		return startTime;
+	}
+
+	public Client getClient()
+	{
+		return client;
+	}
+
+	public void setClient(Client client)
+	{
+		this.client = client;
+	}
+
+	boolean isFirstRunecraft()
+	{
+		return firstRunecraft;
+	}
+
+	public Instant getLastRunecraftingAnimation()
+	{
+		return lastRunecraftingAnimation;
+	}
+
+	public RunecraftingProfitSession getSession()
+	{
+		return session;
+	}
+
+	public void setSession(RunecraftingProfitSession session)
+	{
+		this.session = session;
+	}
+
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/runecraftingprofit/RunecraftingProfitSession.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/runecraftingprofit/RunecraftingProfitSession.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright (c) 2018, Adam <Adam@sigterm.info>
+ * Copyright (c) 2018, Dalton <delps1001@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.runecraftingprofit;
+
+
+import net.runelite.api.Item;
+import net.runelite.client.game.ItemManager;
+import net.runelite.http.api.item.ItemPrice;
+import javax.inject.Inject;
+import java.io.IOException;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+
+import static net.runelite.client.callback.Hooks.log;
+
+
+public class RunecraftingProfitSession
+{
+
+
+	private final RunecraftingProfitPlugin plugin;
+	private HashMap<Integer, Integer> previousRunesInInventory = new HashMap<>();
+	private HashMap<Integer, Integer> numberOfTotalRunesCrafted = new HashMap<>();
+	private HashMap<Runes, Integer> profitPerRuneType = new HashMap<>();
+	private HashSet<Integer> runesSet = new HashSet<>();
+	private HashMap<Integer, Integer> runePrices = new HashMap<>();
+	private int totalProfit = 0;
+	private int totalRunesCrafted = 0;
+	private double totalProfitPerHour = 0.0;
+
+
+	@Inject
+	public RunecraftingProfitSession(RunecraftingProfitPlugin plugin, ItemManager itemManager)
+	{
+		for (Runes rune : Runes.values())
+		{
+			previousRunesInInventory.put(rune.getItemId(), 0);
+			runesSet.add(rune.getItemId());
+			numberOfTotalRunesCrafted.put(rune.getItemId(), 0);
+			profitPerRuneType.put(rune, 0);
+			try
+			{
+				ItemPrice price = itemManager.getItemPrice(rune.getItemId());
+				runePrices.put(rune.getItemId(), price.getPrice());
+			} catch (IOException e)
+			{
+				log.debug(Arrays.asList(e.getStackTrace()).toString());
+			}
+		}
+		this.plugin = plugin;
+	}
+
+	void updatePreviousRunesInInventory(ArrayList<Item> items)
+	{
+		clearPreviousRunesInInventory();
+		for (Item item : items)
+		{
+			this.previousRunesInInventory.replace(item.getId(), item.getQuantity());
+		}
+	}
+
+	void updateTotalCraftedRunes(ArrayList<Item> items)
+	{
+		for (Item item : items)
+		{
+			if (runesSet.contains(item.getId()))
+			{
+				int updatedRuneCount = this.numberOfTotalRunesCrafted.get(item.getId()) + (item.getQuantity() - this.previousRunesInInventory.get(item.getId()));
+				this.numberOfTotalRunesCrafted.replace(item.getId(), updatedRuneCount);
+			}
+		}
+		updateProfitPerRuneType();
+	}
+
+	private void clearPreviousRunesInInventory()
+	{
+		for (Map.Entry<Integer, Integer> entry : this.previousRunesInInventory.entrySet())
+		{
+			this.previousRunesInInventory.replace(entry.getKey(), 0);
+		}
+	}
+
+	private void updateProfitPerRuneType()
+	{
+		totalProfit = 0;
+		totalRunesCrafted = 0;
+		for (Map.Entry<Runes, Integer> entry : profitPerRuneType.entrySet())
+		{
+			int runeId = entry.getKey().getItemId();
+			int numberOfRunesCrafted = this.numberOfTotalRunesCrafted.get(runeId);
+			int profitForRuneType = this.runePrices.get(runeId) * numberOfRunesCrafted;
+			profitPerRuneType.replace(entry.getKey(), profitForRuneType);
+			totalProfit += profitForRuneType;
+			totalRunesCrafted += numberOfRunesCrafted;
+		}
+		updateTotalProfitPerHour();
+	}
+
+	int getTotalProfit()
+	{
+		return totalProfit;
+	}
+
+	int getTotalRunesCrafted()
+	{
+		return totalRunesCrafted;
+	}
+
+	HashMap<Runes, Integer> getProfitPerRuneType()
+	{
+		return profitPerRuneType;
+	}
+
+	HashMap<Integer, Integer> getNumberOfTotalRunesCrafted()
+	{
+		return numberOfTotalRunesCrafted;
+	}
+
+	public double getTotalProfitPerHour()
+	{
+		return totalProfitPerHour;
+	}
+
+	void clearSession()
+	{
+		for (Runes rune : Runes.values())
+		{
+			previousRunesInInventory.replace(rune.getItemId(), 0);
+			numberOfTotalRunesCrafted.replace(rune.getItemId(), 0);
+			profitPerRuneType.replace(rune, 0);
+		}
+		this.totalProfit = 0;
+		this.totalRunesCrafted = 0;
+		this.totalProfitPerHour = 0;
+	}
+
+	private void updateTotalProfitPerHour()
+	{
+		double timeElapsedHours = (double) ChronoUnit.SECONDS.between(plugin.getStartTime(), Instant.now()) / 3600.0;
+		this.totalProfitPerHour = this.totalProfit / timeElapsedHours;
+	}
+
+	private void logProfitPerRuneType()
+	{
+		log.debug("Profit Per Runetype: ------------------------");
+		StringBuilder totalRunesCrafted = new StringBuilder();
+		for (Runes rune : Runes.values())
+		{
+			totalRunesCrafted.append(rune.getName()).append(",").append(this.profitPerRuneType.get(rune)).append("\n");
+		}
+		totalRunesCrafted.append("Total," + Integer.toString(totalProfit));
+		log.debug(totalRunesCrafted.toString());
+	}
+
+	private void logTotalNumberOfRunesCrafted()
+	{
+		log.debug("Total Number of runes crafted: ------------------------");
+		StringBuilder totalRunesCrafted = new StringBuilder();
+		for (Runes rune : Runes.values())
+		{
+			totalRunesCrafted.append(rune.getName()).append(",").append(this.numberOfTotalRunesCrafted.get(rune.getItemId())).append(";");
+		}
+		log.debug(totalRunesCrafted.toString());
+	}
+
+	void logPreviousRunesInInventory()
+	{
+		StringBuilder previousRunesInInventory = new StringBuilder();
+		for (Runes rune : Runes.values())
+		{
+			previousRunesInInventory.append(rune.getName()).append(",").append(this.previousRunesInInventory.get(rune.getItemId())).append(";");
+		}
+		log.debug(previousRunesInInventory.toString());
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/runecraftingprofit/RunecraftingProfitSession.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/runecraftingprofit/RunecraftingProfitSession.java
@@ -167,37 +167,4 @@ public class RunecraftingProfitSession
 		double timeElapsedHours = (double) ChronoUnit.SECONDS.between(plugin.getStartTime(), Instant.now()) / 3600.0;
 		this.totalProfitPerHour = this.totalProfit / timeElapsedHours;
 	}
-
-	private void logProfitPerRuneType()
-	{
-		log.debug("Profit Per Runetype: ------------------------");
-		StringBuilder totalRunesCrafted = new StringBuilder();
-		for (Runes rune : Runes.values())
-		{
-			totalRunesCrafted.append(rune.getName()).append(",").append(this.profitPerRuneType.get(rune)).append("\n");
-		}
-		totalRunesCrafted.append("Total," + Integer.toString(totalProfit));
-		log.debug(totalRunesCrafted.toString());
-	}
-
-	private void logTotalNumberOfRunesCrafted()
-	{
-		log.debug("Total Number of runes crafted: ------------------------");
-		StringBuilder totalRunesCrafted = new StringBuilder();
-		for (Runes rune : Runes.values())
-		{
-			totalRunesCrafted.append(rune.getName()).append(",").append(this.numberOfTotalRunesCrafted.get(rune.getItemId())).append(";");
-		}
-		log.debug(totalRunesCrafted.toString());
-	}
-
-	void logPreviousRunesInInventory()
-	{
-		StringBuilder previousRunesInInventory = new StringBuilder();
-		for (Runes rune : Runes.values())
-		{
-			previousRunesInInventory.append(rune.getName()).append(",").append(this.previousRunesInInventory.get(rune.getItemId())).append(";");
-		}
-		log.debug(previousRunesInInventory.toString());
-	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/runecraftingprofit/Runes.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/runecraftingprofit/Runes.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2018, Adam <Adam@sigterm.info>
+ * Copyright (c) 2018, Dalton <delps1001@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.runecraftingprofit;
+
+import lombok.Getter;
+import static net.runelite.api.ItemID.AIR_RUNE;
+import static net.runelite.api.ItemID.ASTRAL_RUNE;
+import static net.runelite.api.ItemID.BLOOD_RUNE;
+import static net.runelite.api.ItemID.BODY_RUNE;
+import static net.runelite.api.ItemID.CHAOS_RUNE;
+import static net.runelite.api.ItemID.COSMIC_RUNE;
+import static net.runelite.api.ItemID.DEATH_RUNE;
+import static net.runelite.api.ItemID.EARTH_RUNE;
+import static net.runelite.api.ItemID.FIRE_RUNE;
+import static net.runelite.api.ItemID.LAW_RUNE;
+import static net.runelite.api.ItemID.MIND_RUNE;
+import static net.runelite.api.ItemID.NATURE_RUNE;
+import static net.runelite.api.ItemID.SOUL_RUNE;
+import static net.runelite.api.ItemID.WATER_RUNE;
+
+public enum Runes
+{
+	AIR(1, AIR_RUNE),
+	WATER(2, WATER_RUNE),
+	EARTH(3, EARTH_RUNE),
+	FIRE(4, FIRE_RUNE),
+	MIND(5, MIND_RUNE),
+	CHAOS(6, CHAOS_RUNE),
+	DEATH(7, DEATH_RUNE),
+	BLOOD(8, BLOOD_RUNE),
+	COSMIC(9, COSMIC_RUNE),
+	NATURE(10, NATURE_RUNE),
+	LAW(11, LAW_RUNE),
+	BODY(12, BODY_RUNE),
+	SOUL(13, SOUL_RUNE),
+	ASTRAL(14, ASTRAL_RUNE);
+
+	@Getter
+	private final int id;
+	@Getter
+	private final int itemId;
+
+	Runes(int id, int itemId)
+	{
+		this.id = id;
+		this.itemId = itemId;
+	}
+
+	public String getName()
+	{
+		String name = this.name();
+		name = name.substring(0, 1) + name.substring(1, name.length()).toLowerCase();
+		return name;
+	}
+
+}


### PR DESCRIPTION
This plugin can be used to track the amount of profit gained from runecrafting at any altar. It also shows profit per rune type and also profit per hour.