### PR TITLE
Add configurable bottom line contents for XP tracker

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpInfoBoxOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpInfoBoxOverlay.java
@@ -125,14 +125,30 @@ class XpInfoBoxOverlay extends Overlay
 			.right(StackFormatter.quantityToRSDecimalStack(rightNum, true))
 			.build();
 
-		final LineComponent xpHour = LineComponent.builder()
-				.left("XP/Hour:")
-				.right(StackFormatter.quantityToRSDecimalStack(snapshot.getXpPerHour(), true))
+		final String bottemLeftStr;
+		final int bottomRightNum;
+
+		switch (config.onScreenDisplayModeBottom())
+		{
+			case ACTIONS_HOUR:
+				bottemLeftStr = snapshot.getActionType().getLabel() + "/Hour";
+				bottomRightNum = snapshot.getActionsPerHour();
+				break;
+			case XP_HOUR:
+			default:
+				bottemLeftStr = "XP/Hour";
+				bottomRightNum = snapshot.getXpPerHour();
+				break;
+		}
+
+		final LineComponent xpLineBottom = LineComponent.builder()
+				.left(bottemLeftStr + ":")
+				.right(StackFormatter.quantityToRSDecimalStack(bottomRightNum, true))
 				.build();
 
 		final SplitComponent xpSplit = SplitComponent.builder()
 				.first(xpLine)
-				.second(xpHour)
+				.second(xpLineBottom)
 				.orientation(ComponentOrientation.VERTICAL)
 				.build();
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerConfig.java
@@ -41,6 +41,13 @@ public interface XpTrackerConfig extends Config
 		ACTIONS_LEFT
 	}
 
+	@AllArgsConstructor
+	enum OnScreenDisplayModeBottom
+	{
+		XP_HOUR,
+		ACTIONS_HOUR,
+	}
+
 	@ConfigItem(
 		position = 0,
 		keyName = "hideMaxed",
@@ -88,11 +95,22 @@ public interface XpTrackerConfig extends Config
 	@ConfigItem(
 		position = 4,
 		keyName = "onScreenDisplayMode",
-		name = "On-screen tracker display mode",
+		name = "On-screen tracker display mode (top)",
 		description = "Configures the information displayed in the first line of on-screen XP overlays"
 	)
 	default OnScreenDisplayMode onScreenDisplayMode()
 	{
 		return OnScreenDisplayMode.XP_GAINED;
+	}
+
+	@ConfigItem(
+		position = 4,
+		keyName = "onScreenDisplayMode",
+		name = "On-screen tracker display mode (bottom)",
+		description = "Configures the information displayed in the second line of on-screen XP overlays"
+	)
+	default OnScreenDisplayModeBottom onScreenDisplayModeBottom()
+	{
+		return OnScreenDisplayModeBottom.XP_HOUR;
 	}
 }


### PR DESCRIPTION
Add option to switch between xp/hour and actions/hour for bottom line of
XP tracker.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>