### PR TITLE
Scout overlay hotkey

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsConfig.java
@@ -87,16 +87,15 @@ public interface RaidsConfig extends Config
 		return false;
 	}
 
-    @ConfigItem(
-            keyName = "hotkey",
-            name = "Toggle scout overlay",
-            description = "When pressed the scout overlay will be toggled. Must enable show scout overlay in raid",
-            position = 5
-    )
-    default Keybind hotkey()
-    {
-        return Keybind.NOT_SET;
-    }
+	@ConfigItem(
+		keyName = "hotkey", name = "Toggle scout overlay",
+		description = "When pressed the scout overlay will be toggled. Must enable show scout overlay in raid",
+		position = 5
+	)
+	default Keybind hotkey()
+	{
+		return Keybind.NOT_SET;
+	}
 
 	@ConfigItem(
 		position = 6,

--- a/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsConfig.java
@@ -87,8 +87,19 @@ public interface RaidsConfig extends Config
 		return false;
 	}
 
+    @ConfigItem(
+            keyName = "hotkey",
+            name = "Scout overlay hotkey",
+            description = "When pressed the scout overlay will be toggled. Must enable show scout overlay in raid",
+            position = 5
+    )
+    default Keybind hotkey()
+    {
+        return Keybind.NOT_SET;
+    }
+
 	@ConfigItem(
-		position = 5,
+		position = 6,
 		keyName = "whitelistedRooms",
 		name = "Whitelisted rooms",
 		description = "Display whitelisted rooms in green on the overlay. Separate with comma (full name)"
@@ -99,7 +110,7 @@ public interface RaidsConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 6,
+		position = 7,
 		keyName = "blacklistedRooms",
 		name = "Blacklisted rooms",
 		description = "Display blacklisted rooms in red on the overlay. Separate with comma (full name)"
@@ -110,7 +121,7 @@ public interface RaidsConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 7,
+		position = 8,
 		keyName = "enableRotationWhitelist",
 		name = "Enable rotation whitelist",
 		description = "Enable the rotation whitelist"
@@ -121,7 +132,7 @@ public interface RaidsConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 8,
+		position = 9,
 		keyName = "whitelistedRotations",
 		name = "Whitelisted rotations",
 		description = "Warn when boss rotation doesn't match a whitelisted one. Add rotations like [tekton, muttadile, guardians]"
@@ -132,7 +143,7 @@ public interface RaidsConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 9,
+		position = 10,
 		keyName = "enableLayoutWhitelist",
 		name = "Enable layout whitelist",
 		description = "Enable the layout whitelist"
@@ -143,7 +154,7 @@ public interface RaidsConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 10,
+		position = 11,
 		keyName = "whitelistedLayouts",
 		name = "Whitelisted layouts",
 		description = "Warn when layout doesn't match a whitelisted one. Add layouts like CFSCPPCSCF separated with comma"
@@ -152,16 +163,4 @@ public interface RaidsConfig extends Config
 	{
 		return "";
 	}
-
-	@ConfigItem(
-			keyName = "hotkey",
-			name = "Disable/Enable scout overlay hotkey",
-			description = "When you press this key the scout overlay will be hidden/displayed.",
-			position = 11
-	)
-	default Keybind hotkey()
-	{
-		return Keybind.NOT_SET;
-	}
-
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsConfig.java
@@ -27,6 +27,7 @@ package net.runelite.client.plugins.raids;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.Keybind;
 
 @ConfigGroup("raids")
 public interface RaidsConfig extends Config
@@ -151,4 +152,16 @@ public interface RaidsConfig extends Config
 	{
 		return "";
 	}
+
+	@ConfigItem(
+			keyName = "hotkey",
+			name = "Disable/Enable scout overlay hotkey",
+			description = "When you press this key the scout overlay will be hidden/displayed.",
+			position = 11
+	)
+	default Keybind hotkey()
+	{
+		return Keybind.NOT_SET;
+	}
+
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsConfig.java
@@ -89,7 +89,7 @@ public interface RaidsConfig extends Config
 
     @ConfigItem(
             keyName = "hotkey",
-            name = "Scout overlay hotkey",
+            name = "Toggle scout overlay",
             description = "When pressed the scout overlay will be toggled. Must enable show scout overlay in raid",
             position = 5
     )

--- a/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsOverlay.java
@@ -29,6 +29,7 @@ import java.awt.Dimension;
 import java.awt.Graphics2D;
 import javax.inject.Inject;
 import lombok.Setter;
+import lombok.Getter;
 import net.runelite.client.plugins.raids.solver.Room;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayPosition;
@@ -43,7 +44,7 @@ public class RaidsOverlay extends Overlay
 	private RaidsConfig config;
 	private final PanelComponent panelComponent = new PanelComponent();
 
-	@Setter
+	@Getter @Setter
 	private boolean scoutOverlayShown = false;
 
 	@Inject

--- a/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsPlugin.java
@@ -617,9 +617,9 @@ public class RaidsPlugin extends Plugin
 		@Override
 		public void hotkeyPressed()
 		{
-			if(config.scoutOverlayInRaid() && raidStarted)
+			if (config.scoutOverlayInRaid() && raidStarted)
 			{
-				if(overlay.isScoutOverlayShown())
+				if (overlay.isScoutOverlayShown())
 				{
 					overlay.setScoutOverlayShown(false);
 				}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsPlugin.java
@@ -135,7 +135,7 @@ public class RaidsPlugin extends Plugin
 	@Getter
 	private boolean inRaidChambers;
 
-    private boolean raidStarted;
+	private boolean raidStarted;
 
 	private RaidsTimer timer;
 
@@ -320,7 +320,7 @@ public class RaidsPlugin extends Plugin
 		if (client.getVar(VarPlayer.IN_RAID_PARTY) == -1 && (!inRaidChambers || !config.scoutOverlayInRaid()))
 		{
 			overlay.setScoutOverlayShown(false);
-		    raidStarted = false;
+			raidStarted = false;
 		}
 	}
 


### PR DESCRIPTION
Added hotkey functionality to hide the chambers of xeric scout overlay once you have begun a raid. The "Show scout overlay inside raid" setting must also be enable for this to work. 

I could not find any issues opened for this enhancement, but I find it useful when I solo and want to check the layout without always having the overlay on.