### PR TITLE
Idle Notifier for repairing Piscarilius Cranes

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/AnimationID.java
+++ b/runelite-api/src/main/java/net/runelite/api/AnimationID.java
@@ -145,6 +145,7 @@ public final class AnimationID
 	public static final int COW_HOME_TELEPORT_6 = 1701;
 	public static final int CONSTRUCTION = 3676;
 	public static final int SAND_COLLECTION = 895;
+	public static final int PISCARILIUS_CRANE_REPAIR = 7199;
 
 	// NPC animations
 	public static final int TZTOK_JAD_MAGIC_ATTACK = 2656;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
@@ -207,7 +207,6 @@ public class IdleNotifierPlugin extends Plugin
 			case FARMING_MIX_ULTRACOMPOST:
 			/* Misc */
 			case PISCARILIUS_CRANE_REPAIR:
-				lastAnimation = animation;
 			case SAND_COLLECTION:
 				resetTimers();
 				lastAnimation = animation;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
@@ -219,6 +219,8 @@ public class IdleNotifierPlugin extends Plugin
 					lastAnimating = Instant.now();
 					break;
 				}
+			case PISCARILIUS_CRANE_REPAIR:
+				lastAnimation = animation;
 			case IDLE:
 				lastAnimating = Instant.now();
 				break;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
@@ -206,6 +206,8 @@ public class IdleNotifierPlugin extends Plugin
 			/* Farming */
 			case FARMING_MIX_ULTRACOMPOST:
 			/* Misc */
+			case PISCARILIUS_CRANE_REPAIR:
+				lastAnimation = animation;
 			case SAND_COLLECTION:
 				resetTimers();
 				lastAnimation = animation;
@@ -219,8 +221,6 @@ public class IdleNotifierPlugin extends Plugin
 					lastAnimating = Instant.now();
 					break;
 				}
-			case PISCARILIUS_CRANE_REPAIR:
-				lastAnimation = animation;
 			case IDLE:
 				lastAnimating = Instant.now();
 				break;


### PR DESCRIPTION
Fixed [#7095](https://github.com/runelite/runelite/issues/7095)

Default Idle notifications will execute when animation 7199 (pisc crane repair) has ended.