### PR TITLE
Add default skill color to XP globes

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesConfig.java
@@ -55,10 +55,21 @@ public interface XpGlobesConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "enableCustomArcColor",
+		name = "Enable custom arc color",
+		description = "Enables the custom coloring of the globe's arc instead of using the skill's default color.",
+		position = 2
+	)
+	default boolean enableCustomArcColor()
+	{
+		return false;
+	}
+
+	@ConfigItem(
 		keyName = "Progress arc color",
 		name = "Progress arc color",
 		description = "Change the color of the progress arc in the xp orb",
-		position = 2
+		position = 3
 	)
 	default Color progressArcColor()
 	{
@@ -69,7 +80,7 @@ public interface XpGlobesConfig extends Config
 		keyName = "Progress orb outline color",
 		name = "Progress orb outline color",
 		description = "Change the color of the progress orb outline",
-		position = 3
+		position = 4
 	)
 	default Color progressOrbOutLineColor()
 	{
@@ -80,7 +91,7 @@ public interface XpGlobesConfig extends Config
 		keyName = "Progress orb background color",
 		name = "Progress orb background color",
 		description = "Change the color of the progress orb background",
-		position = 4
+		position = 5
 	)
 	default Color progressOrbBackgroundColor()
 	{
@@ -91,7 +102,7 @@ public interface XpGlobesConfig extends Config
 		keyName = "Progress arc width",
 		name = "Progress arc width",
 		description = "Change the stroke width of the progress arc",
-		position = 5
+		position = 6
 	)
 	default int progressArcStrokeWidth()
 	{
@@ -102,7 +113,7 @@ public interface XpGlobesConfig extends Config
 		keyName = "Orb size",
 		name = "Size of orbs",
 		description = "Change the size of the xp orbs",
-		position = 6
+		position = 7
 	)
 	default int xpOrbSize()
 	{
@@ -113,7 +124,7 @@ public interface XpGlobesConfig extends Config
 		keyName = "Orb duration",
 		name = "Duration of orbs",
 		description = "Change the duration the xp orbs are visible",
-		position = 7
+		position = 8
 	)
 	default int xpOrbDuration()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesOverlay.java
@@ -42,6 +42,7 @@ import net.runelite.api.Experience;
 import net.runelite.api.Point;
 import net.runelite.client.game.SkillIconManager;
 import net.runelite.client.plugins.xptracker.XpTrackerService;
+import net.runelite.client.ui.SkillColor;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.components.LineComponent;
@@ -124,7 +125,7 @@ public class XpGlobesOverlay extends Overlay
 			config.xpOrbSize(), config.xpOrbSize(),
 			PROGRESS_RADIUS_START, radiusCurrentXp,
 			config.progressArcStrokeWidth(),
-			config.progressArcColor());
+			config.enableCustomArcColor() ? config.progressArcColor() : SkillColor.find(skillToDraw.getSkill()).getColor());
 
 		graphics.setRenderingHint(RenderingHints.KEY_STROKE_CONTROL, renderHint);
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpInfoBox.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpInfoBox.java
@@ -46,6 +46,7 @@ import net.runelite.client.game.SkillIconManager;
 import net.runelite.client.ui.ColorScheme;
 import net.runelite.client.ui.DynamicGridLayout;
 import net.runelite.client.ui.FontManager;
+import net.runelite.client.ui.SkillColor;
 import net.runelite.client.ui.components.ProgressBar;
 import net.runelite.client.util.ColorUtil;
 import net.runelite.client.util.LinkBrowser;
@@ -152,7 +153,7 @@ class XpInfoBox extends JPanel
 
 		progressBar.setMaximumValue(100);
 		progressBar.setBackground(new Color(61, 56, 49));
-		progressBar.setForeground(SkillColor.values()[skill.ordinal()].getColor());
+		progressBar.setForeground(SkillColor.find(skill).getColor());
 		progressBar.setDimmedText("Paused");
 
 		progressWrapper.add(progressBar, BorderLayout.NORTH);

--- a/runelite-client/src/main/java/net/runelite/client/ui/SkillColor.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/SkillColor.java
@@ -22,12 +22,13 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package net.runelite.client.plugins.xptracker;
+package net.runelite.client.ui;
 
 import java.awt.Color;
 import lombok.Getter;
+import net.runelite.api.Skill;
 
-enum SkillColor
+public enum SkillColor
 {
 	ATTACK(105, 32, 7),
 	DEFENCE(98, 119, 190),
@@ -61,4 +62,11 @@ enum SkillColor
 		this.color = new Color(red, green, blue);
 	}
 
+	/**
+	 * Finds the corresponding SkillColor for a given Skill.
+	 */
+	public static SkillColor find(Skill skill)
+	{
+		return values()[skill.ordinal()];
+	}
 }


### PR DESCRIPTION
The previous similar PR has been abandoned for months even tho I supplied most of the code for it (wasn't a lot anyways).

This is a simple improvement to the exp globes, something that I'm sure a lot of people want, including me.

![](https://i.gyazo.com/14c5628150d7e0743cb4ff3b7e8a44c1.png)

**If any of you native english speakers have some ideas on how to improve the wording of the config item, i'd appreciate it, I had a bit of trouble with that.**

Should probably close #4591
Closes #2888 