### PR TITLE
Do not draw yellow dot for local player in barrows plugin

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/barrows/BarrowsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/barrows/BarrowsOverlay.java
@@ -94,6 +94,12 @@ class BarrowsOverlay extends Overlay
 			final List<Player> players = client.getPlayers();
 			for (Player player : players)
 			{
+				if (player == local)
+				{
+					// Skip local player as we draw square for it later
+					continue;
+				}
+
 				net.runelite.api.Point minimapLocation = player.getMinimapLocation();
 				if (minimapLocation != null)
 				{


### PR DESCRIPTION
It is already drawn as white square later.

Closes #6918

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>