### PR TITLE
Allow hop-to option in clan chat menu when target player is a friend and their private chat is off

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldHopperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldHopperPlugin.java
@@ -660,19 +660,8 @@ public class WorldHopperPlugin extends Plugin
 	{
 		String cleanName = Text.removeTags(name);
 
-		Friend[] friends = client.getFriends();
-
-		if (friends != null)
-		{
-			for (Friend friend : friends)
-			{
-				if (friend != null && friend.getName().equals(cleanName))
-				{
-					return friend;
-				}
-			}
-		}
-
+		// Search clan members first, because if a friend is in the clan chat but their private
+		// chat is 'off', then the hop-to option will not get shown in the menu (issue #5679).
 		ClanMember[] clanMembers = client.getClanMembers();
 
 		if (clanMembers != null)
@@ -682,6 +671,19 @@ public class WorldHopperPlugin extends Plugin
 				if (clanMember != null && clanMember.getUsername().equals(cleanName))
 				{
 					return clanMember;
+				}
+			}
+		}
+
+		Friend[] friends = client.getFriends();
+
+		if (friends != null)
+		{
+			for (Friend friend : friends)
+			{
+				if (friend != null && friend.getName().equals(cleanName))
+				{
+					return friend;
 				}
 			}
 		}


### PR DESCRIPTION
Fixes #5679 

Because `getChatPlayerFromName` checks to see if the target player is a friend first, it finds the target player as their friend. However, if their private chat is off, their world will be returned as `0`, and thus the hop-to option is not displayed. This fix checks for the target player in the clan chat list first, and if it can't find the player, then it searches the friends list.