### PR TITLE
prayer: fix dose indicator not accounting for super restores or sanfews

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/prayer/PrayerDoseOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/prayer/PrayerDoseOverlay.java
@@ -66,6 +66,8 @@ class PrayerDoseOverlay extends Overlay
 	@Setter(AccessLevel.PACKAGE)
 	private boolean hasPrayerRestore;
 	@Setter(AccessLevel.PACKAGE)
+	private int bonusPrayer;
+	@Setter(AccessLevel.PACKAGE)
 	private boolean hasHolyWrench;
 
 	@Inject
@@ -135,14 +137,9 @@ class PrayerDoseOverlay extends Overlay
 		final double dosePercentage = hasHolyWrench ? .27 : .25;
 		final int basePointsRestored = (int) Math.floor(maxPrayer * dosePercentage);
 
-		// how many points a prayer and super restore will heal
-		final int prayerPotionPointsRestored = basePointsRestored + 7;
-		final int superRestorePointsRestored = basePointsRestored + 8;
+		final int pointsRestored = basePointsRestored + 7 + bonusPrayer;
 
-		final boolean usePrayerPotion = prayerPointsMissing >= prayerPotionPointsRestored;
-		final boolean useSuperRestore = prayerPointsMissing >= superRestorePointsRestored;
-
-		if (!usePrayerPotion && !useSuperRestore)
+		if (prayerPointsMissing < pointsRestored)
 		{
 			return null;
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/prayer/PrayerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/prayer/PrayerPlugin.java
@@ -135,6 +135,7 @@ public class PrayerPlugin extends Plugin
 		{
 			doseOverlay.setHasHolyWrench(false);
 			doseOverlay.setHasPrayerRestore(false);
+			doseOverlay.setBonusPrayer(0);
 
 			if (inventory != null)
 			{
@@ -211,6 +212,10 @@ public class PrayerPlugin extends Plugin
 
 		int total = 0;
 
+		boolean hasPrayerPotion = false;
+		boolean hasSuperRestore = false;
+		boolean hasSanfew = false;
+
 		for (Item item : items)
 		{
 			if (item == null)
@@ -225,9 +230,13 @@ public class PrayerPlugin extends Plugin
 				switch (type)
 				{
 					case PRAYERPOT:
+						hasPrayerPotion = true;
+						break;
 					case RESTOREPOT:
+						hasSuperRestore = true;
+						break;
 					case SANFEWPOT:
-						doseOverlay.setHasPrayerRestore(true);
+						hasSanfew = true;
 						break;
 					case HOLYWRENCH:
 						doseOverlay.setHasHolyWrench(true);
@@ -237,6 +246,19 @@ public class PrayerPlugin extends Plugin
 
 			int bonus = PrayerItems.getItemPrayerBonus(item.getId());
 			total += bonus;
+		}
+
+		if (hasSanfew || hasSuperRestore || hasPrayerPotion)
+		{
+			doseOverlay.setHasPrayerRestore(true);
+			if (hasSanfew)
+			{
+				doseOverlay.setBonusPrayer(2);
+			}
+			else if (hasSuperRestore)
+			{
+				doseOverlay.setBonusPrayer(1);
+			}
 		}
 
 		return total;


### PR DESCRIPTION
Currently, the Prayer Dose indicator will show when you can drink a prayer potion, even if you're using Super Restores or Sanfews which both restore more prayer. This leads to lost prayer points.