### PR TITLE
Vengeance active indicator

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/widgets/WidgetID.java
+++ b/runelite-api/src/main/java/net/runelite/api/widgets/WidgetID.java
@@ -123,6 +123,7 @@ public class WidgetID
 	public static final int KOUREND_FAVOUR_GROUP_ID = 246;
 	public static final int LOOTING_BAG_GROUP_ID = 81;
 	public static final int SKOTIZO_GROUP_ID = 308;
+	public static final int ENTERING_HOUSE_GROUP_ID = 71;
 
 	static class WorldMap
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timers/GameIndicator.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timers/GameIndicator.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2018, Tyler <https://github.com/tylerthardy>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.timers;
+
+import java.awt.Color;
+import java.awt.image.BufferedImage;
+import lombok.AccessLevel;
+import lombok.Getter;
+import net.runelite.api.GraphicID;
+import net.runelite.api.SpriteID;
+import net.runelite.client.game.ItemManager;
+import net.runelite.client.game.SpriteManager;
+
+enum GameIndicator
+{
+	VENGEANCE_ACTIVE(SpriteID.SPELL_VENGEANCE_OTHER, GameTimerImageType.SPRITE, GraphicID.VENGEANCE, "Vengeance active");
+
+	@Getter(AccessLevel.PACKAGE)
+	private final String description;
+	@Getter(AccessLevel.PACKAGE)
+	private String text;
+	@Getter(AccessLevel.PACKAGE)
+	private Color textColor;
+	@Getter(AccessLevel.PACKAGE)
+	private final int graphicId;
+	private final int imageId;
+	private final GameTimerImageType imageType;
+
+	GameIndicator(int imageId, GameTimerImageType idType, int graphicId, String description, String text, Color textColor)
+	{
+		this.imageId = imageId;
+		this.imageType = idType;
+		this.graphicId = graphicId;
+		this.description = description;
+		this.text = text;
+		this.textColor = textColor;
+	}
+
+	GameIndicator(int imageId, GameTimerImageType idType, int graphicId, String description) // No text
+	{
+		this(imageId, idType, graphicId, description, "", null);
+	}
+
+	BufferedImage getImage(ItemManager itemManager, SpriteManager spriteManager)
+	{
+		switch (imageType)
+		{
+			case ITEM:
+				return itemManager.getImage(imageId);
+			case SPRITE:
+				return spriteManager.getSprite(imageId, 0);
+			default:
+				return null;
+		}
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timers/GameTimer.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timers/GameTimer.java
@@ -63,7 +63,7 @@ enum GameTimer
 	ICEBARRAGE(SpriteID.SPELL_ICE_BARRAGE, GameTimerImageType.SPRITE, "Ice barrage", GraphicID.ICE_BARRAGE, 20, ChronoUnit.SECONDS, true),
 	IMBUEDHEART(ItemID.IMBUED_HEART, GameTimerImageType.ITEM, "Imbued heart", GraphicID.IMBUED_HEART, 420, ChronoUnit.SECONDS),
 	VENGEANCE(SpriteID.SPELL_VENGEANCE, GameTimerImageType.SPRITE, "Vengeance", GraphicID.VENGEANCE, 30, ChronoUnit.SECONDS),
-	VENGEANCEOTHER(SpriteID.SPELL_VENGEANCE_OTHER, GameTimerImageType.SPRITE, "Vengeance Other", GraphicID.VENGEANCE_OTHER, 30, ChronoUnit.SECONDS),
+	VENGEANCEOTHER(SpriteID.SPELL_VENGEANCE, GameTimerImageType.SPRITE, "Vengeance Other", GraphicID.VENGEANCE_OTHER, 30, ChronoUnit.SECONDS),
 	ANTIDOTEPLUS(ItemID.ANTIDOTE4, GameTimerImageType.ITEM, "Antidote+", 518, ChronoUnit.SECONDS),
 	ANTIVENOM(ItemID.ANTIVENOM4, GameTimerImageType.ITEM, "Anti-venom", 12, ChronoUnit.MINUTES, true),
 	EXSUPERANTIFIRE(ItemID.EXTENDED_SUPER_ANTIFIRE4, GameTimerImageType.ITEM, "Extended Super AntiFire", 6, ChronoUnit.MINUTES),
@@ -87,10 +87,8 @@ enum GameTimer
 	private final String description;
 	@Getter
 	private final boolean removedOnDeath;
-	private int imageId = -1;
-	private GameTimerImageType imageType;
-
-	private BufferedImage image;
+	private final int imageId;
+	private final GameTimerImageType imageType;
 
 	GameTimer(int imageId, GameTimerImageType idType, String description, Integer graphicId, long time, ChronoUnit unit, boolean removedOnDeath)
 	{
@@ -119,21 +117,14 @@ enum GameTimer
 
 	BufferedImage getImage(ItemManager itemManager, SpriteManager spriteManager)
 	{
-		if (image != null)
-		{
-			return image;
-		}
-
 		switch (imageType)
 		{
 			case ITEM:
-				image = itemManager.getImage(imageId);
-				break;
+				return itemManager.getImage(imageId);
 			case SPRITE:
-				image = spriteManager.getSprite(imageId, 0);
-				break;
+				return spriteManager.getSprite(imageId, 0);
+			default:
+				return null;
 		}
-
-		return image;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timers/IndicatorIndicator.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timers/IndicatorIndicator.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2018, Tyler <https://github.com/tylerthardy>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.timers;
+
+import java.awt.Color;
+import java.awt.Image;
+import lombok.Getter;
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.ui.overlay.infobox.InfoBox;
+import net.runelite.client.ui.overlay.infobox.InfoBoxPriority;
+
+public class IndicatorIndicator extends InfoBox
+{
+	@Getter
+	private final GameIndicator indicator;
+
+	IndicatorIndicator(GameIndicator indicator, Image image, Plugin plugin)
+	{
+		super(image, plugin);
+		this.indicator = indicator;
+		setPriority(InfoBoxPriority.MED);
+	}
+
+	@Override
+	public String getText()
+	{
+		return indicator.getText();
+	}
+
+	@Override
+	public Color getTextColor()
+	{
+		return indicator.getTextColor();
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersConfig.java
@@ -142,6 +142,16 @@ public interface TimersConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "showVengeanceActive",
+		name = "Vengeance active",
+		description = "Configures whether an indicator for vengeance being active is displayed"
+	)
+	default boolean showVengeanceActive()
+	{
+		return true;
+	}
+
+	@ConfigItem(
 		keyName = "showTeleblock",
 		name = "Teleblock timer",
 		description = "Configures whether teleblock timer is displayed"

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersPlugin.java
@@ -58,7 +58,9 @@ import net.runelite.api.events.MenuOptionClicked;
 import net.runelite.api.events.NpcDespawned;
 import net.runelite.api.events.VarbitChanged;
 import net.runelite.api.events.WidgetHiddenChanged;
+import net.runelite.api.events.WidgetLoaded;
 import net.runelite.api.widgets.Widget;
+import net.runelite.api.widgets.WidgetID;
 import net.runelite.api.widgets.WidgetInfo;
 import static net.runelite.api.widgets.WidgetInfo.PVP_WORLD_SAFE_ZONE;
 import net.runelite.client.config.ConfigManager;
@@ -67,8 +69,10 @@ import net.runelite.client.game.ItemManager;
 import net.runelite.client.game.SpriteManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
+import static net.runelite.client.plugins.timers.GameIndicator.VENGEANCE_ACTIVE;
 import static net.runelite.client.plugins.timers.GameTimer.*;
 import net.runelite.client.ui.overlay.infobox.InfoBoxManager;
+import net.runelite.client.util.Text;
 
 @PluginDescriptor(
 	name = "Timers",
@@ -105,6 +109,7 @@ public class TimersPlugin extends Plugin
 	private static final String SUPER_ANTIFIRE_DRINK_MESSAGE = "You drink some of your super antifire potion";
 	private static final String SUPER_ANTIFIRE_EXPIRED_MESSAGE = "<col=7f007f>Your super antifire potion has expired.</col>";
 	private static final String SUPER_ANTIVENOM_DRINK_MESSAGE = "You drink some of your super antivenom potion";
+	private static final String VENGEANCE_USED_MESSAGE = "Taste vengeance!";
 
 	private TimerTimer freezeTimer;
 	private int freezeTime = -1; // time frozen, in game ticks
@@ -350,6 +355,11 @@ public class TimersPlugin extends Plugin
 	@Subscribe
 	public void onChatMessage(ChatMessage event)
 	{
+		if (config.showVengeanceActive() && event.getMessage().equals(VENGEANCE_USED_MESSAGE) && event.getType() == ChatMessageType.PUBLIC
+			&& Text.toJagexName(event.getName()).equals(client.getLocalPlayer().getName()))
+		{
+			removeGameIndicator(VENGEANCE_ACTIVE);
+		}
 
 		if (event.getType() != ChatMessageType.FILTERED && event.getType() != ChatMessageType.SERVER)
 		{
@@ -554,6 +564,7 @@ public class TimersPlugin extends Plugin
 		{
 			case HOPPING:
 			case LOGIN_SCREEN:
+				removeGameIndicator(VENGEANCE_ACTIVE);
 				removeTbTimers();
 				break;
 			case LOGGED_IN:
@@ -623,6 +634,14 @@ public class TimersPlugin extends Plugin
 		lastAnimation = client.getLocalPlayer().getAnimation();
 	}
 
+	@Subscribe
+	public void onWidgetLoaded(WidgetLoaded event)
+	{
+		if (config.showVengeanceActive() && event.getGroupId() == WidgetID.ENTERING_HOUSE_GROUP_ID)
+		{
+			removeGameIndicator(VENGEANCE_ACTIVE);
+		}
+	}
 
 	@Subscribe
 	public void onGraphicChanged(GraphicChanged event)
@@ -642,6 +661,11 @@ public class TimersPlugin extends Plugin
 		if (config.showVengeance() && actor.getGraphic() == VENGEANCE.getGraphicId())
 		{
 			createGameTimer(VENGEANCE);
+		}
+
+		if (config.showVengeanceActive() && actor.getGraphic() == VENGEANCE_ACTIVE.getGraphicId())
+		{
+			createGameIndicator(VENGEANCE_ACTIVE);
 		}
 
 		if (config.showFreezes())
@@ -788,6 +812,23 @@ public class TimersPlugin extends Plugin
 	private void removeGameTimer(GameTimer timer)
 	{
 		infoBoxManager.removeIf(t -> t instanceof TimerTimer && ((TimerTimer) t).getTimer() == timer);
+	}
+
+	private IndicatorIndicator createGameIndicator(GameIndicator gameIndicator)
+	{
+		removeGameIndicator(gameIndicator);
+
+		BufferedImage image = gameIndicator.getImage(itemManager, spriteManager);
+		IndicatorIndicator indicator = new IndicatorIndicator(gameIndicator, image, this);
+		indicator.setTooltip(gameIndicator.getDescription());
+		infoBoxManager.addInfoBox(indicator);
+
+		return indicator;
+	}
+
+	private void removeGameIndicator(GameIndicator indicator)
+	{
+		infoBoxManager.removeIf(t -> t instanceof IndicatorIndicator && ((IndicatorIndicator) t).getIndicator() == indicator);
 	}
 
 	private void removeTbTimers()


### PR DESCRIPTION
Adds an indicator to the Timers plugin that shows when vengeance is active on the player.  
Removes indicator when vengeance is used, player enters their house, or logs out.
![image](https://user-images.githubusercontent.com/17709869/49334356-8aaa0600-f599-11e8-8105-3cf25f6b9ce7.png)

I wasn't sure about where to put this feature. @deathbeam suggested the Timers plugin. I created `GameIndicator` in the plugin for indicator-type InfoBoxes . It might be worth creating a new plugin "GameIndicators" and adding non-timer or boost related indicators to it. (e.g. I'd like to add an InfoBox for current poison/venom hit amount.) Feel free to discuss in comments.

Edit: Addresses #3809