### PR TITLE
xp tracker: fix on-screen information type label

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpInfoBoxOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpInfoBoxOverlay.java
@@ -110,12 +110,12 @@ class XpInfoBoxOverlay extends Overlay
 				rightNum = snapshot.getActionsRemainingToGoal();
 				break;
 			case XP_LEFT:
-				leftStr = config.onScreenDisplayMode().toString();
+				leftStr = "XP Left";
 				rightNum = snapshot.getXpRemainingToGoal();
 				break;
 			case XP_GAINED:
 			default:
-				leftStr = config.onScreenDisplayMode().toString();
+				leftStr = "XP Gained";
 				rightNum = snapshot.getXpGainedInSession();
 				break;
 		}


### PR DESCRIPTION
https://github.com/runelite/runelite/pull/8816/files#diff-33d61506b07f292b5a93fe379bc9a203 broke it: 

![image](https://user-images.githubusercontent.com/8920674/57800417-a96c1580-7751-11e9-8843-2a6404543b04.png)
