### PR TITLE
Clanchat: clear counter on login/connection lost instead of loading

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/clanchat/ClanChatPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/clanchat/ClanChatPlugin.java
@@ -184,9 +184,9 @@ public class ClanChatPlugin extends Plugin
 	@Subscribe
 	public void onGameStateChanged(GameStateChanged state)
 	{
-		if (state.getGameState() == GameState.LOGGING_IN ||
-			state.getGameState() == GameState.CONNECTION_LOST ||
-			state.getGameState() == GameState.HOPPING)
+		GameState gameState = state.getGameState();
+
+		if (gameState == GameState.LOGIN_SCREEN || gameState == GameState.CONNECTION_LOST || gameState == GameState.HOPPING)
 		{
 			clanMembers.clear();
 			removeClanCounter();

--- a/runelite-client/src/main/java/net/runelite/client/plugins/clanchat/ClanChatPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/clanchat/ClanChatPlugin.java
@@ -184,7 +184,7 @@ public class ClanChatPlugin extends Plugin
 	@Subscribe
 	public void onGameStateChanged(GameStateChanged state)
 	{
-		if (state.getGameState() == GameState.LOADING)
+		if (state.getGameState() == GameState.LOGGING_IN)
 		{
 			clanMembers.clear();
 			removeClanCounter();

--- a/runelite-client/src/main/java/net/runelite/client/plugins/clanchat/ClanChatPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/clanchat/ClanChatPlugin.java
@@ -184,7 +184,9 @@ public class ClanChatPlugin extends Plugin
 	@Subscribe
 	public void onGameStateChanged(GameStateChanged state)
 	{
-		if (state.getGameState() == GameState.LOGGING_IN)
+		if (state.getGameState() == GameState.LOGGING_IN ||
+			state.getGameState() == GameState.CONNECTION_LOST ||
+			state.getGameState() == GameState.HOPPING)
 		{
 			clanMembers.clear();
 			removeClanCounter();


### PR DESCRIPTION
Clear counter on logging_in state instead of loading. Sometimes when you run into new regions (revenant caves pking for example) you get the loading state which clears the counter.