### PR TITLE
Default option for teleport crystal changed to prifddinas

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -301,4 +301,12 @@ public interface MenuEntrySwapperConfig extends Config
 	{
 		return true;
 	}
+
+	@ConfigItem(
+			keyName = "swapTeleportCrystal",
+			name = "Teleport Crystal",
+			description = "Swap the default teleport crystal location from Lletya to Prifddinas"
+	)
+	default boolean swapCrystal() {return true; }
+
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -371,6 +371,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 			return;
 		}
 
+
 		if (option.equals("talk-to"))
 		{
 			if (config.swapPickpocket() && target.contains("h.a.m."))
@@ -593,6 +594,11 @@ public class MenuEntrySwapperPlugin extends Plugin
 		else if (config.swapBones() && option.equals("bury"))
 		{
 			swap("use", option, target, true);
+		}
+
+		if (config.swapCrystal() && option.equals("lletya"))
+		{
+			swap("prifddinas", option, target, true);
 		}
 	}
 


### PR DESCRIPTION
Thought it'd be nice to have a toggle for the teleport crystal now that prifddinas is accessible, and most people post-SOTE are probably only travelling to prif now