### PR TITLE
Disable bury and harpoon swaps by default

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -72,7 +72,7 @@ public interface MenuEntrySwapperConfig extends Config
 	)
 	default boolean swapBones()
 	{
-		return true;
+		return false;
 	}
 
 	@ConfigItem(
@@ -127,7 +127,7 @@ public interface MenuEntrySwapperConfig extends Config
 	)
 	default boolean swapHarpoon()
 	{
-		return true;
+		return false;
 	}
 
 	@ConfigItem(


### PR DESCRIPTION
Even though the swapper plugin is disabled by default, many people
enable it and these defaults are very niche and annoying in some
scenarios.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>