### PR TITLE
Fix freeze on disabling GPU plugin

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/GameEngine.java
+++ b/runelite-api/src/main/java/net/runelite/api/GameEngine.java
@@ -53,4 +53,6 @@ public interface GameEngine
 	boolean isClientThread();
 
 	void resizeCanvas();
+
+	void setReplaceCanvasNextFrame(boolean replace);
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuPlugin.java
@@ -420,6 +420,8 @@ public class GpuPlugin extends Plugin implements DrawCallbacks
 
 			// force main buffer provider rebuild to turn off alpha channel
 			client.resizeCanvas();
+
+			client.setReplaceCanvasNextFrame(true);
 		});
 	}
 


### PR DESCRIPTION
Fixes #6524 

Not gonna lie, I don't really know what I'm doing here because there doesn't seem to be a way to see exactly what setReplaceCanvasNextFrame() does other than inferring from its name, but this fixes the issue I was having by calling setReplaceCanvasNextFrame(true) on shutdown of the GPU plugin.