### PR TITLE
More World hopper bug fixes

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldHopperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldHopperPlugin.java
@@ -44,6 +44,7 @@ import java.util.concurrent.TimeUnit;
 import javax.imageio.ImageIO;
 import javax.inject.Inject;
 import javax.swing.SwingUtilities;
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.ChatMessageType;
 import net.runelite.api.ChatPlayer;
@@ -124,6 +125,7 @@ public class WorldHopperPlugin extends Plugin
 	private NavigationButton navButton;
 	private WorldSwitcherPanel panel;
 
+	@Getter
 	private int lastWorld;
 
 	private int favoriteWorld1, favoriteWorld2;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldHopperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldHopperPlugin.java
@@ -228,6 +228,7 @@ public class WorldHopperPlugin extends Plugin
 	private void clearFavoriteConfig(int world)
 	{
 		configManager.unsetConfiguration(WorldHopperConfig.GROUP, "favorite_" + world);
+		panel.resetAllFavoriteMenus();
 	}
 
 	boolean isFavorite(World world)
@@ -250,12 +251,14 @@ public class WorldHopperPlugin extends Plugin
 	{
 		log.debug("Adding world {} to favorites", world.getId());
 		setFavoriteConfig(world.getId());
+		panel.updateFavoriteMenu(world.getId(), true);
 	}
 
 	void removeFromFavorites(World world)
 	{
 		log.debug("Removing world {} from favorites", world.getId());
 		clearFavoriteConfig(world.getId());
+		panel.updateFavoriteMenu(world.getId(), false);
 	}
 
 	@Subscribe

--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldSwitcherPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldSwitcherPanel.java
@@ -177,7 +177,7 @@ class WorldSwitcherPanel extends PluginPanel
 		for (int i = 0; i < worlds.size(); i++)
 		{
 			World world = worlds.get(i);
-			rows.add(buildRow(world, i % 2 == 0, world.getId() == plugin.getCurrentWorld(), plugin.isFavorite(world)));
+			rows.add(buildRow(world, i % 2 == 0, world.getId() == plugin.getCurrentWorld() && plugin.getLastWorld() != 0, plugin.isFavorite(world)));
 		}
 
 		updateList();

--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldSwitcherPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldSwitcherPanel.java
@@ -150,6 +150,26 @@ class WorldSwitcherPanel extends PluginPanel
 		listContainer.repaint();
 	}
 
+	void updateFavoriteMenu(int world, boolean favorite)
+	{
+		for (WorldTableRow row : rows)
+		{
+			if (row.getWorld().getId() == world)
+			{
+				row.setFavoriteMenu(favorite);
+			}
+		}
+	}
+
+	void resetAllFavoriteMenus()
+	{
+		for (WorldTableRow row : rows)
+		{
+			row.setFavoriteMenu(false);
+		}
+
+	}
+
 	void populate(List<World> worlds)
 	{
 		rows.clear();

--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldTableRow.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldTableRow.java
@@ -27,6 +27,7 @@ package net.runelite.client.plugins.worldhopper;
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Dimension;
+import java.awt.event.ActionListener;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.util.function.BiConsumer;
@@ -69,9 +70,12 @@ class WorldTableRow extends JPanel
 		FLAG_GER = new ImageIcon(ImageUtil.getResourceStreamFromClass(WorldHopperPlugin.class, "flag_ger.png"));
 	}
 
+	private final JMenuItem favoriteMenuOption = new JMenuItem();
+
 	private JLabel worldField;
 	private JLabel playerCountField;
 	private JLabel activityField;
+	private BiConsumer<World, Boolean> onFavorite;
 
 	@Getter
 	private final World world;
@@ -86,6 +90,7 @@ class WorldTableRow extends JPanel
 	{
 		this.current = current;
 		this.world = world;
+		this.onFavorite = onFavorite;
 		this.updatedPlayerCount = world.getPlayers();
 
 		setLayout(new BorderLayout());
@@ -137,19 +142,11 @@ class WorldTableRow extends JPanel
 			}
 		});
 
-		String favoriteAction = favorite ?
-			"Remove " + world.getId() + " from favorites" :
-			"Add " + world.getId() + " to favorites";
-
-		final JMenuItem fav = new JMenuItem(favoriteAction);
-		fav.addActionListener(e ->
-		{
-			onFavorite.accept(world, !favorite);
-		});
+		setFavoriteMenu(favorite);
 
 		final JPopupMenu popupMenu = new JPopupMenu();
 		popupMenu.setBorder(new EmptyBorder(5, 5, 5, 5));
-		popupMenu.add(fav);
+		popupMenu.add(favoriteMenuOption);
 
 		setComponentPopupMenu(popupMenu);
 
@@ -175,6 +172,25 @@ class WorldTableRow extends JPanel
 
 		add(leftSide, BorderLayout.WEST);
 		add(activityField, BorderLayout.CENTER);
+	}
+
+	void setFavoriteMenu(boolean favorite)
+	{
+		String favoriteAction = favorite ?
+			"Remove " + world.getId() + " from favorites" :
+			"Add " + world.getId() + " to favorites";
+
+		favoriteMenuOption.setText(favoriteAction);
+
+		for (ActionListener listener : favoriteMenuOption.getActionListeners())
+		{
+			favoriteMenuOption.removeActionListener(listener);
+		}
+
+		favoriteMenuOption.addActionListener(e ->
+		{
+			onFavorite.accept(world, !favorite);
+		});
 	}
 
 	void updatePlayerCount(int playerCount)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldTableRow.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldTableRow.java
@@ -220,6 +220,10 @@ class WorldTableRow extends JPanel
 		{
 			activityField.setForeground(TOURNAMENT_WORLD);
 		}
+		else
+		{
+			activityField.setForeground(Color.WHITE);
+		}
 
 		worldField.setForeground(world.getTypes().contains(WorldType.MEMBERS) ? MEMBERS_WORLD : FREE_WORLD);
 	}


### PR DESCRIPTION
Bugs reported by @devLotto.

- Add to favorite/Remove from favorites menu options now update when clicked
- When you hop off a world it will now have a correct coloring on the activity label
- Remove default world hightlighting to prevent issues with the default world plugin running after the list has been painted