### PR TITLE
Implemented NPC name truncation in loot tracker

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerBox.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerBox.java
@@ -28,6 +28,7 @@ package net.runelite.client.plugins.loottracker;
 import com.google.common.base.Strings;
 import java.awt.BorderLayout;
 import java.awt.Color;
+import java.awt.Dimension;
 import java.awt.GridLayout;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -49,6 +50,7 @@ class LootTrackerBox extends JPanel
 	private final JPanel itemContainer = new JPanel();
 	private final JLabel priceLabel = new JLabel();
 	private final JLabel subTitleLabel = new JLabel();
+	private final JLabel titleLabel;
 	private final ItemManager itemManager;
 	private final String id;
 
@@ -70,9 +72,10 @@ class LootTrackerBox extends JPanel
 		logTitle.setBorder(new EmptyBorder(7, 7, 7, 7));
 		logTitle.setBackground(ColorScheme.DARKER_GRAY_COLOR.darker());
 
-		final JLabel titleLabel = new JLabel(id);
+		titleLabel = new JLabel(id);
 		titleLabel.setFont(FontManager.getRunescapeSmallFont());
 		titleLabel.setForeground(Color.WHITE);
+		titleLabel.setToolTipText(id);
 
 		logTitle.add(titleLabel, BorderLayout.WEST);
 
@@ -143,7 +146,19 @@ class LootTrackerBox extends JPanel
 			subTitleLabel.setText("x " + records.size());
 		}
 
+		resizeLogTitle();
+
 		repaint();
+	}
+
+	private void resizeLogTitle()
+	{
+		double maxWidth = itemContainer.getMinimumSize().getWidth() - 14;
+		int titleLabelHeight = titleLabel.getFontMetrics(titleLabel.getFont()).getHeight();
+		int subtitleLabelWidth = subTitleLabel.getFontMetrics(subTitleLabel.getFont()).stringWidth(subTitleLabel.getText());
+		int priceLabelWidth = priceLabel.getFontMetrics(priceLabel.getFont()).stringWidth(priceLabel.getText());
+		int titleLabelTruncatedWidth = (int) (maxWidth - subtitleLabelWidth - priceLabelWidth - 18);
+		titleLabel.setPreferredSize(new Dimension(titleLabelTruncatedWidth, titleLabelHeight));
 	}
 
 	/**

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerBox.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerBox.java
@@ -28,7 +28,7 @@ package net.runelite.client.plugins.loottracker;
 import com.google.common.base.Strings;
 import java.awt.BorderLayout;
 import java.awt.Color;
-import java.awt.Dimension;
+import java.awt.FlowLayout;
 import java.awt.GridLayout;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -50,7 +50,6 @@ class LootTrackerBox extends JPanel
 	private final JPanel itemContainer = new JPanel();
 	private final JLabel priceLabel = new JLabel();
 	private final JLabel subTitleLabel = new JLabel();
-	private final JLabel titleLabel;
 	private final ItemManager itemManager;
 	private final String id;
 
@@ -68,20 +67,24 @@ class LootTrackerBox extends JPanel
 		setLayout(new BorderLayout(0, 1));
 		setBorder(new EmptyBorder(5, 0, 0, 0));
 
-		final JPanel logTitle = new JPanel(new BorderLayout(5, 0));
+		int gap = 5;
+		final JPanel logTitle = new JPanel(new BorderLayout(gap, 0));
 		logTitle.setBorder(new EmptyBorder(7, 7, 7, 7));
 		logTitle.setBackground(ColorScheme.DARKER_GRAY_COLOR.darker());
 
-		titleLabel = new JLabel(id);
+		final JLabel titleLabel = new JLabel(id);
 		titleLabel.setFont(FontManager.getRunescapeSmallFont());
 		titleLabel.setForeground(Color.WHITE);
 		titleLabel.setToolTipText(id);
+		logTitle.add(titleLabel, BorderLayout.CENTER);
 
-		logTitle.add(titleLabel, BorderLayout.WEST);
+		final JPanel logSubtitleAndPrice = new JPanel(new FlowLayout(FlowLayout.CENTER, 0, 0));
+		logSubtitleAndPrice.setBackground(ColorScheme.DARKER_GRAY_COLOR.darker());
 
 		subTitleLabel.setFont(FontManager.getRunescapeSmallFont());
 		subTitleLabel.setForeground(ColorScheme.LIGHT_GRAY_COLOR);
-		logTitle.add(subTitleLabel, BorderLayout.CENTER);
+		subTitleLabel.setBorder(new EmptyBorder(0, 0, 0, gap));
+		logSubtitleAndPrice.add(subTitleLabel);
 
 		if (!Strings.isNullOrEmpty(subtitle))
 		{
@@ -90,7 +93,9 @@ class LootTrackerBox extends JPanel
 
 		priceLabel.setFont(FontManager.getRunescapeSmallFont());
 		priceLabel.setForeground(ColorScheme.LIGHT_GRAY_COLOR);
-		logTitle.add(priceLabel, BorderLayout.EAST);
+		logSubtitleAndPrice.add(priceLabel);
+
+		logTitle.add(logSubtitleAndPrice, BorderLayout.EAST);
 
 		add(logTitle, BorderLayout.NORTH);
 		add(itemContainer, BorderLayout.CENTER);
@@ -146,19 +151,7 @@ class LootTrackerBox extends JPanel
 			subTitleLabel.setText("x " + records.size());
 		}
 
-		resizeLogTitle();
-
 		repaint();
-	}
-
-	private void resizeLogTitle()
-	{
-		double maxWidth = itemContainer.getMinimumSize().getWidth() - 14;
-		int titleLabelHeight = titleLabel.getFontMetrics(titleLabel.getFont()).getHeight();
-		int subtitleLabelWidth = subTitleLabel.getFontMetrics(subTitleLabel.getFont()).stringWidth(subTitleLabel.getText());
-		int priceLabelWidth = priceLabel.getFontMetrics(priceLabel.getFont()).stringWidth(priceLabel.getText());
-		int titleLabelTruncatedWidth = (int) (maxWidth - subtitleLabelWidth - priceLabelWidth - 18);
-		titleLabel.setPreferredSize(new Dimension(titleLabelTruncatedWidth, titleLabelHeight));
 	}
 
 	/**


### PR DESCRIPTION
Fixes #5673.

Only truncates the title of the log. Which means both subtitle and price will show up totally.
Because the name can now be truncated, I also added a tool tip for usability sake.

Example of it working:
![example](https://i.imgur.com/TFTkun8.png "NPC name truncated")