### PR TITLE
Cap fog depth to 100 in the GPU Plugin.

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuPlugin.java
@@ -102,6 +102,7 @@ public class GpuPlugin extends Plugin implements DrawCallbacks
 	private static final int SMALL_TRIANGLE_COUNT = 512;
 	private static final int FLAG_SCENE_BUFFER = Integer.MIN_VALUE;
 	static final int MAX_DISTANCE = 90;
+	static final int MAX_FOG_DEPTH = 100;
 
 	@Inject
 	private Client client;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuPluginConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuPluginConfig.java
@@ -28,6 +28,7 @@ import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
 import net.runelite.client.config.Range;
+import static net.runelite.client.plugins.gpu.GpuPlugin.MAX_FOG_DEPTH;
 import net.runelite.client.plugins.gpu.config.AntiAliasingMode;
 import static net.runelite.client.plugins.gpu.GpuPlugin.MAX_DISTANCE;
 
@@ -70,6 +71,9 @@ public interface GpuPluginConfig extends Config
 		return AntiAliasingMode.DISABLED;
 	}
 
+	@Range(
+		max = MAX_FOG_DEPTH
+	)
 	@ConfigItem(
 		keyName = "fogDepth",
 		name = "Fog depth",


### PR DESCRIPTION
Add a cap to the 'fog depth' config in the GPU Plugin using the `@Range` annotation. The `@Range` annotation is already used for the 'draw distance' config, so I'm just adding it to the 'fog depth' config as well. The cap was selected to be 100, though 100 seems excessive, surely some people will/would like to use higher than my decided cap of 50, which I personally think is the highest reasonable fog depth, but to each their own. we'll set the cap to 100 for now.