### PR TITLE
Remove "Tag" toggle from NPC indicators

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsConfig.java
@@ -67,17 +67,6 @@ public interface NpcIndicatorsConfig extends Config
 
 	@ConfigItem(
 		position = 3,
-		keyName = "enableTag",
-		name = "Enable Tag Option",
-		description = "Enable the NPC tag menu option"
-	)
-	default boolean isTagEnabled()
-	{
-		return false;
-	}
-
-	@ConfigItem(
-		position = 4,
 		keyName = "drawNames",
 		name = "Draw names above NPC",
 		description = "Configures whether or not NPC names should be drawn above the NPC"
@@ -88,7 +77,7 @@ public interface NpcIndicatorsConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 5,
+		position = 4,
 		keyName = "drawMinimapNames",
 		name = "Draw names on minimap",
 		description = "Configures whether or not NPC names should be drawn on the minimap"
@@ -99,7 +88,7 @@ public interface NpcIndicatorsConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 6,
+		position = 5,
 		keyName = "showRespawnTimer",
 		name = "Show respawn timer",
 		description = "Show respawn timer of tagged NPCs")

--- a/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsPlugin.java
@@ -248,7 +248,7 @@ public class NpcIndicatorsPlugin extends Plugin
 	@Subscribe
 	public void onMenuEntryAdded(MenuEntryAdded event)
 	{
-		if (!hotKeyPressed || !config.isTagEnabled() || event.getType() != MenuAction.EXAMINE_NPC.getId())
+		if (!hotKeyPressed || event.getType() != MenuAction.EXAMINE_NPC.getId())
 		{
 			return;
 		}


### PR DESCRIPTION
This toggle was here originally because NPC tagging did not required
shift, but now it does so to bring it with line of other shift-click
plugins, simply remove this option.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>