### PR TITLE
Skybox: Do bounds check on the localPlayer's location, not the camera's

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/skybox/Skybox.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/skybox/Skybox.java
@@ -327,7 +327,7 @@ class Skybox
 			{
 				return -1;
 			}
-			
+
 			cy = itp >> 3 & 0x7FF;
 			cx = itp >> 14 & 0x3FF;
 			plane = itp >> 24 & 0x3;
@@ -365,11 +365,13 @@ class Skybox
 	/**
 	 * Calculates the RGB color for a specific world coordinate. Arguments are floats for sub-tile accuracy.
 	 *
-	 * @param x           X coordinate in tiles
-	 * @param y           Y coordinate in tiles
+	 * @param x           Sample X coordinate in tiles
+	 * @param y           Samlpe Y coordinate in tiles
+	 * @param x           Player X coordinate in tiles
+	 * @param y           Player Y coordinate in tiles
 	 * @param chunkMapper maps chunks to their instance templates, or null if not in an instance
 	 */
-	public int getColorForPoint(double x, double y, int plane, double brightness, ChunkMapper chunkMapper)
+	public int getColorForPoint(double x, double y, int px, int py, int plane, double brightness, ChunkMapper chunkMapper)
 	{
 		x /= 8.d;
 		y /= 8.d;
@@ -377,7 +379,7 @@ class Skybox
 		int cx = (int) x;
 		int cy = (int) y;
 
-		int centerChunkData = chunkData(cx, cy, plane, chunkMapper);
+		int centerChunkData = chunkData(px / 8, py / 8, plane, chunkMapper);
 		if (centerChunkData == -1)
 		{
 			// No data in the center chunk?
@@ -477,7 +479,7 @@ class Skybox
 	 *
 	 * @param resolution The number of pixels per tile
 	 * @param line       How many tiles to put a line
-	 * @param plane     the plane (0-4) to render
+	 * @param plane      the plane (0-4) to render
 	 */
 	BufferedImage render(double resolution, int line, int plane, ChunkMapper chunkMapper)
 	{
@@ -499,7 +501,7 @@ class Skybox
 				{
 					double fx = (x1 * 8) + (x / resolution);
 					double fy = (y1 * 8) + (y / resolution);
-					color = getColorForPoint(fx, fy, plane, .8, chunkMapper);
+					color = getColorForPoint(fx, fy, (int) fx, (int) fy, plane, .8, chunkMapper);
 				}
 				img.setRGB(x, h - 1 - y, color | 0xFF000000);
 			}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/skybox/SkyboxPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/skybox/SkyboxPlugin.java
@@ -105,12 +105,17 @@ public class SkyboxPlugin extends Plugin
 		}
 
 		// Inverse of camera location / 2
-		int spx = px - ((client.getCameraX() - px) >> 1);
-		int spy = py - ((client.getCameraY() - py) >> 1);
+		int spx = -((client.getCameraX() - px) >> 1);
+		int spy = -((client.getCameraY() - py) >> 1);
+
+		int baseX = client.getBaseX();
+		int baseY = client.getBaseY();
 
 		client.setSkyboxColor(skybox.getColorForPoint(
-			client.getBaseX() + (spx / 128.f),
-			client.getBaseY() + (spy / 128.f),
+			baseX + ((px + spx) / 128.f),
+			baseY + ((py + spy) / 128.f),
+			baseX + (px / 128),
+			baseY + (py / 128),
 			client.getPlane(),
 			client.getTextureProvider().getBrightness(),
 			client.isInInstancedRegion() ? this::mapChunk : null

--- a/runelite-client/src/test/java/net/runelite/client/plugins/skybox/SkyboxTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/skybox/SkyboxTest.java
@@ -41,8 +41,10 @@ public class SkyboxTest
 	public void testLoadSimple() throws IOException
 	{
 		Skybox skybox = new Skybox(CharSource.wrap("bounds 0 0 100 100 #00F // R 0 0 100 100\r\nr 99 99").openStream(), "simple");
-		Assert.assertEquals(0, skybox.getColorForPoint(0, 0, 0, 1, null));
-		Assert.assertEquals(0x0000FF, skybox.getColorForPoint((99 * 64) + 32, (99 * 64) + 32, 0, 1, null));
+		Assert.assertEquals(0, skybox.getColorForPoint(0, 0, 0, 0, 0, 1, null));
+		int x = (99 * 64) + 32;
+		int y = (99 * 64) + 32;
+		Assert.assertEquals(0x0000FF, skybox.getColorForPoint(x, y, x, y, 0, 1, null));
 	}
 
 	@Test
@@ -63,6 +65,6 @@ public class SkyboxTest
 			ImageIO.write(img, "png", new File(skyboxFile));
 		}
 
-		Assert.assertNotEquals(skybox.getColorForPoint(3232, 3232, 0, .9, null), 0); // Lumbridge will never be black
+		Assert.assertNotEquals(skybox.getColorForPoint(3232, 3232, 3232, 3232, 0, .9, null), 0); // Lumbridge will never be black
 	}
 }


### PR DESCRIPTION
This prevents the skybox from turning black when the camera goes out of bounds, but the player is still inbounds.

Closes #7239