### PR TITLE
Add Inventory Viewer config option to hide viewer when player inventory is open

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/VarClientInt.java
+++ b/runelite-api/src/main/java/net/runelite/api/VarClientInt.java
@@ -46,6 +46,12 @@ public enum VarClientInt
 
 	MEMBERSHIP_STATUS(103),
 
+	/**
+	 * -1 = player inventory closed
+	 * 3 = player inventory opened
+	 */
+	PLAYER_INVENTORY_OPENED(171),
+
 	WORLD_MAP_SEARCH_FOCUSED(190);
 
 	private final int index;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/inventoryviewer/InventoryViewerConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/inventoryviewer/InventoryViewerConfig.java
@@ -8,9 +8,9 @@ import net.runelite.client.config.ConfigItem;
 public interface InventoryViewerConfig extends Config
 {
 	@ConfigItem(
-			keyName = "hideWhenInvOpen",
-			name = "Hide when inventory is open",
-			description = "Hide the inventory viewer when the player's inventory is open"
+		keyName = "hideWhenInvOpen",
+		name = "Hide when inventory is open",
+		description = "Hide the inventory viewer when the player's inventory is open"
 	)
 	default boolean hideWhenInvOpen()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/inventoryviewer/InventoryViewerConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/inventoryviewer/InventoryViewerConfig.java
@@ -1,0 +1,16 @@
+package net.runelite.client.plugins.inventoryviewer;
+
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+
+@ConfigGroup("inventoryviewer")
+public interface InventoryViewerConfig extends Config
+{
+	@ConfigItem(
+			keyName = "hideWhenInvOpen",
+			name = "Hide when inventory is open",
+			description = "Hide the inventory viewer when the player's inventory is open"
+	)
+	default boolean hideWhenInvOpen() { return false; }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/inventoryviewer/InventoryViewerConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/inventoryviewer/InventoryViewerConfig.java
@@ -12,5 +12,8 @@ public interface InventoryViewerConfig extends Config
 			name = "Hide when inventory is open",
 			description = "Hide the inventory viewer when the player's inventory is open"
 	)
-	default boolean hideWhenInvOpen() { return false; }
+	default boolean hideWhenInvOpen()
+	{
+		return false;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/inventoryviewer/InventoryViewerOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/inventoryviewer/InventoryViewerOverlay.java
@@ -33,6 +33,7 @@ import net.runelite.api.Client;
 import net.runelite.api.InventoryID;
 import net.runelite.api.Item;
 import net.runelite.api.ItemContainer;
+import net.runelite.api.VarClientInt;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayPosition;
@@ -47,24 +48,32 @@ class InventoryViewerOverlay extends Overlay
 	private static final ImageComponent PLACEHOLDER_IMAGE = new ImageComponent(new BufferedImage(PLACEHOLDER_WIDTH, PLACEHOLDER_HEIGHT, BufferedImage.TYPE_4BYTE_ABGR));
 
 	private final Client client;
+	private final InventoryViewerConfig config;
 	private final ItemManager itemManager;
 
 	private final PanelComponent panelComponent = new PanelComponent();
 
 	@Inject
-	private InventoryViewerOverlay(Client client, ItemManager itemManager)
+	private InventoryViewerOverlay(Client client, InventoryViewerConfig config, ItemManager itemManager)
 	{
 		setPosition(OverlayPosition.BOTTOM_RIGHT);
 		panelComponent.setWrapping(4);
 		panelComponent.setGap(new Point(6, 4));
 		panelComponent.setOrientation(PanelComponent.Orientation.HORIZONTAL);
-		this.itemManager = itemManager;
 		this.client = client;
+		this.config = config;
+		this.itemManager = itemManager;
 	}
 
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
+		if (config.hideWhenInvOpen()
+			&& client.getVar(VarClientInt.PLAYER_INVENTORY_OPENED) == 3)
+		{
+			return null;
+		}
+
 		final ItemContainer itemContainer = client.getItemContainer(InventoryID.INVENTORY);
 
 		if (itemContainer == null)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/inventoryviewer/InventoryViewerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/inventoryviewer/InventoryViewerPlugin.java
@@ -24,6 +24,8 @@
  */
 package net.runelite.client.plugins.inventoryviewer;
 
+import com.google.inject.Provides;
+import net.runelite.client.config.ConfigManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import javax.inject.Inject;
@@ -42,6 +44,12 @@ public class InventoryViewerPlugin extends Plugin
 
 	@Inject
 	private OverlayManager overlayManager;
+
+	@Provides
+	InventoryViewerConfig getConfig(ConfigManager configManager)
+	{
+		return configManager.getConfig(InventoryViewerConfig.class);
+	}
 
 	@Override
 	public void startUp()


### PR DESCRIPTION
I love the inventory viewer but it drives me nuts to have a duplicate inventory visible while my player inventory is open. This PR adds a simple config option which hides the viewer when then player's inventory is currently open.