### PR TITLE
runelite: log client and launcher versions

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/RuneLite.java
+++ b/runelite-client/src/main/java/net/runelite/client/RuneLite.java
@@ -116,6 +116,9 @@ public class RuneLite
 	private PartyService partyService;
 
 	@Inject
+	private RuneLiteProperties runeLiteProperties;
+
+	@Inject
 	private Provider<ItemManager> itemManager;
 
 	@Inject
@@ -228,6 +231,12 @@ public class RuneLite
 
 	public void start() throws Exception
 	{
+		log.info("Client version: {}", runeLiteProperties.getVersion());
+		if (RuneLiteProperties.getLauncherVersion() != null)
+		{
+			log.info("Launcher version: {}", RuneLiteProperties.getLauncherVersion());
+		}
+
 		// Load RuneLite or Vanilla client
 		final boolean isOutdated = client == null;
 


### PR DESCRIPTION
Having the version number in the log allows readers to link it to that client version, instead of having to guess what version of the client it is based on when it was receive.

Launcher option is there for convenience, but that could be in the Launcher itself.