### PR TITLE
Reverse order of loot tracker grouped view

### DIFF
--- a/AlwaysOnTopConfig.java
+++ b/AlwaysOnTopConfig.java
@@ -1,0 +1,25 @@
+package net.runelite.client.plugins.alwaysontop;
+
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.Keybind;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
+
+@ConfigGroup(AlwaysOnTopConfig.GROUP)
+public interface AlwaysOnTopConfig extends Config
+{
+    String GROUP = "alwaysontop";
+
+    @ConfigItem(
+            keyName = "hotkey",
+            name = "Toggle Always on Top",
+            description = "Pressing this key will enable/disable the Runelite client showing over all other windows",
+            position = 0
+    )
+    default Keybind hotkey()
+    {
+        return new Keybind(KeyEvent.VK_SPACE, InputEvent.CTRL_DOWN_MASK | InputEvent.SHIFT_DOWN_MASK);
+    }
+}

--- a/AlwaysOnTopPlugin.java
+++ b/AlwaysOnTopPlugin.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2019, Seven-Ate <https://github.com/Seven-Ate>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.alwaysontop;
+
+import com.google.inject.Provides;
+
+import java.awt.*;
+import javax.inject.Inject;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.input.KeyManager;
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.util.HotkeyListener;
+
+@PluginDescriptor(
+        name = "Always on top",
+        description = "Sets Runelite client to always show over other windows"
+)
+public class AlwaysOnTopPlugin extends Plugin{
+
+    private boolean enabled;
+
+    @Inject
+    private AlwaysOnTopConfig config;
+
+    @Inject
+    private KeyManager keyManager;
+
+    @Provides
+    AlwaysOnTopConfig getConfig(ConfigManager configManager) {
+        return configManager.getConfig(AlwaysOnTopConfig.class);
+    }
+
+    private final HotkeyListener hotkeyListener = new HotkeyListener(() -> config.hotkey())
+    {
+        @Override
+        public void hotkeyPressed()
+        {
+            enabled = !enabled;
+            Window.getWindows()[0].setAlwaysOnTop(enabled);
+        }
+    };
+
+    @Override
+    protected void startUp() throws Exception {
+        enabled = false;
+        keyManager.registerKeyListener(hotkeyListener);
+
+        Window.getWindows()[0].setAlwaysOnTop(enabled);
+    }
+
+    @Override
+    protected void shutDown() throws Exception {
+        keyManager.unregisterKeyListener(hotkeyListener);
+
+        Window.getWindows()[0].setAlwaysOnTop(false);
+    }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
@@ -32,6 +32,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -442,7 +443,7 @@ public class LootTrackerPlugin extends Plugin
 
 	private Collection<LootTrackerRecord> convertToLootTrackerRecord(final Collection<LootRecord> records)
 	{
-		Collection<LootTrackerRecord> trackerRecords = new ArrayList<>();
+		List<LootTrackerRecord> trackerRecords = new ArrayList<>();
 		for (LootRecord record : records)
 		{
 			LootTrackerItem[] drops = record.getDrops().stream().map(itemStack ->
@@ -451,7 +452,7 @@ public class LootTrackerPlugin extends Plugin
 
 			trackerRecords.add(new LootTrackerRecord(record.getEventId(), "", drops, -1));
 		}
-
+		Collections.reverse(trackerRecords);
 		return trackerRecords;
 	}
 }


### PR DESCRIPTION
This puts monsters that were recently killed near the top of the list, instead of having to scroll down to find loot from your current session. Thought a config was superfluous, can add if it's wanted.