### PR TITLE
Change 'username' to 'display name' in usernameInTitle

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/config/RuneLiteConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/RuneLiteConfig.java
@@ -121,8 +121,8 @@ public interface RuneLiteConfig extends Config
 
 	@ConfigItem(
 		keyName = "usernameInTitle",
-		name = "Display username in title",
-		description = "Toggles displaying of username in client title",
+		name = "Show display name in title",
+		description = "Toggles displaying of local player's display name in client title",
 		position = 18
 	)
 	default boolean usernameInTitle()


### PR DESCRIPTION
The feature displays your display name in the title, not your login username. This change is to avoid ambiguity between the two.