### PR TITLE
Fix wine fermentation timer to begin at appropriate time

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/cooking/CookingPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cooking/CookingPlugin.java
@@ -31,7 +31,11 @@ import java.time.Instant;
 import javax.inject.Inject;
 import lombok.AccessLevel;
 import lombok.Getter;
+import static net.runelite.api.AnimationID.COOKING_WINE;
 import net.runelite.api.ChatMessageType;
+import net.runelite.api.Client;
+import net.runelite.api.Player;
+import net.runelite.api.events.AnimationChanged;
 import net.runelite.api.events.ChatMessage;
 import net.runelite.api.events.GameTick;
 import net.runelite.client.config.ConfigManager;
@@ -50,7 +54,8 @@ import net.runelite.client.ui.overlay.OverlayManager;
 @PluginDependency(XpTrackerPlugin.class)
 public class CookingPlugin extends Plugin
 {
-	private static final String WINE_MESSAGE = "You squeeze the grapes into the jug";
+	@Inject
+	private Client client;
 
 	@Inject
 	private CookingConfig config;
@@ -125,6 +130,27 @@ public class CookingPlugin extends Plugin
 	}
 
 	@Subscribe
+	public void onAnimationChanged(AnimationChanged animationChanged)
+	{
+		Player localPlayer = client.getLocalPlayer();
+
+		if (localPlayer != animationChanged.getActor())
+		{
+			return;
+		}
+
+		if (localPlayer.getAnimation() == COOKING_WINE && config.fermentTimer())
+		{
+			if (fermentTimerSession == null)
+			{
+				fermentTimerSession = new FermentTimerSession();
+			}
+
+			fermentTimerSession.updateLastWineMakingAction();
+		}
+	}
+
+	@Subscribe
 	public void onChatMessage(ChatMessage event)
 	{
 		if (event.getType() != ChatMessageType.SPAM)
@@ -134,22 +160,11 @@ public class CookingPlugin extends Plugin
 
 		final String message = event.getMessage();
 
-		if (message.startsWith(WINE_MESSAGE) && config.fermentTimer())
-		{
-			if (fermentTimerSession == null)
-			{
-				fermentTimerSession = new FermentTimerSession();
-			}
-
-			fermentTimerSession.updateLastWineMakingAction();
-		}
-
 		if (message.startsWith("You successfully cook")
 			|| message.startsWith("You successfully bake")
 			|| message.startsWith("You manage to cook")
 			|| message.startsWith("You roast a")
-			|| message.startsWith("You cook")
-			|| message.startsWith(WINE_MESSAGE))
+			|| message.startsWith("You cook"))
 		{
 			if (cookingSession == null)
 			{

--- a/runelite-client/src/test/java/net/runelite/client/plugins/cooking/CookingPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/cooking/CookingPluginTest.java
@@ -29,12 +29,11 @@ import com.google.inject.testing.fieldbinder.Bind;
 import com.google.inject.testing.fieldbinder.BoundFieldModule;
 import javax.inject.Inject;
 import net.runelite.api.ChatMessageType;
+import net.runelite.api.Client;
 import net.runelite.api.events.ChatMessage;
 import net.runelite.client.ui.overlay.OverlayManager;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.mockito.Mockito.when;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -52,12 +51,15 @@ public class CookingPluginTest
 		"You cook the karambwan. It looks delicious.",
 		"You roast a lobster.",
 		"You cook a bass.",
-		"You squeeze the grapes into the jug. The wine begins to ferment.",
 		"You successfully bake a tasty garden pie."
 	};
 
 	@Inject
 	CookingPlugin cookingPlugin;
+
+	@Mock
+	@Bind
+	Client client;
 
 	@Mock
 	@Bind
@@ -93,27 +95,5 @@ public class CookingPluginTest
 		CookingSession cookingSession = cookingPlugin.getCookingSession();
 		assertNotNull(cookingSession);
 		assertEquals(COOKING_MESSAGES.length, cookingSession.getCookAmount());
-	}
-
-	@Test
-	public void testFermentTimerOnChatMessage()
-	{
-		when(config.fermentTimer()).thenReturn(true);
-		ChatMessage chatMessage = new ChatMessage(null, ChatMessageType.SPAM, "", COOKING_MESSAGES[6], "", 0);
-		cookingPlugin.onChatMessage(chatMessage);
-		FermentTimerSession fermentTimerSession = cookingPlugin.getFermentTimerSession();
-
-		assertNotNull(fermentTimerSession);
-	}
-
-	@Test
-	public void testFermentTimerOnChatMessage_pluginDisabled()
-	{
-		when(config.fermentTimer()).thenReturn(false);
-		ChatMessage chatMessage = new ChatMessage(null, ChatMessageType.SPAM, "", COOKING_MESSAGES[6], "", 0);
-		cookingPlugin.onChatMessage(chatMessage);
-		FermentTimerSession fermentTimerSession = cookingPlugin.getFermentTimerSession();
-
-		assertNull(fermentTimerSession);
 	}
 }


### PR DESCRIPTION
Previously, the wine fermentation timer would enter into a negative range if the user cooked an inventory full of wine and then tried to cook another inventory.

This change resets the fermentation timer each time the player is performing the wine cooking animation, giving a more accurate measure of the remaining time to fermentation.