### PR TITLE
bank plugin: improve responsiveness of bank searches

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/ScriptID.java
+++ b/runelite-api/src/main/java/net/runelite/api/ScriptID.java
@@ -271,4 +271,13 @@ public final class ScriptID
 	 */
 	@ScriptArguments(integer = 7)
 	public static final int IGNORE_UPDATE = 630;
+
+	/**
+	 * Called in an onTimer, determines whether to layout the bank during a search
+	 * <ul>
+	 * <li> int (WidgetID) * 16, various widgets making up the bank interface </li>
+	 * </ul>
+	 */
+	@ScriptArguments(integer = 16)
+	public static final int BANKMAIN_SEARCH_REFRESH = 283;
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/bank/BankPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/bank/BankPlugin.java
@@ -45,11 +45,14 @@ import net.runelite.api.ItemComposition;
 import net.runelite.api.ItemContainer;
 import net.runelite.api.ItemID;
 import net.runelite.api.MenuEntry;
+import net.runelite.api.ScriptID;
+import net.runelite.api.VarClientStr;
 import net.runelite.api.Varbits;
 import net.runelite.api.events.ItemContainerChanged;
 import net.runelite.api.events.MenuEntryAdded;
 import net.runelite.api.events.MenuShouldLeftClick;
 import net.runelite.api.events.ScriptCallbackEvent;
+import net.runelite.api.events.ScriptPostFired;
 import net.runelite.api.events.WidgetLoaded;
 import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetID;
@@ -115,6 +118,7 @@ public class BankPlugin extends Plugin
 
 	private boolean forceRightClickFlag;
 	private Multiset<Integer> itemQuantities; // bank item quantities for bank value search
+	private String searchString;
 
 	@Provides
 	BankConfig getConfig(ConfigManager configManager)
@@ -128,6 +132,7 @@ public class BankPlugin extends Plugin
 		clientThread.invokeLater(() -> bankSearch.reset(false));
 		forceRightClickFlag = false;
 		itemQuantities = null;
+		searchString = null;
 	}
 
 	@Subscribe
@@ -207,6 +212,24 @@ public class BankPlugin extends Plugin
 		}
 
 		updateSeedVaultTotal();
+	}
+
+	@Subscribe
+	public void onScriptPostFired(ScriptPostFired event)
+	{
+		if (event.getScriptId() != ScriptID.BANKMAIN_SEARCH_REFRESH)
+		{
+			return;
+		}
+
+		// vanilla only lays out the bank every 40 client ticks, so if the search input has changed,
+		// and the bank wasn't laid out this tick, lay it out early
+		final String inputText = client.getVar(VarClientStr.INPUT_TEXT);
+		if (searchString != inputText && client.getGameCycle() % 40 != 0)
+		{
+			clientThread.invokeLater(bankSearch::layoutBank);
+			searchString = inputText;
+		}
 	}
 
 	@Subscribe

--- a/runelite-client/src/main/java/net/runelite/client/plugins/banktags/tabs/BankSearch.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/banktags/tabs/BankSearch.java
@@ -54,19 +54,6 @@ public class BankSearch
 	{
 		clientThread.invoke(() ->
 		{
-			Widget bankContainer = client.getWidget(WidgetInfo.BANK_ITEM_CONTAINER);
-			if (bankContainer == null || bankContainer.isHidden())
-			{
-				return;
-			}
-
-			Object[] scriptArgs = bankContainer.getOnInvTransmitListener();
-
-			if (scriptArgs == null)
-			{
-				return;
-			}
-
 			// This ensures that any chatbox input (e.g from search) will not remain visible when
 			// selecting/changing tab
 			if (closeInput)
@@ -77,8 +64,25 @@ public class BankSearch
 			client.setVar(VarClientInt.INPUT_TYPE, inputType.getType());
 			client.setVar(VarClientStr.INPUT_TEXT, search);
 
-			client.runScript(scriptArgs);
+			layoutBank();
 		});
+	}
+
+	public void layoutBank()
+	{
+		Widget bankContainer = client.getWidget(WidgetInfo.BANK_ITEM_CONTAINER);
+		if (bankContainer == null || bankContainer.isHidden())
+		{
+			return;
+		}
+
+		Object[] scriptArgs = bankContainer.getOnInvTransmitListener();
+		if (scriptArgs == null)
+		{
+			return;
+		}
+
+		client.runScript(scriptArgs);
 	}
 
 	public void reset(boolean closeChat)


### PR DESCRIPTION
The client will normally layout the bank during a search only once every 40 client ticks, causing slow response times after the search input is updated. Instead, hook the search refresh script that is called every client tick, and if the bank hasn't been laid out on the current tick, and the search input has changed, lay it out early.

![](https://i.imgur.com/3aAQB0G.gif)

Closes #9569 