### PR TITLE
Add highlight to fairy rings

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/ObjectID.java
+++ b/runelite-api/src/main/java/net/runelite/api/ObjectID.java
@@ -15723,6 +15723,7 @@ public final class ObjectID
 	public static final int CORPSE_29492 = 29492;
 	public static final int CORPSE_29493 = 29493;
 	public static final int SKELETON_29494 = 29494;
+	public static final int FAIRY_RING_OUTSIDE_ZANARIS = 29495;
 	public static final int FAIRY_RING_29496 = 29496;
 	public static final int FAIRY_RING_29497 = 29497;
 	public static final int FAIRY_RING_29498 = 29498;
@@ -15787,6 +15788,7 @@ public final class ObjectID
 	public static final int FAIRY_RING_29557 = 29557;
 	public static final int FAIRY_RING_29558 = 29558;
 	public static final int FAIRY_RING_29559 = 29559;
+	public static final int FAIRY_RING_ZANARIS = 29560;
 	public static final int FAIRY_RING_29561 = 29561;
 	public static final int FAIRY_RING_29562 = 29562;
 	public static final int FAIRY_RING_29563 = 29563;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/fairyring/FairyRingConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/fairyring/FairyRingConfig.java
@@ -24,6 +24,7 @@
  */
 package net.runelite.client.plugins.fairyring;
 
+import java.awt.Color;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
@@ -39,5 +40,23 @@ public interface FairyRingConfig extends Config
 	default boolean autoOpen()
 	{
 		return true;
+	}
+
+	@ConfigItem(
+			keyName = "highlightRings",
+			name = "Highlight fairy ring hitboxes",
+			description = "Highlights the hitbox for the player to click on fairy rings"
+	)
+	default boolean highlightRings() { return true; }
+
+	@ConfigItem(
+			keyName = "overlayColor",
+			name = "Overlay Color",
+			description = "Color of Fairy ring overlay",
+			position = 3
+	)
+	default Color getOverlayColor()
+	{
+		return new Color(255, 110, 231);
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/fairyring/FairyRingOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/fairyring/FairyRingOverlay.java
@@ -1,0 +1,75 @@
+package net.runelite.client.plugins.fairyring;
+
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Graphics2D;
+import java.awt.geom.Area;
+import javax.inject.Inject;
+import net.runelite.api.Client;
+import net.runelite.api.Perspective;
+import net.runelite.api.Point;
+import net.runelite.api.coords.LocalPoint;
+import net.runelite.client.ui.overlay.Overlay;
+import net.runelite.client.ui.overlay.OverlayLayer;
+import net.runelite.client.ui.overlay.OverlayPosition;
+
+public class FairyRingOverlay extends Overlay
+{
+
+    private static final int OBJECT_INTERACTION_FAR = 35; // Max distance, in tiles, from camera
+    private static final int FUDGE_FACTOR = 8; // Can't seem to exactly replicate the distance check in ClickboxMixin
+
+    private Client client;
+    private final FairyRingPlugin plugin;
+    private final FairyRingConfig config;
+
+    @Inject
+    private FairyRingOverlay(Client client, FairyRingPlugin plugin ,FairyRingConfig config)
+    {
+        super(plugin);
+        setPosition(OverlayPosition.DYNAMIC);
+        setLayer(OverlayLayer.ABOVE_SCENE);
+        this.client = client;
+        this.plugin = plugin;
+        this.config = config;
+    }
+
+    @Override
+    public Dimension render(Graphics2D graphics)
+    {
+        Point mousePosition = client.getMouseCanvasPosition();
+        plugin.getRings().forEach((object, tile) -> {
+            if (Rings.FAIRY_RING_IDS.contains(object.getId()) && !config.highlightRings())
+            {
+                return;
+            }
+
+            final LocalPoint cameraPoint = new LocalPoint(client.getCameraX(), client.getCameraY());
+            int distance = object.getLocalLocation().distanceTo(cameraPoint);
+            if (tile.getPlane() == client.getPlane() &&
+                    (distance <= (OBJECT_INTERACTION_FAR - FUDGE_FACTOR) * Perspective.LOCAL_TILE_SIZE))
+            {
+                Area objectClickbox = object.getClickbox();
+                if (objectClickbox != null)
+                {
+                    Color configColor = config.getOverlayColor();
+                    if (objectClickbox.contains(mousePosition.getX(), mousePosition.getY()))
+                    {
+                        graphics.setColor(configColor.darker());
+                    }
+                    else
+                    {
+                        graphics.setColor(configColor);
+                    }
+
+                    graphics.draw(objectClickbox);
+                    graphics.setColor(new Color(configColor.getRed(), configColor.getGreen(), configColor.getBlue(), 50));
+                    graphics.fill(objectClickbox);
+                }
+            }
+        });
+
+        return null;
+    }
+
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/fairyring/Rings.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/fairyring/Rings.java
@@ -1,0 +1,11 @@
+package net.runelite.client.plugins.fairyring;
+
+import com.google.common.collect.ImmutableSet;
+import java.util.Set;
+import static net.runelite.api.ObjectID.*;
+
+public class Rings
+{
+    static final Set<Integer> FAIRY_RING_IDS = ImmutableSet.of(FAIRY_RING_OUTSIDE_ZANARIS, FAIRY_RING_ZANARIS);
+
+}


### PR DESCRIPTION
This plugin highlights the clickbox of fairy rings when the player is close enough to use them.
![fairy ring highlight](https://user-images.githubusercontent.com/10566967/51684628-74795e80-1fba-11e9-9304-015265ace4ad.png)

With the GPU plugin allowing for the users to see more of the world (and #6539 preventing them from interacting with it) it's easy to try to interact with fairy rings too early while moving around OSRS. This modification to the fairy ring plugin helps to eliminate that issue by highlighting the fairy rings.
![too_far](https://user-images.githubusercontent.com/10566967/51684630-75aa8b80-1fba-11e9-9f38-04d42f23fe62.png)

Additionally the fairy ring hitbox is a square when clearly the mushrooms are in a circle on the ground so this clarifies that to the player.
![square_clickbox](https://user-images.githubusercontent.com/10566967/51684633-76dbb880-1fba-11e9-8e49-7eaa249a59ed.png)

In zanaris.
![in_zanaris](https://user-images.githubusercontent.com/10566967/51684967-4a746c00-1fbb-11e9-982d-f7faf595e6fe.png)

At the lighthouse.
![at_the_lighthouse](https://user-images.githubusercontent.com/10566967/51684975-4e07f300-1fbb-11e9-8ff6-11328f1195b0.png)

