### PR TITLE
Add chat command shorthand for challenge mode raids killcount

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
@@ -1089,6 +1089,7 @@ public class ChatCommandsPlugin extends Plugin
 			case "barrows":
 				return "Barrows Chests";
 
+			// cox
 			case "cox":
 			case "xeric":
 			case "chambers":
@@ -1096,6 +1097,15 @@ public class ChatCommandsPlugin extends Plugin
 			case "raids":
 				return "Chambers of Xeric";
 
+			// cox cm
+			case "cox cm":
+			case "xeric cm":
+			case "chambers cm":
+			case "olm cm":
+			case "raids cm":
+				return "Chambers of Xeric Challenge Mode";
+
+			// tob
 			case "tob":
 			case "theatre":
 			case "verzik":


### PR DESCRIPTION
There was no shorthand for Challenge Mode Chambers of Xeric killcount so I decided to add some. Before this you had to type out the whole thing "!kc chambers of xeric:challenge" and now you can also use "chambers:cm", "olm:cm", "raids:cm", "cm", "cm cox" and "challenge mode".