### PR TITLE
[CMM] Make update not access varbits outside the client thread

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/chat/ChatMessageManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/chat/ChatMessageManager.java
@@ -574,7 +574,7 @@ public class ChatMessageManager
 			return;
 		}
 
-		final boolean transparent = client.isResized() && client.getVar(Varbits.TRANSPARENT_CHATBOX) != 0;
+		final boolean transparent = client.isResized() && transparencyVarbit != 0;
 		final Collection<ChatColor> chatColors = colorCache.get(target.getType());
 
 		// If we do not have any colors cached, simply set clean message


### PR DESCRIPTION
Currently, Chat Commands doesn't work on dev builds when updating messages outside of the client thread, due to `ChatMessageManager#update` calling `Client#getVar` to get whether the chatbox is transparent. The value of this varbit is already stored when it changes, so it can be changed to work even outside the client thread.

Fixes #6348 