### PR TITLE
WASD plugin: Use clientscript to determine what input to block

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/wasdcamera/WASDCameraListener.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/wasdcamera/WASDCameraListener.java
@@ -55,22 +55,6 @@ class WASDCameraListener extends MouseListener implements KeyListener
 	@Override
 	public void keyTyped(KeyEvent e)
 	{
-		// allow if not typing in chatbox, or typing mode is enabled
-		if (client.getGameState() != GameState.LOGGED_IN
-			|| !plugin.chatboxFocused()
-			|| plugin.isTyping())
-		{
-			return;
-		}
-
-		// otherwise allow typing if a digit and this is a dialog
-		if (Character.isDigit(e.getKeyChar()) && plugin.chatboxDialog())
-		{
-			return;
-		}
-
-		// otherwise consume
-		e.consume();
 	}
 
 	@Override
@@ -107,35 +91,6 @@ class WASDCameraListener extends MouseListener implements KeyListener
 			{
 				switch (e.getKeyCode())
 				{
-					case KeyEvent.VK_0:
-					case KeyEvent.VK_1:
-					case KeyEvent.VK_2:
-					case KeyEvent.VK_3:
-					case KeyEvent.VK_4:
-					case KeyEvent.VK_5:
-					case KeyEvent.VK_6:
-					case KeyEvent.VK_7:
-					case KeyEvent.VK_8:
-					case KeyEvent.VK_9:
-					case KeyEvent.VK_NUMPAD0:
-					case KeyEvent.VK_NUMPAD1:
-					case KeyEvent.VK_NUMPAD2:
-					case KeyEvent.VK_NUMPAD3:
-					case KeyEvent.VK_NUMPAD4:
-					case KeyEvent.VK_NUMPAD5:
-					case KeyEvent.VK_NUMPAD6:
-					case KeyEvent.VK_NUMPAD7:
-					case KeyEvent.VK_NUMPAD8:
-					case KeyEvent.VK_NUMPAD9:
-					case KeyEvent.VK_SPACE:
-						// numbers normally are consumed, unless a dialog box is open.
-						// most dialogs in the chatbox use the same chatbox input handler
-						// as normal chat
-						if (!plugin.chatboxDialog())
-						{
-							e.consume();
-						}
-						break;
 					case KeyEvent.VK_ENTER:
 					case KeyEvent.VK_SLASH:
 						// refocus chatbox
@@ -145,32 +100,6 @@ class WASDCameraListener extends MouseListener implements KeyListener
 							plugin.unlockChat();
 						});
 						break;
-					case KeyEvent.VK_F1:
-					case KeyEvent.VK_F2:
-					case KeyEvent.VK_F3:
-					case KeyEvent.VK_F4:
-					case KeyEvent.VK_F5:
-					case KeyEvent.VK_F6:
-					case KeyEvent.VK_F7:
-					case KeyEvent.VK_F8:
-					case KeyEvent.VK_F9:
-					case KeyEvent.VK_F10:
-					case KeyEvent.VK_F11:
-					case KeyEvent.VK_F12:
-					case KeyEvent.VK_UP:
-					case KeyEvent.VK_DOWN:
-					case KeyEvent.VK_LEFT:
-					case KeyEvent.VK_RIGHT:
-					case KeyEvent.VK_SHIFT:
-					case KeyEvent.VK_ESCAPE:
-					case KeyEvent.VK_CONTROL:
-					case KeyEvent.VK_ALT:
-					case KeyEvent.VK_TAB:
-						break;
-					default:
-						e.consume();
-						break;
-
 				}
 			}
 		}
@@ -224,64 +153,6 @@ class WASDCameraListener extends MouseListener implements KeyListener
 			else if (config.right().matches(e))
 			{
 				e.setKeyCode(KeyEvent.VK_RIGHT);
-			}
-			else
-			{
-				switch (e.getKeyCode())
-				{
-					case KeyEvent.VK_0:
-					case KeyEvent.VK_1:
-					case KeyEvent.VK_2:
-					case KeyEvent.VK_3:
-					case KeyEvent.VK_4:
-					case KeyEvent.VK_5:
-					case KeyEvent.VK_6:
-					case KeyEvent.VK_7:
-					case KeyEvent.VK_8:
-					case KeyEvent.VK_9:
-					case KeyEvent.VK_NUMPAD0:
-					case KeyEvent.VK_NUMPAD1:
-					case KeyEvent.VK_NUMPAD2:
-					case KeyEvent.VK_NUMPAD3:
-					case KeyEvent.VK_NUMPAD4:
-					case KeyEvent.VK_NUMPAD5:
-					case KeyEvent.VK_NUMPAD6:
-					case KeyEvent.VK_NUMPAD7:
-					case KeyEvent.VK_NUMPAD8:
-					case KeyEvent.VK_NUMPAD9:
-					case KeyEvent.VK_SPACE:
-						if (!plugin.chatboxDialog())
-						{
-							e.consume();
-						}
-						break;
-					case KeyEvent.VK_SLASH:
-					case KeyEvent.VK_F1:
-					case KeyEvent.VK_F2:
-					case KeyEvent.VK_F3:
-					case KeyEvent.VK_F4:
-					case KeyEvent.VK_F5:
-					case KeyEvent.VK_F6:
-					case KeyEvent.VK_F7:
-					case KeyEvent.VK_F8:
-					case KeyEvent.VK_F9:
-					case KeyEvent.VK_F10:
-					case KeyEvent.VK_F11:
-					case KeyEvent.VK_F12:
-					case KeyEvent.VK_UP:
-					case KeyEvent.VK_DOWN:
-					case KeyEvent.VK_LEFT:
-					case KeyEvent.VK_RIGHT:
-					case KeyEvent.VK_SHIFT:
-					case KeyEvent.VK_ESCAPE:
-					case KeyEvent.VK_CONTROL:
-					case KeyEvent.VK_ALT:
-					case KeyEvent.VK_TAB:
-						break;
-					default:
-						e.consume();
-						break;
-				}
 			}
 		}
 		else

--- a/runelite-client/src/main/java/net/runelite/client/plugins/wasdcamera/WASDCameraPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/wasdcamera/WASDCameraPlugin.java
@@ -54,6 +54,7 @@ public class WASDCameraPlugin extends Plugin
 {
 	private static final String PRESS_ENTER_TO_CHAT = "Press Enter to Chat...";
 	private static final String SCRIPT_EVENT_SET_CHATBOX_INPUT = "setChatboxInput";
+	private static final String SCRIPT_EVENT_BLOCK_CHAT_INPUT = "blockChatInput";
 
 	@Inject
 	private Client client;
@@ -125,25 +126,29 @@ public class WASDCameraPlugin extends Plugin
 		return true;
 	}
 
-	boolean chatboxDialog()
-	{
-		Widget chatboxInput = client.getWidget(WidgetInfo.CHATBOX_INPUT);
-		return chatboxInput == null || chatboxInput.isHidden();
-	}
-
 	@Subscribe
 	public void onScriptEvent(ScriptCallbackEvent scriptCallbackEvent)
 	{
-		if (scriptCallbackEvent.getEventName().equals(SCRIPT_EVENT_SET_CHATBOX_INPUT))
+		switch (scriptCallbackEvent.getEventName())
 		{
-			Widget chatboxInput = client.getWidget(WidgetInfo.CHATBOX_INPUT);
-			if (chatboxInput != null)
-			{
-				if (chatboxFocused() && !typing)
+			case SCRIPT_EVENT_SET_CHATBOX_INPUT:
+				Widget chatboxInput = client.getWidget(WidgetInfo.CHATBOX_INPUT);
+				if (chatboxInput != null)
 				{
-					chatboxInput.setText(PRESS_ENTER_TO_CHAT);
+					if (chatboxFocused() && !typing)
+					{
+						chatboxInput.setText(PRESS_ENTER_TO_CHAT);
+					}
 				}
-			}
+				break;
+			case SCRIPT_EVENT_BLOCK_CHAT_INPUT:
+				if (!typing)
+				{
+					int[] intStack = client.getIntStack();
+					int intStackSize = client.getIntStackSize();
+					intStack[intStackSize - 1] = 1;
+				}
+				break;
 		}
 	}
 

--- a/runelite-client/src/main/scripts/CommandScript.rs2asm
+++ b/runelite-client/src/main/scripts/CommandScript.rs2asm
@@ -317,6 +317,11 @@ LABEL244:
    iload                  0
    iload                  1
    invoke                 74
+   load_int               1                 ; check if we're ignoring input
+   load_int               0                 ;
+   load_string            "blockChatInput"  ;
+   runelite_callback                        ;
+   if_icmpeq              LABEL250          ; don't add to input varcstr
    put_varc_string        1
 LABEL250:
    invoke                 223


### PR DESCRIPTION
Uses the key listener assigned to the chatbox input to determine what input to block. 

As Jagex special cases all the other inputs inside of this script, this removes most of that logic from the KeyListener. This should also ensure that it doesn't break on some obscure input we haven't found yet. 