### PR TITLE
mixins: Fix convex hulls being incorrectly contoured

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/Perspective.java
+++ b/runelite-api/src/main/java/net/runelite/api/Perspective.java
@@ -54,6 +54,7 @@ public class Perspective
 
 	public static final int LOCAL_COORD_BITS = 7;
 	public static final int LOCAL_TILE_SIZE = 1 << LOCAL_COORD_BITS; // 128 - size of a tile in local coordinates
+	public static final int LOCAL_HALF_TILE_SIZE = LOCAL_TILE_SIZE / 2;
 
 	public static final int SCENE_SIZE = Constants.SCENE_SIZE; // in tiles
 
@@ -114,7 +115,7 @@ public class Perspective
 	 * @return a {@link Point} on screen corresponding to the position in
 	 * 3D-space
 	 */
-	private static Point localToCanvas(@Nonnull Client client, int x, int y, int z)
+	public static Point localToCanvas(@Nonnull Client client, int x, int y, int z)
 	{
 		if (x >= 128 && y >= 128 && x <= 13056 && y <= 13056)
 		{

--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSActorMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSActorMixin.java
@@ -55,7 +55,6 @@ import net.runelite.rs.api.RSCombatInfo1;
 import net.runelite.rs.api.RSCombatInfo2;
 import net.runelite.rs.api.RSCombatInfoList;
 import net.runelite.rs.api.RSCombatInfoListHolder;
-import net.runelite.rs.api.RSModel;
 import net.runelite.rs.api.RSNPC;
 import net.runelite.rs.api.RSNode;
 
@@ -219,18 +218,6 @@ public abstract class RSActorMixin implements RSActor
 			OverheadTextChanged overheadTextChanged = new OverheadTextChanged(this, overheadText);
 			client.getCallbacks().post(overheadTextChanged);
 		}
-	}
-
-	@Inject
-	@Override
-	public Polygon getConvexHull()
-	{
-		RSModel model = getModel();
-		if (model == null)
-		{
-			return null;
-		}
-		return model.getConvexHull(getX(), getY(), getOrientation());
 	}
 
 	@Inject

--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSDecorativeObjectMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSDecorativeObjectMixin.java
@@ -28,6 +28,7 @@ import java.awt.Polygon;
 import java.awt.geom.Area;
 import net.runelite.api.Model;
 import net.runelite.api.Perspective;
+import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.mixins.Inject;
 import net.runelite.api.mixins.Mixin;
 import net.runelite.api.mixins.Shadow;
@@ -123,7 +124,8 @@ public abstract class RSDecorativeObjectMixin implements RSDecorativeObject
 			return null;
 		}
 
-		return model.getConvexHull(getX() + getXOffset(), getY() + getYOffset(), 0);
+		int tileHeight = Perspective.getTileHeight(client, new LocalPoint(getX(), getY()), client.getPlane());
+		return model.getConvexHull(getX() + getXOffset(), getY() + getYOffset(), 0, tileHeight);
 	}
 
 	@Inject
@@ -137,6 +139,7 @@ public abstract class RSDecorativeObjectMixin implements RSDecorativeObject
 			return null;
 		}
 
-		return model.getConvexHull(getX(), getY(), 0);
+		int tileHeight = Perspective.getTileHeight(client, new LocalPoint(getX(), getY()), client.getPlane());
+		return model.getConvexHull(getX(), getY(), 0, tileHeight);
 	}
 }

--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSGameObjectMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSGameObjectMixin.java
@@ -29,6 +29,7 @@ import java.awt.geom.Area;
 import net.runelite.api.Perspective;
 import net.runelite.api.Point;
 import net.runelite.api.coords.Angle;
+import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.mixins.Inject;
 import net.runelite.api.mixins.Mixin;
 import net.runelite.api.mixins.Shadow;
@@ -94,7 +95,8 @@ public abstract class RSGameObjectMixin implements RSGameObject
 			return null;
 		}
 
-		return model.getConvexHull(getX(), getY(), getRsOrientation());
+		int tileHeight = Perspective.getTileHeight(client, new LocalPoint(getX(), getY()), client.getPlane());
+		return model.getConvexHull(getX(), getY(), getRsOrientation(), tileHeight);
 	}
 
 	@Override

--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSModelMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSModelMixin.java
@@ -30,7 +30,6 @@ import java.util.List;
 import net.runelite.api.Model;
 import net.runelite.api.Perspective;
 import net.runelite.api.Point;
-import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.mixins.Copy;
 import net.runelite.api.mixins.Inject;
 import net.runelite.api.mixins.MethodHook;
@@ -323,7 +322,7 @@ public abstract class RSModelMixin implements RSModel
 
 	@Override
 	@Inject
-	public Polygon getConvexHull(int localX, int localY, int orientation)
+	public Polygon getConvexHull(int localX, int localY, int orientation, int tileHeight)
 	{
 		List<Vertex> vertices = getVertices();
 
@@ -340,9 +339,9 @@ public abstract class RSModelMixin implements RSModel
 		{
 			// Compute canvas location of vertex
 			Point p = Perspective.localToCanvas(client,
-				new LocalPoint(localX - v.getX(), localY - v.getZ()),
-				client.getPlane(),
-				-v.getY());
+				localX - v.getX(),
+				localY - v.getZ(),
+				tileHeight + v.getY());
 			if (p != null)
 			{
 				points.add(p);

--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSNPCMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSNPCMixin.java
@@ -24,8 +24,11 @@
  */
 package net.runelite.mixins;
 
+import java.awt.Polygon;
 import net.runelite.api.AnimationID;
 import net.runelite.api.NPCComposition;
+import net.runelite.api.Perspective;
+import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.events.NpcDespawned;
 import net.runelite.api.mixins.Copy;
 import net.runelite.api.mixins.FieldHook;
@@ -166,5 +169,24 @@ public abstract class RSNPCMixin implements RSNPC
 	public void setDead(boolean dead)
 	{
 		this.dead = dead;
+	}
+
+	@Inject
+	@Override
+	public Polygon getConvexHull()
+	{
+		RSModel model = getModel();
+		if (model == null)
+		{
+			return null;
+		}
+
+		int size = getComposition().getSize();
+		LocalPoint tileHeightPoint = new LocalPoint(
+			size * Perspective.LOCAL_HALF_TILE_SIZE - Perspective.LOCAL_HALF_TILE_SIZE + getX(),
+			size * Perspective.LOCAL_HALF_TILE_SIZE - Perspective.LOCAL_HALF_TILE_SIZE + getY());
+
+		int tileHeight = Perspective.getTileHeight(client, tileHeightPoint, client.getPlane());
+		return model.getConvexHull(getX(), getY(), getOrientation(), tileHeight);
 	}
 }

--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSPlayerMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSPlayerMixin.java
@@ -155,6 +155,8 @@ public abstract class RSPlayerMixin implements RSPlayer
 
 		int orientation = getOrientation();
 
+		final int tileHeight = Perspective.getTileHeight(client, new LocalPoint(localX, localY), client.getPlane());
+
 		List<Triangle> triangles = model.getTriangles();
 
 		triangles = rotate(triangles, orientation);
@@ -167,25 +169,25 @@ public abstract class RSPlayerMixin implements RSPlayer
 			Vertex vz = triangle.getC();
 
 			Point x = Perspective.localToCanvas(client,
-				new LocalPoint(localX - vx.getX(), localY - vx.getZ()),
-				client.getPlane(),
-				-vx.getY());
+				localX - vx.getX(),
+				localY - vx.getZ(),
+				tileHeight + vx.getY());
 
 			Point y = Perspective.localToCanvas(client,
-				new LocalPoint(localX - vy.getX(), localY - vy.getZ()),
-				client.getPlane(),
-				-vy.getY());
+				localX - vy.getX(),
+				localY - vy.getZ(),
+				tileHeight + vy.getY());
 
 			Point z = Perspective.localToCanvas(client,
-				new LocalPoint(localX - vz.getX(), localY - vz.getZ()),
-				client.getPlane(),
-				-vz.getY());
+				localX - vz.getX(),
+				localY - vz.getZ(),
+				tileHeight + vz.getY());
 
-			int xx[] =
+			int[] xx =
 			{
 				x.getX(), y.getX(), z.getX()
 			};
-			int yy[] =
+			int[] yy =
 			{
 				x.getY(), y.getY(), z.getY()
 			};
@@ -193,6 +195,20 @@ public abstract class RSPlayerMixin implements RSPlayer
 		}
 
 		return polys.toArray(new Polygon[polys.size()]);
+	}
+
+	@Inject
+	@Override
+	public Polygon getConvexHull()
+	{
+		RSModel model = getModel();
+		if (model == null)
+		{
+			return null;
+		}
+
+		int tileHeight = Perspective.getTileHeight(client, new LocalPoint(getX(), getY()), client.getPlane());
+		return model.getConvexHull(getX(), getY(), getOrientation(), tileHeight);
 	}
 
 	@Inject

--- a/runescape-api/src/main/java/net/runelite/rs/api/RSModel.java
+++ b/runescape-api/src/main/java/net/runelite/rs/api/RSModel.java
@@ -162,12 +162,8 @@ public interface RSModel extends RSRenderable, Model
 
 	/**
 	 * Compute the convex hull of this model
-	 * @param localX
-	 * @param localY
-	 * @param orientation
-	 * @return
 	 */
-	Polygon getConvexHull(int localX, int localY, int orientation);
+	Polygon getConvexHull(int localX, int localY, int orientation, int tileHeight);
 
 	float[][] getFaceTextureUCoordinates();
 	void setFaceTextureUCoordinates(float[][] rl$faceTextureUCoordinates);


### PR DESCRIPTION
the Models returned by getModel are already contoured if required; we do not need to do it again.

Closes #7872