### PR TITLE
Change Ge search panel api endpoint.

### DIFF
--- a/http-api/src/main/java/net/runelite/http/api/item/Current.java
+++ b/http-api/src/main/java/net/runelite/http/api/item/Current.java
@@ -27,10 +27,8 @@ package net.runelite.http.api.item;
 import lombok.Data;
 
 @Data
-public class Item
+public class Current
 {
-	private int id;
-	private String name;
-	private String description;
-	private Current current;
+    private String trend;
+    private String price;
 }

--- a/http-api/src/main/java/net/runelite/http/api/item/Current.java
+++ b/http-api/src/main/java/net/runelite/http/api/item/Current.java
@@ -29,6 +29,6 @@ import lombok.Data;
 @Data
 public class Current
 {
-    private String trend;
-    private String price;
+	private String trend;
+	private String price;
 }

--- a/http-api/src/main/java/net/runelite/http/api/item/Item.java
+++ b/http-api/src/main/java/net/runelite/http/api/item/Item.java
@@ -33,4 +33,5 @@ public class Item
 	private String name;
 	private String description;
 	private Current current;
+    private ItemType type;
 }

--- a/http-api/src/main/java/net/runelite/http/api/item/Item.java
+++ b/http-api/src/main/java/net/runelite/http/api/item/Item.java
@@ -33,5 +33,5 @@ public class Item
 	private String name;
 	private String description;
 	private Current current;
-    private ItemType type;
+	private ItemType type;
 }

--- a/http-api/src/main/java/net/runelite/http/api/item/ItemClient.java
+++ b/http-api/src/main/java/net/runelite/http/api/item/ItemClient.java
@@ -141,7 +141,7 @@ public class ItemClient
 
 	public SearchResult search(String itemName) throws IOException
 	{
-	    HttpUrl url = HttpUrl.parse("http://services.runescape.com/m=itemdb_oldschool/api/catalogue/").newBuilder()
+		HttpUrl url = HttpUrl.parse("http://services.runescape.com/m=itemdb_oldschool/api/catalogue/").newBuilder()
 				.addPathSegment("search.json")
 				.addQueryParameter("page", "1")
 				.addQueryParameter("query", itemName)

--- a/http-api/src/main/java/net/runelite/http/api/item/ItemClient.java
+++ b/http-api/src/main/java/net/runelite/http/api/item/ItemClient.java
@@ -141,11 +141,11 @@ public class ItemClient
 
 	public SearchResult search(String itemName) throws IOException
 	{
-		HttpUrl url = RuneLiteAPI.getApiBase().newBuilder()
-			.addPathSegment("item")
-			.addPathSegment("search")
-			.addQueryParameter("query", itemName)
-			.build();
+	    HttpUrl url = HttpUrl.parse("http://services.runescape.com/m=itemdb_oldschool/api/catalogue/").newBuilder()
+				.addPathSegment("search.json")
+				.addQueryParameter("page", "1")
+				.addQueryParameter("query", itemName)
+				.addQueryParameter("simple", "1").build();
 
 		logger.debug("Built URI: {}", url);
 

--- a/http-api/src/main/java/net/runelite/http/api/item/SearchResult.java
+++ b/http-api/src/main/java/net/runelite/http/api/item/SearchResult.java
@@ -28,15 +28,15 @@ import java.util.List;
 
 public class SearchResult
 {
-	private List<Item> items;
+	private List<Item> results;
 
 	public List<Item> getItems()
 	{
-		return items;
+		return results;
 	}
 
 	public void setItems(List<Item> items)
 	{
-		this.items = items;
+		this.results = items;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangeItemPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangeItemPanel.java
@@ -52,7 +52,7 @@ class GrandExchangeItemPanel extends JPanel
 {
 	private static final Dimension ICON_SIZE = new Dimension(32, 32);
 
-	GrandExchangeItemPanel(AsyncBufferedImage icon, String name, int itemID, int gePrice, Double
+	GrandExchangeItemPanel(AsyncBufferedImage icon, String name, int itemID, String gePrice, Double
 		haPrice, int geItemLimit)
 	{
 		BorderLayout layout = new BorderLayout();
@@ -122,9 +122,9 @@ class GrandExchangeItemPanel extends JPanel
 
 		// Ge price
 		JLabel gePriceLabel = new JLabel();
-		if (gePrice > 0)
+		if (gePrice != null && !gePrice.isEmpty())
 		{
-			gePriceLabel.setText(StackFormatter.formatNumber(gePrice) + " gp");
+			gePriceLabel.setText(gePrice + " gp");
 		}
 		else
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangeItems.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangeItems.java
@@ -33,7 +33,7 @@ class GrandExchangeItems
 	private final AsyncBufferedImage icon;
 	private final String name;
 	private final int itemId;
-	private final int gePrice;
+	private final String gePrice;
 	private final double haPrice;
 	private final int geItemLimit;
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangeSearchPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangeSearchPanel.java
@@ -207,7 +207,7 @@ class GrandExchangeSearchPanel extends JPanel
 					continue;
 				}
 
-				int itemPrice = itemManager.getItemPrice(itemId);
+				String itemPrice = item.getCurrent().getPrice();
 				int itemLimit = itemGELimits.getOrDefault(itemId, 0);
 				AsyncBufferedImage itemImage = itemManager.getImage(itemId);
 


### PR DESCRIPTION
Change Ge Search Panel plugin from searching Rune Lite api endpoint for prices to
searching a before undocumented Jagex Endpoint for ge prices.
This is the end point.
http://services.runescape.com/m=itemdb_oldschool/api/catalogue/search.json?page=1&query={searchedItemName}&simple=1

Pros:
-  Takes some traffic off of RuneLite APi.
-  Could possible get rid of the search by name function on API

Cons:
- Price is rounded after 100,000 so if something is 104,304 it shows as 104k, same with million.
- Different search order than what people are used to.



