### PR TITLE
Fix woodcutting overlay hiding during long chop delays

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/Axe.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/Axe.java
@@ -50,6 +50,7 @@ import static net.runelite.api.ItemID.MITHRIL_AXE;
 import static net.runelite.api.ItemID.RUNE_AXE;
 import static net.runelite.api.ItemID.STEEL_AXE;
 import static net.runelite.api.ItemID._3RD_AGE_AXE;
+import net.runelite.api.Player;
 
 @AllArgsConstructor
 @Getter
@@ -82,6 +83,11 @@ enum Axe
 		}
 
 		AXE_ANIM_IDS = builder.build();
+	}
+
+	boolean matchesChoppingAnimation(final Player player)
+	{
+		return player != null && animId == player.getAnimation();
 	}
 
 	static Axe findAxeByAnimId(int animId)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingOverlay.java
@@ -81,7 +81,7 @@ class WoodcuttingOverlay extends Overlay
 		panelComponent.getChildren().clear();
 
 		Axe axe = plugin.getAxe();
-		if (axe != null && axe.getAnimId() == client.getLocalPlayer().getAnimation())
+		if (axe != null && axe.matchesChoppingAnimation(client.getLocalPlayer()))
 		{
 			panelComponent.getChildren().add(TitleComponent.builder()
 				.text("Woodcutting")

--- a/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingPlugin.java
@@ -148,13 +148,19 @@ public class WoodcuttingPlugin extends Plugin
 
 		respawns.removeIf(TreeRespawn::isExpired);
 
-		if (session == null || session.getLastLogCut() == null)
+		if (session == null || session.getLastChopping() == null)
 		{
 			return;
 		}
 
+		if (axe != null && axe.matchesChoppingAnimation(client.getLocalPlayer()))
+		{
+			session.setLastChopping();
+			return;
+		}
+
 		Duration statTimeout = Duration.ofMinutes(config.statTimeout());
-		Duration sinceCut = Duration.between(session.getLastLogCut(), Instant.now());
+		Duration sinceCut = Duration.between(session.getLastChopping(), Instant.now());
 
 		if (sinceCut.compareTo(statTimeout) >= 0)
 		{
@@ -175,7 +181,7 @@ public class WoodcuttingPlugin extends Plugin
 					session = new WoodcuttingSession();
 				}
 
-				session.setLastLogCut();
+				session.setLastChopping();
 			}
 
 			if (event.getMessage().contains("A bird's nest falls out of the tree") && config.showNestNotification())

--- a/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingPlugin.java
@@ -32,6 +32,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.regex.Pattern;
+import javax.annotation.Nullable;
 import javax.inject.Inject;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -90,9 +91,11 @@ public class WoodcuttingPlugin extends Plugin
 	private WoodcuttingConfig config;
 
 	@Getter
+	@Nullable
 	private WoodcuttingSession session;
 
 	@Getter
+	@Nullable
 	private Axe axe;
 
 	@Getter

--- a/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingSession.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingSession.java
@@ -26,16 +26,16 @@ package net.runelite.client.plugins.woodcutting;
 
 import java.time.Instant;
 
-public class WoodcuttingSession
+class WoodcuttingSession
 {
 	private Instant lastLogCut;
 
-	public void setLastLogCut()
+	void setLastLogCut()
 	{
 		lastLogCut = Instant.now();
 	}
 
-	public Instant getLastLogCut()
+	Instant getLastLogCut()
 	{
 		return lastLogCut;
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingSession.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingSession.java
@@ -28,15 +28,15 @@ import java.time.Instant;
 
 class WoodcuttingSession
 {
-	private Instant lastLogCut;
+	private Instant lastChopping;
 
-	void setLastLogCut()
+	void setLastChopping()
 	{
-		lastLogCut = Instant.now();
+		lastChopping = Instant.now();
 	}
 
-	Instant getLastLogCut()
+	Instant getLastChopping()
 	{
-		return lastLogCut;
+		return lastChopping;
 	}
 }


### PR DESCRIPTION
This fixes a bug where the overlay would become hidden when chopping at
a tree without successfully chopping a log for longer than the
configured timeout, and would display "NOT woodcutting" if a log was
successfully chopped thereafter.

Fixes #7506