### PR TITLE
dev tools: Fix overlay layer

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/devtools/DevToolsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/devtools/DevToolsOverlay.java
@@ -103,7 +103,7 @@ class DevToolsOverlay extends Overlay
 	private DevToolsOverlay(Client client, DevToolsPlugin plugin, TooltipManager toolTipManager)
 	{
 		setPosition(OverlayPosition.DYNAMIC);
-		setLayer(OverlayLayer.ALWAYS_ON_TOP);
+		setLayer(OverlayLayer.ABOVE_MAP);
 		this.client = client;
 		this.plugin = plugin;
 		this.toolTipManager = toolTipManager;


### PR DESCRIPTION
After the introduction of the new ABOVE_MAP layer, the dev tools overlay
was no longer able to draw above the map, which is needed for the widget
inspector.