### PR TITLE
Move greater demon cannon spot to better location

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonSpots.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonSpots.java
@@ -41,7 +41,7 @@ public enum CannonSpots
 	ELVES(new WorldPoint(2044, 4635, 0)),
 	SUQAHS(new WorldPoint(2114, 3943, 0)),
 	TROLLS(new WorldPoint(2405, 3857, 0)),
-	GREATER_DEMONS(new WorldPoint(1438, 10089, 2)),
+	GREATER_DEMONS(new WorldPoint(1435, 10086, 2)),
 	BRINE_RAT(new WorldPoint(2707, 10132, 0)),
 	DAGGANOTH(new WorldPoint(2524, 10020, 0)),
 	DARK_BEAST(new WorldPoint(1992, 4655, 0)),


### PR DESCRIPTION
Implements #4753 

Moved the cannon spot to a more efficient location

![greater](https://user-images.githubusercontent.com/21043852/43807318-e5399772-9a75-11e8-8fe7-a8894f21b343.png)
