### PR TITLE
Runecrafting Altar menu-entry swap

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -239,4 +239,15 @@ public interface MenuEntrySwapperConfig extends Config
 	{
 		return false;
 	}
+
+		@ConfigItem(
+			position = 19,
+			keyName = "swapRune",
+			name = "Combination Runes",
+			description = "Swap Craft-Rune with Walk here for runecrafting altars"
+		)
+		default boolean swapRune()
+		{
+			return false;
+		}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -37,6 +37,8 @@ import net.runelite.api.Client;
 import net.runelite.api.GameState;
 import net.runelite.api.ItemComposition;
 import net.runelite.api.MenuAction;
+import static net.runelite.api.MenuAction.MENU_ACTION_DEPRIORITIZE_OFFSET;
+import static net.runelite.api.MenuAction.WALK;
 import net.runelite.api.MenuEntry;
 import net.runelite.api.events.ConfigChanged;
 import net.runelite.api.events.FocusChanged;
@@ -489,6 +491,17 @@ public class MenuEntrySwapperPlugin extends Plugin
 		else if (config.swapBirdhouseEmpty() && option.equals("interact") && target.contains("birdhouse"))
 		{
 			swap("empty", option, target, true);
+		}
+		else if (config.swapRune() && option.equals("craft-rune"))
+		{
+			if (event.getType() < WALK.getId())
+			{
+				MenuEntry[] menuEntries = client.getMenuEntries();
+				MenuEntry menuEntry = menuEntries[menuEntries.length - 1];
+				menuEntry.setType(event.getType() + MENU_ACTION_DEPRIORITIZE_OFFSET);
+ 				client.setMenuEntries(menuEntries);
+			}
+			return;
 		}
 	}
 


### PR DESCRIPTION
This is for the feature-request https://github.com/runelite/runelite/issues/4960

Makes it so a left click on the runecrafting altar is walk here, preventing you from accidentally crafting normal runes while doing combination tunes.