### PR TITLE
#3911 - Update library plugin encapsulation

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/kourendlibrary/Book.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/kourendlibrary/Book.java
@@ -32,7 +32,7 @@ import net.runelite.api.ItemID;
 import net.runelite.client.game.AsyncBufferedImage;
 import net.runelite.client.game.ItemManager;
 
-public enum Book
+enum Book
 {
 	DARK_MANUSCRIPT_13514(ItemID.DARK_MANUSCRIPT),
 	DARK_MANUSCRIPT_13515(ItemID.DARK_MANUSCRIPT_13515),
@@ -89,12 +89,12 @@ public enum Book
 		return Collections.unmodifiableMap(byName);
 	}
 
-	public static Book byId(int id)
+	static Book byId(int id)
 	{
 		return BY_ID.get(id);
 	}
 
-	public static Book byName(String name)
+	static Book byName(String name)
 	{
 		return BY_NAME.get(name);
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/kourendlibrary/BookPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/kourendlibrary/BookPanel.java
@@ -70,12 +70,12 @@ class BookPanel extends JPanel
 		setComponentZOrder(image, getComponentCount() - 1);
 	}
 
-	public void setLocation(String location)
+	void setLocation(String location)
 	{
 		this.location.setText(location);
 	}
 
-	public void setIsTarget(boolean target)
+	void setIsTarget(boolean target)
 	{
 		location.setForeground(target ? Color.GREEN : Color.WHITE);
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/kourendlibrary/Bookcase.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/kourendlibrary/Bookcase.java
@@ -34,7 +34,7 @@ import net.runelite.api.coords.WorldPoint;
 
 class Bookcase
 {
-	public Bookcase(WorldPoint location)
+	Bookcase(WorldPoint location)
 	{
 		this.location = location;
 		this.index = new ArrayList<>();
@@ -62,19 +62,19 @@ class Bookcase
 	@Getter
 	private Set<Book> possibleBooks = new HashSet<>();
 
-	public void clearBook()
+	void clearBook()
 	{
 		book = null;
 		isBookSet = false;
 	}
 
-	public void setBook(Book book)
+	void setBook(Book book)
 	{
 		this.book = book;
 		this.isBookSet = true;
 	}
 
-	public String getLocationString()
+	String getLocationString()
 	{
 		StringBuilder b = new StringBuilder();
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/kourendlibrary/KourendLibraryOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/kourendlibrary/KourendLibraryOverlay.java
@@ -49,9 +49,8 @@ import net.runelite.client.ui.overlay.OverlayUtil;
 
 import static net.runelite.api.Perspective.getCanvasTilePoly;
 
-public class KourendLibraryOverlay extends Overlay
+class KourendLibraryOverlay extends Overlay
 {
-	private final static WorldPoint LIBRARY_CENTER = new WorldPoint(1632, 3807, 1);
 	private final static int MAXIMUM_DISTANCE = 24;
 
 	private final Library library;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/kourendlibrary/KourendLibraryPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/kourendlibrary/KourendLibraryPanel.java
@@ -55,7 +55,7 @@ import net.runelite.client.ui.PluginPanel;
 import net.runelite.client.util.SwingUtil;
 
 @Singleton
-public class KourendLibraryPanel extends PluginPanel
+class KourendLibraryPanel extends PluginPanel
 {
 	private static final ImageIcon RESET_ICON;
 	private static final ImageIcon RESET_CLICK_ICON;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/kourendlibrary/Library.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/kourendlibrary/Library.java
@@ -57,7 +57,7 @@ import static net.runelite.client.plugins.kourendlibrary.Book.*;
  */
 @Singleton
 @Slf4j
-public class Library
+class Library
 {
 	private final Map<WorldPoint, Bookcase> byPoint = new HashMap<>();
 	private final Map<Integer, ArrayList<Bookcase>> byLevel = new HashMap<>();
@@ -83,23 +83,23 @@ public class Library
 		reset();
 	}
 
-	public synchronized List<Bookcase> getBookcasesOnLevel(int z)
+	synchronized List<Bookcase> getBookcasesOnLevel(int z)
 	{
 		return Collections.unmodifiableList(byLevel.get(z));
 	}
 
-	public synchronized List<Bookcase> getBookcases()
+	synchronized List<Bookcase> getBookcases()
 	{
 		return Collections.unmodifiableList(byIndex);
 	}
 
-	public void setCustomer(LibraryCustomer customer, Book book)
+	void setCustomer(LibraryCustomer customer, Book book)
 	{
 		this.customer = customer;
 		this.customerBook = book;
 	}
 
-	public synchronized void reset()
+	synchronized void reset()
 	{
 		state = SolvedState.NO_DATA;
 		for (Bookcase b : byIndex)
@@ -110,7 +110,7 @@ public class Library
 		log.info("Library is now reset");
 	}
 
-	public synchronized void mark(WorldPoint loc, Book book)
+	synchronized void mark(WorldPoint loc, Book book)
 	{
 		Bookcase bookcase = byPoint.get(loc);
 		if (bookcase == null)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/kourendlibrary/LibraryCustomer.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/kourendlibrary/LibraryCustomer.java
@@ -30,7 +30,7 @@ import lombok.Getter;
 
 import net.runelite.api.NpcID;
 
-public enum LibraryCustomer
+enum LibraryCustomer
 {
 	VILLIA(NpcID.VILLIA, "Villia"),
 	PROFESSOR_GRACKLEBONE(NpcID.PROFESSOR_GRACKLEBONE, "Prof. Gracklebone"),
@@ -50,7 +50,7 @@ public enum LibraryCustomer
 		this.name = name;
 	}
 
-	public static LibraryCustomer getById(int id)
+	static LibraryCustomer getById(int id)
 	{
 		return byId.get(id);
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/kourendlibrary/SolvedState.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/kourendlibrary/SolvedState.java
@@ -24,7 +24,7 @@
  */
 package net.runelite.client.plugins.kourendlibrary;
 
-public enum SolvedState
+enum SolvedState
 {
 	NO_DATA,
 	INCOMPLETE,


### PR DESCRIPTION
Relating to #3911 

Simply reducing public methods/class to package-private to prevent re-use of plugin logic/classes external to the plugin itself

Tested post-change
![development_-_discord_2018-06-23_01-00-36](https://user-images.githubusercontent.com/9803552/41803453-e24706da-7680-11e8-8dab-05f4dc6598c0.png)

