### PR TITLE
Update to BA plugin:

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/barbarianassault/BarbarianAssaultConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/barbarianassault/BarbarianAssaultConfig.java
@@ -43,6 +43,16 @@ public interface BarbarianAssaultConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "secondsTimer",
+		name = "Show elapsed seconds",
+		description = "Instead of showing the call change timer, the wave elapsed time will be shown (in seconds)"
+	)
+	default boolean secondsTimer()
+	{
+		return false;
+	}
+
+	@ConfigItem(
 		keyName = "waveTimes",
 		name = "Show wave and game duration",
 		description = "Displays wave and game duration"

--- a/runelite-client/src/main/java/net/runelite/client/plugins/barbarianassault/BarbarianAssaultConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/barbarianassault/BarbarianAssaultConfig.java
@@ -44,8 +44,8 @@ public interface BarbarianAssaultConfig extends Config
 
 	@ConfigItem(
 		keyName = "secondsTimer",
-		name = "Show elapsed seconds",
-		description = "Instead of showing the call change timer, the wave elapsed time will be shown (in seconds)"
+		name = "Show elapsed seconds of wave",
+		description = "Show the elapsed time of the current wave (in seconds)"
 	)
 	default boolean secondsTimer()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/barbarianassault/BarbarianAssaultOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/barbarianassault/BarbarianAssaultOverlay.java
@@ -75,9 +75,18 @@ class BarbarianAssaultOverlay extends Overlay
 		Widget roleText = client.getWidget(role.getRoleText());
 		Widget roleSprite = client.getWidget(role.getRoleSprite());
 
-		if (config.showTimer() && roleText != null && roleSprite != null)
+		if ((config.showTimer() || config.secondsTimer()) && roleText != null && roleSprite != null)
 		{
-			roleText.setText(String.format("00:%02d", currentRound.getTimeToChange()));
+			if (config.showTimer() && config.secondsTimer())
+			{
+				roleText.setText(String.format("00:%02d (%d)", currentRound.getTimeToChange(), currentRound.getRoundTime()));
+			}
+			else
+			{
+				roleText.setText(config.showTimer() ? String.format("00:%02d", currentRound.getTimeToChange())
+					: String.format("%d", currentRound.getRoundTime()));
+			}
+
 			Rectangle spriteBounds = roleSprite.getBounds();
 			roleSprite.setHidden(true);
 			graphics.drawImage(plugin.getClockImage(), spriteBounds.x, spriteBounds.y, null);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/barbarianassault/BarbarianAssaultPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/barbarianassault/BarbarianAssaultPlugin.java
@@ -120,6 +120,7 @@ public class BarbarianAssaultPlugin extends Plugin
 			if (config.waveTimes() && rewardWidget != null && rewardWidget.getText().contains(ENDGAME_REWARD_NEEDLE_TEXT) && gameTime != null)
 			{
 				announceTime("Game finished, duration: ", gameTime.getTime(false));
+				gameTime = null;
 			}
 		}
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/barbarianassault/GameTimer.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/barbarianassault/GameTimer.java
@@ -48,7 +48,7 @@ class GameTimer
 			elapsed = Duration.between(startTime, now).minusMillis(600);
 		}
 
-		return formatTime(LocalTime.ofSecondOfDay(elapsed.getSeconds()));
+		return formatTime(LocalTime.ofSecondOfDay(Math.round((double)elapsed.toMillis() / 1000)));
 	}
 
 	void setWaveStartTime()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/barbarianassault/Round.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/barbarianassault/Round.java
@@ -57,7 +57,7 @@ class Round
 
 	public long getRoundTime()
 	{
-		return Duration.between(roundStartTime, Instant.now()).getSeconds();
+		return Duration.between(roundStartTime.minusMillis(1000), Instant.now()).getSeconds();
 	}
 
 	public long getTimeToChange()


### PR DESCRIPTION
- Fixed this: https://i.imgur.com/APUYSyL.jpg by nulling the GameTimer when the game is complete.
- Added an option (by popular demand) that shows the round time (in seconds) instead of the call change time (off by default).
- Fix a rounding issue with the timer, by rounding Duration.toMillis() instead of just using the Duration.getSeconds() (which was always rounded down)