### PR TITLE
Fix issue where chat replayed from the chat history plugin is not filtered through the chat filter plugin

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatfilter/ChatFilterPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatfilter/ChatFilterPlugin.java
@@ -180,7 +180,8 @@ public class ChatFilterPlugin extends Plugin
 
 	String censorMessage(final String message)
 	{
-		String strippedMessage = jagexPrintableCharMatcher.retainFrom(message.replace('\u00A0', ' '));
+		String strippedMessage = jagexPrintableCharMatcher.retainFrom(message)
+			.replace('\u00A0', ' ');
 		boolean filtered = false;
 		for (Pattern pattern : filteredPatterns)
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatfilter/ChatFilterPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatfilter/ChatFilterPlugin.java
@@ -180,8 +180,7 @@ public class ChatFilterPlugin extends Plugin
 
 	String censorMessage(final String message)
 	{
-		String strippedMessage = jagexPrintableCharMatcher.retainFrom(message)
-			.replace('\u00A0', ' ');
+		String strippedMessage = jagexPrintableCharMatcher.retainFrom(message.replace('\u00A0', ' '));
 		boolean filtered = false;
 		for (Pattern pattern : filteredPatterns)
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatfilter/JagexPrintableCharMatcher.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatfilter/JagexPrintableCharMatcher.java
@@ -34,6 +34,6 @@ class JagexPrintableCharMatcher extends CharMatcher
 		// Characters which are printable
 		return (c >= 32 && c <= 126)
 			|| c == 128
-			|| (c >= 161 && c <= 255);
+			|| (c >= 160 && c <= 255);
 	}
 }

--- a/runelite-client/src/test/java/net/runelite/client/plugins/chatfilter/ChatFilterPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/chatfilter/ChatFilterPluginTest.java
@@ -121,6 +121,16 @@ public class ChatFilterPluginTest
 	}
 
 	@Test
+	public void testReplayedMessage()
+	{
+		when(chatFilterConfig.filterType()).thenReturn(ChatFilterType.REMOVE_MESSAGE);
+		when(chatFilterConfig.filteredWords()).thenReturn("hello osrs");
+
+		chatFilterPlugin.updateFilteredPatterns();
+		assertNull(chatFilterPlugin.censorMessage("hello\u00A0osrs"));
+	}
+
+	@Test
 	public void testMessageFromFriendIsFiltered()
 	{
 		when(client.isFriended("Iron Mammal", false)).thenReturn(true);


### PR DESCRIPTION
Fixes #8545 

The chat history plugin replaces spaces with NBSPs (`\u00A0`) when it replays historical messages so that the chat commands and chat notifications plugins don't trigger on these messages. The problematic line of code in the chat filter plugin removes all characters that cannot be displayed in the chatbox, *including the NBSP*, via the `jagexPrintableCharMatcher.retainFrom` call. This results in a historical message of `hello world` turning into `helloworld` before being checked for matching filter patterns, because the space gets converted into an NBSP by the chat history plugin, and this NBSP is then removed by the chat filter plugin.

I've added NBSP to the list of characters that JagexPrintableCharMatcher matches so that multi-word historical messages keep their spaces after passing through the chat history plugin and subsequently the chat filter plugin.