### PR TITLE
Clear search bar when switching between skill calculators

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/SkillCalculator.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/SkillCalculator.java
@@ -126,6 +126,9 @@ class SkillCalculator extends JPanel
 		// Remove all components (action slots) from this panel.
 		removeAll();
 
+		// Clear the search bar
+		searchBar.setText(null);
+
 		// Add in checkboxes for available skill bonuses.
 		renderBonusOptions();
 


### PR DESCRIPTION
Any search bar filters persist when the user switches between skill calculators - instead, clear them.