### PR TITLE
Move slayer weakness overlay 1 layer up above

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/TargetWeaknessOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/TargetWeaknessOverlay.java
@@ -59,7 +59,7 @@ class TargetWeaknessOverlay extends Overlay
 		this.itemManager = itemManager;
 		this.npcManager = npcManager;
 		setPosition(OverlayPosition.DYNAMIC);
-		setLayer(OverlayLayer.ABOVE_SCENE);
+		setLayer(OverlayLayer.UNDER_WIDGETS);
 	}
 
 	@Override


### PR DESCRIPTION
In order to not draw the weakness overlay under NPC HP bars
and prayers move overlay 1 layer up to UNDER_WIDGETS.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>