### PR TITLE
Correct Falador teleport XP in Skill Calc

### DIFF
--- a/runelite-client/src/main/resources/net/runelite/client/plugins/skillcalculator/skill_magic.json
+++ b/runelite-client/src/main/resources/net/runelite/client/plugins/skillcalculator/skill_magic.json
@@ -238,7 +238,7 @@
       "level": 37,
       "sprite": 33,
       "name": "Falador Teleport",
-      "xp": 47
+      "xp": 48
     },
     {
       "level": 39,


### PR DESCRIPTION
Was using it a bunch and noticed the calculator contained the incorrect amount.

Before: 47 XP
After: 48 XP

[Here's the wiki link](https://oldschool.runescape.wiki/w/Falador_Teleport) in case you'd like to double-check.