### PR TITLE
Remove unnecessary fishing spot configuration

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingConfig.java
@@ -54,175 +54,10 @@ public interface FishingConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "showShrimp",
-		name = "Show Shrimp/Anchovies",
-		description = "Configures whether shrimp/anchovies is displayed",
-		position = 3
-	)
-	default boolean showShrimp()
-	{
-		return true;
-	}
-
-	@ConfigItem(
-		keyName = "showLobster",
-		name = "Show Lobster/Swordfish/Tuna",
-		description = "Configures whether lobster/swordfish/tuna is displayed",
-		position = 4
-	)
-	default boolean showLobster()
-	{
-		return true;
-	}
-
-	@ConfigItem(
-		keyName = "showShark",
-		name = "Show Shark",
-		description = "Configures whether shark is displayed",
-		position = 5
-	)
-	default boolean showShark()
-	{
-		return true;
-	}
-
-	@ConfigItem(
-		keyName = "showMonkfish",
-		name = "Show Monkfish",
-		description = "Configures whether monkfish displayed",
-		position = 6
-	)
-	default boolean showMonkfish()
-	{
-		return true;
-	}
-
-	@ConfigItem(
-		keyName = "showSalmon",
-		name = "Show Salmon/Trout",
-		description = "Configures whether salmon/trout is displayed",
-		position = 7
-	)
-	default boolean showSalmon()
-	{
-		return true;
-	}
-
-	@ConfigItem(
-		keyName = "showBarb",
-		name = "Show Barbarian fish",
-		description = "Configures whether barbarian fish is displayed",
-		position = 8
-	)
-	default boolean showBarb()
-	{
-		return true;
-	}
-
-	@ConfigItem(
-		keyName = "showAngler",
-		name = "Show Anglerfish",
-		description = "Configures whether anglerfish is displayed",
-		position = 9
-	)
-	default boolean showAngler()
-	{
-		return true;
-	}
-
-	@ConfigItem(
-		keyName = "showMinnow",
-		name = "Show Minnow fish",
-		description = "Configures whether minnow fish is displayed",
-		position = 10
-	)
-	default boolean showMinnow()
-	{
-		return true;
-	}
-
-	@ConfigItem(
-		keyName = "showInfernalEel",
-		name = "Show Infernal Eel",
-		description = "Configures whether infernal eel is displayed",
-		position = 11
-	)
-	default boolean showInfernalEel()
-	{
-		return true;
-	}
-
-	@ConfigItem(
-		keyName = "showSacredEel",
-		name = "Show Sacred Eel",
-		description = "Configures whether sacred eel is displayed",
-		position = 12
-	)
-	default boolean showSacredEel()
-	{
-		return true;
-	}
-
-	@ConfigItem(
-		keyName = "showCaveEel",
-		name = "Show Cave Eel",
-		description = "Configures whether cave eel is displayed",
-		position = 13
-	)
-	default boolean showCaveEel()
-	{
-		return true;
-	}
-
-	@ConfigItem(
-		keyName = "showSlimyEel",
-		name = "Show Slimy Eel",
-		description = "Configures whether slimy eel is displayed",
-		position = 14
-	)
-	default boolean showSlimyEel()
-	{
-		return true;
-	}
-
-	@ConfigItem(
-		keyName = "showKarambwanji",
-		name = "Show Karambwanji",
-		description = "Configures whether karambwanji is displayed",
-		position = 15
-	)
-	default boolean showKarambwanji()
-	{
-		return true;
-	}
-
-	@ConfigItem(
-		keyName = "showKarambwan",
-		name = "Show Karambwan",
-		description = "Configures whether karambwan is displayed",
-		position = 16
-	)
-	default boolean showKarambwan()
-	{
-		return true;
-	}
-
-	@ConfigItem(
-		keyName = "showDarkCrab",
-		name = "Show Dark Crab",
-		description = "Configures whether dark crab is displayed",
-		position = 17
-	)
-	default boolean showDarkCrab()
-	{
-		return true;
-	}
-
-	@ConfigItem(
 		keyName = "showFishingStats",
 		name = "Show Fishing session stats",
 		description = "Configures whether to display the fishing session stats",
-		position = 18
+		position = 3
 	)
 	default boolean showFishingStats()
 	{
@@ -233,7 +68,7 @@ public interface FishingConfig extends Config
 		keyName = "showMinnowOverlay",
 		name = "Show Minnow Movement overlay",
 		description = "Configures whether to display the minnow progress pie overlay",
-		position = 19
+		position = 4
 	)
 	default boolean showMinnowOverlay()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingPlugin.java
@@ -29,11 +29,9 @@ import com.google.common.eventbus.Subscribe;
 import com.google.common.primitives.Ints;
 import com.google.inject.Provides;
 import java.time.Instant;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -49,7 +47,6 @@ import net.runelite.api.ItemID;
 import net.runelite.api.NPC;
 import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.events.ChatMessage;
-import net.runelite.api.events.ConfigChanged;
 import net.runelite.api.events.GameTick;
 import net.runelite.api.events.ItemContainerChanged;
 import net.runelite.api.events.NpcDespawned;
@@ -72,8 +69,6 @@ import net.runelite.client.util.QueryRunner;
 @Slf4j
 public class FishingPlugin extends Plugin
 {
-	private final List<Integer> spotIds = new ArrayList<>();
-
 	@Getter(AccessLevel.PACKAGE)
 	private final FishingSession session = new FishingSession();
 
@@ -116,7 +111,6 @@ public class FishingPlugin extends Plugin
 		overlayManager.add(overlay);
 		overlayManager.add(spotOverlay);
 		overlayManager.add(fishingSpotMinimapOverlay);
-		updateConfig();
 	}
 
 	@Override
@@ -163,12 +157,6 @@ public class FishingPlugin extends Plugin
 		}
 	}
 
-	@Subscribe
-	public void updateConfig(ConfigChanged event)
-	{
-		updateConfig();
-	}
-
 	private boolean canPlayerFish(final ItemContainer itemContainer)
 	{
 		if (itemContainer == null)
@@ -206,78 +194,13 @@ public class FishingPlugin extends Plugin
 		return false;
 	}
 
-	private void updateConfig()
-	{
-		spotIds.clear();
-		if (config.showShrimp())
-		{
-			spotIds.addAll(Ints.asList(FishingSpot.SHRIMP.getIds()));
-		}
-		if (config.showLobster())
-		{
-			spotIds.addAll(Ints.asList(FishingSpot.LOBSTER.getIds()));
-		}
-		if (config.showShark())
-		{
-			spotIds.addAll(Ints.asList(FishingSpot.SHARK.getIds()));
-		}
-		if (config.showMonkfish())
-		{
-			spotIds.addAll(Ints.asList(FishingSpot.MONKFISH.getIds()));
-		}
-		if (config.showSalmon())
-		{
-			spotIds.addAll(Ints.asList(FishingSpot.SALMON.getIds()));
-		}
-		if (config.showBarb())
-		{
-			spotIds.addAll(Ints.asList(FishingSpot.BARB_FISH.getIds()));
-		}
-		if (config.showAngler())
-		{
-			spotIds.addAll(Ints.asList(FishingSpot.ANGLERFISH.getIds()));
-		}
-		if (config.showMinnow())
-		{
-			spotIds.addAll(Ints.asList(FishingSpot.MINNOW.getIds()));
-		}
-		if (config.showInfernalEel())
-		{
-			spotIds.addAll(Ints.asList(FishingSpot.INFERNAL_EEL.getIds()));
-		}
-		if (config.showSacredEel())
-		{
-			spotIds.addAll(Ints.asList(FishingSpot.SACRED_EEL.getIds()));
-		}
-		if (config.showCaveEel())
-		{
-			spotIds.addAll(Ints.asList(FishingSpot.CAVE_EEL.getIds()));
-		}
-		if (config.showSlimyEel())
-		{
-			spotIds.addAll(Ints.asList(FishingSpot.SLIMY_EEL.getIds()));
-		}
-		if (config.showKarambwanji())
-		{
-			spotIds.addAll(Ints.asList(FishingSpot.KARAMBWANJI.getIds()));
-		}
-		if (config.showKarambwan())
-		{
-			spotIds.addAll(Ints.asList(FishingSpot.KARAMBWAN.getIds()));
-		}
-		if (config.showDarkCrab())
-		{
-			spotIds.addAll(Ints.asList(FishingSpot.DARK_CRAB.getIds()));
-		}
-	}
-
 	@Subscribe
 	public void onGameTick(GameTick event)
 	{
 		final LocalPoint cameraPoint = new LocalPoint(client.getCameraX(), client.getCameraY());
 
 		final NPCQuery query = new NPCQuery()
-			.idEquals(Ints.toArray(spotIds));
+			.idEquals(Ints.toArray(FishingSpot.getSPOTS().keySet()));
 		NPC[] spots = queryRunner.runQuery(query);
 		// -1 to make closer things draw last (on top of farther things)
 		Arrays.sort(spots, Comparator.comparing(npc -> -1 * npc.getLocalLocation().distanceTo(cameraPoint)));
@@ -286,7 +209,7 @@ public class FishingPlugin extends Plugin
 		// process minnows
 		for (NPC npc : spots)
 		{
-			FishingSpot spot = FishingSpot.getSpot(npc.getId());
+			FishingSpot spot = FishingSpot.getSPOTS().get(npc.getId());
 
 			if (spot == null)
 			{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingSpot.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingSpot.java
@@ -26,6 +26,7 @@ package net.runelite.client.plugins.fishing;
 
 import java.util.HashMap;
 import java.util.Map;
+import lombok.Getter;
 import net.runelite.api.ItemID;
 import static net.runelite.api.NpcID.FISHING_SPOT_1497;
 import static net.runelite.api.NpcID.FISHING_SPOT_1498;
@@ -93,7 +94,8 @@ import static net.runelite.api.NpcID.ROD_FISHING_SPOT_7464;
 import static net.runelite.api.NpcID.ROD_FISHING_SPOT_7468;
 import static net.runelite.api.NpcID.ROD_FISHING_SPOT_7676;
 
-public enum FishingSpot
+@Getter
+enum FishingSpot
 {
 	SHRIMP("Shrimp, Anchovies", ItemID.RAW_SHRIMPS,
 		FISHING_SPOT_1518, FISHING_SPOT_1521, FISHING_SPOT_1523,
@@ -154,11 +156,12 @@ public enum FishingSpot
 		FISHING_SPOT_1536
 	);
 
-	private static final Map<Integer, FishingSpot> fishingSpots = new HashMap<>();
+	@Getter
+	private static final Map<Integer, FishingSpot> SPOTS = new HashMap<>();
 
 	private final String name;
 	private final int fishSpriteId;
-	private final int[] spots;
+	private final int[] ids;
 
 	static
 	{
@@ -168,35 +171,15 @@ public enum FishingSpot
 		{
 			for (int spotId : spot.getIds())
 			{
-				fishingSpots.put(spotId, spot);
+				SPOTS.put(spotId, spot);
 			}
 		}
 	}
 
-	FishingSpot(String spot, int fishSpriteId, int... spots)
+	FishingSpot(String spot, int fishSpriteId, int... ids)
 	{
 		this.name = spot;
 		this.fishSpriteId = fishSpriteId;
-		this.spots = spots;
-	}
-
-	public String getName()
-	{
-		return name;
-	}
-
-	public int getFishSpriteId()
-	{
-		return fishSpriteId;
-	}
-
-	public int[] getIds()
-	{
-		return spots;
-	}
-
-	public static FishingSpot getSpot(int npcId)
-	{
-		return fishingSpots.get(npcId);
+		this.ids = ids;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingSpotMinimapOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingSpotMinimapOverlay.java
@@ -68,7 +68,7 @@ class FishingSpotMinimapOverlay extends Overlay
 
 		for (NPC npc : fishingSpots)
 		{
-			FishingSpot spot = FishingSpot.getSpot(npc.getId());
+			FishingSpot spot = FishingSpot.getSPOTS().get(npc.getId());
 
 			if (spot == null)
 			{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingSpotOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingSpotOverlay.java
@@ -86,7 +86,7 @@ class FishingSpotOverlay extends Overlay
 
 		for (NPC npc : fishingSpots)
 		{
-			FishingSpot spot = FishingSpot.getSpot(npc.getId());
+			FishingSpot spot = FishingSpot.getSPOTS().get(npc.getId());
 
 			if (spot == null)
 			{


### PR DESCRIPTION
As now the fishing spots get hidden automatically and shown
automatically it is no longer necessary to have per-spot configuration.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>