### PR TITLE
DiscordPlugin: Add Woodcutting Guild to Activities

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordGameEventType.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordGameEventType.java
@@ -137,7 +137,7 @@ enum DiscordGameEventType
 	CITY_UZER("Uzer" , DiscordAreaType.CITIES, 13872),
 	CITY_VARROCK("Varrock" , DiscordAreaType.CITIES, 12596, 12597, 12598, 12852, 12853, 12854, 13108, 13109, 13110),
 	CITY_WITCHHAVEN("Witchaven" , DiscordAreaType.CITIES, 10803),
-	CITY_WOODCUTTING_GUILD("Woodcutting Guild", DiscordAreaType.CITIES, 6454, 6198),
+	CITY_WOODCUTTING_GUILD("Woodcutting Guild", DiscordAreaType.CITIES, 6454, 6198, 6298),
 	CITY_YANILLE("Yanille" , DiscordAreaType.CITIES, 10288, 10032),
 	CITY_ZANARIS("Zanaris" , DiscordAreaType.CITIES, 9285, 9541, 9540, 9797),
 	CITY_ZULANDRA("Zul-Andra" , DiscordAreaType.CITIES, 8751),

--- a/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordGameEventType.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordGameEventType.java
@@ -137,6 +137,7 @@ enum DiscordGameEventType
 	CITY_UZER("Uzer" , DiscordAreaType.CITIES, 13872),
 	CITY_VARROCK("Varrock" , DiscordAreaType.CITIES, 12596, 12597, 12598, 12852, 12853, 12854, 13108, 13109, 13110),
 	CITY_WITCHHAVEN("Witchaven" , DiscordAreaType.CITIES, 10803),
+	CITY_WOODCUTTING_GUILD("Woodcutting Guild", DiscordAreaType.CITIES, 6454, 6198),
 	CITY_YANILLE("Yanille" , DiscordAreaType.CITIES, 10288, 10032),
 	CITY_ZANARIS("Zanaris" , DiscordAreaType.CITIES, 9285, 9541, 9540, 9797),
 	CITY_ZULANDRA("Zul-Andra" , DiscordAreaType.CITIES, 8751),


### PR DESCRIPTION
Add the Woodcutting Guild location to the activities on the "Discord" plugin.

Concerns #4218