### PR TITLE
Split the Reset menu entry to two seperate checkboxes

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -173,9 +173,19 @@ public interface MenuEntrySwapperConfig extends Config
 	{
 		return true;
 	}
+	@ConfigItem(
+			position = 13,
+			keyName = "layBoxTrap",
+			name = "Lay",
+			description = "Swap Loot with Lay on box trap"
+	)
+	default boolean layBoxTrap()
+	{
+		return true;
+	}
 
 	@ConfigItem(
-		position = 13,
+		position = 14,
 		keyName = "swapTeleportItem",
 		name = "Teleport item",
 		description = "Swap Wear, Wield with Rub, Teleport on teleport item<br>Example: Amulet of glory, Ardougne cloak, Chronicle"
@@ -186,7 +196,7 @@ public interface MenuEntrySwapperConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 14,
+		position = 15,
 		keyName = "swapAbyssTeleport",
 		name = "Teleport to Abyss",
 		description = "Swap Talk-to with Teleport for the Mage of Zamorak"
@@ -197,7 +207,7 @@ public interface MenuEntrySwapperConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 15,
+		position = 16,
 		keyName = "swapTrade",
 		name = "Trade",
 		description = "Swap Talk-to with Trade on NPC<br>Example: Shop keeper, Shop assistant"
@@ -208,7 +218,7 @@ public interface MenuEntrySwapperConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 16,
+		position = 17,
 		keyName = "swapTravel",
 		name = "Travel",
 		description = "Swap Talk-to with Travel, Take-boat, Pay-fare, Charter on NPC<br>Example: Squire, Monk of Entrana, Customs officer, Trader Crewmember"
@@ -219,7 +229,7 @@ public interface MenuEntrySwapperConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 17,
+		position = 18,
 		keyName = "swapAssignment",
 		name = "Assignment",
 		description = "Swap Talk-to with Assignment for Slayer Masters. This will take priority over swapping Trade."
@@ -230,7 +240,7 @@ public interface MenuEntrySwapperConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 18,
+		position = 19,
 		keyName = "swapDecant",
 		name = "Decant",
 		description = "Swap Talk-to with Decant for Bob Barter and Murky Matt at the Grand Exchange."

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -443,7 +443,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 		{
 			swap("reset", option, target, true);
 		}
-		else if (config.swapBoxTrap() && option.equals("take"))
+		else if (config.layBoxTrap() && option.equals("take"))
 		{
 			swap("lay", option, target, true);
 		}


### PR DESCRIPTION
Split the Reset menu entry to two seperate checkboxes, one for Reset and one for Lay to better cater for seperate training methods.