### PR TITLE
Bug/9780 Add Forthos Dungeon monsters to the NPC health list

### DIFF
--- a/runelite-client/src/main/resources/npc_health.json
+++ b/runelite-client/src/main/resources/npc_health.json
@@ -1157,5 +1157,8 @@
 	"Wyrm_99": 130,
 	"Drake_192": 250,
 	"Hydra_194": 300,
-	"Alchemical Hydra_426": 1100
+	"Alchemical Hydra_426": 1100,
+	"Undead Druid_105": 140,
+	"Temple Spider_75": 70,
+	"Sarachnis_318": 400
 }


### PR DESCRIPTION
Add NPCs in the Forthos Dungeon to the <a href="https://github.com/runelite/runelite/blob/master/runelite-client/src/main/resources/npc_health.json">npc_health.json</a> as described in https://github.com/runelite/runelite/issues/9780

Closes #9890