### PR TITLE
Fix Achievment Diary widget ids

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/widgets/WidgetID.java
+++ b/runelite-api/src/main/java/net/runelite/api/widgets/WidgetID.java
@@ -108,7 +108,7 @@ public class WidgetID
 	public static final int DESTROY_ITEM_GROUP_ID = 584;
 	public static final int VARROCK_MUSEUM_QUIZ_GROUP_ID = 533;
 	public static final int KILL_LOGS_GROUP_ID = 549;
-	public static final int DIARY_QUEST_GROUP_ID = 275;
+	public static final int DIARY_QUEST_GROUP_ID = 119;
 	public static final int THEATRE_OF_BLOOD_GROUP_ID = 23;
 	public static final int WORLD_SWITCHER_GROUP_ID = 69;
 	public static final int DIALOG_OPTION_GROUP_ID = 219;
@@ -609,7 +609,7 @@ public class WidgetID
 	static class Diary
 	{
 		static final int DIARY_TITLE = 2;
-		static final int DIARY_TEXT = 1;
+		static final int DIARY_TEXT = 3;
 	}
 
 	static class MTA


### PR DESCRIPTION
This makes the achievment diary plugin work again.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>