### PR TITLE
Change the loottracker hide feature to be less overzealous

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
@@ -573,7 +573,7 @@ public class LootTrackerPlugin extends Plugin
 
 	boolean isIgnored(String name)
 	{
-		return ignoredItems.contains(name);
+		return ignoredItems.equals(name);
 	}
 
 	private LootTrackerItem buildLootTrackerItem(int itemId, int quantity)


### PR DESCRIPTION
Per #8631, the Loot Tracker plugin would hide items based off of substrings. Fixed to do an exact comparison.