### PR TITLE
Move Barrows chat value message to LootTracker Plugin and add support for Raids

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/barrows/BarrowsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/barrows/BarrowsConfig.java
@@ -55,21 +55,10 @@ public interface BarrowsConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "showChestValue",
-		name = "Show Value of Chests",
-		description = "Configure whether to show total exchange value of chest when opened",
-		position = 2
-	)
-	default boolean showChestValue()
-	{
-		return true;
-	}
-
-	@ConfigItem(
 		keyName = "brotherLocColor",
 		name = "Brother location color",
 		description = "Change the color of the name displayed on the minimap",
-		position = 3
+		position = 2
 	)
 	default Color brotherLocColor()
 	{
@@ -80,7 +69,7 @@ public interface BarrowsConfig extends Config
 		keyName = "deadBrotherLocColor",
 		name = "Dead Brother loc. color",
 		description = "Change the color of the name displayed on the minimap for a dead brother",
-		position = 4
+		position = 3
 	)
 	default Color deadBrotherLocColor()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/barrows/BarrowsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/barrows/BarrowsPlugin.java
@@ -31,13 +31,9 @@ import java.util.Set;
 import javax.inject.Inject;
 import lombok.AccessLevel;
 import lombok.Getter;
-import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
 import net.runelite.api.GameObject;
 import net.runelite.api.GameState;
-import net.runelite.api.InventoryID;
-import net.runelite.api.Item;
-import net.runelite.api.ItemContainer;
 import net.runelite.api.NullObjectID;
 import net.runelite.api.ObjectID;
 import net.runelite.api.WallObject;
@@ -50,19 +46,13 @@ import net.runelite.api.events.WallObjectDespawned;
 import net.runelite.api.events.WallObjectSpawned;
 import net.runelite.api.events.WidgetLoaded;
 import net.runelite.api.widgets.Widget;
-import net.runelite.api.widgets.WidgetID;
 import net.runelite.api.widgets.WidgetInfo;
-import net.runelite.client.chat.ChatColorType;
-import net.runelite.client.chat.ChatMessageBuilder;
-import net.runelite.client.chat.ChatMessageManager;
 import net.runelite.client.chat.QueuedMessage;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
-import net.runelite.client.game.ItemManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.OverlayManager;
-import net.runelite.client.util.StackFormatter;
 
 @PluginDescriptor(
 	name = "Barrows Brothers",
@@ -213,35 +203,6 @@ public class BarrowsPlugin extends Plugin
 			// on region changes the tiles get set to null
 			walls.clear();
 			ladders.clear();
-		}
-	}
-
-	@Subscribe
-	public void onWidgetLoaded(WidgetLoaded event)
-	{
-		if (event.getGroupId() == WidgetID.BARROWS_REWARD_GROUP_ID && config.showChestValue())
-		{
-			ItemContainer barrowsRewardContainer = client.getItemContainer(InventoryID.BARROWS_REWARD);
-			Item[] items = barrowsRewardContainer.getItems();
-			long chestPrice = 0;
-
-			for (Item item : items)
-			{
-				long itemStack = (long) itemManager.getItemPrice(item.getId()) * (long) item.getQuantity();
-				chestPrice += itemStack;
-			}
-
-			final ChatMessageBuilder message = new ChatMessageBuilder()
-				.append(ChatColorType.HIGHLIGHT)
-				.append("Your chest is worth around ")
-				.append(StackFormatter.formatNumber(chestPrice))
-				.append(" coins.")
-				.append(ChatColorType.NORMAL);
-
-			chatMessageManager.queue(QueuedMessage.builder()
-				.type(ChatMessageType.EXAMINE_ITEM)
-				.runeLiteFormattedMessage(message.build())
-				.build());
 		}
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/barrows/BarrowsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/barrows/BarrowsPlugin.java
@@ -92,12 +92,6 @@ public class BarrowsPlugin extends Plugin
 	private Client client;
 
 	@Inject
-	private ItemManager itemManager;
-
-	@Inject
-	private ChatMessageManager chatMessageManager;
-
-	@Inject
 	private BarrowsConfig config;
 
 	@Provides

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerConfig.java
@@ -58,4 +58,14 @@ public interface LootTrackerConfig extends Config
 	{
 		return true;
 	}
+
+	@ConfigItem(
+		keyName = "chestLootChat",
+		name = "Show chest loot value in chat",
+		description = "Show the value of items from CoX/ToB/Barrows chests in chat"
+	)
+	default boolean chestLootChat()
+	{
+		return true;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
@@ -45,7 +45,6 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.*;
-import net.runelite.api.ChatMessageType;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.ChatMessage;
 import net.runelite.api.events.ConfigChanged;
@@ -298,28 +297,6 @@ public class LootTrackerPlugin extends Plugin
 			lootTrackerClient.submit(lootRecord);
 		}
 	}
-
-	
-	// 		Item[] items = raidsRewardContainer.getItems();
-	// 		long chestPrice = 0;
-	// 		for (Item item : items) {
-	// 			long itemStack = (long) itemManager.getItemPrice(item.getId()) * (long) item.getQuantity();
-	// 			chestPrice += itemStack;
-	// 		}
-
-	// 		final ChatMessageBuilder message = new ChatMessageBuilder()
-	// 				.append(ChatColorType.HIGHLIGHT)
-	// 				.append("Your loot is worth around ")
-	// 				.append(StackFormatter.formatNumber(chestPrice))
-	// 				.append(" coins.")
-	// 				.append(ChatColorType.NORMAL);
-
-	// 		chatMessageManager.queue(QueuedMessage.builder()
-	// 				.type(ChatMessageType.EXAMINE_ITEM)
-	// 				.runeLiteFormattedMessage(message.build())
-	// 				.build());
-	// 	}
-	// }
 
 	@Subscribe
 	public void onWidgetLoaded(WidgetLoaded event)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
@@ -44,14 +44,8 @@ import javax.swing.SwingUtilities;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.*;
 import net.runelite.api.ChatMessageType;
-import net.runelite.api.Client;
-import net.runelite.api.InventoryID;
-import net.runelite.api.ItemComposition;
-import net.runelite.api.ItemContainer;
-import net.runelite.api.NPC;
-import net.runelite.api.Player;
-import net.runelite.api.SpriteID;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.ChatMessage;
 import net.runelite.api.events.ConfigChanged;
@@ -62,6 +56,10 @@ import net.runelite.api.widgets.WidgetID;
 import net.runelite.client.account.AccountSession;
 import net.runelite.client.account.SessionManager;
 import net.runelite.client.callback.ClientThread;
+import net.runelite.client.chat.ChatColorType;
+import net.runelite.client.chat.ChatMessageBuilder;
+import net.runelite.client.chat.ChatMessageManager;
+import net.runelite.client.chat.QueuedMessage;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.events.NpcLootReceived;
@@ -74,6 +72,7 @@ import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.ClientToolbar;
 import net.runelite.client.ui.NavigationButton;
 import net.runelite.client.util.ImageUtil;
+import net.runelite.client.util.StackFormatter;
 import net.runelite.client.util.Text;
 import net.runelite.http.api.loottracker.GameItem;
 import net.runelite.http.api.loottracker.LootRecord;
@@ -98,6 +97,9 @@ public class LootTrackerPlugin extends Plugin
 
 	@Inject
 	private ItemManager itemManager;
+
+	@Inject
+	private ChatMessageManager chatMessageManager;
 
 	@Inject
 	private SpriteManager spriteManager;
@@ -297,6 +299,28 @@ public class LootTrackerPlugin extends Plugin
 		}
 	}
 
+	
+	// 		Item[] items = raidsRewardContainer.getItems();
+	// 		long chestPrice = 0;
+	// 		for (Item item : items) {
+	// 			long itemStack = (long) itemManager.getItemPrice(item.getId()) * (long) item.getQuantity();
+	// 			chestPrice += itemStack;
+	// 		}
+
+	// 		final ChatMessageBuilder message = new ChatMessageBuilder()
+	// 				.append(ChatColorType.HIGHLIGHT)
+	// 				.append("Your loot is worth around ")
+	// 				.append(StackFormatter.formatNumber(chestPrice))
+	// 				.append(" coins.")
+	// 				.append(ChatColorType.NORMAL);
+
+	// 		chatMessageManager.queue(QueuedMessage.builder()
+	// 				.type(ChatMessageType.EXAMINE_ITEM)
+	// 				.runeLiteFormattedMessage(message.build())
+	// 				.build());
+	// 	}
+	// }
+
 	@Subscribe
 	public void onWidgetLoaded(WidgetLoaded event)
 	{
@@ -332,6 +356,28 @@ public class LootTrackerPlugin extends Plugin
 		if (container == null)
 		{
 			return;
+		}
+
+		if (!(event.getGroupId() == WidgetID.CLUE_SCROLL_REWARD_GROUP_ID) && config.chestLootChat())
+		{
+			Item[] items = container.getItems();
+			long chestPrice = 0;
+			for (Item item : items) {
+				long itemStack = (long) itemManager.getItemPrice(item.getId()) * (long) item.getQuantity();
+				chestPrice += itemStack;
+			}
+
+			final ChatMessageBuilder message = new ChatMessageBuilder()
+					.append(ChatColorType.HIGHLIGHT)
+					.append("Your loot is worth around ")
+					.append(StackFormatter.formatNumber(chestPrice))
+					.append(" coins.")
+					.append(ChatColorType.NORMAL);
+
+			chatMessageManager.queue(QueuedMessage.builder()
+					.type(ChatMessageType.EXAMINE_ITEM)
+					.runeLiteFormattedMessage(message.build())
+					.build());
 		}
 
 		// Convert container items to array of ItemStack


### PR DESCRIPTION
First time contributing to the client, this is a feature that I have wanted in the client for a while as each time I complete a raid I either price check my loot or look at my loot tracker as I know many others do, this enhancement will eliminate that step 😄 , this may be appropriate somewhere other than loottracker and originally I had it in RaidsPlugin but as I wanted it in ToB as well and there is no base ToB plugin loottracker was the plugin that made the most sense