### PR TITLE
Properly use javax.inject.Provider

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/Notifier.java
+++ b/runelite-client/src/main/java/net/runelite/client/Notifier.java
@@ -41,7 +41,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ScheduledExecutorService;
-import javax.inject.Provider;
 import javax.inject.Singleton;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.ChatMessageType;
@@ -67,18 +66,18 @@ public class Notifier
 	private static final int FLASH_DURATION = 2000;
 	private static final String MESSAGE_COLOR = "FF0000";
 
-	private final Provider<Client> client;
+	private final Client client;
 	private final String appName;
 	private final RuneLiteConfig runeLiteConfig;
-	private final Provider<ClientUI> clientUI;
+	private final ClientUI clientUI;
 	private final ScheduledExecutorService executorService;
 	private final Path notifyIconPath;
 	private Instant flashStart;
 
 	@Inject
 	private Notifier(
-			final Provider<ClientUI> clientUI,
-			final Provider<Client> client,
+			final ClientUI clientUI,
+			final Client client,
 			final RuneLiteConfig runeliteConfig,
 			final RuneLiteProperties runeLiteProperties,
 			final ScheduledExecutorService executorService)
@@ -99,13 +98,6 @@ public class Notifier
 
 	public void notify(String message, TrayIcon.MessageType type)
 	{
-		final ClientUI clientUI = this.clientUI.get();
-
-		if (clientUI == null)
-		{
-			return;
-		}
-
 		if (!runeLiteConfig.sendNotificationsWhenFocused() && clientUI.isFocused())
 		{
 			return;
@@ -128,9 +120,7 @@ public class Notifier
 
 		if (runeLiteConfig.enableGameMessageNotification())
 		{
-			final Client client = this.client.get();
-
-			if (client != null && client.getGameState() == GameState.LOGGED_IN)
+			if (client.getGameState() == GameState.LOGGED_IN)
 			{
 				client.addChatMessage(ChatMessageType.GAME, appName,
 					"<col=" + MESSAGE_COLOR + ">" + message + "</col>", "");
@@ -150,9 +140,7 @@ public class Notifier
 			return;
 		}
 
-		final Client client = this.client.get();
-
-		if (client == null || client.getGameCycle() % 40 >= 20)
+		if (client.getGameCycle() % 40 >= 20)
 		{
 			return;
 		}
@@ -195,13 +183,6 @@ public class Notifier
 		final String message,
 		final TrayIcon.MessageType type)
 	{
-		final ClientUI clientUI = this.clientUI.get();
-
-		if (clientUI == null)
-		{
-			return;
-		}
-
 		if (clientUI.getTrayIcon() != null)
 		{
 			clientUI.getTrayIcon().displayMessage(title, message, type);

--- a/runelite-client/src/main/java/net/runelite/client/RuneLite.java
+++ b/runelite-client/src/main/java/net/runelite/client/RuneLite.java
@@ -82,22 +82,10 @@ public class RuneLite
 	private PluginManager pluginManager;
 
 	@Inject
-	private MenuManager menuManager;
-
-	@Inject
 	private EventBus eventBus;
 
 	@Inject
 	private ConfigManager configManager;
-
-	@Inject
-	private ChatMessageManager chatMessageManager;
-
-	@Inject
-	private CommandManager commandManager;
-
-	@Inject
-	private OverlayRenderer overlayRenderer;
 
 	@Inject
 	private DrawManager drawManager;
@@ -115,25 +103,37 @@ public class RuneLite
 	private ClientUI clientUI;
 
 	@Inject
-	private Provider<ItemManager> itemManager;
-
-	@Inject
-	private ClanManager clanManager;
-
-	@Inject
 	private InfoBoxManager infoBoxManager;
 
 	@Inject
 	private OverlayManager overlayManager;
 
 	@Inject
-	private InfoBoxOverlay infoBoxOverlay;
+	private Provider<ItemManager> itemManager;
 
 	@Inject
-	private TooltipOverlay tooltipOverlay;
+	private Provider<OverlayRenderer> overlayRenderer;
 
 	@Inject
-	private WorldMapOverlay worldMapOverlay;
+	private Provider<ClanManager> clanManager;
+
+	@Inject
+	private Provider<ChatMessageManager> chatMessageManager;
+
+	@Inject
+	private Provider<MenuManager> menuManager;
+
+	@Inject
+	private Provider<CommandManager> commandManager;
+
+	@Inject
+	private Provider<InfoBoxOverlay> infoBoxOverlay;
+
+	@Inject
+	private Provider<TooltipOverlay> tooltipOverlay;
+
+	@Inject
+	private Provider<WorldMapOverlay> worldMapOverlay;
 
 	@Inject
 	@Nullable
@@ -243,35 +243,34 @@ public class RuneLite
 		// Initialize UI
 		clientUI.open(this);
 
-		// Initialize chat colors
-		chatMessageManager.loadColors();
-
 		// Initialize Discord service
 		discordService.init();
 
 		// Register event listeners
 		eventBus.register(clientUI);
 		eventBus.register(pluginManager);
-		eventBus.register(overlayRenderer);
 		eventBus.register(overlayManager);
 		eventBus.register(drawManager);
-		eventBus.register(menuManager);
-		eventBus.register(chatMessageManager);
-		eventBus.register(commandManager);
-		eventBus.register(clanManager);
 		eventBus.register(infoBoxManager);
 
 		if (!isOutdated)
 		{
-			eventBus.register(itemManager.get());
-			WidgetOverlay.createOverlays(client).forEach(overlayManager::add);
-		}
+			// Initialize chat colors
+			chatMessageManager.get().loadColors();
 
-		// Add core overlays after configuration has been loaded so their properties will be
-		// loaded properly
-		overlayManager.add(infoBoxOverlay);
-		overlayManager.add(worldMapOverlay);
-		overlayManager.add(tooltipOverlay);
+			eventBus.register(overlayRenderer.get());
+			eventBus.register(clanManager.get());
+			eventBus.register(itemManager.get());
+			eventBus.register(menuManager.get());
+			eventBus.register(chatMessageManager.get());
+			eventBus.register(commandManager.get());
+
+			// Add core overlays
+			WidgetOverlay.createOverlays(client).forEach(overlayManager::add);
+			overlayManager.add(infoBoxOverlay.get());
+			overlayManager.add(worldMapOverlay.get());
+			overlayManager.add(tooltipOverlay.get());
+		}
 
 		// Start plugins
 		pluginManager.startCorePlugins();

--- a/runelite-client/src/main/java/net/runelite/client/chat/CommandManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/chat/CommandManager.java
@@ -31,7 +31,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import javax.inject.Inject;
-import javax.inject.Provider;
 import javax.inject.Singleton;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
@@ -51,19 +50,19 @@ public class CommandManager
 	private static final String CHATBOX_INPUT = "chatboxInput";
 	private static final String PRIVMATE_MESSAGE = "privateMessage";
 
-	private final Provider<Client> clientProvider;
+	private final Client client;
 	private final EventBus eventBus;
-	private final Provider<ClientThread> clientThreadProvider;
+	private final ClientThread clientThread;
 	private boolean sending;
 
 	private final List<ChatboxInputListener> chatboxInputListenerList = new ArrayList<>();
 
 	@Inject
-	public CommandManager(Provider<Client> clientProvider, EventBus eventBus, Provider<ClientThread> clientThreadProvider)
+	private CommandManager(Client client, EventBus eventBus, ClientThread clientThread)
 	{
-		this.clientProvider = clientProvider;
+		this.client = client;
 		this.eventBus = eventBus;
-		this.clientThreadProvider = clientThreadProvider;
+		this.clientThread = clientThread;
 	}
 
 	public void register(ChatboxInputListener chatboxInputListener)
@@ -100,7 +99,6 @@ public class CommandManager
 
 	private void runCommand()
 	{
-		Client client = clientProvider.get();
 		String typedText = client.getVar(VarClientStr.CHATBOX_TYPED_TEXT).substring(2); // strip ::
 
 		log.debug("Command: {}", typedText);
@@ -122,7 +120,6 @@ public class CommandManager
 
 	private void handleInput(ScriptCallbackEvent event)
 	{
-		Client client = clientProvider.get();
 		final String[] stringStack = client.getStringStack();
 		final int[] intStack = client.getIntStack();
 		int stringStackCount = client.getStringStackSize();
@@ -144,7 +141,6 @@ public class CommandManager
 				}
 				resumed = true;
 
-				ClientThread clientThread = clientThreadProvider.get();
 				clientThread.invokeLater(() -> sendChatboxInput(chatType, typedText));
 			}
 		};
@@ -163,7 +159,6 @@ public class CommandManager
 
 	private void handlePrivateMessage(ScriptCallbackEvent event)
 	{
-		Client client = clientProvider.get();
 		final String[] stringStack = client.getStringStack();
 		final int[] intStack = client.getIntStack();
 		int stringStackCount = client.getStringStackSize();
@@ -185,7 +180,6 @@ public class CommandManager
 				}
 				resumed = true;
 
-				ClientThread clientThread = clientThreadProvider.get();
 				clientThread.invokeLater(() -> sendPrivmsg(target, message));
 			}
 		};
@@ -205,7 +199,6 @@ public class CommandManager
 
 	private void sendChatboxInput(int chatType, String input)
 	{
-		Client client = clientProvider.get();
 		sending = true;
 		try
 		{
@@ -219,7 +212,6 @@ public class CommandManager
 
 	private void sendPrivmsg(String target, String message)
 	{
-		Client client = clientProvider.get();
 		client.runScript(ScriptID.PRIVMSG, target, message);
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/game/ClanManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/game/ClanManager.java
@@ -39,7 +39,6 @@ import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import javax.imageio.ImageIO;
 import javax.inject.Inject;
-import javax.inject.Provider;
 import javax.inject.Singleton;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.ClanMember;
@@ -66,7 +65,7 @@ public class ClanManager
 
 	private int modIconsLength;
 
-	private final Provider<Client> clientProvider;
+	private final Client client;
 	private final BufferedImage[] clanChatImages = new BufferedImage[CLANCHAT_IMAGES.length];
 
 	private final LoadingCache<String, ClanMemberRank> clanRanksCache = CacheBuilder.newBuilder()
@@ -77,7 +76,6 @@ public class ClanManager
 			@Override
 			public ClanMemberRank load(String key) throws Exception
 			{
-				final Client client = clientProvider.get();
 				final ClanMember[] clanMembersArr = client.getClanMembers();
 
 				if (clanMembersArr == null || clanMembersArr.length == 0)
@@ -95,9 +93,9 @@ public class ClanManager
 		});
 
 	@Inject
-	public ClanManager(Provider<Client> clientProvider)
+	private ClanManager(Client client)
 	{
-		this.clientProvider = clientProvider;
+		this.client = client;
 
 		int i = 0;
 		for (String resource : CLANCHAT_IMAGES)
@@ -158,7 +156,6 @@ public class ClanManager
 	{
 		try
 		{
-			final Client client = clientProvider.get();
 			final IndexedSprite[] modIcons = client.getModIcons();
 			final IndexedSprite[] newModIcons = Arrays.copyOf(modIcons, modIcons.length + CLANCHAT_IMAGES.length);
 			int curPosition = newModIcons.length - CLANCHAT_IMAGES.length;

--- a/runelite-client/src/main/java/net/runelite/client/menus/MenuManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/menus/MenuManager.java
@@ -36,7 +36,6 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import javax.inject.Inject;
-import javax.inject.Provider;
 import javax.inject.Singleton;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
@@ -63,7 +62,7 @@ public class MenuManager
 	private static final int IDX_LOWER = 4;
 	private static final int IDX_UPPER = 8;
 
-	private final Provider<Client> clientProvider;
+	private final Client client;
 	private final EventBus eventBus;
 
 	//Maps the indexes that are being used to the menu option.
@@ -73,9 +72,9 @@ public class MenuManager
 	private final Set<String> npcMenuOptions = new HashSet<>();
 
 	@Inject
-	public MenuManager(Provider<Client> clientProvider, EventBus eventBus)
+	private MenuManager(Client client, EventBus eventBus)
 	{
-		this.clientProvider = clientProvider;
+		this.client = client;
 		this.eventBus = eventBus;
 	}
 
@@ -84,13 +83,6 @@ public class MenuManager
 		npcMenuOptions.add(option);
 
 		// add to surrounding npcs
-		Client client = clientProvider.get();
-
-		if (client == null)
-		{
-			return;
-		}
-
 		for (NPC npc : client.getNpcs())
 		{
 			NPCComposition composition = npc.getComposition();
@@ -103,13 +95,6 @@ public class MenuManager
 		npcMenuOptions.remove(option);
 
 		// remove this option from all npc compositions
-		Client client = clientProvider.get();
-
-		if (client == null)
-		{
-			return;
-		}
-
 		for (NPC npc : client.getNpcs())
 		{
 			NPCComposition composition = npc.getComposition();
@@ -141,13 +126,6 @@ public class MenuManager
 
 	private boolean menuContainsCustomMenu(WidgetMenuOption customMenuOption)
 	{
-		Client client = clientProvider.get();
-
-		if (client == null)
-		{
-			return false;
-		}
-
 		for (MenuEntry menuEntry : client.getMenuEntries())
 		{
 			String option = menuEntry.getOption();
@@ -166,12 +144,6 @@ public class MenuManager
 	{
 		int widgetId = event.getActionParam1();
 		Collection<WidgetMenuOption> options = managedMenuOptions.get(widgetId);
-		Client client = clientProvider.get();
-
-		if (client == null)
-		{
-			return;
-		}
 
 		for (WidgetMenuOption currentMenu : options)
 		{
@@ -332,13 +304,6 @@ public class MenuManager
 
 	private void addPlayerMenuItem(int playerOptionIndex, String menuText)
 	{
-		Client client = clientProvider.get();
-
-		if (client == null)
-		{
-			return;
-		}
-
 		client.getPlayerOptions()[playerOptionIndex] = menuText;
 		client.getPlayerOptionsPriorities()[playerOptionIndex] = true;
 		client.getPlayerMenuTypes()[playerOptionIndex] = MenuAction.RUNELITE.getId();
@@ -348,31 +313,16 @@ public class MenuManager
 
 	private void removePlayerMenuItem(int playerOptionIndex)
 	{
-		Client client = clientProvider.get();
-
-		if (client == null)
-		{
-			return;
-		}
-
 		client.getPlayerOptions()[playerOptionIndex] = null;
 		playerMenuIndexMap.remove(playerOptionIndex);
 	}
 
 	/**
 	 * Find the next empty player menu slot index
-	 *
-	 * @return
 	 */
 	private int findEmptyPlayerMenuIndex()
 	{
 		int index = IDX_LOWER;
-		Client client = clientProvider.get();
-
-		if (client == null)
-		{
-			return IDX_UPPER;
-		}
 
 		String[] playerOptions = client.getPlayerOptions();
 		while (index < IDX_UPPER && playerOptions[index] != null)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/PluginManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/PluginManager.java
@@ -54,6 +54,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
 import javax.inject.Named;
+import javax.inject.Provider;
 import javax.inject.Singleton;
 import javax.swing.SwingUtilities;
 import lombok.Setter;
@@ -85,7 +86,7 @@ public class PluginManager
 	private final Scheduler scheduler;
 	private final ConfigManager configManager;
 	private final ScheduledExecutorService executor;
-	private final SceneTileManager sceneTileManager;
+	private final Provider<SceneTileManager> sceneTileManager;
 	private final List<Plugin> plugins = new CopyOnWriteArrayList<>();
 	private final List<Plugin> activePlugins = new CopyOnWriteArrayList<>();
 	private final String runeliteGroupName = RuneLiteConfig.class
@@ -102,7 +103,7 @@ public class PluginManager
 		final Scheduler scheduler,
 		final ConfigManager configManager,
 		final ScheduledExecutorService executor,
-		final SceneTileManager sceneTileManager)
+		final Provider<SceneTileManager> sceneTileManager)
 	{
 		this.developerMode = developerMode;
 		this.eventBus = eventBus;
@@ -323,7 +324,15 @@ public class PluginManager
 			});
 
 			log.debug("Plugin {} is now running", plugin.getClass().getSimpleName());
-			sceneTileManager.simulateObjectSpawns(plugin);
+			if (!isOutdated && sceneTileManager != null)
+			{
+				final SceneTileManager sceneTileManager = this.sceneTileManager.get();
+				if (sceneTileManager != null)
+				{
+					sceneTileManager.simulateObjectSpawns(plugin);
+				}
+			}
+
 			eventBus.register(plugin);
 			schedule(plugin);
 			eventBus.post(new PluginChanged(plugin, true));

--- a/runelite-client/src/main/java/net/runelite/client/plugins/hiscore/HiscorePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/hiscore/HiscorePlugin.java
@@ -34,6 +34,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import javax.annotation.Nullable;
 import javax.imageio.ImageIO;
 import javax.inject.Inject;
+import javax.inject.Provider;
 import javax.swing.SwingUtilities;
 import net.runelite.api.Client;
 import net.runelite.api.MenuAction;
@@ -69,10 +70,10 @@ public class HiscorePlugin extends Plugin
 	private Client client;
 
 	@Inject
-	private ClientToolbar clientToolbar;
+	private Provider<MenuManager> menuManager;
 
 	@Inject
-	private MenuManager menuManager;
+	private ClientToolbar clientToolbar;
 
 	@Inject
 	private ScheduledExecutorService executor;
@@ -112,9 +113,9 @@ public class HiscorePlugin extends Plugin
 
 		clientToolbar.addNavigation(navButton);
 
-		if (config.playerOption())
+		if (config.playerOption() && client != null)
 		{
-			menuManager.addPlayerMenuItem(LOOKUP);
+			menuManager.get().addPlayerMenuItem(LOOKUP);
 		}
 		if (config.autocomplete())
 		{
@@ -127,7 +128,11 @@ public class HiscorePlugin extends Plugin
 	{
 		hiscorePanel.removeInputKeyListener(autocompleter);
 		clientToolbar.removeNavigation(navButton);
-		menuManager.removePlayerMenuItem(LOOKUP);
+
+		if (client != null)
+		{
+			menuManager.get().removePlayerMenuItem(LOOKUP);
+		}
 	}
 
 	@Subscribe
@@ -135,11 +140,14 @@ public class HiscorePlugin extends Plugin
 	{
 		if (event.getGroup().equals("hiscore"))
 		{
-			menuManager.removePlayerMenuItem(LOOKUP);
-
-			if (config.playerOption())
+			if (client != null)
 			{
-				menuManager.addPlayerMenuItem(LOOKUP);
+				menuManager.get().removePlayerMenuItem(LOOKUP);
+
+				if (config.playerOption())
+				{
+					menuManager.get().addPlayerMenuItem(LOOKUP);
+				}
 			}
 
 			if (event.getKey().equals("autocomplete"))

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayRenderer.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayRenderer.java
@@ -35,7 +35,6 @@ import java.awt.event.KeyEvent;
 import java.awt.event.MouseEvent;
 import java.util.List;
 import javax.inject.Inject;
-import javax.inject.Provider;
 import javax.inject.Singleton;
 import javax.swing.SwingUtilities;
 import lombok.extern.slf4j.Slf4j;
@@ -68,7 +67,7 @@ public class OverlayRenderer extends MouseListener implements KeyListener
 	private static final Color SNAP_CORNER_ACTIVE_COLOR = new Color(0, 255, 0, 100);
 	private static final Color MOVING_OVERLAY_COLOR = new Color(255, 255, 0, 100);
 	private static final Color MOVING_OVERLAY_ACTIVE_COLOR = new Color(255, 255, 0, 200);
-	private final Provider<Client> clientProvider;
+	private final Client client;
 	private final OverlayManager overlayManager;
 	private final RuneLiteConfig runeLiteConfig;
 
@@ -87,13 +86,13 @@ public class OverlayRenderer extends MouseListener implements KeyListener
 
 	@Inject
 	private OverlayRenderer(
-		final Provider<Client> clientProvider,
+		final Client client,
 		final OverlayManager overlayManager,
 		final RuneLiteConfig runeLiteConfig,
 		final MouseManager mouseManager,
 		final KeyManager keyManager)
 	{
-		this.clientProvider = clientProvider;
+		this.client = client;
 		this.overlayManager = overlayManager;
 		this.runeLiteConfig = runeLiteConfig;
 		keyManager.registerKeyListener(this);
@@ -111,11 +110,9 @@ public class OverlayRenderer extends MouseListener implements KeyListener
 
 	public void render(Graphics2D graphics, final OverlayLayer layer)
 	{
-		final Client client = clientProvider.get();
 		final List<Overlay> overlays = overlayManager.getLayer(layer);
 
-		if (client == null
-			|| overlays == null
+		if (overlays == null
 			|| overlays.isEmpty()
 			|| client.getGameState() != GameState.LOGGED_IN
 			|| client.getWidget(WidgetInfo.LOGIN_CLICK_TO_PLAY_SCREEN) != null
@@ -274,13 +271,6 @@ public class OverlayRenderer extends MouseListener implements KeyListener
 			return mouseEvent;
 		}
 
-		final Client client = clientProvider.get();
-
-		if (client == null)
-		{
-			return mouseEvent;
-		}
-
 		final Point mousePoint = mouseEvent.getPoint();
 		mousePosition.setLocation(mousePoint);
 		final Rectangle canvasRect = new Rectangle(client.getRealDimensions());
@@ -399,7 +389,6 @@ public class OverlayRenderer extends MouseListener implements KeyListener
 
 	private boolean shouldInvalidateBounds()
 	{
-		final Client client = clientProvider.get();
 		final Widget chatbox = client.getWidget(WidgetInfo.CHATBOX_MESSAGES);
 		final boolean resizeableChanged = isResizeable != client.isResized();
 		boolean changed = false;

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/infobox/InfoBoxOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/infobox/InfoBoxOverlay.java
@@ -32,7 +32,6 @@ import java.awt.Point;
 import java.awt.Rectangle;
 import java.util.List;
 import javax.inject.Inject;
-import javax.inject.Provider;
 import javax.inject.Singleton;
 import net.runelite.api.Client;
 import net.runelite.client.config.RuneLiteConfig;
@@ -51,19 +50,19 @@ public class InfoBoxOverlay extends Overlay
 	private final PanelComponent panelComponent = new PanelComponent();
 	private final InfoBoxManager infoboxManager;
 	private final TooltipManager tooltipManager;
-	private final Provider<Client> clientProvider;
+	private final Client client;
 	private final RuneLiteConfig config;
 
 	@Inject
 	private InfoBoxOverlay(
 		InfoBoxManager infoboxManager,
 		TooltipManager tooltipManager,
-		Provider<Client> clientProvider,
+		Client client,
 		RuneLiteConfig config)
 	{
 		this.tooltipManager = tooltipManager;
 		this.infoboxManager = infoboxManager;
-		this.clientProvider = clientProvider;
+		this.client = client;
 		this.config = config;
 		setPosition(OverlayPosition.TOP_LEFT);
 
@@ -105,34 +104,30 @@ public class InfoBoxOverlay extends Overlay
 		}
 
 		final Dimension dimension = panelComponent.render(graphics);
-		final Client client = clientProvider.get();
 
 		// Handle tooltips
-		if (client != null)
+		final Point mouse = new Point(client.getMouseCanvasPosition().getX(), client.getMouseCanvasPosition().getY());
+
+		for (final LayoutableRenderableEntity child : panelComponent.getChildren())
 		{
-			final Point mouse = new Point(client.getMouseCanvasPosition().getX(), client.getMouseCanvasPosition().getY());
-
-			for (final LayoutableRenderableEntity child : panelComponent.getChildren())
+			if (child instanceof InfoBoxComponent)
 			{
-				if (child instanceof InfoBoxComponent)
+				final InfoBoxComponent component = (InfoBoxComponent) child;
+
+				if (!Strings.isNullOrEmpty(component.getTooltip()))
 				{
-					final InfoBoxComponent component = (InfoBoxComponent) child;
+					final Rectangle intersectionRectangle = new Rectangle(component.getPreferredLocation(), component.getPreferredSize());
 
-					if (!Strings.isNullOrEmpty(component.getTooltip()))
+					// Move the intersection based on overlay position
+					intersectionRectangle.translate(getBounds().x, getBounds().y);
+
+					// Move the intersection based on overlay "orientation"
+					final Point transformed = OverlayUtil.transformPosition(getPosition(), intersectionRectangle.getSize());
+					intersectionRectangle.translate(transformed.x, transformed.y);
+
+					if (intersectionRectangle.contains(mouse))
 					{
-						final Rectangle intersectionRectangle = new Rectangle(component.getPreferredLocation(), component.getPreferredSize());
-
-						// Move the intersection based on overlay position
-						intersectionRectangle.translate(getBounds().x, getBounds().y);
-
-						// Move the intersection based on overlay "orientation"
-						final Point transformed = OverlayUtil.transformPosition(getPosition(), intersectionRectangle.getSize());
-						intersectionRectangle.translate(transformed.x, transformed.y);
-
-						if (intersectionRectangle.contains(mouse))
-						{
-							tooltipManager.add(new Tooltip(component.getTooltip()));
-						}
+						tooltipManager.add(new Tooltip(component.getTooltip()));
 					}
 				}
 			}

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/tooltip/TooltipOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/tooltip/TooltipOverlay.java
@@ -30,7 +30,6 @@ import java.awt.Point;
 import java.awt.Rectangle;
 import java.util.List;
 import javax.inject.Inject;
-import javax.inject.Provider;
 import javax.inject.Singleton;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
@@ -47,12 +46,12 @@ public class TooltipOverlay extends Overlay
 	private static final int OFFSET = 24;
 	private static final int PADDING = 2;
 	private final TooltipManager tooltipManager;
-	private final Provider<Client> clientProvider;
+	private final Client client;
 
 	@Inject
-	private TooltipOverlay(Provider<Client> clientProvider, TooltipManager tooltipManager)
+	private TooltipOverlay(Client client, TooltipManager tooltipManager)
 	{
-		this.clientProvider = clientProvider;
+		this.client = client;
 		this.tooltipManager = tooltipManager;
 		setPosition(OverlayPosition.TOOLTIP);
 		setPriority(OverlayPriority.HIGHEST);
@@ -69,7 +68,6 @@ public class TooltipOverlay extends Overlay
 			return null;
 		}
 
-		final Client client = clientProvider.get();
 		final Rectangle clientCanvasBounds = new Rectangle(client.getRealDimensions());
 		final net.runelite.api.Point mouseCanvasPosition = client.getMouseCanvasPosition();
 		final Point mousePosition = new Point(mouseCanvasPosition.getX(), mouseCanvasPosition.getY() + OFFSET);

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/worldmap/WorldMapOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/worldmap/WorldMapOverlay.java
@@ -33,7 +33,6 @@ import java.awt.Rectangle;
 import java.awt.image.BufferedImage;
 import java.util.List;
 import javax.inject.Inject;
-import javax.inject.Provider;
 import javax.inject.Singleton;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
@@ -60,16 +59,16 @@ public class WorldMapOverlay extends Overlay
 	private static final int TOOLTIP_PADDING_WIDTH = 2;
 
 	private final WorldMapPointManager worldMapPointManager;
-	private final Provider<Client> clientProvider;
+	private final Client client;
 
 	@Inject
 	private WorldMapOverlay(
-		Provider<Client> clientProvider,
+		Client client,
 		WorldMapPointManager worldMapPointManager,
 		MouseManager mouseManager,
 		WorldMapOverlayMouseListener worldMapOverlayMouseListener)
 	{
-		this.clientProvider = clientProvider;
+		this.client = client;
 		this.worldMapPointManager = worldMapPointManager;
 		setPosition(OverlayPosition.DYNAMIC);
 		setPriority(OverlayPriority.HIGHEST);
@@ -86,8 +85,6 @@ public class WorldMapOverlay extends Overlay
 		{
 			return null;
 		}
-
-		final Client client = clientProvider.get();
 
 		Widget widget = client.getWidget(WidgetInfo.WORLD_MAP_VIEW);
 		if (widget == null)
@@ -181,7 +178,7 @@ public class WorldMapOverlay extends Overlay
 	 */
 	public Point mapWorldPointToGraphicsPoint(WorldPoint worldPoint)
 	{
-		RenderOverview ro = clientProvider.get().getRenderOverview();
+		RenderOverview ro = client.getRenderOverview();
 
 		if (!ro.getWorldMapData().surfaceContainsPosition(worldPoint.getX(), worldPoint.getY()))
 		{
@@ -190,7 +187,7 @@ public class WorldMapOverlay extends Overlay
 
 		Float pixelsPerTile = ro.getWorldMapZoom();
 
-		Widget map = clientProvider.get().getWidget(WidgetInfo.WORLD_MAP_VIEW);
+		Widget map = client.getWidget(WidgetInfo.WORLD_MAP_VIEW);
 		if (map != null)
 		{
 			Rectangle worldMapRect = map.getBounds();
@@ -232,7 +229,7 @@ public class WorldMapOverlay extends Overlay
 
 		drawPoint = new Point(drawPoint.getX() + TOOLTIP_OFFSET_WIDTH, drawPoint.getY() + TOOLTIP_OFFSET_HEIGHT);
 
-		graphics.setClip(0, 0, clientProvider.get().getCanvas().getWidth(), clientProvider.get().getCanvas().getHeight());
+		graphics.setClip(0, 0, client.getCanvas().getWidth(), client.getCanvas().getHeight());
 		graphics.setColor(TOOLTIP_BACKGROUND);
 		graphics.setFont(FontManager.getRunescapeFont());
 		FontMetrics fm = graphics.getFontMetrics();

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/worldmap/WorldMapOverlayMouseListener.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/worldmap/WorldMapOverlayMouseListener.java
@@ -28,7 +28,6 @@ import java.awt.Rectangle;
 import java.awt.event.MouseEvent;
 import java.util.List;
 import javax.inject.Inject;
-import javax.inject.Provider;
 import javax.inject.Singleton;
 import javax.swing.SwingUtilities;
 import net.runelite.api.Client;
@@ -42,14 +41,14 @@ import net.runelite.client.input.MouseListener;
 @Singleton
 public class WorldMapOverlayMouseListener extends MouseListener
 {
-	private final Provider<Client> clientProvider;
+	private final Client client;
 	private final WorldMapPointManager worldMapPointManager;
 	private WorldMapPoint tooltipPoint = null;
 
 	@Inject
-	private WorldMapOverlayMouseListener(Provider<Client> clientProvider, WorldMapPointManager worldMapPointManager)
+	private WorldMapOverlayMouseListener(Client client, WorldMapPointManager worldMapPointManager)
 	{
-		this.clientProvider = clientProvider;
+		this.client = client;
 		this.worldMapPointManager = worldMapPointManager;
 	}
 
@@ -60,7 +59,7 @@ public class WorldMapOverlayMouseListener extends MouseListener
 
 		if (SwingUtilities.isLeftMouseButton(e) && !worldMapPoints.isEmpty())
 		{
-			Point mousePos = clientProvider.get().getMouseCanvasPosition();
+			Point mousePos = client.getMouseCanvasPosition();
 
 			for (WorldMapPoint worldMapPoint : worldMapPoints)
 			{
@@ -71,7 +70,6 @@ public class WorldMapOverlayMouseListener extends MouseListener
 					{
 						// jump map to position of point
 						WorldPoint target = worldMapPoint.getWorldPoint();
-						Client client = clientProvider.get();
 						RenderOverview renderOverview = client.getRenderOverview();
 						renderOverview.setWorldMapPositionTarget(target);
 					}
@@ -92,7 +90,6 @@ public class WorldMapOverlayMouseListener extends MouseListener
 			return mouseEvent;
 		}
 
-		final Client client = clientProvider.get();
 		final Point mousePos = client.getMouseCanvasPosition();
 		final Widget view = client.getWidget(WidgetInfo.WORLD_MAP_VIEW);
 

--- a/runelite-client/src/main/java/net/runelite/client/util/SceneTileManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/util/SceneTileManager.java
@@ -30,7 +30,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Consumer;
 import javax.inject.Inject;
-import javax.inject.Provider;
 import javax.inject.Singleton;
 import net.runelite.api.Client;
 import net.runelite.api.Constants;
@@ -49,12 +48,12 @@ import net.runelite.api.events.WallObjectSpawned;
 public class SceneTileManager
 {
 	private final EventBus eventBus = new EventBus();
-	private final Provider<Client> clientProvider;
+	private final Client client;
 
 	@Inject
-	public SceneTileManager(Provider<Client> clientProvider)
+	private SceneTileManager(Client client)
 	{
-		this.clientProvider = clientProvider;
+		this.client = client;
 	}
 
 	/**
@@ -64,9 +63,7 @@ public class SceneTileManager
 	 */
 	public void forEachTile(Consumer<Tile> consumer)
 	{
-		final Client client = clientProvider.get();
-
-		if (client == null || client.getGameState() != GameState.LOGGED_IN)
+		if (client.getGameState() != GameState.LOGGED_IN)
 		{
 			return;
 		}


### PR DESCRIPTION
Instead of using providers in classes that should not be even used when
the optional dependencies are not present, move all Provider<> injects
to RuneLite (and to other top-level classes in other cases).

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>