### PR TITLE
Add toggle to hide OpponentInfo targets target

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/opponentinfo/OpponentInfoConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/opponentinfo/OpponentInfoConfig.java
@@ -54,13 +54,13 @@ public interface OpponentInfoConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "showTargetsTarget",
-		name = "Show targets target",
-		description = "Shows your targets target name",
+		keyName = "hideTargetsTarget",
+		name = "Hide targets target",
+		description = "Configures whether your targets target will be visible",
 		position = 2
 	)
-	default boolean showTargetsTarget()
+	default boolean hideTargetsTarget()
 	{
-		return true;
+		return false;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/opponentinfo/OpponentInfoConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/opponentinfo/OpponentInfoConfig.java
@@ -56,7 +56,7 @@ public interface OpponentInfoConfig extends Config
 	@ConfigItem(
 		keyName = "hideTargetsTarget",
 		name = "Hide targets target",
-		description = "Configures whether your targets target will be visible",
+		description = "Configures whether your target's target will be visible",
 		position = 2
 	)
 	default boolean hideTargetsTarget()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/opponentinfo/OpponentInfoConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/opponentinfo/OpponentInfoConfig.java
@@ -55,7 +55,7 @@ public interface OpponentInfoConfig extends Config
 
 	@ConfigItem(
 		keyName = "hideTargetsTarget",
-		name = "Hide targets target",
+		name = "Hide target's target",
 		description = "Configures whether your target's target will be visible",
 		position = 2
 	)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/opponentinfo/OpponentInfoConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/opponentinfo/OpponentInfoConfig.java
@@ -52,4 +52,15 @@ public interface OpponentInfoConfig extends Config
 	{
 		return false;
 	}
+
+	@ConfigItem(
+		keyName = "showTargetsTarget",
+		name = "Show targets target",
+		description = "Shows your targets target name",
+		position = 2
+	)
+	default boolean showTargetsTarget()
+	{
+		return true;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/opponentinfo/OpponentInfoOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/opponentinfo/OpponentInfoOverlay.java
@@ -165,7 +165,7 @@ class OpponentInfoOverlay extends Overlay
 		}
 
 		// Opponents opponent
-		if (opponentsOpponentName != null)
+		if (opponentsOpponentName != null && opponentInfoConfig.showTargetsTarget())
 		{
 			textWidth = Math.max(textWidth, fontMetrics.stringWidth(opponentsOpponentName));
 			panelComponent.setPreferredSize(new Dimension(textWidth, 0));

--- a/runelite-client/src/main/java/net/runelite/client/plugins/opponentinfo/OpponentInfoOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/opponentinfo/OpponentInfoOverlay.java
@@ -165,7 +165,7 @@ class OpponentInfoOverlay extends Overlay
 		}
 
 		// Opponents opponent
-		if (opponentsOpponentName != null && opponentInfoConfig.showTargetsTarget())
+		if (opponentsOpponentName != null && !opponentInfoConfig.hideTargetsTarget())
 		{
 			textWidth = Math.max(textWidth, fontMetrics.stringWidth(opponentsOpponentName));
 			panelComponent.setPreferredSize(new Dimension(textWidth, 0));


### PR DESCRIPTION
Implements a config toggle to hide the name of your Targets target.

Closes #4361 