### PR TITLE
Properly name Perspective methods, remove unused method params

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/Actor.java
+++ b/runelite-api/src/main/java/net/runelite/api/Actor.java
@@ -181,24 +181,22 @@ public interface Actor extends Renderable
 	 * Gets the point at which an image should be drawn, relative to the
 	 * current location with the given z-axis offset.
 	 *
-	 * @param graphics engine graphics
 	 * @param image the image to draw
 	 * @param zOffset the z-axis offset
 	 * @return the image drawing location
 	 */
-	Point getCanvasImageLocation(Graphics2D graphics, BufferedImage image, int zOffset);
+	Point getCanvasImageLocation(BufferedImage image, int zOffset);
 
 
 	/**
 	 * Gets the point at which a sprite should be drawn, relative to the
 	 * current location with the given z-axis offset.
 	 *
-	 * @param graphics engine graphics
 	 * @param sprite the sprite to draw
 	 * @param zOffset the z-axis offset
 	 * @return the sprite drawing location
 	 */
-	Point getCanvasSpriteLocation(Graphics2D graphics, SpritePixels sprite, int zOffset);
+	Point getCanvasSpriteLocation(SpritePixels sprite, int zOffset);
 
 	/**
 	 * Gets a point on the canvas of where this actors mini-map indicator

--- a/runelite-client/src/main/java/net/runelite/client/plugins/blastmine/BlastMineRockOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/blastmine/BlastMineRockOverlay.java
@@ -130,7 +130,7 @@ public class BlastMineRockOverlay extends Overlay
 			return;
 		}
 
-		Point loc = Perspective.getCanvasImageLocation(client, graphics, rock.getGameObject().getLocalLocation(), icon, 150);
+		Point loc = Perspective.getCanvasImageLocation(client, rock.getGameObject().getLocalLocation(), icon, 150);
 
 		if (loc != null)
 		{
@@ -145,7 +145,7 @@ public class BlastMineRockOverlay extends Overlay
 			return;
 		}
 
-		Point loc = Perspective.worldToCanvas(client, rock.getGameObject().getX(), rock.getGameObject().getY(), client.getPlane(), 150);
+		Point loc = Perspective.localToCanvas(client, rock.getGameObject().getLocalLocation(), rock.getGameObject().getPlane(), 150);
 
 		if (loc != null)
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonSpotOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonSpotOverlay.java
@@ -104,7 +104,7 @@ public class CannonSpotOverlay extends Overlay
 		}
 
 		//Render icon
-		Point imageLoc = Perspective.getCanvasImageLocation(client, graphics, point, image, 0);
+		Point imageLoc = Perspective.getCanvasImageLocation(client, point, image, 0);
 
 		if (imageLoc != null)
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/demonicgorilla/DemonicGorillaOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/demonicgorilla/DemonicGorillaOverlay.java
@@ -90,7 +90,7 @@ public class DemonicGorillaOverlay extends Overlay
 			LocalPoint lp = gorilla.getNpc().getLocalLocation();
 			if (lp != null)
 			{
-				Point point = Perspective.worldToCanvas(client, lp.getX(), lp.getY(), client.getPlane(),
+				Point point = Perspective.localToCanvas(client, lp, client.getPlane(),
 					gorilla.getNpc().getLogicalHeight() + 16);
 				if (point != null)
 				{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/devtools/SceneOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/devtools/SceneOverlay.java
@@ -135,9 +135,8 @@ public class SceneOverlay extends Overlay
 			boolean first = true;
 			for (int y = lp1.getY(); y <= lp2.getY(); y += LOCAL_TILE_SIZE)
 			{
-				Point p = Perspective.worldToCanvas(client,
-					lp1.getX() - LOCAL_TILE_SIZE / 2,
-					y - LOCAL_TILE_SIZE / 2,
+				Point p = Perspective.localToCanvas(client,
+					new LocalPoint(lp1.getX() - LOCAL_TILE_SIZE / 2, y - LOCAL_TILE_SIZE / 2),
 					client.getPlane());
 				if (p != null)
 				{
@@ -161,9 +160,8 @@ public class SceneOverlay extends Overlay
 			boolean first = true;
 			for (int x = lp1.getX(); x <= lp2.getX(); x += LOCAL_TILE_SIZE)
 			{
-				Point p = Perspective.worldToCanvas(client,
-					x - LOCAL_TILE_SIZE / 2,
-					lp1.getY() - LOCAL_TILE_SIZE / 2,
+				Point p = Perspective.localToCanvas(client,
+					new LocalPoint(x - LOCAL_TILE_SIZE / 2, lp1.getY() - LOCAL_TILE_SIZE / 2),
 					client.getPlane());
 				if (p != null)
 				{
@@ -202,9 +200,8 @@ public class SceneOverlay extends Overlay
 			boolean first = true;
 			for (int y = lp1.getY(); y <= lp2.getY(); y += LOCAL_TILE_SIZE)
 			{
-				Point p = Perspective.worldToCanvas(client,
-					lp1.getX() - LOCAL_TILE_SIZE / 2,
-					y - LOCAL_TILE_SIZE / 2,
+				Point p = Perspective.localToCanvas(client,
+					new LocalPoint(lp1.getX() - LOCAL_TILE_SIZE / 2, y - LOCAL_TILE_SIZE / 2),
 					client.getPlane());
 				if (p != null)
 				{
@@ -228,9 +225,8 @@ public class SceneOverlay extends Overlay
 			boolean first = true;
 			for (int x = lp1.getX(); x <= lp2.getX(); x += LOCAL_TILE_SIZE)
 			{
-				Point p = Perspective.worldToCanvas(client,
-					x - LOCAL_TILE_SIZE / 2,
-					lp1.getY() - LOCAL_TILE_SIZE / 2,
+				Point p = Perspective.localToCanvas(client,
+					new LocalPoint(x - LOCAL_TILE_SIZE / 2, lp1.getY() - LOCAL_TILE_SIZE / 2),
 					client.getPlane());
 				if (p != null)
 				{
@@ -376,7 +372,7 @@ public class SceneOverlay extends Overlay
 			}
 
 			LocalPoint fl = fa.getLocalLocation();
-			Point fs = Perspective.worldToCanvas(client, fl.getX(), fl.getY(), client.getPlane(), fa.getLogicalHeight() / 2);
+			Point fs = Perspective.localToCanvas(client, fl, client.getPlane(), fa.getLogicalHeight() / 2);
 			if (fs == null)
 			{
 				return;
@@ -385,7 +381,7 @@ public class SceneOverlay extends Overlay
 			int fsy = fs.getY() - INTERACTING_SHIFT;
 
 			LocalPoint tl = ta.getLocalLocation();
-			Point ts = Perspective.worldToCanvas(client, tl.getX(), tl.getY(), client.getPlane(), ta.getLogicalHeight() / 2);
+			Point ts = Perspective.localToCanvas(client, tl, client.getPlane(), ta.getLogicalHeight() / 2);
 			if (ts == null)
 			{
 				return;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingSpotOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingSpotOverlay.java
@@ -113,7 +113,7 @@ class FishingSpotOverlay extends Overlay
 					}
 
 					LocalPoint localPoint = npc.getLocalLocation();
-					Point location = Perspective.worldToCanvas(client, localPoint.getX(), localPoint.getY(), client.getPlane());
+					Point location = Perspective.localToCanvas(client, localPoint, client.getPlane());
 
 					if (location != null)
 					{
@@ -141,7 +141,7 @@ class FishingSpotOverlay extends Overlay
 				BufferedImage fishImage = itemManager.getImage(spot.getFishSpriteId());;
 				if (fishImage != null)
 				{
-					Point imageLocation = npc.getCanvasImageLocation(graphics, fishImage, npc.getLogicalHeight());
+					Point imageLocation = npc.getCanvasImageLocation(fishImage, npc.getLogicalHeight());
 					if (imageLocation != null)
 					{
 						OverlayUtil.renderImageLocation(graphics, imageLocation, fishImage);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/hunter/TrapOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/hunter/TrapOverlay.java
@@ -141,7 +141,7 @@ public class TrapOverlay extends Overlay
 		{
 			return;
 		}
-		net.runelite.api.Point loc = Perspective.worldToCanvas(client, localLoc.getX(), localLoc.getY(), trap.getWorldLocation().getPlane());
+		net.runelite.api.Point loc = Perspective.localToCanvas(client, localLoc, client.getPlane());
 
 		double timeLeft = 1 - trap.getTrapTimeRelative();
 
@@ -172,7 +172,7 @@ public class TrapOverlay extends Overlay
 		{
 			return;
 		}
-		net.runelite.api.Point loc = Perspective.worldToCanvas(client, localLoc.getX(), localLoc.getY(), trap.getWorldLocation().getPlane());
+		net.runelite.api.Point loc = Perspective.localToCanvas(client, localLoc, client.getPlane());
 
 		ProgressPieComponent pie = new ProgressPieComponent();
 		pie.setFill(fill);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/kourendlibrary/KourendLibraryOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/kourendlibrary/KourendLibraryOverlay.java
@@ -106,7 +106,7 @@ class KourendLibraryOverlay extends Overlay
 			{
 				continue;
 			}
-			Point screenBookcase = Perspective.worldToCanvas(client, localBookcase.getX(), localBookcase.getY(), caseLoc.getPlane(), 25);
+			Point screenBookcase = Perspective.localToCanvas(client, localBookcase, caseLoc.getPlane(), 25);
 
 			if (screenBookcase != null)
 			{
@@ -219,7 +219,7 @@ class KourendLibraryOverlay extends Overlay
 					LocalPoint local = n.getLocalLocation();
 					Polygon poly = getCanvasTilePoly(client, local);
 					OverlayUtil.renderPolygon(g, poly, Color.WHITE);
-					Point screen = Perspective.worldToCanvas(client, local.getX(), local.getY(), client.getPlane(), n.getLogicalHeight());
+					Point screen = Perspective.localToCanvas(client, local, client.getPlane(), n.getLogicalHeight());
 					if (screen != null)
 					{
 						g.drawImage(b.getIcon(), screen.getX() - (b.getIcon().getWidth() / 2), screen.getY() - b.getIcon().getHeight(), null);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/motherlode/MotherlodePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/motherlode/MotherlodePlugin.java
@@ -438,6 +438,6 @@ public class MotherlodePlugin extends Plugin
 	 */
 	boolean isUpstairs(LocalPoint localPoint)
 	{
-		return Perspective.getTileHeight(client, localPoint.getX(), localPoint.getY(), 0) < UPPER_FLOOR_HEIGHT;
+		return Perspective.getTileHeight(client, localPoint, 0) < UPPER_FLOOR_HEIGHT;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/motherlode/MotherlodeRocksOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/motherlode/MotherlodeRocksOverlay.java
@@ -111,7 +111,7 @@ class MotherlodeRocksOverlay extends Overlay
 
 	private void renderVein(Graphics2D graphics, WallObject vein)
 	{
-		Point canvasLoc = Perspective.getCanvasImageLocation(client, graphics, vein.getLocalLocation(), miningIcon, 150);
+		Point canvasLoc = Perspective.getCanvasImageLocation(client, vein.getLocalLocation(), miningIcon, 150);
 
 		if (canvasLoc != null)
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/mta/alchemy/AlchemyRoom.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/mta/alchemy/AlchemyRoom.java
@@ -384,7 +384,7 @@ public class AlchemyRoom extends MTARoom
 			}
 
 			BufferedImage image = itemManager.getImage(alchemyItem.getId());
-			Point canvasLoc = Perspective.getCanvasImageLocation(client, graphics, object.getLocalLocation(), image, IMAGE_Z_OFFSET);
+			Point canvasLoc = Perspective.getCanvasImageLocation(client, object.getLocalLocation(), image, IMAGE_Z_OFFSET);
 
 			if (canvasLoc != null)
 			{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcSceneOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcSceneOverlay.java
@@ -131,7 +131,7 @@ public class NpcSceneOverlay extends Overlay
 		final int textHeight = graphics.getFontMetrics().getAscent();
 
 		final Point canvasPoint = Perspective
-			.worldToCanvas(client, centerLp.getX(), centerLp.getY(), respawnLocation.getPlane());
+			.localToCanvas(client, centerLp, respawnLocation.getPlane());
 
 		if (canvasPoint != null)
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/prayer/PrayerBarOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/prayer/PrayerBarOverlay.java
@@ -77,7 +77,7 @@ class PrayerBarOverlay extends Overlay
 
 		final int height = client.getLocalPlayer().getLogicalHeight() + 10;
 		final LocalPoint localLocation = client.getLocalPlayer().getLocalLocation();
-		final Point canvasPoint = Perspective.worldToCanvas(client, localLocation.getX(), localLocation.getY(), client.getPlane(), height);
+		final Point canvasPoint = Perspective.localToCanvas(client, localLocation, client.getPlane(), height);
 
 		// Draw bar
 		final int barX = canvasPoint.getX() + client.getViewportXOffset() - 15;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/tithefarm/TitheFarmPlantOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/tithefarm/TitheFarmPlantOverlay.java
@@ -101,7 +101,7 @@ public class TitheFarmPlantOverlay extends Overlay
 				continue;
 			}
 
-			final Point canvasLocation = Perspective.worldToCanvas(client, localLocation.getX(), localLocation.getY(), client.getPlane());
+			final Point canvasLocation = Perspective.localToCanvas(client, localLocation, client.getPlane());
 
 			if (viewport != null && canvasLocation != null)
 			{

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayUtil.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayUtil.java
@@ -85,7 +85,7 @@ public class OverlayUtil
 
 	public static void renderImageLocation(Client client, Graphics2D graphics, LocalPoint localPoint, BufferedImage image, int zOffset)
 	{
-		net.runelite.api.Point imageLocation = Perspective.getCanvasImageLocation(client, graphics, localPoint, image, zOffset);
+		net.runelite.api.Point imageLocation = Perspective.getCanvasImageLocation(client, localPoint, image, zOffset);
 		if (imageLocation != null)
 		{
 			renderImageLocation(graphics, imageLocation, image);
@@ -123,7 +123,7 @@ public class OverlayUtil
 			renderPolygon(graphics, poly, color);
 		}
 
-		Point imageLocation = actor.getCanvasImageLocation(graphics, image, zOffset);
+		Point imageLocation = actor.getCanvasImageLocation(image, zOffset);
 		if (imageLocation != null)
 		{
 			renderImageLocation(graphics, imageLocation, image);

--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSActorMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSActorMixin.java
@@ -163,23 +163,23 @@ public abstract class RSActorMixin implements RSActor
 
 	@Inject
 	@Override
-	public Point getCanvasImageLocation(Graphics2D graphics, BufferedImage image, int zOffset)
+	public Point getCanvasImageLocation(BufferedImage image, int zOffset)
 	{
-		return Perspective.getCanvasImageLocation(client, graphics, getLocalLocation(), image, zOffset);
+		return Perspective.getCanvasImageLocation(client, getLocalLocation(), image, zOffset);
 	}
 
 	@Inject
 	@Override
-	public Point getCanvasSpriteLocation(Graphics2D graphics, SpritePixels sprite, int zOffset)
+	public Point getCanvasSpriteLocation(SpritePixels sprite, int zOffset)
 	{
-		return Perspective.getCanvasSpriteLocation(client, graphics, getLocalLocation(), sprite, zOffset);
+		return Perspective.getCanvasSpriteLocation(client, getLocalLocation(), sprite, zOffset);
 	}
 
 	@Inject
 	@Override
 	public Point getMinimapLocation()
 	{
-		return Perspective.worldToMiniMap(client, getX(), getY());
+		return Perspective.localToMinimap(client, getLocalLocation());
 	}
 
 	@FieldHook("animation")

--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSDecorativeObjectMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSDecorativeObjectMixin.java
@@ -86,7 +86,7 @@ public abstract class RSDecorativeObjectMixin implements RSDecorativeObject
 	@Override
 	public Area getClickbox()
 	{
-		return Perspective.getClickbox(client, getModel(), getOrientation(), getX(), getY());
+		return Perspective.getClickbox(client, getModel(), getOrientation(), getLocalLocation());
 	}
 
 	@Inject

--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSGameObjectMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSGameObjectMixin.java
@@ -80,7 +80,7 @@ public abstract class RSGameObjectMixin implements RSGameObject
 	@Override
 	public Area getClickbox()
 	{
-		return Perspective.getClickbox(client, getModel(), getRsOrientation(), getX(), getY());
+		return Perspective.getClickbox(client, getModel(), getRsOrientation(), getLocalLocation());
 	}
 
 	@Inject

--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSGroundObjectMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSGroundObjectMixin.java
@@ -80,6 +80,6 @@ public abstract class RSGroundObjectMixin implements RSGroundObject
 	@Override
 	public Area getClickbox()
 	{
-		return Perspective.getClickbox(client, getModel(), 0, getX(), getY());
+		return Perspective.getClickbox(client, getModel(), 0, getLocalLocation());
 	}
 }

--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSModelMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSModelMixin.java
@@ -29,6 +29,7 @@ import java.util.ArrayList;
 import java.util.List;
 import net.runelite.api.Perspective;
 import net.runelite.api.Point;
+import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.mixins.Inject;
 import net.runelite.api.mixins.Mixin;
 import net.runelite.api.mixins.Shadow;
@@ -250,9 +251,8 @@ public abstract class RSModelMixin implements RSModel
 		for (Vertex v : vertices)
 		{
 			// Compute canvas location of vertex
-			Point p = Perspective.worldToCanvas(client,
-				localX - v.getX(),
-				localY - v.getZ(),
+			Point p = Perspective.localToCanvas(client,
+				new LocalPoint(localX - v.getX(), localY - v.getZ()),
 				client.getPlane(),
 				-v.getY());
 			if (p != null)

--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSPlayerMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSPlayerMixin.java
@@ -37,6 +37,7 @@ import static net.runelite.api.HeadIcon.SMITE;
 import net.runelite.api.Model;
 import net.runelite.api.Perspective;
 import net.runelite.api.Point;
+import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.mixins.Copy;
 import net.runelite.api.mixins.Inject;
 import net.runelite.api.mixins.Mixin;
@@ -129,21 +130,18 @@ public abstract class RSPlayerMixin implements RSPlayer
 			Vertex vy = triangle.getB();
 			Vertex vz = triangle.getC();
 
-			Point x = Perspective.worldToCanvas(client,
-				localX - vx.getX(),
-				localY - vx.getZ(),
+			Point x = Perspective.localToCanvas(client,
+				new LocalPoint(localX - vx.getX(), localY - vx.getZ()),
 				client.getPlane(),
 				-vx.getY());
 
-			Point y = Perspective.worldToCanvas(client,
-				localX - vy.getX(),
-				localY - vy.getZ(),
+			Point y = Perspective.localToCanvas(client,
+				new LocalPoint(localX - vy.getX(), localY - vy.getZ()),
 				client.getPlane(),
 				-vy.getY());
 
-			Point z = Perspective.worldToCanvas(client,
-				localX - vz.getX(),
-				localY - vz.getZ(),
+			Point z = Perspective.localToCanvas(client,
+				new LocalPoint(localX - vz.getX(), localY - vz.getZ()),
 				client.getPlane(),
 				-vz.getY());
 

--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSWallObjectMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSWallObjectMixin.java
@@ -101,8 +101,8 @@ public abstract class RSWallObjectMixin implements RSWallObject
 	{
 		Area clickbox = new Area();
 
-		Area clickboxA = Perspective.getClickbox(client, getModelA(), getOrientationA(), getX(), getY());
-		Area clickboxB = Perspective.getClickbox(client, getModelB(), getOrientationB(), getX(), getY());
+		Area clickboxA = Perspective.getClickbox(client, getModelA(), getOrientationA(), getLocalLocation());
+		Area clickboxB = Perspective.getClickbox(client, getModelB(), getOrientationB(), getLocalLocation());
 
 		if (clickboxA == null && clickboxB == null)
 		{

--- a/runelite-mixins/src/main/java/net/runelite/mixins/TileObjectMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/TileObjectMixin.java
@@ -87,7 +87,7 @@ public abstract class TileObjectMixin implements TileObject
 	@Inject
 	public Point getCanvasLocation(int zOffset)
 	{
-		return Perspective.worldToCanvas(client, getX(), getY(), getPlane(), zOffset);
+		return Perspective.localToCanvas(client, getLocalLocation(), getPlane(), zOffset);
 	}
 
 	@Override
@@ -108,6 +108,6 @@ public abstract class TileObjectMixin implements TileObject
 	@Inject
 	public Point getMinimapLocation()
 	{
-		return Perspective.worldToMiniMap(client, getX(), getY());
+		return Perspective.localToMinimap(client, getLocalLocation());
 	}
 }


### PR DESCRIPTION
- Properly rename world->local Perspective methods and force them to
accept LocalPoint to prevent confusion
- Remove unused params from Perspective methods

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>