### PR TITLE
Fix incorrect text in Ardy hard diary requirements

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/ArdougneDiaryRequirement.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/ArdougneDiaryRequirement.java
@@ -79,7 +79,7 @@ public class ArdougneDiaryRequirement extends GenericDiaryRequirement
 			new QuestRequirement(Quest.FAIRYTALE_II__CURE_A_QUEEN, true));
 
 		// HARD
-		add("Recharge some Jewellery at Totem in the Legends Guild.",
+		add("Recharge some Jewellery at the Totem in the Legends Guild.",
 			new QuestRequirement(Quest.LEGENDS_QUEST));
 		add("Enter the Magic Guild.",
 			new SkillRequirement(Skill.MAGIC, 66));


### PR DESCRIPTION
Fixes #8986 - "Ardougne hard diary task is missing Legends' Quest requirement"
<img width="481" alt="Screen Shot 2019-06-01 at 4 33 25 PM" src="https://user-images.githubusercontent.com/16943514/58754336-00c8f000-848b-11e9-91bc-f02276d7f279.png">