### PR TITLE
Update chatbox widget IDs

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/widgets/WidgetID.java
+++ b/runelite-api/src/main/java/net/runelite/api/widgets/WidgetID.java
@@ -340,10 +340,10 @@ public class WidgetID
 
 	static class Chatbox
 	{
-		static final int CHATBOX_MESSAGES = 30;
-		static final int CHATBOX_REPORT_TEXT = 29;
-		static final int CHATBOX_FRAME = 1;
-		static final int CHATBOX_BUTTONS = 2;
+		static final int CHATBOX_BUTTONS = 1;
+		static final int CHATBOX_REPORT_TEXT = 28;
+		static final int CHATBOX_FRAME = 29;
+		static final int CHATBOX_MESSAGES = 47;
 	}
 
 	static class Prayer


### PR DESCRIPTION
With the latest update some widget IDs changed. Report button was no longer showing any text set from the Report Button plugin.