### PR TITLE
client: notification flash during login only

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/Notifier.java
+++ b/runelite-client/src/main/java/net/runelite/client/Notifier.java
@@ -154,13 +154,13 @@ public class Notifier
 
 	public void processFlash(final Graphics2D graphics)
 	{
-		if (flashStart == null)
+		if (flashStart == null || client.getGameCycle() % 40 >= 20)
 		{
 			return;
 		}
-
-		if (client.getGameCycle() % 40 >= 20)
+		else if (client.getGameState() != GameState.LOGGED_IN)
 		{
+			flashStart = null;
 			return;
 		}
 


### PR DESCRIPTION
Make notifications only flash during the LOGGED_IN GameState

Fixes #7316 