### PR TITLE
POC - Add support for Discord parties and data sharing

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/discord/DiscordService.java
+++ b/runelite-client/src/main/java/net/runelite/client/discord/DiscordService.java
@@ -186,6 +186,7 @@ public class DiscordService implements AutoCloseable
 
 	private void errored(int errorCode, String message)
 	{
+		log.warn("Discord error: {} - {}", errorCode, message);
 		eventBus.post(new DiscordErrored(errorCode, message));
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordPlugin.java
@@ -117,8 +117,6 @@ public class DiscordPlugin extends Plugin
 
 		clientToolbar.addNavigation(discordButton);
 		checkForGameStateUpdate();
-
-		discordParty.join(discordSession.getCurrentJoinSecret());
 	}
 
 	@Override
@@ -134,6 +132,7 @@ public class DiscordPlugin extends Plugin
 		switch (event.getGameState())
 		{
 			case LOGIN_SCREEN:
+				discordParty.join(discordSession.getCurrentJoinSecret());
 				discordParty.send(DiscordPartyMessageType.LOGOUT, client.getUsername());
 				checkForGameStateUpdate();
 				return;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordPlugin.java
@@ -213,6 +213,9 @@ public class DiscordPlugin extends Plugin
 
 		discordParty.join(joinGame.getJoinSecret());
 		discordParty.send(DiscordPartyMessageType.HELLO, client.getUsername());
+		discordState.triggerEvent(client.getGameState() == GameState.LOGGED_IN
+			? DiscordGameEventType.IN_GAME
+			: DiscordGameEventType.IN_MENU);
 	}
 
 	@Subscribe

--- a/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordState.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordState.java
@@ -138,16 +138,22 @@ class DiscordState
 			}
 		}
 
-		final DiscordPresence presence = DiscordPresence.builder()
+		final DiscordPresence.DiscordPresenceBuilder presenceBuilder = DiscordPresence.builder()
 			.state(MoreObjects.firstNonNull(state, "Idle"))
 			.details(MoreObjects.firstNonNull(details, ""))
 			.startTimestamp(event.getStart())
 			.smallImageKey(MoreObjects.firstNonNull(imageKey, "default"))
 			.partyMax(15)
-			.partySize(session.getPartySize())
-			.partyId(session.getCurrentPartyId())
-			.joinSecret(session.getCurrentJoinSecret())
-			.build();
+			.partySize(session.getPartySize());
+
+		if (session.isOwner())
+		{
+			presenceBuilder.partyId(session.getPartyId());
+			presenceBuilder.joinSecret(session.getCurrentJoinSecret());
+
+		}
+
+		final DiscordPresence presence = presenceBuilder.build();
 
 		// This is to reduce amount of RPC calls
 		if (!presence.equals(lastPresence))

--- a/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordState.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordState.java
@@ -35,6 +35,7 @@ import javax.inject.Inject;
 import lombok.Data;
 import net.runelite.client.discord.DiscordPresence;
 import net.runelite.client.discord.DiscordService;
+import net.runelite.client.plugins.discord.party.DiscordSession;
 
 /**
  * This class contains data about currently active discord state.
@@ -52,13 +53,15 @@ class DiscordState
 	private final List<EventWithTime> events = new ArrayList<>();
 	private final DiscordService discordService;
 	private final DiscordConfig config;
+	private DiscordSession session;
 	private DiscordPresence lastPresence;
 
 	@Inject
-	private DiscordState(final DiscordService discordService, final DiscordConfig config)
+	private DiscordState(final DiscordService discordService, final DiscordConfig config, final DiscordSession session)
 	{
 		this.discordService = discordService;
 		this.config = config;
+		this.session = session;
 	}
 
 	/**
@@ -140,6 +143,10 @@ class DiscordState
 			.details(MoreObjects.firstNonNull(details, ""))
 			.startTimestamp(event.getStart())
 			.smallImageKey(MoreObjects.firstNonNull(imageKey, "default"))
+			.partyMax(15)
+			.partySize(session.getPartySize())
+			.partyId(session.getCurrentPartyId())
+			.joinSecret(session.getCurrentJoinSecret())
 			.build();
 
 		// This is to reduce amount of RPC calls

--- a/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordState.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordState.java
@@ -139,7 +139,7 @@ class DiscordState
 		}
 
 		final DiscordPresence presence = DiscordPresence.builder()
-			.state(MoreObjects.firstNonNull(state, ""))
+			.state(MoreObjects.firstNonNull(state, "Idle"))
 			.details(MoreObjects.firstNonNull(details, ""))
 			.startTimestamp(event.getStart())
 			.smallImageKey(MoreObjects.firstNonNull(imageKey, "default"))

--- a/runelite-client/src/main/java/net/runelite/client/plugins/discord/party/DiscordParty.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/discord/party/DiscordParty.java
@@ -26,6 +26,7 @@ package net.runelite.client.plugins.discord.party;
 
 import java.util.UUID;
 import javax.inject.Inject;
+import javax.inject.Singleton;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.client.eventbus.EventBus;
 import net.runelite.http.api.RuneLiteAPI;
@@ -36,6 +37,7 @@ import okhttp3.WebSocket;
 import okhttp3.WebSocketListener;
 
 @Slf4j
+@Singleton
 public class DiscordParty extends WebSocketListener
 {
 	private static final String WSS_PARTY = "https://discord-rooms.herokuapp.com/";

--- a/runelite-client/src/main/java/net/runelite/client/plugins/discord/party/DiscordParty.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/discord/party/DiscordParty.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2018, Tomas Slusny <slusnucky@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.discord.party;
+
+import java.util.UUID;
+import javax.inject.Inject;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.client.eventbus.EventBus;
+import net.runelite.http.api.RuneLiteAPI;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.WebSocket;
+import okhttp3.WebSocketListener;
+
+@Slf4j
+public class DiscordParty extends WebSocketListener
+{
+	private static final String WSS_PARTY = "https://discord-rooms.herokuapp.com/";
+	private final OkHttpClient client;
+	private EventBus eventBus;
+	private final String uuid = UUID.randomUUID().toString();
+	private WebSocket socket;
+	private String secret;
+
+	@Inject
+	private DiscordParty(final OkHttpClient client, final EventBus eventBus)
+	{
+		this.client = client;
+		this.eventBus = eventBus;
+	}
+
+	public void join(final String secret)
+	{
+		if (socket != null)
+		{
+			socket.close(1000, null);
+		}
+
+		final Request request = new Request.Builder()
+			.url(WSS_PARTY)
+			.build();
+
+		this.secret = secret;
+		socket = client.newWebSocket(request, this);
+	}
+
+	public void send(final DiscordPartyMessageType type, final String message)
+	{
+		if (socket == null || secret == null)
+		{
+			return;
+		}
+
+		socket.send(RuneLiteAPI.GSON.toJson(new DiscordPartyMessage(uuid, secret, type, message)));
+	}
+
+	@Override
+	public void onMessage(WebSocket webSocket, String text)
+	{
+		final DiscordPartyMessage message = RuneLiteAPI.GSON.fromJson(text, DiscordPartyMessage.class);
+		log.info("Got message {}", message);
+		eventBus.post(message);
+	}
+
+	@Override
+	public void onClosed(WebSocket webSocket, int code, String reason)
+	{
+		log.info("Websocket {} closed: {}/{}", webSocket, code, reason);
+		secret = null;
+		socket = null;
+	}
+
+	@Override
+	public void onFailure(WebSocket webSocket, Throwable t, Response response)
+	{
+		log.warn("Error in websocket", t);
+		secret = null;
+		socket = null;
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/discord/party/DiscordParty.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/discord/party/DiscordParty.java
@@ -99,7 +99,6 @@ public class DiscordParty extends WebSocketListener
 	public void onFailure(WebSocket webSocket, Throwable t, Response response)
 	{
 		log.warn("Error in websocket", t);
-		secret = null;
-		socket = null;
+		join(secret);
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/discord/party/DiscordPartyMessage.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/discord/party/DiscordPartyMessage.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2018, Tomas Slusny <slusnucky@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.discord.party;
+
+import lombok.Value;
+
+@Value
+public class DiscordPartyMessage
+{
+	private String uuid;
+	private String group;
+	private DiscordPartyMessageType type;
+	private String message;
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/discord/party/DiscordPartyMessageType.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/discord/party/DiscordPartyMessageType.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2018, Tomas Slusny <slusnucky@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.discord.party;
+
+public enum DiscordPartyMessageType
+{
+	HELLO,
+	LOGIN,
+	LOGOUT,
+	COUNT
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/discord/party/DiscordSession.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/discord/party/DiscordSession.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2018, Tomas Slusny <slusnucky@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.discord.party;
+
+import java.util.UUID;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class DiscordSession
+{
+	private final String uuid = UUID.randomUUID().toString();
+	private final String joinSecret = UUID.randomUUID().toString();
+	private final String partyId = UUID.randomUUID().toString();
+
+	private String currentJoinSecret = joinSecret;
+	private String currentPartyId = partyId;
+	private int partySize = 1;
+
+	public void reset()
+	{
+		currentJoinSecret = joinSecret;
+		currentPartyId = partyId;
+		partySize = 1;
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/discord/party/DiscordSession.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/discord/party/DiscordSession.java
@@ -39,13 +39,16 @@ public class DiscordSession
 	private final String partyId = UUID.randomUUID().toString();
 
 	private String currentJoinSecret = joinSecret;
-	private String currentPartyId = partyId;
 	private int partySize = 1;
+
+	public boolean isOwner()
+	{
+		return joinSecret.equals(currentJoinSecret);
+	}
 
 	public void reset()
 	{
 		currentJoinSecret = joinSecret;
-		currentPartyId = partyId;
 		partySize = 1;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/discord/party/DiscordSession.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/discord/party/DiscordSession.java
@@ -25,11 +25,13 @@
 package net.runelite.client.plugins.discord.party;
 
 import java.util.UUID;
+import javax.inject.Singleton;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
+@Singleton
 public class DiscordSession
 {
 	private final String uuid = UUID.randomUUID().toString();


### PR DESCRIPTION
This is just proof of concept that something like this can work. The
implementation is using Redis-backed websocket server
(https://github.com/deathbeam/discord-rooms) hosted on Heroku for
creating rooms based on UUIDs generated in client and shared via
Discord. I do not really have partyId figured out (or I have no idea to
what I should set it), but in this POC I decided to showcase party
count, logout/login and hello messages, what in theory should work as
long as the discord api is working (untested).