### PR TITLE
runelite-client: Don't consume keyReleased events

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/util/HotkeyListener.java
+++ b/runelite-client/src/main/java/net/runelite/client/util/HotkeyListener.java
@@ -75,11 +75,6 @@ public abstract class HotkeyListener implements KeyListener
 		{
 			isPressed = false;
 			isConsumingTyped = false;
-			if (Keybind.getModifierForKeyCode(e.getKeyCode()) == null)
-			{
-				// Only consume non modifier keys
-				e.consume();
-			}
 		}
 	}
 


### PR DESCRIPTION
The client doesn't care if it gets erroneous keyReleased events, and fixing this is not entirely trivial.

Fixes #4897