### PR TITLE
runelite-client: Don't duplicate chatbox input when widget ids are wrong

### DIFF
--- a/runelite-client/src/main/scripts/ChatboxInputHandler.rs2asm
+++ b/runelite-client/src/main/scripts/ChatboxInputHandler.rs2asm
@@ -36,6 +36,18 @@
 .int_var_count      2
 .string_var_count   1
 
+; If we are not the active listener, the widget ids have probably changed
+   get_varc               5
+   load_int               -2
+   if_icmpeq              LABEL2
+
+; Log the error
+   load_string "Got input while not active; Widget ids in ChatboxInputInit are probably wrong."
+   load_string "debug"
+   runelite_callback
+   return
+
+LABEL2:
 ; Discard zero presses
    iload                  0
    load_int               0

--- a/runelite-client/src/main/scripts/ChatboxInputInit.rs2asm
+++ b/runelite-client/src/main/scripts/ChatboxInputInit.rs2asm
@@ -46,6 +46,10 @@
    sload                  1
    put_varc_string        22
 
+; Mark varcstring22 for our use
+   load_int               -2
+   put_varc               5
+
 ; Set text
    sload                  0
    load_int               10616869 ; 162:37


### PR DESCRIPTION
Whenever the widetids for the chatbox input change the listener gets added twice, so all inputs get duplicated. This makes our handler check the varc before adding text, preventing this from happening as much.