### PR TITLE
Ground Items: Retrieve ItemLayer height in render rather than on spawn

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
@@ -41,6 +41,7 @@ import net.runelite.api.Client;
 import net.runelite.api.Perspective;
 import net.runelite.api.Player;
 import net.runelite.api.Point;
+import net.runelite.api.Tile;
 import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.coords.WorldPoint;
 import static net.runelite.client.plugins.grounditems.config.ItemHighlightMode.MENU;
@@ -258,6 +259,13 @@ public class GroundItemsOverlay extends Overlay
 
 			final String itemString = itemStringBuilder.toString();
 			itemStringBuilder.setLength(0);
+
+			if (item.getHeight() == -1)
+			{
+				final Tile[][][] sceneTiles = client.getScene().getTiles();
+				final Tile itemTile = sceneTiles[client.getPlane()][groundPoint.getSceneX()][groundPoint.getSceneY()];
+				item.setHeight(itemTile.getItemLayer().getHeight());
+			}
 
 			final Point textPoint = Perspective.getCanvasTextLocation(client,
 				graphics,

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
@@ -313,7 +313,7 @@ public class GroundItemsPlugin extends Plugin
 			.quantity(item.getQuantity())
 			.name(itemComposition.getName())
 			.haPrice(alchPrice)
-			.height(tile.getItemLayer().getHeight())
+			.height(-1)
 			.tradeable(itemComposition.isTradeable())
 			.build();
 


### PR DESCRIPTION
After a scene load, the `ItemLayer`'s height isn't updated at the time of the item spawn event. This causes the height to be incorrect if the height for that scene tile was different in the previous scene. 

Closes #5330, Closes #6849