### PR TITLE
Fix clipping in fixed mode for edge snapping map points

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/worldmap/WorldMapOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/worldmap/WorldMapOverlay.java
@@ -92,7 +92,11 @@ public class WorldMapOverlay extends Overlay
 
 		final Rectangle worldMapRectangle = widget.getBounds();
 		final Area mapViewArea = getWorldMapClipArea(worldMapRectangle);
-		final Area canvasViewArea = getWorldMapClipArea(client.getCanvas().getBounds());
+		final Rectangle canvasBounds = client.getCanvas().getBounds();
+		// in fixed, the bounds are offset by the size of the black borders outside the canvas
+		canvasBounds.setLocation(0, 0);
+		final Area canvasViewArea = getWorldMapClipArea(canvasBounds);
+
 		WorldMapPoint tooltipPoint = null;
 
 		for (WorldMapPoint worldPoint : points)


### PR DESCRIPTION
The bounds for the canvas in fixed mode are offset to the right by the size of the border. This translates the canvas bounds back to the left so we don't clip the icon if it's on the left side.

Fixes #5618 