### PR TITLE
Fix action and time estimates only appearing after 2 actions

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpStateSingle.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpStateSingle.java
@@ -72,21 +72,11 @@ class XpStateSingle
 
 	private int toHourly(int value)
 	{
-		if (skillTime == 0)
-		{
-			return 0;
-		}
-
 		return (int) ((1.0 / (getTimeElapsedInSeconds() / 3600.0)) * value);
 	}
 
 	private long getTimeElapsedInSeconds()
 	{
-		if (skillTime == 0)
-		{
-			return 0;
-		}
-
 		// If the skill started just now, we can divide by near zero, this results in odd behavior.
 		// To prevent that, pretend the skill has been active for a minute (60 seconds)
 		// This will create a lower estimate for the first minute,


### PR DESCRIPTION
fixes #6623 

works because after the 1st action skillTime is 0 so the two checks for `skillTime == 0` force the hourly actions and time to goal to be force set to 0.
we don't need these checks because the line in getTimeElapsedInSeconds that forces the skillTime to 60 if it's less than 0 handles the case of skillTime = 0 in addition to the really small skillTimes that line of code was designed to handle (according to the comment)