### PR TITLE
Create Overlay LayoutTextComponent

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/components/LayoutTextComponent.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/components/LayoutTextComponent.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2018, Ron <https://github.com/raiyni>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.ui.overlay.components;
+
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.FontMetrics;
+import java.awt.Graphics2D;
+import java.awt.Point;
+import lombok.AllArgsConstructor;
+import lombok.Setter;
+
+@Setter
+@AllArgsConstructor
+public class LayoutTextComponent implements LayoutableRenderableEntity
+{
+	private String text;
+	private Color color;
+
+	private Point preferredLocation;
+
+	public LayoutTextComponent()
+	{
+		this("");
+	}
+
+	public LayoutTextComponent(String t)
+	{
+		this(t, Color.WHITE);
+	}
+
+	public LayoutTextComponent(String t, Color c)
+	{
+		this(t, c, new Point());
+	}
+
+	@Override
+	public Dimension render(Graphics2D graphics)
+	{
+		graphics.translate(preferredLocation.x, preferredLocation.y);
+
+		final FontMetrics metrics = graphics.getFontMetrics();
+
+		final TextComponent titleComponent = new TextComponent();
+		titleComponent.setText(text);
+		titleComponent.setColor(color);
+		titleComponent.setPosition(new Point(0, metrics.getHeight()));
+		titleComponent.render(graphics);
+
+		graphics.translate(-preferredLocation.x, -preferredLocation.y);
+		return new Dimension(metrics.stringWidth(text), metrics.getHeight());
+	}
+
+	public void setPreferredSize(Dimension d)
+	{
+		// Just use text dimensions for now
+	}
+}


### PR DESCRIPTION
Provides the ability to have a TextComponent that is layoutable and only provides its own size. Implementing LayoutRenderableEntity on TextComponent. Doesn't use builder api for simplicity. 



Using LineComponent like this in a HORIZONTAL panel results in a forced sized for each text.
![](https://i.imgur.com/4wmX45m.png)



```
horizontal.getChildren().add(new ImageComponent(damageIcon));
horizontal.getChildren().add(new LayoutTextComponent("abc"));

horizontal.getChildren().add(new ImageComponent(damageIcon));
horizontal.getChildren().add(new LayoutTextComponent("abc"));

horizontal.getChildren().add(new ImageComponent(damageIcon));
horizontal.getChildren().add(new LayoutTextComponent("abc"));

horizontal.getChildren().add(new ImageComponent(damageIcon));
horizontal.getChildren().add(new LayoutTextComponent("abc"));
```
Using LayoutTextComponent
![](https://i.imgur.com/Miq2Wob.png)