### PR TITLE
clue scroll overlay: Show visible emote widget area

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/ClueScrollEmoteOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/ClueScrollEmoteOverlay.java
@@ -122,13 +122,21 @@ public class ClueScrollEmoteOverlay extends Overlay
 		// Don't draw outside the emotes window
 		net.runelite.api.Point windowLocation = window.getCanvasLocation();
 
-		if (windowLocation.getY() > canvasLocation.getY()
-			|| windowLocation.getY() + window.getHeight() < canvasLocation.getY() + widget.getHeight())
+		if (windowLocation.getY() > canvasLocation.getY() + widget.getHeight()
+			|| windowLocation.getY() + window.getHeight() < canvasLocation.getY())
 		{
 			return;
 		}
 
-		Area widgetArea = new Area(new Rectangle(canvasLocation.getX(), canvasLocation.getY(), widget.getWidth(), widget.getHeight()));
+		// Visible area of emote widget
+		Area widgetArea = new Area(
+			new Rectangle(
+				canvasLocation.getX(),
+				Math.max(canvasLocation.getY(), windowLocation.getY()),
+				widget.getWidth(),
+				Math.min(
+					Math.min(windowLocation.getY() + window.getHeight() - canvasLocation.getY(), widget.getHeight()),
+					Math.min(canvasLocation.getY() + widget.getHeight() - windowLocation.getY(), widget.getHeight()))));
 
 		OverlayUtil.renderHoverableArea(graphics, widgetArea, client.getMouseCanvasPosition(),
 				HIGHLIGHT_FILL_COLOR, HIGHLIGHT_BORDER_COLOR, HIGHLIGHT_HOVER_BORDER_COLOR);


### PR DESCRIPTION
The visible area of emote widgets will now be highlighted, regardless of
whether the widget is partially outside the emote window.

![Highlighted emote widget resizes to show visible area within emote window](https://user-images.githubusercontent.com/2199511/45579707-777c7980-b879-11e8-90bf-1e34fc1cb790.gif)

Fixes runelite/runelite#4163

P.S. This is the code I used to test the updated rendering logic: https://gist.github.com/Nightfirecat/8775bcc940988914535167efa84c4731