### PR TITLE
GroundMarker plugin: Clear local markers option

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/groundmarkers/GroundMarkerConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/groundmarkers/GroundMarkerConfig.java
@@ -36,6 +36,7 @@ import java.awt.Color;
 public interface GroundMarkerConfig extends Config
 {
 	@ConfigItem(
+		position = 0,
 		keyName = "markerColor",
 		name = "Color of the tile",
 		description = "Configures the color of marked tile"
@@ -43,5 +44,16 @@ public interface GroundMarkerConfig extends Config
 	default Color markerColor()
 	{
 		return Color.YELLOW;
+	}
+
+	@ConfigItem(
+			position = 1,
+			keyName = "clearLocalMarkers",
+			name = "Clear Local Marks",
+			description = "When this option is enabled you get the option to clear your local markers."
+	)
+	default boolean clearLocalMarkers()
+	{
+		return false;
 	}
 }


### PR DESCRIPTION
Option to clear ground markers in current region. (64x64 tiles)
![marker](https://user-images.githubusercontent.com/34197030/44864115-236d7480-ac7f-11e8-95b5-38fac4b312c6.gif)
Simple solution for some cases where people can't clear their markers

(PR #2208 already solved this but it got closed)