### PR TITLE
Enable Command-V login screen pasting on macOS

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/loginscreen/LoginScreenPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loginscreen/LoginScreenPlugin.java
@@ -43,6 +43,7 @@ import net.runelite.client.input.KeyListener;
 import net.runelite.client.input.KeyManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.util.OSType;
 
 @PluginDescriptor(
 	name = "Login Screen",
@@ -167,7 +168,10 @@ public class LoginScreenPlugin extends Plugin implements KeyListener
 			return;
 		}
 
-		if (e.getKeyCode() == KeyEvent.VK_V && e.isControlDown())
+		// enable pasting on macOS with the Command (meta) key
+		boolean isModifierDown = OSType.getOSType() == OSType.MacOS ? e.isMetaDown() : e.isControlDown();
+
+		if (e.getKeyCode() == KeyEvent.VK_V && isModifierDown)
 		{
 			try
 			{


### PR DESCRIPTION
Use the default command modifier key to paste on macOS instead of control.