### PR TITLE
Refresh infoboxes only when needed

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/infobox/InfoBoxManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/infobox/InfoBoxManager.java
@@ -77,17 +77,19 @@ public class InfoBoxManager
 	public void removeInfoBox(InfoBox infoBox)
 	{
 		log.debug("Removing InfoBox {}", infoBox);
-		infoBoxes.remove(infoBox);
-
-		refreshInfoBoxes();
+		if (infoBoxes.remove(infoBox))
+		{
+			refreshInfoBoxes();
+		}
 	}
 
 	public void removeIf(Predicate<InfoBox> filter)
 	{
 		log.debug("Removing InfoBoxes for filter {}", filter);
-		infoBoxes.removeIf(filter);
-
-		refreshInfoBoxes();
+		if (infoBoxes.removeIf(filter))
+		{
+			refreshInfoBoxes();
+		}
 	}
 
 	public List<InfoBox> getInfoBoxes()


### PR DESCRIPTION
Refresh infoboxes only when removeIf and remove actually removes
anything to avoid constant refreshing for no reason.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>