### PR TITLE
colorpicker: force hex color to update on window close

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ui/components/colorpicker/RuneliteColorPicker.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/components/colorpicker/RuneliteColorPicker.java
@@ -298,6 +298,9 @@ public class RuneliteColorPicker extends JDialog
 			@Override
 			public void windowClosing(WindowEvent e)
 			{
+				//  force update hex color because focus lost events fire after window closing
+				updateHex();
+
 				if (onClose != null)
 				{
 					onClose.accept(selectedColor);


### PR DESCRIPTION
Closes #9587 

Bug occured because focus lost events are fired after the window closing event in Swing. Thus the selected color wasn't updated yet.