### PR TITLE
playerindicators-specifichighlight

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsConfig.java
@@ -24,10 +24,11 @@
  */
 package net.runelite.client.plugins.playerindicators;
 
-import java.awt.Color;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
+
+import java.awt.*;
 
 @ConfigGroup("playerindicators")
 public interface PlayerIndicatorsConfig extends Config
@@ -56,6 +57,30 @@ public interface PlayerIndicatorsConfig extends Config
 
 	@ConfigItem(
 		position = 2,
+		keyName = "drawSpecificNames",
+		name = "Tag/Highlight Specific Players",
+		description = "Configures whether or not the names entered in the below box/tagged players should be highlighted"
+	)
+	default boolean highlightSpecificNames() { return false; }
+
+	@ConfigItem(
+		position = 3,
+		keyName = "specificPlayerNames",
+		name = "Specific player names",
+		description = "Specific Player names to highlight"
+	)
+	default String getSpecificPlayerNames() { return ""; }
+
+	@ConfigItem(
+		position = 4,
+		keyName = "specificPlayerColor",
+		name = "Specific Player color",
+		description = "Color of specific player names"
+	)
+	default Color getSpecificPlayerColor() { return new Color(255,157,100); }
+
+	@ConfigItem(
+		position = 5,
 		keyName = "drawFriendNames",
 		name = "Highlight friends",
 		description = "Configures whether or not friends should be highlighted"
@@ -66,7 +91,7 @@ public interface PlayerIndicatorsConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 3,
+		position = 6,
 		keyName = "friendNameColor",
 		name = "Friend color",
 		description = "Color of friend names"
@@ -77,7 +102,7 @@ public interface PlayerIndicatorsConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 4,
+		position = 7,
 		keyName = "drawClanMemberNames",
 		name = "Highlight clan members",
 		description = "Configures whether or clan members should be highlighted"
@@ -88,7 +113,7 @@ public interface PlayerIndicatorsConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 5,
+		position = 8,
 		keyName = "clanMemberColor",
 		name = "Clan member color",
 		description = "Color of clan members"
@@ -99,7 +124,7 @@ public interface PlayerIndicatorsConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 6,
+		position = 9,
 		keyName = "drawTeamMemberNames",
 		name = "Highlight team members",
 		description = "Configures whether or not team members should be highlighted"
@@ -110,7 +135,7 @@ public interface PlayerIndicatorsConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 7,
+		position = 10,
 		keyName = "teamMemberColor",
 		name = "Team member color",
 		description = "Color of team members"
@@ -121,7 +146,7 @@ public interface PlayerIndicatorsConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 8,
+		position = 11,
 		keyName = "drawNonClanMemberNames",
 		name = "Highlight non-clan members",
 		description = "Configures whether or not non-clan members should be highlighted"
@@ -132,7 +157,7 @@ public interface PlayerIndicatorsConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 9,
+		position = 12,
 		keyName = "nonClanMemberColor",
 		name = "Non-clan member color",
 		description = "Color of non-clan member names"
@@ -143,7 +168,7 @@ public interface PlayerIndicatorsConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 10,
+		position = 13,
 		keyName = "drawPlayerTiles",
 		name = "Draw tiles under players",
 		description = "Configures whether or not tiles under highlighted players should be drawn"
@@ -154,7 +179,7 @@ public interface PlayerIndicatorsConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 11,
+		position = 14,
 		keyName = "playerNamePosition",
 		name = "Name position",
 		description = "Configures the position of drawn player names, or if they should be disabled"
@@ -165,7 +190,7 @@ public interface PlayerIndicatorsConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 12,
+		position = 15,
 		keyName = "drawMinimapNames",
 		name = "Draw names on minimap",
 		description = "Configures whether or not minimap names for players with rendered names should be drawn"
@@ -176,7 +201,7 @@ public interface PlayerIndicatorsConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 13,
+		position = 16,
 		keyName = "colorPlayerMenu",
 		name = "Colorize player menu",
 		description = "Color right click menu for players"
@@ -187,7 +212,7 @@ public interface PlayerIndicatorsConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 14,
+		position = 17,
 		keyName = "clanMenuIcons",
 		name = "Show clan ranks",
 		description = "Add clan rank to right click menu and next to player names"

--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsConfig.java
@@ -28,7 +28,7 @@ import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
 
-import java.awt.*;
+import java.awt.Color;
 
 @ConfigGroup("playerindicators")
 public interface PlayerIndicatorsConfig extends Config

--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsInput.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsInput.java
@@ -1,0 +1,40 @@
+package net.runelite.client.plugins.playerindicators;
+
+
+import net.runelite.client.input.KeyListener;
+
+import javax.inject.Inject;
+import java.awt.event.KeyEvent;
+
+public class PlayerIndicatorsInput implements KeyListener
+{
+    private static final int HOTKEY = KeyEvent.VK_SHIFT;
+
+    @Inject
+    private PlayerIndicatorsPlugin plugin;
+
+    @Override
+    public void keyTyped(KeyEvent e)
+    {
+
+    }
+
+    @Override
+    public void keyPressed(KeyEvent e)
+    {
+        if (e.getKeyCode() == HOTKEY)
+        {
+            plugin.setHotKeyPressed(true);
+        }
+    }
+
+    @Override
+    public void keyReleased(KeyEvent e)
+    {
+        if (e.getKeyCode() == HOTKEY)
+        {
+            plugin.setHotKeyPressed(false);
+        }
+    }
+
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsMinimapOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsMinimapOverlay.java
@@ -24,17 +24,12 @@
  */
 package net.runelite.client.plugins.playerindicators;
 
-import java.awt.Color;
-import java.awt.Dimension;
-import java.awt.Graphics2D;
+import net.runelite.api.Player;
+import net.runelite.client.ui.overlay.*;
+
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import net.runelite.api.Player;
-import net.runelite.client.ui.overlay.Overlay;
-import net.runelite.client.ui.overlay.OverlayLayer;
-import net.runelite.client.ui.overlay.OverlayPosition;
-import net.runelite.client.ui.overlay.OverlayPriority;
-import net.runelite.client.ui.overlay.OverlayUtil;
+import java.awt.*;
 
 @Singleton
 public class PlayerIndicatorsMinimapOverlay extends Overlay

--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsMinimapOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsMinimapOverlay.java
@@ -25,11 +25,17 @@
 package net.runelite.client.plugins.playerindicators;
 
 import net.runelite.api.Player;
-import net.runelite.client.ui.overlay.*;
+import net.runelite.client.ui.overlay.OverlayLayer;
+import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.OverlayPriority;
+import net.runelite.client.ui.overlay.OverlayUtil;
+import net.runelite.client.ui.overlay.Overlay;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import java.awt.*;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Graphics2D;
 
 @Singleton
 public class PlayerIndicatorsMinimapOverlay extends Overlay

--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsOverlay.java
@@ -37,8 +37,12 @@ import net.runelite.client.util.Text;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import java.awt.*;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Graphics2D;
 import java.awt.image.BufferedImage;
+
+
 
 @Singleton
 public class PlayerIndicatorsOverlay extends Overlay

--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsOverlay.java
@@ -25,12 +25,6 @@
  */
 package net.runelite.client.plugins.playerindicators;
 
-import java.awt.Color;
-import java.awt.Dimension;
-import java.awt.Graphics2D;
-import java.awt.image.BufferedImage;
-import javax.inject.Inject;
-import javax.inject.Singleton;
 import net.runelite.api.ClanMemberRank;
 import net.runelite.api.Player;
 import net.runelite.api.Point;
@@ -40,6 +34,11 @@ import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.OverlayPriority;
 import net.runelite.client.ui.overlay.OverlayUtil;
 import net.runelite.client.util.Text;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.awt.*;
+import java.awt.image.BufferedImage;
 
 @Singleton
 public class PlayerIndicatorsOverlay extends Overlay
@@ -53,7 +52,7 @@ public class PlayerIndicatorsOverlay extends Overlay
 
 	@Inject
 	private PlayerIndicatorsOverlay(PlayerIndicatorsConfig config, PlayerIndicatorsService playerIndicatorsService,
-		ClanManager clanManager)
+                                    ClanManager clanManager)
 	{
 		this.config = config;
 		this.playerIndicatorsService = playerIndicatorsService;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsPlugin.java
@@ -44,13 +44,15 @@ import net.runelite.client.util.Text;
 
 import javax.inject.Inject;
 import javax.inject.Provider;
-import java.awt.*;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
+import java.awt.Color;
 import static net.runelite.api.ClanMemberRank.UNRANKED;
 import static net.runelite.api.MenuAction.*;
+
+
 
 @PluginDescriptor(
 	name = "Player Indicators",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsService.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsService.java
@@ -26,35 +26,30 @@ package net.runelite.client.plugins.playerindicators;
 
 import net.runelite.api.Client;
 import net.runelite.api.Player;
-import net.runelite.client.plugins.Plugin;
 import net.runelite.client.util.Text;
 
 import javax.inject.Inject;
-import javax.inject.Singleton;
-import java.awt.*;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.function.BiConsumer;
+import java.awt.Color;
 
-@Singleton
 public class PlayerIndicatorsService
 {
 	private final Client client;
-	private final Plugin plugin;
 	private final PlayerIndicatorsConfig config;
 
 	@Inject
-	private PlayerIndicatorsService(Client client, PlayerIndicatorsConfig config, PlayerIndicatorsPlugin plugin)
+	private PlayerIndicatorsService(Client client, PlayerIndicatorsConfig config)
 	{
 		this.config = config;
 		this.client = client;
-		this.plugin = plugin;
 	}
 
 	public void forEachPlayer(final BiConsumer<Player, Color> consumer)
 	{
-		if (!config.highlightOwnPlayer() && !config.drawClanMemberNames()
+		if (!config.highlightSpecificNames() && !config.highlightOwnPlayer() && !config.drawClanMemberNames()
 			&& !config.highlightFriends() && !config.highlightNonClanMembers())
 		{
 			return;
@@ -68,8 +63,6 @@ public class PlayerIndicatorsService
 			{
 				continue;
 			}
-
-			boolean isClanMember = player.isClanMember();
 
 			if (player == localPlayer)
 			{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsTileOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsTileOverlay.java
@@ -28,7 +28,14 @@ package net.runelite.client.plugins.playerindicators;
 import net.runelite.client.ui.overlay.*;
 
 import javax.inject.Inject;
-import java.awt.*;
+import net.runelite.client.ui.overlay.OverlayLayer;
+import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.OverlayPriority;
+import net.runelite.client.ui.overlay.OverlayUtil;
+import net.runelite.client.ui.overlay.Overlay;
+import java.awt.Polygon;
+import java.awt.Graphics2D;
+import java.awt.Dimension;
 
 public class PlayerIndicatorsTileOverlay extends Overlay
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsTileOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsTileOverlay.java
@@ -25,8 +25,6 @@
 
 package net.runelite.client.plugins.playerindicators;
 
-import net.runelite.client.ui.overlay.*;
-
 import javax.inject.Inject;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsTileOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsTileOverlay.java
@@ -25,15 +25,10 @@
 
 package net.runelite.client.plugins.playerindicators;
 
-import java.awt.Dimension;
-import java.awt.Graphics2D;
-import java.awt.Polygon;
+import net.runelite.client.ui.overlay.*;
+
 import javax.inject.Inject;
-import net.runelite.client.ui.overlay.Overlay;
-import net.runelite.client.ui.overlay.OverlayLayer;
-import net.runelite.client.ui.overlay.OverlayPosition;
-import net.runelite.client.ui.overlay.OverlayPriority;
-import net.runelite.client.ui.overlay.OverlayUtil;
+import java.awt.*;
 
 public class PlayerIndicatorsTileOverlay extends Overlay
 {


### PR DESCRIPTION
Add functionality to the player indicators plugin for specific player highlighting. Highlighting takes precedence over all other highlighting (e.g. specific color shows over clan member color for example). Highlighting can be done through a shift-right click tag menu option or through a string config box.