### PR TITLE
Remove special cased wizard death from loot manage

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/game/LootManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/game/LootManager.java
@@ -60,11 +60,7 @@ import net.runelite.client.events.PlayerLootReceived;
 public class LootManager
 {
 	private static final Map<Integer, Integer> NPC_DEATH_ANIMATIONS = ImmutableMap.of(
-		NpcID.CAVE_KRAKEN, AnimationID.CAVE_KRAKEN_DEATH,
-		NpcID.AIR_WIZARD, AnimationID.WIZARD_DEATH,
-		NpcID.WATER_WIZARD, AnimationID.WIZARD_DEATH,
-		NpcID.EARTH_WIZARD, AnimationID.WIZARD_DEATH,
-		NpcID.FIRE_WIZARD, AnimationID.WIZARD_DEATH
+		NpcID.CAVE_KRAKEN, AnimationID.CAVE_KRAKEN_DEATH
 	);
 
 	private final EventBus eventBus;


### PR DESCRIPTION
Remove special cased wizard death animations from loot manager as as of
latest OSRS update this now works normally:

The Elemental Wizards south of Falador now give loot at the end of their
death animation rather than the beginning.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>