### PR TITLE
Agility Plugin - Diary Requirements

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/Diary.java
+++ b/runelite-api/src/main/java/net/runelite/api/Diary.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2019 MrGroggle
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.api;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * An enumeration of Diaries.
+ */
+@RequiredArgsConstructor
+@Getter
+public enum Diary
+{
+	ARDOUGNE_EASY("Ardougne Easy", Varbits.DIARY_ARDOUGNE_EASY),
+	ARDOUGNE_MEDIUM("Ardougne Medium", Varbits.DIARY_ARDOUGNE_MEDIUM),
+	ARDOUGNE_HARD("Ardougne Hard", Varbits.DIARY_ARDOUGNE_HARD),
+	ARDOUGNE_ELITE("Ardougne Elite", Varbits.DIARY_ARDOUGNE_ELITE),
+	DESERT_EASY("Desert Easy", Varbits.DIARY_DESERT_EASY),
+	DESERT_MEDIUM("Desert Medium", Varbits.DIARY_DESERT_MEDIUM),
+	DESERT_HARD("Desert Hard", Varbits.DIARY_DESERT_HARD),
+	DESERT_ELITE("Desert Elite", Varbits.DIARY_DESERT_ELITE),
+	FALADOR_EASY("Falador Easy", Varbits.DIARY_FALADOR_EASY),
+	FALADOR_MEDIUM("Falador Medium", Varbits.DIARY_FALADOR_MEDIUM),
+	FALADOR_HARD("Falador Hard", Varbits.DIARY_FALADOR_HARD),
+	FALADOR_ELITE("Falador Elite", Varbits.DIARY_FALADOR_ELITE),
+	FREMENNIK_EASY("Fremennik Easy", Varbits.DIARY_FREMENNIK_EASY),
+	FREMENNIK_MEDIUM("Fremennik Medium", Varbits.DIARY_FREMENNIK_MEDIUM),
+	FREMENNIK_HARD("Fremennik Hard", Varbits.DIARY_FREMENNIK_HARD),
+	FREMENNIK_ELITE("Fremennik Elite", Varbits.DIARY_FREMENNIK_ELITE),
+	KANDARIN_EASY("Kandarin Easy", Varbits.DIARY_KANDARIN_EASY),
+	KANDARIN_MEDIUM("Kandarin Medium", Varbits.DIARY_KANDARIN_MEDIUM),
+	KANDARIN_HARD("Kandarin Hard", Varbits.DIARY_KANDARIN_HARD),
+	KANDARIN_ELITE("Kandarin Elite", Varbits.DIARY_KANDARIN_ELITE),
+	KARAMJA_EASY("Karamja Easy", Varbits.DIARY_KARAMJA_EASY),
+	KARAMJA_MEDIUM("Karamja Medium", Varbits.DIARY_KARAMJA_MEDIUM),
+	KARAMJA_HARD("Karamja Hard", Varbits.DIARY_KARAMJA_HARD),
+	KARAMJA_ELITE("Karamja Elite", Varbits.DIARY_KARAMJA_ELITE),
+	KOUREND_EASY("Kourend Easy", Varbits.DIARY_KOUREND_EASY),
+	KOUREND_MEDIUM("Kourend Medium", Varbits.DIARY_KOUREND_MEDIUM),
+	KOUREND_HARD("Kourend Hard", Varbits.DIARY_KOUREND_HARD),
+	KOUREND_ELITE("Kourend Elite", Varbits.DIARY_KOUREND_ELITE),
+	LUMBRIDGE_EASY("Lumbridge Easy", Varbits.DIARY_LUMBRIDGE_EASY),
+	LUMBRIDGE_MEDIUM("Lumbridge Medium", Varbits.DIARY_LUMBRIDGE_MEDIUM),
+	LUMBRIDGE_HARD("Lumbridge Hard", Varbits.DIARY_LUMBRIDGE_HARD),
+	LUMBRIDGE_ELITE("Lumbridge Elite", Varbits.DIARY_LUMBRIDGE_ELITE),
+	MORYTANIA_EASY("Morytania Easy", Varbits.DIARY_MORYTANIA_EASY),
+	MORYTANIA_MEDIUM("Morytania Medium", Varbits.DIARY_MORYTANIA_MEDIUM),
+	MORYTANIA_HARD("Morytania Hard", Varbits.DIARY_MORYTANIA_HARD),
+	MORYTANIA_ELITE("Morytania Elite", Varbits.DIARY_MORYTANIA_ELITE),
+	VARROCK_EASY("Varrock Easy", Varbits.DIARY_VARROCK_EASY),
+	VARROCK_MEDIUM("Varrock Medium", Varbits.DIARY_VARROCK_MEDIUM),
+	VARROCK_HARD("Varrock Hard", Varbits.DIARY_VARROCK_HARD),
+	VARROCK_ELITE("Varrock Elite", Varbits.DIARY_VARROCK_ELITE),
+	WESTERN_EASY("Western Provinces Easy", Varbits.DIARY_WESTERN_EASY),
+	WESTERN_MEDIUM("Western Provinces Medium", Varbits.DIARY_WESTERN_MEDIUM),
+	WESTERN_HARD("Western Provinces Hard", Varbits.DIARY_WESTERN_HARD),
+	WESTERN_ELITE("Western Provinces Elite", Varbits.DIARY_WESTERN_ELITE),
+	WILDERNESS_EASY("Wilderness Easy", Varbits.DIARY_WILDERNESS_EASY),
+	WILDERNESS_MEDIUM("Wilderness Medium", Varbits.DIARY_WILDERNESS_MEDIUM),
+	WILDERNESS_HARD("Wilderness Hard", Varbits.DIARY_WILDERNESS_HARD),
+	WILDERNESS_ELITE("Wilderness Elite", Varbits.DIARY_WILDERNESS_ELITE);
+
+	private final String name;
+	private final Varbits varbit;
+}

--- a/runelite-client/src/main/java/net/runelite/client/game/AgilityShortcut.java
+++ b/runelite-client/src/main/java/net/runelite/client/game/AgilityShortcut.java
@@ -25,10 +25,20 @@
  */
 package net.runelite.client.game;
 
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableList;
 import lombok.Getter;
+import net.runelite.api.Client;
+import net.runelite.api.Diary;
 import static net.runelite.api.NullObjectID.*;
 import static net.runelite.api.ObjectID.*;
+import net.runelite.api.Skill;
 import net.runelite.api.coords.WorldPoint;
+import net.runelite.client.game.requirement.AchievementDiaryRequirement;
+import net.runelite.client.game.requirement.Requirement;
+import net.runelite.client.game.requirement.SkillRequirement;
+
+import java.util.List;
 
 @Getter
 public enum AgilityShortcut
@@ -81,7 +91,7 @@ public enum AgilityShortcut
 	FALADOR_GRAPPLE_WALL(11, "Grapple Wall", new WorldPoint(3031, 3391, 0), WALL_17049, WALL_17050),
 	BRIMHAVEN_DUNGEON_STEPPING_STONES(12, "Stepping Stones", null, STEPPING_STONE_21738),
 	VARROCK_SOUTH_FENCE(13, "Fence", new WorldPoint(3239, 3334, 0), FENCE_16518),
-	GOBLIN_VILLAGE_WALL(14, "Wall", new WorldPoint(2925, 3523, 0), TIGHTGAP),
+	GOBLIN_VILLAGE_WALL(14, Diary.FALADOR_EASY, "Wall", new WorldPoint(2925, 3523, 0), TIGHTGAP),
 	CORSAIR_COVE_DUNGEON_PILLAR(15, "Pillar Jump", new WorldPoint(1980, 8996, 0), PILLAR_31809),
 	EDGEVILLE_DUNGEON_MONKEYBARS(15, "Monkey Bars", null, MONKEYBARS_23566),
 	TROLLHEIM_ROCKS(15, "Rocks", null, new WorldPoint(2838, 3614, 0), ROCKS_3748),	// No fixed world map location, but rocks near death plateau have a requirement of 15
@@ -117,15 +127,15 @@ public enum AgilityShortcut
 	YANILLE_DUNGEON_BALANCE(40, "Balancing Ledge", null, BALANCING_LEDGE_23548),
 	TROLLHEIM_EASY_CLIFF_SCRAMBLE(41, "Rocks", new WorldPoint(2869, 3670, 0), ROCKS_16521),
 	DWARVEN_MINE_NARROW_CREVICE(42, "Narrow Crevice", new WorldPoint(3034, 9806, 0), CREVICE_16543),
-	DRAYNOR_UNDERWALL_TUNNEL(42, "Underwall Tunnel", new WorldPoint(3068, 3261, 0), UNDERWALL_TUNNEL_19032, UNDERWALL_TUNNEL_19036),
+	DRAYNOR_UNDERWALL_TUNNEL(42, Diary.LUMBRIDGE_MEDIUM, "Underwall Tunnel", new WorldPoint(3068, 3261, 0), UNDERWALL_TUNNEL_19032, UNDERWALL_TUNNEL_19036),
 	TROLLHEIM_MEDIUM_CLIFF_SCRAMBLE_NORTH(43, "Rocks", new WorldPoint(2886, 3684, 0), ROCKS_3803, ROCKS_3804, ROCKS_16522),
 	TROLLHEIM_MEDIUM_CLIFF_SCRAMBLE_SOUTH(43, "Rocks", new WorldPoint(2876, 3666, 0), ROCKS_3803, ROCKS_3804, ROCKS_16522),
 	TROLLHEIM_ADVANCED_CLIFF_SCRAMBLE(44, "Rocks", new WorldPoint(2907, 3686, 0), ROCKS_16523, ROCKS_3748),
 	KOUREND_RIVER_STEPPING_STONES(45, "Stepping Stones", new WorldPoint(1721, 3509, 0), STEPPING_STONE_29728),
 	TIRANNWN_LOG_BALANCE(45, "Log Balance", null, LOG_BALANCE_3933, LOG_BALANCE_3931, LOG_BALANCE_3930, LOG_BALANCE_3929, LOG_BALANCE_3932),
 	COSMIC_ALTAR_MEDIUM_WALKWAY(46, "Narrow Walkway", new WorldPoint(2399, 4403, 0), JUTTING_WALL_17002),
-	DEEP_WILDERNESS_DUNGEON_CREVICE_NORTH(46, "Narrow Crevice", new WorldPoint(3047, 10335, 0), CREVICE_19043),
-	DEEP_WILDERNESS_DUNGEON_CREVICE_SOUTH(46, "Narrow Crevice", new WorldPoint(3045, 10327, 0), CREVICE_19043),
+	DEEP_WILDERNESS_DUNGEON_CREVICE_NORTH(46, Diary.WILDERNESS_MEDIUM, "Narrow Crevice", new WorldPoint(3047, 10335, 0), CREVICE_19043),
+	DEEP_WILDERNESS_DUNGEON_CREVICE_SOUTH(46, Diary.WILDERNESS_MEDIUM, "Narrow Crevice", new WorldPoint(3045, 10327, 0), CREVICE_19043),
 	TROLLHEIM_HARD_CLIFF_SCRAMBLE(47, "Rocks", new WorldPoint(2902, 3680, 0), ROCKS_16524),
 	FREMENNIK_LOG_BALANCE(48, "Log Balance", new WorldPoint(2721, 3591, 0), LOG_BALANCE_16540, LOG_BALANCE_16541, LOG_BALANCE_16542),
 	YANILLE_DUNGEON_PIPE_SQUEEZE(49, "Pipe Squeeze", null,  OBSTACLE_PIPE_23140),
@@ -135,9 +145,9 @@ public enum AgilityShortcut
 	ARCEUUS_ESSENCE_MINE_EAST_SCRAMBLE(52, "Rock Climb", new WorldPoint(1770, 3851, 0), ROCKS_27987, ROCKS_27988),
 	KARAMJA_VOLCANO_GRAPPLE_NORTH(53, "Grapple Rock", new WorldPoint(2873, 3143, 0), STRONG_TREE_17074),
 	KARAMJA_VOLCANO_GRAPPLE_SOUTH(53, "Grapple Rock", new WorldPoint(2874, 3128, 0), STRONG_TREE_17074),
-	MOTHERLODE_MINE_WALL_EAST(54, "Wall", new WorldPoint(3124, 9703, 0), DARK_TUNNEL_10047),
-	MOTHERLODE_MINE_WALL_WEST(54, "Wall", new WorldPoint(3118, 9702, 0), DARK_TUNNEL_10047),
-	MISCELLANIA_DOCK_STEPPING_STONE(55, "Stepping Stone", new WorldPoint(2572, 3862, 0), STEPPING_STONE_11768),
+	MOTHERLODE_MINE_WALL_EAST(54, Diary.FALADOR_MEDIUM, "Wall", new WorldPoint(3124, 9703, 0), DARK_TUNNEL_10047),
+	MOTHERLODE_MINE_WALL_WEST(54, Diary.FALADOR_MEDIUM, "Wall", new WorldPoint(3118, 9702, 0), DARK_TUNNEL_10047),
+	MISCELLANIA_DOCK_STEPPING_STONE(55, Diary.FREMENNIK_MEDIUM, "Stepping Stone", new WorldPoint(2572, 3862, 0), STEPPING_STONE_11768),
 	ISAFDAR_FOREST_OBSTACLES(56, "Trap", null, DENSE_FOREST_3938, DENSE_FOREST_3939, DENSE_FOREST_3998, DENSE_FOREST_3999, DENSE_FOREST, LEAVES, LEAVES_3924, LEAVES_3925, STICKS, TRIPWIRE),
 	RELEKKA_EAST_FENCE(57, "Fence", new WorldPoint(2688, 3697, 0), BROKEN_FENCE),
 	YANILLE_DUNGEON_MONKEY_BARS(57, "Monkey Bars", null, MONKEYBARS_23567),
@@ -145,7 +155,7 @@ public enum AgilityShortcut
 	ELVEN_OVERPASS_CLIFF_SCRAMBLE(59, "Rocks", new WorldPoint(2345, 3300, 0), ROCKS_16514, ROCKS_16515),
 	WILDERNESS_GWD_CLIMB_EAST(60, "Rocks", new WorldPoint(2943, 3770, 0), ROCKY_HANDHOLDS_26400, ROCKY_HANDHOLDS_26401, ROCKY_HANDHOLDS_26402, ROCKY_HANDHOLDS_26404, ROCKY_HANDHOLDS_26405, ROCKY_HANDHOLDS_26406),
 	WILDERNESS_GWD_CLIMB_WEST(60, "Rocks", new WorldPoint(2928, 3760, 0), ROCKY_HANDHOLDS_26400, ROCKY_HANDHOLDS_26401, ROCKY_HANDHOLDS_26402, ROCKY_HANDHOLDS_26404, ROCKY_HANDHOLDS_26405, ROCKY_HANDHOLDS_26406),
-	MOS_LEHARMLESS_STEPPING_STONE(60, "Stepping Stone", new WorldPoint(3710, 2970, 0), STEPPING_STONE_19042),
+	MOS_LEHARMLESS_STEPPING_STONE(60, Diary.MORYTANIA_HARD, "Stepping Stone", new WorldPoint(3710, 2970, 0), STEPPING_STONE_19042),
 	WINTERTODT_GAP(60, "Gap", new WorldPoint(1629, 4023, 0), GAP_29326),
 	UNGAEL_ICE(60, "Ice Chunks", null, NULL_25337, NULL_29868, NULL_29869, NULL_29870, ICE_CHUNKS_31822, NULL_31823, ICE_CHUNKS_31990),
 	SLAYER_TOWER_MEDIUM_CHAIN_FIRST(61, "Spiked Chain (Floor 1)", new WorldPoint(3421, 3550, 0), SPIKEY_CHAIN),
@@ -159,9 +169,9 @@ public enum AgilityShortcut
 	MORYTANIA_TEMPLE(65, "Loose Railing", new WorldPoint(3422, 3476, 0), ROCKS_16998, ROCKS_16999, ORNATE_RAILING, ORNATE_RAILING_17000),
 	REVENANT_CAVES_GREEN_DRAGONS(65, "Jump", new WorldPoint(3220, 10086, 0), PILLAR_31561),
 	COSMIC_ALTAR_ADVANCED_WALKWAY(66, "Narrow Walkway", new WorldPoint(2408, 4401, 0), JUTTING_WALL_17002),
-	LUMBRIDGE_DESERT_STEPPING_STONE(66, "Stepping Stone", new WorldPoint(3210, 3135, 0), STEPPING_STONE_16513),
-	HEROES_GUILD_TUNNEL_EAST(67, "Crevice", new WorldPoint(2898, 9901, 0), CREVICE_9739, CREVICE_9740),
-	HEROES_GUILD_TUNNEL_WEST(67, "Crevice", new WorldPoint(2913, 9895, 0), CREVICE_9739, CREVICE_9740),
+	LUMBRIDGE_DESERT_STEPPING_STONE(66, Diary.LUMBRIDGE_HARD, "Stepping Stone", new WorldPoint(3210, 3135, 0), STEPPING_STONE_16513),
+	HEROES_GUILD_TUNNEL_EAST(67, Diary.FALADOR_HARD, "Crevice", new WorldPoint(2898, 9901, 0), CREVICE_9739, CREVICE_9740),
+	HEROES_GUILD_TUNNEL_WEST(67, Diary.FALADOR_HARD, "Crevice", new WorldPoint(2913, 9895, 0), CREVICE_9739, CREVICE_9740),
 	YANILLE_DUNGEON_RUBBLE_CLIMB(67, "Pile of Rubble", null, PILE_OF_RUBBLE_23563, PILE_OF_RUBBLE_23564),
 	ELVEN_OVERPASS_MEDIUM_CLIFF(68, "Rocks", new WorldPoint(2337, 3288, 0), ROCKS_16514, ROCKS_16515),
 	WEISS_OBSTACLES(68, "Shortcut", null, LITTLE_BOULDER, ROCKSLIDE_33184, ROCKSLIDE_33185, NULL_33327, NULL_33328, LEDGE_33190, ROCKSLIDE_33191, FALLEN_TREE_33192),
@@ -177,22 +187,22 @@ public enum AgilityShortcut
 	SLAYER_TOWER_ADVANCED_CHAIN_FIRST(71, "Spiked Chain (Floor 2)", new WorldPoint(3447, 3578, 0), SPIKEY_CHAIN ),
 	SLAYER_TOWER_ADVANCED_CHAIN_SECOND(71, "Spiked Chain (Floor 3)", new WorldPoint(3446, 3576, 0), SPIKEY_CHAIN_16538),
 	STRONGHOLD_SLAYER_CAVE_TUNNEL(72, "Tunnel", new WorldPoint(2431, 9806, 0), TUNNEL_30174, TUNNEL_30175),
-	TROLL_STRONGHOLD_WALL_CLIMB(73, "Rocks", new WorldPoint(2841, 3694, 0), ROCKS_16464),
+	TROLL_STRONGHOLD_WALL_CLIMB(73, Diary.FREMENNIK_HARD, "Rocks", new WorldPoint(2841, 3694, 0), ROCKS_16464),
 	ARCEUUS_ESSENSE_MINE_WEST(73, "Rock Climb", new WorldPoint(1742, 3853, 0), ROCKS_27984, ROCKS_27985 ),
-	LAVA_DRAGON_ISLE_JUMP(74, "Stepping Stone", new WorldPoint(3200, 3807, 0), STEPPING_STONE_14918),
+	LAVA_DRAGON_ISLE_JUMP(74, Diary.WILDERNESS_HARD, "Stepping Stone", new WorldPoint(3200, 3807, 0), STEPPING_STONE_14918),
 	REVENANT_CAVES_DEMONS_JUMP(75, "Jump", new WorldPoint(3199, 10135, 0), PILLAR_31561),
 	REVENANT_CAVES_ANKOU_EAST(75, "Jump", new WorldPoint(3201, 10195, 0), PILLAR_31561),
 	REVENANT_CAVES_ANKOU_NORTH(75, "Jump", new WorldPoint(3180, 10209, 0), PILLAR_31561),
 	ZUL_ANDRA_ISLAND_CROSSING(76, "Stepping Stone", new WorldPoint(2156, 3073, 0), STEPPING_STONE_10663),
-	SHILO_VILLAGE_STEPPING_STONES( 77, "Stepping Stones", new WorldPoint(2863, 2974, 0), STEPPING_STONE_16466),
+	SHILO_VILLAGE_STEPPING_STONES(77, Diary.KARAMJA_ELITE, "Stepping Stones", new WorldPoint(2863, 2974, 0), STEPPING_STONE_16466),
 	KHARAZI_JUNGLE_VINE_CLIMB(79, "Vine", new WorldPoint(2897, 2939, 0), NULL_26884, NULL_26886),
 	TAVERLEY_DUNGEON_SPIKED_BLADES(80, "Strange Floor", new WorldPoint(2877, 9813, 0), STRANGE_FLOOR),
 	SLAYER_DUNGEON_CHASM_JUMP(81, "Spiked Blades", new WorldPoint(2770, 10003, 0), STRANGE_FLOOR_16544),
-	LAVA_MAZE_NORTH_JUMP(82, "Stepping Stone", new WorldPoint(3092, 3880, 0), STEPPING_STONE_14917),
-	BRIMHAVEN_DUNGEON_EAST_STEPPING_STONES_NORTH(83, "Stepping Stones", new WorldPoint(2685, 9547, 0), STEPPING_STONE_19040),
-	BRIMHAVEN_DUNGEON_EAST_STEPPING_STONES_SOUTH(83, "Stepping Stones", new WorldPoint(2693, 9529, 0), STEPPING_STONE_19040),
+	LAVA_MAZE_NORTH_JUMP(82, Diary.WILDERNESS_HARD, "Stepping Stone", new WorldPoint(3092, 3880, 0), STEPPING_STONE_14917),
+	BRIMHAVEN_DUNGEON_EAST_STEPPING_STONES_NORTH(83, Diary.KARAMJA_ELITE, "Stepping Stones", new WorldPoint(2685, 9547, 0), STEPPING_STONE_19040),
+	BRIMHAVEN_DUNGEON_EAST_STEPPING_STONES_SOUTH(83, Diary.KARAMJA_ELITE, "Stepping Stones", new WorldPoint(2693, 9529, 0), STEPPING_STONE_19040),
 	ELVEN_ADVANCED_CLIFF_SCRAMBLE(85, "Rocks", new WorldPoint(2337, 3253, 0), ROCKS_16514, ROCKS_16514),
-	KALPHITE_WALL(86, "Crevice", new WorldPoint(3214, 9508, 0), CREVICE_16465),
+	KALPHITE_WALL(86, Diary.DESERT_ELITE, "Crevice", new WorldPoint(3214, 9508, 0), CREVICE_16465),
 	BRIMHAVEN_DUNGEON_VINE_EAST(87, "Vine", new WorldPoint(2672, 9582, 0), VINE_26880, VINE_26882),
 	BRIMHAVEN_DUNGEON_VINE_WEST(87, "Vine", new WorldPoint(2606, 9584, 0), VINE_26880, VINE_26882),
 	MOUNT_KARUULM_PIPE_SOUTH(88, "Pipe", new WorldPoint(1316, 10214, 0), MYSTERIOUS_PIPE),
@@ -203,7 +213,7 @@ public enum AgilityShortcut
 	 * The agility level required to pass the shortcut
 	 */
 	@Getter
-	private final int level;
+	private final List<Requirement> requirements;
 	/**
 	 * Brief description of the shortcut (e.g. 'Rocks', 'Stepping Stones', 'Jump')
 	 */
@@ -227,22 +237,42 @@ public enum AgilityShortcut
 	@Getter
 	private final int[] obstacleIds;
 
-	AgilityShortcut(int level, String description, WorldPoint mapLocation, WorldPoint worldLocation, int... obstacleIds)
+	AgilityShortcut(List<Requirement> requirements, String description, WorldPoint mapLocation, WorldPoint worldLocation, int... obstacleIds)
 	{
-		this.level = level;
+		this.requirements = requirements;
 		this.description = description;
 		this.worldMapLocation = mapLocation;
 		this.worldLocation = worldLocation;
 		this.obstacleIds = obstacleIds;
 	}
 
+	AgilityShortcut(int level, String description, WorldPoint mapLocation, WorldPoint worldLocation, int... obstacleIds)
+	{
+		this(ImmutableList.of(new SkillRequirement(Skill.AGILITY, level)), description, mapLocation, worldLocation, obstacleIds);
+	}
+
 	AgilityShortcut(int level, String description, WorldPoint location, int... obstacleIds)
 	{
-		this(level, description, location, location, obstacleIds);
+		this(ImmutableList.of(new SkillRequirement(Skill.AGILITY, level)), description, location, location, obstacleIds);
+	}
+
+	AgilityShortcut(int level, Diary diaryRequirement, String description, WorldPoint location, int... obstacleIds)
+	{
+		this(ImmutableList.of(new SkillRequirement(Skill.AGILITY, level), new AchievementDiaryRequirement(diaryRequirement)), description, location, location, obstacleIds);
+	}
+
+	public boolean satisfiesAll(Client client)
+	{
+		boolean satisfies = true;
+		for (Requirement requirement : requirements)
+		{
+			satisfies &= requirement.isSatisfied(client);
+		}
+		return satisfies;
 	}
 
 	public String getTooltip()
 	{
-		return description + " - Level " + level;
+		return description + " - " + Joiner.on(", ").join(requirements);
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/game/requirement/AchievementDiaryRequirement.java
+++ b/runelite-client/src/main/java/net/runelite/client/game/requirement/AchievementDiaryRequirement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Abex
+ * Copyright (c) 2019 MrGroggle
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -21,8 +21,30 @@
  * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */package net.runelite.client.plugins.achievementdiary;
+ */
+package net.runelite.client.game.requirement;
 
-public interface Requirement
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import net.runelite.api.Client;
+import net.runelite.api.Diary;
+
+@Getter
+@RequiredArgsConstructor
+public class AchievementDiaryRequirement implements Requirement
 {
+	private final Diary diary;
+
+	@Override
+	public String toString()
+	{
+		return diary.getName() + " Diary";
+	}
+
+	@Override
+	public boolean isSatisfied(Client client)
+	{
+		int var = client.getVar(diary.getVarbit());
+		return var == 1;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/game/requirement/CombatLevelRequirement.java
+++ b/runelite-client/src/main/java/net/runelite/client/game/requirement/CombatLevelRequirement.java
@@ -22,22 +22,27 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package net.runelite.client.plugins.achievementdiary;
+package net.runelite.client.game.requirement;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import net.runelite.api.Skill;
+import net.runelite.api.Client;
 
 @RequiredArgsConstructor
 @Getter
-public class SkillRequirement implements Requirement
+public class CombatLevelRequirement implements Requirement
 {
-	private final Skill skill;
 	private final int level;
 
 	@Override
 	public String toString()
 	{
-		return level + " " + skill.getName();
+		return level + " " + "Combat";
+	}
+
+	@Override
+	public boolean isSatisfied(Client client)
+	{
+		return client.getLocalPlayer().getCombatLevel() >= getLevel();
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/game/requirement/FavourRequirement.java
+++ b/runelite-client/src/main/java/net/runelite/client/game/requirement/FavourRequirement.java
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) 2018, Marshall <https://github.com/marshdevs>
- * Copyright (c) 2018, Adam <Adam@sigterm.info>
+ * Copyright (c) 2019 William <https://github.com/monsterxsync>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -23,21 +22,30 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package net.runelite.client.plugins.achievementdiary;
+package net.runelite.client.game.requirement;
 
-import java.util.HashSet;
-import java.util.Set;
 import lombok.Getter;
-import net.runelite.client.game.requirement.Requirement;
+import lombok.RequiredArgsConstructor;
+import net.runelite.api.Client;
+import net.runelite.api.Favour;
 
-public abstract class GenericDiaryRequirement
+@RequiredArgsConstructor
+@Getter
+public class FavourRequirement implements Requirement
 {
-	@Getter
-	private Set<DiaryRequirement> requirements = new HashSet<>();
+	private final Favour house;
+	private final int percent;
 
-	protected void add(String task, Requirement... requirements)
+	@Override
+	public String toString()
 	{
-		DiaryRequirement diaryRequirement = new DiaryRequirement(task, requirements);
-		this.requirements.add(diaryRequirement);
+		return percent + "% " + house.getName() + " favour";
+	}
+
+	@Override
+	public boolean isSatisfied(Client client)
+	{
+		int realFavour = client.getVar(getHouse().getVarbit());
+		return (realFavour / 10) >= getPercent();
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/game/requirement/OrRequirement.java
+++ b/runelite-client/src/main/java/net/runelite/client/game/requirement/OrRequirement.java
@@ -22,32 +22,35 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package net.runelite.client.plugins.achievementdiary;
+package net.runelite.client.game.requirement;
 
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableList;
+import java.util.List;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-import net.runelite.api.Quest;
+import net.runelite.api.Client;
 
-@Getter
-@RequiredArgsConstructor
-public class QuestRequirement implements Requirement
+public class OrRequirement implements Requirement
 {
-	private final Quest quest;
-	private final boolean started;
+	@Getter
+	private final List<Requirement> requirements;
 
-	public QuestRequirement(Quest quest)
+	public OrRequirement(Requirement... reqs)
 	{
-		this(quest, false);
+		this.requirements = ImmutableList.copyOf(reqs);
 	}
 
 	@Override
 	public String toString()
 	{
-		if (started)
-		{
-			return "Started " + quest.getName();
-		}
+		return Joiner.on(" or ").join(requirements);
+	}
 
-		return quest.getName();
+	@Override
+	public boolean isSatisfied(Client client)
+	{
+		return getRequirements()
+				.stream()
+				.anyMatch(r -> r.isSatisfied(client));
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/game/requirement/QuestPointRequirement.java
+++ b/runelite-client/src/main/java/net/runelite/client/game/requirement/QuestPointRequirement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 William <https://github.com/monsterxsync>
+ * Copyright (c) 2019 Abex
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -22,22 +22,28 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package net.runelite.client.plugins.achievementdiary;
+package net.runelite.client.game.requirement;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import net.runelite.api.Favour;
+import net.runelite.api.Client;
+import net.runelite.api.VarPlayer;
 
 @RequiredArgsConstructor
 @Getter
-public class FavourRequirement implements Requirement
+public class QuestPointRequirement implements Requirement
 {
-	private final Favour house;
-	private final int percent;
+	private final int qp;
 
 	@Override
 	public String toString()
 	{
-		return percent + "% " + house.getName() + " favour";
+		return qp + " " + "Quest points";
+	}
+
+	@Override
+	public boolean isSatisfied(Client client)
+	{
+		return client.getVar(VarPlayer.QUEST_POINTS) >= getQp();
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/game/requirement/QuestRequirement.java
+++ b/runelite-client/src/main/java/net/runelite/client/game/requirement/QuestRequirement.java
@@ -22,20 +22,45 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package net.runelite.client.plugins.achievementdiary;
+package net.runelite.client.game.requirement;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import net.runelite.api.Client;
+import net.runelite.api.Quest;
+import net.runelite.api.QuestState;
 
-@RequiredArgsConstructor
 @Getter
-public class CombatLevelRequirement implements Requirement
+@RequiredArgsConstructor
+public class QuestRequirement implements Requirement
 {
-	private final int level;
+	private final Quest quest;
+	private final boolean started;
+
+	public QuestRequirement(Quest quest)
+	{
+		this(quest, false);
+	}
 
 	@Override
 	public String toString()
 	{
-		return level + " " + "Combat";
+		if (started)
+		{
+			return "Started " + quest.getName();
+		}
+
+		return quest.getName();
+	}
+
+	@Override
+	public boolean isSatisfied(Client client)
+	{
+		QuestState state = getQuest().getState(client);
+		if (isStarted())
+		{
+			return state != QuestState.NOT_STARTED;
+		}
+		return state == QuestState.FINISHED;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/game/requirement/Requirement.java
+++ b/runelite-client/src/main/java/net/runelite/client/game/requirement/Requirement.java
@@ -21,27 +21,16 @@
  * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
-package net.runelite.client.plugins.achievementdiary;
+ */package net.runelite.client.game.requirement;
 
-import com.google.common.base.Joiner;
-import com.google.common.collect.ImmutableList;
-import java.util.List;
-import lombok.Getter;
+import net.runelite.api.Client;
 
-public class OrRequirement implements Requirement
+public interface Requirement
 {
-	@Getter
-	private final List<Requirement> requirements;
-
-	public OrRequirement(Requirement... reqs)
-	{
-		this.requirements = ImmutableList.copyOf(reqs);
-	}
-
-	@Override
-	public String toString()
-	{
-		return Joiner.on(" or ").join(requirements);
-	}
+	/**
+	 * Check the client to see if the requirement is satisfied
+	 * @param client
+	 * @return Whether the requirement is satisfied by the client
+	 */
+	boolean isSatisfied(Client client);
 }

--- a/runelite-client/src/main/java/net/runelite/client/game/requirement/SkillRequirement.java
+++ b/runelite-client/src/main/java/net/runelite/client/game/requirement/SkillRequirement.java
@@ -22,20 +22,29 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package net.runelite.client.plugins.achievementdiary;
+package net.runelite.client.game.requirement;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import net.runelite.api.Client;
+import net.runelite.api.Skill;
 
 @RequiredArgsConstructor
 @Getter
-public class QuestPointRequirement implements Requirement
+public class SkillRequirement implements Requirement
 {
-	private final int qp;
+	private final Skill skill;
+	private final int level;
 
 	@Override
 	public String toString()
 	{
-		return qp + " " + "Quest points";
+		return level + " " + skill.getName();
+	}
+
+	@Override
+	public boolean isSatisfied(Client client)
+	{
+		return client.getRealSkillLevel(getSkill()) >= getLevel();
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/DiaryRequirement.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/DiaryRequirement.java
@@ -28,6 +28,7 @@ package net.runelite.client.plugins.achievementdiary;
 import com.google.common.collect.ImmutableList;
 import java.util.List;
 import lombok.Getter;
+import net.runelite.client.game.requirement.Requirement;
 
 @Getter
 class DiaryRequirement

--- a/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/DiaryRequirementsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/DiaryRequirementsPlugin.java
@@ -35,15 +35,14 @@ import javax.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.FontTypeFace;
-import net.runelite.api.QuestState;
 import net.runelite.api.ScriptID;
-import net.runelite.api.VarPlayer;
 import net.runelite.api.events.WidgetLoaded;
 import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetID;
 import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.callback.ClientThread;
 import net.runelite.client.eventbus.Subscribe;
+import net.runelite.client.game.requirement.Requirement;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.plugins.achievementdiary.diaries.ArdougneDiaryRequirement;
@@ -277,10 +276,10 @@ public class DiaryRequirementsPlugin extends Plugin
 			assert !req.getRequirements().isEmpty();
 			for (Requirement ireq : req.getRequirements())
 			{
-				boolean satifisfied = satisfiesRequirement(ireq);
-				b.append(satifisfied ? "<col=000080><str>" : "<col=800000>");
+				boolean satisfied = ireq.isSatisfied(client);
+				b.append(satisfied ? "<col=000080><str>" : "<col=800000>");
 				b.append(ireq.toString());
-				b.append(satifisfied ? "</str>" : "<col=000080>");
+				b.append(satisfied ? "</str>" : "<col=000080>");
 				b.append(AND_JOINER);
 			}
 
@@ -291,46 +290,5 @@ public class DiaryRequirementsPlugin extends Plugin
 			reqs.put(req.getTask(), b.toString());
 		}
 		return reqs;
-	}
-
-	private boolean satisfiesRequirement(Requirement r)
-	{
-		if (r instanceof OrRequirement)
-		{
-			return ((OrRequirement) r).getRequirements()
-				.stream()
-				.anyMatch(this::satisfiesRequirement);
-		}
-		if (r instanceof SkillRequirement)
-		{
-			SkillRequirement s = (SkillRequirement) r;
-			return client.getRealSkillLevel(s.getSkill()) >= s.getLevel();
-		}
-		if (r instanceof CombatLevelRequirement)
-		{
-			return client.getLocalPlayer().getCombatLevel() >= ((CombatLevelRequirement) r).getLevel();
-		}
-		if (r instanceof QuestRequirement)
-		{
-			QuestRequirement q = (QuestRequirement) r;
-			QuestState state = q.getQuest().getState(client);
-			if (q.isStarted())
-			{
-				return state != QuestState.NOT_STARTED;
-			}
-			return state == QuestState.FINISHED;
-		}
-		if (r instanceof QuestPointRequirement)
-		{
-			return client.getVar(VarPlayer.QUEST_POINTS) >= ((QuestPointRequirement) r).getQp();
-		}
-		if (r instanceof FavourRequirement)
-		{
-			FavourRequirement f = (FavourRequirement) r;
-			int realFavour = client.getVar(f.getHouse().getVarbit());
-			return (realFavour / 10) >= f.getPercent();
-		}
-		log.warn("Unknown requirement {}", r);
-		return false;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/ArdougneDiaryRequirement.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/ArdougneDiaryRequirement.java
@@ -28,8 +28,8 @@ package net.runelite.client.plugins.achievementdiary.diaries;
 import net.runelite.api.Quest;
 import net.runelite.api.Skill;
 import net.runelite.client.plugins.achievementdiary.GenericDiaryRequirement;
-import net.runelite.client.plugins.achievementdiary.QuestRequirement;
-import net.runelite.client.plugins.achievementdiary.SkillRequirement;
+import net.runelite.client.game.requirement.QuestRequirement;
+import net.runelite.client.game.requirement.SkillRequirement;
 
 public class ArdougneDiaryRequirement extends GenericDiaryRequirement
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/DesertDiaryRequirement.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/DesertDiaryRequirement.java
@@ -28,8 +28,8 @@ package net.runelite.client.plugins.achievementdiary.diaries;
 import net.runelite.api.Quest;
 import net.runelite.api.Skill;
 import net.runelite.client.plugins.achievementdiary.GenericDiaryRequirement;
-import net.runelite.client.plugins.achievementdiary.QuestRequirement;
-import net.runelite.client.plugins.achievementdiary.SkillRequirement;
+import net.runelite.client.game.requirement.QuestRequirement;
+import net.runelite.client.game.requirement.SkillRequirement;
 
 public class DesertDiaryRequirement extends GenericDiaryRequirement
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/FaladorDiaryRequirement.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/FaladorDiaryRequirement.java
@@ -28,8 +28,8 @@ package net.runelite.client.plugins.achievementdiary.diaries;
 import net.runelite.api.Quest;
 import net.runelite.api.Skill;
 import net.runelite.client.plugins.achievementdiary.GenericDiaryRequirement;
-import net.runelite.client.plugins.achievementdiary.QuestRequirement;
-import net.runelite.client.plugins.achievementdiary.SkillRequirement;
+import net.runelite.client.game.requirement.QuestRequirement;
+import net.runelite.client.game.requirement.SkillRequirement;
 
 public class FaladorDiaryRequirement extends GenericDiaryRequirement
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/FremennikDiaryRequirement.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/FremennikDiaryRequirement.java
@@ -28,8 +28,8 @@ package net.runelite.client.plugins.achievementdiary.diaries;
 import net.runelite.api.Quest;
 import net.runelite.api.Skill;
 import net.runelite.client.plugins.achievementdiary.GenericDiaryRequirement;
-import net.runelite.client.plugins.achievementdiary.QuestRequirement;
-import net.runelite.client.plugins.achievementdiary.SkillRequirement;
+import net.runelite.client.game.requirement.QuestRequirement;
+import net.runelite.client.game.requirement.SkillRequirement;
 
 public class FremennikDiaryRequirement extends GenericDiaryRequirement
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/KandarinDiaryRequirement.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/KandarinDiaryRequirement.java
@@ -28,8 +28,8 @@ package net.runelite.client.plugins.achievementdiary.diaries;
 import net.runelite.api.Quest;
 import net.runelite.api.Skill;
 import net.runelite.client.plugins.achievementdiary.GenericDiaryRequirement;
-import net.runelite.client.plugins.achievementdiary.QuestRequirement;
-import net.runelite.client.plugins.achievementdiary.SkillRequirement;
+import net.runelite.client.game.requirement.QuestRequirement;
+import net.runelite.client.game.requirement.SkillRequirement;
 
 public class KandarinDiaryRequirement extends GenericDiaryRequirement
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/KaramjaDiaryRequirement.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/KaramjaDiaryRequirement.java
@@ -27,11 +27,11 @@ package net.runelite.client.plugins.achievementdiary.diaries;
 
 import net.runelite.api.Quest;
 import net.runelite.api.Skill;
-import net.runelite.client.plugins.achievementdiary.CombatLevelRequirement;
+import net.runelite.client.game.requirement.CombatLevelRequirement;
 import net.runelite.client.plugins.achievementdiary.GenericDiaryRequirement;
-import net.runelite.client.plugins.achievementdiary.OrRequirement;
-import net.runelite.client.plugins.achievementdiary.QuestRequirement;
-import net.runelite.client.plugins.achievementdiary.SkillRequirement;
+import net.runelite.client.game.requirement.OrRequirement;
+import net.runelite.client.game.requirement.QuestRequirement;
+import net.runelite.client.game.requirement.SkillRequirement;
 
 public class KaramjaDiaryRequirement extends GenericDiaryRequirement
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/KourendDiaryRequirement.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/KourendDiaryRequirement.java
@@ -28,9 +28,9 @@ import net.runelite.api.Favour;
 import net.runelite.api.Quest;
 import net.runelite.api.Skill;
 import net.runelite.client.plugins.achievementdiary.GenericDiaryRequirement;
-import net.runelite.client.plugins.achievementdiary.SkillRequirement;
-import net.runelite.client.plugins.achievementdiary.QuestRequirement;
-import net.runelite.client.plugins.achievementdiary.FavourRequirement;
+import net.runelite.client.game.requirement.SkillRequirement;
+import net.runelite.client.game.requirement.QuestRequirement;
+import net.runelite.client.game.requirement.FavourRequirement;
 
 public class KourendDiaryRequirement extends GenericDiaryRequirement
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/LumbridgeDiaryRequirement.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/LumbridgeDiaryRequirement.java
@@ -27,10 +27,10 @@ package net.runelite.client.plugins.achievementdiary.diaries;
 
 import net.runelite.api.Quest;
 import net.runelite.api.Skill;
-import net.runelite.client.plugins.achievementdiary.CombatLevelRequirement;
+import net.runelite.client.game.requirement.CombatLevelRequirement;
 import net.runelite.client.plugins.achievementdiary.GenericDiaryRequirement;
-import net.runelite.client.plugins.achievementdiary.QuestRequirement;
-import net.runelite.client.plugins.achievementdiary.SkillRequirement;
+import net.runelite.client.game.requirement.QuestRequirement;
+import net.runelite.client.game.requirement.SkillRequirement;
 
 public class LumbridgeDiaryRequirement extends GenericDiaryRequirement
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/MorytaniaDiaryRequirement.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/MorytaniaDiaryRequirement.java
@@ -27,11 +27,11 @@ package net.runelite.client.plugins.achievementdiary.diaries;
 
 import net.runelite.api.Quest;
 import net.runelite.api.Skill;
-import net.runelite.client.plugins.achievementdiary.CombatLevelRequirement;
+import net.runelite.client.game.requirement.CombatLevelRequirement;
 import net.runelite.client.plugins.achievementdiary.GenericDiaryRequirement;
-import net.runelite.client.plugins.achievementdiary.OrRequirement;
-import net.runelite.client.plugins.achievementdiary.QuestRequirement;
-import net.runelite.client.plugins.achievementdiary.SkillRequirement;
+import net.runelite.client.game.requirement.OrRequirement;
+import net.runelite.client.game.requirement.QuestRequirement;
+import net.runelite.client.game.requirement.SkillRequirement;
 
 public class MorytaniaDiaryRequirement extends GenericDiaryRequirement
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/VarrockDiaryRequirement.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/VarrockDiaryRequirement.java
@@ -27,11 +27,11 @@ package net.runelite.client.plugins.achievementdiary.diaries;
 
 import net.runelite.api.Quest;
 import net.runelite.api.Skill;
-import net.runelite.client.plugins.achievementdiary.CombatLevelRequirement;
+import net.runelite.client.game.requirement.CombatLevelRequirement;
 import net.runelite.client.plugins.achievementdiary.GenericDiaryRequirement;
-import net.runelite.client.plugins.achievementdiary.QuestPointRequirement;
-import net.runelite.client.plugins.achievementdiary.QuestRequirement;
-import net.runelite.client.plugins.achievementdiary.SkillRequirement;
+import net.runelite.client.game.requirement.QuestPointRequirement;
+import net.runelite.client.game.requirement.QuestRequirement;
+import net.runelite.client.game.requirement.SkillRequirement;
 
 public class VarrockDiaryRequirement extends GenericDiaryRequirement
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/WesternDiaryRequirement.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/WesternDiaryRequirement.java
@@ -27,10 +27,10 @@ package net.runelite.client.plugins.achievementdiary.diaries;
 
 import net.runelite.api.Quest;
 import net.runelite.api.Skill;
-import net.runelite.client.plugins.achievementdiary.CombatLevelRequirement;
+import net.runelite.client.game.requirement.CombatLevelRequirement;
 import net.runelite.client.plugins.achievementdiary.GenericDiaryRequirement;
-import net.runelite.client.plugins.achievementdiary.QuestRequirement;
-import net.runelite.client.plugins.achievementdiary.SkillRequirement;
+import net.runelite.client.game.requirement.QuestRequirement;
+import net.runelite.client.game.requirement.SkillRequirement;
 
 public class WesternDiaryRequirement extends GenericDiaryRequirement
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/WildernessDiaryRequirement.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/WildernessDiaryRequirement.java
@@ -28,9 +28,9 @@ package net.runelite.client.plugins.achievementdiary.diaries;
 import net.runelite.api.Quest;
 import net.runelite.api.Skill;
 import net.runelite.client.plugins.achievementdiary.GenericDiaryRequirement;
-import net.runelite.client.plugins.achievementdiary.OrRequirement;
-import net.runelite.client.plugins.achievementdiary.QuestRequirement;
-import net.runelite.client.plugins.achievementdiary.SkillRequirement;
+import net.runelite.client.game.requirement.OrRequirement;
+import net.runelite.client.game.requirement.QuestRequirement;
+import net.runelite.client.game.requirement.SkillRequirement;
 
 public class WildernessDiaryRequirement extends GenericDiaryRequirement
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/agility/AgilityOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/agility/AgilityOverlay.java
@@ -94,7 +94,7 @@ class AgilityOverlay extends Overlay
 				if (objectClickbox != null)
 				{
 					AgilityShortcut agilityShortcut = obstacle.getShortcut();
-					Color configColor = agilityShortcut == null || agilityShortcut.getLevel() <= plugin.getAgilityLevel() ? config.getOverlayColor() : SHORTCUT_HIGH_LEVEL_COLOR;
+					Color configColor = agilityShortcut == null || agilityShortcut.satisfiesAll(client) ? config.getOverlayColor() : SHORTCUT_HIGH_LEVEL_COLOR;
 					if (config.highlightMarks() && !marksOfGrace.isEmpty())
 					{
 						configColor = config.getMarkColor();

--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldmap/WorldMapPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldmap/WorldMapPlugin.java
@@ -31,9 +31,11 @@ import java.awt.image.BufferedImage;
 import java.util.Arrays;
 import net.runelite.api.Client;
 import net.runelite.api.Experience;
+import net.runelite.api.GameState;
 import net.runelite.api.Skill;
 import net.runelite.api.events.ConfigChanged;
 import net.runelite.api.events.ExperienceChanged;
+import net.runelite.client.callback.ClientThread;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.game.AgilityShortcut;
@@ -90,6 +92,9 @@ public class WorldMapPlugin extends Plugin
 
 	@Inject
 	private Client client;
+
+	@Inject
+	private ClientThread clientThread;
 
 	@Inject
 	private WorldMapConfig config;
@@ -149,7 +154,7 @@ public class WorldMapPlugin extends Plugin
 			if (newAgilityLevel != agilityLevel)
 			{
 				agilityLevel = newAgilityLevel;
-				updateAgilityIcons();
+				clientThread.invokeLater(this::updateAgilityIcons);
 			}
 		}
 
@@ -173,7 +178,7 @@ public class WorldMapPlugin extends Plugin
 			Arrays.stream(AgilityShortcut.values())
 				.filter(value -> value.getWorldMapLocation() != null)
 				.map(value -> new AgilityShortcutPoint(value,
-					agilityLevel > 0 && config.agilityShortcutLevelIcon() && value.getLevel() > agilityLevel ? NOPE_ICON : BLANK_ICON,
+					config.agilityShortcutLevelIcon() && !value.satisfiesAll(client) ? NOPE_ICON : BLANK_ICON,
 					config.agilityShortcutTooltips()))
 				.forEach(worldMapPointManager::add);
 		}
@@ -198,7 +203,7 @@ public class WorldMapPlugin extends Plugin
 
 	private void updateShownIcons()
 	{
-		updateAgilityIcons();
+		clientThread.invokeLater(this::updateAgilityIcons);
 		updateRareTreeIcons();
 
 		worldMapPointManager.removeIf(FairyRingPoint.class::isInstance);


### PR DESCRIPTION
- Move requirements to net.runelite.client.game
- Remove logic from diary requirements plugin, allowing requirements to implement how they are satisfied
- Add new Diary enum, mapping achievement diaries to a description
- Add new AchievementDiaryRequirement
- Refactor AgilityShortcut to take a list of requirements, add new constructors to create shortcuts with levels and an optional Achievement diary requirement. World Map tooltip now returns a comma-separated list of requirements
- Change WorldMapPlugin to invoke Agility Shortcut updates on the client thread, as the shortcuts now require the client to verify requirements