### PR TITLE
Added range to NPC Indicator

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsConfig.java
@@ -107,4 +107,14 @@ public interface NpcIndicatorsConfig extends Config
 	{
 		return false;
 	}
+	
+	@ConfigItem(
+		position = 7,
+		keyName = "drawDistance",
+		name = "Monster Render Distance",
+		description = "The distance that monsters will be highlighted up to.")
+	default int drawDistance()
+	{
+		return 3;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcMinimapOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcMinimapOverlay.java
@@ -56,9 +56,12 @@ public class NpcMinimapOverlay extends Overlay
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
+		
 		for (NPC npc : plugin.getHighlightedNpcs())
 		{
-			renderNpcOverlay(graphics, npc, npc.getName(), config.getHighlightColor());
+			if ((int) Math.hypot(client.getLocalPlayer().getWorldLocation().getX() - npc.getWorldLocation().getX(), client.getLocalPlayer().getWorldLocation().getY() - npc.getWorldLocation().getY()) < config.drawDistance()){
+				renderNpcOverlay(graphics, npc, npc.getName(), config.getHighlightColor());
+			}
 		}
 
 		return null;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcSceneOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcSceneOverlay.java
@@ -88,7 +88,9 @@ public class NpcSceneOverlay extends Overlay
 
 		for (NPC npc : plugin.getHighlightedNpcs())
 		{
-			renderNpcOverlay(graphics, npc, config.getHighlightColor());
+			if ((int) Math.hypot(client.getLocalPlayer().getWorldLocation().getX() - npc.getWorldLocation().getX(), client.getLocalPlayer().getWorldLocation().getY() - npc.getWorldLocation().getY()) < config.drawDistance()){
+				renderNpcOverlay(graphics, npc, config.getHighlightColor());
+			}
 		}
 
 		return null;


### PR DESCRIPTION
Given user option to edit the range the monsters will be highlighted to instead of the constant 15.

Works on both minimap and screen rendering.

![](https://i.imgur.com/QnRpUOp.gif)
