### PR TITLE
Send message to user if they do not have a Slayer task

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerPlugin.java
@@ -756,9 +756,17 @@ public class SlayerPlugin extends Plugin
 
 		if (task == null)
 		{
+			StringBuilder sb = new StringBuilder();
+			sb.append("Unable to find current Slayer task");
+			if (chatMessage.getName().equals(client.getLocalPlayer().getName()))
+			{
+				sb.append(".");
+				sb.append(" ");
+				sb.append("Do you have one? Check your Enchanted gem");
+			}
 			String response = new ChatMessageBuilder()
 				.append(ChatColorType.NORMAL)
-				.append("Unable to find current Slayer task. Do you have one? Check your Enchanted gem/Slayer ring/Slayer helmet")
+				.append(sb.toString())
 				.build();
 
 			final MessageNode messageNode = chatMessage.getMessageNode();

--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerPlugin.java
@@ -587,7 +587,7 @@ public class SlayerPlugin extends Plugin
 	private boolean doubleTroubleExtraKill()
 	{
 		return WorldPoint.fromLocalInstance(client, client.getLocalPlayer().getLocalLocation()).getRegionID() == GROTESQUE_GUARDIANS_REGION &&
-				SlayerUnlock.GROTESQUE_GARDIAN_DOUBLE_COUNT.isEnabled(client);
+			SlayerUnlock.GROTESQUE_GARDIAN_DOUBLE_COUNT.isEnabled(client);
 	}
 
 	private boolean isTarget(NPC npc)
@@ -751,6 +751,20 @@ public class SlayerPlugin extends Plugin
 		catch (IOException ex)
 		{
 			log.debug("unable to lookup slayer task", ex);
+			return;
+		}
+
+		if (task == null)
+		{
+			String response = new ChatMessageBuilder()
+				.append(ChatColorType.NORMAL)
+				.append("Unable to find current Slayer task. Do you have one? Check your Enchanted gem/Slayer ring/Slayer helmet")
+				.build();
+
+			final MessageNode messageNode = chatMessage.getMessageNode();
+			messageNode.setRuneLiteFormatMessage(response);
+			chatMessageManager.update(messageNode);
+			client.refreshChat();
 			return;
 		}
 

--- a/runelite-client/src/test/java/net/runelite/client/plugins/slayer/SlayerPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/slayer/SlayerPluginTest.java
@@ -53,6 +53,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.contains;
 import org.mockito.Mock;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -109,6 +110,8 @@ public class SlayerPluginTest
 
 	private static final String BREAK_SLAUGHTER = "The bracelet shatters. Your next bracelet of slaughter<br>will start afresh from 30 charges.";
 	private static final String BREAK_EXPEDITIOUS = "The bracelet shatters. Your next expeditious bracelet<br>will start afresh from 30 charges.";
+
+	private static final String NO_TASK_FOUND_MESSAGE = "Unable to find current Slayer task. Do you have one? Check your Enchanted gem/Slayer ring/Slayer helmet";
 
 	@Mock
 	@Bind
@@ -560,5 +563,25 @@ public class SlayerPluginTest
 		slayerPlugin.taskLookup(chatMessage, "!task");
 
 		verify(chatMessageManager, never()).update(any(MessageNode.class));
+	}
+
+	@Test
+	public void testTaskLookupNoCurrentTask() throws IOException
+	{
+		net.runelite.http.api.chat.Task task = null;
+		MessageNode messageNode = mock(MessageNode.class);
+
+		when(slayerConfig.taskCommand()).thenReturn(true);
+		when(chatClient.getTask(anyString())).thenReturn(task);
+
+		ChatMessage chatMessage = new ChatMessage();
+		chatMessage.setType(ChatMessageType.PUBLIC);
+		chatMessage.setName("Adam");
+		chatMessage.setMessageNode(messageNode);
+
+		slayerPlugin.taskLookup(chatMessage, "!task");
+
+		verify(chatMessageManager).update(messageNode);
+		verify(messageNode).setRuneLiteFormatMessage(contains(NO_TASK_FOUND_MESSAGE));
 	}
 }


### PR DESCRIPTION
The RuneLite API returns empty string if no task is set, and serializing that into a Task object returns null.

Example of the chat message: https://i.imgur.com/6MNRqTI.png

Resolves `!task` issue from #8047.