### PR TITLE
configPanel: remove tooltips for JTextArea

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
@@ -494,11 +494,9 @@ public class ConfigPanel extends PluginPanel
 					public void focusLost(FocusEvent e)
 					{
 						changeConfiguration(config, textField, cd, cid);
-						textField.setToolTipText(textField.getText());
 					}
 				});
 
-				textField.setToolTipText(textField.getText());
 				item.add(textField, BorderLayout.SOUTH);
 			}
 


### PR DESCRIPTION
remove the unnecessary tool tip for JTextArea that can sometimes take up the entire screens width

![lol](https://user-images.githubusercontent.com/5454364/41493360-febe7df8-70cb-11e8-8259-0cd101079b2c.png)

Fixes #2716