### PR TITLE
update Prifddinas agility course xp values to fix lap counter

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/agility/Courses.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/agility/Courses.java
@@ -46,7 +46,7 @@ enum Courses
 	SEERS(570.0, 435, 10806),
 	POLLNIVNEACH(890.0, 540, 13358),
 	RELLEKA(780.0, 475, 10553),
-	PRIFDDINAS(1199.0, 968, 12895),
+	PRIFDDINAS(1285.2, 1037, 12895),
 	ARDOUGNE(793.0, 529, 10547);
 
 	private final static Map<Integer, Courses> coursesByRegion;


### PR DESCRIPTION
Last game update changed the xp rewarded for the last obstacle.
Due to this change, the lap counter would not show on the Prifddinas agility course.

By changing the xp values this problem is solved.