### PR TITLE
Update CheckStyle XML link to one that exists

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -23,8 +23,9 @@
  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 -->
-<!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
-        "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+<!DOCTYPE module PUBLIC
+	"-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+	"https://checkstyle.org/dtds/configuration_1_3.dtd">
 <module name="Checker">
 	<module name="TreeWalker">
 		<module name="LeftCurly">


### PR DESCRIPTION
https://checkstyle.org/dtds/configuration_1_3.dtd is a link that exists (see https://github.com/checkstyle/checkstyle/blob/master/src/main/resources/google_checks.xml for an example). The old puppycrawl links 404 (both HTTP and HTTPS).