### PR TITLE
BA plugin: widget overlay fix

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/widgets/WidgetID.java
+++ b/runelite-api/src/main/java/net/runelite/api/widgets/WidgetID.java
@@ -504,17 +504,21 @@ public class WidgetID
 	{
 		static class ATK
 		{
-			static final int CORRECT_STYLE2 = 4;
-			static final int TO_CALL = 6;
-			static final int ROLE = 8;
-			static final int ROLE_SPRITE = 7;
+			static final int CALL_TEXT = 8;
+			static final int TO_CALL_WIDGET = 9;
+			static final int TO_CALL = 10;
+			static final int ROLE_SPRITE = 11;
+			static final int ROLE = 12;
 		}
-
-		static final int CURRENT_WAVE = 1;
 		static final int CORRECT_STYLE = 3;
-		static final int TO_CALL = 5;
-		static final int ROLE_SPRITE = 6;
-		static final int ROLE = 7;
+		static final int CURRENT_WAVE_WIDGET = 4;
+		static final int CURRENT_WAVE = 5;
+		static final int CALL_WIDGET = 6;
+		static final int CALL_TEXT = 7;
+		static final int TO_CALL_WIDGET = 8;
+		static final int TO_CALL = 9;
+		static final int ROLE_SPRITE = 10;
+		static final int ROLE = 11;
 	}
 
 	static class LevelUp


### PR DESCRIPTION
Fixed WidgetIDs for Barbarian Assault plugin to work as intended:
before:
![](https://user-images.githubusercontent.com/22001512/45492101-5a558700-b763-11e8-84c7-cad5e844febb.png)
after:
![](https://i.gyazo.com/b10f4c131b9a8e588c3f653ea74402a2.png)

fixes #5471 