### PR TITLE
World hopper activity ordering improvements

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldSwitcherPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldSwitcherPanel.java
@@ -130,6 +130,12 @@ class WorldSwitcherPanel extends PluginPanel
 			}
 		});
 
+		// Leave empty activity worlds on the bottom of the list
+		if (orderIndex == WorldOrder.ACTIVITY)
+		{
+			rows.sort((r1, r2) -> r1.getWorld().getActivity().equals("-") ? 1 : -1);
+		}
+
 		rows.sort((r1, r2) ->
 		{
 			boolean b1 = plugin.isFavorite(r1.getWorld());

--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldSwitcherPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldSwitcherPanel.java
@@ -123,7 +123,7 @@ class WorldSwitcherPanel extends PluginPanel
 				case PLAYERS:
 					return Integer.compare(r1.getUpdatedPlayerCount(), r2.getUpdatedPlayerCount()) * (ascendingOrder ? 1 : -1);
 				case ACTIVITY:
-					return r1.getWorld().getActivity().compareTo(r2.getWorld().getActivity()) * (ascendingOrder ? 1 : -1);
+					return r1.getWorld().getActivity().compareTo(r2.getWorld().getActivity()) * -1 * (ascendingOrder ? 1 : -1);
 				default:
 					return 0;
 


### PR DESCRIPTION
- If ordering by activity, it will now push empty activity worlds to the bottom of the list
- Activity ordering will now be consistent with the other ordering modes, ascending by default

Fixes #4938