### PR TITLE
Add tooltip to show levels required for next combat level

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/VarClientInt.java
+++ b/runelite-api/src/main/java/net/runelite/api/VarClientInt.java
@@ -34,7 +34,15 @@ import lombok.Getter;
 @Getter
 public enum VarClientInt
 {
-	TOOLTIP_TIMEOUT(1);
+	TOOLTIP_TIMEOUT(1),
+
+	/**
+	 * Current opened tab
+	 * 	Attack Styles = 0, Stats = 1, Quest log = 2, Inventory = 3, Worn Equipment = 4,
+	 * 	Prayer = 5, Magic = 6, Clan Chat = 7, Friends List = 8, Ignore List = 9, Logout = 10,
+	 *	Options = 11, Emotes = 12, Music Player = 13
+	 */
+	CURRENT_TAB(171);
 
 	private final int index;
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/combatlevel/CombatLevelConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/combatlevel/CombatLevelConfig.java
@@ -1,0 +1,24 @@
+package net.runelite.client.plugins.combatlevel;
+
+
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+
+@ConfigGroup(
+	keyName = "combatLevel",
+	name = "Combat Level",
+	description = "Configure the combat level plugin"
+)
+public interface CombatLevelConfig extends Config
+{
+	@ConfigItem(
+		keyName = "showLevelsUntil",
+		name = "Calculate next level",
+		description = "Mouse over the combat level when activated to show how many levels until the next combat level"
+	)
+	default boolean showLevelsUntil()
+	{
+		return false;
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/combatlevel/CombatLevelOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/combatlevel/CombatLevelOverlay.java
@@ -1,0 +1,61 @@
+package net.runelite.client.plugins.combatlevel;
+
+import joptsimple.util.KeyValuePair;
+import net.runelite.api.Client;
+import net.runelite.api.Skill;
+import net.runelite.api.VarClientInt;
+import net.runelite.api.Varbits;
+import net.runelite.api.widgets.Widget;
+import net.runelite.api.widgets.WidgetInfo;
+import net.runelite.client.ui.overlay.Overlay;
+import net.runelite.client.ui.overlay.tooltip.Tooltip;
+import net.runelite.client.ui.overlay.tooltip.TooltipManager;
+
+import javax.inject.Inject;
+import java.awt.Dimension;
+import java.awt.Graphics2D;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.util.Map;
+
+public class CombatLevelOverlay extends Overlay {
+	@Inject
+	private Client client;
+
+	@Inject
+	private CombatLevelConfig config;
+
+	@Inject
+	private CombatLevelPlugin plugin;
+
+	@Inject
+	private TooltipManager tooltipManager;
+
+	@Override
+	public Dimension render(Graphics2D graphics)
+	{
+		if (!config.showLevelsUntil() || plugin.getCombatLevel() == 126
+			|| client.getVar(VarClientInt.CURRENT_TAB) != 0)
+		{
+			return null;
+		}
+
+		Point mousePoint = new Point(client.getMouseCanvasPosition().getX(), client.getMouseCanvasPosition().getY());
+		Widget combatLevelWidget = client.getWidget(WidgetInfo.COMBAT_LEVEL);
+		Rectangle combatCanvas = combatLevelWidget.getBounds();
+		if (combatCanvas.contains(mousePoint))
+		{
+			Map<Skill, Integer> levels = plugin.getLevelsUntil();
+			StringBuilder sb = new StringBuilder();
+			sb.append("<col=ff981f>");
+			sb.append("Levels until next level:</col></br>");
+			sb.append(levels.get(Skill.ATTACK)).append(" Attack/Strength").append("</br>");
+			sb.append(levels.get(Skill.DEFENCE)).append(" Defence/Hitpoints").append("</br>");
+			sb.append(levels.get(Skill.MAGIC)).append(" Magic").append("</br>");
+			sb.append(levels.get(Skill.RANGED)).append(" Ranged").append("</br>");
+			sb.append(levels.get(Skill.PRAYER)).append(" Prayer");
+			tooltipManager.add(new Tooltip(sb.toString()));
+		}
+		return null;
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/combatlevel/CombatLevelPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/combatlevel/CombatLevelPlugin.java
@@ -26,7 +26,11 @@ package net.runelite.client.plugins.combatlevel;
 
 import com.google.common.eventbus.Subscribe;
 import java.text.DecimalFormat;
+import java.util.HashMap;
+import java.util.Map;
 import javax.inject.Inject;
+
+import com.google.inject.Provides;
 import net.runelite.api.Client;
 import net.runelite.api.Experience;
 import net.runelite.api.GameState;
@@ -34,8 +38,13 @@ import net.runelite.api.Skill;
 import net.runelite.api.events.GameTick;
 import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetInfo;
+import net.runelite.client.config.ConfigManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.ui.overlay.Overlay;
+
+import static java.lang.Math.ceil;
+import static java.lang.Math.floor;
 
 @PluginDescriptor(
 	name = "Combat Level"
@@ -46,6 +55,18 @@ public class CombatLevelPlugin extends Plugin
 
 	@Inject
 	Client client;
+
+	@Inject
+	CombatLevelConfig config;
+
+	@Inject
+	CombatLevelOverlay overlay;
+
+	@Provides
+	CombatLevelConfig provideConfig(ConfigManager configManager)
+	{
+		return configManager.getConfig(CombatLevelConfig.class);
+	}
 
 	@Override
 	protected void shutDown() throws Exception
@@ -61,6 +82,12 @@ public class CombatLevelPlugin extends Plugin
 				combatLevelWidget.setText(widgetText.substring(0, widgetText.indexOf(".")));
 			}
 		}
+	}
+
+	@Override
+	public Overlay getOverlay()
+	{
+		return overlay;
 	}
 
 	@Subscribe
@@ -88,5 +115,96 @@ public class CombatLevelPlugin extends Plugin
 		);
 
 		combatLevelWidget.setText("Combat Lvl: " + decimalFormat.format(combatLevelPrecise));
+	}
+
+	public Map<Skill, Integer> getLevelsUntil()
+	{
+		// put together information
+		int attackLevel = client.getRealSkillLevel(Skill.ATTACK);
+		int strengthLevel = client.getRealSkillLevel(Skill.STRENGTH);
+		int defenceLevel = client.getRealSkillLevel(Skill.DEFENCE);
+		int hitpointsLevel = client.getRealSkillLevel(Skill.HITPOINTS);
+		int magicLevel = client.getRealSkillLevel(Skill.MAGIC);
+		int rangedLevel = client.getRealSkillLevel(Skill.RANGED);
+		int prayerLevel = client.getRealSkillLevel(Skill.PRAYER);
+		final Map<Skill, Integer> skillsLeft = new HashMap<>();
+		skillsLeft.put(Skill.ATTACK, 0);
+		skillsLeft.put(Skill.DEFENCE, 0);
+		skillsLeft.put(Skill.MAGIC, 0);
+		skillsLeft.put(Skill.RANGED, 0);
+		skillsLeft.put(Skill.PRAYER, 0);
+		double base = 0.25 * (defenceLevel + hitpointsLevel + floor(prayerLevel / 2));
+		double melee = 0.325 * (attackLevel + strengthLevel);
+		double range = 0.325 * (floor(rangedLevel / 2) + rangedLevel);
+		double mage = 0.325 * (floor(magicLevel / 2) + magicLevel);
+		double max = Math.max(melee, Math.max(range, mage));
+
+		// begin calculating levels
+		int next = (int) floor(base + max) + 1;
+		int meleeNeed = calcLevels((base + melee), next, 0.325);
+		int hpdefNeed = calcLevels((base + max), next, 0.25025);
+		int prayNeed = calcLevels((base + max), next, 0.125);
+		int rangeNeed = calcLevelsRM(rangedLevel, next, base);
+		int magicNeed = calcLevelsRM(magicLevel, next, base);
+
+
+		if ((attackLevel + strengthLevel + meleeNeed) <= 198)
+		{
+			skillsLeft.put(Skill.ATTACK, meleeNeed);
+		}
+		if ((hitpointsLevel + defenceLevel + hpdefNeed) <= 198)
+		{
+			skillsLeft.put(Skill.DEFENCE, hpdefNeed);
+		}
+		if ((rangedLevel + rangeNeed) <= 99)
+		{
+			skillsLeft.put(Skill.RANGED, rangeNeed);
+		}
+		if ((magicLevel + magicNeed) <= 99)
+		{
+			skillsLeft.put(Skill.MAGIC, magicNeed);
+		}
+		if ((prayerLevel + prayNeed) <= 99)
+		{
+			skillsLeft.put(Skill.PRAYER, prayNeed);
+		}
+		return skillsLeft;
+	}
+
+	private int calcLevels(double start, int end, double multiple)
+	{
+		int need = 0;
+		while(start < end)
+		{
+			start += multiple;
+			need++;
+		}
+		return need;
+	}
+
+	private int calcLevelsRM(double start, int end, double dhp)
+	{
+		int need = 0;
+		double base = start;
+		start = floor(start * 1.5) * 0.325;
+		while((start + dhp) < end)
+		{
+			need++;
+			start = floor((base + need) * 1.5) * 0.325;
+		}
+		return need;
+	}
+
+	public int getCombatLevel()
+	{
+		return Experience.getCombatLevel(
+			client.getRealSkillLevel(Skill.ATTACK),
+			client.getRealSkillLevel(Skill.STRENGTH),
+			client.getRealSkillLevel(Skill.DEFENCE),
+			client.getRealSkillLevel(Skill.HITPOINTS),
+			client.getRealSkillLevel(Skill.MAGIC),
+			client.getRealSkillLevel(Skill.RANGED),
+			client.getRealSkillLevel(Skill.PRAYER)
+		);
 	}
 }


### PR DESCRIPTION
# What I've added
* New VarClientInt for the interface's current tab called `CURRENT_TAB`
* Created a tooltip that calculates the levels required to increase your combat level
* New configuration setting, calculating next combat level is defaulted to false