### PR TITLE
Fix XP Timing regression

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpStateSingle.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpStateSingle.java
@@ -232,6 +232,11 @@ class XpStateSingle
 
 	public void tick(long delta)
 	{
+		// Don't tick skills that have not gained XP or have been reset.
+		if (xpGained <= 0)
+		{
+			return;
+		}
 		skillTime += delta;
 	}
 


### PR DESCRIPTION
PR #4114 added XP pausing and changed how timing was done. This introduced a regression which caused all skills to have time added, whether or not they have gained xp.

The previous behavior was that the initial time was only set after the xpGained changed from 0 to > 0.
Similarly, tick will now not add time if xpGained is the initial value.

Resolves #4452 

This was tested with an hour of gameplay, doing cannon balls, then trying some fletching.
![hour-play](https://user-images.githubusercontent.com/245911/43114178-56997770-8ec3-11e8-9c1f-02faa444c0e6.gif)
You will notice the behavior where the first 60 seconds of experience are scaled to 60 seconds, that was introduced a long time ago to help with near division by zero problems. This demonstrates that the time for this skill JUST started. 
