### PR TITLE
Do not forget last idle state when in IDLE already + add unit tests

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
@@ -205,12 +205,14 @@ public class IdleNotifierPlugin extends Plugin
 			case USING_GILDED_ALTAR:
 				resetTimers();
 				lastAnimation = animation;
-				break;
+				// Fall through
 			case IDLE:
+				lastAnimating = Instant.now();
 				break;
 			default:
 				// On unknown animation simply assume the animation is invalid and dont throw notification
 				lastAnimation = IDLE;
+				lastAnimating = null;
 		}
 	}
 
@@ -225,9 +227,14 @@ public class IdleNotifierPlugin extends Plugin
 
 		final Actor target = event.getTarget();
 
-		// Reset last interact
-		if (target != null)
+		if (target == null)
 		{
+			// We just ended combat so update last interacted time
+			lastInteracting = Instant.now();
+		}
+		else
+		{
+			// Reset last interact
 			lastInteract = null;
 		}
 
@@ -248,6 +255,7 @@ public class IdleNotifierPlugin extends Plugin
 			// Player is most likely in combat with attack-able NPC
 			resetTimers();
 			lastInteract = target;
+			lastInteracting = Instant.now();
 		}
 	}
 
@@ -502,14 +510,14 @@ public class IdleNotifierPlugin extends Plugin
 		lastCombatCountdown = 0;
 
 		// Reset animation idle timer
-		lastAnimating = null;
+		lastAnimating = Instant.now();
 		if (client.getGameState() == GameState.LOGIN_SCREEN || local == null || local.getAnimation() != lastAnimation)
 		{
 			lastAnimation = IDLE;
 		}
 
 		// Reset combat idle timer
-		lastInteracting = null;
+		lastInteracting = Instant.now();
 		if (client.getGameState() == GameState.LOGIN_SCREEN || local == null || local.getInteracting() != lastInteract)
 		{
 			lastInteract = null;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
@@ -511,14 +511,18 @@ public class IdleNotifierPlugin extends Plugin
 
 		// Reset animation idle timer
 		lastAnimating = Instant.now();
-		if (client.getGameState() == GameState.LOGIN_SCREEN || local == null || local.getAnimation() != lastAnimation)
+		if (client.getGameState() == GameState.LOGIN_SCREEN
+			|| local == null
+			|| (local.getAnimation() != IDLE && local.getAnimation() != lastAnimation))
 		{
 			lastAnimation = IDLE;
 		}
 
 		// Reset combat idle timer
 		lastInteracting = Instant.now();
-		if (client.getGameState() == GameState.LOGIN_SCREEN || local == null || local.getInteracting() != lastInteract)
+		if (client.getGameState() == GameState.LOGIN_SCREEN
+			|| local == null
+			|| (local.getInteracting() != null && local.getInteracting() != lastInteract))
 		{
 			lastInteract = null;
 		}

--- a/runelite-client/src/test/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPluginTest.java
@@ -192,6 +192,26 @@ public class IdleNotifierPluginTest
 	}
 
 	@Test
+	public void checkAnimationResetMouse()
+	{
+		when(player.getAnimation()).thenReturn(AnimationID.MINING_MOTHERLODE_INFERNAL);
+		AnimationChanged animationChanged = new AnimationChanged();
+		animationChanged.setActor(player);
+		plugin.onAnimationChanged(animationChanged);
+		plugin.onGameTick(new GameTick());
+
+		when(client.getMouseIdleTicks()).thenReturn(1);
+		when(player.getAnimation()).thenReturn(AnimationID.IDLE);
+		plugin.onAnimationChanged(animationChanged);
+		plugin.onGameTick(new GameTick());
+
+		when(client.getMouseIdleTicks()).thenReturn(12);
+		plugin.onGameTick(new GameTick());
+		plugin.onGameTick(new GameTick());
+		verify(notifier).notify("[" + PLAYER_NAME + "] is now idle!");
+	}
+
+	@Test
 	public void checkCombatIdle()
 	{
 		when(player.getInteracting()).thenReturn(monster);

--- a/runelite-client/src/test/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPluginTest.java
@@ -175,6 +175,23 @@ public class IdleNotifierPluginTest
 	}
 
 	@Test
+	public void checkAnimationMultipleIdle()
+	{
+		when(player.getAnimation()).thenReturn(AnimationID.MINING_INFERNAL_PICKAXE);
+		AnimationChanged animationChanged = new AnimationChanged();
+		animationChanged.setActor(player);
+		plugin.onAnimationChanged(animationChanged);
+		plugin.onGameTick(new GameTick());
+		when(player.getAnimation()).thenReturn(AnimationID.DENSE_ESSENCE_CHIPPING);
+		plugin.onAnimationChanged(animationChanged);
+		plugin.onGameTick(new GameTick());
+		when(player.getAnimation()).thenReturn(AnimationID.IDLE);
+		plugin.onAnimationChanged(animationChanged);
+		plugin.onGameTick(new GameTick());
+		verify(notifier).notify("[" + PLAYER_NAME + "] is now idle!");
+	}
+
+	@Test
 	public void checkCombatIdle()
 	{
 		when(player.getInteracting()).thenReturn(monster);

--- a/runelite-client/src/test/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPluginTest.java
@@ -154,7 +154,6 @@ public class IdleNotifierPluginTest
 		AnimationChanged animationChanged = new AnimationChanged();
 		animationChanged.setActor(player);
 		plugin.onAnimationChanged(animationChanged);
-		plugin.onInteractingChanged(new InteractingChanged(player, monster));
 		plugin.onGameTick(new GameTick());
 
 		// Logout
@@ -205,8 +204,8 @@ public class IdleNotifierPluginTest
 	@Test
 	public void checkCombatLogout()
 	{
-		plugin.onInteractingChanged(new InteractingChanged(player, monster));
 		when(player.getInteracting()).thenReturn(monster);
+		plugin.onInteractingChanged(new InteractingChanged(player, monster));
 		plugin.onGameTick(new GameTick());
 
 		// Logout


### PR DESCRIPTION
Do not forget last state when we are already in IDLE state and there
was mouse activity

Depends on and closes #5369 

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>