### PR TITLE
Add dismiss swap to menu entry swapper

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -261,4 +261,14 @@ public interface MenuEntrySwapperConfig extends Config
 	{
 		return true;
 	}
+
+	@ConfigItem(
+		keyName = "swapDismiss",
+		name = "Dismiss",
+		description = "Swap Talk-to with Dismiss on all random events apart from the Genie and Dunce."
+	)
+	default boolean swapDismiss()
+	{
+		return false;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -419,6 +419,11 @@ public class MenuEntrySwapperPlugin extends Plugin
 			{
 				swap("quick-travel", option, target, true);
 			}
+
+			if (config.swapDismiss() && !(target.contains("dunce") || target.contains("genie")))
+			{
+				swap("dismiss", option, target, true);
+			}
 		}
 		else if (config.swapTravel() && option.equals("pass") && target.equals("energy barrier"))
 		{


### PR DESCRIPTION
ignores Dunce & Genie since they reward xp

Co-Authored-By: Dava <dava96@users.noreply.github.com>

Added to the menu entry swapper. The Dismiss option is now the top option when the Dismiss option is checked (off by default). Applies to every random event other than the Dunce and Genie (xp giving events).