### PR TITLE
Ignore modifiers in WASD plugin input

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/config/Keybind.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/Keybind.java
@@ -88,12 +88,23 @@ public class Keybind
 	}
 
 	/**
+	 * @see Keybind#matches(KeyEvent, boolean)
+	 */
+	public boolean matches(KeyEvent e)
+	{
+		return matches(e, false);
+	}
+
+	/**
 	 * If the KeyEvent is from a KeyPressed event this returns if the
 	 * Event is this hotkey being pressed. If the KeyEvent is a
 	 * KeyReleased event this returns if the event is this hotkey being
 	 * released
+	 *
+	 * @param e AWT key event
+	 * @param ignoreModifiers if true ignores any key modifiers (ctrl, shift etc)
 	 */
-	public boolean matches(KeyEvent e)
+	public boolean matches(KeyEvent e, boolean ignoreModifiers)
 	{
 		if (NOT_SET.equals(this))
 		{
@@ -115,7 +126,7 @@ public class Keybind
 			return this.keyCode == keyCode;
 		}
 
-		return this.keyCode == keyCode && this.modifiers == modifiers;
+		return this.keyCode == keyCode && (ignoreModifiers || this.modifiers == modifiers);
 	}
 
 	@Override

--- a/runelite-client/src/main/java/net/runelite/client/plugins/wasdcamera/WASDCameraConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/wasdcamera/WASDCameraConfig.java
@@ -37,7 +37,7 @@ public interface WASDCameraConfig extends Config
 		position = 1,
 		keyName = "up",
 		name = "Up key",
-		description = "The key which will replace up."
+		description = "The key which will replace up (modifiers are ignored)."
 	)
 	default Keybind up()
 	{
@@ -48,7 +48,7 @@ public interface WASDCameraConfig extends Config
 		position = 2,
 		keyName = "down",
 		name = "Down key",
-		description = "The key which will replace down."
+		description = "The key which will replace down (modifiers are ignored)."
 	)
 	default Keybind down()
 	{
@@ -59,7 +59,7 @@ public interface WASDCameraConfig extends Config
 		position = 3,
 		keyName = "left",
 		name = "Left key",
-		description = "The key which will replace left."
+		description = "The key which will replace left (modifiers are ignored)."
 	)
 	default Keybind left()
 	{
@@ -70,7 +70,7 @@ public interface WASDCameraConfig extends Config
 		position = 4,
 		keyName = "right",
 		name = "Right key",
-		description = "The key which will replace right."
+		description = "The key which will replace right (modifiers are ignored)."
 	)
 	default Keybind right()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/wasdcamera/WASDCameraListener.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/wasdcamera/WASDCameraListener.java
@@ -68,22 +68,22 @@ class WASDCameraListener extends MouseAdapter implements KeyListener
 
 		if (!plugin.isTyping())
 		{
-			if (config.up().matches(e))
+			if (config.up().matches(e, true))
 			{
 				modified.put(e.getKeyCode(), KeyEvent.VK_UP);
 				e.setKeyCode(KeyEvent.VK_UP);
 			}
-			else if (config.down().matches(e))
+			else if (config.down().matches(e, true))
 			{
 				modified.put(e.getKeyCode(), KeyEvent.VK_DOWN);
 				e.setKeyCode(KeyEvent.VK_DOWN);
 			}
-			else if (config.left().matches(e))
+			else if (config.left().matches(e, true))
 			{
 				modified.put(e.getKeyCode(), KeyEvent.VK_LEFT);
 				e.setKeyCode(KeyEvent.VK_LEFT);
 			}
-			else if (config.right().matches(e))
+			else if (config.right().matches(e, true))
 			{
 				modified.put(e.getKeyCode(), KeyEvent.VK_RIGHT);
 				e.setKeyCode(KeyEvent.VK_RIGHT);
@@ -146,19 +146,19 @@ class WASDCameraListener extends MouseAdapter implements KeyListener
 		{
 			modified.remove(e.getKeyCode());
 
-			if (config.up().matches(e))
+			if (config.up().matches(e, true))
 			{
 				e.setKeyCode(KeyEvent.VK_UP);
 			}
-			else if (config.down().matches(e))
+			else if (config.down().matches(e, true))
 			{
 				e.setKeyCode(KeyEvent.VK_DOWN);
 			}
-			else if (config.left().matches(e))
+			else if (config.left().matches(e, true))
 			{
 				e.setKeyCode(KeyEvent.VK_LEFT);
 			}
-			else if (config.right().matches(e))
+			else if (config.right().matches(e, true))
 			{
 				e.setKeyCode(KeyEvent.VK_RIGHT);
 			}


### PR DESCRIPTION
- Extend Keybind#matches to allow ignoring modifiers
- Ignore modifiers in WASD plugin input

Closes #7331
Closes #7165 

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>