### PR TITLE
Add Grotesque Guardian plugin

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/GraphicID.java
+++ b/runelite-api/src/main/java/net/runelite/api/GraphicID.java
@@ -28,6 +28,7 @@ public class GraphicID
 {
 	public static final int TELEPORT = 111;
 	public static final int GREY_BUBBLE_TELEPORT = 86;
+	public static final int GROTESQUE_GUARDIANS_STONE_ORB = 160;
 	public static final int ENTANGLE = 179;
 	public static final int SNARE = 180;
 	public static final int BIND = 181;
@@ -40,8 +41,7 @@ public class GraphicID
 	public static final int STAFF_OF_THE_DEAD = 1228;
 	public static final int IMBUED_HEART = 1316;
 	public static final int FLYING_FISH = 1387;
-	public static final int GROTESQUE_GUARDIANS_LIGHTNING_BEG = 1416;
+	public static final int GROTESQUE_GUARDIANS_LIGHTNING_START = 1416;
 	public static final int GROTESQUE_GUARDIANS_LIGHTNING_END = 1431;
-	public static final int GROTESQUE_GUARDIANS_STONE_ORB = 160;
 	public static final int GROTESQUE_GUARDIANS_FALLING_ROCKS = 1436;
 }

--- a/runelite-api/src/main/java/net/runelite/api/GraphicID.java
+++ b/runelite-api/src/main/java/net/runelite/api/GraphicID.java
@@ -40,4 +40,8 @@ public class GraphicID
 	public static final int STAFF_OF_THE_DEAD = 1228;
 	public static final int IMBUED_HEART = 1316;
 	public static final int FLYING_FISH = 1387;
+	public static final int GROTESQUE_GUARDIANS_LIGHTNING_BEG = 1416;
+	public static final int GROTESQUE_GUARDIANS_LIGHTNING_END = 1431;
+	public static final int GROTESQUE_GUARDIANS_STONE_ORB = 160;
+	public static final int GROTESQUE_GUARDIANS_FALLING_ROCKS = 1436;
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grotesqueguardians/GrotesqueGuardiansOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grotesqueguardians/GrotesqueGuardiansOverlay.java
@@ -40,7 +40,7 @@ import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.OverlayPriority;
 import net.runelite.client.ui.overlay.OverlayUtil;
 
-public class GrotesqueGuardiansOverlay extends Overlay
+class GrotesqueGuardiansOverlay extends Overlay
 {
 	private final Client client;
 	private final int GROTESQUE_GUARDIANS_REGION_ID = 6727;
@@ -81,7 +81,7 @@ public class GrotesqueGuardiansOverlay extends Overlay
 				return null;
 			}
 
-			if (graphicsObject.getId() >= GraphicID.GROTESQUE_GUARDIANS_LIGHTNING_BEG && graphicsObject.getId() <= GraphicID.GROTESQUE_GUARDIANS_LIGHTNING_END)
+			if (graphicsObject.getId() >= GraphicID.GROTESQUE_GUARDIANS_LIGHTNING_START && graphicsObject.getId() <= GraphicID.GROTESQUE_GUARDIANS_LIGHTNING_END)
 			{
 				color = Color.ORANGE;
 			}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grotesqueguardians/GrotesqueGuardiansOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grotesqueguardians/GrotesqueGuardiansOverlay.java
@@ -65,32 +65,29 @@ class GrotesqueGuardiansOverlay extends Overlay
 		// TODO: Awaiting GraphicsObjectDespawn event to be tracked to make this more efficient.
 		for (GraphicsObject graphicsObject : client.getGraphicsObjects())
 		{
-			LocalPoint lp = graphicsObject.getLocation();
-			Polygon poly = Perspective.getCanvasTilePoly(client, lp);
 			Color color = null;
-
-			if (poly == null)
-			{
-				return null;
-			}
 
 			if (graphicsObject.getId() >= GraphicID.GROTESQUE_GUARDIANS_LIGHTNING_START && graphicsObject.getId() <= GraphicID.GROTESQUE_GUARDIANS_LIGHTNING_END)
 			{
 				color = Color.ORANGE;
 			}
-
-			if (graphicsObject.getId() == GraphicID.GROTESQUE_GUARDIANS_STONE_ORB)
+			else if (graphicsObject.getId() == GraphicID.GROTESQUE_GUARDIANS_STONE_ORB)
 			{
 				color = Color.GRAY;
 			}
-
-			if (graphicsObject.getId() == GraphicID.GROTESQUE_GUARDIANS_FALLING_ROCKS)
+			else if (graphicsObject.getId() == GraphicID.GROTESQUE_GUARDIANS_FALLING_ROCKS)
 			{
 				color = Color.YELLOW;
-
+			}
+			else
+			{
+				continue;
 			}
 
-			if (color != null)
+			LocalPoint lp = graphicsObject.getLocation();
+			Polygon poly = Perspective.getCanvasTilePoly(client, lp);
+
+			if (poly != null)
 			{
 				OverlayUtil.renderPolygon(graphics, poly, color);
 			}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grotesqueguardians/GrotesqueGuardiansOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grotesqueguardians/GrotesqueGuardiansOverlay.java
@@ -33,7 +33,6 @@ import net.runelite.api.Client;
 import net.runelite.api.GraphicID;
 import net.runelite.api.GraphicsObject;
 import net.runelite.api.Perspective;
-import net.runelite.api.Point;
 import net.runelite.api.coords.LocalPoint;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
@@ -101,13 +100,6 @@ public class GrotesqueGuardiansOverlay extends Overlay
 			if (color != null)
 			{
 				OverlayUtil.renderPolygon(graphics, poly, color);
-
-				Point textLocation = Perspective.getCanvasTextLocation(client, graphics, lp, "", 0);
-
-				if (textLocation != null)
-				{
-					OverlayUtil.renderTextLocation(graphics, textLocation, "", color);
-				}
 			}
 		}
 		return null;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grotesqueguardians/GrotesqueGuardiansOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grotesqueguardians/GrotesqueGuardiansOverlay.java
@@ -42,7 +42,7 @@ import net.runelite.client.ui.overlay.OverlayUtil;
 
 class GrotesqueGuardiansOverlay extends Overlay
 {
-	static final int GROTESQUE_GUARDIANS_REGION_ID = 6727;
+	private static final int GROTESQUE_GUARDIANS_REGION_ID = 6727;
 	private final Client client;
 
 	@Inject

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grotesqueguardians/GrotesqueGuardiansOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grotesqueguardians/GrotesqueGuardiansOverlay.java
@@ -76,7 +76,6 @@ public class GrotesqueGuardiansOverlay extends Overlay
 			LocalPoint lp = graphicsObject.getLocation();
 			Polygon poly = Perspective.getCanvasTilePoly(client, lp);
 			Color color = null;
-			String text = "";
 
 			if (poly == null)
 			{
@@ -86,19 +85,16 @@ public class GrotesqueGuardiansOverlay extends Overlay
 			if (graphicsObject.getId() >= GraphicID.GROTESQUE_GUARDIANS_LIGHTNING_BEG && graphicsObject.getId() <= GraphicID.GROTESQUE_GUARDIANS_LIGHTNING_END)
 			{
 				color = Color.ORANGE;
-				text = "Lightning";
 			}
 
 			if (graphicsObject.getId() == GraphicID.GROTESQUE_GUARDIANS_STONE_ORB)
 			{
 				color = Color.GRAY;
-				text = "Stone Orb";
 			}
 
 			if (graphicsObject.getId() == GraphicID.GROTESQUE_GUARDIANS_FALLING_ROCKS)
 			{
 				color = Color.YELLOW;
-				text = "Falling Rocks";
 
 			}
 
@@ -106,11 +102,11 @@ public class GrotesqueGuardiansOverlay extends Overlay
 			{
 				OverlayUtil.renderPolygon(graphics, poly, color);
 
-				Point textLocation = Perspective.getCanvasTextLocation(client, graphics, lp, text, 0);
+				Point textLocation = Perspective.getCanvasTextLocation(client, graphics, lp, "", 0);
 
 				if (textLocation != null)
 				{
-					OverlayUtil.renderTextLocation(graphics, textLocation, text, color);
+					OverlayUtil.renderTextLocation(graphics, textLocation, "", color);
 				}
 			}
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grotesqueguardians/GrotesqueGuardiansOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grotesqueguardians/GrotesqueGuardiansOverlay.java
@@ -57,16 +57,9 @@ class GrotesqueGuardiansOverlay extends Overlay
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
-		if (!client.isInInstancedRegion())
+		if (!client.isInInstancedRegion() || client.getMapRegions()[0] != GROTESQUE_GUARDIANS_REGION_ID)
 		{
 			return null;
-		}
-		else
-		{
-			if (client.getMapRegions()[0] != GROTESQUE_GUARDIANS_REGION_ID)
-			{
-				return null;
-			}
 		}
 
 		// TODO: Awaiting GraphicsObjectDespawn event to be tracked to make this more efficient.

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grotesqueguardians/GrotesqueGuardiansOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grotesqueguardians/GrotesqueGuardiansOverlay.java
@@ -42,8 +42,8 @@ import net.runelite.client.ui.overlay.OverlayUtil;
 
 class GrotesqueGuardiansOverlay extends Overlay
 {
+	static final int GROTESQUE_GUARDIANS_REGION_ID = 6727;
 	private final Client client;
-	private final int GROTESQUE_GUARDIANS_REGION_ID = 6727;
 
 	@Inject
 	private GrotesqueGuardiansOverlay(Client client)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grotesqueguardians/GrotesqueGuardiansOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grotesqueguardians/GrotesqueGuardiansOverlay.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2018, Damen <https://github.com/basicDamen>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *	list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *	this list of conditions and the following disclaimer in the documentation
+ *	and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.grotesqueguardians;
+
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Graphics2D;
+import java.awt.Polygon;
+import javax.inject.Inject;
+import net.runelite.api.Client;
+import net.runelite.api.GraphicID;
+import net.runelite.api.GraphicsObject;
+import net.runelite.api.Perspective;
+import net.runelite.api.Point;
+import net.runelite.api.coords.LocalPoint;
+import net.runelite.client.ui.overlay.Overlay;
+import net.runelite.client.ui.overlay.OverlayLayer;
+import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.OverlayPriority;
+import net.runelite.client.ui.overlay.OverlayUtil;
+
+public class GrotesqueGuardiansOverlay extends Overlay
+{
+	private final Client client;
+
+	@Inject
+	private GrotesqueGuardiansOverlay(Client client)
+	{
+		this.client = client;
+		setPosition(OverlayPosition.DYNAMIC);
+		setLayer(OverlayLayer.ABOVE_SCENE);
+		setPriority(OverlayPriority.LOW);
+	}
+
+	@Override
+	public Dimension render(Graphics2D graphics)
+	{
+		if (!client.isInInstancedRegion())
+		{
+			return null;
+		}
+		else
+		{
+			if (client.getMapRegions()[0] != 6727)
+			{
+				return null;
+			}
+		}
+
+		// TODO: Awaiting GraphicsObjectDespawn event to be tracked to make this more efficient.
+		for (GraphicsObject graphicsObject : client.getGraphicsObjects())
+		{
+			LocalPoint lp = graphicsObject.getLocation();
+			Polygon poly = Perspective.getCanvasTilePoly(client, lp);
+			Color color = null;
+			String text = "";
+
+			if (poly == null)
+			{
+				return null;
+			}
+
+			if (graphicsObject.getId() >= GraphicID.GROTESQUE_GUARDIANS_LIGHTNING_BEG && graphicsObject.getId() <= GraphicID.GROTESQUE_GUARDIANS_LIGHTNING_END)
+			{
+				color = Color.ORANGE;
+				text = "Lightning";
+			}
+
+			if (graphicsObject.getId() == GraphicID.GROTESQUE_GUARDIANS_STONE_ORB)
+			{
+				color = Color.GRAY;
+				text = "Stone Orb";
+			}
+
+			if (graphicsObject.getId() == GraphicID.GROTESQUE_GUARDIANS_FALLING_ROCKS)
+			{
+				color = Color.YELLOW;
+				text = "Falling Rocks";
+
+			}
+
+			if (color != null)
+			{
+				OverlayUtil.renderPolygon(graphics, poly, color);
+
+				Point textLocation = Perspective.getCanvasTextLocation(client, graphics, lp, text, 0);
+
+				if (textLocation != null)
+				{
+					OverlayUtil.renderTextLocation(graphics, textLocation, text, color);
+				}
+			}
+		}
+		return null;
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grotesqueguardians/GrotesqueGuardiansOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grotesqueguardians/GrotesqueGuardiansOverlay.java
@@ -44,6 +44,7 @@ import net.runelite.client.ui.overlay.OverlayUtil;
 public class GrotesqueGuardiansOverlay extends Overlay
 {
 	private final Client client;
+	private final int GROTESQUE_GUARDIANS_REGION_ID = 6727;
 
 	@Inject
 	private GrotesqueGuardiansOverlay(Client client)
@@ -63,7 +64,7 @@ public class GrotesqueGuardiansOverlay extends Overlay
 		}
 		else
 		{
-			if (client.getMapRegions()[0] != 6727)
+			if (client.getMapRegions()[0] != GROTESQUE_GUARDIANS_REGION_ID)
 			{
 				return null;
 			}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grotesqueguardians/GrotesqueGuardiansPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grotesqueguardians/GrotesqueGuardiansPlugin.java
@@ -32,8 +32,7 @@ import net.runelite.client.ui.overlay.OverlayManager;
 @PluginDescriptor(
 	name = "Grotesque Guardians",
 	description = "Display tile indicators for the Grotesque Guardian special attacks",
-	tags = {"grotesque", "guardians", "gargoyle", "garg"},
-	enabledByDefault = true
+	tags = {"grotesque", "guardians", "gargoyle", "garg"}
 )
 public class GrotesqueGuardiansPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grotesqueguardians/GrotesqueGuardiansPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grotesqueguardians/GrotesqueGuardiansPlugin.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2018, Damen <https://github.com/basicDamen>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *	list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *	this list of conditions and the following disclaimer in the documentation
+ *	and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.grotesqueguardians;
+
+import javax.inject.Inject;
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.ui.overlay.OverlayManager;
+
+@PluginDescriptor(
+	name = "Grotesque Guardians",
+	description = "Display tile indicators for the Grotesque Guardian special attacks",
+	tags = {"grotesque", "guardians", "gargoyle", "garg"},
+	enabledByDefault = true
+)
+public class GrotesqueGuardiansPlugin extends Plugin
+{
+	@Inject
+	private OverlayManager overlayManager;
+
+	@Inject
+	private GrotesqueGuardiansOverlay overlay;
+
+	@Override
+	protected void startUp() throws Exception
+	{
+		overlayManager.add(overlay);
+	}
+
+	@Override
+	protected void shutDown() throws Exception
+	{
+		overlayManager.remove(overlay);
+	}
+}


### PR DESCRIPTION
The plugin utilizes tile indicators to display lightning attack special, stone ball, and falling rock destination tiles, as seen in the pictures. (excludes Stone Ball, didn't grab a screenshot)

This plugin helps an individual player know exactly where the objects spawn to avoid standing near them and taking damage, being stunned, frozen, etc.

Note: I have removed the tile text, though, updating pictures is not possible without a slayer task, which I no longer have.

![fallingrocks](https://user-images.githubusercontent.com/16967401/42731797-c84a2c44-87e2-11e8-9083-2662da32c9bf.png)
![lightningspecial](https://user-images.githubusercontent.com/16967401/42731798-c855f538-87e2-11e8-824f-468be62848cd.png)

NOTE: This is a re-post with all the correct additions, due to old branch having issues with merging. This was the most time-effective fix for myself.