### PR TITLE
Log infobox removal only if infobox was removed

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/infobox/InfoBoxManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/infobox/InfoBoxManager.java
@@ -76,18 +76,18 @@ public class InfoBoxManager
 
 	public void removeInfoBox(InfoBox infoBox)
 	{
-		log.debug("Removing InfoBox {}", infoBox);
 		if (infoBoxes.remove(infoBox))
 		{
+			log.debug("Removed InfoBox {}", infoBox);
 			refreshInfoBoxes();
 		}
 	}
 
 	public void removeIf(Predicate<InfoBox> filter)
 	{
-		log.debug("Removing InfoBoxes for filter {}", filter);
 		if (infoBoxes.removeIf(filter))
 		{
+			log.debug("Removed InfoBoxes for filter {}", filter);
 			refreshInfoBoxes();
 		}
 	}


### PR DESCRIPTION
Debug log infobox removal from infobox manager only if infobox was
really removed.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>