### PR TITLE
Player indicator name positions

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/Actor.java
+++ b/runelite-api/src/main/java/net/runelite/api/Actor.java
@@ -27,6 +27,7 @@ package net.runelite.api;
 import java.awt.Graphics2D;
 import java.awt.Polygon;
 import java.awt.image.BufferedImage;
+import javax.annotation.Nullable;
 import net.runelite.api.annotations.VisibleForDevtools;
 import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.coords.WorldArea;
@@ -175,6 +176,7 @@ public interface Actor extends Renderable
 	 * @param zOffset the z-axis offset
 	 * @return the text drawing location
 	 */
+	@Nullable
 	Point getCanvasTextLocation(Graphics2D graphics, String text, int zOffset);
 
 	/**

--- a/runelite-api/src/main/java/net/runelite/api/Perspective.java
+++ b/runelite-api/src/main/java/net/runelite/api/Perspective.java
@@ -379,7 +379,7 @@ public class Perspective
 		@Nullable String text,
 		int zOffset)
 	{
-		if (text == null || "".equals(text))
+		if (text == null)
 		{
 			return null;
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsConfig.java
@@ -155,13 +155,13 @@ public interface PlayerIndicatorsConfig extends Config
 
 	@ConfigItem(
 		position = 11,
-		keyName = "drawOverheadPlayerNames",
-		name = "Draw names above players",
-		description = "Configures whether or not player names should be drawn above players"
+		keyName = "playerNamePosition",
+		name = "Name position",
+		description = "Configures the position of drawn player names, or if they should be disabled"
 	)
-	default boolean drawOverheadPlayerNames()
+	default PlayerNameLocation playerNamePosition()
 	{
-		return true;
+		return PlayerNameLocation.ABOVE_HEAD;
 	}
 
 	@ConfigItem(

--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerNameLocation.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerNameLocation.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2019, Jordan Atwood <nightfirecat@protonmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.playerindicators;
+
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public enum PlayerNameLocation
+{
+
+	DISABLED("Disabled"),
+	ABOVE_HEAD("Above head"),
+	MODEL_CENTER("Center of model"),
+	MODEL_RIGHT("Right of model");
+
+	private final String name;
+
+	@Override
+	public String toString()
+	{
+		return name;
+	}
+}


### PR DESCRIPTION
This allows players to select from a number of positions where they
would like highlighted player's names to be drawn relative to the
player's model.

Closes #878 

![config](https://user-images.githubusercontent.com/2199511/51949967-a3faf180-2426-11e9-8e58-7fff48d0b65a.png)
![demonstration](https://user-images.githubusercontent.com/2199511/51949968-a3faf180-2426-11e9-8a61-bd4d53d14451.gif)
