### PR TITLE
Make the LootTrackerClient log when submitting isn't successful

### DIFF
--- a/http-api/src/main/java/net/runelite/http/api/loottracker/LootTrackerClient.java
+++ b/http-api/src/main/java/net/runelite/http/api/loottracker/LootTrackerClient.java
@@ -76,7 +76,14 @@ public class LootTrackerClient
 			@Override
 			public void onResponse(Call call, Response response)
 			{
-				log.debug("Submitted loot");
+				if (response.isSuccessful())
+				{
+					log.debug("Submitted loot");
+				}
+				else
+				{
+					log.warn("Error submitting loot: {} - {}", response.code(), response.message());
+				}
 				response.close();
 			}
 		});


### PR DESCRIPTION
Currently the LootTrackerClient will claim it has successfully submitted loot as long as a response came back.