### PR TITLE
Add option to hide traps placed by other players

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018, Adam <Adam@sigterm.info>
+ * Copyright (c) 2018, Lucas <https://github.com/Lucwousin>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -268,6 +269,16 @@ public interface MenuEntrySwapperConfig extends Config
 		description = "Swap Talk-to with Travel, Take-boat, Pay-fare, Charter on NPC<br>Example: Squire, Monk of Entrana, Customs officer, Trader Crewmember"
 	)
 	default boolean swapTravel()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		keyName = "hideTraps",
+		name = "Hide unowned traps",
+		description = "Hide left click options on other hunter traps placed by other people."
+	)
+	default boolean hideTraps()
 	{
 		return true;
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -503,6 +503,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 		else if (config.swapBoxTrap() && option.equals("take"))
 		{
 			swap("lay", option, target, true);
+			swap("activate", option, target, true);
 		}
 		else if (config.swapChase() && option.equals("pick-up"))
 		{


### PR DESCRIPTION
Add an option to make "Walk here" the standard left-click option for hunter traps placed by other players. This uses the hunter plugin to add locations to a set of worldpoints, and every trap not on a 'whitelisted' tile will have their options moved swapped. The positions are reset on client restart.