### PR TITLE
item stats: fix tooltip not appearing when hovering over item

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatOverlay.java
@@ -27,10 +27,9 @@ package net.runelite.client.plugins.itemstats;
 import com.google.inject.Inject;
 import java.awt.Dimension;
 import java.awt.Graphics2D;
-import java.awt.Point;
 import net.runelite.api.Client;
-import net.runelite.api.queries.InventoryWidgetItemQuery;
-import net.runelite.api.widgets.WidgetItem;
+import net.runelite.api.MenuEntry;
+import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.tooltip.Tooltip;
 import net.runelite.client.ui.overlay.tooltip.TooltipManager;
@@ -62,25 +61,35 @@ public class ItemStatOverlay extends Overlay
 			return null;
 		}
 
-		WidgetItem[] inventory = queryRunner.runQuery(new InventoryWidgetItemQuery());
-		Point mousePos = new Point(client.getMouseCanvasPosition().getX(), client.getMouseCanvasPosition().getY());
-		for (WidgetItem item : inventory)
+		final MenuEntry[] menu = client.getMenuEntries();
+		final int menuSize = menu.length;
+
+		if (menuSize <= 0)
 		{
-			if (item.getCanvasBounds().contains(mousePos))
-			{
-				Effect change = statChanges.get(item.getId());
-				if (change != null)
-				{
-					StringBuilder b = new StringBuilder();
-					StatsChanges statsChanges = change.calculate(client);
-					for (StatChange c : statsChanges.getStatChanges())
-					{
-						b.append(buildStatChangeString(c));
-					}
-					tooltipManager.add(new Tooltip(b.toString()));
-				}
-			}
+			return null;
 		}
+
+		final MenuEntry entry = menu[menuSize - 1];
+
+		if (entry.getParam1() != WidgetInfo.INVENTORY.getId())
+		{
+			return null;
+		}
+
+		final Effect change = statChanges.get(entry.getIdentifier());
+		if (change != null)
+		{
+			final StringBuilder b = new StringBuilder();
+			final StatsChanges statsChanges = change.calculate(client);
+
+			for (final StatChange c : statsChanges.getStatChanges())
+			{
+				b.append(buildStatChangeString(c));
+			}
+
+			tooltipManager.add(new Tooltip(b.toString()));
+		}
+
 		return null;
 	}
 


### PR DESCRIPTION
Fixes #1505

This fix will change the plugin to use the last menu entry instead of the widget item query it did before.
The widget item area is off by a pixel (needs to be moved +1 from top and left). If it is desired to keep using the widget item query then this PR should be discarded.

Issue at hand:
![image](https://user-images.githubusercontent.com/35824069/43551915-105c33a6-95e9-11e8-8e15-2c252dc4ce47.png)
![image](https://user-images.githubusercontent.com/35824069/43551935-1c9bffde-95e9-11e8-950f-746daec8fefb.png)


After fix:
![image](https://user-images.githubusercontent.com/35824069/43551963-31b49534-95e9-11e8-8e60-022e586f951b.png)
![image](https://user-images.githubusercontent.com/35824069/43551970-366ab176-95e9-11e8-951b-64ff60def6dd.png)
