### PR TITLE
 Loot Tracker - Add client username to LootRecords

### DIFF
--- a/http-api/src/main/java/net/runelite/http/api/loottracker/LootRecord.java
+++ b/http-api/src/main/java/net/runelite/http/api/loottracker/LootRecord.java
@@ -35,6 +35,7 @@ import lombok.NoArgsConstructor;
 public class LootRecord
 {
 	private String eventId;
+	private String username;
 	private LootRecordType type;
 	private Collection<GameItem> drops;
 }

--- a/http-service/src/main/java/net/runelite/http/service/loottracker/LootResult.java
+++ b/http-service/src/main/java/net/runelite/http/service/loottracker/LootResult.java
@@ -32,6 +32,7 @@ import net.runelite.http.api.loottracker.LootRecordType;
 class LootResult
 {
 	private int killId;
+	private String username;
 	private Instant time;
 	private LootRecordType type;
 	private String eventId;

--- a/http-service/src/main/java/net/runelite/http/service/loottracker/LootTrackerService.java
+++ b/http-service/src/main/java/net/runelite/http/service/loottracker/LootTrackerService.java
@@ -46,6 +46,7 @@ public class LootTrackerService
 		+ "  `id` INT AUTO_INCREMENT UNIQUE,\n"
 		+ "  `time` timestamp NOT NULL DEFAULT current_timestamp() ON UPDATE current_timestamp(),\n"
 		+ "  `accountId` INT NOT NULL,\n"
+		+ "  `username` VARCHAT(255) NOT NULL,\n"
 		+ "  `type` enum('NPC', 'PLAYER', 'EVENT', 'UNKNOWN') NOT NULL,\n"
 		+ "  `eventId` VARCHAR(255) NOT NULL,\n"
 		+ "  PRIMARY KEY (id),\n"
@@ -63,10 +64,10 @@ public class LootTrackerService
 		+ ") ENGINE=InnoDB";
 
 	// Queries for inserting kills
-	private static final String INSERT_KILL_QUERY = "INSERT INTO kills (accountId, type, eventId) VALUES (:accountId, :type, :eventId)";
+	private static final String INSERT_KILL_QUERY = "INSERT INTO kills (accountId, username, type, eventId) VALUES (:accountId, :username, :type, :eventId)";
 	private static final String INSERT_DROP_QUERY = "INSERT INTO drops (killId, itemId, itemQuantity) VALUES (LAST_INSERT_ID(), :itemId, :itemQuantity)";
 
-	private static final String SELECT_LOOT_QUERY = "SELECT killId,time,type,eventId,itemId,itemQuantity FROM kills JOIN drops ON drops.killId = kills.id WHERE accountId = :accountId ORDER BY TIME DESC LIMIT :limit";
+	private static final String SELECT_LOOT_QUERY = "SELECT killId,username,time,type,eventId,itemId,itemQuantity FROM kills JOIN drops ON drops.killId = kills.id WHERE accountId = :accountId ORDER BY TIME DESC LIMIT :limit";
 
 	private static final String DELETE_LOOT_ACCOUNT = "DELETE FROM kills WHERE accountId = :accountId";
 	private static final String DELETE_LOOT_ACCOUNT_EVENTID = "DELETE FROM kills WHERE accountId = :accountId AND eventId = :eventId";
@@ -99,6 +100,7 @@ public class LootTrackerService
 			// Kill Entry Query
 			con.createQuery(INSERT_KILL_QUERY, true)
 				.addParameter("accountId", accountId)
+				.addParameter("username", record.getUsername())
 				.addParameter("type", record.getType())
 				.addParameter("eventId", record.getEventId())
 				.executeUpdate();
@@ -141,7 +143,7 @@ public class LootTrackerService
 			{
 				if (!gameItems.isEmpty())
 				{
-					LootRecord lootRecord = new LootRecord(current.getEventId(), current.getType(), gameItems);
+					LootRecord lootRecord = new LootRecord(current.getEventId(), current.getUsername(), current.getType(), gameItems);
 					lootRecords.add(lootRecord);
 
 					gameItems = new ArrayList<>();
@@ -156,7 +158,7 @@ public class LootTrackerService
 
 		if (!gameItems.isEmpty())
 		{
-			LootRecord lootRecord = new LootRecord(current.getEventId(), current.getType(), gameItems);
+			LootRecord lootRecord = new LootRecord(current.getEventId(), current.getUsername(), current.getType(), gameItems);
 			lootRecords.add(lootRecord);
 		}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
@@ -283,7 +283,7 @@ public class LootTrackerPlugin extends Plugin
 
 		if (lootTrackerClient != null && config.saveLoot())
 		{
-			LootRecord lootRecord = new LootRecord(name, LootRecordType.NPC, toGameItems(items));
+			LootRecord lootRecord = new LootRecord(name, client.getUsername(), LootRecordType.NPC, toGameItems(items));
 			lootTrackerClient.submit(lootRecord);
 		}
 	}
@@ -300,7 +300,7 @@ public class LootTrackerPlugin extends Plugin
 
 		if (lootTrackerClient != null && config.saveLoot())
 		{
-			LootRecord lootRecord = new LootRecord(name, LootRecordType.PLAYER, toGameItems(items));
+			LootRecord lootRecord = new LootRecord(name, client.getUsername(), LootRecordType.PLAYER, toGameItems(items));
 			lootTrackerClient.submit(lootRecord);
 		}
 	}
@@ -359,7 +359,7 @@ public class LootTrackerPlugin extends Plugin
 
 		if (lootTrackerClient != null && config.saveLoot())
 		{
-			LootRecord lootRecord = new LootRecord(eventType, LootRecordType.EVENT, toGameItems(items));
+			LootRecord lootRecord = new LootRecord(eventType, client.getUsername(), LootRecordType.EVENT, toGameItems(items));
 			lootTrackerClient.submit(lootRecord);
 		}
 	}


### PR DESCRIPTION
Adds `client.getUsername()` to LootRecord for future reference. 

Having the option to see which accounts got which loot via the website sounds like a cool idea and this would facilitate it. 

I can add a toggle to the client UI to limit based on current username (upon login) if decided.