### PR TITLE
Color Picker: add recent colors

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
@@ -35,8 +35,6 @@ import java.awt.event.FocusEvent;
 import java.awt.event.ItemEvent;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
-import java.awt.event.WindowAdapter;
-import java.awt.event.WindowEvent;
 import java.awt.image.BufferedImage;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -88,6 +86,7 @@ import net.runelite.client.ui.PluginPanel;
 import net.runelite.client.ui.components.ComboBoxListRenderer;
 import net.runelite.client.ui.components.IconButton;
 import net.runelite.client.ui.components.IconTextField;
+import net.runelite.client.ui.components.colorpicker.ColorPickerManager;
 import net.runelite.client.ui.components.colorpicker.RuneliteColorPicker;
 import net.runelite.client.util.ColorUtil;
 import net.runelite.client.util.ImageUtil;
@@ -112,6 +111,7 @@ public class ConfigPanel extends PluginPanel
 	private final ScheduledExecutorService executorService;
 	private final RuneLiteConfig runeLiteConfig;
 	private final ChatColorConfig chatColorConfig;
+	private final ColorPickerManager colorPickerManager;
 	private final List<PluginListItem> pluginList = new ArrayList<>();
 
 	private final IconTextField searchBar = new IconTextField();
@@ -130,7 +130,7 @@ public class ConfigPanel extends PluginPanel
 	}
 
 	ConfigPanel(PluginManager pluginManager, ConfigManager configManager, ScheduledExecutorService executorService,
-		RuneLiteConfig runeLiteConfig, ChatColorConfig chatColorConfig)
+		RuneLiteConfig runeLiteConfig, ChatColorConfig chatColorConfig, ColorPickerManager colorPickerManager)
 	{
 		super(false);
 		this.pluginManager = pluginManager;
@@ -138,6 +138,7 @@ public class ConfigPanel extends PluginPanel
 		this.executorService = executorService;
 		this.runeLiteConfig = runeLiteConfig;
 		this.chatColorConfig = chatColorConfig;
+		this.colorPickerManager = colorPickerManager;
 
 		searchBar.setIcon(IconTextField.Icon.SEARCH);
 		searchBar.setPreferredSize(new Dimension(PluginPanel.PANEL_WIDTH - 20, 30));
@@ -420,8 +421,11 @@ public class ConfigPanel extends PluginPanel
 					@Override
 					public void mouseClicked(MouseEvent e)
 					{
-						RuneliteColorPicker colorPicker = new RuneliteColorPicker(SwingUtilities.windowForComponent(ConfigPanel.this),
-							colorPickerBtn.getBackground(), cid.getItem().name(), cid.getAlpha() == null);
+						RuneliteColorPicker colorPicker = colorPickerManager.create(
+							SwingUtilities.windowForComponent(ConfigPanel.this),
+							colorPickerBtn.getBackground(),
+							cid.getItem().name(),
+							cid.getAlpha() == null);
 						colorPicker.setLocation(getLocationOnScreen());
 						colorPicker.setOnColorChange(c ->
 						{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
@@ -428,15 +428,7 @@ public class ConfigPanel extends PluginPanel
 							colorPickerBtn.setBackground(c);
 							colorPickerBtn.setText(ColorUtil.toHexColor(c).toUpperCase());
 						});
-
-						colorPicker.addWindowListener(new WindowAdapter()
-						{
-							@Override
-							public void windowClosing(WindowEvent e)
-							{
-								changeConfiguration(listItem, config, colorPicker, cd, cid);
-							}
-						});
+						colorPicker.setOnClose(c -> changeConfiguration(listItem, config, colorPicker, cd, cid));
 						colorPicker.setVisible(true);
 					}
 				});

--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPlugin.java
@@ -41,6 +41,7 @@ import net.runelite.client.plugins.PluginManager;
 import net.runelite.client.ui.ClientToolbar;
 import net.runelite.client.ui.ClientUI;
 import net.runelite.client.ui.NavigationButton;
+import net.runelite.client.ui.components.colorpicker.ColorPickerManager;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayMenuEntry;
 import net.runelite.client.util.ImageUtil;
@@ -73,13 +74,16 @@ public class ConfigPlugin extends Plugin
 	@Inject
 	private ChatColorConfig chatColorConfig;
 
+	@Inject
+	private ColorPickerManager colorPickerManager;
+
 	private ConfigPanel configPanel;
 	private NavigationButton navButton;
 
 	@Override
 	protected void startUp() throws Exception
 	{
-		configPanel = new ConfigPanel(pluginManager, configManager, executorService, runeLiteConfig, chatColorConfig);
+		configPanel = new ConfigPanel(pluginManager, configManager, executorService, runeLiteConfig, chatColorConfig, colorPickerManager);
 
 		final BufferedImage icon = ImageUtil.getResourceStreamFromClass(getClass(), "config_icon.png");
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenmarkers/ScreenMarkerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenmarkers/ScreenMarkerPlugin.java
@@ -50,6 +50,7 @@ import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.plugins.screenmarkers.ui.ScreenMarkerPluginPanel;
 import net.runelite.client.ui.ClientToolbar;
 import net.runelite.client.ui.NavigationButton;
+import net.runelite.client.ui.components.colorpicker.ColorPickerManager;
 import net.runelite.client.ui.overlay.OverlayManager;
 import net.runelite.client.util.ImageUtil;
 
@@ -84,6 +85,10 @@ public class ScreenMarkerPlugin extends Plugin
 
 	@Inject
 	private ScreenMarkerCreationOverlay overlay;
+
+	@Getter
+	@Inject
+	private ColorPickerManager colorPickerManager;
 
 	private ScreenMarkerMouseListener mouseListener;
 	private ScreenMarkerPluginPanel pluginPanel;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenmarkers/ui/ScreenMarkerPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenmarkers/ui/ScreenMarkerPanel.java
@@ -497,15 +497,7 @@ class ScreenMarkerPanel extends JPanel
 			marker.getMarker().setFill(c);
 			updateFill();
 		});
-
-		colorPicker.addWindowListener(new WindowAdapter()
-		{
-			@Override
-			public void windowClosing(WindowEvent e)
-			{
-				plugin.updateConfig();
-			}
-		});
+		colorPicker.setOnClose(c -> plugin.updateConfig());
 		colorPicker.setVisible(true);
 	}
 
@@ -519,15 +511,7 @@ class ScreenMarkerPanel extends JPanel
 			marker.getMarker().setColor(c);
 			updateBorder();
 		});
-
-		colorPicker.addWindowListener(new WindowAdapter()
-		{
-			@Override
-			public void windowClosing(WindowEvent e)
-			{
-				plugin.updateConfig();
-			}
-		});
+		colorPicker.setOnClose(c -> plugin.updateConfig());
 		colorPicker.setVisible(true);
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenmarkers/ui/ScreenMarkerPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenmarkers/ui/ScreenMarkerPanel.java
@@ -31,8 +31,6 @@ import java.awt.Dimension;
 import java.awt.FlowLayout;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
-import java.awt.event.WindowAdapter;
-import java.awt.event.WindowEvent;
 import java.awt.image.BufferedImage;
 import javax.swing.BorderFactory;
 import javax.swing.ImageIcon;
@@ -489,8 +487,11 @@ class ScreenMarkerPanel extends JPanel
 
 	private void openFillColorPicker()
 	{
-		RuneliteColorPicker colorPicker = new RuneliteColorPicker(SwingUtilities.windowForComponent(this),
-			marker.getMarker().getFill(), marker.getMarker().getName() + " Fill", false);
+		RuneliteColorPicker colorPicker = plugin.getColorPickerManager().create(
+			SwingUtilities.windowForComponent(this),
+			marker.getMarker().getFill(),
+			marker.getMarker().getName() + " Fill",
+			false);
 		colorPicker.setLocation(getLocationOnScreen());
 		colorPicker.setOnColorChange(c ->
 		{
@@ -503,8 +504,11 @@ class ScreenMarkerPanel extends JPanel
 
 	private void openBorderColorPicker()
 	{
-		RuneliteColorPicker colorPicker = new RuneliteColorPicker(SwingUtilities.windowForComponent(this),
-			marker.getMarker().getColor(), marker.getMarker().getName() + " Border", false);
+		RuneliteColorPicker colorPicker = plugin.getColorPickerManager().create(
+			SwingUtilities.windowForComponent(this),
+			marker.getMarker().getColor(),
+			marker.getMarker().getName() + " Border",
+			false);
 		colorPicker.setLocation(getLocationOnScreen());
 		colorPicker.setOnColorChange(c ->
 		{

--- a/runelite-client/src/main/java/net/runelite/client/ui/components/colorpicker/ColorPickerManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/components/colorpicker/ColorPickerManager.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2019, Ron Young <https://github.com/raiyni>
+ * All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *     list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package net.runelite.client.ui.components.colorpicker;
+
+import java.awt.Color;
+import java.awt.Window;
+import java.awt.event.WindowEvent;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.Setter;
+import net.runelite.client.config.ConfigManager;
+
+@Singleton
+public class ColorPickerManager
+{
+	private final ConfigManager configManager;
+
+	@Setter(AccessLevel.PACKAGE)
+	@Getter(AccessLevel.PACKAGE)
+	private RuneliteColorPicker currentPicker;
+
+	@Inject
+	private ColorPickerManager(final ConfigManager configManager)
+	{
+		this.configManager = configManager;
+	}
+
+	public RuneliteColorPicker create(Window owner, Color previousColor, String title, boolean alphaHidden)
+	{
+		if (currentPicker != null)
+		{
+			currentPicker.dispatchEvent(new WindowEvent(currentPicker, WindowEvent.WINDOW_CLOSING));
+		}
+
+		currentPicker = new RuneliteColorPicker(owner, previousColor, title, alphaHidden, configManager, this);
+		return currentPicker;
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/ui/components/colorpicker/RecentColors.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/components/colorpicker/RecentColors.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2019, Ron Young <https://github.com/raiyni>
+ * All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *     list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package net.runelite.client.ui.components.colorpicker;
+
+import com.google.common.collect.EvictingQueue;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.util.function.Consumer;
+import javax.swing.JPanel;
+import net.runelite.client.config.ConfigManager;
+import static net.runelite.client.ui.components.colorpicker.RuneliteColorPicker.CONFIG_GROUP;
+import net.runelite.client.util.ColorUtil;
+import net.runelite.client.util.Text;
+
+final class RecentColors
+{
+	private static final String CONFIG_KEY = "recentColors";
+	private static final int MAX = 16;
+	private static final int BOX_SIZE = 16;
+
+	private final EvictingQueue<String> recentColors = EvictingQueue.create(MAX);
+	private final ConfigManager configManager;
+
+	RecentColors(final ConfigManager configManager)
+	{
+		this.configManager = configManager;
+	}
+
+	private void load()
+	{
+		String str = configManager.getConfiguration(CONFIG_GROUP, CONFIG_KEY);
+		if (str != null)
+		{
+			recentColors.addAll(Text.fromCSV(str));
+		}
+	}
+
+	void add(final String color)
+	{
+		if (ColorUtil.fromString(color) == null)
+		{
+			return;
+		}
+
+		recentColors.remove(color);
+		recentColors.add(color);
+
+		configManager.setConfiguration(CONFIG_GROUP, CONFIG_KEY, Text.toCSV(recentColors));
+	}
+
+	JPanel build(final Consumer<Color> consumer, final boolean alphaHidden)
+	{
+		load();
+
+		JPanel container = new JPanel(new GridBagLayout());
+
+		GridBagConstraints cx = new GridBagConstraints();
+		cx.insets = new Insets(0, 1, 4, 2);
+		cx.gridy = 0;
+		cx.gridx = 0;
+		cx.anchor = GridBagConstraints.WEST;
+
+		for (String s : recentColors)
+		{
+			if (cx.gridx == MAX / 2)
+			{
+				cx.gridy++;
+				cx.gridx = 0;
+			}
+
+			// Make sure the last element stays in line with all of the others
+			if (container.getComponentCount() == recentColors.size() - 1)
+			{
+				cx.weightx = 1;
+				cx.gridwidth = MAX / 2 - cx.gridx;
+			}
+
+			container.add(createBox(ColorUtil.fromString(s), consumer, alphaHidden), cx);
+			cx.gridx++;
+		}
+
+		return container;
+	}
+
+	private static JPanel createBox(final Color color, final Consumer<Color> consumer, final boolean alphaHidden)
+	{
+		final JPanel box = new JPanel();
+		String hex = alphaHidden ? ColorUtil.colorToHexCode(color) : ColorUtil.colorToAlphaHexCode(color);
+
+		box.setBackground(color);
+		box.setOpaque(true);
+		box.setPreferredSize(new Dimension(BOX_SIZE, BOX_SIZE));
+		box.setToolTipText("#" + hex.toUpperCase());
+		box.addMouseListener(new MouseAdapter()
+		{
+			@Override
+			public void mouseClicked(MouseEvent e)
+			{
+				consumer.accept(color);
+			}
+		});
+
+		return box;
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/ui/components/colorpicker/RuneliteColorPicker.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/components/colorpicker/RuneliteColorPicker.java
@@ -41,6 +41,7 @@ import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
+import java.util.Objects;
 import java.util.function.Consumer;
 import javax.swing.JDialog;
 import javax.swing.JFrame;
@@ -55,6 +56,7 @@ import javax.swing.text.Document;
 import javax.swing.text.DocumentFilter;
 import lombok.Getter;
 import lombok.Setter;
+import net.runelite.client.config.ConfigManager;
 import net.runelite.client.ui.ColorScheme;
 import net.runelite.client.util.ColorUtil;
 import org.pushingpixels.substance.internal.SubstanceSynapse;
@@ -89,7 +91,8 @@ public class RuneliteColorPicker extends JDialog
 	@Setter
 	private Consumer<Color> onClose;
 
-	public RuneliteColorPicker(Window parent, Color previousColor, String title, boolean alphaHidden)
+	RuneliteColorPicker(Window parent, Color previousColor, String title, boolean alphaHidden,
+		final ConfigManager configManager, final ColorPickerManager colorPickerManager)
 	{
 		super(parent, "RuneLite Color Picker - " + title, ModalityType.MODELESS);
 
@@ -99,6 +102,7 @@ public class RuneliteColorPicker extends JDialog
 		setResizable(false);
 		setSize(FRAME_WIDTH, FRAME_HEIGHT);
 		setBackground(ColorScheme.PROGRESS_COMPLETE_COLOR);
+		setDefaultCloseOperation(DISPOSE_ON_CLOSE);
 
 		JPanel content = new JPanel(new BorderLayout());
 		content.putClientProperty(SubstanceSynapse.COLORIZATION_FACTOR, 1.0);
@@ -279,6 +283,12 @@ public class RuneliteColorPicker extends JDialog
 				if (onClose != null)
 				{
 					onClose.accept(selectedColor);
+				}
+
+				RuneliteColorPicker cp = colorPickerManager.getCurrentPicker();
+				if (Objects.equals(cp, RuneliteColorPicker.this))
+				{
+					colorPickerManager.setCurrentPicker(null);
 				}
 			}
 		});

--- a/runelite-client/src/main/java/net/runelite/client/ui/components/colorpicker/RuneliteColorPicker.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/components/colorpicker/RuneliteColorPicker.java
@@ -39,6 +39,8 @@ import java.awt.event.FocusAdapter;
 import java.awt.event.FocusEvent;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 import java.util.function.Consumer;
 import javax.swing.JDialog;
 import javax.swing.JFrame;
@@ -83,6 +85,9 @@ public class RuneliteColorPicker extends JDialog
 
 	@Setter
 	private Consumer<Color> onColorChange;
+
+	@Setter
+	private Consumer<Color> onClose;
 
 	public RuneliteColorPicker(Window parent, Color previousColor, String title, boolean alphaHidden)
 	{
@@ -265,6 +270,18 @@ public class RuneliteColorPicker extends JDialog
 
 		updatePanels();
 		updateText();
+
+		addWindowListener(new WindowAdapter()
+		{
+			@Override
+			public void windowClosing(WindowEvent e)
+			{
+				if (onClose != null)
+				{
+					onClose.accept(selectedColor);
+				}
+			}
+		});
 	}
 
 	private void updatePanels()

--- a/runelite-client/src/main/java/net/runelite/client/ui/components/colorpicker/RuneliteColorPicker.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/components/colorpicker/RuneliteColorPicker.java
@@ -63,6 +63,8 @@ import org.pushingpixels.substance.internal.SubstanceSynapse;
 
 public class RuneliteColorPicker extends JDialog
 {
+	static final String CONFIG_GROUP = "colorpicker";
+
 	private final static int FRAME_WIDTH = 400;
 	private final static int FRAME_HEIGHT = 380;
 	private final static int TONE_PANEL_SIZE = 160;
@@ -97,6 +99,9 @@ public class RuneliteColorPicker extends JDialog
 		super(parent, "RuneLite Color Picker - " + title, ModalityType.MODELESS);
 
 		this.selectedColor = previousColor;
+		this.alphaHidden = alphaHidden;
+
+		RecentColors recentColors = new RecentColors(configManager);
 
 		setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
 		setResizable(false);
@@ -117,7 +122,6 @@ public class RuneliteColorPicker extends JDialog
 		JPanel rightPanel = new JPanel();
 		rightPanel.setLayout(new GridBagLayout());
 		GridBagConstraints cx = new GridBagConstraints();
-
 
 		cx.insets = new Insets(0, 0, 0, 0);
 		JLabel old = new JLabel("Previous");
@@ -149,11 +153,26 @@ public class RuneliteColorPicker extends JDialog
 		hexContainer.add(hexInput, cx);
 
 		cx.fill = GridBagConstraints.BOTH;
-		cx.gridwidth = GridBagConstraints.RELATIVE;
 		cx.weightx = 1;
 		cx.weighty = 1;
 		cx.gridy = 0;
 		cx.gridx = 0;
+
+		JPanel recentColorsContainer = recentColors.build(c ->
+		{
+			if (!alphaHidden)
+			{
+				alphaSlider.update(c.getAlpha());
+			}
+
+			colorChange(c);
+			updatePanels();
+		}, alphaHidden);
+
+		rightPanel.add(recentColorsContainer, cx);
+
+		cx.gridwidth = GridBagConstraints.RELATIVE;
+		cx.gridy++;
 		rightPanel.add(old, cx);
 
 		cx.gridx++;
@@ -185,7 +204,6 @@ public class RuneliteColorPicker extends JDialog
 		slidersContainer.add(blueSlider);
 		slidersContainer.add(alphaSlider);
 
-		this.alphaHidden = alphaHidden;
 		if (alphaHidden)
 		{
 			alphaSlider.setVisible(false);
@@ -283,6 +301,11 @@ public class RuneliteColorPicker extends JDialog
 				if (onClose != null)
 				{
 					onClose.accept(selectedColor);
+				}
+
+				if (!Objects.equals(previousColor, selectedColor))
+				{
+					recentColors.add(selectedColor.getRGB() + "");
 				}
 
 				RuneliteColorPicker cp = colorPickerManager.getCurrentPicker();


### PR DESCRIPTION
Closes https://github.com/runelite/runelite/issues/7926

Only 1 color picker can be open at a time now. When a new one is opened, the onClose will be executed for the old one.

Everyone will start with no recent colors and then it will slowly build up until there are 16 colors and start evicting the oldest color.

![java_2019-02-23_17-00-54](https://user-images.githubusercontent.com/22979513/53292732-bc8fca80-378c-11e9-9c80-2a558d4d68b4.png)
![java_2019-02-23_17-01-23](https://user-images.githubusercontent.com/22979513/53292734-bef22480-378c-11e9-8ea1-2ef5da2bb5d4.png)
![java_2019-02-20_10-34-14](https://user-images.githubusercontent.com/22979513/53292737-c285ab80-378c-11e9-9bc4-6dba39adacc3.png)



![2019-02-23_16-58-01](https://user-images.githubusercontent.com/22979513/53292706-3d01fb80-378c-11e9-87d0-8957e2b35229.gif)
