### PR TITLE
stretchedmode: fix size not being reset on plugin disable

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/stretchedmode/StretchedModePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/stretchedmode/StretchedModePlugin.java
@@ -80,6 +80,7 @@ public class StretchedModePlugin extends Plugin
 	protected void shutDown() throws Exception
 	{
 		client.setStretchedEnabled(false);
+		client.invalidateStretching(true);
 
 		mouseManager.unregisterMouseListener(mouseListener);
 		mouseManager.unregisterMouseWheelListener(mouseWheelListener);


### PR DESCRIPTION
Fixes #6294

Triggers max canvas size to set itself again. Now with the usual max size and not our getRealDimensions one.