### PR TITLE
Added Gu'Tanoth Hard Coord Clue Step Help Text

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java
@@ -94,7 +94,7 @@ public class CoordinateClue extends ClueScroll implements TextClueScroll, Locati
 		.put(new WorldPoint(3544, 3256, 0), "North-east of Burgh de Rott.")
 		.put(new WorldPoint(2841, 3267, 0), "Crandor island.")
 		.put(new WorldPoint(3168, 3041, 0), "Bedabin Camp.")
-		.put(new WorldPoint(2542, 3031, 0), "Gu'Tanoth.")
+		.put(new WorldPoint(2542, 3031, 0), "Gu'Tanoth, bring 20 for bridge jump.")
 		.put(new WorldPoint(2581, 3030, 0), "Gu'Tanoth island, enter cave north-west of Feldip Hills (AKS).")
 		.put(new WorldPoint(2961, 3024, 0), "Ship yard (DKP).")
 		.put(new WorldPoint(2339, 3311, 0), "East of Prifddinas on Arandar mountain pass.")

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java
@@ -94,7 +94,7 @@ public class CoordinateClue extends ClueScroll implements TextClueScroll, Locati
 		.put(new WorldPoint(3544, 3256, 0), "North-east of Burgh de Rott.")
 		.put(new WorldPoint(2841, 3267, 0), "Crandor island.")
 		.put(new WorldPoint(3168, 3041, 0), "Bedabin Camp.")
-		.put(new WorldPoint(2542, 3031, 0), "Gu'Tanoth, bring 20 for bridge jump.")
+		.put(new WorldPoint(2542, 3031, 0), "Gu'Tanoth, bring 20gp for bridge jump.")
 		.put(new WorldPoint(2581, 3030, 0), "Gu'Tanoth island, enter cave north-west of Feldip Hills (AKS).")
 		.put(new WorldPoint(2961, 3024, 0), "Ship yard (DKP).")
 		.put(new WorldPoint(2339, 3311, 0), "East of Prifddinas on Arandar mountain pass.")

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java
@@ -94,7 +94,7 @@ public class CoordinateClue extends ClueScroll implements TextClueScroll, Locati
 		.put(new WorldPoint(3544, 3256, 0), "North-east of Burgh de Rott.")
 		.put(new WorldPoint(2841, 3267, 0), "Crandor island.")
 		.put(new WorldPoint(3168, 3041, 0), "Bedabin Camp.")
-		.put(new WorldPoint(2542, 3031, 0), "Gu'Tanoth, bring 20gp for bridge jump.")
+		.put(new WorldPoint(2542, 3031, 0), "Gu'Tanoth, may require 20gp.")
 		.put(new WorldPoint(2581, 3030, 0), "Gu'Tanoth island, enter cave north-west of Feldip Hills (AKS).")
 		.put(new WorldPoint(2961, 3024, 0), "Ship yard (DKP).")
 		.put(new WorldPoint(2339, 3311, 0), "East of Prifddinas on Arandar mountain pass.")


### PR DESCRIPTION
Fixes #9847
Made change to Gu'Tanoth hard coordinate clue to add help text for user ease of use. After hopping over the bridge, the flag for the 20gp is reset, resulting in the player having to provide another 20gp on next visit.