### PR TITLE
[WIP] Add Loot Tracker Group View

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerConfig.java
@@ -40,6 +40,6 @@ public interface LootTrackerConfig extends Config
 	)
 	default boolean groupLoot()
 	{
-		return false;
+		return true;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerConfig.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2018, Psikoi <https://github.com/psikoi>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.loottracker;
+
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+
+@ConfigGroup("loottracker")
+public interface LootTrackerConfig extends Config
+{
+	String GROUP_KEY = "loottracker";
+
+	@ConfigItem(
+		keyName = "groupView",
+		name = "Group loot by NPC/Activity",
+		description = "Groups the loot received from a NPC or Activity into one single log."
+	)
+	default boolean groupLoot()
+	{
+		return false;
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerEntry.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerEntry.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2018, Psikoi <https://github.com/psikoi>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.loottracker;
+
+import lombok.Value;
+
+@Value
+class LootTrackerEntry
+{
+	private final String title;
+	private final String subTitle;
+	private final long timestamp;
+	private final LootTrackerItemEntry[] items;
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerLog.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerLog.java
@@ -31,7 +31,6 @@ import java.awt.Color;
 import java.awt.GridLayout;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
@@ -49,6 +48,7 @@ class LootTrackerLog extends JPanel
 	private static final int ITEMS_PER_ROW = 5;
 
 	private final JLabel priceLabel = new JLabel();
+	private final JLabel subTitleLabel = new JLabel();
 	private final JPanel itemContainer = new JPanel();
 
 	private final ArrayList<LootTrackerItemEntry> entries = new ArrayList<>();
@@ -65,7 +65,7 @@ class LootTrackerLog extends JPanel
 		setLayout(new BorderLayout(0, 1));
 		setBorder(new EmptyBorder(5, 0, 0, 0));
 
-		final JPanel logTitle = new JPanel(new BorderLayout(5, 0));
+		final JPanel logTitle = new JPanel(new BorderLayout(3, 0));
 		logTitle.setBorder(new EmptyBorder(7, 7, 7, 7));
 		logTitle.setBackground(ColorScheme.DARKER_GRAY_COLOR.darker());
 
@@ -78,7 +78,7 @@ class LootTrackerLog extends JPanel
 		// If we have subtitle, add it
 		if (!Strings.isNullOrEmpty(subTitle))
 		{
-			final JLabel subTitleLabel = new JLabel(subTitle);
+			subTitleLabel.setText(subTitle);
 			subTitleLabel.setFont(FontManager.getRunescapeSmallFont());
 			subTitleLabel.setForeground(ColorScheme.LIGHT_GRAY_COLOR);
 			logTitle.add(subTitleLabel, BorderLayout.CENTER);
@@ -167,6 +167,11 @@ class LootTrackerLog extends JPanel
 		if (totalPrice > 0)
 		{
 			priceLabel.setText(StackFormatter.quantityToStackSize(totalPrice) + " gp");
+		}
+
+		if (totalKills > 1)
+		{
+			subTitleLabel.setText(" x " + totalKills);
 		}
 
 		rebuildItemContainer();

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerLog.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerLog.java
@@ -40,12 +40,12 @@ import net.runelite.client.ui.FontManager;
 import net.runelite.client.util.StackFormatter;
 
 @Getter
-class LootTrackerBox extends JPanel
+class LootTrackerLog extends JPanel
 {
 	private static final int ITEMS_PER_ROW = 5;
 	private final long totalPrice;
 
-	LootTrackerBox(final ItemManager itemManager, final String title, final String subTitle, final LootTrackerItemEntry[] items)
+	LootTrackerLog(final ItemManager itemManager, final String title, final String subTitle, final LootTrackerItemEntry[] items)
 	{
 		setLayout(new BorderLayout(0, 1));
 		setBorder(new EmptyBorder(5, 0, 0, 0));

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPanel.java
@@ -137,14 +137,14 @@ class LootTrackerPanel extends PluginPanel
 		remove(errorPanel);
 		overallPanel.setVisible(true);
 
-		// Create box
+		// Create log
 		final String subTitle = actorLevel > -1 ? "(lvl-" + actorLevel + ")" : "";
-		final LootTrackerBox box = new LootTrackerBox(itemManager, eventName, subTitle, items);
-		logsContainer.add(box, 0);
+		final LootTrackerLog log = new LootTrackerLog(itemManager, eventName, subTitle, items);
+		logsContainer.add(log, 0);
 		logsContainer.repaint();
 
 		// Update overall
-		overallGp += box.getTotalPrice();
+		overallGp += log.getTotalPrice();
 		overallKills += 1;
 		updateOverall();
 
@@ -152,10 +152,10 @@ class LootTrackerPanel extends PluginPanel
 		final JMenuItem reset = new JMenuItem("Reset");
 		reset.addActionListener(e ->
 		{
-			overallGp -= box.getTotalPrice();
+			overallGp -= log.getTotalPrice();
 			overallKills -= 1;
 			updateOverall();
-			logsContainer.remove(box);
+			logsContainer.remove(log);
 			logsContainer.repaint();
 		});
 
@@ -163,7 +163,7 @@ class LootTrackerPanel extends PluginPanel
 		final JPopupMenu popupMenu = new JPopupMenu();
 		popupMenu.setBorder(new EmptyBorder(5, 5, 5, 5));
 		popupMenu.add(reset);
-		box.setComponentPopupMenu(popupMenu);
+		log.setComponentPopupMenu(popupMenu);
 	}
 
 	private void updateOverall()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
@@ -26,6 +26,7 @@
 package net.runelite.client.plugins.loottracker;
 
 import com.google.common.eventbus.Subscribe;
+import com.google.inject.Provides;
 import java.awt.image.BufferedImage;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -48,6 +49,7 @@ import net.runelite.api.SpriteID;
 import net.runelite.api.events.ChatMessage;
 import net.runelite.api.events.WidgetLoaded;
 import net.runelite.api.widgets.WidgetID;
+import net.runelite.client.config.ConfigManager;
 import net.runelite.client.events.NpcLootReceived;
 import net.runelite.client.events.PlayerLootReceived;
 import net.runelite.client.game.ItemManager;
@@ -84,6 +86,9 @@ public class LootTrackerPlugin extends Plugin
 	@Inject
 	private Client client;
 
+	@Inject
+	private LootTrackerConfig config;
+
 	private LootTrackerPanel panel;
 	private NavigationButton navButton;
 	private String eventType;
@@ -115,6 +120,12 @@ public class LootTrackerPlugin extends Plugin
 		}
 
 		return list;
+	}
+
+	@Provides
+	LootTrackerConfig provideConfig(ConfigManager configManager)
+	{
+		return configManager.getConfig(LootTrackerConfig.class);
 	}
 
 	@Override

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
@@ -160,7 +160,7 @@ public class LootTrackerPlugin extends Plugin
 		final String name = npc.getName();
 		final int combat = npc.getCombatLevel();
 		final LootTrackerItemEntry[] entries = buildEntries(stack(items));
-		SwingUtilities.invokeLater(() -> panel.addLog(name, combat, entries));
+		SwingUtilities.invokeLater(() -> panel.addLog(name, combat, entries, config.groupLoot()));
 	}
 
 	@Subscribe
@@ -171,7 +171,7 @@ public class LootTrackerPlugin extends Plugin
 		final String name = player.getName();
 		final int combat = player.getCombatLevel();
 		final LootTrackerItemEntry[] entries = buildEntries(stack(items));
-		SwingUtilities.invokeLater(() -> panel.addLog(name, combat, entries));
+		SwingUtilities.invokeLater(() -> panel.addLog(name, combat, entries, config.groupLoot()));
 	}
 
 	@Subscribe
@@ -214,7 +214,7 @@ public class LootTrackerPlugin extends Plugin
 		if (!items.isEmpty())
 		{
 			final LootTrackerItemEntry[] entries = buildEntries(stack(items));
-			SwingUtilities.invokeLater(() -> panel.addLog(eventType, -1, entries));
+			SwingUtilities.invokeLater(() -> panel.addLog(eventType, -1, entries, config.groupLoot()));
 		}
 		else
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
@@ -47,6 +47,7 @@ import net.runelite.api.NPC;
 import net.runelite.api.Player;
 import net.runelite.api.SpriteID;
 import net.runelite.api.events.ChatMessage;
+import net.runelite.api.events.ConfigChanged;
 import net.runelite.api.events.WidgetLoaded;
 import net.runelite.api.widgets.WidgetID;
 import net.runelite.client.config.ConfigManager;
@@ -120,6 +121,19 @@ public class LootTrackerPlugin extends Plugin
 		}
 
 		return list;
+	}
+
+	@Subscribe
+	public void onConfigChanged(ConfigChanged ev)
+	{
+		if (!LootTrackerConfig.GROUP_KEY.equals(ev.getGroup()))
+		{
+			return;
+		}
+
+		if(ev.getKey().equals("groupView")){
+			panel.reconstruct(Boolean.parseBoolean(ev.getNewValue()));
+		}
 	}
 
 	@Provides
@@ -262,7 +276,7 @@ public class LootTrackerPlugin extends Plugin
 		{
 			final ItemComposition itemComposition = itemManager.getItemComposition(itemStack.getId());
 			final int realItemId = itemComposition.getNote() != -1 ? itemComposition.getLinkedNoteId() : itemStack.getId();
-			final long price = (long)itemManager.getItemPrice(realItemId) * (long)itemStack.getQuantity();
+			final long price = (long) itemManager.getItemPrice(realItemId) * (long) itemStack.getQuantity();
 
 			return new LootTrackerItemEntry(
 				itemStack.getId(),


### PR DESCRIPTION
Adds a new viewing mode, grouped view. This mode groups the loot by NPC/Event name and can be toggled on/off in the plugin configs.

![](https://i.gyazo.com/6f6fe784374612ce7d4e515a27f3348c.png)

TO-DO: Figure out how to reassemble single logs from a grouped log.

