### PR TITLE
Remove 'Take' option from items on the ignored list.

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
@@ -302,4 +302,16 @@ public interface GroundItemsConfig extends Config
 	{
 		return 10000000;
 	}
+
+
+	@ConfigItem(
+			position = 13,
+			keyName = "removeIgnored",
+			name = "Hide Ignored",
+			description = "Remove take option for items that are on the hidden items list."
+	)
+	default boolean removeIgnored()
+	{
+		return false;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
@@ -76,6 +76,7 @@ import static net.runelite.client.plugins.grounditems.config.MenuHighlightMode.N
 import static net.runelite.client.plugins.grounditems.config.MenuHighlightMode.OPTION;
 import net.runelite.client.ui.overlay.OverlayManager;
 import net.runelite.client.util.ColorUtil;
+import net.runelite.client.util.Text;
 
 @PluginDescriptor(
 	name = "Ground Items",
@@ -393,9 +394,38 @@ public class GroundItemsPlugin extends Plugin
 			{
 				lastEntry.setTarget(lastEntry.getTarget() + " (" + quantity + ")");
 			}
+			if(config.removeIgnored() && event.getOption().equals("Take") && hiddenItemList.contains(Text.removeTags(event.getTarget())))
+			{
+				menuEntries = removeOption(event.getOption(), event.getTarget());
+			}
 
 			client.setMenuEntries(menuEntries);
 		}
+	}
+
+	private MenuEntry[] removeOption(String option, String target)
+	{
+		MenuEntry[] entries = client.getMenuEntries();
+		int j = 0;
+		if(entries.length > 1)
+		{
+			MenuEntry[] newEntries = new MenuEntry[entries.length - 1];
+			for (int i = 0; i < entries.length; ++i)
+			{
+				if (!(entries[i].getOption().equals(option) && entries[i].getTarget().equals(target)))
+				{
+					newEntries[j++] = entries[i];
+				}
+			}
+
+			return newEntries;
+		}
+		else
+		{
+			return entries;
+		}
+
+
 	}
 
 	void updateList(String item, boolean hiddenList)


### PR DESCRIPTION
This option is added under the grounditems plugin. Appears as

![Option](https://i.imgur.com/phkBdMH.png)

This allows the user to hide items on the hidden list. Making it easier to loot and generally ignore people dropping junk at various activities.

![Demo](https://i.imgur.com/CvOwxE9.gif)