### PR TITLE
Cooking Skill Calculator Correction

### DIFF
--- a/runelite-client/src/main/resources/net/runelite/client/plugins/skillcalculator/skill_cooking.json
+++ b/runelite-client/src/main/resources/net/runelite/client/plugins/skillcalculator/skill_cooking.json
@@ -482,15 +482,15 @@
     },
     {
       "level": 85,
-      "icon": 11936,
-      "name": "Dark Crab",
-      "xp": 215
-    },
-    {
-      "level": 85,
       "icon": 7208,
       "name": "Wild Pie",
       "xp": 240
+    },
+    {
+      "level": 90,
+      "icon": 11936,
+      "name": "Dark Crab",
+      "xp": 215
     },
     {
       "level": 91,


### PR DESCRIPTION
Corrects the Dark Crab Cooking requirement in the Skill Calculator Plugin as reported in Issue #4069