### PR TITLE
stop overlay methods from triggering off of hidden items

### DIFF
--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSClientMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSClientMixin.java
@@ -1335,7 +1335,7 @@ public abstract class RSClientMixin implements RSClient
 		for (Widget rlWidget : widgets)
 		{
 			RSWidget widget = (RSWidget) rlWidget;
-			if (widget == null || widget.getRSParentId() != parentId)
+			if (widget == null || widget.getRSParentId() != parentId || widget.isSelfHidden())
 			{
 				continue;
 			}


### PR DESCRIPTION
Before:
![before](https://user-images.githubusercontent.com/2979691/56401091-225d7780-624f-11e9-984e-29ebbbaa42a0.png)
After:
![after](https://user-images.githubusercontent.com/2979691/56401145-6486b900-624f-11e9-9f27-f9db71870f33.png)
