### PR TITLE
Add support for mod public chat to ChatCommands

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
@@ -167,6 +167,7 @@ public class ChatCommandsPlugin extends Plugin implements ChatboxInputListener
 		switch (setMessage.getType())
 		{
 			case PUBLIC:
+			case PUBLIC_MOD:
 			case CLANCHAT:
 			case PRIVATE_MESSAGE_RECEIVED:
 			case PRIVATE_MESSAGE_SENT:


### PR DESCRIPTION
Without this chat commands were not working because it just exited
early for pmods.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>