### PR TITLE
Add support for mouse tooltip icons

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/mousehighlight/MouseHighlightConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/mousehighlight/MouseHighlightConfig.java
@@ -31,6 +31,13 @@ import net.runelite.client.config.ConfigItem;
 @ConfigGroup("mousehighlight")
 public interface MouseHighlightConfig extends Config
 {
+	enum TooltipMode
+	{
+		TEXT,
+		ICON,
+		BOTH
+	}
+
 	@ConfigItem(
 		position = 0,
 		keyName = "uiTooltip",
@@ -51,5 +58,16 @@ public interface MouseHighlightConfig extends Config
 	default boolean chatboxTooltip()
 	{
 		return true;
+	}
+
+	@ConfigItem(
+		position = 2,
+		keyName = "tooltipMode",
+		name = "Tooltip Mode",
+		description = "What type of tooltips should mouse highlighting display"
+	)
+	default TooltipMode tooltipMode()
+	{
+		return TooltipMode.TEXT;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/mousehighlight/MouseHighlightOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/mousehighlight/MouseHighlightOverlay.java
@@ -27,14 +27,19 @@ package net.runelite.client.plugins.mousehighlight;
 import com.google.common.base.Strings;
 import java.awt.Dimension;
 import java.awt.Graphics2D;
+import java.awt.Image;
 import javax.inject.Inject;
 import net.runelite.api.Client;
 import net.runelite.api.MenuEntry;
+import net.runelite.api.SpriteID;
 import net.runelite.api.VarClientInt;
 import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetInfo;
+import net.runelite.client.game.SpriteManager;
 import net.runelite.client.ui.overlay.Overlay;
+import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.OverlayPriority;
 import net.runelite.client.ui.overlay.tooltip.Tooltip;
 import net.runelite.client.ui.overlay.tooltip.TooltipManager;
 
@@ -43,14 +48,18 @@ class MouseHighlightOverlay extends Overlay
 	private final TooltipManager tooltipManager;
 	private final Client client;
 	private final MouseHighlightConfig config;
+	private final SpriteManager spriteManager;
 
 	@Inject
-	MouseHighlightOverlay(Client client, TooltipManager tooltipManager, MouseHighlightConfig config)
+	MouseHighlightOverlay(Client client, TooltipManager tooltipManager, MouseHighlightConfig config, SpriteManager spriteManager)
 	{
 		setPosition(OverlayPosition.DYNAMIC);
+		setPriority(OverlayPriority.HIGHEST);
+		setLayer(OverlayLayer.ALWAYS_ON_TOP);
 		this.client = client;
 		this.tooltipManager = tooltipManager;
 		this.config = config;
+		this.spriteManager = spriteManager;
 	}
 
 	@Override
@@ -125,7 +134,50 @@ class MouseHighlightOverlay extends Overlay
 			return null;
 		}
 
-		tooltipManager.addFront(new Tooltip(option + (Strings.isNullOrEmpty(target) ? "" : " " + target)));
+		Image image = null;
+
+		if (config.tooltipMode() != MouseHighlightConfig.TooltipMode.TEXT)
+		{
+			switch (menuEntry.getOption())
+			{
+				case "Take":
+					image = spriteManager.getSprite(SpriteID.MAP_ICON_STAFF_SHOP, 0);
+					break;
+				case "Talk-to":
+					image = spriteManager.getSprite(SpriteID.MAP_ICON_MAKEOVER_MAGE, 0);
+					break;
+				case "Bank":
+					image = spriteManager.getSprite(SpriteID.MAP_ICON_BANK, 0);
+					break;
+				case "Eat":
+					image = spriteManager.getSprite(SpriteID.MAP_ICON_FOOD_SHOP_FRUIT, 0);
+					break;
+				case "Wear":
+				case "Wield":
+					image = spriteManager.getSprite(SpriteID.MAP_ICON_CLOTHES_SHOP, 0);
+					break;
+				case "Destroy":
+					image = spriteManager.getSprite(SpriteID.MAP_ICON_DUNGEON, 0);
+					break;
+				case "Attack":
+					image = spriteManager.getSprite(SpriteID.MAP_ICON_SWORD_SHOP, 0);
+					break;
+				case "Examine":
+					image = spriteManager.getSprite(SpriteID.MAP_ICON_GUIDE, 0);
+					break;
+				case "Catch":
+					image = spriteManager.getSprite(SpriteID.MAP_ICON_HUNTER_TRAINING, 0);
+					break;
+				case "Exchange":
+				case "Buy":
+				case "Sell":
+					image = spriteManager.getSprite(SpriteID.MAP_ICON_GRAND_EXCHANGE, 0);
+					break;
+			}
+		}
+
+		final String text = option + (Strings.isNullOrEmpty(target) ? "" : " " + target);
+		tooltipManager.addFront(new Tooltip(config.tooltipMode() != MouseHighlightConfig.TooltipMode.ICON ? text : null, image));
 		return null;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/components/TooltipComponent.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/components/TooltipComponent.java
@@ -24,10 +24,12 @@
  */
 package net.runelite.client.ui.overlay.components;
 
+import com.google.common.base.Strings;
 import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.FontMetrics;
 import java.awt.Graphics2D;
+import java.awt.Image;
 import java.awt.Point;
 import java.awt.Rectangle;
 import java.util.regex.Pattern;
@@ -43,6 +45,7 @@ public class TooltipComponent implements RenderableEntity
 	private static final int MOD_ICON_WIDTH = 13; // they are generally 13px wide
 
 	private String text;
+	private Image image;
 	private Color backgroundColor = ComponentConstants.STANDARD_BACKGROUND_COLOR;
 	private Point position = new Point();
 	private IndexedSprite[] modIcons;
@@ -50,6 +53,29 @@ public class TooltipComponent implements RenderableEntity
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
+		// Tooltip position
+		int x = position.x;
+		int y = position.y;
+
+		// Render tooltip image
+		if (image != null)
+		{
+			int width = image.getWidth(null);
+			int height = image.getHeight(null);
+			graphics.drawImage(image, x, y + OFFSET / 2, width, height, null);
+			x += width + OFFSET;
+		}
+
+		if (Strings.isNullOrEmpty(text))
+		{
+			if (image == null)
+			{
+				return null;
+			}
+
+			return new Dimension(image.getWidth(null) + OFFSET * 2, image.getHeight(null) + OFFSET * 2);
+		}
+
 		// Tooltip size
 		final FontMetrics metrics = graphics.getFontMetrics();
 		final int textDescent = metrics.getDescent();
@@ -70,10 +96,6 @@ public class TooltipComponent implements RenderableEntity
 
 			tooltipHeight += textHeight;
 		}
-
-		// Tooltip position
-		int x = position.x;
-		int y = position.y;
 
 		// Render tooltip - background
 		final Rectangle tooltipBackground = new Rectangle(x, y,
@@ -154,7 +176,7 @@ public class TooltipComponent implements RenderableEntity
 			// Draw trailing text (after last tag)
 			final TextComponent textComponent = new TextComponent();
 			textComponent.setColor(nextColor);
-			textComponent.setText(line.substring(begin, line.length()));
+			textComponent.setText(line.substring(begin));
 			textComponent.setPosition(new Point(lineX, textY + (i + 1) * textHeight - textDescent));
 			textComponent.render(graphics);
 		}

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/tooltip/Tooltip.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/tooltip/Tooltip.java
@@ -24,12 +24,24 @@
  */
 package net.runelite.client.ui.overlay.tooltip;
 
+import java.awt.Image;
 import lombok.AllArgsConstructor;
-import lombok.Data;
+import lombok.Getter;
 
-@Data
 @AllArgsConstructor
+@Getter
 public class Tooltip
 {
-	private final String text;
+	private String text;
+	private Image image;
+
+	public Tooltip(final String text)
+	{
+		this.text = text;
+	}
+
+	public Tooltip(final Image image)
+	{
+		this.image = image;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/tooltip/TooltipOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/tooltip/TooltipOverlay.java
@@ -97,6 +97,7 @@ public class TooltipOverlay extends Overlay
 			final TooltipComponent tooltipComponent = new TooltipComponent();
 			tooltipComponent.setModIcons(client.getModIcons());
 			tooltipComponent.setText(tooltip.getText());
+			tooltipComponent.setImage(tooltip.getImage());
 
 			if (newBounds.contains(mousePosition))
 			{
@@ -105,6 +106,11 @@ public class TooltipOverlay extends Overlay
 
 			tooltipComponent.setPosition(mousePosition);
 			final Dimension dimension = tooltipComponent.render(graphics);
+
+			if (dimension == null)
+			{
+				continue;
+			}
 
 			// Create incremental tooltip newBounds
 			newBounds.x = newBounds.x != -1 ? Math.min(newBounds.x, mousePosition.x) : mousePosition.x;


### PR DESCRIPTION
- Add support for setting image to Tooltip and rendering it before text.
- Add support for showing item image tooltips next to text tooltip to
MouseHighlightingPlugin (disabled by default)

Preview:
![peek 2018-10-13 01-41](https://user-images.githubusercontent.com/5115805/46898352-33d15b80-ce89-11e8-9543-809b4661ef7c.gif)
