### PR TITLE
Remove activity prefix from Discord plugin

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordGameEventType.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordGameEventType.java
@@ -345,21 +345,7 @@ enum DiscordGameEventType
 
 	private static String exploring(DiscordAreaType areaType, String areaName)
 	{
-		switch (areaType)
-		{
-			case BOSSES:
-				return "Fighting: " + areaName;
-			case DUNGEONS:
-				return "Exploring: " + areaName;
-			case CITIES:
-				return "Location: " + areaName;
-			case MINIGAMES:
-				return "Playing: " + areaName;
-			case RAIDS:
-				return "Raiding: " + areaName;
-		}
-
-		return "";
+		return areaName;
 	}
 
 	public static DiscordGameEventType fromSkill(final Skill skill)


### PR DESCRIPTION
The space in the Discord Rich Presence is very limited and it is being
truncated by non-important prefix, so remove this prefix.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>