### PR TITLE
Fix Werewolf agility XP given in skill calculator

### DIFF
--- a/runelite-client/src/main/resources/net/runelite/client/plugins/skillcalculator/skill_agility.json
+++ b/runelite-client/src/main/resources/net/runelite/client/plugins/skillcalculator/skill_agility.json
@@ -70,7 +70,7 @@
       "level": 60,
       "icon": 4179,
       "name": "Werewolf Agility Course",
-      "xp": 540
+      "xp": 730
     },
     {
       "level": 70,


### PR DESCRIPTION
~~Looks like the XP for the Penguin course was copied to the Werewolf course.~~

Edit: as waycooler pointed out, Jagex have doubled the stick bonus.