### PR TITLE
http-service: fix twitter feed links not working with newer theme

### DIFF
--- a/http-service/src/main/java/net/runelite/http/service/feed/twitter/TwitterService.java
+++ b/http-service/src/main/java/net/runelite/http/service/feed/twitter/TwitterService.java
@@ -124,7 +124,7 @@ public class TwitterService
 					i.getUser().getProfileImageUrl(),
 					i.getUser().getScreenName(),
 					i.getText().replace("\n\n", " ").replaceAll("\n", " "),
-					"https://twitter.com/statuses/" + i.getId(),
+					"https://twitter.com/" + i.getUser().getScreenName() + "/status/" + i.getId(),
 					getTimestampFromSnowflake(i.getId())));
 			}
 


### PR DESCRIPTION
When using Twitter's new theme, https://twitter.com/statuses/[tweet_id] style links don't redirect to the tweet in question.

Urls before this change:
https://twitter.com/statuses/1102962117509087234

After this change:
https://twitter.com/OldSchoolRS/status/1102962117509087234