### PR TITLE
adding combat level notifiers to idlenotifier plugin

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierConfig.java
@@ -76,10 +76,31 @@ public interface IdleNotifierConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "hitpoints",
-		name = "Hitpoints Notification Threshold",
-		description = "The amount of hitpoints to send a notification at. A value of 0 will disable notification.",
-		position = 5
+		keyName = "oxygen",
+		name = "Oxygen Notification Threshold",
+		position = 5,
+		description = "The amount of remaining oxygen to send a notification at. A value of 0 will disable notification."
+	)
+	default int getOxygenThreshold()
+	{
+		return 0;
+	}
+	@ConfigItem(
+			keyName = "spec",
+			name = "Special Attack Energy Notification Threshold",
+			position = 6,
+			description = "The amount of spec energy reached to send a notification at. A value of 0 will disable notification."
+	)
+	default int getSpecEnergyThreshold()
+	{
+		return 0;
+	}
+
+	@ConfigItem(
+			keyName = "hitpoints",
+			name = "Hitpoints Notification Threshold",
+			description = "The amount of hitpoints to send a notification at. A value of 0 will disable notification.",
+			position = 7
 	)
 	default int getHitpointsThreshold()
 	{
@@ -87,10 +108,10 @@ public interface IdleNotifierConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "prayer",
-		name = "Prayer Notification Threshold",
-		description = "The amount of prayer points to send a notification at. A value of 0 will disable notification.",
-		position = 6
+			keyName = "prayer",
+			name = "Prayer Notification Threshold",
+			description = "The amount of prayer points to send a notification at. A value of 0 will disable notification.",
+			position = 8
 	)
 	default int getPrayerThreshold()
 	{
@@ -98,23 +119,45 @@ public interface IdleNotifierConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "oxygen",
-		name = "Oxygen Notification Threshold",
-		position = 7,
-		description = "The amount of remaining oxygen to send a notification at. A value of 0 will disable notification."
+			keyName = "ranged",
+			name = "Ranged Notification Threshold",
+			description = "The ranged level to send a notification at. A value of 0 will disable notification.",
+			position = 9
 	)
-	default int getOxygenThreshold()
+	default int getRangedThreshold()
 	{
 		return 0;
 	}
 
 	@ConfigItem(
-		keyName = "spec",
-		name = "Special Attack Energy Notification Threshold",
-		position = 8,
-		description = "The amount of spec energy reached to send a notification at. A value of 0 will disable notification."
+			keyName = "attack",
+			name = "Attack Notification Threshold",
+			description = "The attack level to send a notification at. A value of 0 will disable notification.",
+			position = 10
 	)
-	default int getSpecEnergyThreshold()
+	default int getAttackThreshold()
+	{
+		return 0;
+	}
+
+	@ConfigItem(
+			keyName = "strength",
+			name = "Strength Notification Threshold",
+			description = "The strength level to send a notification at. A value of 0 will disable notification.",
+			position = 11
+	)
+	default int getStrengthThreshold()
+	{
+		return 0;
+	}
+
+	@ConfigItem(
+			keyName = "defence",
+			name = "Defence Notification Threshold",
+			description = "The defence level to send a notification at. A value of 0 will disable notification.",
+			position = 12
+	)
+	default int getDefenceThreshold()
 	{
 		return 0;
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
@@ -534,7 +534,7 @@ public class IdleNotifierPlugin extends Plugin
 			return false;
 		}
 
-		// ranged is boostable so we wont check than RealSkillLevel > RangedThreshold
+		// ranged is boostable so we wont check that RealSkillLevel > RangedThreshold
 		if (client.getBoostedSkillLevel(Skill.RANGED) <= config.getRangedThreshold())
 		{
 			if (!notifyRanged)
@@ -558,7 +558,7 @@ public class IdleNotifierPlugin extends Plugin
 			return false;
 		}
 
-		// strength is boostable so we wont check than RealSkillLevel > StrengthThreshold
+		// strength is boostable so we wont check that RealSkillLevel > StrengthThreshold
 		if (client.getBoostedSkillLevel(Skill.STRENGTH) <= config.getStrengthThreshold())
 		{
 			if (!notifyStrength)
@@ -582,7 +582,7 @@ public class IdleNotifierPlugin extends Plugin
 			return false;
 		}
 
-		// attack is boostable so we wont check than RealSkillLevel > AttackThreshold
+		// attack is boostable so we wont check that RealSkillLevel > AttackThreshold
 		if (client.getBoostedSkillLevel(Skill.ATTACK) <= config.getAttackThreshold())
 		{
 			if (!notifyAttack)
@@ -606,7 +606,7 @@ public class IdleNotifierPlugin extends Plugin
 			return false;
 		}
 
-		// attack is boostable so we wont check than RealSkillLevel > DefenceThreshold
+		// attack is boostable so we wont check that RealSkillLevel > DefenceThreshold
 		if (client.getBoostedSkillLevel(Skill.DEFENCE) <= config.getDefenceThreshold())
 		{
 			if (!notifyDefence)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
@@ -58,8 +58,8 @@ import net.runelite.client.plugins.PluginDescriptor;
 
 @PluginDescriptor(
 	name = "Idle Notifier",
-	description = "Send a notification when going idle, or when HP/Prayer reaches a threshold",
-	tags = {"health", "hitpoints", "notifications", "prayer"}
+	description = "Send a notification when going idle, or when HP/Prayer or combat stats reach a threshold",
+	tags = {"health", "hitpoints", "notifications", "prayer", "combat"}
 )
 public class IdleNotifierPlugin extends Plugin
 {
@@ -88,6 +88,10 @@ public class IdleNotifierPlugin extends Plugin
 	private Actor lastInteract;
 	private boolean notifyHitpoints = true;
 	private boolean notifyPrayer = true;
+	private boolean notifyRanged = true;
+	private boolean notifyAttack = true;
+	private boolean notifyStrength = true;
+	private boolean notifyDefence = true;
 	private boolean notifyOxygen = true;
 	private boolean notifyIdleLogout = true;
 	private boolean notify6HourLogout = true;
@@ -411,6 +415,26 @@ public class IdleNotifierPlugin extends Plugin
 		{
 			notifier.notify("[" + local.getName() + "] has restored spec energy!");
 		}
+
+		if (checkLowRanged())
+		{
+			notifier.notify("[" + local.getName() + "] has low ranged!");
+		}
+
+		if (checkLowAttack())
+		{
+			notifier.notify("[" + local.getName() + "] has low attack!");
+		}
+
+		if (checkLowStrength())
+		{
+			notifier.notify("[" + local.getName() + "] has low strength!");
+		}
+
+		if (checkLowDefence())
+		{
+			notifier.notify("[" + local.getName() + "] has low defence!");
+		}
 	}
 
 	private boolean checkFullSpecEnergy()
@@ -498,6 +522,102 @@ public class IdleNotifierPlugin extends Plugin
 			{
 				notifyPrayer = false;
 			}
+		}
+
+		return false;
+	}
+
+	private boolean checkLowRanged()
+	{
+		if (config.getRangedThreshold() == 0)
+		{
+			return false;
+		}
+
+		// ranged is boostable so we wont check than RealSkillLevel > RangedThreshold
+		if (client.getBoostedSkillLevel(Skill.RANGED) <= config.getRangedThreshold())
+		{
+			if (!notifyRanged)
+			{
+				notifyRanged = true;
+				return true;
+			}
+		}
+		else
+		{
+			notifyRanged = false;
+		}
+
+		return false;
+	}
+
+	private boolean checkLowStrength()
+	{
+		if (config.getStrengthThreshold() == 0)
+		{
+			return false;
+		}
+
+		// strength is boostable so we wont check than RealSkillLevel > StrengthThreshold
+		if (client.getBoostedSkillLevel(Skill.STRENGTH) <= config.getStrengthThreshold())
+		{
+			if (!notifyStrength)
+			{
+				notifyStrength = true;
+				return true;
+			}
+		}
+		else
+		{
+			notifyStrength = false;
+		}
+
+		return false;
+	}
+
+	private boolean checkLowAttack()
+	{
+		if (config.getAttackThreshold() == 0)
+		{
+			return false;
+		}
+
+		// attack is boostable so we wont check than RealSkillLevel > AttackThreshold
+		if (client.getBoostedSkillLevel(Skill.ATTACK) <= config.getAttackThreshold())
+		{
+			if (!notifyAttack)
+			{
+				notifyAttack = true;
+				return true;
+			}
+		}
+		else
+		{
+			notifyAttack = false;
+		}
+
+		return false;
+	}
+
+	private boolean checkLowDefence()
+	{
+		if (config.getDefenceThreshold() == 0)
+		{
+			return false;
+		}
+
+		// attack is boostable so we wont check than RealSkillLevel > DefenceThreshold
+		if (client.getBoostedSkillLevel(Skill.DEFENCE) <= config.getDefenceThreshold())
+		{
+			if (!notifyDefence)
+			{
+				notifyDefence = true;
+				return true;
+			}
+		}
+		else
+		{
+			notifyDefence = false;
 		}
 
 		return false;


### PR DESCRIPTION
I found myself forgetting to pot up while in the nightmare zone or while doing slayer tasks. This addition to the idle notifier lets you receive notifications when you should pot up again