### PR TITLE
Add Herbiboar support to the Loottracker

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
@@ -99,6 +99,10 @@ public class LootTrackerPlugin extends Plugin
 	private static final Pattern CLUE_SCROLL_PATTERN = Pattern.compile("You have completed [0-9]+ ([a-z]+) Treasure Trails.");
 	private static final int THEATRE_OF_BLOOD_REGION = 12867;
 
+	// Herbiboar loot handling
+	private static final String HERBIBOAR_LOOTED_MESSAGE = "You harvest herbs from the herbiboar, whereupon it escapes";
+	private static final String HERBIBOAR_TRACKING_MESSAGE = "Something has passed this way.";
+
 	// Chest loot handling
 	private static final String CHEST_LOOTED_MESSAGE = "You find some treasure in the chest!";
 	private static final Map<Integer, String> CHEST_EVENT_TYPES = ImmutableMap.of(
@@ -389,14 +393,15 @@ public class LootTrackerPlugin extends Plugin
 			}
 
 			eventType = CHEST_EVENT_TYPES.get(regionID);
+			takeInventorySnapshot();
 
-			final ItemContainer itemContainer = client.getItemContainer(InventoryID.INVENTORY);
-			if (itemContainer != null)
-			{
-				inventorySnapshot = HashMultiset.create();
-				Arrays.stream(itemContainer.getItems())
-						.forEach(item -> inventorySnapshot.add(item.getId(), item.getQuantity()));
-			}
+			return;
+		}
+
+		if (message.equals(HERBIBOAR_LOOTED_MESSAGE) || message.contains(HERBIBOAR_TRACKING_MESSAGE))
+		{
+			eventType = "Herbiboar";
+			takeInventorySnapshot();
 
 			return;
 		}
@@ -433,7 +438,7 @@ public class LootTrackerPlugin extends Plugin
 	@Subscribe
 	public void onItemContainerChanged(ItemContainerChanged event)
 	{
-		if (eventType != null && CHEST_EVENT_TYPES.containsValue(eventType))
+		if (eventType != null && (CHEST_EVENT_TYPES.containsValue(eventType) || eventType.equals("Herbiboar")))
 		{
 			if (event.getItemContainer() != client.getItemContainer(InventoryID.INVENTORY))
 			{
@@ -442,6 +447,17 @@ public class LootTrackerPlugin extends Plugin
 
 			processChestLoot(eventType, event.getItemContainer());
 			eventType = null;
+		}
+	}
+
+	private void takeInventorySnapshot()
+	{
+		final ItemContainer itemContainer = client.getItemContainer(InventoryID.INVENTORY);
+		if (itemContainer != null)
+		{
+			inventorySnapshot = HashMultiset.create();
+			Arrays.stream(itemContainer.getItems())
+					.forEach(item -> inventorySnapshot.add(item.getId(), item.getQuantity()));
 		}
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
@@ -100,8 +100,8 @@ public class LootTrackerPlugin extends Plugin
 	private static final int THEATRE_OF_BLOOD_REGION = 12867;
 
 	// Herbiboar loot handling
-	private static final String HERBIBOAR_LOOTED_MESSAGE = "You harvest herbs from the herbiboar, whereupon it escapes";
-	private static final String HERBIBOAR_TRACKING_MESSAGE = "Something has passed this way.";
+	private static final String HERBIBOAR_LOOTED_MESSAGE = "You harvest herbs from the herbiboar, whereupon it escapes.";
+	private static final String HERBIBOR_EVENT = "Herbiboar";
 
 	// Chest loot handling
 	private static final String CHEST_LOOTED_MESSAGE = "You find some treasure in the chest!";
@@ -398,9 +398,9 @@ public class LootTrackerPlugin extends Plugin
 			return;
 		}
 
-		if (message.equals(HERBIBOAR_LOOTED_MESSAGE) || message.contains(HERBIBOAR_TRACKING_MESSAGE))
+		if (message.equals(HERBIBOAR_LOOTED_MESSAGE))
 		{
-			eventType = "Herbiboar";
+			eventType = HERBIBOR_EVENT;
 			takeInventorySnapshot();
 
 			return;
@@ -438,7 +438,7 @@ public class LootTrackerPlugin extends Plugin
 	@Subscribe
 	public void onItemContainerChanged(ItemContainerChanged event)
 	{
-		if (eventType != null && (CHEST_EVENT_TYPES.containsValue(eventType) || eventType.equals("Herbiboar")))
+		if (eventType != null && (CHEST_EVENT_TYPES.containsValue(eventType) || HERBIBOR_EVENT.equals(eventType)))
 		{
 			if (event.getItemContainer() != client.getItemContainer(InventoryID.INVENTORY))
 			{


### PR DESCRIPTION
Figured Herbiboar deserved a spot in the loot tracker. The code already there to process chest loot fit Herbiboar pretty well so I moved some of it around as to be more general purpose.
![herbiboar](https://user-images.githubusercontent.com/16238069/56844666-fb6ff880-6881-11e9-85b2-926a73888774.png)

Closes #6136
