### PR TITLE
Skip empty spots in Loot Tracker when getting items

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
@@ -204,6 +204,7 @@ public class LootTrackerPlugin extends Plugin
 
 		// Convert container items to array of ItemStack
 		final Collection<ItemStack> items = Arrays.stream(container.getItems())
+			.filter(item -> item.getId() > 0)
 			.map(item -> new ItemStack(item.getId(), item.getQuantity()))
 			.collect(Collectors.toList());
 


### PR DESCRIPTION
Skip all empty spots in ItemContainer#getItems array by checking if
itemId > 0.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>