### PR TITLE
Add text labels to ground markers

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/groundmarkers/ColorTileMarker.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/groundmarkers/ColorTileMarker.java
@@ -37,4 +37,5 @@ class ColorTileMarker
 {
 	private WorldPoint worldPoint;
 	private Color color;
+	private String label;
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/groundmarkers/GroundMarkerConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/groundmarkers/GroundMarkerConfig.java
@@ -64,4 +64,14 @@ public interface GroundMarkerConfig extends Config
 	{
 		return false;
 	}
+
+    @ConfigItem(
+            keyName = "drawTextLabel",
+            name = "Draw text label on tile",
+            description = "Configures whether to show text label on ground tiles"
+    )
+    default boolean drawTextLabel()
+    {
+        return false;
+    }
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/groundmarkers/GroundMarkerOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/groundmarkers/GroundMarkerOverlay.java
@@ -33,6 +33,7 @@ import java.util.Collection;
 import javax.inject.Inject;
 import net.runelite.api.Client;
 import net.runelite.api.Perspective;
+import net.runelite.api.Point;
 import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.client.ui.overlay.Overlay;
@@ -40,6 +41,7 @@ import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.OverlayPriority;
 import net.runelite.client.ui.overlay.OverlayUtil;
+import net.runelite.client.ui.overlay.components.TextComponent;
 
 public class GroundMarkerOverlay extends Overlay
 {
@@ -48,6 +50,7 @@ public class GroundMarkerOverlay extends Overlay
 	private final Client client;
 	private final GroundMarkerConfig config;
 	private final GroundMarkerPlugin plugin;
+    private final TextComponent textComponent = new TextComponent();
 
 	@Inject
 	private GroundMarkerOverlay(Client client, GroundMarkerConfig config, GroundMarkerPlugin plugin)
@@ -79,13 +82,13 @@ public class GroundMarkerOverlay extends Overlay
 				tileColor = config.markerColor();
 			}
 
-			drawTile(graphics, worldPoint, tileColor);
+			drawTile(graphics, worldPoint, tileColor, point.getLabel());
 		}
 
 		return null;
 	}
 
-	private void drawTile(Graphics2D graphics, WorldPoint point, Color color)
+	private void drawTile(Graphics2D graphics, WorldPoint point, Color color, String label)
 	{
 		WorldPoint playerLocation = client.getLocalPlayer().getWorldLocation();
 
@@ -107,5 +110,21 @@ public class GroundMarkerOverlay extends Overlay
 		}
 
 		OverlayUtil.renderPolygon(graphics, poly, color);
+
+		if (label.isEmpty())
+        {
+           return;
+        }
+
+        final Point textPoint = Perspective.getCanvasTextLocation(client,
+                graphics,
+                lp,
+                label,
+                0);
+
+        textComponent.setText(label);
+        textComponent.setColor(color);
+        textComponent.setPosition(new java.awt.Point(textPoint.getX(), textPoint.getY()));
+        textComponent.render(graphics);
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/groundmarkers/GroundMarkerPoint.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/groundmarkers/GroundMarkerPoint.java
@@ -41,4 +41,5 @@ class GroundMarkerPoint
 	private int regionY;
 	private int z;
 	private Color color;
+	private String label;
 }


### PR DESCRIPTION
This will add text labels to ground markers. They use the same color as the tile markers.

![demo](https://i.imgur.com/gxs4nzR.png)