### PR TITLE
Have the equipment stats be off by default

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatConfig.java
@@ -49,7 +49,7 @@ public interface ItemStatConfig extends Config
 	)
 	default boolean equipmentStats()
 	{
-		return true;
+		return false;
 	}
 
 	@ConfigItem(


### PR DESCRIPTION
This overlay most likely won't be used by most people and should, therefore, be off by default.