### PR TITLE
Render abyss rift portals as soon as visible

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/runecraft/AbyssOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/runecraft/AbyssOverlay.java
@@ -53,7 +53,6 @@ import net.runelite.api.DecorativeObject;
 import net.runelite.api.NPC;
 import net.runelite.api.Perspective;
 import net.runelite.api.Point;
-import net.runelite.api.coords.LocalPoint;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/runecraft/AbyssOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/runecraft/AbyssOverlay.java
@@ -93,11 +93,7 @@ class AbyssOverlay extends Overlay
 			LocalPoint localLocation = client.getLocalPlayer().getLocalLocation();
 			for (DecorativeObject object : plugin.getAbyssObjects())
 			{
-				LocalPoint location = object.getLocalLocation();
-				if (localLocation.distanceTo(location) <= MAX_DISTANCE)
-				{
-					renderRifts(graphics, object);
-				}
+				renderRifts(graphics, object);
 			}
 		}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/runecraft/AbyssOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/runecraft/AbyssOverlay.java
@@ -62,7 +62,6 @@ import net.runelite.client.ui.overlay.OverlayUtil;
 
 class AbyssOverlay extends Overlay
 {
-	private static final int MAX_DISTANCE = 2350;
 	private static final Dimension IMAGE_SIZE = new Dimension(15, 14);
 
 	private final Set<AbyssRifts> rifts = new HashSet<>();

--- a/runelite-client/src/main/java/net/runelite/client/plugins/runecraft/AbyssOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/runecraft/AbyssOverlay.java
@@ -89,7 +89,6 @@ class AbyssOverlay extends Overlay
 	{
 		if (config.showRifts())
 		{
-			LocalPoint localLocation = client.getLocalPlayer().getLocalLocation();
 			for (DecorativeObject object : plugin.getAbyssObjects())
 			{
 				renderRifts(graphics, object);


### PR DESCRIPTION
This increases usability of running the abyss. Because if you can see the portal sooner, you know which direction/entry obstacle is closest to it.