### PR TITLE
Wrap DiscordEventHandlers in native lib try/catch

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/discord/DiscordService.java
+++ b/runelite-client/src/main/java/net/runelite/client/discord/DiscordService.java
@@ -47,18 +47,41 @@ import net.runelite.discord.DiscordUser;
 @Slf4j
 public class DiscordService implements AutoCloseable
 {
-	@Inject
-	private EventBus eventBus;
+	private final EventBus eventBus;
+	private final RuneLiteProperties runeLiteProperties;
+	private final ScheduledExecutorService executorService;
+	private final DiscordRPC discordRPC;
 
-	@Inject
-	private RuneLiteProperties runeLiteProperties;
-
-	@Inject
-	private ScheduledExecutorService executorService;
-
-	private DiscordRPC discordRPC;
 	// Hold a reference to the event handlers to prevent the garbage collector from deleting them
-	private final DiscordEventHandlers discordEventHandlers = new DiscordEventHandlers();
+	private final DiscordEventHandlers discordEventHandlers;
+
+	@Inject
+	private DiscordService(
+		final EventBus eventBus,
+		final RuneLiteProperties runeLiteProperties,
+		final ScheduledExecutorService executorService)
+	{
+
+		this.eventBus = eventBus;
+		this.runeLiteProperties = runeLiteProperties;
+		this.executorService = executorService;
+
+		DiscordRPC discordRPC = null;
+		DiscordEventHandlers discordEventHandlers = null;
+
+		try
+		{
+			discordRPC = DiscordRPC.INSTANCE;
+			discordEventHandlers = new DiscordEventHandlers();
+		}
+		catch (UnsatisfiedLinkError e)
+		{
+			log.warn("Failed to load Discord library, Discord support will be disabled.");
+		}
+
+		this.discordRPC = discordRPC;
+		this.discordEventHandlers = discordEventHandlers;
+	}
 
 	/**
 	 * Initializes the Discord service, sets up the event handlers and starts worker thread that will poll discord
@@ -67,18 +90,12 @@ public class DiscordService implements AutoCloseable
 	 */
 	public void init()
 	{
-		log.info("Initializing Discord RPC service.");
-
-		try
+		if (discordEventHandlers == null)
 		{
-			discordRPC = DiscordRPC.INSTANCE;
-		}
-		catch (UnsatisfiedLinkError e)
-		{
-			log.warn("Failed to load Discord library, Discord support will be disabled.");
 			return;
 		}
 
+		log.info("Initializing Discord RPC service.");
 		discordEventHandlers.ready = this::ready;
 		discordEventHandlers.disconnected = this::disconnected;
 		discordEventHandlers.errored = this::errored;


### PR DESCRIPTION
Even construction of DiscordEventHandlers causes UnsatisfieldLinkError
on unsupported systems, avoid this.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>

The error: https://pastebin.com/Md80g8KU