### PR TITLE
Add notification option for valuable and untradeable items

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/Notifier.java
+++ b/runelite-client/src/main/java/net/runelite/client/Notifier.java
@@ -105,12 +105,22 @@ public class Notifier
 		storeIcon();
 	}
 
+	public  void notify(String message, boolean shouldPrint)
+	{
+		notify(message, TrayIcon.MessageType.NONE, shouldPrint);
+	}
+
 	public void notify(String message)
 	{
-		notify(message, TrayIcon.MessageType.NONE);
+		notify(message, TrayIcon.MessageType.NONE, true);
 	}
 
 	public void notify(String message, TrayIcon.MessageType type)
+	{
+		notify(message, type, true);
+	}
+
+	public void notify(String message, TrayIcon.MessageType type, boolean shouldPrint)
 	{
 		if (!runeLiteConfig.sendNotificationsWhenFocused() && clientUI.isFocused())
 		{
@@ -132,7 +142,7 @@ public class Notifier
 			Toolkit.getDefaultToolkit().beep();
 		}
 
-		if (runeLiteConfig.enableGameMessageNotification() && client.getGameState() == GameState.LOGGED_IN)
+		if (runeLiteConfig.enableGameMessageNotification() && client.getGameState() == GameState.LOGGED_IN && shouldPrint)
 		{
 			chatMessageManager.queue(QueuedMessage.builder()
 				.type(ChatMessageType.GAME)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatnotifications/ChatNotificationsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatnotifications/ChatNotificationsConfig.java
@@ -97,4 +97,26 @@ public interface ChatNotificationsConfig extends Config
 	{
 		return false;
 	}
+
+	@ConfigItem(
+			position = 6,
+			keyName = "notifyOnValuable",
+			name = "Notify on valuable drop",
+			description = "Notifies you whenever you receive a valuable drop"
+	)
+	default boolean notifyOnValuable()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+			position = 7,
+			keyName = "notifyOnUntradeable",
+			name = "Notify on untradeable drop",
+			description = "Notifies you whenever you receive an untradeable drop"
+	)
+	default boolean notifyOnUntradeable()
+	{
+		return false;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatnotifications/ChatNotificationsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatnotifications/ChatNotificationsPlugin.java
@@ -29,6 +29,7 @@ import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
 import com.google.common.eventbus.Subscribe;
 import com.google.inject.Provides;
+
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -137,13 +138,22 @@ public class ChatNotificationsPlugin extends Plugin
 			case TRADE:
 				if (event.getValue().contains("wishes to trade with you.") && config.notifyOnTrade())
 				{
-					notifier.notify(event.getValue());
+					notifier.notify(event.getValue(), false);
 				}
 				break;
 			case DUEL:
 				if (event.getValue().contains("wishes to duel with you.") && config.notifyOnDuel())
 				{
-					notifier.notify(event.getValue());
+					notifier.notify(event.getValue(), false);
+				}
+				break;
+			case SERVER:
+				if ((config.notifyOnValuable() && event.getValue().startsWith("Valuable drop:")) || (config.notifyOnUntradeable() && event.getValue().startsWith("Untradeable drop:")))
+				{
+					event.setValue(Text.removeTags(event.getValue()));
+					event.setSender(client.getLocalPlayer().getName());
+					sendNotification(event);
+					return;
 				}
 				break;
 			case GAME:
@@ -227,6 +237,6 @@ public class ChatNotificationsPlugin extends Plugin
 		stringBuilder.append(message.getValue());
 
 		String notification = stringBuilder.toString();
-		notifier.notify(notification);
+		notifier.notify(notification, false);
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
@@ -525,6 +525,6 @@ public class GroundItemsPlugin extends Plugin
 		}
 
 		notificationStringBuilder.append("!");
-		notifier.notify(notificationStringBuilder.toString());
+		notifier.notify(notificationStringBuilder.toString(), false);
 	}
 }


### PR DESCRIPTION
This adds an option to notify player when they receive a valuable drop or untradeable drop as configured by the in game options.

Also this will fix the issue where chat notifications would send game messages as well when the option was selected resulting in double game messages.

![Settings](https://i.imgur.com/HmW57ee.png)

[Demo](https://i.imgur.com/hogEsYD.gif)