### PR TITLE
Make Enum dump output nicer

### DIFF
--- a/cache/src/main/java/net/runelite/cache/definitions/EnumDefinition.java
+++ b/cache/src/main/java/net/runelite/cache/definitions/EnumDefinition.java
@@ -26,14 +26,15 @@
 package net.runelite.cache.definitions;
 
 import lombok.Data;
+import net.runelite.cache.util.ScriptVarType;
 
 @Data
 public class EnumDefinition
 {
 	private int id;
 	private int[] intVals;
-	private char keyType;
-	private char valType;
+	private ScriptVarType keyType;
+	private ScriptVarType valType;
 	private String defaultString = "null";
 	private int defaultInt;
 	private int size;

--- a/cache/src/main/java/net/runelite/cache/definitions/loaders/EnumLoader.java
+++ b/cache/src/main/java/net/runelite/cache/definitions/loaders/EnumLoader.java
@@ -36,6 +36,11 @@ public class EnumLoader
 
 	public EnumDefinition load(int id, byte[] b)
 	{
+		if (b.length == 1 && b[0] == 0)
+		{
+			return null;
+		}
+
 		EnumDefinition def = new EnumDefinition();
 		InputStream is = new InputStream(b);
 

--- a/cache/src/main/java/net/runelite/cache/definitions/loaders/EnumLoader.java
+++ b/cache/src/main/java/net/runelite/cache/definitions/loaders/EnumLoader.java
@@ -26,6 +26,7 @@ package net.runelite.cache.definitions.loaders;
 
 import net.runelite.cache.definitions.EnumDefinition;
 import net.runelite.cache.io.InputStream;
+import net.runelite.cache.util.ScriptVarType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -59,10 +60,10 @@ public class EnumLoader
 		switch (opcode)
 		{
 			case 1:
-				def.setKeyType((char) is.readUnsignedByte());
+				def.setKeyType(ScriptVarType.forCharKey((char) is.readUnsignedByte()));
 				break;
 			case 2:
-				def.setValType((char) is.readUnsignedByte());
+				def.setValType(ScriptVarType.forCharKey((char) is.readUnsignedByte()));
 				break;
 			case 3:
 				def.setDefaultString(is.readString());

--- a/cache/src/main/java/net/runelite/cache/util/ScriptVarType.java
+++ b/cache/src/main/java/net/runelite/cache/util/ScriptVarType.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2018, Joshua Filby <joshua@filby.me>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.cache.util;
+
+import java.util.HashMap;
+import java.util.Map;
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public enum ScriptVarType
+{
+	INTEGER('i', "integer"),
+	BOOLEAN('l', "boolean"),
+	SEQ('A', "seq"),
+	COLOUR('C', "colour"),
+	COMPONENT('I', "component"),
+	IDKIT('K', "idkit"),
+	MIDI('M', "midi"),
+	NAMEDOBJ('O', "namedobj"),
+	SYNTH('P', "synth"),
+	STAT('S', "stat"),
+	COORDGRID('c', "coordgrid"),
+	GRAPHIC('d', "graphic"),
+	FONTMETRICS('f', "fontmetrics"),
+	ENUM('g', "enum"),
+	JINGLE('j', "jingle"),
+	CHATCAT('k', "chatcat"),
+	LOC('l', "loc"),
+	MODEL('m', "model"),
+	NPC('n', "npc"),
+	OBJ('o', "obj"),
+	STRING('s', "string"),
+	SPOTANIM('t', "spotanim"),
+	INV('v', "inv"),
+	TEXTURE('x', "texture"),
+	CATEGORY('y', "category"),
+	CHAR('z', "char"),
+	BAS('€', "bas"),
+	MAPSCENEICON('£', "mapsceneicon"),
+	MAPELEMENT('µ', "mapelement"),
+	HITMARK('×', "hitmark"),
+	STRUCT('J', "struct");
+
+	private static final Map<Character, ScriptVarType> keyToTypeMap = new HashMap<>();
+
+	static
+	{
+		for (ScriptVarType type : values())
+		{
+			keyToTypeMap.put(type.keyChar, type);
+		}
+	}
+
+	public static ScriptVarType forCharKey(char key)
+	{
+		return keyToTypeMap.get(key);
+	}
+
+	/**
+	 * The character used when encoding or decoding types.
+	 */
+	private final char keyChar;
+
+	/**
+	 * The full name of the var type.
+	 */
+	private final String fullName;
+
+}

--- a/cache/src/main/java/net/runelite/cache/util/ScriptVarType.java
+++ b/cache/src/main/java/net/runelite/cache/util/ScriptVarType.java
@@ -35,10 +35,12 @@ public enum ScriptVarType
 	BOOLEAN('l', "boolean"),
 	SEQ('A', "seq"),
 	COLOUR('C', "colour"),
+	/**
+	 * Also known as {@code Widget}.
+	 */
 	COMPONENT('I', "component"),
 	IDKIT('K', "idkit"),
 	MIDI('M', "midi"),
-	NAMEDOBJ('O', "namedobj"),
 	SYNTH('P', "synth"),
 	STAT('S', "stat"),
 	COORDGRID('c', "coordgrid"),
@@ -46,18 +48,25 @@ public enum ScriptVarType
 	FONTMETRICS('f', "fontmetrics"),
 	ENUM('g', "enum"),
 	JINGLE('j', "jingle"),
-	CHATCAT('k', "chatcat"),
+	/**
+	 * Also known as {@code Object}.
+	 */
 	LOC('l', "loc"),
 	MODEL('m', "model"),
 	NPC('n', "npc"),
+	/**
+	 * Also known as {@code Item}.
+	 */
 	OBJ('o', "obj"),
+	/**
+	 * Another version of {@code OBJ}, but means that on Jagex's side they used the internal name for an item.
+	 */
+	NAMEDOBJ('O', "namedobj"),
 	STRING('s', "string"),
 	SPOTANIM('t', "spotanim"),
 	INV('v', "inv"),
 	TEXTURE('x', "texture"),
-	CATEGORY('y', "category"),
 	CHAR('z', "char"),
-	BAS('€', "bas"),
 	MAPSCENEICON('£', "mapsceneicon"),
 	MAPELEMENT('µ', "mapelement"),
 	HITMARK('×', "hitmark"),

--- a/cache/src/test/java/net/runelite/cache/EnumDumperTest.java
+++ b/cache/src/test/java/net/runelite/cache/EnumDumperTest.java
@@ -78,8 +78,11 @@ public class EnumDumperTest
 
 				EnumDefinition def = loader.load(file.getFileId(), b);
 
-				Files.write(gson.toJson(def), new File(dumpDir, file.getFileId() + ".json"), Charset.defaultCharset());
-				++count;
+				if (def.getKeyType() != null)
+				{
+					Files.write(gson.toJson(def), new File(dumpDir, file.getFileId() + ".json"), Charset.defaultCharset());
+					++count;
+				}
 			}
 		}
 

--- a/cache/src/test/java/net/runelite/cache/EnumDumperTest.java
+++ b/cache/src/test/java/net/runelite/cache/EnumDumperTest.java
@@ -78,7 +78,7 @@ public class EnumDumperTest
 
 				EnumDefinition def = loader.load(file.getFileId(), b);
 
-				if (def.getKeyType() != null)
+				if (def != null)
 				{
 					Files.write(gson.toJson(def), new File(dumpDir, file.getFileId() + ".json"), Charset.defaultCharset());
 					++count;


### PR DESCRIPTION
Adds `ScriptVarType` which includes a way to convert a `char` to a `ScriptVarType`. This enum contains (most) types used in OSRS.