### PR TITLE
XP globes: added lines in arc to show individual levels

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/Experience.java
+++ b/runelite-api/src/main/java/net/runelite/api/Experience.java
@@ -26,6 +26,9 @@ package net.runelite.api;
 
 import static java.lang.Math.floor;
 import static java.lang.Math.max;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 /**
  * A utility class used for calculating experience related values.
@@ -172,5 +175,23 @@ public class Experience
 		int rangeLevel, int prayerLevel)
 	{
 		return (int) getCombatLevelPrecise(attackLevel, strengthLevel, defenceLevel, hitpointsLevel, magicLevel, rangeLevel, prayerLevel);
+	}
+
+	/**
+	 * Calculate the percentages of each level compared to the difference of the goal exp and the start exp
+	 *
+	 * @param startXp Starting exp
+	 * @param goalXp The goal exp
+	 */
+	public static List<Double> levelPercentagesBetweenExperience(int startXp, int goalXp)
+	{
+		final int startLevel = Experience.getLevelForXp(startXp);
+		final int endLevel = Experience.getLevelForXp(goalXp);
+
+		return IntStream.range(startLevel + 1, endLevel)
+			.map(Experience::getXpForLevel)
+			.mapToDouble(expRequiredForLevel -> (expRequiredForLevel - startXp) * 1f / (goalXp - startXp))
+			.boxed()
+			.collect(Collectors.toList());
 	}
 }

--- a/runelite-api/src/test/java/net/runelite/api/ExperienceTest.java
+++ b/runelite-api/src/test/java/net/runelite/api/ExperienceTest.java
@@ -24,6 +24,9 @@
  */
 package net.runelite.api;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -90,5 +93,37 @@ public class ExperienceTest
 	{
 		Assert.assertEquals(126, Experience.getCombatLevel(99, 99, 99, 99, 70, 42, 98));
 		Assert.assertEquals(40, Experience.getCombatLevel(27, 22, 1, 36, 64, 45, 1));
+	}
+
+	@Test
+	public void testLevelMarkersWithEnoughExperienceInBetween()
+	{
+		final List<Double> expectedList = new ArrayList<>();
+		expectedList.add(0.083);
+		expectedList.add(0.174);
+		expectedList.add(0.276);
+		expectedList.add(0.388);
+		expectedList.add(0.512);
+		expectedList.add(0.650);
+		expectedList.add(0.801);
+		expectedList.add(0.969);
+
+		final List<Double> actualList = Experience.levelPercentagesBetweenExperience(0, 1000);
+
+		// Use a loop because we want to compare doubles (with only 0.001 precision)
+		for (int i = 0; i < actualList.size(); i++)
+		{
+			Assert.assertEquals(expectedList.get(i), actualList.get(i), 0.001);
+		}
+	}
+
+	@Test
+	public void testLevelMarkersWithNotEnoughExperienceInBetween()
+	{
+		final List<Double> expected = Collections.emptyList();
+
+		final List<Double> actual = Experience.levelPercentagesBetweenExperience(0, 1);
+
+		Assert.assertEquals(expected, actual);
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesConfig.java
@@ -66,12 +66,23 @@ public interface XpGlobesConfig extends Config
 		return false;
 	}
 
+	@ConfigItem(
+		keyName = "intermediateLevelMarkers",
+		name = "Show intermediate level markers",
+		description = "Marks intermediate levels on the globes",
+		position = 3
+	)
+	default boolean showIntermediateLevels()
+	{
+		return false;
+	}
+
 	@Alpha
 	@ConfigItem(
 		keyName = "Progress arc color",
 		name = "Progress arc color",
 		description = "Change the color of the progress arc in the xp orb",
-		position = 3
+		position = 4
 	)
 	default Color progressArcColor()
 	{
@@ -83,7 +94,7 @@ public interface XpGlobesConfig extends Config
 		keyName = "Progress orb outline color",
 		name = "Progress orb outline color",
 		description = "Change the color of the progress orb outline",
-		position = 4
+		position = 5
 	)
 	default Color progressOrbOutLineColor()
 	{
@@ -95,7 +106,7 @@ public interface XpGlobesConfig extends Config
 		keyName = "Progress orb background color",
 		name = "Progress orb background color",
 		description = "Change the color of the progress orb background",
-		position = 5
+		position = 6
 	)
 	default Color progressOrbBackgroundColor()
 	{
@@ -106,7 +117,7 @@ public interface XpGlobesConfig extends Config
 		keyName = "Progress arc width",
 		name = "Progress arc width",
 		description = "Change the stroke width of the progress arc",
-		position = 6
+		position = 7
 	)
 	default int progressArcStrokeWidth()
 	{
@@ -117,7 +128,7 @@ public interface XpGlobesConfig extends Config
 		keyName = "Orb size",
 		name = "Size of orbs",
 		description = "Change the size of the xp orbs",
-		position = 7
+		position = 8
 	)
 	default int xpOrbSize()
 	{
@@ -128,7 +139,7 @@ public interface XpGlobesConfig extends Config
 		keyName = "Orb duration",
 		name = "Duration of orbs",
 		description = "Change the duration the xp orbs are visible",
-		position = 8
+		position = 9
 	)
 	default int xpOrbDuration()
 	{


### PR DESCRIPTION
Adds lines in arc to show individual levels like requested in #8007.

This also fixes an issue where the size of the arc did not follow the configured value.

Preview:
![image](https://user-images.githubusercontent.com/3083785/53530077-09f29b80-3aef-11e9-8a2c-f448037c0551.png)

Closes #8007 

