### PR TITLE
fix: use correct char for boolean type

### DIFF
--- a/cache/src/main/java/net/runelite/cache/util/ScriptVarType.java
+++ b/cache/src/main/java/net/runelite/cache/util/ScriptVarType.java
@@ -32,7 +32,7 @@ import lombok.AllArgsConstructor;
 public enum ScriptVarType
 {
 	INTEGER('i', "integer"),
-	BOOLEAN('l', "boolean"),
+	BOOLEAN('1', "boolean"),
 	SEQ('A', "seq"),
 	COLOUR('C', "colour"),
 	/**


### PR DESCRIPTION
When first adding this enum I copied the characters wrong for `loc` and `boolean` since `l` and `1` look the same with the intellij font.