### PR TITLE
(OLD) Chambers scouter extra features

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsConfig.java
@@ -24,9 +24,13 @@
  */
 package net.runelite.client.plugins.raids;
 
+import java.awt.Color;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.Keybind;
 
 @ConfigGroup("raids")
 public interface RaidsConfig extends Config
@@ -150,6 +154,116 @@ public interface RaidsConfig extends Config
 	default String whitelistedLayouts()
 	{
 		return "";
+	}
+
+	@ConfigItem(
+		position = 11,
+		keyName = "showScavsFarms",
+		name = "Show scavengers and farming",
+		description = "Adds scavengers and farming to the room breakdown"
+	)
+	default boolean showScavsFarms()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		position = 12,
+		keyName = "enhanceScouterTitle",
+		name = "Enhance scouter title",
+		description = "Adds #combat and good puzzles to scouter title"
+	)
+	default boolean enhanceScouterTitle()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		position = 13,
+		keyName = "enableSharableImage",
+		name = "Enable sharable image",
+		description = "Use the specified hotkey to capture the raid scouter"
+	)
+	default boolean enableSharableImage()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		position = 14,
+		keyName = "hotkey",
+		name = "Capture hotkey",
+		description = "Hotkey used to capture the scouter"
+	)
+	default Keybind hotkey()
+	{
+		return new Keybind(KeyEvent.VK_C, InputEvent.CTRL_DOWN_MASK);
+	}
+
+	@ConfigItem(
+		position = 15,
+		keyName = "enableTrayNotification",
+		name = "Enable tray notification",
+		description = "Adds a system tray notification on successful screen capture"
+	)
+	default boolean enableTrayNotification()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		position = 16,
+		keyName = "showRecommendedItems",
+		name = "Show recommended items",
+		description = "Adds overlay with recommended items to scouter"
+	)
+	default boolean showRecommendedItems()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		position = 17,
+		keyName = "recommendedItems",
+		name = "Recommended items",
+		description = "User-set recommended items in the form: [muttadiles,ice barrage,zamorak godsword],[tekton,elder maul], ..."
+	)
+	default String recommendedItems()
+	{
+		return "";
+	}
+
+	@ConfigItem(
+		position = 18,
+		keyName = "scavsBeforeIce",
+		name = "Show last scavs for Ice Demon",
+		description = "Highlights final scavengers before Ice Demon"
+	)
+	default boolean scavsBeforeIce()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		position = 19,
+		keyName = "scavsBeforeOlm",
+		name = "Show last scavs for Olm",
+		description = "Highlights final scavengers before Olm"
+	)
+	default boolean scavsBeforeOlm()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		position = 20,
+		keyName = "scavPrepColor",
+		name = "Last scavs color",
+		description = "The color of the final scavs before Ice Demon/Olm"
+	)
+	default Color scavPrepColor()
+	{
+		return Color.MAGENTA;
 	}
 
 	@ConfigItem(

--- a/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsConfig.java
@@ -31,6 +31,7 @@ import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
 import net.runelite.client.config.Keybind;
+import net.runelite.client.plugins.screenshot.UploadStyle;
 
 @ConfigGroup("raids")
 public interface RaidsConfig extends Config
@@ -333,7 +334,18 @@ public interface RaidsConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 27,
+			position = 27,
+			keyName = "hideUnknownPuzzle",
+			name = "Hide Unknown puzzle raids",
+			description = "Completely hides raids with Unknown puzzle"
+	)
+	default boolean hideUnknownPuzzle()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		position = 28,
 		keyName = "layoutMessage",
 		name = "Send raid layout message when entering raid",
 		description = "Sends game message with raid layout on entering new raid"
@@ -344,6 +356,7 @@ public interface RaidsConfig extends Config
 	}
 
 	@ConfigItem(
+			position = 29,
 		position = 12,
 		keyName = "showLootValue",
 		name = "Show Loot Value",
@@ -363,5 +376,16 @@ public interface RaidsConfig extends Config
 	default boolean displayFloorBreak()
 	{
 		return false;
+	}
+
+	@ConfigItem(
+			position = 30,
+			keyName = "uploadScreenshot",
+			name = "Upload",
+			description = "Configures whether or not screenshots are uploaded to Imgur, or placed on your clipboard"
+	)
+	default UploadStyle uploadScreenshot()
+	{
+		return UploadStyle.CLIPBOARD;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsConfig.java
@@ -170,194 +170,6 @@ public interface RaidsConfig extends Config
 
 	@ConfigItem(
 		position = 12,
-		keyName = "enhanceScouterTitle",
-		name = "Enhance scouter title",
-		description = "Adds #combat and good puzzles to scouter title"
-	)
-	default boolean enhanceScouterTitle()
-	{
-		return false;
-	}
-
-	@ConfigItem(
-		position = 13,
-		keyName = "enableSharableImage",
-		name = "Enable sharable image",
-		description = "Use the specified hotkey to capture the raid scouter"
-	)
-	default boolean enableSharableImage()
-	{
-		return false;
-	}
-
-	@ConfigItem(
-		position = 14,
-		keyName = "hotkey",
-		name = "Capture hotkey",
-		description = "Hotkey used to capture the scouter"
-	)
-	default Keybind hotkey()
-	{
-		return new Keybind(KeyEvent.VK_C, InputEvent.CTRL_DOWN_MASK);
-	}
-
-	@ConfigItem(
-		position = 15,
-		keyName = "enableTrayNotification",
-		name = "Enable tray notification",
-		description = "Adds a system tray notification on successful screen capture"
-	)
-	default boolean enableTrayNotification()
-	{
-		return false;
-	}
-
-	@ConfigItem(
-		position = 16,
-		keyName = "showRecommendedItems",
-		name = "Show recommended items",
-		description = "Adds overlay with recommended items to scouter"
-	)
-	default boolean showRecommendedItems()
-	{
-		return false;
-	}
-
-	@ConfigItem(
-		position = 17,
-		keyName = "recommendedItems",
-		name = "Recommended items",
-		description = "User-set recommended items in the form: [muttadiles,ice barrage,zamorak godsword],[tekton,elder maul], ..."
-	)
-	default String recommendedItems()
-	{
-		return "";
-	}
-
-	@ConfigItem(
-		position = 18,
-		keyName = "scavsBeforeIce",
-		name = "Show last scavs for Ice Demon",
-		description = "Highlights final scavengers before Ice Demon"
-	)
-	default boolean scavsBeforeIce()
-	{
-		return false;
-	}
-
-	@ConfigItem(
-		position = 19,
-		keyName = "scavsBeforeOlm",
-		name = "Show last scavs for Olm",
-		description = "Highlights final scavengers before Olm"
-	)
-	default boolean scavsBeforeOlm()
-	{
-		return false;
-	}
-
-	@ConfigItem(
-		position = 20,
-		keyName = "scavPrepColor",
-		name = "Last scavs color",
-		description = "The color of the final scavs before Ice Demon/Olm"
-	)
-	default Color scavPrepColor()
-	{
-		return new Color(130, 222, 255); //light blue
-	}
-
-	@ConfigItem(
-		position = 21,
-		keyName = "alwaysShowWorldAndCC",
-		name = "Always show CC and World",
-		description = "The CC and World are not removed from being in the in-game scouter"
-	)
-	default boolean alwaysShowWorldAndCC()
-	{
-		return false;
-	}
-
-	@ConfigItem(
-		position = 22,
-		keyName = "colorTightrope",
-		name = "Color tightrope",
-		description = "Colors tightrope a separate color"
-	)
-	default boolean colorTightrope()
-	{
-		return false;
-	}
-
-	@ConfigItem(
-		position = 23,
-		keyName = "tightropeColor",
-		name = "Tightrope color",
-		description = "The color of tightropes"
-	)
-	default Color tightropeColor()
-	{
-		return Color.MAGENTA;
-	}
-
-	@ConfigItem(
-		position = 24,
-		keyName = "hideRopeless",
-		name = "Hide no Tightrope raids",
-		description = "Completely hides raids with no tightrope"
-	)
-	default boolean hideRopeless()
-	{
-		return false;
-	}
-
-	@ConfigItem(
-			position = 25,
-			keyName = "hideVanguards",
-			name = "Hide Vanguard raids",
-			description = "Completely hides raids with Vanguards"
-	)
-	default boolean hideVanguards()
-	{
-		return false;
-	}
-
-	@ConfigItem(
-			position = 26,
-			keyName = "hideUnknownCombat",
-			name = "Hide Unknown combat raids",
-			description = "Completely hides raids with Unknown combat"
-	)
-	default boolean hideUnknownCombat()
-	{
-		return false;
-	}
-
-	@ConfigItem(
-			position = 27,
-			keyName = "hideUnknownPuzzle",
-			name = "Hide Unknown puzzle raids",
-			description = "Completely hides raids with Unknown puzzle"
-	)
-	default boolean hideUnknownPuzzle()
-	{
-		return false;
-	}
-
-	@ConfigItem(
-		position = 28,
-		keyName = "layoutMessage",
-		name = "Send raid layout message when entering raid",
-		description = "Sends game message with raid layout on entering new raid"
-	)
-	default boolean layoutMessage()
-	{
-		return false;
-	}
-
-	@ConfigItem(
-			position = 29,
-		position = 12,
 		keyName = "showLootValue",
 		name = "Show Loot Value",
 		description = "Shows the value of your loot at the end of a raid"
@@ -368,7 +180,194 @@ public interface RaidsConfig extends Config
 	}
 
 	@ConfigItem(
+		position = 13,
+		keyName = "enhanceScouterTitle",
+		name = "Enhance scouter title",
+		description = "Adds #combat and good puzzles to scouter title"
+	)
+	default boolean enhanceScouterTitle()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		position = 14,
+		keyName = "enableSharableImage",
+		name = "Enable sharable image",
+		description = "Use the specified hotkey to capture the raid scouter"
+	)
+	default boolean enableSharableImage()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		position = 15,
+		keyName = "hotkey",
+		name = "Capture hotkey",
+		description = "Hotkey used to capture the scouter"
+	)
+	default Keybind hotkey()
+	{
+		return new Keybind(KeyEvent.VK_C, InputEvent.CTRL_DOWN_MASK);
+	}
+
+	@ConfigItem(
+		position = 16,
+		keyName = "enableTrayNotification",
+		name = "Enable tray notification",
+		description = "Adds a system tray notification on successful screen capture"
+	)
+	default boolean enableTrayNotification()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		position = 17,
+		keyName = "showRecommendedItems",
+		name = "Show recommended items",
+		description = "Adds overlay with recommended items to scouter"
+	)
+	default boolean showRecommendedItems()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		position = 18,
+		keyName = "recommendedItems",
+		name = "Recommended items",
+		description = "User-set recommended items in the form: [muttadiles,ice barrage,zamorak godsword],[tekton,elder maul], ..."
+	)
+	default String recommendedItems()
+	{
+		return "";
+	}
+
+	@ConfigItem(
+		position = 19,
+		keyName = "scavsBeforeIce",
+		name = "Show last scavs for Ice Demon",
+		description = "Highlights final scavengers before Ice Demon"
+	)
+	default boolean scavsBeforeIce()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		position = 20,
+		keyName = "scavsBeforeOlm",
+		name = "Show last scavs for Olm",
+		description = "Highlights final scavengers before Olm"
+	)
+	default boolean scavsBeforeOlm()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		position = 21,
+		keyName = "scavPrepColor",
+		name = "Last scavs color",
+		description = "The color of the final scavs before Ice Demon/Olm"
+	)
+	default Color scavPrepColor()
+	{
+		return new Color(130, 222, 255); //light blue
+	}
+
+	@ConfigItem(
+		position = 22,
+		keyName = "alwaysShowWorldAndCC",
+		name = "Always show CC and World",
+		description = "The CC and World are not removed from being in the in-game scouter"
+	)
+	default boolean alwaysShowWorldAndCC()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		position = 23,
+		keyName = "colorTightrope",
+		name = "Color tightrope",
+		description = "Colors tightrope a separate color"
+	)
+	default boolean colorTightrope()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		position = 24,
+		keyName = "tightropeColor",
+		name = "Tightrope color",
+		description = "The color of tightropes"
+	)
+	default Color tightropeColor()
+	{
+		return Color.MAGENTA;
+	}
+
+	@ConfigItem(
+		position = 25,
+		keyName = "hideRopeless",
+		name = "Hide no Tightrope raids",
+		description = "Completely hides raids with no tightrope"
+	)
+	default boolean hideRopeless()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+			position = 26,
+			keyName = "hideVanguards",
+			name = "Hide Vanguard raids",
+			description = "Completely hides raids with Vanguards"
+	)
+	default boolean hideVanguards()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+			position = 27,
+			keyName = "hideUnknownCombat",
+			name = "Hide Unknown combat raids",
+			description = "Completely hides raids with Unknown combat"
+	)
+	default boolean hideUnknownCombat()
+	{
+		return false;
+	}
+
+	@ConfigItem(
 			position = 28,
+			keyName = "hideUnknownPuzzle",
+			name = "Hide Unknown puzzle raids",
+			description = "Completely hides raids with Unknown puzzle"
+	)
+	default boolean hideUnknownPuzzle()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		position = 29,
+		keyName = "layoutMessage",
+		name = "Send raid layout message when entering raid",
+		description = "Sends game message with raid layout on entering new raid"
+	)
+	default boolean layoutMessage()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+			position = 30,
 			keyName = "displayFloorBreak",
 			name = "Layout floor break",
 			description = "Displays floor break in layout"
@@ -379,7 +378,7 @@ public interface RaidsConfig extends Config
 	}
 
 	@ConfigItem(
-			position = 30,
+			position = 31,
 			keyName = "uploadScreenshot",
 			name = "Upload",
 			description = "Configures whether or not screenshots are uploaded to Imgur, or placed on your clipboard"

--- a/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsConfig.java
@@ -263,11 +263,77 @@ public interface RaidsConfig extends Config
 	)
 	default Color scavPrepColor()
 	{
+		return new Color(130, 222, 255); //light blue
+	}
+
+	@ConfigItem(
+		position = 21,
+		keyName = "alwaysShowWorldAndCC",
+		name = "Always show CC and World",
+		description = "The CC and World are not removed from being in the in-game scouter"
+	)
+	default boolean alwaysShowWorldAndCC()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		position = 22,
+		keyName = "colorTightrope",
+		name = "Color tightrope",
+		description = "Colors tightrope a separate color"
+	)
+	default boolean colorTightrope()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		position = 23,
+		keyName = "tightropeColor",
+		name = "Tightrope color",
+		description = "The color of tightropes"
+	)
+	default Color tightropeColor()
+	{
 		return Color.MAGENTA;
 	}
 
 	@ConfigItem(
-		position = 11,
+		position = 24,
+		keyName = "hideRopeless",
+		name = "Hide no Tightrope raids",
+		description = "Completely hides raids with no tightrope"
+	)
+	default boolean hideRopeless()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+			position = 25,
+			keyName = "hideVanguards",
+			name = "Hide Vanguard raids",
+			description = "Completely hides raids with Vanguards"
+	)
+	default boolean hideVanguards()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+			position = 26,
+			keyName = "hideUnknownCombat",
+			name = "Hide Unknown combat raids",
+			description = "Completely hides raids with Unknown combat"
+	)
+	default boolean hideUnknownCombat()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		position = 27,
 		keyName = "layoutMessage",
 		name = "Send raid layout message when entering raid",
 		description = "Sends game message with raid layout on entering new raid"
@@ -286,5 +352,16 @@ public interface RaidsConfig extends Config
 	default boolean showLootValue()
 	{
 		return true;
+	}
+
+	@ConfigItem(
+			position = 28,
+			keyName = "displayFloorBreak",
+			name = "Layout floor break",
+			description = "Displays floor break in layout"
+	)
+	default boolean displayFloorBreak()
+	{
+		return false;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsOverlay.java
@@ -24,13 +24,24 @@
  */
 package net.runelite.client.plugins.raids;
 
+import java.awt.Point;
+import java.awt.image.BufferedImage;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import lombok.Getter;
+import lombok.Setter;
 import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Graphics2D;
 import javax.inject.Inject;
-import lombok.Setter;
 import net.runelite.api.Client;
 import static net.runelite.api.MenuAction.RUNELITE_OVERLAY;
+import net.runelite.api.SpriteID;
+import net.runelite.api.widgets.WidgetInfo;
+import net.runelite.client.game.ItemManager;
+import net.runelite.client.game.SpriteManager;
 import static net.runelite.api.MenuAction.RUNELITE_OVERLAY_CONFIG;
 import net.runelite.client.plugins.raids.solver.Room;
 import net.runelite.client.ui.overlay.Overlay;
@@ -38,25 +49,46 @@ import static net.runelite.client.ui.overlay.OverlayManager.OPTION_CONFIGURE;
 import net.runelite.client.ui.overlay.OverlayMenuEntry;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.OverlayPriority;
+import net.runelite.client.ui.overlay.components.ImageComponent;
 import net.runelite.client.ui.overlay.components.LineComponent;
 import net.runelite.client.ui.overlay.components.PanelComponent;
 import net.runelite.client.ui.overlay.components.TitleComponent;
+import net.runelite.client.util.ImageUtil;
+import net.runelite.client.util.Text;
 
 public class RaidsOverlay extends Overlay
 {
 	private static final int OLM_PLANE = 0;
 	static final String BROADCAST_ACTION = "Broadcast layout";
+	private static final int BORDER_OFFSET = 2;
+	private static final int ICON_SIZE = 32;
+	private static final int SMALL_ICON_SIZE = 21;
+	//might need to edit these if they are not standard
+	private static final int TITLE_COMPONENT_HEIGHT = 20;
+	private static final int LINE_COMPONENT_HEIGHT = 16;
 
 	private Client client;
 	private RaidsPlugin plugin;
 	private RaidsConfig config;
 	private final PanelComponent panelComponent = new PanelComponent();
+	private final ItemManager itemManager;
+	private final SpriteManager spriteManager;
+	private final PanelComponent panelImages = new PanelComponent();
+
+	@Setter
+	private boolean sharable = false;
 
 	@Setter
 	private boolean scoutOverlayShown = false;
 
+	@Getter
+	private int width;
+
+	@Getter
+	private int height;
+
 	@Inject
-	private RaidsOverlay(Client client, RaidsPlugin plugin, RaidsConfig config)
+	private RaidsOverlay(Client client, RaidsPlugin plugin, RaidsConfig config, ItemManager itemManager, SpriteManager spriteManager)
 	{
 		super(plugin);
 		setPosition(OverlayPosition.TOP_LEFT);
@@ -64,6 +96,8 @@ public class RaidsOverlay extends Overlay
 		this.client = client;
 		this.plugin = plugin;
 		this.config = config;
+		this.itemManager = itemManager;
+		this.spriteManager = spriteManager;
 		getMenuEntries().add(new OverlayMenuEntry(RUNELITE_OVERLAY_CONFIG, OPTION_CONFIGURE, "Raids overlay"));
 		getMenuEntries().add(new OverlayMenuEntry(RUNELITE_OVERLAY, BROADCAST_ACTION, "Raids overlay"));
 	}
@@ -96,11 +130,106 @@ public class RaidsOverlay extends Overlay
 			color = Color.RED;
 		}
 
+		int combatCount = 0;
+		int roomCount = 0;
+		List<Integer> iceRooms = new ArrayList<>();
+		List<Integer> scavRooms = new ArrayList<>();
+		List<Integer> scavsBeforeIceRooms = new ArrayList<>();
+		boolean crabs = false;
+		boolean iceDemon = false;
+		boolean tightrope = false;
+		boolean thieving = false;
+		String puzzles = "";
+		if (config.enhanceScouterTitle() || config.scavsBeforeIce() || sharable)
+		{
+			for (Room layoutRoom : plugin.getRaid().getLayout().getRooms())
+			{
+				int position = layoutRoom.getPosition();
+				RaidRoom room = plugin.getRaid().getRoom(position);
+
+				if (room == null)
+				{
+					continue;
+				}
+
+				switch (room.getType())
+				{
+					case COMBAT:
+						combatCount++;
+						break;
+					case PUZZLE:
+						String roomName = room.getPuzzle().getName();
+						switch (RaidRoom.Puzzle.fromString(roomName))
+						{
+							case CRABS:
+								crabs = true;
+								break;
+							case ICE_DEMON:
+								iceDemon = true;
+								iceRooms.add(roomCount);
+								break;
+							case THIEVING:
+								thieving = true;
+								break;
+							case TIGHTROPE:
+								tightrope = true;
+								break;
+						}
+						break;
+					case SCAVENGERS:
+						scavRooms.add(roomCount);
+						break;
+				}
+				roomCount++;
+			}
+			if (tightrope)
+				puzzles = crabs ? "cr" : iceDemon ? "ri" : thieving ? "" : "?r";
+			layout = (config.enhanceScouterTitle() ? "" + combatCount + "c " + puzzles + " " : "") + layout;
+
+			for (Integer i : iceRooms)
+			{
+				int prev = 0;
+				for (Integer s : scavRooms)
+				{
+					if (s > i)
+						break;
+					prev = s;
+				}
+				scavsBeforeIceRooms.add(prev);
+			}
+		}
+		int lastScavs = scavRooms.get(scavRooms.size() - 1);
 		panelComponent.getChildren().add(TitleComponent.builder()
 			.text(layout)
 			.color(color)
 			.build());
+		color = Color.ORANGE;
+		if (sharable)
+		{
+			String clanOwner = Text.removeTags(client.getWidget(WidgetInfo.CLAN_CHAT_OWNER).getText());
+			if (clanOwner.equals("None"))
+			{
+				clanOwner = "Open CC tab...";
+				color = Color.RED;
+			}
+			panelComponent.getChildren().add(LineComponent.builder()
+				.left("W" + client.getWorld())
+				.right("" + clanOwner)
+				.leftColor(Color.ORANGE)
+				.rightColor(color)
+				.build());
+		}
 
+		int bossMatches = 0;
+		int bossCount = 0;
+		roomCount = 0;
+
+		if (config.enableRotationWhitelist())
+		{
+			bossMatches = plugin.getRotationMatches();
+		}
+
+		Set<Integer> imageIds = new HashSet<>();
 		for (Room layoutRoom : plugin.getRaid().getLayout().getRooms())
 		{
 			int position = layoutRoom.getPosition();
@@ -120,28 +249,40 @@ public class RaidsOverlay extends Overlay
 					{
 						color = Color.GREEN;
 					}
+					else if (plugin.getRoomBlacklist().contains(room.getBoss().getName().toLowerCase())
+						|| config.enableRotationWhitelist() && bossCount > bossMatches)
 					else if (plugin.getRoomBlacklist().contains(room.getName().toLowerCase())
 							|| config.enableRotationWhitelist() && !plugin.getRotationMatches())
 					{
 						color = Color.RED;
 					}
 
-					String name = room == RaidRoom.UNKNOWN_COMBAT ? "Unknown" : room.getName();
+					String bossName = room.getBoss().getName();
+					String bossNameLC = bossName.toLowerCase();
+					if (config.showRecommendedItems())
+					{
+						if (plugin.getRecommendedItemsList().get(bossNameLC) != null)
+							imageIds.addAll(plugin.getRecommendedItemsList().get(bossNameLC));
+					}
 
 					panelComponent.getChildren().add(LineComponent.builder()
-						.left(room.getType().getName())
-						.right(name)
+						.left(config.showRecommendedItems() ? "" : room.getType().getName())
+						.right(bossName)
 						.rightColor(color)
 						.build());
 
 					break;
 
 				case PUZZLE:
-					if (plugin.getRoomWhitelist().contains(room.getName().toLowerCase()))
+					String puzzleName = room.getPuzzle().getName();
+					String puzzleNameLC = puzzleName.toLowerCase();
+					if (plugin.getRecommendedItemsList().get(puzzleNameLC) != null)
+						imageIds.addAll(plugin.getRecommendedItemsList().get(puzzleNameLC));
+					if (plugin.getRoomWhitelist().contains(puzzleNameLC))
 					{
 						color = Color.GREEN;
 					}
-					else if (plugin.getRoomBlacklist().contains(room.getName().toLowerCase()))
+					else if (plugin.getRoomBlacklist().contains(puzzleNameLC))
 					{
 						color = Color.RED;
 					}
@@ -149,14 +290,104 @@ public class RaidsOverlay extends Overlay
 					name = room == RaidRoom.UNKNOWN_PUZZLE ? "Unknown" : room.getName();
 
 					panelComponent.getChildren().add(LineComponent.builder()
-						.left(room.getType().getName())
-						.right(name)
+						.left(config.showRecommendedItems() ? "" : room.getType().getName())
+						.right(puzzleName)
 						.rightColor(color)
 						.build());
 					break;
+				case FARMING:
+					if (config.showScavsFarms())
+					{
+						panelComponent.getChildren().add(LineComponent.builder()
+							.left("")
+							.right(room.getType().getName())
+							.rightColor(new Color(181, 230, 29)) //yellow green
+							.build());
+					}
+					break;
+				case SCAVENGERS:
+					if (config.scavsBeforeOlm() && roomCount == lastScavs)
+					{
+						panelComponent.getChildren().add(LineComponent.builder()
+							.left(config.showRecommendedItems() ? "" : "OlmPrep")
+							.right("Scavs")
+							.rightColor(config.scavPrepColor())
+							.build());
+					}
+					else if (config.scavsBeforeIce() && scavsBeforeIceRooms.contains(roomCount))
+					{
+						panelComponent.getChildren().add(LineComponent.builder()
+							.left(config.showRecommendedItems() ? "" : "IcePrep")
+							.right("Scavs")
+							.rightColor(config.scavPrepColor())
+							.build());
+					}
+					else if (config.showScavsFarms())
+					{
+						panelComponent.getChildren().add(LineComponent.builder()
+							.left("")
+							.right("Scavs")
+							.rightColor(new Color(181, 230, 29)) //yellow green
+							.build());
+					}
+					break;
 			}
+			roomCount++;
 		}
 
-		return panelComponent.render(graphics);
+		Dimension panelDims = panelComponent.render(graphics);
+		width = (int) panelDims.getWidth();
+		height = (int) panelDims.getHeight();
+
+		//add recommended items
+		if (config.showRecommendedItems() && imageIds.size() > 0)
+		{
+			panelImages.getChildren().clear();
+			Integer[] idArray = imageIds.toArray(new Integer[0]);
+			int imagesVerticalOffset = TITLE_COMPONENT_HEIGHT + (sharable ? LINE_COMPONENT_HEIGHT : 0) - BORDER_OFFSET;
+			int imagesMaxHeight = height - 2 * BORDER_OFFSET - TITLE_COMPONENT_HEIGHT - (sharable ? LINE_COMPONENT_HEIGHT : 0);
+			boolean smallImages = false;
+
+			panelImages.setPreferredLocation(new Point(0, imagesVerticalOffset));
+			panelImages.setBackgroundColor(null);
+			if (2 * (imagesMaxHeight / ICON_SIZE) >= idArray.length )
+			{
+				panelImages.setWrapping(2);
+			}
+			else
+			{
+				panelImages.setWrapping(3);
+				smallImages = true;
+			}
+
+			panelImages.setOrientation(PanelComponent.Orientation.HORIZONTAL);
+			for (Integer e : idArray)
+			{
+				final BufferedImage image = getImage(e, smallImages);
+				if (image != null)
+				{
+					panelImages.getChildren().add(new ImageComponent(image));
+				}
+			}
+
+			panelImages.render(graphics);
+		}
+		return panelDims;
+	}
+
+	private BufferedImage getImage(int id, boolean small)
+	{
+		BufferedImage bim;
+		if (id != SpriteID.SPELL_ICE_BARRAGE)
+			bim = itemManager.getImage(id);
+		else
+			bim = spriteManager.getSprite(id, 0);
+		if (bim == null)
+			return null;
+		if (!small)
+			return ImageUtil.resizeCanvas(bim, ICON_SIZE, ICON_SIZE);
+		if (id != SpriteID.SPELL_ICE_BARRAGE)
+			return ImageUtil.resizeImage(bim, SMALL_ICON_SIZE, SMALL_ICON_SIZE);
+		return ImageUtil.resizeCanvas(bim, SMALL_ICON_SIZE, SMALL_ICON_SIZE);
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsOverlay.java
@@ -261,11 +261,6 @@ public class RaidsOverlay extends Overlay
 		int bossCount = 0;
 		roomCount = 0;
 
-		if (config.enableRotationWhitelist())
-		{
-			bossMatches = plugin.getRotationMatches();
-		}
-
 		Set<Integer> imageIds = new HashSet<>();
 		for (Room layoutRoom : plugin.getRaid().getLayout().getRooms())
 		{
@@ -286,8 +281,6 @@ public class RaidsOverlay extends Overlay
 					{
 						color = Color.GREEN;
 					}
-					else if (plugin.getRoomBlacklist().contains(room.getName().toLowerCase())
-						|| config.enableRotationWhitelist() && bossCount > bossMatches)
 					else if (plugin.getRoomBlacklist().contains(room.getName().toLowerCase())
 							|| config.enableRotationWhitelist() && !plugin.getRotationMatches())
 					{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsOverlay.java
@@ -152,8 +152,8 @@ public class RaidsOverlay extends Overlay
 		boolean thieving = false;
 		boolean vanguards = false;
 		boolean unknownCombat = false;
+		boolean unknownPuzzle = false;
 		String puzzles = "";
-		String roomName = "";
 		if (config.enhanceScouterTitle() || config.scavsBeforeIce() || sharable)
 		{
 			for (Room layoutRoom : plugin.getRaid().getLayout().getRooms())
@@ -170,20 +170,18 @@ public class RaidsOverlay extends Overlay
 				{
 					case COMBAT:
 						combatCount++;
-						roomName = room.getBoss().getName();
-						switch (RaidRoom.Boss.fromString(roomName))
+						switch (room)
 						{
 							case VANGUARDS:
 								vanguards = true;
 								break;
-							case UNKNOWN:
+							case UNKNOWN_COMBAT:
 								unknownCombat = true;
 								break;
 						}
 						break;
 					case PUZZLE:
-						roomName = room.getPuzzle().getName();
-						switch (RaidRoom.Puzzle.fromString(roomName))
+						switch (room)
 						{
 							case CRABS:
 								crabs = true;
@@ -198,6 +196,9 @@ public class RaidsOverlay extends Overlay
 							case TIGHTROPE:
 								tightrope = true;
 								break;
+							case UNKNOWN_PUZZLE:
+								unknownPuzzle = true;
+								break;
 						}
 						break;
 					case SCAVENGERS:
@@ -209,7 +210,7 @@ public class RaidsOverlay extends Overlay
 			if (tightrope)
 				puzzles = crabs ? "cr" : iceDemon ? "ri" : thieving ? "tr" : "?r";
 
-			if ((config.hideVanguards() && vanguards) || (config.hideRopeless() && !tightrope) || (config.hideUnknownCombat() && unknownCombat))
+			if ((config.hideVanguards() && vanguards) || (config.hideRopeless() && !tightrope) || (config.hideUnknownCombat() && unknownCombat) || (config.hideUnknownPuzzle() && unknownPuzzle))
 			{
 				panelComponent.getChildren().add(TitleComponent.builder()
 						.text("Bad Raid!")
@@ -285,7 +286,7 @@ public class RaidsOverlay extends Overlay
 					{
 						color = Color.GREEN;
 					}
-					else if (plugin.getRoomBlacklist().contains(room.getBoss().getName().toLowerCase())
+					else if (plugin.getRoomBlacklist().contains(room.getName().toLowerCase())
 						|| config.enableRotationWhitelist() && bossCount > bossMatches)
 					else if (plugin.getRoomBlacklist().contains(room.getName().toLowerCase())
 							|| config.enableRotationWhitelist() && !plugin.getRotationMatches())
@@ -293,7 +294,7 @@ public class RaidsOverlay extends Overlay
 						color = Color.RED;
 					}
 
-					String bossName = room.getBoss().getName();
+					String bossName = room.getName();
 					String bossNameLC = bossName.toLowerCase();
 					if (config.showRecommendedItems())
 					{
@@ -310,7 +311,7 @@ public class RaidsOverlay extends Overlay
 					break;
 
 				case PUZZLE:
-					String puzzleName = room.getPuzzle().getName();
+					String puzzleName = room.getName();
 					String puzzleNameLC = puzzleName.toLowerCase();
 					if (plugin.getRecommendedItemsList().get(puzzleNameLC) != null)
 						imageIds.addAll(plugin.getRecommendedItemsList().get(puzzleNameLC));
@@ -327,11 +328,11 @@ public class RaidsOverlay extends Overlay
 						color = config.tightropeColor();
 					}
 
-					name = room == RaidRoom.UNKNOWN_PUZZLE ? "Unknown" : room.getName();
+					String name = room == RaidRoom.UNKNOWN_PUZZLE ? "Unknown" : puzzleName;
 
 					panelComponent.getChildren().add(LineComponent.builder()
 						.left(config.showRecommendedItems() ? "" : room.getType().getName())
-						.right(puzzleName)
+						.right(name)
 						.rightColor(color)
 						.build());
 					break;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsPlugin.java
@@ -802,13 +802,14 @@ public class RaidsPlugin extends Plugin
 
 	private void initiateCopyImage()
 	{
-		if (!config.enableSharableImage())
+		if (!config.enableSharableImage() || !overlay.isScouterActive())
 			return;
 
 		Rectangle overlaySize = overlay.getBounds();
 		if (overlaySize.width <= 0 || overlaySize.height <= 0)
 			return;
-		overlaySize.height += LINE_COMPONENT_HEIGHT;
+		if (!config.alwaysShowWorldAndCC())
+			overlaySize.height += LINE_COMPONENT_HEIGHT;
 
 		BufferedImage bim = new BufferedImage(overlaySize.width, overlaySize.height, BufferedImage.TYPE_INT_ARGB);
 		overlay.setSharable(true);
@@ -816,13 +817,15 @@ public class RaidsPlugin extends Plugin
 		g.setFont(FontManager.getRunescapeFont());
 
 		//this is needed to update the PanelComponent childDimensions, because they are a frame behind
-		overlay.render(g);
+		if (!config.alwaysShowWorldAndCC())
+			overlay.render(g);
 		g.setColor(Color.BLACK);
 		g.fillRect(0, 0, overlaySize.width, overlaySize.height);
 
 		overlay.render(g);
 		screenCapture.takeScreenshot(bim, config.enableTrayNotification(), "Chambers");
 		g.dispose();
+
 		overlay.setSharable(false);
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsPlugin.java
@@ -90,7 +90,6 @@ import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.plugins.raids.solver.Layout;
 import net.runelite.client.plugins.raids.solver.LayoutSolver;
-import net.runelite.client.plugins.raids.solver.RotationSolver;
 import net.runelite.client.ui.DrawManager;
 import net.runelite.client.ui.FontManager;
 import net.runelite.client.ui.overlay.OverlayManager;
@@ -521,7 +520,7 @@ public class RaidsPlugin extends Plugin
 			String key = everything.substring(0, split);
 			if (key.length() < 1)
 				continue;
-			String[] itemNames = everything.substring(split).split(SPLIT_REGEX);
+			List<String> itemNames = Text.fromCSV(everything.substring(split));
 
 			map.computeIfAbsent(key, k -> new ArrayList<>());
 
@@ -823,7 +822,7 @@ public class RaidsPlugin extends Plugin
 		g.fillRect(0, 0, overlaySize.width, overlaySize.height);
 
 		overlay.render(g);
-		screenCapture.takeScreenshot(bim, config.enableTrayNotification(), "Chambers");
+		screenCapture.takeScreenshot(bim, config.enableTrayNotification(), config.uploadScreenshot(), "Chambers");
 		g.dispose();
 
 		overlay.setSharable(false);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsPlugin.java
@@ -79,7 +79,6 @@ import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.events.ChatInput;
 import net.runelite.client.events.ConfigChanged;
 import net.runelite.client.events.OverlayMenuClicked;
-import net.runelite.client.game.ItemManager;
 import net.runelite.client.game.SpriteManager;
 import net.runelite.client.input.KeyManager;
 import net.runelite.client.plugins.Plugin;
@@ -177,9 +176,6 @@ public class RaidsPlugin extends Plugin
 
 	@Inject
 	private ScreenCapture screenCapture;
-
-	@Inject
-	private ItemManager itemManager;
 
 	@Getter
 	private final Set<String> roomWhitelist = new HashSet<String>();

--- a/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsPlugin.java
@@ -35,15 +35,11 @@ import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.text.DecimalFormat;
 import java.time.Instant;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashSet;
+import java.util.*;
 import java.util.List;
-import java.util.Set;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
 import lombok.AccessLevel;
@@ -122,6 +118,7 @@ public class RaidsPlugin extends Plugin
 	private static final DecimalFormat POINTS_FORMAT = new DecimalFormat("#,###");
 	private static final String LAYOUT_COMMAND = "!layout";
 	private static final int LINE_COMPONENT_HEIGHT = 16;
+	private static final Pattern ROTATION_REGEX = Pattern.compile("\\[(.*?)]");
 	private static final int MAX_LAYOUT_LEN = 300;
 
 	@Inject
@@ -196,10 +193,10 @@ public class RaidsPlugin extends Plugin
 	@Getter
 	private final Set<String> layoutWhitelist = new HashSet<String>();
 
-	@Setter(AccessLevel.PACKAGE) // for the test
 	@Getter
 	private final Map<String, List<Integer>> recommendedItemsList = new HashMap<>();
 
+	@Setter(AccessLevel.PACKAGE) // for the test
 	@Getter
 	private Raid raid;
 
@@ -496,6 +493,7 @@ public class RaidsPlugin extends Plugin
 		updateList(roomWhitelist, config.whitelistedRooms());
 		updateList(roomBlacklist, config.blacklistedRooms());
 		updateList(layoutWhitelist, config.whitelistedLayouts());
+		updateMap(recommendedItemsList, config.recommendedItems());
 
 		// Update rotation whitelist
 		rotationWhitelist.clear();
@@ -505,7 +503,6 @@ public class RaidsPlugin extends Plugin
 		}
 	}
 
-	private void updateList(Collection<String> list, String input)
 	private void updateMap(Map<String, List<Integer>> map, String input)
 	{
 		map.clear();
@@ -540,6 +537,7 @@ public class RaidsPlugin extends Plugin
 		}
 	}
 
+	private void updateList(Collection<String> list, String input)
 	{
 		list.clear();
 		for (String s : Text.fromCSV(input.toLowerCase()))

--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
@@ -587,10 +587,6 @@ public class ScreenshotPlugin extends Plugin
 
 		// Draw the game onto the screenshot
 		graphics.drawImage(image, gameOffsetX, gameOffsetY, null);
-			else if (worldTypes.contains(WorldType.LEAGUE))
-			{
-				playerDir += "-League";
-			}
 		screenCapture.takeScreenshot(screenshot, fileName, config.notifyWhenTaken(), config.uploadScreenshot());
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/TransferableBufferedImage.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/TransferableBufferedImage.java
@@ -34,7 +34,7 @@ import lombok.AllArgsConstructor;
 import lombok.NonNull;
 
 @AllArgsConstructor
-class TransferableBufferedImage implements Transferable
+public class TransferableBufferedImage implements Transferable
 {
 	@NonNull
 	private final BufferedImage image;

--- a/runelite-client/src/main/java/net/runelite/client/util/ScreenCapture.java
+++ b/runelite-client/src/main/java/net/runelite/client/util/ScreenCapture.java
@@ -1,0 +1,205 @@
+package net.runelite.client.util;
+
+import java.awt.Toolkit;
+import java.awt.TrayIcon;
+import java.awt.datatransfer.Clipboard;
+import java.awt.datatransfer.StringSelection;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.EnumSet;
+import java.util.concurrent.ScheduledExecutorService;
+import javax.imageio.ImageIO;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.Client;
+import net.runelite.api.GameState;
+import net.runelite.api.WorldType;
+import net.runelite.client.Notifier;
+import static net.runelite.client.RuneLite.SCREENSHOT_DIR;
+import net.runelite.client.plugins.screenshot.imgur.ImageUploadRequest;
+import net.runelite.client.plugins.screenshot.imgur.ImageUploadResponse;
+import net.runelite.http.api.RuneLiteAPI;
+import okhttp3.Call;
+import okhttp3.Callback;
+import okhttp3.HttpUrl;
+import okhttp3.MediaType;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+
+@Slf4j
+@Singleton
+public class ScreenCapture
+{
+	private static final String IMGUR_CLIENT_ID = "30d71e5f6860809";
+	private static final HttpUrl IMGUR_IMAGE_UPLOAD_URL = HttpUrl.parse("https://api.imgur.com/3/image");
+	private static final MediaType JSON = MediaType.parse("application/json");
+	private static final DateFormat TIME_FORMAT = new SimpleDateFormat("yyyy-MM-dd_HH-mm-ss");
+
+	@Inject
+	private ScheduledExecutorService executor;
+
+	@Inject
+	private Client client;
+
+	@Inject
+	private Notifier notifier;
+
+	/**
+	 * Saves a screenshot of the client window to the screenshot folder as a PNG,
+	 * sends a notification to the system tray, and uploads it to an image-hosting service.
+	 *
+	 * @param screenshot BufferedImage to capture.
+	 * @param notify Send a notification to the system tray when the image is captured.
+	 * @param subDirectory Subdirectory of the default screenshot directory to save the image in.
+	 */
+	public void takeScreenshot(BufferedImage screenshot, boolean notify, String subDirectory)
+	{
+		takeScreenshot(screenshot, null, notify, true, subDirectory);
+	}
+
+	/**
+	 * Saves a screenshot of the client window to the screenshot folder as a PNG,
+	 * and optionally uploads it to an image-hosting service.
+	 *
+	 * @param screenshot BufferedImage to capture.
+	 * @param name Filename to use, without file extension.
+	 * @param notify Send a notification to the system tray when the image is captured.
+	 * @param upload Upload the image to a hosting service.
+	 */
+	public void takeScreenshot(BufferedImage screenshot, String name, boolean notify, boolean upload)
+	{
+		takeScreenshot(screenshot, name, notify, upload, null);
+	}
+
+	/**
+	 * Saves a screenshot of the client window to the screenshot folder as a PNG,
+	 * and optionally uploads it to an image-hosting service.
+	 *
+	 * @param screenshot BufferedImage to capture.
+	 * @param name Filename to use, without file extension.
+	 * @param subDirectory Subdirectory of the default screenshot directory to save the image in.
+	 * @param notify Send a notification to the system tray when the image is captured.
+	 * @param upload Upload the image to a hosting service.
+	 */
+	public void takeScreenshot(BufferedImage screenshot, String name, boolean notify, boolean upload, String subDirectory)
+	{
+		if (client.getGameState() == GameState.LOGIN_SCREEN)
+		{
+			// Prevent the screenshot from being captured
+			log.info("Login screenshot prevented");
+			return;
+		}
+
+		if (name == null)
+			name = format(new Date());
+
+		String fileName = name;
+		File imageDirectory;
+		if (client.getLocalPlayer() != null && client.getLocalPlayer().getName() != null)
+		{
+			final EnumSet<WorldType> worldTypes = client.getWorldType();
+			final boolean dmm = worldTypes.contains(WorldType.DEADMAN);
+			final boolean sdmm = worldTypes.contains(WorldType.SEASONAL_DEADMAN);
+			final boolean isDmmWorld = dmm || sdmm;
+
+			String playerDir = client.getLocalPlayer().getName();
+			if (isDmmWorld)
+				playerDir += "-Deadman";
+			imageDirectory = new File(SCREENSHOT_DIR, playerDir);
+		}
+		else
+		{
+			imageDirectory = SCREENSHOT_DIR;
+		}
+		if (subDirectory != null)
+			imageDirectory = new File(imageDirectory, subDirectory);
+
+		imageDirectory.mkdirs();
+		File writeDirectory = imageDirectory;
+
+		executor.execute(() ->
+		{
+			try
+			{
+				File screenshotFile = new File(writeDirectory, fileName + ".png");
+
+				ImageIO.write(screenshot, "PNG", screenshotFile);
+
+				if (upload)
+					uploadScreenshot(screenshotFile, notify);
+				else if (notify)
+					notifier.notify("A screenshot was saved to " + screenshotFile, TrayIcon.MessageType.INFO);
+			}
+			catch (IOException ex)
+			{
+				log.warn("error writing screenshot", ex);
+			}
+		});
+	}
+
+	/**
+	 * Uploads a screenshot to the Imgur image-hosting service,
+	 * and copies the image link to the clipboard.
+	 *
+	 * @param screenshotFile Image file to upload.
+	 * @throws IOException Thrown if the file cannot be read.
+	 */
+	private void uploadScreenshot(File screenshotFile, boolean notify) throws IOException
+	{
+		String json = RuneLiteAPI.GSON.toJson(new ImageUploadRequest(screenshotFile));
+
+		Request request = new Request.Builder()
+			.url(IMGUR_IMAGE_UPLOAD_URL)
+			.addHeader("Authorization", "Client-ID " + IMGUR_CLIENT_ID)
+			.post(RequestBody.create(JSON, json))
+			.build();
+
+		executor.execute(() ->
+			RuneLiteAPI.CLIENT.newCall(request).enqueue(new Callback()
+			{
+				@Override
+				public void onFailure(Call call, IOException ex)
+				{
+					log.warn("error uploading screenshot", ex);
+				}
+
+				@Override
+				public void onResponse(Call call, Response response) throws IOException
+				{
+					try (InputStream in = response.body().byteStream())
+					{
+						ImageUploadResponse imageUploadResponse = RuneLiteAPI.GSON
+							.fromJson(new InputStreamReader(in), ImageUploadResponse.class);
+
+						if (imageUploadResponse.isSuccess())
+						{
+							String link = imageUploadResponse.getData().getLink();
+
+							StringSelection selection = new StringSelection(link);
+							Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
+							clipboard.setContents(selection, selection);
+							if (notify)
+								notifier.notify("A screenshot was uploaded and inserted into your clipboard!", TrayIcon.MessageType.INFO);
+						}
+					}
+				}
+			})
+		);
+	}
+
+	private static String format(Date date)
+	{
+		synchronized (TIME_FORMAT)
+		{
+			return TIME_FORMAT.format(date);
+		}
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/util/ScreenCapture.java
+++ b/runelite-client/src/main/java/net/runelite/client/util/ScreenCapture.java
@@ -108,7 +108,8 @@ public class ScreenCapture
 			final EnumSet<WorldType> worldTypes = client.getWorldType();
 			final boolean dmm = worldTypes.contains(WorldType.DEADMAN);
 			final boolean sdmm = worldTypes.contains(WorldType.SEASONAL_DEADMAN);
-			final boolean isDmmWorld = dmm || sdmm;
+			final boolean dmmt = worldTypes.contains(WorldType.DEADMAN_TOURNAMENT);
+			final boolean isDmmWorld = dmm || sdmm || dmmt;
 
 			String playerDir = client.getLocalPlayer().getName();
 			if (isDmmWorld)

--- a/runelite-client/src/main/java/net/runelite/client/util/ScreenCapture.java
+++ b/runelite-client/src/main/java/net/runelite/client/util/ScreenCapture.java
@@ -109,14 +109,16 @@ public class ScreenCapture
 		if (client.getLocalPlayer() != null && client.getLocalPlayer().getName() != null)
 		{
 			final EnumSet<WorldType> worldTypes = client.getWorldType();
-			final boolean dmm = worldTypes.contains(WorldType.DEADMAN);
-			final boolean sdmm = worldTypes.contains(WorldType.SEASONAL_DEADMAN);
-			final boolean dmmt = worldTypes.contains(WorldType.DEADMAN_TOURNAMENT);
-			final boolean isDmmWorld = dmm || sdmm || dmmt;
 
 			String playerDir = client.getLocalPlayer().getName();
-			if (isDmmWorld)
+			if (worldTypes.contains(WorldType.DEADMAN))
+			{
 				playerDir += "-Deadman";
+			}
+			else if (worldTypes.contains(WorldType.LEAGUE))
+			{
+				playerDir += "-League";
+			}
 			imageDirectory = new File(SCREENSHOT_DIR, playerDir);
 		}
 		else


### PR DESCRIPTION
### Why?
Some chambers groups use out of game communication software such as Discord and Teamspeak to share their raid scouts. These feature additions would streamline the sharing process.

### Normal RuneLite Capture:
![current_example](https://i.gyazo.com/99951df615dc266776f382fc98376b5c.png)

### With My Modifications:
![feature_additions](https://i.gyazo.com/1f3df16f724c10499bce72c77cea199a.png)

## Added functionality is opt-in:
1. **Sharable Image**
 - Add ability to copy the scouter to **imgur**, and copy a **link** to the clipboard
    - has a configurable hotkey
2. **CC and World**
 - Adds the current **clan chan** and **world**
    - toggle-able view in-client
3. **Enhance Scouter Title**
 - Add small text string of "**#combat puzzles**" to TitleComponent
    - Where puzzle shows if the raid is rope + (crabs, ice demon, or unknown)
    - Example: "4c cr"
4. **Recommended Items Overlay**
 - Add an overlay of recommended items. This is user-set(see Notes section below).
    - Also allows the spell: ice barrage.
5. **Scavenger Prep**
 - Shows final scavenger room before Ice Demon/Olm.
    - Scavenger prep color is customizable in the config.
6. **Color Tightrope**
 - Tightropes can be given a user-set color to make them more distinct.
7. **Hide undesirable Raids**
 - Vanguards and/or Unknown Combat and/or raids without a Tightrope room may be hidden completely.
 - I may eventually add a custom config here so users can specify other things, but these are the most commonly avoided raid rooms.
8. **All Scavengers and Farming**
 - A friend of mine who is not a native Latin alphabet user requested it. It is easier for them to comprehend whole words instead of the string of capital letters. Yes, I **know** it's ugly as sin.

## Notes
The recommended items are set in the config like: "[room_name,item1,item2],[room_name, ...
![recommended_item_example](https://i.gyazo.com/798e5d4fc79f0b82ac34df86fe7897d6.png)
My current recommended item list:
"[guardians,dragon pickaxe],[muttadiles,ice barrage],[mystics,salve amulet],[shamans],[tekton,abyssal bludgeon],[thieving,lockpick],[vasa,abyssal dagger],[vespula,super restore],[ice demon,tome of fire]"
If there are too many items to fit in the scouter, they are scaled down.
![too_many_items](https://i.imgur.com/yQSFSKF.png)

### ScreenCapture Util:
Since the capture ability is so similar to the capturing done by the ScreenshotPlugin, the capture portion of that code has been relocated to the ScreenCapture Util.

## Compiling a Modded Client: 
Follow the instructions in the link below for building with IntelliJ, *except* download and use my latest commit *instead of* using the Runelite master branch.
You can download my latest commit by clicking "Commits" near the top of this PR, then clicking the "<>" button of my latest commit, then clicking the green "Clone or download" button.
https://github.com/runelite/runelite/wiki/Building-with-IntelliJ-IDEA
After successfully building the project, a jarred client can be found at:
(your git folder)\runelite\runelite-client\target\client-#.#.#-SNAPSHOT-shaded.jar