### PR TITLE
hiscore plugin: Colorize "Lookup" player menu entry

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/hiscore/HiscorePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/hiscore/HiscorePlugin.java
@@ -201,6 +201,7 @@ public class HiscorePlugin extends Plugin
 			lookup.setType(MenuAction.RUNELITE.getId());
 			lookup.setParam0(event.getActionParam0());
 			lookup.setParam1(event.getActionParam1());
+			lookup.setIdentifier(event.getIdentifier());
 
 			insertMenuEntry(lookup, client.getMenuEntries(), after);
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsPlugin.java
@@ -111,7 +111,8 @@ public class PlayerIndicatorsPlugin extends Plugin
 			|| type == PLAYER_FIFTH_OPTION.getId()
 			|| type == PLAYER_SIXTH_OPTION.getId()
 			|| type == PLAYER_SEVENTH_OPTION.getId()
-			|| type == PLAYER_EIGTH_OPTION.getId())
+			|| type == PLAYER_EIGTH_OPTION.getId()
+			|| type == RUNELITE.getId())
 		{
 			final Player localPlayer = client.getLocalPlayer();
 			Player[] players = client.getCachedPlayers();


### PR DESCRIPTION
This will cause the "Lookup" player menu entry to be colorized according
to the player indicators plugin options.

Fixes runelite/runelite#3806