### PR TITLE
Add Tablet Creation Idle Notification to Idle Notifier

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/AnimationID.java
+++ b/runelite-api/src/main/java/net/runelite/api/AnimationID.java
@@ -146,6 +146,7 @@ public final class AnimationID
 	public static final int CONSTRUCTION = 3676;
 	public static final int SAND_COLLECTION = 895;
 	public static final int PISCARILIUS_CRANE_REPAIR = 7199;
+	public static final int HOME_MAKE_TABLET = 7199;
 
 	// NPC animations
 	public static final int TZTOK_JAD_MAGIC_ATTACK = 2656;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
@@ -360,14 +360,14 @@ public class IdleNotifierPlugin extends Plugin
 
 		if (config.animationIdle() && checkAnimationIdle(waitDuration, local))
 		{
-		    if (makeTabletFinished())
-            {
-                notifier.notify("[" + local.getName() + "] is finished making tablets!");
-            }
-		    else
-            {
-                notifier.notify("[" + local.getName() + "] is now idle!");
-            }
+			if (makeTabletFinished())
+			{
+				notifier.notify("[" + local.getName() + "] is finished making tablets!");
+			}
+			else
+			{
+				notifier.notify("[" + local.getName() + "] is now idle!");
+			}
 		}
 
 		if (config.interactionIdle() && checkInteractionIdle(waitDuration, local))

--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
@@ -90,7 +90,6 @@ public class IdleNotifierPlugin extends Plugin
 	private boolean notifyOxygen = true;
 	private boolean notifyIdleLogout = true;
 	private boolean notify6HourLogout = true;
-	private boolean notifyTabletFinished = true;
 	private int lastSpecEnergy = 1000;
 	private int lastCombatCountdown = 0;
 	private Instant sixHourWarningTime;
@@ -360,14 +359,7 @@ public class IdleNotifierPlugin extends Plugin
 
 		if (config.animationIdle() && checkAnimationIdle(waitDuration, local))
 		{
-			if (makeTabletFinished())
-			{
-				notifier.notify("[" + local.getName() + "] is finished making tablets!");
-			}
-			else
-			{
 				notifier.notify("[" + local.getName() + "] is now idle!");
-			}
 		}
 
 		if (config.interactionIdle() && checkInteractionIdle(waitDuration, local))
@@ -577,21 +569,6 @@ public class IdleNotifierPlugin extends Plugin
 		else
 		{
 			notify6HourLogout = true;
-		}
-
-		return false;
-	}
-
-	private boolean makeTabletFinished()
-	{
-		if (notifyTabletFinished)
-		{
-			notifyTabletFinished = false;
-			return true;
-		}
-		else
-		{
-			notifyTabletFinished = true;
 		}
 
 		return false;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
@@ -208,6 +208,7 @@ public class IdleNotifierPlugin extends Plugin
 			/* Construction */
 			case HOME_MAKE_TABLET:
 			/* Misc */
+			case PISCARILIUS_CRANE_REPAIR:
 			case SAND_COLLECTION:
 				resetTimers();
 				lastAnimation = animation;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
@@ -360,14 +360,14 @@ public class IdleNotifierPlugin extends Plugin
 
 		if (config.animationIdle() && checkAnimationIdle(waitDuration, local))
 		{
-            if (makeTabletFinished())
-            {
-                notifier.notify("[" + local.getName() + "] is finished making tablets!");
-            }
-            else
-            {
-                notifier.notify("[" + local.getName() + "] is now idle!");
-            }
+			if (makeTabletFinished())
+			{
+				notifier.notify("[" + local.getName() + "] is finished making tablets!");
+			}
+			else
+			{
+				notifier.notify("[" + local.getName() + "] is now idle!");
+			}
 		}
 
 		if (config.interactionIdle() && checkInteractionIdle(waitDuration, local))

--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
@@ -90,6 +90,7 @@ public class IdleNotifierPlugin extends Plugin
 	private boolean notifyOxygen = true;
 	private boolean notifyIdleLogout = true;
 	private boolean notify6HourLogout = true;
+	private boolean notifyTabletFinished = true;
 	private int lastSpecEnergy = 1000;
 	private int lastCombatCountdown = 0;
 	private Instant sixHourWarningTime;
@@ -205,6 +206,12 @@ public class IdleNotifierPlugin extends Plugin
 			case USING_GILDED_ALTAR:
 			/* Farming */
 			case FARMING_MIX_ULTRACOMPOST:
+			/* Construction */
+			case HOME_MAKE_TABLET:
+				resetTimers();
+				lastAnimation = animation;
+				lastAnimating = Instant.now();
+				break;
 			/* Misc */
 			case PISCARILIUS_CRANE_REPAIR:
 			case SAND_COLLECTION:
@@ -356,7 +363,7 @@ public class IdleNotifierPlugin extends Plugin
 
 		if (config.animationIdle() && checkAnimationIdle(waitDuration, local))
 		{
-			notifier.notify("[" + local.getName() + "] is now idle!");
+				notifier.notify("[" + local.getName() + "] is now idle!");
 		}
 
 		if (config.interactionIdle() && checkInteractionIdle(waitDuration, local))
@@ -389,6 +396,11 @@ public class IdleNotifierPlugin extends Plugin
 		if (checkFullSpecEnergy())
 		{
 			notifier.notify("[" + local.getName() + "] has restored spec energy!");;
+		}
+
+		if (config.animationIdle() && makeTabletFinished())
+		{
+			notifier.notify("[" + local.getName() + "] is finished making tablets!");
 		}
 	}
 
@@ -568,6 +580,20 @@ public class IdleNotifierPlugin extends Plugin
 			notify6HourLogout = true;
 		}
 
+		return false;
+	}
+
+	private boolean makeTabletFinished()
+	{
+		if (notifyTabletFinished && lastAnimation == 4067)
+		{
+			notifyTabletFinished = false;
+			return true;
+		}
+		else
+		{
+			notifyTabletFinished = true;
+		}
 		return false;
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
@@ -207,7 +207,6 @@ public class IdleNotifierPlugin extends Plugin
 			case FARMING_MIX_ULTRACOMPOST:
 			/* Construction */
 			case HOME_MAKE_TABLET:
-				lastAnimation = animation;
 			/* Misc */
 			case PISCARILIUS_CRANE_REPAIR:
 			case SAND_COLLECTION:
@@ -359,7 +358,7 @@ public class IdleNotifierPlugin extends Plugin
 
 		if (config.animationIdle() && checkAnimationIdle(waitDuration, local))
 		{
-				notifier.notify("[" + local.getName() + "] is now idle!");
+			notifier.notify("[" + local.getName() + "] is now idle!");
 		}
 
 		if (config.interactionIdle() && checkInteractionIdle(waitDuration, local))

--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
@@ -208,7 +208,6 @@ public class IdleNotifierPlugin extends Plugin
 			/* Construction */
 			case HOME_MAKE_TABLET:
 			/* Misc */
-			case PISCARILIUS_CRANE_REPAIR:
 			case SAND_COLLECTION:
 				resetTimers();
 				lastAnimation = animation;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
@@ -360,14 +360,14 @@ public class IdleNotifierPlugin extends Plugin
 
 		if (config.animationIdle() && checkAnimationIdle(waitDuration, local))
 		{
-			if (makeTabletFinished())
-			{
-				notifier.notify("[" + local.getName() + "] is finished making tablets!");
-			}
-			else
-			{
-				notifier.notify("[" + local.getName() + "] is now idle!");
-			}
+		    if (makeTabletFinished())
+            {
+                notifier.notify("[" + local.getName() + "] is finished making tablets!");
+            }
+		    else
+            {
+                notifier.notify("[" + local.getName() + "] is now idle!");
+            }
 		}
 
 		if (config.interactionIdle() && checkInteractionIdle(waitDuration, local))

--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
@@ -584,7 +584,7 @@ public class IdleNotifierPlugin extends Plugin
 
 	private boolean makeTabletFinished()
 	{
-        if (notifyTabletFinished)
+		if (notifyTabletFinished)
 		{
 			notifyTabletFinished = false;
 			return true;
@@ -593,6 +593,7 @@ public class IdleNotifierPlugin extends Plugin
 		{
 			notifyTabletFinished = true;
 		}
+
 		return false;
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
@@ -208,10 +208,7 @@ public class IdleNotifierPlugin extends Plugin
 			case FARMING_MIX_ULTRACOMPOST:
 			/* Construction */
 			case HOME_MAKE_TABLET:
-				resetTimers();
 				lastAnimation = animation;
-				lastAnimating = Instant.now();
-				break;
 			/* Misc */
 			case PISCARILIUS_CRANE_REPAIR:
 			case SAND_COLLECTION:
@@ -363,7 +360,14 @@ public class IdleNotifierPlugin extends Plugin
 
 		if (config.animationIdle() && checkAnimationIdle(waitDuration, local))
 		{
-				notifier.notify("[" + local.getName() + "] is now idle!");
+            if (makeTabletFinished())
+            {
+                notifier.notify("[" + local.getName() + "] is finished making tablets!");
+            }
+            else
+            {
+                notifier.notify("[" + local.getName() + "] is now idle!");
+            }
 		}
 
 		if (config.interactionIdle() && checkInteractionIdle(waitDuration, local))
@@ -396,11 +400,6 @@ public class IdleNotifierPlugin extends Plugin
 		if (checkFullSpecEnergy())
 		{
 			notifier.notify("[" + local.getName() + "] has restored spec energy!");;
-		}
-
-		if (config.animationIdle() && makeTabletFinished())
-		{
-			notifier.notify("[" + local.getName() + "] is finished making tablets!");
 		}
 	}
 
@@ -585,7 +584,7 @@ public class IdleNotifierPlugin extends Plugin
 
 	private boolean makeTabletFinished()
 	{
-		if (notifyTabletFinished && lastAnimation == 4067)
+        if (notifyTabletFinished)
 		{
 			notifyTabletFinished = false;
 			return true;


### PR DESCRIPTION
Sends notification when finished making tablets in home.

- Added HOME_MAKE_TABLET Animation ID to AnimationID
- Added makeTabletFinished() to IdleNotifierPlugin
- Added Custom string "[USER] is finished making tablets!" instead of using the default "[USER] is now idle."


Closes [7220](https://github.com/runelite/runelite/issues/7220)