### PR TITLE
Upgrade git commit id plugin from 2.2.5 to 2.2.6

### DIFF
--- a/http-api/pom.xml
+++ b/http-api/pom.xml
@@ -95,7 +95,7 @@
 			<plugin>
 				<groupId>pl.project13.maven</groupId>
 				<artifactId>git-commit-id-plugin</artifactId>
-				<version>2.2.5</version>
+				<version>2.2.6</version>
 				<executions>
 					<execution>
 						<id>query-git-info</id>


### PR DESCRIPTION
Security update for [CVE-2018-19360](https://nvd.nist.gov/vuln/detail/CVE-2018-19360), [CVE-2018-19361](https://nvd.nist.gov/vuln/detail/CVE-2018-19361) and [CVE-2018-19362](https://nvd.nist.gov/vuln/detail/CVE-2018-19362)
[2.2.6](https://github.com/git-commit-id/maven-git-commit-id-plugin/releases/tag/v2.2.6) upgrades the jackson-databind dependency which resolves a potential security issue.

Jackson-databind security issue can be found [here](https://github.com/FasterXML/jackson-databind/issues/2186).