### PR TITLE
Fix #4101 - Add swap options for Decant

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -243,4 +243,15 @@ public interface MenuEntrySwapperConfig extends Config
 	{
 		return true;
 	}
+
+	@ConfigItem(
+		position = 19,
+		keyName = "swapDecant",
+		name = "Decant",
+		description = "Swap Talk-to with Decant for Bob Barter and Murky Matt at the Grand Exchange."
+	)
+	default boolean swapDecant()
+	{
+		return false;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -385,6 +385,11 @@ public class MenuEntrySwapperPlugin extends Plugin
 			{
 				swap("pay", option, target, true);
 			}
+
+			if (config.swapDecant())
+			{
+				swap("decant", option, target, true);
+			}
 		}
 		else if (config.swapTravel() && option.equals("pass") && target.equals("energy barrier"))
 		{


### PR DESCRIPTION
This pull request adds the ability to swap the talk-to menu entry with the decant menu entry which is used at NPC's at the GE. 
The default state for this is set to off, to not conflict with anyone's existing gameplay.

Fix #4101 