### PR TITLE
Hot cold fixes

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/HotColdClue.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/HotColdClue.java
@@ -307,6 +307,7 @@ public class HotColdClue extends ClueScroll implements LocationClueScroll, Locat
 	@Override
 	public void reset()
 	{
+		location = null;
 		initializeSolver();
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/HotColdClue.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/HotColdClue.java
@@ -296,10 +296,10 @@ public class HotColdClue extends ClueScroll implements LocationClueScroll, Locat
 		else
 		{
 			location = null;
-
-			final HotColdTemperatureChange temperatureChange = HotColdTemperatureChange.of(message);
-			hotColdSolver.signal(localWorld, temperature, temperatureChange);
 		}
+
+		final HotColdTemperatureChange temperatureChange = HotColdTemperatureChange.of(message);
+		hotColdSolver.signal(localWorld, temperature, temperatureChange);
 
 		return true;
 	}
@@ -339,7 +339,6 @@ public class HotColdClue extends ClueScroll implements LocationClueScroll, Locat
 	private void markFinalSpot(WorldPoint wp)
 	{
 		this.location = wp;
-		reset();
 	}
 
 	public String[] getNpcs()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdTemperature.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdTemperature.java
@@ -32,6 +32,7 @@ import java.util.Set;
 import javax.annotation.Nullable;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import net.runelite.client.util.Text;
 
 @AllArgsConstructor
 @Getter
@@ -93,11 +94,12 @@ public enum HotColdTemperature
 			return null;
 		}
 
+		final String messageStart = Text.fromCSV(message).get(0);
 		final List<HotColdTemperature> possibleTemperatures = new ArrayList<>();
 
 		for (final HotColdTemperature temperature : temperatureSet)
 		{
-			if (message.contains(temperature.getText()))
+			if (messageStart.contains(temperature.getText()))
 			{
 				possibleTemperatures.add(temperature);
 			}

--- a/runelite-client/src/test/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdTemperatureTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdTemperatureTest.java
@@ -73,5 +73,7 @@ public class HotColdTemperatureTest
 		assertEquals(HotColdTemperature.ICE_COLD, HotColdTemperature.getFromTemperatureSet(HotColdTemperature.MASTER_HOT_COLD_TEMPERATURES, "The device is ice cold."));
 		assertEquals(HotColdTemperature.VERY_COLD, HotColdTemperature.getFromTemperatureSet(HotColdTemperature.MASTER_HOT_COLD_TEMPERATURES, "The device is very cold."));
 		assertEquals(HotColdTemperature.VERY_HOT, HotColdTemperature.getFromTemperatureSet(HotColdTemperature.MASTER_HOT_COLD_TEMPERATURES, "The device is very hot."));
+		assertEquals(HotColdTemperature.COLD, HotColdTemperature.getFromTemperatureSet(HotColdTemperature.BEGINNER_HOT_COLD_TEMPERATURES, "The device is cold, and warmer than last time."));
+		assertEquals(HotColdTemperature.WARM, HotColdTemperature.getFromTemperatureSet(HotColdTemperature.BEGINNER_HOT_COLD_TEMPERATURES, "The device is warm, but colder than last time."));
 	}
 }


### PR DESCRIPTION
Bugfixes/improvements for the hot-cold port.

1. Hot-cold temperature gets the wrong temperature of the string "The device is warm, but colder than last time."
2. When a locator orb is activated at a location where it is visibly shaking, it resets the possible locations list instead of displaying the location.
3. When reading a new hot-cold clue, if a location had been marked from a prior hot-cold clue in the session, the final location is not cleared.

cc: @Hydrox6, as he helped point out some of these bugs. This branch should address the issues you found