### PR TITLE
Fix Item Stats overlay with null equipement container

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatOverlay.java
@@ -31,6 +31,7 @@ import java.awt.Graphics2D;
 import net.runelite.api.Client;
 import net.runelite.api.InventoryID;
 import net.runelite.api.Item;
+import net.runelite.api.ItemContainer;
 import net.runelite.api.MenuEntry;
 import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetInfo;
@@ -186,9 +187,10 @@ public class ItemStatOverlay extends Overlay
 		ItemStats other = null;
 		final ItemEquipmentStats currentEquipment = s.getEquipment();
 
-		if (s.isEquipable() && currentEquipment != null)
+		ItemContainer c = client.getItemContainer(InventoryID.EQUIPMENT);
+		if (s.isEquipable() && currentEquipment != null && c != null)
 		{
-			final Item[] items = client.getItemContainer(InventoryID.EQUIPMENT).getItems();
+			final Item[] items = c.getItems();
 
 			if (currentEquipment.getSlot() != -1 && currentEquipment.getSlot() < items.length)
 			{


### PR DESCRIPTION
Fix the Item Stats overlay null pointer exception when item container is null.

Before:
![2018-12-12_23-29-00](https://user-images.githubusercontent.com/29030969/49922569-f62b8780-fe65-11e8-9b91-ef39a2595734.gif)
After:
![2018-12-12_23-31-21](https://user-images.githubusercontent.com/29030969/49922650-2d9a3400-fe66-11e8-92df-7b6e16d52e09.gif)
