### PR TITLE
xp drop on a set tick for efficient skilling

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/ScriptID.java
+++ b/runelite-api/src/main/java/net/runelite/api/ScriptID.java
@@ -97,4 +97,14 @@ public final class ScriptID
 	 * Send a private message.
 	 */
 	public static final int PRIVMSG = 10004;
+
+	/**
+	 * Creates a disabled experience drop
+	 *
+	 * <ul>
+	 * <li>int (Skill ordinal) Sets what icon to use</li>
+	 * <li>int Amount of exp to drop</li>
+	 * </ul>
+	 */
+	public static final int XPDROP_DISABLED = 2091;
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/experiencedrop/XpDropConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/experiencedrop/XpDropConfig.java
@@ -75,4 +75,16 @@ public interface XpDropConfig extends Config
 	{
 		return new Color(0x15, 0x80, 0xAD);
 	}
+
+	@ConfigItem(
+		keyName = "fakeXpDropDelay",
+		name = "Fake Xp Drop delay",
+		description = "Configures how many ticks should pass between fake XP drops, 0 to disable",
+		position = 4
+	)
+	default int fakeXpDropDelay()
+	{
+		return 0;
+	}
+
 }


### PR DESCRIPTION
    new file:   runelite-client/src/main/java/net/runelite/client/plugins/fakexpdrop/FakeXpDrop.java
    new file:   runelite-client/src/main/java/net/runelite/client/plugins/fakexpdrop/FakeXpDropConfiguration.java
Enable fake xp drops on given tick to help with timing in efficient skilling as suggested by #6840. Defaults to disabled.

Closes #6840