### PR TITLE
Disable camera zoom by default (because all options inside are anyway disabled by default)

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/zoom/ZoomConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/zoom/ZoomConfig.java
@@ -42,7 +42,7 @@ public interface ZoomConfig extends Config
 	)
 	default boolean outerLimit()
 	{
-		return false;
+		return true;
 	}
 
 	@ConfigItem(

--- a/runelite-client/src/main/java/net/runelite/client/plugins/zoom/ZoomPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/zoom/ZoomPlugin.java
@@ -37,7 +37,8 @@ import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 
 @PluginDescriptor(
-	name = "Camera Zoom"
+	name = "Camera Zoom",
+	enabledByDefault = false
 )
 @Slf4j
 public class ZoomPlugin extends Plugin


### PR DESCRIPTION
Instead of having the plugin enabled and everything inside disabled just
disable it and by default enable 1 option.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>