### PR TITLE
PluginListItem: Reset label color on popup menu item click

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/PluginListItem.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/PluginListItem.java
@@ -317,10 +317,14 @@ class PluginListItem extends JPanel
 	static void addLabelPopupMenu(final JLabel label, final Collection<JMenuItem> menuItems)
 	{
 		final JPopupMenu menu = new JPopupMenu();
+		final Color labelForeground = label.getForeground();
 		menu.setBorder(new EmptyBorder(5, 5, 5, 5));
 
 		for (final JMenuItem menuItem : menuItems)
 		{
+			// Some machines register mouseEntered through a popup menu, and do not register mouseExited when a popup
+			// menu item is clicked, so reset the label's color when we click one of these options.
+			menuItem.addActionListener(e -> label.setForeground(labelForeground));
 			menu.add(menuItem);
 		}
 


### PR DESCRIPTION
I wasn't able to repro myself, but commenting out the `mouseExited` override method of the mouse listener is a simple way to see that this change works.

Fixes runelite/runelite#9007