### PR TITLE
Fix size of RuneLite minimap dots

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayUtil.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayUtil.java
@@ -47,6 +47,8 @@ import net.runelite.api.coords.LocalPoint;
  */
 public class OverlayUtil
 {
+	private static final int MINIMAP_DOT_RADIUS = 4;
+
 	public static void renderPolygon(Graphics2D graphics, Polygon poly, Color color)
 	{
 		graphics.setColor(color);
@@ -61,9 +63,9 @@ public class OverlayUtil
 	public static void renderMinimapLocation(Graphics2D graphics, Point mini, Color color)
 	{
 		graphics.setColor(Color.BLACK);
-		graphics.fillOval(mini.getX() - 2, mini.getY() - 2 + 1, 4, 4);
+		graphics.fillOval(mini.getX() - MINIMAP_DOT_RADIUS / 2, mini.getY() - MINIMAP_DOT_RADIUS / 2 + 1, MINIMAP_DOT_RADIUS, MINIMAP_DOT_RADIUS);
 		graphics.setColor(color);
-		graphics.fillOval(mini.getX() - 2, mini.getY() - 2, 4, 4);
+		graphics.fillOval(mini.getX() - MINIMAP_DOT_RADIUS / 2, mini.getY() - MINIMAP_DOT_RADIUS / 2, MINIMAP_DOT_RADIUS, MINIMAP_DOT_RADIUS);
 	}
 
 	public static void renderTextLocation(Graphics2D graphics, Point txtLoc, String text, Color color)

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayUtil.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayUtil.java
@@ -61,9 +61,9 @@ public class OverlayUtil
 	public static void renderMinimapLocation(Graphics2D graphics, Point mini, Color color)
 	{
 		graphics.setColor(Color.BLACK);
-		graphics.fillOval(mini.getX() - 2, mini.getY() - 2 + 1, 5, 5);
+		graphics.fillOval(mini.getX() - 2, mini.getY() - 2 + 1, 4, 4);
 		graphics.setColor(color);
-		graphics.fillOval(mini.getX() - 2, mini.getY() - 2, 5, 5);
+		graphics.fillOval(mini.getX() - 2, mini.getY() - 2, 4, 4);
 	}
 
 	public static void renderTextLocation(Graphics2D graphics, Point txtLoc, String text, Color color)


### PR DESCRIPTION
The dots are supposed to be size of 4 and not 5.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>