### PR TITLE
Add quantity specifier to Ground Items filters (Highlight + Hidden)

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/FilterItem.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/FilterItem.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2019, Mikhail <mikhail@huizenvlees.nl>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.grounditems;
+
+import lombok.Data;
+
+@Data
+class FilterItem
+{
+	static final int[] POWERS_OF_10 = {1, 10, 100, 1000, 10000, 100000, 1000000, 10000000, 100000000, 1000000000};
+
+	private String pattern;
+	private String operator = "";
+	private int amount = 0;
+
+	FilterItem(String pattern)
+	{
+		this.pattern = pattern;
+	}
+
+	FilterItem(String pattern, String operator, int amount, String quantifier)
+	{
+		this.pattern = pattern;
+		this.operator = operator;
+		this.amount = amount * getQuantifier(quantifier);
+	}
+
+	private int getQuantifier(String quantifier)
+	{
+		switch (quantifier)
+		{
+			case "k":
+			case "K":
+				return POWERS_OF_10[3];
+			case "m":
+			case "M":
+				return POWERS_OF_10[6];
+			case "b":
+			case "B":
+				return POWERS_OF_10[9];
+			default:
+				return POWERS_OF_10[0];
+		}
+	}
+
+	Boolean checkAmount(int amount)
+	{
+		switch (operator)
+		{
+			case ">":
+				return amount > this.amount;
+			case "<":
+				return amount < this.amount;
+			case "=":
+				return amount == this.amount;
+			default:
+				return true;
+		}
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
@@ -39,7 +39,7 @@ public interface GroundItemsConfig extends Config
 	@ConfigItem(
 		keyName = "highlightedItems",
 		name = "Highlighted Items",
-		description = "Configures specifically highlighted ground items. Format: (item), (item)",
+		description = "Configures specifically highlighted ground items. Format: (item), (item), (item[<=>]quantity[kmb])",
 		position = 0
 	)
 	default String getHighlightItems()
@@ -57,12 +57,12 @@ public interface GroundItemsConfig extends Config
 	@ConfigItem(
 		keyName = "hiddenItems",
 		name = "Hidden Items",
-		description = "Configures hidden ground items. Format: (item), (item)",
+		description = "Configures hidden ground items. Format: (item), (item), (item[<=>]quantity[kmb])",
 		position = 1
 	)
 	default String getHiddenItems()
 	{
-		return "Vial, Ashes, Coins, Bones, Bucket, Jug, Seaweed";
+		return "Vial, Ashes, Coins<1k, Bones, Bucket, Jug, Seaweed";
 	}
 
 	@ConfigItem(

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
@@ -174,8 +174,8 @@ public class GroundItemsOverlay extends Overlay
 				continue;
 			}
 
-			final Color highlighted = plugin.getHighlighted(item.getName(), item.getGePrice(), item.getHaPrice());
-			final Color hidden = plugin.getHidden(item.getName(), item.getGePrice(), item.getHaPrice(), item.isTradeable());
+			final Color highlighted = plugin.getHighlighted(item.getName(), item.getQuantity(), item.getGePrice(), item.getHaPrice());
+			final Color hidden = plugin.getHidden(item.getName(), item.getQuantity(), item.getGePrice(), item.getHaPrice(), item.isTradeable());
 
 			if (highlighted == null && !plugin.isHotKeyPressed())
 			{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/ItemNameWithQuantity.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/ItemNameWithQuantity.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2019, Mikhail <mikhail@huizenvlees.nl>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.grounditems;
+
+import lombok.Data;
+import lombok.Getter;
+
+@Data
+class ItemNameWithQuantity
+{
+	@Getter private String name;
+	@Getter private int quantity;
+
+	ItemNameWithQuantity(String name, int quantity)
+	{
+		this.name = name.trim();
+		this.quantity = quantity;
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/WildcardMatchLoader.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/WildcardMatchLoader.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018, Tomas Slusny <slusnucky@gmail.com>
+ * Copyright (c) 2019, Mikhail <mikhail@huizenvlees.nl>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -23,40 +24,32 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 package net.runelite.client.plugins.grounditems;
-
 import com.google.common.base.Strings;
 import com.google.common.cache.CacheLoader;
 import java.util.List;
 import javax.annotation.Nonnull;
 import net.runelite.client.util.WildcardMatcher;
-
-class WildcardMatchLoader extends CacheLoader<String, Boolean>
+class WildcardMatchLoader extends CacheLoader<ItemNameWithQuantity, Boolean>
 {
-	private final List<String> nameFilters;
-
-	WildcardMatchLoader(List<String> nameFilters)
+	private final List<FilterItem> nameFilters;
+	WildcardMatchLoader(List<FilterItem> nameFilters)
 	{
 		this.nameFilters = nameFilters;
 	}
-
 	@Override
-	public Boolean load(@Nonnull final String key)
+	public Boolean load(@Nonnull final ItemNameWithQuantity itemNameWithQuantity)
 	{
-		if (Strings.isNullOrEmpty(key))
+		if (Strings.isNullOrEmpty(itemNameWithQuantity.getName()))
 		{
 			return false;
 		}
-
-		final String filteredName = key.trim();
-
-		for (final String filter : nameFilters)
+		for (final FilterItem filter : nameFilters)
 		{
-			if (WildcardMatcher.matches(filter, filteredName))
+			if (WildcardMatcher.matches(filter.getPattern(), itemNameWithQuantity.getName()))
 			{
-				return true;
+				return filter.checkAmount(itemNameWithQuantity.getQuantity());
 			}
 		}
-
 		return false;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/WildcardMatchLoader.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/WildcardMatchLoader.java
@@ -24,11 +24,13 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 package net.runelite.client.plugins.grounditems;
+
 import com.google.common.base.Strings;
 import com.google.common.cache.CacheLoader;
 import java.util.List;
 import javax.annotation.Nonnull;
 import net.runelite.client.util.WildcardMatcher;
+
 class WildcardMatchLoader extends CacheLoader<ItemNameWithQuantity, Boolean>
 {
 	private final List<FilterItem> nameFilters;
@@ -43,6 +45,7 @@ class WildcardMatchLoader extends CacheLoader<ItemNameWithQuantity, Boolean>
 		{
 			return false;
 		}
+
 		for (final FilterItem filter : nameFilters)
 		{
 			if (WildcardMatcher.matches(filter.getPattern(), itemNameWithQuantity.getName()))
@@ -50,6 +53,7 @@ class WildcardMatchLoader extends CacheLoader<ItemNameWithQuantity, Boolean>
 				return filter.checkAmount(itemNameWithQuantity.getQuantity());
 			}
 		}
+
 		return false;
 	}
 }

--- a/runelite-client/src/test/java/net/runelite/client/plugins/grounditems/WildcardMatchLoaderTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/grounditems/WildcardMatchLoaderTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018, Adam <Adam@sigterm.info>
+ * Copyright (c) 2019, Mikhail <mikhail@huizenvlees.nl>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -25,6 +26,8 @@
 package net.runelite.client.plugins.grounditems;
 
 import java.util.Arrays;
+import java.util.List;
+
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import org.junit.Test;
@@ -34,12 +37,25 @@ public class WildcardMatchLoaderTest
 	@Test
 	public void testLoad()
 	{
-		WildcardMatchLoader loader = new WildcardMatchLoader(Arrays.asList("rune*", "Abyssal whip"));
-		assertTrue(loader.load("rune pouch"));
-		assertTrue(loader.load("Rune pouch"));
-		assertFalse(loader.load("Adamant dagger"));
-		assertTrue(loader.load("Runeite Ore"));
-		assertTrue(loader.load("Abyssal whip"));
-		assertFalse(loader.load("Abyssal dagger"));
+		List<FilterItem> filterItemList = Arrays.asList(
+				new FilterItem("rune*"),
+				new FilterItem("Abyssal whip"),
+				new FilterItem("Egg", "<", 5, ""),
+				new FilterItem("Coins", ">", 2, "m"),
+				new FilterItem("Arrow", "=", 2, "")
+		);
+
+		WildcardMatchLoader loader = new WildcardMatchLoader(filterItemList);
+		assertTrue(loader.load(new ItemNameWithQuantity("rune pouch", 1)));
+		assertTrue(loader.load(new ItemNameWithQuantity("Rune pouch", 1)));
+		assertFalse(loader.load(new ItemNameWithQuantity("Adamant dagger", 1)));
+		assertTrue(loader.load(new ItemNameWithQuantity("Runeite Ore", 1)));
+		assertTrue(loader.load(new ItemNameWithQuantity("Abyssal whip", 1)));
+		assertFalse(loader.load(new ItemNameWithQuantity("Abyssal dagger", 1)));
+		assertTrue(loader.load(new ItemNameWithQuantity("Egg", 4)));
+		assertFalse(loader.load(new ItemNameWithQuantity("Egg", 6)));
+		assertFalse(loader.load(new ItemNameWithQuantity("Coins", 1500000)));
+		assertTrue(loader.load(new ItemNameWithQuantity("coins", 2000001)));
+		assertTrue(loader.load(new ItemNameWithQuantity("Arrow", 2)));
 	}
 }


### PR DESCRIPTION
This enchantment to the Ground Items plugin will allow you to filter/highlight specific amounts and or use greater then/less then in the filter:
Example with `coins=1000` (You can also use quantifiers -> `coins=1k`)

![image](https://user-images.githubusercontent.com/7824786/54028047-ec36cd80-41a3-11e9-9f73-ca3c7a32b75a.png)
