### PR TITLE
metronome plugin: allow metronome to play sound effects while volume is muted

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/Client.java
+++ b/runelite-api/src/main/java/net/runelite/api/Client.java
@@ -983,6 +983,15 @@ public interface Client extends GameEngine
 	void playSoundEffect(int id, int x, int y, int range, int delay);
 
 	/**
+	 * Plays a sound effect, even if the player's sound effect volume is muted.
+	 *
+	 * @param id     the ID of the sound effect - {@link SoundEffectID}
+	 * @param volume the volume to play the sound effect at, see {@link SoundEffectVolume} for values used
+	 *               in the settings interface. if the sound effect volume is not muted, uses the set volume
+	 */
+	void playSoundEffect(int id, int volume);
+
+	/**
 	 * Gets the clients graphic buffer provider.
 	 *
 	 * @return the buffer provider

--- a/runelite-api/src/main/java/net/runelite/api/SoundEffectVolume.java
+++ b/runelite-api/src/main/java/net/runelite/api/SoundEffectVolume.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, SomeoneWithAnInternetConnection
+ * Copyright (c) 2018, trimbe <github.com/trimbe>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -22,12 +22,16 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package net.runelite.rs.api;
+package net.runelite.api;
 
-import net.runelite.mapping.Import;
-
-public interface RSSoundEffect
+/**
+ * Volume values for each of the stops on the volume interface
+ */
+public final class SoundEffectVolume
 {
-	@Import("toRawAudioNode")
-	RSRawAudioNode toRawAudioNode();
+	public static final int MUTED = 0;
+	public static final int LOW = 32;
+	public static final int MEDIUM_LOW = 64;
+	public static final int MEDIUM_HIGH = 96;
+	public static final int HIGH = 127;
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/metronome/MetronomePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/metronome/MetronomePlugin.java
@@ -27,6 +27,7 @@ package net.runelite.client.plugins.metronome;
 
 import com.google.inject.Provides;
 import javax.inject.Inject;
+import net.runelite.api.SoundEffectVolume;
 import net.runelite.api.Client;
 import net.runelite.api.SoundEffectID;
 import net.runelite.api.events.GameTick;
@@ -70,11 +71,11 @@ public class MetronomePlugin extends Plugin
 		{
 			if (config.enableTock() && shouldTock)
 			{
-				client.playSoundEffect(SoundEffectID.GE_DECREMENT_PLOP);
+				client.playSoundEffect(SoundEffectID.GE_DECREMENT_PLOP, SoundEffectVolume.MEDIUM_HIGH);
 			}
 			else
 			{
-				client.playSoundEffect(SoundEffectID.GE_INCREMENT_PLOP);
+				client.playSoundEffect(SoundEffectID.GE_INCREMENT_PLOP, SoundEffectVolume.MEDIUM_HIGH);
 			}
 			shouldTock = !shouldTock;
 		}

--- a/runescape-api/src/main/java/net/runelite/rs/api/RSAudioTaskNode.java
+++ b/runescape-api/src/main/java/net/runelite/rs/api/RSAudioTaskNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, SomeoneWithAnInternetConnection
+ * Copyright (c) 2018, trimbe <github.com/trimbe>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -26,8 +26,8 @@ package net.runelite.rs.api;
 
 import net.runelite.mapping.Import;
 
-public interface RSSoundEffect
+public interface RSAudioTaskNode
 {
-	@Import("toRawAudioNode")
-	RSRawAudioNode toRawAudioNode();
+	@Import("setNumLoops")
+	void setNumLoops(int numLoops);
 }

--- a/runescape-api/src/main/java/net/runelite/rs/api/RSAudioTaskNodeQueue.java
+++ b/runescape-api/src/main/java/net/runelite/rs/api/RSAudioTaskNodeQueue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, SomeoneWithAnInternetConnection
+ * Copyright (c) 2018, trimbe <github.com/trimbe>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -26,8 +26,8 @@ package net.runelite.rs.api;
 
 import net.runelite.mapping.Import;
 
-public interface RSSoundEffect
+public interface RSAudioTaskNodeQueue
 {
-	@Import("toRawAudioNode")
-	RSRawAudioNode toRawAudioNode();
+	@Import("queueAudioTaskNode")
+	void queueAudioTaskNode(RSTaskDataNode taskDataNode);
 }

--- a/runescape-api/src/main/java/net/runelite/rs/api/RSClient.java
+++ b/runescape-api/src/main/java/net/runelite/rs/api/RSClient.java
@@ -564,6 +564,9 @@ public interface RSClient extends RSGameEngine, Client
 	@Import("queuedSoundEffectCount")
 	void setQueuedSoundEffectCount(int queuedSoundEffectCount);
 
+	@Import("queueSoundEffect")
+	void queueSoundEffect(int id, int numLoops, int delay);
+
 	@Import("rasterProvider")
 	@Override
 	RSBufferProvider getBufferProvider();
@@ -986,4 +989,22 @@ public interface RSClient extends RSGameEngine, Client
 
 	@Import("healthBarSpriteCache")
 	RSNodeCache getHealthBarSpriteCache();
+
+	@Import("getTrack")
+	RSSoundEffect getTrack(RSIndexData indexData, int id, int var0);
+
+	@Import("createSoundEffectAudioTaskNode")
+	RSAudioTaskNode createSoundEffectAudioTaskNode(RSRawAudioNode audioNode, int var0, int volume);
+
+	@Import("soundEffectAudioQueue")
+	RSAudioTaskNodeQueue getSoundEffectAudioQueue();
+
+	@Import("indexCache4")
+	RSIndexData getIndexCache4();
+
+	@Import("soundEffectResampler")
+	RSResampler getSoundEffectResampler();
+
+	@Import("soundEffectVolume")
+	int getSoundEffectVolume();
 }

--- a/runescape-api/src/main/java/net/runelite/rs/api/RSRawAudioNode.java
+++ b/runescape-api/src/main/java/net/runelite/rs/api/RSRawAudioNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, SomeoneWithAnInternetConnection
+ * Copyright (c) 2018, trimbe <github.com/trimbe>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -26,8 +26,8 @@ package net.runelite.rs.api;
 
 import net.runelite.mapping.Import;
 
-public interface RSSoundEffect
+public interface RSRawAudioNode
 {
-	@Import("toRawAudioNode")
-	RSRawAudioNode toRawAudioNode();
+	@Import("applyResampler")
+	RSRawAudioNode applyResampler(RSResampler resampler);
 }

--- a/runescape-api/src/main/java/net/runelite/rs/api/RSResampler.java
+++ b/runescape-api/src/main/java/net/runelite/rs/api/RSResampler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, SomeoneWithAnInternetConnection
+ * Copyright (c) 2018, trimbe <github.com/trimbe>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -24,10 +24,6 @@
  */
 package net.runelite.rs.api;
 
-import net.runelite.mapping.Import;
-
-public interface RSSoundEffect
+public interface RSResampler
 {
-	@Import("toRawAudioNode")
-	RSRawAudioNode toRawAudioNode();
 }

--- a/runescape-api/src/main/java/net/runelite/rs/api/RSTaskDataNode.java
+++ b/runescape-api/src/main/java/net/runelite/rs/api/RSTaskDataNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, SomeoneWithAnInternetConnection
+ * Copyright (c) 2018, trimbe <github.com/trimbe>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -24,10 +24,6 @@
  */
 package net.runelite.rs.api;
 
-import net.runelite.mapping.Import;
-
-public interface RSSoundEffect
+public interface RSTaskDataNode
 {
-	@Import("toRawAudioNode")
-	RSRawAudioNode toRawAudioNode();
 }


### PR DESCRIPTION
Closes #530 
Depends on !47

Manually queues sound effects, bypassing the volume check the vanilla client normally does. 

Currently uses a medium high volume (2nd to last pip on the slider) but it may be more desirable to have this configurable or a different volume, not sure. 