### PR TITLE
Add temporary measure to fix the alkharid course.

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/agility/AgilityPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/agility/AgilityPlugin.java
@@ -106,6 +106,7 @@ public class AgilityPlugin extends Plugin
 
 	private int lastAgilityXp;
 	private WorldPoint lastArenaTicketPosition;
+	private boolean pastTightrope;
 
 	@Provides
 	AgilityConfig getConfig(ConfigManager configManager)
@@ -186,6 +187,14 @@ public class AgilityPlugin extends Plugin
 
 		if (session != null && session.getCourse() == course)
 		{
+			//todo track entire course experience instead of just the last obstacle
+			if (course == Courses.AL_KARID) {
+				if (!pastTightrope) {
+					this.pastTightrope = true;
+					return;
+				}
+				this.pastTightrope = false;
+			}
 			session.incrementLapCount(client);
 		}
 		else


### PR DESCRIPTION
Added a temporary fix for the Al Kharid agility course. A better solution would be to check the player has started the lap and then check the total experience gained matches the lap total. This would, however, change the behavior should they run the course after logging in.

Fixes #4020