### PR TITLE
Add wilderness cannon spots

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonSpots.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonSpots.java
@@ -36,7 +36,7 @@ public enum CannonSpots
 	BLOODVELDS(new WorldPoint(2439, 9821, 0), new WorldPoint(2448, 9821, 0), new WorldPoint(2472, 9833, 0), new WorldPoint(2453, 9817, 0)),
 	FIRE_GIANTS(new WorldPoint(2393, 9782, 0), new WorldPoint(2412, 9776, 0), new WorldPoint(2401, 9780, 0)),
 	ABBERANT_SPECTRES(new WorldPoint(2456, 9791, 0)),
-	HELLHOUNDS(new WorldPoint(2431, 9776, 0), new WorldPoint(2413, 9786, 0), new WorldPoint(2783, 9686, 0)),
+	HELLHOUNDS(new WorldPoint(2431, 9776, 0), new WorldPoint(2413, 9786, 0), new WorldPoint(2783, 9686, 0), new WorldPoint(3198, 10071, 0)),
 	BLACK_DEMONS(new WorldPoint(2859, 9778, 0), new WorldPoint(2841, 9791, 0)),
 	ELVES(new WorldPoint(2044, 4635, 0)),
 	SUQAHS(new WorldPoint(2114, 3943, 0)),
@@ -47,12 +47,25 @@ public enum CannonSpots
 	DARK_BEAST(new WorldPoint(1992, 4655, 0)),
 	DUST_DEVIL(new WorldPoint(3218, 9366, 0)),
 	KALPHITE(new WorldPoint(3307, 9528, 0)),
-	LESSER_DEMON(new WorldPoint(2838, 9559, 0)),
+	LESSER_DEMON(new WorldPoint(2838, 9559, 0), new WorldPoint(3163, 10114, 0)),
 	LIZARDMEN(new WorldPoint(1500, 3703, 0)),
 	MINIONS_OF_SCARABAS(new WorldPoint(3297, 9252, 0)),
 	SMOKE_DEVIL(new WorldPoint(2398, 9444, 0)),
 	CAVE_HORROR(new WorldPoint(3785, 9460, 0)),
-	BLUE_DRAGON(new WorldPoint(1933, 8973, 1));
+	BLUE_DRAGON(new WorldPoint(1933, 8973, 1)),
+    ANKOU(new WorldPoint(3177, 10193, 0)),
+    BLACK_DRAGON(new WorldPoint(3239, 10206, 0)),
+    ICE_GIANT(new WorldPoint(3207, 10164, 0)),
+    GREEN_DRAGON(new WorldPoint(3225, 10068, 0)),
+    SPIDER(new WorldPoint(3169, 3886, 0)),
+    ROGUE(new WorldPoint(3285, 3930, 0)),
+    MAMMOTH(new WorldPoint(3160, 3619, 0)),
+    SKELETON(new WorldPoint(3018, 3592, 0)),
+    DARK_WARRIOR(new WorldPoint(3030, 3632, 0)),
+    MAGIC_AXE(new WorldPoint(3190, 3960, 0)),
+    EARTH_WARRIOR(new WorldPoint(3120, 9987, 0)),
+    ICE_WARRIOR(new WorldPoint(2955, 3876, 0)),
+    BANDIT(new WorldPoint(3037, 3700, 0));
 
 	@Getter
 	private static final List<WorldPoint> cannonSpots = new ArrayList<>();

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonSpots.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonSpots.java
@@ -36,7 +36,7 @@ public enum CannonSpots
 	BLOODVELDS(new WorldPoint(2439, 9821, 0), new WorldPoint(2448, 9821, 0), new WorldPoint(2472, 9833, 0), new WorldPoint(2453, 9817, 0)),
 	FIRE_GIANTS(new WorldPoint(2393, 9782, 0), new WorldPoint(2412, 9776, 0), new WorldPoint(2401, 9780, 0)),
 	ABBERANT_SPECTRES(new WorldPoint(2456, 9791, 0)),
-	HELLHOUNDS(new WorldPoint(2431, 9776, 0), new WorldPoint(2413, 9786, 0), new WorldPoint(2783, 9686, 0), new WorldPoint(3198, 10071, 0)),
+	HELLHOUNDS(new WorldPoint(2431, 9776, 0), new WorldPoint(2413, 9786, 0), new WorldPoint(2783, 9686, 0)),
 	BLACK_DEMONS(new WorldPoint(2859, 9778, 0), new WorldPoint(2841, 9791, 0)),
 	ELVES(new WorldPoint(2044, 4635, 0)),
 	SUQAHS(new WorldPoint(2114, 3943, 0)),
@@ -47,25 +47,12 @@ public enum CannonSpots
 	DARK_BEAST(new WorldPoint(1992, 4655, 0)),
 	DUST_DEVIL(new WorldPoint(3218, 9366, 0)),
 	KALPHITE(new WorldPoint(3307, 9528, 0)),
-	LESSER_DEMON(new WorldPoint(2838, 9559, 0), new WorldPoint(3163, 10114, 0)),
+	LESSER_DEMON(new WorldPoint(2838, 9559, 0)),
 	LIZARDMEN(new WorldPoint(1500, 3703, 0)),
 	MINIONS_OF_SCARABAS(new WorldPoint(3297, 9252, 0)),
 	SMOKE_DEVIL(new WorldPoint(2398, 9444, 0)),
 	CAVE_HORROR(new WorldPoint(3785, 9460, 0)),
-	BLUE_DRAGON(new WorldPoint(1933, 8973, 1)),
-    ANKOU(new WorldPoint(3177, 10193, 0)),
-    BLACK_DRAGON(new WorldPoint(3239, 10206, 0)),
-    ICE_GIANT(new WorldPoint(3207, 10164, 0)),
-    GREEN_DRAGON(new WorldPoint(3225, 10068, 0)),
-    SPIDER(new WorldPoint(3169, 3886, 0)),
-    ROGUE(new WorldPoint(3285, 3930, 0)),
-    MAMMOTH(new WorldPoint(3160, 3619, 0)),
-    SKELETON(new WorldPoint(3018, 3592, 0)),
-    DARK_WARRIOR(new WorldPoint(3030, 3632, 0)),
-    MAGIC_AXE(new WorldPoint(3190, 3960, 0)),
-    EARTH_WARRIOR(new WorldPoint(3120, 9987, 0)),
-    ICE_WARRIOR(new WorldPoint(2955, 3876, 0)),
-    BANDIT(new WorldPoint(3037, 3700, 0));
+	BLUE_DRAGON(new WorldPoint(1933, 8973, 1));
 
 	@Getter
 	private static final List<WorldPoint> cannonSpots = new ArrayList<>();

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonSpots.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonSpots.java
@@ -6,10 +6,10 @@
  * modification, are permitted provided that the following conditions are met:
  *
  * 1. Redistributions of source code must retain the above copyright notice, this
- * list of conditions and the following disclaimer.
+ *    list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonSpots.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonSpots.java
@@ -6,10 +6,10 @@
  * modification, are permitted provided that the following conditions are met:
  *
  * 1. Redistributions of source code must retain the above copyright notice, this
- *list of conditions and the following disclaimer.
+ * list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
- *this list of conditions and the following disclaimer in the documentation
- *and/or other materials provided with the distribution.
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonSpots.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonSpots.java
@@ -6,10 +6,10 @@
  * modification, are permitted provided that the following conditions are met:
  *
  * 1. Redistributions of source code must retain the above copyright notice, this
- *    list of conditions and the following disclaimer.
+ *list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
+ *this list of conditions and the following disclaimer in the documentation
+ *and/or other materials provided with the distribution.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
@@ -36,7 +36,7 @@ public enum CannonSpots
 	BLOODVELDS(new WorldPoint(2439, 9821, 0), new WorldPoint(2448, 9821, 0), new WorldPoint(2472, 9833, 0), new WorldPoint(2453, 9817, 0)),
 	FIRE_GIANTS(new WorldPoint(2393, 9782, 0), new WorldPoint(2412, 9776, 0), new WorldPoint(2401, 9780, 0)),
 	ABBERANT_SPECTRES(new WorldPoint(2456, 9791, 0)),
-	HELLHOUNDS(new WorldPoint(2431, 9776, 0), new WorldPoint(2413, 9786, 0), new WorldPoint(2783, 9686, 0)),
+	HELLHOUNDS(new WorldPoint(2431, 9776, 0), new WorldPoint(2413, 9786, 0), new WorldPoint(2783, 9686, 0), new WorldPoint(3198, 10071, 0)),
 	BLACK_DEMONS(new WorldPoint(2859, 9778, 0), new WorldPoint(2841, 9791, 0)),
 	ELVES(new WorldPoint(2044, 4635, 0)),
 	SUQAHS(new WorldPoint(2114, 3943, 0)),
@@ -47,12 +47,25 @@ public enum CannonSpots
 	DARK_BEAST(new WorldPoint(1992, 4655, 0)),
 	DUST_DEVIL(new WorldPoint(3218, 9366, 0)),
 	KALPHITE(new WorldPoint(3307, 9528, 0)),
-	LESSER_DEMON(new WorldPoint(2838, 9559, 0)),
+	LESSER_DEMON(new WorldPoint(2838, 9559, 0), new WorldPoint(3163, 10114, 0)),
 	LIZARDMEN(new WorldPoint(1500, 3703, 0)),
 	MINIONS_OF_SCARABAS(new WorldPoint(3297, 9252, 0)),
 	SMOKE_DEVIL(new WorldPoint(2398, 9444, 0)),
 	CAVE_HORROR(new WorldPoint(3785, 9460, 0)),
-	BLUE_DRAGON(new WorldPoint(1933, 8973, 1));
+	BLUE_DRAGON(new WorldPoint(1933, 8973, 1)),
+	ANKOU(new WorldPoint(3177, 10193, 0)),
+	BLACK_DRAGON(new WorldPoint(3239, 10206, 0)),
+	ICE_GIANT(new WorldPoint(3207, 10164, 0)),
+	GREEN_DRAGON(new WorldPoint(3225, 10068, 0)),
+	SPIDER(new WorldPoint(3169, 3886, 0)),
+	ROGUE(new WorldPoint(3285, 3930, 0)),
+	MAMMOTH(new WorldPoint(3160, 3619, 0)),
+	SKELETON(new WorldPoint(3018, 3592, 0)),
+	DARK_WARRIOR(new WorldPoint(3030, 3632, 0)),
+	MAGIC_AXE(new WorldPoint(3190, 3960, 0)),
+	EARTH_WARRIOR(new WorldPoint(3120, 9987, 0)),
+	ICE_WARRIOR(new WorldPoint(2955, 3876, 0)),
+	BANDIT(new WorldPoint(3037, 3700, 0));
 
 	@Getter
 	private static final List<WorldPoint> cannonSpots = new ArrayList<>();


### PR DESCRIPTION
Update cannon spots to add the Wilderness slayer spots as outlined in the Oblivion Wilderness Slayer Points guide.