### PR TITLE
mouse tooltips: Don't add a tooltip if another is present

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/VarClientInt.java
+++ b/runelite-api/src/main/java/net/runelite/api/VarClientInt.java
@@ -36,6 +36,12 @@ public enum VarClientInt
 {
 	TOOLTIP_TIMEOUT(1),
 
+	/**
+	 * 0 = no tooltip displayed
+	 * 1 = tooltip displaying
+	 */
+	TOOLTIP_VISIBLE(2),
+
 	MEMBERSHIP_STATUS(103),
 
 	WORLD_MAP_SEARCH_FOCUSED(190);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/mousehighlight/MouseHighlightOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/mousehighlight/MouseHighlightOverlay.java
@@ -118,6 +118,13 @@ class MouseHighlightOverlay extends Overlay
 			}
 		}
 
+		// If this varc is set, a tooltip is already being displayed
+		int tooltipDisplayed = client.getVar(VarClientInt.TOOLTIP_VISIBLE);
+		if (tooltipDisplayed == 1)
+		{
+			return null;
+		}
+
 		tooltipManager.addFront(new Tooltip(option + (Strings.isNullOrEmpty(target) ? "" : " " + target)));
 		return null;
 	}


### PR DESCRIPTION
VarClientInt(2) is set to `1` whenever a tooltip is present, meaning we should never render a tooltip when it is set that way. Some menu options (world map dungeon links) have a null widget associated with them, and do not utilize the TOOLTIP_TIMEOUT VarClientInt, so this check is necessary to avoid adding a duplicate tooltip.

Fixes runelite/runelite#3278