### PR TITLE
Keep WidgetOverlay always on UNDER_WIDGETS layer

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayManager.java
@@ -224,7 +224,7 @@ public class OverlayManager
 			{
 				// When UNDER_WIDGET overlays are in preferred locations, move to
 				// ABOVE_WIDGETS so that it can draw over interfaces
-				if (layer == OverlayLayer.UNDER_WIDGETS)
+				if (layer == OverlayLayer.UNDER_WIDGETS && !(overlay instanceof WidgetOverlay))
 				{
 					layer = OverlayLayer.ABOVE_WIDGETS;
 				}


### PR DESCRIPTION
The update needs to be done ALWAYS before widgets are drawn

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>