### PR TITLE
western diary: Fix elf pickpocket quest requirement

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/WesternDiaryRequirement.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/WesternDiaryRequirement.java
@@ -140,6 +140,6 @@ public class WesternDiaryRequirement extends GenericDiaryRequirement
 			new QuestRequirement(Quest.BIG_CHOMPY_BIRD_HUNTING));
 		add("Pickpocket an Elf.",
 			new SkillRequirement(Skill.THIEVING, 85),
-			new QuestRequirement(Quest.MOURNINGS_ENDS_PART_II));
+			new QuestRequirement(Quest.MOURNINGS_ENDS_PART_I, true));
 	}
 }


### PR DESCRIPTION
The requirement for pickpocketing an elf is to have started Mourning's
End Part I for access to Lletya, not to have completed Mourning's End
Part II.

Fixes runelite/runelite#8806