### PR TITLE
Fix WC icons around Hosidius area

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldmap/RareTreeLocation.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldmap/RareTreeLocation.java
@@ -67,6 +67,7 @@ enum RareTreeLocation
 		new WorldPoint(1640, 3496, 0),
 		new WorldPoint(1613, 3494, 0),
 		new WorldPoint(1560, 3636, 0),
+		new WorldPoint(1646, 3590, 0),
 
 		// Miscellania
 		new WorldPoint(2550, 3869, 0),
@@ -109,9 +110,8 @@ enum RareTreeLocation
 		new WorldPoint(1353, 3731, 0),
 		new WorldPoint(1529, 3452, 0),
 		new WorldPoint(1591, 3421, 0),
-		new WorldPoint(1647, 3510, 0),
-		new WorldPoint(1632, 3509, 0),
-		new WorldPoint(1623, 3512, 0),
+		new WorldPoint(1647, 3508, 0),
+		new WorldPoint(1621, 3512, 0),
 		new WorldPoint(1593, 3491, 0),
 		new WorldPoint(1583, 3499, 0),
 		new WorldPoint(1696, 3554, 0),
@@ -119,6 +119,9 @@ enum RareTreeLocation
 		new WorldPoint(1625, 3669, 0),
 		new WorldPoint(1642, 3683, 0),
 		new WorldPoint(1642, 3663, 0),
+		new WorldPoint(1642, 3533, 0),
+		new WorldPoint(1671, 3657, 0),
+		new WorldPoint(1680, 3657, 0),
 
 		// Tirannwn
 		new WorldPoint(2217, 3141, 0),
@@ -187,8 +190,10 @@ enum RareTreeLocation
 		new WorldPoint(1389, 3821, 0),
 		new WorldPoint(1610, 3443, 0),
 		new WorldPoint(1578, 3488, 0),
-		new WorldPoint(1772, 3510, 0),
 		new WorldPoint(1685, 3740, 0),
+		new WorldPoint(1681, 3689, 0),
+		new WorldPoint(1751, 3564, 0),
+		new WorldPoint(1796, 3600, 0),
 
 		// Misthalin
 		new WorldPoint(3355, 3312, 0),


### PR DESCRIPTION
![Screenshot 2019-06-25 at 15 17 32](https://user-images.githubusercontent.com/24303281/60100471-79595e80-9762-11e9-9d8b-39c7af22c81c.png)
![Screenshot 2019-06-25 at 15 18 35](https://user-images.githubusercontent.com/24303281/60100472-79595e80-9762-11e9-9d26-4c4c8e0899da.png)


Also removes the rogue icon near Tithe farm but too much work to screenshot.
