### PR TITLE
Dismiss Option

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -261,4 +261,12 @@ public interface MenuEntrySwapperConfig extends Config
 	{
 		return true;
 	}
+
+	@ConfigItem(
+			keyName = "swapDismiss",
+			name = "Dismiss",
+			description = "Swaps the talk-to option to dismiss on all random events apart from the Genie and Dunce."
+	)
+	default boolean swapDismiss() {return false;}
+
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -349,9 +349,17 @@ public class MenuEntrySwapperPlugin extends Plugin
 
 		if (option.equals("talk-to"))
 		{
-			if (config.swapPickpocket() && target.contains("h.a.m."))
-			{
+			if (config.swapPickpocket() && target.contains("h.a.m.")) {
 				swap("pickpocket", option, target, true);
+			}
+
+			if (config.swapDismiss() && target.contains("dunce") || target.contains("genie"))
+			{
+				return;
+			}
+			else
+			{
+				swap("dismiss", option, target, true);
 			}
 
 			if (config.swapAbyssTeleport() && target.contains("mage of zamorak"))


### PR DESCRIPTION
Added to the menu entry swapper. The Dismiss option is now the top option when the Dismiss option is checked (off by default). Applies to every random event other than the Dunce and Genie (xp giving events).