### PR TITLE
boosts plugin: Fix overlay below-threshold color

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/boosts/BoostsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/boosts/BoostsOverlay.java
@@ -137,7 +137,7 @@ class BoostsOverlay extends Overlay
 			return new Color(238, 51, 51);
 		}
 
-		return boost < config.boostThreshold() ? Color.YELLOW : Color.GREEN;
+		return boost <= config.boostThreshold() ? Color.YELLOW : Color.GREEN;
 
 	}
 }


### PR DESCRIPTION
This patch updates the boosts overlay to match the threshold color
comparison used in the plugin (for notifications) and in the indicator
infobox.

Ref/actually fixes: #6243