### PR TITLE
Revert "Shutdown plugins on window close"

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/RuneLite.java
+++ b/runelite-client/src/main/java/net/runelite/client/RuneLite.java
@@ -55,8 +55,6 @@ import net.runelite.client.game.ItemManager;
 import net.runelite.client.game.LootManager;
 import net.runelite.client.game.chatbox.ChatboxPanelManager;
 import net.runelite.client.menus.MenuManager;
-import net.runelite.client.plugins.Plugin;
-import net.runelite.client.plugins.PluginInstantiationException;
 import net.runelite.client.plugins.PluginManager;
 import net.runelite.client.rs.ClientUpdateCheckMode;
 import net.runelite.client.ui.ClientUI;
@@ -301,18 +299,6 @@ public class RuneLite
 		configManager.sendConfig();
 		clientSessionManager.shutdown();
 		discordService.close();
-
-		for (final Plugin plugin : pluginManager.getPlugins())
-		{
-			try
-			{
-				pluginManager.stopPlugin(plugin);
-			}
-			catch (PluginInstantiationException e)
-			{
-				log.warn("Failed to gracefully close plugin", e);
-			}
-		}
 	}
 
 	@VisibleForTesting


### PR DESCRIPTION
This reverts commit 6e080949f9943ac118b62840bac0624f1f3e6d7b.

This never worked because it ran stopPlugin on the AWT thread
which calls invokeAndWait, which throws when not on the awt
thread. Also stopPlugin only attempts to stop plugins that are
marked as disabled, but it is only called for plugins which are
enabled, so nothing actually happens. This also creates a deadlock
if you try to close the client while starting it, because
startPlugin is locked on one thread, but stop plugin is trying
to take the lock on the edt.

Closes #7633