### PR TITLE
slayerplugin: Correct Jad and Zuk task tracking

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerPlugin.java
@@ -535,7 +535,15 @@ public class SlayerPlugin extends Plugin
 			return;
 		}
 
-		killedOne();
+		final int taskKillExp = Task.getTask(taskName).getExpectedKillExp();
+
+		// Only count exp gain as a kill if the task either has no expected exp for a kill, or if the exp gain is equal
+		// to the expected exp gain for the task.
+		if (taskKillExp == 0 || taskKillExp == slayerExp - cachedXp)
+		{
+			killedOne();
+		}
+
 		cachedXp = slayerExp;
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/Task.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/Task.java
@@ -107,7 +107,7 @@ enum Task
 	ICEFIENDS("Icefiends", ItemID.ICE_DIAMOND),
 	INFERNAL_MAGES("Infernal mages", ItemID.INFERNAL_MAGE, "Malevolent mage"),
 	IRON_DRAGONS("Iron dragons", ItemID.IRON_DRAGON_MASK),
-	JAD("TzTok-Jad", ItemID.TZREKJAD),
+	JAD("TzTok-Jad", ItemID.TZREKJAD, 25250),
 	JELLIES("Jellies", ItemID.JELLY, "Jelly"),
 	JUNGLE_HORROR("Jungle horrors", ItemID.ENSOULED_HORROR_HEAD),
 	KALPHITE("Kalphite", ItemID.KALPHITE_SOLDIER),
@@ -171,7 +171,7 @@ enum Task
 	ZILYANA("Commander Zilyana", ItemID.PET_ZILYANA),
 	ZOMBIES("Zombies", ItemID.ZOMBIE_HEAD, "Undead"),
 	ZULRAH("Zulrah", ItemID.PET_SNAKELING),
-	ZUK("TzKal-Zuk", ItemID.TZREKZUK);
+	ZUK("TzKal-Zuk", ItemID.TZREKZUK, 101890);
 	//</editor-fold>
 
 	private static final Map<String, Task> tasks;
@@ -181,6 +181,7 @@ enum Task
 	private final String[] targetNames;
 	private final int weaknessThreshold;
 	private final int weaknessItem;
+	private final int expectedKillExp;
 
 	static
 	{
@@ -202,6 +203,7 @@ enum Task
 		this.weaknessThreshold = -1;
 		this.weaknessItem = -1;
 		this.targetNames = targetNames;
+		this.expectedKillExp = 0;
 	}
 
 	Task(String name, int itemSpriteId, int weaknessThreshold, int weaknessItem, String... targetNames)
@@ -212,6 +214,18 @@ enum Task
 		this.weaknessThreshold = weaknessThreshold;
 		this.weaknessItem = weaknessItem;
 		this.targetNames = targetNames;
+		this.expectedKillExp = 0;
+	}
+
+	Task(String name, int itemSpriteId, int expectedKillExp)
+	{
+		Preconditions.checkArgument(itemSpriteId >= 0);
+		this.name = name;
+		this.itemSpriteId = itemSpriteId;
+		this.weaknessThreshold = -1;
+		this.weaknessItem = -1;
+		this.targetNames = new String[0];
+		this.expectedKillExp = expectedKillExp;
 	}
 
 	static Task getTask(String taskName)

--- a/runelite-client/src/test/java/net/runelite/client/plugins/slayer/SlayerPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/slayer/SlayerPluginTest.java
@@ -35,8 +35,10 @@ import static net.runelite.api.ChatMessageType.GAMEMESSAGE;
 import net.runelite.api.Client;
 import net.runelite.api.MessageNode;
 import net.runelite.api.Player;
+import net.runelite.api.Skill;
 import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.events.ChatMessage;
+import net.runelite.api.events.ExperienceChanged;
 import net.runelite.api.events.GameTick;
 import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetInfo;
@@ -416,6 +418,64 @@ public class SlayerPluginTest
 		when(slayerConfig.showSuperiorNotification()).thenReturn(false);
 		slayerPlugin.onChatMessage(chatMessageEvent);
 		verifyNoMoreInteractions(notifier);
+	}
+
+	@Test
+	public void testJadTaskKill()
+	{
+		final Player player = mock(Player.class);
+		when(player.getLocalLocation()).thenReturn(new LocalPoint(0, 0));
+		when(client.getLocalPlayer()).thenReturn(player);
+
+		final ExperienceChanged experienceChanged = new ExperienceChanged();
+		experienceChanged.setSkill(Skill.SLAYER);
+
+		when(client.getSkillExperience(Skill.SLAYER)).thenReturn(100);
+		slayerPlugin.onExperienceChanged(experienceChanged);
+
+		slayerPlugin.setTaskName("TzTok-Jad");
+		slayerPlugin.setAmount(1);
+
+		// One bat kill
+		when(client.getSkillExperience(Skill.SLAYER)).thenReturn(110);
+		slayerPlugin.onExperienceChanged(experienceChanged);
+
+		assertEquals(1, slayerPlugin.getAmount());
+
+		// One Jad kill
+		when(client.getSkillExperience(Skill.SLAYER)).thenReturn(25_360);
+		slayerPlugin.onExperienceChanged(experienceChanged);
+
+		assertEquals(0, slayerPlugin.getAmount());
+	}
+
+	@Test
+	public void testZukTaskKill()
+	{
+		final Player player = mock(Player.class);
+		when(player.getLocalLocation()).thenReturn(new LocalPoint(0, 0));
+		when(client.getLocalPlayer()).thenReturn(player);
+
+		final ExperienceChanged experienceChanged = new ExperienceChanged();
+		experienceChanged.setSkill(Skill.SLAYER);
+
+		when(client.getSkillExperience(Skill.SLAYER)).thenReturn(100);
+		slayerPlugin.onExperienceChanged(experienceChanged);
+
+		slayerPlugin.setTaskName("TzKal-Zuk");
+		slayerPlugin.setAmount(1);
+
+		// One bat kill
+		when(client.getSkillExperience(Skill.SLAYER)).thenReturn(125);
+		slayerPlugin.onExperienceChanged(experienceChanged);
+
+		assertEquals(1, slayerPlugin.getAmount());
+
+		// One Zuk kill
+		when(client.getSkillExperience(Skill.SLAYER)).thenReturn(102_015);
+		slayerPlugin.onExperienceChanged(experienceChanged);
+
+		assertEquals(0, slayerPlugin.getAmount());
 	}
 
 	@Test


### PR DESCRIPTION
This adds a field to Task which dictates the expected exp gain of the
task. When set to a non-zero value, it will prevent slayer exp gains
from registering as a kill unless they are of exactly that amount.

Closes runelite/runelite#1865