### PR TITLE
fix typo SOUL_JORUNEY to SOUL_JOURNEY in Book.java from kourendlibrary plugin

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/kourendlibrary/Book.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/kourendlibrary/Book.java
@@ -59,7 +59,7 @@ enum Book
 	TRISTESSAS_TRAGEDY(ItemID.TRISTESSAS_TRAGEDY, "Tristessa's Tragedy", "The Tragedy of Tristessa."),
 	TREACHERY_OF_ROYALTY(ItemID.TREACHERY_OF_ROYALTY, "The Treachery of Royalty", "The Treachery of Royalty, by Professor Answith."),
 	TRANSPORTATION_INCANTATIONS(ItemID.TRANSPORTATION_INCANTATIONS, "Transportation Incantations", "Transportation Incantations, by Amon Ducot."),
-	SOUL_JORUNEY(ItemID.SOUL_JOURNEY, "Soul Journey", "The Journey of Souls, by Aretha."),
+	SOUL_JOURNEY(ItemID.SOUL_JOURNEY, "Soul Journey", "The Journey of Souls, by Aretha."),
 	VARLAMORE_ENVOY(ItemID.VARLAMORE_ENVOY, "Varlamore Envoy", "The Envoy to Varlamore, by Deryk Paulson.");
 
 	private static final Map<Integer, Book> BY_ID = buildById();


### PR DESCRIPTION
As requested in issue #7731

Change:
SOUL_JORUNEY(ItemID.SOUL_JOURNEY, "Soul Journey", "The Journey of Souls, by Aretha."),

To:
SOUL_JOURNEY(ItemID.SOUL_JOURNEY, "Soul Journey", "The Journey of Souls, by Aretha."),

In:
https://github.com/runelite/runelite/blob/master/runelite-client/src/main/java/net/runelite/client/plugins/kourendlibrary/Book.java