### PR TITLE
Added config for showing stat overlay for worn equipment

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatConfig.java
@@ -53,6 +53,16 @@ public interface ItemStatConfig extends Config
 	}
 
 	@ConfigItem(
+			keyName = "showInEquipmentGroup",
+			name = "Show in worn equipment",
+			description = "Will show equipment stat tooltips within worn equipment"
+	)
+	default boolean showInEquipmentGroup()
+	{
+		return false;
+	}
+
+	@ConfigItem(
 		keyName = "geStats",
 		name = "Enable GE item information",
 		description = "Shows an item information panel when buying items in the GE"

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatOverlay.java
@@ -143,7 +143,7 @@ public class ItemStatOverlay extends Overlay
 
 			if (stats != null)
 			{
-				final String tooltip = buildStatBonusString(stats);
+				final String tooltip = buildStatBonusString(stats, group);
 
 				if (!tooltip.isEmpty())
 				{
@@ -186,33 +186,37 @@ public class ItemStatOverlay extends Overlay
 		return label + ": " + ColorUtil.wrapWithColorTag(prefix + valueString + suffix, color) + "</br>";
 	}
 
-	private String buildStatBonusString(ItemStats s)
+	private String buildStatBonusString(ItemStats s, int groupId)
 	{
 		final StringBuilder b = new StringBuilder();
 		b.append(getChangeString("Weight", s.getWeight(), true, false));
 
 		ItemStats other = null;
-		final ItemEquipmentStats currentEquipment = s.getEquipment();
 
-		ItemContainer c = client.getItemContainer(InventoryID.EQUIPMENT);
-		if (s.isEquipable() && currentEquipment != null && c != null)
+		if (!(config.showInEquipmentGroup() && groupId == WidgetInfo.EQUIPMENT.getGroupId()))
 		{
-			final Item[] items = c.getItems();
-			final int slot = currentEquipment.getSlot();
+			final ItemEquipmentStats currentEquipment = s.getEquipment();
+			ItemContainer c = client.getItemContainer(InventoryID.EQUIPMENT);
 
-			if (slot != -1 && slot < items.length)
+			if (s.isEquipable() && currentEquipment != null && c != null)
 			{
-				final Item item = items[slot];
-				if (item != null)
+				final Item[] items = c.getItems();
+				final int slot = currentEquipment.getSlot();
+
+				if (slot != -1 && slot < items.length)
 				{
-					other = itemManager.getItemStats(item.getId(), false);
+					final Item item = items[slot];
+					if (item != null)
+					{
+						other = itemManager.getItemStats(item.getId(), false);
+					}
 				}
-			}
 
-			if (other == null && slot == EquipmentInventorySlot.WEAPON.getSlotIdx())
-			{
-				// Unarmed
-				other = UNARMED;
+				if (other == null && slot == EquipmentInventorySlot.WEAPON.getSlotIdx())
+				{
+					// Unarmed
+					other = UNARMED;
+				}
 			}
 		}
 


### PR DESCRIPTION
Added a new config for the Item Stat plugin that will allow for stats to be displayed via the tooltip within the worn equipment tab of the interface. The default setting for this will be false, just since the majority of players likely won't enjoy having the tooltips showing up all of a sudden.

![image](https://user-images.githubusercontent.com/10378593/58232467-67614780-7cee-11e9-8e7e-aaf70126795a.png)

Similar to some of the other configs for this plugin, if "Enable equipment stats" is false, then the item stat tooltip will not show up within the worn equipment tab.