### PR TITLE
Move configManager.sendConfig to RuneLite#shutdown

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/RuneLite.java
+++ b/runelite-client/src/main/java/net/runelite/client/RuneLite.java
@@ -291,6 +291,7 @@ public class RuneLite
 
 	public void shutdown()
 	{
+		configManager.sendConfig();
 		clientSessionManager.shutdown();
 		discordService.close();
 	}

--- a/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
@@ -320,7 +320,6 @@ public class ClientUI
 				() ->
 				{
 					saveClientBoundsConfig();
-					configManager.sendConfig();
 					runelite.shutdown();
 				},
 				this::showWarningOnExit


### PR DESCRIPTION
It should've been here in first place, there is no reason for it to be
in ClientUI.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>