### PR TITLE
Box trap entry swap improvement

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -165,17 +165,39 @@ public interface MenuEntrySwapperConfig extends Config
 
 	@ConfigItem(
 		position = 12,
-		keyName = "swapBoxTrap",
-		name = "Reset",
+		keyName = "swapBoxTrapCheck",
+		name = "Reset trap",
 		description = "Swap Check with Reset on box trap"
 	)
-	default boolean swapBoxTrap()
+	default boolean swapBoxTrapCheck()
 	{
 		return true;
 	}
 
 	@ConfigItem(
-		position = 13,
+			position = 13,
+			keyName = "swapBoxTrapTake",
+			name = "Take trap",
+			description = "Swap Take with Lay on box trap"
+	)
+	default boolean swapBoxTrapTake()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+			position = 14,
+			keyName = "swapBoxTrapDismantle",
+			name = "Dismantle trap",
+			description = "Swap Dismantle with Reset on box trap"
+	)
+	default boolean swapBoxTrapDismantle()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		position = 15,
 		keyName = "swapTeleportItem",
 		name = "Teleport item",
 		description = "Swap Wear, Wield with Rub, Teleport on teleport item<br>Example: Amulet of glory, Ardougne cloak, Chronicle"
@@ -186,7 +208,7 @@ public interface MenuEntrySwapperConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 14,
+		position = 16,
 		keyName = "swapAbyssTeleport",
 		name = "Teleport to Abyss",
 		description = "Swap Talk-to with Teleport for the Mage of Zamorak"
@@ -197,7 +219,7 @@ public interface MenuEntrySwapperConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 15,
+		position = 17,
 		keyName = "swapTrade",
 		name = "Trade",
 		description = "Swap Talk-to with Trade on NPC<br>Example: Shop keeper, Shop assistant"
@@ -208,7 +230,7 @@ public interface MenuEntrySwapperConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 16,
+		position = 18,
 		keyName = "swapTravel",
 		name = "Travel",
 		description = "Swap Talk-to with Travel, Take-boat, Pay-fare, Charter on NPC<br>Example: Squire, Monk of Entrana, Customs officer, Trader Crewmember"
@@ -219,7 +241,7 @@ public interface MenuEntrySwapperConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 17,
+		position = 19,
 		keyName = "swapAssignment",
 		name = "Assignment",
 		description = "Swap Talk-to with Assignment for Slayer Masters. This will take priority over swapping Trade."
@@ -230,7 +252,7 @@ public interface MenuEntrySwapperConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 18,
+		position = 20,
 		keyName = "swapDecant",
 		name = "Decant",
 		description = "Swap Talk-to with Decant for Bob Barter and Murky Matt at the Grand Exchange."

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -166,7 +166,7 @@ public interface MenuEntrySwapperConfig extends Config
 	@ConfigItem(
 		position = 12,
 		keyName = "swapBoxTrapCheck",
-		name = "Reset trap",
+		name = "Check trap",
 		description = "Swap Check with Reset on box trap"
 	)
 	default boolean swapBoxTrapCheck()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -448,13 +448,17 @@ public class MenuEntrySwapperPlugin extends Plugin
 		{
 			swap("zanaris", option, target, false);
 		}
-		else if (config.swapBoxTrap() && (option.equals("check") || option.equals("dismantle")))
+		else if (config.swapBoxTrapCheck() && (option.equals("reset")))
 		{
 			swap("reset", option, target, true);
 		}
-		else if (config.swapBoxTrap() && option.equals("take"))
+		else if (config.swapBoxTrapTake() && option.equals("take"))
 		{
 			swap("lay", option, target, true);
+		}
+		else if (config.swapBoxTrapDismantle() && option.equals("dismantle"))
+		{
+			swap("reset", option, target, true);
 		}
 		else if (config.swapChase() && option.equals("pick-up"))
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -448,7 +448,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 		{
 			swap("zanaris", option, target, false);
 		}
-		else if (config.swapBoxTrapCheck() && (option.equals("reset")))
+		else if (config.swapBoxTrapCheck() && (option.equals("check")))
 		{
 			swap("reset", option, target, true);
 		}


### PR DESCRIPTION
Closes #5335 
There are now three options that relate to different states on a box trip while hunting. It should give a user the ability to swap every useful entry when using box traps.
The config options do as follows:

- Check trap: Swap "Check" with "Reset" on box trap when a chin is successfully caught.
- Take trap: Swap "Take" with "Lay" on box trap when a box is on the ground and needs to be built.
- Dismantle trap: "Swap" Dismantle with "Reset" on box trap when a chin has disabled a trap when unsuccessfully caught.

*There is currently no feature to swap "Investigate" and "Dismantle" when a trap is active and waiting to be tripped. It can be added but seems unnecessary and not useful.*