### PR TITLE
Added ability to change which coin value GroundItems color highlighting uses

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
@@ -179,9 +179,9 @@ public interface GroundItemsConfig extends Config
 		position = 11
 	)
 	default ValueCalculationMode valueCalculationMode()
-    {
-        return ValueCalculationMode.HIGHEST;
-    }
+	{
+		return ValueCalculationMode.HIGHEST;
+	}
 
 	@ConfigItem(
 		keyName = "highlightOverValue2",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
@@ -32,6 +32,7 @@ import net.runelite.client.config.ConfigItem;
 import net.runelite.client.plugins.grounditems.config.ItemHighlightMode;
 import net.runelite.client.plugins.grounditems.config.MenuHighlightMode;
 import net.runelite.client.plugins.grounditems.config.PriceDisplayMode;
+import net.runelite.client.plugins.grounditems.config.ValueCalculationMode;
 
 @ConfigGroup("grounditems")
 public interface GroundItemsConfig extends Config
@@ -172,10 +173,18 @@ public interface GroundItemsConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "highlightValueCalculation",
+		name = "Highlight Value Calculation",
+		description = "Configures which coin value is used to determine highlight color",
+		position = 11
+	)
+	default ValueCalculationMode valueCalculationMode() { return ValueCalculationMode.BOTH; }
+
+	@ConfigItem(
 		keyName = "highlightOverValue2",
 		name = "Highlight > Value",
 		description = "Configures highlighted ground items over either GE or HA value",
-		position = 11
+		position = 12
 	)
 	default int getHighlightOverValue()
 	{
@@ -186,7 +195,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "hideUnderValue",
 		name = "Hide < Value",
 		description = "Configures hidden ground items under both GE and HA value",
-		position = 12
+		position = 13
 	)
 	default int getHideUnderValue()
 	{
@@ -197,7 +206,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "defaultColor",
 		name = "Default items color",
 		description = "Configures the color for default, non-highlighted items",
-		position = 13
+		position = 14
 	)
 	default Color defaultColor()
 	{
@@ -208,7 +217,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "highlightedColor",
 		name = "Highlighted items color",
 		description = "Configures the color for highlighted items",
-		position = 14
+		position = 15
 	)
 	default Color highlightedColor()
 	{
@@ -219,7 +228,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "hiddenColor",
 		name = "Hidden items color",
 		description = "Configures the color for hidden items in right-click menu and when holding ALT",
-		position = 15
+		position = 16
 	)
 	default Color hiddenColor()
 	{
@@ -230,7 +239,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "lowValueColor",
 		name = "Low value items color",
 		description = "Configures the color for low value items",
-		position = 16
+		position = 17
 	)
 	default Color lowValueColor()
 	{
@@ -241,7 +250,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "lowValuePrice",
 		name = "Low value price",
 		description = "Configures the start price for low value items",
-		position = 17
+		position = 18
 	)
 	default int lowValuePrice()
 	{
@@ -252,7 +261,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "mediumValueColor",
 		name = "Medium value items color",
 		description = "Configures the color for medium value items",
-		position = 18
+		position = 19
 	)
 	default Color mediumValueColor()
 	{
@@ -263,7 +272,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "mediumValuePrice",
 		name = "Medium value price",
 		description = "Configures the start price for medium value items",
-		position = 19
+		position = 20
 	)
 	default int mediumValuePrice()
 	{
@@ -274,7 +283,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "highValueColor",
 		name = "High value items color",
 		description = "Configures the color for high value items",
-		position = 20
+		position = 21
 	)
 	default Color highValueColor()
 	{
@@ -285,7 +294,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "highValuePrice",
 		name = "High value price",
 		description = "Configures the start price for high value items",
-		position = 21
+		position = 22
 	)
 	default int highValuePrice()
 	{
@@ -296,7 +305,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "insaneValueColor",
 		name = "Insane value items color",
 		description = "Configures the color for insane value items",
-		position = 22
+		position = 23
 	)
 	default Color insaneValueColor()
 	{
@@ -307,7 +316,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "insaneValuePrice",
 		name = "Insane value price",
 		description = "Configures the start price for insane value items",
-		position = 23
+		position = 24
 	)
 	default int insaneValuePrice()
 	{
@@ -318,7 +327,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "onlyShowLoot",
 		name = "Only show loot",
 		description = "Only shows drops from NPCs and players",
-		position = 24
+		position = 25
 	)
 	default boolean onlyShowLoot()
 	{
@@ -329,7 +338,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "doubleTapDelay",
 		name = "Delay for double-tap ALT to hide",
 		description = "Decrease this number if you accidentally hide ground items often. (0 = Disabled)",
-		position = 25
+		position = 26
 	)
 	default int doubleTapDelay()
 	{
@@ -340,7 +349,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "collapseEntries",
 		name = "Collapse ground item menu entries",
 		description = "Collapses ground item menu entries together and appends count",
-		position = 26
+		position = 27
 	)
 	default boolean collapseEntries()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
@@ -178,7 +178,10 @@ public interface GroundItemsConfig extends Config
 		description = "Configures which coin value is used to determine highlight color",
 		position = 11
 	)
-	default ValueCalculationMode valueCalculationMode() { return ValueCalculationMode.BOTH; }
+	default ValueCalculationMode valueCalculationMode()
+    {
+        return ValueCalculationMode.HIGHEST;
+    }
 
 	@ConfigItem(
 		keyName = "highlightOverValue2",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
@@ -82,6 +82,8 @@ import net.runelite.client.plugins.grounditems.config.MenuHighlightMode;
 import static net.runelite.client.plugins.grounditems.config.MenuHighlightMode.BOTH;
 import static net.runelite.client.plugins.grounditems.config.MenuHighlightMode.NAME;
 import static net.runelite.client.plugins.grounditems.config.MenuHighlightMode.OPTION;
+
+import net.runelite.client.plugins.grounditems.config.ValueCalculationMode;
 import net.runelite.client.ui.overlay.OverlayManager;
 import net.runelite.client.util.ColorUtil;
 import net.runelite.client.util.StackFormatter;
@@ -550,11 +552,23 @@ public class GroundItemsPlugin extends Plugin
 			return null;
 		}
 
+		ValueCalculationMode mode = config.valueCalculationMode();
 		for (Map.Entry<Integer, Color> entry : priceChecks.entrySet())
 		{
-			if (gePrice > entry.getKey() || haPrice > entry.getKey())
+			switch(mode)
 			{
-				return entry.getValue();
+				case GE:
+					if(gePrice > entry.getKey())
+						return entry.getValue();
+					break;
+				case HA:
+					if(haPrice > entry.getKey())
+						return entry.getValue();
+					break;
+				default: // case BOTH
+					if(gePrice > entry.getKey() || haPrice > entry.getKey())
+						return entry.getValue();
+					break;
 			}
 		}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
@@ -559,15 +559,21 @@ public class GroundItemsPlugin extends Plugin
 			{
 				case GE:
 					if(gePrice > entry.getKey())
+					{
 						return entry.getValue();
+					}
 					break;
 				case HA:
 					if(haPrice > entry.getKey())
+					{
 						return entry.getValue();
+					}
 					break;
 				default: // case BOTH
 					if(gePrice > entry.getKey() || haPrice > entry.getKey())
+					{
 						return entry.getValue();
+					}
 					break;
 			}
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
@@ -554,22 +554,22 @@ public class GroundItemsPlugin extends Plugin
 		ValueCalculationMode mode = config.valueCalculationMode();
 		for (Map.Entry<Integer, Color> entry : priceChecks.entrySet())
 		{
-			switch(mode)
+			switch (mode)
 			{
 				case GE:
-					if(gePrice > entry.getKey())
+					if (gePrice > entry.getKey())
 					{
 						return entry.getValue();
 					}
 					break;
 				case HA:
-					if(haPrice > entry.getKey())
+					if (haPrice > entry.getKey())
 					{
 						return entry.getValue();
 					}
 					break;
 				default: // case HIGHEST
-					if(gePrice > entry.getKey() || haPrice > entry.getKey())
+					if (gePrice > entry.getKey() || haPrice > entry.getKey())
 					{
 						return entry.getValue();
 					}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
@@ -82,7 +82,6 @@ import net.runelite.client.plugins.grounditems.config.MenuHighlightMode;
 import static net.runelite.client.plugins.grounditems.config.MenuHighlightMode.BOTH;
 import static net.runelite.client.plugins.grounditems.config.MenuHighlightMode.NAME;
 import static net.runelite.client.plugins.grounditems.config.MenuHighlightMode.OPTION;
-
 import net.runelite.client.plugins.grounditems.config.ValueCalculationMode;
 import net.runelite.client.ui.overlay.OverlayManager;
 import net.runelite.client.util.ColorUtil;
@@ -569,7 +568,7 @@ public class GroundItemsPlugin extends Plugin
 						return entry.getValue();
 					}
 					break;
-				default: // case BOTH
+				default: // case HIGHEST
 					if(gePrice > entry.getKey() || haPrice > entry.getKey())
 					{
 						return entry.getValue();

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/config/ValueCalculationMode.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/config/ValueCalculationMode.java
@@ -32,15 +32,15 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum ValueCalculationMode
 {
-    HA("High Alchemy"), // calc highlight by HA value
-    GE("Grand Exchange"), // calc by GE
-    HIGHEST("Highest"); // use whatever is highest.
+	HA("High Alchemy"), // calc highlight by HA value
+	GE("Grand Exchange"), // calc by GE
+	HIGHEST("Highest"); // use whatever is highest.
 
-    private final String name;
+	private final String name;
 
-    @Override
-    public String toString()
-    {
-        return name;
-    }
+	@Override
+	public String toString()
+	{
+		return name;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/config/ValueCalculationMode.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/config/ValueCalculationMode.java
@@ -1,0 +1,5 @@
+package net.runelite.client.plugins.grounditems.config;
+
+public class ValueCalculationMode
+{
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/config/ValueCalculationMode.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/config/ValueCalculationMode.java
@@ -1,5 +1,21 @@
 package net.runelite.client.plugins.grounditems.config;
 
-public class ValueCalculationMode
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ValueCalculationMode
 {
+    HA("High Alchemy"), // calc highlight by HA value
+    GE("Grand Exchange"), // calc by GE
+    BOTH("Both"); // use whatever is highest.
+
+    private final String name;
+
+    @Override
+    public String toString()
+    {
+        return name;
+    }
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/config/ValueCalculationMode.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/config/ValueCalculationMode.java
@@ -1,3 +1,28 @@
+/*
+ * Copyright (c) 2019, Abel Briggs <https://github.com/abelbriggs1>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package net.runelite.client.plugins.grounditems.config;
 
 import lombok.Getter;
@@ -9,7 +34,7 @@ public enum ValueCalculationMode
 {
     HA("High Alchemy"), // calc highlight by HA value
     GE("Grand Exchange"), // calc by GE
-    BOTH("Both"); // use whatever is highest.
+    HIGHEST("Highest"); // use whatever is highest.
 
     private final String name;
 


### PR DESCRIPTION
Fixes #7737.

Right now the color highlighting(low/medium/high/insane) uses whatever's highest of Grand Exchange and High Alchemy to determine an item's color. Not all players care about both, however.

This PR lets users select a specific mode for the color highlighting. Default is BOTH, which is the current functionality.

Example of usage: https://imgur.com/a/PRISDUB