### PR TITLE
Improve client error exit handler

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/RuneLite.java
+++ b/runelite-client/src/main/java/net/runelite/client/RuneLite.java
@@ -76,6 +76,7 @@ import org.slf4j.LoggerFactory;
 public class RuneLite
 {
 	public static final File RUNELITE_DIR = new File(System.getProperty("user.home"), ".runelite");
+	public static final File LOGS_DIR = new File(RUNELITE_DIR, "logs");
 	public static final File PROFILES_DIR = new File(RUNELITE_DIR, "profiles");
 	public static final File SCREENSHOT_DIR = new File(RUNELITE_DIR, "screenshots");
 


### PR DESCRIPTION
- Add 2 options:
  - Exit
  - Open logs and exit

Exit will just exit client (it should do that anyway).
Open logs and exit will open client.log in default text editor.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>