### PR TITLE
Replace use of deprecated Guava Files write method

### DIFF
--- a/cache/src/test/java/net/runelite/cache/AreaDumper.java
+++ b/cache/src/test/java/net/runelite/cache/AreaDumper.java
@@ -64,7 +64,7 @@ public class AreaDumper
 
 			for (AreaDefinition area : areaManager.getAreas())
 			{
-				Files.write(gson.toJson(area), new File(outDir, area.id + ".json"), Charset.defaultCharset());
+				Files.asCharSink(new File(outDir, area.id + ".json"),  Charset.defaultCharset()).write(gson.toJson(area));
 				++count;
 			}
 		}

--- a/cache/src/test/java/net/runelite/cache/EnumDumperTest.java
+++ b/cache/src/test/java/net/runelite/cache/EnumDumperTest.java
@@ -80,7 +80,7 @@ public class EnumDumperTest
 
 				if (def != null)
 				{
-					Files.write(gson.toJson(def), new File(dumpDir, file.getFileId() + ".json"), Charset.defaultCharset());
+					Files.asCharSink(new File(dumpDir, file.getFileId() + ".json"), Charset.defaultCharset()).write(gson.toJson(def));
 					++count;
 				}
 			}

--- a/cache/src/test/java/net/runelite/cache/FrameDumper.java
+++ b/cache/src/test/java/net/runelite/cache/FrameDumper.java
@@ -101,7 +101,7 @@ public class FrameDumper
 					frames.add(frame);
 				}
 
-				Files.write(gson.toJson(frames), new File(outDir, archive.getArchiveId() + ".json"), Charset.defaultCharset());
+				Files.asCharSink(new File(outDir, archive.getArchiveId() + ".json"), Charset.defaultCharset()).write(gson.toJson(frames));
 				++count;
 			}
 		}

--- a/cache/src/test/java/net/runelite/cache/FramemapDumper.java
+++ b/cache/src/test/java/net/runelite/cache/FramemapDumper.java
@@ -74,7 +74,7 @@ public class FramemapDumper
 				FramemapLoader loader = new FramemapLoader();
 				FramemapDefinition framemap = loader.load(0, contents);
 
-				Files.write(gson.toJson(framemap), new File(outDir, archive.getArchiveId() + ".json"), Charset.defaultCharset());
+				Files.asCharSink(new File(outDir, archive.getArchiveId() + ".json"), Charset.defaultCharset()).write(gson.toJson(framemap));
 				++count;
 			}
 		}

--- a/cache/src/test/java/net/runelite/cache/InventoryDumper.java
+++ b/cache/src/test/java/net/runelite/cache/InventoryDumper.java
@@ -77,7 +77,7 @@ public class InventoryDumper
 				InventoryLoader loader = new InventoryLoader();
 				InventoryDefinition inv = loader.load(file.getFileId(), file.getContents());
 
-				Files.write(gson.toJson(inv), new File(outDir, inv.id + ".json"), Charset.defaultCharset());
+				Files.asCharSink(new File(outDir, inv.id + ".json"), Charset.defaultCharset()).write(gson.toJson(inv));
 				++count;
 			}
 		}

--- a/cache/src/test/java/net/runelite/cache/KitDumperTest.java
+++ b/cache/src/test/java/net/runelite/cache/KitDumperTest.java
@@ -78,7 +78,7 @@ public class KitDumperTest
 
 				KitDefinition def = loader.load(file.getFileId(), b);
 
-				Files.write(gson.toJson(def), new File(dumpDir, file.getFileId() + ".json"), Charset.defaultCharset());
+				Files.asCharSink(new File(dumpDir, file.getFileId() + ".json"), Charset.defaultCharset()).write(gson.toJson(def));
 				++count;
 			}
 		}

--- a/cache/src/test/java/net/runelite/cache/OverlayDumper.java
+++ b/cache/src/test/java/net/runelite/cache/OverlayDumper.java
@@ -77,7 +77,7 @@ public class OverlayDumper
 				OverlayLoader loader = new OverlayLoader();
 				OverlayDefinition overlay = loader.load(file.getFileId(), file.getContents());
 
-				Files.write(gson.toJson(overlay), new File(outDir, file.getFileId() + ".json"), Charset.defaultCharset());
+				Files.asCharSink(new File(outDir, file.getFileId() + ".json"), Charset.defaultCharset()).write(gson.toJson(overlay));
 				++count;
 			}
 		}

--- a/cache/src/test/java/net/runelite/cache/SequenceDumper.java
+++ b/cache/src/test/java/net/runelite/cache/SequenceDumper.java
@@ -77,7 +77,7 @@ public class SequenceDumper
 				SequenceLoader loader = new SequenceLoader();
 				SequenceDefinition seq = loader.load(file.getFileId(), file.getContents());
 
-				Files.write(gson.toJson(seq), new File(outDir, file.getFileId() + ".json"), Charset.defaultCharset());
+				Files.asCharSink(new File(outDir, file.getFileId() + ".json"), Charset.defaultCharset()).write(gson.toJson(seq));
 				++count;
 			}
 		}

--- a/cache/src/test/java/net/runelite/cache/SoundEffectsDumperTest.java
+++ b/cache/src/test/java/net/runelite/cache/SoundEffectsDumperTest.java
@@ -71,7 +71,7 @@ public class SoundEffectsDumperTest
 				SoundEffectLoader soundEffectLoader = new SoundEffectLoader();
 				SoundEffectDefinition soundEffect = soundEffectLoader.load(contents);
 
-				Files.write(gson.toJson(soundEffect), new File(dumpDir, archive.getArchiveId() + ".json"), Charset.defaultCharset());
+				Files.asCharSink(new File(dumpDir, archive.getArchiveId() + ".json"), Charset.defaultCharset()).write(gson.toJson(soundEffect));
 				++count;
 			}
 		}

--- a/cache/src/test/java/net/runelite/cache/StructManagerTest.java
+++ b/cache/src/test/java/net/runelite/cache/StructManagerTest.java
@@ -64,7 +64,7 @@ public class StructManagerTest
 			{
 				StructDefinition def = struct.getValue();
 
-				Files.write(gson.toJson(def), new File(dumpDir, struct.getKey() + ".json"), Charset.defaultCharset());
+				Files.asCharSink(new File(dumpDir, struct.getKey() + ".json"), Charset.defaultCharset()).write(gson.toJson(def));
 				++count;
 			}
 		}

--- a/cache/src/test/java/net/runelite/cache/TextureDumper.java
+++ b/cache/src/test/java/net/runelite/cache/TextureDumper.java
@@ -64,7 +64,7 @@ public class TextureDumper
 
 			for (TextureDefinition texture : tm.getTextures())
 			{
-				Files.write(gson.toJson(texture), new File(outDir, texture.getId() + ".json"), Charset.defaultCharset());
+				Files.asCharSink(new File(outDir, texture.getId() + ".json"), Charset.defaultCharset()).write(gson.toJson(texture));
 				++count;
 			}
 		}

--- a/cache/src/test/java/net/runelite/cache/UnderlayDumper.java
+++ b/cache/src/test/java/net/runelite/cache/UnderlayDumper.java
@@ -77,7 +77,7 @@ public class UnderlayDumper
 				UnderlayLoader loader = new UnderlayLoader();
 				UnderlayDefinition underlay = loader.load(file.getFileId(), file.getContents());
 
-				Files.write(gson.toJson(underlay), new File(outDir, file.getFileId() + ".json"), Charset.defaultCharset());
+				Files.asCharSink(new File(outDir, file.getFileId() + ".json"), Charset.defaultCharset()).write(gson.toJson(underlay));
 				++count;
 			}
 		}

--- a/cache/src/test/java/net/runelite/cache/VarbitDumper.java
+++ b/cache/src/test/java/net/runelite/cache/VarbitDumper.java
@@ -77,7 +77,7 @@ public class VarbitDumper
 				VarbitLoader loader = new VarbitLoader();
 				VarbitDefinition varbit = loader.load(file.getFileId(), file.getContents());
 
-				Files.write(gson.toJson(varbit), new File(outDir, file.getFileId() + ".json"), Charset.defaultCharset());
+				Files.asCharSink(new File(outDir, file.getFileId() + ".json"), Charset.defaultCharset()).write(gson.toJson(varbit));
 				++count;
 			}
 		}

--- a/cache/src/test/java/net/runelite/cache/WorldMapDumperTest.java
+++ b/cache/src/test/java/net/runelite/cache/WorldMapDumperTest.java
@@ -77,7 +77,7 @@ public class WorldMapDumperTest
 				WorldMapLoader loader = new WorldMapLoader();
 				WorldMapDefinition def = loader.load(file.getContents(), file.getFileId());
 
-				Files.write(gson.toJson(def), new File(outDir, file.getFileId() + ".json"), Charset.defaultCharset());
+				Files.asCharSink(new File(outDir, file.getFileId() + ".json"), Charset.defaultCharset()).write(gson.toJson(def));
 				++count;
 			}
 		}


### PR DESCRIPTION
The Guava [Files.write(CharSequence from, File to, Charset charset)](https://guava.dev/releases/28.0-jre/api/docs/com/google/common/io/Files.html#write-java.lang.CharSequence-java.io.File-java.nio.charset.Charset-) is deprecated and is [scheduled to be removed in October 2019. ](https://github.com/google/guava/commit/554ca092bc57f44c5a69ce44078df5bb0793b232#diff-f2d9908269a353910c986657b03f048c)

Currently, the deprecated write function simply calls the suggested replacement [asCharSink(to, charset)](https://guava.dev/releases/28.0-jre/api/docs/com/google/common/io/Files.html#asCharSink-java.io.File-java.nio.charset.Charset-com.google.common.io.FileWriteMode...-).write(from) meaning this PR does not change any functionality, just removes the deprecated middle man.