### PR TITLE
Add Item overlay to show when monsters are weak enough to finish off

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerConfig.java
@@ -100,15 +100,13 @@ public interface SlayerConfig extends Config
 	}
 
 	@ConfigItem(
-			position = 7,
-			keyName = "weaknessPrompt",
-			name = "Show Monster Weakness",
-			description = "Show an overlay on a monster when it is weak enough to finish off (Only Lizards, Gargoyles & Rockslugs)"
+		position = 7,
+		keyName = "weaknessPrompt",
+		name = "Show Monster Weakness",
+		description = "Show an overlay on a monster when it is weak enough to finish off (Only Lizards, Gargoyles & Rockslugs)"
 	)
-	default boolean weaknessPrompt()
-	{
-		return true;
-	}
+	default boolean weaknessPrompt() { return true;	}
+
 	// Stored data
 	@ConfigItem(
 		keyName = "taskName",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerConfig.java
@@ -106,7 +106,9 @@ public interface SlayerConfig extends Config
 		description = "Show an overlay on a monster when it is weak enough to finish off (Only Lizards, Gargoyles & Rockslugs)"
 	)
 	default boolean weaknessPrompt()
-	{ return true; }
+	{
+		return true;
+	}
 
 	// Stored data
 	@ConfigItem(

--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerConfig.java
@@ -105,7 +105,8 @@ public interface SlayerConfig extends Config
 		name = "Show Monster Weakness",
 		description = "Show an overlay on a monster when it is weak enough to finish off (Only Lizards, Gargoyles & Rockslugs)"
 	)
-	default boolean weaknessPrompt() { return true;	}
+	default boolean weaknessPrompt()
+	{ return true; }
 
 	// Stored data
 	@ConfigItem(

--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerConfig.java
@@ -99,6 +99,16 @@ public interface SlayerConfig extends Config
 		return Color.RED;
 	}
 
+	@ConfigItem(
+			position = 7,
+			keyName = "weaknessPrompt",
+			name = "Show Monster Weakness",
+			description = "Show an overlay on a monster when it is weak enough to finish off (Only Lizards, Gargoyles & Rockslugs)"
+	)
+	default boolean weaknessPrompt()
+	{
+		return true;
+	}
 	// Stored data
 	@ConfigItem(
 		keyName = "taskName",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerPlugin.java
@@ -562,7 +562,8 @@ public class SlayerPlugin extends Plugin
 			if (name.contains(target))
 			{
 				NPCComposition composition = npc.getTransformedComposition();
-				if (composition != null && Arrays.asList(composition.getActions()).contains("Attack"))
+				List actions = Arrays.asList(composition.getActions());
+				if (composition != null && (actions.contains("Attack") || actions.contains("Pick"))) //Pick action is for zygomite-fungi
 				{
 					return true;
 				}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerPlugin.java
@@ -139,6 +139,9 @@ public class SlayerPlugin extends Plugin
 	private TargetClickboxOverlay targetClickboxOverlay;
 
 	@Inject
+	private TargetWeaknessOverlay targetWeaknessOverlay;
+
+	@Inject
 	private TargetMinimapOverlay targetMinimapOverlay;
 
 	@Getter(AccessLevel.PACKAGE)
@@ -181,6 +184,7 @@ public class SlayerPlugin extends Plugin
 	{
 		overlayManager.add(overlay);
 		overlayManager.add(targetClickboxOverlay);
+		overlayManager.add(targetWeaknessOverlay);
 		overlayManager.add(targetMinimapOverlay);
 
 		if (client.getGameState() == GameState.LOGGED_IN
@@ -200,6 +204,7 @@ public class SlayerPlugin extends Plugin
 	{
 		overlayManager.remove(overlay);
 		overlayManager.remove(targetClickboxOverlay);
+		overlayManager.remove(targetWeaknessOverlay);
 		overlayManager.remove(targetMinimapOverlay);
 		removeCounter();
 		highlightedTargets.clear();

--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/TargetWeaknessOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/TargetWeaknessOverlay.java
@@ -41,7 +41,7 @@ import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.OverlayUtil;
 
-public class TargetWeaknessOverlay extends Overlay
+class TargetWeaknessOverlay extends Overlay
 {
 	private final Client client;
 	private final SlayerConfig config;
@@ -49,7 +49,7 @@ public class TargetWeaknessOverlay extends Overlay
 	private final ItemManager itemManager;
 
 	@Inject
-	TargetWeaknessOverlay(Client client, SlayerConfig config, SlayerPlugin plugin, ItemManager itemManager)
+	private TargetWeaknessOverlay(Client client, SlayerConfig config, SlayerPlugin plugin, ItemManager itemManager)
 	{
 		this.client = client;
 		this.config = config;
@@ -67,6 +67,21 @@ public class TargetWeaknessOverlay extends Overlay
 			return null;
 		}
 
+		Task curTask = Task.getTask(plugin.getTaskName());
+		if (curTask == null)
+		{
+			return null;
+		}
+
+		float threshold = 0f;
+		switch (curTask)
+		{
+			case DESERT_LIZARDS:	threshold = 0.1f;	break;
+			case GARGOYLES:			threshold = 0.086f; break;
+			case ROCKSLUGS:			threshold = 0.185f; break;
+		}
+
+
 		List<NPC> targets = plugin.getHighlightedTargets();
 		for (NPC target : targets)
 		{
@@ -79,24 +94,24 @@ public class TargetWeaknessOverlay extends Overlay
 
 			float currentHealth = healthRatio / healthScale;
 
-			if (target.getName().toLowerCase().contains("lizard") && currentHealth <= 0.1f)
+			if (currentHealth <= threshold)
 			{
-				renderTargetItem(graphics, target, itemManager.getImage(ItemID.ICE_COOLER));
-			}
-			else if (target.getName().toLowerCase().contains("gargoyle") && currentHealth <= 0.086f)
-			{
-				renderTargetItem(graphics, target, itemManager.getImage(ItemID.ROCK_HAMMER));
-			}
-			else if (target.getName().toLowerCase().contains("rockslug") && currentHealth <= 0.185f)
-			{
-				renderTargetItem(graphics, target, itemManager.getImage(ItemID.BAG_OF_SALT));
+				renderTargetItem(graphics, target, curTask);
 			}
 		}
 		return null;
 	}
 
-	private void renderTargetItem(Graphics2D graphics, NPC actor, BufferedImage image)
+	private void renderTargetItem(Graphics2D graphics, NPC actor, Task curTask)
 	{
+		BufferedImage image = null;
+		switch (curTask)
+		{
+			case DESERT_LIZARDS:	image = itemManager.getImage(ItemID.ICE_COOLER);	break;
+			case GARGOYLES:			image = itemManager.getImage(ItemID.ROCK_HAMMER);	break;
+			case ROCKSLUGS:			image = itemManager.getImage(ItemID.BAG_OF_SALT);	break;
+		}
+
 		LocalPoint actorPosition = actor.getLocalLocation();
 		int offset = actor.getLogicalHeight() + 40;
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/TargetWeaknessOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/TargetWeaknessOverlay.java
@@ -67,12 +67,13 @@ class TargetWeaknessOverlay extends Overlay
 		}
 
 		Task curTask = Task.getTask(plugin.getTaskName());
-		if (curTask == null || curTask.getWeaknessThreshold() < 0)
+		if (curTask == null || curTask.getWeaknessThreshold() < 0 || curTask.getWeaknessItem() < 0)
 		{
 			return null;
 		}
 
 		float threshold = curTask.getWeaknessThreshold();
+		BufferedImage image = itemManager.getImage(curTask.getWeaknessItem());
 
 		List<NPC> targets = plugin.getHighlightedTargets();
 		for (NPC target : targets)
@@ -88,19 +89,14 @@ class TargetWeaknessOverlay extends Overlay
 
 			if (currentHealth <= threshold)
 			{
-				renderTargetItem(graphics, target, curTask);
+				renderTargetItem(graphics, target, image);
 			}
 		}
 		return null;
 	}
 
-	private void renderTargetItem(Graphics2D graphics, NPC actor, Task curTask)
+	private void renderTargetItem(Graphics2D graphics, NPC actor, BufferedImage image)
 	{
-		if (curTask.getWeaknessItem() < 0)
-		{
-			return;
-		}
-		BufferedImage image = itemManager.getImage(curTask.getWeaknessItem());
 		LocalPoint actorPosition = actor.getLocalLocation();
 		int offset = actor.getLogicalHeight() + 40;
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/TargetWeaknessOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/TargetWeaknessOverlay.java
@@ -30,7 +30,6 @@ import java.awt.image.BufferedImage;
 import java.util.List;
 import javax.inject.Inject;
 import net.runelite.api.Client;
-import net.runelite.api.ItemID;
 import net.runelite.api.NPC;
 import net.runelite.api.Perspective;
 import net.runelite.api.Point;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/TargetWeaknessOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/TargetWeaknessOverlay.java
@@ -112,34 +112,12 @@ class TargetWeaknessOverlay extends Overlay
 		int healthScale = target.getHealth();
 		String targetName = Text.removeTags(target.getName());
 		Integer maxHealth = npcManager.getHealth(targetName, target.getCombatLevel());
-		if (healthRatio < 0 || healthScale <= 0 || maxHealth == null)
+		if (healthRatio <= 0 || healthScale <= 0 || maxHealth == null)
 		{
 			return 0;
 		}
-		int minCurHealth = 1;
-		int maxCurHealth;
-		if (healthScale > 1)
-		{
-			if (healthRatio > 1)
-			{
-				// This doesn't apply if healthRatio = 1, because of the special case in the server calculation that
-				// health = 0 forces healthRatio = 0 instead of the expected healthRatio = 1
-				minCurHealth = (maxHealth * (healthRatio - 1) + healthScale - 2) / (healthScale - 1);
-			}
-			maxCurHealth = (maxHealth * healthRatio - 1) / (healthScale - 1);
-			if (maxCurHealth > maxHealth)
-			{
-				maxCurHealth = maxHealth;
-			}
-		}
-		else
-		{
-			// If healthScale is 1, healthRatio will always be 1 unless health = 0
-			// so we know nothing about the upper limit except that it can't be higher than maxHealth
-			maxCurHealth = maxHealth;
-		}
-		// Take the average of min and max possible healths
-		return (minCurHealth + maxCurHealth + 1) / 2;
+
+		return (int)((maxHealth * healthRatio / healthScale) + 0.5f);
 	}
 
 	private void renderTargetItem(Graphics2D graphics, NPC actor, BufferedImage image)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/TargetWeaknessOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/TargetWeaknessOverlay.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2018, Sam "Berry" Beresford <seb1g13@soton.ac.uk>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.slayer;
+
+import java.awt.Dimension;
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+import java.util.List;
+import javax.inject.Inject;
+import net.runelite.api.Client;
+import net.runelite.api.ItemID;
+import net.runelite.api.NPC;
+import net.runelite.api.Perspective;
+import net.runelite.api.Point;
+import net.runelite.api.coords.LocalPoint;
+import net.runelite.client.game.ItemManager;
+import net.runelite.client.ui.overlay.Overlay;
+import net.runelite.client.ui.overlay.OverlayLayer;
+import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.OverlayUtil;
+
+public class TargetWeaknessOverlay extends Overlay
+{
+	private final Client client;
+	private final SlayerConfig config;
+	private final SlayerPlugin plugin;
+	private final ItemManager itemManager;
+
+	@Inject
+	TargetWeaknessOverlay(Client client, SlayerConfig config, SlayerPlugin plugin, ItemManager itemManager)
+	{
+		this.client = client;
+		this.config = config;
+		this.plugin = plugin;
+		this.itemManager = itemManager;
+		setPosition(OverlayPosition.DYNAMIC);
+		setLayer(OverlayLayer.ABOVE_SCENE);
+	}
+
+	@Override
+	public Dimension render(Graphics2D graphics)
+	{
+		if (!config.weaknessPrompt())
+		{
+			return null;
+		}
+
+		List<NPC> targets = plugin.getHighlightedTargets();
+		for (NPC target : targets)
+		{
+			float healthRatio = target.getHealthRatio();
+			float healthScale = target.getHealth();
+			if (healthRatio <= 0 || healthScale <= 0)
+			{
+				continue;
+			}
+
+			float currentHealth = healthRatio / healthScale;
+
+			if (target.getName().toLowerCase().contains("lizard") && currentHealth <= 0.1f)
+			{
+				renderTargetItem(graphics, target, itemManager.getImage(ItemID.ICE_COOLER));
+			}
+			else if (target.getName().toLowerCase().contains("gargoyle") && currentHealth <= 0.086f)
+			{
+				renderTargetItem(graphics, target, itemManager.getImage(ItemID.ROCK_HAMMER));
+			}
+			else if (target.getName().toLowerCase().contains("rockslug") && currentHealth <= 0.185f)
+			{
+				renderTargetItem(graphics, target, itemManager.getImage(ItemID.BAG_OF_SALT));
+			}
+		}
+		return null;
+	}
+
+	private void renderTargetItem(Graphics2D graphics, NPC actor, BufferedImage image)
+	{
+		LocalPoint actorPosition = actor.getLocalLocation();
+		int offset = actor.getLogicalHeight() + 40;
+
+		if (actorPosition != null && image != null)
+		{
+			Point imageLoc = Perspective.getCanvasImageLocation(client, actorPosition, image, offset);
+			if (imageLoc != null)
+			{
+				OverlayUtil.renderImageLocation(graphics, imageLoc, image);
+			}
+		}
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/TargetWeaknessOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/TargetWeaknessOverlay.java
@@ -89,7 +89,7 @@ class TargetWeaknessOverlay extends Overlay
 		{
 			int currentHealth = calculateHealth(target);
 
-			if (currentHealth > 0 && currentHealth <= threshold)
+			if (currentHealth >= 0 && currentHealth <= threshold)
 			{
 				renderTargetItem(graphics, target, image);
 			}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/TargetWeaknessOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/TargetWeaknessOverlay.java
@@ -70,51 +70,50 @@ class TargetWeaknessOverlay extends Overlay
 			return null;
 		}
 
-		Task curTask = Task.getTask(plugin.getTaskName());
+		final Task curTask = Task.getTask(plugin.getTaskName());
 		if (curTask == null || curTask.getWeaknessThreshold() < 0 || curTask.getWeaknessItem() < 0)
 		{
 			return null;
 		}
 
-		int threshold = curTask.getWeaknessThreshold();
-		BufferedImage image = itemManager.getImage(curTask.getWeaknessItem());
+		final int threshold = curTask.getWeaknessThreshold();
+		final BufferedImage image = itemManager.getImage(curTask.getWeaknessItem());
 
 		if (image == null)
 		{
 			return null;
 		}
 
-		List<NPC> targets = plugin.getHighlightedTargets();
+		final List<NPC> targets = plugin.getHighlightedTargets();
 		for (NPC target : targets)
 		{
-			int currentHealth = calculateHealth(target);
+			final int currentHealth = calculateHealth(target);
 
 			if (currentHealth >= 0 && currentHealth <= threshold)
 			{
 				renderTargetItem(graphics, target, image);
 			}
 		}
+
 		return null;
 	}
 
-
-	/**
-	 * Based on how health is calculated in OpponentInfoOverlay
-	 */
 	private int calculateHealth(NPC target)
 	{
-		if (target == null || target.getName() == null || target.getHealth() <= 0)
+		// Based on OpponentInfoOverlay HP calculation
+		if (target == null || target.getName() == null)
 		{
 			return -1;
 		}
 
-		int healthRatio = target.getHealthRatio();
-		int healthScale = target.getHealth();
-		String targetName = Text.removeTags(target.getName());
-		Integer maxHealth = npcManager.getHealth(targetName, target.getCombatLevel());
-		if (healthRatio <= 0 || healthScale <= 0 || maxHealth == null)
+		final int healthScale = target.getHealth();
+		final int healthRatio = target.getHealthRatio();
+		final String targetName = Text.removeTags(target.getName());
+		final Integer maxHealth = npcManager.getHealth(targetName, target.getCombatLevel());
+
+		if (healthRatio < 0 || healthScale <= 0 || maxHealth == null)
 		{
-			return 0;
+			return -1;
 		}
 
 		return (int)((maxHealth * healthRatio / healthScale) + 0.5f);
@@ -122,16 +121,19 @@ class TargetWeaknessOverlay extends Overlay
 
 	private void renderTargetItem(Graphics2D graphics, NPC actor, BufferedImage image)
 	{
-		LocalPoint actorPosition = actor.getLocalLocation();
-		int offset = actor.getLogicalHeight() + 40;
+		final LocalPoint actorPosition = actor.getLocalLocation();
+		final int offset = actor.getLogicalHeight() + 40;
 
-		if (actorPosition != null && image != null)
+		if (actorPosition == null || image == null)
 		{
-			Point imageLoc = Perspective.getCanvasImageLocation(client, actorPosition, image, offset);
-			if (imageLoc != null)
-			{
-				OverlayUtil.renderImageLocation(graphics, imageLoc, image);
-			}
+			return;
+		}
+
+		final Point imageLoc = Perspective.getCanvasImageLocation(client, actorPosition, image, offset);
+
+		if (imageLoc != null)
+		{
+			OverlayUtil.renderImageLocation(graphics, imageLoc, image);
 		}
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/TargetWeaknessOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/TargetWeaknessOverlay.java
@@ -68,19 +68,12 @@ class TargetWeaknessOverlay extends Overlay
 		}
 
 		Task curTask = Task.getTask(plugin.getTaskName());
-		if (curTask == null)
+		if (curTask == null || curTask.getWeaknessThreshold() < 0)
 		{
 			return null;
 		}
 
-		float threshold = 0f;
-		switch (curTask)
-		{
-			case DESERT_LIZARDS:	threshold = 0.1f;	break;
-			case GARGOYLES:			threshold = 0.086f; break;
-			case ROCKSLUGS:			threshold = 0.185f; break;
-		}
-
+		float threshold = curTask.getWeaknessThreshold();
 
 		List<NPC> targets = plugin.getHighlightedTargets();
 		for (NPC target : targets)
@@ -104,14 +97,11 @@ class TargetWeaknessOverlay extends Overlay
 
 	private void renderTargetItem(Graphics2D graphics, NPC actor, Task curTask)
 	{
-		BufferedImage image = null;
-		switch (curTask)
+		if (curTask.getWeaknessItem() < 0)
 		{
-			case DESERT_LIZARDS:	image = itemManager.getImage(ItemID.ICE_COOLER);	break;
-			case GARGOYLES:			image = itemManager.getImage(ItemID.ROCK_HAMMER);	break;
-			case ROCKSLUGS:			image = itemManager.getImage(ItemID.BAG_OF_SALT);	break;
+			return;
 		}
-
+		BufferedImage image = itemManager.getImage(curTask.getWeaknessItem());
 		LocalPoint actorPosition = actor.getLocalLocation();
 		int offset = actor.getLogicalHeight() + 40;
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/TargetWeaknessOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/TargetWeaknessOverlay.java
@@ -75,6 +75,11 @@ class TargetWeaknessOverlay extends Overlay
 		float threshold = curTask.getWeaknessThreshold();
 		BufferedImage image = itemManager.getImage(curTask.getWeaknessItem());
 
+		if (image == null)
+		{
+			return null;
+		}
+
 		List<NPC> targets = plugin.getHighlightedTargets();
 		for (NPC target : targets)
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/Task.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/Task.java
@@ -75,7 +75,7 @@ enum Task
 	DARK_BEASTS("Dark beasts", ItemID.DARK_BEAST, "Night beast"),
 	DARK_WARRIORS("Dark warriors", ItemID.BLACK_MED_HELM, "Dark warrior"),
 	DERANGED_ARCHAEOLOGIST("Deranged Archaeologist", ItemID.ARCHAEOLOGISTS_DIARY),
-	DESERT_LIZARDS("Desert lizards", ItemID.DESERT_LIZARD, "Small lizard", "Lizard"),
+	DESERT_LIZARDS("Desert lizards", ItemID.DESERT_LIZARD, 0.1f, ItemID.ICE_COOLER, "Small lizard", "Lizard"),
 	DOGS("Dogs", ItemID.GUARD_DOG, "Jackal"),
 	DUST_DEVILS("Dust devils", ItemID.DUST_DEVIL, "Choke devil"),
 	DWARVES("Dwarves", ItemID.DWARVEN_HELMET, "Dwarf"),
@@ -86,7 +86,7 @@ enum Task
 	REVENANTS("Revenants", ItemID.REVENANT_ETHER, "Revenant imp", "Revenant goblin", "Revenant pyrefiend", "Revenant hobgoblin", "Revenant cyclops", "Revenant hellhound", "Revenant demon", "Revenant ork", "Revenant dark beast", "Revenant knight", "Revenant dragon"),
 	FLESH_CRAWLERS("Flesh crawlers", ItemID.ENSOULED_SCORPION_HEAD),
 	FOSSIL_ISLAND_WYVERNS("Fossil island wyverns", ItemID.FOSSIL_ISLAND_WYVERN, "Ancient wyvern", "Long-tailed wyvern", "Spitting wyvern", "Taloned wyvern"),
-	GARGOYLES("Gargoyles", ItemID.GARGOYLE),
+	GARGOYLES("Gargoyles", ItemID.GARGOYLE, 0.086f, ItemID.ROCK_HAMMER),
 	GENERAL_GRAARDOR("General Graardor", ItemID.PET_GENERAL_GRAARDOR),
 	GHOSTS("Ghosts", ItemID.GHOSTSPEAK_AMULET, "Tortured soul"),
 	GIANT_MOLE("Giant Mole", ItemID.BABY_MOLE),
@@ -133,7 +133,7 @@ enum Task
 	PYREFIENDS("Pyrefiends", ItemID.PYREFIEND, "Flaming pyrelord"),
 	RATS("Rats", ItemID.RATS_TAIL),
 	RED_DRAGONS("Red dragons", ItemID.BABY_RED_DRAGON),
-	ROCKSLUGS("Rockslugs", ItemID.ROCKSLUG),
+	ROCKSLUGS("Rockslugs", ItemID.ROCKSLUG, 0.185f, ItemID.BAG_OF_SALT),
 	RUNE_DRAGONS("Rune dragons", ItemID.RUNITE_BAR),
 	SCORPIA("Scorpia", ItemID.SCORPIAS_OFFSPRING),
 	CHAOS_DRUIDS("Chaos druids", ItemID.ELDER_CHAOS_HOOD, "Elder Chaos druid", "Chaos druid"),
@@ -174,6 +174,8 @@ enum Task
 	private final String name;
 	private final int itemSpriteId;
 	private final String[] targetNames;
+	private final float weaknessThreshold;
+	private final int weaknessItem;
 
 	static
 	{
@@ -188,6 +190,18 @@ enum Task
 		Preconditions.checkArgument(itemSpriteId >= 0);
 		this.name = name;
 		this.itemSpriteId = itemSpriteId;
+		this.weaknessThreshold = -1f;
+		this.weaknessItem = -1;
+		this.targetNames = targetNames;
+	}
+
+	Task(String name, int itemSpriteId, float weaknessThreshold, int weaknessItem, String... targetNames)
+	{
+		Preconditions.checkArgument(itemSpriteId >= 0);
+		this.name = name;
+		this.itemSpriteId = itemSpriteId;
+		this.weaknessThreshold = weaknessThreshold;
+		this.weaknessItem = weaknessItem;
 		this.targetNames = targetNames;
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/Task.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/Task.java
@@ -75,7 +75,7 @@ enum Task
 	DARK_BEASTS("Dark beasts", ItemID.DARK_BEAST, "Night beast"),
 	DARK_WARRIORS("Dark warriors", ItemID.BLACK_MED_HELM, "Dark warrior"),
 	DERANGED_ARCHAEOLOGIST("Deranged Archaeologist", ItemID.ARCHAEOLOGISTS_DIARY),
-	DESERT_LIZARDS("Desert lizards", ItemID.DESERT_LIZARD, 0.1f, ItemID.ICE_COOLER, "Small lizard", "Lizard"),
+	DESERT_LIZARDS("Desert lizards", ItemID.DESERT_LIZARD, 4, ItemID.ICE_COOLER, "Small lizard", "Lizard"),
 	DOGS("Dogs", ItemID.GUARD_DOG, "Jackal"),
 	DUST_DEVILS("Dust devils", ItemID.DUST_DEVIL, "Choke devil"),
 	DWARVES("Dwarves", ItemID.DWARVEN_HELMET, "Dwarf"),
@@ -86,7 +86,7 @@ enum Task
 	REVENANTS("Revenants", ItemID.REVENANT_ETHER, "Revenant imp", "Revenant goblin", "Revenant pyrefiend", "Revenant hobgoblin", "Revenant cyclops", "Revenant hellhound", "Revenant demon", "Revenant ork", "Revenant dark beast", "Revenant knight", "Revenant dragon"),
 	FLESH_CRAWLERS("Flesh crawlers", ItemID.ENSOULED_SCORPION_HEAD),
 	FOSSIL_ISLAND_WYVERNS("Fossil island wyverns", ItemID.FOSSIL_ISLAND_WYVERN, "Ancient wyvern", "Long-tailed wyvern", "Spitting wyvern", "Taloned wyvern"),
-	GARGOYLES("Gargoyles", ItemID.GARGOYLE, 0.086f, ItemID.ROCK_HAMMER),
+	GARGOYLES("Gargoyles", ItemID.GARGOYLE, 9, ItemID.ROCK_HAMMER),
 	GENERAL_GRAARDOR("General Graardor", ItemID.PET_GENERAL_GRAARDOR),
 	GHOSTS("Ghosts", ItemID.GHOSTSPEAK_AMULET, "Tortured soul"),
 	GIANT_MOLE("Giant Mole", ItemID.BABY_MOLE),
@@ -94,7 +94,7 @@ enum Task
 	GOBLINS("Goblins", ItemID.ENSOULED_GOBLIN_HEAD),
 	GREATER_DEMONS("Greater demons", ItemID.GREATER_DEMON_MASK),
 	GREEN_DRAGONS("Green dragons", ItemID.GREEN_DRAGON_MASK),
-	GROTESQUE_GUARDIANS("Grotesque Guardians", ItemID.MIDNIGHT),
+	GROTESQUE_GUARDIANS("Grotesque Guardians", ItemID.MIDNIGHT, 9, ItemID.ROCK_HAMMER),
 	HARPIE_BUG_SWARMS("Harpie bug swarms", ItemID.SWARM),
 	HELLHOUNDS("Hellhounds", ItemID.HELLHOUND),
 	HILL_GIANTS("Hill giants", ItemID.ENSOULED_GIANT_HEAD),
@@ -133,7 +133,7 @@ enum Task
 	PYREFIENDS("Pyrefiends", ItemID.PYREFIEND, "Flaming pyrelord"),
 	RATS("Rats", ItemID.RATS_TAIL),
 	RED_DRAGONS("Red dragons", ItemID.BABY_RED_DRAGON),
-	ROCKSLUGS("Rockslugs", ItemID.ROCKSLUG, 0.185f, ItemID.BAG_OF_SALT),
+	ROCKSLUGS("Rockslugs", ItemID.ROCKSLUG, 5, ItemID.BAG_OF_SALT),
 	RUNE_DRAGONS("Rune dragons", ItemID.RUNITE_BAR),
 	SCORPIA("Scorpia", ItemID.SCORPIAS_OFFSPRING),
 	CHAOS_DRUIDS("Chaos druids", ItemID.ELDER_CHAOS_HOOD, "Elder Chaos druid", "Chaos druid"),
@@ -174,7 +174,7 @@ enum Task
 	private final String name;
 	private final int itemSpriteId;
 	private final String[] targetNames;
-	private final float weaknessThreshold;
+	private final int weaknessThreshold;
 	private final int weaknessItem;
 
 	static
@@ -190,12 +190,12 @@ enum Task
 		Preconditions.checkArgument(itemSpriteId >= 0);
 		this.name = name;
 		this.itemSpriteId = itemSpriteId;
-		this.weaknessThreshold = -1f;
+		this.weaknessThreshold = -1;
 		this.weaknessItem = -1;
 		this.targetNames = targetNames;
 	}
 
-	Task(String name, int itemSpriteId, float weaknessThreshold, int weaknessItem, String... targetNames)
+	Task(String name, int itemSpriteId, int weaknessThreshold, int weaknessItem, String... targetNames)
 	{
 		Preconditions.checkArgument(itemSpriteId >= 0);
 		this.name = name;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/Task.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/Task.java
@@ -126,7 +126,7 @@ enum Task
 	MOLANISKS("Molanisks", ItemID.MOLANISK),
 	MONKEYS("Monkeys", ItemID.ENSOULED_MONKEY_HEAD),
 	MOSS_GIANTS("Moss giants", ItemID.HILL_GIANT_CLUB),
-	MUTATED_ZYGOMITES("Mutated zygomites", ItemID.MUTATED_ZYGOMITE),
+	MUTATED_ZYGOMITES("Mutated zygomites", ItemID.MUTATED_ZYGOMITE, 0, ItemID.FUNGICIDE_SPRAY_0, "Zygomite", "Fungi"),
 	NECHRYAEL("Nechryael", ItemID.NECHRYAEL, "Nechryarch"),
 	OGRES("Ogres", ItemID.ENSOULED_OGRE_HEAD),
 	OTHERWORLDLY_BEING("Otherworldly beings", ItemID.GHOSTLY_HOOD),

--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/Task.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/Task.java
@@ -133,7 +133,7 @@ enum Task
 	PYREFIENDS("Pyrefiends", ItemID.PYREFIEND, "Flaming pyrelord"),
 	RATS("Rats", ItemID.RATS_TAIL),
 	RED_DRAGONS("Red dragons", ItemID.BABY_RED_DRAGON),
-	ROCKSLUGS("Rockslugs", ItemID.ROCKSLUG, 5, ItemID.BAG_OF_SALT),
+	ROCKSLUGS("Rockslugs", ItemID.ROCKSLUG, 4, ItemID.BAG_OF_SALT),
 	RUNE_DRAGONS("Rune dragons", ItemID.RUNITE_BAR),
 	SCORPIA("Scorpia", ItemID.SCORPIAS_OFFSPRING),
 	CHAOS_DRUIDS("Chaos druids", ItemID.ELDER_CHAOS_HOOD, "Elder Chaos druid", "Chaos druid"),

--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/Task.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/Task.java
@@ -94,7 +94,7 @@ enum Task
 	GOBLINS("Goblins", ItemID.ENSOULED_GOBLIN_HEAD),
 	GREATER_DEMONS("Greater demons", ItemID.GREATER_DEMON_MASK),
 	GREEN_DRAGONS("Green dragons", ItemID.GREEN_DRAGON_MASK),
-	GROTESQUE_GUARDIANS("Grotesque Guardians", ItemID.MIDNIGHT, 9, ItemID.ROCK_HAMMER),
+	GROTESQUE_GUARDIANS("Grotesque Guardians", ItemID.MIDNIGHT, 0, ItemID.ROCK_HAMMER, "Dusk", "Dawn"),
 	HARPIE_BUG_SWARMS("Harpie bug swarms", ItemID.SWARM),
 	HELLHOUNDS("Hellhounds", ItemID.HELLHOUND),
 	HILL_GIANTS("Hill giants", ItemID.ENSOULED_GIANT_HEAD),


### PR DESCRIPTION
Fixes: #784
Current behaviour shows the required item to finish an NPC off above it's head when it's health is below the required threshold.
Works for Rockslugs, Gargoyles and Desert Lizards. (Let me know if I forgot any others).