### PR TITLE
Add option to require shift for overlay menus

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/config/RuneLiteConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/RuneLiteConfig.java
@@ -230,10 +230,21 @@ public interface RuneLiteConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "menuEntryShift",
+		name = "Require Shift for overlay menu",
+		description = "Overlay right-click menu will require shift to be added",
+		position = 33
+	)
+	default boolean menuEntryShift()
+	{
+		return true;
+	}
+
+	@ConfigItem(
 		keyName = "infoBoxVertical",
 		name = "Display infoboxes vertically",
 		description = "Toggles the infoboxes to display vertically",
-		position = 33
+		position = 40
 	)
 	default boolean infoBoxVertical()
 	{
@@ -244,7 +255,7 @@ public interface RuneLiteConfig extends Config
 		keyName = "infoBoxWrap",
 		name = "Infobox wrap count",
 		description = "Configures the amount of infoboxes shown before wrapping",
-		position = 34
+		position = 41
 	)
 	default int infoBoxWrap()
 	{
@@ -255,7 +266,7 @@ public interface RuneLiteConfig extends Config
 		keyName = "infoBoxSize",
 		name = "Infobox size (px)",
 		description = "Configures the size of each infobox in pixels",
-		position = 35
+		position = 42
 	)
 	default int infoBoxSize()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayRenderer.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayRenderer.java
@@ -75,6 +75,7 @@ public class OverlayRenderer extends MouseAdapter implements KeyListener
 	private final Point mousePosition = new Point();
 	private Overlay movedOverlay;
 	private boolean inOverlayDraggingMode;
+	private boolean inMenuEntryMode;
 	private MenuEntry[] menuEntries;
 
 	// Overlay state validation
@@ -106,6 +107,7 @@ public class OverlayRenderer extends MouseAdapter implements KeyListener
 		if (!event.isFocused())
 		{
 			inOverlayDraggingMode = false;
+			inMenuEntryMode = false;
 			menuEntries = null;
 		}
 	}
@@ -114,6 +116,11 @@ public class OverlayRenderer extends MouseAdapter implements KeyListener
 	protected void onClientTick(ClientTick t)
 	{
 		if (menuEntries == null)
+		{
+			return;
+		}
+
+		if (!inMenuEntryMode && runeLiteConfig.menuEntryShift())
 		{
 			return;
 		}
@@ -401,6 +408,11 @@ public class OverlayRenderer extends MouseAdapter implements KeyListener
 		{
 			inOverlayDraggingMode = true;
 		}
+
+		if (e.isShiftDown() && runeLiteConfig.menuEntryShift())
+		{
+			inMenuEntryMode = true;
+		}
 	}
 
 	@Override
@@ -409,6 +421,11 @@ public class OverlayRenderer extends MouseAdapter implements KeyListener
 		if (!e.isAltDown())
 		{
 			inOverlayDraggingMode = false;
+		}
+
+		if (!e.isShiftDown())
+		{
+			inMenuEntryMode = false;
 		}
 	}
 


### PR DESCRIPTION
Enabled by default. This was on original PR review and was discussed in
Discord. It is better to just use what we already use for adding our
custom entries at other places, and there is possibility that overlays
will have a lot of right click menus in future, so making it require
shift is most sane option.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>