### PR TITLE
Added ability to toggle on/off the item weight tooltip in the Item Stats Plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,7 @@ cache:
   directories:
     - $HOME/.m2
 jdk:
-- openjdk8
-- openjdk11
+- openjdk12
 install: true
 script: ./travis/build.sh
 notifications:

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatConfig.java
@@ -93,6 +93,13 @@ public interface ItemStatConfig extends Config
 	}
 
 	@ConfigItem(
+			keyName = "weight",
+			name = "Show Item Weight",
+			description = "Show the weight of an item in tooltip"
+	)
+	default boolean weight(){ return true; }
+
+	@ConfigItem(
 		keyName = "colorBetterUncapped",
 		name = "Better (Uncapped)",
 		description = "Color to show when the stat change is fully consumed",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatOverlay.java
@@ -188,8 +188,13 @@ public class ItemStatOverlay extends Overlay
 
 	private String buildStatBonusString(ItemStats s)
 	{
+
 		final StringBuilder b = new StringBuilder();
-		b.append(getChangeString("Weight", s.getWeight(), true, false));
+
+		if(config.weight()){
+
+			b.append(getChangeString("Weight", s.getWeight(), true, false));
+		}
 
 		ItemStats other = null;
 		final ItemEquipmentStats currentEquipment = s.getEquipment();


### PR DESCRIPTION
Added ability to toggle on/off the item weight tooltip in the Item Stats Plugin. Having the weight displayed for every item in the game can be annoying, so this modification to the Item Stats plugin will allow users to toggle the weight tooltip off.