### PR TITLE
added swapping of the climb-up and climb-down options when clicking a ladder

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -239,4 +239,15 @@ public interface MenuEntrySwapperConfig extends Config
 	{
 		return false;
 	}
+
+	@ConfigItem(
+		position = 19,
+		keyName = "swapClimb",
+		name = "Climb",
+		description = "Swap Climb with Climb-Up or Climb-Down with Shift held when interacting with ladders"
+	)
+	default boolean swapClimb()
+	{
+		return false;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -460,6 +460,10 @@ public class MenuEntrySwapperPlugin extends Plugin
 		{
 			swap("chase", option, target, true);
 		}
+		else if (config.swapBirdhouseEmpty() && option.equals("interact") && target.contains("birdhouse"))
+		{
+			swap("empty", option, target, true);
+		}
 		else if (config.shiftClickCustomization() && shiftModifier && !option.equals("use"))
 		{
 			Integer customOption = getSwapConfig(itemId);
@@ -475,20 +479,26 @@ public class MenuEntrySwapperPlugin extends Plugin
 			swap("rub", option, target, true);
 			swap("teleport", option, target, true);
 		}
-		else if (option.equals("wield"))
+		else if (config.swapTeleportItem() && option.equals("wield"))
 		{
-			if (config.swapTeleportItem())
-			{
-				swap("teleport", option, target, true);
-			}
+			swap("teleport", option, target, true);
 		}
 		else if (config.swapBones() && option.equals("bury"))
 		{
 			swap("use", option, target, true);
 		}
-		else if (config.swapBirdhouseEmpty() && option.equals("interact") && target.contains("birdhouse"))
+
+		// Below here goes all menu options that change with the shift modifier key
+		if (config.swapClimb() && option.equals("climb") && target.contains("ladder"))
 		{
-			swap("empty", option, target, true);
+			if (shiftModifier)
+			{
+				swap("climb-down", option, target, true);
+			}
+			else
+			{
+				swap("climb-up", option, target, true);
+			}
 		}
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -489,7 +489,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 		}
 
 		// Below here goes all menu options that change with the shift modifier key
-		if (config.swapClimb() && option.equals("climb") && target.contains("ladder"))
+		if (config.swapClimb() && option.equals("climb"))
 		{
 			if (shiftModifier)
 			{


### PR DESCRIPTION
Adds an option to the menu swapper to swap the default climb option on ladders to climb-up or climb-down when shift is held

+ various cleanup/bugfix in menuentryswapper