### PR TITLE
Disable OSB prices by default

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangeConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangeConfig.java
@@ -65,6 +65,6 @@ public interface GrandExchangeConfig extends Config
 	)
 	default boolean enableOsbPrices()
 	{
-		return true;
+		return false;
 	}
 }


### PR DESCRIPTION
Depending on 3rd party API is bad enough, having it enabled by default
is worse.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>