### PR TITLE
Menu Entry Swapper - Start-minigame at Pyramid Plunder

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -307,7 +307,10 @@ public interface MenuEntrySwapperConfig extends Config
 		name = "Enchant",
 		description = "Swap Talk-to with Enchant for Eluned"
 	)
-	default boolean swapEnchant() { return true;	}
+	default boolean swapEnchant()
+    {
+	    return true;
+    }
 
 	@ConfigItem(
 		keyName = "swapPyramidPlunderMummy",
@@ -315,7 +318,7 @@ public interface MenuEntrySwapperConfig extends Config
 		description =  "Swap Talk-to with Start-minigame at the Guardian Mummy"
 	)
 	default boolean swapPyramidPlunderMummy()
-	{
-		return true;
+    {
+        return true;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -308,9 +308,9 @@ public interface MenuEntrySwapperConfig extends Config
 		description = "Swap Talk-to with Enchant for Eluned"
 	)
 	default boolean swapEnchant()
-    {
-	    return true;
-    }
+	{
+		return true;
+	}
 
 	@ConfigItem(
 		keyName = "swapPyramidPlunderMummy",
@@ -318,7 +318,7 @@ public interface MenuEntrySwapperConfig extends Config
 		description =  "Swap Talk-to with Start-minigame at the Guardian Mummy"
 	)
 	default boolean swapPyramidPlunderMummy()
-    {
-        return true;
+	{
+		return true;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -307,7 +307,14 @@ public interface MenuEntrySwapperConfig extends Config
 		name = "Enchant",
 		description = "Swap Talk-to with Enchant for Eluned"
 	)
-	default boolean swapEnchant()
+	default boolean swapEnchant() { return true;	}
+
+	@ConfigItem(
+		keyName = "swapPyramidPlunderMummy",
+		name = "Pyramid Plunder Start-minigame",
+		description =  "Swap Talk-to with Start-minigame at the Guardian Mummy"
+	)
+	default boolean swapPyramidPlunderMummy()
 	{
 		return true;
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -458,6 +458,11 @@ public class MenuEntrySwapperPlugin extends Plugin
 			{
 				swap("enchant", option, target, index);
 			}
+
+			if (config.swapPyramidPlunderMummy())
+			{
+				swap("start-minigame", option, target, index);
+			}
 		}
 		else if (config.swapTravel() && option.equals("pass") && target.equals("energy barrier"))
 		{


### PR DESCRIPTION
Adds a Menu Entry Swapper option for using Start-minigame instead of Talk-to at the Guardian Mummy at Pyramid Plunder.

Closes #7138