### PR TITLE
Reset Discord state if now > updated + timeout

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordState.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordState.java
@@ -153,7 +153,7 @@ class DiscordState
 	void checkForTimeout()
 	{
 		final Duration actionTimeout = Duration.ofMinutes(config.actionTimeout());
-		events.removeIf(event -> event.getType().isShouldTimeout() &&
-			event.getUpdated().isAfter(event.getStart().plus(actionTimeout)));
+		final Instant now = Instant.now();
+		events.removeIf(event -> event.getType().isShouldTimeout() && now.isAfter(event.getUpdated().plus(actionTimeout)));
 	}
 }


### PR DESCRIPTION
Correctly reset Discord state only if now > updated + timeout instead of
updated > start + timeout.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>