### PR TITLE
Remove duplicate coordinate clue

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java
@@ -182,7 +182,6 @@ public class CoordinateClue extends ClueScroll implements TextClueScroll, Locati
 		.put(new WorldPoint(2934, 2727, 0), "Eastern shore of Crash Island.")
 		.put(new WorldPoint(1451, 3695, 0), "West side of Lizardman Canyon with Lizardman shaman.")
 		.put(new WorldPoint(2538, 3739, 0), "Waterbirth Island.")
-		.put(new WorldPoint(1248, 3751, 0), "Farming Guild.")
 		.put(new WorldPoint(1698, 3792, 0), "Arceuus church.")
 		.put(new WorldPoint(2951, 3820, 0), "Wilderness. Chaos Temple (level 38).")
 		.put(new WorldPoint(2202, 3825, 0), "Pirates' Cove, between Lunar Isle and Rellekka.")


### PR DESCRIPTION
The duplicate entry causes the client to crash when trying to build the ImmutableMap.