### PR TITLE
Fix Skillcalc plugin for Dragon Fruit level

### DIFF
--- a/runelite-client/src/main/resources/net/runelite/client/plugins/skillcalculator/skill_farming.json
+++ b/runelite-client/src/main/resources/net/runelite/client/plugins/skillcalculator/skill_farming.json
@@ -253,7 +253,7 @@
       "xp": 170.5
     },
     {
-      "level": 82,
+      "level": 81,
       "icon": 22929,
       "name": "Dragonfruit Tree",
       "xp": 17895


### PR DESCRIPTION
Resolves issue #8309, super basic fix. I went through and verified all other levels too in farming just as a sanity check, and they all seem good.

![image](https://user-images.githubusercontent.com/26416138/54935239-e522f580-4eed-11e9-8095-772a0cae32a1.png)
