### PR TITLE
loot tracker: validate boxes after rebuilding

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerBox.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerBox.java
@@ -175,6 +175,7 @@ class LootTrackerBox extends JPanel
 			subTitleLabel.setText("x " + kills);
 		}
 
+		validate();
 		repaint();
 	}
 


### PR DESCRIPTION
The items container would show up empty if only ignored loot was dropped, validating the loot tracker box before repainting fixes this.

closes #6240 