### PR TITLE
Use GL_DYNAMIC_DRAW for ever-changing uniformBuffer

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuPlugin.java
@@ -651,7 +651,7 @@ public class GpuPlugin extends Plugin implements DrawCallbacks
 		}
 		uniformBuffer.flip();
 
-		gl.glBufferData(gl.GL_UNIFORM_BUFFER, uniformBuffer.limit() * Integer.BYTES, uniformBuffer, gl.GL_STATIC_DRAW);
+		gl.glBufferData(gl.GL_UNIFORM_BUFFER, uniformBuffer.limit() * Integer.BYTES, uniformBuffer, gl.GL_DYNAMIC_DRAW);
 		gl.glBindBuffer(gl.GL_UNIFORM_BUFFER, 0);
 	}
 


### PR DESCRIPTION
GL_STATIC_DRAW means that the buffer will be created once, set once, and
used once, but its created once, updated a lot, and used a lot, what
means it should use GL_DYNAMIC_DRAW (this param affects how
glBufferSubData later works).

Closes #7320 

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>