### PR TITLE
NMZ 1 HP Notifier

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/nightmarezone/NightmareZoneConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/nightmarezone/NightmareZoneConfig.java
@@ -110,10 +110,21 @@ public interface NightmareZoneConfig extends Config
 	}
 
 	@ConfigItem(
+			keyName = "hitpointsnotification",
+			name = "Hitpoints notification",
+			description = "Toggles notifications when your hitpoints gets above your threshold",
+			position = 8
+	)
+	default boolean hitpointsNotification()
+	{
+		return false;
+	}
+
+	@ConfigItem(
 		keyName = "absorptionthreshold",
 		name = "Absorption Threshold",
 		description = "The amount of absorption points to send a notification at",
-		position = 8
+		position = 9
 	)
 	default int absorptionThreshold()
 	{
@@ -121,10 +132,21 @@ public interface NightmareZoneConfig extends Config
 	}
 
 	@ConfigItem(
+			keyName = "hitpointsthreshold",
+			name = "Hitpoints Threshold",
+			description = "The max amount of hitpoints to send a notification at",
+			position = 10
+	)
+	default int hitpointsThreshold()
+	{
+		return 2;
+	}
+
+	@ConfigItem(
 		keyName = "absorptioncoloroverthreshold",
 		name = "Color above threshold",
 		description = "Configures the color for the absorption widget when above the threshold",
-		position = 9
+		position = 11
 	)
 	default Color absorptionColorAboveThreshold()
 	{
@@ -135,7 +157,7 @@ public interface NightmareZoneConfig extends Config
 		keyName = "absorptioncolorbelowthreshold",
 		name = "Color below threshold",
 		description = "Configures the color for the absorption widget when below the threshold",
-		position = 10
+		position = 12
 	)
 	default Color absorptionColorBelowThreshold()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/nightmarezone/NightmareZoneConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/nightmarezone/NightmareZoneConfig.java
@@ -111,8 +111,8 @@ public interface NightmareZoneConfig extends Config
 
 	@ConfigItem(
 			keyName = "hitpointsnotification",
-			name = "Hitpoints notification",
-			description = "Toggles notifications when your hitpoints gets above your threshold",
+			name = "1 HP notification",
+			description = "Sends a notification if your hitpoints goes above 1",
 			position = 8
 	)
 	default boolean hitpointsNotification()
@@ -132,21 +132,10 @@ public interface NightmareZoneConfig extends Config
 	}
 
 	@ConfigItem(
-			keyName = "hitpointsthreshold",
-			name = "Hitpoints Threshold",
-			description = "The max amount of hitpoints to send a notification at",
-			position = 10
-	)
-	default int hitpointsThreshold()
-	{
-		return 2;
-	}
-
-	@ConfigItem(
 		keyName = "absorptioncoloroverthreshold",
 		name = "Color above threshold",
 		description = "Configures the color for the absorption widget when above the threshold",
-		position = 11
+		position = 10
 	)
 	default Color absorptionColorAboveThreshold()
 	{
@@ -157,7 +146,7 @@ public interface NightmareZoneConfig extends Config
 		keyName = "absorptioncolorbelowthreshold",
 		name = "Color below threshold",
 		description = "Configures the color for the absorption widget when below the threshold",
-		position = 12
+		position = 11
 	)
 	default Color absorptionColorBelowThreshold()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/nightmarezone/NightmareZonePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/nightmarezone/NightmareZonePlugin.java
@@ -29,6 +29,7 @@ import java.util.Arrays;
 import javax.inject.Inject;
 import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
+import net.runelite.api.Skill;
 import net.runelite.api.Varbits;
 import net.runelite.api.events.ChatMessage;
 import net.runelite.api.events.ConfigChanged;
@@ -70,6 +71,7 @@ public class NightmareZonePlugin extends Plugin
 	// This starts as true since you need to get
 	// above the threshold before sending notifications
 	private boolean absorptionNotificationSend = true;
+	private boolean hitpointsNotificationSend = true;
 
 	@Override
 	protected void startUp() throws Exception
@@ -119,6 +121,10 @@ public class NightmareZonePlugin extends Plugin
 		if (config.absorptionNotification())
 		{
 			checkAbsorption();
+		}
+
+		if (config.hitpointsNotification()) {
+			checkHitpoints();
 		}
 	}
 
@@ -189,6 +195,24 @@ public class NightmareZonePlugin extends Plugin
 			if (absorptionPoints > config.absorptionThreshold())
 			{
 				absorptionNotificationSend = false;
+			}
+		}
+	}
+
+	private void checkHitpoints()
+	{
+		if (!hitpointsNotificationSend)
+		{
+			if (client.getBoostedSkillLevel(Skill.HITPOINTS) >= config.hitpointsThreshold())
+			{
+				notifier.notify("Hitpoints above: " + config.hitpointsThreshold());
+				hitpointsNotificationSend = true;
+			}
+		}
+		else {
+			if (client.getBoostedSkillLevel(Skill.HITPOINTS) < config.hitpointsThreshold())
+			{
+				hitpointsNotificationSend = false;
 			}
 		}
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/nightmarezone/NightmareZonePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/nightmarezone/NightmareZonePlugin.java
@@ -116,6 +116,11 @@ public class NightmareZonePlugin extends Plugin
 				absorptionNotificationSend = true;
 			}
 
+			if (!hitpointsNotificationSend)
+            {
+                hitpointsNotificationSend = true;
+            }
+
 			return;
 		}
 		if (config.absorptionNotification())
@@ -203,14 +208,23 @@ public class NightmareZonePlugin extends Plugin
 	{
 		if (!hitpointsNotificationSend)
 		{
-			if (client.getBoostedSkillLevel(Skill.HITPOINTS) >= config.hitpointsThreshold())
+			if (client.getBoostedSkillLevel(Skill.HITPOINTS) > 1)
 			{
-				notifier.notify("Hitpoints above: " + config.hitpointsThreshold());
-				hitpointsNotificationSend = true;
+				boolean shouldSend = true;
+			    if (config.overloadNotification()) {
+			        if (client.getBoostedSkillLevel(Skill.HITPOINTS) == 51)
+			        {
+			            shouldSend = false;
+					}
+				}
+			    if (shouldSend) {
+					notifier.notify("Hitpoints went above 1");
+					hitpointsNotificationSend = true;
+				}
 			}
 		}
 		else {
-			if (client.getBoostedSkillLevel(Skill.HITPOINTS) < config.hitpointsThreshold())
+			if (client.getBoostedSkillLevel(Skill.HITPOINTS) == 1)
 			{
 				hitpointsNotificationSend = false;
 			}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/nightmarezone/NightmareZonePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/nightmarezone/NightmareZonePlugin.java
@@ -72,6 +72,7 @@ public class NightmareZonePlugin extends Plugin
 	// above the threshold before sending notifications
 	private boolean absorptionNotificationSend = true;
 	private boolean hitpointsNotificationSend = true;
+	private int lastTickHitpointsVal = 0;
 
 	@Override
 	protected void startUp() throws Exception
@@ -117,10 +118,9 @@ public class NightmareZonePlugin extends Plugin
 			}
 
 			if (!hitpointsNotificationSend)
-            {
-                hitpointsNotificationSend = true;
-            }
-
+			{
+				hitpointsNotificationSend = true;
+			}
 			return;
 		}
 		if (config.absorptionNotification())
@@ -128,7 +128,8 @@ public class NightmareZonePlugin extends Plugin
 			checkAbsorption();
 		}
 
-		if (config.hitpointsNotification()) {
+		if (config.hitpointsNotification())
+		{
 			checkHitpoints();
 		}
 	}
@@ -208,27 +209,20 @@ public class NightmareZonePlugin extends Plugin
 	{
 		if (!hitpointsNotificationSend)
 		{
-			if (client.getBoostedSkillLevel(Skill.HITPOINTS) > 1)
+			if (lastTickHitpointsVal == 1 && client.getBoostedSkillLevel(Skill.HITPOINTS) == 2)
 			{
-				boolean shouldSend = true;
-			    if (config.overloadNotification()) {
-			        if (client.getBoostedSkillLevel(Skill.HITPOINTS) == 51)
-			        {
-			            shouldSend = false;
-					}
-				}
-			    if (shouldSend) {
-					notifier.notify("Hitpoints went above 1");
-					hitpointsNotificationSend = true;
-				}
+				notifier.notify("Hitpoints went above 1");
+				hitpointsNotificationSend = true;
 			}
 		}
-		else {
+		else
+		{
 			if (client.getBoostedSkillLevel(Skill.HITPOINTS) == 1)
 			{
 				hitpointsNotificationSend = false;
 			}
 		}
+		lastTickHitpointsVal = client.getBoostedSkillLevel(Skill.HITPOINTS);
 	}
 
 	public boolean isInNightmareZone()


### PR DESCRIPTION
- Adds a toggle in the NMZ plugin to get notified when your HP goes above 1
- Checks if HP went from 1hp -> 2hp (wont fire if overloads is the reason HP went up)