### PR TITLE
IconTextField: make mouse listener affect the whole area

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ui/components/FlatTextField.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/components/FlatTextField.java
@@ -31,6 +31,7 @@ import java.awt.event.ActionListener;
 import java.awt.event.KeyListener;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
+import java.awt.event.MouseListener;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
 import javax.swing.border.EmptyBorder;
@@ -108,6 +109,18 @@ public class FlatTextField extends JPanel
 	public void setText(String text)
 	{
 		textField.setText(text);
+	}
+
+	@Override
+	public void addMouseListener(MouseListener mouseListener)
+	{
+		textField.addMouseListener(mouseListener);
+	}
+
+	@Override
+	public void removeMouseListener(MouseListener mouseListener)
+	{
+		textField.removeMouseListener(mouseListener);
 	}
 
 	@Override

--- a/runelite-client/src/main/java/net/runelite/client/ui/components/IconTextField.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/components/IconTextField.java
@@ -169,6 +169,20 @@ public class IconTextField extends JPanel
 		add(clearButton, BorderLayout.EAST);
 	}
 
+	@Override
+	public void addMouseListener(MouseListener mouseListener)
+	{
+		super.addMouseListener(mouseListener);
+		textField.addMouseListener(mouseListener);
+	}
+
+	@Override
+	public void removeMouseListener(MouseListener mouseListener)
+	{
+		super.removeMouseListener(mouseListener);
+		textField.removeMouseListener(mouseListener);
+	}
+
 	public void addActionListener(ActionListener actionListener)
 	{
 		textField.addActionListener(actionListener);


### PR DESCRIPTION
I was looking into adding doubling clicking the search bar in the hiscore panel to lookup the local player like OSB used to have. I never realized we already had this because right now it only works if you double click the picture section of the search bar which is a low percent of the total area. This lets you also double click the textbox part of the search bar.