### PR TITLE
Add bank title rounding options

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/bankvalue/BankTitle.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/bankvalue/BankTitle.java
@@ -100,7 +100,7 @@ class BankTitle
 			}
 			else
 			{
-				strCurrentTab += StackFormatter.quantityToStackSize(gePrice) + ")";
+				strCurrentTab += formatBankTitle(gePrice) + ")";
 			}
 		}
 
@@ -114,11 +114,37 @@ class BankTitle
 			}
 			else
 			{
-				strCurrentTab += StackFormatter.quantityToStackSize(haPrice) + ")";
+				strCurrentTab += formatBankTitle(haPrice) + ")";
 			}
 		}
 
 		log.debug("Setting bank title: {}", bankTitle + strCurrentTab);
 		widgetBankTitleBar.setText(bankTitle + strCurrentTab);
+	}
+
+
+	String formatBankTitle(long value)
+	{
+		if (config.titleDecimal() == BankValueConfig.BankTitleDecimalOptions.One)
+		{
+			return StackFormatter.quantityToDecimalStack(value, 1);
+		}
+
+		if (config.titleDecimal() == BankValueConfig.BankTitleDecimalOptions.Two)
+		{
+			return StackFormatter.quantityToDecimalStack(value, 2);
+		}
+
+		if (config.titleDecimal() == BankValueConfig.BankTitleDecimalOptions.Three)
+		{
+			return StackFormatter.quantityToDecimalStack(value, 3);
+		}
+
+		if (config.titleDecimal() == BankValueConfig.BankTitleDecimalOptions.Four)
+		{
+			return StackFormatter.quantityToDecimalStack(value, 4);
+		}
+
+		return StackFormatter.quantityToStackSize(value);
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/bankvalue/BankValueConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/bankvalue/BankValueConfig.java
@@ -32,6 +32,15 @@ import net.runelite.client.config.ConfigItem;
 @ConfigGroup("bankvalue")
 public interface BankValueConfig extends Config
 {
+	enum BankTitleDecimalOptions
+	{
+		Dynamic,
+		One,
+		Two,
+		Three,
+		Four
+	}
+
 	@ConfigItem(
 		keyName = "showGE",
 		name = "Show Grand Exchange price",
@@ -63,5 +72,16 @@ public interface BankValueConfig extends Config
 	default boolean showExact()
 	{
 		return false;
+	}
+
+	@ConfigItem(
+		keyName = "bankTitleDecimal",
+		name = "Bank Title Rounding",
+		description = "How Many Decimals to Show in the Bank Title",
+		position = 4
+	)
+	default BankTitleDecimalOptions titleDecimal()
+	{
+		return BankTitleDecimalOptions.Dynamic;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangeOfferSlot.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangeOfferSlot.java
@@ -216,8 +216,8 @@ public class GrandExchangeOfferSlot extends JPanel
 				|| newOffer.getState() == GrandExchangeOfferState.CANCELLED_BUY;
 
 			String offerState = (buying ? "Bought " : "Sold ")
-				+ StackFormatter.quantityToRSDecimalStack(newOffer.getQuantitySold()) + " / "
-				+ StackFormatter.quantityToRSDecimalStack(newOffer.getTotalQuantity());
+				+ StackFormatter.quantityToRSDecimalStack(newOffer.getQuantitySold(), 1) + " / "
+				+ StackFormatter.quantityToRSDecimalStack(newOffer.getTotalQuantity(), 1);
 
 			offerInfo.setText(offerState);
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpInfoBox.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpInfoBox.java
@@ -236,7 +236,7 @@ class XpInfoBox extends JPanel
 
 	static String htmlLabel(String key, int value)
 	{
-		String valueStr = StackFormatter.quantityToRSDecimalStack(value);
+		String valueStr = StackFormatter.quantityToRSDecimalStack(value, 1);
 		return String.format(HTML_LABEL_TEMPLATE, ColorUtil.toHexColor(ColorScheme.LIGHT_GRAY_COLOR), key, valueStr);
 	}
 }

--- a/runelite-client/src/test/java/net/runelite/client/util/StackFormatterTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/util/StackFormatterTest.java
@@ -43,21 +43,21 @@ public class StackFormatterTest
 	@Test
 	public void quantityToRSDecimalStackSize()
 	{
-		assertEquals("0", StackFormatter.quantityToRSDecimalStack(0));
-		assertEquals("8500", StackFormatter.quantityToRSDecimalStack(8_500));
-		assertEquals("10K", StackFormatter.quantityToRSDecimalStack(10_000));
-		assertEquals("21.7K", StackFormatter.quantityToRSDecimalStack(21_700));
-		assertEquals("100K", StackFormatter.quantityToRSDecimalStack(100_000));
-		assertEquals("100.3K", StackFormatter.quantityToRSDecimalStack(100_300));
-		assertEquals("1M", StackFormatter.quantityToRSDecimalStack(1_000_000));
-		assertEquals("8.4M", StackFormatter.quantityToRSDecimalStack(8_450_000));
-		assertEquals("10M", StackFormatter.quantityToRSDecimalStack(10_000_000));
-		assertEquals("12.8M", StackFormatter.quantityToRSDecimalStack(12_800_000));
-		assertEquals("100M", StackFormatter.quantityToRSDecimalStack(100_000_000));
-		assertEquals("250.1M", StackFormatter.quantityToRSDecimalStack(250_100_000));
-		assertEquals("1B", StackFormatter.quantityToRSDecimalStack(1_000_000_000));
-		assertEquals("1.5B", StackFormatter.quantityToRSDecimalStack(1500_000_000));
-		assertEquals("2.1B", StackFormatter.quantityToRSDecimalStack(Integer.MAX_VALUE));
+		assertEquals("0", StackFormatter.quantityToRSDecimalStack(0, 1));
+		assertEquals("8500", StackFormatter.quantityToRSDecimalStack(8_500, 1));
+		assertEquals("10K", StackFormatter.quantityToRSDecimalStack(10_000, 1));
+		assertEquals("21.7K", StackFormatter.quantityToRSDecimalStack(21_700, 1));
+		assertEquals("100K", StackFormatter.quantityToRSDecimalStack(100_000, 1));
+		assertEquals("100.3K", StackFormatter.quantityToRSDecimalStack(100_300, 1));
+		assertEquals("1M", StackFormatter.quantityToRSDecimalStack(1_000_000, 1));
+		assertEquals("8.4M", StackFormatter.quantityToRSDecimalStack(8_450_000, 1));
+		assertEquals("10M", StackFormatter.quantityToRSDecimalStack(10_000_000, 1));
+		assertEquals("12.8M", StackFormatter.quantityToRSDecimalStack(12_800_000, 1));
+		assertEquals("100M", StackFormatter.quantityToRSDecimalStack(100_000_000, 1));
+		assertEquals("250.1M", StackFormatter.quantityToRSDecimalStack(250_100_000, 1));
+		assertEquals("1B", StackFormatter.quantityToRSDecimalStack(1_000_000_000, 1));
+		assertEquals("1.5B", StackFormatter.quantityToRSDecimalStack(1500_000_000, 1));
+		assertEquals("2.1B", StackFormatter.quantityToRSDecimalStack(Integer.MAX_VALUE, 1));
 	}
 
 	@Test
@@ -96,6 +96,24 @@ public class StackFormatterTest
 		assertEquals("-40M", StackFormatter.quantityToStackSize(-40_000_000));
 		assertEquals(NumberFormat.getNumberInstance().format(-2.14) + "B", StackFormatter.quantityToStackSize(Integer.MIN_VALUE));
 		assertEquals("-400B", StackFormatter.quantityToStackSize(-400_000_000_000L));
+	}
+
+	@Test
+	public void quantityToDecimalStack()
+	{
+		assertEquals("0", StackFormatter.quantityToDecimalStack(0,0));
+		assertEquals("100K", StackFormatter.quantityToDecimalStack(100000,0));
+		assertEquals("100M", StackFormatter.quantityToDecimalStack(100000000,0));
+		assertEquals("100B", StackFormatter.quantityToDecimalStack(100_000_000_000L,0));
+		assertEquals("0", StackFormatter.quantityToDecimalStack(0,2));
+		assertEquals("100.23K", StackFormatter.quantityToDecimalStack(100230,2));
+		assertEquals("100.23M", StackFormatter.quantityToDecimalStack(100230000,2));
+		assertEquals("100.23B", StackFormatter.quantityToDecimalStack(100_230_000_000L,2));
+		assertEquals("100.232K", StackFormatter.quantityToDecimalStack(100232,3));
+		assertEquals("100.233M", StackFormatter.quantityToDecimalStack(100233400,3));
+		assertEquals("100.2334M", StackFormatter.quantityToDecimalStack(100233400,4));
+		assertEquals("2B", StackFormatter.quantityToDecimalStack(Integer.MAX_VALUE, 0));
+		assertEquals("-2.14B", StackFormatter.quantityToDecimalStack(Integer.MIN_VALUE, 2));
 	}
 
 	@Test


### PR DESCRIPTION
I refactored the StackFormatter class mentioned in #5311.  However I may need some guidance getting this formatted to the code base's current design guide.  I can't tell if it's expected to follow the old commenting style found in some of these classes, or newer comments more recently added.

I'm also unsure of where the Kingdom Coffer tooltip is in game to test that aspect of the formatting.