### PR TITLE
Implemented the ability to hide both globes and xp tracker after 99

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/Experience.java
+++ b/runelite-api/src/main/java/net/runelite/api/Experience.java
@@ -43,6 +43,11 @@ public class Experience
 	public static final int MAX_SKILL_XP = 200_000_000;
 
 	/**
+	 * Maximum effective skill level at 13,034,431 experience.
+	 */
+	public static final int MAX_REAL_LEVEL = 99;
+
+	/**
 	 * The total experience required for each skill level.
 	 */
 	private static final int[] XP_FOR_LEVEL = new int[MAX_VIRT_LEVEL];

--- a/runelite-api/src/main/java/net/runelite/api/Experience.java
+++ b/runelite-api/src/main/java/net/runelite/api/Experience.java
@@ -37,15 +37,15 @@ import static java.lang.Math.max;
 public class Experience
 {
 	/**
+	 * Maximum effective skill level at 13,034,431 experience.
+	 */
+	public static final int MAX_REAL_LEVEL = 99;
+
+	/**
 	 * The maximum virtual skill level for any skill (200M experience).
 	 */
 	public static final int MAX_VIRT_LEVEL = 126;
 	public static final int MAX_SKILL_XP = 200_000_000;
-
-	/**
-	 * Maximum effective skill level at 13,034,431 experience.
-	 */
-	public static final int MAX_REAL_LEVEL = 99;
 
 	/**
 	 * The total experience required for each skill level.

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesConfig.java
@@ -44,10 +44,21 @@ public interface XpGlobesConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "hideMaxed",
+		name = "Hide maxed skills",
+		description = "Stop globes from showing up for level 99 skills ",
+		position = 1
+	)
+	default boolean hideMaxed()
+	{
+		return false;
+	}
+
+	@ConfigItem(
 		keyName = "Progress arc color",
 		name = "Progress arc color",
 		description = "Change the color of the progress arc in the xp orb",
-		position = 1
+		position = 2
 	)
 	default Color progressArcColor()
 	{
@@ -58,7 +69,7 @@ public interface XpGlobesConfig extends Config
 		keyName = "Progress orb outline color",
 		name = "Progress orb outline color",
 		description = "Change the color of the progress orb outline",
-		position = 2
+		position = 3
 	)
 	default Color progressOrbOutLineColor()
 	{
@@ -69,7 +80,7 @@ public interface XpGlobesConfig extends Config
 		keyName = "Progress orb background color",
 		name = "Progress orb background color",
 		description = "Change the color of the progress orb background",
-		position = 3
+		position = 4
 	)
 	default Color progressOrbBackgroundColor()
 	{
@@ -80,7 +91,7 @@ public interface XpGlobesConfig extends Config
 		keyName = "Progress arc width",
 		name = "Progress arc width",
 		description = "Change the stroke width of the progress arc",
-		position = 4
+		position = 5
 	)
 	default int progressArcStrokeWidth()
 	{
@@ -91,7 +102,7 @@ public interface XpGlobesConfig extends Config
 		keyName = "Orb size",
 		name = "Size of orbs",
 		description = "Change the size of the xp orbs",
-		position = 5
+		position = 6
 	)
 	default int xpOrbSize()
 	{
@@ -102,7 +113,7 @@ public interface XpGlobesConfig extends Config
 		keyName = "Orb duration",
 		name = "Duration of orbs",
 		description = "Change the duration the xp orbs are visible",
-		position = 6
+		position = 7
 	)
 	default int xpOrbDuration()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesPlugin.java
@@ -104,6 +104,11 @@ public class XpGlobesPlugin extends Plugin
 			return;
 		}
 
+		if (config.hideMaxed() && currentLevel >= Experience.MAX_REAL_LEVEL)
+		{
+			return;
+		}
+
 		int startingXp = Experience.getXpForLevel(currentLevel);
 		int goalXp = currentLevel + 1 <= Experience.MAX_VIRT_LEVEL ? Experience.getXpForLevel(currentLevel + 1) : -1;
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerConfig.java
@@ -33,6 +33,17 @@ public interface XpTrackerConfig extends Config
 {
 	@ConfigItem(
 		position = 0,
+		keyName = "hideMaxed",
+		name = "Hide maxed skills",
+		description = "Stop globes from showing up for level 99 skills "
+	)
+	default boolean hideMaxed()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		position = 1,
 		keyName = "logoutPausing",
 		name = "Pause on Logout",
 		description = "Configures whether skills should pause on logout"
@@ -43,7 +54,7 @@ public interface XpTrackerConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 1,
+		position = 2,
 		keyName = "pauseSkillAfter",
 		name = "Auto pause after",
 		description = "Configures how many minutes passes before pausing a skill while in game and there's no XP, 0 means disabled"

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerPlugin.java
@@ -36,6 +36,7 @@ import java.util.Objects;
 import javax.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
+import net.runelite.api.Experience;
 import net.runelite.api.GameState;
 import net.runelite.api.Player;
 import net.runelite.api.Skill;
@@ -230,10 +231,16 @@ public class XpTrackerPlugin extends Plugin
 	{
 		final Skill skill = event.getSkill();
 		final int currentXp = client.getSkillExperience(skill);
+		final int currentLevel = Experience.getLevelForXp(currentXp);
 		final VarPlayer startGoal = startGoalVarpForSkill(skill);
 		final VarPlayer endGoal = endGoalVarpForSkill(skill);
 		final int startGoalXp = startGoal != null ? client.getVar(startGoal) : -1;
 		final int endGoalXp = endGoal != null ? client.getVar(endGoal) : -1;
+
+		if (xpTrackerConfig.hideMaxed() && currentLevel >= Experience.MAX_REAL_LEVEL)
+		{
+			return;
+		}
 
 		final XpUpdateResult updateResult = xpState.updateSkill(skill, currentXp, startGoalXp, endGoalXp);
 


### PR DESCRIPTION
Fixes #2631.

Not sure if two different configurations was the best way of do it. I could have used the XP Tracker config for the XP Globals, but thought mixing configs was a mess.

Let me know if I should change this.