### PR TITLE
Fix loading of chat colors on startup

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/RuneLite.java
+++ b/runelite-client/src/main/java/net/runelite/client/RuneLite.java
@@ -243,6 +243,9 @@ public class RuneLite
 		// Initialize UI
 		clientUI.open(this);
 
+		// Initialize chat colors
+		chatMessageManager.loadColors();
+
 		// Initialize Discord service
 		discordService.init();
 

--- a/runelite-client/src/main/java/net/runelite/client/chat/ChatMessageManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/chat/ChatMessageManager.java
@@ -216,7 +216,10 @@ public class ChatMessageManager
 		return null;
 	}
 
-	private void loadColors()
+	/**
+	 * Load all configured colors
+	 */
+	public void loadColors()
 	{
 		colorCache.clear();
 


### PR DESCRIPTION
ConfigChanged is no longer propagated on startup, so colors need to be
loaded explictly for first time.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>