### PR TITLE
Corp Plugin Option Enhancement (Left Clickable Core)

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/corp/CorpConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/corp/CorpConfig.java
@@ -40,7 +40,7 @@ public interface CorpConfig extends Config
 	)
 	default boolean leftClickableCore()
 	{
-		return true;
+		return false;
 	}
 
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/corp/CorpConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/corp/CorpConfig.java
@@ -34,8 +34,8 @@ public interface CorpConfig extends Config
 
 	@ConfigItem(
 		keyName = "leftClickableCore",
-		name = "Left Clickable Core",
-		description = "Allows you to left click core when core running",
+		name = "Left clickable core",
+		description = "Sets walk here option as the default left click option for core running",
 		position = 1
 	)
 	default boolean leftClickableCore()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/corp/CorpConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/corp/CorpConfig.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2018, Adam <Adam@sigterm.info>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.corp;
+
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+
+@ConfigGroup(CorpPlugin.CONFIG_GROUP)
+public interface CorpConfig extends Config
+{
+
+	@ConfigItem(
+		keyName = "leftClickableCore",
+		name = "Left Clickable Core",
+		description = "Allows you to left click core when core running",
+		position = 1
+	)
+	default boolean leftClickableCore()
+	{
+		return true;
+	}
+
+
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/corp/CorpPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/corp/CorpPlugin.java
@@ -210,7 +210,7 @@ public class CorpPlugin extends Plugin
 	@Subscribe
 	public void onMenuEntryAdded(MenuEntryAdded event)
 	{
-		if (client.getGameState() != GameState.LOGGED_IN)
+		if (client.getGameState() != GameState.LOGGED_IN || !config.leftClickableCore())
 		{
 			return;
 		}
@@ -218,7 +218,7 @@ public class CorpPlugin extends Plugin
 		String target = Text.removeTags(event.getTarget()).toLowerCase();
 		if (option.equals("attack"))
 		{
-			if (config.leftClickableCore() && target.contains("dark energy core"))
+			if (target.contains("dark energy core"))
 			{
 				MenuEntry[] entries = client.getMenuEntries();
 				int idxA = searchIndexCorp(entries, "Attack", target);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/corp/CorpPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/corp/CorpPlugin.java
@@ -38,8 +38,6 @@ import net.runelite.client.chat.ChatMessageManager;
 import net.runelite.client.chat.QueuedMessage;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
-import net.runelite.client.plugins.menuentryswapper.MenuEntrySwapperConfig;
-import net.runelite.client.plugins.menuentryswapper.MenuEntrySwapperPlugin;
 import net.runelite.client.ui.overlay.OverlayManager;
 import com.google.inject.Provides;
 import net.runelite.client.config.ConfigManager;


### PR DESCRIPTION
A similar plugin to this existed with OSBuddy (or still does -  I don't use OSBuddy any more so I don't know).

In scenarios where a player doesn't opt to kill the core and just wants to run back and forth to hug it, it can be annoying to constantly have to right click to it's current position as it has a left click attack option (by default). 

I have added an additional setting (that can be toggled) that swaps the first option of the core to be "walk here" so players have an easier time running the core.

![java_2018-07-29_23-06-14](https://user-images.githubusercontent.com/41882962/43375602-1987038c-9384-11e8-8e13-d9808e96ee03.png)

I sort of copied some existing code from the menu entry swapper plugin since all the methods there are private (if there's some more elegant way to do this let me know and I'd be more than happy to fix it per Runelite standards).