### PR TITLE
Configure stale bot  to manage stale contributions

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -21,7 +21,7 @@ pulls:
 
 
 # Optionally, specify configuration settings that are specific to just 'issues' or 'pulls':
-issues
+issues:
   daysUntilStale: 120
   markComment: >
     This issue has been automatically marked as stale because it has not had

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,29 @@
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 7
+
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - jagex-bug
+  - jvm-bug
+
+# Label to use when marking an issue as stale
+staleLabel: innactive
+closeComment: false
+
+
+# Optionally, specify configuration settings that are specific to just 'issues' or 'pulls':
+pulls:
+  daysUntilStale: 120
+  markComment: >
+    This pull request has been automatically marked as stale because it has not had
+    recent activity. It will be closed if no further activity occurs. Thank you
+    for your contributions.
+
+
+# Optionally, specify configuration settings that are specific to just 'issues' or 'pulls':
+issues
+  daysUntilStale: 120
+  markComment: >
+    This issue has been automatically marked as stale because it has not had
+    recent activity. It will be closed if no further activity occurs. Thank you
+    for your contributions.


### PR DESCRIPTION
This adds an initial stale bot config which allows separate configuration of issues and PRs. 

[Install](https://github.com/apps/stale) the bot to the repository
https://imgur.com/a/ZxH0hGA

120 days ago is May 24 2019
[issues](https://github.com/runelite/runelite/issues?page=33&q=is%3Aissue+is%3Aopen+sort%3Aupdated-asc): removes about 33 pages
[PRs](https://github.com/runelite/runelite/pulls?page=1&q=is%3Apr+is%3Aopen+sort%3Aupdated-asc):  only removes one page. But these go stale faster so possibly better to lower this to 30 days. 


You'd need to install the app, not sure if the bot will create the "innactive" tag. 
