### PR TITLE
Do not add Hop-to option to chatbox and raiding party

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldHopperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldHopperPlugin.java
@@ -280,8 +280,7 @@ public class WorldHopperPlugin extends Plugin
 		String option = event.getOption();
 
 		if (groupId == WidgetInfo.FRIENDS_LIST.getGroupId() || groupId == WidgetInfo.CLAN_CHAT.getGroupId() ||
-			groupId == WidgetInfo.CHATBOX.getGroupId() && !KICK_OPTION.equals(option) || //prevent from adding for Kick option (interferes with the raiding party one)
-			groupId == WidgetInfo.RAIDING_PARTY.getGroupId() || groupId == WidgetInfo.PRIVATE_CHAT_MESSAGE.getGroupId())
+			groupId == WidgetInfo.PRIVATE_CHAT_MESSAGE.getGroupId())
 		{
 			boolean after;
 


### PR DESCRIPTION
Currently you can left-click a player's message in the chatbox and it will try to hop, which will more than likely cause unintentional hops or even fatal ones.

The raiding party has no use here because when you are in one, only members on the same world are displayed.