### PR TITLE
 Loot Tracker - Add optional automatic local data output 

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootRecordWriter.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootRecordWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Psikoi <https://github.com/psikoi>
+ * Copyright (c) 2018, TheStonedTurtle <https://github.com/TheStonedTurtle>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -22,50 +22,56 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-
 package net.runelite.client.plugins.loottracker;
 
-import net.runelite.client.config.Config;
-import net.runelite.client.config.ConfigGroup;
-import net.runelite.client.config.ConfigItem;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import lombok.extern.slf4j.Slf4j;
+import static net.runelite.client.RuneLite.RUNELITE_DIR;
+import net.runelite.http.api.RuneLiteAPI;
+import net.runelite.http.api.loottracker.LootRecord;
 
-@ConfigGroup("loottracker")
-public interface LootTrackerConfig extends Config
+@Slf4j
+class LootRecordWriter
 {
-	@ConfigItem(
-		keyName = "ignoredItems",
-		name = "Ignored items",
-		description = "Configures which items should be ignored when calculating loot prices."
-	)
-	default String getIgnoredItems()
+	private static final String FILE_EXTENSION = ".log";
+	private static final File LOOT_RECORD_DIR = new File(RUNELITE_DIR, "loots");
+
+	private File playerFolder = LOOT_RECORD_DIR;
+
+	LootRecordWriter()
 	{
-		return "";
+		playerFolder.mkdir();
 	}
 
-	@ConfigItem(
-		keyName = "ignoredItems",
-		name = "",
-		description = ""
-	)
-	void setIgnoredItems(String key);
-
-	@ConfigItem(
-		keyName = "saveLoot",
-		name = "Save loot",
-		description = "Save loot between client sessions (requires being logged in)"
-	)
-	default boolean saveLoot()
+	private static String asFileName(String name)
 	{
-		return true;
+		return name.toLowerCase().trim() + FILE_EXTENSION;
 	}
 
-	@ConfigItem(
-		keyName = "saveLocalLoot",
-		name = "Save loot locally",
-		description = "Outputs loot as json to log files on your local machine (only saves data)"
-	)
-	default boolean saveLocalLoot()
+	void setPlayerUsername(String username)
 	{
-		return false;
+		playerFolder = new File(LOOT_RECORD_DIR, username);
+		playerFolder.mkdir();
+	}
+
+	synchronized void addLootTrackerRecord(LootRecord rec)
+	{
+		File lootFile = new File(playerFolder, asFileName(rec.getEventId()));
+		String dataAsString = RuneLiteAPI.GSON.toJson(rec);
+
+		try
+		{
+			BufferedWriter file = new BufferedWriter(new FileWriter(String.valueOf(lootFile), true));
+			file.append(dataAsString);
+			file.newLine();
+			file.close();
+		}
+		catch (IOException ioe)
+		{
+			log.warn("Error writing loot data to file {}: {}", asFileName(rec.getEventId()), ioe.getMessage());
+		}
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
@@ -47,6 +47,7 @@ import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
+import net.runelite.api.GameState;
 import net.runelite.api.InventoryID;
 import net.runelite.api.ItemComposition;
 import net.runelite.api.ItemContainer;
@@ -56,6 +57,7 @@ import net.runelite.api.SpriteID;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.ChatMessage;
 import net.runelite.api.events.ConfigChanged;
+import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.SessionClose;
 import net.runelite.api.events.SessionOpen;
 import net.runelite.api.events.WidgetLoaded;
@@ -133,6 +135,8 @@ public class LootTrackerPlugin extends Plugin
 
 	@Getter(AccessLevel.PACKAGE)
 	private LootTrackerClient lootTrackerClient;
+
+	private LootRecordWriter writer;
 
 	private static Collection<ItemStack> stack(Collection<ItemStack> items)
 	{
@@ -262,6 +266,8 @@ public class LootTrackerPlugin extends Plugin
 				return true;
 			});
 		}
+
+		writer = new LootRecordWriter();
 	}
 
 	@Override
@@ -281,10 +287,15 @@ public class LootTrackerPlugin extends Plugin
 		final LootTrackerItem[] entries = buildEntries(stack(items));
 		SwingUtilities.invokeLater(() -> panel.add(name, combat, entries));
 
+		LootRecord lootRecord = new LootRecord(name, LootRecordType.NPC, toGameItems(items));
 		if (lootTrackerClient != null && config.saveLoot())
 		{
-			LootRecord lootRecord = new LootRecord(name, LootRecordType.NPC, toGameItems(items));
 			lootTrackerClient.submit(lootRecord);
+		}
+
+		if (config.saveLocalLoot())
+		{
+			writer.addLootTrackerRecord(lootRecord);
 		}
 	}
 
@@ -298,10 +309,15 @@ public class LootTrackerPlugin extends Plugin
 		final LootTrackerItem[] entries = buildEntries(stack(items));
 		SwingUtilities.invokeLater(() -> panel.add(name, combat, entries));
 
+		LootRecord lootRecord = new LootRecord(name, LootRecordType.PLAYER, toGameItems(items));
 		if (lootTrackerClient != null && config.saveLoot())
 		{
-			LootRecord lootRecord = new LootRecord(name, LootRecordType.PLAYER, toGameItems(items));
 			lootTrackerClient.submit(lootRecord);
+		}
+
+		if (config.saveLocalLoot())
+		{
+			writer.addLootTrackerRecord(lootRecord);
 		}
 	}
 
@@ -357,10 +373,15 @@ public class LootTrackerPlugin extends Plugin
 		final LootTrackerItem[] entries = buildEntries(stack(items));
 		SwingUtilities.invokeLater(() -> panel.add(eventType, -1, entries));
 
+		LootRecord lootRecord = new LootRecord(eventType, LootRecordType.EVENT, toGameItems(items));
 		if (lootTrackerClient != null && config.saveLoot())
 		{
-			LootRecord lootRecord = new LootRecord(eventType, LootRecordType.EVENT, toGameItems(items));
 			lootTrackerClient.submit(lootRecord);
+		}
+
+		if (config.saveLocalLoot())
+		{
+			writer.addLootTrackerRecord(lootRecord);
 		}
 	}
 
@@ -462,5 +483,39 @@ public class LootTrackerPlugin extends Plugin
 		}
 
 		return trackerRecords;
+	}
+
+	@Subscribe
+	public void onGameStateChanged(GameStateChanged c)
+	{
+		// Check for players in-game name every time they login
+		if (c.getGameState().equals(GameState.LOGGING_IN))
+		{
+			clientThread.invokeLater(() ->
+			{
+				switch (client.getGameState())
+				{
+					case LOGGED_IN:
+						break;
+					case LOGGING_IN:
+					case LOADING:
+						return false;
+					default:
+						// Quit running if any other state
+						return true;
+				}
+
+				String name = client.getLocalPlayer().getName();
+				if (name != null)
+				{
+					writer.setPlayerUsername(name);
+					return true;
+				}
+				else
+				{
+					return false;
+				}
+			});
+		}
 	}
 }


### PR DESCRIPTION
Since data is only stored in the database for 30 days, and I personally want to keep my loot for excel spreadsheet fun, I added a config option that will automatically append `LootRecord`s as JSON to `.log` files located in `.runelite/loots/<ingame-username>/`

Output Format:
```JSON
{"eventId":"Man","type":"NPC","drops":[{"id":526,"qty":1},{"id":877,"qty":2}]}
```