### PR TITLE
Cluescroll Widget - Update width to scale up some.

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/ClueScrollOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/ClueScrollOverlay.java
@@ -61,7 +61,8 @@ public class ClueScrollOverlay extends Overlay
 		}
 
 		panelComponent.getChildren().clear();
-		panelComponent.setPreferredSize(new Dimension(ComponentConstants.STANDARD_WIDTH, 0));
+		panelComponent.setPreferredSize(new Dimension((int) Math.round(ComponentConstants.STANDARD_WIDTH * 1.5) , 0));
+
 
 		clue.makeOverlayHint(panelComponent, plugin);
 


### PR DESCRIPTION
This will let more text be on same line for the clue scrolls, as it looks a bit weird when listing currently.

From:
![d6251c99cc1152a4d7ab6ad759da5a9b](https://user-images.githubusercontent.com/5571347/49454608-7b9ea000-f7b3-11e8-951b-9a3c17cc7d52.png)


To:
![ae5539001af178145b57c73a805f31b6](https://user-images.githubusercontent.com/5571347/49454635-8bb67f80-f7b3-11e8-945e-c2a9aae80528.png)