### PR TITLE
Ground item timers

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
@@ -49,26 +49,6 @@ public interface GroundItemsConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "privateDurationColor",
-		name = "Private timer color",
-		description = "Configures the color for the private duration timer"
-	)
-	default Color privateDurationColor()
-	{
-		return Color.GREEN;
-	}
-
-	@ConfigItem(
-		keyName = "publicDurationColor",
-		name = "Public timer color",
-		description = "Configures the color for the public duration timer"
-	)
-	default Color publicDurationColor()
-	{
-		return Color.YELLOW;
-	}
-
-	@ConfigItem(
 		keyName = "highlightedItems",
 		name = "Highlighted Items",
 		description = "Configures specifically highlighted ground items. Format: (item), (item)",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
@@ -32,10 +32,42 @@ import net.runelite.client.config.ConfigItem;
 import net.runelite.client.plugins.grounditems.config.ItemHighlightMode;
 import net.runelite.client.plugins.grounditems.config.MenuHighlightMode;
 import net.runelite.client.plugins.grounditems.config.PriceDisplayMode;
+import net.runelite.client.plugins.grounditems.config.TimerDisplayMode;
 
 @ConfigGroup("grounditems")
 public interface GroundItemsConfig extends Config
 {
+
+	@ConfigItem(
+		keyName = "showGroundItemDuration",
+		name = "Show time remaining",
+		description = "Turn on a countdown timer to show how long an item will remain on the ground"
+	)
+	default TimerDisplayMode showGroundItemDuration()
+	{
+		return TimerDisplayMode.HOTKEY_PRESSED;
+	}
+
+	@ConfigItem(
+		keyName = "privateDurationColor",
+		name = "Private timer color",
+		description = "Configures the color for the private duration timer"
+	)
+	default Color privateDurationColor()
+	{
+		return Color.GREEN;
+	}
+
+	@ConfigItem(
+		keyName = "publicDurationColor",
+		name = "Public timer color",
+		description = "Configures the color for the public duration timer"
+	)
+	default Color publicDurationColor()
+	{
+		return Color.YELLOW;
+	}
+
 	@ConfigItem(
 		keyName = "highlightedItems",
 		name = "Highlighted Items",
@@ -115,16 +147,16 @@ public interface GroundItemsConfig extends Config
 	{
 		return false;
 	}
-	
+
 	@ConfigItem(
 		keyName = "highlightTiles",
 		name = "Highlight Tiles",
 		description = "Configures whether or not to highlight tiles containing ground items",
 		position = 6
 	)
-	default boolean highlightTiles() 
-	{ 
-		return false; 
+	default boolean highlightTiles()
+	{
+		return false;
 	}
 
 	@ConfigItem(

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
@@ -76,7 +76,6 @@ public class GroundItemsOverlay extends Overlay
 	private static final Color PUBLIC_TIMER_COLOR = Color.YELLOW;
 	private static final Color PRIVATE_TIMER_COLOR = Color.GREEN;
 	private static final Color PUBLIC_WARNING_TIMER_COLOR = Color.RED;
-	private static final Color PRIVATE_WARNING_TIMER_COLOR = Color.ORANGE;
 	private final Client client;
 	private final GroundItemsPlugin plugin;
 	private final GroundItemsConfig config;
@@ -399,7 +398,7 @@ public class GroundItemsOverlay extends Overlay
 		progressPieComponent.setDiameter(TIMER_OVERLAY_DIAMETER);
 
 		int x = (int) location.getX() - TIMER_OVERLAY_DIAMETER;
-		int y = (int) location.getY() - TIMER_OVERLAY_DIAMETER;
+		int y = (int) location.getY() - TIMER_OVERLAY_DIAMETER / 2;
 
 		progressPieComponent.setPosition(new Point(x, y));
 
@@ -420,20 +419,20 @@ public class GroundItemsOverlay extends Overlay
 				timeLeftRelative = getTimeLeftRelative(millisOnGround, PUBLIC_ITEM_DURATION_MILLIS);
 			}
 
-			if(timeLeftRelative < WARNING_THRESHOLD){
-			 	fillColor = PUBLIC_WARNING_TIMER_COLOR;
-			} else{
+			if (timeLeftRelative < WARNING_THRESHOLD)
+			{
+				fillColor = PUBLIC_WARNING_TIMER_COLOR;
+			}
+			else
+			{
 				fillColor = PUBLIC_TIMER_COLOR;
 			}
 		}
 		else
 		{
 			timeLeftRelative = getTimeLeftRelative(millisOnGround, item.getDurationMillis());
-			if(timeLeftRelative < WARNING_THRESHOLD){
-				fillColor = PRIVATE_WARNING_TIMER_COLOR;
-			} else{
-				fillColor = PRIVATE_TIMER_COLOR;
-			}
+			fillColor = PRIVATE_TIMER_COLOR;
+
 		}
 
 		// don't draw timer for any permanently spawned items or broken edge cases

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
@@ -72,6 +72,11 @@ public class GroundItemsOverlay extends Overlay
 	private static final int RECTANGLE_SIZE = 8;
 	private static final int TIMER_OVERLAY_DIAMETER = 10;
 	private static final int PUBLIC_ITEM_DURATION_MILLIS = 60000;
+	private static final float WARNING_THRESHOLD = 0.25f;
+	private static final Color PUBLIC_TIMER_COLOR = Color.YELLOW;
+	private static final Color PRIVATE_TIMER_COLOR = Color.GREEN;
+	private static final Color PUBLIC_WARNING_TIMER_COLOR = Color.RED;
+	private static final Color PRIVATE_WARNING_TIMER_COLOR = Color.ORANGE;
 	private final Client client;
 	private final GroundItemsPlugin plugin;
 	private final GroundItemsConfig config;
@@ -334,14 +339,10 @@ public class GroundItemsOverlay extends Overlay
 
 				// Draw highlight box
 				drawRectangle(graphics, itemHighlightBox, topItem && mouseInHighlightBox ? Color.GREEN : color, highlighted != null, false);
-
-				if (config.showGroundItemDuration() == TimerDisplayMode.HOTKEY_PRESSED)
-				{
-					drawTimerOverlay(graphics, new java.awt.Point(textX, textY), item);
-				}
 			}
 
-			if (config.showGroundItemDuration() == TimerDisplayMode.ALWAYS)
+			if (config.showGroundItemDuration() == TimerDisplayMode.ALWAYS
+				|| (config.showGroundItemDuration() == TimerDisplayMode.HOTKEY_PRESSED && plugin.isHotKeyPressed()))
 			{
 				drawTimerOverlay(graphics, new java.awt.Point(textX, textY), item);
 			}
@@ -398,7 +399,7 @@ public class GroundItemsOverlay extends Overlay
 		progressPieComponent.setDiameter(TIMER_OVERLAY_DIAMETER);
 
 		int x = (int) location.getX() - TIMER_OVERLAY_DIAMETER;
-		int y = (int) location.getY() - TIMER_OVERLAY_DIAMETER / 2;
+		int y = (int) location.getY() - TIMER_OVERLAY_DIAMETER;
 
 		progressPieComponent.setPosition(new Point(x, y));
 
@@ -412,18 +413,27 @@ public class GroundItemsOverlay extends Overlay
 			if (item.isOwnedByPlayer())
 			{
 				timeLeftRelative = getTimeLeftRelative(millisOnGround - PUBLIC_ITEM_DURATION_MILLIS, PUBLIC_ITEM_DURATION_MILLIS);
+
 			}
 			else
 			{
 				timeLeftRelative = getTimeLeftRelative(millisOnGround, PUBLIC_ITEM_DURATION_MILLIS);
 			}
 
-			fillColor = config.publicDurationColor();
+			if(timeLeftRelative < WARNING_THRESHOLD){
+			 	fillColor = PUBLIC_WARNING_TIMER_COLOR;
+			} else{
+				fillColor = PUBLIC_TIMER_COLOR;
+			}
 		}
 		else
 		{
 			timeLeftRelative = getTimeLeftRelative(millisOnGround, item.getDurationMillis());
-			fillColor = config.privateDurationColor();
+			if(timeLeftRelative < WARNING_THRESHOLD){
+				fillColor = PRIVATE_WARNING_TIMER_COLOR;
+			} else{
+				fillColor = PRIVATE_TIMER_COLOR;
+			}
 		}
 
 		// don't draw timer for any permanently spawned items or broken edge cases

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
@@ -335,12 +335,14 @@ public class GroundItemsOverlay extends Overlay
 				// Draw highlight box
 				drawRectangle(graphics, itemHighlightBox, topItem && mouseInHighlightBox ? Color.GREEN : color, highlighted != null, false);
 
-				if(config.showGroundItemDuration() == TimerDisplayMode.HOTKEY_PRESSED){
-					drawTimerOverlay(graphics,  new java.awt.Point(textX, textY), item);
+				if (config.showGroundItemDuration() == TimerDisplayMode.HOTKEY_PRESSED)
+				{
+					drawTimerOverlay(graphics, new java.awt.Point(textX, textY), item);
 				}
 			}
 
-			if(config.showGroundItemDuration() == TimerDisplayMode.ALWAYS){
+			if (config.showGroundItemDuration() == TimerDisplayMode.ALWAYS)
+			{
 				drawTimerOverlay(graphics, new java.awt.Point(textX, textY), item);
 			}
 
@@ -425,7 +427,8 @@ public class GroundItemsOverlay extends Overlay
 		}
 
 		// don't draw timer for any permanently spawned items or broken edge cases
-		if(timeLeftRelative > 1 || timeLeftRelative < 0){
+		if (timeLeftRelative > 1 || timeLeftRelative < 0)
+		{
 			return;
 		}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
@@ -270,15 +270,20 @@ public class GroundItemsPlugin extends Plugin
 		final ItemComposition itemComposition = itemManager.getItemComposition(itemId);
 		final int realItemId = itemComposition.getNote() != -1 ? itemComposition.getLinkedNoteId() : itemId;
 		final int alchPrice = Math.round(itemComposition.getPrice() * HIGH_ALCHEMY_CONSTANT);
-		int durationMillis = NORMAL_DURATION_MILLIS;
+		int durationMillis;
 		if (client.isInInstancedRegion())
 		{
 			durationMillis = INSTANCE_DURATION_MILLIS;
 		}
-		if (!itemComposition.isTradeable())
+		else if (!itemComposition.isTradeable() && realItemId != COINS)
 		{
 			durationMillis = UNTRADEABLE_DURATION_MILLIS;
 		}
+		else
+		{
+			durationMillis = NORMAL_DURATION_MILLIS;
+		}
+
 
 		WorldPoint playerLocation = client.getLocalPlayer().getWorldLocation();
 
@@ -293,7 +298,7 @@ public class GroundItemsPlugin extends Plugin
 			.tradeable(itemComposition.isTradeable())
 			.droppedInstant(Instant.now())
 			.durationMillis(durationMillis)
-			.isAlwaysPrivate(client.isInInstancedRegion() || !itemComposition.isTradeable())
+			.isAlwaysPrivate(client.isInInstancedRegion() || (!itemComposition.isTradeable() && realItemId != COINS))
 			.isOwnedByPlayer(tile.getWorldLocation().equals(playerLocation))
 			.build();
 
@@ -302,8 +307,6 @@ public class GroundItemsPlugin extends Plugin
 		{
 			groundItem.setHaPrice(1);
 			groundItem.setGePrice(1);
-			groundItem.setAlwaysPrivate(false);
-			groundItem.setDurationMillis(NORMAL_DURATION_MILLIS);
 		}
 		else
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
@@ -109,9 +109,6 @@ public class GroundItemsPlugin extends Plugin
 	private static final int DEATH_DURATION_MILLIS = 60 * 60 * 1000;
 	private static final int NORMAL_DURATION_MILLIS = 60 * 1000;
 
-	@Getter
-	private final Map<GroundItem.GroundItemKey, GroundItem> collectedGroundItems = new LinkedHashMap<>();
-	private final Map<Integer, Color> priceChecks = new LinkedHashMap<>();
 	@Getter(AccessLevel.PACKAGE)
 	@Setter(AccessLevel.PACKAGE)
 	private Map.Entry<Rectangle, GroundItem> textBoxBounds;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/config/TimerDisplayMode.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/config/TimerDisplayMode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Tomas Slusny <slusnucky@gmail.com>
+ * Copyright (c) 2018
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -22,47 +22,24 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package net.runelite.client.plugins.grounditems;
+package net.runelite.client.plugins.grounditems.config;
 
-import java.time.Instant;
-import lombok.Builder;
-import lombok.Data;
-import lombok.Value;
-import net.runelite.api.coords.WorldPoint;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
-@Data
-@Builder
-class GroundItem
+@Getter
+@RequiredArgsConstructor
+public enum TimerDisplayMode
 {
-	private int id;
-	private int itemId;
-	private String name;
-	private int quantity;
-	private WorldPoint location;
-	private int height;
-	private int haPrice;
-	private int gePrice;
-	private int offset;
-	private boolean tradeable;
-	private int durationMillis;
-	private boolean isAlwaysPrivate;
-	private boolean isOwnedByPlayer;
-	private Instant droppedInstant;
+	ALWAYS("Always"),
+	HOTKEY_PRESSED("When Hotkey Pressed"),
+	NEVER("Never");
 
-	int getHaPrice()
-	{
-		return haPrice * quantity;
-	}
+	private final String name;
 
-	int getGePrice()
+	@Override
+	public String toString()
 	{
-		return gePrice * quantity;
-	}
-
-	@Value
-	static class GroundItemKey
-	{
-		private int itemId;
-		private WorldPoint location;
+		return name;
 	}
 }


### PR DESCRIPTION
Closes #2383 and closes #4535 and closes #4609 

Known issues:
* items already on ground when you see them assume the public timer starts from 60 seconds and may disappear before that
* wilderness not handled correctly
* items dropped under you by another player are assumed to be yours so show the private timer instead of the public timer
* items dropped on player death show the 1 min public timer instead of a 1 hour timer
* stacks of items that are dropped one at a time (e.g when shift dropping an inventory) are not handled well