### PR TITLE
Ignore level goals which have been passed

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpStateSingle.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpStateSingle.java
@@ -210,10 +210,9 @@ class XpStateSingle
 		xpGained = currentXp - startXp;
 
 		// Determine XP goals
-		int currentLevelXp = Experience.getXpForLevel(Experience.getLevelForXp(currentXp));
-		if (goalStartXp <= 0 || currentLevelXp > goalEndXp)
+		if (goalStartXp <= 0 || currentXp > goalEndXp)
 		{
-			startLevelExp = currentLevelXp;
+			startLevelExp = Experience.getXpForLevel(Experience.getLevelForXp(currentXp));
 		}
 		else
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpStateSingle.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpStateSingle.java
@@ -210,9 +210,10 @@ class XpStateSingle
 		xpGained = currentXp - startXp;
 
 		// Determine XP goals
-		if (goalStartXp <= 0)
+		int currentLevelXp = Experience.getXpForLevel(Experience.getLevelForXp(currentXp));
+		if (goalStartXp <= 0 || currentLevelXp > goalEndXp)
 		{
-			startLevelExp = Experience.getXpForLevel(Experience.getLevelForXp(currentXp));
+			startLevelExp = currentLevelXp;
 		}
 		else
 		{


### PR DESCRIPTION
Fixes runelite/runelite#3639

Some screenshots to prove that it is working:
* [Current behavior (old goal was level 79 - 84)](https://user-images.githubusercontent.com/2199511/41439881-0235e594-701c-11e8-8c39-91d23f6144c0.png)
* [New behavior (no change to smithing goal)](https://user-images.githubusercontent.com/2199511/41439883-03710010-701c-11e8-8136-6ea4c7b8c5d1.png)
* [New behavior is identical for current goals (and showing my currently-set goals)](https://user-images.githubusercontent.com/2199511/41439884-05320e30-701c-11e8-995e-1e28eaee8d58.png)

