### PR TITLE
Do not explode on illegal unicode char in settings

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/config/ConfigManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/ConfigManager.java
@@ -185,7 +185,7 @@ public class ConfigManager
 		{
 			log.debug("Unable to load settings - no such file");
 		}
-		catch (IOException ex)
+		catch (IllegalArgumentException | IOException ex)
 		{
 			log.warn("Unable to load settings", ex);
 		}


### PR DESCRIPTION
Prevent client shutting down from main method in case settings contain
illegal unicode string due to config file corruption.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>