### PR TITLE
attack styles: Fix style hiding after autocast selection

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/attackstyles/AttackStylesPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/attackstyles/AttackStylesPlugin.java
@@ -41,6 +41,7 @@ import net.runelite.api.events.ConfigChanged;
 import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.VarbitChanged;
 import net.runelite.api.events.WidgetHiddenChanged;
+import net.runelite.api.events.WidgetLoaded;
 import net.runelite.api.widgets.Widget;
 import static net.runelite.api.widgets.WidgetID.COMBAT_GROUP_ID;
 import net.runelite.api.widgets.WidgetInfo;
@@ -141,6 +142,17 @@ public class AttackStylesPlugin extends Plugin
 	public void onWidgetHiddenChanged(WidgetHiddenChanged event)
 	{
 		if (event.getWidget().isSelfHidden() || TO_GROUP(event.getWidget().getId()) != COMBAT_GROUP_ID)
+		{
+			return;
+		}
+
+		processWidgets();
+	}
+
+	@Subscribe
+	public void onWidgetLoaded(WidgetLoaded event)
+	{
+		if (event.getGroupId() != COMBAT_GROUP_ID)
 		{
 			return;
 		}


### PR DESCRIPTION
In side stones view, going through the spell autocast selection process
will cause the combat widget to become unloaded and reloaded, rather
than triggering the previous code path where the widget would change
hidden state. This commit adds a second subscriber to handle this path
as well.

Why do they do this differently? Who knows! :woman_shrugging: 

Fixes runelite/runelite#6557