### PR TITLE
Add generic lizards task to slayer plugin

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/Task.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/Task.java
@@ -111,6 +111,7 @@ enum Task
 	JELLIES("Jellies", ItemID.JELLY, "Jelly"),
 	JUNGLE_HORROR("Jungle horrors", ItemID.ENSOULED_HORROR_HEAD),
 	KALPHITE("Kalphite", ItemID.KALPHITE_SOLDIER),
+	LIZARDS("Lizards", ItemID.ORANGE_SALAMANDER, "Desert lizard", "Sulphur lizard", "Small lizard", "Lizard"),
 	MAMMOTHS("Mammoths", ItemID.ATTACKER_HORN, "Mammoth"),
 	KALPHITE_QUEEN("Kalphite Queen", ItemID.KALPHITE_PRINCESS),
 	KILLERWATTS("Killerwatts", ItemID.KILLERWATT),


### PR DESCRIPTION
**Bug:**
"Lizards" task was not defined in the Tasks list, so xp drops didn't count towards counter.
#7565 

**Solution:**
Adds generic "lizards" task to Slayer plugin with icon of Orange Salamander, targeting Desert Lizards, Small Lizards, Lizards, and Sulphur Lizards.

**Before:**
![lizard-bug](https://user-images.githubusercontent.com/17709869/63217095-60877c80-c105-11e9-991c-c0952d27f27e.gif)

**Fixed:**
![lizard-bug-fixed](https://user-images.githubusercontent.com/17709869/63217128-ffac7400-c105-11e9-86ce-dd5a1d6efed9.gif)