### PR TITLE
ChatCommandsPlugin: add !kc penance queen feature

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
@@ -49,6 +49,7 @@ import net.runelite.api.events.VarbitChanged;
 import net.runelite.api.events.WidgetLoaded;
 import net.runelite.api.vars.AccountType;
 import net.runelite.api.widgets.Widget;
+import static net.runelite.api.widgets.WidgetID.BA_REWARD_GROUP_ID;
 import static net.runelite.api.widgets.WidgetID.KILL_LOGS_GROUP_ID;
 import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.chat.ChatColorType;
@@ -380,14 +381,35 @@ public class ChatCommandsPlugin extends Plugin
 	@Subscribe
 	public void onWidgetLoaded(WidgetLoaded widget)
 	{
-		// don't load kc if in an instance, if the player is in another players poh
-		// and reading their boss log
-		if (widget.getGroupId() != KILL_LOGS_GROUP_ID || client.isInInstancedRegion())
+		switch (widget.getGroupId())
 		{
-			return;
-		}
+			case KILL_LOGS_GROUP_ID:
+			{
+				// don't load kc if in an instance, if the player is in another players poh
+				// and reading their boss log
+				if (client.isInInstancedRegion())
+				{
+					return;
+				}
+				logKills = true;
 
-		logKills = true;
+				break;
+			}
+			case BA_REWARD_GROUP_ID:
+			{
+				// Record Penance Queen KC when reward widget appears after wave 10.
+				Widget rewardWidget = client.getWidget(WidgetInfo.BA_REWARD_TEXT);
+				if (rewardWidget != null
+					&& rewardWidget.getText().contains("<br>5"))
+				{
+					int kc = getKc("Penance Queen");
+					setKc("Penance Queen", kc + 1);
+					log.debug("Setting penance queen kill count: {}", kc + 1);
+				}
+
+				break;
+			}
+		}
 	}
 
 	@Subscribe
@@ -1304,6 +1326,11 @@ public class ChatCommandsPlugin extends Plugin
 
 			case "hydra":
 				return "Alchemical Hydra";
+
+			case "pq":
+			case "ba":
+			case "penance":
+				return "Penance Queen";
 
 			// gwd
 			case "sara":


### PR DESCRIPTION
When the final reward widget appears after wave 10 in Barbarian Assault, increment and submit a user's penance queen kc. 

Usage: !kc [ba | pq | penance]

Basically a barbarian assault round counter, but since the penance queen is a boss I figured it needed a !kc command.

Since the game does not track # of completed ba games, all users start at 0. 

The code for identifying the final BA reward widget was based off of [BarbarianAssaultPlugin.java](https://github.com/runelite/runelite/blob/master/runelite-client/src/main/java/net/runelite/client/plugins/barbarianassault/BarbarianAssaultPlugin.java#L119).

