### PR TITLE
Make colon (":") enter chat in WASD mode

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/wasdcamera/WASDCameraListener.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/wasdcamera/WASDCameraListener.java
@@ -94,6 +94,7 @@ class WASDCameraListener extends MouseListener implements KeyListener
 				{
 					case KeyEvent.VK_ENTER:
 					case KeyEvent.VK_SLASH:
+					case KeyEvent.VK_COLON:
 						// refocus chatbox
 						plugin.setTyping(true);
 						clientThread.invoke(() ->


### PR DESCRIPTION
For quick entering in-game and RuneLite commands. Same principe as for
clan chat applies.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>