### PR TITLE
 clanchat: Add world info to join/leave messages

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/clanchat/ClanChatConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/clanchat/ClanChatConfig.java
@@ -106,10 +106,21 @@ public interface ClanChatConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "addWorldInfo",
+		name = "Join/Leave World info",
+		description = "Adds the players world & type to the join/leave messages.",
+		position = 6
+	)
+	default boolean addWorldInfo()
+	{
+		return true;
+	}
+
+	@ConfigItem(
 		keyName = "privateMessageIcons",
 		name = "Private Message Icons",
 		description = "Add clan chat rank icons to private messages received from clan mates.",
-		position = 6
+		position = 7
 	)
 	default boolean privateMessageIcons()
 	{
@@ -120,7 +131,7 @@ public interface ClanChatConfig extends Config
 		keyName = "publicChatIcons",
 		name = "Public Chat Icons",
 		description = "Add clan chat rank icons to public chat messages from clan mates.",
-		position = 7
+		position = 8
 	)
 	default boolean publicChatIcons()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/clanchat/ClanChatConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/clanchat/ClanChatConfig.java
@@ -117,10 +117,54 @@ public interface ClanChatConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "forceF2PMessages",
+		name = "Force F2P Join/Leave messages",
+		description = "Ignores message rank requirement for people in Free-2-Play worlds.",
+		position = 7
+	)
+	default boolean forceF2PMessages()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		keyName = "forceP2PMessages",
+		name = "Force P2P Join/Leave messages",
+		description = "Ignores message rank requirement for people in Pay-2-Play worlds.",
+		position = 8
+	)
+	default boolean forceP2PMessages()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		keyName = "forceDeadmanMessages",
+		name = "Force DMM Join/Leave messages",
+		description = "Ignores message rank requirement for people in Deadman related worlds.",
+		position = 9
+	)
+	default boolean forceDeadmanMessages()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		keyName = "forceRS3Messages",
+		name = "Force RS3 Join/Leave messages",
+		description = "Ignores message rank requirement for people in RS3 worlds/lobbies.",
+		position = 10
+	)
+	default boolean forceRS3Messages()
+	{
+		return false;
+	}
+
+	@ConfigItem(
 		keyName = "privateMessageIcons",
 		name = "Private Message Icons",
 		description = "Add clan chat rank icons to private messages received from clan mates.",
-		position = 7
+		position = 11
 	)
 	default boolean privateMessageIcons()
 	{
@@ -131,7 +175,7 @@ public interface ClanChatConfig extends Config
 		keyName = "publicChatIcons",
 		name = "Public Chat Icons",
 		description = "Add clan chat rank icons to public chat messages from clan mates.",
-		position = 8
+		position = 12
 	)
 	default boolean publicChatIcons()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/clanchat/ClanChatConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/clanchat/ClanChatConfig.java
@@ -119,7 +119,7 @@ public interface ClanChatConfig extends Config
 	@ConfigItem(
 		keyName = "forceF2PMessages",
 		name = "Force F2P Join/Leave messages",
-		description = "Ignores message rank requirement for people in Free-2-Play worlds.",
+		description = "Ignores message rank requirement for people in Free-to-Play worlds.",
 		position = 7
 	)
 	default boolean forceF2PMessages()
@@ -130,7 +130,7 @@ public interface ClanChatConfig extends Config
 	@ConfigItem(
 		keyName = "forceP2PMessages",
 		name = "Force P2P Join/Leave messages",
-		description = "Ignores message rank requirement for people in Pay-2-Play worlds.",
+		description = "Ignores message rank requirement for people in member's worlds.",
 		position = 8
 	)
 	default boolean forceP2PMessages()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/clanchat/ClanChatPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/clanchat/ClanChatPlugin.java
@@ -27,7 +27,9 @@
 package net.runelite.client.plugins.clanchat;
 
 import com.google.common.base.Strings;
+import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Lists;
+import com.google.common.collect.SetMultimap;
 import com.google.inject.Provides;
 import java.awt.Color;
 import java.awt.image.BufferedImage;
@@ -35,11 +37,11 @@ import java.io.IOException;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;
-import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import javax.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.ChatLineBuffer;
@@ -133,7 +135,7 @@ public class ClanChatPlugin extends Plugin
 	private Map<String, ClanMemberActivity> activityBuffer = new HashMap<>();
 	private int clanJoinedTick;
 
-	private final Map<Integer, EnumSet<WorldType>> worldTypeMap = new HashMap<>();
+	private final SetMultimap<Integer, WorldType> worldTypeMap = HashMultimap.create();
 
 	@Provides
 	ClanChatConfig getConfig(ConfigManager configManager)
@@ -150,7 +152,7 @@ public class ClanChatPlugin extends Plugin
 			final WorldResult worldResult = new WorldClient(RuneLiteAPI.CLIENT).lookupWorlds();
 			for (World w : worldResult.getWorlds())
 			{
-				worldTypeMap.put(w.getId(), w.getTypes());
+				worldTypeMap.putAll(w.getId(), w.getTypes());
 			}
 		}
 		catch (IOException ex)
@@ -417,7 +419,7 @@ public class ClanChatPlugin extends Plugin
 			}
 			else
 			{
-				final EnumSet<WorldType> worldTypes = worldTypeMap.get(world);
+				final Set<WorldType> worldTypes = worldTypeMap.get(world);
 				if (worldTypes != null)
 				{
 					worldInfo = getWorldPrefix(worldTypes);
@@ -678,7 +680,7 @@ public class ClanChatPlugin extends Plugin
 		infoBoxManager.addInfoBox(clanMemberCounter);
 	}
 
-	private String getWorldPrefix(final EnumSet<WorldType> worldTypes)
+	private String getWorldPrefix(final Set<WorldType> worldTypes)
 	{
 		if (worldTypes.contains(WorldType.DEADMAN_TOURNAMENT))
 		{
@@ -706,7 +708,7 @@ public class ClanChatPlugin extends Plugin
 			return config.forceRS3Messages();
 		}
 
-		final EnumSet<WorldType> worldTypes = worldTypeMap.get(worldNumber);
+		final Set<WorldType> worldTypes = worldTypeMap.get(worldNumber);
 		if (worldTypes != null)
 		{
 			if (worldTypes.contains(WorldType.DEADMAN) || worldTypes.contains(WorldType.SEASONAL_DEADMAN) || worldTypes.contains(WorldType.DEADMAN_TOURNAMENT))

--- a/runelite-client/src/main/java/net/runelite/client/plugins/clanchat/ClanChatPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/clanchat/ClanChatPlugin.java
@@ -215,8 +215,14 @@ public class ClanChatPlugin extends Plugin
 			return;
 		}
 
-		if (!config.showJoinLeave() ||
-			member.getRank().getValue() < config.joinLeaveRank().getValue())
+		if (!config.showJoinLeave())
+		{
+			return;
+		}
+
+		final boolean rankCheck = member.getRank().getValue() >= config.joinLeaveRank().getValue();
+		final boolean forceCheck = worldForceCheck(member.getWorld());
+		if (!rankCheck && !forceCheck)
 		{
 			return;
 		}
@@ -260,8 +266,14 @@ public class ClanChatPlugin extends Plugin
 			}
 		}
 
-		if (!config.showJoinLeave() ||
-			member.getRank().getValue() < config.joinLeaveRank().getValue())
+		if (!config.showJoinLeave())
+		{
+			return;
+		}
+
+		final boolean rankCheck = member.getRank().getValue() >= config.joinLeaveRank().getValue();
+		final boolean forceCheck = worldForceCheck(member.getWorld());
+		if (!rankCheck && !forceCheck)
 		{
 			return;
 		}
@@ -685,5 +697,26 @@ public class ClanChatPlugin extends Plugin
 
 		final ClanMemberRank rank = worldTypes.contains(WorldType.MEMBERS) ? ClanMemberRank.GENERAL : ClanMemberRank.CAPTAIN;
 		return "<img=" + clanManager.getIconNumber(rank) + "> ";
+	}
+
+	private boolean worldForceCheck(final int worldNumber)
+	{
+		if (worldNumber < OSRS_WORLD_THRESHOLD || worldNumber >= RS3_LOBBY_THRESHOLD)
+		{
+			return config.forceRS3Messages();
+		}
+
+		final EnumSet<WorldType> worldTypes = worldTypeMap.get(worldNumber);
+		if (worldTypes != null)
+		{
+			if (worldTypes.contains(WorldType.DEADMAN) || worldTypes.contains(WorldType.SEASONAL_DEADMAN) || worldTypes.contains(WorldType.DEADMAN_TOURNAMENT))
+			{
+				return config.forceDeadmanMessages();
+			}
+
+			return worldTypes.contains(WorldType.MEMBERS) ? config.forceP2PMessages() : config.forceF2PMessages();
+		}
+
+		return false;
 	}
 }


### PR DESCRIPTION
Adds the world information to the join/leave messages. Has a config option that is on by default.

![https://i.imgur.com/gMdT2b2.png](https://i.imgur.com/gMdT2b2.png)
![https://i.imgur.com/0GK3rqP.png](https://i.imgur.com/0GK3rqP.png)
![https://i.imgur.com/QnPz99X.png](https://i.imgur.com/QnPz99X.png)
![https://i.imgur.com/RSlPpsb.png](https://i.imgur.com/RSlPpsb.png)
![https://i.imgur.com/V9RXLbh.png](https://i.imgur.com/V9RXLbh.png)
