### PR TITLE
Move raid scouter layout to title

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsOverlay.java
@@ -51,7 +51,7 @@ public class RaidsOverlay extends Overlay
 	private boolean scoutOverlayShown = false;
 
 	@Inject
-	public RaidsOverlay(Client client, RaidsPlugin plugin, RaidsConfig config)
+	private RaidsOverlay(Client client, RaidsPlugin plugin, RaidsConfig config)
 	{
 		setPosition(OverlayPosition.TOP_LEFT);
 		setPriority(OverlayPriority.LOW);
@@ -80,10 +80,6 @@ public class RaidsOverlay extends Overlay
 			return panelComponent.render(graphics);
 		}
 
-		panelComponent.getChildren().add(TitleComponent.builder()
-			.text("Raid scouter")
-			.build());
-
 		Color color = Color.WHITE;
 		String layout = plugin.getRaid().getLayout().toCode().replaceAll("#", "").replaceAll("¤", "");
 
@@ -92,10 +88,9 @@ public class RaidsOverlay extends Overlay
 			color = Color.RED;
 		}
 
-		panelComponent.getChildren().add(LineComponent.builder()
-			.left("Layout")
-			.right(layout)
-			.rightColor(color)
+		panelComponent.getChildren().add(TitleComponent.builder()
+			.text(layout)
+			.color(color)
 			.build());
 
 		int bossMatches = 0;


### PR DESCRIPTION
- Remove "Raid scouter" title
- Move raid layout to title instead

This change is because the raid scouter is quite big and now that it can
be persisted after raid starts, it is a bit annoying in fixed mode.
Also, the title is effectively useless as it is visible only in raid and
it is quite obvious what is it.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>