### PR TITLE
Add barrows prayer drain timer

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/barrows/BarrowsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/barrows/BarrowsConfig.java
@@ -97,4 +97,15 @@ public interface BarrowsConfig extends Config
 	{
 		return true;
 	}
+
+	@ConfigItem(
+		keyName = "showPrayerDrainTimer",
+		name = "Show Prayer Drain Timer",
+		description = "Configure whether or not a countdown until the next prayer drain is displayed",
+		position = 6
+	)
+	default boolean showPrayerDrainTimer()
+	{
+		return true;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/barrows/BarrowsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/barrows/BarrowsPlugin.java
@@ -42,6 +42,7 @@ import net.runelite.api.ItemContainer;
 import net.runelite.api.NullObjectID;
 import net.runelite.api.ObjectID;
 import net.runelite.api.WallObject;
+import net.runelite.api.events.ConfigChanged;
 import net.runelite.api.events.GameObjectChanged;
 import net.runelite.api.events.GameObjectDespawned;
 import net.runelite.api.events.GameObjectSpawned;
@@ -60,9 +61,11 @@ import net.runelite.client.chat.QueuedMessage;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.game.ItemManager;
+import net.runelite.client.game.SpriteManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.OverlayManager;
+import net.runelite.client.ui.overlay.infobox.InfoBoxManager;
 import net.runelite.client.util.StackFormatter;
 
 @PluginDescriptor(
@@ -89,11 +92,15 @@ public class BarrowsPlugin extends Plugin
 		WidgetInfo.BARROWS_PUZZLE_ANSWER3
 	);
 
+	private static final int CRYPT_REGION_ID = 14231;
+
 	@Getter(AccessLevel.PACKAGE)
 	private final Set<WallObject> walls = new HashSet<>();
 
 	@Getter(AccessLevel.PACKAGE)
 	private final Set<GameObject> ladders = new HashSet<>();
+
+	private boolean wasInCrypt = false;
 
 	@Getter
 	private Widget puzzleAnswer;
@@ -112,6 +119,12 @@ public class BarrowsPlugin extends Plugin
 
 	@Inject
 	private ItemManager itemManager;
+
+	@Inject
+	private SpriteManager spriteManager;
+
+	@Inject
+	private InfoBoxManager infoBoxManager;
 
 	@Inject
 	private ChatMessageManager chatMessageManager;
@@ -140,6 +153,8 @@ public class BarrowsPlugin extends Plugin
 		walls.clear();
 		ladders.clear();
 		puzzleAnswer = null;
+		wasInCrypt = false;
+		stopPrayerDrainTimer();
 
 		// Restore widgets
 		final Widget potential = client.getWidget(WidgetInfo.BARROWS_POTENTIAL);
@@ -152,6 +167,15 @@ public class BarrowsPlugin extends Plugin
 		if (barrowsBrothers != null)
 		{
 			barrowsBrothers.setHidden(false);
+		}
+	}
+
+	@Subscribe
+	public void onConfigChanged(ConfigChanged event)
+	{
+		if (event.getGroup().equals("barrows") && !config.showPrayerDrainTimer())
+		{
+			stopPrayerDrainTimer();
 		}
 	}
 
@@ -220,10 +244,23 @@ public class BarrowsPlugin extends Plugin
 	{
 		if (event.getGameState() == GameState.LOADING)
 		{
+			wasInCrypt = isInCrypt();
 			// on region changes the tiles get set to null
 			walls.clear();
 			ladders.clear();
 			puzzleAnswer = null;
+		}
+		else if (event.getGameState() == GameState.LOGGED_IN)
+		{
+			boolean isInCrypt = isInCrypt();
+			if (wasInCrypt && !isInCrypt)
+			{
+				stopPrayerDrainTimer();
+			}
+			else if (!wasInCrypt && isInCrypt)
+			{
+				startPrayerDrainTimer();
+			}
 		}
 	}
 
@@ -270,5 +307,23 @@ public class BarrowsPlugin extends Plugin
 				}
 			}
 		}
+	}
+
+	private void startPrayerDrainTimer()
+	{
+		if (config.showPrayerDrainTimer())
+		{
+			infoBoxManager.addInfoBox(new BarrowsPrayerDrainTimer(this, spriteManager));
+		}
+	}
+
+	private void stopPrayerDrainTimer()
+	{
+		infoBoxManager.removeIf(BarrowsPrayerDrainTimer.class::isInstance);
+	}
+
+	private boolean isInCrypt()
+	{
+		return client.getLocalPlayer().getWorldLocation().getRegionID() == CRYPT_REGION_ID;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/barrows/BarrowsPrayerDrainTimer.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/barrows/BarrowsPrayerDrainTimer.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2019, Ryan <progrs.site@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.barrows;
+
+import java.awt.Color;
+import java.time.Duration;
+import java.time.Instant;
+import net.runelite.api.SpriteID;
+import net.runelite.client.game.SpriteManager;
+import net.runelite.client.ui.overlay.infobox.InfoBox;
+import net.runelite.client.ui.overlay.infobox.InfoBoxPriority;
+
+class BarrowsPrayerDrainTimer extends InfoBox
+{
+	private static final long PRAYER_DRAIN_INTERVAL_MS = 18200;
+
+	private final Instant startTime;
+
+	BarrowsPrayerDrainTimer(BarrowsPlugin plugin, SpriteManager spriteManager)
+	{
+		super(spriteManager.getSprite(SpriteID.TAB_PRAYER, 0), plugin);
+		setPriority(InfoBoxPriority.MED);
+		setTooltip("Prayer Drain");
+		startTime = Instant.now();
+	}
+
+	@Override
+	public String getText()
+	{
+		Duration timeLeft = Duration.between(Instant.now(), getNextPrayerDrainTime());
+		int seconds = (int) (timeLeft.toMillis() / 1000L);
+		return String.format("0:%02d", seconds);
+	}
+
+	@Override
+	public Color getTextColor()
+	{
+		Duration timeLeft = Duration.between(Instant.now(), getNextPrayerDrainTime());
+
+		//check if timer has 10% of time left
+		if (timeLeft.getSeconds() < (PRAYER_DRAIN_INTERVAL_MS / 1000 * .10))
+		{
+			return Color.RED.brighter();
+		}
+
+		return Color.WHITE;
+	}
+
+	private Instant getNextPrayerDrainTime()
+	{
+		Duration timePassed = Duration.between(startTime, Instant.now());
+		// Get how many intervals have passed so far and add one more to find the next prayer drain time
+		return startTime.plusMillis((timePassed.toMillis() / PRAYER_DRAIN_INTERVAL_MS + 1) * PRAYER_DRAIN_INTERVAL_MS);
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/runelite/runelite/issues/2134

This adds a timer that has a duration of 18.2 seconds and only appears inside Barrows crypts or tunnels. I've tested all situations of being in a crypt and then going into a tunnel, being in a crypt/tunnel and logging out, and dying in Barrows. It's my first PR so please point out any mistakes I made! Really hoping this can be in the next release. I've found it quite useful :)

![238f546d2eb62ddd370a2ffca5aaf0a1](https://user-images.githubusercontent.com/9620289/57171422-3de58800-6de2-11e9-859f-36b62927c714.gif)

