### PR TITLE
Add option to highlight items already stacked in inventory

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
@@ -369,4 +369,15 @@ public interface GroundItemsConfig extends Config
 	{
 		return false;
 	}
+
+	@ConfigItem(
+		keyName = "inventoryStacks",
+		name = "Inventory Stacks",
+		description = "Highlights items already stacked in inventory",
+		position = 29
+	)
+	default boolean inventoryStacks()
+	{
+		return false;
+	}
 }


### PR DESCRIPTION
Adds an option to the Ground Items plugin to highlight stackable items which already exists in the players inventory. This is useful when training slayer.

Closes #9332