### PR TITLE
Log only exception message on feed lookup failures

### DIFF
--- a/http-service/src/main/java/net/runelite/http/service/feed/FeedController.java
+++ b/http-service/src/main/java/net/runelite/http/service/feed/FeedController.java
@@ -71,7 +71,7 @@ public class FeedController
 		}
 		catch (IOException e)
 		{
-			log.warn(null, e);
+			log.warn(e.getMessage());
 		}
 
 		try
@@ -80,7 +80,7 @@ public class FeedController
 		}
 		catch (IOException e)
 		{
-			log.warn(null, e);
+			log.warn(e.getMessage());
 		}
 
 		try
@@ -89,7 +89,7 @@ public class FeedController
 		}
 		catch (IOException e)
 		{
-			log.warn(null, e);
+			log.warn(e.getMessage());
 		}
 
 		feedResult = new FeedResult(items);


### PR DESCRIPTION
Seeing same exceptions over and over again is not very useful, mainly
when their stacktraces are not useful too.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>