### PR TITLE
Add rightclick options plugin

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/rightclick/RightclickOptionsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/rightclick/RightclickOptionsConfig.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2017, Aria <aria@ar1as.space>
+ * Copyright (c) 2018, Bryan Keller <b@bk.gg>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package net.runelite.client.plugins.rightclick;
+
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+import net.runelite.client.plugins.rightclick.config.MenuHighlightMode;
+
+import java.awt.*;
+
+@ConfigGroup("rightclick")
+public interface RightclickOptionsConfig extends Config
+{
+	@ConfigItem(
+		keyName = "highlightedRightclickItems",
+		name = "Highlighted Menu Items",
+		description = "List of right-click menu entries to highlight, separated by commas.",
+		position = 0
+	)
+	default String getHighlightedRightclickItems()
+	{
+		return "";
+	}
+
+	@ConfigItem(
+		keyName = "hiddenItems",
+		name = "Hidden Items",
+		description = "List of right-click menu entries to prevent from appearing, separated by commas.",
+		position = 1
+	)
+	default String getHiddenItems()
+	{
+		return "";
+	}
+
+	@ConfigItem(
+		keyName = "menuHighlightMode",
+		name = "Menu Highlight Mode",
+		description = "Configures what to highlight in right-click menu",
+		position = 2
+	)
+	default MenuHighlightMode menuHighlightMode()
+	{
+		return MenuHighlightMode.NAME;
+	}
+
+	@ConfigItem(
+		keyName = "highlightedColor",
+		name = "Highlighted items color",
+		description = "Configures the color for highlighted entries",
+		position = 3
+	)
+	default Color highlightedColor()
+	{
+		return Color.decode("#AA00FF");
+	}
+
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/rightclick/RightclickOptionsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/rightclick/RightclickOptionsConfig.java
@@ -26,12 +26,11 @@
 
 package net.runelite.client.plugins.rightclick;
 
+import java.awt.Color;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
 import net.runelite.client.plugins.rightclick.config.MenuHighlightMode;
-
-import java.awt.*;
 
 @ConfigGroup("rightclick")
 public interface RightclickOptionsConfig extends Config

--- a/runelite-client/src/main/java/net/runelite/client/plugins/rightclick/RightclickOptionsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/rightclick/RightclickOptionsConfig.java
@@ -48,12 +48,12 @@ public interface RightclickOptionsConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "hiddenItems",
-		name = "Hidden Items",
-		description = "List of right-click menu entries to prevent from appearing, separated by commas.",
+		keyName = "dimmedItems",
+		name = "Dimmed Items",
+		description = "List of right-click menu entries to dim, separated by commas",
 		position = 1
 	)
-	default String getHiddenItems()
+	default String getDimmedItems()
 	{
 		return "";
 	}
@@ -70,14 +70,101 @@ public interface RightclickOptionsConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "highlightedColor",
-		name = "Highlighted items color",
-		description = "Configures the color for highlighted entries",
-		position = 3
+			keyName = "highlightedColor",
+			name = "Highlighted items color",
+			description = "Configures the color for highlighted entries",
+			position = 3
 	)
 	default Color highlightedColor()
 	{
-		return Color.decode("#AA00FF");
+		return Color.decode("#FF66AA");
 	}
 
+	@ConfigItem(
+			keyName = "dimmedColor",
+			name = "Dimmed items color",
+			description = "Configures the color for dimmed entries",
+			position = 4
+	)
+	default Color dimmedColor()
+	{
+		return Color.decode("#808080");
+	}
+
+	@ConfigItem(
+			keyName = "hideExamine",
+			name = "Hide \"Examine\"",
+			description = "Hides Examine from all right-click menus",
+			position = 5
+	)
+	default boolean hideExamine()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+			keyName = "hideTradeWith",
+			name = "Hide \"Trade with\"",
+			description = "Hides Trade from all right-click menus",
+			position = 6
+	)
+	default boolean hideTradeWith()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+			keyName = "hideFollow",
+			name = "Hide \"Follow\"",
+			description = "Hides Follow from all right-click menus",
+			position = 7
+	)
+	default boolean hideFollow()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+			keyName = "hideWithdraw5",
+			name = "Hide \"Withdraw-5\"",
+			description = "Hides Withdraw-5 from all right-click menus",
+			position = 8
+	)
+	default boolean hideWithdraw5()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+			keyName = "hideWithdraw10",
+			name = "Hide \"Withdraw-10\"",
+			description = "Hides Withdraw-10 from all right-click menus",
+			position = 9
+	)
+	default boolean hideWithdraw10()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+			keyName = "hideWithdrawAllButOne",
+			name = "Hide \"Withdraw-All-But-One\"",
+			description = "Hides WithdrawAllButOne from all right-click menus",
+			position = 10
+	)
+	default boolean hideWithdrawAllButOne()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+			keyName = "hideDepositWornItems",
+			name = "Hide \"Deposit worn items\"",
+			description = "Prevents you from depositing your worn items by accident",
+			position = 11
+	)
+	default boolean hideDepositWornItems()
+	{
+		return false;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/rightclick/RightclickOptionsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/rightclick/RightclickOptionsConfig.java
@@ -70,10 +70,10 @@ public interface RightclickOptionsConfig extends Config
 	}
 
 	@ConfigItem(
-			keyName = "highlightedColor",
-			name = "Highlighted items color",
-			description = "Configures the color for highlighted entries",
-			position = 3
+		keyName = "highlightedColor",
+		name = "Highlighted items color",
+		description = "Configures the color for highlighted entries",
+		position = 3
 	)
 	default Color highlightedColor()
 	{
@@ -81,10 +81,10 @@ public interface RightclickOptionsConfig extends Config
 	}
 
 	@ConfigItem(
-			keyName = "dimmedColor",
-			name = "Dimmed items color",
-			description = "Configures the color for dimmed entries",
-			position = 4
+		keyName = "dimmedColor",
+		name = "Dimmed items color",
+		description = "Configures the color for dimmed entries",
+		position = 4
 	)
 	default Color dimmedColor()
 	{
@@ -92,10 +92,10 @@ public interface RightclickOptionsConfig extends Config
 	}
 
 	@ConfigItem(
-			keyName = "hideExamine",
-			name = "Hide \"Examine\"",
-			description = "Hides Examine from all right-click menus",
-			position = 5
+		keyName = "hideExamine",
+		name = "Hide \"Examine\"",
+		description = "Hides Examine from all right-click menus",
+		position = 5
 	)
 	default boolean hideExamine()
 	{
@@ -103,10 +103,10 @@ public interface RightclickOptionsConfig extends Config
 	}
 
 	@ConfigItem(
-			keyName = "hideTradeWith",
-			name = "Hide \"Trade with\"",
-			description = "Hides Trade from all right-click menus",
-			position = 6
+		keyName = "hideTradeWith",
+		name = "Hide \"Trade with\"",
+		description = "Hides Trade from all right-click menus",
+		position = 6
 	)
 	default boolean hideTradeWith()
 	{
@@ -114,10 +114,10 @@ public interface RightclickOptionsConfig extends Config
 	}
 
 	@ConfigItem(
-			keyName = "hideFollow",
-			name = "Hide \"Follow\"",
-			description = "Hides Follow from all right-click menus",
-			position = 7
+		keyName = "hideFollow",
+		name = "Hide \"Follow\"",
+		description = "Hides Follow from all right-click menus",
+		position = 7
 	)
 	default boolean hideFollow()
 	{
@@ -125,10 +125,10 @@ public interface RightclickOptionsConfig extends Config
 	}
 
 	@ConfigItem(
-			keyName = "hideWithdraw5",
-			name = "Hide \"Withdraw-5\"",
-			description = "Hides Withdraw-5 from all right-click menus",
-			position = 8
+		keyName = "hideWithdraw5",
+		name = "Hide \"Withdraw-5\"",
+		description = "Hides Withdraw-5 from all right-click menus",
+		position = 8
 	)
 	default boolean hideWithdraw5()
 	{
@@ -136,10 +136,10 @@ public interface RightclickOptionsConfig extends Config
 	}
 
 	@ConfigItem(
-			keyName = "hideWithdraw10",
-			name = "Hide \"Withdraw-10\"",
-			description = "Hides Withdraw-10 from all right-click menus",
-			position = 9
+		keyName = "hideWithdraw10",
+		name = "Hide \"Withdraw-10\"",
+		description = "Hides Withdraw-10 from all right-click menus",
+		position = 9
 	)
 	default boolean hideWithdraw10()
 	{
@@ -147,10 +147,10 @@ public interface RightclickOptionsConfig extends Config
 	}
 
 	@ConfigItem(
-			keyName = "hideWithdrawAllButOne",
-			name = "Hide \"Withdraw-All-But-One\"",
-			description = "Hides WithdrawAllButOne from all right-click menus",
-			position = 10
+		keyName = "hideWithdrawAllButOne",
+		name = "Hide \"Withdraw-All-But-One\"",
+		description = "Hides WithdrawAllButOne from all right-click menus",
+		position = 10
 	)
 	default boolean hideWithdrawAllButOne()
 	{
@@ -158,10 +158,10 @@ public interface RightclickOptionsConfig extends Config
 	}
 
 	@ConfigItem(
-			keyName = "hideDepositWornItems",
-			name = "Hide \"Deposit worn items\"",
-			description = "Prevents you from depositing your worn items by accident",
-			position = 11
+		keyName = "hideDepositWornItems",
+		name = "Hide \"Deposit worn items\"",
+		description = "Prevents you from depositing your worn items by accident",
+		position = 11
 	)
 	default boolean hideDepositWornItems()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/rightclick/RightclickOptionsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/rightclick/RightclickOptionsPlugin.java
@@ -51,147 +51,172 @@ import java.util.stream.Stream;
 import static net.runelite.client.plugins.rightclick.config.MenuHighlightMode.*;
 
 @PluginDescriptor(
-        name = "Right-Click Menu",
-        description = "Changes the appearance of right-click menus",
-        tags = {"rightclick", "examine", "hide", "highlight"},
-        enabledByDefault = false
+	name = "Right-Click Menu",
+	description = "Changes the appearance of right-click menus",
+	tags = {"rightclick", "examine", "hide", "highlight"},
+	enabledByDefault = false
 )
-public class RightclickOptionsPlugin extends Plugin {
-    // Based on grounditems plugin
+public class RightclickOptionsPlugin extends Plugin
+{
+	// Based on grounditems plugin
 
-    private static final Splitter COMMA_SPLITTER = Splitter
-            .on(",")
-            .omitEmptyStrings()
-            .trimResults();
+	private static final Splitter COMMA_SPLITTER = Splitter
+		.on(",")
+		.omitEmptyStrings()
+		.trimResults();
 
-    private List<String> highlightedItemsList = new CopyOnWriteArrayList<>();
-    private List<String> dimmedItemsList = new CopyOnWriteArrayList<>();
-    private List<String> hiddenItemList = new CopyOnWriteArrayList<>();
+	private List<String> highlightedItemsList = new CopyOnWriteArrayList<>();
+	private List<String> dimmedItemsList = new CopyOnWriteArrayList<>();
+	private List<String> hiddenItemList = new CopyOnWriteArrayList<>();
 
-    @Inject
-    private Client client;
+	@Inject
+	private Client client;
 
-    @Inject
-    private RightclickOptionsConfig config;
+	@Inject
+	private RightclickOptionsConfig config;
 
-    private Color highlightedColor;
-    private Color dimmedColor;
+	private Color highlightedColor;
+	private Color dimmedColor;
 
-    @Provides
-    RightclickOptionsConfig provideConfig(ConfigManager configManager) {
-        return configManager.getConfig(RightclickOptionsConfig.class);
-    }
+	@Provides
+	RightclickOptionsConfig provideConfig(ConfigManager configManager)
+	{
+		return configManager.getConfig(RightclickOptionsConfig.class);
+	}
 
-    @Override
-    protected void startUp() {
-        reset();
-    }
+	@Override
+	protected void startUp()
+	{
+		reset();
+	}
 
-    @Override
-    protected void shutDown() throws Exception {
-        highlightedItemsList = null;
-        dimmedItemsList = null;
-        hiddenItemList = null;
-    }
+	@Override
+	protected void shutDown() throws Exception
+	{
+		highlightedItemsList = null;
+		dimmedItemsList = null;
+		hiddenItemList = null;
+	}
 
-    @Subscribe
-    public void onConfigChanged(ConfigChanged event) {
-        if (event.getGroup().equals("rightclick")) {
-            reset();
-        }
-    }
+	@Subscribe
+	public void onConfigChanged(ConfigChanged event)
+	{
+		if (event.getGroup().equals("rightclick"))
+		{
+			reset();
+		}
+	}
 
-    private void reset() {
-        // gets the highlighted items from the text box in the config
-        highlightedItemsList = COMMA_SPLITTER.splitToList(config.getHighlightedRightclickItems());
+	private void reset()
+	{
+		// gets the highlighted items from the text box in the config
+		highlightedItemsList = COMMA_SPLITTER.splitToList(config.getHighlightedRightclickItems());
 
-        // gets the hidden items from the text box in the config
-        dimmedItemsList = COMMA_SPLITTER.splitToList(config.getDimmedItems());
+		// gets the hidden items from the text box in the config
+		dimmedItemsList = COMMA_SPLITTER.splitToList(config.getDimmedItems());
 
-        hiddenItemList = new ArrayList<>();
-        if (config.hideExamine()) {
-            hiddenItemList.add("Examine");
-        }
-        if (config.hideFollow()) {
-            hiddenItemList.add("Follow");
-        }
-        if (config.hideTradeWith()) {
-            hiddenItemList.add("Trade with");
-        }
-        if (config.hideWithdraw5()) {
-            hiddenItemList.add("Withdraw-5");
-        }
-        if (config.hideWithdraw10()) {
-            hiddenItemList.add("Withdraw-10");
-        }
-        if (config.hideWithdrawAllButOne()) {
-            hiddenItemList.add("Withdraw-All-But-One");
-        }
-        if (config.hideDepositWornItems()) {
-            hiddenItemList.add("Deposit worn items");
-        }
+		hiddenItemList = new ArrayList<>();
+		if (config.hideExamine())
+		{
+			hiddenItemList.add("Examine");
+		}
+		if (config.hideFollow())
+		{
+			hiddenItemList.add("Follow");
+		}
+		if (config.hideTradeWith())
+		{
+			hiddenItemList.add("Trade with");
+		}
+		if (config.hideWithdraw5())
+		{
+			hiddenItemList.add("Withdraw-5");
+		}
+		if (config.hideWithdraw10())
+		{
+			hiddenItemList.add("Withdraw-10");
+		}
+		if (config.hideWithdrawAllButOne())
+		{
+			hiddenItemList.add("Withdraw-All-But-One");
+		}
+		if (config.hideDepositWornItems())
+		{
+			hiddenItemList.add("Deposit worn items");
+		}
 
-        highlightedColor = config.highlightedColor();
-        dimmedColor = config.dimmedColor();
-    }
+		highlightedColor = config.highlightedColor();
+		dimmedColor = config.dimmedColor();
+	}
 
-    @Subscribe
-    public void onMenuEntryAdded(MenuEntryAdded event) {
-        MenuEntry[] menuEntries = client.getMenuEntries();
-        MenuEntry lastEntry = menuEntries[menuEntries.length - 1];
+	@Subscribe
+	public void onMenuEntryAdded(MenuEntryAdded event)
+	{
+		MenuEntry[] menuEntries = client.getMenuEntries();
+		MenuEntry lastEntry = menuEntries[menuEntries.length - 1];
 
-        // Check for removal of entries
-        if (hiddenItemList.contains(lastEntry.getOption()))
-        {
-            if (menuEntries.length > 1)
-            {
-                MenuEntry[] newEntries = Arrays.copyOfRange(menuEntries, 0, menuEntries.length - 1);
-                client.setMenuEntries(newEntries);
-            }
-            else
-            {
-                client.setMenuEntries(new MenuEntry[]{});
-            }
-        }
+		// Check for removal of entries
+		if (hiddenItemList.contains(lastEntry.getOption()))
+		{
+			if (menuEntries.length > 1)
+			{
+				MenuEntry[] newEntries = Arrays.copyOfRange(menuEntries, 0, menuEntries.length - 1);
+				client.setMenuEntries(newEntries);
+			}
+			else
+			{
+				client.setMenuEntries(new MenuEntry[]{});
+			}
+		}
 
-        // Highlighted options and dimmed options
-        if (highlightedColor != null &&
-                matchesPatterns(event.getOption(), event.getTarget(), highlightedItemsList)) {
-            final MenuHighlightMode mode = config.menuHighlightMode();
+		// Highlighted options and dimmed options
+		if (highlightedColor != null &&
+			matchesPatterns(event.getOption(), event.getTarget(), highlightedItemsList))
+		{
+			final MenuHighlightMode mode = config.menuHighlightMode();
 
-            if (mode == BOTH || mode == OPTION) {
-                lastEntry.setOption(ColorUtil.prependColorTag(lastEntry.getOption(), highlightedColor));
-            }
-            if (mode == BOTH || mode == NAME) {
-                String target = lastEntry.getTarget().substring(lastEntry.getTarget().indexOf(">") + 1);
-                lastEntry.setTarget(ColorUtil.prependColorTag(target, highlightedColor));
-            }
-            client.setMenuEntries(menuEntries);
-        } else if (dimmedColor != null &&
-                matchesPatterns(event.getOption(), event.getTarget(), dimmedItemsList)) {
-            final MenuHighlightMode mode = config.menuHighlightMode();
+			if (mode == BOTH || mode == OPTION)
+			{
+				lastEntry.setOption(ColorUtil.prependColorTag(lastEntry.getOption(), highlightedColor));
+			}
+			if (mode == BOTH || mode == NAME)
+			{
+				String target = lastEntry.getTarget().substring(lastEntry.getTarget().indexOf(">") + 1);
+				lastEntry.setTarget(ColorUtil.prependColorTag(target, highlightedColor));
+			}
+			client.setMenuEntries(menuEntries);
+		}
+		else if (dimmedColor != null &&
+			matchesPatterns(event.getOption(), event.getTarget(), dimmedItemsList))
+		{
+			final MenuHighlightMode mode = config.menuHighlightMode();
 
-            if (mode == BOTH || mode == OPTION) {
-                lastEntry.setOption(ColorUtil.prependColorTag(lastEntry.getOption(), dimmedColor));
-            }
-            if (mode == BOTH || mode == NAME) {
-                String target = lastEntry.getTarget().substring(lastEntry.getTarget().indexOf(">") + 1);
-                lastEntry.setTarget(ColorUtil.prependColorTag(target, dimmedColor));
-            }
-            client.setMenuEntries(menuEntries);
-        }
+			if (mode == BOTH || mode == OPTION)
+			{
+				lastEntry.setOption(ColorUtil.prependColorTag(lastEntry.getOption(), dimmedColor));
+			}
+			if (mode == BOTH || mode == NAME)
+			{
+				String target = lastEntry.getTarget().substring(lastEntry.getTarget().indexOf(">") + 1);
+				lastEntry.setTarget(ColorUtil.prependColorTag(target, dimmedColor));
+			}
+			client.setMenuEntries(menuEntries);
+		}
 
-    }
+	}
 
-    boolean matchesPatterns(String action, String target, List<String> patterns) {
-        for (String pattern : patterns) {
-            if (WildcardMatcher.matches(pattern, action) ||
-                    WildcardMatcher.matches(pattern, target) ||
-                    WildcardMatcher.matches(pattern, action + " " + target)) {
-                return true;
-            }
-        }
-        return false;
-    }
+	boolean matchesPatterns(String action, String target, List<String> patterns)
+	{
+		for (String pattern : patterns)
+		{
+			if (WildcardMatcher.matches(pattern, action) ||
+				WildcardMatcher.matches(pattern, target) ||
+				WildcardMatcher.matches(pattern, action + " " + target))
+			{
+				return true;
+			}
+		}
+		return false;
+	}
 
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/rightclick/RightclickOptionsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/rightclick/RightclickOptionsPlugin.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 2017, Aria <aria@ar1as.space>
+ * Copyright (c) 2018, Adam <Adam@sigterm.info>
+ * Copyright (c) 2018, Bryan Keller <b@bk.gg>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.rightclick;
+
+import com.google.common.base.Splitter;
+import com.google.common.eventbus.Subscribe;
+import com.google.inject.Provides;
+import lombok.Getter;
+import net.runelite.api.*;
+import net.runelite.api.events.*;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.plugins.rightclick.config.MenuHighlightMode;
+import net.runelite.client.util.ColorUtil;
+import net.runelite.client.util.WildcardMatcher;
+
+import javax.inject.Inject;
+import java.awt.*;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import static net.runelite.client.plugins.rightclick.config.MenuHighlightMode.*;
+
+@PluginDescriptor(
+	name = "Right-Click Menu",
+	description = "Changes the appearance of right-click menus",
+	tags = {"rightclick", "examine", "hide", "highlight"},
+	enabledByDefault = false
+)
+public class RightclickOptionsPlugin extends Plugin
+{
+	// Based on grounditems plugin
+
+	private static final Splitter COMMA_SPLITTER = Splitter
+		.on(",")
+		.omitEmptyStrings()
+		.trimResults();
+
+	private List<String> hiddenItemList = new CopyOnWriteArrayList<>();
+	private List<String> highlightedItemsList = new CopyOnWriteArrayList<>();
+
+	@Inject
+	private Client client;
+
+	@Inject
+	private RightclickOptionsConfig config;
+
+	@Getter
+	private Color highlightedColor;
+
+	@Provides
+	RightclickOptionsConfig provideConfig(ConfigManager configManager)
+	{
+		return configManager.getConfig(RightclickOptionsConfig.class);
+	}
+
+	@Override
+	protected void startUp()
+	{
+		reset();
+	}
+
+	@Override
+	protected void shutDown() throws Exception
+	{
+		hiddenItemList = null;
+		highlightedItemsList = null;
+	}
+
+	@Subscribe
+	public void onConfigChanged(ConfigChanged event)
+	{
+		if (event.getGroup().equals("rightclick"))
+		{
+			reset();
+		}
+	}
+
+	private void reset()
+	{
+		// gets the hidden items from the text box in the config
+		hiddenItemList = COMMA_SPLITTER.splitToList(config.getHiddenItems());
+
+		// gets the highlighted items from the text box in the config
+		highlightedItemsList = COMMA_SPLITTER.splitToList(config.getHighlightedRightclickItems());
+
+		highlightedColor = config.highlightedColor();
+	}
+
+	@Subscribe
+	public void onMenuEntryAdded(MenuEntryAdded event)
+	{
+		MenuEntry[] menuEntries = client.getMenuEntries();
+		MenuEntry lastEntry = menuEntries[menuEntries.length - 1];
+
+		if (matchesPatterns(event.getOption(), event.getTarget(), hiddenItemList))
+		{
+			if (menuEntries.length > 1)
+			{
+				MenuEntry[] newEntries = Arrays.copyOfRange(menuEntries, 0, menuEntries.length - 1);
+				client.setMenuEntries(newEntries);
+			}
+			else
+			{
+				client.setMenuEntries(new MenuEntry[]{});
+			}
+		}
+		else if (highlightedColor != null &&
+			matchesPatterns(event.getOption(), event.getTarget(), highlightedItemsList))
+		{
+			final MenuHighlightMode mode = config.menuHighlightMode();
+
+			if (mode == BOTH || mode == OPTION)
+			{
+				lastEntry.setOption(ColorUtil.prependColorTag(lastEntry.getOption(), highlightedColor));
+			}
+
+			if (mode == BOTH || mode == NAME)
+			{
+				String target = lastEntry.getTarget().substring(lastEntry.getTarget().indexOf(">") + 1);
+				lastEntry.setTarget(ColorUtil.prependColorTag(target, highlightedColor));
+			}
+			client.setMenuEntries(menuEntries);
+		}
+
+	}
+
+	boolean matchesPatterns(String action, String target, List<String> patterns)
+	{
+		for (String pattern : patterns)
+		{
+			if (WildcardMatcher.matches(pattern, action) ||
+				WildcardMatcher.matches(pattern, target) ||
+				WildcardMatcher.matches(pattern, action + " " + target))
+			{
+				return true;
+			}
+		}
+		return false;
+	}
+
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/rightclick/RightclickOptionsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/rightclick/RightclickOptionsPlugin.java
@@ -29,26 +29,25 @@ package net.runelite.client.plugins.rightclick;
 import com.google.common.base.Splitter;
 import com.google.common.eventbus.Subscribe;
 import com.google.inject.Provides;
-import lombok.Getter;
-import net.runelite.api.*;
-import net.runelite.api.events.*;
-import net.runelite.client.config.ConfigManager;
-import net.runelite.client.plugins.Plugin;
-import net.runelite.client.plugins.PluginDescriptor;
-import net.runelite.client.plugins.rightclick.config.MenuHighlightMode;
-import net.runelite.client.util.ColorUtil;
-import net.runelite.client.util.WildcardMatcher;
-
-import javax.inject.Inject;
-import java.awt.*;
+import java.awt.Color;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
-import static net.runelite.client.plugins.rightclick.config.MenuHighlightMode.*;
+import javax.inject.Inject;
+import net.runelite.api.Client;
+import net.runelite.api.MenuEntry;
+import net.runelite.api.events.ConfigChanged;
+import net.runelite.api.events.MenuEntryAdded;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.plugins.rightclick.config.MenuHighlightMode;
+import static net.runelite.client.plugins.rightclick.config.MenuHighlightMode.BOTH;
+import static net.runelite.client.plugins.rightclick.config.MenuHighlightMode.NAME;
+import static net.runelite.client.plugins.rightclick.config.MenuHighlightMode.OPTION;
+import net.runelite.client.util.ColorUtil;
+import net.runelite.client.util.WildcardMatcher;
 
 @PluginDescriptor(
 	name = "Right-Click Menu",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/rightclick/WildcardMatchLoader.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/rightclick/WildcardMatchLoader.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2018, Tomas Slusny <slusnucky@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.rightclick;
+
+import com.google.common.base.Strings;
+import com.google.common.cache.CacheLoader;
+import net.runelite.client.util.WildcardMatcher;
+
+import javax.annotation.Nonnull;
+import java.util.List;
+
+class WildcardMatchLoader extends CacheLoader<String, Boolean>
+{
+	private final List<String> nameFilters;
+
+	WildcardMatchLoader(List<String> nameFilters)
+	{
+		this.nameFilters = nameFilters;
+	}
+
+	@Override
+	public Boolean load(@Nonnull final String key)
+	{
+		if (Strings.isNullOrEmpty(key))
+		{
+			return false;
+		}
+
+		final String filteredName = key.trim();
+
+		for (final String filter : nameFilters)
+		{
+			if (WildcardMatcher.matches(filter, filteredName))
+			{
+				return true;
+			}
+		}
+
+		return false;
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/rightclick/config/MenuHighlightMode.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/rightclick/config/MenuHighlightMode.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2018, Tomas Slusny <slusnucky@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.rightclick.config;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum MenuHighlightMode
+{
+	OPTION("Menu option"),
+	NAME("Menu item name"),
+	BOTH("Both");
+
+	private final String name;
+
+	@Override
+	public String toString()
+	{
+		return name;
+	}
+}


### PR DESCRIPTION
Adds a plugin that can

* Highlight user-defined right-click menu items

* Dim user-defined right-click menu items

* Hide some pre-selected menu items:

   * Examine
   * Trade with
   * Follow
   * Withdraw-5
   * Withdraw-10
   * Withdraw-All-But-One
   * Deposit worn items

Example:

![image](https://user-images.githubusercontent.com/7691630/45398396-89f07c00-b609-11e8-9154-7444ac0475ac.png)

