### PR TITLE
Unify calls for getting real item id for bank tag

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/banktags/BankTagsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/banktags/BankTagsPlugin.java
@@ -160,7 +160,7 @@ public class BankTagsPlugin extends Plugin implements MouseWheelListener
 				break;
 			}
 			case "bankSearchFilter":
-				int itemId = itemManager.canonicalize(intStack[intStackSize - 1]);
+				int itemId = intStack[intStackSize - 1];
 				String itemName = stringStack[stringStackSize - 2];
 				String search = stringStack[stringStackSize - 1];
 
@@ -196,7 +196,7 @@ public class BankTagsPlugin extends Plugin implements MouseWheelListener
 		{
 			Widget container = client.getWidget(WidgetInfo.BANK_ITEM_CONTAINER);
 			Widget item = container.getChild(event.getActionParam0());
-			int itemID = itemManager.canonicalize(item.getItemId());
+			int itemID = item.getItemId();
 			String text = EDIT_TAGS_MENU_OPTION;
 			int tagCount = tagManager.getTags(itemID).size();
 			if (tagCount > 0)
@@ -243,7 +243,7 @@ public class BankTagsPlugin extends Plugin implements MouseWheelListener
 				return;
 			}
 
-			int itemId = itemManager.canonicalize(item.getId());
+			int itemId = item.getId();
 			ItemComposition itemComposition = itemManager.getItemComposition(itemId);
 			String itemName = itemComposition.getName();
 			String initialValue = tagManager.getTagString(itemId);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/banktags/TagManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/banktags/TagManager.java
@@ -33,6 +33,7 @@ import java.util.stream.Collectors;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import net.runelite.client.config.ConfigManager;
+import net.runelite.client.game.ItemManager;
 import static net.runelite.client.plugins.banktags.BankTagsPlugin.CONFIG_GROUP;
 import static net.runelite.client.plugins.banktags.BankTagsPlugin.JOINER;
 import static net.runelite.client.plugins.banktags.BankTagsPlugin.SPLITTER;
@@ -42,16 +43,19 @@ import net.runelite.client.util.Text;
 public class TagManager
 {
 	private static final String ITEM_KEY_PREFIX = "item_";
+	private final ItemManager itemManager;
 	private final ConfigManager configManager;
 
 	@Inject
-	private TagManager(final ConfigManager configManager)
+	private TagManager(final ItemManager itemManager, final ConfigManager configManager)
 	{
+		this.itemManager = itemManager;
 		this.configManager = configManager;
 	}
 
-	public String getTagString(int itemId)
+	String getTagString(int itemId)
 	{
+		itemId = itemManager.canonicalize(itemId);
 		String config = configManager.getConfiguration(CONFIG_GROUP, ITEM_KEY_PREFIX + itemId);
 		if (config == null)
 		{
@@ -66,8 +70,9 @@ public class TagManager
 		return new LinkedHashSet<>(SPLITTER.splitToList(getTagString(itemId).toLowerCase()));
 	}
 
-	public void setTagString(int itemId, String tags)
+	void setTagString(int itemId, String tags)
 	{
+		itemId = itemManager.canonicalize(itemId);
 		if (Strings.isNullOrEmpty(tags))
 		{
 			configManager.unsetConfiguration(CONFIG_GROUP, ITEM_KEY_PREFIX + itemId);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/banktags/tabs/TabInterface.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/banktags/tabs/TabInterface.java
@@ -416,7 +416,7 @@ public class TabInterface
 			// Add "remove" menu entry to all items in bank while tab is selected
 			event.consume();
 			final ItemComposition item = getItem(event.getActionParam());
-			final int itemId = itemManager.canonicalize(item.getId());
+			final int itemId = item.getId();
 			tagManager.removeTag(itemId, activeTab.getTag());
 			doSearch(InputType.SEARCH, TAG_SEARCH + activeTab.getTag());
 		}
@@ -434,7 +434,7 @@ public class TabInterface
 
 			List<Integer> items = Arrays.stream(container.getItems())
 				.filter(Objects::nonNull)
-				.map(i -> itemManager.canonicalize(i.getId()))
+				.map(Item::getId)
 				.collect(Collectors.toList());
 
 			if (activeTab != null && event.getMenuTarget() != null && Text.removeTags(event.getMenuTarget()).equals(activeTab.getTag()))
@@ -620,7 +620,7 @@ public class TabInterface
 				// Tag an item dragged on a tag tab
 				if (draggedOn.getId() == parent.getId())
 				{
-					int itemId = itemManager.canonicalize(draggedWidget.getItemId());
+					int itemId = draggedWidget.getItemId();
 					tagManager.addTag(itemId, draggedOn.getName());
 				}
 			}


### PR DESCRIPTION
Instead of trying to tag and find notes and placeholders, find real item
ids.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>