### PR TITLE
Correct some explanatory comments in runelite api

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/Client.java
+++ b/runelite-api/src/main/java/net/runelite/api/Client.java
@@ -971,19 +971,20 @@ public interface Client extends GameEngine
 	BufferProvider getBufferProvider();
 
 	/**
-	 * Gets the amount of ticks since the last mouse movement occurred.
+	 * Gets the amount of client ticks {@link ClientTickLength} since the last mouse movement occurred.
 	 *
 	 * @return amount of idle mouse ticks
 	 */
 	int getMouseIdleTicks();
 
 	/**
-	 * Gets the number of milliseconds since the last mouse press occurred.
+	 * Gets the time at which the last mouse press occurred in milliseconds since
+	 * the UNIX epoch.
 	 */
 	long getMouseLastPressedMillis();
 
 	/**
-	 * Gets the amount of ticks since the last keyboard press occurred.
+	 * Gets the amount of client ticks {@link ClientTickLength} since the last keyboard press occurred.
 	 *
 	 * @return amount of idle keyboard ticks
 	 */

--- a/runelite-api/src/main/java/net/runelite/api/Client.java
+++ b/runelite-api/src/main/java/net/runelite/api/Client.java
@@ -971,9 +971,10 @@ public interface Client extends GameEngine
 	BufferProvider getBufferProvider();
 
 	/**
-	 * Gets the amount of client ticks {@link ClientTickLength} since the last mouse movement occurred.
+	 * Gets the amount of client ticks since the last mouse movement occurred.
 	 *
 	 * @return amount of idle mouse ticks
+	 * @see Constants#CLIENT_TICK_LENGTH
 	 */
 	int getMouseIdleTicks();
 
@@ -984,9 +985,10 @@ public interface Client extends GameEngine
 	long getMouseLastPressedMillis();
 
 	/**
-	 * Gets the amount of client ticks {@link ClientTickLength} since the last keyboard press occurred.
+	 * Gets the amount of client ticks since the last keyboard press occurred.
 	 *
 	 * @return amount of idle keyboard ticks
+	 * @see Constants#CLIENT_TICK_LENGTH
 	 */
 	int getKeyboardIdleTicks();
 

--- a/runelite-api/src/main/java/net/runelite/api/Constants.java
+++ b/runelite-api/src/main/java/net/runelite/api/Constants.java
@@ -36,30 +36,37 @@ public class Constants
 	 * The original width of the game when running in fixed mode.
 	 */
 	public static final int GAME_FIXED_WIDTH = 765;
+
 	/**
 	 * The original height of the game when running in fixed mode.
 	 */
 	public static final int GAME_FIXED_HEIGHT = 503;
+
 	/**
 	 * Dimension representation of the width and height of the game in fixed mode.
 	 */
 	public static final Dimension GAME_FIXED_SIZE = new Dimension(GAME_FIXED_WIDTH, GAME_FIXED_HEIGHT);
+
 	/**
 	 * The aspect ratio of the game when running in fixed mode.
 	 */
 	public static final double GAME_FIXED_ASPECT_RATIO = (double) GAME_FIXED_WIDTH / (double) GAME_FIXED_HEIGHT;
+
 	/**
 	 * The default camera zoom value.
 	 */
 	public static final int CLIENT_DEFAULT_ZOOM = 512;
+
 	/**
 	 * The width and length of a chunk (8x8 tiles).
 	 */
 	public static final int CHUNK_SIZE = 8;
+
 	/**
 	 * The width and length of the scene (13 chunks x 8 tiles).
 	 */
 	public static final int SCENE_SIZE = 104;
+
 	/**
 	 * The max allowed plane by the game.
 	 * <p>

--- a/runelite-api/src/main/java/net/runelite/api/Constants.java
+++ b/runelite-api/src/main/java/net/runelite/api/Constants.java
@@ -69,4 +69,12 @@ public class Constants
 	public static final int MAX_Z = 4;
 
 	public static final int TILE_FLAG_BRIDGE = 2;
+
+	/**
+	 * The number of milliseconds in a client tick.
+	 * <p>
+	 * This is the length of a single frame when the client is running at
+	 * the maximum framerate of 50 fps.
+	 */
+	public static final int CLIENT_TICK_LENGTH = 20;
 }


### PR DESCRIPTION
While working with getMouseIdleTicks(), getKeyboardIdleTicks() and getMouseLastPressedMillis() I noticed that the comments were incorrect or misleading so I've clarified them.