### PR TITLE
Chat Commands: Add hints to config description

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsConfig.java
@@ -35,7 +35,7 @@ public interface ChatCommandsConfig extends Config
 		position = 0,
 		keyName = "price",
 		name = "Price Command",
-		description = "Configures whether the Price command is enabled"
+		description = "Configures whether the Price command is enabled<br> !price [item]"
 	)
 	default boolean price()
 	{
@@ -46,7 +46,7 @@ public interface ChatCommandsConfig extends Config
 		position = 1,
 		keyName = "lvl",
 		name = "Level Command",
-		description = "Configures whether the Level command is enabled"
+		description = "Configures whether the Level command is enabled<br> !lvl [skill]"
 	)
 	default boolean lvl()
 	{
@@ -57,7 +57,7 @@ public interface ChatCommandsConfig extends Config
 		position = 2,
 		keyName = "clue",
 		name = "Clue Command",
-		description = "Configures whether the Clue command is enabled"
+		description = "Configures whether the Clue command is enabled<br> !clues"
 	)
 	default boolean clue()
 	{
@@ -68,7 +68,7 @@ public interface ChatCommandsConfig extends Config
 		position = 3,
 		keyName = "killcount",
 		name = "Killcount Command",
-		description = "Configures whether the Killcount command is enabled"
+		description = "Configures whether the Killcount command is enabled<br> !kc [boss]"
 	)
 	default boolean killcount()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
@@ -82,10 +82,10 @@ import net.runelite.http.api.kc.KillCountClient;
 public class ChatCommandsPlugin extends Plugin implements ChatboxInputListener
 {
 	private static final float HIGH_ALCHEMY_CONSTANT = 0.6f;
-	private static final Pattern KILLCOUNT_PATERN = Pattern.compile("Your (.+) kill count is: <col=ff0000>(\\d+)</col>.");
+	private static final Pattern KILLCOUNT_PATTERN = Pattern.compile("Your (.+) kill count is: <col=ff0000>(\\d+)</col>.");
 	private static final Pattern RAIDS_PATTERN = Pattern.compile("Your completed (.+) count is: <col=ff0000>(\\d+)</col>.");
-	private static final Pattern WINTERTODT_PATERN = Pattern.compile("Your subdued Wintertodt count is: <col=ff0000>(\\d+)</col>.");
-	private static final Pattern BARROWS_PATERN = Pattern.compile("Your Barrows chest count is: <col=ff0000>(\\d+)</col>.");
+	private static final Pattern WINTERTODT_PATTERN = Pattern.compile("Your subdued Wintertodt count is: <col=ff0000>(\\d+)</col>.");
+	private static final Pattern BARROWS_PATTERN = Pattern.compile("Your Barrows chest count is: <col=ff0000>(\\d+)</col>.");
 	private static final String TOTAL_LEVEL_COMMAND_STRING = "!total";
 	private static final String PRICE_COMMAND_STRING = "!price";
 	private static final String LEVEL_COMMAND_STRING = "!lvl";
@@ -244,7 +244,7 @@ public class ChatCommandsPlugin extends Plugin implements ChatboxInputListener
 		}
 
 		String message = chatMessage.getMessage();
-		Matcher matcher = KILLCOUNT_PATERN.matcher(message);
+		Matcher matcher = KILLCOUNT_PATTERN.matcher(message);
 		if (matcher.find())
 		{
 			String boss = matcher.group(1);
@@ -253,7 +253,7 @@ public class ChatCommandsPlugin extends Plugin implements ChatboxInputListener
 			setKc(boss, kc);
 		}
 
-		matcher = WINTERTODT_PATERN.matcher(message);
+		matcher = WINTERTODT_PATTERN.matcher(message);
 		if (matcher.find())
 		{
 			int kc = Integer.parseInt(matcher.group(1));
@@ -270,7 +270,7 @@ public class ChatCommandsPlugin extends Plugin implements ChatboxInputListener
 			setKc(boss, kc);
 		}
 
-		matcher = BARROWS_PATERN.matcher(message);
+		matcher = BARROWS_PATTERN.matcher(message);
 		if (matcher.find())
 		{
 			int kc = Integer.parseInt(matcher.group(1));


### PR DESCRIPTION
Adds usage hints to the config description for each of the chat commands.

Closes #4298