### PR TITLE
Do not reset equipment/inventory in clues croll plugin each tick

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/ClueScrollPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/ClueScrollPlugin.java
@@ -290,8 +290,6 @@ public class ClueScrollPlugin extends Plugin
 	public void onGameTick(final GameTick event)
 	{
 		objectsToMark = null;
-		equippedItems = null;
-		inventoryItems = null;
 
 		if (clue instanceof LocationsClueScroll)
 		{


### PR DESCRIPTION
Because it is now updated from changed events, this will simply make the
item reqs not work.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>