### PR TITLE
Swapping 'wear' and 'wield' with 'use' on all mta alchemy room items

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -291,4 +291,14 @@ public interface MenuEntrySwapperConfig extends Config
 	{
 		return true;
 	}
+
+	@ConfigItem(
+		keyName = "swapMtaItems",
+		name = "MTA Alchemy Room Items",
+		description = "Swap 'Wear' and 'Wield' on the mage training arena items with 'use'"
+	)
+	default boolean swapMtaItems()
+	{
+		return true;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -28,7 +28,6 @@ package net.runelite.client.plugins.menuentryswapper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Provides;
-import java.util.Arrays;
 import java.util.Set;
 import javax.inject.Inject;
 import lombok.Getter;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -25,8 +25,10 @@
  */
 package net.runelite.client.plugins.menuentryswapper;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Provides;
+import java.util.Arrays;
 import java.util.Set;
 import javax.inject.Inject;
 import lombok.Getter;
@@ -73,6 +75,8 @@ public class MenuEntrySwapperPlugin extends Plugin
 
 	private static final String CONFIG_GROUP = "shiftclick";
 	private static final String ITEM_KEY_PREFIX = "item_";
+
+	public static final ImmutableList<Integer> MTA_ITEMS = ImmutableList.of(6893, 6894, 6895, 6897); //item id's of mage training arena alchemy room items
 
 	private static final WidgetMenuOption FIXED_INVENTORY_TAB_CONFIGURE = new WidgetMenuOption(CONFIGURE,
 		MENU_TARGET, WidgetInfo.FIXED_VIEWPORT_INVENTORY_TAB);
@@ -362,7 +366,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 		final int eventId = event.getIdentifier();
 		final String option = Text.removeTags(event.getOption()).toLowerCase();
 		final String target = Text.removeTags(event.getTarget()).toLowerCase();
-		final NPC hintArrowNpc  = client.getHintArrowNpc();
+		final NPC hintArrowNpc = client.getHintArrowNpc();
 
 		if (hintArrowNpc != null
 			&& hintArrowNpc.getIndex() == eventId
@@ -568,6 +572,10 @@ public class MenuEntrySwapperPlugin extends Plugin
 		{
 			swap("rub", option, target, true);
 			swap("teleport", option, target, true);
+		}
+		else if (config.swapMtaItems() && MTA_ITEMS.contains(eventId) && Arrays.asList("wield", "wear").contains(option))
+		{
+			swap("use", option, target, true);
 		}
 		else if (option.equals("wield"))
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -36,6 +36,10 @@ import lombok.Setter;
 import net.runelite.api.Client;
 import net.runelite.api.GameState;
 import net.runelite.api.ItemComposition;
+import static net.runelite.api.ItemID.ADAMANT_KITESHIELD_6894;
+import static net.runelite.api.ItemID.ADAMANT_MED_HELM_6895;
+import static net.runelite.api.ItemID.LEATHER_BOOTS_6893;
+import static net.runelite.api.ItemID.RUNE_LONGSWORD_6897;
 import net.runelite.api.MenuAction;
 import net.runelite.api.MenuEntry;
 import net.runelite.api.NPC;
@@ -76,7 +80,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 	private static final String CONFIG_GROUP = "shiftclick";
 	private static final String ITEM_KEY_PREFIX = "item_";
 
-	public static final ImmutableList<Integer> MTA_ITEMS = ImmutableList.of(6893, 6894, 6895, 6897); //item id's of mage training arena alchemy room items
+	private static final ImmutableList<Integer> MTA_ITEMS = ImmutableList.of(LEATHER_BOOTS_6893, ADAMANT_KITESHIELD_6894, ADAMANT_MED_HELM_6895, RUNE_LONGSWORD_6897); //item id's of mage training arena alchemy room items
 
 	private static final WidgetMenuOption FIXED_INVENTORY_TAB_CONFIGURE = new WidgetMenuOption(CONFIGURE,
 		MENU_TARGET, WidgetInfo.FIXED_VIEWPORT_INVENTORY_TAB);
@@ -573,7 +577,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 			swap("rub", option, target, true);
 			swap("teleport", option, target, true);
 		}
-		else if (config.swapMtaItems() && MTA_ITEMS.contains(eventId) && Arrays.asList("wield", "wear").contains(option))
+		else if (config.swapMtaItems() && MTA_ITEMS.contains(eventId) && ("wield".equals(option) || "wear".equals(option)))
 		{
 			swap("use", option, target, true);
 		}


### PR DESCRIPTION
For those unfamiliar with the alchemy room in the mage training arena: You are supposed to cast high alchemy on a random item specific to the arena that switches every 30 seconds, 4 out of 5 of those items are equippable but you get a message saying you can't when you try it (This option cancels all actions until you click continue). This menu swapper entry addition makes it less annoying by swapping the equip option with the use option.