### PR TITLE
Kingdom Plugin: fix throne completion state check

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/VarPlayer.java
+++ b/runelite-api/src/main/java/net/runelite/api/VarPlayer.java
@@ -48,6 +48,13 @@ public enum VarPlayer
 	NMZ_REWARD_POINTS(1060),
 
 	/**
+	 * 0 : not started
+	 * greater than 0 : in progress
+	 * greater than 99 : completed
+	 */
+	THRONE_OF_MISCELLANIA(359),
+
+	/**
 	 * Experience tracker goal start.
 	 */
 	ATTACK_GOAL_START(1229),

--- a/runelite-api/src/main/java/net/runelite/api/Varbits.java
+++ b/runelite-api/src/main/java/net/runelite/api/Varbits.java
@@ -342,7 +342,6 @@ public enum Varbits
 	 */
 	KINGDOM_FAVOR(72),
 	KINGDOM_COFFER(74),
-	THRONE_OF_MISCELLANIA_QUEST(359),
 
 	/**
 	 * The Hand in the Sand quest status

--- a/runelite-client/src/main/java/net/runelite/client/plugins/kingdomofmiscellania/KingdomPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/kingdomofmiscellania/KingdomPlugin.java
@@ -32,7 +32,6 @@ import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.GameState;
 import static net.runelite.api.ItemID.TEAK_CHEST;
-
 import net.runelite.api.VarPlayer;
 import net.runelite.api.Varbits;
 import net.runelite.api.events.GameStateChanged;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/kingdomofmiscellania/KingdomPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/kingdomofmiscellania/KingdomPlugin.java
@@ -32,6 +32,8 @@ import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.GameState;
 import static net.runelite.api.ItemID.TEAK_CHEST;
+
+import net.runelite.api.VarPlayer;
 import net.runelite.api.Varbits;
 import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.VarbitChanged;
@@ -129,7 +131,7 @@ public class KingdomPlugin extends Plugin
 
 	private boolean hasCompletedQuest()
 	{
-		return client.getVar(Varbits.THRONE_OF_MISCELLANIA_QUEST) == 1;
+		return client.getVar(VarPlayer.THRONE_OF_MISCELLANIA) > 0;
 	}
 
 	static int getFavorPercent(int favor)


### PR DESCRIPTION
Now uses the correct varp from the quest list completion state script (1358).

Additionally, allows the infobox to show if the quest is in progress to allow users to check favor during the last part of the quest. 

Closes #1980 