### PR TITLE
Don't show recent chats if account is new enough

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/clanchat/ClanChatPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/clanchat/ClanChatPlugin.java
@@ -113,12 +113,12 @@ public class ClanChatPlugin extends Plugin
 		if (clanChatTitleWidget != null)
 		{
 			Widget clanChatList = client.getWidget(WidgetInfo.CLAN_CHAT_LIST);
-
+			Widget owner = client.getWidget(WidgetInfo.CLAN_CHAT_OWNER);
 			if (client.getClanChatCount() > 0)
 			{
 				clanChatTitleWidget.setText(CLAN_CHAT_TITLE + " (" + client.getClanChatCount() + "/100)");
 			}
-			else if (config.recentChats() && clanChatList.getChildren() == null)
+			else if (config.recentChats() && clanChatList.getChildren() == null && !Strings.isNullOrEmpty(owner.getText()))
 			{
 				clanChatTitleWidget.setText(RECENT_TITLE);
 


### PR DESCRIPTION
Fixes recent clan chats showing behind new account overlay

![](https://i.imgur.com/jnQGrVB.png)