### PR TITLE
XP Globes - Move progress bar display from tooltip to globe

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesOverlay.java
@@ -111,6 +111,8 @@ public class XpGlobesOverlay extends Overlay
 
 		Ellipse2D backgroundCircle = drawEllipse(graphics, x, y);
 
+		drawSkillImage(graphics, skillToDraw, x, y);
+
 		Point mouse = client.getMouseCanvasPosition();
 		int mouseX = mouse.getX() - bounds.x;
 		int mouseY = mouse.getY() - bounds.y;
@@ -145,8 +147,6 @@ public class XpGlobesOverlay extends Overlay
 			config.enableCustomArcColor() ? config.progressArcColor() : SkillColor.find(skillToDraw.getSkill()).getColor());
 
 		graphics.setRenderingHint(RenderingHints.KEY_STROKE_CONTROL, renderHint);
-
-		drawSkillImage(graphics, skillToDraw, x, y);
 
 		if (hovering)
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesOverlay.java
@@ -56,6 +56,7 @@ public class XpGlobesOverlay extends Overlay
 	private static final int PROGRESS_RADIUS_REMAINDER = 0;
 	private static final int DEFAULT_START_Y = 10;
 	private static final int TOOLTIP_RECT_SIZE_X = 150;
+	private static final Color DARK_OVERLAY_COLOR = new Color(0, 0, 0, 180);
 
 	private final Client client;
 	private final XpGlobesPlugin plugin;
@@ -131,14 +132,18 @@ public class XpGlobesOverlay extends Overlay
 
 		drawSkillImage(graphics, skillToDraw, x, y);
 
-		if (config.enableTooltips())
-		{
-			Point mouse = client.getMouseCanvasPosition();
-			int mouseX = mouse.getX() - bounds.x;
-			int mouseY = mouse.getY() - bounds.y;
+		Point mouse = client.getMouseCanvasPosition();
+		int mouseX = mouse.getX() - bounds.x;
+		int mouseY = mouse.getY() - bounds.y;
 
-			// If mouse is hovering the globe
-			if (backgroundCircle.contains(mouseX, mouseY))
+		// If mouse is hovering the globe
+		if (backgroundCircle.contains(mouseX, mouseY))
+		{
+			// Fill a darker overlay circle
+			graphics.setColor(DARK_OVERLAY_COLOR);
+			graphics.fill(backgroundCircle);
+
+			if (config.enableTooltips())
 			{
 				drawTooltip(graphics, skillToDraw, backgroundCircle);
 			}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesOverlay.java
@@ -133,7 +133,15 @@ public class XpGlobesOverlay extends Overlay
 
 		if (config.enableTooltips())
 		{
-			drawTooltipIfMouseover(graphics, skillToDraw, backgroundCircle, bounds);
+			Point mouse = client.getMouseCanvasPosition();
+			int mouseX = mouse.getX() - bounds.x;
+			int mouseY = mouse.getY() - bounds.y;
+
+			// If mouse is hovering the globe
+			if (backgroundCircle.contains(mouseX, mouseY))
+			{
+				drawTooltip(graphics, skillToDraw, backgroundCircle);
+			}
 		}
 	}
 
@@ -176,17 +184,8 @@ public class XpGlobesOverlay extends Overlay
 		);
 	}
 
-	private void drawTooltipIfMouseover(Graphics2D graphics, XpGlobe mouseOverSkill, Ellipse2D drawnGlobe, Rectangle bounds)
+	private void drawTooltip(Graphics2D graphics, XpGlobe mouseOverSkill, Ellipse2D drawnGlobe)
 	{
-		Point mouse = client.getMouseCanvasPosition();
-		int mouseX = mouse.getX() - bounds.x;
-		int mouseY = mouse.getY() - bounds.y;
-
-		if (!drawnGlobe.contains(mouseX, mouseY))
-		{
-			return;
-		}
-
 		//draw tooltip under the globe of the mouse location
 		int x = (int) drawnGlobe.getX() - (TOOLTIP_RECT_SIZE_X / 2) + (config.xpOrbSize() / 2);
 		int y = (int) drawnGlobe.getY() + config.xpOrbSize() + 10;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesOverlay.java
@@ -49,7 +49,6 @@ import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.OverlayUtil;
 import net.runelite.client.ui.overlay.components.LineComponent;
 import net.runelite.client.ui.overlay.components.PanelComponent;
-import net.runelite.client.ui.overlay.components.ProgressBarComponent;
 
 public class XpGlobesOverlay extends Overlay
 {
@@ -275,13 +274,6 @@ public class XpGlobesOverlay extends Overlay
 					.right(xpHrString)
 					.build());
 			}
-
-			//Create progress bar for skill.
-			ProgressBarComponent progressBar = new ProgressBarComponent();
-			double progress = mouseOverSkill.getSkillProgress(Experience.getXpForLevel(mouseOverSkill.getCurrentLevel()),
-				mouseOverSkill.getCurrentXp(), mouseOverSkill.getGoalXp());
-			progressBar.setValue(progress);
-			xpTooltip.getChildren().add(progressBar);
 		}
 
 		xpTooltip.render(graphics);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesOverlay.java
@@ -117,16 +117,20 @@ public class XpGlobesOverlay extends Overlay
 		int mouseY = mouse.getY() - bounds.y;
 
 		// If mouse is hovering the globe
-		boolean hovering = backgroundCircle.contains(mouseX, mouseY);
-
-		if (hovering)
+		if (backgroundCircle.contains(mouseX, mouseY))
 		{
 			// Fill a darker overlay circle
 			graphics.setColor(DARK_OVERLAY_COLOR);
 			graphics.fill(backgroundCircle);
+
+			drawProgressLabel(graphics, skillToDraw, x, y);
+
+			if (config.enableTooltips())
+			{
+				drawTooltip(graphics, skillToDraw, backgroundCircle);
+			}
 		}
 
-		Object renderHint = graphics.getRenderingHint(RenderingHints.KEY_STROKE_CONTROL);
 		graphics.setRenderingHint(RenderingHints.KEY_STROKE_CONTROL, RenderingHints.VALUE_STROKE_PURE);
 
 		drawProgressArc(
@@ -144,18 +148,6 @@ public class XpGlobesOverlay extends Overlay
 			PROGRESS_RADIUS_START, radiusCurrentXp,
 			config.progressArcStrokeWidth(),
 			config.enableCustomArcColor() ? config.progressArcColor() : SkillColor.find(skillToDraw.getSkill()).getColor());
-
-		graphics.setRenderingHint(RenderingHints.KEY_STROKE_CONTROL, renderHint);
-
-		if (hovering)
-		{
-			drawProgressLabel(graphics, skillToDraw, x, y);
-
-			if (config.enableTooltips())
-			{
-				drawTooltip(graphics, skillToDraw, backgroundCircle);
-			}
-		}
 	}
 
 	private void drawProgressLabel(Graphics2D graphics, XpGlobe globe, int x, int y)


### PR DESCRIPTION
The old progress bar was annoying me apparently @deathbeam too, I decided to try and improve the progress display.

Started by refactoring slightly the logic on the "on hover" rendering as it made little sense.

I also had to move the rendering of the skill image as it was being displayed on top of the dark overlay, the whole point of the dark overlay was to darken the background so that the white text was very readable.

![](https://i.gyazo.com/f75959e82408b4ff1a64e13ccad62486.png)

I'm sure there are going to be people that complain about loosing the decimal places, but the exp tracker also does not show them and I haven't heard of that being an issue yet, who cares if it's 25,6 or 25, come on.