### PR TITLE
clanchat: update counter when player in scene joins / leaves clan chat

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/clanchat/ClanChatPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/clanchat/ClanChatPlugin.java
@@ -165,13 +165,26 @@ public class ClanChatPlugin extends Plugin
 	@Subscribe
 	public void onClanMemberJoined(ClanMemberJoined event)
 	{
+		ClanMember member = event.getMember();
+		String clanMemberName = Text.toJagexName(member.getUsername());
+		List<Player> players = client.getPlayers();
+
+		for (Player player : players)
+		{
+			String playerName = Text.toJagexName(player.getName());
+
+			if (playerName.equalsIgnoreCase(clanMemberName) && !clanMembers.contains(player))
+			{
+				clanMembers.add(player);
+			}
+		}
+
 		// clan members getting initialized isn't relevant
 		if (clanJoinedTick == client.getTickCount())
 		{
 			return;
 		}
 
-		ClanMember member = event.getMember();
 		if (!config.showJoinLeave() ||
 			member.getRank().getValue() < config.joinLeaveRank().getValue())
 		{
@@ -195,6 +208,19 @@ public class ClanChatPlugin extends Plugin
 	public void onClanMemberLeft(ClanMemberLeft event)
 	{
 		ClanMember member = event.getMember();
+		String clanMemberName = Text.toJagexName(member.getUsername());
+		List<Player> players = client.getPlayers();
+
+		for (Player player : players)
+		{
+			String playerName = Text.toJagexName(player.getName());
+
+			if (playerName.equalsIgnoreCase(clanMemberName))
+			{
+				clanMembers.remove(player);
+			}
+		}
+
 		if (!config.showJoinLeave() ||
 			member.getRank().getValue() < config.joinLeaveRank().getValue())
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/clanchat/ClanChatPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/clanchat/ClanChatPlugin.java
@@ -425,12 +425,6 @@ public class ClanChatPlugin extends Plugin
 		{
 			clanMembers.clear();
 			removeClanCounter();
-		}
-
-		if (state.getGameState() == GameState.LOGIN_SCREEN
-			|| state.getGameState() == GameState.HOPPING
-			|| state.getGameState() == GameState.CONNECTION_LOST)
-		{
 			clanJoinMessages.clear();
 		}
 	}


### PR DESCRIPTION
Currently when a player in already scene joins the clan chat, the counter does not get updated.
This fix checks on the ClanMemberJoined / ClanMemberLeft event, gets the clanmember name, checks all names in scene and adds / removes the player from counter if there is a match.
