### PR TITLE
Show common cannon spots without cannon set in inventory

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonConfig.java
@@ -85,7 +85,7 @@ public interface CannonConfig extends Config
     @ConfigItem(
             keyName = "requireCannon",
             name = "Require cannon for spots",
-            description = "Configures whether cannon in inventory required to show spots or not"
+            description = "Configures whether cannon in inventory is required to show spots or not"
     )
     default boolean requireCannon()
     {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonConfig.java
@@ -82,13 +82,13 @@ public interface CannonConfig extends Config
 		return true;
 	}
 
-    @ConfigItem(
-            keyName = "requireCannon",
-            name = "Require cannon for spots",
-            description = "Configures whether cannon in inventory is required to show spots or not"
-    )
-    default boolean requireCannon()
-    {
-        return true;
-    }
+	@ConfigItem(
+		keyName = "requireCannon",
+		name = "Require cannon for spots",
+		description = "Configures whether cannon in inventory is required to show spots or not"
+	)
+	default boolean requireCannon()
+	{
+		return true;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonConfig.java
@@ -81,4 +81,14 @@ public interface CannonConfig extends Config
 	{
 		return true;
 	}
+
+    @ConfigItem(
+            keyName = "requireCannon",
+            name = "Require cannon for spots",
+            description = "Configures whether cannon in inventory required to show spots or not"
+    )
+    default boolean requireCannon()
+    {
+        return true;
+    }
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonSpotOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonSpotOverlay.java
@@ -69,7 +69,7 @@ public class CannonSpotOverlay extends Overlay
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
-		if (hidden || !config.showCannonSpots() || plugin.isCannonPlaced())
+		if ((hidden && config.requireCannon()) || !config.showCannonSpots() || plugin.isCannonPlaced())
 		{
 			return null;
 		}


### PR DESCRIPTION
Adds optional setting for showing common cannon spots without having a cannon in your inventory.

Resolves #5562 