### PR TITLE
Add a Notification to show amount of Ammo left

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonConfig.java
@@ -35,8 +35,7 @@ public interface CannonConfig extends Config
 	@ConfigItem(
 		keyName = "showEmptyCannonNotification",
 		name = "Empty cannon notification",
-		description = "Configures whether to notify you that the cannon is empty",
-		position = 1
+		description = "Configures whether to notify you that the cannon is empty"
 	)
 	default boolean showEmptyCannonNotification()
 	{
@@ -46,8 +45,7 @@ public interface CannonConfig extends Config
 	@ConfigItem(
 		keyName = "showInfobox",
 		name = "Show Cannonball infobox",
-		description = "Configures whether to show the cannonballs in an infobox",
-		position = 2
+		description = "Configures whether to show the cannonballs in an infobox"
 	)
 	default boolean showInfobox()
 	{
@@ -57,8 +55,7 @@ public interface CannonConfig extends Config
 	@ConfigItem(
 		keyName = "showDoubleHitSpot",
 		name = "Show double hit spots",
-		description = "Configures whether to show the NPC double hit spot",
-		position = 3
+		description = "Configures whether to show the NPC double hit spot"
 	)
 	default boolean showDoubleHitSpot()
 	{
@@ -68,8 +65,7 @@ public interface CannonConfig extends Config
 	@ConfigItem(
 		keyName = "highlightDoubleHitColor",
 		name = "Color of double hit spots",
-		description = "Configures the highlight color of double hit spots",
-		position = 4
+		description = "Configures the highlight color of double hit spots"
 	)
 	default Color highlightDoubleHitColor()
 	{
@@ -79,8 +75,7 @@ public interface CannonConfig extends Config
 	@ConfigItem(
 		keyName = "showCannonSpots",
 		name = "Show common cannon spots",
-		description = "Configures whether to show common cannon spots or not",
-		position = 5
+		description = "Configures whether to show common cannon spots or not"
 	)
 	default boolean showCannonSpots()
 	{
@@ -89,9 +84,8 @@ public interface CannonConfig extends Config
 
 	@ConfigItem(
 		keyName = "ammoAmount",
-		name = "Ammo left notification",
-		description = "Configure to set the amount of ammo left to receive low ammo notification",
-		position = 6
+		name = "Ammo left",
+		description = "Configure to set the amount of ammo left to receive ammo left notification"
 	)
 	default int ammoAmount()
 	{
@@ -100,9 +94,8 @@ public interface CannonConfig extends Config
 
 	@ConfigItem(
 		keyName = "notifyAmmoLeft",
-		name = "Show amount left notification",
-		description = "Sends a notification when cannon ammo is under the specified amount",
-		position = 7
+		name = "Ammo left notification",
+		description = "Sends a notification when cannon ammo is under the specified amount"
 	)
 	default boolean notifyAmmoLeft()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonConfig.java
@@ -35,7 +35,8 @@ public interface CannonConfig extends Config
 	@ConfigItem(
 		keyName = "showEmptyCannonNotification",
 		name = "Empty cannon notification",
-		description = "Configures whether to notify you that the cannon is empty"
+		description = "Configures whether to notify you that the cannon is empty",
+		position = 1
 	)
 	default boolean showEmptyCannonNotification()
 	{
@@ -45,7 +46,8 @@ public interface CannonConfig extends Config
 	@ConfigItem(
 		keyName = "showInfobox",
 		name = "Show Cannonball infobox",
-		description = "Configures whether to show the cannonballs in an infobox"
+		description = "Configures whether to show the cannonballs in an infobox",
+		position = 2
 	)
 	default boolean showInfobox()
 	{
@@ -55,7 +57,8 @@ public interface CannonConfig extends Config
 	@ConfigItem(
 		keyName = "showDoubleHitSpot",
 		name = "Show double hit spots",
-		description = "Configures whether to show the NPC double hit spot"
+		description = "Configures whether to show the NPC double hit spot",
+		position = 3
 	)
 	default boolean showDoubleHitSpot()
 	{
@@ -65,7 +68,8 @@ public interface CannonConfig extends Config
 	@ConfigItem(
 		keyName = "highlightDoubleHitColor",
 		name = "Color of double hit spots",
-		description = "Configures the highlight color of double hit spots"
+		description = "Configures the highlight color of double hit spots",
+		position = 4
 	)
 	default Color highlightDoubleHitColor()
 	{
@@ -75,9 +79,32 @@ public interface CannonConfig extends Config
 	@ConfigItem(
 		keyName = "showCannonSpots",
 		name = "Show common cannon spots",
-		description = "Configures whether to show common cannon spots or not"
+		description = "Configures whether to show common cannon spots or not",
+		position = 5
 	)
 	default boolean showCannonSpots()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		keyName = "ammoAmount",
+		name = "Ammo left notification",
+		description = "Configure to set the amount of ammo left to receive low ammo notification",
+		position = 6
+	)
+	default int ammoAmount()
+	{
+		return 5;
+	}
+
+	@ConfigItem(
+		keyName = "notifyAmmoLeft",
+		name = "Show amount left notification",
+		description = "Sends a notification when cannon ammo is under the specified amount",
+		position = 7
+	)
+	default boolean notifyAmmoLeft()
 	{
 		return true;
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonPlugin.java
@@ -379,6 +379,13 @@ public class CannonPlugin extends Plugin
 		{
 			return Color.orange;
 		}
+		else if (cballsLeft <= config.ammoAmount())
+		{
+			if (config.notifyAmmoLeft())
+			{
+				notifier.notify("Your cannon has " + config.ammoAmount() + " balls left!");
+			}
+		}
 
 		return Color.red;
 	}


### PR DESCRIPTION
Integrated into the Cannon Plugin
Closes: #7465 & #1820
Created 2 config items:
1) Set value of Ammo Left in order to send notification
2) Turn the config option on to show this notification

Created the notification on CannonPlugin.java
Added position to Config to make more readable/user-friendly