### PR TITLE
Fix loot tracker order on client reload

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPanel.java
@@ -378,7 +378,7 @@ class LootTrackerPanel extends PluginPanel
 	void add(final String eventName, final int actorLevel, LootTrackerItem[] items)
 	{
 		final String subTitle = actorLevel > -1 ? "(lvl-" + actorLevel + ")" : "";
-		final LootTrackerRecord record = new LootTrackerRecord(eventName, subTitle, items, System.currentTimeMillis());
+		final LootTrackerRecord record = new LootTrackerRecord(eventName, subTitle, items);
 		records.add(record);
 		LootTrackerBox box = buildBox(record);
 		if (box != null)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
@@ -614,7 +614,7 @@ public class LootTrackerPlugin extends Plugin
 				buildLootTrackerItem(itemStack.getId(), itemStack.getQty())
 			).toArray(LootTrackerItem[]::new);
 
-			trackerRecords.add(new LootTrackerRecord(record.getEventId(), "", drops, -1));
+			trackerRecords.add(new LootTrackerRecord(record.getEventId(), "", drops));
 		}
 
 		return trackerRecords;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
@@ -37,6 +37,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -607,17 +608,17 @@ public class LootTrackerPlugin extends Plugin
 
 	private Collection<LootTrackerRecord> convertToLootTrackerRecord(final Collection<LootRecord> records)
 	{
-		Collection<LootTrackerRecord> trackerRecords = new ArrayList<>();
-		for (LootRecord record : records)
-		{
-			LootTrackerItem[] drops = record.getDrops().stream().map(itemStack ->
-				buildLootTrackerItem(itemStack.getId(), itemStack.getQty())
-			).toArray(LootTrackerItem[]::new);
+		return records.stream()
+			.sorted(Comparator.comparing(LootRecord::getTime))
+			.map(record ->
+			{
+				LootTrackerItem[] drops = record.getDrops().stream().map(itemStack ->
+					buildLootTrackerItem(itemStack.getId(), itemStack.getQty())
+				).toArray(LootTrackerItem[]::new);
 
-			trackerRecords.add(new LootTrackerRecord(record.getEventId(), "", drops));
-		}
-
-		return trackerRecords;
+				return new LootTrackerRecord(record.getEventId(), "", drops);
+			})
+			.collect(Collectors.toCollection(ArrayList::new));
 	}
 
 	/**

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerRecord.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerRecord.java
@@ -32,7 +32,6 @@ class LootTrackerRecord
 	private final String title;
 	private final String subTitle;
 	private final LootTrackerItem[] items;
-	private final long timestamp;
 
 	/**
 	 * Checks if this record matches specified id


### PR DESCRIPTION
The panel is currently rebuilt with the earliest loots at the top.
For consistency's sake it should be the other way around.

Closes #9575