### PR TITLE
Use correct marker name when cancelling edit

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenmarkers/ui/ScreenMarkerPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenmarkers/ui/ScreenMarkerPanel.java
@@ -207,7 +207,7 @@ class ScreenMarkerPanel extends JPanel
 			public void mousePressed(MouseEvent mouseEvent)
 			{
 				nameInput.setEditable(false);
-				nameInput.setText(marker.getName());
+				nameInput.setText(marker.getMarker().getName());
 				updateNameActions(false);
 				requestFocusInWindow();
 			}


### PR DESCRIPTION
Instead of using marker overlay name use marker name, as marker overlay
name contains date.

Fixes #4634

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>