### PR TITLE
Add nexus menu swap option to menu entry swapper

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -271,4 +271,14 @@ public interface MenuEntrySwapperConfig extends Config
 	{
 		return true;
 	}
+
+	@ConfigItem(
+		keyName = "swapNexus",
+		name = "Portal Nexus",
+		description = "Makes the teleport menu have priority over the left click destination on the portal nexus"
+	)
+	default boolean swapNexus()
+	{
+		return true;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -542,6 +542,18 @@ public class MenuEntrySwapperPlugin extends Plugin
 		{
 			swap("use", option, target, true);
 		}
+		else if (config.swapNexus() && target.equals("portal nexus") && option.equals("examine")) //examine is added last
+		{
+			MenuEntry[] entries = client.getMenuEntries();
+			int teleMenuIdx = searchIndex(entries, "teleport menu", target, true);
+			int examineIdx = searchIndex(entries, option, target, true);
+
+			if (teleMenuIdx + 2 == examineIdx)
+			{
+				String optionToSwap = Text.removeTags(entries[examineIdx].getOption()).toLowerCase();
+				swap("teleport menu", optionToSwap, target, true);
+			}
+		}
 	}
 
 	@Subscribe


### PR DESCRIPTION
Adds the option to swap the left click destination for the teleport nexus with the teleport menu option. This means you can still teleport to your selected destination faster if you right click, instead of completely removing the menu option like currently in game.