### PR TITLE
Add Monkey Madness I as requirement for Western Hard Diaries - Ape Atoll Teleport

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/WesternDiaryRequirement.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/WesternDiaryRequirement.java
@@ -120,6 +120,7 @@ public class WesternDiaryRequirement extends GenericDiaryRequirement
 			new QuestRequirement(Quest.REGICIDE, true));
 		add("Teleport to Ape Atoll.",
 			new SkillRequirement(Skill.MAGIC, 64),
+			new QuestRequirement(Quest.MONKEY_MADNESS_I),
 			new QuestRequirement(Quest.RECIPE_FOR_DISASTER, true));
 		add("Pickpocket a Gnome.",
 			new SkillRequirement(Skill.THIEVING, 75),


### PR DESCRIPTION
Fixes #7309 so users will not get confused when completing Ape Atoll Teleport task in the hard Western Provinces Diary.