### PR TITLE
Make sidebar icon consistent without custom chrome

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
@@ -629,7 +629,7 @@ public class ClientUI
 			? logoutButton.getHeight() + logoutButton.getRelativeY()
 			: 5;
 
-		final BufferedImage image = sidebarOpen ? sidebarOpenIcon : sidebarClosedIcon;
+		final BufferedImage image = sidebarOpen ? sidebarClosedIcon : sidebarOpenIcon;
 		graphics.drawImage(image, x, y, null);
 
 		// Update button dimensions


### PR DESCRIPTION
Use same icon alignment that is used for opening/closing sidebar with
custom chrome.

Closes #6435

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>