### PR TITLE
Cluescrolls Plugin: Adds Spade Check to Cryptic Clues

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java
@@ -333,6 +333,7 @@ public class CrypticClue extends ClueScroll implements TextClueScroll, NpcClueSc
 		this.objectId = objectId;
 		this.location = location;
 		this.solution = solution;
+		setRequiresSpade(getLocation() != null && getNpc() == null && objectId == -1);
 	}
 
 	@Override


### PR DESCRIPTION
Closes #7494

@Adam- Please review as you recently committed the centralized spade check in this snapshot

This was overlooked because the issue is missing a "clues" label