### PR TITLE
Use mouse press events and not mouse movement events in idle notifier

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/Client.java
+++ b/runelite-api/src/main/java/net/runelite/api/Client.java
@@ -928,6 +928,11 @@ public interface Client extends GameEngine
 	int getMouseIdleTicks();
 
 	/**
+	 * Gets the number of milliseconds since the last mouse press occurred.
+	 */
+	long getMouseLastPressedMillis();
+
+	/**
 	 * Gets the amount of ticks since the last keyboard press occurred.
 	 *
 	 * @return amount of idle keyboard ticks

--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
@@ -61,7 +61,9 @@ import net.runelite.client.plugins.PluginDescriptor;
 public class IdleNotifierPlugin extends Plugin
 {
 	private static final int LOGOUT_WARNING_AFTER_TICKS = 280 * 50; // 4 minutes and 40 seconds
+	private static final long LOGOUT_WARNING_AFTER_MILLIS = (long) (LOGOUT_WARNING_AFTER_TICKS * 0.6 * 1000);
 	private static final int LOGOUT_WARNING_AFTER_TICKS_IN_COMBAT = 1140 * 50; // 19 minutes
+	private static final long LOGOUT_WARNING_AFTER_MILLIS_IN_COMBAT = (long) (LOGOUT_WARNING_AFTER_TICKS_IN_COMBAT * 0.6 * 1000);
 	private static final int HIGHEST_MONSTER_ATTACK_SPEED = 8; // Except Scarab Mage, but they are with other monsters
 	private static final Duration SIX_HOUR_LOGOUT_WARNING_AFTER_DURATION = Duration.ofMinutes(340);
 
@@ -304,7 +306,10 @@ public class IdleNotifierPlugin extends Plugin
 		final Duration waitDuration = Duration.ofMillis(config.getIdleNotificationDelay());
 		lastCombatCountdown = Math.max(lastCombatCountdown - 1, 0);
 
-		if (client.getGameState() != GameState.LOGGED_IN || local == null || client.getMouseIdleTicks() < 10)
+		if (client.getGameState() != GameState.LOGGED_IN
+			|| local == null
+			|| System.currentTimeMillis() - client.getMouseLastPressedMillis() < 200
+			|| client.getKeyboardIdleTicks() < 10)
 		{
 			resetTimers();
 			return;
@@ -419,12 +424,14 @@ public class IdleNotifierPlugin extends Plugin
 
 	private boolean checkIdleLogout()
 	{
-		if (client.getMouseIdleTicks() > LOGOUT_WARNING_AFTER_TICKS
+		final long mouseDiff = System.currentTimeMillis() - client.getMouseLastPressedMillis();
+
+		if (mouseDiff > LOGOUT_WARNING_AFTER_MILLIS
 			&& client.getKeyboardIdleTicks() > LOGOUT_WARNING_AFTER_TICKS)
 		{
 			if (lastCombatCountdown > 0)
 			{
-				if (client.getMouseIdleTicks() > LOGOUT_WARNING_AFTER_TICKS_IN_COMBAT
+				if (mouseDiff > LOGOUT_WARNING_AFTER_MILLIS_IN_COMBAT
 					&& client.getKeyboardIdleTicks() > LOGOUT_WARNING_AFTER_TICKS_IN_COMBAT && notifyIdleLogout)
 				{
 					notifyIdleLogout = false;

--- a/runelite-client/src/test/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPluginTest.java
@@ -113,7 +113,8 @@ public class IdleNotifierPluginTest
 
 		// Mock client
 		when(client.getGameState()).thenReturn(GameState.LOGGED_IN);
-		when(client.getMouseIdleTicks()).thenReturn(42);
+		when(client.getKeyboardIdleTicks()).thenReturn(42);
+		when(client.getMouseLastPressedMillis()).thenReturn(System.currentTimeMillis() - 100_000L);
 	}
 
 	@Test
@@ -231,7 +232,7 @@ public class IdleNotifierPluginTest
 	public void checkCombatLogoutIdle()
 	{
         // Player is idle
-		when(client.getMouseIdleTicks()).thenReturn(282 * 50);
+		when(client.getMouseLastPressedMillis()).thenReturn(System.currentTimeMillis() - 300_000L);
 
 		// But player is being damaged (is in combat)
 		final HitsplatApplied hitsplatApplied = new HitsplatApplied();

--- a/runescape-api/src/main/java/net/runelite/rs/api/RSClient.java
+++ b/runescape-api/src/main/java/net/runelite/rs/api/RSClient.java
@@ -479,6 +479,10 @@ public interface RSClient extends RSGameEngine, Client
 	@Override
 	int getMouseIdleTicks();
 
+	@Import("mouseLastPressedTimeMillis")
+	@Override
+	long getMouseLastPressedMillis();
+
 	@Import("keyboardIdleTicks")
 	@Override
 	int getKeyboardIdleTicks();


### PR DESCRIPTION
- Add mappings for mouse last pressed millis 
- Use mouseLastPressedMillis instead of mouseIdleTicks as
only mouse press events indicate that player is idle, and not mouse
movements
- Use also keyboard check when resetting idle when active

Closes #5374