### PR TITLE
Make sure varbit access happen on the client thread

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/motherlode/MotherlodePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/motherlode/MotherlodePlugin.java
@@ -66,6 +66,7 @@ import net.runelite.api.events.WallObjectDespawned;
 import net.runelite.api.events.WallObjectSpawned;
 import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetInfo;
+import net.runelite.client.callback.ClientThread;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
@@ -112,6 +113,9 @@ public class MotherlodePlugin extends Plugin
 	@Inject
 	private Client client;
 
+	@Inject
+	private ClientThread clientThread;
+
 	@Getter(AccessLevel.PACKAGE)
 	private boolean inMlm;
 
@@ -148,7 +152,7 @@ public class MotherlodePlugin extends Plugin
 
 		if (inMlm)
 		{
-			refreshSackValues();
+			clientThread.invokeLater(this::refreshSackValues);
 		}
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsPlugin.java
@@ -53,6 +53,7 @@ import net.runelite.api.events.VarbitChanged;
 import net.runelite.api.events.WidgetHiddenChanged;
 import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetInfo;
+import net.runelite.client.callback.ClientThread;
 import net.runelite.client.chat.ChatColorType;
 import net.runelite.client.chat.ChatMessageBuilder;
 import net.runelite.client.chat.ChatMessageManager;
@@ -112,6 +113,9 @@ public class RaidsPlugin extends Plugin
 	@Inject
 	private SpriteManager spriteManager;
 
+	@Inject
+	private ClientThread clientThread;
+
 	@Getter
 	private final ArrayList<String> roomWhitelist = new ArrayList<>();
 
@@ -150,7 +154,7 @@ public class RaidsPlugin extends Plugin
 		overlayManager.add(overlay);
 		overlayManager.add(pointsOverlay);
 		updateLists();
-		checkRaidPresence(true);
+		clientThread.invokeLater(() -> checkRaidPresence(true));
 	}
 
 	@Override

--- a/runelite-mixins/src/main/java/net/runelite/mixins/VarbitMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/VarbitMixin.java
@@ -72,6 +72,8 @@ public abstract class VarbitMixin implements RSClient
 	@Override
 	public int getVarbitValue(int[] varps, int varbitId)
 	{
+		assert client.isClientThread();
+
 		RSVarbit v = varbitCache.getIfPresent(varbitId);
 		if (v == null)
 		{


### PR DESCRIPTION
Loading a varbit requires interaction with the cache, and therefore must happen on the client thread.