### PR TITLE
Add Config Sections

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/config/ChatColorConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/ChatColorConfig.java
@@ -30,19 +30,37 @@ import net.runelite.client.ui.JagexColors;
 @ConfigGroup("textrecolor")
 public interface ChatColorConfig extends Config
 {
+	@ConfigSection(
+		name = "Opaque",
+		description = "The options that control the colours for the Opaque Chatbox",
+		position = 0,
+		closedByDefault = true
+	)
+	String opaqueSection = "opaqueSection";
+
+	@ConfigSection(
+		name = "Transparent",
+		description = "The options that control the colours for the Transparent Chatbox",
+		position = 50,
+		closedByDefault = true
+	)
+	String transparentSection = "transparentSection";
+
 	@ConfigItem(
-		position = 31,
+		position = 1,
 		keyName = "opaquePublicChat",
 		name = "Public chat",
-		description = "Color of Public chat"
+		description = "Color of Public chat",
+		section = opaqueSection
 	)
 	Color opaquePublicChat();
 
 	@ConfigItem(
-		position = 32,
+		position = 2,
 		keyName = "opaquePublicChatHighlight",
 		name = "Public chat highlight",
-		description = "Color of highlights in Public chat"
+		description = "Color of highlights in Public chat",
+		section = opaqueSection
 	)
 	default Color opaquePublicChatHighlight()
 	{
@@ -50,18 +68,20 @@ public interface ChatColorConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 33,
+		position = 3,
 		keyName = "opaquePrivateMessageSent",
 		name = "Sent private messages",
-		description = "Color of Private messages you've sent"
+		description = "Color of Private messages you've sent",
+		section = opaqueSection
 	)
 	Color opaquePrivateMessageSent();
 
 	@ConfigItem(
-		position = 34,
+		position = 4,
 		keyName = "opaquePrivateMessageSentHighlight",
 		name = "Sent private messages highlight",
-		description = "Color of highlights in Private messages you've sent"
+		description = "Color of highlights in Private messages you've sent",
+		section = opaqueSection
 	)
 	default Color opaquePrivateMessageSentHighlight()
 	{
@@ -69,18 +89,20 @@ public interface ChatColorConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 35,
+		position = 5,
 		keyName = "opaquePrivateMessageReceived",
 		name = "Received private messages",
-		description = "Color of Private messages you've received"
+		description = "Color of Private messages you've received",
+		section = opaqueSection
 	)
 	Color opaquePrivateMessageReceived();
 
 	@ConfigItem(
-		position = 36,
+		position = 6,
 		keyName = "opaquePrivateMessageReceivedHighlight",
 		name = "Received private messages highlight",
-		description = "Color of highlights in Private messages you've received"
+		description = "Color of highlights in Private messages you've received",
+		section = opaqueSection
 	)
 	default Color opaquePrivateMessageReceivedHighlight()
 	{
@@ -88,10 +110,11 @@ public interface ChatColorConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 37,
+		position = 7,
 		keyName = "opaqueClanChatInfo",
 		name = "Clan chat info",
-		description = "Clan Chat Information (eg. when joining a channel)"
+		description = "Clan Chat Information (eg. when joining a channel)",
+		section = opaqueSection
 	)
 	default Color opaqueClanChatInfo()
 	{
@@ -99,10 +122,11 @@ public interface ChatColorConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 38,
+		position = 8,
 		keyName = "opaqueClanChatInfoHighlight",
 		name = "Clan chat info highlight",
-		description = "Clan Chat Information highlight (used for the Raids plugin)"
+		description = "Clan Chat Information highlight (used for the Raids plugin)",
+		section = opaqueSection
 	)
 	default Color opaqueClanChatInfoHighlight()
 	{
@@ -110,18 +134,20 @@ public interface ChatColorConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 39,
+		position = 9,
 		keyName = "opaqueClanChatMessage",
 		name = "Clan chat message",
-		description = "Color of Clan Chat Messages"
+		description = "Color of Clan Chat Messages",
+		section = opaqueSection
 	)
 	Color opaqueClanChatMessage();
 
 	@ConfigItem(
-		position = 40,
+		position = 10,
 		keyName = "opaqueClanChatMessageHighlight",
 		name = "Clan chat message highlight",
-		description = "Color of highlights in Clan Chat Messages"
+		description = "Color of highlights in Clan Chat Messages",
+		section = opaqueSection
 	)
 	default Color opaqueClanChatMessageHighlight()
 	{
@@ -129,66 +155,74 @@ public interface ChatColorConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 41,
+		position = 11,
 		keyName = "opaqueAutochatMessage",
 		name = "Autochat",
-		description = "Color of Autochat messages"
+		description = "Color of Autochat messages",
+		section = opaqueSection
 	)
 	Color opaqueAutochatMessage();
 
 	@ConfigItem(
-		position = 42,
+		position = 12,
 		keyName = "opaqueAutochatMessageHighlight",
 		name = "Autochat highlight",
-		description = "Color of highlights in Autochat messages"
+		description = "Color of highlights in Autochat messages",
+		section = opaqueSection
 	)
 	Color opaqueAutochatMessageHighlight();
 
 	@ConfigItem(
-		position = 43,
+		position = 13,
 		keyName = "opaqueTradeChatMessage",
 		name = "Trade chat",
-		description = "Color of Trade Chat Messages"
+		description = "Color of Trade Chat Messages",
+		section = opaqueSection
 	)
 	Color opaqueTradeChatMessage();
 
 	@ConfigItem(
-		position = 44,
+		position = 14,
 		keyName = "opaqueTradeChatMessageHighlight",
 		name = "Trade chat highlight",
-		description = "Color of highlights in Trade Chat Messages"
+		description = "Color of highlights in Trade Chat Messages",
+		section = opaqueSection
 	)
 	Color opaqueTradeChatMessageHighlight();
 
 	@ConfigItem(
-		position = 45,
+		position = 15,
 		keyName = "opaqueServerMessage",
 		name = "Server message",
-		description = "Color of Server Messages (eg. 'Welcome to RuneScape')"
+		description = "Color of Server Messages (eg. 'Welcome to RuneScape')",
+		section = opaqueSection
 	)
 	Color opaqueServerMessage();
 
 	@ConfigItem(
-		position = 46,
+		position = 16,
 		keyName = "opaqueServerMessageHighlight",
 		name = "Server message highlight",
-		description = "Color of highlights in Server Messages"
+		description = "Color of highlights in Server Messages",
+		section = opaqueSection
 	)
 	Color opaqueServerMessageHighlight();
 
 	@ConfigItem(
-		position = 47,
+		position = 17,
 		keyName = "opaqueGameMessage",
 		name = "Game message",
-		description = "Color of Game Messages"
+		description = "Color of Game Messages",
+		section = opaqueSection
 	)
 	Color opaqueGameMessage();
 
 	@ConfigItem(
-		position = 48,
+		position = 18,
 		keyName = "opaqueGameMessageHighlight",
 		name = "Game message highlight",
-		description = "Color of highlights in Game Messages"
+		description = "Color of highlights in Game Messages",
+		section = opaqueSection
 	)
 	default Color opaqueGameMessageHighlight()
 	{
@@ -196,18 +230,20 @@ public interface ChatColorConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 49,
+		position = 19,
 		keyName = "opaqueExamine",
 		name = "Examine",
-		description = "Color of Examine Text"
+		description = "Color of Examine Text",
+		section = opaqueSection
 	)
 	Color opaqueExamine();
 
 	@ConfigItem(
-		position = 50,
+		position = 20,
 		keyName = "opaqueExamineHighlight",
 		name = "Examine highlight",
-		description = "Color of highlights in Examine Text"
+		description = "Color of highlights in Examine Text",
+		section = opaqueSection
 	)
 	default Color opaqueExamineHighlight()
 	{
@@ -215,74 +251,83 @@ public interface ChatColorConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 51,
+		position = 21,
 		keyName = "opaqueFiltered",
 		name = "Filtered",
-		description = "Color of Filtered Text (messages that aren't shown when Game messages are filtered)"
+		description = "Color of Filtered Text (messages that aren't shown when Game messages are filtered)",
+		section = opaqueSection
 	)
 	Color opaqueFiltered();
 
 	@ConfigItem(
-		position = 52,
+		position = 22,
 		keyName = "opaqueFilteredHighlight",
 		name = "Filtered highlight",
-		description = "Color of highlights in Filtered Text"
+		description = "Color of highlights in Filtered Text",
+		section = opaqueSection
 	)
 	Color opaqueFilteredHighlight();
 
 	@ConfigItem(
-		position = 53,
+		position = 23,
 		keyName = "opaqueUsername",
 		name = "Usernames",
-		description = "Color of Usernames"
+		description = "Color of Usernames",
+		section = opaqueSection
 	)
 	Color opaqueUsername();
 
 	@ConfigItem(
-		position = 54,
+		position = 24,
 		keyName = "opaquePrivateUsernames",
 		name = "Private chat usernames",
-		description = "Color of Usernames in Private Chat"
+		description = "Color of Usernames in Private Chat",
+		section = opaqueSection
 	)
 	Color opaquePrivateUsernames();
 
 	@ConfigItem(
-		position = 55,
+		position = 25,
 		keyName = "opaqueClanChannelName",
 		name = "Clan channel name",
-		description = "Color of Clan Channel Name"
+		description = "Color of Clan Channel Name",
+		section = opaqueSection
 	)
 	Color opaqueClanChannelName();
 
 	@ConfigItem(
-		position = 56,
+		position = 26,
 		keyName = "opaqueClanUsernames",
 		name = "Clan usernames",
-		description = "Color of Usernames in Clan Chat"
+		description = "Color of Usernames in Clan Chat",
+		section = opaqueSection
 	)
 	Color opaqueClanUsernames();
 
 	@ConfigItem(
-		position = 57,
+		position = 27,
 		keyName = "opaquePublicFriendUsernames",
 		name = "Public friend usernames",
-		description = "Color of Friend Usernames in Public Chat"
+		description = "Color of Friend Usernames in Public Chat",
+		section = opaqueSection
 	)
 	Color opaquePublicFriendUsernames();
 
 	@ConfigItem(
-		position = 61,
+		position = 51,
 		keyName = "transparentPublicChat",
 		name = "Public chat (transparent)",
-		description = "Color of Public chat (transparent)"
+		description = "Color of Public chat (transparent)",
+		section = transparentSection
 	)
 	Color transparentPublicChat();
 
 	@ConfigItem(
-		position = 62,
+		position = 52,
 		keyName = "transparentPublicChatHighlight",
 		name = "Public chat highlight (transparent)",
-		description = "Color of highlights in Public chat (transparent)"
+		description = "Color of highlights in Public chat (transparent)",
+		section = transparentSection
 	)
 	default Color transparentPublicChatHighlight()
 	{
@@ -290,18 +335,20 @@ public interface ChatColorConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 63,
+		position = 53,
 		keyName = "transparentPrivateMessageSent",
 		name = "Sent private messages (transparent)",
-		description = "Color of Private messages you've sent (transparent)"
+		description = "Color of Private messages you've sent (transparent)",
+		section = transparentSection
 	)
 	Color transparentPrivateMessageSent();
 
 	@ConfigItem(
-		position = 64,
+		position = 54,
 		keyName = "transparentPrivateMessageSentHighlight",
 		name = "Sent private messages highlight (transparent)",
-		description = "Color of highlights in Private messages you've sent (transparent)"
+		description = "Color of highlights in Private messages you've sent (transparent)",
+		section = transparentSection
 	)
 	default Color transparentPrivateMessageSentHighlight()
 	{
@@ -309,18 +356,20 @@ public interface ChatColorConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 65,
+		position = 55,
 		keyName = "transparentPrivateMessageReceived",
 		name = "Received private messages (transparent)",
-		description = "Color of Private messages you've received (transparent)"
+		description = "Color of Private messages you've received (transparent)",
+		section = transparentSection
 	)
 	Color transparentPrivateMessageReceived();
 
 	@ConfigItem(
-		position = 66,
+		position = 56,
 		keyName = "transparentPrivateMessageReceivedHighlight",
 		name = "Received private messages highlight (transparent)",
-		description = "Color of highlights in Private messages you've received (transparent)"
+		description = "Color of highlights in Private messages you've received (transparent)",
+		section = transparentSection
 	)
 	default Color transparentPrivateMessageReceivedHighlight()
 	{
@@ -328,10 +377,11 @@ public interface ChatColorConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 67,
+		position = 57,
 		keyName = "transparentClanChatInfo",
 		name = "Clan chat info (transparent)",
-		description = "Clan Chat Information (eg. when joining a channel) (transparent)"
+		description = "Clan Chat Information (eg. when joining a channel) (transparent)",
+		section = transparentSection
 	)
 	default Color transparentClanChatInfo()
 	{
@@ -339,10 +389,11 @@ public interface ChatColorConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 68,
+		position = 58,
 		keyName = "transparentClanChatInfoHighlight",
 		name = "Clan chat info highlight (transparent)",
-		description = "Clan Chat Information highlight (used for the Raids plugin) (transparent)"
+		description = "Clan Chat Information highlight (used for the Raids plugin) (transparent)",
+		section = transparentSection
 	)
 	default Color transparentClanChatInfoHighlight()
 	{
@@ -350,18 +401,20 @@ public interface ChatColorConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 69,
+		position = 59,
 		keyName = "transparentClanChatMessage",
 		name = "Clan chat message (transparent)",
-		description = "Color of Clan Chat Messages (transparent)"
+		description = "Color of Clan Chat Messages (transparent)",
+		section = transparentSection
 	)
 	Color transparentClanChatMessage();
 
 	@ConfigItem(
-		position = 70,
+		position = 60,
 		keyName = "transparentClanChatMessageHighlight",
 		name = "Clan chat message highlight (transparent)",
-		description = "Color of highlights in Clan Chat Messages (transparent)"
+		description = "Color of highlights in Clan Chat Messages (transparent)",
+		section = transparentSection
 	)
 	default Color transparentClanChatMessageHighlight()
 	{
@@ -369,66 +422,74 @@ public interface ChatColorConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 71,
+		position = 61,
 		keyName = "transparentAutochatMessage",
 		name = "Autochat (transparent)",
-		description = "Color of Autochat messages (transparent)"
+		description = "Color of Autochat messages (transparent)",
+		section = transparentSection
 	)
 	Color transparentAutochatMessage();
 
 	@ConfigItem(
-		position = 72,
+		position = 62,
 		keyName = "transparentAutochatMessageHighlight",
 		name = "Autochat highlight (transparent)",
-		description = "Color of highlights in Autochat messages (transparent)"
+		description = "Color of highlights in Autochat messages (transparent)",
+		section = transparentSection
 	)
 	Color transparentAutochatMessageHighlight();
 
 	@ConfigItem(
-		position = 73,
+		position = 63,
 		keyName = "transparentTradeChatMessage",
 		name = "Trade chat (transparent)",
-		description = "Color of Trade Chat Messages (transparent)"
+		description = "Color of Trade Chat Messages (transparent)",
+		section = transparentSection
 	)
 	Color transparentTradeChatMessage();
 
 	@ConfigItem(
-		position = 74,
+		position = 64,
 		keyName = "transparentTradeChatMessageHighlight",
 		name = "Trade chat highlight (transparent)",
-		description = "Color of highlights in Trade Chat Messages (transparent)"
+		description = "Color of highlights in Trade Chat Messages (transparent)",
+		section = transparentSection
 	)
 	Color transparentTradeChatMessageHighlight();
 
 	@ConfigItem(
-		position = 75,
+		position = 65,
 		keyName = "transparentServerMessage",
 		name = "Server message (transparent)",
-		description = "Color of Server Messages (eg. 'Welcome to RuneScape') (transparent)"
+		description = "Color of Server Messages (eg. 'Welcome to RuneScape') (transparent)",
+		section = transparentSection
 	)
 	Color transparentServerMessage();
 
 	@ConfigItem(
-		position = 76,
+		position = 66,
 		keyName = "transparentServerMessageHighlight",
 		name = "Server message highlight (transparent)",
-		description = "Color of highlights in Server Messages (transparent)"
+		description = "Color of highlights in Server Messages (transparent)",
+		section = transparentSection
 	)
 	Color transparentServerMessageHighlight();
 
 	@ConfigItem(
-		position = 77,
+		position = 67,
 		keyName = "transparentGameMessage",
 		name = "Game message (transparent)",
-		description = "Color of Game Messages (transparent)"
+		description = "Color of Game Messages (transparent)",
+		section = transparentSection
 	)
 	Color transparentGameMessage();
 
 	@ConfigItem(
-		position = 78,
+		position = 68,
 		keyName = "transparentGameMessageHighlight",
 		name = "Game message highlight (transparent)",
-		description = "Color of highlights in Game Messages (transparent)"
+		description = "Color of highlights in Game Messages (transparent)",
+		section = transparentSection
 	)
 	default Color transparentGameMessageHighlight()
 	{
@@ -436,18 +497,20 @@ public interface ChatColorConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 79,
+		position = 69,
 		keyName = "transparentExamine",
 		name = "Examine (transparent)",
-		description = "Color of Examine Text (transparent)"
+		description = "Color of Examine Text (transparent)",
+		section = transparentSection
 	)
 	Color transparentExamine();
 
 	@ConfigItem(
-		position = 80,
+		position = 70,
 		keyName = "transparentExamineHighlight",
 		name = "Examine highlight (transparent)",
-		description = "Color of highlights in Examine Text (transparent)"
+		description = "Color of highlights in Examine Text (transparent)",
+		section = transparentSection
 	)
 	default Color transparentExamineHighlight()
 	{
@@ -455,58 +518,65 @@ public interface ChatColorConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 81,
+		position = 71,
 		keyName = "transparentFiltered",
 		name = "Filtered (transparent)",
-		description = "Color of Filtered Text (messages that aren't shown when Game messages are filtered) (transparent)"
+		description = "Color of Filtered Text (messages that aren't shown when Game messages are filtered) (transparent)",
+		section = transparentSection
 	)
 	Color transparentFiltered();
 
 	@ConfigItem(
-		position = 82,
+		position = 72,
 		keyName = "transparentFilteredHighlight",
 		name = "Filtered highlight (transparent)",
-		description = "Color of highlights in Filtered Text (transparent)"
+		description = "Color of highlights in Filtered Text (transparent)",
+		section = transparentSection
 	)
 	Color transparentFilteredHighlight();
 
 	@ConfigItem(
-		position = 83,
+		position = 73,
 		keyName = "transparentUsername",
 		name = "Usernames (transparent)",
-		description = "Color of Usernames (transparent)"
+		description = "Color of Usernames (transparent)",
+		section = transparentSection
 	)
 	Color transparentUsername();
 
 	@ConfigItem(
-		position = 84,
+		position = 74,
 		keyName = "transparentPrivateUsernames",
 		name = "Private chat usernames (transparent)",
-		description = "Color of Usernames in Private Chat (transparent)"
+		description = "Color of Usernames in Private Chat (transparent)",
+		section = transparentSection
 	)
 	Color transparentPrivateUsernames();
 
 	@ConfigItem(
-		position = 85,
+		position = 75,
 		keyName = "transparentClanChannelName",
 		name = "Clan channel name (transparent)",
-		description = "Color of Clan Channel Name (transparent)"
+		description = "Color of Clan Channel Name (transparent)",
+		section = transparentSection
 	)
 	Color transparentClanChannelName();
 
 	@ConfigItem(
-		position = 86,
+		position = 76,
 		keyName = "transparentClanUsernames",
 		name = "Clan usernames (transparent)",
-		description = "Color of Usernames in Clan Chat (transparent)"
+		description = "Color of Usernames in Clan Chat (transparent)",
+		section = transparentSection
 	)
 	Color transparentClanUsernames();
 
 	@ConfigItem(
-		position = 87,
+		position = 77,
 		keyName = "transparentPublicFriendUsernames",
 		name = "Public friend usernames (transparent)",
-		description = "Color of Friend Usernames in Public Chat (transparent)"
+		description = "Color of Friend Usernames in Public Chat (transparent)",
+		section = transparentSection
 	)
 	Color transparentPublicFriendUsernames();
 }

--- a/runelite-client/src/main/java/net/runelite/client/config/ConfigDescriptor.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/ConfigDescriptor.java
@@ -24,26 +24,20 @@
  */
 package net.runelite.client.config;
 
+import lombok.Getter;
 import java.util.Collection;
 
+@Getter
 public class ConfigDescriptor
 {
 	private final ConfigGroup group;
+	private final Collection<ConfigSectionDescriptor> sections;
 	private final Collection<ConfigItemDescriptor> items;
 
-	public ConfigDescriptor(ConfigGroup group, Collection<ConfigItemDescriptor> items)
+	public ConfigDescriptor(ConfigGroup group, Collection<ConfigSectionDescriptor> sections, Collection<ConfigItemDescriptor> items)
 	{
 		this.group = group;
+		this.sections = sections;
 		this.items = items;
-	}
-
-	public ConfigGroup getGroup()
-	{
-		return group;
-	}
-
-	public Collection<ConfigItemDescriptor> getItems()
-	{
-		return items;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/config/ConfigItemDescriptor.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/ConfigItemDescriptor.java
@@ -27,11 +27,29 @@ package net.runelite.client.config;
 import lombok.Value;
 
 @Value
-public class ConfigItemDescriptor
+public class ConfigItemDescriptor implements ConfigObject
 {
 	private final ConfigItem item;
 	private final Class<?> type;
 	private final Range range;
 	private final Alpha alpha;
 	private final Units units;
+
+	@Override
+	public String key()
+	{
+		return item.keyName();
+	}
+
+	@Override
+	public String name()
+	{
+		return item.name();
+	}
+
+	@Override
+	public int position()
+	{
+		return item.position();
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/config/ConfigObject.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/ConfigObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Adam <Adam@sigterm.info>
+ * Copyright (c) 2020, Hydrox6 <ikada@protonmail.ch>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -24,28 +24,9 @@
  */
 package net.runelite.client.config;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
-
-@Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.METHOD)
-public @interface ConfigItem
+public interface ConfigObject
 {
-	int position() default -1;
-
-	String keyName();
-
+	String key();
 	String name();
-
-	String description();
-
-	boolean hidden() default false;
-
-	String warning() default "";
-
-	boolean secret() default false;
-
-	String section() default "";
+	int position();
 }

--- a/runelite-client/src/main/java/net/runelite/client/config/ConfigSection.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/ConfigSection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Adam <Adam@sigterm.info>
+ * Copyright (c) 2019, Hydrox6 <ikada@protonmail.ch>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -30,22 +30,14 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 @Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.METHOD)
-public @interface ConfigItem
+@Target(ElementType.FIELD)
+public @interface ConfigSection
 {
-	int position() default -1;
-
-	String keyName();
-
 	String name();
 
 	String description();
 
-	boolean hidden() default false;
+	int position();
 
-	String warning() default "";
-
-	boolean secret() default false;
-
-	String section() default "";
+	boolean closedByDefault() default false;
 }

--- a/runelite-client/src/main/java/net/runelite/client/config/ConfigSectionDescriptor.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/ConfigSectionDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Adam <Adam@sigterm.info>
+ * Copyright (c) 2020, Hydrox6 <ikada@protonmail.ch>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -24,28 +24,29 @@
  */
 package net.runelite.client.config;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+import lombok.Value;
 
-@Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.METHOD)
-public @interface ConfigItem
+@Value
+public class ConfigSectionDescriptor implements ConfigObject
 {
-	int position() default -1;
+	private final String key;
+	private final ConfigSection section;
 
-	String keyName();
+	@Override
+	public String key()
+	{
+		return key;
+	}
 
-	String name();
+	@Override
+	public String name()
+	{
+		return section.name();
+	}
 
-	String description();
-
-	boolean hidden() default false;
-
-	String warning() default "";
-
-	boolean secret() default false;
-
-	String section() default "";
+	@Override
+	public int position()
+	{
+		return section.position();
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/config/RuneLiteConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/RuneLiteConfig.java
@@ -38,11 +38,33 @@ public interface RuneLiteConfig extends Config
 {
 	String GROUP_NAME = "runelite";
 
+	@ConfigSection(
+		name = "Window Settings",
+		description = "Settings relating to the client's window and frame",
+		position = 0
+	)
+	String windowSettings = "windowSettings";
+
+	@ConfigSection(
+		name = "Notification Settings",
+		description = "Settings relating to notifications",
+		position = 1
+	)
+	String notificationSettings = "notificationSettings";
+
+	@ConfigSection(
+		name = "Overlay Settings",
+		description = "Settings relating to fonts",
+		position = 2
+	)
+	String overlaySettings = "overlaySettings";
+
 	@ConfigItem(
 		keyName = "gameSize",
 		name = "Game size",
 		description = "The game will resize to this resolution upon starting the client",
-		position = 10
+		position = 10,
+		section = windowSettings
 	)
 	default Dimension gameSize()
 	{
@@ -53,7 +75,8 @@ public interface RuneLiteConfig extends Config
 		keyName = "automaticResizeType",
 		name = "Resize type",
 		description = "Choose how the window should resize when opening and closing panels",
-		position = 11
+		position = 11,
+		section = windowSettings
 	)
 	default ExpandResizeType automaticResizeType()
 	{
@@ -64,7 +87,8 @@ public interface RuneLiteConfig extends Config
 		keyName = "lockWindowSize",
 		name = "Lock window size",
 		description = "Determines if the window resizing is allowed or not",
-		position = 12
+		position = 12,
+		section = windowSettings
 	)
 	default boolean lockWindowSize()
 	{
@@ -75,7 +99,8 @@ public interface RuneLiteConfig extends Config
 		keyName = "containInScreen2",
 		name = "Contain in screen",
 		description = "Makes the client stay contained in the screen when attempted to move out of it.<br>Note: 'Always' only works if custom chrome is enabled.",
-		position = 13
+		position = 13,
+		section = windowSettings
 	)
 	default ContainableFrame.Mode containInScreen()
 	{
@@ -86,7 +111,8 @@ public interface RuneLiteConfig extends Config
 		keyName = "rememberScreenBounds",
 		name = "Remember client position",
 		description = "Save the position and size of the client after exiting",
-		position = 14
+		position = 14,
+		section = windowSettings
 	)
 	default boolean rememberScreenBounds()
 	{
@@ -98,7 +124,8 @@ public interface RuneLiteConfig extends Config
 		name = "Enable custom window chrome",
 		description = "Use Runelite's custom window title and borders.",
 		warning = "Please restart your client after changing this setting",
-		position = 15
+		position = 15,
+		section = windowSettings
 	)
 	default boolean enableCustomChrome()
 	{
@@ -113,7 +140,8 @@ public interface RuneLiteConfig extends Config
 		keyName = "uiWindowOpacity",
 		name = "Window opacity",
 		description = "Set the windows opacity. Requires \"Enable custom window chrome\" to be enabled.",
-		position = 16
+		position = 16,
+		section = windowSettings
 	)
 	default int windowOpacity()
 	{
@@ -124,7 +152,8 @@ public interface RuneLiteConfig extends Config
 		keyName = "gameAlwaysOnTop",
 		name = "Enable client always on top",
 		description = "The game will always be on the top of the screen",
-		position = 17
+		position = 17,
+		section = windowSettings
 	)
 	default boolean gameAlwaysOnTop()
 	{
@@ -135,7 +164,8 @@ public interface RuneLiteConfig extends Config
 		keyName = "warningOnExit",
 		name = "Display warning on exit",
 		description = "Toggles a warning popup when trying to exit the client",
-		position = 18
+		position = 18,
+		section = windowSettings
 	)
 	default WarningOnExit warningOnExit()
 	{
@@ -146,7 +176,8 @@ public interface RuneLiteConfig extends Config
 		keyName = "usernameInTitle",
 		name = "Show display name in title",
 		description = "Toggles displaying of local player's display name in client title",
-		position = 19
+		position = 19,
+		section = windowSettings
 	)
 	default boolean usernameInTitle()
 	{
@@ -157,7 +188,8 @@ public interface RuneLiteConfig extends Config
 		keyName = "notificationTray",
 		name = "Enable tray notifications",
 		description = "Enables tray notifications",
-		position = 20
+		position = 20,
+		section = notificationSettings
 	)
 	default boolean enableTrayNotifications()
 	{
@@ -168,7 +200,8 @@ public interface RuneLiteConfig extends Config
 		keyName = "notificationRequestFocus",
 		name = "Request focus on notification",
 		description = "Configures the window focus request type on notification",
-		position = 21
+		position = 21,
+		section = notificationSettings
 	)
 	default RequestFocusType notificationRequestFocus()
 	{
@@ -179,7 +212,8 @@ public interface RuneLiteConfig extends Config
 		keyName = "notificationSound",
 		name = "Notification sound",
 		description = "Enables the playing of a beep sound when notifications are displayed",
-		position = 22
+		position = 22,
+		section = notificationSettings
 	)
 	default Notifier.NativeCustomOff notificationSound()
 	{
@@ -190,7 +224,8 @@ public interface RuneLiteConfig extends Config
 		keyName = "notificationGameMessage",
 		name = "Enable game message notifications",
 		description = "Puts a notification message in the chatbox",
-		position = 23
+		position = 23,
+		section = notificationSettings
 	)
 	default boolean enableGameMessageNotification()
 	{
@@ -201,7 +236,8 @@ public interface RuneLiteConfig extends Config
 		keyName = "flashNotification",
 		name = "Flash notification",
 		description = "Flashes the game frame as a notification",
-		position = 24
+		position = 24,
+		section = notificationSettings
 	)
 	default FlashNotification flashNotification()
 	{
@@ -212,7 +248,8 @@ public interface RuneLiteConfig extends Config
 		keyName = "notificationFocused",
 		name = "Send notifications when focused",
 		description = "Toggles all notifications for when the client is focused",
-		position = 25
+		position = 25,
+		section = notificationSettings
 	)
 	default boolean sendNotificationsWhenFocused()
 	{
@@ -223,7 +260,8 @@ public interface RuneLiteConfig extends Config
 		keyName = "fontType",
 		name = "Dynamic Overlay Font",
 		description = "Configures what font type is used for in-game overlays such as player name, ground items, etc.",
-		position = 30
+		position = 30,
+		section = overlaySettings
 	)
 	default FontType fontType()
 	{
@@ -234,7 +272,8 @@ public interface RuneLiteConfig extends Config
 		keyName = "tooltipFontType",
 		name = "Tooltip Font",
 		description = "Configures what font type is used for in-game tooltips such as food stats, NPC names, etc.",
-		position = 31
+		position = 31,
+		section = overlaySettings
 	)
 	default FontType tooltipFontType()
 	{
@@ -245,7 +284,8 @@ public interface RuneLiteConfig extends Config
 		keyName = "interfaceFontType",
 		name = "Interface Overlay Font",
 		description = "Configures what font type is used for in-game interface overlays such as panels, opponent info, clue scrolls etc.",
-		position = 32
+		position = 32,
+		section = overlaySettings
 	)
 	default FontType interfaceFontType()
 	{
@@ -256,7 +296,8 @@ public interface RuneLiteConfig extends Config
 		keyName = "menuEntryShift",
 		name = "Require Shift for overlay menu",
 		description = "Overlay right-click menu will require shift to be added",
-		position = 33
+		position = 33,
+		section = overlaySettings
 	)
 	default boolean menuEntryShift()
 	{
@@ -267,7 +308,8 @@ public interface RuneLiteConfig extends Config
 		keyName = "tooltipPosition",
 		name = "Tooltip Position",
 		description = "Configures whether to show the tooltip above or under the cursor",
-		position = 35
+		position = 35,
+		section = overlaySettings
 	)
 	default TooltipPositionType tooltipPosition()
 	{
@@ -278,7 +320,8 @@ public interface RuneLiteConfig extends Config
 		keyName = "infoBoxVertical",
 		name = "Display infoboxes vertically",
 		description = "Toggles the infoboxes to display vertically",
-		position = 40
+		position = 40,
+		section = overlaySettings
 	)
 	default boolean infoBoxVertical()
 	{
@@ -289,7 +332,8 @@ public interface RuneLiteConfig extends Config
 		keyName = "infoBoxSize",
 		name = "Infobox size",
 		description = "Configures the size of each infobox in pixels",
-		position = 42
+		position = 42,
+		section = overlaySettings
 	)
 	@Units(Units.PIXELS)
 	default int infoBoxSize()
@@ -301,7 +345,8 @@ public interface RuneLiteConfig extends Config
 		keyName = "overlayBackgroundColor",
 		name = "Overlay Color",
 		description = "Configures the background color of infoboxes and overlays",
-		position = 43
+		position = 43,
+		section = overlaySettings
 	)
 	@Alpha
 	default Color overlayBackgroundColor()
@@ -324,7 +369,8 @@ public interface RuneLiteConfig extends Config
 		keyName = "sidebarToggleKey",
 		name = "Sidebar Toggle Key",
 		description = "The key that will toggle the sidebar (accepts modifiers)",
-		position = 45
+		position = 45,
+		section = windowSettings
 	)
 	default Keybind sidebarToggleKey()
 	{
@@ -335,7 +381,8 @@ public interface RuneLiteConfig extends Config
 		keyName = "panelToggleKey",
 		name = "Plugin Panel Toggle Key",
 		description = "The key that will toggle the current or last opened plugin panel (accepts modifiers)",
-		position = 46
+		position = 46,
+		section = windowSettings
 	)
 	default Keybind panelToggleKey()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
@@ -30,6 +30,7 @@ import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
 import net.runelite.client.config.Units;
+import net.runelite.client.config.ConfigSection;
 import net.runelite.client.plugins.grounditems.config.HighlightTier;
 import net.runelite.client.plugins.grounditems.config.ItemHighlightMode;
 import net.runelite.client.plugins.grounditems.config.MenuHighlightMode;
@@ -39,11 +40,20 @@ import net.runelite.client.plugins.grounditems.config.ValueCalculationMode;
 @ConfigGroup("grounditems")
 public interface GroundItemsConfig extends Config
 {
+	@ConfigSection(
+		name = "Item Lists",
+		description = "The highlighted and hidden item lists",
+		position = 0,
+		closedByDefault = true
+	)
+	String itemLists = "itemLists";
+
 	@ConfigItem(
 		keyName = "highlightedItems",
 		name = "Highlighted Items",
 		description = "Configures specifically highlighted ground items. Format: (item), (item)",
-		position = 0
+		position = 0,
+		section = itemLists
 	)
 	default String getHighlightItems()
 	{
@@ -61,7 +71,8 @@ public interface GroundItemsConfig extends Config
 		keyName = "hiddenItems",
 		name = "Hidden Items",
 		description = "Configures hidden ground items. Format: (item), (item)",
-		position = 1
+		position = 1,
+		section = itemLists
 	)
 	default String getHiddenItems()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/implings/ImplingsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/implings/ImplingsConfig.java
@@ -28,6 +28,7 @@ import java.awt.Color;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.ConfigSection;
 
 /**
  *
@@ -43,11 +44,19 @@ public interface ImplingsConfig extends Config
 		NOTIFY
 	}
 
+	@ConfigSection(
+		name = "Impling Type Settings",
+		description = "Configuration for each type of impling",
+		position = 99
+	)
+	String implingSection = "implings";
+
 	@ConfigItem(
 		position = 1,
 		keyName = "showbaby",
 		name = "Show Baby implings",
-		description = "Configures whether or not Baby impling tags are displayed"
+		description = "Configures whether or not Baby impling tags are displayed",
+		section = implingSection
 	)
 	default ImplingMode showBaby()
 	{
@@ -58,7 +67,8 @@ public interface ImplingsConfig extends Config
 		position = 2,
 		keyName = "babyColor",
 		name = "Baby impling color",
-		description = "Text color for Baby implings"
+		description = "Text color for Baby implings",
+		section = implingSection
 	)
 	default Color getBabyColor()
 	{
@@ -69,7 +79,8 @@ public interface ImplingsConfig extends Config
 		position = 3,
 		keyName = "showyoung",
 		name = "Show Young implings",
-		description = "Configures whether or not Young impling tags are displayed"
+		description = "Configures whether or not Young impling tags are displayed",
+		section = implingSection
 	)
 	default ImplingMode showYoung()
 	{
@@ -80,7 +91,8 @@ public interface ImplingsConfig extends Config
 		position = 4,
 		keyName = "youngColor",
 		name = "Young impling color",
-		description = "Text color for Young implings"
+		description = "Text color for Young implings",
+		section = implingSection
 	)
 	default Color getYoungColor()
 	{
@@ -91,7 +103,8 @@ public interface ImplingsConfig extends Config
 		position = 5,
 		keyName = "showgourmet",
 		name = "Show Gourmet implings",
-		description = "Configures whether or not Gourmet impling tags are displayed"
+		description = "Configures whether or not Gourmet impling tags are displayed",
+		section = implingSection
 	)
 	default ImplingMode showGourmet()
 	{
@@ -102,7 +115,8 @@ public interface ImplingsConfig extends Config
 		position = 6,
 		keyName = "gourmetColor",
 		name = "Gourmet impling color",
-		description = "Text color for Gourmet implings"
+		description = "Text color for Gourmet implings",
+		section = implingSection
 	)
 	default Color getGourmetColor()
 	{
@@ -113,7 +127,8 @@ public interface ImplingsConfig extends Config
 		position = 7,
 		keyName = "showearth",
 		name = "Show Earth implings",
-		description = "Configures whether or not Earth impling tags are displayed"
+		description = "Configures whether or not Earth impling tags are displayed",
+		section = implingSection
 	)
 	default ImplingMode showEarth()
 	{
@@ -124,7 +139,8 @@ public interface ImplingsConfig extends Config
 		position = 8,
 		keyName = "earthColor",
 		name = "Earth impling color",
-		description = "Text color for Earth implings"
+		description = "Text color for Earth implings",
+		section = implingSection
 	)
 	default Color getEarthColor()
 	{
@@ -135,7 +151,8 @@ public interface ImplingsConfig extends Config
 		position = 9,
 		keyName = "showessence",
 		name = "Show Essence implings",
-		description = "Configures whether or not Essence impling tags are displayed"
+		description = "Configures whether or not Essence impling tags are displayed",
+		section = implingSection
 	)
 	default ImplingMode showEssence()
 	{
@@ -146,7 +163,8 @@ public interface ImplingsConfig extends Config
 		position = 10,
 		keyName = "essenceColor",
 		name = "Essence impling color",
-		description = "Text color for Essence implings"
+		description = "Text color for Essence implings",
+		section = implingSection
 	)
 	default Color getEssenceColor()
 	{
@@ -157,7 +175,8 @@ public interface ImplingsConfig extends Config
 		position = 11,
 		keyName = "showeclectic",
 		name = "Show Eclectic implings",
-		description = "Configures whether or not Eclectic impling tags are displayed"
+		description = "Configures whether or not Eclectic impling tags are displayed",
+		section = implingSection
 	)
 	default ImplingMode showEclectic()
 	{
@@ -168,7 +187,8 @@ public interface ImplingsConfig extends Config
 		position = 12,
 		keyName = "eclecticColor",
 		name = "Eclectic impling color",
-		description = "Text color for Eclectic implings"
+		description = "Text color for Eclectic implings",
+		section = implingSection
 	)
 	default Color getEclecticColor()
 	{
@@ -179,7 +199,8 @@ public interface ImplingsConfig extends Config
 		position = 13,
 		keyName = "shownature",
 		name = "Show Nature implings",
-		description = "Configures whether or not Nature impling tags are displayed"
+		description = "Configures whether or not Nature impling tags are displayed",
+		section = implingSection
 	)
 	default ImplingMode showNature()
 	{
@@ -190,7 +211,8 @@ public interface ImplingsConfig extends Config
 		position = 14,
 		keyName = "natureColor",
 		name = "Nature impling color",
-		description = "Text color for Nature implings"
+		description = "Text color for Nature implings",
+		section = implingSection
 	)
 	default Color getNatureColor()
 	{
@@ -201,7 +223,8 @@ public interface ImplingsConfig extends Config
 		position = 15,
 		keyName = "showmagpie",
 		name = "Show Magpie implings",
-		description = "Configures whether or not Magpie impling tags are displayed"
+		description = "Configures whether or not Magpie impling tags are displayed",
+		section = implingSection
 	)
 	default ImplingMode showMagpie()
 	{
@@ -212,7 +235,8 @@ public interface ImplingsConfig extends Config
 		position = 16,
 		keyName = "magpieColor",
 		name = "Magpie impling color",
-		description = "Text color for Magpie implings"
+		description = "Text color for Magpie implings",
+		section = implingSection
 	)
 	default Color getMagpieColor()
 	{
@@ -223,7 +247,8 @@ public interface ImplingsConfig extends Config
 		position = 17,
 		keyName = "showninja",
 		name = "Show Ninja implings",
-		description = "Configures whether or not Ninja impling tags are displayed"
+		description = "Configures whether or not Ninja impling tags are displayed",
+		section = implingSection
 	)
 	default ImplingMode showNinja()
 	{
@@ -234,7 +259,8 @@ public interface ImplingsConfig extends Config
 		position = 18,
 		keyName = "ninjaColor",
 		name = "Ninja impling color",
-		description = "Text color for Ninja implings"
+		description = "Text color for Ninja implings",
+		section = implingSection
 	)
 	default Color getNinjaColor()
 	{
@@ -245,7 +271,8 @@ public interface ImplingsConfig extends Config
 		position = 19,
 		keyName = "showCrystal",
 		name = "Show Crystal implings",
-		description = "Configures whether or not Crystal implings are displayed"
+		description = "Configures whether or not Crystal implings are displayed",
+		section = implingSection
 	)
 	default ImplingMode showCrystal()
 	{
@@ -256,7 +283,8 @@ public interface ImplingsConfig extends Config
 		position = 20,
 		keyName = "crystalColor",
 		name = "Crystal impling color",
-		description = "Text color for Crystal implings"
+		description = "Text color for Crystal implings",
+		section = implingSection
 	)
 	default Color getCrystalColor()
 	{
@@ -267,7 +295,8 @@ public interface ImplingsConfig extends Config
 		position = 21,
 		keyName = "showdragon",
 		name = "Show Dragon implings",
-		description = "Configures whether or not Dragon impling tags are displayed"
+		description = "Configures whether or not Dragon impling tags are displayed",
+		section = implingSection
 	)
 	default ImplingMode showDragon()
 	{
@@ -278,7 +307,8 @@ public interface ImplingsConfig extends Config
 		position = 22,
 		keyName = "dragonColor",
 		name = "Dragon impling color",
-		description = "Text color for Dragon implings"
+		description = "Text color for Dragon implings",
+		section = implingSection
 	)
 	default Color getDragonColor()
 	{
@@ -289,7 +319,8 @@ public interface ImplingsConfig extends Config
 		position = 23,
 		keyName = "showlucky",
 		name = "Show Lucky implings",
-		description = "Configures whether or not Lucky impling tags are displayed"
+		description = "Configures whether or not Lucky impling tags are displayed",
+		section = implingSection
 	)
 	default ImplingMode showLucky()
 	{
@@ -300,7 +331,8 @@ public interface ImplingsConfig extends Config
 		position = 24,
 		keyName = "luckyColor",
 		name = "Lucky impling color",
-		description = "Text color for Lucky implings"
+		description = "Text color for Lucky implings",
+		section = implingSection
 	)
 	default Color getLuckyColor()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemcharges/ItemChargeConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemcharges/ItemChargeConfig.java
@@ -29,10 +29,25 @@ import java.awt.Color;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.ConfigSection;
 
 @ConfigGroup("itemCharge")
 public interface ItemChargeConfig extends Config
 {
+	@ConfigSection(
+		name = "Charge Settings",
+		description = "Configuration for which charges should be displayed",
+		position = 98
+	)
+	String chargesSection = "charges";
+
+	@ConfigSection(
+		name = "Notification Settings",
+		description = "Configuration for notifications",
+		position = 99
+	)
+	String notificationSection = "notifications";
+
 	@ConfigItem(
 		keyName = "veryLowWarningColor",
 		name = "Very Low Warning Color",
@@ -81,7 +96,8 @@ public interface ItemChargeConfig extends Config
 		keyName = "showTeleportCharges",
 		name = "Show Teleport Charges",
 		description = "Configures if teleport item count is shown",
-		position = 5
+		position = 5,
+		section = chargesSection
 	)
 	default boolean showTeleportCharges()
 	{
@@ -92,7 +108,8 @@ public interface ItemChargeConfig extends Config
 		keyName = "showDodgyCount",
 		name = "Dodgy Necklace Count",
 		description = "Configures if Dodgy Necklace charge count is shown",
-		position = 6
+		position = 6,
+		section = chargesSection
 	)
 	default boolean showDodgyCount()
 	{
@@ -103,7 +120,8 @@ public interface ItemChargeConfig extends Config
 		keyName = "dodgyNotification",
 		name = "Dodgy Necklace Notification",
 		description = "Configures if the dodgy necklace breaking notification is shown",
-		position = 7
+		position = 7,
+		section = notificationSection
 	)
 	default boolean dodgyNotification()
 	{
@@ -132,7 +150,8 @@ public interface ItemChargeConfig extends Config
 		keyName = "showImpCharges",
 		name = "Show Imp-in-a-box charges",
 		description = "Configures if imp-in-a-box item charges is shown",
-		position = 8
+		position = 8,
+		section = chargesSection
 	)
 	default boolean showImpCharges()
 	{
@@ -143,7 +162,8 @@ public interface ItemChargeConfig extends Config
 		keyName = "showFungicideCharges",
 		name = "Show Fungicide Charges",
 		description = "Configures if fungicide item charges is shown",
-		position = 9
+		position = 9,
+		section = chargesSection
 	)
 	default boolean showFungicideCharges()
 	{
@@ -154,7 +174,8 @@ public interface ItemChargeConfig extends Config
 		keyName = "showWateringCanCharges",
 		name = "Show Watering Can Charges",
 		description = "Configures if watering can item charge is shown",
-		position = 10
+		position = 10,
+		section = chargesSection
 	)
 	default boolean showWateringCanCharges()
 	{
@@ -165,7 +186,8 @@ public interface ItemChargeConfig extends Config
 		keyName = "showWaterskinCharges",
 		name = "Show Waterskin Charges",
 		description = "Configures if waterskin item charge is shown",
-		position = 11
+		position = 11,
+		section = chargesSection
 	)
 	default boolean showWaterskinCharges()
 	{
@@ -176,7 +198,8 @@ public interface ItemChargeConfig extends Config
 		keyName = "showBellowCharges",
 		name = "Show Bellow Charges",
 		description = "Configures if ogre bellow item charge is shown",
-		position = 12
+		position = 12,
+		section = chargesSection
 	)
 	default boolean showBellowCharges()
 	{
@@ -187,7 +210,8 @@ public interface ItemChargeConfig extends Config
 		keyName = "showBasketCharges",
 		name = "Show Basket Charges",
 		description = "Configures if fruit basket item charge is shown",
-		position = 13
+		position = 13,
+		section = chargesSection
 	)
 	default boolean showBasketCharges()
 	{
@@ -198,7 +222,8 @@ public interface ItemChargeConfig extends Config
 		keyName = "showSackCharges",
 		name = "Show Sack Charges",
 		description = "Configures if sack item charge is shown",
-		position = 14
+		position = 14,
+		section = chargesSection
 	)
 	default boolean showSackCharges()
 	{
@@ -209,7 +234,8 @@ public interface ItemChargeConfig extends Config
 		keyName = "showAbyssalBraceletCharges",
 		name = "Show Abyssal Bracelet Charges",
 		description = "Configures if abyssal bracelet item charge is shown",
-		position = 15
+		position = 15,
+		section = chargesSection
 	)
 	default boolean showAbyssalBraceletCharges()
 	{
@@ -220,7 +246,8 @@ public interface ItemChargeConfig extends Config
 		keyName = "showAmuletOfChemistryCharges",
 		name = "Show Amulet of Chemistry Charges",
 		description = "Configures if amulet of chemistry item charge is shown",
-		position = 16
+		position = 16,
+		section = chargesSection
 	)
 	default boolean showAmuletOfChemistryCharges()
 	{
@@ -249,7 +276,8 @@ public interface ItemChargeConfig extends Config
 		keyName = "showAmuletOfBountyCharges",
 		name = "Show Amulet of Bounty Charges",
 		description = "Configures if amulet of bounty item charge is shown",
-		position = 17
+		position = 17,
+		section = chargesSection
 	)
 	default boolean showAmuletOfBountyCharges()
 	{
@@ -278,7 +306,8 @@ public interface ItemChargeConfig extends Config
 		keyName = "recoilNotification",
 		name = "Ring of Recoil Notification",
 		description = "Configures if the ring of recoil breaking notification is shown",
-		position = 18
+		position = 18,
+		section = notificationSection
 	)
 	default boolean recoilNotification()
 	{
@@ -289,7 +318,8 @@ public interface ItemChargeConfig extends Config
 		keyName = "showBindingNecklaceCharges",
 		name = "Show Binding Necklace Charges",
 		description = "Configures if binding necklace item charge is shown",
-		position = 19
+		position = 19,
+		section = chargesSection
 	)
 	default boolean showBindingNecklaceCharges()
 	{
@@ -318,7 +348,8 @@ public interface ItemChargeConfig extends Config
 		keyName = "bindingNotification",
 		name = "Binding Necklace Notification",
 		description = "Configures if the binding necklace breaking notification is shown",
-		position = 20
+		position = 20,
+		section = notificationSection
 	)
 	default boolean bindingNotification()
 	{
@@ -329,7 +360,8 @@ public interface ItemChargeConfig extends Config
 		keyName = "showExplorerRingCharges",
 		name = "Show Explorer's Ring Alch Charges",
 		description = "Configures if explorer's ring alchemy charges are shown",
-		position = 21
+		position = 21,
+		section = chargesSection
 	)
 	default boolean showExplorerRingCharges()
 	{
@@ -358,7 +390,8 @@ public interface ItemChargeConfig extends Config
 		keyName = "showRingOfForgingCount",
 		name = "Show Ring of Forging Charges",
 		description = "Configures if the Ring of Forging charge count is shown",
-		position = 22
+		position = 22,
+		section = chargesSection
 	)
 	default boolean showRingOfForgingCount()
 	{
@@ -387,7 +420,8 @@ public interface ItemChargeConfig extends Config
 		keyName = "ringOfForgingNotification",
 		name = "Ring of Forging Notification",
 		description = "Configures if the Ring of Forging breaking notification is enabled",
-		position = 23
+		position = 23,
+		section = notificationSection
 	)
 	default boolean ringOfForgingNotification()
 	{
@@ -409,7 +443,8 @@ public interface ItemChargeConfig extends Config
 		keyName = "showPotionDoseCount",
 		name = "Show Potion Doses",
 		description = "Configures if potion doses are shown",
-		position = 25
+		position = 25,
+		section = chargesSection
 	)
 	default boolean showPotionDoseCount()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemidentification/ItemIdentificationConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemidentification/ItemIdentificationConfig.java
@@ -28,10 +28,18 @@ import java.awt.Color;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.ConfigSection;
 
 @ConfigGroup("itemidentification")
 public interface ItemIdentificationConfig extends Config
 {
+	@ConfigSection(
+		name = "Categories",
+		description = "The categories of items to identify",
+		position = 99
+	)
+	String identificationSection = "identification";
+
 	@ConfigItem(
 		keyName = "identificationType",
 		name = "Identification Type",
@@ -57,7 +65,8 @@ public interface ItemIdentificationConfig extends Config
 	@ConfigItem(
 		keyName = "showSeeds",
 		name = "Seeds",
-		description = "Show identification on Seeds"
+		description = "Show identification on Seeds",
+		section = identificationSection
 	)
 	default boolean showSeeds()
 	{
@@ -67,7 +76,8 @@ public interface ItemIdentificationConfig extends Config
 	@ConfigItem(
 		keyName = "showHerbs",
 		name = "Herbs",
-		description = "Show identification on Herbs"
+		description = "Show identification on Herbs",
+		section = identificationSection
 	)
 	default boolean showHerbs()
 	{
@@ -77,7 +87,8 @@ public interface ItemIdentificationConfig extends Config
 	@ConfigItem(
 		keyName = "showSaplings",
 		name = "Saplings",
-		description = "Show identification on Saplings and Seedlings"
+		description = "Show identification on Saplings and Seedlings",
+		section = identificationSection
 	)
 	default boolean showSaplings()
 	{
@@ -87,7 +98,8 @@ public interface ItemIdentificationConfig extends Config
 	@ConfigItem(
 		keyName = "showOres",
 		name = "Ores",
-		description = "Show identification on Ores"
+		description = "Show identification on Ores",
+		section = identificationSection
 	)
 	default boolean showOres()
 	{
@@ -97,7 +109,8 @@ public interface ItemIdentificationConfig extends Config
 	@ConfigItem(
 		keyName = "showGems",
 		name = "Gems",
-		description = "Show identification on Gems"
+		description = "Show identification on Gems",
+		section = identificationSection
 	)
 	default boolean showGems()
 	{
@@ -107,7 +120,8 @@ public interface ItemIdentificationConfig extends Config
 	@ConfigItem(
 		keyName = "showPotions",
 		name = "Potions",
-		description = "Show identification on Potions"
+		description = "Show identification on Potions",
+		section = identificationSection
 	)
 	default boolean showPotions()
 	{
@@ -117,7 +131,8 @@ public interface ItemIdentificationConfig extends Config
 	@ConfigItem(
 		keyName = "showImplingJars",
 		name = "Impling jars",
-		description = "Show identification on Impling jars"
+		description = "Show identification on Impling jars",
+		section = identificationSection
 	)
 	default boolean showImplingJars()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/keyremapping/KeyRemappingConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/keyremapping/KeyRemappingConfig.java
@@ -28,16 +28,32 @@ import java.awt.event.KeyEvent;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.ConfigSection;
 import net.runelite.client.config.ModifierlessKeybind;
 
 @ConfigGroup("keyremapping")
 public interface KeyRemappingConfig extends Config
 {
+	@ConfigSection(
+		name = "Camera Remapping",
+		description = "Settings for remapping the camera",
+		position = 0
+	)
+	String cameraSection = "camera";
+
+	@ConfigSection(
+		name = "F Key Remapping",
+		description = "Settings for remapping the F Keys",
+		position = 1
+	)
+	String fKeySection = "fKeys";
+
 	@ConfigItem(
 		position = 1,
 		keyName = "cameraRemap",
 		name = "Remap Camera",
-		description = "Configures whether the camera movement uses remapped keys"
+		description = "Configures whether the camera movement uses remapped keys",
+		section = cameraSection
 	)
 	default boolean cameraRemap()
 	{
@@ -48,7 +64,8 @@ public interface KeyRemappingConfig extends Config
 		position = 2,
 		keyName = "up",
 		name = "Camera Up key",
-		description = "The key which will replace up."
+		description = "The key which will replace up.",
+		section = cameraSection
 	)
 	default ModifierlessKeybind up()
 	{
@@ -59,7 +76,8 @@ public interface KeyRemappingConfig extends Config
 		position = 3,
 		keyName = "down",
 		name = "Camera Down key",
-		description = "The key which will replace down."
+		description = "The key which will replace down.",
+		section = cameraSection
 	)
 	default ModifierlessKeybind down()
 	{
@@ -70,7 +88,8 @@ public interface KeyRemappingConfig extends Config
 		position = 4,
 		keyName = "left",
 		name = "Camera Left key",
-		description = "The key which will replace left."
+		description = "The key which will replace left.",
+		section = cameraSection
 	)
 	default ModifierlessKeybind left()
 	{
@@ -81,7 +100,8 @@ public interface KeyRemappingConfig extends Config
 		position = 5,
 		keyName = "right",
 		name = "Camera Right key",
-		description = "The key which will replace right."
+		description = "The key which will replace right.",
+		section = cameraSection
 	)
 	default ModifierlessKeybind right()
 	{
@@ -92,7 +112,8 @@ public interface KeyRemappingConfig extends Config
 		position = 6,
 		keyName = "fkeyRemap",
 		name = "Remap F Keys",
-		description = "Configures whether F-Keys use remapped keys"
+		description = "Configures whether F-Keys use remapped keys",
+		section = fKeySection
 	)
 	default boolean fkeyRemap()
 	{
@@ -103,7 +124,8 @@ public interface KeyRemappingConfig extends Config
 		position = 7,
 		keyName = "f1",
 		name = "F1",
-		description = "The key which will replace {F1}."
+		description = "The key which will replace {F1}.",
+		section = fKeySection
 	)
 	default ModifierlessKeybind f1()
 	{
@@ -114,7 +136,8 @@ public interface KeyRemappingConfig extends Config
 		position = 8,
 		keyName = "f2",
 		name = "F2",
-		description = "The key which will replace {F2}."
+		description = "The key which will replace {F2}.",
+		section = fKeySection
 	)
 	default ModifierlessKeybind f2()
 	{
@@ -125,7 +148,8 @@ public interface KeyRemappingConfig extends Config
 		position = 9,
 		keyName = "f3",
 		name = "F3",
-		description = "The key which will replace {F3}."
+		description = "The key which will replace {F3}.",
+		section = fKeySection
 	)
 	default ModifierlessKeybind f3()
 	{
@@ -136,7 +160,8 @@ public interface KeyRemappingConfig extends Config
 		position = 10,
 		keyName = "f4",
 		name = "F4",
-		description = "The key which will replace {F4}."
+		description = "The key which will replace {F4}.",
+		section = fKeySection
 	)
 	default ModifierlessKeybind f4()
 	{
@@ -147,7 +172,8 @@ public interface KeyRemappingConfig extends Config
 		position = 11,
 		keyName = "f5",
 		name = "F5",
-		description = "The key which will replace {F5}."
+		description = "The key which will replace {F5}.",
+		section = fKeySection
 	)
 	default ModifierlessKeybind f5()
 	{
@@ -158,7 +184,8 @@ public interface KeyRemappingConfig extends Config
 		position = 12,
 		keyName = "f6",
 		name = "F6",
-		description = "The key which will replace {F6}."
+		description = "The key which will replace {F6}.",
+		section = fKeySection
 	)
 	default ModifierlessKeybind f6()
 	{
@@ -169,7 +196,8 @@ public interface KeyRemappingConfig extends Config
 		position = 13,
 		keyName = "f7",
 		name = "F7",
-		description = "The key which will replace {F7}."
+		description = "The key which will replace {F7}.",
+		section = fKeySection
 	)
 	default ModifierlessKeybind f7()
 	{
@@ -180,7 +208,8 @@ public interface KeyRemappingConfig extends Config
 		position = 14,
 		keyName = "f8",
 		name = "F8",
-		description = "The key which will replace {F8}."
+		description = "The key which will replace {F8}.",
+		section = fKeySection
 	)
 	default ModifierlessKeybind f8()
 	{
@@ -191,7 +220,8 @@ public interface KeyRemappingConfig extends Config
 		position = 15,
 		keyName = "f9",
 		name = "F9",
-		description = "The key which will replace {F9}."
+		description = "The key which will replace {F9}.",
+		section = fKeySection
 	)
 	default ModifierlessKeybind f9()
 	{
@@ -202,7 +232,8 @@ public interface KeyRemappingConfig extends Config
 		position = 16,
 		keyName = "f10",
 		name = "F10",
-		description = "The key which will replace {F10}."
+		description = "The key which will replace {F10}.",
+		section = fKeySection
 	)
 	default ModifierlessKeybind f10()
 	{
@@ -213,7 +244,8 @@ public interface KeyRemappingConfig extends Config
 		position = 17,
 		keyName = "f11",
 		name = "F11",
-		description = "The key which will replace {F11}."
+		description = "The key which will replace {F11}.",
+		section = fKeySection
 	)
 	default ModifierlessKeybind f11()
 	{
@@ -224,7 +256,8 @@ public interface KeyRemappingConfig extends Config
 		position = 18,
 		keyName = "f12",
 		name = "F12",
-		description = "The key which will replace {F12}."
+		description = "The key which will replace {F12}.",
+		section = fKeySection
 	)
 	default ModifierlessKeybind f12()
 	{
@@ -235,7 +268,8 @@ public interface KeyRemappingConfig extends Config
 		position = 19,
 		keyName = "esc",
 		name = "ESC",
-		description = "The key which will replace {ESC}."
+		description = "The key which will replace {ESC}.",
+		section = fKeySection
 	)
 	default ModifierlessKeybind esc()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerConfig.java
@@ -28,14 +28,24 @@ package net.runelite.client.plugins.loottracker;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.ConfigSection;
 
 @ConfigGroup("loottracker")
 public interface LootTrackerConfig extends Config
 {
+	@ConfigSection(
+		name = "Ignored Entries",
+		description = "The Ignore items and Ignore groups options",
+		position = -2,
+		closedByDefault = true
+	)
+	String ignored = "ignored";
+
 	@ConfigItem(
 		keyName = "ignoredItems",
 		name = "Ignored items",
-		description = "Configures which items should be ignored when calculating loot prices."
+		description = "Configures which items should be ignored when calculating loot prices.",
+		section = ignored
 	)
 	default String getIgnoredItems()
 	{
@@ -94,7 +104,8 @@ public interface LootTrackerConfig extends Config
 	@ConfigItem(
 		keyName = "ignoredEvents",
 		name = "Ignored Loot Sources",
-		description = "Hide specific NPCs or sources of loot in the loot tracker (e.g., Goblin, Barrows Chest, H.A.M. Member)."
+		description = "Hide specific NPCs or sources of loot in the loot tracker (e.g., Goblin, Barrows Chest, H.A.M. Member).",
+		section = ignored
 	)
 	default String getIgnoredEvents()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -27,15 +27,49 @@ package net.runelite.client.plugins.menuentryswapper;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.ConfigSection;
 
 @ConfigGroup("menuentryswapper")
 public interface MenuEntrySwapperConfig extends Config
 {
+	@ConfigSection(
+		name = "Item Swaps",
+		description = "All options that swap item menu entries",
+		position = 0,
+		closedByDefault = true
+	)
+	String itemSection = "items";
+
+	@ConfigSection(
+		name = "NPC Swaps",
+		description = "All options that swap NPC menu entries",
+		position = 1,
+		closedByDefault = true
+	)
+	String npcSection = "npcs";
+
+	@ConfigSection(
+		name = "Object Swaps",
+		description = "All options that swap object menu entries",
+		position = 2,
+		closedByDefault = true
+	)
+	String objectSection = "objects";
+
+	@ConfigSection(
+		name = "UI Swaps",
+		description = "All options that swap entries in the UI (except Items)",
+		position = 3,
+		closedByDefault = true
+	)
+	String uiSection = "ui";
+
 	@ConfigItem(
 		position = -2,
 		keyName = "shiftClickCustomization",
 		name = "Customizable shift-click",
-		description = "Allows customization of shift-clicks on items"
+		description = "Allows customization of shift-clicks on items",
+		section = itemSection
 	)
 	default boolean shiftClickCustomization()
 	{
@@ -45,7 +79,8 @@ public interface MenuEntrySwapperConfig extends Config
 	@ConfigItem(
 		keyName = "swapAdmire",
 		name = "Admire",
-		description = "Swap Admire with Teleport, Spellbook and Perks (max cape) for mounted skill capes."
+		description = "Swap Admire with Teleport, Spellbook and Perks (max cape) for mounted skill capes.",
+		section = objectSection
 	)
 	default boolean swapAdmire()
 	{
@@ -55,7 +90,8 @@ public interface MenuEntrySwapperConfig extends Config
 	@ConfigItem(
 		keyName = "swapAssignment",
 		name = "Assignment",
-		description = "Swap Talk-to with Assignment for Slayer Masters. This will take priority over swapping Trade."
+		description = "Swap Talk-to with Assignment for Slayer Masters. This will take priority over swapping Trade.",
+		section = npcSection
 	)
 	default boolean swapAssignment()
 	{
@@ -65,7 +101,8 @@ public interface MenuEntrySwapperConfig extends Config
 	@ConfigItem(
 		keyName = "swapBanker",
 		name = "Bank",
-		description = "Swap Talk-to with Bank on Bank NPC<br>Example: Banker"
+		description = "Swap Talk-to with Bank on Bank NPC<br>Example: Banker",
+		section = npcSection
 	)
 	default boolean swapBank()
 	{
@@ -75,7 +112,8 @@ public interface MenuEntrySwapperConfig extends Config
 	@ConfigItem(
 		keyName = "swapBirdhouseEmpty",
 		name = "Birdhouse",
-		description = "Swap Interact with Empty for birdhouses on Fossil Island"
+		description = "Swap Interact with Empty for birdhouses on Fossil Island",
+		section = objectSection
 	)
 	default boolean swapBirdhouseEmpty()
 	{
@@ -85,7 +123,8 @@ public interface MenuEntrySwapperConfig extends Config
 	@ConfigItem(
 		keyName = "swapBones",
 		name = "Bury",
-		description = "Swap Bury with Use on Bones"
+		description = "Swap Bury with Use on Bones",
+		section = itemSection
 	)
 	default boolean swapBones()
 	{
@@ -95,7 +134,8 @@ public interface MenuEntrySwapperConfig extends Config
 	@ConfigItem(
 		keyName = "swapContract",
 		name = "Contract",
-		description = "Swap Talk-to with Contract on Guildmaster Jane"
+		description = "Swap Talk-to with Contract on Guildmaster Jane",
+		section = npcSection
 	)
 	default boolean swapContract()
 	{
@@ -105,7 +145,8 @@ public interface MenuEntrySwapperConfig extends Config
 	@ConfigItem(
 		keyName = "swapChase",
 		name = "Chase",
-		description = "Allows to left click your cat to chase"
+		description = "Allows to left click your cat to chase",
+		section = npcSection
 	)
 	default boolean swapChase()
 	{
@@ -115,7 +156,8 @@ public interface MenuEntrySwapperConfig extends Config
 	@ConfigItem(
 		keyName = "claimSlime",
 		name = "Claim Slime",
-		description = "Swap Talk-to with Claim Slime from Morytania diaries"
+		description = "Swap Talk-to with Claim Slime from Morytania diaries",
+		section = npcSection
 	)
 	default boolean claimSlime()
 	{
@@ -125,7 +167,8 @@ public interface MenuEntrySwapperConfig extends Config
 	@ConfigItem(
 		keyName = "swapDarkMage",
 		name = "Repairs",
-		description = "Swap Talk-to with Repairs for Dark Mage"
+		description = "Swap Talk-to with Repairs for Dark Mage",
+		section = npcSection
 	)
 	default boolean swapDarkMage()
 	{
@@ -135,7 +178,8 @@ public interface MenuEntrySwapperConfig extends Config
 	@ConfigItem(
 		keyName = "swapCaptainKhaled",
 		name = "Task",
-		description = "Swap Talk-to with Task for Captain Khaled in Port Piscarilius"
+		description = "Swap Talk-to with Task for Captain Khaled in Port Piscarilius",
+		section = npcSection
 	)
 	default boolean swapCaptainKhaled()
 	{
@@ -145,7 +189,8 @@ public interface MenuEntrySwapperConfig extends Config
 	@ConfigItem(
 		keyName = "swapDecant",
 		name = "Decant",
-		description = "Swap Talk-to with Decant for Bob Barter and Murky Matt at the Grand Exchange."
+		description = "Swap Talk-to with Decant for Bob Barter and Murky Matt at the Grand Exchange.",
+		section = npcSection
 	)
 	default boolean swapDecant()
 	{
@@ -155,7 +200,8 @@ public interface MenuEntrySwapperConfig extends Config
 	@ConfigItem(
 		keyName = "swapExchange",
 		name = "Exchange",
-		description = "Swap Talk-to with Exchange on NPC<br>Example: Grand Exchange Clerk, Tool Leprechaun, Void Knight"
+		description = "Swap Talk-to with Exchange on NPC<br>Example: Grand Exchange Clerk, Tool Leprechaun, Void Knight",
+		section = npcSection
 	)
 	default boolean swapExchange()
 	{
@@ -165,7 +211,8 @@ public interface MenuEntrySwapperConfig extends Config
 	@ConfigItem(
 		keyName = "swapFairyRing",
 		name = "Fairy ring",
-		description = "Swap Zanaris with Last-destination or Configure on Fairy rings"
+		description = "Swap Zanaris with Last-destination or Configure on Fairy rings",
+		section = objectSection
 	)
 	default FairyRingMode swapFairyRing()
 	{
@@ -185,7 +232,8 @@ public interface MenuEntrySwapperConfig extends Config
 	@ConfigItem(
 		keyName = "swapHarpoon",
 		name = "Harpoon",
-		description = "Swap Cage, Big Net with Harpoon on Fishing spot"
+		description = "Swap Cage, Big Net with Harpoon on Fishing spot",
+		section = objectSection
 	)
 	default boolean swapHarpoon()
 	{
@@ -195,7 +243,8 @@ public interface MenuEntrySwapperConfig extends Config
 	@ConfigItem(
 		keyName = "swapHelp",
 		name = "Help",
-		description = "Swap Talk-to with Help on Arceuus library customers"
+		description = "Swap Talk-to with Help on Arceuus library customers",
+		section = npcSection
 	)
 	default boolean swapHelp()
 	{
@@ -205,7 +254,8 @@ public interface MenuEntrySwapperConfig extends Config
 	@ConfigItem(
 		keyName = "swapHomePortal",
 		name = "Home",
-		description = "Swap Enter with Home or Build or Friend's house on Portal"
+		description = "Swap Enter with Home or Build or Friend's house on Portal",
+		section = objectSection
 	)
 	default HouseMode swapHomePortal()
 	{
@@ -215,7 +265,8 @@ public interface MenuEntrySwapperConfig extends Config
 	@ConfigItem(
 		keyName = "swapHouseAdvertisement",
 		name = "House Advertisement",
-		description = "Swap View with Add-House or Visit-Last on House Advertisement board"
+		description = "Swap View with Add-House or Visit-Last on House Advertisement board",
+		section = objectSection
 	)
 	default HouseAdvertisementMode swapHouseAdvertisement()
 	{
@@ -225,7 +276,8 @@ public interface MenuEntrySwapperConfig extends Config
 	@ConfigItem(
 		keyName = "swapPay",
 		name = "Pay",
-		description = "Swap Talk-to with Pay on NPC<br>Example: Elstan, Heskel, Fayeth"
+		description = "Swap Talk-to with Pay on NPC<br>Example: Elstan, Heskel, Fayeth",
+		section = npcSection
 	)
 	default boolean swapPay()
 	{
@@ -235,7 +287,8 @@ public interface MenuEntrySwapperConfig extends Config
 	@ConfigItem(
 		keyName = "swapJewelleryBox",
 		name = "Jewellery Box",
-		description = "Swap Teleport Menu with previous destination on Jewellery Box"
+		description = "Swap Teleport Menu with previous destination on Jewellery Box",
+		section = objectSection
 	)
 	default boolean swapJewelleryBox()
 	{
@@ -245,7 +298,8 @@ public interface MenuEntrySwapperConfig extends Config
 	@ConfigItem(
 		keyName = "swapPrivate",
 		name = "Private",
-		description = "Swap Shared with Private on the Chambers of Xeric storage units."
+		description = "Swap Shared with Private on the Chambers of Xeric storage units.",
+		section = objectSection
 	)
 	default boolean swapPrivate()
 	{
@@ -255,7 +309,8 @@ public interface MenuEntrySwapperConfig extends Config
 	@ConfigItem(
 		keyName = "swapPick",
 		name = "Pick",
-		description = "Swap Pick with Pick-lots of the Gourd tree in the Chambers of Xeric"
+		description = "Swap Pick with Pick-lots of the Gourd tree in the Chambers of Xeric",
+		section = objectSection
 	)
 	default boolean swapPick()
 	{
@@ -265,7 +320,8 @@ public interface MenuEntrySwapperConfig extends Config
 	@ConfigItem(
 		keyName = "swapQuick",
 		name = "Quick Pass/Open/Start/Travel",
-		description = "Swap Pass with Quick-Pass, Open with Quick-Open, Ring with Quick-Start and Talk-to with Quick-Travel"
+		description = "Swap Pass with Quick-Pass, Open with Quick-Open, Ring with Quick-Start and Talk-to with Quick-Travel",
+		section = objectSection
 	)
 	default boolean swapQuick()
 	{
@@ -275,7 +331,8 @@ public interface MenuEntrySwapperConfig extends Config
 	@ConfigItem(
 		keyName = "swapBoxTrap",
 		name = "Reset",
-		description = "Swap Check with Reset on box trap"
+		description = "Swap Check with Reset on box trap",
+		section = objectSection
 	)
 	default boolean swapBoxTrap()
 	{
@@ -285,7 +342,8 @@ public interface MenuEntrySwapperConfig extends Config
 	@ConfigItem(
 		keyName = "swapTeleportItem",
 		name = "Teleport item",
-		description = "Swap Wear, Wield with Rub, Teleport on teleport item<br>Example: Amulet of glory, Explorer's ring, Chronicle"
+		description = "Swap Wear, Wield with Rub, Teleport on teleport item<br>Example: Amulet of glory, Explorer's ring, Chronicle",
+		section = itemSection
 	)
 	default boolean swapTeleportItem()
 	{
@@ -295,7 +353,8 @@ public interface MenuEntrySwapperConfig extends Config
 	@ConfigItem(
 		keyName = "swapAbyssTeleport",
 		name = "Teleport to Abyss",
-		description = "Swap Talk-to with Teleport for the Mage of Zamorak"
+		description = "Swap Talk-to with Teleport for the Mage of Zamorak",
+		section = npcSection
 	)
 	default boolean swapAbyssTeleport()
 	{
@@ -305,7 +364,8 @@ public interface MenuEntrySwapperConfig extends Config
 	@ConfigItem(
 		keyName = "swapTrade",
 		name = "Trade",
-		description = "Swap Talk-to with Trade on NPC<br>Example: Shop keeper, Shop assistant"
+		description = "Swap Talk-to with Trade on NPC<br>Example: Shop keeper, Shop assistant",
+		section = npcSection
 	)
 	default boolean swapTrade()
 	{
@@ -315,7 +375,8 @@ public interface MenuEntrySwapperConfig extends Config
 	@ConfigItem(
 		keyName = "swapTravel",
 		name = "Travel",
-		description = "Swap Talk-to with Travel, Take-boat, Pay-fare, Charter on NPC<br>Example: Squire, Monk of Entrana, Customs officer, Trader Crewmember"
+		description = "Swap Talk-to with Travel, Take-boat, Pay-fare, Charter on NPC<br>Example: Squire, Monk of Entrana, Customs officer, Trader Crewmember",
+		section = npcSection
 	)
 	default boolean swapTravel()
 	{
@@ -325,7 +386,8 @@ public interface MenuEntrySwapperConfig extends Config
 	@ConfigItem(
 		keyName = "swapEnchant",
 		name = "Enchant",
-		description = "Swap Talk-to with Enchant for Eluned"
+		description = "Swap Talk-to with Enchant for Eluned",
+		section = npcSection
 	)
 	default boolean swapEnchant()
 	{
@@ -335,7 +397,8 @@ public interface MenuEntrySwapperConfig extends Config
 	@ConfigItem(
 		keyName = "swapTeleportSpell",
 		name = "Shift-click teleport spells",
-		description = "Swap teleport spells that have a second destination on shift"
+		description = "Swap teleport spells that have a second destination on shift",
+		section = uiSection
 	)
 	default boolean swapTeleportSpell()
 	{
@@ -345,7 +408,8 @@ public interface MenuEntrySwapperConfig extends Config
 	@ConfigItem(
 		keyName = "swapStartMinigame",
 		name = "Pyramid Plunder Start-minigame",
-		description = "Swap Talk-to with Start-minigame at the Guardian Mummy"
+		description = "Swap Talk-to with Start-minigame at the Guardian Mummy",
+		section = npcSection
 	)
 	default boolean swapStartMinigame()
 	{
@@ -355,7 +419,8 @@ public interface MenuEntrySwapperConfig extends Config
 	@ConfigItem(
 		keyName = "swapQuickleave",
 		name = "Quick-Leave",
-		description = "Swap Leave Tomb with Quick-Leave at Pyramid Plunder"
+		description = "Swap Leave Tomb with Quick-Leave at Pyramid Plunder",
+		section = objectSection
 	)
 	default boolean swapQuickLeave()
 	{
@@ -365,7 +430,8 @@ public interface MenuEntrySwapperConfig extends Config
 	@ConfigItem(
 		keyName = "swapGEItemCollect",
 		name = "GE Item Collect",
-		description = "Swap Collect-notes, Collect-items, or Bank options from GE offer"
+		description = "Swap Collect-notes, Collect-items, or Bank options from GE offer",
+		section = uiSection
 	)
 	default GEItemCollectMode swapGEItemCollect()
 	{
@@ -376,6 +442,8 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapGEAbort",
 		name = "GE Abort",
 		description = "Swap abort offer on Grand Exchange offers when shift-clicking"
+		,
+		section = uiSection
 	)
 	default boolean swapGEAbort()
 	{
@@ -385,7 +453,8 @@ public interface MenuEntrySwapperConfig extends Config
 	@ConfigItem(
 		keyName = "swapNpcContact",
 		name = "NPC Contact",
-		description = "Swap NPC Contact with last contacted NPC when shift-clicking"
+		description = "Swap NPC Contact with last contacted NPC when shift-clicking",
+		section = uiSection
 	)
 	default boolean swapNpcContact()
 	{
@@ -395,7 +464,8 @@ public interface MenuEntrySwapperConfig extends Config
 	@ConfigItem(
 		keyName = "bankWithdrawShiftClick",
 		name = "Bank Withdraw Shift-Click",
-		description = "Swaps the behavior of shift-click when withdrawing from bank."
+		description = "Swaps the behavior of shift-click when withdrawing from bank.",
+		section = itemSection
 	)
 	default ShiftWithdrawMode bankWithdrawShiftClick()
 	{
@@ -405,7 +475,8 @@ public interface MenuEntrySwapperConfig extends Config
 	@ConfigItem(
 		keyName = "bankDepositShiftClick",
 		name = "Bank Deposit Shift-Click",
-		description = "Swaps the behavior of shift-click when depositing to bank."
+		description = "Swaps the behavior of shift-click when depositing to bank.",
+		section = itemSection
 	)
 	default ShiftDepositMode bankDepositShiftClick()
 	{
@@ -415,7 +486,8 @@ public interface MenuEntrySwapperConfig extends Config
 	@ConfigItem(
 		keyName = "shopBuy",
 		name = "Shop Buy Shift-Click",
-		description = "Swaps the Buy options with Value on items in shops when shift is held."
+		description = "Swaps the Buy options with Value on items in shops when shift is held.",
+		section = uiSection
 	)
 	default BuyMode shopBuy()
 	{
@@ -425,7 +497,8 @@ public interface MenuEntrySwapperConfig extends Config
 	@ConfigItem(
 		keyName = "shopSell",
 		name = "Shop Sell Shift-Click",
-		description = "Swaps the Sell options with Value on items in your inventory when selling to shops when shift is held."
+		description = "Swaps the Sell options with Value on items in your inventory when selling to shops when shift is held.",
+		section = uiSection
 	)
 	default SellMode shopSell()
 	{
@@ -435,7 +508,8 @@ public interface MenuEntrySwapperConfig extends Config
 	@ConfigItem(
 		keyName = "swapEssenceMineTeleport",
 		name = "Essence Mine Teleport",
-		description = "Swaps Talk-To with Teleport for NPCs which teleport you to the essence mine"
+		description = "Swaps Talk-To with Teleport for NPCs which teleport you to the essence mine",
+		section = npcSection
 	)
 	default boolean swapEssenceMineTeleport()
 	{
@@ -445,7 +519,8 @@ public interface MenuEntrySwapperConfig extends Config
 	@ConfigItem(
 		keyName = "swapNets",
 		name = "Nets",
-		description = "Swap Talk-to with Nets on Annette"
+		description = "Swap Talk-to with Nets on Annette",
+		section = npcSection
 	)
 	default boolean swapNets()
 	{
@@ -455,7 +530,8 @@ public interface MenuEntrySwapperConfig extends Config
 	@ConfigItem(
 		keyName = "swapGauntlet",
 		name = "Corrupted Gauntlet",
-		description = "Swap Enter with Enter-corrupted when entering The Gauntlet"
+		description = "Swap Enter with Enter-corrupted when entering The Gauntlet",
+		section = objectSection
 	)
 	default boolean swapGauntlet()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -221,10 +221,22 @@ public interface MenuEntrySwapperConfig extends Config
 
 	@ConfigItem(
 		keyName = "swapHardWoodGrove",
-		name = "Hardwood Grove",
-		description = "Swap Quick-Pay(100) and Send-Parcel at Hardwood Grove"
+		name = "Hardwood Grove Quick-Pay",
+		description = "Swap Quick-Pay(100) at the Hardwood Grove",
+		section = objectSection
 	)
 	default boolean swapHardWoodGrove()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		keyName = "swapHardWoodGroveParcel",
+		name = "Hardwood Grove Send-Parcel",
+		description = "Swap Send-Parcel at the Hardwood Grove",
+		section = npcSection
+	)
+	default boolean swapHardWoodGroveParcel()
 	{
 		return true;
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -442,7 +442,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 				swap("teleport", option, target, index);
 			}
 
-			if (config.swapHardWoodGrove() && target.contains("rionasta"))
+			if (config.swapHardWoodGroveParcel() && target.contains("rionasta"))
 			{
 				swap("send-parcel", option, target, index);
 			}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsConfig.java
@@ -28,15 +28,24 @@ import java.awt.Color;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.ConfigSection;
 
 @ConfigGroup("playerindicators")
 public interface PlayerIndicatorsConfig extends Config
 {
+	@ConfigSection(
+		name = "Highlight Options",
+		description = "Toggle highlighted players by type (self, friends, etc.) and choose their highlight colors",
+		position = 99
+	)
+	String highlightSection = "section";
+
 	@ConfigItem(
 		position = 0,
 		keyName = "drawOwnName",
 		name = "Highlight own player",
-		description = "Configures whether or not your own player should be highlighted"
+		description = "Configures whether or not your own player should be highlighted",
+		section = highlightSection
 	)
 	default boolean highlightOwnPlayer()
 	{
@@ -47,7 +56,8 @@ public interface PlayerIndicatorsConfig extends Config
 		position = 1,
 		keyName = "ownNameColor",
 		name = "Own player color",
-		description = "Color of your own player"
+		description = "Color of your own player",
+		section = highlightSection
 	)
 	default Color getOwnPlayerColor()
 	{
@@ -58,7 +68,8 @@ public interface PlayerIndicatorsConfig extends Config
 		position = 2,
 		keyName = "drawFriendNames",
 		name = "Highlight friends",
-		description = "Configures whether or not friends should be highlighted"
+		description = "Configures whether or not friends should be highlighted",
+		section = highlightSection
 	)
 	default boolean highlightFriends()
 	{
@@ -69,7 +80,8 @@ public interface PlayerIndicatorsConfig extends Config
 		position = 3,
 		keyName = "friendNameColor",
 		name = "Friend color",
-		description = "Color of friend names"
+		description = "Color of friend names",
+		section = highlightSection
 	)
 	default Color getFriendColor()
 	{
@@ -80,7 +92,8 @@ public interface PlayerIndicatorsConfig extends Config
 		position = 4,
 		keyName = "drawClanMemberNames",
 		name = "Highlight clan members",
-		description = "Configures whether or clan members should be highlighted"
+		description = "Configures whether or clan members should be highlighted",
+		section = highlightSection
 	)
 	default boolean drawClanMemberNames()
 	{
@@ -91,7 +104,8 @@ public interface PlayerIndicatorsConfig extends Config
 		position = 5,
 		keyName = "clanMemberColor",
 		name = "Clan member color",
-		description = "Color of clan members"
+		description = "Color of clan members",
+		section = highlightSection
 	)
 	default Color getClanMemberColor()
 	{
@@ -102,7 +116,8 @@ public interface PlayerIndicatorsConfig extends Config
 		position = 6,
 		keyName = "drawTeamMemberNames",
 		name = "Highlight team members",
-		description = "Configures whether or not team members should be highlighted"
+		description = "Configures whether or not team members should be highlighted",
+		section = highlightSection
 	)
 	default boolean highlightTeamMembers()
 	{
@@ -113,7 +128,8 @@ public interface PlayerIndicatorsConfig extends Config
 		position = 7,
 		keyName = "teamMemberColor",
 		name = "Team member color",
-		description = "Color of team members"
+		description = "Color of team members",
+		section = highlightSection
 	)
 	default Color getTeamMemberColor()
 	{
@@ -124,7 +140,8 @@ public interface PlayerIndicatorsConfig extends Config
 		position = 8,
 		keyName = "drawNonClanMemberNames",
 		name = "Highlight non-clan members",
-		description = "Configures whether or not non-clan members should be highlighted"
+		description = "Configures whether or not non-clan members should be highlighted",
+		section = highlightSection
 	)
 	default boolean highlightNonClanMembers()
 	{
@@ -135,7 +152,8 @@ public interface PlayerIndicatorsConfig extends Config
 		position = 9,
 		keyName = "nonClanMemberColor",
 		name = "Non-clan member color",
-		description = "Color of non-clan member names"
+		description = "Color of non-clan member names",
+		section = highlightSection
 	)
 	default Color getNonClanMemberColor()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/randomevents/RandomEventConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/randomevents/RandomEventConfig.java
@@ -28,10 +28,18 @@ package net.runelite.client.plugins.randomevents;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.ConfigSection;
 
 @ConfigGroup("randomevents")
 public interface RandomEventConfig extends Config
 {
+	@ConfigSection(
+		name = "Notification Settings",
+		description = "Choose which random events will trigger notifications when spawned",
+		position = 99
+	)
+	String notificationSection = "section";
+
 	@ConfigItem(
 		keyName = "removeMenuOptions",
 		name = "Remove others' menu options",
@@ -47,7 +55,8 @@ public interface RandomEventConfig extends Config
 		keyName = "notifyDunce",
 		name = "Notify on Surprise Exam",
 		description = "",
-		position = 1
+		position = 1,
+		section = notificationSection
 	)
 	default boolean notifyDunce()
 	{
@@ -58,7 +67,8 @@ public interface RandomEventConfig extends Config
 		keyName = "notifyGenie",
 		name = "Notify on Genie",
 		description = "",
-		position = 2
+		position = 2,
+		section = notificationSection
 	)
 	default boolean notifyGenie()
 	{
@@ -69,7 +79,8 @@ public interface RandomEventConfig extends Config
 		keyName = "notifyDemon",
 		name = "Notify on Drill Demon",
 		description = "",
-		position = 3
+		position = 3,
+		section = notificationSection
 	)
 	default boolean notifyDemon()
 	{
@@ -80,7 +91,8 @@ public interface RandomEventConfig extends Config
 		keyName = "notifyForester",
 		name = "Notify on Freaky Forester",
 		description = "",
-		position = 4
+		position = 4,
+		section = notificationSection
 	)
 	default boolean notifyForester()
 	{
@@ -91,7 +103,8 @@ public interface RandomEventConfig extends Config
 		keyName = "notifyFrog",
 		name = "Notify on Kiss the Frog",
 		description = "",
-		position = 5
+		position = 5,
+		section = notificationSection
 	)
 	default boolean notifyFrog()
 	{
@@ -102,7 +115,8 @@ public interface RandomEventConfig extends Config
 		keyName = "notifyGravedigger",
 		name = "Notify on Gravedigger",
 		description = "",
-		position = 6
+		position = 6,
+		section = notificationSection
 	)
 	default boolean notifyGravedigger()
 	{
@@ -113,7 +127,8 @@ public interface RandomEventConfig extends Config
 		keyName = "notifyMoM",
 		name = "Notify on Mysterious Old Man",
 		description = "",
-		position = 7
+		position = 7,
+		section = notificationSection
 	)
 	default boolean notifyMoM()
 	{
@@ -124,7 +139,8 @@ public interface RandomEventConfig extends Config
 		keyName = "notifyBob",
 		name = "Notify on Evil Bob",
 		description = "",
-		position = 8
+		position = 8,
+		section = notificationSection
 	)
 	default boolean notifyBob()
 	{
@@ -135,7 +151,8 @@ public interface RandomEventConfig extends Config
 		keyName = "notifyQuiz",
 		name = "Notify on Quiz Master",
 		description = "",
-		position = 9
+		position = 9,
+		section = notificationSection
 	)
 	default boolean notifyQuiz()
 	{
@@ -146,7 +163,8 @@ public interface RandomEventConfig extends Config
 		keyName = "notifyAll",
 		name = "Notify for all events",
 		description = "",
-		position = 10
+		position = 10,
+		section = notificationSection
 	)
 	default boolean notifyAllEvents()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/runecraft/RunecraftConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/runecraft/RunecraftConfig.java
@@ -28,17 +28,38 @@ package net.runelite.client.plugins.runecraft;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.ConfigSection;
 
 @ConfigGroup("runecraft")
 public interface RunecraftConfig extends Config
 {
+	@ConfigSection(
+		name = "Rift Settings",
+		description = "Abyss rift overlay settings",
+		position = 99
+	)
+	String riftSection = "rifts";
+
 	@ConfigItem(
 		keyName = "showRifts",
 		name = "Show Rifts in Abyss",
 		description = "Configures whether the rifts in the abyss will be displayed",
-		position = 3
+		position = 2,
+		section = riftSection
 	)
 	default boolean showRifts()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		keyName = "showClickBox",
+		name = "Show Rift click box",
+		description = "Configures whether to display the click box of the rift",
+		position = 3,
+		section = riftSection
+	)
+	default boolean showClickBox()
 	{
 		return true;
 	}
@@ -47,7 +68,8 @@ public interface RunecraftConfig extends Config
 		keyName = "showAir",
 		name = "Show Air rift",
 		description = "Configures whether to display the air rift",
-		position = 4
+		position = 4,
+		section = riftSection
 	)
 	default boolean showAir()
 	{
@@ -69,7 +91,8 @@ public interface RunecraftConfig extends Config
 		keyName = "showBody",
 		name = "Show Body rift",
 		description = "Configures whether to display the Body rift",
-		position = 6
+		position = 6,
+		section = riftSection
 	)
 	default boolean showBody()
 	{
@@ -80,7 +103,8 @@ public interface RunecraftConfig extends Config
 		keyName = "showChaos",
 		name = "Show Chaos rift",
 		description = "Configures whether to display the Chaos rift",
-		position = 7
+		position = 7,
+		section = riftSection
 	)
 	default boolean showChaos()
 	{
@@ -91,7 +115,8 @@ public interface RunecraftConfig extends Config
 		keyName = "showCosmic",
 		name = "Show Cosmic rift",
 		description = "Configures whether to display the Cosmic rift",
-		position = 8
+		position = 8,
+		section = riftSection
 	)
 	default boolean showCosmic()
 	{
@@ -102,7 +127,8 @@ public interface RunecraftConfig extends Config
 		keyName = "showDeath",
 		name = "Show Death rift",
 		description = "Configures whether to display the Death rift",
-		position = 9
+		position = 9,
+		section = riftSection
 	)
 	default boolean showDeath()
 	{
@@ -113,7 +139,8 @@ public interface RunecraftConfig extends Config
 		keyName = "showEarth",
 		name = "Show Earth rift",
 		description = "Configures whether to display the Earth rift",
-		position = 10
+		position = 10,
+		section = riftSection
 	)
 	default boolean showEarth()
 	{
@@ -124,7 +151,8 @@ public interface RunecraftConfig extends Config
 		keyName = "showFire",
 		name = "Show Fire rift",
 		description = "Configures whether to display the Fire rift",
-		position = 11
+		position = 11,
+		section = riftSection
 	)
 	default boolean showFire()
 	{
@@ -135,7 +163,8 @@ public interface RunecraftConfig extends Config
 		keyName = "showLaw",
 		name = "Show Law rift",
 		description = "Configures whether to display the Law rift",
-		position = 12
+		position = 12,
+		section = riftSection
 	)
 	default boolean showLaw()
 	{
@@ -146,7 +175,8 @@ public interface RunecraftConfig extends Config
 		keyName = "showMind",
 		name = "Show Mind rift",
 		description = "Configures whether to display the Mind rift",
-		position = 13
+		position = 13,
+		section = riftSection
 	)
 	default boolean showMind()
 	{
@@ -157,7 +187,8 @@ public interface RunecraftConfig extends Config
 		keyName = "showNature",
 		name = "Show Nature rift",
 		description = "Configures whether to display the Nature rift",
-		position = 14
+		position = 14,
+		section = riftSection
 	)
 	default boolean showNature()
 	{
@@ -168,7 +199,8 @@ public interface RunecraftConfig extends Config
 		keyName = "showSoul",
 		name = "Show Soul rift",
 		description = "Configures whether to display the Soul rift",
-		position = 15
+		position = 15,
+		section = riftSection
 	)
 	default boolean showSoul()
 	{
@@ -179,20 +211,10 @@ public interface RunecraftConfig extends Config
 		keyName = "showWater",
 		name = "Show Water rift",
 		description = "Configures whether to display the Water rift",
-		position = 16
+		position = 16,
+		section = riftSection
 	)
 	default boolean showWater()
-	{
-		return true;
-	}
-
-	@ConfigItem(
-		keyName = "showClickBox",
-		name = "Show Rift click box",
-		description = "Configures whether to display the click box of the rift",
-		position = 17
-	)
-	default boolean showClickBox()
 	{
 		return true;
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotConfig.java
@@ -27,12 +27,20 @@ package net.runelite.client.plugins.screenshot;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.ConfigSection;
 import net.runelite.client.config.Keybind;
 import net.runelite.client.util.ImageUploadStyle;
 
 @ConfigGroup("screenshot")
 public interface ScreenshotConfig extends Config
 {
+	@ConfigSection(
+		name = "What to Screenshot",
+		description = "All the options that select what to screenshot",
+		position = 99
+	)
+	String whatSection = "what";
+
 	@ConfigItem(
 		keyName = "includeFrame",
 		name = "Include Client Frame",
@@ -70,7 +78,8 @@ public interface ScreenshotConfig extends Config
 		keyName = "rewards",
 		name = "Screenshot Rewards",
 		description = "Configures whether screenshots are taken of clues, barrows, and quest completion",
-		position = 3
+		position = 3,
+		section = whatSection
 	)
 	default boolean screenshotRewards()
 	{
@@ -81,7 +90,8 @@ public interface ScreenshotConfig extends Config
 		keyName = "levels",
 		name = "Screenshot Levels",
 		description = "Configures whether screenshots are taken of level ups",
-		position = 4
+		position = 4,
+		section = whatSection
 	)
 	default boolean screenshotLevels()
 	{
@@ -92,7 +102,8 @@ public interface ScreenshotConfig extends Config
 		keyName = "kingdom",
 		name = "Screenshot Kingdom Reward",
 		description = "Configures whether screenshots are taken of Kingdom Reward",
-		position = 5
+		position = 5,
+		section = whatSection
 	)
 	default boolean screenshotKingdom()
 	{
@@ -103,7 +114,8 @@ public interface ScreenshotConfig extends Config
 		keyName = "pets",
 		name = "Screenshot Pet",
 		description = "Configures whether screenshots are taken of receiving pets",
-		position = 6
+		position = 6,
+		section = whatSection
 	)
 	default boolean screenshotPet()
 	{
@@ -125,7 +137,8 @@ public interface ScreenshotConfig extends Config
 		keyName = "kills",
 		name = "Screenshot PvP Kills",
 		description = "Configures whether or not screenshots are automatically taken of PvP kills",
-		position = 8
+		position = 8,
+		section = whatSection
 	)
 	default boolean screenshotKills()
 	{
@@ -136,7 +149,8 @@ public interface ScreenshotConfig extends Config
 		keyName = "boss",
 		name = "Screenshot Boss Kills",
 		description = "Configures whether or not screenshots are automatically taken of boss kills",
-		position = 9
+		position = 9,
+		section = whatSection
 	)
 	default boolean screenshotBossKills()
 	{
@@ -147,7 +161,8 @@ public interface ScreenshotConfig extends Config
 		keyName = "playerDeath",
 		name = "Screenshot Deaths",
 		description = "Configures whether or not screenshots are automatically taken when you die.",
-		position = 10
+		position = 10,
+		section = whatSection
 	)
 	default boolean screenshotPlayerDeath()
 	{
@@ -158,7 +173,8 @@ public interface ScreenshotConfig extends Config
 		keyName = "friendDeath",
 		name = "Screenshot Friend Deaths",
 		description = "Configures whether or not screenshots are automatically taken when friends or clan members die.",
-		position = 11
+		position = 11,
+		section = whatSection
 	)
 	default boolean screenshotFriendDeath()
 	{
@@ -169,7 +185,8 @@ public interface ScreenshotConfig extends Config
 		keyName = "duels",
 		name = "Screenshot Duels",
 		description = "Configures whether or not screenshots are automatically taken of the duel end screen.",
-		position = 12
+		position = 12,
+		section = whatSection
 	)
 	default boolean screenshotDuels()
 	{
@@ -180,7 +197,8 @@ public interface ScreenshotConfig extends Config
 		keyName = "valuableDrop",
 		name = "Screenshot Valuable drops",
 		description = "Configures whether or not screenshots are automatically taken when you receive a valuable drop.",
-		position = 13
+		position = 13,
+		section = whatSection
 	)
 	default boolean screenshotValuableDrop()
 	{
@@ -191,7 +209,8 @@ public interface ScreenshotConfig extends Config
 		keyName = "untradeableDrop",
 		name = "Screenshot Untradeable drops",
 		description = "Configures whether or not screenshots are automatically taken when you receive an untradeable drop.",
-		position = 14
+		position = 14,
+		section = whatSection
 	)
 	default boolean screenshotUntradeableDrop()
 	{
@@ -202,7 +221,8 @@ public interface ScreenshotConfig extends Config
 		keyName = "ccKick",
 		name = "Screenshot Kicks from CC",
 		description = "Take a screenshot when you kick a user from a clan chat.",
-		position = 15
+		position = 15,
+		section = whatSection
 	)
 	default boolean screenshotCcKick()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerConfig.java
@@ -28,11 +28,19 @@ package net.runelite.client.plugins.xptracker;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.ConfigSection;
 import net.runelite.client.config.Units;
 
 @ConfigGroup("xpTracker")
 public interface XpTrackerConfig extends Config
 {
+	@ConfigSection(
+		name = "Overlay",
+		description = "Canvas overlay options",
+		position = 99
+	)
+	String overlaySection = "overlay";
+
 	@ConfigItem(
 		position = 0,
 		keyName = "hideMaxed",
@@ -82,7 +90,8 @@ public interface XpTrackerConfig extends Config
 		position = 4,
 		keyName = "skillTabOverlayMenuOptions",
 		name = "Add skill tab canvas menu option",
-		description = "Configures whether a menu option to show/hide canvas XP trackers will be added to skills on the skill tab"
+		description = "Configures whether a menu option to show/hide canvas XP trackers will be added to skills on the skill tab",
+		section = overlaySection
 	)
 	default boolean skillTabOverlayMenuOptions()
 	{
@@ -93,7 +102,8 @@ public interface XpTrackerConfig extends Config
 		position = 5,
 		keyName = "onScreenDisplayMode",
 		name = "On-screen tracker display mode (top)",
-		description = "Configures the information displayed in the first line of on-screen XP overlays"
+		description = "Configures the information displayed in the first line of on-screen XP overlays",
+		section = overlaySection
 	)
 	default XpPanelLabel onScreenDisplayMode()
 	{
@@ -104,7 +114,8 @@ public interface XpTrackerConfig extends Config
 		position = 6,
 		keyName = "onScreenDisplayModeBottom",
 		name = "On-screen tracker display mode (bottom)",
-		description = "Configures the information displayed in the second line of on-screen XP overlays"
+		description = "Configures the information displayed in the second line of on-screen XP overlays",
+		section = overlaySection
 	)
 	default XpPanelLabel onScreenDisplayModeBottom()
 	{


### PR DESCRIPTION
Closes #11602

Certain configs have always been begging for some form of section system. When merging multiple plugins together, being able to separate their options would be very useful.

Sections can be toggled by clicking anywhere on them, and are persisted through the config. It is possible to nest configs inside one another. Each level of nesting adds a small but noticeable margin on the left side.

I have added sections to Chat Color (which desperately needed it) to show users that there are 2 sets of options, and to Ground Items to hide potentially gigantic item lists.

Feedback on the design of the sections is very much appreciated

![](https://giant.gfycat.com/FlakyFittingBumblebee.gif)

(Above gif is outdated, as the text is now RL orange. See comments below)