### PR TITLE
item stats: fix detecting when GE has closed, fix threading issue

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatPlugin.java
@@ -44,9 +44,9 @@ import net.runelite.api.SpriteID;
 import net.runelite.api.VarPlayer;
 import net.runelite.api.Varbits;
 import net.runelite.api.events.ConfigChanged;
+import net.runelite.api.events.GameTick;
 import net.runelite.api.events.ScriptCallbackEvent;
 import net.runelite.api.events.VarbitChanged;
-import net.runelite.api.events.WidgetHiddenChanged;
 import net.runelite.api.widgets.JavaScriptCallback;
 import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetInfo;
@@ -127,14 +127,10 @@ public class ItemStatPlugin extends Plugin
 	}
 
 	@Subscribe
-	public void onWidgetHiddenChanged(WidgetHiddenChanged event)
+	public void onGameTick(GameTick event)
 	{
-		if (!config.geStats())
-		{
-			return;
-		}
-
-		if (event.getWidget() == client.getWidget(WidgetInfo.INVENTORY))
+		if (itemInformationTitle != null && config.geStats()
+			&& client.getWidget(WidgetInfo.GRAND_EXCHANGE_WINDOW_CONTAINER) == null)
 		{
 			resetGEInventory();
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatPlugin.java
@@ -52,6 +52,7 @@ import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.api.widgets.WidgetTextAlignment;
 import net.runelite.api.widgets.WidgetType;
+import net.runelite.client.callback.ClientThread;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.game.ItemManager;
@@ -90,6 +91,9 @@ public class ItemStatPlugin extends Plugin
 	@Inject
 	private ItemStatConfig config;
 
+	@Inject
+	private ClientThread clientThread;
+
 	private Widget itemInformationTitle;
 
 	@Provides
@@ -114,7 +118,7 @@ public class ItemStatPlugin extends Plugin
 	protected void shutDown() throws Exception
 	{
 		overlayManager.remove(overlay);
-		resetGEInventory();
+		clientThread.invokeLater(this::resetGEInventory);
 	}
 
 	@Subscribe
@@ -122,7 +126,7 @@ public class ItemStatPlugin extends Plugin
 	{
 		if (event.getKey().equals("geStats"))
 		{
-			resetGEInventory();
+			clientThread.invokeLater(this::resetGEInventory);
 		}
 	}
 


### PR DESCRIPTION
When side panels are enabled, the inventory is loaded when the GE is closed rather than being unhidden. Now uses `GameTick` to reset when the GE has closed. 

Using `WidgetLoaded`, alongside `WidgetHiddenChanged` is also possible, but is a tick slower than checking in `GameTick`. 

This PR also fixes an issue where `resetGEInventory` was not always being called on the client thread. 