### PR TITLE
Add menu swapper for Altar of the Occult to swap to magic book of choice

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -173,6 +173,16 @@ public interface MenuEntrySwapperConfig extends Config
 	}
 
 	@ConfigItem(
+			keyName = "swapOccultAltar",
+			name = "Occult Altar",
+			description = "Swap Venerate with Ancient, Lunar, or Arceuus on an Altar of the Occult"
+	)
+	default OccultAltarMode swapOccultAltar()
+	{
+		return OccultAltarMode.VENERATE;
+	}
+
+	@ConfigItem(
 		keyName = "swapPickpocket",
 		name = "Pickpocket on H.A.M.",
 		description = "Swap Talk-to with Pickpocket on H.A.M members"

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -471,6 +471,23 @@ public class MenuEntrySwapperPlugin extends Plugin
 		{
 			swap("zanaris", option, target, false);
 		}
+		else if (config.swapOccultAltar() != OccultAltarMode.VENERATE && option.equals("venerate"))
+		{
+			switch (config.swapOccultAltar())
+			{
+				case ANCIENT:
+					swap("ancient", option, target, true);
+					break;
+				case LUNAR:
+					swap("lunar", option, target, true);
+					break;
+				case ARCEUUS:
+					swap("arceuus", option, target, true);
+					break;
+			}
+			// Hacky way to swap back to standard if not already on it.
+			swap("standard", option, target, true);
+		}
 		else if (config.swapBoxTrap() && (option.equals("check") || option.equals("dismantle")))
 		{
 			swap("reset", option, target, true);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/OccultAltarMode.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/OccultAltarMode.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2019, Spedwards <http://github.com/Spedwards>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.menuentryswapper;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum OccultAltarMode
+{
+	ANCIENT("Ancient"),
+	LUNAR("Lunar"),
+	ARCEUUS("Arceuus"),
+	VENERATE("Venerate");
+
+	private final String name;
+
+	@Override
+	public String toString()
+	{
+		return name;
+	}
+}


### PR DESCRIPTION
Many players use hosted occult altars to swap their magic book. Most of the time, it's back-and-forth between the standard book and one of the other books. With this extension, you'll be able to set which magic book they want to switch between.

This extension is disabled by default.

Example: https://gfycat.com/ThatDisastrousBobwhite