### PR TITLE
[WIP] Add Discord webhook plugin

### DIFF
--- a/http-api/src/main/java/net/runelite/http/api/discord/DiscordClient.java
+++ b/http-api/src/main/java/net/runelite/http/api/discord/DiscordClient.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2018, Forsco <https://github.com/forsco>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package net.runelite.http.api.discord;
+
+import com.google.gson.Gson;
+import java.io.IOException;
+import net.runelite.http.api.RuneLiteAPI;
+import okhttp3.Call;
+import okhttp3.Callback;
+import okhttp3.HttpUrl;
+import okhttp3.MediaType;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DiscordClient
+{
+	public static final Gson gson = new Gson();
+	private static final MediaType JSON = MediaType.parse("application/json");
+
+	private static final Logger logger = LoggerFactory.getLogger(DiscordClient.class);
+
+	public void message(HttpUrl url, DiscordMessage discordMessage)
+	{
+		message(url, discordMessage, 0, 5);
+	}
+
+	private void message(HttpUrl url, DiscordMessage discordMessage, int retryAttempt, int maxAttempts)
+	{
+		Request request = new Request.Builder()
+			.post(RequestBody.create(JSON, gson.toJson(discordMessage)))
+			.url(url)
+			.build();
+
+		RuneLiteAPI.CLIENT.newCall(request).enqueue(new Callback()
+		{
+
+			@Override
+			public void onFailure(Call call, IOException e)
+			{
+				logger.warn("unable to submit discord post", e);
+				if (retryAttempt < maxAttempts)
+				{
+					message(url, discordMessage, retryAttempt + 1, maxAttempts);
+				}
+			}
+
+			@Override
+			public void onResponse(Call call, Response response) throws IOException
+			{
+				try
+				{
+					if (response.body().string().contains("You are being rate limited") && retryAttempt < maxAttempts)
+					{
+						logger.debug("you are being rate limited, retrying...");
+						message(url, discordMessage, retryAttempt + 1, maxAttempts);
+					}
+				}
+				finally
+				{
+					response.close();
+					logger.debug("submitted discord log record");
+				}
+			}
+		});
+	}
+}

--- a/http-api/src/main/java/net/runelite/http/api/discord/DiscordEmbed.java
+++ b/http-api/src/main/java/net/runelite/http/api/discord/DiscordEmbed.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2018, Forsco <https://github.com/forsco>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package net.runelite.http.api.discord;
+
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import net.runelite.http.api.discord.embed.AuthorEmbed;
+import net.runelite.http.api.discord.embed.FieldEmbed;
+import net.runelite.http.api.discord.embed.FooterEmbed;
+import net.runelite.http.api.discord.embed.ImageEmbed;
+import net.runelite.http.api.discord.embed.ProviderEmbed;
+import net.runelite.http.api.discord.embed.ThumbnailEmbed;
+import net.runelite.http.api.discord.embed.VideoEmbed;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+public class DiscordEmbed
+{
+	String title;
+	String type;
+	String description;
+	String url;
+	String timestamp;
+	String iconurl;
+	int color;
+	FooterEmbed footer;
+	ImageEmbed image;
+	ThumbnailEmbed thumbnail;
+	VideoEmbed video;
+	ProviderEmbed provider;
+	AuthorEmbed author;
+	List<FieldEmbed> fields = new ArrayList<FieldEmbed>();
+
+	public DiscordEmbed()
+	{
+
+	}
+
+	public DiscordEmbed(String title, String description)
+	{
+		this(title, description, null);
+	}
+
+	public DiscordEmbed(String title, String description, String url)
+	{
+		setTitle(title);
+		setDescription(description);
+		setUrl(url);
+	}
+
+	public static DiscordMessage toDiscordMessage(DiscordEmbed embed, String username, String avatarURL)
+	{
+		DiscordMessage dm = DiscordMessage.builder()
+			.username(username)
+			.avatarUrl(avatarURL)
+			.content("")
+			.embed(embed)
+			.build();
+
+		return dm;
+	}
+
+	public DiscordMessage toDiscordMessage(String username, String avatarUrl)
+	{
+		return DiscordEmbed.toDiscordMessage(this, username, avatarUrl);
+	}
+
+	public static class DiscordEmbedBuilder
+	{
+		List<FieldEmbed> fields = new ArrayList<FieldEmbed>();
+
+		public DiscordEmbedBuilder field(FieldEmbed field)
+		{
+			fields.add(field);
+			return this;
+		}
+	}
+}

--- a/http-api/src/main/java/net/runelite/http/api/discord/DiscordMessage.java
+++ b/http-api/src/main/java/net/runelite/http/api/discord/DiscordMessage.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2018, Forsco <https://github.com/forsco>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package net.runelite.http.api.discord;
+
+import com.google.gson.annotations.SerializedName;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+public class DiscordMessage
+{
+	String username;
+	String content;
+	@SerializedName("avatar_url")
+	String avatarUrl;
+	@SerializedName("tts")
+	boolean textToSpeech;
+	List<DiscordEmbed> embeds = new ArrayList<DiscordEmbed>();
+
+	public DiscordMessage()
+	{
+
+	}
+
+	public DiscordMessage(String username, String content, String avatar_url)
+	{
+		this(username, content, avatar_url, false);
+	}
+
+	public DiscordMessage(String username, String content, String avatar_url, boolean tts)
+	{
+		setUsername(username);
+		setContent(content);
+		setAvatarUrl(avatar_url);
+		setTextToSpeech(tts);
+	}
+
+	public void setUsername(String username)
+	{
+		if (username != null)
+		{
+			this.username = username.substring(0, Math.min(31, username.length()));
+		}
+		else
+		{
+			this.username = null;
+		}
+	}
+
+	public static class DiscordMessageBuilder
+	{
+		List<DiscordEmbed> embeds = new ArrayList<DiscordEmbed>();
+
+		public DiscordMessageBuilder embed(DiscordEmbed embed)
+		{
+			embeds.add(embed);
+			return this;
+		}
+	}
+}

--- a/http-api/src/main/java/net/runelite/http/api/discord/embed/AuthorEmbed.java
+++ b/http-api/src/main/java/net/runelite/http/api/discord/embed/AuthorEmbed.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2018, Forsco <https://github.com/forsco>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package net.runelite.http.api.discord.embed;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class AuthorEmbed
+{
+	String name;
+	String url;
+	String icon_url;
+	String proxy_icon_url;
+}

--- a/http-api/src/main/java/net/runelite/http/api/discord/embed/FieldEmbed.java
+++ b/http-api/src/main/java/net/runelite/http/api/discord/embed/FieldEmbed.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2018, Forsco <https://github.com/forsco>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package net.runelite.http.api.discord.embed;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class FieldEmbed
+{
+	String name;
+	String value;
+	boolean inline;
+}

--- a/http-api/src/main/java/net/runelite/http/api/discord/embed/FooterEmbed.java
+++ b/http-api/src/main/java/net/runelite/http/api/discord/embed/FooterEmbed.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2018, Forsco <https://github.com/forsco>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package net.runelite.http.api.discord.embed;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class FooterEmbed
+{
+	String text;
+	String icon_url;
+	String proxy_icon_url;
+}

--- a/http-api/src/main/java/net/runelite/http/api/discord/embed/ImageEmbed.java
+++ b/http-api/src/main/java/net/runelite/http/api/discord/embed/ImageEmbed.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2018, Forsco <https://github.com/forsco>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package net.runelite.http.api.discord.embed;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ImageEmbed
+{
+	String url;
+	String proxy_url;
+	int height;
+	int width;
+}

--- a/http-api/src/main/java/net/runelite/http/api/discord/embed/ProviderEmbed.java
+++ b/http-api/src/main/java/net/runelite/http/api/discord/embed/ProviderEmbed.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2018, Forsco <https://github.com/forsco>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package net.runelite.http.api.discord.embed;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ProviderEmbed
+{
+	String name;
+	String url;
+}

--- a/http-api/src/main/java/net/runelite/http/api/discord/embed/ThumbnailEmbed.java
+++ b/http-api/src/main/java/net/runelite/http/api/discord/embed/ThumbnailEmbed.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2018, Forsco <https://github.com/forsco>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package net.runelite.http.api.discord.embed;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ThumbnailEmbed
+{
+	String url;
+	String proxy_url;
+	int height;
+	int width;
+}

--- a/http-api/src/main/java/net/runelite/http/api/discord/embed/VideoEmbed.java
+++ b/http-api/src/main/java/net/runelite/http/api/discord/embed/VideoEmbed.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2018, Forsco <https://github.com/forsco>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package net.runelite.http.api.discord.embed;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class VideoEmbed
+{
+	String url;
+	int height;
+	int width;
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/discordwebhook/DiscordWebhookConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/discordwebhook/DiscordWebhookConfig.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2018, Forsco <https://github.com/forsco>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package net.runelite.client.plugins.discordwebhook;
+
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+
+@ConfigGroup("discordwebhook")
+public interface DiscordWebhookConfig extends Config
+{
+	@ConfigItem(
+		name = "Webhook URL",
+		keyName = "discordUrl",
+		description = "Enter your Discord Webhook URL",
+		position = 0
+	)
+	default String getDiscordUrl() {
+		return "";
+	}
+
+	@ConfigItem(
+		name = "Log loot received",
+		keyName = "logLootType",
+		description = "configure what received loot is logged",
+		position = 1
+	)
+	default LootLogType lootLogType() {
+		return LootLogType.NONE;
+	}
+
+	@ConfigItem(
+		name = "Log > GE Value",
+		keyName = "minLootValue",
+		description = "Configures the minimum value which loot received is logged",
+		position = 2
+	)
+	default int getMinLootValue() {
+		return 0;
+	}
+
+	@ConfigItem(
+		name = "Log boss kc",
+		keyName = "logBossKc",
+		description = "Configures logging boss kill count",
+		position = 3
+	)
+	default boolean isLoggingBossKc() {
+		return false;
+	}
+
+	@ConfigItem(
+		name = "Log clue scrolls",
+		keyName = "logClues",
+		description = "Configures logging clue scrolls",
+		position = 4
+	)
+	default boolean isLoggingClues() {
+		return false;
+	}
+
+	@ConfigItem(
+		name = "Log pvp kills",
+		keyName = "logPvpKills",
+		description = "Configures logging PvP kills",
+		position = 5
+	)
+	default boolean isLoggingPvpKills() {
+		return false;
+	}
+
+	@ConfigItem(
+		name = "Log level ups",
+		keyName = "logLevelUps",
+		description = "Configures logging level ups",
+		position = 6
+	)
+	default boolean isLoggingLevelUps() {
+		return false;
+	}
+
+	@ConfigItem(
+		name = "Log slayer tasks/streak",
+		keyName = "logSlayer",
+		description = "Configures logging slayer tasks completion and streak count",
+		position = 7
+	)
+	default boolean isLoggingSlayer() {
+		return false;
+	}
+
+	@ConfigItem(
+		name = "Log your deaths",
+		keyName = "logDeaths",
+		description = "Configures logging your deaths",
+		position = 8
+	)
+	default boolean isLoggingDeaths() {
+		return false;
+	}
+
+	@ConfigItem(
+		name = "Log quest completion",
+		keyName = "logQuests",
+		description = "Configures logging quest completions",
+		position = 9
+	)
+	default boolean isLoggingQuests() {
+		return false;
+	}
+
+	@ConfigItem(
+		name = "Log pets received",
+		keyName = "logPets",
+		description = "Configures logging pets received",
+		position = 10
+	)
+	default boolean isLoggingPets()
+	{
+		return false;
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/discordwebhook/DiscordWebhookConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/discordwebhook/DiscordWebhookConfig.java
@@ -38,7 +38,8 @@ public interface DiscordWebhookConfig extends Config
 		description = "Enter your Discord Webhook URL",
 		position = 0
 	)
-	default String getDiscordUrl() {
+	default String getDiscordUrl()
+	{
 		return "";
 	}
 
@@ -48,7 +49,8 @@ public interface DiscordWebhookConfig extends Config
 		description = "configure what received loot is logged",
 		position = 1
 	)
-	default LootLogType lootLogType() {
+	default LootLogType lootLogType()
+	{
 		return LootLogType.NONE;
 	}
 
@@ -58,7 +60,8 @@ public interface DiscordWebhookConfig extends Config
 		description = "Configures the minimum value which loot received is logged",
 		position = 2
 	)
-	default int getMinLootValue() {
+	default int getMinLootValue()
+	{
 		return 0;
 	}
 
@@ -68,7 +71,8 @@ public interface DiscordWebhookConfig extends Config
 		description = "Configures logging boss kill count",
 		position = 3
 	)
-	default boolean isLoggingBossKc() {
+	default boolean isLoggingBossKc()
+	{
 		return false;
 	}
 
@@ -78,7 +82,8 @@ public interface DiscordWebhookConfig extends Config
 		description = "Configures logging clue scrolls",
 		position = 4
 	)
-	default boolean isLoggingClues() {
+	default boolean isLoggingClues()
+	{
 		return false;
 	}
 
@@ -88,7 +93,8 @@ public interface DiscordWebhookConfig extends Config
 		description = "Configures logging PvP kills",
 		position = 5
 	)
-	default boolean isLoggingPvpKills() {
+	default boolean isLoggingPvpKills()
+	{
 		return false;
 	}
 
@@ -98,7 +104,8 @@ public interface DiscordWebhookConfig extends Config
 		description = "Configures logging level ups",
 		position = 6
 	)
-	default boolean isLoggingLevelUps() {
+	default boolean isLoggingLevelUps()
+	{
 		return false;
 	}
 
@@ -108,7 +115,8 @@ public interface DiscordWebhookConfig extends Config
 		description = "Configures logging slayer tasks completion and streak count",
 		position = 7
 	)
-	default boolean isLoggingSlayer() {
+	default boolean isLoggingSlayer()
+	{
 		return false;
 	}
 
@@ -118,7 +126,8 @@ public interface DiscordWebhookConfig extends Config
 		description = "Configures logging your deaths",
 		position = 8
 	)
-	default boolean isLoggingDeaths() {
+	default boolean isLoggingDeaths()
+	{
 		return false;
 	}
 
@@ -128,7 +137,8 @@ public interface DiscordWebhookConfig extends Config
 		description = "Configures logging quest completions",
 		position = 9
 	)
-	default boolean isLoggingQuests() {
+	default boolean isLoggingQuests()
+	{
 		return false;
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/discordwebhook/DiscordWebhookPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/discordwebhook/DiscordWebhookPlugin.java
@@ -131,7 +131,7 @@ public class DiscordWebhookPlugin extends Plugin
 			switch (accountType)
 			{
 				case NORMAL:
-					iconUrl = ICONBASEURL + 1038 + ".png";
+					iconUrl = getIcon(1038);
 					break;
 				case IRONMAN:
 					iconUrl = "https://raw.githubusercontent.com/runelite/runelite/master/runelite-client/src/main/resources/net/runelite/client/plugins/hiscore/ironman.png";
@@ -239,5 +239,10 @@ public class DiscordWebhookPlugin extends Plugin
 	private void discordInit()
 	{
 		url = HttpUrl.parse(config.getDiscordUrl());
+	}
+
+	private String getIcon(int itemID)
+	{
+		return ICONBASEURL + itemID + ".png";
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/discordwebhook/DiscordWebhookPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/discordwebhook/DiscordWebhookPlugin.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright (c) 2018, Forsco <https://github.com/forsco>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package net.runelite.client.plugins.discordwebhook;
+
+import com.google.common.eventbus.Subscribe;
+import com.google.inject.Provides;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
+import javax.inject.Inject;
+import net.runelite.api.Client;
+import net.runelite.api.ItemComposition;
+import net.runelite.api.NPC;
+import net.runelite.api.WorldType;
+import net.runelite.api.events.GameStateChanged;
+import net.runelite.api.events.GameTick;
+import net.runelite.api.vars.AccountType;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.events.NpcLootReceived;
+import net.runelite.client.game.ItemManager;
+import net.runelite.client.game.ItemStack;
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.http.api.discord.DiscordClient;
+import net.runelite.http.api.discord.DiscordEmbed;
+import net.runelite.http.api.discord.DiscordMessage;
+import net.runelite.http.api.discord.embed.AuthorEmbed;
+import net.runelite.http.api.discord.embed.FieldEmbed;
+import net.runelite.http.api.discord.embed.FooterEmbed;
+import okhttp3.HttpUrl;
+
+@PluginDescriptor(
+	name = "Discord Logger",
+	description = "Configure events to be posted to a Discord channel via a webhook",
+	tags = {"discord", "webhook", "log", "logger"}
+)
+public class DiscordWebhookPlugin extends Plugin
+{
+	private static final DiscordClient CLIENT = new DiscordClient();
+	private static final String ICONBASEURL = "https://static.runelite.net/cache/item/icon/"; // Add item id + ".png"
+
+	private String iconUrl;
+	private boolean checkAccount;
+	private AccountType accountType;
+
+	private HttpUrl url;
+
+	@Inject
+	private Client client;
+
+	@Inject
+	private DiscordWebhookConfig config;
+
+	@Inject
+	private ItemManager itemManager;
+
+	@Inject
+	private ScheduledExecutorService executorService;
+
+	@Provides
+	DiscordWebhookConfig provideConfig(ConfigManager configManager)
+	{
+		return configManager.getConfig(DiscordWebhookConfig.class);
+	}
+
+	@Override
+	protected void startUp()
+	{
+		discordInit();
+	}
+
+	@Subscribe
+	public void onGameStateChanged(GameStateChanged event)
+	{
+		switch (event.getGameState())
+		{
+			case LOGIN_SCREEN:
+			case LOGGED_IN:
+				checkAccount = true;
+				break;
+		}
+	}
+
+	@Subscribe
+	public void onGameTick(GameTick tick)
+	{
+		if (!checkAccount)
+		{
+			return;
+		}
+
+		checkAccount = false;
+		accountType = client.getAccountType();
+
+		if (!client.getWorldType().equals(WorldType.DEADMAN) || !client.getWorldType().equals(WorldType.SEASONAL_DEADMAN))
+		{
+			switch (accountType)
+			{
+				case NORMAL:
+					iconUrl = ICONBASEURL + 1038 + ".png";
+					break;
+				case IRONMAN:
+					iconUrl = "https://raw.githubusercontent.com/runelite/runelite/master/runelite-client/src/main/resources/net/runelite/client/plugins/hiscore/ironman.png";
+					break;
+				case HARDCORE_IRONMAN:
+					iconUrl = "https://raw.githubusercontent.com/runelite/runelite/master/runelite-client/src/main/resources/net/runelite/client/plugins/hiscore/hardcore_ironman.png";
+					break;
+				case ULTIMATE_IRONMAN:
+					iconUrl = "https://raw.githubusercontent.com/runelite/runelite/master/runelite-client/src/main/resources/net/runelite/client/plugins/hiscore/ultimate_ironman.png";
+					break;
+			}
+		}
+
+		if (client.getWorldType().equals(WorldType.DEADMAN) || client.getWorldType().equals(WorldType.SEASONAL_DEADMAN))
+		{
+			iconUrl = "https://raw.githubusercontent.com/runelite/runelite/master/runelite-client/src/main/resources/net/runelite/client/plugins/hiscore/seasonal_deadman.png";
+		}
+	}
+
+	@Subscribe
+	public void npcLootReceived(final NpcLootReceived npcLootReceived)
+	{
+		if (config.lootLogType().equals(LootLogType.NONE) || !url.isHttps())
+		{
+			return;
+		}
+
+		if (config.lootLogType().equals(LootLogType.ALL) && url.pathSize() > 1)
+		{
+			final NPC npc = npcLootReceived.getNpc();
+			final String npcName = npc.getName();
+			final Collection<ItemStack> items = npcLootReceived.getItems();
+
+			List lootList = new ArrayList();
+
+			for (ItemStack item : items)
+			{
+				final int itemId = item.getId();
+				final ItemComposition itemComposition = itemManager.getItemComposition(itemId);
+				final String itemName = itemComposition.getName();
+				final int itemQuantity = item.getQuantity();
+				final int gePrice = itemManager.getItemPrice(itemId);
+
+				if ((itemQuantity * gePrice) > config.getMinLootValue())
+				{
+					lootList.add(FieldEmbed.builder()
+					.name(itemName + " x " + itemQuantity)
+					.value((itemQuantity * gePrice) + " gp")
+					.build());
+				}
+			}
+
+			if (!lootList.isEmpty())
+			{
+				DiscordEmbed npcLootRecord = DiscordEmbed.builder()
+					.author(AuthorEmbed.builder()
+						.icon_url("")
+						.name(npcName)
+						.build())
+					.description("has been slain for:")
+					.fields(lootList)
+					.footer(FooterEmbed.builder()
+						.icon_url(iconUrl)
+						.text(client.getLocalPlayer().getName())
+						.build())
+					.build();
+
+				DiscordMessage discordMessage = new DiscordMessage("Runelite", "", "");
+				discordMessage.getEmbeds().add(npcLootRecord);
+				CLIENT.message(url, discordMessage);
+				lootList.clear();
+			}
+		}
+	}
+
+	private void discordInit()
+	{
+		url = HttpUrl.parse(config.getDiscordUrl());
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/discordwebhook/DiscordWebhookPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/discordwebhook/DiscordWebhookPlugin.java
@@ -57,7 +57,6 @@ import net.runelite.http.api.discord.embed.AuthorEmbed;
 import net.runelite.http.api.discord.embed.FieldEmbed;
 import net.runelite.http.api.discord.embed.FooterEmbed;
 import okhttp3.HttpUrl;
-import org.slf4j.Logger;
 
 @PluginDescriptor(
 	name = "Discord Logger",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/discordwebhook/LootLogType.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/discordwebhook/LootLogType.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2018, Forsco <https://github.com/forsco>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package net.runelite.client.plugins.discordwebhook;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum LootLogType
+{
+	NONE("Off"),
+	ALL("All Loot"),
+	UNIQUE("Uniques Only"),
+	PVP("PvP Loot Only");
+
+	private final String name;
+
+	@Override
+	public String toString()
+	{
+		return name;
+	}
+}


### PR DESCRIPTION
This is very much still a work in progress and will be looking for as much feedback as possible as i slowly plod away at this.

The aim of this is to allow players and/or clans whom would like a way to share events that occur in game to their Discord server.

- [x] Provide a connection to the payload url
- [x] Implement Discord messages and embed utilities
- [x] Loot receiced types (All, uniques only, pvp only or none)
- [ ] Define item uniques
- [ ] Filter (all?) loot records with a minimum ge value
- [ ] Boss KC
- [ ] Player death (DMM, SDMM, HCIM etc.)
- [ ] Pet received
- [ ] Clue completion and items received
- [ ] PvP kills
- [ ] Skill level ups
- [ ] Slayer task completion and streak count
- [ ] Quest completion

Any other ideas are welcome

![discord_2018-09-20_22-14-57](https://user-images.githubusercontent.com/9327323/47426783-eedaec80-d7d9-11e8-911b-1fe9b85a2efa.png)
![discord_2018-09-16_03-42-49](https://user-images.githubusercontent.com/9327323/47426785-eedaec80-d7d9-11e8-8191-b8452934a500.png)
![discord_2018-09-29_00-03-05](https://user-images.githubusercontent.com/9327323/47426803-07e39d80-d7da-11e8-8580-4f826b515ae2.png)
