### PR TITLE
Remove .revalidate() from ClientPluginToolbar

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ui/ClientPluginToolbar.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ClientPluginToolbar.java
@@ -66,7 +66,6 @@ public class ClientPluginToolbar extends JToolBar
 				add(component, index);
 			}
 
-			revalidate();
 			repaint();
 		}
 	}
@@ -78,7 +77,6 @@ public class ClientPluginToolbar extends JToolBar
 		if (component != null)
 		{
 			remove(component);
-			revalidate();
 			repaint();
 		}
 	}


### PR DESCRIPTION
This call is completely unnecessary and removing it is saving some
milliseconds from startup time.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>