### PR TITLE
Catch JVM incompatible library JNA error when initializing Discord

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/discord/DiscordService.java
+++ b/runelite-client/src/main/java/net/runelite/client/discord/DiscordService.java
@@ -78,7 +78,7 @@ public class DiscordService implements AutoCloseable
 			discordRPC = DiscordRPC.INSTANCE;
 			discordEventHandlers = new DiscordEventHandlers();
 		}
-		catch (UnsatisfiedLinkError e)
+		catch (Error e)
 		{
 			log.warn("Failed to load Discord library, Discord support will be disabled.");
 		}


### PR DESCRIPTION
Signed-off-by: Tomas Slusny <slusnucky@gmail.com>