### PR TITLE
Added Copy-To-Clipboard for Raid Scouting

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsConfig.java
@@ -83,7 +83,7 @@ public interface RaidsConfig extends Config
 	)
 	default boolean scoutOverlayInRaid()
 	{
-		return true;
+		return false;
 	}
 
 	@ConfigItem(

--- a/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsConfig.java
@@ -83,11 +83,22 @@ public interface RaidsConfig extends Config
 	)
 	default boolean scoutOverlayInRaid()
 	{
-		return false;
+		return true;
 	}
 
 	@ConfigItem(
 		position = 5,
+		keyName = "copyLayoutToClipboard",
+		name = "Copy raid layout to clipboard",
+		description = "Copies the layout to your clipboard for pasting elsewhere e.g. notes/discord"
+	)
+	default boolean copyLayoutToClipboard()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		position = 6,
 		keyName = "whitelistedRooms",
 		name = "Whitelisted rooms",
 		description = "Display whitelisted rooms in green on the overlay. Separate with comma (full name)"
@@ -98,7 +109,7 @@ public interface RaidsConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 6,
+		position = 7,
 		keyName = "blacklistedRooms",
 		name = "Blacklisted rooms",
 		description = "Display blacklisted rooms in red on the overlay. Separate with comma (full name)"
@@ -109,7 +120,7 @@ public interface RaidsConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 7,
+		position = 8,
 		keyName = "enableRotationWhitelist",
 		name = "Enable rotation whitelist",
 		description = "Enable the rotation whitelist"
@@ -120,7 +131,7 @@ public interface RaidsConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 8,
+		position = 9,
 		keyName = "whitelistedRotations",
 		name = "Whitelisted rotations",
 		description = "Warn when boss rotation doesn't match a whitelisted one. Add rotations like [tekton, muttadile, guardians]"
@@ -131,7 +142,7 @@ public interface RaidsConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 9,
+		position = 10,
 		keyName = "enableLayoutWhitelist",
 		name = "Enable layout whitelist",
 		description = "Enable the layout whitelist"
@@ -142,7 +153,7 @@ public interface RaidsConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 10,
+		position = 11,
 		keyName = "whitelistedLayouts",
 		name = "Whitelisted layouts",
 		description = "Warn when layout doesn't match a whitelisted one. Add layouts like CFSCPPCSCF separated with comma"

--- a/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsPlugin.java
@@ -27,6 +27,10 @@ package net.runelite.client.plugins.raids;
 import com.google.common.eventbus.Subscribe;
 import com.google.inject.Binder;
 import com.google.inject.Provides;
+
+import java.awt.*;
+import java.awt.datatransfer.Clipboard;
+import java.awt.datatransfer.StringSelection;
 import java.text.DecimalFormat;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -63,6 +67,7 @@ import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.plugins.raids.solver.Layout;
 import net.runelite.client.plugins.raids.solver.LayoutSolver;
+import net.runelite.client.plugins.raids.solver.Room;
 import net.runelite.client.plugins.raids.solver.RotationSolver;
 import net.runelite.client.ui.overlay.OverlayManager;
 import net.runelite.client.ui.overlay.infobox.InfoBoxManager;
@@ -296,6 +301,13 @@ public class RaidsPlugin extends Plugin
 				}
 
 				raid.updateLayout(layout);
+
+				if (config.copyLayoutToClipboard())
+				{
+					Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
+					clipboard.setContents(new StringSelection(getRaidLayoutString(layout)), null);
+				}
+
 				RotationSolver.solve(raid.getCombatRooms());
 				overlay.setScoutOverlayShown(true);
 			}
@@ -598,5 +610,25 @@ public class RaidsPlugin extends Plugin
 		}
 
 		return room;
+	}
+
+	public String getRaidLayoutString(Layout layout)
+	{
+		StringBuilder raidDescription = new StringBuilder();
+		raidDescription.append("Layout:\t" + layout.toCode());
+		for (Room findStartRoom : raid.getLayout().getRooms())
+		{
+			RaidRoom rroom = raid.getRoom(findStartRoom.getPosition());
+			switch (rroom.getType())
+			{
+				case COMBAT:
+					raidDescription.append("\nCombat:\t" + rroom.getBoss().getName());
+					break;
+				case PUZZLE:
+					raidDescription.append("\nPuzzle:\t" + rroom.getPuzzle().getName());
+					break;
+			}
+		}
+		return raidDescription.toString();
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsPlugin.java
@@ -27,8 +27,7 @@ package net.runelite.client.plugins.raids;
 import com.google.common.eventbus.Subscribe;
 import com.google.inject.Binder;
 import com.google.inject.Provides;
-
-import java.awt.*;
+import java.awt.Toolkit;
 import java.awt.datatransfer.Clipboard;
 import java.awt.datatransfer.StringSelection;
 import java.text.DecimalFormat;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsPlugin.java
@@ -300,14 +300,12 @@ public class RaidsPlugin extends Plugin
 				}
 
 				raid.updateLayout(layout);
-
+				RotationSolver.solve(raid.getCombatRooms());
 				if (config.copyLayoutToClipboard())
 				{
 					Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
 					clipboard.setContents(new StringSelection(getRaidLayoutString(layout)), null);
 				}
-
-				RotationSolver.solve(raid.getCombatRooms());
 				overlay.setScoutOverlayShown(true);
 			}
 			else if (!config.scoutOverlayAtBank())


### PR DESCRIPTION
When enabled, will copy the raid layout + puzzle/combat names to clipboard for saving during the raid in e.g. notes or similar

During raids as soon as the raid has begun the overlay disappears. This can be annoying if later trying to remember what order and what is next, particularly where scav/farm rooms are