### PR TITLE
clue scroll plugin: Remove useless null check

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/ClueScrollPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/ClueScrollPlugin.java
@@ -447,7 +447,7 @@ public class ClueScrollPlugin extends Plugin
 					.replaceAll("[ ]+", " ")
 					.toLowerCase());
 
-			if (clue != null && clue instanceof TextClueScroll)
+			if (clue instanceof TextClueScroll)
 			{
 				if (((TextClueScroll) clue).getText().equalsIgnoreCase(text))
 				{


### PR DESCRIPTION
`null` can never be an instance of any type of object, thus `clue != null` is not needed when the other check is `clue instanceof TextClueScroll`.

```
java> null instanceof Object
java.lang.Boolean res0 = false
```