### PR TITLE
hiscore: use a builder to build the tooltips

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/hiscore/HiscorePanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/hiscore/HiscorePanel.java
@@ -39,7 +39,9 @@ import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.EnumSet;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ScheduledExecutorService;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
@@ -489,10 +491,7 @@ public class HiscorePanel extends PluginPanel
 	 */
 	private String detailsHtml(HiscoreResult result, HiscoreSkill skill)
 	{
-		String openingTags = "<html><body style = 'padding: 5px;color:#989898'>";
-		String closingTags = "</html><body>";
-
-		String content = "";
+		final Tooltip.TooltipBuilder tooltipBuilder = Tooltip.builder();
 
 		if (skill == null)
 		{
@@ -511,9 +510,9 @@ public class HiscorePanel extends PluginPanel
 				+ result.getHitpoints().getExperience() + result.getMagic().getExperience()
 				+ result.getRanged().getExperience() + result.getPrayer().getExperience();
 
-			content += "<p><span style = 'color:white'>Skill:</span> Combat</p>";
-			content += "<p><span style = 'color:white'>Exact Combat Level:</span> " + StackFormatter.formatNumber(combatLevel) + "</p>";
-			content += "<p><span style = 'color:white'>Experience:</span> " + StackFormatter.formatNumber(combatExperience) + "</p>";
+			tooltipBuilder.skill("Combat")
+				.xp((int) combatExperience)
+				.other("Exact Combat Level", StackFormatter.formatNumber(combatLevel));
 		}
 		else
 		{
@@ -535,99 +534,80 @@ public class HiscorePanel extends PluginPanel
 					String hard = (result.getClueScrollHard().getLevel() == -1 ? "0" : StackFormatter.formatNumber(result.getClueScrollHard().getLevel()));
 					String elite = (result.getClueScrollElite().getLevel() == -1 ? "0" : StackFormatter.formatNumber(result.getClueScrollElite().getLevel()));
 					String master = (result.getClueScrollMaster().getLevel() == -1 ? "0" : StackFormatter.formatNumber(result.getClueScrollMaster().getLevel()));
-					content += "<p><span style = 'color:white'>All:</span> " + all + " <span style = 'color:white'>Rank:</span> " + allRank + "</p>";
-					content += "<p><span style = 'color:white'>Beginner:</span> " + beginner + " <span style = 'color:white'>Rank:</span> " + beginnerRank + "</p>";
-					content += "<p><span style = 'color:white'>Easy:</span> " + easy + " <span style = 'color:white'>Rank:</span> " + easyRank + "</p>";
-					content += "<p><span style = 'color:white'>Medium:</span> " + medium + " <span style = 'color:white'>Rank:</span> " + mediumRank + "</p>";
-					content += "<p><span style = 'color:white'>Hard:</span> " + hard + " <span style = 'color:white'>Rank:</span> " + hardRank + "</p>";
-					content += "<p><span style = 'color:white'>Elite:</span> " + elite + " <span style = 'color:white'>Rank:</span> " + eliteRank + "</p>";
-					content += "<p><span style = 'color:white'>Master:</span> " + master + " <span style = 'color:white'>Rank:</span> " + masterRank + "</p>";
+
+					// TODO: Figure out a better way to show the clue scroll tooltips
+					final Map<String, String> scrolls = new LinkedHashMap<>();
+					scrolls.put("All", all + " <span style = 'color:white'>Rank:</span> " + allRank);
+					scrolls.put("Beginner", beginner + " <span style = 'color:white'>Rank:</span> " + beginnerRank);
+					scrolls.put("Easy", easy + " <span style = 'color:white'>Rank:</span> " + easyRank);
+					scrolls.put("Medium", medium + " <span style = 'color:white'>Rank:</span> " + mediumRank);
+					scrolls.put("Hard", hard + " <span style = 'color:white'>Rank:</span> " + hardRank);
+					scrolls.put("Elite", elite + " <span style = 'color:white'>Rank:</span> " + eliteRank);
+					scrolls.put("Master", master + " <span style = 'color:white'>Rank:</span> " + masterRank);
+
+					tooltipBuilder.title("Clue Scrolls")
+						.others(scrolls);
 					break;
 				}
 				case BOUNTY_HUNTER_ROGUE:
 				{
-					String rank = (result.getBountyHunterRogue().getRank() == -1) ? "Unranked" : StackFormatter.formatNumber(result.getBountyHunterRogue().getRank());
-					content += "<p><span style = 'color:white'>Rank:</span> " + rank + "</p>";
+					tooltipBuilder.title("Bounty Hunter (Rogue)")
+						.rank(result.getBountyHunterRogue().getRank());
 					break;
 				}
 				case BOUNTY_HUNTER_HUNTER:
 				{
-					String rank = (result.getBountyHunterHunter().getRank() == -1) ? "Unranked" : StackFormatter.formatNumber(result.getBountyHunterHunter().getRank());
-					content += "<p><span style = 'color:white'>Rank:</span> " + rank + "</p>";
+					tooltipBuilder.title("Bounty Hunter (Hunter)")
+						.rank(result.getBountyHunterHunter().getRank());
 					break;
 				}
 				case LAST_MAN_STANDING:
 				{
-					String rank = (result.getLastManStanding().getRank() == -1) ? "Unranked" : StackFormatter.formatNumber(result.getLastManStanding().getRank());
-					content += "<p><span style = 'color:white'>Rank:</span> " + rank + "</p>";
+					tooltipBuilder.title("Last Man Standing")
+						.rank(result.getLastManStanding().getRank());
 					break;
 				}
 				case OVERALL:
 				{
-					Skill requestedSkill = result.getSkill(skill);
-					String rank = (requestedSkill.getRank() == -1) ? "Unranked" : StackFormatter.formatNumber(requestedSkill.getRank());
-					String exp = (requestedSkill.getExperience() == -1L) ? "Unranked" : StackFormatter.formatNumber(requestedSkill.getExperience());
-					content += "<p><span style = 'color:white'>Skill:</span> " + skill.getName() + "</p>";
-					content += "<p><span style = 'color:white'>Rank:</span> " + rank + "</p>";
-					content += "<p><span style = 'color:white'>Experience:</span> " + exp + "</p>";
+					final Skill requestedSkill = result.getSkill(skill);
+					tooltipBuilder.skill("Overall")
+						.xp(requestedSkill.getExperience())
+						.rank(requestedSkill.getRank());
 					break;
 				}
 				default:
 				{
-					Skill requestedSkill = result.getSkill(skill);
-					final long experience = requestedSkill.getExperience();
+					final Skill requestedSkill = result.getSkill(skill);
+					final int experience = (int) requestedSkill.getExperience();
+					final int remainingXp;
 
-					String rank = (requestedSkill.getRank() == -1) ? "Unranked" : StackFormatter.formatNumber(requestedSkill.getRank());
-					String exp = (experience == -1L) ? "Unranked" : StackFormatter.formatNumber(experience);
-					String remainingXp;
-					if (experience == -1L)
+					if (experience == -1)
 					{
-						remainingXp = "Unranked";
+						// if the xp is unknown, there is no reason to show anything but name & rank
+						tooltipBuilder.skill(skill.getName())
+							.rank(requestedSkill.getRank());
 					}
 					else
 					{
-						int currentLevel = Experience.getLevelForXp((int) experience);
-						remainingXp = (currentLevel + 1 <= Experience.MAX_VIRT_LEVEL) ? StackFormatter.formatNumber(Experience.getXpForLevel(currentLevel + 1) - experience) : "0";
+						final int currentLevel = Experience.getLevelForXp(experience);
+						remainingXp = (currentLevel + 1 <= Experience.MAX_VIRT_LEVEL) ? Experience.getXpForLevel(currentLevel + 1) - experience : 0;
+
+						tooltipBuilder.skill(skill.getName())
+							.xp(experience)
+							.remainingXp(remainingXp)
+							.rank(requestedSkill.getRank());
 					}
-
-					content += "<p><span style = 'color:white'>Skill:</span> " + skill.getName() + "</p>";
-					content += "<p><span style = 'color:white'>Rank:</span> " + rank + "</p>";
-					content += "<p><span style = 'color:white'>Experience:</span> " + exp + "</p>";
-					content += "<p><span style = 'color:white'>Remaining XP:</span> " + remainingXp + "</p>";
-
 					break;
 				}
 			}
 		}
 
-		/**
-		 * Adds a html progress bar to the hover information
-		 */
 		if (SKILLS.contains(skill))
 		{
-			long experience = result.getSkill(skill).getExperience();
-			if (experience >= 0)
-			{
-				int currentXp = (int) experience;
-				int currentLevel = Experience.getLevelForXp(currentXp);
-				int xpForCurrentLevel = Experience.getXpForLevel(currentLevel);
-				int xpForNextLevel = currentLevel + 1 <= Experience.MAX_VIRT_LEVEL ? Experience.getXpForLevel(currentLevel + 1) : -1;
-
-				double xpGained = currentXp - xpForCurrentLevel;
-				double xpGoal = xpForNextLevel != -1 ? xpForNextLevel - xpForCurrentLevel : 100;
-				int progress = (int) ((xpGained / xpGoal) * 100f);
-
-				// had to wrap the bar with an empty div, if i added the margin directly to the bar, it would mess up
-				content += "<div style = 'margin-top:3px'>"
-					+ "<div style = 'background: #070707; border: 1px solid #070707; height: 6px; width: 100%;'>"
-					+ "<div style = 'height: 6px; width: " + progress + "%; background: #dc8a00;'>"
-					+ "</div>"
-					+ "</div>"
-					+ "</div>";
-			}
+			tooltipBuilder.progressbar(true);
 		}
 
-		return openingTags + content + closingTags;
+		return tooltipBuilder.build().toHtml();
 	}
 
 	private static String sanitize(String lookup)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/hiscore/Tooltip.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/hiscore/Tooltip.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2019, Adam Witkowski <https://github.com/adwitkow>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.hiscore;
+
+import com.google.common.base.Strings;
+import lombok.Builder;
+import lombok.Singular;
+import lombok.Value;
+import net.runelite.api.Experience;
+import net.runelite.client.util.StackFormatter;
+import java.util.Map;
+
+@Value
+@Builder
+class Tooltip
+{
+	private static final String OPENING_TAGS = "<html><body style = 'padding: 5px;color:#989898'>";
+	private static final String CLOSING_TAGS = "</body></html>";
+	private static final String UNRANKED = "Unranked";
+
+	private String title;
+	private String skill;
+	private int rank;
+	@Builder.Default
+	private long xp = -1;
+	@Builder.Default
+	private int remainingXp = -1;
+	private boolean progressbar;
+	@Singular
+	private Map<String, String> others;
+
+	String toHtml()
+	{
+		final StringBuilder contentBuilder = new StringBuilder();
+		contentBuilder.append(OPENING_TAGS);
+
+		if (!Strings.isNullOrEmpty(title))
+		{
+			contentBuilder.append(wrapNewLine(wrapTitle(title)));
+		}
+
+		if (!Strings.isNullOrEmpty(skill))
+		{
+			contentBuilder.append(wrapNewLine(wrapTitle("Skill") + skill));
+		}
+
+		final String rankTitle = wrapTitle("Rank");
+
+		switch (rank)
+		{
+			case 0:
+			{
+				// We can assume that it has not been set, so we should not show it
+				// (e.g. Combat Level has no rank row)
+				break;
+			}
+			case -1:
+			{
+				contentBuilder.append(wrapNewLine(rankTitle + UNRANKED));
+				break;
+			}
+			default:
+			{
+				contentBuilder.append(wrapNewLine(rankTitle + formatNumber(rank)));
+				break;
+			}
+		}
+
+		if (xp >= 0)
+		{
+			contentBuilder.append(wrapNewLine(wrapTitle("Experience") + formatNumber(xp)));
+		}
+
+		if (remainingXp >= 0)
+		{
+			contentBuilder.append(wrapNewLine(wrapTitle("Remaining XP") + formatNumber(remainingXp)));
+		}
+
+		if (progressbar)
+		{
+			if (xp >= 0)
+			{
+				final int currentXp = (int) xp;
+				final int currentLevel = Experience.getLevelForXp(currentXp);
+				final int xpForCurrentLevel = Experience.getXpForLevel(currentLevel);
+				final int xpForNextLevel = currentLevel + 1 <= Experience.MAX_VIRT_LEVEL ? Experience.getXpForLevel(currentLevel + 1) : -1;
+
+				final double xpGained = currentXp - xpForCurrentLevel;
+				final double xpGoal = xpForNextLevel != -1 ? xpForNextLevel - xpForCurrentLevel : 100;
+				final int progress = (int) ((xpGained / xpGoal) * 100f);
+
+				final String htmlProgress = "<div style='margin-top:3px;'>"
+					+ "<div style = 'background: #070707; border: 1px solid #070707; height: 6px; width: 100%;'>"
+					+ "<div style = 'height: 6px; width: " + progress + "%; background: #dc8a00;' />"
+					+ "</div></div>";
+				contentBuilder.append(htmlProgress);
+			}
+		}
+
+		if (others.size() > 0)
+		{
+			{
+				for (final Map.Entry<String, String> entry : others.entrySet())
+				{
+					contentBuilder.append(wrapNewLine(wrapTitle(entry.getKey()) + entry.getValue()));
+				}
+			}
+		}
+
+		contentBuilder.append(CLOSING_TAGS);
+		return contentBuilder.toString();
+	}
+
+	private String wrapTitle(final String title)
+	{
+		return "<span style = 'color:white'>" + title + ":</span> ";
+	}
+
+	private String wrapNewLine(final String line)
+	{
+		return "<p>" + line + "</p>";
+	}
+
+	private String formatNumber(final int number)
+	{
+		return StackFormatter.formatNumber(number);
+	}
+
+	private String formatNumber(final long number)
+	{
+		return StackFormatter.formatNumber(number);
+	}
+}


### PR DESCRIPTION
- instead of using a raw html string to build the tooltips, we can use builder components and convert them on return
- hiding the elements based on availability is easier now (instead of showing three null values for a tooltip - `rank: unranked`, `xp: unranked` and `remaining xp: unranked` for some reason - we can just omit anything but `rank: unranked`)
- clue scrolls are still bad but they have a title now
- I am not sure how the `closingTags` ever worked
- also, closes #6368 because titles were added

I am still learning lombok so pls no bully