### PR TITLE
Add id to script output

### DIFF
--- a/cache/src/main/java/net/runelite/cache/script/disassembler/Disassembler.java
+++ b/cache/src/main/java/net/runelite/cache/script/disassembler/Disassembler.java
@@ -218,11 +218,13 @@ public class Disassembler
 
 	private void writerHeader(StringBuilder writer, ScriptDefinition script)
 	{
+		int id = script.getId();
 		int intStackCount = script.getIntStackCount();
 		int stringStackCount = script.getStringStackCount();
 		int localIntCount = script.getLocalIntCount();
 		int localStringCount = script.getLocalStringCount();
 
+		writer.append(".id                 ").append(id).append('\n');
 		writer.append(".int_stack_count    ").append(intStackCount).append('\n');
 		writer.append(".string_stack_count ").append(stringStackCount).append('\n');
 		writer.append(".int_var_count      ").append(localIntCount).append('\n');

--- a/cache/src/test/java/net/runelite/cache/definitions/savers/ScriptSaverTest.java
+++ b/cache/src/test/java/net/runelite/cache/definitions/savers/ScriptSaverTest.java
@@ -48,7 +48,7 @@ public class ScriptSaverTest
 		instructions.init();
 		ScriptDefinition script = new Assembler(instructions).assemble(getClass().getResourceAsStream(SCRIPT_RESOURCE));
 		byte[] saved = new ScriptSaver().save(script);
-		ScriptDefinition loadedScripot = new ScriptLoader().load(0, saved);
+		ScriptDefinition loadedScripot = new ScriptLoader().load(91, saved);
 		assertEquals(script, loadedScripot);
 	}
 
@@ -59,7 +59,7 @@ public class ScriptSaverTest
 		instructions.init();
 		ScriptDefinition script = new Assembler(instructions).assemble(getClass().getResourceAsStream(SCRIPT_RESOURCE_UNICODE));
 		byte[] saved = new ScriptSaver().save(script);
-		ScriptDefinition loadedScripot = new ScriptLoader().load(0, saved);
+		ScriptDefinition loadedScripot = new ScriptLoader().load(1001, saved);
 		assertEquals(script, loadedScripot);
 	}
 

--- a/cache/src/test/resources/net/runelite/cache/script/assembler/681.rs2asm
+++ b/cache/src/test/resources/net/runelite/cache/script/assembler/681.rs2asm
@@ -1,3 +1,4 @@
+.id                 681
 .int_stack_count    0
 .string_stack_count 0
 .int_var_count      2

--- a/cache/src/test/resources/net/runelite/cache/script/assembler/91.rs2asm
+++ b/cache/src/test/resources/net/runelite/cache/script/assembler/91.rs2asm
@@ -1,3 +1,4 @@
+.id                 91
 .int_stack_count    2
 .string_stack_count 1
 .int_var_count      2

--- a/cache/src/test/resources/net/runelite/cache/script/assembler/Unicode.rs2asm
+++ b/cache/src/test/resources/net/runelite/cache/script/assembler/Unicode.rs2asm
@@ -1,3 +1,4 @@
+.id                 1001
 .int_stack_count    0
 .string_stack_count 0
 .int_var_count      0


### PR DESCRIPTION
The id is needed for the script to be picked up, and is annoying to have to add manually.