### PR TITLE
Opponent Info - Added Show opponents opponent checkbox

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/opponentinfo/OpponentInfoConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/opponentinfo/OpponentInfoConfig.java
@@ -52,4 +52,15 @@ public interface OpponentInfoConfig extends Config
 	{
 		return false;
 	}
+
+	@ConfigItem(
+		keyName = "showOpponentsOpponent",
+		name = "Show Opponents Opponent",
+		description = "Toggle showing opponents opponent if within a multi-combat area",
+		position = 2
+	)
+	default boolean showOpponentsOpponent()
+	{
+		return true;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/opponentinfo/OpponentInfoConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/opponentinfo/OpponentInfoConfig.java
@@ -55,8 +55,8 @@ public interface OpponentInfoConfig extends Config
 
 	@ConfigItem(
 		keyName = "showOpponentsOpponent",
-		name = "Show Opponents Opponent",
-		description = "Toggle showing opponents opponent if within a multi-combat area",
+		name = "Show opponent's opponent",
+		description = "Toggle showing opponent's opponent if within a multi-combat area",
 		position = 2
 	)
 	default boolean showOpponentsOpponent()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/opponentinfo/OpponentInfoOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/opponentinfo/OpponentInfoOverlay.java
@@ -200,7 +200,8 @@ class OpponentInfoOverlay extends Overlay
 		}
 
 		// Opponents opponent
-		if (opponentsOpponentName != null)
+		// Show if checkbox is marked within plugin panel
+		if (opponentsOpponentName != null && opponentInfoConfig.showOpponentsOpponent())
 		{
 			textWidth = Math.max(textWidth, fontMetrics.stringWidth(opponentsOpponentName));
 			panelComponent.setPreferredSize(new Dimension(textWidth, 0));

--- a/runelite-client/src/main/java/net/runelite/client/plugins/opponentinfo/OpponentInfoOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/opponentinfo/OpponentInfoOverlay.java
@@ -200,7 +200,6 @@ class OpponentInfoOverlay extends Overlay
 		}
 
 		// Opponents opponent
-		// Show if checkbox is marked within plugin panel
 		if (opponentsOpponentName != null && opponentInfoConfig.showOpponentsOpponent())
 		{
 			textWidth = Math.max(textWidth, fontMetrics.stringWidth(opponentsOpponentName));


### PR DESCRIPTION
Added new checkbox that if left unchecked, will not display the opponents opponent when in multi combat areas for the opponent info overlay, acting as it does in single combat areas.

Closes #4361