### PR TITLE
Add right click menu functionality to overlays

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/MenuAction.java
+++ b/runelite-api/src/main/java/net/runelite/api/MenuAction.java
@@ -260,6 +260,10 @@ public enum MenuAction
 	 * Menu action injected by runelite for its menu items.
 	 */
 	RUNELITE(1500),
+	/**
+	 * Menu action injected by runelite for overlay menu items.
+	 */
+	RUNELITE_OVERLAY(1501),
 
 	FOLLOW(2046),
 	TRADE(2047),

--- a/runelite-client/src/main/java/net/runelite/client/config/RuneLiteConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/RuneLiteConfig.java
@@ -230,10 +230,21 @@ public interface RuneLiteConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "overlayRightClick",
+		name = "Require Shift for overlay menu options",
+		description = "Toggles whether the overlay right-click menu requires holding down the shift key",
+		position = 33
+	)
+	default boolean overlayRightClick()
+	{
+		return true;
+	}
+
+	@ConfigItem(
 		keyName = "infoBoxVertical",
 		name = "Display infoboxes vertically",
 		description = "Toggles the infoboxes to display vertically",
-		position = 33
+		position = 34
 	)
 	default boolean infoBoxVertical()
 	{
@@ -244,7 +255,7 @@ public interface RuneLiteConfig extends Config
 		keyName = "infoBoxWrap",
 		name = "Infobox wrap count",
 		description = "Configures the amount of infoboxes shown before wrapping",
-		position = 34
+		position = 35
 	)
 	default int infoBoxWrap()
 	{
@@ -255,7 +266,7 @@ public interface RuneLiteConfig extends Config
 		keyName = "infoBoxSize",
 		name = "Infobox size (px)",
 		description = "Configures the size of each infobox in pixels",
-		position = 35
+		position = 36
 	)
 	default int infoBoxSize()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/Overlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/Overlay.java
@@ -27,6 +27,7 @@ package net.runelite.client.ui.overlay;
 import java.awt.Dimension;
 import java.awt.Point;
 import java.awt.Rectangle;
+import java.util.LinkedHashMap;
 import lombok.Getter;
 import lombok.Setter;
 import net.runelite.client.ui.overlay.components.LayoutableRenderableEntity;
@@ -42,6 +43,7 @@ public abstract class Overlay implements LayoutableRenderableEntity
 	private OverlayPosition position = OverlayPosition.TOP_LEFT;
 	private OverlayPriority priority = OverlayPriority.NONE;
 	private OverlayLayer layer = OverlayLayer.UNDER_WIDGETS;
+	private final LinkedHashMap<String, Runnable> menuOptions = new LinkedHashMap<>();
 
 	/**
 	 * Overlay name, used for saving the overlay, needs to be unique

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayManager.java
@@ -38,11 +38,14 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 import lombok.AccessLevel;
 import lombok.Getter;
+import net.runelite.api.MenuAction;
+import net.runelite.api.events.MenuOptionClicked;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.config.RuneLiteConfig;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.events.PluginChanged;
+import net.runelite.client.util.Text;
 
 /**
  * Manages state of all game overlays
@@ -105,6 +108,39 @@ public class OverlayManager
 	{
 		overlays.forEach(this::loadOverlay);
 		rebuildOverlayLayers();
+	}
+
+	@Subscribe
+	public void onMenuOptionClicked(MenuOptionClicked event)
+	{
+		if (!MenuAction.RUNELITE_OVERLAY.equals(event.getMenuAction()))
+		{
+			return;
+		}
+
+		event.consume();
+
+		final String overlayName = Text.removeTags(event.getMenuTarget());
+		Overlay overlay = null;
+		for (Overlay o : overlays)
+		{
+			if (o.getName().equals(overlayName))
+			{
+				overlay = o;
+				break;
+			}
+		}
+
+		if (overlay == null)
+		{
+			return;
+		}
+
+		final Runnable r = overlay.getMenuOptions().get(event.getMenuOption());
+		if (r != null)
+		{
+			r.run();
+		}
 	}
 
 	/**


### PR DESCRIPTION
Adds the ability to add right-click menu options to overlays. By default these options requires the `shift` modifier key to be held when right-clicking but this can be changed via the RuneLite config settings.


![https://i.imgur.com/SjlMphg.png](https://i.imgur.com/SjlMphg.png)

![2019-01-03_02-59-58](https://user-images.githubusercontent.com/29030969/50634515-c3742c80-0f03-11e9-8051-f77978b0c499.gif)



<details>
<summary>
Code for adding the right click menu options
</summary>

<p>

```java
@Override
public List<MenuOption> buildMenuOptions()
{
	List<MenuOption> options = new ArrayList<>();
	options.add(new MenuOption("Reset", () -> log.info("Reset Option")));
	options.add(new MenuOption("Pause", () -> log.info("Pause Option")));
	options.add(new MenuOption("Something", () -> log.info("Something Option")));
	return options;
}
```

</p>
</details>