### PR TITLE
mining plugin: correct coal timer, missing copper rock and align other timers to game ticks

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/mining/Rock.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/mining/Rock.java
@@ -29,6 +29,7 @@ import java.time.Duration;
 import java.util.Map;
 import lombok.AccessLevel;
 import lombok.Getter;
+import static net.runelite.api.ObjectID.ROCKS_10943;
 import static net.runelite.api.ObjectID.ROCKS_11161;
 import static net.runelite.api.ObjectID.ROCKS_11360;
 import static net.runelite.api.ObjectID.ROCKS_11361;
@@ -50,22 +51,22 @@ import static net.runelite.api.ObjectID.ROCKS_11387;
 
 enum Rock
 {
-	TIN(Duration.ofMillis(2300), 0, ROCKS_11360, ROCKS_11361),
-	COPPER(Duration.ofMillis(2200), 0, ROCKS_11161),
-	IRON(Duration.ofMillis(5300), 0, ROCKS_11364, ROCKS_11365)
+	TIN(Duration.ofMillis(2400), 0, ROCKS_11360, ROCKS_11361),
+	COPPER(Duration.ofMillis(2400), 0, ROCKS_10943, ROCKS_11161),
+	IRON(Duration.ofMillis(5400), 0, ROCKS_11364, ROCKS_11365)
 		{
 			@Override
 			Duration getRespawnTime(boolean inMiningGuild)
 			{
-				return inMiningGuild ? Duration.ofMillis(2200) : super.respawnTime;
+				return inMiningGuild ? Duration.ofMillis(2400) : super.respawnTime;
 			}
 		},
-	COAL(Duration.ofSeconds(40), 0, ROCKS_11366, ROCKS_11367)
+	COAL(Duration.ofMillis(29400), 0, ROCKS_11366, ROCKS_11367)
 		{
 			@Override
 			Duration getRespawnTime(boolean inMiningGuild)
 			{
-				return inMiningGuild ? Duration.ofMillis(14_500) : super.respawnTime;
+				return inMiningGuild ? Duration.ofMillis(14400) : super.respawnTime;
 			}
 		},
 	SILVER(Duration.ofMinutes(1), 0, ROCKS_11369),


### PR DESCRIPTION
Fixes issue from this comment: https://github.com/runelite/runelite/issues/9042#issuecomment-499691513

Wiki says 30 seconds, but on testing it out personally I found the respawn time to be 29.4 seconds.

All the timers should be multiple of 0.6 seconds to match game ticks so I also corrected those and overlays now match up perfectly with the ores respawning.

Also came across this copper rock which wasn't yet in the plugin while testing the copper rock timer.

![2019-06-09_22-39-04](https://user-images.githubusercontent.com/29353990/59164656-dff63f80-8b07-11e9-93a0-9adf574a6516.png)

