### PR TITLE
Add CC icons to Public Chat & Private Messages

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/clanchat/ClanChatConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/clanchat/ClanChatConfig.java
@@ -104,4 +104,26 @@ public interface ClanChatConfig extends Config
 	{
 		return ClanMemberRank.UNRANKED;
 	}
+
+	@ConfigItem(
+		keyName = "privateMessageIcons",
+		name = "Private Message Icons",
+		description = "Add clan chat rank icons to private messages received from clan mates.",
+		position = 6
+	)
+	default boolean privateMessageIcons()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		keyName = "publicChatIcons",
+		name = "Public Chat Icons",
+		description = "Add clan chat rank icons to public chat messages from clan mates.",
+		position = 7
+	)
+	default boolean publicChatIcons()
+	{
+		return false;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/clanchat/ClanChatPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/clanchat/ClanChatPlugin.java
@@ -353,10 +353,38 @@ public class ClanChatPlugin extends Plugin
 			return;
 		}
 
-		if (chatMessage.getType() == ChatMessageType.CLANCHAT && client.getClanChatCount() > 0)
+		if (client.getClanChatCount() <= 0)
 		{
-			insertClanRankIcon(chatMessage);
+			return;
 		}
+
+		switch (chatMessage.getType())
+		{
+			case PRIVATE_MESSAGE_RECEIVED:
+			case PRIVATE_MESSAGE_RECEIVED_MOD:
+				if (!config.privateMessageIcons())
+				{
+					return;
+				}
+				break;
+			case PUBLIC:
+			case PUBLIC_MOD:
+				if (!config.publicChatIcons())
+				{
+					return;
+				}
+				break;
+			case CLANCHAT:
+				if (!config.clanChatIcons())
+				{
+					return;
+				}
+				break;
+			default:
+				return;
+		}
+
+		insertClanRankIcon(chatMessage);
 	}
 
 	@Subscribe
@@ -431,18 +459,22 @@ public class ClanChatPlugin extends Plugin
 
 	private void insertClanRankIcon(final ChatMessage message)
 	{
-		if (!config.clanChatIcons())
-		{
-			return;
-		}
-
 		final ClanMemberRank rank = clanManager.getRank(message.getName());
 
 		if (rank != null && rank != ClanMemberRank.UNRANKED)
 		{
 			int iconNumber = clanManager.getIconNumber(rank);
-			message.getMessageNode()
-				.setSender(message.getMessageNode().getSender() + " <img=" + iconNumber + ">");
+			final String img = "<img=" + iconNumber + ">";
+			if (message.getType() == ChatMessageType.CLANCHAT)
+			{
+				message.getMessageNode()
+					.setSender(message.getMessageNode().getSender() + " " + img);
+			}
+			else
+			{
+				message.getMessageNode()
+					.setName(img + message.getMessageNode().getName());
+			}
 			client.refreshChat();
 		}
 	}


### PR DESCRIPTION
Updates the Clan Chat plugin to add rank icons to public & private messages. Each feature has a config toggle that is on by default.

![https://i.imgur.com/649Dnh3.png](https://i.imgur.com/649Dnh3.png)
![https://i.imgur.com/aycGkJo.png](https://i.imgur.com/aycGkJo.png)