### PR TITLE
GPU: Fix Textured Faces With Alpha

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/gpu/SceneUploader.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/gpu/SceneUploader.java
@@ -475,7 +475,7 @@ class SceneUploader
 		int color3 = color3s[face];
 
 		int alpha = 0;
-		if (transparencies != null)
+		if (transparencies != null && (faceTextures == null || faceTextures[face] == -1))
 		{
 			alpha = (transparencies[face] & 0xFF) << 24;
 		}


### PR DESCRIPTION
The software renderer ignores the alpha when drawing textured faces

Fixes: https://github.com/runelite/runelite/issues/6540

Before:
![image](https://user-images.githubusercontent.com/11643842/48919023-a540f880-ee90-11e8-8f5e-590fc41ebdcf.png)
![image](https://user-images.githubusercontent.com/11643842/48919123-4f208500-ee91-11e8-87fc-23ed8c967f72.png)

After:
![image](https://user-images.githubusercontent.com/11643842/48919100-344e1080-ee91-11e8-9282-32b7b5671edc.png)
![image](https://user-images.githubusercontent.com/11643842/48919112-42039600-ee91-11e8-9a19-28cb7d065ccf.png)
