### PR TITLE
friendnotes: Use new chatbox input dialogue

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/friendnotes/FriendNotesPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/friendnotes/FriendNotesPlugin.java
@@ -46,7 +46,7 @@ import net.runelite.api.events.NameableNameChanged;
 import net.runelite.api.events.RemovedFriend;
 import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.config.ConfigManager;
-import net.runelite.client.game.ChatboxInputManager;
+import net.runelite.client.game.chatbox.ChatboxPanelManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.OverlayManager;
@@ -81,7 +81,7 @@ public class FriendNotesPlugin extends Plugin
 	private FriendNoteOverlay overlay;
 
 	@Inject
-	private ChatboxInputManager chatboxInputManager;
+	private ChatboxPanelManager chatboxPanelManager;
 
 	@Getter
 	private HoveredFriend hoveredFriend = null;
@@ -204,22 +204,22 @@ public class FriendNotesPlugin extends Plugin
 			if (event.getMenuOption().equals(ADD_NOTE) || event.getMenuOption().equals(EDIT_NOTE))
 			{
 				event.consume();
-
 				final String note = getFriendNote(sanitizedTarget);
 
-				// Open the chatbox input dialog
-				chatboxInputManager.openInputWindow(String.format(NOTE_PROMPT_FORMAT, sanitizedTarget,
-					CHARACTER_LIMIT), Strings.nullToEmpty(note), CHARACTER_LIMIT, (content) ->
-				{
-					if (content == null)
+				// Open the new chatbox input dialog
+				chatboxPanelManager.openTextInput(String.format(NOTE_PROMPT_FORMAT, sanitizedTarget, CHARACTER_LIMIT))
+					.value(Strings.nullToEmpty(note))
+					.onDone((content) ->
 					{
-						return;
-					}
+						if (content == null)
+						{
+							return;
+						}
 
-					content = Text.removeTags(content).trim();
-					log.debug("Set note for '{}': '{}'", sanitizedTarget, content);
-					setFriendNote(sanitizedTarget, content);
-				});
+						content = Text.removeTags(content).trim();
+						log.debug("Set note for '{}': '{}'", sanitizedTarget, content);
+						setFriendNote(sanitizedTarget, content);
+					}).build();
 			}
 		}
 


### PR DESCRIPTION
Requires #6430 to avoid an issue where a player's password can become the note by relogging while editing the note.