### PR TITLE
HP Regeneration notifier option

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/regenmeter/RegenMeterConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/regenmeter/RegenMeterConfig.java
@@ -61,7 +61,7 @@ public interface RegenMeterConfig extends Config
 	@ConfigItem(
 		keyName = "regenWarning",
 		name = "Show a warning when about to regenerate health.",
-		description = "0 Means disabled, the value can be 0 - 99 with the value equalling the percentage of hp regeneration.")
+		description = "0 Means disabled, the value can be 0 - 99 with the value being the percentage of hp that triggers a warning.")
 	default int regenWarning()
 	{
 		return 0;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/regenmeter/RegenMeterConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/regenmeter/RegenMeterConfig.java
@@ -57,4 +57,13 @@ public interface RegenMeterConfig extends Config
 	{
 		return false;
 	}
+
+	@ConfigItem(
+		keyName = "regenWarning",
+		name = "Show a warning when about to regenerate health.",
+		description = "0 Means disabled, the value can be 0 - 99 with the value equalling the percentage of hp regeneration.")
+	default int regenWarning()
+	{
+		return 0;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/regenmeter/RegenMeterConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/regenmeter/RegenMeterConfig.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018 Abex
+ * Copyright (c) 2018 Robin Withes
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/runelite-client/src/main/java/net/runelite/client/plugins/regenmeter/RegenMeterConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/regenmeter/RegenMeterConfig.java
@@ -60,8 +60,8 @@ public interface RegenMeterConfig extends Config
 
 	@ConfigItem(
 		keyName = "regenWarning",
-		name = "Show a warning when about to regenerate health.",
-		description = "0 Means disabled, the value can be 0 - 99 with the value being the percentage of hp that triggers a warning.")
+		name = "Health Regeneration Notification Threshold",
+		description = "The amount of remaining health regeneration % to send a notification at. A value of 0 will disable notification.")
 	default int regenWarning()
 	{
 		return 0;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/regenmeter/RegenMeterPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/regenmeter/RegenMeterPlugin.java
@@ -154,11 +154,7 @@ public class RegenMeterPlugin extends Plugin
 			// Show it going down
 			hitpointsPercentage = 1 - hitpointsPercentage;
 		}
-		else if (maxHP > currentHP && config.regenWarning() > 0 && config.regenWarning() < 100 && (Math.round(hitpointsPercentage * 100)) == config.regenWarning() && !client.isPrayerActive(Prayer.RAPID_HEAL))
-		{
-			notifier.notify("You have reached your HP Regeneration Threshold!");
-		}
-		else if (!messageSend && maxHP > currentHP && config.regenWarning() > 0 && config.regenWarning() < 100 && ((Math.round(hitpointsPercentage * 100)) == config.regenWarning() - 1 || (Math.round(hitpointsPercentage * 100)) == config.regenWarning() ) && client.isPrayerActive(Prayer.RAPID_HEAL))
+		else if (!messageSend && maxHP > currentHP && config.regenWarning() > 0 && config.regenWarning() < 100 && ((Math.round(hitpointsPercentage * 100)) == config.regenWarning() || (Math.round(hitpointsPercentage * 100)) == config.regenWarning() - 1))
 		{
 			notifier.notify("You have reached your HP Regeneration Threshold!");
 			messageSend = true;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/regenmeter/RegenMeterPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/regenmeter/RegenMeterPlugin.java
@@ -149,9 +149,12 @@ public class RegenMeterPlugin extends Plugin
 		int maxHP = client.getRealSkillLevel(Skill.HITPOINTS);
 		long hpPercentage = (Math.round(hitpointsPercentage * 100));
 		boolean checkHealthPercentage = (hpPercentage == config.regenWarning() || hpPercentage == config.regenWarning() - 1);
-		if (!config.showWhenNoChange() && currentHP == maxHP)
+		if (currentHP == maxHP)
 		{
-			hitpointsPercentage = 0;
+			if (!config.showWhenNoChange())
+			{
+				hitpointsPercentage = 0;
+			}
 		}
 		else if (currentHP > maxHP)
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/regenmeter/RegenMeterPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/regenmeter/RegenMeterPlugin.java
@@ -149,6 +149,7 @@ public class RegenMeterPlugin extends Plugin
 		int maxHP = client.getRealSkillLevel(Skill.HITPOINTS);
 		long hpPercentage = (Math.round(hitpointsPercentage * 100));
 		boolean checkHealthPercentage = (hpPercentage == config.regenWarning() || hpPercentage == config.regenWarning() - 1);
+		
 		if (currentHP == maxHP)
 		{
 			if (!config.showWhenNoChange())

--- a/runelite-client/src/main/java/net/runelite/client/plugins/regenmeter/RegenMeterPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/regenmeter/RegenMeterPlugin.java
@@ -158,7 +158,7 @@ public class RegenMeterPlugin extends Plugin
 		else if (!messageSend && maxHP > currentHP && config.regenWarning() > 0 && config.regenWarning() < 100 && ((Math.round(hitpointsPercentage * 100)) == config.regenWarning() || (Math.round(hitpointsPercentage * 100)) == config.regenWarning() - 1))
 		{
 			Player local = client.getLocalPlayer();
-			notifier.notify("[" + local.getName() + "] has reached the regeneration threshold!");
+			notifier.notify("[" + local.getName() + "] is about to regenerate health!");
 			messageSend = true;
 			return;
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/regenmeter/RegenMeterPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/regenmeter/RegenMeterPlugin.java
@@ -38,6 +38,7 @@ import net.runelite.api.VarPlayer;
 import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.GameTick;
 import net.runelite.api.events.VarbitChanged;
+import net.runelite.client.Notifier;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
@@ -63,6 +64,9 @@ public class RegenMeterPlugin extends Plugin
 	private RegenMeterOverlay overlay;
 
 	@Inject
+	private Notifier notifier;
+
+	@Inject
 	private RegenMeterConfig config;
 
 	@Getter
@@ -74,6 +78,7 @@ public class RegenMeterPlugin extends Plugin
 	private int ticksSinceSpecRegen;
 	private int ticksSinceHPRegen;
 	private boolean wasRapidHeal;
+	private boolean messageSend;
 
 	@Provides
 	RegenMeterConfig provideConfig(ConfigManager configManager)
@@ -149,5 +154,16 @@ public class RegenMeterPlugin extends Plugin
 			// Show it going down
 			hitpointsPercentage = 1 - hitpointsPercentage;
 		}
+		else if (maxHP > currentHP && config.regenWarning() > 0 && config.regenWarning() < 100 && (Math.round(hitpointsPercentage * 100)) == config.regenWarning() && !client.isPrayerActive(Prayer.RAPID_HEAL))
+		{
+			notifier.notify("You have reached your HP Regeneration Threshold!");
+		}
+		else if (!messageSend && maxHP > currentHP && config.regenWarning() > 0 && config.regenWarning() < 100 && ((Math.round(hitpointsPercentage * 100)) == config.regenWarning() - 1 || (Math.round(hitpointsPercentage * 100)) == config.regenWarning() ) && client.isPrayerActive(Prayer.RAPID_HEAL))
+		{
+			notifier.notify("You have reached your HP Regeneration Threshold!");
+			messageSend = true;
+			return;
+		}
+		messageSend = false;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/regenmeter/RegenMeterPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/regenmeter/RegenMeterPlugin.java
@@ -32,6 +32,7 @@ import javax.inject.Inject;
 import lombok.Getter;
 import net.runelite.api.Client;
 import net.runelite.api.GameState;
+import net.runelite.api.Player;
 import net.runelite.api.Prayer;
 import net.runelite.api.Skill;
 import net.runelite.api.VarPlayer;
@@ -156,7 +157,8 @@ public class RegenMeterPlugin extends Plugin
 		}
 		else if (!messageSend && maxHP > currentHP && config.regenWarning() > 0 && config.regenWarning() < 100 && ((Math.round(hitpointsPercentage * 100)) == config.regenWarning() || (Math.round(hitpointsPercentage * 100)) == config.regenWarning() - 1))
 		{
-			notifier.notify("You have reached your HP Regeneration Threshold!");
+			Player local = client.getLocalPlayer();
+			notifier.notify("[" + local.getName() + "] has reached the regeneration threshold!");
 			messageSend = true;
 			return;
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/regenmeter/RegenMeterPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/regenmeter/RegenMeterPlugin.java
@@ -81,7 +81,6 @@ public class RegenMeterPlugin extends Plugin
 	private int ticksSinceHPRegen;
 	private boolean wasRapidHeal;
 	private boolean messageSend;
-	private boolean checkHealthPercentage;
 
 	@Provides
 	RegenMeterConfig provideConfig(ConfigManager configManager)
@@ -148,8 +147,9 @@ public class RegenMeterPlugin extends Plugin
 
 		int currentHP = client.getBoostedSkillLevel(Skill.HITPOINTS);
 		int maxHP = client.getRealSkillLevel(Skill.HITPOINTS);
-		checkHealthPercentage = ((Math.round(hitpointsPercentage * 100)) == config.regenWarning() || (Math.round(hitpointsPercentage * 100)) == config.regenWarning() - 1);
-		if (currentHP == maxHP && !config.showWhenNoChange())
+		long hpPercentage = (Math.round(hitpointsPercentage * 100));
+		boolean checkHealthPercentage = (hpPercentage == config.regenWarning() || hpPercentage == config.regenWarning() - 1);
+		if (!config.showWhenNoChange() && currentHP == maxHP)
 		{
 			hitpointsPercentage = 0;
 		}
@@ -158,7 +158,7 @@ public class RegenMeterPlugin extends Plugin
 			// Show it going down
 			hitpointsPercentage = 1 - hitpointsPercentage;
 		}
-		else if (!messageSend && maxHP > currentHP && checkHealthPercentage && config.regenWarning() > 0)
+		else if (config.regenWarning() > 0 && !messageSend && maxHP > currentHP && checkHealthPercentage)
 		{
 			Player local = client.getLocalPlayer();
 			notifier.notify("[" + local.getName() + "] is about to regenerate health!");

--- a/runelite-client/src/main/java/net/runelite/client/plugins/regenmeter/RegenMeterPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/regenmeter/RegenMeterPlugin.java
@@ -2,6 +2,7 @@
  * Copyright (c) 2018 Abex
  * Copyright (c) 2018, Zimaya <https://github.com/Zimaya>
  * Copyright (c) 2017, Adam <Adam@sigterm.info>
+ * Copyright (c) 2018 Robin Withes
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -80,6 +81,7 @@ public class RegenMeterPlugin extends Plugin
 	private int ticksSinceHPRegen;
 	private boolean wasRapidHeal;
 	private boolean messageSend;
+	private boolean checkHealthPercentage;
 
 	@Provides
 	RegenMeterConfig provideConfig(ConfigManager configManager)
@@ -146,6 +148,7 @@ public class RegenMeterPlugin extends Plugin
 
 		int currentHP = client.getBoostedSkillLevel(Skill.HITPOINTS);
 		int maxHP = client.getRealSkillLevel(Skill.HITPOINTS);
+		checkHealthPercentage = ((Math.round(hitpointsPercentage * 100)) == config.regenWarning() || (Math.round(hitpointsPercentage * 100)) == config.regenWarning() - 1);
 		if (currentHP == maxHP && !config.showWhenNoChange())
 		{
 			hitpointsPercentage = 0;
@@ -155,7 +158,7 @@ public class RegenMeterPlugin extends Plugin
 			// Show it going down
 			hitpointsPercentage = 1 - hitpointsPercentage;
 		}
-		else if (!messageSend && maxHP > currentHP && config.regenWarning() > 0 && config.regenWarning() < 100 && ((Math.round(hitpointsPercentage * 100)) == config.regenWarning() || (Math.round(hitpointsPercentage * 100)) == config.regenWarning() - 1))
+		else if (!messageSend && maxHP > currentHP && checkHealthPercentage && config.regenWarning() > 0)
 		{
 			Player local = client.getLocalPlayer();
 			notifier.notify("[" + local.getName() + "] is about to regenerate health!");


### PR DESCRIPTION
This is a personal addition i made a while back to aid with nightmare zone afk-ing and i figured it might be useful to some other people as well.

Q:
Why didn't i make it into idle notifiers or the nightmare zone plugin?
A:
2 Reasons: Either i would have to remake what regen meter does in a different place or i would have to rely on regen meter being enabled, as well as this being useful in situations like giant mole as well. thus not fitting solely in the nightmare zone area.