### PR TITLE
Unlock surface only with X11JAWTWindow

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuPlugin.java
@@ -49,6 +49,7 @@ import java.nio.FloatBuffer;
 import java.nio.IntBuffer;
 import java.util.function.Function;
 import javax.inject.Inject;
+import jogamp.nativewindow.jawt.x11.X11JAWTWindow;
 import jogamp.newt.awt.NewtFactoryAWT;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.BufferProvider;
@@ -255,7 +256,8 @@ public class GpuPlugin extends Plugin implements DrawCallbacks
 					throw new GLException("Unable to make context current");
 				}
 
-				if (jawtWindow.getLock().isLocked())
+				// Surface needs to be unlocked on X11 window otherwise input is blocked
+				if (jawtWindow instanceof X11JAWTWindow && jawtWindow.getLock().isLocked())
 				{
 					jawtWindow.unlockSurface();
 				}


### PR DESCRIPTION
Unlocking it on Windows with some iGPUs apparently causes problems and
this is relevant only for X11, so unlock only there.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>