### PR TITLE
Instead of absolute positions, use relative for overlays

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenmarkers/ScreenMarkerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenmarkers/ScreenMarkerPlugin.java
@@ -42,6 +42,7 @@ import java.util.stream.Stream;
 import javax.inject.Inject;
 import lombok.AccessLevel;
 import lombok.Getter;
+import net.runelite.api.Client;
 import net.runelite.api.events.ConfigChanged;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.input.MouseManager;
@@ -84,6 +85,9 @@ public class ScreenMarkerPlugin extends Plugin
 
 	@Inject
 	private ScreenMarkerCreationOverlay overlay;
+
+	@Inject
+	private Client client;
 
 	private ScreenMarkerMouseListener mouseListener;
 	private ScreenMarkerPluginPanel pluginPanel;
@@ -159,7 +163,7 @@ public class ScreenMarkerPlugin extends Plugin
 		}
 	}
 
-	public void startCreation(Point location)
+	void startCreation(Point location)
 	{
 		currentMarker = new ScreenMarker(
 			Instant.now().toEpochMilli(),
@@ -172,7 +176,7 @@ public class ScreenMarkerPlugin extends Plugin
 
 		// Set overlay creator bounds to current position and default size
 		startLocation = location;
-		overlay.setPreferredLocation(location);
+		overlay.setAbsolutePreferredLocation(client, location);
 		overlay.setPreferredSize(DEFAULT_SIZE);
 		creatingScreenMarker = true;
 	}
@@ -182,7 +186,7 @@ public class ScreenMarkerPlugin extends Plugin
 		if (!aborted)
 		{
 			final ScreenMarkerOverlay screenMarkerOverlay = new ScreenMarkerOverlay(currentMarker);
-			screenMarkerOverlay.setPreferredLocation(overlay.getBounds().getLocation());
+			screenMarkerOverlay.setAbsolutePreferredLocation(client, overlay.getBounds().getLocation());
 			screenMarkerOverlay.setPreferredSize(overlay.getBounds().getSize());
 
 			screenMarkers.add(screenMarkerOverlay);
@@ -201,7 +205,7 @@ public class ScreenMarkerPlugin extends Plugin
 	}
 
 	/* The marker area has been drawn, inform the user and unlock the confirm button */
-	public void completeSelection()
+	void completeSelection()
 	{
 		pluginPanel.getCreationPanel().unlockConfirm();
 	}
@@ -219,7 +223,7 @@ public class ScreenMarkerPlugin extends Plugin
 	{
 		Rectangle bounds = new Rectangle(startLocation);
 		bounds.add(point);
-		overlay.setPreferredLocation(bounds.getLocation());
+		overlay.setAbsolutePreferredLocation(client, bounds.getLocation());
 		overlay.setPreferredSize(bounds.getSize());
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/Overlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/Overlay.java
@@ -29,6 +29,7 @@ import java.awt.Point;
 import java.awt.Rectangle;
 import lombok.Getter;
 import lombok.Setter;
+import net.runelite.api.Client;
 import net.runelite.client.ui.overlay.components.LayoutableRenderableEntity;
 
 @Getter
@@ -50,5 +51,34 @@ public abstract class Overlay implements LayoutableRenderableEntity
 	public String getName()
 	{
 		return this.getClass().getSimpleName();
+	}
+
+	/**
+	 * Sets preferred location using absolute location converting it to relative location to client dimensions
+	 * @param client client
+	 * @param preferredLocation preferred absolute location to use
+	 */
+	public void setAbsolutePreferredLocation(final Client client, final Point preferredLocation)
+	{
+		final double x = (preferredLocation.getX() / client.getRealDimensions().getWidth()) * 1000;
+		final double y = (preferredLocation.getY() / client.getRealDimensions().getHeight()) * 1000;
+		this.preferredLocation = new Point((int)x, (int)y);
+	}
+
+	/**
+	 * Gets absolute location from current preferred location
+	 * @param client client
+	 * @return absolute location
+	 */
+	public Point getAbsolutePreferredLocation(final Client client)
+	{
+		if (preferredLocation == null)
+		{
+			return null;
+		}
+
+		final double x = (client.getRealDimensions().getWidth() / 1000) * preferredLocation.getX();
+		final double y = (client.getRealDimensions().getHeight() / 1000) * preferredLocation.getY();
+		return new Point((int)x, (int)y);
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayManager.java
@@ -50,7 +50,7 @@ import net.runelite.client.events.PluginChanged;
 @Singleton
 public class OverlayManager
 {
-	private static final String OVERLAY_CONFIG_PREFERRED_LOCATION = "_preferredLocation";
+	private static final String OVERLAY_CONFIG_PREFERRED_LOCATION = "_preferredLocationRelative";
 	private static final String OVERLAY_CONFIG_PREFERRED_POSITION = "_preferredPosition";
 	private static final String OVERLAY_CONFIG_PREFERRED_SIZE = "_preferredSize";
 	private static final String RUNELITE_CONFIG_GROUP_NAME = RuneLiteConfig.class.getAnnotation(ConfigGroup.class).value();

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayRenderer.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayRenderer.java
@@ -187,14 +187,11 @@ public class OverlayRenderer extends MouseAdapter implements KeyListener
 				}
 				else
 				{
-					final Point preferredLocation = overlay.getPreferredLocation();
+					final Point preferredLocation = overlay.getAbsolutePreferredLocation(client);
 
 					if (preferredLocation != null)
 					{
-						final Dimension realDimensions = client.getRealDimensions();
-						final int x = Math.min(realDimensions.width - 5, preferredLocation.x);
-						final int y = Math.min(realDimensions.height - 5, preferredLocation.y);
-						location.setLocation(x, y);
+						location.setLocation(preferredLocation);
 					}
 				}
 
@@ -252,7 +249,7 @@ public class OverlayRenderer extends MouseAdapter implements KeyListener
 						mousePoint.translate(-offset.x, -offset.y);
 						movedOverlay = overlay;
 						movedOverlay.setPreferredPosition(null);
-						movedOverlay.setPreferredLocation(mousePoint);
+						movedOverlay.setAbsolutePreferredLocation(client, mousePoint);
 						overlayManager.saveOverlay(movedOverlay);
 					}
 
@@ -286,7 +283,7 @@ public class OverlayRenderer extends MouseAdapter implements KeyListener
 		{
 			mousePoint.translate(-overlayOffset.x, -overlayOffset.y);
 			movedOverlay.setPreferredPosition(null);
-			movedOverlay.setPreferredLocation(mousePoint);
+			movedOverlay.setAbsolutePreferredLocation(client, mousePoint);
 			mouseEvent.consume();
 		}
 


### PR DESCRIPTION
Instead of using absolute positions for overlays, use relative so the
positions will be preserved properly on screen resize.

Closes #3784

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>

Preview:
![peek 2018-07-21 02-06](https://user-images.githubusercontent.com/5115805/43030000-d5a0ce0e-8c8b-11e8-8562-64a5a2142d06.gif)
