### PR TITLE
regenmeter: notif before next hp regen & refactor existing code to use Constants.GAME_TICK_LENGTH

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/Constants.java
+++ b/runelite-api/src/main/java/net/runelite/api/Constants.java
@@ -89,4 +89,12 @@ public class Constants
 	 * the maximum framerate of 50 fps.
 	 */
 	public static final int CLIENT_TICK_LENGTH = 20;
+
+	/**
+	 * The number of milliseconds in a server game tick.
+	 * <p>
+	 * This is the length of a single game cycle under ideal conditions.
+	 * All game-play actions operate within multiples of this duration.
+	 */
+	public static final int GAME_TICK_LENGTH = 600;
 }

--- a/runelite-client/src/main/java/net/runelite/client/callback/Hooks.java
+++ b/runelite-client/src/main/java/net/runelite/client/callback/Hooks.java
@@ -42,6 +42,7 @@ import javax.inject.Singleton;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.BufferProvider;
 import net.runelite.api.Client;
+import net.runelite.api.Constants;
 import net.runelite.api.MainBufferProvider;
 import net.runelite.api.NullItemID;
 import net.runelite.api.RenderOverview;
@@ -79,7 +80,7 @@ import net.runelite.client.util.DeferredEventBus;
 @Slf4j
 public class Hooks implements Callbacks
 {
-	private static final long CHECK = 600; // ms - how often to run checks
+	private static final long CHECK = Constants.GAME_TICK_LENGTH; // ms - how often to run checks
 
 	private static final Injector injector = RuneLite.getInjector();
 	private static final Client client = injector.getInstance(Client.class);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/antidrag/AntiDragConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/antidrag/AntiDragConfig.java
@@ -24,6 +24,7 @@
  */
 package net.runelite.client.plugins.antidrag;
 
+import net.runelite.api.Constants;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
@@ -39,6 +40,6 @@ public interface AntiDragConfig extends Config
 	)
 	default int dragDelay()
 	{
-		return 600 / 20; // one game tick
+		return Constants.GAME_TICK_LENGTH / Constants.CLIENT_TICK_LENGTH; // one game tick
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/barbarianassault/GameTimer.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/barbarianassault/GameTimer.java
@@ -28,6 +28,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
+import net.runelite.api.Constants;
 
 class GameTimer
 {
@@ -45,7 +46,7 @@ class GameTimer
 		}
 		else
 		{
-			elapsed = Duration.between(startTime, now).minusMillis(600);
+			elapsed = Duration.between(startTime, now).minusMillis(Constants.GAME_TICK_LENGTH);
 		}
 
 		return formatTime(LocalTime.ofSecondOfDay(elapsed.getSeconds()));

--- a/runelite-client/src/main/java/net/runelite/client/plugins/barbarianassault/Round.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/barbarianassault/Round.java
@@ -29,6 +29,7 @@ import java.time.Instant;
 import javax.inject.Inject;
 import lombok.Getter;
 import lombok.Setter;
+import net.runelite.api.Constants;
 
 class Round
 {
@@ -52,7 +53,7 @@ class Round
 	public Round(Role role)
 	{
 		this.roundRole = role;
-		this.roundStartTime = Instant.now().plusMillis(1200);
+		this.roundStartTime = Instant.now().plusMillis(2 * Constants.GAME_TICK_LENGTH);
 	}
 
 	public long getRoundTime()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/boosts/BoostsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/boosts/BoostsPlugin.java
@@ -33,6 +33,7 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 import lombok.Getter;
 import net.runelite.api.Client;
+import net.runelite.api.Constants;
 import net.runelite.api.Prayer;
 import net.runelite.api.Skill;
 import net.runelite.api.events.BoostedLevelChanged;
@@ -372,6 +373,6 @@ public class BoostsPlugin extends Plugin
 	int getChangeTime(final int time)
 	{
 		final long diff = System.currentTimeMillis() - lastTickMillis;
-		return time != -1 ? (int)(time * 0.6 - (diff / 1000d)) : time;
+		return time != -1 ? (int)((time * Constants.GAME_TICK_LENGTH - diff) / 1000d) : time;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
@@ -35,6 +35,7 @@ import net.runelite.api.Actor;
 import net.runelite.api.AnimationID;
 import static net.runelite.api.AnimationID.*;
 import net.runelite.api.Client;
+import net.runelite.api.Constants;
 import net.runelite.api.GameState;
 import net.runelite.api.GraphicID;
 import net.runelite.api.Hitsplat;
@@ -64,9 +65,10 @@ import net.runelite.client.plugins.PluginDescriptor;
 public class IdleNotifierPlugin extends Plugin
 {
 	// This must be more than 500 client ticks (10 seconds) before you get AFK kicked
-	private static final int LOGOUT_WARNING_CLIENT_TICKS = ((4 * 60) + 40) * 50;// 4 minutes and 40 seconds
+	private static final int LOGOUT_WARNING_MILLIS = (4 * 60 + 40) * 1000; // 4 minutes and 40 seconds
 	private static final int COMBAT_WARNING_MILLIS = 19 * 60 * 1000; // 19 minutes
-	private static final int COMBAT_WARNING_CLIENT_TICKS = COMBAT_WARNING_MILLIS / 20;
+	private static final int LOGOUT_WARNING_CLIENT_TICKS = LOGOUT_WARNING_MILLIS / Constants.CLIENT_TICK_LENGTH;
+	private static final int COMBAT_WARNING_CLIENT_TICKS = COMBAT_WARNING_MILLIS / Constants.CLIENT_TICK_LENGTH;
 
 	private static final int HIGHEST_MONSTER_ATTACK_SPEED = 8; // Except Scarab Mage, but they are with other monsters
 	private static final Duration SIX_HOUR_LOGOUT_WARNING_AFTER_DURATION = Duration.ofMinutes(340);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcSceneOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcSceneOverlay.java
@@ -36,6 +36,7 @@ import java.time.Instant;
 import java.util.Locale;
 import javax.inject.Inject;
 import net.runelite.api.Client;
+import net.runelite.api.Constants;
 import net.runelite.api.NPC;
 import net.runelite.api.NPCComposition;
 import net.runelite.api.Perspective;
@@ -53,9 +54,6 @@ public class NpcSceneOverlay extends Overlay
 	// Anything but white text is quite hard to see since it is drawn on
 	// a dark background
 	private static final Color TEXT_COLOR = Color.WHITE;
-
-	// Estimated time of a game tick in seconds
-	private static final double ESTIMATED_TICK_LENGTH = 0.6;
 
 	private static final NumberFormat TIME_LEFT_FORMATTER = DecimalFormat.getInstance(Locale.US);
 
@@ -123,7 +121,7 @@ public class NpcSceneOverlay extends Overlay
 		}
 
 		final Instant now = Instant.now();
-		final double baseTick = ((npc.getDiedOnTick() + npc.getRespawnTime()) - client.getTickCount()) * ESTIMATED_TICK_LENGTH;
+		final double baseTick = ((npc.getDiedOnTick() + npc.getRespawnTime()) - client.getTickCount()) * (Constants.GAME_TICK_LENGTH / 1000.0);
 		final double sinceLast = (now.toEpochMilli() - plugin.getLastTickUpdate().toEpochMilli()) / 1000.0;
 		final double timeLeft = Math.max(0.0, baseTick - sinceLast);
 		final String timeLeftStr = TIME_LEFT_FORMATTER.format(timeLeft);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/poh/PohPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/poh/PohPlugin.java
@@ -39,6 +39,7 @@ import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Actor;
 import net.runelite.api.AnimationID;
 import net.runelite.api.Client;
+import net.runelite.api.Constants;
 import net.runelite.api.DecorativeObject;
 import net.runelite.api.GameObject;
 import net.runelite.api.GameState;
@@ -74,7 +75,6 @@ public class PohPlugin extends Plugin
 {
 	static final Set<Integer> BURNER_UNLIT = Sets.newHashSet(ObjectID.INCENSE_BURNER, ObjectID.INCENSE_BURNER_13210, ObjectID.INCENSE_BURNER_13212);
 	static final Set<Integer> BURNER_LIT = Sets.newHashSet(ObjectID.INCENSE_BURNER_13209, ObjectID.INCENSE_BURNER_13211, ObjectID.INCENSE_BURNER_13213);
-	private static final double ESTIMATED_TICK_LENGTH = 0.6;
 
 	@Getter(AccessLevel.PACKAGE)
 	private final Map<TileObject, Tile> pohObjects = new HashMap<>();
@@ -243,7 +243,8 @@ public class PohPlugin extends Plugin
 
 	private static void updateBurner(IncenseBurner incenseBurner, int fmLevel)
 	{
-		incenseBurner.setCountdownTimer((200 + fmLevel) * ESTIMATED_TICK_LENGTH);
-		incenseBurner.setRandomTimer(fmLevel * ESTIMATED_TICK_LENGTH);
+		final double tickLengthSeconds = Constants.GAME_TICK_LENGTH / 1000.0;
+		incenseBurner.setCountdownTimer((200 + fmLevel) * tickLengthSeconds);
+		incenseBurner.setRandomTimer(fmLevel * tickLengthSeconds);
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/prayer/PrayerDoseOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/prayer/PrayerDoseOverlay.java
@@ -35,6 +35,7 @@ import javax.inject.Inject;
 import lombok.AccessLevel;
 import lombok.Setter;
 import net.runelite.api.Client;
+import net.runelite.api.Constants;
 import net.runelite.api.Point;
 import net.runelite.api.Prayer;
 import net.runelite.api.Skill;
@@ -50,7 +51,7 @@ import org.apache.commons.lang3.StringUtils;
 
 class PrayerDoseOverlay extends Overlay
 {
-	private static final float PULSE_TIME = 1200f;
+	private static final float PULSE_TIME = 2f * Constants.GAME_TICK_LENGTH;
 
 	private static final Color START_COLOR = new Color(0, 255, 255);
 	private static final Color END_COLOR = new Color(0, 92, 92);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/prayer/PrayerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/prayer/PrayerPlugin.java
@@ -32,6 +32,7 @@ import javax.inject.Inject;
 import lombok.AccessLevel;
 import lombok.Getter;
 import net.runelite.api.Client;
+import net.runelite.api.Constants;
 import net.runelite.api.InventoryID;
 import net.runelite.api.Item;
 import net.runelite.api.ItemContainer;
@@ -268,7 +269,7 @@ public class PrayerPlugin extends Plugin
 	{
 		long timeSinceLastTick = Duration.between(startOfLastTick, Instant.now()).toMillis();
 
-		float tickProgress = (timeSinceLastTick % 600) / 600f;
+		float tickProgress = (timeSinceLastTick % Constants.GAME_TICK_LENGTH) / (float) Constants.GAME_TICK_LENGTH;
 		return tickProgress * Math.PI;
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/regenmeter/RegenMeterConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/regenmeter/RegenMeterConfig.java
@@ -57,4 +57,14 @@ public interface RegenMeterConfig extends Config
 	{
 		return false;
 	}
+
+	@ConfigItem(
+		keyName = "notifyBeforeHpRegenDuration",
+		name = "Hitpoint Regen Notification (seconds)",
+		description = "Notify approximately when your next hitpoint is about to regen. A value of 0 will disable notification."
+	)
+	default int getNotifyBeforeHpRegenSeconds()
+	{
+		return 0;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/runenergy/RunEnergyPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/runenergy/RunEnergyPlugin.java
@@ -28,6 +28,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.inject.Provides;
 import javax.inject.Inject;
 import net.runelite.api.Client;
+import net.runelite.api.Constants;
 import net.runelite.api.EquipmentInventorySlot;
 import net.runelite.api.InventoryID;
 import net.runelite.api.Item;
@@ -171,7 +172,7 @@ public class RunEnergyPlugin extends Plugin
 
 	String getEstimatedRunTimeRemaining(boolean inSeconds)
 	{
-		// Calculate the amount of energy lost every 2 ticks (0.6 seconds).
+		// Calculate the amount of energy lost every tick.
 		// Negative weight has the same depletion effect as 0 kg.
 		final int effectiveWeight = Math.max(client.getWeight(), 0);
 		double lossRate = (Math.min(effectiveWeight, 64) / 100.0) + 0.64;
@@ -182,7 +183,7 @@ public class RunEnergyPlugin extends Plugin
 		}
 
 		// Calculate the number of seconds left
-		final double secondsLeft = (client.getEnergy() * 0.6) / lossRate;
+		final double secondsLeft = (client.getEnergy() * Constants.GAME_TICK_LENGTH) / (lossRate * 1000.0);
 
 		// Return the text
 		if (inSeconds)


### PR DESCRIPTION
Adds a configuration option for notifying the player before their next HP regen occurs, and refactors existing code to utilise `Constants.GAME_TICK_LENGTH` where approperiate.

The following notification is sent:
![](https://i.imgur.com/YzaOCcA.png)

Should be especially useful for NMZ. Its accuracy is limited to that of the Regeneration Meter plugin itself.
Closes #2704.

**Note:** the config accepts the amount of milliseconds before the regen to send the notification, but this is instead converted to the earliest corresponding 0.6s tick interval in the code. Maybe it would be a better idea to accept something like seconds instead?