### PR TITLE
Truncate username and password string before pasting if necessary

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/loginscreen/LoginScreenPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loginscreen/LoginScreenPlugin.java
@@ -178,11 +178,13 @@ public class LoginScreenPlugin extends Plugin implements KeyListener
 				// 0 is username, 1 is password
 				if (client.getCurrentLoginField() == 0)
 				{
-					client.setUsername(data);
+					// Truncate data to maximum email length if necessary
+					client.setUsername(data.substring(0, Math.min(data.length(), 254)));
 				}
 				else
 				{
-					client.setPassword(data);
+					// Truncate data to maximum password length if necessary
+					client.setPassword(data.substring(0, Math.min(data.length(), 20)));
 				}
 			}
 			catch (UnsupportedFlavorException | IOException ex)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loginscreen/LoginScreenPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loginscreen/LoginScreenPlugin.java
@@ -174,17 +174,18 @@ public class LoginScreenPlugin extends Plugin implements KeyListener
 					.getData(DataFlavor.stringFlavor)
 					.toString()
 					.trim();
+				final int maxEmailLength = 254, maxPasswordLength = 20;
 
 				// 0 is username, 1 is password
 				if (client.getCurrentLoginField() == 0)
 				{
 					// Truncate data to maximum email length if necessary
-					client.setUsername(data.substring(0, Math.min(data.length(), 254)));
+					client.setUsername(data.substring(0, Math.min(data.length(), maxEmailLength)));
 				}
 				else
 				{
 					// Truncate data to maximum password length if necessary
-					client.setPassword(data.substring(0, Math.min(data.length(), 20)));
+					client.setPassword(data.substring(0, Math.min(data.length(), maxPasswordLength)));
 				}
 			}
 			catch (UnsupportedFlavorException | IOException ex)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loginscreen/LoginScreenPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loginscreen/LoginScreenPlugin.java
@@ -62,6 +62,8 @@ public class LoginScreenPlugin extends Plugin implements KeyListener
 
 	private String usernameCache;
 
+	private static final int MAX_EMAIL_LENGTH = 254, MAX_PASSWORD_LENGTH = 20;
+
 	@Override
 	protected void startUp() throws Exception
 	{
@@ -174,18 +176,17 @@ public class LoginScreenPlugin extends Plugin implements KeyListener
 					.getData(DataFlavor.stringFlavor)
 					.toString()
 					.trim();
-				final int maxEmailLength = 254, maxPasswordLength = 20;
 
 				// 0 is username, 1 is password
 				if (client.getCurrentLoginField() == 0)
 				{
 					// Truncate data to maximum email length if necessary
-					client.setUsername(data.substring(0, Math.min(data.length(), maxEmailLength)));
+					client.setUsername(data.substring(0, Math.min(data.length(), MAX_EMAIL_LENGTH)));
 				}
 				else
 				{
 					// Truncate data to maximum password length if necessary
-					client.setPassword(data.substring(0, Math.min(data.length(), maxPasswordLength)));
+					client.setPassword(data.substring(0, Math.min(data.length(), MAX_PASSWORD_LENGTH)));
 				}
 			}
 			catch (UnsupportedFlavorException | IOException ex)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loginscreen/LoginScreenPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loginscreen/LoginScreenPlugin.java
@@ -51,6 +51,9 @@ import net.runelite.client.plugins.PluginDescriptor;
 @Slf4j
 public class LoginScreenPlugin extends Plugin implements KeyListener
 {
+	private static final int MAX_USERNAME_LENGTH = 254;
+	private static final int MAX_PASSWORD_LENGTH = 20;
+
 	@Inject
 	private Client client;
 
@@ -61,8 +64,6 @@ public class LoginScreenPlugin extends Plugin implements KeyListener
 	private KeyManager keyManager;
 
 	private String usernameCache;
-
-	private static final int MAX_EMAIL_LENGTH = 254, MAX_PASSWORD_LENGTH = 20;
 
 	@Override
 	protected void startUp() throws Exception
@@ -180,8 +181,8 @@ public class LoginScreenPlugin extends Plugin implements KeyListener
 				// 0 is username, 1 is password
 				if (client.getCurrentLoginField() == 0)
 				{
-					// Truncate data to maximum email length if necessary
-					client.setUsername(data.substring(0, Math.min(data.length(), MAX_EMAIL_LENGTH)));
+					// Truncate data to maximum username length if necessary
+					client.setUsername(data.substring(0, Math.min(data.length(), MAX_USERNAME_LENGTH)));
 				}
 				else
 				{


### PR DESCRIPTION
Trying to log in after pasting a string that was too long into the username or password field would cause an ArrayIndexOutOfBoundsException beforehand.