### PR TITLE
Add Contract for the Farming Guildmaster to Menu Entry Swapper

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -261,4 +261,14 @@ public interface MenuEntrySwapperConfig extends Config
 	{
 		return true;
 	}
+
+	@ConfigItem(
+		keyName = "swapContract",
+		name = "Contract",
+		description = "Swap Talk-to with Contract on Farming Guildmaster"
+	)
+	default boolean swapContract()
+	{
+		return true;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -374,6 +374,11 @@ public class MenuEntrySwapperPlugin extends Plugin
 				swap("repairs", option, target, true);
 			}
 
+			if (config.swapContract())
+			{
+				swap("contract", option, target, true);
+			}
+
 			// make sure assignment swap is higher priority than trade swap for slayer masters
 			if (config.swapAssignment())
 			{


### PR DESCRIPTION
Closes [#7326](https://github.com/runelite/runelite/issues/7326)

Added Contract for Farming Guildmaster into the Menu Entry Swapper Plugin
