### PR TITLE
Fix loot tracker box subtitle

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerBox.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerBox.java
@@ -76,13 +76,13 @@ class LootTrackerBox extends JPanel
 
 		logTitle.add(titleLabel, BorderLayout.WEST);
 
-		// If we have subtitle, add it
+		subTitleLabel.setFont(FontManager.getRunescapeSmallFont());
+		subTitleLabel.setForeground(ColorScheme.LIGHT_GRAY_COLOR);
+		logTitle.add(subTitleLabel, BorderLayout.CENTER);
+
 		if (!Strings.isNullOrEmpty(subtitle))
 		{
 			subTitleLabel.setText(subtitle);
-			subTitleLabel.setFont(FontManager.getRunescapeSmallFont());
-			subTitleLabel.setForeground(ColorScheme.LIGHT_GRAY_COLOR);
-			logTitle.add(subTitleLabel, BorderLayout.CENTER);
 		}
 
 		priceLabel.setFont(FontManager.getRunescapeSmallFont());


### PR DESCRIPTION
Fixes #5573 

There was a check in the box's constructor that checked if the subtitle was null or empty. This was left from the first version of the loot tracker where a box's subtitle would never change, but now, a box's title can be changed in grouped view.

All I had to do was still add the subtitle label to the container regardless of wether the initial subtitle was valid or not.