### PR TITLE
Update widget used for retrieving Kourend Library book ID

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/widgets/WidgetID.java
+++ b/runelite-api/src/main/java/net/runelite/api/widgets/WidgetID.java
@@ -498,8 +498,8 @@ public class WidgetID
 
 	static class DialogSprite
 	{
-		static final int SPRITE = 0;
-		static final int TEXT = 1;
+		static final int SPRITE = 1;
+		static final int TEXT = 2;
 	}
 
 	static class ExperienceTracker


### PR DESCRIPTION
Child IDs for sprite and text in sprite dialogs were changed and broke finding the id for the found book.