### PR TITLE
Fix exp tracker UI margin incosistency

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpPanel.java
@@ -67,7 +67,7 @@ class XpPanel extends PluginPanel
 	{
 		super();
 
-		setBorder(new EmptyBorder(10, 6, 10, 6));
+		setBorder(new EmptyBorder(6, 6, 6, 6));
 		setBackground(ColorScheme.DARK_GRAY_COLOR);
 		setLayout(new BorderLayout());
 


### PR DESCRIPTION
This reduces the top margin of the exp tracker UI to match the other sides and the similarly designed Loot Tracker.

Before:
![](https://i.gyazo.com/cf99315cac181f95f2d4d85e0a0af16c.png)

After:
![](https://i.gyazo.com/ebb9a25d6f6c21464b4fcc9d2664545c.png)