### PR TITLE
worldhopper: change WorldTableHeader highlight text and arrow color

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldTableHeader.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldTableHeader.java
@@ -46,13 +46,11 @@ import net.runelite.client.util.ImageUtil;
 class WorldTableHeader extends JPanel
 {
 	private static final ImageIcon ARROW_UP;
-
-	private static final Color ARROW_COLOR = ColorScheme.LIGHT_GRAY_COLOR;
-
 	private static final ImageIcon HIGHLIGHT_ARROW_DOWN;
 	private static final ImageIcon HIGHLIGHT_ARROW_UP;
 
-	private static final Color HIGHLIGHT_COLOR = new Color(210, 193, 53);
+	private static final Color ARROW_COLOR = ColorScheme.LIGHT_GRAY_COLOR;
+	private static final Color HIGHLIGHT_COLOR = ColorScheme.BRAND_ORANGE;
 
 	static
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldTableHeader.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldTableHeader.java
@@ -45,18 +45,26 @@ import net.runelite.client.util.ImageUtil;
 
 class WorldTableHeader extends JPanel
 {
-	private static final ImageIcon ARROW_DOWN;
 	private static final ImageIcon ARROW_UP;
-	private static final ImageIcon ARROW_UP_FADED;
+
+	private static final Color ARROW_COLOR = ColorScheme.LIGHT_GRAY_COLOR;
+
+	private static final ImageIcon HIGHLIGHT_ARROW_DOWN;
+	private static final ImageIcon HIGHLIGHT_ARROW_UP;
+
+	private static final Color HIGHLIGHT_COLOR = new Color(210, 193, 53);
 
 	static
 	{
 		final BufferedImage arrowDown = ImageUtil.getResourceStreamFromClass(WorldHopperPlugin.class, "arrow_down.png");
 		final BufferedImage arrowUp = ImageUtil.rotateImage(arrowDown, Math.PI);
 		final BufferedImage arrowUpFaded = ImageUtil.grayscaleOffset(arrowUp, -80);
-		ARROW_DOWN = new ImageIcon(arrowDown);
-		ARROW_UP = new ImageIcon(arrowUp);
-		ARROW_UP_FADED = new ImageIcon(arrowUpFaded);
+		ARROW_UP = new ImageIcon(arrowUpFaded);
+
+		final BufferedImage highlightArrowDown = ImageUtil.fillImage(arrowDown, HIGHLIGHT_COLOR);
+		final BufferedImage highlightArrowUp = ImageUtil.fillImage(arrowUp, HIGHLIGHT_COLOR);
+		HIGHLIGHT_ARROW_DOWN = new ImageIcon(highlightArrowDown);
+		HIGHLIGHT_ARROW_UP = new ImageIcon(highlightArrowUp);
 	}
 
 	private final JLabel textLabel = new JLabel();
@@ -77,19 +85,21 @@ class WorldTableHeader extends JPanel
 			@Override
 			public void mouseEntered(MouseEvent mouseEvent)
 			{
-				textLabel.setForeground(Color.WHITE);
+				textLabel.setForeground(HIGHLIGHT_COLOR);
+				if (!ordering)
+				{
+					arrowLabel.setIcon(HIGHLIGHT_ARROW_UP);
+				}
 			}
 
 			@Override
 			public void mouseExited(MouseEvent mouseEvent)
 			{
-				if (ordering)
+				if (!ordering)
 				{
-					textLabel.setForeground(Color.WHITE);
-					return;
+					textLabel.setForeground(ARROW_COLOR);
+					arrowLabel.setIcon(ARROW_UP);
 				}
-
-				textLabel.setForeground(ColorScheme.LIGHT_GRAY_COLOR);
 			}
 		});
 
@@ -133,7 +143,8 @@ class WorldTableHeader extends JPanel
 	public void highlight(boolean on, boolean ascending)
 	{
 		ordering = on;
-		arrowLabel.setIcon(on ? (ascending ? ARROW_DOWN : ARROW_UP) : ARROW_UP_FADED);
-		textLabel.setForeground(on ? Color.WHITE : ColorScheme.LIGHT_GRAY_COLOR);
+		arrowLabel.setIcon(on ? (ascending ? HIGHLIGHT_ARROW_DOWN : HIGHLIGHT_ARROW_UP) : ARROW_UP);
+		textLabel.setForeground(on ? HIGHLIGHT_COLOR : ARROW_COLOR);
 	}
+
 }

--- a/runelite-client/src/main/java/net/runelite/client/util/ImageUtil.java
+++ b/runelite-client/src/main/java/net/runelite/client/util/ImageUtil.java
@@ -376,7 +376,7 @@ public class ImageUtil
 	 * @return              The given image with all pixels fulfilling the fill condition predicate
 	 *                      set to the given color.
 	 */
-	public static BufferedImage fillImage(final BufferedImage image, final Color color, final Predicate<Color> fillCondition)
+	static BufferedImage fillImage(final BufferedImage image, final Color color, final Predicate<Color> fillCondition)
 	{
 		final BufferedImage filledImage = new BufferedImage(image.getWidth(), image.getHeight(), BufferedImage.TYPE_INT_ARGB);
 		for (int x = 0; x < filledImage.getWidth(); x++)

--- a/runelite-client/src/main/java/net/runelite/client/util/ImageUtil.java
+++ b/runelite-client/src/main/java/net/runelite/client/util/ImageUtil.java
@@ -361,7 +361,7 @@ public class ImageUtil
 	 * @param color The color with which to fill pixels.
 	 * @return      The given image with all non-transparent pixels set to the given color.
 	 */
-	static BufferedImage fillImage(final BufferedImage image, final Color color)
+	public static BufferedImage fillImage(final BufferedImage image, final Color color)
 	{
 		return fillImage(image, color, ColorUtil::isNotFullyTransparent);
 	}
@@ -376,7 +376,7 @@ public class ImageUtil
 	 * @return              The given image with all pixels fulfilling the fill condition predicate
 	 *                      set to the given color.
 	 */
-	static BufferedImage fillImage(final BufferedImage image, final Color color, final Predicate<Color> fillCondition)
+	public static BufferedImage fillImage(final BufferedImage image, final Color color, final Predicate<Color> fillCondition)
 	{
 		final BufferedImage filledImage = new BufferedImage(image.getWidth(), image.getHeight(), BufferedImage.TYPE_INT_ARGB);
 		for (int x = 0; x < filledImage.getWidth(); x++)


### PR DESCRIPTION
Closes #7022

Highlighted text is now a golden color (same color as the "Members World" color in WorldTableRow.java). Removed the white arrow images and replaced them with golden ones.


![](https://media.giphy.com/media/42uBute8I1UiVdtgFw/giphy.gif)
