### PR TITLE
Chat message on virtual level up + Level up event

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/events/SkillLeveledUp.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/SkillLeveledUp.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2018, Haashi <https://github.com/Haashi>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package net.runelite.api.events;
+
+import lombok.Data;
+import net.runelite.api.Skill;
+
+/**
+ * An event where the level of a {@link Skill} has been increased.
+ */
+@Data
+public class SkillLeveledUp
+{
+	/**
+	 * The leveled up skill.
+	 */
+	private Skill skill;
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/levelup/LevelUpPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/levelup/LevelUpPlugin.java
@@ -46,9 +46,9 @@ import net.runelite.client.plugins.PluginDescriptor;
 	name = "levelup",
 	hidden = true
 )
-public class LevelUpPlugin extends Plugin {
+public class LevelUpPlugin extends Plugin
+{
 
-	
 	private final Map<Skill, Integer> xpSkills = new EnumMap<>(Skill.class);
 	
 	@Inject
@@ -64,8 +64,7 @@ public class LevelUpPlugin extends Plugin {
 		{
 			for (Skill skill : Skill.values())
 			{
-				final int experience = client.getSkillExperience(skill);
-				xpSkills.put(skill,experience);
+				xpSkills.put(skill, null);
 			}
 		}
 	}
@@ -74,6 +73,17 @@ public class LevelUpPlugin extends Plugin {
 	public void onExperienceChanged(ExperienceChanged event)
 	{
 		final Skill skill = event.getSkill();
+		final Integer experience = xpSkills.get(skill);
+		if (experience != null)
+		{
+			checkLevelUp(skill);
+		}
+		final int experienceAfter = client.getSkillExperience(skill);
+		xpSkills.put(skill, experienceAfter);
+	}
+
+	private void checkLevelUp(Skill skill)
+	{
 		final int experienceBefore = xpSkills.get(skill);
 		final int experienceAfter = client.getSkillExperience(skill);
 		final int lvlBefore = Experience.getLevelForXp(experienceBefore);
@@ -85,5 +95,4 @@ public class LevelUpPlugin extends Plugin {
 			eventBus.post(skillLeveledUp);
 		}
 	}
-
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/virtuallevels/VirtualLevelsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/virtuallevels/VirtualLevelsPlugin.java
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2018, Joshua Filby <joshua@filby.me>
  * Copyright (c) 2018, Jordan Atwood <jordan.atwood423@gmail.com>
+ * Copyright (c) 2018, Haashi <https://github.com/Haashi>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,11 +28,18 @@ package net.runelite.client.plugins.virtuallevels;
 
 import com.google.common.eventbus.Subscribe;
 import javax.inject.Inject;
+
+import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
 import net.runelite.api.Experience;
 import net.runelite.api.Skill;
 import net.runelite.api.events.ScriptCallbackEvent;
+import net.runelite.api.events.SkillLeveledUp;
 import net.runelite.client.callback.ClientThread;
+import net.runelite.client.chat.ChatColorType;
+import net.runelite.client.chat.ChatMessageBuilder;
+import net.runelite.client.chat.ChatMessageManager;
+import net.runelite.client.chat.QueuedMessage;
 import net.runelite.client.events.PluginChanged;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
@@ -51,6 +59,9 @@ public class VirtualLevelsPlugin extends Plugin
 
 	@Inject
 	private ClientThread clientThread;
+
+	@Inject
+	private ChatMessageManager chatMessageManager;
 
 	@Override
 	protected void shutDown()
@@ -121,4 +132,25 @@ public class VirtualLevelsPlugin extends Plugin
 			}
 		}
 	}
+
+	@Subscribe
+	public void onSkillLeveledUp(SkillLeveledUp event)
+	{
+		final Skill skill = event.getSkill();
+		final int lvl = Experience.getLevelForXp(client.getSkillExperience(skill));
+		if (lvl > 99)
+		{
+			final String message = new ChatMessageBuilder()
+			.append(ChatColorType.HIGHLIGHT)
+			.append("Congratulations, you've just advanced your " + skill.getName() + " level. You are now level " + lvl + ".")
+			.build();
+
+			chatMessageManager.queue(
+				QueuedMessage.builder()
+					.type(ChatMessageType.GAME)
+					.runeLiteFormattedMessage(message)
+					.build());
+			}
+	}
+
 }


### PR DESCRIPTION
First look at #6619 feature-request.

First commit is about adding an event on level up (any level, even real level) and xptracker posting the event.

Second one is adding the message in the chatbox using the already existing virtual level plugin.

Any suggestions is welcome.