### PR TITLE
Add option for 12 hour clock format to chat timestamps

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/timestamp/TimestampConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timestamp/TimestampConfig.java
@@ -45,4 +45,14 @@ public interface TimestampConfig extends Config
 		description = "Colour of Timestamps from the Timestamps plugin (transparent)"
 	)
 	Color transparentTimestamp();
+
+	@ConfigItem(
+		keyName = "twelveHourClock",
+		name = "Twelve hour clock",
+		description = "Use a 12 hour clock instead of 24. (e.g. 4:00pm instead of 16:00)"
+	)
+	default boolean twelveHourClock()
+	{
+		return false;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timestamp/TimestampPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timestamp/TimestampPlugin.java
@@ -82,9 +82,19 @@ public class TimestampPlugin extends Plugin
 
 		final ZonedDateTime time = ZonedDateTime.ofInstant(
 			Instant.ofEpochSecond(messageNode.getTimestamp()), ZoneId.systemDefault());
+		String dateFormat;
 
-		final String dateFormat = time.get(ChronoField.HOUR_OF_DAY) + ":" +
-			String.format("%02d", time.get(ChronoField.MINUTE_OF_HOUR));
+		if (config.twelveHourClock())
+		{
+			String ampm = time.get(ChronoField.AMPM_OF_DAY) == 0 ? "am" : "pm";
+			dateFormat = time.get(ChronoField.HOUR_OF_AMPM) + ":" +
+				String.format("%02d", time.get(ChronoField.MINUTE_OF_HOUR)) + ampm;
+		}
+		else
+		{
+			dateFormat = time.get(ChronoField.HOUR_OF_DAY) + ":" +
+				String.format("%02d", time.get(ChronoField.MINUTE_OF_HOUR));
+		}
 
 		String timestamp = "[" + dateFormat + "] ";
 


### PR DESCRIPTION
Add config for using am/pm in chat timestamps rather than a 24 hour clock.