### PR TITLE
World Map Plugin: optimize clipping for world map points

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/worldmap/WorldMapOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/worldmap/WorldMapOverlay.java
@@ -95,6 +95,7 @@ public class WorldMapOverlay extends Overlay
 		// in fixed, the bounds are offset by the size of the black borders outside the canvas
 		canvasBounds.setLocation(0, 0);
 		final Area canvasViewArea = getWorldMapClipArea(canvasBounds);
+		Area currentClip = null;
 
 		WorldMapPoint tooltipPoint = null;
 
@@ -113,10 +114,19 @@ public class WorldMapOverlay extends Overlay
 					continue;
 				}
 
-				if (worldPoint.isSnapToEdge())
+				if (worldPoint.isSnapToEdge() && canvasViewArea != currentClip)
 				{
 					graphics.setClip(canvasViewArea);
+					currentClip = canvasViewArea;
+				}
+				else if (!worldPoint.isSnapToEdge() && mapViewArea != currentClip)
+				{
+					graphics.setClip(mapViewArea);
+					currentClip = mapViewArea;
+				}
 
+				if (worldPoint.isSnapToEdge())
+				{
 					if (worldMapRectangle.contains(drawPoint.getX(), drawPoint.getY()))
 					{
 						if (worldPoint.isCurrentlyEdgeSnapped())
@@ -134,10 +144,6 @@ public class WorldMapOverlay extends Overlay
 							worldPoint.onEdgeSnap();
 						}
 					}
-				}
-				else
-				{
-					graphics.setClip(mapViewArea);
 				}
 
 				int drawX = drawPoint.getX();


### PR DESCRIPTION
Changes the world map overlay to only clip the graphics if it's necessary. `setClip` is fairly expensive and re-setting the clip for every map point could almost halve FPS when the world map was open. 