### PR TITLE
Return preferredSize.width from TitleComponent

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/components/TitleComponent.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/components/TitleComponent.java
@@ -58,6 +58,6 @@ public class TitleComponent implements LayoutableRenderableEntity
 		titleComponent.setPosition(new Point((preferredSize.width - metrics.stringWidth(text)) / 2, metrics.getHeight()));
 		final Dimension dimension = titleComponent.render(graphics);
 		graphics.translate(-preferredLocation.x, -preferredLocation.y);
-		return new Dimension(Math.min(preferredSize.width, dimension.width), dimension.height);
+		return new Dimension(preferredSize.width, dimension.height);
 	}
 }


### PR DESCRIPTION
To return parent defined dimensions properly, return preferredSize.width
instead of text width, as this is block component so it should act like
block and not return custom sizes.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>