### PR TITLE
tooltips: show tooltip based on advanced settings

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/VarPlayer.java
+++ b/runelite-api/src/main/java/net/runelite/api/VarPlayer.java
@@ -39,6 +39,12 @@ public enum VarPlayer
 
 	BANK_TAB(115),
 
+	/**
+	 * Use prayer tooltip bit setting: 30
+	 * Use special attack tooltip bit setting: 31
+	 */
+	TOOLTIPS(284),
+
 	MEMBERSHIP_DAYS(1780),
 
 	SPECIAL_ATTACK_PERCENT(300),

--- a/runelite-client/src/main/java/net/runelite/client/plugins/mousehighlight/MouseHighlightConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/mousehighlight/MouseHighlightConfig.java
@@ -52,4 +52,15 @@ public interface MouseHighlightConfig extends Config
 	{
 		return true;
 	}
+
+	@ConfigItem(
+		position = 2,
+		keyName = "followRuneScape",
+		name = "Follow RuneScape's Tooltip Options",
+		description = "Show RuneLite tooltips based on the RuneScape advanced options"
+	)
+	default boolean followRuneScape()
+	{
+		return false;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/mousehighlight/MouseHighlightOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/mousehighlight/MouseHighlightOverlay.java
@@ -31,7 +31,9 @@ import javax.inject.Inject;
 import net.runelite.api.Client;
 import net.runelite.api.MenuEntry;
 import net.runelite.api.VarClientInt;
+import net.runelite.api.VarPlayer;
 import net.runelite.api.widgets.Widget;
+import net.runelite.api.widgets.WidgetID;
 import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayPosition;
@@ -43,6 +45,9 @@ class MouseHighlightOverlay extends Overlay
 	private final TooltipManager tooltipManager;
 	private final Client client;
 	private final MouseHighlightConfig config;
+
+	private static final int PRAYER_TOOLTIP_SET_BIT = 30;
+	private static final int SPECIAL_ATTACK_TOOLTIP_SET_BIT = 31;
 
 	@Inject
 	MouseHighlightOverlay(Client client, TooltipManager tooltipManager, MouseHighlightConfig config)
@@ -123,6 +128,22 @@ class MouseHighlightOverlay extends Overlay
 		if (tooltipDisplayed == 1)
 		{
 			return null;
+		}
+
+		if (config.followRuneScape())
+		{
+			// If the tooltip is disabled in the advanced settings, don't show our tooltip
+			int tooltips = client.getVar(VarPlayer.TOOLTIPS);
+
+			if (groupId == WidgetID.PRAYER_GROUP_ID && (tooltips >> PRAYER_TOOLTIP_SET_BIT & 1) == 1)
+			{
+				return null;
+			}
+
+			if (groupId == WidgetID.COMBAT_GROUP_ID && tooltips >>> SPECIAL_ATTACK_TOOLTIP_SET_BIT == 1)
+			{
+				return null;
+			}
 		}
 
 		tooltipManager.addFront(new Tooltip(option + (Strings.isNullOrEmpty(target) ? "" : " " + target)));


### PR DESCRIPTION
If the advanced setting has the tooltip set to disabled, then also disable the RuneLite tooltips.

Closes #1143

(Revive of PR #1570)

Runescape and Runelite default:
![image](https://user-images.githubusercontent.com/2388657/50718752-ee27c780-1060-11e9-93bb-bd6571e38aa5.png)

Runescape disable tooltip and Runelite default:
![image](https://user-images.githubusercontent.com/2388657/50718767-0ef01d00-1061-11e9-86c8-90295448ebc4.png)

Runescape disable tooltip and Runelite follow advanced tooltip settings:
![image](https://user-images.githubusercontent.com/2388657/50718783-30510900-1061-11e9-81d7-e58b92347c25.png)
(imagine there is a mouse over the bar ;) )