### PR TITLE
opponentinfo: Track NPCs which spawn and attack simultaneously

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/opponentinfo/OpponentInfoPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/opponentinfo/OpponentInfoPlugin.java
@@ -149,13 +149,21 @@ public class OpponentInfoPlugin extends Plugin
 	@Subscribe
 	public void onGameTick(GameTick gameTick)
 	{
-		if (lastOpponent != null
-			&& lastTime != null
-			&& client.getLocalPlayer().getInteracting() == null)
+		if (lastOpponent != null)
 		{
-			if (Duration.between(lastTime, Instant.now()).compareTo(WAIT) > 0)
+			if (lastTime != null
+				&& client.getLocalPlayer().getInteracting() == null
+				&& Duration.between(lastTime, Instant.now()).compareTo(WAIT) > 0)
 			{
 				lastOpponent = null;
+			}
+		}
+		else
+		{
+			lastOpponent = client.getLocalPlayer().getInteracting();
+			if (lastOpponent != null)
+			{
+				lastTime = Instant.now();
 			}
 		}
 	}


### PR DESCRIPTION
When being attacked by an NPC which spawned on the same tick it attacks
(an example being the Double agent when doing emote clues), if a player's
auto-retaliate is on, the plugin would not properly identify the
NPC as being attacked because it would be `null` when the player's
interacting changed. This is fixed by reassigning the last tracked
opponent to the current interacted NPC if it was null.

Fixes runelite/runelite#6425