### PR TITLE
client: add right click only tooltips toggle

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/mousehighlight/MouseHighlightConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/mousehighlight/MouseHighlightConfig.java
@@ -52,4 +52,12 @@ public interface MouseHighlightConfig extends Config
 	{
 		return true;
 	}
+
+	@ConfigItem(
+			position = 2,
+			keyName = "rightclickoptionTooltip",
+			name = "Right Click Option Tooltips",
+			description = "Whether or not tooltips are shown for options that right-click only."
+	)
+	default boolean isRightClickTooltipEnabled() { return false; }
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/mousehighlight/MouseHighlightOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/mousehighlight/MouseHighlightOverlay.java
@@ -75,7 +75,7 @@ class MouseHighlightOverlay extends Overlay
 		String option = menuEntry.getOption();
 		int type = menuEntry.getType();
 
-		if (type == MenuAction.RUNELITE_OVERLAY.getId() || type == MenuAction.EXAMINE_ITEM_BANK_EQ.getId())
+		if (!config.isRightClickTooltipEnabled() && isMenuActionRightClickOnly(type))
 		{
 			// These are always right click only
 			return null;
@@ -135,5 +135,10 @@ class MouseHighlightOverlay extends Overlay
 
 		tooltipManager.addFront(new Tooltip(option + (Strings.isNullOrEmpty(target) ? "" : " " + target)));
 		return null;
+	}
+
+	private boolean isMenuActionRightClickOnly(int type) {
+		return type == MenuAction.RUNELITE_OVERLAY.getId()
+				|| type == MenuAction.EXAMINE_ITEM_BANK_EQ.getId();
 	}
 }


### PR DESCRIPTION
A toggle for right-click-only option tooltips has been added to MouseHighlightConfig

Fixes #7770