### PR TITLE
mixins: Prevent runScript from being called recursively

### DIFF
--- a/runelite-mixins/src/main/java/net/runelite/mixins/ScriptVMMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/ScriptVMMixin.java
@@ -130,6 +130,7 @@ public abstract class ScriptVMMixin implements RSClient
 	public void runScript(int id, Object... args)
 	{
 		assert isClientThread();
+		assert currentScript == null;
 		Object[] cargs = new Object[args.length + 1];
 		cargs[0] = id;
 		System.arraycopy(args, 0, cargs, 1, args.length);


### PR DESCRIPTION
Due to the extensive use of globals in the ScriptVM it is not reentrant