### PR TITLE
plugin/coalbag: add Coal Bag plugin

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/coalbag/CoalBagConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/coalbag/CoalBagConfig.java
@@ -1,3 +1,27 @@
+/*
+ * Copyright (c) 2018, Anthony <cvballa3g0@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package net.runelite.client.plugins.coalbag;
 
 import net.runelite.client.config.Config;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/coalbag/CoalBagConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/coalbag/CoalBagConfig.java
@@ -1,0 +1,27 @@
+package net.runelite.client.plugins.coalbag;
+
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+
+@ConfigGroup("coalbag")
+public interface CoalBagConfig extends Config
+{
+	@ConfigItem(
+			keyName = "amount",
+			name = "",
+			description = "",
+			hidden = true
+	)
+	default int amount()
+	{
+		return 0;
+	}
+
+	@ConfigItem(
+			keyName = "amount",
+			name = "",
+			description = ""
+	)
+	void amount(int amount);
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/coalbag/CoalBagOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/coalbag/CoalBagOverlay.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2018, Anthony <cvballa3g0@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.coalbag;
+
+
+import net.runelite.api.ItemID;
+import net.runelite.api.Point;
+import net.runelite.api.Query;
+import net.runelite.api.queries.InventoryWidgetItemQuery;
+import net.runelite.api.widgets.WidgetItem;
+import net.runelite.client.ui.FontManager;
+import net.runelite.client.ui.overlay.Overlay;
+import net.runelite.client.ui.overlay.OverlayLayer;
+import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.util.QueryRunner;
+
+import javax.inject.Inject;
+import java.awt.*;
+
+public class CoalBagOverlay extends Overlay
+{
+	private final QueryRunner queryRunner;
+	private final CoalBagPlugin plugin;
+
+	@Inject
+	CoalBagOverlay(QueryRunner queryRunner, CoalBagPlugin plugin)
+	{
+		setPosition(OverlayPosition.DYNAMIC);
+		setLayer(OverlayLayer.ABOVE_WIDGETS);
+		this.queryRunner = queryRunner;
+		this.plugin = plugin;
+	}
+
+	@Override
+	public Dimension render(Graphics2D graphics)
+	{
+		Query query = new InventoryWidgetItemQuery().idEquals(ItemID.COAL_BAG_12019);
+		WidgetItem[] items = queryRunner.runQuery(query);
+		if (items.length == 0)
+		{
+			return null;
+		}
+
+		WidgetItem coalBag = items[0];
+		Point location = coalBag.getCanvasLocation();
+		if (location == null)
+		{
+			return null;
+		}
+
+		graphics.setFont(FontManager.getRunescapeSmallFont());
+		graphics.drawString(plugin.getAmount() + "", location.getX(), location.getY() + 14);
+		return null;
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/coalbag/CoalBagPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/coalbag/CoalBagPlugin.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 2018, Anthony <cvballa3g0@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.coalbag;
+
+
+import com.google.common.eventbus.Subscribe;
+import com.google.inject.Provides;
+import net.runelite.api.ChatMessageType;
+import net.runelite.api.ItemID;
+import net.runelite.api.events.ChatMessage;
+import net.runelite.api.events.MenuOptionClicked;
+import net.runelite.api.queries.InventoryWidgetItemQuery;
+import net.runelite.api.widgets.WidgetInfo;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.ui.overlay.OverlayManager;
+import net.runelite.client.util.QueryRunner;
+import net.runelite.client.util.Text;
+
+import javax.inject.Inject;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@PluginDescriptor(
+		name = "Coal Bag",
+		description = "Show the coal count of your Coal Bag",
+		tags = {"coalbag", "coal", "bag", "bf", "blastfurnce", "mlm", "motherloadmine", "mining", "smithing"}
+)
+public class CoalBagPlugin extends Plugin
+{
+	private static final Pattern COAL_BAG_EMPTY_MESSAGE = Pattern.compile("^The coal bag is (now )?empty\\.$");
+	private static final Pattern COAL_BAG_ONE_MESSAGE = Pattern.compile("^The coal bag contains one piece of coal\\.$");
+	private static final Pattern COAL_BAG_AMOUNT_MESSAGE = Pattern.compile("^The coal bag contains (\\d+) pieces of coal\\.$");
+
+	static final int MAX_INVY_SPACE = 28;
+	private static final int FULL_BAG_AMOUNT = 27;
+
+	static final String FILL_OPTION = "fill";
+	static final String EMPTY_OPTION = "empty";
+
+	@Inject
+	private OverlayManager overlayManager;
+
+	@Inject
+	private CoalBagOverlay overlay;
+
+	@Inject
+	private QueryRunner queryRunner;
+
+	@Inject
+	private CoalBagConfig config;
+
+	@Override
+	protected void startUp() throws Exception
+	{
+		overlayManager.add(overlay);
+	}
+
+	@Override
+	protected void shutDown() throws Exception
+	{
+		overlayManager.remove(overlay);
+	}
+
+	@Provides
+	CoalBagConfig getConfig(ConfigManager configManager)
+	{
+		return configManager.getConfig(CoalBagConfig.class);
+	}
+
+	@Subscribe
+	public void onMenuOptionClicked(MenuOptionClicked event)
+	{
+		if (event.getWidgetId() != WidgetInfo.INVENTORY.getId())
+		{
+			return;
+		}
+
+		switch (event.getMenuOption().toLowerCase())
+		{
+			case FILL_OPTION:
+				update(queryRunner.runQuery(new InventoryWidgetItemQuery().idEquals(ItemID.COAL)).length);
+				break;
+			case EMPTY_OPTION:
+				int amt = MAX_INVY_SPACE - queryRunner.runQuery(new InventoryWidgetItemQuery()).length;
+				update(-amt);
+				break;
+		}
+	}
+
+	/**
+	 * Use onChatMessage when a player chooses the `Check` menu option.
+	 *
+	 * @param event
+	 */
+	@Subscribe
+	public void onChatMessage(ChatMessage event)
+	{
+		if (event.getType() != ChatMessageType.SERVER && event.getType() != ChatMessageType.FILTERED)
+		{
+			return;
+		}
+
+		String chatMsg = Text.removeTags(event.getMessage()); //remove color and linebreaks
+		if (COAL_BAG_EMPTY_MESSAGE.matcher(chatMsg).find())
+		{
+			update(-getAmount());
+		}
+		else if (COAL_BAG_ONE_MESSAGE.matcher(chatMsg).find())
+		{
+			update(-getAmount() + 1);
+		}
+		else
+		{
+			Matcher matcher = COAL_BAG_AMOUNT_MESSAGE.matcher(chatMsg);
+			if (matcher.find())
+			{
+				update(Integer.parseInt(matcher.group(1)) - getAmount());
+			}
+		}
+	}
+
+	/**
+	 * Get amount of coal the player has in their Coal Bag
+	 *
+	 * @return
+	 */
+	int getAmount()
+	{
+		return config.amount();
+	}
+
+	/**
+	 * Update the player's count of coal in their Coal Bag
+	 *
+	 * @param delta How much to add/subtract from the amount.
+	 *              Supply a negative number to subtract, or positive number to add.
+	 */
+	private void update(int delta)
+	{
+		// check for upper/lower bounds of amount of coal in a bag
+		// 0 <= X <= 27
+		config.amount(Math.max(0, Math.min(FULL_BAG_AMOUNT, getAmount() + delta)));
+	}
+}

--- a/runelite-client/src/test/java/net/runelite/client/plugins/coalbag/CoalBagPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/coalbag/CoalBagPluginTest.java
@@ -1,0 +1,252 @@
+/*
+ * Copyright (c) 2018, Anthony <cvballa3g0@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.coalbag;
+
+import com.google.inject.Guice;
+import com.google.inject.Inject;
+import com.google.inject.testing.fieldbinder.Bind;
+import com.google.inject.testing.fieldbinder.BoundFieldModule;
+import net.runelite.api.ChatMessageType;
+import net.runelite.api.Client;
+import net.runelite.api.events.ChatMessage;
+import net.runelite.api.events.MenuOptionClicked;
+import net.runelite.api.widgets.WidgetInfo;
+import net.runelite.api.widgets.WidgetItem;
+import net.runelite.client.ui.overlay.OverlayManager;
+import net.runelite.client.util.QueryRunner;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static net.runelite.client.plugins.coalbag.CoalBagPlugin.*;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CoalBagPluginTest
+{
+
+	@Mock
+	@Bind
+	private OverlayManager overlayManager;
+
+	@Mock
+	@Bind
+	private Client client;
+
+	@Mock
+	@Bind
+	private QueryRunner queryRunner;
+
+	@Bind
+	private CoalBagConfig config = new CoalBagConfig()
+	{
+		int amount = 0;
+
+		@Override
+		public void amount(int amount)
+		{
+			this.amount = amount;
+		}
+
+		@Override
+		public int amount()
+		{
+			return amount;
+		}
+	};
+
+	@Inject
+	private CoalBagPlugin plugin;
+
+	@Before
+	public void before()
+	{
+		config.amount(0);
+		Guice.createInjector(BoundFieldModule.of(this)).injectMembers(this);
+	}
+
+	@Test
+	public void checkBagUpdateOnChatMessage()
+	{
+
+		class Case
+		{
+			private String msg;
+			private int amount;
+
+			private Case(String msg, int amount)
+			{
+				this.msg = msg;
+				this.amount = amount;
+			}
+		}
+
+		Case[] cases = new Case[]{
+				new Case("Hey Dwight", 0),
+				new Case("The coal bag contains 12 pieces of coal.", 12),
+				new Case("The coal bag contains 11 pieces of coal.", 11),
+				new Case("The coal bag contains 11 pieces of coal.", 11),
+				new Case("The coal bag contains 12 pieces of coal.............", 11),
+				new Case("The coal bag contains 12 pieces of coal", 11),
+				new Case("The coal bag is empty.", 0),
+				new Case("The coal bag is empty.", 0),
+				new Case("The coal bag contains 44 pieces of coal.", 27),
+				new Case("The coal bag contains one piece of coal.", 1),
+				new Case("The coal bag contains 16 pieces of coal.", 16),
+				new Case("The coal bag contains one piece of coal.", 1),
+				new Case("The coal bag is empty.", 0),
+		};
+
+		for (int i = 0; i < cases.length; i++)
+		{
+			Case tc = cases[i];
+			plugin.onChatMessage(msg(tc.msg));
+			assertEquals("failed test case: " + i, tc.amount, plugin.getAmount());
+		}
+	}
+
+	@Test
+	public void checkAmountOnMenuClick()
+	{
+		class Case
+		{
+			private String option;
+			private int itemCount;
+			private int expected;
+
+			private Case(String option, int itemCount, int expected)
+			{
+				this.option = option;
+				this.itemCount = itemCount;
+				this.expected = expected;
+			}
+		}
+
+		config.amount(7); // start with 7
+		Case[] cases = new Case[]{
+				new Case(FILL_OPTION, 3, 10),
+				new Case(EMPTY_OPTION, MAX_INVY_SPACE - 27, 0),
+				new Case(FILL_OPTION, 27, 27),
+				new Case(EMPTY_OPTION, MAX_INVY_SPACE - 10, 17),
+				new Case(FILL_OPTION, 27, 27),
+				new Case(EMPTY_OPTION, MAX_INVY_SPACE - 0, 27),
+				new Case(EMPTY_OPTION, MAX_INVY_SPACE - 5, 22),
+				new Case(FILL_OPTION, 0, 22),
+				new Case(FILL_OPTION, 3, 25),
+				new Case(EMPTY_OPTION, MAX_INVY_SPACE - 24, 1),
+				new Case(EMPTY_OPTION, MAX_INVY_SPACE - 24, 0),
+				new Case(EMPTY_OPTION, MAX_INVY_SPACE - 24, 0),
+		};
+
+		for (int i = 0; i < cases.length; i++)
+		{
+			Case tc = cases[i];
+			when(queryRunner.runQuery(any())).thenReturn(wi(tc.itemCount));
+			plugin.onMenuOptionClicked(opt(tc.option));
+			assertEquals("failed test case: " + i, tc.expected, plugin.getAmount());
+		}
+	}
+
+	@Test
+	public void checkMenuAndChatAmounts()
+	{
+		class Case
+		{
+			private String type;
+			private String option;
+			private String msg;
+			private int itemCount;
+			private int expected;
+
+			private Case(String msg, int expected)
+			{
+				type = "msg";
+				this.msg = msg;
+				this.expected = expected;
+			}
+
+			public Case(String option, int itemCount, int expected)
+			{
+				type = "menu";
+				this.option = option;
+				this.itemCount = itemCount;
+				this.expected = expected;
+			}
+		}
+
+		Case[] cases = new Case[]{
+				new Case("The coal bag is empty.", 0),
+				new Case(EMPTY_OPTION, MAX_INVY_SPACE - 27, 0),
+				new Case(FILL_OPTION, 27, 27),
+				new Case(EMPTY_OPTION, MAX_INVY_SPACE - 10, 17),
+				new Case(FILL_OPTION, 27, 27),
+				new Case(EMPTY_OPTION, MAX_INVY_SPACE - 5, 22),
+				new Case("The coal bag contains 22 pieces of coal.", 22),
+				new Case(EMPTY_OPTION, MAX_INVY_SPACE - 5, 17),
+				new Case("The coal bag contains 22 pieces of coal.", 22),
+				new Case(EMPTY_OPTION, MAX_INVY_SPACE - 5, 17),
+				new Case("The coal bag contains one piece of coal.", 1),
+				new Case(FILL_OPTION, 12, 13),
+		};
+
+		for (int i = 0; i < cases.length; i++)
+		{
+			Case tc = cases[i];
+			if (tc.type.equalsIgnoreCase("msg"))
+			{
+				plugin.onChatMessage(msg(tc.msg));
+			}
+			else
+			{
+				when(queryRunner.runQuery(any())).thenReturn(wi(tc.itemCount));
+				plugin.onMenuOptionClicked(opt(tc.option));
+			}
+
+			assertEquals("failed test case: " + i, tc.expected, plugin.getAmount());
+		}
+	}
+
+	private ChatMessage msg(String msg)
+	{
+		return new ChatMessage(ChatMessageType.SERVER, "", msg, "");
+	}
+
+	private MenuOptionClicked opt(String option)
+	{
+		MenuOptionClicked moc = new MenuOptionClicked();
+		moc.setWidgetId(WidgetInfo.INVENTORY.getId());
+		moc.setMenuOption(option);
+		return moc;
+	}
+
+	private WidgetItem[] wi(int count)
+	{
+		return new WidgetItem[count];
+	}
+}


### PR DESCRIPTION
Add Coal Bag overlay to RuneLite.

This plugin keeps track of when a player Fills and Empties their coal bag as the Coal Bag does not use Varbits.

#5133
 
![screen shot 2018-10-28 at 10 45 36 pm](https://user-images.githubusercontent.com/2635519/47626786-3a0b3d00-db03-11e8-96e1-1fdec6ad5708.png)