### PR TITLE
Kourend library customer book overlay

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ project.properties
 .project
 .settings/
 .classpath
+.jar

--- a/runelite-api/src/main/java/META-INF/MANIFEST.MF
+++ b/runelite-api/src/main/java/META-INF/MANIFEST.MF
@@ -1,0 +1,3 @@
+Manifest-Version: 1.0
+Main-Class: net.runelite.client.RuneLite
+

--- a/runelite-client/src/main/java/net/runelite/client/plugins/kourendlibrary/KourendLibraryConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/kourendlibrary/KourendLibraryConfig.java
@@ -36,9 +36,21 @@ public interface KourendLibraryConfig extends Config
 	@ConfigItem(
 		keyName = "hideButton",
 		name = "Hide when outside of the library",
-		description = "Don't show the button in the sidebar when your not in the library"
+		description = "Don't show the button in the sidebar when your not in the library",
+		position = 1
 	)
 	default boolean hideButton()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+			keyName = "showRequestedBookOverlay",
+			name = "Show overlay for requested book",
+			description = "Configures whether to display the overlay of the requested book",
+			position = 2
+	)
+	default boolean showRequestedBookOverlay()
 	{
 		return true;
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/kourendlibrary/KourendLibraryCornerOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/kourendlibrary/KourendLibraryCornerOverlay.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Seth <Sethtroll3@gmail.com>
+ * Copyright (c) 2018, dekvall <github.com/dekvall>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/runelite-client/src/main/java/net/runelite/client/plugins/kourendlibrary/KourendLibraryCornerOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/kourendlibrary/KourendLibraryCornerOverlay.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2017, Seth <Sethtroll3@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.kourendlibrary;
+
+import net.runelite.api.Client;
+import net.runelite.api.Item;
+import net.runelite.api.Player;
+import net.runelite.api.coords.WorldPoint;
+import net.runelite.client.ui.overlay.Overlay;
+import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.components.PanelComponent;
+import net.runelite.client.ui.overlay.components.TitleComponent;
+
+import javax.inject.Inject;
+import java.awt.*;
+import java.util.ArrayList;
+import java.util.List;
+
+
+class KourendLibraryCornerOverlay extends Overlay
+{
+	private static final int OVERLAY_WIDTH = 170;
+	private final Library library;
+	private final Client client;
+
+	private final KourendLibraryPlugin plugin;
+	private final PanelComponent panelComponent = new PanelComponent();
+
+
+	@Inject
+	KourendLibraryCornerOverlay(Library library, Client client, KourendLibraryPlugin plugin)
+	{
+		this.library = library;
+		this.client = client;
+		this.plugin = plugin;
+		setPosition(OverlayPosition.TOP_LEFT);
+	}
+
+	@Override
+	public Dimension render(Graphics2D graphics)
+	{
+		Player player = client.getLocalPlayer();
+		if (player == null)
+		{
+			return null;
+		}
+
+		WorldPoint playerLoc = player.getWorldLocation();
+
+		if (playerLoc.getRegionID() != KourendLibraryPlugin.REGION)
+		{
+			return null;
+		}
+
+		List<Bookcase> allBookcases = library.getBookcasesOnLevel(client.getPlane());
+
+		if (allBookcases == null)
+		{
+			return null;
+		}
+		if (library.getCustomerBook() == null)
+		{
+			return null;
+		}
+
+		List<String> locations = new ArrayList<>();
+
+		for (Bookcase bc : library.getBookcases())
+		{
+			if (bc.isBookSet()
+				&& bc.getBook() == library.getCustomerBook()
+				|| library.getState() != SolvedState.NO_DATA
+				&& bc.getPossibleBooks().contains(library.getCustomerBook()))
+			{
+				locations.add(bc.getLocationString());
+			}
+		}
+		if (locations.isEmpty())
+		{
+			locations.add("Unknown");
+		}
+
+		Color mark = Color.RED;
+		for (Item it: plugin.getInventoryItems())
+		{
+			if (it.getId() == library.getCustomerBook().getItem())
+			{
+				mark = Color.GREEN;
+				break;
+			}
+		}
+		panelComponent.setPreferredSize(new Dimension(OVERLAY_WIDTH, 0));
+		panelComponent.getChildren().clear();
+
+		panelComponent.getChildren().add(TitleComponent.builder()
+			.text(library.getCustomerBook().getShortName())
+			.color(mark)
+			.build());
+
+		for (String location: locations)
+		{
+			panelComponent.getChildren().add(TitleComponent.builder()
+					.text(location)
+					.color(mark)
+					.build());
+		}
+		return panelComponent.render(graphics);
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/kourendlibrary/KourendLibraryCornerOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/kourendlibrary/KourendLibraryCornerOverlay.java
@@ -47,20 +47,27 @@ class KourendLibraryCornerOverlay extends Overlay
 
 	private final KourendLibraryPlugin plugin;
 	private final PanelComponent panelComponent = new PanelComponent();
+	private final KourendLibraryConfig config;
 
 
 	@Inject
-	KourendLibraryCornerOverlay(Library library, Client client, KourendLibraryPlugin plugin)
+	KourendLibraryCornerOverlay(Library library, Client client, KourendLibraryPlugin plugin, KourendLibraryConfig config)
 	{
 		this.library = library;
 		this.client = client;
 		this.plugin = plugin;
+		this.config = config;
 		setPosition(OverlayPosition.TOP_LEFT);
 	}
 
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
+		if (!config.showRequestedBookOverlay())
+		{
+			return null;
+		}
+
 		Player player = client.getLocalPlayer();
 		if (player == null)
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/kourendlibrary/KourendLibraryOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/kourendlibrary/KourendLibraryOverlay.java
@@ -24,7 +24,6 @@
  */
 package net.runelite.client.plugins.kourendlibrary;
 
-import com.google.inject.Inject;
 import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.FontMetrics;
@@ -36,18 +35,20 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
-import net.runelite.api.Client;
-import net.runelite.api.Perspective;
-import net.runelite.api.Player;
-import net.runelite.api.Point;
+
+import com.google.inject.Inject;
+import net.runelite.api.*;
 import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.coords.WorldPoint;
+
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.OverlayUtil;
+import net.runelite.api.Item;
 
 import static net.runelite.api.Perspective.getCanvasTilePoly;
+
 
 class KourendLibraryOverlay extends Overlay
 {
@@ -56,11 +57,14 @@ class KourendLibraryOverlay extends Overlay
 	private final Library library;
 	private final Client client;
 
+	private final KourendLibraryPlugin plugin;
+
 	@Inject
-	KourendLibraryOverlay(Library library, Client client)
+	KourendLibraryOverlay(Library library, Client client, KourendLibraryPlugin plugin)
 	{
 		this.library = library;
 		this.client = client;
+		this.plugin = plugin;
 
 		setPosition(OverlayPosition.DYNAMIC);
 		setLayer(OverlayLayer.ABOVE_SCENE);
@@ -83,6 +87,12 @@ class KourendLibraryOverlay extends Overlay
 		}
 
 		List<Bookcase> allBookcases = library.getBookcasesOnLevel(client.getPlane());
+		if (allBookcases == null)
+		{
+			return null;
+		}
+
+		Item [] items = plugin.getInventoryItems();
 
 		for (Bookcase bookcase : allBookcases)
 		{
@@ -123,8 +133,17 @@ class KourendLibraryOverlay extends Overlay
 					book = possible.iterator().next();
 					bookIsKnown = true;
 				}
+
 				Color color = bookIsKnown ? Color.ORANGE : Color.WHITE;
 
+				for (Item it : items)
+				{
+					if (it != null && book != null && !book.isDarkManuscript() && book == Book.byId(it.getId()))
+					{
+						color = Color.RED;
+						break;
+					}
+				}
 				// Render the poly on the floor
 				if (!(bookIsKnown && book == null) && (library.getState() == SolvedState.NO_DATA || book != null || possible.size() > 0))
 				{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/kourendlibrary/KourendLibraryPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/kourendlibrary/KourendLibraryPlugin.java
@@ -29,6 +29,7 @@ import com.google.inject.Provides;
 import java.awt.image.BufferedImage;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
 import javax.inject.Inject;
 import javax.swing.SwingUtilities;
 import lombok.extern.slf4j.Slf4j;
@@ -43,6 +44,9 @@ import net.runelite.api.events.ChatMessage;
 import net.runelite.api.events.ConfigChanged;
 import net.runelite.api.events.GameTick;
 import net.runelite.api.events.MenuOptionClicked;
+import lombok.Getter;
+import net.runelite.api.*;
+import net.runelite.api.events.*;
 import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.config.ConfigManager;
@@ -53,6 +57,7 @@ import net.runelite.client.ui.NavigationButton;
 import net.runelite.client.ui.ClientToolbar;
 import net.runelite.client.ui.overlay.OverlayManager;
 import net.runelite.client.util.ImageUtil;
+import net.runelite.api.Item;
 
 @PluginDescriptor(
 	name = "Kourend Library",
@@ -82,6 +87,9 @@ public class KourendLibraryPlugin extends Plugin
 	private KourendLibraryOverlay overlay;
 
 	@Inject
+	private KourendLibraryCornerOverlay kourendLibraryCornerOverlay;
+
+	@Inject
 	private KourendLibraryConfig config;
 
 	@Inject
@@ -99,11 +107,14 @@ public class KourendLibraryPlugin extends Plugin
 	{
 		return configManager.getConfig(KourendLibraryConfig.class);
 	}
+	@Getter
+	private Item [] inventoryItems;
 
 	@Override
 	protected void startUp() throws Exception
 	{
 		overlayManager.add(overlay);
+		overlayManager.add(kourendLibraryCornerOverlay);
 		Book.fillImages(itemManager);
 
 		panel = injector.getInstance(KourendLibraryPanel.class);
@@ -177,6 +188,16 @@ public class KourendLibraryPlugin extends Plugin
 		if (anim.getActor() == client.getLocalPlayer() && anim.getActor().getAnimation() == AnimationID.LOOKING_INTO)
 		{
 			lastBookcaseAnimatedOn = lastBookcaseClick;
+			inventoryItems = client.getItemContainer(InventoryID.INVENTORY).getItems();
+		}
+	}
+
+	@Subscribe
+	public void onItemContainerChanged(final ItemContainerChanged event)
+	{
+		if (event.getItemContainer() == client.getItemContainer(InventoryID.INVENTORY))
+		{
+			inventoryItems = client.getItemContainer(InventoryID.INVENTORY).getItems();
 		}
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/kourendlibrary/KourendLibraryPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/kourendlibrary/KourendLibraryPlugin.java
@@ -81,6 +81,9 @@ public class KourendLibraryPlugin extends Plugin
 	private Library library;
 
 	@Inject
+	private KourendLibraryConfig config;
+
+	@Inject
 	private OverlayManager overlayManager;
 
 	@Inject
@@ -88,9 +91,6 @@ public class KourendLibraryPlugin extends Plugin
 
 	@Inject
 	private KourendLibraryCornerOverlay kourendLibraryCornerOverlay;
-
-	@Inject
-	private KourendLibraryConfig config;
 
 	@Inject
 	private ItemManager itemManager;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -235,8 +235,13 @@ public interface MenuEntrySwapperConfig extends Config
 		name = "Decant",
 		description = "Swap Talk-to with Decant for Bob Barter and Murky Matt at the Grand Exchange."
 	)
-	default boolean swapDecant()
-	{
-		return false;
-	}
+	default boolean swapDecant() { return false; }
+
+	@ConfigItem(
+	    position = 18,
+		keyName = "swapLibrary",
+		name = "Help",
+		description = "Swap Help on the library customers"
+	)
+	default boolean swapLibrary() { return true; }
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -235,13 +235,19 @@ public interface MenuEntrySwapperConfig extends Config
 		name = "Decant",
 		description = "Swap Talk-to with Decant for Bob Barter and Murky Matt at the Grand Exchange."
 	)
-	default boolean swapDecant() { return false; }
+	default boolean swapDecant()
+	{
+		return false;
+	}
 
 	@ConfigItem(
-	    position = 18,
+		position = 18,
 		keyName = "swapLibrary",
 		name = "Help",
 		description = "Swap Help on the library customers"
 	)
-	default boolean swapLibrary() { return true; }
+	default boolean swapLibrary()
+	{
+		return true;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -372,6 +372,11 @@ public class MenuEntrySwapperPlugin extends Plugin
 				swap("claim-slime", option, target, true);
 			}
 
+			if (config.swapLibrary())
+			{
+				swap("help", option, target, true);
+			}
+
 			if (config.swapTravel())
 			{
 				swap("travel", option, target, true);


### PR DESCRIPTION
Adds a panel in the top left corner for showing the book requested by the customer. The text will turn green when the book is in the player's inventory indicating you can return to the customer. Since you can only have one of each book in your inventory, the bookcase in which the book is located will also turn red when acquired.
This also adds the help option of the library customers to the menuentryswapper. 
<img width="383" alt="ininvy" src="https://user-images.githubusercontent.com/25151927/44400582-f5d04f00-a54b-11e8-823b-5e9a4a71216a.png">
<img width="384" alt="notininvy" src="https://user-images.githubusercontent.com/25151927/44400588-f963d600-a54b-11e8-8780-63e8de4e77b7.png">

