### PR TITLE
GroundItems: Add Highlight Untradeable Items Config

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
@@ -95,10 +95,21 @@ public interface GroundItemsConfig extends Config
 	}
 
 	@ConfigItem(
+			keyName = "highlightUntradables",
+			name = "Highlight untradables",
+			description = "Configures whether or not untradeable items should always be highlighted",
+			position = 4
+	)
+	default boolean highlightUntradables()
+	{
+		return true;
+	}
+
+	@ConfigItem(
 		keyName = "showMenuItemQuantities",
 		name = "Show Menu Item Quantities",
 		description = "Configures whether or not to show the item quantities in the menu",
-		position = 4
+		position = 5
 	)
 	default boolean showMenuItemQuantities()
 	{
@@ -109,7 +120,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "recolorMenuHiddenItems",
 		name = "Recolor Menu Hidden Items",
 		description = "Configures whether or not hidden items in right click menu will be recolored",
-		position = 5
+		position = 6
 	)
 	default boolean recolorMenuHiddenItems()
 	{
@@ -120,7 +131,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "highlightTiles",
 		name = "Highlight Tiles",
 		description = "Configures whether or not to highlight tiles containing ground items",
-		position = 6
+		position = 7
 	)
 	default boolean highlightTiles() 
 	{ 
@@ -131,7 +142,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "priceDisplayMode",
 		name = "Price Display Mode",
 		description = "Configures what price types are shown alongside of ground item name",
-		position = 7
+		position = 8
 	)
 	default PriceDisplayMode priceDisplayMode()
 	{
@@ -142,7 +153,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "itemHighlightMode",
 		name = "Item Highlight Mode",
 		description = "Configures how ground items will be highlighted",
-		position = 8
+		position = 9
 	)
 	default ItemHighlightMode itemHighlightMode()
 	{
@@ -153,7 +164,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "menuHighlightMode",
 		name = "Menu Highlight Mode",
 		description = "Configures what to highlight in right-click menu",
-		position = 9
+		position = 10
 	)
 	default MenuHighlightMode menuHighlightMode()
 	{
@@ -164,7 +175,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "highlightOverValue2",
 		name = "Highlight > Value",
 		description = "Configures highlighted ground items over either GE or HA value",
-		position = 10
+		position = 11
 	)
 	default int getHighlightOverValue()
 	{
@@ -175,7 +186,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "hideUnderValue",
 		name = "Hide < Value",
 		description = "Configures hidden ground items under both GE and HA value",
-		position = 11
+		position = 12
 	)
 	default int getHideUnderValue()
 	{
@@ -186,7 +197,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "defaultColor",
 		name = "Default items color",
 		description = "Configures the color for default, non-highlighted items",
-		position = 12
+		position = 13
 	)
 	default Color defaultColor()
 	{
@@ -197,7 +208,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "highlightedColor",
 		name = "Highlighted items color",
 		description = "Configures the color for highlighted items",
-		position = 13
+		position = 14
 	)
 	default Color highlightedColor()
 	{
@@ -208,7 +219,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "hiddenColor",
 		name = "Hidden items color",
 		description = "Configures the color for hidden items in right-click menu and when holding ALT",
-		position = 14
+		position = 15
 	)
 	default Color hiddenColor()
 	{
@@ -219,7 +230,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "lowValueColor",
 		name = "Low value items color",
 		description = "Configures the color for low value items",
-		position = 15
+		position = 16
 	)
 	default Color lowValueColor()
 	{
@@ -230,7 +241,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "lowValuePrice",
 		name = "Low value price",
 		description = "Configures the start price for low value items",
-		position = 16
+		position = 17
 	)
 	default int lowValuePrice()
 	{
@@ -241,7 +252,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "mediumValueColor",
 		name = "Medium value items color",
 		description = "Configures the color for medium value items",
-		position = 17
+		position = 18
 	)
 	default Color mediumValueColor()
 	{
@@ -252,7 +263,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "mediumValuePrice",
 		name = "Medium value price",
 		description = "Configures the start price for medium value items",
-		position = 18
+		position = 19
 	)
 	default int mediumValuePrice()
 	{
@@ -263,7 +274,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "highValueColor",
 		name = "High value items color",
 		description = "Configures the color for high value items",
-		position = 19
+		position = 20
 	)
 	default Color highValueColor()
 	{
@@ -274,7 +285,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "highValuePrice",
 		name = "High value price",
 		description = "Configures the start price for high value items",
-		position = 20
+		position = 21
 	)
 	default int highValuePrice()
 	{
@@ -285,7 +296,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "insaneValueColor",
 		name = "Insane value items color",
 		description = "Configures the color for insane value items",
-		position = 21
+		position = 22
 	)
 	default Color insaneValueColor()
 	{
@@ -296,7 +307,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "insaneValuePrice",
 		name = "Insane value price",
 		description = "Configures the start price for insane value items",
-		position = 22
+		position = 23
 	)
 	default int insaneValuePrice()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
@@ -171,7 +171,7 @@ public class GroundItemsOverlay extends Overlay
 				continue;
 			}
 
-			final Color highlighted = plugin.getHighlighted(item.getName(), item.getGePrice(), item.getHaPrice());
+			final Color highlighted = plugin.getHighlighted(item.getName(), item.getGePrice(), item.getHaPrice(), item.isTradeable());
 			final Color hidden = plugin.getHidden(item.getName(), item.getGePrice(), item.getHaPrice(), item.isTradeable());
 
 			if (highlighted == null && !plugin.isHotKeyPressed())

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
@@ -369,7 +369,7 @@ public class GroundItemsPlugin extends Plugin
 			final int haPrice = Math.round(itemComposition.getPrice() * HIGH_ALCHEMY_CONSTANT) * quantity;
 			final int gePrice = quantity * price;
 			final Color hidden = getHidden(itemComposition.getName(), gePrice, haPrice, itemComposition.isTradeable());
-			final Color highlighted = getHighlighted(itemComposition.getName(), gePrice, haPrice);
+			final Color highlighted = getHighlighted(itemComposition.getName(), gePrice, haPrice, itemComposition.isTradeable());
 			final Color color = getItemColor(highlighted, hidden);
 			final boolean canBeRecolored = highlighted != null || (hidden != null && config.recolorMenuHiddenItems());
 
@@ -423,7 +423,7 @@ public class GroundItemsPlugin extends Plugin
 		config.setHighlightedItem(COMMA_JOINER.join(highlightedItemSet));
 	}
 
-	Color getHighlighted(String item, int gePrice, int haPrice)
+	Color getHighlighted(String item, int gePrice, int haPrice, boolean tradeable)
 	{
 		if (TRUE.equals(highlightedItems.getUnchecked(item)))
 		{
@@ -434,6 +434,11 @@ public class GroundItemsPlugin extends Plugin
 		if (TRUE.equals(hiddenItems.getUnchecked(item)))
 		{
 			return null;
+		}
+
+		if (config.highlightUntradables() && !tradeable)
+		{
+			return config.highlightedColor();
 		}
 
 		for (Map.Entry<Integer, Color> entry : priceChecks.entrySet())


### PR DESCRIPTION
Allow the ability to specifically highlight all untradeable items to avoid losing out on them if you forget to add them to the "highlighted items" list whilst having "show highlighted items only" enabled.

Closes #4779