### PR TITLE
menyentryswapper: Add ability to swap Castle Wars teleport to default on equipped rings of dueling

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -253,6 +253,16 @@ public interface MenuEntrySwapperConfig extends Config
 	}
 
 	@ConfigItem(
+			keyName = "swapCastleWars",
+			name = "Castle Wars",
+			description = "Swap Remove with Castle Wars teleport on an equipped Ring of dueling"
+	)
+	default boolean swapCastleWars()
+	{
+		return false;
+	}
+
+	@ConfigItem(
 		keyName = "swapAbyssTeleport",
 		name = "Teleport to Abyss",
 		description = "Swap Talk-to with Teleport for the Mage of Zamorak"

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -559,6 +559,10 @@ public class MenuEntrySwapperPlugin extends Plugin
 			swap("rub", option, target, true);
 			swap("teleport", option, target, true);
 		}
+		else if (config.swapCastleWars() && target.contains("ring of dueling") && option.equals("remove"))
+		{
+			swap("castle wars", option, target, true);
+		}
 		else if (option.equals("wield"))
 		{
 			if (config.swapTeleportItem())


### PR DESCRIPTION
![cwars](https://user-images.githubusercontent.com/16238069/57170155-e2fb6300-6dd8-11e9-8531-1d826d6279cd.png)

Pretty useful for most skills that require banking. Default config is off.