### PR TITLE
Add option to disable time elapsed on discord activity

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/discord/DiscordPresence.java
+++ b/runelite-client/src/main/java/net/runelite/client/discord/DiscordPresence.java
@@ -57,7 +57,7 @@ public class DiscordPresence
 	private Instant startTimestamp;
 
 	/**
-	 * Unix timestamp (seconds) for the start of the game.
+	 * Unix timestamp (seconds) for the end of the game.
 	 */
 	private Instant endTimestamp;
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordConfig.java
@@ -32,25 +32,25 @@ import net.runelite.client.config.ConfigItem;
 public interface DiscordConfig extends Config
 {
 	@ConfigItem(
-		keyName = "showElapsedTime",
-		name = "Show elapsed time",
-		description = "Configures if the elapsed time of your activity should be shown.",
-		position = 1
-	)
-	default boolean showElapsedTime()
-	{
-		return true;
-	}
-
-	@ConfigItem(
 		keyName = "actionTimeout",
 		name = "Action timeout (minutes)",
 		description = "Configures after how long of not updating status will be reset (in minutes)",
-		position = 2
+		position = 1
 	)
 	default int actionTimeout()
 	{
 		return 5;
+	}
+
+	@ConfigItem(
+		keyName = "hideElapsedTime",
+		name = "Hide elapsed time",
+		description = "Configures if the elapsed time of your activity should be hidden.",
+		position = 2
+	)
+	default boolean hideElapsedTime()
+	{
+		return false;
 	}
 
 	@ConfigItem(

--- a/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordConfig.java
@@ -32,10 +32,21 @@ import net.runelite.client.config.ConfigItem;
 public interface DiscordConfig extends Config
 {
 	@ConfigItem(
+		keyName = "showElapsedTime",
+		name = "Show elapsed time",
+		description = "Configures if the elapsed time of your activity should be shown.",
+		position = 1
+	)
+	default boolean showElapsedTime()
+	{
+		return true;
+	}
+
+	@ConfigItem(
 		keyName = "actionTimeout",
 		name = "Action timeout (minutes)",
 		description = "Configures after how long of not updating status will be reset (in minutes)",
-		position = 1
+		position = 2
 	)
 	default int actionTimeout()
 	{
@@ -46,7 +57,7 @@ public interface DiscordConfig extends Config
 		keyName = "showSkillActivity",
 		name = "Show activity while skilling",
 		description = "Configures if your activity while training skills should be shown.",
-		position = 2
+		position = 3
 	)
 	default boolean showSkillingActivity()
 	{
@@ -57,7 +68,7 @@ public interface DiscordConfig extends Config
 		keyName = "showBossActivity",
 		name = "Show activity at bosses",
 		description = "Configures if your activity at bosses should be shown.",
-		position = 3
+		position = 4
 	)
 	default boolean showBossActivity()
 	{
@@ -68,7 +79,7 @@ public interface DiscordConfig extends Config
 		keyName = "showCityActivity",
 		name = "Show activity at cities",
 		description = "Configures if your activity at cities should be shown.",
-		position = 4
+		position = 5
 	)
 	default boolean showCityActivity()
 	{
@@ -79,7 +90,7 @@ public interface DiscordConfig extends Config
 		keyName = "showDungeonActivity",
 		name = "Show activity at dungeons",
 		description = "Configures if your activity at dungeons should be shown.",
-		position = 5
+		position = 6
 	)
 	default boolean showDungeonActivity()
 	{
@@ -90,7 +101,7 @@ public interface DiscordConfig extends Config
 		keyName = "showMinigameActivity",
 		name = "Show activity at minigames",
 		description = "Configures if your activity at minigames should be shown.",
-		position = 6
+		position = 7
 	)
 	default boolean showMinigameActivity()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordState.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordState.java
@@ -87,16 +87,9 @@ class DiscordState
 		}
 		else
 		{
-			if (config.hideElapsedTime())
-			{
-				// If we aren't showing the elapsed time within Discord then
-				// We null out the event start property
-				event = new EventWithTime(eventType, null);
-			}
-			else
-			{
-				event = new EventWithTime(eventType, Instant.now());
-			}
+			// If we aren't showing the elapsed time within Discord then
+			// We null out the event start property
+			event = new EventWithTime(eventType, config.hideElapsedTime() ? null : Instant.now());
 
 			events.add(event);
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordState.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordState.java
@@ -45,7 +45,7 @@ class DiscordState
 	private class EventWithTime
 	{
 		private final DiscordGameEventType type;
-		private Instant start;
+		private final Instant start;
 		private Instant updated;
 	}
 
@@ -87,11 +87,15 @@ class DiscordState
 		}
 		else
 		{
-			event = new EventWithTime(eventType);
-
-			if (config.showElapsedTime())
+			if (config.hideElapsedTime())
 			{
-				event.start = Instant.now();
+				// If we aren't showing the elapsed time within Discord then
+				// We null out the event start property
+				event = new EventWithTime(eventType, null);
+			}
+			else
+			{
+				event = new EventWithTime(eventType, Instant.now());
 			}
 
 			events.add(event);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordState.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordState.java
@@ -45,7 +45,7 @@ class DiscordState
 	private class EventWithTime
 	{
 		private final DiscordGameEventType type;
-		private final Instant start;
+		private Instant start;
 		private Instant updated;
 	}
 
@@ -87,7 +87,13 @@ class DiscordState
 		}
 		else
 		{
-			event = new EventWithTime(eventType, Instant.now());
+			event = new EventWithTime(eventType);
+
+			if (config.showElapsedTime())
+			{
+				event.start = Instant.now();
+			}
+
 			events.add(event);
 		}
 


### PR DESCRIPTION
Updated plugin to allow disabling of elapsed time. EventWithTime start property now nullable and will be set depending upon config checkbox.
Also fixed a comment that was a copy paste error.

Closes #5282