### PR TITLE
opponentinfo: Option to show both HP value and percentage

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/opponentinfo/HitpointsDisplayStyle.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/opponentinfo/HitpointsDisplayStyle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Jordan Atwood <jordan.atwood423@gmail.com>
+ * Copyright (c) 2019, Sean Dewar <https://github.com/seandewar>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -24,43 +24,9 @@
  */
 package net.runelite.client.plugins.opponentinfo;
 
-import net.runelite.client.config.Config;
-import net.runelite.client.config.ConfigGroup;
-import net.runelite.client.config.ConfigItem;
-
-@ConfigGroup("opponentinfo")
-public interface OpponentInfoConfig extends Config
+public enum HitpointsDisplayStyle
 {
-	@ConfigItem(
-		keyName = "lookupOnInteraction",
-		name = "Lookup players on interaction",
-		description = "Display a combat stat comparison panel on player interaction. (follow, trade, challenge, attack, etc.)",
-		position = 0
-	)
-	default boolean lookupOnInteraction()
-	{
-		return false;
-	}
-
-	@ConfigItem(
-		keyName = "hitpointsDisplayStyle",
-		name = "Hitpoints display style",
-		description = "Show opponent's hitpoints as a value (if known), percentage, or both",
-		position = 1
-	)
-	default HitpointsDisplayStyle hitpointsDisplayStyle()
-	{
-		return HitpointsDisplayStyle.HITPOINTS;
-	}
-
-	@ConfigItem(
-		keyName = "showOpponentsOpponent",
-		name = "Show opponent's opponent",
-		description = "Toggle showing opponent's opponent if within a multi-combat area",
-		position = 2
-	)
-	default boolean showOpponentsOpponent()
-	{
-		return true;
-	}
+	HITPOINTS,
+	PERCENTAGE,
+	BOTH;
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/opponentinfo/OpponentInfoOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/opponentinfo/OpponentInfoOverlay.java
@@ -164,7 +164,10 @@ class OpponentInfoOverlay extends Overlay
 			progressBarComponent.setBackgroundColor(HP_RED);
 			progressBarComponent.setForegroundColor(HP_GREEN);
 
-			if (lastMaxHealth != null && !opponentInfoConfig.showPercent())
+			final HitpointsDisplayStyle displayStyle = opponentInfoConfig.hitpointsDisplayStyle();
+
+			if ((displayStyle == HitpointsDisplayStyle.HITPOINTS || displayStyle == HitpointsDisplayStyle.BOTH)
+				&& lastMaxHealth != null)
 			{
 				// This is the reverse of the calculation of healthRatio done by the server
 				// which is: healthRatio = 1 + (healthScale - 1) * health / maxHealth (if health > 0, 0 otherwise)
@@ -194,11 +197,15 @@ class OpponentInfoOverlay extends Overlay
 						// so we know nothing about the upper limit except that it can't be higher than maxHealth
 						maxHealth = lastMaxHealth;
 					}
-					// Take the average of min and max possible healts
+					// Take the average of min and max possible healths
 					health = (minHealth + maxHealth + 1) / 2;
 				}
 
-				progressBarComponent.setLabelDisplayMode(ProgressBarComponent.LabelDisplayMode.FULL);
+				// Show both the hitpoint and percentage values if enabled in the config
+				final ProgressBarComponent.LabelDisplayMode progressBarDisplayMode = displayStyle == HitpointsDisplayStyle.BOTH ?
+					ProgressBarComponent.LabelDisplayMode.BOTH : ProgressBarComponent.LabelDisplayMode.FULL;
+
+				progressBarComponent.setLabelDisplayMode(progressBarDisplayMode);
 				progressBarComponent.setMaximum(lastMaxHealth);
 				progressBarComponent.setValue(health);
 			}

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/components/ProgressBarComponent.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/components/ProgressBarComponent.java
@@ -40,7 +40,8 @@ public class ProgressBarComponent implements LayoutableRenderableEntity
 	public enum LabelDisplayMode
 	{
 		PERCENTAGE,
-		FULL
+		FULL,
+		BOTH
 	}
 
 	private static final DecimalFormat DECIMAL_FORMAT = new DecimalFormat("0.0");
@@ -79,10 +80,13 @@ public class ProgressBarComponent implements LayoutableRenderableEntity
 		switch (labelDisplayMode)
 		{
 			case PERCENTAGE:
-				textToWrite = DECIMAL_FORMAT.format(pc * 100d) + "%";
+				textToWrite = formatPercentageProgress(pc);
+				break;
+			case BOTH:
+				textToWrite = formatFullProgress(currentValue, maximum) + " (" + formatPercentageProgress(pc) + ")";
 				break;
 			default:
-				textToWrite = DECIMAL_FORMAT_ABS.format(Math.floor(currentValue)) + "/" + maximum;
+				textToWrite = formatFullProgress(currentValue, maximum);
 		}
 
 		final int width = preferredSize.width;
@@ -125,5 +129,15 @@ public class ProgressBarComponent implements LayoutableRenderableEntity
 		bounds.setLocation(preferredLocation);
 		bounds.setSize(dimension);
 		return dimension;
+	}
+
+	private static String formatFullProgress(double current, long maximum)
+	{
+		return DECIMAL_FORMAT_ABS.format(Math.floor(current)) + "/" + maximum;
+	}
+
+	private static String formatPercentageProgress(double ratio)
+	{
+		return DECIMAL_FORMAT.format(ratio * 100d) + "%";
 	}
 }


### PR DESCRIPTION
A simple and maybe niche feature -- but I've sometimes found it useful to see both the opponent's HP and HP percentage (as a number):

![Healthbar](https://i.imgur.com/K9J8oBq.png)

Currently, you can only see either the approx. HP value (if max HP is known) **_or_** the raw percentage. 

With this proposed _Both_ option, the percentage from the approx. health over max health ratio is shown too.

![Config](https://i.imgur.com/gB3fS3z.png)

This PR slightly changes the `ProgressBarComponent` to allow both its current value and percentage to be shown if wanted.

There should be enough room to display up to 9999 HP with the _Both_ setting without the label escaping the bounds of the panel by default, I think.
