### PR TITLE
idle notifier: allow animations fallback for interacting checks

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
@@ -561,6 +561,11 @@ public class IdleNotifierPlugin extends Plugin
 			{
 				lastInteract = null;
 				lastInteracting = null;
+
+				// prevent animation notifications from firing too
+				lastAnimation = IDLE;
+				lastAnimating = null;
+
 				return true;
 			}
 		}
@@ -648,6 +653,11 @@ public class IdleNotifierPlugin extends Plugin
 			{
 				lastAnimation = IDLE;
 				lastAnimating = null;
+
+				// prevent interaction notifications from firing too
+				lastInteract = null;
+				lastInteracting = null;
+
 				return true;
 			}
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
@@ -181,6 +181,18 @@ public class IdleNotifierPlugin extends Plugin
 			/* Fishing */
 			case FISHING_CRUSHING_INFERNAL_EELS:
 			case FISHING_CUTTING_SACRED_EELS:
+			case FISHING_BIG_NET:
+			case FISHING_NET:
+			case FISHING_POLE_CAST:
+			case FISHING_CAGE:
+			case FISHING_HARPOON:
+			case FISHING_BARBTAIL_HARPOON:
+			case FISHING_DRAGON_HARPOON:
+			case FISHING_INFERNAL_HARPOON:
+			case FISHING_CRYSTAL_HARPOON:
+			case FISHING_OILY_ROD:
+			case FISHING_KARAMBWAN:
+			case FISHING_BAREHAND:
 			/* Mining(Normal) */
 			case MINING_BRONZE_PICKAXE:
 			case MINING_IRON_PICKAXE:


### PR DESCRIPTION
adds back the fishing animations to check for animation idle
checks to see if the character has been interacting notified when attempting to send animation notification for the same activity, if so it skips the animation notification.

fixes #8429 
fixes #9714 