### PR TITLE
#5068 fix: cant quick hop to w26

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldHopperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldHopperPlugin.java
@@ -471,6 +471,8 @@ public class WorldHopperPlugin extends Plugin
 		currentWorldTypes.remove(WorldType.SKILL_TOTAL);
 		// Allow hopping from a high risk world to a non-high risk world
 		currentWorldTypes.remove(WorldType.PVP_HIGH_RISK);
+		// Allow hopping from a LMS world to a non-LMS world
+		currentWorldTypes.remove(WorldType.LAST_MAN_STANDING);
 
 		List<World> worlds = worldResult.getWorlds();
 
@@ -510,6 +512,8 @@ public class WorldHopperPlugin extends Plugin
 			EnumSet<WorldType> types = world.getTypes().clone();
 
 			types.remove(WorldType.BOUNTY);
+			// Treat LMS world like casual world
+			types.remove(WorldType.LAST_MAN_STANDING);
 
 			if (types.contains(WorldType.SKILL_TOTAL))
 			{


### PR DESCRIPTION
Fixes #5068

Now it is possible to quick hop into (and out) w26

![deepin-screen-recorder_sun-awt-x11-xframepeer_20180826161640](https://user-images.githubusercontent.com/15970653/44629153-898a8c80-a94b-11e8-9cd5-d1dd1cc33687.gif)
