### PR TITLE
Show loss rate of ammo

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/ammo/AmmoCounter.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/ammo/AmmoCounter.java
@@ -25,22 +25,35 @@
 package net.runelite.client.plugins.ammo;
 
 import java.awt.image.BufferedImage;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.Temporal;
+
 import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.ui.overlay.infobox.Counter;
 import net.runelite.client.util.StackFormatter;
 
+@Slf4j
 class AmmoCounter extends Counter
 {
 	@Getter
-	private final int itemID;
-	private final String name;
+	private int itemID;
+	private String name;
+	private int total;
+	private Instant time;
 
 	AmmoCounter(Plugin plugin, int itemID, int count, String name, BufferedImage image)
 	{
 		super(image, plugin, count);
+		this.total = count;
 		this.itemID = itemID;
 		this.name = name;
+		this.time = Instant.now();
 	}
 
 	@Override
@@ -52,6 +65,15 @@ class AmmoCounter extends Counter
 	@Override
 	public String getTooltip()
 	{
-		return name;
+		return String.format("%s</br>Loss Rate: %s/h", name, lossRate());
+	}
+
+	int lossRate() {
+		BigDecimal diff = BigDecimal.valueOf(total).subtract(BigDecimal.valueOf(getCount()));
+		BigDecimal timeSinceStart = BigDecimal.valueOf(Duration.between(time, Instant.now()).getSeconds())
+				.setScale(6, RoundingMode.UP);
+		BigDecimal timeSinceStartInHours = timeSinceStart.divide(BigDecimal.valueOf(3600), RoundingMode.UP);
+		BigDecimal ammoPerHour = diff.divide(timeSinceStartInHours, RoundingMode.HALF_UP);
+		return ammoPerHour.intValue();
 	}
 }


### PR DESCRIPTION
Whilst training it's useful to know how much ammo per time unit you're
losing. This can help predict how much ammo needs to be bought for
training.