### PR TITLE
Add ability to set combat requirements for achievement diaries

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/DiaryRequirementsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/DiaryRequirementsPlugin.java
@@ -36,6 +36,7 @@ import javax.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.ScriptID;
+import net.runelite.api.Skill;
 import net.runelite.api.events.WidgetLoaded;
 import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetID;
@@ -242,7 +243,16 @@ public class DiaryRequirementsPlugin extends Plugin
 			{
 				RequirementStringBuilder requirementStringBuilder = new RequirementStringBuilder(i);
 
-				int realSkillLevel = client.getRealSkillLevel(i.getSkill());
+				Skill skill = i.getSkill();
+				int realSkillLevel;
+				if (skill == null && i.getCustomRequirement().equals("Combat"))
+				{
+					realSkillLevel = client.getLocalPlayer().getCombatLevel();
+				}
+				else
+				{
+					realSkillLevel = client.getRealSkillLevel(skill);
+				}
 				List<Integer> altRealSkillLevels = null;
 				if (i.getAltRequirements() != null)
 				{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/Requirement.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/Requirement.java
@@ -30,12 +30,22 @@ import net.runelite.api.Skill;
 public class Requirement
 {
 	private final Skill skill;
+	private final String customRequirement;
 	private final int levelRequirement;
 	private final Requirement[] altRequirements;
 
 	public Requirement(Skill skill, int levelRequirement, Requirement... altRequirements)
 	{
 		this.skill = skill;
+		this.customRequirement = null;
+		this.levelRequirement = levelRequirement;
+		this.altRequirements = altRequirements;
+	}
+
+	public Requirement(String customRequirement, int levelRequirement, Requirement... altRequirements)
+	{
+		this.skill = null;
+		this.customRequirement = customRequirement;
 		this.levelRequirement = levelRequirement;
 		this.altRequirements = altRequirements;
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/RequirementStringBuilder.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/RequirementStringBuilder.java
@@ -48,7 +48,7 @@ class RequirementStringBuilder
 		StringBuilder requirementStringBuilder = new StringBuilder()
 			.append(levelRequirement)
 			.append(" ")
-			.append(skill.getName());
+			.append(skill != null ? skill.getName() : requirement.getCustomRequirement());
 		for (Requirement i : altRequirements)
 		{
 			requirementStringBuilder.append(" or ")

--- a/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/KaramjaDiaryRequirement.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/KaramjaDiaryRequirement.java
@@ -86,6 +86,7 @@ public class KaramjaDiaryRequirement extends GenericDiaryRequirement
 		add("Collect 5 palm leaves.",
 			new Requirement(Skill.WOODCUTTING, 15));
 		add("Be assigned a Slayer task by Duradel north of Shilo Village.",
+			new Requirement("Combat", 100),
 			new Requirement(Skill.SLAYER, 50));
 		add("Kill a metal dragon in Brimhaven Dungeon.",
 			new Requirement(Skill.AGILITY, 12),

--- a/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/LumbridgeDiaryRequirement.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/LumbridgeDiaryRequirement.java
@@ -63,6 +63,8 @@ public class LumbridgeDiaryRequirement extends GenericDiaryRequirement
 			new Requirement(Skill.FISHING, 30));
 		add("Craft a coif in the Lumbridge cow pen.",
 			new Requirement(Skill.CRAFTING, 38));
+		add("Get a slayer task from Chaeldar.",
+			new Requirement("Combat", 70));
 		add("Chop some willow logs in Draynor Village.",
 			new Requirement(Skill.WOODCUTTING, 30));
 		add("Pickpocket Martin the Master Gardener.",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/MorytaniaDiaryRequirement.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/MorytaniaDiaryRequirement.java
@@ -38,6 +38,8 @@ public class MorytaniaDiaryRequirement extends GenericDiaryRequirement
 			new Requirement(Skill.CRAFTING, 15));
 		add("Cook a thin Snail on the Port Phasmatys range.",
 			new Requirement(Skill.COOKING, 12));
+		add("Get a slayer task from Mazchna.",
+			new Requirement("Combat", 20));
 		add("Kill a Banshee in the Slayer Tower.",
 			new Requirement(Skill.SLAYER, 15));
 		add("Place a Scarecrow in the Morytania flower patch.",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/VarrockDiaryRequirement.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/VarrockDiaryRequirement.java
@@ -50,6 +50,8 @@ public class VarrockDiaryRequirement extends GenericDiaryRequirement
 		// MEDIUM
 		add("Cast the teleport to Varrock spell.",
 			new Requirement(Skill.MAGIC, 25));
+		add("Get a Slayer task from Vannaka.",
+			new Requirement("Combat", 40));
 		add("Pick a White tree fruit.",
 			new Requirement(Skill.FARMING, 25));
 		add("Use the balloon to travel from Varrock.",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/WesternDiaryRequirement.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/WesternDiaryRequirement.java
@@ -36,6 +36,8 @@ public class WesternDiaryRequirement extends GenericDiaryRequirement
 		// EASY
 		add("Catch a Copper Longtail.",
 			new Requirement(Skill.HUNTER, 9));
+		add("Complete a novice game of Pest Control.",
+			new Requirement("Combat", 40));
 		add("Mine some Iron Ore near Piscatoris.",
 			new Requirement(Skill.MINING, 15));
 		add("Fletch an Oak shortbow from the Gnome Stronghold.",
@@ -51,6 +53,8 @@ public class WesternDiaryRequirement extends GenericDiaryRequirement
 		add("Chop and burn some teak logs on Ape Atoll.",
 			new Requirement(Skill.WOODCUTTING, 35),
 			new Requirement(Skill.FIREMAKING, 35));
+		add("Complete an intermediate game of Pest Control.",
+			new Requirement("Combat", 70));
 		add("Make a Chocolate Bomb at the Grand Tree.",
 			new Requirement(Skill.COOKING, 42));
 		add("Complete a delivery for the Gnome Restaurant.",
@@ -65,6 +69,8 @@ public class WesternDiaryRequirement extends GenericDiaryRequirement
 		add("Catch and cook a Monkfish in Piscatoris.",
 			new Requirement(Skill.FISHING, 62),
 			new Requirement(Skill.COOKING, 62));
+		add("Complete a Veteran game of Pest Control.",
+			new Requirement("Combat", 100));
 		add("Catch a Dashing Kebbit.",
 			new Requirement(Skill.HUNTER, 69));
 		add("Complete a lap of the Ape Atoll agility course.",


### PR DESCRIPTION
Added ability to add combat requirements to diarys also added all the current combat requirements.

ScreenShots:
When you meet the combat requirement.
![when you have requirement](https://puu.sh/BTHtl/35755b3003.png)
When you don't meet the combat requirement.
![when you don't have requirement](https://puu.sh/BTHtM/ce5c50ef33.png)