### PR TITLE
Woodcutting: Sulluiscep logs/h

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/Tree.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/Tree.java
@@ -29,11 +29,14 @@ import java.util.Map;
 import lombok.Getter;
 import static net.runelite.api.ObjectID.REDWOOD;
 import static net.runelite.api.ObjectID.REDWOOD_29670;
+import static net.runelite.api.ObjectID.SULLIUSCEP;
+import static net.runelite.api.ObjectID.SULLIUSCEP_SPROUT;
 
 @Getter
 enum Tree
 {
-	REDWOOD_TREE_SPAWN(REDWOOD, REDWOOD_29670);
+	REDWOOD_TREE_SPAWN(REDWOOD, REDWOOD_29670),
+	SULLUISCEP_MUSHROOM_SPAWN(SULLIUSCEP, SULLIUSCEP_SPROUT);
 
 	private final int[] treeIds;
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingPlugin.java
@@ -133,7 +133,7 @@ public class WoodcuttingPlugin extends Plugin
 	{
 		if (event.getType() == ChatMessageType.FILTERED || event.getType() == ChatMessageType.SERVER)
 		{
-			if (event.getMessage().startsWith("You get some") && event.getMessage().endsWith("logs."))
+			if (event.getMessage().startsWith("You get some") && ( event.getMessage().endsWith("logs.") || event.getMessage().endsWith("mushrooms.")) )
 			{
 				if (session == null)
 				{


### PR DESCRIPTION
Added Sulluiscep logs/h to the woodcutting plugin.
This is the chat message for cutting suilluisceps:
![image](https://user-images.githubusercontent.com/43320258/47642296-95234b00-db68-11e8-93e7-626d19ec6208.png)
![sulluiscep](https://user-images.githubusercontent.com/43320258/47642343-b7b56400-db68-11e8-860d-1832353ccdcc.gif)
Fixes #6195 
