### PR TITLE
cluescrolls: Reset clue on new beginner/master step 

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/ClueScrollPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/ClueScrollPlugin.java
@@ -233,14 +233,6 @@ public class ClueScrollPlugin extends Plugin
 				((SkillChallengeClue) clue).setChallengeCompleted(true);
 			}
 		}
-
-		if (!event.getMessage().equals("The strange device cools as you find your treasure.")
-			&& !event.getMessage().equals("Well done, you've completed the Treasure Trail!"))
-		{
-			return;
-		}
-
-		resetClue(true);
 	}
 
 	@Subscribe
@@ -406,6 +398,15 @@ public class ClueScrollPlugin extends Plugin
 					}
 				}
 			}
+		}
+
+		// Reset clue when receiving a new beginner or master clue
+		// These clues use a single item ID, so we cannot detect step changes based on the item ID changing
+		final Widget chatDialogClueItem = client.getWidget(WidgetInfo.DIALOG_SPRITE_SPRITE);
+		if (chatDialogClueItem != null
+			&& (chatDialogClueItem.getItemId() == ItemID.CLUE_SCROLL_BEGINNER || chatDialogClueItem.getItemId() == ItemID.CLUE_SCROLL_MASTER))
+		{
+			resetClue(true);
 		}
 
 		// If we have a clue, save that knowledge


### PR DESCRIPTION
When receiving a new beginner or master clue step (which can be detected
by checking the item ID shown in the chat dialog), the clue ID does not
change, because all beginner and master clues share a single ID. Hence,
we can reset the current clue when the "You've found a new clue!" dialog
appears to prevent stale clue information from persisting between steps.

Closes #9830