### PR TITLE
grandexchangeplugin: bug-fix where total amount is not updated properly.

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangePlugin.java
@@ -261,6 +261,8 @@ public class GrandExchangePlugin extends Plugin
 					keyManager.unregisterKeyListener(inputListener);
 				}
 			}
+
+			updateTopText(); //add others in need of change
 		}
 	}
 
@@ -437,13 +439,18 @@ public class GrandExchangePlugin extends Plugin
 			return;
 		}
 
+		updateTopText();
+	}
+
+	private void updateTopText()
+	{
 		long total = 0;
 		GrandExchangeOffer[] offers = client.getGrandExchangeOffers();
 		for (GrandExchangeOffer offer : offers)
 		{
 			if (offer != null)
 			{
-				total += offer.getPrice() * offer.getTotalQuantity();
+				total += offer.getPrice() * (offer.getTotalQuantity() - offer.getQuantitySold());
 			}
 		}
 
@@ -471,7 +478,6 @@ public class GrandExchangePlugin extends Plugin
 
 		stringStack[stringStackSize - 1] += titleBuilder.toString();
 	}
-
 	@Subscribe
 	public void onGameTick(GameTick event)
 	{


### PR DESCRIPTION
Additional small bug-fix to toggle total value on toggling plugin on/off.

25.000 coins through remainder of purchase and 39 of selling a single rune.
![Screenshot 2019-07-28 at 18 34 13](https://user-images.githubusercontent.com/26043130/62010131-eea3bf00-b166-11e9-8f03-2f983ef7b2fe.png)

Remainder of purchase (100k worth of runes extracted)
![Screenshot 2019-07-28 at 18 33 37](https://user-images.githubusercontent.com/26043130/62010132-f2cfdc80-b166-11e9-970c-2f1aca37646c.png)

Does not take completed offers into account
![Screenshot 2019-07-28 at 18 41 52](https://user-images.githubusercontent.com/26043130/62010155-5fe37200-b167-11e9-95fc-f9319b199b6b.png)

fixes #9310