### PR TITLE
Disable inventory grid if the dragged item is removed

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/inventorygrid/InventoryGridOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/inventorygrid/InventoryGridOverlay.java
@@ -79,6 +79,14 @@ class InventoryGridOverlay extends Overlay
 
 		final net.runelite.api.Point mouse = client.getMouseCanvasPosition();
 		final Point mousePoint = new Point(mouse.getX(), mouse.getY());
+		final int if1DraggedItemIndex = client.getIf1DraggedItemIndex();
+		final WidgetItem draggedItem = inventoryWidget.getWidgetItem(if1DraggedItemIndex);
+		final int itemId = draggedItem.getId();
+
+		if (itemId == -1)
+		{
+			return null;
+		}
 
 		for (int i = 0; i < INVENTORY_SIZE; ++i)
 		{
@@ -89,8 +97,7 @@ class InventoryGridOverlay extends Overlay
 
 			if (config.showItem() && inBounds)
 			{
-				final WidgetItem draggedItem = inventoryWidget.getWidgetItem(client.getIf1DraggedItemIndex());
-				final BufferedImage draggedItemImage = itemManager.getImage(draggedItem.getId());
+				final BufferedImage draggedItemImage = itemManager.getImage(itemId);
 				final int x = (int) bounds.getX();
 				final int y = (int) bounds.getY();
 


### PR DESCRIPTION
When dragging an item and its original slot gets emptied, the dragged item sprite is removed to indicate that you are no longer dragging an item. The inventory grid should be held to the same standard.

Closes #9053 