### PR TITLE
Notification for highlighted items bound to player loot

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
@@ -73,21 +73,10 @@ public interface GroundItemsConfig extends Config
 	void setHiddenItems(String key);
 
 	@ConfigItem(
-			keyName = "notifyHighlightedDrops",
-			name = "Notify for Highlighted drops",
-			description = "Configures whether or not to notify for drops on your highlighted list",
-			position = 2
-	)
-	default boolean notifyHighlightedDrops()
-	{
-		return false;
-	}
-
-	@ConfigItem(
 		keyName = "showHighlightedOnly",
 		name = "Show Highlighted items only",
 		description = "Configures whether or not to draw items only on your highlighted list",
-		position = 3
+		position = 2
 	)
 	default boolean showHighlightedOnly()
 	{
@@ -98,7 +87,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "dontHideUntradeables",
 		name = "Do not hide untradeables",
 		description = "Configures whether or not untradeable items ignore hiding under settings",
-		position = 4
+		position = 3
 	)
 	default boolean dontHideUntradeables()
 	{
@@ -109,7 +98,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "showMenuItemQuantities",
 		name = "Show Menu Item Quantities",
 		description = "Configures whether or not to show the item quantities in the menu",
-		position = 5
+		position = 4
 	)
 	default boolean showMenuItemQuantities()
 	{
@@ -120,7 +109,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "recolorMenuHiddenItems",
 		name = "Recolor Menu Hidden Items",
 		description = "Configures whether or not hidden items in right click menu will be recolored",
-		position = 6
+		position = 5
 	)
 	default boolean recolorMenuHiddenItems()
 	{
@@ -131,11 +120,22 @@ public interface GroundItemsConfig extends Config
 		keyName = "highlightTiles",
 		name = "Highlight Tiles",
 		description = "Configures whether or not to highlight tiles containing ground items",
-		position = 7
+		position = 6
 	)
 	default boolean highlightTiles() 
 	{ 
 		return false; 
+	}
+
+	@ConfigItem(
+		keyName = "notifyHighlightedDrops",
+		name = "Notify for Highlighted drops",
+		description = "Configures whether or not to notify for drops on your highlighted list",
+		position = 7
+	)
+	default boolean notifyHighlightedDrops()
+	{
+		return false;
 	}
 
 	@ConfigItem(
@@ -249,21 +249,10 @@ public interface GroundItemsConfig extends Config
 	}
 
 	@ConfigItem(
-			keyName = "notifyLowValueDrops",
-			name = "Notify for low value drops",
-			description = "Configures whether or not to notify for drops of low value",
-			position = 18
-	)
-	default boolean notifyLowValueDrops()
-	{
-		return false;
-	}
-
-	@ConfigItem(
 		keyName = "mediumValueColor",
 		name = "Medium value items color",
 		description = "Configures the color for medium value items",
-		position = 19
+		position = 18
 	)
 	default Color mediumValueColor()
 	{
@@ -274,7 +263,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "mediumValuePrice",
 		name = "Medium value price",
 		description = "Configures the start price for medium value items",
-		position = 20
+		position = 19
 	)
 	default int mediumValuePrice()
 	{
@@ -282,21 +271,10 @@ public interface GroundItemsConfig extends Config
 	}
 
 	@ConfigItem(
-			keyName = "notifyMediumValueDrops",
-			name = "Notify for medium value drops",
-			description = "Configures whether or not to notify for drops of medium value",
-			position = 21
-	)
-	default boolean notifyMediumValueDrops()
-	{
-		return false;
-	}
-
-	@ConfigItem(
 		keyName = "highValueColor",
 		name = "High value items color",
 		description = "Configures the color for high value items",
-		position = 22
+		position = 20
 	)
 	default Color highValueColor()
 	{
@@ -307,7 +285,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "highValuePrice",
 		name = "High value price",
 		description = "Configures the start price for high value items",
-		position = 23
+		position = 21
 	)
 	default int highValuePrice()
 	{
@@ -315,21 +293,10 @@ public interface GroundItemsConfig extends Config
 	}
 
 	@ConfigItem(
-			keyName = "notifyHighValueDrops",
-			name = "Notify for high value drops",
-			description = "Configures whether or not to notify for drops of high value",
-			position = 24
-	)
-	default boolean notifyHighValueDrops()
-	{
-		return false;
-	}
-
-	@ConfigItem(
 		keyName = "insaneValueColor",
 		name = "Insane value items color",
 		description = "Configures the color for insane value items",
-		position = 25
+		position = 22
 	)
 	default Color insaneValueColor()
 	{
@@ -340,7 +307,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "insaneValuePrice",
 		name = "Insane value price",
 		description = "Configures the start price for insane value items",
-		position = 26
+		position = 23
 	)
 	default int insaneValuePrice()
 	{
@@ -348,12 +315,12 @@ public interface GroundItemsConfig extends Config
 	}
 
 	@ConfigItem(
-			keyName = "notifyInsaneValueDrops",
-			name = "Notify for insane value drops",
-			description = "Configures whether or not to notify for drops of insane value",
-			position = 27
+		keyName = "notifyOwnDrops",
+		name = "Notify own drops",
+		description = "Configures whether to notify only for user loots instead of all loots",
+		position = 23
 	)
-	default boolean notifyInsaneValueDrops()
+	default boolean notifyOwnDrops()
 	{
 		return false;
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
@@ -73,10 +73,21 @@ public interface GroundItemsConfig extends Config
 	void setHiddenItems(String key);
 
 	@ConfigItem(
+			keyName = "notifyHighlightedDrops",
+			name = "Notify for Highlighted drops",
+			description = "Configures whether or not to notify for drops on your highlighted list",
+			position = 2
+	)
+	default boolean notifyHighlightedDrops()
+	{
+		return false;
+	}
+
+	@ConfigItem(
 		keyName = "showHighlightedOnly",
 		name = "Show Highlighted items only",
 		description = "Configures whether or not to draw items only on your highlighted list",
-		position = 2
+		position = 3
 	)
 	default boolean showHighlightedOnly()
 	{
@@ -87,7 +98,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "dontHideUntradeables",
 		name = "Do not hide untradeables",
 		description = "Configures whether or not untradeable items ignore hiding under settings",
-		position = 3
+		position = 4
 	)
 	default boolean dontHideUntradeables()
 	{
@@ -98,7 +109,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "showMenuItemQuantities",
 		name = "Show Menu Item Quantities",
 		description = "Configures whether or not to show the item quantities in the menu",
-		position = 4
+		position = 5
 	)
 	default boolean showMenuItemQuantities()
 	{
@@ -109,7 +120,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "recolorMenuHiddenItems",
 		name = "Recolor Menu Hidden Items",
 		description = "Configures whether or not hidden items in right click menu will be recolored",
-		position = 5
+		position = 6
 	)
 	default boolean recolorMenuHiddenItems()
 	{
@@ -120,22 +131,11 @@ public interface GroundItemsConfig extends Config
 		keyName = "highlightTiles",
 		name = "Highlight Tiles",
 		description = "Configures whether or not to highlight tiles containing ground items",
-		position = 6
+		position = 7
 	)
 	default boolean highlightTiles() 
 	{ 
 		return false; 
-	}
-
-	@ConfigItem(
-		keyName = "notifyHighlightedDrops",
-		name = "Notify for Highlighted drops",
-		description = "Configures whether or not to notify for drops on your highlighted list",
-		position = 7
-	)
-	default boolean notifyHighlightedDrops()
-	{
-		return false;
 	}
 
 	@ConfigItem(
@@ -249,10 +249,21 @@ public interface GroundItemsConfig extends Config
 	}
 
 	@ConfigItem(
+			keyName = "notifyLowValueDrops",
+			name = "Notify for low value drops",
+			description = "Configures whether or not to notify for drops of low value",
+			position = 18
+	)
+	default boolean notifyLowValueDrops()
+	{
+		return false;
+	}
+
+	@ConfigItem(
 		keyName = "mediumValueColor",
 		name = "Medium value items color",
 		description = "Configures the color for medium value items",
-		position = 18
+		position = 19
 	)
 	default Color mediumValueColor()
 	{
@@ -263,7 +274,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "mediumValuePrice",
 		name = "Medium value price",
 		description = "Configures the start price for medium value items",
-		position = 19
+		position = 20
 	)
 	default int mediumValuePrice()
 	{
@@ -271,10 +282,21 @@ public interface GroundItemsConfig extends Config
 	}
 
 	@ConfigItem(
+			keyName = "notifyMediumValueDrops",
+			name = "Notify for medium value drops",
+			description = "Configures whether or not to notify for drops of medium value",
+			position = 21
+	)
+	default boolean notifyMediumValueDrops()
+	{
+		return false;
+	}
+
+	@ConfigItem(
 		keyName = "highValueColor",
 		name = "High value items color",
 		description = "Configures the color for high value items",
-		position = 20
+		position = 22
 	)
 	default Color highValueColor()
 	{
@@ -285,7 +307,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "highValuePrice",
 		name = "High value price",
 		description = "Configures the start price for high value items",
-		position = 21
+		position = 23
 	)
 	default int highValuePrice()
 	{
@@ -293,10 +315,21 @@ public interface GroundItemsConfig extends Config
 	}
 
 	@ConfigItem(
+			keyName = "notifyHighValueDrops",
+			name = "Notify for high value drops",
+			description = "Configures whether or not to notify for drops of high value",
+			position = 24
+	)
+	default boolean notifyHighValueDrops()
+	{
+		return false;
+	}
+
+	@ConfigItem(
 		keyName = "insaneValueColor",
 		name = "Insane value items color",
 		description = "Configures the color for insane value items",
-		position = 22
+		position = 25
 	)
 	default Color insaneValueColor()
 	{
@@ -307,10 +340,21 @@ public interface GroundItemsConfig extends Config
 		keyName = "insaneValuePrice",
 		name = "Insane value price",
 		description = "Configures the start price for insane value items",
-		position = 23
+		position = 26
 	)
 	default int insaneValuePrice()
 	{
 		return 10000000;
+	}
+
+	@ConfigItem(
+			keyName = "notifyInsaneValueDrops",
+			name = "Notify for insane value drops",
+			description = "Configures whether or not to notify for drops of insane value",
+			position = 27
+	)
+	default boolean notifyInsaneValueDrops()
+	{
+		return false;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerConfig.java
@@ -48,4 +48,15 @@ public interface LootTrackerConfig extends Config
 		description = ""
 	)
 	void setIgnoredItems(String key);
+
+	@ConfigItem(
+			keyName = "notifyHighlighted",
+			name = "Notify on highlighted",
+			description = "Notifies player on recieving highlights drops"
+	)
+
+	default boolean notifyHighlighted()
+	{
+		return false;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
@@ -328,4 +328,5 @@ public class LootTrackerPlugin extends Plugin
 				ignored);
 		}).toArray(LootTrackerItem[]::new);
 	}
+
 }


### PR DESCRIPTION
This changes the notify on highlighted item option in Ground Items plugin to only trigger for your loot instead of all loot.

Also added toggles for each level of value for ground items. 

![demo](https://i.imgur.com/jXDPjJ1.gif)


This means that if someone is doing a slayer task in a different section of the map to you and gets a drop but leaves it visible for you, then you don't get notified. Also Ironmen don't have to fuss over what is and isn't lootable.