### PR TITLE
Fix overlay when smelting cannonballs

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/smelting/SmeltingOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/smelting/SmeltingOverlay.java
@@ -46,7 +46,7 @@ import net.runelite.client.ui.overlay.components.TitleComponent;
 
 class SmeltingOverlay extends Overlay
 {
-	private static final int SMELT_TIMEOUT = 5;
+	private static final int SMELT_TIMEOUT = 7;
 
 	private final Client client;
 	private final SmeltingPlugin plugin;


### PR DESCRIPTION
Smelting cannonballs takes 10 ticks per bar so the current delay was simply too short. 

Closes #9418