### PR TITLE
interfacestyles: Fix resizeable mode widgets 

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/interfacestyles/InterfaceStylesPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/interfacestyles/InterfaceStylesPlugin.java
@@ -270,29 +270,7 @@ public class InterfaceStylesPlugin extends Plugin
 
 			if (widget != null)
 			{
-				if (widgetOffset.isOriginalWidthAndHeight())
-				{
-					widget.setHeight(widget.getOriginalHeight());
-					widget.setWidth(widget.getOriginalWidth());
-				}
-
-				if (widgetOffset.getOriginalX() != null)
-				{
-					widget.setRelativeX(widgetOffset.getOriginalX());
-				}
-				else
-				{
-					widget.setRelativeX(widget.getOriginalX());
-				}
-
-				if (widgetOffset.getOriginalY() != null)
-				{
-					widget.setRelativeY(widgetOffset.getOriginalY());
-				}
-				else
-				{
-					widget.setRelativeY(widget.getOriginalY());
-				}
+				widget.revalidate();
 			}
 		}
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/interfacestyles/WidgetOffset.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/interfacestyles/WidgetOffset.java
@@ -39,7 +39,7 @@ enum WidgetOffset
 	RESIZABLE_2010_QUESTS_HIGHLIGHT(Skin.AROUND_2010, WidgetInfo.RESIZABLE_VIEWPORT_QUESTS_TAB, 69, 1, 33, null),
 	RESIZABLE_2010_QUESTS_ICON(Skin.AROUND_2010, WidgetInfo.RESIZABLE_VIEWPORT_QUESTS_ICON, 70, 1, 33, null),
 	RESIZABLE_2010_INVENTORY_HIGHLIGHT(Skin.AROUND_2010, WidgetInfo.RESIZABLE_VIEWPORT_INVENTORY_TAB, 103, 1, null, null),
-	RESIZABLE_2010_INVENTORY_ICON(Skin.AROUND_2010, WidgetInfo.RESIZABLE_VIEWPORT_INVENTORY_ICON, null, null, null, null, true, 105, -1),
+	RESIZABLE_2010_INVENTORY_ICON(Skin.AROUND_2010, WidgetInfo.RESIZABLE_VIEWPORT_INVENTORY_ICON, null, null, null, null),
 	RESIZABLE_2010_EQUIPMENT_ICON(Skin.AROUND_2010, WidgetInfo.RESIZABLE_VIEWPORT_EQUIPMENT_ICON, null, 3, null, null),
 	RESIZABLE_2010_EQUIPMENT_HIGHLIGHT(Skin.AROUND_2010, WidgetInfo.RESIZABLE_VIEWPORT_EQUIPMENT_TAB, null, 1, null, null),
 	RESIZABLE_2010_PRAYER_HIGHLIGHT(Skin.AROUND_2010, WidgetInfo.RESIZABLE_VIEWPORT_PRAYER_TAB, 171, 1, null, null),
@@ -66,7 +66,7 @@ enum WidgetOffset
 	RESIZABLE_BOTTOM_2010_QUESTS_ICON(Skin.AROUND_2010, WidgetInfo.RESIZABLE_VIEWPORT_BOTTOM_LINE_QUESTS_ICON, null, 1, null, null),
 	RESIZABLE_BOTTOM_2010_EQUIPMENT_ICON(Skin.AROUND_2010, WidgetInfo.RESIZABLE_VIEWPORT_BOTTOM_LINE_EQUIPMENT_ICON, 132, 3, null, null),
 	RESIZABLE_BOTTOM_2010_PRAYERS_ICON(Skin.AROUND_2010, WidgetInfo.RESIZABLE_VIEWPORT_BOTTOM_LINE_PRAYER_ICON, 165, 1, null, null),
-	RESIZABLE_BOTTOM_2010_LOGOUT_BUTTON(Skin.AROUND_2010, WidgetInfo.RESIZABLE_VIEWPORT_BOTTOM_LINE_LOGOUT_BUTTON, 185, null, null, null, true, 183, 2),
+	RESIZABLE_BOTTOM_2010_LOGOUT_BUTTON(Skin.AROUND_2010, WidgetInfo.RESIZABLE_VIEWPORT_BOTTOM_LINE_LOGOUT_BUTTON, 185, null, null, null),
 	RESIZABLE_BOTTOM_2010_MAGIC_ICON(Skin.AROUND_2010, WidgetInfo.RESIZABLE_VIEWPORT_BOTTOM_LINE_MAGIC_ICON, null, 2, null, null),
 	RESIZABLE_BOTTOM_2010_FRIEND_ICON(Skin.AROUND_2010, WidgetInfo.RESIZABLE_VIEWPORT_BOTTOM_LINE_FRIEND_ICON, null, 3, null, null),
 	RESIZABLE_BOTTOM_2010_FRIEND_CHAT_ICON(Skin.AROUND_2010, WidgetInfo.RESIZABLE_VIEWPORT_BOTTOM_LINE_FRIEND_CHAT_ICON, null, 2, null, null),
@@ -81,7 +81,7 @@ enum WidgetOffset
 	FIXED_2010_QUESTS_HIGHLIGHT(Skin.AROUND_2010, WidgetInfo.FIXED_VIEWPORT_QUESTS_TAB, 75, 1, 33, null),
 	FIXED_2010_QUESTS_ICON(Skin.AROUND_2010, WidgetInfo.FIXED_VIEWPORT_QUESTS_ICON, 75, 0, null, null),
 	FIXED_2010_INVENTORY_HIGHLIGHT(Skin.AROUND_2010, WidgetInfo.FIXED_VIEWPORT_INVENTORY_TAB, 109, 1, null, null),
-	FIXED_2010_INVENTORY_ICON(Skin.AROUND_2010, WidgetInfo.FIXED_VIEWPORT_INVENTORY_ICON, 111, -1, null, null, true, 105, -1),
+	FIXED_2010_INVENTORY_ICON(Skin.AROUND_2010, WidgetInfo.FIXED_VIEWPORT_INVENTORY_ICON, 111, -1, null, null),
 	FIXED_2010_EQUIPMENT_ICON(Skin.AROUND_2010, WidgetInfo.FIXED_VIEWPORT_EQUIPMENT_ICON, 143, 2, null, null),
 	FIXED_2010_PRAYER_HIGHLIGHT(Skin.AROUND_2010, WidgetInfo.FIXED_VIEWPORT_PRAYER_TAB, 177, 1, null, null),
 	FIXED_2010_PRAYER_ICON(Skin.AROUND_2010, WidgetInfo.FIXED_VIEWPORT_PRAYER_ICON, 178, 1, null, null),
@@ -107,13 +107,13 @@ enum WidgetOffset
 	RESIZABLE_2005_OPTIONS_ICON(Skin.AROUND_2005, WidgetInfo.RESIZABLE_VIEWPORT_OPTIONS_ICON, 137, null, null, null),
 	RESIZABLE_2005_EMOTE_ICON(Skin.AROUND_2005, WidgetInfo.RESIZABLE_VIEWPORT_EMOTES_ICON, 173, null, null, null),
 
-	RESIZABLE_BOTTOM_2005_INVENTORY_ICON(Skin.AROUND_2005, WidgetInfo.RESIZABLE_VIEWPORT_BOTTOM_LINE_INVENTORY_ICON, null, -2, null, null, true, null, -2),
+	RESIZABLE_BOTTOM_2005_INVENTORY_ICON(Skin.AROUND_2005, WidgetInfo.RESIZABLE_VIEWPORT_BOTTOM_LINE_INVENTORY_ICON, null, -2, null, null),
 	RESIZABLE_BOTTOM_2005_QUESTS_ICON(Skin.AROUND_2005, WidgetInfo.RESIZABLE_VIEWPORT_BOTTOM_LINE_QUESTS_ICON, 67, 0, null, null),
 	RESIZABLE_BOTTOM_2005_EQUIPMENT_ICON(Skin.AROUND_2005, WidgetInfo.RESIZABLE_VIEWPORT_BOTTOM_LINE_EQUIPMENT_ICON, 132, 2, null, null),
 
 	FIXED_2005_ROOT_INTERFACE_CONTAINER(Skin.AROUND_2005, WidgetInfo.FIXED_VIEWPORT_ROOT_INTERFACE_CONTAINER, null, null, 197, null),
-	FIXED_2005_INTERFACE_CONTAINER(Skin.AROUND_2005, WidgetInfo.FIXED_VIEWPORT_INTERFACE_CONTAINER, 7, null, null, null, false),
-	FIXED_2005_BANK_CONTAINER(Skin.AROUND_2005, WidgetInfo.FIXED_VIEWPORT_BANK_CONTAINER, 7, null, null, null, false),
+	FIXED_2005_INTERFACE_CONTAINER(Skin.AROUND_2005, WidgetInfo.FIXED_VIEWPORT_INTERFACE_CONTAINER, 7, null, null, null),
+	FIXED_2005_BANK_CONTAINER(Skin.AROUND_2005, WidgetInfo.FIXED_VIEWPORT_BANK_CONTAINER, 7, null, null, null),
 	FIXED_2005_COMBAT_HIGHLIGHT(Skin.AROUND_2005, WidgetInfo.FIXED_VIEWPORT_COMBAT_TAB, 19, 2, null, null),
 	FIXED_2005_COMBAT_ICON(Skin.AROUND_2005, WidgetInfo.FIXED_VIEWPORT_COMBAT_ICON, 26, null, null, null),
 	FIXED_2005_STATS_HIGHLIGHT(Skin.AROUND_2005, WidgetInfo.FIXED_VIEWPORT_STATS_TAB, 55, null, 30, null),
@@ -149,23 +149,8 @@ enum WidgetOffset
 	private Integer offsetY;
 	private Integer width;
 	private Integer height;
-	private boolean originalWidthAndHeight;
-	private Integer originalX;
-	private Integer originalY;
 
 	WidgetOffset(Skin skin, WidgetInfo widgetInfo, Integer offsetX, Integer offsetY, Integer width, Integer height)
-	{
-		this(skin, widgetInfo, offsetX, offsetY, width, height, true);
-	}
-
-	WidgetOffset(Skin skin, WidgetInfo widgetInfo, Integer offsetX, Integer offsetY, Integer width, Integer height,
-		boolean originalWidthAndHeight)
-	{
-		this(skin, widgetInfo, offsetX, offsetY, width, height, originalWidthAndHeight, null, null);
-	}
-
-	WidgetOffset(Skin skin, WidgetInfo widgetInfo, Integer offsetX, Integer offsetY, Integer width, Integer height,
-		boolean originalWidthAndHeight, Integer originalX, Integer originalY)
 	{
 		this.skin = skin;
 		this.widgetInfo = widgetInfo;
@@ -173,8 +158,5 @@ enum WidgetOffset
 		this.offsetY = offsetY;
 		this.width = width;
 		this.height = height;
-		this.originalWidthAndHeight = originalWidthAndHeight;
-		this.originalX = originalX;
-		this.originalY = originalY;
 	}
 }


### PR DESCRIPTION
When using the Bottom Line mode in resizeable, the icons are fine until one of the following events happens:

* The window is resized
* The plugin's state is toggled
* The game frame that should be applied is changed

Currently, fixing this requires the user to go into fixed mode and back into resizeable.

This happens due to the plugin using a widget's original X and Y values as the positions to reset the widget to. For every other widget, this works perfectly, but for whatever reason the original X and Y values for these icons are completely wrong. To fix this, the plugin now simply re-validates each widget, letting RuneScape place them in the correct position.

Before:
![](https:\/\/thumbs.gfycat.com\/RapidUnknownAurochs-size_restricted.gif)

After:
![](https:\/\/thumbs.gfycat.com\/GentleWastefulGannet-size_restricted.gif)
