### PR TITLE
Screen markers UX improvements

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenmarkers/ui/ScreenMarkerPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenmarkers/ui/ScreenMarkerPanel.java
@@ -29,6 +29,8 @@ import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.FlowLayout;
+import java.awt.event.KeyAdapter;
+import java.awt.event.KeyEvent;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.awt.event.WindowAdapter;
@@ -169,12 +171,7 @@ class ScreenMarkerPanel extends JPanel
 			@Override
 			public void mousePressed(MouseEvent mouseEvent)
 			{
-				marker.getMarker().setName(nameInput.getText());
-				plugin.updateConfig();
-
-				nameInput.setEditable(false);
-				updateNameActions(false);
-				requestFocusInWindow();
+				save();
 			}
 
 			@Override
@@ -198,10 +195,7 @@ class ScreenMarkerPanel extends JPanel
 			@Override
 			public void mousePressed(MouseEvent mouseEvent)
 			{
-				nameInput.setEditable(false);
-				nameInput.setText(marker.getMarker().getName());
-				updateNameActions(false);
-				requestFocusInWindow();
+				cancel();
 			}
 
 			@Override
@@ -252,6 +246,21 @@ class ScreenMarkerPanel extends JPanel
 		nameInput.setPreferredSize(new Dimension(0, 24));
 		nameInput.getTextField().setForeground(Color.WHITE);
 		nameInput.getTextField().setBorder(new EmptyBorder(0, 8, 0, 0));
+		nameInput.addKeyListener(new KeyAdapter()
+		{
+			@Override
+			public void keyPressed(KeyEvent e)
+			{
+				if (e.getKeyCode() == KeyEvent.VK_ENTER)
+				{
+					save();
+				}
+				else if (e.getKeyCode() == KeyEvent.VK_ESCAPE)
+				{
+					cancel();
+				}
+			}
+		});
 
 		nameWrapper.add(nameInput, BorderLayout.CENTER);
 		nameWrapper.add(nameActions, BorderLayout.EAST);
@@ -422,6 +431,24 @@ class ScreenMarkerPanel extends JPanel
 		updateBorder();
 		updateBorder();
 
+	}
+
+	private void save()
+	{
+		marker.getMarker().setName(nameInput.getText());
+		plugin.updateConfig();
+
+		nameInput.setEditable(false);
+		updateNameActions(false);
+		requestFocusInWindow();
+	}
+
+	private void cancel()
+	{
+		nameInput.setEditable(false);
+		nameInput.setText(marker.getMarker().getName());
+		updateNameActions(false);
+		requestFocusInWindow();
 	}
 
 	private void updateNameActions(boolean saveAndCancel)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenmarkers/ui/ScreenMarkerPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenmarkers/ui/ScreenMarkerPanel.java
@@ -261,6 +261,20 @@ class ScreenMarkerPanel extends JPanel
 				}
 			}
 		});
+		nameInput.getTextField().addMouseListener(new MouseAdapter()
+		{
+			@Override
+			public void mouseEntered(MouseEvent mouseEvent)
+			{
+				preview(true);
+			}
+
+			@Override
+			public void mouseExited(MouseEvent mouseEvent)
+			{
+				preview(false);
+			}
+		});
 
 		nameWrapper.add(nameInput, BorderLayout.CENTER);
 		nameWrapper.add(nameActions, BorderLayout.EAST);
@@ -368,10 +382,7 @@ class ScreenMarkerPanel extends JPanel
 			@Override
 			public void mousePressed(MouseEvent mouseEvent)
 			{
-				visible = !visible;
-				marker.getMarker().setVisible(visible);
-				plugin.updateConfig();
-				updateVisibility();
+				toggle(!visible);
 			}
 
 			@Override
@@ -431,6 +442,24 @@ class ScreenMarkerPanel extends JPanel
 		updateBorder();
 		updateBorder();
 
+	}
+
+	private void preview(boolean on)
+	{
+		if (visible)
+		{
+			return;
+		}
+
+		marker.getMarker().setVisible(on);
+	}
+
+	private void toggle(boolean on)
+	{
+		visible = on;
+		marker.getMarker().setVisible(visible);
+		plugin.updateConfig();
+		updateVisibility();
 	}
 
 	private void save()


### PR DESCRIPTION
- On screen marker renaming, ENTER to save, ESC to cancel
- On screen marker title hover, preview that screen marker ingame

(This last one is useful when you have a bunch of hidden markers and you want to look for a specific one, faster than toggling one at a time)