### PR TITLE
Properly update last action times in Idle Notifier

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
@@ -214,19 +214,23 @@ public class IdleNotifierPlugin extends Plugin
 			case SAND_COLLECTION:
 				resetTimers();
 				lastAnimation = animation;
+				lastAnimating = Instant.now();
 				break;
 			case MAGIC_LUNAR_SHARED:
 				if (graphic == GraphicID.BAKE_PIE)
 				{
 					resetTimers();
 					lastAnimation = animation;
+					lastAnimating = Instant.now();
 					break;
 				}
 			case IDLE:
+				lastAnimating = Instant.now();
 				break;
 			default:
 				// On unknown animation simply assume the animation is invalid and dont throw notification
 				lastAnimation = IDLE;
+				lastAnimating = null;
 		}
 	}
 
@@ -246,6 +250,10 @@ public class IdleNotifierPlugin extends Plugin
 		{
 			lastInteract = null;
 		}
+		else
+		{
+			lastInteracting = Instant.now();
+		}
 
 		final boolean isNpc = target instanceof NPC;
 
@@ -264,6 +272,7 @@ public class IdleNotifierPlugin extends Plugin
 			// Player is most likely in combat with attack-able NPC
 			resetTimers();
 			lastInteract = target;
+			lastInteracting = Instant.now();
 		}
 	}
 
@@ -552,9 +561,6 @@ public class IdleNotifierPlugin extends Plugin
 	private void resetTimers()
 	{
 		final Player local = client.getLocalPlayer();
-
-		// Reset combat idle timer
-		lastCombatCountdown = 0;
 
 		// Reset animation idle timer
 		lastAnimating = null;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
@@ -456,7 +456,9 @@ public class IdleNotifierPlugin extends Plugin
 
 		if (interact == null)
 		{
-			if (lastInteracting != null && Instant.now().compareTo(lastInteracting.plus(waitDuration)) >= 0)
+			if (lastInteracting != null
+				&& Instant.now().compareTo(lastInteracting.plus(waitDuration)) >= 0
+				&& lastCombatCountdown == 0)
 			{
 				lastInteract = null;
 				lastInteracting = null;

--- a/runelite-client/src/test/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPluginTest.java
@@ -155,7 +155,6 @@ public class IdleNotifierPluginTest
 		AnimationChanged animationChanged = new AnimationChanged();
 		animationChanged.setActor(player);
 		plugin.onAnimationChanged(animationChanged);
-		plugin.onInteractingChanged(new InteractingChanged(player, monster));
 		plugin.onGameTick(new GameTick());
 
 		// Logout


### PR DESCRIPTION
- Properly update last action times in Idle Notifier right after the
action is changed/updated.
- Do not reset lastCombatCountdown in resetTimers()
- Take lastCombatCountdown in account when throwing combat idle notif. In case user has combat idle set to 0, this ensures that the idle notif
will not fire right away.

Supersedes/closes #6241
Extracted from #5369
Closes #5961 

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>