### PR TITLE
WIP: Add raid data storer to raids plugin

### DIFF
--- a/http-api/src/main/java/net/runelite/http/api/raidtracker/RaidRecord.java
+++ b/http-api/src/main/java/net/runelite/http/api/raidtracker/RaidRecord.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2018, TheStonedTurtle <https://github.com/TheStonedTurtle>
+ * Copyright (c) 2019, Trevor <https://github.com/15987632>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.http.api.raidtracker;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import net.runelite.http.api.loottracker.GameItem;
+import java.util.Collection;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class RaidRecord
+{
+	private String username;
+	private int kc;
+	private boolean CM;
+	private int upperTime;
+	private int middleTime;
+	private int lowerTime;
+	private int	raidTime;
+	private int personalPoints;
+	private int teamPoints;
+	private int teamSize;
+	private String rotation;
+	private boolean prep;
+	private Collection<GameItem> drops;
+}

--- a/http-api/src/main/java/net/runelite/http/api/raidtracker/RaidTrackerClient.java
+++ b/http-api/src/main/java/net/runelite/http/api/raidtracker/RaidTrackerClient.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2018, Adam <Adam@sigterm.info>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.http.api.raidtracker;
+
+import com.google.gson.Gson;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.http.api.RuneLiteAPI;
+import okhttp3.Call;
+import okhttp3.Callback;
+import okhttp3.HttpUrl;
+import okhttp3.MediaType;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import java.io.IOException;
+import java.util.UUID;
+
+@Slf4j
+@AllArgsConstructor
+public class RaidTrackerClient
+{
+	private static final MediaType JSON = MediaType.parse("application/json");
+	private static final Gson GSON = RuneLiteAPI.GSON;
+
+	private final UUID uuid;
+
+	public void submit(RaidRecord raidRecord)
+	{
+		HttpUrl url = RuneLiteAPI.getApiBase().newBuilder()
+			.addPathSegment("raidtracker")
+			.build();
+
+		Request request = new Request.Builder()
+			.header(RuneLiteAPI.RUNELITE_AUTH, uuid.toString())
+			.post(RequestBody.create(JSON, GSON.toJson(raidRecord)))
+			.url(url)
+			.build();
+
+		RuneLiteAPI.CLIENT.newCall(request).enqueue(new Callback()
+		{
+			@Override
+			public void onFailure(Call call, IOException e)
+			{
+				log.warn("unable to submit raid info", e);
+			}
+
+			@Override
+			public void onResponse(Call call, Response response)
+			{
+				log.debug("Submitted raid info");
+				response.close();
+			}
+		});
+	}
+}

--- a/http-service/src/main/java/net/runelite/http/service/raidtracker/RaidTrackerController.java
+++ b/http-service/src/main/java/net/runelite/http/service/raidtracker/RaidTrackerController.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2018, TheStonedTurtle <https://github.com/TheStonedTurtle>
+ * Copyright (c) 2018, Adam <Adam@sigterm.info>
+ * Copyright (c) 2019, Trevor <https://github.com/15987632>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.http.service.raidtracker;
+
+import com.google.api.client.http.HttpStatusCodes;
+import net.runelite.http.api.raidtracker.RaidRecord;
+import net.runelite.http.service.account.AuthFilter;
+import net.runelite.http.service.account.beans.SessionEntry;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@RestController
+@RequestMapping("/raidtracker")
+public class RaidTrackerController
+{
+	@Autowired
+	private RaidTrackerService service;
+
+	@Autowired
+	private AuthFilter auth;
+
+	@RequestMapping(method = RequestMethod.POST)
+	public void storeLootRecord(HttpServletRequest request, HttpServletResponse response, @RequestBody RaidRecord record) throws IOException
+	{
+		SessionEntry e = auth.handle(request, response);
+		if (e == null)
+		{
+			response.setStatus(HttpStatusCodes.STATUS_CODE_UNAUTHORIZED);
+			return;
+		}
+
+		service.store(record, e.getUser());
+		response.setStatus(HttpStatusCodes.STATUS_CODE_OK);
+	}
+}

--- a/http-service/src/main/java/net/runelite/http/service/raidtracker/RaidTrackerService.java
+++ b/http-service/src/main/java/net/runelite/http/service/raidtracker/RaidTrackerService.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2018, TheStonedTurtle <https://github.com/TheStonedTurtle>
+ * Copyright (c) 2018, Adam <Adam@sigterm.info>
+ * Copyright (c) 2019, Trevor <https://github.com/15987632>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.http.service.raidtracker;
+
+import net.runelite.http.api.loottracker.GameItem;
+import net.runelite.http.api.raidtracker.RaidRecord;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
+import org.sql2o.Connection;
+import org.sql2o.Query;
+import org.sql2o.Sql2o;
+
+@Service
+public class RaidTrackerService
+{
+	// Table for storing individual LootRecords
+	private static final String CREATE_KILLS = "CREATE TABLE IF NOT EXISTS `raids` (\n"
+		+ "  `id` INT AUTO_INCREMENT UNIQUE,\n"
+		+ "  `accountId` INT NOT NULL,\n"
+		+ "  `username` VARCHAR(255) NOT NULL,\n"
+		+ "  `kc` INT NOT NULL,\n"
+		+ "  `cm` TINYINT NOT NULL,\n"
+		+ "  `upperTime` INT NOT NULL,\n"
+		+ "  `middleTime` INT NOT NULL,\n"
+		+ "  `lowerTime` INT NOT NULL,\n"
+		+ "  `raidTime` INT NOT NULL,\n"
+		+ "  `points` INT NOT NULL,\n"
+		+ "  `teamPoints` INT NOT NULL,\n"
+		+ "  `teamSize` INT NOT NULL,\n"
+		+ "  `rotation` VARCHAR(255) NOT NULL,\n"
+		+ "  `prep` TINYINT NOT NULL,\n"
+		+ "  PRIMARY KEY (id),\n"	//TODO: these definitely need to be changed
+		+ "  FOREIGN KEY (accountId) REFERENCES users(id) ON DELETE CASCADE ON UPDATE CASCADE,\n"
+		+ "  INDEX idx_acc (accountId, time),"
+		+ "  INDEX idx_time (time)"
+		+ ") ENGINE=InnoDB";
+
+	// Table for storing Items received as loot for individual LootRecords
+	private static final String CREATE_DROPS = "CREATE TABLE IF NOT EXISTS `raidDrops` (\n"
+		+ "  `raidId` INT NOT NULL,\n"
+		+ "  `itemId` INT NOT NULL,\n"
+		+ "  `itemQuantity` INT NOT NULL,\n"
+		+ "  FOREIGN KEY (raidId) REFERENCES raids(id) ON DELETE CASCADE\n"	//TODO: should be looked at cause idk what these are
+		+ ") ENGINE=InnoDB";
+
+	// Queries for inserting raids
+	private static final String INSERT_RAID_QUERY = "INSERT INTO raids (accountId, username, kc, cm, upperTime, middleTime, lowerTime, raidTime, points, teamPoints, teamSize, rotation, prep) "
+		+ "VALUES (:accountId, :username, :kc, :cm, :upperTime, :middleTime, :lowerTime, :raidTime, :points, :teamPoints, :teamSize, :rotation, :prep)";
+	private static final String INSERT_DROP_QUERY = "INSERT INTO raidDrops (raidId, itemId, itemQuantity) VALUES (LAST_INSERT_ID(), :itemId, :itemQuantity)";
+
+	private final Sql2o sql2o;
+
+	@Autowired
+	public RaidTrackerService(@Qualifier("Runelite SQL2O") Sql2o sql2o)
+	{
+		this.sql2o = sql2o;
+
+		// Ensure necessary tables exist
+		try (Connection con = sql2o.open())
+		{
+			con.createQuery(CREATE_KILLS).executeUpdate();
+			con.createQuery(CREATE_DROPS).executeUpdate();
+		}
+	}
+
+	/**
+	 * Store RaidRecord
+	 *
+	 * @param record    RaidRecord to store
+	 * @param accountId runelite account id to tie data too
+	 */
+	public void store(RaidRecord record, int accountId)
+	{
+		try (Connection con = sql2o.beginTransaction())
+		{
+			// Kill Entry Query
+			con.createQuery(INSERT_RAID_QUERY, true)
+				.addParameter("accountId", accountId)
+				.addParameter("username", record.getUsername())
+				.addParameter("kc", record.getKc())
+				.addParameter("cm", record.isCM())
+				.addParameter("upperTime", record.getUpperTime())
+				.addParameter("middleTime", record.getMiddleTime())
+				.addParameter("lowerTime", record.getLowerTime())
+				.addParameter("raidTime", record.getRaidTime())
+				.addParameter("points", record.getPersonalPoints())
+				.addParameter("teamPoints", record.getTeamPoints())
+				.addParameter("teamSize", record.getTeamSize())
+				.addParameter("rotation", record.getRotation())
+				.addParameter("prep", record.isPrep())
+				.executeUpdate();
+
+			Query insertDrop = con.createQuery(INSERT_DROP_QUERY);
+
+			// Append all queries for inserting drops
+			for (GameItem drop : record.getDrops())
+			{
+				insertDrop
+					.addParameter("raidId", drop.getId())
+					.addParameter("itemQuantity", drop.getQty())
+					.addToBatch();
+			}
+
+			insertDrop.executeBatch();
+			con.commit(false);
+		}
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsConfig.java
@@ -162,4 +162,15 @@ public interface RaidsConfig extends Config
 	{
 		return true;
 	}
+
+	@ConfigItem(
+		position = 12,
+		keyName = "saveRaidInfo",
+		name = "Save raid data",
+		description = "Submit raid data (requires being logged in)"
+	)
+	default boolean saveRaid()
+	{
+		return true;
+	}
 }


### PR DESCRIPTION
Hopefully this isn't completely wrong, but I wouldn't be surprised if it is.

The goal is to have something like this except not terrible on the website behind oauth https://streamable.com/bwklw 

Right now this stores:
username
kc
whether the raid was challenge mode or not (this can probably be removed as you know if it was cm or not based on if the raid had a middle floor or not)
the downtimes of each floor and the raid time
personal points
team points
team size
the rotation of the raid
and whether you preped in the raid or not (this can be removed if it isn't wanted, as a soloer its nice to have)

These are obviously subject to change and I want feedback for them, right now I am storing the rotation as the long string it is. This is obviously not optimal.

Someone will probably have to touch on the SQL, I am not very knowledgeable on it. I did get rid of the 30 day deletion on the entries as that seemed a lot less needed as very few people even have thousands of raids kc. This is the reason I store the drops even though they might be stored in the loot tracker also.


This was mostly copied from the loot tracker plugin.

I want #7981 merged first so the rotations never show unknown rooms and so raid never gets set to null before the raid is over (current it does if a player logs out or DCs)
Relies on #8122 so the times will use regex and be accurate