### PR TITLE
Expand player indicators plugin configurations

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/DisplayOption.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/DisplayOption.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2018, Jordan Atwood <jordan.atwood423@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.playerindicators;
+
+public enum DisplayOption
+{
+	DISABLED("Off"),
+	PLAYER("Player"),
+	MINIMAP("Minimap"),
+	BOTH("Both");
+
+	private final String name;
+
+	DisplayOption(String name)
+	{
+		this.name = name;
+	}
+
+	@Override
+	public String toString()
+	{
+		return name;
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsConfig.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018, Tomas Slusny <slusnucky@gmail.com>
+ * Copyright (c) 2018, Jordan Atwood <jordan.atwood423@gmail.com>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -34,13 +35,13 @@ public interface PlayerIndicatorsConfig extends Config
 {
 	@ConfigItem(
 		position = 0,
-		keyName = "drawOwnName",
-		name = "Highlight own player",
-		description = "Configures whether or not your own player should be highlighted"
+		keyName = "displayOwnPlayer",
+		name = "Own player indicator",
+		description = "Configures whether or not your own player should be highlighted and/or shown on the minimap"
 	)
-	default boolean highlightOwnPlayer()
+	default DisplayOption displayOwnPlayer()
 	{
-		return false;
+		return DisplayOption.DISABLED;
 	}
 
 	@ConfigItem(
@@ -56,13 +57,13 @@ public interface PlayerIndicatorsConfig extends Config
 
 	@ConfigItem(
 		position = 2,
-		keyName = "drawFriendNames",
-		name = "Highlight friends",
-		description = "Configures whether or not friends should be highlighted"
+		keyName = "displayFriends",
+		name = "Friend indicators",
+		description = "Configures whether or not friends should be highlighted and/or shown on the minimap"
 	)
-	default boolean highlightFriends()
+	default DisplayOption displayFriends()
 	{
-		return true;
+		return DisplayOption.PLAYER;
 	}
 
 	@ConfigItem(
@@ -78,13 +79,13 @@ public interface PlayerIndicatorsConfig extends Config
 
 	@ConfigItem(
 		position = 4,
-		keyName = "drawClanMemberNames",
-		name = "Highlight clan members",
-		description = "Configures whether or clan members should be highlighted"
+		keyName = "displayClanMembers",
+		name = "Clan member indicators",
+		description = "Configures whether or not clan members should be highlighted and/or shown on the minimap"
 	)
-	default boolean drawClanMemberNames()
+	default DisplayOption displayClanMembers()
 	{
-		return true;
+		return DisplayOption.PLAYER;
 	}
 
 	@ConfigItem(
@@ -100,13 +101,13 @@ public interface PlayerIndicatorsConfig extends Config
 
 	@ConfigItem(
 		position = 6,
-		keyName = "drawTeamMemberNames",
-		name = "Highlight team members",
-		description = "Configures whether or not team members should be highlighted"
+		keyName = "displayTeamMembers",
+		name = "Team member indicators",
+		description = "Configures whether or not team members should be highlighted and/or shown on the minimap"
 	)
-	default boolean highlightTeamMembers()
+	default DisplayOption displayTeamMembers()
 	{
-		return true;
+		return DisplayOption.PLAYER;
 	}
 
 	@ConfigItem(
@@ -122,13 +123,13 @@ public interface PlayerIndicatorsConfig extends Config
 
 	@ConfigItem(
 		position = 8,
-		keyName = "drawNonClanMemberNames",
-		name = "Highlight non-clan members",
-		description = "Configures whether or not non-clan members should be highlighted"
+		keyName = "displayNonClanMembers",
+		name = "Non-clan member indicators",
+		description = "Configures whether or not non-clan members should be highlighted and/or shown on the minimap"
 	)
-	default boolean highlightNonClanMembers()
+	default DisplayOption displayNonClanMembers()
 	{
-		return false;
+		return DisplayOption.DISABLED;
 	}
 
 	@ConfigItem(
@@ -166,17 +167,6 @@ public interface PlayerIndicatorsConfig extends Config
 
 	@ConfigItem(
 		position = 12,
-		keyName = "drawMinimapNames",
-		name = "Draw names on minimap",
-		description = "Configures whether or not minimap names for players with rendered names should be drawn"
-	)
-	default boolean drawMinimapNames()
-	{
-		return false;
-	}
-
-	@ConfigItem(
-		position = 13,
 		keyName = "colorPlayerMenu",
 		name = "Colorize player menu",
 		description = "Color right click menu for players"
@@ -187,7 +177,7 @@ public interface PlayerIndicatorsConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 14,
+		position = 13,
 		keyName = "clanMenuIcons",
 		name = "Show clan ranks",
 		description = "Add clan rank to right click menu and next to player names"

--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsMinimapOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsMinimapOverlay.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018, Tomas Slusny <slusnucky@gmail.com>
+ * Copyright (c) 2018, Jordan Atwood <jordan.atwood423@gmail.com>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -55,22 +56,18 @@ public class PlayerIndicatorsMinimapOverlay extends Overlay
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
-		playerIndicatorsService.forEachPlayer((player, color) -> renderPlayerOverlay(graphics, player, color));
+		playerIndicatorsService.forEachPlayer((player, color) -> renderPlayerOverlay(graphics, player, color), DisplayOption.MINIMAP);
 		return null;
 	}
 
 	private void renderPlayerOverlay(Graphics2D graphics, Player actor, Color color)
 	{
 		final String name = actor.getName().replace('\u00A0', ' ');
+		final net.runelite.api.Point minimapLocation = actor.getMinimapLocation();
 
-		if (config.drawMinimapNames())
+		if (minimapLocation != null)
 		{
-			final net.runelite.api.Point minimapLocation = actor.getMinimapLocation();
-
-			if (minimapLocation != null)
-			{
-				OverlayUtil.renderTextLocation(graphics, minimapLocation, name, color);
-			}
+			OverlayUtil.renderTextLocation(graphics, minimapLocation, name, color);
 		}
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsOverlay.java
@@ -65,7 +65,7 @@ public class PlayerIndicatorsOverlay extends Overlay
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
-		playerIndicatorsService.forEachPlayer((player, color) -> renderPlayerOverlay(graphics, player, color));
+		playerIndicatorsService.forEachPlayer((player, color) -> renderPlayerOverlay(graphics, player, color), DisplayOption.PLAYER);
 		return null;
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsPlugin.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018, Tomas Slusny <slusnucky@gmail.com>
+ * Copyright (c) 2018, Jordan Atwood <jordan.atwood423@gmail.com>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -132,11 +133,15 @@ public class PlayerIndicatorsPlugin extends Plugin
 			int image = -1;
 			Color color = null;
 
-			if (config.highlightFriends() && player.isFriend())
+			if ((config.displayFriends() == DisplayOption.PLAYER
+				|| config.displayFriends() == DisplayOption.BOTH)
+				&& player.isFriend())
 			{
 				color = config.getFriendColor();
 			}
-			else if (config.drawClanMemberNames() && player.isClanMember())
+			else if ((config.displayClanMembers() == DisplayOption.PLAYER
+					|| config.displayClanMembers() == DisplayOption.BOTH)
+					&& player.isClanMember())
 			{
 				color = config.getClanMemberColor();
 
@@ -146,11 +151,16 @@ public class PlayerIndicatorsPlugin extends Plugin
 					image = clanManager.getIconNumber(rank);
 				}
 			}
-			else if (config.highlightTeamMembers() && player.getTeam() > 0 && localPlayer.getTeam() == player.getTeam())
+			else if ((config.displayTeamMembers() == DisplayOption.PLAYER
+					|| config.displayTeamMembers() == DisplayOption.BOTH)
+					&& player.getTeam() > 0
+					&& localPlayer.getTeam() == player.getTeam())
 			{
 				color = config.getTeamMemberColor();
 			}
-			else if (config.highlightNonClanMembers() && !player.isClanMember())
+			else if ((config.displayNonClanMembers() == DisplayOption.PLAYER
+					|| config.displayNonClanMembers() == DisplayOption.BOTH)
+					&& !player.isClanMember())
 			{
 				color = config.getNonClanMemberColor();
 			}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsService.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsService.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018, Tomas Slusny <slusnucky@gmail.com>
+ * Copyright (c) 2018, Jordan Atwood <jordan.atwood423@gmail.com>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -44,10 +45,13 @@ public class PlayerIndicatorsService
 		this.client = client;
 	}
 
-	public void forEachPlayer(final BiConsumer<Player, Color> consumer)
+	public void forEachPlayer(final BiConsumer<Player, Color> consumer, final DisplayOption display)
 	{
-		if (!config.highlightOwnPlayer() && !config.drawClanMemberNames()
-			&& !config.highlightFriends() && !config.highlightNonClanMembers())
+		if (config.displayOwnPlayer() == DisplayOption.DISABLED
+			&& config.displayFriends() == DisplayOption.DISABLED
+			&& config.displayClanMembers() == DisplayOption.DISABLED
+			&& config.displayTeamMembers() == DisplayOption.DISABLED
+			&& config.displayNonClanMembers() == DisplayOption.DISABLED)
 		{
 			return;
 		}
@@ -65,24 +69,34 @@ public class PlayerIndicatorsService
 
 			if (player == localPlayer)
 			{
-				if (config.highlightOwnPlayer())
+				if (config.displayOwnPlayer() == DisplayOption.BOTH
+					|| config.displayOwnPlayer() == display)
 				{
 					consumer.accept(player, config.getOwnPlayerColor());
 				}
 			}
-			else if (config.highlightFriends() && player.isFriend())
+			else if ((config.displayFriends() == DisplayOption.BOTH
+					|| config.displayFriends() == display)
+					&& player.isFriend())
 			{
 				consumer.accept(player, config.getFriendColor());
 			}
-			else if (config.drawClanMemberNames() && isClanMember)
+			else if ((config.displayClanMembers() == DisplayOption.BOTH
+					|| config.displayClanMembers() == display)
+					&& isClanMember)
 			{
 				consumer.accept(player, config.getClanMemberColor());
 			}
-			else if (config.highlightTeamMembers() && localPlayer.getTeam() > 0 && localPlayer.getTeam() == player.getTeam())
+			else if ((config.displayTeamMembers() == DisplayOption.BOTH
+					|| config.displayTeamMembers() == DisplayOption.BOTH)
+					&& localPlayer.getTeam() > 0
+					&& localPlayer.getTeam() == player.getTeam())
 			{
 				consumer.accept(player, config.getTeamMemberColor());
 			}
-			else if (config.highlightNonClanMembers() && !isClanMember)
+			else if ((config.displayNonClanMembers() == DisplayOption.BOTH
+					|| config.displayNonClanMembers() == display)
+					&& !isClanMember)
 			{
 				consumer.accept(player, config.getNonClanMemberColor());
 			}


### PR DESCRIPTION
A drop-down menu is introduced for each category of players, allowing
the choice of highlighting players, having them appear on the minimap,
or both.

The "draw names on minimap" option has also been removed.

![updated-player-indicators-configuration](https://user-images.githubusercontent.com/2199511/41504149-fab0c3fa-71d5-11e8-8570-25b084415c08.png)

Closes runelite/runelite#3592