### PR TITLE
Notify on Full Special Attack

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierConfig.java
@@ -107,4 +107,15 @@ public interface IdleNotifierConfig extends Config
 	{
 		return 0;
 	}
+
+	@ConfigItem(
+		keyName = "spec",
+		name = "Special Attack Energy Notification Threshold",
+		position = 8,
+		description = "The amount of spec energy reached to send a notification at. A value of 0 will disable notification."
+	)
+	default int getSpecEnergyThreshold()
+	{
+		return 0;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
@@ -42,6 +42,7 @@ import net.runelite.api.NPC;
 import net.runelite.api.NPCComposition;
 import net.runelite.api.Player;
 import net.runelite.api.Skill;
+import net.runelite.api.VarPlayer;
 import net.runelite.api.Varbits;
 import net.runelite.api.events.AnimationChanged;
 import net.runelite.api.events.GameStateChanged;
@@ -89,6 +90,7 @@ public class IdleNotifierPlugin extends Plugin
 	private boolean notifyOxygen = true;
 	private boolean notifyIdleLogout = true;
 	private boolean notify6HourLogout = true;
+	private int lastSpecEnergy = 1000;
 	private int lastCombatCountdown = 0;
 	private Instant sixHourWarningTime;
 	private boolean ready;
@@ -382,6 +384,30 @@ public class IdleNotifierPlugin extends Plugin
 		{
 			notifier.notify("[" + local.getName() + "] has low oxygen!");
 		}
+
+		if (checkFullSpecEnergy())
+		{
+			notifier.notify("[" + local.getName() + "] has restored spec energy!");;
+		}
+	}
+
+	private boolean checkFullSpecEnergy()
+	{
+		int currentSpecEnergy = client.getVar(VarPlayer.SPECIAL_ATTACK_PERCENT);
+
+		int threshold = config.getSpecEnergyThreshold() * 10;
+		if (threshold == 0)
+		{
+			lastSpecEnergy = currentSpecEnergy;
+			return false;
+		}
+
+		// Check if we have regenerated over the threshold, and that the
+		// regen was small enough.
+		boolean notify = lastSpecEnergy < threshold && currentSpecEnergy >= threshold
+			&& currentSpecEnergy - lastSpecEnergy <= 100;
+		lastSpecEnergy = currentSpecEnergy;
+		return notify;
 	}
 
 	private boolean checkLowOxygen()

--- a/runelite-client/src/test/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPluginTest.java
@@ -35,6 +35,7 @@ import net.runelite.api.Hitsplat;
 import net.runelite.api.NPC;
 import net.runelite.api.NPCComposition;
 import net.runelite.api.Player;
+import net.runelite.api.VarPlayer;
 import net.runelite.api.events.AnimationChanged;
 import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.GameTick;
@@ -44,9 +45,11 @@ import net.runelite.client.Notifier;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Matchers;
 import static org.mockito.Matchers.any;
 import org.mockito.Mock;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -254,5 +257,19 @@ public class IdleNotifierPluginTest
 		plugin.onGameTick(new GameTick());
 		plugin.onGameTick(new GameTick());
 		verify(notifier, times(1)).notify(any());
+	}
+
+	@Test
+	public void testSpecRegen()
+	{
+		when(config.getSpecEnergyThreshold()).thenReturn(50);
+
+		when(client.getVar(Matchers.eq(VarPlayer.SPECIAL_ATTACK_PERCENT))).thenReturn(400); // 40%
+		plugin.onGameTick(new GameTick()); // once to set lastSpecEnergy to 400
+		verify(notifier, never()).notify(any());
+
+		when(client.getVar(Matchers.eq(VarPlayer.SPECIAL_ATTACK_PERCENT))).thenReturn(500); // 50%
+		plugin.onGameTick(new GameTick());
+		verify(notifier).notify(Matchers.eq("[" + PLAYER_NAME + "] has restored spec energy!"));
 	}
 }


### PR DESCRIPTION
This is made under the Idle Notifier plugin as requested by @Adam- in the #3922 thread. Users should  be notified when special attack energy naturally regenerates to a set value (and if set to 0 it will be disabled just like other options in the plugin).

Fixes #1727
Closes #3922 