### PR TITLE
Fix snapped overlays above chatbox not being rendered

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayRenderer.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayRenderer.java
@@ -392,7 +392,7 @@ public class OverlayRenderer extends MouseListener implements KeyListener
 
 	private boolean shouldInvalidateBounds()
 	{
-		final Widget chatbox = client.getWidget(WidgetInfo.CHATBOX_MESSAGES);
+		final Widget chatbox = client.getWidget(WidgetInfo.CHATBOX);
 		final boolean resizeableChanged = isResizeable != client.isResized();
 		boolean changed = false;
 


### PR DESCRIPTION
This is to fix an issue where under certain circumstances such as input or dialogue being open, these snapped overlays were not being rendered.