### PR TITLE
Use xenial in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 sudo: false
-dist: trusty
+dist: xenial
 cache:
   directories:
     - $HOME/.m2

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ cache:
   directories:
     - $HOME/.m2
 jdk:
-- oraclejdk8
+- openjdk8
 - openjdk11
 install: true
 script: ./travis/build.sh


### PR DESCRIPTION
trusty is going EOL at end of this month and this also fixes openjdk11
builds.

Ref: https://travis-ci.community/t/oracle-jdk11-build-error/1865/6

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>