### PR TITLE
Fix chat history wrapping

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/chathistory/ChatHistoryPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chathistory/ChatHistoryPlugin.java
@@ -145,8 +145,8 @@ public class ChatHistoryPlugin extends Plugin implements KeyListener
 					.type(chatMessage.getType())
 					.name(chatMessage.getName())
 					.sender(chatMessage.getSender())
-					.value(nbsp(chatMessage.getMessage()))
-					.runeLiteFormattedMessage(nbsp(chatMessage.getMessageNode().getRuneLiteFormatMessage()))
+					.value(tweakSpaces(chatMessage.getMessage()))
+					.runeLiteFormattedMessage(tweakSpaces(chatMessage.getMessageNode().getRuneLiteFormatMessage()))
 					.timestamp(chatMessage.getTimestamp())
 					.build();
 
@@ -177,15 +177,17 @@ public class ChatHistoryPlugin extends Plugin implements KeyListener
 	}
 
 	/**
-	 * Small hack to prevent plugins checking for specific messages to match
+	 * Small hack to prevent plugins checking for specific messages to match. This works because the "—" character
+	 * cannot be seen in-game. This replacement preserves wrapping on chat history messages.
 	 * @param message message
-	 * @return message with nbsp
+	 * @return message with invisible character before every space
 	 */
-	private static String nbsp(final String message)
+	private static String tweakSpaces(final String message)
 	{
 		if (message != null)
 		{
-			return message.replace(' ', '\u00A0');
+			// First replacement cleans up prior applications of this so as not to keep extending the message
+			return message.replace("— ", " ").replace(" ", "— ");
 		}
 
 		return null;


### PR DESCRIPTION
Fixes #1162

The reason that chat history doesn't wrap is because spaces are replaced by non-breaking spaces in order to prevent various plugins that detect chat messages from triggering incorrectly when chat history is replayed.

I've found a way to do this while still preserving wrapping by utilising the fact that "—" does not show up in-game.

<details><summary>Expand for before and after GIFs</summary>

Before
![Before chat history wrapping fix](https://user-images.githubusercontent.com/29353990/56498328-1c8abf00-64f9-11e9-92e3-b8c63f3357d1.gif)

After
![After chat history wrapping fix](https://user-images.githubusercontent.com/29353990/56498331-1dbbec00-64f9-11e9-8939-70f37515d370.gif)

</details>