### PR TITLE
Add farming patch type to tooltips on world map

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldmap/FarmingPatchLocation.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldmap/FarmingPatchLocation.java
@@ -31,52 +31,67 @@ import net.runelite.api.coords.WorldPoint;
 @Getter
 enum FarmingPatchLocation
 {
-	AL_KHARID_CACTUS("Cactus", new WorldPoint(3313, 3201, 0)),
-	ARDOUGNE_BUSH("Bush", new WorldPoint(2615, 3224, 0)),
-	ARDOUGNE_ALLOTMENT("Allotment/Herb/Flower", new WorldPoint(2663, 3375, 0)),
-	BRIMHAVEN_SPIRIT_TREE("Spirit Tree", new WorldPoint(2799, 3205, 0)),
-	BRIMHAVEN_FRUIT_TREE("Fruit Tree", new WorldPoint(2765, 3211, 0)),
-	CATHERBY_ALLOTMENT("Allotment/Herb/Flower", new WorldPoint(2810, 3462, 0)),
-	CATHERBY_FRUIT_TREE("Fruit Tree", new WorldPoint(2858, 3432, 0)),
-	CHAMPIONS_GUILD_BUSH("Bush", new WorldPoint(3182, 3356, 0)),
-	DRAYNOR_MANOR_BELLADONNA("Belladonna", new WorldPoint(3084, 3356, 0)),
-	ENTRANA_HOPS("Hops", new WorldPoint(3812, 3334, 0)),
-	ETCETERIA_BUSH("Bush", new WorldPoint(2589, 3862, 0)),
-	ETCETERIA_SPIRIT_TREE("Spirit Tree", new WorldPoint(3614, 3856, 0)),
-	FALADOR_TREE("Tree", new WorldPoint(3005, 3375, 0)),
-	FALADOR_ALLOTMENT("Allotment/Herb/Flower", new WorldPoint(3052, 3309, 0)),
-	FOSSIL_ISLAND_HARDWOOD("Hardwood", new WorldPoint(3707, 3838, 0)),
-	FOSSIL_ISLAND_SEAWEED("Seaweed", new WorldPoint(3730, 10271, 0)),
-	GNOME_STRONGHOLD_TREE("Tree", new WorldPoint(2434, 3418, 0)),
-	GNOME_STRONGHOLD_FRUIT_TREE("Fruit Tree", new WorldPoint(2472, 3445, 0)),
-	HARMONY_ALLOTMENT("Allotment/Herb/Flower", new WorldPoint(3793, 2836, 0)),
-	HARMONY_HERB("Herb", new WorldPoint(3789, 2840, 0)),
-	KOUREND_ALLOTMENT("Allotment/Herb/Flower", new WorldPoint(1809, 3490, 0)),
-	KOUREND_SPIRIT_TREE("Spirit Tree", new WorldPoint(1690, 3540, 0)),
-	KOUREND_GRAPES("Grapes", new WorldPoint(1807, 3555, 0)),
-	LLTEYA_FRUIT_TREE("Fruit Tree", new WorldPoint(2343, 3160, 0)),
-	LUMBRIDGE_HOPS("Hops", new WorldPoint(3224, 3313, 0)),
-	LUMBRIDGE_TREE("Tree", new WorldPoint(3189, 3233, 0)),
-	MORYTANIA_MUSHROOM("Mushroom", new WorldPoint(3449, 3471, 0)),
-	MORYTANIA_ALLOTMENT("Allotment/Herb/Flower", new WorldPoint(3598, 3524, 0)),
-	PORT_SARIM_SPIRIT_TREE("Spirit Tree", new WorldPoint(3056, 3259, 0)),
-	RIMMINGTON_BUSH("Bush", new WorldPoint(2938, 3223, 0)),
-	SEERS_VILLAGE_HOPS("Hops", new WorldPoint(2661, 3523, 0)),
-	TAI_BWO_WANNAI_CALQUAT("Calquat", new WorldPoint(2793, 3099, 0)),
-	TAVERLEY_TREE("Tree", new WorldPoint(2933, 3436, 0)),
-	TREE_GNOME_VILLAGE_FRUIT_TREE("Fruit tree", new WorldPoint(2487, 3181, 0)),
-	TROLL_STRONGHOLD_HERB("Herb", new WorldPoint(2828, 3696, 0)),
-	VARROCK_TREE("Tree", new WorldPoint(3226, 3457, 0)),
-	YANILLE_HOPS("Hops", new WorldPoint(2572, 3102, 0)),
-	WEISS_HERB("Herb", new WorldPoint(2847, 3933, 0));
-
+	ALLOTMENT("Allotment", new WorldPoint(3793, 2836, 0)),
+	ALLOTMENT_HERB_FLOWER("Allotment/Herb/Flower",
+		new WorldPoint(1809, 3490, 0),
+		new WorldPoint(3598, 3524, 0),
+		new WorldPoint(3052, 3309, 0),
+		new WorldPoint(2810, 3462, 0),
+		new WorldPoint(2663, 3375, 0)
+	),
+	BELLADONNA("Belladonna", new WorldPoint(3084, 3356, 0)),
+	BUSH("Bush",
+		new WorldPoint(2938, 3223, 0),
+		new WorldPoint(2589, 3862, 0),
+		new WorldPoint(3182, 3356, 0),
+		new WorldPoint(2615, 3224, 0)
+	),
+	CACTUS("Cactus", new WorldPoint(3313, 3201, 0)),
+	CALQUAT("Calquat", new WorldPoint(2793, 3099, 0)),
+	FRUIT_TREE("Fruit Tree",
+		new WorldPoint(2487, 3181, 0),
+		new WorldPoint(2343, 3160, 0),
+		new WorldPoint(2472, 3445, 0),
+		new WorldPoint(2858, 3432, 0),
+		new WorldPoint(2765, 3211, 0)
+	),
+	GRAPES("Grapes", new WorldPoint(1807, 3555, 0)),
+	HARDWOOD("Hardwood",
+		new WorldPoint(3707, 3838, 0)
+	),
+	HERB("Herb",
+		new WorldPoint(3789, 2840, 0),
+		new WorldPoint(2847, 3933, 0),
+		new WorldPoint(2828, 3696, 0)
+	),
+	HOPS("Hops",
+		new WorldPoint(2572, 3102, 0),
+		new WorldPoint(2661, 3523, 0),
+		new WorldPoint(3224, 3313, 0),
+		new WorldPoint(3812, 3334, 0)
+	),
+	MUSHROOM("Mushroom", new WorldPoint(3449, 3471, 0)),
+	SEAWEED("Seaweed", new WorldPoint(3730, 10271, 0)),
+	SPIRIT_TREE("Spirit Tree",
+		new WorldPoint(3056, 3259, 0),
+		new WorldPoint(1690, 3540, 0),
+		new WorldPoint(3614, 3856, 0),
+		new WorldPoint(2799, 3205, 0)
+	),
+	TREE("Tree",
+		new WorldPoint(3226, 3457, 0),
+		new WorldPoint(2933, 3436, 0),
+		new WorldPoint(3189, 3233, 0),
+		new WorldPoint(2434, 3418, 0),
+		new WorldPoint(3005, 3375, 0)
+	);
 
 	private final String tooltip;
-	private final WorldPoint location;
+	private final WorldPoint[] locations;
 
-	FarmingPatchLocation(String description, WorldPoint location)
+	FarmingPatchLocation(String description, WorldPoint... locations)
 	{
 		this.tooltip = "Farming patch - " + description;
-		this.location = location;
+		this.locations = locations;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldmap/FarmingPatchLocation.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldmap/FarmingPatchLocation.java
@@ -1,3 +1,28 @@
+/*
+ * Copyright (c) 2018, Torkel Velure <https://github.com/TorkelV>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package net.runelite.client.plugins.worldmap;
 
 import lombok.Getter;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldmap/FarmingPatchLocation.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldmap/FarmingPatchLocation.java
@@ -1,0 +1,57 @@
+package net.runelite.client.plugins.worldmap;
+
+import lombok.Getter;
+import net.runelite.api.coords.WorldPoint;
+
+@Getter
+enum FarmingPatchLocation
+{
+	AL_KHARID_CACTUS("Cactus", new WorldPoint(3313, 3201, 0)),
+	ARDOUGNE_BUSH("Bush", new WorldPoint(2615, 3224, 0)),
+	ARDOUGNE_ALLOTMENT("Allotment/Herb/Flower", new WorldPoint(2663, 3375, 0)),
+	BRIMHAVEN_SPIRIT_TREE("Spirit Tree", new WorldPoint(2799, 3205, 0)),
+	BRIMHAVEN_FRUIT_TREE("Fruit Tree", new WorldPoint(2765, 3211, 0)),
+	CATHERBY_ALLOTMENT("Allotment/Herb/Flower", new WorldPoint(2810, 3462, 0)),
+	CATHERBY_FRUIT_TREE("Fruit Tree", new WorldPoint(2858, 3432, 0)),
+	CHAMPIONS_GUILD_BUSH("Bush", new WorldPoint(3182, 3356, 0)),
+	DRAYNOR_MANOR_BELLADONNA("Belladonna", new WorldPoint(3084, 3356, 0)),
+	ENTRANA_HOPS("Hops", new WorldPoint(3812, 3334, 0)),
+	ETCETERIA_BUSH("Bush", new WorldPoint(2589, 3862, 0)),
+	ETCETERIA_SPIRIT_TREE("Spirit Tree", new WorldPoint(3614, 3856, 0)),
+	FALADOR_TREE("Tree", new WorldPoint(3005, 3375, 0)),
+	FALADOR_ALLOTMENT("Allotment/Herb/Flower", new WorldPoint(3052, 3309, 0)),
+	FOSSIL_ISLAND_HARDWOOD("Hardwood", new WorldPoint(3707, 3838, 0)),
+	FOSSIL_ISLAND_SEAWEED("Seaweed", new WorldPoint(3730, 10271, 0)),
+	GNOME_STRONGHOLD_TREE("Tree", new WorldPoint(2434, 3418, 0)),
+	GNOME_STRONGHOLD_FRUIT_TREE("Fruit Tree", new WorldPoint(2472, 3445, 0)),
+	HARMONY_ALLOTMENT("Allotment/Herb/Flower", new WorldPoint(3793, 2836, 0)),
+	HARMONY_HERB("Herb", new WorldPoint(3789, 2840, 0)),
+	KOUREND_ALLOTMENT("Allotment/Herb/Flower", new WorldPoint(1809, 3490, 0)),
+	KOUREND_SPIRIT_TREE("Spirit Tree", new WorldPoint(1690, 3540, 0)),
+	KOUREND_GRAPES("Grapes", new WorldPoint(1807, 3555, 0)),
+	LLTEYA_FRUIT_TREE("Fruit Tree", new WorldPoint(2343, 3160, 0)),
+	LUMBRIDGE_HOPS("Hops", new WorldPoint(3224, 3313, 0)),
+	LUMBRIDGE_TREE("Tree", new WorldPoint(3189, 3233, 0)),
+	MORYTANIA_MUSHROOM("Mushroom", new WorldPoint(3449, 3471, 0)),
+	MORYTANIA_ALLOTMENT("Allotment/Herb/Flower", new WorldPoint(3598, 3524, 0)),
+	PORT_SARIM_SPIRIT_TREE("Spirit Tree", new WorldPoint(3056, 3259, 0)),
+	RIMMINGTON_BUSH("Bush", new WorldPoint(2938, 3223, 0)),
+	SEERS_VILLAGE_HOPS("Hops", new WorldPoint(2661, 3523, 0)),
+	TAI_BWO_WANNAI_CALQUAT("Calquat", new WorldPoint(2793, 3099, 0)),
+	TAVERLEY_TREE("Tree", new WorldPoint(2933, 3436, 0)),
+	TREE_GNOME_VILLAGE_FRUIT_TREE("Fruit tree", new WorldPoint(2487, 3181, 0)),
+	TROLL_STRONGHOLD_HERB("Herb", new WorldPoint(2828, 3696, 0)),
+	VARROCK_TREE("Tree", new WorldPoint(3226, 3457, 0)),
+	YANILLE_HOPS("Hops", new WorldPoint(2572, 3102, 0)),
+	WEISS_HERB("Herb", new WorldPoint(2847, 3933, 0));
+
+
+	private final String tooltip;
+	private final WorldPoint location;
+
+	FarmingPatchLocation(String description, WorldPoint location)
+	{
+		this.tooltip = "Farming patch - " + description;
+		this.location = location;
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldmap/FarmingPatchPoint.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldmap/FarmingPatchPoint.java
@@ -31,7 +31,6 @@ import net.runelite.client.ui.overlay.worldmap.WorldMapPoint;
 
 class FarmingPatchPoint extends WorldMapPoint
 {
-
 	FarmingPatchPoint(WorldPoint point, String tooltip, BufferedImage icon)
 	{
 		super(point, icon);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldmap/FarmingPatchPoint.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldmap/FarmingPatchPoint.java
@@ -1,3 +1,28 @@
+/*
+ * Copyright (c) 2018, Torkel Velure <https://github.com/TorkelV>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package net.runelite.client.plugins.worldmap;
 
 import java.awt.image.BufferedImage;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldmap/FarmingPatchPoint.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldmap/FarmingPatchPoint.java
@@ -1,0 +1,14 @@
+package net.runelite.client.plugins.worldmap;
+
+import java.awt.image.BufferedImage;
+import net.runelite.client.ui.overlay.worldmap.WorldMapPoint;
+
+class FarmingPatchPoint extends WorldMapPoint
+{
+
+	FarmingPatchPoint(FarmingPatchLocation data, BufferedImage icon)
+	{
+		super(data.getLocation(), icon);
+		setTooltip(data.getTooltip());
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldmap/FarmingPatchPoint.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldmap/FarmingPatchPoint.java
@@ -26,14 +26,15 @@
 package net.runelite.client.plugins.worldmap;
 
 import java.awt.image.BufferedImage;
+import net.runelite.api.coords.WorldPoint;
 import net.runelite.client.ui.overlay.worldmap.WorldMapPoint;
 
 class FarmingPatchPoint extends WorldMapPoint
 {
 
-	FarmingPatchPoint(FarmingPatchLocation data, BufferedImage icon)
+	FarmingPatchPoint(WorldPoint point, String tooltip, BufferedImage icon)
 	{
-		super(data.getLocation(), icon);
-		setTooltip(data.getTooltip());
+		super(point, icon);
+		setTooltip(tooltip);
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldmap/WorldMapConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldmap/WorldMapConfig.java
@@ -76,6 +76,7 @@ public interface WorldMapConfig extends Config
 		return true;
 	}
 
+
 	@ConfigItem(
 		keyName = WorldMapPlugin.CONFIG_KEY_NORMAL_TELEPORT_ICON,
 		name = "Show Standard Spellbook destinations",
@@ -171,6 +172,17 @@ public interface WorldMapConfig extends Config
 		position = 13
 	)
 	default boolean questStartTooltips()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		keyName = WorldMapPlugin.CONFIG_KEY_FARMING_PATCH_TOOLTIPS,
+		name = "Show farming patch type",
+		description = "Display the type of farming patches in the icon tooltip",
+		position = 14
+	)
+	default boolean farmingPatchTooltips()
 	{
 		return true;
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldmap/WorldMapConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldmap/WorldMapConfig.java
@@ -76,7 +76,6 @@ public interface WorldMapConfig extends Config
 		return true;
 	}
 
-
 	@ConfigItem(
 		keyName = WorldMapPlugin.CONFIG_KEY_NORMAL_TELEPORT_ICON,
 		name = "Show Standard Spellbook destinations",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldmap/WorldMapPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldmap/WorldMapPlugin.java
@@ -197,7 +197,6 @@ public class WorldMapPlugin extends Plugin
 				.forEach(worldMapPointManager::add);
 		}
 
-
 		worldMapPointManager.removeIf(TeleportPoint.class::isInstance);
 		Arrays.stream(TeleportLocationData.values())
 			.filter(data ->

--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldmap/WorldMapPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldmap/WorldMapPlugin.java
@@ -44,7 +44,7 @@ import net.runelite.client.util.ImageUtil;
 @PluginDescriptor(
 	name = "World Map",
 	description = "Enhance the world map to display additional information",
-	tags = {"agility", "fairy", "rings", "teleports"}
+	tags = {"agility", "fairy", "rings", "teleports", "farming"}
 )
 public class WorldMapPlugin extends Plugin
 {
@@ -66,6 +66,7 @@ public class WorldMapPlugin extends Plugin
 	static final String CONFIG_KEY_MISC_TELEPORT_ICON = "miscellaneousTeleportIcon";
 	static final String CONFIG_KEY_QUEST_START_TOOLTIPS = "questStartTooltips";
 	static final String CONFIG_KEY_MINIGAME_TOOLTIP = "minigameTooltip";
+	static final String CONFIG_KEY_FARMING_PATCH_TOOLTIPS = "farmingpatchTooltips";
 
 	static
 	{
@@ -115,6 +116,7 @@ public class WorldMapPlugin extends Plugin
 		worldMapPointManager.removeIf(QuestStartPoint.class::isInstance);
 		worldMapPointManager.removeIf(TeleportPoint.class::isInstance);
 		worldMapPointManager.removeIf(MinigamePoint.class::isInstance);
+		worldMapPointManager.removeIf(FarmingPatchPoint.class::isInstance);
 		agilityLevel = 0;
 	}
 
@@ -186,6 +188,15 @@ public class WorldMapPlugin extends Plugin
 				.map(value -> new QuestStartPoint(value, BLANK_ICON))
 				.forEach(worldMapPointManager::add);
 		}
+
+		worldMapPointManager.removeIf(FarmingPatchPoint.class::isInstance);
+		if (config.farmingPatchTooltips())
+		{
+			Arrays.stream(FarmingPatchLocation.values())
+				.map(value -> new FarmingPatchPoint(value, BLANK_ICON))
+				.forEach(worldMapPointManager::add);
+		}
+
 
 		worldMapPointManager.removeIf(TeleportPoint.class::isInstance);
 		Arrays.stream(TeleportLocationData.values())

--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldmap/WorldMapPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldmap/WorldMapPlugin.java
@@ -44,7 +44,7 @@ import net.runelite.client.util.ImageUtil;
 @PluginDescriptor(
 	name = "World Map",
 	description = "Enhance the world map to display additional information",
-	tags = {"agility", "fairy", "rings", "teleports", "farming"}
+	tags = {"agility", "fairy", "farming", "rings", "teleports"}
 )
 public class WorldMapPlugin extends Plugin
 {
@@ -192,9 +192,11 @@ public class WorldMapPlugin extends Plugin
 		worldMapPointManager.removeIf(FarmingPatchPoint.class::isInstance);
 		if (config.farmingPatchTooltips())
 		{
-			Arrays.stream(FarmingPatchLocation.values())
-				.map(value -> new FarmingPatchPoint(value, BLANK_ICON))
-				.forEach(worldMapPointManager::add);
+			Arrays.stream(FarmingPatchLocation.values()).forEach(location ->
+				Arrays.stream(location.getLocations())
+					.map(point -> new FarmingPatchPoint(point, location.getTooltip(), BLANK_ICON))
+					.forEach(worldMapPointManager::add)
+			);
 		}
 
 		worldMapPointManager.removeIf(TeleportPoint.class::isInstance);


### PR DESCRIPTION
In response to #7091. 
Simply changes the tooltips of farming patches on the world map to show the farming patch type (Bush, Tree, Herb...).

Closes #7091 