### PR TITLE
Add ping option to FPS Control plugin

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/performance/FpsDrawListener.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/performance/FpsDrawListener.java
@@ -22,7 +22,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package net.runelite.client.plugins.fps;
+package net.runelite.client.plugins.performance;
 
 import javax.inject.Inject;
 import net.runelite.api.events.FocusChanged;
@@ -44,7 +44,7 @@ public class FpsDrawListener implements Runnable
 {
 	private static final int SAMPLE_SIZE = 4;
 
-	private final FpsConfig config;
+	private final PerformanceConfig config;
 
 	private long targetDelay = 0;
 
@@ -58,7 +58,7 @@ public class FpsDrawListener implements Runnable
 	private long sleepDelay = 0;
 
 	@Inject
-	private FpsDrawListener(FpsConfig config)
+	private FpsDrawListener(PerformanceConfig config)
 	{
 		this.config = config;
 		reloadConfig();

--- a/runelite-client/src/main/java/net/runelite/client/plugins/performance/FpsLimitMode.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/performance/FpsLimitMode.java
@@ -22,7 +22,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package net.runelite.client.plugins.fps;
+package net.runelite.client.plugins.performance;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/performance/PerformanceConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/performance/PerformanceConfig.java
@@ -22,14 +22,14 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package net.runelite.client.plugins.fps;
+package net.runelite.client.plugins.performance;
 
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
 
-@ConfigGroup(FpsPlugin.CONFIG_GROUP_KEY)
-public interface FpsConfig extends Config
+@ConfigGroup(PerformancePlugin.CONFIG_GROUP_KEY)
+public interface PerformanceConfig extends Config
 {
 	@ConfigItem(
 		keyName = "limitMode",
@@ -62,5 +62,16 @@ public interface FpsConfig extends Config
 	default boolean drawFps()
 	{
 		return true;
+	}
+
+	@ConfigItem(
+		keyName = "drawPing",
+		name = "Draw ping indicator",
+		description = "Show a number in the corner for the current ping",
+		position = 3
+	)
+	default boolean drawPing()
+	{
+		return false;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldHopperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldHopperPlugin.java
@@ -75,7 +75,7 @@ import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.input.KeyManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
-import net.runelite.client.plugins.worldhopper.ping.Ping;
+import net.runelite.client.util.ping.Ping;
 import net.runelite.client.ui.ClientToolbar;
 import net.runelite.client.ui.NavigationButton;
 import net.runelite.client.util.ExecutorServiceExceptionLogger;

--- a/runelite-client/src/main/java/net/runelite/client/util/ping/IPHlpAPI.java
+++ b/runelite-client/src/main/java/net/runelite/client/util/ping/IPHlpAPI.java
@@ -22,7 +22,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package net.runelite.client.plugins.worldhopper.ping;
+package net.runelite.client.util.ping;
 
 import com.sun.jna.Library;
 import com.sun.jna.Native;

--- a/runelite-client/src/main/java/net/runelite/client/util/ping/IcmpEchoReply.java
+++ b/runelite-client/src/main/java/net/runelite/client/util/ping/IcmpEchoReply.java
@@ -22,7 +22,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package net.runelite.client.plugins.worldhopper.ping;
+package net.runelite.client.util.ping;
 
 import com.sun.jna.Pointer;
 import com.sun.jna.Structure;

--- a/runelite-client/src/main/java/net/runelite/client/util/ping/Ping.java
+++ b/runelite-client/src/main/java/net/runelite/client/util/ping/Ping.java
@@ -22,7 +22,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package net.runelite.client.plugins.worldhopper.ping;
+package net.runelite.client.util.ping;
 
 import com.sun.jna.Memory;
 import com.sun.jna.Pointer;

--- a/runelite-client/src/main/java/net/runelite/client/util/ping/Ping.java
+++ b/runelite-client/src/main/java/net/runelite/client/util/ping/Ping.java
@@ -45,14 +45,19 @@ public class Ping
 
 	public static int ping(World world)
 	{
+		return ping(world.getAddress());
+	}
+
+	public static int ping(String address)
+	{
 		try
 		{
 			switch (OSType.getOSType())
 			{
 				case Windows:
-					return windowsPing(world);
+					return windowsPing(address);
 				default:
-					return tcpPing(world);
+					return tcpPing(address);
 			}
 		}
 		catch (IOException ex)
@@ -62,11 +67,11 @@ public class Ping
 		}
 	}
 
-	private static int windowsPing(World world) throws UnknownHostException
+	private static int windowsPing(String worldAddress) throws UnknownHostException
 	{
 		IPHlpAPI ipHlpAPI = IPHlpAPI.INSTANCE;
 		Pointer ptr = ipHlpAPI.IcmpCreateFile();
-		InetAddress inetAddress = InetAddress.getByName(world.getAddress());
+		InetAddress inetAddress = InetAddress.getByName(worldAddress);
 		byte[] address = inetAddress.getAddress();
 		String dataStr = RUNELITE_PING;
 		int dataLength = dataStr.length() + 1;
@@ -88,12 +93,12 @@ public class Ping
 		return rtt;
 	}
 
-	private static int tcpPing(World world) throws IOException
+	private static int tcpPing(String worldAddress) throws IOException
 	{
 		try (Socket socket = new Socket())
 		{
 			socket.setSoTimeout(TIMEOUT);
-			InetAddress inetAddress = InetAddress.getByName(world.getAddress());
+			InetAddress inetAddress = InetAddress.getByName(worldAddress);
 			long start = System.nanoTime();
 			socket.connect(new InetSocketAddress(inetAddress, PORT));
 			long end = System.nanoTime();


### PR DESCRIPTION
Adds an indicator in the top right corner that shows the user's ping to the current world.

- Indicators automatically move out of the way of the log out button on resizeable mode
- Allows you to disable both FPS and Ping indicators

Text color is Green below 50, Yellow from 50 to 99, and Red above 100.

Fixes #2544
Fixes #2640
Fixes #3171

_This PR is based on #3171 with some slight changes, I'm not 100% sure if the current implementation of getting the ping to the current game-server is a great implementation, as we are also pinging all game-servers every `x` seconds if the server selector is open, and the plugin is active, so some form of shared storage might be a good change, I'll leave that up for discussion and I'm happy to change it as required_