### PR TITLE
Fix noted item prices & updated hover text [Loot Tracker]

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/game/ItemManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/game/ItemManager.java
@@ -208,6 +208,23 @@ public class ItemManager
 	}
 
 	/**
+	 * Look up an item's composition. If the noted variant of the item
+	 * is passed, this will return the composition for the unnoted version.
+	 *
+	 * @param itemId item id
+	 * @return item composition
+	 */
+	public ItemComposition getUnnotedItemComposition(int itemId)
+	{
+		ItemComposition composition = getItemComposition(itemId);
+		if (composition.getNote() == -1)
+		{
+			return composition;
+		}
+		return getItemComposition(composition.getLinkedNoteId());
+	}
+
+	/**
 	 * Loads item sprite from game, makes transparent, and generates image
 	 *
 	 * @param itemId

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerBox.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerBox.java
@@ -113,9 +113,12 @@ class LootTrackerBox extends JPanel
 	{
 		final String name = itemManager.getItemComposition(item.getId()).getName();
 		final int quantity = item.getQuantity();
-		final long price = calculatePrice(itemManager, new ItemStack[]{item});
+		ItemPrice p = itemManager.getItemPrice(itemManager.getUnnotedItemComposition(item.getId()).getId());
+		final int price = item.getId() == ItemID.COINS_995 ? 1 : (p == null ? 0 : p.getPrice());
 
-		return name + " x " + quantity + " (" + price + ")";
+		return "<html>" + name + " x " + quantity + "<br/>"
+				+ "Price: " + StackFormatter.formatNumber(price) + "<br/>"
+				+ "Total: " + StackFormatter.formatNumber(price * quantity) + "</html>";
 	}
 
 	private static long calculatePrice(final ItemManager itemManager, final ItemStack[] itemStacks)
@@ -123,7 +126,7 @@ class LootTrackerBox extends JPanel
 		long total = 0;
 		for (ItemStack itemStack : itemStacks)
 		{
-			ItemPrice itemPrice = itemManager.getItemPrice(itemStack.getId());
+			ItemPrice itemPrice = itemManager.getItemPrice(itemManager.getUnnotedItemComposition(itemStack.getId()).getId());
 			if (itemPrice != null)
 			{
 				total += (long) itemPrice.getPrice() * itemStack.getQuantity();


### PR DESCRIPTION
Added `getUnnotedItemComposition` to `ItemManager.java`.

Updated Hover Text Format: 
![](https://i.imgur.com/sDBswE7.png)

A different take on #4630.