### PR TITLE
Revert "Remove distance check from agility plugin"

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/agility/AgilityOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/agility/AgilityOverlay.java
@@ -35,6 +35,7 @@ import javax.inject.Inject;
 import net.runelite.api.Client;
 import net.runelite.api.Point;
 import net.runelite.api.Tile;
+import net.runelite.api.coords.LocalPoint;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
@@ -42,6 +43,8 @@ import net.runelite.client.ui.overlay.OverlayUtil;
 
 class AgilityOverlay extends Overlay
 {
+	private static final int MAX_DISTANCE = 2350;
+
 	private final Client client;
 	private final AgilityPlugin plugin;
 	private final AgilityConfig config;
@@ -59,6 +62,7 @@ class AgilityOverlay extends Overlay
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
+		LocalPoint playerLocation = client.getLocalPlayer().getLocalLocation();
 		Point mousePosition = client.getMouseCanvasPosition();
 		final List<Tile> marksOfGrace = plugin.getMarksOfGrace();
 		plugin.getObstacles().forEach((object, tile) ->
@@ -69,7 +73,8 @@ class AgilityOverlay extends Overlay
 				return;
 			}
 
-			if (tile.getPlane() == client.getPlane())
+			if (tile.getPlane() == client.getPlane()
+				&& object.getLocalLocation().distanceTo(playerLocation) < MAX_DISTANCE)
 			{
 				// This assumes that the obstacle is not clickable.
 				if (Obstacles.TRAP_OBSTACLE_IDS.contains(object.getId()))
@@ -112,7 +117,8 @@ class AgilityOverlay extends Overlay
 		{
 			for (Tile markOfGraceTile : marksOfGrace)
 			{
-				if (markOfGraceTile.getPlane() == client.getPlane() && markOfGraceTile.getItemLayer() != null)
+				if (markOfGraceTile.getPlane() == client.getPlane() && markOfGraceTile.getItemLayer() != null
+						&& markOfGraceTile.getLocalLocation().distanceTo(playerLocation) < MAX_DISTANCE)
 				{
 					final Polygon poly = markOfGraceTile.getItemLayer().getCanvasTilePoly();
 


### PR DESCRIPTION
Reverts runelite/runelite#6697. This very negatively affects FPS in elven lands since there are a large number of objects there with clickboxes, and it is checking each one on the whole scene each frame.