### PR TITLE
Add option to highlight object clickbox

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/objectindicators/ObjectIndicatorsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/objectindicators/ObjectIndicatorsOverlay.java
@@ -25,6 +25,7 @@
 package net.runelite.client.plugins.objectindicators;
 
 import java.awt.*;
+import java.awt.geom.Area;
 import javax.inject.Inject;
 
 import net.runelite.api.Client;
@@ -71,7 +72,11 @@ class ObjectIndicatorsOverlay extends Overlay
 
 			if (objectPoint.getStyle() == ObjectPoint.STYLE_CLICKBOX)
 			{
-				OverlayUtil.renderHoverableArea(graphics, object.getClickbox(), client.getMouseCanvasPosition(), fillColor, markerColor, markerColor.darker());
+				Area clickbox = object.getClickbox();
+				if (clickbox != null)
+				{
+					OverlayUtil.renderHoverableArea(graphics, object.getClickbox(), client.getMouseCanvasPosition(), fillColor, markerColor, markerColor.darker());
+				}
 				continue;
 			}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/objectindicators/ObjectIndicatorsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/objectindicators/ObjectIndicatorsOverlay.java
@@ -24,10 +24,9 @@
  */
 package net.runelite.client.plugins.objectindicators;
 
-import java.awt.Dimension;
-import java.awt.Graphics2D;
-import java.awt.Polygon;
+import java.awt.*;
 import javax.inject.Inject;
+
 import net.runelite.api.Client;
 import net.runelite.api.DecorativeObject;
 import net.runelite.api.GameObject;
@@ -37,6 +36,7 @@ import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.OverlayPriority;
 import net.runelite.client.ui.overlay.OverlayUtil;
+import org.apache.commons.lang3.tuple.Pair;
 
 class ObjectIndicatorsOverlay extends Overlay
 {
@@ -58,10 +58,20 @@ class ObjectIndicatorsOverlay extends Overlay
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
-		for (TileObject object : plugin.getObjects())
+		Color markerColor = config.markerColor();
+		Color fillColor = new Color(markerColor.getRed(), markerColor.getGreen(), markerColor.getBlue(), 50); // Based on agility plugin
+		for (Pair<TileObject, ObjectPoint> pair : plugin.getObjects())
 		{
+			TileObject object = pair.getLeft();
+			ObjectPoint objectPoint = pair.getRight();
 			if (object.getPlane() != client.getPlane())
 			{
+				continue;
+			}
+
+			if (objectPoint.getStyle() == ObjectPoint.STYLE_CLICKBOX)
+			{
+				OverlayUtil.renderHoverableArea(graphics, object.getClickbox(), client.getMouseCanvasPosition(), fillColor, markerColor, markerColor.darker());
 				continue;
 			}
 
@@ -84,12 +94,12 @@ class ObjectIndicatorsOverlay extends Overlay
 
 			if (polygon != null)
 			{
-				OverlayUtil.renderPolygon(graphics, polygon, config.markerColor());
+				OverlayUtil.renderPolygon(graphics, polygon, markerColor);
 			}
 
 			if (polygon2 != null)
 			{
-				OverlayUtil.renderPolygon(graphics, polygon2, config.markerColor());
+				OverlayUtil.renderPolygon(graphics, polygon2, markerColor);
 			}
 		}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/objectindicators/ObjectPoint.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/objectindicators/ObjectPoint.java
@@ -30,9 +30,13 @@ import lombok.Value;
 @Value
 class ObjectPoint
 {
+	public static final int STYLE_OUTLINE = 0;
+	public static final int STYLE_CLICKBOX = 1;
+
 	private String name;
 	private int regionId;
 	private int regionX;
 	private int regionY;
 	private int z;
+	private int style;
 }


### PR DESCRIPTION
Sometimes an objects hull can be very different from the clickbox and it can be nice to see the clickbox instead.

Also adds some basic framework for future customization of object highlighting.