### PR TITLE
Fix some plugins that reset internals incorrectly when changing scene

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingPlugin.java
@@ -65,6 +65,7 @@ import net.runelite.client.plugins.PluginDependency;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.plugins.xptracker.XpTrackerPlugin;
 import net.runelite.client.ui.overlay.OverlayManager;
+import net.runelite.client.util.GameEventManager;
 
 @PluginDescriptor(
 	name = "Fishing",
@@ -147,7 +148,7 @@ public class FishingPlugin extends Plugin
 	@Subscribe
 	public void onGameStateChanged(GameStateChanged gameStateChanged)
 	{
-		if (gameStateChanged.getGameState() == GameState.LOADING)
+		if (GameEventManager.shouldClearSpawns(gameStateChanged))
 		{
 			fishingSpots.clear();
 			minnowSpots.clear();

--- a/runelite-client/src/main/java/net/runelite/client/plugins/pestcontrol/PestControlPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/pestcontrol/PestControlPlugin.java
@@ -35,7 +35,6 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
-import net.runelite.api.GameState;
 import net.runelite.api.NPC;
 import net.runelite.api.NpcID;
 import net.runelite.api.events.ChatMessage;
@@ -46,6 +45,7 @@ import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.OverlayManager;
+import net.runelite.client.util.GameEventManager;
 
 @PluginDescriptor(
 	name = "Pest Control",
@@ -92,7 +92,7 @@ public class PestControlPlugin extends Plugin
 	@Subscribe
 	public void onGameStateChanged(GameStateChanged event)
 	{
-		if (event.getGameState() == GameState.LOADING)
+		if (GameEventManager.shouldClearSpawns(event))
 		{
 			spinners.clear();
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/runecraft/RunecraftPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/runecraft/RunecraftPlugin.java
@@ -61,6 +61,7 @@ import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.OverlayManager;
+import net.runelite.client.util.GameEventManager;
 
 @PluginDescriptor(
 	name = "Runecraft",
@@ -232,6 +233,9 @@ public class RunecraftPlugin extends Plugin
 		if (event.getGameState() == GameState.LOADING)
 		{
 			abyssObjects.clear();
+		}
+		if (GameEventManager.shouldClearSpawns(event))
+		{
 			darkMage = null;
 		}
 	}

--- a/runelite-client/src/main/java/net/runelite/client/util/GameEventManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/util/GameEventManager.java
@@ -49,6 +49,7 @@ import net.runelite.api.events.ItemSpawned;
 import net.runelite.api.events.NpcSpawned;
 import net.runelite.api.events.PlayerSpawned;
 import net.runelite.api.events.WallObjectSpawned;
+import net.runelite.api.events.GameStateChanged;
 import net.runelite.client.callback.ClientThread;
 import net.runelite.client.eventbus.EventBus;
 
@@ -194,5 +195,13 @@ public class GameEventManager
 
 			eventBus.unregister(subscriber);
 		});
+	}
+
+	public static Boolean shouldClearSpawns(GameStateChanged gameStateChanged)
+	{
+		return (gameStateChanged.getGameState() == GameState.CONNECTION_LOST) ||
+				(gameStateChanged.getGameState() == GameState.HOPPING) ||
+				(gameStateChanged.getGameState() == GameState.LOGIN_SCREEN);
+
 	}
 }


### PR DESCRIPTION
Fishing spot list is cleared on any LOADING gamestate change. Some events eg scene change appear to not generate new NPC spawn events leaving spots unmarked.
Fix this by only clearing spot list on World hop, connection lost, and logout GameState changes.

Should close #7750.

Signed-off-by: Will Thomas <github@willthoms.org.uk>