### PR TITLE
Deprecate queries with already existing events

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/queries/ActorQuery.java
+++ b/runelite-api/src/main/java/net/runelite/api/queries/ActorQuery.java
@@ -29,6 +29,13 @@ import net.runelite.api.Actor;
 import net.runelite.api.Query;
 import net.runelite.api.coords.LocalPoint;
 
+/**
+ * Used for getting players in view,deprecated as of existence of Actor spawn events
+ *
+ * @see net.runelite.api.events.ActorSpawned
+ * @see net.runelite.api.events.ActorDespawned
+ */
+@Deprecated
 public abstract class ActorQuery<EntityType extends Actor, QueryType> extends Query<EntityType, QueryType>
 {
 	@SuppressWarnings("unchecked")

--- a/runelite-api/src/main/java/net/runelite/api/queries/DecorativeObjectQuery.java
+++ b/runelite-api/src/main/java/net/runelite/api/queries/DecorativeObjectQuery.java
@@ -32,6 +32,14 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Objects;
 
+/**
+ * Used for getting decorative objects in view, deprecated as of existence of DecorativeObject spawn events
+ *
+ * @see net.runelite.api.events.DecorativeObjectSpawned
+ * @see net.runelite.api.events.DecorativeObjectDespawned
+ * @see net.runelite.api.events.DecorativeObjectChanged
+ */
+@Deprecated
 public class DecorativeObjectQuery extends TileObjectQuery<DecorativeObject, DecorativeObjectQuery>
 {
 	@Override

--- a/runelite-api/src/main/java/net/runelite/api/queries/GameObjectQuery.java
+++ b/runelite-api/src/main/java/net/runelite/api/queries/GameObjectQuery.java
@@ -33,6 +33,14 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Objects;
 
+/**
+ * Used for getting game objects in view,deprecated as of existence of GameObject spawn events
+ *
+ * @see net.runelite.api.events.GameObjectSpawned
+ * @see net.runelite.api.events.GameObjectDespawned
+ * @see net.runelite.api.events.GameObjectChanged
+ */
+@Deprecated
 public class GameObjectQuery extends TileObjectQuery<GameObject, GameObjectQuery>
 {
 	@Override

--- a/runelite-api/src/main/java/net/runelite/api/queries/GroundObjectQuery.java
+++ b/runelite-api/src/main/java/net/runelite/api/queries/GroundObjectQuery.java
@@ -32,6 +32,14 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Objects;
 
+/**
+ * Used for getting ground objects in view,deprecated as of existence of Item spawn events
+ *
+ * @see net.runelite.api.events.ItemSpawned
+ * @see net.runelite.api.events.ItemDespawned
+ * @see net.runelite.api.events.ItemQuantityChanged
+ */
+@Deprecated
 public class GroundObjectQuery extends TileObjectQuery<GroundObject, GroundObjectQuery>
 {
 	@Override

--- a/runelite-api/src/main/java/net/runelite/api/queries/InventoryItemQuery.java
+++ b/runelite-api/src/main/java/net/runelite/api/queries/InventoryItemQuery.java
@@ -33,6 +33,12 @@ import net.runelite.api.Item;
 import net.runelite.api.ItemContainer;
 import net.runelite.api.Query;
 
+/**
+ * Used for getting inventory items,deprecated as of existence of item container changed events
+ *
+ * @see net.runelite.api.events.ItemContainerChanged
+ */
+@Deprecated
 @RequiredArgsConstructor
 public class InventoryItemQuery extends Query<Item, InventoryItemQuery>
 {

--- a/runelite-api/src/main/java/net/runelite/api/queries/NPCQuery.java
+++ b/runelite-api/src/main/java/net/runelite/api/queries/NPCQuery.java
@@ -27,7 +27,13 @@ package net.runelite.api.queries;
 import net.runelite.api.Client;
 import net.runelite.api.NPC;
 
-
+/**
+ * Used for getting NPCs in view,deprecated as of existence of NPC spawn events
+ *
+ * @see net.runelite.api.events.NpcSpawned
+ * @see net.runelite.api.events.NpcDespawned
+ */
+@Deprecated
 public class NPCQuery extends ActorQuery<NPC, NPCQuery>
 {
 	@Override

--- a/runelite-api/src/main/java/net/runelite/api/queries/PlayerQuery.java
+++ b/runelite-api/src/main/java/net/runelite/api/queries/PlayerQuery.java
@@ -27,6 +27,13 @@ package net.runelite.api.queries;
 import net.runelite.api.Client;
 import net.runelite.api.Player;
 
+/**
+ * Used for getting players in view,deprecated as of existence of Player spawn events
+ *
+ * @see net.runelite.api.events.PlayerSpawned
+ * @see net.runelite.api.events.PlayerDespawned
+ */
+@Deprecated
 public class PlayerQuery extends ActorQuery<Player, PlayerQuery>
 {
 	@Override

--- a/runelite-api/src/main/java/net/runelite/api/queries/TileObjectQuery.java
+++ b/runelite-api/src/main/java/net/runelite/api/queries/TileObjectQuery.java
@@ -37,6 +37,10 @@ import java.util.List;
 import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.coords.WorldPoint;
 
+/**
+ * Used for getting decorative objects in view, deprecated as of existence of Object* spawn events
+ */
+@Deprecated
 public abstract class TileObjectQuery<EntityType extends TileObject, QueryType> extends Query<EntityType, QueryType>
 {
 	protected List<Tile> getTiles(Client client)

--- a/runelite-api/src/main/java/net/runelite/api/queries/WallObjectQuery.java
+++ b/runelite-api/src/main/java/net/runelite/api/queries/WallObjectQuery.java
@@ -32,6 +32,14 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Objects;
 
+/**
+ * Used for getting wall objects in view,deprecated as of existence of Wall object spawn events
+ *
+ * @see net.runelite.api.events.WallObjectSpawned
+ * @see net.runelite.api.events.WallObjectDespawned
+ * @see net.runelite.api.events.WallObjectChanged
+ */
+@Deprecated
 public class WallObjectQuery extends TileObjectQuery<WallObject, WallObjectQuery>
 {
 	@Override


### PR DESCRIPTION
Deprecate all queries that have already existing
spawned/despawned/change events.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>