### PR TITLE
experiencedrop: Maintain active prayer per tick

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/experiencedrop/XpDropPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/experiencedrop/XpDropPlugin.java
@@ -66,6 +66,7 @@ public class XpDropPlugin extends Plugin
 	private boolean hasDropped = false;
 	private Skill lastSkill = null;
 	private Map<Skill, Integer> previousSkillExpTable = new EnumMap<>(Skill.class);
+	private PrayerType currentTickPrayer;
 
 	@Provides
 	XpDropConfig provideConfig(ConfigManager configManager)
@@ -133,7 +134,7 @@ public class XpDropPlugin extends Plugin
 			}
 		}
 
-		PrayerType prayer = getActivePrayerType();
+		PrayerType prayer = currentTickPrayer;
 		if (prayer == null)
 		{
 			resetTextColor(widget);
@@ -199,6 +200,8 @@ public class XpDropPlugin extends Plugin
 	@Subscribe
 	public void onGameTick(GameTick tick)
 	{
+		currentTickPrayer = getActivePrayerType();
+
 		final int fakeTickDelay = config.fakeXpDropDelay();
 
 		if (fakeTickDelay == 0 || lastSkill == null)


### PR DESCRIPTION
This commit fixes the occasional issue of xp drops not being highlighted
while flicking prayer from the prayer menu; that is, before this commit
it was possible to select or deselect a prayer between xp drop widgets
being spawned, causing different highlighting for them. This commit
saves the active prayer at the beginning of each tick and uses that
tick's prayer for all widgets unhidden during that tick.

Fixes runelite/runelite#1280
Closes runelite/runelite#6679