### PR TITLE
Update slayer task based on VarPlayer value if available

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/VarPlayer.java
+++ b/runelite-api/src/main/java/net/runelite/api/VarPlayer.java
@@ -47,6 +47,8 @@ public enum VarPlayer
 
 	NMZ_REWARD_POINTS(1060),
 
+	SLAYER_TARGETS_LEFT(261),
+
 	/**
 	 * 0 : not started
 	 * greater than 0 : in progress

--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerPlugin.java
@@ -49,6 +49,7 @@ import net.runelite.api.ItemID;
 import net.runelite.api.NPC;
 import net.runelite.api.NPCComposition;
 import static net.runelite.api.Skill.SLAYER;
+import net.runelite.api.VarPlayer;
 import net.runelite.api.events.ChatMessage;
 import net.runelite.api.events.ConfigChanged;
 import net.runelite.api.events.ExperienceChanged;
@@ -56,6 +57,7 @@ import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.GameTick;
 import net.runelite.api.events.NpcDespawned;
 import net.runelite.api.events.NpcSpawned;
+import net.runelite.api.events.VarbitChanged;
 import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.Notifier;
@@ -256,6 +258,17 @@ public class SlayerPlugin extends Plugin
 		NPC npc = npcDespawned.getNpc();
 		highlightedTargets.remove(npc);
 	}
+
+	@Subscribe
+	public void onVarbitChanged(VarbitChanged event)
+	{
+		int slayerTargetsLeft = client.getVar(VarPlayer.SLAYER_TARGETS_LEFT);
+		if (slayerTargetsLeft > 0 && taskName != null)
+		{
+			setTask(taskName, slayerTargetsLeft);
+		}
+	}
+
 
 	@Subscribe
 	public void onGameTick(GameTick tick)


### PR DESCRIPTION
When opening the slayer reward shop it will update your remaining task count granted runelite already knows what task you have.



Closes https://github.com/runelite/runelite/issues/5984