### PR TITLE
Wait for process termination when sending notification

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/Notifier.java
+++ b/runelite-client/src/main/java/net/runelite/client/Notifier.java
@@ -42,6 +42,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import javax.inject.Singleton;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.ChatMessageType;
@@ -216,8 +217,23 @@ public class Notifier
 		executorService.submit(() ->
 		{
 			final boolean success = sendCommand(commands)
-					.map(process -> process.exitValue() == 0)
-					.orElse(false);
+				.map(process ->
+				{
+					try
+					{
+						if (!process.waitFor(500, TimeUnit.MILLISECONDS))
+						{
+							return false;
+						}
+					}
+					catch (InterruptedException e)
+					{
+						return false;
+					}
+
+					return process.exitValue() == 0;
+				})
+				.orElse(false);
 
 			if (!success)
 			{


### PR DESCRIPTION
Wait for process termination before calling .exitValue when sending
notification from notifier via command.

Fixes #5956
Closes #6034

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>