### PR TITLE
Unlimit stretched resizable mode and properly limit scaling factor

### DIFF
--- a/runelite-mixins/src/main/java/net/runelite/mixins/StretchedModeMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/StretchedModeMixin.java
@@ -122,8 +122,18 @@ public abstract class StretchedModeMixin implements RSClient
 				int parentWidth = canvasParent.getWidth();
 				int parentHeight = canvasParent.getHeight();
 
-				int newWidth = Math.max(Constants.GAME_FIXED_WIDTH, (int) (parentWidth / scalingFactor));
-				int newHeight = Math.max(Constants.GAME_FIXED_HEIGHT, (int) (parentHeight / scalingFactor));
+				int newWidth = (int) (parentWidth / scalingFactor);
+				int newHeight = (int) (parentHeight / scalingFactor);
+
+				if (newWidth < Constants.GAME_FIXED_WIDTH || newHeight < Constants.GAME_FIXED_HEIGHT)
+				{
+					double scalingFactorW = (double)parentWidth / Constants.GAME_FIXED_WIDTH;
+					double scalingFactorH = (double)parentHeight / Constants.GAME_FIXED_HEIGHT;
+					double scalingFactor = Math.min(scalingFactorW, scalingFactorH);
+
+					newWidth = (int) (parentWidth / scalingFactor);
+					newHeight = (int) (parentHeight / scalingFactor);
+				}
 
 				cachedRealDimensions = new Dimension(newWidth, newHeight);
 			}

--- a/runelite-mixins/src/main/java/net/runelite/mixins/StretchedModeMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/StretchedModeMixin.java
@@ -24,7 +24,6 @@
  */
 package net.runelite.mixins;
 
-import com.google.common.primitives.Ints;
 import java.awt.Container;
 import java.awt.Dimension;
 import net.runelite.api.Constants;
@@ -102,8 +101,6 @@ public abstract class StretchedModeMixin implements RSClient
 	@Override
 	public void setScalingFactor(int factor)
 	{
-		factor = Ints.constrainToRange(factor, 0, 100);
-
 		scalingFactor = 1 + (factor / 100D);
 	}
 


### PR DESCRIPTION
- The limits are no longer necessary as it is limited anyway to fixed mode
base size, and with new method of scaling the 100% max is quite
limiting.
- Instead of limiting width and height when stretching to fixed mode size,
limit scaling factor to fixed mode size to prevent improportional
stretching in resizable mode.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>