### PR TITLE
Use proxy methods for setting cursor via ClientUI

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/customcursor/CustomCursorPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/customcursor/CustomCursorPlugin.java
@@ -25,11 +25,7 @@
 package net.runelite.client.plugins.customcursor;
 
 import com.google.inject.Provides;
-import java.awt.Cursor;
-import java.awt.Point;
-import java.awt.Toolkit;
 import javax.inject.Inject;
-import javax.swing.JPanel;
 import net.runelite.api.events.ConfigChanged;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
@@ -65,7 +61,7 @@ public class CustomCursorPlugin extends Plugin
 	@Override
 	protected void shutDown()
 	{
-		clientUI.getContainer().setCursor(Cursor.getDefaultCursor());
+		clientUI.resetCursor();
 	}
 
 	@Subscribe
@@ -79,11 +75,7 @@ public class CustomCursorPlugin extends Plugin
 
 	private void updateCursor()
 	{
-		JPanel container = clientUI.getContainer();
 		CustomCursor selectedCursor = config.selectedCursor();
-
-		Cursor cursor = Toolkit.getDefaultToolkit().createCustomCursor(selectedCursor.getCursorImage(),
-			new Point(container.getX(), container.getY()), selectedCursor.toString());
-		container.setCursor(cursor);
+		clientUI.setCursor(selectedCursor.getCursorImage(), selectedCursor.toString());
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
@@ -37,6 +37,7 @@ import java.awt.Graphics2D;
 import java.awt.GraphicsConfiguration;
 import java.awt.LayoutManager;
 import java.awt.Rectangle;
+import java.awt.Toolkit;
 import java.awt.TrayIcon;
 import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
@@ -110,9 +111,6 @@ public class ClientUI
 	@Getter
 	private TrayIcon trayIcon;
 
-	@Getter
-	private JPanel container;
-
 	private final RuneLiteProperties properties;
 	private final RuneLiteConfig config;
 	private final KeyManager keyManager;
@@ -133,6 +131,7 @@ public class ClientUI
 	private JButton currentButton;
 	private NavigationButton currentNavButton;
 	private boolean sidebarOpen;
+	private JPanel container;
 	private NavigationButton sidebarNavigationButton;
 	private JButton sidebarNavigationJButton;
 	private Dimension lastClientSize;
@@ -601,6 +600,38 @@ public class ClientUI
 
 		frame.requestFocus();
 		giveClientFocus();
+	}
+
+	/**
+	 * Changes cursor for client window. Requires ${@link ClientUI#open(RuneLite)} to be called first.
+	 * FIXME: This is working properly only on Windows, Linux and Mac are displaying cursor incorrectly
+	 * @param image cursor image
+	 * @param name cursor name
+	 */
+	public void setCursor(final BufferedImage image, final String name)
+	{
+		if (container == null)
+		{
+			return;
+		}
+
+		final java.awt.Point hotspot = new java.awt.Point(container.getX(), container.getY());
+		final Cursor cursorAwt = Toolkit.getDefaultToolkit().createCustomCursor(image, hotspot, name);
+		container.setCursor(cursorAwt);
+	}
+
+	/**
+	 * Resets client window cursor to default one.
+	 * @see ClientUI#setCursor(BufferedImage, String)
+	 */
+	public void resetCursor()
+	{
+		if (container == null)
+		{
+			return;
+		}
+
+		container.setCursor(Cursor.getDefaultCursor());
 	}
 
 	/**


### PR DESCRIPTION
To not expose swing components directly just to set cursor on them,
create convenient proxy methods for updating and resetting cursor. Also
document that it is working properly only on Windows.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>