### PR TITLE
Slayer overlay items refresh on render

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerOverlay.java
@@ -34,8 +34,11 @@ import java.awt.Rectangle;
 import java.util.Collection;
 import java.util.Set;
 import javax.inject.Inject;
+
+import com.google.common.eventbus.Subscribe;
 import net.runelite.api.ItemID;
 import net.runelite.api.Query;
+import net.runelite.api.events.ItemContainerChanged;
 import net.runelite.api.queries.EquipmentItemQuery;
 import net.runelite.api.queries.InventoryWidgetItemQuery;
 import net.runelite.api.widgets.WidgetInfo;
@@ -51,7 +54,7 @@ class SlayerOverlay extends Overlay
 {
 	private final SlayerConfig config;
 	private final SlayerPlugin plugin;
-        
+	private Collection<WidgetItem> items;
 	@Inject
 	private QueryRunner queryRunner;
 
@@ -86,8 +89,8 @@ class SlayerOverlay extends Overlay
 		ItemID.EXPEDITIOUS_BRACELET
 	);
 
-        private ImmutableList<WidgetItem> checkInventory()
-        {    
+	private ImmutableList<WidgetItem> checkInventory()
+	{
 		Query inventoryQuery = new InventoryWidgetItemQuery();
 		WidgetItem[] inventoryWidgetItems = queryRunner.runQuery(inventoryQuery);
 
@@ -96,8 +99,14 @@ class SlayerOverlay extends Overlay
 
 		WidgetItem[] items = concat(inventoryWidgetItems, equipmentWidgetItems, WidgetItem.class);
 		return ImmutableList.copyOf(items);
-        }
-        
+	}
+
+	@Subscribe
+	public void onItemContainerChanged(ItemContainerChanged event)
+	{
+		items = checkInventory();
+	}
+
 	@Inject
 	private SlayerOverlay(SlayerPlugin plugin, SlayerConfig config)
 	{
@@ -126,7 +135,6 @@ class SlayerOverlay extends Overlay
 
 		graphics.setFont(FontManager.getRunescapeSmallFont());
 
-		Collection<WidgetItem> items = checkInventory();
 		for (WidgetItem item : items)
 		{
 			int itemId = item.getId();

--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerOverlay.java
@@ -31,14 +31,10 @@ import java.awt.Dimension;
 import java.awt.Graphics2D;
 import java.awt.Point;
 import java.awt.Rectangle;
-import java.util.Collection;
 import java.util.Set;
 import javax.inject.Inject;
-
-import com.google.common.eventbus.Subscribe;
 import net.runelite.api.ItemID;
 import net.runelite.api.Query;
-import net.runelite.api.events.ItemContainerChanged;
 import net.runelite.api.queries.EquipmentItemQuery;
 import net.runelite.api.queries.InventoryWidgetItemQuery;
 import net.runelite.api.widgets.WidgetInfo;
@@ -54,7 +50,7 @@ class SlayerOverlay extends Overlay
 {
 	private final SlayerConfig config;
 	private final SlayerPlugin plugin;
-	private Collection<WidgetItem> items;
+
 	@Inject
 	private QueryRunner queryRunner;
 
@@ -101,12 +97,6 @@ class SlayerOverlay extends Overlay
 		return ImmutableList.copyOf(items);
 	}
 
-	@Subscribe
-	public void onItemContainerChanged(ItemContainerChanged event)
-	{
-		items = checkInventory();
-	}
-
 	@Inject
 	private SlayerOverlay(SlayerPlugin plugin, SlayerConfig config)
 	{
@@ -135,7 +125,7 @@ class SlayerOverlay extends Overlay
 
 		graphics.setFont(FontManager.getRunescapeSmallFont());
 
-		for (WidgetItem item : items)
+		for (WidgetItem item : checkInventory())
 		{
 			int itemId = item.getId();
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerOverlay.java
@@ -24,7 +24,9 @@
  */
 package net.runelite.client.plugins.slayer;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import static com.google.common.collect.ObjectArrays.concat;
 import java.awt.Dimension;
 import java.awt.Graphics2D;
 import java.awt.Point;
@@ -33,17 +35,25 @@ import java.util.Collection;
 import java.util.Set;
 import javax.inject.Inject;
 import net.runelite.api.ItemID;
+import net.runelite.api.Query;
+import net.runelite.api.queries.EquipmentItemQuery;
+import net.runelite.api.queries.InventoryWidgetItemQuery;
+import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.api.widgets.WidgetItem;
 import net.runelite.client.ui.FontManager;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.components.TextComponent;
+import net.runelite.client.util.QueryRunner;
 
 class SlayerOverlay extends Overlay
 {
 	private final SlayerConfig config;
 	private final SlayerPlugin plugin;
+        
+	@Inject
+	private QueryRunner queryRunner;
 
 	private final Set<Integer> slayerJewelry = ImmutableSet.of(
 		ItemID.SLAYER_RING_1,
@@ -76,6 +86,18 @@ class SlayerOverlay extends Overlay
 		ItemID.EXPEDITIOUS_BRACELET
 	);
 
+        private ImmutableList<WidgetItem> checkInventory()
+        {    
+		Query inventoryQuery = new InventoryWidgetItemQuery();
+		WidgetItem[] inventoryWidgetItems = queryRunner.runQuery(inventoryQuery);
+
+		Query equipmentQuery = new EquipmentItemQuery().slotEquals(WidgetInfo.EQUIPMENT_HELMET, WidgetInfo.EQUIPMENT_RING, WidgetInfo.EQUIPMENT_GLOVES);
+		WidgetItem[] equipmentWidgetItems = queryRunner.runQuery(equipmentQuery);
+
+		WidgetItem[] items = concat(inventoryWidgetItems, equipmentWidgetItems, WidgetItem.class);
+		return ImmutableList.copyOf(items);
+        }
+        
 	@Inject
 	private SlayerOverlay(SlayerPlugin plugin, SlayerConfig config)
 	{
@@ -104,7 +126,7 @@ class SlayerOverlay extends Overlay
 
 		graphics.setFont(FontManager.getRunescapeSmallFont());
 
-		Collection<WidgetItem> items = plugin.getSlayerItems();
+		Collection<WidgetItem> items = checkInventory();
 		for (WidgetItem item : items)
 		{
 			int itemId = item.getId();

--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerPlugin.java
@@ -131,9 +131,6 @@ public class SlayerPlugin extends Plugin
 	private ClientThread clientThread;
 
 	@Inject
-	private QueryRunner queryRunner;
-
-	@Inject
 	private TargetClickboxOverlay targetClickboxOverlay;
 
 	@Inject
@@ -141,9 +138,6 @@ public class SlayerPlugin extends Plugin
 
 	@Getter(AccessLevel.PACKAGE)
 	private List<NPC> highlightedTargets = new ArrayList<>();
-
-	@Getter(AccessLevel.PACKAGE)
-	private Collection<WidgetItem> slayerItems = Collections.emptyList();
 
 	@Getter(AccessLevel.PACKAGE)
 	@Setter(AccessLevel.PACKAGE)
@@ -247,8 +241,6 @@ public class SlayerPlugin extends Plugin
 	@Subscribe
 	public void onGameTick(GameTick tick)
 	{
-		checkInventories();
-
 		Widget NPCDialog = client.getWidget(WidgetInfo.DIALOG_NPC_TEXT);
 		if (NPCDialog != null)
 		{
@@ -317,18 +309,6 @@ public class SlayerPlugin extends Plugin
 		{
 			highlightedTargets.clear();
 		}
-	}
-
-	private void checkInventories()
-	{
-		Query inventoryQuery = new InventoryWidgetItemQuery();
-		WidgetItem[] inventoryWidgetItems = queryRunner.runQuery(inventoryQuery);
-
-		Query equipmentQuery = new EquipmentItemQuery().slotEquals(WidgetInfo.EQUIPMENT_HELMET, WidgetInfo.EQUIPMENT_RING, WidgetInfo.EQUIPMENT_GLOVES);
-		WidgetItem[] equipmentWidgetItems = queryRunner.runQuery(equipmentQuery);
-
-		WidgetItem[] items = concat(inventoryWidgetItems, equipmentWidgetItems, WidgetItem.class);
-		slayerItems = ImmutableList.copyOf(items);
 	}
 
 	@Subscribe

--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerPlugin.java
@@ -25,8 +25,6 @@
  */
 package net.runelite.client.plugins.slayer;
 
-import com.google.common.collect.ImmutableList;
-import static com.google.common.collect.ObjectArrays.concat;
 import com.google.common.eventbus.Subscribe;
 import com.google.inject.Provides;
 import java.awt.image.BufferedImage;
@@ -34,7 +32,6 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -51,18 +48,14 @@ import net.runelite.api.GameState;
 import net.runelite.api.ItemID;
 import net.runelite.api.NPC;
 import net.runelite.api.NPCComposition;
-import net.runelite.api.Query;
 import static net.runelite.api.Skill.SLAYER;
 import net.runelite.api.events.ChatMessage;
 import net.runelite.api.events.ConfigChanged;
 import net.runelite.api.events.ExperienceChanged;
 import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.GameTick;
-import net.runelite.api.queries.EquipmentItemQuery;
-import net.runelite.api.queries.InventoryWidgetItemQuery;
 import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetInfo;
-import net.runelite.api.widgets.WidgetItem;
 import net.runelite.client.Notifier;
 import net.runelite.client.callback.ClientThread;
 import net.runelite.client.config.ConfigManager;
@@ -71,7 +64,6 @@ import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.OverlayManager;
 import net.runelite.client.ui.overlay.infobox.InfoBoxManager;
-import net.runelite.client.util.QueryRunner;
 import net.runelite.client.util.Text;
 
 @PluginDescriptor(


### PR DESCRIPTION
Currently the slayer plugin checks for slayer items on each game tick, which on occasion causes text to be persist longer than expected when swapping between the inventory and equipment instances.
The queries are now run in the render call in the SlayerOverlay class, preventing this issue from occurring.