### PR TITLE
notes: strip input of invisible control characters before saving

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/notes/NotesPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/notes/NotesPanel.java
@@ -140,8 +140,9 @@ class NotesPanel extends PluginPanel
 				try
 				{
 					// get document text and save to config whenever editor is changed
-					String data = doc.getText(0, doc.getLength());
+					String data = doc.getText(0, doc.getLength()).replaceAll("[\\p{Cc}\\p{Cf}\\p{Co}\\p{Cn}]", "");
 					config.notesData(data);
+					setNotes(data);
 				}
 				catch (BadLocationException ex)
 				{


### PR DESCRIPTION
When copying from windows calculator the characters U+202D (LEFT-TO-RIGHT OVERRIDE) and U+202C (POP DIRECTIONAL FORMATTING) are added to the beginning and the end of the desired content respectively. If they are copied into the notes plugin they will yield weird characters after a client reload when the notes are restored from a save.

This commit removes all invisible:
 - control characters 0x00-0x0F and 0x7F-0x9F
 - formatting indicators
 - code points reserved for private use
 - unassinged characters

Where number 2 in the list solves the case of windows calculator.
Invisible characters part of a surrogate pair in UTF-16 encoding are not removed due to keep emoji support for simple emojis in the plugin.

Closes #9248