### PR TITLE
Disable XP globes plugin by default

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesPlugin.java
@@ -48,7 +48,8 @@ import net.runelite.client.ui.overlay.OverlayManager;
 @PluginDescriptor(
 	name = "XP Globes",
 	description = "Show XP globes for the respective skill when gaining XP",
-	tags = {"experience", "levels", "overlay"}
+	tags = {"experience", "levels", "overlay"},
+	enabledByDefault = false
 )
 @PluginDependency(XpTrackerPlugin.class)
 public class XpGlobesPlugin extends Plugin


### PR DESCRIPTION
Vanilla RuneScape interface together with XP tracker already provides
all informations that is contained withing XP globes, so disable this
plugin by default to reduce the unnecessary noise for casual users.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>