### PR TITLE
inventory viewer: add the ability to minimize the overlay

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/inventoryviewer/InventoryViewerOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/inventoryviewer/InventoryViewerOverlay.java
@@ -29,14 +29,19 @@ import java.awt.Graphics2D;
 import java.awt.Point;
 import java.awt.image.BufferedImage;
 import javax.inject.Inject;
+import lombok.Getter;
+import lombok.Setter;
 import net.runelite.api.Client;
 import net.runelite.api.Constants;
 import net.runelite.api.InventoryID;
 import net.runelite.api.Item;
 import net.runelite.api.ItemComposition;
 import net.runelite.api.ItemContainer;
+import net.runelite.api.ItemID;
+import static net.runelite.api.MenuAction.RUNELITE_OVERLAY;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.ui.overlay.Overlay;
+import net.runelite.client.ui.overlay.OverlayMenuEntry;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.components.ComponentOrientation;
 import net.runelite.client.ui.overlay.components.ImageComponent;
@@ -48,10 +53,19 @@ class InventoryViewerOverlay extends Overlay
 	private static final ImageComponent PLACEHOLDER_IMAGE = new ImageComponent(
 		new BufferedImage(Constants.ITEM_SPRITE_WIDTH, Constants.ITEM_SPRITE_HEIGHT, BufferedImage.TYPE_4BYTE_ABGR));
 
+	static final String MENU_OPTION = "Toggle";
+	static final String MENU_TARGET = "Inventory Viewer";
+
 	private final Client client;
 	private final ItemManager itemManager;
 
 	private final PanelComponent panelComponent = new PanelComponent();
+
+	private final BufferedImage MINIMIZED_IMAGE;
+
+	@Setter
+	@Getter
+	private boolean minimized;
 
 	@Inject
 	private InventoryViewerOverlay(Client client, ItemManager itemManager)
@@ -62,6 +76,10 @@ class InventoryViewerOverlay extends Overlay
 		panelComponent.setOrientation(ComponentOrientation.HORIZONTAL);
 		this.itemManager = itemManager;
 		this.client = client;
+
+		MINIMIZED_IMAGE = itemManager.getImage(ItemID.BAG_FULL_OF_GEMS);
+
+		getMenuEntries().add(new OverlayMenuEntry(RUNELITE_OVERLAY, MENU_OPTION, MENU_TARGET));
 	}
 
 	@Override
@@ -75,6 +93,12 @@ class InventoryViewerOverlay extends Overlay
 		}
 
 		panelComponent.getChildren().clear();
+
+		if (minimized)
+		{
+			panelComponent.getChildren().add(new ImageComponent(MINIMIZED_IMAGE));
+			return panelComponent.render(graphics);
+		}
 
 		final Item[] items = itemContainer.getItems();
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/inventoryviewer/InventoryViewerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/inventoryviewer/InventoryViewerPlugin.java
@@ -25,9 +25,15 @@
 package net.runelite.client.plugins.inventoryviewer;
 
 import javax.inject.Inject;
+import static net.runelite.api.MenuAction.RUNELITE_OVERLAY;
+import net.runelite.api.events.MenuOptionClicked;
+import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
+import static net.runelite.client.plugins.inventoryviewer.InventoryViewerOverlay.MENU_OPTION;
+import static net.runelite.client.plugins.inventoryviewer.InventoryViewerOverlay.MENU_TARGET;
 import net.runelite.client.ui.overlay.OverlayManager;
+import net.runelite.client.util.Text;
 
 @PluginDescriptor(
 	name = "Inventory Viewer",
@@ -53,5 +59,15 @@ public class InventoryViewerPlugin extends Plugin
 	public void shutDown()
 	{
 		overlayManager.remove(overlay);
+	}
+
+	@Subscribe
+	public void onMenuOptionClicked(final MenuOptionClicked event)
+	{
+		if (event.getMenuAction() == RUNELITE_OVERLAY && event.getMenuOption().equals(MENU_OPTION)
+			&& Text.removeTags(event.getMenuTarget()).equals(MENU_TARGET))
+		{
+			overlay.setMinimized(!overlay.isMinimized());
+		}
 	}
 }


### PR DESCRIPTION
Closes #4148

This adds an overlay menu option to inventory viewer `Toggle Inventory Viewer`. When clicked, it collapses the overlay down to 1 item image.

Collapsed
![java_kT0raKQv7r](https://user-images.githubusercontent.com/22979513/66242429-33982480-e6c7-11e9-96bd-4c54c0afd022.png)
