### PR TITLE
Bug/9875 Change nmz label Points/Hour

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/nightmarezone/NightmareZoneOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/nightmarezone/NightmareZoneOverlay.java
@@ -111,7 +111,7 @@ class NightmareZoneOverlay extends Overlay
 			.right(StackFormatter.formatNumber(currentPoints))
 			.build());
 		panelComponent.getChildren().add(LineComponent.builder()
-			.left("Points/Hour: ")
+			.left("Points/hr: ")
 			.right(StackFormatter.formatNumber(plugin.getPointsPerHour()))
 			.build());
 		panelComponent.getChildren().add(LineComponent.builder()


### PR DESCRIPTION
Fixes #9875 

Chosen result based on that points is already defined above this label.("Points") P/h would be to cryptic and short to understand, so we chose for P/Hour.
