### PR TITLE
Use Object.equals for Overlays

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/Overlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/Overlay.java
@@ -27,10 +27,12 @@ package net.runelite.client.ui.overlay;
 import java.awt.Dimension;
 import java.awt.Point;
 import java.awt.Rectangle;
-import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
 import net.runelite.client.ui.overlay.components.LayoutableRenderableEntity;
 
-@Data
+@Getter
+@Setter
 public abstract class Overlay implements LayoutableRenderableEntity
 {
 	private Point preferredLocation;

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayManager.java
@@ -109,6 +109,11 @@ public class OverlayManager
 	 */
 	public synchronized boolean add(final Overlay overlay)
 	{
+		if (overlays.contains(overlay))
+		{
+			return false;
+		}
+
 		final boolean add = overlays.add(overlay);
 
 		if (add)

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayManager.java
@@ -114,20 +114,16 @@ public class OverlayManager
 			return false;
 		}
 
-		final boolean add = overlays.add(overlay);
-
-		if (add)
-		{
-			final Point location = loadOverlayLocation(overlay);
-			overlay.setPreferredLocation(location);
-			final Dimension size = loadOverlaySize(overlay);
-			overlay.setPreferredSize(size);
-			final OverlayPosition position = loadOverlayPosition(overlay);
-			overlay.setPreferredPosition(position);
-			rebuildOverlayLayers();
-		}
-
-		return add;
+		// Add is always true
+		overlays.add(overlay);
+		final Point location = loadOverlayLocation(overlay);
+		overlay.setPreferredLocation(location);
+		final Dimension size = loadOverlaySize(overlay);
+		overlay.setPreferredSize(size);
+		final OverlayPosition position = loadOverlayPosition(overlay);
+		overlay.setPreferredPosition(position);
+		rebuildOverlayLayers();
+		return true;
 	}
 
 	/**
@@ -157,7 +153,12 @@ public class OverlayManager
 	public synchronized boolean removeIf(Predicate<Overlay> filter)
 	{
 		final boolean removeIf = overlays.removeIf(filter);
-		rebuildOverlayLayers();
+
+		if (removeIf)
+		{
+			rebuildOverlayLayers();
+		}
+
 		return removeIf;
 	}
 

--- a/runelite-client/src/test/java/net/runelite/client/ui/overlay/OverlayManagerTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/ui/overlay/OverlayManagerTest.java
@@ -29,6 +29,8 @@ import java.awt.Graphics2D;
 import java.util.Arrays;
 import java.util.List;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 
 public class OverlayManagerTest
@@ -46,6 +48,38 @@ public class OverlayManagerTest
 		{
 			throw new UnsupportedOperationException("Not supported yet.");
 		}
+	}
+
+	private static class OverlayA extends Overlay
+	{
+		@Override
+		public Dimension render(Graphics2D graphics)
+		{
+			return null;
+		}
+	}
+
+	private static class OverlayB extends Overlay
+	{
+		@Override
+		public Dimension render(Graphics2D graphics)
+		{
+			return null;
+		}
+	}
+
+	@Test
+	public void testEquality()
+	{
+		Overlay a1 = new OverlayA();
+		Overlay a2 = new OverlayA();
+		Overlay b = new OverlayB();
+		// The same instance of the same overlay should be equal
+		assertTrue(a1.equals(a1));
+		// A different instance of the same overlay should not be equal by default
+		assertFalse(a1.equals(a2));
+		// A different instance of a different overlay should not be equal
+		assertFalse(a1.equals(b));
 	}
 
 	@Test


### PR DESCRIPTION
- Generated equals from Lombok can cause falsy equals checks and so match
with unrelated overlay.
- Do not add overlay twice to overlay list based on equals

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>