### PR TITLE
Slayer tooltip fix

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerPlugin.java
@@ -78,7 +78,7 @@ public class SlayerPlugin extends Plugin
 	//Chat messages
 	private static final Pattern CHAT_GEM_PROGRESS_MESSAGE = Pattern.compile("You're assigned to kill (.*); only (\\d*) more to go\\.");
 	private static final String CHAT_GEM_COMPLETE_MESSAGE = "You need something new to hunt.";
-	private static final Pattern CHAT_COMPLETE_MESSAGE = Pattern.compile("[\\d]+(?:,[\\d]+)?");
+	private static final Pattern CHAT_COMPLETE_MESSAGE = Pattern.compile("(?:\\d+,)*\\d+");
 	private static final String CHAT_CANCEL_MESSAGE = "Your task has been cancelled.";
 	private static final String CHAT_CANCEL_MESSAGE_JAD = "You no longer have a slayer task as you left the fight cave.";
 	private static final String CHAT_SUPERIOR_MESSAGE = "A superior foe has appeared...";
@@ -96,7 +96,7 @@ public class SlayerPlugin extends Plugin
 	private static final Pattern NPC_CURRENT_MESSAGE = Pattern.compile("You're still hunting (.*); you have (\\d*) to go\\..*");
 
 	//Reward UI
-	private static final Pattern REWARD_POINTS = Pattern.compile("Reward points: (\\d*)");
+	private static final Pattern REWARD_POINTS = Pattern.compile("Reward points: ((?:\\d+,)*\\d+)");
 
 	private static final int EXPEDITIOUS_CHARGE = 30;
 	private static final int SLAUGHTER_CHARGE = 30;
@@ -297,7 +297,7 @@ public class SlayerPlugin extends Plugin
 				Matcher mPoints = REWARD_POINTS.matcher(w.getText());
 				if (mPoints.find())
 				{
-					points = Integer.parseInt(mPoints.group(1));
+					points = Integer.parseInt(mPoints.group(1).replaceAll(",", ""));
 					break;
 				}
 			}
@@ -374,7 +374,7 @@ public class SlayerPlugin extends Plugin
 			List<String> matches = new ArrayList<>();
 			while (mComplete.find())
 			{
-				matches.add(mComplete.group(0));
+				matches.add(mComplete.group(0).replaceAll(",", ""));
 			}
 
 			switch (matches.size())
@@ -387,7 +387,7 @@ public class SlayerPlugin extends Plugin
 					break;
 				case 3:
 					streak = Integer.parseInt(matches.get(0));
-					points = Integer.parseInt(matches.get(2).replaceAll(",", ""));
+					points = Integer.parseInt(matches.get(2));
 					break;
 				default:
 					log.warn("Unreachable default case for message ending in '; return to Slayer master'");

--- a/runelite-client/src/test/java/net/runelite/client/plugins/slayer/SlayerPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/slayer/SlayerPluginTest.java
@@ -58,9 +58,12 @@ public class SlayerPluginTest
 
 	private static final String TASK_EXISTING = "You're still hunting suqahs; you have 222 to go. Come<br>back when you've finished your task.";
 
+	private static final String REWARD_POINTS = "Reward points: 17,566";
+
 	private static final String TASK_ONE = "You've completed one task; return to a Slayer master.";
 	private static final String TASK_COMPLETE_NO_POINTS = "<col=ef1020>You've completed 3 tasks; return to a Slayer master.</col>";
 	private static final String TASK_POINTS = "You've completed 9 tasks and received 0 points, giving you a total of 18,000; return to a Slayer master.";
+	private static final String TASK_LARGE_STREAK = "You've completed 2,465 tasks and received 15 points, giving you a total of 17,566,000; return to a Slayer master.";
 
 	private static final String TASK_COMPLETE = "You need something new to hunt.";
 	private static final String TASK_CANCELED = "Your task has been cancelled.";
@@ -159,6 +162,21 @@ public class SlayerPluginTest
 	}
 
 	@Test
+	public void testRewardPointsWidget()
+	{
+		Widget rewardBar = mock(Widget.class);
+		Widget rewardBarText = mock(Widget.class);
+		Widget[] rewardBarChildren = new Widget[]{rewardBarText};
+
+		when(rewardBar.getDynamicChildren()).thenReturn(rewardBarChildren);
+		when(rewardBarText.getText()).thenReturn(REWARD_POINTS);
+		when(client.getWidget(WidgetInfo.SLAYER_REWARDS_TOPBAR)).thenReturn(rewardBar);
+		slayerPlugin.onGameTick(new GameTick());
+
+		assertEquals(17566, slayerPlugin.getPoints());
+	}
+
+	@Test
 	public void testOneTask()
 	{
 		ChatMessage chatMessageEvent = new ChatMessage(SERVER, "Perterter", TASK_ONE, null);
@@ -190,6 +208,18 @@ public class SlayerPluginTest
 		assertEquals("", slayerPlugin.getTaskName());
 		assertEquals(0, slayerPlugin.getAmount());
 		assertEquals(18_000, slayerPlugin.getPoints());
+	}
+
+	@Test
+	public void testLargeStreak()
+	{
+		ChatMessage chatMessageEvent = new ChatMessage(SERVER, "Perterter", TASK_LARGE_STREAK, null);
+		slayerPlugin.onChatMessage(chatMessageEvent);
+
+		assertEquals(2465, slayerPlugin.getStreak());
+		assertEquals("", slayerPlugin.getTaskName());
+		assertEquals(0, slayerPlugin.getAmount());
+		assertEquals(17_566_000, slayerPlugin.getPoints());
 	}
 
 	@Test


### PR DESCRIPTION
Fixes the regex matching to eliminate all commas in the numbers parsed before converting them to Integers.
Updates the REWARD_POINTS pattern to take into account possibility of commas.

fixes: #3673 

Before: ![](https://i.imgur.com/UReYuS9.png)
After: ![](https://i.imgur.com/i8qUOFw.png)


