### PR TITLE
Prevent screenshot overwriting

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
@@ -41,10 +41,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.lang.reflect.InvocationTargetException;
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
-import java.time.LocalDate;
-import java.util.Date;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.EnumSet;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Consumer;
@@ -118,7 +116,7 @@ public class ScreenshotPlugin extends Plugin
 	private static final HttpUrl IMGUR_IMAGE_UPLOAD_URL = HttpUrl.parse("https://api.imgur.com/3/image");
 	private static final MediaType JSON = MediaType.parse("application/json");
 
-	private static final DateFormat TIME_FORMAT = new SimpleDateFormat("yyyy-MM-dd_HH-mm-ss");
+	private static final DateTimeFormatter TIME_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd_HH-mm-ss");
 
 	private static final Pattern NUMBER_PATTERN = Pattern.compile("([0-9]+)");
 	private static final Pattern LEVEL_UP_PATTERN = Pattern.compile(".*Your ([a-zA-Z]+) (?:level is|are)? now (\\d+)\\.");
@@ -130,11 +128,11 @@ public class ScreenshotPlugin extends Plugin
 		"You feel something weird sneaking into your backpack",
 		"You have a funny feeling like you would have been followed");
 
-	static String format(Date date)
+	static String format(LocalDateTime date)
 	{
 		synchronized (TIME_FORMAT)
 		{
-			return TIME_FORMAT.format(date);
+			return date.format(TIME_FORMAT);
 		}
 	}
 
@@ -192,7 +190,7 @@ public class ScreenshotPlugin extends Plugin
 		@Override
 		public void hotkeyPressed()
 		{
-			takeScreenshot(format(new Date()));
+			takeScreenshot(format(LocalDateTime.now()));
 		}
 	};
 
@@ -215,7 +213,7 @@ public class ScreenshotPlugin extends Plugin
 			.tab(false)
 			.tooltip("Take screenshot")
 			.icon(iconImage)
-			.onClick(() -> takeScreenshot(format(new Date())))
+			.onClick(() -> takeScreenshot(format(LocalDateTime.now())))
 			.popup(ImmutableMap
 				.<String, Runnable>builder()
 				.put("Open screenshot folder...", () ->
@@ -266,17 +264,17 @@ public class ScreenshotPlugin extends Plugin
 		String fileName = null;
 		if (client.getWidget(WidgetInfo.LEVEL_UP_LEVEL) != null)
 		{
-			fileName = parseLevelUpWidget(WidgetInfo.LEVEL_UP_LEVEL);
+			fileName = parseLevelUpWidget(WidgetInfo.LEVEL_UP_LEVEL) + " " + format(LocalDateTime.now());
 		}
 		else if (client.getWidget(WidgetInfo.DIALOG_SPRITE_TEXT) != null)
 		{
-			fileName = parseLevelUpWidget(WidgetInfo.DIALOG_SPRITE_TEXT);
+			fileName = parseLevelUpWidget(WidgetInfo.DIALOG_SPRITE_TEXT) + " " + format(LocalDateTime.now());
 		}
 		else if (client.getWidget(WidgetInfo.QUEST_COMPLETED_NAME_TEXT) != null)
 		{
 			// "You have completed The Corsair Curse!"
 			String text = client.getWidget(WidgetInfo.QUEST_COMPLETED_NAME_TEXT).getText();
-			fileName = "Quest(" + text.substring(19, text.length() - 1) + ")";
+			fileName = "Quest(" + text.substring(19, text.length() - 1) + ") " + format(LocalDateTime.now());
 		}
 
 		if (fileName != null)
@@ -290,7 +288,7 @@ public class ScreenshotPlugin extends Plugin
 	{
 		if (config.screenshotPlayerDeath())
 		{
-			takeScreenshot("Death " + format(new Date()));
+			takeScreenshot("Death " + format(LocalDateTime.now()));
 		}
 	}
 
@@ -301,7 +299,7 @@ public class ScreenshotPlugin extends Plugin
 		{
 			final Player player = playerLootReceived.getPlayer();
 			final String name = player.getName();
-			String fileName = "Kill " + name + " " + format(new Date());
+			String fileName = "Kill " + name + " " + format(LocalDateTime.now());
 			takeScreenshot(fileName);
 		}
 	}
@@ -359,7 +357,7 @@ public class ScreenshotPlugin extends Plugin
 
 		if (config.screenshotPet() && PET_MESSAGES.stream().anyMatch(chatMessage::contains))
 		{
-			String fileName = "Pet " + format(new Date());
+			String fileName = "Pet " + format(LocalDateTime.now());
 			takeScreenshot(fileName);
 		}
 
@@ -370,7 +368,7 @@ public class ScreenshotPlugin extends Plugin
 			{
 				String bossName = m.group(1);
 				String bossKillcount = m.group(2);
-				String fileName = bossName + "(" + bossKillcount + ")";
+				String fileName = bossName + "(" + bossKillcount + ") " + format(LocalDateTime.now());
 				takeScreenshot(fileName);
 			}
 		}
@@ -381,7 +379,7 @@ public class ScreenshotPlugin extends Plugin
 			if (m.matches())
 			{
 				String valuableDropName = m.group(1);
-				String fileName = "Valuable drop " + valuableDropName + " " + format(new Date());
+				String fileName = "Valuable drop " + valuableDropName + " " + format(LocalDateTime.now());
 				takeScreenshot(fileName);
 			}
 		}
@@ -392,7 +390,7 @@ public class ScreenshotPlugin extends Plugin
 			if (m.matches())
 			{
 				String untradeableDropName = m.group(1);
-				String fileName = "Untradeable drop " + untradeableDropName + " " + format(new Date());
+				String fileName = "Untradeable drop " + untradeableDropName + " " + format(LocalDateTime.now());
 				takeScreenshot(fileName);
 			}
 		}
@@ -404,7 +402,7 @@ public class ScreenshotPlugin extends Plugin
 			{
 				String result = m.group(1);
 				String count = m.group(2);
-				String fileName = "Duel " + result + " (" + count + ")";
+				String fileName = "Duel " + result + " (" + count + ") " + format(LocalDateTime.now());
 				takeScreenshot(fileName);
 			}
 		}
@@ -447,8 +445,7 @@ public class ScreenshotPlugin extends Plugin
 		{
 			case KINGDOM_GROUP_ID:
 			{
-				fileName = "Kingdom " + LocalDate.now();
-				takeScreenshot(fileName);
+				fileName = "Kingdom " + format(LocalDateTime.now());
 				break;
 			}
 			case CHAMBERS_OF_XERIC_REWARD_GROUP_ID:
@@ -458,7 +455,7 @@ public class ScreenshotPlugin extends Plugin
 					return;
 				}
 
-				fileName = "Chambers of Xeric(" + chambersOfXericNumber + ")";
+				fileName = "Chambers of Xeric(" + chambersOfXericNumber + ") " + format(LocalDateTime.now());
 				chambersOfXericNumber = null;
 				break;
 			}
@@ -469,7 +466,7 @@ public class ScreenshotPlugin extends Plugin
 					return;
 				}
 
-				fileName = "Theatre of Blood(" + theatreOfBloodNumber + ")";
+				fileName = "Theatre of Blood(" + theatreOfBloodNumber + ") " + format(LocalDateTime.now());
 				theatreOfBloodNumber = null;
 				break;
 			}
@@ -480,7 +477,7 @@ public class ScreenshotPlugin extends Plugin
 					return;
 				}
 
-				fileName = "Barrows(" + barrowsNumber + ")";
+				fileName = "Barrows(" + barrowsNumber + ") " + format(LocalDateTime.now());
 				barrowsNumber = null;
 				break;
 			}
@@ -499,7 +496,7 @@ public class ScreenshotPlugin extends Plugin
 					return;
 				}
 
-				fileName = Character.toUpperCase(clueType.charAt(0)) + clueType.substring(1) + "(" + clueNumber + ")";
+				fileName = Character.toUpperCase(clueType.charAt(0)) + clueType.substring(1) + "(" + clueNumber + ") " + format(LocalDateTime.now());
 				clueType = null;
 				clueNumber = null;
 				break;


### PR DESCRIPTION
Closes #7840
The current datetime was not being appended to every screenshot filename, resulting in overwritten screenshots. This commit adds missing datetime values to filenames and switches to the local datetime, which should be more meaningful to the user than UTC.
 - Use LocalDateTime API and DateTimeFormatter
 - Append missing formatted date to file name strings
 - Remove duplicate call to takeScreenshot