### PR TITLE
Allow lowering of outer zoom limit in the camera zoom plugin

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/config/ConfigItem.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/ConfigItem.java
@@ -46,4 +46,6 @@ public @interface ConfigItem
 	String warning() default "";
 
 	boolean secret() default false;
+
+	int minimumInt() default 0;
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
@@ -340,8 +340,9 @@ public class ConfigPanel extends PluginPanel
 			if (cid.getType() == int.class)
 			{
 				int value = Integer.parseInt(configManager.getConfiguration(cd.getGroup().value(), cid.getItem().keyName()));
+				int minimumInt = cid.getItem().minimumInt();
 
-				SpinnerModel model = new SpinnerNumberModel(value, 0, Integer.MAX_VALUE, 1);
+				SpinnerModel model = new SpinnerNumberModel(value, minimumInt, Integer.MAX_VALUE, 1);
 				JSpinner spinner = new JSpinner(model);
 				Component editor = spinner.getEditor();
 				JFormattedTextField spinnerTextField = ((JSpinner.DefaultEditor) editor).getTextField();

--- a/runelite-client/src/main/java/net/runelite/client/plugins/zoom/ZoomConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/zoom/ZoomConfig.java
@@ -44,8 +44,9 @@ public interface ZoomConfig extends Config
 
 	@ConfigItem(
 		keyName = "outerLimit",
-		name = "Expand outer zoom limit",
-		description = "Configures how much the outer zoom limit is increased, 0 is off",
+		name = "Adjust outer zoom limit",
+		description = "Configures how much the outer zoom limit is adjusted",
+		minimumInt = -400,
 		position = 2
 	)
 	default int outerLimit()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/zoom/ZoomPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/zoom/ZoomPlugin.java
@@ -28,7 +28,6 @@ package net.runelite.client.plugins.zoom;
 import com.google.inject.Inject;
 import com.google.inject.Provides;
 import java.awt.event.KeyEvent;
-import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.events.ConfigChanged;
 import net.runelite.api.events.FocusChanged;
@@ -46,7 +45,6 @@ import net.runelite.client.plugins.PluginDescriptor;
 	tags = {"limit", "vertical"},
 	enabledByDefault = false
 )
-@Slf4j
 public class ZoomPlugin extends Plugin implements KeyListener
 {
 	/**

--- a/runelite-client/src/main/java/net/runelite/client/plugins/zoom/ZoomPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/zoom/ZoomPlugin.java
@@ -28,6 +28,7 @@ package net.runelite.client.plugins.zoom;
 import com.google.inject.Inject;
 import com.google.inject.Provides;
 import java.awt.event.KeyEvent;
+import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.events.ConfigChanged;
 import net.runelite.api.events.FocusChanged;
@@ -45,6 +46,7 @@ import net.runelite.client.plugins.PluginDescriptor;
 	tags = {"limit", "vertical"},
 	enabledByDefault = false
 )
+@Slf4j
 public class ZoomPlugin extends Plugin implements KeyListener
 {
 	/**
@@ -54,7 +56,7 @@ public class ZoomPlugin extends Plugin implements KeyListener
 	 */
 	private static final int INNER_ZOOM_LIMIT = 1004;
 
-	private static final int OUTER_CONFIG_ZOOM_LIMIT_MIN = 0;
+	private static final int OUTER_CONFIG_ZOOM_LIMIT_MIN = -400;
 	private static final int OUTER_CONFIG_ZOOM_LIMIT_MAX = 400;
 
 	private boolean controlDown;


### PR DESCRIPTION
Closes #6832 

Added support for negative values on the int spinner and applied to the camera zoom plugin.

<Details><Summary>Expand for GIF demonstration</Summary>
![decrease outer zoom limit](https://user-images.githubusercontent.com/29353990/49680199-e557cc00-fa89-11e8-93f7-a1133dafa41d.gif)
</Details>