### PR TITLE
Adjust HA req. on Ground Items Overlay

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
@@ -245,7 +245,7 @@ public class GroundItemsOverlay extends Overlay
 						.append(" gp)");
 				}
 
-				if (item.getHaPrice() > 0)
+				if (item.getHaPrice() > 1)
 				{
 					itemStringBuilder.append(" (HA: ")
 						.append(StackFormatter.quantityToStackSize(item.getHaPrice()))


### PR DESCRIPTION
Changes the High Alch requirement to be greater than 1GP as certain items become fairly long with the string including the High Alch price, though it's only 1GP.

![ha 1 gp](https://user-images.githubusercontent.com/16967401/42523080-be4e3858-843a-11e8-921b-5f18719bc01c.png)