### PR TITLE
widget:expose setchildren

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/widgets/Widget.java
+++ b/runelite-api/src/main/java/net/runelite/api/widgets/Widget.java
@@ -125,6 +125,11 @@ public interface Widget
 	Widget[] getChildren();
 
 	/**
+	 * Sets the widget children
+	 */
+	void setChildren(Widget[] children);
+
+	/**
 	 * Gets all dynamic children.
 	 *
 	 * @return the dynamic children

--- a/runescape-api/src/main/java/net/runelite/rs/api/RSWidget.java
+++ b/runescape-api/src/main/java/net/runelite/rs/api/RSWidget.java
@@ -37,7 +37,8 @@ public interface RSWidget extends Widget
 	RSWidget[] getChildren();
 
 	@Import("children")
-	void setChildren(RSWidget[] children);
+	@Override
+	void setChildren(Widget[] children);
 
 	@Import("id")
 	@Override


### PR DESCRIPTION
Some widgets set children to null vs just hiding all of the children when switching views. 