### PR TITLE
Add profanity filter

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/Actor.java
+++ b/runelite-api/src/main/java/net/runelite/api/Actor.java
@@ -237,4 +237,11 @@ public interface Actor extends Renderable
 	 * @return the overhead text
 	 */
 	String getOverhead();
+
+	/**
+	 * Sets the overhead text that is displayed above the actor
+	 *
+	 * @param overheadText the overhead text
+	 */
+	void setOverheadText(String overheadText);
 }

--- a/runelite-api/src/main/java/net/runelite/api/Actor.java
+++ b/runelite-api/src/main/java/net/runelite/api/Actor.java
@@ -236,7 +236,7 @@ public interface Actor extends Renderable
 	 *
 	 * @return the overhead text
 	 */
-	String getOverhead();
+	String getOverheadText();
 
 	/**
 	 * Sets the overhead text that is displayed above the actor

--- a/runelite-api/src/main/java/net/runelite/api/events/OverheadTextChanged.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/OverheadTextChanged.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2018, Magic fTail
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.api.events;
+
+import lombok.Value;
+import net.runelite.api.Actor;
+
+@Value
+public class OverheadTextChanged
+{
+	private final Actor actor;
+
+	private final String overheadText;
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/profanityfilter/ProfanityFilterConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/profanityfilter/ProfanityFilterConfig.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2018, Magic fTail
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.profanityfilter;
+
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+
+@ConfigGroup("profanityfilter")
+public interface ProfanityFilterConfig extends Config
+{
+	@ConfigItem(
+		keyName = "bannedWords",
+		name = "Banned Words",
+		description = "List of banned words, seperate words by comma"
+	)
+	default String bannedWords()
+	{
+		return "";
+	}
+
+	@ConfigItem(
+		keyName = "removeMessage",
+		name = "Remove Message",
+		description = "Remove the entire message if it contains a banned word"
+	)
+	default boolean removeMessage()
+	{
+		return false;
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/profanityfilter/ProfanityFilterPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/profanityfilter/ProfanityFilterPlugin.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2018, Magic fTail
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.profanityfilter;
+
+import com.google.common.base.Splitter;
+import com.google.common.eventbus.Subscribe;
+import com.google.inject.Provides;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import javax.inject.Inject;
+import net.runelite.api.ChatMessageType;
+import net.runelite.api.Client;
+import net.runelite.api.MessageNode;
+import net.runelite.api.events.ConfigChanged;
+import net.runelite.api.events.OverheadTextChanged;
+import net.runelite.api.events.SetMessage;
+import net.runelite.client.chat.ChatMessageManager;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginDescriptor;
+import org.apache.commons.lang3.StringUtils;
+
+@PluginDescriptor(
+	name = "Profanity Filter",
+	description = "Censor user configurable words from chat"
+)
+public class ProfanityFilterPlugin extends Plugin
+{
+	private static final Splitter COMMA_SPLITTER = Splitter
+		.on(",")
+		.omitEmptyStrings()
+		.trimResults();
+
+	private List<String> bannedWords = new ArrayList<>();
+
+	@Inject
+	private Client client;
+
+	@Inject
+	private ProfanityFilterConfig config;
+
+	@Inject
+	private ChatMessageManager chatMessageManager;
+
+	@Provides
+	ProfanityFilterConfig provideConfig(ConfigManager configManager)
+	{
+		return configManager.getConfig(ProfanityFilterConfig.class);
+	}
+
+	@Subscribe
+	public void onSetMessage(SetMessage setMessage)
+	{
+		if (setMessage.getType() == ChatMessageType.SERVER)
+		{
+			return;
+		}
+
+		String message = censorMessage(setMessage.getValue());
+		MessageNode messageNode = setMessage.getMessageNode();
+		messageNode.setRuneLiteFormatMessage(message);
+		chatMessageManager.update(messageNode);
+		client.refreshChat();
+	}
+
+	@Subscribe
+	public void onOverheadTextChanged(OverheadTextChanged event)
+	{
+		String message = censorMessage(event.getOverheadText());
+
+		event.getActor().setOverheadText(message);
+	}
+
+	private String censorMessage(String message)
+	{
+		for (String bannedWord : bannedWords)
+		{
+			if (config.removeMessage() && message.toLowerCase().contains(bannedWord))
+			{
+				message = "Hey, everyone, I just tried to say something very silly!";
+				break;
+			}
+			else
+			{
+				message = message.replaceAll("(?i)" + bannedWord, StringUtils.repeat("*", bannedWord.length()));
+			}
+		}
+
+		return message;
+	}
+
+	private void updateBannedWords()
+	{
+		final String configBannedWords = config.bannedWords().toLowerCase();
+
+		if (configBannedWords.isEmpty())
+		{
+			bannedWords = Collections.emptyList();
+			return;
+		}
+
+		bannedWords = COMMA_SPLITTER.splitToList(configBannedWords);
+	}
+
+	@Override
+	protected void startUp() throws Exception
+	{
+		updateBannedWords();
+	}
+
+	@Subscribe
+	public void onConfigChanged(ConfigChanged event)
+	{
+		if (!"profanityfilter".equals(event.getGroup()))
+		{
+			return;
+		}
+
+		updateBannedWords();
+	}
+}

--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSActorMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSActorMixin.java
@@ -213,7 +213,7 @@ public abstract class RSActorMixin implements RSActor
 	@Inject
 	public void overheadTextChanged(int idx)
 	{
-		OverheadTextChanged overheadTextChanged = new OverheadTextChanged(this, getOverhead());
+		OverheadTextChanged overheadTextChanged = new OverheadTextChanged(this, getOverheadText());
 		client.getCallbacks().post(overheadTextChanged);
 	}
 

--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSActorMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSActorMixin.java
@@ -43,6 +43,7 @@ import net.runelite.api.events.GraphicChanged;
 import net.runelite.api.events.HitsplatApplied;
 import net.runelite.api.events.InteractingChanged;
 import net.runelite.api.events.LocalPlayerDeath;
+import net.runelite.api.events.OverheadTextChanged;
 import net.runelite.api.mixins.FieldHook;
 import net.runelite.api.mixins.Inject;
 import net.runelite.api.mixins.MethodHook;
@@ -206,6 +207,14 @@ public abstract class RSActorMixin implements RSActor
 	{
 		InteractingChanged interactingChanged = new InteractingChanged(this, getInteracting());
 		client.getCallbacks().post(interactingChanged);
+	}
+
+	@FieldHook("overhead")
+	@Inject
+	public void overheadTextChanged(int idx)
+	{
+		OverheadTextChanged overheadTextChanged = new OverheadTextChanged(this, getOverhead());
+		client.getCallbacks().post(overheadTextChanged);
 	}
 
 	@Inject

--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSActorMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSActorMixin.java
@@ -213,8 +213,12 @@ public abstract class RSActorMixin implements RSActor
 	@Inject
 	public void overheadTextChanged(int idx)
 	{
-		OverheadTextChanged overheadTextChanged = new OverheadTextChanged(this, getOverheadText());
-		client.getCallbacks().post(overheadTextChanged);
+		String overheadText = getOverheadText();
+		if (overheadText != null)
+		{
+			OverheadTextChanged overheadTextChanged = new OverheadTextChanged(this, overheadText);
+			client.getCallbacks().post(overheadTextChanged);
+		}
 	}
 
 	@Inject

--- a/runescape-api/src/main/java/net/runelite/rs/api/RSActor.java
+++ b/runescape-api/src/main/java/net/runelite/rs/api/RSActor.java
@@ -36,6 +36,10 @@ public interface RSActor extends RSRenderable, Actor
 	@Override
 	String getOverhead();
 
+	@Import("overhead")
+	@Override
+	void setOverheadText(String overheadText);
+
 	@Import("x")
 	int getX();
 

--- a/runescape-api/src/main/java/net/runelite/rs/api/RSActor.java
+++ b/runescape-api/src/main/java/net/runelite/rs/api/RSActor.java
@@ -34,7 +34,7 @@ public interface RSActor extends RSRenderable, Actor
 
 	@Import("overhead")
 	@Override
-	String getOverhead();
+	String getOverheadText();
 
 	@Import("overhead")
 	@Override


### PR DESCRIPTION
Add a plugin censoring user-defined words/sentences or remove the entire message containing them.

Note: This is not meant as an anti-spam plugin. It's for removing racist/whatever messages from the chat, and letting people add these people to their ignore-list themselves.

Fixes [Ian's request](https://twitter.com/ianspam/status/1058104900121518082)