### PR TITLE
Add custom RuneLite Color picker

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
@@ -48,11 +48,8 @@ import javax.swing.BorderFactory;
 import javax.swing.ImageIcon;
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
-import javax.swing.JColorChooser;
 import javax.swing.JComboBox;
-import javax.swing.JComponent;
 import javax.swing.JFormattedTextField;
-import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
@@ -88,6 +85,7 @@ import net.runelite.client.ui.PluginPanel;
 import net.runelite.client.ui.components.ComboBoxListRenderer;
 import net.runelite.client.ui.components.IconButton;
 import net.runelite.client.ui.components.IconTextField;
+import net.runelite.client.ui.components.colorpicker.RuneliteColorPicker;
 import net.runelite.client.util.ImageUtil;
 
 @Slf4j
@@ -128,7 +126,7 @@ public class ConfigPanel extends PluginPanel
 	}
 
 	ConfigPanel(PluginManager pluginManager, ConfigManager configManager, ScheduledExecutorService executorService,
-		RuneLiteConfig runeLiteConfig, ChatColorConfig chatColorConfig)
+				RuneLiteConfig runeLiteConfig, ChatColorConfig chatColorConfig)
 	{
 		super(false);
 		this.pluginManager = pluginManager;
@@ -387,47 +385,44 @@ public class ConfigPanel extends PluginPanel
 				String existing = configManager.getConfiguration(cd.getGroup().value(), cid.getItem().keyName());
 
 				Color existingColor;
-				JButton colorPicker;
+				JButton colorPickerBtn;
 
 				if (existing == null)
 				{
 					existingColor = Color.BLACK;
-					colorPicker = new JButton("Pick a color");
+					colorPickerBtn = new JButton("Pick a color");
 				}
 				else
 				{
 					existingColor = Color.decode(existing);
-					colorPicker = new JButton("#" + Integer.toHexString(existingColor.getRGB()).substring(2).toUpperCase());
+					colorPickerBtn = new JButton("#" + Integer.toHexString(existingColor.getRGB()).substring(2).toUpperCase());
 				}
 
-				colorPicker.setFocusable(false);
-				colorPicker.setBackground(existingColor);
-				colorPicker.addMouseListener(new MouseAdapter()
+				colorPickerBtn.setFocusable(false);
+				colorPickerBtn.setBackground(existingColor);
+				colorPickerBtn.addMouseListener(new MouseAdapter()
 				{
 					@Override
 					public void mouseClicked(MouseEvent e)
 					{
-						final JFrame parent = new JFrame();
-						JColorChooser jColorChooser = new JColorChooser(existingColor);
-						jColorChooser.getSelectionModel().addChangeListener(e1 ->
+						RuneliteColorPicker colorPicker = new RuneliteColorPicker(existingColor);
+						colorPicker.setOnColorChange(c ->
 						{
-							colorPicker.setBackground(jColorChooser.getColor());
-							colorPicker.setText("#" + Integer.toHexString(jColorChooser.getColor().getRGB()).substring(2).toUpperCase());
+							colorPickerBtn.setBackground(c);
+							colorPickerBtn.setText("#" + Integer.toHexString(c.getRGB()).substring(2).toUpperCase());
 						});
-						parent.addWindowListener(new WindowAdapter()
+
+						colorPicker.addWindowListener(new WindowAdapter()
 						{
 							@Override
 							public void windowClosing(WindowEvent e)
 							{
-								changeConfiguration(listItem, config, jColorChooser, cd, cid);
+								changeConfiguration(listItem, config, colorPicker, cd, cid);
 							}
 						});
-						parent.add(jColorChooser);
-						parent.pack();
-						parent.setVisible(true);
 					}
 				});
-				item.add(colorPicker, BorderLayout.EAST);
+				item.add(colorPickerBtn, BorderLayout.EAST);
 			}
 
 			if (cid.getType() == Dimension.class)
@@ -534,7 +529,7 @@ public class ConfigPanel extends PluginPanel
 		scrollPane.getVerticalScrollBar().setValue(0);
 	}
 
-	private void changeConfiguration(PluginListItem listItem, Config config, JComponent component, ConfigDescriptor cd, ConfigItemDescriptor cid)
+	private void changeConfiguration(PluginListItem listItem, Config config, Component component, ConfigDescriptor cd, ConfigItemDescriptor cid)
 	{
 		final ConfigItem configItem = cid.getItem();
 
@@ -566,10 +561,10 @@ public class ConfigPanel extends PluginPanel
 			JTextComponent textField = (JTextComponent) component;
 			configManager.setConfiguration(cd.getGroup().value(), cid.getItem().keyName(), textField.getText());
 		}
-		else if (component instanceof JColorChooser)
+		else if (component instanceof RuneliteColorPicker)
 		{
-			JColorChooser jColorChooser = (JColorChooser) component;
-			configManager.setConfiguration(cd.getGroup().value(), cid.getItem().keyName(), String.valueOf(jColorChooser.getColor().getRGB()));
+			RuneliteColorPicker colorPicker = (RuneliteColorPicker) component;
+			configManager.setConfiguration(cd.getGroup().value(), cid.getItem().keyName(), String.valueOf(colorPicker.getSelectedColor().getRGB()));
 		}
 		else if (component instanceof JComboBox)
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenmarkers/ui/ScreenMarkerPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenmarkers/ui/ScreenMarkerPanel.java
@@ -36,8 +36,6 @@ import java.awt.event.WindowEvent;
 import java.awt.image.BufferedImage;
 import javax.swing.BorderFactory;
 import javax.swing.ImageIcon;
-import javax.swing.JColorChooser;
-import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
@@ -53,6 +51,7 @@ import net.runelite.client.plugins.screenmarkers.ScreenMarkerPlugin;
 import net.runelite.client.ui.ColorScheme;
 import net.runelite.client.ui.FontManager;
 import net.runelite.client.ui.components.FlatTextField;
+import net.runelite.client.ui.components.colorpicker.RuneliteColorPicker;
 import net.runelite.client.util.ImageUtil;
 
 class ScreenMarkerPanel extends JPanel
@@ -489,17 +488,14 @@ class ScreenMarkerPanel extends JPanel
 
 	private void openFillColorPicker()
 	{
-		final JFrame parent = new JFrame();
-		JColorChooser jColorChooser = new JColorChooser(marker.getMarker().getFill());
-
-		jColorChooser.getSelectionModel().addChangeListener(e1 ->
+		RuneliteColorPicker colorPicker = new RuneliteColorPicker(marker.getMarker().getFill());
+		colorPicker.setOnColorChange(c ->
 		{
-			Color chosen = jColorChooser.getColor();
-			marker.getMarker().setFill(new Color(chosen.getRed(), chosen.getGreen(), chosen.getBlue(), DEFAULT_FILL_OPACITY));
+			marker.getMarker().setFill(new Color(c.getRed(), c.getGreen(), c.getBlue(), DEFAULT_FILL_OPACITY));
 			updateFill();
 		});
 
-		parent.addWindowListener(new WindowAdapter()
+		colorPicker.addWindowListener(new WindowAdapter()
 		{
 			@Override
 			public void windowClosing(WindowEvent e)
@@ -507,25 +503,18 @@ class ScreenMarkerPanel extends JPanel
 				plugin.updateConfig();
 			}
 		});
-
-		parent.add(jColorChooser);
-		parent.pack();
-		parent.setLocationRelativeTo(null);
-		parent.setVisible(true);
 	}
 
 	private void openBorderColorPicker()
 	{
-		final JFrame parent = new JFrame();
-		JColorChooser jColorChooser = new JColorChooser(marker.getMarker().getColor());
-
-		jColorChooser.getSelectionModel().addChangeListener(e1 ->
+		RuneliteColorPicker colorPicker = new RuneliteColorPicker(marker.getMarker().getColor());
+		colorPicker.setOnColorChange(c ->
 		{
-			marker.getMarker().setColor(jColorChooser.getColor());
+			marker.getMarker().setColor(new Color(c.getRed(), c.getGreen(), c.getBlue(), DEFAULT_FILL_OPACITY));
 			updateBorder();
 		});
 
-		parent.addWindowListener(new WindowAdapter()
+		colorPicker.addWindowListener(new WindowAdapter()
 		{
 			@Override
 			public void windowClosing(WindowEvent e)
@@ -533,10 +522,5 @@ class ScreenMarkerPanel extends JPanel
 				plugin.updateConfig();
 			}
 		});
-
-		parent.add(jColorChooser);
-		parent.pack();
-		parent.setLocationRelativeTo(null);
-		parent.setVisible(true);
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/ui/components/colorpicker/ColorPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/components/colorpicker/ColorPanel.java
@@ -1,0 +1,236 @@
+/*
+ * Copyright (c) 2018, Psikoi <https://github.com/psikoi>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.ui.components.colorpicker;
+
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Graphics;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseMotionAdapter;
+import java.util.function.BiConsumer;
+import javax.swing.JPanel;
+import lombok.Setter;
+
+public class ColorPanel extends JPanel
+{
+	private final static int PANEL_WIDTH = 15;
+
+	private final int height;
+	private final Color[] gradient;
+
+	private int selectedY = 0;
+
+	// The color which it was changed to, and wether this change was the
+	// result of a forced update
+	@Setter
+	private BiConsumer<Color, Boolean> onColorChange;
+
+	ColorPanel(int height)
+	{
+		this.height = height;
+		this.gradient = new Color[]{
+			Color.RED,
+			Color.MAGENTA,
+			Color.BLUE,
+			Color.CYAN,
+			Color.GREEN,
+			Color.YELLOW,
+			Color.RED};
+
+		setPreferredSize(new Dimension(PANEL_WIDTH, height));
+
+		addMouseMotionListener(new MouseMotionAdapter()
+		{
+			@Override
+			public void mouseDragged(MouseEvent me)
+			{
+				moveSelector(me.getY());
+			}
+		});
+
+		addMouseListener(new MouseAdapter()
+		{
+			@Override
+			public void mouseReleased(MouseEvent me)
+			{
+				moveSelector(me.getY());
+			}
+
+			@Override
+			public void mousePressed(MouseEvent me)
+			{
+				moveSelector(me.getY());
+			}
+		});
+	}
+
+	public void select(Color color)
+	{
+		this.selectedY = closestYToColor(color);
+
+		if (this.onColorChange != null)
+		{
+			this.onColorChange.accept(colorAt(selectedY), true);
+		}
+
+		repaint();
+	}
+
+	/**
+	 * Moves the selector to a specified y coordinate.
+	 */
+	private void moveSelector(int y)
+	{
+		if (y < 0)
+		{
+			y = 0;
+		}
+
+		if (y > height)
+		{
+			y = height;
+		}
+
+		this.selectedY = y;
+
+		if (this.onColorChange != null)
+		{
+			this.onColorChange.accept(colorAt(selectedY), false);
+		}
+
+		repaint();
+	}
+
+	/**
+	 * Calculates the closest y value to the base color of a given target color.
+	 */
+	private int closestYToColor(Color target)
+	{
+		// Check the current gradient for matches before searching
+		// through all of the other gradients
+		Color currentBase = colorAt(selectedY);
+
+		for (int x = 0; x < height; x++)
+		{
+			for (int y = 0; y < height; y++)
+			{
+				Color c = TonePanel.colorAt(currentBase, x, y, height);
+
+				if (c.equals(target))
+				{
+					return selectedY;
+				}
+			}
+		}
+
+		// Search through all the gradients for the best match
+		double minDistance = Double.MAX_VALUE;
+		int closestY = height;
+
+		for (int i = 0; i < height; i++)
+		{
+			Color base = colorAt(i);
+
+			for (int x = 0; x < height; x++)
+			{
+				for (int y = 0; y < height; y++)
+				{
+					Color c = TonePanel.colorAt(base, x, y, height);
+
+					if (c.equals(target))
+					{
+						return i;
+					}
+
+					double dv = ColorUtils.colorDistance(c, target);
+
+					if (dv < minDistance)
+					{
+						minDistance = dv;
+						closestY = i;
+					}
+				}
+			}
+		}
+
+		return closestY;
+	}
+
+	/**
+	 * Determines which color is displayed on the gradient on a given y
+	 * coordinate.
+	 */
+	private Color colorAt(int y)
+	{
+		// The height of each color divison (the different colors of the gradient)
+		int divisionHeight = height / (gradient.length - 1);
+
+		// Which section the color is at
+		int colorSection = y / divisionHeight;
+
+		// Where inside the section the color is at
+		int sectionPosition = y % divisionHeight;
+
+		// The current base color
+		Color current = gradient[colorSection];
+
+		// The next base color (the color we should be transitioning to)
+		Color next = colorSection < gradient.length - 1 ? gradient[colorSection + 1] : current;
+
+		// The distances (differences) between the current and the target color
+		int redDiff = current.getRed() - next.getRed();
+		int greenDiff = current.getGreen() - next.getGreen();
+		int blueDiff = current.getBlue() - next.getBlue();
+
+		// The differences in colors scaled to the section position
+		float redFraction = sectionPosition * (redDiff / divisionHeight);
+		float greenFraction = sectionPosition * (greenDiff / divisionHeight);
+		float blueFraction = sectionPosition * (blueDiff / divisionHeight);
+
+		int newRed = ColorUtils.limitRGB((int) (current.getRed() - redFraction));
+		int newGreen = ColorUtils.limitRGB((int) (current.getGreen() - greenFraction));
+		int newBlue = ColorUtils.limitRGB((int) (current.getBlue() - blueFraction));
+
+		return new Color(newRed, newGreen, newBlue);
+	}
+
+	@Override
+	public void paint(Graphics g)
+	{
+		// Paint the gradient
+		for (int y = 0; y < height; y++)
+		{
+			g.setColor(colorAt(y));
+			g.fillRect(0, y, 30, 1);
+		}
+
+		// Paint the selector
+		g.setColor(Color.WHITE);
+		g.fillRect(0, selectedY - 1, 50, 2);
+		g.setColor(Color.BLACK);
+		g.drawRect(0, selectedY - 2, 50, 3);
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/ui/components/colorpicker/ColorUtils.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/components/colorpicker/ColorUtils.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2018, Psikoi <https://github.com/psikoi>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.ui.components.colorpicker;
+
+import java.awt.Color;
+
+class ColorUtils
+{
+	static final int MAX_RGB_VALUE = 255;
+	static final int MIN_RGB_VALUE = 0;
+
+	/**
+	 * Limits an int to the rgb value range (0-255)
+	 */
+	static int limitRGB(int value)
+	{
+		if (value < MIN_RGB_VALUE)
+		{
+			return MIN_RGB_VALUE;
+		}
+
+		if (value > MAX_RGB_VALUE)
+		{
+			return MAX_RGB_VALUE;
+		}
+
+		return value;
+	}
+
+	/**
+	 * Calculates the distance between two color objects' values.
+	 */
+	static double colorDistance(Color a, Color b)
+	{
+		int redDistance = a.getRed() - b.getRed();
+		int greenDistance = a.getGreen() - b.getGreen();
+		int blueDistance = a.getBlue() - b.getBlue();
+		return Math.sqrt(redDistance * redDistance
+			+ greenDistance * greenDistance
+			+ blueDistance * blueDistance);
+	}
+
+	static String getRGB(Color c)
+	{
+		return c.getRed() + ", " + c.getGreen() + ", " + c.getBlue() + ", " + c.getAlpha();
+	}
+
+	static String getHex(Color c)
+	{
+		return String.format("#%02x%02x%02x", c.getRed(), c.getGreen(), c.getBlue());
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/ui/components/colorpicker/ColorValueSlider.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/components/colorpicker/ColorValueSlider.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2018, Psikoi <https://github.com/psikoi>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.ui.components.colorpicker;
+
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.util.function.Consumer;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JSlider;
+import javax.swing.JTextField;
+import javax.swing.border.EmptyBorder;
+import lombok.Setter;
+
+public class ColorValueSlider extends JPanel
+{
+	private JSlider slider;
+	private JTextField input;
+
+	@Setter
+	private Consumer<Integer> onValueChanged;
+
+	// This variable makes sure we only fire the onValueChanged event when
+	// the slider is manually edited, otherwise it will fire when force updated.
+	// It seems there is no way in swing to verify if a slider movement was manual.
+	private boolean forcedUpdate;
+
+	ColorValueSlider(String labelText)
+	{
+		setBackground(new Color(30, 30, 30));
+		setLayout(new BorderLayout(10, 0));
+
+		input = new JTextField();
+		input.setPreferredSize(new Dimension(40, 30));
+		input.setBorder(new EmptyBorder(5, 5, 5, 5));
+		input.setBackground(new Color(20, 20, 20));
+		input.setForeground(Color.WHITE);
+		input.addActionListener(a ->
+		{
+			if (!input.getText().isEmpty() && input.getText().matches("-?(0|[1-9]\\d*)"))
+			{
+				int value = Integer.parseInt(input.getText());
+
+				update(value);
+
+				if (onValueChanged != null)
+				{
+					onValueChanged.accept(value);
+				}
+			}
+		});
+
+		JLabel label = new JLabel(labelText);
+		label.setForeground(Color.WHITE);
+
+		slider = new JSlider();
+		slider.setMinimum(ColorUtils.MIN_RGB_VALUE);
+		slider.setMaximum(ColorUtils.MAX_RGB_VALUE);
+		slider.setBackground(new Color(30, 30, 30));
+		slider.setBorder(new EmptyBorder(0, 0, 5, 0));
+		slider.setUI(new CustomSliderUI(slider));
+
+		slider.addChangeListener(c ->
+		{
+			if (!forcedUpdate && onValueChanged != null)
+			{
+				onValueChanged.accept(slider.getValue());
+			}
+
+			update(slider.getValue());
+		});
+
+		add(label, BorderLayout.WEST);
+		add(slider, BorderLayout.CENTER);
+		add(input, BorderLayout.EAST);
+	}
+
+	public void update(int value)
+	{
+		value = ColorUtils.limitRGB(value);
+
+		forcedUpdate = true;
+		slider.setValue(value);
+		forcedUpdate = false;
+
+		input.setText(value + "");
+	}
+
+	public int getValue()
+	{
+		return slider.getValue();
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/ui/components/colorpicker/ColorValueSlider.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/components/colorpicker/ColorValueSlider.java
@@ -34,6 +34,7 @@ import javax.swing.JSlider;
 import javax.swing.JTextField;
 import javax.swing.border.EmptyBorder;
 import lombok.Setter;
+import net.runelite.client.ui.ColorScheme;
 
 public class ColorValueSlider extends JPanel
 {
@@ -50,14 +51,13 @@ public class ColorValueSlider extends JPanel
 
 	ColorValueSlider(String labelText)
 	{
-		setBackground(new Color(30, 30, 30));
 		setLayout(new BorderLayout(10, 0));
+		setBackground(ColorScheme.DARK_GRAY_COLOR);
 
 		input = new JTextField();
+		input.setBackground(ColorScheme.DARKER_GRAY_COLOR);
 		input.setPreferredSize(new Dimension(40, 30));
 		input.setBorder(new EmptyBorder(5, 5, 5, 5));
-		input.setBackground(new Color(20, 20, 20));
-		input.setForeground(Color.WHITE);
 		input.addActionListener(a ->
 		{
 			if (!input.getText().isEmpty() && input.getText().matches("-?(0|[1-9]\\d*)"))
@@ -74,12 +74,13 @@ public class ColorValueSlider extends JPanel
 		});
 
 		JLabel label = new JLabel(labelText);
+		label.setPreferredSize(new Dimension(40, 0));
 		label.setForeground(Color.WHITE);
 
 		slider = new JSlider();
+		slider.setBackground(ColorScheme.DARK_GRAY_COLOR);
 		slider.setMinimum(ColorUtils.MIN_RGB_VALUE);
 		slider.setMaximum(ColorUtils.MAX_RGB_VALUE);
-		slider.setBackground(new Color(30, 30, 30));
 		slider.setBorder(new EmptyBorder(0, 0, 5, 0));
 		slider.setUI(new CustomSliderUI(slider));
 

--- a/runelite-client/src/main/java/net/runelite/client/ui/components/colorpicker/CustomSliderUI.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/components/colorpicker/CustomSliderUI.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2018, Psikoi <https://github.com/psikoi>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.ui.components.colorpicker;
+
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Graphics;
+import javax.swing.JSlider;
+import javax.swing.plaf.basic.BasicSliderUI;
+
+public class CustomSliderUI extends BasicSliderUI
+{
+	public CustomSliderUI(JSlider b)
+	{
+		super(b);
+	}
+
+	@Override
+	protected Dimension getThumbSize()
+	{
+		return new Dimension(15, 10);
+	}
+
+	@Override
+	public void paintFocus(Graphics grphcs)
+	{
+	}
+
+	@Override
+	public void paintTrack(Graphics g)
+	{
+		g.setColor(new Color(20, 20, 20));
+		g.fillRect(trackRect.x - 10, trackRect.y + 7, trackRect.width + 20, 5);
+	}
+
+	@Override
+	public void paintThumb(Graphics g)
+	{
+		g.setColor(new Color(150, 150, 150));
+		g.fillRect(thumbRect.x + 5, thumbRect.y, thumbRect.width - 10, thumbRect.height);
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/ui/components/colorpicker/RuneliteColorPicker.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/components/colorpicker/RuneliteColorPicker.java
@@ -1,0 +1,312 @@
+/*
+ * Copyright (c) 2018, Psikoi <https://github.com/psikoi>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.ui.components.colorpicker;
+
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.GridLayout;
+import java.awt.event.ActionEvent;
+import java.util.function.Consumer;
+import javax.swing.AbstractAction;
+import javax.swing.BoxLayout;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JTextField;
+import javax.swing.SwingConstants;
+import javax.swing.border.EmptyBorder;
+import lombok.Setter;
+
+class RuneliteColorPicker extends JFrame
+{
+
+	private final static int FRAME_WIDTH = 400;
+	private final static int FRAME_HEIGHT = 380;
+	private final static int TONE_PANEL_SIZE = 160;
+
+	private final TonePanel tonePanel = new TonePanel(TONE_PANEL_SIZE);
+	private final ColorPanel colorPanel = new ColorPanel(TONE_PANEL_SIZE);
+	private final JPanel afterPreview = new JPanel();
+
+	private final ColorValueSlider redSlider = new ColorValueSlider("Red");
+	private final ColorValueSlider greenSlider = new ColorValueSlider("Green");
+	private final ColorValueSlider blueSlider = new ColorValueSlider("Blue");
+	private final ColorValueSlider alphaSlider = new ColorValueSlider("Alpha");
+
+	private final JTextField hexInput = new JTextField();
+	private final JTextField rgbaInput = new JTextField();
+
+	private Color selectedColor;
+	@Setter
+	private Consumer<Color> onColorChange;
+
+	RuneliteColorPicker(Color previousColor)
+	{
+		setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+		setTitle("RuneLite Color Picker");
+		setResizable(false);
+		setSize(FRAME_WIDTH, FRAME_HEIGHT);
+
+		JPanel content = new JPanel(new BorderLayout());
+		content.setBorder(new EmptyBorder(15, 15, 15, 15));
+		content.setBackground(new Color(30, 30, 30));
+
+		JPanel colorSelection = new JPanel(new BorderLayout(15, 0));
+		colorSelection.setBackground(new Color(30, 30, 30));
+
+		JPanel leftPanel = new JPanel(new BorderLayout(15, 0));
+		leftPanel.setBackground(new Color(30, 30, 30));
+
+		leftPanel.add(colorPanel, BorderLayout.WEST);
+		leftPanel.add(tonePanel, BorderLayout.CENTER);
+
+		JPanel rightPanel = new JPanel();
+		rightPanel.setLayout(new BoxLayout(rightPanel, BoxLayout.Y_AXIS));
+		rightPanel.setBackground(new Color(30, 30, 30));
+
+		JPanel contrastPanel = new JPanel(new GridLayout(1, 2));
+		contrastPanel.setBackground(new Color(30, 30, 30));
+
+		JPanel beforePreview = new JPanel();
+		beforePreview.setBackground(selectedColor);
+		afterPreview.setBackground(selectedColor);
+
+		contrastPanel.add(beforePreview);
+		contrastPanel.add(afterPreview);
+
+		JPanel hexContainer = new JPanel(new GridLayout(2, 1, 0, 5));
+		hexContainer.setBackground(new Color(30, 30, 30));
+
+		JLabel hexLabel = new JLabel("Hex color:");
+		hexLabel.setVerticalAlignment(SwingConstants.BOTTOM);
+		hexLabel.setForeground(Color.WHITE);
+
+		hexInput.setBorder(new EmptyBorder(5, 5, 5, 5));
+		hexInput.setBackground(new Color(20, 20, 20));
+		hexInput.setForeground(Color.WHITE);
+
+		hexContainer.add(hexLabel);
+		hexContainer.add(hexInput);
+
+		JPanel rgbContainer = new JPanel(new GridLayout(2, 1, 0, 5));
+		rgbContainer.setBackground(new Color(30, 30, 30));
+
+		JLabel rgbLabel = new JLabel("RGBA color:");
+		rgbLabel.setVerticalAlignment(SwingConstants.BOTTOM);
+		rgbLabel.setForeground(Color.WHITE);
+
+		rgbaInput.setBorder(new EmptyBorder(5, 5, 5, 5));
+		rgbaInput.setBackground(new Color(20, 20, 20));
+		rgbaInput.setForeground(Color.WHITE);
+
+		rgbContainer.add(rgbLabel);
+		rgbContainer.add(rgbaInput);
+
+		rightPanel.add(contrastPanel);
+		rightPanel.add(hexContainer);
+		rightPanel.add(rgbContainer);
+
+		JPanel slidersContainer = new JPanel(new GridLayout(4, 1, 0, 10));
+		slidersContainer.setBorder(new EmptyBorder(15, 0, 0, 0));
+		slidersContainer.setBackground(new Color(30, 30, 30));
+
+		slidersContainer.add(redSlider);
+		slidersContainer.add(greenSlider);
+		slidersContainer.add(blueSlider);
+		slidersContainer.add(alphaSlider);
+
+		colorSelection.add(leftPanel, BorderLayout.WEST);
+		colorSelection.add(rightPanel, BorderLayout.CENTER);
+		colorSelection.add(slidersContainer, BorderLayout.SOUTH);
+
+		content.add(colorSelection, BorderLayout.NORTH);
+
+		setContentPane(content);
+
+		this.selectedColor = previousColor;
+		beforePreview.setBackground(previousColor);
+
+		alphaSlider.update(previousColor.getAlpha());
+
+		colorPanel.setOnColorChange((color, forced) ->
+		{
+			tonePanel.setBaseColor(color, forced);
+		});
+
+		tonePanel.setOnColorChange(c ->
+		{
+			hexInput.setText(ColorUtils.getHex(c));
+			rgbaInput.setText(ColorUtils.getRGB(c));
+			afterPreview.setBackground(c);
+
+			redSlider.update(c.getRed());
+			greenSlider.update(c.getGreen());
+			blueSlider.update(c.getBlue());
+
+			colorChange(c);
+		});
+
+		rgbaInput.addActionListener(new AbstractAction()
+		{
+			@Override
+			public void actionPerformed(ActionEvent e)
+			{
+				validateRGB();
+			}
+		});
+
+		hexInput.addActionListener(new AbstractAction()
+		{
+			@Override
+			public void actionPerformed(ActionEvent e)
+			{
+				validateHex();
+			}
+		});
+
+		redSlider.setOnValueChanged(i ->
+		{
+			colorChange(new Color(i, selectedColor.getGreen(), selectedColor.getBlue()));
+			update();
+		});
+
+		greenSlider.setOnValueChanged(i ->
+		{
+			colorChange(new Color(selectedColor.getRed(), i, selectedColor.getBlue()));
+			update();
+		});
+
+		blueSlider.setOnValueChanged(i ->
+		{
+			colorChange(new Color(selectedColor.getRed(), selectedColor.getGreen(), i));
+			update();
+		});
+
+		alphaSlider.setOnValueChanged(i ->
+		{
+			colorChange(new Color(
+				selectedColor.getRed(),
+				selectedColor.getGreen(),
+				selectedColor.getBlue(), i));
+			rgbaInput.setText(ColorUtils.getRGB(selectedColor));
+		});
+
+		update();
+		setVisible(true);
+	}
+
+	private void update()
+	{
+		colorPanel.select(selectedColor);
+		tonePanel.select(selectedColor);
+	}
+
+	private void colorChange(Color newColor)
+	{
+		this.selectedColor = newColor;
+
+		// Finally, before firing the color changed event, apply any transparency
+		// that might have been edited by the user
+		if (this.selectedColor.getAlpha() != this.alphaSlider.getValue())
+		{
+			colorChange(new Color(
+				selectedColor.getRed(),
+				selectedColor.getGreen(),
+				selectedColor.getBlue(),
+				alphaSlider.getValue()));
+		}
+
+		if (onColorChange != null)
+		{
+			onColorChange.accept(this.selectedColor);
+		}
+	}
+
+	/**
+	 * Validates the hex input, updating the color with the new values.
+	 */
+	private void validateHex()
+	{
+		String colorStr = hexInput.getText();
+
+		if (!colorStr.startsWith("#"))
+		{
+			colorStr = "#" + colorStr;
+		}
+
+		int r = Integer.valueOf(colorStr.substring(1, 3), 16);
+		int g = Integer.valueOf(colorStr.substring(3, 5), 16);
+		int b = Integer.valueOf(colorStr.substring(5, 7), 16);
+
+		colorChange(new Color(r, g, b));
+		update();
+	}
+
+	/**
+	 * Validates the rgba input, updating the color with the new values.
+	 */
+	private void validateRGB()
+	{
+		String colorStr = rgbaInput.getText().replace(" ", "");
+
+		if (!colorStr.contains(","))
+		{
+			return;
+		}
+
+		String[] values = colorStr.split(",");
+
+		if (values.length < 3)
+		{
+			return;
+		}
+
+		for (String s : values)
+		{
+			if (!s.matches("-?(0|[1-9]\\d*)"))
+			{
+				return;
+			}
+		}
+
+		int r = ColorUtils.limitRGB(Integer.parseInt(values[0]));
+		int g = ColorUtils.limitRGB(Integer.parseInt(values[1]));
+		int b = ColorUtils.limitRGB(Integer.parseInt(values[2]));
+		int a = values.length == 3 ? 255 : ColorUtils.limitRGB(Integer.parseInt(values[3]));
+
+		colorChange(new Color(r, g, b, a));
+		update();
+
+		// When updating tones, the algorithm will default to 255 alpha because
+		// it doesn't take transparency into consideration for calculations
+		// to make sure the alpha value is displayed on the slider and rgba input
+		// we have to force it post-update
+		if (a < 255)
+		{
+			alphaSlider.update(a);
+			rgbaInput.setText(ColorUtils.getRGB(selectedColor));
+		}
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/ui/components/colorpicker/RuneliteColorPicker.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/components/colorpicker/RuneliteColorPicker.java
@@ -37,9 +37,10 @@ import javax.swing.JPanel;
 import javax.swing.JTextField;
 import javax.swing.SwingConstants;
 import javax.swing.border.EmptyBorder;
+import lombok.Getter;
 import lombok.Setter;
 
-class RuneliteColorPicker extends JFrame
+public class RuneliteColorPicker extends JFrame
 {
 
 	private final static int FRAME_WIDTH = 400;
@@ -58,13 +59,14 @@ class RuneliteColorPicker extends JFrame
 	private final JTextField hexInput = new JTextField();
 	private final JTextField rgbaInput = new JTextField();
 
+	@Getter
 	private Color selectedColor;
 	@Setter
 	private Consumer<Color> onColorChange;
 
-	RuneliteColorPicker(Color previousColor)
+	public RuneliteColorPicker(Color previousColor)
 	{
-		setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+		setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
 		setTitle("RuneLite Color Picker");
 		setResizable(false);
 		setSize(FRAME_WIDTH, FRAME_HEIGHT);

--- a/runelite-client/src/main/java/net/runelite/client/ui/components/colorpicker/RuneliteColorPicker.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/components/colorpicker/RuneliteColorPicker.java
@@ -39,6 +39,8 @@ import javax.swing.SwingConstants;
 import javax.swing.border.EmptyBorder;
 import lombok.Getter;
 import lombok.Setter;
+import net.runelite.client.ui.ColorScheme;
+import org.pushingpixels.substance.internal.SubstanceSynapse;
 
 public class RuneliteColorPicker extends JFrame
 {
@@ -70,26 +72,23 @@ public class RuneliteColorPicker extends JFrame
 		setTitle("RuneLite Color Picker");
 		setResizable(false);
 		setSize(FRAME_WIDTH, FRAME_HEIGHT);
+		setBackground(ColorScheme.PROGRESS_COMPLETE_COLOR);
 
 		JPanel content = new JPanel(new BorderLayout());
+		content.putClientProperty(SubstanceSynapse.COLORIZATION_FACTOR, 1.0);
 		content.setBorder(new EmptyBorder(15, 15, 15, 15));
-		content.setBackground(new Color(30, 30, 30));
 
 		JPanel colorSelection = new JPanel(new BorderLayout(15, 0));
-		colorSelection.setBackground(new Color(30, 30, 30));
 
 		JPanel leftPanel = new JPanel(new BorderLayout(15, 0));
-		leftPanel.setBackground(new Color(30, 30, 30));
 
 		leftPanel.add(colorPanel, BorderLayout.WEST);
 		leftPanel.add(tonePanel, BorderLayout.CENTER);
 
 		JPanel rightPanel = new JPanel();
 		rightPanel.setLayout(new BoxLayout(rightPanel, BoxLayout.Y_AXIS));
-		rightPanel.setBackground(new Color(30, 30, 30));
 
 		JPanel contrastPanel = new JPanel(new GridLayout(1, 2));
-		contrastPanel.setBackground(new Color(30, 30, 30));
 
 		JPanel beforePreview = new JPanel();
 		beforePreview.setBackground(selectedColor);
@@ -99,29 +98,25 @@ public class RuneliteColorPicker extends JFrame
 		contrastPanel.add(afterPreview);
 
 		JPanel hexContainer = new JPanel(new GridLayout(2, 1, 0, 5));
-		hexContainer.setBackground(new Color(30, 30, 30));
 
 		JLabel hexLabel = new JLabel("Hex color:");
-		hexLabel.setVerticalAlignment(SwingConstants.BOTTOM);
 		hexLabel.setForeground(Color.WHITE);
+		hexLabel.setVerticalAlignment(SwingConstants.BOTTOM);
 
 		hexInput.setBorder(new EmptyBorder(5, 5, 5, 5));
-		hexInput.setBackground(new Color(20, 20, 20));
-		hexInput.setForeground(Color.WHITE);
+		hexInput.setBackground(ColorScheme.DARKER_GRAY_COLOR);
 
 		hexContainer.add(hexLabel);
 		hexContainer.add(hexInput);
 
 		JPanel rgbContainer = new JPanel(new GridLayout(2, 1, 0, 5));
-		rgbContainer.setBackground(new Color(30, 30, 30));
 
 		JLabel rgbLabel = new JLabel("RGBA color:");
-		rgbLabel.setVerticalAlignment(SwingConstants.BOTTOM);
 		rgbLabel.setForeground(Color.WHITE);
+		rgbLabel.setVerticalAlignment(SwingConstants.BOTTOM);
 
 		rgbaInput.setBorder(new EmptyBorder(5, 5, 5, 5));
-		rgbaInput.setBackground(new Color(20, 20, 20));
-		rgbaInput.setForeground(Color.WHITE);
+		rgbaInput.setBackground(ColorScheme.DARKER_GRAY_COLOR);
 
 		rgbContainer.add(rgbLabel);
 		rgbContainer.add(rgbaInput);
@@ -132,7 +127,6 @@ public class RuneliteColorPicker extends JFrame
 
 		JPanel slidersContainer = new JPanel(new GridLayout(4, 1, 0, 10));
 		slidersContainer.setBorder(new EmptyBorder(15, 0, 0, 0));
-		slidersContainer.setBackground(new Color(30, 30, 30));
 
 		slidersContainer.add(redSlider);
 		slidersContainer.add(greenSlider);

--- a/runelite-client/src/main/java/net/runelite/client/ui/components/colorpicker/TonePanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/components/colorpicker/TonePanel.java
@@ -1,0 +1,244 @@
+/*
+ * Copyright (c) 2018, Psikoi <https://github.com/psikoi>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.ui.components.colorpicker;
+
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Graphics;
+import java.awt.Point;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseMotionAdapter;
+import java.util.function.Consumer;
+import javax.swing.JPanel;
+import lombok.Setter;
+
+public class TonePanel extends JPanel
+{
+	// The radius of the selector target
+	private static final int SELECTOR_SIZE = 7;
+
+	private final int size;
+
+	private Point targetPosition;
+	private Color baseColor;
+	@Setter
+	private Consumer<Color> onColorChange;
+
+	TonePanel(int size)
+	{
+		this.size = size;
+		this.targetPosition = new Point(size, 0);
+		setPreferredSize(new Dimension(size, size));
+
+		addMouseMotionListener(new MouseMotionAdapter()
+		{
+			@Override
+			public void mouseDragged(MouseEvent me)
+			{
+				moveTarget(me.getX(), me.getY());
+			}
+		});
+
+		addMouseListener(new MouseAdapter()
+		{
+			@Override
+			public void mouseReleased(MouseEvent me)
+			{
+				moveTarget(me.getX(), me.getY());
+			}
+
+			@Override
+			public void mousePressed(MouseEvent me)
+			{
+				moveTarget(me.getX(), me.getY());
+			}
+		});
+	}
+
+	/*
+	 * Sets the gradient's base color (top-right) to a specified color.
+	 *
+	 * If this method isn't called as a result of a forced update, then it will
+	 * call the onColorChange event.
+	 */
+	void setBaseColor(Color baseColor, boolean forceUpdate)
+	{
+		this.baseColor = baseColor;
+
+		if (!forceUpdate && onColorChange != null)
+		{
+			onColorChange.accept(colorAt(baseColor, targetPosition.x, targetPosition.y, size));
+		}
+
+		repaint();
+	}
+
+	public void select(Color color)
+	{
+		Point closest = closestPointToColor(color);
+		moveTarget(closest.x, closest.y);
+	}
+
+	/*
+	 * Calculates the closest point to a given color.
+	 *
+	 * It iterates through all the colors in the gradient and finds the nearest
+	 * match to the target color.
+	 */
+	private Point closestPointToColor(Color target)
+	{
+		double minDistance = Double.MAX_VALUE;
+		Point closest = new Point(0, 0);
+
+		for (int x = 0; x < size + 1; x++)
+		{
+			for (int y = 0; y < size + 1; y++)
+			{
+				Color c = colorAt(baseColor, x, y, size);
+
+				if (c.equals(target))
+				{
+					return new Point(x, y);
+				}
+
+				double dv = ColorUtils.colorDistance(c, target);
+
+				if (dv < minDistance)
+				{
+					minDistance = dv;
+					closest = new Point(x, y);
+				}
+			}
+		}
+
+		return closest;
+	}
+
+	/**
+	 * Moves the target (selector) to a specified x,y coordinates.
+	 */
+	private void moveTarget(int x, int y)
+	{
+		if (x > size)
+		{
+			x = size;
+		}
+
+		if (x < 0)
+		{
+			x = 0;
+		}
+
+		if (y > size)
+		{
+			y = size;
+		}
+
+		if (y < 0)
+		{
+			y = 0;
+		}
+
+		targetPosition = new Point(x, y);
+
+		if (onColorChange != null)
+		{
+			onColorChange.accept(colorAt(baseColor, x, y, size));
+		}
+
+		repaint();
+	}
+
+	@Override
+	public void paint(Graphics g)
+	{
+		// Paint the gradient
+		for (int x = 0; x < size; x++)
+		{
+			for (int y = 0; y < size; y++)
+			{
+				g.setColor(colorAt(baseColor, x, y, size));
+				g.fillRect(x, y, 1, 1);
+			}
+		}
+
+		int targetX = targetPosition.x - (SELECTOR_SIZE / 2);
+		int targetY = targetPosition.y - (SELECTOR_SIZE / 2);
+
+		// Paint the target (selector)
+		g.setColor(Color.WHITE);
+		g.fillOval(targetX, targetY, SELECTOR_SIZE, SELECTOR_SIZE);
+		g.setColor(Color.BLACK);
+		g.drawOval(targetX, targetY, SELECTOR_SIZE, SELECTOR_SIZE);
+	}
+
+	/*
+	 * Determines which color is displayed on the gradient on given coordinates.
+	 */
+	static Color colorAt(Color baseColor, int x, int y, int size)
+	{
+		int red = baseColor.getRed();
+		int green = baseColor.getGreen();
+		int blue = baseColor.getBlue();
+
+		// Force the brightest color to be white
+		if (x == 0 && y == 0)
+		{
+			return Color.WHITE;
+		}
+
+		// Force the darkest color to be white
+		if (y > size - 1)
+		{
+			return Color.BLACK;
+		}
+
+		// The scaling factor (if == 1, then 1 px for every color value difference)
+		float yScale = ((float) 255 / size);
+
+		// The brightness difference, the higher the Y, the darker the color
+		// should be. This value will be deducted from the r g b values to make
+		// the gradient fade into dark
+		float yDiff = y * yScale;
+
+		// The distances (differences) between the maximum and the target values
+		float redDiff = 255 - red;
+		float greenDiff = 255 - green;
+		float blueDiff = 255 - blue;
+
+		// The differences in color values, adjusted for the x position in the gradient
+		float gRed = 255 - (x * (redDiff / size));
+		float gGreen = 255 - (x * (greenDiff / size));
+		float gBlue = 255 - (x * (blueDiff / size));
+
+		// The final rgb values adjusted for the x and y positions
+		int newRed = ColorUtils.limitRGB((int) (gRed - (yDiff)));
+		int newGreen = ColorUtils.limitRGB((int) (gGreen - (yDiff)));
+		int newBlue = ColorUtils.limitRGB((int) (gBlue - (yDiff)));
+
+		return new Color(newRed, newGreen, newBlue);
+	}
+}


### PR DESCRIPTION
Fixes #2503

Adds a custom runelite color picker with the long awaited alpha slider. This new color picker attempts to give a modern but functional look to the default substance/java color pickers. It also adds **rgb value sliders**, **hex and rgba inputs** and the **transparency slider**. So we can finally have **user-selected transparent colors**.

This is my first time doing something of this sort so I'm sure you guys will have some fun pointing out where I can clean up or optimize. **I'd really appreciate some feedback and reviews**.

![](https://i.gyazo.com/608c37742b90b6aea19d29a8c3aa6bbe.gif)

**A big thanks to @raiyni for helping me with some bugs and calculations**
