### PR TITLE
runecraft: change layer of AbyssOverlay

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/runecraft/AbyssOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/runecraft/AbyssOverlay.java
@@ -77,7 +77,7 @@ class AbyssOverlay extends Overlay
 	AbyssOverlay(Client client, RunecraftPlugin plugin, RunecraftConfig config)
 	{
 		setPosition(OverlayPosition.DYNAMIC);
-		setLayer(OverlayLayer.ABOVE_WIDGETS);
+		setLayer(OverlayLayer.ABOVE_SCENE);
 		this.client = client;
 		this.plugin = plugin;
 		this.config = config;


### PR DESCRIPTION
This stops the rift highlights being drawn over the UI