### PR TITLE
Add blast mine collection exp

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/blastmine/BlastMineCollectExp.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/blastmine/BlastMineCollectExp.java
@@ -44,11 +44,11 @@ class BlastMineCollectExp extends Overlay
 	private final BlastMinePluginConfig config;
 	private final PanelComponent panelComponent = new PanelComponent();
 
-	public static final int COAL_EXP = 30;
-	public static final int GOLD_EXP = 60;
-	public static final int MITHRIL_EXP = 110;
-	public static final int ADAMANT_EXP = 170;
-	public static final int RUNITE_EXP = 240;
+	private static final int COAL_EXP = 30;
+	private static final int GOLD_EXP = 60;
+	private static final int MITHRIL_EXP = 110;
+	private static final int ADAMANT_EXP = 170;
+	private static final int RUNITE_EXP = 240;
 
 	@Inject
 	public BlastMineCollectExp(Client client, BlastMinePluginConfig config)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/blastmine/BlastMineCollectExp.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/blastmine/BlastMineCollectExp.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2017, Jacky Liang <liangj97@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.blastmine;
+
+import java.awt.Dimension;
+import java.awt.Graphics2D;
+import java.text.NumberFormat;
+import java.util.Locale;
+import javax.inject.Inject;
+import net.runelite.api.Client;
+import net.runelite.api.Varbits;
+import net.runelite.api.widgets.Widget;
+import net.runelite.api.widgets.WidgetInfo;
+import net.runelite.client.ui.overlay.Overlay;
+import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.components.LineComponent;
+import net.runelite.client.ui.overlay.components.PanelComponent;
+
+class BlastMineCollectExp extends Overlay
+{
+	private final Client client;
+	private final BlastMinePluginConfig config;
+	private final PanelComponent panelComponent = new PanelComponent();
+
+	public static final int COAL_EXP = 30;
+	public static final int GOLD_EXP = 60;
+	public static final int MITHRIL_EXP = 110;
+	public static final int ADAMANT_EXP = 170;
+	public static final int RUNITE_EXP = 240;
+
+	@Inject
+	public BlastMineCollectExp(Client client, BlastMinePluginConfig config)
+	{
+		setPosition(OverlayPosition.TOP_LEFT);
+		this.client = client;
+		this.config = config;
+	}
+
+	@Override
+	public Dimension render(Graphics2D graphics)
+	{
+		final Widget blastMineWidget = client.getWidget(WidgetInfo.BLAST_MINE);
+
+		if (blastMineWidget == null)
+		{
+			return null;
+		}
+
+		panelComponent.getChildren().clear();
+		if (config.showCollectionExp())
+		{
+			panelComponent.getChildren().add(LineComponent.builder()
+				.left("Exp")
+				.right(NumberFormat.getIntegerInstance(Locale.getDefault()).format(calculateExp()))
+				.build());
+		}
+		return panelComponent.render(graphics);
+	}
+
+	private int calculateExp()
+	{
+		int coal = client.getVar(Varbits.BLAST_MINE_COAL);
+		int gold = client.getVar(Varbits.BLAST_MINE_GOLD);
+		int mithril = client.getVar(Varbits.BLAST_MINE_MITHRIL);
+		int adamant = client.getVar(Varbits.BLAST_MINE_ADAMANTITE);
+		int rune = client.getVar(Varbits.BLAST_MINE_RUNITE);
+		int exp = COAL_EXP * coal + GOLD_EXP * gold + MITHRIL_EXP * mithril + ADAMANT_EXP * adamant + RUNITE_EXP * rune;
+
+		if (config.isWearingFullProspector())
+		{
+			return (int) Math.round(exp * 1.025);
+		}
+
+		return exp;
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/blastmine/BlastMinePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/blastmine/BlastMinePlugin.java
@@ -61,6 +61,9 @@ public class BlastMinePlugin extends Plugin
 	private Client client;
 
 	@Inject
+	private BlastMineCollectExp blastMineCollectExp;
+
+	@Inject
 	private BlastMineRockOverlay blastMineRockOverlay;
 
 	@Inject
@@ -77,6 +80,7 @@ public class BlastMinePlugin extends Plugin
 	{
 		overlayManager.add(blastMineRockOverlay);
 		overlayManager.add(blastMineOreCountOverlay);
+		overlayManager.add(blastMineCollectExp);
 	}
 
 	@Override
@@ -84,6 +88,7 @@ public class BlastMinePlugin extends Plugin
 	{
 		overlayManager.remove(blastMineRockOverlay);
 		overlayManager.remove(blastMineOreCountOverlay);
+		overlayManager.remove(blastMineCollectExp);
 		final Widget blastMineWidget = client.getWidget(WidgetInfo.BLAST_MINE);
 
 		if (blastMineWidget != null)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/blastmine/BlastMinePluginConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/blastmine/BlastMinePluginConfig.java
@@ -98,4 +98,26 @@ public interface BlastMinePluginConfig extends Config
 	{
 		return new Color(217, 54, 0);
 	}
+
+	@ConfigItem(
+		position = 6,
+		keyName = "showCollectionExp",
+		name = "Show collection exp",
+		description = "Configures whether or not to show the exp from collecting ores"
+	)
+	default boolean showCollectionExp()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		position = 7,
+		keyName = "isWearingFullProspector",
+		name = "Prospector's outfit equipped",
+		description = "Configures whether or not the collection exp should be multiplied by bonus"
+	)
+	default boolean isWearingFullProspector()
+	{
+		return false;
+	}
 }


### PR DESCRIPTION
Adds an overlay that displays the total exp that would be recieved from the operator at blast mine. There is also an option to display the exp if collecting with full prospectors outfit on.

<img width="299" alt="bm exp counter" src="https://user-images.githubusercontent.com/37294123/49334455-b7f2c480-f62a-11e8-99f2-fc45a5f7429d.PNG">
