### PR TITLE
Add Slayer Task Locations (Konar)

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerConfig.java
@@ -165,6 +165,24 @@ public interface SlayerConfig extends Config
 	void initialAmount(int initialAmount);
 
 	@ConfigItem(
+		keyName = "taskLocation",
+		name = "",
+		description = "",
+		hidden = true
+	)
+	default String taskLocation()
+	{
+		return "";
+	}
+
+	@ConfigItem(
+		keyName = "taskLocation",
+		name = "",
+		description = ""
+	)
+	void taskLocation(String key);
+
+	@ConfigItem(
 		keyName = "streak",
 		name = "",
 		description = "",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerConfig.java
@@ -141,6 +141,13 @@ public interface SlayerConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "amount",
+		name = "",
+		description = ""
+	)
+	void amount(int amt);
+
+	@ConfigItem(
 		keyName = "initialAmount",
 		name = "",
 		description = "",
@@ -156,13 +163,6 @@ public interface SlayerConfig extends Config
 		description = ""
 	)
 	void initialAmount(int initialAmount);
-
-	@ConfigItem(
-		keyName = "amount",
-		name = "",
-		description = ""
-	)
-	void amount(int amt);
 
 	@ConfigItem(
 		keyName = "streak",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerPlugin.java
@@ -81,7 +81,7 @@ import net.runelite.client.util.Text;
 public class SlayerPlugin extends Plugin
 {
 	//Chat messages
-	private static final Pattern CHAT_GEM_PROGRESS_MESSAGE = Pattern.compile("^(?:You're assigned to kill|You have received a new Slayer assignment from .*:) (?:the )?(.*?)(?: in the Wilderness)?(?:; only | \\()(\\d*)(?: more to go\\.|\\))$");
+	private static final Pattern CHAT_GEM_PROGRESS_MESSAGE = Pattern.compile("^(?:You're assigned to kill|You have received a new Slayer assignment from .*:) (?:[Tt]he )?(?<name>.+?)(?: (?:in|on) (?:the )?(?:[^;]+))?(?:; only | \\()(?<amount>\\d+)(?: more to go\\.|\\))$");
 	private static final String CHAT_GEM_COMPLETE_MESSAGE = "You need something new to hunt.";
 	private static final Pattern CHAT_COMPLETE_MESSAGE = Pattern.compile("(?:\\d+,)*\\d+");
 	private static final String CHAT_CANCEL_MESSAGE = "Your task has been cancelled.";
@@ -98,10 +98,10 @@ public class SlayerPlugin extends Plugin
 	private static final Pattern COMBAT_BRACELET_TASK_UPDATE_MESSAGE = Pattern.compile("^You still need to kill (\\d+) monsters to complete your current Slayer assignment");
 
 	//NPC messages
-	private static final Pattern NPC_ASSIGN_MESSAGE = Pattern.compile(".*Your new task is to kill\\s*(\\d*) (.*)\\.");
+	private static final Pattern NPC_ASSIGN_MESSAGE = Pattern.compile(".*(?:Your new task is to kill|You are to bring balance to)\\s*(?<amount>\\d+) (?<name>.+?)(?: (?:in|on) (?:the )?(?:.+))?\\.");
 	private static final Pattern NPC_ASSIGN_BOSS_MESSAGE = Pattern.compile("^Excellent. You're now assigned to kill (?:the )?(.*) (\\d+) times.*Your reward point tally is (.*)\\.$");
 	private static final Pattern NPC_ASSIGN_FIRST_MESSAGE = Pattern.compile("^We'll start you off hunting (.*), you'll need to kill (\\d*) of them.");
-	private static final Pattern NPC_CURRENT_MESSAGE = Pattern.compile("You're still hunting (.*); you have (\\d*) to go\\..*");
+	private static final Pattern NPC_CURRENT_MESSAGE = Pattern.compile("^You're still (?:hunting|bringing balance to) (?<name>.+)(?: (?:in|on) (?:the )?(?:.+), with|; you have) (?<amount>\\d+) to go\\..*");
 
 	//Reward UI
 	private static final Pattern REWARD_POINTS = Pattern.compile("Reward points: ((?:\\d+,)*\\d+)");
@@ -287,8 +287,9 @@ public class SlayerPlugin extends Plugin
 
 			if (mAssign.find())
 			{
-				int amount = Integer.parseInt(mAssign.group(1));
-				setTask(mAssign.group(2), amount, amount);
+				String name = mAssign.group("name");
+				int amount = Integer.parseInt(mAssign.group("amount"));
+				setTask(name, amount, amount);
 			}
 			else if (mAssignFirst.find())
 			{
@@ -303,8 +304,9 @@ public class SlayerPlugin extends Plugin
 			}
 			else if (mCurrent.find())
 			{
-				int amount = Integer.parseInt(mCurrent.group(2));
-				setTask(mCurrent.group(1), amount, amount);
+				String name = mCurrent.group("name");
+				int amount = Integer.parseInt(mCurrent.group("amount"));
+				setTask(name, amount, initialAmount);
 			}
 		}
 
@@ -447,9 +449,9 @@ public class SlayerPlugin extends Plugin
 
 		if (mProgress.find())
 		{
-			String gemTaskName = mProgress.group(1);
-			int gemAmount = Integer.parseInt(mProgress.group(2));
-			setTask(gemTaskName, gemAmount, initialAmount);
+			String name = mProgress.group("name");
+			int gemAmount = Integer.parseInt(mProgress.group("amount"));
+			setTask(name, gemAmount, initialAmount);
 			return;
 		}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerPlugin.java
@@ -81,7 +81,7 @@ import net.runelite.client.util.Text;
 public class SlayerPlugin extends Plugin
 {
 	//Chat messages
-	private static final Pattern CHAT_GEM_PROGRESS_MESSAGE = Pattern.compile("^(?:You're assigned to kill|You have received a new Slayer assignment from .*:) (?:[Tt]he )?(?<name>.+?)(?: (?:in|on) (?:the )?(?:[^;]+))?(?:; only | \\()(?<amount>\\d+)(?: more to go\\.|\\))$");
+	private static final Pattern CHAT_GEM_PROGRESS_MESSAGE = Pattern.compile("^(?:You're assigned to kill|You have received a new Slayer assignment from .*:) (?:[Tt]he )?(?<name>.+?)(?: (?:in|on) (?:the )?(?<location>[^;]+))?(?:; only | \\()(?<amount>\\d+)(?: more to go\\.|\\))$");
 	private static final String CHAT_GEM_COMPLETE_MESSAGE = "You need something new to hunt.";
 	private static final Pattern CHAT_COMPLETE_MESSAGE = Pattern.compile("(?:\\d+,)*\\d+");
 	private static final String CHAT_CANCEL_MESSAGE = "Your task has been cancelled.";
@@ -98,10 +98,10 @@ public class SlayerPlugin extends Plugin
 	private static final Pattern COMBAT_BRACELET_TASK_UPDATE_MESSAGE = Pattern.compile("^You still need to kill (\\d+) monsters to complete your current Slayer assignment");
 
 	//NPC messages
-	private static final Pattern NPC_ASSIGN_MESSAGE = Pattern.compile(".*(?:Your new task is to kill|You are to bring balance to)\\s*(?<amount>\\d+) (?<name>.+?)(?: (?:in|on) (?:the )?(?:.+))?\\.");
+	private static final Pattern NPC_ASSIGN_MESSAGE = Pattern.compile(".*(?:Your new task is to kill|You are to bring balance to)\\s*(?<amount>\\d+) (?<name>.+?)(?: (?:in|on) (?:the )?(?<location>.+))?\\.");
 	private static final Pattern NPC_ASSIGN_BOSS_MESSAGE = Pattern.compile("^Excellent. You're now assigned to kill (?:the )?(.*) (\\d+) times.*Your reward point tally is (.*)\\.$");
 	private static final Pattern NPC_ASSIGN_FIRST_MESSAGE = Pattern.compile("^We'll start you off hunting (.*), you'll need to kill (\\d*) of them.");
-	private static final Pattern NPC_CURRENT_MESSAGE = Pattern.compile("^You're still (?:hunting|bringing balance to) (?<name>.+)(?: (?:in|on) (?:the )?(?:.+), with|; you have) (?<amount>\\d+) to go\\..*");
+	private static final Pattern NPC_CURRENT_MESSAGE = Pattern.compile("^You're still (?:hunting|bringing balance to) (?<name>.+)(?: (?:in|on) (?:the )?(?<location>.+), with|; you have) (?<amount>\\d+) to go\\..*");
 
 	//Reward UI
 	private static final Pattern REWARD_POINTS = Pattern.compile("Reward points: ((?:\\d+,)*\\d+)");
@@ -157,6 +157,10 @@ public class SlayerPlugin extends Plugin
 
 	@Getter(AccessLevel.PACKAGE)
 	@Setter(AccessLevel.PACKAGE)
+	private String taskLocation;
+
+	@Getter(AccessLevel.PACKAGE)
+	@Setter(AccessLevel.PACKAGE)
 	private int expeditiousChargeCount;
 
 	@Getter(AccessLevel.PACKAGE)
@@ -195,7 +199,7 @@ public class SlayerPlugin extends Plugin
 			streak = config.streak();
 			setExpeditiousChargeCount(config.expeditious());
 			setSlaughterChargeCount(config.slaughter());
-			clientThread.invoke(() -> setTask(config.taskName(), config.amount(), config.initialAmount()));
+			clientThread.invoke(() -> setTask(config.taskName(), config.amount(), config.initialAmount(), config.taskLocation()));
 		}
 	}
 
@@ -238,7 +242,7 @@ public class SlayerPlugin extends Plugin
 					streak = config.streak();
 					setExpeditiousChargeCount(config.expeditious());
 					setSlaughterChargeCount(config.slaughter());
-					setTask(config.taskName(), config.amount(), config.initialAmount());
+					setTask(config.taskName(), config.amount(), config.initialAmount(), config.taskLocation());
 					loginFlag = false;
 				}
 				break;
@@ -250,6 +254,7 @@ public class SlayerPlugin extends Plugin
 		config.amount(amount);
 		config.initialAmount(initialAmount);
 		config.taskName(taskName);
+		config.taskLocation(taskLocation);
 		config.points(points);
 		config.streak(streak);
 		config.expeditious(expeditiousChargeCount);
@@ -280,16 +285,17 @@ public class SlayerPlugin extends Plugin
 		if (npcDialog != null)
 		{
 			String npcText = Text.sanitizeMultilineText(npcDialog.getText()); //remove color and linebreaks
-			final Matcher mAssign = NPC_ASSIGN_MESSAGE.matcher(npcText); //number, name
-			final Matcher mAssignFirst = NPC_ASSIGN_FIRST_MESSAGE.matcher(npcText); //name, number
+			final Matcher mAssign = NPC_ASSIGN_MESSAGE.matcher(npcText); // amount, name, (location)
+			final Matcher mAssignFirst = NPC_ASSIGN_FIRST_MESSAGE.matcher(npcText); // name, number
 			final Matcher mAssignBoss = NPC_ASSIGN_BOSS_MESSAGE.matcher(npcText); // name, number, points
-			final Matcher mCurrent = NPC_CURRENT_MESSAGE.matcher(npcText); //name, number
+			final Matcher mCurrent = NPC_CURRENT_MESSAGE.matcher(npcText); // name, (location), amount
 
 			if (mAssign.find())
 			{
 				String name = mAssign.group("name");
 				int amount = Integer.parseInt(mAssign.group("amount"));
-				setTask(name, amount, amount);
+				String location = mAssign.group("location");
+				setTask(name, amount, amount, location);
 			}
 			else if (mAssignFirst.find())
 			{
@@ -306,7 +312,8 @@ public class SlayerPlugin extends Plugin
 			{
 				String name = mCurrent.group("name");
 				int amount = Integer.parseInt(mCurrent.group("amount"));
-				setTask(name, amount, initialAmount);
+				String location = mCurrent.group("location");
+				setTask(name, amount, initialAmount, location);
 			}
 		}
 
@@ -451,7 +458,8 @@ public class SlayerPlugin extends Plugin
 		{
 			String name = mProgress.group("name");
 			int gemAmount = Integer.parseInt(mProgress.group("amount"));
-			setTask(name, gemAmount, initialAmount);
+			String location = mProgress.group("location");
+			setTask(name, gemAmount, initialAmount, location);
 			return;
 		}
 
@@ -607,9 +615,15 @@ public class SlayerPlugin extends Plugin
 
 	private void setTask(String name, int amt, int initAmt)
 	{
+		setTask(name, amt, initAmt, null);
+	}
+
+	private void setTask(String name, int amt, int initAmt, String location)
+	{
 		taskName = name;
 		amount = amt;
 		initialAmount = initAmt;
+		taskLocation = location;
 		save();
 		removeCounter();
 		addCounter();
@@ -635,8 +649,14 @@ public class SlayerPlugin extends Plugin
 		}
 
 		BufferedImage taskImg = itemManager.getImage(itemSpriteId);
-		String taskTooltip = ColorUtil.prependColorTag("%s</br>", new Color(255, 119, 0))
-			+ ColorUtil.wrapWithColorTag("Pts:", Color.YELLOW)
+		String taskTooltip = ColorUtil.wrapWithColorTag("%s", new Color(255, 119, 0)) + "</br>";
+
+		if (taskLocation != null && !taskLocation.isEmpty())
+		{
+			taskTooltip += taskLocation + "</br>";
+		}
+
+		taskTooltip += ColorUtil.wrapWithColorTag("Pts:", Color.YELLOW)
 			+ " %s</br>"
 			+ ColorUtil.wrapWithColorTag("Streak:", Color.YELLOW)
 			+ " %s";

--- a/runelite-client/src/test/java/net/runelite/client/plugins/slayer/SlayerPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/slayer/SlayerPluginTest.java
@@ -56,11 +56,14 @@ import org.mockito.runners.MockitoJUnitRunner;
 public class SlayerPluginTest
 {
 	private static final String TASK_NEW = "Your new task is to kill 231 Suqahs.";
+	private static final String TASK_NEW_KONAR = "You are to bring balance to 147 Wyrms in the Karuulm Slayer Dungeon.";
+	private static final String TASK_NEW_KONAR_2 = "You are to bring balance to 142 Hellhounds in Witchhaven Dungeon.";
 	private static final String TASK_NEW_FIRST = "We'll start you off hunting goblins, you'll need to kill 17 of them.";
 	private static final String TASK_NEW_NPC_CONTACT = "Excellent, you're doing great. Your new task is to kill<br>211 Suqahs.";
 	private static final String TASK_NEW_FROM_PARTNER = "You have received a new Slayer assignment from breaklulz: Dust Devils (377)";
-	private static final String TASK_CHECKSLAYERGEM_WILDERNESS = "You're assigned to kill Suqahs in the Wilderness; only 211 more to go.";
 	private static final String TASK_CHECKSLAYERGEM = "You're assigned to kill Suqahs; only 211 more to go.";
+	private static final String TASK_CHECKSLAYERGEM_WILDERNESS = "You're assigned to kill Suqahs in the Wilderness; only 211 more to go.";
+	private static final String TASK_CHECKSLAYERGEM_KONAR = "You're assigned to kill Blue dragons in the Ogre Enclave; only 122 more to go.";
 	private static final String TASK_UPDATE_COMBAT_BRACELET = "You still need to kill 30 monsters to complete your current Slayer assignment";
 
 	private static final String TASK_BOSS_NEW = "Excellent. You're now assigned to kill Vet'ion 3 times.<br>Your reward point tally is 914.";
@@ -148,6 +151,32 @@ public class SlayerPluginTest
 	}
 
 	@Test
+	public void testNewKonarTask()
+	{
+		Widget npcDialog = mock(Widget.class);
+		when(npcDialog.getText()).thenReturn(TASK_NEW_KONAR);
+		when(client.getWidget(WidgetInfo.DIALOG_NPC_TEXT)).thenReturn(npcDialog);
+		slayerPlugin.onGameTick(new GameTick());
+
+		assertEquals("Wyrms", slayerPlugin.getTaskName());
+		assertEquals(147, slayerPlugin.getAmount());
+		assertEquals("Karuulm Slayer Dungeon", slayerPlugin.getTaskLocation());
+	}
+
+	@Test
+	public void testNewKonarTask2()
+	{
+		Widget npcDialog = mock(Widget.class);
+		when(npcDialog.getText()).thenReturn(TASK_NEW_KONAR_2);
+		when(client.getWidget(WidgetInfo.DIALOG_NPC_TEXT)).thenReturn(npcDialog);
+		slayerPlugin.onGameTick(new GameTick());
+
+		assertEquals("Hellhounds", slayerPlugin.getTaskName());
+		assertEquals(142, slayerPlugin.getAmount());
+		assertEquals("Witchhaven Dungeon", slayerPlugin.getTaskLocation());
+	}
+
+	@Test
 	public void testFirstTask()
 	{
 		Widget npcDialog = mock(Widget.class);
@@ -223,6 +252,18 @@ public class SlayerPluginTest
 		slayerPlugin.onChatMessage(chatMessageEvent);
 		assertEquals("Suqahs", slayerPlugin.getTaskName());
 		assertEquals(211, slayerPlugin.getAmount());
+		assertEquals("Wilderness", slayerPlugin.getTaskLocation());
+	}
+
+	@Test
+	public void testCheckSlayerGemKonarTask()
+	{
+		ChatMessage chatMessageEvent = new ChatMessage(SERVER, "", TASK_CHECKSLAYERGEM_KONAR, null);
+		slayerPlugin.onChatMessage(chatMessageEvent);
+
+		assertEquals("Blue dragons", slayerPlugin.getTaskName());
+		assertEquals(122, slayerPlugin.getAmount());
+		assertEquals("Ogre Enclave", slayerPlugin.getTaskLocation());
 	}
 
 	@Test


### PR DESCRIPTION
Fix some pattern matching for new slayer game text, and record task locations. Locations are also stored in config, and displayed on the task counter:

![capture2](https://user-images.githubusercontent.com/2348393/51031963-52b8ba00-156c-11e9-83d5-aa502c54e883.PNG)
(ignore the zero points/streak, the config was somehow wiped out, unrelated to this PR)

This does **NOT** add the new slayer monsters to the plugin, I will leave it to someone else to pick the icons for that.

The game text currently understood:
- Gem 'Check" progress (same as slayer helmet?)
- Konar dialogue for new task
- Konar dialogue with current Konar task
- Konar dialogue with current non-Konar task
- Slayer master dialogue with current Konar task

I don't know what the game text is for Konar tasks with:
- Receiving a task from a slayer partner

Testing this is slow, so help testing would be appreciated.

This would resolve #7267.