### PR TITLE
opponent info plugin: Fix SDMM hiscore lookup

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/opponentinfo/OpponentInfoPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/opponentinfo/OpponentInfoPlugin.java
@@ -118,13 +118,13 @@ public class OpponentInfoPlugin extends Plugin
 		}
 
 		EnumSet<WorldType> worldType = client.getWorldType();
-		if (worldType.contains(WorldType.DEADMAN))
-		{
-			hiscoreEndpoint = HiscoreEndpoint.DEADMAN;
-		}
-		else if (worldType.contains(WorldType.SEASONAL_DEADMAN))
+		if (worldType.contains(WorldType.SEASONAL_DEADMAN))
 		{
 			hiscoreEndpoint = HiscoreEndpoint.SEASONAL_DEADMAN;
+		}
+		else if (worldType.contains(WorldType.DEADMAN))
+		{
+			hiscoreEndpoint = HiscoreEndpoint.DEADMAN;
 		}
 		else
 		{


### PR DESCRIPTION
SDMM worlds have both `DEADMAN` and `SEASONAL_DEADMAN` types, so we
must check for the latter first to accurately determine the hiscore
lookup endpoint.