### PR TITLE
Properly close GL context and lock surface

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuPlugin.java
@@ -368,17 +368,20 @@ public class GpuPlugin extends Plugin implements DrawCallbacks
 				shutdownProgram();
 				shutdownVao();
 				shutdownStretchedFbo();
+			}
 
+			if (jawtWindow != null)
+			{
 				if (!jawtWindow.getLock().isLocked())
 				{
 					jawtWindow.lockSurface();
 				}
 
-				glContext.destroy();
-			}
+				if (glContext != null)
+				{
+					glContext.destroy();
+				}
 
-			if (jawtWindow != null)
-			{
 				NewtFactoryAWT.destroyNativeWindow(jawtWindow);
 			}
 


### PR DESCRIPTION
- Context can be created without GL being assigned (e.g in case version
is not supported)
- We need to lock jawtWindow if it is not locked always in case it is
not null, and not only when GL is set

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>