### PR TITLE
Adds a chat message that shows the layout when starting the raid

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsConfig.java
@@ -81,6 +81,17 @@ public interface RaidsConfig extends Config
 
 	@ConfigItem(
 		position = 4,
+		keyName = "layoutChatMsg",
+		name = "Show layout in chat on raid start",
+		description = "Shows the raid layout in chat when starting the raid, similarly to the overlay."
+	)
+	default boolean layoutChatMsg()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		position = 5,
 		keyName = "whitelistedRooms",
 		name = "Whitelisted rooms",
 		description = "Display whitelisted rooms in green on the overlay. Separate with comma (full name)"
@@ -91,7 +102,7 @@ public interface RaidsConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 5,
+		position = 6,
 		keyName = "blacklistedRooms",
 		name = "Blacklisted rooms",
 		description = "Display blacklisted rooms in red on the overlay. Separate with comma (full name)"
@@ -102,7 +113,7 @@ public interface RaidsConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 6,
+		position = 7,
 		keyName = "enableRotationWhitelist",
 		name = "Enable rotation whitelist",
 		description = "Enable the rotation whitelist"
@@ -113,7 +124,7 @@ public interface RaidsConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 7,
+		position = 8,
 		keyName = "whitelistedRotations",
 		name = "Whitelisted rotations",
 		description = "Warn when boss rotation doesn't match a whitelisted one. Add rotations like [tekton, muttadile, guardians]"
@@ -124,7 +135,7 @@ public interface RaidsConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 8,
+		position = 9,
 		keyName = "enableLayoutWhitelist",
 		name = "Enable layout whitelist",
 		description = "Enable the layout whitelist"
@@ -135,7 +146,7 @@ public interface RaidsConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 9,
+		position = 10,
 		keyName = "whitelistedLayouts",
 		name = "Whitelisted layouts",
 		description = "Warn when layout doesn't match a whitelisted one. Add layouts like CFSCPPCSCF separated with comma"

--- a/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsConfig.java
@@ -81,17 +81,28 @@ public interface RaidsConfig extends Config
 
 	@ConfigItem(
 		position = 4,
-		keyName = "layoutChatMsg",
+		keyName = "layoutChatMsgOnEnter",
+		name = "Show layout in chat",
+		description = "Shows the raid layout in chat when entering the raid, similarly to the overlay."
+	)
+	default boolean layoutChatMsgOnEnter()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		position = 5,
+		keyName = "layoutChatMsgOnStart",
 		name = "Show layout in chat on raid start",
 		description = "Shows the raid layout in chat when starting the raid, similarly to the overlay."
 	)
-	default boolean layoutChatMsg()
+	default boolean layoutChatMsgOnStart()
 	{
 		return true;
 	}
 
 	@ConfigItem(
-		position = 5,
+		position = 6,
 		keyName = "whitelistedRooms",
 		name = "Whitelisted rooms",
 		description = "Display whitelisted rooms in green on the overlay. Separate with comma (full name)"
@@ -102,7 +113,7 @@ public interface RaidsConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 6,
+		position = 7,
 		keyName = "blacklistedRooms",
 		name = "Blacklisted rooms",
 		description = "Display blacklisted rooms in red on the overlay. Separate with comma (full name)"
@@ -113,7 +124,7 @@ public interface RaidsConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 7,
+		position = 8,
 		keyName = "enableRotationWhitelist",
 		name = "Enable rotation whitelist",
 		description = "Enable the rotation whitelist"
@@ -124,7 +135,7 @@ public interface RaidsConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 8,
+		position = 9,
 		keyName = "whitelistedRotations",
 		name = "Whitelisted rotations",
 		description = "Warn when boss rotation doesn't match a whitelisted one. Add rotations like [tekton, muttadile, guardians]"
@@ -135,7 +146,7 @@ public interface RaidsConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 9,
+		position = 10,
 		keyName = "enableLayoutWhitelist",
 		name = "Enable layout whitelist",
 		description = "Enable the layout whitelist"
@@ -146,7 +157,7 @@ public interface RaidsConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 10,
+		position = 11,
 		keyName = "whitelistedLayouts",
 		name = "Whitelisted layouts",
 		description = "Warn when layout doesn't match a whitelisted one. Add layouts like CFSCPPCSCF separated with comma"

--- a/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsPlugin.java
@@ -1,5 +1,7 @@
 /*
- * Copyright (c) 2018, Kamiel, Matsyir, Jasper-ketelaar
+ * Copyright (c) 2018, Kamiel
+ * Copyright (c) 2018, Matsyir
+ * Copyright (c) 2018, Jasper-ketelaar
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
![image](https://i.imgur.com/yuj4jEO.png)
Little QOL for Chambers of Xeric so you can keep track of the rotation and know what's next. I usually write it in the chat but this is a bit better. I tested it on 20+ raids like in the picture, writing the rotations beforehand. Included a toggle which is default to on. I'm not a big fan of the text color either but it's to keep it consistent with the rest of the raid's text, and it will contrast with the regular game text once you actually start doing stuff.