### PR TITLE
Group simultaneous boost notifications into one to reduce notification spam

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/boosts/BoostsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/boosts/BoostsConfig.java
@@ -103,4 +103,15 @@ public interface BoostsConfig extends Config
 	{
 		return 0;
 	}
+
+	@ConfigItem(
+		keyName = "groupNotifications",
+		name = "Group Notifications",
+		description = "Configures whether or not to group notifications for multiple skills into a single notification",
+		position = 7
+	)
+	default boolean groupNotifications()
+	{
+		return false;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/boosts/BoostsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/boosts/BoostsPlugin.java
@@ -100,6 +100,8 @@ public class BoostsPlugin extends Plugin
 	private int lastChangeUp = -1;
 	private boolean preserveBeenActive = false;
 	private long lastTickMillis;
+	private int boostedSkillsChanged = 0;
+	private String lastBoostedSkillChanged;
 
 	@Provides
 	BoostsConfig provideConfig(ConfigManager configManager)
@@ -213,7 +215,15 @@ public class BoostsPlugin extends Plugin
 			int boost = cur - real;
 			if (boost <= boostThreshold && boostThreshold < lastBoost)
 			{
-				notifier.notify(skill.getName() + " level is getting low!");
+				if (config.groupNotifications())
+				{
+					boostedSkillsChanged++;
+					lastBoostedSkillChanged = skill.getName();
+				}
+				else
+				{
+					notifier.notify(skill.getName() + " level is getting low!");
+				}
 			}
 		}
 	}
@@ -222,6 +232,20 @@ public class BoostsPlugin extends Plugin
 	public void onGameTick(GameTick event)
 	{
 		lastTickMillis = System.currentTimeMillis();
+
+		if (config.groupNotifications())
+		{
+			if (boostedSkillsChanged == 1)
+			{
+				notifier.notify(lastBoostedSkillChanged + " level is getting low!");
+				boostedSkillsChanged = 0;
+			}
+			else if (boostedSkillsChanged > 1)
+			{
+				notifier.notify("Multiple skills are getting low!");
+				boostedSkillsChanged = 0;
+			}
+		}
 
 		if (getChangeUpTicks() <= 0)
 		{


### PR DESCRIPTION
Besides the chatbox spam the multiple notifications are particularly annoying with the way Windows queues up multiple notifications and sends them to you spaced out over the next half a minute or so.

![image](https://user-images.githubusercontent.com/29353990/56086797-3b80b580-5e56-11e9-8918-9af02bd80ae5.png)