### PR TITLE
client: fix sticky WASDCamera keys

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/wasdcamera/WASDCameraListener.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/wasdcamera/WASDCameraListener.java
@@ -137,7 +137,9 @@ class WASDCameraListener extends MouseAdapter implements KeyListener
 	@Override
 	public void keyReleased(KeyEvent e)
 	{
-		if (client.getGameState() != GameState.LOGGED_IN)
+		if (client.getGameState() == GameState.LOGIN_SCREEN
+			|| client.getGameState() == GameState.STARTING
+			|| client.getGameState() == GameState.UNKNOWN)
 		{
 			return;
 		}


### PR DESCRIPTION
Release WASDCamera keys in all GameStates except LOGIN_SCREEN, STARTING, and UNKOWN states.

* Possible fix for issue #7438

I was unable to reproduce the sticky keys described once the WASDCameraListener was releasing keys during the LOADING GameState.

My testing wasn't very thorough and I was loading regions very quickly, so it was hard to time the key release perfectly with the game loading. Please let me know if the bug still exists!