### PR TITLE
Add JDK12 support and fix a "Illegal reflective access" warning

### DIFF
--- a/http-api/src/main/java/net/runelite/http/api/RuneLiteAPI.java
+++ b/http-api/src/main/java/net/runelite/http/api/RuneLiteAPI.java
@@ -25,8 +25,12 @@
 package net.runelite.http.api;
 
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonObject;
 import java.io.IOException;
 import java.io.InputStream;
+import java.time.Instant;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 import okhttp3.HttpUrl;
@@ -44,7 +48,7 @@ public class RuneLiteAPI
 	public static final String RUNELITE_AUTH = "RUNELITE-AUTH";
 
 	public static final OkHttpClient CLIENT;
-	public static final Gson GSON = new Gson();
+	public static final Gson GSON;
 	public static String userAgent;
 
 	private static final String BASE = "https://api.runelite.net";
@@ -56,6 +60,16 @@ public class RuneLiteAPI
 
 	static
 	{
+		GSON = new GsonBuilder()
+			.registerTypeAdapter(Instant.class, (JsonDeserializer<Instant>) (jsonElement, type, jsonDeserializationContext) ->
+			{
+				JsonObject jsonObject = jsonElement.getAsJsonObject();
+				long seconds = jsonObject.get("seconds").getAsLong();
+				long nanos = jsonObject.get("nanos").getAsLong();
+				return Instant.ofEpochSecond(seconds, nanos);
+			})
+			.create();
+
 		try
 		{
 			InputStream in = RuneLiteAPI.class.getResourceAsStream("/runelite.properties");

--- a/runelite-mixins/pom.xml
+++ b/runelite-mixins/pom.xml
@@ -78,13 +78,6 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<configuration>
-					<!-- RuneScape classes do not verify
-					 under Java 7+ due to the obfuscation
-					 -->
-					<source>1.6</source>
-					<target>1.6</target>
-				</configuration>
 			</plugin>
 		</plugins>
 	</build>


### PR DESCRIPTION
Remove 1.6 target for mixins project since this is no longer supported. Add a custom java.time.Instant Gson deserializer to fix a "Illegal reflective access" warning caused by `seconds` and `nanos` being private final fields.

<details><summary>Here is a snippet of the output from running mvn install before the pom.xml change.</summary>
<p>

```
[INFO] --- maven-compiler-plugin:3.6.1:compile (default-compile) @ mixins ---
[INFO] Changes detected - recompiling the module!
[INFO] Compiling 78 source files to C:\Source\IdeaProjects\runelite\runelite-mixins\target\classes
[INFO] -------------------------------------------------------------
[ERROR] COMPILATION ERROR : 
[INFO] -------------------------------------------------------------
[ERROR] Source option 6 is no longer supported. Use 7 or later.
[ERROR] Target option 6 is no longer supported. Use 7 or later.
[INFO] 2 errors 
[INFO] -------------------------------------------------------------
```

</p>
</details>

<details><summary>And here are the logs from running RuneLite before the Gson change, with the option --illegal-access=warn, using JDK12.</summary>
<p>

```
Connected to the target VM, address: '127.0.0.1:52019', transport: 'socket'
OpenJDK 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended
14:58:59,271 |-INFO in ch.qos.logback.classic.LoggerContext[default] - Could NOT find resource [logback-test.xml]
14:58:59,273 |-INFO in ch.qos.logback.classic.LoggerContext[default] - Could NOT find resource [logback.groovy]
14:58:59,273 |-INFO in ch.qos.logback.classic.LoggerContext[default] - Found resource [logback.xml] at [file:/C:/Source/IdeaProjects/runelite/runelite-client/target/classes/logback.xml]
14:58:59,369 |-INFO in ch.qos.logback.classic.joran.action.ConfigurationAction - debug attribute not set
14:58:59,379 |-INFO in ch.qos.logback.core.joran.action.AppenderAction - About to instantiate appender of type [ch.qos.logback.core.ConsoleAppender]
14:58:59,385 |-INFO in ch.qos.logback.core.joran.action.AppenderAction - Naming appender as [STDOUT]
14:58:59,401 |-INFO in ch.qos.logback.core.joran.action.NestedComplexPropertyIA - Assuming default type [ch.qos.logback.classic.encoder.PatternLayoutEncoder] for [encoder] property
14:58:59,466 |-INFO in ch.qos.logback.core.joran.action.AppenderAction - About to instantiate appender of type [ch.qos.logback.core.rolling.RollingFileAppender]
14:58:59,472 |-INFO in ch.qos.logback.core.joran.action.AppenderAction - Naming appender as [FILE]
14:58:59,492 |-INFO in c.q.l.core.rolling.TimeBasedRollingPolicy@1864230087 - No compression will be used
14:58:59,493 |-INFO in c.q.l.core.rolling.TimeBasedRollingPolicy@1864230087 - Will use the pattern C:/Users/[USER]/.runelite/logs/client_%d{yyyy-MM-dd}.%i.log for the active file
14:58:59,495 |-INFO in ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP@459e9125 - The date pattern is 'yyyy-MM-dd' from file name pattern 'C:/Users/[USER]/.runelite/logs/client_%d{yyyy-MM-dd}.%i.log'.
14:58:59,495 |-INFO in ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP@459e9125 - Roll-over at midnight.
14:58:59,502 |-INFO in ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP@459e9125 - Setting initial period to Sat Jun 01 14:58:56 NZST 2019
14:58:59,503 |-WARN in ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP@459e9125 - SizeAndTimeBasedFNATP is deprecated. Use SizeAndTimeBasedRollingPolicy instead
14:58:59,503 |-WARN in ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP@459e9125 - For more information see http://logback.qos.ch/manual/appenders.html#SizeAndTimeBasedRollingPolicy
14:58:59,505 |-INFO in ch.qos.logback.core.joran.action.NestedComplexPropertyIA - Assuming default type [ch.qos.logback.classic.encoder.PatternLayoutEncoder] for [encoder] property
14:58:59,507 |-INFO in ch.qos.logback.core.rolling.RollingFileAppender[FILE] - Active log file name: C:\Users\[USER]/.runelite/logs/client.log
14:58:59,507 |-INFO in ch.qos.logback.core.rolling.RollingFileAppender[FILE] - File property is set to [C:\Users\[USER]/.runelite/logs/client.log]
14:58:59,508 |-INFO in ch.qos.logback.classic.joran.action.RootLoggerAction - Setting level of ROOT logger to INFO
14:58:59,508 |-INFO in ch.qos.logback.core.joran.action.AppenderRefAction - Attaching appender named [STDOUT] to Logger[ROOT]
14:58:59,509 |-INFO in ch.qos.logback.core.joran.action.AppenderRefAction - Attaching appender named [FILE] to Logger[ROOT]
14:58:59,509 |-INFO in ch.qos.logback.classic.joran.action.ConfigurationAction - End of configuration.
14:58:59,509 |-INFO in ch.qos.logback.classic.joran.JoranConfigurator@128d2484 - Registering current configuration as safe fallback point

2019-06-01 14:59:03 [main] INFO  net.runelite.client.rs.ClientLoader - client-patch 223120882.151
2019-06-01 14:59:03 [main] INFO  n.r.client.account.SessionManager - No session file exists
2019-06-01 14:59:04 [main] INFO  n.r.c.plugins.kourendlibrary.Library - Library is now reset
WARNING: Illegal reflective access by com.google.gson.internal.reflect.UnsafeReflectionAccessor (file:/C:/Users/[USER]/.m2/repository/com/google/code/gson/gson/2.8.5/gson-2.8.5.jar) to field java.time.Instant.seconds
WARNING: Illegal reflective access by com.google.gson.internal.reflect.UnsafeReflectionAccessor (file:/C:/Users/[USER]/.m2/repository/com/google/code/gson/gson/2.8.5/gson-2.8.5.jar) to field java.time.Instant.nanos
2019-06-01 14:59:05 [AWT-EventQueue-0] INFO  net.runelite.client.ui.ClientUI - Showing frame net.runelite.client.ui.ContainableFrame[frame0,0,0,1920x1050,layout=java.awt.BorderLayout,title=RuneLite,resizable,maximized,defaultCloseOperation=DO_NOTHING_ON_CLOSE,rootPane=javax.swing.JRootPane[,0,0,809x534,layout=org.pushingpixels.substance.internal.ui.SubstanceRootPaneUI$SubstanceRootLayout,alignmentX=0.0,alignmentY=0.0,border=org.pushingpixels.substance.internal.utils.border.SubstancePaneBorder@16e4440b,flags=16777673,maximumSize=,minimumSize=,preferredSize=],rootPaneCheckingEnabled=true]
2019-06-01 14:59:05 [main] INFO  n.r.client.discord.DiscordService - Initializing Discord RPC service.
2019-06-01 14:59:08 [main] INFO  net.runelite.client.RuneLite - Client initialization took 8948ms. Uptime: 9443ms
WARNING: Illegal reflective access by com.jogamp.common.os.NativeLibrary$3 (file:/C:/Users/[USER]/.m2/repository/org/jogamp/gluegen/gluegen-rt/2.3.2/gluegen-rt-2.3.2.jar) to method java.lang.ClassLoader.findLibrary(java.lang.String)
WARNING: Illegal reflective access by jogamp.opengl.awt.Java2D$2 (file:/C:/Users/[USER]/.m2/repository/org/jogamp/jogl/jogl-all/2.3.2/jogl-all-2.3.2.jar) to field sun.java2d.opengl.OGLUtilities.UNDEFINED
WARNING: Illegal reflective access by jogamp.opengl.awt.Java2D$2 (file:/C:/Users/[USER]/.m2/repository/org/jogamp/jogl/jogl-all/2.3.2/jogl-all-2.3.2.jar) to field sun.java2d.opengl.OGLUtilities.WINDOW
WARNING: Illegal reflective access by jogamp.opengl.awt.Java2D$2 (file:/C:/Users/[USER]/.m2/repository/org/jogamp/jogl/jogl-all/2.3.2/jogl-all-2.3.2.jar) to field sun.java2d.opengl.OGLUtilities.TEXTURE
WARNING: Illegal reflective access by jogamp.opengl.awt.Java2D$2 (file:/C:/Users/[USER]/.m2/repository/org/jogamp/jogl/jogl-all/2.3.2/jogl-all-2.3.2.jar) to field sun.java2d.opengl.OGLUtilities.FLIP_BACKBUFFER
WARNING: Illegal reflective access by jogamp.opengl.awt.Java2D$2 (file:/C:/Users/[USER]/.m2/repository/org/jogamp/jogl/jogl-all/2.3.2/jogl-all-2.3.2.jar) to field sun.java2d.opengl.OGLUtilities.FBOBJECT
WARNING: Illegal reflective access by jogamp.nativewindow.jawt.JAWTUtil$1 (file:/C:/Users/[USER]/.m2/repository/org/jogamp/jogl/jogl-all/2.3.2/jogl-all-2.3.2.jar) to method sun.awt.SunToolkit.awtLock()
WARNING: Illegal reflective access by jogamp.nativewindow.jawt.JAWTUtil$1 (file:/C:/Users/[USER]/.m2/repository/org/jogamp/jogl/jogl-all/2.3.2/jogl-all-2.3.2.jar) to method sun.awt.SunToolkit.awtUnlock()
WARNING: Illegal reflective access by jogamp.nativewindow.jawt.windows.Win32SunJDKReflection$1 (file:/C:/Users/[USER]/.m2/repository/org/jogamp/jogl/jogl-all/2.3.2/jogl-all-2.3.2.jar) to method sun.awt.Win32GraphicsConfig.getConfig(sun.awt.Win32GraphicsDevice,int)
WARNING: Illegal reflective access by jogamp.nativewindow.jawt.windows.Win32SunJDKReflection$1 (file:/C:/Users/[USER]/.m2/repository/org/jogamp/jogl/jogl-all/2.3.2/jogl-all-2.3.2.jar) to method sun.awt.Win32GraphicsConfig.getVisual()
WARNING: Illegal reflective access by com.jogamp.nativewindow.awt.AppContextInfo (file:/C:/Users/[USER]/.m2/repository/org/jogamp/jogl/jogl-all/2.3.2/jogl-all-2.3.2.jar) to method sun.awt.AppContext.getAppContext()
Disconnected from the target VM, address: '127.0.0.1:52019', transport: 'socket'

Process finished with exit code 0
```

</p>
</details>

Note that there are more "illegal reflective access" warnings for the `jogamp` library, but this seems out of our control for now.

Thanks!