### PR TITLE
Add Ammo plugin

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/ammo/AmmoCounter.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/ammo/AmmoCounter.java
@@ -30,15 +30,13 @@ import net.runelite.client.plugins.Plugin;
 import net.runelite.client.ui.overlay.infobox.Counter;
 import net.runelite.client.util.StackFormatter;
 
-public class AmmoCounter extends Counter
+class AmmoCounter extends Counter
 {
 	@Getter
-	private int itemID;
+	private final int itemID;
+	private final String name;
 
-	@Getter
-	private String name;
-
-	public AmmoCounter(Plugin plugin, int itemID, int count, String name, BufferedImage image)
+	AmmoCounter(Plugin plugin, int itemID, int count, String name, BufferedImage image)
 	{
 		super(image, plugin, count);
 		this.itemID = itemID;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/ammo/AmmoCounter.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/ammo/AmmoCounter.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2019 Hydrox6 <ikada@protonmail.ch>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.ammo;
+
+import java.awt.image.BufferedImage;
+import lombok.Getter;
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.ui.overlay.infobox.Counter;
+
+public class AmmoCounter extends Counter
+{
+	@Getter
+	private int itemID;
+
+	@Getter
+	private String name;
+
+	public AmmoCounter(Plugin plugin, int itemID, int count, String name, BufferedImage image)
+	{
+		super(image, plugin, count);
+		this.itemID = itemID;
+		this.name = name;
+	}
+
+	@Override
+	public String getTooltip()
+	{
+		return name;
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/ammo/AmmoCounter.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/ammo/AmmoCounter.java
@@ -28,6 +28,7 @@ import java.awt.image.BufferedImage;
 import lombok.Getter;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.ui.overlay.infobox.Counter;
+import net.runelite.client.util.StackFormatter;
 
 public class AmmoCounter extends Counter
 {
@@ -42,6 +43,12 @@ public class AmmoCounter extends Counter
 		super(image, plugin, count);
 		this.itemID = itemID;
 		this.name = name;
+	}
+
+	@Override
+	public String getText()
+	{
+		return StackFormatter.quantityToRSDecimalStack(getCount());
 	}
 
 	@Override

--- a/runelite-client/src/main/java/net/runelite/client/plugins/ammo/AmmoPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/ammo/AmmoPlugin.java
@@ -67,7 +67,7 @@ public class AmmoPlugin extends Plugin
 			ItemContainer container = client.getItemContainer(InventoryID.EQUIPMENT);
 			if (container != null)
 			{
-				updateInfobox(container.getItems());
+				parseInventory(container.getItems());
 			}
 		});
 	}
@@ -87,18 +87,30 @@ public class AmmoPlugin extends Plugin
 			return;
 		}
 
-		updateInfobox(event.getItemContainer().getItems());
+		parseInventory(event.getItemContainer().getItems());
 	}
 
-	private void updateInfobox(Item[] items)
+	private void parseInventory(Item[] items)
 	{
+		//Check for weapon slot items. This overrides the ammo slot
+		if (items.length >= EquipmentInventorySlot.WEAPON.getSlotIdx() - 1)
+		{
+			final Item weapon = items[EquipmentInventorySlot.WEAPON.getSlotIdx()];
+			final ItemComposition weaponComp = itemManager.getItemComposition(weapon.getId());
+			if (weaponComp.isStackable())
+			{
+				updateInfobox(weapon, weaponComp);
+				return;
+			}
+		}
+
 		if (items.length <= EquipmentInventorySlot.AMMO.getSlotIdx())
 		{
 			return;
 		}
 
-		Item ammo = items[EquipmentInventorySlot.AMMO.getSlotIdx()];
-		ItemComposition comp = itemManager.getItemComposition(ammo.getId());
+		final Item ammo = items[EquipmentInventorySlot.AMMO.getSlotIdx()];
+		final ItemComposition comp = itemManager.getItemComposition(ammo.getId());
 
 		if (!comp.isStackable())
 		{
@@ -107,15 +119,21 @@ public class AmmoPlugin extends Plugin
 			return;
 		}
 
-		if (counterBox != null && counterBox.getItemID() == ammo.getId())
+		updateInfobox(ammo, comp);
+	}
+
+	private void updateInfobox(Item item, ItemComposition comp)
+	{
+
+		if (counterBox != null && counterBox.getItemID() == item.getId())
 		{
-			counterBox.setCount(ammo.getQuantity());
+			counterBox.setCount(item.getQuantity());
 			return;
 		}
 
 		infoBoxManager.removeInfoBox(counterBox);
-		final BufferedImage image = itemManager.getImage(ammo.getId(), 5, false);
-		counterBox = new AmmoCounter(this, ammo.getId(), ammo.getQuantity(), comp.getName(), image);
+		final BufferedImage image = itemManager.getImage(item.getId(), 5, false);
+		counterBox = new AmmoCounter(this, item.getId(), item.getQuantity(), comp.getName(), image);
 		infoBoxManager.addInfoBox(counterBox);
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/ammo/AmmoPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/ammo/AmmoPlugin.java
@@ -41,7 +41,9 @@ import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.infobox.InfoBoxManager;
 
 @PluginDescriptor(
-	name = "Ammo"
+	name = "Ammo",
+	description = "Shows the current ammo the player has equipped",
+	tags = {"bolts", "darts", "chinchompa"}
 )
 public class AmmoPlugin extends Plugin
 {
@@ -92,7 +94,8 @@ public class AmmoPlugin extends Plugin
 
 	private void parseInventory(Item[] items)
 	{
-		//Check for weapon slot items. This overrides the ammo slot
+		// Check for weapon slot items. This overrides the ammo slot,
+		// as the player will use the thrown weapon (eg. chinchompas, knives, darts)
 		if (items.length >= EquipmentInventorySlot.WEAPON.getSlotIdx() - 1)
 		{
 			final Item weapon = items[EquipmentInventorySlot.WEAPON.getSlotIdx()];
@@ -124,7 +127,6 @@ public class AmmoPlugin extends Plugin
 
 	private void updateInfobox(Item item, ItemComposition comp)
 	{
-
 		if (counterBox != null && counterBox.getItemID() == item.getId())
 		{
 			counterBox.setCount(item.getQuantity());

--- a/runelite-client/src/main/java/net/runelite/client/plugins/ammo/AmmoPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/ammo/AmmoPlugin.java
@@ -43,7 +43,7 @@ import net.runelite.client.ui.overlay.infobox.InfoBoxManager;
 @PluginDescriptor(
 	name = "Ammo",
 	description = "Shows the current ammo the player has equipped",
-	tags = {"bolts", "darts", "chinchompa"}
+	tags = {"bolts", "darts", "chinchompa", "equipment"}
 )
 public class AmmoPlugin extends Plugin
 {
@@ -62,20 +62,21 @@ public class AmmoPlugin extends Plugin
 	private AmmoCounter counterBox;
 
 	@Override
-	public void startUp() throws Exception
+	protected void startUp() throws Exception
 	{
 		clientThread.invokeLater(() ->
 		{
-			ItemContainer container = client.getItemContainer(InventoryID.EQUIPMENT);
+			final ItemContainer container = client.getItemContainer(InventoryID.EQUIPMENT);
+
 			if (container != null)
 			{
-				parseInventory(container.getItems());
+				checkInventory(container.getItems());
 			}
 		});
 	}
 
 	@Override
-	public void shutDown() throws Exception
+	protected void shutDown() throws Exception
 	{
 		infoBoxManager.removeInfoBox(counterBox);
 		counterBox = null;
@@ -89,10 +90,10 @@ public class AmmoPlugin extends Plugin
 			return;
 		}
 
-		parseInventory(event.getItemContainer().getItems());
+		checkInventory(event.getItemContainer().getItems());
 	}
 
-	private void parseInventory(Item[] items)
+	private void checkInventory(final Item[] items)
 	{
 		// Check for weapon slot items. This overrides the ammo slot,
 		// as the player will use the thrown weapon (eg. chinchompas, knives, darts)
@@ -125,7 +126,7 @@ public class AmmoPlugin extends Plugin
 		updateInfobox(ammo, comp);
 	}
 
-	private void updateInfobox(Item item, ItemComposition comp)
+	private void updateInfobox(final Item item, final ItemComposition comp)
 	{
 		if (counterBox != null && counterBox.getItemID() == item.getId())
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/ammo/AmmoPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/ammo/AmmoPlugin.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2019 Hydrox6 <ikada@protonmail.ch>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.ammo;
+
+import java.awt.image.BufferedImage;
+import javax.inject.Inject;
+import net.runelite.api.Client;
+import net.runelite.api.EquipmentInventorySlot;
+import net.runelite.api.InventoryID;
+import net.runelite.api.Item;
+import net.runelite.api.ItemComposition;
+import net.runelite.api.ItemContainer;
+import net.runelite.api.events.ItemContainerChanged;
+import net.runelite.client.callback.ClientThread;
+import net.runelite.client.eventbus.Subscribe;
+import net.runelite.client.game.ItemManager;
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.ui.overlay.infobox.InfoBoxManager;
+
+@PluginDescriptor(
+	name = "Ammo"
+)
+public class AmmoPlugin extends Plugin
+{
+	@Inject
+	private Client client;
+
+	@Inject
+	private ClientThread clientThread;
+
+	@Inject
+	private InfoBoxManager infoBoxManager;
+
+	@Inject
+	private ItemManager itemManager;
+
+	private AmmoCounter counterBox;
+
+	@Override
+	public void startUp() throws Exception
+	{
+		clientThread.invokeLater(() ->
+		{
+			ItemContainer container = client.getItemContainer(InventoryID.EQUIPMENT);
+			if (container != null)
+			{
+				updateInfobox(container.getItems());
+			}
+		});
+	}
+
+	@Override
+	public void shutDown() throws Exception
+	{
+		infoBoxManager.removeInfoBox(counterBox);
+		counterBox = null;
+	}
+
+	@Subscribe
+	public void onItemContainerChanged(ItemContainerChanged event)
+	{
+		if (event.getItemContainer() != client.getItemContainer(InventoryID.EQUIPMENT))
+		{
+			return;
+		}
+
+		updateInfobox(event.getItemContainer().getItems());
+	}
+
+	private void updateInfobox(Item[] items)
+	{
+		if (items.length <= EquipmentInventorySlot.AMMO.getSlotIdx())
+		{
+			return;
+		}
+
+		Item ammo = items[EquipmentInventorySlot.AMMO.getSlotIdx()];
+		ItemComposition comp = itemManager.getItemComposition(ammo.getId());
+
+		if (!comp.isStackable())
+		{
+			infoBoxManager.removeInfoBox(counterBox);
+			counterBox = null;
+			return;
+		}
+
+		if (counterBox != null && counterBox.getItemID() == ammo.getId())
+		{
+			counterBox.setCount(ammo.getQuantity());
+			return;
+		}
+
+		infoBoxManager.removeInfoBox(counterBox);
+		final BufferedImage image = itemManager.getImage(ammo.getId(), 5, false);
+		counterBox = new AmmoCounter(this, ammo.getId(), ammo.getQuantity(), comp.getName(), image);
+		infoBoxManager.addInfoBox(counterBox);
+	}
+}


### PR DESCRIPTION
Closes #864

Shows the current ammo the player has equipped. If the player is using a stackable weapon (chinchompas, darts, etc) those will show, otherwise it'll show the ammo slot (unless the item is a blessing or empty)

If the value is over 1,000,000 the number will have an M. If it's over 10,000 the number will have a K. Let me know if I should add colours

![](https://i.imgur.com/KykRTL7.gif)

I tried to find an existing plugin this would fit in, but I couldn't find a suitable one. If you can think of one, please let me know and I'll move it.