### PR TITLE
Compare session in WSClient only if websocket is open

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ws/WSClient.java
+++ b/runelite-client/src/main/java/net/runelite/client/ws/WSClient.java
@@ -71,13 +71,13 @@ public class WSClient extends WebSocketListener implements AutoCloseable
 
 	public void changeSession(UUID sessionId)
 	{
-		if (Objects.equals(sessionId, this.sessionId))
-		{
-			return;
-		}
-
 		if (webSocket != null)
 		{
+			if (Objects.equals(sessionId, this.sessionId))
+			{
+				return;
+			}
+
 			close();
 			webSocket = null;
 		}


### PR DESCRIPTION
If websocket is closed we need to open new session anyway.

Fixes #8089

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>