### PR TITLE
Add a filter for player indicator based on your level. feature-request

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsConfig.java
@@ -196,4 +196,26 @@ public interface PlayerIndicatorsConfig extends Config
 	{
 		return true;
 	}
+
+	@ConfigItem(
+			position = 15,
+			keyName = "limitLevel",
+			name = "Limit Level",
+			description = "Limit the players to show +-x your level. Useful for BH"
+	)
+	default boolean limitLevel()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+			position = 16,
+			keyName = "level",
+			name = "Level",
+			description = "The level to limit players shown +-x"
+	)
+	default int intLevel()
+	{
+		return 5;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsOverlay.java
@@ -75,9 +75,9 @@ public class PlayerIndicatorsOverlay extends Overlay
 			return;
 		}
 
-		if(config.limitLevel())
+		if (config.limitLevel())
 		{
-			if(!(client.getLocalPlayer().getCombatLevel() >= actor.getCombatLevel() - config.intLevel() && client.getLocalPlayer().getCombatLevel() <= actor.getCombatLevel() + config.intLevel()))
+			if (!(client.getLocalPlayer().getCombatLevel() >= actor.getCombatLevel() - config.intLevel() && client.getLocalPlayer().getCombatLevel() <= actor.getCombatLevel() + config.intLevel()))
 			{
 				return;
 			}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsOverlay.java
@@ -31,6 +31,7 @@ import java.awt.image.BufferedImage;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import net.runelite.api.ClanMemberRank;
+import net.runelite.api.Client;
 import net.runelite.api.Player;
 import net.runelite.api.Point;
 import net.runelite.client.game.ClanManager;
@@ -45,6 +46,9 @@ public class PlayerIndicatorsOverlay extends Overlay
 	private final PlayerIndicatorsService playerIndicatorsService;
 	private final PlayerIndicatorsConfig config;
 	private final ClanManager clanManager;
+
+	@Inject
+	private Client client;
 
 	@Inject
 	private PlayerIndicatorsOverlay(PlayerIndicatorsConfig config, PlayerIndicatorsService playerIndicatorsService,
@@ -71,7 +75,15 @@ public class PlayerIndicatorsOverlay extends Overlay
 			return;
 		}
 
-		String name = actor.getName().replace('\u00A0', ' ');
+		if(config.limitLevel())
+		{
+			if(!(client.getLocalPlayer().getCombatLevel() >= actor.getCombatLevel() - config.intLevel() && client.getLocalPlayer().getCombatLevel() <= actor.getCombatLevel() + config.intLevel()))
+			{
+				return;
+			}
+		}
+
+		String name = actor.getName().replace('\u00A0', ' ') + (config.limitLevel() ? " Lvl: " + actor.getCombatLevel() : "");
 		int offset = actor.getLogicalHeight() + 40;
 		Point textLocation = actor.getCanvasTextLocation(graphics, name, offset);
 


### PR DESCRIPTION
Useful for things like BH and the wildy when you have to keep right clicking people to find out their combat level. This will add an option to limit the player names seen based on the your level and an option you configure. So it could be your_level +-5 names are displayed along with their combat lvl.