### PR TITLE
client: fix puzzle solver not completing if executor waits before starting solver

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/puzzlesolver/solver/PuzzleSolver.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/puzzlesolver/solver/PuzzleSolver.java
@@ -78,7 +78,7 @@ public class PuzzleSolver implements Runnable
 
 	public boolean hasExceededWaitDuration()
 	{
-		return stopwatch.elapsed().compareTo(MAX_WAIT_DURATION) > 0;
+		return stopwatch != null && stopwatch.elapsed().compareTo(MAX_WAIT_DURATION) > 0;
 	}
 
 	public boolean hasFailed()


### PR DESCRIPTION
If the executor waits a while until it starts executing the puzzle solver, the stopwatch will have a null value when hasExceededWaitDuration is called the next frame, causing a NullPointerException to be thrown. This has the effect that the puzzle solver never finishes.

Extract from [whatnamenow's client log](https://gist.github.com/whatnamenow/2738e85bf99ab70a8fc934c2ec4495de): 
```
2019-04-04 18:03:08 [Thread-7] WARN  net.runelite.client.callback.Hooks - Error during overlay rendering
java.lang.NullPointerException: null
	at net.runelite.client.plugins.puzzlesolver.solver.PuzzleSolver.hasExceededWaitDuration(PuzzleSolver.java:81)
	at net.runelite.client.plugins.puzzlesolver.PuzzleSolverOverlay.render(PuzzleSolverOverlay.java:344)
	at net.runelite.client.ui.overlay.OverlayRenderer.safeRender(OverlayRenderer.java:461)
	at net.runelite.client.ui.overlay.OverlayRenderer.render(OverlayRenderer.java:227)
	at net.runelite.client.callback.Hooks.drawAfterWidgets(Hooks.java:435)
	at client.gv(client.java:4054)
	at client.ak(client.java:1402)
	at bf.ag(bf.java:397)
	at bf.run(bf.java:351)
at java.lang.Thread.run(Thread.java:748)
```