### PR TITLE
Fix empty GE search render bug

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangeSearchPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangeSearchPanel.java
@@ -184,6 +184,7 @@ class GrandExchangeSearchPanel extends JPanel
 		if (Strings.isNullOrEmpty(lookup))
 		{
 			searchItemsPanel.removeAll();
+			SwingUtilities.invokeLater(searchItemsPanel::updateUI);
 			return;
 		}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangeSearchPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangeSearchPanel.java
@@ -204,7 +204,7 @@ class GrandExchangeSearchPanel extends JPanel
 			log.warn("Unable to search for item {}", lookup, ex);
 			searchBox.setIcon(ERROR_ICON);
 			searchBox.setEditable(true);
-			errorPanel.setContent("Error fetching results", "An error occured why trying to fetch item data, please try again later.");
+			errorPanel.setContent("Error fetching results", "An error occurred while trying to fetch item data, please try again later.");
 			cardLayout.show(centerPanel, ERROR_PANEL);
 			return;
 		}


### PR DESCRIPTION
Before: (note: the render is refreshed upon attempting to scroll while hovering the old rendered panels)
![Blank GE search render bug](https://user-images.githubusercontent.com/2199511/42140211-7ecfe060-7d8b-11e8-937b-66545553a42f.gif)

After:
![Blank GE search render bug fixed](https://user-images.githubusercontent.com/2199511/42140213-80a265f2-7d8b-11e8-9b29-1d558ffbcc54.gif)

Also fixes some typos in an error message string in a separate commit.