### PR TITLE
Null-check GL and window on plugin shutdown 

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuPlugin.java
@@ -320,44 +320,51 @@ public class GpuPlugin extends Plugin implements DrawCallbacks
 	{
 		clientThread.invoke(() ->
 		{
-			if (textureArrayId != -1)
-			{
-				textureManager.freeTextureArray(gl, textureArrayId);
-				textureArrayId = -1;
-			}
-
 			client.setGpu(false);
 			client.setDrawCallbacks(null);
 
-			if (bufferId != -1)
+			if (gl != null)
 			{
-				GLUtil.glDeleteBuffer(gl, bufferId);
-				bufferId = -1;
+				if (textureArrayId != -1)
+				{
+					textureManager.freeTextureArray(gl, textureArrayId);
+					textureArrayId = -1;
+				}
+
+				if (bufferId != -1)
+				{
+					GLUtil.glDeleteBuffer(gl, bufferId);
+					bufferId = -1;
+				}
+
+				if (uvBufferId != -1)
+				{
+					GLUtil.glDeleteBuffer(gl, uvBufferId);
+					uvBufferId = -1;
+				}
+
+				if (uniformBufferId != -1)
+				{
+					GLUtil.glDeleteBuffer(gl, uniformBufferId);
+					uniformBufferId = -1;
+				}
+
+				shutdownInterfaceTexture();
+				shutdownProgram();
+				shutdownVao();
+
+				if (!jawtWindow.getLock().isLocked())
+				{
+					jawtWindow.lockSurface();
+				}
+
+				glContext.destroy();
 			}
 
-			if (uvBufferId != -1)
+			if (jawtWindow != null)
 			{
-				GLUtil.glDeleteBuffer(gl, uvBufferId);
-				uvBufferId = -1;
+				NewtFactoryAWT.destroyNativeWindow(jawtWindow);
 			}
-
-			if (uniformBufferId != -1)
-			{
-				GLUtil.glDeleteBuffer(gl, uniformBufferId);
-				uniformBufferId = -1;
-			}
-
-			shutdownInterfaceTexture();
-			shutdownProgram();
-			shutdownVao();
-
-			if (!jawtWindow.getLock().isLocked())
-			{
-				jawtWindow.lockSurface();
-			}
-
-			glContext.destroy();
-			NewtFactoryAWT.destroyNativeWindow(jawtWindow);
 
 			jawtWindow = null;
 			gl = null;


### PR DESCRIPTION
If GL is not even created due to missing library error or unsupported
 version, this throws a lot of unnecessary exceptions to log and fails
 on shutDown resulting in possibly improperly feed objects and displays.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>