### PR TITLE
Move menu entry nulling to BeforeRender

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayRenderer.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayRenderer.java
@@ -41,6 +41,7 @@ import net.runelite.api.Client;
 import net.runelite.api.GameState;
 import net.runelite.api.MenuAction;
 import net.runelite.api.MenuEntry;
+import net.runelite.api.events.BeforeRender;
 import net.runelite.api.events.ClientTick;
 import net.runelite.api.events.FocusChanged;
 import net.runelite.api.widgets.Widget;
@@ -119,7 +120,6 @@ public class OverlayRenderer extends MouseAdapter implements KeyListener
 
 		if (client.isMenuOpen())
 		{
-			menuEntries = null;
 			return;
 		}
 
@@ -130,7 +130,11 @@ public class OverlayRenderer extends MouseAdapter implements KeyListener
 		System.arraycopy(menuEntries, 0, newEntries, 1, menuEntries.length); // Add overlay menu entries
 		System.arraycopy(clientMenuEntries, 1, newEntries, menuEntries.length + 1, clientMenuEntries.length - 1); // Add remaining menu entries
 		client.setMenuEntries(newEntries);
+	}
 
+	@Subscribe
+	public void onBeforeRender(BeforeRender event)
+	{
 		menuEntries = null;
 	}
 


### PR DESCRIPTION
As render() and ClientTick rates are inconsistent (unless user has
50FPS, then they are same) the menu entries can flicker because
ClientTick will be called more often than render and so when frame is
skipped, menu entry is nulled and that causes flicker.

Closes #7537 

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>