### PR TITLE
Changed  produce image of maple and yew trees to their respective logs

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/farming/Produce.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/farming/Produce.java
@@ -93,8 +93,8 @@ public enum Produce
 	// Tree crops
 	OAK("Oak", ItemID.OAK_LOGS, 40, 5),
 	WILLOW("Willow", ItemID.WILLOW_LOGS, 40, 7),
-	MAPLE("Maple", ItemID.MAPLE_TREE, 40, 9),
-	YEW("Yew", ItemID.YEW_TREE, 40, 11),
+	MAPLE("Maple", ItemID.MAPLE_LOGS, 40, 9),
+	YEW("Yew", ItemID.YEW_LOGS, 40, 11),
 	MAGIC("Magic", ItemID.MAGIC_LOGS, 40, 13),
 
 	// Fruit tree crops


### PR DESCRIPTION
Well not much to say except that before the pictures used for maple and yew tree were from the construction skill icons. These have been changed to pictures of the logs to stay consistent with the other trees.

Before:
![image](https://user-images.githubusercontent.com/8947593/54437786-b65e8f80-4735-11e9-9723-eb25a0a80625.png)
After;
![image](https://user-images.githubusercontent.com/8947593/54437797-ba8aad00-4735-11e9-84ec-c0972d125168.png)

I don't have a picture for maple trees because I was not growing them at the time, teehee.
