### PR TITLE
Reduce tab size in notes panel to 2

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/notes/NotesPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/notes/NotesPanel.java
@@ -54,6 +54,7 @@ class NotesPanel extends PluginPanel
 		setBorder(BorderFactory.createEmptyBorder(10, 10, 10, 10));
 		setBackground(ColorScheme.DARK_GRAY_COLOR);
 
+		notesEditor.setTabSize(2);
 		notesEditor.setLineWrap(true);
 		notesEditor.setWrapStyleWord(true);
 


### PR DESCRIPTION
Fixes #5591 

New tab size:
![image](https://user-images.githubusercontent.com/3868171/45924639-01e85d00-beba-11e8-9aa9-7f1e6c64453b.png)
