### PR TITLE
puzzlesolver: wait a duration before recomputing the solution

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/puzzlesolver/PuzzleSolverOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/puzzlesolver/PuzzleSolverOverlay.java
@@ -333,7 +333,8 @@ public class PuzzleSolverOverlay extends Overlay
 		}
 
 		// Solve the puzzle if we don't have an up to date solution
-		if (solver == null || cachedItems == null || (!shouldCache && !Arrays.equals(cachedItems, itemIds)))
+		if (solver == null || cachedItems == null
+			|| (!shouldCache && solver.hasExceededWaitDuration() && !Arrays.equals(cachedItems, itemIds)))
 		{
 			solve(itemIds);
 			shouldCache = true;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/puzzlesolver/solver/PuzzleSolver.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/puzzlesolver/solver/PuzzleSolver.java
@@ -25,6 +25,8 @@
  */
 package net.runelite.client.plugins.puzzlesolver.solver;
 
+import com.google.common.base.Stopwatch;
+import java.time.Duration;
 import java.util.List;
 import net.runelite.client.plugins.puzzlesolver.solver.pathfinding.Pathfinder;
 
@@ -32,11 +34,14 @@ public class PuzzleSolver implements Runnable
 {
 	public static final int DIMENSION = 5;
 
+	private static final Duration MAX_WAIT_DURATION = Duration.ofMillis(1500);
+
 	private Pathfinder pathfinder;
 	private PuzzleState startState;
 
 	private List<PuzzleState> solution;
 	private int position;
+	private Stopwatch stopwatch;
 	private boolean failed = false;
 
 	public PuzzleSolver(Pathfinder pathfinder, PuzzleState startState)
@@ -70,6 +75,11 @@ public class PuzzleSolver implements Runnable
 		this.position = position;
 	}
 
+	public boolean hasExceededWaitDuration()
+	{
+		return stopwatch.elapsed().compareTo(MAX_WAIT_DURATION) > 0;
+	}
+
 	public boolean hasFailed()
 	{
 		return failed;
@@ -78,6 +88,7 @@ public class PuzzleSolver implements Runnable
 	@Override
 	public void run()
 	{
+		stopwatch = Stopwatch.createStarted();
 		solution = pathfinder.computePath(startState);
 		failed = solution == null;
 	}


### PR DESCRIPTION
Fixes #5325.

Waits 1500ms after the start of computation before it thrashes the solver and remakes it.

Most puzzles take less than 20ms to solve, so it should always display a solution even though the user is spamming tiles (or, eh.. solving it quickly themselves).