### PR TITLE
Add kills/hr to loot tracker

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
@@ -30,6 +30,7 @@ import com.google.common.base.Splitter;
 import com.google.inject.Provides;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -72,6 +73,7 @@ import net.runelite.client.game.ItemStack;
 import net.runelite.client.game.SpriteManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.task.Schedule;
 import net.runelite.client.ui.ClientToolbar;
 import net.runelite.client.ui.NavigationButton;
 import net.runelite.client.util.ImageUtil;
@@ -396,6 +398,15 @@ public class LootTrackerPlugin extends Plugin
 					break;
 			}
 		}
+	}
+
+	@Schedule(
+		period = 5,
+		unit = ChronoUnit.SECONDS
+	)
+	public void tickSkillTimes()
+	{
+		panel.updateOverall();
 	}
 
 	void toggleItem(String name, boolean ignore)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerRecord.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerRecord.java
@@ -24,15 +24,19 @@
  */
 package net.runelite.client.plugins.loottracker;
 
-import lombok.Value;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
 
-@Value
+@AllArgsConstructor
+@Getter
 class LootTrackerRecord
 {
 	private final String title;
 	private final String subTitle;
 	private final LootTrackerItem[] items;
-	private final long timestamp;
+	@Setter
+	private long timestamp;
 
 	/**
 	 * Checks if this record matches specified id


### PR DESCRIPTION
Add a field to the loot tracker showing how many kills/hr you're getting. To see the kills/hr of a specific npc, go to the details page. The kills/hr isn't affected by imported kills and can be reset without resetting the loot tracker.

https://i.imgur.com/pu7GPcO.gifv