### PR TITLE
Add WASD Camera Plugin

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/wasdcamera/WASDCameraConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/wasdcamera/WASDCameraConfig.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2018, Abexlry <abexlry@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.wasdcamera;
+
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+
+@ConfigGroup("wasdcamera")
+public interface WASDCameraConfig extends Config
+{}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/wasdcamera/WASDCameraConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/wasdcamera/WASDCameraConfig.java
@@ -26,8 +26,9 @@ package net.runelite.client.plugins.wasdcamera;
 
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
-import net.runelite.client.config.ConfigItem;
 
 @ConfigGroup("wasdcamera")
 public interface WASDCameraConfig extends Config
-{}
+{
+
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/wasdcamera/WASDCameraOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/wasdcamera/WASDCameraOverlay.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2018, Abexlry <abexlry@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.wasdcamera;
+
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Graphics2D;
+import java.awt.Point;
+import javax.inject.Inject;
+import net.runelite.api.Client;
+import net.runelite.client.ui.overlay.Overlay;
+import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.components.PanelComponent;
+import net.runelite.client.ui.overlay.components.TitleComponent;
+
+public class WASDCameraOverlay extends Overlay
+{
+	private final PanelComponent panelComponent = new PanelComponent();
+	private WASDCameraPlugin plugin;
+	private boolean rendered;
+
+	@Inject
+	private WASDCameraOverlay(Client client, WASDCameraPlugin plugin)
+	{
+		setPosition(OverlayPosition.BOTTOM_LEFT);
+		this.plugin = plugin;
+		rendered = false;
+	}
+
+	@Override
+	public Dimension render(Graphics2D graphics)
+	{
+		panelComponent.setPreferredLocation(new Point(0, 145));
+		panelComponent.setPreferredSize(new Dimension(514, 5));
+
+		// If player can type, remove panel
+		if (plugin.canType)
+		{
+			panelComponent.getChildren().clear();
+			rendered = false;
+		}
+
+		// If player can't type, render the panel
+		if (!plugin.canType && !rendered)
+		{
+			panelComponent.getChildren().add(TitleComponent.builder()
+					.text("Press Enter to Chat...")
+					.color(Color.GRAY)
+					.build());
+			rendered = true;
+		}
+
+		return panelComponent.render(graphics);
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/wasdcamera/WASDCameraPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/wasdcamera/WASDCameraPlugin.java
@@ -120,7 +120,6 @@ public class WASDCameraPlugin extends Plugin
 	 */
 	private void handleCamera()
 	{
-		System.out.println("Initializing Key Listener");
 		KeyboardFocusManager.getCurrentKeyboardFocusManager().addKeyEventDispatcher(new KeyEventDispatcher()
 		{
 			@Override
@@ -135,7 +134,7 @@ public class WASDCameraPlugin extends Plugin
 							// If chatbox is enabled or at login screen, don't handle camera movement
 							if (canType || robot == null) { break; }
 
-							// Delete the last key press from chatbox if alphanumeric
+							// Delete the last key press from chatbox if alphabet, numeric or whitespace
 							if (Character.isAlphabetic(event.getKeyCode()) ||
 									(Character.isDigit(event.getKeyCode()) ||
 									 Character.isWhitespace(event.getKeyCode())))

--- a/runelite-client/src/main/java/net/runelite/client/plugins/wasdcamera/WASDCameraPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/wasdcamera/WASDCameraPlugin.java
@@ -136,7 +136,9 @@ public class WASDCameraPlugin extends Plugin
 							if (canType || robot == null) { break; }
 
 							// Delete the last key press from chatbox if alphanumeric
-							if (Character.isAlphabetic(event.getKeyCode()) || (Character.isDigit(event.getKeyCode())))
+							if (Character.isAlphabetic(event.getKeyCode()) ||
+									(Character.isDigit(event.getKeyCode()) ||
+									 Character.isWhitespace(event.getKeyCode())))
 							{
 								robot.keyPress(KeyEvent.VK_BACK_SPACE);
 							}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/wasdcamera/WASDCameraPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/wasdcamera/WASDCameraPlugin.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright (c) 2018, Abexlry <abexlry@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.wasdcamera;
+
+import com.google.common.eventbus.Subscribe;
+import com.google.inject.Provides;
+import java.awt.KeyEventDispatcher;
+import java.awt.KeyboardFocusManager;
+import java.awt.Robot;
+import java.awt.event.KeyEvent;
+import javax.inject.Inject;
+import net.runelite.api.Client;
+import net.runelite.api.events.GameTick;
+import net.runelite.api.events.MenuOptionClicked;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.ui.overlay.OverlayManager;
+
+@PluginDescriptor(
+		name = "WASD Camera",
+		description = "Allows use of WASD keys for camera movement with 'Press Enter to Chat'",
+		tags = {"wasd", "camera", "chat"}
+)
+
+public class WASDCameraPlugin extends Plugin
+{
+
+	@Inject
+	private Client client;
+
+	@Inject
+	private OverlayManager overlayManager;
+
+	@Inject
+	private WASDCameraOverlay overlay;
+
+	@Inject
+	private WASDCameraConfig config;
+
+	private Robot robot;
+	public boolean canType;
+
+	@Provides
+	WASDCameraConfig getConfig(ConfigManager configManager)
+	{
+		return configManager.getConfig(WASDCameraConfig.class);
+	}
+
+	@Override
+	protected void startUp() throws Exception
+	{
+		//overlayManager.add(overlay);
+		canType = true;
+	}
+
+	@Override
+	protected void shutDown() throws Exception
+	{
+		robot = null;
+		overlayManager.remove(overlay);
+	}
+
+	@Subscribe
+	public void onGameTick(GameTick gameTick) throws Exception
+	{
+		if (robot == null)
+		{
+			initializeCamera();
+		}
+	}
+
+	@Subscribe
+	public void onMenuOptionClicked(MenuOptionClicked event)
+	{
+		int widgetId = event.getWidgetId();
+
+		// If clicking on friend for private messaging, set canType to true
+		if (widgetId == 28114953)
+		{
+			canType = true;
+		}
+	}
+
+	/**
+	 * Initialize plugin
+	 */
+	private void initializeCamera() throws Exception
+	{
+		robot = new Robot();
+		canType = false;
+		handleCamera();
+		overlayManager.add(overlay);
+	}
+
+	/**
+	 * Handles key listener events
+	 */
+	private void handleCamera()
+	{
+		System.out.println("Initializing Key Listener");
+		KeyboardFocusManager.getCurrentKeyboardFocusManager().addKeyEventDispatcher(new KeyEventDispatcher()
+		{
+			@Override
+			public boolean dispatchKeyEvent(KeyEvent event)
+			{
+				synchronized (WASDCameraPlugin.class)
+				{
+					switch (event.getID())
+					{
+						// On key press
+						case KeyEvent.KEY_PRESSED:
+							// If chatbox is enabled or at login screen, don't handle camera movement
+							if (canType || robot == null) { break; }
+
+							// Delete the last key press from chatbox if alphanumeric
+							if (Character.isAlphabetic(event.getKeyCode()) || (Character.isDigit(event.getKeyCode())))
+							{
+								robot.keyPress(KeyEvent.VK_BACK_SPACE);
+							}
+							if (event.getKeyCode() == KeyEvent.VK_W)
+							{
+								robot.keyPress(KeyEvent.VK_UP);
+							}
+							if (event.getKeyCode() == KeyEvent.VK_A)
+							{
+								robot.keyPress(KeyEvent.VK_LEFT);
+							}
+							if (event.getKeyCode() == KeyEvent.VK_S)
+							{
+								robot.keyPress(KeyEvent.VK_DOWN);
+							}
+							if (event.getKeyCode() == KeyEvent.VK_D)
+							{
+								robot.keyPress(KeyEvent.VK_RIGHT);
+							}
+							break;
+
+						// On key release
+						case KeyEvent.KEY_RELEASED:
+							// If enter was pressed, toggle chatbox state
+							if (event.getKeyCode() == KeyEvent.VK_ENTER || event.getKeyCode() == KeyEvent.VK_TAB)
+							{
+								handleEnter();
+							}
+
+							// If chatbox is enabled or at login screen, don't handle camera movement
+							if (canType || robot == null) { break; }
+							if (event.getKeyCode() == KeyEvent.VK_W)
+							{
+								robot.keyRelease(KeyEvent.VK_UP);
+							}
+							if (event.getKeyCode() == KeyEvent.VK_A)
+							{
+								robot.keyRelease(KeyEvent.VK_LEFT);
+							}
+							if (event.getKeyCode() == KeyEvent.VK_S)
+							{
+								robot.keyRelease(KeyEvent.VK_DOWN);
+							}
+							if (event.getKeyCode() == KeyEvent.VK_D)
+							{
+								robot.keyRelease(KeyEvent.VK_RIGHT);
+							}
+							break;
+					}
+					return false;
+				}
+			}
+		});
+	}
+
+	/**
+	 * Handles what happens when hitting enter
+	 */
+	private void handleEnter()
+	{
+		if (robot == null)
+		{
+			return;
+		}
+		releaseAllKeys();
+		canType = !canType;
+	}
+
+	/**
+	 * Release any camera keys still left down upon hitting enter to avoid continuous camera movement
+	 */
+	private void releaseAllKeys()
+	{
+		robot.keyRelease(KeyEvent.VK_UP);
+		robot.keyRelease(KeyEvent.VK_LEFT);
+		robot.keyRelease(KeyEvent.VK_DOWN);
+		robot.keyRelease(KeyEvent.VK_RIGHT);
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/wasdcamera/WASDCameraPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/wasdcamera/WASDCameraPlugin.java
@@ -132,12 +132,15 @@ public class WASDCameraPlugin extends Plugin
 						// On key press
 						case KeyEvent.KEY_PRESSED:
 							// If chatbox is enabled or at login screen, don't handle camera movement
-							if (canType || robot == null) { break; }
+							if (canType || robot == null)
+							{
+								break;
+							}
 
 							// Delete the last key press from chatbox if alphabet, numeric or whitespace
 							if (Character.isAlphabetic(event.getKeyCode()) ||
 									(Character.isDigit(event.getKeyCode()) ||
-									 Character.isWhitespace(event.getKeyCode())))
+											Character.isWhitespace(event.getKeyCode())))
 							{
 								robot.keyPress(KeyEvent.VK_BACK_SPACE);
 							}
@@ -168,7 +171,9 @@ public class WASDCameraPlugin extends Plugin
 							}
 
 							// If chatbox is enabled or at login screen, don't handle camera movement
-							if (canType || robot == null) { break; }
+							if (canType || robot == null) {
+								break;
+							}
 							if (event.getKeyCode() == KeyEvent.VK_W)
 							{
 								robot.keyRelease(KeyEvent.VK_UP);


### PR DESCRIPTION
WASD Camera Plugin
-Listed under "WASD Camera"
-Allows use of WASD keys to move camera
-Chatbox is disabled with an overlay that says "Press Enter to Chat..."
-Upon hitting Enter, Tab or clicking a friend to PM the chat entry enables
-Hitting Enter again disables the chat entry
-Does not affect/disable F keys, arrow keys, etc.