### PR TITLE
Set the default off all entity hider options to false

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/entityhider/EntityHiderConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/entityhider/EntityHiderConfig.java
@@ -40,7 +40,7 @@ public interface EntityHiderConfig extends Config
 	)
 	default boolean hidePlayers()
 	{
-		return true;
+		return false;
 	}
 
 	@ConfigItem(
@@ -51,7 +51,7 @@ public interface EntityHiderConfig extends Config
 	)
 	default boolean hidePlayers2D()
 	{
-		return true;
+		return false;
 	}
 
 	@ConfigItem(


### PR DESCRIPTION
Helps the people who turn on random plugins and don't know why they suddenly can't see any other players.