### PR TITLE
Add toggle to enable/disable the team-cape image styled overlay

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/teamcapes/TeamCapesConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/teamcapes/TeamCapesConfig.java
@@ -41,4 +41,16 @@ public interface TeamCapesConfig extends Config
 	{
 		return 1;
 	}
+
+	@ConfigItem(
+		keyName = "imageCapeStyle",
+		name = "Image Overlay Style",
+		description = "Enables/disables the item image overlay style and replaces with the classic team cape overlay",
+		position = 0
+	)
+
+	default boolean imageCapeStyle()
+	{
+		return true;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/teamcapes/TeamCapesOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/teamcapes/TeamCapesOverlay.java
@@ -34,6 +34,7 @@ import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.OverlayPriority;
 import net.runelite.client.ui.overlay.components.ImageComponent;
+import net.runelite.client.ui.overlay.components.LineComponent;
 import net.runelite.client.ui.overlay.components.PanelComponent;
 
 public class TeamCapesOverlay extends Overlay
@@ -51,8 +52,6 @@ public class TeamCapesOverlay extends Overlay
 		this.plugin = plugin;
 		this.config = config;
 		this.manager = manager;
-		panelComponent.setOrientation(PanelComponent.Orientation.HORIZONTAL);
-		panelComponent.setWrapping(4);
 	}
 
 	@Override
@@ -74,21 +73,35 @@ public class TeamCapesOverlay extends Overlay
 				continue;
 			}
 
-			// Make the number 0 based
-			final int teamcapeNumber = team.getKey() - 1;
-			final int itemID;
-			if (teamcapeNumber < 50)
+			if (config.imageCapeStyle())
 			{
-				// The team cape is every 2nd item id based on tc number
-				itemID = 2 * teamcapeNumber + ItemID.TEAM1_CAPE;
-			}
-			else
-			{
-				// The team cape is every 3rd item id based on tc number starting from 0
-				itemID = 3 * (teamcapeNumber - 50) + ItemID.TEAM_CAPE_ZERO;
+				panelComponent.setOrientation(PanelComponent.Orientation.HORIZONTAL);
+				panelComponent.setWrapping(4);
+				// Make the number 0 based
+				final int teamcapeNumber = team.getKey() - 1;
+				final int itemID;
+				if (teamcapeNumber < 50)
+				{
+					// The team cape is every 2nd item id based on tc number
+					itemID = 2 * teamcapeNumber + ItemID.TEAM1_CAPE;
+				}
+				else
+				{
+					// The team cape is every 3rd item id based on tc number starting from 0
+					itemID = 3 * (teamcapeNumber - 50) + ItemID.TEAM_CAPE_ZERO;
+				}
+
+				panelComponent.getChildren().add(new ImageComponent(manager.getImage(itemID, team.getValue(), true)));
+			} else {
+				panelComponent.setOrientation(PanelComponent.Orientation.VERTICAL);
+				panelComponent.setWrapping(-1);
+				panelComponent.getChildren().add(LineComponent.builder()
+					.left("Team-" + Integer.toString(team.getKey()))
+					.right(Integer.toString(team.getValue()))
+					.build());
+
 			}
 
-			panelComponent.getChildren().add(new ImageComponent(manager.getImage(itemID, team.getValue(), true)));
 		}
 
 		return panelComponent.render(graphics);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/teamcapes/TeamCapesOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/teamcapes/TeamCapesOverlay.java
@@ -92,7 +92,9 @@ public class TeamCapesOverlay extends Overlay
 				}
 
 				panelComponent.getChildren().add(new ImageComponent(manager.getImage(itemID, team.getValue(), true)));
-			} else {
+			}
+			else
+			{
 				panelComponent.setOrientation(PanelComponent.Orientation.VERTICAL);
 				panelComponent.setWrapping(-1);
 				panelComponent.getChildren().add(LineComponent.builder()


### PR DESCRIPTION
Allows for the user to define what type of overlay they prefer (text-style or image-based) for the team-cape plugin.

![scdg7kj](https://user-images.githubusercontent.com/9088799/46564854-edec2480-c8d7-11e8-959e-a68c526dc85c.png)
