### PR TITLE
Fix localToCanvas on fixed screen

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/Perspective.java
+++ b/runelite-api/src/main/java/net/runelite/api/Perspective.java
@@ -139,7 +139,9 @@ public class Perspective
 			{
 				int pointX = client.getViewportWidth() / 2 + x * client.getScale() / y;
 				int pointY = client.getViewportHeight() / 2 + var8 * client.getScale() / y;
-				return new Point(pointX, pointY);
+				return new Point(
+					pointX + client.getViewportXOffset(),
+					pointY + client.getViewportYOffset());
 			}
 		}
 

--- a/runelite-api/src/main/java/net/runelite/api/Perspective.java
+++ b/runelite-api/src/main/java/net/runelite/api/Perspective.java
@@ -595,15 +595,6 @@ public class Perspective
 			int maxX = Math.max(Math.max(a.getX(), b.getX()), c.getX()) + 4;
 			int maxY = Math.max(Math.max(a.getY(), b.getY()), c.getY()) + 4;
 
-			// ...and the rectangles in the fixed client are shifted 4 pixels right and down
-			if (!client.isResized())
-			{
-				minX += client.getViewportXOffset();
-				minY += client.getViewportYOffset();
-				maxX += client.getViewportXOffset();
-				maxY += client.getViewportYOffset();
-			}
-
 			Rectangle clickableRect = new Rectangle(
 				minX - radius, minY - radius,
 				maxX - minX + radius, maxY - minY + radius

--- a/runelite-client/src/main/java/net/runelite/client/plugins/demonicgorilla/DemonicGorillaOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/demonicgorilla/DemonicGorillaOverlay.java
@@ -94,9 +94,7 @@ public class DemonicGorillaOverlay extends Overlay
 					gorilla.getNpc().getLogicalHeight() + 16);
 				if (point != null)
 				{
-					point = new Point(
-						client.getViewportXOffset() + point.getX(),
-						client.getViewportYOffset() + point.getY());
+					point = new Point(point.getX(), point.getY());
 
 					List<DemonicGorilla.AttackStyle> attackStyles = gorilla.getNextPosibleAttackStyles();
 					List<BufferedImage> icons = new ArrayList<>();

--- a/runelite-client/src/main/java/net/runelite/client/plugins/prayer/PrayerBarOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/prayer/PrayerBarOverlay.java
@@ -80,8 +80,8 @@ class PrayerBarOverlay extends Overlay
 		final Point canvasPoint = Perspective.localToCanvas(client, localLocation, client.getPlane(), height);
 
 		// Draw bar
-		final int barX = canvasPoint.getX() + client.getViewportXOffset() - 15;
-		final int barY = canvasPoint.getY() + client.getViewportYOffset();
+		final int barX = canvasPoint.getX() - 15;
+		final int barY = canvasPoint.getY();
 		final int barWidth = PRAYER_BAR_SIZE.width;
 		final int barHeight = PRAYER_BAR_SIZE.height;
 		final float ratio = (float) client.getBoostedSkillLevel(Skill.PRAYER) / client.getRealSkillLevel(Skill.PRAYER);


### PR DESCRIPTION
Our localToCanvas isn't taking the viewport offset into account which means a lot of scene overlays are currently misplaced by 4 pixels both horizontally and vertically when using fixed screen.

Before:
![image](https://user-images.githubusercontent.com/26200523/47856367-54853500-dde7-11e8-9943-c6214c62f620.png)

After:
![image](https://user-images.githubusercontent.com/26200523/47856371-58b15280-dde7-11e8-8846-0ebfadd3dbac.png)

Closes #4539
