### PR TITLE
Remove idle alerts from Lunar Spells shared animation

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/AnimationID.java
+++ b/runelite-api/src/main/java/net/runelite/api/AnimationID.java
@@ -120,8 +120,6 @@ public final class AnimationID
 	public static final int DENSE_ESSENCE_CHIPPING = 7201;
 	public static final int HERBLORE_POTIONMAKING = 363; //used for both herb and secondary
 	public static final int MAGIC_CHARGING_ORBS = 726;
-	public static final int MAGIC_LUNAR_STRING_JEWELRY = 4412;
-	public static final int MAGIC_LUNAR_BAKE_PIE = 4413;
 	public static final int MAGIC_MAKE_TABLET = 4068;
 	public static final int BURYING_BONES = 827;
 	public static final int USING_GILDED_ALTAR = 3705;
@@ -163,9 +161,10 @@ public final class AnimationID
 
 	// Lunar spellbook
 	public static final int ENERGY_TRANSFER_VENGEANCE_OTHER = 4411;
-	public static final int MAGIC_LUNAR_FERTILE_SOIL = 4413;
+	public static final int MAGIC_LUNAR_SHARED = 4413; // Utilized by Fertile Soil, Boost/Stat Potion Share, NPC Contact, Bake Pie
 	public static final int MAGIC_LUNAR_CURE_PLANT = 4432;
 	public static final int MAGIC_LUNAR_GEOMANCY = 7118;
+	public static final int MAGIC_LUNAR_STRING_JEWELRY = 4412;
 
 	// Arceuus spellbook
 	public static final int MAGIC_ARCEUUS_RESURRECT_CROPS = 7118;

--- a/runelite-api/src/main/java/net/runelite/api/GraphicID.java
+++ b/runelite-api/src/main/java/net/runelite/api/GraphicID.java
@@ -44,4 +44,7 @@ public class GraphicID
 	public static final int STAFF_OF_THE_DEAD = 1228;
 	public static final int IMBUED_HEART = 1316;
 	public static final int FLYING_FISH = 1387;
+	public static final int NPC_CONTACT = 728;
+	public static final int POT_SHARE = 733;
+	public static final int BAKE_PIE = 746;
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
@@ -37,6 +37,7 @@ import net.runelite.api.AnimationID;
 import static net.runelite.api.AnimationID.*;
 import net.runelite.api.Client;
 import net.runelite.api.GameState;
+import net.runelite.api.GraphicID;
 import net.runelite.api.Hitsplat;
 import net.runelite.api.NPC;
 import net.runelite.api.NPCComposition;
@@ -110,6 +111,7 @@ public class IdleNotifierPlugin extends Plugin
 			return;
 		}
 
+		int graphic = localPlayer.getGraphic();
 		int animation = localPlayer.getAnimation();
 		switch (animation)
 		{
@@ -203,7 +205,6 @@ public class IdleNotifierPlugin extends Plugin
 			/* Magic */
 			case MAGIC_CHARGING_ORBS:
 			case MAGIC_LUNAR_STRING_JEWELRY:
-			case MAGIC_LUNAR_BAKE_PIE:
 			case MAGIC_MAKE_TABLET:
 			/* Prayer */
 			case USING_GILDED_ALTAR:
@@ -212,6 +213,13 @@ public class IdleNotifierPlugin extends Plugin
 				resetTimers();
 				lastAnimation = animation;
 				break;
+			case MAGIC_LUNAR_SHARED:
+				if (graphic == GraphicID.BAKE_PIE)
+				{
+					resetTimers();
+					lastAnimation = animation;
+					break;
+				}
 			case IDLE:
 				break;
 			default:


### PR DESCRIPTION
Closes #5571 

Prevents Idle alert notifications being sent for:

- Fertile Soil
- Boost/Stat Potion Share
- NPC Contact