### PR TITLE
Fix Inaccurate Blood & Soul Rune XP

### DIFF
--- a/runelite-client/src/main/resources/net/runelite/client/plugins/skillcalculator/skill_runecraft.json
+++ b/runelite-client/src/main/resources/net/runelite/client/plugins/skillcalculator/skill_runecraft.json
@@ -184,13 +184,13 @@
       "level": 77,
       "icon": 565,
       "name": "Blood Rune",
-      "xp": 23.8
+      "xp": 24.425
     },
     {
       "level": 90,
       "icon": 566,
       "name": "Soul Rune",
-      "xp": 29.7
+      "xp": 30.325
     },
     {
       "level": 95,


### PR DESCRIPTION
Closes #6953 

Based on the conversation in the issue, this appears to be the easiest way to consider the xp from dark essence blocks when crafting blood and/or soul runes.