### PR TITLE
LootTracker: Add Kingdom of Miscellania

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/InventoryID.java
+++ b/runelite-api/src/main/java/net/runelite/api/InventoryID.java
@@ -54,7 +54,7 @@ public enum InventoryID
 	 */
 	MONKEY_MADNESS_PUZZLE_BOX(221),
 	/**
-	 * Kingdom Of Miscellania reward inventory
+	 * Kingdom Of Miscellania reward inventory.
 	 */
 	KINGDOM_OF_MISCELLANIA(390),
 	/**

--- a/runelite-api/src/main/java/net/runelite/api/InventoryID.java
+++ b/runelite-api/src/main/java/net/runelite/api/InventoryID.java
@@ -54,6 +54,10 @@ public enum InventoryID
 	 */
 	MONKEY_MADNESS_PUZZLE_BOX(221),
 	/**
+	 * Kingdom Of Miscellania reward inventory
+	 */
+	KINGDOM_OF_MISCELLANIA(390),
+	/**
 	 * Chambers of Xeric chest inventory.
 	 */
 	CHAMBERS_OF_XERIC_CHEST(581),

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
@@ -391,6 +391,10 @@ public class LootTrackerPlugin extends Plugin
 				// Clue Scrolls use same InventoryID as Barrows
 				container = client.getItemContainer(InventoryID.BARROWS_REWARD);
 				break;
+			case (WidgetID.KINGDOM_GROUP_ID):
+				eventType = "Kingdom of Miscellania";
+				container = client.getItemContainer(InventoryID.KINGDOM_OF_MISCELLANIA);
+				break;
 			default:
 				return;
 		}


### PR DESCRIPTION
saw some inventory checks have region checks but not 100% sure as to why. I got the region id for managing miscellania (10044) and can add if needed.

![image](https://user-images.githubusercontent.com/5316046/62601705-d8a0a780-b8a6-11e9-9b8b-29d91acb1016.png)
