### PR TITLE
Fix screenshots in GPU mode with Stretched Mode enabled

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuPlugin.java
@@ -1154,8 +1154,15 @@ public class GpuPlugin extends Plugin implements DrawCallbacks
 	 */
 	private Image screenshot()
 	{
-		final int width = client.getCanvasWidth();
-		final int height = client.getCanvasHeight();
+		int width  = client.getCanvasWidth();
+		int height = client.getCanvasHeight();
+
+		if (client.isStretchedEnabled())
+		{
+			Dimension dim = client.getStretchedDimensions();
+			width  = dim.width;
+			height = dim.height;
+		}
 
 		ByteBuffer buffer = ByteBuffer.allocateDirect(width * height * 4)
 			.order(ByteOrder.nativeOrder());


### PR DESCRIPTION
Fixes #6649.

Previous behavior:
![image](https://user-images.githubusercontent.com/19721752/49055454-6d95c180-f1ac-11e8-8ea4-246b49d9115a.png)

New behavior:
![image](https://user-images.githubusercontent.com/19721752/49055473-7e463780-f1ac-11e8-9933-825dcdce5ec7.png)