### PR TITLE
Slayer overlay code structure and query refactoring.

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerOverlay.java
@@ -64,7 +64,7 @@ class SlayerOverlay extends Overlay
 		ItemID.SLAYER_RING_8
 	);
 
-	private final ImmutableIntArray allSlayerItems = ImmutableIntArray.of(
+	private final static ImmutableIntArray ALL_SLAYER_ITEMS = ImmutableIntArray.of(
 		ItemID.SLAYER_HELMET,
 		ItemID.SLAYER_HELMET_I,
 		ItemID.BLACK_SLAYER_HELMET,
@@ -104,7 +104,7 @@ class SlayerOverlay extends Overlay
 
 	private ImmutableList<WidgetItem> getSlayerItems()
 	{
-		int[] slayerItems = allSlayerItems.toArray();
+		int[] slayerItems = ALL_SLAYER_ITEMS.toArray();
 		Query inventoryQuery = new InventoryWidgetItemQuery().idEquals(slayerItems);
 		WidgetItem[] inventoryWidgetItems = queryRunner.runQuery(inventoryQuery);
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerOverlay.java
@@ -49,48 +49,48 @@ import net.runelite.client.util.QueryRunner;
 
 class SlayerOverlay extends Overlay
 {
-	private final SlayerConfig config;
-	private final SlayerPlugin plugin;
-	private final QueryRunner queryRunner;
-
-	private final Set<Integer> slayerJewelry = ImmutableSet.of(
-		ItemID.SLAYER_RING_1,
-		ItemID.SLAYER_RING_2,
-		ItemID.SLAYER_RING_3,
-		ItemID.SLAYER_RING_4,
-		ItemID.SLAYER_RING_5,
-		ItemID.SLAYER_RING_6,
-		ItemID.SLAYER_RING_7,
-		ItemID.SLAYER_RING_8
+	private final static Set<Integer> SLAYER_JEWELRY = ImmutableSet.of(
+			ItemID.SLAYER_RING_1,
+			ItemID.SLAYER_RING_2,
+			ItemID.SLAYER_RING_3,
+			ItemID.SLAYER_RING_4,
+			ItemID.SLAYER_RING_5,
+			ItemID.SLAYER_RING_6,
+			ItemID.SLAYER_RING_7,
+			ItemID.SLAYER_RING_8
 	);
 
 	private final static ImmutableIntArray ALL_SLAYER_ITEMS = ImmutableIntArray.of(
-		ItemID.SLAYER_HELMET,
-		ItemID.SLAYER_HELMET_I,
-		ItemID.BLACK_SLAYER_HELMET,
-		ItemID.BLACK_SLAYER_HELMET_I,
-		ItemID.GREEN_SLAYER_HELMET,
-		ItemID.GREEN_SLAYER_HELMET_I,
-		ItemID.PURPLE_SLAYER_HELMET,
-		ItemID.PURPLE_SLAYER_HELMET_I,
-		ItemID.RED_SLAYER_HELMET,
-		ItemID.RED_SLAYER_HELMET_I,
-		ItemID.TURQUOISE_SLAYER_HELMET,
-		ItemID.TURQUOISE_SLAYER_HELMET_I,
-		ItemID.SLAYER_RING_ETERNAL,
-		ItemID.ENCHANTED_GEM,
-		ItemID.ETERNAL_GEM,
-		ItemID.BRACELET_OF_SLAUGHTER,
-		ItemID.EXPEDITIOUS_BRACELET,
-		ItemID.SLAYER_RING_1,
-		ItemID.SLAYER_RING_2,
-		ItemID.SLAYER_RING_3,
-		ItemID.SLAYER_RING_4,
-		ItemID.SLAYER_RING_5,
-		ItemID.SLAYER_RING_6,
-		ItemID.SLAYER_RING_7,
-		ItemID.SLAYER_RING_8
+			ItemID.SLAYER_HELMET,
+			ItemID.SLAYER_HELMET_I,
+			ItemID.BLACK_SLAYER_HELMET,
+			ItemID.BLACK_SLAYER_HELMET_I,
+			ItemID.GREEN_SLAYER_HELMET,
+			ItemID.GREEN_SLAYER_HELMET_I,
+			ItemID.PURPLE_SLAYER_HELMET,
+			ItemID.PURPLE_SLAYER_HELMET_I,
+			ItemID.RED_SLAYER_HELMET,
+			ItemID.RED_SLAYER_HELMET_I,
+			ItemID.TURQUOISE_SLAYER_HELMET,
+			ItemID.TURQUOISE_SLAYER_HELMET_I,
+			ItemID.SLAYER_RING_ETERNAL,
+			ItemID.ENCHANTED_GEM,
+			ItemID.ETERNAL_GEM,
+			ItemID.BRACELET_OF_SLAUGHTER,
+			ItemID.EXPEDITIOUS_BRACELET,
+			ItemID.SLAYER_RING_1,
+			ItemID.SLAYER_RING_2,
+			ItemID.SLAYER_RING_3,
+			ItemID.SLAYER_RING_4,
+			ItemID.SLAYER_RING_5,
+			ItemID.SLAYER_RING_6,
+			ItemID.SLAYER_RING_7,
+			ItemID.SLAYER_RING_8
 	);
+
+	private final SlayerConfig config;
+	private final SlayerPlugin plugin;
+	private final QueryRunner queryRunner;
 
 	@Inject
 	private SlayerOverlay(SlayerPlugin plugin, SlayerConfig config, QueryRunner queryRunner)
@@ -155,7 +155,7 @@ class SlayerOverlay extends Overlay
 			}
 
 			// Draw the counter in the bottom left for equipment, and top left for jewelry
-			textComponent.setPosition(new Point(bounds.x, bounds.y + (slayerJewelry.contains(itemId)
+			textComponent.setPosition(new Point(bounds.x, bounds.y + (SLAYER_JEWELRY.contains(itemId)
 				? bounds.height
 				: graphics.getFontMetrics().getHeight())));
 			textComponent.render(graphics);


### PR DESCRIPTION
QueryRunner is now injected in the constructor.
Method checkInventory moved bellow the constructor.
Restructured queries inside checkInventory to utilize idEquals.
Renamed method checkInventory to getSlayerItems to better reflect the new business logic.
Removed the now unnecessary check in the render call.
Changed Set<Integer> of slayer equipment to ImmutableIntArray, and expanded it to include jewelry to prevent the necessity of repeated concat calls when calling idEquals.