### PR TITLE
Cluescrolls: Use "Location" Label Consistently in Hint Overlays

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java
@@ -203,7 +203,7 @@ public class AnagramClue extends ClueScroll implements TextClueScroll, NpcClueSc
 			.leftColor(TITLED_CONTENT_COLOR)
 			.build());
 
-		panelComponent.getChildren().add(LineComponent.builder().left("Area:").build());
+		panelComponent.getChildren().add(LineComponent.builder().left("Location:").build());
 		panelComponent.getChildren().add(LineComponent.builder()
 			.left(getArea())
 			.leftColor(TITLED_CONTENT_COLOR)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CipherClue.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CipherClue.java
@@ -85,7 +85,7 @@ public class CipherClue extends ClueScroll implements TextClueScroll, NpcClueScr
 			.leftColor(TITLED_CONTENT_COLOR)
 			.build());
 
-		panelComponent.getChildren().add(LineComponent.builder().left("Area:").build());
+		panelComponent.getChildren().add(LineComponent.builder().left("Location:").build());
 		panelComponent.getChildren().add(LineComponent.builder()
 			.left(getArea())
 			.leftColor(TITLED_CONTENT_COLOR)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/HotColdClue.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/HotColdClue.java
@@ -160,7 +160,7 @@ public class HotColdClue extends ClueScroll implements LocationClueScroll, Locat
 		else
 		{
 			panelComponent.getChildren().add(LineComponent.builder()
-				.left("Possible areas:")
+				.left("Possible locations:")
 				.build());
 
 			final Map<HotColdArea, Integer> locationCounts = new EnumMap<>(HotColdArea.class);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/MusicClue.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/MusicClue.java
@@ -61,7 +61,7 @@ public class MusicClue extends ClueScroll implements NpcClueScroll
 			.leftColor(TITLED_CONTENT_COLOR)
 			.build());
 
-		panelComponent.getChildren().add(LineComponent.builder().left("Area:").build());
+		panelComponent.getChildren().add(LineComponent.builder().left("Location:").build());
 		panelComponent.getChildren().add(LineComponent.builder()
 			.left("Falador Park")
 			.leftColor(TITLED_CONTENT_COLOR)


### PR DESCRIPTION
I noticed some of the hint overlays use "Area" and others use "Location". Figured I would do this for consistency's sake, but if it's not worth it, I'll close it.