### PR TITLE
item stats: check if GE container is hidden when detecting GE close

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatPlugin.java
@@ -134,7 +134,8 @@ public class ItemStatPlugin extends Plugin
 	public void onGameTick(GameTick event)
 	{
 		if (itemInformationTitle != null && config.geStats()
-			&& client.getWidget(WidgetInfo.GRAND_EXCHANGE_WINDOW_CONTAINER) == null)
+			&& (client.getWidget(WidgetInfo.GRAND_EXCHANGE_WINDOW_CONTAINER) == null
+			|| client.getWidget(WidgetInfo.GRAND_EXCHANGE_WINDOW_CONTAINER).isHidden()))
 		{
 			resetGEInventory();
 		}


### PR DESCRIPTION
When closed with esc, the container is hidden rather than unloaded.

Closes #8211 