### PR TITLE
Monk health correction

### DIFF
--- a/runelite-client/src/main/resources/npc_health.json
+++ b/runelite-client/src/main/resources/npc_health.json
@@ -612,7 +612,7 @@
   "Ice troll male_82": 80,
   "Ice Troll_124": 100,
   "Woman_2": 7,
-  "Monk_5": 15,
+  "Monk_5": 5,
   "Rabbit_1": 5,
   "Woman_4": 7,
   "Rabbit_2": 5,


### PR DESCRIPTION
Monks in Kandarin Monastery have 5 HP. Not sure about Monk_3.