### PR TITLE
Added Drift Net to Crafting Calculator

### DIFF
--- a/runelite-client/src/main/resources/net/runelite/client/plugins/skillcalculator/skill_crafting.json
+++ b/runelite-client/src/main/resources/net/runelite/client/plugins/skillcalculator/skill_crafting.json
@@ -218,6 +218,12 @@
       "xp": 54
     },
     {
+      "level": 26,
+      "icon": 6209,
+      "name": "Drift Net",
+      "xp": 55
+    },
+    {
       "level": 27,
       "icon": 1605,
       "name": "Emerald",


### PR DESCRIPTION
Just added a net icon and the values for the drift net at the crafting calculator.

closes #9957 