### PR TITLE
xptracker: Add support for target/goal levels

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpInfoBox.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpInfoBox.java
@@ -27,6 +27,8 @@ package net.runelite.client.plugins.xptracker;
 
 import java.awt.BorderLayout;
 import java.awt.Color;
+import java.awt.Component;
+import javax.swing.JOptionPane;
 import java.awt.Dimension;
 import java.io.IOException;
 import java.text.DecimalFormat;
@@ -113,6 +115,10 @@ class XpInfoBox extends JPanel
 		final JMenuItem resetOthers = new JMenuItem("Reset others");
 		resetOthers.addActionListener(e -> xpTrackerPlugin.resetOtherSkillState(skill));
 
+		// Set a target level for this skill
+		final JMenuItem targetLevel = new JMenuItem("Set target level");
+		targetLevel.addActionListener(e -> showTargetLevel(targetLevel, xpTrackerPlugin));
+
 		// Create reset others menu
 		pauseSkill.addActionListener(e -> xpTrackerPlugin.pauseSkill(skill, !paused));
 
@@ -123,6 +129,7 @@ class XpInfoBox extends JPanel
 		popupMenu.add(reset);
 		popupMenu.add(resetOthers);
 		popupMenu.add(pauseSkill);
+		popupMenu.add(targetLevel);
 
 		JLabel skillIcon = new JLabel(new ImageIcon(iconManager.getSkillImage(skill)));
 		skillIcon.setHorizontalAlignment(SwingConstants.CENTER);
@@ -168,6 +175,23 @@ class XpInfoBox extends JPanel
 		progressBar.setComponentPopupMenu(popupMenu);
 
 		add(container, BorderLayout.NORTH);
+	}
+
+	private void showTargetLevel(Component parent, XpTrackerPlugin xpTrackerPlugin)
+	{
+		String strLevel = JOptionPane.showInputDialog(parent, "Target level", null);
+		if (strLevel == null || strLevel.isEmpty())
+		{
+			return;
+		}
+
+		try
+		{
+			xpTrackerPlugin.setTargetLevel(skill, Integer.parseInt(strLevel));
+		}
+		catch (NumberFormatException exc)
+		{
+		}
 	}
 
 	void reset()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpStateSingle.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpStateSingle.java
@@ -53,6 +53,7 @@ class XpStateSingle
 	private long skillTime = 0;
 	private int startLevelExp = 0;
 	private int endLevelExp = 0;
+	private int targetLevel = 0;
 
 	XpAction getXpAction(final XpActionType type)
 	{
@@ -225,9 +226,11 @@ class XpStateSingle
 		if (goalEndXp <= 0 || currentXp > goalEndXp)
 		{
 			int currentLevel = Experience.getLevelForXp(currentXp);
-			endLevelExp = currentLevel + 1 <= Experience.MAX_VIRT_LEVEL
-				? Experience.getXpForLevel(currentLevel + 1)
-				: Experience.MAX_SKILL_XP;
+			if (targetLevel <= 0 || targetLevel <= currentLevel)
+			{
+				targetLevel = currentLevel + 1;
+			}
+			endLevelExp = getEndLevelExp();
 		}
 		else
 		{
@@ -235,6 +238,13 @@ class XpStateSingle
 		}
 
 		return true;
+	}
+
+	private int getEndLevelExp()
+	{
+		return targetLevel <= Experience.MAX_VIRT_LEVEL
+				? Experience.getXpForLevel(targetLevel)
+				: Experience.MAX_SKILL_XP;
 	}
 
 	public void tick(long delta)
@@ -251,7 +261,7 @@ class XpStateSingle
 	{
 		return XpSnapshotSingle.builder()
 			.startLevel(Experience.getLevelForXp(startLevelExp))
-			.endLevel(Experience.getLevelForXp(endLevelExp))
+			.endLevel(targetLevel)
 			.xpGainedInSession(xpGained)
 			.xpRemainingToGoal(getXpRemaining())
 			.xpPerHour(getXpHr())
@@ -264,5 +274,22 @@ class XpStateSingle
 			.startGoalXp(startLevelExp)
 			.endGoalXp(endLevelExp)
 			.build();
+	}
+
+	public void setTargetLevel(int level)
+	{
+		int currentLevel = Experience.getLevelForXp(getCurrentXp());
+		if (level <= currentLevel)
+		{
+			// set next level
+			targetLevel = currentLevel + 1;
+			return;
+		}
+		else
+		{
+			targetLevel = level;
+		}
+
+		endLevelExp = getEndLevelExp();
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerPlugin.java
@@ -480,4 +480,10 @@ public class XpTrackerPlugin extends Plugin
 			pauseSkill(skill, pause);
 		}
 	}
+
+	void setTargetLevel(Skill skill, int level)
+	{
+		xpState.getSkill(skill).setTargetLevel(level);
+		xpPanel.updateSkillExperience(true, xpPauseState.isPaused(skill), skill, xpState.getSkillSnapshot(skill));
+	}
 }


### PR DESCRIPTION
This PR allows users to set a custom target level from 1 - 126 in XP Tracker.
TTL and xp to level is also reflected in this PR.

<img width="348" alt="screen shot 2018-11-27 at 5 16 09 pm" src="https://user-images.githubusercontent.com/2635519/49115238-43a1d500-f268-11e8-809f-e6ddedb9dc55.png">
