### PR TITLE
loottracker: add support for beginner clues

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
@@ -408,6 +408,9 @@ public class LootTrackerPlugin extends Plugin
 			final String type = m.group(1).toLowerCase();
 			switch (type)
 			{
+				case "beginner":
+					eventType = "Clue Scroll (Beginner)";
+					break;
 				case "easy":
 					eventType = "Clue Scroll (Easy)";
 					break;


### PR DESCRIPTION
This also fixes an issue where the Loot Tracker completely breaks after the user completes a Beginner clue and views the details of a specific monster/event