### PR TITLE
add mouse listener to reset search results when clear button is pressed

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/SkillCalculator.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/SkillCalculator.java
@@ -89,6 +89,7 @@ class SkillCalculator extends JPanel
 		searchBar.setBackground(ColorScheme.DARKER_GRAY_COLOR);
 		searchBar.setHoverBackgroundColor(ColorScheme.DARK_GRAY_HOVER_COLOR);
 		searchBar.addKeyListener(e -> onSearch());
+		searchBar.addMouseListener(e -> onClear());
 
 		setLayout(new DynamicGridLayout(0, 1, 0, 5));
 
@@ -409,4 +410,12 @@ class SkillCalculator extends JPanel
 		return slot.getAction().getName().toLowerCase().contains(text.toLowerCase());
 	}
 
+	private void onClear()
+	{
+		uiActionSlots.forEach(slot ->
+		{
+			super.add(slot);
+			revalidate();
+		});
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/ui/components/IconTextField.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/components/IconTextField.java
@@ -252,6 +252,21 @@ public class IconTextField extends JPanel
 		textField.removeKeyListener(keyListener);
 	}
 
+	@Override
+	public void addMouseListener(MouseListener mouseListener)
+	{
+		clearButton.addMouseListener(mouseListener);
+	}
+
+	public void addMouseListener(Consumer<MouseEvent> mouseEventConsumer)
+	{
+		addMouseListener(new MouseAdapter()
+		{
+			@Override
+			public void mousePressed(MouseEvent e) { mouseEventConsumer.accept(e); }
+		});
+	}
+
 	public void setEditable(boolean editable)
 	{
 		textField.setEditable(editable);


### PR DESCRIPTION
This pull request addresses the unwanted behavior detailed in this [issue](https://github.com/runelite/runelite/issues/9545).

Currently, when a user enters text into the search bar, then clicks the `x` button to clear the search text, the skill calculator does not reset the search result. The implementation in this pull request will reset the list of results to the default list, which is the list of all items associated with the skill calculator of the selected skill.

Closes #9545