### PR TITLE
Clear Cerberus ghost on LOADING game state

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/cerberus/CerberusPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cerberus/CerberusPlugin.java
@@ -75,7 +75,7 @@ public class CerberusPlugin extends Plugin
 	@Subscribe
 	public void onGameStateChanged(GameStateChanged event)
 	{
-		if (event.getGameState() == GameState.LOGIN_SCREEN || event.getGameState() == GameState.HOPPING)
+		if (event.getGameState() == GameState.LOADING)
 		{
 			ghosts.clear();
 		}


### PR DESCRIPTION
When leaving the are with cerberus ghosts player will not receive
despawn events for them and so they will be stuck (they are just GCed
later instead). This solves the issue and goes in line with rest of
logic we have that relies on spawn/despawn events.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>