### PR TITLE
Feature implementation for request #2593: Add customization of flash notifications.

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/Notifier.java
+++ b/runelite-client/src/main/java/net/runelite/client/Notifier.java
@@ -63,7 +63,7 @@ public class Notifier
 		.build();
 
 	// Notifier properties
-	private static final Color FLASH_COLOR = new Color(255, 0, 0, 70);
+	public static final Color FLASH_COLOR = new Color(255, 0, 0, 70);
 	private static final int FLASH_DURATION = 2000;
 	private static final String MESSAGE_COLOR = "FF0000";
 
@@ -74,6 +74,7 @@ public class Notifier
 	private final ScheduledExecutorService executorService;
 	private final Path notifyIconPath;
 	private Instant flashStart;
+	private Color flashColor = FLASH_COLOR;
 
 	@Inject
 	private Notifier(
@@ -94,10 +95,17 @@ public class Notifier
 
 	public void notify(String message)
 	{
-		notify(message, TrayIcon.MessageType.NONE);
+		notify(message, TrayIcon.MessageType.NONE, FLASH_COLOR);
 	}
-
+	public void notify(String message, Color color)
+	{
+		notify(message, TrayIcon.MessageType.NONE, color);
+	}
 	public void notify(String message, TrayIcon.MessageType type)
+	{
+		notify(message, type, FLASH_COLOR);
+	}
+	public void notify(String message, TrayIcon.MessageType type, Color color)
 	{
 		final ClientUI clientUI = this.clientUI.get();
 
@@ -140,6 +148,7 @@ public class Notifier
 		if (runeLiteConfig.enableFlashNotification())
 		{
 			flashStart = Instant.now();
+			flashColor = new Color(color.getRed(), color.getGreen(), color.getBlue(), 70);
 		}
 	}
 
@@ -158,13 +167,14 @@ public class Notifier
 		}
 
 		final Color color = graphics.getColor();
-		graphics.setColor(FLASH_COLOR);
+		graphics.setColor(flashColor);
 		graphics.fill(new Rectangle(client.getCanvas().getSize()));
 		graphics.setColor(color);
 
 		if (Instant.now().minusMillis(FLASH_DURATION).isAfter(flashStart))
 		{
 			flashStart = null;
+			flashColor = FLASH_COLOR;
 		}
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierConfig.java
@@ -24,6 +24,8 @@
  */
 package net.runelite.client.plugins.idlenotifier;
 
+import java.awt.Color;
+import net.runelite.client.Notifier;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
@@ -88,5 +90,60 @@ public interface IdleNotifierConfig extends Config
 	default int getPrayerThreshold()
 	{
 		return 0;
+	}
+
+	@ConfigItem(
+		keyName = "animationidleflashcolor",
+		name = "Idle Animation Color",
+		description = "Color of flash notification after the player is idle",
+		position = 6
+	)
+	default Color getAnimationIdleFlashColor()
+	{
+		return Notifier.FLASH_COLOR;
+	}
+
+	@ConfigItem(
+		keyName = "logoutidleflashcolor",
+		name = "Idle Logout Color",
+		description = "Color of flash notification when the player is about to be logged out",
+		position = 6
+	)
+	default Color getLogoutIdleFlashColor()
+	{
+		return Notifier.FLASH_COLOR;
+	}
+
+	@ConfigItem(
+		keyName = "combatidleflashcolor",
+		name = "Combat Idle Color",
+		description = "Color of flash notification after the player is out of combat",
+		position = 8
+	)
+	default Color getCombatIdleFlashColor()
+	{
+		return Notifier.FLASH_COLOR;
+	}
+
+	@ConfigItem(
+		keyName = "hitpointsflashcolor",
+		name = "Hitpoints Color",
+		description = "Color of flash notification after hitpoints reach the threshold",
+		position = 9
+	)
+	default Color getHitpointsFlashColor()
+	{
+		return Notifier.FLASH_COLOR;
+	}
+
+	@ConfigItem(
+		keyName = "prayerflashcolor",
+		name = "Prayer Color",
+		description = "Color of flash notification after prayer points reach the threshold",
+		position = 10
+	)
+	default Color getPrayerFlashColor()
+	{
+		return Notifier.FLASH_COLOR;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
@@ -27,6 +27,7 @@ package net.runelite.client.plugins.idlenotifier;
 
 import com.google.common.eventbus.Subscribe;
 import com.google.inject.Provides;
+import java.awt.Color;
 import java.time.Duration;
 import java.time.Instant;
 import javax.inject.Inject;
@@ -221,6 +222,11 @@ public class IdleNotifierPlugin extends Plugin
 	{
 		final Player local = client.getLocalPlayer();
 		final Duration waitDuration = Duration.ofMillis(config.getIdleNotificationDelay());
+		final Color animationIdleColor = config.getAnimationIdleFlashColor();
+		final Color logoutIdleColor = config.getLogoutIdleFlashColor();
+		final Color combatIdleColor = config.getCombatIdleFlashColor();
+		final Color hitpointsColor = config.getHitpointsFlashColor();
+		final Color prayerColor = config.getPrayerFlashColor();
 
 		if (client.getGameState() != GameState.LOGGED_IN || local == null)
 		{
@@ -229,32 +235,32 @@ public class IdleNotifierPlugin extends Plugin
 
 		if (checkIdleLogout())
 		{
-			notifier.notify("[" + local.getName() + "] is about to log out from idling too long!");
+			notifier.notify("[" + local.getName() + "] is about to log out from idling too long!", logoutIdleColor);
 		}
 
 		if (check6hrLogout())
 		{
-			notifier.notify("[" + local.getName() + "] is about to log out from being online for 6 hours!");
+			notifier.notify("[" + local.getName() + "] is about to log out from being online for 6 hours!", logoutIdleColor);
 		}
 
 		if (config.animationIdle() && checkAnimationIdle(waitDuration, local))
 		{
-			notifier.notify("[" + local.getName() + "] is now idle!");
+			notifier.notify("[" + local.getName() + "] is now idle!", animationIdleColor);
 		}
 
 		if (config.combatIdle() && checkOutOfCombat(waitDuration, local))
 		{
-			notifier.notify("[" + local.getName() + "] is now out of combat!");
+			notifier.notify("[" + local.getName() + "] is now out of combat!", combatIdleColor);
 		}
 
 		if (checkLowHitpoints())
 		{
-			notifier.notify("[" + local.getName() + "] has low hitpoints!");
+			notifier.notify("[" + local.getName() + "] has low hitpoints!", hitpointsColor);
 		}
 
 		if (checkLowPrayer())
 		{
-			notifier.notify("[" + local.getName() + "] has low prayer!");
+			notifier.notify("[" + local.getName() + "] has low prayer!", prayerColor);
 		}
 	}
 


### PR DESCRIPTION
![](https://i.imgur.com/NGHOrE3.png)

References issue: #2593 
Added optional argument to Notifier.notify to be able to pass in a color that will override the default flash notification color.
Added color picker options to the Idle Notifier plugin for animation idle, logout idle, combat idle, low health, and low prayer.