### PR TITLE
Support specifying API endpoins via java props

### DIFF
--- a/http-api/src/main/java/net/runelite/http/api/RuneLiteAPI.java
+++ b/http-api/src/main/java/net/runelite/http/api/RuneLiteAPI.java
@@ -95,9 +95,9 @@ public class RuneLiteAPI
 			.build();
 	}
 
-	public static HttpUrl getApiRoot()
+	public static HttpUrl getSessionBase()
 	{
-		return HttpUrl.parse(BASE);
+		return HttpUrl.parse(BASE + "/session");
 	}
 
 	public static HttpUrl getApiBase()

--- a/http-api/src/main/java/net/runelite/http/api/RuneLiteAPI.java
+++ b/http-api/src/main/java/net/runelite/http/api/RuneLiteAPI.java
@@ -97,21 +97,49 @@ public class RuneLiteAPI
 
 	public static HttpUrl getSessionBase()
 	{
+		final String prop = System.getProperty("runelite.session.url");
+
+		if (prop != null && !prop.isEmpty())
+		{
+			return HttpUrl.parse(prop);
+		}
+
 		return HttpUrl.parse(BASE + "/session");
 	}
 
 	public static HttpUrl getApiBase()
 	{
+		final String prop = System.getProperty("runelite.http-service.url");
+
+		if (prop != null && !prop.isEmpty())
+		{
+			return HttpUrl.parse(prop);
+		}
+
 		return HttpUrl.parse(BASE + "/runelite-" + getVersion());
 	}
 
 	public static HttpUrl getStaticBase()
 	{
+		final String prop = System.getProperty("runelite.static.url");
+
+		if (prop != null && !prop.isEmpty())
+		{
+			return HttpUrl.parse(prop);
+		}
+
 		return HttpUrl.parse(STATICBASE);
 	}
 
 	public static HttpUrl getWsEndpoint()
 	{
+		final String prop = System.getProperty("runelite.ws.url");
+
+		if (prop != null && !prop.isEmpty())
+		{
+			return HttpUrl.parse(prop);
+		}
+
 		return HttpUrl.parse(WSBASE);
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/SessionClient.java
+++ b/runelite-client/src/main/java/net/runelite/client/SessionClient.java
@@ -39,8 +39,7 @@ class SessionClient
 {
 	UUID open() throws IOException
 	{
-		HttpUrl url = RuneLiteAPI.getApiRoot().newBuilder()
-			.addPathSegment("session")
+		HttpUrl url = RuneLiteAPI.getSessionBase().newBuilder()
 			.build();
 
 		Request request = new Request.Builder()
@@ -62,8 +61,7 @@ class SessionClient
 
 	void ping(UUID uuid) throws IOException
 	{
-		HttpUrl url = RuneLiteAPI.getApiRoot().newBuilder()
-			.addPathSegment("session")
+		HttpUrl url = RuneLiteAPI.getSessionBase().newBuilder()
 			.addPathSegment("ping")
 			.addQueryParameter("session", uuid.toString())
 			.build();
@@ -83,8 +81,7 @@ class SessionClient
 
 	void delete(UUID uuid) throws IOException
 	{
-		HttpUrl url = RuneLiteAPI.getApiRoot().newBuilder()
-			.addPathSegment("session")
+		HttpUrl url = RuneLiteAPI.getSessionBase().newBuilder()
 			.addQueryParameter("session", uuid.toString())
 			.build();
 


### PR DESCRIPTION
- Add support fo specifying runelite.session.url java prop to be used
instead of RuneLite session base
- Add support fo specifying runelite.http-service.url java prop to be used
instead of RuneLite api base url
- Add support fo specifying runelite.ws.url java prop to be used
instead of RuneLite websocket url
- Add support for specifying runelite.static.url java prop to be used
instead of RuneLite s.r.n url

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>