### PR TITLE
Add version information to Discord tooltip

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordState.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordState.java
@@ -34,6 +34,7 @@ import java.util.Optional;
 import java.util.UUID;
 import javax.inject.Inject;
 import lombok.Data;
+import net.runelite.client.RuneLiteProperties;
 import net.runelite.client.discord.DiscordPresence;
 import net.runelite.client.discord.DiscordService;
 import net.runelite.client.ws.PartyService;
@@ -57,14 +58,16 @@ class DiscordState
 	private final DiscordService discordService;
 	private final DiscordConfig config;
 	private PartyService party;
+	private final RuneLiteProperties properties;
 	private DiscordPresence lastPresence;
 
 	@Inject
-	private DiscordState(final DiscordService discordService, final DiscordConfig config, final PartyService party)
+	private DiscordState(final DiscordService discordService, final DiscordConfig config, final PartyService party, final RuneLiteProperties properties)
 	{
 		this.discordService = discordService;
 		this.config = config;
 		this.party = party;
+		this.properties = properties;
 	}
 
 	/**
@@ -90,6 +93,7 @@ class DiscordState
 		final DiscordPresence.DiscordPresenceBuilder presenceBuilder = DiscordPresence.builder()
 			.state(lastPresence.getState())
 			.details(lastPresence.getDetails())
+			.largeImageText(lastPresence.getLargeImageText())
 			.startTimestamp(lastPresence.getStartTimestamp())
 			.smallImageKey(lastPresence.getSmallImageKey())
 			.partyMax(lastPresence.getPartyMax())
@@ -168,9 +172,13 @@ class DiscordState
 			}
 		}
 
+		// Replace snapshot with + to make tooltip shorter (so it will span only 1 line)
+		final String versionShortHand = properties.getVersion().replace("-SNAPSHOT", "+");
+
 		final DiscordPresence.DiscordPresenceBuilder presenceBuilder = DiscordPresence.builder()
 			.state(MoreObjects.firstNonNull(state, ""))
 			.details(MoreObjects.firstNonNull(details, ""))
+			.largeImageText(properties.getTitle() + " v" + versionShortHand)
 			.startTimestamp(event.getStart())
 			.smallImageKey(MoreObjects.firstNonNull(imageKey, "default"))
 			.partyMax(PARTY_MAX)


### PR DESCRIPTION
Signed-off-by: Tomas Slusny <slusnucky@gmail.com>

![screenie](https://user-images.githubusercontent.com/5115805/52980018-775c4900-33d8-11e9-8abc-78255c90e503.png)

1. It's common practice to put version info to tooltip
2. It reduces my time wasted providing support to people running outdated or custom versions in Discord