### PR TITLE
Issue #3960 - Clear freeze/entangle timers on movement

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersPlugin.java
@@ -26,8 +26,8 @@ package net.runelite.client.plugins.timers;
 
 import com.google.common.eventbus.Subscribe;
 import com.google.inject.Provides;
+import java.util.function.Predicate;
 import javax.inject.Inject;
-
 import net.runelite.api.Actor;
 import net.runelite.api.AnimationID;
 import net.runelite.api.ChatMessageType;
@@ -86,33 +86,35 @@ import static net.runelite.client.plugins.timers.GameTimer.SUPERANTIFIRE;
 import static net.runelite.client.plugins.timers.GameTimer.SUPERANTIPOISON;
 import static net.runelite.client.plugins.timers.GameTimer.VENGEANCE;
 import static net.runelite.client.plugins.timers.GameTimer.VENGEANCEOTHER;
-
 import net.runelite.client.ui.overlay.infobox.InfoBox;
 import net.runelite.client.ui.overlay.infobox.InfoBoxManager;
 
-import java.util.function.Predicate;
-
 @PluginDescriptor(
-	name = "Timers"
+		name = "Timers"
 )
 public class TimersPlugin extends Plugin
 {
 	private static final GameTimer[] FREEZE_TIMERS = {
-            BIND, HALFBIND, SNARE, HALFSNARE, ENTANGLE, HALFENTANGLE, ICERUSH, ICEBURST, ICEBLITZ, ICEBARRAGE
-    };
+			BIND, HALFBIND, SNARE, HALFSNARE, ENTANGLE, HALFENTANGLE, ICERUSH, ICEBURST, ICEBLITZ, ICEBARRAGE
+	};
 
-    private static Predicate<InfoBox> isOfTimer(GameTimer... timers) {
-        return t -> {
-            if (t instanceof TimerTimer) {
-                for (GameTimer timer : timers) {
-                    if (timer == ((TimerTimer) t).getTimer()) {
-                        return true;
-                    }
-                }
-            }
-            return false;
-        };
-    }
+	private static Predicate<InfoBox> isOfTimer(GameTimer... timers)
+	{
+		return t ->
+		{
+			if (t instanceof TimerTimer)
+			{
+				for (GameTimer timer : timers)
+				{
+					if (timer == ((TimerTimer) t).getTimer())
+					{
+						return true;
+					}
+				}
+			}
+			return false;
+		};
+	}
 
 	private int lastRaidVarb;
 
@@ -261,11 +263,11 @@ public class TimersPlugin extends Plugin
 	public void onMenuOptionClicked(MenuOptionClicked event)
 	{
 		if (config.showAntidotePlusPlus()
-			&& event.getMenuOption().contains("Drink")
-			&& (event.getId() == ItemID.ANTIDOTE1_5958
-			|| event.getId() == ItemID.ANTIDOTE2_5956
-			|| event.getId() == ItemID.ANTIDOTE3_5954
-			|| event.getId() == ItemID.ANTIDOTE4_5952))
+				&& event.getMenuOption().contains("Drink")
+				&& (event.getId() == ItemID.ANTIDOTE1_5958
+				|| event.getId() == ItemID.ANTIDOTE2_5956
+				|| event.getId() == ItemID.ANTIDOTE3_5954
+				|| event.getId() == ItemID.ANTIDOTE4_5952))
 		{
 			// Needs menu option hook because drink message is intercepting with antipoison message
 			createGameTimer(ANTIDOTEPLUSPLUS);
@@ -273,11 +275,11 @@ public class TimersPlugin extends Plugin
 		}
 
 		if (config.showAntidotePlus()
-			&& event.getMenuOption().contains("Drink")
-			&& (event.getId() == ItemID.ANTIDOTE1
-			|| event.getId() == ItemID.ANTIDOTE2
-			|| event.getId() == ItemID.ANTIDOTE3
-			|| event.getId() == ItemID.ANTIDOTE4))
+				&& event.getMenuOption().contains("Drink")
+				&& (event.getId() == ItemID.ANTIDOTE1
+				|| event.getId() == ItemID.ANTIDOTE2
+				|| event.getId() == ItemID.ANTIDOTE3
+				|| event.getId() == ItemID.ANTIDOTE4))
 		{
 			// Needs menu option hook because drink message is intercepting with antipoison message
 			createGameTimer(ANTIDOTEPLUS);
@@ -285,31 +287,31 @@ public class TimersPlugin extends Plugin
 		}
 
 		if (config.showAntiPoison()
-			&& event.getMenuOption().contains("Drink")
-			&& (event.getId() == ItemID.ANTIPOISON1
-			|| event.getId() == ItemID.ANTIPOISON2
-			|| event.getId() == ItemID.ANTIPOISON3
-			|| event.getId() == ItemID.ANTIPOISON4))
+				&& event.getMenuOption().contains("Drink")
+				&& (event.getId() == ItemID.ANTIPOISON1
+				|| event.getId() == ItemID.ANTIPOISON2
+				|| event.getId() == ItemID.ANTIPOISON3
+				|| event.getId() == ItemID.ANTIPOISON4))
 		{
 			createGameTimer(ANTIPOISON);
 			return;
 		}
 
 		if (config.showSuperantipoison()
-			&& event.getMenuOption().contains("Drink")
-			&& (event.getId() == ItemID.SUPERANTIPOISON1
-			|| event.getId() == ItemID.SUPERANTIPOISON2
-			|| event.getId() == ItemID.SUPERANTIPOISON3
-			|| event.getId() == ItemID.SUPERANTIPOISON4))
+				&& event.getMenuOption().contains("Drink")
+				&& (event.getId() == ItemID.SUPERANTIPOISON1
+				|| event.getId() == ItemID.SUPERANTIPOISON2
+				|| event.getId() == ItemID.SUPERANTIPOISON3
+				|| event.getId() == ItemID.SUPERANTIPOISON4))
 		{
 			createGameTimer(SUPERANTIPOISON);
 			return;
 		}
 
 		if (config.showStamina()
-			&& event.getMenuOption().contains("Drink")
-			&& (event.getId() == ItemID.STAMINA_MIX1
-			|| event.getId() == ItemID.STAMINA_MIX2))
+				&& event.getMenuOption().contains("Drink")
+				&& (event.getId() == ItemID.STAMINA_MIX1
+				|| event.getId() == ItemID.STAMINA_MIX2))
 		{
 			// Needs menu option hook because mixes use a common drink message, distinct from their standard potion messages
 			createGameTimer(STAMINA);
@@ -607,24 +609,24 @@ public class TimersPlugin extends Plugin
 			this.previousPoint = null;
 			return;
 		}
-        WorldPoint current = client.getLocalPlayer().getWorldLocation();
-        if (previousPoint != null)
-        {
-            if (!current.equals(previousPoint) && client.getLocalDestinationLocation() != null)
-            {
-                removeGameTimers(FREEZE_TIMERS);
-                this.previousPoint = null;
-            }
-        }
-        else
-        {
-            this.previousPoint = current;
-        }
+		WorldPoint current = client.getLocalPlayer().getWorldLocation();
+		if (previousPoint != null)
+		{
+			if (!current.equals(previousPoint) && client.getLocalDestinationLocation() != null)
+			{
+				removeGameTimers(FREEZE_TIMERS);
+				this.previousPoint = null;
+			}
+		}
+		else
+		{
+			this.previousPoint = current;
+		}
 	}
 
 	public boolean hasGameTimer(GameTimer... timers)
-    {
-        return infoBoxManager.getInfoBoxes().stream().anyMatch(isOfTimer(timers));
+	{
+		return infoBoxManager.getInfoBoxes().stream().anyMatch(isOfTimer(timers));
 	}
 
 	public void createGameTimer(GameTimer timer)
@@ -636,10 +638,10 @@ public class TimersPlugin extends Plugin
 		infoBoxManager.addInfoBox(t);
 	}
 
-    public void removeGameTimers(GameTimer... timers)
-    {
-        infoBoxManager.removeIf(isOfTimer(timers));
-    }
+	public void removeGameTimers(GameTimer... timers)
+	{
+		infoBoxManager.removeIf(isOfTimer(timers));
+	}
 
 	public void removeGameTimer(GameTimer timer)
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersPlugin.java
@@ -28,9 +28,25 @@ import com.google.common.eventbus.Subscribe;
 import com.google.inject.Provides;
 import javax.inject.Inject;
 
-import net.runelite.api.*;
+import net.runelite.api.Actor;
+import net.runelite.api.ChatMessageType;
+import net.runelite.api.Client;
+import net.runelite.api.EquipmentInventorySlot;
+import net.runelite.api.InventoryID;
+import net.runelite.api.Item;
+import net.runelite.api.ItemContainer;
+import net.runelite.api.ItemID;
+import net.runelite.api.Prayer;
+import net.runelite.api.Varbits;
 import net.runelite.api.coords.WorldPoint;
-import net.runelite.api.events.*;
+import net.runelite.api.events.AnimationChanged;
+import net.runelite.api.events.ChatMessage;
+import net.runelite.api.events.ConfigChanged;
+import net.runelite.api.events.GameTick;
+import net.runelite.api.events.GraphicChanged;
+import net.runelite.api.events.ItemContainerChanged;
+import net.runelite.api.events.MenuOptionClicked;
+import net.runelite.api.events.VarbitChanged;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
@@ -73,9 +89,6 @@ import static net.runelite.client.plugins.timers.GameTimer.VENGEANCEOTHER;
 import net.runelite.client.ui.overlay.infobox.InfoBox;
 import net.runelite.client.ui.overlay.infobox.InfoBoxManager;
 
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.List;
 import java.util.function.Predicate;
 
 @PluginDescriptor(

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersPlugin.java
@@ -29,6 +29,7 @@ import com.google.inject.Provides;
 import javax.inject.Inject;
 
 import net.runelite.api.Actor;
+import net.runelite.api.AnimationID;
 import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
 import net.runelite.api.EquipmentInventorySlot;
@@ -599,22 +600,30 @@ public class TimersPlugin extends Plugin
 	{
 		if (!config.showFreezes())
 		{
-		    if (hasGameTimer(FREEZE_TIMERS)) {
-                WorldPoint current = client.getLocalPlayer().getWorldLocation();
-                if (previousPoint != null) {
-                    if (!current.equals(previousPoint) && client.getLocalDestinationLocation() != null) {
-                        removeGameTimers(FREEZE_TIMERS);
-                    }
-                } else {
-                    this.previousPoint = current;
-                }
-            } else {
-		        this.previousPoint = null;
-            }
+			return;
 		}
+		if (!hasGameTimer(FREEZE_TIMERS))
+		{
+			this.previousPoint = null;
+			return;
+		}
+        WorldPoint current = client.getLocalPlayer().getWorldLocation();
+        if (previousPoint != null)
+        {
+            if (!current.equals(previousPoint) && client.getLocalDestinationLocation() != null)
+            {
+                removeGameTimers(FREEZE_TIMERS);
+                this.previousPoint = null;
+            }
+        }
+        else
+        {
+            this.previousPoint = current;
+        }
 	}
 
-	public boolean hasGameTimer(GameTimer... timers) {
+	public boolean hasGameTimer(GameTimer... timers)
+    {
         return infoBoxManager.getInfoBoxes().stream().anyMatch(isOfTimer(timers));
 	}
 


### PR DESCRIPTION
Addresses issue #3960 while leaving possible edge cases open. Would need to have the ability to check the actual players movement either by event or the actor class and implementing it with that.