### PR TITLE
client: show names of members items in F2P

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/ItemComposition.java
+++ b/runelite-api/src/main/java/net/runelite/api/ItemComposition.java
@@ -32,11 +32,21 @@ import javax.annotation.Nullable;
 public interface ItemComposition extends ParamHolder
 {
 	/**
-	 * Gets the item's name.
+	 * Gets the item's name as it appears in game.
+	 * On a members server, this is always the item's actual name.
+	 * On a free server, this will be the actual name, with " (Members)" appended to it, e.g. Twisted bow (Members)
 	 *
-	 * @return the name of the item
+	 * @return the name of the item as it appears in game
 	 */
 	String getName();
+
+	/**
+	 * Gets the real item name, even if the player is on a F2P server.
+	 * Unlike {@link ItemComposition#getName()}, this will not have " (Members)" at the end on F2P servers.
+	 *
+	 * @return the real name of the item
+	 */
+	String getMembersName();
 
 	/**
 	 * Sets the item's name.

--- a/runelite-client/src/main/java/net/runelite/client/party/PartyService.java
+++ b/runelite-client/src/main/java/net/runelite/client/party/PartyService.java
@@ -102,7 +102,7 @@ public class PartyService
 			{
 				final int itemId = r.nextInt(client.getItemCount());
 				final ItemComposition def = client.getItemDefinition(itemId);
-				final String name = def.getName();
+				final String name = def.getMembersName();
 				if (name == null || name.isEmpty() || name.equalsIgnoreCase("null"))
 				{
 					continue;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/devtools/InventoryInspector.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/devtools/InventoryInspector.java
@@ -261,7 +261,7 @@ class InventoryInspector extends DevToolsFrame
 		{
 			final Item item = items[i];
 			final ItemComposition c = itemManager.getItemComposition(item.getId());
-			out[i] = new InventoryItem(i, item, c.getName(), c.isStackable());
+			out[i] = new InventoryItem(i, item, c.getMembersName(), c.isStackable());
 		}
 
 		return out;
@@ -303,7 +303,7 @@ class InventoryInspector extends DevToolsFrame
 				final ItemComposition c = itemManager.getItemComposition(e.getKey());
 
 				InventoryItem[] items = {
-					new InventoryItem(-1, new Item(id, qty), c.getName(), c.isStackable())
+					new InventoryItem(-1, new Item(id, qty), c.getMembersName(), c.isStackable())
 				};
 				if (!c.isStackable() && (qty > 1 || qty < -1))
 				{
@@ -311,7 +311,7 @@ class InventoryInspector extends DevToolsFrame
 					for (int i = 0; i < Math.abs(qty); i++)
 					{
 						final Item item = new Item(id, Integer.signum(qty));
-						items[i] = new InventoryItem(-1, item, c.getName(), c.isStackable());
+						items[i] = new InventoryItem(-1, item, c.getMembersName(), c.isStackable());
 					}
 				}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/examine/ExaminePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/examine/ExaminePlugin.java
@@ -108,7 +108,7 @@ public class ExaminePlugin extends Plugin
 				{
 					int itemId = event.getId();
 					final ChatMessageBuilder message = new ChatMessageBuilder()
-						.append(QuantityFormatter.formatNumber(quantity)).append(" x ").append(itemManager.getItemComposition(itemId).getName());
+						.append(QuantityFormatter.formatNumber(quantity)).append(" x ").append(itemManager.getItemComposition(itemId).getMembersName());
 					chatMessageManager.queue(QueuedMessage.builder()
 						.type(ChatMessageType.ITEM_EXAMINE)
 						.runeLiteFormattedMessage(message.build())
@@ -243,7 +243,7 @@ public class ExaminePlugin extends Plugin
 			}
 
 			message
-				.append(itemComposition.getName())
+				.append(itemComposition.getMembersName())
 				.append(ChatColorType.NORMAL)
 				.append(":");
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangeOfferSlot.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangeOfferSlot.java
@@ -211,7 +211,7 @@ public class GrandExchangeOfferSlot extends JPanel
 		{
 			cardLayout.show(container, FACE_CARD);
 
-			itemName.setText(offerItem.getName());
+			itemName.setText(offerItem.getMembersName());
 			itemIcon.setIcon(new ImageIcon(itemImage));
 
 			boolean buying = newOffer.getState() == BOUGHT
@@ -239,7 +239,7 @@ public class GrandExchangeOfferSlot extends JPanel
 			popupMenu.setBorder(new EmptyBorder(5, 5, 5, 5));
 
 			final JMenuItem openGeLink = new JMenuItem("Open Grand Exchange website");
-			openGeLink.addActionListener(e -> grandExchangePlugin.openGeLink(offerItem.getName(), offerItem.getId()));
+			openGeLink.addActionListener(e -> grandExchangePlugin.openGeLink(offerItem.getMembersName(), offerItem.getId()));
 			popupMenu.add(openGeLink);
 
 			/* Couldn't set the tooltip for the container panel as the children override it, so I'm setting

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
@@ -1018,7 +1018,7 @@ public class LootTrackerPlugin extends Plugin
 					int cnt = removedItems.count(itemId);
 					if (cnt > 0)
 					{
-						String name = itemManager.getItemComposition(itemId).getName();
+						String name = itemManager.getItemComposition(itemId).getMembersName();
 						addLoot(name, -1, LootRecordType.EVENT, null, invItems, cnt);
 					}
 				}));
@@ -1248,11 +1248,11 @@ public class LootTrackerPlugin extends Plugin
 		final ItemComposition itemComposition = itemManager.getItemComposition(itemId);
 		final int gePrice = itemManager.getItemPrice(itemId);
 		final int haPrice = itemComposition.getHaPrice();
-		final boolean ignored = ignoredItems.contains(itemComposition.getName());
+		final boolean ignored = ignoredItems.contains(itemComposition.getMembersName());
 
 		return new LootTrackerItem(
 			itemId,
-			itemComposition.getName(),
+			itemComposition.getMembersName(),
 			quantity,
 			gePrice,
 			haPrice,

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -824,7 +824,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 							.onClick(e ->
 							{
 								final String message = new ChatMessageBuilder()
-									.append("The default worn left click option for '").append(itemComposition.getName()).append("' ")
+									.append("The default worn left click option for '").append(itemComposition.getMembersName()).append("' ")
 									.append("has been reset.")
 									.build();
 
@@ -833,7 +833,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 									.runeLiteFormattedMessage(message)
 									.build());
 
-								log.debug("Unset worn item left swap for {}", itemComposition.getName());
+								log.debug("Unset worn item left swap for {}", itemComposition.getMembersName());
 								unsetWornItemSwapConfig(false, itemComposition.getId());
 							});
 					}
@@ -846,7 +846,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 							.onClick(e ->
 							{
 								final String message = new ChatMessageBuilder()
-									.append("The default worn shift click option for '").append(itemComposition.getName()).append("' ")
+									.append("The default worn shift click option for '").append(itemComposition.getMembersName()).append("' ")
 									.append("has been reset.")
 									.build();
 
@@ -855,7 +855,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 									.runeLiteFormattedMessage(message)
 									.build());
 
-								log.debug("Unset worn item shift swap for {}", itemComposition.getName());
+								log.debug("Unset worn item shift swap for {}", itemComposition.getMembersName());
 								unsetWornItemSwapConfig(true, itemComposition.getId());
 							});
 					}
@@ -870,7 +870,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 		return e ->
 		{
 			final String message = new ChatMessageBuilder()
-				.append("The default worn ").append(shift ? "shift" : "left").append(" click option for '").append(Text.removeTags(itemComposition.getName())).append("' ")
+				.append("The default worn ").append(shift ? "shift" : "left").append(" click option for '").append(Text.removeTags(itemComposition.getMembersName())).append("' ")
 				.append("has been set to '").append(opName).append("'.")
 				.build();
 
@@ -879,7 +879,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 				.runeLiteFormattedMessage(message)
 				.build());
 
-			log.debug("Set worn item {} swap for {} to {}", shift ? "shift" : "left", itemComposition.getName(), opIdx);
+			log.debug("Set worn item {} swap for {} to {}", shift ? "shift" : "left", itemComposition.getMembersName(), opIdx);
 			setWornItemSwapConfig(shift, itemComposition.getId(), opIdx);
 		};
 	}
@@ -971,7 +971,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 							.onClick(e ->
 							{
 								final String message = new ChatMessageBuilder()
-									.append("The default held left click option for '").append(itemComposition.getName()).append("' ")
+									.append("The default held left click option for '").append(itemComposition.getMembersName()).append("' ")
 									.append("has been reset.")
 									.build();
 
@@ -980,7 +980,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 									.runeLiteFormattedMessage(message)
 									.build());
 
-								log.debug("Unset held item left swap for {}", itemComposition.getName());
+								log.debug("Unset held item left swap for {}", itemComposition.getMembersName());
 								unsetItemSwapConfig(false, itemComposition.getId());
 							});
 					}
@@ -993,7 +993,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 							.onClick(e ->
 							{
 								final String message = new ChatMessageBuilder()
-									.append("The default held shift click option for '").append(itemComposition.getName()).append("' ")
+									.append("The default held shift click option for '").append(itemComposition.getMembersName()).append("' ")
 									.append("has been reset.")
 									.build();
 
@@ -1002,7 +1002,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 									.runeLiteFormattedMessage(message)
 									.build());
 
-								log.debug("Unset held item shift swap for {}", itemComposition.getName());
+								log.debug("Unset held item shift swap for {}", itemComposition.getMembersName());
 								unsetItemSwapConfig(true, itemComposition.getId());
 							});
 					}
@@ -1017,7 +1017,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 		return e ->
 		{
 			final String message = new ChatMessageBuilder()
-				.append("The default held ").append(shift ? "shift" : "left").append(" click option for '").append(Text.removeTags(itemComposition.getName())).append("' ")
+				.append("The default held ").append(shift ? "shift" : "left").append(" click option for '").append(Text.removeTags(itemComposition.getMembersName())).append("' ")
 				.append("has been set to '").append(opName).append("'.")
 				.build();
 
@@ -1026,7 +1026,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 				.runeLiteFormattedMessage(message)
 				.build());
 
-			log.debug("Set held item {} swap for {} to {}", shift ? "shift" : "left", itemComposition.getName(), opIdx);
+			log.debug("Set held item {} swap for {} to {}", shift ? "shift" : "left", itemComposition.getMembersName(), opIdx);
 			setItemSwapConfig(shift, itemComposition.getId(), opIdx);
 		};
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/skills/ItemSkillAction.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/skills/ItemSkillAction.java
@@ -62,6 +62,6 @@ public interface ItemSkillAction extends SkillAction
 	@Override
 	default String getName(final ItemManager itemManager)
 	{
-		return itemManager.getItemComposition(getItemId()).getName();
+		return itemManager.getItemComposition(getItemId()).getMembersName();
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/skills/SkillAction.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/skills/SkillAction.java
@@ -34,7 +34,7 @@ public interface SkillAction
 {
 	/**
 	 * Gets the name of this skill action, usually the item or object created, or the spell cast. This name may be
-	 * fetched via {@link ItemComposition#getName()} from some defined item ID or explicitly defined.
+	 * fetched via {@link ItemComposition#getMembersName()} from some defined item ID or explicitly defined.
 	 *
 	 * @param itemManager An {@link ItemManager item manager} instance.
 	 * @return The name of this skill action.

--- a/runelite-client/src/main/java/net/runelite/client/plugins/wiki/WikiPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/wiki/WikiPlugin.java
@@ -272,7 +272,7 @@ public class WikiPlugin extends Plugin
 				{
 					type = "item";
 					id = itemManager.canonicalize(ev.getId());
-					name = itemManager.getItemComposition(id).getName();
+					name = itemManager.getItemComposition(id).getMembersName();
 					location = null;
 					break;
 				}
@@ -307,7 +307,7 @@ public class WikiPlugin extends Plugin
 					{
 						type = "item";
 						id = itemManager.canonicalize(w.getItemId());
-						name = itemManager.getItemComposition(id).getName();
+						name = itemManager.getItemComposition(id).getMembersName();
 						location = null;
 						break;
 					}
@@ -373,7 +373,7 @@ public class WikiPlugin extends Plugin
 					if (entry.getType() == MenuAction.WIDGET_TARGET_ON_WIDGET)
 					{
 						int id = itemManager.canonicalize(w.getItemId());
-						String name = itemManager.getItemComposition(id).getName();
+						String name = itemManager.getItemComposition(id).getMembersName();
 						entry.setTarget(JagexColors.MENU_TARGET_TAG + name);
 						break;
 					}

--- a/runelite-client/src/test/java/net/runelite/client/plugins/examine/ExaminePluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/examine/ExaminePluginTest.java
@@ -73,7 +73,7 @@ public class ExaminePluginTest
 	public void testGetItemPrice()
 	{
 		ItemComposition itemComposition = mock(ItemComposition.class);
-		when(itemComposition.getName()).thenReturn("Abyssal whip");
+		when(itemComposition.getMembersName()).thenReturn("Abyssal whip");
 		when(itemComposition.getHaPrice()).thenReturn(2);
 		when(itemManager.getItemPrice(ItemID.ABYSSAL_WHIP)).thenReturn(3);
 		examinePlugin.getItemPrice(ItemID.ABYSSAL_WHIP, itemComposition, 2_000_000_000);


### PR DESCRIPTION
Depends on !10
Closes #5597
Closes #13282

![image](https://user-images.githubusercontent.com/2979691/65391200-5be66180-dd5e-11e9-8de3-73fd99f43252.png)

This PR now also updates sidebar-based plugins to always use the real item name even when on F2P