### PR TITLE
opponent info plugin: Fix possible onGameTick NPE

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/opponentinfo/OpponentInfoPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/opponentinfo/OpponentInfoPlugin.java
@@ -154,7 +154,9 @@ public class OpponentInfoPlugin extends Plugin
 	@Subscribe
 	public void onGameTick(GameTick gameTick)
 	{
-		if (lastOpponent != null && client.getLocalPlayer().getInteracting() == null)
+		if (lastOpponent != null
+			&& lastTime != null
+			&& client.getLocalPlayer().getInteracting() == null)
 		{
 			if (Duration.between(lastTime, Instant.now()).compareTo(WAIT) > 0)
 			{


### PR DESCRIPTION
The plugin is initialized with `lastTime` as null, meaning that if
`onGameTick` is called before `onInteractingChanged`, you can encounter
a case where after starting the client or plugin, `lastTime` has not yet
been set while `client.getLocalPlayer().getInteracting` is null (because
`onGameTick` gets sequenced before `onInteractingChanged` per tick),
causing an NPE when trying to compare a null Duration.

Fixes runelite/runelite#5451