### PR TITLE
Add additional reset configuration for plugins

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/Plugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/Plugin.java
@@ -45,6 +45,10 @@ public abstract class Plugin implements Module
 	{
 	}
 
+	public void resetConfiguration()
+	{
+	}
+
 	public final Injector getInjector()
 	{
 		return injector;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/banktags/BankTagsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/banktags/BankTagsPlugin.java
@@ -26,6 +26,7 @@
  */
 package net.runelite.client.plugins.banktags;
 
+import com.google.common.collect.Lists;
 import com.google.inject.Provides;
 import java.awt.event.KeyEvent;
 import java.awt.event.MouseWheelEvent;
@@ -89,6 +90,7 @@ public class BankTagsPlugin extends Plugin implements MouseWheelListener, KeyLis
 	public static final String TAG_SEARCH = "tag:";
 	private static final String EDIT_TAGS_MENU_OPTION = "Edit-tags";
 	public static final String ICON_SEARCH = "icon_";
+	public static final String TAG_TABS_CONFIG = "tagtabs";
 	public static final String VAR_TAG_SUFFIX = "*";
 
 	private static final String SEARCH_BANK_INPUT_TEXT =
@@ -141,6 +143,36 @@ public class BankTagsPlugin extends Plugin implements MouseWheelListener, KeyLis
 	{
 		return configManager.getConfig(BankTagsConfig.class);
 	}
+
+	@Override
+	public void resetConfiguration()
+	{
+		List<String> extraKeys = Lists.newArrayList(
+			CONFIG_GROUP + "." + TagManager.ITEM_KEY_PREFIX,
+			CONFIG_GROUP + "." + ICON_SEARCH,
+			CONFIG_GROUP + "." + TAG_TABS_CONFIG
+		);
+
+		for (String prefix : extraKeys)
+		{
+			List<String> keys = configManager.getConfigurationKeys(prefix);
+			for (String key : keys)
+			{
+				String[] str = key.split("\\.", 2);
+				if (str.length == 2)
+				{
+					configManager.unsetConfiguration(str[0], str[1]);
+				}
+			}
+		}
+
+		clientThread.invokeLater(() ->
+		{
+			tabInterface.destroy();
+			tabInterface.init();
+		});
+	}
+
 
 	@Override
 	public void startUp()
@@ -376,7 +408,7 @@ public class BankTagsPlugin extends Plugin implements MouseWheelListener, KeyLis
 	@Subscribe
 	public void onConfigChanged(ConfigChanged configChanged)
 	{
-		if (configChanged.getGroup().equals("banktags") && configChanged.getKey().equals("useTabs"))
+		if (configChanged.getGroup().equals(CONFIG_GROUP) && configChanged.getKey().equals("useTabs"))
 		{
 			if (config.tabs())
 			{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/banktags/TagManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/banktags/TagManager.java
@@ -50,7 +50,7 @@ import net.runelite.client.util.Text;
 @Singleton
 public class TagManager
 {
-	private static final String ITEM_KEY_PREFIX = "item_";
+	static final String ITEM_KEY_PREFIX = "item_";
 	private final ConfigManager configManager;
 	private final ItemManager itemManager;
 	private final ClueScrollService clueScrollService;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/banktags/tabs/TabManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/banktags/tabs/TabManager.java
@@ -38,14 +38,13 @@ import net.runelite.api.ItemID;
 import net.runelite.client.config.ConfigManager;
 import static net.runelite.client.plugins.banktags.BankTagsPlugin.CONFIG_GROUP;
 import static net.runelite.client.plugins.banktags.BankTagsPlugin.ICON_SEARCH;
+import static net.runelite.client.plugins.banktags.BankTagsPlugin.TAG_TABS_CONFIG;
 import net.runelite.client.util.Text;
 import org.apache.commons.lang3.math.NumberUtils;
 
 @Singleton
 class TabManager
 {
-	private static final String TAG_TABS_CONFIG = "tagtabs";
-
 	@Getter
 	private final List<TagTab> tabs = new ArrayList<>();
 	private final ConfigManager configManager;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
@@ -71,6 +71,7 @@ import net.runelite.client.events.ExternalPluginsChanged;
 import net.runelite.client.events.PluginChanged;
 import net.runelite.client.externalplugins.ExternalPluginManager;
 import net.runelite.client.externalplugins.ExternalPluginManifest;
+import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginManager;
 import net.runelite.client.ui.ColorScheme;
 import net.runelite.client.ui.DynamicGridLayout;
@@ -432,6 +433,13 @@ class ConfigPanel extends PluginPanel
 			if (result == JOptionPane.YES_OPTION)
 			{
 				configManager.setDefaultConfiguration(pluginConfig.getConfig(), true);
+
+				// Reset non-config panel keys
+				Plugin plugin = pluginConfig.getPlugin();
+				if (plugin != null)
+				{
+					plugin.resetConfiguration();
+				}
 
 				rebuild();
 			}


### PR DESCRIPTION
Some plugins create config keys that aren't reset by the config reset button (IE banktags).

This adds an overridable method to the Plugin class that that is called on reset button click. 