### PR TITLE
Fix the string encoding for building scripts with the maven plugin on windows

### DIFF
--- a/cache/src/main/java/net/runelite/cache/io/OutputStream.java
+++ b/cache/src/main/java/net/runelite/cache/io/OutputStream.java
@@ -26,7 +26,6 @@ package net.runelite.cache.io;
 
 import com.google.common.base.Preconditions;
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.nio.charset.Charset;
@@ -184,23 +183,13 @@ public final class OutputStream extends java.io.OutputStream
 	public void writeString(String str)
 	{
 		Charset utf8charset = Charset.forName("UTF-8");
-		Charset iso88591charset = Charset.forName("ISO-8859-1");
+		Charset cp1252charset = Charset.forName("Cp1252");
 
-		byte[] b;
-		try
-		{
-			b = str.getBytes("ISO-8859-1");
-		}
-		catch (UnsupportedEncodingException ex)
-		{
-			throw new RuntimeException(ex);
-		}
-
-		ByteBuffer inputBuffer = ByteBuffer.wrap(b);
+		ByteBuffer inputBuffer = ByteBuffer.wrap(str.getBytes());
 
 		CharBuffer data = utf8charset.decode(inputBuffer);
 
-		ByteBuffer outputBuffer = iso88591charset.encode(data);
+		ByteBuffer outputBuffer = cp1252charset.encode(data);
 		byte[] outputData = outputBuffer.array();
 
 		writeBytes(outputData);

--- a/cache/src/main/java/net/runelite/cache/io/OutputStream.java
+++ b/cache/src/main/java/net/runelite/cache/io/OutputStream.java
@@ -28,6 +28,8 @@ import com.google.common.base.Preconditions;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.Charset;
 
 public final class OutputStream extends java.io.OutputStream
 {
@@ -181,6 +183,9 @@ public final class OutputStream extends java.io.OutputStream
 
 	public void writeString(String str)
 	{
+		Charset utf8charset = Charset.forName("UTF-8");
+		Charset iso88591charset = Charset.forName("ISO-8859-1");
+
 		byte[] b;
 		try
 		{
@@ -190,7 +195,15 @@ public final class OutputStream extends java.io.OutputStream
 		{
 			throw new RuntimeException(ex);
 		}
-		writeBytes(b);
+
+		ByteBuffer inputBuffer = ByteBuffer.wrap(b);
+
+		CharBuffer data = utf8charset.decode(inputBuffer);
+
+		ByteBuffer outputBuffer = iso88591charset.encode(data);
+		byte[] outputData = outputBuffer.array();
+
+		writeBytes(outputData);
 		writeByte(0);
 	}
 


### PR DESCRIPTION
java Strings are utf-16 and the current implementation implicitly converts from utf-16 to iso88591.
This seems to go alright on unix but results in weird characters such as the Â behind the name in the chatbox, privatechat and clanchat.
https://stackoverflow.com/a/655948
decoding to utf-8 first and then encoding it to iso88591 fixes this problem for me and i no longer see the Â.