### PR TITLE
Add chat command shorthand for challenge mode raids killcount

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
@@ -966,6 +966,16 @@ public class ChatCommandsPlugin extends Plugin
 			case "raids":
 				return "Chambers of Xeric";
 
+			case "cox:cm":
+			case "chambers:cm":
+			case "olm:cm":
+			case "raids:cm":
+			case "cm":
+			case "cm cox":
+			case "cm raids":
+			case "challenge mode":
+				return "Chambers of Xeric:Challenge";
+
 			case "tob":
 			case "theatre":
 			case "verzik":


### PR DESCRIPTION
There was no shorthand for Challenge Mode Chambers of Xeric killcount so I decided to add some. Before this you had to type out the whole thing "!kc chambers of xeric:challenge" and now you can also use "chambers:cm", "olm:cm", "raids:cm", "cm", "cm cox" and "challenge mode".