### PR TITLE
Fix NPC indicators to not consume tags clicks on non-NPCs

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsPlugin.java
@@ -26,6 +26,7 @@
 package net.runelite.client.plugins.npchighlight;
 
 import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableList;
 import com.google.common.eventbus.Subscribe;
 import com.google.inject.Provides;
 import java.time.Instant;
@@ -44,6 +45,7 @@ import net.runelite.api.Client;
 import net.runelite.api.GameState;
 import net.runelite.api.GraphicID;
 import net.runelite.api.GraphicsObject;
+import net.runelite.api.MenuAction;
 import net.runelite.api.NPC;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.ConfigChanged;
@@ -70,6 +72,9 @@ public class NpcIndicatorsPlugin extends Plugin
 
 	// Option added to NPC menu
 	private static final String TAG = "Tag";
+
+	private static final List<MenuAction> NPC_MENU_ACTIONS = ImmutableList.of(MenuAction.NPC_FIRST_OPTION, MenuAction.NPC_SECOND_OPTION,
+		MenuAction.NPC_THIRD_OPTION, MenuAction.NPC_FOURTH_OPTION, MenuAction.NPC_FIFTH_OPTION);
 
 	// Regex for splitting the hidden items in the config.
 	private static final Splitter COMMA_SPLITTER = Splitter.on(Pattern.compile("\\s*,\\s*")).trimResults();
@@ -238,12 +243,15 @@ public class NpcIndicatorsPlugin extends Plugin
 	}
 
 	@Subscribe
-	public void onMenuObjectClicked(MenuOptionClicked click)
+	public void onMenuOptionClicked(MenuOptionClicked click)
 	{
-		if (click.getMenuOption().equals(TAG))
+		if (!config.isTagEnabled())
 		{
-			click.consume();
+			return;
+		}
 
+		if (click.getMenuOption().equals(TAG) && NPC_MENU_ACTIONS.contains(click.getMenuAction()))
+		{
 			final int id = click.getId();
 			final boolean removed = npcTags.remove(id);
 			final NPC[] cachedNPCs = client.getCachedNPCs();
@@ -262,6 +270,8 @@ public class NpcIndicatorsPlugin extends Plugin
 					npcTags.add(id);
 					highlightedNpcs.add(npc);
 				}
+
+				click.consume();
 			}
 		}
 	}


### PR DESCRIPTION
Fix an issue introduced by #3778 that would prevent the player from clicking the "Tag" option on pillars in the pinball random event.