### PR TITLE
Add camera setters (X, Y, Z, Pitch, and Yaw).

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/Client.java
+++ b/runelite-api/src/main/java/net/runelite/api/Client.java
@@ -1444,4 +1444,39 @@ public interface Client extends GameEngine
 	 * @param world target world to hop to
 	 */
 	void hopToWorld(World world);
+
+	/**
+	 * Sets the x-axis coordinate of the camera.
+	 *
+	 * @param cameraX the new camera x-value.
+	 */
+	void setCameraX(int cameraX);
+
+	/**
+	 * Sets the y-axis coordinate of the camera.
+	 *
+	 * @param cameraY the new camera y-value.
+	 */
+	void setCameraY(int cameraY);
+
+	/**
+	 * Sets the z-axis coordinate of the camera.
+	 *
+	 * @param cameraZ the new camera z-value.
+	 */
+	void setCameraZ(int cameraZ);
+
+	/**
+	 * Sets the pitch of the camera.
+	 *
+	 * @param cameraPitch the new camera pitch.
+	 */
+	void setCameraPitch(int cameraPitch);
+
+	/**
+	 * Sets the yaw of the camera.
+	 *
+	 * @param cameraYaw the new camera yaw.
+	 */
+	void setCameraYaw(int cameraYaw);
 }

--- a/runescape-api/src/main/java/net/runelite/rs/api/RSClient.java
+++ b/runescape-api/src/main/java/net/runelite/rs/api/RSClient.java
@@ -40,13 +40,25 @@ public interface RSClient extends RSGameEngine, Client
 	@Override
 	int getCameraX();
 
+	@Import("cameraX")
+	@Override
+	void setCameraX(int cameraX);
+
 	@Import("cameraY")
 	@Override
 	int getCameraY();
 
+	@Import("cameraY")
+	@Override
+	void setCameraY(int cameraY);
+
 	@Import("cameraZ")
 	@Override
 	int getCameraZ();
+
+	@Import("cameraZ")
+	@Override
+	void setCameraZ(int cameraZ);
 
 	@Import("plane")
 	@Override
@@ -57,11 +69,16 @@ public interface RSClient extends RSGameEngine, Client
 	int getCameraPitch();
 
 	@Import("cameraPitch")
+	@Override
 	void setCameraPitch(int cameraPitch);
 
 	@Import("cameraYaw")
 	@Override
 	int getCameraYaw();
+
+	@Import("cameraYaw")
+	@Override
+	void setCameraYaw(int cameraYaw);
 
 	@Import("world")
 	int getWorld();


### PR DESCRIPTION
I just wanted to verify this is the proper way to add camera setters before continuing work on a new plugin.  The plugin will add a 'look south', 'look east', and 'look west' to the compass similar to the current 'look north' option in the vanilla client. Thanks.