### PR TITLE
ConfigPanel: Confirm plugin configuration reset

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
@@ -532,10 +532,17 @@ public class ConfigPanel extends PluginPanel
 		JButton resetButton = new JButton("Reset");
 		resetButton.addActionListener((e) ->
 		{
-			configManager.setDefaultConfiguration(config, true);
+			final int result = JOptionPane.showOptionDialog(resetButton, "Are you sure you want to reset this plugin's configuration?",
+				"Are you sure?", JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE,
+				null, new String[]{"Yes", "No"}, "No");
 
-			// Reload configuration panel
-			openGroupConfigPanel(listItem, config, cd);
+			if (result == JOptionPane.YES_OPTION)
+			{
+				configManager.setDefaultConfiguration(config, true);
+
+				// Reload configuration panel
+				openGroupConfigPanel(listItem, config, cd);
+			}
 		});
 		mainPanel.add(resetButton);
 


### PR DESCRIPTION
Simply adds a configuration dialog to confirm resetting a pulgin's configuration. 

![capture3](https://user-images.githubusercontent.com/2348393/51422142-96688080-1b77-11e9-8241-d4f7b06c9937.PNG)

I have long lists of items, npcs, etc in several plugins that would be a major pain to accidentally reset. I don't see any downside to this.