### PR TITLE
Consider anything with GE > 0 as tradeable too

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
@@ -472,7 +472,7 @@ public class GroundItemsPlugin extends Plugin
 	{
 		final boolean isExplicitHidden = TRUE.equals(hiddenItems.getUnchecked(item));
 		final boolean isExplicitHighlight = TRUE.equals(highlightedItems.getUnchecked(item));
-		final boolean canBeHidden = isTradeable || !config.dontHideUntradeables();
+		final boolean canBeHidden = gePrice > 0 || isTradeable || !config.dontHideUntradeables();
 		final boolean underGe = gePrice < config.getHideUnderValue();
 		final boolean underHa = haPrice < config.getHideUnderValue();
 


### PR DESCRIPTION
In ground items, consider anything that has positive GE value as
tradeable and exclude it from untradeable checks.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>