### PR TITLE
Swap also "quick pass" in Cerb lair

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -476,6 +476,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 		else if (config.swapQuick() && option.equals("pass"))
 		{
 			swap("quick-pass", option, target, true);
+			swap("quick pass", option, target, true);
 		}
 		else if (config.swapAdmire() && option.equals("admire"))
 		{


### PR DESCRIPTION
In cerb lair the option is "Quick Pass" not "Quick-pass" like in Raids
1.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>