### PR TITLE
Separate the combat idle notification from the fishing idle notification

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierConfig.java
@@ -45,7 +45,7 @@ public interface IdleNotifierConfig extends Config
 	@ConfigItem(
 		keyName = "interactionidle",
 		name = "Idle Interaction Notifications",
-		description = "Configures if idle interaction notifications are enabled e.g. combat, fishing",
+		description = "Configures if idle non-combat interaction notifications are enabled e.g. fishing",
 		position = 2
 	)
 	default boolean interactionIdle()
@@ -65,10 +65,21 @@ public interface IdleNotifierConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "combatidle",
+		name = "Combat Idle Notifications",
+		description = "Configures if idle combat notifications are enabled",
+		position = 4
+	)
+	default boolean combatIdle()
+	{
+		return true;
+	}
+
+	@ConfigItem(
 		keyName = "timeout",
 		name = "Idle Notification Delay (ms)",
 		description = "The notification delay after the player is idle",
-		position = 4
+		position = 5
 	)
 	default int getIdleNotificationDelay()
 	{
@@ -79,7 +90,7 @@ public interface IdleNotifierConfig extends Config
 		keyName = "hitpoints",
 		name = "Hitpoints Notification Threshold",
 		description = "The amount of hitpoints to send a notification at. A value of 0 will disable notification.",
-		position = 5
+		position = 6
 	)
 	default int getHitpointsThreshold()
 	{
@@ -90,7 +101,7 @@ public interface IdleNotifierConfig extends Config
 		keyName = "prayer",
 		name = "Prayer Notification Threshold",
 		description = "The amount of prayer points to send a notification at. A value of 0 will disable notification.",
-		position = 6
+		position = 7
 	)
 	default int getPrayerThreshold()
 	{
@@ -100,7 +111,7 @@ public interface IdleNotifierConfig extends Config
 	@ConfigItem(
 		keyName = "oxygen",
 		name = "Oxygen Notification Threshold",
-		position = 7,
+		position = 8,
 		description = "The amount of remaining oxygen to send a notification at. A value of 0 will disable notification."
 	)
 	default int getOxygenThreshold()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
@@ -57,7 +57,7 @@ import net.runelite.client.plugins.PluginDescriptor;
 @PluginDescriptor(
 	name = "Idle Notifier",
 	description = "Send a notification when going idle, or when HP/Prayer reaches a threshold",
-	tags = {"health", "hitpoints", "notifications", "prayer"}
+	tags = {"health", "hitpoints", "notifications", "prayer", "fishing", "oxygen"}
 )
 public class IdleNotifierPlugin extends Plugin
 {
@@ -356,13 +356,13 @@ public class IdleNotifierPlugin extends Plugin
 			notifier.notify("[" + local.getName() + "] is now idle!");
 		}
 
-		if (config.interactionIdle() && checkInteractionIdle(waitDuration, local))
+		if ((config.combatIdle() || config.interactionIdle()) && checkInteractionIdle(waitDuration, local))
 		{
-			if (lastInteractWasCombat)
+			if (config.combatIdle() && lastInteractWasCombat)
 			{
 				notifier.notify("[" + local.getName() + "] is now out of combat!");
 			}
-			else
+			else if (config.interactionIdle() && !lastInteractWasCombat)
 			{
 				notifier.notify("[" + local.getName() + "] is now idle!");
 			}

--- a/runelite-client/src/test/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPluginTest.java
@@ -106,7 +106,7 @@ public class IdleNotifierPluginTest
 		// Mock config
 		when(config.logoutIdle()).thenReturn(true);
 		when(config.animationIdle()).thenReturn(true);
-		when(config.interactionIdle()).thenReturn(true);
+		when(config.combatIdle()).thenReturn(true);
 		when(config.getIdleNotificationDelay()).thenReturn(0);
 		when(config.getHitpointsThreshold()).thenReturn(42);
 		when(config.getPrayerThreshold()).thenReturn(42);


### PR DESCRIPTION
I think that it was a bad idea to combine the fishing and combat idle notifications under a single config option. I'd like to be able to turn off combat idle notifications without having to turn them back every time I go fishing.

I've seen a few complaints about this in discord too since my PR that improved the fishing notification and simultaneously grouped it with the combat idle notification under "Idle Interaction Notifications". Having now played with this a bit more I agree with the complaints and would like to propose it be changed.

I've kept the fishing notification generic enough that further non-combat interaction idle notifications can be added to it easily in future if ever it becomes relevant.