### PR TITLE
Fixed maniacal monkey hunting trap bug

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/hunter/HunterPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/hunter/HunterPlugin.java
@@ -128,7 +128,7 @@ public class HunterPlugin extends Plugin
 
 			case ObjectID.MONKEY_TRAP: // Maniacal monkey trap placed
 				// If player is right next to "object" trap assume that player placed the trap
-				if (localPlayer.getWorldLocation().distanceTo(trapLocation) <= 1)
+				if (localPlayer.getWorldLocation().distanceTo(trapLocation) <= 2)
 				{
 					log.debug("Trap placed by \"{}\" on {}", localPlayer.getName(), trapLocation);
 					traps.put(trapLocation, new HunterTrap(gameObject));


### PR DESCRIPTION
Closes #6269 

As far as I can tell, this bug occurred because when the player's distance to the trap was greater than 1 tile, it didn't register the trap as being set by the player. As the boulders are 2x2 objects, the threshold needs to be set to 2 tiles.

![2018-11-08_14-55-59](https://user-images.githubusercontent.com/15676309/48224307-57dc6b80-e367-11e8-9616-adeec85bed98.png)