### PR TITLE
ChatboxPanelManager: Be more resilient when scripts mismatch

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/game/chatbox/ChatboxPanelManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/game/chatbox/ChatboxPanelManager.java
@@ -93,6 +93,10 @@ public class ChatboxPanelManager
 			0,
 			1
 		);
+		if (currentInput != null)
+		{
+			killCurrentPanel();
+		}
 	}
 
 	private void unsafeOpenInput(ChatboxInput input)
@@ -111,6 +115,11 @@ public class ChatboxPanelManager
 		if (input instanceof MouseWheelListener)
 		{
 			mouseManager.registerMouseWheelListener((MouseWheelListener) input);
+		}
+
+		if (currentInput != null)
+		{
+			killCurrentPanel();
 		}
 
 		currentInput = input;


### PR DESCRIPTION
If RESET_CHATBOX_INPUT doesn't invoke runelite_callback resetChatboxInput because the script hash mismatches panels never get killed, so they a) break jagex inputs, and b) can be lost and not get unregistered, so they will record passwords on the login screen