### PR TITLE
Replace "Send notifications when focused" global setting with plugin specific settings

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/Notifier.java
+++ b/runelite-client/src/main/java/net/runelite/client/Notifier.java
@@ -92,12 +92,12 @@ public class Notifier
 		storeIcon();
 	}
 
-	public void notify(String message)
+	public void notify(String message, boolean sendWhenFocused)
 	{
-		notify(message, TrayIcon.MessageType.NONE);
+		notify(message, TrayIcon.MessageType.NONE, sendWhenFocused);
 	}
 
-	public void notify(String message, TrayIcon.MessageType type)
+	public void notify(String message, TrayIcon.MessageType type, boolean sendWhenFocused)
 	{
 		final ClientUI clientUI = this.clientUI.get();
 
@@ -106,7 +106,7 @@ public class Notifier
 			return;
 		}
 
-		if (!runeLiteConfig.sendNotificationsWhenFocused() && clientUI.isFocused())
+		if (!sendWhenFocused && clientUI.isFocused())
 		{
 			return;
 		}

--- a/runelite-client/src/main/java/net/runelite/client/config/RuneLiteConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/RuneLiteConfig.java
@@ -179,17 +179,6 @@ public interface RuneLiteConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "notificationFocused",
-		name = "Send notifications when focused",
-		description = "Toggles idle notifications for when the client is focused",
-		position = 25
-	)
-	default boolean sendNotificationsWhenFocused()
-	{
-		return false;
-	}
-
-	@ConfigItem(
 		keyName = "fontType",
 		name = "Dynamic Overlay Font",
 		description = "Configures what font type is used for in-game overlays such as player name, ground items, etc.",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/agility/AgilityConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/agility/AgilityConfig.java
@@ -145,4 +145,15 @@ public interface AgilityConfig extends Config
 	{
 		return true;
 	}
+
+	@ConfigItem(
+		keyName = "notificationFocused",
+		name = "Send notifications when focused",
+		description = "Toggles notifications for when the client is focused",
+		position = 11
+	)
+	default boolean sendNotificationsWhenFocused()
+	{
+		return false;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/agility/AgilityPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/agility/AgilityPlugin.java
@@ -254,7 +254,7 @@ public class AgilityPlugin extends Plugin
 				{
 					if (config.notifyAgilityArena())
 					{
-						notifier.notify("Ticket location changed");
+						notifier.notify("Ticket location changed", config.sendNotificationsWhenFocused());
 					}
 
 					if (config.showAgilityArenaTimer())

--- a/runelite-client/src/main/java/net/runelite/client/plugins/boosts/BoostsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/boosts/BoostsConfig.java
@@ -89,4 +89,15 @@ public interface BoostsConfig extends Config
 	{
 		return 0;
 	}
+
+	@ConfigItem(
+		keyName = "notificationFocused",
+		name = "Send notifications when focused",
+		description = "Toggles notifications for when the client is focused",
+		position = 6
+	)
+	default boolean sendNotificationsWhenFocused()
+	{
+		return false;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/boosts/BoostsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/boosts/BoostsPlugin.java
@@ -175,7 +175,7 @@ public class BoostsPlugin extends Plugin
 			int boost = cur - real;
 			if (boost <= boostThreshold && boostThreshold < lastBoost)
 			{
-				notifier.notify(skill.getName() + " level is getting low!");
+				notifier.notify(skill.getName() + " level is getting low!", config.sendNotificationsWhenFocused());
 			}
 		}
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonConfig.java
@@ -37,6 +37,7 @@ import net.runelite.client.config.ConfigItem;
 public interface CannonConfig extends Config
 {
 	@ConfigItem(
+		position = 1,
 		keyName = "showEmptyCannonNotification",
 		name = "Empty cannon notification",
 		description = "Configures whether to notify you that the cannon is empty"
@@ -47,6 +48,7 @@ public interface CannonConfig extends Config
 	}
 
 	@ConfigItem(
+		position = 2,
 		keyName = "showInfobox",
 		name = "Show Cannonball infobox",
 		description = "Configures whether to show the cannonballs in an infobox"
@@ -57,6 +59,7 @@ public interface CannonConfig extends Config
 	}
 
 	@ConfigItem(
+		position = 3,
 		keyName = "showDoubleHitSpot",
 		name = "Show double hit spots",
 		description = "Configures whether to show the NPC double hit spot"
@@ -67,6 +70,7 @@ public interface CannonConfig extends Config
 	}
 
 	@ConfigItem(
+		position = 4,
 		keyName = "highlightDoubleHitColor",
 		name = "Color of double hit spots",
 		description = "Configures the highlight color of double hit spots"
@@ -77,6 +81,7 @@ public interface CannonConfig extends Config
 	}
 
 	@ConfigItem(
+		position = 5,
 		keyName = "showCannonSpots",
 		name = "Show common cannon spots",
 		description = "Configures whether to show common cannon spots or not"
@@ -84,5 +89,16 @@ public interface CannonConfig extends Config
 	default boolean showCannonSpots()
 	{
 		return true;
+	}
+
+	@ConfigItem(
+		position = 6,
+		keyName = "notificationFocused",
+		name = "Send notifications when focused",
+		description = "Toggles notifications for when the client is focused"
+	)
+	default boolean sendNotificationsWhenFocused()
+	{
+		return false;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonPlugin.java
@@ -292,7 +292,7 @@ public class CannonPlugin extends Plugin
 
 			if (config.showEmptyCannonNotification())
 			{
-				notifier.notify("Your cannon is out of ammo!");
+				notifier.notify("Your cannon is out of ammo!", config.sendNotificationsWhenFocused());
 			}
 		}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatnotifications/ChatNotificationsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatnotifications/ChatNotificationsConfig.java
@@ -101,4 +101,15 @@ public interface ChatNotificationsConfig extends Config
 	{
 		return false;
 	}
+
+	@ConfigItem(
+		position = 6,
+		keyName = "notificationFocused",
+		name = "Send notifications when focused",
+		description = "Toggles notifications for when the client is focused"
+	)
+	default boolean sendNotificationsWhenFocused()
+	{
+		return false;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatnotifications/ChatNotificationsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatnotifications/ChatNotificationsPlugin.java
@@ -132,13 +132,13 @@ public class ChatNotificationsPlugin extends Plugin
 			case TRADE:
 				if (event.getValue().contains("wishes to trade with you.") && config.notifyOnTrade())
 				{
-					notifier.notify(event.getValue());
+					notifier.notify(event.getValue(), config.sendNotificationsWhenFocused());
 				}
 				break;
 			case DUEL:
 				if (event.getValue().contains("wishes to duel with you.") && config.notifyOnDuel())
 				{
-					notifier.notify(event.getValue());
+					notifier.notify(event.getValue(), config.sendNotificationsWhenFocused());
 				}
 				break;
 			case GAME:
@@ -222,6 +222,6 @@ public class ChatNotificationsPlugin extends Plugin
 		stringBuilder.append(message.getValue());
 
 		String notification = stringBuilder.toString();
-		notifier.notify(notification);
+		notifier.notify(notification, config.sendNotificationsWhenFocused());
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangeConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangeConfig.java
@@ -67,4 +67,15 @@ public interface GrandExchangeConfig extends Config
 	{
 		return false;
 	}
+
+	@ConfigItem(
+		position = 4,
+		keyName = "notificationFocused",
+		name = "Send notifications when focused",
+		description = "Toggles notifications for when the client is focused"
+	)
+	default boolean sendNotificationsWhenFocused()
+	{
+		return false;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangePlugin.java
@@ -206,7 +206,7 @@ public class GrandExchangePlugin extends Plugin
 
 		if (message.startsWith("Grand Exchange:"))
 		{
-			this.notifier.notify(message);
+			this.notifier.notify(message, config.sendNotificationsWhenFocused());
 		}
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/hunter/HunterConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/hunter/HunterConfig.java
@@ -90,4 +90,15 @@ public interface HunterConfig extends Config
 	{
 		return false;
 	}
+
+	@ConfigItem(
+		position = 6,
+		keyName = "notificationFocused",
+		name = "Send notifications when focused",
+		description = "Toggles notifications for when the client is focused"
+	)
+	default boolean sendNotificationsWhenFocused()
+	{
+		return false;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/hunter/HunterPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/hunter/HunterPlugin.java
@@ -210,7 +210,7 @@ public class HunterPlugin extends Plugin
 
 					if (config.maniacalMonkeyNotify() && myTrap.getObjectId() == ObjectID.MONKEY_TRAP)
 					{
-						notifier.notify("You've caught part of a monkey's tail.");
+						notifier.notify("You've caught part of a monkey's tail.", config.sendNotificationsWhenFocused());
 					}
 				}
 
@@ -369,7 +369,7 @@ public class HunterPlugin extends Plugin
 				if (config.maniacalMonkeyNotify() && trap.getObjectId() == ObjectID.MONKEY_TRAP &&
 					!trap.getState().equals(HunterTrap.State.FULL) && !trap.getState().equals(HunterTrap.State.OPEN))
 				{
-					notifier.notify("The monkey escaped.");
+					notifier.notify("The monkey escaped.", config.sendNotificationsWhenFocused());
 				}
 			}
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierConfig.java
@@ -89,4 +89,15 @@ public interface IdleNotifierConfig extends Config
 	{
 		return 0;
 	}
+
+	@ConfigItem(
+		keyName = "notificationFocused",
+		name = "Send notifications when focused",
+		description = "Toggles notifications for when the client is focused",
+		position = 6
+	)
+	default boolean sendNotificationsWhenFocused()
+	{
+		return false;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
@@ -229,32 +229,32 @@ public class IdleNotifierPlugin extends Plugin
 
 		if (checkIdleLogout())
 		{
-			notifier.notify("[" + local.getName() + "] is about to log out from idling too long!");
+			notifier.notify("[" + local.getName() + "] is about to log out from idling too long!", config.sendNotificationsWhenFocused());
 		}
 
 		if (check6hrLogout())
 		{
-			notifier.notify("[" + local.getName() + "] is about to log out from being online for 6 hours!");
+			notifier.notify("[" + local.getName() + "] is about to log out from being online for 6 hours!", config.sendNotificationsWhenFocused());
 		}
 
 		if (config.animationIdle() && checkAnimationIdle(waitDuration, local))
 		{
-			notifier.notify("[" + local.getName() + "] is now idle!");
+			notifier.notify("[" + local.getName() + "] is now idle!", config.sendNotificationsWhenFocused());
 		}
 
 		if (config.combatIdle() && checkOutOfCombat(waitDuration, local))
 		{
-			notifier.notify("[" + local.getName() + "] is now out of combat!");
+			notifier.notify("[" + local.getName() + "] is now out of combat!", config.sendNotificationsWhenFocused());
 		}
 
 		if (checkLowHitpoints())
 		{
-			notifier.notify("[" + local.getName() + "] has low hitpoints!");
+			notifier.notify("[" + local.getName() + "] has low hitpoints!", config.sendNotificationsWhenFocused());
 		}
 
 		if (checkLowPrayer())
 		{
-			notifier.notify("[" + local.getName() + "] has low prayer!");
+			notifier.notify("[" + local.getName() + "] has low prayer!", config.sendNotificationsWhenFocused());
 		}
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemcharges/ItemChargeConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemcharges/ItemChargeConfig.java
@@ -145,4 +145,15 @@ public interface ItemChargeConfig extends Config
 	{
 		return false;
 	}
+
+	@ConfigItem(
+		keyName = "notificationFocused",
+		name = "Send notifications when focused",
+		description = "Toggles notifications for when the client is focused",
+		position = 11
+	)
+	default boolean sendNotificationsWhenFocused()
+	{
+		return false;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemcharges/ItemChargePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemcharges/ItemChargePlugin.java
@@ -77,7 +77,7 @@ public class ItemChargePlugin extends Plugin
 		{
 			if (config.recoilNotification() && event.getMessage().contains("<col=7f007f>Your Ring of Recoil has shattered.</col>"))
 			{
-				notifier.notify("Your Ring of Recoil has shattered");
+				notifier.notify("Your Ring of Recoil has shattered", config.sendNotificationsWhenFocused());
 			}
 		}
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/nightmarezone/NightmareZoneConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/nightmarezone/NightmareZoneConfig.java
@@ -135,4 +135,14 @@ public interface NightmareZoneConfig extends Config
 		return Color.RED;
 	}
 
+	@ConfigItem(
+		keyName = "notificationFocused",
+		name = "Send notifications when focused",
+		description = "Toggles notifications for when the client is focused",
+		position = 10
+	)
+	default boolean sendNotificationsWhenFocused()
+	{
+		return false;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/nightmarezone/NightmareZonePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/nightmarezone/NightmareZonePlugin.java
@@ -125,7 +125,7 @@ public class NightmareZonePlugin extends Plugin
 		{
 			if (config.overloadNotification())
 			{
-				notifier.notify("Your overload has worn off");
+				notifier.notify("Your overload has worn off", config.sendNotificationsWhenFocused());
 			}
 		}
 		else if (msg.contains("A power-up has spawned:"))
@@ -134,21 +134,21 @@ public class NightmareZonePlugin extends Plugin
 			{
 				if (config.powerSurgeNotification())
 				{
-					notifier.notify(msg);
+					notifier.notify(msg, config.sendNotificationsWhenFocused());
 				}
 			}
 			else if (msg.contains("Recurrent damage"))
 			{
 				if (config.recurrentDamageNotification())
 				{
-					notifier.notify(msg);
+					notifier.notify(msg, config.sendNotificationsWhenFocused());
 				}
 			}
 			else if (msg.contains("Zapper"))
 			{
 				if (config.zapperNotification())
 				{
-					notifier.notify(msg);
+					notifier.notify(msg, config.sendNotificationsWhenFocused());
 				}
 			}
 		}
@@ -162,7 +162,7 @@ public class NightmareZonePlugin extends Plugin
 		{
 			if (absorptionPoints < config.absorptionThreshold())
 			{
-				notifier.notify("Absorption points below: " + config.absorptionThreshold());
+				notifier.notify("Absorption points below: " + config.absorptionThreshold(), config.sendNotificationsWhenFocused());
 				absorptionNotificationSend = true;
 			}
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotConfig.java
@@ -144,4 +144,15 @@ public interface ScreenshotConfig extends Config
 	{
 		return false;
 	}
+
+	@ConfigItem(
+		keyName = "notificationFocused",
+		name = "Send notifications when focused",
+		description = "Toggles notifications for when the client is focused",
+		position = 10
+	)
+	default boolean sendNotificationsWhenFocused()
+	{
+		return false;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
@@ -490,7 +490,7 @@ public class ScreenshotPlugin extends Plugin
 					}
 					else if (config.notifyWhenTaken())
 					{
-						notifier.notify("A screenshot was saved to " + screenshotFile, TrayIcon.MessageType.INFO);
+						notifier.notify("A screenshot was saved to " + screenshotFile, TrayIcon.MessageType.INFO, config.sendNotificationsWhenFocused());
 					}
 				}
 				catch (IOException ex)
@@ -553,7 +553,7 @@ public class ScreenshotPlugin extends Plugin
 
 						if (config.notifyWhenTaken())
 						{
-							notifier.notify("A screenshot was uploaded and inserted into your clipboard!", TrayIcon.MessageType.INFO);
+							notifier.notify("A screenshot was uploaded and inserted into your clipboard!", TrayIcon.MessageType.INFO, config.sendNotificationsWhenFocused());
 						}
 					}
 				}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerConfig.java
@@ -103,6 +103,17 @@ public interface SlayerConfig extends Config
 		return Color.RED;
 	}
 
+	@ConfigItem(
+		position = 7,
+		keyName = "notificationFocused",
+		name = "Send notifications when focused",
+		description = "Toggles notifications for when the client is focused"
+	)
+	default boolean sendNotificationsWhenFocused()
+	{
+		return false;
+	}
+
 	// Stored data
 	@ConfigItem(
 		keyName = "taskName",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerPlugin.java
@@ -420,7 +420,7 @@ public class SlayerPlugin extends Plugin
 
 		if (config.showSuperiorNotification() && chatMsg.equals(CHAT_SUPERIOR_MESSAGE))
 		{
-			notifier.notify(CHAT_SUPERIOR_MESSAGE);
+			notifier.notify(CHAT_SUPERIOR_MESSAGE, config.sendNotificationsWhenFocused());
 			return;
 		}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingConfig.java
@@ -78,4 +78,15 @@ public interface WoodcuttingConfig extends Config
 	{
 		return true;
 	}
+
+	@ConfigItem(
+		position = 5,
+		keyName = "notificationFocused",
+		name = "Send notifications when focused",
+		description = "Toggles notifications for when the client is focused"
+	)
+	default boolean sendNotificationsWhenFocused()
+	{
+		return false;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingPlugin.java
@@ -143,7 +143,7 @@ public class WoodcuttingPlugin extends Plugin
 
 			if (event.getMessage().contains("A bird's nest falls out of the tree") && config.showNestNotification())
 			{
-				notifier.notify("A bird nest has spawned!");
+				notifier.notify("A bird nest has spawned!", config.sendNotificationsWhenFocused());
 			}
 		}
 	}

--- a/runelite-client/src/test/java/net/runelite/client/plugins/slayer/SlayerPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/slayer/SlayerPluginTest.java
@@ -225,7 +225,7 @@ public class SlayerPluginTest
 
 		when(slayerConfig.showSuperiorNotification()).thenReturn(true);
 		slayerPlugin.onChatMessage(chatMessageEvent);
-		verify(notifier).notify(SUPERIOR_MESSAGE);
+		verify(notifier).notify(SUPERIOR_MESSAGE, slayerConfig.sendNotificationsWhenFocused());
 
 		when(slayerConfig.showSuperiorNotification()).thenReturn(false);
 		slayerPlugin.onChatMessage(chatMessageEvent);


### PR DESCRIPTION
its nice to have the ability to have some of these plugins notify you even when the client is focused while having some of them not notify you while focused