### PR TITLE
Inventorygrid: Draw image for replaced item

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/inventorygrid/InventoryGridOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/inventorygrid/InventoryGridOverlay.java
@@ -82,6 +82,7 @@ class InventoryGridOverlay extends Overlay
 		final int if1DraggedItemIndex = client.getIf1DraggedItemIndex();
 		final WidgetItem draggedItem = inventoryWidget.getWidgetItem(if1DraggedItemIndex);
 		final int itemId = draggedItem.getId();
+		final Rectangle initialBounds = draggedItem.getCanvasBounds();
 
 		if (itemId == -1)
 		{
@@ -91,19 +92,15 @@ class InventoryGridOverlay extends Overlay
 		for (int i = 0; i < INVENTORY_SIZE; ++i)
 		{
 			WidgetItem widgetItem = inventoryWidget.getWidgetItem(i);
+			final int targetItemId = widgetItem.getId();
 
 			final Rectangle bounds = widgetItem.getCanvasBounds();
 			boolean inBounds = bounds.contains(mousePoint);
 
 			if (config.showItem() && inBounds)
 			{
-				final BufferedImage draggedItemImage = itemManager.getImage(itemId);
-				final int x = (int) bounds.getX();
-				final int y = (int) bounds.getY();
-
-				graphics.setComposite(AlphaComposite.SrcOver.derive(0.3f));
-				graphics.drawImage(draggedItemImage, x, y, null);
-				graphics.setComposite(AlphaComposite.SrcOver);
+				drawItem(graphics, bounds, itemId);
+				drawItem(graphics, initialBounds, targetItemId);
 			}
 
 			if (config.showHighlight() && inBounds)
@@ -119,5 +116,21 @@ class InventoryGridOverlay extends Overlay
 		}
 
 		return null;
+	}
+
+	private void drawItem(Graphics2D graphics, Rectangle bounds, int itemId)
+	{
+		if (itemId == -1)
+		{
+			return;
+		}
+
+		final BufferedImage draggedItemImage = itemManager.getImage(itemId);
+		final int x = (int) bounds.getX();
+		final int y = (int) bounds.getY();
+
+		graphics.setComposite(AlphaComposite.SrcOver.derive(0.3f));
+		graphics.drawImage(draggedItemImage, x, y, null);
+		graphics.setComposite(AlphaComposite.SrcOver);
 	}
 }


### PR DESCRIPTION
Display the sprite of the swapped item in the inventory grid overlay, if there is one.

![grid_swap](https://user-images.githubusercontent.com/25151927/65910760-9fc70f80-e3cb-11e9-8aa8-1ec49eb5e786.gif)
