### PR TITLE
Add caching to config invocation handler

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/config/ConfigInvocationHandler.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/ConfigInvocationHandler.java
@@ -28,6 +28,8 @@ import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import lombok.extern.slf4j.Slf4j;
 
@@ -36,26 +38,47 @@ class ConfigInvocationHandler implements InvocationHandler
 {
 	private final ConfigManager manager;
 
+	// Caches for annotation values
+	private static final Map<Class<?>, String> groupValueCache = new HashMap<>();
+	private static final Map<Method, String> methodKeyNameCache = new HashMap<>();
+
 	public ConfigInvocationHandler(ConfigManager manager)
 	{
 		this.manager = manager;
 	}
 
+	private static String groupValueFromProxy(Class<?> proxyClass)
+	{
+		Class<?> iface = proxyClass.getInterfaces()[0];
+		ConfigGroup group = iface.getAnnotation(ConfigGroup.class);
+		return group == null ? null : group.value();
+	}
+
+	private static String keyNameFromMethod(Method method)
+	{
+		ConfigItem item = method.getAnnotation(ConfigItem.class);
+		return item == null ? null : item.keyName();
+	}
+
 	@Override
 	public Object invoke(Object proxy, Method method, Object[] args) throws Throwable
 	{
-		Class<?> iface = proxy.getClass().getInterfaces()[0];
-
-		ConfigGroup group = iface.getAnnotation(ConfigGroup.class);
-		ConfigItem item = method.getAnnotation(ConfigItem.class);
-
-		if (group == null)
+		String itemKeyName, groupValue;
+		try
+		{
+			groupValue = groupValueCache.computeIfAbsent(proxy.getClass(), ConfigInvocationHandler::groupValueFromProxy);
+		}
+		catch (NullPointerException e)
 		{
 			log.warn("Configuration proxy class {} has no @ConfigGroup!", proxy.getClass());
 			return null;
 		}
 
-		if (item == null)
+		try
+		{
+			itemKeyName = methodKeyNameCache.computeIfAbsent(method, ConfigInvocationHandler::keyNameFromMethod);
+		}
+		catch (NullPointerException e)
 		{
 			log.warn("Configuration method {} has no @ConfigItem!", method);
 			return null;
@@ -64,34 +87,43 @@ class ConfigInvocationHandler implements InvocationHandler
 		if (args == null)
 		{
 			// Getting configuration item
-			String value = manager.getConfiguration(group.value(), item.keyName());
-
-			if (value == null)
+			return manager.getConfigObjectFromCacheOrElse(groupValue, itemKeyName, (value) ->
 			{
-				if (method.isDefault())
+				try
 				{
-					return callDefaultMethod(proxy, method, null);
+					value = manager.getConfiguration(value);
+					if (value == null)
+					{
+						if (method.isDefault())
+						{
+							return callDefaultMethod(proxy, method, null);
+						}
+						return null;
+					}
+
+					// Convert value to return type
+					Class<?> returnType = method.getReturnType();
+
+					try
+					{
+						return ConfigManager.stringToObject(value, returnType);
+					}
+					catch (Exception e)
+					{
+						log.warn("Unable to unmarshal {}.{} ", groupValue, itemKeyName, e);
+						if (method.isDefault())
+						{
+							return callDefaultMethod(proxy, method, null);
+						}
+						return null;
+					}
 				}
-
-				return null;
-			}
-
-			// Convert value to return type
-			Class<?> returnType = method.getReturnType();
-			
-			try
-			{
-				return ConfigManager.stringToObject(value, returnType);
-			}
-			catch (Exception e)
-			{
-				log.warn("Unable to unmarshal {}.{} ", group.value(), item.keyName(), e);
-				if (method.isDefault())
+				catch (Throwable throwable)
 				{
-					return callDefaultMethod(proxy, method, null);
+					log.error("Unable to resolve configuration value {}.{}", groupValue, itemKeyName, throwable);
+					return null;
 				}
-				return null;
-			}
+			});
 		}
 		else
 		{
@@ -99,13 +131,13 @@ class ConfigInvocationHandler implements InvocationHandler
 
 			if (args.length != 1)
 			{
-				throw new RuntimeException("Invalid number of arguents to configuration method");
+				throw new RuntimeException("Invalid number of arguments to configuration method");
 			}
 
 			Object newValue = args[0];
 
 			Class<?> type = method.getParameterTypes()[0];
-			Object oldValue = manager.getConfiguration(group.value(), item.keyName(), type);
+			Object oldValue = manager.getConfiguration(groupValue, itemKeyName, type);
 
 			if (Objects.equals(oldValue, newValue))
 			{
@@ -120,19 +152,19 @@ class ConfigInvocationHandler implements InvocationHandler
 				if (Objects.equals(newValue, defaultValue))
 				{
 					// Just unset if it goes back to the default
-					manager.unsetConfiguration(group.value(), item.keyName());
+					manager.unsetConfiguration(groupValue, itemKeyName);
 					return null;
 				}
 			}
 
 			if (newValue == null)
 			{
-				manager.unsetConfiguration(group.value(), item.keyName());
+				manager.unsetConfiguration(groupValue, itemKeyName);
 			}
 			else
 			{
 				String newValueStr = ConfigManager.objectToString(newValue);
-				manager.setConfiguration(group.value(), item.keyName(), newValueStr);
+				manager.setConfiguration(groupValue, itemKeyName, newValueStr);
 			}
 			return null;
 		}

--- a/runelite-client/src/main/java/net/runelite/client/config/ConfigManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/ConfigManager.java
@@ -45,12 +45,13 @@ import java.nio.channels.FileLock;
 import java.nio.charset.Charset;
 import java.time.Instant;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.HashMap;
 import java.util.Objects;
 import java.util.Properties;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.function.Function;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
@@ -81,6 +82,7 @@ public class ConfigManager
 
 	private final ConfigInvocationHandler handler = new ConfigInvocationHandler(this);
 	private final Properties properties = new Properties();
+	private final Map<String, Object> configObjectCache = new HashMap<>();
 	private final Map<String, String> pendingChanges = new HashMap<>();
 
 	@Inject
@@ -249,6 +251,20 @@ public class ConfigManager
 		}
 	}
 
+	// Attempts to fetch the config value from the cache if present. Otherwise it calls the get value function and caches the result
+	Object getConfigObjectFromCacheOrElse(String groupName, String key, Function<String, Object> getValue)
+	{
+		String configItemKey = groupName + "." + key;
+		return configObjectCache.computeIfAbsent(configItemKey, getValue);
+	}
+
+	// Posts the configchanged event to the event bus and remove the changed key from the cache
+	private void postConfigChanged(ConfigChanged configChanged)
+	{
+		configObjectCache.remove(configChanged.getGroup() + "." + configChanged.getKey());
+		eventBus.post(configChanged);
+	}
+
 	public <T> T getConfig(Class<T> clazz)
 	{
 		if (!Modifier.isPublic(clazz.getModifiers()))
@@ -272,6 +288,11 @@ public class ConfigManager
 	public String getConfiguration(String groupName, String key)
 	{
 		return properties.getProperty(groupName + "." + key);
+	}
+
+	public String getConfiguration(String propertyKey)
+	{
+		return properties.getProperty(propertyKey);
 	}
 
 	public <T> T getConfiguration(String groupName, String key, Class<T> clazz)
@@ -326,7 +347,7 @@ public class ConfigManager
 		configChanged.setOldValue(oldValue);
 		configChanged.setNewValue(value);
 
-		eventBus.post(configChanged);
+		postConfigChanged(configChanged);
 	}
 
 	public void setConfiguration(String groupName, String key, Object value)


### PR DESCRIPTION
I added caching for resolving the annotation values of config classes in the config invocation handler and also added caching for getting the value of a config entry to minimize the amount of stringToObject and callDefaultMethod calls. 