### PR TITLE
Add OSBuddy Active Price to GE Item Panel (in Search Panel)

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangeItemPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangeItemPanel.java
@@ -52,7 +52,7 @@ class GrandExchangeItemPanel extends JPanel
 {
 	private static final Dimension ICON_SIZE = new Dimension(32, 32);
 
-	GrandExchangeItemPanel(AsyncBufferedImage icon, String name, int itemID, int gePrice, Double
+	GrandExchangeItemPanel(AsyncBufferedImage icon, String name, int itemID, int gePrice, int osbPrice, Double
 		haPrice, int geItemLimit)
 	{
 		BorderLayout layout = new BorderLayout();
@@ -108,7 +108,7 @@ class GrandExchangeItemPanel extends JPanel
 		add(itemIcon, BorderLayout.LINE_START);
 
 		// Item details panel
-		JPanel rightPanel = new JPanel(new GridLayout(3, 1));
+		JPanel rightPanel = new JPanel(new GridLayout((osbPrice > 0) ? 4 : 3, 1));
 		panels.add(rightPanel);
 		rightPanel.setBackground(background);
 
@@ -132,6 +132,15 @@ class GrandExchangeItemPanel extends JPanel
 		}
 		gePriceLabel.setForeground(ColorScheme.GRAND_EXCHANGE_PRICE);
 		rightPanel.add(gePriceLabel);
+
+		// Osb price
+		if (osbPrice > 0)
+		{
+			JLabel osbPriceLabel = new JLabel();
+			osbPriceLabel.setText(" (Active: " + StackFormatter.formatNumber(osbPrice) + " gp" + ")");
+			osbPriceLabel.setForeground(ColorScheme.GRAND_EXCHANGE_PRICE);
+			rightPanel.add(osbPriceLabel);
+		}
 
 		JPanel alchAndLimitPanel = new JPanel(new BorderLayout());
 		panels.add(alchAndLimitPanel);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangePanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangePanel.java
@@ -55,7 +55,7 @@ class GrandExchangePanel extends PluginPanel
 	private GrandExchangeOffersPanel offersPanel;
 
 	@Inject
-	private GrandExchangePanel(ClientThread clientThread, ItemManager itemManager, ScheduledExecutorService executor)
+	private GrandExchangePanel(ClientThread clientThread, ItemManager itemManager, ScheduledExecutorService executor, GrandExchangeConfig config)
 	{
 		super(false);
 
@@ -63,7 +63,7 @@ class GrandExchangePanel extends PluginPanel
 		setBackground(ColorScheme.DARK_GRAY_COLOR);
 
 		// Search Panel
-		searchPanel = new GrandExchangeSearchPanel(clientThread, itemManager, executor);
+		searchPanel = new GrandExchangeSearchPanel(clientThread, itemManager, executor, config);
 
 		//Offers Panel
 		offersPanel = new GrandExchangeOffersPanel();


### PR DESCRIPTION
Add lookup of OSBuddy price in Search Panel
Utilises current 'Enable OSB Prices' config

Solves not being able to look up OSBuddy Prices on the fly in the GE Plugin Panel (currently have to be in the GE in-game interface), as mentioned in: #3927