### PR TITLE
clues: fix emote hint ordering

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java
@@ -216,12 +216,6 @@ public class EmoteClue extends ClueScroll implements TextClueScroll, LocationClu
 			.leftColor(TITLED_CONTENT_COLOR)
 			.build());
 
-		panelComponent.getChildren().add(LineComponent.builder().left("Location:").build());
-		panelComponent.getChildren().add(LineComponent.builder()
-			.left(getLocationName())
-			.leftColor(TITLED_CONTENT_COLOR)
-			.build());
-
 		if (getSecondEmote() != null)
 		{
 			panelComponent.getChildren().add(LineComponent.builder()
@@ -229,6 +223,12 @@ public class EmoteClue extends ClueScroll implements TextClueScroll, LocationClu
 				.leftColor(TITLED_CONTENT_COLOR)
 				.build());
 		}
+
+		panelComponent.getChildren().add(LineComponent.builder().left("Location:").build());
+		panelComponent.getChildren().add(LineComponent.builder()
+			.left(getLocationName())
+			.leftColor(TITLED_CONTENT_COLOR)
+			.build());
 
 		if (itemRequirements.length > 0)
 		{


### PR DESCRIPTION
Fixes this:
![image](https://user-images.githubusercontent.com/2979691/64532637-c7194800-d309-11e9-8a51-69e1c82bbccc.png)


Somehow, the ordering has been wrong since https://github.com/runelite/runelite/commit/a244ca22649c71eb92dd1a890eced2fe1a82036c, for a month and a half.