### PR TITLE
banktags: save current tab tag on click

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/banktags/tabs/TabInterface.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/banktags/tabs/TabInterface.java
@@ -334,10 +334,20 @@ public class TabInterface
 					bankSearch.reset(true);
 
 					clientThread.invokeLater(() -> client.runScript(ScriptID.RESET_CHATBOX_INPUT));
+
+					if (config.rememberTab())
+					{
+						config.tab("");
+					}
 				}
 				else
 				{
-					openTag(Text.removeTags(clicked.getName()));
+					final String tagName = Text.removeTags(clicked.getName());
+					openTag(tagName);
+					if (config.rememberTab())
+					{
+						config.tab(tagName);
+					}
 				}
 
 				client.playSoundEffect(SoundEffectID.UI_BOOP);


### PR DESCRIPTION
Closes #9401

People were clicking too fast for the game tick event to save the current tab. 