### PR TITLE
Only log the IOException message on failure to submit CML update.

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/crystalmathlabs/CrystalMathLabs.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/crystalmathlabs/CrystalMathLabs.java
@@ -128,7 +128,7 @@ public class CrystalMathLabs extends Plugin
 			@Override
 			public void onFailure(Call call, IOException e)
 			{
-				log.warn("error submitting CML update", e);
+				log.warn("Error submitting CML update, caused by {}.", e.getMessage());
 			}
 
 			@Override


### PR DESCRIPTION
Make the CML Plugin only log the IOException message on failure to submit CML update.
<br>
<details><summary> The log.warn() output to console before:  </summary>
<br>

`
2019-01-02 14:26:48 [OkHttp https://crystalmathlabs.com/...] WARN  n.r.c.p.c.CrystalMathLabs - error submitting CML update
java.net.SocketTimeoutException: timeout
    at okio.Okio$4.newTimeoutException(Okio.java:227)
    at okio.AsyncTimeout.exit(AsyncTimeout.java:284)
    at okio.AsyncTimeout$2.read(AsyncTimeout.java:240)
    at okio.RealBufferedSource.indexOf(RealBufferedSource.java:344)
    at okio.RealBufferedSource.readUtf8LineStrict(RealBufferedSource.java:216)
    at okio.RealBufferedSource.readUtf8LineStrict(RealBufferedSource.java:210)
    at okhttp3.internal.http1.Http1Codec.readResponseHeaders(Http1Codec.java:189)
    at okhttp3.internal.http.CallServerInterceptor.intercept(CallServerInterceptor.java:75)
    at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:92)
    at okhttp3.internal.connection.ConnectInterceptor.intercept(ConnectInterceptor.java:45)
    at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:92)
    at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:67)
    at okhttp3.internal.cache.CacheInterceptor.intercept(CacheInterceptor.java:93)
    at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:92)
    at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:67)
    at okhttp3.internal.http.BridgeInterceptor.intercept(BridgeInterceptor.java:93)
    at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:92)
    at okhttp3.internal.http.RetryAndFollowUpInterceptor.intercept(RetryAndFollowUpInterceptor.java:120)
    at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:92)
    at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:67)
    at okhttp3.RealCall.getResponseWithInterceptorChain(RealCall.java:185)
    at okhttp3.RealCall$AsyncCall.execute(RealCall.java:135)
    at okhttp3.internal.NamedRunnable.run(NamedRunnable.java:32)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
    at java.lang.Thread.run(Thread.java:748)
Caused by: java.net.SocketTimeoutException: Read timed out
    at java.net.SocketInputStream.socketRead0(Native Method)
    at java.net.SocketInputStream.socketRead(SocketInputStream.java:116)
    at java.net.SocketInputStream.read(SocketInputStream.java:171)
    at java.net.SocketInputStream.read(SocketInputStream.java:141)
    at sun.security.ssl.InputRecord.readFully(InputRecord.java:465)
    at sun.security.ssl.InputRecord.read(InputRecord.java:503)
    at sun.security.ssl.SSLSocketImpl.readRecord(SSLSocketImpl.java:983)
    at sun.security.ssl.SSLSocketImpl.readDataRecord(SSLSocketImpl.java:940)
    at sun.security.ssl.AppInputStream.read(AppInputStream.java:105)
    at okio.Okio$2.read(Okio.java:138)
    at okio.AsyncTimeout$2.read(AsyncTimeout.java:236)
    ... 23 common frames omitted
`

</details>
<br>
<details><summary> The log.warn() output to console after: </summary>
<br>

`
2019-01-02 23:27:20 [OkHttp https://crystalmathlabs.com/...] WARN  n.r.c.p.c.CrystalMathLabs - Error submitting CML update, caused by timeout.
`
</details>