### PR TITLE
Clanchat: Show amount of members near you

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/clanchat/ClanChatConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/clanchat/ClanChatConfig.java
@@ -32,10 +32,19 @@ import net.runelite.client.config.ConfigItem;
 public interface ClanChatConfig extends Config
 {
 	@ConfigItem(
+		keyName = "clanChatIcons",
+		name = "Clan Chat Icons",
+		description = "Show clan chat icons next to clan members."
+	)
+	default boolean clanChatIcons()
+	{
+		return true;
+	}
+
+	@ConfigItem(
 		keyName = "recentChats",
 		name = "Recent Chats",
-		description = "Show recent clan chats.",
-		position = 1
+		description = "Show recent clan chats."
 	)
 	default boolean recentChats()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/clanchat/ClanChatIndicator.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/clanchat/ClanChatIndicator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Ron <https://github.com/raiyni>
+ * Copyright (c) 2018 Sebastiaan <https://github.com/SebastiaanVanspauwen>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -24,58 +24,35 @@
  */
 package net.runelite.client.plugins.clanchat;
 
-import net.runelite.client.config.Config;
-import net.runelite.client.config.ConfigGroup;
-import net.runelite.client.config.ConfigItem;
+import java.awt.Color;
+import java.awt.image.BufferedImage;
+import net.runelite.client.ui.overlay.infobox.Counter;
 
-@ConfigGroup("clanchat")
-public interface ClanChatConfig extends Config
+class ClanChatIndicator extends Counter
 {
-	@ConfigItem(
-		keyName = "clanChatIcons",
-		name = "Clan Chat Icons",
-		description = "Show clan chat icons next to clan members."
-	)
-	default boolean clanChatIcons()
+	private final ClanChatPlugin plugin;
+
+	ClanChatIndicator(BufferedImage image, ClanChatPlugin plugin)
 	{
-		return true;
+		super(image, plugin, plugin.getClanAmount());
+		this.plugin = plugin;
 	}
 
-	@ConfigItem(
-		keyName = "recentChats",
-		name = "Recent Chats",
-		description = "Show recent clan chats."
-	)
-	default boolean recentChats()
+	@Override
+	public int getCount()
 	{
-		return true;
+		return plugin.getClanAmount();
 	}
 
-	@ConfigItem(
-		keyName = "clanCounter",
-		name = "Clan Members Counter",
-		description = "Show the amount of clan members near you."
-	)
-	default boolean showClanCounter()
+	@Override
+	public String getTooltip()
 	{
-		return false;
+		return plugin.getClanAmount() + " clan member(s) near you";
 	}
 
-	@ConfigItem(
-		keyName = "chatsData",
-		name = "",
-		description = "",
-		hidden = true
-	)
-	default String chatsData()
+	@Override
+	public Color getTextColor()
 	{
-		return "";
+		return Color.WHITE;
 	}
-
-	@ConfigItem(
-		keyName = "chatsData",
-		name = "",
-		description = ""
-	)
-	void chatsData(String str);
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/clanchat/ClanChatPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/clanchat/ClanChatPlugin.java
@@ -149,6 +149,11 @@ public class ClanChatPlugin extends Plugin
 
 	private void insertClanRankIcon(final ChatMessage message)
 	{
+		if (!config.clanChatIcons())
+		{
+			return;
+		}
+
 		final ClanMemberRank rank = clanManager.getRank(message.getName());
 
 		if (rank != null && rank != ClanMemberRank.UNRANKED)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/clanchat/ClanChatPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/clanchat/ClanChatPlugin.java
@@ -27,6 +27,7 @@ package net.runelite.client.plugins.clanchat;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.inject.Provides;
+import java.awt.image.BufferedImage;
 import java.util.ArrayList;
 import java.util.List;
 import javax.inject.Inject;
@@ -34,19 +35,27 @@ import net.runelite.api.ChatMessageType;
 import net.runelite.api.ClanMemberRank;
 import net.runelite.api.Client;
 import net.runelite.api.GameState;
+import net.runelite.api.Player;
+import net.runelite.api.SpriteID;
 import net.runelite.api.VarClientStr;
 import net.runelite.api.events.ChatMessage;
 import net.runelite.api.events.ConfigChanged;
+import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.GameTick;
+import net.runelite.api.events.PlayerDespawned;
+import net.runelite.api.events.PlayerSpawned;
 import net.runelite.api.events.VarClientStrChanged;
 import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.api.widgets.WidgetType;
+import net.runelite.client.callback.ClientThread;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.game.ClanManager;
+import net.runelite.client.game.SpriteManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.ui.overlay.infobox.InfoBoxManager;
 import net.runelite.client.util.Text;
 
 @PluginDescriptor(
@@ -69,7 +78,18 @@ public class ClanChatPlugin extends Plugin
 	@Inject
 	private ClanChatConfig config;
 
+	@Inject
+	private InfoBoxManager infoBoxManager;
+
+	@Inject
+	private SpriteManager spriteManager;
+
+	@Inject
+	private ClientThread clientThread;
+
 	private List<String> chats = new ArrayList<>();
+	private List<Player> clanMembers = new ArrayList<>();
+	private ClanChatIndicator clanMemberCounter;
 
 	@Provides
 	ClanChatConfig getConfig(ConfigManager configManager)
@@ -86,15 +106,29 @@ public class ClanChatPlugin extends Plugin
 	@Override
 	public void shutDown()
 	{
+		clanMembers.clear();
+		removeClanCounter();
 		resetClanChats();
 	}
 
 	@Subscribe
 	public void onConfigChanged(ConfigChanged configChanged)
 	{
-		if (configChanged.getGroup().equals("clanchat") && !config.recentChats())
+		if (configChanged.getGroup().equals("clanchat"))
 		{
-			resetClanChats();
+			if (!config.recentChats())
+			{
+				resetClanChats();
+			}
+
+			if (config.showClanCounter())
+			{
+				clientThread.invoke(this::addClanCounter);
+			}
+			else
+			{
+				removeClanCounter();
+			}
 		}
 	}
 
@@ -145,6 +179,44 @@ public class ClanChatPlugin extends Plugin
 		{
 			insertClanRankIcon(chatMessage);
 		}
+	}
+
+	@Subscribe
+	public void onGameStateChanged(GameStateChanged state)
+	{
+		if (state.getGameState() == GameState.LOADING)
+		{
+			clanMembers.clear();
+			removeClanCounter();
+		}
+	}
+
+	@Subscribe
+	public void onPlayerSpawned(PlayerSpawned event)
+	{
+		if (event.getPlayer().isClanMember())
+		{
+			clanMembers.add(event.getPlayer());
+
+			if (clanMemberCounter == null)
+			{
+				addClanCounter();
+			}
+		}
+	}
+
+	@Subscribe
+	public void onPlayerDespawned(PlayerDespawned event)
+	{
+		if (clanMembers.remove(event.getPlayer()) && clanMembers.isEmpty())
+		{
+			removeClanCounter();
+		}
+	}
+
+	int getClanAmount()
+	{
+		return clanMembers.size();
 	}
 
 	private void insertClanRankIcon(final ChatMessage message)
@@ -227,5 +299,23 @@ public class ClanChatPlugin extends Plugin
 		}
 
 		config.chatsData(Text.toCSV(chats));
+	}
+
+	private void removeClanCounter()
+	{
+		infoBoxManager.removeInfoBox(clanMemberCounter);
+		clanMemberCounter = null;
+	}
+
+	private void addClanCounter()
+	{
+		if (!config.showClanCounter() || clanMemberCounter != null )
+		{
+			return;
+		}
+
+		final BufferedImage image = spriteManager.getSprite(SpriteID.TAB_CLAN_CHAT, 0);
+		clanMemberCounter = new ClanChatIndicator(image, this);
+		infoBoxManager.addInfoBox(clanMemberCounter);
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/infobox/Counter.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/infobox/Counter.java
@@ -47,7 +47,7 @@ public class Counter extends InfoBox
 	@Override
 	public String getText()
 	{
-		return Integer.toString(count);
+		return Integer.toString(getCount());
 	}
 
 	@Override


### PR DESCRIPTION
Shows amount of clan members near you (default disabled). Can be useful for when trying to know how many clan members turned up to an event, so you don't have to manually count them.
![image](https://user-images.githubusercontent.com/43320258/52214272-8a780080-2891-11e9-9e96-a90cd20a610d.png)
