### PR TITLE
events: Fix ItemContainerChanged NPEs

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/events/ItemContainerChanged.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/ItemContainerChanged.java
@@ -24,6 +24,7 @@
  */
 package net.runelite.api.events;
 
+import javax.annotation.Nullable;
 import lombok.Value;
 import net.runelite.api.ItemContainer;
 
@@ -49,5 +50,6 @@ public class ItemContainerChanged
 	/**
 	 * The modified item container.
 	 */
+	@Nullable
 	private final ItemContainer itemContainer;
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/ammo/AmmoPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/ammo/AmmoPlugin.java
@@ -85,12 +85,14 @@ public class AmmoPlugin extends Plugin
 	@Subscribe
 	public void onItemContainerChanged(ItemContainerChanged event)
 	{
-		if (event.getItemContainer() != client.getItemContainer(InventoryID.EQUIPMENT))
+		final ItemContainer container = event.getItemContainer();
+
+		if (container == null || container != client.getItemContainer(InventoryID.EQUIPMENT))
 		{
 			return;
 		}
 
-		checkInventory(event.getItemContainer().getItems());
+		checkInventory(container.getItems());
 	}
 
 	private void checkInventory(final Item[] items)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonPlugin.java
@@ -39,6 +39,7 @@ import net.runelite.api.Client;
 import net.runelite.api.GameObject;
 import net.runelite.api.InventoryID;
 import net.runelite.api.Item;
+import net.runelite.api.ItemContainer;
 import net.runelite.api.ItemID;
 import static net.runelite.api.ObjectID.CANNON_BASE;
 import net.runelite.api.Player;
@@ -148,7 +149,8 @@ public class CannonPlugin extends Plugin
 	@Subscribe
 	public void onItemContainerChanged(ItemContainerChanged event)
 	{
-		if (event.getItemContainer() != client.getItemContainer(InventoryID.INVENTORY))
+		final ItemContainer container = event.getItemContainer();
+		if (container == null || container != client.getItemContainer(InventoryID.INVENTORY))
 		{
 			return;
 		}
@@ -161,7 +163,7 @@ public class CannonPlugin extends Plugin
 
 		if (!cannonPlaced)
 		{
-			for (Item item : event.getItemContainer().getItems())
+			for (Item item : container.getItems())
 			{
 				if (item == null)
 				{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/ClueScrollPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/ClueScrollPlugin.java
@@ -50,6 +50,7 @@ import net.runelite.api.GameState;
 import net.runelite.api.InventoryID;
 import net.runelite.api.Item;
 import net.runelite.api.ItemComposition;
+import net.runelite.api.ItemContainer;
 import net.runelite.api.ItemID;
 import net.runelite.api.NPC;
 import net.runelite.api.ObjectComposition;
@@ -241,23 +242,30 @@ public class ClueScrollPlugin extends Plugin
 	@Subscribe
 	public void onItemContainerChanged(final ItemContainerChanged event)
 	{
-		if (event.getItemContainer() == client.getItemContainer(InventoryID.EQUIPMENT))
-		{
-			equippedItems = event.getItemContainer().getItems();
-			return;
-		}
+		final ItemContainer container = event.getItemContainer();
 
-		if (event.getItemContainer() != client.getItemContainer(InventoryID.INVENTORY))
+		if (container == null)
 		{
 			return;
 		}
 
-		inventoryItems = event.getItemContainer().getItems();
+		if (container == client.getItemContainer(InventoryID.EQUIPMENT))
+		{
+			equippedItems = container.getItems();
+			return;
+		}
+
+		if (container != client.getItemContainer(InventoryID.INVENTORY))
+		{
+			return;
+		}
+
+		inventoryItems = container.getItems();
 
 		// Check if item was removed from inventory
 		if (clue != null && clueItemId != null)
 		{
-			final Stream<Item> items = Arrays.stream(event.getItemContainer().getItems());
+			final Stream<Item> items = Arrays.stream(container.getItems());
 
 			// Check if clue was removed from inventory
 			if (items.noneMatch(item -> itemManager.getItemComposition(item.getId()).getId() == clueItemId))

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/ThreeStepCrypticClue.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/ThreeStepCrypticClue.java
@@ -37,6 +37,7 @@ import lombok.RequiredArgsConstructor;
 import net.runelite.api.Client;
 import net.runelite.api.InventoryID;
 import net.runelite.api.Item;
+import net.runelite.api.ItemContainer;
 import static net.runelite.api.ItemID.TORN_CLUE_SCROLL_PART_1;
 import static net.runelite.api.ItemID.TORN_CLUE_SCROLL_PART_2;
 import static net.runelite.api.ItemID.TORN_CLUE_SCROLL_PART_3;
@@ -138,7 +139,14 @@ public class ThreeStepCrypticClue extends ClueScroll implements TextClueScroll, 
 
 	private boolean checkForPart(final ItemContainerChanged event, ItemManager itemManager, int clueScrollPart, int index)
 	{
-		final Stream<Item> items = Arrays.stream(event.getItemContainer().getItems());
+		final ItemContainer container = event.getItemContainer();
+
+		if (container == null)
+		{
+			return false;
+		}
+
+		final Stream<Item> items = Arrays.stream(container.getItems());
 
 		// If we have the part then that step is done
 		if (items.anyMatch(item -> itemManager.getItemComposition(item.getId()).getId() == clueScrollPart))

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemcharges/ItemChargePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemcharges/ItemChargePlugin.java
@@ -231,12 +231,14 @@ public class ItemChargePlugin extends Plugin
 	@Subscribe
 	public void onItemContainerChanged(ItemContainerChanged event)
 	{
-		if (event.getItemContainer() != client.getItemContainer(InventoryID.EQUIPMENT) || !config.showInfoboxes())
+		final ItemContainer container = event.getItemContainer();
+
+		if (container == null || container != client.getItemContainer(InventoryID.EQUIPMENT) || !config.showInfoboxes())
 		{
 			return;
 		}
 
-		final Item[] items = event.getItemContainer().getItems();
+		final Item[] items = container.getItems();
 
 		if (config.showTeleportCharges())
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/motherlode/MotherlodePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/motherlode/MotherlodePlugin.java
@@ -391,7 +391,7 @@ public class MotherlodePlugin extends Plugin
 	{
 		final ItemContainer container = event.getItemContainer();
 
-		if (!inMlm || !shouldUpdateOres || inventorySnapshot == null || container != client.getItemContainer(InventoryID.INVENTORY))
+		if (!inMlm || !shouldUpdateOres || inventorySnapshot == null || container == null || container != client.getItemContainer(InventoryID.INVENTORY))
 		{
 			return;
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/mta/graveyard/GraveyardRoom.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/mta/graveyard/GraveyardRoom.java
@@ -100,7 +100,7 @@ public class GraveyardRoom extends MTARoom
 
 		ItemContainer container = event.getItemContainer();
 
-		if (container == client.getItemContainer(InventoryID.INVENTORY))
+		if (container != null && container == client.getItemContainer(InventoryID.INVENTORY))
 		{
 			this.score = score(container.getItems());
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/roguesden/RoguesDenPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/roguesden/RoguesDenPlugin.java
@@ -32,6 +32,7 @@ import net.runelite.api.Client;
 import net.runelite.api.GameState;
 import net.runelite.api.InventoryID;
 import net.runelite.api.Item;
+import net.runelite.api.ItemContainer;
 import net.runelite.api.ItemID;
 import net.runelite.api.Tile;
 import net.runelite.api.TileObject;
@@ -91,12 +92,14 @@ public class RoguesDenPlugin extends Plugin
 	@Subscribe
 	public void onItemContainerChanged(ItemContainerChanged event)
 	{
-		if (event.getItemContainer() != client.getItemContainer(InventoryID.INVENTORY))
+		final ItemContainer container = event.getItemContainer();
+
+		if (container == null || container != client.getItemContainer(InventoryID.INVENTORY))
 		{
 			return;
 		}
 
-		for (Item item : event.getItemContainer().getItems())
+		for (Item item : container.getItems())
 		{
 			if (item.getId() == ItemID.MYSTIC_JEWEL)
 			{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/runecraft/RunecraftPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/runecraft/RunecraftPlugin.java
@@ -39,6 +39,7 @@ import net.runelite.api.DecorativeObject;
 import net.runelite.api.GameState;
 import net.runelite.api.InventoryID;
 import net.runelite.api.Item;
+import net.runelite.api.ItemContainer;
 import net.runelite.api.ItemID;
 import net.runelite.api.NPC;
 import net.runelite.api.NpcID;
@@ -178,12 +179,14 @@ public class RunecraftPlugin extends Plugin
 	@Subscribe
 	public void onItemContainerChanged(ItemContainerChanged event)
 	{
-		if (event.getItemContainer() != client.getItemContainer(InventoryID.INVENTORY))
+		final ItemContainer container = event.getItemContainer();
+
+		if (container == null || container != client.getItemContainer(InventoryID.INVENTORY))
 		{
 			return;
 		}
 
-		final Item[] items = event.getItemContainer().getItems();
+		final Item[] items = container.getItems();
 		degradedPouchInInventory = Stream.of(items).anyMatch(i -> DEGRADED_POUCHES.contains(i.getId()));
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersPlugin.java
@@ -806,7 +806,7 @@ public class TimersPlugin extends Plugin
 	public void onItemContainerChanged(ItemContainerChanged itemContainerChanged)
 	{
 		ItemContainer container = itemContainerChanged.getItemContainer();
-		if (container == client.getItemContainer(InventoryID.EQUIPMENT))
+		if (container != null && container == client.getItemContainer(InventoryID.EQUIPMENT))
 		{
 			Item[] items = container.getItems();
 			int weaponIdx = EquipmentInventorySlot.WEAPON.getSlotIdx();

--- a/runelite-client/src/main/java/net/runelite/client/plugins/wintertodt/WintertodtPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/wintertodt/WintertodtPlugin.java
@@ -431,7 +431,7 @@ public class WintertodtPlugin extends Plugin
 	{
 		final ItemContainer container = event.getItemContainer();
 
-		if (!isInWintertodt || container != client.getItemContainer(InventoryID.INVENTORY))
+		if (!isInWintertodt || container == null || container != client.getItemContainer(InventoryID.INVENTORY))
 		{
 			return;
 		}


### PR DESCRIPTION
`ItemContainerChanged.getItemContainer()' is nullable, therefore should
be null-checked in subscribers. This commit marks the field as nullable
and changes its usages to properly null-check it.