### PR TITLE
Do not use default smallImageKey for Rich Presence

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/discord/DiscordService.java
+++ b/runelite-client/src/main/java/net/runelite/client/discord/DiscordService.java
@@ -150,9 +150,12 @@ public class DiscordService implements AutoCloseable
 			? "default"
 			: discordPresence.getLargeImageKey();
 		discordRichPresence.largeImageText = discordPresence.getLargeImageText();
-		discordRichPresence.smallImageKey = Strings.isNullOrEmpty(discordPresence.getSmallImageKey())
-			? "default"
-			: discordPresence.getSmallImageKey();
+
+		if (!Strings.isNullOrEmpty(discordPresence.getSmallImageKey()))
+		{
+			discordRichPresence.smallImageKey = discordPresence.getSmallImageKey();
+		}
+
 		discordRichPresence.smallImageText = discordPresence.getSmallImageText();
 		discordRichPresence.partyId = discordPresence.getPartyId();
 		discordRichPresence.partySize = discordPresence.getPartySize();

--- a/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordState.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordState.java
@@ -180,7 +180,7 @@ class DiscordState
 			.details(MoreObjects.firstNonNull(details, ""))
 			.largeImageText(properties.getTitle() + " v" + versionShortHand)
 			.startTimestamp(event.getStart())
-			.smallImageKey(MoreObjects.firstNonNull(imageKey, "default"))
+			.smallImageKey(imageKey)
 			.partyMax(PARTY_MAX)
 			.partySize(party.getMembers().size());
 


### PR DESCRIPTION
Having big image with RuneLite logo and then small image with RuneLite
logo in it's corner do not looks very good, so update the small icon
only when it is showing something interesting.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>