### PR TITLE
correct misunderstandings related to wall orientation

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/WallObject.java
+++ b/runelite-api/src/main/java/net/runelite/api/WallObject.java
@@ -25,28 +25,33 @@
 package net.runelite.api;
 
 /**
- * Represents the wall of a tile, which is an un-passable boundary.
+ * Represents one or two walls on a tile
  */
 public interface WallObject extends TileObject
 {
 	/**
-	 * Gets the first orientation of the wall.
-	 *
-	 * @return the first orientation, 0-2048 where 0 is north
+	 * A bitfield with the orientation of a wall
+	 * 1 = East
+	 * 2 = North
+	 * 4 = West
+	 * 8 = South
 	 */
 	int getOrientationA();
 
 	/**
-	 * Gets the second orientation value of the wall.
-	 *
-	 * @return the second orientation, 0-2048 where 0 is north
+	 * A bitfield containing the orientation of the second wall on this tile,
+	 * or 0 if there is no second wall.
+	 * @see #getOrientationA
 	 */
 	int getOrientationB();
 
 	/**
-	 * Gets the boundary configuration of the wall.
-	 *
-	 * @return the boundary configuration
+	 * A bitfield containing various flags:
+	 * <pre>{@code
+	 * object type id = bits & 0x20
+	 * orientation (0-3) = bits >>> 6 & 3
+	 * supports items = bits >>> 8 & 1
+	 * }</pre>
 	 */
 	int getConfig();
 

--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSDecorativeObjectMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSDecorativeObjectMixin.java
@@ -110,7 +110,29 @@ public abstract class RSDecorativeObjectMixin implements RSDecorativeObject
 	@Override
 	public Area getClickbox()
 	{
-		return Perspective.getClickbox(client, getModel(), getOrientation(), getLocalLocation());
+		Area clickbox = new Area();
+
+		LocalPoint lp = getLocalLocation();
+		Area clickboxA = Perspective.getClickbox(client, getModel(), 0,
+			new LocalPoint(lp.getX() + getXOffset(), lp.getY() + getYOffset()));
+		Area clickboxB = Perspective.getClickbox(client, getModel2(), 0, lp);
+
+		if (clickboxA == null && clickboxB == null)
+		{
+			return null;
+		}
+
+		if (clickboxA != null)
+		{
+			clickbox.add(clickboxA);
+		}
+
+		if (clickboxB != null)
+		{
+			clickbox.add(clickboxB);
+		}
+
+		return clickbox;
 	}
 
 	@Inject

--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSWallObjectMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSWallObjectMixin.java
@@ -101,8 +101,8 @@ public abstract class RSWallObjectMixin implements RSWallObject
 	{
 		Area clickbox = new Area();
 
-		Area clickboxA = Perspective.getClickbox(client, getModelA(), getOrientationA(), getLocalLocation());
-		Area clickboxB = Perspective.getClickbox(client, getModelB(), getOrientationB(), getLocalLocation());
+		Area clickboxA = Perspective.getClickbox(client, getModelA(), 0, getLocalLocation());
+		Area clickboxB = Perspective.getClickbox(client, getModelB(), 0, getLocalLocation());
 
 		if (clickboxA == null && clickboxB == null)
 		{


### PR DESCRIPTION
Closes #8825

Orientation for WallObject and DecorativeObject is not used for rendering, as their rotation is baked into their model. As such it not in the normal jagex angle format, and should not be used for projection.