### PR TITLE
Fix Discord party size refresh

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordState.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordState.java
@@ -87,7 +87,21 @@ class DiscordState
 			return;
 		}
 
-		discordService.updatePresence(lastPresence);
+		final DiscordPresence.DiscordPresenceBuilder presenceBuilder = DiscordPresence.builder()
+			.state(lastPresence.getState())
+			.details(lastPresence.getDetails())
+			.startTimestamp(lastPresence.getStartTimestamp())
+			.smallImageKey(lastPresence.getSmallImageKey())
+			.partyMax(lastPresence.getPartyMax())
+			.partySize(party.getMembers().size());
+
+		if (party.isOwner())
+		{
+			presenceBuilder.partyId(partyId.toString());
+			presenceBuilder.joinSecret(party.getPartyId().toString());
+		}
+
+		discordService.updatePresence(presenceBuilder.build());
 	}
 
 	/**


### PR DESCRIPTION
When force-refreshing discord presence use updated party size values.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>