### PR TITLE
Revert "Auto-hide sidebar close button when not hovered (#6694)"

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
@@ -630,16 +630,7 @@ public class ClientUI
 			: 5;
 
 		final BufferedImage image = sidebarOpen ? sidebarClosedIcon : sidebarOpenIcon;
-
-		final Rectangle sidebarButtonRange = new Rectangle(x - 15, 0, image.getWidth() + 25, client.getRealDimensions().height);
-		final Point mousePosition = new Point(
-			client.getMouseCanvasPosition().getX() + client.getViewportXOffset(),
-			client.getMouseCanvasPosition().getY() + client.getViewportYOffset());
-
-		if (sidebarButtonRange.contains(mousePosition.getX(), mousePosition.getY()))
-		{
-			graphics.drawImage(image, x, y, null);
-		}
+		graphics.drawImage(image, x, y, null);
 
 		// Update button dimensions
 		sidebarButtonPosition.setBounds(x, y, image.getWidth(), image.getHeight());


### PR DESCRIPTION
This is really bad UX because it hides an important interaction, and does the opposite of what was intended, as it flashing constantly makes it more noticeable than just leaving it there.