### PR TITLE
 Add ingame player name to party data

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/party/PartyConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/party/PartyConfig.java
@@ -80,4 +80,14 @@ public interface PartyConfig extends Config
 	{
 		return true;
 	}
+
+	@ConfigItem(
+		keyName = "playerNames",
+		name = "Player names",
+		description = "Use in-game player names when available"
+	)
+	default boolean playerNames()
+	{
+		return false;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/party/PartyStatsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/party/PartyStatsOverlay.java
@@ -105,8 +105,13 @@ public class PartyStatsOverlay extends Overlay
 				final PanelComponent panel = v.getPanel();
 				panel.getChildren().clear();
 
+				String displayName = v.getName();
+				if (config.playerNames() && v.getPlayerName() != null)
+				{
+					displayName = v.getPlayerName();
+				}
 				final TitleComponent name = TitleComponent.builder()
-					.text(v.getName())
+					.text(displayName)
 					.color(config.recolorNames() ? v.getColor() : Color.WHITE)
 					.build();
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/party/messages/PlayerNameUpdate.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/party/messages/PlayerNameUpdate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Tomas Slusny <slusnucky@gmail.com>
+ * Copyright (c) 2018, TheStonedTurtle <https://github.com/TheStonedTurtle>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -22,30 +22,15 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package net.runelite.client.plugins.party.data;
+package net.runelite.client.plugins.party.messages;
 
-import java.awt.Color;
-import java.util.UUID;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-import lombok.Setter;
-import net.runelite.client.ui.overlay.components.PanelComponent;
-import net.runelite.client.ui.overlay.worldmap.WorldMapPoint;
+import net.runelite.http.api.ws.messages.party.PartyMemberMessage;
 
-@Setter
+@AllArgsConstructor
 @Getter
-@RequiredArgsConstructor
-public class PartyData
+public class PlayerNameUpdate extends PartyMemberMessage
 {
-	private final UUID memberId;
-	private final String name;
-	private final WorldMapPoint worldMapPoint;
-	private final PanelComponent panel = new PanelComponent();
-	private final Color color;
-
-	private int hitpoints;
-	private int maxHitpoints;
-	private int prayer;
-	private int maxPrayer;
 	private String playerName;
 }


### PR DESCRIPTION
Adds a config option to show player name in overlays instead of discord name. Will show the other on hover.

![https://i.imgur.com/Sk7a71m.png](https://i.imgur.com/Sk7a71m.png)
![https://i.imgur.com/p3vrPnm.png](https://i.imgur.com/p3vrPnm.png)
![https://i.imgur.com/9UP9gUx.png](https://i.imgur.com/9UP9gUx.png)