### PR TITLE
add AttackStyle Chat Message Warnings

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/attackstyles/AttackStylesConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/attackstyles/AttackStylesConfig.java
@@ -43,10 +43,21 @@ public interface AttackStylesConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "warningMessages",
+		name = "Display Warning Messages",
+		description = "Send client messages when a warning appears",
+		position = 2
+	)
+	default boolean warningMessages()
+	{
+		return true;
+	}
+
+	@ConfigItem(
 		keyName = "warnForDefensive",
 		name = "Warn for defence",
 		description = "Show warning when a Defence skill combat option is selected",
-		position = 2
+		position = 3
 	)
 	default boolean warnForDefence()
 	{
@@ -57,7 +68,7 @@ public interface AttackStylesConfig extends Config
 		keyName = "warnForAttack",
 		name = "Warn for attack",
 		description = "Show warning when an Attack skill combat option is selected",
-		position = 3
+		position = 4
 	)
 	default boolean warnForAttack()
 	{
@@ -68,7 +79,7 @@ public interface AttackStylesConfig extends Config
 		keyName = "warnForStrength",
 		name = "Warn for strength",
 		description = "Show warning when a Strength skill combat option is selected",
-		position = 4
+		position = 5
 	)
 	default boolean warnForStrength()
 	{
@@ -79,7 +90,7 @@ public interface AttackStylesConfig extends Config
 		keyName = "warnForRanged",
 		name = "Warn for ranged",
 		description = "Show warning when a Ranged skill combat option is selected",
-		position = 5
+		position = 6
 	)
 	default boolean warnForRanged()
 	{
@@ -90,7 +101,7 @@ public interface AttackStylesConfig extends Config
 		keyName = "warnForMagic",
 		name = "Warn for magic",
 		description = "Show warning when a Magic skill combat option is selected",
-		position = 6
+		position = 7
 	)
 	default boolean warnForMagic()
 	{
@@ -101,7 +112,7 @@ public interface AttackStylesConfig extends Config
 		keyName = "removeWarnedStyles",
 		name = "Remove warned styles",
 		description = "Remove warned styles from the combat options tab",
-		position = 7
+		position = 8
 	)
 	default boolean removeWarnedStyles()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/attackstyles/AttackStylesPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/attackstyles/AttackStylesPlugin.java
@@ -338,21 +338,24 @@ public class AttackStylesPlugin extends Plugin
 			{
 				if (!messageTickGuarded)
 				{
-					// If the login message has been sent, it will run the corresponding messages if it's a weaponSwitch or just a combatStyle change.
-					if (loginMessageSent)
+					if (builder.length() > 0)
 					{
-						if (weaponSwitch)
+						// If the login message has been sent, it will run the corresponding messages if it's a weaponSwitch or just a combatStyle change.
+						if (loginMessageSent)
 						{
-							sendChatMessage("This weapon's attack style will grant XP in: " + builder);
+							if (weaponSwitch)
+							{
+								sendChatMessage("This weapon's attack style will grant XP in: " + builder);
+							}
+							else
+							{
+								sendChatMessage("This attack style will grant XP in: " + builder);
+							}
 						}
 						else
 						{
-							sendChatMessage("This attack style will grant XP in: " + builder);
+							sendChatMessage("You logged in wielding a weapon that will grant XP in: " + builder);
 						}
-					}
-					else
-					{
-						sendChatMessage("You logged in wielding a weapon that will grant XP in: " + builder);
 					}
 				}
 			}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/attackstyles/AttackStylesPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/attackstyles/AttackStylesPlugin.java
@@ -310,9 +310,7 @@ public class AttackStylesPlugin extends Plugin
 	private void updateWarning(boolean weaponSwitch)
 	{
 		warnedSkillSelected = false;
-		String[]styleBuilderArray = new String[4];
-		String styleBuilder = "";
-		int count = 0;
+		StringBuilder builder = new StringBuilder();
 		if (attackStyle != null)
 		{
 			for (Skill skill : attackStyle.getSkills())
@@ -324,8 +322,12 @@ public class AttackStylesPlugin extends Plugin
 						// If all variables have been set, this guard will be set to false, therefore, continuing the code block pertaining to messages.
 						if (!messageTickGuarded)
 						{
-							count++;
-							styleBuilderArray[count] = getAttackColor(skill);
+							if (builder.length() > 0)
+							{
+								builder.append(", ");
+							}
+
+							builder.append(getAttackColor(skill));
 						}
 					}
 					warnedSkillSelected = true;
@@ -336,45 +338,21 @@ public class AttackStylesPlugin extends Plugin
 			{
 				if (!messageTickGuarded)
 				{
-					for (int i = 1; i <= count; i++)
-					{
-						if (i == 1)
-						{
-							styleBuilder = styleBuilderArray[i];
-							continue;
-						}
-						else if (i == 2 && count != 2)
-						{
-							styleBuilder += (", " + styleBuilderArray[i]);
-							continue;
-						}
-						else if (i == 2 && count == 2)
-						{
-							styleBuilder += (" and " + styleBuilderArray[i]);
-							continue;
-						}
-						else if (i == 3)
-						{
-							styleBuilder += (", and " + styleBuilderArray[i]);
-							continue;
-						}
-					}
-
 					// If the login message has been sent, it will run the corresponding messages if it's a weaponSwitch or just a combatStyle change.
 					if (loginMessageSent)
 					{
 						if (weaponSwitch)
 						{
-							sendChatMessage("This weapon's attack style will grant you " + styleBuilder + " XP.");
+							sendChatMessage("This weapon's attack style will grant XP in: " + builder);
 						}
 						else
 						{
-							sendChatMessage("This attack style will grant you " + styleBuilder + " XP.");
+							sendChatMessage("This attack style will grant XP in: " + builder);
 						}
 					}
 					else
 					{
-						sendChatMessage("You logged in wielding a weapon that will grant you " + styleBuilder + " XP.");
+						sendChatMessage("You logged in wielding a weapon that will grant XP in: " + builder);
 					}
 				}
 			}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/attackstyles/AttackStylesPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/attackstyles/AttackStylesPlugin.java
@@ -310,33 +310,72 @@ public class AttackStylesPlugin extends Plugin
 	private void updateWarning(boolean weaponSwitch)
 	{
 		warnedSkillSelected = false;
+		String[]styleBuilderArray = new String[4];
+		String styleBuilder = "";
+		int count = 0;
 		if (attackStyle != null)
 		{
 			for (Skill skill : attackStyle.getSkills())
 			{
 				if (warnedSkills.contains(skill))
 				{
-					// If all variables have been set, this guard will be set to false, therefore, continuing the code block pertaining to messages.
-					if (!messageTickGuarded)
+					if (config.warningMessages())
 					{
-						// If the login message has been sent, it will run the corresponding messages if it's a weaponSwitch or just a combatStyle change.
-						if (loginMessageSent)
+						// If all variables have been set, this guard will be set to false, therefore, continuing the code block pertaining to messages.
+						if (!messageTickGuarded)
 						{
-							if (weaponSwitch)
-							{
-								sendChatMessage("This weapon's attack style will grant you " + getAttackColor(skill) + " XP.");
-							}
-							else
-							{
-								sendChatMessage("This attack style will grant you " + getAttackColor(skill) + " XP.");
-							}
-						}
-						else
-						{
-							sendChatMessage("You logged in wielding a weapon that will grant you " + getAttackColor(skill) + " XP.");
+							count++;
+							styleBuilderArray[count] = getAttackColor(skill);
 						}
 					}
 					warnedSkillSelected = true;
+				}
+			}
+
+			if (config.warningMessages())
+			{
+				if (!messageTickGuarded)
+				{
+					for (int i = 1; i <= count; i++)
+					{
+						if (i == 1)
+						{
+							styleBuilder = styleBuilderArray[i];
+							continue;
+						}
+						else if (i == 2 && count != 2)
+						{
+							styleBuilder += (", " + styleBuilderArray[i]);
+							continue;
+						}
+						else if (i == 2 && count == 2)
+						{
+							styleBuilder += (" and " + styleBuilderArray[i]);
+							continue;
+						}
+						else if (i == 3)
+						{
+							styleBuilder += (", and " + styleBuilderArray[i]);
+							continue;
+						}
+					}
+
+					// If the login message has been sent, it will run the corresponding messages if it's a weaponSwitch or just a combatStyle change.
+					if (loginMessageSent)
+					{
+						if (weaponSwitch)
+						{
+							sendChatMessage("This weapon's attack style will grant you " + styleBuilder + " XP.");
+						}
+						else
+						{
+							sendChatMessage("This attack style will grant you " + styleBuilder + " XP.");
+						}
+					}
+					else
+					{
+						sendChatMessage("You logged in wielding a weapon that will grant you " + styleBuilder + " XP.");
+					}
 				}
 			}
 		}
@@ -415,20 +454,16 @@ public class AttackStylesPlugin extends Plugin
 
 	private void sendChatMessage(String chatMessage)
 	{
-		if (config.warningMessages())
-		{
-			final String message = new ChatMessageBuilder()
-				.append(ChatColorType.NORMAL)
-				.append("<col=871A1A>[ATTACK STYLE]</col> ")
-				.append(chatMessage)
-				.build();
+		final String message = new ChatMessageBuilder()
+			.append(ChatColorType.NORMAL)
+			.append(chatMessage)
+			.build();
 
-			chatMessageManager.queue(
-				QueuedMessage.builder()
-					.type(ChatMessageType.GAME)
-					.runeLiteFormattedMessage(message)
-					.build());
-		}
+		chatMessageManager.queue(
+			QueuedMessage.builder()
+				.type(ChatMessageType.GAME)
+				.runeLiteFormattedMessage(message)
+				.build());
 	}
 
 	private String getAttackColor(Skill skill)
@@ -439,13 +474,22 @@ public class AttackStylesPlugin extends Plugin
 			case ATTACK:
 			case STRENGTH:
 			case DEFENCE:
+			{
 				color = "<col=D44A4A>";
+				break;
+			}
 			case RANGED:
+			{
 				color = "<col=259443>";
+				break;
+			}
 			case MAGIC:
+			{
 				color = "<col=369EB3>";
+				break;
+			}
 		}
-		return color + skill + "</col>";
+		return color + skill.getName() + "</col>";
 	}
 
 	@VisibleForTesting

--- a/runelite-client/src/main/java/net/runelite/client/plugins/attackstyles/AttackStylesPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/attackstyles/AttackStylesPlugin.java
@@ -341,21 +341,23 @@ public class AttackStylesPlugin extends Plugin
 					if (builder.length() > 0)
 					{
 						// If the login message has been sent, it will run the corresponding messages if it's a weaponSwitch or just a combatStyle change.
+						String attackStyleWarningFormat = "";
 						if (loginMessageSent)
 						{
 							if (weaponSwitch)
 							{
-								sendChatMessage("This weapon's attack style will grant XP in: " + builder);
+								attackStyleWarningFormat = "This weapon's attack style will grant XP in: ";
 							}
 							else
 							{
-								sendChatMessage("This attack style will grant XP in: " + builder);
+								attackStyleWarningFormat = "This attack style will grant XP in: ";
 							}
 						}
 						else
 						{
-							sendChatMessage("You logged in wielding a weapon that will grant XP in: " + builder);
+							attackStyleWarningFormat = "You logged in wielding a weapon that will grant XP in: ";
 						}
+						sendChatMessage(attackStyleWarningFormat + builder);
 					}
 				}
 			}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/attackstyles/AttackStylesPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/attackstyles/AttackStylesPlugin.java
@@ -260,21 +260,27 @@ public class AttackStylesPlugin extends Plugin
 			switch (event.getKey())
 			{
 				case "warnForDefensive":
+					sendChatMessage("You have " + (enabled ? "enabled" : "disabled") + " the warning for " + returnAttackColor(Skill.DEFENCE) + " XP." );
 					updateWarnedSkills(enabled, Skill.DEFENCE);
 					break;
 				case "warnForAttack":
+					sendChatMessage("You have " + (enabled ? "enabled" : "disabled") + " the warning for " + returnAttackColor(Skill.ATTACK) + " XP." );
 					updateWarnedSkills(enabled, Skill.ATTACK);
 					break;
 				case "warnForStrength":
+					sendChatMessage("You have " + (enabled ? "enabled" : "disabled") + " the warning for " + returnAttackColor(Skill.STRENGTH) + " XP." );
 					updateWarnedSkills(enabled, Skill.STRENGTH);
 					break;
 				case "warnForRanged":
+					sendChatMessage("You have " + (enabled ? "enabled" : "disabled") + " the warning for " + returnAttackColor(Skill.RANGED) + " XP." );
 					updateWarnedSkills(enabled, Skill.RANGED);
 					break;
 				case "warnForMagic":
+					sendChatMessage("You have " + (enabled ? "enabled" : "disabled") + " the warning for " + returnAttackColor(Skill.MAGIC) + " XP." );
 					updateWarnedSkills(enabled, Skill.MAGIC);
 					break;
 				case "removeWarnedStyles":
+					sendChatMessage("You have decided to " + (enabled ? "hide" : "show") + " the warned styles from the combat styles interface." );
 					hideWarnedStyles(enabled);
 					break;
 			}
@@ -323,17 +329,20 @@ public class AttackStylesPlugin extends Plugin
 				{
 					if (loginWarningMessageCount == 3)
 					{
-						sendChatMessage("<col=871A1A>[ATTACK STYLE]</col> You logged in wielding a weapon that will grant you " + returnAttackColor(skill) + " XP. #" + loginWarningMessageCount);
+						if (config.warningMessages())
+							sendChatMessage("<col=871A1A>[ATTACK STYLE]</col> You logged in wielding a weapon that will grant you " + returnAttackColor(skill) + " XP. #" + loginWarningMessageCount);
 					}
 					else if (loginWarningMessageCount == 4)
 					{
 						if (weaponSwitch)
 						{
-							sendChatMessage("<col=871A1A>[ATTACK STYLE]</col> This weapon's attack style will grant you " + returnAttackColor(skill) + " XP. #" + loginWarningMessageCount);
+							if (config.warningMessages())
+								sendChatMessage("<col=871A1A>[ATTACK STYLE]</col> This weapon's attack style will grant you " + returnAttackColor(skill) + " XP. #" + loginWarningMessageCount);
 						}
 						else
 						{
-							sendChatMessage("<col=871A1A>[ATTACK STYLE]</col> This attack style will grant you " + returnAttackColor(skill) + " XP. #" + loginWarningMessageCount);
+							if (config.warningMessages())
+								sendChatMessage("<col=871A1A>[ATTACK STYLE]</col> This attack style will grant you " + returnAttackColor(skill) + " XP. #" + loginWarningMessageCount);
 						}
 					}
 					warnedSkillSelected = true;
@@ -432,7 +441,7 @@ public class AttackStylesPlugin extends Plugin
 	private String returnAttackColor(Skill skill)
 	{
 		String color = "<col=ff0000>" + skill + "</col>";
-		switch(skill)
+		switch (skill)
 		{
 			case ATTACK:
 			case STRENGTH:

--- a/runelite-client/src/main/java/net/runelite/client/plugins/attackstyles/AttackStylesPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/attackstyles/AttackStylesPlugin.java
@@ -445,7 +445,7 @@ public class AttackStylesPlugin extends Plugin
 			case MAGIC:
 				color = "<col=369EB3>";
 		}
-		return color  + skill + "</col>";
+		return color + skill + "</col>";
 	}
 
 	@VisibleForTesting

--- a/runelite-client/src/main/java/net/runelite/client/plugins/attackstyles/AttackStylesPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/attackstyles/AttackStylesPlugin.java
@@ -127,6 +127,7 @@ public class AttackStylesPlugin extends Plugin
 			equippedWeaponTypeVarbit,
 			attackStyleVarbit,
 			castingModeVarbit);
+		updateWarning(false);
 		processWidgets();
 	}
 
@@ -136,6 +137,8 @@ public class AttackStylesPlugin extends Plugin
 		overlayManager.remove(overlay);
 		hideWarnedStyles(false);
 		processWidgets();
+
+
 	}
 
 	public AttackStyle getAttackStyle()
@@ -203,11 +206,12 @@ public class AttackStylesPlugin extends Plugin
 			attackStyleVarbit = client.getVar(VarPlayer.ATTACK_STYLE);
 			updateAttackStyle(client.getVar(Varbits.EQUIPPED_WEAPON_TYPE), attackStyleVarbit,
 				client.getVar(Varbits.DEFENSIVE_CASTING_MODE));
+			updateWarning(false);
 
-			if (loginWarningMessageCount == 4)
-				updateWarning(false);
-			else if (loginWarningMessageCount <= 2)
+			if (loginWarningMessageCount <= 2)
 				loginWarningMessageCount++;
+
+
 		}
 	}
 
@@ -216,7 +220,7 @@ public class AttackStylesPlugin extends Plugin
 	{
 		if (equippedWeaponTypeVarbit == -1 || equippedWeaponTypeVarbit != client.getVar(Varbits.EQUIPPED_WEAPON_TYPE))
 		{
-			if (client.getVar(VarPlayer.ATTACK_STYLE) == 0 && loginWarningMessageCount < 4)
+			if (client.getVar(VarPlayer.ATTACK_STYLE) == 0 && loginWarningMessageCount < 4 && loginWarningMessageCount != 1)
 			{
 				loginWarningMessageCount++;
 			}
@@ -225,9 +229,7 @@ public class AttackStylesPlugin extends Plugin
 			updateAttackStyle(equippedWeaponTypeVarbit, client.getVar(VarPlayer.ATTACK_STYLE),
 				client.getVar(Varbits.DEFENSIVE_CASTING_MODE));
 
-			if (loginWarningMessageCount == 3)
-				updateWarning(true);
-			else if (loginWarningMessageCount == 4 )
+			if (loginWarningMessageCount == 3 || loginWarningMessageCount == 4)
 				updateWarning(true);
 			else
 				loginWarningMessageCount++;
@@ -242,9 +244,10 @@ public class AttackStylesPlugin extends Plugin
 			castingModeVarbit = client.getVar(Varbits.DEFENSIVE_CASTING_MODE);
 			updateAttackStyle(client.getVar(Varbits.EQUIPPED_WEAPON_TYPE), client.getVar(VarPlayer.ATTACK_STYLE),
 				castingModeVarbit);
+			updateWarning(false);
 
-			if (loginWarningMessageCount == 4)
-				updateWarning(false);
+			if (loginWarningMessageCount != 4)
+				loginWarningMessageCount++;
 		}
 	}
 
@@ -306,6 +309,7 @@ public class AttackStylesPlugin extends Plugin
 		{
 			warnedSkills.remove(skill);
 		}
+		updateWarning(false);
 	}
 
 	private void updateWarning(boolean weaponSwitch)
@@ -319,17 +323,17 @@ public class AttackStylesPlugin extends Plugin
 				{
 					if (loginWarningMessageCount == 3)
 					{
-						sendChatMessage("<col=871A1A>[ATTACK STYLE]</col> You logged in wielding a weapon that will grant you " + returnAttackColor(skill) + " XP.");
+						sendChatMessage("<col=871A1A>[ATTACK STYLE]</col> You logged in wielding a weapon that will grant you " + returnAttackColor(skill) + " XP. #" + loginWarningMessageCount);
 					}
 					else if (loginWarningMessageCount == 4)
 					{
 						if (weaponSwitch)
 						{
-							sendChatMessage("<col=871A1A>[ATTACK STYLE]</col> This weapon's attack style will grant you " + returnAttackColor(skill) + " XP.");
+							sendChatMessage("<col=871A1A>[ATTACK STYLE]</col> This weapon's attack style will grant you " + returnAttackColor(skill) + " XP. #" + loginWarningMessageCount);
 						}
 						else
 						{
-							sendChatMessage("<col=871A1A>[ATTACK STYLE]</col> This attack style will grant you " + returnAttackColor(skill) + " XP.");
+							sendChatMessage("<col=871A1A>[ATTACK STYLE]</col> This attack style will grant you " + returnAttackColor(skill) + " XP. #" + loginWarningMessageCount);
 						}
 					}
 					warnedSkillSelected = true;
@@ -428,17 +432,16 @@ public class AttackStylesPlugin extends Plugin
 	private String returnAttackColor(Skill skill)
 	{
 		String color = "<col=ff0000>" + skill + "</col>";
-
-		switch (skill)
+		switch(skill)
 		{
 			case ATTACK:
 			case STRENGTH:
 			case DEFENCE:
 				return color = "<col=D44A4A>" + skill + "</col>";
 			case RANGED:
-				return color = "<col=259443>RANGED</col>";
+				return color = "<col=259443>" + skill + "</col>";
 			case MAGIC:
-				return color = "<col=369EB3>MAGIC</col>";
+				return color = "<col=369EB3>" + skill + "</col>";
 		}
 		return color;
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/attackstyles/AttackStylesPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/attackstyles/AttackStylesPlugin.java
@@ -201,10 +201,7 @@ public class AttackStylesPlugin extends Plugin
 	@Subscribe
 	public void onGameTick(GameTick e)
 	{
-		// Utilizes GameTicks, seeing as variables are set PRIOR to a GameTick actually being ran.
-		// The messages are guarded by this tick-set, therefore, the messages aren't spammed upon
-		// variable setting and then once all variables are set, this code block runs and sends
-		// the corresponding login message(s).
+		// One tick delay to ensure vars are set
 		if (messageTickGuarded)
 		{
 			messageTickGuarded = false;
@@ -327,16 +324,16 @@ public class AttackStylesPlugin extends Plugin
 						{
 							if (weaponSwitch)
 							{
-								sendChatMessage("This weapon's attack style will grant you " + returnAttackColor(skill) + " XP.");
+								sendChatMessage("This weapon's attack style will grant you " + getAttackColor(skill) + " XP.");
 							}
 							else
 							{
-								sendChatMessage("This attack style will grant you " + returnAttackColor(skill) + " XP.");
+								sendChatMessage("This attack style will grant you " + getAttackColor(skill) + " XP.");
 							}
 						}
 						else
 						{
-							sendChatMessage("You logged in wielding a weapon that will grant you " + returnAttackColor(skill) + " XP.");
+							sendChatMessage("You logged in wielding a weapon that will grant you " + getAttackColor(skill) + " XP.");
 						}
 					}
 					warnedSkillSelected = true;
@@ -434,21 +431,21 @@ public class AttackStylesPlugin extends Plugin
 		}
 	}
 
-	private String returnAttackColor(Skill skill)
+	private String getAttackColor(Skill skill)
 	{
-		String color = "<col=ff0000>" + skill + "</col>";
+		String color = "<col=ff0000>";
 		switch (skill)
 		{
 			case ATTACK:
 			case STRENGTH:
 			case DEFENCE:
-				return color = "<col=D44A4A>" + skill + "</col>";
+				color = "<col=D44A4A>";
 			case RANGED:
-				return color = "<col=259443>" + skill + "</col>";
+				color = "<col=259443>";
 			case MAGIC:
-				return color = "<col=369EB3>" + skill + "</col>";
+				color = "<col=369EB3>";
 		}
-		return color;
+		return color  + skill + "</col>";
 	}
 
 	@VisibleForTesting

--- a/runelite-client/src/test/java/net/runelite/client/plugins/attackstyles/AttackStylesPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/attackstyles/AttackStylesPluginTest.java
@@ -37,6 +37,7 @@ import net.runelite.api.events.ConfigChanged;
 import net.runelite.api.events.VarbitChanged;
 import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetInfo;
+import net.runelite.client.chat.ChatMessageManager;
 import net.runelite.client.ui.overlay.OverlayManager;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -62,6 +63,10 @@ public class AttackStylesPluginTest
 	@Mock
 	@Bind
 	AttackStylesConfig attackConfig;
+
+	@Mock
+	@Bind
+	ChatMessageManager chatMessageManager;
 
 	@Inject
 	AttackStylesPlugin attackPlugin;


### PR DESCRIPTION
Was a TODO sitting in `AttackStyle` for a while, so, I figured I'd give it a shot.

**TODO:** "chat message to warn players that their weapon switch also caused an unwanted attack style change"

This handles login, weapon change, and attackstyle change notifications.

All logic is commented. (HANDLES COMPLETELY DIFFERENT NOW.)

// Utilizes GameTicks, seeing as variables are set PRIOR to a GameTick actually being ran.
// The messages are guarded by this tick-set, therefore, the messages aren't spammed upon
// variable setting and then once all variables are set, this code block runs and sends
// the corresponding login message(s).

![attackstyle - combined messages](https://user-images.githubusercontent.com/16967401/43152547-cc97de66-8f3c-11e8-99c7-da3abebd9da3.png)