### PR TITLE
Remove unnecessary .get() on OkHttp request

### DIFF
--- a/http-api/src/main/java/net/runelite/http/api/loottracker/LootTrackerClient.java
+++ b/http-api/src/main/java/net/runelite/http/api/loottracker/LootTrackerClient.java
@@ -90,7 +90,6 @@ public class LootTrackerClient
 
 		Request request = new Request.Builder()
 			.header(RuneLiteAPI.RUNELITE_AUTH, uuid.toString())
-			.get()
 			.url(url)
 			.build();
 


### PR DESCRIPTION
GET is default method for OkHttp request builder, no need to explicitely
define it.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>