### PR TITLE
Add raids private storage menuentryswapper config

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -193,6 +193,16 @@ public interface MenuEntrySwapperConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "swapPrivate",
+		name = "Private",
+		description = "Swap Shared with Private on the Chamber of Xeric storage units."
+	)
+	default boolean swapPrivate()
+	{
+		return false;
+	}
+
+	@ConfigItem(
 		keyName = "swapQuick",
 		name = "Quick Pass/Start/Travel",
 		description = "Swap Pass with Quick-Pass, Ring with Quick-Start and Talk-to with Quick-Travel"
@@ -250,15 +260,5 @@ public interface MenuEntrySwapperConfig extends Config
 	default boolean swapTravel()
 	{
 		return true;
-	}
-
-	@ConfigItem(
-		keyName = "swapPrivateRaidChest",
-		name = "Private Raid Chest",
-		description = "Swap Shared with Private on the Chamber of Xeric storage units."
-	)
-	default boolean swapPrivateRaidChest()
-	{
-		return false;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -251,4 +251,14 @@ public interface MenuEntrySwapperConfig extends Config
 	{
 		return true;
 	}
+
+	@ConfigItem(
+		keyName = "swapPrivateRaidChest",
+		name = "Private Raid Chest",
+		description = "Swap Shared with Private on the Chamber of Xeric storage units."
+	)
+	default boolean swapPrivateRaidChest()
+	{
+		return false;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -487,6 +487,10 @@ public class MenuEntrySwapperPlugin extends Plugin
 			swap("spellbook", option, target, true);
 			swap("perks", option, target, true);
 		}
+		else if (config.swapPrivateRaidChest() && option.equals("shared"))
+		{
+			swap("private", option, target, true);
+		}
 		else if (config.shiftClickCustomization() && shiftModifier && !option.equals("use"))
 		{
 			Integer customOption = getSwapConfig(itemId);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -487,7 +487,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 			swap("spellbook", option, target, true);
 			swap("perks", option, target, true);
 		}
-		else if (config.swapPrivateRaidChest() && option.equals("shared"))
+		else if (config.swapPrivate() && option.equals("shared"))
 		{
 			swap("private", option, target, true);
 		}


### PR DESCRIPTION
Adds a config option that will swap `Shared` and `Private` on Raids storage units.


![](https://i.imgur.com/JhmMPgq.png)
![](https://i.imgur.com/FLyRI0X.png)

Closes #6015 