### PR TITLE
Properly destroy JAWT window on plugin shutdown

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuPlugin.java
@@ -26,7 +26,6 @@ package net.runelite.client.plugins.gpu;
 
 import com.google.common.eventbus.Subscribe;
 import com.google.inject.Provides;
-import com.jogamp.nativewindow.NativeSurface;
 import com.jogamp.nativewindow.awt.AWTGraphicsConfiguration;
 import com.jogamp.nativewindow.awt.JAWTWindow;
 import com.jogamp.opengl.GL;
@@ -328,11 +327,6 @@ public class GpuPlugin extends Plugin implements DrawCallbacks
 			client.setGpu(false);
 			client.setDrawCallbacks(null);
 
-			if (jawtWindow.getLock().getHoldCount() != NativeSurface.LOCK_SURFACE_NOT_READY)
-			{
-				jawtWindow.lockSurface();
-			}
-
 			if (bufferId != -1)
 			{
 				GLUtil.glDeleteBuffer(gl, bufferId);
@@ -355,7 +349,13 @@ public class GpuPlugin extends Plugin implements DrawCallbacks
 			shutdownProgram();
 			shutdownVao();
 
+			if (!jawtWindow.getLock().isLocked())
+			{
+				jawtWindow.lockSurface();
+			}
+
 			glContext.destroy();
+			NewtFactoryAWT.destroyNativeWindow(jawtWindow);
 
 			jawtWindow = null;
 			gl = null;


### PR DESCRIPTION
This is necessary in order to properly free all resources on e.g Linux
(happens less often on Windows). Without
NewtFactoryAWT.destroyNativeWindow, the JAWT window created display
stays open after disabling the plugin and is freed only on application
close.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>