### PR TITLE
Opponentinfo removed if boss with healthbar

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/opponentinfo/OpponentInfoConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/opponentinfo/OpponentInfoConfig.java
@@ -52,4 +52,15 @@ public interface OpponentInfoConfig extends Config
 	{
 		return false;
 	}
+
+	@ConfigItem(
+		keyName = "hideOnExisting",
+		name = "Hide on existing healthbar",
+		description = "NPC's that are known to have health bars already will not have a Runelite one.",
+		position = 2
+	)
+	default boolean hideOnExisting()
+	{
+		return true;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/opponentinfo/OpponentInfoOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/opponentinfo/OpponentInfoOverlay.java
@@ -35,6 +35,7 @@ import javax.inject.Inject;
 import net.runelite.api.Actor;
 import net.runelite.api.Client;
 import net.runelite.api.NPC;
+import static net.runelite.api.NpcID.*;
 import net.runelite.api.Player;
 import net.runelite.api.Varbits;
 import net.runelite.client.game.HiscoreManager;
@@ -100,6 +101,10 @@ class OpponentInfoOverlay extends Overlay
 			lastMaxHealth = null;
 			if (opponent instanceof NPC)
 			{
+				if (bosHasHealthbar(((NPC) opponent).getId()))
+				{
+					return null;
+				}
 				lastMaxHealth = opponentInfoPlugin.getOppInfoHealth().get(opponentName + "_" + opponent.getCombatLevel());
 			}
 			else if (opponent instanceof Player)
@@ -175,5 +180,36 @@ class OpponentInfoOverlay extends Overlay
 		}
 
 		return panelComponent.render(graphics);
+	}
+
+	private boolean bosHasHealthbar(int bossId)
+	{
+		switch (bossId)
+		{ //all defined in NpcID.java
+			case TZKALZUK:
+			case THE_MAIDEN_OF_SUGADINTI:
+			case THE_MAIDEN_OF_SUGADINTI_8361:
+			case THE_MAIDEN_OF_SUGADINTI_8362:
+			case THE_MAIDEN_OF_SUGADINTI_8363:
+			case THE_MAIDEN_OF_SUGADINTI_8364:
+			case THE_MAIDEN_OF_SUGADINTI_8365:
+			case PESTILENT_BLOAT:
+			case XARPUS:
+			case XARPUS_8339:
+			case XARPUS_8340:
+			case XARPUS_8341:
+			case VERZIK_VITUR:
+			case VERZIK_VITUR_8369:
+			case VERZIK_VITUR_8370:
+			case VERZIK_VITUR_8371:
+			case VERZIK_VITUR_8372:
+			case VERZIK_VITUR_8373:
+			case VERZIK_VITUR_8374:
+			case VERZIK_VITUR_8375:
+			case GALVEK:
+				return true;
+			default:
+				return false;
+		}
 	}
 }


### PR DESCRIPTION
If a boss is defined to have a healthbar then it will not show up when attacked.
I looked into detecting if the healthbar widget is open but jagex seems to use multiple ones as well as doing this would not show other npc's health when in a boss room (TOB for example) thus making this solution around the same effort for a better result.

Fixes #5570 