### PR TITLE
runecraft: add pouch contents tracker

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/runecraft/ClickOperation.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/runecraft/ClickOperation.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2019 Hydrox6 <ikada@protonmail.ch>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.runecraft;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+class ClickOperation
+{
+	/**
+	 * The ItemId that was clicked on.
+	 * Degraded pouches are converted before-hand
+	 * Can be any non-degraded pouch, pure essence, else -1
+	 */
+	int itemId;
+	int tick;
+	int delta;
+
+	ClickOperation(int itemId, int tick)
+	{
+		this(itemId, tick, 0);
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/runecraft/EssencePouchOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/runecraft/EssencePouchOverlay.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2019 Hydrox6 <ikada@protonmail.ch>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.runecraft;
+
+import net.runelite.api.widgets.WidgetItem;
+import net.runelite.client.ui.overlay.WidgetItemOverlay;
+import net.runelite.client.ui.overlay.components.TextComponent;
+import javax.inject.Inject;
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.Point;
+import java.awt.Rectangle;
+
+public class EssencePouchOverlay extends WidgetItemOverlay
+{
+	private final RunecraftPlugin plugin;
+	private final RunecraftConfig config;
+
+	@Inject
+	EssencePouchOverlay(RunecraftPlugin plugin, RunecraftConfig config)
+	{
+		this.plugin = plugin;
+		this.config = config;
+		showOnInventory();
+	}
+
+	@Override
+	public void renderItemOverlay(Graphics2D graphics, int itemId, WidgetItem itemWidget)
+	{
+		if (!config.showPouch())
+		{
+			return;
+		}
+
+		final Pouch pouch = plugin.getPouches().get(RunecraftPlugin.getPouchID(itemId));
+		if (pouch == null)
+		{
+			return;
+		}
+
+		final Rectangle bounds = itemWidget.getCanvasBounds();
+		final TextComponent textComponent = new TextComponent();
+		textComponent.setPosition(new Point(bounds.x - 1, bounds.y + 8));
+		textComponent.setColor(Color.CYAN);
+		if (pouch.getHolding() == 15)
+		{
+			textComponent.setText("?");
+		}
+		else
+		{
+			textComponent.setText(pouch.getHolding() + (pouch.isDegraded() ? "?" : ""));
+		}
+		textComponent.render(graphics);
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/runecraft/Pouch.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/runecraft/Pouch.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2019 Hydrox6 <ikada@protonmail.ch>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.runecraft;
+
+import lombok.Data;
+
+@Data
+class Pouch
+{
+	private final int tier;
+
+	private final int itemId;
+	private int holdAmount;
+	private final int baseHoldAmount;
+
+	private boolean degraded;
+	private final int degradedItemId;
+	private final int degradedBaseHoldAmount;
+
+	private int holding;
+
+	Pouch(int tier, int itemId, int holdAmount)
+	{
+		this(tier, itemId, holdAmount, -1, -1);
+	}
+
+	Pouch(int tier, int itemId, int holdAmount, int degradedId, int degradedHoldAmount)
+	{
+		this.tier = tier;
+		this.itemId = itemId;
+		this.holdAmount = holdAmount;
+		this.baseHoldAmount = holdAmount;
+		this.degradedBaseHoldAmount = degradedHoldAmount;
+		this.degradedItemId = degradedId;
+
+		this.holding = 0;
+		this.degraded = false;
+	}
+
+	int getRemaining()
+	{
+		return holdAmount - holding;
+	}
+
+	void addHolding(int delta)
+	{
+		holding += delta;
+		if (holding < 0)
+		{
+			holding = 0;
+		}
+		if (holding > holdAmount)
+		{
+			holding = holdAmount;
+		}
+	}
+
+	void shouldDegradeStateChange(int itemId)
+	{
+		final boolean state = itemId == degradedItemId;
+		if (state != degraded)
+		{
+			degraded = state;
+			holdAmount = state ? degradedBaseHoldAmount : baseHoldAmount;
+			holding = Math.min(holding, holdAmount);
+		}
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/runecraft/RunecraftConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/runecraft/RunecraftConfig.java
@@ -33,6 +33,17 @@ import net.runelite.client.config.ConfigItem;
 public interface RunecraftConfig extends Config
 {
 	@ConfigItem(
+		keyName = "showPouch",
+		name = "Show Pouch count",
+		description = "Configures whether the pouch ess count is displayed",
+		position = 1
+	)
+	default boolean showPouch()
+	{
+		return true;
+	}
+
+	@ConfigItem(
 		keyName = "showRifts",
 		name = "Show Rifts in Abyss",
 		description = "Configures whether the rifts in the abyss will be displayed",
@@ -218,4 +229,22 @@ public interface RunecraftConfig extends Config
 	{
 		return true;
 	}
+
+	@ConfigItem(
+		keyName = "pouchState",
+		name = "",
+		description = "",
+		hidden = true
+	)
+	default int pouchState()
+	{
+		return 65535;
+	}
+
+	@ConfigItem(
+		keyName = "pouchState",
+		name = "",
+		description = ""
+	)
+	void pouchState(int value);
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/runecraft/RunecraftPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/runecraft/RunecraftPlugin.java
@@ -24,12 +24,14 @@
  */
 package net.runelite.client.plugins.runecraft;
 
-import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.inject.Provides;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Stream;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import javax.inject.Inject;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -48,6 +50,7 @@ import net.runelite.api.events.DecorativeObjectDespawned;
 import net.runelite.api.events.DecorativeObjectSpawned;
 import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.ItemContainerChanged;
+import net.runelite.api.events.MenuOptionClicked;
 import net.runelite.api.events.NpcDespawned;
 import net.runelite.api.events.NpcSpawned;
 import net.runelite.client.Notifier;
@@ -66,11 +69,36 @@ public class RunecraftPlugin extends Plugin
 {
 	private static final String POUCH_DECAYED_NOTIFICATION_MESSAGE = "Your rune pouch has decayed.";
 	private static final String POUCH_DECAYED_MESSAGE = "Your pouch has decayed through use.";
-	private static final List<Integer> DEGRADED_POUCHES = ImmutableList.of(
-		ItemID.MEDIUM_POUCH_5511,
-		ItemID.LARGE_POUCH_5513,
-		ItemID.GIANT_POUCH_5515
-	);
+	private static final Pattern POUCH_CHECK_MESSAGE = Pattern.compile("^There (?:is|are) ([a-z]+)(?: pure)? essences? in this pouch.$");
+	private static final ImmutableMap<String, Integer> TEXT_TO_NUMBER = ImmutableMap.<String, Integer>builder()
+		.put("no", 0)
+		.put("one", 1)
+		.put("two", 2)
+		.put("three", 3)
+		.put("four", 4)
+		.put("five", 5)
+		.put("six", 6)
+		.put("seven", 7)
+		.put("eight", 8)
+		.put("nine", 9)
+		.put("ten", 10)
+		.put("eleven", 11)
+		.put("twelve", 12)
+		.build();
+
+	private boolean loginFlag = true;
+	private final List<ClickOperation> clickedItems = new ArrayList<>();
+	private final List<ClickOperation> checkedPouches = new ArrayList<>();
+	private int lastEssence = 0;
+	private int lastSpace = 0;
+
+	@Getter(AccessLevel.PACKAGE)
+	private final ImmutableMap<Integer, Pouch> pouches = ImmutableMap.<Integer, Pouch>builder()
+		.put(ItemID.SMALL_POUCH, new Pouch(0, ItemID.SMALL_POUCH, 3))
+		.put(ItemID.MEDIUM_POUCH, new Pouch(1, ItemID.MEDIUM_POUCH, 6, ItemID.MEDIUM_POUCH_5511, 3))
+		.put(ItemID.LARGE_POUCH, new Pouch(2, ItemID.LARGE_POUCH, 9, ItemID.LARGE_POUCH_5513, 7))
+		.put(ItemID.GIANT_POUCH, new Pouch(3, ItemID.GIANT_POUCH, 12, ItemID.GIANT_POUCH_5515, 9))
+		.build();
 
 	@Getter(AccessLevel.PACKAGE)
 	private final Set<DecorativeObject> abyssObjects = new HashSet<>();
@@ -91,6 +119,9 @@ public class RunecraftPlugin extends Plugin
 	private AbyssOverlay abyssOverlay;
 
 	@Inject
+	private EssencePouchOverlay essencePouchOverlay;
+
+	@Inject
 	private RunecraftConfig config;
 
 	@Inject
@@ -106,6 +137,7 @@ public class RunecraftPlugin extends Plugin
 	protected void startUp() throws Exception
 	{
 		overlayManager.add(abyssOverlay);
+		overlayManager.add(essencePouchOverlay);
 		abyssOverlay.updateConfig();
 	}
 
@@ -113,6 +145,7 @@ public class RunecraftPlugin extends Plugin
 	protected void shutDown() throws Exception
 	{
 		overlayManager.remove(abyssOverlay);
+		overlayManager.remove(essencePouchOverlay);
 		abyssObjects.clear();
 		darkMage = null;
 		degradedPouchInInventory = false;
@@ -121,7 +154,10 @@ public class RunecraftPlugin extends Plugin
 	@Subscribe
 	public void onConfigChanged(ConfigChanged event)
 	{
-		abyssOverlay.updateConfig();
+		if (event.getGroup().equals("runecraft"))
+		{
+			abyssOverlay.updateConfig();
+		}
 	}
 
 	@Subscribe
@@ -137,6 +173,26 @@ public class RunecraftPlugin extends Plugin
 			if (event.getMessage().contains(POUCH_DECAYED_MESSAGE))
 			{
 				notifier.notify(POUCH_DECAYED_NOTIFICATION_MESSAGE);
+			}
+		}
+		if (checkedPouches.size() > 0)
+		{
+			Matcher matcher = POUCH_CHECK_MESSAGE.matcher(event.getMessage());
+			if (matcher.matches())
+			{
+				final int num = TEXT_TO_NUMBER.get(matcher.group(1));
+				// Keep getting operations until we get a valid one
+				while (checkedPouches.size() > 0)
+				{
+					final ClickOperation op = checkedPouches.remove(0);
+					if (op.tick >= client.getTickCount())
+					{
+						Pouch pouch = pouches.get(op.itemId);
+						pouch.setHolding(num);
+						updatePouchContents(pouch.getTier(), num);
+						break;
+					}
+				}
 			}
 		}
 	}
@@ -171,6 +227,17 @@ public class RunecraftPlugin extends Plugin
 			case HOPPING:
 			case LOGIN_SCREEN:
 				darkMage = null;
+				loginFlag = true;
+				break;
+			case LOGGED_IN:
+				if (loginFlag)
+				{
+					loginFlag = false;
+					for (Pouch pouch : pouches.values())
+					{
+						pouch.setHolding(getPouchContents(pouch.getTier()));
+					}
+				}
 				break;
 		}
 	}
@@ -184,7 +251,134 @@ public class RunecraftPlugin extends Plugin
 		}
 
 		final Item[] items = event.getItemContainer().getItems();
-		degradedPouchInInventory = Stream.of(items).anyMatch(i -> DEGRADED_POUCHES.contains(i.getId()));
+
+		int newEss = 0;
+		int newSpace = 0;
+		Pouch medium = pouches.get(ItemID.MEDIUM_POUCH);
+		Pouch large = pouches.get(ItemID.LARGE_POUCH);
+		Pouch giant = pouches.get(ItemID.GIANT_POUCH);
+
+		for (Item item : items)
+		{
+			switch (item.getId())
+			{
+				case ItemID.PURE_ESSENCE:
+					newEss += 1;
+					break;
+				case -1:
+					newSpace += 1;
+					break;
+				case ItemID.MEDIUM_POUCH:
+				case ItemID.MEDIUM_POUCH_5511:
+					medium.shouldDegradeStateChange(item.getId());
+					break;
+				case ItemID.LARGE_POUCH:
+				case ItemID.LARGE_POUCH_5513:
+					large.shouldDegradeStateChange(item.getId());
+					break;
+				case ItemID.GIANT_POUCH:
+				case ItemID.GIANT_POUCH_5515:
+					giant.shouldDegradeStateChange(item.getId());
+					break;
+			}
+		}
+		degradedPouchInInventory = medium.isDegraded() || large.isDegraded() || giant.isDegraded();
+
+		final int tick = client.getTickCount();
+
+		int essence = lastEssence;
+		int space = lastSpace;
+
+		for (ClickOperation op : clickedItems)
+		{
+			if (tick > op.tick)
+			{
+				continue;
+			}
+			if (op.getItemId() == -1)
+			{
+				space -= op.delta;
+				space = Math.max(0, space);
+				continue;
+			}
+			if (op.getItemId() == ItemID.PURE_ESSENCE)
+			{
+				// Ensure that the essence can be added
+				space -= op.delta;
+				if (space < 0)
+				{
+					essence += op.delta + space;
+					space = 0;
+				}
+				else
+				{
+					essence += op.delta;
+				}
+				continue;
+			}
+
+			Pouch pouch = pouches.get(op.getItemId());
+
+			final boolean fill = op.getDelta() > 0;
+			final int required = fill ? pouch.getRemaining() : pouch.getHolding();
+			final int essenceGot = op.getDelta() * Math.min(required, fill ? essence : space);
+
+			essence -= essenceGot;
+			pouch.addHolding(essenceGot);
+			space += essenceGot;
+			updatePouchContents(pouch.getTier(), pouch.getHolding());
+		}
+		clickedItems.clear();
+
+		lastSpace = newSpace;
+		lastEssence = newEss;
+	}
+
+	@Subscribe
+	public void onMenuOptionClicked(MenuOptionClicked event)
+	{
+		final int id = getPouchID(event.getId());
+		final Pouch pouch = pouches.get(id);
+		final int tick = client.getTickCount() + 3;
+		if (pouch == null)
+		{
+			if (id == ItemID.PURE_ESSENCE)
+			{
+				if (event.getMenuOption().equals("Drop"))
+				{
+					clickedItems.add(new ClickOperation(ItemID.PURE_ESSENCE, tick, -1));
+				}
+				else if (event.getMenuOption().equals("Take"))
+				{
+					clickedItems.add(new ClickOperation(ItemID.PURE_ESSENCE, tick, 1));
+				}
+			}
+			else if (event.getMenuOption().equals("Drop"))
+			{
+				clickedItems.add(new ClickOperation(-1, tick, -1));
+			}
+			else if (event.getMenuOption().equals("Take"))
+			{
+				clickedItems.add(new ClickOperation(-1, tick, 1));
+			}
+			return;
+		}
+
+		switch (event.getMenuOption())
+		{
+			case "Fill":
+				clickedItems.add(new ClickOperation(id, tick, 1));
+				break;
+			case "Empty":
+				clickedItems.add(new ClickOperation(id, tick, -1));
+				break;
+			case "Check":
+				checkedPouches.add(new ClickOperation(id, tick));
+				break;
+			case "Take":
+				pouch.setHolding(0);
+				break;
+		}
 	}
 
 	@Subscribe
@@ -204,6 +398,54 @@ public class RunecraftPlugin extends Plugin
 		if (npc == darkMage)
 		{
 			darkMage = null;
+		}
+	}
+
+	/**
+	 * Updates a pouch's contents in the config.
+	 * Values are bitpacked, since they each fit into 4 bits.
+	 * A value of 15 represents unknown
+	 * @param tier of the pouch
+	 * @param value to update with
+	 */
+	private void updatePouchContents(int tier, int value)
+	{
+		int current = config.pouchState();
+		final int offset = tier * 4;
+		final int mask = ~(15 << offset);
+		current = (current & mask) | (value << offset);
+		config.pouchState(current);
+	}
+
+	/**
+	 * Get a pouch's value from the bitpacked config value
+	 * See {@link RunecraftPlugin#updatePouchContents(int, int)} for more information
+	 * @param tier
+	 * @return the pouch's contents
+	 */
+	private int getPouchContents(int tier)
+	{
+		final int offset = tier * 4;
+		return (config.pouchState() & (15 << offset)) >> offset;
+	}
+
+	/**
+	 * Convert degraded pouch IDs into their repaired counterparts
+	 * @param itemId
+	 * @return repaired pouch id if degraded, otherwise itemId
+	 */
+	static int getPouchID(int itemId)
+	{
+		switch (itemId)
+		{
+			case ItemID.MEDIUM_POUCH_5511:
+				return ItemID.MEDIUM_POUCH;
+			case ItemID.LARGE_POUCH_5513:
+				return ItemID.LARGE_POUCH;
+			case ItemID.GIANT_POUCH_5515:
+				return ItemID.GIANT_POUCH;
+			default:
+				return itemId;
 		}
 	}
 }


### PR DESCRIPTION
Adds an overlay to Essence Pouches that shows how many essence they contain.
Handling of degraded pouches is only accurate on the first degradation tier; as a result, they show with a `?` after the number.
As with anything that tracks the inventory state, it is prone to breaking when clicking too fast. This is mostly handled correctly, though it isn't perfect, and major lag can break any checks we could do.

![unknown](https://user-images.githubusercontent.com/2979691/63655306-6d981180-c77e-11e9-9ac0-cc794be09aa5.png)
![empty](https://user-images.githubusercontent.com/2979691/63655307-712b9880-c77e-11e9-9660-75dfaeabea4e.png)
![filled](https://user-images.githubusercontent.com/2979691/63655308-74bf1f80-c77e-11e9-8823-6975151bca85.png)
![degraded](https://user-images.githubusercontent.com/2979691/63655310-7a1c6a00-c77e-11e9-931f-4432623b9a9e.png)


