### PR TITLE
Add default cc info chatcolor and change cc info highlight to red

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/config/ChatColorConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/ChatColorConfig.java
@@ -92,7 +92,10 @@ public interface ChatColorConfig extends Config
 		name = "Clan chat info",
 		description = "Clan Chat Information (eg. when joining a channel)"
 	)
-	Color opaqueClanChatInfo();
+	default Color opaqueClanChatInfo()
+	{
+		return Color.BLACK;
+	}
 
 	@ConfigItem(
 		position = 38,
@@ -102,7 +105,7 @@ public interface ChatColorConfig extends Config
 	)
 	default Color opaqueClanChatInfoHighlight()
 	{
-		return Color.decode("#EF20FF");
+		return Color.RED;
 	}
 
 	@ConfigItem(
@@ -329,7 +332,10 @@ public interface ChatColorConfig extends Config
 		name = "Clan chat info (transparent)",
 		description = "Clan Chat Information (eg. when joining a channel) (transparent)"
 	)
-	Color transparentClanChatInfo();
+	default Color transparentClanChatInfo()
+	{
+		return Color.WHITE;
+	}
 
 	@ConfigItem(
 		position = 68,
@@ -339,7 +345,7 @@ public interface ChatColorConfig extends Config
 	)
 	default Color transparentClanChatInfoHighlight()
 	{
-		return Color.decode("#EF20FF");
+		return Color.RED;
 	}
 
 	@ConfigItem(


### PR DESCRIPTION
This is to prevent the highlight color from bleeding trough which happens currently for the raids ending message (see image)

![image](https://user-images.githubusercontent.com/35824069/46305930-224ba200-c5b3-11e8-869f-cc350f3005dc.png)

It also changes the highlight colour to red because:

1) it seems the other raids messages use the pink as normal colour and red as highlight
2) the pink is sometimes (e.g. transparent chat) not easily readable.