### PR TITLE
Move isOverlayOutdated to IndexDatabase

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/Client.java
+++ b/runelite-api/src/main/java/net/runelite/api/Client.java
@@ -328,6 +328,13 @@ public interface Client extends GameEngine
 	IndexDataBase getIndexSprites();
 
 	/**
+	 * Gets the script index database.
+	 *
+	 * @return the script database
+	 */
+	IndexDataBase getIndexScripts();
+
+	/**
 	 * Returns the x-axis base coordinate.
 	 * <p>
 	 * This value is the x-axis world coordinate of tile (0, 0) in

--- a/runelite-api/src/main/java/net/runelite/api/IndexDataBase.java
+++ b/runelite-api/src/main/java/net/runelite/api/IndexDataBase.java
@@ -29,4 +29,8 @@ package net.runelite.api;
  */
 public interface IndexDataBase
 {
+	/**
+	 * Returns true if any cache overlay in this index is outdated due to hash mismatch
+	 */
+	boolean isOverlayOutdated();
 }

--- a/runelite-api/src/main/java/net/runelite/api/hooks/Callbacks.java
+++ b/runelite-api/src/main/java/net/runelite/api/hooks/Callbacks.java
@@ -28,7 +28,6 @@ import java.awt.Graphics;
 import java.awt.event.KeyEvent;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseWheelEvent;
-import net.runelite.api.IndexDataBase;
 import net.runelite.api.MainBufferProvider;
 
 /**
@@ -164,12 +163,4 @@ public interface Callbacks
 	 * @param keyEvent the key event
 	 */
 	void keyTyped(KeyEvent keyEvent);
-
-	/**
-	 * Called whenever a cache overlay fails to load due to a hash mismatch
-	 * @param indexDataBase
-	 * @param archiveId
-	 * @param fileId
-	 */
-	void overlayLoadFailed(IndexDataBase indexDataBase, int archiveId, int fileId);
 }

--- a/runelite-client/src/main/java/net/runelite/client/RuneLite.java
+++ b/runelite-client/src/main/java/net/runelite/client/RuneLite.java
@@ -43,7 +43,6 @@ import joptsimple.OptionParser;
 import joptsimple.OptionSet;
 import joptsimple.util.EnumConverter;
 import lombok.Getter;
-import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.client.account.SessionManager;
@@ -145,10 +144,6 @@ public class RuneLite
 	@Inject
 	@Nullable
 	private Client client;
-
-	@Getter
-	@Setter
-	private boolean overlayOutdated;
 
 	public static void main(String[] args) throws Exception
 	{

--- a/runelite-client/src/main/java/net/runelite/client/callback/Hooks.java
+++ b/runelite-client/src/main/java/net/runelite/client/callback/Hooks.java
@@ -42,7 +42,6 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
-import net.runelite.api.IndexDataBase;
 import net.runelite.api.MainBufferProvider;
 import net.runelite.api.RenderOverview;
 import net.runelite.api.WorldMapManager;
@@ -273,13 +272,6 @@ public class Hooks implements Callbacks
 	public void keyTyped(KeyEvent keyEvent)
 	{
 		keyManager.processKeyTyped(keyEvent);
-	}
-
-	@Override
-	public void overlayLoadFailed(IndexDataBase indexDataBase, int archiveId, int fileId)
-	{
-		RuneLite runeLite = injector.getInstance(RuneLite.class);
-		runeLite.setOverlayOutdated(true);
 	}
 
 	@Override

--- a/runelite-client/src/main/java/net/runelite/client/plugins/zoom/ZoomPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/zoom/ZoomPlugin.java
@@ -32,7 +32,6 @@ import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.events.ConfigChanged;
 import net.runelite.api.events.ScriptCallbackEvent;
-import net.runelite.client.RuneLite;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
@@ -46,9 +45,6 @@ import net.runelite.client.plugins.PluginDescriptor;
 @Slf4j
 public class ZoomPlugin extends Plugin
 {
-	@Inject
-	private RuneLite runeLite;
-
 	@Inject
 	private Client client;
 
@@ -64,7 +60,7 @@ public class ZoomPlugin extends Plugin
 	@Subscribe
 	public void onScriptEvent(ScriptCallbackEvent event)
 	{
-		if (runeLite.isOverlayOutdated())
+		if (client.getIndexScripts().isOverlayOutdated())
 		{
 			// if any cache overlay fails to load then assume at least one of the zoom scripts is outdated
 			// and prevent zoom extending entirely.

--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSIndexDataBaseMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSIndexDataBaseMixin.java
@@ -32,8 +32,8 @@ import com.google.common.io.CharStreams;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import net.runelite.api.hooks.Callbacks;
 import net.runelite.api.mixins.Copy;
+import net.runelite.api.mixins.Inject;
 import net.runelite.api.mixins.Mixin;
 import net.runelite.api.mixins.Replace;
 import net.runelite.api.mixins.Shadow;
@@ -48,6 +48,16 @@ public abstract class RSIndexDataBaseMixin implements RSIndexDataBase
 {
 	@Shadow("clientInstance")
 	private static RSClient client;
+
+	@Inject
+	private boolean overlayOutdated;
+
+	@Inject
+	@Override
+	public boolean isOverlayOutdated()
+	{
+		return overlayOutdated;
+	}
 
 	@Copy("getConfigData")
 	abstract byte[] rs$getConfigData(int archiveId, int fileId);
@@ -117,9 +127,7 @@ public abstract class RSIndexDataBaseMixin implements RSIndexDataBase
 
 			log.warn("Mismatch in overlaid cache archive hash for {}/{}: {} != {}",
 				indexData.getIndex(), archiveId, replaceHash, rsHash);
-
-			Callbacks callbacks = client.getCallbacks();
-			callbacks.overlayLoadFailed(this, archiveId, fileId);
+			overlayOutdated = true;
 		}
 		catch (IOException ex)
 		{

--- a/runescape-api/src/main/java/net/runelite/rs/api/RSClient.java
+++ b/runescape-api/src/main/java/net/runelite/rs/api/RSClient.java
@@ -323,6 +323,10 @@ public interface RSClient extends RSGameEngine, Client
 	@Override
 	RSIndexDataBase getIndexSprites();
 
+	@Import("indexScripts")
+	@Override
+	RSIndexDataBase getIndexScripts();
+
 	@Import("widgetFlags")
 	@Override
 	RSHashTable getWidgetFlags();


### PR DESCRIPTION
Instead of creating new callback and then simply setting boolean on
RuneLite to dump it somewhere, expose this boolean from IndexDatabase
and remove injection of RuneLite.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>