### PR TITLE
Fix ground marker plugin layer

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/groundmarkers/GroundMarkerInputListener.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/groundmarkers/GroundMarkerInputListener.java
@@ -27,20 +27,17 @@ package net.runelite.client.plugins.groundmarkers;
 
 import java.awt.event.KeyEvent;
 import javax.inject.Inject;
-import net.runelite.api.Client;
 import net.runelite.client.input.KeyListener;
 
 public class GroundMarkerInputListener implements KeyListener
 {
 	private static final int HOTKEY = KeyEvent.VK_SHIFT;
 
-	private final Client client;
 	private final GroundMarkerPlugin plugin;
 
 	@Inject
-	private GroundMarkerInputListener(Client client, GroundMarkerPlugin plugin)
+	private GroundMarkerInputListener(GroundMarkerPlugin plugin)
 	{
-		this.client = client;
 		this.plugin = plugin;
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/groundmarkers/GroundMarkerOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/groundmarkers/GroundMarkerOverlay.java
@@ -53,8 +53,8 @@ public class GroundMarkerOverlay extends Overlay
 		this.config = config;
 		this.plugin = plugin;
 		setPosition(OverlayPosition.DYNAMIC);
-		setPriority(OverlayPriority.HIGH);
-		setLayer(OverlayLayer.UNDER_WIDGETS);
+		setPriority(OverlayPriority.LOW);
+		setLayer(OverlayLayer.ABOVE_SCENE);
 	}
 
 	@Override


### PR DESCRIPTION
This plugin is marking ground, it should be at lowest possible layer to
not interfere/draw over other overlays.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>