### PR TITLE
Remove invalid OverlayMenuEntries

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/cerberus/CerberusOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cerberus/CerberusOverlay.java
@@ -28,11 +28,8 @@ import java.awt.Dimension;
 import java.awt.Graphics2D;
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import static net.runelite.api.MenuAction.RUNELITE_OVERLAY_CONFIG;
 import net.runelite.client.game.SkillIconManager;
 import net.runelite.client.ui.overlay.Overlay;
-import static net.runelite.client.ui.overlay.OverlayManager.OPTION_CONFIGURE;
-import net.runelite.client.ui.overlay.OverlayMenuEntry;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.components.ImageComponent;
 import net.runelite.client.ui.overlay.components.PanelComponent;
@@ -47,12 +44,10 @@ public class CerberusOverlay extends Overlay
 	@Inject
 	CerberusOverlay(final CerberusPlugin plugin, final SkillIconManager iconManager)
 	{
-		super(plugin);
 		this.plugin = plugin;
 		this.iconManager = iconManager;
 		setPosition(OverlayPosition.BOTTOM_RIGHT);
 		panelComponent.setOrientation(PanelComponent.Orientation.HORIZONTAL);
-		getMenuEntries().add(new OverlayMenuEntry(RUNELITE_OVERLAY_CONFIG, OPTION_CONFIGURE, "Cerberus overlay"));
 	}
 
 	@Override

--- a/runelite-client/src/main/java/net/runelite/client/plugins/inventoryviewer/InventoryViewerOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/inventoryviewer/InventoryViewerOverlay.java
@@ -33,11 +33,8 @@ import net.runelite.api.Client;
 import net.runelite.api.InventoryID;
 import net.runelite.api.Item;
 import net.runelite.api.ItemContainer;
-import static net.runelite.api.MenuAction.RUNELITE_OVERLAY_CONFIG;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.ui.overlay.Overlay;
-import static net.runelite.client.ui.overlay.OverlayManager.OPTION_CONFIGURE;
-import net.runelite.client.ui.overlay.OverlayMenuEntry;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.components.ImageComponent;
 import net.runelite.client.ui.overlay.components.PanelComponent;
@@ -55,16 +52,14 @@ class InventoryViewerOverlay extends Overlay
 	private final PanelComponent panelComponent = new PanelComponent();
 
 	@Inject
-	private InventoryViewerOverlay(InventoryViewerPlugin plugin, Client client, ItemManager itemManager)
+	private InventoryViewerOverlay(Client client, ItemManager itemManager)
 	{
-		super(plugin);
 		setPosition(OverlayPosition.BOTTOM_RIGHT);
 		panelComponent.setWrapping(4);
 		panelComponent.setGap(new Point(6, 4));
 		panelComponent.setOrientation(PanelComponent.Orientation.HORIZONTAL);
 		this.itemManager = itemManager;
 		this.client = client;
-		getMenuEntries().add(new OverlayMenuEntry(RUNELITE_OVERLAY_CONFIG, OPTION_CONFIGURE, "Inventory viewer overlay"));
 	}
 
 	@Override


### PR DESCRIPTION
Two plugins were using `OverlayMenuEntry` when they had nothing to configure.
Interacting with this menu item resulted in a null pointer being thrown inside `ConfigPanel` locking up a portion of the side panel until scrolling or clicking off onto another navitem.

Didn't see a need to add a check inside `ConfigPanel` to handle this as it shouldn't occur in the first place.
Removed two occurrences of this. I don't believe it is present in any other plugin.