### PR TITLE
Add a zalcano helper plugin

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/GraphicID.java
+++ b/runelite-api/src/main/java/net/runelite/api/GraphicID.java
@@ -49,4 +49,5 @@ public class GraphicID
 	public static final int NPC_CONTACT = 728;
 	public static final int POT_SHARE = 733;
 	public static final int BAKE_PIE = 746;
+	public static final int GRAPHICS_OBJECT_ROCKFALL = 1727;
 }

--- a/runelite-api/src/main/java/net/runelite/api/ProjectileID.java
+++ b/runelite-api/src/main/java/net/runelite/api/ProjectileID.java
@@ -84,4 +84,6 @@ public class ProjectileID
 	public static final int VORKATH_PRAYER_DISABLE = 1471;
 	public static final int VORKATH_VENOM = 1470;
 	public static final int VORKATH_ICE = 350;
+
+	public static final int ZALCANO_PROJECTILE_FIREBALL = 1728;
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/zalcano/ZalcanoOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/zalcano/ZalcanoOverlay.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2019, Hexagon <hexagon@fking.work>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.zalcano;
+
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Graphics2D;
+import java.awt.Polygon;
+import java.util.List;
+import javax.inject.Inject;
+import net.runelite.api.Client;
+import net.runelite.api.GraphicsObject;
+import net.runelite.api.Perspective;
+import net.runelite.api.Player;
+import net.runelite.api.coords.LocalPoint;
+import net.runelite.client.ui.overlay.Overlay;
+import net.runelite.client.ui.overlay.OverlayLayer;
+import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.OverlayPriority;
+import net.runelite.client.ui.overlay.OverlayUtil;
+
+class ZalcanoOverlay extends Overlay
+{
+	private final Client client;
+	private final ZalcanoPlugin zalcanoPlugin;
+
+	@Inject
+	private ZalcanoOverlay(Client client, ZalcanoPlugin zalcanoPlugin)
+	{
+		this.client = client;
+		this.zalcanoPlugin = zalcanoPlugin;
+		setPosition(OverlayPosition.DYNAMIC);
+		setLayer(OverlayLayer.ABOVE_SCENE);
+		setPriority(OverlayPriority.MED);
+	}
+
+	@Override
+	public Dimension render(Graphics2D graphics)
+	{
+		List<GraphicsObject> rocks = zalcanoPlugin.getRocks();
+		if (!rocks.isEmpty())
+		{
+			rocks.removeIf(GraphicsObject::finished);
+
+			for (GraphicsObject graphicsObject : rocks)
+			{
+				final Player localPlayer = client.getLocalPlayer();
+				final LocalPoint graphicsObjectLocation = graphicsObject.getLocation();
+				final Polygon polygon = Perspective.getCanvasTilePoly(client, graphicsObjectLocation);
+
+				if (polygon != null)
+				{
+					OverlayUtil.renderPolygon(graphics, polygon, localPlayer.getLocalLocation().equals(graphicsObjectLocation) ? Color.RED : Color.ORANGE);
+				}
+			}
+		}
+
+		LocalPoint targetedGlowingRock = zalcanoPlugin.getTargetedGlowingRock();
+		if (targetedGlowingRock != null && client.getGameCycle() < zalcanoPlugin.getTargetedGlowingRockEndCycle())
+		{
+			final Polygon polygon = Perspective.getCanvasTileAreaPoly(client, targetedGlowingRock, 3);
+
+			if (polygon != null)
+			{
+				OverlayUtil.renderPolygon(graphics, polygon, Color.RED);
+			}
+		}
+		return null;
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/zalcano/ZalcanoPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/zalcano/ZalcanoPlugin.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) 2019, Hexagon <hexagon@fking.work>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.zalcano;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.inject.Inject;
+import lombok.Getter;
+import net.runelite.api.Client;
+import net.runelite.api.GameObject;
+import static net.runelite.api.GraphicID.GRAPHICS_OBJECT_ROCKFALL;
+import net.runelite.api.GraphicsObject;
+import net.runelite.api.NPC;
+import net.runelite.api.NpcID;
+import static net.runelite.api.NpcID.ZALCANO;
+import net.runelite.api.ObjectID;
+import net.runelite.api.Projectile;
+import static net.runelite.api.ProjectileID.ZALCANO_PROJECTILE_FIREBALL;
+import net.runelite.api.coords.LocalPoint;
+import net.runelite.api.coords.WorldPoint;
+import net.runelite.api.events.GameObjectSpawned;
+import net.runelite.api.events.GraphicsObjectCreated;
+import net.runelite.api.events.NpcChanged;
+import net.runelite.api.events.NpcDespawned;
+import net.runelite.api.events.NpcSpawned;
+import net.runelite.api.events.ProjectileMoved;
+import net.runelite.client.eventbus.Subscribe;
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.ui.overlay.OverlayManager;
+
+@PluginDescriptor(
+	name = "Zalcano",
+	description = "Assistance for the Zalcano fight",
+	enabledByDefault = false
+)
+public class ZalcanoPlugin extends Plugin
+{
+	private static final int ZALCANO_WEAKENED = NpcID.ZALCANO_9050;
+	private static final int GOLEM = NpcID.GOLEM_9051;
+
+	@Inject
+	private Client client;
+
+	@Inject
+	private OverlayManager overlayManager;
+
+	@Inject
+	private ZalcanoOverlay overlay;
+
+	@Getter
+	private LocalPoint targetedGlowingRock;
+	@Getter
+	private int targetedGlowingRockEndCycle;
+	private WorldPoint lastGlowingRock;
+
+	@Getter
+	private final List<GraphicsObject> rocks = new ArrayList<>();
+
+	@Override
+	protected void startUp()
+	{
+		overlayManager.add(overlay);
+		rocks.clear();
+	}
+
+	@Override
+	protected void shutDown()
+	{
+		overlayManager.remove(overlay);
+	}
+
+	@Subscribe
+	public void onGraphicsObjectCreated(GraphicsObjectCreated graphicsObjectCreated)
+	{
+		GraphicsObject graphicsObject = graphicsObjectCreated.getGraphicsObject();
+		if (graphicsObject.getId() == GRAPHICS_OBJECT_ROCKFALL)
+		{
+			rocks.add(graphicsObject);
+		}
+	}
+
+	@Subscribe
+	public void onNpcSpawned(NpcSpawned event)
+	{
+		final NPC npc = event.getNpc();
+
+		if (npc.getId() == GOLEM)
+		{
+			client.setHintArrow(npc);
+		}
+	}
+
+	@Subscribe
+	public void onNpcDespawned(NpcDespawned event)
+	{
+		final NPC npc = event.getNpc();
+
+		if (npc.getId() == ZALCANO_WEAKENED)
+		{
+			client.clearHintArrow();
+		}
+		else if (npc.getId() == GOLEM)
+		{
+			if (lastGlowingRock != null)
+			{
+				client.setHintArrow(lastGlowingRock);
+			}
+		}
+	}
+
+	@Subscribe
+	public void onGameObjectSpawned(GameObjectSpawned event)
+	{
+		final GameObject gameObject = event.getGameObject();
+
+		if (gameObject.getId() == ObjectID.ROCK_FORMATION_GLOWING)
+		{
+			WorldPoint worldLocation = lastGlowingRock = gameObject.getWorldLocation();
+			client.setHintArrow(worldLocation);
+		}
+	}
+
+	@Subscribe
+	public void onNpcChanged(NpcChanged event)
+	{
+		final NPC npc = event.getNpc();
+
+		if (npc.getId() == ZALCANO_WEAKENED)
+		{
+			client.setHintArrow(npc);
+		}
+		else if (npc.getId() == ZALCANO)
+		{
+			if (lastGlowingRock != null)
+			{
+				client.setHintArrow(lastGlowingRock);
+			}
+		}
+	}
+
+	@Subscribe
+	public void onProjectileMoved(ProjectileMoved event)
+	{
+		final Projectile projectile = event.getProjectile();
+
+		if (projectile.getId() == ZALCANO_PROJECTILE_FIREBALL)
+		{
+			targetedGlowingRock = event.getPosition();
+			targetedGlowingRockEndCycle = projectile.getEndCycle();
+		}
+	}
+}


### PR DESCRIPTION
This PR adds a plugin that assists the player with Zalcano, similarly to OSbuddy's Zalcano helper.

The plugin currently assists the player by:
* Highlighting the glowing rocks with hint arrows;
* Highlighting the weakened Zalcano with hint arrows;
* Highlighting tiles where rocks are falling;
* Highlighting if Zalcano shot a fireball at a glowing rock;

Some example images:

![](https://i.imgur.com/ilCAfvf.png)
![](https://i.imgur.com/KRmjoTz.png)
![](https://i.imgur.com/0V9XT91.png)