### PR TITLE
Show party instructional message on login if user joined on login screen

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/party/PartyPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/party/PartyPlugin.java
@@ -128,6 +128,7 @@ public class PartyPlugin extends Plugin implements KeyListener
 
 	private int lastHp, lastPray;
 	private boolean hotkeyDown, doSync;
+	private boolean sendAlert;
 
 	@Override
 	public void configure(Binder binder)
@@ -161,6 +162,7 @@ public class PartyPlugin extends Plugin implements KeyListener
 		keyManager.unregisterKeyListener(this);
 		hotkeyDown = false;
 		doSync = false;
+		sendAlert = false;
 	}
 
 	@Provides
@@ -286,6 +288,12 @@ public class PartyPlugin extends Plugin implements KeyListener
 	@Subscribe
 	public void onGameTick(final GameTick event)
 	{
+		if (sendAlert && client.getGameState() == GameState.LOGGED_IN)
+		{
+			sendAlert = false;
+			sendInstructionMessage();
+		}
+
 		if (doSync && !party.getMembers().isEmpty())
 		{
 			// Request sync
@@ -383,15 +391,7 @@ public class PartyPlugin extends Plugin implements KeyListener
 
 		if (localMember != null && partyData.getMemberId().equals(localMember.getMemberId()))
 		{
-			final String helpMessage = new ChatMessageBuilder()
-				.append(ChatColorType.HIGHLIGHT)
-				.append("To leave party hold SHIFT and right click party stats overlay.")
-				.build();
-
-			chatMessageManager.queue(QueuedMessage.builder()
-				.type(ChatMessageType.GAME)
-				.runeLiteFormattedMessage(helpMessage)
-				.build());
+			sendAlert = true;
 		}
 	}
 
@@ -511,5 +511,18 @@ public class PartyPlugin extends Plugin implements KeyListener
 		{
 			hotkeyDown = false;
 		}
+	}
+
+	private void sendInstructionMessage()
+	{
+		final String helpMessage = new ChatMessageBuilder()
+			.append(ChatColorType.HIGHLIGHT)
+			.append("To leave party hold SHIFT and right click party stats overlay.")
+			.build();
+
+		chatMessageManager.queue(QueuedMessage.builder()
+			.type(ChatMessageType.GAME)
+			.runeLiteFormattedMessage(helpMessage)
+			.build());
 	}
 }


### PR DESCRIPTION
Currently, if the user joins a party whilst on the login screen, they don't get the instructional message on how to leave the party