### PR TITLE
Fix splashes not resetting idle countdown

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/GraphicID.java
+++ b/runelite-api/src/main/java/net/runelite/api/GraphicID.java
@@ -26,6 +26,7 @@ package net.runelite.api;
 
 public class GraphicID
 {
+	public static final int SPLASH = 85;
 	public static final int TELEPORT = 111;
 	public static final int GREY_BUBBLE_TELEPORT = 86;
 	public static final int ENTANGLE = 179;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
@@ -47,6 +47,7 @@ import net.runelite.api.Varbits;
 import net.runelite.api.events.AnimationChanged;
 import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.GameTick;
+import net.runelite.api.events.GraphicChanged;
 import net.runelite.api.events.HitsplatApplied;
 import net.runelite.api.events.InteractingChanged;
 import net.runelite.client.Notifier;
@@ -325,6 +326,22 @@ public class IdleNotifierPlugin extends Plugin
 
 		if (hitsplat.getHitsplatType() == Hitsplat.HitsplatType.DAMAGE
 			|| hitsplat.getHitsplatType() == Hitsplat.HitsplatType.BLOCK)
+		{
+			lastCombatCountdown = HIGHEST_MONSTER_ATTACK_SPEED;
+		}
+	}
+
+	@Subscribe
+	public void onGraphicChanged(GraphicChanged event)
+	{
+		Actor actor = event.getActor();
+
+		if (actor != client.getLocalPlayer())
+		{
+			return;
+		}
+
+		if (actor.getGraphic() == GraphicID.SPLASH)
 		{
 			lastCombatCountdown = HIGHEST_MONSTER_ATTACK_SPEED;
 		}


### PR DESCRIPTION
A splash doesn't make a hitsplat, but will still keep you logged in.
Useful for when splashing on yourself 