### PR TITLE
Add menu swap for magic boxes

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -503,6 +503,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 		else if (config.swapBoxTrap() && option.equals("take"))
 		{
 			swap("lay", option, target, true);
+			swap("activate", option, target, true);
 		}
 		else if (config.swapChase() && option.equals("pick-up"))
 		{


### PR DESCRIPTION
Swaps take with activate on [magic box](os.rs.wiki/w/Magic_box) ground items, like take and lay are swapped on box traps.