### PR TITLE
Statusbars : fixing number format exceptions for food with random values

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/statusbars/StatusBarsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/statusbars/StatusBarsOverlay.java
@@ -190,6 +190,11 @@ class StatusBarsOverlay extends Overlay
 
 				for (final StatChange c : statsChanges.getStatChanges())
 				{
+					if (c.getTheoretical().length() > 3)
+					{
+						break;
+					}
+
 					if (c.getStat().getName().equals(Skill.HITPOINTS.getName()))
 					{
 						foodHealValue = Integer.parseInt(c.getTheoretical());

--- a/runelite-client/src/main/java/net/runelite/client/plugins/statusbars/StatusBarsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/statusbars/StatusBarsOverlay.java
@@ -24,6 +24,7 @@
  */
 package net.runelite.client.plugins.statusbars;
 
+import com.google.common.primitives.Ints;
 import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Graphics2D;
@@ -190,7 +191,8 @@ class StatusBarsOverlay extends Overlay
 
 				for (final StatChange c : statsChanges.getStatChanges())
 				{
-					if (c.getTheoretical().contains("~"))
+					Integer string = Ints.tryParse(c.getTheoretical().substring(1));
+					if (string == null)
 					{
 						foodHealValue = Integer.parseInt(c.getTheoretical().substring(c.getTheoretical().lastIndexOf("~") + 1));
 						break;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/statusbars/StatusBarsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/statusbars/StatusBarsOverlay.java
@@ -190,8 +190,9 @@ class StatusBarsOverlay extends Overlay
 
 				for (final StatChange c : statsChanges.getStatChanges())
 				{
-					if (c.getTheoretical().length() > 3)
+					if (c.getTheoretical().contains("~"))
 					{
+						foodHealValue = Integer.parseInt(c.getTheoretical().substring(c.getTheoretical().lastIndexOf("~") + 1));
 						break;
 					}
 


### PR DESCRIPTION
This is done by ignoring strings that are longer than 3 because it cant parse strings with 2 numbers and a ~ in between and these are the only ones that have longer strings.