### PR TITLE
Add client focus to top on windows 10

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
@@ -512,19 +512,13 @@ public class ClientUI
 		{
 			OSXUtil.requestFocus();
 		}
+		else if (OSType.getOSType() == OSType.Windows && System.getProperty("os.name").contains("10"))
+		{
+			frame.toFront();
+		}
 
-		if (System.getProperty("os.name").equals("Windows 10"))
-		{
-			frame.setAlwaysOnTop(true);
-			frame.requestFocus();
-			giveClientFocus();
-			frame.setAlwaysOnTop(config.gameAlwaysOnTop());
-		}
-		else
-		{
-			frame.requestFocus();
-			giveClientFocus();
-		}
+		frame.requestFocus();
+		giveClientFocus();
 	}
 
 	/**

--- a/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
@@ -513,7 +513,7 @@ public class ClientUI
 			OSXUtil.requestFocus();
 		}
 
-		if (System.getProperty("os.name").contains("10"))
+		if (System.getProperty("os.name").equals("Windows 10"))
 		{
 			frame.setAlwaysOnTop(true);
 			frame.requestFocus();

--- a/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
@@ -512,13 +512,16 @@ public class ClientUI
 		{
 			OSXUtil.requestFocus();
 		}
-		else if (OSType.getOSType() == OSType.Windows && System.getProperty("os.name").contains("10"))
+		else if (OSType.getOSType() == OSType.Windows)
 		{
 			frame.toFront();
+			frame.setAlwaysOnTop(true);
+			frame.setAlwaysOnTop(config.gameAlwaysOnTop());
 		}
 
 		frame.requestFocus();
 		giveClientFocus();
+
 	}
 
 	/**

--- a/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
@@ -513,8 +513,18 @@ public class ClientUI
 			OSXUtil.requestFocus();
 		}
 
-		frame.requestFocus();
-		giveClientFocus();
+		if (System.getProperty("os.name").contains("10"))
+		{
+			frame.setAlwaysOnTop(true);
+			frame.requestFocus();
+			giveClientFocus();
+			frame.setAlwaysOnTop(config.gameAlwaysOnTop());
+		}
+		else
+		{
+			frame.requestFocus();
+			giveClientFocus();
+		}
 	}
 
 	/**


### PR DESCRIPTION
Currently on windows 10, requesting focus only makes the taskbar flash, and the game does not pop up to the top. On other OS (MacOS at least), the client comes to the top when requesting focus.

This workaround makes the client pop up to the top on Windows 10.

Fixes #2335