### PR TITLE
Swap pickpocket with talk-to on any NPC

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -194,8 +194,8 @@ public interface MenuEntrySwapperConfig extends Config
 
 	@ConfigItem(
 		keyName = "swapPickpocket",
-		name = "Pickpocket on H.A.M.",
-		description = "Swap Talk-to with Pickpocket on H.A.M members"
+		name = "Pickpocket",
+		description = "Swap Talk-to with Pickpocket on NPC<br>Example: H.A.M. members, Elves"
 	)
 	default boolean swapPickpocket()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -373,7 +373,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 
 		if (option.equals("talk-to"))
 		{
-			if (config.swapPickpocket() && target.contains("h.a.m."))
+			if (config.swapPickpocket())
 			{
 				swap("pickpocket", option, target, true);
 			}


### PR DESCRIPTION
Due to the recent addition to the pickpocket table of Elves (crystal shards + eternal teleport crystal), I felt there might be a need for a left-click pickpocket option, much like H.A.M. members. 
Because of the similarity, I renamed "Pickpocket on H.A.M." to simply "Pickpocket" and modified the behavior to function on any NPC, rather than H.A.M. members alone.