### PR TITLE
ClientLoader: Sanity check client patch linkage

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/RuneLite.java
+++ b/runelite-client/src/main/java/net/runelite/client/RuneLite.java
@@ -206,18 +206,26 @@ public class RuneLite
 			}
 		});
 
-		final long start = System.currentTimeMillis();
+		try
+		{
+			final long start = System.currentTimeMillis();
 
-		injector = Guice.createInjector(new RuneLiteModule(
-			options.valueOf(updateMode),
-			developerMode));
+			injector = Guice.createInjector(new RuneLiteModule(
+				options.valueOf(updateMode),
+				developerMode));
 
-		injector.getInstance(RuneLite.class).start();
+			injector.getInstance(RuneLite.class).start();
 
-		final long end = System.currentTimeMillis();
-		final RuntimeMXBean rb = ManagementFactory.getRuntimeMXBean();
-		final long uptime = rb.getUptime();
-		log.info("Client initialization took {}ms. Uptime: {}ms", end - start, uptime);
+			final long end = System.currentTimeMillis();
+			final RuntimeMXBean rb = ManagementFactory.getRuntimeMXBean();
+			final long uptime = rb.getUptime();
+			log.info("Client initialization took {}ms. Uptime: {}ms", end - start, uptime);
+		}
+		catch (Exception e)
+		{
+			log.error("Error starting RuneLite", e);
+			System.exit(1);
+		}
 	}
 
 	public void start() throws Exception


### PR DESCRIPTION
If assertions are enabled all runescape classes will be checked to make sure the interfaces in runelite-client are satisfied during startup.