### PR TITLE
Add "true" tile tagging to the NPC highlight plugin

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsPlugin.java
@@ -88,6 +88,7 @@ public class NpcIndicatorsPlugin extends Plugin
 	private static final Set<MenuAction> NPC_MENU_ACTIONS = ImmutableSet.of(MenuAction.NPC_FIRST_OPTION, MenuAction.NPC_SECOND_OPTION,
 		MenuAction.NPC_THIRD_OPTION, MenuAction.NPC_FOURTH_OPTION, MenuAction.NPC_FIFTH_OPTION);
 
+
 	@Inject
 	private Client client;
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsPlugin.java
@@ -88,7 +88,6 @@ public class NpcIndicatorsPlugin extends Plugin
 	private static final Set<MenuAction> NPC_MENU_ACTIONS = ImmutableSet.of(MenuAction.NPC_FIRST_OPTION, MenuAction.NPC_SECOND_OPTION,
 		MenuAction.NPC_THIRD_OPTION, MenuAction.NPC_FOURTH_OPTION, MenuAction.NPC_FIFTH_OPTION);
 
-
 	@Inject
 	private Client client;
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcSceneOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcSceneOverlay.java
@@ -221,31 +221,4 @@ public class NpcSceneOverlay extends Overlay
 			graphics.fill(polygon);
 		}
 	}
-
-	private void drawTile(Graphics2D graphics, WorldPoint point, Color color, int outlineAlpha, int fillAlpha, int strokeWidth)
-	{
-		WorldPoint playerLocation = client.getLocalPlayer().getWorldLocation();
-		if (point.distanceTo(playerLocation) >= 32)
-		{
-			return;
-		}
-
-		LocalPoint lp = LocalPoint.fromWorld(client, point);
-		if (lp == null)
-		{
-			return;
-		}
-
-		Polygon poly = Perspective.getCanvasTilePoly(client, lp);
-		if (poly == null)
-		{
-			return;
-		}
-
-		graphics.setColor(new Color(color.getRed(), color.getGreen(), color.getBlue(), outlineAlpha));
-		graphics.setStroke(new BasicStroke(strokeWidth));
-		graphics.draw(poly);
-		graphics.setColor(new Color(color.getRed(), color.getGreen(), color.getBlue(), fillAlpha));
-		graphics.fill(poly);
-	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcSceneOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcSceneOverlay.java
@@ -111,8 +111,8 @@ public class NpcSceneOverlay extends Overlay
 		final Color color = config.getHighlightColor();
 
 		final LocalPoint centerLp = new LocalPoint(
-			lp.getX() + Perspective.LOCAL_TILE_SIZE * (npc.getNpcSize() - 1) / 2,
-			lp.getY() + Perspective.LOCAL_TILE_SIZE * (npc.getNpcSize() - 1) / 2);
+				lp.getX() + Perspective.LOCAL_TILE_SIZE * (npc.getNpcSize() - 1) / 2,
+				lp.getY() + Perspective.LOCAL_TILE_SIZE * (npc.getNpcSize() - 1) / 2);
 
 		final Polygon poly = Perspective.getCanvasTileAreaPoly(client, centerLp, npc.getNpcSize());
 
@@ -131,13 +131,13 @@ public class NpcSceneOverlay extends Overlay
 		final int textHeight = graphics.getFontMetrics().getAscent();
 
 		final Point canvasPoint = Perspective
-			.localToCanvas(client, centerLp, respawnLocation.getPlane());
+				.localToCanvas(client, centerLp, respawnLocation.getPlane());
 
 		if (canvasPoint != null)
 		{
 			final Point canvasCenterPoint = new Point(
-				canvasPoint.getX() - textWidth / 2,
-				canvasPoint.getY() + textHeight / 2);
+					canvasPoint.getX() - textWidth / 2,
+					canvasPoint.getY() + textHeight / 2);
 
 			OverlayUtil.renderTextLocation(graphics, canvasCenterPoint, timeLeftStr, TEXT_COLOR);
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcSceneOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcSceneOverlay.java
@@ -179,6 +179,19 @@ public class NpcSceneOverlay extends Overlay
 
 				renderPoly(graphics, color, objectClickbox);
 				break;
+			case TRUE_LOCATIONS:
+				size = 1;
+				composition = actor.getTransformedComposition();
+				if (composition != null)
+				{
+					size = composition.getSize();
+				}
+				WorldPoint wp = actor.getWorldLocation();
+				lp = new LocalPoint(wp.getX(), wp.getY());
+				tilePoly = Perspective.getCanvasTileAreaPoly(client, lp, size);
+
+				renderPoly(graphics, color, tilePoly);
+				break;
 		}
 
 		if (config.drawNames() && actor.getName() != null)
@@ -203,5 +216,32 @@ public class NpcSceneOverlay extends Overlay
 			graphics.setColor(new Color(color.getRed(), color.getGreen(), color.getBlue(), 20));
 			graphics.fill(polygon);
 		}
+	}
+
+	private void drawTile(Graphics2D graphics, WorldPoint point, Color color, int outlineAlpha, int fillAlpha, int strokeWidth)
+	{
+		WorldPoint playerLocation = client.getLocalPlayer().getWorldLocation();
+		if (point.distanceTo(playerLocation) >= 32)
+		{
+			return;
+		}
+
+		LocalPoint lp = LocalPoint.fromWorld(client, point);
+		if (lp == null)
+		{
+			return;
+		}
+
+		Polygon poly = Perspective.getCanvasTilePoly(client, lp);
+		if (poly == null)
+		{
+			return;
+		}
+
+		graphics.setColor(new Color(color.getRed(), color.getGreen(), color.getBlue(), outlineAlpha));
+		graphics.setStroke(new BasicStroke(strokeWidth));
+		graphics.draw(poly);
+		graphics.setColor(new Color(color.getRed(), color.getGreen(), color.getBlue(), fillAlpha));
+		graphics.fill(poly);
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcSceneOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcSceneOverlay.java
@@ -111,8 +111,8 @@ public class NpcSceneOverlay extends Overlay
 		final Color color = config.getHighlightColor();
 
 		final LocalPoint centerLp = new LocalPoint(
-			lp.getX() + Perspective.LOCAL_TILE_SIZE * (npc.getNpcSize() - 1) / 2,
-			lp.getY() + Perspective.LOCAL_TILE_SIZE * (npc.getNpcSize() - 1) / 2);
+				lp.getX() + Perspective.LOCAL_TILE_SIZE * (npc.getNpcSize() - 1) / 2,
+				lp.getY() + Perspective.LOCAL_TILE_SIZE * (npc.getNpcSize() - 1) / 2);
 
 		final Polygon poly = Perspective.getCanvasTileAreaPoly(client, centerLp, npc.getNpcSize());
 
@@ -131,13 +131,13 @@ public class NpcSceneOverlay extends Overlay
 		final int textHeight = graphics.getFontMetrics().getAscent();
 
 		final Point canvasPoint = Perspective
-			.localToCanvas(client, centerLp, respawnLocation.getPlane());
+				.localToCanvas(client, centerLp, respawnLocation.getPlane());
 
 		if (canvasPoint != null)
 		{
 			final Point canvasCenterPoint = new Point(
-				canvasPoint.getX() - textWidth / 2,
-				canvasPoint.getY() + textHeight / 2);
+					canvasPoint.getX() - textWidth / 2,
+					canvasPoint.getY() + textHeight / 2);
 
 			OverlayUtil.renderTextLocation(graphics, canvasCenterPoint, timeLeftStr, TEXT_COLOR);
 		}
@@ -187,7 +187,7 @@ public class NpcSceneOverlay extends Overlay
 					size = composition.getSize();
 				}
 				WorldPoint wp = actor.getWorldLocation();
-				lp = new LocalPoint(wp.getX(), wp.getY());
+				lp = LocalPoint.fromWorld(client, wp);
 				tilePoly = Perspective.getCanvasTileAreaPoly(client, lp, size);
 
 				renderPoly(graphics, color, tilePoly);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcSceneOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcSceneOverlay.java
@@ -36,6 +36,8 @@ import java.text.NumberFormat;
 import java.time.Instant;
 import java.util.Locale;
 import javax.inject.Inject;
+
+import jdk.vm.ci.meta.Local;
 import net.runelite.api.Client;
 import net.runelite.api.Constants;
 import net.runelite.api.NPC;
@@ -186,9 +188,13 @@ public class NpcSceneOverlay extends Overlay
 				{
 					size = composition.getSize();
 				}
-				WorldPoint wp = actor.getWorldLocation();
-				lp = LocalPoint.fromWorld(client, wp);
-				tilePoly = Perspective.getCanvasTileAreaPoly(client, lp, size);
+				WorldPoint npcWorldPoint = actor.getWorldLocation();
+				float offsetWorldPoints = ((float)size - 1) / 2;
+				int offsetLocalPoints = (int)(offsetWorldPoints * 128);
+				LocalPoint npcLocalPoint = LocalPoint.fromWorld(client, npcWorldPoint);
+				LocalPoint npcCentreLocalPoints = new LocalPoint(npcLocalPoint.getX() + offsetLocalPoints,
+						npcLocalPoint.getY() + offsetLocalPoints);
+				tilePoly = Perspective.getCanvasTileAreaPoly(client, npcCentreLocalPoints, size);
 
 				renderPoly(graphics, color, tilePoly);
 				break;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcSceneOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcSceneOverlay.java
@@ -111,8 +111,8 @@ public class NpcSceneOverlay extends Overlay
 		final Color color = config.getHighlightColor();
 
 		final LocalPoint centerLp = new LocalPoint(
-				lp.getX() + Perspective.LOCAL_TILE_SIZE * (npc.getNpcSize() - 1) / 2,
-				lp.getY() + Perspective.LOCAL_TILE_SIZE * (npc.getNpcSize() - 1) / 2);
+			lp.getX() + Perspective.LOCAL_TILE_SIZE * (npc.getNpcSize() - 1) / 2,
+			lp.getY() + Perspective.LOCAL_TILE_SIZE * (npc.getNpcSize() - 1) / 2);
 
 		final Polygon poly = Perspective.getCanvasTileAreaPoly(client, centerLp, npc.getNpcSize());
 
@@ -131,13 +131,13 @@ public class NpcSceneOverlay extends Overlay
 		final int textHeight = graphics.getFontMetrics().getAscent();
 
 		final Point canvasPoint = Perspective
-				.localToCanvas(client, centerLp, respawnLocation.getPlane());
+			.localToCanvas(client, centerLp, respawnLocation.getPlane());
 
 		if (canvasPoint != null)
 		{
 			final Point canvasCenterPoint = new Point(
-					canvasPoint.getX() - textWidth / 2,
-					canvasPoint.getY() + textHeight / 2);
+				canvasPoint.getX() - textWidth / 2,
+				canvasPoint.getY() + textHeight / 2);
 
 			OverlayUtil.renderTextLocation(graphics, canvasCenterPoint, timeLeftStr, TEXT_COLOR);
 		}
@@ -157,7 +157,6 @@ public class NpcSceneOverlay extends Overlay
 			{
 				int size = npcComposition.getSize();
 				LocalPoint localPoint = actor.getLocalLocation();
-
 				int x = localPoint.getX() - ((size - 1) * Perspective.LOCAL_TILE_SIZE / 2);
 				int y = localPoint.getY() - ((size - 1) * Perspective.LOCAL_TILE_SIZE / 2);
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcSceneOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcSceneOverlay.java
@@ -221,4 +221,31 @@ public class NpcSceneOverlay extends Overlay
 			graphics.fill(polygon);
 		}
 	}
+
+	private void drawTile(Graphics2D graphics, WorldPoint point, Color color, int outlineAlpha, int fillAlpha, int strokeWidth)
+	{
+		WorldPoint playerLocation = client.getLocalPlayer().getWorldLocation();
+		if (point.distanceTo(playerLocation) >= 32)
+		{
+			return;
+		}
+
+		LocalPoint lp = LocalPoint.fromWorld(client, point);
+		if (lp == null)
+		{
+			return;
+		}
+
+		Polygon poly = Perspective.getCanvasTilePoly(client, lp);
+		if (poly == null)
+		{
+			return;
+		}
+
+		graphics.setColor(new Color(color.getRed(), color.getGreen(), color.getBlue(), outlineAlpha));
+		graphics.setStroke(new BasicStroke(strokeWidth));
+		graphics.draw(poly);
+		graphics.setColor(new Color(color.getRed(), color.getGreen(), color.getBlue(), fillAlpha));
+		graphics.fill(poly);
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcSceneOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcSceneOverlay.java
@@ -36,6 +36,8 @@ import java.text.NumberFormat;
 import java.time.Instant;
 import java.util.Locale;
 import javax.inject.Inject;
+
+import jdk.vm.ci.meta.Local;
 import net.runelite.api.Client;
 import net.runelite.api.Constants;
 import net.runelite.api.NPC;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcSceneOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcSceneOverlay.java
@@ -36,8 +36,6 @@ import java.text.NumberFormat;
 import java.time.Instant;
 import java.util.Locale;
 import javax.inject.Inject;
-
-import jdk.vm.ci.meta.Local;
 import net.runelite.api.Client;
 import net.runelite.api.Constants;
 import net.runelite.api.NPC;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcSceneOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcSceneOverlay.java
@@ -60,7 +60,7 @@ public class NpcSceneOverlay extends Overlay
 
 	static
 	{
-		((DecimalFormat)TIME_LEFT_FORMATTER).applyPattern("#0.0");
+		((DecimalFormat) TIME_LEFT_FORMATTER).applyPattern("#0.0");
 	}
 
 	private final Client client;
@@ -111,8 +111,8 @@ public class NpcSceneOverlay extends Overlay
 		final Color color = config.getHighlightColor();
 
 		final LocalPoint centerLp = new LocalPoint(
-				lp.getX() + Perspective.LOCAL_TILE_SIZE * (npc.getNpcSize() - 1) / 2,
-				lp.getY() + Perspective.LOCAL_TILE_SIZE * (npc.getNpcSize() - 1) / 2);
+			lp.getX() + Perspective.LOCAL_TILE_SIZE * (npc.getNpcSize() - 1) / 2,
+			lp.getY() + Perspective.LOCAL_TILE_SIZE * (npc.getNpcSize() - 1) / 2);
 
 		final Polygon poly = Perspective.getCanvasTileAreaPoly(client, centerLp, npc.getNpcSize());
 
@@ -131,13 +131,13 @@ public class NpcSceneOverlay extends Overlay
 		final int textHeight = graphics.getFontMetrics().getAscent();
 
 		final Point canvasPoint = Perspective
-				.localToCanvas(client, centerLp, respawnLocation.getPlane());
+			.localToCanvas(client, centerLp, respawnLocation.getPlane());
 
 		if (canvasPoint != null)
 		{
 			final Point canvasCenterPoint = new Point(
-					canvasPoint.getX() - textWidth / 2,
-					canvasPoint.getY() + textHeight / 2);
+				canvasPoint.getX() - textWidth / 2,
+				canvasPoint.getY() + textHeight / 2);
 
 			OverlayUtil.renderTextLocation(graphics, canvasCenterPoint, timeLeftStr, TEXT_COLOR);
 		}
@@ -181,17 +181,17 @@ public class NpcSceneOverlay extends Overlay
 				break;
 			case TRUE_LOCATIONS:
 				size = 1;
-				composition = actor.getTransformedComposition();
-				if (composition != null)
+				npcComposition = actor.getTransformedComposition();
+				if (npcComposition != null)
 				{
-					size = composition.getSize();
+					size = npcComposition.getSize();
 				}
 				WorldPoint npcWorldPoint = actor.getWorldLocation();
-				float offsetWorldPoints = ((float)size - 1) / 2;
-				int offsetLocalPoints = (int)(offsetWorldPoints * 128);
+				float offsetWorldPoints = ((float) size - 1) / 2;
+				int offsetLocalPoints = (int) (offsetWorldPoints * 128);
 				LocalPoint npcLocalPoint = LocalPoint.fromWorld(client, npcWorldPoint);
 				LocalPoint npcCentreLocalPoints = new LocalPoint(npcLocalPoint.getX() + offsetLocalPoints,
-						npcLocalPoint.getY() + offsetLocalPoints);
+					npcLocalPoint.getY() + offsetLocalPoints);
 				tilePoly = Perspective.getCanvasTileAreaPoly(client, npcCentreLocalPoints, size);
 
 				renderPoly(graphics, color, tilePoly);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcSceneOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcSceneOverlay.java
@@ -217,31 +217,4 @@ public class NpcSceneOverlay extends Overlay
 			graphics.fill(polygon);
 		}
 	}
-
-	private void drawTile(Graphics2D graphics, WorldPoint point, Color color, int outlineAlpha, int fillAlpha, int strokeWidth)
-	{
-		WorldPoint playerLocation = client.getLocalPlayer().getWorldLocation();
-		if (point.distanceTo(playerLocation) >= 32)
-		{
-			return;
-		}
-
-		LocalPoint lp = LocalPoint.fromWorld(client, point);
-		if (lp == null)
-		{
-			return;
-		}
-
-		Polygon poly = Perspective.getCanvasTilePoly(client, lp);
-		if (poly == null)
-		{
-			return;
-		}
-
-		graphics.setColor(new Color(color.getRed(), color.getGreen(), color.getBlue(), outlineAlpha));
-		graphics.setStroke(new BasicStroke(strokeWidth));
-		graphics.draw(poly);
-		graphics.setColor(new Color(color.getRed(), color.getGreen(), color.getBlue(), fillAlpha));
-		graphics.fill(poly);
-	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/RenderStyle.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/RenderStyle.java
@@ -29,5 +29,6 @@ public enum RenderStyle
 	OFF,
 	TILE,
 	HULL,
-	SOUTH_WEST_TILE
+	SOUTH_WEST_TILE,
+	TRUE_LOCATIONS
 }


### PR DESCRIPTION
Indicates the true tiles that tagged NPCs are currently on. Useful for anywhere animations are staggered or generally vague.

[In action](https://streamable.com/seamx)