### PR TITLE
poison: don't display negative times in tooltip

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/poison/PoisonPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/poison/PoisonPlugin.java
@@ -280,7 +280,7 @@ public class PoisonPlugin extends Plugin
 	private static String getFormattedTime(Instant endTime)
 	{
 		final Duration timeLeft = Duration.between(Instant.now(), endTime);
-		int seconds = (int) (timeLeft.toMillis() / 1000L);
+		int seconds = Math.max(0, (int) (timeLeft.toMillis() / 1000L));
 		int minutes = seconds / 60;
 		int secs = seconds % 60;
 


### PR DESCRIPTION
Some actions can defer the next poison damage tick until after they finish.
When this happens, the poison plugin's tooltip can display a negative time:

![](https://i.imgur.com/NLFRv28.png)

This fixes that.