### PR TITLE
Add pause skill timing feature to the XP Tracker

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpPanel.java
@@ -172,13 +172,13 @@ class XpPanel extends PluginPanel
 		}
 	}
 
-	void updateSkillExperience(boolean updated, Skill skill, XpSnapshotSingle xpSnapshotSingle)
+	void updateSkillExperience(boolean updated, boolean paused, Skill skill, XpSnapshotSingle xpSnapshotSingle)
 	{
 		final XpInfoBox xpInfoBox = infoBoxes.get(skill);
 
 		if (xpInfoBox != null)
 		{
-			xpInfoBox.update(updated, xpSnapshotSingle);
+			xpInfoBox.update(updated, paused, xpSnapshotSingle);
 		}
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpPauseState.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpPauseState.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2018, Levi <me@levischuck.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.xptracker;
+
+import java.util.EnumMap;
+import java.util.Map;
+import net.runelite.api.Skill;
+
+class XpPauseState
+{
+	// Internal state
+	private final Map<Skill, XpPauseStateSingle> skillPauses = new EnumMap<>(Skill.class);
+	private boolean cachedIsLoggedIn = false;
+
+	boolean pauseSkill(Skill skill)
+	{
+		return findPauseState(skill).manualPause();
+	}
+
+	boolean unpauseSkill(Skill skill)
+	{
+		return findPauseState(skill).unpause();
+	}
+
+	boolean isPaused(Skill skill)
+	{
+		return findPauseState(skill).isPaused();
+	}
+
+	void tickXp(Skill skill, int currentXp, int pauseAfterMinutes)
+	{
+		final XpPauseStateSingle state = findPauseState(skill);
+
+		if (state.getXp() != currentXp)
+		{
+			state.xpChanged(currentXp);
+		}
+		else if (pauseAfterMinutes > 0)
+		{
+			final long now = System.currentTimeMillis();
+			final int pauseAfterMillis = pauseAfterMinutes * 60 * 1000;
+			final long lastChangeMillis = state.getLastChangeMillis();
+			// When config.pauseSkillAfter is 0, it is effectively disabled
+			if (lastChangeMillis != 0 && (now - lastChangeMillis) >= pauseAfterMillis)
+			{
+				state.timeout();
+			}
+		}
+	}
+
+	void tickLogout(boolean pauseOnLogout, boolean loggedIn)
+	{
+		// Deduplicated login and logout calls
+		if (!cachedIsLoggedIn && loggedIn)
+		{
+			cachedIsLoggedIn = true;
+
+			for (Skill skill : Skill.values())
+			{
+				findPauseState(skill).login();
+			}
+		}
+		else if (cachedIsLoggedIn && !loggedIn)
+		{
+			cachedIsLoggedIn = false;
+
+			// If configured, then let the pause state know to pause with reason: logout
+			if (pauseOnLogout)
+			{
+				for (Skill skill : Skill.values())
+				{
+					findPauseState(skill).logout();
+				}
+			}
+		}
+	}
+
+	private XpPauseStateSingle findPauseState(Skill skill)
+	{
+		return skillPauses.computeIfAbsent(skill, XpPauseStateSingle::new);
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpPauseStateSingle.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpPauseStateSingle.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2018, Levi <me@levischuck.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.xptracker;
+
+import java.util.EnumSet;
+import java.util.Set;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import net.runelite.api.Skill;
+
+@RequiredArgsConstructor
+class XpPauseStateSingle
+{
+	@Getter
+	private final Skill skill;
+	private final Set<XpPauseReason> pauseReasons = EnumSet.noneOf(XpPauseReason.class);
+	@Getter
+	private long lastChangeMillis;
+	@Getter
+	private int xp;
+
+	boolean isPaused()
+	{
+		return !pauseReasons.isEmpty();
+	}
+
+	boolean login()
+	{
+		return pauseReasons.remove(XpPauseReason.PAUSED_LOGOUT);
+	}
+
+	boolean logout()
+	{
+		return pauseReasons.add(XpPauseReason.PAUSED_LOGOUT);
+	}
+
+	boolean timeout()
+	{
+		return pauseReasons.add(XpPauseReason.PAUSED_TIMEOUT);
+	}
+
+	boolean manualPause()
+	{
+		return pauseReasons.add(XpPauseReason.PAUSE_MANUAL);
+	}
+
+	boolean xpChanged(int xp)
+	{
+		this.xp = xp;
+		this.lastChangeMillis = System.currentTimeMillis();
+		return clearAll();
+	}
+
+	boolean unpause()
+	{
+		this.lastChangeMillis = System.currentTimeMillis();
+		return clearAll();
+	}
+
+	private boolean clearAll()
+	{
+		if (pauseReasons.isEmpty())
+		{
+			return false;
+		}
+
+		pauseReasons.clear();
+		return true;
+	}
+
+	private enum XpPauseReason
+	{
+		PAUSE_MANUAL,
+		PAUSED_LOGOUT,
+		PAUSED_TIMEOUT
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpState.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpState.java
@@ -120,6 +120,11 @@ class XpState
 		}
 	}
 
+	void tick(Skill skill, long delta)
+	{
+		getSkill(skill).tick(delta);
+	}
+
 	/**
 	 * Forcefully initialize a skill with a known start XP from the current XP.
 	 * This is used in resetAndInitState by the plugin. It should not result in showing the XP in the UI.

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpStateSingle.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpStateSingle.java
@@ -25,8 +25,6 @@
  */
 package net.runelite.client.plugins.xptracker;
 
-import java.time.Duration;
-import java.time.Instant;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -45,7 +43,7 @@ class XpStateSingle
 	@Getter
 	private int xpGained = 0;
 
-	private Instant skillTimeStart = null;
+	private long skillTime = 0;
 	private int actions = 0;
 	private int startLevelExp = 0;
 	private int endLevelExp = 0;
@@ -65,7 +63,7 @@ class XpStateSingle
 
 	private int toHourly(int value)
 	{
-		if (skillTimeStart == null)
+		if (skillTime == 0)
 		{
 			return 0;
 		}
@@ -75,7 +73,7 @@ class XpStateSingle
 
 	private long getTimeElapsedInSeconds()
 	{
-		if (skillTimeStart == null)
+		if (skillTime == 0)
 		{
 			return 0;
 		}
@@ -84,7 +82,7 @@ class XpStateSingle
 		// To prevent that, pretend the skill has been active for a minute (60 seconds)
 		// This will create a lower estimate for the first minute,
 		// but it isn't ridiculous like saying 2 billion XP per hour.
-		return Math.max(60, Duration.between(skillTimeStart, Instant.now()).getSeconds());
+		return Math.max(60, skillTime / 1000);
 	}
 
 	private int getXpRemaining()
@@ -229,13 +227,12 @@ class XpStateSingle
 			endLevelExp = goalEndXp;
 		}
 
-		// If this is first time we are updating, we just started tracking
-		if (skillTimeStart == null)
-		{
-			skillTimeStart = Instant.now();
-		}
-
 		return true;
+	}
+
+	public void tick(long delta)
+	{
+		skillTime += delta;
 	}
 
 	XpSnapshotSingle snapshot()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerConfig.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2018, Levi <me@levischuck.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.xptracker;
+
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+
+@ConfigGroup("xpTracker")
+public interface XpTrackerConfig extends Config
+{
+	@ConfigItem(
+		position = 0,
+		keyName = "logoutPausing",
+		name = "Pause on Logout",
+		description = "Configures whether skills should pause on logout"
+	)
+	default boolean pauseOnLogout()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		position = 1,
+		keyName = "pauseSkillAfter",
+		name = "Auto pause after",
+		description = "Configures how many minutes passes before pausing a skill while in game and there's no XP, 0 means disabled"
+	)
+	default int pauseSkillAfter()
+	{
+		return 0;
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/ui/components/DimmableJPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/components/DimmableJPanel.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2018, Levi <me@levischuck.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.ui.components;
+
+import java.awt.Color;
+import javax.swing.JPanel;
+import lombok.Getter;
+
+public class DimmableJPanel extends JPanel
+{
+	// Dimming state, allows for restoring original colors before dimming
+	@Getter
+	private boolean dimmed = false;
+	private Color dimmedForeground = null;
+	private Color dimmedBackground = null;
+	private Color undimmedForeground = null;
+	private Color undimmedBackground = null;
+
+	@Override
+	public void setForeground(Color color)
+	{
+		undimmedForeground = color;
+		dimmedForeground = color.darker();
+		super.setForeground(color);
+	}
+
+	@Override
+	public void setBackground(Color color)
+	{
+		undimmedBackground = color;
+		dimmedBackground = color.darker();
+		super.setBackground(color);
+	}
+
+	@Override
+	public Color getForeground()
+	{
+		return dimmed ? dimmedForeground : undimmedForeground;
+	}
+
+	@Override
+	public Color getBackground()
+	{
+		return dimmed ? dimmedBackground : undimmedBackground;
+	}
+
+	/**
+	 * Dimming sets all parts of this component with darker colors except for the central label
+	 * This is useful for showing that progress is paused
+	 * Setting dim to false will restore the original colors from before the component was dimmed.
+	 * @param dimmed
+	 */
+	public void setDimmed(boolean dimmed)
+	{
+		this.dimmed = dimmed;
+
+		if (dimmed)
+		{
+			super.setBackground(dimmedBackground);
+			super.setForeground(dimmedForeground);
+		}
+		else
+		{
+			super.setBackground(undimmedBackground);
+			super.setForeground(undimmedForeground);
+		}
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/ui/components/ProgressBar.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/components/ProgressBar.java
@@ -29,7 +29,6 @@ import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Graphics;
 import javax.swing.JLabel;
-import javax.swing.JPanel;
 import javax.swing.SwingConstants;
 import javax.swing.border.EmptyBorder;
 import lombok.Setter;
@@ -39,7 +38,7 @@ import net.runelite.client.ui.components.shadowlabel.JShadowedLabel;
 /**
  * A progress bar to be displayed underneath the GE offer item panels
  */
-public class ProgressBar extends JPanel
+public class ProgressBar extends DimmableJPanel
 {
 	@Setter
 	private int maximumValue;
@@ -50,11 +49,16 @@ public class ProgressBar extends JPanel
 	private final JLabel leftLabel = new JShadowedLabel();
 	private final JLabel rightLabel = new JShadowedLabel();
 	private final JLabel centerLabel = new JShadowedLabel();
+	private String centerLabelText = "";
+	private String dimmedText = "";
 
 	public ProgressBar()
 	{
 		setLayout(new BorderLayout());
+		// The background color should be overridden
 		setBackground(Color.GREEN.darker());
+		setForeground(Color.GREEN.brighter());
+
 		setPreferredSize(new Dimension(100, 16));
 
 		leftLabel.setFont(FontManager.getRunescapeSmallFont());
@@ -70,10 +74,10 @@ public class ProgressBar extends JPanel
 		centerLabel.setHorizontalAlignment(SwingConstants.CENTER);
 		centerLabel.setBorder(new EmptyBorder(2, 0, 0, 0));
 
+		// Adds components to be automatically redrawn when paintComponents is called
 		add(leftLabel, BorderLayout.WEST);
 		add(centerLabel, BorderLayout.CENTER);
 		add(rightLabel, BorderLayout.EAST);
-
 	}
 
 	@Override
@@ -88,20 +92,45 @@ public class ProgressBar extends JPanel
 		super.paintComponents(g);
 	}
 
+	@Override
+	public void setDimmed(boolean dimmed)
+	{
+		super.setDimmed(dimmed);
+
+		if (dimmed)
+		{
+			leftLabel.setForeground(Color.GRAY);
+			rightLabel.setForeground(Color.GRAY);
+			centerLabel.setText(dimmedText);
+		}
+		else
+		{
+			leftLabel.setForeground(Color.WHITE);
+			rightLabel.setForeground(Color.WHITE);
+			centerLabel.setText(centerLabelText);
+		}
+	}
 
 	public void setLeftLabel(String txt)
 	{
-		this.leftLabel.setText(txt);
+		leftLabel.setText(txt);
 	}
 
 	public void setRightLabel(String txt)
 	{
-		this.rightLabel.setText(txt);
+		rightLabel.setText(txt);
 	}
 
 	public void setCenterLabel(String txt)
 	{
-		this.centerLabel.setText(txt);
+		centerLabelText = txt;
+		centerLabel.setText(isDimmed() ? dimmedText : txt);
+	}
+
+	public void setDimmedText(String txt)
+	{
+		dimmedText = txt;
+		centerLabel.setText(isDimmed() ? txt : centerLabelText);
 	}
 
 	public double getPercentage()


### PR DESCRIPTION
Add the ability to manually pause a skill, automatically pause a skill after logout, or after a timeout of no XP changes. Similarly, skills will be auto unpaused when XP is gained or when (if paused due to logout) logged back in.

## Motivation
Some players would like to pause their expectations on skill ETAs when having lunch, going on a break, or sleeping for the night. By only counting effective time in game, players don't need to account for time outside of game or between skills when training.

## Configuration changes
![image](https://user-images.githubusercontent.com/245911/42144919-8d3139fe-7d83-11e8-81af-b1e489497ee7.png)

Added a setting for pausing skills without any XP changes, default value: 0 which behaves as no auto pausing by timeout
Added a setting for auto pausing skills in relation to logout, default value: Never

## Changes to default behavior
No changes to default behavior

## UI Changes
ProgressBar now extends a new Component class which comes with dimming of the foreground and background color.
ProgressBar will also dim the left and right label, with the expectation that the center label be used for an alternate display text.
![image](https://user-images.githubusercontent.com/245911/42130569-940a51b4-7cae-11e8-80dc-c8ca5cb663a5.png)

Within the XP Tracker panel, right clicking on a skill will bring up a "Pause" menu item.
![image](https://user-images.githubusercontent.com/245911/42130619-9b5c4e9e-7caf-11e8-8db6-31e82d08fb89.png)
When a skill is paused, it will be labeled as "Unpause"

## Example
![logout-pausing](https://user-images.githubusercontent.com/245911/42190792-b07dbd96-7e24-11e8-9c5d-2501f6e1291c.gif)


Resolves #3598 
Resolves #3113