### PR TITLE
Make SOTD/SOTL timer use chat messsage

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/timers/GameTimer.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timers/GameTimer.java
@@ -71,7 +71,7 @@ public enum GameTimer
 	ANTIPOISON("antipoison", "Antipoison", 90, ChronoUnit.SECONDS),
 	SUPERANTIPOISON("superantipoison", "Superantipoison", 346, ChronoUnit.SECONDS),
 	CHARGE("charge", "Charge", 6, ChronoUnit.MINUTES),
-	STAFF_OF_THE_DEAD("staffofthedead", "Staff of the Dead", GraphicID.STAFF_OF_THE_DEAD, 1, ChronoUnit.MINUTES);
+	STAFF_OF_THE_DEAD("staffofthedead", "Staff of the Dead", 1, ChronoUnit.MINUTES);
 
 	@Getter
 	private final String imageResource;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersPlugin.java
@@ -429,9 +429,19 @@ public class TimersPlugin extends Plugin
 			createGameTimer(CHARGE);
 		}
 
-		if (event.getMessage().equals("<col=ef1020>Your magical charge fades away.</col>"))
+		if (config.showCharge() && event.getMessage().equals("<col=ef1020>Your magical charge fades away.</col>"))
 		{
 			removeGameTimer(CHARGE);
+		}
+
+		if (config.showStaffOfTheDead() && event.getMessage().contains("Spirits of deceased evildoers offer you their protection"))
+		{
+			createGameTimer(STAFF_OF_THE_DEAD);
+		}
+
+		if (config.showStaffOfTheDead() && event.getMessage().contains("Your protection fades away"))
+		{
+			removeGameTimer(STAFF_OF_THE_DEAD);
 		}
 	}
 
@@ -472,11 +482,6 @@ public class TimersPlugin extends Plugin
 		if (config.showVengeance() && actor.getGraphic() == VENGEANCE.getGraphicId())
 		{
 			createGameTimer(VENGEANCE);
-		}
-
-		if (config.showStaffOfTheDead() && actor.getGraphic() == STAFF_OF_THE_DEAD.getGraphicId())
-		{
-			createGameTimer(STAFF_OF_THE_DEAD);
 		}
 
 		if (config.showFreezes())


### PR DESCRIPTION
Instead of using graphic make SOTD/SOTL timer use chat message as that
one is more reliable and same for both.

Fixes #4078

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>