### PR TITLE
Add Beginner Clue to Hiscore lookup, Hiscore plugin and Chat commands plugin

### DIFF
--- a/http-api/src/main/java/net/runelite/http/api/hiscore/HiscoreResult.java
+++ b/http-api/src/main/java/net/runelite/http/api/hiscore/HiscoreResult.java
@@ -57,6 +57,7 @@ public class HiscoreResult
 	private Skill bountyHunterHunter;
 	private Skill bountyHunterRogue;
 	private Skill clueScrollAll;
+	private Skill clueScrollBeginner;
 	private Skill clueScrollEasy;
 	private Skill clueScrollMedium;
 	private Skill clueScrollHard;
@@ -122,6 +123,8 @@ public class HiscoreResult
 				return getBountyHunterRogue();
 			case CLUE_SCROLL_ALL:
 				return getClueScrollAll();
+			case CLUE_SCROLL_BEGINNER:
+				return getClueScrollBeginner();
 			case CLUE_SCROLL_EASY:
 				return getClueScrollEasy();
 			case CLUE_SCROLL_MEDIUM:

--- a/http-api/src/main/java/net/runelite/http/api/hiscore/HiscoreResultBuilder.java
+++ b/http-api/src/main/java/net/runelite/http/api/hiscore/HiscoreResultBuilder.java
@@ -79,13 +79,14 @@ public class HiscoreResultBuilder
 		hiscoreResult.setConstruction(skills.get(23));
 		hiscoreResult.setBountyHunterHunter(skills.get(24));
 		hiscoreResult.setBountyHunterRogue(skills.get(25));
-		hiscoreResult.setClueScrollAll(skills.get(26));
-		hiscoreResult.setClueScrollEasy(skills.get(27));
-		hiscoreResult.setClueScrollMedium(skills.get(28));
-		hiscoreResult.setClueScrollHard(skills.get(29));
-		hiscoreResult.setClueScrollElite(skills.get(30));
-		hiscoreResult.setClueScrollMaster(skills.get(31));
-		hiscoreResult.setLastManStanding(skills.get(32));
+		hiscoreResult.setLastManStanding(skills.get(26));
+		hiscoreResult.setClueScrollAll(skills.get(27));
+		hiscoreResult.setClueScrollBeginner(skills.get(28));
+		hiscoreResult.setClueScrollEasy(skills.get(29));
+		hiscoreResult.setClueScrollMedium(skills.get(30));
+		hiscoreResult.setClueScrollHard(skills.get(31));
+		hiscoreResult.setClueScrollElite(skills.get(32));
+		hiscoreResult.setClueScrollMaster(skills.get(33));
 		return hiscoreResult;
 	}
 }

--- a/http-api/src/main/java/net/runelite/http/api/hiscore/HiscoreSkill.java
+++ b/http-api/src/main/java/net/runelite/http/api/hiscore/HiscoreSkill.java
@@ -52,13 +52,14 @@ public enum HiscoreSkill
 	CONSTRUCTION("Construction"),
 	BOUNTY_HUNTER_HUNTER("Bounty Hunter - Hunter"),
 	BOUNTY_HUNTER_ROGUE("Bounty Hunter - Rogue"),
+	LAST_MAN_STANDING("Last Man Standing"),
 	CLUE_SCROLL_ALL("Clue Scrolls (all)"),
+	CLUE_SCROLL_BEGINNER("Clue Scrolls (beginner)"),
 	CLUE_SCROLL_EASY("Clue Scrolls (easy)"),
 	CLUE_SCROLL_MEDIUM("Clue Scrolls (medium)"),
 	CLUE_SCROLL_HARD("Clue Scrolls (hard)"),
 	CLUE_SCROLL_ELITE("Clue Scrolls (elite)"),
-	CLUE_SCROLL_MASTER("Clue Scrolls (master)"),
-	LAST_MAN_STANDING("Last Man Standing");
+	CLUE_SCROLL_MASTER("Clue Scrolls (master)");
 
 	private final String name;
 

--- a/http-service/src/test/java/net/runelite/http/service/hiscore/HiscoreServiceTest.java
+++ b/http-service/src/test/java/net/runelite/http/service/hiscore/HiscoreServiceTest.java
@@ -62,13 +62,14 @@ public class HiscoreServiceTest
 			+ "492790,1,0\n"
 			+ "-1,-1\n"
 			+ "73,1738\n"
+			+ "-1,-1\n"
 			+ "531,1432\n"
+			+ "324,212\n"
 			+ "8008,131\n"
 			+ "1337,911\n"
 			+ "42,14113\n"
 			+ "1,777\n"
-			+ "254,92\n"
-			+ "-1,-1";
+			+ "254,92\n";
 
 	private final MockWebServer server = new MockWebServer();
 
@@ -97,6 +98,7 @@ public class HiscoreServiceTest
 		Assert.assertEquals(159727L, result.getFishing().getExperience());
 		Assert.assertEquals(492790, result.getConstruction().getRank());
 		Assert.assertEquals(1432, result.getClueScrollAll().getLevel());
+		Assert.assertEquals(324, result.getClueScrollBeginner().getRank());
 		Assert.assertEquals(8008, result.getClueScrollEasy().getRank());
 		Assert.assertEquals(911, result.getClueScrollMedium().getLevel());
 		Assert.assertEquals(42, result.getClueScrollHard().getRank());

--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
@@ -831,6 +831,9 @@ public class ChatCommandsPlugin extends Plugin
 
 			switch (level)
 			{
+				case "beginner":
+					hiscoreSkill = result.getClueScrollBeginner();
+					break;
 				case "easy":
 					hiscoreSkill = result.getClueScrollEasy();
 					break;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/hiscore/HiscorePanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/hiscore/HiscorePanel.java
@@ -522,18 +522,21 @@ public class HiscorePanel extends PluginPanel
 				case CLUE_SCROLL_ALL:
 				{
 					String allRank = (result.getClueScrollAll().getRank() == -1) ? "Unranked" : StackFormatter.formatNumber(result.getClueScrollAll().getRank());
+					String beginnerRank = (result.getClueScrollBeginner().getRank() == -1) ? "Unranked" : StackFormatter.formatNumber(result.getClueScrollBeginner().getRank());
 					String easyRank = (result.getClueScrollEasy().getRank() == -1) ? "Unranked" : StackFormatter.formatNumber(result.getClueScrollEasy().getRank());
 					String mediumRank = (result.getClueScrollMedium().getRank() == -1) ? "Unranked" : StackFormatter.formatNumber(result.getClueScrollMedium().getRank());
 					String hardRank = (result.getClueScrollHard().getRank() == -1) ? "Unranked" : StackFormatter.formatNumber(result.getClueScrollHard().getRank());
 					String eliteRank = (result.getClueScrollElite().getRank() == -1) ? "Unranked" : StackFormatter.formatNumber(result.getClueScrollElite().getRank());
 					String masterRank = (result.getClueScrollMaster().getRank() == -1) ? "Unranked" : StackFormatter.formatNumber(result.getClueScrollMaster().getRank());
 					String all = (result.getClueScrollAll().getLevel() == -1 ? "0" : StackFormatter.formatNumber(result.getClueScrollAll().getLevel()));
+					String beginner = (result.getClueScrollBeginner().getLevel() == -1 ? "0" : StackFormatter.formatNumber(result.getClueScrollBeginner().getLevel()));
 					String easy = (result.getClueScrollEasy().getLevel() == -1 ? "0" : StackFormatter.formatNumber(result.getClueScrollEasy().getLevel()));
 					String medium = (result.getClueScrollMedium().getLevel() == -1 ? "0" : StackFormatter.formatNumber(result.getClueScrollMedium().getLevel()));
 					String hard = (result.getClueScrollHard().getLevel() == -1 ? "0" : StackFormatter.formatNumber(result.getClueScrollHard().getLevel()));
 					String elite = (result.getClueScrollElite().getLevel() == -1 ? "0" : StackFormatter.formatNumber(result.getClueScrollElite().getLevel()));
 					String master = (result.getClueScrollMaster().getLevel() == -1 ? "0" : StackFormatter.formatNumber(result.getClueScrollMaster().getLevel()));
 					content += "<p><span style = 'color:white'>All:</span> " + all + " <span style = 'color:white'>Rank:</span> " + allRank + "</p>";
+					content += "<p><span style = 'color:white'>Beginner:</span> " + beginner + " <span style = 'color:white'>Rank:</span> " + beginnerRank + "</p>";
 					content += "<p><span style = 'color:white'>Easy:</span> " + easy + " <span style = 'color:white'>Rank:</span> " + easyRank + "</p>";
 					content += "<p><span style = 'color:white'>Medium:</span> " + medium + " <span style = 'color:white'>Rank:</span> " + mediumRank + "</p>";
 					content += "<p><span style = 'color:white'>Hard:</span> " + hard + " <span style = 'color:white'>Rank:</span> " + hardRank + "</p>";


### PR DESCRIPTION
Fixes #8469

~Fixed the hiscore lookup, not sure if I should use this branch to fix the HiScore plugin itself to (Like add the clue icon)~
According to Adam I can put that fix/feature in this PR too.

Also fixes:
- Hiscore Plugin
- Adds `!clues beginner` to Chat command Plugin

![Screenshot from 2019-04-11 16-52-01](https://user-images.githubusercontent.com/2945583/55967419-8e057a80-5c7a-11e9-896b-f547d9f5ca99.png)

Also: Sorry for the messy PR, I wanted to do this but didn't have the tools to do it correctly at the moment.
