### PR TITLE
xptracker: fix goals set from level 1

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpStateSingle.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpStateSingle.java
@@ -220,7 +220,7 @@ class XpStateSingle
 		// Determine XP goals, overall has no goals
 		if (skill != Skill.OVERALL)
 		{
-			if (goalStartXp <= 0 || currentXp > goalEndXp)
+			if (goalStartXp < 0 || currentXp > goalEndXp)
 			{
 				startLevelExp = Experience.getXpForLevel(Experience.getLevelForXp((int) currentXp));
 			}


### PR DESCRIPTION
Since the base xp for level 1 is 0 the startLevelXp was initialized from the current level which made the progress bar calculations wrong as they were based on the xp earned from the current level base xp and not level 1.