### PR TITLE
Ignore instant as input to loot tracker

### DIFF
--- a/http-service/src/main/java/net/runelite/http/service/loottracker/LootRequest.java
+++ b/http-service/src/main/java/net/runelite/http/service/loottracker/LootRequest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2019, Tomas Slusny <slusnucky@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.http.service.loottracker;
+
+import java.util.Collection;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import net.runelite.http.api.loottracker.GameItem;
+import net.runelite.http.api.loottracker.LootRecordType;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class LootRequest
+{
+	private String eventId;
+	private LootRecordType type;
+	private Collection<GameItem> drops;
+}

--- a/http-service/src/main/java/net/runelite/http/service/loottracker/LootTrackerController.java
+++ b/http-service/src/main/java/net/runelite/http/service/loottracker/LootTrackerController.java
@@ -52,7 +52,7 @@ public class LootTrackerController
 	private AuthFilter auth;
 
 	@RequestMapping(method = RequestMethod.POST)
-	public void storeLootRecord(HttpServletRequest request, HttpServletResponse response, @RequestBody LootRecord record) throws IOException
+	public void storeLootRecord(HttpServletRequest request, HttpServletResponse response, @RequestBody LootRequest record) throws IOException
 	{
 		SessionEntry e = auth.handle(request, response);
 		if (e == null)

--- a/http-service/src/main/java/net/runelite/http/service/loottracker/LootTrackerService.java
+++ b/http-service/src/main/java/net/runelite/http/service/loottracker/LootTrackerService.java
@@ -92,7 +92,7 @@ public class LootTrackerService
 	 * @param record    LootRecord to store
 	 * @param accountId runelite account id to tie data too
 	 */
-	public void store(LootRecord record, int accountId)
+	public void store(LootRequest record, int accountId)
 	{
 		try (Connection con = sql2o.beginTransaction())
 		{


### PR DESCRIPTION
Deserializer used in Spring is unable to deserialize Instant.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>