### PR TITLE
Add Wintertodt plugin description

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/wintertodt/WintertodtPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/wintertodt/WintertodtPlugin.java
@@ -71,7 +71,7 @@ import net.runelite.client.util.ColorUtil;
 
 @PluginDescriptor(
 	name = "Wintertodt",
-	description = "Wintertodt",
+	description = "Show helpful information for the Wintertodt minigame",
 	tags = {"minigame", "firemaking"}
 )
 @Slf4j


### PR DESCRIPTION
The description of this plugin used a placeholder value. I used the standard plugin description text from other minigame plugins, like Pest Control and Barrows Brothers, which use the same description format.