### PR TITLE
Fix JOGL context debug logging flag

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuPlugin.java
@@ -243,6 +243,12 @@ public class GpuPlugin extends Plugin implements DrawCallbacks
 				glDrawable.setRealized(true);
 
 				glContext = glDrawable.createContext(null);
+				if (log.isDebugEnabled())
+				{
+					// Debug config on context needs to be set before .makeCurrent call
+					glContext.enableGLDebugMessage(true);
+				}
+
 				int res = glContext.makeCurrent();
 				if (res == GLContext.CONTEXT_NOT_CURRENT)
 				{
@@ -259,7 +265,6 @@ public class GpuPlugin extends Plugin implements DrawCallbacks
 
 				if (log.isDebugEnabled())
 				{
-					glContext.enableGLDebugMessage(true);
 					gl.glEnable(GL_DEBUG_OUTPUT);
 				}
 


### PR DESCRIPTION
The flag needs to be set before context is made current  and GL is
obtained.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>

After enabling the flag, this error should be now correctly logged to console in debug:

```
GLDebugMessageHandler: GLDebugEvent[ id 0x3e8
    type Error
    severity High: dangerous undefined behavior
    source GL API
    msg glUniformBlockBinding has generated an error (GL_INVALID_VALUE)
    when 1542376048340
    source 4.5 (Compat profile, arb, debug, compat[ES2, ES3, ES31], FBO, hardware) - 4.5.13521 Compatibility Profile/Debug Context 24.20.11021.1000 - hash 0x139f7e4]```