### PR TITLE
mining plugin: remove progress pie from mlm veins that respawned early

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/mining/MiningOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/mining/MiningOverlay.java
@@ -43,6 +43,12 @@ import net.runelite.client.ui.overlay.components.ProgressPieComponent;
 
 class MiningOverlay extends Overlay
 {
+	// Range of Motherlode vein respawn time - not 100% confirmed but based on observation
+	static final int ORE_VEIN_MAX_RESPAWN_TIME = 123;
+	private static final int ORE_VEIN_MIN_RESPAWN_TIME = 90;
+	private static final float ORE_VEIN_RANDOM_PERCENT_THRESHOLD = (float) ORE_VEIN_MIN_RESPAWN_TIME / ORE_VEIN_MAX_RESPAWN_TIME;
+	private static final Color DARK_GREEN = new Color(0, 100, 0);
+
 	private final Client client;
 	private final MiningPlugin plugin;
 
@@ -67,6 +73,8 @@ class MiningOverlay extends Overlay
 		Instant now = Instant.now();
 		for (Iterator<RockRespawn> it = respawns.iterator(); it.hasNext();)
 		{
+			Color pieFillColor = Color.YELLOW;
+			Color pieBorderColor = Color.ORANGE;
 			RockRespawn rockRespawn = it.next();
 			float percent = (now.toEpochMilli() - rockRespawn.getStartTime().toEpochMilli()) / (float) rockRespawn.getRespawnTime();
 			WorldPoint worldPoint = rockRespawn.getWorldPoint();
@@ -84,9 +92,16 @@ class MiningOverlay extends Overlay
 				continue;
 			}
 
+			// Recolour pie on motherlode veins during the portion of the timer where they may respawn
+			if (rockRespawn.getRock() == Rock.ORE_VEIN && percent > ORE_VEIN_RANDOM_PERCENT_THRESHOLD)
+			{
+				pieFillColor = Color.GREEN;
+				pieBorderColor = DARK_GREEN;
+			}
+
 			ProgressPieComponent ppc = new ProgressPieComponent();
-			ppc.setBorderColor(Color.ORANGE);
-			ppc.setFill(Color.YELLOW);
+			ppc.setBorderColor(pieBorderColor);
+			ppc.setFill(pieFillColor);
 			ppc.setPosition(point);
 			ppc.setProgress(percent);
 			ppc.render(graphics);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/mining/MiningPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/mining/MiningPlugin.java
@@ -39,7 +39,12 @@ import static net.runelite.api.ObjectID.DEPLETED_VEIN_26666;
 import static net.runelite.api.ObjectID.DEPLETED_VEIN_26667;
 import static net.runelite.api.ObjectID.DEPLETED_VEIN_26668;
 import static net.runelite.api.ObjectID.EMPTY_WALL;
+import static net.runelite.api.ObjectID.ORE_VEIN_26661;
+import static net.runelite.api.ObjectID.ORE_VEIN_26662;
+import static net.runelite.api.ObjectID.ORE_VEIN_26663;
+import static net.runelite.api.ObjectID.ORE_VEIN_26664;
 import net.runelite.api.WallObject;
+import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.GameObjectDespawned;
 import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.GameTick;
@@ -156,6 +161,16 @@ public class MiningPlugin extends Plugin
 				Rock rock = Rock.ORE_VEIN;
 				RockRespawn rockRespawn = new RockRespawn(rock, object.getWorldLocation(), Instant.now(), (int) rock.getRespawnTime(inMiningGuild()).toMillis(), rock.getZOffset());
 				respawns.add(rockRespawn);
+				break;
+			}
+			case ORE_VEIN_26661: // Motherlode vein
+			case ORE_VEIN_26662: // Motherlode vein
+			case ORE_VEIN_26663: // Motherlode vein
+			case ORE_VEIN_26664: // Motherlode vein
+			{
+				// If the vein respawns before the timer is up, remove it
+				final WorldPoint point = object.getWorldLocation();
+				respawns.removeIf(rockRespawn -> rockRespawn.getWorldPoint().equals(point));
 				break;
 			}
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/mining/Rock.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/mining/Rock.java
@@ -98,7 +98,7 @@ enum Rock
 				return inMiningGuild ? Duration.ofMinutes(6) : super.respawnTime;
 			}
 		},
-	ORE_VEIN(Duration.ofSeconds(108), 150),
+	ORE_VEIN(Duration.ofSeconds(MiningOverlay.ORE_VEIN_MAX_RESPAWN_TIME), 150),
 	AMETHYST(Duration.ofSeconds(75), 120);
 
 	private static final Map<Integer, Rock> ROCKS;


### PR DESCRIPTION
Veins in MLM are on a variable timer. So far the longest and shortest respawns that I've witnessed have been +/- 15 seconds from the 108 seconds set in the plugin. This PR addresses one half of that by removing the progress pie once the vein has respawned.

Example of what I'm talking about, which this PR fixes:

![Vein respawns before pie disappears](https://user-images.githubusercontent.com/29353990/58920471-43f4be80-872a-11e9-8b98-516fdc9084e5.gif)