### PR TITLE
Use working sprite for puzzle solver arrows

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/puzzlesolver/PuzzleSolverOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/puzzlesolver/PuzzleSolverOverlay.java
@@ -42,7 +42,7 @@ import net.runelite.api.GameState;
 import net.runelite.api.InventoryID;
 import net.runelite.api.Item;
 import net.runelite.api.ItemContainer;
-import static net.runelite.api.SpriteID.MINIMAP_DESTINATION_FLAG;
+import net.runelite.api.SpriteID;
 import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.game.SpriteManager;
@@ -81,6 +81,7 @@ public class PuzzleSolverOverlay extends Overlay
 	private Future<?> solverFuture;
 	private int[] cachedItems;
 
+	private BufferedImage downArrow;
 	private BufferedImage upArrow;
 	private BufferedImage leftArrow;
 	private BufferedImage rightArrow;
@@ -425,7 +426,11 @@ public class PuzzleSolverOverlay extends Overlay
 
 	private BufferedImage getDownArrow()
 	{
-		return spriteManager.getSprite(MINIMAP_DESTINATION_FLAG, 1);
+		if (downArrow == null)
+		{
+			downArrow = ImageUtil.resizeImage(spriteManager.getSprite(SpriteID.MINIMAP_GUIDE_ARROW_YELLOW, 0), 16, 16);
+		}
+		return downArrow;
 	}
 
 	private BufferedImage getUpArrow()


### PR DESCRIPTION
For some reason 422.1 do not works for puzzle solver arrows (throws NPE,
e.g is non-existant) so just use different sprite (BH) and scale it
down.

![preview](https://cdn.discordapp.com/attachments/419891709883973642/477200197110464545/screenie.png)

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>