### PR TITLE
chat commands: rebuild chatbox input after using clear shortcuts

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/ScriptID.java
+++ b/runelite-api/src/main/java/net/runelite/api/ScriptID.java
@@ -68,6 +68,11 @@ public final class ScriptID
 	public static final int CLEAR_CHATBOX_PANEL = 677;
 
 	/**
+	 * Builds the chatbox input widget
+	 */
+	public static final int CHAT_PROMPT_INIT = 223;
+
+	/**
 	 * Queries the completion state of a quest by its struct id
 	 * <ul>
 	 * <li> int (struct) The id of the quest

--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatKeyboardListener.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatKeyboardListener.java
@@ -28,6 +28,7 @@ import java.awt.event.KeyEvent;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import net.runelite.api.Client;
+import net.runelite.api.ScriptID;
 import net.runelite.api.VarClientStr;
 import net.runelite.client.callback.ClientThread;
 import net.runelite.client.input.KeyListener;
@@ -82,11 +83,19 @@ public class ChatKeyboardListener implements KeyListener
 						replacement = "";
 					}
 
-					clientThread.invoke(() -> client.setVar(VarClientStr.CHATBOX_TYPED_TEXT, replacement));
+					clientThread.invoke(() ->
+					{
+						client.setVar(VarClientStr.CHATBOX_TYPED_TEXT, replacement);
+						client.runScript(ScriptID.CHAT_PROMPT_INIT);
+					});
 				}
 				break;
 			case KeyEvent.VK_BACK_SPACE:
-				clientThread.invoke(() -> client.setVar(VarClientStr.CHATBOX_TYPED_TEXT, ""));
+				clientThread.invoke(() ->
+				{
+					client.setVar(VarClientStr.CHATBOX_TYPED_TEXT, "");
+					client.runScript(ScriptID.CHAT_PROMPT_INIT);
+				});
 				break;
 		}
 	}


### PR DESCRIPTION
Chatbox input is normally only rebuilt after a key is pressed, which caused a visual discrepancy after using clear shortcuts.

Closes #7466 