### PR TITLE
Fixed OSB display bug

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangePlugin.java
@@ -300,8 +300,7 @@ public class GrandExchangePlugin extends Plugin
 
 		int itemId = grandExchangeItem.getItemId();
 		if (itemId == OFFER_DEFAULT_ITEM_ID
-			|| itemId == -1
-			|| lastItem == itemId)
+			|| itemId == -1)
 		{
 			return;
 		}
@@ -313,16 +312,19 @@ public class GrandExchangePlugin extends Plugin
 		{
 			try
 			{
-				final GrandExchangeResult result = CLIENT.lookupItem(itemId);
-
-				if (result.getItem_id() != lastItem)
+				String osbText = "<br>OSBuddy Actively traded price: ";
+				if (!geText.getText().contains(osbText))
 				{
-					// something else has since been looked up?
-					return;
-				}
+					final GrandExchangeResult result = CLIENT.lookupItem(itemId);
 
-				final String text = geText.getText() + "<br>OSBuddy Actively traded price: " + StackFormatter.formatNumber(result.getOverall_average());
-				geText.setText(text);
+					if (result.getItem_id() != lastItem)
+					{
+						// something else has since been looked up?
+						return;
+					}
+					final String text = geText.getText() + osbText + StackFormatter.formatNumber(result.getOverall_average());
+					geText.setText(text);
+				}
 			}
 			catch (IOException e)
 			{


### PR DESCRIPTION
There was a bug where if you clicked on an item in the GE, pressed back (or bought) and went back to the item screen the OSB price would not display.

Reproducible Steps:
1. Open GE
2. Look at a Zulrah Scale
3. Press back
4. Look at a Zulrah Scale (notice no OSB)