### PR TITLE
time tracking: fix detection of state for seaweed patches

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/TimeTrackingPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/TimeTrackingPlugin.java
@@ -186,7 +186,7 @@ public class TimeTrackingPlugin extends Plugin
 		WorldPoint loc = lastTickLocation;
 		lastTickLocation = client.getLocalPlayer().getWorldLocation();
 
-		if (loc == null || loc.getPlane() != 0 || loc.getRegionID() != lastTickLocation.getRegionID())
+		if (loc == null || loc.getRegionID() != lastTickLocation.getRegionID())
 		{
 			return;
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/hunter/BirdHouseTracker.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/hunter/BirdHouseTracker.java
@@ -126,7 +126,7 @@ public class BirdHouseTracker
 	{
 		boolean changed = false;
 
-		if (FOSSIL_ISLAND_REGIONS.contains(location.getRegionID()))
+		if (FOSSIL_ISLAND_REGIONS.contains(location.getRegionID()) && location.getPlane() == 0)
 		{
 			final Map<BirdHouseSpace, BirdHouseData> newData = new HashMap<>();
 			final long currentTime = Instant.now().getEpochSecond();


### PR DESCRIPTION
Remove the plane check for the farming tracker, since seaweed patches are found on plane 1, not 0.

Fixes #4807