### PR TITLE
emoji: respect chat colour tags

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/emojis/Emoji.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/emojis/Emoji.java
@@ -27,6 +27,7 @@ package net.runelite.client.plugins.emojis;
 import com.google.common.collect.ImmutableMap;
 import java.awt.image.BufferedImage;
 import java.util.Map;
+import lombok.Getter;
 import net.runelite.client.util.ImageUtil;
 
 enum Emoji
@@ -83,6 +84,7 @@ enum Emoji
 
 	private static final Map<String, Emoji> emojiMap;
 
+	@Getter
 	private final String trigger;
 
 	static

--- a/runelite-client/src/main/java/net/runelite/client/plugins/emojis/EmojiPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/emojis/EmojiPlugin.java
@@ -43,6 +43,7 @@ import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.util.ImageUtil;
+import net.runelite.client.util.Text;
 
 @PluginDescriptor(
 	name = "Emojis",
@@ -128,7 +129,7 @@ public class EmojiPlugin extends Plugin
 				return;
 		}
 
-		final String message = chatMessage.getMessage();
+		final String message = chatMessage.getMessageNode().getValue();
 		final String updatedMessage = updateMessage(message);
 
 		if (updatedMessage == null)
@@ -169,7 +170,7 @@ public class EmojiPlugin extends Plugin
 		boolean editedMessage = false;
 		for (int i = 0; i < messageWords.length; i++)
 		{
-			final Emoji emoji = Emoji.getEmoji(messageWords[i]);
+			final Emoji emoji = Emoji.getEmoji(Text.removeTags(messageWords[i]));
 
 			if (emoji == null)
 			{
@@ -178,7 +179,7 @@ public class EmojiPlugin extends Plugin
 
 			final int emojiId = modIconsStart + emoji.ordinal();
 
-			messageWords[i] = "<img=" + emojiId + ">";
+			messageWords[i] = messageWords[i].replace(emoji.getTrigger(), "<img=" + emojiId + ">");
 			editedMessage = true;
 		}
 

--- a/runelite-client/src/main/java/net/runelite/client/util/Text.java
+++ b/runelite-client/src/main/java/net/runelite/client/util/Text.java
@@ -38,7 +38,7 @@ import org.apache.commons.text.WordUtils;
  */
 public class Text
 {
-	private static final Pattern TAG_REGEXP = Pattern.compile("<[^>]*>");
+	private static final Pattern TAG_REGEXP = Pattern.compile("<(?!gt|lt).*?>");
 	private static final Splitter COMMA_SPLITTER = Splitter
 		.on(",")
 		.omitEmptyStrings()
@@ -69,7 +69,7 @@ public class Text
 	}
 
 	/**
-	 * Removes all tags from the given string.
+	 * Removes all tags from the given string except for `gt` and `lt`, as these are encoded characters.
 	 *
 	 * @param str The string to remove tags from.
 	 * @return The given string with all tags removed from it.


### PR DESCRIPTION
Fixes #8842

Makes the plugin parse the message with its tags, and make the replacement work such that it doesn't overwrite any tags that may be there.

`removeTags` has been changed to preserve the `<gt>` and `<lt>` tags. This also has the side effect of making `Chat Notifications` able to highlight `<gt>` and `<lt>`