### PR TITLE
Improve world hopper sorting

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldSwitcherPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldSwitcherPanel.java
@@ -24,6 +24,7 @@
  */
 package net.runelite.client.plugins.worldhopper;
 
+import com.google.common.collect.Ordering;
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Dimension;
@@ -33,6 +34,7 @@ import java.awt.event.MouseEvent;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 import javax.swing.JPanel;
 import javax.swing.SwingUtilities;
 import lombok.AccessLevel;
@@ -159,23 +161,22 @@ class WorldSwitcherPanel extends PluginPanel
 			switch (orderIndex)
 			{
 				case PING:
-					return Integer.compare(r1.getPing(), r2.getPing()) * (ascendingOrder ? 1 : -1);
+					return getCompareValue(r1, r2, WorldTableRow::getPing);
 				case WORLD:
-					return Integer.compare(r1.getWorld().getId(), r2.getWorld().getId()) * (ascendingOrder ? 1 : -1);
+					return getCompareValue(r1, r2, row -> row.getWorld().getId());
 				case PLAYERS:
-					return Integer.compare(r1.getUpdatedPlayerCount(), r2.getUpdatedPlayerCount()) * (ascendingOrder ? 1 : -1);
+					return getCompareValue(r1, r2, WorldTableRow::getUpdatedPlayerCount);
 				case ACTIVITY:
-					return r1.getWorld().getActivity().compareTo(r2.getWorld().getActivity()) * -1 * (ascendingOrder ? 1 : -1);
+					// Leave empty activity worlds on the bottom of the list
+					return getCompareValue(r1, r2, row ->
+					{
+						String activity = row.getWorld().getActivity();
+						return !activity.equals("-") ? activity : null;
+					});
 				default:
 					return 0;
 			}
 		});
-
-		// Leave empty activity worlds on the bottom of the list
-		if (orderIndex == WorldOrder.ACTIVITY)
-		{
-			rows.sort((r1, r2) -> r1.getWorld().getActivity().equals("-") ? 1 : -1);
-		}
 
 		rows.sort((r1, r2) ->
 		{
@@ -195,6 +196,17 @@ class WorldSwitcherPanel extends PluginPanel
 
 		listContainer.revalidate();
 		listContainer.repaint();
+	}
+
+	private int getCompareValue(WorldTableRow row1, WorldTableRow row2, Function<WorldTableRow, Comparable> compareByFn)
+	{
+		Ordering<Comparable> ordering = Ordering.natural();
+		if (!ascendingOrder)
+		{
+			ordering = ordering.reverse();
+		}
+		ordering = ordering.nullsLast();
+		return ordering.compare(compareByFn.apply(row1), compareByFn.apply(row2));
 	}
 
 	void updateFavoriteMenu(int world, boolean favorite)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldSwitcherPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldSwitcherPanel.java
@@ -161,7 +161,12 @@ class WorldSwitcherPanel extends PluginPanel
 			switch (orderIndex)
 			{
 				case PING:
-					return getCompareValue(r1, r2, WorldTableRow::getPing);
+					// Leave worlds with unknown ping at the bottom
+					return getCompareValue(r1, r2, row ->
+					{
+						int ping = row.getPing();
+						return ping > 0 ? ping : null;
+					});
 				case WORLD:
 					return getCompareValue(r1, r2, row -> row.getWorld().getId());
 				case PLAYERS:


### PR DESCRIPTION
Put worlds with unknown ping at the bottom of the list and fix secondary sorting when sorting by activity, e.g. when sorting by "Ping" and then by "Activity".

Here's a couple of images comparing the results of sorting by "Ping" and then by "Activity":

Before | After
:-------------------------:|:-------------------------:
![bad](https://user-images.githubusercontent.com/11037113/58879934-e0b75c00-872a-11e9-87a3-2b9abedb4031.png) | ![good](https://user-images.githubusercontent.com/11037113/58879941-e44ae300-872a-11e9-9147-b0642f488615.png)

Closes https://github.com/runelite/runelite/issues/8176