### PR TITLE
runecraft: give minimap icons their own overlay

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/runecraft/AbyssMinimapOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/runecraft/AbyssMinimapOverlay.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018, Seth <Sethtroll3@gmail.com>
+ * Copyright (c) 2019 Hydrox6 <ikada@protonmail.ch>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -24,101 +24,86 @@
  */
 package net.runelite.client.plugins.runecraft;
 
-import java.awt.Color;
-import java.awt.Polygon;
-import java.awt.geom.Area;
 import com.google.inject.Inject;
-import java.awt.Dimension;
-import java.awt.Graphics2D;
 import net.runelite.api.Client;
 import net.runelite.api.DecorativeObject;
-import net.runelite.api.NPC;
+import net.runelite.api.Perspective;
 import net.runelite.api.Point;
+import net.runelite.client.game.ItemManager;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
-import net.runelite.client.ui.overlay.OverlayUtil;
+import java.awt.Dimension;
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+import java.util.HashMap;
+import java.util.Map;
 
-class AbyssOverlay extends Overlay
+class AbyssMinimapOverlay extends Overlay
 {
+	private static final Dimension IMAGE_SIZE = new Dimension(15, 14);
+
+	private final Map<AbyssRifts, BufferedImage> abyssIcons = new HashMap<>();
 	private final Client client;
 	private final RunecraftPlugin plugin;
 	private final RunecraftConfig config;
+	private final ItemManager itemManager;
 
 	@Inject
-	AbyssOverlay(Client client, RunecraftPlugin plugin, RunecraftConfig config)
+	AbyssMinimapOverlay(Client client, RunecraftPlugin plugin, RunecraftConfig config, ItemManager itemManager)
 	{
 		setPosition(OverlayPosition.DYNAMIC);
-		setLayer(OverlayLayer.ABOVE_SCENE);
+		setLayer(OverlayLayer.ABOVE_WIDGETS);
 		this.client = client;
 		this.plugin = plugin;
 		this.config = config;
+		this.itemManager = itemManager;
 	}
 
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
-		if (config.showRifts() && config.showClickBox())
+		if (!config.showRifts())
 		{
-			for (DecorativeObject object : plugin.getAbyssObjects())
-			{
-				renderRift(graphics, object);
-			}
+			return null;
 		}
 
-		if (config.hightlightDarkMage())
+		for (DecorativeObject object : plugin.getAbyssObjects())
 		{
-			highlightDarkMage(graphics);
+			AbyssRifts rift = AbyssRifts.getRift(object.getId());
+			if (rift == null || !plugin.getRifts().contains(rift))
+			{
+				continue;
+			}
+
+			BufferedImage image = getImage(rift);
+			Point miniMapImage = Perspective.getMiniMapImageLocation(client, object.getLocalLocation(), image);
+
+			if (miniMapImage != null)
+			{
+				graphics.drawImage(image, miniMapImage.getX(), miniMapImage.getY(), null);
+			}
 		}
 
 		return null;
 	}
 
-	private void highlightDarkMage(Graphics2D graphics)
+	private BufferedImage getImage(AbyssRifts rift)
 	{
-		if (!plugin.isDegradedPouchInInventory())
+		BufferedImage image = abyssIcons.get(rift);
+		if (image != null)
 		{
-			return;
+			return image;
 		}
 
-		NPC darkMage = plugin.getDarkMage();
-		if (darkMage == null)
-		{
-			return;
-		}
+		// Since item image is too big, we must resize it first.
+		image = itemManager.getImage(rift.getItemId());
+		BufferedImage resizedImage = new BufferedImage(IMAGE_SIZE.width, IMAGE_SIZE.height, BufferedImage.TYPE_INT_ARGB);
+		Graphics2D g = resizedImage.createGraphics();
+		g.drawImage(image, 0, 0, IMAGE_SIZE.width, IMAGE_SIZE.height, null);
+		g.dispose();
 
-		Polygon tilePoly = darkMage.getCanvasTilePoly();
-		if (tilePoly == null)
-		{
-			return;
-		}
-
-		OverlayUtil.renderPolygon(graphics, tilePoly, Color.green);
-	}
-
-	private void renderRift(Graphics2D graphics, DecorativeObject object)
-	{
-		AbyssRifts rift = AbyssRifts.getRift(object.getId());
-		if (rift == null || !plugin.getRifts().contains(rift))
-		{
-			return;
-		}
-
-		Point mousePosition = client.getMouseCanvasPosition();
-		Area objectClickbox = object.getClickbox();
-		if (objectClickbox != null)
-		{
-			if (objectClickbox.contains(mousePosition.getX(), mousePosition.getY()))
-			{
-				graphics.setColor(Color.MAGENTA.darker());
-			}
-			else
-			{
-				graphics.setColor(Color.MAGENTA);
-			}
-			graphics.draw(objectClickbox);
-			graphics.setColor(new Color(255, 0, 255, 20));
-			graphics.fill(objectClickbox);
-		}
+		abyssIcons.put(rift, resizedImage);
+		return resizedImage;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/runecraft/AbyssOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/runecraft/AbyssOverlay.java
@@ -27,19 +27,6 @@ package net.runelite.client.plugins.runecraft;
 import java.awt.Color;
 import java.awt.Polygon;
 import java.awt.geom.Area;
-import static net.runelite.client.plugins.runecraft.AbyssRifts.AIR_RIFT;
-import static net.runelite.client.plugins.runecraft.AbyssRifts.BLOOD_RIFT;
-import static net.runelite.client.plugins.runecraft.AbyssRifts.BODY_RIFT;
-import static net.runelite.client.plugins.runecraft.AbyssRifts.CHAOS_RIFT;
-import static net.runelite.client.plugins.runecraft.AbyssRifts.COSMIC_RIFT;
-import static net.runelite.client.plugins.runecraft.AbyssRifts.DEATH_RIFT;
-import static net.runelite.client.plugins.runecraft.AbyssRifts.EARTH_RIFT;
-import static net.runelite.client.plugins.runecraft.AbyssRifts.FIRE_RIFT;
-import static net.runelite.client.plugins.runecraft.AbyssRifts.LAW_RIFT;
-import static net.runelite.client.plugins.runecraft.AbyssRifts.MIND_RIFT;
-import static net.runelite.client.plugins.runecraft.AbyssRifts.NATURE_RIFT;
-import static net.runelite.client.plugins.runecraft.AbyssRifts.SOUL_RIFT;
-import static net.runelite.client.plugins.runecraft.AbyssRifts.WATER_RIFT;
 import com.google.inject.Inject;
 import java.awt.Dimension;
 import java.awt.Graphics2D;
@@ -63,7 +50,6 @@ class AbyssOverlay extends Overlay
 {
 	private static final Dimension IMAGE_SIZE = new Dimension(15, 14);
 
-	private final Set<AbyssRifts> rifts = new HashSet<>();
 	private final Map<AbyssRifts, BufferedImage> abyssIcons = new HashMap<>();
 
 	private final Client client;
@@ -127,7 +113,7 @@ class AbyssOverlay extends Overlay
 	private void renderRifts(Graphics2D graphics, DecorativeObject object)
 	{
 		AbyssRifts rift = AbyssRifts.getRift(object.getId());
-		if (rift == null || !rifts.contains(rift))
+		if (rift == null || !plugin.getRifts().contains(rift))
 		{
 			return;
 		}
@@ -180,62 +166,5 @@ class AbyssOverlay extends Overlay
 
 		abyssIcons.put(rift, resizedImage);
 		return resizedImage;
-	}
-
-	public void updateConfig()
-	{
-		rifts.clear();
-		if (config.showAir())
-		{
-			rifts.add(AIR_RIFT);
-		}
-		if (config.showBlood())
-		{
-			rifts.add(BLOOD_RIFT);
-		}
-		if (config.showBody())
-		{
-			rifts.add(BODY_RIFT);
-		}
-		if (config.showChaos())
-		{
-			rifts.add(CHAOS_RIFT);
-		}
-		if (config.showCosmic())
-		{
-			rifts.add(COSMIC_RIFT);
-		}
-		if (config.showDeath())
-		{
-			rifts.add(DEATH_RIFT);
-		}
-		if (config.showEarth())
-		{
-			rifts.add(EARTH_RIFT);
-		}
-		if (config.showFire())
-		{
-			rifts.add(FIRE_RIFT);
-		}
-		if (config.showLaw())
-		{
-			rifts.add(LAW_RIFT);
-		}
-		if (config.showMind())
-		{
-			rifts.add(MIND_RIFT);
-		}
-		if (config.showNature())
-		{
-			rifts.add(NATURE_RIFT);
-		}
-		if (config.showSoul())
-		{
-			rifts.add(SOUL_RIFT);
-		}
-		if (config.showWater())
-		{
-			rifts.add(WATER_RIFT);
-		}
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/runecraft/RunecraftPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/runecraft/RunecraftPlugin.java
@@ -55,6 +55,7 @@ import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
+import static net.runelite.client.plugins.runecraft.AbyssRifts.*;
 import net.runelite.client.ui.overlay.OverlayManager;
 
 @PluginDescriptor(
@@ -74,6 +75,9 @@ public class RunecraftPlugin extends Plugin
 
 	@Getter(AccessLevel.PACKAGE)
 	private final Set<DecorativeObject> abyssObjects = new HashSet<>();
+
+	@Getter(AccessLevel.PACKAGE)
+	private final Set<AbyssRifts> rifts = new HashSet<>();
 
 	@Getter(AccessLevel.PACKAGE)
 	private boolean degradedPouchInInventory;
@@ -106,7 +110,7 @@ public class RunecraftPlugin extends Plugin
 	protected void startUp() throws Exception
 	{
 		overlayManager.add(abyssOverlay);
-		abyssOverlay.updateConfig();
+		updateRifts();
 	}
 
 	@Override
@@ -123,7 +127,7 @@ public class RunecraftPlugin extends Plugin
 	{
 		if (event.getGroup().equals("runecraft"))
 		{
-			abyssOverlay.updateConfig();
+			updateRifts();
 		}
 	}
 
@@ -207,6 +211,63 @@ public class RunecraftPlugin extends Plugin
 		if (npc == darkMage)
 		{
 			darkMage = null;
+		}
+	}
+
+	private void updateRifts()
+	{
+		rifts.clear();
+		if (config.showAir())
+		{
+			rifts.add(AIR_RIFT);
+		}
+		if (config.showBlood())
+		{
+			rifts.add(BLOOD_RIFT);
+		}
+		if (config.showBody())
+		{
+			rifts.add(BODY_RIFT);
+		}
+		if (config.showChaos())
+		{
+			rifts.add(CHAOS_RIFT);
+		}
+		if (config.showCosmic())
+		{
+			rifts.add(COSMIC_RIFT);
+		}
+		if (config.showDeath())
+		{
+			rifts.add(DEATH_RIFT);
+		}
+		if (config.showEarth())
+		{
+			rifts.add(EARTH_RIFT);
+		}
+		if (config.showFire())
+		{
+			rifts.add(FIRE_RIFT);
+		}
+		if (config.showLaw())
+		{
+			rifts.add(LAW_RIFT);
+		}
+		if (config.showMind())
+		{
+			rifts.add(MIND_RIFT);
+		}
+		if (config.showNature())
+		{
+			rifts.add(NATURE_RIFT);
+		}
+		if (config.showSoul())
+		{
+			rifts.add(SOUL_RIFT);
+		}
+		if (config.showWater())
+		{
+			rifts.add(WATER_RIFT);
 		}
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/runecraft/RunecraftPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/runecraft/RunecraftPlugin.java
@@ -95,6 +95,9 @@ public class RunecraftPlugin extends Plugin
 	private AbyssOverlay abyssOverlay;
 
 	@Inject
+	private AbyssMinimapOverlay abyssMinimapOverlay;
+
+	@Inject
 	private RunecraftConfig config;
 
 	@Inject
@@ -110,6 +113,7 @@ public class RunecraftPlugin extends Plugin
 	protected void startUp() throws Exception
 	{
 		overlayManager.add(abyssOverlay);
+		overlayManager.add(abyssMinimapOverlay);
 		updateRifts();
 	}
 
@@ -117,6 +121,7 @@ public class RunecraftPlugin extends Plugin
 	protected void shutDown() throws Exception
 	{
 		overlayManager.remove(abyssOverlay);
+		overlayManager.remove(abyssMinimapOverlay);
 		abyssObjects.clear();
 		darkMage = null;
 		degradedPouchInInventory = false;


### PR DESCRIPTION
Moving the AbyssOverlay down to the correct layer stopped the runes from displaying on the minimap. Why an overlay was trying to do both Scene and Minimmap rendering I have no idea, but I've moved the minimap code to its own overlay. I've also moved the "what rifts to render" stuff to the plugin, since it's now common