### PR TITLE
Add bank overlay to show current most expensive items.

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/bank/BankCalculation.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/bank/BankCalculation.java
@@ -86,30 +86,9 @@ class BankCalculation
 	 */
 	void calculate()
 	{
-		ItemContainer bankInventory = client.getItemContainer(InventoryID.BANK);
+		Item[] items = getBankItems();
 
-		if (bankInventory == null)
-		{
-			return;
-		}
-
-		Item[] items = bankInventory.getItems();
-		int currentTab = client.getVar(Varbits.CURRENT_BANK_TAB);
-
-		if (currentTab > 0)
-		{
-			int startIndex = 0;
-
-			for (int i = currentTab - 1; i > 0; i--)
-			{
-				startIndex += client.getVar(TAB_VARBITS.get(i - 1));
-			}
-
-			int itemCount = client.getVar(TAB_VARBITS.get(currentTab - 1));
-			items = Arrays.copyOfRange(items, startIndex, startIndex + itemCount);
-		}
-
-		if (items.length == 0 || !isBankDifferent(items))
+		if (items == null || items.length == 0 || !isBankDifferent(items))
 		{
 			return;
 		}
@@ -182,7 +161,35 @@ class BankCalculation
 		}
 	}
 
-	private boolean isBankDifferent(Item[] items)
+	Item[] getBankItems()
+	{
+		ItemContainer bankInventory = client.getItemContainer(InventoryID.BANK);
+
+		if (bankInventory == null)
+		{
+			return null;
+		}
+
+		Item[] items = bankInventory.getItems();
+		int currentTab = client.getVar(Varbits.CURRENT_BANK_TAB);
+
+		if (currentTab > 0)
+		{
+			int startIndex = 0;
+
+			for (int i = currentTab - 1; i > 0; i--)
+			{
+				startIndex += client.getVar(TAB_VARBITS.get(i - 1));
+			}
+
+			int itemCount = client.getVar(TAB_VARBITS.get(currentTab - 1));
+			items = Arrays.copyOfRange(items, startIndex, startIndex + itemCount);
+		}
+
+		return items;
+	}
+
+	boolean isBankDifferent(Item[] items)
 	{
 		Map<Integer, Integer> mapCheck = new HashMap<>();
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/bank/BankConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/bank/BankConfig.java
@@ -97,4 +97,15 @@ public interface BankConfig extends Config
 	{
 		return false;
 	}
+
+	@ConfigItem(
+			keyName = "showMostExpensiveItemsOverlay",
+			name = "Show most expensive items overlay",
+			description = "Show the most expensive items overlay, according to grand exchange price",
+			position = 7
+	)
+	default boolean showMostExpensiveItemsOverlay()
+	{
+		return false;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/bank/BankItemsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/bank/BankItemsOverlay.java
@@ -96,7 +96,8 @@ class BankItemsOverlay extends Overlay
 
 		panelComponent.getChildren().clear();
 
-		if (expensiveItems == null || bankCalculation.isBankDifferent(bankItems)) {
+		if (expensiveItems == null || bankCalculation.isBankDifferent(bankItems)) 
+		{
 			expensiveItems = getExpensiveItems(bankItems);
 			Arrays.sort(expensiveItems, Comparator.comparing(ItemPrice::getPrice).reversed());
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/bank/BankItemsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/bank/BankItemsOverlay.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) 2019, Tal Cohen <https://github.com/talcohen>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.bank;
+
+import lombok.NonNull;
+import lombok.Value;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.Item;
+import net.runelite.client.game.ItemManager;
+import net.runelite.client.ui.overlay.Overlay;
+import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.components.ComponentOrientation;
+import net.runelite.client.ui.overlay.components.ImageComponent;
+import net.runelite.client.ui.overlay.components.PanelComponent;
+import net.runelite.client.ui.overlay.components.TitleComponent;
+import net.runelite.client.util.StackFormatter;
+
+import javax.inject.Inject;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Graphics2D;
+import java.awt.Point;
+import java.awt.image.BufferedImage;
+import java.util.Arrays;
+import java.util.Comparator;
+
+@Slf4j
+class BankItemsOverlay extends Overlay
+{
+	private static final int ITEM_SIZE = 10;
+	private static final int PLACEHOLDER_WIDTH = 36;
+	private static final int PLACEHOLDER_HEIGHT = 32;
+	private static final int WRAPPING = 2;
+	private static final Point GAP = new Point(10, 6);
+	private static final ImageComponent PLACEHOLDER_IMAGE = new ImageComponent(new BufferedImage(PLACEHOLDER_WIDTH, PLACEHOLDER_HEIGHT, BufferedImage.TYPE_4BYTE_ABGR));
+
+	private final PanelComponent panelComponent = new PanelComponent();
+
+	private final ItemManager itemManager;
+	private final BankConfig config;
+	private final BankCalculation bankCalculation;
+
+
+	private ItemPrice[] expensiveItems;
+
+	@Inject
+	private BankItemsOverlay(ItemManager itemManager, BankConfig config, BankCalculation bankCalculation)
+	{
+		setPosition(OverlayPosition.BOTTOM_RIGHT);
+		panelComponent.setWrapping(WRAPPING);
+		panelComponent.setGap(GAP);
+		panelComponent.setOrientation(ComponentOrientation.HORIZONTAL);
+		panelComponent.setPreferredSize(new Dimension(PLACEHOLDER_WIDTH + GAP.x, PLACEHOLDER_HEIGHT + GAP.y));
+
+		this.itemManager = itemManager;
+		this.config = config;
+		this.bankCalculation = bankCalculation;
+	}
+
+	@Override
+	public Dimension render(Graphics2D graphics)
+	{
+		if (!config.showMostExpensiveItemsOverlay())
+		{
+			return null;
+		}
+
+		final Item[] bankItems = bankCalculation.getBankItems();
+
+		if (bankItems == null || bankItems.length == 0)
+		{
+			return null;
+		}
+
+		panelComponent.getChildren().clear();
+
+		if (expensiveItems == null || bankCalculation.isBankDifferent(bankItems)) {
+			expensiveItems = getExpensiveItems(bankItems);
+			Arrays.sort(expensiveItems, Comparator.comparing(ItemPrice::getPrice).reversed());
+		}
+
+
+		for (int i = 0; i < ITEM_SIZE; i++)
+		{
+			if (i < expensiveItems.length)
+			{
+				final ItemPrice itemPrice = expensiveItems[i];
+				if (itemPrice.getItem().getQuantity() > 0)
+				{
+					final BufferedImage image = getImage(itemPrice.getItem());
+
+					if (image != null)
+					{
+						ImageComponent imageComponent = new ImageComponent(image);
+						panelComponent.getChildren().add(imageComponent);
+
+						TitleComponent titleComponent = TitleComponent.builder()
+								.color(Color.white)
+								.text(StackFormatter.quantityToStackSize(itemPrice.getPrice()))
+								.build();
+						panelComponent.getChildren().add(titleComponent);
+						continue;
+					}
+				}
+			}
+
+			// put two placeholder components (one image, one text) so the panel is not resized
+			panelComponent.getChildren().add(PLACEHOLDER_IMAGE);
+			panelComponent.getChildren().add(TitleComponent.builder().text("").build());
+		}
+
+		return panelComponent.render(graphics);
+
+	}
+
+	private BufferedImage getImage(Item item)
+	{
+		return itemManager.getImage(item.getId(), item.getQuantity(), true);
+	}
+
+	private ItemPrice[] getExpensiveItems(Item[] items)
+	{
+		return Arrays.stream(items)
+				.filter(i -> i.getQuantity() > 0)
+				.filter(i -> getGePrice(i) > 0)
+				.map(i -> new ItemPrice(i, getGePrice(i)))
+				.toArray(ItemPrice[]::new);
+	}
+
+	private long getGePrice(Item item)
+	{
+		return (long) itemManager.getItemPrice(item.getId()) * item.getQuantity();
+	}
+
+	@Value
+	private static class ItemPrice
+	{
+		@NonNull
+		Item item;
+		@NonNull
+		Long price;
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/bank/BankPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/bank/BankPlugin.java
@@ -39,6 +39,7 @@ import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.plugins.banktags.tabs.BankSearch;
+import net.runelite.client.ui.overlay.OverlayManager;
 import net.runelite.client.util.StackFormatter;
 
 @PluginDescriptor(
@@ -67,6 +68,12 @@ public class BankPlugin extends Plugin
 	@Inject
 	private BankSearch bankSearch;
 
+	@Inject
+	private BankItemsOverlay overlay;
+
+	@Inject
+	private OverlayManager overlayManager;
+
 	private boolean forceRightClickFlag;
 
 	@Provides
@@ -76,8 +83,15 @@ public class BankPlugin extends Plugin
 	}
 
 	@Override
+	public void startUp()
+	{
+		overlayManager.add(overlay);
+	}
+
+	@Override
 	protected void shutDown()
 	{
+		overlayManager.remove(overlay);
 		clientThread.invokeLater(() -> bankSearch.reset(false));
 		forceRightClickFlag = false;
 	}

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/components/TitleComponent.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/components/TitleComponent.java
@@ -66,7 +66,7 @@ public class TitleComponent implements LayoutableRenderableEntity
 			baseX + ((preferredSize.width - metrics.stringWidth(text)) / 2),
 			baseY + metrics.getHeight()));
 		final Dimension rendered = titleComponent.render(graphics);
-		final Dimension dimension = new Dimension(preferredSize.width, rendered.height);
+		final Dimension dimension = new Dimension(preferredSize.width, Math.max(rendered.height, preferredSize.height));
 		bounds.setLocation(preferredLocation);
 		bounds.setSize(dimension);
 		return dimension;


### PR DESCRIPTION
Adds the option to show the most (currently 10, could be configurable) expensive items in your bank, by GE price.

Oftentimes I'm clearing out my bank and am wondering which items are contributing the most to my total. I made this recently and thought I'd share it.

It currently works per tab, or for the whole bank if "all items" tab is shown, as you'd expect.

Some screenshots:
### Random Tab
![image](https://user-images.githubusercontent.com/2976769/59663076-16b10300-9163-11e9-89a6-15f0c37baa70.png)

### Another Random Tab
![image](https://user-images.githubusercontent.com/2976769/59663097-23355b80-9163-11e9-9e67-c5343a709b5f.png)

### All Items Tab
![image](https://user-images.githubusercontent.com/2976769/59663116-2d575a00-9163-11e9-945c-2773d4fb25ce.png)

### Removing an item
![image](https://user-images.githubusercontent.com/2976769/59663178-537cfa00-9163-11e9-8c7f-f508a40b305e.png)

### Tab with less than 10 items with a GE price
![image](https://user-images.githubusercontent.com/2976769/59663348-b9698180-9163-11e9-97f5-4896f3aa444e.png)

### The New Bank Config (I don't mind changing the config entry name)
![image](https://user-images.githubusercontent.com/2976769/59663974-026e0580-9165-11e9-8609-6c73ebf8f120.png)


UI code is not my strong-suit, but it seems to work fine. Someone better at it can come along and redesign it, if they'd like.