### PR TITLE
Reduce default plugin noise for regular users

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/blastfurnace/BlastFurnaceConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/blastfurnace/BlastFurnaceConfig.java
@@ -39,7 +39,7 @@ public interface BlastFurnaceConfig extends Config
 	)
 	default boolean showConveyorBelt()
 	{
-		return true;
+		return false;
 	}
 
 	@ConfigItem(
@@ -50,6 +50,6 @@ public interface BlastFurnaceConfig extends Config
 	)
 	default boolean showBarDispenser()
 	{
-		return true;
+		return false;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
@@ -62,7 +62,7 @@ public interface GroundItemsConfig extends Config
 	)
 	default String getHiddenItems()
 	{
-		return "";
+		return "Vial, Ashes, Coins, Bones, Bucket, Jug, Seaweed";
 	}
 
 	@ConfigItem(

--- a/runelite-client/src/main/java/net/runelite/client/plugins/kourendlibrary/KourendLibraryOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/kourendlibrary/KourendLibraryOverlay.java
@@ -29,7 +29,6 @@ import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.FontMetrics;
 import java.awt.Graphics2D;
-
 import java.awt.Polygon;
 import java.awt.geom.Rectangle2D;
 import java.util.List;
@@ -38,6 +37,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import net.runelite.api.Client;
 import net.runelite.api.Perspective;
+import static net.runelite.api.Perspective.getCanvasTilePoly;
 import net.runelite.api.Player;
 import net.runelite.api.Point;
 import net.runelite.api.coords.LocalPoint;
@@ -47,17 +47,14 @@ import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.OverlayUtil;
 
-import static net.runelite.api.Perspective.getCanvasTilePoly;
-
 class KourendLibraryOverlay extends Overlay
 {
 	private final static int MAXIMUM_DISTANCE = 24;
-
 	private final Library library;
 	private final Client client;
 
 	@Inject
-	KourendLibraryOverlay(Library library, Client client)
+	private KourendLibraryOverlay(Library library, Client client)
 	{
 		this.library = library;
 		this.client = client;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/poh/PohConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/poh/PohConfig.java
@@ -98,7 +98,7 @@ public interface PohConfig extends Config
 	)
 	default boolean showBurner()
 	{
-		return true;
+		return false;
 	}
 
 	@ConfigItem(


### PR DESCRIPTION
### Disable blast furnace clickboxes by default

A lot of people visit blast furnace without intention to actually do the
activity (e.g to buy ores) so simply disable the clickbox noise by
default and leave to user if they want them.

### Make KourendLibrary overlay show only on interact

Make KourendLibrary plugin overlay show only on interaction with
bookcase or with customer after login, as by default the noise caused by
the overlays is horrendous.

### Add common hidden items to GroundItemsPlugin

To reduce default plugin noise add some common hidden items to
GroundItemsPlugin (basically same default hidden list as OSBuddy has).

### Disable lit/unlit burner indicators by default

Majority of players do not care about these and it is just permanent
noise in POH for them, leave the enabling of this setting to minority.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>
