### PR TITLE
Add MODPRIVATECHAT to chat command manager

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/chat/ChatCommandManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/chat/ChatCommandManager.java
@@ -98,6 +98,7 @@ public class ChatCommandManager implements ChatboxInputListener
 			case MODCHAT:
 			case FRIENDSCHAT:
 			case PRIVATECHAT:
+			case MODPRIVATECHAT:
 			case PRIVATECHATOUT:
 				break;
 			default:


### PR DESCRIPTION
This allows ChatCommandManager to handle also priv messages from pmods.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>