### PR TITLE
Worldmap: Fix CIR fairy ring location

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldmap/FairyRingLocation.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldmap/FairyRingLocation.java
@@ -49,7 +49,7 @@ enum FairyRingLocation
 	BLP("BLP", new WorldPoint(2432, 5127, 0)),
 	BLR("BLR", new WorldPoint(2739, 3353, 0)),
 	CIP("CIP", new WorldPoint(2512, 3886, 0)),
-	CIR("CIR", new WorldPoint(1302, 3762, 0)),
+	CIR("CIR", new WorldPoint(1303, 3762, 0)),
 	CIQ("CIQ", new WorldPoint(2527, 3129, 0)),
 	CJR("CJR", new WorldPoint(2704, 3578, 0)),
 	CKR("CKR", new WorldPoint(2800, 3005, 0)),


### PR DESCRIPTION
It was misplaced by 1 tile.

Before: 
![image](https://user-images.githubusercontent.com/43320258/51072226-89223200-165d-11e9-84e8-ce0c3cec7435.png)
After:
![image](https://user-images.githubusercontent.com/43320258/51072227-917a6d00-165d-11e9-8c08-2bf2ac2be34e.png)

