### PR TITLE
Add color utility class

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/Notifier.java
+++ b/runelite-client/src/main/java/net/runelite/client/Notifier.java
@@ -49,6 +49,7 @@ import net.runelite.api.Client;
 import net.runelite.api.GameState;
 import net.runelite.client.config.RuneLiteConfig;
 import net.runelite.client.ui.ClientUI;
+import net.runelite.client.util.ColorUtil;
 import net.runelite.client.util.OSType;
 
 @Singleton
@@ -65,7 +66,7 @@ public class Notifier
 	// Notifier properties
 	private static final Color FLASH_COLOR = new Color(255, 0, 0, 70);
 	private static final int FLASH_DURATION = 2000;
-	private static final String MESSAGE_COLOR = "FF0000";
+	private static final Color MESSAGE_COLOR = Color.RED;
 
 	private final Provider<Client> client;
 	private final String appName;
@@ -133,7 +134,7 @@ public class Notifier
 			if (client != null && client.getGameState() == GameState.LOGGED_IN)
 			{
 				client.addChatMessage(ChatMessageType.GAME, appName,
-					"<col=" + MESSAGE_COLOR + ">" + message + "</col>", "");
+					ColorUtil.wrapWithColorTag(message, MESSAGE_COLOR), "");
 			}
 		}
 

--- a/runelite-client/src/main/java/net/runelite/client/chat/ChatMessageManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/chat/ChatMessageManager.java
@@ -51,6 +51,7 @@ import net.runelite.api.events.ResizeableChanged;
 import net.runelite.api.events.SetMessage;
 import net.runelite.api.events.VarbitChanged;
 import net.runelite.client.config.ChatColorConfig;
+import net.runelite.client.util.ColorUtil;
 
 @Slf4j
 @Singleton
@@ -145,13 +146,13 @@ public class ChatMessageManager
 
 		if (usernameColor != null)
 		{
-			messageNode.setName(wrapTextWithColour(messageNode.getName(), usernameColor));
+			messageNode.setName(ColorUtil.wrapWithColorTag(messageNode.getName(), usernameColor));
 		}
 
 		String sender = setMessage.getSender();
 		if (senderColor != null && !Strings.isNullOrEmpty(sender))
 		{
-			messageNode.setSender(wrapTextWithColour(sender, senderColor));
+			messageNode.setSender(ColorUtil.wrapWithColorTag(sender, senderColor));
 		}
 
 		final Collection<ChatColor> chatColors = colorCache.get(chatMessageType);
@@ -162,14 +163,9 @@ public class ChatMessageManager
 				continue;
 			}
 
-			messageNode.setValue(wrapTextWithColour(messageNode.getValue(), chatColor.getColor()));
+			messageNode.setValue(ColorUtil.wrapWithColorTag(messageNode.getValue(), chatColor.getColor()));
 			break;
 		}
-	}
-
-	private static String wrapTextWithColour(String text, Color colour)
-	{
-		return "<col=" + Integer.toHexString(colour.getRGB() & 0xFFFFFF) + ">" + text + "</col>";
 	}
 
 	private static Color getDefaultColor(ChatMessageType type, boolean transparent)
@@ -566,7 +562,7 @@ public class ChatMessageManager
 			.forEach(chatColor ->
 				resultMessage.getAndUpdate(oldMessage -> oldMessage.replaceAll(
 					"<col" + chatColor.getType().name() + ">",
-					"<col=" + Integer.toHexString(chatColor.getColor().getRGB() & 0xFFFFFF) + ">")));
+					ColorUtil.colorTag(chatColor.getColor()))));
 
 		return resultMessage.get();
 	}

--- a/runelite-client/src/main/java/net/runelite/client/menus/WidgetMenuOption.java
+++ b/runelite-client/src/main/java/net/runelite/client/menus/WidgetMenuOption.java
@@ -27,6 +27,7 @@ package net.runelite.client.menus;
 import net.runelite.api.widgets.WidgetInfo;
 
 import java.awt.Color;
+import net.runelite.client.util.ColorUtil;
 
 public final class WidgetMenuOption
 {
@@ -74,8 +75,7 @@ public final class WidgetMenuOption
 	 */
 	public void setMenuTarget(String target)
 	{
-		menuTarget = String.format("<col=%02x%02x%02x>%s</col>",
-			color.getRed(), color.getGreen(), color.getBlue(), target);
+		menuTarget = ColorUtil.wrapWithColorTag(target, color);
 	}
 
 	public String getMenuOption()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/DiaryRequirementsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/DiaryRequirementsPlugin.java
@@ -26,6 +26,7 @@
 package net.runelite.client.plugins.achievementdiary;
 
 import com.google.common.eventbus.Subscribe;
+import java.awt.Color;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -51,6 +52,7 @@ import net.runelite.client.plugins.achievementdiary.diaries.MorytaniaDiaryRequir
 import net.runelite.client.plugins.achievementdiary.diaries.VarrockDiaryRequirement;
 import net.runelite.client.plugins.achievementdiary.diaries.WesternDiaryRequirement;
 import net.runelite.client.plugins.achievementdiary.diaries.WildernessDiaryRequirement;
+import net.runelite.client.util.ColorUtil;
 import net.runelite.client.util.Text;
 
 @Slf4j
@@ -256,16 +258,16 @@ public class DiaryRequirementsPlugin extends Plugin
 	private String combine(List<RequirementStringBuilder> list)
 	{
 		StringBuilder requirementsString = new StringBuilder();
-		requirementsString.append("<col=000000> (");
+		requirementsString.append(ColorUtil.prependColorTag(" (", Color.WHITE));
 		for (RequirementStringBuilder req : list)
 		{
-			requirementsString.append("<col=000080>")
+			requirementsString.append(ColorUtil.colorTag(new Color(0x80)))
 				.append(req.getRequirementString())
 				.append(", ");
 		}
 		requirementsString.deleteCharAt(requirementsString.length() - 1);
 		requirementsString.deleteCharAt(requirementsString.length() - 2);
-		requirementsString.append("<col=000000>)");
+		requirementsString.append(ColorUtil.prependColorTag(")", Color.WHITE));
 
 		return requirementsString.toString();
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/RequirementStringBuilder.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/RequirementStringBuilder.java
@@ -25,9 +25,11 @@
  */
 package net.runelite.client.plugins.achievementdiary;
 
+import java.awt.Color;
 import java.util.List;
 import lombok.Getter;
 import net.runelite.api.Skill;
+import net.runelite.client.util.ColorUtil;
 
 class RequirementStringBuilder
 {
@@ -64,7 +66,7 @@ class RequirementStringBuilder
 
 	void colorRedRequirement()
 	{
-		this.requirementString = "<col=800000>" + this.requirementString + "</col>";
+		this.requirementString = ColorUtil.wrapWithColorTag(this.requirementString, new Color(0x800000));
 	}
 
 	boolean hasLevelRequirement(int realSkillLevel, List<Integer> altRealSkillLevels)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/boosts/BoostsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/boosts/BoostsOverlay.java
@@ -35,6 +35,7 @@ import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.OverlayPriority;
 import net.runelite.client.ui.overlay.components.LineComponent;
 import net.runelite.client.ui.overlay.components.PanelComponent;
+import net.runelite.client.util.ColorUtil;
 
 class BoostsOverlay extends Overlay
 {
@@ -109,7 +110,8 @@ class BoostsOverlay extends Overlay
 				}
 				else
 				{
-					str = "<col=" + Integer.toHexString(strColor.getRGB() & 0xFFFFFF) + ">" + boosted + "<col=ffffff>/" + base;
+					str = ColorUtil.prependColorTag(Integer.toString(boosted), strColor)
+						+ ColorUtil.prependColorTag("/" + base, Color.WHITE);
 				}
 
 				panelComponent.getChildren().add(LineComponent.builder()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/friendnotes/FriendNotesPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/friendnotes/FriendNotesPlugin.java
@@ -30,6 +30,7 @@ package net.runelite.client.plugins.friendnotes;
 import com.google.common.base.Strings;
 import com.google.common.collect.ObjectArrays;
 import com.google.common.eventbus.Subscribe;
+import java.awt.Color;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
 import lombok.Getter;
@@ -49,6 +50,7 @@ import net.runelite.client.game.ChatboxInputManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.OverlayManager;
+import net.runelite.client.util.ColorUtil;
 import net.runelite.client.util.Text;
 
 @Slf4j
@@ -64,7 +66,7 @@ public class FriendNotesPlugin extends Plugin
 	private static final String ADD_NOTE = "Add Note";
 	private static final String EDIT_NOTE = "Edit Note";
 	private static final String NOTE_PROMPT_FORMAT = "%s's Notes<br>" +
-		"<col=0000AA>(Limit %s Characters)";
+		ColorUtil.prependColorTag("(Limit %s Characters)", new Color(0, 0, 170));
 
 	@Inject
 	private Client client;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangeOfferSlot.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangeOfferSlot.java
@@ -53,8 +53,8 @@ import net.runelite.api.ItemComposition;
 import net.runelite.client.ui.ColorScheme;
 import net.runelite.client.ui.FontManager;
 import net.runelite.client.ui.components.ThinProgressBar;
+import net.runelite.client.util.ColorUtil;
 import net.runelite.client.util.StackFormatter;
-import net.runelite.client.util.SwingUtil;
 
 @Slf4j
 public class GrandExchangeOfferSlot extends JPanel
@@ -263,12 +263,12 @@ public class GrandExchangeOfferSlot extends JPanel
 
 	private String htmlTooltip(String value)
 	{
-		return "<html><body style = 'color:" + SwingUtil.toHexColor(ColorScheme.LIGHT_GRAY_COLOR) + "'>Progress: <span style = 'color:white'>" + value + "</span></body></html>";
+		return "<html><body style = 'color:" + ColorUtil.toHexColor(ColorScheme.LIGHT_GRAY_COLOR) + "'>Progress: <span style = 'color:white'>" + value + "</span></body></html>";
 	}
 
 	private String htmlLabel(String key, String value)
 	{
-		return "<html><body style = 'color:white'>" + key + "<span style = 'color:" + SwingUtil.toHexColor(ColorScheme.LIGHT_GRAY_COLOR) + "'>" + value + "</span></body></html>";
+		return "<html><body style = 'color:white'>" + key + "<span style = 'color:" + ColorUtil.toHexColor(ColorScheme.LIGHT_GRAY_COLOR) + "'>" + value + "</span></body></html>";
 	}
 
 	private void switchPanel()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
@@ -76,6 +76,7 @@ import static net.runelite.client.plugins.grounditems.config.MenuHighlightMode.B
 import static net.runelite.client.plugins.grounditems.config.MenuHighlightMode.NAME;
 import static net.runelite.client.plugins.grounditems.config.MenuHighlightMode.OPTION;
 import net.runelite.client.ui.overlay.OverlayManager;
+import net.runelite.client.util.ColorUtil;
 import net.runelite.http.api.item.ItemPrice;
 
 @PluginDescriptor(
@@ -381,19 +382,17 @@ public class GroundItemsPlugin extends Plugin
 
 			if (color != null && canBeRecolored && !color.equals(config.defaultColor()))
 			{
-				String hexColor = Integer.toHexString(color.getRGB() & 0xFFFFFF);
-				String colTag = "<col=" + hexColor + ">";
 				final MenuHighlightMode mode = config.menuHighlightMode();
 
 				if (mode == BOTH || mode == OPTION)
 				{
-					lastEntry.setOption(colTag + "Take");
+					lastEntry.setOption(ColorUtil.prependColorTag("Take", color));
 				}
 
 				if (mode == BOTH || mode == NAME)
 				{
 					String target = lastEntry.getTarget().substring(lastEntry.getTarget().indexOf(">") + 1);
-					lastEntry.setTarget(colTag + target);
+					lastEntry.setTarget(ColorUtil.prependColorTag(target, color));
 				}
 			}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/inventorytags/InventoryTagsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/inventorytags/InventoryTagsPlugin.java
@@ -47,6 +47,7 @@ import net.runelite.client.config.ConfigManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.OverlayManager;
+import net.runelite.client.util.ColorUtil;
 import net.runelite.client.util.Text;
 import org.apache.commons.lang3.ArrayUtils;
 
@@ -67,7 +68,7 @@ public class InventoryTagsPlugin extends Plugin
 
 	private static final String CONFIGURE = "Configure";
 	private static final String SAVE = "Save";
-	private static final String MENU_TARGET = "<col=ff9040>Inventory Tags";
+	private static final String MENU_TARGET = ColorUtil.prependColorTag("Inventory Tags", new Color(255, 144, 64));
 	private static final String MENU_SET = "Mark";
 	private static final String MENU_REMOVE = "Remove";
 
@@ -228,7 +229,7 @@ public class InventoryTagsPlugin extends Plugin
 				final MenuEntry newMenu = new MenuEntry();
 				final Color color = getGroupNameColor(groupName);
 				newMenu.setOption(group != null && groupName.equals(group) ? MENU_REMOVE : MENU_SET);
-				newMenu.setTarget("<col=" + getHexColor(MoreObjects.firstNonNull(color, Color.WHITE)) + ">" + groupName);
+				newMenu.setTarget(ColorUtil.prependColorTag(groupName, MoreObjects.firstNonNull(color, Color.WHITE)));
 				newMenu.setIdentifier(itemId);
 				newMenu.setParam1(widgetId);
 				newMenu.setType(MenuAction.RUNELITE.getId());
@@ -278,11 +279,6 @@ public class InventoryTagsPlugin extends Plugin
 				return;
 			}
 		}
-	}
-
-	private String getHexColor(final Color color)
-	{
-		return String.format("%02x%02x%02x", color.getRed(), color.getGreen(), color.getBlue());
 	}
 
 	Color getGroupNameColor(final String name)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemcharges/ItemChargePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemcharges/ItemChargePlugin.java
@@ -52,6 +52,7 @@ public class ItemChargePlugin extends Plugin
 		"Your dodgy necklace protects you\\..*It has (\\d+) charges? left\\.");
 	private static final Pattern DODGY_BREAK_PATTERN = Pattern.compile(
 		"Your dodgy necklace protects you\\..*It then crumbles to dust\\.");
+	private static final String RING_OF_RECOIL_BREAK_MESSAGE = "<col=7f007f>Your Ring of Recoil has shattered.</col>";
 
 	private static final int MAX_DODGY_CHARGES = 10;
 
@@ -98,7 +99,7 @@ public class ItemChargePlugin extends Plugin
 		Matcher dodgyBreakMatcher = DODGY_BREAK_PATTERN.matcher(message);
 		if (event.getType() == ChatMessageType.SERVER || event.getType() == ChatMessageType.FILTERED)
 		{
-			if (config.recoilNotification() && message.contains("<col=7f007f>Your Ring of Recoil has shattered.</col>"))
+			if (config.recoilNotification() && message.contains(RING_OF_RECOIL_BREAK_MESSAGE))
 			{
 				notifier.notify("Your Ring of Recoil has shattered");
 			}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemprices/ItemPricesOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemprices/ItemPricesOverlay.java
@@ -24,6 +24,7 @@
  */
 package net.runelite.client.plugins.itemprices;
 
+import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Graphics2D;
 import javax.inject.Inject;
@@ -42,6 +43,7 @@ import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.tooltip.Tooltip;
 import net.runelite.client.ui.overlay.tooltip.TooltipManager;
+import net.runelite.client.util.ColorUtil;
 import net.runelite.client.util.StackFormatter;
 import net.runelite.http.api.item.ItemPrice;
 
@@ -117,7 +119,7 @@ class ItemPricesOverlay extends Overlay
 						final String text = makeValueTooltip(menuEntry);
 						if (text != null)
 						{
-							tooltipManager.add(new Tooltip("<col=eeeeee>" + text));
+							tooltipManager.add(new Tooltip(ColorUtil.prependColorTag(text, new Color(238, 238, 238))));
 						}
 						break;
 				}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatOverlay.java
@@ -34,6 +34,7 @@ import net.runelite.api.widgets.WidgetItem;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.tooltip.Tooltip;
 import net.runelite.client.ui.overlay.tooltip.TooltipManager;
+import net.runelite.client.util.ColorUtil;
 import net.runelite.client.util.QueryRunner;
 
 public class ItemStatOverlay extends Overlay
@@ -86,9 +87,7 @@ public class ItemStatOverlay extends Overlay
 	private String buildStatChangeString(StatChange c)
 	{
 		StringBuilder b = new StringBuilder();
-		b.append("<col=");
-		b.append(Integer.toHexString(Positivity.getColor(config, c.getPositivity()).getRGB() & 0xFFFFFF));
-		b.append(">");
+		b.append(ColorUtil.colorTag(Positivity.getColor(config, c.getPositivity())));
 
 		if (config.relative())
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -27,6 +27,7 @@ package net.runelite.client.plugins.menuentryswapper;
 
 import com.google.common.eventbus.Subscribe;
 import com.google.inject.Provides;
+import java.awt.Color;
 import java.util.Collection;
 import java.util.Collections;
 import javax.inject.Inject;
@@ -52,6 +53,7 @@ import net.runelite.client.menus.MenuManager;
 import net.runelite.client.menus.WidgetMenuOption;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.util.ColorUtil;
 import net.runelite.client.util.Text;
 import org.apache.commons.lang3.ArrayUtils;
 
@@ -66,7 +68,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 	private static final String CONFIGURE = "Configure";
 	private static final String SAVE = "Save";
 	private static final String RESET = "Reset";
-	private static final String MENU_TARGET = "<col=ff9040>Shift-click";
+	private static final String MENU_TARGET = ColorUtil.prependColorTag("Shift-click", new Color(255, 144, 64));
 
 	private static final String CONFIG_GROUP = "shiftclick";
 	private static final String ITEM_KEY_PREFIX = "item_";

--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsPlugin.java
@@ -40,6 +40,8 @@ import net.runelite.client.game.ClanManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.OverlayManager;
+import net.runelite.client.util.ColorUtil;
+import net.runelite.client.util.Text;
 
 @PluginDescriptor(
 	name = "Player Indicators",
@@ -155,15 +157,9 @@ public class PlayerIndicatorsPlugin extends Plugin
 
 				if (color != null && config.colorPlayerMenu())
 				{
-					// strip out existing <col...
-					String target = lastEntry.getTarget();
-					int idx = target.indexOf('>');
-					if (idx != -1)
-					{
-						target = target.substring(idx + 1);
-					}
-
-					lastEntry.setTarget("<col=" + Integer.toHexString(color.getRGB() & 0xFFFFFF) + ">" + target);
+					// strip out existing tags (color, etc.)
+					String target = Text.removeTags(lastEntry.getTarget());
+					lastEntry.setTarget(ColorUtil.prependColorTag(target, color));
 				}
 
 				if (image != -1 && config.showClanRanks())

--- a/runelite-client/src/main/java/net/runelite/client/plugins/prayer/PrayerDoseOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/prayer/PrayerDoseOverlay.java
@@ -45,7 +45,7 @@ import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.tooltip.Tooltip;
 import net.runelite.client.ui.overlay.tooltip.TooltipManager;
-import net.runelite.client.util.SwingUtil;
+import net.runelite.client.util.ColorUtil;
 import org.apache.commons.lang3.StringUtils;
 
 class PrayerDoseOverlay extends Overlay
@@ -160,7 +160,7 @@ class PrayerDoseOverlay extends Overlay
 		final float tickProgress = Math.min(timeSinceLastTick / PULSE_TIME, 1); // Cap between 0 and 1
 		final double t = tickProgress * Math.PI; // Convert to 0 - pi
 
-		graphics.setColor(SwingUtil.colorLerp(START_COLOR, END_COLOR, Math.sin(t)));
+		graphics.setColor(ColorUtil.colorLerp(START_COLOR, END_COLOR, Math.sin(t)));
 		graphics.setStroke(new BasicStroke(2));
 		graphics.drawOval(orbInnerX, orbInnerY, orbInnerSize, orbInnerSize);
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/puzzlesolver/PuzzleSolverPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/puzzlesolver/PuzzleSolverPlugin.java
@@ -27,6 +27,7 @@ package net.runelite.client.plugins.puzzlesolver;
 
 import com.google.common.eventbus.Subscribe;
 import com.google.inject.Provides;
+import java.awt.Color;
 import java.util.Arrays;
 import javax.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
@@ -55,6 +56,8 @@ import net.runelite.client.plugins.puzzlesolver.lightbox.LightboxSolution;
 import net.runelite.client.plugins.puzzlesolver.lightbox.LightboxSolver;
 import net.runelite.client.plugins.puzzlesolver.lightbox.LightboxState;
 import net.runelite.client.ui.overlay.OverlayManager;
+import net.runelite.client.util.ColorUtil;
+import net.runelite.client.util.Text;
 
 @PluginDescriptor(
 	name = "Puzzle Solver",
@@ -64,6 +67,8 @@ import net.runelite.client.ui.overlay.OverlayManager;
 @Slf4j
 public class PuzzleSolverPlugin extends Plugin
 {
+	private static final Color CORRECT_MUSEUM_PUZZLE_ANSWER_COLOR = new Color(0, 248, 128);
+
 	@Inject
 	private OverlayManager overlayManager;
 
@@ -118,9 +123,15 @@ public class PuzzleSolverPlugin extends Plugin
 			WidgetInfo.VARROCK_MUSEUM_SECOND_ANSWER,
 			WidgetInfo.VARROCK_MUSEUM_THIRD_ANSWER);
 
-		if (answerWidget != null && !answerWidget.getText().contains("<col="))
+		if (answerWidget == null)
 		{
-			answerWidget.setText("<col=00FF80>" + answerWidget.getText() + "</col>");
+			return;
+		}
+
+		final String answerText = answerWidget.getText();
+		if (answerText.equals(Text.removeTags(answerText)))
+		{
+			answerWidget.setText(ColorUtil.wrapWithColorTag(answerText, CORRECT_MUSEUM_PUZZLE_ANSWER_COLOR));
 		}
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/runepouch/RunepouchOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/runepouch/RunepouchOverlay.java
@@ -46,6 +46,7 @@ import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.OverlayUtil;
 import net.runelite.client.ui.overlay.tooltip.Tooltip;
 import net.runelite.client.ui.overlay.tooltip.TooltipManager;
+import net.runelite.client.util.ColorUtil;
 import net.runelite.client.util.QueryRunner;
 
 public class RunepouchOverlay extends Overlay
@@ -123,9 +124,9 @@ public class RunepouchOverlay extends Overlay
 
 			tooltipBuilder
 				.append(amount)
-				.append(" <col=ffff00>")
-				.append(rune.getName())
-				.append("</col></br>");
+				.append(" ")
+				.append(ColorUtil.wrapWithColorTag(rune.getName(), Color.YELLOW))
+				.append("</br>");
 
 			if (config.runePouchOverlayMode() == MOUSE_HOVER)
 			{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerPlugin.java
@@ -27,6 +27,7 @@ package net.runelite.client.plugins.slayer;
 
 import com.google.common.eventbus.Subscribe;
 import com.google.inject.Provides;
+import java.awt.Color;
 import java.awt.image.BufferedImage;
 import java.time.Duration;
 import java.time.Instant;
@@ -65,6 +66,7 @@ import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.OverlayManager;
 import net.runelite.client.ui.overlay.infobox.InfoBoxManager;
+import net.runelite.client.util.ColorUtil;
 import net.runelite.client.util.Text;
 
 @PluginDescriptor(
@@ -569,9 +571,13 @@ public class SlayerPlugin extends Plugin
 		}
 
 		BufferedImage taskImg = itemManager.getImage(itemSpriteId);
+		final String taskTooltip = ColorUtil.prependColorTag("%s</br>", new Color(255, 119, 0))
+			+ ColorUtil.wrapWithColorTag("Pts:", Color.YELLOW)
+			+ " %s</br>"
+			+ ColorUtil.wrapWithColorTag("Streak:", Color.YELLOW)
+			+ " %s";
 		counter = new TaskCounter(taskImg, this, amount);
-		counter.setTooltip(String.format("<col=ff7700>%s</br><col=ffff00>Pts:</col> %s</br><col=ffff00>Streak:</col> %s",
-			capsString(taskName), points, streak));
+		counter.setTooltip(String.format(taskTooltip, capsString(taskName), points, streak));
 
 		infoBoxManager.addInfoBox(counter);
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersPlugin.java
@@ -99,6 +99,31 @@ import net.runelite.client.ui.overlay.infobox.InfoBoxManager;
 )
 public class TimersPlugin extends Plugin
 {
+	private static final String ANTIFIRE_DRINK_MESSAGE = "You drink some of your antifire potion.";
+	private static final String ANTIFIRE_EXPIRED_MESSAGE = "<col=7f007f>Your antifire potion has expired.</col>";
+	private static final String ANTIVENOM_DRINK_MESSAGE = "You drink some of your antivenom potion";
+	private static final String CANNON_FURNACE_MESSAGE = "You add the furnace.";
+	private static final String CANNON_PICKUP_MESSAGE = "You pick up the cannon. It's really heavy.";
+	private static final String CANNON_REPAIR_MESSAGE = "You repair your cannon, restoring it to working order.";
+	private static final String CHARGE_EXPIRED_MESSAGE = "<col=ef1020>Your magical charge fades away.</col>";
+	private static final String CHARGE_MESSAGE = "<col=ef1020>You feel charged with magic power.</col>";
+	private static final String EXTENDED_ANTIFIRE_DRINK_MESSAGE = "You drink some of your extended antifire potion.";
+	private static final String EXTENDED_SUPER_ANTIFIRE_DRINK_MESSAGE = "You drink some of your extended super antifire potion.";
+	private static final String FULL_TELEBLOCK_MESSAGE = "<col=4f006f>A teleblock spell has been cast on you. It will expire in 5 minutes, 0 seconds.</col>";
+	private static final String GOD_WARS_ALTAR_MESSAGE = "you recharge your prayer.";
+	private static final String HALF_TELEBLOCK_MESSAGE = "<col=4f006f>A teleblock spell has been cast on you. It will expire in 2 minutes, 30 seconds.</col>";
+	private static final String IMBUED_HEART_READY_MESSAGE = "<col=ef1020>Your imbued heart has regained its magical power.</col>";
+	private static final String MAGIC_IMBUE_EXPIRED_MESSAGE = "Your Magic Imbue charge has ended.";
+	private static final String MAGIC_IMBUE_MESSAGE = "You are charged to combine runes!";
+	private static final String SANFEW_SERUM_DRINK_MESSAGE = "You drink some of your Sanfew Serum.";
+	private static final String STAFF_OF_THE_DEAD_SPEC_EXPIRED_MESSAGE = "Your protection fades away";
+	private static final String STAFF_OF_THE_DEAD_SPEC_MESSAGE = "Spirits of deceased evildoers offer you their protection";
+	private static final String STAMINA_DRINK_MESSAGE = "You drink some of your stamina potion.";
+	private static final String STAMINA_EXPIRED_MESSAGE = "<col=8f4808>Your stamina potion has expired.</col>";
+	private static final String SUPER_ANTIFIRE_DRINK_MESSAGE = "You drink some of your super antifire potion";
+	private static final String SUPER_ANTIFIRE_EXPIRED_MESSAGE = "<col=7f007f>Your super antifire potion has expired.</col>";
+	private static final String SUPER_ANTIVENOM_DRINK_MESSAGE = "You drink some of your super antivenom potion";
+
 	private int lastRaidVarb;
 
 	@Inject
@@ -324,37 +349,37 @@ public class TimersPlugin extends Plugin
 			return;
 		}
 
-		if (config.showStamina() && event.getMessage().equals("You drink some of your stamina potion."))
+		if (config.showStamina() && event.getMessage().equals(STAMINA_DRINK_MESSAGE))
 		{
 			createGameTimer(STAMINA);
 		}
 
-		if (event.getMessage().equals("<col=8f4808>Your stamina potion has expired.</col>"))
+		if (event.getMessage().equals(STAMINA_EXPIRED_MESSAGE))
 		{
 			removeGameTimer(STAMINA);
 		}
 
-		if (config.showAntiFire() && event.getMessage().equals("You drink some of your antifire potion."))
+		if (config.showAntiFire() && event.getMessage().equals(ANTIFIRE_DRINK_MESSAGE))
 		{
 			createGameTimer(ANTIFIRE);
 		}
 
-		if (config.showExAntiFire() && event.getMessage().equals("You drink some of your extended antifire potion."))
+		if (config.showExAntiFire() && event.getMessage().equals(EXTENDED_ANTIFIRE_DRINK_MESSAGE))
 		{
 			createGameTimer(EXANTIFIRE);
 		}
 
-		if (config.showGodWarsAltar() && event.getMessage().equalsIgnoreCase("you recharge your prayer."))//Normal altars are "You recharge your Prayer points." while gwd is "You recharge your Prayer."
+		if (config.showGodWarsAltar() && event.getMessage().equalsIgnoreCase(GOD_WARS_ALTAR_MESSAGE))//Normal altars are "You recharge your Prayer points." while gwd is "You recharge your Prayer."
 		{
 			createGameTimer(GOD_WARS_ALTAR);
 		}
 
-		if (config.showExSuperAntifire() && event.getMessage().equals("You drink some of your extended super antifire potion."))
+		if (config.showExSuperAntifire() && event.getMessage().equals(EXTENDED_SUPER_ANTIFIRE_DRINK_MESSAGE))
 		{
 			createGameTimer(EXSUPERANTIFIRE);
 		}
 
-		if (event.getMessage().equals("<col=7f007f>Your antifire potion has expired.</col>"))
+		if (event.getMessage().equals(ANTIFIRE_EXPIRED_MESSAGE))
 		{
 			//they have the same expired message
 			removeGameTimer(ANTIFIRE);
@@ -374,62 +399,62 @@ public class TimersPlugin extends Plugin
 
 		}
 
-		if (config.showCannon() && (event.getMessage().equals("You add the furnace.") || event.getMessage().contains("You repair your cannon, restoring it to working order.")))
+		if (config.showCannon() && (event.getMessage().equals(CANNON_FURNACE_MESSAGE) || event.getMessage().contains(CANNON_REPAIR_MESSAGE)))
 		{
 			createGameTimer(CANNON);
 		}
 
-		if (event.getMessage().equals("You pick up the cannon. It's really heavy."))
+		if (event.getMessage().equals(CANNON_PICKUP_MESSAGE))
 		{
 			removeGameTimer(CANNON);
 		}
 
-		if (config.showAntiVenomPlus() && event.getMessage().contains("You drink some of your super antivenom potion"))
+		if (config.showAntiVenomPlus() && event.getMessage().contains(SUPER_ANTIVENOM_DRINK_MESSAGE))
 		{
 			createGameTimer(ANTIVENOMPLUS);
 		}
 
-		if (config.showMagicImbue() && event.getMessage().equals("You are charged to combine runes!"))
+		if (config.showMagicImbue() && event.getMessage().equals(MAGIC_IMBUE_MESSAGE))
 		{
 			createGameTimer(MAGICIMBUE);
 		}
 
-		if (event.getMessage().equals("Your Magic Imbue charge has ended."))
+		if (event.getMessage().equals(MAGIC_IMBUE_EXPIRED_MESSAGE))
 		{
 			removeGameTimer(MAGICIMBUE);
 		}
 
-		if (config.showTeleblock() && event.getMessage().equals("<col=4f006f>A teleblock spell has been cast on you. It will expire in 5 minutes, 0 seconds.</col>"))
+		if (config.showTeleblock() && event.getMessage().equals(FULL_TELEBLOCK_MESSAGE))
 		{
 			createGameTimer(FULLTB);
 		}
 
-		if (config.showTeleblock() && event.getMessage().equals("<col=4f006f>A teleblock spell has been cast on you. It will expire in 2 minutes, 30 seconds.</col>"))
+		if (config.showTeleblock() && event.getMessage().equals(HALF_TELEBLOCK_MESSAGE))
 		{
 			createGameTimer(HALFTB);
 		}
 
-		if (config.showSuperAntiFire() && event.getMessage().contains("You drink some of your super antifire potion"))
+		if (config.showSuperAntiFire() && event.getMessage().contains(SUPER_ANTIFIRE_DRINK_MESSAGE))
 		{
 			createGameTimer(SUPERANTIFIRE);
 		}
 
-		if (event.getMessage().equals("<col=7f007f>Your super antifire potion has expired.</col>"))
+		if (event.getMessage().equals(SUPER_ANTIFIRE_EXPIRED_MESSAGE))
 		{
 			removeGameTimer(SUPERANTIFIRE);
 		}
 
-		if (event.getMessage().equals("<col=ef1020>Your imbued heart has regained its magical power.</col>"))
+		if (event.getMessage().equals(IMBUED_HEART_READY_MESSAGE))
 		{
 			removeGameTimer(IMBUEDHEART);
 		}
 
-		if (config.showAntiVenom() && event.getMessage().contains("You drink some of your antivenom potion"))
+		if (config.showAntiVenom() && event.getMessage().contains(ANTIVENOM_DRINK_MESSAGE))
 		{
 			createGameTimer(ANTIVENOM);
 		}
 
-		if (config.showSanfew() && event.getMessage().contains("You drink some of your Sanfew Serum."))
+		if (config.showSanfew() && event.getMessage().contains(SANFEW_SERUM_DRINK_MESSAGE))
 		{
 			createGameTimer(SANFEW);
 		}
@@ -439,22 +464,22 @@ public class TimersPlugin extends Plugin
 			createGameTimer(PRAYER_ENHANCE);
 		}
 
-		if (config.showCharge() && event.getMessage().equals("<col=ef1020>You feel charged with magic power.</col>"))
+		if (config.showCharge() && event.getMessage().equals(CHARGE_MESSAGE))
 		{
 			createGameTimer(CHARGE);
 		}
 
-		if (config.showCharge() && event.getMessage().equals("<col=ef1020>Your magical charge fades away.</col>"))
+		if (config.showCharge() && event.getMessage().equals(CHARGE_EXPIRED_MESSAGE))
 		{
 			removeGameTimer(CHARGE);
 		}
 
-		if (config.showStaffOfTheDead() && event.getMessage().contains("Spirits of deceased evildoers offer you their protection"))
+		if (config.showStaffOfTheDead() && event.getMessage().contains(STAFF_OF_THE_DEAD_SPEC_MESSAGE))
 		{
 			createGameTimer(STAFF_OF_THE_DEAD);
 		}
 
-		if (config.showStaffOfTheDead() && event.getMessage().contains("Your protection fades away"))
+		if (config.showStaffOfTheDead() && event.getMessage().contains(STAFF_OF_THE_DEAD_SPEC_EXPIRED_MESSAGE))
 		{
 			removeGameTimer(STAFF_OF_THE_DEAD);
 		}
@@ -618,7 +643,7 @@ public class TimersPlugin extends Plugin
 				case ItemID.TOXIC_STAFF_OF_THE_DEAD:
 				case ItemID.STAFF_OF_LIGHT:
 				case ItemID.TOXIC_STAFF_UNCHARGED:
-					// don't reset timer if still weilding staff
+					// don't reset timer if still wielding staff
 					return;
 				default:
 					removeGameTimer(STAFF_OF_THE_DEAD);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpInfoBox.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpInfoBox.java
@@ -48,9 +48,9 @@ import net.runelite.client.ui.ColorScheme;
 import net.runelite.client.ui.DynamicGridLayout;
 import net.runelite.client.ui.FontManager;
 import net.runelite.client.ui.components.ProgressBar;
+import net.runelite.client.util.ColorUtil;
 import net.runelite.client.util.LinkBrowser;
 import net.runelite.client.util.StackFormatter;
-import net.runelite.client.util.SwingUtil;
 
 @Slf4j
 class XpInfoBox extends JPanel
@@ -239,6 +239,6 @@ class XpInfoBox extends JPanel
 	static String htmlLabel(String key, int value)
 	{
 		String valueStr = StackFormatter.quantityToRSDecimalStack(value);
-		return String.format(HTML_LABEL_TEMPLATE, SwingUtil.toHexColor(ColorScheme.LIGHT_GRAY_COLOR), key, valueStr);
+		return String.format(HTML_LABEL_TEMPLATE, ColorUtil.toHexColor(ColorScheme.LIGHT_GRAY_COLOR), key, valueStr);
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/util/ColorUtil.java
+++ b/runelite-client/src/main/java/net/runelite/client/util/ColorUtil.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2018, Jordan Atwood <jordan.atwood423@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.util;
+
+import java.awt.Color;
+
+public class ColorUtil
+{
+	private static final String OPENING_COLOR_TAG_START = "<col=";
+	private static final String OPENING_COLOR_TAG_END = ">";
+	private static final String CLOSING_COLOR_TAG = "</col>";
+
+	/**
+	 * Creates a color tag from the given color.
+	 *
+	 * @param color The Color to create a tag from.
+	 * @return      A string of the color tag for the given color.
+	 */
+	public static String colorTag(Color color)
+	{
+		return OPENING_COLOR_TAG_START + colorToHexCode(color) + OPENING_COLOR_TAG_END;
+	}
+
+	/**
+	 * Prepends the given str with an opening color tag of the given color.
+	 *
+	 * @param str   The string to be colorized.
+	 * @param color The color to be used in the color tag.
+	 * @return      The passed str with a prepended color tag.
+	 */
+	public static String prependColorTag(final String str, final Color color)
+	{
+		return colorTag(color) + str;
+	}
+
+	/**
+	 * Wraps the given str with a color tag of the given color.
+	 *
+	 * @param str   The string to be colorized.
+	 * @param color The color to be used in the color tag.
+	 * @return      The passed str wrapped with opening and closing color tags.
+	 */
+	public static String wrapWithColorTag(final String str, final Color color)
+	{
+		return prependColorTag(str, color) + CLOSING_COLOR_TAG;
+	}
+
+	/**
+	 * Converts a given color to it's hexidecimal equivalent.
+	 *
+	 * @param color Color to get hexidecimal string from.
+	 * @return      Hexidecimal string representing the given color, in the form "#abcdef".
+	 */
+	public static String toHexColor(final Color color)
+	{
+		return "#" + colorToHexCode(color);
+	}
+
+	/**
+	 * Linearly interpolates between colors a and b by t.
+	 *
+	 * @param a first color
+	 * @param b second color
+	 * @param t factor
+	 * @return  interpolated color
+	 */
+	public static Color colorLerp(final Color a, final Color b, final double t)
+	{
+		final double r1 = a.getRed();
+		final double r2 = b.getRed();
+		final double g1 = a.getGreen();
+		final double g2 = b.getGreen();
+		final double b1 = a.getBlue();
+		final double b2 = b.getBlue();
+
+		return new Color(
+			(int) Math.round(r1 + (t * (r2 - r1))),
+			(int) Math.round(g1 + (t * (g2 - g1))),
+			(int) Math.round(b1 + (t * (b2 - b1)))
+		);
+	}
+
+	/**
+	 * Gets the RGB hex color code of the passed color.
+	 *
+	 * @param color The color to get a hex code from.
+	 * @return      A lower-cased string of the RGB hex code of color.
+	 */
+	static String colorToHexCode(final Color color)
+	{
+		return String.format("%06x", color.getRGB() & 0xFFFFFF);
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/util/SwingUtil.java
+++ b/runelite-client/src/main/java/net/runelite/client/util/SwingUtil.java
@@ -141,14 +141,6 @@ public class SwingUtil
 	}
 
 	/**
-	 * Converts a given color to it's hexidecimal equivalent.
-	 */
-	public static String toHexColor(Color color)
-	{
-		return "#" + Integer.toHexString(color.getRGB()).substring(2);
-	}
-
-	/**
 	 * Safely sets Swing theme
 	 *
 	 * @param laf the swing look and feel
@@ -373,26 +365,4 @@ public class SwingUtil
 		return SubstanceCoreUtilities.getTitlePaneComponent(frame) != null;
 	}
 
-	/**
-	 * Linearly interpolates between colors a and b by t.
-	 * @param a first color
-	 * @param b second color
-	 * @param t factor
-	 * @return interpolated color
-	 */
-	public static Color colorLerp(Color a, Color b, double t)
-	{
-		final double r1 = a.getRed();
-		final double r2 = b.getRed();
-		final double g1 = a.getGreen();
-		final double g2 = b.getGreen();
-		final double b1 = a.getBlue();
-		final double b2 = b.getBlue();
-
-		return new Color(
-			(int) Math.round(r1 + (t * (r2 - r1))),
-			(int) Math.round(g1 + (t * (g2 - g1))),
-			(int) Math.round(b1 + (t * (b2 - b1)))
-		);
-	}
 }

--- a/runelite-client/src/test/java/net/runelite/client/util/ColorUtilTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/util/ColorUtilTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2018, Jordan Atwood <jordan.atwood423@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.util;
+
+import java.awt.Color;
+import java.util.HashMap;
+import java.util.Map;
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+
+public class ColorUtilTest
+{
+	private static final Map<Color, String> COLOR_HEXSTRING_MAP = new HashMap<Color, String>()
+	{{
+		put(Color.BLACK, "000000");
+		put(new Color(0x1), "000001");
+		put(new Color(0x100000), "100000");
+		put(Color.RED, "ff0000");
+		put(Color.GREEN, "00ff00");
+		put(Color.BLUE, "0000ff");
+		put(new Color(0xA1B2C3), "a1b2c3");
+		put(Color.WHITE, "ffffff");
+	}};
+
+	@Test
+	public void colorTag()
+	{
+		COLOR_HEXSTRING_MAP.forEach((color, hex) -> {
+			assertEquals("<col=" + hex + ">", ColorUtil.colorTag(color));
+		});
+	}
+
+	@Test
+	public void prependColorTag()
+	{
+		COLOR_HEXSTRING_MAP.forEach((color, hex) -> {
+			assertEquals("<col=" + hex + ">test", ColorUtil.prependColorTag("test", color));
+			assertEquals("<col=" + hex + ">", ColorUtil.prependColorTag("", color));
+		});
+
+		assertEquals("<col=ff0000>94<col=ffffff>/99", ColorUtil.prependColorTag("94" + ColorUtil.prependColorTag("/99", Color.WHITE), Color.RED));
+	}
+
+	@Test
+	public void wrapWithColorTag()
+	{
+		COLOR_HEXSTRING_MAP.forEach((color, hex) -> {
+			assertEquals("<col=" + hex + ">test</col>", ColorUtil.wrapWithColorTag("test", color));
+			assertEquals("<col=" + hex + "></col>", ColorUtil.wrapWithColorTag("", color));
+		});
+	}
+
+	@Test
+	public void toHexColor()
+	{
+		COLOR_HEXSTRING_MAP.forEach((color, hex) -> {
+			assertEquals("#" + hex, ColorUtil.toHexColor(color));
+		});
+	}
+
+	@Test
+	public void colorLerp()
+	{
+		assertEquals(Color.WHITE, ColorUtil.colorLerp(Color.WHITE, Color.WHITE, 0.9));
+		assertEquals(new Color(128, 128, 128), ColorUtil.colorLerp(Color.BLACK, Color.WHITE, 0.5));
+		assertEquals(Color.BLACK, ColorUtil.colorLerp(Color.BLACK, Color.CYAN, 0));
+		assertEquals(Color.CYAN, ColorUtil.colorLerp(Color.BLACK, Color.CYAN, 1));
+	}
+
+	@Test
+	public void colorToHexCode()
+	{
+		COLOR_HEXSTRING_MAP.forEach((color, hex) -> {
+			assertEquals(hex, ColorUtil.colorToHexCode(color));
+		});
+	}
+}


### PR DESCRIPTION
This adds `ColorUtil::colorTag`, `ColorUtil::prependColorTag`, and `ColorUtil::wrapWithColorTag`, and implements them in existing plugins, as well as moving some color-related functions from `SwingUtil` into this new class.

Uses of `<col` in strings have been maintained as it is entirely proprietary to our code. (specifically the chat notifications plugin) Some uses of `<col=` ([1](https://github.com/Nightfirecat/runelite/blob/37407976a529cffc4cf34ee8fef5216c750a76b2/runelite-client/src/main/java/net/runelite/client/plugins/itemcharges/ItemChargePlugin.java#L53), [2](https://github.com/Nightfirecat/runelite/blob/37407976a529cffc4cf34ee8fef5216c750a76b2/runelite-client/src/main/java/net/runelite/client/plugins/kourendlibrary/KourendLibraryPlugin.java#L199), [3](https://github.com/Nightfirecat/runelite/blob/cfd06f7c9a855592982de318dbb4fed0f54edc6c/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersPlugin.java#L93-L116), [4](https://github.com/Nightfirecat/runelite/blob/37407976a529cffc4cf34ee8fef5216c750a76b2/runelite-client/src/main/java/net/runelite/client/ui/overlay/components/TextComponent.java#L39)) in strings have been maintained for readability and have been moved as needed to constants.