### PR TITLE
add toggle for drawing player combat levels in player indicators plugin

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsConfig.java
@@ -196,4 +196,15 @@ public interface PlayerIndicatorsConfig extends Config
 	{
 		return true;
 	}
+
+	@ConfigItem(
+		position = 15,
+		keyName = "drawOverheadLevels",
+		name = "Draw combat levels",
+		description = "Configures whether or not combat levels should be drawn above players"
+	)
+	default boolean drawOverheadLevels()
+	{
+		return true;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsOverlay.java
@@ -48,7 +48,7 @@ public class PlayerIndicatorsOverlay extends Overlay
 
 	@Inject
 	private PlayerIndicatorsOverlay(PlayerIndicatorsConfig config, PlayerIndicatorsService playerIndicatorsService,
-		ClanManager clanManager)
+									ClanManager clanManager)
 	{
 		this.config = config;
 		this.playerIndicatorsService = playerIndicatorsService;
@@ -66,14 +66,27 @@ public class PlayerIndicatorsOverlay extends Overlay
 
 	private void renderPlayerOverlay(Graphics2D graphics, Player actor, Color color)
 	{
-		if (!config.drawOverheadPlayerNames())
+		if (!config.drawOverheadPlayerNames() && !config.drawOverheadLevels())
 		{
 			return;
 		}
 
 		String name = actor.getName().replace('\u00A0', ' ');
+		String combatLevel = "(" + Integer.toString(actor.getCombatLevel()) + ")";
+		String playerInfo = "";
+
+		if (config.drawOverheadPlayerNames())
+		{
+			playerInfo = playerInfo.concat(name);
+		}
+
+		if (config.drawOverheadLevels())
+		{
+			playerInfo = playerInfo.concat(combatLevel);
+		}
+
 		int offset = actor.getLogicalHeight() + 40;
-		Point textLocation = actor.getCanvasTextLocation(graphics, name, offset);
+		Point textLocation = actor.getCanvasTextLocation(graphics, playerInfo, offset);
 
 		if (textLocation != null)
 		{
@@ -98,7 +111,7 @@ public class PlayerIndicatorsOverlay extends Overlay
 				}
 			}
 
-			OverlayUtil.renderTextLocation(graphics, textLocation, name, color);
+			OverlayUtil.renderTextLocation(graphics, textLocation, playerInfo, color);
 		}
 	}
 }


### PR DESCRIPTION
Add the option to either draw a player's combat level next to their name or draw the player's combat only.

Addresses issue #6567, without the ability to see which players you can attack in the wilderness since I believe that would be rejected.