### PR TITLE
customcursor: option for a larger version for resolutions above 1600x900.

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/customcursor/CustomCursorConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/customcursor/CustomCursorConfig.java
@@ -32,6 +32,7 @@ import net.runelite.client.config.ConfigItem;
 public interface CustomCursorConfig extends Config
 {
 	@ConfigItem(
+		position = 0,
 		keyName = "cursorStyle",
 		name = "Cursor",
 		description = "Select which cursor you wish to use"
@@ -39,5 +40,16 @@ public interface CustomCursorConfig extends Config
 	default CustomCursor selectedCursor()
 	{
 		return CustomCursor.RS3_GOLD;
+	}
+
+	@ConfigItem(
+			position = 1,
+			keyName = "bigScreenStyle",
+			name = "Big screen mode",
+			description = "Enlarges the cursor when having a screen resolution of 1920x1080 or above."
+	)
+	default boolean bigScreenMode()
+	{
+		return false;
 	}
 }


### PR DESCRIPTION
Option to toggle a larger version of the custom cursors.
Doubles in size for resolutions larger than 1600x900.
(ignore color)

Before:
![Untitled 2](https://user-images.githubusercontent.com/26043130/62045386-82c46380-b205-11e9-91e0-0fca939d9ccc.png)

After:
![Untitled](https://user-images.githubusercontent.com/26043130/62045385-822bcd00-b205-11e9-8f23-6ffa6e79e957.png)