### PR TITLE
Fix Item prices high alch profit

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemprices/ItemPricesOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemprices/ItemPricesOverlay.java
@@ -195,6 +195,7 @@ class ItemPricesOverlay extends Overlay
 		int gePrice = 0;
 		int haPrice = 0;
 		int haProfit = 0;
+		final int itemHaPrice = Math.round(itemDef.getPrice() * Constants.HIGH_ALCHEMY_MULTIPLIER);
 
 		if (config.showGEPrice())
 		{
@@ -202,11 +203,11 @@ class ItemPricesOverlay extends Overlay
 		}
 		if (config.showHAValue())
 		{
-			haPrice = Math.round(itemDef.getPrice() * Constants.HIGH_ALCHEMY_MULTIPLIER);
+			haPrice = itemHaPrice;
 		}
-		if (gePrice > 0 && haPrice > 0 && config.showAlchProfit())
+		if (gePrice > 0 && itemHaPrice > 0 && config.showAlchProfit())
 		{
-			haProfit = calculateHAProfit(haPrice, gePrice);
+			haProfit = calculateHAProfit(itemHaPrice, gePrice);
 		}
 
 		if (gePrice > 0 || haPrice > 0)


### PR DESCRIPTION
Fixes Item Prices plugin to correctly show High Alchemy profit when show High Alchemy values is disabled.

![capture5](https://user-images.githubusercontent.com/14902604/58845737-e84f0600-8641-11e9-941b-3b43ee8c8fba.gif)

Fixes #9011