### PR TITLE
Add a Toggle to the Status Bars w/ a Delay to show only in Combat

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/statusbars/StatusBarsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/statusbars/StatusBarsConfig.java
@@ -32,6 +32,7 @@ import net.runelite.client.config.ConfigItem;
 public interface StatusBarsConfig extends Config
 {
 	@ConfigItem(
+		position = 1,
 		keyName = "enableCounter",
 		name = "Show hitpoints & prayer counter",
 		description = "Shows current amount of hitpoints & prayer on the status bars"
@@ -42,6 +43,7 @@ public interface StatusBarsConfig extends Config
 	}
 
 	@ConfigItem(
+		position = 2,
 		keyName = "enableSkillIcon",
 		name = "Show hitpoints & prayer icons",
 		description = "Adds skill icons at the top of the bars."
@@ -52,6 +54,7 @@ public interface StatusBarsConfig extends Config
 	}
 
 	@ConfigItem(
+		position = 3,
 		keyName = "enableRestorationBars",
 		name = "Show amount of hitpoints and prayer restored",
 		description = "Visually shows how much a food or prayer will heal/restore you on the bars."
@@ -62,16 +65,7 @@ public interface StatusBarsConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "hideStatusBarDelay",
-		name = "Delay (seconds)",
-		description = "Number of seconds after combat to hide the status bars."
-	)
-	default int hideStatusBarDelay()
-	{
-		return 3;
-	}
-
-	@ConfigItem(
+		position = 4,
 		keyName = "toggleRestorationBars",
 		name = "Toggle to Hide when not in Combat",
 		description = "Visually hides the Status Bars when player is out of combat."
@@ -79,5 +73,16 @@ public interface StatusBarsConfig extends Config
 	default boolean toggleRestorationBars()
 	{
 		return true;
+	}
+
+	@ConfigItem(
+		position = 5,
+		keyName = "hideStatusBarDelay",
+		name = "Delay (seconds)",
+		description = "Number of seconds after combat to hide the status bars."
+	)
+	default int hideStatusBarDelay()
+	{
+		return 3;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/statusbars/StatusBarsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/statusbars/StatusBarsConfig.java
@@ -80,5 +80,4 @@ public interface StatusBarsConfig extends Config
 	{
 		return true;
 	}
-
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/statusbars/StatusBarsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/statusbars/StatusBarsConfig.java
@@ -67,7 +67,7 @@ public interface StatusBarsConfig extends Config
 	@ConfigItem(
 		position = 4,
 		keyName = "toggleRestorationBars",
-		name = "Toggle to Hide when not in Combat",
+		name = "Toggle to hide when not in combat",
 		description = "Visually hides the Status Bars when player is out of combat."
 	)
 	default boolean toggleRestorationBars()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/statusbars/StatusBarsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/statusbars/StatusBarsConfig.java
@@ -60,4 +60,25 @@ public interface StatusBarsConfig extends Config
 	{
 		return true;
 	}
+
+	@ConfigItem(
+		keyName = "hideStatusBarDelay",
+		name = "Delay (seconds)",
+		description = "Number of seconds after combat to hide the status bars."
+	)
+	default int hideStatusBarDelay()
+	{
+		return 3;
+	}
+
+	@ConfigItem(
+		keyName = "toggleRestorationBars",
+		name = "Toggle to Hide when not in Combat",
+		description = "Visually hides the Status Bars when player is out of combat."
+	)
+	default boolean toggleRestorationBars()
+	{
+		return true;
+	}
+
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/statusbars/StatusBarsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/statusbars/StatusBarsPlugin.java
@@ -24,9 +24,21 @@
  */
 package net.runelite.client.plugins.statusbars;
 
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.List;
 import javax.inject.Inject;
 import com.google.inject.Provides;
+import lombok.AccessLevel;
+import lombok.Getter;
+import net.runelite.api.Actor;
+import net.runelite.api.Client;
+import net.runelite.api.NPC;
+import net.runelite.api.NPCComposition;
+import net.runelite.api.events.GameTick;
 import net.runelite.client.config.ConfigManager;
+import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDependency;
 import net.runelite.client.plugins.PluginDescriptor;
@@ -47,10 +59,56 @@ public class StatusBarsPlugin extends Plugin
 	@Inject
 	private OverlayManager overlayManager;
 
+	@Inject
+	private Client client;
+
+	@Inject
+	private StatusBarsConfig config;
+
+	@Getter(AccessLevel.PACKAGE)
+	private Instant lastCombatAction;
+
 	@Override
 	protected void startUp() throws Exception
 	{
-		overlayManager.add(overlay);
+	}
+
+	void updateLastCombatAction()
+	{
+		this.lastCombatAction = Instant.now();
+	}
+
+	@Subscribe
+	public void onGameTick(GameTick gameTick)
+	{
+		final Actor interacting = client.getLocalPlayer().getInteracting();
+		final boolean isNpc = interacting instanceof NPC;
+		final int COMBAT_TIMEOUT = config.hideStatusBarDelay();
+
+		if (!config.toggleRestorationBars())
+		{
+			overlayManager.add(overlay);
+			return;
+		}
+
+		if (isNpc)
+		{
+			final NPC npc = (NPC) interacting;
+			final NPCComposition npcComposition = npc.getComposition();
+			final List<String> npcMenuActions = Arrays.asList(npcComposition.getActions());
+			if (npcMenuActions.contains("Attack"))
+				{
+					updateLastCombatAction();
+					overlayManager.add(overlay);
+				}
+		}
+		else if (lastCombatAction != null)
+		{
+			if (Duration.between(getLastCombatAction(), Instant.now()).getSeconds() > COMBAT_TIMEOUT)
+			{
+				overlayManager.remove(overlay);
+			}
+		}
 	}
 
 	@Override

--- a/runelite-client/src/main/java/net/runelite/client/plugins/statusbars/StatusBarsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/statusbars/StatusBarsPlugin.java
@@ -81,32 +81,34 @@ public class StatusBarsPlugin extends Plugin
 	@Subscribe
 	public void onGameTick(GameTick gameTick)
 	{
-		final Actor interacting = client.getLocalPlayer().getInteracting();
-		final boolean isNpc = interacting instanceof NPC;
-		final int COMBAT_TIMEOUT = config.hideStatusBarDelay();
-
 		if (!config.toggleRestorationBars())
 		{
 			overlayManager.add(overlay);
 			return;
 		}
-
-		if (isNpc)
+		else
 		{
-			final NPC npc = (NPC) interacting;
-			final NPCComposition npcComposition = npc.getComposition();
-			final List<String> npcMenuActions = Arrays.asList(npcComposition.getActions());
-			if (npcMenuActions.contains("Attack"))
+			final Actor interacting = client.getLocalPlayer().getInteracting();
+			final boolean isNpc = interacting instanceof NPC;
+			final int COMBAT_TIMEOUT = config.hideStatusBarDelay();
+
+			if (isNpc)
+			{
+				final NPC npc = (NPC) interacting;
+				final NPCComposition npcComposition = npc.getComposition();
+				final List<String> npcMenuActions = Arrays.asList(npcComposition.getActions());
+				if (npcMenuActions.contains("Attack") && config.toggleRestorationBars())
 				{
 					updateLastCombatAction();
 					overlayManager.add(overlay);
 				}
-		}
-		else if (lastCombatAction != null)
-		{
-			if (Duration.between(getLastCombatAction(), Instant.now()).getSeconds() > COMBAT_TIMEOUT)
+			}
+			else if (lastCombatAction != null)
 			{
-				overlayManager.remove(overlay);
+				if (Duration.between(getLastCombatAction(), Instant.now()).getSeconds() > COMBAT_TIMEOUT)
+				{
+					overlayManager.remove(overlay);
+				}
 			}
 		}
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/statusbars/StatusBarsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/statusbars/StatusBarsPlugin.java
@@ -88,27 +88,32 @@ public class StatusBarsPlugin extends Plugin
 		}
 		else
 		{
-			final Actor interacting = client.getLocalPlayer().getInteracting();
-			final boolean isNpc = interacting instanceof NPC;
-			final int COMBAT_TIMEOUT = config.hideStatusBarDelay();
+			hideStatusBar();
+		}
+	}
 
-			if (isNpc)
+	private void hideStatusBar()
+	{
+		final Actor interacting = client.getLocalPlayer().getInteracting();
+		final boolean isNpc = interacting instanceof NPC;
+		final int combatTimeout = config.hideStatusBarDelay();
+
+		if (isNpc)
+		{
+			final NPC npc = (NPC) interacting;
+			final NPCComposition npcComposition = npc.getComposition();
+			final List<String> npcMenuActions = Arrays.asList(npcComposition.getActions());
+			if (npcMenuActions.contains("Attack") && config.toggleRestorationBars())
 			{
-				final NPC npc = (NPC) interacting;
-				final NPCComposition npcComposition = npc.getComposition();
-				final List<String> npcMenuActions = Arrays.asList(npcComposition.getActions());
-				if (npcMenuActions.contains("Attack") && config.toggleRestorationBars())
-				{
-					updateLastCombatAction();
-					overlayManager.add(overlay);
-				}
+				updateLastCombatAction();
+				overlayManager.add(overlay);
 			}
-			else if (lastCombatAction != null)
+		}
+		else if (lastCombatAction != null)
+		{
+			if (Duration.between(getLastCombatAction(), Instant.now()).getSeconds() > combatTimeout)
 			{
-				if (Duration.between(getLastCombatAction(), Instant.now()).getSeconds() > COMBAT_TIMEOUT)
-				{
-					overlayManager.remove(overlay);
-				}
+				overlayManager.remove(overlay);
 			}
 		}
 	}


### PR DESCRIPTION
This is to only show the Status Bars only when in Combat, and hides it based on the delay set.
Closes #7436
Toggle Demo: https://gyazo.com/ee277e5f0d4bfad598a7a1049d972a67
Delay Demo: https://gyazo.com/421e2a4a725725f1b7b5e62f96a6a8a3

**Note: I know my diffs are messed up - I have updated my .gitconfig to match the settings that deathbeam provided to me to fix this for any future commits.** 