### PR TITLE
Format config enums as "Config Option" by default

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatfilter/ChatFilterType.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatfilter/ChatFilterType.java
@@ -24,20 +24,9 @@
  */
 package net.runelite.client.plugins.chatfilter;
 
-import lombok.RequiredArgsConstructor;
-
-@RequiredArgsConstructor
 public enum ChatFilterType
 {
-	CENSOR_WORDS("Censor words"),
-	CENSOR_MESSAGE("Censor message"),
-	REMOVE_MESSAGE("Remove message");
-
-	private final String name;
-
-	@Override
-	public String toString()
-	{
-		return name;
-	}
+	CENSOR_WORDS,
+	CENSOR_MESSAGE,
+	REMOVE_MESSAGE
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
@@ -492,7 +492,7 @@ public class ConfigPanel extends PluginPanel
 				{
 					Enum selectedItem = Enum.valueOf(type, configManager.getConfiguration(cd.getGroup().value(), cid.getItem().keyName()));
 					box.setSelectedItem(selectedItem);
-					box.setToolTipText(selectedItem.toString());
+					box.setToolTipText(Text.titleCase(selectedItem));
 				}
 				catch (IllegalArgumentException ex)
 				{
@@ -503,7 +503,7 @@ public class ConfigPanel extends PluginPanel
 					if (e.getStateChange() == ItemEvent.SELECTED)
 					{
 						changeConfiguration(listItem, config, box, cd, cid);
-						box.setToolTipText(box.getSelectedItem().toString());
+						box.setToolTipText(Text.titleCase((Enum) box.getSelectedItem()));
 					}
 				});
 				item.add(box, BorderLayout.EAST);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/fps/FpsLimitMode.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/fps/FpsLimitMode.java
@@ -24,22 +24,9 @@
  */
 package net.runelite.client.plugins.fps;
 
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-
-@Getter
-@RequiredArgsConstructor
 public enum FpsLimitMode
 {
-	NEVER("Never"),
-	UNFOCUSED("Unfocused"),
-	ALWAYS("Always");
-
-	private final String name;
-
-	@Override
-	public String toString()
-	{
-		return name;
-	}
+	NEVER,
+	UNFOCUSED,
+	ALWAYS
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemidentification/ItemIdentificationMode.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemidentification/ItemIdentificationMode.java
@@ -24,21 +24,8 @@
  */
 package net.runelite.client.plugins.itemidentification;
 
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-
-@Getter
-@RequiredArgsConstructor
 public enum ItemIdentificationMode
 {
-	SHORT("Short"),
-	MEDIUM("Medium");
-
-	private final String type;
-
-	@Override
-	public String toString()
-	{
-		return type;
-	}
+	SHORT,
+	MEDIUM
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/RenderStyle.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/RenderStyle.java
@@ -26,21 +26,8 @@ package net.runelite.client.plugins.npchighlight;
 
 public enum RenderStyle
 {
-	OFF("Off"),
-	TILE("Tile"),
-	HULL("Hull"),
-	SOUTH_WEST_TILE("South West Tile");
-
-	private final String name;
-
-	RenderStyle(String name)
-	{
-		this.name = name;
-	}
-
-	@Override
-	public String toString()
-	{
-		return name;
-	}
+	OFF,
+	TILE,
+	HULL,
+	SOUTH_WEST_TILE
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/prayer/PrayerFlickLocation.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/prayer/PrayerFlickLocation.java
@@ -26,23 +26,10 @@
 
 package net.runelite.client.plugins.prayer;
 
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-
-@Getter
-@RequiredArgsConstructor
 public enum PrayerFlickLocation
 {
-	NONE("Off"),
-	PRAYER_ORB("Prayer Orb"),
-	PRAYER_BAR("Prayer Bar"),
-	BOTH("Both");
-
-	private final String name;
-
-	@Override
-	public String toString()
-	{
-		return name;
-	}
+	NONE,
+	PRAYER_ORB,
+	PRAYER_BAR,
+	BOTH
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/runepouch/config/RunePouchOverlayMode.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/runepouch/config/RunePouchOverlayMode.java
@@ -24,22 +24,9 @@
  */
 package net.runelite.client.plugins.runepouch.config;
 
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-
-@Getter
-@RequiredArgsConstructor
 public enum RunePouchOverlayMode
 {
-	INVENTORY("Inventory"),
-	MOUSE_HOVER("Mouse hover"),
-	BOTH("Both");
-
-	private final String name;
-
-	@Override
-	public String toString()
-	{
-		return name;
-	}
+	INVENTORY,
+	MOUSE_HOVER,
+	BOTH
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/SubscriptionFilterMode.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/SubscriptionFilterMode.java
@@ -24,22 +24,9 @@
  */
 package net.runelite.client.plugins.worldhopper;
 
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-
-@Getter
-@RequiredArgsConstructor
 public enum SubscriptionFilterMode
 {
-	BOTH("Both"),
-	FREE("Free"),
-	MEMBERS("Member");
-
-	private final String name;
-
-	@Override
-	public String toString()
-	{
-		return name;
-	}
+	BOTH,
+	FREE,
+	MEMBERS
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerConfig.java
@@ -35,18 +35,10 @@ public interface XpTrackerConfig extends Config
 	@AllArgsConstructor
 	enum OnScreenDisplayMode
 	{
-		XP_GAINED("XP Gained"),
-		XP_LEFT("XP Left"),
-		ACTIONS_DONE("Actions Done"),
-		ACTIONS_LEFT("Actions Left");
-
-		private final String name;
-
-		@Override
-		public String toString()
-		{
-			return name;
-		}
+		XP_GAINED,
+		XP_LEFT,
+		ACTIONS_DONE,
+		ACTIONS_LEFT
 	}
 
 	@ConfigItem(

--- a/runelite-client/src/main/java/net/runelite/client/ui/components/ComboBoxListRenderer.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/components/ComboBoxListRenderer.java
@@ -31,6 +31,7 @@ import javax.swing.JList;
 import javax.swing.ListCellRenderer;
 import javax.swing.border.EmptyBorder;
 import net.runelite.client.ui.ColorScheme;
+import net.runelite.client.util.Text;
 
 /**
  * A custom list renderer to avoid substance's weird coloring.
@@ -57,7 +58,16 @@ public final class ComboBoxListRenderer extends JLabel implements ListCellRender
 
 		setBorder(new EmptyBorder(5, 5, 5, 0));
 
-		String text = o.toString();
+		String text;
+		if (o instanceof Enum)
+		{
+			text = Text.titleCase((Enum) o);
+		}
+		else
+		{
+			text = o.toString();
+		}
+
 		setText(text);
 
 		return this;

--- a/runelite-client/src/main/java/net/runelite/client/util/Text.java
+++ b/runelite-client/src/main/java/net/runelite/client/util/Text.java
@@ -31,6 +31,7 @@ import com.google.common.base.Splitter;
 import java.util.Collection;
 import java.util.List;
 import java.util.regex.Pattern;
+import org.apache.commons.text.WordUtils;
 
 /**
  * A set of utilities to use when dealing with text.
@@ -158,5 +159,29 @@ public class Text
 	{
 		String cleaned = name.contains("<img") ? name.substring(name.lastIndexOf('>') + 1) : name;
 		return cleaned.replace('\u00A0', ' ');
+	}
+
+	/**
+	 * If passed in enum doesn't implement its own toString,
+	 * converts enum name format from THIS_FORMAT to This Format.
+	 *
+	 * @param o an enum
+	 * @return  the enum's name in title case,
+	 *          or if it overrides toString,
+	 *          the value returned by toString
+	 */
+	public static String titleCase(Enum o)
+	{
+		String toString = o.toString();
+
+		// .toString() returns the value of .name() if not overridden
+		if (o.name().equals(toString))
+		{
+			return WordUtils
+				.capitalize(toString.toLowerCase(), '_')
+				.replace("_", " ");
+		}
+
+		return toString;
 	}
 }


### PR DESCRIPTION
Makes it so enum options that don't override toString already don't shout at you anymore.

For example, CONFIG becomes Config and CONFIG_OPTION becomes Config Option.

You can still override toString on the enums if you want the config option to display apostrophes for example.

**Before:**

![image](https://user-images.githubusercontent.com/8920674/57583719-ab28a580-74d3-11e9-86e0-b479529b6085.png)

**After:**

![image](https://user-images.githubusercontent.com/8920674/57583727-bb408500-74d3-11e9-851f-d57156218e29.png)

