### PR TITLE
menuentryswapper - Add volcanic mine entrance

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -552,6 +552,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 		else if (config.swapQuick() && option.equals("climb-down"))
 		{
 			swap("quick-start", option, target, true);
+			swap("pay", option, target, true);
 		}
 		else if (config.swapAdmire() && option.equals("admire"))
 		{


### PR DESCRIPTION
Text is based on the game update blog post. I believe this is correct but cant test until update is live.

![https://cdn.runescape.com/assets/img/external/oldschool/2019/newsposts/2019-08-01/volcanic%20mine.PNG](https://cdn.runescape.com/assets/img/external/oldschool/2019/newsposts/2019-08-01/volcanic%20mine.PNG)