### PR TITLE
Dont display bank value GE/HA text when not needed

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/bankvalue/BankValuePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/bankvalue/BankValuePlugin.java
@@ -86,7 +86,12 @@ public class BankValuePlugin extends Plugin
 
 		if (config.showGE() && gePrice != 0)
 		{
-			strCurrentTab += " (EX: ";
+			strCurrentTab += " (";
+
+			if (config.showHA())
+			{
+				strCurrentTab += "EX: ";
+			}
 
 			if (config.showExact())
 			{
@@ -100,7 +105,12 @@ public class BankValuePlugin extends Plugin
 
 		if (config.showHA() && haPrice != 0)
 		{
-			strCurrentTab += " (HA: ";
+			strCurrentTab += " (";
+
+			if (config.showGE())
+			{
+				strCurrentTab += "HA: ";
+			}
 
 			if (config.showExact())
 			{


### PR DESCRIPTION
If showing only GE or HA value do not add the GE/HA prefix.

Closes #1479

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>