### PR TITLE
Add inventory viewer plugin

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/inventoryviewer/InventoryViewerOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/inventoryviewer/InventoryViewerOverlay.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2018 AWPH-I
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.inventoryviewer;
+
+import java.awt.Dimension;
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+import javax.inject.Inject;
+import net.runelite.api.Client;
+import net.runelite.api.InventoryID;
+import net.runelite.api.Item;
+import net.runelite.api.ItemContainer;
+import net.runelite.client.game.ItemManager;
+import net.runelite.client.ui.overlay.Overlay;
+import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.components.ImageComponent;
+import net.runelite.client.ui.overlay.components.PanelComponent;
+
+class InventoryViewerOverlay extends Overlay
+{
+	private static final int INVENTORY_SIZE = 28;
+	private static final int PLACEHOLDER_WIDTH = 36;
+	private static final int PLACEHOLDER_HEIGHT = 32;
+	private static final ImageComponent PLACEHOLDER_IMAGE = new ImageComponent(new BufferedImage(PLACEHOLDER_WIDTH, PLACEHOLDER_HEIGHT, BufferedImage.TYPE_4BYTE_ABGR));
+
+	private final Client client;
+	private final ItemManager itemManager;
+
+	private final PanelComponent panelComponent = new PanelComponent();
+
+	@Inject
+	private InventoryViewerOverlay(Client client, ItemManager itemManager)
+	{
+		setPosition(OverlayPosition.BOTTOM_RIGHT);
+		panelComponent.setWrapping(4);
+		panelComponent.setOrientation(PanelComponent.Orientation.HORIZONTAL);
+		this.itemManager = itemManager;
+		this.client = client;
+	}
+
+	@Override
+	public Dimension render(Graphics2D graphics)
+	{
+		final ItemContainer itemContainer = client.getItemContainer(InventoryID.INVENTORY);
+
+		if (itemContainer == null)
+		{
+			return null;
+		}
+
+		panelComponent.getChildren().clear();
+
+		final Item[] items = itemContainer.getItems();
+
+		for (int i = 0; i < INVENTORY_SIZE; i++)
+		{
+			if (i < items.length)
+			{
+				final Item item = items[i];
+				if (item.getQuantity() > 0)
+				{
+					final BufferedImage image = getImage(item);
+					if (image != null)
+					{
+						panelComponent.getChildren().add(new ImageComponent(image));
+						continue;
+					}
+				}
+			}
+
+			// put a placeholder image so each item is aligned properly and the panel is not resized
+			panelComponent.getChildren().add(PLACEHOLDER_IMAGE);
+		}
+
+		return panelComponent.render(graphics);
+	}
+
+	private BufferedImage getImage(Item item)
+	{
+		return itemManager.getImage(item.getId(), item.getQuantity(), item.getQuantity() > 1);
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/inventoryviewer/InventoryViewerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/inventoryviewer/InventoryViewerPlugin.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2018 AWPH-I
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.inventoryviewer;
+
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginDescriptor;
+import javax.inject.Inject;
+import net.runelite.client.ui.overlay.OverlayManager;
+
+@PluginDescriptor(
+	name = "Inventory Viewer",
+	enabledByDefault = false
+)
+public class InventoryViewerPlugin extends Plugin
+{
+	@Inject
+	private InventoryViewerOverlay overlay;
+
+	@Inject
+	private OverlayManager overlayManager;
+
+	@Override
+	public void startUp()
+	{
+		overlayManager.add(overlay);
+	}
+
+	@Override
+	public void shutDown()
+	{
+		overlayManager.remove(overlay);
+	}
+}


### PR DESCRIPTION
This a rebase of the inventory viewer due to inactivity.

This also has some code changes, such as exiting early if the item container is null. If there was a reason to always show the panel, I can change it back and add a comment to the code.

This undoes the changes made to the panel component. That should be in a separate PR IMO, if people want it.

[Here](https://github.com/runelite/runelite/blob/279d2e3ca56c606e3bbcfb9faf27da7e08dc325f/runelite-client/src/main/java/net/runelite/client/plugins/inventoryviewer/InventoryViewerOverlay.java) is the original overlay file for reference.

Screenshots:
![1](https://user-images.githubusercontent.com/2388657/41814407-1eb1ad76-7719-11e8-8145-f39fd37b4483.PNG)
![2](https://user-images.githubusercontent.com/2388657/41814409-210d86a8-7719-11e8-93ae-1c6fec10b72f.png)
![original](https://user-images.githubusercontent.com/26072111/39696063-706f6216-51e4-11e8-9fc8-0c1d85d3f325.png)

Closes #2214