### PR TITLE
Replace redundant StringBuilder append String.subString with append CharSequence

### DIFF
--- a/cache-updater/src/main/java/net/runelite/cache/updater/CacheUploader.java
+++ b/cache-updater/src/main/java/net/runelite/cache/updater/CacheUploader.java
@@ -69,7 +69,7 @@ public class CacheUploader implements Runnable
 		archive.setHash(hash);
 
 		String path = new StringBuilder()
-			.append(hashStr.substring(0, 2))
+			.append(hashStr, 0, 2)
 			.append('/')
 			.append(hashStr.substring(2))
 			.toString();

--- a/http-service/src/main/java/net/runelite/http/service/cache/CacheService.java
+++ b/http-service/src/main/java/net/runelite/http/service/cache/CacheService.java
@@ -104,7 +104,7 @@ public class CacheService
 	{
 		String hashStr = BaseEncoding.base16().encode(archiveEntry.getHash());
 		String path = new StringBuilder()
-			.append(hashStr.substring(0, 2))
+			.append(hashStr, 0, 2)
 			.append('/')
 			.append(hashStr.substring(2))
 			.toString();


### PR DESCRIPTION
Replace all instances of redundant StringBuilder append String.subString with append CharSequence 
Both the following samples produce the same output:
```
sb.append(str.substring(startIndex, endIndex));
sb.append(str, startIndex, endIndex);
```
This minor enhancement removes an intermediate String construction during append

[append(CharSequence s, int start, int end) Javadoc](https://docs.oracle.com/javase/7/docs/api/java/lang/StringBuilder.html#append(java.lang.CharSequence,%20int,%20int))
[Relevant Stack Overflow discussion](https://stackoverflow.com/questions/52559564/call-to-substring-is-redundant)