### PR TITLE
Move core configs outside Scroll Pane

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
@@ -70,6 +70,7 @@ import javax.swing.border.Border;
 import javax.swing.border.CompoundBorder;
 import javax.swing.border.EmptyBorder;
 import javax.swing.border.MatteBorder;
+import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
@@ -232,6 +233,19 @@ public class ConfigPanel extends PluginPanel
 		b.addMouseWheelListener(scrollListener);
 		scrollPane.addMouseWheelListener(scrollListener);
 
+		scrollPane.getViewport().addChangeListener(new ChangeListener()
+		{
+			@Override
+			public void stateChanged(ChangeEvent e)
+			{
+				if (showingPluginList)
+				{
+					corePanel.setBorder(scrollPane.getVerticalScrollBar().isVisible() ? CORE_BORDER : null);
+					corePanel.revalidate();
+				}
+			}
+		});
+
 		add(scrollPane, BorderLayout.CENTER);
 
 		initializePluginList();
@@ -308,11 +322,6 @@ public class ConfigPanel extends PluginPanel
 		showMatchingPlugins(false, text);
 
 		revalidate();
-
-		// Check if a scrollbar is going to be visible with the new children quantity
-		boolean scrollBar = mainPanel.getComponentCount() * SCROLL_INCREMENT > scrollPane.getHeight();
-		corePanel.setBorder(scrollBar ? CORE_BORDER : null);
-		topPanel.revalidate();
 	}
 
 	private void showMatchingPlugins(boolean pinned, String text)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/PluginListItem.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/PluginListItem.java
@@ -234,6 +234,11 @@ class PluginListItem extends JPanel
 		pinButton.setToolTipText(pinned ? "Unpin plugin" : "Pin plugin");
 	}
 
+	void removePinnedButton()
+	{
+		remove(pinButton);
+	}
+
 	private void updateToggleButton(IconButton button)
 	{
 		button.setIcon(isPluginEnabled ? ON_SWITCHER : OFF_SWITCHER);


### PR DESCRIPTION
Just an idea. Also updated the scroll increment (with mouse wheel) to be exactly the height of one config entry regardless of OS scroll amount.

![2018-12-04_21-32-02](https://user-images.githubusercontent.com/29030969/49492201-2e9ae800-f80c-11e8-80c9-ec241ff5e6d7.gif)