### PR TITLE
Add persistant flashing option to notifier

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/Notifier.java
+++ b/runelite-client/src/main/java/net/runelite/client/Notifier.java
@@ -144,7 +144,7 @@ public class Notifier
 
 		if (runeLiteConfig.enableFlashNotification() == FlashingType.PERSISTANT)
 		{
-			if (client.getMouseCurrentButton() == 1 || client.getGameState() != GameState.LOGGED_IN)
+			if (client.getMouseCurrentButton() != 0 || client.getGameState() != GameState.LOGGED_IN)
 			{
 				flashStart = null;
 				return;

--- a/runelite-client/src/main/java/net/runelite/client/Notifier.java
+++ b/runelite-client/src/main/java/net/runelite/client/Notifier.java
@@ -46,6 +46,7 @@ import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
 import net.runelite.api.GameState;
+import net.runelite.client.config.FlashingType;
 import net.runelite.client.config.RuneLiteConfig;
 import net.runelite.client.ui.ClientUI;
 import net.runelite.client.util.ColorUtil;
@@ -128,7 +129,7 @@ public class Notifier
 			}
 		}
 
-		if (runeLiteConfig.enableFlashNotification())
+		if (runeLiteConfig.enableFlashNotification() != FlashingType.OFF)
 		{
 			flashStart = Instant.now();
 		}
@@ -141,6 +142,15 @@ public class Notifier
 			return;
 		}
 
+		if (runeLiteConfig.enableFlashNotification() == FlashingType.PERSISTANT)
+		{
+			if (client.getMouseCurrentButton() == 1 || client.getGameState() != GameState.LOGGED_IN)
+			{
+				flashStart = null;
+				return;
+			}
+		}
+
 		if (client.getGameCycle() % 40 >= 20)
 		{
 			return;
@@ -151,7 +161,7 @@ public class Notifier
 		graphics.fill(new Rectangle(client.getCanvas().getSize()));
 		graphics.setColor(color);
 
-		if (Instant.now().minusMillis(FLASH_DURATION).isAfter(flashStart))
+		if (runeLiteConfig.enableFlashNotification() == FlashingType.DEFAULT && Instant.now().minusMillis(FLASH_DURATION).isAfter(flashStart))
 		{
 			flashStart = null;
 		}

--- a/runelite-client/src/main/java/net/runelite/client/config/FlashingType.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/FlashingType.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2018, Matt <https://github.com/ms813>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.config;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum FlashingType
+{
+	DEFAULT("Default"),
+	PERSISTANT("Persistant"),
+	OFF("Off");
+
+	private final String type;
+
+	@Override
+	public String toString()
+	{
+		return type;
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/config/RuneLiteConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/RuneLiteConfig.java
@@ -169,9 +169,9 @@ public interface RuneLiteConfig extends Config
 		description = "Flashes the game frame as a notification",
 		position = 24
 	)
-	default boolean enableFlashNotification()
+	default FlashingType enableFlashNotification()
 	{
-		return false;
+		return FlashingType.OFF;
 	}
 
 	@ConfigItem(


### PR DESCRIPTION
Currently, I like to use flashing notifications to grab my attention when my character is idle, however due to how short the default flashing notifier lasts, I may miss it due to not paying attention.

This PR adds the option for the flashing notification to keep flashing until the user clicks on the game. 

![image](https://user-images.githubusercontent.com/37294123/43891856-badab846-9c0d-11e8-802b-42bfbf02d8ab.png)
