### PR TITLE
Achievement Diary: Add Missing Requirements

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/ArdougneDiaryRequirement.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/ArdougneDiaryRequirement.java
@@ -42,6 +42,8 @@ public class ArdougneDiaryRequirement extends GenericDiaryRequirement
 			new SkillRequirement(Skill.THIEVING, 5));
 		add("Enter the Combat Training Camp north of W. Ardougne.",
 			new QuestRequirement(Quest.BIOHAZARD));
+		add("Go out fishing on the Fishing Trawler",
+			new SkillRequirement(Skill.FISHING, 15));
 
 		// MEDIUM
 		add("Enter the Unicorn pen in Ardougne zoo using Fairy rings.",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/ArdougneDiaryRequirement.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/ArdougneDiaryRequirement.java
@@ -42,7 +42,7 @@ public class ArdougneDiaryRequirement extends GenericDiaryRequirement
 			new SkillRequirement(Skill.THIEVING, 5));
 		add("Enter the Combat Training Camp north of W. Ardougne.",
 			new QuestRequirement(Quest.BIOHAZARD));
-		add("Go out fishing on the Fishing Trawler",
+		add("Go out fishing on the Fishing Trawler.",
 			new SkillRequirement(Skill.FISHING, 15));
 
 		// MEDIUM

--- a/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/FaladorDiaryRequirement.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/FaladorDiaryRequirement.java
@@ -95,7 +95,7 @@ public class FaladorDiaryRequirement extends GenericDiaryRequirement
 		add("Enter the mining guild wearing full prospector.",
 			new SkillRequirement(Skill.MINING, 60));
 		add("Kill the Blue Dragon under the Heroes' Guild.",
-			new QuestRequirement((Quest.HEROES_QUEST)));
+			new QuestRequirement(Quest.HEROES_QUEST));
 		add("Crack a wall safe within Rogues Den.",
 			new SkillRequirement(Skill.THIEVING, 50));
 		add("Recharge your prayer in the Port Sarim church while wearing full Proselyte.",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/FaladorDiaryRequirement.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/FaladorDiaryRequirement.java
@@ -94,6 +94,8 @@ public class FaladorDiaryRequirement extends GenericDiaryRequirement
 			new SkillRequirement(Skill.AGILITY, 50));
 		add("Enter the mining guild wearing full prospector.",
 			new SkillRequirement(Skill.MINING, 60));
+		add("Kill the Blue Dragon under the Heroes' Guild.",
+			new QuestRequirement((Quest.HEROES_QUEST)));
 		add("Crack a wall safe within Rogues Den.",
 			new SkillRequirement(Skill.THIEVING, 50));
 		add("Recharge your prayer in the Port Sarim church while wearing full Proselyte.",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/FremennikDiaryRequirement.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/FremennikDiaryRequirement.java
@@ -52,7 +52,7 @@ public class FremennikDiaryRequirement extends GenericDiaryRequirement
 			new QuestRequirement(Quest.THE_GIANT_DWARF, true));
 		add("Enter the Troll Stronghold",
 			new QuestRequirement(Quest.DEATH_PLATEAU),
-			new QuestRequirement(Quest.TROLL_STRONGHOLD));
+			new QuestRequirement(Quest.TROLL_STRONGHOLD, true));
 		add("Chop and burn some oak logs in the Fremennik Province.",
 			new SkillRequirement(Skill.WOODCUTTING, 15),
 			new SkillRequirement(Skill.FIREMAKING, 15));

--- a/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/FremennikDiaryRequirement.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/FremennikDiaryRequirement.java
@@ -50,7 +50,7 @@ public class FremennikDiaryRequirement extends GenericDiaryRequirement
 		add("Steal from the Keldagrim crafting or baker's stall.",
 			new SkillRequirement(Skill.THIEVING, 5),
 			new QuestRequirement(Quest.THE_GIANT_DWARF, true));
-		add("Enter the Troll Stronghold",
+		add("Enter the Troll Stronghold.",
 			new QuestRequirement(Quest.DEATH_PLATEAU),
 			new QuestRequirement(Quest.TROLL_STRONGHOLD, true));
 		add("Chop and burn some oak logs in the Fremennik Province.",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/KandarinDiaryRequirement.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/KandarinDiaryRequirement.java
@@ -40,7 +40,7 @@ public class KandarinDiaryRequirement extends GenericDiaryRequirement
 			new SkillRequirement(Skill.FISHING, 16));
 		add("Plant some Jute seeds in the patch north of McGrubor's Wood.",
 			new SkillRequirement(Skill.FARMING, 13));
-		add("Defeat on of each elemental in the workshop.",
+		add("Defeat one of each elemental in the workshop.",
 			new QuestRequirement(Quest.ELEMENTAL_WORKSHOP_I, true));
 		add("Cross the Coal truck log shortcut.",
 			new SkillRequirement(Skill.AGILITY, 20));

--- a/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/KandarinDiaryRequirement.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/KandarinDiaryRequirement.java
@@ -96,6 +96,9 @@ public class KandarinDiaryRequirement extends GenericDiaryRequirement
 			new SkillRequirement(Skill.MAGIC, 56));
 		add("Burn some Maple logs with a bow in Seers' Village.",
 			new SkillRequirement(Skill.FIREMAKING, 65));
+		add("Kill a Shadow Hound in the Shadow dungeon.",
+			new SkillRequirement(Skill.THIEVING, 53),
+			new QuestRequirement(Quest.DESERT_TREASURE, true));
 		add("Purchase and equip a granite body from Barbarian Assault.",
 			new SkillRequirement(Skill.STRENGTH, 50),
 			new SkillRequirement(Skill.DEFENCE, 50));

--- a/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/MorytaniaDiaryRequirement.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/MorytaniaDiaryRequirement.java
@@ -48,6 +48,8 @@ public class MorytaniaDiaryRequirement extends GenericDiaryRequirement
 			new SkillRequirement(Skill.SLAYER, 15));
 		add("Place a Scarecrow in the Morytania flower patch.",
 			new SkillRequirement(Skill.FARMING, 23));
+		add("Kill a werewolf in its human form using the Wolfbane Dagger.",
+			new QuestRequirement(Quest.PRIEST_IN_PERIL));
 		add("Restore your prayer points at the nature altar.",
 			new QuestRequirement(Quest.NATURE_SPIRIT));
 
@@ -74,7 +76,7 @@ public class MorytaniaDiaryRequirement extends GenericDiaryRequirement
 		add("Use an ectophial to return to Port Phasmatys.",
 			new QuestRequirement(Quest.GHOSTS_AHOY));
 		add("Mix a Guthix Balance potion while in Morytania.",
-			new SkillRequirement(Skill.HERBLORE, 36),
+			new SkillRequirement(Skill.HERBLORE, 22),
 			new QuestRequirement(Quest.IN_AID_OF_THE_MYREQUE, true));
 
 		// HARD

--- a/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/WesternDiaryRequirement.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/WesternDiaryRequirement.java
@@ -88,7 +88,7 @@ public class WesternDiaryRequirement extends GenericDiaryRequirement
 		// HARD
 		add("Kill an Elf with a Crystal bow.",
 			new SkillRequirement(Skill.RANGED, 70),
-			new SkillRequirement(Skill.AGILITY, 50),
+			new SkillRequirement(Skill.AGILITY, 56),
 			new QuestRequirement(Quest.ROVING_ELVES));
 		add("Catch and cook a Monkfish in Piscatoris.",
 			new SkillRequirement(Skill.FISHING, 62),


### PR DESCRIPTION
Fixes #8210 

**Ardougne Easy**  - "Go out fishing on the Fishing Trawler" - requires 15 fishing 
**Fremmy Easy** - "Enter the troll stronghold" - requires death plateau and started troll stronghold
**Kandarin Easy**  - kill 1 of each elemental in the workshop - requires starting elemental workshop
**Kandarin Hard** - Kill a shadow hound in the Shadow Dungeon - requires starting Desert Treasure and 53 thieving
**Falador Hard** - Kill the blue dragon under the Heroes' Guild - requires Heroes' Quest
**Morytania Easy** - Kill a werewolf in its human form using the Wolfbane Dagger - requires Priest in Peril
**Morytania Easy** - Mix a Guthix Balance potion while in Morytania - requires 22 herblore not 36
**Western Diary** - Teleport to Pest Control using the Minigame teleport - requires 40 combat
**Western Diary** - Kill an Elf with a Crystal bow - requires 56 Agility not 50
~~**Western Diary** - Claim a Chompy bird hat from Rantz after registering at least X Kills - requires 5 fletching and 30 ranged.~~



