### PR TITLE
Use consistent rounding for XP bar markers

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpInfoBox.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpInfoBox.java
@@ -215,13 +215,13 @@ class XpInfoBox extends JPanel
 			// Add intermediate level positions to progressBar
 			if (xpTrackerConfig.showIntermediateLevels() && xpSnapshotSingle.getEndLevel() - xpSnapshotSingle.getStartLevel() > 1)
 			{
-				final List<Double> positions = new ArrayList<>();
+				final List<Integer> positions = new ArrayList<>();
 
 				for (int level = xpSnapshotSingle.getStartLevel() + 1; level < xpSnapshotSingle.getEndLevel(); level++)
 				{
 					double relativeStartExperience = Experience.getXpForLevel(level) - xpSnapshotSingle.getStartGoalXp();
 					double relativeEndExperience = xpSnapshotSingle.getEndGoalXp() - xpSnapshotSingle.getStartGoalXp();
-					positions.add(relativeStartExperience / relativeEndExperience);
+					positions.add((int) (relativeStartExperience / relativeEndExperience * 100));
 				}
 
 				progressBar.setPositions(positions);

--- a/runelite-client/src/main/java/net/runelite/client/ui/components/ProgressBar.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/components/ProgressBar.java
@@ -49,7 +49,7 @@ public class ProgressBar extends DimmableJPanel
 	private int value;
 
 	@Setter
-	private List<Double> positions = Collections.emptyList();
+	private List<Integer> positions = Collections.emptyList();
 
 	private final JLabel leftLabel = new JShadowedLabel();
 	private final JLabel rightLabel = new JShadowedLabel();
@@ -95,9 +95,9 @@ public class ProgressBar extends DimmableJPanel
 		g.setColor(getForeground());
 		g.fillRect(0, 0, topWidth, 16);
 
-		for (final Double position : positions)
+		for (final Integer position : positions)
 		{
-			final int xCord = (int) (getSize().width * position);
+			final int xCord = getSize().width * position / maximumValue;
 			if (xCord > topWidth)
 			{
 				g.fillRect(xCord, 0, 1, 16);


### PR DESCRIPTION
Closes #7479

XP bar progress is stored as an integer of percentage, while the intermediate markers are stored as a double from 0 to 1. This means that even if the progress is higher than the intermediate level (but not by more than 1%), the intermediate line will render to the right.

This PR makes both as a percentage integer, which means both are rounded in the same fashion, preventing any discrepancy in rendering.

(This is a duplicate PR because I messed up my branches. The old one has been closed.)