### PR TITLE
Revert "Add support for kills left to XpTrackerPlugin"

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpActionType.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpActionType.java
@@ -31,8 +31,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum XpActionType
 {
-	EXPERIENCE("Actions"),
-	ACTOR_HEALTH("Kills");
+	EXPERIENCE("Actions");
 
 	private final String label;
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpState.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpState.java
@@ -27,7 +27,6 @@ package net.runelite.client.plugins.xptracker;
 import java.util.EnumMap;
 import java.util.Map;
 import lombok.NonNull;
-import net.runelite.api.NPC;
 import net.runelite.api.Skill;
 
 /**
@@ -38,11 +37,8 @@ import net.runelite.api.Skill;
  */
 class XpState
 {
-	private static final double DEFAULT_XP_MODIFIER = 4.0;
-	private static final double SHARED_XP_MODIFIER = DEFAULT_XP_MODIFIER / 3.0;
 	private final XpStateTotal xpTotal = new XpStateTotal();
 	private final Map<Skill, XpStateSingle> xpSkills = new EnumMap<>(Skill.class);
-	private NPC interactedNPC;
 
 	/**
 	 * Destroys all internal state, however any XpSnapshotSingle or XpSnapshotTotal remain unaffected.
@@ -124,79 +120,6 @@ class XpState
 		}
 	}
 
-	private double getCombatXPModifier(Skill skill)
-	{
-		if (skill == Skill.HITPOINTS)
-		{
-			return SHARED_XP_MODIFIER;
-		}
-
-		return DEFAULT_XP_MODIFIER;
-	}
-
-	/**
-	 * Updates skill with average actions based on currently interacted NPC.
-	 * @param skill experience gained skill
-	 * @param npc currently interacted NPC
-	 * @param npcHealth health of currently interacted NPC
-	 */
-	void updateNpcExperience(Skill skill, NPC npc, Integer npcHealth)
-	{
-		if (npc == null || npc.getCombatLevel() <= 0 || npcHealth == null)
-		{
-			return;
-		}
-
-		final XpStateSingle state = getSkill(skill);
-		final int actionExp = (int) (npcHealth * getCombatXPModifier(skill));
-		final XpAction action = state.getXpAction(XpActionType.ACTOR_HEALTH);
-
-		if (action.isActionsHistoryInitialized())
-		{
-			action.getActionExps()[action.getActionExpIndex()] = actionExp;
-
-			if (interactedNPC != npc)
-			{
-				action.setActionExpIndex((action.getActionExpIndex() + 1) % action.getActionExps().length);
-			}
-		}
-		else
-		{
-			// So we have a decent average off the bat, lets populate all values with what we see.
-			for (int i = 0; i < action.getActionExps().length; i++)
-			{
-				action.getActionExps()[i] = actionExp;
-			}
-
-			action.setActionsHistoryInitialized(true);
-		}
-
-		interactedNPC = npc;
-		state.setActionType(XpActionType.ACTOR_HEALTH);
-	}
-
-	/**
-	 * Update number of actions performed for skill (e.g amount of kills in this case) if last interacted
-	 * NPC died
-	 * @param skill skill to update actions for
-	 * @param npc npc that just died
-	 * @param npcHealth max health of npc that just died
-	 * @return UPDATED in case new kill was successfully added
-	 */
-	XpUpdateResult updateNpcKills(Skill skill, NPC npc, Integer npcHealth)
-	{
-		XpStateSingle state = getSkill(skill);
-
-		if (state.getXpGained() <= 0 || npcHealth == null || npc != interactedNPC)
-		{
-			return XpUpdateResult.NO_CHANGE;
-		}
-
-		final XpAction xpAction = state.getXpAction(XpActionType.ACTOR_HEALTH);
-		xpAction.setActions(xpAction.getActions() + 1);
-		return xpAction.isActionsHistoryInitialized() ? XpUpdateResult.UPDATED : XpUpdateResult.NO_CHANGE;
-	}
-
 	void tick(Skill skill, long delta)
 	{
 		getSkill(skill).tick(delta);
@@ -214,7 +137,7 @@ class XpState
 	}
 
 	@NonNull
-	XpStateSingle getSkill(Skill skill)
+	private XpStateSingle getSkill(Skill skill)
 	{
 		return xpSkills.computeIfAbsent(skill, (s) -> new XpStateSingle(s, -1));
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpStateSingle.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpStateSingle.java
@@ -54,7 +54,7 @@ class XpStateSingle
 	private int startLevelExp = 0;
 	private int endLevelExp = 0;
 
-	XpAction getXpAction(final XpActionType type)
+	private XpAction getXpAction(final XpActionType type)
 	{
 		actions.putIfAbsent(type, new XpAction());
 		return actions.get(type);


### PR DESCRIPTION
This feature doesn't work at all if you are:
 - Using an attack style that gives you multiple types of XP
 - Using ranged at range
 - Using a cannon
 - Barraging/Bursting
 - Attacking multiple monsters
 - Attacking monsters in series with differing HP values

As most of these are either difficult to solve or unsolvable and common cases this feature should be removed.

Fixes #6576
Fixes #6479
Closes #6643