### PR TITLE
Swap eat for guzzle for the dwarven rock cake

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -301,4 +301,14 @@ public interface MenuEntrySwapperConfig extends Config
 	{
 		return true;
 	}
+
+	@ConfigItem(
+			keyName = "swapGuzzle",
+			name = "Guzzle",
+			description = "Swap Eat with Guzzle for Dwarven rock cake"
+	)
+	default boolean swapGuzzle()
+	{
+		return true;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -594,6 +594,10 @@ public class MenuEntrySwapperPlugin extends Plugin
 		{
 			swap("use", option, target, true);
 		}
+		else if (config.swapGuzzle() && option.equals("eat"))
+		{
+			swap("guzzle", option, target, true);
+		}
 	}
 
 	private static boolean shouldSwapPickpocket(String target)


### PR DESCRIPTION
Guzzling the Dwarven rock cake provides damage of 10% vs 1hp when eating. This should make reaching 1 player hitpoint much less click intensive.