### PR TITLE
Revert revert shutdown + remove call to client.shutDown()

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/RuneLite.java
+++ b/runelite-client/src/main/java/net/runelite/client/RuneLite.java
@@ -35,6 +35,7 @@ import java.io.File;
 import java.lang.management.ManagementFactory;
 import java.lang.management.RuntimeMXBean;
 import java.util.Locale;
+import java.util.concurrent.ScheduledExecutorService;
 import javax.annotation.Nullable;
 import javax.inject.Provider;
 import javax.inject.Singleton;
@@ -110,6 +111,9 @@ public class RuneLite
 
 	@Inject
 	private OverlayManager overlayManager;
+
+	@Inject
+	private ScheduledExecutorService executorService;
 
 	@Inject
 	private Provider<ItemManager> itemManager;
@@ -292,8 +296,10 @@ public class RuneLite
 
 	public void shutdown()
 	{
+		pluginManager.stopCorePlugins();
 		clientSessionManager.shutdown();
 		discordService.close();
+		executorService.shutdown();
 	}
 
 	@VisibleForTesting

--- a/runelite-client/src/main/java/net/runelite/client/plugins/PluginManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/PluginManager.java
@@ -214,6 +214,23 @@ public class PluginManager
 		}
 	}
 
+	public void stopCorePlugins()
+	{
+		List<Plugin> scannedPlugins = new ArrayList<>(plugins);
+		for (Plugin plugin : scannedPlugins)
+		{
+			try
+			{
+				stopPlugin(plugin);
+				plugins.remove(plugin);
+			}
+			catch (PluginInstantiationException ex)
+			{
+				log.warn("Unable to stop plugin {}. {}", plugin.getClass().getSimpleName(), ex);
+			}
+		}
+	}
+
 	List<Plugin> scanAndInstantiate(ClassLoader classLoader, String packageName) throws IOException
 	{
 		MutableGraph<Class<? extends Plugin>> graph = GraphBuilder

--- a/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
@@ -36,6 +36,7 @@ import java.awt.Graphics;
 import java.awt.GraphicsConfiguration;
 import java.awt.LayoutManager;
 import java.awt.Rectangle;
+import java.awt.SystemTray;
 import java.awt.TrayIcon;
 import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
@@ -271,6 +272,16 @@ public class ClientUI
 				{
 					saveClientBoundsConfig();
 					runelite.shutdown();
+
+					if (SystemTray.isSupported())
+					{
+						SystemTray.getSystemTray().remove(trayIcon);
+					}
+
+					if (client != null)
+					{
+						client.stop();
+					}
 				},
 				this::showWarningOnExit
 			);


### PR DESCRIPTION
This was causing race with packet handler, and so spamming logs with
unrelated messages.