### PR TITLE
Add Option To Hide Bank Tag Menu Items

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/banktags/BankTagsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/banktags/BankTagsConfig.java
@@ -59,7 +59,8 @@ public interface BankTagsConfig extends Config
 		description = "Hide menu options for adding/removing tags.",
 		position = 3
 	)
-	default boolean hideTagMenuItems() {
+	default boolean hideTagMenuItems()
+	{
 		return false;
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/banktags/BankTagsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/banktags/BankTagsConfig.java
@@ -54,6 +54,16 @@ public interface BankTagsConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "hideTagMenuItems",
+		name = "Hide Menu Items",
+		description = "Hide menu options for adding/removing tags.",
+		position = 3
+	)
+	default boolean hideTagMenuItems() {
+		return false;
+	}
+
+	@ConfigItem(
 		keyName = "position",
 		name = "",
 		description = "",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/banktags/BankTagsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/banktags/BankTagsPlugin.java
@@ -213,7 +213,8 @@ public class BankTagsPlugin extends Plugin implements MouseWheelListener, KeyLis
 		MenuEntry[] entries = client.getMenuEntries();
 
 		if (event.getActionParam1() == WidgetInfo.BANK_ITEM_CONTAINER.getId()
-			&& event.getOption().equals("Examine"))
+			&& event.getOption().equals("Examine")
+			&& !config.hideTagMenuItems())
 		{
 			Widget container = client.getWidget(WidgetInfo.BANK_ITEM_CONTAINER);
 			Widget item = container.getChild(event.getActionParam0());

--- a/runelite-client/src/main/java/net/runelite/client/plugins/banktags/tabs/TabInterface.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/banktags/tabs/TabInterface.java
@@ -344,7 +344,8 @@ public class TabInterface
 
 		if (activeTab != null
 			&& event.getActionParam1() == WidgetInfo.BANK_ITEM_CONTAINER.getId()
-			&& event.getOption().equals("Examine"))
+			&& event.getOption().equals("Examine")
+			&& !config.hideTagMenuItems())
 		{
 			entries = createMenuEntry(event, REMOVE_TAG + " (" + activeTab.getTag() + ")", event.getTarget(), entries);
 			client.setMenuEntries(entries);


### PR DESCRIPTION
Add option to `Bank Tags` plugin config to hide the menu options for adding & removing tags for items in the bank. 

Resolves #6274

### Hidden In Bank Screen
<img width="1097" alt="hidden in bank screen" src="https://user-images.githubusercontent.com/11299264/47968182-1ec89200-e01b-11e8-87e0-69206e4fd785.png">

### Shown In Bank Screen
<img width="1097" alt="shown in bank screen" src="https://user-images.githubusercontent.com/11299264/47968195-46b7f580-e01b-11e8-8375-03c77056bb1e.png">

### Hidden In Bank Tag Screen
<img width="1097" alt="hidden in bank tag screen" src="https://user-images.githubusercontent.com/11299264/47968198-56373e80-e01b-11e8-8d4f-982339baa7e4.png">

### Shown In Bank Tag Screen
<img width="1097" alt="shown in bank tag screen" src="https://user-images.githubusercontent.com/11299264/47968201-60f1d380-e01b-11e8-8a83-dc7a9423ff6a.png">