### PR TITLE
Add tablet creation animation to idle notifier

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/AnimationID.java
+++ b/runelite-api/src/main/java/net/runelite/api/AnimationID.java
@@ -120,6 +120,7 @@ public final class AnimationID
 	public static final int MAGIC_CHARGING_ORBS = 726;
 	public static final int MAGIC_LUNAR_STRING_JEWELRY = 4412;
 	public static final int MAGIC_LUNAR_BAKE_PIE = 4413;
+	public static final int MAGIC_MAKE_TABLET = 4068;
 	public static final int BURYING_BONES = 827;
 	public static final int USING_GILDED_ALTAR = 3705;
 	public static final int LOOKING_INTO = 832;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
@@ -188,6 +188,7 @@ public class IdleNotifierPlugin extends Plugin
 			case MAGIC_CHARGING_ORBS:
 			case MAGIC_LUNAR_STRING_JEWELRY:
 			case MAGIC_LUNAR_BAKE_PIE:
+			case MAGIC_MAKE_TABLET:
 			/* Prayer */
 			case USING_GILDED_ALTAR:
 				resetTimers();


### PR DESCRIPTION
Added tablet creation animation to the idle notifier. Tested with b2p, 3 enchants and 3 teleports.
All had same animation.

Resolves #4694