### PR TITLE
diaryreqs: Update scrollbar with new length

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/ScriptID.java
+++ b/runelite-api/src/main/java/net/runelite/api/ScriptID.java
@@ -55,6 +55,15 @@ public final class ScriptID
 	public static final int CLOSE_CHATBOX_INPUT = 299;
 
 	/**
+	 * Updates the Diary/Quest interface's scrollbar
+	 * <ul>
+	 * <li> int (boolean) Reset scroll position </li>
+	 * <li> int Number of lines </li>
+	 * </ul>
+	 */
+	public static final int DIARY_QUEST_UPDATE_LINECOUNT = 2523;
+
+	/**
 	 * Initializes the chatbox input to use RuneLite callbacks
 	 * <ul>
 	 * <li> String  Prompt text </li>

--- a/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/DiaryRequirementsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/DiaryRequirementsPlugin.java
@@ -35,10 +35,12 @@ import java.util.Map;
 import javax.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
+import net.runelite.api.ScriptID;
 import net.runelite.api.events.WidgetLoaded;
 import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetID;
 import net.runelite.api.widgets.WidgetInfo;
+import net.runelite.client.callback.ClientThread;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.plugins.achievementdiary.diaries.ArdougneDiaryRequirement;
@@ -65,6 +67,9 @@ public class DiaryRequirementsPlugin extends Plugin
 {
 	@Inject
 	private Client client;
+
+	@Inject
+	private ClientThread clientThread;
 
 	@Subscribe
 	public void onWidgetLoaded(final WidgetLoaded event)
@@ -150,11 +155,20 @@ public class DiaryRequirementsPlugin extends Plugin
 			}
 		}
 
+		int lastLine = 0;
 		for (int i = 0; i < newRequirements.size() && i < children.length; i++)
 		{
 			Widget achievementWidget = children[i];
-			achievementWidget.setText(newRequirements.get(i));
+			String text = newRequirements.get(i);
+			achievementWidget.setText(text);
+			if (text != null && !text.isEmpty())
+			{
+				lastLine = i;
+			}
 		}
+
+		int numLines = lastLine;
+		clientThread.invokeLater(() -> client.runScript(ScriptID.DIARY_QUEST_UPDATE_LINECOUNT, 1, numLines));
 	}
 
 	private List<String> getOriginalAchievements(Widget[] children)


### PR DESCRIPTION
This interface was ported to a different widget (in #5346), but that interface has a dynamic length, controlled by cs2 2523, which is called by the server when the interface is filled. Simply call the cs2 again after the next one has ran with our new linecount.