### PR TITLE
ScreenshotPlugin: Bugfixes

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/widgets/WidgetID.java
+++ b/runelite-api/src/main/java/net/runelite/api/widgets/WidgetID.java
@@ -91,7 +91,7 @@ public class WidgetID
 	public static final int BLAST_FURNACE_GROUP_ID = 474;
 	public static final int WORLD_MAP_GROUP_ID = 595;
 	public static final int PYRAMID_PLUNDER_GROUP_ID = 428;
-	public static final int RAIDS_REWARD_GROUP_ID = 539;
+	public static final int CHAMBERS_OF_XERIC_REWARD_GROUP_ID = 539;
 	public static final int EXPERIENCE_TRACKER_GROUP_ID = 122;
 	public static final int TITHE_FARM_GROUP_ID = 241;
 	public static final int KINGDOM_GROUP_ID = 392;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
@@ -61,7 +61,7 @@ import net.runelite.api.events.ChatMessage;
 import net.runelite.api.events.WidgetLoaded;
 import net.runelite.api.widgets.Widget;
 import static net.runelite.api.widgets.WidgetID.BARROWS_REWARD_GROUP_ID;
-import static net.runelite.api.widgets.WidgetID.RAIDS_REWARD_GROUP_ID;
+import static net.runelite.api.widgets.WidgetID.CHAMBERS_OF_XERIC_REWARD_GROUP_ID;
 import static net.runelite.api.widgets.WidgetID.CLUE_SCROLL_REWARD_GROUP_ID;
 import static net.runelite.api.widgets.WidgetID.DIALOG_SPRITE_GROUP_ID;
 import static net.runelite.api.widgets.WidgetID.KINGDOM_GROUP_ID;
@@ -131,7 +131,7 @@ public class ScreenshotPlugin extends Plugin
 
 	private Integer barrowsNumber;
 
-	private Integer raidsNumber;
+	private Integer chambersOfXericNumber;
 
 	private boolean shouldTakeScreenshot;
 
@@ -302,7 +302,7 @@ public class ScreenshotPlugin extends Plugin
 			Matcher m = NUMBER_PATTERN.matcher(Text.removeTags(chatMessage));
 			if (m.find())
 			{
-				raidsNumber = Integer.valueOf(m.group());
+				chambersOfXericNumber = Integer.valueOf(m.group());
 				return;
 			}
 		}
@@ -330,7 +330,7 @@ public class ScreenshotPlugin extends Plugin
 		{
 			case QUEST_COMPLETED_GROUP_ID:
 			case CLUE_SCROLL_REWARD_GROUP_ID:
-			case RAIDS_REWARD_GROUP_ID:
+			case CHAMBERS_OF_XERIC_REWARD_GROUP_ID:
 			case BARROWS_REWARD_GROUP_ID:
 				if (!config.screenshotRewards())
 				{
@@ -360,15 +360,15 @@ public class ScreenshotPlugin extends Plugin
 				takeScreenshot(fileName);
 				break;
 			}
-			case RAIDS_REWARD_GROUP_ID:
+			case CHAMBERS_OF_XERIC_REWARD_GROUP_ID:
 			{
-				if (raidsNumber == null)
+				if (chambersOfXericNumber == null)
 				{
 					return;
 				}
 
-				fileName = "Chambers of Xeric(" + raidsNumber + ")";
-				raidsNumber = null;
+				fileName = "Chambers of Xeric(" + chambersOfXericNumber + ")";
+				chambersOfXericNumber = null;
 				break;
 			}
 			case BARROWS_REWARD_GROUP_ID:
@@ -592,8 +592,8 @@ public class ScreenshotPlugin extends Plugin
 	}
 
 	@VisibleForTesting
-	int getRaidsNumber()
+	int getChambersOfXericNumber()
 	{
-		return raidsNumber;
+		return chambersOfXericNumber;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
@@ -107,7 +107,7 @@ public class ScreenshotPlugin extends Plugin
 	private static final DateFormat TIME_FORMAT = new SimpleDateFormat("yyyy-MM-dd_HH-mm-ss");
 
 	private static final Pattern NUMBER_PATTERN = Pattern.compile("([0-9]+)");
-	private static final Pattern LEVEL_UP_PATTERN = Pattern.compile("Your ([a-zA-Z]+) (?:level is|are)? now (\\d+)\\.");
+	private static final Pattern LEVEL_UP_PATTERN = Pattern.compile(".*Your ([a-zA-Z]+) (?:level is|are)? now (\\d+)\\.");
 
 	private static final ImmutableList<String> PET_MESSAGES = ImmutableList.of("You have a funny feeling like you're being followed",
 		"You feel something weird sneaking into your backpack",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
@@ -43,6 +43,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
+import net.runelite.api.events.GameTick;
 import java.time.LocalDate;
 import java.util.Date;
 import java.util.concurrent.ScheduledExecutorService;
@@ -57,18 +58,16 @@ import net.runelite.api.Client;
 import net.runelite.api.GameState;
 import net.runelite.api.Point;
 import net.runelite.api.events.ChatMessage;
-import net.runelite.api.events.WidgetHiddenChanged;
 import net.runelite.api.events.WidgetLoaded;
 import net.runelite.api.widgets.Widget;
-import net.runelite.api.widgets.WidgetID;
 import static net.runelite.api.widgets.WidgetID.BARROWS_REWARD_GROUP_ID;
+import static net.runelite.api.widgets.WidgetID.RAIDS_REWARD_GROUP_ID;
 import static net.runelite.api.widgets.WidgetID.CLUE_SCROLL_REWARD_GROUP_ID;
 import static net.runelite.api.widgets.WidgetID.DIALOG_SPRITE_GROUP_ID;
+import static net.runelite.api.widgets.WidgetID.KINGDOM_GROUP_ID;
 import static net.runelite.api.widgets.WidgetID.LEVEL_UP_GROUP_ID;
 import static net.runelite.api.widgets.WidgetID.QUEST_COMPLETED_GROUP_ID;
-import static net.runelite.api.widgets.WidgetID.RAIDS_REWARD_GROUP_ID;
 import net.runelite.api.widgets.WidgetInfo;
-import static net.runelite.api.widgets.WidgetInfo.TO_GROUP;
 import net.runelite.client.Notifier;
 import static net.runelite.client.RuneLite.SCREENSHOT_DIR;
 import net.runelite.client.config.ConfigManager;
@@ -133,6 +132,8 @@ public class ScreenshotPlugin extends Plugin
 	private Integer barrowsNumber;
 
 	private Integer raidsNumber;
+
+	private boolean shouldTakeScreenshot;
 
 	@Inject
 	private ScreenshotConfig config;
@@ -234,6 +235,38 @@ public class ScreenshotPlugin extends Plugin
 	}
 
 	@Subscribe
+	public void onGameTick(GameTick event)
+	{
+		if (!shouldTakeScreenshot)
+		{
+			return;
+		}
+
+		shouldTakeScreenshot = false;
+
+		String fileName = null;
+		if (client.getWidget(WidgetInfo.LEVEL_UP_LEVEL) != null)
+		{
+			fileName = parseLevelUpWidget(WidgetInfo.LEVEL_UP_LEVEL);
+		}
+		else if (client.getWidget(WidgetInfo.DIALOG_SPRITE_TEXT) != null)
+		{
+			fileName = parseLevelUpWidget(WidgetInfo.DIALOG_SPRITE_TEXT);
+		}
+		else if (client.getWidget(WidgetInfo.QUEST_COMPLETED_NAME_TEXT) != null)
+		{
+			// "You have completed The Corsair Curse!"
+			String text = client.getWidget(WidgetInfo.QUEST_COMPLETED_NAME_TEXT).getText();
+			fileName = text.substring(19, text.length() - 1);
+		}
+
+		if (fileName != null)
+		{
+			takeScreenshot(fileName);
+		}
+	}
+
+	@Subscribe
 	public void onChatMessage(ChatMessage event)
 	{
 		if (event.getType() != ChatMessageType.SERVER && event.getType() != ChatMessageType.FILTERED)
@@ -290,29 +323,20 @@ public class ScreenshotPlugin extends Plugin
 	@Subscribe
 	public void loadWidgets(WidgetLoaded event)
 	{
-		if (!config.screenshotKingdom())
-		{
-			return;
-		}
-		if (event.getGroupId() == WidgetID.KINGDOM_GROUP_ID)
-		{
-			String fileName = "Kingdom " + LocalDate.now();
-			takeScreenshot(fileName);
-		}
-	}
+		String fileName;
+		int groupId = event.getGroupId();
 
-	@Subscribe
-	public void hideWidgets(WidgetHiddenChanged event)
-	{
-		Widget widget = event.getWidget();
-
-		if (widget.isHidden())
+		switch (groupId)
 		{
-			return;
-		}
-
-		switch (TO_GROUP(widget.getId()))
-		{
+			case QUEST_COMPLETED_GROUP_ID:
+			case CLUE_SCROLL_REWARD_GROUP_ID:
+			case RAIDS_REWARD_GROUP_ID:
+			case BARROWS_REWARD_GROUP_ID:
+				if (!config.screenshotRewards())
+				{
+					return;
+				}
+				break;
 			case LEVEL_UP_GROUP_ID:
 			case DIALOG_SPRITE_GROUP_ID:
 				if (!config.screenshotLevels())
@@ -320,56 +344,31 @@ public class ScreenshotPlugin extends Plugin
 					return;
 				}
 				break;
-			case QUEST_COMPLETED_GROUP_ID:
-			case CLUE_SCROLL_REWARD_GROUP_ID:
-			case BARROWS_REWARD_GROUP_ID:
-			case RAIDS_REWARD_GROUP_ID:
-				if (!config.screenshotRewards())
+			case KINGDOM_GROUP_ID:
+				if (!config.screenshotKingdom())
 				{
 					return;
 				}
 				break;
 		}
 
-		String fileName;
-
-		switch (TO_GROUP(widget.getId()))
+		switch (groupId)
 		{
-			case LEVEL_UP_GROUP_ID:
+			case KINGDOM_GROUP_ID:
 			{
-				fileName = parseLevelUpWidget(WidgetInfo.LEVEL_UP_LEVEL);
+				fileName = "Kingdom " + LocalDate.now();
+				takeScreenshot(fileName);
 				break;
 			}
-			case DIALOG_SPRITE_GROUP_ID:
+			case RAIDS_REWARD_GROUP_ID:
 			{
-				fileName = parseLevelUpWidget(WidgetInfo.DIALOG_SPRITE_TEXT);
-				break;
-			}
-			case QUEST_COMPLETED_GROUP_ID:
-			{
-				Widget textChild = client.getWidget(WidgetInfo.QUEST_COMPLETED_NAME_TEXT);
-
-				if (textChild == null)
+				if (raidsNumber == null)
 				{
 					return;
 				}
 
-				// "You have completed The Corsair Curse!"
-				String text = textChild.getText();
-
-				fileName = text.substring(19, text.length() - 1);
-				break;
-			}
-			case CLUE_SCROLL_REWARD_GROUP_ID:
-			{
-				if (clueType == null || clueNumber == null)
-				{
-					return;
-				}
-
-				fileName = Character.toUpperCase(clueType.charAt(0)) + clueType.substring(1) + "(" + clueNumber + ")";
-				clueType = null;
-				clueNumber = null;
+				fileName = "Chambers of Xeric(" + raidsNumber + ")";
+				raidsNumber = null;
 				break;
 			}
 			case BARROWS_REWARD_GROUP_ID:
@@ -383,24 +382,28 @@ public class ScreenshotPlugin extends Plugin
 				barrowsNumber = null;
 				break;
 			}
-			case RAIDS_REWARD_GROUP_ID:
+			case LEVEL_UP_GROUP_ID:
+			case DIALOG_SPRITE_GROUP_ID:
+			case QUEST_COMPLETED_GROUP_ID:
 			{
-				if (raidsNumber == null)
+				// level up widget gets loaded prior to the text being set, so wait until the next tick
+				shouldTakeScreenshot = true;
+				return;
+			}
+			case CLUE_SCROLL_REWARD_GROUP_ID:
+			{
+				if (clueType == null || clueNumber == null)
 				{
 					return;
 				}
 
-				fileName = "Raids(" + raidsNumber + ")";
-				raidsNumber = null;
+				fileName = Character.toUpperCase(clueType.charAt(0)) + clueType.substring(1) + "(" + clueNumber + ")";
+				clueType = null;
+				clueNumber = null;
 				break;
 			}
 			default:
 				return;
-		}
-
-		if (fileName == null)
-		{
-			return;
 		}
 
 		takeScreenshot(fileName);

--- a/runelite-client/src/test/java/net/runelite/client/plugins/screenshot/ScreenshotPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/screenshot/ScreenshotPluginTest.java
@@ -33,7 +33,8 @@ import javax.inject.Inject;
 import static net.runelite.api.ChatMessageType.SERVER;
 import net.runelite.api.Client;
 import net.runelite.api.events.ChatMessage;
-import net.runelite.api.events.WidgetHiddenChanged;
+import net.runelite.api.events.GameTick;
+import net.runelite.api.events.WidgetLoaded;
 import net.runelite.api.widgets.Widget;
 import static net.runelite.api.widgets.WidgetID.DIALOG_SPRITE_GROUP_ID;
 import static net.runelite.api.widgets.WidgetID.LEVEL_UP_GROUP_ID;
@@ -60,7 +61,7 @@ public class ScreenshotPluginTest
 {
 	private static final String CLUE_SCROLL = "<col=3300ff>You have completed 28 medium Treasure Trails</col>";
 	private static final String BARROWS_CHEST = "Your Barrows chest count is <col=ff0000>310</col>";
-	private static final String RAIDS_CHEST = "Your completed Chambers of Xeric count is: <col=ff0000>489.</col>";
+	private static final String RAIDS_CHEST = "Your completed Chambers of Xeric count is: <col=ff0000>489</col>.";
 
 	@Mock
 	@Bind
@@ -121,7 +122,7 @@ public class ScreenshotPluginTest
 	}
 
 	@Test
-	public void testRaidsChest()
+	public void testChambersOfXericChest()
 	{
 		ChatMessage chatMessageEvent = new ChatMessage(SERVER, "Seth", RAIDS_CHEST, null);
 		screenshotPlugin.onChatMessage(chatMessageEvent);
@@ -142,9 +143,12 @@ public class ScreenshotPluginTest
 
 		assertEquals("Hitpoints(99)", screenshotPlugin.parseLevelUpWidget(LEVEL_UP_LEVEL));
 
-		WidgetHiddenChanged event = new WidgetHiddenChanged();
-		event.setWidget(widget);
-		screenshotPlugin.hideWidgets(event);
+		WidgetLoaded event = new WidgetLoaded();
+		event.setGroupId(LEVEL_UP_GROUP_ID);
+		screenshotPlugin.loadWidgets(event);
+
+		GameTick tick = new GameTick();
+		screenshotPlugin.onGameTick(tick);
 
 		verify(drawManager).requestNextFrameListener(Matchers.any(Consumer.class));
 	}
@@ -162,9 +166,12 @@ public class ScreenshotPluginTest
 
 		assertEquals("Firemaking(9)", screenshotPlugin.parseLevelUpWidget(LEVEL_UP_LEVEL));
 
-		WidgetHiddenChanged event = new WidgetHiddenChanged();
-		event.setWidget(widget);
-		screenshotPlugin.hideWidgets(event);
+		WidgetLoaded event = new WidgetLoaded();
+		event.setGroupId(LEVEL_UP_GROUP_ID);
+		screenshotPlugin.loadWidgets(event);
+
+		GameTick tick = new GameTick();
+		screenshotPlugin.onGameTick(tick);
 
 		verify(drawManager).requestNextFrameListener(Matchers.any(Consumer.class));
 	}
@@ -182,9 +189,12 @@ public class ScreenshotPluginTest
 
 		assertEquals("Attack(70)", screenshotPlugin.parseLevelUpWidget(LEVEL_UP_LEVEL));
 
-		WidgetHiddenChanged event = new WidgetHiddenChanged();
-		event.setWidget(widget);
-		screenshotPlugin.hideWidgets(event);
+		WidgetLoaded event = new WidgetLoaded();
+		event.setGroupId(LEVEL_UP_GROUP_ID);
+		screenshotPlugin.loadWidgets(event);
+
+		GameTick tick = new GameTick();
+		screenshotPlugin.onGameTick(tick);
 
 		verify(drawManager).requestNextFrameListener(Matchers.any(Consumer.class));
 	}
@@ -202,9 +212,12 @@ public class ScreenshotPluginTest
 
 		assertEquals("Hunter(2)", screenshotPlugin.parseLevelUpWidget(DIALOG_SPRITE_TEXT));
 
-		WidgetHiddenChanged event = new WidgetHiddenChanged();
-		event.setWidget(widget);
-		screenshotPlugin.hideWidgets(event);
+		WidgetLoaded event = new WidgetLoaded();
+		event.setGroupId(DIALOG_SPRITE_GROUP_ID);
+		screenshotPlugin.loadWidgets(event);
+
+		GameTick tick = new GameTick();
+		screenshotPlugin.onGameTick(tick);
 
 		verify(drawManager).requestNextFrameListener(Matchers.any(Consumer.class));
 	}

--- a/runelite-client/src/test/java/net/runelite/client/plugins/screenshot/ScreenshotPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/screenshot/ScreenshotPluginTest.java
@@ -61,7 +61,7 @@ public class ScreenshotPluginTest
 {
 	private static final String CLUE_SCROLL = "<col=3300ff>You have completed 28 medium Treasure Trails</col>";
 	private static final String BARROWS_CHEST = "Your Barrows chest count is <col=ff0000>310</col>";
-	private static final String RAIDS_CHEST = "Your completed Chambers of Xeric count is: <col=ff0000>489</col>.";
+	private static final String CHAMBERS_OF_XERIC_CHEST = "Your completed Chambers of Xeric count is: <col=ff0000>489</col>.";
 
 	@Mock
 	@Bind
@@ -124,10 +124,10 @@ public class ScreenshotPluginTest
 	@Test
 	public void testChambersOfXericChest()
 	{
-		ChatMessage chatMessageEvent = new ChatMessage(SERVER, "Seth", RAIDS_CHEST, null);
+		ChatMessage chatMessageEvent = new ChatMessage(SERVER, "Seth", CHAMBERS_OF_XERIC_CHEST, null);
 		screenshotPlugin.onChatMessage(chatMessageEvent);
 
-		assertEquals(489, screenshotPlugin.getRaidsNumber());
+		assertEquals(489, screenshotPlugin.getChambersOfXericNumber());
 	}
 
 	@Test

--- a/runelite-client/src/test/java/net/runelite/client/plugins/screenshot/ScreenshotPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/screenshot/ScreenshotPluginTest.java
@@ -208,7 +208,7 @@ public class ScreenshotPluginTest
 		Widget levelChild = mock(Widget.class);
 		when(client.getWidget(Matchers.eq(DIALOG_SPRITE_TEXT))).thenReturn(levelChild);
 
-		when(levelChild.getText()).thenReturn("Your Hunter level is now 2.");
+		when(levelChild.getText()).thenReturn("<col=000080>Congratulations, you've just advanced a Hunter level.<col=000000><br><br>Your Hunter level is now 2.");
 
 		assertEquals("Hunter(2)", screenshotPlugin.parseLevelUpWidget(DIALOG_SPRITE_TEXT));
 


### PR DESCRIPTION
- Rename references to Chambers of Xeric in preparation for ToB
See #4246 

- Correct hunter lvl up message
The hunter lvl up widget is different from other widgets and uses another string, the matcher was therefore always returning null. Add special case for hunter lvl up widget.

- Move from hideWiget to more robust loadWidgets event
The hideWidget event would often not fire resulting in raids and barrows screenshots not being taken. All of the screenshots relying on that event has therefore been moved to the more reliable loadWidget event. 

Fixes #2485 
Fixes #2114
Fixes #986
