### PR TITLE
Fix WikiPlugin Crash

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/wiki/WikiPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/wiki/WikiPlugin.java
@@ -131,6 +131,9 @@ public class WikiPlugin extends Plugin
 				return;
 			}
 			children[0] = null;
+
+			onDeselect();
+			client.setSpellSelected(false);
 		});
 	}
 
@@ -186,7 +189,10 @@ public class WikiPlugin extends Plugin
 	private void onDeselect()
 	{
 		wikiSelected = false;
-		icon.setSpriteId(WikiSprite.WIKI_ICON.getSpriteId());
+		if (icon != null)
+		{
+			icon.setSpriteId(WikiSprite.WIKI_ICON.getSpriteId());
+		}
 	}
 
 	@Subscribe


### PR DESCRIPTION
Currently the client will crash when you use the wiki lookup option on something after the plugin has been turned off.
This will deselect the lookup option when the plugin is turned off so you can no longer do that.

```
ERROR net.runelite.client.RuneLite - Game crash: null
java.lang.NullPointerException: null
	at ae.jj(ae.java:10584)
	at fh.is(fh.java:8500)
	at client.copy$menuAction(client.java:8382)
	at bi.he(bi.java:1267)
	at client.hq(client.java:7558)
	at client.fw(client.java:3248)
	at client.an(client.java:1333)
	at bf.ai(bf.java:371)
	at bf.run(bf.java:350)
	at java.lang.Thread.run(Thread.java:748)
Error: ae.jj() fh.is() bi.he() client.hq() client.fw() client.an() bf.ai() | ae:10584 fh:8500 client:8382 bi:1267 client:7558 client:3248 client:1333 bf:371 bf:350 Thread:748 | java.lang.NullPointerException
error_game_crash
```