### PR TITLE
XpGlobes: Use correct target XP

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobe.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobe.java
@@ -25,101 +25,18 @@
 package net.runelite.client.plugins.xpglobes;
 
 import java.time.Instant;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
 import net.runelite.api.Skill;
 
-public class XpGlobe
+@Getter
+@Setter
+@AllArgsConstructor
+class XpGlobe
 {
-
 	private Skill skill;
 	private int currentXp;
 	private int currentLevel;
-	private int goalXp;
 	private Instant time;
-	private double skillProgressRadius;
-
-	public XpGlobe(Skill skill, int currentXp, int currentLevel, int goalXp)
-	{
-		this.skill = skill;
-		this.currentXp = currentXp;
-		this.currentLevel = currentLevel;
-		this.goalXp = goalXp;
-	}
-
-	public Skill getSkill()
-	{
-		return skill;
-	}
-
-	public void setSkill(Skill skill)
-	{
-		this.skill = skill;
-	}
-
-	public int getCurrentXp()
-	{
-		return currentXp;
-	}
-
-	public void setCurrentXp(int currentXp)
-	{
-		this.currentXp = currentXp;
-	}
-
-	public int getCurrentLevel()
-	{
-		return currentLevel;
-	}
-
-	public void setCurrentLevel(int currentLevel)
-	{
-		this.currentLevel = currentLevel;
-	}
-
-	public int getGoalXp()
-	{
-		return goalXp;
-	}
-
-	public void setGoalXp(int goalXp)
-	{
-		this.goalXp = goalXp;
-	}
-
-	public int getGoalLevel()
-	{
-		return this.currentLevel++;
-	}
-
-	public String getSkillName()
-	{
-		return skill.getName();
-	}
-
-	public double getSkillProgressRadius()
-	{
-		return skillProgressRadius;
-	}
-
-	public void setSkillProgressRadius(int startXp, int currentXp, int goalXp)
-	{
-		this.skillProgressRadius = -(3.6 * getSkillProgress(startXp, currentXp, goalXp)); //arc goes backwards
-	}
-
-	public double getSkillProgress(int startXp, int currentXp, int goalXp)
-	{
-		double xpGained = currentXp - startXp;
-		double xpGoal = goalXp - startXp;
-
-		return ((xpGained / xpGoal) * 100);
-	}
-
-	public Instant getTime()
-	{
-		return time;
-	}
-
-	public void setTime(Instant time)
-	{
-		this.time = time;
-	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesOverlay.java
@@ -39,7 +39,6 @@ import java.text.DecimalFormat;
 import java.time.Instant;
 import javax.inject.Inject;
 import net.runelite.api.Client;
-import net.runelite.api.Experience;
 import net.runelite.api.Point;
 import net.runelite.client.game.SkillIconManager;
 import net.runelite.client.plugins.xptracker.XpTrackerService;
@@ -55,7 +54,6 @@ public class XpGlobesOverlay extends Overlay
 	private static final int MINIMUM_STEP = 10;
 	private static final int PROGRESS_RADIUS_START = 90;
 	private static final int PROGRESS_RADIUS_REMAINDER = 0;
-	private static final int DEFAULT_START_Y = 10;
 	private static final int TOOLTIP_RECT_SIZE_X = 150;
 	private static final Color DARK_OVERLAY_COLOR = new Color(0, 0, 0, 180);
 
@@ -94,7 +92,9 @@ public class XpGlobesOverlay extends Overlay
 		int curDrawX = 0;
 		for (final XpGlobe xpGlobe : plugin.getXpGlobes())
 		{
-			renderProgressCircle(graphics, xpGlobe, curDrawX, 0, getBounds());
+			int startXp = xpTrackerService.getStartGoalXp(xpGlobe.getSkill());
+			int goalXp = xpTrackerService.getEndGoalXp(xpGlobe.getSkill());
+			renderProgressCircle(graphics, xpGlobe, startXp, goalXp, curDrawX, 0, getBounds());
 			curDrawX += MINIMUM_STEP + config.xpOrbSize();
 		}
 
@@ -103,9 +103,22 @@ public class XpGlobesOverlay extends Overlay
 		return new Dimension(markersLength, config.xpOrbSize());
 	}
 
-	private void renderProgressCircle(Graphics2D graphics, XpGlobe skillToDraw, int x, int y, Rectangle bounds)
+	private double getSkillProgress(int startXp, int currentXp, int goalXp)
 	{
-		double radiusCurrentXp = skillToDraw.getSkillProgressRadius();
+		double xpGained = currentXp - startXp;
+		double xpGoal = goalXp - startXp;
+
+		return ((xpGained / xpGoal) * 100);
+	}
+
+	private double getSkillProgressRadius(int startXp, int currentXp, int goalXp)
+	{
+		return -(3.6 * getSkillProgress(startXp, currentXp, goalXp)); //arc goes backwards
+	}
+
+	private void renderProgressCircle(Graphics2D graphics, XpGlobe skillToDraw, int startXp, int goalXp, int x, int y, Rectangle bounds)
+	{
+		double radiusCurrentXp = getSkillProgressRadius(startXp, skillToDraw.getCurrentXp(), goalXp);
 		double radiusToGoalXp = 360; //draw a circle
 
 		Ellipse2D backgroundCircle = drawEllipse(graphics, x, y);
@@ -123,11 +136,11 @@ public class XpGlobesOverlay extends Overlay
 			graphics.setColor(DARK_OVERLAY_COLOR);
 			graphics.fill(backgroundCircle);
 
-			drawProgressLabel(graphics, skillToDraw, x, y);
+			drawProgressLabel(graphics, skillToDraw, startXp, goalXp, x, y);
 
 			if (config.enableTooltips())
 			{
-				drawTooltip(graphics, skillToDraw, backgroundCircle);
+				drawTooltip(graphics, skillToDraw, goalXp, backgroundCircle);
 			}
 		}
 
@@ -150,14 +163,10 @@ public class XpGlobesOverlay extends Overlay
 			config.enableCustomArcColor() ? config.progressArcColor() : SkillColor.find(skillToDraw.getSkill()).getColor());
 	}
 
-	private void drawProgressLabel(Graphics2D graphics, XpGlobe globe, int x, int y)
+	private void drawProgressLabel(Graphics2D graphics, XpGlobe globe, int startXp, int goalXp, int x, int y)
 	{
-		final int currentExp = globe.getCurrentXp();
-		final int goalExp = globe.getGoalXp();
-		final int expForLevel = Experience.getXpForLevel(globe.getCurrentLevel());
-
 		// Convert to int just to limit the decimal cases
-		String progress = (int) (globe.getSkillProgress(expForLevel, currentExp, goalExp)) + "%";
+		String progress = (int) (getSkillProgress(startXp, globe.getCurrentXp(), goalXp)) + "%";
 
 		final FontMetrics metrics = graphics.getFontMetrics();
 		int drawX = x + (config.xpOrbSize() / 2) - (metrics.stringWidth(progress) / 2);
@@ -205,7 +214,7 @@ public class XpGlobesOverlay extends Overlay
 		);
 	}
 
-	private void drawTooltip(Graphics2D graphics, XpGlobe mouseOverSkill, Ellipse2D drawnGlobe)
+	private void drawTooltip(Graphics2D graphics, XpGlobe mouseOverSkill, int goalXp, Ellipse2D drawnGlobe)
 	{
 		//draw tooltip under the globe of the mouse location
 		int x = (int) drawnGlobe.getX() - (TOOLTIP_RECT_SIZE_X / 2) + (config.xpOrbSize() / 2);
@@ -214,7 +223,7 @@ public class XpGlobesOverlay extends Overlay
 		// reset the timer on XpGlobe to prevent it from disappearing while hovered over it
 		mouseOverSkill.setTime(Instant.now());
 
-		String skillName = mouseOverSkill.getSkillName();
+		String skillName = mouseOverSkill.getSkill().getName();
 		String skillLevel = Integer.toString(mouseOverSkill.getCurrentLevel());
 
 		DecimalFormat decimalFormat = new DecimalFormat("###,###,###");
@@ -235,7 +244,7 @@ public class XpGlobesOverlay extends Overlay
 			.right(skillCurrentXp)
 			.build());
 
-		if (mouseOverSkill.getGoalXp() != -1)
+		if (goalXp != -1)
 		{
 			int actionsLeft = xpTrackerService.getActionsLeft(mouseOverSkill.getSkill());
 			if (actionsLeft != Integer.MAX_VALUE)
@@ -248,10 +257,10 @@ public class XpGlobesOverlay extends Overlay
 					.build());
 			}
 
-			int xpLeft = mouseOverSkill.getGoalXp() - mouseOverSkill.getCurrentXp();
+			int xpLeft = goalXp - mouseOverSkill.getCurrentXp();
 			String skillXpToLvl = decimalFormat.format(xpLeft);
 			xpTooltip.getChildren().add(LineComponent.builder()
-				.left("Xp to level:")
+				.left("Xp left:")
 				.leftColor(Color.ORANGE)
 				.right(skillXpToLvl)
 				.build());

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesPlugin.java
@@ -32,6 +32,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import javax.inject.Inject;
+import lombok.Getter;
 import net.runelite.api.Client;
 import net.runelite.api.Experience;
 import net.runelite.api.Skill;
@@ -57,6 +58,8 @@ public class XpGlobesPlugin extends Plugin
 	private static final int MAXIMUM_SHOWN_GLOBES = 5;
 
 	private XpGlobe[] globeCache = new XpGlobe[Skill.values().length - 1]; //overall does not trigger xp change event
+
+	@Getter
 	private final List<XpGlobe> xpGlobes = new ArrayList<>();
 
 	@Inject
@@ -109,33 +112,22 @@ public class XpGlobesPlugin extends Plugin
 			return;
 		}
 
-		int startingXp = Experience.getXpForLevel(currentLevel);
-		int goalXp = currentLevel + 1 <= Experience.MAX_VIRT_LEVEL ? Experience.getXpForLevel(currentLevel + 1) : -1;
-
 		if (cachedGlobe != null)
 		{
 			cachedGlobe.setSkill(skill);
 			cachedGlobe.setCurrentXp(currentXp);
 			cachedGlobe.setCurrentLevel(currentLevel);
-			cachedGlobe.setGoalXp(goalXp);
 			cachedGlobe.setTime(Instant.now());
-			cachedGlobe.setSkillProgressRadius(startingXp, currentXp, goalXp);
-
 			this.addXpGlobe(globeCache[skillIdx], MAXIMUM_SHOWN_GLOBES);
 		}
 		else
 		{
-			//dont draw non cached globes, this is triggered on login to setup all of the initial values
-			globeCache[skillIdx] = new XpGlobe(skill, currentXp, currentLevel, goalXp);
+			// dont draw non cached globes, this is triggered on login to setup all of the initial values
+			globeCache[skillIdx] = new XpGlobe(skill, currentXp, currentLevel, Instant.now());
 		}
 	}
 
-	public List<XpGlobe> getXpGlobes()
-	{
-		return xpGlobes;
-	}
-
-	public void addXpGlobe(XpGlobe xpGlobe, int maxLength)
+	private void addXpGlobe(XpGlobe xpGlobe, int maxLength)
 	{
 		//remove the old globe, allowing it to be readded as the most recent (right) side when drawn
 		xpGlobes.remove(xpGlobe);
@@ -146,7 +138,7 @@ public class XpGlobesPlugin extends Plugin
 		xpGlobes.add(xpGlobe);
 	}
 
-	public int getXpGlobesSize()
+	int getXpGlobesSize()
 	{
 		return xpGlobes.size();
 	}
@@ -174,7 +166,7 @@ public class XpGlobesPlugin extends Plugin
 		}
 	}
 
-	public void resetGlobeState()
+	private void resetGlobeState()
 	{
 		xpGlobes.clear();
 		globeCache = new XpGlobe[Skill.values().length - 1];

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerService.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerService.java
@@ -30,29 +30,31 @@ public interface XpTrackerService
 {
 	/**
 	 * Get the number of actions done
-	 * @param skill
-	 * @return
 	 */
 	int getActions(Skill skill);
 
 	/**
 	 * Get the number of actions per hour
-	 * @param skill
-	 * @return
 	 */
 	int getActionsHr(Skill skill);
 
 	/**
 	 * Get the number of actions remaining
-	 * @param skill
-	 * @return
 	 */
 	int getActionsLeft(Skill skill);
 
 	/**
 	 * Get the amount of xp per hour
-	 * @param skill
-	 * @return
 	 */
 	int getXpHr(Skill skill);
+
+	/**
+	 * Get the start goal XP
+	 */
+	int getStartGoalXp(Skill skill);
+
+	/**
+	 * Get the amount of XP left until goal level
+	 */
+	int getEndGoalXp(Skill skill);
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerServiceImpl.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerServiceImpl.java
@@ -62,4 +62,16 @@ class XpTrackerServiceImpl implements XpTrackerService
 	{
 		return plugin.getSkillSnapshot(skill).getXpPerHour();
 	}
+
+	@Override
+	public int getStartGoalXp(Skill skill)
+	{
+		return plugin.getSkillSnapshot(skill).getStartGoalXp();
+	}
+
+	@Override
+	public int getEndGoalXp(Skill skill)
+	{
+		return plugin.getSkillSnapshot(skill).getEndGoalXp();
+	}
 }


### PR DESCRIPTION
Use correct target XP so actions left with set goal are not wrong (and
also to simply support in-game target goals).

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>