### PR TITLE
Add Karuulm Slayer Dungeon Obstacles

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/agility/Obstacles.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/agility/Obstacles.java
@@ -227,7 +227,9 @@ class Obstacles
 		// Fossil Island Wyvern Cave
 		STAIRS_31485,
 		// Mount Karuulm
-		ROCKS_34397, ROCKS_34396
+		ROCKS_34397, ROCKS_34396,
+		// Karuulm Slayer Dungeon
+		ROCKS_34544, ROCKS_34548, STEPS_34530, STEPS_34531, LAVA_GAP, TUNNEL_34516
 	);
 
 	static final Set<Integer> TRAP_OBSTACLE_IDS = ImmutableSet.of(


### PR DESCRIPTION
Adds obstacles found in Karuulm Slayer Dungeon to the Agility plugin.
![image](https://user-images.githubusercontent.com/43320258/51216475-d3890480-1924-11e9-8c5e-47cb7ca64b7b.png)
![image](https://user-images.githubusercontent.com/43320258/51216506-ee5b7900-1924-11e9-8f0d-249b0cdce1b9.png)
![image](https://user-images.githubusercontent.com/43320258/51216552-134fec00-1925-11e9-8a43-fa171087a1e3.png)
