### PR TITLE
Do not reset current activity on discord party update

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordPlugin.java
@@ -352,9 +352,7 @@ public class DiscordPlugin extends Plugin
 
 	private void updatePresence()
 	{
-		discordState.triggerEvent(client.getGameState() == GameState.LOGGED_IN
-			? DiscordGameEventType.IN_GAME
-			: DiscordGameEventType.IN_MENU);
+		discordState.refresh();
 	}
 
 	private void checkForGameStateUpdate()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordState.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordState.java
@@ -78,6 +78,19 @@ class DiscordState
 	}
 
 	/**
+	 * Force refresh discord presence
+	 */
+	void refresh()
+	{
+		if (lastPresence == null)
+		{
+			return;
+		}
+
+		discordService.updatePresence(lastPresence);
+	}
+
+	/**
 	 * Trigger new discord state update.
 	 *
 	 * @param eventType discord event type


### PR DESCRIPTION
Instead of setting activity to in_game, in_menu just send again current
discord activity.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>