### PR TITLE
Fix MSAA white pixels

### DIFF
--- a/runelite-client/src/main/resources/net/runelite/client/plugins/gpu/frag.glsl
+++ b/runelite-client/src/main/resources/net/runelite/client/plugins/gpu/frag.glsl
@@ -31,7 +31,7 @@ uniform float smoothBanding;
 uniform vec4 fogColor;
 
 in vec4 Color;
-in float fHsl;
+centroid in float fHsl;
 in vec4 fUv;
 in float fogAmount;
 


### PR DESCRIPTION
Fixes the white pixels at the edges of objects when using MSAA.

Before:
![Before](https://i.imgur.com/OnUL5bE.png)
After:
![After](https://i.imgur.com/Z0sKRdA.png)