### PR TITLE
mixins: Include game crash string in log

### DIFF
--- a/runelite-mixins/src/main/java/net/runelite/mixins/ProcessClientErrorMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/ProcessClientErrorMixin.java
@@ -55,7 +55,7 @@ public abstract class ProcessClientErrorMixin implements RSClient
 				throwableToScan = ((RSRunException) throwable).getParent();
 			}
 
-			client.getLogger().error("Game crash", throwableToScan);
+			client.getLogger().error("Game crash: {}", string, throwableToScan);
 
 			StackTraceElement[] stackTrace = throwableToScan.getStackTrace();
 


### PR DESCRIPTION
This lets the client print the cs2 vm stack to our logs