### PR TITLE
grounditemsplugin: Color telegrab menu entries

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
@@ -105,6 +105,9 @@ public class GroundItemsPlugin extends Plugin
 	private static final int FOURTH_OPTION = MenuAction.GROUND_ITEM_FOURTH_OPTION.getId();
 	private static final int FIFTH_OPTION = MenuAction.GROUND_ITEM_FIFTH_OPTION.getId();
 	private static final int EXAMINE_ITEM = MenuAction.EXAMINE_ITEM_GROUND.getId();
+	private static final int CAST_ON_ITEM = MenuAction.SPELL_CAST_ON_GROUND_ITEM.getId();
+
+	private static final String TELEGRAB_TEXT = ColorUtil.wrapWithColorTag("Telekinetic Grab", Color.GREEN) + ColorUtil.prependColorTag(" -> ", Color.WHITE);
 
 	@Getter(AccessLevel.PACKAGE)
 	@Setter(AccessLevel.PACKAGE)
@@ -446,10 +449,14 @@ public class GroundItemsPlugin extends Plugin
 	@Subscribe
 	public void onMenuEntryAdded(MenuEntryAdded event)
 	{
-		if (config.itemHighlightMode() != OVERLAY
-			&& event.getOption().equals("Take")
-			&& event.getType() == THIRD_OPTION)
+		if (config.itemHighlightMode() != OVERLAY)
 		{
+			final boolean telegrabEntry = event.getOption().equals("Cast") && event.getTarget().startsWith(TELEGRAB_TEXT) && event.getType() == CAST_ON_ITEM;
+			if (!(event.getOption().equals("Take") && event.getType() == THIRD_OPTION) && !telegrabEntry)
+			{
+				return;
+			}
+
 			int itemId = event.getIdentifier();
 			Scene scene = client.getScene();
 			Tile tile = scene.getTiles()[client.getPlane()][event.getActionParam0()][event.getActionParam1()];
@@ -493,13 +500,27 @@ public class GroundItemsPlugin extends Plugin
 
 				if (mode == BOTH || mode == OPTION)
 				{
-					lastEntry.setOption(ColorUtil.prependColorTag("Take", color));
+					final String optionText = telegrabEntry ? "Cast" : "Take";
+					lastEntry.setOption(ColorUtil.prependColorTag(optionText, color));
 				}
 
 				if (mode == BOTH || mode == NAME)
 				{
-					String target = lastEntry.getTarget().substring(lastEntry.getTarget().indexOf(">") + 1);
-					lastEntry.setTarget(ColorUtil.prependColorTag(target, color));
+					String target = lastEntry.getTarget();
+
+					if (telegrabEntry)
+					{
+						target = target.substring(TELEGRAB_TEXT.length());
+					}
+
+					target = ColorUtil.prependColorTag(target.substring(target.indexOf('>') + 1), color);
+
+					if (telegrabEntry)
+					{
+						target = TELEGRAB_TEXT + target;
+					}
+
+					lastEntry.setTarget(target);
 				}
 			}
 


### PR DESCRIPTION
This patch will cause menu entries to have their options and/or targets
recolored in the same way as "Take" menu entries are already recolored
when telegrab menu entries are added.

Closes runelite/runelite#4930