### PR TITLE
Add OSBuddy links and popup menus to GE plugin

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangeItemPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangeItemPanel.java
@@ -41,7 +41,6 @@ import javax.swing.border.CompoundBorder;
 import javax.swing.border.EmptyBorder;
 import net.runelite.client.util.AsyncBufferedImage;
 import net.runelite.client.ui.ColorScheme;
-import net.runelite.client.util.LinkBrowser;
 import net.runelite.client.util.QuantityFormatter;
 
 /**
@@ -51,10 +50,17 @@ import net.runelite.client.util.QuantityFormatter;
 class GrandExchangeItemPanel extends JPanel
 {
 	private static final Dimension ICON_SIZE = new Dimension(32, 32);
+	private final String name;
+	private final int itemId;
+	private boolean enableOsbPrices;
 
-	GrandExchangeItemPanel(AsyncBufferedImage icon, String name, int itemID, int gePrice, Double
-		haPrice, int geItemLimit)
+	GrandExchangeItemPanel(AsyncBufferedImage icon, String name, int itemId, int gePrice,
+		Double haPrice, int geItemLimit, boolean enableOsbPrices)
 	{
+		this.name = name;
+		this.itemId = itemId;
+		this.enableOsbPrices = enableOsbPrices;
+
 		BorderLayout layout = new BorderLayout();
 		layout.setHgap(5);
 		setLayout(layout);
@@ -90,11 +96,26 @@ class GrandExchangeItemPanel extends JPanel
 			@Override
 			public void mouseReleased(MouseEvent e)
 			{
-				geLink(name, itemID);
+				if (e.getButton() == MouseEvent.BUTTON1)
+				{
+					if (GrandExchangeItemPanel.this.enableOsbPrices)
+					{
+						GrandExchangeLinks.openOsbuddyGeLink(itemId);
+					}
+					else
+					{
+						GrandExchangeLinks.openGeLink(name, itemId);
+					}
+				}
 			}
 		};
 
 		addMouseListener(itemPanelMouseListener);
+
+		if (enableOsbPrices)
+		{
+			setComponentPopupMenu(new GrandExchangePricesPopupMenu(name, itemId, true));
+		}
 
 		setBorder(new EmptyBorder(5, 5, 5, 0));
 
@@ -165,13 +186,16 @@ class GrandExchangeItemPanel extends JPanel
 		}
 	}
 
-	private static void geLink(String name, int itemID)
+	void onEnableOsbPricesChanged(boolean enableOsbPrices)
 	{
-		final String url = "http://services.runescape.com/m=itemdb_oldschool/"
-			+ name.replaceAll(" ", "_")
-			+ "/viewitem?obj="
-			+ itemID;
-
-		LinkBrowser.browse(url);
+		if (enableOsbPrices)
+		{
+			setComponentPopupMenu(new GrandExchangePricesPopupMenu(name, itemId, true));
+		}
+		else
+		{
+			setComponentPopupMenu(null);
+		}
+		this.enableOsbPrices = enableOsbPrices;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangeLinks.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangeLinks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, SomeoneWithAnInternetConnection
+ * Copyright (c) 2018, Shingyx <https://github.com/Shingyx>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -22,33 +22,24 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-
 package net.runelite.client.plugins.grandexchange;
 
-import net.runelite.api.GrandExchangeOffer;
-import net.runelite.api.GrandExchangeOfferState;
-import net.runelite.api.ItemComposition;
-import net.runelite.client.util.AsyncBufferedImage;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-import org.mockito.junit.MockitoJUnitRunner;
+import net.runelite.client.util.LinkBrowser;
 
-@RunWith(MockitoJUnitRunner.class)
-public class GrandExchangeOfferSlotTest
+class GrandExchangeLinks
 {
-	@Mock
-	private GrandExchangeOffer offer;
-
-	@Test
-	public void testUpdateOffer()
+	static void openGeLink(String name, int itemId)
 	{
-		when(offer.getState()).thenReturn(GrandExchangeOfferState.CANCELLED_BUY);
-
-		GrandExchangeOfferSlot offerSlot = new GrandExchangeOfferSlot();
-		offerSlot.updateOffer(mock(ItemComposition.class), mock(AsyncBufferedImage.class), offer, false);
+		final String url = "http://services.runescape.com/m=itemdb_oldschool/"
+				+ name.replaceAll(" ", "_")
+				+ "/viewitem?obj="
+				+ itemId;
+		LinkBrowser.browse(url);
 	}
 
+	static void openOsbuddyGeLink(int itemId)
+	{
+		final String url = "https://rsbuddy.com/exchange?id=" + itemId;
+		LinkBrowser.browse(url);
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangeOfferSlot.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangeOfferSlot.java
@@ -38,8 +38,10 @@ import java.awt.event.MouseListener;
 import java.awt.image.BufferedImage;
 import javax.annotation.Nullable;
 import javax.swing.ImageIcon;
+import javax.swing.JComponent;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
+import javax.swing.JPopupMenu;
 import javax.swing.border.EmptyBorder;
 import net.runelite.api.GrandExchangeOffer;
 import net.runelite.api.GrandExchangeOfferState;
@@ -96,23 +98,23 @@ public class GrandExchangeOfferSlot extends JPanel
 		final MouseListener ml = new MouseAdapter()
 		{
 			@Override
-			public void mousePressed(MouseEvent mouseEvent)
+			public void mouseReleased(MouseEvent mouseEvent)
 			{
-				super.mousePressed(mouseEvent);
-				switchPanel();
+				if (mouseEvent.getButton() == MouseEvent.BUTTON1)
+				{
+					switchPanel();
+				}
 			}
 
 			@Override
 			public void mouseEntered(MouseEvent mouseEvent)
 			{
-				super.mouseEntered(mouseEvent);
 				container.setBackground(ColorScheme.DARKER_GRAY_HOVER_COLOR);
 			}
 
 			@Override
 			public void mouseExited(MouseEvent mouseEvent)
 			{
-				super.mouseExited(mouseEvent);
 				container.setBackground(ColorScheme.DARKER_GRAY_COLOR);
 			}
 		};
@@ -193,7 +195,7 @@ public class GrandExchangeOfferSlot extends JPanel
 		add(progressBar, BorderLayout.SOUTH);
 	}
 
-	void updateOffer(ItemComposition offerItem, BufferedImage itemImage, @Nullable GrandExchangeOffer newOffer)
+	void updateOffer(ItemComposition offerItem, BufferedImage itemImage, @Nullable GrandExchangeOffer newOffer, boolean enableOsbPrices)
 	{
 		if (newOffer == null || newOffer.getState() == EMPTY)
 		{
@@ -227,6 +229,7 @@ public class GrandExchangeOfferSlot extends JPanel
 			progressBar.setMaximumValue(newOffer.getTotalQuantity());
 			progressBar.setValue(newOffer.getQuantitySold());
 
+			GrandExchangePricesPopupMenu popupMenu = new GrandExchangePricesPopupMenu(offerItem.getName(), offerItem.getId(), enableOsbPrices);
 			/* Couldn't set the tooltip for the container panel as the children override it, so I'm setting
 			 * the tooltips on the children instead. */
 			for (Component c : container.getComponents())
@@ -235,6 +238,7 @@ public class GrandExchangeOfferSlot extends JPanel
 				{
 					JPanel panel = (JPanel) c;
 					panel.setToolTipText(htmlTooltip(((int) progressBar.getPercentage()) + "%"));
+					panel.setComponentPopupMenu(popupMenu);
 				}
 			}
 		}
@@ -272,6 +276,18 @@ public class GrandExchangeOfferSlot extends JPanel
 		}
 
 		return ColorScheme.PROGRESS_INPROGRESS_COLOR;
+	}
+
+	void onEnableOsbPricesChanged(boolean enableOsbPrices)
+	{
+		for (Component component : container.getComponents())
+		{
+			JPopupMenu popupMenu = ((JComponent) component).getComponentPopupMenu();
+			if (popupMenu instanceof GrandExchangePricesPopupMenu)
+			{
+				((GrandExchangePricesPopupMenu) popupMenu).recalculateMenuItems(enableOsbPrices);
+			}
+		}
 	}
 }
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangeOffersPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangeOffersPanel.java
@@ -103,7 +103,7 @@ public class GrandExchangeOffersPanel extends JPanel
 		updateEmptyOffersPanel();
 	}
 
-	void updateOffer(ItemComposition item, BufferedImage itemImage, GrandExchangeOffer newOffer, int slot)
+	void updateOffer(ItemComposition item, BufferedImage itemImage, GrandExchangeOffer newOffer, int slot, boolean enableOsbPrices)
 	{
 		/* If slot was previously filled, and is now empty, remove it from the list */
 		if (newOffer == null || newOffer.getState() == GrandExchangeOfferState.EMPTY)
@@ -130,7 +130,7 @@ public class GrandExchangeOffersPanel extends JPanel
 			constraints.gridy++;
 		}
 
-		offerSlotPanels[slot].updateOffer(item, itemImage, newOffer);
+		offerSlotPanels[slot].updateOffer(item, itemImage, newOffer, enableOsbPrices);
 
 		removeTopMargin();
 
@@ -180,5 +180,16 @@ public class GrandExchangeOffersPanel extends JPanel
 			cardLayout.show(container, OFFERS_PANEL);
 		}
 
+	}
+
+	void onEnableOsbPricesChanged(boolean enableOsbPrices)
+	{
+		for (GrandExchangeOfferSlot slot : offerSlotPanels)
+		{
+			if (slot != null)
+			{
+				slot.onEnableOsbPricesChanged(enableOsbPrices);
+			}
+		}
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangePanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangePanel.java
@@ -54,7 +54,7 @@ class GrandExchangePanel extends PluginPanel
 	private GrandExchangeOffersPanel offersPanel;
 
 	@Inject
-	private GrandExchangePanel(ClientThread clientThread, ItemManager itemManager, ScheduledExecutorService executor)
+	private GrandExchangePanel(ClientThread clientThread, ItemManager itemManager, ScheduledExecutorService executor, GrandExchangeConfig config)
 	{
 		super(false);
 
@@ -62,7 +62,7 @@ class GrandExchangePanel extends PluginPanel
 		setBackground(ColorScheme.DARK_GRAY_COLOR);
 
 		// Search Panel
-		searchPanel = new GrandExchangeSearchPanel(clientThread, itemManager, executor);
+		searchPanel = new GrandExchangeSearchPanel(clientThread, itemManager, executor, config);
 
 		//Offers Panel
 		offersPanel = new GrandExchangeOffersPanel();

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangePlugin.java
@@ -356,18 +356,28 @@ public class GrandExchangePlugin extends Plugin
 	{
 		if (event.getGroup().equals(GrandExchangeConfig.CONFIG_GROUP))
 		{
-			if (event.getKey().equals("quickLookup"))
+			final boolean enabled = event.getNewValue().equals("true");
+			switch (event.getKey())
 			{
-				if (config.quickLookup())
-				{
-					mouseManager.registerMouseListener(inputListener);
-					keyManager.registerKeyListener(inputListener);
-				}
-				else
-				{
-					mouseManager.unregisterMouseListener(inputListener);
-					keyManager.unregisterKeyListener(inputListener);
-				}
+				case "quickLookup":
+					if (enabled)
+					{
+						mouseManager.registerMouseListener(inputListener);
+						keyManager.registerKeyListener(inputListener);
+					}
+					else
+					{
+						mouseManager.unregisterMouseListener(inputListener);
+						keyManager.unregisterKeyListener(inputListener);
+					}
+					break;
+				case "enableOsbPrices":
+					SwingUtilities.invokeLater(() ->
+					{
+						panel.getOffersPanel().onEnableOsbPricesChanged(enabled);
+						panel.getSearchPanel().onEnableOsbPricesChanged(enabled);
+					});
+					break;
 			}
 		}
 	}
@@ -391,7 +401,7 @@ public class GrandExchangePlugin extends Plugin
 		ItemComposition offerItem = itemManager.getItemComposition(offer.getItemId());
 		boolean shouldStack = offerItem.isStackable() || offer.getTotalQuantity() > 1;
 		BufferedImage itemImage = itemManager.getImage(offer.getItemId(), offer.getTotalQuantity(), shouldStack);
-		SwingUtilities.invokeLater(() -> panel.getOffersPanel().updateOffer(offerItem, itemImage, offer, slot));
+		SwingUtilities.invokeLater(() -> panel.getOffersPanel().updateOffer(offerItem, itemImage, offer, slot, config.enableOsbPrices()));
 
 		submitTrade(slot, offer);
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangePricesPopupMenu.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangePricesPopupMenu.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, SomeoneWithAnInternetConnection
+ * Copyright (c) 2018, Shingyx <https://github.com/Shingyx>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -22,33 +22,38 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-
 package net.runelite.client.plugins.grandexchange;
 
-import net.runelite.api.GrandExchangeOffer;
-import net.runelite.api.GrandExchangeOfferState;
-import net.runelite.api.ItemComposition;
-import net.runelite.client.util.AsyncBufferedImage;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-import org.mockito.junit.MockitoJUnitRunner;
+import javax.swing.JMenuItem;
+import javax.swing.JPopupMenu;
+import javax.swing.border.EmptyBorder;
 
-@RunWith(MockitoJUnitRunner.class)
-public class GrandExchangeOfferSlotTest
+class GrandExchangePricesPopupMenu extends JPopupMenu
 {
-	@Mock
-	private GrandExchangeOffer offer;
+	private final String name;
+	private final int itemId;
 
-	@Test
-	public void testUpdateOffer()
+	GrandExchangePricesPopupMenu(String name, int itemId, boolean enableOsbPrices)
 	{
-		when(offer.getState()).thenReturn(GrandExchangeOfferState.CANCELLED_BUY);
-
-		GrandExchangeOfferSlot offerSlot = new GrandExchangeOfferSlot();
-		offerSlot.updateOffer(mock(ItemComposition.class), mock(AsyncBufferedImage.class), offer, false);
+		this.name = name;
+		this.itemId = itemId;
+		setBorder(new EmptyBorder(5, 5, 5, 5));
+		recalculateMenuItems(enableOsbPrices);
 	}
 
+	void recalculateMenuItems(boolean enableOsbPrices)
+	{
+		removeAll();
+
+		if (enableOsbPrices)
+		{
+			final JMenuItem openOsbuddyGeLink = new JMenuItem("Lookup OSBuddy GE price");
+			openOsbuddyGeLink.addActionListener(e -> GrandExchangeLinks.openOsbuddyGeLink(itemId));
+			add(openOsbuddyGeLink);
+		}
+
+		final JMenuItem openGeLink = new JMenuItem("Lookup GE price");
+		openGeLink.addActionListener(e -> GrandExchangeLinks.openGeLink(name, itemId));
+		add(openGeLink);
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangeSearchPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangeSearchPanel.java
@@ -28,6 +28,7 @@ package net.runelite.client.plugins.grandexchange;
 import com.google.common.base.Strings;
 import java.awt.BorderLayout;
 import java.awt.CardLayout;
+import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
@@ -64,6 +65,7 @@ class GrandExchangeSearchPanel extends JPanel
 	private final ClientThread clientThread;
 	private final ItemManager itemManager;
 	private final ScheduledExecutorService executor;
+	private final GrandExchangeConfig config;
 
 	private final IconTextField searchBar = new IconTextField();
 
@@ -78,11 +80,12 @@ class GrandExchangeSearchPanel extends JPanel
 
 	private final List<GrandExchangeItems> itemsList = new ArrayList<>();
 
-	GrandExchangeSearchPanel(ClientThread clientThread, ItemManager itemManager, ScheduledExecutorService executor)
+	GrandExchangeSearchPanel(ClientThread clientThread, ItemManager itemManager, ScheduledExecutorService executor, GrandExchangeConfig config)
 	{
 		this.clientThread = clientThread;
 		this.itemManager = itemManager;
 		this.executor = executor;
+		this.config = config;
 
 		setLayout(new BorderLayout());
 		setBackground(ColorScheme.DARK_GRAY_COLOR);
@@ -225,7 +228,7 @@ class GrandExchangeSearchPanel extends JPanel
 			for (GrandExchangeItems item : itemsList)
 			{
 				GrandExchangeItemPanel panel = new GrandExchangeItemPanel(item.getIcon(), item.getName(),
-					item.getItemId(), item.getGePrice(), item.getHaPrice(), item.getGeItemLimit());
+					item.getItemId(), item.getGePrice(), item.getHaPrice(), item.getGeItemLimit(), config.enableOsbPrices());
 
 				/*
 				Add the first item directly, wrap the rest with margin. This margin hack is because
@@ -262,4 +265,22 @@ class GrandExchangeSearchPanel extends JPanel
 		});
 	}
 
+	void onEnableOsbPricesChanged(boolean enableOsbPrices)
+	{
+		for (Component component : searchItemsPanel.getComponents())
+		{
+			if (component instanceof JPanel)
+			{
+				if (!(component instanceof GrandExchangeItemPanel))
+				{
+					// work around margin wrapper
+					component = ((JPanel) component).getComponent(0);
+				}
+				if (component instanceof GrandExchangeItemPanel)
+				{
+					((GrandExchangeItemPanel) component).onEnableOsbPricesChanged(enableOsbPrices);
+				}
+			}
+		}
+	}
 }


### PR DESCRIPTION
Add popup menus to both the offers and search tabs, allowing links to either the official GE prices or the OSBuddy GE prices. Add option to prefer OSBuddy prices when left clicking search results.

Resolves https://github.com/runelite/runelite/issues/4056.

![image](https://user-images.githubusercontent.com/11037113/43393881-c94e663e-944c-11e8-97d9-ae0930056e5f.png)
