### PR TITLE
Remove unused @Slf4j annotations and imports

### DIFF
--- a/cache-updater/src/main/java/net/runelite/cache/updater/CacheStorage.java
+++ b/cache-updater/src/main/java/net/runelite/cache/updater/CacheStorage.java
@@ -26,7 +26,6 @@ package net.runelite.cache.updater;
 
 import java.io.IOException;
 import java.util.List;
-import lombok.extern.slf4j.Slf4j;
 import net.runelite.cache.fs.Archive;
 import net.runelite.cache.fs.Index;
 import net.runelite.cache.fs.Storage;
@@ -38,7 +37,6 @@ import net.runelite.cache.updater.beans.IndexEntry;
 import org.sql2o.Connection;
 import org.sql2o.ResultSetIterable;
 
-@Slf4j
 public class CacheStorage implements Storage
 {
 	private CacheEntry cacheEntry;

--- a/http-api/src/main/java/net/runelite/http/api/session/SessionClient.java
+++ b/http-api/src/main/java/net/runelite/http/api/session/SessionClient.java
@@ -29,14 +29,12 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.UUID;
-import lombok.extern.slf4j.Slf4j;
 import net.runelite.http.api.RuneLiteAPI;
 import okhttp3.HttpUrl;
 import okhttp3.Request;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
 
-@Slf4j
 public class SessionClient
 {
 	public UUID open() throws IOException

--- a/http-service/src/main/java/net/runelite/http/service/feed/blog/BlogService.java
+++ b/http-service/src/main/java/net/runelite/http/service/feed/blog/BlogService.java
@@ -33,7 +33,6 @@ import java.util.List;
 import java.util.Locale;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
-import lombok.extern.slf4j.Slf4j;
 import net.runelite.http.api.RuneLiteAPI;
 import net.runelite.http.api.feed.FeedItem;
 import net.runelite.http.api.feed.FeedItemType;
@@ -49,7 +48,6 @@ import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 
 @Service
-@Slf4j
 public class BlogService
 {
 	private static final HttpUrl RSS_URL = HttpUrl.parse("https://runelite.net/atom.xml");

--- a/http-service/src/main/java/net/runelite/http/service/feed/osrsnews/OSRSNewsService.java
+++ b/http-service/src/main/java/net/runelite/http/service/feed/osrsnews/OSRSNewsService.java
@@ -33,7 +33,6 @@ import java.util.List;
 import java.util.Locale;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
-import lombok.extern.slf4j.Slf4j;
 import net.runelite.http.api.RuneLiteAPI;
 import net.runelite.http.api.feed.FeedItem;
 import net.runelite.http.api.feed.FeedItemType;
@@ -49,7 +48,6 @@ import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 
 @Service
-@Slf4j
 public class OSRSNewsService
 {
 	private static final HttpUrl RSS_URL = HttpUrl.parse("http://services.runescape.com/m=news/latest_news.rss?oldschool=true");

--- a/http-service/src/main/java/net/runelite/http/service/feed/twitter/TwitterService.java
+++ b/http-service/src/main/java/net/runelite/http/service/feed/twitter/TwitterService.java
@@ -32,7 +32,6 @@ import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
-import lombok.extern.slf4j.Slf4j;
 import net.runelite.http.api.RuneLiteAPI;
 import net.runelite.http.api.feed.FeedItem;
 import net.runelite.http.api.feed.FeedItemType;
@@ -47,7 +46,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 
 @Service
-@Slf4j
 public class TwitterService
 {
 	private static final HttpUrl AUTH_URL = HttpUrl.parse("https://api.twitter.com/oauth2/token");

--- a/http-service/src/main/java/net/runelite/http/service/item/ItemController.java
+++ b/http-service/src/main/java/net/runelite/http/service/item/ItemController.java
@@ -35,7 +35,6 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import javax.servlet.http.HttpServletResponse;
-import lombok.extern.slf4j.Slf4j;
 import net.runelite.http.api.item.Item;
 import net.runelite.http.api.item.ItemPrice;
 import net.runelite.http.api.item.SearchResult;
@@ -49,7 +48,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/item")
-@Slf4j
 public class ItemController
 {
 	private static final Duration CACHE_DUATION = Duration.ofMinutes(30);

--- a/runelite-client/src/main/java/net/runelite/client/chat/ChatMessageManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/chat/ChatMessageManager.java
@@ -39,7 +39,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.ChatLineBuffer;
 import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
@@ -52,7 +51,6 @@ import net.runelite.api.events.VarbitChanged;
 import net.runelite.client.config.ChatColorConfig;
 import net.runelite.client.util.ColorUtil;
 
-@Slf4j
 @Singleton
 public class ChatMessageManager
 {

--- a/runelite-client/src/main/java/net/runelite/client/game/ChatboxInputManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/game/ChatboxInputManager.java
@@ -30,14 +30,12 @@ import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import java.util.function.Consumer;
 import lombok.Getter;
-import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.ScriptID;
 import net.runelite.api.events.ScriptCallbackEvent;
 import net.runelite.client.callback.ClientThread;
 
 @Singleton
-@Slf4j
 public class ChatboxInputManager
 {
 	public static final int NO_LIMIT = Integer.MAX_VALUE;

--- a/runelite-client/src/main/java/net/runelite/client/game/ClanManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/game/ClanManager.java
@@ -41,7 +41,6 @@ import java.util.concurrent.TimeUnit;
 import javax.annotation.Nonnull;
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.ClanMember;
 import net.runelite.api.ClanMemberRank;
 import net.runelite.api.Client;
@@ -54,7 +53,6 @@ import net.runelite.client.util.ImageUtil;
 import net.runelite.client.util.Text;
 
 @Singleton
-@Slf4j
 public class ClanManager
 {
 	private static final int[] CLANCHAT_IMAGES =

--- a/runelite-client/src/main/java/net/runelite/client/game/HiscoreManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/game/HiscoreManager.java
@@ -33,7 +33,6 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 import lombok.AllArgsConstructor;
 import lombok.Data;
-import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.client.callback.ClientThread;
 import net.runelite.http.api.hiscore.HiscoreClient;
@@ -41,7 +40,6 @@ import net.runelite.http.api.hiscore.HiscoreEndpoint;
 import net.runelite.http.api.hiscore.HiscoreResult;
 
 @Singleton
-@Slf4j
 public class HiscoreManager
 {
 	@AllArgsConstructor

--- a/runelite-client/src/main/java/net/runelite/client/plugins/agility/AgilityArenaTimer.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/agility/AgilityArenaTimer.java
@@ -26,11 +26,9 @@ package net.runelite.client.plugins.agility;
 
 import java.awt.image.BufferedImage;
 import java.time.temporal.ChronoUnit;
-import lombok.extern.slf4j.Slf4j;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.ui.overlay.infobox.Timer;
 
-@Slf4j
 class AgilityArenaTimer extends Timer
 {
 	AgilityArenaTimer(Plugin plugin, BufferedImage image)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/attackstyles/AttackStylesPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/attackstyles/AttackStylesPlugin.java
@@ -32,7 +32,6 @@ import com.google.inject.Provides;
 import java.util.HashSet;
 import java.util.Set;
 import javax.inject.Inject;
-import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.GameState;
 import net.runelite.api.Skill;
@@ -60,7 +59,6 @@ import net.runelite.client.ui.overlay.OverlayManager;
 	description = "Show your current attack style as an overlay",
 	tags = {"combat", "defence", "magic", "overlay", "ranged", "strength"}
 )
-@Slf4j
 public class AttackStylesPlugin extends Plugin
 {
 	private int attackStyleVarbit = -1;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/banktags/BankTagsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/banktags/BankTagsPlugin.java
@@ -28,7 +28,6 @@ import com.google.common.eventbus.Subscribe;
 import java.util.Arrays;
 import java.util.List;
 import javax.inject.Inject;
-import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.IntegerNode;
 import net.runelite.api.InventoryID;
@@ -52,7 +51,6 @@ import net.runelite.client.plugins.PluginDescriptor;
 	description = "Enable tagging of bank items and searching of bank tags",
 	tags = {"searching", "tagging"}
 )
-@Slf4j
 public class BankTagsPlugin extends Plugin
 {
 	private static final String CONFIG_GROUP = "banktags";

--- a/runelite-client/src/main/java/net/runelite/client/plugins/barrows/BarrowsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/barrows/BarrowsPlugin.java
@@ -32,7 +32,6 @@ import java.util.Set;
 import javax.inject.Inject;
 import lombok.AccessLevel;
 import lombok.Getter;
-import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
 import net.runelite.api.GameObject;
@@ -70,7 +69,6 @@ import net.runelite.http.api.item.ItemPrice;
 	description = "Show helpful information for the Barrows minigame",
 	tags = {"combat", "minigame", "minimap"}
 )
-@Slf4j
 public class BarrowsPlugin extends Plugin
 {
 	@Getter(AccessLevel.PACKAGE)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/boosts/BoostsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/boosts/BoostsPlugin.java
@@ -33,7 +33,6 @@ import java.util.Set;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import lombok.Getter;
-import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.Prayer;
 import net.runelite.api.Skill;
@@ -55,7 +54,6 @@ import net.runelite.client.util.ImageUtil;
 	description = "Show combat and/or skill boost information",
 	tags = {"combat", "notifications", "skilling", "overlay"}
 )
-@Slf4j
 @Singleton
 public class BoostsPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/bosstimer/Boss.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/bosstimer/Boss.java
@@ -29,11 +29,9 @@ import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.HashMap;
 import java.util.Map;
-import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.ItemID;
 import net.runelite.api.NpcID;
 
-@Slf4j
 enum Boss
 {
 	GENERAL_GRAARDOR(NpcID.GENERAL_GRAARDOR, 90, ChronoUnit.SECONDS, ItemID.PET_GENERAL_GRAARDOR),

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cerberus/CerberusOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cerberus/CerberusOverlay.java
@@ -28,14 +28,12 @@ import java.awt.Dimension;
 import java.awt.Graphics2D;
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import lombok.extern.slf4j.Slf4j;
 import net.runelite.client.game.SkillIconManager;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.components.ImageComponent;
 import net.runelite.client.ui.overlay.components.PanelComponent;
 
-@Slf4j
 @Singleton
 public class CerberusOverlay extends Overlay
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/clanchat/ClanChatPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/clanchat/ClanChatPlugin.java
@@ -27,7 +27,6 @@ package net.runelite.client.plugins.clanchat;
 import com.google.common.eventbus.Subscribe;
 import java.time.temporal.ChronoUnit;
 import javax.inject.Inject;
-import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.ChatMessageType;
 import net.runelite.api.ClanMemberRank;
 import net.runelite.api.Client;
@@ -45,7 +44,6 @@ import net.runelite.client.task.Schedule;
 	description = "Add rank icons to users talking in clan chat",
 	tags = {"icons", "rank"}
 )
-@Slf4j
 public class ClanChatPlugin extends Plugin
 {
 	@Inject

--- a/runelite-client/src/main/java/net/runelite/client/plugins/dailytaskindicators/DailyTasksPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/dailytaskindicators/DailyTasksPlugin.java
@@ -28,7 +28,6 @@ package net.runelite.client.plugins.dailytaskindicators;
 import com.google.common.eventbus.Subscribe;
 import com.google.inject.Provides;
 import javax.inject.Inject;
-import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
 import net.runelite.api.Varbits;
@@ -49,7 +48,6 @@ import net.runelite.client.plugins.PluginDescriptor;
 	description = "Show chat notifications for daily tasks upon login",
 	enabledByDefault = false
 )
-@Slf4j
 public class DailyTasksPlugin extends Plugin
 {
 	@Inject

--- a/runelite-client/src/main/java/net/runelite/client/plugins/demonicgorilla/DemonicGorillaPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/demonicgorilla/DemonicGorillaPlugin.java
@@ -34,7 +34,6 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
 import lombok.Getter;
-import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.AnimationID;
 import net.runelite.api.Client;
 import net.runelite.api.GameState;
@@ -65,7 +64,6 @@ import net.runelite.client.ui.overlay.OverlayManager;
 	description = "Count demonic gorilla attacks and display their next possible attack styles",
 	tags = {"combat", "overlay"}
 )
-@Slf4j
 public class DemonicGorillaPlugin extends Plugin
 {
 	@Inject

--- a/runelite-client/src/main/java/net/runelite/client/plugins/devtools/DevToolsPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/devtools/DevToolsPanel.java
@@ -30,12 +30,10 @@ import java.awt.GridLayout;
 import javax.inject.Inject;
 import javax.swing.JButton;
 import javax.swing.JPanel;
-import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.client.ui.ColorScheme;
 import net.runelite.client.ui.PluginPanel;
 
-@Slf4j
 public class DevToolsPanel extends PluginPanel
 {
 	private final Client client;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/devtools/DevToolsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/devtools/DevToolsPlugin.java
@@ -33,7 +33,6 @@ import java.awt.Font;
 import java.awt.image.BufferedImage;
 import static java.lang.Math.min;
 import javax.inject.Inject;
-import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
 import net.runelite.api.Experience;
@@ -58,7 +57,6 @@ import org.slf4j.LoggerFactory;
 	tags = {"panel"},
 	developerPlugin = true
 )
-@Slf4j
 public class DevToolsPlugin extends Plugin
 {
 	@Inject

--- a/runelite-client/src/main/java/net/runelite/client/plugins/fightcave/FightCaveOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/fightcave/FightCaveOverlay.java
@@ -29,7 +29,6 @@ import java.awt.Dimension;
 import java.awt.Graphics2D;
 import java.awt.image.BufferedImage;
 import javax.inject.Inject;
-import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.SpriteID;
 import net.runelite.client.game.SpriteManager;
@@ -40,7 +39,6 @@ import net.runelite.client.ui.overlay.components.ComponentConstants;
 import net.runelite.client.ui.overlay.components.ImageComponent;
 import net.runelite.client.ui.overlay.components.PanelComponent;
 
-@Slf4j
 public class FightCaveOverlay extends Overlay
 {
 	private static final Color NOT_ACTIVATED_BACKGROUND_COLOR = new Color(150, 0, 0, 150);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangeItemPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangeItemPanel.java
@@ -36,7 +36,6 @@ import java.awt.event.MouseEvent;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.border.EmptyBorder;
-import lombok.extern.slf4j.Slf4j;
 import net.runelite.client.ui.ColorScheme;
 import net.runelite.client.game.AsyncBufferedImage;
 import net.runelite.client.util.LinkBrowser;
@@ -46,7 +45,6 @@ import net.runelite.client.util.StackFormatter;
  * This panel displays an individual item result in the
  * Grand Exchange search plugin.
  */
-@Slf4j
 class GrandExchangeItemPanel extends JPanel
 {
 	private static final Dimension ICON_SIZE = new Dimension(32, 32);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangeOfferSlot.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangeOfferSlot.java
@@ -41,7 +41,6 @@ import javax.swing.ImageIcon;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.border.EmptyBorder;
-import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.GrandExchangeOffer;
 import net.runelite.api.GrandExchangeOfferState;
 import static net.runelite.api.GrandExchangeOfferState.CANCELLED_BUY;
@@ -55,7 +54,6 @@ import net.runelite.client.util.ColorUtil;
 import net.runelite.client.util.ImageUtil;
 import net.runelite.client.util.StackFormatter;
 
-@Slf4j
 public class GrandExchangeOfferSlot extends JPanel
 {
 	private static final String FACE_CARD = "FACE_CARD";

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangePanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangePanel.java
@@ -32,7 +32,6 @@ import javax.inject.Inject;
 import javax.swing.JPanel;
 import javax.swing.border.EmptyBorder;
 import lombok.Getter;
-import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.client.callback.ClientThread;
 import net.runelite.client.game.ItemManager;
@@ -41,7 +40,6 @@ import net.runelite.client.ui.PluginPanel;
 import net.runelite.client.ui.components.materialtabs.MaterialTab;
 import net.runelite.client.ui.components.materialtabs.MaterialTabGroup;
 
-@Slf4j
 class GrandExchangePanel extends PluginPanel
 {
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
@@ -45,7 +45,6 @@ import javax.inject.Inject;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
-import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.GameState;
 import net.runelite.api.Item;
@@ -84,7 +83,6 @@ import net.runelite.http.api.item.ItemPrice;
 	description = "Highlight ground items and/or show price information",
 	tags = {"grand", "exchange", "high", "alchemy", "prices", "highlight", "overlay"}
 )
-@Slf4j
 public class GroundItemsPlugin extends Plugin
 {
 	private static final Splitter COMMA_SPLITTER = Splitter

--- a/runelite-client/src/main/java/net/runelite/client/plugins/herbiboars/HerbiboarPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/herbiboars/HerbiboarPlugin.java
@@ -35,7 +35,6 @@ import java.util.Set;
 import javax.inject.Inject;
 import lombok.Getter;
 import lombok.Setter;
-import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import static net.runelite.api.ObjectID.DRIFTWOOD_30523;
 import static net.runelite.api.ObjectID.MUSHROOM_30520;
@@ -59,7 +58,6 @@ import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.OverlayManager;
 
-@Slf4j
 @PluginDescriptor(
 	name = "Herbiboar",
 	description = "Highlight starting rocks, trails, and the objects to search at the end of each trail",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/info/InfoPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/info/InfoPanel.java
@@ -45,7 +45,6 @@ import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.border.EmptyBorder;
 import javax.swing.event.HyperlinkEvent;
-import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.events.SessionClose;
 import net.runelite.api.events.SessionOpen;
@@ -58,7 +57,6 @@ import net.runelite.client.util.ImageUtil;
 import net.runelite.client.util.LinkBrowser;
 import net.runelite.client.util.RunnableExceptionLogger;
 
-@Slf4j
 @Singleton
 public class InfoPanel extends PluginPanel
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPanel.java
@@ -35,7 +35,6 @@ import javax.swing.JMenuItem;
 import javax.swing.JPanel;
 import javax.swing.JPopupMenu;
 import javax.swing.border.EmptyBorder;
-import lombok.extern.slf4j.Slf4j;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.ui.ColorScheme;
 import net.runelite.client.ui.FontManager;
@@ -44,7 +43,6 @@ import net.runelite.client.ui.components.PluginErrorPanel;
 import net.runelite.client.util.ColorUtil;
 import net.runelite.client.util.StackFormatter;
 
-@Slf4j
 class LootTrackerPanel extends PluginPanel
 {
 	private static final String HTML_LABEL_TEMPLATE =

--- a/runelite-client/src/main/java/net/runelite/client/plugins/mta/alchemy/AlchemyRoomTimer.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/mta/alchemy/AlchemyRoomTimer.java
@@ -26,12 +26,10 @@ package net.runelite.client.plugins.mta.alchemy;
 
 import java.awt.image.BufferedImage;
 import java.time.temporal.ChronoUnit;
-import lombok.extern.slf4j.Slf4j;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.ui.overlay.infobox.Timer;
 import net.runelite.client.util.ImageUtil;
 
-@Slf4j
 public class AlchemyRoomTimer extends Timer
 {
 	private static final int RESET_PERIOD = 42;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/notes/NotesPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/notes/NotesPlugin.java
@@ -28,7 +28,6 @@ import com.google.common.eventbus.Subscribe;
 import com.google.inject.Provides;
 import java.awt.image.BufferedImage;
 import javax.inject.Inject;
-import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.events.SessionOpen;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.plugins.Plugin;
@@ -43,7 +42,6 @@ import net.runelite.client.util.ImageUtil;
 	tags = {"panel"},
 	loadWhenOutdated = true
 )
-@Slf4j
 public class NotesPlugin extends Plugin
 {
 	@Inject

--- a/runelite-client/src/main/java/net/runelite/client/plugins/poh/PohIcons.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/poh/PohIcons.java
@@ -28,12 +28,10 @@ import java.awt.image.BufferedImage;
 import java.util.HashMap;
 import java.util.Map;
 import lombok.Getter;
-import lombok.extern.slf4j.Slf4j;
 import static net.runelite.api.ObjectID.*;
 import static net.runelite.api.NullObjectID.*;
 import net.runelite.client.util.ImageUtil;
 
-@Slf4j
 public enum PohIcons
 {
 	EXITPORTAL("exitportal", PORTAL_4525),

--- a/runelite-client/src/main/java/net/runelite/client/plugins/puzzlesolver/PuzzleSolverOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/puzzlesolver/PuzzleSolverOverlay.java
@@ -37,7 +37,6 @@ import java.util.Arrays;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import javax.inject.Inject;
-import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.GameState;
 import net.runelite.api.InventoryID;
@@ -60,7 +59,6 @@ import net.runelite.client.ui.overlay.components.BackgroundComponent;
 import net.runelite.client.ui.overlay.components.TextComponent;
 import net.runelite.client.util.ImageUtil;
 
-@Slf4j
 public class PuzzleSolverOverlay extends Overlay
 {
 	private static final int INFO_BOX_WIDTH = 100;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/reorderprayers/ReorderPrayersPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/reorderprayers/ReorderPrayersPlugin.java
@@ -32,7 +32,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
-import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.GameState;
 import net.runelite.api.HashTable;
@@ -54,7 +53,6 @@ import net.runelite.client.menus.WidgetMenuOption;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 
-@Slf4j
 @PluginDescriptor(
 	name = "Reorder Prayers",
 	description = "Reorder the prayers displayed on the Prayer panel"

--- a/runelite-client/src/main/java/net/runelite/client/plugins/reportbutton/ReportButtonPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/reportbutton/ReportButtonPlugin.java
@@ -34,7 +34,6 @@ import java.time.format.DateTimeFormatter;
 import java.time.format.FormatStyle;
 import java.time.temporal.ChronoUnit;
 import javax.inject.Inject;
-import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.GameState;
 import net.runelite.api.events.GameStateChanged;
@@ -51,7 +50,6 @@ import net.runelite.client.task.Schedule;
 	description = "Replace the text on the Report button with the current time",
 	tags = {"time", "utc"}
 )
-@Slf4j
 public class ReportButtonPlugin extends Plugin
 {
 	private static final ZoneId UTC = ZoneId.of("UTC");

--- a/runelite-client/src/main/java/net/runelite/client/plugins/roguesden/RoguesDenOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/roguesden/RoguesDenOverlay.java
@@ -29,14 +29,12 @@ import java.awt.Dimension;
 import java.awt.Graphics2D;
 import java.awt.Polygon;
 import javax.inject.Inject;
-import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.coords.LocalPoint;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
 
-@Slf4j
 public class RoguesDenOverlay extends Overlay
 {
 	private static final int MAX_DISTANCE = 2350;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/roguesden/RoguesDenPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/roguesden/RoguesDenPlugin.java
@@ -30,7 +30,6 @@ import java.util.HashMap;
 import javax.inject.Inject;
 import lombok.AccessLevel;
 import lombok.Getter;
-import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.GameState;
 import net.runelite.api.InventoryID;
@@ -56,7 +55,6 @@ import net.runelite.client.ui.overlay.OverlayManager;
 	description = "Mark tiles and clickboxes to help traverse the maze",
 	tags = {"agility", "maze", "minigame", "overlay", "thieving"}
 )
-@Slf4j
 public class RoguesDenPlugin extends Plugin
 {
 	@Getter(AccessLevel.PACKAGE)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenmarkers/ScreenMarkerMouseListener.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenmarkers/ScreenMarkerMouseListener.java
@@ -26,10 +26,8 @@ package net.runelite.client.plugins.screenmarkers;
 
 import java.awt.event.MouseEvent;
 import javax.swing.SwingUtilities;
-import lombok.extern.slf4j.Slf4j;
 import net.runelite.client.input.MouseListener;
 
-@Slf4j
 public class ScreenMarkerMouseListener extends MouseListener
 {
 	private final ScreenMarkerPlugin plugin;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenmarkers/ScreenMarkerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenmarkers/ScreenMarkerPlugin.java
@@ -42,7 +42,6 @@ import java.util.stream.Stream;
 import javax.inject.Inject;
 import lombok.AccessLevel;
 import lombok.Getter;
-import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.events.ConfigChanged;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.input.MouseManager;
@@ -59,7 +58,6 @@ import net.runelite.client.util.ImageUtil;
 	description = "Enable drawing of screen markers on top of the client",
 	tags = {"boxes", "overlay", "panel"}
 )
-@Slf4j
 public class ScreenMarkerPlugin extends Plugin
 {
 	private static final String PLUGIN_NAME = "Screen Markers";

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timers/GameTimer.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timers/GameTimer.java
@@ -30,14 +30,12 @@ import java.awt.image.BufferedImage;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import lombok.Getter;
-import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.GraphicID;
 import net.runelite.api.ItemID;
 import net.runelite.api.SpriteID;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.game.SpriteManager;
 
-@Slf4j
 enum GameTimer
 {
 	STAMINA(ItemID.STAMINA_POTION4, GameTimerImageType.ITEM, "Stamina", 2, ChronoUnit.MINUTES),

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/TimeTrackingPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/TimeTrackingPanel.java
@@ -38,7 +38,6 @@ import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.SwingUtilities;
 import javax.swing.border.EmptyBorder;
-import lombok.extern.slf4j.Slf4j;
 import net.runelite.client.game.AsyncBufferedImage;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.plugins.timetracking.clocks.ClockManager;
@@ -49,7 +48,6 @@ import net.runelite.client.ui.PluginPanel;
 import net.runelite.client.ui.components.materialtabs.MaterialTab;
 import net.runelite.client.ui.components.materialtabs.MaterialTabGroup;
 
-@Slf4j
 class TimeTrackingPanel extends PluginPanel
 {
 	private final ItemManager itemManager;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/TimeTrackingPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/TimeTrackingPlugin.java
@@ -34,7 +34,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import javax.inject.Inject;
-import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.GameState;
 import net.runelite.api.coords.WorldPoint;
@@ -63,7 +62,6 @@ import net.runelite.client.util.ImageUtil;
 	description = "Enable the Time Tracking panel, which contains timers, stopwatches, and farming and bird house trackers",
 	tags = {"birdhouse", "farming", "hunter", "notifications", "skilling", "stopwatches", "timers", "panel"}
 )
-@Slf4j
 public class TimeTrackingPlugin extends Plugin
 {
 	@Inject

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesOverlay.java
@@ -37,7 +37,6 @@ import java.text.DecimalFormat;
 import java.time.Instant;
 import java.util.List;
 import javax.inject.Inject;
-import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.Experience;
 import net.runelite.api.Point;
@@ -51,7 +50,6 @@ import net.runelite.client.ui.overlay.components.LineComponent;
 import net.runelite.client.ui.overlay.components.PanelComponent;
 import net.runelite.client.ui.overlay.components.ProgressBarComponent;
 
-@Slf4j
 public class XpGlobesOverlay extends Overlay
 {
 	private final Client client;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpInfoBox.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpInfoBox.java
@@ -39,7 +39,6 @@ import javax.swing.SwingUtilities;
 import javax.swing.border.EmptyBorder;
 import lombok.AccessLevel;
 import lombok.Getter;
-import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.Experience;
 import net.runelite.api.Skill;
@@ -52,7 +51,6 @@ import net.runelite.client.util.ColorUtil;
 import net.runelite.client.util.LinkBrowser;
 import net.runelite.client.util.StackFormatter;
 
-@Slf4j
 class XpInfoBox extends JPanel
 {
 	// Templates

--- a/runelite-client/src/main/java/net/runelite/client/plugins/zoom/ZoomPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/zoom/ZoomPlugin.java
@@ -28,7 +28,6 @@ package net.runelite.client.plugins.zoom;
 import com.google.common.eventbus.Subscribe;
 import com.google.inject.Inject;
 import com.google.inject.Provides;
-import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.events.ConfigChanged;
 import net.runelite.api.events.ScriptCallbackEvent;
@@ -43,7 +42,6 @@ import net.runelite.client.plugins.PluginDescriptor;
 	tags = {"limit", "vertical"},
 	enabledByDefault = false
 )
-@Slf4j
 public class ZoomPlugin extends Plugin
 {
 	@Inject

--- a/runelite-client/src/main/java/net/runelite/client/ui/ClientPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ClientPanel.java
@@ -29,11 +29,9 @@ import java.awt.BorderLayout;
 import java.awt.Color;
 import javax.annotation.Nullable;
 import javax.swing.JPanel;
-import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.Constants;
 
-@Slf4j
 final class ClientPanel extends JPanel
 {
 	public ClientPanel(@Nullable Applet client)

--- a/runelite-client/src/main/java/net/runelite/client/ui/components/materialtabs/MaterialTab.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/components/materialtabs/MaterialTab.java
@@ -38,7 +38,6 @@ import javax.swing.border.Border;
 import javax.swing.border.CompoundBorder;
 import lombok.Getter;
 import lombok.Setter;
-import lombok.extern.slf4j.Slf4j;
 import net.runelite.client.ui.ColorScheme;
 
 /**
@@ -49,7 +48,6 @@ import net.runelite.client.ui.ColorScheme;
  *
  * @author Psikoi
  */
-@Slf4j
 public class MaterialTab extends JLabel
 {
 	private static final Border SELECTED_BORDER = new CompoundBorder(

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayRenderer.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayRenderer.java
@@ -37,7 +37,6 @@ import java.util.List;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import javax.swing.SwingUtilities;
-import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.GameState;
 import net.runelite.api.events.FocusChanged;
@@ -51,7 +50,6 @@ import net.runelite.client.input.MouseManager;
 import net.runelite.client.ui.FontManager;
 
 @Singleton
-@Slf4j
 public class OverlayRenderer extends MouseListener implements KeyListener
 {
 	private static final int BORDER_LEFT_RESIZABLE = 5;

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/tooltip/TooltipOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/tooltip/TooltipOverlay.java
@@ -31,7 +31,6 @@ import java.awt.Rectangle;
 import java.util.List;
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
@@ -40,7 +39,6 @@ import net.runelite.client.ui.overlay.OverlayPriority;
 import net.runelite.client.ui.overlay.components.TooltipComponent;
 
 @Singleton
-@Slf4j
 public class TooltipOverlay extends Overlay
 {
 	private static final int OFFSET = 24;

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/worldmap/WorldMapOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/worldmap/WorldMapOverlay.java
@@ -34,7 +34,6 @@ import java.awt.image.BufferedImage;
 import java.util.List;
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.Point;
 import net.runelite.api.RenderOverview;
@@ -49,7 +48,6 @@ import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.OverlayPriority;
 
 @Singleton
-@Slf4j
 public class WorldMapOverlay extends Overlay
 {
 	private static final Color TOOLTIP_BACKGROUND = new Color(255, 255, 160);


### PR DESCRIPTION
The following script was used to remove the offending instances, run from the root of the project:

```bash
foo="$(git ls-files ./*.java)"
while IFS='' read -r file || [[ -n "$file" ]]; do
  if grep --quiet -F '@Slf4j' "$file"; then
    if ! grep --quiet -F 'log.' "$file"; then
      sed -i -r -e '/^@Slf4j/d' -e '/^import lombok\.extern\.slf4j\.Slf4j;/d' "$file"
      git add "$file"
    fi
  fi
done <<< "$foo"
```