### PR TITLE
Aggro area: only add a timer if the time left isn't negative

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/npcunaggroarea/NpcAggroAreaPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npcunaggroarea/NpcAggroAreaPlugin.java
@@ -394,7 +394,7 @@ public class NpcAggroAreaPlugin extends Plugin
 		lastPlayerLocation = configManager.getConfiguration(NpcAggroAreaConfig.CONFIG_GROUP, NpcAggroAreaConfig.CONFIG_LOCATION, WorldPoint.class);
 
 		Duration timeLeft = configManager.getConfiguration(NpcAggroAreaConfig.CONFIG_GROUP, NpcAggroAreaConfig.CONFIG_DURATION, Duration.class);
-		if (timeLeft != null)
+		if (timeLeft != null && !timeLeft.isNegative())
 		{
 			createTimer(timeLeft);
 		}


### PR DESCRIPTION
Fixes `java.lang.IllegalArgumentException: negative period!` when logging in if the monsters in the area you are aren't aggro'd to you anymore.