### PR TITLE
Fix color picker opening partly off screen when client is maximized

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
@@ -422,7 +422,8 @@ public class ConfigPanel extends PluginPanel
 					{
 						RuneliteColorPicker colorPicker = new RuneliteColorPicker(SwingUtilities.windowForComponent(ConfigPanel.this),
 							colorPickerBtn.getBackground(), cid.getItem().name(), cid.getAlpha() == null);
-						colorPicker.setLocation(getLocationOnScreen());
+						colorPicker.pack();
+						colorPicker.setLocationRelativeTo(colorPickerBtn);
 						colorPicker.setOnColorChange(c ->
 						{
 							colorPickerBtn.setBackground(c);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
@@ -423,6 +423,7 @@ public class ConfigPanel extends PluginPanel
 						RuneliteColorPicker colorPicker = new RuneliteColorPicker(SwingUtilities.windowForComponent(ConfigPanel.this),
 							colorPickerBtn.getBackground(), cid.getItem().name(), cid.getAlpha() == null);
 						colorPicker.setLocationRelativeTo(colorPickerBtn);
+						colorPicker.fitInWindowBounds();
 						colorPicker.setOnColorChange(c ->
 						{
 							colorPickerBtn.setBackground(c);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
@@ -422,7 +422,6 @@ public class ConfigPanel extends PluginPanel
 					{
 						RuneliteColorPicker colorPicker = new RuneliteColorPicker(SwingUtilities.windowForComponent(ConfigPanel.this),
 							colorPickerBtn.getBackground(), cid.getItem().name(), cid.getAlpha() == null);
-						colorPicker.pack();
 						colorPicker.setLocationRelativeTo(colorPickerBtn);
 						colorPicker.setOnColorChange(c ->
 						{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenmarkers/ui/ScreenMarkerPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenmarkers/ui/ScreenMarkerPanel.java
@@ -492,6 +492,7 @@ class ScreenMarkerPanel extends JPanel
 		RuneliteColorPicker colorPicker = new RuneliteColorPicker(SwingUtilities.windowForComponent(this),
 			marker.getMarker().getFill(), marker.getMarker().getName() + " Fill", false);
 		colorPicker.setLocationRelativeTo(this);
+		colorPicker.fitInWindowBounds();
 		colorPicker.setOnColorChange(c ->
 		{
 			marker.getMarker().setFill(c);
@@ -514,6 +515,7 @@ class ScreenMarkerPanel extends JPanel
 		RuneliteColorPicker colorPicker = new RuneliteColorPicker(SwingUtilities.windowForComponent(this),
 			marker.getMarker().getColor(), marker.getMarker().getName() + " Border", false);
 		colorPicker.setLocationRelativeTo(this);
+		colorPicker.fitInWindowBounds();
 		colorPicker.setOnColorChange(c ->
 		{
 			marker.getMarker().setColor(c);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenmarkers/ui/ScreenMarkerPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenmarkers/ui/ScreenMarkerPanel.java
@@ -27,6 +27,7 @@ package net.runelite.client.plugins.screenmarkers.ui;
 
 import java.awt.BorderLayout;
 import java.awt.Color;
+import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.FlowLayout;
 import java.awt.event.MouseAdapter;
@@ -269,7 +270,7 @@ class ScreenMarkerPanel extends JPanel
 			@Override
 			public void mousePressed(MouseEvent mouseEvent)
 			{
-				openBorderColorPicker();
+				openBorderColorPicker(borderColorIndicator);
 			}
 
 			@Override
@@ -291,7 +292,7 @@ class ScreenMarkerPanel extends JPanel
 			@Override
 			public void mousePressed(MouseEvent mouseEvent)
 			{
-				openFillColorPicker();
+				openFillColorPicker(fillColorIndicator);
 			}
 
 			@Override
@@ -487,11 +488,12 @@ class ScreenMarkerPanel extends JPanel
 		borderColorIndicator.setIcon(marker.getMarker().getBorderThickness() == 0 ? NO_BORDER_COLOR_ICON : BORDER_COLOR_ICON);
 	}
 
-	private void openFillColorPicker()
+	private void openFillColorPicker(Component parent)
 	{
 		RuneliteColorPicker colorPicker = new RuneliteColorPicker(SwingUtilities.windowForComponent(this),
 			marker.getMarker().getFill(), marker.getMarker().getName() + " Fill", false);
-		colorPicker.setLocation(getLocationOnScreen());
+		colorPicker.pack();
+		colorPicker.setLocationRelativeTo(parent);
 		colorPicker.setOnColorChange(c ->
 		{
 			marker.getMarker().setFill(c);
@@ -509,11 +511,12 @@ class ScreenMarkerPanel extends JPanel
 		colorPicker.setVisible(true);
 	}
 
-	private void openBorderColorPicker()
+	private void openBorderColorPicker(Component parent)
 	{
 		RuneliteColorPicker colorPicker = new RuneliteColorPicker(SwingUtilities.windowForComponent(this),
 			marker.getMarker().getColor(), marker.getMarker().getName() + " Border", false);
-		colorPicker.setLocation(getLocationOnScreen());
+		colorPicker.pack();
+		colorPicker.setLocationRelativeTo(parent);
 		colorPicker.setOnColorChange(c ->
 		{
 			marker.getMarker().setColor(c);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenmarkers/ui/ScreenMarkerPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenmarkers/ui/ScreenMarkerPanel.java
@@ -270,7 +270,7 @@ class ScreenMarkerPanel extends JPanel
 			@Override
 			public void mousePressed(MouseEvent mouseEvent)
 			{
-				openBorderColorPicker(borderColorIndicator);
+				openBorderColorPicker();
 			}
 
 			@Override
@@ -292,7 +292,7 @@ class ScreenMarkerPanel extends JPanel
 			@Override
 			public void mousePressed(MouseEvent mouseEvent)
 			{
-				openFillColorPicker(fillColorIndicator);
+				openFillColorPicker();
 			}
 
 			@Override
@@ -488,12 +488,11 @@ class ScreenMarkerPanel extends JPanel
 		borderColorIndicator.setIcon(marker.getMarker().getBorderThickness() == 0 ? NO_BORDER_COLOR_ICON : BORDER_COLOR_ICON);
 	}
 
-	private void openFillColorPicker(Component parent)
+	private void openFillColorPicker()
 	{
 		RuneliteColorPicker colorPicker = new RuneliteColorPicker(SwingUtilities.windowForComponent(this),
 			marker.getMarker().getFill(), marker.getMarker().getName() + " Fill", false);
-		colorPicker.pack();
-		colorPicker.setLocationRelativeTo(parent);
+		colorPicker.setLocationRelativeTo(this);
 		colorPicker.setOnColorChange(c ->
 		{
 			marker.getMarker().setFill(c);
@@ -511,12 +510,11 @@ class ScreenMarkerPanel extends JPanel
 		colorPicker.setVisible(true);
 	}
 
-	private void openBorderColorPicker(Component parent)
+	private void openBorderColorPicker()
 	{
 		RuneliteColorPicker colorPicker = new RuneliteColorPicker(SwingUtilities.windowForComponent(this),
 			marker.getMarker().getColor(), marker.getMarker().getName() + " Border", false);
-		colorPicker.pack();
-		colorPicker.setLocationRelativeTo(parent);
+		colorPicker.setLocationRelativeTo(this);
 		colorPicker.setOnColorChange(c ->
 		{
 			marker.getMarker().setColor(c);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenmarkers/ui/ScreenMarkerPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenmarkers/ui/ScreenMarkerPanel.java
@@ -27,7 +27,6 @@ package net.runelite.client.plugins.screenmarkers.ui;
 
 import java.awt.BorderLayout;
 import java.awt.Color;
-import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.FlowLayout;
 import java.awt.event.MouseAdapter;

--- a/runelite-client/src/main/java/net/runelite/client/ui/components/colorpicker/RuneliteColorPicker.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/components/colorpicker/RuneliteColorPicker.java
@@ -28,10 +28,12 @@ package net.runelite.client.ui.components.colorpicker;
 import com.google.common.base.Strings;
 import java.awt.BorderLayout;
 import java.awt.Color;
+import java.awt.GraphicsEnvironment;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.GridLayout;
 import java.awt.Insets;
+import java.awt.Rectangle;
 import java.awt.Toolkit;
 import java.awt.Window;
 import java.awt.event.ActionEvent;
@@ -340,6 +342,15 @@ public class RuneliteColorPicker extends JDialog
 
 		colorChange(color);
 		updatePanels();
+	}
+
+	public void fitInWindowBounds()
+	{
+		Rectangle winSize = GraphicsEnvironment.getLocalGraphicsEnvironment().getMaximumWindowBounds();
+		if (this.getHeight() + this.getY() > winSize.height)
+		{
+			this.setLocation(this.getX(), winSize.height - this.getHeight());
+		}
 	}
 
 	/**


### PR DESCRIPTION
Not a huge deal, but fixes the color picker dialogs opened by screen marker and chat color configs and keeps them from opening partially off screen.  Also opens them in slightly more logical place (centered on the button you clicked, instead of at the top of the window) all the time.