### PR TITLE
gpu plugin: fix camera effects used for drunkeness and fishing trawler

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuPlugin.java
@@ -207,6 +207,8 @@ public class GpuPlugin extends Plugin implements DrawCallbacks
 
 	private int centerX;
 	private int centerY;
+	private int yaw;
+	private int pitch;
 
 	// Uniforms
 	private int uniUseFog;
@@ -719,6 +721,8 @@ public class GpuPlugin extends Plugin implements DrawCallbacks
 	{
 		centerX = client.getCenterX();
 		centerY = client.getCenterY();
+		yaw = client.getCameraYaw();
+		pitch = client.getCameraPitch();
 
 		final Scene scene = client.getScene();
 		final int drawDistance = Math.max(0, Math.min(MAX_DISTANCE, config.drawDistance()));
@@ -911,8 +915,8 @@ public class GpuPlugin extends Plugin implements DrawCallbacks
 		gl.glBindBuffer(gl.GL_UNIFORM_BUFFER, uniformBufferId);
 		uniformBuffer.clear();
 		uniformBuffer
-			.put(client.getCameraYaw())
-			.put(client.getCameraPitch())
+			.put(yaw)
+			.put(pitch)
 			.put(centerX)
 			.put(centerY)
 			.put(client.getScale())


### PR DESCRIPTION
Yaw and pitch for these effects is only altered during scene drawing, so we need to cache those values at that point.

Closes #7585