### PR TITLE
Fix friend notes not saving on display names with spaces

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/friendnotes/FriendNotesPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/friendnotes/FriendNotesPlugin.java
@@ -29,9 +29,16 @@ package net.runelite.client.plugins.friendnotes;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.ObjectArrays;
+import java.awt.Color;
+import javax.annotation.Nullable;
+import javax.inject.Inject;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
-import net.runelite.api.*;
+import net.runelite.api.Client;
+import net.runelite.api.Friend;
+import net.runelite.api.MenuAction;
+import net.runelite.api.MenuEntry;
+import net.runelite.api.Nameable;
 import net.runelite.api.events.MenuEntryAdded;
 import net.runelite.api.events.MenuOptionClicked;
 import net.runelite.api.events.NameableNameChanged;
@@ -45,10 +52,6 @@ import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.OverlayManager;
 import net.runelite.client.util.ColorUtil;
 import net.runelite.client.util.Text;
-
-import javax.annotation.Nullable;
-import javax.inject.Inject;
-import java.awt.*;
 
 @Slf4j
 @PluginDescriptor(
@@ -164,7 +167,7 @@ public class FriendNotesPlugin extends Plugin
 		if (groupId == WidgetInfo.FRIENDS_LIST.getGroupId() && event.getOption().equals("Message"))
 		{
 			// Friends have color tags
-			setHoveredFriend(Text.toJagexName(Text.removeTags(event.getTarget())));
+			setHoveredFriend(Text.removeTags(event.getTarget()));
 
 			// Build "Add Note" or "Edit Note" menu entry
 			final MenuEntry addNote = new MenuEntry();
@@ -195,7 +198,7 @@ public class FriendNotesPlugin extends Plugin
 			}
 
 			//Friends have color tags
-			final String sanitizedTarget = Text.toJagexName(Text.removeTags(event.getMenuTarget()));
+			final String sanitizedTarget = Text.removeTags(event.getMenuTarget());
 
 			// Handle clicks on "Add Note" or "Edit Note"
 			if (event.getMenuOption().equals(ADD_NOTE) || event.getMenuOption().equals(EDIT_NOTE))

--- a/runelite-client/src/main/java/net/runelite/client/plugins/friendnotes/FriendNotesPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/friendnotes/FriendNotesPlugin.java
@@ -167,7 +167,7 @@ public class FriendNotesPlugin extends Plugin
 		if (groupId == WidgetInfo.FRIENDS_LIST.getGroupId() && event.getOption().equals("Message"))
 		{
 			// Friends have color tags
-			setHoveredFriend(Text.removeTags(event.getTarget()));
+			setHoveredFriend(Text.toJagexName(Text.removeTags(event.getTarget())));
 
 			// Build "Add Note" or "Edit Note" menu entry
 			final MenuEntry addNote = new MenuEntry();
@@ -198,7 +198,7 @@ public class FriendNotesPlugin extends Plugin
 			}
 
 			//Friends have color tags
-			final String sanitizedTarget = Text.removeTags(event.getMenuTarget());
+			final String sanitizedTarget = Text.toJagexName(Text.removeTags(event.getMenuTarget()));
 
 			// Handle clicks on "Add Note" or "Edit Note"
 			if (event.getMenuOption().equals(ADD_NOTE) || event.getMenuOption().equals(EDIT_NOTE))

--- a/runelite-client/src/main/java/net/runelite/client/plugins/friendnotes/FriendNotesPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/friendnotes/FriendNotesPlugin.java
@@ -29,16 +29,9 @@ package net.runelite.client.plugins.friendnotes;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.ObjectArrays;
-import java.awt.Color;
-import javax.annotation.Nullable;
-import javax.inject.Inject;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
-import net.runelite.api.Client;
-import net.runelite.api.Friend;
-import net.runelite.api.MenuAction;
-import net.runelite.api.MenuEntry;
-import net.runelite.api.Nameable;
+import net.runelite.api.*;
 import net.runelite.api.events.MenuEntryAdded;
 import net.runelite.api.events.MenuOptionClicked;
 import net.runelite.api.events.NameableNameChanged;
@@ -52,6 +45,10 @@ import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.OverlayManager;
 import net.runelite.client.util.ColorUtil;
 import net.runelite.client.util.Text;
+
+import javax.annotation.Nullable;
+import javax.inject.Inject;
+import java.awt.*;
 
 @Slf4j
 @PluginDescriptor(
@@ -167,7 +164,7 @@ public class FriendNotesPlugin extends Plugin
 		if (groupId == WidgetInfo.FRIENDS_LIST.getGroupId() && event.getOption().equals("Message"))
 		{
 			// Friends have color tags
-			setHoveredFriend(Text.removeTags(event.getTarget()));
+			setHoveredFriend(Text.toJagexName(Text.removeTags(event.getTarget())));
 
 			// Build "Add Note" or "Edit Note" menu entry
 			final MenuEntry addNote = new MenuEntry();
@@ -198,7 +195,7 @@ public class FriendNotesPlugin extends Plugin
 			}
 
 			//Friends have color tags
-			final String sanitizedTarget = Text.removeTags(event.getMenuTarget());
+			final String sanitizedTarget = Text.toJagexName(Text.removeTags(event.getMenuTarget()));
 
 			// Handle clicks on "Add Note" or "Edit Note"
 			if (event.getMenuOption().equals(ADD_NOTE) || event.getMenuOption().equals(EDIT_NOTE))

--- a/runelite-client/src/main/java/net/runelite/client/plugins/friendnotes/FriendNotesPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/friendnotes/FriendNotesPlugin.java
@@ -166,7 +166,8 @@ public class FriendNotesPlugin extends Plugin
 		// Look for "Message" on friends list
 		if (groupId == WidgetInfo.FRIENDS_LIST.getGroupId() && event.getOption().equals("Message"))
 		{
-			// Friends have color tags
+			// Friends have color tags, .toJagexName is necessary to save key using only ASCII characters,
+			// preventing config loading issues. This is specifically an issue for names with spaces.
 			setHoveredFriend(Text.toJagexName(Text.removeTags(event.getTarget())));
 
 			// Build "Add Note" or "Edit Note" menu entry
@@ -197,7 +198,8 @@ public class FriendNotesPlugin extends Plugin
 				return;
 			}
 
-			//Friends have color tags
+			//Friends have color tags .toJagexName is necessary to save key using only ASCII characters,
+			// preventing config loading issues. This is specifically and issue for names with spaces.
 			final String sanitizedTarget = Text.toJagexName(Text.removeTags(event.getMenuTarget()));
 
 			// Handle clicks on "Add Note" or "Edit Note"


### PR DESCRIPTION
Resolves issue #8173 

The display names were not being formatted correctly when utilizing the name as a key, as however the key is saved resulted in a format looking like "LordÂ Vionas" When it should be retrieving/saving a key of "Lord Vionas". Using Text.toJagexName resolved the formatting issue with the characters. I assume that would have been an issue with unicode or something, but I wasn't sure.