### PR TITLE
Deleting outdated client files (repository2)

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/RuneLite.java
+++ b/runelite-client/src/main/java/net/runelite/client/RuneLite.java
@@ -75,6 +75,13 @@ public class RuneLite
 	public static final File RUNELITE_DIR = new File(System.getProperty("user.home"), ".runelite");
 	public static final File PROFILES_DIR = new File(RUNELITE_DIR, "profiles");
 	public static final File SCREENSHOT_DIR = new File(RUNELITE_DIR, "screenshots");
+	
+	public static String[] client_files = new String[] {
+		"http-api-",
+		"runelite-api-",
+		"runescape-api-",
+		"client-"
+	};
 
 	@Getter
 	private static Injector injector;
@@ -287,6 +294,18 @@ public class RuneLite
 
 		// Start plugins
 		pluginManager.startCorePlugins();
+		
+		File subFolder = new File(RUNELITE_DIR, "repository2");
+		File[] dir = subFolder.listFiles();
+
+		if (dir != null) {
+			for (File child : dir) {
+				for (String files : client_files) {
+					if(child.toString().contains(files) && !child.toString().endsWith(new RuneLiteProperties().getVersion() + ".jar"))
+						child.delete();
+				}
+			}
+		}
 	}
 
 	public void shutdown()


### PR DESCRIPTION
For users who use the jar distribution to play Runelite, a directory is created in RUNELITE_DIR called 'repository2'. Every weekly update, there is a version update, so each of those files is re-generated with a new version number.

![1](https://user-images.githubusercontent.com/41882962/50060370-05aa1980-0161-11e9-91bd-54bfe84c39f6.png)

What this means is about every week, another 4 MB of storage is added to the user's hard drive for no apparent reason. I propose a method by which old client version files are deleted on startup, as this could save a good amount of storage for Runelite users (granted there are 52 updates a year, one for each week - that's 52 * 4 = 208 MB saved!)
