### PR TITLE
Don't fetch itemid of Change Icon menu option on tabs

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/banktags/tabs/TabInterface.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/banktags/tabs/TabInterface.java
@@ -320,7 +320,7 @@ public class TabInterface
 
 		if (iconToSet != null)
 		{
-			if (event.getMenuOption().startsWith(CHANGE_ICON))
+			if (event.getMenuOption().startsWith(CHANGE_ICON + " ("))
 			{
 				ItemComposition item = getItem(event.getActionParam());
 				int itemId = itemManager.canonicalize(item.getId());


### PR DESCRIPTION
Fixes an issue reported from IRC/discord.

```
When I have three bank tag tabs, third bank tag tab in focus; When I right click second tag tab and "change icon", then immediately click "change icon" again to cancel that action, my icon changes (to a dust rune). This does not happen when I do the same to my tag tab in focus.

Similarly, the bug happens with first bank tag tab except it turns into a mist rune. The two runes aren't next to each other in the actual bank tab (there's an earth rune in between).
```