### PR TITLE
Options to remove additional bank options

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -32,7 +32,7 @@ import net.runelite.client.config.ConfigItem;
 public interface MenuEntrySwapperConfig extends Config
 {
 	@ConfigItem(
-		position = -2,
+		position = -4,
 		keyName = "shiftClickCustomization",
 		name = "Customizable shift-click",
 		description = "Allows customization of shift-clicks on items"
@@ -40,6 +40,28 @@ public interface MenuEntrySwapperConfig extends Config
 	default boolean shiftClickCustomization()
 	{
 		return true;
+	}
+
+	@ConfigItem(
+			position = -3,
+			keyName = "removeRepeatedBankOptions",
+			name = "Remove repeated bank options",
+			description = "Removes repeated Withdraw and Deposit options when the default quantity is changed"
+	)
+	default boolean removeRepeatedBankOptions()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+			position = -2,
+			keyName = "removeWithdrawAllButOne",
+			name = "Remove Withdraw All but 1",
+			description = "Removes Withdraw All but 1 option"
+	)
+	default boolean removeWithdrawAllButOne()
+	{
+		return false;
 	}
 
 	@ConfigItem(

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -570,6 +570,50 @@ public class MenuEntrySwapperPlugin extends Plugin
 		{
 			swap("use", option, target, true);
 		}
+		else if (config.removeWithdrawAllButOne() && option.equals("withdraw-all-but-1"))
+		{
+			MenuEntry[] entries = client.getMenuEntries();
+
+			int index = searchIndex(entries, option, target, true);
+
+			remove(index);
+		}
+		else if (config.removeRepeatedBankOptions() && (option.contains("withdraw-") || option.contains("deposit-")))
+		{
+			MenuEntry[] entries = client.getMenuEntries();
+			MenuEntry prevMenuEntry = entries[entries.length - 2];
+			String prevOption = Text.removeTags(prevMenuEntry.getOption()).toLowerCase();
+
+			if ((!option.equals("withdraw-1") && prevOption.equals("withdraw-1")) || (!option.equals("deposit-1") && prevOption.equals("deposit-1")))
+			{
+				if (option.equals("withdraw-5") || option.equals("deposit-5"))
+				{
+					remove(entries.length - 3);
+				}
+				else if (option.equals("withdraw-10") || option.equals("deposit-10"))
+				{
+					remove(entries.length - 4);
+				}
+				else if (option.equals("withdraw-all") || option.equals("deposit-all"))
+				{
+					// check if there is an X option set
+					MenuEntry testMenuEntry = entries[entries.length - 6];
+					String testOption = Text.removeTags(testMenuEntry.getOption()).toLowerCase();
+					if (testOption.equals("withdraw-all") || testOption.equals("deposit-all"))
+					{
+						remove(entries.length - 6);
+					}
+					else
+					{
+						remove(entries.length - 7);
+					}
+				}
+				else // X option
+				{
+					remove(entries.length - 5);
+				}
+			}
+		}
 	}
 
 	@Subscribe
@@ -635,6 +679,15 @@ public class MenuEntrySwapperPlugin extends Plugin
 
 			client.setMenuEntries(entries);
 		}
+	}
+
+	private void remove(int index)
+	{
+		MenuEntry[] entries = client.getMenuEntries();
+
+		entries = ArrayUtils.remove(entries, index);
+
+		client.setMenuEntries(entries);
 	}
 
 	private void removeShiftClickCustomizationMenus()


### PR DESCRIPTION
Adds the option to remove repeated bank options when the default quantity is changed, and also adds the option to remove Withdraw All but 1.

![Remove Additional Bank Options](https://user-images.githubusercontent.com/20487224/55696100-58a61780-5970-11e9-9374-4cdf0ca4e498.gif)
