### PR TITLE
Optional support for recoloring right-click menu

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
@@ -110,10 +110,21 @@ public interface GroundItemsConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "recolorMenuHiddenItems",
+		name = "Recolor Menu Hidden Items",
+		description = "Configures whether or not hidden items in right click menu will be recolored",
+		position = 5
+	)
+	default boolean recolorMenuHiddenItems()
+	{
+		return false;
+	}
+
+	@ConfigItem(
 		keyName = "priceDisplayMode",
 		name = "Price Display Mode",
 		description = "Configures what price types are shown alongside of ground item name",
-		position = 5
+		position = 6
 	)
 	default PriceDisplayMode priceDisplayMode()
 	{
@@ -124,7 +135,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "itemHighlightMode",
 		name = "Item Highlight Mode",
 		description = "Configures how ground items will be highlighted",
-		position = 6
+		position = 7
 	)
 	default ItemHighlightMode itemHighlightMode()
 	{
@@ -135,7 +146,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "menuHighlightMode",
 		name = "Menu Highlight Mode",
 		description = "Configures what to highlight in right-click menu",
-		position = 7
+		position = 8
 	)
 	default MenuHighlightMode menuHighlightMode()
 	{
@@ -146,7 +157,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "highlightOverValue2",
 		name = "Highlight > Value",
 		description = "Configures highlighted ground items over either GE or HA value",
-		position = 8
+		position = 9
 	)
 	default int getHighlightOverValue()
 	{
@@ -157,7 +168,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "hideUnderValue",
 		name = "Hide < Value",
 		description = "Configures hidden ground items under both GE and HA value",
-		position = 9
+		position = 10
 	)
 	default int getHideUnderValue()
 	{
@@ -168,7 +179,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "defaultColor",
 		name = "Default items color",
 		description = "Configures the color for default, non-highlighted items",
-		position = 10
+		position = 11
 	)
 	default Color defaultColor()
 	{
@@ -179,7 +190,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "highlightedColor",
 		name = "Highlighted items color",
 		description = "Configures the color for highlighted items",
-		position = 11
+		position = 12
 	)
 	default Color highlightedColor()
 	{
@@ -189,8 +200,8 @@ public interface GroundItemsConfig extends Config
 	@ConfigItem(
 		keyName = "hiddenColor",
 		name = "Hidden items color",
-		description = "Configures the color for hidden items when holding ALT",
-		position = 12
+		description = "Configures the color for hidden items in right-click menu and when holding ALT",
+		position = 13
 	)
 	default Color hiddenColor()
 	{
@@ -201,7 +212,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "lowValueColor",
 		name = "Low value items color",
 		description = "Configures the color for low value items",
-		position = 13
+		position = 14
 	)
 	default Color lowValueColor()
 	{
@@ -212,7 +223,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "lowValuePrice",
 		name = "Low value price",
 		description = "Configures the start price for low value items",
-		position = 14
+		position = 15
 	)
 	default int lowValuePrice()
 	{
@@ -223,7 +234,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "mediumValueColor",
 		name = "Medium value items color",
 		description = "Configures the color for medium value items",
-		position = 15
+		position = 16
 	)
 	default Color mediumValueColor()
 	{
@@ -234,7 +245,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "mediumValuePrice",
 		name = "Medium value price",
 		description = "Configures the start price for medium value items",
-		position = 16
+		position = 17
 	)
 	default int mediumValuePrice()
 	{
@@ -245,7 +256,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "highValueColor",
 		name = "High value items color",
 		description = "Configures the color for high value items",
-		position = 17
+		position = 18
 	)
 	default Color highValueColor()
 	{
@@ -256,7 +267,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "highValuePrice",
 		name = "High value price",
 		description = "Configures the start price for high value items",
-		position = 18
+		position = 19
 	)
 	default int highValuePrice()
 	{
@@ -267,7 +278,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "insaneValueColor",
 		name = "Insane value items color",
 		description = "Configures the color for insane value items",
-		position = 19
+		position = 20
 	)
 	default Color insaneValueColor()
 	{
@@ -278,7 +289,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "insaneValuePrice",
 		name = "Insane value price",
 		description = "Configures the start price for insane value items",
-		position = 20
+		position = 21
 	)
 	default int insaneValuePrice()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
@@ -410,8 +410,9 @@ public class GroundItemsPlugin extends Plugin
 			final Color hidden = getHidden(itemComposition.getName(), gePrice, haPrice, itemComposition.isTradeable());
 			final Color highlighted = getHighlighted(itemComposition.getName(), gePrice, haPrice);
 			final Color color = getItemColor(highlighted, hidden);
+			final boolean canBeRecolored = highlighted != null || (hidden != null && config.recolorMenuHiddenItems());
 
-			if (color != null && hidden == null && !color.equals(config.defaultColor()))
+			if (color != null && canBeRecolored && !color.equals(config.defaultColor()))
 			{
 				String hexColor = Integer.toHexString(color.getRGB() & 0xFFFFFF);
 				String colTag = "<col=" + hexColor + ">";


### PR DESCRIPTION
Add back support for recoloring right-click menu in Ground Items, but
make it optional and disabled by default.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>