### PR TITLE
Don't show orb overlays when the orbs are hidden

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/prayer/PrayerDoseOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/prayer/PrayerDoseOverlay.java
@@ -98,7 +98,7 @@ class PrayerDoseOverlay extends Overlay
 	public Dimension render(Graphics2D graphics)
 	{
 		final Widget xpOrb = client.getWidget(WidgetInfo.MINIMAP_QUICK_PRAYER_ORB);
-		if (xpOrb == null)
+		if (xpOrb == null || xpOrb.isHidden())
 		{
 			return null;
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/runenergy/RunEnergyOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/runenergy/RunEnergyOverlay.java
@@ -60,7 +60,7 @@ class RunEnergyOverlay extends Overlay
 	{
 		final Widget runOrb = client.getWidget(WidgetInfo.MINIMAP_TOGGLE_RUN_ORB);
 
-		if (runOrb == null)
+		if (runOrb == null || runOrb.isHidden())
 		{
 			return null;
 		}


### PR DESCRIPTION
Fixes both prayer and run energy orb overlays showing when minimap is hidden.

Before:
![image](https://user-images.githubusercontent.com/7273082/45038352-bcc6cd00-b069-11e8-87f5-8ac16d33135c.png)
After:
![image](https://user-images.githubusercontent.com/7273082/45038355-bfc1bd80-b069-11e8-84d1-5a469b4bf3a1.png)
