### PR TITLE
New Plugin: Walk Here

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/walkhere/WalkHereInputListener.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/walkhere/WalkHereInputListener.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2019, Thource <reyitgex@hotmail.co.uk>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.walkhere;
+
+import net.runelite.client.input.KeyListener;
+
+import javax.inject.Inject;
+import java.awt.event.KeyEvent;
+
+public class WalkHereInputListener implements KeyListener
+{
+	private static final int HOTKEY = KeyEvent.VK_CONTROL;
+
+	private final WalkHerePlugin plugin;
+
+	@Inject
+	private WalkHereInputListener(WalkHerePlugin plugin)
+	{
+		this.plugin = plugin;
+	}
+
+	@Override
+	public void keyTyped(KeyEvent e)
+	{
+
+	}
+
+	@Override
+	public void keyPressed(KeyEvent e)
+	{
+		if (e.getKeyCode() == HOTKEY)
+		{
+			plugin.setHotKeyPressed(true);
+		}
+	}
+
+	@Override
+	public void keyReleased(KeyEvent e)
+	{
+		if (e.getKeyCode() == HOTKEY)
+		{
+			plugin.setHotKeyPressed(false);
+		}
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/walkhere/WalkHerePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/walkhere/WalkHerePlugin.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2019, Thource <reyitgex@hotmail.co.uk>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.walkhere;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.Setter;
+import net.runelite.api.Client;
+import net.runelite.api.MenuAction;
+import net.runelite.api.MenuEntry;
+import net.runelite.api.events.ClientTick;
+import net.runelite.api.events.FocusChanged;
+import net.runelite.client.eventbus.Subscribe;
+import net.runelite.client.input.KeyManager;
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginDescriptor;
+
+import javax.inject.Inject;
+import java.util.*;
+
+@PluginDescriptor(
+	name = "Walk Here",
+	description = "Hold CTRL to put 'Walk Here' at the top of the menu, nothing will ever stop you from walking again!",
+	tags = {"walk"},
+	enabledByDefault = false
+)
+public class WalkHerePlugin extends Plugin
+{
+	@Inject
+	private Client client;
+
+	@Inject
+	private WalkHereInputListener inputListener;
+
+	@Inject
+	private KeyManager keyManager;
+
+	private static final int WALK = MenuAction.WALK.getId();
+
+	@Getter(AccessLevel.PACKAGE)
+	@Setter(AccessLevel.PACKAGE)
+	private boolean hotKeyPressed;
+
+	@Override
+	protected void startUp() throws Exception
+	{
+		keyManager.registerKeyListener(inputListener);
+	}
+
+	@Override
+	protected void shutDown() throws Exception
+	{
+		keyManager.unregisterKeyListener(inputListener);
+	}
+
+	@Subscribe
+	public void onFocusChanged(FocusChanged focusChanged)
+	{
+		if (!focusChanged.isFocused())
+		{
+			hotKeyPressed = false;
+		}
+	}
+
+	@Subscribe
+	public void onClientTick(ClientTick event)
+	{
+		final MenuEntry[] menuEntries = client.getMenuEntries();
+
+		if (hotKeyPressed)
+		{
+			Arrays.sort(menuEntries, (a, b) ->
+			{
+				if (a.getType() == WALK)
+					return 1;
+				if (b.getType() == WALK)
+					return -1;
+
+				return 0;
+			});
+		}
+
+		client.setMenuEntries(menuEntries);
+	}
+}


### PR DESCRIPTION
Walk Here is a plugin that moves the Walk action to the top of the menu when holding control, it's useful for things like easily walking under monsters