### PR TITLE
GroundItems: Add Item Quantity Display Configurability

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
@@ -30,6 +30,7 @@ import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
 import net.runelite.client.plugins.grounditems.config.ItemHighlightMode;
+import net.runelite.client.plugins.grounditems.config.ItemQuantityMode;
 import net.runelite.client.plugins.grounditems.config.MenuHighlightMode;
 import net.runelite.client.plugins.grounditems.config.PriceDisplayMode;
 
@@ -139,10 +140,21 @@ public interface GroundItemsConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "itemQuantityMode",
+		name = "Item Quantity Mode",
+		description = "Configures how ground item quantities will be described",
+		position = 8
+	)
+	default ItemQuantityMode itemQuantityMode()
+	{
+		return ItemQuantityMode.PARENTHESIS;
+	}
+
+	@ConfigItem(
 		keyName = "itemHighlightMode",
 		name = "Item Highlight Mode",
 		description = "Configures how ground items will be highlighted",
-		position = 8
+		position = 9
 	)
 	default ItemHighlightMode itemHighlightMode()
 	{
@@ -153,7 +165,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "menuHighlightMode",
 		name = "Menu Highlight Mode",
 		description = "Configures what to highlight in right-click menu",
-		position = 9
+		position = 10
 	)
 	default MenuHighlightMode menuHighlightMode()
 	{
@@ -164,7 +176,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "highlightOverValue2",
 		name = "Highlight > Value",
 		description = "Configures highlighted ground items over either GE or HA value",
-		position = 10
+		position = 11
 	)
 	default int getHighlightOverValue()
 	{
@@ -175,7 +187,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "hideUnderValue",
 		name = "Hide < Value",
 		description = "Configures hidden ground items under both GE and HA value",
-		position = 11
+		position = 12
 	)
 	default int getHideUnderValue()
 	{
@@ -186,7 +198,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "defaultColor",
 		name = "Default items color",
 		description = "Configures the color for default, non-highlighted items",
-		position = 12
+		position = 13
 	)
 	default Color defaultColor()
 	{
@@ -197,7 +209,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "highlightedColor",
 		name = "Highlighted items color",
 		description = "Configures the color for highlighted items",
-		position = 13
+		position = 14
 	)
 	default Color highlightedColor()
 	{
@@ -208,7 +220,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "hiddenColor",
 		name = "Hidden items color",
 		description = "Configures the color for hidden items in right-click menu and when holding ALT",
-		position = 14
+		position = 15
 	)
 	default Color hiddenColor()
 	{
@@ -219,7 +231,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "lowValueColor",
 		name = "Low value items color",
 		description = "Configures the color for low value items",
-		position = 15
+		position = 16
 	)
 	default Color lowValueColor()
 	{
@@ -230,7 +242,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "lowValuePrice",
 		name = "Low value price",
 		description = "Configures the start price for low value items",
-		position = 16
+		position = 17
 	)
 	default int lowValuePrice()
 	{
@@ -241,7 +253,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "mediumValueColor",
 		name = "Medium value items color",
 		description = "Configures the color for medium value items",
-		position = 17
+		position = 18
 	)
 	default Color mediumValueColor()
 	{
@@ -252,7 +264,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "mediumValuePrice",
 		name = "Medium value price",
 		description = "Configures the start price for medium value items",
-		position = 18
+		position = 19
 	)
 	default int mediumValuePrice()
 	{
@@ -263,7 +275,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "highValueColor",
 		name = "High value items color",
 		description = "Configures the color for high value items",
-		position = 19
+		position = 20
 	)
 	default Color highValueColor()
 	{
@@ -274,7 +286,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "highValuePrice",
 		name = "High value price",
 		description = "Configures the start price for high value items",
-		position = 20
+		position = 21
 	)
 	default int highValuePrice()
 	{
@@ -285,7 +297,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "insaneValueColor",
 		name = "Insane value items color",
 		description = "Configures the color for insane value items",
-		position = 21
+		position = 22
 	)
 	default Color insaneValueColor()
 	{
@@ -296,7 +308,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "insaneValuePrice",
 		name = "Insane value price",
 		description = "Configures the start price for insane value items",
-		position = 22
+		position = 23
 	)
 	default int insaneValuePrice()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
@@ -44,6 +44,7 @@ import net.runelite.api.Point;
 import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.coords.WorldPoint;
 import static net.runelite.client.plugins.grounditems.config.ItemHighlightMode.MENU;
+import net.runelite.client.plugins.grounditems.config.ItemQuantityMode;
 import net.runelite.client.plugins.grounditems.config.PriceDisplayMode;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
@@ -61,7 +62,7 @@ public class GroundItemsOverlay extends Overlay
 	private static final int OFFSET_Z = 20;
 	// The game won't send anything higher than this value to the plugin -
 	// so we replace any item quantity higher with "Lots" instead.
-	private static final int MAX_QUANTITY = 65535;
+	protected static final int MAX_QUANTITY = 65535;
 	// The 15 pixel gap between each drawn ground item.
 	private static final int STRING_GAP = 15;
 	// Size of the hidden/highlight boxes
@@ -210,15 +211,22 @@ public class GroundItemsOverlay extends Overlay
 
 			if (item.getQuantity() > 1)
 			{
-				if (item.getQuantity() >= MAX_QUANTITY)
+				String amount = "Lots!";
+				if (item.getQuantity() < MAX_QUANTITY)
 				{
-					itemStringBuilder.append(" (Lots!)");
+					amount = StackFormatter.quantityToStackSize(item.getQuantity());
+				}
+
+				if (config.itemQuantityMode() == ItemQuantityMode.PARENTHESIS)
+				{
+					itemStringBuilder.append(" (")
+						.append(amount)
+						.append(")");
 				}
 				else
 				{
-					itemStringBuilder.append(" (")
-						.append(StackFormatter.quantityToStackSize(item.getQuantity()))
-						.append(")");
+					itemStringBuilder.append(" x ")
+						.append(amount);
 				}
 			}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
@@ -70,12 +70,14 @@ import net.runelite.client.input.MouseManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import static net.runelite.client.plugins.grounditems.config.ItemHighlightMode.OVERLAY;
+import net.runelite.client.plugins.grounditems.config.ItemQuantityMode;
 import net.runelite.client.plugins.grounditems.config.MenuHighlightMode;
 import static net.runelite.client.plugins.grounditems.config.MenuHighlightMode.BOTH;
 import static net.runelite.client.plugins.grounditems.config.MenuHighlightMode.NAME;
 import static net.runelite.client.plugins.grounditems.config.MenuHighlightMode.OPTION;
 import net.runelite.client.ui.overlay.OverlayManager;
 import net.runelite.client.util.ColorUtil;
+import net.runelite.client.util.StackFormatter;
 
 @PluginDescriptor(
 	name = "Ground Items",
@@ -391,7 +393,26 @@ public class GroundItemsPlugin extends Plugin
 
 			if (config.showMenuItemQuantities() && itemComposition.isStackable() && quantity > 1)
 			{
-				lastEntry.setTarget(lastEntry.getTarget() + " (" + quantity + ")");
+				String amount = "Lots!";
+				if (quantity < GroundItemsOverlay.MAX_QUANTITY)
+				{
+					amount = StackFormatter.quantityToStackSize(quantity);
+				}
+
+				StringBuilder itemStringBuilder = new StringBuilder(lastEntry.getTarget());
+				if (config.itemQuantityMode() == ItemQuantityMode.PARENTHESIS)
+				{
+					itemStringBuilder.append(" (")
+							.append(amount)
+							.append(")");
+				}
+				else
+				{
+					itemStringBuilder.append(" x ")
+							.append(amount);
+				}
+
+				lastEntry.setTarget(itemStringBuilder.toString());
 			}
 
 			client.setMenuEntries(menuEntries);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/config/ItemQuantityMode.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/config/ItemQuantityMode.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2018, Connor <contact@connor-parks.email>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package net.runelite.client.plugins.grounditems.config;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ItemQuantityMode
+{
+	PARENTHESIS("Parenthesis"),
+	TIMES("Times");
+
+	private final String name;
+
+	@Override
+	public String toString()
+	{
+		return name;
+	}
+}


### PR DESCRIPTION
Allows toggling between `Item x amount` and `Item (amount)` for the "Ground Items" plugin. Defaults to parenthesis as that is the current behaviour.

Closes #4715