### PR TITLE
Add Infoboxes for the currently equipped Jewellery

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemcharges/ItemChargeConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemcharges/ItemChargeConfig.java
@@ -203,4 +203,37 @@ public interface ItemChargeConfig extends Config
 	{
 		return false;
 	}
+
+	@ConfigItem(
+		keyName = "showAmuletInfobox",
+		name = "Show Amulet/Necklace Infobox",
+		description = "Configures whether to show an infobox for teleport amulets and necklaces",
+		position = 15
+	)
+	default boolean showAmuletInfobox()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		keyName = "showBraceletInfobox",
+		name = "Show Bracelet Infobox",
+		description = "Configures whether to show an infobox for teleport bracelets",
+		position = 16
+	)
+	default boolean showBraceletInfobox()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		keyName = "showRingInfobox",
+		name = "Show Ring Infobox",
+		description = "Configures whether to show an infobox for teleport rings",
+		position = 17
+	)
+	default boolean showRingInfobox()
+	{
+		return true;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemcharges/ItemChargeInfobox.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemcharges/ItemChargeInfobox.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2018, Hydrox6 <ikada@protonmail.ch>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.itemcharges;
+
+import java.awt.Color;
+import java.awt.image.BufferedImage;
+import lombok.Getter;
+import net.runelite.api.EquipmentInventorySlot;
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.ui.overlay.infobox.InfoBox;
+
+public class ItemChargeInfobox extends InfoBox
+{
+	private int charges;
+
+	@Getter
+	private EquipmentInventorySlot slotID;
+
+	public ItemChargeInfobox(String name, BufferedImage image, Plugin plugin, int charges, EquipmentInventorySlot slotID)
+	{
+		super(image, plugin);
+
+		this.charges = charges;
+		this.slotID = slotID;
+		this.setTooltip(name);
+	}
+
+	@Override
+	public String getText()
+	{
+		return String.valueOf(charges);
+	}
+
+	@Override
+	public Color getTextColor()
+	{
+		return Color.WHITE;
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemcharges/ItemChargePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemcharges/ItemChargePlugin.java
@@ -34,8 +34,11 @@ import javax.inject.Inject;
 import lombok.AccessLevel;
 import lombok.Getter;
 import net.runelite.api.ChatMessageType;
+import net.runelite.api.Client;
 import net.runelite.api.EquipmentInventorySlot;
+import net.runelite.api.InventoryID;
 import net.runelite.api.Item;
+import net.runelite.api.ItemContainer;
 import net.runelite.api.ItemID;
 import net.runelite.api.events.ChatMessage;
 import net.runelite.api.events.ConfigChanged;
@@ -83,6 +86,9 @@ public class ItemChargePlugin extends Plugin
 
 	@Inject
 	private ItemChargeConfig config;
+
+	@Inject
+	private Client client;
 
 	@Getter(AccessLevel.PACKAGE)
 	private int dodgyCharges;
@@ -185,7 +191,7 @@ public class ItemChargePlugin extends Plugin
 	@Subscribe
 	public void onItemContainerChanged(ItemContainerChanged event)
 	{
-		if (event.getItemContainer().getItems().length > 14)
+		if (event.getItemContainer() != client.getItemContainer(InventoryID.EQUIPMENT))
 		{
 			return;
 		}
@@ -239,10 +245,10 @@ public class ItemChargePlugin extends Plugin
 				ItemWithCharge amuletCharges = ItemWithCharge.findItem(amulet);
 				if (amuletCharges != null)
 				{
-				createJewelleryInfobox(amulet, amuletCharges.getCharges(), EquipmentInventorySlot.AMULET);
-			}
-			else
-			{
+					createJewelleryInfobox(amulet, amuletCharges.getCharges(), EquipmentInventorySlot.AMULET);
+				}
+				else
+				{
 					removeJewelleryInfobox(EquipmentInventorySlot.AMULET);
 				}
 			}

--- a/runelite-client/src/test/java/net/runelite/client/plugins/itemcharges/ItemChargePluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/itemcharges/ItemChargePluginTest.java
@@ -32,6 +32,8 @@ import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
 import net.runelite.api.events.ChatMessage;
 import net.runelite.client.Notifier;
+import net.runelite.client.config.RuneLiteConfig;
+import net.runelite.client.game.ItemManager;
 import net.runelite.client.ui.overlay.OverlayManager;
 import static org.junit.Assert.assertEquals;
 import org.junit.Before;
@@ -62,7 +64,15 @@ public class ItemChargePluginTest
 
 	@Mock
 	@Bind
+	private ItemManager itemManager;
+
+	@Mock
+	@Bind
 	private ItemChargeConfig config;
+
+	@Mock
+	@Bind
+	private RuneLiteConfig runeLiteConfig;
 
 	@Inject
 	private ItemChargePlugin itemChargePlugin;
@@ -71,6 +81,7 @@ public class ItemChargePluginTest
 	public void before()
 	{
 		Guice.createInjector(BoundFieldModule.of(this)).injectMembers(this);
+		itemChargePlugin.startUp();
 	}
 
 	@Test


### PR DESCRIPTION
Basically just #2911, but updated.

![](https://thumbs.gfycat.com/PassionateOddAtlasmoth-size_restricted.gif)

Now includes tooltips of the item

![image](https://user-images.githubusercontent.com/2979691/50152625-086d5180-02bc-11e9-85e0-9dcc5d4c1580.png)

Supports every item you can see here

![image](https://user-images.githubusercontent.com/2979691/50152580-e07dee00-02bb-11e9-8ee0-2c27dc718704.png)

Adding support for other items, such as the slayer bracelets and binding necklaces, would require those items to be moved from their current plugin into this one. Maybe a service to track the current charges on these items would be useful?

Adding support for other item slots (Weapon for the Lyre, for example) is relatively easy, and can be done if there's a desire for it