### PR TITLE
Use ColorUtil functions instead of creating the color tag manually

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsPlugin.java
@@ -40,6 +40,7 @@ import net.runelite.client.game.ClanManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.OverlayManager;
+import net.runelite.client.util.ColorUtil;
 
 @PluginDescriptor(
 	name = "Player Indicators",
@@ -169,7 +170,7 @@ public class PlayerIndicatorsPlugin extends Plugin
 						target = target.substring(idx + 1);
 					}
 
-					lastEntry.setTarget("<col=" + Integer.toHexString(color.getRGB() & 0xFFFFFF) + ">" + target);
+					lastEntry.setTarget(ColorUtil.prependColorTag(target, color));
 				}
 
 				if (image != -1 && config.showClanRanks())

--- a/runelite-client/src/main/java/net/runelite/client/plugins/wasdcamera/WASDCameraPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/wasdcamera/WASDCameraPlugin.java
@@ -27,6 +27,7 @@ package net.runelite.client.plugins.wasdcamera;
 
 import com.google.common.eventbus.Subscribe;
 import com.google.inject.Provides;
+import java.awt.Color;
 import javax.inject.Inject;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -43,6 +44,7 @@ import net.runelite.client.config.ConfigManager;
 import net.runelite.client.input.KeyManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.util.ColorUtil;
 
 @PluginDescriptor(
 	name = "WASD Camera",
@@ -175,7 +177,7 @@ public class WASDCameraPlugin extends Plugin
 			{
 				if (client.getGameState() == GameState.LOGGED_IN)
 				{
-					chatboxInput.setText(client.getLocalPlayer().getName() + ": <col=0000ff>" + client.getVar(VarClientStr.CHATBOX_TYPED_TEXT) + "*</col>");
+					chatboxInput.setText(client.getLocalPlayer().getName() + ": " + ColorUtil.wrapWithColorTag(client.getVar(VarClientStr.CHATBOX_TYPED_TEXT) + "*", Color.BLUE));
 				}
 			}
 		}


### PR DESCRIPTION
After the player indicators commit revert there was still an opportunity for ColorUtil functions to be applied, as well as in the newly-added (since creating ColorUtil) WASD camera plugin.