### PR TITLE
Remove redundant subString endindex .length() calls

### DIFF
--- a/cache/src/main/java/net/runelite/cache/fs/flat/FlatStorage.java
+++ b/cache/src/main/java/net/runelite/cache/fs/flat/FlatStorage.java
@@ -116,7 +116,7 @@ public class FlatStorage implements Storage
 					{
 						int lidx = line.indexOf('=');
 						String key = line.substring(0, lidx);
-						String value = line.substring(lidx + 1, line.length());
+						String value = line.substring(lidx + 1);
 
 						if ("file".equals(key))
 						{
@@ -128,7 +128,7 @@ public class FlatStorage implements Storage
 							int vidx = value.indexOf('=');
 							FileData fd = new FileData();
 							fd.setId(Integer.parseInt(value.substring(0, vidx)));
-							fd.setNameHash(Integer.parseInt(value.substring(vidx + 1, value.length())));
+							fd.setNameHash(Integer.parseInt(value.substring(vidx + 1)));
 							fileData.add(fd);
 							continue;
 						}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/runepouch/Runes.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/runepouch/Runes.java
@@ -111,7 +111,7 @@ public enum Runes
 	public String getName()
 	{
 		String name = this.name();
-		name = name.substring(0, 1) + name.substring(1, name.length()).toLowerCase();
+		name = name.substring(0, 1) + name.substring(1).toLowerCase();
 		return name;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/components/TooltipComponent.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/components/TooltipComponent.java
@@ -154,7 +154,7 @@ public class TooltipComponent implements RenderableEntity
 			// Draw trailing text (after last tag)
 			final TextComponent textComponent = new TextComponent();
 			textComponent.setColor(nextColor);
-			textComponent.setText(line.substring(begin, line.length()));
+			textComponent.setText(line.substring(begin));
 			textComponent.setPosition(new Point(lineX, textY + (i + 1) * textHeight - textDescent));
 			textComponent.render(graphics);
 		}
@@ -194,7 +194,7 @@ public class TooltipComponent implements RenderableEntity
 		}
 
 		// Include trailing text (after last tag)
-		textWidth += metrics.stringWidth(line.substring(begin, line.length()));
+		textWidth += metrics.stringWidth(line.substring(begin));
 
 		return textWidth;
 	}


### PR DESCRIPTION
Remove all instances of redundant .length() calls in the String substring calls.
Both the following samples produce the same output:
```
str2 = str1.substring(beginIndex, str1.length()); 
str2 = str1.substring(beginIndex);
```
This minor enhancement removes unnecessary String length() calls.

[substring(int beginIndex, int endIndex) Javadoc](https://docs.oracle.com/javase/7/docs/api/java/lang/String.html#substring(int,%20int))
[substring(int beginIndex) Javadoc](https://docs.oracle.com/javase/7/docs/api/java/lang/String.html#substring(int))