### PR TITLE
Fix chat notification highlight words split regex

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatnotifications/ChatNotificationsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatnotifications/ChatNotificationsPlugin.java
@@ -71,6 +71,8 @@ public class ChatNotificationsPlugin extends Plugin
 	@Inject
 	private RuneLiteProperties runeLiteProperties;
 
+	private final Pattern SPLIT_REGEX = Pattern.compile("\\s*,\\s*");
+
 	//Custom Highlights
 	private Pattern usernameMatcher = null;
 	private String usernameReplacer = "";
@@ -115,7 +117,7 @@ public class ChatNotificationsPlugin extends Plugin
 
 		if (!config.highlightWordsString().trim().equals(""))
 		{
-			String[] items = config.highlightWordsString().trim().split(", ");
+			String[] items = SPLIT_REGEX.split(config.highlightWordsString().trim());
 			String joined = Arrays.stream(items)
 				.map(Pattern::quote)
 				.collect(Collectors.joining("|"));

--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatnotifications/ChatNotificationsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatnotifications/ChatNotificationsPlugin.java
@@ -29,7 +29,6 @@ import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
 import com.google.common.eventbus.Subscribe;
 import com.google.inject.Provides;
-import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatnotifications/ChatNotificationsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatnotifications/ChatNotificationsPlugin.java
@@ -25,10 +25,12 @@
  */
 package net.runelite.client.plugins.chatnotifications;
 
+import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
 import com.google.common.eventbus.Subscribe;
 import com.google.inject.Provides;
 import java.util.Arrays;
+import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import static java.util.regex.Pattern.quote;
@@ -56,6 +58,8 @@ import net.runelite.client.util.Text;
 )
 public class ChatNotificationsPlugin extends Plugin
 {
+	private static final Splitter SPLITTER = Splitter.on(",").trimResults().omitEmptyStrings();
+
 	@Inject
 	private Client client;
 
@@ -70,8 +74,6 @@ public class ChatNotificationsPlugin extends Plugin
 
 	@Inject
 	private RuneLiteProperties runeLiteProperties;
-
-	private final Pattern SPLIT_REGEX = Pattern.compile("\\s*,\\s*");
 
 	//Custom Highlights
 	private Pattern usernameMatcher = null;
@@ -117,8 +119,8 @@ public class ChatNotificationsPlugin extends Plugin
 
 		if (!config.highlightWordsString().trim().equals(""))
 		{
-			String[] items = SPLIT_REGEX.split(config.highlightWordsString().trim());
-			String joined = Arrays.stream(items)
+			List<String> items = SPLITTER.splitToList(config.highlightWordsString());
+			String joined = items.stream()
 				.map(Pattern::quote)
 				.collect(Collectors.joining("|"));
 			highlightMatcher = Pattern.compile("\\b(" + joined + ")\\b", Pattern.CASE_INSENSITIVE);

--- a/runelite-client/src/test/java/net/runelite/client/plugins/chatnotifications/ChatNotificationsPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/chatnotifications/ChatNotificationsPluginTest.java
@@ -24,9 +24,12 @@
  */
 package net.runelite.client.plugins.chatnotifications;
 
+import com.google.common.base.Splitter;
 import com.google.inject.Guice;
 import com.google.inject.testing.fieldbinder.Bind;
 import com.google.inject.testing.fieldbinder.BoundFieldModule;
+import java.util.Iterator;
+import java.util.List;
 import javax.inject.Inject;
 import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
@@ -34,6 +37,7 @@ import net.runelite.api.MessageNode;
 import net.runelite.api.events.SetMessage;
 import net.runelite.client.Notifier;
 import net.runelite.client.chat.ChatMessageManager;
+import static org.junit.Assert.assertEquals;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -87,5 +91,20 @@ public class ChatNotificationsPluginTest
 		chatNotificationsPlugin.onSetMessage(setMessage);
 
 		verify(messageNode).setValue("<colHIGHLIGHT>Deathbeam<colNORMAL>, <colHIGHLIGHT>Deathbeam<colNORMAL> OSRS");
+	}
+
+	@Test
+	public void highlightListTest()
+	{
+		when(config.highlightWordsString()).thenReturn("this,is, a                   , test, ");
+		final Splitter splitter = Splitter.on(",").trimResults().omitEmptyStrings();
+		final List<String> higlights = splitter.splitToList(config.highlightWordsString());
+		assertEquals(4, higlights.size());
+
+		final Iterator<String> iterator = higlights.iterator();
+		assertEquals("this", iterator.next());
+		assertEquals("is", iterator.next());
+		assertEquals("a", iterator.next());
+		assertEquals("test", iterator.next());
 	}
 }


### PR DESCRIPTION
This fixes an issue where the chat notifications plugin would not split word higlights when input as `some,highlight` even though they are supposed to be valid.