### PR TITLE
Fix client not coming to front on Windows while using "Request focus on notification"

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
@@ -591,6 +591,34 @@ public class ClientUI
 		{
 			OSXUtil.requestFocus();
 		}
+		// The workaround for Windows is to minimise and then un-minimise the client to bring
+		// it to the front because java.awt.Window#toFront doesn't work reliably.
+		// See https://stackoverflow.com/questions/309023/how-to-bring-a-window-to-the-front/7435722#7435722
+		else if (OSType.getOSType() == OSType.Windows && !frame.isFocused())
+		{
+			SwingUtilities.invokeLater(() ->
+			{
+				if ((frame.getExtendedState() & JFrame.MAXIMIZED_BOTH) == JFrame.MAXIMIZED_BOTH)
+				{
+					frame.setExtendedState(JFrame.ICONIFIED);
+					frame.setExtendedState(JFrame.MAXIMIZED_BOTH);
+				}
+				else
+				{
+					// If the client is snapped to the top and bottom edges of the screen, setExtendedState will
+					// will reset it so setSize and setLocation ensure that the client doesn't move or resize.
+					// It is done this way because Windows does not support JFrame.MAXIMIZED_VERT
+					int x = frame.getLocation().x;
+					int y = frame.getLocation().y;
+					int width = frame.getWidth();
+					int height = frame.getHeight();
+					frame.setExtendedState(JFrame.ICONIFIED);
+					frame.setExtendedState(JFrame.NORMAL);
+					frame.setLocation(x, y);
+					frame.setSize(width, height);
+				}
+			});
+		}
 
 		frame.requestFocus();
 		giveClientFocus();


### PR DESCRIPTION
Fixes #2335 

Seeing as #5112 hasn't seen any activity in a while I thought I'd take a look at this one. This solution works on Windows 10.

Tested with and without custom chrome as well as minimised, maximised and with the client always on top option turned on (you can still minimise it when that is on). 

Implements [this workaround](https://stackoverflow.com/questions/309023/how-to-bring-a-window-to-the-front/7435722#7435722) with additional code to avoid resizing the client.