### PR TITLE
runelite-client: Don't write all images to disk when loading them

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/util/ImageUtil.java
+++ b/runelite-client/src/main/java/net/runelite/client/util/ImageUtil.java
@@ -52,6 +52,11 @@ import net.runelite.api.SpritePixels;
 @Slf4j
 public class ImageUtil
 {
+	static
+	{
+		ImageIO.setUseCache(false);
+	}
+
 	/**
 	 * Creates a {@link BufferedImage} from an {@link Image}.
 	 *


### PR DESCRIPTION
The runescape client applies this, but we hit ImageIO alot before that happens.

Closes #9156