### PR TITLE
worldpoint: Fix plane value in toLocalInstance

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/coords/WorldPoint.java
+++ b/runelite-api/src/main/java/net/runelite/api/coords/WorldPoint.java
@@ -211,7 +211,7 @@ public class WorldPoint
 
 		// find instance chunks using the template point. there might be more than one.
 		List<WorldPoint> worldPoints = new ArrayList<>();
-		final int z = client.getPlane();
+		final int z = worldPoint.getPlane();
 		int[][][] instanceTemplateChunks = client.getInstanceTemplateChunks();
 		for (int x = 0; x < instanceTemplateChunks[z].length; ++x)
 		{


### PR DESCRIPTION
This fixes the bug introduced in #7788. Original (working) code used the plane of the worldPoint being translated rather than relying on `client.getPlane()`. Going back to that seems to fix instance tile checks when loading into multi-plane instances.

Fixes runelite/runelite#7985
Fixes runelite/runelite#8045