### PR TITLE
menu entry swapper: Swaps wield/release option for salamanders. 

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -239,4 +239,15 @@ public interface MenuEntrySwapperConfig extends Config
 	{
 		return false;
 	}
+
+	@ConfigItem(
+			position = 19,
+			keyName = "swapReleaseSalamander",
+			name = "Release Salamander",
+			description = "Swap wield with release for salamanders when training hunter."
+	)
+	default boolean swapReleaseSalamander()
+	{
+		return false;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -490,6 +490,10 @@ public class MenuEntrySwapperPlugin extends Plugin
 		{
 			swap("empty", option, target, true);
 		}
+		else if (config.swapReleaseSalamander() && target.contains("salamander"))
+		{
+			swap("release", option, target, true);
+		}
 	}
 
 	@Subscribe


### PR DESCRIPTION
The option is disabled by default.

Not sure if there is already another way to do this, but i couldn't find one. Makes hunting salamanders a bit more chill.
