### PR TITLE
Add options for actions left and done for on screen XP

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpInfoBoxOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpInfoBoxOverlay.java
@@ -96,15 +96,38 @@ class XpInfoBoxOverlay extends Overlay
 
 		final XpSnapshotSingle snapshot = plugin.getSkillSnapshot(skill);
 
+		final String leftStr;
+		final int rightNum;
+
+		switch (config.onScreenDisplayMode())
+		{
+			case ACTIONS_DONE:
+				leftStr = snapshot.getActionType().getLabel() + " Done";
+				rightNum = snapshot.getActionsInSession();
+				break;
+			case ACTIONS_LEFT:
+				leftStr = snapshot.getActionType().getLabel() + " Left";
+				rightNum = snapshot.getActionsRemainingToGoal();
+				break;
+			case XP_LEFT:
+				leftStr = config.onScreenDisplayMode().toString();
+				rightNum = snapshot.getXpRemainingToGoal();
+				break;
+			case XP_GAINED:
+			default:
+				leftStr = config.onScreenDisplayMode().toString();
+				rightNum = snapshot.getXpGainedInSession();
+				break;
+		}
+
 		final LineComponent xpLine = LineComponent.builder()
-				.left(config.displayXpLeftOnScreen() ? "XP Left:" : "XP Gained:")
-				.right(StackFormatter.quantityToRSDecimalStack(config.displayXpLeftOnScreen()
-					? snapshot.getXpRemainingToGoal() : snapshot.getXpGainedInSession()))
-				.build();
+			.left(leftStr + ":")
+			.right(StackFormatter.quantityToRSDecimalStack(rightNum, true))
+			.build();
 
 		final LineComponent xpHour = LineComponent.builder()
 				.left("XP/Hour:")
-				.right(StackFormatter.quantityToRSDecimalStack(snapshot.getXpPerHour()))
+				.right(StackFormatter.quantityToRSDecimalStack(snapshot.getXpPerHour(), true))
 				.build();
 
 		final SplitComponent xpSplit = SplitComponent.builder()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerConfig.java
@@ -24,6 +24,7 @@
  */
 package net.runelite.client.plugins.xptracker;
 
+import lombok.AllArgsConstructor;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
@@ -31,6 +32,23 @@ import net.runelite.client.config.ConfigItem;
 @ConfigGroup("xpTracker")
 public interface XpTrackerConfig extends Config
 {
+	@AllArgsConstructor
+	enum OnScreenDisplayMode
+	{
+		XP_GAINED("XP Gained"),
+		XP_LEFT("XP Left"),
+		ACTIONS_DONE("Actions Done"),
+		ACTIONS_LEFT("Actions Left");
+
+		private final String name;
+
+		@Override
+		public String toString()
+		{
+			return name;
+		}
+	}
+
 	@ConfigItem(
 		position = 0,
 		keyName = "hideMaxed",
@@ -77,12 +95,12 @@ public interface XpTrackerConfig extends Config
 
 	@ConfigItem(
 		position = 4,
-		keyName = "onScreenXpLeft",
-		name = "Display XP Left on-screen",
-		description = "Display remaining experience instead of experience gained on on-screen trackers"
+		keyName = "onScreenDisplayMode",
+		name = "On-screen tracker display mode",
+		description = "Configures the information displayed in the first line of on-screen XP overlays"
 	)
-	default boolean displayXpLeftOnScreen()
+	default OnScreenDisplayMode onScreenDisplayMode()
 	{
-		return false;
+		return OnScreenDisplayMode.XP_GAINED;
 	}
 }


### PR DESCRIPTION
Add configurable option for on screen XP display mode, what now
includes:
- Actions done
- Actions left
- Xp gained
- Xp left

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>