### PR TITLE
Migrate onSetMessage to onChatMessage

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/wintertodt/WintertodtPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/wintertodt/WintertodtPlugin.java
@@ -206,7 +206,7 @@ public class WintertodtPlugin extends Plugin
 	}
 
 	@Subscribe
-	public void onSetMessage(ChatMessage chatMessage)
+	public void onChatMessage(ChatMessage chatMessage)
 	{
 		if (!isInWintertodt)
 		{

--- a/runelite-client/src/test/java/net/runelite/client/plugins/chatnotifications/ChatNotificationsPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/chatnotifications/ChatNotificationsPluginTest.java
@@ -76,7 +76,7 @@ public class ChatNotificationsPluginTest
 	}
 
 	@Test
-	public void onSetMessage()
+	public void onChatMessage()
 	{
 		when(config.highlightWordsString()).thenReturn("Deathbeam, Deathbeam OSRS , test");
 


### PR DESCRIPTION
These were probably just missed. They cause warnings in the console and
make it so the Wintertodt plugin doesn't start

Stack trace below:
```
2019-02-07 23:02:12 [main] WARN  n.r.client.plugins.PluginManager - Unable to start plugin WintertodtPlugin. {}
net.runelite.client.plugins.PluginInstantiationException: java.lang.IllegalArgumentException: Subscribed method public void net.runelite.client.plugins.wintertodt.WintertodtPlugin.onSetMessage(net.runelite.api.events.ChatMessage) should be named onChatMessage
	at net.runelite.client.plugins.PluginManager.startPlugin(PluginManager.java:342)
	at net.runelite.client.plugins.PluginManager.startCorePlugins(PluginManager.java:207)
	at net.runelite.client.RuneLite.start(RuneLite.java:296)
	at net.runelite.client.RuneLite.main(RuneLite.java:221)
Caused by: java.lang.IllegalArgumentException: Subscribed method public void net.runelite.client.plugins.wintertodt.WintertodtPlugin.onSetMessage(net.runelite.api.events.ChatMessage) should be named onChatMessage
	at com.google.common.base.Preconditions.checkArgument(Preconditions.java:135)
	at net.runelite.client.eventbus.EventBus.register(EventBus.java:137)
	at net.runelite.client.plugins.PluginManager.startPlugin(PluginManager.java:336)
	... 3 common frames omitted
```