### PR TITLE
Use default PanelComponent size in Cooking plugin

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/cooking/CookingOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cooking/CookingOverlay.java
@@ -78,7 +78,6 @@ class CookingOverlay extends Overlay
 			return null;
 		}
 
-		panelComponent.setPreferredSize(new Dimension(145, 0));
 		panelComponent.getChildren().clear();
 
 		if (isCooking() || Duration.between(session.getLastCookingAction(), Instant.now()).getSeconds() < COOK_TIMEOUT)


### PR DESCRIPTION
So it is consistent with rest of plugins, mainly session ones.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>