### PR TITLE
Add option for configurable level marker width

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpInfoBox.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpInfoBox.java
@@ -226,6 +226,7 @@ class XpInfoBox extends JPanel
 				}
 
 				progressBar.setPositions(positions);
+				progressBar.setPositionWidth(xpTrackerConfig.levelMarkerWidth());
 			}
 			else
 			{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerConfig.java
@@ -27,6 +27,7 @@ package net.runelite.client.plugins.xptracker;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.Range;
 
 @ConfigGroup("xpTracker")
 public interface XpTrackerConfig extends Config
@@ -64,8 +65,23 @@ public interface XpTrackerConfig extends Config
 		return false;
 	}
 
+	@Range(
+		min = 1,
+		max = 5
+	)
 	@ConfigItem(
 		position = 3,
+		keyName = "levelMarkerWidth",
+		name = "Level marker width",
+		description = "Alters the width of the intermediate level markers"
+	)
+	default int levelMarkerWidth()
+	{
+		return 1;
+	}
+
+	@ConfigItem(
+		position = 4,
 		keyName = "pauseSkillAfter",
 		name = "Auto pause after",
 		description = "Configures how many minutes passes before pausing a skill while in game and there's no XP, 0 means disabled"

--- a/runelite-client/src/main/java/net/runelite/client/ui/components/ProgressBar.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/components/ProgressBar.java
@@ -52,7 +52,7 @@ public class ProgressBar extends DimmableJPanel
 	private List<Double> positions = Collections.emptyList();
 
 	@Setter
-	private int positionWidth;
+	private int positionWidth = 1;
 
 	private final JLabel leftLabel = new JShadowedLabel();
 	private final JLabel rightLabel = new JShadowedLabel();

--- a/runelite-client/src/main/java/net/runelite/client/ui/components/ProgressBar.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/components/ProgressBar.java
@@ -51,6 +51,9 @@ public class ProgressBar extends DimmableJPanel
 	@Setter
 	private List<Double> positions = Collections.emptyList();
 
+	@Setter
+	private int positionWidth;
+
 	private final JLabel leftLabel = new JShadowedLabel();
 	private final JLabel rightLabel = new JShadowedLabel();
 	private final JLabel centerLabel = new JShadowedLabel();
@@ -101,7 +104,7 @@ public class ProgressBar extends DimmableJPanel
 			final int xCord = (int) (getSize().width * position);
 			if (xCord > topWidth)
 			{
-				g.fillRect(xCord, 0, 1, 16);
+				g.fillRect(xCord, 0, positionWidth, 16);
 			}
 		}
 


### PR DESCRIPTION
When the intermediate level markers were added, the markers were originally thicker. These changes would add an option to increase the width of the markers. Default remains 1px and the max is currently 5px because anything more would be a little ridiculous.