### PR TITLE
Remove unnecessary headers from plugin panels

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
@@ -62,7 +62,6 @@ import javax.swing.JTextArea;
 import javax.swing.ScrollPaneConstants;
 import javax.swing.SpinnerModel;
 import javax.swing.SpinnerNumberModel;
-import javax.swing.SwingConstants;
 import javax.swing.border.EmptyBorder;
 import javax.swing.event.ChangeListener;
 import javax.swing.event.DocumentEvent;
@@ -251,11 +250,6 @@ public class ConfigPanel extends PluginPanel
 
 		topPanel.removeAll();
 		mainPanel.removeAll();
-
-		JLabel title = new JLabel("Configuration", SwingConstants.LEFT);
-		title.setForeground(Color.WHITE);
-
-		topPanel.add(title, BorderLayout.NORTH);
 		topPanel.add(searchBar, BorderLayout.CENTER);
 
 		onSearchBarChanged();

--- a/runelite-client/src/main/java/net/runelite/client/plugins/feed/FeedPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/feed/FeedPanel.java
@@ -79,11 +79,6 @@ class FeedPanel extends PluginPanel
 	private static final int CONTENT_WIDTH = 148;
 	private static final int TIME_WIDTH = 20;
 
-	/**
-	 * Holds all feed items.
-	 */
-	private final JPanel feedContainer = new JPanel();
-
 	private static final Comparator<FeedItem> FEED_ITEM_COMPARATOR = (o1, o2) ->
 	{
 		if (o1.getType() != o2.getType())
@@ -112,22 +107,13 @@ class FeedPanel extends PluginPanel
 
 	FeedPanel(FeedConfig config, Supplier<FeedResult> feedSupplier)
 	{
+		super(true);
 		this.config = config;
 		this.feedSupplier = feedSupplier;
 
 		setBorder(new EmptyBorder(10, 10, 10, 10));
 		setBackground(ColorScheme.DARK_GRAY_COLOR);
-		setLayout(new BorderLayout());
-
-		feedContainer.setLayout(new GridLayout(0, 1, 0, 4));
-		feedContainer.setBackground(ColorScheme.DARK_GRAY_COLOR);
-
-		JLabel title = new JLabel("News feed");
-		title.setBorder(new EmptyBorder(0, 0, 9, 0));
-		title.setForeground(Color.WHITE);
-
-		add(title, BorderLayout.NORTH);
-		add(feedContainer, BorderLayout.CENTER);
+		setLayout(new GridLayout(0, 1, 0, 4));
 	}
 
 	void rebuildFeed()
@@ -141,7 +127,7 @@ class FeedPanel extends PluginPanel
 
 		SwingUtilities.invokeLater(() ->
 		{
-			feedContainer.removeAll();
+			removeAll();
 
 			feed.getItems()
 				.stream()
@@ -301,7 +287,7 @@ class FeedPanel extends PluginPanel
 			}
 		});
 
-		feedContainer.add(avatarAndRight);
+		add(avatarAndRight);
 	}
 
 	private String durationToString(Duration duration)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/kourendlibrary/KourendLibraryPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/kourendlibrary/KourendLibraryPanel.java
@@ -27,7 +27,6 @@ package net.runelite.client.plugins.kourendlibrary;
 
 import com.google.inject.Inject;
 import java.awt.BorderLayout;
-import java.awt.Color;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.event.MouseAdapter;
@@ -40,13 +39,10 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.inject.Singleton;
-import javax.swing.BorderFactory;
-import javax.swing.GroupLayout;
 import javax.swing.ImageIcon;
-import javax.swing.JLabel;
+import javax.swing.JButton;
 import javax.swing.JPanel;
 import javax.swing.SwingUtilities;
-import javax.swing.border.CompoundBorder;
 import javax.swing.border.EmptyBorder;
 import net.runelite.client.ui.ColorScheme;
 import net.runelite.client.ui.PluginPanel;
@@ -72,8 +68,7 @@ class KourendLibraryPanel extends PluginPanel
 
 	void init()
 	{
-		GroupLayout layout = new GroupLayout(this);
-		setLayout(layout);
+		setLayout(new BorderLayout(0, 5));
 		setBorder(new EmptyBorder(10, 10, 10, 10));
 		setBackground(ColorScheme.DARK_GRAY_COLOR);
 
@@ -94,7 +89,7 @@ class KourendLibraryPanel extends PluginPanel
 				c.gridy++;
 			});
 
-		JLabel reset = new JLabel(RESET_ICON);
+		JButton reset = new JButton("Reset", RESET_ICON);
 		reset.addMouseListener(new MouseAdapter()
 		{
 			@Override
@@ -112,28 +107,8 @@ class KourendLibraryPanel extends PluginPanel
 			}
 		});
 
-		JPanel header = new JPanel();
-		header.setLayout(new BorderLayout());
-		header.setBorder(new CompoundBorder(
-			BorderFactory.createMatteBorder(0, 0, 1, 0, new Color(58, 58, 58)),
-			BorderFactory.createEmptyBorder(0, 0, 10, 0)));
-
-		JLabel pluginName = new JLabel("Kourend Library Plugin");
-		pluginName.setForeground(Color.WHITE);
-
-		header.add(reset, BorderLayout.EAST);
-		header.add(pluginName, BorderLayout.CENTER);
-
-		layout.setHorizontalGroup(layout.createParallelGroup()
-			.addComponent(books)
-			.addComponent(header)
-		);
-		layout.setVerticalGroup(layout.createSequentialGroup()
-			.addComponent(header)
-			.addGap(10)
-			.addComponent(books)
-		);
-
+		add(reset, BorderLayout.NORTH);
+		add(books, BorderLayout.CENTER);
 		update();
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/notes/NotesPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/notes/NotesPanel.java
@@ -25,25 +25,21 @@
  */
 package net.runelite.client.plugins.notes;
 
-import java.awt.Color;
+import java.awt.BorderLayout;
+import java.awt.event.FocusEvent;
+import java.awt.event.FocusListener;
 import javax.swing.BorderFactory;
-import javax.swing.JTextArea;
-import javax.swing.JLabel;
 import javax.swing.JPanel;
+import javax.swing.JTextArea;
 import javax.swing.border.EmptyBorder;
 import javax.swing.text.BadLocationException;
 import javax.swing.text.Document;
-
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.client.ui.ColorScheme;
 import net.runelite.client.ui.PluginPanel;
 
-import java.awt.BorderLayout;
-import java.awt.event.FocusEvent;
-import java.awt.event.FocusListener;
-
 @Slf4j
-public class NotesPanel extends PluginPanel
+class NotesPanel extends PluginPanel
 {
 	private final JTextArea notesEditor = new JTextArea();
 
@@ -57,12 +53,6 @@ public class NotesPanel extends PluginPanel
 		setLayout(new BorderLayout());
 		setBorder(BorderFactory.createEmptyBorder(10, 10, 10, 10));
 		setBackground(ColorScheme.DARK_GRAY_COLOR);
-
-		final JLabel notesHeader = new JLabel("Notes");
-		notesHeader.setForeground(Color.WHITE);
-		notesHeader.setBorder(new EmptyBorder(1, 0, 10, 0));
-
-		add(notesHeader, BorderLayout.NORTH);
 
 		notesEditor.setLineWrap(true);
 		notesEditor.setWrapStyleWord(true);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/SkillCalculatorPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/SkillCalculatorPanel.java
@@ -26,12 +26,10 @@
 
 package net.runelite.client.plugins.skillcalculator;
 
-import java.awt.Color;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.GridLayout;
 import javax.swing.ImageIcon;
-import javax.swing.JLabel;
 import javax.swing.JScrollPane;
 import javax.swing.border.EmptyBorder;
 import net.runelite.api.Client;
@@ -71,15 +69,7 @@ class SkillCalculatorPanel extends PluginPanel
 		final UICalculatorInputArea uiInput = new UICalculatorInputArea();
 		uiInput.setBorder(new EmptyBorder(15, 0, 15, 0));
 		uiInput.setBackground(ColorScheme.DARK_GRAY_COLOR);
-
 		uiCalculator = new SkillCalculator(client, uiInput);
-
-		JLabel title = new JLabel("Skilling Calculator");
-		title.setBorder(new EmptyBorder(0, 1, 8, 0));
-		title.setForeground(Color.WHITE);
-
-		add(title, c);
-		c.gridy++;
 
 		add(tabGroup, c);
 		c.gridy++;


### PR DESCRIPTION
Now all plugin panels have tooltips so the headers are not necessary and
most of plugins do not have them already.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>

Preview:
![screenie4](https://user-images.githubusercontent.com/5115805/43657081-03bd8074-9755-11e8-94a7-1bbce3853861.png)
![screenie3](https://user-images.githubusercontent.com/5115805/43657083-041e12ae-9755-11e8-92cf-b158cb004267.png)
![screenie2](https://user-images.githubusercontent.com/5115805/43657085-0474fab0-9755-11e8-8167-b78edc4bcae9.png)
![screenie](https://user-images.githubusercontent.com/5115805/43657086-04e7bf32-9755-11e8-8800-686451977754.png)
