### PR TITLE
ClientLoader: Cache the patched jar

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/rs/ClientConfigLoader.java
+++ b/runelite-client/src/main/java/net/runelite/client/rs/ClientConfigLoader.java
@@ -28,8 +28,8 @@ package net.runelite.client.rs;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import net.runelite.http.api.RuneLiteAPI;
 import okhttp3.HttpUrl;
+import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
 
@@ -41,7 +41,7 @@ class ClientConfigLoader
 
 	private static final String CONFIG_URL = "http://oldschool.runescape.com/jav_config.ws";
 
-	static RSConfig fetch(String host) throws IOException
+	static RSConfig fetch(OkHttpClient client, String host) throws IOException
 	{
 		HttpUrl url = HttpUrl.parse(CONFIG_URL);
 		if (host != null)
@@ -55,7 +55,7 @@ class ClientConfigLoader
 
 		final RSConfig config = new RSConfig();
 
-		try (final Response response = RuneLiteAPI.CLIENT.newCall(request).execute())
+		try (final Response response = client.newCall(request).execute())
 		{
 			if (!response.isSuccessful())
 			{

--- a/runelite-client/src/main/java/net/runelite/client/rs/ClientUpdateCheckMode.java
+++ b/runelite-client/src/main/java/net/runelite/client/rs/ClientUpdateCheckMode.java
@@ -28,5 +28,6 @@ public enum ClientUpdateCheckMode
 {
 	AUTO,
 	NONE,
-	VANILLA
+	VANILLA,
+	CACHE
 }


### PR DESCRIPTION
This works by checking the mtime in the first file in the vanilla jar against what was it was when the client was last patched. This adds a small amount of time to the slow (patching) path, but saves much more when we are able to hit the cache.

Depends on !80