### PR TITLE
Fix Assembler tests when autocrlf=true on Windows

### DIFF
--- a/cache/src/test/java/net/runelite/cache/script/assembler/AssemblerTest.java
+++ b/cache/src/test/java/net/runelite/cache/script/assembler/AssemblerTest.java
@@ -75,7 +75,7 @@ public class AssemblerTest
 		in = AssemblerTest.class.getResourceAsStream(this.script);
 		Assert.assertNotNull(in);
 
-		String original = new String(IOUtils.toByteArray(in));
+		String original = new String(IOUtils.toByteArray(in)).replaceAll("\r\n", "\n");
 
 		logger.info(original);
 		logger.info("-----------------------");


### PR DESCRIPTION
Tests were failing on Windows for me when running `mvn install`. Fixed by replacing \r\n with \n when asserting the `expected` value.

Another workaround is disabling autocrlf in git for this project, but I feel it's not reasonable to expect all contributors on Windows to do this.