### PR TITLE
Added spade requirement check to fairy ring clues.

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/ClueScrollPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/ClueScrollPlugin.java
@@ -67,20 +67,7 @@ import net.runelite.client.config.ConfigManager;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
-import net.runelite.client.plugins.cluescrolls.clues.AnagramClue;
-import net.runelite.client.plugins.cluescrolls.clues.CipherClue;
-import net.runelite.client.plugins.cluescrolls.clues.ClueScroll;
-import net.runelite.client.plugins.cluescrolls.clues.CoordinateClue;
-import net.runelite.client.plugins.cluescrolls.clues.CrypticClue;
-import net.runelite.client.plugins.cluescrolls.clues.EmoteClue;
-import net.runelite.client.plugins.cluescrolls.clues.FairyRingClue;
-import net.runelite.client.plugins.cluescrolls.clues.HotColdClue;
-import net.runelite.client.plugins.cluescrolls.clues.LocationClueScroll;
-import net.runelite.client.plugins.cluescrolls.clues.LocationsClueScroll;
-import net.runelite.client.plugins.cluescrolls.clues.MapClue;
-import net.runelite.client.plugins.cluescrolls.clues.NpcClueScroll;
-import net.runelite.client.plugins.cluescrolls.clues.ObjectClueScroll;
-import net.runelite.client.plugins.cluescrolls.clues.TextClueScroll;
+import net.runelite.client.plugins.cluescrolls.clues.*;
 import net.runelite.client.ui.overlay.OverlayManager;
 import net.runelite.client.ui.overlay.worldmap.WorldMapPointManager;
 import net.runelite.client.util.QueryRunner;
@@ -374,13 +361,13 @@ public class ClueScrollPlugin extends Plugin
 			}
 		}
 
-		if (clue instanceof CoordinateClue)
+		if (clue instanceof SpadeClueScroll)
 		{
 			ItemContainer container = client.getItemContainer(InventoryID.INVENTORY);
 
 			if (container != null)
 			{
-				equippedItems = container.getItems();
+				inventoryItems = container.getItems();
 			}
 		}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java
@@ -42,7 +42,7 @@ import net.runelite.client.ui.overlay.components.TitleComponent;
 
 @Getter
 @AllArgsConstructor
-public class CoordinateClue extends ClueScroll implements TextClueScroll, LocationClueScroll
+public class CoordinateClue extends SpadeClueScroll implements TextClueScroll, LocationClueScroll
 {
 	private String text;
 	private WorldPoint location;
@@ -57,14 +57,7 @@ public class CoordinateClue extends ClueScroll implements TextClueScroll, Locati
 			.left("Click the clue scroll along the edge of your world map to see where you should dig.")
 			.build());
 
-		if (plugin.getEquippedItems() != null)
-		{
-			if (!HAS_SPADE.fulfilledBy(plugin.getEquippedItems()))
-			{
-				panelComponent.getChildren().add(LineComponent.builder().left("").build());
-				panelComponent.getChildren().add(LineComponent.builder().left("Requires Spade!").leftColor(Color.RED).build());
-			}
-		}
+		panelComponent.getChildren().add(hasSpadeOverlayLine(plugin));
 	}
 
 	@Override

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/FairyRingClue.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/FairyRingClue.java
@@ -24,6 +24,8 @@
  */
 package net.runelite.client.plugins.cluescrolls.clues;
 
+import static net.runelite.client.plugins.cluescrolls.ClueScrollOverlay.TITLED_CONTENT_COLOR;
+import static net.runelite.client.plugins.cluescrolls.ClueScrollPlugin.SPADE_IMAGE;
 import com.google.common.collect.ImmutableSet;
 import java.awt.Color;
 import java.awt.Graphics2D;
@@ -31,14 +33,7 @@ import java.util.Set;
 import lombok.Getter;
 import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.coords.WorldPoint;
-
-import static net.runelite.api.ItemID.SPADE;
-import static net.runelite.client.plugins.cluescrolls.ClueScrollOverlay.TITLED_CONTENT_COLOR;
 import net.runelite.client.plugins.cluescrolls.ClueScrollPlugin;
-import static net.runelite.client.plugins.cluescrolls.ClueScrollPlugin.SPADE_IMAGE;
-
-import net.runelite.client.plugins.cluescrolls.clues.emote.ItemRequirement;
-import net.runelite.client.plugins.cluescrolls.clues.emote.SingleItemRequirement;
 import net.runelite.client.ui.overlay.OverlayUtil;
 import net.runelite.client.ui.overlay.components.LineComponent;
 import net.runelite.client.ui.overlay.components.PanelComponent;
@@ -60,7 +55,6 @@ public class FairyRingClue extends SpadeClueScroll implements TextClueScroll, Lo
 		new FairyRingClue("D K S 2 3 1 0", new WorldPoint(2747, 3720, 0))
 	);
 
-	private static final ItemRequirement requiredItem = new SingleItemRequirement(SPADE);
 	private String text;
 	private WorldPoint location;
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/FairyRingClue.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/FairyRingClue.java
@@ -31,16 +31,21 @@ import java.util.Set;
 import lombok.Getter;
 import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.coords.WorldPoint;
+
+import static net.runelite.api.ItemID.SPADE;
 import static net.runelite.client.plugins.cluescrolls.ClueScrollOverlay.TITLED_CONTENT_COLOR;
 import net.runelite.client.plugins.cluescrolls.ClueScrollPlugin;
 import static net.runelite.client.plugins.cluescrolls.ClueScrollPlugin.SPADE_IMAGE;
+
+import net.runelite.client.plugins.cluescrolls.clues.emote.ItemRequirement;
+import net.runelite.client.plugins.cluescrolls.clues.emote.SingleItemRequirement;
 import net.runelite.client.ui.overlay.OverlayUtil;
 import net.runelite.client.ui.overlay.components.LineComponent;
 import net.runelite.client.ui.overlay.components.PanelComponent;
 import net.runelite.client.ui.overlay.components.TitleComponent;
 
 @Getter
-public class FairyRingClue extends ClueScroll implements TextClueScroll, LocationClueScroll
+public class FairyRingClue extends SpadeClueScroll implements TextClueScroll, LocationClueScroll
 {
 	private static final Set<FairyRingClue> CLUES = ImmutableSet.of(
 		new FairyRingClue("A I R 2 3 3 1", new WorldPoint(2702, 3246, 0)),
@@ -55,6 +60,7 @@ public class FairyRingClue extends ClueScroll implements TextClueScroll, Locatio
 		new FairyRingClue("D K S 2 3 1 0", new WorldPoint(2747, 3720, 0))
 	);
 
+	private static final ItemRequirement requiredItem = new SingleItemRequirement(SPADE);
 	private String text;
 	private WorldPoint location;
 
@@ -77,6 +83,8 @@ public class FairyRingClue extends ClueScroll implements TextClueScroll, Locatio
 		panelComponent.getChildren().add(LineComponent.builder()
 			.left("Travel to the fairy ring to see where to dig.")
 			.build());
+
+		panelComponent.getChildren().add(hasSpadeOverlayLine(plugin));
 	}
 
 	@Override

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/HotColdClue.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/HotColdClue.java
@@ -183,7 +183,6 @@ public class HotColdClue extends SpadeClueScroll implements LocationClueScroll, 
 					}
 				}
 			}
-			// Reminder to bring your spade
 			panelComponent.getChildren().add(hasSpadeOverlayLine(plugin));
 		}
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/HotColdClue.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/HotColdClue.java
@@ -57,7 +57,7 @@ import net.runelite.client.ui.overlay.components.TitleComponent;
 
 @Getter
 @RequiredArgsConstructor
-public class HotColdClue extends ClueScroll implements LocationClueScroll, LocationsClueScroll, TextClueScroll, NpcClueScroll
+public class HotColdClue extends SpadeClueScroll implements LocationClueScroll, LocationsClueScroll, TextClueScroll, NpcClueScroll
 {
 	private static final Pattern INITIAL_STRANGE_DEVICE_MESSAGE = Pattern.compile("The device is (.*)");
 	private static final Pattern STRANGE_DEVICE_MESSAGE = Pattern.compile("The device is (.*), (.*) last time\\.");
@@ -183,6 +183,8 @@ public class HotColdClue extends ClueScroll implements LocationClueScroll, Locat
 					}
 				}
 			}
+			// Reminder to bring your spade
+			panelComponent.getChildren().add(hasSpadeOverlayLine(plugin));
 		}
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/MapClue.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/MapClue.java
@@ -52,7 +52,7 @@ import net.runelite.client.ui.overlay.components.PanelComponent;
 import net.runelite.client.ui.overlay.components.TitleComponent;
 
 @Getter
-public class MapClue extends ClueScroll implements ObjectClueScroll
+public class MapClue extends SpadeClueScroll implements ObjectClueScroll
 {
 	private static final Set<MapClue> CLUES = ImmutableSet.of(
 		new MapClue(CLUE_SCROLL_EASY_12179, new WorldPoint(3300, 3291, 0)),
@@ -134,6 +134,8 @@ public class MapClue extends ClueScroll implements ObjectClueScroll
 			panelComponent.getChildren().add(LineComponent.builder()
 				.left("Travel to the destination and dig on the marked tile.")
 				.build());
+
+			panelComponent.getChildren().add(hasSpadeOverlayLine(plugin));
 		}
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/SpadeClueScroll.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/SpadeClueScroll.java
@@ -30,13 +30,13 @@ import net.runelite.client.plugins.cluescrolls.clues.emote.ItemRequirement;
 import net.runelite.client.plugins.cluescrolls.clues.emote.SingleItemRequirement;
 import net.runelite.client.ui.overlay.components.LineComponent;
 import java.awt.Color;
-
 import static net.runelite.api.ItemID.SPADE;
 import static net.runelite.client.plugins.cluescrolls.ClueScrollOverlay.TITLED_CONTENT_COLOR;
 
 public abstract class SpadeClueScroll extends ClueScroll
 {
 	private static final ItemRequirement SPADE_REQUIRED = new SingleItemRequirement(SPADE);
+
 	private boolean playerHasSpade(ClueScrollPlugin plugin)
 	{
 		Item[] inventory = plugin.getInventoryItems();
@@ -46,6 +46,7 @@ public abstract class SpadeClueScroll extends ClueScroll
 		}
 		return false;
 	}
+
 	LineComponent hasSpadeOverlayLine(ClueScrollPlugin plugin)
 	{
 		boolean hasSpade = playerHasSpade(plugin);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/SpadeClueScroll.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/SpadeClueScroll.java
@@ -1,0 +1,36 @@
+package net.runelite.client.plugins.cluescrolls.clues;
+
+import net.runelite.api.Item;
+import net.runelite.client.plugins.cluescrolls.ClueScrollPlugin;
+import net.runelite.client.plugins.cluescrolls.clues.emote.ItemRequirement;
+import net.runelite.client.plugins.cluescrolls.clues.emote.SingleItemRequirement;
+import net.runelite.client.ui.overlay.components.LineComponent;
+
+import java.awt.*;
+
+import static net.runelite.api.ItemID.SPADE;
+import static net.runelite.client.plugins.cluescrolls.ClueScrollOverlay.TITLED_CONTENT_COLOR;
+
+public abstract class SpadeClueScroll extends ClueScroll
+{
+	private static final ItemRequirement SPADE_REQUIRED = new SingleItemRequirement(SPADE);
+	private boolean playerHasSpade(ClueScrollPlugin plugin)
+	{
+		Item[] inventory = plugin.getInventoryItems();
+		if (inventory != null)
+		{
+			return SPADE_REQUIRED.fulfilledBy(inventory);
+		}
+		return false;
+	}
+	LineComponent hasSpadeOverlayLine(ClueScrollPlugin plugin)
+	{
+		boolean hasSpade = playerHasSpade(plugin);
+		return LineComponent.builder()
+				.left(SPADE_REQUIRED.getCollectiveName(plugin.getClient()))
+				.leftColor(TITLED_CONTENT_COLOR)
+				.right(hasSpade ? "\u2713" : "\u2717")
+				.rightColor(hasSpade ? Color.GREEN : Color.RED)
+				.build();
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/SpadeClueScroll.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/SpadeClueScroll.java
@@ -1,3 +1,27 @@
+/*
+ * Copyright (c) 2018, Lotto <https://github.com/devLotto>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package net.runelite.client.plugins.cluescrolls.clues;
 
 import net.runelite.api.Item;
@@ -5,8 +29,7 @@ import net.runelite.client.plugins.cluescrolls.ClueScrollPlugin;
 import net.runelite.client.plugins.cluescrolls.clues.emote.ItemRequirement;
 import net.runelite.client.plugins.cluescrolls.clues.emote.SingleItemRequirement;
 import net.runelite.client.ui.overlay.components.LineComponent;
-
-import java.awt.*;
+import java.awt.Color;
 
 import static net.runelite.api.ItemID.SPADE;
 import static net.runelite.client.plugins.cluescrolls.ClueScrollOverlay.TITLED_CONTENT_COLOR;


### PR DESCRIPTION
… clue scrolls that require a spade (FairyRing and Coordinates).

FairyRingClue and CoordinateClue now extend SpadeClueScroll instead of ClueScroll.
Added a line in FairyRingClue to notify the player whether he has a spade on him or not.
Made spade warning uniform with required item warnings (cross and check marks next to the required item).