### PR TITLE
fix bronze dart requirement in skillcalculator

### DIFF
--- a/runelite-client/src/main/resources/net/runelite/client/plugins/skillcalculator/skill_fletching.json
+++ b/runelite-client/src/main/resources/net/runelite/client/plugins/skillcalculator/skill_fletching.json
@@ -19,12 +19,6 @@
       "xp": 1.3
     },
     {
-      "level": 1,
-      "icon": 806,
-      "name": "Bronze Dart",
-      "xp": 1.8
-    },
-    {
       "level": 5,
       "icon": 2866,
       "name": "Ogre Arrow",
@@ -65,6 +59,12 @@
       "icon": 9174,
       "name": "Bronze Crossbow",
       "xp": 6
+    },
+    {
+      "level": 10,
+      "icon": 806,
+      "name": "Bronze Dart",
+      "xp": 1.8
     },
     {
       "level": 10,


### PR DESCRIPTION
Fix bronze dart in skillcalculator to be the correct level requirement