### PR TITLE
Make raids scout overlay not show at Olm

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsOverlay.java
@@ -29,6 +29,7 @@ import java.awt.Dimension;
 import java.awt.Graphics2D;
 import javax.inject.Inject;
 import lombok.Setter;
+import net.runelite.api.Client;
 import net.runelite.client.plugins.raids.solver.Room;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayPosition;
@@ -39,6 +40,7 @@ import net.runelite.client.ui.overlay.components.TitleComponent;
 
 public class RaidsOverlay extends Overlay
 {
+	private Client client;
 	private RaidsPlugin plugin;
 	private RaidsConfig config;
 	private final PanelComponent panelComponent = new PanelComponent();
@@ -47,10 +49,11 @@ public class RaidsOverlay extends Overlay
 	private boolean scoutOverlayShown = false;
 
 	@Inject
-	public RaidsOverlay(RaidsPlugin plugin, RaidsConfig config)
+	public RaidsOverlay(Client client, RaidsPlugin plugin, RaidsConfig config)
 	{
 		setPosition(OverlayPosition.TOP_LEFT);
 		setPriority(OverlayPriority.LOW);
+		this.client = client;
 		this.plugin = plugin;
 		this.config = config;
 	}
@@ -58,7 +61,8 @@ public class RaidsOverlay extends Overlay
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
-		if (!config.scoutOverlay() || !scoutOverlayShown)
+		//Do not show the scout overlay while we are down at olm (plane == 0)
+		if (!config.scoutOverlay() || !scoutOverlayShown || client.getPlane() == 0)
 		{
 			return null;
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsOverlay.java
@@ -40,6 +40,8 @@ import net.runelite.client.ui.overlay.components.TitleComponent;
 
 public class RaidsOverlay extends Overlay
 {
+	private static final int OLM_PLANE = 0;
+
 	private Client client;
 	private RaidsPlugin plugin;
 	private RaidsConfig config;
@@ -61,8 +63,7 @@ public class RaidsOverlay extends Overlay
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
-		//Do not show the scout overlay while we are down at olm (plane == 0)
-		if (!config.scoutOverlay() || !scoutOverlayShown || client.getPlane() == 0)
+		if (!config.scoutOverlay() || !scoutOverlayShown || client.getPlane() == OLM_PLANE)
 		{
 			return null;
 		}


### PR DESCRIPTION
This will prevent the scout overlay from rendering while at Olm as the information there is obsolete.

Closes #5721