### PR TITLE
runelite-client: Bypass Jagex load balancer if we can't connect

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/rs/ClientConfigLoader.java
+++ b/runelite-client/src/main/java/net/runelite/client/rs/ClientConfigLoader.java
@@ -29,6 +29,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import net.runelite.http.api.RuneLiteAPI;
+import okhttp3.HttpUrl;
 import okhttp3.Request;
 import okhttp3.Response;
 
@@ -40,10 +41,16 @@ class ClientConfigLoader
 
 	private static final String CONFIG_URL = "http://oldschool.runescape.com/jav_config.ws";
 
-	static RSConfig fetch() throws IOException
+	static RSConfig fetch(String host) throws IOException
 	{
+		HttpUrl url = HttpUrl.parse(CONFIG_URL);
+		if (host != null)
+		{
+			url = url.newBuilder().host(host).build();
+		}
+
 		final Request request = new Request.Builder()
-			.url(CONFIG_URL)
+			.url(url)
 			.build();
 
 		final RSConfig config = new RSConfig();


### PR DESCRIPTION
Some people seems to be unable to connect to the servers that Jagex's load balancer, so if we can't connect to that we now instead:
 - try to grab the worldlist from api.runelite.net and choose some random servers from that
 - failing above; try some random server hostnames