### PR TITLE
Update slayer tasks to use npcids (but only where needed)

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerPlugin.java
@@ -170,6 +170,7 @@ public class SlayerPlugin extends Plugin
 	private Instant infoTimer;
 	private boolean loginFlag;
 	private List<String> targetNames = new ArrayList<>();
+	private List<Integer> targetIds = new ArrayList<>();
 
 	@Override
 	protected void startUp() throws Exception
@@ -524,7 +525,7 @@ public class SlayerPlugin extends Plugin
 
 	private boolean isTarget(NPC npc)
 	{
-		if (targetNames.isEmpty())
+		if (targetNames.isEmpty() && targetIds.isEmpty())
 		{
 			return false;
 		}
@@ -548,6 +549,25 @@ public class SlayerPlugin extends Plugin
 				}
 			}
 		}
+
+		int id = npc.getId();
+		if (id <= 0)
+		{
+			return false;
+		}
+
+		for (int target : targetIds)
+		{
+			if (id == target)
+			{
+				NPCComposition composition = npc.getTransformedComposition();
+				if (composition != null && Arrays.asList(composition.getActions()).contains("Attack"))
+				{
+					return true;
+				}
+			}
+		}
+
 		return false;
 	}
 
@@ -557,11 +577,22 @@ public class SlayerPlugin extends Plugin
 
 		if (task != null)
 		{
-			Arrays.stream(task.getTargetNames())
+			task.getTargetNames().stream()
 				.map(String::toLowerCase)
 				.forEach(targetNames::add);
 
 			targetNames.add(taskName.toLowerCase().replaceAll("s$", ""));
+		}
+	}
+
+	private void rebuildTargetIds(Task task)
+	{
+		targetIds.clear();
+
+		if (task != null)
+		{
+			task.getNpcIds().stream()
+				.forEach(targetIds::add);
 		}
 	}
 
@@ -589,6 +620,7 @@ public class SlayerPlugin extends Plugin
 
 		Task task = Task.getTask(name);
 		rebuildTargetNames(task);
+		rebuildTargetIds(task);
 		rebuildTargetList();
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerPlugin.java
@@ -524,7 +524,7 @@ public class SlayerPlugin extends Plugin
 				SlayerUnlock.GROTESQUE_GARDIAN_DOUBLE_COUNT.isEnabled(client);
 	}
 
-	private boolean contiguousSubsequenceMatches(String[] seq0, String[] seq1)
+	boolean contiguousSubsequenceMatches(String[] seq0, String toMatch)
 	{
 		for (int i = 0; i < seq0.length; i++)
 		{
@@ -536,21 +536,9 @@ public class SlayerPlugin extends Plugin
 					sub0 += seq0[k] + " ";
 				}
 				sub0 = sub0.substring(0, sub0.length() - 1); // remove extra space
-				for (int i1 = 0; i1 < seq1.length; i1++)
+				if (sub0.equals(toMatch))
 				{
-					for (int j1 = i1; j1 < seq1.length; j1++)
-					{
-						String sub1 = "";
-						for (int k1 = i1; k1 <= j1; k1++)
-						{
-							sub1 += seq1[k1] + " ";
-						}
-						sub1 = sub1.substring(0, sub1.length() - 1); // remove extra space
-						if (sub0 == sub1)
-						{
-							return true;
-						}
-					}
+					return true;
 				}
 			}
 		}
@@ -598,8 +586,7 @@ public class SlayerPlugin extends Plugin
 			else
 			{
 				String[] nameTokens = name.split(" ");
-				String[] targetTokens = name.split(" ");
-				if (contiguousSubsequenceMatches(nameTokens, targetTokens))
+				if (contiguousSubsequenceMatches(nameTokens, target))
 				{
 					NPCComposition composition = npc.getTransformedComposition();
 					if (composition != null && Arrays.asList(composition.getActions()).contains("Attack"))

--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/Task.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/Task.java
@@ -26,145 +26,211 @@
 package net.runelite.client.plugins.slayer;
 
 import com.google.common.base.Preconditions;
+
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import lombok.Getter;
 import net.runelite.api.ItemID;
+import net.runelite.api.NpcID;
+
+import static java.util.Arrays.asList;
 
 @Getter
 enum Task
 {
+
+	/*
+	 * format for enum is that the name of the task is first
+	 * second is the item id image we use to represent the task graphically
+	 * third is the list of names of monsters that can be killed on task (note that he task name is already handled
+	 * so that is why for a task like ankou there is no need to include this list)
+	 * fourth is the list of ids of monsters that can be killed on task (main reason for this is weird cases like baby dragons and the elf mourner)
+	 */
+
 	//<editor-fold desc="Enums">
-	ABERRANT_SPECTRES("Aberrant spectres", ItemID.ABERRANT_SPECTRE, "Spectre"),
-	ABYSSAL_DEMONS("Abyssal demons", ItemID.ABYSSAL_DEMON),
+	ABERRANT_SPECTRES("Aberrant spectres", ItemID.ABERRANT_SPECTRE,
+		asList("Abhorrent spectre", "Deviant spectre", "Repugnant spectre"), asList()),
+	ABYSSAL_DEMONS("Abyssal demons", ItemID.ABYSSAL_DEMON,
+		asList("Ayssal Sire"), asList()),
 	ABYSSAL_SIRE("Abyssal Sire", ItemID.ABYSSAL_ORPHAN),
 	ADAMANT_DRAGONS("Adamant dragons", ItemID.ADAMANTITE_BAR),
 	ANKOU("Ankou", ItemID.ANKOU_MASK),
-	AVIANSIES("Aviansies", ItemID.ENSOULED_AVIANSIE_HEAD),
+	AVIANSIES("Aviansies", ItemID.ENSOULED_AVIANSIE_HEAD,
+		asList("Kree'arra"), asList()),
 	BANSHEES("Banshees", ItemID.BANSHEE),
-	BARROWS_BROTHERS("Barrows Brothers", ItemID.KARILS_COIF),
+	BARROWS_BROTHERS("Barrows Brothers", ItemID.KARILS_COIF,
+		asList("Ahrim the blighted", "Dharok the wretched", "Guthan the infested", "Karil the tainted", "Torag the corrupted", "Verac the defiled"), asList()),
 	BASILISKS("Basilisks", ItemID.BASILISK),
 	BATS("Bats", ItemID.GIRAL_BAT_2),
-	BEARS("Bears", ItemID.ENSOULED_BEAR_HEAD),
-	ENTS("Ents", ItemID.ENTS_ROOTS, "Ent"),
-	LAVA_DRAGONS("Lava Dragons", ItemID.LAVA_SCALE, "Lava dragon"),
-	BIRDS("Birds", ItemID.FEATHER, "Chicken", "Rooster", "Terrorbird", "Seagull"),
-	BLACK_DEMONS("Black demons", ItemID.BLACK_DEMON_MASK),
-	BLACK_DRAGONS("Black dragons", ItemID.BLACK_DRAGON_MASK),
+	BEARS("Bears", ItemID.ENSOULED_BEAR_HEAD,
+		asList("Callisto"), asList()),
+	ENTS("Ents", ItemID.ENTS_ROOTS),
+	LAVA_DRAGONS("Lava Dragons", ItemID.LAVA_SCALE),
+	BANDITS("Bandits", ItemID.BANDIT),
+	BIRDS("Birds", ItemID.FEATHER,
+		asList("Chicken", "Rooster", "Terrorbird", "Seagull", "Chompy bird", "Jubbly bird", "Oomlie bird", "Vulture"), asList()),
+	BLACK_DEMONS("Black demons", ItemID.BLACK_DEMON_MASK,
+		asList("Demonic gorrila", "Balfrug kreeyath", "Skotizo"), asList()),
+	BLACK_DRAGONS("Black dragons", ItemID.BLACK_DRAGON_MASK,
+		asList(), asList(NpcID.BABY_DRAGON_1871, NpcID.BABY_DRAGON_1872, NpcID.BABY_DRAGON_7955)),
 	BLOODVELD("Bloodveld", ItemID.BLOODVELD),
-	BLUE_DRAGONS("Blue dragons", ItemID.BLUE_DRAGON_MASK),
+	BLUE_DRAGONS("Blue dragons", ItemID.BLUE_DRAGON_MASK,
+		asList(), asList(NpcID.BABY_DRAGON, NpcID.BABY_DRAGON_242, NpcID.BABY_DRAGON_243)),
 	BRINE_RATS("Brine rats", ItemID.BRINE_RAT),
 	BRONZE_DRAGONS("Bronze dragons", ItemID.BRONZE_DRAGON_MASK),
 	CALLISTO("Callisto", ItemID.CALLISTO_CUB),
 	CATABLEPON("Catablepon", ItemID.LEFT_SKULL_HALF),
 	CAVE_BUGS("Cave bugs", ItemID.SWAMP_CAVE_BUG),
-	CAVE_CRAWLERS("Cave crawlers", ItemID.CAVE_CRAWLER, "Chasm crawler"),
-	CAVE_HORRORS("Cave horrors", ItemID.CAVE_HORROR, "Cave abomination"),
-	CAVE_KRAKEN("Cave kraken", ItemID.CAVE_KRAKEN),
+	CAVE_CRAWLERS("Cave crawlers", ItemID.CAVE_CRAWLER,
+		asList("Chasm crawler"), asList()),
+	CAVE_HORRORS("Cave horrors", ItemID.CAVE_HORROR,
+		asList("Cave abomination"), asList()),
+	CAVE_KRAKEN("Cave kraken", ItemID.CAVE_KRAKEN,
+		asList("Kraken"), asList()),
 	CAVE_SLIMES("Cave slimes", ItemID.SWAMP_CAVE_SLIME),
 	CERBERUS("Cerberus", ItemID.HELLPUPPY),
+	CHAOS_DRUIDS("Chaos druids", ItemID.ELDER_CHAOS_HOOD),
 	CHAOS_ELEMENTAL("Chaos Elemental", ItemID.PET_CHAOS_ELEMENTAL),
 	CHAOS_FANATIC("Chaos Fanatic", ItemID.PET_CHAOS_ELEMENTAL),
-	COCKATRICE("Cockatrice", ItemID.COCKATRICE, "Cockathrice"),
+	COCKATRICE("Cockatrice", ItemID.COCKATRICE,
+		asList("Cockathrice"), asList()),
 	COWS("Cows", ItemID.COW_MASK),
-	CRAWLING_HANDS("Crawling hands", ItemID.CRAWLING_HAND, "Crushing hand"),
+	CRAWLING_HANDS("Crawling hands", ItemID.CRAWLING_HAND,
+		asList("Crushing hand"), asList()),
 	CRAZY_ARCHAEOLOGIST("Crazy Archaeologist", ItemID.FEDORA),
 	CROCODILES("Crocodiles", ItemID.SWAMP_LIZARD),
-	DAGANNOTH("Dagannoth", ItemID.DAGANNOTH),
-	DAGANNOTH_KINGS("Dagannoth Kings", ItemID.PET_DAGANNOTH_PRIME),
-	DARK_BEASTS("Dark beasts", ItemID.DARK_BEAST, "Night beast"),
-	DARK_WARRIORS("Dark warriors", ItemID.BLACK_MED_HELM, "Dark warrior"),
+	DAGANNOTH("Dagannoth", ItemID.DAGANNOTH,
+			asList("Dagannoth Rex", "Dagannoth Prime", "Dagannoth Supreme"), asList()),
+	DAGANNOTH_KINGS("Dagannoth Kings", ItemID.PET_DAGANNOTH_PRIME,
+		asList("Dagannoth Rex", "Dagannoth Prime", "Dagannoth Supreme"), asList()),
+	DARK_BEASTS("Dark beasts", ItemID.DARK_BEAST,
+		asList("Night beast"), asList()),
+	DARK_WARRIORS("Dark warriors", ItemID.BLACK_MED_HELM),
 	DERANGED_ARCHAEOLOGIST("Deranged Archaeologist", ItemID.ARCHAEOLOGISTS_DIARY),
-	DESERT_LIZARDS("Desert lizards", ItemID.DESERT_LIZARD, "Small lizard", "Lizard"),
-	DOGS("Dogs", ItemID.GUARD_DOG, "Jackal"),
-	DUST_DEVILS("Dust devils", ItemID.DUST_DEVIL, "Choke devil"),
-	DWARVES("Dwarves", ItemID.DWARVEN_HELMET, "Dwarf"),
+	DESERT_LIZARDS("Desert lizards", ItemID.DESERT_LIZARD,
+		asList("Small lizard", "Lizard"), asList()),
+	DOGS("Dogs", ItemID.GUARD_DOG, asList("Jackal"), asList()),
+	DUST_DEVILS("Dust devils", ItemID.DUST_DEVIL,
+		asList("Choke devil"), asList()),
+	DWARVES("Dwarves", ItemID.DWARVEN_HELMET,
+		asList("Dwarf", "Black guard"), asList()),
 	EARTH_WARRIORS("Earth warriors", ItemID.BRONZE_FULL_HELM_T),
-	ELVES("Elves", ItemID.ELF, "Elf"),
+	ELVES("Elves", ItemID.ELF,
+		asList("Elf"), asList(NpcID.MOURNER_5311)),
 	FEVER_SPIDERS("Fever spiders", ItemID.FEVER_SPIDER),
 	FIRE_GIANTS("Fire giants", ItemID.FIRE_BATTLESTAFF),
-	REVENANTS("Revenants", ItemID.REVENANT_ETHER, "Revenant imp", "Revenant goblin", "Revenant pyrefiend", "Revenant hobgoblin", "Revenant cyclops", "Revenant hellhound", "Revenant demon", "Revenant ork", "Revenant dark beast", "Revenant knight", "Revenant dragon"),
+	REVENANTS("Revenants", ItemID.REVENANT_ETHER,
+		asList("Revenant imp", "Revenant goblin", "Revenant pyrefiend", "Revenant hobgoblin", "Revenant cyclops", "Revenant hellhound", "Revenant demon", "Revenant ork", "Revenant dark beast", "Revenant knight", "Revenant dragon"), asList()),
 	FLESH_CRAWLERS("Flesh crawlers", ItemID.ENSOULED_SCORPION_HEAD),
-	FOSSIL_ISLAND_WYVERNS("Fossil island wyverns", ItemID.FOSSIL_ISLAND_WYVERN, "Ancient wyvern", "Long-tailed wyvern", "Spitting wyvern", "Taloned wyvern"),
-	GARGOYLES("Gargoyles", ItemID.GARGOYLE),
+	FOSSIL_ISLAND_WYVERNS("Fossil island wyverns", ItemID.FOSSIL_ISLAND_WYVERN,
+		asList("Ancient wyvern", "Long-tailed wyvern", "Spitting wyvern", "Taloned wyvern"), asList()),
+	GARGOYLES("Gargoyles", ItemID.GARGOYLE,
+		asList("Dusk", "Dawn"), asList()),
 	GENERAL_GRAARDOR("General Graardor", ItemID.PET_GENERAL_GRAARDOR),
-	GHOSTS("Ghosts", ItemID.GHOSTSPEAK_AMULET, "Tortured soul"),
+	GHOSTS("Ghosts", ItemID.GHOSTSPEAK_AMULET,
+		asList("Tortured soul"), asList()),
 	GIANT_MOLE("Giant Mole", ItemID.BABY_MOLE),
 	GHOULS("Ghouls", ItemID.ZOMBIE_HEAD),
 	GOBLINS("Goblins", ItemID.ENSOULED_GOBLIN_HEAD),
-	GREATER_DEMONS("Greater demons", ItemID.GREATER_DEMON_MASK),
-	GREEN_DRAGONS("Green dragons", ItemID.GREEN_DRAGON_MASK),
-	GROTESQUE_GUARDIANS("Grotesque Guardians", ItemID.MIDNIGHT),
+	GREATER_DEMONS("Greater demons", ItemID.GREATER_DEMON_MASK,
+		asList("K'ril Tsutsaroth", "Tstanon Karlak", "Skotizo"), asList()),
+	GREEN_DRAGONS("Green dragons", ItemID.GREEN_DRAGON_MASK,
+		asList(), asList(NpcID.BABY_DRAGON_5194, NpcID.BABY_DRAGON_5872, NpcID.BABY_DRAGON_5873)),
+	GROTESQUE_GUARDIANS("Grotesque Guardians", ItemID.MIDNIGHT,
+		asList("Dusk", "Dawn"), asList()),
 	HARPIE_BUG_SWARMS("Harpie bug swarms", ItemID.SWARM),
-	HELLHOUNDS("Hellhounds", ItemID.HELLHOUND),
-	HILL_GIANTS("Hill giants", ItemID.ENSOULED_GIANT_HEAD),
+	HELLHOUNDS("Hellhounds", ItemID.HELLHOUND,
+		asList("Cerberus"), asList()),
+	HILL_GIANTS("Hill giants", ItemID.ENSOULED_GIANT_HEAD,
+		asList("Cyclops"), asList()),
 	HOBGOBLINS("Hobgoblins", ItemID.HOBGOBLIN_GUARD),
+	ICEFIENDS("Icefiends", ItemID.ICE_DIAMOND),
 	ICE_GIANTS("Ice giants", ItemID.ICE_DIAMOND),
 	ICE_WARRIORS("Ice warriors", ItemID.MITHRIL_FULL_HELM_T),
-	ICEFIENDS("Icefiends", ItemID.ICE_DIAMOND),
-	INFERNAL_MAGES("Infernal mages", ItemID.INFERNAL_MAGE, "Malevolent mage"),
+	INFERNAL_MAGES("Infernal mages", ItemID.INFERNAL_MAGE,
+		asList("Malevolent mage"), asList()),
 	IRON_DRAGONS("Iron dragons", ItemID.IRON_DRAGON_MASK),
 	JAD("TzTok-Jad", ItemID.TZREKJAD),
-	JELLIES("Jellies", ItemID.JELLY, "Jelly"),
+	JELLIES("Jellies", ItemID.JELLY,
+		asList("Jelly"), asList()),
 	JUNGLE_HORROR("Jungle horrors", ItemID.ENSOULED_HORROR_HEAD),
 	KALPHITE("Kalphite", ItemID.KALPHITE_SOLDIER),
-	MAMMOTHS("Mammoths", ItemID.ATTACKER_HORN, "Mammoth"),
 	KALPHITE_QUEEN("Kalphite Queen", ItemID.KALPHITE_PRINCESS),
 	KILLERWATTS("Killerwatts", ItemID.KILLERWATT),
 	KING_BLACK_DRAGON("King Black Dragon", ItemID.PRINCE_BLACK_DRAGON),
-	KRAKEN("Cave Kraken Boss", ItemID.PET_KRAKEN, "Kraken"),
+	KRAKEN("Cave Kraken Boss", ItemID.PET_KRAKEN,
+		asList("Kraken"), asList()),
 	KREEARRA("Kree'arra", ItemID.PET_KREEARRA),
 	KRIL_TSUTSAROTH("K'ril Tsutsaroth", ItemID.PET_KRIL_TSUTSAROTH),
 	KURASK("Kurask", ItemID.KURASK),
-	ROGUES("Rogues", ItemID.ROGUE_MASK, "Rogue"),
+	ROGUES("Rogues", ItemID.ROGUE_MASK, asList("Rogue"), asList()),
 	LESSER_DEMONS("Lesser demons", ItemID.LESSER_DEMON_MASK),
-	LIZARDMEN("Lizardmen", ItemID.LIZARDMAN_FANG, "Lizardman"),
-	MINIONS_OF_SCABARAS("Minions of scabaras", ItemID.GOLDEN_SCARAB, "Scarab swarm", "Locust rider", "Scarab mage"),
+	LIZARDMEN("Lizardmen", ItemID.LIZARDMAN_FANG,
+		asList("Lizardman"), asList()),
+	MAGIC_AXES("Magic axes", ItemID.IRON_BATTLEAXE),
+	MAMMOTHS("Mammoths", ItemID.ATTACKER_HORN,
+		asList("Mammoth"), asList()),
+	MINIONS_OF_SCABARAS("Minions of scabaras", ItemID.GOLDEN_SCARAB,
+		asList("Scarab swarm", "Locust rider", "Scarab mage"), asList()),
 	MINOTAURS("Minotaurs", ItemID.ENSOULED_MINOTAUR_HEAD),
 	MITHRIL_DRAGONS("Mithril dragons", ItemID.MITHRIL_DRAGON_MASK),
 	MOGRES("Mogres", ItemID.MOGRE),
 	MOLANISKS("Molanisks", ItemID.MOLANISK),
 	MONKEYS("Monkeys", ItemID.ENSOULED_MONKEY_HEAD),
-	MOSS_GIANTS("Moss giants", ItemID.HILL_GIANT_CLUB),
-	MUTATED_ZYGOMITES("Mutated zygomites", ItemID.MUTATED_ZYGOMITE),
-	NECHRYAEL("Nechryael", ItemID.NECHRYAEL, "Nechryarch"),
-	OGRES("Ogres", ItemID.ENSOULED_OGRE_HEAD),
+	MOSS_GIANTS("Moss giants", ItemID.HILL_GIANT_CLUB,
+		asList("Bryophyta"), asList()),
+	MUTATED_ZYGOMITES("Mutated zygomites", ItemID.MUTATED_ZYGOMITE,
+		asList("Zygomite"), asList()),
+	NECHRYAEL("Nechryael", ItemID.NECHRYAEL,
+		asList("Nechryarch"), asList()),
+	OGRES("Ogres", ItemID.ENSOULED_OGRE_HEAD,
+		asList("Enclave guard"), asList()),
 	OTHERWORLDLY_BEING("Otherworldly beings", ItemID.GHOSTLY_HOOD),
-	PYREFIENDS("Pyrefiends", ItemID.PYREFIEND, "Flaming pyrelord"),
+	PYREFIENDS("Pyrefiends", ItemID.PYREFIEND,
+		asList("Flaming pyrelord"), asList()),
 	RATS("Rats", ItemID.RATS_TAIL),
-	RED_DRAGONS("Red dragons", ItemID.BABY_RED_DRAGON),
+	RED_DRAGONS("Red dragons", ItemID.BABY_RED_DRAGON,
+		asList(), asList(NpcID.BABY_DRAGON_244, NpcID.BABY_DRAGON_245, NpcID.BABY_DRAGON_246)),
 	ROCKSLUGS("Rockslugs", ItemID.ROCKSLUG),
 	RUNE_DRAGONS("Rune dragons", ItemID.RUNITE_BAR),
 	SCORPIA("Scorpia", ItemID.SCORPIAS_OFFSPRING),
-	CHAOS_DRUIDS("Chaos druids", ItemID.ELDER_CHAOS_HOOD, "Elder Chaos druid", "Chaos druid"),
-	BANDITS("Bandits", ItemID.BANDIT, "Bandit"),
-	MAGIC_AXES("Magic axes", ItemID.IRON_BATTLEAXE, "Magic axe"),
-	SCORPIONS("Scorpions", ItemID.ENSOULED_SCORPION_HEAD),
+	SCORPIONS("Scorpions", ItemID.ENSOULED_SCORPION_HEAD,
+		asList("Scorpia"), asList()),
 	SEA_SNAKES("Sea snakes", ItemID.SNAKE_CORPSE),
-	SHADES("Shades", ItemID.SHADE_ROBE_TOP, "Loar Shadow", "Loar Shade", "Phrin Shadow", "Phrin Shade", "Riyl Shadow", "Riyl Shade", "Asyn Shadow", "Asyn Shade", "Fiyr Shadow", "Fiyr Shade"),
+	SHADES("Shades", ItemID.SHADE_ROBE_TOP,
+		asList("Loar Shadow", "Loar Shade", "Phrin Shadow", "Phrin Shade", "Riyl Shadow", "Riyl Shade", "Asyn Shadow", "Asyn Shade", "Fiyr Shadow", "Fiyr Shade"), asList()),
 	SHADOW_WARRIORS("Shadow warriors", ItemID.BLACK_FULL_HELM),
 	SKELETAL_WYVERNS("Skeletal wyverns", ItemID.SKELETAL_WYVERN),
 	SKELETONS("Skeletons", ItemID.SKELETON_GUARD),
 	SMOKE_DEVILS("Smoke devils", ItemID.SMOKE_DEVIL),
-	SPIDERS("Spiders", ItemID.HUGE_SPIDER),
-	SPIRITUAL_CREATURES("Spiritual creatures", ItemID.DRAGON_BOOTS, "Spiritual ranger", "Spiritual mage", "Spiritual warrior"),
+	SPIDERS("Spiders", ItemID.HUGE_SPIDER,
+		asList("Venenatis"), asList()),
+	SPIRITUAL_CREATURES("Spiritual creatures", ItemID.DRAGON_BOOTS,
+		asList("Spiritual ranger", "Spiritual mage", "Spiritual warrior"), asList()),
 	STEEL_DRAGONS("Steel dragons", ItemID.STEEL_DRAGON),
 	SUQAHS("Suqahs", ItemID.SUQAH_TOOTH),
 	TERROR_DOGS("Terror dogs", ItemID.TERROR_DOG),
 	THERMONUCLEAR_SMOKE_DEVIL("Thermonuclear Smoke Devil", ItemID.PET_SMOKE_DEVIL),
 	TROLLS("Trolls", ItemID.TROLL_GUARD),
 	TUROTH("Turoth", ItemID.TUROTH),
-	TZHAAR("Tzhaar", ItemID.ENSOULED_TZHAAR_HEAD),
-	VAMPIRES("Vampires", ItemID.STAKE),
+	TZHAAR("Tzhaar", ItemID.ENSOULED_TZHAAR_HEAD,
+		asList("Tz-"), asList()),
+	VAMPIRES("Vampires", ItemID.STAKE,
+		asList("Vampyre"), asList()),
 	VENENATIS("Venenatis", ItemID.VENENATIS_SPIDERLING),
 	VETION("Vet'ion", ItemID.VETION_JR),
 	VORKATH("Vorkath", ItemID.VORKI),
 	WALL_BEASTS("Wall beasts", ItemID.SWAMP_WALLBEAST),
 	WATERFIENDS("Waterfiends", ItemID.WATER_ORB),
-	WEREWOLVES("Werewolves", ItemID.WOLFBANE, "Werewolf"),
-	WOLVES("Wolves", ItemID.GREY_WOLF_FUR, "Wolf"),
+	WEREWOLVES("Werewolves", ItemID.WOLFBANE,
+		asList("Werewolf"), asList()),
+	WOLVES("Wolves", ItemID.GREY_WOLF_FUR,
+		asList("Wolf"), asList()),
 	ZILYANA("Zilyana", ItemID.PET_ZILYANA),
-	ZOMBIES("Zombies", ItemID.ZOMBIE_HEAD, "Undead"),
+	ZOMBIES("Zombies", ItemID.ZOMBIE_HEAD,
+		asList("Undead"), asList()),
 	ZULRAH("Zulrah", ItemID.PET_SNAKELING),
 	ZUK("TzKal-Zuk", ItemID.TZREKZUK);
 	//</editor-fold>
@@ -173,7 +239,8 @@ enum Task
 
 	private final String name;
 	private final int itemSpriteId;
-	private final String[] targetNames;
+	private final List<String> targetNames;
+	private final List<Integer> npcIds;
 
 	static
 	{
@@ -183,12 +250,22 @@ enum Task
 		}
 	}
 
-	Task(String name, int itemSpriteId, String... targetNames)
+	Task(String name, int itemSpriteId)
+	{
+		Preconditions.checkArgument(itemSpriteId >= 0);
+		this.name = name;
+		this.itemSpriteId = itemSpriteId;
+		this.targetNames = new ArrayList<>();
+		this.npcIds = new ArrayList<>();
+	}
+
+	Task(String name, int itemSpriteId, List<String> targetNames, List<Integer> npcIds)
 	{
 		Preconditions.checkArgument(itemSpriteId >= 0);
 		this.name = name;
 		this.itemSpriteId = itemSpriteId;
 		this.targetNames = targetNames;
+		this.npcIds = npcIds;
 	}
 
 	static Task getTask(String taskName)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/Task.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/Task.java
@@ -216,7 +216,7 @@ enum Task
 	TROLLS("Trolls", ItemID.TROLL_GUARD),
 	TUROTH("Turoth", ItemID.TUROTH),
 	TZHAAR("Tzhaar", ItemID.ENSOULED_TZHAAR_HEAD,
-		asList("Tz-"), asList()),
+		asList("Tz-"), asList(), false),
 	VAMPIRES("Vampires", ItemID.STAKE,
 		asList("Vampyre"), asList()),
 	VENENATIS("Venenatis", ItemID.VENENATIS_SPIDERLING),
@@ -241,6 +241,7 @@ enum Task
 	private final int itemSpriteId;
 	private final List<String> targetNames;
 	private final List<Integer> npcIds;
+	private final boolean checkAsTokens;
 
 	static
 	{
@@ -257,6 +258,17 @@ enum Task
 		this.itemSpriteId = itemSpriteId;
 		this.targetNames = new ArrayList<>();
 		this.npcIds = new ArrayList<>();
+		this.checkAsTokens = true;
+	}
+
+	Task(String name, int itemSpriteId, boolean checkAsTokens)
+	{
+		Preconditions.checkArgument(itemSpriteId >= 0);
+		this.name = name;
+		this.itemSpriteId = itemSpriteId;
+		this.targetNames = new ArrayList<>();
+		this.npcIds = new ArrayList<>();
+		this.checkAsTokens = checkAsTokens;
 	}
 
 	Task(String name, int itemSpriteId, List<String> targetNames, List<Integer> npcIds)
@@ -266,6 +278,17 @@ enum Task
 		this.itemSpriteId = itemSpriteId;
 		this.targetNames = targetNames;
 		this.npcIds = npcIds;
+		this.checkAsTokens = true;
+	}
+
+	Task(String name, int itemSpriteId, List<String> targetNames, List<Integer> npcIds, boolean checkAsTokens)
+	{
+		Preconditions.checkArgument(itemSpriteId >= 0);
+		this.name = name;
+		this.itemSpriteId = itemSpriteId;
+		this.targetNames = targetNames;
+		this.npcIds = npcIds;
+		this.checkAsTokens = checkAsTokens;
 	}
 
 	static Task getTask(String taskName)

--- a/runelite-client/src/test/java/net/runelite/client/plugins/slayer/SlayerPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/slayer/SlayerPluginTest.java
@@ -438,4 +438,39 @@ public class SlayerPluginTest
 		slayerPlugin.killedOne();
 		assertEquals(30, slayerPlugin.getAmount());
 	}
+
+	@Test
+	public void testSubsequenceMatches()
+	{
+		String name0 = "Brutal Black Dragon".toLowerCase();
+		String target0 = "Black Dragon".toLowerCase();
+
+		String[] name0A = name0.split(" ");
+		assertEquals(true, slayerPlugin.contiguousSubsequenceMatches(name0A, target0));
+
+		String name1 = "Green Dragon".toLowerCase();
+		String target1 = "Black Dragon".toLowerCase();
+
+		String[] name1A = name1.split(" ");
+		assertEquals(false, slayerPlugin.contiguousSubsequenceMatches(name1A, target1));
+
+		String name2 = "Pirate".toLowerCase();
+		String target2 = "Rat".toLowerCase();
+
+		String[] name2A = name2.split(" ");
+		assertEquals(false, slayerPlugin.contiguousSubsequenceMatches(name2A, target2));
+
+		String name3 = "Giant Bat".toLowerCase();
+		String target3 = "Bat".toLowerCase();
+
+		String[] name3A = name3.split(" ");
+		assertEquals(true, slayerPlugin.contiguousSubsequenceMatches(name3A, target3));
+
+		String name4 = "Nechryael";
+		String target4 = "Nechryael";
+
+		String[] name4A = name4.split(" ");
+		assertEquals(true, slayerPlugin.contiguousSubsequenceMatches(name4A, target4));
+	}
+
 }


### PR DESCRIPTION
like #6465 but it only adds in the npcids when necessary (specifically baby dragons and the elf mourner). Also tries to fix the pirate = rat issue by rather than doing a simple string in other string check it checks if the target string is exactly equal to any contiguous subsequence of the name of the npc we are checking split on the space character. So a brutal black dragon is a black dragon, a giant bat is a bat but a pirate is not a rat.

for the npc id bit it first checks if the npc name matches any of the names we expect and only if none of the names match does it check for the npc ids. This makes it possible to only need to track npc id in the two above mentioned cases and all others are covered just by updating the name list to include the ones that were left out.