### PR TITLE
Fix NPE Object Indicators Plugin

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/objectindicators/ObjectIndicatorsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/objectindicators/ObjectIndicatorsPlugin.java
@@ -257,6 +257,11 @@ public class ObjectIndicatorsPlugin extends Plugin implements KeyListener
 
 	private TileObject findTileObject(Tile tile, int id)
 	{
+		if (tile == null)
+		{
+			return null;
+		}
+
 		final GameObject[] tileGameObjects = tile.getGameObjects();
 
 		for (GameObject object : tileGameObjects)


### PR DESCRIPTION
When trying to highlight an object such as a trapdoor, the one to Keldagrim from the GE for example, or a staircase, the down stairs in Varrock West Bank for another example, a Null Pointer Exception was being thrown. Make sure the target objects tile is not null before trying to find the object to mark.