### PR TITLE
Fix rs2asm parser grammar to correctly handle EOF

### DIFF
--- a/cache/src/main/antlr4/net/runelite/cache/script/assembler/rs2asm.g4
+++ b/cache/src/main/antlr4/net/runelite/cache/script/assembler/rs2asm.g4
@@ -24,7 +24,7 @@
  */
 grammar rs2asm;
 
-prog: NEWLINE* (header NEWLINE+)* (line NEWLINE+)+ ;
+prog: NEWLINE* (header NEWLINE+)* (line NEWLINE*)+ EOF;
 
 header: id | int_stack_count | string_stack_count | int_var_count | string_var_count ;
 


### PR DESCRIPTION
If the file do not ends with newline, it is still valid script but
grammar assumed that newline at the end of each statement is always
required. Also add checking of EOF to correctly wait for end of file
instead of trying to process even unfinished input.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>