### PR TITLE
Add seed vault inventory to widget item overlays

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/widgets/WidgetID.java
+++ b/runelite-api/src/main/java/net/runelite/api/widgets/WidgetID.java
@@ -133,7 +133,7 @@ public class WidgetID
 	public static final int BARROWS_PUZZLE_GROUP_ID = 25;
 	public static final int KEPT_ON_DEATH_GROUP_ID = 4;
 	public static final int GUIDE_PRICE_GROUP_ID = 464;
-	public static final int SEED_VAULT_GROUP_ID = 630;
+	public static final int SEED_VAULT_INVENTORY_GROUP_ID = 630;
 
 	static class WorldMap
 	{

--- a/runelite-api/src/main/java/net/runelite/api/widgets/WidgetID.java
+++ b/runelite-api/src/main/java/net/runelite/api/widgets/WidgetID.java
@@ -133,6 +133,7 @@ public class WidgetID
 	public static final int BARROWS_PUZZLE_GROUP_ID = 25;
 	public static final int KEPT_ON_DEATH_GROUP_ID = 4;
 	public static final int GUIDE_PRICE_GROUP_ID = 464;
+	public static final int SEED_VAULT_GROUP_ID = 630;
 
 	static class WorldMap
 	{

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/WidgetItemOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/WidgetItemOverlay.java
@@ -41,6 +41,7 @@ import static net.runelite.api.widgets.WidgetID.EQUIPMENT_INVENTORY_GROUP_ID;
 import static net.runelite.api.widgets.WidgetID.GRAND_EXCHANGE_INVENTORY_GROUP_ID;
 import static net.runelite.api.widgets.WidgetID.GUIDE_PRICES_INVENTORY_GROUP_ID;
 import static net.runelite.api.widgets.WidgetID.INVENTORY_GROUP_ID;
+import static net.runelite.api.widgets.WidgetID.SEED_VAULT_GROUP_ID;
 import static net.runelite.api.widgets.WidgetID.SHOP_INVENTORY_GROUP_ID;
 import static net.runelite.api.widgets.WidgetInfo.TO_GROUP;
 import net.runelite.api.widgets.WidgetItem;
@@ -92,7 +93,8 @@ public abstract class WidgetItemOverlay extends Overlay
 			GRAND_EXCHANGE_INVENTORY_GROUP_ID,
 			GUIDE_PRICES_INVENTORY_GROUP_ID,
 			EQUIPMENT_INVENTORY_GROUP_ID,
-			INVENTORY_GROUP_ID);
+			INVENTORY_GROUP_ID,
+			SEED_VAULT_GROUP_ID);
 	}
 
 	protected void showOnBank()

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/WidgetItemOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/WidgetItemOverlay.java
@@ -41,7 +41,7 @@ import static net.runelite.api.widgets.WidgetID.EQUIPMENT_INVENTORY_GROUP_ID;
 import static net.runelite.api.widgets.WidgetID.GRAND_EXCHANGE_INVENTORY_GROUP_ID;
 import static net.runelite.api.widgets.WidgetID.GUIDE_PRICES_INVENTORY_GROUP_ID;
 import static net.runelite.api.widgets.WidgetID.INVENTORY_GROUP_ID;
-import static net.runelite.api.widgets.WidgetID.SEED_VAULT_GROUP_ID;
+import static net.runelite.api.widgets.WidgetID.SEED_VAULT_INVENTORY_GROUP_ID;
 import static net.runelite.api.widgets.WidgetID.SHOP_INVENTORY_GROUP_ID;
 import static net.runelite.api.widgets.WidgetInfo.TO_GROUP;
 import net.runelite.api.widgets.WidgetItem;
@@ -94,7 +94,7 @@ public abstract class WidgetItemOverlay extends Overlay
 			GUIDE_PRICES_INVENTORY_GROUP_ID,
 			EQUIPMENT_INVENTORY_GROUP_ID,
 			INVENTORY_GROUP_ID,
-			SEED_VAULT_GROUP_ID);
+			SEED_VAULT_INVENTORY_GROUP_ID);
 	}
 
 	protected void showOnBank()


### PR DESCRIPTION
allow overlays (e.g. item charges) to be displayed whilst in the seed vault interface
resolves #8359 