### PR TITLE
OverlayRenderer: Prevent overlays rendering if fullscreen map is open

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/widgets/WidgetID.java
+++ b/runelite-api/src/main/java/net/runelite/api/widgets/WidgetID.java
@@ -124,6 +124,7 @@ public class WidgetID
 	public static final int LOOTING_BAG_GROUP_ID = 81;
 	public static final int SKOTIZO_GROUP_ID = 308;
 	public static final int ENTERING_HOUSE_GROUP_ID = 71;
+	public static final int FULLSCREEN_MAP_GROUP_ID = 165;
 
 	static class WorldMap
 	{
@@ -739,5 +740,10 @@ public class WidgetID
 	static class Skotizo
 	{
 		static final int CONTAINER = 3;
+	}
+
+	static class FullScreenMap
+	{
+		static final int ROOT = 25;
 	}
 }

--- a/runelite-api/src/main/java/net/runelite/api/widgets/WidgetInfo.java
+++ b/runelite-api/src/main/java/net/runelite/api/widgets/WidgetInfo.java
@@ -460,7 +460,9 @@ public enum WidgetInfo
 
 	LOOTING_BAG_CONTAINER(WidgetID.LOOTING_BAG_GROUP_ID, WidgetID.LootingBag.LOOTING_BAG_INVENTORY),
 
-	SKOTIZO_CONTAINER(WidgetID.SKOTIZO_GROUP_ID, WidgetID.Skotizo.CONTAINER);
+	SKOTIZO_CONTAINER(WidgetID.SKOTIZO_GROUP_ID, WidgetID.Skotizo.CONTAINER),
+
+	FULLSCREEN_MAP_ROOT(WidgetID.FULLSCREEN_MAP_GROUP_ID, WidgetID.FullScreenMap.ROOT);
 
 	private final int groupId;
 	private final int childId;

--- a/runelite-client/src/main/java/net/runelite/client/callback/Hooks.java
+++ b/runelite-client/src/main/java/net/runelite/client/callback/Hooks.java
@@ -411,6 +411,7 @@ public class Hooks implements Callbacks
 		try
 		{
 			renderer.render(graphics2d, OverlayLayer.ABOVE_WIDGETS);
+			renderer.render(graphics2d, OverlayLayer.ABOVE_MAP);
 		}
 		catch (Exception ex)
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/devtools/WorldMapLocationOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/devtools/WorldMapLocationOverlay.java
@@ -56,7 +56,7 @@ public class WorldMapLocationOverlay extends Overlay
 		this.plugin = plugin;
 		setPosition(OverlayPosition.DYNAMIC);
 		setPriority(OverlayPriority.HIGH);
-		setLayer(OverlayLayer.ALWAYS_ON_TOP);
+		setLayer(OverlayLayer.ABOVE_MAP);
 	}
 
 	@Override

--- a/runelite-client/src/main/java/net/runelite/client/plugins/devtools/WorldMapRegionOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/devtools/WorldMapRegionOverlay.java
@@ -56,7 +56,7 @@ class WorldMapRegionOverlay extends Overlay
 	{
 		setPosition(OverlayPosition.DYNAMIC);
 		setPriority(OverlayPriority.HIGH);
-		setLayer(OverlayLayer.ALWAYS_ON_TOP);
+		setLayer(OverlayLayer.ABOVE_MAP);
 		this.client = client;
 		this.plugin = plugin;
 	}

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayLayer.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayLayer.java
@@ -45,4 +45,9 @@ public enum OverlayLayer
 	 * Render overlay above all game elements
 	 */
 	ALWAYS_ON_TOP,
+
+	/**
+	 * Render over the map, even when it's fullscreen
+	 */
+	ABOVE_MAP,
 }

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayRenderer.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayRenderer.java
@@ -104,6 +104,13 @@ public class OverlayRenderer extends MouseAdapter implements KeyListener
 
 	public void render(Graphics2D graphics, final OverlayLayer layer)
 	{
+		if (layer != OverlayLayer.ABOVE_MAP
+			&& client.getWidget(WidgetInfo.FULLSCREEN_MAP_ROOT) != null
+			&& !client.getWidget(WidgetInfo.FULLSCREEN_MAP_ROOT).isHidden())
+		{
+			return;
+		}
+
 		final List<Overlay> overlays = overlayManager.getLayer(layer);
 
 		if (overlays == null

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/worldmap/WorldMapOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/worldmap/WorldMapOverlay.java
@@ -69,7 +69,7 @@ public class WorldMapOverlay extends Overlay
 		this.worldMapPointManager = worldMapPointManager;
 		setPosition(OverlayPosition.DYNAMIC);
 		setPriority(OverlayPriority.HIGHEST);
-		setLayer(OverlayLayer.ABOVE_WIDGETS);
+		setLayer(OverlayLayer.ABOVE_MAP);
 		mouseManager.registerMouseListener(worldMapOverlayMouseListener);
 	}
 


### PR DESCRIPTION
Skips all overlays that aren't map related if the fullscreen map is open. 

Closes #5851