### PR TITLE
Flip state and details in Discord status

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordGameEventType.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordGameEventType.java
@@ -291,7 +291,7 @@ enum DiscordGameEventType
 
 	DiscordGameEventType(Skill skill, int priority)
 	{
-		this.state = training(skill);
+		this.details = training(skill);
 		this.priority = priority;
 		this.imageKey = imageKeyOf(skill);
 		this.priority = priority;
@@ -300,7 +300,7 @@ enum DiscordGameEventType
 
 	DiscordGameEventType(String areaName, DiscordAreaType areaType, int... regionIds)
 	{
-		this.details = exploring(areaType, areaName);
+		this.state = exploring(areaType, areaName);
 		this.priority = -2;
 		this.discordAreaType = areaType;
 		this.regionIds = regionIds;
@@ -309,14 +309,14 @@ enum DiscordGameEventType
 
 	DiscordGameEventType(String state, int priority)
 	{
-		this.details = state;
+		this.state = state;
 		this.priority = priority;
 		this.shouldClear = true;
 	}
 
 	DiscordGameEventType(String areaName, DiscordAreaType areaType, Varbits varbits)
 	{
-		this.details = exploring(areaType, areaName);
+		this.state = exploring(areaType, areaName);
 		this.priority = -2;
 		this.discordAreaType = areaType;
 		this.varbits = varbits;


### PR DESCRIPTION
Currently we have this implemented inverse. Training should be "details"
as it is more detailed description of what player is currently doing,
and "state" should be "In Game", "In Menu", "Exploring", "Raiding" etc,
as that describes best what is player currently doing (also, e.g for
discord party integration, it is appended after state, so there always
MUST be some state, and this PR ensures that).

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>