### PR TITLE
Fix freeze on disabling GPU plugin

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/GameEngine.java
+++ b/runelite-api/src/main/java/net/runelite/api/GameEngine.java
@@ -53,4 +53,6 @@ public interface GameEngine
 	boolean isClientThread();
 
 	void resizeCanvas();
+
+	void setReplaceCanvasNextFrame(boolean replace);
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuPlugin.java
@@ -422,6 +422,9 @@ public class GpuPlugin extends Plugin implements DrawCallbacks
 			// force main buffer provider rebuild to turn off alpha channel
 			client.resizeCanvas();
 		});
+
+		// Prevents canvas from freezing in place when disabling gpu plugin on some clients
+		client.setReplaceCanvasNextFrame(true);
 	}
 
 	@Provides


### PR DESCRIPTION
Fixes #6524 (again)

This is an amendment to #6909 that does not cause an endless loop upon invalidating the canvas (which would be caused by the user moving their client to a second monitor or interacting with the sidebar while it is still loading and the GPU plugin is enabled).