### PR TITLE
Implement locking and corrupted file sanitization to ConfigManager

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/config/ConfigManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/ConfigManager.java
@@ -41,6 +41,7 @@ import java.io.OutputStreamWriter;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.Proxy;
+import java.nio.channels.FileLock;
 import java.nio.charset.Charset;
 import java.time.Instant;
 import java.util.Arrays;
@@ -229,7 +230,16 @@ public class ConfigManager
 
 		try (FileOutputStream out = new FileOutputStream(propertiesFile))
 		{
-			properties.store(new OutputStreamWriter(out, Charset.forName("UTF-8")), "RuneLite configuration");
+			final FileLock lock = out.getChannel().lock();
+
+			try
+			{
+				properties.store(new OutputStreamWriter(out, Charset.forName("UTF-8")), "RuneLite configuration");
+			}
+			finally
+			{
+				lock.release();
+			}
 		}
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/config/ConfigManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/ConfigManager.java
@@ -199,6 +199,7 @@ public class ConfigManager
 				if (split.length != 2)
 				{
 					log.debug("Properties key malformed!: {}", groupAndKey);
+					properties.remove(groupAndKey);
 					return;
 				}
 

--- a/runelite-client/src/main/java/net/runelite/client/config/ConfigManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/ConfigManager.java
@@ -36,9 +36,12 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.Proxy;
+import java.nio.charset.Charset;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -179,7 +182,7 @@ public class ConfigManager
 
 		try (FileInputStream in = new FileInputStream(propertiesFile))
 		{
-			properties.load(in);
+			properties.load(new InputStreamReader(in, Charset.forName("UTF-8")));
 		}
 		catch (FileNotFoundException ex)
 		{
@@ -226,7 +229,7 @@ public class ConfigManager
 
 		try (FileOutputStream out = new FileOutputStream(propertiesFile))
 		{
-			properties.store(out, "RuneLite configuration");
+			properties.store(new OutputStreamWriter(out, Charset.forName("UTF-8")), "RuneLite configuration");
 		}
 	}
 


### PR DESCRIPTION
## Remove invalid properties from map on property load

In order to not have config file flooded with invalid and corrupted
properties in case of file corruption, remove all these invalid
properties from property map on configuration load.

## Use UTF-8 instead of ISO 8859-1 when loading/saving config

In order to prevent failures on reading/writing incorrectly escaped
characters or writing special UTF-8 characters on save as gibberish,
explicitly specify UTF-8 encoding when loading and writing properties.

## Lock configuration file when writing to filesystem

Use OS-wide exclusive lock when writing configuration file to filesystem
to prevent config file corruption when multiple concurrent writers try
to write to same config file at same time.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>

Closes #4853