### PR TITLE
OpponentInfo - Added Toggle for opponents opponent display

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/opponentinfo/OpponentInfoConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/opponentinfo/OpponentInfoConfig.java
@@ -32,10 +32,10 @@ import net.runelite.client.config.ConfigItem;
 public interface OpponentInfoConfig extends Config
 {
 	@ConfigItem(
-		keyName = "lookupOnInteraction",
-		name = "Lookup players on interaction",
-		description = "Display a combat stat comparison panel on player interaction. (follow, trade, challenge, attack, etc.)",
-		position = 0
+			keyName = "lookupOnInteraction",
+			name = "Lookup players on interaction",
+			description = "Display a combat stat comparison panel on player interaction. (follow, trade, challenge, attack, etc.)",
+			position = 0
 	)
 	default boolean lookupOnInteraction()
 	{
@@ -43,13 +43,21 @@ public interface OpponentInfoConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "showPercent",
-		name = "Show percent",
-		description = "Shows hitpoints as a percentage even if hitpoints are known",
-		position = 1
+			keyName = "showPercent",
+			name = "Show percent",
+			description = "Shows hitpoints as a percentage even if hitpoints are known",
+			position = 1
 	)
 	default boolean showPercent()
 	{
 		return false;
 	}
+
+	@ConfigItem(
+			keyName = "showOpponentsOpponent",
+			name = "Show Opponents Opponent",
+			description = "Toggle showing opponents opponent if within a multi-combat area",
+			position = 2
+	)
+	default boolean showOpponentsOpponent() {return true;}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/opponentinfo/OpponentInfoOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/opponentinfo/OpponentInfoOverlay.java
@@ -68,7 +68,7 @@ class OpponentInfoOverlay extends Overlay
 
 	@Inject
 	private OpponentInfoOverlay(Client client, OpponentInfoPlugin opponentInfoPlugin,
-		OpponentInfoConfig opponentInfoConfig, HiscoreManager hiscoreManager)
+								OpponentInfoConfig opponentInfoConfig, HiscoreManager hiscoreManager)
 	{
 		this.client = client;
 		this.opponentInfoPlugin = opponentInfoPlugin;
@@ -93,25 +93,19 @@ class OpponentInfoOverlay extends Overlay
 			return null;
 		}
 
-		if (opponent.getName() != null && opponent.getHealth() > 0)
-		{
+		if (opponent.getName() != null && opponent.getHealth() > 0) {
 			lastRatio = opponent.getHealthRatio();
 			lastHealthScale = opponent.getHealth();
 			opponentName = Text.removeTags(opponent.getName());
 
 			lastMaxHealth = null;
-			if (opponent instanceof NPC)
-			{
+			if (opponent instanceof NPC) {
 				lastMaxHealth = opponentInfoPlugin.getOppInfoHealth().get(opponentName + "_" + opponent.getCombatLevel());
-			}
-			else if (opponent instanceof Player)
-			{
+			} else if (opponent instanceof Player) {
 				final HiscoreResult hiscoreResult = hiscoreManager.lookupAsync(opponentName, opponentInfoPlugin.getHiscoreEndpoint());
-				if (hiscoreResult != null)
-				{
+				if (hiscoreResult != null) {
 					final int hp = hiscoreResult.getHitpoints().getLevel();
-					if (hp > 0)
-					{
+					if (hp > 0) {
 						lastMaxHealth = hp;
 					}
 				}
@@ -119,16 +113,12 @@ class OpponentInfoOverlay extends Overlay
 
 			final Actor opponentsOpponent = opponent.getInteracting();
 			if (opponentsOpponent != null
-				&& (opponentsOpponent != client.getLocalPlayer() || client.getVar(Varbits.MULTICOMBAT_AREA) == 1))
-			{
+					&& (opponentsOpponent != client.getLocalPlayer() || client.getVar(Varbits.MULTICOMBAT_AREA) == 1)) {
 				opponentsOpponentName = Text.removeTags(opponentsOpponent.getName());
-			}
-			else
-			{
+			} else {
 				opponentsOpponentName = null;
 			}
 		}
-
 		if (opponentName == null)
 		{
 			return null;
@@ -142,8 +132,8 @@ class OpponentInfoOverlay extends Overlay
 		int textWidth = Math.max(ComponentConstants.STANDARD_WIDTH, fontMetrics.stringWidth(opponentName));
 		panelComponent.setPreferredSize(new Dimension(textWidth, 0));
 		panelComponent.getChildren().add(TitleComponent.builder()
-			.text(opponentName)
-			.build());
+				.text(opponentName)
+				.build());
 
 		// Health bar
 		if (lastRatio >= 0 && lastHealthScale > 0)
@@ -200,13 +190,14 @@ class OpponentInfoOverlay extends Overlay
 		}
 
 		// Opponents opponent
-		if (opponentsOpponentName != null)
+		// Show if checkbox is checked within plugin panel
+		if (opponentsOpponentName != null && opponentInfoConfig.showOpponentsOpponent())
 		{
 			textWidth = Math.max(textWidth, fontMetrics.stringWidth(opponentsOpponentName));
 			panelComponent.setPreferredSize(new Dimension(textWidth, 0));
 			panelComponent.getChildren().add(TitleComponent.builder()
-				.text(opponentsOpponentName)
-				.build());
+					.text(opponentsOpponentName)
+					.build());
 		}
 
 		return panelComponent.render(graphics);


### PR DESCRIPTION
Within the opponentInfo plugin, I've added a new checkbox to allow for players to turn off seeing the opponents opponent within multi combat areas. The plugin overlay would then just act like it does while in a single combat area.