### PR TITLE
Add "rescale to multiple" config option

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/config/ResizeScaleType.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/ResizeScaleType.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2018, Bryan Keller <b@bk.gg>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.config;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ResizeScaleType
+{
+	MULT_NOT_SET("-", 0.),
+	MULT_ONE("1x", 1.),
+	MULT_ONE_AND_HALF("1.5x", 1.5),
+	MULT_TWO("2x", 2.),
+	MULT_TWO_AND_HALF("2.5x", 2.5),
+	MULT_THREE("3x", 3.),
+	MULT_THREE_AND_HALF("3.5x", 3.5),
+	MULT_FOUR("4x", 4.);
+
+	private final String label;
+	private final double multiple;
+
+	@Override
+	public String toString()
+	{
+		return label;
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/config/RuneLiteConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/RuneLiteConfig.java
@@ -42,10 +42,21 @@ public interface RuneLiteConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "resizeToMultiple",
+		name = "Resize to",
+		description = "Set the current client size to a multiple of the minimum size",
+		position = 11
+	)
+	default ResizeScaleType resizeToMultiple()
+	{
+		return ResizeScaleType.MULT_NOT_SET;
+	}
+
+	@ConfigItem(
 		keyName = "automaticResizeType",
 		name = "Resize type",
 		description = "Choose how the window should resize when opening and closing panels",
-		position = 11
+		position = 12
 	)
 	default ExpandResizeType automaticResizeType()
 	{
@@ -56,7 +67,7 @@ public interface RuneLiteConfig extends Config
 		keyName = "lockWindowSize",
 		name = "Lock window size",
 		description = "Determines if the window resizing is allowed or not",
-		position = 12
+		position = 13
 	)
 	default boolean lockWindowSize()
 	{
@@ -67,7 +78,7 @@ public interface RuneLiteConfig extends Config
 		keyName = "containInScreen",
 		name = "Contain in screen",
 		description = "Makes the client stay contained in the screen when attempted to move out of it.<br>Note: Only works if custom chrome is enabled.",
-		position = 13
+		position = 14
 	)
 	default boolean containInScreen()
 	{
@@ -78,7 +89,7 @@ public interface RuneLiteConfig extends Config
 		keyName = "rememberScreenBounds",
 		name = "Remember client position",
 		description = "Save the position and size of the client after exiting",
-		position = 14
+		position = 15
 	)
 	default boolean rememberScreenBounds()
 	{
@@ -90,7 +101,7 @@ public interface RuneLiteConfig extends Config
 		name = "Enable custom window chrome",
 		description = "Use Runelite's custom window title and borders.",
 		warning = "Please restart your client after changing this setting",
-		position = 15
+		position = 16
 	)
 	default boolean enableCustomChrome()
 	{
@@ -101,7 +112,7 @@ public interface RuneLiteConfig extends Config
 		keyName = "gameAlwaysOnTop",
 		name = "Enable client always on top",
 		description = "The game will always be on the top of the screen",
-		position = 16
+		position = 17
 	)
 	default boolean gameAlwaysOnTop()
 	{
@@ -112,7 +123,7 @@ public interface RuneLiteConfig extends Config
 		keyName = "warningOnExit",
 		name = "Display warning on exit",
 		description = "Toggles a warning popup when trying to exit the client",
-		position = 17
+		position = 18
 	)
 	default WarningOnExit warningOnExit()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
@@ -65,6 +65,7 @@ import net.runelite.client.RuneLiteProperties;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.config.ExpandResizeType;
 import net.runelite.client.config.Keybind;
+import net.runelite.client.config.ResizeScaleType;
 import net.runelite.client.config.RuneLiteConfig;
 import net.runelite.client.config.WarningOnExit;
 import net.runelite.client.events.NavigationButtonAdded;
@@ -702,6 +703,13 @@ public class ClientUI
 		if (client == null)
 		{
 			return;
+		}
+
+		if (config.resizeToMultiple() != ResizeScaleType.MULT_NOT_SET) {
+			int width = (int)(Constants.GAME_FIXED_WIDTH * config.resizeToMultiple().getMultiple());
+			int height = (int)(Constants.GAME_FIXED_HEIGHT * config.resizeToMultiple().getMultiple());
+			configManager.setConfiguration(CONFIG_GROUP, "gameSize", new Dimension(width, height));
+			configManager.setConfiguration(CONFIG_GROUP, "resizeToMultiple", ResizeScaleType.MULT_NOT_SET);
 		}
 
 		// The upper bounds are defined by the applet's max size


### PR DESCRIPTION
Adds option next to client dimensions to scale to a particular multiple of the base client size.

Mostly this is because making stretched fixed mode look nice is rather difficult, as you have to calculate the dimensions want every time.

The intent was to have it also update the dimensions in the panel but it looks like RuneLite can't do that. The values are still set, and will be visible when you navigate back to the list of plugins and back into the preferences though.

![2018-10-09_15-26-39_2](https://user-images.githubusercontent.com/7691630/46696685-5721af80-cbd8-11e8-9553-d0b652ea78f1.gif)
