### PR TITLE
Prevent NPE in recent clan chats when var is null

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/clanchat/ClanChatPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/clanchat/ClanChatPlugin.java
@@ -133,7 +133,7 @@ public class ClanChatPlugin extends Plugin
 	{
 		if (strChanged.getIndex() == VarClientStr.RECENT_CLAN_CHAT.getIndex() && config.recentChats())
 		{
-			updateRecentChat(Text.toJagexName(client.getVar(VarClientStr.RECENT_CLAN_CHAT)));
+			updateRecentChat(client.getVar(VarClientStr.RECENT_CLAN_CHAT));
 		}
 	}
 
@@ -214,6 +214,8 @@ public class ClanChatPlugin extends Plugin
 		{
 			return;
 		}
+
+		s = Text.toJagexName(s);
 
 		chats.removeIf(s::equalsIgnoreCase);
 		chats.add(s);


### PR DESCRIPTION
RECENT_CLAN_CHAT can be null when reset, so move the jagex name
sanitization to updateRecentChat method (after null check).

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>