### PR TITLE
WIP: Add Pest Control features

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/pestcontrol/NpcHighlightContext.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/pestcontrol/NpcHighlightContext.java
@@ -1,0 +1,17 @@
+package net.runelite.client.plugins.pestcontrol;
+
+import java.awt.Color;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+import net.runelite.client.plugins.pestcontrol.config.NpcHighlightStyle;
+
+@AllArgsConstructor
+@Getter
+@Setter
+public class NpcHighlightContext
+{
+	private NpcHighlightStyle npcRenderStyle;
+	private Color color;
+	private boolean showNpcName = false;
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/pestcontrol/NpcHighlightOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/pestcontrol/NpcHighlightOverlay.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2018, James Swindle <wilingua@gmail.com>
+ * Copyright (c) 2018, Adam <Adam@sigterm.info>
+ * Copyright (c) 2018, Shaun Dreclin <shaundreclin@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.pestcontrol;
+
+import javax.inject.Inject;
+import java.awt.BasicStroke;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Graphics2D;
+import java.awt.Polygon;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.Client;
+import net.runelite.api.NPC;
+import net.runelite.api.Perspective;
+import net.runelite.api.Point;
+import net.runelite.api.widgets.WidgetInfo;
+import net.runelite.client.plugins.pestcontrol.config.NpcHighlightStyle;
+import net.runelite.client.ui.overlay.Overlay;
+import net.runelite.client.ui.overlay.OverlayLayer;
+import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.OverlayUtil;
+
+@Slf4j
+public class NpcHighlightOverlay extends Overlay
+{
+	private final PestControlConfig config;
+	private final PestControlPlugin plugin;
+	private final Client client;
+
+	@Inject
+	NpcHighlightOverlay(PestControlConfig config, PestControlPlugin plugin, Client client)
+	{
+		this.config = config;
+		this.plugin = plugin;
+		this.client = client;
+
+		setPosition(OverlayPosition.DYNAMIC);
+		setLayer(OverlayLayer.ABOVE_SCENE);
+	}
+
+	@Override
+	public Dimension render(Graphics2D graphics)
+	{
+		if (client.getWidget(WidgetInfo.PEST_CONTROL_BLUE_SHIELD) == null)
+		{
+			return null;
+		}
+
+		HashMap aliveNpcList = plugin.getAliveNpcList();
+
+		if(aliveNpcList == null){
+			return null;
+		}
+
+		Iterator entries = aliveNpcList.entrySet().iterator();
+		while (entries.hasNext())
+		{
+			HashMap.Entry entry = (HashMap.Entry) entries.next();
+
+			Integer npcParentId = (Integer)entry.getKey();
+			List<NPC> npcList = (List<NPC>)entry.getValue();
+
+			for(NPC npc : npcList)
+			{
+
+				NpcHighlightContext npcHighlightContext = plugin.getHighlightedNpcList().get(npcParentId);
+
+				String name = npcHighlightContext.isShowNpcName() ? npc.getName() : null;
+				Color color = npcHighlightContext.getColor();
+				NpcHighlightStyle highlightStyle = npcHighlightContext.getNpcRenderStyle();
+
+				switch(highlightStyle){
+					case HULL: {
+						renderHullOverlay(graphics, npc, color);
+						break;
+					}
+					case TILE: {
+						renderTileOverlay(graphics, npc, color);
+						break;
+					}
+					case BOTH: {
+						renderHullOverlay(graphics, npc, color);
+						renderTileOverlay(graphics, npc, color);
+						break;
+					}
+				}
+
+				if(name != null){
+					renderTextOverlay(graphics, npc, name, color);
+				}
+			}
+		}
+
+		return null;
+	}
+
+	private void renderTileOverlay(Graphics2D graphics, NPC actor, Color color)
+	{
+		Polygon polygon;
+
+		// Double the polygon size if it's a Brawler
+		if(PestControlPlugin.isBrawler(actor.getId())){
+			polygon = Perspective.getCanvasTileAreaPoly(client, actor.getLocalLocation(), 2);
+		} else {
+			polygon = actor.getCanvasTilePoly();
+		}
+
+		if (polygon != null)
+		{
+			OverlayUtil.renderPolygon(graphics, polygon, color);
+		}
+	}
+
+	private void renderHullOverlay(Graphics2D graphics, NPC actor, Color color)
+	{
+		Polygon objectClickbox = actor.getConvexHull();
+		if (objectClickbox != null)
+		{
+			graphics.setColor(color);
+			graphics.setStroke(new BasicStroke(2));
+			graphics.draw(objectClickbox);
+			graphics.setColor(new Color(color.getRed(), color.getGreen(), color.getBlue(), 20));
+			graphics.fill(objectClickbox);
+		}
+	}
+
+	private void renderTextOverlay(Graphics2D graphics, NPC npc, String text, Color color){
+		Point textLocation = npc.getCanvasTextLocation(graphics, text, npc.getLogicalHeight() + 40);
+		if (textLocation != null)
+		{
+			OverlayUtil.renderTextLocation(graphics, textLocation, text, color);
+		}
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/pestcontrol/PestControlConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/pestcontrol/PestControlConfig.java
@@ -1,0 +1,257 @@
+/*
+ * Copyright (c) 2018, Cas <https://github.com/casvandongen>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.pestcontrol;
+
+import java.awt.Color;
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+import net.runelite.client.plugins.pestcontrol.config.HighlightPortalOption;
+import net.runelite.client.plugins.pestcontrol.config.NpcHighlightStyle;
+
+@ConfigGroup("pestcontrol")
+public interface PestControlConfig extends Config
+{
+	@ConfigItem(
+		keyName = "showHintArrow",
+		name = "Show hint arrows",
+		description = "Show hint arrows to the portals that can be attacked.",
+		position = 2
+	)
+	default boolean showHintArrow()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		keyName = "showPortalWeakness",
+		name = "Show portal weakness",
+		description = "Show the combat style weakness of the portals.",
+		position = 3
+	)
+	default boolean showCombatWeakness()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		keyName = "showCombatRequirements",
+		name = "Show combat requirements",
+		description = "Adds the minimum required combat level to the banner pole.",
+		position = 4
+	)
+	default boolean showCombatRequirements()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		keyName = "highlightPortals",
+		name = "Highlight portals",
+		description = "Adds the minimum required combat level to the banner pole.",
+		position = 5
+	)
+	default HighlightPortalOption highlightPortals()
+	{
+		return HighlightPortalOption.ALL;
+	}
+
+	@ConfigItem(
+		keyName = "activePortalColor",
+		name = "Active portal color",
+		description = "Color of the portals that can be attacked.",
+		position = 6
+	)
+	default Color activePortalColor()
+	{
+		return Color.GREEN;
+	}
+
+	@ConfigItem(
+		keyName = "shieldedPortalColor",
+		name = "Shielded portal color",
+		description = "Color of the portals that can not be attacked yet.",
+		position = 7
+	)
+	default Color shieldedPortalColor()
+	{
+		return Color.BLUE;
+	}
+
+	@ConfigItem(
+		keyName = "spinnerHighlight",
+		name = "Highlight Spinners",
+		description = "Highlights Spinners. Highlighting them is recommended as Spinners heal the portals.",
+		position = 8
+	)
+	default NpcHighlightStyle spinnerHighlight()
+	{
+		return NpcHighlightStyle.BOTH;
+	}
+
+	@ConfigItem(
+		keyName = "spinnerColor",
+		name = "Spinner color",
+		description = "Color of highlighted Spinners.",
+		position = 9
+	)
+	default Color spinnerColor()
+	{
+		return Color.CYAN;
+	}
+
+	@ConfigItem(
+		keyName = "brawlerHighlight",
+		name = "Highlight Brawlers",
+		description = "Highlights Brawlers.",
+		position = 10
+	)
+	default NpcHighlightStyle brawlerHighlight()
+	{
+		return NpcHighlightStyle.TILE;
+	}
+
+	@ConfigItem(
+		keyName = "brawlerColor",
+		name = "Brawler color",
+		description = "Color of highlighted Brawlers.",
+		position = 11
+	)
+	default Color brawlerColor()
+	{
+		return Color.ORANGE;
+	}
+
+	@ConfigItem(
+		keyName = "splatterHighlight",
+		name = "Highlight Splatters",
+		description = "Highlights Splatters.",
+		position = 12
+	)
+	default NpcHighlightStyle splatterHighlight()
+	{
+		return NpcHighlightStyle.TILE;
+	}
+
+	@ConfigItem(
+		keyName = "splatterColor",
+		name = "Splatter color",
+		description = "Color of highlighted Splatters.",
+		position = 13
+	)
+	default Color splatterColor()
+	{
+		return Color.RED;
+	}
+
+	@ConfigItem(
+		keyName = "shifterHighlight",
+		name = "Highlight Shifters",
+		description = "Highlights Brawlers.",
+		position = 14
+	)
+	default NpcHighlightStyle shifterHighlight()
+	{
+		return NpcHighlightStyle.TILE;
+	}
+
+	@ConfigItem(
+		keyName = "shifterColor",
+		name = "Spinner color",
+		description = "Color of highlighted Spinners.",
+		position = 15
+	)
+	default Color shifterColor()
+	{
+		return Color.GRAY;
+	}
+
+	@ConfigItem(
+		keyName = "defilerHighlight",
+		name = "Highlight Defilers",
+		description = "Highlights Defilers.",
+		position = 16
+	)
+	default NpcHighlightStyle defilerHighlight()
+	{
+		return NpcHighlightStyle.TILE;
+	}
+
+	@ConfigItem(
+		keyName = "defilerColor",
+		name = "Defiler color",
+		description = "Color of highlighted Defilers.",
+		position = 17
+	)
+	default Color defilerColor()
+	{
+		return Color.GRAY;
+	}
+
+	@ConfigItem(
+		keyName = "ravagerHighlight",
+		name = "Highlight Ravagers",
+		description = "Highlights Ravagers.",
+		position = 18
+	)
+	default NpcHighlightStyle ravagerHighlight()
+	{
+		return NpcHighlightStyle.TILE;
+	}
+
+	@ConfigItem(
+		keyName = "ravagerColor",
+		name = "Ravager color",
+		description = "Color of highlighted Ravagers.",
+		position = 19
+	)
+	default Color ravagerColor()
+	{
+		return Color.GRAY;
+	}
+
+	@ConfigItem(
+		keyName = "torcherHighlight",
+		name = "Highlight Torchers",
+		description = "Highlights Torchers.",
+		position = 20
+	)
+	default NpcHighlightStyle torcherHighlight()
+	{
+		return NpcHighlightStyle.TILE;
+	}
+
+	@ConfigItem(
+		keyName = "torcherColor",
+		name = "Torcher color",
+		description = "Color of highlighted Torchers.",
+		position = 21
+	)
+	default Color torcherColor()
+	{
+		return Color.GRAY;
+	}
+
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/pestcontrol/PestControlPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/pestcontrol/PestControlPlugin.java
@@ -25,7 +25,9 @@
 package net.runelite.client.plugins.pestcontrol;
 
 import com.google.common.collect.ImmutableSet;
+import com.google.inject.Provides;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Set;
 import java.util.regex.Matcher;
@@ -33,20 +35,27 @@ import java.util.regex.Pattern;
 import javax.inject.Inject;
 import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
 import net.runelite.api.GameState;
 import net.runelite.api.NPC;
 import net.runelite.api.NpcID;
 import net.runelite.api.events.ChatMessage;
+import net.runelite.api.events.ConfigChanged;
 import net.runelite.api.events.GameStateChanged;
+import net.runelite.api.events.GameTick;
 import net.runelite.api.events.NpcDespawned;
 import net.runelite.api.events.NpcSpawned;
+import net.runelite.api.widgets.WidgetInfo;
+import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.plugins.pestcontrol.config.NpcHighlightStyle;
 import net.runelite.client.ui.overlay.OverlayManager;
 
+@Slf4j
 @PluginDescriptor(
 	name = "Pest Control",
 	description = "Show helpful information for the Pest Control minigame",
@@ -54,6 +63,35 @@ import net.runelite.client.ui.overlay.OverlayManager;
 )
 public class PestControlPlugin extends Plugin
 {
+	private static final Set<Integer> SPLATTER_IDS = ImmutableSet.of(
+		NpcID.SPLATTER,
+		NpcID.SPLATTER_1690,
+		NpcID.SPLATTER_1691,
+		NpcID.SPLATTER_1692,
+		NpcID.SPLATTER_1693
+	);
+
+	private static final Set<Integer> SHIFTER_IDS = ImmutableSet.of(
+		NpcID.SHIFTER,
+		NpcID.SHIFTER_1695,
+		NpcID.SHIFTER_1696,
+		NpcID.SHIFTER_1697,
+		NpcID.SHIFTER_1698,
+		NpcID.SHIFTER_1699,
+		NpcID.SHIFTER_1700,
+		NpcID.SHIFTER_1701,
+		NpcID.SHIFTER_1702,
+		NpcID.SHIFTER_1703
+	);
+
+	private static final Set<Integer> RAVAGER_IDS = ImmutableSet.of(
+		NpcID.RAVAGER,
+		NpcID.RAVAGER_1705,
+		NpcID.RAVAGER_1706,
+		NpcID.RAVAGER_1707,
+		NpcID.RAVAGER_1708
+	);
+
 	private static final Set<Integer> SPINNER_IDS = ImmutableSet.of(
 		NpcID.SPINNER,
 		NpcID.SPINNER_1710,
@@ -62,10 +100,94 @@ public class PestControlPlugin extends Plugin
 		NpcID.SPINNER_1713
 	);
 
-	private final Pattern SHIELD_DROP = Pattern.compile("The ([a-z]+), [^ ]+ portal shield has dropped!", Pattern.CASE_INSENSITIVE);
+	private static final Set<Integer> TORCHER_IDS = ImmutableSet.of(
+		NpcID.TORCHER,
+		NpcID.TORCHER_1715,
+		NpcID.TORCHER_1716,
+		NpcID.TORCHER_1717,
+		NpcID.TORCHER_1718,
+		NpcID.TORCHER_1719,
+		NpcID.TORCHER_1720,
+		NpcID.TORCHER_1721,
+		NpcID.TORCHER_1722,
+		NpcID.TORCHER_1723
+	);
 
-	@Getter(AccessLevel.PACKAGE)
-	private List<NPC> spinners = new ArrayList<>();
+	private static final Set<Integer> DEFILER_IDS = ImmutableSet.of(
+		NpcID.DEFILER,
+		NpcID.DEFILER_1725,
+		NpcID.DEFILER_1726,
+		NpcID.DEFILER_1727,
+		NpcID.DEFILER_1728,
+		NpcID.DEFILER_1729,
+		NpcID.DEFILER_1730,
+		NpcID.DEFILER_1731,
+		NpcID.DEFILER_1732,
+		NpcID.DEFILER_1733
+	);
+
+	private static final Set<Integer> BRAWLER_IDS = ImmutableSet.of(
+		NpcID.BRAWLER,
+		NpcID.BRAWLER_1735,
+		NpcID.BRAWLER_1736,
+		NpcID.BRAWLER_1737,
+		NpcID.BRAWLER_1738
+	);
+
+	private	static final Set<Integer> PORTAL_SHIELD_IDS = ImmutableSet.of(
+		NpcID.PORTAL_1751,
+		NpcID.PORTAL_1752,
+		NpcID.PORTAL_1753,
+		NpcID.PORTAL_1754
+	);
+
+	private	static final Set<Integer> PORTAL_ACTIVE_IDS = ImmutableSet.of(
+		NpcID.PORTAL_1747,
+		NpcID.PORTAL_1748,
+		NpcID.PORTAL_1749,
+		NpcID.PORTAL_1750
+	);
+
+	private	static final Set<Integer> PORTAL_PURPLE_IDS = ImmutableSet.of(
+		NpcID.PORTAL_1747,
+		NpcID.PORTAL_1751
+	);
+
+	private	static final Set<Integer> PORTAL_BLUE_IDS = ImmutableSet.of(
+		NpcID.PORTAL_1748,
+		NpcID.PORTAL_1752
+	);
+
+	private	static final Set<Integer> PORTAL_YELLOW_IDS = ImmutableSet.of(
+		NpcID.PORTAL_1749,
+		NpcID.PORTAL_1753
+	);
+
+	private	static final Set<Integer> PORTAL_RED_IDS = ImmutableSet.of(
+		NpcID.PORTAL_1750,
+		NpcID.PORTAL_1754
+	);
+
+	private	static final Set<Integer> INGAME_VOID_KNIGHT_IDS = ImmutableSet.of(
+		NpcID.VOID_KNIGHT_2950,
+		NpcID.VOID_KNIGHT_2951,
+		NpcID.VOID_KNIGHT_2952,
+		NpcID.VOID_KNIGHT_2953
+	);
+
+	// Combat 40+ (3 points)
+	private final int NOVICE_BANNER = 25620;
+	private final int NOVICE_GANGPLANK = 14315;
+
+	// Combat 70+ (4 points)
+	private final int INTERMEDIATE_BANNER = 25621;
+	private final int INTERMEDIATE_GANGPLANK = 25631;
+
+	// Combat 100+ (5 points)
+	private final int VETERAN_BANNER = 25622;
+	private final int VETERAN_GANGPLANK = 25632;
+
+	private final Pattern SHIELD_DROP = Pattern.compile("The ([a-z]+), [^ ]+ portal shield has dropped!", Pattern.CASE_INSENSITIVE);
 
 	@Inject
 	private OverlayManager overlayManager;
@@ -74,39 +196,179 @@ public class PestControlPlugin extends Plugin
 	private Client client;
 
 	@Inject
-	private PestControlOverlay overlay;
+	private WidgetOverlay widgetOverlay;
+
+	@Inject
+	private NpcHighlightOverlay npcHighlightOverlay;
+
+	@Inject
+	private PortalOverlay portalOverlay;
+
+	@Inject
+	private PestControlConfig config;
+
+	@Getter
+	private Game game;
+
+	@Getter(AccessLevel.PACKAGE)
+	private HashMap<Integer, List<NPC>> aliveNpcList = new HashMap<Integer, List<NPC>>();
+
+	@Getter(AccessLevel.PACKAGE)
+	private HashMap<Integer, NpcHighlightContext> highlightedNpcList = new HashMap<Integer, NpcHighlightContext>();
+
+	@Provides
+	PestControlConfig provideConfig(ConfigManager configManager)
+	{
+		return configManager.getConfig(PestControlConfig.class);
+	}
 
 	@Override
 	protected void startUp() throws Exception
 	{
-		overlayManager.add(overlay);
+		loadPlugin();
 	}
 
 	@Override
 	protected void shutDown() throws Exception
 	{
-		overlayManager.remove(overlay);
-		spinners.clear();
+		unloadPlugin();
+	}
+
+	private void loadPlugin()
+	{
+		if(config.spinnerHighlight() != NpcHighlightStyle.OFF){
+			highlightedNpcList.put(NpcID.SPINNER, new NpcHighlightContext(
+				config.spinnerHighlight(),
+				config.spinnerColor(),
+				true
+			));
+		}
+
+		if(config.brawlerHighlight() != NpcHighlightStyle.OFF){
+			highlightedNpcList.put(NpcID.BRAWLER, new NpcHighlightContext(
+				config.brawlerHighlight(),
+				config.brawlerColor(),
+				false
+			));
+		}
+
+		if(config.splatterHighlight() != NpcHighlightStyle.OFF){
+			highlightedNpcList.put(NpcID.SPLATTER, new NpcHighlightContext(
+				config.splatterHighlight(),
+				config.splatterColor(),
+				false
+			));
+		}
+
+		if(config.shifterHighlight() != NpcHighlightStyle.OFF){
+			highlightedNpcList.put(NpcID.SHIFTER, new NpcHighlightContext(
+				config.shifterHighlight(),
+				config.shifterColor(),
+				false
+			));
+		}
+
+		if(config.defilerHighlight() != NpcHighlightStyle.OFF){
+			highlightedNpcList.put(NpcID.DEFILER, new NpcHighlightContext(
+				config.defilerHighlight(),
+				config.defilerColor(),
+				false
+			));
+		}
+
+		if(config.ravagerHighlight() != NpcHighlightStyle.OFF){
+			highlightedNpcList.put(NpcID.RAVAGER, new NpcHighlightContext(
+				config.ravagerHighlight(),
+				config.ravagerColor(),
+				false
+			));
+		}
+
+		if(config.torcherHighlight() != NpcHighlightStyle.OFF){
+			highlightedNpcList.put(NpcID.TORCHER, new NpcHighlightContext(
+				config.torcherHighlight(),
+				config.torcherColor(),
+				false
+			));
+		}
+
+		overlayManager.add(widgetOverlay);
+		overlayManager.add(npcHighlightOverlay);
+		overlayManager.add(portalOverlay);
+	}
+
+	private void unloadPlugin()
+	{
+		overlayManager.remove(widgetOverlay);
+		overlayManager.remove(npcHighlightOverlay);
+		overlayManager.remove(portalOverlay);
+
+		highlightedNpcList.clear();
+
+		if(game != null){
+			if(config.showHintArrow() && client.hasHintArrow()){
+				client.clearHintArrow();
+			}
+		}
+	}
+
+	@Subscribe
+	public void onConfigChanged(ConfigChanged event)
+	{
+		if (event.getGroup().equals("pestcontrol"))
+		{
+			unloadPlugin();
+			loadPlugin();
+		}
+	}
+
+	@Subscribe
+	public void onGameTick(GameTick event)
+	{
+		// See if we are in a game or not
+		if (client.getWidget(WidgetInfo.PEST_CONTROL_BLUE_SHIELD) == null)
+		{
+			if (game != null)
+			{
+				log.debug("Pest control game has ended");
+				game = null;
+			}
+
+			return;
+		}
+
+		if (game == null)
+		{
+			log.debug("Pest control game has started");
+			game = new Game(client);
+		}
+
+		if(!game.isPortalLocationsSet())
+		{
+			game.loadPortalLocations();
+		}
+
+		game.updatePortalNpcs();
 	}
 
 	@Subscribe
 	public void onGameStateChanged(GameStateChanged event)
 	{
-		if (event.getGameState() == GameState.LOADING)
+		if (event.getGameState() == GameState.LOADING && client.getWidget(WidgetInfo.PEST_CONTROL_BLUE_SHIELD) == null)
 		{
-			spinners.clear();
+			aliveNpcList.clear();
 		}
 	}
 
 	@Subscribe
 	public void onChatMessage(ChatMessage chatMessage)
 	{
-		if (overlay.getGame() != null && chatMessage.getType() == ChatMessageType.SERVER)
+		if (game != null && chatMessage.getType() == ChatMessageType.SERVER)
 		{
 			Matcher matcher = SHIELD_DROP.matcher(chatMessage.getMessage());
 			if (matcher.lookingAt())
 			{
-				overlay.getGame().fall(matcher.group(1));
+				game.fall(matcher.group(1));
 			}
 		}
 	}
@@ -115,15 +377,167 @@ public class PestControlPlugin extends Plugin
 	public void onNpcSpawned(NpcSpawned event)
 	{
 		final NPC npc = event.getNpc();
-		if (SPINNER_IDS.contains(npc.getId()))
-		{
-			spinners.add(npc);
+		final int npcId = npc.getId();
+		int parentNpcId = getParentNpcId(npcId);
+
+		if(parentNpcId == 0){
+			return;
 		}
+
+		if(!highlightedNpcList.containsKey(parentNpcId))
+		{
+			return;
+		}
+
+		List npcList = aliveNpcList.get(parentNpcId);
+
+		if(npcList == null){
+			npcList = new ArrayList<NPC>();
+			aliveNpcList.put(parentNpcId, npcList);
+		}
+
+		npcList.add(npc);
 	}
 
 	@Subscribe
 	public void onNpcDespawned(NpcDespawned event)
 	{
-		spinners.remove(event.getNpc());
+		if(game == null)
+		{
+			return;
+		}
+
+		final NPC npc = event.getNpc();
+		final int npcId = npc.getId();
+
+		NPC arrowNpc = client.getHintArrowNpc();
+
+		// Handle portal NPCs
+		if(npc == game.getBlue().getNpc())
+		{
+			game.getBlue().setNpc(null);
+			game.updatePortalNpcs();
+			if(arrowNpc != null && arrowNpc == npc)
+			{
+				client.setHintArrow(game.getBlue().getLocation());
+			}
+			return;
+		}
+		if(npc == game.getRed().getNpc())
+		{
+			game.getRed().setNpc(null);
+			game.updatePortalNpcs();
+			if(arrowNpc != null && arrowNpc == npc)
+			{
+				client.setHintArrow(game.getRed().getLocation());
+			}
+			return;
+		}
+		if(npc == game.getYellow().getNpc())
+		{
+			game.getYellow().setNpc(null);
+			game.updatePortalNpcs();
+			if(arrowNpc != null && arrowNpc == npc)
+			{
+				client.setHintArrow(game.getYellow().getLocation());
+			}
+			return;
+		}
+		if(npc == game.getPurple().getNpc())
+		{
+			game.getPurple().setNpc(null);
+			game.updatePortalNpcs();
+			if(arrowNpc != null && arrowNpc == npc)
+			{
+				client.setHintArrow(game.getPurple().getLocation());
+			}
+			return;
+		}
+
+		// Handle normal npc's
+		int parentNpcId = getParentNpcId(npcId);
+		if(parentNpcId == 0){
+			return;
+		}
+
+		if(!aliveNpcList.containsKey(parentNpcId)){
+			return;
+		}
+
+		List npcList = aliveNpcList.get(parentNpcId);
+
+		if(npcList != null){
+			npcList.remove(npc);
+		}
+	}
+
+	private int getParentNpcId(int npcID){
+		if (SHIFTER_IDS.contains(npcID)){
+			return NpcID.SHIFTER;
+		}
+		if (RAVAGER_IDS.contains(npcID)){
+			return NpcID.RAVAGER;
+		}
+		if (SPINNER_IDS.contains(npcID)){
+			return NpcID.SPINNER;
+		}
+		if (SPLATTER_IDS.contains(npcID)){
+			return NpcID.SPLATTER;
+		}
+		if (TORCHER_IDS.contains(npcID)){
+			return NpcID.TORCHER;
+		}
+		if (DEFILER_IDS.contains(npcID)){
+			return NpcID.DEFILER;
+		}
+		if (BRAWLER_IDS.contains(npcID)){
+			return NpcID.BRAWLER;
+		}
+
+		return 0;
+	}
+
+	public static boolean isBrawler(int npcId)
+	{
+		return BRAWLER_IDS.contains(npcId);
+	}
+
+	public static boolean isIngameVoidKnight(int npcId)
+	{
+		return INGAME_VOID_KNIGHT_IDS.contains(npcId);
+	}
+
+	public static boolean isActivePortal(int npcId)
+	{
+		return PORTAL_ACTIVE_IDS.contains(npcId);
+	}
+
+	public static boolean isShieldedPortal(int npcId)
+	{
+		return PORTAL_SHIELD_IDS.contains(npcId);
+	}
+
+	public static boolean isPortal(int npcId) {
+		return (isActivePortal(npcId) || isShieldedPortal(npcId));
+	}
+
+	public static boolean isPurplePortal(int npcId)
+	{
+		return PORTAL_PURPLE_IDS.contains(npcId);
+	}
+
+	public static boolean isBluePortal(int npcId)
+	{
+		return PORTAL_BLUE_IDS.contains(npcId);
+	}
+
+	public static boolean isYellowPortal(int npcId)
+	{
+		return PORTAL_YELLOW_IDS.contains(npcId);
+	}
+
+	public static boolean isRedPortal(int npcId)
+	{
+		return PORTAL_RED_IDS.contains(npcId);
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/pestcontrol/PortalContext.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/pestcontrol/PortalContext.java
@@ -27,6 +27,8 @@ package net.runelite.client.plugins.pestcontrol;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
+import net.runelite.api.NPC;
+import net.runelite.api.coords.WorldPoint;
 
 @RequiredArgsConstructor
 @Getter
@@ -34,6 +36,8 @@ import lombok.Setter;
 class PortalContext
 {
 	private final Portal portal;
+	private WorldPoint location;
+	private NPC npc;
 	private boolean isShielded = true;
 	private boolean isDead;
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/pestcontrol/PortalOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/pestcontrol/PortalOverlay.java
@@ -1,0 +1,87 @@
+package net.runelite.client.plugins.pestcontrol;
+
+
+import java.awt.BasicStroke;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Graphics2D;
+import java.awt.Polygon;
+import javax.inject.Inject;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.Client;
+import net.runelite.api.NPC;
+import net.runelite.api.Point;
+import net.runelite.client.plugins.pestcontrol.config.HighlightPortalOption;
+import net.runelite.client.ui.overlay.Overlay;
+import net.runelite.client.ui.overlay.OverlayLayer;
+import net.runelite.client.ui.overlay.OverlayPosition;
+
+@Slf4j
+public class PortalOverlay extends Overlay
+{
+	private final PestControlConfig config;
+	private final PestControlPlugin plugin;
+	private final Client client;
+
+	@Inject
+	PortalOverlay(PestControlConfig config, PestControlPlugin plugin, Client client)
+	{
+		this.config = config;
+		this.plugin = plugin;
+		this.client = client;
+
+		setPosition(OverlayPosition.DYNAMIC);
+		setLayer(OverlayLayer.ABOVE_SCENE);
+	}
+
+	@Override
+	public Dimension render(Graphics2D graphics)
+	{
+		if(config.highlightPortals() == HighlightPortalOption.OFF){
+			return null;
+		}
+
+		boolean highlightActivePortals = (
+			config.highlightPortals() == HighlightPortalOption.ACTIVE ||
+				config.highlightPortals() == HighlightPortalOption.ALL
+		);
+
+		boolean highlightShieldedPortals = (
+			config.highlightPortals() == HighlightPortalOption.SHIELDED ||
+				config.highlightPortals() == HighlightPortalOption.ALL
+		);
+
+		Point mousePosition = client.getMouseCanvasPosition();
+
+		for(NPC npc : client.getNpcs())
+		{
+			if(!PestControlPlugin.isPortal(npc.getId()))
+			{
+				continue;
+			}
+
+			if(!(PestControlPlugin.isActivePortal(npc.getId()) && highlightActivePortals) &&
+					!(PestControlPlugin.isShieldedPortal(npc.getId()) && highlightShieldedPortals)
+			)
+			{
+				continue;
+			}
+
+			Color color = PestControlPlugin.isActivePortal(npc.getId()) ?
+				config.activePortalColor() :
+				config.shieldedPortalColor();
+
+			Polygon objectClickbox = npc.getConvexHull();
+			if (objectClickbox != null)
+			{
+				graphics.setColor(color);
+				graphics.setStroke(new BasicStroke(2));
+				graphics.draw(objectClickbox);
+				graphics.setColor(new Color(color.getRed(), color.getGreen(), color.getBlue(), 20));
+				graphics.fill(objectClickbox);
+			}
+		}
+
+		return null;
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/pestcontrol/config/HighlightPortalOption.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/pestcontrol/config/HighlightPortalOption.java
@@ -1,0 +1,22 @@
+package net.runelite.client.plugins.pestcontrol.config;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum HighlightPortalOption
+{
+	OFF("Off"),
+	ACTIVE("Active"),
+	SHIELDED("Shielded"),
+	ALL("All");
+
+	private final String option;
+
+	@Override
+	public String toString()
+	{
+		return option;
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/pestcontrol/config/NpcHighlightStyle.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/pestcontrol/config/NpcHighlightStyle.java
@@ -1,0 +1,22 @@
+package net.runelite.client.plugins.pestcontrol.config;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum NpcHighlightStyle
+{
+	OFF("Off"),
+	TILE("Tile"),
+	HULL("Hull"),
+	BOTH("Hull + Tile");
+
+	private final String style;
+
+	@Override
+	public String toString()
+	{
+		return style;
+	}
+}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6956790/53305667-8b92c100-3884-11e9-8e65-2f88b3a1ca10.png)

This PR is currently a WIP. I started building on it thinking I wouldn't have to change too much but to keep everything nice and clean I will refactor this. 

Current Features:
- Different NPC highlighting
- Portal highlighting
- Portal hint arrow (works across the whole instance as it switches between WorldPoint & NPC)

Todo:
- Refactor
- Always show points on the island
- Add combat requirements (examine text banner and/or gangplank)
- Option to highlight gangplanks
- Test this with Intermediate & Veteran boats

Interesting things:
- For the Brawlers I had to increase the Dimension of the Tile Polygon by 2. This method could maybe be hardcoded to work with all multiple-space-occupying NPC's.
- The coords of the portals are different within every game instance. I had to calculate them relative to the Void Knight's coords. I think this is the best way of doing this as enables hint arrows across the whole instance.

Any discussion is welcome.