### PR TITLE
Reverse ClientUI sidebar condition

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
@@ -735,13 +735,14 @@ public class ClientUI
 		{
 			final Rectangle bounds = frame.getBounds();
 
+			// Try to expand sidebar
+			if (!sidebarOpen)
+			{
+				bounds.width += pluginToolbar.getWidth();
+			}
+
 			if (config.automaticResizeType() == ExpandResizeType.KEEP_GAME_SIZE)
 			{
-				// Try to contract sidebar
-				if (sidebarOpen)
-				{
-					bounds.width -= pluginToolbar.getWidth();
-				}
 
 				// Try to contract plugin panel
 				if (pluginPanel != null)


### PR DESCRIPTION
- Reverse ClientUI sidebar condition as when opening sidebar is always
open so current master will effectively shrink window instead of
restoring to correct size
- Apply this condition also to KEEP_WINDOW_SIZE

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>