### PR TITLE
inventory viewer: add item grouping and free slots display

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/inventoryviewer/InventoryViewerConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/inventoryviewer/InventoryViewerConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 AWPH-I
+ * Copyright (c) 2019 Hydrox6 <ikada@protonmail.ch>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -24,42 +24,20 @@
  */
 package net.runelite.client.plugins.inventoryviewer;
 
-import javax.inject.Inject;
-import com.google.inject.Provides;
-import net.runelite.client.config.ConfigManager;
-import net.runelite.client.plugins.Plugin;
-import net.runelite.client.plugins.PluginDescriptor;
-import net.runelite.client.ui.overlay.OverlayManager;
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
 
-@PluginDescriptor(
-	name = "Inventory Viewer",
-	description = "Add an overlay showing the contents of your inventory",
-	tags = {"alternate", "items", "overlay", "second"},
-	enabledByDefault = false
-)
-public class InventoryViewerPlugin extends Plugin
+@ConfigGroup("inventoryviewer")
+public interface InventoryViewerConfig extends Config
 {
-	@Inject
-	private InventoryViewerOverlay overlay;
-
-	@Inject
-	private OverlayManager overlayManager;
-
-	@Provides
-	InventoryViewerConfig provideConfig(ConfigManager configManager)
+	@ConfigItem(
+		keyName = "groupItems",
+		name = "Group items",
+		description = "Whether or not to group the items together"
+	)
+	default boolean groupItems()
 	{
-		return configManager.getConfig(InventoryViewerConfig.class);
-	}
-
-	@Override
-	public void startUp()
-	{
-		overlayManager.add(overlay);
-	}
-
-	@Override
-	public void shutDown()
-	{
-		overlayManager.remove(overlay);
+		return false;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/inventoryviewer/InventoryViewerConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/inventoryviewer/InventoryViewerConfig.java
@@ -40,4 +40,14 @@ public interface InventoryViewerConfig extends Config
 	{
 		return false;
 	}
+
+	@ConfigItem(
+		keyName = "showFreeSlots",
+		name = "Show Free Slots",
+		description = "Whether to show a label with the free slots in the inventory"
+	)
+	default boolean showFreeSlots()
+	{
+		return false;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/inventoryviewer/InventoryViewerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/inventoryviewer/InventoryViewerPlugin.java
@@ -26,7 +26,10 @@ package net.runelite.client.plugins.inventoryviewer;
 
 import javax.inject.Inject;
 import com.google.inject.Provides;
+import net.runelite.api.InventoryID;
+import net.runelite.api.events.ItemContainerChanged;
 import net.runelite.client.config.ConfigManager;
+import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.OverlayManager;
@@ -61,5 +64,16 @@ public class InventoryViewerPlugin extends Plugin
 	public void shutDown()
 	{
 		overlayManager.remove(overlay);
+	}
+
+	@Subscribe
+	public void onItemContainerChanged(ItemContainerChanged event)
+	{
+		if (event.getContainerId() != InventoryID.INVENTORY.getId())
+		{
+			return;
+		}
+		overlay.setGroupedItems(null);
+		overlay.setRemainingSpaces(-1);
 	}
 }


### PR DESCRIPTION
Closes #2771

Adds an option to have the inventory viewer group the same items together.

Now with an option to show the number of empty slots remaining in your inventory

![java_2019-03-02_01-03-42](https://user-images.githubusercontent.com/2979691/53674628-23c6e680-3c87-11e9-8d36-ed49dbdf5eee.png)
![java_2019-03-02_01-04-17](https://user-images.githubusercontent.com/2979691/53674630-24f81380-3c87-11e9-8d36-ab05f480b85a.png)

