### PR TITLE
Transparent text support for TextComponent

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
@@ -26,9 +26,11 @@
 package net.runelite.client.plugins.grounditems;
 
 import java.awt.Color;
+import net.runelite.client.config.Alpha;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.FontType;
 import net.runelite.client.plugins.grounditems.config.ItemHighlightMode;
 import net.runelite.client.plugins.grounditems.config.MenuHighlightMode;
 import net.runelite.client.plugins.grounditems.config.PriceDisplayMode;
@@ -115,16 +117,16 @@ public interface GroundItemsConfig extends Config
 	{
 		return false;
 	}
-	
+
 	@ConfigItem(
 		keyName = "highlightTiles",
 		name = "Highlight Tiles",
 		description = "Configures whether or not to highlight tiles containing ground items",
 		position = 6
 	)
-	default boolean highlightTiles() 
-	{ 
-		return false; 
+	default boolean highlightTiles()
+	{
+		return false;
 	}
 
 	@ConfigItem(
@@ -199,6 +201,7 @@ public interface GroundItemsConfig extends Config
 		description = "Configures the color for default, non-highlighted items",
 		position = 13
 	)
+	@Alpha
 	default Color defaultColor()
 	{
 		return Color.WHITE;
@@ -210,6 +213,7 @@ public interface GroundItemsConfig extends Config
 		description = "Configures the color for highlighted items",
 		position = 14
 	)
+	@Alpha
 	default Color highlightedColor()
 	{
 		return Color.decode("#AA00FF");
@@ -221,6 +225,7 @@ public interface GroundItemsConfig extends Config
 		description = "Configures the color for hidden items in right-click menu and when holding ALT",
 		position = 15
 	)
+	@Alpha
 	default Color hiddenColor()
 	{
 		return Color.GRAY;
@@ -232,6 +237,7 @@ public interface GroundItemsConfig extends Config
 		description = "Configures the color for low value items",
 		position = 16
 	)
+	@Alpha
 	default Color lowValueColor()
 	{
 		return Color.decode("#66B2FF");
@@ -254,6 +260,7 @@ public interface GroundItemsConfig extends Config
 		description = "Configures the color for medium value items",
 		position = 18
 	)
+	@Alpha
 	default Color mediumValueColor()
 	{
 		return Color.decode("#99FF99");
@@ -276,6 +283,7 @@ public interface GroundItemsConfig extends Config
 		description = "Configures the color for high value items",
 		position = 20
 	)
+	@Alpha
 	default Color highValueColor()
 	{
 		return Color.decode("#FF9600");
@@ -298,6 +306,7 @@ public interface GroundItemsConfig extends Config
 		description = "Configures the color for insane value items",
 		position = 22
 	)
+	@Alpha
 	default Color insaneValueColor()
 	{
 		return Color.decode("#FF66B2");
@@ -345,5 +354,16 @@ public interface GroundItemsConfig extends Config
 	default boolean collapseEntries()
 	{
 		return false;
+	}
+
+	@ConfigItem(
+		keyName = "fontType",
+		name = "Font type",
+		description = "Configures the font type to use when drawing items",
+		position = 27
+	)
+	default FontType fontStyle()
+	{
+		return FontType.REGULAR;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
@@ -27,6 +27,7 @@ package net.runelite.client.plugins.grounditems;
 
 import java.awt.Color;
 import java.awt.Dimension;
+import java.awt.Font;
 import java.awt.FontMetrics;
 import java.awt.Graphics2D;
 import java.awt.Polygon;
@@ -94,14 +95,19 @@ public class GroundItemsOverlay extends Overlay
 		{
 			return null;
 		}
-
-		final FontMetrics fm = graphics.getFontMetrics();
 		final Player player = client.getLocalPlayer();
 
 		if (player == null || client.getViewportWidget() == null)
 		{
 			return null;
 		}
+
+		final Font originalFont = graphics.getFont();
+		final Font font = config.fontStyle().getFont();
+
+		graphics.setFont(font);
+
+		final FontMetrics fm = graphics.getFontMetrics();
 
 		offsetMap.clear();
 		final LocalPoint localLocation = player.getLocalLocation();
@@ -338,6 +344,8 @@ public class GroundItemsOverlay extends Overlay
 			textComponent.setPosition(new java.awt.Point(textX, textY));
 			textComponent.render(graphics);
 		}
+
+		graphics.setFont(originalFont);
 
 		return null;
 	}

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/components/TextComponent.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/components/TextComponent.java
@@ -24,11 +24,15 @@
  */
 package net.runelite.client.ui.overlay.components;
 
+import java.awt.AlphaComposite;
 import java.awt.Color;
+import java.awt.Composite;
 import java.awt.Dimension;
 import java.awt.FontMetrics;
 import java.awt.Graphics2D;
 import java.awt.Point;
+import java.awt.Shape;
+import java.awt.font.GlyphVector;
 import java.util.regex.Pattern;
 import lombok.Setter;
 import net.runelite.client.ui.overlay.RenderableEntity;
@@ -43,6 +47,7 @@ public class TextComponent implements RenderableEntity
 	private String text;
 	private Point position = new Point();
 	private Color color = Color.WHITE;
+	private Color borderColor = Color.BLACK;
 
 	public static String textWithoutColTags(String text)
 	{
@@ -64,28 +69,43 @@ public class TextComponent implements RenderableEntity
 				final String textWithoutCol = textWithoutColTags(textSplitOnCol);
 				final String colColor = textSplitOnCol.substring(textSplitOnCol.indexOf("=") + 1, textSplitOnCol.indexOf(">"));
 
-				// shadow
-				graphics.setColor(Color.BLACK);
-				graphics.drawString(textWithoutCol, x + 1, position.y + 1);
-
-				// actual text
-				graphics.setColor(Color.decode("#" + colColor));
-				graphics.drawString(textWithoutCol, x, position.y);
+				renderText(graphics, x, position.y, textWithoutCol, Color.decode("#" + colColor), borderColor);
 
 				x += fontMetrics.stringWidth(textWithoutCol);
 			}
 		}
 		else
 		{
-			// shadow
-			graphics.setColor(Color.BLACK);
-			graphics.drawString(text, position.x + 1, position.y + 1);
-
-			// actual text
-			graphics.setColor(color);
-			graphics.drawString(text, position.x, position.y);
+			renderText(graphics, position.x, position.y, text, color, borderColor);
 		}
-
 		return new Dimension(fontMetrics.stringWidth(text), fontMetrics.getHeight());
 	}
+
+	private void renderText(Graphics2D graphics, int x, int y, String text, Color color, Color border)
+	{
+		// remember previous composite
+		Composite originalComposite = graphics.getComposite();
+
+		// create a vector of the text
+		GlyphVector vector = graphics.getFont().createGlyphVector(graphics.getFontRenderContext(), text);
+
+		// compute the text shape
+		Shape stroke = vector.getOutline(x + 1, y + 1);
+		Shape shape = vector.getOutline(x, y);
+
+		// draw text border
+		graphics.setColor(border);
+		graphics.fill(stroke);
+
+		// replace the pixels instead of overlaying
+		graphics.setComposite(AlphaComposite.Src);
+
+		// draw actual text
+		graphics.setColor(color);
+		graphics.fill(shape);
+
+		// reset composite to original
+		graphics.setComposite(originalComposite);
+	}
+
 }


### PR DESCRIPTION
I changed how TextComponent is rendered, so that the text can be transparent, without being affected by the border color.

Originally the text was simply rendered on top of the border, which meant that text couldn't be transparent, it would simply result in a darker variant of the text.

With the new technique the text can be completely transparent, showing only the border.

Opaque Text
![image](https://user-images.githubusercontent.com/1300430/54202721-8f4f5600-44c8-11e9-9cef-9c1e97e191cd.png)

Half Opaque
![image](https://user-images.githubusercontent.com/1300430/54202349-c3764700-44c7-11e9-9eb5-4370128eca6a.png)

Transparent
![image](https://user-images.githubusercontent.com/1300430/54202657-6f1f9700-44c8-11e9-81e7-45adb75fdfe5.png)

I've also added a couple of features to the ground items plugin
* Font style customisation
* Alpha channel customisation