### PR TITLE
Expand checkstyle

### DIFF
--- a/cache/src/main/java/net/runelite/cache/definitions/loaders/SpriteLoader.java
+++ b/cache/src/main/java/net/runelite/cache/definitions/loaders/SpriteLoader.java
@@ -161,7 +161,9 @@ public class SpriteLoader
 					int index = pixelPaletteIndicies[j];
 
 					if (index != 0)
+					{
 						pixelAlphas[j] = (byte) 0xFF;
+					}
 				}
 			}
 

--- a/cache/src/main/java/net/runelite/cache/definitions/loaders/TextureLoader.java
+++ b/cache/src/main/java/net/runelite/cache/definitions/loaders/TextureLoader.java
@@ -46,7 +46,9 @@ public class TextureLoader
 		int[] files = new int[count];
 
 		for (int i = 0; i < count; ++i)
+		{
 			files[i] = is.readUnsignedShort();
+		}
 
 		def.setFileIds(files);
 

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -26,6 +26,7 @@
 <!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
         "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
 <module name="Checker">
+	<property name="charset" value="UTF-8"/>
 	<module name="TreeWalker">
 		<module name="LeftCurly">
 			<property name="option" value="nl"/>

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -34,6 +34,9 @@
 		<module name="RightCurly">
 			<property name="option" value="alone"/>
 		</module>
+		<module name="NeedBraces">
+			<property name="allowEmptyLoopBody" value="true"/>
+		</module>
 		<!-- require tabs for indenting - https://stackoverflow.com/a/28550141 -->
 		<module name="RegexpSinglelineJava">
 			<property name="format" value="^\t* "/>
@@ -45,6 +48,9 @@
 			<property name="tokens" value="COMMA"/>
 		</module>
 		<module name="UnusedImports"/>
+		<module name="AvoidStarImport">
+			<property name="allowStaticMemberImports" value="true"/>
+		</module>
 		<module name="SuppressionCommentFilter"/>
 	</module>
 	<module name="RegexpMultiline">

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/special/SpicyStew.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/special/SpicyStew.java
@@ -28,7 +28,10 @@ import java.util.ArrayList;
 import java.util.List;
 import net.runelite.api.Client;
 import net.runelite.api.Varbits;
-import net.runelite.client.plugins.itemstats.*;
+import net.runelite.client.plugins.itemstats.Effect;
+import net.runelite.client.plugins.itemstats.Positivity;
+import net.runelite.client.plugins.itemstats.StatChange;
+import net.runelite.client.plugins.itemstats.StatsChanges;
 import net.runelite.client.plugins.itemstats.stats.Stat;
 import net.runelite.client.plugins.itemstats.stats.Stats;
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/puzzlesolver/solver/heuristics/ManhattanDistance.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/puzzlesolver/solver/heuristics/ManhattanDistance.java
@@ -87,32 +87,56 @@ public class ManhattanDistance implements Heuristic
 				int targetX = piece % DIMENSION;
 
 				// right
-				if (targetX > x) value++;
-				else value--;
+				if (targetX > x)
+				{
+					value++;
+				}
+				else
+				{
+					value--;
+				}
 			}
 			else if (x2 < x)
 			{
 				int targetX = piece % DIMENSION;
 
 				// left
-				if (targetX < x) value++;
-				else value--;
+				if (targetX < x)
+				{
+					value++;
+				}
+				else
+				{
+					value--;
+				}
 			}
 			else if (y2 > y)
 			{
 				int targetY = piece / DIMENSION;
 
 				// down
-				if (targetY > y) value++;
-				else value--;
+				if (targetY > y)
+				{
+					value++;
+				}
+				else
+				{
+					value--;
+				}
 			}
 			else
 			{
 				int targetY = piece / DIMENSION;
 
 				// up
-				if (targetY < y) value++;
-				else value--;
+				if (targetY < y)
+				{
+					value++;
+				}
+				else
+				{
+					value--;
+				}
 			}
 		}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/SkillCalculator.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/SkillCalculator.java
@@ -151,10 +151,14 @@ class SkillCalculator extends JPanel
 		double xp = 0;
 
 		for (UIActionSlot slot : combinedActionSlots)
+		{
 			xp += slot.getValue();
+		}
 
 		if (neededXP > 0)
+		{
 			actionCount = (int) Math.ceil(neededXP / xp);
+		}
 
 		combinedActionSlot.setText(formatXPActionString(xp, actionCount, "exp - "));
 	}
@@ -162,7 +166,9 @@ class SkillCalculator extends JPanel
 	private void clearCombinedSlots()
 	{
 		for (UIActionSlot slot : combinedActionSlots)
+		{
 			slot.setSelected(false);
+		}
 
 		combinedActionSlots.clear();
 	}
@@ -214,12 +220,18 @@ class SkillCalculator extends JPanel
 				public void mousePressed(MouseEvent e)
 				{
 					if (!e.isShiftDown())
+					{
 						clearCombinedSlots();
+					}
 
 					if (slot.isSelected())
+					{
 						combinedActionSlots.remove(slot);
+					}
 					else
+					{
 						combinedActionSlots.add(slot);
+					}
 
 					slot.setSelected(!slot.isSelected());
 					updateCombinedAction();
@@ -242,7 +254,9 @@ class SkillCalculator extends JPanel
 			double xp = (action.isIgnoreBonus()) ? action.getXp() : action.getXp() * xpFactor;
 
 			if (neededXP > 0)
+			{
 				actionCount = (int) Math.ceil(neededXP / xp);
+			}
 
 			slot.setText("Lvl. " + action.getLevel() + " (" + formatXPActionString(xp, actionCount, "exp) - "));
 			slot.setAvailable(currentLevel >= action.getLevel());

--- a/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/UIActionSlot.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/UIActionSlot.java
@@ -116,9 +116,13 @@ class UIActionSlot extends JPanel
 		JLabel uiIcon = new JLabel();
 
 		if (action.getIcon() != null)
+		{
 			SkillCalculator.itemManager.getImage(action.getIcon()).addTo(uiIcon);
+		}
 		else if (action.getSprite() != null)
+		{
 			SkillCalculator.spriteManager.addSpriteTo(uiIcon, action.getSprite(), 0);
+		}
 
 		uiIcon.setMinimumSize(ICON_SIZE);
 		uiIcon.setMaximumSize(ICON_SIZE);


### PR DESCRIPTION
This introduces the charset property to help avoid issues on Windows machines, and adds rules regarding braces (required except for empty-body loops) and import wildcards (disallowed, except static imports).

Depends on !25