### PR TITLE
NMZ High HP Notifier

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/nightmarezone/NightmareZoneConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/nightmarezone/NightmareZoneConfig.java
@@ -110,10 +110,21 @@ public interface NightmareZoneConfig extends Config
 	}
 
 	@ConfigItem(
+			keyName = "hitpointsnotification",
+			name = "Hitpoints notification",
+			description = "Toggles notifications when your hitpoints gets above your threshold",
+			position = 8
+	)
+	default boolean hitpointsNotification()
+	{
+		return false;
+	}
+
+	@ConfigItem(
 		keyName = "absorptionthreshold",
 		name = "Absorption Threshold",
 		description = "The amount of absorption points to send a notification at",
-		position = 8
+		position = 9
 	)
 	default int absorptionThreshold()
 	{
@@ -121,10 +132,21 @@ public interface NightmareZoneConfig extends Config
 	}
 
 	@ConfigItem(
+			keyName = "hitpointsthreshold",
+			name = "Hitpoints Threshold",
+			description = "The max amount of hitpoints to send a notification at",
+			position = 10
+	)
+	default int hitpointsThreshold()
+	{
+		return 2;
+	}
+
+	@ConfigItem(
 		keyName = "absorptioncoloroverthreshold",
 		name = "Color above threshold",
 		description = "Configures the color for the absorption widget when above the threshold",
-		position = 9
+		position = 11
 	)
 	default Color absorptionColorAboveThreshold()
 	{
@@ -135,7 +157,7 @@ public interface NightmareZoneConfig extends Config
 		keyName = "absorptioncolorbelowthreshold",
 		name = "Color below threshold",
 		description = "Configures the color for the absorption widget when below the threshold",
-		position = 10
+		position = 12
 	)
 	default Color absorptionColorBelowThreshold()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/nightmarezone/NightmareZonePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/nightmarezone/NightmareZonePlugin.java
@@ -29,6 +29,7 @@ import java.util.Arrays;
 import javax.inject.Inject;
 import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
+import net.runelite.api.Skill;
 import net.runelite.api.Varbits;
 import net.runelite.api.events.ChatMessage;
 import net.runelite.api.events.ConfigChanged;
@@ -70,6 +71,7 @@ public class NightmareZonePlugin extends Plugin
 	// This starts as true since you need to get
 	// above the threshold before sending notifications
 	private boolean absorptionNotificationSend = true;
+	private boolean hitpointsNotificationSend = true;
 
 	@Override
 	protected void startUp() throws Exception
@@ -119,6 +121,10 @@ public class NightmareZonePlugin extends Plugin
 		if (config.absorptionNotification())
 		{
 			checkAbsorption();
+		}
+
+		if (config.hitpointsNotification()) {
+			checkHitpoints();
 		}
 	}
 
@@ -189,6 +195,24 @@ public class NightmareZonePlugin extends Plugin
 			if (absorptionPoints > config.absorptionThreshold())
 			{
 				absorptionNotificationSend = false;
+			}
+		}
+	}
+
+	private void checkHitpoints()
+	{
+		if (!hitpointsNotificationSend)
+		{
+			if (client.getBoostedSkillLevel(Skill.HITPOINTS) >= config.hitpointsThreshold())
+			{
+				notifier.notify("Hitpoints above: " + config.hitpointsThreshold());
+				hitpointsNotificationSend = true;
+			}
+		}
+		else {
+			if (client.getBoostedSkillLevel(Skill.HITPOINTS) < config.hitpointsThreshold())
+			{
+				hitpointsNotificationSend = false;
 			}
 		}
 	}


### PR DESCRIPTION
- NMZ ability to set a max HP level to receive a notification at
- Useful for when using DH and want to be notified when your HP goes from 1 to 2