### PR TITLE
Raid bank swapper

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -250,4 +250,15 @@ public interface MenuEntrySwapperConfig extends Config
 	{
 		return true;
 	}
+
+	@ConfigItem(
+		position = 20,
+		keyName = "swapStorageUnit",
+		name = "Private",
+		description = "Swap Shared with Private on raids storage unit"
+	)
+	default boolean swapStorage()
+	{
+		return false;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -63,7 +63,7 @@ import org.apache.commons.lang3.ArrayUtils;
 	description = "Change the default option that is displayed when hovering over objects",
 	tags = {"npcs", "inventory", "items", "objects"},
 	enabledByDefault = false
-)
+	)
 public class MenuEntrySwapperPlugin extends Plugin
 {
 	private static final String CONFIGURE = "Configure";
@@ -427,14 +427,14 @@ public class MenuEntrySwapperPlugin extends Plugin
 			switch (config.swapHomePortal())
 			{
 				case HOME:
-					swap("home", option, target, true);
-					break;
+				swap("home", option, target, true);
+				break;
 				case BUILD_MODE:
-					swap("build mode", option, target, true);
-					break;
+				swap("build mode", option, target, true);
+				break;
 				case FRIENDS_HOUSE:
-					swap("friend's house", option, target, true);
-					break;
+				swap("friend's house", option, target, true);
+				break;
 			}
 		}
 		else if (config.swapFairyRing() != FairyRingMode.OFF && config.swapFairyRing() != FairyRingMode.ZANARIS
@@ -476,6 +476,10 @@ public class MenuEntrySwapperPlugin extends Plugin
 		else if (config.swapQuick() && option.equals("pass"))
 		{
 			swap("quick-pass", option, target, true);
+		}
+		else if (config.swapStorage() && option.equals("shared"))
+		{
+			swap("private", option, target, true);
 		}
 		else if (config.shiftClickCustomization() && shiftModifier && !option.equals("use"))
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -63,7 +63,7 @@ import org.apache.commons.lang3.ArrayUtils;
 	description = "Change the default option that is displayed when hovering over objects",
 	tags = {"npcs", "inventory", "items", "objects"},
 	enabledByDefault = false
-	)
+)
 public class MenuEntrySwapperPlugin extends Plugin
 {
 	private static final String CONFIGURE = "Configure";
@@ -427,14 +427,14 @@ public class MenuEntrySwapperPlugin extends Plugin
 			switch (config.swapHomePortal())
 			{
 				case HOME:
-				swap("home", option, target, true);
-				break;
+					swap("home", option, target, true);
+					break;
 				case BUILD_MODE:
-				swap("build mode", option, target, true);
-				break;
+					swap("build mode", option, target, true);
+					break;
 				case FRIENDS_HOUSE:
-				swap("friend's house", option, target, true);
-				break;
+					swap("friend's house", option, target, true);
+					break;
 			}
 		}
 		else if (config.swapFairyRing() != FairyRingMode.OFF && config.swapFairyRing() != FairyRingMode.ZANARIS


### PR DESCRIPTION
Added another option in menu entry swapper to swap the right click of raids storage units:
![6a12040170fbe2b5f7840ec151a199d1](https://user-images.githubusercontent.com/36159685/46966253-2bd90d80-d07b-11e8-9875-36a9ab234ce9.png)

Switches shared to private for ironman as suggested by #6015
Default is off