### PR TITLE
Try to enable compute shaders on GL 4.2

### DIFF
--- a/runelite-client/src/main/resources/net/runelite/client/plugins/gpu/comp.glsl
+++ b/runelite-client/src/main/resources/net/runelite/client/plugins/gpu/comp.glsl
@@ -22,7 +22,10 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-#version 430 core
+
+#version 420
+#extension GL_ARB_compute_shader : require
+#extension GL_ARB_shader_storage_buffer_object : require
 
 shared int totalNum[12]; // number of faces with a given priority
 shared int totalDistance[12]; // sum of distances to faces of a given priority

--- a/runelite-client/src/main/resources/net/runelite/client/plugins/gpu/comp_small.glsl
+++ b/runelite-client/src/main/resources/net/runelite/client/plugins/gpu/comp_small.glsl
@@ -22,7 +22,10 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-#version 430 core
+
+#version 420
+#extension GL_ARB_compute_shader : require
+#extension GL_ARB_shader_storage_buffer_object : require
 
 shared int totalNum[12]; // number of faces with a given priority
 shared int totalDistance[12]; // sum of distances to faces of a given priority


### PR DESCRIPTION
Compute shaders should be supported on GL4.2 with ARB_compute_shader
extension so try to load the GLSL version with 420 support.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>