### PR TITLE
Fishing Plugin: Duplicate fishing icons fix

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingSpotOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingSpotOverlay.java
@@ -160,16 +160,26 @@ class FishingSpotOverlay extends Overlay
 				}
 			}
 
-			Map.Entry<NPC, Integer> npcArray[] = (Map.Entry<NPC, Integer>[]) fishingSpots.entrySet().toArray();
+			Object npcArray[] = fishingSpots.entrySet().toArray();
 			for (int i = 0; i < npcArray.length; i++)
 			{
-				Map.Entry<NPC, Integer> fishingSpot = npcArray[i];
+				Map.Entry<NPC, Integer> fishingSpot = (Map.Entry<NPC, Integer>) npcArray[i];
 				NPC npc = fishingSpot.getKey();
 				FishingSpot spot = FishingSpot.getSPOTS().get(npc.getId());
 
 				if (config.showSpotIcons()) {
-					BufferedImage fishImage = itemManager.getImage(spot.getFishSpriteId(), fishingSpot.getValue(), true);
-					;
+					BufferedImage fishImage = null;
+
+					int fishingSpotCount = fishingSpot.getValue();
+					if (fishingSpotCount > 1)
+					{
+						fishImage = itemManager.getImage(spot.getFishSpriteId(), fishingSpot.getValue(), true);
+					}
+					else
+					{
+						fishImage = itemManager.getImage(spot.getFishSpriteId());
+					}
+
 					if (fishImage != null) {
 						Point imageLocation = npc.getCanvasImageLocation(fishImage, npc.getLogicalHeight());
 						if (imageLocation != null) {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingSpotOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingSpotOverlay.java
@@ -31,6 +31,8 @@ import java.awt.Polygon;
 import java.awt.image.BufferedImage;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
 import javax.inject.Inject;
 import lombok.AccessLevel;
 import lombok.Setter;
@@ -40,6 +42,7 @@ import net.runelite.api.NPC;
 import net.runelite.api.Perspective;
 import net.runelite.api.Point;
 import net.runelite.api.coords.LocalPoint;
+import net.runelite.api.coords.WorldPoint;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
@@ -56,6 +59,8 @@ class FishingSpotOverlay extends Overlay
 	private final FishingConfig config;
 	private final Client client;
 	private final ItemManager itemManager;
+
+	private static HashMap<WorldPoint, ArrayList<FishingSpot>> SPOTS_LIST = new HashMap<>();
 
 	@Setter(AccessLevel.PACKAGE)
 	private boolean hidden;
@@ -92,6 +97,15 @@ class FishingSpotOverlay extends Overlay
 			{
 				continue;
 			}
+
+			ArrayList<FishingSpot> list = SPOTS_LIST.get(npc.getWorldLocation());
+			if (list == NULL)
+			{
+				list = new ArrayList<FishingSpot>();
+				SPOTS_LIST.put(npc.getWorldLocation(), list);
+			}
+			if (!list.contains(spot))
+				list.add(spot);
 
 			Color color = npc.getGraphic() == GraphicID.FLYING_FISH ? Color.RED : Color.CYAN;
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingSpotOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingSpotOverlay.java
@@ -160,16 +160,21 @@ class FishingSpotOverlay extends Overlay
 				}
 			}
 
-			for (Map.Entry fishingSpot : fishingSpots.entrySet())
+			Map.Entry<NPC, Integer> npcArray[] = (Map.Entry<NPC, Integer>[]) fishingSpots.entrySet().toArray();
+			for (int i = 0; i < npcArray.length; i++)
+		//	for (Map.Entry fishingSpot : fishingSpots.entrySet())
 			{
-				NPC npc = (NPC) fishingSpot.getKey();
+				Map.Entry<NPC, Integer> fishingSpot = npcArray[i];
+				NPC npc = fishingSpot.getKey();
 				FishingSpot spot = FishingSpot.getSPOTS().get(npc.getId());
 
 				if (config.showSpotIcons()) {
-					BufferedImage fishImage = itemManager.getImage(spot.getFishSpriteId(), (int) fishingSpot.getValue(), true);
+					BufferedImage fishImage = itemManager.getImage(spot.getFishSpriteId(), fishingSpot.getValue(), true);
 					;
 					if (fishImage != null) {
 						Point imageLocation = npc.getCanvasImageLocation(fishImage, npc.getLogicalHeight());
+						int offset = ((i) * 17) - ((34*(npcArray.length - 1)) / 2);
+						Point shiftedImage = new Point(imageLocation.getX() + offset, imageLocation.getY());
 						if (imageLocation != null) {
 							OverlayUtil.renderImageLocation(graphics, imageLocation, fishImage);
 						}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingSpotOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingSpotOverlay.java
@@ -108,13 +108,13 @@ class FishingSpotOverlay extends Overlay
 				SPOTS_LIST.put(npc.getWorldLocation(), map);
 			}
 
-			int spotCount = map.get(npc);
-			if (spotCount == 0)
+			if (map.get(npc) == null)
 			{
 				map.put(npc, 1);
 			}
 			else
 			{
+				int spotCount = map.get(npc);
 				map.replace(npc, spotCount + 1);
 			}
 		}
@@ -162,7 +162,6 @@ class FishingSpotOverlay extends Overlay
 
 			Map.Entry<NPC, Integer> npcArray[] = (Map.Entry<NPC, Integer>[]) fishingSpots.entrySet().toArray();
 			for (int i = 0; i < npcArray.length; i++)
-		//	for (Map.Entry fishingSpot : fishingSpots.entrySet())
 			{
 				Map.Entry<NPC, Integer> fishingSpot = npcArray[i];
 				NPC npc = fishingSpot.getKey();

--- a/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingSpotOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingSpotOverlay.java
@@ -186,7 +186,7 @@ class FishingSpotOverlay extends Overlay
 				{
 					BufferedImage fishImage = null;
 
-					if (spotCount > 1)
+					if (spotCount > 1 && !(config.showSpotNames()))
 					{
 						fishImage = itemManager.getImage(spot.getFishSpriteId(), spotCount, true);
 					}
@@ -212,7 +212,7 @@ class FishingSpotOverlay extends Overlay
 					String text = spot.getName();
 					if (spotCount > 1)
 					{
-						text.concat(" (" +  spotCount + ")");
+						text += " (" +  spotCount + ")";
 					}
 					Point textLocation = npc.getCanvasTextLocation(graphics, text, 74 + (i * 20));
 					if (textLocation != null)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingSpotOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingSpotOverlay.java
@@ -173,10 +173,10 @@ class FishingSpotOverlay extends Overlay
 					;
 					if (fishImage != null) {
 						Point imageLocation = npc.getCanvasImageLocation(fishImage, npc.getLogicalHeight());
-						int offset = ((i) * 17) - ((34*(npcArray.length - 1)) / 2);
-						Point shiftedImage = new Point(imageLocation.getX() + offset, imageLocation.getY());
 						if (imageLocation != null) {
-							OverlayUtil.renderImageLocation(graphics, imageLocation, fishImage);
+							int offset = ((i) * 17) - ((34*(npcArray.length - 1)) / 2);
+							Point shiftedImageLocation = new Point(imageLocation.getX() + offset, imageLocation.getY());
+							OverlayUtil.renderImageLocation(graphics, shiftedImageLocation, fishImage);
 						}
 					}
 				}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingSpotOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingSpotOverlay.java
@@ -33,6 +33,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Map;
 import javax.inject.Inject;
 import lombok.AccessLevel;
 import lombok.Setter;
@@ -159,11 +160,13 @@ class FishingSpotOverlay extends Overlay
 				}
 			}
 
-			for (NPC npc : fishingSpots)
+			for (Map.Entry fishingSpot : fishingSpots.entrySet())
 			{
+				NPC npc = (NPC) fishingSpot.getKey();
+				FishingSpot spot = FishingSpot.getSPOTS().get(npc.getId());
 
 				if (config.showSpotIcons()) {
-					BufferedImage fishImage = itemManager.getImage(spot.getFishSpriteId());
+					BufferedImage fishImage = itemManager.getImage(spot.getFishSpriteId(), (int) fishingSpot.getValue(), true);
 					;
 					if (fishImage != null) {
 						Point imageLocation = npc.getCanvasImageLocation(fishImage, npc.getLogicalHeight());

--- a/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingSpotOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingSpotOverlay.java
@@ -167,7 +167,8 @@ class FishingSpotOverlay extends Overlay
 				NPC npc = fishingSpot.getKey();
 				FishingSpot spot = FishingSpot.getSPOTS().get(npc.getId());
 
-				if (config.showSpotIcons()) {
+				if (config.showSpotIcons())
+				{
 					BufferedImage fishImage = null;
 
 					int fishingSpotCount = fishingSpot.getValue();
@@ -180,9 +181,11 @@ class FishingSpotOverlay extends Overlay
 						fishImage = itemManager.getImage(spot.getFishSpriteId());
 					}
 
-					if (fishImage != null) {
-						Point imageLocation = npc.getCanvasImageLocation(fishImage, npc.getLogicalHeight());
-						if (imageLocation != null) {
+					if (fishImage != null)
+					{
+						Point imageLocation = npc.getCanvasImageLocation(fishImage, 34);
+						if (imageLocation != null)
+						{
 							int offset = ((i) * 17) - ((34*(npcArray.length - 1)) / 2);
 							Point shiftedImageLocation = new Point(imageLocation.getX() + offset, imageLocation.getY());
 							OverlayUtil.renderImageLocation(graphics, shiftedImageLocation, fishImage);
@@ -190,10 +193,12 @@ class FishingSpotOverlay extends Overlay
 					}
 				}
 
-				if (config.showSpotNames()) {
+				if (config.showSpotNames())
+				{
 					String text = spot.getName();
 					Point textLocation = npc.getCanvasTextLocation(graphics, text, npc.getLogicalHeight() + 40);
-					if (textLocation != null) {
+					if (textLocation != null)
+					{
 						OverlayUtil.renderTextLocation(graphics, textLocation, text, color.darker());
 					}
 				}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingSpotOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingSpotOverlay.java
@@ -186,7 +186,7 @@ class FishingSpotOverlay extends Overlay
 						Point imageLocation = npc.getCanvasImageLocation(fishImage, 34);
 						if (imageLocation != null)
 						{
-							int offset = ((i) * 17) - ((34*(npcArray.length - 1)) / 2);
+							int offset = (i * 17) - ((68*(npcArray.length - 1)) / 2);
 							Point shiftedImageLocation = new Point(imageLocation.getX() + offset, imageLocation.getY());
 							OverlayUtil.renderImageLocation(graphics, shiftedImageLocation, fishImage);
 						}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingSpotOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingSpotOverlay.java
@@ -60,7 +60,7 @@ class FishingSpotOverlay extends Overlay
 	private final Client client;
 	private final ItemManager itemManager;
 
-	private static HashMap<WorldPoint, ArrayList<NPC>> SPOTS_LIST = new HashMap<>();
+	private static HashMap<WorldPoint, HashMap<NPC, Integer>> SPOTS_LIST = new HashMap<>();
 
 	@Setter(AccessLevel.PACKAGE)
 	private boolean hidden;
@@ -100,24 +100,32 @@ class FishingSpotOverlay extends Overlay
 				continue;
 			}
 
-			ArrayList<NPC> list = SPOTS_LIST.get(npc.getWorldLocation());
-			if (list == null)
+			HashMap<NPC, Integer> map = SPOTS_LIST.get(npc.getWorldLocation());
+			if (map == null)
 			{
-				list = new ArrayList<NPC>();
-				SPOTS_LIST.put(npc.getWorldLocation(), list);
+				map = new HashMap<NPC, Integer>();
+				SPOTS_LIST.put(npc.getWorldLocation(), map);
 			}
-			if (!list.contains(npc))
-				list.add(npc);
+
+			int spotCount = map.get(npc);
+			if (spotCount == 0)
+			{
+				map.put(npc, 1);
+			}
+			else
+			{
+				map.replace(npc, spotCount + 1);
+			}
 		}
 
-		for (HashMap.Entry<WorldPoint, ArrayList<NPC>> entry : SPOTS_LIST.entrySet())
+		for (HashMap.Entry<WorldPoint, HashMap<NPC, Integer>> entry : SPOTS_LIST.entrySet())
 		{
 			WorldPoint tile = entry.getKey();
-			ArrayList<NPC> fishingSpots = entry.getValue();
+			HashMap<NPC, Integer> fishingSpots = entry.getValue();
 			int spotCount = fishingSpots.size();
 
 			// minnow fishing spots will only ever share tiles with other minnow fishing spots
-			NPC firstSpot = fishingSpots.get(0);
+			NPC firstSpot = (NPC) fishingSpots.keySet().toArray()[0];
 			FishingSpot possibleMinnowSpot = FishingSpot.getSPOTS().get(firstSpot.getId());
 			Color color = firstSpot.getGraphic() == GraphicID.FLYING_FISH ? Color.RED : Color.CYAN;
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingSpotOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingSpotOverlay.java
@@ -144,7 +144,8 @@ class FishingSpotOverlay extends Overlay
 			}
 
 			if (config.showSpotTiles()) {
-				Polygon poly = npc.getCanvasTilePoly();
+				// each entry in the list corresponds to the same tile
+				Polygon poly = firstSpot.getCanvasTilePoly();
 				if (poly != null) {
 					OverlayUtil.renderPolygon(graphics, poly, color.darker());
 				}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingSpotOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingSpotOverlay.java
@@ -31,7 +31,6 @@ import java.awt.Polygon;
 import java.awt.image.BufferedImage;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 import javax.inject.Inject;
@@ -135,7 +134,8 @@ class FishingSpotOverlay extends Overlay
 			NPC firstSpot  = fishingSpots.get(possibleMinnowSpot);
 			Color color = firstSpot.getGraphic() == GraphicID.FLYING_FISH ? Color.RED : Color.CYAN;
 
-			if (possibleMinnowSpot == FishingSpot.MINNOW && config.showMinnowOverlay()) {
+			if (possibleMinnowSpot == FishingSpot.MINNOW && config.showMinnowOverlay())
+			{
 				MinnowSpot minnowSpot = plugin.getMinnowSpots().get(firstSpot.getIndex());
 				if (minnowSpot != null)
 				{
@@ -200,7 +200,7 @@ class FishingSpotOverlay extends Overlay
 						Point imageLocation = npc.getCanvasImageLocation(fishImage, 34);
 						if (imageLocation != null)
 						{
-							int offset = (i * 34) - ((34*(spotCountArray.length - 1)) / 2);
+							int offset = (i * 34) - ((34 * (spotCountArray.length - 1)) / 2);
 							Point shiftedImageLocation = new Point(imageLocation.getX() + offset, imageLocation.getY());
 							OverlayUtil.renderImageLocation(graphics, shiftedImageLocation, fishImage);
 						}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingSpotOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingSpotOverlay.java
@@ -104,7 +104,7 @@ class FishingSpotOverlay extends Overlay
 			HashMap<NPC, Integer> map = SPOTS_LIST.get(npc.getWorldLocation());
 			if (map == null)
 			{
-				map = new HashMap<NPC, Integer>();
+				map = new HashMap<>();
 				SPOTS_LIST.put(npc.getWorldLocation(), map);
 			}
 
@@ -123,25 +123,28 @@ class FishingSpotOverlay extends Overlay
 		{
 			WorldPoint tile = entry.getKey();
 			HashMap<NPC, Integer> fishingSpots = entry.getValue();
-			int spotCount = fishingSpots.size();
 
 			// minnow fishing spots will only ever share tiles with other minnow fishing spots
 			NPC firstSpot = (NPC) fishingSpots.keySet().toArray()[0];
 			FishingSpot possibleMinnowSpot = FishingSpot.getSPOTS().get(firstSpot.getId());
 			Color color = firstSpot.getGraphic() == GraphicID.FLYING_FISH ? Color.RED : Color.CYAN;
 
-			if (possibleMinnowSpot == FishingSpot.MINNOW && config.showMinnowOverlay()) {
+			if (possibleMinnowSpot == FishingSpot.MINNOW && config.showMinnowOverlay())
+			{
 				MinnowSpot minnowSpot = plugin.getMinnowSpots().get(firstSpot.getIndex());
-				if (minnowSpot != null) {
+				if (minnowSpot != null)
+				{
 					long millisLeft = MINNOW_MOVE.toMillis() - Duration.between(minnowSpot.getTime(), Instant.now()).toMillis();
-					if (millisLeft < MINNOW_WARN.toMillis()) {
+					if (millisLeft < MINNOW_WARN.toMillis())
+					{
 						color = Color.ORANGE;
 					}
 
 					LocalPoint localPoint = firstSpot.getLocalLocation();
 					Point location = Perspective.localToCanvas(client, localPoint, client.getPlane());
 
-					if (location != null) {
+					if (location != null)
+					{
 						ProgressPieComponent pie = new ProgressPieComponent();
 						pie.setFill(color);
 						pie.setBorderColor(color);
@@ -152,10 +155,12 @@ class FishingSpotOverlay extends Overlay
 				}
 			}
 
-			if (config.showSpotTiles()) {
+			if (config.showSpotTiles())
+			{
 				// each entry in the list corresponds to the same tile
 				Polygon poly = firstSpot.getCanvasTilePoly();
-				if (poly != null) {
+				if (poly != null)
+				{
 					OverlayUtil.renderPolygon(graphics, poly, color.darker());
 				}
 			}
@@ -186,7 +191,7 @@ class FishingSpotOverlay extends Overlay
 						Point imageLocation = npc.getCanvasImageLocation(fishImage, 34);
 						if (imageLocation != null)
 						{
-							int offset = (i * 17) - ((68*(npcArray.length - 1)) / 2);
+							int offset = (i * 34) - ((34*(npcArray.length - 1)) / 2);
 							Point shiftedImageLocation = new Point(imageLocation.getX() + offset, imageLocation.getY());
 							OverlayUtil.renderImageLocation(graphics, shiftedImageLocation, fishImage);
 						}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingSpotOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingSpotOverlay.java
@@ -60,7 +60,7 @@ class FishingSpotOverlay extends Overlay
 	private final Client client;
 	private final ItemManager itemManager;
 
-	private static HashMap<WorldPoint, ArrayList<FishingSpot>> SPOTS_LIST = new HashMap<>();
+	private static HashMap<WorldPoint, ArrayList<NPC>> SPOTS_LIST = new HashMap<>();
 
 	@Setter(AccessLevel.PACKAGE)
 	private boolean hidden;
@@ -98,72 +98,72 @@ class FishingSpotOverlay extends Overlay
 				continue;
 			}
 
-			ArrayList<FishingSpot> list = SPOTS_LIST.get(npc.getWorldLocation());
-			if (list == NULL)
+			ArrayList<NPC> list = SPOTS_LIST.get(npc.getWorldLocation());
+			if (list == null)
 			{
-				list = new ArrayList<FishingSpot>();
+				list = new ArrayList<NPC>();
 				SPOTS_LIST.put(npc.getWorldLocation(), list);
 			}
-			if (!list.contains(spot))
-				list.add(spot);
+			if (!list.contains(npc))
+				list.add(npc);
+		}
 
-			Color color = npc.getGraphic() == GraphicID.FLYING_FISH ? Color.RED : Color.CYAN;
+		for (HashMap.Entry<WorldPoint, ArrayList<NPC>> entry : SPOTS_LIST.entrySet())
+		{
+			WorldPoint tile = entry.getKey();
+			ArrayList<NPC> fishingSpots = entry.getValue();
 
-			if (spot == FishingSpot.MINNOW && config.showMinnowOverlay())
+			for (NPC npc : fishingSpots)
 			{
-				MinnowSpot minnowSpot = plugin.getMinnowSpots().get(npc.getIndex());
-				if (minnowSpot != null)
-				{
-					long millisLeft = MINNOW_MOVE.toMillis() - Duration.between(minnowSpot.getTime(), Instant.now()).toMillis();
-					if (millisLeft < MINNOW_WARN.toMillis())
-					{
-						color = Color.ORANGE;
-					}
+				FishingSpot spot = FishingSpot.getSPOTS().get(npc.getId());
+				Color color = npc.getGraphic() == GraphicID.FLYING_FISH ? Color.RED : Color.CYAN;
 
-					LocalPoint localPoint = npc.getLocalLocation();
-					Point location = Perspective.localToCanvas(client, localPoint, client.getPlane());
+				if (spot == FishingSpot.MINNOW && config.showMinnowOverlay()) {
+					MinnowSpot minnowSpot = plugin.getMinnowSpots().get(npc.getIndex());
+					if (minnowSpot != null) {
+						long millisLeft = MINNOW_MOVE.toMillis() - Duration.between(minnowSpot.getTime(), Instant.now()).toMillis();
+						if (millisLeft < MINNOW_WARN.toMillis()) {
+							color = Color.ORANGE;
+						}
 
-					if (location != null)
-					{
-						ProgressPieComponent pie = new ProgressPieComponent();
-						pie.setFill(color);
-						pie.setBorderColor(color);
-						pie.setPosition(location);
-						pie.setProgress((float) millisLeft / MINNOW_MOVE.toMillis());
-						pie.render(graphics);
-					}
-				}
-			}
+						LocalPoint localPoint = npc.getLocalLocation();
+						Point location = Perspective.localToCanvas(client, localPoint, client.getPlane());
 
-			if (config.showSpotTiles())
-			{
-				Polygon poly = npc.getCanvasTilePoly();
-				if (poly != null)
-				{
-					OverlayUtil.renderPolygon(graphics, poly, color.darker());
-				}
-			}
-
-			if (config.showSpotIcons())
-			{
-				BufferedImage fishImage = itemManager.getImage(spot.getFishSpriteId());;
-				if (fishImage != null)
-				{
-					Point imageLocation = npc.getCanvasImageLocation(fishImage, npc.getLogicalHeight());
-					if (imageLocation != null)
-					{
-						OverlayUtil.renderImageLocation(graphics, imageLocation, fishImage);
+						if (location != null) {
+							ProgressPieComponent pie = new ProgressPieComponent();
+							pie.setFill(color);
+							pie.setBorderColor(color);
+							pie.setPosition(location);
+							pie.setProgress((float) millisLeft / MINNOW_MOVE.toMillis());
+							pie.render(graphics);
+						}
 					}
 				}
-			}
 
-			if (config.showSpotNames())
-			{
-				String text = spot.getName();
-				Point textLocation = npc.getCanvasTextLocation(graphics, text, npc.getLogicalHeight() + 40);
-				if (textLocation != null)
-				{
-					OverlayUtil.renderTextLocation(graphics, textLocation, text, color.darker());
+				if (config.showSpotTiles()) {
+					Polygon poly = npc.getCanvasTilePoly();
+					if (poly != null) {
+						OverlayUtil.renderPolygon(graphics, poly, color.darker());
+					}
+				}
+
+				if (config.showSpotIcons()) {
+					BufferedImage fishImage = itemManager.getImage(spot.getFishSpriteId());
+					;
+					if (fishImage != null) {
+						Point imageLocation = npc.getCanvasImageLocation(fishImage, npc.getLogicalHeight());
+						if (imageLocation != null) {
+							OverlayUtil.renderImageLocation(graphics, imageLocation, fishImage);
+						}
+					}
+				}
+
+				if (config.showSpotNames()) {
+					String text = spot.getName();
+					Point textLocation = npc.getCanvasTextLocation(graphics, text, npc.getLogicalHeight() + 40);
+					if (textLocation != null) {
+						OverlayUtil.renderTextLocation(graphics, textLocation, text, color.darker());
+					}
 				}
 			}
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingSpotOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingSpotOverlay.java
@@ -179,12 +179,13 @@ class FishingSpotOverlay extends Overlay
 				FishingSpot spot = fishingSpot.getKey();
 				NPC npc = fishingSpot.getValue();
 
+				Map.Entry<FishingSpot, Integer> spotCountEntry = (Map.Entry<FishingSpot, Integer>) spotCountArray[i];
+				int spotCount = spotCountEntry.getValue();
+
 				if (config.showSpotIcons())
 				{
 					BufferedImage fishImage = null;
 
-					Map.Entry<FishingSpot, Integer> spotCountEntry = (Map.Entry<FishingSpot, Integer>) spotCountArray[i];
-					int spotCount = spotCountEntry.getValue();
 					if (spotCount > 1)
 					{
 						fishImage = itemManager.getImage(spot.getFishSpriteId(), spotCount, true);
@@ -209,7 +210,11 @@ class FishingSpotOverlay extends Overlay
 				if (config.showSpotNames())
 				{
 					String text = spot.getName();
-					Point textLocation = npc.getCanvasTextLocation(graphics, text, npc.getLogicalHeight() + 40);
+					if (spotCount > 1)
+					{
+						text.concat(" (" +  spotCount + ")");
+					}
+					Point textLocation = npc.getCanvasTextLocation(graphics, text, 74 + (i * 20));
 					if (textLocation != null)
 					{
 						OverlayUtil.renderTextLocation(graphics, textLocation, text, color.darker());


### PR DESCRIPTION
This bug fix addresses #1392.

**Problem:** The fishing plugin doesn't keep track of the fishing spots near the player. As a result, it tries to draw multiple icons in the same spot whenever fishing spots are stacked. 

**Fix:** I implemented 2 HashMaps to keep track of core information regarding each fishing spot. The logical height is no longer used to determine the height of text/icons. Instead, a fixed value (derived from the logical height of a fishing spot) is used to avoid odd logical heights caused by stacked spots.

![image](https://user-images.githubusercontent.com/25905465/52918820-9a4c0780-32c9-11e9-8b48-eea36c3cbc3c.png)

**Concerns**: I'm not confident that using two HashMaps is the right approach. Any feedback on this will be appreciated.