### PR TITLE
Correctly reset boosts when on NEVER

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/boosts/BoostsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/boosts/BoostsPlugin.java
@@ -329,7 +329,7 @@ public class BoostsPlugin extends Plugin
 	int getChangeDownTicks()
 	{
 		if (lastChangeDown == -1 ||
-				config.displayNextBuffChange() == BoostConfig.DisplayChangeMode.NEVER ||
+				config.displayNextBuffChange() == BoostsConfig.DisplayChangeMode.NEVER ||
 				(config.displayNextBuffChange() == BoostsConfig.DisplayChangeMode.BOOSTED && !isChangedUp))
 		{
 			return -1;
@@ -357,7 +357,7 @@ public class BoostsPlugin extends Plugin
 	int getChangeUpTicks()
 	{
 		if (lastChangeUp == -1 ||
-				config.displayNextDebuffChange() == BoostConfig.DisplayChangeMode.NEVER ||
+				config.displayNextDebuffChange() == BoostsConfig.DisplayChangeMode.NEVER ||
 				(config.displayNextDebuffChange() == BoostsConfig.DisplayChangeMode.BOOSTED && !isChangedDown))
 		{
 			return -1;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/boosts/BoostsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/boosts/BoostsPlugin.java
@@ -328,7 +328,9 @@ public class BoostsPlugin extends Plugin
 	 */
 	int getChangeDownTicks()
 	{
-		if (lastChangeDown == -1 || (config.displayNextBuffChange() == BoostsConfig.DisplayChangeMode.BOOSTED && !isChangedUp))
+		if (lastChangeDown == -1 ||
+				config.displayNextBuffChange() == BoostConfig.DisplayChangeMode.NEVER ||
+				(config.displayNextBuffChange() == BoostsConfig.DisplayChangeMode.BOOSTED && !isChangedUp))
 		{
 			return -1;
 		}
@@ -354,7 +356,9 @@ public class BoostsPlugin extends Plugin
 	 */
 	int getChangeUpTicks()
 	{
-		if (lastChangeUp == -1 || (config.displayNextDebuffChange() == BoostsConfig.DisplayChangeMode.BOOSTED && !isChangedDown))
+		if (lastChangeUp == -1 ||
+				config.displayNextDebuffChange() == BoostConfig.DisplayChangeMode.NEVER ||
+				(config.displayNextDebuffChange() == BoostsConfig.DisplayChangeMode.BOOSTED && !isChangedDown))
 		{
 			return -1;
 		}


### PR DESCRIPTION
Correctly reset change up and change down times when boosts are set to
NEVER instead of resetting it only after first tick down.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>