### PR TITLE
Add threshold value for logging loot

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerConfig.java
@@ -1,0 +1,22 @@
+package net.runelite.client.plugins.loottracker;
+
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+
+@ConfigGroup("lootTracker")
+public interface LootTrackerConfig extends Config
+{
+
+	@ConfigItem(
+		keyName = "ignoreUnderValue",
+		name = "Ignore < Value",
+		description = "Configures the minimum value for loot to show up, set to 0 to show all loot",
+		position = 1
+	)
+	default int getIgnoreUnderValue()
+	{
+		return 0;
+	}
+
+}


### PR DESCRIPTION
Add an option to ignore loot that doesn't meet the value threshold. Useful for hiding bone drops and keeping the loot tracker clean.

Related #4659 
