### PR TITLE
mixins: Don't post mouse events that have already been posted

### DIFF
--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSMouseInputMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSMouseInputMixin.java
@@ -26,6 +26,7 @@ package net.runelite.mixins;
 
 import java.awt.event.MouseEvent;
 import net.runelite.api.mixins.Copy;
+import net.runelite.api.mixins.Inject;
 import net.runelite.api.mixins.Mixin;
 import net.runelite.api.mixins.Replace;
 import net.runelite.api.mixins.Shadow;
@@ -37,6 +38,9 @@ public abstract class RSMouseInputMixin implements RSMouseInput
 {
 	@Shadow("clientInstance")
 	private static RSClient client;
+
+	@Inject
+	private int isInEvent;
 
 	@Copy("mousePressed")
 	abstract void rs$mousePressed(MouseEvent mouseEvent);
@@ -63,10 +67,21 @@ public abstract class RSMouseInputMixin implements RSMouseInput
 	@Replace("mousePressed")
 	public synchronized void mousePressed(MouseEvent mouseEvent)
 	{
-		mouseEvent = client.getCallbacks().mousePressed(mouseEvent);
+		if (isInEvent == 0)
+		{
+			mouseEvent = client.getCallbacks().mousePressed(mouseEvent);
+		}
 		if (!mouseEvent.isConsumed())
 		{
-			rs$mousePressed(mouseEvent);
+			isInEvent++;
+			try
+			{
+				rs$mousePressed(mouseEvent);
+			}
+			finally
+			{
+				isInEvent--;
+			}
 		}
 	}
 
@@ -74,10 +89,21 @@ public abstract class RSMouseInputMixin implements RSMouseInput
 	@Replace("mouseReleased")
 	public synchronized void mouseReleased(MouseEvent mouseEvent)
 	{
-		mouseEvent = client.getCallbacks().mouseReleased(mouseEvent);
+		if (isInEvent == 0)
+		{
+			mouseEvent = client.getCallbacks().mouseReleased(mouseEvent);
+		}
 		if (!mouseEvent.isConsumed())
 		{
-			rs$mouseReleased(mouseEvent);
+			isInEvent++;
+			try
+			{
+				rs$mouseReleased(mouseEvent);
+			}
+			finally
+			{
+				isInEvent--;
+			}
 		}
 	}
 
@@ -96,10 +122,21 @@ public abstract class RSMouseInputMixin implements RSMouseInput
 	@Replace("mouseEntered")
 	public synchronized void mouseEntered(MouseEvent mouseEvent)
 	{
-		mouseEvent = client.getCallbacks().mouseEntered(mouseEvent);
+		if (isInEvent == 0)
+		{
+			mouseEvent = client.getCallbacks().mouseEntered(mouseEvent);
+		}
 		if (!mouseEvent.isConsumed())
 		{
-			rs$mouseEntered(mouseEvent);
+			isInEvent++;
+			try
+			{
+				rs$mouseEntered(mouseEvent);
+			}
+			finally
+			{
+				isInEvent--;
+			}
 		}
 	}
 
@@ -108,10 +145,21 @@ public abstract class RSMouseInputMixin implements RSMouseInput
 	@Replace("mouseExited")
 	public synchronized void mouseExited(MouseEvent mouseEvent)
 	{
-		mouseEvent = client.getCallbacks().mouseExited(mouseEvent);
+		if (isInEvent == 0)
+		{
+			mouseEvent = client.getCallbacks().mouseExited(mouseEvent);
+		}
 		if (!mouseEvent.isConsumed())
 		{
-			rs$mouseExited(mouseEvent);
+			isInEvent++;
+			try
+			{
+				rs$mouseExited(mouseEvent);
+			}
+			finally
+			{
+				isInEvent--;
+			}
 		}
 	}
 
@@ -119,10 +167,21 @@ public abstract class RSMouseInputMixin implements RSMouseInput
 	@Replace("mouseDragged")
 	public synchronized void mouseDragged(MouseEvent mouseEvent)
 	{
-		mouseEvent = client.getCallbacks().mouseDragged(mouseEvent);
+		if (isInEvent == 0)
+		{
+			mouseEvent = client.getCallbacks().mouseDragged(mouseEvent);
+		}
 		if (!mouseEvent.isConsumed())
 		{
-			rs$mouseDragged(mouseEvent);
+			isInEvent++;
+			try
+			{
+				rs$mouseDragged(mouseEvent);
+			}
+			finally
+			{
+				isInEvent--;
+			}
 		}
 	}
 
@@ -130,10 +189,21 @@ public abstract class RSMouseInputMixin implements RSMouseInput
 	@Replace("mouseMoved")
 	public synchronized void mouseMoved(MouseEvent mouseEvent)
 	{
-		mouseEvent = client.getCallbacks().mouseMoved(mouseEvent);
+		if (isInEvent == 0)
+		{
+			mouseEvent = client.getCallbacks().mouseMoved(mouseEvent);
+		}
 		if (!mouseEvent.isConsumed())
 		{
-			rs$mouseMoved(mouseEvent);
+			isInEvent++;
+			try
+			{
+				rs$mouseMoved(mouseEvent);
+			}
+			finally
+			{
+				isInEvent--;
+			}
 		}
 	}
 }


### PR DESCRIPTION
The 172 client calls mouseMoved from mouseEntered and mouseDragged, so the events get processed twice.

Fixes #4401