### PR TITLE
Skill Calculator: adds all dairy churn cooking training methods

### DIFF
--- a/runelite-client/src/main/resources/net/runelite/client/plugins/skillcalculator/skill_cooking.json
+++ b/runelite-client/src/main/resources/net/runelite/client/plugins/skillcalculator/skill_cooking.json
@@ -188,6 +188,12 @@
     },
     {
       "level": 21,
+      "icon": 2130,
+      "name": "Pot of Cream",
+      "xp": 18
+    },
+    {
+      "level": 21,
       "icon": 9988,
       "name": "Roast Beast Meat",
       "xp": 82.5
@@ -331,6 +337,18 @@
       "xp": 115
     },
     {
+      "level": 38,
+      "icon": 6697,
+      "name": "Pat of Butter (Cream)",
+      "xp": 22.5
+    },
+    {
+      "level": 38,
+      "icon": 6697,
+      "name": "Pat of Butter (Milk)",
+      "xp": 40.5
+    },
+    {
       "level": 39,
       "icon": 1911,
       "name": "Dragon Bitter",
@@ -389,6 +407,24 @@
       "icon": 7188,
       "name": "Fish Pie",
       "xp": 164
+    },
+    {
+      "level": 48,
+      "icon": 1985,
+      "name": "Cheese (Butter)",
+      "xp": 23.5
+    },
+    {
+      "level": 48,
+      "icon": 1985,
+      "name": "Cheese (Cream)",
+      "xp": 46
+    },
+    {
+      "level": 48,
+      "icon": 1985,
+      "name": "Cheese (Milk)",
+      "xp": 64
     },
     {
       "level": 50,


### PR DESCRIPTION
All dairy churn methods are added, including butter from cream and cheese from cream and/or butter as well as the standard milk.

![XAfqUAk](https://user-images.githubusercontent.com/49340570/64961039-829f2680-d88c-11e9-8ca1-fabc0d9c9fc3.png)

![kC1ZkD8](https://user-images.githubusercontent.com/49340570/64961048-859a1700-d88c-11e9-982b-63fb2330dffc.png)

![gC7ZozU](https://user-images.githubusercontent.com/49340570/64961056-892d9e00-d88c-11e9-841a-c9afc24c2fd5.png)

Fixes #9870 