### PR TITLE
Revert "Remove raids points overlay"

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsPlugin.java
@@ -49,6 +49,9 @@ import net.runelite.api.Varbits;
 import net.runelite.api.events.ChatMessage;
 import net.runelite.api.events.ConfigChanged;
 import net.runelite.api.events.VarbitChanged;
+import net.runelite.api.events.WidgetHiddenChanged;
+import net.runelite.api.widgets.Widget;
+import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.callback.ClientThread;
 import net.runelite.client.chat.ChatColorType;
 import net.runelite.client.chat.ChatMessageBuilder;
@@ -102,6 +105,9 @@ public class RaidsPlugin extends Plugin
 	private RaidsOverlay overlay;
 
 	@Inject
+	private RaidsPointsOverlay pointsOverlay;
+
+	@Inject
 	private LayoutSolver layoutSolver;
 
 	@Inject
@@ -146,6 +152,7 @@ public class RaidsPlugin extends Plugin
 	protected void startUp() throws Exception
 	{
 		overlayManager.add(overlay);
+		overlayManager.add(pointsOverlay);
 		updateLists();
 		clientThread.invokeLater(() -> checkRaidPresence(true));
 	}
@@ -154,10 +161,17 @@ public class RaidsPlugin extends Plugin
 	protected void shutDown() throws Exception
 	{
 		overlayManager.remove(overlay);
+		overlayManager.remove(pointsOverlay);
 		infoBoxManager.removeInfoBox(timer);
 		inRaidChambers = false;
 		raid = null;
 		timer = null;
+
+		final Widget widget = client.getWidget(WidgetInfo.RAIDS_POINTS_INFOBOX);
+		if (widget != null)
+		{
+			widget.setHidden(false);
+		}
 	}
 
 	@Subscribe
@@ -176,6 +190,22 @@ public class RaidsPlugin extends Plugin
 
 		updateLists();
 		clientThread.invokeLater(() -> checkRaidPresence(true));
+	}
+
+	@Subscribe
+	public void onWidgetHiddenChanged(WidgetHiddenChanged event)
+	{
+		if (!inRaidChambers || event.isHidden())
+		{
+			return;
+		}
+
+		Widget widget = event.getWidget();
+
+		if (widget == client.getWidget(WidgetInfo.RAIDS_POINTS_INFOBOX))
+		{
+			widget.setHidden(true);
+		}
 	}
 
 	@Subscribe

--- a/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsPointsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsPointsOverlay.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2018, Kamiel
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.raids;
+
+import java.awt.Dimension;
+import java.awt.Graphics2D;
+import javax.inject.Inject;
+import net.runelite.api.Client;
+import static net.runelite.api.MenuAction.RUNELITE_OVERLAY_CONFIG;
+import net.runelite.api.Varbits;
+import static net.runelite.client.plugins.raids.RaidsPlugin.POINTS_FORMAT;
+import net.runelite.client.ui.overlay.Overlay;
+import static net.runelite.client.ui.overlay.OverlayManager.OPTION_CONFIGURE;
+import net.runelite.client.ui.overlay.OverlayMenuEntry;
+import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.OverlayPriority;
+import net.runelite.client.ui.overlay.components.LineComponent;
+import net.runelite.client.ui.overlay.components.PanelComponent;
+
+public class RaidsPointsOverlay extends Overlay
+{
+	@Inject
+	private Client client;
+
+	@Inject
+	private RaidsPlugin plugin;
+
+	private final PanelComponent panel = new PanelComponent();
+
+	@Inject
+	private RaidsPointsOverlay(RaidsPlugin plugin)
+	{
+		super(plugin);
+		setPosition(OverlayPosition.TOP_RIGHT);
+		setPriority(OverlayPriority.HIGH);
+		getMenuEntries().add(new OverlayMenuEntry(RUNELITE_OVERLAY_CONFIG, OPTION_CONFIGURE, "Raids overlay"));
+	}
+
+	@Override
+	public Dimension render(Graphics2D graphics)
+	{
+		if (!plugin.isInRaidChambers())
+		{
+			return null;
+		}
+
+		int totalPoints = client.getVar(Varbits.TOTAL_POINTS);
+		int personalPoints = client.getVar(Varbits.PERSONAL_POINTS);
+		int partySize = client.getVar(Varbits.RAID_PARTY_SIZE);
+
+		panel.getChildren().clear();
+		panel.getChildren().add(LineComponent.builder()
+			.left("Total:")
+			.right(POINTS_FORMAT.format(totalPoints))
+			.build());
+
+		panel.getChildren().add(LineComponent.builder()
+			.left(client.getLocalPlayer().getName() + ":")
+			.right(POINTS_FORMAT.format(personalPoints))
+			.build());
+
+		if (partySize > 1)
+		{
+			panel.getChildren().add(LineComponent.builder()
+				.left("Party size:")
+				.right(String.valueOf(partySize))
+				.build());
+		}
+
+		return panel.render(graphics);
+	}
+}


### PR DESCRIPTION
Our old overlay:

1. Looked better
2. Had more functionality
3. Was able to be moved more freely

closes #8164 

This reverts commit fbd3ea6202a07b4dc4d3aab4eeebf62afa793c7c.