### PR TITLE
Add cache control to more API endpoints

### DIFF
--- a/http-service/src/main/java/net/runelite/http/service/CacheControlFilter.java
+++ b/http-service/src/main/java/net/runelite/http/service/CacheControlFilter.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2017, Adam <Adam@sigterm.info>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.http.service;
+
+
+import org.springframework.web.filter.OncePerRequestFilter;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class CacheControlFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response, FilterChain filterChain)  throws ServletException, IOException {
+
+        if (!response.containsHeader("Cache-Control"))
+        {
+            response.addHeader("Cache-Control", "no-cache, no-store, must-revalidate");
+            response.addHeader("pragma", "no-cache");
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/http-service/src/main/java/net/runelite/http/service/examine/ExamineService.java
+++ b/http-service/src/main/java/net/runelite/http/service/examine/ExamineService.java
@@ -123,7 +123,7 @@ public class ExamineService
 			if (entry != null)
 			{
 				return ResponseEntity.ok()
-					.cacheControl(CacheControl.maxAge(10, TimeUnit.DAYS).cachePublic())
+					.cacheControl(CacheControl.maxAge(30, TimeUnit.MINUTES).cachePublic())
 					.body(entry.getText());
 			}
 		}

--- a/http-service/src/main/java/net/runelite/http/service/examine/ExamineService.java
+++ b/http-service/src/main/java/net/runelite/http/service/examine/ExamineService.java
@@ -26,6 +26,8 @@ package net.runelite.http.service.examine;
 
 import java.sql.Timestamp;
 import java.time.Instant;
+import java.util.concurrent.TimeUnit;
+
 import static net.runelite.http.service.examine.ExamineType.ITEM;
 import static net.runelite.http.service.examine.ExamineType.NPC;
 import static net.runelite.http.service.examine.ExamineType.OBJECT;
@@ -33,6 +35,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.CacheControl;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -71,19 +75,19 @@ public class ExamineService
 	}
 
 	@RequestMapping("/npc/{id}")
-	public String getNpc(@PathVariable int id)
+	public ResponseEntity<String> getNpc(@PathVariable int id)
 	{
 		return get(NPC, id);
 	}
 
 	@RequestMapping("/object/{id}")
-	public String getObject(@PathVariable int id)
+	public ResponseEntity<String> getObject(@PathVariable int id)
 	{
 		return get(OBJECT, id);
 	}
 
 	@RequestMapping("/item/{id}")
-	public String getItem(@PathVariable int id)
+	public ResponseEntity<String> getItem(@PathVariable int id)
 	{
 		return get(ITEM, id);
 	}
@@ -106,7 +110,7 @@ public class ExamineService
 		insert(ITEM, id, examine);
 	}
 
-	private String get(ExamineType type, int id)
+	private ResponseEntity<String> get(ExamineType type, int id)
 	{
 		try (Connection con = sql2o.open())
 		{
@@ -118,11 +122,13 @@ public class ExamineService
 
 			if (entry != null)
 			{
-				return entry.getText();
+				return ResponseEntity.ok()
+					.cacheControl(CacheControl.maxAge(10, TimeUnit.DAYS).cachePublic())
+					.body(entry.getText());
 			}
 		}
 
-		return null;
+		return ResponseEntity.notFound().build();
 	}
 
 	private void insert(ExamineType type, int id, String examine)

--- a/http-service/src/main/java/net/runelite/http/service/hiscore/HiscoreController.java
+++ b/http-service/src/main/java/net/runelite/http/service/hiscore/HiscoreController.java
@@ -25,6 +25,8 @@
 package net.runelite.http.service.hiscore;
 
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
 import net.runelite.http.api.hiscore.HiscoreEndpoint;
 import net.runelite.http.api.hiscore.HiscoreResult;
 import net.runelite.http.api.hiscore.HiscoreSkill;
@@ -33,6 +35,8 @@ import net.runelite.http.api.hiscore.Skill;
 import net.runelite.http.service.util.HiscoreEndpointEditor;
 import net.runelite.http.service.xp.XpTrackerService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.CacheControl;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.WebDataBinder;
 import org.springframework.web.bind.annotation.InitBinder;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -51,7 +55,7 @@ public class HiscoreController
 	private XpTrackerService xpTrackerService;
 
 	@RequestMapping("/{endpoint}")
-	public HiscoreResult lookup(@PathVariable HiscoreEndpoint endpoint, @RequestParam String username) throws ExecutionException
+	public ResponseEntity<HiscoreResult> lookup(@PathVariable HiscoreEndpoint endpoint, @RequestParam String username) throws ExecutionException
 	{
 		HiscoreResult result = hiscoreService.lookupUsername(username, endpoint);
 
@@ -65,11 +69,13 @@ public class HiscoreController
 				xpTrackerService.update(username, result);
 		}
 
-		return result;
+		return ResponseEntity.ok()
+				.cacheControl(CacheControl.maxAge(2, TimeUnit.MINUTES).cachePublic())
+				.body(result);
 	}
 
 	@RequestMapping("/{endpoint}/{skillName}")
-	public SingleHiscoreSkillResult singleSkillLookup(@PathVariable HiscoreEndpoint endpoint, @PathVariable String skillName, @RequestParam String username) throws ExecutionException
+	public ResponseEntity<SingleHiscoreSkillResult> singleSkillLookup(@PathVariable HiscoreEndpoint endpoint, @PathVariable String skillName, @RequestParam String username) throws ExecutionException
 	{
 		HiscoreSkill skill = HiscoreSkill.valueOf(skillName.toUpperCase());
 
@@ -84,7 +90,9 @@ public class HiscoreController
 		skillResult.setSkillName(skillName);
 		skillResult.setSkill(requested);
 
-		return skillResult;
+		return ResponseEntity.ok()
+				.cacheControl(CacheControl.maxAge(2, TimeUnit.MINUTES).cachePublic())
+				.body(skillResult);
 	}
 
 	@InitBinder

--- a/http-service/src/main/java/net/runelite/http/service/hiscore/HiscoreController.java
+++ b/http-service/src/main/java/net/runelite/http/service/hiscore/HiscoreController.java
@@ -70,7 +70,7 @@ public class HiscoreController
 		}
 
 		return ResponseEntity.ok()
-				.cacheControl(CacheControl.maxAge(2, TimeUnit.MINUTES).cachePublic())
+				.cacheControl(CacheControl.maxAge(10, TimeUnit.MINUTES).cachePublic())
 				.body(result);
 	}
 
@@ -91,7 +91,7 @@ public class HiscoreController
 		skillResult.setSkill(requested);
 
 		return ResponseEntity.ok()
-				.cacheControl(CacheControl.maxAge(2, TimeUnit.MINUTES).cachePublic())
+				.cacheControl(CacheControl.maxAge(10, TimeUnit.MINUTES).cachePublic())
 				.body(skillResult);
 	}
 

--- a/http-service/src/main/java/net/runelite/http/service/item/ItemController.java
+++ b/http-service/src/main/java/net/runelite/http/service/item/ItemController.java
@@ -100,7 +100,7 @@ public class ItemController
 		if (item != null && item.getIcon() != null)
 		{
 			return ResponseEntity.ok()
-				.cacheControl(CacheControl.maxAge(1, TimeUnit.DAYS).cachePublic())
+				.cacheControl(CacheControl.maxAge(30, TimeUnit.MINUTES).cachePublic())
 				.body(item.getIcon());
 		}
 
@@ -115,7 +115,7 @@ public class ItemController
 		if (item != null && item.getIcon_large() != null)
 		{
 			return ResponseEntity.ok()
-				.cacheControl(CacheControl.maxAge(1, TimeUnit.DAYS).cachePublic())
+				.cacheControl(CacheControl.maxAge(30, TimeUnit.MINUTES).cachePublic())
 				.body(item.getIcon_large());
 		}
 

--- a/http-service/src/main/java/net/runelite/http/service/item/ItemController.java
+++ b/http-service/src/main/java/net/runelite/http/service/item/ItemController.java
@@ -79,12 +79,14 @@ public class ItemController
 	}
 
 	@RequestMapping("/{itemId}")
-	public Item getItem(HttpServletResponse response, @PathVariable int itemId)
+	public ResponseEntity<Item> getItem(HttpServletResponse response, @PathVariable int itemId)
 	{
 		ItemEntry item = itemService.getItem(itemId);
 		if (item != null)
 		{
-			return item.toItem();
+			return ResponseEntity.ok()
+				.cacheControl(CacheControl.maxAge(30, TimeUnit.MINUTES).cachePublic())
+				.body(item.toItem());
 		}
 
 		itemService.queueItem(itemId);
@@ -97,7 +99,9 @@ public class ItemController
 		ItemEntry item = itemService.getItem(itemId);
 		if (item != null && item.getIcon() != null)
 		{
-			return ResponseEntity.ok(item.getIcon());
+			return ResponseEntity.ok()
+				.cacheControl(CacheControl.maxAge(1, TimeUnit.DAYS).cachePublic())
+				.body(item.getIcon());
 		}
 
 		itemService.queueItem(itemId);
@@ -110,7 +114,9 @@ public class ItemController
 		ItemEntry item = itemService.getItem(itemId);
 		if (item != null && item.getIcon_large() != null)
 		{
-			return ResponseEntity.ok(item.getIcon_large());
+			return ResponseEntity.ok()
+				.cacheControl(CacheControl.maxAge(1, TimeUnit.DAYS).cachePublic())
+				.body(item.getIcon_large());
 		}
 
 		itemService.queueItem(itemId);

--- a/http-service/src/main/java/net/runelite/http/service/kc/KillCountController.java
+++ b/http-service/src/main/java/net/runelite/http/service/kc/KillCountController.java
@@ -29,6 +29,8 @@ import com.google.common.cache.CacheBuilder;
 import java.util.concurrent.TimeUnit;
 import net.runelite.http.service.util.exception.NotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.CacheControl;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -60,7 +62,7 @@ public class KillCountController
 	}
 
 	@GetMapping
-	public int get(@RequestParam String name, @RequestParam String boss)
+	public ResponseEntity<Integer> get(@RequestParam String name, @RequestParam String boss)
 	{
 		Integer kc = cache.getIfPresent(new KillCountKey(name, boss));
 		if (kc == null)
@@ -76,6 +78,8 @@ public class KillCountController
 		{
 			throw new NotFoundException();
 		}
-		return kc;
+		return ResponseEntity.ok()
+			.cacheControl(CacheControl.maxAge(2, TimeUnit.MINUTES).cachePublic())
+			.body(kc);
 	}
 }

--- a/http-service/src/main/java/net/runelite/http/service/sprite/SpriteController.java
+++ b/http-service/src/main/java/net/runelite/http/service/sprite/SpriteController.java
@@ -30,6 +30,7 @@ import com.google.common.cache.LoadingCache;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.CacheControl;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -67,6 +68,6 @@ public class SpriteController
 			return ResponseEntity.notFound().build();
 		}
 
-		return ResponseEntity.ok(data);
+		return ResponseEntity.ok().cacheControl(CacheControl.maxAge(8, TimeUnit.HOURS).cachePublic()).body(data);
 	}
 }

--- a/http-service/src/main/java/net/runelite/http/service/util/CacheControlFilter.java
+++ b/http-service/src/main/java/net/runelite/http/service/util/CacheControlFilter.java
@@ -22,28 +22,41 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package net.runelite.http.service;
+package net.runelite.http.service.util;
 
+import org.springframework.core.MethodParameter;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
 
-import org.springframework.web.filter.OncePerRequestFilter;
-import javax.servlet.FilterChain;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import java.io.IOException;
+@ControllerAdvice
+public class CacheControlFilter implements ResponseBodyAdvice<Object>
+{
 
-public class CacheControlFilter extends OncePerRequestFilter {
+	@Override
+	public boolean supports(MethodParameter returnType, Class<? extends HttpMessageConverter<?>> converterType)
+	{
+		return true;
+	}
 
-    @Override
-    protected void doFilterInternal(HttpServletRequest request,
-                                    HttpServletResponse response, FilterChain filterChain)  throws ServletException, IOException {
-
-        if (!response.containsHeader("Cache-Control"))
-        {
-            response.addHeader("Cache-Control", "no-cache, no-store, must-revalidate");
-            response.addHeader("pragma", "no-cache");
-        }
-
-        filterChain.doFilter(request, response);
-    }
+	@Override
+	public Object beforeBodyWrite(
+			Object body,
+			MethodParameter returnType,
+			MediaType selectedContentType,
+			Class<? extends HttpMessageConverter<?>> selectedConverterType,
+			ServerHttpRequest request,
+			ServerHttpResponse response
+	)
+	{
+		if (!response.getHeaders().containsKey("Cache-Control"))
+		{
+			response.getHeaders().add("Cache-Control", "no-cache, no-store, must-revalidate");
+			response.getHeaders().add("pragma", "no-cache");
+		}
+		return body;
+	}
 }

--- a/http-service/src/main/webapp/WEB-INF/web.xml
+++ b/http-service/src/main/webapp/WEB-INF/web.xml
@@ -29,4 +29,13 @@
 	 version="3.1">
 
 	<display-name>RuneLite API</display-name>
+
+	<filter>
+		<filter-name>cacheControlFilter</filter-name>
+		<filter-class>net.runelite.http.service.CacheControlFilter</filter-class>
+	</filter>
+	<filter-mapping>
+		<filter-name>cacheControlFilter</filter-name>
+		<url-pattern>/*</url-pattern>
+	</filter-mapping>
 </web-app>


### PR DESCRIPTION
Adding cache control to a few more API endpoints. I realize there's already some caching built into some of these endpoints but this will allow CloudFlare to cache it on the edge layer.