### PR TITLE
Inventory idle notification

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierConfig.java
@@ -43,10 +43,21 @@ public interface IdleNotifierConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "outOfItemsIdle",
+		name = "Out of Items Idle Notifications",
+		position = 2,
+		description = "Configures if notifications for running out of items for another action are enabled."
+	)
+	default boolean outOfItemsIdle()
+	{
+		return true;
+	}
+
+	@ConfigItem(
 		keyName = "interactionidle",
 		name = "Idle Interaction Notifications",
 		description = "Configures if idle interaction notifications are enabled e.g. combat, fishing",
-		position = 2
+		position = 3
 	)
 	default boolean interactionIdle()
 	{
@@ -57,7 +68,7 @@ public interface IdleNotifierConfig extends Config
 		keyName = "logoutidle",
 		name = "Idle Logout Notifications",
 		description = "Configures if the idle logout notifications are enabled",
-		position = 3
+		position = 4
 	)
 	default boolean logoutIdle()
 	{
@@ -68,7 +79,7 @@ public interface IdleNotifierConfig extends Config
 		keyName = "timeout",
 		name = "Idle Notification Delay (ms)",
 		description = "The notification delay after the player is idle",
-		position = 4
+		position = 5
 	)
 	default int getIdleNotificationDelay()
 	{
@@ -79,7 +90,7 @@ public interface IdleNotifierConfig extends Config
 		keyName = "hitpoints",
 		name = "Hitpoints Notification Threshold",
 		description = "The amount of hitpoints to send a notification at. A value of 0 will disable notification.",
-		position = 5
+		position = 6
 	)
 	default int getHitpointsThreshold()
 	{
@@ -90,7 +101,7 @@ public interface IdleNotifierConfig extends Config
 		keyName = "prayer",
 		name = "Prayer Notification Threshold",
 		description = "The amount of prayer points to send a notification at. A value of 0 will disable notification.",
-		position = 6
+		position = 7
 	)
 	default int getPrayerThreshold()
 	{
@@ -100,7 +111,7 @@ public interface IdleNotifierConfig extends Config
 	@ConfigItem(
 		keyName = "oxygen",
 		name = "Oxygen Notification Threshold",
-		position = 7,
+		position = 8,
 		description = "The amount of remaining oxygen to send a notification at. A value of 0 will disable notification."
 	)
 	default int getOxygenThreshold()
@@ -111,7 +122,7 @@ public interface IdleNotifierConfig extends Config
 	@ConfigItem(
 		keyName = "spec",
 		name = "Special Attack Energy Notification Threshold",
-		position = 8,
+		position = 9,
 		description = "The amount of spec energy reached to send a notification at. A value of 0 will disable notification."
 	)
 	default int getSpecEnergyThreshold()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/OutOfItemsMapping.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/OutOfItemsMapping.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2019, Twiglet1022 <https://github.com/Twiglet1022>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.idlenotifier;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Multimap;
+import java.util.Collection;
+import static net.runelite.api.ItemID.*;
+
+public enum OutOfItemsMapping
+{
+	AERIAL_FISHING_CUTTING(BLUEGILL, COMMON_TENCH, MOTTLED_EEL, GREATER_SIREN);
+
+	private static final Multimap<Integer, Integer> MAPPINGS = HashMultimap.create();
+	private final int groupedItemKey;
+	private final int[] groupedItemIDs;
+
+	static
+	{
+		for (final OutOfItemsMapping item : values())
+		{
+			for (int itemId : item.groupedItemIDs)
+			{
+				MAPPINGS.put(itemId, item.groupedItemKey);
+			}
+		}
+	}
+
+	OutOfItemsMapping(int groupedItemKey, int... groupedItemIDs)
+	{
+		this.groupedItemKey = groupedItemKey;
+		this.groupedItemIDs = groupedItemIDs;
+	}
+
+	/**
+	 * Some actions consume multiple different items. To properly handle these
+	 * cases for the out of items notification the different items must be
+	 * recognised as belonging to a single group.
+	 *
+	 * Map an item that is part of a group of items that are consumed by a single
+	 * action to the first item in that group.
+	 */
+	public static int mapFirst(int itemId)
+	{
+		final Collection<Integer> mapping = MAPPINGS.get(itemId);
+
+		if (mapping == null || mapping.isEmpty())
+		{
+			return itemId;
+		}
+
+		return mapping.iterator().next();
+	}
+
+}


### PR DESCRIPTION
The idle notifier now tracks changes to your inventory to detect when you are performing an action that automatically consumes items in your inventory. When you run out of enough items for another action it sends the following notification.

![image](https://user-images.githubusercontent.com/29353990/48716403-3012c080-ec0f-11e8-9b96-92effb5146fd.png)

Benefits of this approach over checking animations:
- Triggers more quickly than waiting for the animation to end
- Works even if there is no animation e.g. cutting fish from Lake Molch
- Is generic so doesn't need a new cases added for new or obscure activities
- Some animations like stringing longbows go idle for a game tick or two between actions and so trigger animation idle notification if the delay is set too low. This approach doesn't have that issue.

Here's a demonstration of using it at Lake Molch while cutting fish, which does not have an animation:

![OoO Aerial Fishing](https://user-images.githubusercontent.com/29353990/56850135-2d22a700-68f6-11e9-96d8-c9b9a501f190.gif)


Some things that I had to consider when making this:
- The activities that this applies to overlap with those that animation idle checks for. So I prevent animation idle notifications being sent after an out of items notification.
- Some automated actions use multiple different items so I have included support for creating item groups for use with this check. Currently this only applies to Aerial Fishing at Lake Molch. I didn't add the case for baking multiple pies with lunar magic because it's an unreasonable edge case, but this could cope with that if added.
- The notification does not trigger if doing things like banking items or dropping them because the variables that track inventory changes are reset if the user clicked recently.

<Details><summary>Expand for more GIF examples</summary>
The simplest possible case, using one item per action:

![OoO Magic Long Cutting](https://user-images.githubusercontent.com/29353990/56850144-50e5ed00-68f6-11e9-9192-872b232783f2.gif)

Using multiple different items in the same tick:

![OoO Magic Long Stringing](https://user-images.githubusercontent.com/29353990/56850159-7672f680-68f6-11e9-8225-6774980da73c.gif)

Using multiple of the same item in one tick:

![OoO Green Dragonhide](https://user-images.githubusercontent.com/29353990/56850168-88ed3000-68f6-11e9-84b2-fca48c598efd.gif)

</Details>