### PR TITLE
Add raid layout message

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
@@ -62,6 +62,7 @@ import net.runelite.client.input.KeyManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.util.StackFormatter;
+import static net.runelite.client.util.Text.sanitize;
 import net.runelite.http.api.chat.ChatClient;
 import net.runelite.http.api.hiscore.HiscoreClient;
 import net.runelite.http.api.hiscore.HiscoreEndpoint;
@@ -790,19 +791,6 @@ public class ChatCommandsPlugin extends Plugin
 
 		// Take a guess
 		return shortest;
-	}
-
-	/**
-	 * Cleans the ironman status icon from playername string if present and
-	 * corrects spaces.
-	 *
-	 * @param lookup Playername to lookup.
-	 * @return Cleaned playername.
-	 */
-	private static String sanitize(String lookup)
-	{
-		String cleaned = lookup.contains("<img") ? lookup.substring(lookup.lastIndexOf('>') + 1) : lookup;
-		return cleaned.replace('\u00A0', ' ');
 	}
 
 	/**

--- a/runelite-client/src/main/java/net/runelite/client/plugins/raids/Raid.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/raids/Raid.java
@@ -134,4 +134,49 @@ public class Raid
 
 		return builder.toString();
 	}
+
+	public String toRoomString()
+	{
+		final StringBuilder sb = new StringBuilder();
+
+		for (Room r : getLayout().getRooms())
+		{
+			final int position = r.getPosition();
+			final RaidRoom room = getRoom(position);
+
+			if (room == null || !(room.getType() == RaidRoom.Type.COMBAT || room.getType() == RaidRoom.Type.PUZZLE))
+			{
+				continue;
+			}
+
+			switch (room.getType())
+			{
+				case PUZZLE:
+					final RaidRoom.Puzzle puzzle = room.getPuzzle();
+					sb.append(puzzle.getName());
+
+					if (puzzle == RaidRoom.Puzzle.UNKNOWN)
+					{
+						sb.append(" (puzzle)");
+					}
+
+					sb.append(", ");
+					break;
+				case COMBAT:
+					final RaidRoom.Boss boss = room.getBoss();
+					sb.append(boss.getName());
+
+					if (boss == RaidRoom.Boss.UNKNOWN)
+					{
+						sb.append(" (combat)");
+					}
+
+					sb.append(", ");
+					break;
+			}
+		}
+
+		final String roomsString = sb.toString();
+		return roomsString.substring(0, roomsString.length() - 2);
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsConfig.java
@@ -151,4 +151,15 @@ public interface RaidsConfig extends Config
 	{
 		return "";
 	}
+
+	@ConfigItem(
+		position = 11,
+		keyName = "layoutMessage",
+		name = "Send raid layout message when entering raid",
+		description = "Sends game message with raid layout on entering new raid"
+	)
+	default boolean layoutMessage()
+	{
+		return true;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsOverlay.java
@@ -86,7 +86,7 @@ public class RaidsOverlay extends Overlay
 		}
 
 		Color color = Color.WHITE;
-		String layout = plugin.getRaid().getLayout().toCode().replaceAll("#", "").replaceAll("¤", "");
+		String layout = plugin.getRaid().getLayout().toCodeString();
 
 		if (config.enableLayoutWhitelist() && !plugin.getLayoutWhitelist().contains(layout.toLowerCase()))
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsPlugin.java
@@ -242,21 +242,21 @@ public class RaidsPlugin extends Plugin
 					double percentage = personalPoints / (totalPoints / 100.0);
 
 					String chatMessage = new ChatMessageBuilder()
-							.append(ChatColorType.NORMAL)
-							.append("Total points: ")
-							.append(ChatColorType.HIGHLIGHT)
-							.append(POINTS_FORMAT.format(totalPoints))
-							.append(ChatColorType.NORMAL)
-							.append(", Personal points: ")
-							.append(ChatColorType.HIGHLIGHT)
-							.append(POINTS_FORMAT.format(personalPoints))
-							.append(ChatColorType.NORMAL)
-							.append(" (")
-							.append(ChatColorType.HIGHLIGHT)
-							.append(DECIMAL_FORMAT.format(percentage))
-							.append(ChatColorType.NORMAL)
-							.append("%)")
-							.build();
+						.append(ChatColorType.NORMAL)
+						.append("Total points: ")
+						.append(ChatColorType.HIGHLIGHT)
+						.append(POINTS_FORMAT.format(totalPoints))
+						.append(ChatColorType.NORMAL)
+						.append(", Personal points: ")
+						.append(ChatColorType.HIGHLIGHT)
+						.append(POINTS_FORMAT.format(personalPoints))
+						.append(ChatColorType.NORMAL)
+						.append(" (")
+						.append(ChatColorType.HIGHLIGHT)
+						.append(DECIMAL_FORMAT.format(percentage))
+						.append(ChatColorType.NORMAL)
+						.append("%)")
+						.build();
 
 					chatMessageManager.queue(QueuedMessage.builder()
 						.type(ChatMessageType.CLANCHAT_INFO)
@@ -302,6 +302,7 @@ public class RaidsPlugin extends Plugin
 				raid.updateLayout(layout);
 				RotationSolver.solve(raid.getCombatRooms());
 				overlay.setScoutOverlayShown(true);
+				sendRaidLayoutMessage();
 			}
 			else if (!config.scoutOverlayAtBank())
 			{
@@ -314,6 +315,28 @@ public class RaidsPlugin extends Plugin
 		{
 			overlay.setScoutOverlayShown(false);
 		}
+	}
+
+	private void sendRaidLayoutMessage()
+	{
+		if (!config.layoutMessage())
+		{
+			return;
+		}
+
+		final String layout = getRaid().getLayout().toCodeString();
+		final String rooms = getRaid().toRoomString();
+		final String raidData = "[" + layout + "]: " + rooms;
+
+		chatMessageManager.queue(QueuedMessage.builder()
+			.type(ChatMessageType.CLANCHAT_INFO)
+			.runeLiteFormattedMessage(new ChatMessageBuilder()
+				.append(ChatColorType.HIGHLIGHT)
+				.append("Layout: ")
+				.append(ChatColorType.NORMAL)
+				.append(raidData)
+				.build())
+			.build());
 	}
 
 	private void updateInfoBoxState()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/raids/solver/Layout.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/raids/solver/Layout.java
@@ -62,4 +62,9 @@ public class Layout
 
 		return builder.toString();
 	}
+
+	public String toCodeString()
+	{
+		return toCode().replaceAll("#", "").replaceAll("¤", "");
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/util/Text.java
+++ b/runelite-client/src/main/java/net/runelite/client/util/Text.java
@@ -146,4 +146,17 @@ public class Text
 
 		return out.toString();
 	}
+
+	/**
+	 * Cleans the ironman status icon from playername string if present and
+	 * corrects spaces.
+	 *
+	 * @param name Playername to lookup.
+	 * @return Cleaned playername.
+	 */
+	public static String sanitize(String name)
+	{
+		String cleaned = name.contains("<img") ? name.substring(name.lastIndexOf('>') + 1) : name;
+		return cleaned.replace('\u00A0', ' ');
+	}
 }


### PR DESCRIPTION
- Move ChatCommandsPlugin#sanitize to Text
- Add toRoomString and toCodeString Raid utilities - Add new util methods that will build room and code string from current raid layout.
- Send raid layout message on raid enter - Sends raid layout message as clan chat game message when entering raid.

Preview:
![screenie](https://user-images.githubusercontent.com/5115805/51786598-c9f26e80-2166-11e9-9ec9-dc90d12f2c53.png)
