### PR TITLE
Add user-defined cursor images

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/config/ConfigManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/ConfigManager.java
@@ -602,6 +602,10 @@ public class ConfigManager
 		{
 			return Duration.ofMillis(Long.parseLong(str));
 		}
+		if (type == File.class)
+		{
+			return new File(str);
+		}
 		return str;
 	}
 
@@ -647,6 +651,10 @@ public class ConfigManager
 		if (object instanceof Duration)
 		{
 			return Long.toString(((Duration) object).toMillis());
+		}
+		if (object instanceof File)
+		{
+			return ((File) object).getAbsolutePath();
 		}
 		return object.toString();
 	}

--- a/runelite-client/src/main/java/net/runelite/client/config/ConfigManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/ConfigManager.java
@@ -656,6 +656,10 @@ public class ConfigManager
 		{
 			return ((File) object).getAbsolutePath();
 		}
+		if (object == null)
+		{
+			return "";
+		}
 		return object.toString();
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
@@ -38,6 +38,7 @@ import java.awt.event.MouseEvent;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import java.awt.image.BufferedImage;
+import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -49,6 +50,7 @@ import javax.swing.ImageIcon;
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
+import javax.swing.JFileChooser;
 import javax.swing.JFormattedTextField;
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
@@ -65,6 +67,7 @@ import javax.swing.border.EmptyBorder;
 import javax.swing.event.ChangeListener;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
+import javax.swing.filechooser.FileNameExtensionFilter;
 import javax.swing.text.JTextComponent;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.client.config.ChatColorConfig;
@@ -529,6 +532,34 @@ public class ConfigPanel extends PluginPanel
 				item.add(button, BorderLayout.EAST);
 			}
 
+			if (cid.getType() == File.class)
+			{
+				JFileChooser fileChooser = new JFileChooser();
+				fileChooser.setDialogTitle("Select a custom cursor image");
+				fileChooser.setAcceptAllFileFilterUsed(false);
+				FileNameExtensionFilter filter = new FileNameExtensionFilter("image files", "png", "gif", "jpeg", "jpg", "bmp", "ico", "cur");
+				fileChooser.addChoosableFileFilter(filter);
+
+				JButton chooserButton = new JButton("Select Image File");
+				chooserButton.setPreferredSize(new Dimension(140, 20));
+				chooserButton.addActionListener(e ->
+				{
+					int returnValue = fileChooser.showOpenDialog(null);
+					if (returnValue == JFileChooser.APPROVE_OPTION)
+					{
+						changeConfiguration(listItem, config, fileChooser, cd, cid);
+						chooserButton.setText(fileChooser.getSelectedFile().getName());
+					}
+				});
+				String currentFilePath = configManager.getConfiguration(cd.getGroup().value(), cid.getItem().keyName());
+				String fileName = currentFilePath.substring(currentFilePath.lastIndexOf("\\") + 1);
+				if (!fileName.isEmpty())
+				{
+					chooserButton.setText(fileName);
+				}
+				item.add(chooserButton, BorderLayout.EAST);
+			}
+
 			mainPanel.add(item);
 		}
 
@@ -603,6 +634,11 @@ public class ConfigPanel extends PluginPanel
 		{
 			HotkeyButton hotkeyButton = (HotkeyButton) component;
 			configManager.setConfiguration(cd.getGroup().value(), cid.getItem().keyName(), hotkeyButton.getValue());
+		}
+		else if (component instanceof JFileChooser)
+		{
+			JFileChooser fileChooser = (JFileChooser) component;
+			configManager.setConfiguration(cd.getGroup().value(), cid.getItem().keyName(), fileChooser.getSelectedFile());
 		}
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
@@ -535,12 +535,15 @@ public class ConfigPanel extends PluginPanel
 			if (cid.getType() == File.class)
 			{
 				JFileChooser fileChooser = new JFileChooser();
-				fileChooser.setDialogTitle("Select a custom cursor image");
-				fileChooser.setAcceptAllFileFilterUsed(false);
-				FileNameExtensionFilter filter = new FileNameExtensionFilter("image files", "png", "gif", "jpeg", "jpg", "bmp", "ico", "cur");
-				fileChooser.addChoosableFileFilter(filter);
+				fileChooser.setDialogTitle("Select a file");
+				if (cd.getGroup().value().equals("customcursor"))
+				{
+					fileChooser.setAcceptAllFileFilterUsed(false);
+					FileNameExtensionFilter filter = new FileNameExtensionFilter("image files", "png", "gif", "jpeg", "jpg", "bmp", "ico", "cur");
+					fileChooser.addChoosableFileFilter(filter);
+				}
 
-				JButton chooserButton = new JButton("Select Image File");
+				JButton chooserButton = new JButton("Choose File");
 				chooserButton.setPreferredSize(new Dimension(140, 20));
 				chooserButton.addActionListener(e ->
 				{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/customcursor/CustomCursorConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/customcursor/CustomCursorConfig.java
@@ -28,6 +28,8 @@ import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
 
+import java.io.File;
+
 @ConfigGroup("customcursor")
 public interface CustomCursorConfig extends Config
 {
@@ -39,5 +41,15 @@ public interface CustomCursorConfig extends Config
 	default CustomCursor selectedCursor()
 	{
 		return CustomCursor.RS3_GOLD;
+	}
+
+	@ConfigItem(
+		keyName = "customImage",
+		name = "Custom Image",
+		description = "Use your own image file for a cursor"
+	)
+	default File customImageFile()
+	{
+		return new File("\\");
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/customcursor/CustomCursorConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/customcursor/CustomCursorConfig.java
@@ -28,6 +28,7 @@ import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
 
+import javax.annotation.Nullable;
 import java.io.File;
 
 @ConfigGroup("customcursor")
@@ -48,8 +49,9 @@ public interface CustomCursorConfig extends Config
 		name = "Custom Image",
 		description = "Use your own image file for a cursor"
 	)
+	@Nullable
 	default File customImageFile()
 	{
-		return new File("\\");
+		return null;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/customcursor/CustomCursorPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/customcursor/CustomCursorPlugin.java
@@ -90,14 +90,14 @@ public class CustomCursorPlugin extends Plugin
 	{
 		// Custom image file takes precedent
 		File customImageFile = config.customImageFile();
-		if (customImageFile.exists() && !customImageFile.isDirectory())
+		if (customImageFile != null && customImageFile.exists() && !customImageFile.isDirectory())
 		{
 			try
 			{
 				BufferedImage image = ImageIO.read(customImageFile);
 				clientUI.setCursor(image, "Custom");
 			}
-			catch (IOException e)
+			catch (Exception e)
 			{
 				useSelectedCursor();
 			}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/customcursor/CustomCursorPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/customcursor/CustomCursorPlugin.java
@@ -25,6 +25,8 @@
 package net.runelite.client.plugins.customcursor;
 
 import com.google.inject.Provides;
+
+import javax.imageio.ImageIO;
 import javax.inject.Inject;
 import net.runelite.api.events.ConfigChanged;
 import net.runelite.client.config.ConfigManager;
@@ -32,6 +34,10 @@ import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.ClientUI;
+
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.IOException;
 
 @PluginDescriptor(
 	name = "Custom Cursor",
@@ -67,13 +73,42 @@ public class CustomCursorPlugin extends Plugin
 	@Subscribe
 	public void onConfigChanged(ConfigChanged event)
 	{
-		if (event.getGroup().equals("customcursor") && event.getKey().equals("cursorStyle"))
+		if (event.getGroup().equals("customcursor"))
 		{
-			updateCursor();
+			if (event.getKey().equals("cursorStyle"))
+			{
+				useSelectedCursor();
+			}
+			else if (event.getKey().equals("customImage"))
+			{
+				updateCursor();
+			}
 		}
 	}
 
 	private void updateCursor()
+	{
+		// Custom image file takes precedent
+		File customImageFile = config.customImageFile();
+		if (customImageFile.exists() && !customImageFile.isDirectory())
+		{
+			try
+			{
+				BufferedImage image = ImageIO.read(customImageFile);
+				clientUI.setCursor(image, "Custom");
+			}
+			catch (IOException e)
+			{
+				useSelectedCursor();
+			}
+		}
+		else
+		{
+			useSelectedCursor();
+		}
+	}
+
+	private void useSelectedCursor()
 	{
 		CustomCursor selectedCursor = config.selectedCursor();
 		clientUI.setCursor(selectedCursor.getCursorImage(), selectedCursor.toString());


### PR DESCRIPTION
Fixes https://github.com/runelite/runelite/issues/8764

To do this, I also added a generic File input and type for configs, which will hopefully be useful in the future.

![bb1291a20a83f1ad31f4f11c45624b57](https://user-images.githubusercontent.com/9620289/57271437-6b8a3580-705d-11e9-9a93-4320d5e5b0be.gif)
