### PR TITLE
Allow WASD Camera movement while shift is pressed.

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/wasdcamera/WASDCameraConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/wasdcamera/WASDCameraConfig.java
@@ -76,4 +76,14 @@ public interface WASDCameraConfig extends Config
 	{
 		return new Keybind(KeyEvent.VK_D, 0);
 	}
+	@ConfigItem(
+			keyName = "ignoreModifiers",
+			name = "Ignore Modifier Keys",
+			description = "Ignore modifier keys like SHIFT & CTRL.",
+			position = 5
+	)
+	default boolean ignoreModifiers()
+	{
+		return true;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/wasdcamera/WASDCameraListener.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/wasdcamera/WASDCameraListener.java
@@ -66,7 +66,7 @@ class WASDCameraListener extends MouseAdapter implements KeyListener
 			return;
 		}
 
-		if(config.ignoreModifiers())
+		if (config.ignoreModifiers())
 		{
 			e.setModifiers(0);
 		}
@@ -148,7 +148,7 @@ class WASDCameraListener extends MouseAdapter implements KeyListener
 			return;
 		}
 
-		if(config.ignoreModifiers())
+		if (config.ignoreModifiers())
 		{
 			e.setModifiers(0);
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/wasdcamera/WASDCameraListener.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/wasdcamera/WASDCameraListener.java
@@ -66,8 +66,14 @@ class WASDCameraListener extends MouseAdapter implements KeyListener
 			return;
 		}
 
+		if(config.ignoreModifiers())
+		{
+			e.setModifiers(0);
+		}
+
 		if (!plugin.isTyping())
 		{
+
 			if (config.up().matches(e))
 			{
 				modified.put(e.getKeyCode(), KeyEvent.VK_UP);
@@ -142,6 +148,11 @@ class WASDCameraListener extends MouseAdapter implements KeyListener
 			return;
 		}
 
+		if(config.ignoreModifiers())
+		{
+			e.setModifiers(0);
+		}
+
 		if (plugin.chatboxFocused() && !plugin.isTyping())
 		{
 			modified.remove(e.getKeyCode());
@@ -171,6 +182,7 @@ class WASDCameraListener extends MouseAdapter implements KeyListener
 			{
 				modified.remove(e.getKeyCode());
 				e.setKeyCode(m);
+				
 			}
 		}
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/wasdcamera/WASDCameraListener.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/wasdcamera/WASDCameraListener.java
@@ -182,7 +182,6 @@ class WASDCameraListener extends MouseAdapter implements KeyListener
 			{
 				modified.remove(e.getKeyCode());
 				e.setKeyCode(m);
-				
 			}
 		}
 	}


### PR DESCRIPTION
Fixes #7165 and allows camera movement while modifier keys are pressed. Also add an option to disable this option if anyone modified the default WASD keys and key combination like CTRL+W.