### PR TITLE
Improve responsiveness of fishing idle notification

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierConfig.java
@@ -43,12 +43,12 @@ public interface IdleNotifierConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "combatidle",
-		name = "Combat Idle Notifications",
-		description = "Configures if out of combat notifications are enabled",
+		keyName = "interactionidle",
+		name = "Idle Interaction Notifications",
+		description = "Configures if idle interaction notifications are enabled e.g. combat, fishing",
 		position = 2
 	)
-	default boolean combatIdle()
+	default boolean interactionIdle()
 	{
 		return true;
 	}
@@ -107,16 +107,4 @@ public interface IdleNotifierConfig extends Config
 	{
 		return 0;
 	}
-
-	@ConfigItem(
-		keyName = "fishingIdle",
-		name = "Fishing Idle Notifications",
-		position = 8,
-		description = "Configures if fishing idle notifications are enabled."
-	)
-	default boolean fishingIdle()
-	{
-		return true;
-	}
-
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierConfig.java
@@ -108,4 +108,15 @@ public interface IdleNotifierConfig extends Config
 		return 0;
 	}
 
+	@ConfigItem(
+		keyName = "fishingIdle",
+		name = "Fishing Idle Notifications",
+		position = 8,
+		description = "Configures if fishing idle notifications are enabled."
+	)
+	default boolean fishingIdle()
+	{
+		return true;
+	}
+
 }

--- a/runelite-client/src/test/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPluginTest.java
@@ -106,7 +106,7 @@ public class IdleNotifierPluginTest
 		// Mock config
 		when(config.logoutIdle()).thenReturn(true);
 		when(config.animationIdle()).thenReturn(true);
-		when(config.combatIdle()).thenReturn(true);
+		when(config.interactionIdle()).thenReturn(true);
 		when(config.getIdleNotificationDelay()).thenReturn(0);
 		when(config.getHitpointsThreshold()).thenReturn(42);
 		when(config.getPrayerThreshold()).thenReturn(42);


### PR DESCRIPTION
Using interactions instead of animations detects idling while fishing much sooner because fishing animations are incredibly long and can persists for up to 10 seconds beyond the point when the character has stopped fishing.

Here is a video demonstration of the new notification while barehanded fishing sharks. You can see how the  animation continues long after fishing has stopped.

https://www.youtube.com/watch?v=g5IkN4N8GtM

Example with cage fishing for lobsters too:

https://www.youtube.com/watch?v=Ju5m9RSAYMQ

One further change I made was to improve the check that prevents idle notifications from being sent while you're actually playing the game.

At the start of the onGameTick method in there is a check that includes checking for whether the user has clicked recently. If the user has clicked recently then the method is exited and no notification is sent because obviously they are not idle.

The problem is that it checks if the user has clicked within the last 200 ms but game ticks only run every 600 ms. While in debug mode I found that there can be gaps of up to 800 ms between onGameTick running during the normal course of play.

This video demonstrates how idle fishing notifications are sometimes sent when clicking away from the fishing spot, but that extending the window from 200 ms to 1000 ms solves this.

https://www.youtube.com/watch?v=sQC_PRidlo0