### PR TITLE
Add Right-Click rename feature to Bank Tags

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/banktags/TagManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/banktags/TagManager.java
@@ -169,6 +169,33 @@ public class TagManager
 		}
 	}
 
+	public void renameTag(String oldTag, String newTag)
+	{
+		final String prefix = CONFIG_GROUP + "." + ITEM_KEY_PREFIX;
+		configManager.getConfigurationKeys(prefix).forEach(item ->
+		{
+			int id = Integer.parseInt(item.replace(prefix, ""));
+			renameTag(id, oldTag, newTag);
+		});
+	}
+
+	public void renameTag(int itemId, String oldTag, String newTag)
+	{
+		Collection<String> tags = getTags(itemId, false);
+		if (tags.remove(Text.standardize(oldTag)))
+		{
+			tags.add(Text.standardize(newTag));
+			setTags(itemId, tags, false);
+		}
+
+		tags = getTags(itemId, true);
+		if (tags.remove(Text.standardize(oldTag)))
+		{
+			tags.add(Text.standardize(newTag));
+			setTags(itemId, tags, true);
+		}
+	}
+
 	private int getItemId(int itemId, boolean variation)
 	{
 		itemId = Math.abs(itemId);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/banktags/tabs/MenuIndexes.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/banktags/tabs/MenuIndexes.java
@@ -39,5 +39,6 @@ class MenuIndexes
 		static final int CHANGE_ICON = 3;
 		static final int DELETE_TAB = 4;
 		static final int EXPORT_TAB = 5;
+		static final int RENAME_TAB = 6;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/banktags/tabs/TabInterface.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/banktags/tabs/TabInterface.java
@@ -377,13 +377,7 @@ public class TabInterface
 				break;
 			case Tab.RENAME_TAB:
 				String renameTarget = Text.standardize(event.getOpbase());
-				chatboxPanelManager.openTextMenuInput("Rename " + renameTarget + "?")
-						.option("Yes", () ->
-								clientThread.invoke(() ->
-										renameTab(renameTarget))
-						)
-						.option("No", Runnables::doNothing)
-						.build();
+				renameTab(renameTarget);
 				break;
 		}
 	}
@@ -734,7 +728,7 @@ public class TabInterface
 
 	private void renameTab(String oldTag)
 	{
-		chatboxPanelManager.openTextInput("Tag name")
+		chatboxPanelManager.openTextInput("Enter new tag name for tag \"" + oldTag + "\":")
 				.onDone((newTag) -> clientThread.invoke(() ->
 				{
 					if (!Strings.isNullOrEmpty(newTag) && !newTag.equalsIgnoreCase(oldTag))
@@ -764,7 +758,14 @@ public class TabInterface
 						else
 						{
 							chatboxPanelManager.openTextMenuInput("The specified bank tag already exists.")
-									.option("Ok", () ->
+									.option("1. Merge into existing tag \"" + newTag + "\".", () ->
+											clientThread.invoke(() ->
+											{
+												tagManager.renameTag(oldTag, newTag);
+												deleteTab(oldTag);
+											})
+									)
+									.option("2. Choose a different name.", () ->
 											clientThread.invoke(() ->
 													renameTab(oldTag))
 									)


### PR DESCRIPTION
This is a first contribution (to runelite and an open source project in general) so I'm not too familiar with the runelite codebase. ~~Since this is the case, I wasn't too familiar with chatbox notifications and so when renaming a bank tag to a name that's already in use, the chatbox notification that shows is probably not optimal (see image below).~~ Edit: With the revision to how already-existing tags are handled in commit 5347d76, the chatbox notification is no longer an issue.

![renaming](https://user-images.githubusercontent.com/45087016/49638695-96992c00-f9ce-11e8-9d95-483e819cab9c.gif)

Closes #6486 