### PR TITLE
Pin Runelite plugin by default

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
@@ -650,7 +650,7 @@ public class ConfigPanel extends PluginPanel
 
 		if (config == null)
 		{
-			return Collections.emptyList();
+			return Collections.singletonList(RUNELITE_PLUGIN);
 		}
 
 		return Text.fromCSV(config);


### PR DESCRIPTION
Resolves #6256

![noConfig](https://user-images.githubusercontent.com/1836570/56858893-114bef00-6950-11e9-8da1-f66eddf7545f.png)

This only effects new users without a config CSV.