### PR TITLE
player indicators: Fix menu coloring

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsPlugin.java
@@ -162,8 +162,9 @@ public class PlayerIndicatorsPlugin extends Plugin
 
 				if (color != null && config.colorPlayerMenu())
 				{
-					// strip out existing tags (color, etc.)
-					String target = Text.removeTags(lastEntry.getTarget());
+					// strip out existing player color tag
+					// menu targets are formatted: "<col=ffffff>Zezima<col=ff0000>  (level-126)"
+					String target = Text.removeTagsOfType(lastEntry.getTarget(), "col", 1);
 					lastEntry.setTarget(ColorUtil.prependColorTag(target, color));
 				}
 

--- a/runelite-client/src/main/java/net/runelite/client/util/Text.java
+++ b/runelite-client/src/main/java/net/runelite/client/util/Text.java
@@ -32,6 +32,8 @@ import java.util.regex.Pattern;
  */
 public class Text
 {
+	private static final String TAG_START = "</?";
+	private static final String TAG_END = "([ =].*?)?>";
 	private static final Pattern TAG_REGEXP = Pattern.compile("<[^>]*>");
 
 	/**
@@ -45,4 +47,34 @@ public class Text
 		return TAG_REGEXP.matcher(str).replaceAll("");
 	}
 
+	/**
+	 * Removes all tags of a given name from the given str.
+	 *
+	 * @param str The string to remove tags from.
+	 * @param tag The tag type to be removed from the given string.
+	 * @return    The given string, with any tags matching the given tag name removed.
+	 */
+	public static String removeTagsOfType(String str, String tag)
+	{
+		return removeTagsOfType(str, tag, Integer.MAX_VALUE);
+	}
+
+	/**
+	 * Removes a limited number of tags of a given name from the given str.
+	 *
+	 * @param str   The string to remove tags from.
+	 * @param tag   The tag type to be removed from the given string.
+	 * @param limit The maximum number of the given tag to be removed.
+	 * @return      The given string, with at most `limit` tags matching the given tag name removed.
+	 */
+	public static String removeTagsOfType(String str, String tag, int limit)
+	{
+		final Pattern tagRegexp = Pattern.compile(TAG_START + tag + TAG_END);
+		String out = str;
+		for (int i = 0; i < limit && tagRegexp.matcher(out).find(); i++)
+		{
+			out = tagRegexp.matcher(out).replaceFirst("");
+		}
+		return out;
+	}
 }

--- a/runelite-client/src/test/java/net/runelite/client/util/TextTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/util/TextTest.java
@@ -42,4 +42,27 @@ public class TextTest
 		assertEquals("Remove no tags", Text.removeTags("Remove no tags"));
 	}
 
+	@Test
+	public void removeTagsOfType()
+	{
+		// removeTagsOfType(String str, String tag)
+		assertEquals("Test", Text.removeTagsOfType("<col=FFFFFF>Test</col>", "col"));
+		assertEquals("Test", Text.removeTagsOfType("<col=FFFFFF>Test", "col"));
+		assertEquals("Test", Text.removeTagsOfType("Test</col>", "col"));
+		assertEquals("<img=1>Test", Text.removeTagsOfType("<img=1><s>Test</s>", "s"));
+		assertEquals("<s>Test</s>", Text.removeTagsOfType("<img=1><s>Test</s>", "img"));
+		assertEquals("<img=2>Zezima  (level-126)", Text.removeTagsOfType("<col=ffffff><img=2>Zezima<col=00ffff>  (level-126)", "col"));
+		assertEquals("<colrandomtext test>", Text.removeTagsOfType("<colrandomtext test>", "col"));
+		assertEquals("", Text.removeTagsOfType("<col randomtext test>", "col"));
+		assertEquals("Not so much.", Text.removeTagsOfType("<col=FFFFFF This is a very special message.</col>Not so much.", "col"));
+		assertEquals("Use Item -> Man", Text.removeTagsOfType("Use Item -> Man", "col"));
+		assertEquals("a < b", Text.removeTagsOfType("a < b", "col"));
+		assertEquals("Remove no tags", Text.removeTagsOfType("Remove no tags", "col"));
+
+		// removeTagsOfType(String str, String tag, int limit)
+		assertEquals("Test</col>", Text.removeTagsOfType("<col=FFFFFF>Test</col>", "col", 1));
+		assertEquals("Test", Text.removeTagsOfType("<col=FFFFFF>Test</col>", "col", 2));
+		assertEquals("Test", Text.removeTagsOfType("<col=FFFFFF>Test</col>", "col", 3));
+		assertEquals("<img=2>Zezima<col=00ffff>  (level-126)", Text.removeTagsOfType("<col=ffffff><img=2>Zezima<col=00ffff>  (level-126)", "col", 1));
+	}
 }


### PR DESCRIPTION
This fixes a regression from a9d29a7 where instead of coloring only a
player's name with the "Colorize player menu" option enabled, the full
menu entry (name and level) was colored instead.

Fixes runelite/runelite#4820