### PR TITLE
Make sprite and widget sprite overrides more flexible

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/Client.java
+++ b/runelite-api/src/main/java/net/runelite/api/Client.java
@@ -1394,24 +1394,20 @@ public interface Client extends GameEngine
 	void queueChangedSkill(Skill skill);
 
 	/**
-	 * Sets a mapping of sprites to override.
+	 * Gets a mapping of sprites to override.
 	 * <p>
 	 * The key value in the map corresponds to the ID of the sprite,
 	 * and the value the sprite to replace it with.
-	 *
-	 * @param overrides the sprites to override
 	 */
-	void setSpriteOverrides(Map<Integer, SpritePixels> overrides);
+	Map<Integer, SpritePixels> getSpriteOverrides();
 
 	/**
-	 * Sets a mapping of widget sprites to override.
+	 * Gets a mapping of widget sprites to override.
 	 * <p>
 	 * The key value in the map corresponds to the packed widget ID,
 	 * and the value the sprite to replace the widgets sprite with.
-	 *
-	 * @param overrides the sprites to override
 	 */
-	void setWidgetSpriteOverrides(Map<Integer, SpritePixels> overrides);
+	Map<Integer, SpritePixels> getWidgetSpriteOverrides();
 
 	/**
 	 * Sets the compass sprite.
@@ -1419,6 +1415,13 @@ public interface Client extends GameEngine
 	 * @param spritePixels the new sprite
 	 */
 	void setCompass(SpritePixels spritePixels);
+
+	/**
+	 * Returns widget sprite cache, to be used with {@link Client#getSpriteOverrides()}
+	 *
+	 * @return the cache
+	 */
+	NodeCache getWidgetSpriteCache();
 
 	/**
 	 * Gets the current server tick count.

--- a/runelite-api/src/main/java/net/runelite/api/NodeCache.java
+++ b/runelite-api/src/main/java/net/runelite/api/NodeCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Adam <Adam@sigterm.info>
+ * Copyright (c) 2018, Tomas Slusny <slusnucky@gmail.com>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -22,16 +22,15 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package net.runelite.rs.api;
+package net.runelite.api;
 
-import net.runelite.api.NodeCache;
-import net.runelite.mapping.Import;
-
-public interface RSNodeCache extends NodeCache
+/**
+ * Represents a doubly linked node cache.
+ */
+public interface NodeCache
 {
-	@Import("get")
-	RSCacheableNode get(long id);
-
-	@Import("reset")
+	/**
+	 * Resets cache.
+	 */
 	void reset();
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/interfacestyles/InterfaceStylesPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/interfacestyles/InterfaceStylesPlugin.java
@@ -32,8 +32,6 @@ import java.awt.image.BufferedImage;
 import java.awt.image.PixelGrabber;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.HashMap;
-import java.util.Map;
 import javax.imageio.ImageIO;
 import javax.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
@@ -80,13 +78,7 @@ public class InterfaceStylesPlugin extends Plugin
 	@Override
 	protected void startUp() throws Exception
 	{
-		clientThread.invoke(() ->
-		{
-			overrideSprites();
-			overrideWidgetSprites();
-			restoreWidgetDimensions();
-			adjustWidgetDimensions();
-		});
+		clientThread.invoke(this::updateAllOverrides);
 	}
 
 	@Override
@@ -104,14 +96,7 @@ public class InterfaceStylesPlugin extends Plugin
 	{
 		if (config.getGroup().equals("interfaceStyles"))
 		{
-			clientThread.invoke(() ->
-			{
-				removeGameframe();
-				overrideSprites();
-				overrideWidgetSprites();
-				restoreWidgetDimensions();
-				adjustWidgetDimensions();
-			});
+			clientThread.invoke(this::updateAllOverrides);
 		}
 	}
 
@@ -121,10 +106,17 @@ public class InterfaceStylesPlugin extends Plugin
 		adjustWidgetDimensions();
 	}
 
+	private void updateAllOverrides()
+	{
+		removeGameframe();
+		overrideSprites();
+		overrideWidgetSprites();
+		restoreWidgetDimensions();
+		adjustWidgetDimensions();
+	}
+
 	private void overrideSprites()
 	{
-		Map<Integer, SpritePixels> overrides = new HashMap<>();
-
 		for (SpriteOverride spriteOverride : SpriteOverride.values())
 		{
 			for (Skin skin : spriteOverride.getSkin())
@@ -139,21 +131,25 @@ public class InterfaceStylesPlugin extends Plugin
 					}
 					else
 					{
-						overrides.put(spriteOverride.getSpriteID(), spritePixels);
+						client.getSpriteOverrides().put(spriteOverride.getSpriteID(), spritePixels);
 					}
 				}
 			}
 		}
+	}
 
+	private void restoreSprites()
+	{
 		client.getWidgetSpriteCache().reset();
-		client.getSpriteOverrides().clear();
-		client.getSpriteOverrides().putAll(overrides);
+
+		for (SpriteOverride spriteOverride : SpriteOverride.values())
+		{
+			client.getSpriteOverrides().remove(spriteOverride.getSpriteID());
+		}
 	}
 
 	private void overrideWidgetSprites()
 	{
-		Map<Integer, SpritePixels> widgetOverrides = new HashMap<>();
-
 		for (WidgetOverride widgetOverride : WidgetOverride.values())
 		{
 			if (widgetOverride.getSkin() == config.skin())
@@ -164,14 +160,22 @@ public class InterfaceStylesPlugin extends Plugin
 				{
 					for (WidgetInfo widgetInfo : widgetOverride.getWidgetInfo())
 					{
-						widgetOverrides.put(widgetInfo.getPackedId(), spritePixels);
+						client.getWidgetSpriteOverrides().put(widgetInfo.getPackedId(), spritePixels);
 					}
 				}
 			}
 		}
+	}
 
-		client.getWidgetSpriteOverrides().clear();
-		client.getWidgetSpriteOverrides().putAll(widgetOverrides);
+	private void restoreWidgetSprites()
+	{
+		for (WidgetOverride widgetOverride : WidgetOverride.values())
+		{
+			for (WidgetInfo widgetInfo : widgetOverride.getWidgetInfo())
+			{
+				client.getWidgetSpriteOverrides().remove(widgetInfo.getPackedId());
+			}
+		}
 	}
 
 	private SpritePixels getFileSpritePixels(String file, String subfolder)
@@ -295,8 +299,8 @@ public class InterfaceStylesPlugin extends Plugin
 
 	private void removeGameframe()
 	{
-		client.getSpriteOverrides().clear();
-		client.getWidgetSpriteOverrides().clear();
+		restoreSprites();
+		restoreWidgetSprites();
 
 		BufferedImage compassImage = spriteManager.getSprite(SpriteID.COMPASS_TEXTURE, 0);
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/interfacestyles/InterfaceStylesPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/interfacestyles/InterfaceStylesPlugin.java
@@ -145,7 +145,9 @@ public class InterfaceStylesPlugin extends Plugin
 			}
 		}
 
-		client.setSpriteOverrides(overrides);
+		client.getWidgetSpriteCache().reset();
+		client.getSpriteOverrides().clear();
+		client.getSpriteOverrides().putAll(overrides);
 	}
 
 	private void overrideWidgetSprites()
@@ -168,7 +170,8 @@ public class InterfaceStylesPlugin extends Plugin
 			}
 		}
 
-		client.setWidgetSpriteOverrides(widgetOverrides);
+		client.getWidgetSpriteOverrides().clear();
+		client.getWidgetSpriteOverrides().putAll(widgetOverrides);
 	}
 
 	private SpritePixels getFileSpritePixels(String file, String subfolder)
@@ -292,8 +295,8 @@ public class InterfaceStylesPlugin extends Plugin
 
 	private void removeGameframe()
 	{
-		client.setSpriteOverrides(null);
-		client.setWidgetSpriteOverrides(null);
+		client.getSpriteOverrides().clear();
+		client.getWidgetSpriteOverrides().clear();
 
 		BufferedImage compassImage = spriteManager.getSprite(SpriteID.COMPASS_TEXTURE, 0);
 

--- a/runelite-mixins/src/main/java/net/runelite/mixins/SpriteMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/SpriteMixin.java
@@ -25,6 +25,7 @@
  */
 package net.runelite.mixins;
 
+import java.util.HashMap;
 import java.util.Map;
 import net.runelite.api.SpritePixels;
 import net.runelite.api.mixins.Copy;
@@ -39,24 +40,23 @@ import net.runelite.rs.api.RSSpritePixels;
 public abstract class SpriteMixin implements RSClient
 {
 	@Inject
-	private static Map<Integer, SpritePixels> spriteOverrides;
+	private static final Map<Integer, SpritePixels> spriteOverrides = new HashMap<Integer, SpritePixels>();
 
 	@Inject
-	private static Map<Integer, SpritePixels> widgetSpriteOverrides;
+	private static final Map<Integer, SpritePixels> widgetSpriteOverrides = new HashMap<Integer, SpritePixels>();
 
 	@Inject
 	@Override
-	public void setSpriteOverrides(Map<Integer, SpritePixels> overrides)
+	public Map<Integer, SpritePixels> getSpriteOverrides()
 	{
-		getWidgetSpriteCache().reset();
-		spriteOverrides = overrides;
+		return spriteOverrides;
 	}
 
 	@Inject
 	@Override
-	public void setWidgetSpriteOverrides(Map<Integer, SpritePixels> overrides)
+	public Map<Integer, SpritePixels> getWidgetSpriteOverrides()
 	{
-		widgetSpriteOverrides = overrides;
+		return widgetSpriteOverrides;
 	}
 
 	@Copy("getSpriteAsSpritePixels")
@@ -68,14 +68,11 @@ public abstract class SpriteMixin implements RSClient
 	@Replace("getSpriteAsSpritePixels")
 	public static RSSpritePixels rl$loadSprite(RSIndexDataBase var0, int var1, int var2)
 	{
-		if (spriteOverrides != null)
-		{
-			SpritePixels sprite = spriteOverrides.get(var1);
+		SpritePixels sprite = spriteOverrides.get(var1);
 
-			if (sprite != null)
-			{
-				return (RSSpritePixels) sprite;
-			}
+		if (sprite != null)
+		{
+			return (RSSpritePixels) sprite;
 		}
 
 		return rs$loadSprite(var0, var1, var2);

--- a/runelite-mixins/src/main/java/net/runelite/mixins/WidgetSpriteMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/WidgetSpriteMixin.java
@@ -49,7 +49,7 @@ public abstract class WidgetSpriteMixin implements RSWidget
 	@Replace("getWidgetSprite")
 	public RSSpritePixels rl$getWidgetSprite(boolean var1)
 	{
-		if (getSpriteId() != -1 && widgetSpriteOverrides != null)
+		if (getSpriteId() != -1)
 		{
 			SpritePixels sprite = widgetSpriteOverrides.get(getId());
 

--- a/runescape-api/src/main/java/net/runelite/rs/api/RSClient.java
+++ b/runescape-api/src/main/java/net/runelite/rs/api/RSClient.java
@@ -645,6 +645,7 @@ public interface RSClient extends RSGameEngine, Client
 	void setCompass(SpritePixels spritePixels);
 
 	@Import("widgetSpriteCache")
+	@Override
 	RSNodeCache getWidgetSpriteCache();
 
 	@Import("oculusOrbState")


### PR DESCRIPTION
- Expose NodeCache interface in RuneLite
- Expose Client.getWidgetSpriteCache and reset method on it
- Change setters for sprite and widget overrides to be getters

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>