### PR TITLE
Option to show username when chat input is locked (by WASDCamera plugin).

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/wasdcamera/WASDCameraConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/wasdcamera/WASDCameraConfig.java
@@ -30,9 +30,13 @@ import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
 import net.runelite.client.config.Keybind;
 
+import static net.runelite.client.plugins.wasdcamera.WASDCameraPlugin.PRESS_ENTER_TO_CHAT;
+
 @ConfigGroup("wasdcamera")
 public interface WASDCameraConfig extends Config
 {
+	String KEY_SHOW_USERNAME = "show_username";
+
 	@ConfigItem(
 		position = 1,
 		keyName = "up",
@@ -75,5 +79,16 @@ public interface WASDCameraConfig extends Config
 	default Keybind right()
 	{
 		return new Keybind(KeyEvent.VK_D, 0);
+	}
+
+	@ConfigItem(
+		position = 5,
+		keyName = KEY_SHOW_USERNAME,
+		name = "Show username",
+		description = "Prefixes '" + PRESS_ENTER_TO_CHAT + "' with username."
+	)
+	default boolean showUsername()
+	{
+		return false;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/wasdcamera/WASDCameraPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/wasdcamera/WASDCameraPlugin.java
@@ -28,6 +28,7 @@ package net.runelite.client.plugins.wasdcamera;
 import com.google.common.eventbus.Subscribe;
 import com.google.inject.Provides;
 import java.awt.Color;
+import javax.annotation.Nonnull;
 import javax.inject.Inject;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -36,6 +37,7 @@ import net.runelite.api.Client;
 import net.runelite.api.GameState;
 import net.runelite.api.VarClientInt;
 import net.runelite.api.VarClientStr;
+import net.runelite.api.events.ConfigChanged;
 import net.runelite.api.events.ScriptCallbackEvent;
 import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetInfo;
@@ -46,6 +48,8 @@ import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.util.ColorUtil;
 
+import static net.runelite.client.plugins.wasdcamera.WASDCameraConfig.KEY_SHOW_USERNAME;
+
 @PluginDescriptor(
 	name = "WASD Camera",
 	description = "Allows use of WASD keys for camera movement with 'Press Enter to Chat'",
@@ -54,7 +58,7 @@ import net.runelite.client.util.ColorUtil;
 )
 public class WASDCameraPlugin extends Plugin
 {
-	private static final String PRESS_ENTER_TO_CHAT = "Press Enter to Chat...";
+	static final String PRESS_ENTER_TO_CHAT = "Press Enter to Chat...";
 	private static final String SCRIPT_EVENT_SET_CHATBOX_INPUT = "setChatboxInput";
 	private static final String SCRIPT_EVENT_BLOCK_CHAT_INPUT = "blockChatInput";
 
@@ -66,6 +70,9 @@ public class WASDCameraPlugin extends Plugin
 
 	@Inject
 	private KeyManager keyManager;
+
+	@Inject
+	private WASDCameraConfig config;
 
 	@Inject
 	private WASDCameraListener inputListener;
@@ -139,7 +146,7 @@ public class WASDCameraPlugin extends Plugin
 				{
 					if (chatboxFocused() && !typing)
 					{
-						chatboxInput.setText(PRESS_ENTER_TO_CHAT);
+						hideChatInput(chatboxInput);
 					}
 				}
 				break;
@@ -154,6 +161,15 @@ public class WASDCameraPlugin extends Plugin
 		}
 	}
 
+	@Subscribe
+	public void onConfigChanged(ConfigChanged ev)
+	{
+		if (KEY_SHOW_USERNAME.equals(ev.getKey()) && !typing)
+		{
+		    lockChat();
+		}
+	}
+
 	void lockChat()
 	{
 		Widget chatboxParent = client.getWidget(WidgetInfo.CHATBOX_PARENT);
@@ -162,7 +178,7 @@ public class WASDCameraPlugin extends Plugin
 			Widget chatboxInput = client.getWidget(WidgetInfo.CHATBOX_INPUT);
 			if (chatboxInput != null)
 			{
-				chatboxInput.setText(PRESS_ENTER_TO_CHAT);
+				hideChatInput(chatboxInput);
 			}
 		}
 	}
@@ -181,5 +197,21 @@ public class WASDCameraPlugin extends Plugin
 				}
 			}
 		}
+	}
+
+    /**
+     * Helper function used to update the chatbox input field once the chat
+     * has been locked.
+     *
+     * @param chatboxInput Non-null chatbox input widget.
+     */
+	private void hideChatInput(@Nonnull Widget chatboxInput) {
+		String prefix = "";
+
+		if (config.showUsername()) {
+			prefix = client.getLocalPlayer().getName() + ": ";
+		}
+
+		chatboxInput.setText(prefix + PRESS_ENTER_TO_CHAT);
 	}
 }


### PR DESCRIPTION
**Proposed Changes**:
- Add a toggle to prefix the chat prompt with the username when the chat input is disabled.

**Assets**:
Additional config entry to toggle username (disabled by default).
<img width="262" alt="screen shot 2018-10-10 at 6 53 14 am" src="https://user-images.githubusercontent.com/6403614/46731635-32215100-cc59-11e8-97fc-94c0af27148e.png">

Expected result:
<img width="179" alt="screen shot 2018-10-10 at 6 56 01 am" src="https://user-images.githubusercontent.com/6403614/46731777-980dd880-cc59-11e8-9918-8602b957ec18.png">

