### PR TITLE
Use the Sarachnis pet, Sraracha, as the slayer task overlay icon.

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/Task.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/Task.java
@@ -145,6 +145,7 @@ enum Task
 	CHAOS_DRUIDS("Chaos druids", ItemID.ELDER_CHAOS_HOOD, "Elder Chaos druid", "Chaos druid"),
 	BANDITS("Bandits", ItemID.BANDIT, "Bandit"),
 	MAGIC_AXES("Magic axes", ItemID.IRON_BATTLEAXE, "Magic axe"),
+	SARACHNIS("Sarachnis", ItemID.SRARACHA),
 	SCORPIONS("Scorpions", ItemID.ENSOULED_SCORPION_HEAD),
 	SEA_SNAKES("Sea snakes", ItemID.SNAKE_CORPSE),
 	SHADES("Shades", ItemID.SHADE_ROBE_TOP, "Loar Shadow", "Loar Shade", "Phrin Shadow", "Phrin Shade", "Riyl Shadow", "Riyl Shade", "Asyn Shadow", "Asyn Shade", "Fiyr Shadow", "Fiyr Shade"),


### PR DESCRIPTION
The Sarachnis boss slayer task remaining KC overlay will no longer show the slayer gem default. It will now use the pet like other bosses.

![image](https://user-images.githubusercontent.com/29470061/62869150-3ee15c00-bce5-11e9-9441-7daa2fc7e9b5.png)
