### PR TITLE
runelite-client: Make hotkeys run on KeyPressed

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
@@ -175,7 +175,7 @@ public class ScreenshotPlugin extends Plugin
 	private final HotkeyListener hotkeyListener = new HotkeyListener(() -> config.hotkey())
 	{
 		@Override
-		public void hotkeyReleased()
+		public void hotkeyPressed()
 		{
 			takeScreenshot(format(new Date()));
 		}

--- a/runelite-client/src/main/java/net/runelite/client/util/HotkeyListener.java
+++ b/runelite-client/src/main/java/net/runelite/client/util/HotkeyListener.java
@@ -26,7 +26,6 @@ package net.runelite.client.util;
 
 import java.awt.event.KeyEvent;
 import java.util.function.Supplier;
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import net.runelite.client.config.Keybind;
 import net.runelite.client.input.KeyListener;
@@ -36,7 +35,6 @@ public abstract class HotkeyListener implements KeyListener
 {
 	private final Supplier<Keybind> keybind;
 
-	@Getter
 	private boolean isPressed = false;
 
 	private boolean isConsumingTyped = false;
@@ -77,7 +75,6 @@ public abstract class HotkeyListener implements KeyListener
 		{
 			isPressed = false;
 			isConsumingTyped = false;
-			hotkeyReleased();
 			if (Keybind.getModifierForKeyCode(e.getKeyCode()) == null)
 			{
 				// Only consume non modifier keys
@@ -87,10 +84,6 @@ public abstract class HotkeyListener implements KeyListener
 	}
 
 	public void hotkeyPressed()
-	{
-	}
-
-	public void hotkeyReleased()
 	{
 	}
 }


### PR DESCRIPTION
Finding when keyUp actually happens is difficult because you have to store state to tell if a key is up on modifier or it's optional non-modifier. The current implementation is good enough for masking events, but not accurate enough for generating them

Fixes #4513