### PR TITLE
Rename WASDCamera to add Fn key remapped functionality

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/keyremapping/KeyRemappingConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/keyremapping/KeyRemappingConfig.java
@@ -35,6 +35,17 @@ public interface KeyRemappingConfig extends Config
 {
 	@ConfigItem(
 		position = 1,
+		keyName = "cameraRemap",
+		name = "Remap Camera",
+		description = "Configures whether the camera movement uses remapped keys"
+	)
+	default boolean cameraRemap()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		position = 2,
 		keyName = "up",
 		name = "Camera Up key",
 		description = "The key which will replace up."
@@ -45,7 +56,7 @@ public interface KeyRemappingConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 2,
+		position = 3,
 		keyName = "down",
 		name = "Camera Down key",
 		description = "The key which will replace down."
@@ -56,7 +67,7 @@ public interface KeyRemappingConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 3,
+		position = 4,
 		keyName = "left",
 		name = "Camera Left key",
 		description = "The key which will replace left."
@@ -67,7 +78,7 @@ public interface KeyRemappingConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 4,
+		position = 5,
 		keyName = "right",
 		name = "Camera Right key",
 		description = "The key which will replace right."
@@ -75,5 +86,16 @@ public interface KeyRemappingConfig extends Config
 	default ModifierlessKeybind right()
 	{
 		return new ModifierlessKeybind(KeyEvent.VK_D, 0);
+	}
+
+	@ConfigItem(
+		position = 6,
+		keyName = "fkeyRemap",
+		name = "Remap F Keys",
+		description = "Configures whether F-Keys are Remapped to 1 (F1) through 0 (F10), '-' (F11), and '=' (F12)"
+	)
+	default boolean fkeyRemap()
+	{
+		return false;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/keyremapping/KeyRemappingConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/keyremapping/KeyRemappingConfig.java
@@ -22,7 +22,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package net.runelite.client.plugins.wasdcamera;
+package net.runelite.client.plugins.keyremapping;
 
 import java.awt.event.KeyEvent;
 import net.runelite.client.config.Config;
@@ -30,13 +30,13 @@ import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
 import net.runelite.client.config.ModifierlessKeybind;
 
-@ConfigGroup("wasdcamera")
-public interface WASDCameraConfig extends Config
+@ConfigGroup("keyremapping")
+public interface KeyRemappingConfig extends Config
 {
 	@ConfigItem(
 		position = 1,
 		keyName = "up",
-		name = "Up key",
+		name = "Camera Up key",
 		description = "The key which will replace up."
 	)
 	default ModifierlessKeybind up()
@@ -47,7 +47,7 @@ public interface WASDCameraConfig extends Config
 	@ConfigItem(
 		position = 2,
 		keyName = "down",
-		name = "Down key",
+		name = "Camera Down key",
 		description = "The key which will replace down."
 	)
 	default ModifierlessKeybind down()
@@ -58,7 +58,7 @@ public interface WASDCameraConfig extends Config
 	@ConfigItem(
 		position = 3,
 		keyName = "left",
-		name = "Left key",
+		name = "Camera Left key",
 		description = "The key which will replace left."
 	)
 	default ModifierlessKeybind left()
@@ -69,7 +69,7 @@ public interface WASDCameraConfig extends Config
 	@ConfigItem(
 		position = 4,
 		keyName = "right",
-		name = "Right key",
+		name = "Camera Right key",
 		description = "The key which will replace right."
 	)
 	default ModifierlessKeybind right()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/keyremapping/KeyRemappingListener.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/keyremapping/KeyRemappingListener.java
@@ -34,11 +34,26 @@ import net.runelite.api.Client;
 import net.runelite.api.GameState;
 import net.runelite.api.VarClientStr;
 import net.runelite.client.callback.ClientThread;
+import net.runelite.client.config.Keybind;
+import net.runelite.client.config.ModifierlessKeybind;
 import net.runelite.client.input.KeyListener;
 import net.runelite.client.input.MouseAdapter;
 
 class KeyRemappingListener extends MouseAdapter implements KeyListener
 {
+	private static final Keybind ONE = new ModifierlessKeybind(KeyEvent.VK_1, 0);
+	private static final Keybind TWO = new ModifierlessKeybind(KeyEvent.VK_2, 0);
+	private static final Keybind THREE = new ModifierlessKeybind(KeyEvent.VK_3, 0);
+	private static final Keybind FOUR = new ModifierlessKeybind(KeyEvent.VK_4, 0);
+	private static final Keybind FIVE = new ModifierlessKeybind(KeyEvent.VK_5, 0);
+	private static final Keybind SIX = new ModifierlessKeybind(KeyEvent.VK_6, 0);
+	private static final Keybind SEVEN = new ModifierlessKeybind(KeyEvent.VK_7, 0);
+	private static final Keybind EIGHT = new ModifierlessKeybind(KeyEvent.VK_8, 0);
+	private static final Keybind NINE = new ModifierlessKeybind(KeyEvent.VK_9, 0);
+	private static final Keybind ZERO = new ModifierlessKeybind(KeyEvent.VK_0, 0);
+	private static final Keybind MINUS = new ModifierlessKeybind(KeyEvent.VK_MINUS, 0);
+	private static final Keybind EQUALS = new ModifierlessKeybind(KeyEvent.VK_EQUALS, 0);
+
 	@Inject
 	private KeyRemappingPlugin plugin;
 
@@ -68,42 +83,108 @@ class KeyRemappingListener extends MouseAdapter implements KeyListener
 
 		if (!plugin.isTyping())
 		{
-			if (config.up().matches(e))
+			if (config.cameraRemap())
 			{
-				modified.put(e.getKeyCode(), KeyEvent.VK_UP);
-				e.setKeyCode(KeyEvent.VK_UP);
-			}
-			else if (config.down().matches(e))
-			{
-				modified.put(e.getKeyCode(), KeyEvent.VK_DOWN);
-				e.setKeyCode(KeyEvent.VK_DOWN);
-			}
-			else if (config.left().matches(e))
-			{
-				modified.put(e.getKeyCode(), KeyEvent.VK_LEFT);
-				e.setKeyCode(KeyEvent.VK_LEFT);
-			}
-			else if (config.right().matches(e))
-			{
-				modified.put(e.getKeyCode(), KeyEvent.VK_RIGHT);
-				e.setKeyCode(KeyEvent.VK_RIGHT);
-			}
-			else
-			{
-				switch (e.getKeyCode())
+				if (config.up().matches(e))
 				{
-					case KeyEvent.VK_ENTER:
-					case KeyEvent.VK_SLASH:
-					case KeyEvent.VK_COLON:
-						// refocus chatbox
-						plugin.setTyping(true);
-						clientThread.invoke(() ->
-						{
-							plugin.unlockChat();
-						});
-						break;
+					modified.put(e.getKeyCode(), KeyEvent.VK_UP);
+					e.setKeyCode(KeyEvent.VK_UP);
+				}
+				else if (config.down().matches(e))
+				{
+					modified.put(e.getKeyCode(), KeyEvent.VK_DOWN);
+					e.setKeyCode(KeyEvent.VK_DOWN);
+				}
+				else if (config.left().matches(e))
+				{
+					modified.put(e.getKeyCode(), KeyEvent.VK_LEFT);
+					e.setKeyCode(KeyEvent.VK_LEFT);
+				}
+				else if (config.right().matches(e))
+				{
+					modified.put(e.getKeyCode(), KeyEvent.VK_RIGHT);
+					e.setKeyCode(KeyEvent.VK_RIGHT);
 				}
 			}
+
+			if (config.fkeyRemap())
+			{
+				if (ONE.matches(e))
+				{
+					modified.put(e.getKeyCode(), KeyEvent.VK_F1);
+					e.setKeyCode(KeyEvent.VK_F1);
+				}
+				else if (TWO.matches(e))
+				{
+					modified.put(e.getKeyCode(), KeyEvent.VK_F2);
+					e.setKeyCode(KeyEvent.VK_F2);
+				}
+				else if (THREE.matches(e))
+				{
+					modified.put(e.getKeyCode(), KeyEvent.VK_F3);
+					e.setKeyCode(KeyEvent.VK_F3);
+				}
+				else if (FOUR.matches(e))
+				{
+					modified.put(e.getKeyCode(), KeyEvent.VK_F4);
+					e.setKeyCode(KeyEvent.VK_F4);
+				}
+				else if (FIVE.matches(e))
+				{
+					modified.put(e.getKeyCode(), KeyEvent.VK_F5);
+					e.setKeyCode(KeyEvent.VK_F5);
+				}
+				else if (SIX.matches(e))
+				{
+					modified.put(e.getKeyCode(), KeyEvent.VK_F6);
+					e.setKeyCode(KeyEvent.VK_F6);
+				}
+				else if (SEVEN.matches(e))
+				{
+					modified.put(e.getKeyCode(), KeyEvent.VK_F7);
+					e.setKeyCode(KeyEvent.VK_F7);
+				}
+				else if (EIGHT.matches(e))
+				{
+					modified.put(e.getKeyCode(), KeyEvent.VK_F8);
+					e.setKeyCode(KeyEvent.VK_F8);
+				}
+				else if (NINE.matches(e))
+				{
+					modified.put(e.getKeyCode(), KeyEvent.VK_F9);
+					e.setKeyCode(KeyEvent.VK_F9);
+				}
+				else if (ZERO.matches(e))
+				{
+					modified.put(e.getKeyCode(), KeyEvent.VK_F10);
+					e.setKeyCode(KeyEvent.VK_F10);
+				}
+				else if (MINUS.matches(e))
+				{
+					modified.put(e.getKeyCode(), KeyEvent.VK_F11);
+					e.setKeyCode(KeyEvent.VK_F11);
+				}
+				else if (EQUALS.matches(e))
+				{
+					modified.put(e.getKeyCode(), KeyEvent.VK_F12);
+					e.setKeyCode(KeyEvent.VK_F12);
+				}
+			}
+
+			switch (e.getKeyCode())
+			{
+				case KeyEvent.VK_ENTER:
+				case KeyEvent.VK_SLASH:
+				case KeyEvent.VK_COLON:
+					// refocus chatbox
+					plugin.setTyping(true);
+					clientThread.invoke(() ->
+					{
+						plugin.unlockChat();
+					});
+					break;
+			}
+
 		}
 		else
 		{
@@ -146,21 +227,76 @@ class KeyRemappingListener extends MouseAdapter implements KeyListener
 		{
 			modified.remove(e.getKeyCode());
 
-			if (config.up().matches(e))
+			if (config.cameraRemap())
 			{
-				e.setKeyCode(KeyEvent.VK_UP);
+				if (config.up().matches(e))
+				{
+					e.setKeyCode(KeyEvent.VK_UP);
+				}
+				else if (config.down().matches(e))
+				{
+					e.setKeyCode(KeyEvent.VK_DOWN);
+				}
+				else if (config.left().matches(e))
+				{
+					e.setKeyCode(KeyEvent.VK_LEFT);
+				}
+				else if (config.right().matches(e))
+				{
+					e.setKeyCode(KeyEvent.VK_RIGHT);
+				}
 			}
-			else if (config.down().matches(e))
+
+			if (config.fkeyRemap())
 			{
-				e.setKeyCode(KeyEvent.VK_DOWN);
-			}
-			else if (config.left().matches(e))
-			{
-				e.setKeyCode(KeyEvent.VK_LEFT);
-			}
-			else if (config.right().matches(e))
-			{
-				e.setKeyCode(KeyEvent.VK_RIGHT);
+				if (ONE.matches(e))
+				{
+					e.setKeyCode(KeyEvent.VK_F1);
+				}
+				else if (TWO.matches(e))
+				{
+					e.setKeyCode(KeyEvent.VK_F2);
+				}
+				else if (THREE.matches(e))
+				{
+					e.setKeyCode(KeyEvent.VK_F3);
+				}
+				else if (FOUR.matches(e))
+				{
+					e.setKeyCode(KeyEvent.VK_F4);
+				}
+				else if (FIVE.matches(e))
+				{
+					e.setKeyCode(KeyEvent.VK_F5);
+				}
+				else if (SIX.matches(e))
+				{
+					e.setKeyCode(KeyEvent.VK_F6);
+				}
+				else if (SEVEN.matches(e))
+				{
+					e.setKeyCode(KeyEvent.VK_F7);
+				}
+				else if (EIGHT.matches(e))
+				{
+					e.setKeyCode(KeyEvent.VK_F8);
+				}
+				else if (NINE.matches(e))
+				{
+					e.setKeyCode(KeyEvent.VK_F9);
+				}
+				else if (ZERO.matches(e))
+				{
+					e.setKeyCode(KeyEvent.VK_F10);
+				}
+				else if (MINUS.matches(e))
+				{
+					e.setKeyCode(KeyEvent.VK_F11);
+				}
+				else if (EQUALS.matches(e))
+				{
+					e.setKeyCode(KeyEvent.VK_F12);
+				}
 			}
 		}
 		else

--- a/runelite-client/src/main/java/net/runelite/client/plugins/keyremapping/KeyRemappingListener.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/keyremapping/KeyRemappingListener.java
@@ -23,7 +23,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package net.runelite.client.plugins.wasdcamera;
+package net.runelite.client.plugins.keyremapping;
 
 import com.google.common.base.Strings;
 import java.awt.event.KeyEvent;
@@ -37,13 +37,13 @@ import net.runelite.client.callback.ClientThread;
 import net.runelite.client.input.KeyListener;
 import net.runelite.client.input.MouseAdapter;
 
-class WASDCameraListener extends MouseAdapter implements KeyListener
+class KeyRemappingListener extends MouseAdapter implements KeyListener
 {
 	@Inject
-	private WASDCameraPlugin plugin;
+	private KeyRemappingPlugin plugin;
 
 	@Inject
-	private WASDCameraConfig config;
+	private KeyRemappingConfig config;
 
 	@Inject
 	private Client client;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/keyremapping/KeyRemappingPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/keyremapping/KeyRemappingPlugin.java
@@ -51,7 +51,7 @@ import net.runelite.client.util.ColorUtil;
 
 @PluginDescriptor(
 	name = "Key Remapping",
-	description = "Allows use of WASD keys for camera movement with 'Press Enter to Chat'",
+	description = "Allows use of WASD keys for camera movement with 'Press Enter to Chat', and remapping number keys to F-keys",
 	tags = {"enter", "chat", "wasd", "camera"},
 	enabledByDefault = false
 )

--- a/runelite-client/src/main/java/net/runelite/client/plugins/keyremapping/KeyRemappingPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/keyremapping/KeyRemappingPlugin.java
@@ -23,7 +23,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package net.runelite.client.plugins.wasdcamera;
+package net.runelite.client.plugins.keyremapping;
 
 import com.google.inject.Provides;
 import java.awt.Color;
@@ -50,12 +50,12 @@ import net.runelite.client.ui.JagexColors;
 import net.runelite.client.util.ColorUtil;
 
 @PluginDescriptor(
-	name = "WASD Camera",
+	name = "Key Remapping",
 	description = "Allows use of WASD keys for camera movement with 'Press Enter to Chat'",
-	tags = {"enter", "chat"},
+	tags = {"enter", "chat", "wasd", "camera"},
 	enabledByDefault = false
 )
-public class WASDCameraPlugin extends Plugin
+public class KeyRemappingPlugin extends Plugin
 {
 	private static final String PRESS_ENTER_TO_CHAT = "Press Enter to Chat...";
 	private static final String SCRIPT_EVENT_SET_CHATBOX_INPUT = "setChatboxInput";
@@ -71,7 +71,7 @@ public class WASDCameraPlugin extends Plugin
 	private KeyManager keyManager;
 
 	@Inject
-	private WASDCameraListener inputListener;
+	private KeyRemappingListener inputListener;
 
 	@Getter(AccessLevel.PACKAGE)
 	@Setter(AccessLevel.PACKAGE)
@@ -107,9 +107,9 @@ public class WASDCameraPlugin extends Plugin
 	}
 
 	@Provides
-	WASDCameraConfig getConfig(ConfigManager configManager)
+	KeyRemappingConfig getConfig(ConfigManager configManager)
 	{
-		return configManager.getConfig(WASDCameraConfig.class);
+		return configManager.getConfig(KeyRemappingConfig.class);
 	}
 
 	boolean chatboxFocused()


### PR DESCRIPTION
This is a revised edition of the keyboard remapping that adds functionality for the use of Fn keys through their numerical counterparts (1~10). This consolidates WASD and the FN keys to one plugin with separated boolean configs, but keeping the wasd customization.

