### PR TITLE
Gargoyle boss quick start menuentryswapper addon.

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -239,4 +239,15 @@ public interface MenuEntrySwapperConfig extends Config
 	{
 		return false;
 	}
+
+	@ConfigItem(
+			position = 19,
+			keyName = "swapGargoyleBoss",
+			name = "Gargoyle boss bell swapper",
+			description = "Swaps Quick-start option for the boss to leftclick"
+	)
+	default boolean swapGargoyleBoss()
+	{
+		return false;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -490,6 +490,14 @@ public class MenuEntrySwapperPlugin extends Plugin
 		{
 			swap("empty", option, target, true);
 		}
+
+		if (option.equals("ring"))
+		{
+			if (config.swapGargoyleBoss())
+			{
+				swap("quick-start", option, target, true);
+			}
+		}
 	}
 
 	@Subscribe


### PR DESCRIPTION
Addon for the menuentryswapper to have left click on the bell to quick-start a gargoyle boss fight.
partially solves #1459 