### PR TITLE
Check message length before use.

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
@@ -366,6 +366,11 @@ public class ChatCommandsPlugin extends Plugin
 			return;
 		}
 
+		if (message.length() <= KILLCOUNT_COMMAND_STRING.length())
+		{
+			return;
+		}
+
 		ChatMessageType type = chatMessage.getType();
 		String search = message.substring(KILLCOUNT_COMMAND_STRING.length() + 1);
 
@@ -483,6 +488,11 @@ public class ChatCommandsPlugin extends Plugin
 			return;
 		}
 
+		if (message.length() <= PB_COMMAND.length())
+		{
+			return;
+		}
+
 		ChatMessageType type = chatMessage.getType();
 		String search = message.substring(PB_COMMAND.length() + 1);
 
@@ -574,6 +584,11 @@ public class ChatCommandsPlugin extends Plugin
 			return;
 		}
 
+		if (message.length() <= PRICE_COMMAND_STRING.length())
+		{
+			return;
+		}
+
 		MessageNode messageNode = chatMessage.getMessageNode();
 		String search = message.substring(PRICE_COMMAND_STRING.length() + 1);
 
@@ -637,6 +652,11 @@ public class ChatCommandsPlugin extends Plugin
 		}
 		else
 		{
+			if (message.length() <= LEVEL_COMMAND_STRING.length())
+			{
+				return;
+			}
+
 			search = message.substring(LEVEL_COMMAND_STRING.length() + 1);
 		}
 


### PR DESCRIPTION
If we don't check the length of the message before we access it with substring(command.length() + 1) we will get a string index out of range error.
This fixes issue #8047 and #8057.

(Also as a note it's my first pr here so if I did something wrong please let me know thanks!)



Closes #8047 