### PR TITLE
Burnt stews now count towards burn counter in Cooking plugin

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/cooking/CookingPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cooking/CookingPlugin.java
@@ -172,7 +172,8 @@ public class CookingPlugin extends Plugin
 			session.increaseCookAmount();
 
 		}
-		else if (message.startsWith("You accidentally burn"))
+		else if (message.startsWith("You accidentally burn")
+			|| message.startsWith("You accidentally spoil"))
 		{
 			if (session == null)
 			{


### PR DESCRIPTION
The burn message for stews is
> "You accidentally spoil the stew."

![stew_debug](https://user-images.githubusercontent.com/18371085/60079410-b8e06600-96e2-11e9-9ff0-094e307107fa.png)

Closes #9196.