### PR TITLE
Check if NPC is visible on minimap at barrows

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/barrows/BarrowsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/barrows/BarrowsOverlay.java
@@ -32,6 +32,7 @@ import javax.inject.Inject;
 import net.runelite.api.Client;
 import net.runelite.api.GameObject;
 import net.runelite.api.NPC;
+import net.runelite.api.NPCComposition;
 import net.runelite.api.ObjectComposition;
 import net.runelite.api.Perspective;
 import net.runelite.api.Player;
@@ -74,6 +75,13 @@ class BarrowsOverlay extends Overlay
 			final List<NPC> npcs = client.getNpcs();
 			for (NPC npc : npcs)
 			{
+				final NPCComposition composition = npc.getComposition();
+
+				if (composition != null && !composition.isMinimapVisable())
+				{
+					continue;
+				}
+
 				net.runelite.api.Point minimapLocation = npc.getMinimapLocation();
 				if (minimapLocation != null)
 				{


### PR DESCRIPTION
Check the isMinimapVisable variable before drawing NPC dot on minimap in
barrows plugin.

Fixes #6672
Closes #6698 

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>