### PR TITLE
Fix chat history wrapping

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/Constants.java
+++ b/runelite-api/src/main/java/net/runelite/api/Constants.java
@@ -89,4 +89,9 @@ public class Constants
 	 * the maximum framerate of 50 fps.
 	 */
 	public static final int CLIENT_TICK_LENGTH = 20;
+
+	/**
+	 * The text of the welcome message upon logging in.
+	 */
+	public static final String WELCOME_MESSAGE = "Welcome to Old School RuneScape.";
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/chathistory/ChatHistoryPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chathistory/ChatHistoryPlugin.java
@@ -34,6 +34,7 @@ import java.util.Queue;
 import javax.inject.Inject;
 import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
+import net.runelite.api.Constants;
 import net.runelite.api.ScriptID;
 import net.runelite.api.VarClientInt;
 import net.runelite.api.VarClientStr;
@@ -58,7 +59,6 @@ import net.runelite.client.util.Text;
 )
 public class ChatHistoryPlugin extends Plugin implements KeyListener
 {
-	private static final String WELCOME_MESSAGE = "Welcome to Old School RuneScape.";
 	private static final String CLEAR_HISTORY = "Clear history";
 	private static final String CLEAR_PRIVATE = "<col=ffff00>Private:";
 	private static final int CYCLE_HOTKEY = KeyEvent.VK_TAB;
@@ -110,7 +110,7 @@ public class ChatHistoryPlugin extends Plugin implements KeyListener
 	{
 		// Start sending old messages right after the welcome message, as that is most reliable source
 		// of information that chat history was reset
-		if (chatMessage.getMessage().equals(WELCOME_MESSAGE))
+		if (chatMessage.getMessage().equals(Constants.WELCOME_MESSAGE))
 		{
 			if (!config.retainChatHistory())
 			{
@@ -145,8 +145,8 @@ public class ChatHistoryPlugin extends Plugin implements KeyListener
 					.type(chatMessage.getType())
 					.name(chatMessage.getName())
 					.sender(chatMessage.getSender())
-					.value(nbsp(chatMessage.getMessage()))
-					.runeLiteFormattedMessage(nbsp(chatMessage.getMessageNode().getRuneLiteFormatMessage()))
+					.value(chatMessage.getMessage())
+					.runeLiteFormattedMessage(chatMessage.getMessageNode().getRuneLiteFormatMessage())
 					.timestamp(chatMessage.getTimestamp())
 					.build();
 
@@ -174,21 +174,6 @@ public class ChatHistoryPlugin extends Plugin implements KeyListener
 				messageQueue.removeIf(e -> e.getType() == ChatMessageType.PUBLICCHAT || e.getType() == ChatMessageType.MODCHAT);
 			}
 		}
-	}
-
-	/**
-	 * Small hack to prevent plugins checking for specific messages to match
-	 * @param message message
-	 * @return message with nbsp
-	 */
-	private static String nbsp(final String message)
-	{
-		if (message != null)
-		{
-			return message.replace(' ', '\u00A0');
-		}
-
-		return null;
 	}
 
 	@Override

--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSClientMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSClientMixin.java
@@ -35,6 +35,7 @@ import javax.annotation.Nullable;
 import javax.inject.Named;
 import net.runelite.api.ChatMessageType;
 import net.runelite.api.ClanMember;
+import net.runelite.api.Constants;
 import net.runelite.api.EnumComposition;
 import net.runelite.api.Friend;
 import net.runelite.api.GameState;
@@ -189,6 +190,9 @@ public abstract class RSClientMixin implements RSClient
 
 	@Inject
 	private static HealthBarOverride healthBarOverride;
+
+	@Inject
+	private static int loginTime;
 
 	@Inject
 	public RSClientMixin()
@@ -1312,7 +1316,17 @@ public abstract class RSClientMixin implements RSClient
 
 		final ChatMessageType chatMessageType = ChatMessageType.of(type);
 		final ChatMessage chatMessage = new ChatMessage(messageNode, chatMessageType, name, message, sender, messageNode.getTimestamp());
-		client.getCallbacks().post(chatMessage);
+
+		if (chatMessage.getMessage().equals(Constants.WELCOME_MESSAGE))
+		{
+			loginTime = (int) System.currentTimeMillis() / 1000;
+		}
+
+		// Don't post events for chat messages earlier than the welcome message to prevent chat history from sending events
+		if (chatMessage.getTimestamp() >= loginTime)
+		{
+			client.getCallbacks().post(chatMessage);
+		}
 	}
 
 	@Inject


### PR DESCRIPTION
Fixes #1162

I had to edit mixins so I can't actually test one half of this change, but the reason for chat history not wrapping was because of the `nbsp()` method in the chat history plugin. It was a small hack to prevent chat history messages from triggering various plugins that detect chat messages. It did this by replacing spaces with non-breaking-spaces and that's what broke the wrapping.

However I figured that a better way of doing this now is to not send ChatMessage events for any chat message with a timestamp from before you logged in.