### PR TITLE
Add bank filter by price range

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/banktags/BankTagsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/banktags/BankTagsConfig.java
@@ -87,10 +87,10 @@ public interface BankTagsConfig extends Config
 	}
 
 	@ConfigItem(
-			keyName = "minimumValue",
-			name = "Minimum price",
-			description = "Configures the minimum value of the bank item to show",
-			position = 6
+		keyName = "minimumValue",
+		name = "Minimum price",
+		description = "Configures the minimum value of the bank item to show",
+		position = 6
 	)
 	default int lowValuePrice()
 	{
@@ -98,10 +98,10 @@ public interface BankTagsConfig extends Config
 	}
 
 	@ConfigItem(
-			keyName = "maximumValue",
-			name = "Maximum price",
-			description = "Configures the maximum value of the bank item to show",
-			position = 7
+		keyName = "maximumValue",
+		name = "Maximum price",
+		description = "Configures the maximum value of the bank item to show",
+		position = 7
 	)
 	default int highValuePrice()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/banktags/BankTagsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/banktags/BankTagsConfig.java
@@ -54,6 +54,61 @@ public interface BankTagsConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "priceFilter",
+		name = "Filter by price",
+		description = "Enable hiding of items not within given price range.",
+		position = 3
+	)
+	default boolean priceFilter()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		keyName = "highAlchemyPrice",
+		name = "Filter by HA value",
+		description = "Enable filtering by HA value.",
+		position = 4
+	)
+	default boolean filterHAValue()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		keyName = "rememberTab",
+		name = "Filter by GE value",
+		description = "Enable filtering by GE value.",
+		position = 5
+	)
+	default boolean filterGEValue()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+			keyName = "minimumValue",
+			name = "Minimum price",
+			description = "Configures the minimum value of the bank item to show",
+			position = 6
+	)
+	default int lowValuePrice()
+	{
+		return 20000;
+	}
+
+	@ConfigItem(
+			keyName = "maximumValue",
+			name = "Maximum price",
+			description = "Configures the maximum value of the bank item to show",
+			position = 7
+	)
+	default int highValuePrice()
+	{
+		return 1000000;
+	}
+
+	@ConfigItem(
 		keyName = "position",
 		name = "",
 		description = "",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/banktags/BankTagsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/banktags/BankTagsPlugin.java
@@ -90,6 +90,7 @@ public class BankTagsPlugin extends Plugin implements MouseWheelListener, KeyLis
 	private static final String EDIT_TAGS_MENU_OPTION = "Edit-tags";
 	public static final String ICON_SEARCH = "icon_";
 	public static final String VAR_TAG_SUFFIX = "*";
+	public static final String PRICE_FILTER = "pricefilter";
 
 	private static final String SEARCH_BANK_INPUT_TEXT =
 		"Show items whose names or tags contain the following text:<br>" +
@@ -204,6 +205,21 @@ public class BankTagsPlugin extends Plugin implements MouseWheelListener, KeyLis
 				else if (!tagSearch)
 				{
 					intStack[intStackSize - 2] = itemName.contains(search) ? 1 : 0;
+				}
+
+				if (config.priceFilter()) {
+					if (search.equals(PRICE_FILTER)) {
+						intStack[intStackSize - 2] = 1;
+					}
+					if (intStack[intStackSize - 2] == 1) {
+						ItemContainer container = client.getItemContainer(InventoryID.BANK);
+						if (container != null) {
+							for (Item item : container.getItems()) {
+								if (item.getId() != itemId) continue;
+								intStack[intStackSize - 2] = tagManager.itemWithinPriceRange(item) ? 1 : 0;
+							}
+						}
+					}
 				}
 				break;
 			case "getSearchingTagTab":
@@ -334,6 +350,10 @@ public class BankTagsPlugin extends Plugin implements MouseWheelListener, KeyLis
 			{
 				clientThread.invokeLater(tabInterface::destroy);
 			}
+		}
+		if (configChanged.getGroup().equals("banktags") && configChanged.getKey().equals("priceFilter"))
+		{
+			bankSearch.reset(true);
 		}
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/banktags/BankTagsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/banktags/BankTagsPlugin.java
@@ -54,6 +54,7 @@ import net.runelite.api.events.MenuEntryAdded;
 import net.runelite.api.events.MenuOptionClicked;
 import net.runelite.api.events.ScriptCallbackEvent;
 import net.runelite.api.events.WidgetLoaded;
+import net.runelite.api.events.ItemContainerChanged;
 import net.runelite.api.vars.InputType;
 import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetID;
@@ -101,6 +102,9 @@ public class BankTagsPlugin extends Plugin implements MouseWheelListener, KeyLis
 
 	@Inject
 	private ItemManager itemManager;
+
+	@Inject
+    private ItemContainer itemContainer;
 
 	@Inject
 	private Client client;
@@ -212,9 +216,8 @@ public class BankTagsPlugin extends Plugin implements MouseWheelListener, KeyLis
 						intStack[intStackSize - 2] = 1;
 					}
 					if (intStack[intStackSize - 2] == 1) {
-						ItemContainer container = client.getItemContainer(InventoryID.BANK);
-						if (container != null) {
-							for (Item item : container.getItems()) {
+						if (itemContainer != null) {
+							for (Item item : itemContainer.getItems()) {
 								if (item.getId() != itemId) continue;
 								intStack[intStackSize - 2] = tagManager.itemWithinPriceRange(item) ? 1 : 0;
 							}
@@ -385,6 +388,12 @@ public class BankTagsPlugin extends Plugin implements MouseWheelListener, KeyLis
 		{
 			shiftPressed = false;
 		}
+	}
+
+	@Subscribe
+    public void onItemContainerChanged(ItemContainerChanged itemContainerChanged)
+    {
+        itemContainer = client.getItemContainer(InventoryID.BANK);
 	}
 
 	@Override

--- a/runelite-client/src/main/java/net/runelite/client/plugins/banktags/TagManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/banktags/TagManager.java
@@ -66,10 +66,10 @@ public class TagManager
 
 	@Inject
 	private TagManager(
-			final ItemManager itemManager,
-			final ConfigManager configManager,
-			final ClueScrollService clueScrollService,
-			final BankTagsConfig config)
+		final ItemManager itemManager,
+		final ConfigManager configManager,
+		final ClueScrollService clueScrollService,
+		final BankTagsConfig config)
 	{
 		this.itemManager = itemManager;
 		this.configManager = configManager;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/banktags/tabs/TabInterface.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/banktags/tabs/TabInterface.java
@@ -80,7 +80,6 @@ import net.runelite.client.game.ItemManager;
 import net.runelite.client.game.chatbox.ChatboxPanelManager;
 import net.runelite.client.plugins.banktags.BankTagsConfig;
 import net.runelite.client.plugins.banktags.BankTagsPlugin;
-import net.runelite.client.plugins.banktags.TagManager;
 import static net.runelite.client.plugins.banktags.BankTagsPlugin.CONFIG_GROUP;
 import static net.runelite.client.plugins.banktags.BankTagsPlugin.ICON_SEARCH;
 import static net.runelite.client.plugins.banktags.BankTagsPlugin.SPLITTER;
@@ -89,6 +88,7 @@ import static net.runelite.client.plugins.banktags.BankTagsPlugin.VAR_TAG_SUFFIX
 import static net.runelite.client.plugins.banktags.BankTagsPlugin.PRICE_FILTER;
 import static net.runelite.client.plugins.banktags.tabs.MenuIndexes.NewTab;
 import static net.runelite.client.plugins.banktags.tabs.MenuIndexes.Tab;
+import net.runelite.client.plugins.banktags.TagManager;
 import net.runelite.client.ui.JagexColors;
 import net.runelite.client.util.ColorUtil;
 import net.runelite.client.util.Text;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/banktags/tabs/TabInterface.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/banktags/tabs/TabInterface.java
@@ -80,12 +80,13 @@ import net.runelite.client.game.ItemManager;
 import net.runelite.client.game.chatbox.ChatboxPanelManager;
 import net.runelite.client.plugins.banktags.BankTagsConfig;
 import net.runelite.client.plugins.banktags.BankTagsPlugin;
+import net.runelite.client.plugins.banktags.TagManager;
 import static net.runelite.client.plugins.banktags.BankTagsPlugin.CONFIG_GROUP;
 import static net.runelite.client.plugins.banktags.BankTagsPlugin.ICON_SEARCH;
 import static net.runelite.client.plugins.banktags.BankTagsPlugin.SPLITTER;
 import static net.runelite.client.plugins.banktags.BankTagsPlugin.TAG_SEARCH;
 import static net.runelite.client.plugins.banktags.BankTagsPlugin.VAR_TAG_SUFFIX;
-import net.runelite.client.plugins.banktags.TagManager;
+import static net.runelite.client.plugins.banktags.BankTagsPlugin.PRICE_FILTER;
 import static net.runelite.client.plugins.banktags.tabs.MenuIndexes.NewTab;
 import static net.runelite.client.plugins.banktags.tabs.MenuIndexes.Tab;
 import net.runelite.client.ui.JagexColors;
@@ -445,10 +446,15 @@ public class TabInterface
 		if (bankTitle != null && !bankTitle.isHidden() && !str.startsWith(TAG_SEARCH))
 		{
 			str = bankTitle.getText().replaceFirst("Showing items: ", "");
+			boolean isSearchOpen = client.getVar(VarClientInt.INPUT_TYPE) == InputType.SEARCH.getType();
 
 			if (str.startsWith("Tab "))
 			{
 				str = "";
+			}
+			else if (config.priceFilter() && !isSearchOpen)
+			{
+				str = PRICE_FILTER;
 			}
 		}
 
@@ -461,6 +467,9 @@ public class TabInterface
 		else
 		{
 			activateTab(null);
+			if (str.equals(PRICE_FILTER)) {
+				bankSearch.search(InputType.SEARCH, PRICE_FILTER, false);
+			}
 		}
 
 		updateBounds();


### PR DESCRIPTION
#6778 

Option to filter by GE or HA price
Ability to set price range
Hides items in bank not within price range when doing any bank filtering, including with tags
When active, if no filter is being applied, automatically applies a "pricefilter" search to begin filtering items
    If user opens search box, this filter is disabled (bug: requires spam clicking to open search box if on All items tab)

Mostly due to my lack of knowledge of how the bank filtering works, I've spent the last couple days working on this plugin, hoping for some feedback especially on where I should be calling banksearch.search() so the bug doesn't occur.