### PR TITLE
MenuEntrySwapper: include "shop" for trade option

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -418,6 +418,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 			{
 				swap("trade", option, target, true);
 				swap("trade-with", option, target, true);
+				swap("shop", option, target, true);
 			}
 
 			if (config.claimSlime() && target.equals("robin"))


### PR DESCRIPTION
Example - the [fishing shop in Witchhaven](https://oldschool.runescape.wiki/w/Lovecraft%27s_Tackle) is `shop`, not `trade`. Don't know if there are others.