### PR TITLE
Do not filter messages from yourself, friends, or clan members when using chat filter plugin.

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatfilter/ChatFilterPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatfilter/ChatFilterPlugin.java
@@ -204,7 +204,7 @@ public class ChatFilterPlugin extends Plugin
 	boolean shouldFilterPlayerMessage(Player player)
 	{
 		return !(player.isClanMember() || player.isFriend() ||
-				player.getName() .equals(client.getLocalPlayer().getName()));
+				player.getName().equals(client.getLocalPlayer().getName()));
 	}
 
 	@Subscribe

--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatfilter/ChatFilterPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatfilter/ChatFilterPlugin.java
@@ -134,7 +134,7 @@ public class ChatFilterPlugin extends Plugin
 	@Subscribe
 	public void onOverheadTextChanged(OverheadTextChanged event)
 	{
-		if (!(event.getActor() instanceof Player))
+		if (!(event.getActor() instanceof Player) || !shouldFilterPlayerMessage((Player) event.getActor()))
 		{
 			return;
 		}
@@ -199,6 +199,12 @@ public class ChatFilterPlugin extends Plugin
 			})
 			.filter(Objects::nonNull)
 			.forEach(filteredPatterns::add);
+	}
+
+	boolean shouldFilterPlayerMessage(Player player)
+	{
+		return !(player.isClanMember() || player.isFriend() ||
+				player.getName() .equals(client.getLocalPlayer().getName()));
 	}
 
 	@Subscribe

--- a/runelite-client/src/test/java/net/runelite/client/plugins/chatfilter/ChatFilterPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/chatfilter/ChatFilterPluginTest.java
@@ -56,6 +56,9 @@ public class ChatFilterPluginTest
 	@Bind
 	private Player player;
 
+	@Mock
+	private Player localPlayer;
+
 	@Inject
 	private ChatFilterPlugin chatFilterPlugin;
 
@@ -67,8 +70,7 @@ public class ChatFilterPluginTest
 		when(chatFilterConfig.filterType()).thenReturn(ChatFilterType.CENSOR_WORDS);
 		when(chatFilterConfig.filteredWords()).thenReturn("");
 		when(chatFilterConfig.filteredRegex()).thenReturn("");
-
-
+		when(client.getLocalPlayer()).thenReturn(localPlayer);
 	}
 
 	@Test
@@ -131,6 +133,8 @@ public class ChatFilterPluginTest
 	public void testFilteredMessageFromNonFriend()
 	{
 		when(player.isFriend()).thenReturn(false);
+		when(player.getName()).thenReturn("MyPlayerName432");
+		when(localPlayer.getName()).thenReturn("NamePlayerMy234");
 		assertTrue(chatFilterPlugin.shouldFilterPlayerMessage(player));
 	}
 
@@ -145,6 +149,24 @@ public class ChatFilterPluginTest
 	public void testFilteredMessageFromNonClanMember()
 	{
 		when(player.isClanMember()).thenReturn(false);
+		when(player.getName()).thenReturn("MyPlayerName432");
+		when(localPlayer.getName()).thenReturn("NamePlayerMy234");
+		assertTrue(chatFilterPlugin.shouldFilterPlayerMessage(player));
+	}
+
+	@Test
+	public void testFilteredMessageFromSelf()
+	{
+		when(player.getName()).thenReturn("MyPlayerName432");
+		when(localPlayer.getName()).thenReturn("MyPlayerName432");
+		assertFalse(chatFilterPlugin.shouldFilterPlayerMessage(player));
+	}
+
+	@Test
+	public void testFilteredMessageFromOtherPlayer()
+	{
+		when(player.getName()).thenReturn("MyPlayerName432");
+		when(localPlayer.getName()).thenReturn("NamePlayerMy234");
 		assertTrue(chatFilterPlugin.shouldFilterPlayerMessage(player));
 	}
 }

--- a/runelite-client/src/test/java/net/runelite/client/plugins/chatfilter/ChatFilterPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/chatfilter/ChatFilterPluginTest.java
@@ -31,6 +31,9 @@ import javax.inject.Inject;
 import net.runelite.api.Client;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import net.runelite.api.Player;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -49,6 +52,10 @@ public class ChatFilterPluginTest
 	@Bind
 	private ChatFilterConfig chatFilterConfig;
 
+	@Mock
+	@Bind
+	private Player player;
+
 	@Inject
 	private ChatFilterPlugin chatFilterPlugin;
 
@@ -60,6 +67,8 @@ public class ChatFilterPluginTest
 		when(chatFilterConfig.filterType()).thenReturn(ChatFilterType.CENSOR_WORDS);
 		when(chatFilterConfig.filteredWords()).thenReturn("");
 		when(chatFilterConfig.filteredRegex()).thenReturn("");
+
+
 	}
 
 	@Test
@@ -109,5 +118,33 @@ public class ChatFilterPluginTest
 
 		chatFilterPlugin.updateFilteredPatterns();
 		assertNull(chatFilterPlugin.censorMessage("te\u008Cst"));
+	}
+
+	@Test
+	public void testFilteredMessageFromFriend()
+	{
+		when(player.isFriend()).thenReturn(true);
+		assertFalse(chatFilterPlugin.shouldFilterPlayerMessage(player));
+	}
+
+	@Test
+	public void testFilteredMessageFromNonFriend()
+	{
+		when(player.isFriend()).thenReturn(false);
+		assertTrue(chatFilterPlugin.shouldFilterPlayerMessage(player));
+	}
+
+	@Test
+	public void testFilteredMessageFromClanMember()
+	{
+		when(player.isClanMember()).thenReturn(true);
+		assertFalse(chatFilterPlugin.shouldFilterPlayerMessage(player));
+	}
+
+	@Test
+	public void testFilteredMessageFromNonClanMember()
+	{
+		when(player.isClanMember()).thenReturn(false);
+		assertTrue(chatFilterPlugin.shouldFilterPlayerMessage(player));
 	}
 }


### PR DESCRIPTION
Fixes issue #8282. No longer filters messages from yourself, clan members, or friends. 

Not a huge fan of how the unit testing is mocked, maybe I should make a separate method for checking local player? Tests are passing, though.