### PR TITLE
Remove duplicate progress bar from XP globes

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobe.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobe.java
@@ -37,7 +37,7 @@ public class XpGlobe
 	private Instant time;
 	private double skillProgressRadius;
 
-	public XpGlobe(Skill skill, int currentXp, int currentLevel, int goalXp)
+	XpGlobe(Skill skill, int currentXp, int currentLevel, int goalXp)
 	{
 		this.skill = skill;
 		this.currentXp = currentXp;
@@ -55,57 +55,52 @@ public class XpGlobe
 		this.skill = skill;
 	}
 
-	public int getCurrentXp()
+	int getCurrentXp()
 	{
 		return currentXp;
 	}
 
-	public void setCurrentXp(int currentXp)
+	void setCurrentXp(int currentXp)
 	{
 		this.currentXp = currentXp;
 	}
 
-	public int getCurrentLevel()
+	int getCurrentLevel()
 	{
 		return currentLevel;
 	}
 
-	public void setCurrentLevel(int currentLevel)
+	void setCurrentLevel(int currentLevel)
 	{
 		this.currentLevel = currentLevel;
 	}
 
-	public int getGoalXp()
+	int getGoalXp()
 	{
 		return goalXp;
 	}
 
-	public void setGoalXp(int goalXp)
+	void setGoalXp(int goalXp)
 	{
 		this.goalXp = goalXp;
 	}
 
-	public int getGoalLevel()
-	{
-		return this.currentLevel++;
-	}
-
-	public String getSkillName()
+	String getSkillName()
 	{
 		return skill.getName();
 	}
 
-	public double getSkillProgressRadius()
+	double getSkillProgressRadius()
 	{
 		return skillProgressRadius;
 	}
 
-	public void setSkillProgressRadius(int startXp, int currentXp, int goalXp)
+	void setSkillProgressRadius(int startXp, int currentXp, int goalXp)
 	{
 		this.skillProgressRadius = -(3.6 * getSkillProgress(startXp, currentXp, goalXp)); //arc goes backwards
 	}
 
-	public double getSkillProgress(int startXp, int currentXp, int goalXp)
+	double getSkillProgress(int startXp, int currentXp, int goalXp)
 	{
 		double xpGained = currentXp - startXp;
 		double xpGoal = goalXp - startXp;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesOverlay.java
@@ -48,7 +48,6 @@ import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.OverlayPriority;
 import net.runelite.client.ui.overlay.components.LineComponent;
 import net.runelite.client.ui.overlay.components.PanelComponent;
-import net.runelite.client.ui.overlay.components.ProgressBarComponent;
 
 public class XpGlobesOverlay extends Overlay
 {
@@ -257,9 +256,12 @@ public class XpGlobesOverlay extends Overlay
 		xpTooltip.setPreferredLocation(new java.awt.Point(x, y));
 		xpTooltip.setPreferredSize(new Dimension(TOOLTIP_RECT_SIZE_X, 0));
 
+		final double progress = mouseOverSkill.getSkillProgress(Experience.getXpForLevel(mouseOverSkill.getCurrentLevel()),
+			mouseOverSkill.getCurrentXp(), mouseOverSkill.getGoalXp());
+
 		xpTooltip.getChildren().add(LineComponent.builder()
 			.left(skillName)
-			.right(skillLevel)
+			.right(skillLevel + " (" + progress + "%)")
 			.build());
 
 		xpTooltip.getChildren().add(LineComponent.builder()
@@ -299,13 +301,6 @@ public class XpGlobesOverlay extends Overlay
 					.right(xpHrString)
 					.build());
 			}
-
-			//Create progress bar for skill.
-			ProgressBarComponent progressBar = new ProgressBarComponent();
-			double progress = mouseOverSkill.getSkillProgress(Experience.getXpForLevel(mouseOverSkill.getCurrentLevel()),
-				mouseOverSkill.getCurrentXp(), mouseOverSkill.getGoalXp());
-			progressBar.setValue(progress);
-			xpTooltip.getChildren().add(progressBar);
 		}
 
 		xpTooltip.render(graphics);


### PR DESCRIPTION
Remove progress bar that is duplicating already existing progress bar
around XP globes. This progress bar is just taking screen space and no
other clients have it.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>