### PR TITLE
clanchat: retrieve rank from ClanMember rather than ClanManager

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/events/ClanMemberJoined.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/ClanMemberJoined.java
@@ -25,12 +25,13 @@
 package net.runelite.api.events;
 
 import lombok.Value;
+import net.runelite.api.ClanMember;
 
 @Value
 public class ClanMemberJoined
 {
 	/**
-	 * Name of the player who joined
+	 * The ClanMember that joined
 	 */
-	private String name;
+	private ClanMember member;
 }

--- a/runelite-api/src/main/java/net/runelite/api/events/ClanMemberLeft.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/ClanMemberLeft.java
@@ -25,12 +25,13 @@
 package net.runelite.api.events;
 
 import lombok.Value;
+import net.runelite.api.ClanMember;
 
 @Value
 public class ClanMemberLeft
 {
 	/**
-	 * Name of the player who left
+	 * The ClanMember that left
 	 */
-	private String name;
+	private ClanMember member;
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/clanchat/ClanMemberActivity.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/clanchat/ClanMemberActivity.java
@@ -26,12 +26,13 @@ package net.runelite.client.plugins.clanchat;
 
 import lombok.AllArgsConstructor;
 import lombok.Value;
+import net.runelite.api.ClanMember;
 
 @Value
 @AllArgsConstructor
 class ClanMemberActivity
 {
 	private ClanActivityType activityType;
-	private String member;
+	private ClanMember member;
 	private Integer tick;
 }

--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSClanMemberManagerMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSClanMemberManagerMixin.java
@@ -24,6 +24,7 @@
  */
 package net.runelite.mixins;
 
+import net.runelite.api.ClanMember;
 import net.runelite.api.events.ClanMemberJoined;
 import net.runelite.api.events.ClanMemberLeft;
 import net.runelite.api.mixins.Inject;
@@ -44,15 +45,27 @@ public abstract class RSClanMemberManagerMixin implements RSClanMemberManager
 	@Override
 	public void rl$add(RSName name, RSName prevName)
 	{
-		ClanMemberJoined event = new ClanMemberJoined(name.getName());
-		client.getCallbacks().post(event);
+		ClanMember member = findByName(name);
+		if (member == null)
+		{
+			return;
+		}
+
+		ClanMemberJoined event = new ClanMemberJoined(member);
+		client.getCallbacks().postDeferred(event);
 	}
 
 	@Inject
 	@Override
 	public void rl$remove(RSNameable nameable)
 	{
-		ClanMemberLeft event = new ClanMemberLeft(nameable.getRsName().getName());
-		client.getCallbacks().post(event);
+		ClanMember member = findByName(nameable.getRsName());
+		if (member == null)
+		{
+			return;
+		}
+
+		ClanMemberLeft event = new ClanMemberLeft(member);
+		client.getCallbacks().postDeferred(event);
 	}
 }

--- a/runescape-api/src/main/java/net/runelite/rs/api/RSNameableContainer.java
+++ b/runescape-api/src/main/java/net/runelite/rs/api/RSNameableContainer.java
@@ -37,6 +37,9 @@ public interface RSNameableContainer<T extends RSNameable>
 	@Import("isMember")
 	boolean isMember(RSName var1);
 
+	@Import("findByName")
+	T findByName(RSName name);
+
 	/**
 	 * Method called by the container when an element is added
 	 * @param name


### PR DESCRIPTION
Ranks would be cached at the time of join/leave which was incorrect. Using the rank from ClanMember will always be correct and won't require the user to have spoken recently to cache their rank.