### PR TITLE
Remove full clue description from Hot/Cold and Cryptic Clues

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java
@@ -338,11 +338,6 @@ public class CrypticClue extends ClueScroll implements TextClueScroll, NpcClueSc
 	public void makeOverlayHint(PanelComponent panelComponent, ClueScrollPlugin plugin)
 	{
 		panelComponent.getChildren().add(TitleComponent.builder().text("Cryptic Clue").build());
-		panelComponent.getChildren().add(LineComponent.builder().left("Clue:").build());
-		panelComponent.getChildren().add(LineComponent.builder()
-			.left(getText())
-			.leftColor(TITLED_CONTENT_COLOR)
-			.build());
 
 		if (getNpc() != null)
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/HotColdClue.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/HotColdClue.java
@@ -100,14 +100,6 @@ public class HotColdClue extends ClueScroll implements LocationClueScroll, Locat
 		// strange device has not been tested yet, show how to get it
 		if (lastWorldPoint == null && location == null)
 		{
-			panelComponent.getChildren().add(LineComponent.builder()
-				.left("Clue:")
-				.build());
-			panelComponent.getChildren().add(LineComponent.builder()
-				.left(getText())
-				.leftColor(TITLED_CONTENT_COLOR)
-				.build());
-
 			if (getNpc() != null)
 			{
 				panelComponent.getChildren().add(LineComponent.builder()
@@ -137,7 +129,6 @@ public class HotColdClue extends ClueScroll implements LocationClueScroll, Locat
 
 			for (HotColdLocation hotColdLocation : digLocations)
 			{
-				Rectangle2D r = hotColdLocation.getRect();
 				HotColdArea hotColdArea = hotColdLocation.getHotColdArea();
 
 				if (locationCounts.containsKey(hotColdArea))


### PR DESCRIPTION
Remove full clue description (clue text) from cryptic clues and hot/cold clue as the solutions are written right below and with the full text this sometimes makes clue helper unusable in fixed mode.