### PR TITLE
Revert "kourendlibrary: Hide navbutton when not in the library"

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/kourendlibrary/KourendLibraryOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/kourendlibrary/KourendLibraryOverlay.java
@@ -53,6 +53,7 @@ public class KourendLibraryOverlay extends Overlay
 {
 	private final static WorldPoint LIBRARY_CENTER = new WorldPoint(1632, 3807, 1);
 	private final static int MAXIMUM_DISTANCE = 24;
+	private final static int ROUGH_ENABLE_DISTANCE = 45;
 
 	private final Library library;
 	private final Client client;
@@ -78,7 +79,7 @@ public class KourendLibraryOverlay extends Overlay
 
 		WorldPoint playerLoc = player.getWorldLocation();
 
-		if (playerLoc.getRegionID() != KourendLibraryPlugin.REGION)
+		if (playerLoc.distanceTo2D(LIBRARY_CENTER) > ROUGH_ENABLE_DISTANCE)
 		{
 			return null;
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/kourendlibrary/KourendLibraryPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/kourendlibrary/KourendLibraryPlugin.java
@@ -30,7 +30,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.imageio.ImageIO;
 import javax.inject.Inject;
-import javax.swing.SwingUtilities;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.AnimationID;
 import net.runelite.api.ChatMessageType;
@@ -56,8 +55,6 @@ import net.runelite.client.ui.overlay.OverlayManager;
 @Slf4j
 public class KourendLibraryPlugin extends Plugin
 {
-	final static int REGION = 6459;
-
 	final static boolean debug = false;
 
 	@Inject
@@ -80,7 +77,6 @@ public class KourendLibraryPlugin extends Plugin
 
 	private KourendLibraryPanel panel;
 	private NavigationButton navButton;
-	private boolean buttonAttached = false;
 
 	private WorldPoint lastBookcaseClick = null;
 	private WorldPoint lastBookcaseAnimatedOn = null;
@@ -106,13 +102,14 @@ public class KourendLibraryPlugin extends Plugin
 			.icon(icon)
 			.panel(panel)
 			.build();
+
+		pluginToolbar.addNavigation(navButton);
 	}
 
 	@Override
 	protected void shutDown()
 	{
 		overlayManager.remove(overlay);
-
 		pluginToolbar.removeNavigation(navButton);
 	}
 
@@ -154,28 +151,6 @@ public class KourendLibraryPlugin extends Plugin
 	@Subscribe
 	void onTick(GameTick tick)
 	{
-		boolean inRegion = client.getLocalPlayer().getWorldLocation().getRegionID() == REGION;
-		if (inRegion != buttonAttached)
-		{
-			SwingUtilities.invokeLater(() ->
-			{
-				if (inRegion)
-				{
-					pluginToolbar.addNavigation(navButton);
-				}
-				else
-				{
-					pluginToolbar.removeNavigation(navButton);
-				}
-			});
-			buttonAttached = inRegion;
-		}
-
-		if (!inRegion)
-		{
-			return;
-		}
-
 		if (lastBookcaseAnimatedOn != null)
 		{
 			Widget find = client.getWidget(WidgetInfo.DIALOG_SPRITE_SPRITE);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/kourendlibrary/KourendLibraryPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/kourendlibrary/KourendLibraryPlugin.java
@@ -50,7 +50,8 @@ import net.runelite.client.ui.PluginToolbar;
 import net.runelite.client.ui.overlay.OverlayManager;
 
 @PluginDescriptor(
-	name = "Kourend Library"
+	name = "Kourend Library",
+	enabledByDefault = false
 )
 @Slf4j
 public class KourendLibraryPlugin extends Plugin


### PR DESCRIPTION
Ironmen were using the tab being visible when not being at the library when doing the "Woox method". If people don't use the panel they can simply turn off the plugin.
Also, set the plugin to be disabled by default.

This reverts commit 64b9b7a1686c150249a9a3c17fe81c77e24e1e07.

Fixes #3929 