### PR TITLE
Added herb sack content value to examine plugin

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/examine/ExaminePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/examine/ExaminePlugin.java
@@ -162,13 +162,16 @@ public class ExaminePlugin extends Plugin
 		{
 			String name = new String(event.getMessage().replaceAll(".* x Grimy ", "").trim().toLowerCase());
 
-			PendingExamine pendingExamine = new PendingExamine();
-			pendingExamine.setWidgetId(CHATBOX.getId());
-			pendingExamine.setActionParam(Integer.parseInt(event.getMessage().replaceAll( " x Grimy .*", "")));
-			pendingExamine.setType(ExamineType.ITEM_BANK_EQ);
-			pendingExamine.setId(herbs.get(name));
-			pendingExamine.setCreated(Instant.now());
-			pending.push(pendingExamine);
+			if (herbs.containsKey(name))
+			{
+				PendingExamine pendingExamine = new PendingExamine();
+				pendingExamine.setWidgetId(CHATBOX.getId());
+				pendingExamine.setActionParam(Integer.parseInt(event.getMessage().replaceAll( " x Grimy .*", "")));
+				pendingExamine.setType(ExamineType.ITEM_BANK_EQ);
+				pendingExamine.setId(herbs.get(name));
+				pendingExamine.setCreated(Instant.now());
+				pending.push(pendingExamine);
+			}
 		}
 
 		ExamineType type;


### PR DESCRIPTION
This PR adds the functionality to display the value of the herbs within the herb sack. The values are displayed when the user uses the 'check' option.

![image](https://user-images.githubusercontent.com/8240706/46527788-6e883200-c892-11e8-9ce9-9997c0a4b880.png)

![image](https://user-images.githubusercontent.com/8240706/46527819-7d6ee480-c892-11e8-96f7-b18ad2637cf6.png)


The way it works is by checking the chat messages and checking if said message is a SERVER message and contains the keyword 'Grimy'. After this it just extracts the herb's name and quantity.

