### PR TITLE
Add account prompt to the OAuth URL

### DIFF
--- a/http-service/src/main/java/net/runelite/http/service/account/AccountService.java
+++ b/http-service/src/main/java/net/runelite/http/service/account/AccountService.java
@@ -33,6 +33,8 @@ import com.github.scribejava.core.model.Verb;
 import com.github.scribejava.core.oauth.OAuth20Service;
 import com.google.gson.Gson;
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import javax.servlet.http.HttpServletRequest;
@@ -148,7 +150,10 @@ public class AccountService
 			.state(gson.toJson(state))
 			.build(GoogleApi20.instance());
 
-		String authorizationUrl = service.getAuthorizationUrl();
+		final Map<String, String> additionalParams = new HashMap<>();
+		additionalParams.put("prompt", "select_account");
+
+		String authorizationUrl = service.getAuthorizationUrl(additionalParams);
 
 		OAuthResponse lr = new OAuthResponse();
 		lr.setOauthUrl(authorizationUrl);


### PR DESCRIPTION
This will allow users to select what Google Account to use, since Chrome will just use the currently logged in account without a prompt.

The user will now see this upon logging in
![vivaldi_2019-02-26_13-11-32](https://user-images.githubusercontent.com/2979691/53422725-e983ed80-39d7-11e9-8858-853058c1233d.png)
