### PR TITLE
Menu Entry Swapper: Add 'Search' swap

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -243,6 +243,16 @@ public interface MenuEntrySwapperConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "swapSearch",
+		name = "Search",
+		description = "Swap Close, Shut with Search on chests, cupboards, etc."
+	)
+	default boolean swapSearch()
+	{
+		return true;
+	}
+
+	@ConfigItem(
 		keyName = "swapTeleportItem",
 		name = "Teleport item",
 		description = "Swap Wear, Wield with Rub, Teleport on teleport item<br>Example: Amulet of glory, Explorer's ring, Chronicle"

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -544,6 +544,10 @@ public class MenuEntrySwapperPlugin extends Plugin
 		{
 			swap("pick-lots", option, target, true);
 		}
+		else if (config.swapSearch() && (option.equals("close") || option.equals("shut")))
+		{
+			swap("search", option, target, true);
+		}
 		else if (config.shiftClickCustomization() && shiftModifier && !option.equals("use"))
 		{
 			Integer customOption = getSwapConfig(eventId);


### PR DESCRIPTION
To fix the regular annoyance of opening something, closing it by accident, opening it again, then having to right click and select search