### PR TITLE
Remove npc highlights on task completed message.

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerPlugin.java
@@ -397,6 +397,7 @@ public class SlayerPlugin extends Plugin
 					log.warn("Unreachable default case for message ending in '; return to Slayer master'");
 			}
 			setTask("", 0);
+			highlightedTargets.clear();
 			return;
 		}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerPlugin.java
@@ -397,7 +397,6 @@ public class SlayerPlugin extends Plugin
 					log.warn("Unreachable default case for message ending in '; return to Slayer master'");
 			}
 			setTask("", 0);
-			highlightedTargets.clear();
 			return;
 		}
 
@@ -521,12 +520,16 @@ public class SlayerPlugin extends Plugin
 	private void rebuildTargetNames(Task task)
 	{
 		targetNames.clear();
-		Arrays.stream(task.getTargetNames())
-			.map(String::toLowerCase)
-			.forEach(targetNames::add);
-		targetNames.add(taskName.toLowerCase().replaceAll("s$", ""));
-	}
+		highlightedTargets.clear();
 
+		if (task != null)
+		{
+			Arrays.stream(task.getTargetNames())
+					.map(String::toLowerCase)
+					.forEach(targetNames::add);
+			targetNames.add(taskName.toLowerCase().replaceAll("s$", ""));
+		}
+	}
 	private void rebuildTargetList()
 	{
 		highlightedTargets.clear();
@@ -550,10 +553,7 @@ public class SlayerPlugin extends Plugin
 		infoTimer = Instant.now();
 
 		Task task = Task.getTask(name);
-		if (task != null)
-		{
-			rebuildTargetNames(task);
-		}
+		rebuildTargetNames(task);
 		rebuildTargetList();
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerPlugin.java
@@ -520,16 +520,17 @@ public class SlayerPlugin extends Plugin
 	private void rebuildTargetNames(Task task)
 	{
 		targetNames.clear();
-		highlightedTargets.clear();
 
 		if (task != null)
 		{
 			Arrays.stream(task.getTargetNames())
-					.map(String::toLowerCase)
-					.forEach(targetNames::add);
+				.map(String::toLowerCase)
+				.forEach(targetNames::add);
+
 			targetNames.add(taskName.toLowerCase().replaceAll("s$", ""));
 		}
 	}
+
 	private void rebuildTargetList()
 	{
 		highlightedTargets.clear();


### PR DESCRIPTION
Closes #5414

Simple fix, they wanted highlights to clear after they have killed the final monster on task. Previously it would only remove them once a new task was received from a slayer master.

Not sure if entirely useful or wanted but only took a minute so do with it as you please.