### PR TITLE
Combat level plugin: Yet another prayer level calculation fix

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/combatlevel/CombatLevelOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/combatlevel/CombatLevelOverlay.java
@@ -168,12 +168,18 @@ class CombatLevelOverlay extends Overlay
 	@VisibleForTesting
 	static int calcLevelsPray(double start, int end, int prayerLevel)
 	{
-		final int neededLevels = (int) Math.floor(calcMultipliedLevels(start, end, PRAY_MULT));
+		int neededLevels = (int) Math.ceil(calcMultipliedLevels(start, end, PRAY_MULT));
+
+		if (prayerLevel % 2 != 0)
+		{
+			neededLevels--;
+		}
 
 		if ((prayerLevel + neededLevels) % 2 != 0)
 		{
 			return neededLevels + 1;
 		}
+
 		return neededLevels;
 	}
 

--- a/runelite-client/src/test/java/net/runelite/client/plugins/combatlevel/CombatLevelPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/combatlevel/CombatLevelPluginTest.java
@@ -270,10 +270,47 @@ public class CombatLevelPluginTest
 		when(client.getRealSkillLevel(Skill.MAGIC)).thenReturn(99);
 		when(client.getRealSkillLevel(Skill.HITPOINTS)).thenReturn(99);
 
+		assertEquals(1, neededPrayerLevels());
+	}
+
+	@Test
+	public void testEvenPrayerLevelsNeededWhenNearNextCombatLevel()
+	{
+		when(player.getCombatLevel()).thenReturn(90);
+		when(client.getRealSkillLevel(Skill.ATTACK)).thenReturn(74);
+		when(client.getRealSkillLevel(Skill.STRENGTH)).thenReturn(75);
+		when(client.getRealSkillLevel(Skill.DEFENCE)).thenReturn(72);
+		when(client.getRealSkillLevel(Skill.PRAYER)).thenReturn(52);
+		when(client.getRealSkillLevel(Skill.RANGED)).thenReturn(44);
+		when(client.getRealSkillLevel(Skill.MAGIC)).thenReturn(60);
+		when(client.getRealSkillLevel(Skill.HITPOINTS)).thenReturn(72);
+
+		assertEquals(2, neededPrayerLevels());
+	}
+
+	@Test
+	public void testOddPrayerLevelsNeededWhenNearNextCombatLevel()
+	{
+		when(player.getCombatLevel()).thenReturn(90);
+		when(client.getRealSkillLevel(Skill.ATTACK)).thenReturn(74);
+		when(client.getRealSkillLevel(Skill.STRENGTH)).thenReturn(75);
+		when(client.getRealSkillLevel(Skill.DEFENCE)).thenReturn(72);
+		when(client.getRealSkillLevel(Skill.PRAYER)).thenReturn(53);
+		when(client.getRealSkillLevel(Skill.RANGED)).thenReturn(44);
+		when(client.getRealSkillLevel(Skill.MAGIC)).thenReturn(60);
+		when(client.getRealSkillLevel(Skill.HITPOINTS)).thenReturn(72);
+
+		assertEquals(1, neededPrayerLevels());
+	}
+
+	private int neededPrayerLevels()
+	{
 		HashMap<String, Double> baseValues = getBaseValues();
 
-		// test prayer
-		assertEquals(1, calcLevelsPray(baseValues.get("base") + baseValues.get("max"),
-			player.getCombatLevel() + 1, client.getRealSkillLevel(Skill.PRAYER)));
+		return calcLevelsPray(
+				baseValues.get("base") + baseValues.get("max"),
+				player.getCombatLevel() + 1,
+				client.getRealSkillLevel(Skill.PRAYER)
+		);
 	}
 }


### PR DESCRIPTION
After reading the issues (#7411) and pull requests (#7526) I found out that the combat level plugin has had a lot of problems with prayer level calculation. I also found this bug on my own in which needed prayer levels for the next combat level was 0 instead of 2 in some corner cases.

This PR should fix the issue by (1) changing the usage of Math.floor to Math.ceil and (2) subtracting 1 from the needed levels if the current prayer level is an odd number.

**For example**: Let prayer level `p` be an odd number. The current combat level is exactly same for `p` and `p - 1`. Therefore given `n` is the number of needed prayer levels for a combat level with prayer `p - 1` then `n - 1` is the needed prayer levels for a combat level with prayer `p`.

The usage of Math.floor was incorrect in every case so it is changed to Math.ceil. The flooring comes to the right conclusion about needed levels to next combat level in most cases by mistake.

There are quite a lot of changes to the plugin in #7528 which might make this obsolete but maybe this fix could inspire to keep the static calculation instead of a while loop.

