### PR TITLE
Add a tooltip to loot tracker value, showing exact value

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerBox.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerBox.java
@@ -167,6 +167,7 @@ class LootTrackerBox extends JPanel
 		buildItems();
 
 		priceLabel.setText(StackFormatter.quantityToStackSize(totalPrice) + " gp");
+		priceLabel.setToolTipText(StackFormatter.formatNumber(totalPrice) + " gp");
 
 		final long kills = getTotalKills();
 		if (kills > 1)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/12607046/49328095-e14c1b80-f56a-11e8-9613-72bd78c02e56.png)

Fixes #6766