### PR TITLE
Add option for Minimap Orbs to be left aligned

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/minimap/AlignmentMode.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/minimap/AlignmentMode.java
@@ -1,3 +1,27 @@
+/*
+ * Copyright (c) 2018, Hydrox6 <ikada@protonmail.ch>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package net.runelite.client.plugins.minimap;
 
 public enum AlignmentMode

--- a/runelite-client/src/main/java/net/runelite/client/plugins/minimap/AlignmentMode.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/minimap/AlignmentMode.java
@@ -1,0 +1,22 @@
+package net.runelite.client.plugins.minimap;
+
+public enum AlignmentMode
+{
+	OFF("Off"),
+	FIXED("Fixed"),
+	RESIZEABLE("Resizeable"),
+	BOTH("Both");
+
+	private final String name;
+
+	AlignmentMode(String name)
+	{
+		this.name = name;
+	}
+
+	@Override
+	public String toString()
+	{
+		return name;
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/minimap/MinimapConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/minimap/MinimapConfig.java
@@ -101,4 +101,14 @@ public interface MinimapConfig extends Config
 	{
 		return false;
 	}
+
+	@ConfigItem(
+		keyName = "leftAlignOrbs",
+		name = "Left Align Orbs",
+		description = "Align the Health, Prayer, Run and Special Attack orbs to the left."
+	)
+	default boolean leftAlignOrbs()
+	{
+		return false;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/minimap/MinimapConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/minimap/MinimapConfig.java
@@ -107,8 +107,8 @@ public interface MinimapConfig extends Config
 		name = "Left Align Orbs",
 		description = "Align the Health, Prayer, Run and Special Attack orbs to the left."
 	)
-	default boolean leftAlignOrbs()
+	default AlignmentMode leftAlignOrbs()
 	{
-		return false;
+		return AlignmentMode.OFF;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/minimap/MinimapPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/minimap/MinimapPlugin.java
@@ -35,7 +35,9 @@ import net.runelite.api.SpritePixels;
 import net.runelite.api.events.ConfigChanged;
 import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.WidgetHiddenChanged;
+import net.runelite.api.events.WidgetLoaded;
 import net.runelite.api.widgets.Widget;
+import net.runelite.api.widgets.WidgetID;
 import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.plugins.Plugin;
@@ -101,6 +103,18 @@ public class MinimapPlugin extends Plugin
 		{
 			updateMinimapWidgetVisibility(config.hideMinimap());
 			return;
+		}
+
+		if (event.getKey().equals("leftAlignOrbs"))
+		{
+			if (config.leftAlignOrbs())
+			{
+				moveOrbs();
+			}
+			else
+			{
+				resetOrbs();
+			}
 		}
 
 		replaceMapDots();
@@ -186,5 +200,88 @@ public class MinimapPlugin extends Plugin
 		}
 
 		System.arraycopy(originalDotSprites, 0, mapDots, 0, mapDots.length);
+	}
+	@Subscribe
+	public void onWidgetLoaded(WidgetLoaded event)
+	{
+		if (event.getGroupId() == WidgetID.MINIMAP_GROUP_ID)
+		{
+			if (config.leftAlignOrbs())
+			{
+				moveOrbs();
+			}
+		}
+	}
+
+	private void moveOrbs()
+	{
+		Widget healthOrb = client.getWidget(WidgetInfo.MINIMAP_HEALTH_ORB);
+		Widget prayerOrb = client.getWidget(WidgetInfo.MINIMAP_PRAYER_ORB);
+		Widget runOrb = client.getWidget(WidgetInfo.MINIMAP_RUN_ORB);
+		Widget specOrb = client.getWidget(WidgetInfo.MINIMAP_SPEC_ORB);
+
+		if (healthOrb != null)
+		{
+			healthOrb.setRelativeY(33);
+			healthOrb.setOriginalY(33);
+		}
+
+		if (prayerOrb != null)
+		{
+			prayerOrb.setRelativeY(65);
+			prayerOrb.setOriginalY(65);
+		}
+
+		if (runOrb != null)
+		{
+			runOrb.setRelativeX(0);
+			runOrb.setRelativeY(97);
+			runOrb.setOriginalX(0);
+			runOrb.setOriginalY(97);
+		}
+
+		if (specOrb != null)
+		{
+			specOrb.setRelativeX(0);
+			specOrb.setRelativeY(129);
+			specOrb.setOriginalX(0);
+			specOrb.setOriginalY(129);
+		}
+	}
+
+	private void resetOrbs()
+	{
+		Widget healthOrb = client.getWidget(WidgetInfo.MINIMAP_HEALTH_ORB);
+		Widget prayerOrb = client.getWidget(WidgetInfo.MINIMAP_PRAYER_ORB);
+		Widget runOrb = client.getWidget(WidgetInfo.MINIMAP_RUN_ORB);
+		Widget specOrb = client.getWidget(WidgetInfo.MINIMAP_SPEC_ORB);
+
+		if (healthOrb != null)
+		{
+			healthOrb.setRelativeY(37);
+			healthOrb.setOriginalY(37);
+		}
+
+		if (prayerOrb != null)
+		{
+			prayerOrb.setRelativeY(71);
+			prayerOrb.setOriginalY(71);
+		}
+
+		if (runOrb != null)
+		{
+			runOrb.setRelativeX(10);
+			runOrb.setRelativeY(103);
+			runOrb.setOriginalX(10);
+			runOrb.setOriginalY(103);
+		}
+
+		if (specOrb != null)
+		{
+			specOrb.setRelativeX(32);
+			specOrb.setRelativeY(128);
+			specOrb.setOriginalX(32);
+			specOrb.setOriginalY(128);
+		}
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/minimap/MinimapPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/minimap/MinimapPlugin.java
@@ -24,10 +24,12 @@
  */
 package net.runelite.client.plugins.minimap;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.eventbus.Subscribe;
 import com.google.inject.Provides;
 import java.awt.Color;
 import java.util.Arrays;
+import java.util.List;
 import javax.inject.Inject;
 import net.runelite.api.Client;
 import net.runelite.api.GameState;
@@ -52,6 +54,21 @@ import net.runelite.client.plugins.PluginDescriptor;
 public class MinimapPlugin extends Plugin
 {
 	private static final int NUM_MAPDOTS = 6;
+
+	private static List<WidgetInfo> orbs = ImmutableList
+		.<WidgetInfo>builder()
+		.add(WidgetInfo.MINIMAP_HEALTH_ORB)
+		.add(WidgetInfo.MINIMAP_PRAYER_ORB)
+		.add(WidgetInfo.MINIMAP_RUN_ORB)
+		.add(WidgetInfo.MINIMAP_SPEC_ORB)
+		.build();
+
+	private static int[][] orbDefaultPositions = {
+		{-1, -1, -1, -1},
+		{-1, -1, -1, -1},
+		{-1, -1, -1, -1},
+		{-1, -1, -1, -1}
+	};
 
 	@Inject
 	private Client client;
@@ -263,73 +280,55 @@ public class MinimapPlugin extends Plugin
 
 	private void moveOrbs()
 	{
-		Widget healthOrb = client.getWidget(WidgetInfo.MINIMAP_HEALTH_ORB);
-		Widget prayerOrb = client.getWidget(WidgetInfo.MINIMAP_PRAYER_ORB);
-		Widget runOrb = client.getWidget(WidgetInfo.MINIMAP_RUN_ORB);
-		Widget specOrb = client.getWidget(WidgetInfo.MINIMAP_SPEC_ORB);
-
-		if (healthOrb != null)
+		for (int i = 0; i < orbs.size(); i++)
 		{
-			healthOrb.setRelativeY(33);
-			healthOrb.setOriginalY(33);
-		}
+			Widget widget = client.getWidget(orbs.get(i));
+			if (widget != null)
+			{
+				//Back up default widget positions before they are changed
+				if (orbDefaultPositions[i][0] == -1)
+				{
+					orbDefaultPositions[i] = new int[]{
+						widget.getOriginalX(),
+						widget.getRelativeX(),
+						widget.getOriginalY(),
+						widget.getRelativeY()};
+				}
+				widget.setOriginalX(1);
+				widget.setRelativeX(1);
 
-		if (prayerOrb != null)
-		{
-			prayerOrb.setRelativeY(65);
-			prayerOrb.setOriginalY(65);
-		}
-
-		if (runOrb != null)
-		{
-			runOrb.setRelativeX(0);
-			runOrb.setRelativeY(97);
-			runOrb.setOriginalX(0);
-			runOrb.setOriginalY(97);
-		}
-
-		if (specOrb != null)
-		{
-			specOrb.setRelativeX(0);
-			specOrb.setRelativeY(129);
-			specOrb.setOriginalX(0);
-			specOrb.setOriginalY(129);
+				widget.setOriginalY(((i + 1) * 32) + 3);
+				widget.setRelativeY(((i + 1) * 32) + 3);
+			}
 		}
 	}
 
 	private void resetOrbs()
 	{
-		Widget healthOrb = client.getWidget(WidgetInfo.MINIMAP_HEALTH_ORB);
-		Widget prayerOrb = client.getWidget(WidgetInfo.MINIMAP_PRAYER_ORB);
-		Widget runOrb = client.getWidget(WidgetInfo.MINIMAP_RUN_ORB);
-		Widget specOrb = client.getWidget(WidgetInfo.MINIMAP_SPEC_ORB);
-
-		if (healthOrb != null)
+		for (int i = 0; i < orbs.size(); i++)
 		{
-			healthOrb.setRelativeY(37);
-			healthOrb.setOriginalY(37);
-		}
+			Widget widget = client.getWidget(orbs.get(i));
+			if (widget != null)
+			{
+				//Set widget backup before it's used below
+				if (orbDefaultPositions[i][0] == -1)
+				{
+					orbDefaultPositions[i] = new int[]{
+						widget.getOriginalX(),
+						widget.getRelativeX(),
+						widget.getOriginalY(),
+						widget.getRelativeY()};
+				}
+				int[] positions = orbDefaultPositions[i];
+				if (positions[0] != -1)
+				{
+					widget.setOriginalX(positions[0]);
+					widget.setRelativeX(positions[1]);
 
-		if (prayerOrb != null)
-		{
-			prayerOrb.setRelativeY(71);
-			prayerOrb.setOriginalY(71);
-		}
-
-		if (runOrb != null)
-		{
-			runOrb.setRelativeX(10);
-			runOrb.setRelativeY(103);
-			runOrb.setOriginalX(10);
-			runOrb.setOriginalY(103);
-		}
-
-		if (specOrb != null)
-		{
-			specOrb.setRelativeX(32);
-			specOrb.setRelativeY(128);
-			specOrb.setOriginalX(32);
-			specOrb.setOriginalY(128);
+					widget.setOriginalY(positions[2]);
+					widget.setRelativeY(positions[3]);
+				}
+			}
 		}
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/minimap/MinimapPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/minimap/MinimapPlugin.java
@@ -70,6 +70,10 @@ public class MinimapPlugin extends Plugin
 		{-1, -1, -1, -1}
 	};
 
+	private static int orbHeight = 32;
+	private static int orbXOffset = 1;
+	private static int orbYOffset = 3;
+
 	@Inject
 	private Client client;
 
@@ -294,11 +298,11 @@ public class MinimapPlugin extends Plugin
 						widget.getOriginalY(),
 						widget.getRelativeY()};
 				}
-				widget.setOriginalX(1);
-				widget.setRelativeX(1);
+				widget.setOriginalX(orbXOffset);
+				widget.setRelativeX(orbXOffset);
 
-				widget.setOriginalY(((i + 1) * 32) + 3);
-				widget.setRelativeY(((i + 1) * 32) + 3);
+				widget.setOriginalY(((i + 1) * orbHeight) + orbYOffset);
+				widget.setRelativeY(((i + 1) * orbHeight) + orbYOffset);
 			}
 		}
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/minimap/MinimapPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/minimap/MinimapPlugin.java
@@ -34,6 +34,7 @@ import net.runelite.api.GameState;
 import net.runelite.api.SpritePixels;
 import net.runelite.api.events.ConfigChanged;
 import net.runelite.api.events.GameStateChanged;
+import net.runelite.api.events.ResizeableChanged;
 import net.runelite.api.events.WidgetHiddenChanged;
 import net.runelite.api.events.WidgetLoaded;
 import net.runelite.api.widgets.Widget;
@@ -107,9 +108,24 @@ public class MinimapPlugin extends Plugin
 
 		if (event.getKey().equals("leftAlignOrbs"))
 		{
-			if (config.leftAlignOrbs())
+			if (config.leftAlignOrbs() != AlignmentMode.OFF)
 			{
-				moveOrbs();
+				if (config.leftAlignOrbs() == AlignmentMode.BOTH)
+				{
+					moveOrbs();
+				}
+				else if (!client.isResized() && config.leftAlignOrbs() == AlignmentMode.FIXED)
+				{
+					moveOrbs();
+				}
+				else if (client.isResized() && config.leftAlignOrbs() == AlignmentMode.RESIZEABLE)
+				{
+					moveOrbs();
+				}
+				else
+				{
+					resetOrbs();
+				}
 			}
 			else
 			{
@@ -118,6 +134,27 @@ public class MinimapPlugin extends Plugin
 		}
 
 		replaceMapDots();
+	}
+
+	@Subscribe
+	public void onResizeableChanged(ResizeableChanged event)
+	{
+		if (config.leftAlignOrbs() == AlignmentMode.BOTH)
+		{
+			moveOrbs();
+		}
+		else if (!client.isResized() && config.leftAlignOrbs() == AlignmentMode.FIXED)
+		{
+			moveOrbs();
+		}
+		else if (client.isResized() && config.leftAlignOrbs() == AlignmentMode.RESIZEABLE)
+		{
+			moveOrbs();
+		}
+		else
+		{
+			resetOrbs();
+		}
 	}
 
 	@Subscribe
@@ -206,9 +243,20 @@ public class MinimapPlugin extends Plugin
 	{
 		if (event.getGroupId() == WidgetID.MINIMAP_GROUP_ID)
 		{
-			if (config.leftAlignOrbs())
+			if (config.leftAlignOrbs() != AlignmentMode.OFF)
 			{
-				moveOrbs();
+				if (config.leftAlignOrbs() == AlignmentMode.BOTH)
+				{
+					moveOrbs();
+				}
+				else if (!client.isResized() && config.leftAlignOrbs() == AlignmentMode.FIXED)
+				{
+					moveOrbs();
+				}
+				else if (client.isResized() && config.leftAlignOrbs() == AlignmentMode.RESIZEABLE)
+				{
+					moveOrbs();
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Accidentally broke #2591, sorry. This is just a rebased version of that PR.

![idea64_2018-05-11_04-08-28](https://user-images.githubusercontent.com/2979691/39904663-fba56346-54d0-11e8-9649-e0035a5760c3.png)

Simply aligns the orbs to the left. Allows Streamers who cover their minimap to still have their orbs showing without much effort.

Works in Fixed, Stretched Fixed, and Resizeable Modes.