### PR TITLE
Inventory grid only shows once item is dragged

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/inventorygrid/InventoryGridConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/inventorygrid/InventoryGridConfig.java
@@ -27,7 +27,6 @@ package net.runelite.client.plugins.inventorygrid;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
-import net.runelite.client.config.Range;
 
 @ConfigGroup("inventorygrid")
 public interface InventoryGridConfig extends Config

--- a/runelite-client/src/main/java/net/runelite/client/plugins/inventorygrid/InventoryGridConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/inventorygrid/InventoryGridConfig.java
@@ -61,15 +61,4 @@ public interface InventoryGridConfig extends Config
 	{
 		return true;
 	}
-
-	@ConfigItem(
-		keyName = "dragDelay",
-		name = "Drag Delay",
-		description = "Time in ms to wait after item press before showing grid"
-	)
-	@Range(min = 100)
-	default int dragDelay()
-	{
-		return 100;
-	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/inventorygrid/InventoryGridOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/inventorygrid/InventoryGridOverlay.java
@@ -54,6 +54,10 @@ class InventoryGridOverlay extends Overlay
 	private final Client client;
 	private final ItemManager itemManager;
 
+	private static final int initialMousePointAreaRadius = 5;
+	private static Rectangle initialMousePointArea = null;
+	private static boolean passedInitialMousePointArea = false;
+
 	@Inject
 	private InventoryGridOverlay(InventoryGridConfig config, Client client, ItemManager itemManager)
 	{
@@ -71,9 +75,10 @@ class InventoryGridOverlay extends Overlay
 		final Widget if1DraggingWidget = client.getIf1DraggedWidget();
 		final Widget inventoryWidget = client.getWidget(WidgetInfo.INVENTORY);
 
-		if (if1DraggingWidget == null || if1DraggingWidget != inventoryWidget
-			|| client.getItemPressedDuration() < config.dragDelay() / Constants.CLIENT_TICK_LENGTH)
+		if (if1DraggingWidget == null || if1DraggingWidget != inventoryWidget)
 		{
+			initialMousePointArea = null;
+			passedInitialMousePointArea = false;
 			return null;
 		}
 
@@ -83,10 +88,23 @@ class InventoryGridOverlay extends Overlay
 		final WidgetItem draggedItem = inventoryWidget.getWidgetItem(if1DraggedItemIndex);
 		final int itemId = draggedItem.getId();
 
+		if (initialMousePointArea == null)
+		{
+			initialMousePointArea = new Rectangle((int) mousePoint.getX() - initialMousePointAreaRadius, (int) mousePoint.getY() - initialMousePointAreaRadius, initialMousePointAreaRadius * 2, initialMousePointAreaRadius * 2);
+			return null;
+		}
+
+		if(initialMousePointArea.contains(mousePoint) && !passedInitialMousePointArea)
+		{
+			return null;
+		}
+
 		if (itemId == -1)
 		{
 			return null;
 		}
+
+		passedInitialMousePointArea = true;
 
 		for (int i = 0; i < INVENTORY_SIZE; ++i)
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/inventorygrid/InventoryGridOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/inventorygrid/InventoryGridOverlay.java
@@ -34,7 +34,6 @@ import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.image.BufferedImage;
 import net.runelite.api.Client;
-import net.runelite.api.Constants;
 import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.api.widgets.WidgetItem;
@@ -94,7 +93,7 @@ class InventoryGridOverlay extends Overlay
 			return null;
 		}
 
-		if(initialMousePointArea.contains(mousePoint) && !passedInitialMousePointArea)
+		if (initialMousePointArea.contains(mousePoint) && !passedInitialMousePointArea)
 		{
 			return null;
 		}


### PR DESCRIPTION
![Inventory Grid Improvements](https://user-images.githubusercontent.com/20487224/63913197-1a26fd00-c9e4-11e9-8fb4-c9a165745dbc.gif)

- Inventory Grid does not show up until item is dragged 5 pixels away, which is when the client recognizes the action as moving the item and not clicking it
- Can hold the item in place as long as you want, and the grid will not show up
- Grid shows up immediately after dragging the item
- Removed the option for drag delay as it is no longer necessary with these improvements