### PR TITLE
Enable PlugIns to be Defaulted to Pinned

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/PluginDescriptor.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/PluginDescriptor.java
@@ -58,4 +58,9 @@ public @interface PluginDescriptor
 	boolean developerPlugin() default false;
 
 	boolean loadWhenOutdated() default false;
+
+	/**
+	 * Whether this Plugin should be starred when running the application for the first time
+	 */
+	boolean pinnedByDefault() default false;
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
@@ -663,7 +663,7 @@ public class ConfigPanel extends PluginPanel
 	void disablePinningDefaultPlugin(@NonNull PluginListItem pluginListItem)
 	{
 		// Cannot disable a default pinned plugin if it is not pinned by default
-		if(!pluginListItem.isPinnedByDefault())
+		if (!pluginListItem.isPinnedByDefault())
 		{
 			throw new IllegalArgumentException("PluginListItem must be a default");
 		}
@@ -671,12 +671,14 @@ public class ConfigPanel extends PluginPanel
 		// Grab the configuration if it exists
 		String defaultPinnedConfiguration = configManager.getConfiguration(RUNELITE_GROUP_NAME, DEFAULT_OVERRIDDEN_PINNED_PLUGINS_CONFIG_KEY);
 		// If it does not exist, create the configuration add this list item to it
-		if(defaultPinnedConfiguration == null)
+		if (defaultPinnedConfiguration == null)
 		{
 			configManager.setConfiguration(RUNELITE_GROUP_NAME, DEFAULT_OVERRIDDEN_PINNED_PLUGINS_CONFIG_KEY, pluginListItem.getName());
 			return;
 		// if the default was already overridden, we do not need to re-add
-		} else if(hasDisabledPinningDefaultPlugin(pluginListItem)) {
+		} 
+		else if (hasDisabledPinningDefaultPlugin(pluginListItem))
+		{
 			return;
 		}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
@@ -208,13 +208,14 @@ public class ConfigPanel extends PluginPanel
 		// add special entries for core client configurations
 		final PluginListItem runeLite = new PluginListItem(this, runeLiteConfig,
 			configManager.getConfigDescriptor(runeLiteConfig),
-			RUNELITE_PLUGIN, "RuneLite client settings", "client");
-		runeLite.setPinned(pinnedPlugins.contains(RUNELITE_PLUGIN));
+			RUNELITE_PLUGIN, "RuneLite client settings", true, "client");
+		//runeLite.setPinned(pinnedPlugins.contains(RUNELITE_PLUGIN));
 		pluginList.add(runeLite);
+
 
 		final PluginListItem chatColor = new PluginListItem(this, chatColorConfig,
 			configManager.getConfigDescriptor(chatColorConfig),
-			CHAT_COLOR_PLUGIN, "Recolor chat text", "colour", "messages");
+			CHAT_COLOR_PLUGIN, "Recolor chat text", false, "colour", "messages");
 		chatColor.setPinned(pinnedPlugins.contains(CHAT_COLOR_PLUGIN));
 		pluginList.add(chatColor);
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
@@ -676,7 +676,7 @@ public class ConfigPanel extends PluginPanel
 			configManager.setConfiguration(RUNELITE_GROUP_NAME, DEFAULT_OVERRIDDEN_PINNED_PLUGINS_CONFIG_KEY, pluginListItem.getName());
 			return;
 		// if the default was already overridden, we do not need to re-add
-		} 
+		}
 		else if (hasDisabledPinningDefaultPlugin(pluginListItem))
 		{
 			return;
@@ -701,7 +701,7 @@ public class ConfigPanel extends PluginPanel
 		String defaultPinnedConfiguration = configManager.getConfiguration(RUNELITE_GROUP_NAME, DEFAULT_OVERRIDDEN_PINNED_PLUGINS_CONFIG_KEY);
 
 		// If there is no configuration specified, it has not been overriden yet
-		if(defaultPinnedConfiguration == null) return false;
+		if (defaultPinnedConfiguration == null) return false;
 
 		// If it contains the default pinning in the override setting
 		return defaultPinnedConfiguration.contains(pluginListItem.getName());

--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
@@ -204,7 +204,10 @@ public class ConfigPanel extends PluginPanel
 				final ConfigDescriptor configDescriptor = config == null ? null : configManager.getConfigDescriptor(config);
 
 				final PluginListItem listItem = new PluginListItem(this, plugin, descriptor, config, configDescriptor);
-				listItem.setPinned(pinnedPlugins.contains(listItem.getName()));
+
+				// If pinned plugins has this item OR (if it is pinned by default AND it has not been overridden) we can pin
+				// Else, don't pin
+				listItem.setPinned(pinnedPlugins.contains(listItem.getName()) || (listItem.isPinnedByDefault() && !hasDisabledPinningDefaultPlugin(listItem)));
 				pluginList.add(listItem);
 			});
 
@@ -212,15 +215,18 @@ public class ConfigPanel extends PluginPanel
 		final PluginListItem runeLite = new PluginListItem(this, runeLiteConfig,
 			configManager.getConfigDescriptor(runeLiteConfig),
 			RUNELITE_PLUGIN, "RuneLite client settings", true, "client");
-		// pin this if the pinned plugin list contains runelite OR if it has not been disabled yet
-		runeLite.setPinned(pinnedPlugins.contains(RUNELITE_PLUGIN) || !hasDisabledPinningDefaultPlugin(runeLite));
+		// If pinned plugins has this item OR (if it is pinned by default AND it has not been overridden) we can pin
+		// Else, don't pin
+		runeLite.setPinned(pinnedPlugins.contains(RUNELITE_PLUGIN) || (runeLite.isPinnedByDefault() && !hasDisabledPinningDefaultPlugin(runeLite)));
 		pluginList.add(runeLite);
 
 
 		final PluginListItem chatColor = new PluginListItem(this, chatColorConfig,
 			configManager.getConfigDescriptor(chatColorConfig),
 			CHAT_COLOR_PLUGIN, "Recolor chat text", false, "colour", "messages");
-		chatColor.setPinned(pinnedPlugins.contains(CHAT_COLOR_PLUGIN));
+		// If pinned plugins has this item OR (if it is pinned by default AND it has not been overridden) we can pin
+		// Else, don't pin
+		chatColor.setPinned(pinnedPlugins.contains(CHAT_COLOR_PLUGIN) || (chatColor.isPinnedByDefault() && !hasDisabledPinningDefaultPlugin(chatColor)));
 		pluginList.add(chatColor);
 
 		pluginList.sort(Comparator.comparing(PluginListItem::getName));

--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/PluginListItem.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/PluginListItem.java
@@ -250,7 +250,7 @@ class PluginListItem extends JPanel
 	void setPinned(boolean pinned)
 	{
 		// If we are unpinning && this is a pin by default plugin,
-		// lets add the overriden configuration to the configuration file
+		// lets add the overridden configuration to the configuration file
 		if(!pinned && isPinnedByDefault())
 		{
 			configPanel.disablePinningDefaultPlugin(this);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/PluginListItem.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/PluginListItem.java
@@ -80,6 +80,9 @@ class PluginListItem extends JPanel
 	@Getter
 	private boolean isPinned = false;
 
+	@Getter
+	private boolean isPinnedByDefault = false;
+
 	static
 	{
 		BufferedImage configIcon = ImageUtil.getResourceStreamFromClass(ConfigPanel.class, "config_edit_icon.png");
@@ -115,25 +118,26 @@ class PluginListItem extends JPanel
 		@Nullable Config config, @Nullable ConfigDescriptor configDescriptor)
 	{
 		this(configPanel, plugin, config, configDescriptor,
-			descriptor.name(), descriptor.description(), descriptor.tags());
+			descriptor.name(), descriptor.description(), descriptor.pinnedByDefault(), descriptor.tags());
 	}
 
 	/**
 	 * Creates a new {@code PluginListItem} for a core configuration.
 	 */
 	PluginListItem(ConfigPanel configPanel, Config config, ConfigDescriptor configDescriptor,
-		String name, String description, String... tags)
+		String name, String description, boolean starredByDefault, String... tags)
 	{
-		this(configPanel, null, config, configDescriptor, name, description, tags);
+		this(configPanel, null, config, configDescriptor, name, description, starredByDefault, tags);
 	}
 
 	private PluginListItem(ConfigPanel configPanel, @Nullable Plugin plugin, @Nullable Config config,
-		@Nullable ConfigDescriptor configDescriptor, String name, String description, String... tags)
+		@Nullable ConfigDescriptor configDescriptor, String name, String description, boolean isPinnedByDefault, String... tags)
 	{
 		this.configPanel = configPanel;
 		this.plugin = plugin;
 		this.name = name;
 		this.description = description;
+		this.isPinnedByDefault = isPinnedByDefault;
 		Collections.addAll(keywords, name.toLowerCase().split(" "));
 		Collections.addAll(keywords, description.toLowerCase().split(" "));
 		Collections.addAll(keywords, tags);
@@ -156,7 +160,11 @@ class PluginListItem extends JPanel
 
 		pinButton.addActionListener(e ->
 		{
+			// Cannot update the pinning if it is pinnedByDefault
+			if(isPinnedByDefault()) return;
+
 			setPinned(!isPinned);
+			// If it is now no longer pinned && it was pinned by default, lets update the default config
 			configPanel.savePinnedPlugins();
 			configPanel.openConfigList();
 		});
@@ -185,6 +193,12 @@ class PluginListItem extends JPanel
 		toggleButton.setPreferredSize(new Dimension(25, 0));
 		attachToggleButtonListener(toggleButton);
 		buttonPanel.add(toggleButton);
+
+		// Update the pinning if it is pinned by default
+		if(this.isPinnedByDefault)
+		{
+			setPinned(true);
+		}
 	}
 
 	private void attachToggleButtonListener(IconButton button)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/PluginListItem.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/PluginListItem.java
@@ -161,7 +161,7 @@ class PluginListItem extends JPanel
 		pinButton.addActionListener(e ->
 		{
 			// If this plugin is pinned by default, and it has not been overridden yet
-			if(isPinnedByDefault() && !configPanel.hasDisabledPinningDefaultPlugin(this))
+			if (isPinnedByDefault() && !configPanel.hasDisabledPinningDefaultPlugin(this))
 			{
 				// Update config that this defaulted-to-pinned list item has been removed from default
 				configPanel.disablePinningDefaultPlugin(this);
@@ -251,7 +251,7 @@ class PluginListItem extends JPanel
 	{
 		// If we are unpinning && this is a pin by default plugin,
 		// lets add the overridden configuration to the configuration file
-		if(!pinned && isPinnedByDefault())
+		if (!pinned && isPinnedByDefault())
 		{
 			configPanel.disablePinningDefaultPlugin(this);
 		}


### PR DESCRIPTION
Plugins have the option to be defaulted as pinned (within the source code). The RuneLite Plugin currently implements this feature as per the request of #6256 