### PR TITLE
Do not hide party bars when value is changed to 0

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/party/PartyStatsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/party/PartyStatsOverlay.java
@@ -106,7 +106,7 @@ public class PartyStatsOverlay extends Overlay
 
 				panel.getChildren().add(name);
 
-				if (v.getHitpoints() > 0)
+				if (v.getMaxHitpoints() > 0)
 				{
 					final ProgressBarComponent hpBar = new ProgressBarComponent();
 					hpBar.setBackgroundColor(HP_BG);
@@ -117,7 +117,7 @@ public class PartyStatsOverlay extends Overlay
 					panel.getChildren().add(hpBar);
 				}
 
-				if (v.getPrayer() > 0)
+				if (v.getMaxPrayer() > 0)
 				{
 					final ProgressBarComponent prayBar = new ProgressBarComponent();
 					prayBar.setBackgroundColor(PRAY_BG);


### PR DESCRIPTION
Instead of checking for current value being > 0 to determine if we have
any stat data, instead check for max value.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>