### PR TITLE
Explorer's ring overlay

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/Varbits.java
+++ b/runelite-api/src/main/java/net/runelite/api/Varbits.java
@@ -487,7 +487,15 @@ public enum Varbits
 	/**
 	 * The active tab within the quest interface
 	 */
-	QUEST_TAB(8168);
+	QUEST_TAB(8168),
+
+	/**
+	 * Explorer ring
+	 */
+	EXPLORER_RING_ALCHTYPE(5398),
+	EXPLORER_RING_TELEPORTS(4552),
+	EXPLORER_RING_ALCHS(4554),
+	EXPLORER_RING_RUNENERGY(4553);
 
 	/**
 	 * The raw varbit ID.

--- a/runelite-client/src/main/java/net/runelite/client/plugins/explorerring/ExplorerRingConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/explorerring/ExplorerRingConfig.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2019, Aleios <https://github.com/aleios>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.explorerring;
+
+import java.awt.Color;
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+
+@ConfigGroup("explorerring")
+public interface ExplorerRingConfig extends Config
+{
+	@ConfigItem(
+		keyName = "fontcolor",
+		name = "Font Color",
+		description = "Color of the font for the number of charges",
+		position = 1
+	)
+	default Color fontColor()
+	{
+		return Color.yellow;
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/explorerring/ExplorerRingConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/explorerring/ExplorerRingConfig.java
@@ -28,6 +28,7 @@ import java.awt.Color;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
+import net.runelite.client.plugins.explorerring.config.ExplorerRingOverlayMode;
 
 @ConfigGroup("explorerring")
 public interface ExplorerRingConfig extends Config
@@ -41,5 +42,16 @@ public interface ExplorerRingConfig extends Config
 	default Color fontColor()
 	{
 		return Color.yellow;
+	}
+
+	@ConfigItem(
+		keyName = "explorerRingOverlayMode",
+		name = "Display mode",
+		description = "Configures where explorer ring overlay is displayed",
+		position = 3
+	)
+	default ExplorerRingOverlayMode explorerRingOverlayMode()
+	{
+		return ExplorerRingOverlayMode.BOTH;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/explorerring/ExplorerRingOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/explorerring/ExplorerRingOverlay.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2019, Aleios <https://github.com/aleios>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.explorerring;
+
+import javax.inject.Inject;
+import net.runelite.api.Client;
+import net.runelite.api.ItemID;
+import net.runelite.api.Point;
+import net.runelite.api.Varbits;
+import net.runelite.api.widgets.WidgetItem;
+import net.runelite.client.ui.FontManager;
+import net.runelite.client.ui.overlay.WidgetItemOverlay;
+
+import java.awt.*;
+import net.runelite.client.ui.overlay.tooltip.TooltipManager;
+
+public class ExplorerRingOverlay extends WidgetItemOverlay
+{
+	private static final Varbits TELEPORTS = Varbits.EXPLORER_RING_TELEPORTS;
+	private static final Varbits ALCHS = Varbits.EXPLORER_RING_ALCHS;
+	private static final Varbits RUNENERGY = Varbits.EXPLORER_RING_RUNENERGY;
+	private static final Varbits ALCHTYPE = Varbits.EXPLORER_RING_ALCHTYPE;
+
+	private static final int MAX_ALCHS = 30;
+	private static final int MAX_TELEPORTS = 3;
+	private static final int[] MAX_RUNREPLENISH = {
+		2,
+		3,
+		4,
+		3
+	};
+
+	private final Client client;
+	private final ExplorerRingConfig config;
+
+	@Inject
+	ExplorerRingOverlay(Client client, ExplorerRingConfig config, TooltipManager tooltipManager)
+	{
+		this.client = client;
+		this.config = config;
+
+		showOnInventory();
+		showOnBank();
+		showOnEquipment();
+	}
+
+	@Override
+	public void renderItemOverlay(Graphics2D graphics, int itemId, WidgetItem itemWidget)
+	{
+		if (itemId < ItemID.EXPLORERS_RING_1 || itemId > ItemID.EXPLORERS_RING_4)
+			return;
+
+		graphics.setFont(FontManager.getRunescapeSmallFont());
+
+		Point location = itemWidget.getCanvasLocation();
+		StringBuilder tooltipBuilder = new StringBuilder();
+
+		// Pen position tracking.
+		int penShadowY = location.getY();
+		int penY = location.getY();
+
+		// Alchemy (level 4 ring is High Alc)
+		int alchAmount = client.getVar(ALCHS);
+		String alchStr = "A: " + (MAX_ALCHS - alchAmount);
+
+		penShadowY += 1 + (graphics.getFontMetrics().getHeight() - 1);
+		graphics.setColor(Color.BLACK);
+		graphics.drawString(alchStr, location.getX() + 1,
+				penShadowY);
+
+		penY += (graphics.getFontMetrics().getHeight() - 1);
+		graphics.setColor(config.fontColor());
+		graphics.drawString(alchStr, location.getX(),
+				penY);
+
+		// Run energy
+		int runAmount = client.getVar(RUNENERGY);
+		String runStr = "R: " + (MAX_RUNREPLENISH[itemId - ItemID.EXPLORERS_RING_1] - runAmount);
+
+		penShadowY += 1 + (graphics.getFontMetrics().getHeight() - 1);
+		graphics.setColor(Color.BLACK);
+		graphics.drawString(runStr, location.getX() + 1,
+				penShadowY);
+
+		penY += (graphics.getFontMetrics().getHeight() - 1);
+		graphics.setColor(config.fontColor());
+		graphics.drawString(runStr, location.getX(),
+				penY);
+
+		// Teleport charges (unique to level 2 ring).
+		if (itemId == ItemID.EXPLORERS_RING_2)
+		{
+			int amount = client.getVar(TELEPORTS);
+			String teleStr = "T: " + (MAX_TELEPORTS - amount);
+
+			penShadowY += 1 + (graphics.getFontMetrics().getHeight() - 1);
+			graphics.setColor(Color.BLACK);
+			graphics.drawString(teleStr, location.getX() + 2,
+					penShadowY);
+
+			penY += (graphics.getFontMetrics().getHeight() - 1);
+			graphics.setColor(config.fontColor());
+			graphics.drawString(teleStr, location.getX() + 1,
+					penY);
+		}
+
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/explorerring/ExplorerRingPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/explorerring/ExplorerRingPlugin.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2019, Aleios <https://github.com/aleios>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.explorerring;
+
+import com.google.inject.Provides;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.ui.overlay.OverlayManager;
+
+import javax.inject.Inject;
+
+@PluginDescriptor(
+	name = "Explorer Ring",
+	description = "Show the charges left on your explorers ring",
+	tags = {"combat", "magic", "overlay"}
+)
+
+public class ExplorerRingPlugin extends Plugin
+{
+	@Inject
+	private OverlayManager overlayManager;
+
+	@Inject
+	private ExplorerRingOverlay overlay;
+
+	@Provides
+	ExplorerRingConfig getConfig(ConfigManager configManager)
+	{
+		return configManager.getConfig(ExplorerRingConfig.class);
+	}
+
+	@Override
+	protected void startUp() throws Exception
+	{
+		overlayManager.add(overlay);
+	}
+
+	@Override
+	protected void shutDown() throws Exception
+	{
+		overlayManager.remove(overlay);
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/explorerring/config/ExplorerRingOverlayMode.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/explorerring/config/ExplorerRingOverlayMode.java
@@ -22,45 +22,11 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package net.runelite.client.plugins.explorerring;
+package net.runelite.client.plugins.explorerring.config;
 
-import com.google.inject.Provides;
-import net.runelite.client.config.ConfigManager;
-import net.runelite.client.plugins.Plugin;
-import net.runelite.client.plugins.PluginDescriptor;
-import net.runelite.client.ui.overlay.OverlayManager;
-
-import javax.inject.Inject;
-
-@PluginDescriptor(
-	name = "Explorer Ring",
-	description = "Show the charges left on your explorer's ring",
-	tags = {"combat", "magic", "overlay"}
-)
-
-public class ExplorerRingPlugin extends Plugin
+public enum ExplorerRingOverlayMode
 {
-	@Inject
-	private OverlayManager overlayManager;
-
-	@Inject
-	private ExplorerRingOverlay overlay;
-
-	@Provides
-	ExplorerRingConfig getConfig(ConfigManager configManager)
-	{
-		return configManager.getConfig(ExplorerRingConfig.class);
-	}
-
-	@Override
-	protected void startUp() throws Exception
-	{
-		overlayManager.add(overlay);
-	}
-
-	@Override
-	protected void shutDown() throws Exception
-	{
-		overlayManager.remove(overlay);
-	}
+	INVENTORY,
+	MOUSE_HOVER,
+	BOTH
 }


### PR DESCRIPTION
Adds an overlay to the explorer's ring showing the remaining charges on High/Low-Alchemy, Run energy replenishment, and Teleports(If level-2 ring). 

![ering-3](https://user-images.githubusercontent.com/3796313/57906977-37194380-78bf-11e9-9d5f-49fa0551be04.png)

![ering-2](https://user-images.githubusercontent.com/3796313/57906983-3e405180-78bf-11e9-838f-096d3885d67e.png)

Plugin has same options that rune pouch plugin provides including text color and switching the display mode to allow showing in inventory, tooltip or both.

![ering-4](https://user-images.githubusercontent.com/3796313/57906948-1cdf6580-78bf-11e9-8033-3e79a263f015.png)

I think maybe the text needs to be changed. I am open to suggestion.
