### PR TITLE
Adding filtering to the World Hopper Plugin

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldHopperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldHopperPlugin.java
@@ -480,7 +480,7 @@ public class WorldHopperPlugin extends Plugin
 	/**
 	 * This method ONLY updates the list's UI, not the actual world list and data it displays.
 	 */
-	private void updateList()
+	public void updateList()
 	{
 		SwingUtilities.invokeLater(() -> panel.populate(worldResult.getWorlds()));
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldSwitcherPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldSwitcherPanel.java
@@ -36,6 +36,8 @@ import java.util.Map;
 import javax.swing.JPanel;
 import javax.swing.SwingUtilities;
 import lombok.extern.slf4j.Slf4j;
+import net.runelite.client.plugins.worldhopper.filter.WorldFilterPanel;
+import net.runelite.client.plugins.worldhopper.filter.WorldFilter;
 import net.runelite.client.ui.ColorScheme;
 import net.runelite.client.ui.DynamicGridLayout;
 import net.runelite.client.ui.PluginPanel;
@@ -51,6 +53,7 @@ class WorldSwitcherPanel extends PluginPanel
 	private static final int PING_COLUMN_WIDTH = 47;
 
 	private final JPanel listContainer = new JPanel();
+	private final WorldFilterPanel worldFilterPanel;
 
 	private WorldTableHeader worldHeader;
 	private WorldTableHeader playersHeader;
@@ -70,10 +73,13 @@ class WorldSwitcherPanel extends PluginPanel
 		setBorder(null);
 		setLayout(new DynamicGridLayout(0, 1));
 
+		worldFilterPanel = new WorldFilterPanel(plugin);
+
 		JPanel headerContainer = buildHeader();
 
 		listContainer.setLayout(new GridLayout(0, 1));
 
+		add(worldFilterPanel);
 		add(headerContainer);
 		add(listContainer);
 	}
@@ -149,6 +155,9 @@ class WorldSwitcherPanel extends PluginPanel
 
 	void updateList()
 	{
+		WorldFilter worldFilter = new WorldFilter(worldFilterPanel.getWorldFilterDefinition());
+		rows.removeIf(row -> worldFilter.hide(row.getWorld().getTypes()));
+
 		rows.sort((r1, r2) ->
 		{
 			switch (orderIndex)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/filter/WorldFilter.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/filter/WorldFilter.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2019, Royce Mathews <mathewsr23@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package net.runelite.client.plugins.worldhopper.filter;
+
+
+import java.util.Collection;
+import java.util.Collections;
+import net.runelite.http.api.worlds.WorldType;
+
+public class WorldFilter
+{
+	private WorldFilterDefinition worldFilterDefinition;
+
+	public WorldFilter(WorldFilterDefinition aWorldFilterDefinition)
+	{
+		worldFilterDefinition = aWorldFilterDefinition;
+	}
+
+	public boolean hide(Collection<WorldType> aWorldTypes)
+	{
+		if (worldFilterDefinition.shouldHideF2P())
+		{
+			return !aWorldTypes.contains(WorldType.MEMBERS)
+				|| containsAnyHiddenTypes(aWorldTypes);
+		}
+		else
+		{
+			return containsAnyHiddenTypes(aWorldTypes);
+		}
+	}
+
+	private boolean containsAnyHiddenTypes(Collection<WorldType> aWorldTypes)
+	{
+		return !Collections.disjoint(aWorldTypes, worldFilterDefinition.getHiddenTypes());
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/filter/WorldFilterDefinition.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/filter/WorldFilterDefinition.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2019, Royce Mathews <mathewsr23@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package net.runelite.client.plugins.worldhopper.filter;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import net.runelite.http.api.worlds.WorldType;
+import static net.runelite.http.api.worlds.WorldType.*;
+
+public class WorldFilterDefinition
+{
+
+	private boolean hideF2P;
+	private Collection<WorldType> hiddenTypes;
+
+	WorldFilterDefinition()
+	{
+		hiddenTypes = new HashSet<>();
+	}
+
+	WorldFilterDefinition hideF2P(boolean aHidden)
+	{
+		hideF2P = aHidden;
+		return this;
+	}
+
+	WorldFilterDefinition hideP2P(boolean aHidden)
+	{
+		if (aHidden)
+		{
+			hiddenTypes.add(MEMBERS);
+		}
+		return this;
+	}
+
+	WorldFilterDefinition hideSkillWorld(boolean aHidden)
+	{
+		if (aHidden)
+		{
+			hiddenTypes.add(SKILL_TOTAL);
+		}
+		return this;
+	}
+
+	WorldFilterDefinition hidePvP(boolean aHidden)
+	{
+		if (aHidden)
+		{
+			hiddenTypes.addAll(Arrays.asList(PVP, PVP_HIGH_RISK, BOUNTY, LAST_MAN_STANDING));
+		}
+		return this;
+	}
+
+	WorldFilterDefinition hideDeadman(boolean aHidden)
+	{
+		if (aHidden)
+		{
+			hiddenTypes.addAll(Arrays.asList(DEADMAN, SEASONAL_DEADMAN, DEADMAN_TOURNAMENT));
+		}
+		return this;
+	}
+
+	WorldFilterDefinition hideUnrestricted(boolean aHidden)
+	{
+		if (aHidden)
+		{
+			hiddenTypes.add(TOURNAMENT);
+		}
+		return this;
+	}
+
+	boolean shouldHideF2P()
+	{
+		return hideF2P;
+	}
+
+	Collection<WorldType> getHiddenTypes()
+	{
+		return hiddenTypes;
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/filter/WorldFilterPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/filter/WorldFilterPanel.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2019, Royce Mathews <mathewsr23@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package net.runelite.client.plugins.worldhopper.filter;
+
+import java.awt.BorderLayout;
+import java.awt.GridLayout;
+import java.awt.event.ActionListener;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.awt.image.BufferedImage;
+import javax.swing.BorderFactory;
+import javax.swing.ImageIcon;
+import javax.swing.JButton;
+import javax.swing.JCheckBoxMenuItem;
+import javax.swing.JPanel;
+import javax.swing.SwingUtilities;
+import net.runelite.client.plugins.worldhopper.WorldHopperPlugin;
+import net.runelite.client.util.ImageUtil;
+
+public class WorldFilterPanel extends JPanel
+{
+	private static final ImageIcon ARROW_UP;
+	private static final ImageIcon ARROW_DOWN;
+
+	static {
+		final BufferedImage arrowDown = ImageUtil.getResourceStreamFromClass(WorldHopperPlugin.class, "arrow_down.png");
+		final BufferedImage arrowDownFaded = ImageUtil.grayscaleOffset(arrowDown, -80);
+		final BufferedImage arrowUpFaded = ImageUtil.rotateImage(arrowDownFaded, Math.PI);
+		ARROW_UP = new ImageIcon(arrowUpFaded);
+		ARROW_DOWN = new ImageIcon(arrowDownFaded);
+	}
+
+	private JCheckBoxMenuItem hideF2PCheckbox;
+	private JCheckBoxMenuItem hideP2PCheckbox;
+	private JCheckBoxMenuItem hideSkillTotalCheckbox;
+	private JCheckBoxMenuItem hidePvPCheckbox;
+	private JCheckBoxMenuItem hideDeadmanCheckbox;
+	private JCheckBoxMenuItem hideUnrestrictedCheckbox;
+
+	public WorldFilterPanel(WorldHopperPlugin plugin)
+	{
+		super(new BorderLayout(), true);
+
+		JPanel filtersContainer = new JPanel();
+		filtersContainer.setVisible(false);
+		filtersContainer.setLayout(new GridLayout(0, 1));
+
+		createFilterCheckBoxes(plugin);
+
+		filtersContainer.add(hideF2PCheckbox);
+		filtersContainer.add(hideP2PCheckbox);
+		filtersContainer.add(hideSkillTotalCheckbox);
+		filtersContainer.add(hidePvPCheckbox);
+		filtersContainer.add(hideDeadmanCheckbox);
+		filtersContainer.add(hideUnrestrictedCheckbox);
+
+		JButton filtersButton = new JButton("Filters", ARROW_DOWN);
+		filtersButton.setBorder(BorderFactory.createEmptyBorder());
+		filtersButton.setFocusPainted(false);
+		filtersButton.addMouseListener(new MouseAdapter()
+		{
+			@Override
+			public void mousePressed(MouseEvent mouseEvent)
+			{
+				if (SwingUtilities.isRightMouseButton(mouseEvent))
+				{
+					return;
+				}
+
+				if (!filtersContainer.isVisible())
+				{
+					filtersButton.setIcon(ARROW_UP);
+					filtersContainer.setVisible(true);
+				}
+				else
+				{
+					filtersButton.setIcon(ARROW_DOWN);
+					filtersContainer.setVisible(false);
+				}
+			}
+		});
+
+		add(filtersButton, BorderLayout.NORTH);
+		add(filtersContainer, BorderLayout.CENTER);
+	}
+
+	private void createFilterCheckBoxes(WorldHopperPlugin plugin)
+	{
+		ActionListener updateListListener = e -> plugin.updateList();
+
+		hideF2PCheckbox = new JCheckBoxMenuItem("Hide F2P Worlds");
+		hideF2PCheckbox.addActionListener(updateListListener);
+
+		hideP2PCheckbox = new JCheckBoxMenuItem("Hide P2P Worlds");
+		hideP2PCheckbox.addActionListener(updateListListener);
+
+		hideSkillTotalCheckbox = new JCheckBoxMenuItem("Hide Skill Total Worlds");
+		hideSkillTotalCheckbox.addActionListener(updateListListener);
+
+		hidePvPCheckbox = new JCheckBoxMenuItem("Hide PVP Worlds");
+		hidePvPCheckbox.addActionListener(updateListListener);
+
+		hideDeadmanCheckbox = new JCheckBoxMenuItem("Hide Deadman Worlds");
+		hideDeadmanCheckbox.addActionListener(updateListListener);
+
+		hideUnrestrictedCheckbox = new JCheckBoxMenuItem("Hide Unrestricted Worlds");
+		hideUnrestrictedCheckbox.addActionListener(updateListListener);
+	}
+
+	public WorldFilterDefinition getWorldFilterDefinition(){
+		return new WorldFilterDefinition()
+			.hideF2P(hideF2PCheckbox.getState())
+			.hideP2P(hideP2PCheckbox.getState())
+			.hideSkillWorld(hideSkillTotalCheckbox.getState())
+			.hidePvP(hidePvPCheckbox.getState())
+			.hideDeadman(hideDeadmanCheckbox.getState())
+			.hideUnrestricted(hideUnrestrictedCheckbox.getState());
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/filter/WorldFilterPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/filter/WorldFilterPanel.java
@@ -44,7 +44,8 @@ public class WorldFilterPanel extends JPanel
 	private static final ImageIcon ARROW_UP;
 	private static final ImageIcon ARROW_DOWN;
 
-	static {
+	static
+	{
 		final BufferedImage arrowDown = ImageUtil.getResourceStreamFromClass(WorldHopperPlugin.class, "arrow_down.png");
 		final BufferedImage arrowDownFaded = ImageUtil.grayscaleOffset(arrowDown, -80);
 		final BufferedImage arrowUpFaded = ImageUtil.rotateImage(arrowDownFaded, Math.PI);
@@ -129,7 +130,8 @@ public class WorldFilterPanel extends JPanel
 		hideUnrestrictedCheckbox.addActionListener(updateListListener);
 	}
 
-	public WorldFilterDefinition getWorldFilterDefinition(){
+	public WorldFilterDefinition getWorldFilterDefinition()
+	{
 		return new WorldFilterDefinition()
 			.hideF2P(hideF2PCheckbox.getState())
 			.hideP2P(hideP2PCheckbox.getState())


### PR DESCRIPTION
Fixes #4970 - Adding filtering to the World Hopper Plugin

* Adds a new button above the header used to sort the worlds. The button expands a panel with checkboxes for selecting filters.
* Checks WorldTypes to determine which worlds to display.
* `WorldHopperPlugin#updateList` is used since I wanted to update the list of worlds without triggering a world refresh that may be throttled.