### PR TITLE
Fix !kc abbreviations and add more abbreviations

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
@@ -659,8 +659,11 @@ public class ChatCommandsPlugin extends Plugin
 			case "gargs":
 				return "Grotesque Guardians";
 
-			case "archaeologist":
+			case "crazy arch":
 				return "Crazy Archaeologist";
+
+			case "deranged arch":
+				return "Deranged Archaeologist";
 
 			case "mole":
 				return "Giant Mole";
@@ -715,12 +718,17 @@ public class ChatCommandsPlugin extends Plugin
 			case "barrows":
 				return "Barrows Chests";
 
+			case "cox":
 			case "xeric":
+			case "chambers":
 			case "olm":
 			case "raids":
 				return "Chambers of Xeric";
 
+			case "tob":
+			case "theatre":
 			case "verzik":
+			case "verzik vitur":
 			case "raids 2":
 				return "Theatre of Blood";
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
@@ -720,7 +720,7 @@ public class ChatCommandsPlugin extends Plugin
 			case "raids":
 				return "Chambers of Xeric";
 
-			case "verxik":
+			case "verzik":
 			case "raids 2":
 				return "Theatre of Blood";
 


### PR DESCRIPTION
- Remove ambiguous "archaelogist" abbreviation and replace it with
respective crazy and deranged arch abbrevs
- Add "chambers" abbrev to raids 1
- Add "theatre", "verzik" and "verzik vitur" abbrevs to raids 2
- Fix "verxik" typo in ChatCommandsPlugin
