### PR TITLE
timetracking: add default time in minutes to config

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/TimeTrackingConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/TimeTrackingConfig.java
@@ -76,7 +76,8 @@ public interface TimeTrackingConfig extends Config
 			description = "The default time for the timer in minutes",
 			position = 4
 	)
-	default int defaultTimerMinutes() {
+	default int defaultTimerMinutes()
+	{
 		return 5;
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/TimeTrackingConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/TimeTrackingConfig.java
@@ -71,10 +71,10 @@ public interface TimeTrackingConfig extends Config
 	}
 
 	@ConfigItem(
-			keyName = "defaultTimerMinutes",
-			name = "Default Time (Minutes)",
-			description = "The default time for the timer in minutes",
-			position = 4
+		keyName = "defaultTimerMinutes",
+		name = "Default Time (Minutes)",
+		description = "The default time for the timer in minutes",
+		position = 4
 	)
 	default int defaultTimerMinutes()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/TimeTrackingConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/TimeTrackingConfig.java
@@ -71,6 +71,16 @@ public interface TimeTrackingConfig extends Config
 	}
 
 	@ConfigItem(
+			keyName = "defaultTimerMinutes",
+			name = "Default Time (Minutes)",
+			description = "The default time for the timer in minutes",
+			position = 4
+	)
+	default int defaultTimerMinutes() {
+		return 5;
+	}
+
+	@ConfigItem(
 		keyName = "activeTab",
 		name = "Active Tab",
 		description = "The currently selected tab",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/clocks/ClockManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/clocks/ClockManager.java
@@ -41,8 +41,6 @@ import net.runelite.client.plugins.timetracking.TimeTrackingConfig;
 @Singleton
 public class ClockManager
 {
-	private static final long DEFAULT_TIMER_DURATION = 60 * 5; // 5 minutes
-
 	@Inject
 	private ConfigManager configManager;
 
@@ -63,7 +61,7 @@ public class ClockManager
 
 	void addTimer()
 	{
-		timers.add(new Timer("Timer " + (timers.size() + 1), DEFAULT_TIMER_DURATION));
+		timers.add(new Timer("Timer " + (timers.size() + 1), config.defaultTimerMinutes() * 60));
 		saveTimers();
 
 		SwingUtilities.invokeLater(clockTabPanel::rebuild);


### PR DESCRIPTION
The default time for timers in the timetracking plugin is now configurable.

Closes #7224

![](https://media.giphy.com/media/4NeWWd9B7Kumd2dxoj/giphy.gif)
