### PR TITLE
Fix music list plugin growing search/filter menu bug

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/musiclist/MusicListPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/musiclist/MusicListPlugin.java
@@ -123,6 +123,14 @@ public class MusicListPlugin extends Plugin
 			return;
 		}
 
+		//See if the search and filter buttons have already been added to avoid re-adding
+		if (header.getChildren() != null)
+		{
+			for (Widget w : header.getChildren())
+				if (w.getName().equals("Search") || w.getName().equals("All"))
+					return;
+		}
+
 		//Creation of the search and toggle status buttons
 		musicSearchButton = header.createChild(-1, WidgetType.GRAPHIC);
 		musicSearchButton.setSpriteId(SpriteID.GE_SEARCH);


### PR DESCRIPTION
This fix is in response to issue #8971. A simple name check is included to see if either of the search or filter buttons have been previously added, and doesn't add new buttons if this is the case. This seems to have been the cause of the bug initially, as two new buttons (and their options) would be added every time the onWidgetLoaded method was called with the correct id.

Assumes that the two buttons will either both be there or neither be there. Could always add more checks to handle cases of one but not the other being there if desired.