### PR TITLE
Fix DecorativeObject ConvexHulls

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/DecorativeObject.java
+++ b/runelite-api/src/main/java/net/runelite/api/DecorativeObject.java
@@ -38,6 +38,7 @@ public interface DecorativeObject extends TileObject
 	 * @see net.runelite.api.model.Jarvis
 	 */
 	Polygon getConvexHull();
+	Polygon getConvexHull2();
 
 	Renderable getRenderable();
 	Renderable getRenderable2();

--- a/runelite-client/src/main/java/net/runelite/client/plugins/devtools/DevToolsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/devtools/DevToolsOverlay.java
@@ -347,6 +347,12 @@ class DevToolsOverlay extends Overlay
 			{
 				graphics.drawPolygon(p);
 			}
+
+			p = decorObject.getConvexHull2();
+			if (p != null)
+			{
+				graphics.drawPolygon(p);
+			}
 		}
 	}
 

--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSDecorativeObjectMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSDecorativeObjectMixin.java
@@ -83,6 +83,29 @@ public abstract class RSDecorativeObjectMixin implements RSDecorativeObject
 	}
 
 	@Inject
+	private RSModel getModel2()
+	{
+		RSRenderable renderable = getRenderable2();
+		if (renderable == null)
+		{
+			return null;
+		}
+
+		RSModel model;
+
+		if (renderable instanceof Model)
+		{
+			model = (RSModel) renderable;
+		}
+		else
+		{
+			model = renderable.getModel();
+		}
+
+		return model;
+	}
+
+	@Inject
 	@Override
 	public Area getClickbox()
 	{
@@ -100,6 +123,20 @@ public abstract class RSDecorativeObjectMixin implements RSDecorativeObject
 			return null;
 		}
 
-		return model.getConvexHull(getX(), getY(), getOrientation());
+		return model.getConvexHull(getX() + getXOffset(), getY() + getYOffset(), 0);
+	}
+
+	@Inject
+	@Override
+	public Polygon getConvexHull2()
+	{
+		RSModel model = getModel2();
+
+		if (model == null)
+		{
+			return null;
+		}
+
+		return model.getConvexHull(getX(), getY(), 0);
 	}
 }

--- a/runescape-api/src/main/java/net/runelite/rs/api/RSDecorativeObject.java
+++ b/runescape-api/src/main/java/net/runelite/rs/api/RSDecorativeObject.java
@@ -39,6 +39,12 @@ public interface RSDecorativeObject extends DecorativeObject
 	@Import("y")
 	int getY();
 
+	@Import("offsetX")
+	int getXOffset();
+
+	@Import("offsetY")
+	int getYOffset();
+
 	@Import("rotation")
 	int getOrientation();
 


### PR DESCRIPTION
There are a number of things wrong with the way we do it now
1) There are up to 2 models in each `DecorativeObject`, so we have to have a `getConvexHull` method for each of them. Both models must be from the same ObjectComposition, but have different rotations.
2) `renderable1` gets offset by `offset[XY]`
3) `DecorativeObject::rotation` is not the 0-2048 "JAU" rotation, but the 0-8 type rotation
4) The rotation is baked into the model, and does not need to be accounted for by `Model::getConvexHull`