### PR TITLE
ItemPricesPlugin: Add Hide Tooltips in Bank Config

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemprices/ItemPricesConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemprices/ItemPricesConfig.java
@@ -65,12 +65,23 @@ public interface ItemPricesConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "hideInventory",
-		name = "Hide Tooltips on Inventory Items",
-		description = "Tooltips should be hidden on items in the inventory",
-		position = 4
+			keyName = "hideInventory",
+			name = "Hide Tooltips on Inventory Items",
+			description = "Tooltips should be hidden on items in the inventory",
+			position = 4
 	)
 	default boolean hideInventory()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+			keyName = "hideBank",
+			name = "Hide Tooltips on Bank Items",
+			description = "Tooltips should be hidden on items in the bank",
+			position = 5
+	)
+	default boolean hideBank()
 	{
 		return true;
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemprices/ItemPricesOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemprices/ItemPricesOverlay.java
@@ -111,20 +111,34 @@ class ItemPricesOverlay extends Overlay
 						{
 							return null;
 						}
-						// intentional fallthrough
+
+						addValueTooltip(menuEntry);
+						break;
 					case WidgetID.BANK_GROUP_ID:
 					case WidgetID.BANK_INVENTORY_GROUP_ID:
-						// Make tooltip
-						final String text = makeValueTooltip(menuEntry);
-						if (text != null)
+						if (config.hideBank())
 						{
-							tooltipManager.add(new Tooltip(ColorUtil.prependColorTag(text, new Color(238, 238, 238))));
+							return null;
 						}
+
+						addValueTooltip(menuEntry);
 						break;
 				}
 				break;
 		}
 		return null;
+	}
+
+	private void addValueTooltip(MenuEntry menuEntry)
+	{
+		final String text = makeValueTooltip(menuEntry);
+
+		if (text == null || text.isEmpty())
+		{
+			return;
+		}
+
+		tooltipManager.add(new Tooltip(ColorUtil.prependColorTag(text, new Color(238, 238, 238))));
 	}
 
 	private String makeValueTooltip(MenuEntry menuEntry)


### PR DESCRIPTION
Allow the ability to hide value tooltips when in the bank within the "Item Prices" plugin.

Closes #4713