### PR TITLE
Fix crystal chest in loot tracker

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
@@ -26,6 +26,7 @@
 package net.runelite.client.plugins.loottracker;
 
 import com.google.common.collect.HashMultiset;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Multiset;
 import com.google.common.collect.Multisets;
 import com.google.inject.Provides;
@@ -37,6 +38,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.regex.Matcher;
@@ -97,9 +99,12 @@ public class LootTrackerPlugin extends Plugin
 	private static final Pattern CLUE_SCROLL_PATTERN = Pattern.compile("You have completed [0-9]+ ([a-z]+) Treasure Trails.");
 	private static final int THEATRE_OF_BLOOD_REGION = 12867;
 
-	// Brimstone loot handling
-	private static final String BRIMSTONE_CHEST_MESSAGE = "You find some treasure in the chest!";
-	private static final String BRIMSTONE_CHEST_EVENT_TYPE = "Brimstone Chest";
+	// Chest loot handling
+	private static final String CHEST_LOOTED_MESSAGE = "You find some treasure in the chest!";
+	private static final Map<Integer, String> CHEST_EVENT_TYPES = ImmutableMap.of(
+		5179, "Brimstone Chest",
+		11573, "Crystal Chest"
+	);
 
 	@Inject
 	private ClientToolbar clientToolbar;
@@ -375,9 +380,15 @@ public class LootTrackerPlugin extends Plugin
 
 		final String message = event.getMessage();
 
-		if (message.equals(BRIMSTONE_CHEST_MESSAGE))
+		if (message.equals(CHEST_LOOTED_MESSAGE))
 		{
-			eventType = BRIMSTONE_CHEST_EVENT_TYPE;
+			final int regionID = client.getLocalPlayer().getWorldLocation().getRegionID();
+			if (!CHEST_EVENT_TYPES.containsKey(regionID))
+			{
+				return;
+			}
+
+			eventType = CHEST_EVENT_TYPES.get(regionID);
 
 			final ItemContainer itemContainer = client.getItemContainer(InventoryID.INVENTORY);
 			if (itemContainer != null)
@@ -419,21 +430,19 @@ public class LootTrackerPlugin extends Plugin
 	@Subscribe
 	public void onItemContainerChanged(ItemContainerChanged event)
 	{
-		if (eventType == null || !eventType.equals(BRIMSTONE_CHEST_EVENT_TYPE))
+		if (eventType != null && CHEST_EVENT_TYPES.containsValue(eventType))
 		{
-			return;
-		}
+			if (event.getItemContainer() != client.getItemContainer(InventoryID.INVENTORY))
+			{
+				return;
+			}
 
-		if (event.getItemContainer() != client.getItemContainer(InventoryID.INVENTORY))
-		{
-			return;
+			processChestLoot(eventType, event.getItemContainer());
+			eventType = null;
 		}
-
-		processBrimstoneChestLoot(event.getItemContainer());
-		eventType = null;
 	}
 
-	private void processBrimstoneChestLoot(ItemContainer inventoryContainer)
+	private void processChestLoot(String chestType, ItemContainer inventoryContainer)
 	{
 		if (inventorySnapshot != null)
 		{
@@ -448,11 +457,11 @@ public class LootTrackerPlugin extends Plugin
 				.collect(Collectors.toList());
 
 			final LootTrackerItem[] entries = buildEntries(stack(items));
-			SwingUtilities.invokeLater(() -> panel.add(BRIMSTONE_CHEST_EVENT_TYPE, -1, entries));
+			SwingUtilities.invokeLater(() -> panel.add(chestType, -1, entries));
 
 			if (lootTrackerClient != null && config.saveLoot())
 			{
-				LootRecord lootRecord = new LootRecord(BRIMSTONE_CHEST_EVENT_TYPE, LootRecordType.EVENT, toGameItems(items), Instant.now());
+				LootRecord lootRecord = new LootRecord(chestType, LootRecordType.EVENT, toGameItems(items), Instant.now());
 				lootTrackerClient.submit(lootRecord);
 			}
 


### PR DESCRIPTION
Fixes crystal chests counting as brimstone chests in the loot tracker by checking the current region the player is in.
![7b8f130b411f09fcb3b7060d7916bd43](https://user-images.githubusercontent.com/5104566/55281493-17d54f80-532d-11e9-9682-c0b6ac1b8dbc.png)

Closes #8356 