### PR TITLE
Fix NPE in Miscellania plugin on DC

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/kingdomofmiscellania/KingdomPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/kingdomofmiscellania/KingdomPlugin.java
@@ -123,7 +123,8 @@ public class KingdomPlugin extends Plugin
 
 	private boolean isInKingdom()
 	{
-		return KINGDOM_REGION.contains(client.getLocalPlayer().getWorldLocation().getRegionID());
+		return client.getLocalPlayer() != null
+			&& KINGDOM_REGION.contains(client.getLocalPlayer().getWorldLocation().getRegionID());
 	}
 
 	private boolean hasCompletedQuest()


### PR DESCRIPTION
When you DC, isInKingdom throws NPE in isInKingdom method because
localPlayer is null.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>