### PR TITLE
Price tooltip hidden when in bank

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemprices/ItemPricesOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemprices/ItemPricesOverlay.java
@@ -113,8 +113,13 @@ class ItemPricesOverlay extends Overlay
 							return null;
 						}
 						// intentional fallthrough
-					case WidgetID.BANK_GROUP_ID:
 					case WidgetID.BANK_INVENTORY_GROUP_ID:
+						if (config.hideInventory())
+						{
+							return null;
+						}
+						// intentional fallthrough
+					case WidgetID.BANK_GROUP_ID:
 						// Make tooltip
 						final String text = makeValueTooltip(menuEntry);
 						if (text != null)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemprices/ItemPricesOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemprices/ItemPricesOverlay.java
@@ -107,13 +107,8 @@ class ItemPricesOverlay extends Overlay
 				// Item tooltip values
 				switch (groupId)
 				{
-					case WidgetID.INVENTORY_GROUP_ID:
-						if (config.hideInventory())
-						{
-							return null;
-						}
-						// intentional fallthrough
 					case WidgetID.BANK_INVENTORY_GROUP_ID:
+					case WidgetID.INVENTORY_GROUP_ID:
 						if (config.hideInventory())
 						{
 							return null;


### PR DESCRIPTION
When the item price plugin is enabled and the setting hide in inventory is set the price tooltip is now also hidden in the invertory when the bank is open. Which fixes issue #4713