### PR TITLE
Add tooltips to devtool buttons

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/devtools/DevToolsButton.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/devtools/DevToolsButton.java
@@ -37,6 +37,7 @@ class DevToolsButton extends JButton
 	{
 		super(title);
 		addActionListener((ev) -> setActive(!active));
+		this.setToolTipText(title);
 	}
 
 	void setActive(boolean active)


### PR DESCRIPTION
closes #4458
replaces #5186 (approach of shortening the button names was not received well)

Before: 
![image](https://user-images.githubusercontent.com/5851433/43052334-c5523db8-8df2-11e8-98ed-e465157dc94d.png)
After: 
![image](https://i.imgur.com/5JPVLg7.png)
