### PR TITLE
Inventory Tags: preserve 'cancel' when creating the custom menu

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/inventorytags/InventoryTagsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/inventorytags/InventoryTagsPlugin.java
@@ -212,8 +212,11 @@ public class InventoryTagsPlugin extends Plugin
 				return;
 			}
 
-			MenuEntry[] menuList = new MenuEntry[GROUPS.size()];
+			MenuEntry[] menuList = new MenuEntry[GROUPS.size() + 1];
 			int num = 0;
+
+			// preserve the 'Cancel' option as the client will reuse the first entry for Cancel and only resets option/action
+			menuList[num++] = event.getMenuEntries()[0];
 
 			for (final String groupName : GROUPS)
 			{


### PR DESCRIPTION
The client will use the first menu entry for 'Cancel' and only resets the menu action and menu option as that's all it uses. Overwriting the menu entries with all custom entries caused the 'Cancel' option to have erroneous fields.

Closes #5579 