### PR TITLE
Fix examine coins extra line

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/examine/ExaminePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/examine/ExaminePlugin.java
@@ -37,6 +37,7 @@ import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
 import net.runelite.api.Constants;
 import net.runelite.api.ItemComposition;
+import net.runelite.api.ItemID;
 import net.runelite.api.events.ChatMessage;
 import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.MenuOptionClicked;
@@ -201,6 +202,12 @@ public class ExaminePlugin extends Plugin
 		{
 			final int itemId = pendingExamine.getId();
 			final int itemQuantity = pendingExamine.getQuantity();
+
+			if (itemId == ItemID.COINS_995)
+			{
+				return;
+			}
+
 			itemComposition = itemManager.getItemComposition(itemId);
 
 			if (itemComposition != null)


### PR DESCRIPTION
Removed the GE and HA price message when examining coins since it's redundant information.
![coins_correct](https://user-images.githubusercontent.com/25151927/61996712-ad90a980-b097-11e9-86ca-00a23c1283d0.png)

Closes #9483 