### PR TITLE
Ensure runScript is invoked with the correct number of arguments

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/Client.java
+++ b/runelite-api/src/main/java/net/runelite/api/Client.java
@@ -1253,11 +1253,10 @@ public interface Client extends GameEngine
 	 *
 	 * This method must be ran on the client thread and is not reentrant
 	 *
-	 * @param id the script ID
-	 * @param args additional arguments to execute the script with
+	 * @param args the script id, then any additional arguments to execute the script with
 	 * @see ScriptID
 	 */
-	void runScript(int id, Object... args);
+	void runScript(Object... args);
 
 	/**
 	 * Checks whether or not there is any active hint arrow.

--- a/runelite-api/src/main/java/net/runelite/api/ScriptArguments.java
+++ b/runelite-api/src/main/java/net/runelite/api/ScriptArguments.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2019 Abex
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.api;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.SOURCE)
+@Documented
+@Target(ElementType.FIELD)
+@interface ScriptArguments
+{
+	/**
+	 * The number of int arguments the script takes
+	 */
+	int integer() default 0;
+
+	/**
+	 * The number of string arguments the script takes
+	 */
+	int string() default 0;
+}

--- a/runelite-api/src/main/java/net/runelite/api/ScriptID.java
+++ b/runelite-api/src/main/java/net/runelite/api/ScriptID.java
@@ -34,6 +34,7 @@ public final class ScriptID
 	 * <li> int how far down to scroll </li>
 	 * </ul>
 	 */
+	@ScriptArguments(integer = 3)
 	public static final int UPDATE_SCROLLBAR = 72;
 
 	/**
@@ -43,11 +44,13 @@ public final class ScriptID
 	 * <li> String Message to send </li>
 	 * </ul>
 	 */
+	@ScriptArguments(integer = 1, string = 1)
 	public static final int CHATBOX_INPUT = 96;
 
 	/**
 	 * Rebuilds the chatbox
 	 */
+	@ScriptArguments()
 	public static final int BUILD_CHATBOX = 216;
 
 	/**
@@ -58,6 +61,7 @@ public final class ScriptID
 	 * <li> String Player to send private message to</li>
 	 * </ul>
 	 */
+	@ScriptArguments(string = 1)
 	public static final int OPEN_PRIVATE_MESSAGE_INTERFACE = 107;
 
 	/**
@@ -66,6 +70,7 @@ public final class ScriptID
 	 * <li> String Message Prefix. Only used inside the GE search interfaces
 	 * </ul>
 	 */
+	@ScriptArguments(string = 1)
 	public static final int CHAT_TEXT_INPUT_REBUILD = 222;
 
 	/**
@@ -73,6 +78,7 @@ public final class ScriptID
 	 *
 	 * Takes 13 widget ids of various parts of the bank interface
 	 */
+	@ScriptArguments(integer = 17)
 	public static final int BANK_LAYOUT = 277;
 
 	/**
@@ -82,17 +88,20 @@ public final class ScriptID
 	 * <li> int (boolean) Restore to chat view </li>
 	 * </ul>
 	 */
+	@ScriptArguments(integer = 2)
 	public static final int RESET_CHATBOX_INPUT = 299;
 
 	/**
 	 * Readies the chatbox panel for things like the chatbox input
 	 * Inverse of RESET_CHATBOX_INPUT
 	 */
+	@ScriptArguments(integer = 1)
 	public static final int CLEAR_CHATBOX_PANEL = 677;
 
 	/**
 	 * Builds the chatbox input widget
 	 */
+	@ScriptArguments()
 	public static final int CHAT_PROMPT_INIT = 223;
 
 	/**
@@ -103,19 +112,21 @@ public final class ScriptID
 	 * <li> String Item Name </li>
 	 * </ul>
 	 */
+	@ScriptArguments(integer = 2, string = 1)
 	public static final int DEATH_KEEP_ITEM_EXAMINE = 1603;
 
 	/**
 	 * Checks the state of the given stash unit.
 	 * <ul>
 	 * <li>int (loc) The stash unit object id</li>
-	 *  <li>int Bitpacked stash unit states</li>
-	 *  <li>int Bitpacked stash unit states 2</li>
-	 *  <li>int Bitpacked stash unit states 3</li>
+	 * <li>int Bitpacked stash unit states</li>
+	 * <li>int Bitpacked stash unit states 2</li>
+	 * <li>int Bitpacked stash unit states 3</li>
 	 * </ul>
 	 *
 	 * Returns a pair of booleans indicating if the stash unit is built and if it is filled
 	 */
+	@ScriptArguments(integer = 4)
 	public static final int WATSON_STASH_UNIT_CHECK = 1479;
 
 	/**
@@ -128,6 +139,7 @@ public final class ScriptID
 	 * <li> int (QuestState) the normalized state of the quest
 	 * </ul>
 	 */
+	@ScriptArguments(integer = 1)
 	public static final int QUESTLIST_PROGRESS = 2267;
 
 	/**
@@ -137,6 +149,7 @@ public final class ScriptID
 	 * <li> int Number of lines </li>
 	 * </ul>
 	 */
+	@ScriptArguments(integer = 2)
 	public static final int DIARY_QUEST_UPDATE_LINECOUNT = 2523;
 
 	/**
@@ -148,6 +161,7 @@ public final class ScriptID
 	 * <li> int  Reset zoom position </li>
 	 * </ul>
 	 */
+	@ScriptArguments(integer = 2)
 	public static final int CAMERA_DO_ZOOM = 42;
 
 	/**
@@ -156,11 +170,13 @@ public final class ScriptID
 	 * This is used to eat events when you want a menu action attached to it
 	 * because you need an op listener attached to it for it to work
 	 */
+	@ScriptArguments()
 	public static final int NULL = 10003;
 
 	/**
 	 * Send a private message.
 	 */
+	@ScriptArguments(string = 2)
 	public static final int PRIVMSG = 10004;
 
 	/**
@@ -171,5 +187,6 @@ public final class ScriptID
 	 * <li>int Amount of exp to drop</li>
 	 * </ul>
 	 */
+	@ScriptArguments(integer = 2)
 	public static final int XPDROP_DISABLED = 2091;
 }

--- a/runelite-api/src/main/java/net/runelite/api/ScriptID.java
+++ b/runelite-api/src/main/java/net/runelite/api/ScriptID.java
@@ -74,14 +74,6 @@ public final class ScriptID
 	public static final int CHAT_TEXT_INPUT_REBUILD = 222;
 
 	/**
-	 * Layouts the bank widgets
-	 *
-	 * Takes 13 widget ids of various parts of the bank interface
-	 */
-	@ScriptArguments(integer = 17)
-	public static final int BANK_LAYOUT = 277;
-
-	/**
 	 * Closes the chatbox input
 	 * <ul>
 	 * <li> int (boolean) Clear the current text </li>
@@ -89,14 +81,17 @@ public final class ScriptID
 	 * </ul>
 	 */
 	@ScriptArguments(integer = 2)
-	public static final int RESET_CHATBOX_INPUT = 299;
+	public static final int MESSAGE_LAYER_CLOSE = 299;
 
 	/**
 	 * Readies the chatbox panel for things like the chatbox input
-	 * Inverse of RESET_CHATBOX_INPUT
+	 * Inverse of MESSAGE_LAYER_CLOSE
+	 * <ul>
+	 * <li> int (InputType) message layer type we are changing to </li>
+	 * </ul>
 	 */
 	@ScriptArguments(integer = 1)
-	public static final int CLEAR_CHATBOX_PANEL = 677;
+	public static final int MESSAGE_LAYER_OPEN = 677;
 
 	/**
 	 * Builds the chatbox input widget

--- a/runelite-api/src/main/java/net/runelite/api/VarClientInt.java
+++ b/runelite-api/src/main/java/net/runelite/api/VarClientInt.java
@@ -42,6 +42,10 @@ public enum VarClientInt
 	 */
 	TOOLTIP_VISIBLE(2),
 
+	/**
+	 * Current message layer mode
+	 * @see net.runelite.api.vars.InputType
+	 */
 	INPUT_TYPE(5),
 
 	MEMBERSHIP_STATUS(103),

--- a/runelite-api/src/main/java/net/runelite/api/widgets/Widget.java
+++ b/runelite-api/src/main/java/net/runelite/api/widgets/Widget.java
@@ -622,6 +622,8 @@ public interface Widget
 	 */
 	Object[] getOnLoadListener();
 
+	Object[] getOnInvTransmitListener();
+
 	/**
 	 * Returns the archive id of the font used
 	 *

--- a/runelite-client/src/main/java/net/runelite/client/game/chatbox/ChatboxPanelManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/game/chatbox/ChatboxPanelManager.java
@@ -89,7 +89,7 @@ public class ChatboxPanelManager
 	private void unsafeCloseInput()
 	{
 		client.runScript(
-			ScriptID.RESET_CHATBOX_INPUT,
+			ScriptID.MESSAGE_LAYER_CLOSE,
 			0,
 			1
 		);
@@ -101,7 +101,7 @@ public class ChatboxPanelManager
 
 	private void unsafeOpenInput(ChatboxInput input)
 	{
-		client.runScript(ScriptID.CLEAR_CHATBOX_PANEL);
+		client.runScript(ScriptID.MESSAGE_LAYER_OPEN, 0);
 
 		eventBus.register(input);
 		if (input instanceof KeyListener)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/banktags/tabs/BankSearch.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/banktags/tabs/BankSearch.java
@@ -37,20 +37,6 @@ import net.runelite.client.callback.ClientThread;
 
 public class BankSearch
 {
-	// Widget indexes for searching
-	private static final int INNER_CONTAINER_IDX = 2;
-	private static final int SETTINGS_IDX = 4;
-	private static final int ITEM_CONTAINER_IDX = 7;
-	private static final int SCROLLBAR_IDX = 8;
-	private static final int BOTTOM_BAR_IDX = 9;
-	private static final int SEARCH_BUTTON_BACKGROUND_IDX = 15;
-	private static final int TITLE_BAR_IDX = 16;
-	private static final int ITEM_COUNT_IDX = 17;
-	private static final int TAB_BAR_IDX = 18;
-	private static final int INCINERATOR_IDX = 19;
-	private static final int INCINERATOR_CONFIRM_IDX = 20;
-	private static final int HIDDEN_WIDGET_IDX = 21;
-
 	private final Client client;
 	private final ClientThread clientThread;
 
@@ -64,51 +50,38 @@ public class BankSearch
 		this.clientThread = clientThread;
 	}
 
-	public void search(InputType inputType, String search, Boolean closeInput)
+	public void search(InputType inputType, String search, boolean closeInput)
 	{
 		clientThread.invoke(() ->
 		{
-			Widget bankContainer = client.getWidget(WidgetInfo.BANK_CONTAINER);
+			Widget bankContainer = client.getWidget(WidgetInfo.BANK_ITEM_CONTAINER);
 			if (bankContainer == null || bankContainer.isHidden())
 			{
 				return;
 			}
 
-			Object[] widgetIds = bankContainer.getOnLoadListener();
+			Object[] scriptArgs = bankContainer.getOnInvTransmitListener();
 
-			// In case the widget ids array is incorrect, do not proceed
-			if (widgetIds == null || widgetIds.length < 21)
+			if (scriptArgs == null)
 			{
 				return;
 			}
+
 			// This ensures that any chatbox input (e.g from search) will not remain visible when
 			// selecting/changing tab
 			if (closeInput)
 			{
-				client.runScript(ScriptID.RESET_CHATBOX_INPUT, 0, 0);
+				client.runScript(ScriptID.MESSAGE_LAYER_CLOSE, 0, 0);
 			}
 
 			client.setVar(VarClientInt.INPUT_TYPE, inputType.getType());
 			client.setVar(VarClientStr.INPUT_TEXT, search);
 
-			client.runScript(ScriptID.BANK_LAYOUT,
-				WidgetInfo.BANK_CONTAINER.getId(),
-				widgetIds[INNER_CONTAINER_IDX],
-				widgetIds[SETTINGS_IDX],
-				widgetIds[ITEM_CONTAINER_IDX],
-				widgetIds[SCROLLBAR_IDX],
-				widgetIds[BOTTOM_BAR_IDX],
-				widgetIds[TITLE_BAR_IDX],
-				widgetIds[ITEM_COUNT_IDX],
-				widgetIds[SEARCH_BUTTON_BACKGROUND_IDX],
-				widgetIds[TAB_BAR_IDX],
-				widgetIds[INCINERATOR_IDX],
-				widgetIds[INCINERATOR_CONFIRM_IDX],
-				widgetIds[HIDDEN_WIDGET_IDX]);
+			client.runScript(scriptArgs);
 		});
 	}
 
-	public void reset(Boolean closeChat)
+	public void reset(boolean closeChat)
 	{
 		search(InputType.NONE, "", closeChat);
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/banktags/tabs/TabInterface.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/banktags/tabs/TabInterface.java
@@ -336,7 +336,7 @@ public class TabInterface
 				{
 					bankSearch.reset(true);
 
-					clientThread.invokeLater(() -> client.runScript(ScriptID.RESET_CHATBOX_INPUT, 0, 0));
+					clientThread.invokeLater(() -> client.runScript(ScriptID.MESSAGE_LAYER_CLOSE, 0, 0));
 				}
 				else
 				{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatboxperformance/ChatboxPerformancePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatboxperformance/ChatboxPerformancePlugin.java
@@ -56,7 +56,7 @@ public class ChatboxPerformancePlugin extends Plugin
 	{
 		if (client.getGameState() == GameState.LOGGED_IN)
 		{
-			clientThread.invokeLater(() -> client.runScript(ScriptID.RESET_CHATBOX_INPUT));
+			clientThread.invokeLater(() -> client.runScript(ScriptID.MESSAGE_LAYER_CLOSE, 0, 0));
 		}
 	}
 
@@ -65,7 +65,7 @@ public class ChatboxPerformancePlugin extends Plugin
 	{
 		if (client.getGameState() == GameState.LOGGED_IN)
 		{
-			clientThread.invokeLater(() -> client.runScript(ScriptID.RESET_CHATBOX_INPUT));
+			clientThread.invokeLater(() -> client.runScript(ScriptID.MESSAGE_LAYER_CLOSE, 0, 0));
 		}
 	}
 


### PR DESCRIPTION
 - trip an assertion when invoking a script with the wrong number of arguments
 - Store the number of args machine readably in our repo
 - stop tripping the aforementioned assertion