### PR TITLE
runelite-client: Add a equals implementation to Keybind

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/config/Keybind.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/Keybind.java
@@ -28,6 +28,7 @@ import com.google.common.collect.BiMap;
 import com.google.common.collect.ImmutableBiMap;
 import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 /**
@@ -35,6 +36,7 @@ import lombok.Getter;
  * and an optional non-modifier key
  */
 @Getter
+@EqualsAndHashCode
 public class Keybind
 {
 	private static final BiMap<Integer, Integer> modifierToKeyCode = new ImmutableBiMap.Builder<Integer, Integer>()


### PR DESCRIPTION
Without this certain key combos that java doesn't support (fn+fkeys on laptops) are supposed to be hit by the equals check, but ofc they weren't