### PR TITLE
Null-check remote configuration in config manager

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/config/ConfigManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/ConfigManager.java
@@ -155,7 +155,7 @@ public class ConfigManager
 			return;
 		}
 
-		if (configuration.getConfig().isEmpty())
+		if (configuration.getConfig() == null || configuration.getConfig().isEmpty())
 		{
 			log.debug("No configuration from client, using saved configuration on disk");
 			loadFromFile();


### PR DESCRIPTION
This field can be null if the config service do not find absolutely
anything in config table for the user.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>