### PR TITLE
Add display current ping to world hopper

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/fps/FpsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/fps/FpsOverlay.java
@@ -31,6 +31,8 @@ import javax.inject.Inject;
 import net.runelite.api.Client;
 import net.runelite.api.Point;
 import net.runelite.api.events.FocusChanged;
+import net.runelite.api.widgets.Widget;
+import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
@@ -48,7 +50,7 @@ import net.runelite.client.ui.overlay.OverlayUtil;
 public class FpsOverlay extends Overlay
 {
 	private static final int Y_OFFSET = 1;
-	private static final int VALUE_X_OFFSET = 1;
+	private static final int X_OFFSET = 1;
 	private static final String FPS_STRING = " FPS";
 
 	// Local dependencies
@@ -91,13 +93,22 @@ public class FpsOverlay extends Overlay
 		{
 			return null;
 		}
+
+		// On resizable bottom line mode the logout button is at the top right, so offset the overlay
+		// to account for it
+		Widget logoutButton = client.getWidget(WidgetInfo.RESIZABLE_MINIMAP_LOGOUT_BUTTON);
+		int xOffset = X_OFFSET;
+		if (logoutButton != null && !logoutButton.isHidden())
+		{
+			xOffset += logoutButton.getWidth();
+		}
 		
 		final String text = client.getFPS() + FPS_STRING;
 		final int textWidth = graphics.getFontMetrics().stringWidth(text);
 		final int textHeight = graphics.getFontMetrics().getAscent() - graphics.getFontMetrics().getDescent();
 
 		final int width = (int) client.getRealDimensions().getWidth();
-		final Point point = new Point(width - textWidth - VALUE_X_OFFSET, textHeight + Y_OFFSET);
+		final Point point = new Point(width - textWidth - xOffset, textHeight + Y_OFFSET);
 		OverlayUtil.renderTextLocation(graphics, point, text, getFpsValueColor());
 
 		return null;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldHopperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldHopperConfig.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018, Lotto <https://github.com/devLotto>
+ * Copyright (c) 2019, gregg1494 <https://github.com/gregg1494>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -122,5 +123,16 @@ public interface WorldHopperConfig extends Config
 	default SubscriptionFilterMode subscriptionFilter()
 	{
 		return SubscriptionFilterMode.BOTH;
+	}
+
+	@ConfigItem(
+		keyName = "displayPing",
+		name = "Display current ping",
+		description = "Displays ping to current game world",
+		position = 7
+	)
+	default boolean displayPing()
+	{
+		return false;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldHopperPingOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldHopperPingOverlay.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2019, gregg1494 <https://github.com/gregg1494>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.worldhopper;
+
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Graphics2D;
+import javax.inject.Inject;
+import net.runelite.api.Client;
+import net.runelite.api.Point;
+import net.runelite.api.widgets.Widget;
+import net.runelite.api.widgets.WidgetInfo;
+import net.runelite.client.ui.overlay.Overlay;
+import net.runelite.client.ui.overlay.OverlayLayer;
+import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.OverlayPriority;
+import net.runelite.client.ui.overlay.OverlayUtil;
+
+class WorldHopperPingOverlay extends Overlay
+{
+	private static final int Y_OFFSET = 11;
+	private static final int X_OFFSET = 1;
+
+	private final Client client;
+	private final WorldHopperPlugin worldHopperPlugin;
+	private final WorldHopperConfig worldHopperConfig;
+
+	@Inject
+	private WorldHopperPingOverlay(Client client, WorldHopperPlugin worldHopperPlugin, WorldHopperConfig worldHopperConfig)
+	{
+		this.client = client;
+		this.worldHopperPlugin = worldHopperPlugin;
+		this.worldHopperConfig = worldHopperConfig;
+		setLayer(OverlayLayer.ABOVE_WIDGETS);
+		setPriority(OverlayPriority.HIGH);
+		setPosition(OverlayPosition.DYNAMIC);
+	}
+
+	@Override
+	public Dimension render(Graphics2D graphics)
+	{
+		if (!worldHopperConfig.displayPing())
+		{
+			return null;
+		}
+
+		final int ping = worldHopperPlugin.getCurrentPing();
+		if (ping < 0)
+		{
+			return null;
+		}
+
+		final String text = ping + " ms";
+		final int textWidth = graphics.getFontMetrics().stringWidth(text);
+		final int textHeight = graphics.getFontMetrics().getAscent() - graphics.getFontMetrics().getDescent();
+
+		// Adjust ping offset for logout button
+		Widget logoutButton = client.getWidget(WidgetInfo.RESIZABLE_MINIMAP_LOGOUT_BUTTON);
+		int xOffset = X_OFFSET;
+		if (logoutButton != null && !logoutButton.isHidden())
+		{
+			xOffset += logoutButton.getWidth();
+		}
+
+		final int width = (int) client.getRealDimensions().getWidth();
+		final Point point = new Point(width - textWidth - xOffset, textHeight + Y_OFFSET);
+		OverlayUtil.renderTextLocation(graphics, point, text, Color.YELLOW);
+
+		return null;
+	}
+}


### PR DESCRIPTION
![ping](https://user-images.githubusercontent.com/14902604/57975863-3e605000-7998-11e9-9ff2-93f8850b7ef7.gif)

Moved my other PR into world hopper as it was redundant to have its own plugin. The current ping time is every second. It can be changed if that is too frequent. 

If display current ping is checked it will also update the world hopper ping panel as well, so they are consistent.