### PR TITLE
Remove mustBeLoggedIn from client#isFriended

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/Client.java
+++ b/runelite-api/src/main/java/net/runelite/api/Client.java
@@ -1033,13 +1033,12 @@ public interface Client extends GameEngine
 	String[] getStringStack();
 
 	/**
-	 * Checks whether a player is on the friends list.
+	 * Checks whether a player is on the friends list and online.
 	 *
 	 * @param name the name of the player
-	 * @param mustBeLoggedIn if they player is online
 	 * @return true if the player is friends
 	 */
-	boolean isFriended(String name, boolean mustBeLoggedIn);
+	boolean isFriended(String name);
 
 	/**
 	 * Gets the number of players in the clan chat.

--- a/runelite-client/src/main/java/net/runelite/client/chat/ChatMessageManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/chat/ChatMessageManager.java
@@ -125,7 +125,7 @@ public class ChatMessageManager
 			case PUBLIC:
 			case PUBLIC_MOD:
 			{
-				boolean isFriend = client.isFriended(chatMessage.getName(), true) && !client.getLocalPlayer().getName().equals(chatMessage.getName());
+				boolean isFriend = client.isFriended(chatMessage.getName()) && !client.getLocalPlayer().getName().equals(chatMessage.getName());
 
 				if (isFriend)
 				{

--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSClientMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSClientMixin.java
@@ -692,10 +692,10 @@ public abstract class RSClientMixin implements RSClient
 
 	@Inject
 	@Override
-	public boolean isFriended(String name, boolean mustBeLoggedIn)
+	public boolean isFriended(String name)
 	{
 		RSName rsName = createName(name, getLoginType());
-		return getFriendManager().isFriended(rsName, mustBeLoggedIn);
+		return getFriendManager().isFriended(rsName, true);
 	}
 
 	@Inject


### PR DESCRIPTION
Always use mustBeLoggedIn true when checking if passed name is friend.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>