### PR TITLE
Update slayer points in tooltip while in rewards

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerPlugin.java
@@ -372,7 +372,15 @@ public class SlayerPlugin extends Plugin
 				Matcher mPoints = REWARD_POINTS.matcher(w.getText());
 				if (mPoints.find())
 				{
+					int prevPoints = points;
 					points = Integer.parseInt(mPoints.group(1).replaceAll(",", ""));
+
+					if (prevPoints != points)
+					{
+						removeCounter();
+						addCounter();
+					}
+
 					break;
 				}
 			}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerPlugin.java
@@ -372,7 +372,7 @@ public class SlayerPlugin extends Plugin
 				Matcher mPoints = REWARD_POINTS.matcher(w.getText());
 				if (mPoints.find())
 				{
-					int prevPoints = points;
+					final int prevPoints = points;
 					points = Integer.parseInt(mPoints.group(1).replaceAll(",", ""));
 
 					if (prevPoints != points)


### PR DESCRIPTION
Slayer points are updated while in the rewards menu, including before
and after a purchase. Previously, the points variable was updated on
each tick to whatever was displayed in the "Slayer points: "
widget, but that change was never reflected in the tooltip until the
next tooltip update. The tooltip now updates whenever a change in
slayer points is detected while in the rewards menu.

Closes #7611 