### PR TITLE
Refresh Loot Tracker side panel after Runescape account login & logouts

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPanel.java
@@ -326,7 +326,6 @@ class LootTrackerPanel extends PluginPanel
 				client.delete(currentView);
 			}
 		});
-
 		// Create popup menu
 		final JPopupMenu popupMenu = new JPopupMenu();
 		popupMenu.setBorder(new EmptyBorder(5, 5, 5, 5));
@@ -342,6 +341,21 @@ class LootTrackerPanel extends PluginPanel
 		// Add error pane
 		errorPanel.setContent("Loot tracker", "You have not received any loot yet.");
 		add(errorPanel);
+	}
+
+	void resetLootPanel()
+	{
+		records.removeIf(r -> r.matches(currentView));
+		boxes.removeIf(b -> b.matches(currentView));
+		updateOverall();
+		logsContainer.removeAll();
+		logsContainer.repaint();
+        // Delete all loot, or loot matching the current view
+		LootTrackerClient client = plugin.getLootTrackerClient();
+		if (client != null && config.syncPanel())
+		{
+			client.delete(currentView);
+		}
 	}
 
 	void updateCollapseText()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPanel.java
@@ -326,6 +326,7 @@ class LootTrackerPanel extends PluginPanel
 				client.delete(currentView);
 			}
 		});
+
 		// Create popup menu
 		final JPopupMenu popupMenu = new JPopupMenu();
 		popupMenu.setBorder(new EmptyBorder(5, 5, 5, 5));
@@ -350,7 +351,6 @@ class LootTrackerPanel extends PluginPanel
 		updateOverall();
 		logsContainer.removeAll();
 		logsContainer.repaint();
-        // Delete all loot, or loot matching the current view
 		LootTrackerClient client = plugin.getLootTrackerClient();
 		if (client != null && config.syncPanel())
 		{
@@ -358,7 +358,7 @@ class LootTrackerPanel extends PluginPanel
 		}
 	}
 
-	void updateCollapseText()
+	private void updateCollapseText()
 	{
 		if (isAllCollapsed())
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
@@ -170,6 +170,7 @@ public class LootTrackerPlugin extends Plugin
 	@Getter(AccessLevel.PACKAGE)
 	private LootTrackerClient lootTrackerClient;
 	private final List<LootRecord> queuedLoots = new ArrayList<>();
+	private GameStateChanged gameStateChanged;
 
 	private static Collection<ItemStack> stack(Collection<ItemStack> items)
 	{
@@ -213,17 +214,20 @@ public class LootTrackerPlugin extends Plugin
 		if (accountSession.getUuid() != null)
 		{
 			lootTrackerClient = new LootTrackerClient(accountSession.getUuid());
+			chestLooted = false;
+			panel.resetLootPanel();
 		}
 		else
 		{
 			lootTrackerClient = null;
 		}
 	}
-
 	@Subscribe
 	public void onSessionClose(SessionClose sessionClose)
 	{
 		submitLoot();
+		chestLooted = false;
+		panel.resetLootPanel();
 		lootTrackerClient = null;
 	}
 
@@ -305,9 +309,9 @@ public class LootTrackerPlugin extends Plugin
 	protected void shutDown()
 	{
 		submitLoot();
-		clientToolbar.removeNavigation(navButton);
 		lootTrackerClient = null;
 		chestLooted = false;
+		clientToolbar.removeNavigation(navButton);
 	}
 
 	@Subscribe
@@ -316,6 +320,12 @@ public class LootTrackerPlugin extends Plugin
 		if (event.getGameState() == GameState.LOADING)
 		{
 			chestLooted = false;
+		}
+		else if (event.getGameState() == GameState.LOGIN_SCREEN)
+		{
+			chestLooted = false;
+			panel.resetLootPanel();
+			lootTrackerClient = null;
 		}
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
@@ -222,6 +222,7 @@ public class LootTrackerPlugin extends Plugin
 			lootTrackerClient = null;
 		}
 	}
+
 	@Subscribe
 	public void onSessionClose(SessionClose sessionClose)
 	{


### PR DESCRIPTION
Fixes #7896 
Loot tracker plugin will refresh and reload the side panel whenever a Runescape account logs in or logs out. Constructive criticism are very much welcomed, please advise of any improvements.  