### PR TITLE
don't check chatbox status on last tick for fairyring search

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/fairyring/FairyRingPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/fairyring/FairyRingPlugin.java
@@ -91,7 +91,6 @@ public class FairyRingPlugin extends Plugin
 
 	private ChatboxTextInput searchInput = null;
 	private Widget searchBtn;
-	private boolean chatboxOpenLastTick = false;
 	private Collection<CodeWidgets> codes = null;
 
 	@Data
@@ -214,12 +213,10 @@ public class FairyRingPlugin extends Plugin
 		boolean fairyRingWidgetOpen = fairyRingTeleportButton != null && !fairyRingTeleportButton.isHidden();
 		boolean chatboxOpen = chatboxPanelManager.getCurrentInput() == searchInput;
 
-		if (!fairyRingWidgetOpen && chatboxOpen && chatboxOpenLastTick)
+		if (!fairyRingWidgetOpen && chatboxOpen)
 		{
 			chatboxPanelManager.close();
 		}
-
-		chatboxOpenLastTick = chatboxOpen && fairyRingWidgetOpen;
 	}
 
 	private void updateFilter(String filter)


### PR DESCRIPTION
fixes #6759

fairyring plugin was only closing the chatbox if the fairyring menu was gone and the chatbox had been open on the last tick (which wasn't the case when opening the chatbox and then teleporting on the same tick as in #6759) so now we only check if the fairyring menu is gone and the chatbox is currently open.