### PR TITLE
Change regen meter stroke end-cap style to CAP_BUTT

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/regenmeter/RegenMeterOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/regenmeter/RegenMeterOverlay.java
@@ -112,8 +112,8 @@ public class RegenMeterOverlay extends Overlay
 		}
 		Rectangle bounds = widget.getBounds();
 
-		Arc2D.Double arc = new Arc2D.Double(bounds.x + OFFSET, bounds.y + (bounds.height / 2 - DIAMETER / 2), DIAMETER, DIAMETER, 88.d, -360.d * percent, Arc2D.OPEN);
-		final Stroke STROKE = new BasicStroke(2f);
+		Arc2D.Double arc = new Arc2D.Double(bounds.x + OFFSET, bounds.y + (bounds.height / 2 - DIAMETER / 2), DIAMETER, DIAMETER, 90.d, -360.d * percent, Arc2D.OPEN);
+		final Stroke STROKE = new BasicStroke(2f, BasicStroke.CAP_BUTT, BasicStroke.JOIN_MITER);
 		g.setStroke(STROKE);
 		g.setColor(color);
 		g.draw(arc);


### PR DESCRIPTION
This will prevent the end of the stroke from overlapping the beginning

![preview](https://puu.sh/BHJAO/8dfd4a277a.gif)
