### PR TITLE
Unidentified herbs plugin

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/unids/UnidHerbsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/unids/UnidHerbsPlugin.java
@@ -1,0 +1,104 @@
+package net.runelite.client.plugins.unids;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import javax.inject.Inject;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.Client;
+import net.runelite.api.ItemComposition;
+import net.runelite.api.events.ChatMessage;
+import net.runelite.api.events.PostItemComposition;
+import net.runelite.client.eventbus.Subscribe;
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginDescriptor;
+
+@PluginDescriptor(
+	name = "Unidentified Herbs",
+	description = "Replaces grimy herbs with unidentified herbs",
+	enabledByDefault = false
+)
+@Slf4j
+public class UnidHerbsPlugin extends Plugin
+{
+
+	private static final int[] GRIMY_HERBS = {199, 201, 203, 205, 207, 209, 211, 213, 215, 217, 219, 2485, 3049, 3051};
+	private static final int ORIGINAL_UNID_MODEL = 2364;
+	private static final String CLEAN_MESSAGE_PATTERN = "You need level \\d{1,2} Herblore to clean the .+";
+	private static final String CLEAN_MESSAGE_REPLACEMENT = "Your Herblore level is not high enough to identify this herb.";
+
+	@Inject
+	private Client client;
+
+	private Field itemNameField;
+	private Field itemModelField;
+	private Field itemInventoryActionsField;
+	private Field itemSourceColorsField;
+	private Field itemReplacementColorsField;
+	private int encodedModelId;
+
+	@Override
+	protected void startUp() throws Exception
+	{
+		client.getItemCompositionCache().reset();
+		ClassLoader classLoader = client.getClass().getClassLoader();
+		Class<?> itemComposition = classLoader.loadClass("jz");
+
+		itemNameField = getFieldAndSetAccessible(itemComposition, "r");
+		itemModelField = getFieldAndSetAccessible(itemComposition, "v");
+		itemInventoryActionsField = getFieldAndSetAccessible(itemComposition, "ad");
+		itemSourceColorsField = getFieldAndSetAccessible(itemComposition, "x");
+		itemReplacementColorsField = getFieldAndSetAccessible(itemComposition, "y");
+
+		encodedModelId = 1310457931 * ORIGINAL_UNID_MODEL;
+	}
+
+	@Override
+	protected void shutDown() throws Exception
+	{
+		client.getItemCompositionCache().reset();
+	}
+
+	@Subscribe
+	public void onPostItemComposition(PostItemComposition event)
+	{
+		ItemComposition itemComposition = event.getItemComposition();
+		int itemId = itemComposition.getId();
+
+		if (isGrimyHerb(itemId))
+		{
+			try
+			{
+				itemNameField.set(itemComposition, "Herb");
+				itemModelField.set(itemComposition, encodedModelId);
+				itemSourceColorsField.set(itemComposition, null);
+				itemReplacementColorsField.set(itemComposition, null);
+				itemInventoryActionsField.set(itemComposition, new String[]{"Identify", null, null, null, null});
+			}
+			catch (Exception e)
+			{
+				log.error("Could not modify the item composition", e);
+			}
+		}
+	}
+
+	@Subscribe
+	public void onChatMessage(ChatMessage chatMessage)
+	{
+		if (chatMessage.getMessage().matches(CLEAN_MESSAGE_PATTERN))
+		{
+			chatMessage.getMessageNode().setValue(CLEAN_MESSAGE_REPLACEMENT);
+		}
+	}
+
+	private Field getFieldAndSetAccessible(Class clazz, String fieldName) throws Exception
+	{
+		Field field = clazz.getDeclaredField(fieldName);
+		field.setAccessible(true);
+		return field;
+	}
+
+	private boolean isGrimyHerb(int itemId)
+	{
+		return Arrays.binarySearch(GRIMY_HERBS, itemId) >= 0;
+	}
+}


### PR DESCRIPTION
This is a fun plugin that modifies grimy herbs item compositions so they look like the old unidentified herbs that were present in the game at the launch of oldschool. 
It also intercepts chat messages when the player fails to clean a herb due to not having the required level and replaces it with a generic message that doesn't give it away which herb it is.

Currently this plugin **cannot be merged** because it is relying on reflection to set some item composition fields that are not exposed by the runelite's api, the following fields are being reflected:

* name (opcode 2)
* modelId (opcode 1)
* sourceColors (opcode 40)
* targetColors (opcode 40)
* inventoryActions (opcodes 35-39)

It would also need access to the `itemSpriteCache` to reset it when enabling/disabling the plugin.

##### Known issues

* After enabling/disabling the item sprite will not change imediately (fixed by reseting the itemSpriteCache)
* This plugin affects the grand exchange search results

##### Images of the plugin
![Plugin image 1](https://i.imgur.com/mA0TGmC.png)
![Plugin image 2](https://i.imgur.com/boVXLEe.png)
![Plugin image 3](https://i.imgur.com/tzrJeYg.png)

If this plugin is something that is not wanted on runelite or if it is not possible to expose those item compositions fields please close this PR.