### PR TITLE
New Player Information Plugin

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/SpriteID.java
+++ b/runelite-api/src/main/java/net/runelite/api/SpriteID.java
@@ -1042,7 +1042,7 @@ public final class SpriteID
 	public static final int MINIMAP_ORB_PRAYER_ACTIVATED = 1066;
 	public static final int MINIMAP_ORB_HITPOINTS_ICON = 1067;
 	public static final int MINIMAP_ORB_PRAYER_ICON = 1068;
-	public static final int MINIMAP_ORB_RUN_ICON = 1070;
+	public static final int MINIMAP_ORB_RUN_ICON = 1069;
 	public static final int MINIMAP_ORB_RUN_ICON_ACTIVATED = 1070;
 	public static final int MINIMAP_ORB_FRAME = 1071;
 	public static final int MINIMAP_ORB_FRAME_HOVERED = 1072;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerinfo/PlayerInfoConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerinfo/PlayerInfoConfig.java
@@ -9,80 +9,80 @@ import java.awt.*;
 @ConfigGroup("playerinfo")
 public interface PlayerInfoConfig extends Config
 {
-    @ConfigItem(
-            keyName = "enableHealth",
-            name = "Enable Health Display",
-            description = "Configures whether or not to display health information",
-            position = 1
-    )
-    default boolean enableHealth()
-    {
-        return true;
-    }
+	@ConfigItem(
+		keyName = "enableHealth",
+		name = "Enable Health Display",
+		description = "Configures whether or not to display health information",
+		position = 1
+	)
+	default boolean enableHealth()
+	{
+		return true;
+	}
 
-    @ConfigItem(
-            keyName = "enablePrayer",
-            name = "Enable Prayer Display",
-            description = "Configures whether or not to display prayer information",
-            position = 2
-    )
-    default boolean enablePrayer()
-    {
-        return true;
-    }
+	@ConfigItem(
+		keyName = "enablePrayer",
+		name = "Enable Prayer Display",
+		description = "Configures whether or not to display prayer information",
+		position = 2
+	)
+	default boolean enablePrayer()
+	{
+		return true;
+	}
 
-    @ConfigItem(
-            keyName = "enableEnergy",
-            name = "Enable Run Energy Display",
-            description = "Configures whether or not to display run energy information",
-            position = 3
-    )
-    default boolean enableEnergy()
-    {
-        return true;
-    }
+	@ConfigItem(
+			keyName = "enableEnergy",
+			name = "Enable Run Energy Display",
+			description = "Configures whether or not to display run energy information",
+			position = 3
+	)
+	default boolean enableEnergy()
+	{
+		return true;
+	}
 
-    @ConfigItem(
-            keyName = "enableSpec",
-            name = "Enable Special Attack Display",
-            description = "Configures whether or not to display special attack information",
-            position = 4
-    )
-    default boolean enableSpec()
-    {
-        return true;
-    }
+	@ConfigItem(
+		keyName = "enableSpec",
+		name = "Enable Special Attack Display",
+		description = "Configures whether or not to display special attack information",
+		position = 4
+	)
+	default boolean enableSpec()
+	{
+		return true;
+	}
 
-    @ConfigItem(
-            keyName = "colorHigh",
-            name = "Color High",
-            description = "The color displayed for high values.",
-            position = 5
-    )
-    default Color colorHigh()
-    {
-        return Color.GREEN;
-    }
+	@ConfigItem(
+		keyName = "colorHigh",
+		name = "Color High",
+		description = "The color displayed for high values.",
+		position = 5
+	)
+	default Color colorHigh()
+	{
+		return Color.GREEN;
+	}
 
-    @ConfigItem(
-            keyName = "colorMed",
-            name = "Color Medium",
-            description = "The color displayed for medium values.",
-            position = 6
-    )
-    default Color colorMed()
-    {
-        return Color.YELLOW;
-    }
+	@ConfigItem(
+		keyName = "colorMed",
+		name = "Color Medium",
+		description = "The color displayed for medium values.",
+		position = 6
+	)
+	default Color colorMed()
+	{
+		return Color.YELLOW;
+	}
 
-    @ConfigItem(
-            keyName = "colorLow",
-            name = "Color Low",
-            description = "The color displayed for low values.",
-            position = 7
-    )
-    default Color colorLow()
-    {
-        return Color.RED;
-    }
+	@ConfigItem(
+		keyName = "colorLow",
+		name = "Color Low",
+		description = "The color displayed for low values.",
+		position = 7
+	)
+	default Color colorLow()
+	{
+		return Color.RED;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerinfo/PlayerInfoConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerinfo/PlayerInfoConfig.java
@@ -1,0 +1,88 @@
+package net.runelite.client.plugins.playerinfo;
+
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+
+import java.awt.*;
+
+@ConfigGroup("playerinfo")
+public interface PlayerInfoConfig extends Config
+{
+    @ConfigItem(
+            keyName = "enableHealth",
+            name = "Enable Health Display",
+            description = "Configures whether or not to display health information",
+            position = 1
+    )
+    default boolean enableHealth()
+    {
+        return true;
+    }
+
+    @ConfigItem(
+            keyName = "enablePrayer",
+            name = "Enable Prayer Display",
+            description = "Configures whether or not to display prayer information",
+            position = 2
+    )
+    default boolean enablePrayer()
+    {
+        return true;
+    }
+
+    @ConfigItem(
+            keyName = "enableEnergy",
+            name = "Enable Run Energy Display",
+            description = "Configures whether or not to display run energy information",
+            position = 3
+    )
+    default boolean enableEnergy()
+    {
+        return true;
+    }
+
+    @ConfigItem(
+            keyName = "enableSpec",
+            name = "Enable Special Attack Display",
+            description = "Configures whether or not to display special attack information",
+            position = 4
+    )
+    default boolean enableSpec()
+    {
+        return true;
+    }
+
+    @ConfigItem(
+            keyName = "colorHigh",
+            name = "Color High",
+            description = "The color displayed for high values.",
+            position = 5
+    )
+    default Color colorHigh()
+    {
+        return Color.GREEN;
+    }
+
+    @ConfigItem(
+            keyName = "colorMed",
+            name = "Color Medium",
+            description = "The color displayed for medium values.",
+            position = 6
+    )
+    default Color colorMed()
+    {
+        return Color.YELLOW;
+    }
+
+    @ConfigItem(
+            keyName = "colorLow",
+            name = "Color Low",
+            description = "The color displayed for low values.",
+            position = 7
+    )
+    default Color colorLow()
+    {
+        return Color.RED;
+    }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerinfo/PlayerInfoCustomIndicator.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerinfo/PlayerInfoCustomIndicator.java
@@ -41,7 +41,7 @@ public class PlayerInfoCustomIndicator extends InfoBox
 	@Override
 	public String getText()
 	{
-		switch(type)
+		switch (type)
 		{
 			case HEALTH:
 				return String.valueOf(client.getBoostedSkillLevel(Skill.HITPOINTS));
@@ -60,7 +60,7 @@ public class PlayerInfoCustomIndicator extends InfoBox
 	public Color getTextColor()
 	{
 		float currLvl = 0;
-		switch(type)
+		switch (type)
 		{
 			case HEALTH:
 				currLvl = client.getBoostedSkillLevel(Skill.HITPOINTS) / (float) client.getRealSkillLevel(Skill.HITPOINTS);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerinfo/PlayerInfoCustomIndicator.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerinfo/PlayerInfoCustomIndicator.java
@@ -1,0 +1,109 @@
+package net.runelite.client.plugins.playerinfo;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import net.runelite.api.Client;
+import net.runelite.api.Skill;
+import net.runelite.api.VarPlayer;
+import net.runelite.client.ui.overlay.infobox.InfoBox;
+import net.runelite.client.util.ColorUtil;
+
+import java.awt.*;
+
+public class PlayerInfoCustomIndicator extends InfoBox
+{
+    @AllArgsConstructor
+    @Getter
+    enum IndicatorType
+    {
+        HEALTH("Current Hitpoints"),
+        PRAYER("Current Prayer Points"),
+        ENERGY("Current Run Energy"),
+        SPECIAL("Current Special Attack");
+
+        private final String description;
+    }
+
+    private final PlayerInfoConfig config;
+    private final Client client;
+    private final IndicatorType type;
+
+    PlayerInfoCustomIndicator(Image image, PlayerInfoPlugin plugin, PlayerInfoConfig config, Client client, IndicatorType type)
+    {
+        super(image, plugin);
+        this.config = config;
+        this.client = client;
+        this.type = type;
+
+        setTooltip(type.getDescription());
+    }
+
+    @Override
+    public String getText()
+    {
+        switch(type)
+        {
+            case HEALTH:
+                return String.valueOf(client.getBoostedSkillLevel(Skill.HITPOINTS));
+            case PRAYER:
+                return String.valueOf(client.getBoostedSkillLevel(Skill.PRAYER));
+            case ENERGY:
+                return String.valueOf(client.getEnergy());
+            case SPECIAL:
+                return String.valueOf(client.getVar(VarPlayer.SPECIAL_ATTACK_PERCENT) / 10);
+        }
+
+        return null;
+    }
+
+    @Override
+    public Color getTextColor()
+    {
+        float currLvl = 0;
+        switch(type)
+        {
+            case HEALTH:
+                currLvl = client.getBoostedSkillLevel(Skill.HITPOINTS) / (float) client.getRealSkillLevel(Skill.HITPOINTS);
+                break;
+            case PRAYER:
+                currLvl = client.getBoostedSkillLevel(Skill.PRAYER) / (float) client.getRealSkillLevel(Skill.PRAYER);
+                break;
+            case ENERGY:
+                currLvl = client.getEnergy() / 100.0F;
+                break;
+            case SPECIAL:
+                currLvl = client.getVar(VarPlayer.SPECIAL_ATTACK_PERCENT) / 1000.0F;
+        }
+
+        if (currLvl > 1.0)
+        {
+            return config.colorHigh();
+        }
+        else if (currLvl > 0.5)
+        {
+            return ColorUtil.colorLerp(config.colorMed(), config.colorHigh(), (currLvl * 2) - 1.0F);
+        }
+        else
+        {
+            return ColorUtil.colorLerp(config.colorLow(), config.colorMed(), (currLvl * 2));
+        }
+    }
+
+    @Override
+    public boolean render()
+    {
+        switch (type)
+        {
+            case HEALTH:
+                return config.enableHealth();
+            case PRAYER:
+                return config.enablePrayer();
+            case ENERGY:
+                return config.enableEnergy();
+            case SPECIAL:
+                return config.enableSpec();
+        }
+
+        return false;
+    }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerinfo/PlayerInfoCustomIndicator.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerinfo/PlayerInfoCustomIndicator.java
@@ -12,98 +12,98 @@ import java.awt.*;
 
 public class PlayerInfoCustomIndicator extends InfoBox
 {
-    @AllArgsConstructor
-    @Getter
-    enum IndicatorType
-    {
-        HEALTH("Current Hitpoints"),
-        PRAYER("Current Prayer Points"),
-        ENERGY("Current Run Energy"),
-        SPECIAL("Current Special Attack");
+	@AllArgsConstructor
+	@Getter
+	enum IndicatorType
+	{
+		HEALTH("Current Hitpoints"),
+		PRAYER("Current Prayer Points"),
+		ENERGY("Current Run Energy"),
+		SPECIAL("Current Special Attack");
 
-        private final String description;
-    }
+		private final String description;
+	}
 
-    private final PlayerInfoConfig config;
-    private final Client client;
-    private final IndicatorType type;
+	private final PlayerInfoConfig config;
+	private final Client client;
+	private final IndicatorType type;
 
-    PlayerInfoCustomIndicator(Image image, PlayerInfoPlugin plugin, PlayerInfoConfig config, Client client, IndicatorType type)
-    {
-        super(image, plugin);
-        this.config = config;
-        this.client = client;
-        this.type = type;
+	PlayerInfoCustomIndicator(Image image, PlayerInfoPlugin plugin, PlayerInfoConfig config, Client client, IndicatorType type)
+	{
+		super(image, plugin);
+		this.config = config;
+		this.client = client;
+		this.type = type;
 
-        setTooltip(type.getDescription());
-    }
+		setTooltip(type.getDescription());
+	}
 
-    @Override
-    public String getText()
-    {
-        switch(type)
-        {
-            case HEALTH:
-                return String.valueOf(client.getBoostedSkillLevel(Skill.HITPOINTS));
-            case PRAYER:
-                return String.valueOf(client.getBoostedSkillLevel(Skill.PRAYER));
-            case ENERGY:
-                return String.valueOf(client.getEnergy());
-            case SPECIAL:
-                return String.valueOf(client.getVar(VarPlayer.SPECIAL_ATTACK_PERCENT) / 10);
-        }
+	@Override
+	public String getText()
+	{
+		switch(type)
+		{
+			case HEALTH:
+				return String.valueOf(client.getBoostedSkillLevel(Skill.HITPOINTS));
+			case PRAYER:
+				return String.valueOf(client.getBoostedSkillLevel(Skill.PRAYER));
+			case ENERGY:
+				return String.valueOf(client.getEnergy());
+			case SPECIAL:
+				return String.valueOf(client.getVar(VarPlayer.SPECIAL_ATTACK_PERCENT) / 10);
+		}
 
-        return null;
-    }
+		return null;
+	}
 
-    @Override
-    public Color getTextColor()
-    {
-        float currLvl = 0;
-        switch(type)
-        {
-            case HEALTH:
-                currLvl = client.getBoostedSkillLevel(Skill.HITPOINTS) / (float) client.getRealSkillLevel(Skill.HITPOINTS);
-                break;
-            case PRAYER:
-                currLvl = client.getBoostedSkillLevel(Skill.PRAYER) / (float) client.getRealSkillLevel(Skill.PRAYER);
-                break;
-            case ENERGY:
-                currLvl = client.getEnergy() / 100.0F;
-                break;
-            case SPECIAL:
-                currLvl = client.getVar(VarPlayer.SPECIAL_ATTACK_PERCENT) / 1000.0F;
-        }
+	@Override
+	public Color getTextColor()
+	{
+		float currLvl = 0;
+		switch(type)
+		{
+			case HEALTH:
+				currLvl = client.getBoostedSkillLevel(Skill.HITPOINTS) / (float) client.getRealSkillLevel(Skill.HITPOINTS);
+				break;
+			case PRAYER:
+				currLvl = client.getBoostedSkillLevel(Skill.PRAYER) / (float) client.getRealSkillLevel(Skill.PRAYER);
+				break;
+			case ENERGY:
+				currLvl = client.getEnergy() / 100.0F;
+				break;
+			case SPECIAL:
+				currLvl = client.getVar(VarPlayer.SPECIAL_ATTACK_PERCENT) / 1000.0F;
+		}
 
-        if (currLvl > 1.0)
-        {
-            return config.colorHigh();
-        }
-        else if (currLvl > 0.5)
-        {
-            return ColorUtil.colorLerp(config.colorMed(), config.colorHigh(), (currLvl * 2) - 1.0F);
-        }
-        else
-        {
-            return ColorUtil.colorLerp(config.colorLow(), config.colorMed(), (currLvl * 2));
-        }
-    }
+		if (currLvl > 1.0)
+		{
+			return config.colorHigh();
+		}
+		else if (currLvl > 0.5)
+		{
+			return ColorUtil.colorLerp(config.colorMed(), config.colorHigh(), (currLvl * 2) - 1.0F);
+		}
+		else
+		{
+			return ColorUtil.colorLerp(config.colorLow(), config.colorMed(), (currLvl * 2));
+		}
+	}
 
-    @Override
-    public boolean render()
-    {
-        switch (type)
-        {
-            case HEALTH:
-                return config.enableHealth();
-            case PRAYER:
-                return config.enablePrayer();
-            case ENERGY:
-                return config.enableEnergy();
-            case SPECIAL:
-                return config.enableSpec();
-        }
+	@Override
+	public boolean render()
+	{
+		switch (type)
+		{
+			case HEALTH:
+				return config.enableHealth();
+			case PRAYER:
+				return config.enablePrayer();
+			case ENERGY:
+				return config.enableEnergy();
+			case SPECIAL:
+				return config.enableSpec();
+		}
 
-        return false;
-    }
+		return false;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerinfo/PlayerInfoPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerinfo/PlayerInfoPlugin.java
@@ -1,0 +1,82 @@
+package net.runelite.client.plugins.playerinfo;
+
+import com.google.inject.Provides;
+import net.runelite.api.*;
+import net.runelite.client.callback.ClientThread;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.game.SkillIconManager;
+import net.runelite.client.game.SpriteManager;
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.ui.overlay.infobox.InfoBoxManager;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import java.awt.image.BufferedImage;
+
+import static net.runelite.client.plugins.playerinfo.PlayerInfoCustomIndicator.*;
+
+@PluginDescriptor(
+        name = "Player Information",
+        description = "An alternative to the Minimap Orbs",
+        tags = {"combat", "overlay"},
+        enabledByDefault = false
+)
+@Singleton
+public class PlayerInfoPlugin extends Plugin
+{
+    @Inject
+    private Client client;
+
+    @Inject
+    private ClientThread clientThread;
+
+    @Inject
+    private InfoBoxManager infoBoxManager;
+
+    @Inject
+    private PlayerInfoConfig config;
+
+    @Inject
+    private SpriteManager spriteManager;
+
+    @Inject
+    private SkillIconManager skillIconManager;
+
+    @Provides
+    PlayerInfoConfig provideConfig(ConfigManager configManager)
+    {
+        return configManager.getConfig(PlayerInfoConfig.class);
+    }
+
+    @Override
+    protected void startUp() throws Exception
+    {
+        clientThread.invoke(() ->
+        {
+            if (client.getGameState().ordinal() < GameState.LOGIN_SCREEN.ordinal())
+            {
+                return false;
+            }
+
+            BufferedImage healthImg = spriteManager.getSprite(SpriteID.MINIMAP_ORB_HITPOINTS_ICON, 0);
+            BufferedImage prayerImg = spriteManager.getSprite(SpriteID.MINIMAP_ORB_PRAYER_ICON, 0);
+            BufferedImage energyImg = spriteManager.getSprite(SpriteID.MINIMAP_ORB_RUN_ICON, 0);
+            BufferedImage combatImg = spriteManager.getSprite(SpriteID.MINIMAP_ORB_SPECIAL_ICON, 0);
+
+            infoBoxManager.addInfoBox(new PlayerInfoCustomIndicator(healthImg, this, config, client, IndicatorType.HEALTH));
+            infoBoxManager.addInfoBox(new PlayerInfoCustomIndicator(prayerImg, this, config, client, IndicatorType.PRAYER));
+            infoBoxManager.addInfoBox(new PlayerInfoCustomIndicator(energyImg, this, config, client, IndicatorType.ENERGY));
+            infoBoxManager.addInfoBox(new PlayerInfoCustomIndicator(combatImg, this, config, client, IndicatorType.SPECIAL));
+
+            return true;
+        });
+    }
+
+    @Override
+    protected void shutDown() throws Exception
+    {
+        infoBoxManager.removeIf(i -> i instanceof PlayerInfoCustomIndicator);
+    }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerinfo/PlayerInfoPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerinfo/PlayerInfoPlugin.java
@@ -18,65 +18,65 @@ import java.awt.image.BufferedImage;
 import static net.runelite.client.plugins.playerinfo.PlayerInfoCustomIndicator.*;
 
 @PluginDescriptor(
-        name = "Player Information",
-        description = "An alternative to the Minimap Orbs",
-        tags = {"combat", "overlay"},
-        enabledByDefault = false
+	name = "Player Information",
+	description = "An alternative to the Minimap Orbs",
+	tags = {"combat", "overlay"},
+	enabledByDefault = false
 )
 @Singleton
 public class PlayerInfoPlugin extends Plugin
 {
-    @Inject
-    private Client client;
+	@Inject
+	private Client client;
 
-    @Inject
-    private ClientThread clientThread;
+	@Inject
+	private ClientThread clientThread;
 
-    @Inject
-    private InfoBoxManager infoBoxManager;
+	@Inject
+	private InfoBoxManager infoBoxManager;
 
-    @Inject
-    private PlayerInfoConfig config;
+	@Inject
+	private PlayerInfoConfig config;
 
-    @Inject
-    private SpriteManager spriteManager;
+	@Inject
+	private SpriteManager spriteManager;
 
-    @Inject
-    private SkillIconManager skillIconManager;
+	@Inject
+	private SkillIconManager skillIconManager;
 
-    @Provides
-    PlayerInfoConfig provideConfig(ConfigManager configManager)
-    {
-        return configManager.getConfig(PlayerInfoConfig.class);
-    }
+	@Provides
+	PlayerInfoConfig provideConfig(ConfigManager configManager)
+	{
+		return configManager.getConfig(PlayerInfoConfig.class);
+	}
 
-    @Override
-    protected void startUp() throws Exception
-    {
-        clientThread.invoke(() ->
-        {
-            if (client.getGameState().ordinal() < GameState.LOGIN_SCREEN.ordinal())
-            {
-                return false;
-            }
+	@Override
+	protected void startUp() throws Exception
+	{
+		clientThread.invoke(() ->
+		{
+			if (client.getGameState().ordinal() < GameState.LOGIN_SCREEN.ordinal())
+			{
+				return false;
+			}
 
-            BufferedImage healthImg = spriteManager.getSprite(SpriteID.MINIMAP_ORB_HITPOINTS_ICON, 0);
-            BufferedImage prayerImg = spriteManager.getSprite(SpriteID.MINIMAP_ORB_PRAYER_ICON, 0);
-            BufferedImage energyImg = spriteManager.getSprite(SpriteID.MINIMAP_ORB_RUN_ICON, 0);
-            BufferedImage combatImg = spriteManager.getSprite(SpriteID.MINIMAP_ORB_SPECIAL_ICON, 0);
+			BufferedImage healthImg = spriteManager.getSprite(SpriteID.MINIMAP_ORB_HITPOINTS_ICON, 0);
+			BufferedImage prayerImg = spriteManager.getSprite(SpriteID.MINIMAP_ORB_PRAYER_ICON, 0);
+			BufferedImage energyImg = spriteManager.getSprite(SpriteID.MINIMAP_ORB_RUN_ICON, 0);
+			BufferedImage combatImg = spriteManager.getSprite(SpriteID.MINIMAP_ORB_SPECIAL_ICON, 0);
 
-            infoBoxManager.addInfoBox(new PlayerInfoCustomIndicator(healthImg, this, config, client, IndicatorType.HEALTH));
-            infoBoxManager.addInfoBox(new PlayerInfoCustomIndicator(prayerImg, this, config, client, IndicatorType.PRAYER));
-            infoBoxManager.addInfoBox(new PlayerInfoCustomIndicator(energyImg, this, config, client, IndicatorType.ENERGY));
-            infoBoxManager.addInfoBox(new PlayerInfoCustomIndicator(combatImg, this, config, client, IndicatorType.SPECIAL));
+			infoBoxManager.addInfoBox(new PlayerInfoCustomIndicator(healthImg, this, config, client, IndicatorType.HEALTH));
+			infoBoxManager.addInfoBox(new PlayerInfoCustomIndicator(prayerImg, this, config, client, IndicatorType.PRAYER));
+			infoBoxManager.addInfoBox(new PlayerInfoCustomIndicator(energyImg, this, config, client, IndicatorType.ENERGY));
+			infoBoxManager.addInfoBox(new PlayerInfoCustomIndicator(combatImg, this, config, client, IndicatorType.SPECIAL));
 
-            return true;
-        });
-    }
+			return true;
+		});
+	}
 
-    @Override
-    protected void shutDown() throws Exception
-    {
-        infoBoxManager.removeIf(i -> i instanceof PlayerInfoCustomIndicator);
-    }
+	@Override
+	protected void shutDown() throws Exception
+	{
+		infoBoxManager.removeIf(i -> i instanceof PlayerInfoCustomIndicator);
+	}
 }


### PR DESCRIPTION
A new plugin for replicating the information provided by the Minimap Orbs as InfoBoxes.

Specifically useful for Steamers/Content Providers who's overlay blocks the minimap orbs but still want their viewers to be able to see them easily.

Also fixes an issue with net.runelite.api.SpriteID.MINIMAP_ORB_RUN_ICON having an incorrect value (1070 instead of 1069)

![Preview](https://user-images.githubusercontent.com/5209724/45861052-6ae79d80-bd1f-11e8-81aa-ec3e1bcd1c0f.png)
