### PR TITLE
ChatboxItemSearch: check for duplicate item images

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/ItemComposition.java
+++ b/runelite-api/src/main/java/net/runelite/api/ItemComposition.java
@@ -24,6 +24,8 @@
  */
 package net.runelite.api;
 
+import javax.annotation.Nullable;
+
 /**
  * Represents the template of a specific item type.
  */
@@ -138,4 +140,29 @@ public interface ItemComposition
 	 * default value.
 	 */
 	void resetShiftClickActionIndex();
+
+	/**
+	 * Gets the model ID of the inventory item.
+	 *
+	 * @return the model ID
+	 */
+	int getInventoryModel();
+
+	/**
+	 * Since the client reuses item models, it stores colors that can be replaced.
+	 * This returns what colors the item model will be replaced with.
+	 *
+	 * @return the colors to replace with
+	 */
+	@Nullable
+	short[] getColorToReplaceWith();
+
+	/**
+	 * Since the client reuses item models, it stores textures that can be replaced.
+	 * This returns what textures the item model will be replaced with.
+	 *
+	 * @return the textures to replace with
+	 */
+	@Nullable
+	short[] getTextureToReplaceWith();
 }


### PR DESCRIPTION
Depends on !78

Closes https://github.com/runelite/runelite/issues/9644

Supersedes/Closes  https://github.com/runelite/runelite/pull/9647

Uses item model information to filter out duplicate item images. 
![java_G1j5Fj2Y7i](https://user-images.githubusercontent.com/22979513/63397407-15cd6500-c390-11e9-83b4-8392450b4f8c.png)

![java_QQqXWFMBOj](https://user-images.githubusercontent.com/22979513/63397394-06e6b280-c390-11e9-8bf3-92ad482d1b8d.png)
