### PR TITLE
Make sure WorldHopperPlugin's executor is active on startup

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldHopperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldHopperPlugin.java
@@ -131,7 +131,7 @@ public class WorldHopperPlugin extends Plugin
 	@Inject
 	private WorldHopperConfig config;
 
-	private final ScheduledExecutorService hopperExecutorService = new ExecutorServiceExceptionLogger(Executors.newSingleThreadScheduledExecutor());
+	private ScheduledExecutorService hopperExecutorService;
 
 	private NavigationButton navButton;
 	private WorldSwitcherPanel panel;
@@ -201,6 +201,8 @@ public class WorldHopperPlugin extends Plugin
 		}
 
 		worldResultFuture = executorService.scheduleAtFixedRate(this::tick, 0, WORLD_FETCH_TIMER, TimeUnit.MINUTES);
+
+		hopperExecutorService = new ExecutorServiceExceptionLogger(Executors.newSingleThreadScheduledExecutor());
 		pingFuture = hopperExecutorService.scheduleAtFixedRate(this::pingWorlds, WORLD_PING_TIMER, WORLD_PING_TIMER, TimeUnit.MINUTES);
 	}
 
@@ -221,6 +223,7 @@ public class WorldHopperPlugin extends Plugin
 		clientToolbar.removeNavigation(navButton);
 
 		hopperExecutorService.shutdown();
+		hopperExecutorService = null;
 	}
 
 	@Subscribe


### PR DESCRIPTION
Fixes #6923

We can't submit tasks to shutdown Executors. These need to be recreated
on startup