### PR TITLE
Menu Entry Swapper: Quick-leave instead of Leave tomb at Pyramid Plunder

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -319,6 +319,6 @@ public interface MenuEntrySwapperConfig extends Config
 	)
 	default boolean swapQuickLeave()
 	{
-		return true;
+		return false;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -311,4 +311,14 @@ public interface MenuEntrySwapperConfig extends Config
 	{
 		return true;
 	}
+
+	@ConfigItem(
+		keyName = "swapQuickleave",
+		name = "Quick-Leave",
+		description = "Swap Leave Tomb with Quick-Leave at Pyramid Plunder"
+	)
+	default boolean swapQuickLeave()
+	{
+		return true;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -459,6 +459,10 @@ public class MenuEntrySwapperPlugin extends Plugin
 				swap("enchant", option, target, index);
 			}
 		}
+		else if (config.swapQuickLeave() && option.equals("leave tomb") && target.equals("tomb door"))
+		{
+			swap("quick-leave", option, target, index);
+		}
 		else if (config.swapTravel() && option.equals("pass") && target.equals("energy barrier"))
 		{
 			swap("pay-toll(2-ecto)", option, target, index);


### PR DESCRIPTION
Adds a menu entry swapper option for Quick-Leaving instead of Leave tomb at Pyramid Plunder.

Closes #9912