### PR TITLE
timers: Correctly add freeze timer upon frozen while moving

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersPlugin.java
@@ -521,7 +521,8 @@ public class TimersPlugin extends Plugin
 		if (freezeTimer != null)
 		{
 			// assume movement means unfrozen
-			if (!currentWorldPoint.equals(lastPoint))
+			if (freezeTime != client.getTickCount()
+				&& !currentWorldPoint.equals(lastPoint))
 			{
 				removeGameTimer(freezeTimer.getTimer());
 				freezeTimer = null;


### PR DESCRIPTION
When becoming affected by an ice spell, such as Ice Barrage, when moving
prior to the effect's start, the previous code had a subtle bug where
the freeze timer would be applied in the chat message subscriber, but
the `client` would update the player's position before the onGameTick
subscriber was executed, meaning any movement on the same tick the
player became frozen would be registered as "movement", thus removing
that timer.

This fix sidesteps that issue by also ensuring that the client's tick
is different than the freeze tick, since that value appears to remain
unmodified between execution of these two methods.

Fixes runelite/runelite#6658