### PR TITLE
XP tracker: Fix issue where progress bar shows 100.00% before level up

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpInfoBox.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpInfoBox.java
@@ -28,6 +28,7 @@ package net.runelite.client.plugins.xptracker;
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Dimension;
+import java.math.RoundingMode;
 import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -58,6 +59,11 @@ import net.runelite.client.util.StackFormatter;
 class XpInfoBox extends JPanel
 {
 	private static final DecimalFormat TWO_DECIMAL_FORMAT = new DecimalFormat("0.00");
+
+	static
+	{
+		TWO_DECIMAL_FORMAT.setRoundingMode(RoundingMode.DOWN);
+	}
 
 	// Templates
 	private static final String HTML_TOOL_TIP_TEMPLATE =


### PR DESCRIPTION
Saw this in discord:
![2019-07-15-200239_679x101_scrot](https://user-images.githubusercontent.com/47735848/61209135-450f0780-a73c-11e9-947b-22c3d49f0b89.png)
Before:
![2019-07-15-200045_227x63_scrot](https://user-images.githubusercontent.com/47735848/61209155-50623300-a73c-11e9-92d6-9a3fc985a6ad.png)
After:
![2019-07-15-200149_237x64_scrot](https://user-images.githubusercontent.com/47735848/61209168-58ba6e00-a73c-11e9-8678-c74940fd9aed.png)

My first pull request so let me know if I did anything wrong!