### PR TITLE
Add sound when taking a screenshot

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotConfig.java
@@ -165,12 +165,15 @@ public interface ScreenshotConfig extends Config
 		return Keybind.NOT_SET;
 	}
 
-	
+
 	@ConfigItem(
 			keyName = "sound",
 			name = "Play Sound",
 			description = "Configures whether or not screenshots are taken and play a sound.",
 			position = 12
 	)
-	default boolean screenshotSound(){return false;}
+	default boolean screenshotSound()
+	{
+		return false;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotConfig.java
@@ -165,7 +165,7 @@ public interface ScreenshotConfig extends Config
 		return Keybind.NOT_SET;
 	}
 
-	//default is set to off just incase if someone has the notification on still
+	
 	@ConfigItem(
 			keyName = "sound",
 			name = "Play Sound",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotConfig.java
@@ -164,4 +164,13 @@ public interface ScreenshotConfig extends Config
 	{
 		return Keybind.NOT_SET;
 	}
+
+	//default is set to off just incase if someone has the notification on still
+	@ConfigItem(
+			keyName = "sound",
+			name = "Play Sound",
+			description = "Configures whether or not screenshots are taken and play a sound.",
+			position = 12
+	)
+	default boolean screenshotSound(){return false;}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
@@ -633,7 +633,7 @@ public class ScreenshotPlugin extends Plugin
 						StringSelection selection = new StringSelection(link);
 						Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
 						clipboard.setContents(selection, selection);
-						//plays a sound
+
 						if (config.screenshotSound())
 						{
 							client.playSoundEffect(SoundEffectID.MAGIC_SPLASH_BOING);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
@@ -60,6 +60,7 @@ import net.runelite.api.Client;
 import net.runelite.api.GameState;
 import net.runelite.api.Point;
 import net.runelite.api.SpriteID;
+import net.runelite.api.SoundEffectID;
 import net.runelite.api.WorldType;
 import net.runelite.api.events.ChatMessage;
 import net.runelite.api.events.GameStateChanged;
@@ -632,7 +633,11 @@ public class ScreenshotPlugin extends Plugin
 						StringSelection selection = new StringSelection(link);
 						Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
 						clipboard.setContents(selection, selection);
-
+						//plays a sound
+						if (config.screenshotSound())
+						{
+							client.playSoundEffect(SoundEffectID.MAGIC_SPLASH_BOING);
+						}
 						if (config.notifyWhenTaken())
 						{
 							notifier.notify("A screenshot was uploaded and inserted into your clipboard!", TrayIcon.MessageType.INFO);


### PR DESCRIPTION
I have my notification set to off because I do not like the windows notification system. Sometimes when I take a screenshot I might forget that I already did. I just added a sound to the plugin the failing splashing sound. The config is to set off for default because the notification is set on by default the user can change whenever he/she feels like it. I know you can check your screenshot by pasting the link this change allows you to remember if you taken a screen shot or not.