### PR TITLE
Make Game Notification use the Game message highlight colour

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/Notifier.java
+++ b/runelite-client/src/main/java/net/runelite/client/Notifier.java
@@ -47,11 +47,12 @@ import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
 import net.runelite.api.GameState;
+import net.runelite.client.chat.ChatColorType;
+import net.runelite.client.chat.ChatMessageBuilder;
 import net.runelite.client.chat.ChatMessageManager;
 import net.runelite.client.chat.QueuedMessage;
 import net.runelite.client.config.RuneLiteConfig;
 import net.runelite.client.ui.ClientUI;
-import net.runelite.client.util.ColorUtil;
 import net.runelite.client.util.OSType;
 
 @Singleton
@@ -68,7 +69,6 @@ public class Notifier
 	// Notifier properties
 	private static final Color FLASH_COLOR = new Color(255, 0, 0, 70);
 	private static final int FLASH_DURATION = 2000;
-	private static final Color MESSAGE_COLOR = Color.RED;
 
 	private final Client client;
 	private final String appName;
@@ -134,10 +134,15 @@ public class Notifier
 
 		if (runeLiteConfig.enableGameMessageNotification() && client.getGameState() == GameState.LOGGED_IN)
 		{
+			final String formattedMessage = new ChatMessageBuilder()
+				.append(ChatColorType.HIGHLIGHT)
+				.append(message)
+				.build();
+
 			chatMessageManager.queue(QueuedMessage.builder()
 				.type(ChatMessageType.GAME)
 				.name(appName)
-				.value(ColorUtil.wrapWithColorTag(message, MESSAGE_COLOR))
+				.runeLiteFormattedMessage(formattedMessage)
 				.build());
 		}
 


### PR DESCRIPTION
Default colour won't change since both Game highlights are `#EF1020` by default

Examples alongside other Game type messages
![java_2019-01-17_16-56-34](https://user-images.githubusercontent.com/2979691/51335219-6935a880-1a79-11e9-93de-afcf59f60e9a.png)
![java_2019-01-17_16-56-50](https://user-images.githubusercontent.com/2979691/51335220-6a66d580-1a79-11e9-83d5-dc3a4401e473.png)

