### PR TITLE
Dont use animation when checking for placing cannon

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonOverlay.java
@@ -62,7 +62,7 @@ class CannonOverlay extends Overlay
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
-		if (!plugin.isCannonPlaced() || plugin.getCannon() == null)
+		if (plugin.getCannon() == null)
 		{
 			return null;
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonOverlay.java
@@ -62,12 +62,12 @@ class CannonOverlay extends Overlay
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
-		if (!plugin.isCannonPlaced() || plugin.getCannonPosition() == null)
+		if (!plugin.isCannonPlaced() || plugin.getCannon() == null)
 		{
 			return null;
 		}
 
-		LocalPoint cannonPoint = LocalPoint.fromWorld(client, plugin.getCannonPosition());
+		LocalPoint cannonPoint = LocalPoint.fromWorld(client, plugin.getCannon().getWorldLocation());
 
 		if (cannonPoint == null)
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonSpotOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonSpotOverlay.java
@@ -69,7 +69,7 @@ public class CannonSpotOverlay extends Overlay
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
-		if (hidden || !config.showCannonSpots() || plugin.isCannonPlaced())
+		if (hidden || !config.showCannonSpots() || plugin.getCannon() != null)
 		{
 			return null;
 		}


### PR DESCRIPTION
Instead of animation simply check next closest cannon spawn next to
player after placing cannon (getting message about placing furnace).

Closes #8106
Closes #8107

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>