### PR TITLE
stretchedmode: reduce wait time after changing scaling percentage

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/stretchedmode/StretchedModePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/stretchedmode/StretchedModePlugin.java
@@ -29,7 +29,6 @@ import com.google.common.eventbus.Subscribe;
 import com.google.inject.Provides;
 import javax.inject.Inject;
 import net.runelite.api.Client;
-import net.runelite.api.events.CanvasSizeChanged;
 import net.runelite.api.events.ConfigChanged;
 import net.runelite.api.events.ResizeableChanged;
 import net.runelite.client.config.ConfigManager;
@@ -90,12 +89,6 @@ public class StretchedModePlugin extends Plugin
 	public void onResizeableChanged(ResizeableChanged event)
 	{
 		client.invalidateStretching(true);
-	}
-
-	@Subscribe
-	public void onCanvasSizeChanged(CanvasSizeChanged event)
-	{
-		client.invalidateStretching(false);
 	}
 
 	@Subscribe

--- a/runelite-mixins/src/main/java/net/runelite/mixins/StretchedModeMaxSizeMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/StretchedModeMaxSizeMixin.java
@@ -38,21 +38,39 @@ public abstract class StretchedModeMaxSizeMixin implements RSGameEngine
 	@Shadow("clientInstance")
 	private static RSClient client;
 
+	@Copy("resizeCanvas")
+	abstract void rs$resizeCanvas();
+
+	@Replace("resizeCanvas")
+	public void rl$resizeCanvas()
+	{
+		if (client.isStretchedEnabled())
+		{
+			client.invalidateStretching(false);
+
+			if (client.isResized())
+			{
+				Dimension realDimensions = client.getRealDimensions();
+
+				setMaxCanvasWidth(realDimensions.width);
+				setMaxCanvasHeight(realDimensions.height);
+			}
+		}
+
+		rs$resizeCanvas();
+	}
+
 	@Copy("setMaxCanvasSize")
 	abstract void rs$setMaxCanvasSize(int width, int height);
 
 	@Replace("setMaxCanvasSize")
-	public void setMaxCanvasSize(int width, int height)
+	public void rl$setMaxCanvasSize(int width, int height)
 	{
 		if (client.isStretchedEnabled() && client.isResized())
 		{
-			Dimension realDimensions = client.getRealDimensions();
+			return;
+		}
 
-			rs$setMaxCanvasSize(realDimensions.width, realDimensions.height);
-		}
-		else
-		{
-			rs$setMaxCanvasSize(width, height);
-		}
+		rs$setMaxCanvasSize(width, height);
 	}
 }

--- a/runelite-mixins/src/main/java/net/runelite/mixins/StretchedModeMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/StretchedModeMixin.java
@@ -197,23 +197,13 @@ public abstract class StretchedModeMixin implements RSClient
 	@Override
 	public void invalidateStretching(boolean resize)
 	{
-		cachedStretchedDimensions = null;
 		cachedRealDimensions = null;
+		cachedStretchedDimensions = null;
 
 		if (resize && isResized())
 		{
 			/*
 				Tells the game to run resizeCanvas the next frame.
-
-				resizeCanvas in turn calls the method that
-				determines the maximum size of the canvas,
-				AFTER setting the size of the canvas.
-
-				The frame after that, the game sees that
-				the maximum size of the canvas isn't
-				the current size, so it runs resizeCanvas again.
-				This time it uses our new maximum size
-				as the bounds for the canvas size.
 
 				This is useful when resizeCanvas wouldn't usually run,
 				for example when we've only changed the scaling factor

--- a/runescape-api/src/main/java/net/runelite/rs/api/RSGameEngine.java
+++ b/runescape-api/src/main/java/net/runelite/rs/api/RSGameEngine.java
@@ -51,4 +51,10 @@ public interface RSGameEngine extends GameEngine
 
 	@Import("replaceCanvasNextFrame")
 	void setReplaceCanvasNextFrame(boolean replace);
+
+	@Import("maxCanvasWidth")
+	void setMaxCanvasWidth(int width);
+
+	@Import("maxCanvasHeight")
+	void setMaxCanvasHeight(int height);
 }


### PR DESCRIPTION
Now it takes max 1 frame for it to resize the canvas after changing the scaling percentage, instead of at most 500ms.

It now sets the max width and height right before the canvas is resized, so the canvas size uses those max bounds immediately, instead of setting it 500ms after the canvas is resized initially.