### PR TITLE
log notifications

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/Notifier.java
+++ b/runelite-client/src/main/java/net/runelite/client/Notifier.java
@@ -150,6 +150,10 @@ public class Notifier
 		{
 			flashStart = Instant.now();
 		}
+
+		if (runeLiteConfig.logNotification()) {
+			log.info(message);
+		}
 	}
 
 	public void processFlash(final Graphics2D graphics)

--- a/runelite-client/src/main/java/net/runelite/client/Notifier.java
+++ b/runelite-client/src/main/java/net/runelite/client/Notifier.java
@@ -151,9 +151,7 @@ public class Notifier
 			flashStart = Instant.now();
 		}
 
-		if (runeLiteConfig.logNotification()) {
-			log.info(message);
-		}
+		log.debug(message);
 	}
 
 	public void processFlash(final Graphics2D graphics)

--- a/runelite-client/src/main/java/net/runelite/client/config/RuneLiteConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/RuneLiteConfig.java
@@ -186,21 +186,10 @@ public interface RuneLiteConfig extends Config
 	}
 
 	@ConfigItem(
-			keyName = "logNotification",
-			name = "Log notifications",
-			description = "Logs notifications.<br>This is useful as a developer for implementing your own hooks.",
-			position = 25
-	)
-	default boolean logNotification()
-	{
-		return false;
-	}
-
-	@ConfigItem(
-			keyName = "notificationFocused",
-			name = "Send notifications when focused",
-			description = "Toggles all notifications for when the client is focused",
-			position = 26
+		keyName = "notificationFocused",
+		name = "Send notifications when focused",
+		description = "Toggles all notifications for when the client is focused",
+		position = 25
 	)
 	default boolean sendNotificationsWhenFocused()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/config/RuneLiteConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/RuneLiteConfig.java
@@ -186,10 +186,21 @@ public interface RuneLiteConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "notificationFocused",
-		name = "Send notifications when focused",
-		description = "Toggles all notifications for when the client is focused",
-		position = 25
+			keyName = "logNotification",
+			name = "Log notifications",
+			description = "Logs notifications.<br>This is useful as a developer for implementing your own hooks.",
+			position = 25
+	)
+	default boolean logNotification()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+			keyName = "notificationFocused",
+			name = "Send notifications when focused",
+			description = "Toggles all notifications for when the client is focused",
+			position = 26
 	)
 	default boolean sendNotificationsWhenFocused()
 	{


### PR DESCRIPTION
This adds a Runelite config option for logging notifications. My use case for this is handling the notifications outside of Runelite. I want to be able to run a NodeJS script that watches for certain notifications and performs actions based on them. Ie on log file change, if the notification i was looking for was added, perform XYZ.  Currently, at least on OSX, its very tricky finding where notifications are stored in the filesystem. This solves that problem.