### PR TITLE
Fix level 126 next goal to be max XP (200,000,000) instead of -1 xp

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/Experience.java
+++ b/runelite-api/src/main/java/net/runelite/api/Experience.java
@@ -40,6 +40,7 @@ public class Experience
 	 * The maximum virtual skill level for any skill (200M experience).
 	 */
 	public static final int MAX_VIRT_LEVEL = 126;
+	public static final int MAX_SKILL_XP = 200_000_000;
 
 	/**
 	 * The total experience required for each skill level.

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpInfoBox.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpInfoBox.java
@@ -41,6 +41,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
+import net.runelite.api.Experience;
 import net.runelite.api.Skill;
 import net.runelite.client.game.SkillIconManager;
 import net.runelite.client.ui.ColorScheme;
@@ -200,7 +201,9 @@ class XpInfoBox extends JPanel
 			progressBar.setValue(xpSnapshotSingle.getSkillProgressToGoal());
 			progressBar.setCenterLabel(xpSnapshotSingle.getSkillProgressToGoal() + "%");
 			progressBar.setLeftLabel("Lvl. " + xpSnapshotSingle.getStartLevel());
-			progressBar.setRightLabel("Lvl. " + xpSnapshotSingle.getEndLevel());
+			progressBar.setRightLabel(xpSnapshotSingle.getEndGoalXp() == Experience.MAX_SKILL_XP
+				? "200M"
+				: "Lvl. " + xpSnapshotSingle.getEndLevel());
 
 			progressBar.setToolTipText(String.format(
 				HTML_TOOL_TIP_TEMPLATE,

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpSnapshotSingle.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpSnapshotSingle.java
@@ -33,6 +33,8 @@ class XpSnapshotSingle
 {
 	private int startLevel;
 	private int endLevel;
+	private int startGoalXp;
+	private int endGoalXp;
 	private int xpGainedInSession;
 	private int xpRemainingToGoal;
 	private int xpPerHour;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpStateSingle.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpStateSingle.java
@@ -220,7 +220,9 @@ class XpStateSingle
 		if (goalEndXp <= 0 || currentXp > goalEndXp)
 		{
 			int currentLevel = Experience.getLevelForXp(currentXp);
-			endLevelExp = currentLevel + 1 <= Experience.MAX_VIRT_LEVEL ? Experience.getXpForLevel(currentLevel + 1) : -1;
+			endLevelExp = currentLevel + 1 <= Experience.MAX_VIRT_LEVEL
+				? Experience.getXpForLevel(currentLevel + 1)
+				: Experience.MAX_SKILL_XP;
 		}
 		else
 		{
@@ -248,6 +250,8 @@ class XpStateSingle
 			.actionsRemainingToGoal(getActionsRemaining())
 			.actionsPerHour(getActionsHr())
 			.timeTillGoal(getTimeTillLevel())
+			.startGoalXp(startLevelExp)
+			.endGoalXp(endLevelExp)
 			.build();
 	}
 }


### PR DESCRIPTION
This is a fix for endLevelExp being set to -1, which then causes an exception later when creating a snapshot for the GUI. That exception is thrown in `Experience.getLevelForXp` on a `< 0` xp amount.

The fix is to use the max XP value, which also is convenient for those that want to hit the max XP in the game, namely 200,000,000.

![image](https://user-images.githubusercontent.com/245911/43109168-0294db1e-8eab-11e8-9609-fb4e50a6954b.png)

![image](https://user-images.githubusercontent.com/245911/43109214-40d2efe2-8eab-11e8-8d67-33bf4351eef8.png)

Used `::addxp fishing <big number here>` to test this.

Resolves #3658