### PR TITLE
widget overlay: Don't draw empty wilderness K/D box

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/Varbits.java
+++ b/runelite-api/src/main/java/net/runelite/api/Varbits.java
@@ -631,7 +631,16 @@ public enum Varbits
 	 * 0 = on
 	 * 1 = off
 	 */
-	BOSS_HEALTH_OVERLAY(12389);
+	BOSS_HEALTH_OVERLAY(12389),
+
+	/**
+	 * Whether the PVP kill-death stats widget should be drawn while in the wilderness or in PVP worlds.
+	 *
+	 * 0 = Disabled
+	 * 1 = Enabled
+	 */
+	SHOW_PVP_KDR_STATS(4143),
+	;
 
 	/**
 	 * The raw varbit ID.

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/WidgetOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/WidgetOverlay.java
@@ -56,7 +56,7 @@ public class WidgetOverlay extends Overlay
 			new WidgetOverlay(client, WidgetInfo.PEST_CONTROL_KNIGHT_INFO_CONTAINER, OverlayPosition.TOP_LEFT),
 			new WidgetOverlay(client, WidgetInfo.PEST_CONTROL_ACTIVITY_SHIELD_INFO_CONTAINER, OverlayPosition.TOP_RIGHT),
 			new WidgetOverlay(client, WidgetInfo.ZEAH_MESS_HALL_COOKING_DISPLAY, OverlayPosition.TOP_LEFT),
-			new WidgetOverlay(client, WidgetInfo.PVP_KILLDEATH_COUNTER, OverlayPosition.TOP_LEFT),
+			new PvpKDRWidgetOverlay(client, WidgetInfo.PVP_KILLDEATH_COUNTER, OverlayPosition.TOP_LEFT),
 			new WidgetOverlay(client, WidgetInfo.SKOTIZO_CONTAINER, OverlayPosition.TOP_LEFT),
 			new WidgetOverlay(client, WidgetInfo.KOUREND_FAVOUR_OVERLAY, OverlayPosition.TOP_CENTER),
 			new WidgetOverlay(client, WidgetInfo.PYRAMID_PLUNDER_DATA, OverlayPosition.TOP_CENTER),
@@ -255,6 +255,26 @@ public class WidgetOverlay extends Overlay
 				overlayManager.rebuildOverlayLayers();
 			}
 			return position;
+		}
+	}
+
+	private static class PvpKDRWidgetOverlay extends WidgetOverlay
+	{
+		private PvpKDRWidgetOverlay(Client client, WidgetInfo widgetInfo, OverlayPosition overlayPosition)
+		{
+			super(client, widgetInfo, overlayPosition);
+		}
+
+		@Override
+		public Dimension render(Graphics2D graphics)
+		{
+			// Don't draw widget overlay if the PVP KDR stats text will be empty
+			if (client.getVar(Varbits.SHOW_PVP_KDR_STATS) == 1)
+			{
+				return super.render(graphics);
+			}
+
+			return null;
 		}
 	}
 }


### PR DESCRIPTION
The Wilderness and PVP kill-death information box is created while in
these areas regardless of whether the setting (configured via the notice
board at the Edgeville bank) is enabled to show the text, meaning the
widget contains only empty text widgets when the setting is disabled
rather than being null, causing a bounding box to still be drawn and
affecting other snapped widget layout. This commit adds a child class of
WidgetOverlay specific to this widget and prevents it from being drawn
when the setting to show this information is disabled.

Fixes runelite/runelite#6089