### PR TITLE
Add brimstone chest support to loot tracker

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
@@ -25,6 +25,9 @@
  */
 package net.runelite.client.plugins.loottracker;
 
+import com.google.common.collect.HashMultiset;
+import com.google.common.collect.Multiset;
+import com.google.common.collect.Multisets;
 import com.google.inject.Provides;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
@@ -55,8 +58,7 @@ import net.runelite.api.SpriteID;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.ChatMessage;
 import net.runelite.api.events.ConfigChanged;
-import net.runelite.client.events.SessionClose;
-import net.runelite.client.events.SessionOpen;
+import net.runelite.api.events.ItemContainerChanged;
 import net.runelite.api.events.WidgetLoaded;
 import net.runelite.api.widgets.WidgetID;
 import net.runelite.client.account.AccountSession;
@@ -66,6 +68,8 @@ import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.events.NpcLootReceived;
 import net.runelite.client.events.PlayerLootReceived;
+import net.runelite.client.events.SessionClose;
+import net.runelite.client.events.SessionOpen;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.game.ItemStack;
 import net.runelite.client.game.SpriteManager;
@@ -92,6 +96,10 @@ public class LootTrackerPlugin extends Plugin
 	// Activity/Event loot handling
 	private static final Pattern CLUE_SCROLL_PATTERN = Pattern.compile("You have completed [0-9]+ ([a-z]+) Treasure Trails.");
 	private static final int THEATRE_OF_BLOOD_REGION = 12867;
+
+	// Brimstone loot handling
+	private static final String BRIMSTONE_CHEST_MESSAGE = "You find some treasure in the chest!";
+	private static final String BRIMSTONE_CHEST_EVENT_TYPE = "Brimstone Chest";
 
 	@Inject
 	private ClientToolbar clientToolbar;
@@ -122,6 +130,8 @@ public class LootTrackerPlugin extends Plugin
 	private String eventType;
 
 	private List<String> ignoredItems = new ArrayList<>();
+
+	private Multiset<Integer> inventorySnapshot;
 
 	@Getter(AccessLevel.PACKAGE)
 	private LootTrackerClient lootTrackerClient;
@@ -363,8 +373,25 @@ public class LootTrackerPlugin extends Plugin
 			return;
 		}
 
+		final String message = event.getMessage();
+
+		if (message.equals(BRIMSTONE_CHEST_MESSAGE))
+		{
+			eventType = BRIMSTONE_CHEST_EVENT_TYPE;
+
+			final ItemContainer itemContainer = client.getItemContainer(InventoryID.INVENTORY);
+			if (itemContainer != null)
+			{
+				inventorySnapshot = HashMultiset.create();
+				Arrays.stream(itemContainer.getItems())
+						.forEach(item -> inventorySnapshot.add(item.getId(), item.getQuantity()));
+			}
+
+			return;
+		}
+
 		// Check if message is for a clue scroll reward
-		final Matcher m = CLUE_SCROLL_PATTERN.matcher(Text.removeTags(event.getMessage()));
+		final Matcher m = CLUE_SCROLL_PATTERN.matcher(Text.removeTags(message));
 		if (m.find())
 		{
 			final String type = m.group(1).toLowerCase();
@@ -386,6 +413,50 @@ public class LootTrackerPlugin extends Plugin
 					eventType = "Clue Scroll (Master)";
 					break;
 			}
+		}
+	}
+
+	@Subscribe
+	public void onItemContainerChanged(ItemContainerChanged event)
+	{
+		if (eventType == null || !eventType.equals(BRIMSTONE_CHEST_EVENT_TYPE))
+		{
+			return;
+		}
+
+		if (event.getItemContainer() != client.getItemContainer(InventoryID.INVENTORY))
+		{
+			return;
+		}
+
+		processBrimstoneChestLoot(event.getItemContainer());
+		eventType = null;
+	}
+
+	private void processBrimstoneChestLoot(ItemContainer inventoryContainer)
+	{
+		if (inventorySnapshot != null)
+		{
+			Multiset<Integer> currentInventory = HashMultiset.create();
+			Arrays.stream(inventoryContainer.getItems())
+				.forEach(item -> currentInventory.add(item.getId(), item.getQuantity()));
+
+			final Multiset<Integer> diff = Multisets.difference(currentInventory, inventorySnapshot);
+
+			List<ItemStack> items = diff.entrySet().stream()
+				.map(e -> new ItemStack(e.getElement(), e.getCount(), client.getLocalPlayer().getLocalLocation()))
+				.collect(Collectors.toList());
+
+			final LootTrackerItem[] entries = buildEntries(stack(items));
+			SwingUtilities.invokeLater(() -> panel.add(BRIMSTONE_CHEST_EVENT_TYPE, -1, entries));
+
+			if (lootTrackerClient != null && config.saveLoot())
+			{
+				LootRecord lootRecord = new LootRecord(BRIMSTONE_CHEST_EVENT_TYPE, LootRecordType.EVENT, toGameItems(items), Instant.now());
+				lootTrackerClient.submit(lootRecord);
+			}
+
+			inventorySnapshot = null;
 		}
 	}
 


### PR DESCRIPTION
Adds loot from brimstone chest to the loot tracker.

![789b2005384d3502525817c6f97a05d2](https://user-images.githubusercontent.com/5104566/53757673-222e3600-3eb4-11e9-8544-0c10b0d6a363.png)

Closes #7749