### PR TITLE
Add sorting to the loot tracker

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootEntrySorting.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootEntrySorting.java
@@ -1,7 +1,30 @@
+/*
+ * Copyright (c) 2019, Eingin <https://github.com/eingin>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package net.runelite.client.plugins.loottracker;
 
 import lombok.Getter;
-
 import java.util.Comparator;
 
 public enum LootEntrySorting
@@ -54,7 +77,6 @@ public enum LootEntrySorting
 
 	@Getter
 	private final Comparator<LootTrackerBox> sorter;
-
 
 	LootEntrySorting(String name, Comparator<LootTrackerBox> sorter)
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootEntrySorting.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootEntrySorting.java
@@ -1,0 +1,70 @@
+package net.runelite.client.plugins.loottracker;
+
+import lombok.Getter;
+
+import java.util.Comparator;
+
+public enum LootEntrySorting
+{
+	FIRST("Most Recent Drop",
+		(LootTrackerBox a, LootTrackerBox b) ->
+		{
+			long aMax = a.getRecords()
+				.stream()
+				.mapToLong(LootTrackerRecord::getTimestamp)
+				.max()
+				.orElse(0);
+
+			long bMax = b.getRecords()
+				.stream()
+				.mapToLong(LootTrackerRecord::getTimestamp)
+				.max()
+				.orElse(0);
+
+			return Long.compare(aMax, bMax);
+		}),
+	LAST("Oldest Drop",
+		(LootTrackerBox a, LootTrackerBox b) ->
+		{
+			long aMax = a.getRecords()
+				.stream()
+				.mapToLong(LootTrackerRecord::getTimestamp)
+				.max()
+				.orElse(0);
+
+			long bMax = b.getRecords()
+				.stream()
+				.mapToLong(LootTrackerRecord::getTimestamp)
+				.max()
+				.orElse(0);
+
+			return Long.compare(bMax, aMax);
+		}),
+	HIGHEST_VALUE("Highest Value",
+		(LootTrackerBox a, LootTrackerBox b) ->
+			Long.compare(a.getTotalPrice(), b.getTotalPrice())
+	),
+	LOWEST_VALUE("Lowest Value",
+		(LootTrackerBox a, LootTrackerBox b) ->
+			Long.compare(b.getTotalPrice(), a.getTotalPrice())
+	);
+
+
+	private final String name;
+
+	@Getter
+	private final Comparator<LootTrackerBox> sorter;
+
+
+	LootEntrySorting(String name, Comparator<LootTrackerBox> sorter)
+	{
+		this.name = name;
+		this.sorter = sorter;
+	}
+
+	@Override
+	public String toString()
+	{
+		return name;
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerBox.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerBox.java
@@ -66,6 +66,7 @@ class LootTrackerBox extends JPanel
 	@Getter
 	private final List<LootTrackerRecord> records = new ArrayList<>();
 
+	@Getter
 	private long totalPrice;
 	private boolean hideIgnoredItems;
 	private BiConsumer<String, Boolean> onItemToggle;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerConfig.java
@@ -50,6 +50,16 @@ public interface LootTrackerConfig extends Config
 	void setIgnoredItems(String key);
 
 	@ConfigItem(
+		keyName = "lootSorting",
+		name = "Loot Sorting",
+		description = "How the entries in the loot tracking panel are sorted."
+	)
+	default LootEntrySorting getLootSorting()
+	{
+		return LootEntrySorting.LAST;
+	}
+
+	@ConfigItem(
 		keyName = "saveLoot",
 		name = "Submit loot tracker data",
 		description = "Submit loot tracker data (requires being logged in)"

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPanel.java
@@ -341,8 +341,7 @@ class LootTrackerPanel extends PluginPanel
 		LootTrackerBox box = buildBox(record);
 		if (box != null)
 		{
-			box.rebuild();
-			updateOverall();
+			rebuild();
 		}
 	}
 
@@ -418,6 +417,14 @@ class LootTrackerPanel extends PluginPanel
 		}
 		boxes.forEach(LootTrackerBox::rebuild);
 		updateOverall();
+		boxes.sort(config.getLootSorting().getSorter());
+		boxes.forEach(box -> {
+			logsContainer.add(box, 0);
+			if (!groupLoot && boxes.size() > MAX_LOOT_BOXES)
+			{
+				logsContainer.remove(boxes.remove(0));
+			}
+		});
 		logsContainer.revalidate();
 		logsContainer.repaint();
 	}
@@ -496,12 +503,6 @@ class LootTrackerPanel extends PluginPanel
 
 		// Add box to panel
 		boxes.add(box);
-		logsContainer.add(box, 0);
-
-		if (!groupLoot && boxes.size() > MAX_LOOT_BOXES)
-		{
-			logsContainer.remove(boxes.remove(0));
-		}
 
 		return box;
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPanel.java
@@ -418,7 +418,8 @@ class LootTrackerPanel extends PluginPanel
 		boxes.forEach(LootTrackerBox::rebuild);
 		updateOverall();
 		boxes.sort(config.getLootSorting().getSorter());
-		boxes.forEach(box -> {
+		boxes.forEach(box ->
+		{
 			logsContainer.add(box, 0);
 			if (!groupLoot && boxes.size() > MAX_LOOT_BOXES)
 			{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
@@ -532,7 +532,7 @@ public class LootTrackerPlugin extends Plugin
 				buildLootTrackerItem(itemStack.getId(), itemStack.getQty())
 			).toArray(LootTrackerItem[]::new);
 
-			trackerRecords.add(new LootTrackerRecord(record.getEventId(), "", drops, -1));
+			trackerRecords.add(new LootTrackerRecord(record.getEventId(), "", drops, record.getTime().toEpochMilli()));
 		}
 
 		return trackerRecords;


### PR DESCRIPTION
Addresses: #8519 

Adds a sorting setting into the loot tracker config that lets users control how the drop group entries are sorted.

Currently supports:
- Most recent drop
- Lest recent drop
- Highest value
- Lowest value

![Config Panel](https://i.imgur.com/ZpA2ewQ.png)