### PR TITLE
Log error when encountering an unmatched clue string

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/ClueScrollPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/ClueScrollPlugin.java
@@ -477,6 +477,7 @@ public class ClueScrollPlugin extends Plugin
 		}
 
 		// We have unknown clue, reset
+		log.warn("Encountered unhandled clue text: {}", clueScrollText.getText());
 		resetClue(true);
 		return null;
 	}


### PR DESCRIPTION
Given the recent, and ongoing problems with clue text, this adds an error when we fail to match against any known clue.

This means in scenarios where strange formatting on jagex's side is to blame, the user can provide the needed information on how the string is formatted, rather than a developer having to run clues until they're able to reproduce it.