### PR TITLE
Add back check for widget.isHidden() to TabInterface

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/banktags/tabs/TabInterface.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/banktags/tabs/TabInterface.java
@@ -312,16 +312,22 @@ public class TabInterface
 
 	public void handleWheel(final MouseWheelEvent event)
 	{
-		if (isHidden())
+		if (parent == null || !canvasBounds.contains(event.getPoint()))
 		{
 			return;
 		}
 
-		if (canvasBounds.contains(event.getPoint()))
+		event.consume();
+
+		clientThread.invoke(() ->
 		{
-			event.consume();
-			clientThread.invoke(() -> scrollTab(event.getWheelRotation()));
-		}
+			if (isHidden())
+			{
+				return;
+			}
+
+			scrollTab(event.getWheelRotation());
+		});
 	}
 
 	public void handleAdd(MenuEntryAdded event)
@@ -687,7 +693,7 @@ public class TabInterface
 	private boolean isHidden()
 	{
 		Widget widget = client.getWidget(WidgetInfo.BANK_CONTAINER);
-		return !config.tabs() || widget == null;
+		return !config.tabs() || widget == null || widget.isHidden();
 	}
 
 	private void loadTab(String tag)


### PR DESCRIPTION
This check is still required, because in rare circumstances the bank
widget is simply not nulled.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>