### PR TITLE
Added the maven-compiler-plugin with the useIncrementalCompilation set to false

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -165,6 +165,9 @@
 				<configuration>
 					<source>${java.version}</source>
 					<target>${java.version}</target>
+					<!-- Enable incremental compilation so that unchanged files dont have to be recompiled.
+					     False seems to actually enable incremental compilation, due to a bug in this mvn plugin:
+					     See: https://issues.apache.org/jira/browse/MCOMPILER-209 -->
 					<useIncrementalCompilation>false</useIncrementalCompilation>
 				</configuration>
 			</plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -165,6 +165,7 @@
 				<configuration>
 					<source>${java.version}</source>
 					<target>${java.version}</target>
+					<useIncrementalCompilation>false</useIncrementalCompilation>
 				</configuration>
 			</plugin>
 			<plugin>


### PR DESCRIPTION
This change will make sure that when recompiling your code, it doesnt have to recompile all the files when it detects a change in only one file. Now it only has to compile that one file. This significantly speeds up the compilation time.