### PR TITLE
Fix Npc Aggression Timer instructions not showing up when plugin is first turned on

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/npcunaggroarea/NpcAggroAreaPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npcunaggroarea/NpcAggroAreaPlugin.java
@@ -141,6 +141,7 @@ public class NpcAggroAreaPlugin extends Plugin
 		overlayManager.add(overlay);
 		overlayManager.add(notWorkingOverlay);
 		npcNamePatterns = NAME_SPLITTER.splitToList(config.npcNamePatterns());
+		recheckActive();
 	}
 
 	@Override


### PR DESCRIPTION
Upon turning on the `NPC Aggression Timer` plugin there should be an overlay informing the user that they need to teleport away or enter a dungeon to make it work. This works correctly upon login, but not if you previously had the plugin turned off and then switch it on while in-game.

This should solve some of the confusion people sometimes have as to why this plugin isn't working for them.

<details><summary>Current: turning on the plugin doesn't show the warning</summary>

![hCKAp3FQXc](https://user-images.githubusercontent.com/29353990/56099814-e30af000-5f09-11e9-8eda-40d02349bcff.gif)
</details>

<details><summary>Fixed: turning on the plugin shows the warning</summary>

![xVrQJKq79e](https://user-images.githubusercontent.com/29353990/56099816-e4d4b380-5f09-11e9-868d-b79726d54b37.gif)
</details>