### PR TITLE
Reset skill states when starting XpTracker

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerPlugin.java
@@ -142,6 +142,11 @@ public class XpTrackerPlugin extends Plugin
 	{
 		xpPanel = new XpPanel(this, xpTrackerConfig, client, skillIconManager);
 
+		for (Skill skill : Skill.values())
+		{
+			resetSkillState(skill);
+		}
+
 		final BufferedImage icon = ImageUtil.getResourceStreamFromClass(getClass(), "/skill_icons/overall.png");
 
 		navButton = NavigationButton.builder()


### PR DESCRIPTION
When resetting the XpState on startup I was unable to reproduce the issue and everything works as expected.

Closes #9089  