### PR TITLE
change prayer levels needed math from floor to ceiling

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/combatlevel/CombatLevelOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/combatlevel/CombatLevelOverlay.java
@@ -168,7 +168,7 @@ class CombatLevelOverlay extends Overlay
 	@VisibleForTesting
 	static int calcLevelsPray(double start, int end, int prayerLevel)
 	{
-		final int neededLevels = (int) Math.floor(calcMultipliedLevels(start, end, PRAY_MULT));
+		final int neededLevels = (int) Math.ceil(calcMultipliedLevels(start, end, PRAY_MULT));
 
 		if ((prayerLevel + neededLevels) % 2 != 0)
 		{


### PR DESCRIPTION
From what I can see, the RL calculations were correct except for prayer. Prayer should be fixed now, although I will admit I wasn't able to extensively test in game.

https://oldschool.tools/calculators/combat-level < correct
https://oldschool.runescape.wiki/w/Calculator:Combat_level < incorrect

Should resolve issue #7411 