### PR TITLE
GroundItemsPlugin: Add an option to not group unstackable items

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItem.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItem.java
@@ -43,6 +43,7 @@ class GroundItem
 	private int gePrice;
 	private int offset;
 	private boolean tradeable;
+	private boolean stackable;
 
 	@Value
 	static class GroundItemKey

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
@@ -106,10 +106,21 @@ public interface GroundItemsConfig extends Config
 	}
 
 	@ConfigItem(
+			keyName = "groupUnstackables",
+			name = "Group Unstackable Item Piles",
+			description = "Group together unstackable items for highlighting and pricing",
+			position = 5
+	)
+	default boolean groupUnstackables()
+	{
+		return true;
+	}
+
+	@ConfigItem(
 		keyName = "recolorMenuHiddenItems",
 		name = "Recolor Menu Hidden Items",
 		description = "Configures whether or not hidden items in right click menu will be recolored",
-		position = 5
+		position = 6
 	)
 	default boolean recolorMenuHiddenItems()
 	{
@@ -120,7 +131,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "highlightTiles",
 		name = "Highlight Tiles",
 		description = "Configures whether or not to highlight tiles containing ground items",
-		position = 6
+		position = 7
 	)
 	default boolean highlightTiles() 
 	{ 
@@ -131,7 +142,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "priceDisplayMode",
 		name = "Price Display Mode",
 		description = "Configures what price types are shown alongside of ground item name",
-		position = 7
+		position = 8
 	)
 	default PriceDisplayMode priceDisplayMode()
 	{
@@ -142,7 +153,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "itemHighlightMode",
 		name = "Item Highlight Mode",
 		description = "Configures how ground items will be highlighted",
-		position = 8
+		position = 9
 	)
 	default ItemHighlightMode itemHighlightMode()
 	{
@@ -153,7 +164,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "menuHighlightMode",
 		name = "Menu Highlight Mode",
 		description = "Configures what to highlight in right-click menu",
-		position = 9
+		position = 10
 	)
 	default MenuHighlightMode menuHighlightMode()
 	{
@@ -164,7 +175,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "highlightOverValue2",
 		name = "Highlight > Value",
 		description = "Configures highlighted ground items over either GE or HA value",
-		position = 10
+		position = 11
 	)
 	default int getHighlightOverValue()
 	{
@@ -175,7 +186,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "hideUnderValue",
 		name = "Hide < Value",
 		description = "Configures hidden ground items under both GE and HA value",
-		position = 11
+		position = 12
 	)
 	default int getHideUnderValue()
 	{
@@ -186,7 +197,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "defaultColor",
 		name = "Default items color",
 		description = "Configures the color for default, non-highlighted items",
-		position = 12
+		position = 13
 	)
 	default Color defaultColor()
 	{
@@ -197,7 +208,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "highlightedColor",
 		name = "Highlighted items color",
 		description = "Configures the color for highlighted items",
-		position = 13
+		position = 14
 	)
 	default Color highlightedColor()
 	{
@@ -208,7 +219,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "hiddenColor",
 		name = "Hidden items color",
 		description = "Configures the color for hidden items in right-click menu and when holding ALT",
-		position = 14
+		position = 15
 	)
 	default Color hiddenColor()
 	{
@@ -219,7 +230,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "lowValueColor",
 		name = "Low value items color",
 		description = "Configures the color for low value items",
-		position = 15
+		position = 16
 	)
 	default Color lowValueColor()
 	{
@@ -230,7 +241,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "lowValuePrice",
 		name = "Low value price",
 		description = "Configures the start price for low value items",
-		position = 16
+		position = 17
 	)
 	default int lowValuePrice()
 	{
@@ -241,7 +252,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "mediumValueColor",
 		name = "Medium value items color",
 		description = "Configures the color for medium value items",
-		position = 17
+		position = 18
 	)
 	default Color mediumValueColor()
 	{
@@ -252,7 +263,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "mediumValuePrice",
 		name = "Medium value price",
 		description = "Configures the start price for medium value items",
-		position = 18
+		position = 19
 	)
 	default int mediumValuePrice()
 	{
@@ -263,7 +274,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "highValueColor",
 		name = "High value items color",
 		description = "Configures the color for high value items",
-		position = 19
+		position = 20
 	)
 	default Color highValueColor()
 	{
@@ -274,7 +285,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "highValuePrice",
 		name = "High value price",
 		description = "Configures the start price for high value items",
-		position = 20
+		position = 21
 	)
 	default int highValuePrice()
 	{
@@ -285,7 +296,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "insaneValueColor",
 		name = "Insane value items color",
 		description = "Configures the color for insane value items",
-		position = 21
+		position = 22
 	)
 	default Color insaneValueColor()
 	{
@@ -296,7 +307,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "insaneValuePrice",
 		name = "Insane value price",
 		description = "Configures the start price for insane value items",
-		position = 22
+		position = 23
 	)
 	default int insaneValuePrice()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
@@ -182,11 +182,16 @@ public class GroundItemsOverlay extends Overlay
 
 			if (itemPrice != null && itemPrice.getPrice() > 0)
 			{
-				item.setGePrice(itemPrice.getPrice() * item.getQuantity());
+				item.setGePrice(itemPrice.getPrice());
 			}
 
-			final Color highlighted = plugin.getHighlighted(item.getName(), item.getGePrice(), item.getHaPrice());
-			final Color hidden = plugin.getHidden(item.getName(), item.getGePrice(), item.getHaPrice(), item.isTradeable());
+			boolean groupItems = item.isStackable() || config.groupUnstackables();
+
+			int gePrice = item.getGePrice() * (groupItems ? item.getQuantity() : 1);
+			int haPrice = item.getHaPrice() * (groupItems ? item.getQuantity() : 1);
+
+			final Color highlighted = plugin.getHighlighted(item.getName(), gePrice, haPrice);
+			final Color hidden = plugin.getHidden(item.getName(), gePrice, haPrice, item.isTradeable());
 
 			if (highlighted == null && !plugin.isHotKeyPressed())
 			{
@@ -241,29 +246,32 @@ public class GroundItemsOverlay extends Overlay
 				if (item.getGePrice() > 0)
 				{
 					itemStringBuilder.append(" (EX: ")
-						.append(StackFormatter.quantityToStackSize(item.getGePrice()))
-						.append(" gp)");
+						.append(StackFormatter.quantityToStackSize(gePrice))
+						.append(" gp")
+						.append(groupItems ? "" : " ea")
+						.append(")");
 				}
 
 				if (item.getHaPrice() > 0)
 				{
 					itemStringBuilder.append(" (HA: ")
-						.append(StackFormatter.quantityToStackSize(item.getHaPrice()))
-						.append(" gp)");
+						.append(StackFormatter.quantityToStackSize(haPrice))
+						.append(" gp")
+						.append(groupItems ? "" : " ea")
+						.append(")");
 				}
 			}
 			else if (config.priceDisplayMode() != PriceDisplayMode.OFF)
 			{
-				final int price = config.priceDisplayMode() == PriceDisplayMode.GE
-					? item.getGePrice()
-					: item.getHaPrice();
-
+				final int price = (config.priceDisplayMode() == PriceDisplayMode.GE ? gePrice : haPrice);
 				if (price > 0)
 				{
 					itemStringBuilder
 						.append(" (")
 						.append(StackFormatter.quantityToStackSize(price))
-						.append(" gp)");
+						.append(" gp")
+						.append(groupItems ? "" : " ea")
+						.append(")");
 				}
 			}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
@@ -163,8 +163,6 @@ public class GroundItemsPlugin extends Plugin
 		.toMap
 			((item) -> new GroundItem.GroundItemKey(item.getItemId(), item.getLocation()), Function.identity(), (a, b) ->
 				{
-					b.setHaPrice(a.getHaPrice() + b.getHaPrice());
-					b.setGePrice(a.getGePrice() + b.getGePrice());
 					b.setQuantity(a.getQuantity() + b.getQuantity());
 					return b;
 				},
@@ -306,10 +304,10 @@ public class GroundItemsPlugin extends Plugin
 			.itemId(realItemId)
 			.quantity(item.getQuantity())
 			.name(itemComposition.getName())
-			.haPrice(alchPrice * item.getQuantity())
+			.haPrice(alchPrice)
 			.tradeable(itemComposition.isTradeable())
+			.stackable(itemComposition.isStackable())
 			.build();
-
 
 		// Update item price in case it is coins
 		if (realItemId == COINS)


### PR DESCRIPTION
When enabled, stacks of unstackable items display their individual value and highlighting is based on this rather than the total value of the stack.
[Short clip of toggling the option](https://streamable.com/wm0dp)
Fixes #4252