### PR TITLE
Function key remapping

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/cameraandhotkeys/CameraAndHotkeysConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cameraandhotkeys/CameraAndHotkeysConfig.java
@@ -22,7 +22,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package net.runelite.client.plugins.wasdcamera;
+package net.runelite.client.plugins.cameraandhotkeys;
 
 import java.awt.event.KeyEvent;
 import net.runelite.client.config.Config;
@@ -30,8 +30,8 @@ import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
 import net.runelite.client.config.ModifierlessKeybind;
 
-@ConfigGroup("wasdcamera")
-public interface WASDCameraConfig extends Config
+@ConfigGroup("cameraandhotkeys")
+public interface CameraAndHotkeysConfig extends Config
 {
 	@ConfigItem(
 		position = 1,
@@ -75,5 +75,115 @@ public interface WASDCameraConfig extends Config
 	default ModifierlessKeybind right()
 	{
 		return new ModifierlessKeybind(KeyEvent.VK_D, 0);
+	}
+
+	@ConfigItem(
+		position = 5,
+		keyName = "F1",
+		name = "F1 key",
+		description = "The key which will replace F1."
+	)
+	default ModifierlessKeybind f1()
+	{
+		return new ModifierlessKeybind(KeyEvent.VK_1, 0);
+	}
+
+	@ConfigItem(
+		position = 6,
+		keyName = "F2",
+		name = "F2 key",
+		description = "The key which will replace F2."
+	)
+	default ModifierlessKeybind f2()
+	{
+		return new ModifierlessKeybind(KeyEvent.VK_2, 0);
+	}
+
+	@ConfigItem(
+		position = 7,
+		keyName = "F3",
+		name = "F3 key",
+		description = "The key which will replace F3."
+	)
+	default ModifierlessKeybind f3()
+	{
+		return new ModifierlessKeybind(KeyEvent.VK_3, 0);
+	}
+
+	@ConfigItem(
+		position = 8,
+		keyName = "F4",
+		name = "F4 key",
+		description = "The key which will replace F4."
+	)
+	default ModifierlessKeybind f4()
+	{
+		return new ModifierlessKeybind(KeyEvent.VK_4, 0);
+	}
+
+	@ConfigItem(
+		position = 9,
+		keyName = "F5",
+		name = "F5 key",
+		description = "The key which will replace F5."
+	)
+	default ModifierlessKeybind f5()
+	{
+		return new ModifierlessKeybind(KeyEvent.VK_5, 0);
+	}
+
+	@ConfigItem(
+		position = 10,
+		keyName = "F6",
+		name = "F6 key",
+		description = "The key which will replace F6."
+	)
+	default ModifierlessKeybind f6()
+	{
+		return new ModifierlessKeybind(KeyEvent.VK_6, 0);
+	}
+
+	@ConfigItem(
+		position = 11,
+		keyName = "F7",
+		name = "F7 key",
+		description = "The key which will replace F7."
+	)
+	default ModifierlessKeybind f7()
+	{
+		return new ModifierlessKeybind(KeyEvent.VK_7, 0);
+	}
+
+	@ConfigItem(
+		position = 12,
+		keyName = "F8",
+		name = "F8 key",
+		description = "The key which will replace F8."
+	)
+	default ModifierlessKeybind f8()
+	{
+		return new ModifierlessKeybind(KeyEvent.VK_8, 0);
+	}
+
+	@ConfigItem(
+		position = 13,
+		keyName = "F9",
+		name = "F9 key",
+		description = "The key which will replace F9."
+	)
+	default ModifierlessKeybind f9()
+	{
+		return new ModifierlessKeybind(KeyEvent.VK_9, 0);
+	}
+
+	@ConfigItem(
+		position = 14,
+		keyName = "F10",
+		name = "F10 key",
+		description = "The key which will replace F10."
+	)
+	default ModifierlessKeybind f10()
+	{
+		return new ModifierlessKeybind(KeyEvent.VK_0, 0);
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cameraandhotkeys/CameraAndHotkeysListener.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cameraandhotkeys/CameraAndHotkeysListener.java
@@ -61,7 +61,7 @@ class CameraAndHotkeysListener extends MouseAdapter implements KeyListener
 	@Override
 	public void keyPressed(KeyEvent e)
 	{
-		if (client.getGameState() != GameState.LOGGED_IN || !plugin.chatboxFocused() || !plugin.dialogOpen())
+		if (client.getGameState() != GameState.LOGGED_IN || !plugin.chatboxFocused() || plugin.dialogOpen())
 		{
 			return;
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cameraandhotkeys/CameraAndHotkeysListener.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cameraandhotkeys/CameraAndHotkeysListener.java
@@ -23,7 +23,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package net.runelite.client.plugins.wasdcamera;
+package net.runelite.client.plugins.cameraandhotkeys;
 
 import com.google.common.base.Strings;
 import java.awt.event.KeyEvent;
@@ -37,13 +37,13 @@ import net.runelite.client.callback.ClientThread;
 import net.runelite.client.input.KeyListener;
 import net.runelite.client.input.MouseAdapter;
 
-class WASDCameraListener extends MouseAdapter implements KeyListener
+class CameraAndHotkeysListener extends MouseAdapter implements KeyListener
 {
 	@Inject
-	private WASDCameraPlugin plugin;
+	private CameraAndHotkeysPlugin plugin;
 
 	@Inject
-	private WASDCameraConfig config;
+	private CameraAndHotkeysConfig config;
 
 	@Inject
 	private Client client;
@@ -61,7 +61,7 @@ class WASDCameraListener extends MouseAdapter implements KeyListener
 	@Override
 	public void keyPressed(KeyEvent e)
 	{
-		if (client.getGameState() != GameState.LOGGED_IN || !plugin.chatboxFocused())
+		if (client.getGameState() != GameState.LOGGED_IN || !plugin.chatboxFocused() || !plugin.dialogOpen())
 		{
 			return;
 		}
@@ -87,6 +87,56 @@ class WASDCameraListener extends MouseAdapter implements KeyListener
 			{
 				modified.put(e.getKeyCode(), KeyEvent.VK_RIGHT);
 				e.setKeyCode(KeyEvent.VK_RIGHT);
+			}
+			else if (config.f1().matches(e))
+			{
+				modified.put(e.getKeyCode(), KeyEvent.VK_F1);
+				e.setKeyCode(KeyEvent.VK_F1);
+			}
+			else if (config.f2().matches(e))
+			{
+				modified.put(e.getKeyCode(), KeyEvent.VK_F2);
+				e.setKeyCode(KeyEvent.VK_F2);
+			}
+			else if (config.f3().matches(e))
+			{
+				modified.put(e.getKeyCode(), KeyEvent.VK_F3);
+				e.setKeyCode(KeyEvent.VK_F3);
+			}
+			else if (config.f4().matches(e))
+			{
+				modified.put(e.getKeyCode(), KeyEvent.VK_F4);
+				e.setKeyCode(KeyEvent.VK_F4);
+			}
+			else if (config.f5().matches(e))
+			{
+				modified.put(e.getKeyCode(), KeyEvent.VK_F5);
+				e.setKeyCode(KeyEvent.VK_F5);
+			}
+			else if (config.f6().matches(e))
+			{
+				modified.put(e.getKeyCode(), KeyEvent.VK_F6);
+				e.setKeyCode(KeyEvent.VK_F6);
+			}
+			else if (config.f7().matches(e))
+			{
+				modified.put(e.getKeyCode(), KeyEvent.VK_F7);
+				e.setKeyCode(KeyEvent.VK_F7);
+			}
+			else if (config.f8().matches(e))
+			{
+				modified.put(e.getKeyCode(), KeyEvent.VK_F8);
+				e.setKeyCode(KeyEvent.VK_F8);
+			}
+			else if (config.f9().matches(e))
+			{
+				modified.put(e.getKeyCode(), KeyEvent.VK_F9);
+				e.setKeyCode(KeyEvent.VK_F9);
+			}
+			else if (config.f10().matches(e))
+			{
+				modified.put(e.getKeyCode(), KeyEvent.VK_F10);
+				e.setKeyCode(KeyEvent.VK_F10);
 			}
 			else
 			{
@@ -161,6 +211,46 @@ class WASDCameraListener extends MouseAdapter implements KeyListener
 			else if (config.right().matches(e))
 			{
 				e.setKeyCode(KeyEvent.VK_RIGHT);
+			}
+			else if (config.f1().matches(e))
+			{
+				e.setKeyCode(KeyEvent.VK_F1);
+			}
+			else if (config.f2().matches(e))
+			{
+				e.setKeyCode(KeyEvent.VK_F2);
+			}
+			else if (config.f3().matches(e))
+			{
+				e.setKeyCode(KeyEvent.VK_F3);
+			}
+			else if (config.f4().matches(e))
+			{
+				e.setKeyCode(KeyEvent.VK_F4);
+			}
+			else if (config.f5().matches(e))
+			{
+				e.setKeyCode(KeyEvent.VK_F5);
+			}
+			else if (config.f6().matches(e))
+			{
+				e.setKeyCode(KeyEvent.VK_F6);
+			}
+			else if (config.f7().matches(e))
+			{
+				e.setKeyCode(KeyEvent.VK_F7);
+			}
+			else if (config.f8().matches(e))
+			{
+				e.setKeyCode(KeyEvent.VK_F8);
+			}
+			else if (config.f9().matches(e))
+			{
+				e.setKeyCode(KeyEvent.VK_F9);
+			}
+			else if (config.f10().matches(e))
+			{
+				e.setKeyCode(KeyEvent.VK_F10);
 			}
 		}
 		else

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cameraandhotkeys/CameraAndHotkeysPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cameraandhotkeys/CameraAndHotkeysPlugin.java
@@ -52,7 +52,7 @@ import net.runelite.client.util.ColorUtil;
 @PluginDescriptor(
 	name = "Camera and Hotkeys",
 	description = "Allows remapping of the Camera and Function Keys",
-	tags = {"camera", "hotkeys"},
+	tags = {"wasd", "camera", "hotkeys"},
 	enabledByDefault = false
 )
 
@@ -134,12 +134,11 @@ public class CameraAndHotkeysPlugin extends Plugin
 
 	boolean dialogOpen()
 	{
-		//disable function rebinds when NPC Dialog or an Dialog Option widget is open
+		//disable function rebinds when an Dialog Option widget is open
 		//so that 0-9 keys can be used for remapping
 
-		Widget npcDialog = client.getWidget(WidgetInfo.DIALOG_NPC);
 		Widget optionDialog = client.getWidget(WidgetInfo.DIALOG_OPTION);
-		if (npcDialog == null && optionDialog == null)
+		if (optionDialog == null)
 		{
 			return true;
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cameraandhotkeys/CameraAndHotkeysPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cameraandhotkeys/CameraAndHotkeysPlugin.java
@@ -23,7 +23,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package net.runelite.client.plugins.wasdcamera;
+package net.runelite.client.plugins.cameraandhotkeys;
 
 import com.google.inject.Provides;
 import java.awt.Color;
@@ -50,12 +50,13 @@ import net.runelite.client.ui.JagexColors;
 import net.runelite.client.util.ColorUtil;
 
 @PluginDescriptor(
-	name = "WASD Camera",
-	description = "Allows use of WASD keys for camera movement with 'Press Enter to Chat'",
+	name = "Camera and Hotkeys",
+	description = "Allows use of WASD keys for camera movement and rebinding F Keys with 'Press Enter to Chat'",
 	tags = {"enter", "chat"},
 	enabledByDefault = false
 )
-public class WASDCameraPlugin extends Plugin
+
+public class CameraAndHotkeysPlugin extends Plugin
 {
 	private static final String PRESS_ENTER_TO_CHAT = "Press Enter to Chat...";
 	private static final String SCRIPT_EVENT_SET_CHATBOX_INPUT = "setChatboxInput";
@@ -71,7 +72,7 @@ public class WASDCameraPlugin extends Plugin
 	private KeyManager keyManager;
 
 	@Inject
-	private WASDCameraListener inputListener;
+	private CameraAndHotkeysListener inputListener;
 
 	@Getter(AccessLevel.PACKAGE)
 	@Setter(AccessLevel.PACKAGE)
@@ -107,9 +108,9 @@ public class WASDCameraPlugin extends Plugin
 	}
 
 	@Provides
-	WASDCameraConfig getConfig(ConfigManager configManager)
+	CameraAndHotkeysConfig getConfig(ConfigManager configManager)
 	{
-		return configManager.getConfig(WASDCameraConfig.class);
+		return configManager.getConfig(CameraAndHotkeysConfig.class);
 	}
 
 	boolean chatboxFocused()
@@ -129,6 +130,21 @@ public class WASDCameraPlugin extends Plugin
 		}
 
 		return true;
+	}
+
+	boolean dialogOpen()
+	{
+		//disable function rebinds when NPC Dialog or an Dialog Option widget is open
+		//so that 0-9 keys can be used for remapping
+
+		Widget npcDialog = client.getWidget(WidgetInfo.DIALOG_NPC);
+		Widget optionDialog = client.getWidget(WidgetInfo.DIALOG_OPTION);
+		if (npcDialog == null && optionDialog == null)
+		{
+			return true;
+		}
+
+		return false;
 	}
 
 	@Subscribe

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cameraandhotkeys/CameraAndHotkeysPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cameraandhotkeys/CameraAndHotkeysPlugin.java
@@ -51,8 +51,8 @@ import net.runelite.client.util.ColorUtil;
 
 @PluginDescriptor(
 	name = "Camera and Hotkeys",
-	description = "Allows use of WASD keys for camera movement and rebinding F Keys with 'Press Enter to Chat'",
-	tags = {"enter", "chat"},
+	description = "Allows remapping of the Camera and Function Keys",
+	tags = {"camera", "hotkeys"},
 	enabledByDefault = false
 )
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cameraandhotkeys/CameraAndHotkeysPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cameraandhotkeys/CameraAndHotkeysPlugin.java
@@ -136,14 +136,13 @@ public class CameraAndHotkeysPlugin extends Plugin
 	{
 		//disable function rebinds when an Dialog Option widget is open
 		//so that 0-9 keys can be used for remapping
-
 		Widget optionDialog = client.getWidget(WidgetInfo.DIALOG_OPTION);
 		if (optionDialog == null)
 		{
-			return true;
+			return false;
 		}
 
-		return false;
+		return true;
 	}
 
 	@Subscribe


### PR DESCRIPTION
I modified the WASD Camera plugin to also let you remap the function keys.

I realize that there have been some PRs for this in the past that were closed and never merged in, but the main argument I saw was "Just use AHK".  However, there are a couple of problems with that, especially if you want to use the 1-0 number keys.

1)  You have to be using the WASD Camera plugin already to use an AHK script unless you want it to be typing in the chatbox all day.

2) You either have to have a keybind to manually pause the AHK script when you actually want to chat, or you have to write all the logic to deal with actually wanting to chat.  WASD Camera already has that logic fleshed out, for the most part.

3)  If you want to use number keys, then when you have NPC  or crafting dialogs where you can use the number keys to progress, you again need to manually pause the script.  There's no real workaround for it that I can think of.  But if I do it in RuneLite, i can check if a DIALOG_NPC or DIALOG_OPTION widget is open and automatically disable my custom remaps.

So, while AHK is a 'workable' solution, it isn't ideal.  Hopefully something like this can be added into runelite.