### PR TITLE
Window snap feature

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/windowsnap/WindowSnapConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/windowsnap/WindowSnapConfig.java
@@ -12,7 +12,7 @@ public interface WindowSnapConfig extends Config
 			position = 1,
 			keyName = "enableMouseSnap",
 			name = "Mouse Drag Snaps Window",
-			description = "The window will snap to the side of the screen with the mouse")
+			description = "The window will snap to the side/corner of the screen with the mouse")
 	default boolean mouseEnabled()
 	{
 		return true;
@@ -22,7 +22,7 @@ public interface WindowSnapConfig extends Config
 			position = 2,
 			keyName = "enableKeySnap",
 			name = "Keyboard Shortcut Snaps Window",
-			description = "The window will snap to the side of the screen with keyboard shortcut")
+			description = "ctrl + arrow to control the window")
 	default boolean keyboardShortcutEnabled()
 	{
 		return true;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/windowsnap/WindowSnapConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/windowsnap/WindowSnapConfig.java
@@ -1,0 +1,66 @@
+package net.runelite.client.plugins.windowsnap;
+
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.Range;
+
+@ConfigGroup("windowsnap")
+public interface WindowSnapConfig extends Config
+{
+	@ConfigItem(
+			position = 1,
+			keyName = "enableMouseSnap",
+			name = "Mouse Drag Snaps Window",
+			description = "The window will snap to the side of the screen with the mouse")
+	default boolean mouseEnabled()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+			position = 2,
+			keyName = "enableKeySnap",
+			name = "Keyboard Shortcut Snaps Window",
+			description = "The window will snap to the side of the screen with keyboard shortcut")
+	default boolean keyboardShortcutEnabled()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+			position = 3,
+			keyName = "enableCustomSize",
+			name = "Enable Custom Size",
+			description = "Client will change to this dimension when enabled")
+	default boolean enableCustomSize()
+	{
+		return false;
+	}
+
+	@Range(
+			min = 773
+	)
+	@ConfigItem(
+			position = 4,
+			keyName = "customSizeWidth",
+			name = "Custom Snap Width",
+			description = "Size client will change to when snapped")
+	default int customWidth()
+	{
+		return 773;
+	}
+
+	@Range(
+			min = 534
+	)
+	@ConfigItem(
+			position = 5,
+			keyName = "customSizeHeight",
+			name = "Custom Snap Height",
+			description = "Size client will change to when snapped")
+	default int customHeight()
+	{
+		return 534;
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/windowsnap/WindowSnapListener.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/windowsnap/WindowSnapListener.java
@@ -1,0 +1,88 @@
+package net.runelite.client.plugins.windowsnap;
+
+
+import java.awt.event.KeyEvent;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseListener;
+import java.awt.event.MouseMotionListener;
+import javax.inject.Inject;
+import net.runelite.client.input.KeyListener;
+
+public class WindowSnapListener implements MouseListener, MouseMotionListener, KeyListener
+{
+
+	private boolean mouseDragging;
+
+	@Inject
+	WindowSnapConfig windowSnapConfig;
+
+	@Inject
+	WindowSnapPlugin windowSnapPlugin;
+
+	@Override
+	public void mouseClicked(MouseEvent e)
+	{
+
+	}
+
+	@Override
+	public void mousePressed(MouseEvent e)
+	{
+
+	}
+
+	@Override
+	public void mouseReleased(MouseEvent e)
+	{
+		if (mouseDragging && windowSnapConfig.mouseEnabled())
+		{
+			windowSnapPlugin.windowDragged(e.getXOnScreen(), e.getYOnScreen());
+		}
+
+	}
+
+	@Override
+	public void mouseEntered(MouseEvent e)
+	{
+
+	}
+
+	@Override
+	public void mouseExited(MouseEvent e)
+	{
+
+	}
+
+	@Override
+	public void mouseDragged(MouseEvent e)
+	{
+		mouseDragging = true;
+	}
+
+	@Override
+	public void mouseMoved(MouseEvent e)
+	{
+
+	}
+
+	@Override
+	public void keyTyped(KeyEvent e)
+	{
+
+	}
+
+	@Override
+	public void keyPressed(KeyEvent e)
+	{
+		if (windowSnapConfig.keyboardShortcutEnabled() && e.isControlDown())
+		{
+			windowSnapPlugin.keyboardShortcutPressed(e.getKeyCode());
+		}
+	}
+
+	@Override
+	public void keyReleased(KeyEvent e)
+	{
+
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/windowsnap/WindowSnapPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/windowsnap/WindowSnapPlugin.java
@@ -1,0 +1,181 @@
+package net.runelite.client.plugins.windowsnap;
+
+import com.google.inject.Provides;
+import java.awt.Insets;
+import java.awt.Toolkit;
+import java.awt.event.KeyEvent;
+import javax.inject.Inject;
+import javax.swing.JComponent;
+import javax.swing.JFrame;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.input.KeyManager;
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.ui.ClientUI;
+import net.runelite.client.ui.ContainableFrame;
+
+@PluginDescriptor(
+		name = "Window Snap",
+		description = "Allows the RuneLite window to snap like the windows feature",
+		tags = {"window", "snap"},
+		enabledByDefault = false
+)
+public class WindowSnapPlugin extends Plugin
+{
+
+	@Inject
+	ClientUI clientUI;
+
+	@Inject
+	WindowSnapListener windowSnapListener;
+
+	@Inject
+	KeyManager keyManager;
+
+	@Inject
+	WindowSnapConfig windowSnapConfig;
+
+	ContainableFrame frame;
+	private int screenWidth;
+	private int screenHeight;
+
+	@Override
+	protected void startUp() throws Exception
+	{
+		frame = clientUI.getFrame();
+		Insets bounds = Toolkit.getDefaultToolkit().getScreenInsets(frame.getGraphicsConfiguration());
+		screenWidth = frame.getGraphicsConfiguration().getBounds().width - bounds.left - bounds.right;
+		screenHeight = frame.getGraphicsConfiguration().getBounds().height - bounds.top - bounds.bottom;
+		JComponent titleBar = clientUI.getTitleBar();
+		if (titleBar != null)
+		{
+			titleBar.addMouseListener(windowSnapListener);
+			titleBar.addMouseMotionListener(windowSnapListener);
+			keyManager.registerKeyListener(windowSnapListener);
+		}
+		super.startUp();
+	}
+
+	@Override
+	protected void shutDown() throws Exception
+	{
+		JComponent titleBar = clientUI.getTitleBar();
+		if (titleBar != null)
+		{
+			titleBar.removeMouseListener(windowSnapListener);
+			titleBar.removeMouseMotionListener(windowSnapListener);
+			keyManager.unregisterKeyListener(windowSnapListener);
+		}
+		super.shutDown();
+	}
+
+	@Provides
+	WindowSnapConfig getConfig(ConfigManager configManager)
+	{
+		return configManager.getConfig(WindowSnapConfig.class);
+	}
+
+	public void windowDragged(int xOnScreen, int yOnScreen)
+	{
+		if (xOnScreen == 0)
+		{
+			if (yOnScreen == 0)
+			{
+				snapUpperLeft();
+			}
+			else if (yOnScreen >= screenHeight - 1)
+			{
+				snapLowerLeft();
+			}
+			else
+			{
+				snapLeft();
+			}
+		}
+		else if (xOnScreen == screenWidth - 1)
+		{
+			if (yOnScreen == 0)
+			{
+				snapUpperRight();
+			}
+			else if (yOnScreen >= screenHeight - 1)
+			{
+				snapLowerRight();
+			}
+			else
+			{
+				snapRight();
+			}
+		}
+		else if (yOnScreen == 0)
+		{
+			snapFull();
+		}
+	}
+
+	public void keyboardShortcutPressed(int keyEvent)
+	{
+		if (keyEvent == KeyEvent.VK_UP)
+			snapFull();
+		else if (keyEvent == KeyEvent.VK_LEFT)
+			snapLeft();
+		else if (keyEvent == KeyEvent.VK_RIGHT)
+			snapRight();
+	}
+
+	public void snapLeft()
+	{
+		int width = windowSnapConfig.enableCustomSize() ? windowSnapConfig.customWidth() : screenWidth / 2;
+		int height = windowSnapConfig.enableCustomSize() ? windowSnapConfig.customHeight() : screenHeight;
+		int y = windowSnapConfig.enableCustomSize() ? frame.getY() : 0;
+		frame.setBounds(0, y, width, height);
+	}
+
+	public void snapUpperLeft()
+	{
+		int width = windowSnapConfig.enableCustomSize() ? windowSnapConfig.customWidth() : screenWidth / 2;
+		int height = windowSnapConfig.enableCustomSize() ? windowSnapConfig.customHeight() : screenHeight / 2;
+		frame.setBounds(0, 0, width, height);
+	}
+
+	public void snapLowerLeft()
+	{
+		int width = windowSnapConfig.enableCustomSize() ? windowSnapConfig.customWidth() : screenWidth / 2;
+		int height = windowSnapConfig.enableCustomSize() ? windowSnapConfig.customHeight() : screenHeight / 2;
+		frame.setBounds(0, screenHeight / 2, width, height);
+	}
+
+	public void snapRight()
+	{
+		int width = windowSnapConfig.enableCustomSize() ? windowSnapConfig.customWidth() : screenWidth / 2;
+		int height = windowSnapConfig.enableCustomSize() ? windowSnapConfig.customHeight() : screenHeight;
+		int y = windowSnapConfig.enableCustomSize() ? frame.getY() : 0;
+		frame.setBounds(screenWidth - width, y, width, height);
+	}
+
+	public void snapUpperRight()
+	{
+		int width = windowSnapConfig.enableCustomSize() ? windowSnapConfig.customWidth() : screenWidth / 2;
+		int height = windowSnapConfig.enableCustomSize() ? windowSnapConfig.customHeight() : screenHeight / 2;
+		frame.setBounds(screenWidth - width, 0, width, height);
+	}
+
+	public void snapLowerRight()
+	{
+		int width = windowSnapConfig.enableCustomSize() ? windowSnapConfig.customWidth() : screenWidth / 2;
+		int height = windowSnapConfig.enableCustomSize() ? windowSnapConfig.customHeight() : screenHeight / 2;
+		frame.setBounds(screenWidth - width, screenHeight / 2, width, height);
+	}
+
+	public void snapFull()
+	{
+		if (windowSnapConfig.enableCustomSize())
+		{
+			frame.setBounds(frame.getX(), 0, windowSnapConfig.customWidth(), windowSnapConfig.customHeight());
+		}
+		else
+		{
+			frame.setExtendedState(frame.getExtendedState() | JFrame.MAXIMIZED_BOTH);
+		}
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/windowsnap/WindowSnapPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/windowsnap/WindowSnapPlugin.java
@@ -121,14 +121,14 @@ public class WindowSnapPlugin extends Plugin
 			snapLeft();
 		else if (keyEvent == KeyEvent.VK_RIGHT)
 			snapRight();
+		else if (keyEvent == KeyEvent.VK_DOWN)
+			frame.setExtendedState(JFrame.ICONIFIED);
 	}
 
 	public void snapLeft()
 	{
 		int width = windowSnapConfig.enableCustomSize() ? windowSnapConfig.customWidth() : screenWidth / 2;
-		int height = windowSnapConfig.enableCustomSize() ? windowSnapConfig.customHeight() : screenHeight;
-		int y = windowSnapConfig.enableCustomSize() ? frame.getY() : 0;
-		frame.setBounds(0, y, width, height);
+		frame.setBounds(0, 0, width, screenHeight);
 	}
 
 	public void snapUpperLeft()
@@ -148,9 +148,7 @@ public class WindowSnapPlugin extends Plugin
 	public void snapRight()
 	{
 		int width = windowSnapConfig.enableCustomSize() ? windowSnapConfig.customWidth() : screenWidth / 2;
-		int height = windowSnapConfig.enableCustomSize() ? windowSnapConfig.customHeight() : screenHeight;
-		int y = windowSnapConfig.enableCustomSize() ? frame.getY() : 0;
-		frame.setBounds(screenWidth - width, y, width, height);
+		frame.setBounds(screenWidth - width, 0, width, screenHeight);
 	}
 
 	public void snapUpperRight()
@@ -169,13 +167,6 @@ public class WindowSnapPlugin extends Plugin
 
 	public void snapFull()
 	{
-		if (windowSnapConfig.enableCustomSize())
-		{
-			frame.setBounds(frame.getX(), 0, windowSnapConfig.customWidth(), windowSnapConfig.customHeight());
-		}
-		else
-		{
-			frame.setExtendedState(frame.getExtendedState() | JFrame.MAXIMIZED_BOTH);
-		}
+		frame.setExtendedState(frame.getExtendedState() | JFrame.MAXIMIZED_BOTH);
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/ui/ClientTitleToolbar.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ClientTitleToolbar.java
@@ -36,7 +36,7 @@ import javax.swing.JPanel;
 /**
  * Client title toolbar component.
  */
-public class ClientTitleToolbar extends JPanel
+class ClientTitleToolbar extends JPanel
 {
 	private static final int TITLEBAR_SIZE = 23;
 	private static final int ITEM_PADDING = 4;

--- a/runelite-client/src/main/java/net/runelite/client/ui/ClientTitleToolbar.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ClientTitleToolbar.java
@@ -36,7 +36,7 @@ import javax.swing.JPanel;
 /**
  * Client title toolbar component.
  */
-class ClientTitleToolbar extends JPanel
+public class ClientTitleToolbar extends JPanel
 {
 	private static final int TITLEBAR_SIZE = 23;
 	private static final int ITEM_PADDING = 4;

--- a/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
@@ -126,6 +126,7 @@ public class ClientUI
 	private PluginPanel pluginPanel;
 	private ClientPluginToolbar pluginToolbar;
 	private ClientTitleToolbar titleToolbar;
+	private JComponent titleBar;
 	private JButton currentButton;
 	private NavigationButton currentNavButton;
 	private boolean sidebarOpen;
@@ -382,7 +383,7 @@ public class ClientUI
 			{
 				frame.getRootPane().setWindowDecorationStyle(JRootPane.FRAME);
 
-				final JComponent titleBar = SubstanceCoreUtilities.getTitlePaneComponent(frame);
+				titleBar = SubstanceCoreUtilities.getTitlePaneComponent(frame);
 				titleToolbar.putClientProperty(SubstanceTitlePaneUtilities.EXTRA_COMPONENT_KIND, SubstanceTitlePaneUtilities.ExtraComponentKind.TRAILING);
 				titleBar.add(titleToolbar);
 
@@ -877,5 +878,15 @@ public class ClientUI
 			configManager.unsetConfiguration(CONFIG_GROUP, CONFIG_CLIENT_MAXIMIZED);
 			configManager.setConfiguration(CONFIG_GROUP, CONFIG_CLIENT_BOUNDS, bounds);
 		}
+	}
+
+	public ContainableFrame getFrame()
+	{
+		return frame;
+	}
+
+	public JComponent getTitleBar()
+	{
+		return titleBar;
 	}
 }


### PR DESCRIPTION
I added a window-snap feature to the default runelite client.

With this plugin, you can drag the client to the side or the corner of your screen, and it will snap to side or the corner. I also added some keyboard shortcuts, ctrl + arrow keys to do the same thing. It is very much like the default Windows snap feature, however this does work with the custom chrome that RuneLite uses.

Here is a screenshot of what the settings look like:
![image](https://user-images.githubusercontent.com/22247745/54304464-96936400-459b-11e9-815e-c19f410d1cbb.png)

The custom size will be used if enabled, rather than snapping to half of the screen size. This is so if people like their client a particular size, they can enable it, and then still snap it so that it goes to the corner of the screen.

I have only tested this on windows, so it would be awesome if someone could test on mac (and possibly linux as well).

I posted what this looks like on the subreddit [here](https://www.reddit.com/r/2007scape/comments/b0he2m/would_anyone_be_interested_in_runelite_having_the/)

Let me know you think