### PR TITLE
Show run energy remaining in overlay if orb shows run time remaining

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/runenergy/RunEnergyOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/runenergy/RunEnergyOverlay.java
@@ -43,13 +43,15 @@ class RunEnergyOverlay extends Overlay
 {
 	private final RunEnergyPlugin plugin;
 	private final Client client;
+	private final RunEnergyConfig config;
 	private final TooltipManager tooltipManager;
 
 	@Inject
-	private RunEnergyOverlay(final RunEnergyPlugin plugin, final Client client, final TooltipManager tooltipManager)
+	private RunEnergyOverlay(final RunEnergyPlugin plugin, final Client client, final RunEnergyConfig config, final TooltipManager tooltipManager)
 	{
 		this.plugin = plugin;
 		this.client = client;
+		this.config = config;
 		this.tooltipManager = tooltipManager;
 		setPosition(OverlayPosition.DYNAMIC);
 		setLayer(OverlayLayer.ABOVE_WIDGETS);
@@ -77,8 +79,16 @@ class RunEnergyOverlay extends Overlay
 		if (bounds.contains(mousePosition.getX(), mousePosition.getY()))
 		{
 			StringBuilder sb = new StringBuilder();
-			sb.append("Weight: ").append(client.getWeight()).append(" kg</br>")
-				.append("Run Time Remaining: ").append(plugin.getEstimatedRunTimeRemaining(false));
+			sb.append("Weight: ").append(client.getWeight()).append(" kg</br>");
+
+			if (config.replaceOrbText())
+			{
+				sb.append("Run Energy: ").append(client.getEnergy()).append("%");
+			}
+			else
+			{
+				sb.append("Run Time Remaining: ").append(plugin.getEstimatedRunTimeRemaining(false));
+			}
 
 			int secondsUntil100 = plugin.getEstimatedRecoverTimeRemaining();
 			if (secondsUntil100 > 0)


### PR DESCRIPTION
I'm not sure if there should be a separate toggle (probably not..) for this, since the hover does show in minutes:seconds instead of just seconds like the orb.

Before:
![image](https://user-images.githubusercontent.com/7273082/45039929-69ef1480-b06d-11e8-9bb0-d9b0e30eb7da.png)

After:
![image](https://user-images.githubusercontent.com/7273082/45039892-47f59200-b06d-11e8-8dda-fd781357acf1.png)
