### PR TITLE
Add option to Herbiboar plugin to only show the most recent trail and highlight herbiboar at the end of the trail

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/herbiboars/HerbiboarConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/herbiboars/HerbiboarConfig.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2017, Tyler <https://github.com/tylerthardy>
+ * Copyright (c) 2019, Gamer1120 <https://github.com/Gamer1120>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -122,6 +123,17 @@ public interface HerbiboarConfig extends Config
 
 	@ConfigItem(
 		position = 8,
+		keyName = "showOnlyCurrentTrail",
+		name = "Show Current Trail Only",
+		description = "Only show the trail that you currently have to follow to get to the next object you have to inspect. Requires that the \"Show Trail\" option is enabled"
+	)
+	default boolean isOnlyCurrentTrailShown()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		position = 9,
 		keyName = "colorTrail",
 		name = "Trail Color",
 		description = "Color for mushrooms, mud, seaweed, etc"

--- a/runelite-client/src/main/java/net/runelite/client/plugins/herbiboars/HerbiboarMinimapOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/herbiboars/HerbiboarMinimapOverlay.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018, Kamiel
+ * Copyright (c) 2019, Gamer1120 <https://github.com/Gamer1120>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -56,8 +57,15 @@ public class HerbiboarMinimapOverlay extends Overlay
 		{
 			HerbiboarTrail currentTrail = plugin.getCurrentTrail();
 			int finishId = plugin.getFinishId();
-			Set<Integer> shownTrailIds = plugin.getShownTrails();
-
+			Set<Integer> shownTrailIds;
+			if (config.isOnlyCurrentTrailShown())
+			{
+				shownTrailIds = plugin.getCurrentTrailIds();
+			}
+			else
+			{
+				shownTrailIds = plugin.getShownTrails();
+			}
 			for (TileObject tileObject : plugin.getTrails().values())
 			{
 				int id = tileObject.getId();


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9074448/63086580-77d13900-bf50-11e9-8b0d-58d7aa0a5054.png)
When watching Netflix or doing something semi-AFK, I sometimes forget which way I have to go. This means that I have to manually zoom out, or in case of a very long trail that goes outside of the screen, I have to guess. This PR includes the following features:

- Option to only show the trail that you currently have to follow
- Option to highlight the herbiboar at the end of the trail
- The plugin will now not highlight the start of trails while the herbiboar is highlighted. It will show them again once the herbiboar is dying (just after harvesting).

This should result in a better semi-afk Herbiboar experience.

The current state of this PR is that it is ready to be reviewed.

Information for myself and future reviewers/developers:
- Herbiboar only works with the NPCSpawned event, it does not have an NPCChanged or NPCDespawned event.
- Herbiboar does NOT reliably provide an NPCSpawned event. It sometimes does it after you have harvested it and sometimes not at all. Use AnimationChanged events!
- Once the herbiboar comes out of the tunnel and spawns on the ground, the initial NPC has ID 7786. Once it is harvestable, the ID becomes 7785. After it is harvested, it becomes 7786 again until it is no longer visible and the herbiboar becomes a null NPC. This does not fire an NPCChanged or NPCDespawned event.
- You cannot reliably detect the stunned state of the Herbiboar with AnimationChanged. It sometimes only triggers after you've harvested the Herbiboar.

- The following is observed when logging AnimationChanged, NpcSpawned, NpcChanged and NpcDespawned events:

Herbiboar spawns:
Animation changed: HiscoresOnly: 423
(after some small time:)
Animation changed: Herbiboar: 7687
Spawned: Herbiboar: 7786

Herbiboar gets harvested:
Animation changed: HiscoresOnly: 2277
Animation changed: Herbiboar: 7689

Herbiboar dies:
Animation changed: HiscoresOnly: -1
Animation changed: Herbiboar: 7690

Locations where the Herbiboar can spawn, the first argument is the finish id (varbit), and the second argument is the WorldPoint (x, y, plane). I figured this out during the development of this PR and maybe it saves someone time in the future.
	HB_LOCATION_1(1, new WorldPoint(3696, 3796, 0)),
	HB_LOCATION_2(2, new WorldPoint(3704, 3808, 0)),
	HB_LOCATION_3(3, new WorldPoint(3705, 3827, 0)),
	HB_LOCATION_4(4, new WorldPoint(3710, 3883, 0)),
	HB_LOCATION_5(5, new WorldPoint(3697, 3876, 0)),
	HB_LOCATION_6(6, new WorldPoint(3717, 3840, 0)),
	HB_LOCATION_7(7, new WorldPoint(3753, 3851, 0)),
	HB_LOCATION_8(8, new WorldPoint(3683, 3870, 0)),
	HB_LOCATION_9(9, new WorldPoint(3681, 3865, 0));