### PR TITLE
Add Toggle for XpTracker Xp/Time Left Swap

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpInfoBox.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpInfoBox.java
@@ -90,12 +90,14 @@ class XpInfoBox extends JPanel
 	private final JLabel actionsLeft = new JLabel();
 	private final JMenuItem pauseSkill = new JMenuItem("Pause");
 
+	private final XpTrackerPlugin xpTrackerPlugin;
 	private final XpTrackerConfig xpTrackerConfig;
 
 	private boolean paused = false;
 
 	XpInfoBox(XpTrackerPlugin xpTrackerPlugin, XpTrackerConfig xpTrackerConfig, Client client, JPanel panel, Skill skill, SkillIconManager iconManager)
 	{
+		this.xpTrackerPlugin = xpTrackerPlugin;
 		this.xpTrackerConfig = xpTrackerConfig;
 		this.panel = panel;
 		this.skill = skill;
@@ -201,8 +203,16 @@ class XpInfoBox extends JPanel
 
 			// Update information labels
 			expGained.setText(htmlLabel("XP Gained: ", xpSnapshotSingle.getXpGainedInSession()));
-			expLeft.setText(htmlLabel("XP Left: ", xpSnapshotSingle.getXpRemainingToGoal()));
 			actionsLeft.setText(htmlLabel(xpSnapshotSingle.getActionType().getLabel() + ": ", xpSnapshotSingle.getActionsRemainingToGoal()));
+			if (xpTrackerConfig.swapXpRemaining())//User has chosen to toggle the swap for Xp left and Time Left
+			{
+				String timeLeft = xpTrackerPlugin.convertTimeToShortText(String.format(xpSnapshotSingle.getTimeTillGoal()));
+				expLeft.setText("<html>Time Left: <font color=WHITE>" + timeLeft + "</font></html>");
+			}
+			else
+			{
+				expLeft.setText(htmlLabel("XP Left: ", xpSnapshotSingle.getXpRemainingToGoal()));
+			}
 
 			// Update progress bar
 			progressBar.setValue((int) xpSnapshotSingle.getSkillProgressToGoal());
@@ -231,13 +241,25 @@ class XpInfoBox extends JPanel
 				progressBar.setPositions(Collections.emptyList());
 			}
 
+			//If "Xp/Time Left" swap is enabled the tooltip data will change as well
+			String xpTillGoalText = "";
+			if (xpTrackerConfig.swapXpRemaining())
+			{
+				Double number = Double.valueOf(xpSnapshotSingle.getXpRemainingToGoal()); //Doesn't work without converting into to double
+				xpTillGoalText = "XP Left: " + String.format("%,.0f", number);
+			}
+			else
+			{
+				xpTillGoalText = xpSnapshotSingle.getTimeTillGoal();
+			}
+
 			progressBar.setToolTipText(String.format(
 				HTML_TOOL_TIP_TEMPLATE,
 				xpSnapshotSingle.getActionsInSession(),
 				xpSnapshotSingle.getActionType().getLabel(),
 				xpSnapshotSingle.getActionsPerHour(),
 				xpSnapshotSingle.getActionType().getLabel(),
-				xpSnapshotSingle.getTimeTillGoal()));
+				xpTillGoalText));
 
 			progressBar.setDimmed(skillPaused);
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerConfig.java
@@ -65,7 +65,18 @@ public interface XpTrackerConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 3,
+			position = 3,
+			keyName = "swapXpRemaining",
+			name = "Swap XP/Time Left",
+			description = "Swaps the amount of xp remaining with the estimated time remaining"
+	)
+	default boolean swapXpRemaining()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		position = 4,
 		keyName = "pauseSkillAfter",
 		name = "Auto pause after",
 		description = "Configures how many minutes passes before pausing a skill while in game and there's no XP, 0 means disabled"

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerPlugin.java
@@ -547,9 +547,16 @@ public class XpTrackerPlugin extends Plugin
 		boolean over24Hr = false;
 		boolean over60min = false;
 
-		if (time.contains(" days ")) //Split Days if applicable (example text: "35 days 04:12:59")
+		if (time.contains(" days " ) || time.contains(" day ")) //Split Days if applicable (example text: "35 days 04:12:59")
 		{
-			daysAndHours  = time.split(" days ");
+			if (time.charAt(0) == '1' && time.charAt(1) == ' ')
+			{
+				daysAndHours  = time.split(" day ");
+			}
+			else
+			{
+				daysAndHours  = time.split(" days ");
+			}
 			days = daysAndHours[0];
 			timeWithoutDays = daysAndHours[1];
 			over24Hr = true;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerPlugin.java
@@ -533,4 +533,50 @@ public class XpTrackerPlugin extends Plugin
 			pauseSkill(skill, pause);
 		}
 	}
+
+	/**
+	 * Converts the long format time text to a short format.
+	 * Allows the toggling of rather xp left or time left is shown on the InfoBox.
+	 * @param time Time left remaining in goal
+	 */
+	String convertTimeToShortText(String time)
+	{
+		String days = "0", hours = null, minutes = null, seconds = null;
+		String timeWithoutDays = null;
+		String[] daysAndHours = null;
+		boolean over24Hr = false;
+		boolean over60min = false;
+
+		if (time.contains(" days ")) //Split Days if applicable (example text: "35 days 04:12:59")
+		{
+			daysAndHours  = time.split(" days ");
+			days = daysAndHours[0];
+			timeWithoutDays = daysAndHours[1];
+			over24Hr = true;
+		}
+		else
+		{
+			timeWithoutDays = time;
+		}
+
+		String[] hourMinSeconds = timeWithoutDays.split(":"); //Split Hours/Minutes/Seconds if applicable
+		if (hourMinSeconds.length > 2)
+		{
+			hours = hourMinSeconds[0];
+			minutes = hourMinSeconds[1];
+			seconds = hourMinSeconds[2];
+			over60min = true;
+		}
+		else
+		{
+			minutes = hourMinSeconds[0];
+			seconds = hourMinSeconds[1];
+		}
+		String shortenedTime = ""; //There are a few conditions to ensure only 2 significant time measurements being shown
+		if (over24Hr) shortenedTime += days + "D ";
+		if (hours != null) shortenedTime += hours + "H ";
+		if (!over24Hr && !minutes.equals("00")) shortenedTime += minutes + "M ";
+		if (!over60min) shortenedTime += seconds + "S";
+		return shortenedTime;
+	}
 }


### PR DESCRIPTION
Closes #8373. This will allow the toggling of XP Left on the Xp Panel to be swapped with the Time Left on the Progress Bar's tooltip.

The Time left is formatted to show shorthand units and limits the amount of text to show only the significant units.

Eg: 
- "3 days 12:23:48" will be changed to "3D 12H".
- "00:11:23" will be changed to "11M 23S".

This is my first contribution so feel free to let me know if there's anything I should be doing better.