### PR TITLE
Loot tracker average value per kill

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerBox.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerBox.java
@@ -173,6 +173,7 @@ class LootTrackerBox extends JPanel
 		if (kills > 1)
 		{
 			subTitleLabel.setText("x " + kills);
+			priceLabel.setToolTipText(priceLabel.getToolTipText() + " (" + StackFormatter.formatNumber(totalPrice / kills) + " gp ea.)");
 		}
 
 		validate();


### PR DESCRIPTION
Adds the average value per kill to the loot tracker plugin

![screenshot_29](https://user-images.githubusercontent.com/22432233/50042881-a10c9300-006a-11e9-80d9-48cf459edbc3.png)
