### PR TITLE
Fix wrong rock respawn timers

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/mining/MiningPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/mining/MiningPlugin.java
@@ -62,7 +62,6 @@ import net.runelite.client.ui.overlay.OverlayManager;
 public class MiningPlugin extends Plugin
 {
 	private static final int ROCK_DISTANCE = 14;
-	private static final int MINING_GUILD_REGION = 12183;
 
 	@Inject
 	private Client client;
@@ -123,11 +122,12 @@ public class MiningPlugin extends Plugin
 		}
 
 		final GameObject object = event.getGameObject();
+		final int region = client.getLocalPlayer().getWorldLocation().getRegionID();
 
 		Rock rock = Rock.getRock(object.getId());
 		if (rock != null)
 		{
-			RockRespawn rockRespawn = new RockRespawn(rock, object.getWorldLocation(), Instant.now(), (int) rock.getRespawnTime(inMiningGuild()).toMillis(), rock.getZOffset());
+			RockRespawn rockRespawn = new RockRespawn(rock, object.getWorldLocation(), Instant.now(), (int) rock.getRespawnTime(region).toMillis(), rock.getZOffset());
 			respawns.add(rockRespawn);
 		}
 	}
@@ -141,13 +141,14 @@ public class MiningPlugin extends Plugin
 		}
 
 		final WallObject object = event.getWallObject();
+		final int region = client.getLocalPlayer().getWorldLocation().getRegionID();
 
 		switch (object.getId())
 		{
 			case EMPTY_WALL:
 			{
 				Rock rock = Rock.AMETHYST;
-				RockRespawn rockRespawn = new RockRespawn(rock, object.getWorldLocation(), Instant.now(), (int) rock.getRespawnTime(inMiningGuild()).toMillis(), rock.getZOffset());
+				RockRespawn rockRespawn = new RockRespawn(rock, object.getWorldLocation(), Instant.now(), (int) rock.getRespawnTime(region).toMillis(), rock.getZOffset());
 				respawns.add(rockRespawn);
 				break;
 			}
@@ -157,7 +158,7 @@ public class MiningPlugin extends Plugin
 			case DEPLETED_VEIN_26668: // Depleted motherlode vein
 			{
 				Rock rock = Rock.ORE_VEIN;
-				RockRespawn rockRespawn = new RockRespawn(rock, object.getWorldLocation(), Instant.now(), (int) rock.getRespawnTime(inMiningGuild()).toMillis(), rock.getZOffset());
+				RockRespawn rockRespawn = new RockRespawn(rock, object.getWorldLocation(), Instant.now(), (int) rock.getRespawnTime(region).toMillis(), rock.getZOffset());
 				respawns.add(rockRespawn);
 				break;
 			}
@@ -172,10 +173,5 @@ public class MiningPlugin extends Plugin
 				break;
 			}
 		}
-	}
-
-	private boolean inMiningGuild()
-	{
-		return client.getLocalPlayer().getWorldLocation().getRegionID() == MINING_GUILD_REGION;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/mining/Rock.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/mining/Rock.java
@@ -29,36 +29,7 @@ import java.time.Duration;
 import java.util.Map;
 import lombok.AccessLevel;
 import lombok.Getter;
-import static net.runelite.api.ObjectID.ASH_PILE;
-import static net.runelite.api.ObjectID.ROCKS_10943;
-import static net.runelite.api.ObjectID.ROCKS_11161;
-import static net.runelite.api.ObjectID.ROCKS_11360;
-import static net.runelite.api.ObjectID.ROCKS_11361;
-import static net.runelite.api.ObjectID.ROCKS_11364;
-import static net.runelite.api.ObjectID.ROCKS_11365;
-import static net.runelite.api.ObjectID.ROCKS_11366;
-import static net.runelite.api.ObjectID.ROCKS_11367;
-import static net.runelite.api.ObjectID.ROCKS_11368;
-import static net.runelite.api.ObjectID.ROCKS_11369;
-import static net.runelite.api.ObjectID.ROCKS_11370;
-import static net.runelite.api.ObjectID.ROCKS_11371;
-import static net.runelite.api.ObjectID.ROCKS_11372;
-import static net.runelite.api.ObjectID.ROCKS_11373;
-import static net.runelite.api.ObjectID.ROCKS_11374;
-import static net.runelite.api.ObjectID.ROCKS_11375;
-import static net.runelite.api.ObjectID.ROCKS_11376;
-import static net.runelite.api.ObjectID.ROCKS_11377;
-import static net.runelite.api.ObjectID.ROCKS_11380;
-import static net.runelite.api.ObjectID.ROCKS_11381;
-import static net.runelite.api.ObjectID.ROCKS_11386;
-import static net.runelite.api.ObjectID.ROCKS_11387;
-import static net.runelite.api.ObjectID.ROCKS_36203;
-import static net.runelite.api.ObjectID.ROCKS_36204;
-import static net.runelite.api.ObjectID.ROCKS_36205;
-import static net.runelite.api.ObjectID.ROCKS_36206;
-import static net.runelite.api.ObjectID.ROCKS_36207;
-import static net.runelite.api.ObjectID.ROCKS_36208;
-import static net.runelite.api.ObjectID.ROCKS_36209;
+import static net.runelite.api.ObjectID.*;
 
 enum Rock
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/mining/Rock.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/mining/Rock.java
@@ -29,7 +29,36 @@ import java.time.Duration;
 import java.util.Map;
 import lombok.AccessLevel;
 import lombok.Getter;
-import static net.runelite.api.ObjectID.*;
+import static net.runelite.api.ObjectID.ASH_PILE;
+import static net.runelite.api.ObjectID.ROCKS_10943;
+import static net.runelite.api.ObjectID.ROCKS_11161;
+import static net.runelite.api.ObjectID.ROCKS_11360;
+import static net.runelite.api.ObjectID.ROCKS_11361;
+import static net.runelite.api.ObjectID.ROCKS_11364;
+import static net.runelite.api.ObjectID.ROCKS_11365;
+import static net.runelite.api.ObjectID.ROCKS_11366;
+import static net.runelite.api.ObjectID.ROCKS_11367;
+import static net.runelite.api.ObjectID.ROCKS_11368;
+import static net.runelite.api.ObjectID.ROCKS_11369;
+import static net.runelite.api.ObjectID.ROCKS_11370;
+import static net.runelite.api.ObjectID.ROCKS_11371;
+import static net.runelite.api.ObjectID.ROCKS_11372;
+import static net.runelite.api.ObjectID.ROCKS_11373;
+import static net.runelite.api.ObjectID.ROCKS_11374;
+import static net.runelite.api.ObjectID.ROCKS_11375;
+import static net.runelite.api.ObjectID.ROCKS_11376;
+import static net.runelite.api.ObjectID.ROCKS_11377;
+import static net.runelite.api.ObjectID.ROCKS_11380;
+import static net.runelite.api.ObjectID.ROCKS_11381;
+import static net.runelite.api.ObjectID.ROCKS_11386;
+import static net.runelite.api.ObjectID.ROCKS_11387;
+import static net.runelite.api.ObjectID.ROCKS_36203;
+import static net.runelite.api.ObjectID.ROCKS_36204;
+import static net.runelite.api.ObjectID.ROCKS_36205;
+import static net.runelite.api.ObjectID.ROCKS_36206;
+import static net.runelite.api.ObjectID.ROCKS_36207;
+import static net.runelite.api.ObjectID.ROCKS_36208;
+import static net.runelite.api.ObjectID.ROCKS_36209;
 
 enum Rock
 {
@@ -38,17 +67,25 @@ enum Rock
 	IRON(Duration.ofMillis(5400), 0, ROCKS_11364, ROCKS_11365, ROCKS_36203)
 		{
 			@Override
-			Duration getRespawnTime(boolean inMiningGuild)
+			Duration getRespawnTime(int region)
 			{
-				return inMiningGuild ? Duration.ofMillis(2400) : super.respawnTime;
+				return region == MINING_GUILD ? Duration.ofMillis(2400) : super.respawnTime;
 			}
 		},
 	COAL(Duration.ofMillis(29400), 0, ROCKS_11366, ROCKS_11367, ROCKS_36204)
 		{
 			@Override
-			Duration getRespawnTime(boolean inMiningGuild)
+			Duration getRespawnTime(int region)
 			{
-				return inMiningGuild ? Duration.ofMillis(14400) : super.respawnTime;
+				switch (region)
+				{
+					case MINING_GUILD:
+						return Duration.ofMillis(14400);
+					case MISCELLANIA:
+						return Duration.ofMillis(6600);
+					default:
+						return super.respawnTime;
+				}
 			}
 		},
 	SILVER(Duration.ofMinutes(1), 0, ROCKS_11368, ROCKS_11369, ROCKS_36205),
@@ -58,25 +95,25 @@ enum Rock
 	MITHRIL(Duration.ofMinutes(2), 0, ROCKS_11372, ROCKS_11373, ROCKS_36207)
 		{
 			@Override
-			Duration getRespawnTime(boolean inMiningGuild)
+			Duration getRespawnTime(int region)
 			{
-				return inMiningGuild ? Duration.ofMinutes(1) : super.respawnTime;
+				return region == MINING_GUILD ? Duration.ofMinutes(1) : super.respawnTime;
 			}
 		},
 	ADAMANTITE(Duration.ofMinutes(4), 0, ROCKS_11374, ROCKS_11375, ROCKS_36208)
 		{
 			@Override
-			Duration getRespawnTime(boolean inMiningGuild)
+			Duration getRespawnTime(int region)
 			{
-				return inMiningGuild ? Duration.ofMinutes(2) : super.respawnTime;
+				return region == MINING_GUILD || region == WILDERNESS_RESOURCE_AREA ? Duration.ofMinutes(2) : super.respawnTime;
 			}
 		},
 	RUNITE(Duration.ofMinutes(12), 0, ROCKS_11376, ROCKS_11377, ROCKS_36209)
 		{
 			@Override
-			Duration getRespawnTime(boolean inMiningGuild)
+			Duration getRespawnTime(int region)
 			{
-				return inMiningGuild ? Duration.ofMinutes(6) : super.respawnTime;
+				return region == MINING_GUILD ? Duration.ofMinutes(6) : super.respawnTime;
 			}
 		},
 	ORE_VEIN(Duration.ofSeconds(MiningOverlay.ORE_VEIN_MAX_RESPAWN_TIME), 150),
@@ -84,6 +121,9 @@ enum Rock
 	ASH_VEIN(Duration.ofSeconds(30), 0, ASH_PILE),
 	GEM_ROCK(Duration.ofMinutes(1), 0, ROCKS_11380, ROCKS_11381);
 
+	private static final int WILDERNESS_RESOURCE_AREA = 12605;
+	private static final int MISCELLANIA = 10044;
+	private static final int MINING_GUILD = 12183;
 	private static final Map<Integer, Rock> ROCKS;
 
 	static
@@ -111,7 +151,7 @@ enum Rock
 		this.ids = ids;
 	}
 
-	Duration getRespawnTime(boolean inMiningGuild)
+	Duration getRespawnTime(int region)
 	{
 		return respawnTime;
 	}


### PR DESCRIPTION
Fix respawn timers for
 - Adamant rocks in Wilderness Resource area
 - Coal rocks in Miscellania
The doubled respawn rate of the adamant rocks is a possible Jagex bug as
they are the only type of rock within the Wilderness resource area to do so.
The coal rocks in Miscellania are mined for favour instead of ores
and therefore have a shortened respawn time.

Closes #9442, #9452  