### PR TITLE
Feature/idle overlay

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierConfig.java
@@ -92,10 +92,10 @@ public interface IdleNotifierConfig extends Config
 	}
 
 	@ConfigItem(
-			keyName = "timer",
-			name = "Display Idle Timer",
-			description = "Displays a MM:SS timer until the user will log out due to idling.",
-			position = 6
+		keyName = "timer",
+		name = "Display Idle Timer",
+		description = "Displays a MM:SS timer until the user will log out due to idling.",
+		position = 6
 	)
 	default boolean getTimerEnabled()
 	{
@@ -103,10 +103,13 @@ public interface IdleNotifierConfig extends Config
 	}
 
 	@ConfigItem(
-			keyName = "timerThreshold",
-			name = "Display when X seconds until logout",
-			description = "Threshold in seconds for when the timer should be displayed",
-			position = 7
+		keyName = "timerThreshold",
+		name = "Display when X seconds until logout",
+		description = "Threshold in seconds for when the timer should be displayed",
+		position = 7
 	)
-	default int getTimerThreshold() { return 120; }
+	default int getTimerThreshold()
+	{
+		return 120;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierConfig.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2017, Devin French <https://github.com/devinfrench>
+ * Copyright (c) 2018, Nathen Sample <https://github.com/nathensample>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -96,7 +97,10 @@ public interface IdleNotifierConfig extends Config
 			description = "Displays a MM:SS timer until the user will log out due to idling.",
 			position = 6
 	)
-	default boolean getTimerEnabled() { return false;}
+	default boolean getTimerEnabled()
+	{
+		return false;
+	}
 
 	@ConfigItem(
 			keyName = "timerThreshold",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierConfig.java
@@ -89,4 +89,20 @@ public interface IdleNotifierConfig extends Config
 	{
 		return 0;
 	}
+
+	@ConfigItem(
+			keyName = "timer",
+			name = "Display Idle Timer",
+			description = "Displays a MM:SS timer until the user will log out due to idling.",
+			position = 6
+	)
+	default boolean getTimerEnabled() { return false;}
+
+	@ConfigItem(
+			keyName = "timerThreshold",
+			name = "Display when X seconds until logout",
+			description = "Threshold in seconds for when the timer should be displayed",
+			position = 7
+	)
+	default int getTimerThreshold() { return 120; }
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2016-2017, Abel Briggs
  * Copyright (c) 2017, Kronos <https://github.com/KronosDesign>
+ * Copyright (c) 2018, Nathen Sample <https://github.com/nathensample>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -285,7 +286,7 @@ public class IdleNotifierPlugin extends Plugin
 		Duration durationTillLogout = durationTillLogout();
 		if (client.getKeyboardIdleTicks() > idleTicks && client.getMouseIdleTicks() > idleTicks && shouldRenderTimer(durationTillLogout))
 		{
-			if(!timerRendered)
+			if (!timerRendered)
 			{
 				renderIdleTimer(durationTillLogout);
 			}
@@ -294,7 +295,7 @@ public class IdleNotifierPlugin extends Plugin
 		{
 			infoBoxManager.removeIf(t -> t instanceof IdleTimer);
 			timerRendered = false;
-			if(shouldRenderTimer(durationTillLogout))
+			if (shouldRenderTimer(durationTillLogout))
 			{
 				renderIdleTimer(durationTillLogout);
 			}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
@@ -475,4 +475,10 @@ public class IdleNotifierPlugin extends Plugin
 		lastOpponent = null;
 		lastInteracting = null;
 	}
+
+	@Override
+	protected void shutDown()
+	{
+		infoBoxManager.removeIf(t -> t instanceof IdleTimer);
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
@@ -282,31 +282,35 @@ public class IdleNotifierPlugin extends Plugin
 
 	private void updateTimer()
 	{
-		if (client.getKeyboardIdleTicks() > idleTicks && client.getMouseIdleTicks() > idleTicks)
+		Duration durationTillLogout = durationTillLogout();
+		if (client.getKeyboardIdleTicks() > idleTicks && client.getMouseIdleTicks() > idleTicks && shouldRenderTimer(durationTillLogout))
 		{
 			if(!timerRendered)
 			{
-				Duration timeToLogout = durationTillLogout();
-				renderIdleTimer(timeToLogout);
+				renderIdleTimer(durationTillLogout);
 			}
 		}
 		else
 		{
-			Duration timeToLogout = durationTillLogout();
 			infoBoxManager.removeIf(t -> t instanceof IdleTimer);
 			timerRendered = false;
-			renderIdleTimer(timeToLogout);
+			if(shouldRenderTimer(durationTillLogout))
+			{
+				renderIdleTimer(durationTillLogout);
+			}
 		}
+	}
+
+	private boolean shouldRenderTimer(Duration timeToLogout)
+	{
+		return timeToLogout.compareTo(Duration.ofSeconds(config.getTimerThreshold())) < 0;
 	}
 
 	private void renderIdleTimer(Duration timeToLogout)
 	{
-		if (timeToLogout.compareTo(Duration.ofSeconds(config.getTimerThreshold())) < 0)
-		{
-			IdleTimer timer = new IdleTimer(spriteManager.getSprite(SpriteID.RS2_TAB_LOGOUT, 0), this, timeToLogout);
-			infoBoxManager.addInfoBox(timer);
-			timerRendered = true;
-		}
+		IdleTimer timer = new IdleTimer(spriteManager.getSprite(SpriteID.RS2_TAB_LOGOUT, 0), this, timeToLogout);
+		infoBoxManager.addInfoBox(timer);
+		timerRendered = true;
 	}
 
 	private Duration durationTillLogout()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
@@ -122,11 +122,11 @@ public class IdleNotifierPlugin extends Plugin
 			case WOODCUTTING_DRAGON:
 			case WOODCUTTING_INFERNAL:
 			case WOODCUTTING_3A_AXE:
-			/* Cooking(Fire, Range) */
+				/* Cooking(Fire, Range) */
 			case COOKING_FIRE:
 			case COOKING_RANGE:
 			case COOKING_WINE:
-			/* Crafting(Gem Cutting, Glassblowing, Spinning) */
+				/* Crafting(Gem Cutting, Glassblowing, Spinning) */
 			case GEM_CUTTING_OPAL:
 			case GEM_CUTTING_JADE:
 			case GEM_CUTTING_REDTOPAZ:
@@ -136,7 +136,7 @@ public class IdleNotifierPlugin extends Plugin
 			case GEM_CUTTING_DIAMOND:
 			case CRAFTING_GLASSBLOWING:
 			case CRAFTING_SPINNING:
-			/* Fletching(Cutting, Stringing) */
+				/* Fletching(Cutting, Stringing) */
 			case FLETCHING_BOW_CUTTING:
 			case FLETCHING_STRING_NORMAL_SHORTBOW:
 			case FLETCHING_STRING_OAK_SHORTBOW:
@@ -150,11 +150,11 @@ public class IdleNotifierPlugin extends Plugin
 			case FLETCHING_STRING_MAPLE_LONGBOW:
 			case FLETCHING_STRING_YEW_LONGBOW:
 			case FLETCHING_STRING_MAGIC_LONGBOW:
-			/* Smithing(Anvil, Furnace, Cannonballs */
+				/* Smithing(Anvil, Furnace, Cannonballs */
 			case SMITHING_ANVIL:
 			case SMITHING_SMELTING:
 			case SMITHING_CANNONBALL:
-			/* Fishing */
+				/* Fishing */
 			case FISHING_NET:
 			case FISHING_BIG_NET:
 			case FISHING_HARPOON:
@@ -167,7 +167,7 @@ public class IdleNotifierPlugin extends Plugin
 			case FISHING_KARAMBWAN:
 			case FISHING_CRUSHING_INFERNAL_EELS:
 			case FISHING_BAREHAND:
-			/* Mining(Normal) */
+				/* Mining(Normal) */
 			case MINING_BRONZE_PICKAXE:
 			case MINING_IRON_PICKAXE:
 			case MINING_STEEL_PICKAXE:
@@ -179,7 +179,7 @@ public class IdleNotifierPlugin extends Plugin
 			case MINING_DRAGON_PICKAXE_ORN:
 			case MINING_INFERNAL_PICKAXE:
 			case MINING_3A_PICKAXE:
-			/* Mining(Motherlode) */
+				/* Mining(Motherlode) */
 			case MINING_MOTHERLODE_BRONZE:
 			case MINING_MOTHERLODE_IRON:
 			case MINING_MOTHERLODE_STEEL:
@@ -191,14 +191,14 @@ public class IdleNotifierPlugin extends Plugin
 			case MINING_MOTHERLODE_DRAGON_ORN:
 			case MINING_MOTHERLODE_INFERNAL:
 			case MINING_MOTHERLODE_3A:
-			/* Herblore */
+				/* Herblore */
 			case HERBLORE_POTIONMAKING:
 			case HERBLORE_MAKE_TAR:
-			/* Magic */
+				/* Magic */
 			case MAGIC_CHARGING_ORBS:
 			case MAGIC_LUNAR_STRING_JEWELRY:
 			case MAGIC_LUNAR_BAKE_PIE:
-			/* Prayer */
+				/* Prayer */
 			case USING_GILDED_ALTAR:
 				resetTimers();
 				notifyIdle = true;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
@@ -83,10 +83,8 @@ public class IdleNotifierPlugin extends Plugin
 	private boolean notify6HourLogout = true;
 	private boolean timerRendered = false;
 
-
 	private Instant sixHourWarningTime;
 	private boolean ready;
-
 	private int idleTicks = 0;
 
 	@Provides
@@ -239,7 +237,7 @@ public class IdleNotifierPlugin extends Plugin
 
 		if (config.getTimerEnabled())
 		{
-			renderIdleTimer();
+			updateTimer();
 		}
 		else if (timerRendered)
 		{
@@ -282,17 +280,14 @@ public class IdleNotifierPlugin extends Plugin
 		}
 	}
 
-	private void renderIdleTimer()
+	private void updateTimer()
 	{
-
 		if (client.getKeyboardIdleTicks() > idleTicks && client.getMouseIdleTicks() > idleTicks)
 		{
-			Duration timeToLogout = durationTillLogout();
-			if (timeToLogout.compareTo(Duration.ofSeconds(config.getTimerThreshold())) < 0 && !timerRendered)
+			if(!timerRendered)
 			{
-				IdleTimer timer = new IdleTimer(spriteManager.getSprite(SpriteID.RS2_TAB_LOGOUT, 0), this, timeToLogout);
-				infoBoxManager.addInfoBox(timer);
-				timerRendered = true;
+				Duration timeToLogout = durationTillLogout();
+				renderIdleTimer(timeToLogout);
 			}
 		}
 		else
@@ -300,12 +295,17 @@ public class IdleNotifierPlugin extends Plugin
 			Duration timeToLogout = durationTillLogout();
 			infoBoxManager.removeIf(t -> t instanceof IdleTimer);
 			timerRendered = false;
-			if (timeToLogout.compareTo(Duration.ofSeconds(config.getTimerThreshold())) < 0)
-			{
-				IdleTimer timer = new IdleTimer(spriteManager.getSprite(SpriteID.RS2_TAB_LOGOUT, 0), this, timeToLogout);
-				infoBoxManager.addInfoBox(timer);
-				timerRendered = true;
-			}
+			renderIdleTimer(timeToLogout);
+		}
+	}
+
+	private void renderIdleTimer(Duration timeToLogout)
+	{
+		if (timeToLogout.compareTo(Duration.ofSeconds(config.getTimerThreshold())) < 0)
+		{
+			IdleTimer timer = new IdleTimer(spriteManager.getSprite(SpriteID.RS2_TAB_LOGOUT, 0), this, timeToLogout);
+			infoBoxManager.addInfoBox(timer);
+			timerRendered = true;
 		}
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleTimer.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleTimer.java
@@ -24,16 +24,16 @@
  */
 package net.runelite.client.plugins.idlenotifier;
 
-import net.runelite.client.plugins.Plugin;
-import net.runelite.client.ui.overlay.infobox.Timer;
-
 import java.awt.image.BufferedImage;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.ui.overlay.infobox.Timer;
 
 class IdleTimer extends Timer
 {
-    IdleTimer(BufferedImage infoImage, Plugin plugin, Duration seconds){
-        super(seconds.toMillis(), ChronoUnit.MILLIS, infoImage, plugin);
-    }
+	IdleTimer(BufferedImage infoImage, Plugin plugin, Duration seconds)
+	{
+		super(seconds.toMillis(), ChronoUnit.MILLIS, infoImage, plugin);
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleTimer.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleTimer.java
@@ -1,3 +1,27 @@
+/*
+ * Copyright (c) 2018, Nathen Sample <https://github.com/nathensample>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package net.runelite.client.plugins.idlenotifier;
 
 import net.runelite.client.plugins.Plugin;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleTimer.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleTimer.java
@@ -1,0 +1,14 @@
+package net.runelite.client.plugins.idlenotifier;
+
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.ui.overlay.infobox.Timer;
+
+import java.awt.image.BufferedImage;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+
+class IdleTimer extends Timer {
+    IdleTimer(BufferedImage infoImage, Plugin plugin, Duration seconds){
+        super(seconds.toMillis(), ChronoUnit.MILLIS, infoImage, plugin);
+    }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleTimer.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleTimer.java
@@ -7,7 +7,8 @@ import java.awt.image.BufferedImage;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 
-class IdleTimer extends Timer {
+class IdleTimer extends Timer
+{
     IdleTimer(BufferedImage infoImage, Plugin plugin, Duration seconds){
         super(seconds.toMillis(), ChronoUnit.MILLIS, infoImage, plugin);
     }


### PR DESCRIPTION
Exposes a configuration option to enable a overlay utilising the logout door sprite, with a timer representing MM:SS until logout due to idle.

Also has an option for `seconds until logout` representing the time at which the plugin should render the overlay.

Revisions to name and description of the configuration options highly appreciated, because I can't word things to save my life apparently.

![runelite_2018-06-19_23-40-01](https://user-images.githubusercontent.com/9803552/41629352-f4a5c09e-7420-11e8-977a-f9625e9db41b.png)
