### PR TITLE
changes prayer to light up with any prayer activated instead of quick-prayers

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/statusbars/StatusBarsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/statusbars/StatusBarsOverlay.java
@@ -33,9 +33,9 @@ import net.runelite.api.Client;
 import net.runelite.api.ItemID;
 import net.runelite.api.MenuEntry;
 import net.runelite.api.Point;
+import net.runelite.api.Prayer;
 import net.runelite.api.Skill;
 import net.runelite.api.VarPlayer;
-import net.runelite.api.Varbits;
 import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.game.SkillIconManager;
@@ -53,7 +53,7 @@ import net.runelite.client.util.ImageUtil;
 class StatusBarsOverlay extends Overlay
 {
 	private static final Color PRAYER_COLOR = new Color(50, 200, 200, 175);
-	private static final Color QUICK_PRAYER_COLOR = new Color(57, 255, 186, 225);
+	private static final Color ACTIVE_PRAYER_COLOR = new Color(57, 255, 186, 225);
 	private static final Color BACKGROUND = new Color(0, 0, 0, 150);
 	private static final Color HEALTH_COLOR = new Color(225, 35, 0, 125);
 	private static final Color POISONED_COLOR = new Color(0, 145, 0, 150);
@@ -164,8 +164,15 @@ class StatusBarsOverlay extends Overlay
 		final int maxPrayer = client.getRealSkillLevel(Skill.PRAYER);
 		final int currentHealth = client.getBoostedSkillLevel(Skill.HITPOINTS);
 		final int currentPrayer = client.getBoostedSkillLevel(Skill.PRAYER);
-		final int quickPrayerState = client.getVar(Varbits.QUICK_PRAYER);
-		final Color prayerBar = quickPrayerState == 1 ? QUICK_PRAYER_COLOR : PRAYER_COLOR;
+		Color prayerBar = PRAYER_COLOR;
+
+		for (Prayer pray : Prayer.values())
+		{
+			if (client.isPrayerActive(pray))
+			{
+				prayerBar = ACTIVE_PRAYER_COLOR;
+			}
+		}
 
 		renderBar(g, offsetHealthX, offsetHealthY,
 			maxHealth, currentHealth, height, healthBar);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/statusbars/StatusBarsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/statusbars/StatusBarsOverlay.java
@@ -33,9 +33,7 @@ import net.runelite.api.Client;
 import net.runelite.api.ItemID;
 import net.runelite.api.MenuEntry;
 import net.runelite.api.Point;
-import net.runelite.api.Prayer;
 import net.runelite.api.Skill;
-import net.runelite.api.VarPlayer;
 import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.game.SkillIconManager;
@@ -52,12 +50,12 @@ import net.runelite.client.util.ImageUtil;
 
 class StatusBarsOverlay extends Overlay
 {
-	private static final Color PRAYER_COLOR = new Color(50, 200, 200, 175);
-	private static final Color ACTIVE_PRAYER_COLOR = new Color(57, 255, 186, 225);
+	public static final Color PRAYER_COLOR = new Color(50, 200, 200, 175);
+	public static final Color ACTIVE_PRAYER_COLOR = new Color(57, 255, 186, 225);
 	private static final Color BACKGROUND = new Color(0, 0, 0, 150);
-	private static final Color HEALTH_COLOR = new Color(225, 35, 0, 125);
-	private static final Color POISONED_COLOR = new Color(0, 145, 0, 150);
-	private static final Color VENOMED_COLOR = new Color(0, 65, 0, 150);
+	public static final Color HEALTH_COLOR = new Color(225, 35, 0, 125);
+	public static final Color POISONED_COLOR = new Color(0, 145, 0, 150);
+	public static final Color VENOMED_COLOR = new Color(0, 65, 0, 150);
 	private static final Color HEAL_COLOR = new Color(255, 112, 6, 150);
 	private static final Color PRAYER_HEAL_COLOR = new Color(57, 255, 186, 75);
 	private static final Color OVERHEAL_COLOR = new Color(216, 255, 139, 150);
@@ -77,6 +75,8 @@ class StatusBarsOverlay extends Overlay
 	private static final int SKILL_ICON_HEIGHT = 35;
 	private static final int COUNTER_ICON_HEIGHT = 18;
 	private static final int OFFSET = 2;
+	public Color healthBar;
+	public Color prayerBar;
 	private final Client client;
 	private final StatusBarsConfig config;
 	private final SkillIconManager skillIconManager;
@@ -144,35 +144,10 @@ class StatusBarsOverlay extends Overlay
 			offsetPrayerY = (location.getY() - offsetRight.getY());
 		}
 
-		final int poisonState = client.getVar(VarPlayer.IS_POISONED);
-		final Color healthBar;
-
-		if (poisonState > 0 && poisonState < 50)
-		{
-			healthBar = POISONED_COLOR;
-		}
-		else if (poisonState >= 1000000)
-		{
-			healthBar = VENOMED_COLOR;
-		}
-		else
-		{
-			healthBar = HEALTH_COLOR;
-		}
-
 		final int maxHealth = client.getRealSkillLevel(Skill.HITPOINTS);
 		final int maxPrayer = client.getRealSkillLevel(Skill.PRAYER);
 		final int currentHealth = client.getBoostedSkillLevel(Skill.HITPOINTS);
 		final int currentPrayer = client.getBoostedSkillLevel(Skill.PRAYER);
-		Color prayerBar = PRAYER_COLOR;
-
-		for (Prayer pray : Prayer.values())
-		{
-			if (client.isPrayerActive(pray))
-			{
-				prayerBar = ACTIVE_PRAYER_COLOR;
-			}
-		}
 
 		renderBar(g, offsetHealthX, offsetHealthY,
 			maxHealth, currentHealth, height, healthBar);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/statusbars/StatusBarsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/statusbars/StatusBarsPlugin.java
@@ -24,13 +24,23 @@
  */
 package net.runelite.client.plugins.statusbars;
 
+import com.google.common.eventbus.Subscribe;
 import javax.inject.Inject;
 import com.google.inject.Provides;
+import net.runelite.api.Client;
+import net.runelite.api.Prayer;
+import net.runelite.api.VarPlayer;
+import net.runelite.api.events.GameTick;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDependency;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.plugins.itemstats.ItemStatPlugin;
+import static net.runelite.client.plugins.statusbars.StatusBarsOverlay.ACTIVE_PRAYER_COLOR;
+import static net.runelite.client.plugins.statusbars.StatusBarsOverlay.HEALTH_COLOR;
+import static net.runelite.client.plugins.statusbars.StatusBarsOverlay.POISONED_COLOR;
+import static net.runelite.client.plugins.statusbars.StatusBarsOverlay.PRAYER_COLOR;
+import static net.runelite.client.plugins.statusbars.StatusBarsOverlay.VENOMED_COLOR;
 import net.runelite.client.ui.overlay.OverlayManager;
 
 @PluginDescriptor(
@@ -46,6 +56,9 @@ public class StatusBarsPlugin extends Plugin
 
 	@Inject
 	private OverlayManager overlayManager;
+
+	@Inject
+	private Client client;
 
 	@Override
 	protected void startUp() throws Exception
@@ -64,4 +77,36 @@ public class StatusBarsPlugin extends Plugin
 	{
 		return configManager.getConfig(StatusBarsConfig.class);
 	}
+
+	@Subscribe
+	public void CheckVars(GameTick event)
+	{
+		final int poisonState = client.getVar(VarPlayer.IS_POISONED);
+		if (poisonState > 0 && poisonState < 50)
+		{
+			overlay.healthBar = POISONED_COLOR;
+		}
+		else if (poisonState >= 1000000)
+		{
+			overlay.healthBar = VENOMED_COLOR;
+		}
+		else
+		{
+			overlay.healthBar = HEALTH_COLOR;
+		}
+
+		for (Prayer pray : Prayer.values())
+		{
+			if (client.isPrayerActive(pray))
+			{
+				overlay.prayerBar = ACTIVE_PRAYER_COLOR;
+				break;
+			}
+			else
+			{
+				overlay.prayerBar = PRAYER_COLOR;
+			}
+		}
+	}
+
 }


### PR DESCRIPTION
Changes prayer bar to light up when any prayer is activated instead of only quick-prayer activation.

This makes more sense and will alert people that they have prayers activated.
people can still check if quick-prayers are active on the orb if they want to know that.

closes #6605 