### PR TITLE
Fix tile setting and tile height ArrayOutOfBounds

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/Perspective.java
+++ b/runelite-api/src/main/java/net/runelite/api/Perspective.java
@@ -328,6 +328,11 @@ public class Perspective
 		final int sceneX = localLocation.getSceneX();
 		final int sceneY = localLocation.getSceneY();
 
+		if (sceneX < 0 || sceneY < 0 || sceneX >= SCENE_SIZE || sceneY >= SCENE_SIZE)
+		{
+			return null;
+		}
+
 		int tilePlane = plane;
 		if (plane < Constants.MAX_Z - 1 && (tileSettings[1][sceneX][sceneY] & TILE_FLAG_BRIDGE) == TILE_FLAG_BRIDGE)
 		{


### PR DESCRIPTION
Safe-check tile settings size to prevent array out of bounds exception.

Fixes #4579

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>