### PR TITLE
Fix order of loading session settings

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/RuneLite.java
+++ b/runelite-client/src/main/java/net/runelite/client/RuneLite.java
@@ -241,6 +241,9 @@ public class RuneLite
 		// Load user configuration
 		configManager.load();
 
+		// Load the session, including saved configuration
+		sessionManager.loadSession();
+
 		// Tell the plugin manager if client is outdated or not
 		pluginManager.setOutdated(isOutdated);
 
@@ -254,9 +257,6 @@ public class RuneLite
 
 		// Start client session
 		clientSessionManager.start();
-
-		// Load the session, including saved configuration
-		sessionManager.loadSession();
 
 		// Initialize UI
 		clientUI.open(this);


### PR DESCRIPTION
Currently the session simply overwrites default settings and if they
were not persisted before, they will be just null. Load session before
loading default config to fill empty places.

Fixes #4681

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>