### PR TITLE
Added Feature for Hiding Other Player's Loot

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/overlay/OverlayIndex.java
+++ b/runelite-api/src/main/java/net/runelite/api/overlay/OverlayIndex.java
@@ -52,6 +52,10 @@ public class OverlayIndex
 		{
 			log.warn("unable to load overlay index", ex);
 		}
+		catch (NullPointerException ex)
+		{
+			log.warn("unable to load overlays", ex);
+		}
 	}
 
 	public static boolean hasOverlay(int indexId, int archiveId)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItem.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItem.java
@@ -27,6 +27,7 @@ package net.runelite.client.plugins.grounditems;
 import lombok.Builder;
 import lombok.Data;
 import lombok.Value;
+import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.coords.WorldPoint;
 
 @Data
@@ -38,11 +39,14 @@ class GroundItem
 	private String name;
 	private int quantity;
 	private WorldPoint location;
+	private LocalPoint localLoc;
 	private int height;
 	private int haPrice;
 	private int gePrice;
 	private int offset;
 	private boolean tradeable;
+
+	int getId() { return id; }
 
 	int getHaPrice()
 	{
@@ -53,6 +57,10 @@ class GroundItem
 	{
 		return gePrice * quantity;
 	}
+
+	WorldPoint getWorldLocation() { return location; }
+
+	LocalPoint getLocalLocation() { return localLoc; }
 
 	@Value
 	static class GroundItemKey

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
@@ -37,10 +37,10 @@ import net.runelite.client.plugins.grounditems.config.PriceDisplayMode;
 public interface GroundItemsConfig extends Config
 {
 	@ConfigItem(
-		keyName = "highlightedItems",
-		name = "Highlighted Items",
-		description = "Configures specifically highlighted ground items. Format: (item), (item)",
-		position = 0
+			keyName = "highlightedItems",
+			name = "Highlighted Items",
+			description = "Configures specifically highlighted ground items. Format: (item), (item)",
+			position = 0
 	)
 	default String getHighlightItems()
 	{
@@ -48,17 +48,17 @@ public interface GroundItemsConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "highlightedItems",
-		name = "",
-		description = ""
+			keyName = "highlightedItems",
+			name = "",
+			description = ""
 	)
 	void setHighlightedItem(String key);
 
 	@ConfigItem(
-		keyName = "hiddenItems",
-		name = "Hidden Items",
-		description = "Configures hidden ground items. Format: (item), (item)",
-		position = 1
+			keyName = "hiddenItems",
+			name = "Hidden Items",
+			description = "Configures hidden ground items. Format: (item), (item)",
+			position = 1
 	)
 	default String getHiddenItems()
 	{
@@ -66,17 +66,17 @@ public interface GroundItemsConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "hiddenItems",
-		name = "",
-		description = ""
+			keyName = "hiddenItems",
+			name = "",
+			description = ""
 	)
 	void setHiddenItems(String key);
 
 	@ConfigItem(
-		keyName = "showHighlightedOnly",
-		name = "Show Highlighted items only",
-		description = "Configures whether or not to draw items only on your highlighted list",
-		position = 2
+			keyName = "showHighlightedOnly",
+			name = "Show Highlighted items only",
+			description = "Configures whether or not to draw items only on your highlighted list",
+			position = 2
 	)
 	default boolean showHighlightedOnly()
 	{
@@ -84,10 +84,10 @@ public interface GroundItemsConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "dontHideUntradeables",
-		name = "Do not hide untradeables",
-		description = "Configures whether or not untradeable items ignore hiding under settings",
-		position = 3
+			keyName = "dontHideUntradeables",
+			name = "Do not hide untradeables",
+			description = "Configures whether or not untradeable items ignore hiding under settings",
+			position = 3
 	)
 	default boolean dontHideUntradeables()
 	{
@@ -95,10 +95,21 @@ public interface GroundItemsConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "showMenuItemQuantities",
-		name = "Show Menu Item Quantities",
-		description = "Configures whether or not to show the item quantities in the menu",
-		position = 4
+			keyName = "hideOtherPlayersLoot",
+			name = "Hide other player's loot",
+			description = "Don't show overlay on items dropped by NPCs killed by other players",
+			position = 4
+	)
+	default boolean hideOtherPlayersLoot()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+			keyName = "showMenuItemQuantities",
+			name = "Show Menu Item Quantities",
+			description = "Configures whether or not to show the item quantities in the menu",
+			position = 5
 	)
 	default boolean showMenuItemQuantities()
 	{
@@ -106,32 +117,32 @@ public interface GroundItemsConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "recolorMenuHiddenItems",
-		name = "Recolor Menu Hidden Items",
-		description = "Configures whether or not hidden items in right click menu will be recolored",
-		position = 5
+			keyName = "recolorMenuHiddenItems",
+			name = "Recolor Menu Hidden Items",
+			description = "Configures whether or not hidden items in right click menu will be recolored",
+			position = 6
 	)
 	default boolean recolorMenuHiddenItems()
 	{
 		return false;
 	}
-	
+
 	@ConfigItem(
-		keyName = "highlightTiles",
-		name = "Highlight Tiles",
-		description = "Configures whether or not to highlight tiles containing ground items",
-		position = 6
+			keyName = "highlightTiles",
+			name = "Highlight Tiles",
+			description = "Configures whether or not to highlight tiles containing ground items",
+			position = 7
 	)
-	default boolean highlightTiles() 
-	{ 
-		return false; 
+	default boolean highlightTiles()
+	{
+		return false;
 	}
 
 	@ConfigItem(
-		keyName = "notifyHighlightedDrops",
-		name = "Notify for Highlighted drops",
-		description = "Configures whether or not to notify for drops on your highlighted list",
-		position = 7
+			keyName = "notifyHighlightedDrops",
+			name = "Notify for Highlighted drops",
+			description = "Configures whether or not to notify for drops on your highlighted list",
+			position = 8
 	)
 	default boolean notifyHighlightedDrops()
 	{
@@ -139,10 +150,10 @@ public interface GroundItemsConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "priceDisplayMode",
-		name = "Price Display Mode",
-		description = "Configures what price types are shown alongside of ground item name",
-		position = 8
+			keyName = "priceDisplayMode",
+			name = "Price Display Mode",
+			description = "Configures what price types are shown alongside of ground item name",
+			position = 9
 	)
 	default PriceDisplayMode priceDisplayMode()
 	{
@@ -150,10 +161,10 @@ public interface GroundItemsConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "itemHighlightMode",
-		name = "Item Highlight Mode",
-		description = "Configures how ground items will be highlighted",
-		position = 9
+			keyName = "itemHighlightMode",
+			name = "Item Highlight Mode",
+			description = "Configures how ground items will be highlighted",
+			position = 10
 	)
 	default ItemHighlightMode itemHighlightMode()
 	{
@@ -161,10 +172,10 @@ public interface GroundItemsConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "menuHighlightMode",
-		name = "Menu Highlight Mode",
-		description = "Configures what to highlight in right-click menu",
-		position = 10
+			keyName = "menuHighlightMode",
+			name = "Menu Highlight Mode",
+			description = "Configures what to highlight in right-click menu",
+			position = 11
 	)
 	default MenuHighlightMode menuHighlightMode()
 	{
@@ -172,10 +183,10 @@ public interface GroundItemsConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "highlightOverValue2",
-		name = "Highlight > Value",
-		description = "Configures highlighted ground items over either GE or HA value",
-		position = 11
+			keyName = "highlightOverValue2",
+			name = "Highlight > Value",
+			description = "Configures highlighted ground items over either GE or HA value",
+			position = 12
 	)
 	default int getHighlightOverValue()
 	{
@@ -183,10 +194,10 @@ public interface GroundItemsConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "hideUnderValue",
-		name = "Hide < Value",
-		description = "Configures hidden ground items under both GE and HA value",
-		position = 12
+			keyName = "hideUnderValue",
+			name = "Hide < Value",
+			description = "Configures hidden ground items under both GE and HA value",
+			position = 13
 	)
 	default int getHideUnderValue()
 	{
@@ -194,10 +205,10 @@ public interface GroundItemsConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "defaultColor",
-		name = "Default items color",
-		description = "Configures the color for default, non-highlighted items",
-		position = 13
+			keyName = "defaultColor",
+			name = "Default items color",
+			description = "Configures the color for default, non-highlighted items",
+			position = 14
 	)
 	default Color defaultColor()
 	{
@@ -205,10 +216,10 @@ public interface GroundItemsConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "highlightedColor",
-		name = "Highlighted items color",
-		description = "Configures the color for highlighted items",
-		position = 14
+			keyName = "highlightedColor",
+			name = "Highlighted items color",
+			description = "Configures the color for highlighted items",
+			position = 15
 	)
 	default Color highlightedColor()
 	{
@@ -216,10 +227,10 @@ public interface GroundItemsConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "hiddenColor",
-		name = "Hidden items color",
-		description = "Configures the color for hidden items in right-click menu and when holding ALT",
-		position = 15
+			keyName = "hiddenColor",
+			name = "Hidden items color",
+			description = "Configures the color for hidden items in right-click menu and when holding ALT",
+			position = 16
 	)
 	default Color hiddenColor()
 	{
@@ -227,10 +238,10 @@ public interface GroundItemsConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "lowValueColor",
-		name = "Low value items color",
-		description = "Configures the color for low value items",
-		position = 16
+			keyName = "lowValueColor",
+			name = "Low value items color",
+			description = "Configures the color for low value items",
+			position = 17
 	)
 	default Color lowValueColor()
 	{
@@ -238,10 +249,10 @@ public interface GroundItemsConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "lowValuePrice",
-		name = "Low value price",
-		description = "Configures the start price for low value items",
-		position = 17
+			keyName = "lowValuePrice",
+			name = "Low value price",
+			description = "Configures the start price for low value items",
+			position = 18
 	)
 	default int lowValuePrice()
 	{
@@ -249,10 +260,10 @@ public interface GroundItemsConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "mediumValueColor",
-		name = "Medium value items color",
-		description = "Configures the color for medium value items",
-		position = 18
+			keyName = "mediumValueColor",
+			name = "Medium value items color",
+			description = "Configures the color for medium value items",
+			position = 19
 	)
 	default Color mediumValueColor()
 	{
@@ -260,10 +271,10 @@ public interface GroundItemsConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "mediumValuePrice",
-		name = "Medium value price",
-		description = "Configures the start price for medium value items",
-		position = 19
+			keyName = "mediumValuePrice",
+			name = "Medium value price",
+			description = "Configures the start price for medium value items",
+			position = 20
 	)
 	default int mediumValuePrice()
 	{
@@ -271,10 +282,10 @@ public interface GroundItemsConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "highValueColor",
-		name = "High value items color",
-		description = "Configures the color for high value items",
-		position = 20
+			keyName = "highValueColor",
+			name = "High value items color",
+			description = "Configures the color for high value items",
+			position = 21
 	)
 	default Color highValueColor()
 	{
@@ -282,10 +293,10 @@ public interface GroundItemsConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "highValuePrice",
-		name = "High value price",
-		description = "Configures the start price for high value items",
-		position = 21
+			keyName = "highValuePrice",
+			name = "High value price",
+			description = "Configures the start price for high value items",
+			position = 22
 	)
 	default int highValuePrice()
 	{
@@ -293,10 +304,10 @@ public interface GroundItemsConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "insaneValueColor",
-		name = "Insane value items color",
-		description = "Configures the color for insane value items",
-		position = 22
+			keyName = "insaneValueColor",
+			name = "Insane value items color",
+			description = "Configures the color for insane value items",
+			position = 23
 	)
 	default Color insaneValueColor()
 	{
@@ -304,10 +315,10 @@ public interface GroundItemsConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "insaneValuePrice",
-		name = "Insane value price",
-		description = "Configures the start price for insane value items",
-		position = 23
+			keyName = "insaneValuePrice",
+			name = "Insane value price",
+			description = "Configures the start price for insane value items",
+			position = 24
 	)
 	default int insaneValuePrice()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
@@ -164,6 +164,11 @@ public class GroundItemsOverlay extends Overlay
 
 		for (GroundItem item : groundItemList)
 		{
+			if (config.hideOtherPlayersLoot() && !plugin.isPlayerOwned(item))
+			{
+				continue;
+			}
+
 			final LocalPoint groundPoint = LocalPoint.fromWorld(client, item.getLocation());
 
 			if (groundPoint == null || localLocation.distanceTo(groundPoint) > MAX_DISTANCE)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
@@ -29,34 +29,23 @@ import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.LoadingCache;
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Multimap;
 import com.google.common.eventbus.Subscribe;
 import com.google.inject.Provides;
 import java.awt.Color;
 import java.awt.Rectangle;
 import static java.lang.Boolean.TRUE;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+
+import java.util.*;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
 import javax.inject.Inject;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
-import net.runelite.api.Client;
-import net.runelite.api.GameState;
-import net.runelite.api.Item;
-import net.runelite.api.ItemComposition;
-import net.runelite.api.ItemID;
-import net.runelite.api.ItemLayer;
-import net.runelite.api.MenuAction;
-import net.runelite.api.MenuEntry;
-import net.runelite.api.Node;
-import net.runelite.api.Player;
-import net.runelite.api.Scene;
-import net.runelite.api.Tile;
+import net.runelite.api.*;
+import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.events.ConfigChanged;
 import net.runelite.api.events.FocusChanged;
 import net.runelite.api.events.GameStateChanged;
@@ -66,7 +55,10 @@ import net.runelite.api.events.ItemSpawned;
 import net.runelite.api.events.MenuEntryAdded;
 import net.runelite.client.Notifier;
 import net.runelite.client.config.ConfigManager;
+import net.runelite.client.events.NpcLootReceived;
+import net.runelite.client.events.PlayerLootReceived;
 import net.runelite.client.game.ItemManager;
+import net.runelite.client.game.ItemStack;
 import net.runelite.client.input.KeyManager;
 import net.runelite.client.input.MouseManager;
 import net.runelite.client.plugins.Plugin;
@@ -150,6 +142,8 @@ public class GroundItemsPlugin extends Plugin
 	private LoadingCache<String, Boolean> highlightedItems;
 	private LoadingCache<String, Boolean> hiddenItems;
 
+	private final Multimap<Integer, LocalPoint> lootItems = HashMultimap.create();
+
 	@Provides
 	GroundItemsConfig provideConfig(ConfigManager configManager)
 	{
@@ -195,6 +189,7 @@ public class GroundItemsPlugin extends Plugin
 		if (event.getGameState() == GameState.LOADING)
 		{
 			collectedGroundItems.clear();
+			lootItems.clear();
 		}
 	}
 
@@ -234,6 +229,24 @@ public class GroundItemsPlugin extends Plugin
 			return;
 		}
 
+		if (lootItems.containsKey(groundItem.getId()))
+		{
+			try
+			{
+				for (Map.Entry<Integer, LocalPoint> entry : lootItems.entries())
+				{
+					if (entry.getKey() == groundItem.getId() &&
+							entry.getValue().getSceneX() == groundItem.getLocalLocation().getSceneX() + 1 &&
+							entry.getValue().getSceneY() == groundItem.getLocalLocation().getSceneY() + 1)
+					{
+						lootItems.remove(entry.getKey(), entry.getValue());
+					}
+				}
+			}
+			// Should be safe to ignore
+			catch (ConcurrentModificationException ex) { }
+		}
+
 		if (groundItem.getQuantity() <= item.getQuantity())
 		{
 			collectedGroundItems.remove(groundItemKey);
@@ -261,6 +274,44 @@ public class GroundItemsPlugin extends Plugin
 		}
 	}
 
+	@Subscribe
+	public void onNpcLootReceived(final NpcLootReceived npcLootReceived)
+	{
+		final NPC npc = npcLootReceived.getNpc();
+		final Collection<ItemStack> items = npcLootReceived.getItems();
+
+		for (ItemStack i: items)
+		{
+			lootItems.put(i.getId(), npc.getLocalLocation());
+		}
+	}
+
+	@Subscribe
+	public void onPlayerLootReceived(final PlayerLootReceived playerLootReceived)
+	{
+		final Player player = playerLootReceived.getPlayer();
+		final Collection<ItemStack> items = playerLootReceived.getItems();
+
+		for (ItemStack i: items)
+		{
+			lootItems.put(i.getId(), player.getLocalLocation());
+		}
+	}
+
+	boolean isPlayerOwned(GroundItem groundItem)
+	{
+		for (LocalPoint loc : lootItems.get(groundItem.getId()))
+		{
+			if (loc.getSceneX() == groundItem.getLocalLocation().getSceneX()+1 &&
+					loc.getSceneY() == groundItem.getLocalLocation().getSceneY()+1)
+			{
+				return true;
+			}
+		}
+
+		return false;
+	}
+
 	private GroundItem buildGroundItem(final Tile tile, final Item item)
 	{
 		// Collect the data for the item
@@ -272,6 +323,7 @@ public class GroundItemsPlugin extends Plugin
 		final GroundItem groundItem = GroundItem.builder()
 			.id(itemId)
 			.location(tile.getWorldLocation())
+			.localLoc(tile.getLocalLocation())
 			.itemId(realItemId)
 			.quantity(item.getQuantity())
 			.name(itemComposition.getName())


### PR DESCRIPTION
This is an implementation of the feature request at #3801 

**What does it do?**
This adds an option to the Ground Items plugin that prevents the overlay from being shown on loot that drops from NPCs killed by other players.
<img width="399" alt="screen shot 2018-11-29 at 10 01 00 pm" src="https://user-images.githubusercontent.com/6034499/49274100-05eda980-f42c-11e8-8d69-017666a5113e.png">

Here it is in action:
<img width="368" alt="screen shot 2018-11-29 at 10 40 58 pm" src="https://user-images.githubusercontent.com/6034499/49274018-b7d8a600-f42b-11e8-803c-b0774ad8c223.png">

**What is the purpose of this feature?**
This is a quality-of-life feature for players in Ironman mode. It makes it much easier to differentiate from NPC drops that can and cannot be picked up.

**How does it work?**
The Ground Items plugin now subscribes to onNpcLootReceived and onPlayerLootReceived events, and keeps track of items dropped by NPCs killed by the player, and the location at which they drop. Then, when it's time for the overlay to be rendered, the item that is being checked for an overlay is compared to the list of loot items, and skipped if it is not present in that list.

Items are removed from the loot item list when they despawn. To avoid memory leaks, the loot item list is also cleared when the game enters the "LOADING" state, as this implies the player is moving away from the area (despawn events are not sent once the player has left the area the item is in, afaik).

**Are there any downsides?**
To my knowledge, there is no way to track specific items on the ground; rather, the best I can do is to track the item type and location. For this reason, this option cannot guarentee 100% accuracy for a variety of reasons, including but not limited to: non-pickup-able items dropping in the same tile as pickup-able items of the same type, picking up and re-dropping items, et cetera.

In addition, since the overlay checks the loot item list every frame, there can be a significant performance penalty while the option is enabled. My MBP 2015 i5 handles it without any noticeable drop in framerate, but results may vary on weaker machines.