### PR TITLE
Add "Reset all" to XP tracker plugin

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpInfoBox.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpInfoBox.java
@@ -98,12 +98,17 @@ class XpInfoBox extends JPanel
 		final JMenuItem resetOthers = new JMenuItem("Reset others");
 		resetOthers.addActionListener(e -> xpTrackerPlugin.resetOtherSkillState(skill));
 
+		// Create reset all menu
+		final JMenuItem resetAll = new JMenuItem("Reset all");
+		resetAll.addActionListener(e -> xpTrackerPlugin.resetAllSkillStates());
+
 		// Create popup menu
 		final JPopupMenu popupMenu = new JPopupMenu();
 		popupMenu.setBorder(new EmptyBorder(5, 5, 5, 5));
 		popupMenu.add(openXpTracker);
 		popupMenu.add(reset);
 		popupMenu.add(resetOthers);
+		popupMenu.add(resetAll);
 
 		JLabel skillIcon = new JLabel(new ImageIcon(iconManager.getSkillImage(skill)));
 		skillIcon.setHorizontalAlignment(SwingConstants.CENTER);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerPlugin.java
@@ -256,6 +256,17 @@ public class XpTrackerPlugin extends Plugin
 	}
 
 
+	/**
+	 * Reset all skills
+	 */
+	public void resetAllSkillStates()
+	{
+		for (Skill s : Skill.values())
+		{
+			resetSkillState(s);
+		}
+	}
+
 	@Subscribe
 	public void onXpChanged(ExperienceChanged event)
 	{


### PR DESCRIPTION
Similar to https://github.com/runelite/runelite/pull/3555 but resets everything instead. Useful for tracking exp rates when I'm training combat (which affects multiple skills) and I'm trying to compare different approaches.