### PR TITLE
Changed Chaos Fanatic's slayer task info box sprite from pet to ancient staff to match the respawn timer

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/Task.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/Task.java
@@ -65,7 +65,7 @@ enum Task
 	CAVE_SLIMES("Cave slimes", ItemID.SWAMP_CAVE_SLIME),
 	CERBERUS("Cerberus", ItemID.HELLPUPPY),
 	CHAOS_ELEMENTAL("Chaos Elemental", ItemID.PET_CHAOS_ELEMENTAL),
-	CHAOS_FANATIC("Chaos Fanatic", ItemID.PET_CHAOS_ELEMENTAL),
+	CHAOS_FANATIC("Chaos Fanatic", ItemID.ANCIENT_STAFF),
 	COCKATRICE("Cockatrice", ItemID.COCKATRICE, "Cockathrice"),
 	COWS("Cows", ItemID.COW_MASK),
 	CRAWLING_HANDS("Crawling hands", ItemID.CRAWLING_HAND, "Crushing hand"),


### PR DESCRIPTION
`\runelite\runelite-client\src\main\java\net\runelite\client\plugins\bosstimer\Boss.java` contains `ItemID.ANCIENT_STAFF` as it's sprite as well 👍 

Closes: #8019