### PR TITLE
Added Guard pickpocket entry swap

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -143,7 +143,7 @@ public interface MenuEntrySwapperConfig extends Config
 
 	@ConfigItem(
 		position = 10,
-		keyName = "swapPickpocket", 
+		keyName = "swapPickpocket",
 		name = "Pickpocket on H.A.M.",
 		description = "Swap Talk-to with Pickpocket on H.A.M members"
 	)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -143,9 +143,9 @@ public interface MenuEntrySwapperConfig extends Config
 
 	@ConfigItem(
 		position = 10,
-		keyName = "swapPickpocket",
-		name = "Pickpocket H.A.M Guards and Members",
-		description = "Swap Talk-to and Attack with Pickpocket for H.A.M Guards and members"
+		keyName = "swapPickpocket", 
+		name = "Pickpocket on H.A.M.",
+		description = "Swap Talk-to with Pickpocket on H.A.M members"
 	)
 	default boolean swapPickpocket()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -144,8 +144,8 @@ public interface MenuEntrySwapperConfig extends Config
 	@ConfigItem(
 		position = 10,
 		keyName = "swapPickpocket",
-		name = "Pickpocket on H.A.M.",
-		description = "Swap Talk-to with Pickpocket on H.A.M members"
+		name = "Pickpocket Guards & H.A.M",
+		description = "Swap Talk-to and Attack with Pickpocket on all Guards & H.A.M members"
 	)
 	default boolean swapPickpocket()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -144,8 +144,8 @@ public interface MenuEntrySwapperConfig extends Config
 	@ConfigItem(
 		position = 10,
 		keyName = "swapPickpocket",
-		name = "Pickpocket Guards & H.A.M",
-		description = "Swap Talk-to and Attack with Pickpocket on all Guards & H.A.M members"
+		name = "Pickpocket H.A.M Guards and Members",
+		description = "Swap Talk-to and Attack with Pickpocket for H.A.M Guards and members"
 	)
 	default boolean swapPickpocket()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -338,7 +338,6 @@ public class MenuEntrySwapperPlugin extends Plugin
 				swap("pickpocket", option, target, true);
 			}
 
-
 			if (config.swapAbyssTeleport() && target.contains("mage of zamorak"))
 			{
 				swap("teleport", option, target, true);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -330,21 +330,14 @@ public class MenuEntrySwapperPlugin extends Plugin
 		int itemId = event.getIdentifier();
 		String option = Text.removeTags(event.getOption()).toLowerCase();
 		String target = Text.removeTags(event.getTarget()).toLowerCase();
-		
-		if (option.equals("attack"))
-		{
-			if (config.swapPickpocket() && target.contains("guard"))
-			{
-				swap("pickpocket", option, target, true);
-			}
-		}
-		
+
 		if (option.equals("talk-to"))
 		{
-			if (config.swapPickpocket() && target.contains("h.a.m."))
+			if (config.swapPickpocket() && (target.contains("h.a.m.") || target.contains("guard")))
 			{
 				swap("pickpocket", option, target, true);
 			}
+
 
 			if (config.swapAbyssTeleport() && target.contains("mage of zamorak"))
 			{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -330,7 +330,15 @@ public class MenuEntrySwapperPlugin extends Plugin
 		int itemId = event.getIdentifier();
 		String option = Text.removeTags(event.getOption()).toLowerCase();
 		String target = Text.removeTags(event.getTarget()).toLowerCase();
-
+		
+		if (option.equals("attack"))
+		{
+			if (config.swapPickpocket() && target.contains("guard"))
+			{
+				swap("pickpocket", option, target, true);
+			}
+		}
+		
 		if (option.equals("talk-to"))
 		{
 			if (config.swapPickpocket() && target.contains("h.a.m."))


### PR DESCRIPTION
> edit: jagex compliances... Swapped talk-to with pickpocket for H.A.M. guards, should be 69% compliant in the current format. Once Npc attack option is disabled via ingame options, left click pickpocketing should work.

![untitled](https://user-images.githubusercontent.com/20377320/43169946-e0e5ac00-8f9a-11e8-9c12-a4f2c6819dc5.png)

