### PR TITLE
Untradable item price support for ItemManager

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/game/ItemManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/game/ItemManager.java
@@ -250,6 +250,12 @@ public class ItemManager
 			return 1000;
 		}
 
+		UntradeableItemSellPrice p = UntradeableItemSellPrice.map(ItemVariationMapping.map(itemID));
+		if (p != null)
+		{
+			return getItemPrice(p.getPriceID()) * p.getQuantity();
+		}
+
 		int price = 0;
 		for (int mappedID : ItemMapping.map(itemID))
 		{

--- a/runelite-client/src/main/java/net/runelite/client/game/ItemManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/game/ItemManager.java
@@ -250,7 +250,7 @@ public class ItemManager
 			return 1000;
 		}
 
-		UntradeableItemSellPrice p = UntradeableItemSellPrice.map(ItemVariationMapping.map(itemID));
+		UntradeableItemMapping p = UntradeableItemMapping.map(ItemVariationMapping.map(itemID));
 		if (p != null)
 		{
 			return getItemPrice(p.getPriceID()) * p.getQuantity();

--- a/runelite-client/src/main/java/net/runelite/client/game/UntradeableItemMapping.java
+++ b/runelite-client/src/main/java/net/runelite/client/game/UntradeableItemMapping.java
@@ -26,9 +26,11 @@ package net.runelite.client.game;
 
 import com.google.common.collect.ImmutableMap;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import net.runelite.api.ItemID;
 
 @Getter
+@RequiredArgsConstructor
 public enum UntradeableItemMapping
 {
 	MARK_OF_GRACE(ItemID.MARK_OF_GRACE, 10, ItemID.AMYLASE_CRYSTAL),
@@ -46,11 +48,12 @@ public enum UntradeableItemMapping
 	PROSPECTOR_LEGS(ItemID.PROSPECTOR_LEGS, 40, ItemID.GOLDEN_NUGGET),
 	PROSPECTOR_BOOTS(ItemID.PROSPECTOR_BOOTS, 24, ItemID.GOLDEN_NUGGET);
 
+	private static final ImmutableMap<Integer, UntradeableItemMapping> UNTRADEABLE_RECLAIM_MAP;
+
 	private final int itemID;
 	private final int quantity;
 	private final int priceID;
 
-	private static final ImmutableMap<Integer, UntradeableItemMapping> UNTRADEABLE_RECLAIM_MAP;
 	static
 	{
 		ImmutableMap.Builder<Integer, UntradeableItemMapping> map = ImmutableMap.builder();
@@ -59,13 +62,6 @@ public enum UntradeableItemMapping
 			map.put(p.getItemID(), p);
 		}
 		UNTRADEABLE_RECLAIM_MAP = map.build();
-	}
-
-	UntradeableItemMapping(int itemID, int quantity, int priceID)
-	{
-		this.itemID = itemID;
-		this.quantity = quantity;
-		this.priceID = priceID;
 	}
 
 	public static UntradeableItemMapping map(int itemId)

--- a/runelite-client/src/main/java/net/runelite/client/game/UntradeableItemMapping.java
+++ b/runelite-client/src/main/java/net/runelite/client/game/UntradeableItemMapping.java
@@ -29,7 +29,7 @@ import lombok.Getter;
 import net.runelite.api.ItemID;
 
 @Getter
-public enum UntradeableItemSellPrice
+public enum UntradeableItemMapping
 {
 	MARK_OF_GRACE(ItemID.MARK_OF_GRACE, 10, ItemID.AMYLASE_CRYSTAL),
 	GRACEFUL_HOOD(ItemID.GRACEFUL_HOOD, 28, ItemID.MARK_OF_GRACE),
@@ -50,25 +50,25 @@ public enum UntradeableItemSellPrice
 	private final int quantity;
 	private final int priceID;
 
-	private static final ImmutableMap<Integer, UntradeableItemSellPrice> UNTRADEABLE_RECLAIM_MAP;
+	private static final ImmutableMap<Integer, UntradeableItemMapping> UNTRADEABLE_RECLAIM_MAP;
 	static
 	{
-		ImmutableMap.Builder<Integer, UntradeableItemSellPrice> map = ImmutableMap.builder();
-		for (UntradeableItemSellPrice p : values())
+		ImmutableMap.Builder<Integer, UntradeableItemMapping> map = ImmutableMap.builder();
+		for (UntradeableItemMapping p : values())
 		{
 			map.put(p.getItemID(), p);
 		}
 		UNTRADEABLE_RECLAIM_MAP = map.build();
 	}
 
-	UntradeableItemSellPrice(int itemID, int quantity, int priceID)
+	UntradeableItemMapping(int itemID, int quantity, int priceID)
 	{
 		this.itemID = itemID;
 		this.quantity = quantity;
 		this.priceID = priceID;
 	}
 
-	public static UntradeableItemSellPrice map(int itemId)
+	public static UntradeableItemMapping map(int itemId)
 	{
 		return UNTRADEABLE_RECLAIM_MAP.get(itemId);
 	}

--- a/runelite-client/src/main/java/net/runelite/client/game/UntradeableItemSellPrice.java
+++ b/runelite-client/src/main/java/net/runelite/client/game/UntradeableItemSellPrice.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2018, TheStonedTurtle <https://github.com/TheStonedTurtle>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.game;
+
+import com.google.common.collect.ImmutableMap;
+import lombok.Getter;
+import net.runelite.api.ItemID;
+
+@Getter
+public enum UntradeableItemSellPrice
+{
+	MARK_OF_GRACE(ItemID.MARK_OF_GRACE, 10, ItemID.AMYLASE_CRYSTAL),
+	GRACEFUL_HOOD(ItemID.GRACEFUL_HOOD, 28, ItemID.MARK_OF_GRACE),
+	GRACEFUL_TOP(ItemID.GRACEFUL_TOP, 44, ItemID.MARK_OF_GRACE),
+	GRACEFUL_LEGS(ItemID.GRACEFUL_LEGS, 48, ItemID.MARK_OF_GRACE),
+	GRACEFUL_GLOVES(ItemID.GRACEFUL_GLOVES, 24, ItemID.MARK_OF_GRACE),
+	GRACEFUL_BOOTS(ItemID.GRACEFUL_BOOTS, 32, ItemID.MARK_OF_GRACE),
+	GRACEFUL_CAPE(ItemID.GRACEFUL_CAPE, 32, ItemID.MARK_OF_GRACE),
+
+	// 10 golden nuggets = 100 soft clay
+	GOLDEN_NUGGET(ItemID.GOLDEN_NUGGET, 10, ItemID.SOFT_CLAY),
+	PROSPECTOR_HELMET(ItemID.PROSPECTOR_HELMET, 32, ItemID.GOLDEN_NUGGET),
+	PROSPECTOR_JACKET(ItemID.PROSPECTOR_JACKET, 48, ItemID.GOLDEN_NUGGET),
+	PROSPECTOR_LEGS(ItemID.PROSPECTOR_LEGS, 40, ItemID.GOLDEN_NUGGET),
+	PROSPECTOR_BOOTS(ItemID.PROSPECTOR_BOOTS, 24, ItemID.GOLDEN_NUGGET);
+
+	private final int itemID;
+	private final int quantity;
+	private final int priceID;
+
+	private static final ImmutableMap<Integer, UntradeableItemSellPrice> UNTRADEABLE_RECLAIM_MAP;
+	static
+	{
+		ImmutableMap.Builder<Integer, UntradeableItemSellPrice> map = ImmutableMap.builder();
+		for (UntradeableItemSellPrice p : values())
+		{
+			map.put(p.getItemID(), p);
+		}
+		UNTRADEABLE_RECLAIM_MAP = map.build();
+	}
+
+	UntradeableItemSellPrice(int itemID, int quantity, int priceID)
+	{
+		this.itemID = itemID;
+		this.quantity = quantity;
+		this.priceID = priceID;
+	}
+
+	public static UntradeableItemSellPrice map(int itemId)
+	{
+		return UNTRADEABLE_RECLAIM_MAP.get(itemId);
+	}
+}
+


### PR DESCRIPTION
Add support to set prices of untradable items. The price of the untradable item is an amount of a tradable item (for example a mark of grace is worth 10 amylase crystals). These prices will be used in the getItemPrice method of the ItemManager. 
As a result, these prices will be displayed as GE prices in examine messages and the bank value. 

The following untradable items are already added:
* Marks of grace + Full graceful set
* Golden nuggets + Full prospector outfit

![](https://i.imgur.com/Rnz1GUjh.jpg)
![](https://i.imgur.com/addkfRc.png)
![](https://i.imgur.com/JwRI6vY.png)

Fixes #6418 

