### PR TITLE
Add custom mapping for F keys, Add toggle to consume Esc presses in chat

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/keyremapping/KeyRemappingConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/keyremapping/KeyRemappingConfig.java
@@ -92,10 +92,153 @@ public interface KeyRemappingConfig extends Config
 		position = 6,
 		keyName = "fkeyRemap",
 		name = "Remap F Keys",
-		description = "Configures whether F-Keys are Remapped to 1 (F1) through 0 (F10), '-' (F11), and '=' (F12)"
+		description = "Configures whether F-Keys use remapped keys"
 	)
 	default boolean fkeyRemap()
 	{
 		return false;
+	}
+
+	@ConfigItem(
+		position = 7,
+		keyName = "f1",
+		name = "F1",
+		description = "The key which will replace {F1}."
+	)
+	default ModifierlessKeybind f1()
+	{
+		return new ModifierlessKeybind(KeyEvent.VK_1, 0);
+	}
+
+	@ConfigItem(
+		position = 8,
+		keyName = "f2",
+		name = "F2",
+		description = "The key which will replace {F2}."
+	)
+	default ModifierlessKeybind f2()
+	{
+		return new ModifierlessKeybind(KeyEvent.VK_2, 0);
+	}
+
+	@ConfigItem(
+		position = 9,
+		keyName = "f3",
+		name = "F3",
+		description = "The key which will replace {F3}."
+	)
+	default ModifierlessKeybind f3()
+	{
+		return new ModifierlessKeybind(KeyEvent.VK_3, 0);
+	}
+
+	@ConfigItem(
+		position = 10,
+		keyName = "f4",
+		name = "F4",
+		description = "The key which will replace {F4}."
+	)
+	default ModifierlessKeybind f4()
+	{
+		return new ModifierlessKeybind(KeyEvent.VK_4, 0);
+	}
+
+	@ConfigItem(
+		position = 11,
+		keyName = "f5",
+		name = "F5",
+		description = "The key which will replace {F5}."
+	)
+	default ModifierlessKeybind f5()
+	{
+		return new ModifierlessKeybind(KeyEvent.VK_5, 0);
+	}
+
+	@ConfigItem(
+		position = 12,
+		keyName = "f6",
+		name = "F6",
+		description = "The key which will replace {F6}."
+	)
+	default ModifierlessKeybind f6()
+	{
+		return new ModifierlessKeybind(KeyEvent.VK_6, 0);
+	}
+
+	@ConfigItem(
+		position = 13,
+		keyName = "f7",
+		name = "F7",
+		description = "The key which will replace {F7}."
+	)
+	default ModifierlessKeybind f7()
+	{
+		return new ModifierlessKeybind(KeyEvent.VK_7, 0);
+	}
+
+	@ConfigItem(
+		position = 14,
+		keyName = "f8",
+		name = "F8",
+		description = "The key which will replace {F8}."
+	)
+	default ModifierlessKeybind f8()
+	{
+		return new ModifierlessKeybind(KeyEvent.VK_8, 0);
+	}
+
+	@ConfigItem(
+		position = 15,
+		keyName = "f9",
+		name = "F9",
+		description = "The key which will replace {F9}."
+	)
+	default ModifierlessKeybind f9()
+	{
+		return new ModifierlessKeybind(KeyEvent.VK_9, 0);
+	}
+
+	@ConfigItem(
+		position = 16,
+		keyName = "f10",
+		name = "F10",
+		description = "The key which will replace {F10}."
+	)
+	default ModifierlessKeybind f10()
+	{
+		return new ModifierlessKeybind(KeyEvent.VK_0, 0);
+	}
+
+	@ConfigItem(
+		position = 17,
+		keyName = "f11",
+		name = "F11",
+		description = "The key which will replace {F11}."
+	)
+	default ModifierlessKeybind f11()
+	{
+		return new ModifierlessKeybind(KeyEvent.VK_MINUS, 0);
+	}
+
+	@ConfigItem(
+		position = 18,
+		keyName = "f12",
+		name = "F12",
+		description = "The key which will replace {F12}."
+	)
+	default ModifierlessKeybind f12()
+	{
+		return new ModifierlessKeybind(KeyEvent.VK_EQUALS, 0);
+	}
+
+	@ConfigItem(
+		position = 19,
+		keyName = "esc",
+		name = "ESC",
+		description = "The key which will replace {ESC}."
+	)
+	default ModifierlessKeybind esc()
+	{
+		return new ModifierlessKeybind(KeyEvent.VK_ESCAPE, 0);
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/keyremapping/KeyRemappingListener.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/keyremapping/KeyRemappingListener.java
@@ -34,25 +34,11 @@ import net.runelite.api.Client;
 import net.runelite.api.GameState;
 import net.runelite.api.VarClientStr;
 import net.runelite.client.callback.ClientThread;
-import net.runelite.client.config.Keybind;
-import net.runelite.client.config.ModifierlessKeybind;
 import net.runelite.client.input.KeyListener;
 import net.runelite.client.input.MouseAdapter;
 
 class KeyRemappingListener extends MouseAdapter implements KeyListener
 {
-	private static final Keybind ONE = new ModifierlessKeybind(KeyEvent.VK_1, 0);
-	private static final Keybind TWO = new ModifierlessKeybind(KeyEvent.VK_2, 0);
-	private static final Keybind THREE = new ModifierlessKeybind(KeyEvent.VK_3, 0);
-	private static final Keybind FOUR = new ModifierlessKeybind(KeyEvent.VK_4, 0);
-	private static final Keybind FIVE = new ModifierlessKeybind(KeyEvent.VK_5, 0);
-	private static final Keybind SIX = new ModifierlessKeybind(KeyEvent.VK_6, 0);
-	private static final Keybind SEVEN = new ModifierlessKeybind(KeyEvent.VK_7, 0);
-	private static final Keybind EIGHT = new ModifierlessKeybind(KeyEvent.VK_8, 0);
-	private static final Keybind NINE = new ModifierlessKeybind(KeyEvent.VK_9, 0);
-	private static final Keybind ZERO = new ModifierlessKeybind(KeyEvent.VK_0, 0);
-	private static final Keybind MINUS = new ModifierlessKeybind(KeyEvent.VK_MINUS, 0);
-	private static final Keybind EQUALS = new ModifierlessKeybind(KeyEvent.VK_EQUALS, 0);
 
 	@Inject
 	private KeyRemappingPlugin plugin;
@@ -112,65 +98,70 @@ class KeyRemappingListener extends MouseAdapter implements KeyListener
 			// to select options
 			if (config.fkeyRemap() && !plugin.isDialogOpen())
 			{
-				if (ONE.matches(e))
+				if (config.f1().matches(e))
 				{
 					modified.put(e.getKeyCode(), KeyEvent.VK_F1);
 					e.setKeyCode(KeyEvent.VK_F1);
 				}
-				else if (TWO.matches(e))
+				else if (config.f2().matches(e))
 				{
 					modified.put(e.getKeyCode(), KeyEvent.VK_F2);
 					e.setKeyCode(KeyEvent.VK_F2);
 				}
-				else if (THREE.matches(e))
+				else if (config.f3().matches(e))
 				{
 					modified.put(e.getKeyCode(), KeyEvent.VK_F3);
 					e.setKeyCode(KeyEvent.VK_F3);
 				}
-				else if (FOUR.matches(e))
+				else if (config.f4().matches(e))
 				{
 					modified.put(e.getKeyCode(), KeyEvent.VK_F4);
 					e.setKeyCode(KeyEvent.VK_F4);
 				}
-				else if (FIVE.matches(e))
+				else if (config.f5().matches(e))
 				{
 					modified.put(e.getKeyCode(), KeyEvent.VK_F5);
 					e.setKeyCode(KeyEvent.VK_F5);
 				}
-				else if (SIX.matches(e))
+				else if (config.f6().matches(e))
 				{
 					modified.put(e.getKeyCode(), KeyEvent.VK_F6);
 					e.setKeyCode(KeyEvent.VK_F6);
 				}
-				else if (SEVEN.matches(e))
+				else if (config.f7().matches(e))
 				{
 					modified.put(e.getKeyCode(), KeyEvent.VK_F7);
 					e.setKeyCode(KeyEvent.VK_F7);
 				}
-				else if (EIGHT.matches(e))
+				else if (config.f8().matches(e))
 				{
 					modified.put(e.getKeyCode(), KeyEvent.VK_F8);
 					e.setKeyCode(KeyEvent.VK_F8);
 				}
-				else if (NINE.matches(e))
+				else if (config.f9().matches(e))
 				{
 					modified.put(e.getKeyCode(), KeyEvent.VK_F9);
 					e.setKeyCode(KeyEvent.VK_F9);
 				}
-				else if (ZERO.matches(e))
+				else if (config.f10().matches(e))
 				{
 					modified.put(e.getKeyCode(), KeyEvent.VK_F10);
 					e.setKeyCode(KeyEvent.VK_F10);
 				}
-				else if (MINUS.matches(e))
+				else if (config.f11().matches(e))
 				{
 					modified.put(e.getKeyCode(), KeyEvent.VK_F11);
 					e.setKeyCode(KeyEvent.VK_F11);
 				}
-				else if (EQUALS.matches(e))
+				else if (config.f12().matches(e))
 				{
 					modified.put(e.getKeyCode(), KeyEvent.VK_F12);
 					e.setKeyCode(KeyEvent.VK_F12);
+				}
+				else if (config.esc().matches(e))
+				{
+					modified.put(e.getKeyCode(), KeyEvent.VK_ESCAPE);
+					e.setKeyCode(KeyEvent.VK_ESCAPE);
 				}
 			}
 
@@ -190,8 +181,9 @@ class KeyRemappingListener extends MouseAdapter implements KeyListener
 		{
 			switch (e.getKeyCode())
 			{
-				case KeyEvent.VK_ENTER:
 				case KeyEvent.VK_ESCAPE:
+					e.consume();
+				case KeyEvent.VK_ENTER:
 					plugin.setTyping(false);
 					clientThread.invoke(plugin::lockChat);
 					break;
@@ -241,53 +233,57 @@ class KeyRemappingListener extends MouseAdapter implements KeyListener
 
 			if (config.fkeyRemap())
 			{
-				if (ONE.matches(e))
+				if (config.f1().matches(e))
 				{
 					e.setKeyCode(KeyEvent.VK_F1);
 				}
-				else if (TWO.matches(e))
+				if (config.f2().matches(e))
 				{
 					e.setKeyCode(KeyEvent.VK_F2);
 				}
-				else if (THREE.matches(e))
+				if (config.f3().matches(e))
 				{
 					e.setKeyCode(KeyEvent.VK_F3);
 				}
-				else if (FOUR.matches(e))
+				if (config.f4().matches(e))
 				{
 					e.setKeyCode(KeyEvent.VK_F4);
 				}
-				else if (FIVE.matches(e))
+				if (config.f5().matches(e))
 				{
 					e.setKeyCode(KeyEvent.VK_F5);
 				}
-				else if (SIX.matches(e))
+				if (config.f6().matches(e))
 				{
 					e.setKeyCode(KeyEvent.VK_F6);
 				}
-				else if (SEVEN.matches(e))
+				if (config.f7().matches(e))
 				{
 					e.setKeyCode(KeyEvent.VK_F7);
 				}
-				else if (EIGHT.matches(e))
+				if (config.f8().matches(e))
 				{
 					e.setKeyCode(KeyEvent.VK_F8);
 				}
-				else if (NINE.matches(e))
+				if (config.f9().matches(e))
 				{
 					e.setKeyCode(KeyEvent.VK_F9);
 				}
-				else if (ZERO.matches(e))
+				if (config.f10().matches(e))
 				{
 					e.setKeyCode(KeyEvent.VK_F10);
 				}
-				else if (MINUS.matches(e))
+				if (config.f11().matches(e))
 				{
 					e.setKeyCode(KeyEvent.VK_F11);
 				}
-				else if (EQUALS.matches(e))
+				if (config.f12().matches(e))
 				{
 					e.setKeyCode(KeyEvent.VK_F12);
+				}
+				if (config.esc().matches(e))
+				{
+					e.setKeyCode(KeyEvent.VK_ESCAPE);
 				}
 			}
 		}


### PR DESCRIPTION
Addresses #9097

* Add custom mapping for Fn keys and the Esc key. 
* Consume Esc presses when the chat is in focus

![image](https://user-images.githubusercontent.com/12144643/60741040-0a37f300-9f36-11e9-8b4c-b3c50f9397a1.png)


This is mostly the same as #7623, with the following differences:
* Is based on the most recent version of the Key Remapper plugin
* Supports re-binding F11, F12, and Esc
* Consumes Esc presses when chatting (prevents unintentionally switching tabs when canceling the chat).
