### PR TITLE
Fix bug where !lvl command displays -1 for rank

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
@@ -696,9 +696,21 @@ public class ChatCommandsPlugin extends Plugin
 				.append(String.format("%,d", hiscoreSkill.getExperience()))
 				.append(ChatColorType.NORMAL)
 				.append(" Rank: ")
-				.append(ChatColorType.HIGHLIGHT)
+				.append(ChatColorType.HIGHLIGHT);
+			/**
+			  * Ensures that we don't print -1 for the rank of the player, and print unranked instead.
+			 **/
+			if(highscoreSkill.getRank() == -1) {
+				response.append("Unranked");
+			}
+			else {
+				response.append(String.format("%,d", hiscoreSkill.getRank()))
+			}
+			response.build();
+
+				/**.append(ChatColorType.HIGHLIGHT)
 				.append(String.format("%,d", hiscoreSkill.getRank()))
-				.build();
+				.build();**/
 
 			log.debug("Setting response {}", response);
 			final MessageNode messageNode = chatMessage.getMessageNode();


### PR DESCRIPTION
The chat command !lvl displays -1 for the rank if the player has no experience. This update fixes that and display "unranked" instead of -1.