### PR TITLE
Remove age menu entry swap, move shift-click to the top

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -235,17 +235,6 @@ public interface MenuEntrySwapperConfig extends Config
 
 	@ConfigItem(
 		position = 18,
-		keyName = "swapAge",
-		name = "Age",
-		description = "Swap Talk-to with Age for Hans"
-	)
-	default boolean swapAge()
-	{
-		return true;
-	}
-
-	@ConfigItem(
-		position = 19,
 		keyName = "swapAssignment",
 		name = "Assignment",
 		description = "Swap Talk-to with Assignment for Slayer Masters. This will take priority over swapping Trade."

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -37,6 +37,17 @@ public interface MenuEntrySwapperConfig extends Config
 {
 	@ConfigItem(
 		position = 0,
+		keyName = "shiftClickCustomization",
+		name = "Customizable shift-click",
+		description = "Allows customization of shift-clicks on items"
+	)
+	default boolean shiftClickCustomization()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		position = 1,
 		keyName = "swapBanker",
 		name = "Bank",
 		description = "Swap Talk-to with Bank on Bank NPC<br>Example: Banker"
@@ -47,7 +58,7 @@ public interface MenuEntrySwapperConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 1,
+		position = 2,
 		keyName = "swapBirdhouseEmpty",
 		name = "Birdhouse",
 		description = "Swap Interact with Empty for birdhouses on Fossil Island"
@@ -58,7 +69,7 @@ public interface MenuEntrySwapperConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 2,
+		position = 3,
 		keyName = "swapBones",
 		name = "Bury",
 		description = "Swap Bury with Use on Bones"
@@ -69,7 +80,7 @@ public interface MenuEntrySwapperConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 3,
+		position = 4,
 		keyName = "swapCatacombEntrance",
 		name = "Catacomb entrance",
 		description = "Swap Read with Investigate on Catacombs of Kourend entrance"
@@ -80,7 +91,7 @@ public interface MenuEntrySwapperConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 4,
+		position = 5,
 		keyName = "swapChase",
 		name = "Chase",
 		description = "Allows to left click your cat to chase"
@@ -91,23 +102,12 @@ public interface MenuEntrySwapperConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 5,
+		position = 6,
 		keyName = "claimSlime",
 		name = "Claim Slime",
 		description = "Swap Talk-to with Claim Slime from Morytania diaries"
 	)
 	default boolean claimSlime()
-	{
-		return true;
-	}
-
-	@ConfigItem(
-		position = 6,
-		keyName = "shiftClickCustomization",
-		name = "Customizable shift-click",
-		description = "Allows customization of shift-clicks on items"
-	)
-	default boolean shiftClickCustomization()
 	{
 		return true;
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -385,11 +385,6 @@ public class MenuEntrySwapperPlugin extends Plugin
 			{
 				swap("pay", option, target, true);
 			}
-
-			if (config.swapAge())
-			{
-				swap("age", option, target, true);
-			}
 		}
 		else if (config.swapTravel() && option.equals("pass") && target.equals("energy barrier"))
 		{


### PR DESCRIPTION
## Move shift-click config to top of menu swapper

This should be clearly separated from other options and be priority at
the top.

## Remove Age menu entry swapping

This feature is mostly unnecessary as it is way too spefic and with very
little use.
