### PR TITLE
Null-check cache when getting items in http service

### DIFF
--- a/http-service/src/main/java/net/runelite/http/service/cache/CacheService.java
+++ b/http-service/src/main/java/net/runelite/http/service/cache/CacheService.java
@@ -41,6 +41,7 @@ import java.io.InputStream;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.cache.ConfigType;
@@ -233,6 +234,11 @@ public class CacheService
 	public List<ItemDefinition> getItems() throws IOException
 	{
 		CacheEntry cache = findMostRecent();
+		if (cache == null)
+		{
+			return Collections.emptyList();
+		}
+
 		IndexEntry indexEntry = findIndexForCache(cache, IndexType.CONFIGS.getNumber());
 		ArchiveEntry archiveEntry = findArchiveForIndex(indexEntry, ConfigType.ITEM.getId());
 		ArchiveFiles archiveFiles = getArchiveFiles(archiveEntry);

--- a/http-service/src/main/java/net/runelite/http/service/item/ItemService.java
+++ b/http-service/src/main/java/net/runelite/http/service/item/ItemService.java
@@ -489,10 +489,16 @@ public class ItemService
 	public void reloadItems() throws IOException
 	{
 		List<ItemDefinition> items = cacheService.getItems();
+		if (items.isEmpty())
+		{
+			log.warn("Failed to load any items from cache, item price updating will be disabled");
+		}
+
 		tradeableItems = items.stream()
 			.filter(item -> item.isTradeable)
 			.mapToInt(item -> item.id)
 			.toArray();
+
 		log.debug("Loaded {} tradeable items", tradeableItems.length);
 	}
 


### PR DESCRIPTION
It is not very useful exception and cache entry is null-checked everywhere else. Replace the exception with simple warning in logs.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>

Exception:
```
java.lang.NullPointerException: null
        at net.runelite.http.service.cache.CacheDAO.findIndexForCache(CacheDAO.java:63) ~[classes!/:na]
        at net.runelite.http.service.cache.CacheService.findIndexForCache(CacheService.java:199) ~[classes!/:na]
        at net.runelite.http.service.cache.CacheService.getItems(CacheService.java:236) ~[classes!/:na]
        at net.runelite.http.service.item.ItemService.reloadItems(ItemService.java:491) ~[classes!/:na]
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[na:1.8.0_191]
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[na:1.8.0_191]
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:1.8.0_191]
        at java.lang.reflect.Method.invoke(Method.java:498) ~[na:1.8.0_191]
        at org.springframework.scheduling.support.ScheduledMethodRunnable.run(ScheduledMethodRunnable.java:65) ~[spring-context-4.3.10.RELEASE.jar!/:4.3.10.RELEASE]
        at org.springframework.scheduling.support.DelegatingErrorHandlingRunnable.run(DelegatingErrorHandlingRunnable.java:54) ~[spring-context-4.3.10.RELEASE.jar!/:4.3.10.RELEASE]
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) [na:1.8.0_191]
        at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:308) [na:1.8.0_191]
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$301(ScheduledThreadPoolExecutor.java:180) [na:1.8.0_191]
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:294) [na:1.8.0_191]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [na:1.8.0_191]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [na:1.8.0_191]
        at java.lang.Thread.run(Thread.java:748) [na:1.8.0_191]
```