### PR TITLE
skybox: Add the ability to customize skybox hue in the overworld

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/skybox/SkyboxConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/skybox/SkyboxConfig.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2019, Adam Witkowski <https://github.com/adwitkow>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.skybox;
+
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+
+import java.awt.Color;
+
+@ConfigGroup("skybox")
+public interface SkyboxConfig extends Config
+{
+	@ConfigItem(
+		keyName = "overrideSkyboxHue",
+		name = "Override overworld color",
+		description = "Configures the dynamic color of the skybox to be overridden by static hue"
+	)
+	default boolean overrideSkyboxHue()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		keyName = "skyboxHue",
+		name = "Skybox color",
+		description = "Configures the hue of skybox"
+	)
+	default Color skyboxHue()
+	{
+		return Color.BLACK;
+	}
+}

--- a/runelite-client/src/test/java/net/runelite/client/plugins/skybox/SkyboxTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/skybox/SkyboxTest.java
@@ -30,28 +30,35 @@ import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
 import javax.imageio.ImageIO;
+import com.google.inject.testing.fieldbinder.Bind;
 import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.coords.WorldPoint;
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.Mock;
 
 @Slf4j
 public class SkyboxTest
 {
+	@Mock
+	@Bind
+	private SkyboxConfig config;
+
 	@Test
 	public void testLoadSimple() throws IOException
 	{
-		Skybox skybox = new Skybox(CharSource.wrap("bounds 0 0 100 100 #00F // R 0 0 100 100\r\nr 99 99").openStream(), "simple");
-		Assert.assertEquals(0, skybox.getColorForPoint(0, 0, 0, 0, 0, 1, null));
+		Skybox skybox = new Skybox(CharSource.wrap("bounds 0 0 100 100 #00F // R 0 0 100 100\r\nr 99 99").openStream(), "simple", config);
+		Assert.assertEquals(0, skybox.getColorForPoint(0, 0, 0, 0, 0, WorldPoint.fromRegion(0, 0, 0, 0), 1, null));
 		int x = (99 * 64) + 32;
 		int y = (99 * 64) + 32;
-		Assert.assertEquals(0x0000FF, skybox.getColorForPoint(x, y, x, y, 0, 1, null));
+		Assert.assertEquals(0x0000FF, skybox.getColorForPoint(x, y, x, y, 0, WorldPoint.fromRegion(0, 0, 0, 0), 1, null));
 	}
 
 	@Test
 	public void testLoadActual() throws IOException
 	{
 		long start = System.nanoTime();
-		Skybox skybox = new Skybox(SkyboxPlugin.class.getResourceAsStream("skybox.txt"), "skybox.txt");
+		Skybox skybox = new Skybox(SkyboxPlugin.class.getResourceAsStream("skybox.txt"), "skybox.txt", config);
 		log.info("Parse took {}ms", (System.nanoTime() - start) / 1_000_000);
 
 		String skyboxFile = System.getProperty("skyboxExport");
@@ -65,6 +72,6 @@ public class SkyboxTest
 			ImageIO.write(img, "png", new File(skyboxFile));
 		}
 
-		Assert.assertNotEquals(skybox.getColorForPoint(3232, 3232, 3232, 3232, 0, .9, null), 0); // Lumbridge will never be black
+		Assert.assertNotEquals(skybox.getColorForPoint(3232, 3232, 3232, 3232, 0, WorldPoint.fromRegion(0, 0, 0, 0), .9, null), 0); // Lumbridge will never be black
 	}
 }


### PR DESCRIPTION
Closes #9159, though I am not happy with how this solution currently looks and I'm very open to suggestions on what can be improved.

The config color changes only the hue of the calculated skybox, so that the darker regions will always have lower brightness, e.g. Ver Sinhaza will always have a deeper color than most regions. It also applies only to overworld regions, so that dungeons and things like that will use the original calculated skybox - at least I hope that I didn't catch anything in a crossfire, considering the fact that the overworld map is a bit jagged and not rectangular.

![story](https://user-images.githubusercontent.com/10108473/61816432-a45fcc80-ae4c-11e9-9aa1-1fba891b9000.gif)

