### PR TITLE
Fix "Fix MSAA white pixels"

### DIFF
--- a/runelite-client/src/main/resources/net/runelite/client/plugins/gpu/frag.glsl
+++ b/runelite-client/src/main/resources/net/runelite/client/plugins/gpu/frag.glsl
@@ -31,7 +31,7 @@ uniform float smoothBanding;
 uniform vec4 fogColor;
 
 in vec4 Color;
-in float fHsl;
+centroid in float fHsl;
 in vec4 fUv;
 in float fogAmount;
 

--- a/runelite-client/src/main/resources/net/runelite/client/plugins/gpu/geom.glsl
+++ b/runelite-client/src/main/resources/net/runelite/client/plugins/gpu/geom.glsl
@@ -52,7 +52,7 @@ in vec4 vUv[];
 in float vFogAmount[];
 
 out vec4 Color;
-out float fHsl;
+centroid out float fHsl;
 out vec4 fUv;
 out float fogAmount;
 


### PR DESCRIPTION
#9354 caused an issue where (mostly) Intel iGPUs complained about a type mismatch in the shaders, due to the fragment shader providing a `float` when it was expecting a `centroid float`. 