### PR TITLE
Add support for pasting authenticator code on login screen

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/Client.java
+++ b/runelite-api/src/main/java/net/runelite/api/Client.java
@@ -152,11 +152,25 @@ public interface Client extends GameEngine
 	void setPassword(String password);
 
 	/**
+	 * Sets the 6 digit pin used for authenticator on login screen.
+	 *
+	 * @param otp one time password
+	 */
+	void setOtp(String otp);
+
+	/**
 	 * Gets currently selected login field. 0 is username, and 1 is password.
 	 *
 	 * @return currently selected login field
 	 */
 	int getCurrentLoginField();
+
+	/**
+	 * Gets index of current login state. 2 is username/password form, 4 is authenticator form
+	 *
+	 * @return current login state index
+	 */
+	int getLoginIndex();
 
 	/**
 	 * Gets the account type of the logged in player.

--- a/runelite-api/src/main/java/net/runelite/api/GameState.java
+++ b/runelite-api/src/main/java/net/runelite/api/GameState.java
@@ -42,6 +42,10 @@ public enum GameState
 	 */
 	LOGIN_SCREEN(10),
 	/**
+	 * The client is at the login screen entering authenticator code.
+	 */
+	LOGIN_SCREEN_AUTHENTICATOR(11),
+	/**
 	 * There is a player logging in.
 	 */
 	LOGGING_IN(20),

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loginscreen/LoginScreenPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loginscreen/LoginScreenPlugin.java
@@ -54,6 +54,7 @@ public class LoginScreenPlugin extends Plugin implements KeyListener
 {
 	private static final int MAX_USERNAME_LENGTH = 254;
 	private static final int MAX_PASSWORD_LENGTH = 20;
+	private static final int MAX_PIN_LENGTH = 6;
 
 	@Inject
 	private Client client;
@@ -163,7 +164,9 @@ public class LoginScreenPlugin extends Plugin implements KeyListener
 	@Override
 	public void keyPressed(KeyEvent e)
 	{
-		if (!config.pasteEnabled() || client.getGameState() != GameState.LOGIN_SCREEN)
+		if (!config.pasteEnabled() || (
+			client.getGameState() != GameState.LOGIN_SCREEN &&
+			client.getGameState() != GameState.LOGIN_SCREEN_AUTHENTICATOR))
 		{
 			return;
 		}
@@ -182,16 +185,27 @@ public class LoginScreenPlugin extends Plugin implements KeyListener
 					.toString()
 					.trim();
 
-				// 0 is username, 1 is password
-				if (client.getCurrentLoginField() == 0)
+				switch (client.getLoginIndex())
 				{
-					// Truncate data to maximum username length if necessary
-					client.setUsername(data.substring(0, Math.min(data.length(), MAX_USERNAME_LENGTH)));
-				}
-				else
-				{
-					// Truncate data to maximum password length if necessary
-					client.setPassword(data.substring(0, Math.min(data.length(), MAX_PASSWORD_LENGTH)));
+					// Username/password form
+					case 2:
+						if (client.getCurrentLoginField() == 0)
+						{
+							// Truncate data to maximum username length if necessary
+							client.setUsername(data.substring(0, Math.min(data.length(), MAX_USERNAME_LENGTH)));
+						}
+						else
+						{
+							// Truncate data to maximum password length if necessary
+							client.setPassword(data.substring(0, Math.min(data.length(), MAX_PASSWORD_LENGTH)));
+						}
+
+						break;
+					// Authenticator form
+					case 4:
+						// Truncate data to maximum OTP code length if necessary
+						client.setOtp(data.substring(0, Math.min(data.length(), MAX_PIN_LENGTH)));
+						break;
 				}
 			}
 			catch (UnsupportedFlavorException | IOException ex)

--- a/runescape-api/src/main/java/net/runelite/rs/api/RSClient.java
+++ b/runescape-api/src/main/java/net/runelite/rs/api/RSClient.java
@@ -248,9 +248,17 @@ public interface RSClient extends RSGameEngine, Client
 	@Override
 	void setPassword(String password);
 
+	@Import("otp")
+	@Override
+	void setOtp(String otp);
+
 	@Import("currentLoginField")
 	@Override
 	int getCurrentLoginField();
+
+	@Import("loginIndex")
+	@Override
+	int getLoginIndex();
 
 	@Import("playerOptions")
 	@Override


### PR DESCRIPTION
- Add new LOGIN_SCREEN_AUTHENTICATOR game state
- Export otp and loginIndex from rs api
- Add support for pasting to authenticator pin (otp) field

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>

Depends on !67