### PR TITLE
slayer plugin: do not show task infobox on login

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerPlugin.java
@@ -228,7 +228,7 @@ public class SlayerPlugin extends Plugin
 				streak = config.streak();
 				setExpeditiousChargeCount(config.expeditious());
 				setSlaughterChargeCount(config.slaughter());
-				clientThread.invoke(() -> setTask(config.taskName(), config.amount(), config.initialAmount(), config.taskLocation()));
+				clientThread.invoke(() -> setTask(config.taskName(), config.amount(), config.initialAmount(), config.taskLocation(), false));
 			}
 		}
 
@@ -277,7 +277,7 @@ public class SlayerPlugin extends Plugin
 					streak = config.streak();
 					setExpeditiousChargeCount(config.expeditious());
 					setSlaughterChargeCount(config.slaughter());
-					setTask(config.taskName(), config.amount(), config.initialAmount(), config.taskLocation());
+					setTask(config.taskName(), config.amount(), config.initialAmount(), config.taskLocation(), false);
 					loginFlag = false;
 				}
 				break;
@@ -559,7 +559,7 @@ public class SlayerPlugin extends Plugin
 	@Subscribe
 	private void onConfigChanged(ConfigChanged event)
 	{
-		if (!event.getGroup().equals("slayer"))
+		if (!event.getGroup().equals("slayer") || !event.getKey().equals("infobox"))
 		{
 			return;
 		}
@@ -675,14 +675,23 @@ public class SlayerPlugin extends Plugin
 
 	private void setTask(String name, int amt, int initAmt, String location)
 	{
+		setTask(name, amt, initAmt, location, true);
+	}
+
+	private void setTask(String name, int amt, int initAmt, String location, boolean addCounter)
+	{
 		taskName = name;
 		amount = amt;
 		initialAmount = initAmt;
 		taskLocation = location;
 		save();
 		removeCounter();
-		addCounter();
-		infoTimer = Instant.now();
+
+		if (addCounter)
+		{
+			infoTimer = Instant.now();
+			addCounter();
+		}
 
 		Task task = Task.getTask(name);
 		rebuildTargetNames(task);

--- a/runelite-client/src/test/java/net/runelite/client/plugins/slayer/SlayerPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/slayer/SlayerPluginTest.java
@@ -33,12 +33,14 @@ import javax.inject.Inject;
 import net.runelite.api.ChatMessageType;
 import static net.runelite.api.ChatMessageType.GAMEMESSAGE;
 import net.runelite.api.Client;
+import net.runelite.api.GameState;
 import net.runelite.api.MessageNode;
 import net.runelite.api.Player;
 import net.runelite.api.Skill;
 import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.events.ChatMessage;
 import net.runelite.api.events.ExperienceChanged;
+import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.GameTick;
 import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetInfo;
@@ -702,5 +704,22 @@ public class SlayerPluginTest
 		slayerPlugin.onExperienceChanged(experienceChanged);
 
 		assertEquals(34, slayerPlugin.getAmount());
+	}
+
+	@Test
+	public void infoboxNotAddedOnLogin()
+	{
+		when(slayerConfig.taskName()).thenReturn(Task.BLOODVELD.getName());
+		when(slayerConfig.showInfobox()).thenReturn(true);
+
+		GameStateChanged loggingIn = new GameStateChanged();
+		loggingIn.setGameState(GameState.LOGGING_IN);
+		slayerPlugin.onGameStateChanged(loggingIn);
+
+		GameStateChanged loggedIn = new GameStateChanged();
+		loggedIn.setGameState(GameState.LOGGED_IN);
+		slayerPlugin.onGameStateChanged(loggedIn);
+
+		verify(infoBoxManager, never()).addInfoBox(any());
 	}
 }


### PR DESCRIPTION
Fixes #3987.

This PR adds a boolean in setTask that specifies whether the method was called by performing an action (e.g checking your slayer gem) or if it was called by logging in/starting up. 

Previously if the user were to log in the Instant used to time out the infobox was set to be current. This caused unwanted behaviour where the infobox would appear for the first five minutes of being logged in eventhough the user had not performed any slayer related actions.