### PR TITLE
Allow alt search while grand exchange inventory is active

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangeInputListener.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangeInputListener.java
@@ -29,32 +29,22 @@ import java.awt.event.MouseEvent;
 import javax.inject.Inject;
 import javax.swing.SwingUtilities;
 import net.runelite.api.Client;
-import net.runelite.api.ItemComposition;
-import net.runelite.api.Point;
-import net.runelite.api.queries.BankItemQuery;
-import net.runelite.api.widgets.Widget;
-import net.runelite.api.widgets.WidgetInfo;
-import net.runelite.api.widgets.WidgetItem;
-import net.runelite.client.game.ItemManager;
+import net.runelite.api.MenuEntry;
 import net.runelite.client.input.KeyListener;
 import net.runelite.client.input.MouseListener;
-import net.runelite.client.util.QueryRunner;
+import static net.runelite.client.plugins.grandexchange.GrandExchangePlugin.SEARCH_GRAND_EXCHANGE;
+import net.runelite.client.util.Text;
 
 public class GrandExchangeInputListener extends MouseListener implements KeyListener
 {
 	private final Client client;
 	private final GrandExchangePlugin plugin;
-	private final ItemManager itemManager;
-	private final QueryRunner queryRunner;
 
 	@Inject
-	GrandExchangeInputListener(Client client, GrandExchangePlugin plugin, ItemManager itemManager,
-		QueryRunner queryRunner)
+	GrandExchangeInputListener(Client client, GrandExchangePlugin plugin)
 	{
 		this.client = client;
 		this.plugin = plugin;
-		this.itemManager = itemManager;
-		this.queryRunner = queryRunner;
 	}
 
 	@Override
@@ -63,36 +53,14 @@ public class GrandExchangeInputListener extends MouseListener implements KeyList
 		// Check if left click + alt
 		if (e.getButton() == MouseEvent.BUTTON1 && e.isAltDown())
 		{
-			Widget inventoryWidget = client.getWidget(WidgetInfo.INVENTORY);
-			if (inventoryWidget != null && !inventoryWidget.isHidden())
+			final MenuEntry[] menuEntries = client.getMenuEntries();
+			for (final MenuEntry menuEntry : menuEntries)
 			{
-				if (findAndSearch(inventoryWidget.getWidgetItems().toArray(new WidgetItem[0])))
+				if (menuEntry.getOption().equals(SEARCH_GRAND_EXCHANGE))
 				{
+					search(Text.removeTags(menuEntry.getTarget()));
 					e.consume();
-					return super.mouseClicked(e);
-				}
-			}
-
-			// Check the inventory when the bank is open aswell
-			Widget bankInventoryWidget = client.getWidget(WidgetInfo.BANK_INVENTORY_ITEMS_CONTAINER);
-			if (bankInventoryWidget != null && !bankInventoryWidget.isHidden())
-			{
-				if (findAndSearch(bankInventoryWidget.getDynamicChildren()))
-				{
-					e.consume();
-					return super.mouseClicked(e);
-				}
-			}
-
-			Widget bankWidget = client.getWidget(WidgetInfo.BANK_ITEM_CONTAINER);
-			if (bankWidget != null && !bankWidget.isHidden())
-			{
-				// Use bank item query for only checking the active tab
-				WidgetItem[] items = queryRunner.runQuery(new BankItemQuery());
-				if (findAndSearch(items))
-				{
-					e.consume();
-					return super.mouseClicked(e);
+					break;
 				}
 			}
 		}
@@ -100,42 +68,7 @@ public class GrandExchangeInputListener extends MouseListener implements KeyList
 		return super.mouseClicked(e);
 	}
 
-	private boolean findAndSearch(Widget[] widgets)
-	{
-		Point mousePosition = client.getMouseCanvasPosition();
-		for (Widget widget : widgets)
-		{
-			if (widget.getBounds().contains(mousePosition.getX(), mousePosition.getY()))
-			{
-				ItemComposition itemComposition = itemManager.getItemComposition(widget.getItemId());
-				search(itemComposition);
-				return true;
-			}
-		}
-		return false;
-	}
-
-	/**
-	 * Finds the item clicked based on the mouse location
-	 * @param items
-	 * @return true if an item is found, false otherwise
-	 */
-	private boolean findAndSearch(WidgetItem[] items)
-	{
-		Point mousePosition = client.getMouseCanvasPosition();
-		for (WidgetItem item : items)
-		{
-			if (item.getCanvasBounds().contains(mousePosition.getX(), mousePosition.getY()))
-			{
-				ItemComposition itemComposition = itemManager.getItemComposition(item.getId());
-				search(itemComposition);
-				return true;
-			}
-		}
-		return false;
-	}
-
-	private void search(ItemComposition itemComposition)
+	private void search(final String itemName)
 	{
 		SwingUtilities.invokeLater(() ->
 		{
@@ -146,7 +79,7 @@ public class GrandExchangeInputListener extends MouseListener implements KeyList
 				plugin.getButton().getOnSelect().run();
 			}
 
-			plugin.getPanel().getSearchPanel().priceLookup(itemComposition.getName());
+			plugin.getPanel().getSearchPanel().priceLookup(itemName);
 		});
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangePlugin.java
@@ -44,6 +44,7 @@ import net.runelite.api.Client;
 import net.runelite.api.GameState;
 import net.runelite.api.GrandExchangeOffer;
 import net.runelite.api.ItemComposition;
+import net.runelite.api.MenuAction;
 import net.runelite.api.MenuEntry;
 import net.runelite.api.events.ChatMessage;
 import net.runelite.api.events.ConfigChanged;
@@ -81,6 +82,8 @@ public class GrandExchangePlugin extends Plugin
 	private static final int OFFER_CONTAINER_ITEM = 21;
 	private static final int OFFER_DEFAULT_ITEM_ID = 6512;
 	private static final GrandExchangeClient CLIENT = new GrandExchangeClient();
+
+	static final String SEARCH_GRAND_EXCHANGE = "Search Grand Exchange";
 
 	@Getter(AccessLevel.PACKAGE)
 	private NavigationButton button;
@@ -247,7 +250,10 @@ public class GrandExchangePlugin extends Plugin
 				}
 			case WidgetID.INVENTORY_GROUP_ID:
 			case WidgetID.BANK_INVENTORY_GROUP_ID:
-				menuEntry.setOption("Search Grand Exchange");
+			case WidgetID.GRAND_EXCHANGE_INVENTORY_GROUP_ID:
+			case WidgetID.SHOP_INVENTORY_GROUP_ID:
+				menuEntry.setOption(SEARCH_GRAND_EXCHANGE);
+				menuEntry.setType(MenuAction.RUNELITE.getId());
 				client.setMenuEntries(entries);
 		}
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangeSearchPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangeSearchPanel.java
@@ -273,8 +273,11 @@ class GrandExchangeSearchPanel extends JPanel
 				constraints.gridy++;
 			}
 
-			// remove focus from the search bar
-			searchItemsPanel.requestFocusInWindow();
+			// if exactMatch was set, then it came from the applet, so don't lose focus
+			if (!exactMatch)
+			{
+				searchItemsPanel.requestFocusInWindow();
+			}
 			searchBox.setEditable(true);
 
 			// Remove searching label after search is complete


### PR DESCRIPTION
Rewrote the logic to use menu entries instead of purely a mouse listener. This simplifies the code and fixes several bugs.

Fixes #4040

Some other things fixed now:
- Spam clicking the alt search on an item no longer crashes the applet (however, the exception is still thrown)
- The applet no longer loses focus when using alt search, which caused the tooltip to go away (and may have been the reason for the crash?)
- Now works in the shop interface