### PR TITLE
Add Toggleable Wiki Orb

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/wiki/WikiConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/wiki/WikiConfig.java
@@ -1,0 +1,20 @@
+package net.runelite.client.plugins.wiki;
+
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+
+@ConfigGroup("wiki")
+public interface WikiConfig extends Config
+{
+	@ConfigItem(
+		position = 1,
+		keyName = "orbEnable",
+		name = "Enable Wiki Minimap Orb",
+		description = "Enable the Wiki Minimap Orb to appear"
+	)
+	default boolean orbEnable()
+	{
+		return true;
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/wiki/WikiPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/wiki/WikiPlugin.java
@@ -364,22 +364,31 @@ public class WikiPlugin extends Plugin
 	@Subscribe
 	public void onConfigChanged(ConfigChanged event)
 	{
-		if (event.getGroup().equals("wiki") && !config.orbEnable())
+		if (event.getGroup().equals("wiki"))
 		{
-			orbDestroy();
-		}
-		else
-		{
-			orbCreate();
+			if (!config.orbEnable())
+			{
+				orbDestroy();
+			}
+			else
+			{
+				orbCreate();
+			}
 		}
 	}
 
+	/**
+	 * This will create the minimap orb for the wiki plugin. This does not affect quest guide menu options.
+	 */
 	private void orbCreate()
 	{
 		spriteManager.addSpriteOverrides(WikiSprite.values());
 		clientThread.invokeLater(this::addWidgets);
 	}
 
+	/**
+	 *  Destroys/removes the minimap orb for the wiki plugin. This does not affect quest guide menu options.
+	 */
 	private void orbDestroy()
 	{
 		spriteManager.removeSpriteOverrides(WikiSprite.values());

--- a/runelite-client/src/main/java/net/runelite/client/plugins/wiki/WikiPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/wiki/WikiPlugin.java
@@ -180,6 +180,24 @@ public class WikiPlugin extends Plugin
 		icon.revalidate();
 	}
 
+	private void removeWidgets()
+	{
+		Widget minimapOrbs = client.getWidget(WidgetInfo.MINIMAP_ORBS);
+		if (minimapOrbs == null)
+		{
+			return;
+		}
+		Widget[] children = minimapOrbs.getChildren();
+		if (children == null || children.length < 1)
+		{
+			return;
+		}
+		children[0] = null;
+
+		onDeselect();
+		client.setSpellSelected(false);
+	}
+
 	private void onDeselect()
 	{
 		wikiSelected = false;
@@ -392,22 +410,6 @@ public class WikiPlugin extends Plugin
 	private void orbDestroy()
 	{
 		spriteManager.removeSpriteOverrides(WikiSprite.values());
-		clientThread.invokeLater(() ->
-		{
-			Widget minimapOrbs = client.getWidget(WidgetInfo.MINIMAP_ORBS);
-			if (minimapOrbs == null)
-			{
-				return;
-			}
-			Widget[] children = minimapOrbs.getChildren();
-			if (children == null || children.length < 1)
-			{
-				return;
-			}
-			children[0] = null;
-
-			onDeselect();
-			client.setSpellSelected(false);
-		});
+		clientThread.invokeLater(this::removeWidgets);
 	}
 }


### PR DESCRIPTION
There is now an actual config that can be changed by the user to enable/disable the wiki minimap orb. This does not affect the menu options for Quest Guides/Diary Wiki links. 

**Demo**

Orb is removed then added (not hidden!) based on config.
![2019-03-30_12-12-44](https://user-images.githubusercontent.com/26416138/55279349-0f0d5b00-52e6-11e9-83e4-442647e68b72.gif)

Changing of the config does not affect any menu items and will still go to wiki, and also will persist even on refresh of the tab.
![2019-03-30_12-17-49](https://user-images.githubusercontent.com/26416138/55279350-12a0e200-52e6-11e9-9cef-4ad7b225f649.gif)

