### PR TITLE
#4054 Represent decimals as .'s not ,'s

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/util/StackFormatter.java
+++ b/runelite-client/src/main/java/net/runelite/client/util/StackFormatter.java
@@ -147,7 +147,7 @@ public class StackFormatter
 	 */
 	public static String quantityToRSDecimalStack(int quantity)
 	{
-		if (quantity == 0 || String.valueOf(quantity).length() <= 4)
+		if (String.valueOf(quantity).length() <= 4)
 		{
 			return String.valueOf(quantity);
 		}

--- a/runelite-client/src/main/java/net/runelite/client/util/StackFormatter.java
+++ b/runelite-client/src/main/java/net/runelite/client/util/StackFormatter.java
@@ -24,6 +24,7 @@
  */
 package net.runelite.client.util;
 
+import java.text.DecimalFormat;
 import java.text.NumberFormat;
 import java.text.ParseException;
 import java.util.regex.Matcher;
@@ -50,6 +51,10 @@ public class StackFormatter
 	 */
 	private static final NumberFormat NUMBER_FORMATTER = NumberFormat.getInstance();
 
+	/**
+	 * A decimal number formatter
+	 */
+	private static final NumberFormat DECIMAL_FORMATTER = new DecimalFormat("#,###.#");
 	/**
 	 * Convert a quantity to a nicely formatted stack size.
 	 * See the StackFormatterTest to see expected output.
@@ -133,10 +138,8 @@ public class StackFormatter
 	 * appear in RuneScape. (with decimals)
 	 * <p>
 	 * This differs from quantityToRSStack in that it displays
-	 * decimals. Ex: 27100 is 27,1k (not 27k)
+	 * decimals. Ex: 27100 is 27.1k (not 27k)
 	 * <p>
-	 * This uses the NumberFormat singleton instead of the
-	 * NUMBER_FORMATTER variable to ensure the UK locale.
 	 *
 	 * @param quantity The quantity to convert.
 	 * @return The stack size as it would appear in RS, with decimals,
@@ -144,43 +147,13 @@ public class StackFormatter
 	 */
 	public static String quantityToRSDecimalStack(int quantity)
 	{
+		if (quantity == 0 || String.valueOf(quantity).length() <= 4)
+		{
+			return String.valueOf(quantity);
+		}
 
-		if (quantity < 10_000)
-		{
-			return Integer.toString(quantity);
-		}
-		else if (quantity < 1_000_000)
-		{
-			if (quantity % 1000 == 0)
-			{
-				return quantity / 1000 + "K";
-			}
-			return NUMBER_FORMATTER.format(quantity).substring(0, Integer.toString(quantity).length() - 1) + "K";
-		}
-		else if (quantity < 10_000_000)
-		{
-			if (quantity % 1_000_000 == 0)
-			{
-				return quantity / 1_000_000 + "M";
-			}
-			return NUMBER_FORMATTER.format(quantity).substring(0, Integer.toString(quantity).length() - 4) + "M";
-		}
-		else if (quantity < 1_000_000_000)
-		{
-			if (quantity % 1_000_000 == 0)
-			{
-				return quantity / 1_000_000 + "M";
-			}
-			return NUMBER_FORMATTER.format(quantity).substring(0, Integer.toString(quantity).length() - 4) + "M";
-		}
-		else
-		{
-			if (quantity % 1_000_000_000 == 0)
-			{
-				return quantity / 1_000_000_000 + "B";
-			}
-			return NUMBER_FORMATTER.format(quantity).substring(0, Integer.toString(quantity).length() - 7) + "B";
-		}
+		int power = (int) StrictMath.log10(quantity);
+		return DECIMAL_FORMATTER.format(quantity / (Math.pow(10, (power / 3) * 3))) + SUFFIXES[power/3];
 	}
 
 	/**

--- a/runelite-client/src/main/java/net/runelite/client/util/StackFormatter.java
+++ b/runelite-client/src/main/java/net/runelite/client/util/StackFormatter.java
@@ -154,7 +154,7 @@ public class StackFormatter
 			return quantityStr;
 		}
 
-		int power = (int) StrictMath.log10(quantity);
+		int power = (int) Math.log10(quantity);
 		return DECIMAL_FORMATTER.format(quantity / (Math.pow(10, (power / 3) * 3))) + SUFFIXES[power / 3];
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/util/StackFormatter.java
+++ b/runelite-client/src/main/java/net/runelite/client/util/StackFormatter.java
@@ -55,6 +55,7 @@ public class StackFormatter
 	 * A decimal number formatter
 	 */
 	private static final NumberFormat DECIMAL_FORMATTER = new DecimalFormat("#,###.#");
+
 	/**
 	 * Convert a quantity to a nicely formatted stack size.
 	 * See the StackFormatterTest to see expected output.
@@ -147,13 +148,14 @@ public class StackFormatter
 	 */
 	public static String quantityToRSDecimalStack(int quantity)
 	{
-		if (String.valueOf(quantity).length() <= 4)
+		String quantityStr = String.valueOf(quantity);
+		if (quantityStr.length() <= 4)
 		{
-			return String.valueOf(quantity);
+			return quantityStr;
 		}
 
 		int power = (int) StrictMath.log10(quantity);
-		return DECIMAL_FORMATTER.format(quantity / (Math.pow(10, (power / 3) * 3))) + SUFFIXES[power/3];
+		return DECIMAL_FORMATTER.format(quantity / (Math.pow(10, (power / 3) * 3))) + SUFFIXES[power / 3];
 	}
 
 	/**

--- a/runelite-client/src/test/java/net/runelite/client/util/StackFormatterTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/util/StackFormatterTest.java
@@ -46,18 +46,18 @@ public class StackFormatterTest
 		assertEquals("0", StackFormatter.quantityToRSDecimalStack(0));
 		assertEquals("8500", StackFormatter.quantityToRSDecimalStack(8_500));
 		assertEquals("10K", StackFormatter.quantityToRSDecimalStack(10_000));
-		assertEquals("21,7K", StackFormatter.quantityToRSDecimalStack(21_700));
+		assertEquals("21.7K", StackFormatter.quantityToRSDecimalStack(21_700));
 		assertEquals("100K", StackFormatter.quantityToRSDecimalStack(100_000));
-		assertEquals("100,3K", StackFormatter.quantityToRSDecimalStack(100_300));
+		assertEquals("100.3K", StackFormatter.quantityToRSDecimalStack(100_300));
 		assertEquals("1M", StackFormatter.quantityToRSDecimalStack(1_000_000));
-		assertEquals("8,4M", StackFormatter.quantityToRSDecimalStack(8_450_000));
+		assertEquals("8.4M", StackFormatter.quantityToRSDecimalStack(8_450_000));
 		assertEquals("10M", StackFormatter.quantityToRSDecimalStack(10_000_000));
-		assertEquals("12,8M", StackFormatter.quantityToRSDecimalStack(12_800_000));
+		assertEquals("12.8M", StackFormatter.quantityToRSDecimalStack(12_800_000));
 		assertEquals("100M", StackFormatter.quantityToRSDecimalStack(100_000_000));
-		assertEquals("250,1M", StackFormatter.quantityToRSDecimalStack(250_100_000));
+		assertEquals("250.1M", StackFormatter.quantityToRSDecimalStack(250_100_000));
 		assertEquals("1B", StackFormatter.quantityToRSDecimalStack(1_000_000_000));
-		assertEquals("1,5B", StackFormatter.quantityToRSDecimalStack(1500_000_000));
-		assertEquals("2,1B", StackFormatter.quantityToRSDecimalStack(Integer.MAX_VALUE));
+		assertEquals("1.5B", StackFormatter.quantityToRSDecimalStack(1500_000_000));
+		assertEquals("2.1B", StackFormatter.quantityToRSDecimalStack(Integer.MAX_VALUE));
 	}
 
 	@Test


### PR DESCRIPTION
Addresses #4054 in that it represents stacks with decimals as . rather than ,

I believe the other formatters format logically, since they don't maintain a decimal, and instead produce output like `100,000`

Test updated to reflect the `10.5k` format rather than `10,5k`