### PR TITLE
mining: Add configuration to allow for progress pie customization

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/mining/MiningConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/mining/MiningConfig.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2019, Adam Witkowski <https://github.com/Quasindro>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.mining;
+
+import net.runelite.client.config.Alpha;
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.Range;
+import java.awt.Color;
+
+@ConfigGroup("mining")
+public interface MiningConfig extends Config
+{
+	@Alpha
+	@ConfigItem(
+		keyName = "progressPieColor",
+		name = "Main progress pie color",
+		description = "Configures the color of the main progress pie"
+	)
+	default Color progressPieColor()
+	{
+		return Color.YELLOW;
+	}
+
+	@Alpha
+	@ConfigItem(
+		keyName = "progressPieColorMotherlode",
+		name = "Motherlode random respawn threshold progress pie color",
+		description = "Configures the color of the progress pie after Motherlode respawn threshold"
+	)
+	default Color progressPieColorMotherlode()
+	{
+		return Color.GREEN;
+	}
+
+	@ConfigItem(
+		keyName = "progressPieInverted",
+		name = "Invert progress pie",
+		description = "Configures whether the progress pie goes from empty to full or the other way around"
+	)
+	default boolean progressPieInverted()
+	{
+		return false;
+	}
+
+	@Range(
+		min = 1,
+		max = 50
+	)
+	@ConfigItem(
+		keyName = "progressPieDiameter",
+		name = "Progress pie diameter",
+		description = "Configures how big the progress pie is"
+	)
+	default int progressPieDiameter()
+	{
+		return 1;
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/mining/MiningOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/mining/MiningOverlay.java
@@ -52,14 +52,16 @@ class MiningOverlay extends Overlay
 
 	private final Client client;
 	private final MiningPlugin plugin;
+	private final MiningConfig config;
 
 	@Inject
-	private MiningOverlay(Client client, MiningPlugin plugin)
+	private MiningOverlay(Client client, MiningPlugin plugin, MiningConfig config)
 	{
 		setPosition(OverlayPosition.DYNAMIC);
 		setLayer(OverlayLayer.ABOVE_SCENE);
 		this.plugin = plugin;
 		this.client = client;
+		this.config = config;
 	}
 
 	@Override
@@ -74,8 +76,8 @@ class MiningOverlay extends Overlay
 		Instant now = Instant.now();
 		for (Iterator<RockRespawn> it = respawns.iterator(); it.hasNext();)
 		{
-			Color pieFillColor = Color.YELLOW;
-			Color pieBorderColor = Color.ORANGE;
+			Color pieFillColor = config.progressPieColor();
+			Color pieBorderColor;
 			RockRespawn rockRespawn = it.next();
 			float percent = (now.toEpochMilli() - rockRespawn.getStartTime().toEpochMilli()) / (float) rockRespawn.getRespawnTime();
 			WorldPoint worldPoint = rockRespawn.getWorldPoint();
@@ -105,11 +107,18 @@ class MiningOverlay extends Overlay
 			// Recolour pie on motherlode veins during the portion of the timer where they may respawn
 			if (rock == Rock.ORE_VEIN && percent > ORE_VEIN_RANDOM_PERCENT_THRESHOLD)
 			{
-				pieFillColor = Color.GREEN;
-				pieBorderColor = DARK_GREEN;
+				pieFillColor = config.progressPieColorMotherlode();
 			}
 
+			if (config.progressPieInverted())
+			{
+				percent = 1.0f - percent;
+			}
+
+			pieBorderColor = pieFillColor.darker();
+
 			ProgressPieComponent ppc = new ProgressPieComponent();
+			ppc.setDiameter(config.progressPieDiameter());
 			ppc.setBorderColor(pieBorderColor);
 			ppc.setFill(pieFillColor);
 			ppc.setPosition(point);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/mining/MiningPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/mining/MiningPlugin.java
@@ -28,6 +28,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import javax.inject.Inject;
+import com.google.inject.Provides;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -49,6 +50,7 @@ import net.runelite.api.events.GameObjectDespawned;
 import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.GameTick;
 import net.runelite.api.events.WallObjectSpawned;
+import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
@@ -78,6 +80,12 @@ public class MiningPlugin extends Plugin
 	@Getter(AccessLevel.PACKAGE)
 	private final List<RockRespawn> respawns = new ArrayList<>();
 	private boolean recentlyLoggedIn;
+
+	@Provides
+	MiningConfig provideConfig(ConfigManager configManager)
+	{
+		return configManager.getConfig(MiningConfig.class);
+	}
 
 	@Override
 	protected void startUp()


### PR DESCRIPTION
Adds the option to change the mining respawn progress pies' colors & size and adds the option to invert their value.

![mining](https://user-images.githubusercontent.com/10108473/60922774-caf30480-a29d-11e9-8f5d-a959e87b672d.png)

closes #9100