### PR TITLE
Simple BEDMAS Calculator in Chat (Re-Opened)

### DIFF
--- a/runelite-client/pom.xml
+++ b/runelite-client/pom.xml
@@ -155,6 +155,11 @@
 			<version>${guice.version}</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>net.objecthunter</groupId>
+			<artifactId>exp4j</artifactId>
+			<version>0.4.8</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsConfig.java
@@ -74,4 +74,15 @@ public interface ChatCommandsConfig extends Config
 	{
 		return true;
 	}
+
+	@ConfigItem(
+		position = 4,
+		keyName = "calc",
+		name = "Calculator Command",
+		description = "Configures whether the calculator command is enabled"
+	)
+	default boolean calc()
+	{
+		return true;
+	}
 }


### PR DESCRIPTION
**Note: Opened a new PR due to rebasing issues on my end. Had to re-fork to fix. Old PR here: https://github.com/runelite/runelite/pull/4016**

This is an attempt to close #3967. I implemented a simple BEDMAS calculator used via a chat command.  I feel like it's a "nice to have" feature. It is used in chat like the following:

`!calc <input expression with other sub-expressions involving math operations>`

As per feedback, this now uses exp4j's implementation. From https://www.objecthunter.net/exp4j/apidocs/index.html: 

Supported Operations:
> Addition: '2 + 2'
> Subtraction: '2 - 2'
> Multiplication: '2 * 2'
> Division: '2 / 2'
> Exponential: '2 ^ 2'
> Unary Minus,Plus (Sign Operators): '+2 - (-2)'
> Modulo: '2 % 2'
> the following functions are supported:
> 
> abs: absolute value
> acos: arc cosine
> asin: arc sine
> atan: arc tangent
> cbrt: cubic root
> ceil: nearest upper integer
> cos: cosine
> cosh: hyperbolic cosine
> exp: euler's number raised to the power (e^x)
> floor: nearest lower integer
> log: logarithmus naturalis (base e)
> log2: logarithm to base 2
> log10: logarithm to base 10
> sin: sine
> sinh: hyperbolic sine
> sqrt: square root
> tan: tangent
> tanh: hyperbolic tangent
> signum: signum of a value

The result is `Calc: <input expression> = <input expression evaluation>` if successful or `Calc: Unable to calculate expression: <input expression>` which may happen if the input expressions have unsupported symbols.

For example, `!calc (1+(2^2)/3.5)` yields `Calc: (1+(2^2)/3.5) = 2.142...` (all digits will be printed out in double precision).

Examples:
![capture](https://user-images.githubusercontent.com/10393532/41890865-8d3dfcb4-78df-11e8-9b98-d55fc4f5e2d0.PNG)


Please note I'm new to the API so I may have missed something, or I might have made some logical errors. Perhaps there are better ways of optimizing my code. I'm open to suggestions!

