### PR TITLE
Fix tags resetting when bank window is closed and active tab matching for long tags

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/banktags/BankTagsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/banktags/BankTagsPlugin.java
@@ -32,6 +32,7 @@ import com.google.common.eventbus.Subscribe;
 import com.google.inject.Provides;
 import java.awt.event.MouseWheelEvent;
 import java.util.Arrays;
+import java.util.Objects;
 import javax.inject.Inject;
 import net.runelite.api.Client;
 import net.runelite.api.InventoryID;
@@ -40,6 +41,7 @@ import net.runelite.api.ItemComposition;
 import net.runelite.api.ItemContainer;
 import net.runelite.api.MenuAction;
 import net.runelite.api.MenuEntry;
+import net.runelite.api.VarClientStr;
 import net.runelite.api.events.ConfigChanged;
 import net.runelite.api.events.DraggingWidgetChanged;
 import net.runelite.api.events.GameTick;
@@ -248,7 +250,7 @@ public class BankTagsPlugin extends Plugin implements MouseWheelListener
 
 			chatboxInputManager.openInputWindow(itemName + " tags:", initialValue, (newTags) ->
 			{
-				if (newTags == null)
+				if (!Objects.equals(newTags, client.getVar(VarClientStr.INPUT_TEXT)))
 				{
 					return;
 				}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/banktags/tabs/TabInterface.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/banktags/tabs/TabInterface.java
@@ -240,7 +240,7 @@ public class TabInterface
 		}
 
 		Widget bankTitle = client.getWidget(WidgetInfo.BANK_TITLE_BAR);
-		if (bankTitle != null && !bankTitle.isHidden())
+		if (bankTitle != null && !bankTitle.isHidden() && !str.startsWith(TAG_SEARCH))
 		{
 			str = bankTitle.getText().replaceFirst("Showing items: ", "");
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/banktags/tabs/TabInterface.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/banktags/tabs/TabInterface.java
@@ -224,6 +224,14 @@ public class TabInterface
 			return;
 		}
 
+		if (activeTab != null && client.getVar(VarClientInt.INPUT_TYPE) == InputType.RUNELITE.getType())
+		{
+			// don't reset active tab if we are editing tags
+			updateBounds();
+			scrollTab(0);
+			return;
+		}
+
 		String str = client.getVar(VarClientStr.INPUT_TEXT);
 
 		if (Strings.isNullOrEmpty(str))


### PR DESCRIPTION
Closes: https://github.com/runelite/runelite/issues/3561

Also fixes active tab unactivating with long tags and editing tags

