### PR TITLE
Refactor high alchemy price calculations

### DIFF
--- a/http-api/src/main/java/net/runelite/http/api/item/ItemPrice.java
+++ b/http-api/src/main/java/net/runelite/http/api/item/ItemPrice.java
@@ -32,6 +32,6 @@ public class ItemPrice
 {
 	private int id;
 	private String name;
-	private int price;
+	private long price;
 	private Instant time;
 }

--- a/runelite-client/src/main/java/net/runelite/client/game/ItemManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/game/ItemManager.java
@@ -259,7 +259,7 @@ public class ItemManager
 		return price;
 	}
 
-	public int getAlchValue(int itemID)
+	public long getAlchValue(int itemID)
 	{
 		if (itemID == ItemID.COINS_995)
 		{

--- a/runelite-client/src/main/java/net/runelite/client/game/ItemManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/game/ItemManager.java
@@ -235,7 +235,7 @@ public class ItemManager
 	 * @param itemID item id
 	 * @return item price
 	 */
-	public int getItemPrice(int itemID)
+	public long getItemPrice(int itemID)
 	{
 		if (itemID == ItemID.COINS_995)
 		{

--- a/runelite-client/src/main/java/net/runelite/client/game/ItemManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/game/ItemManager.java
@@ -75,6 +75,9 @@ public class ItemManager
 		private final Color outlineColor;
 	}
 
+	// Used when getting High Alchemy value - multiplied by general store price.
+	private static final float HIGH_ALCHEMY_CONSTANT = 0.6f;
+
 	private final Client client;
 	private final ScheduledExecutorService scheduledExecutorService;
 	private final ClientThread clientThread;
@@ -255,6 +258,28 @@ public class ItemManager
 
 		return price;
 	}
+
+	public int getAlchValue(int itemID)
+	{
+		if (itemID == ItemID.COINS_995)
+		{
+			return 1;
+		}
+		if (itemID == ItemID.PLATINUM_TOKEN)
+		{
+			return 1000;
+		}
+
+		float alchValue = getItemComposition(itemID).getPrice() * HIGH_ALCHEMY_CONSTANT;
+
+		/*
+		 * If the alch value is below 1, do not round up, return 0 instead.
+		 * For example bones have a base price of 1, multiplied by 0.6 will be 0.6,
+		 * if rounded up, the alch price will be 1, when it should be 0.
+		 */
+		return alchValue < 1 ? 0 : Math.round(alchValue);
+	}
+
 
 	/**
 	 * Search for tradeable items based on item name

--- a/runelite-client/src/main/java/net/runelite/client/plugins/bankvalue/BankCalculation.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/bankvalue/BankCalculation.java
@@ -43,8 +43,6 @@ import net.runelite.client.util.QueryRunner;
 @Slf4j
 class BankCalculation
 {
-	private static final float HIGH_ALCHEMY_CONSTANT = 0.6f;
-
 	private final QueryRunner queryRunner;
 	private final BankValueConfig config;
 	private final ItemManager itemManager;
@@ -117,12 +115,11 @@ class BankCalculation
 
 			if (config.showHA())
 			{
-				int price = itemComposition.getPrice();
+				int alchValue = itemManager.getAlchValue(widgetItem.getId());
 
-				if (price > 0)
+				if (alchValue > 0)
 				{
-					haPrice += (long) Math.round(price * HIGH_ALCHEMY_CONSTANT) *
-						(long) quantity;
+					haPrice += alchValue * quantity;
 				}
 			}
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/bankvalue/BankCalculation.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/bankvalue/BankCalculation.java
@@ -115,7 +115,7 @@ class BankCalculation
 
 			if (config.showHA())
 			{
-				int alchValue = itemManager.getAlchValue(widgetItem.getId());
+				long alchValue = itemManager.getAlchValue(widgetItem.getId());
 
 				if (alchValue > 0)
 				{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
@@ -477,7 +477,7 @@ public class ChatCommandsPlugin extends Plugin implements ChatboxInputListener
 			ItemComposition itemComposition = itemManager.getItemComposition(itemId);
 			if (itemComposition != null)
 			{
-				int alchPrice = itemManager.getAlchValue(itemId);
+				long alchPrice = itemManager.getAlchValue(itemId);
 				builder
 					.append(ChatColorType.NORMAL)
 					.append(" HA value ")

--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
@@ -462,7 +462,7 @@ public class ChatCommandsPlugin extends Plugin implements ChatboxInputListener
 			ItemPrice item = retrieveFromList(results, search);
 
 			int itemId = item.getId();
-			int itemPrice = item.getPrice();
+			long itemPrice = itemManager.getItemPrice(itemId);
 
 			final ChatMessageBuilder builder = new ChatMessageBuilder()
 				.append(ChatColorType.NORMAL)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
@@ -79,7 +79,6 @@ import net.runelite.http.api.kc.KillCountClient;
 @Slf4j
 public class ChatCommandsPlugin extends Plugin implements ChatboxInputListener
 {
-	private static final float HIGH_ALCHEMY_CONSTANT = 0.6f;
 	private static final Pattern KILLCOUNT_PATTERN = Pattern.compile("Your (.+) kill count is: <col=ff0000>(\\d+)</col>.");
 	private static final Pattern RAIDS_PATTERN = Pattern.compile("Your completed (.+) count is: <col=ff0000>(\\d+)</col>.");
 	private static final Pattern WINTERTODT_PATTERN = Pattern.compile("Your subdued Wintertodt count is: <col=ff0000>(\\d+)</col>.");
@@ -478,7 +477,7 @@ public class ChatCommandsPlugin extends Plugin implements ChatboxInputListener
 			ItemComposition itemComposition = itemManager.getItemComposition(itemId);
 			if (itemComposition != null)
 			{
-				int alchPrice = Math.round(itemComposition.getPrice() * HIGH_ALCHEMY_CONSTANT);
+				int alchPrice = itemManager.getAlchValue(itemId);
 				builder
 					.append(ChatColorType.NORMAL)
 					.append(" HA value ")

--- a/runelite-client/src/main/java/net/runelite/client/plugins/examine/ExaminePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/examine/ExaminePlugin.java
@@ -289,7 +289,7 @@ public class ExaminePlugin extends Plugin
 		quantity = Math.max(1, quantity);
 		int itemCompositionPrice = itemComposition.getPrice();
 		final int gePrice = itemManager.getItemPrice(id);
-		final int alchPrice = itemCompositionPrice <= 0 ? 0 : itemManager.getAlchValue(id);
+		final long alchPrice = itemCompositionPrice <= 0 ? 0 : itemManager.getAlchValue(id);
 
 		if (gePrice > 0 || alchPrice > 0)
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/examine/ExaminePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/examine/ExaminePlugin.java
@@ -288,7 +288,7 @@ public class ExaminePlugin extends Plugin
 		// quantity is at least 1
 		quantity = Math.max(1, quantity);
 		int itemCompositionPrice = itemComposition.getPrice();
-		final int gePrice = itemManager.getItemPrice(id);
+		final long gePrice = itemManager.getItemPrice(id);
 		final long alchPrice = itemCompositionPrice <= 0 ? 0 : itemManager.getAlchValue(id);
 
 		if (gePrice > 0 || alchPrice > 0)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/examine/ExaminePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/examine/ExaminePlugin.java
@@ -67,8 +67,6 @@ import net.runelite.http.api.examine.ExamineClient;
 @Slf4j
 public class ExaminePlugin extends Plugin
 {
-	private static final float HIGH_ALCHEMY_CONSTANT = 0.6f;
-
 	private final ExamineClient examineClient = new ExamineClient();
 	private final Deque<PendingExamine> pending = new ArrayDeque<>();
 	private final Cache<CacheKey, Boolean> cache = CacheBuilder.newBuilder()
@@ -291,7 +289,7 @@ public class ExaminePlugin extends Plugin
 		quantity = Math.max(1, quantity);
 		int itemCompositionPrice = itemComposition.getPrice();
 		final int gePrice = itemManager.getItemPrice(id);
-		final int alchPrice = itemCompositionPrice <= 0 ? 0 : Math.round(itemCompositionPrice * HIGH_ALCHEMY_CONSTANT);
+		final int alchPrice = itemCompositionPrice <= 0 ? 0 : itemManager.getAlchValue(id);
 
 		if (gePrice > 0 || alchPrice > 0)
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangeItemPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangeItemPanel.java
@@ -52,7 +52,7 @@ class GrandExchangeItemPanel extends JPanel
 {
 	private static final Dimension ICON_SIZE = new Dimension(32, 32);
 
-	GrandExchangeItemPanel(AsyncBufferedImage icon, String name, int itemID, int gePrice, Double
+	GrandExchangeItemPanel(AsyncBufferedImage icon, String name, int itemID, long gePrice, long
 		haPrice, int geItemLimit)
 	{
 		BorderLayout layout = new BorderLayout();
@@ -139,7 +139,7 @@ class GrandExchangeItemPanel extends JPanel
 
 		// Alch price
 		JLabel haPriceLabel = new JLabel();
-		haPriceLabel.setText(StackFormatter.formatNumber(haPrice.intValue()) + " alch");
+		haPriceLabel.setText(StackFormatter.formatNumber((int) haPrice) + " alch");
 		haPriceLabel.setForeground(ColorScheme.GRAND_EXCHANGE_ALCH);
 		alchAndLimitPanel.add(haPriceLabel, BorderLayout.WEST);
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangeItems.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangeItems.java
@@ -33,7 +33,7 @@ class GrandExchangeItems
 	private final AsyncBufferedImage icon;
 	private final String name;
 	private final int itemId;
-	private final int gePrice;
-	private final double haPrice;
+	private final long gePrice;
+	private final long haPrice;
 	private final int geItemLimit;
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangeSearchPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangeSearchPanel.java
@@ -206,11 +206,11 @@ class GrandExchangeSearchPanel extends JPanel
 				continue;
 			}
 
-			int itemPrice = item.getPrice();
+			long itemPrice = item.getPrice();
 			int itemLimit = itemGELimits.getOrDefault(itemId, 0);
 			AsyncBufferedImage itemImage = itemManager.getImage(itemId);
 
-			itemsList.add(new GrandExchangeItems(itemImage, item.getName(), itemId, itemPrice, itemComp.getPrice() * 0.6, itemLimit));
+			itemsList.add(new GrandExchangeItems(itemImage, item.getName(), itemId, itemPrice, itemManager.getAlchValue(itemId), itemLimit));
 
 			// If using hotkey to lookup item, stop after finding match.
 			if (exactMatch && item.getName().equalsIgnoreCase(lookup))

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItem.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItem.java
@@ -40,7 +40,7 @@ class GroundItem
 	private WorldPoint location;
 	private int height;
 	private long haPrice;
-	private int gePrice;
+	private long gePrice;
 	private int offset;
 	private boolean tradeable;
 
@@ -49,7 +49,7 @@ class GroundItem
 		return haPrice * quantity;
 	}
 
-	int getGePrice()
+	long getGePrice()
 	{
 		return gePrice * quantity;
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItem.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItem.java
@@ -39,12 +39,12 @@ class GroundItem
 	private int quantity;
 	private WorldPoint location;
 	private int height;
-	private int haPrice;
+	private long haPrice;
 	private int gePrice;
 	private int offset;
 	private boolean tradeable;
 
-	int getHaPrice()
+	long getHaPrice()
 	{
 		return haPrice * quantity;
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
@@ -240,7 +240,7 @@ public class GroundItemsOverlay extends Overlay
 			}
 			else if (config.priceDisplayMode() != PriceDisplayMode.OFF)
 			{
-				final int price = config.priceDisplayMode() == PriceDisplayMode.GE
+				final long price = config.priceDisplayMode() == PriceDisplayMode.GE
 					? item.getGePrice()
 					: item.getHaPrice();
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
@@ -93,8 +93,6 @@ public class GroundItemsPlugin extends Plugin
 		.trimResults();
 
 	private static final Joiner COMMA_JOINER = Joiner.on(",").skipNulls();
-	// Used when getting High Alchemy value - multiplied by general store price.
-	private static final float HIGH_ALCHEMY_CONSTANT = 0.6f;
 	// ItemID for coins
 	private static final int COINS = ItemID.COINS_995;
 
@@ -267,7 +265,7 @@ public class GroundItemsPlugin extends Plugin
 		final int itemId = item.getId();
 		final ItemComposition itemComposition = itemManager.getItemComposition(itemId);
 		final int realItemId = itemComposition.getNote() != -1 ? itemComposition.getLinkedNoteId() : itemId;
-		final int alchPrice = Math.round(itemComposition.getPrice() * HIGH_ALCHEMY_CONSTANT);
+		final int alchPrice = itemManager.getAlchValue(itemId);
 
 		final GroundItem groundItem = GroundItem.builder()
 			.id(itemId)
@@ -379,7 +377,7 @@ public class GroundItemsPlugin extends Plugin
 			final int realItemId = itemComposition.getNote() != -1 ? itemComposition.getLinkedNoteId() : itemComposition.getId();
 			final int itemPrice = itemManager.getItemPrice(realItemId);
 			final int price = itemPrice <= 0 ? itemComposition.getPrice() : itemPrice;
-			final int haPrice = Math.round(itemComposition.getPrice() * HIGH_ALCHEMY_CONSTANT) * quantity;
+			final int haPrice = itemManager.getAlchValue(realItemId) * quantity;
 			final int gePrice = quantity * price;
 			final Color hidden = getHidden(itemComposition.getName(), gePrice, haPrice, itemComposition.isTradeable());
 			final Color highlighted = getHighlighted(itemComposition.getName(), gePrice, haPrice);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
@@ -265,7 +265,7 @@ public class GroundItemsPlugin extends Plugin
 		final int itemId = item.getId();
 		final ItemComposition itemComposition = itemManager.getItemComposition(itemId);
 		final int realItemId = itemComposition.getNote() != -1 ? itemComposition.getLinkedNoteId() : itemId;
-		final int alchPrice = itemManager.getAlchValue(itemId);
+		final long alchPrice = itemManager.getAlchValue(itemId);
 
 		final GroundItem groundItem = GroundItem.builder()
 			.id(itemId)
@@ -377,7 +377,7 @@ public class GroundItemsPlugin extends Plugin
 			final int realItemId = itemComposition.getNote() != -1 ? itemComposition.getLinkedNoteId() : itemComposition.getId();
 			final int itemPrice = itemManager.getItemPrice(realItemId);
 			final int price = itemPrice <= 0 ? itemComposition.getPrice() : itemPrice;
-			final int haPrice = itemManager.getAlchValue(realItemId) * quantity;
+			final long haPrice = itemManager.getAlchValue(realItemId) * quantity;
 			final int gePrice = quantity * price;
 			final Color hidden = getHidden(itemComposition.getName(), gePrice, haPrice, itemComposition.isTradeable());
 			final Color highlighted = getHighlighted(itemComposition.getName(), gePrice, haPrice);
@@ -434,7 +434,7 @@ public class GroundItemsPlugin extends Plugin
 		config.setHighlightedItem(COMMA_JOINER.join(highlightedItemSet));
 	}
 
-	Color getHighlighted(String item, int gePrice, int haPrice)
+	Color getHighlighted(String item, int gePrice, long haPrice)
 	{
 		if (TRUE.equals(highlightedItems.getUnchecked(item)))
 		{
@@ -458,7 +458,7 @@ public class GroundItemsPlugin extends Plugin
 		return null;
 	}
 
-	Color getHidden(String item, int gePrice, int haPrice, boolean isTradeable)
+	Color getHidden(String item, int gePrice, long haPrice, boolean isTradeable)
 	{
 		final boolean isExplicitHidden = TRUE.equals(hiddenItems.getUnchecked(item));
 		final boolean isExplicitHighlight = TRUE.equals(highlightedItems.getUnchecked(item));

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
@@ -375,10 +375,10 @@ public class GroundItemsPlugin extends Plugin
 
 			final ItemComposition itemComposition = itemManager.getItemComposition(itemId);
 			final int realItemId = itemComposition.getNote() != -1 ? itemComposition.getLinkedNoteId() : itemComposition.getId();
-			final int itemPrice = itemManager.getItemPrice(realItemId);
-			final int price = itemPrice <= 0 ? itemComposition.getPrice() : itemPrice;
+			final long itemPrice = itemManager.getItemPrice(realItemId);
+			final long price = itemPrice <= 0 ? itemComposition.getPrice() : itemPrice;
 			final long haPrice = itemManager.getAlchValue(realItemId) * quantity;
-			final int gePrice = quantity * price;
+			final long gePrice = quantity * price;
 			final Color hidden = getHidden(itemComposition.getName(), gePrice, haPrice, itemComposition.isTradeable());
 			final Color highlighted = getHighlighted(itemComposition.getName(), gePrice, haPrice);
 			final Color color = getItemColor(highlighted, hidden);
@@ -434,7 +434,7 @@ public class GroundItemsPlugin extends Plugin
 		config.setHighlightedItem(COMMA_JOINER.join(highlightedItemSet));
 	}
 
-	Color getHighlighted(String item, int gePrice, long haPrice)
+	Color getHighlighted(String item, long gePrice, long haPrice)
 	{
 		if (TRUE.equals(highlightedItems.getUnchecked(item)))
 		{
@@ -458,7 +458,7 @@ public class GroundItemsPlugin extends Plugin
 		return null;
 	}
 
-	Color getHidden(String item, int gePrice, long haPrice, boolean isTradeable)
+	Color getHidden(String item, long gePrice, long haPrice, boolean isTradeable)
 	{
 		final boolean isExplicitHidden = TRUE.equals(hiddenItems.getUnchecked(item));
 		final boolean isExplicitHighlight = TRUE.equals(highlightedItems.getUnchecked(item));

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemprices/ItemPricesOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemprices/ItemPricesOverlay.java
@@ -48,9 +48,6 @@ import net.runelite.client.util.StackFormatter;
 
 class ItemPricesOverlay extends Overlay
 {
-	// Used when getting High Alchemy value - multiplied by general store price.
-	private static final float HIGH_ALCHEMY_CONSTANT = 0.6f;
-
 	private static final int INVENTORY_ITEM_WIDGETID = WidgetInfo.INVENTORY.getPackedId();
 	private static final int BANK_INVENTORY_ITEM_WIDGETID = WidgetInfo.BANK_INVENTORY_ITEMS_CONTAINER.getPackedId();
 	private static final int BANK_ITEM_WIDGETID = WidgetInfo.BANK_ITEM_CONTAINER.getPackedId();
@@ -203,7 +200,7 @@ class ItemPricesOverlay extends Overlay
 		}
 		if (config.showHAValue())
 		{
-			haPrice = Math.round(itemDef.getPrice() * HIGH_ALCHEMY_CONSTANT);
+			haPrice = itemManager.getAlchValue(id);
 		}
 
 		if (gePrice > 0 || haPrice > 0)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemprices/ItemPricesOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemprices/ItemPricesOverlay.java
@@ -192,7 +192,7 @@ class ItemPricesOverlay extends Overlay
 		}
 
 		int gePrice = 0;
-		int haPrice = 0;
+		long haPrice = 0;
 
 		if (config.showGEPrice())
 		{
@@ -211,7 +211,7 @@ class ItemPricesOverlay extends Overlay
 		return null;
 	}
 
-	private String stackValueText(int qty, int gePrice, int haValue)
+	private String stackValueText(int qty, int gePrice, long haValue)
 	{
 		if (gePrice > 0)
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemprices/ItemPricesOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemprices/ItemPricesOverlay.java
@@ -191,7 +191,7 @@ class ItemPricesOverlay extends Overlay
 			return null;
 		}
 
-		int gePrice = 0;
+		long gePrice = 0;
 		long haPrice = 0;
 
 		if (config.showGEPrice())
@@ -211,7 +211,7 @@ class ItemPricesOverlay extends Overlay
 		return null;
 	}
 
-	private String stackValueText(int qty, int gePrice, long haValue)
+	private String stackValueText(int qty, long gePrice, long haValue)
 	{
 		if (gePrice > 0)
 		{


### PR DESCRIPTION
5 different plugins (was about to 6 with the Loot Tracker) used the same copy and pasted code to calculate high alchemy price of an item, decided to create a method in ItemManager for that and edit all the plugin to reference that method.

There was also introduced a new exception to the calculations that would make sure items with 0 gp alch wouldn't falsely return 1 as the price.

However, there still seems to be a problem in the high alchemy value calculation as some items return wrong values when Math.round is used, and others return wrong values when it is not used, **this problem already existed before this PR**, I just hope that by bringing all those calculations to one single place will make the fix easier, in the future, if one exists.