### PR TITLE
farmingtracker: Correct several patch timings

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/farmingtracker/PatchImplementation.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/farmingtracker/PatchImplementation.java
@@ -74,7 +74,7 @@ public enum PatchImplementation
 				if (value == 31)
 				{
 					// Cactus[Check-health,Inspect,,Guide,] 7758
-					return new PatchState(Produce.CACTUS, CropState.GROWING, 6);
+					return new PatchState(Produce.CACTUS, CropState.GROWING, 7);
 				}
 				if (value >= 32 && value <= 255)
 				{
@@ -1784,7 +1784,7 @@ public enum PatchImplementation
 				if (value == 12)
 				{
 					// Oak[Check-health,Inspect,,Guide,] 8466
-					return new PatchState(Produce.OAK, CropState.GROWING, 5);
+					return new PatchState(Produce.OAK, CropState.GROWING, 4);
 				}
 				if (value == 13)
 				{
@@ -1804,7 +1804,7 @@ public enum PatchImplementation
 				if (value == 21)
 				{
 					// Willow Tree[Check-health,Inspect,,Guide,] 8487
-					return new PatchState(Produce.WILLOW, CropState.GROWING, 7);
+					return new PatchState(Produce.WILLOW, CropState.GROWING, 6);
 				}
 				if (value == 22)
 				{
@@ -1844,7 +1844,7 @@ public enum PatchImplementation
 				if (value >= 36 && value <= 44)
 				{
 					// Yew tree[,Inspect,,Guide,] 8503,8504,8505,8506,8507,8508,8509,8510,8511
-					return new PatchState(Produce.YEW, CropState.GROWING, value - 36);
+					return new PatchState(Produce.YEW, CropState.GROWING, value - 35);
 				}
 				if (value == 45)
 				{
@@ -1894,7 +1894,7 @@ public enum PatchImplementation
 				if (value == 77)
 				{
 					// Diseased Oak[Prune,Inspect,,Guide,] 8476
-					return new PatchState(Produce.OAK, CropState.DISEASED, 5);
+					return new PatchState(Produce.OAK, CropState.DISEASED, 4);
 				}
 				if (value >= 78 && value <= 79)
 				{
@@ -1909,7 +1909,7 @@ public enum PatchImplementation
 				if (value == 86)
 				{
 					// Diseased Willow[Prune,Inspect,,Guide,] 8495
-					return new PatchState(Produce.WILLOW, CropState.DISEASED, 7);
+					return new PatchState(Produce.WILLOW, CropState.DISEASED, 6);
 				}
 				if (value >= 87 && value <= 88)
 				{
@@ -1969,7 +1969,7 @@ public enum PatchImplementation
 				if (value == 141)
 				{
 					// Dead Oak[Clear,Inspect,,Guide,] 8480
-					return new PatchState(Produce.OAK, CropState.DEAD, 5);
+					return new PatchState(Produce.OAK, CropState.DEAD, 4);
 				}
 				if (value >= 142 && value <= 143)
 				{
@@ -1984,7 +1984,7 @@ public enum PatchImplementation
 				if (value == 150)
 				{
 					// Dead Willow[Clear,Inspect,,Guide,] 8501
-					return new PatchState(Produce.WILLOW, CropState.DEAD, 7);
+					return new PatchState(Produce.WILLOW, CropState.DEAD, 6);
 				}
 				if (value >= 151 && value <= 152)
 				{
@@ -2072,7 +2072,7 @@ public enum PatchImplementation
 				if (value == 15)
 				{
 					// Teak Tree[Check-health,Inspect,,Guide,] 30444
-					return new PatchState(Produce.TEAK, CropState.GROWING, 8);
+					return new PatchState(Produce.TEAK, CropState.GROWING, 7);
 				}
 				if (value == 16)
 				{
@@ -2102,12 +2102,12 @@ public enum PatchImplementation
 				if (value >= 31 && value <= 37)
 				{
 					// Mahogany tree[,Inspect,,Guide,] 30407,30408,30409,30410,30411,30412,30413
-					return new PatchState(Produce.MAHOGANY, CropState.GROWING, value - 31);
+					return new PatchState(Produce.MAHOGANY, CropState.GROWING, value - 30);
 				}
 				if (value == 38)
 				{
 					// Mahogany tree[Check-health,Inspect,,Guide,] 30416
-					return new PatchState(Produce.MAHOGANY, CropState.GROWING, 9);
+					return new PatchState(Produce.MAHOGANY, CropState.GROWING, 8);
 				}
 				if (value == 39)
 				{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/farmingtracker/Produce.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/farmingtracker/Produce.java
@@ -88,8 +88,8 @@ public enum Produce
 	ANYHERB("Any Herb", ItemID.GUAM_LEAF, 20, 5, 0, 3),
 
 	// Tree crops
-	OAK("Oak", ItemID.OAK_LOGS, 40, 6),
-	WILLOW("Willow", ItemID.WILLOW_LOGS, 40, 8),
+	OAK("Oak", ItemID.OAK_LOGS, 40, 5),
+	WILLOW("Willow", ItemID.WILLOW_LOGS, 40, 7),
 	MAPLE("Maple", ItemID.MAPLE_TREE, 40, 9),
 	YEW("Yew", ItemID.YEW_TREE, 40, 11),
 	MAGIC("Magic", ItemID.MAGIC_LOGS, 40, 13),
@@ -104,11 +104,11 @@ public enum Produce
 	PALM("Palm", ItemID.COCONUT, 160, 7, 45, 7),
 
 	// Special crops
-	SEAWEED("Seaweed", ItemID.GIANT_SEAWEED, 5, 8, 0, 4),
-	TEAK("Teak", ItemID.TEAK_LOGS, 560, 9),
+	SEAWEED("Seaweed", ItemID.GIANT_SEAWEED, 10, 5, 0, 4),
+	TEAK("Teak", ItemID.TEAK_LOGS, 560, 8),
 	GRAPE("Grape", ItemID.GRAPES, 5, 8, 0, 5),
 	MUSHROOM("Mushroom", ItemID.MUSHROOM, 40, 7, 0, 7),
-	MAHOGANY("Mahogany", ItemID.MAHOGANY_LOGS, 640, 10),
+	MAHOGANY("Mahogany", ItemID.MAHOGANY_LOGS, 640, 9),
 	CACTUS("Cactus", ItemID.POTATO_CACTUS, 80, 8, 20, 4),
 	BELLADONNA("Belladonna", ItemID.CAVE_NIGHTSHADE, 80, 5),
 	CALQUAT("Calquat", ItemID.CALQUAT_FRUIT, 160, 9, 0, 7),

--- a/runelite-client/src/test/java/net/runelite/client/plugins/farmingtracker/PatchImplementationTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/farmingtracker/PatchImplementationTest.java
@@ -24,6 +24,8 @@
  */
 package net.runelite.client.plugins.farmingtracker;
 
+import java.util.HashMap;
+import java.util.Map;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -34,6 +36,7 @@ public class PatchImplementationTest
 	{
 		for (PatchImplementation impl : PatchImplementation.values())
 		{
+			Map<Produce, boolean[]> harvestStages = new HashMap<>();
 			for (int i = 0; i < 256; i++)
 			{
 				PatchState s = impl.forVarbitValue(i);
@@ -53,6 +56,20 @@ public class PatchImplementationTest
 					{
 						Assert.assertTrue(pfx + ": dead seed", s.getStage() > 0);
 					}
+					if (s.getCropState() == CropState.GROWING && s.getProduce() != Produce.WEEDS)
+					{
+						harvestStages.computeIfAbsent(s.getProduce(), k -> new boolean[s.getProduce().getStages()])[s.getStage()] = true;
+					}
+				}
+			}
+
+			for (Map.Entry<Produce, boolean[]> produce : harvestStages.entrySet())
+			{
+				boolean[] states = produce.getValue();
+				// Alot of time the final stage is not hit, because some plants do not have a "Check-health" stage
+				for (int i = 0; i < states.length - 1; i++)
+				{
+					Assert.assertTrue(produce.getKey().getName() + " stage " + i + " never found by varbit", states[i]);
 				}
 			}
 		}


### PR DESCRIPTION
There were several places where the autogenerated patch implementations would double count a stage, and miss another. PatchImplementationTest now checks for missed stages, excluding the final stage because that is often missed on plants which do not have a "Check-health" stage. There were also a couple produces with incorrect tick counts.

Supersedes #4119