### PR TITLE
object markers: use id instead of name to identify objects

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/objectindicators/ObjectIndicatorsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/objectindicators/ObjectIndicatorsOverlay.java
@@ -61,8 +61,11 @@ class ObjectIndicatorsOverlay extends Overlay
 	{
 		for (TileObject object : plugin.getObjects())
 		{
-			if (object.getPlane() != client.getPlane())
+			if (object.getPlane() != client.getPlane() && !(object instanceof WallObject))
 			{
+				//If veins in mlm upper level are depleted when the player logs in, the plane is 1
+				//But if the player sees it get depleted it will be on plane 0
+				//I don't know if this extends to other WallObjects.
 				continue;
 			}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/objectindicators/ObjectIndicatorsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/objectindicators/ObjectIndicatorsPlugin.java
@@ -170,8 +170,8 @@ public class ObjectIndicatorsPlugin extends Plugin implements KeyListener
 	@Subscribe
 	public void onWallObjectChanged(WallObjectChanged event)
 	{
-		WallObject previous = event.getPrevious();
-		WallObject wallObject = event.getWallObject();
+		final WallObject previous = event.getPrevious();
+		final WallObject wallObject = event.getWallObject();
 
 		objects.remove(previous);
 		checkObjectPoints(wallObject);
@@ -212,7 +212,7 @@ public class ObjectIndicatorsPlugin extends Plugin implements KeyListener
 	@Subscribe
 	public void onGameStateChanged(GameStateChanged gameStateChanged)
 	{
-		GameState gameState = gameStateChanged.getGameState();
+		final GameState gameState = gameStateChanged.getGameState();
 		if (gameState == GameState.LOADING)
 		{
 			// Reload points with new map regions
@@ -229,7 +229,7 @@ public class ObjectIndicatorsPlugin extends Plugin implements KeyListener
 			}
 		}
 
-		if (gameStateChanged.getGameState() != GameState.LOGGED_IN)
+		if (gameState != GameState.LOGGED_IN)
 		{
 			objects.clear();
 		}
@@ -279,14 +279,7 @@ public class ObjectIndicatorsPlugin extends Plugin implements KeyListener
 			return;
 		}
 
-		ObjectComposition objectDefinition = client.getObjectDefinition(object.getId());
-		String name = objectDefinition.getName();
-		if (Strings.isNullOrEmpty(name))
-		{
-			return;
-		}
-
-		markObject(name, object);
+		markObject(object);
 	}
 
 	private void checkObjectPoints(TileObject object)
@@ -302,13 +295,11 @@ public class ObjectIndicatorsPlugin extends Plugin implements KeyListener
 		for (ObjectPoint objectPoint : objectPoints)
 		{
 			if ((worldPoint.getX() & (REGION_SIZE - 1)) == objectPoint.getRegionX()
-					&& (worldPoint.getY() & (REGION_SIZE - 1)) == objectPoint.getRegionY())
+					&& (worldPoint.getY() & (REGION_SIZE - 1)) == objectPoint.getRegionY()
+					&& objectPoint.getId() == object.getId())
 			{
-				if (objectPoint.getName().equals(client.getObjectDefinition(object.getId()).getName()))
-				{
-					objects.add(object);
-					break;
-				}
+				objects.add(object);
+				break;
 			}
 		}
 	}
@@ -364,7 +355,7 @@ public class ObjectIndicatorsPlugin extends Plugin implements KeyListener
 		return null;
 	}
 
-	private void markObject(String name, final TileObject object)
+	private void markObject(final TileObject object)
 	{
 		if (object == null)
 		{
@@ -374,7 +365,7 @@ public class ObjectIndicatorsPlugin extends Plugin implements KeyListener
 		final WorldPoint worldPoint = WorldPoint.fromLocalInstance(client, object.getLocalLocation());
 		final int regionId = worldPoint.getRegionID();
 		final ObjectPoint point = new ObjectPoint(
-			name,
+			object.getId(),
 			regionId,
 			worldPoint.getX() & (REGION_SIZE - 1),
 			worldPoint.getY() & (REGION_SIZE - 1),

--- a/runelite-client/src/main/java/net/runelite/client/plugins/objectindicators/ObjectPoint.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/objectindicators/ObjectPoint.java
@@ -30,7 +30,7 @@ import lombok.Value;
 @Value
 class ObjectPoint
 {
-	private String name;
+	private int id;
 	private int regionId;
 	private int regionX;
 	private int regionY;


### PR DESCRIPTION
With the addition of the ability to mark WallObjects some normal object markers created unremovable artifacts when hopping. This is basically because when getting the ObjectComposition of many objects they have the name "null" even some walls. Namely, when marking the top part of the ladder to upper level mlm, which has the name "null". When we then log in again the wall just below it is a part of the same tile with the same name "null" which adds it to the highlighted objects of the region. Since we can never select that wall again, we can never unmark it.

Closes #9959