### PR TITLE
fix prayer highlighting for xp drops

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/experiencedrop/SkillAmountPrayer.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/experiencedrop/SkillAmountPrayer.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2018, Davis Cook <daviscook447@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.experiencedrop;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import net.runelite.api.Skill;
+
+@AllArgsConstructor
+@Data
+public class SkillAmountPrayer
+{
+	private Skill skill;
+	private int amount;
+	private PrayerType prayerType;
+}


### PR DESCRIPTION
fixes (https://github.com/runelite/runelite/issues/1280)

although I'm going to say this feature is a bit weird and buggy. In it's previous implementation if I was wielding a scimitar and had on eagles eye (ranged prayer) it would highlight hitpoint drops. This bug fix doesn't fix that but it does fix the issue of the highlighting being unrelated to the prayer actually enabled when the xp was gained. This does so by tracking the player's current prayer when the xp is gained rather than when the xp widget is rendered. I'm not absolutely confident that that is the right time to capture the prayer info but it definitely elimates #1280 and it seems to work from my limited testing.

The way to do this properly is probably to check the attack style of the player and only highlight the hitpoints drop if the attack style matches the prayer type.