### PR TITLE
slayer task: change 'Zilyana' to 'Commander Zilyana'

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/Task.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/Task.java
@@ -163,7 +163,7 @@ enum Task
 	WATERFIENDS("Waterfiends", ItemID.WATER_ORB),
 	WEREWOLVES("Werewolves", ItemID.WOLFBANE, "Werewolf"),
 	WOLVES("Wolves", ItemID.GREY_WOLF_FUR, "Wolf"),
-	ZILYANA("Zilyana", ItemID.PET_ZILYANA),
+	ZILYANA("Commander Zilyana", ItemID.PET_ZILYANA),
 	ZOMBIES("Zombies", ItemID.ZOMBIE_HEAD, "Undead"),
 	ZULRAH("Zulrah", ItemID.PET_SNAKELING),
 	ZUK("TzKal-Zuk", ItemID.TZREKZUK);


### PR DESCRIPTION
Fixes #6865 .

I don't have an account that has or has the ability to get a Zilyana task, so I'm not 100% sure this works, but I am pretty sure. If someone has an account that could test this, that would be nice.