### PR TITLE
Fix plugin list layout when a plugin dynamically adds / removes buttons.

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
@@ -224,10 +224,12 @@ public class ClientUI
 			if (inTitle)
 			{
 				titleToolbar.addComponent(event.getButton(), button);
+				titleToolbar.revalidate();
 			}
 			else
 			{
 				pluginToolbar.addComponent(event.getButton(), button);
+				pluginToolbar.revalidate();
 			}
 		});
 	}
@@ -238,7 +240,9 @@ public class ClientUI
 		SwingUtilities.invokeLater(() ->
 		{
 			pluginToolbar.removeComponent(event.getButton());
+			pluginToolbar.revalidate();
 			titleToolbar.removeComponent(event.getButton());
+			titleToolbar.revalidate();
 			final PluginPanel pluginPanel = event.getButton().getPanel();
 
 			if (pluginPanel != null)


### PR DESCRIPTION
Specifically this fixes the Kourend Library plugin panel button. Plugins that dynamically add/remove buttons to the plugin panel based on game state would cause the layout to break. Behavior isn't observed when enabling/disabling plugins entirely since it looks like the config invalidates all plugin buttons when it saves.

Steps to reproduce:
1. Turn on Kourend Library plugin, and ensure Hide Button config option selected.
2. Enter Kourend Library region
3. Button appears at top-left of plugin panel, rather than correctly listed with rest of plugins.