### PR TITLE
Improve WSClient and party logging

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/party/PartyPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/party/PartyPlugin.java
@@ -234,8 +234,6 @@ public class PartyPlugin extends Plugin implements KeyListener
 	@Subscribe
 	public void onTilePing(TilePing event)
 	{
-		log.debug("Got tile ping {}", event);
-
 		if (config.pings())
 		{
 			pendingTilePings.add(new PartyTilePingData(event.getPoint()));

--- a/runelite-client/src/main/java/net/runelite/client/ws/PartyService.java
+++ b/runelite-client/src/main/java/net/runelite/client/ws/PartyService.java
@@ -114,7 +114,6 @@ public class PartyService
 	@Subscribe
 	public void onUserJoin(final UserJoin message)
 	{
-		log.debug("User {} joined", message);
 		final PartyMember partyMember = new PartyMember(message.getMemberId(), message.getName());
 		members.add(partyMember);
 
@@ -130,7 +129,6 @@ public class PartyService
 	@Subscribe
 	public void onUserPart(final UserPart message)
 	{
-		log.debug("User {} left", message);
 		members.removeIf(member -> member.getMemberId().equals(message.getMemberId()));
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/ws/WSClient.java
+++ b/runelite-client/src/main/java/net/runelite/client/ws/WSClient.java
@@ -173,7 +173,7 @@ public class WSClient extends WebSocketListener implements AutoCloseable
 			return;
 		}
 
-		log.debug("Got message: {}", message);
+		log.debug("Got: {}", text);
 		eventBus.post(message);
 	}
 
@@ -187,7 +187,7 @@ public class WSClient extends WebSocketListener implements AutoCloseable
 	@Override
 	public void onFailure(WebSocket webSocket, Throwable t, Response response)
 	{
-		log.warn("Error in websocket", t);
+		log.warn("Error in websocket {}:{}", response, t);
 		this.webSocket = null;
 	}
 }


### PR DESCRIPTION
- Remove duplicate logging from both WSClient and plugins listening for
incoming messages
- Log json instead of deserialized message on receiving message (because
toString might not be properly implemented)
- Log also WebSocket failed response on websocket failure

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>