### PR TITLE
Convert game thread events to singletons

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/events/AnimationChanged.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/AnimationChanged.java
@@ -43,6 +43,13 @@ import net.runelite.api.Actor;
 @Data
 public class AnimationChanged
 {
+	public static final AnimationChanged INSTANCE = new AnimationChanged();
+
+	private AnimationChanged()
+	{
+		// noop
+	}
+
 	/**
 	 * The actor that has entered a new animation.
 	 */

--- a/runelite-api/src/main/java/net/runelite/api/events/BeforeRender.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/BeforeRender.java
@@ -29,4 +29,11 @@ package net.runelite.api.events;
  */
 public class BeforeRender
 {
+	public static final BeforeRender INSTANCE = new BeforeRender();
+
+	private BeforeRender()
+	{
+		// noop
+	}
+
 }

--- a/runelite-api/src/main/java/net/runelite/api/events/BoostedLevelChanged.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/BoostedLevelChanged.java
@@ -44,6 +44,13 @@ import net.runelite.api.Skill;
 @Data
 public class BoostedLevelChanged
 {
+	public static final BoostedLevelChanged INSTANCE = new BoostedLevelChanged();
+
+	private BoostedLevelChanged()
+	{
+		// noop
+	}
+
 	/**
 	 * The skill that has had its level modified.
 	 */

--- a/runelite-api/src/main/java/net/runelite/api/events/ChatMessage.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/ChatMessage.java
@@ -40,6 +40,13 @@ import net.runelite.api.ChatMessageType;
 @AllArgsConstructor
 public class ChatMessage
 {
+	public static final ChatMessage INSTANCE = new ChatMessage();
+
+	private ChatMessage()
+	{
+		// noop
+	}
+
 	/**
 	 * The type of message received.
 	 */

--- a/runelite-api/src/main/java/net/runelite/api/events/ClanChanged.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/ClanChanged.java
@@ -24,14 +24,21 @@
  */
 package net.runelite.api.events;
 
-import lombok.Value;
+import lombok.Data;
 
 /**
  * An event where the client has joined or left a clan chat.
  */
-@Value
+@Data
 public class ClanChanged
 {
+	public static final ClanChanged INSTANCE = new ClanChanged();
+
+	private ClanChanged()
+	{
+		// noop
+	}
+
 	/**
 	 * Whether or not the client is now in a clan chat.
 	 */

--- a/runelite-api/src/main/java/net/runelite/api/events/ClientTick.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/ClientTick.java
@@ -29,4 +29,11 @@ package net.runelite.api.events;
  */
 public class ClientTick
 {
+	public static final ClientTick INSTANCE = new ClientTick();
+
+	private ClientTick()
+	{
+		// noop
+	}
+
 }

--- a/runelite-api/src/main/java/net/runelite/api/events/CommandExecuted.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/CommandExecuted.java
@@ -24,7 +24,7 @@
  */
 package net.runelite.api.events;
 
-import lombok.Value;
+import lombok.Data;
 
 /**
  * An event where a command has been used in the chat.
@@ -41,9 +41,16 @@ import lombok.Value;
  * set the command field to an empty string. For example, the message ":: hello world!"
  * will set command to "" and arguments to ["hello", "world!"].
  */
-@Value
+@Data
 public class CommandExecuted
 {
+	public static final CommandExecuted INSTANCE = new CommandExecuted();
+
+	private CommandExecuted()
+	{
+		// noop
+	}
+
 	/**
 	 * The name of the command entered.
 	 */

--- a/runelite-api/src/main/java/net/runelite/api/events/DecorativeObjectChanged.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/DecorativeObjectChanged.java
@@ -35,6 +35,13 @@ import net.runelite.api.Tile;
 @Data
 public class DecorativeObjectChanged
 {
+	public static final DecorativeObjectChanged INSTANCE = new DecorativeObjectChanged();
+
+	private DecorativeObjectChanged()
+	{
+		// noop
+	}
+
 	/**
 	 * The affected tile.
 	 */

--- a/runelite-api/src/main/java/net/runelite/api/events/DecorativeObjectDespawned.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/DecorativeObjectDespawned.java
@@ -35,6 +35,13 @@ import net.runelite.api.Tile;
 @Data
 public class DecorativeObjectDespawned
 {
+	public static final DecorativeObjectDespawned INSTANCE = new DecorativeObjectDespawned();
+
+	private DecorativeObjectDespawned()
+	{
+		// noop
+	}
+
 	/**
 	 * The affected tile.
 	 */

--- a/runelite-api/src/main/java/net/runelite/api/events/DecorativeObjectSpawned.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/DecorativeObjectSpawned.java
@@ -34,6 +34,13 @@ import net.runelite.api.Tile;
 @Data
 public class DecorativeObjectSpawned
 {
+	public static final DecorativeObjectSpawned INSTANCE = new DecorativeObjectSpawned();
+
+	private DecorativeObjectSpawned()
+	{
+		// noop
+	}
+
 	/**
 	 * The affected tile.
 	 */

--- a/runelite-api/src/main/java/net/runelite/api/events/DraggingWidgetChanged.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/DraggingWidgetChanged.java
@@ -33,6 +33,13 @@ import lombok.Data;
 @Data
 public class DraggingWidgetChanged
 {
+	public static final DraggingWidgetChanged INSTANCE = new DraggingWidgetChanged();
+
+	private DraggingWidgetChanged()
+	{
+		// noop
+	}
+
 	/**
 	 * Whether a widget is currently being dragged.
 	 */

--- a/runelite-api/src/main/java/net/runelite/api/events/ExperienceChanged.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/ExperienceChanged.java
@@ -34,6 +34,13 @@ import net.runelite.api.Skill;
 @Data
 public class ExperienceChanged
 {
+	public static final ExperienceChanged INSTANCE = new ExperienceChanged();
+
+	private ExperienceChanged()
+	{
+		// noop
+	}
+
 	/**
 	 * The modified skill.
 	 */

--- a/runelite-api/src/main/java/net/runelite/api/events/GameObjectChanged.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/GameObjectChanged.java
@@ -34,6 +34,13 @@ import net.runelite.api.Tile;
 @Data
 public class GameObjectChanged
 {
+	public static final GameObjectChanged INSTANCE = new GameObjectChanged();
+
+	private GameObjectChanged()
+	{
+		// noop
+	}
+
 	/**
 	 * The affected tile.
 	 */

--- a/runelite-api/src/main/java/net/runelite/api/events/GameObjectDespawned.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/GameObjectDespawned.java
@@ -34,6 +34,13 @@ import net.runelite.api.Tile;
 @Data
 public class GameObjectDespawned
 {
+	public static final GameObjectDespawned INSTANCE = new GameObjectDespawned();
+
+	private GameObjectDespawned()
+	{
+		// noop
+	}
+
 	/**
 	 * The affected tile.
 	 */

--- a/runelite-api/src/main/java/net/runelite/api/events/GameObjectSpawned.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/GameObjectSpawned.java
@@ -34,6 +34,13 @@ import net.runelite.api.Tile;
 @Data
 public class GameObjectSpawned
 {
+	public static final GameObjectSpawned INSTANCE = new GameObjectSpawned();
+
+	private GameObjectSpawned()
+	{
+		// noop
+	}
+
 	/**
 	 * The affected tile.
 	 */

--- a/runelite-api/src/main/java/net/runelite/api/events/GameStateChanged.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/GameStateChanged.java
@@ -33,6 +33,13 @@ import net.runelite.api.GameState;
 @Data
 public class GameStateChanged
 {
+	public static final GameStateChanged INSTANCE = new GameStateChanged();
+
+	private GameStateChanged()
+	{
+		// noop
+	}
+
 	/**
 	 * The new game state.
 	 */

--- a/runelite-api/src/main/java/net/runelite/api/events/GameTick.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/GameTick.java
@@ -24,8 +24,6 @@
  */
 package net.runelite.api.events;
 
-import lombok.Data;
-
 // The NPC update event seem to run every server tick,
 // but having the game tick event after all packets
 // have been processed is typically more useful.
@@ -43,7 +41,13 @@ import lombok.Data;
  * Note that occurrences that take place purely on the client, such as right
  * click menus, are independent of the game tick.
  */
-@Data
 public class GameTick
 {
+	public static final GameTick INSTANCE = new GameTick();
+
+	private GameTick()
+	{
+		// noop
+	}
+
 }

--- a/runelite-api/src/main/java/net/runelite/api/events/GrandExchangeOfferChanged.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/GrandExchangeOfferChanged.java
@@ -44,6 +44,13 @@ import net.runelite.api.GrandExchangeOfferState;
 @Data
 public class GrandExchangeOfferChanged
 {
+	public static final GrandExchangeOfferChanged INSTANCE = new GrandExchangeOfferChanged();
+
+	private GrandExchangeOfferChanged()
+	{
+		// noop
+	}
+
 	/**
 	 * The offer that has been modified.
 	 */

--- a/runelite-api/src/main/java/net/runelite/api/events/GraphicChanged.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/GraphicChanged.java
@@ -45,6 +45,13 @@ import net.runelite.api.Actor;
 @Data
 public class GraphicChanged
 {
+	public static final GraphicChanged INSTANCE = new GraphicChanged();
+
+	private GraphicChanged()
+	{
+		// noop
+	}
+
 	/**
 	 * The actor that has had their graphic changed.
 	 */

--- a/runelite-api/src/main/java/net/runelite/api/events/GraphicsObjectCreated.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/GraphicsObjectCreated.java
@@ -24,17 +24,24 @@
  */
 package net.runelite.api.events;
 
-import lombok.Value;
+import lombok.Data;
 import net.runelite.api.GraphicsObject;
 
 /**
  * An event where a new {@link GraphicsObject} has been created.
  */
-@Value
+@Data
 public class GraphicsObjectCreated
 {
+	public static final GraphicsObjectCreated INSTANCE = new GraphicsObjectCreated();
+
+	private GraphicsObjectCreated()
+	{
+		// noop
+	}
+
 	/**
 	 * The newly created graphics object.
 	 */
-	private final GraphicsObject graphicsObject;
+	private GraphicsObject graphicsObject;
 }

--- a/runelite-api/src/main/java/net/runelite/api/events/GroundObjectChanged.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/GroundObjectChanged.java
@@ -34,6 +34,13 @@ import net.runelite.api.Tile;
 @Data
 public class GroundObjectChanged
 {
+	public static final GroundObjectChanged INSTANCE = new GroundObjectChanged();
+
+	private GroundObjectChanged()
+	{
+		// noop
+	}
+
 	/**
 	 * The affected tile.
 	 */

--- a/runelite-api/src/main/java/net/runelite/api/events/GroundObjectDespawned.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/GroundObjectDespawned.java
@@ -34,6 +34,13 @@ import net.runelite.api.Tile;
 @Data
 public class GroundObjectDespawned
 {
+	public static final GroundObjectDespawned INSTANCE = new GroundObjectDespawned();
+
+	private GroundObjectDespawned()
+	{
+		// noop
+	}
+
 	/**
 	 * The affected tile.
 	 */

--- a/runelite-api/src/main/java/net/runelite/api/events/GroundObjectSpawned.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/GroundObjectSpawned.java
@@ -34,6 +34,13 @@ import net.runelite.api.Tile;
 @Data
 public class GroundObjectSpawned
 {
+	public static final GroundObjectSpawned INSTANCE = new GroundObjectSpawned();
+
+	private GroundObjectSpawned()
+	{
+		// noop
+	}
+
 	/**
 	 * The affected tile.
 	 */

--- a/runelite-api/src/main/java/net/runelite/api/events/HitsplatApplied.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/HitsplatApplied.java
@@ -38,6 +38,13 @@ import net.runelite.api.Hitsplat;
 @Data
 public class HitsplatApplied
 {
+	public static final HitsplatApplied INSTANCE = new HitsplatApplied();
+
+	private HitsplatApplied()
+	{
+		// noop
+	}
+
 	/**
 	 * The actor the hitsplat was applied to.
 	 */

--- a/runelite-api/src/main/java/net/runelite/api/events/InteractingChanged.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/InteractingChanged.java
@@ -24,19 +24,26 @@
  */
 package net.runelite.api.events;
 
-import lombok.Value;
+import lombok.Data;
 import net.runelite.api.Actor;
 
 /**
  * An event called when the actor an actor is interacting with changes
  */
-@Value
+@Data
 public class InteractingChanged
 {
-	private final Actor source;
+	public static final InteractingChanged INSTANCE = new InteractingChanged();
+
+	private InteractingChanged()
+	{
+		// noop
+	}
+
+	private Actor source;
 
 	/**
 	 * Target actor, may be null
 	 */
-	private final Actor target;
+	private Actor target;
 }

--- a/runelite-api/src/main/java/net/runelite/api/events/ItemContainerChanged.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/ItemContainerChanged.java
@@ -24,7 +24,7 @@
  */
 package net.runelite.api.events;
 
-import lombok.Value;
+import lombok.Data;
 import net.runelite.api.ItemContainer;
 
 /**
@@ -38,11 +38,18 @@ import net.runelite.api.ItemContainer;
  *     <li>Dropping an item</li>
  * </ul>
  */
-@Value
+@Data
 public class ItemContainerChanged
 {
+	public static final ItemContainerChanged INSTANCE = new ItemContainerChanged();
+
+	private ItemContainerChanged()
+	{
+		// noop
+	}
+
 	/**
 	 * The modified item container.
 	 */
-	private final ItemContainer itemContainer;
+	private ItemContainer itemContainer;
 }

--- a/runelite-api/src/main/java/net/runelite/api/events/ItemDespawned.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/ItemDespawned.java
@@ -24,7 +24,7 @@
  */
 package net.runelite.api.events;
 
-import lombok.Value;
+import lombok.Data;
 import net.runelite.api.Item;
 import net.runelite.api.Tile;
 
@@ -32,9 +32,16 @@ import net.runelite.api.Tile;
  * Called when an item pile despawns from the ground. When the client loads a new scene,
  * all item piles are implicitly despawned, and despawn events will not be sent.
  */
-@Value
+@Data
 public class ItemDespawned
 {
-	private final Tile tile;
-	private final Item item;
+	public static final ItemDespawned INSTANCE = new ItemDespawned();
+
+	private ItemDespawned()
+	{
+		// noop
+	}
+
+	private Tile tile;
+	private Item item;
 }

--- a/runelite-api/src/main/java/net/runelite/api/events/ItemQuantityChanged.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/ItemQuantityChanged.java
@@ -24,18 +24,25 @@
  */
 package net.runelite.api.events;
 
-import lombok.Value;
+import lombok.Data;
 import net.runelite.api.Item;
 import net.runelite.api.Tile;
 
 /**
  * Called when the quantity of an item pile changes.
  */
-@Value
+@Data
 public class ItemQuantityChanged
 {
-	private final Item item;
-	private final Tile tile;
-	private final int oldQuantity;
-	private final int newQuantity;
+	public static final ItemQuantityChanged INSTANCE = new ItemQuantityChanged();
+
+	private ItemQuantityChanged()
+	{
+		// noop
+	}
+
+	private Item item;
+	private Tile tile;
+	private int oldQuantity;
+	private int newQuantity;
 }

--- a/runelite-api/src/main/java/net/runelite/api/events/ItemSpawned.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/ItemSpawned.java
@@ -24,7 +24,7 @@
  */
 package net.runelite.api.events;
 
-import lombok.Value;
+import lombok.Data;
 import net.runelite.api.Item;
 import net.runelite.api.Tile;
 
@@ -32,9 +32,16 @@ import net.runelite.api.Tile;
  * Called when an item pile spawns on the ground. When the client loads a new scene,
  * all item piles are implicitly reset and a new spawn event will be sent.
  */
-@Value
+@Data
 public class ItemSpawned
 {
-	private final Tile tile;
-	private final Item item;
+	public static final ItemSpawned INSTANCE = new ItemSpawned();
+
+	private ItemSpawned()
+	{
+		// noop
+	}
+
+	private Tile tile;
+	private Item item;
 }

--- a/runelite-api/src/main/java/net/runelite/api/events/LocalPlayerDeath.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/LocalPlayerDeath.java
@@ -29,4 +29,11 @@ package net.runelite.api.events;
  */
 public class LocalPlayerDeath
 {
+	public static final LocalPlayerDeath INSTANCE = new LocalPlayerDeath();
+
+	private LocalPlayerDeath()
+	{
+		// noop
+	}
+
 }

--- a/runelite-api/src/main/java/net/runelite/api/events/MenuEntryAdded.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/MenuEntryAdded.java
@@ -34,31 +34,38 @@ import lombok.Data;
 @AllArgsConstructor
 public class MenuEntryAdded
 {
+	public static final MenuEntryAdded INSTANCE = new MenuEntryAdded();
+
+	private MenuEntryAdded()
+	{
+		// noop
+	}
+
 	/**
 	 * The option text added to the menu (ie. "Walk here", "Use").
 	 */
-	private final String option;
+	private String option;
 	/**
 	 * The target of the action (ie. Item or Actor name).
 	 * <p>
 	 * If the option does not apply to any target, this field
 	 * will be set to empty string.
 	 */
-	private final String target;
+	private String target;
 	/**
 	 * The action type that will be triggered.
 	 */
-	private final int type;
+	private int type;
 	/**
 	 * An identifier value for the target of the action
 	 */
-	private final int identifier;
+	private int identifier;
 	/**
 	 * An additional parameter for the action.
 	 */
-	private final int actionParam0;
+	private int actionParam0;
 	/**
 	 * A second additional parameter for the action.
 	 */
-	private final int actionParam1;
+	private int actionParam1;
 }

--- a/runelite-api/src/main/java/net/runelite/api/events/MenuOpened.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/MenuOpened.java
@@ -33,6 +33,13 @@ import net.runelite.api.MenuEntry;
 @Data
 public class MenuOpened
 {
+	public static final MenuOpened INSTANCE = new MenuOpened();
+
+	private MenuOpened()
+	{
+		// noop
+	}
+
 	/**
 	 * The menu entries in the newly opened menu.
 	 * <p>

--- a/runelite-api/src/main/java/net/runelite/api/events/MenuOptionClicked.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/MenuOptionClicked.java
@@ -41,6 +41,13 @@ import net.runelite.api.MenuAction;
 @Data
 public class MenuOptionClicked
 {
+	public static final MenuOptionClicked INSTANCE = new MenuOptionClicked();
+
+	private MenuOptionClicked()
+	{
+		// noop
+	}
+
 	/**
 	 * The action parameter used in the click.
 	 */

--- a/runelite-api/src/main/java/net/runelite/api/events/NameableNameChanged.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/NameableNameChanged.java
@@ -24,17 +24,24 @@
  */
 package net.runelite.api.events;
 
-import lombok.Value;
+import lombok.Data;
 import net.runelite.api.Nameable;
 
 /**
  * An event where a {@link Nameable} has had their name changed.
  */
-@Value
+@Data
 public class NameableNameChanged
 {
+	public static final NameableNameChanged INSTANCE = new NameableNameChanged();
+
+	private NameableNameChanged()
+	{
+		// noop
+	}
+
 	/**
 	 * The nameable that changed names.
 	 */
-	private final Nameable nameable;
+	private Nameable nameable;
 }

--- a/runelite-api/src/main/java/net/runelite/api/events/NpcActionChanged.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/NpcActionChanged.java
@@ -33,6 +33,13 @@ import net.runelite.api.NPCComposition;
 @Data
 public class NpcActionChanged
 {
+	public static final NpcActionChanged INSTANCE = new NpcActionChanged();
+
+	private NpcActionChanged()
+	{
+		// noop
+	}
+
 	/**
 	 * The NPC composition that has been changed.
 	 */

--- a/runelite-api/src/main/java/net/runelite/api/events/NpcDespawned.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/NpcDespawned.java
@@ -24,20 +24,27 @@
  */
 package net.runelite.api.events;
 
-import lombok.Value;
+import lombok.Data;
 import net.runelite.api.Actor;
 import net.runelite.api.NPC;
 
 /**
  * An event where an {@link NPC} has despawned.
  */
-@Value
+@Data
 public class NpcDespawned
 {
+	public static final NpcDespawned INSTANCE = new NpcDespawned();
+
+	private NpcDespawned()
+	{
+		// noop
+	}
+
 	/**
 	 * The despawned NPC.
 	 */
-	private final NPC npc;
+	private NPC npc;
 
 	public Actor getActor()
 	{

--- a/runelite-api/src/main/java/net/runelite/api/events/NpcSpawned.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/NpcSpawned.java
@@ -24,20 +24,27 @@
  */
 package net.runelite.api.events;
 
-import lombok.Value;
+import lombok.Data;
 import net.runelite.api.Actor;
 import net.runelite.api.NPC;
 
 /**
  * An event where an {@link NPC} has spawned.
  */
-@Value
+@Data
 public class NpcSpawned
 {
+	public static final NpcSpawned INSTANCE = new NpcSpawned();
+
+	private NpcSpawned()
+	{
+		// noop
+	}
+
 	/**
 	 * The spawned NPC.
 	 */
-	private final NPC npc;
+	private NPC npc;
 
 	public Actor getActor()
 	{

--- a/runelite-api/src/main/java/net/runelite/api/events/PlayerDespawned.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/PlayerDespawned.java
@@ -24,7 +24,7 @@
  */
 package net.runelite.api.events;
 
-import lombok.Value;
+import lombok.Data;
 import net.runelite.api.Actor;
 import net.runelite.api.Player;
 
@@ -33,13 +33,20 @@ import net.runelite.api.Player;
  * <p>
  * Note: This event does not get called for the local player.
  */
-@Value
+@Data
 public class PlayerDespawned
 {
+	public static final PlayerDespawned INSTANCE = new PlayerDespawned();
+
+	private PlayerDespawned()
+	{
+		// noop
+	}
+
 	/**
 	 * The despawned player.
 	 */
-	private final Player player;
+	private Player player;
 
 	public Actor getActor()
 	{

--- a/runelite-api/src/main/java/net/runelite/api/events/PlayerMenuOptionClicked.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/PlayerMenuOptionClicked.java
@@ -33,6 +33,13 @@ import lombok.Data;
 @Data
 public class PlayerMenuOptionClicked
 {
+	public static final PlayerMenuOptionClicked INSTANCE = new PlayerMenuOptionClicked();
+
+	private PlayerMenuOptionClicked()
+	{
+		// noop
+	}
+
 	/**
 	 * The menu option clicked.
 	 */

--- a/runelite-api/src/main/java/net/runelite/api/events/PlayerMenuOptionsChanged.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/PlayerMenuOptionsChanged.java
@@ -29,6 +29,13 @@ import lombok.Data;
 @Data
 public class PlayerMenuOptionsChanged
 {
+	public static final PlayerMenuOptionsChanged INSTANCE = new PlayerMenuOptionsChanged();
+
+	private PlayerMenuOptionsChanged()
+	{
+		// noop
+	}
+
 	/**
 	 * Index in playerOptions which changed.
 	 */

--- a/runelite-api/src/main/java/net/runelite/api/events/PlayerSpawned.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/PlayerSpawned.java
@@ -24,20 +24,27 @@
  */
 package net.runelite.api.events;
 
-import lombok.Value;
+import lombok.Data;
 import net.runelite.api.Actor;
 import net.runelite.api.Player;
 
 /**
  * An event where a {@link Player} has spawned.
  */
-@Value
+@Data
 public class PlayerSpawned
 {
+	public static final PlayerSpawned INSTANCE = new PlayerSpawned();
+
+	private PlayerSpawned()
+	{
+		// noop
+	}
+
 	/**
 	 * The spawned player.
 	 */
-	private final Player player;
+	private Player player;
 
 	public Actor getActor()
 	{

--- a/runelite-api/src/main/java/net/runelite/api/events/PostItemComposition.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/PostItemComposition.java
@@ -34,6 +34,13 @@ import net.runelite.api.ItemComposition;
 @Data
 public class PostItemComposition
 {
+	public static final PostItemComposition INSTANCE = new PostItemComposition();
+
+	private PostItemComposition()
+	{
+		// noop
+	}
+
 	/**
 	 * The newly created item.
 	 */

--- a/runelite-api/src/main/java/net/runelite/api/events/ProjectileMoved.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/ProjectileMoved.java
@@ -37,6 +37,13 @@ import net.runelite.api.coords.LocalPoint;
 @Data
 public class ProjectileMoved
 {
+	public static final ProjectileMoved INSTANCE = new ProjectileMoved();
+
+	private ProjectileMoved()
+	{
+		// noop
+	}
+
 	/**
 	 * The projectile being moved.
 	 */

--- a/runelite-api/src/main/java/net/runelite/api/events/RemovedFriend.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/RemovedFriend.java
@@ -24,16 +24,23 @@
  */
 package net.runelite.api.events;
 
-import lombok.Value;
+import lombok.Data;
 
 /**
  * An event where a request to remove a friend is sent to the server.
  */
-@Value
+@Data
 public class RemovedFriend
 {
+	public static final RemovedFriend INSTANCE = new RemovedFriend();
+
+	private RemovedFriend()
+	{
+		// noop
+	}
+
 	/**
 	 * The name of the removed friend.
 	 */
-	private final String name;
+	private String name;
 }

--- a/runelite-api/src/main/java/net/runelite/api/events/ResizeableChanged.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/ResizeableChanged.java
@@ -34,6 +34,13 @@ import lombok.Data;
 @Data
 public class ResizeableChanged
 {
+	public static final ResizeableChanged INSTANCE = new ResizeableChanged();
+
+	private ResizeableChanged()
+	{
+		// noop
+	}
+
 	/**
 	 * Whether the game is in resizable mode.
 	 */

--- a/runelite-api/src/main/java/net/runelite/api/events/ScriptCallbackEvent.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/ScriptCallbackEvent.java
@@ -33,6 +33,13 @@ import net.runelite.api.Script;
 @Data
 public class ScriptCallbackEvent
 {
+	public static final ScriptCallbackEvent INSTANCE = new ScriptCallbackEvent();
+
+	private ScriptCallbackEvent()
+	{
+		// noop
+	}
+
 	/**
 	 * The script being called.
 	 */

--- a/runelite-api/src/main/java/net/runelite/api/events/SessionClose.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/SessionClose.java
@@ -24,8 +24,6 @@
  */
 package net.runelite.api.events;
 
-import lombok.Data;
-
 /**
  * An event where a new RuneLite account session has been closed,
  * typically when logging out of the account.
@@ -33,8 +31,13 @@ import lombok.Data;
  * Note: This event is not to be confused with a RuneScape session,
  * it has nothing to do with whether an account is being logged out.
  */
-@Data
 public class SessionClose
 {
+	public static final SessionClose INSTANCE = new SessionClose();
+
+	private SessionClose()
+	{
+		// noop
+	}
 
 }

--- a/runelite-api/src/main/java/net/runelite/api/events/SessionOpen.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/SessionOpen.java
@@ -24,8 +24,6 @@
  */
 package net.runelite.api.events;
 
-import lombok.Data;
-
 /**
  * An event where a new RuneLite account session has been opened
  * with the server.
@@ -33,8 +31,13 @@ import lombok.Data;
  * Note: This event is not to be confused with a RuneScape session,
  * it has nothing to do with whether an account is being logged in.
  */
-@Data
 public class SessionOpen
 {
+	public static final SessionOpen INSTANCE = new SessionOpen();
+
+	private SessionOpen()
+	{
+		// noop
+	}
 
 }

--- a/runelite-api/src/main/java/net/runelite/api/events/SetMessage.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/SetMessage.java
@@ -16,6 +16,13 @@ import net.runelite.api.MessageNode;
 @Data
 public class SetMessage
 {
+	public static final SetMessage INSTANCE = new SetMessage();
+
+	private SetMessage()
+	{
+		// noop
+	}
+
 	/**
 	 * The updated message node.
 	 */

--- a/runelite-api/src/main/java/net/runelite/api/events/UsernameChanged.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/UsernameChanged.java
@@ -32,4 +32,11 @@ package net.runelite.api.events;
  */
 public class UsernameChanged
 {
+	public static final UsernameChanged INSTANCE = new UsernameChanged();
+
+	private UsernameChanged()
+	{
+		// noop
+	}
+
 }

--- a/runelite-api/src/main/java/net/runelite/api/events/VarClientIntChanged.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/VarClientIntChanged.java
@@ -25,13 +25,20 @@
  */
 package net.runelite.api.events;
 
-import lombok.Value;
+import lombok.Data;
 
 /**
  * An event where a varbit integer has changed.
  */
-@Value
+@Data
 public class VarClientIntChanged
 {
+	public static final VarClientIntChanged INSTANCE = new VarClientIntChanged();
+
+	private VarClientIntChanged()
+	{
+		// noop
+	}
+
 	private int index;
 }

--- a/runelite-api/src/main/java/net/runelite/api/events/VarClientStrChanged.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/VarClientStrChanged.java
@@ -25,13 +25,20 @@
  */
 package net.runelite.api.events;
 
-import lombok.Value;
+import lombok.Data;
 
 /**
  * An event where a varbit string has changed.
  */
-@Value
+@Data
 public class VarClientStrChanged
 {
+	public static final VarClientStrChanged INSTANCE = new VarClientStrChanged();
+
+	private VarClientStrChanged()
+	{
+		// noop
+	}
+
 	private int index;
 }

--- a/runelite-api/src/main/java/net/runelite/api/events/VarbitChanged.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/VarbitChanged.java
@@ -26,12 +26,16 @@
 
 package net.runelite.api.events;
 
-import lombok.Data;
-
 /**
  * An event where a varbit has changed.
  */
-@Data
 public class VarbitChanged
 {
+	public static final VarbitChanged INSTANCE = new VarbitChanged();
+
+	private VarbitChanged()
+	{
+		// noop
+	}
+
 }

--- a/runelite-api/src/main/java/net/runelite/api/events/WallObjectChanged.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/WallObjectChanged.java
@@ -34,6 +34,13 @@ import net.runelite.api.WallObject;
 @Data
 public class WallObjectChanged
 {
+	public static final WallObjectChanged INSTANCE = new WallObjectChanged();
+
+	private WallObjectChanged()
+	{
+		// noop
+	}
+
 	/**
 	 * The affected tile.
 	 */

--- a/runelite-api/src/main/java/net/runelite/api/events/WallObjectDespawned.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/WallObjectDespawned.java
@@ -34,6 +34,13 @@ import net.runelite.api.WallObject;
 @Data
 public class WallObjectDespawned
 {
+	public static final WallObjectDespawned INSTANCE = new WallObjectDespawned();
+
+	private WallObjectDespawned()
+	{
+		// noop
+	}
+
 	/**
 	 * The affected tile.
 	 */

--- a/runelite-api/src/main/java/net/runelite/api/events/WallObjectSpawned.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/WallObjectSpawned.java
@@ -34,6 +34,13 @@ import net.runelite.api.WallObject;
 @Data
 public class WallObjectSpawned
 {
+	public static final WallObjectSpawned INSTANCE = new WallObjectSpawned();
+
+	private WallObjectSpawned()
+	{
+		// noop
+	}
+
 	/**
 	 * The affected tile.
 	 */

--- a/runelite-api/src/main/java/net/runelite/api/events/WidgetHiddenChanged.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/WidgetHiddenChanged.java
@@ -33,6 +33,13 @@ import net.runelite.api.widgets.Widget;
 @Data
 public class WidgetHiddenChanged
 {
+	public static final WidgetHiddenChanged INSTANCE = new WidgetHiddenChanged();
+
+	private WidgetHiddenChanged()
+	{
+		// noop
+	}
+
 	/**
 	 * The affected widget.
 	 */

--- a/runelite-api/src/main/java/net/runelite/api/events/WidgetLoaded.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/WidgetLoaded.java
@@ -32,6 +32,13 @@ import lombok.Data;
 @Data
 public class WidgetLoaded
 {
+	public static final WidgetLoaded INSTANCE = new WidgetLoaded();
+
+	private WidgetLoaded()
+	{
+		// noop
+	}
+
 	/**
 	 * The group ID of the loaded widget.
 	 */

--- a/runelite-api/src/main/java/net/runelite/api/events/WidgetMenuOptionClicked.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/WidgetMenuOptionClicked.java
@@ -33,6 +33,13 @@ import net.runelite.api.widgets.WidgetInfo;
 @Data
 public class WidgetMenuOptionClicked
 {
+	public static final WidgetMenuOptionClicked INSTANCE = new WidgetMenuOptionClicked();
+
+	private WidgetMenuOptionClicked()
+	{
+		// noop
+	}
+
 	/**
 	 * The clicked menu option.
 	 */

--- a/runelite-api/src/main/java/net/runelite/api/events/WidgetPositioned.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/WidgetPositioned.java
@@ -24,13 +24,17 @@
  */
 package net.runelite.api.events;
 
-import lombok.Value;
-
 /**
  * An event where the position of a {@link net.runelite.api.widgets.Widget}
  * relative to its parent has changed.
  */
-@Value
 public class WidgetPositioned
 {
+	public static final WidgetPositioned INSTANCE = new WidgetPositioned();
+
+	private WidgetPositioned()
+	{
+		// noop
+	}
+
 }

--- a/runelite-api/src/main/java/net/runelite/api/events/WorldListLoad.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/WorldListLoad.java
@@ -24,14 +24,21 @@
  */
 package net.runelite.api.events;
 
-import lombok.Value;
+import lombok.Data;
 import net.runelite.api.World;
 
 /**
  * Event when the world list is loaded for the world switcher
  */
-@Value
+@Data
 public class WorldListLoad
 {
-	private final World[] worlds;
+	public static final WorldListLoad INSTANCE = new WorldListLoad();
+
+	private WorldListLoad()
+	{
+		// noop
+	}
+
+	private World[] worlds;
 }

--- a/runelite-client/src/main/java/net/runelite/client/account/SessionManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/account/SessionManager.java
@@ -160,7 +160,7 @@ public class SessionManager
 			configManager.switchSession(session);
 		}
 
-		eventBus.post(new SessionOpen());
+		eventBus.post(SessionOpen.INSTANCE);
 	}
 
 	private void closeSession()
@@ -193,7 +193,7 @@ public class SessionManager
 		// Restore config
 		configManager.switchSession(null);
 
-		eventBus.post(new SessionClose());
+		eventBus.post(SessionClose.INSTANCE);
 	}
 
 	public void login()

--- a/runelite-client/src/main/java/net/runelite/client/callback/Hooks.java
+++ b/runelite-client/src/main/java/net/runelite/client/callback/Hooks.java
@@ -81,9 +81,6 @@ public class Hooks implements Callbacks
 	private static final Client client = injector.getInstance(Client.class);
 	private static final OverlayRenderer renderer = injector.getInstance(OverlayRenderer.class);
 
-	private static final GameTick GAME_TICK = new GameTick();
-	private static final BeforeRender BEFORE_RENDER = new BeforeRender();
-
 	@Inject
 	private EventBus eventBus;
 
@@ -145,13 +142,13 @@ public class Hooks implements Callbacks
 
 			deferredEventBus.replay();
 
-			eventBus.post(GAME_TICK);
+			eventBus.post(GameTick.INSTANCE);
 
 			int tick = client.getTickCount();
 			client.setTickCount(tick + 1);
 		}
 
-		eventBus.post(BEFORE_RENDER);
+		eventBus.post(BeforeRender.INSTANCE);
 
 		clientThread.invoke();
 

--- a/runelite-client/src/main/java/net/runelite/client/chat/CommandManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/chat/CommandManager.java
@@ -114,7 +114,9 @@ public class CommandManager
 		String command = split[0];
 		String[] args = Arrays.copyOfRange(split, 1, split.length);
 
-		CommandExecuted commandExecuted = new CommandExecuted(command, args);
+		CommandExecuted commandExecuted = CommandExecuted.INSTANCE;
+		commandExecuted.setCommand(command);
+		commandExecuted.setArguments(args);
 		eventBus.post(commandExecuted);
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/menus/MenuManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/menus/MenuManager.java
@@ -280,7 +280,7 @@ public class MenuManager
 			if (curMenuOption.getMenuTarget().equals(event.getMenuTarget())
 				&& curMenuOption.getMenuOption().equals(event.getMenuOption()))
 			{
-				WidgetMenuOptionClicked customMenu = new WidgetMenuOptionClicked();
+				WidgetMenuOptionClicked customMenu = WidgetMenuOptionClicked.INSTANCE;
 				customMenu.setMenuOption(event.getMenuOption());
 				customMenu.setMenuTarget(event.getMenuTarget());
 				customMenu.setWidget(curMenuOption.getWidget());
@@ -295,7 +295,7 @@ public class MenuManager
 		// <col=ffffff>username<col=40ff00>  (level-42) or <col=ffffff><img=2>username</col>
 		String username = Text.removeTags(target).split("[(]")[0].trim();
 
-		PlayerMenuOptionClicked playerMenuOptionClicked = new PlayerMenuOptionClicked();
+		PlayerMenuOptionClicked playerMenuOptionClicked = PlayerMenuOptionClicked.INSTANCE;
 		playerMenuOptionClicked.setMenuOption(event.getMenuOption());
 		playerMenuOptionClicked.setMenuTarget(username);
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/devtools/DevToolsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/devtools/DevToolsPlugin.java
@@ -238,7 +238,7 @@ public class DevToolsPlugin extends Plugin
 				int value = Integer.parseInt(args[1]);
 				client.setVarpValue(client.getVarps(), varp, value);
 				client.addChatMessage(ChatMessageType.SERVER, "", "Set VarPlayer " + varp + " to " + value, null);
-				eventBus.post(new VarbitChanged()); // fake event
+				eventBus.post(VarbitChanged.INSTANCE); // fake event
 				break;
 			}
 			case "getvarb":
@@ -254,7 +254,7 @@ public class DevToolsPlugin extends Plugin
 				int value = Integer.parseInt(args[1]);
 				client.setVarbitValue(client.getVarps(), varbit, value);
 				client.addChatMessage(ChatMessageType.SERVER, "", "Set varbit " + varbit + " to " + value, null);
-				eventBus.post(new VarbitChanged()); // fake event
+				eventBus.post(VarbitChanged.INSTANCE); // fake event
 				break;
 			}
 			case "addxp":
@@ -271,7 +271,7 @@ public class DevToolsPlugin extends Plugin
 
 				client.queueChangedSkill(skill);
 
-				ExperienceChanged experienceChanged = new ExperienceChanged();
+				ExperienceChanged experienceChanged = ExperienceChanged.INSTANCE;
 				experienceChanged.setSkill(skill);
 				eventBus.post(experienceChanged);
 				break;

--- a/runelite-client/src/main/java/net/runelite/client/util/GameEventManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/util/GameEventManager.java
@@ -118,7 +118,9 @@ public class GameEventManager
 
 				if (itemContainer != null)
 				{
-					eventBus.post(new ItemContainerChanged(itemContainer));
+					ItemContainerChanged event = ItemContainerChanged.INSTANCE;
+					event.setItemContainer(itemContainer);
+					eventBus.post(event);
 				}
 			}
 
@@ -126,7 +128,8 @@ public class GameEventManager
 			{
 				if (npc != null)
 				{
-					final NpcSpawned npcSpawned = new NpcSpawned(npc);
+					final NpcSpawned npcSpawned = NpcSpawned.INSTANCE;
+					npcSpawned.setNpc(npc);
 					eventBus.post(npcSpawned);
 				}
 			}
@@ -135,7 +138,8 @@ public class GameEventManager
 			{
 				if (player != null)
 				{
-					final PlayerSpawned playerSpawned = new PlayerSpawned(player);
+					final PlayerSpawned playerSpawned = PlayerSpawned.INSTANCE;
+					playerSpawned.setPlayer(player);
 					eventBus.post(playerSpawned);
 				}
 			}
@@ -144,7 +148,7 @@ public class GameEventManager
 			{
 				Optional.ofNullable(tile.getWallObject()).ifPresent(object ->
 				{
-					final WallObjectSpawned objectSpawned = new WallObjectSpawned();
+					final WallObjectSpawned objectSpawned = WallObjectSpawned.INSTANCE;
 					objectSpawned.setTile(tile);
 					objectSpawned.setWallObject(object);
 					eventBus.post(objectSpawned);
@@ -152,7 +156,7 @@ public class GameEventManager
 
 				Optional.ofNullable(tile.getDecorativeObject()).ifPresent(object ->
 				{
-					final DecorativeObjectSpawned objectSpawned = new DecorativeObjectSpawned();
+					final DecorativeObjectSpawned objectSpawned = DecorativeObjectSpawned.INSTANCE;
 					objectSpawned.setTile(tile);
 					objectSpawned.setDecorativeObject(object);
 					eventBus.post(objectSpawned);
@@ -160,7 +164,7 @@ public class GameEventManager
 
 				Optional.ofNullable(tile.getGroundObject()).ifPresent(object ->
 				{
-					final GroundObjectSpawned objectSpawned = new GroundObjectSpawned();
+					final GroundObjectSpawned objectSpawned = GroundObjectSpawned.INSTANCE;
 					objectSpawned.setTile(tile);
 					objectSpawned.setGroundObject(object);
 					eventBus.post(objectSpawned);
@@ -170,7 +174,7 @@ public class GameEventManager
 					.filter(Objects::nonNull)
 					.forEach(object ->
 					{
-						final GameObjectSpawned objectSpawned = new GameObjectSpawned();
+						final GameObjectSpawned objectSpawned = GameObjectSpawned.INSTANCE;
 						objectSpawned.setTile(tile);
 						objectSpawned.setGameObject(object);
 						eventBus.post(objectSpawned);
@@ -186,7 +190,9 @@ public class GameEventManager
 
 						current = current.getNext();
 
-						final ItemSpawned itemSpawned = new ItemSpawned(tile, item);
+						final ItemSpawned itemSpawned = ItemSpawned.INSTANCE;
+						itemSpawned.setItem(item);
+						itemSpawned.setTile(tile);
 						eventBus.post(itemSpawned);
 					}
 				});

--- a/runelite-client/src/test/java/net/runelite/client/plugins/attackstyles/AttackStylesPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/attackstyles/AttackStylesPluginTest.java
@@ -93,14 +93,14 @@ public class AttackStylesPluginTest
 		when(client.getVar(VarPlayer.ATTACK_STYLE)).thenReturn(AttackStyle.ACCURATE.ordinal());
 
 		// verify that earning xp in a warned skill will display red text on the widget
-		attackPlugin.onVarbitChanged(new VarbitChanged());
+		attackPlugin.onVarbitChanged(VarbitChanged.INSTANCE);
 		assertTrue(attackPlugin.isWarnedSkillSelected());
 
 		// Switch to attack style that doesn't give attack xp
 		when(client.getVar(VarPlayer.ATTACK_STYLE)).thenReturn(AttackStyle.AGGRESSIVE.ordinal());
 
 		// Verify the widget will now display white text
-		attackPlugin.onVarbitChanged(new VarbitChanged());
+		attackPlugin.onVarbitChanged(VarbitChanged.INSTANCE);
 		warnedSkills = attackPlugin.getWarnedSkills();
 		assertTrue(warnedSkills.contains(Skill.ATTACK));
 		assertFalse(attackPlugin.isWarnedSkillSelected());
@@ -129,7 +129,7 @@ public class AttackStylesPluginTest
 
 		// equip type_4 weapon type on player
 		when(client.getVar(Varbits.EQUIPPED_WEAPON_TYPE)).thenReturn(WeaponType.TYPE_4.ordinal());
-		attackPlugin.onVarbitChanged(new VarbitChanged());
+		attackPlugin.onVarbitChanged(VarbitChanged.INSTANCE);
 
 		// Verify there is a warned skill
 		Set<Skill> warnedSkills = attackPlugin.getWarnedSkills();

--- a/runelite-client/src/test/java/net/runelite/client/plugins/cerberus/CerberusPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/cerberus/CerberusPluginTest.java
@@ -71,7 +71,7 @@ public class CerberusPluginTest
 			mockNpc(new LocalPoint(2, 5)),
 			mockNpc(new LocalPoint(1, 5))
 		));
-		cerberusPlugin.onGameTick(new GameTick());
+		cerberusPlugin.onGameTick(GameTick.INSTANCE);
 
 		// Expected sort is by lowest y first, then by lowest x
 		assertEquals(ghosts.get(0).getLocalLocation(), new LocalPoint(0, 0));

--- a/runelite-client/src/test/java/net/runelite/client/plugins/chatnotifications/ChatNotificationsPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/chatnotifications/ChatNotificationsPluginTest.java
@@ -83,7 +83,7 @@ public class ChatNotificationsPluginTest
 		MessageNode messageNode = mock(MessageNode.class);
 		when(messageNode.getValue()).thenReturn("Deathbeam, Deathbeam OSRS");
 
-		SetMessage setMessage = new SetMessage();
+		SetMessage setMessage = SetMessage.INSTANCE;
 		setMessage.setType(ChatMessageType.PUBLIC);
 		setMessage.setMessageNode(messageNode);
 

--- a/runelite-client/src/test/java/net/runelite/client/plugins/examine/ExaminePluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/examine/ExaminePluginTest.java
@@ -88,7 +88,7 @@ public class ExaminePluginTest
 	{
 		when(client.getWidget(anyInt(), anyInt())).thenReturn(mock(Widget.class));
 
-		MenuOptionClicked menuOptionClicked = new MenuOptionClicked();
+		MenuOptionClicked menuOptionClicked = MenuOptionClicked.INSTANCE;
 		menuOptionClicked.setMenuOption("Examine");
 		menuOptionClicked.setMenuAction(MenuAction.EXAMINE_ITEM);
 		menuOptionClicked.setId(ItemID.ABYSSAL_WHIP);
@@ -106,7 +106,7 @@ public class ExaminePluginTest
 	{
 		when(client.getWidget(anyInt(), anyInt())).thenReturn(mock(Widget.class));
 
-		MenuOptionClicked menuOptionClicked = new MenuOptionClicked();
+		MenuOptionClicked menuOptionClicked = MenuOptionClicked.INSTANCE;
 		menuOptionClicked.setMenuOption("Examine");
 		menuOptionClicked.setMenuAction(MenuAction.EXAMINE_ITEM);
 		menuOptionClicked.setId(ItemID.ABYSSAL_WHIP);

--- a/runelite-client/src/test/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPluginTest.java
@@ -124,13 +124,13 @@ public class IdleNotifierPluginTest
 	public void checkAnimationIdle()
 	{
 		when(player.getAnimation()).thenReturn(AnimationID.WOODCUTTING_BRONZE);
-		AnimationChanged animationChanged = new AnimationChanged();
+		AnimationChanged animationChanged = AnimationChanged.INSTANCE;
 		animationChanged.setActor(player);
 		plugin.onAnimationChanged(animationChanged);
-		plugin.onGameTick(new GameTick());
+		plugin.onGameTick(GameTick.INSTANCE);
 		when(player.getAnimation()).thenReturn(AnimationID.IDLE);
 		plugin.onAnimationChanged(animationChanged);
-		plugin.onGameTick(new GameTick());
+		plugin.onGameTick(GameTick.INSTANCE);
 		verify(notifier).notify("[" + PLAYER_NAME + "] is now idle!");
 	}
 
@@ -138,16 +138,16 @@ public class IdleNotifierPluginTest
 	public void checkAnimationReset()
 	{
 		when(player.getAnimation()).thenReturn(AnimationID.WOODCUTTING_BRONZE);
-		AnimationChanged animationChanged = new AnimationChanged();
+		AnimationChanged animationChanged = AnimationChanged.INSTANCE;
 		animationChanged.setActor(player);
 		plugin.onAnimationChanged(animationChanged);
-		plugin.onGameTick(new GameTick());
+		plugin.onGameTick(GameTick.INSTANCE);
 		when(player.getAnimation()).thenReturn(AnimationID.LOOKING_INTO);
 		plugin.onAnimationChanged(animationChanged);
-		plugin.onGameTick(new GameTick());
+		plugin.onGameTick(GameTick.INSTANCE);
 		when(player.getAnimation()).thenReturn(AnimationID.IDLE);
 		plugin.onAnimationChanged(animationChanged);
-		plugin.onGameTick(new GameTick());
+		plugin.onGameTick(GameTick.INSTANCE);
 		verify(notifier, times(0)).notify(any());
 	}
 
@@ -155,14 +155,14 @@ public class IdleNotifierPluginTest
 	public void checkAnimationLogout()
 	{
 		when(player.getAnimation()).thenReturn(AnimationID.WOODCUTTING_BRONZE);
-		AnimationChanged animationChanged = new AnimationChanged();
+		AnimationChanged animationChanged = AnimationChanged.INSTANCE;
 		animationChanged.setActor(player);
 		plugin.onAnimationChanged(animationChanged);
-		plugin.onGameTick(new GameTick());
+		plugin.onGameTick(GameTick.INSTANCE);
 
 		// Logout
 		when(client.getGameState()).thenReturn(GameState.LOGIN_SCREEN);
-		GameStateChanged gameStateChanged = new GameStateChanged();
+		GameStateChanged gameStateChanged = GameStateChanged.INSTANCE;
 		gameStateChanged.setGameState(GameState.LOGIN_SCREEN);
 		plugin.onGameStateChanged(gameStateChanged);
 
@@ -174,7 +174,7 @@ public class IdleNotifierPluginTest
 		// Tick
 		when(player.getAnimation()).thenReturn(AnimationID.IDLE);
 		plugin.onAnimationChanged(animationChanged);
-		plugin.onGameTick(new GameTick());
+		plugin.onGameTick(GameTick.INSTANCE);
 		verify(notifier, times(0)).notify(any());
 	}
 
@@ -182,11 +182,15 @@ public class IdleNotifierPluginTest
 	public void checkCombatIdle()
 	{
 		when(player.getInteracting()).thenReturn(monster);
-		plugin.onInteractingChanged(new InteractingChanged(player, monster));
-		plugin.onGameTick(new GameTick());
+		InteractingChanged interactingChanged = InteractingChanged.INSTANCE;
+		interactingChanged.setSource(player);
+		interactingChanged.setTarget(monster);
+		plugin.onInteractingChanged(interactingChanged);
+		plugin.onGameTick(GameTick.INSTANCE);
 		when(player.getInteracting()).thenReturn(null);
-		plugin.onInteractingChanged(new InteractingChanged(player, null));
-		plugin.onGameTick(new GameTick());
+		interactingChanged.setTarget(null);
+		plugin.onInteractingChanged(interactingChanged);
+		plugin.onGameTick(GameTick.INSTANCE);
 		verify(notifier).notify("[" + PLAYER_NAME + "] is now out of combat!");
 	}
 
@@ -194,27 +198,35 @@ public class IdleNotifierPluginTest
 	public void checkCombatReset()
 	{
 		when(player.getInteracting()).thenReturn(monster);
-		plugin.onInteractingChanged(new InteractingChanged(player, monster));
-		plugin.onGameTick(new GameTick());
+		InteractingChanged interactingChanged = InteractingChanged.INSTANCE;
+		interactingChanged.setSource(player);
+		interactingChanged.setTarget(monster);
+		plugin.onInteractingChanged(interactingChanged);
+		plugin.onGameTick(GameTick.INSTANCE);
 		when(player.getInteracting()).thenReturn(randomEvent);
-		plugin.onInteractingChanged(new InteractingChanged(player, randomEvent));
-		plugin.onGameTick(new GameTick());
+		interactingChanged.setTarget(randomEvent);
+		plugin.onInteractingChanged(interactingChanged);
+		plugin.onGameTick(GameTick.INSTANCE);
 		when(player.getInteracting()).thenReturn(null);
-		plugin.onInteractingChanged(new InteractingChanged(player, null));
-		plugin.onGameTick(new GameTick());
+		interactingChanged.setTarget(null);
+		plugin.onInteractingChanged(interactingChanged);
+		plugin.onGameTick(GameTick.INSTANCE);
 		verify(notifier, times(0)).notify(any());
 	}
 
 	@Test
 	public void checkCombatLogout()
 	{
-		plugin.onInteractingChanged(new InteractingChanged(player, monster));
+		InteractingChanged interactingChanged = InteractingChanged.INSTANCE;
+		interactingChanged.setSource(player);
+		interactingChanged.setTarget(monster);
+		plugin.onInteractingChanged(interactingChanged);
 		when(player.getInteracting()).thenReturn(monster);
-		plugin.onGameTick(new GameTick());
+		plugin.onGameTick(GameTick.INSTANCE);
 
 		// Logout
 		when(client.getGameState()).thenReturn(GameState.LOGIN_SCREEN);
-		GameStateChanged gameStateChanged = new GameStateChanged();
+		GameStateChanged gameStateChanged = GameStateChanged.INSTANCE;
 		gameStateChanged.setGameState(GameState.LOGIN_SCREEN);
 		plugin.onGameStateChanged(gameStateChanged);
 
@@ -225,8 +237,9 @@ public class IdleNotifierPluginTest
 
 		// Tick
 		when(player.getInteracting()).thenReturn(null);
-		plugin.onInteractingChanged(new InteractingChanged(player, null));
-		plugin.onGameTick(new GameTick());
+		interactingChanged.setTarget(null);
+		plugin.onInteractingChanged(interactingChanged);
+		plugin.onGameTick(GameTick.INSTANCE);
 		verify(notifier, times(0)).notify(any());
 	}
 
@@ -237,11 +250,11 @@ public class IdleNotifierPluginTest
 		when(client.getMouseIdleTicks()).thenReturn(80_000);
 
 		// But player is being damaged (is in combat)
-		final HitsplatApplied hitsplatApplied = new HitsplatApplied();
+		final HitsplatApplied hitsplatApplied = HitsplatApplied.INSTANCE;
 		hitsplatApplied.setActor(player);
 		hitsplatApplied.setHitsplat(new Hitsplat(Hitsplat.HitsplatType.DAMAGE, 0, 0));
 		plugin.onHitsplatApplied(hitsplatApplied);
-		plugin.onGameTick(new GameTick());
+		plugin.onGameTick(GameTick.INSTANCE);
 		verify(notifier, times(0)).notify(any());
 	}
 
@@ -254,8 +267,8 @@ public class IdleNotifierPluginTest
 		when(client.getKeyboardIdleTicks()).thenReturn(80_000);
 		when(client.getMouseIdleTicks()).thenReturn(14_500);
 
-		plugin.onGameTick(new GameTick());
-		plugin.onGameTick(new GameTick());
+		plugin.onGameTick(GameTick.INSTANCE);
+		plugin.onGameTick(GameTick.INSTANCE);
 		verify(notifier, times(1)).notify(any());
 	}
 
@@ -265,11 +278,11 @@ public class IdleNotifierPluginTest
 		when(config.getSpecEnergyThreshold()).thenReturn(50);
 
 		when(client.getVar(Matchers.eq(VarPlayer.SPECIAL_ATTACK_PERCENT))).thenReturn(400); // 40%
-		plugin.onGameTick(new GameTick()); // once to set lastSpecEnergy to 400
+		plugin.onGameTick(GameTick.INSTANCE); // once to set lastSpecEnergy to 400
 		verify(notifier, never()).notify(any());
 
 		when(client.getVar(Matchers.eq(VarPlayer.SPECIAL_ATTACK_PERCENT))).thenReturn(500); // 50%
-		plugin.onGameTick(new GameTick());
+		plugin.onGameTick(GameTick.INSTANCE);
 		verify(notifier).notify(Matchers.eq("[" + PLAYER_NAME + "] has restored spec energy!"));
 	}
 }

--- a/runelite-client/src/test/java/net/runelite/client/plugins/screenshot/ScreenshotPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/screenshot/ScreenshotPluginTest.java
@@ -175,11 +175,11 @@ public class ScreenshotPluginTest
 
 		assertEquals("Hitpoints(99)", screenshotPlugin.parseLevelUpWidget(LEVEL_UP_LEVEL));
 
-		WidgetLoaded event = new WidgetLoaded();
+		WidgetLoaded event = WidgetLoaded.INSTANCE;
 		event.setGroupId(LEVEL_UP_GROUP_ID);
 		screenshotPlugin.onWidgetLoaded(event);
 
-		GameTick tick = new GameTick();
+		GameTick tick = GameTick.INSTANCE;
 		screenshotPlugin.onGameTick(tick);
 
 		verify(drawManager).requestNextFrameListener(Matchers.any(Consumer.class));
@@ -198,11 +198,11 @@ public class ScreenshotPluginTest
 
 		assertEquals("Firemaking(9)", screenshotPlugin.parseLevelUpWidget(LEVEL_UP_LEVEL));
 
-		WidgetLoaded event = new WidgetLoaded();
+		WidgetLoaded event = WidgetLoaded.INSTANCE;
 		event.setGroupId(LEVEL_UP_GROUP_ID);
 		screenshotPlugin.onWidgetLoaded(event);
 
-		GameTick tick = new GameTick();
+		GameTick tick = GameTick.INSTANCE;
 		screenshotPlugin.onGameTick(tick);
 
 		verify(drawManager).requestNextFrameListener(Matchers.any(Consumer.class));
@@ -221,11 +221,11 @@ public class ScreenshotPluginTest
 
 		assertEquals("Attack(70)", screenshotPlugin.parseLevelUpWidget(LEVEL_UP_LEVEL));
 
-		WidgetLoaded event = new WidgetLoaded();
+		WidgetLoaded event = WidgetLoaded.INSTANCE;
 		event.setGroupId(LEVEL_UP_GROUP_ID);
 		screenshotPlugin.onWidgetLoaded(event);
 
-		GameTick tick = new GameTick();
+		GameTick tick = GameTick.INSTANCE;
 		screenshotPlugin.onGameTick(tick);
 
 		verify(drawManager).requestNextFrameListener(Matchers.any(Consumer.class));
@@ -244,11 +244,11 @@ public class ScreenshotPluginTest
 
 		assertEquals("Hunter(2)", screenshotPlugin.parseLevelUpWidget(DIALOG_SPRITE_TEXT));
 
-		WidgetLoaded event = new WidgetLoaded();
+		WidgetLoaded event = WidgetLoaded.INSTANCE;
 		event.setGroupId(DIALOG_SPRITE_GROUP_ID);
 		screenshotPlugin.onWidgetLoaded(event);
 
-		GameTick tick = new GameTick();
+		GameTick tick = GameTick.INSTANCE;
 		screenshotPlugin.onGameTick(tick);
 
 		verify(drawManager).requestNextFrameListener(Matchers.any(Consumer.class));

--- a/runelite-client/src/test/java/net/runelite/client/plugins/slayer/SlayerPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/slayer/SlayerPluginTest.java
@@ -170,7 +170,7 @@ public class SlayerPluginTest
 		Widget npcDialog = mock(Widget.class);
 		when(npcDialog.getText()).thenReturn(TASK_NEW);
 		when(client.getWidget(WidgetInfo.DIALOG_NPC_TEXT)).thenReturn(npcDialog);
-		slayerPlugin.onGameTick(new GameTick());
+		slayerPlugin.onGameTick(GameTick.INSTANCE);
 
 		assertEquals("Suqahs", slayerPlugin.getTaskName());
 		assertEquals(231, slayerPlugin.getAmount());
@@ -182,7 +182,7 @@ public class SlayerPluginTest
 		Widget npcDialog = mock(Widget.class);
 		when(npcDialog.getText()).thenReturn(TASK_NEW_KONAR);
 		when(client.getWidget(WidgetInfo.DIALOG_NPC_TEXT)).thenReturn(npcDialog);
-		slayerPlugin.onGameTick(new GameTick());
+		slayerPlugin.onGameTick(GameTick.INSTANCE);
 
 		assertEquals("Wyrms", slayerPlugin.getTaskName());
 		assertEquals(147, slayerPlugin.getAmount());
@@ -195,7 +195,7 @@ public class SlayerPluginTest
 		Widget npcDialog = mock(Widget.class);
 		when(npcDialog.getText()).thenReturn(TASK_NEW_KONAR_2);
 		when(client.getWidget(WidgetInfo.DIALOG_NPC_TEXT)).thenReturn(npcDialog);
-		slayerPlugin.onGameTick(new GameTick());
+		slayerPlugin.onGameTick(GameTick.INSTANCE);
 
 		assertEquals("Hellhounds", slayerPlugin.getTaskName());
 		assertEquals(142, slayerPlugin.getAmount());
@@ -208,7 +208,7 @@ public class SlayerPluginTest
 		Widget npcDialog = mock(Widget.class);
 		when(npcDialog.getText()).thenReturn(TASK_NEW_FIRST);
 		when(client.getWidget(WidgetInfo.DIALOG_NPC_TEXT)).thenReturn(npcDialog);
-		slayerPlugin.onGameTick(new GameTick());
+		slayerPlugin.onGameTick(GameTick.INSTANCE);
 
 		assertEquals("goblins", slayerPlugin.getTaskName());
 		assertEquals(17, slayerPlugin.getAmount());
@@ -220,7 +220,7 @@ public class SlayerPluginTest
 		Widget npcDialog = mock(Widget.class);
 		when(npcDialog.getText()).thenReturn(TASK_NEW_NPC_CONTACT);
 		when(client.getWidget(WidgetInfo.DIALOG_NPC_TEXT)).thenReturn(npcDialog);
-		slayerPlugin.onGameTick(new GameTick());
+		slayerPlugin.onGameTick(GameTick.INSTANCE);
 
 		assertEquals("Suqahs", slayerPlugin.getTaskName());
 		assertEquals(211, slayerPlugin.getAmount());
@@ -232,7 +232,7 @@ public class SlayerPluginTest
 		Widget npcDialog = mock(Widget.class);
 		when(npcDialog.getText()).thenReturn(TASK_BOSS_NEW);
 		when(client.getWidget(WidgetInfo.DIALOG_NPC_TEXT)).thenReturn(npcDialog);
-		slayerPlugin.onGameTick(new GameTick());
+		slayerPlugin.onGameTick(GameTick.INSTANCE);
 
 		assertEquals("Vet'ion", slayerPlugin.getTaskName());
 		assertEquals(3, slayerPlugin.getAmount());
@@ -245,7 +245,7 @@ public class SlayerPluginTest
 		Widget npcDialog = mock(Widget.class);
 		when(npcDialog.getText()).thenReturn(TASK_BOSS_NEW_THE);
 		when(client.getWidget(WidgetInfo.DIALOG_NPC_TEXT)).thenReturn(npcDialog);
-		slayerPlugin.onGameTick(new GameTick());
+		slayerPlugin.onGameTick(GameTick.INSTANCE);
 
 		assertEquals("Chaos Elemental", slayerPlugin.getTaskName());
 		assertEquals(3, slayerPlugin.getAmount());
@@ -298,7 +298,7 @@ public class SlayerPluginTest
 		Widget npcDialog = mock(Widget.class);
 		when(npcDialog.getText()).thenReturn(TASK_EXISTING);
 		when(client.getWidget(WidgetInfo.DIALOG_NPC_TEXT)).thenReturn(npcDialog);
-		slayerPlugin.onGameTick(new GameTick());
+		slayerPlugin.onGameTick(GameTick.INSTANCE);
 
 		assertEquals("suqahs", slayerPlugin.getTaskName());
 		assertEquals(222, slayerPlugin.getAmount());
@@ -314,7 +314,7 @@ public class SlayerPluginTest
 		when(rewardBar.getDynamicChildren()).thenReturn(rewardBarChildren);
 		when(rewardBarText.getText()).thenReturn(REWARD_POINTS);
 		when(client.getWidget(WidgetInfo.SLAYER_REWARDS_TOPBAR)).thenReturn(rewardBar);
-		slayerPlugin.onGameTick(new GameTick());
+		slayerPlugin.onGameTick(GameTick.INSTANCE);
 
 		assertEquals(17566, slayerPlugin.getPoints());
 	}
@@ -439,7 +439,7 @@ public class SlayerPluginTest
 		when(client.getWidget(WidgetInfo.DIALOG_SPRITE_TEXT)).thenReturn(braceletBreakWidget);
 
 		slayerPlugin.setSlaughterChargeCount(-1);
-		slayerPlugin.onGameTick(new GameTick());
+		slayerPlugin.onGameTick(GameTick.INSTANCE);
 		assertEquals(30, slayerPlugin.getSlaughterChargeCount());
 
 		chatMessageEvent = new ChatMessage(SERVER, "", BRACLET_SLAUGHTER_V2, null);
@@ -487,7 +487,7 @@ public class SlayerPluginTest
 		when(client.getWidget(WidgetInfo.DIALOG_SPRITE_TEXT)).thenReturn(braceletBreakWidget);
 
 		slayerPlugin.setExpeditiousChargeCount(-1);
-		slayerPlugin.onGameTick(new GameTick());
+		slayerPlugin.onGameTick(GameTick.INSTANCE);
 		assertEquals(30, slayerPlugin.getExpeditiousChargeCount());
 
 		chatMessageEvent = new ChatMessage(SERVER, "", BRACLET_EXPEDITIOUS_V2, null);
@@ -531,7 +531,7 @@ public class SlayerPluginTest
 		when(slayerConfig.taskCommand()).thenReturn(true);
 		when(chatClient.getTask(anyString())).thenReturn(task);
 
-		SetMessage setMessage = new SetMessage();
+		SetMessage setMessage = SetMessage.INSTANCE;
 		setMessage.setType(ChatMessageType.PUBLIC);
 		setMessage.setName("Adam");
 		setMessage.setMessageNode(mock(MessageNode.class));
@@ -553,7 +553,7 @@ public class SlayerPluginTest
 		when(slayerConfig.taskCommand()).thenReturn(true);
 		when(chatClient.getTask(anyString())).thenReturn(task);
 
-		SetMessage setMessage = new SetMessage();
+		SetMessage setMessage = SetMessage.INSTANCE;
 		setMessage.setType(ChatMessageType.PUBLIC);
 		setMessage.setName("Adam");
 		setMessage.setMessageNode(mock(MessageNode.class));

--- a/runelite-mixins/src/main/java/net/runelite/mixins/GraphicsObjectMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/GraphicsObjectMixin.java
@@ -41,7 +41,8 @@ public abstract class GraphicsObjectMixin implements RSGraphicsObject
 	@Inject
 	GraphicsObjectMixin()
 	{
-		final GraphicsObjectCreated event = new GraphicsObjectCreated(this);
+		final GraphicsObjectCreated event = GraphicsObjectCreated.INSTANCE;
+		event.setGraphicsObject(this);
 		client.getCallbacks().post(event);
 	}
 

--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSActorMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSActorMixin.java
@@ -186,7 +186,7 @@ public abstract class RSActorMixin implements RSActor
 	@Inject
 	public void animationChanged(int idx)
 	{
-		AnimationChanged animationChange = new AnimationChanged();
+		AnimationChanged animationChange = AnimationChanged.INSTANCE;
 		animationChange.setActor(this);
 		client.getCallbacks().post(animationChange);
 	}
@@ -195,7 +195,7 @@ public abstract class RSActorMixin implements RSActor
 	@Inject
 	public void graphicChanged(int idx)
 	{
-		GraphicChanged graphicChanged = new GraphicChanged();
+		GraphicChanged graphicChanged = GraphicChanged.INSTANCE;
 		graphicChanged.setActor(this);
 		client.getCallbacks().post(graphicChanged);
 	}
@@ -204,7 +204,9 @@ public abstract class RSActorMixin implements RSActor
 	@Inject
 	public void interactingChanged(int idx)
 	{
-		InteractingChanged interactingChanged = new InteractingChanged(this, getInteracting());
+		InteractingChanged interactingChanged = InteractingChanged.INSTANCE;
+		interactingChanged.setSource(this);
+		interactingChanged.setTarget(getInteracting());
 		client.getCallbacks().post(interactingChanged);
 	}
 
@@ -251,7 +253,7 @@ public abstract class RSActorMixin implements RSActor
 			{
 				client.getLogger().debug("You died!");
 
-				LocalPlayerDeath event = new LocalPlayerDeath();
+				LocalPlayerDeath event = LocalPlayerDeath.INSTANCE;
 				client.getCallbacks().post(event);
 			}
 			else if (this instanceof RSNPC)
@@ -278,7 +280,7 @@ public abstract class RSActorMixin implements RSActor
 	public void applyActorHitsplat(int type, int value, int var3, int var4, int gameCycle, int duration)
 	{
 		final Hitsplat hitsplat = new Hitsplat(Hitsplat.HitsplatType.fromInteger(type), value, gameCycle + duration);
-		final HitsplatApplied event = new HitsplatApplied();
+		final HitsplatApplied event = HitsplatApplied.INSTANCE;
 		event.setActor(this);
 		event.setHitsplat(hitsplat);
 		client.getCallbacks().post(event);

--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSClientMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSClientMixin.java
@@ -797,7 +797,7 @@ public abstract class RSClientMixin implements RSClient
 	@Inject
 	public static void draggingWidgetChanged(int idx)
 	{
-		DraggingWidgetChanged draggingWidgetChanged = new DraggingWidgetChanged();
+		DraggingWidgetChanged draggingWidgetChanged = DraggingWidgetChanged.INSTANCE;
 		draggingWidgetChanged.setDraggingWidget(client.isDraggingWidget());
 		client.getCallbacks().post(draggingWidgetChanged);
 	}
@@ -835,7 +835,7 @@ public abstract class RSClientMixin implements RSClient
 
 		if (loaded)
 		{
-			WidgetLoaded event = new WidgetLoaded();
+			WidgetLoaded event = WidgetLoaded.INSTANCE;
 			event.setGroupId(groupId);
 			client.getCallbacks().post(event);
 		}
@@ -867,7 +867,7 @@ public abstract class RSClientMixin implements RSClient
 	@Inject
 	public static void experiencedChanged(int idx)
 	{
-		ExperienceChanged experienceChanged = new ExperienceChanged();
+		ExperienceChanged experienceChanged = ExperienceChanged.INSTANCE;
 		Skill[] possibleSkills = Skill.values();
 
 		// We subtract one here because 'Overall' isn't considered a skill that's updated.
@@ -888,7 +888,7 @@ public abstract class RSClientMixin implements RSClient
 		if (idx >= 0 && idx < skills.length - 1)
 		{
 			Skill updatedSkill = skills[idx];
-			BoostedLevelChanged boostedLevelChanged = new BoostedLevelChanged();
+			BoostedLevelChanged boostedLevelChanged = BoostedLevelChanged.INSTANCE;
 			boostedLevelChanged.setSkill(updatedSkill);
 			client.getCallbacks().post(boostedLevelChanged);
 		}
@@ -907,7 +907,7 @@ public abstract class RSClientMixin implements RSClient
 			client.getPlayerMenuTypes()[idx] = playerAction.getId();
 		}
 
-		PlayerMenuOptionsChanged optionsChanged = new PlayerMenuOptionsChanged();
+		PlayerMenuOptionsChanged optionsChanged = PlayerMenuOptionsChanged.INSTANCE;
 		optionsChanged.setIndex(idx);
 		client.getCallbacks().post(optionsChanged);
 	}
@@ -916,7 +916,7 @@ public abstract class RSClientMixin implements RSClient
 	@Inject
 	public static void gameStateChanged(int idx)
 	{
-		GameStateChanged gameStateChange = new GameStateChanged();
+		GameStateChanged gameStateChange = GameStateChanged.INSTANCE;
 		gameStateChange.setGameState(client.getGameState());
 		client.getCallbacks().post(gameStateChange);
 	}
@@ -936,8 +936,9 @@ public abstract class RSClientMixin implements RSClient
 		if (npc != null)
 		{
 			npc.setIndex(idx);
-
-			client.getCallbacks().postDeferred(new NpcSpawned(npc));
+			NpcSpawned event = NpcSpawned.INSTANCE;
+			event.setNpc(npc);
+			client.getCallbacks().postDeferred(event);
 		}
 	}
 
@@ -957,11 +958,15 @@ public abstract class RSClientMixin implements RSClient
 
 		if (oldPlayer != null)
 		{
-			client.getCallbacks().post(new PlayerDespawned(oldPlayer));
+			PlayerDespawned event = PlayerDespawned.INSTANCE;
+			event.setPlayer(oldPlayer);
+			client.getCallbacks().post(oldPlayer);
 		}
 		if (player != null)
 		{
-			client.getCallbacks().postDeferred(new PlayerSpawned(player));
+			PlayerSpawned event = PlayerSpawned.INSTANCE;
+			event.setPlayer(player);
+			client.getCallbacks().postDeferred(event);
 		}
 	}
 
@@ -981,7 +986,7 @@ public abstract class RSClientMixin implements RSClient
 			return;
 		}
 
-		GrandExchangeOfferChanged offerChangedEvent = new GrandExchangeOfferChanged();
+		GrandExchangeOfferChanged offerChangedEvent = GrandExchangeOfferChanged.INSTANCE;
 		offerChangedEvent.setOffer(internalOffer);
 		offerChangedEvent.setSlot(idx);
 		client.getCallbacks().post(offerChangedEvent);
@@ -991,7 +996,7 @@ public abstract class RSClientMixin implements RSClient
 	@Inject
 	public static void settingsChanged(int idx)
 	{
-		VarbitChanged varbitChanged = new VarbitChanged();
+		VarbitChanged varbitChanged = VarbitChanged.INSTANCE;
 		client.getCallbacks().post(varbitChanged);
 	}
 
@@ -1004,7 +1009,7 @@ public abstract class RSClientMixin implements RSClient
 
 		if (oldIsResized != isResized)
 		{
-			ResizeableChanged resizeableChanged = new ResizeableChanged();
+			ResizeableChanged resizeableChanged = ResizeableChanged.INSTANCE;
 			resizeableChanged.setResized(isResized);
 			client.getCallbacks().post(resizeableChanged);
 
@@ -1016,7 +1021,9 @@ public abstract class RSClientMixin implements RSClient
 	@Inject
 	public static void clanMemberManagerChanged(int idx)
 	{
-		client.getCallbacks().post(new ClanChanged(client.getClanMemberManager() != null));
+		ClanChanged event = ClanChanged.INSTANCE;
+		event.setJoined(client.getClanMemberManager() != null);
+		client.getCallbacks().post(event);
 	}
 
 	@FieldHook("canvasWidth")
@@ -1169,7 +1176,7 @@ public abstract class RSClientMixin implements RSClient
 			menuAction -= 2000;
 		}
 
-		final MenuOptionClicked menuOptionClicked = new MenuOptionClicked();
+		final MenuOptionClicked menuOptionClicked = MenuOptionClicked.INSTANCE;
 		menuOptionClicked.setActionParam(actionParam);
 		menuOptionClicked.setMenuOption(menuOption);
 		menuOptionClicked.setMenuTarget(menuTarget);
@@ -1190,7 +1197,7 @@ public abstract class RSClientMixin implements RSClient
 	@Inject
 	public static void onUsernameChanged(int idx)
 	{
-		client.getCallbacks().post(new UsernameChanged());
+		client.getCallbacks().post(UsernameChanged.INSTANCE);
 	}
 
 	@Override
@@ -1219,7 +1226,7 @@ public abstract class RSClientMixin implements RSClient
 	@MethodHook("openMenu")
 	public void menuOpened(int var1, int var2)
 	{
-		final MenuOpened event = new MenuOpened();
+		final MenuOpened event = MenuOpened.INSTANCE;
 		event.setMenuEntries(getMenuEntries());
 		callbacks.post(event);
 	}
@@ -1404,6 +1411,6 @@ public abstract class RSClientMixin implements RSClient
 	@FieldHook("cycleCntr")
 	public static void onCycleCntrChanged(int idx)
 	{
-		client.getCallbacks().post(new ClientTick());
+		client.getCallbacks().post(ClientTick.INSTANCE);
 	}
 }

--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSFriendManagerMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSFriendManagerMixin.java
@@ -42,7 +42,8 @@ public abstract class RSFriendManagerMixin implements RSFriendManager
 	@Inject
 	public void rl$removeFriend(String friendName)
 	{
-		RemovedFriend removedFriend = new RemovedFriend(friendName);
+		RemovedFriend removedFriend = RemovedFriend.INSTANCE;
+		removedFriend.setName(friendName);
 		client.getCallbacks().post(removedFriend);
 	}
 }

--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSItemCompositionMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSItemCompositionMixin.java
@@ -85,7 +85,7 @@ public abstract class RSItemCompositionMixin implements RSItemComposition
 	@MethodHook(value = "post", end = true)
 	public void post()
 	{
-		final PostItemComposition event = new PostItemComposition();
+		final PostItemComposition event = PostItemComposition.INSTANCE;
 		event.setItemComposition(this);
 		client.getCallbacks().post(event);
 	}

--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSItemContainerMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSItemContainerMixin.java
@@ -75,7 +75,8 @@ public abstract class RSItemContainerMixin implements RSItemContainer
 
 		rl$lastCycle = cycle;
 
-		ItemContainerChanged event = new ItemContainerChanged(this);
+		ItemContainerChanged event = ItemContainerChanged.INSTANCE;
+		event.setItemContainer(this);
 		client.getCallbacks().postDeferred(event);
 	}
 

--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSItemMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSItemMixin.java
@@ -90,7 +90,11 @@ public abstract class RSItemMixin implements RSItem
 		{
 			client.getLogger().debug("Item quantity changed: {} ({} -> {})", getId(), getQuantity(), quantity);
 
-			ItemQuantityChanged itemQuantityChanged = new ItemQuantityChanged(this, getTile(), getQuantity(), quantity);
+			ItemQuantityChanged itemQuantityChanged = ItemQuantityChanged.INSTANCE;
+			itemQuantityChanged.setItem(this);
+			itemQuantityChanged.setTile(getTile());
+			itemQuantityChanged.setOldQuantity(getQuantity());
+			itemQuantityChanged.setNewQuantity(quantity);
 			client.getCallbacks().post(itemQuantityChanged);
 		}
 	}

--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSMessageNodeMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSMessageNodeMixin.java
@@ -50,7 +50,7 @@ public abstract class RSMessageNodeMixin implements RSMessageNode
 	{
 		rl$timestamp = (int) (System.currentTimeMillis() / 1000L);
 
-		final SetMessage setMessage = new SetMessage();
+		final SetMessage setMessage = SetMessage.INSTANCE;
 		setMessage.setMessageNode(this);
 		setMessage.setType(getType());
 		setMessage.setName(getName());
@@ -104,7 +104,7 @@ public abstract class RSMessageNodeMixin implements RSMessageNode
 		runeLiteFormatMessage = null;
 		rl$timestamp = (int) (System.currentTimeMillis() / 1000L);
 
-		final SetMessage setMessage = new SetMessage();
+		final SetMessage setMessage = SetMessage.INSTANCE;
 		setMessage.setMessageNode(this);
 		setMessage.setType(ChatMessageType.of(type));
 		setMessage.setName(name);

--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSNPCMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSNPCMixin.java
@@ -106,7 +106,9 @@ public abstract class RSNPCMixin implements RSNPC
 	{
 		if (composition == null)
 		{
-			client.getCallbacks().post(new NpcDespawned(this));
+			NpcDespawned event = NpcDespawned.INSTANCE;
+			event.setNpc(this);
+			client.getCallbacks().post(event);
 		}
 	}
 

--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSNameableMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSNameableMixin.java
@@ -42,7 +42,8 @@ public abstract class RSNameableMixin implements RSNameable
 	@Inject
 	public void onPrevNameChanged(int idx)
 	{
-		NameableNameChanged nameableNameChanged = new NameableNameChanged(this);
+		NameableNameChanged nameableNameChanged = NameableNameChanged.INSTANCE;
+		nameableNameChanged.setNameable(this);
 		client.getCallbacks().post(nameableNameChanged);
 	}
 }

--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSNpcCompositionMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSNpcCompositionMixin.java
@@ -66,7 +66,7 @@ public abstract class RSNpcCompositionMixin implements RSNPCComposition
 	@Inject
 	public void actionsHook(int idx)
 	{
-		NpcActionChanged npcActionChanged = new NpcActionChanged();
+		NpcActionChanged npcActionChanged = NpcActionChanged.INSTANCE;
 		npcActionChanged.setNpcComposition(this);
 		npcActionChanged.setIdx(idx);
 		client.getCallbacks().post(npcActionChanged);

--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSProjectileMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSProjectileMixin.java
@@ -96,7 +96,7 @@ public abstract class RSProjectileMixin implements RSProjectile
 	public void projectileMoved(int targetX, int targetY, int targetZ, int cycle)
 	{
 		final LocalPoint position = new LocalPoint(targetX, targetY);
-		final ProjectileMoved projectileMoved = new ProjectileMoved();
+		final ProjectileMoved projectileMoved = ProjectileMoved.INSTANCE;
 		projectileMoved.setProjectile(this);
 		projectileMoved.setPosition(position);
 		projectileMoved.setZ(targetZ);

--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSTileMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSTileMixin.java
@@ -123,21 +123,21 @@ public abstract class RSTileMixin implements RSTile
 
 		if (current == null && previous != null)
 		{
-			WallObjectDespawned wallObjectDespawned = new WallObjectDespawned();
+			WallObjectDespawned wallObjectDespawned = WallObjectDespawned.INSTANCE;
 			wallObjectDespawned.setTile(this);
 			wallObjectDespawned.setWallObject(previous);
 			client.getCallbacks().post(wallObjectDespawned);
 		}
 		else if (current != null && previous == null)
 		{
-			WallObjectSpawned wallObjectSpawned = new WallObjectSpawned();
+			WallObjectSpawned wallObjectSpawned = WallObjectSpawned.INSTANCE;
 			wallObjectSpawned.setTile(this);
 			wallObjectSpawned.setWallObject(current);
 			client.getCallbacks().post(wallObjectSpawned);
 		}
 		else if (current != null && previous != null)
 		{
-			WallObjectChanged wallObjectChanged = new WallObjectChanged();
+			WallObjectChanged wallObjectChanged = WallObjectChanged.INSTANCE;
 			wallObjectChanged.setTile(this);
 			wallObjectChanged.setPrevious(previous);
 			wallObjectChanged.setWallObject(current);
@@ -156,21 +156,21 @@ public abstract class RSTileMixin implements RSTile
 
 		if (current == null && previous != null)
 		{
-			DecorativeObjectDespawned decorativeObjectDespawned = new DecorativeObjectDespawned();
+			DecorativeObjectDespawned decorativeObjectDespawned = DecorativeObjectDespawned.INSTANCE;
 			decorativeObjectDespawned.setTile(this);
 			decorativeObjectDespawned.setDecorativeObject(previous);
 			client.getCallbacks().post(decorativeObjectDespawned);
 		}
 		else if (current != null && previous == null)
 		{
-			DecorativeObjectSpawned decorativeObjectSpawned = new DecorativeObjectSpawned();
+			DecorativeObjectSpawned decorativeObjectSpawned = DecorativeObjectSpawned.INSTANCE;
 			decorativeObjectSpawned.setTile(this);
 			decorativeObjectSpawned.setDecorativeObject(current);
 			client.getCallbacks().post(decorativeObjectSpawned);
 		}
 		else if (current != null && previous != null)
 		{
-			DecorativeObjectChanged decorativeObjectChanged = new DecorativeObjectChanged();
+			DecorativeObjectChanged decorativeObjectChanged = DecorativeObjectChanged.INSTANCE;
 			decorativeObjectChanged.setTile(this);
 			decorativeObjectChanged.setPrevious(previous);
 			decorativeObjectChanged.setDecorativeObject(current);
@@ -189,21 +189,21 @@ public abstract class RSTileMixin implements RSTile
 
 		if (current == null && previous != null)
 		{
-			GroundObjectDespawned groundObjectDespawned = new GroundObjectDespawned();
+			GroundObjectDespawned groundObjectDespawned = GroundObjectDespawned.INSTANCE;
 			groundObjectDespawned.setTile(this);
 			groundObjectDespawned.setGroundObject(previous);
 			client.getCallbacks().post(groundObjectDespawned);
 		}
 		else if (current != null && previous == null)
 		{
-			GroundObjectSpawned groundObjectSpawned = new GroundObjectSpawned();
+			GroundObjectSpawned groundObjectSpawned = GroundObjectSpawned.INSTANCE;
 			groundObjectSpawned.setTile(this);
 			groundObjectSpawned.setGroundObject(current);
 			client.getCallbacks().post(groundObjectSpawned);
 		}
 		else if (current != null && previous != null)
 		{
-			GroundObjectChanged groundObjectChanged = new GroundObjectChanged();
+			GroundObjectChanged groundObjectChanged = GroundObjectChanged.INSTANCE;
 			groundObjectChanged.setTile(this);
 			groundObjectChanged.setPrevious(previous);
 			groundObjectChanged.setGroundObject(current);
@@ -251,21 +251,21 @@ public abstract class RSTileMixin implements RSTile
 		{
 			if (current == null && previous != null)
 			{
-				GameObjectDespawned gameObjectDespawned = new GameObjectDespawned();
+				GameObjectDespawned gameObjectDespawned = GameObjectDespawned.INSTANCE;
 				gameObjectDespawned.setTile(this);
 				gameObjectDespawned.setGameObject(previous);
 				client.getCallbacks().post(gameObjectDespawned);
 			}
 			else if (current != null && previous == null)
 			{
-				GameObjectSpawned gameObjectSpawned = new GameObjectSpawned();
+				GameObjectSpawned gameObjectSpawned = GameObjectSpawned.INSTANCE;
 				gameObjectSpawned.setTile(this);
 				gameObjectSpawned.setGameObject(current);
 				client.getCallbacks().post(gameObjectSpawned);
 			}
 			else if (current != null && previous != null)
 			{
-				GameObjectChanged gameObjectsChanged = new GameObjectChanged();
+				GameObjectChanged gameObjectsChanged = GameObjectChanged.INSTANCE;
 				gameObjectsChanged.setTile(this);
 				gameObjectsChanged.setPrevious(previous);
 				gameObjectsChanged.setGameObject(current);
@@ -295,7 +295,9 @@ public abstract class RSTileMixin implements RSTile
 				for (RSNode cur = head.getNext(); cur != head; cur = cur.getNext())
 				{
 					RSItem item = (RSItem) cur;
-					ItemDespawned itemDespawned = new ItemDespawned(this, item);
+					ItemDespawned itemDespawned = ItemDespawned.INSTANCE;
+					itemDespawned.setTile(this);
+					itemDespawned.setItem(item);
 					client.getCallbacks().post(itemDespawned);
 				}
 			}
@@ -313,7 +315,9 @@ public abstract class RSTileMixin implements RSTile
 		{
 			if (lastUnlink != null)
 			{
-				ItemDespawned itemDespawned = new ItemDespawned(this, lastUnlink);
+				ItemDespawned itemDespawned = ItemDespawned.INSTANCE;
+				itemDespawned.setTile(this);
+				itemDespawned.setItem(lastUnlink);
 				client.getCallbacks().post(itemDespawned);
 			}
 			return;
@@ -325,7 +329,9 @@ public abstract class RSTileMixin implements RSTile
 		{
 			if (lastUnlink != null)
 			{
-				ItemDespawned itemDespawned = new ItemDespawned(this, lastUnlink);
+				ItemDespawned itemDespawned = ItemDespawned.INSTANCE;
+				itemDespawned.setTile(this);
+				itemDespawned.setItem(lastUnlink);
 				client.getCallbacks().post(itemDespawned);
 			}
 			return;
@@ -358,7 +364,9 @@ public abstract class RSTileMixin implements RSTile
 
 		if (lastUnlink != null && lastUnlink != previous && lastUnlink != next)
 		{
-			ItemDespawned itemDespawned = new ItemDespawned(this, lastUnlink);
+			ItemDespawned itemDespawned = ItemDespawned.INSTANCE;
+			itemDespawned.setTile(this);
+			itemDespawned.setItem(lastUnlink);
 			client.getCallbacks().post(itemDespawned);
 		}
 
@@ -373,7 +381,9 @@ public abstract class RSTileMixin implements RSTile
 			item.setX(x);
 			item.setY(y);
 
-			ItemSpawned itemSpawned = new ItemSpawned(this, item);
+			ItemSpawned itemSpawned = ItemSpawned.INSTANCE;
+			itemSpawned.setTile(this);
+			itemSpawned.setItem(item);
 			client.getCallbacks().post(itemSpawned);
 
 			current = forward ? current.getNext() : current.getPrevious();

--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSVarcsMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSVarcsMixin.java
@@ -19,13 +19,17 @@ public abstract class RSVarcsMixin implements RSVarcs
 	@Inject
 	public void onVarCIntChanged(int idx)
 	{
-		client.getCallbacks().post(new VarClientIntChanged(idx));
+		VarClientIntChanged event = VarClientIntChanged.INSTANCE;
+		event.setIndex(idx);
+		client.getCallbacks().post(event);
 	}
 
 	@FieldHook("varCStrings")
 	@Inject
 	public void onVarCStrChanged(int idx)
 	{
-		client.getCallbacks().post(new VarClientStrChanged(idx));
+		VarClientStrChanged event = VarClientStrChanged.INSTANCE;
+		event.setIndex(idx);
+		client.getCallbacks().post(idx);
 	}
 }

--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSWidgetMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSWidgetMixin.java
@@ -405,7 +405,7 @@ public abstract class RSWidgetMixin implements RSWidget
 	@Override
 	public void broadcastHidden(boolean hidden)
 	{
-		WidgetHiddenChanged event = new WidgetHiddenChanged();
+		WidgetHiddenChanged event = WidgetHiddenChanged.INSTANCE;
 		event.setWidget(this);
 		event.setHidden(hidden);
 
@@ -493,7 +493,7 @@ public abstract class RSWidgetMixin implements RSWidget
 
 		client.getLogger().trace("Posting widget position changed");
 
-		WidgetPositioned widgetPositioned = new WidgetPositioned();
+		WidgetPositioned widgetPositioned = WidgetPositioned.INSTANCE;
 		client.getCallbacks().postDeferred(widgetPositioned);
 	}
 

--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSWorldMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSWorldMixin.java
@@ -62,7 +62,8 @@ public abstract class RSWorldMixin implements RSWorld
 		if (worlds != null && worlds.length > 0 && worlds[worlds.length - 1] == this)
 		{
 			// this is the last world in the list.
-			WorldListLoad worldLoad = new WorldListLoad(worlds);
+			WorldListLoad worldLoad = WorldListLoad.INSTANCE;
+			worldLoad.setWorlds(worlds);
 			client.getCallbacks().post(worldLoad);
 		}
 	}

--- a/runelite-mixins/src/main/java/net/runelite/mixins/ScriptVMMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/ScriptVMMixin.java
@@ -98,7 +98,7 @@ public abstract class ScriptVMMixin implements RSClient
 				return true;
 			}
 
-			ScriptCallbackEvent event = new ScriptCallbackEvent();
+			ScriptCallbackEvent event = ScriptCallbackEvent.INSTANCE;
 			event.setScript(currentScript);
 			event.setEventName(stringOp);
 			client.getCallbacks().post(event);


### PR DESCRIPTION
This greatly reduces the amount of objects that need to be created literally all the time thanks to our event publishing.