### PR TITLE
Add home tag to Default World plugin

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/defaultworld/DefaultWorldPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/defaultworld/DefaultWorldPlugin.java
@@ -43,7 +43,8 @@ import net.runelite.http.api.worlds.WorldResult;
 
 @PluginDescriptor(
 	name = "Default World",
-	description = "Enable a default world to be selected when launching the client"
+	description = "Enable a default world to be selected when launching the client",
+	tags = {"home"}
 )
 @Slf4j
 public class DefaultWorldPlugin extends Plugin


### PR DESCRIPTION
Wanted to set my home world but couldn't find the Default World plugin when I searched for home.