### PR TITLE
Update prayer plugin encapsulation

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/prayer/PrayerCounter.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/prayer/PrayerCounter.java
@@ -28,7 +28,7 @@ import lombok.Getter;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.ui.overlay.infobox.Counter;
 
-public class PrayerCounter extends Counter
+class PrayerCounter extends Counter
 {
 	@Getter
 	private final PrayerType prayerType;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/prayer/PrayerDoseOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/prayer/PrayerDoseOverlay.java
@@ -48,7 +48,7 @@ import net.runelite.client.ui.overlay.tooltip.TooltipManager;
 import net.runelite.client.util.SwingUtil;
 import org.apache.commons.lang3.StringUtils;
 
-public class PrayerDoseOverlay extends Overlay
+class PrayerDoseOverlay extends Overlay
 {
 	private static final float PULSE_TIME = 1200f;
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/prayer/PrayerFlickOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/prayer/PrayerFlickOverlay.java
@@ -46,7 +46,7 @@ class PrayerFlickOverlay extends Overlay
 	private Instant startOfLastTick = Instant.now();
 
 	@Inject
-	PrayerFlickOverlay(Client client)
+	private PrayerFlickOverlay(Client client)
 	{
 		setPosition(OverlayPosition.DYNAMIC);
 		setLayer(OverlayLayer.ABOVE_WIDGETS);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/prayer/PrayerFlickOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/prayer/PrayerFlickOverlay.java
@@ -39,14 +39,14 @@ import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
 
-public class PrayerFlickOverlay extends Overlay
+class PrayerFlickOverlay extends Overlay
 {
 	private final Client client;
 	private boolean prayersActive = false;
 	private Instant startOfLastTick = Instant.now();
 
 	@Inject
-	public PrayerFlickOverlay(Client client)
+	PrayerFlickOverlay(Client client)
 	{
 		setPosition(OverlayPosition.DYNAMIC);
 		setLayer(OverlayLayer.ABOVE_WIDGETS);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/prayer/PrayerItems.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/prayer/PrayerItems.java
@@ -32,7 +32,7 @@ import net.runelite.api.ItemID;
 
 @AllArgsConstructor
 @Getter
-public enum PrayerItems
+enum PrayerItems
 {
 	// Blessings
 	PEACEFUL_BLESSING(ItemID.PEACEFUL_BLESSING, 1),
@@ -453,7 +453,7 @@ public enum PrayerItems
 		}
 	}
 
-	public static int getItemPrayerBonus(int itemId)
+	static int getItemPrayerBonus(int itemId)
 	{
 		Integer value = prayerBonuses.get(itemId);
 		return value == null ? 0 : value;


### PR DESCRIPTION
Relating to #3911

Simply reducing public methods/class to package-private to prevent re-use of plugin logic/classes external to the plugin itself

Tested post-change
Boost Indicator/Overhead indicator
![2018-06-23_01-43-50](https://user-images.githubusercontent.com/9803552/41803952-ee6e6a74-7686-11e8-9abd-07534c070e9a.gif)

Flick Helper
![2018-06-23_01-44-49](https://user-images.githubusercontent.com/9803552/41803960-10e4e9f2-7687-11e8-83de-52fd1dbd08d0.gif)

Dose Indicator
![runelite_2018-06-23_01-45-37](https://user-images.githubusercontent.com/9803552/41803969-27b9db10-7687-11e8-8022-19041e8862dd.png)

prayer stats
![2018-06-23_01-46-26](https://user-images.githubusercontent.com/9803552/41803973-42b32836-7687-11e8-9301-2d90291ade2b.gif)


