### PR TITLE
mining plugin: draw overlay at correct height for mlm and amethyst

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/mining/MiningOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/mining/MiningOverlay.java
@@ -77,7 +77,7 @@ class MiningOverlay extends Overlay
 				continue;
 			}
 
-			Point point = Perspective.localToCanvas(client, loc, client.getPlane());
+			Point point = Perspective.localToCanvas(client, loc, client.getPlane(), rockRespawn.getZOffset());
 			if (point == null)
 			{
 				it.remove();

--- a/runelite-client/src/main/java/net/runelite/client/plugins/mining/MiningPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/mining/MiningPlugin.java
@@ -124,7 +124,7 @@ public class MiningPlugin extends Plugin
 		Rock rock = Rock.getRock(object.getId());
 		if (rock != null)
 		{
-			RockRespawn rockRespawn = new RockRespawn(rock, object.getWorldLocation(), Instant.now(), (int) rock.getRespawnTime(inMiningGuild()).toMillis());
+			RockRespawn rockRespawn = new RockRespawn(rock, object.getWorldLocation(), Instant.now(), (int) rock.getRespawnTime(inMiningGuild()).toMillis(), rock.getZOffset());
 			respawns.add(rockRespawn);
 		}
 	}
@@ -144,7 +144,7 @@ public class MiningPlugin extends Plugin
 			case EMPTY_WALL:
 			{
 				Rock rock = Rock.AMETHYST;
-				RockRespawn rockRespawn = new RockRespawn(rock, object.getWorldLocation(), Instant.now(), (int) rock.getRespawnTime(inMiningGuild()).toMillis());
+				RockRespawn rockRespawn = new RockRespawn(rock, object.getWorldLocation(), Instant.now(), (int) rock.getRespawnTime(inMiningGuild()).toMillis(), rock.getZOffset());
 				respawns.add(rockRespawn);
 				break;
 			}
@@ -154,7 +154,7 @@ public class MiningPlugin extends Plugin
 			case DEPLETED_VEIN_26668: // Depleted motherlode vein
 			{
 				Rock rock = Rock.ORE_VEIN;
-				RockRespawn rockRespawn = new RockRespawn(rock, object.getWorldLocation(), Instant.now(), (int) rock.getRespawnTime(inMiningGuild()).toMillis());
+				RockRespawn rockRespawn = new RockRespawn(rock, object.getWorldLocation(), Instant.now(), (int) rock.getRespawnTime(inMiningGuild()).toMillis(), rock.getZOffset());
 				respawns.add(rockRespawn);
 				break;
 			}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/mining/Rock.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/mining/Rock.java
@@ -27,6 +27,8 @@ package net.runelite.client.plugins.mining;
 import com.google.common.collect.ImmutableMap;
 import java.time.Duration;
 import java.util.Map;
+import lombok.AccessLevel;
+import lombok.Getter;
 import static net.runelite.api.ObjectID.ROCKS_11161;
 import static net.runelite.api.ObjectID.ROCKS_11360;
 import static net.runelite.api.ObjectID.ROCKS_11361;
@@ -48,9 +50,9 @@ import static net.runelite.api.ObjectID.ROCKS_11387;
 
 enum Rock
 {
-	TIN(Duration.ofMillis(2300), ROCKS_11360, ROCKS_11361),
-	COPPER(Duration.ofMillis(2200), ROCKS_11161),
-	IRON(Duration.ofMillis(5300), ROCKS_11364, ROCKS_11365)
+	TIN(Duration.ofMillis(2300), 0, ROCKS_11360, ROCKS_11361),
+	COPPER(Duration.ofMillis(2200), 0, ROCKS_11161),
+	IRON(Duration.ofMillis(5300), 0, ROCKS_11364, ROCKS_11365)
 		{
 			@Override
 			Duration getRespawnTime(boolean inMiningGuild)
@@ -58,7 +60,7 @@ enum Rock
 				return inMiningGuild ? Duration.ofMillis(2200) : super.respawnTime;
 			}
 		},
-	COAL(Duration.ofSeconds(40), ROCKS_11366, ROCKS_11367)
+	COAL(Duration.ofSeconds(40), 0, ROCKS_11366, ROCKS_11367)
 		{
 			@Override
 			Duration getRespawnTime(boolean inMiningGuild)
@@ -66,11 +68,11 @@ enum Rock
 				return inMiningGuild ? Duration.ofMillis(14_500) : super.respawnTime;
 			}
 		},
-	SILVER(Duration.ofMinutes(1), ROCKS_11369),
-	SANDSTONE(Duration.ofMillis(5400), ROCKS_11386),
-	GOLD(Duration.ofMinutes(1), ROCKS_11370, ROCKS_11371),
-	GRANITE(Duration.ofMillis(5400), ROCKS_11387),
-	MITHRIL(Duration.ofMinutes(2), ROCKS_11372, ROCKS_11373)
+	SILVER(Duration.ofMinutes(1), 0, ROCKS_11369),
+	SANDSTONE(Duration.ofMillis(5400), 0, ROCKS_11386),
+	GOLD(Duration.ofMinutes(1), 0, ROCKS_11370, ROCKS_11371),
+	GRANITE(Duration.ofMillis(5400), 0, ROCKS_11387),
+	MITHRIL(Duration.ofMinutes(2), 0, ROCKS_11372, ROCKS_11373)
 		{
 			@Override
 			Duration getRespawnTime(boolean inMiningGuild)
@@ -78,7 +80,7 @@ enum Rock
 				return inMiningGuild ? Duration.ofMinutes(1) : super.respawnTime;
 			}
 		},
-	ADAMANTITE(Duration.ofMinutes(4), ROCKS_11374, ROCKS_11375)
+	ADAMANTITE(Duration.ofMinutes(4), 0, ROCKS_11374, ROCKS_11375)
 		{
 			@Override
 			Duration getRespawnTime(boolean inMiningGuild)
@@ -86,7 +88,7 @@ enum Rock
 				return inMiningGuild ? Duration.ofMinutes(2) : super.respawnTime;
 			}
 		},
-	RUNITE(Duration.ofMinutes(12), ROCKS_11376, ROCKS_11377)
+	RUNITE(Duration.ofMinutes(12), 0, ROCKS_11376, ROCKS_11377)
 		{
 			@Override
 			Duration getRespawnTime(boolean inMiningGuild)
@@ -94,8 +96,8 @@ enum Rock
 				return inMiningGuild ? Duration.ofMinutes(6) : super.respawnTime;
 			}
 		},
-	ORE_VEIN(Duration.ofSeconds(108)),
-	AMETHYST(Duration.ofSeconds(75));
+	ORE_VEIN(Duration.ofSeconds(108), 150),
+	AMETHYST(Duration.ofSeconds(75), 120);
 
 	private static final Map<Integer, Rock> ROCKS;
 
@@ -113,11 +115,14 @@ enum Rock
 	}
 
 	private final Duration respawnTime;
+	@Getter(AccessLevel.PACKAGE)
+	private final int zOffset;
 	private final int[] ids;
 
-	Rock(Duration respawnTime, int... ids)
+	Rock(Duration respawnTime, int zOffset, int... ids)
 	{
 		this.respawnTime = respawnTime;
+		this.zOffset = zOffset;
 		this.ids = ids;
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/mining/RockRespawn.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/mining/RockRespawn.java
@@ -37,4 +37,5 @@ class RockRespawn
 	private final WorldPoint worldPoint;
 	private final Instant startTime;
 	private final int respawnTime;
+	private final int zOffset;
 }


### PR DESCRIPTION
It looked weird having the timers appear at floor level while the mining icons in MLM appear at height offset of 150. So I added support for an offset and used it to shift the overlay for veins in MLM to match the MLM plugin.

Did amethyst too because it looks nicer this way IMO.

MLM before:
![2019-06-03_22-57-28](https://user-images.githubusercontent.com/29353990/58837898-d2970c00-8654-11e9-91eb-22d15138fdca.png)

MLM after:
![2019-06-03_22-55-25](https://user-images.githubusercontent.com/29353990/58837902-d6c32980-8654-11e9-8db4-3bd78fe6df59.png)

Amethyst after:
![2019-06-03_23-06-58](https://user-images.githubusercontent.com/29353990/58837918-eb9fbd00-8654-11e9-80fb-11f71795e957.png)

