### PR TITLE
Option to switch notation for groud objects

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
@@ -32,6 +32,7 @@ import net.runelite.client.config.ConfigItem;
 import net.runelite.client.plugins.grounditems.config.ItemHighlightMode;
 import net.runelite.client.plugins.grounditems.config.MenuHighlightMode;
 import net.runelite.client.plugins.grounditems.config.PriceDisplayMode;
+import net.runelite.client.plugins.grounditems.config.QuantityDisplayMode;
 
 @ConfigGroup("grounditems")
 public interface GroundItemsConfig extends Config
@@ -128,10 +129,21 @@ public interface GroundItemsConfig extends Config
 	}
 
 	@ConfigItem(
+			keyName = "quantityDisplayMode",
+			name = "Quantity Display Mode",
+			description = "Configures what quantity notation you would like",
+			position = 7
+	)
+	default QuantityDisplayMode quantityDisplayMode()
+	{
+		return QuantityDisplayMode.PARENTHESES;
+	}
+
+	@ConfigItem(
 		keyName = "priceDisplayMode",
 		name = "Price Display Mode",
 		description = "Configures what price types are shown alongside of ground item name",
-		position = 7
+		position = 8
 	)
 	default PriceDisplayMode priceDisplayMode()
 	{
@@ -142,7 +154,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "itemHighlightMode",
 		name = "Item Highlight Mode",
 		description = "Configures how ground items will be highlighted",
-		position = 8
+		position = 9
 	)
 	default ItemHighlightMode itemHighlightMode()
 	{
@@ -153,7 +165,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "menuHighlightMode",
 		name = "Menu Highlight Mode",
 		description = "Configures what to highlight in right-click menu",
-		position = 9
+		position = 10
 	)
 	default MenuHighlightMode menuHighlightMode()
 	{
@@ -164,7 +176,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "highlightOverValue2",
 		name = "Highlight > Value",
 		description = "Configures highlighted ground items over either GE or HA value",
-		position = 10
+		position = 11
 	)
 	default int getHighlightOverValue()
 	{
@@ -175,7 +187,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "hideUnderValue",
 		name = "Hide < Value",
 		description = "Configures hidden ground items under both GE and HA value",
-		position = 11
+		position = 12
 	)
 	default int getHideUnderValue()
 	{
@@ -186,7 +198,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "defaultColor",
 		name = "Default items color",
 		description = "Configures the color for default, non-highlighted items",
-		position = 12
+		position = 13
 	)
 	default Color defaultColor()
 	{
@@ -197,7 +209,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "highlightedColor",
 		name = "Highlighted items color",
 		description = "Configures the color for highlighted items",
-		position = 13
+		position = 14
 	)
 	default Color highlightedColor()
 	{
@@ -208,7 +220,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "hiddenColor",
 		name = "Hidden items color",
 		description = "Configures the color for hidden items in right-click menu and when holding ALT",
-		position = 14
+		position = 15
 	)
 	default Color hiddenColor()
 	{
@@ -219,7 +231,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "lowValueColor",
 		name = "Low value items color",
 		description = "Configures the color for low value items",
-		position = 15
+		position = 16
 	)
 	default Color lowValueColor()
 	{
@@ -230,7 +242,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "lowValuePrice",
 		name = "Low value price",
 		description = "Configures the start price for low value items",
-		position = 16
+		position = 17
 	)
 	default int lowValuePrice()
 	{
@@ -241,7 +253,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "mediumValueColor",
 		name = "Medium value items color",
 		description = "Configures the color for medium value items",
-		position = 17
+		position = 18
 	)
 	default Color mediumValueColor()
 	{
@@ -252,7 +264,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "mediumValuePrice",
 		name = "Medium value price",
 		description = "Configures the start price for medium value items",
-		position = 18
+		position = 19
 	)
 	default int mediumValuePrice()
 	{
@@ -263,7 +275,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "highValueColor",
 		name = "High value items color",
 		description = "Configures the color for high value items",
-		position = 19
+		position = 20
 	)
 	default Color highValueColor()
 	{
@@ -274,7 +286,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "highValuePrice",
 		name = "High value price",
 		description = "Configures the start price for high value items",
-		position = 20
+		position = 21
 	)
 	default int highValuePrice()
 	{
@@ -285,7 +297,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "insaneValueColor",
 		name = "Insane value items color",
 		description = "Configures the color for insane value items",
-		position = 21
+		position = 22
 	)
 	default Color insaneValueColor()
 	{
@@ -296,7 +308,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "insaneValuePrice",
 		name = "Insane value price",
 		description = "Configures the start price for insane value items",
-		position = 22
+		position = 23
 	)
 	default int insaneValuePrice()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
@@ -45,6 +45,7 @@ import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.coords.WorldPoint;
 import static net.runelite.client.plugins.grounditems.config.ItemHighlightMode.MENU;
 import net.runelite.client.plugins.grounditems.config.PriceDisplayMode;
+import net.runelite.client.plugins.grounditems.config.QuantityDisplayMode;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
@@ -214,11 +215,16 @@ public class GroundItemsOverlay extends Overlay
 				{
 					itemStringBuilder.append(" (Lots!)");
 				}
-				else
+				if (config.quantityDisplayMode() == QuantityDisplayMode.PARENTHESES)
 				{
 					itemStringBuilder.append(" (")
 						.append(StackFormatter.quantityToStackSize(item.getQuantity()))
 						.append(")");
+				}
+				else
+				{
+					itemStringBuilder.append(" x ")
+							.append(StackFormatter.quantityToStackSize(item.getQuantity()));
 				}
 			}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/config/QuantityDisplayMode.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/config/QuantityDisplayMode.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2018, Tomas Slusny <slusnucky@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.grounditems.config;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum QuantityDisplayMode
+{
+	PARENTHESES("Parentheses"),
+	X("X");
+
+	private final String name;
+
+	@Override
+	public String toString()
+	{
+		return name;
+	}
+}


### PR DESCRIPTION
Addresses #4715 
Adds the option to switch from the format of Coins (100) to Coins x 100 for ground items

![paren](https://user-images.githubusercontent.com/21043852/43682667-b4c2e0ae-9849-11e8-9b61-f8c2cfd78ac5.png)
![x](https://user-images.githubusercontent.com/21043852/43682669-b6e644fc-9849-11e8-8cd1-16be853957a4.png)
