### PR TITLE
clanchat plugin: add clan tab chat option

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/clanchat/ClanChatConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/clanchat/ClanChatConfig.java
@@ -126,4 +126,15 @@ public interface ClanChatConfig extends Config
 	{
 		return false;
 	}
+
+	@ConfigItem(
+		keyName = "clanTabChat",
+		name = "Clan Tab Chat",
+		description = "Allows clan chat without prepending '/' to messages when on clan tab",
+		position = 8
+	)
+	default boolean clanTabChat()
+	{
+		return false;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/clanchat/ClanChatPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/clanchat/ClanChatPlugin.java
@@ -60,6 +60,7 @@ import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.GameTick;
 import net.runelite.api.events.PlayerDespawned;
 import net.runelite.api.events.PlayerSpawned;
+import net.runelite.api.events.ScriptCallbackEvent;
 import net.runelite.api.events.VarClientStrChanged;
 import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetInfo;
@@ -489,6 +490,19 @@ public class ClanChatPlugin extends Plugin
 		}
 
 		activityBuffer.clear();
+	}
+
+	@Subscribe
+	public void onScriptCallbackEvent(ScriptCallbackEvent scriptCallbackEvent)
+	{
+		if (!scriptCallbackEvent.getEventName().equalsIgnoreCase("clanchatInput"))
+		{
+			return;
+		}
+
+		final int[] intStack = client.getIntStack();
+		final int size = client.getIntStackSize();
+		intStack[size - 1] = config.clanTabChat() ? 1 : 0;
 	}
 
 	int getClanAmount()

--- a/runelite-client/src/main/scripts/CommandScript.rs2asm
+++ b/runelite-client/src/main/scripts/CommandScript.rs2asm
@@ -37,6 +37,11 @@ LABEL20:
    invoke                 1972
    iconst                 1
    if_icmpeq              LABEL31
+   iconst                 0                 ; Modified to enable clanchat input
+   sconst                 "clanchatInput"
+   runelite_callback
+   iconst                 1
+   if_icmpeq              LABEL31           ; Compare to 1
    jump                   LABEL37
 LABEL31:
    get_varc_int           41


### PR DESCRIPTION
This allows typing messages with the clanchat tab focused without having
to prepend them with '/'.

Closes #4697
Closes #8264