### PR TITLE
npchighlight: Apply correct highlights to changed NPCs

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsPlugin.java
@@ -57,6 +57,7 @@ import net.runelite.api.events.GameTick;
 import net.runelite.api.events.GraphicsObjectCreated;
 import net.runelite.api.events.MenuEntryAdded;
 import net.runelite.api.events.MenuOptionClicked;
+import net.runelite.api.events.NpcChanged;
 import net.runelite.api.events.NpcDespawned;
 import net.runelite.api.events.NpcSpawned;
 import net.runelite.client.callback.ClientThread;
@@ -407,6 +408,26 @@ public class NpcIndicatorsPlugin extends Plugin
 		}
 
 		highlightedNpcs.remove(npc);
+	}
+
+	@Subscribe
+	public void onNpcChanged(NpcChanged event)
+	{
+		final NPC npc = event.getNpc();
+		final String npcName = npc.getName();
+
+		highlightedNpcs.remove(npc);
+
+		if (npcName == null)
+		{
+			return;
+		}
+
+		if (npcTags.contains(npc.getIndex())
+			|| highlightMatchesNPCName(npcName))
+		{
+			highlightedNpcs.add(npc);
+		}
 	}
 
 	@Subscribe

--- a/runelite-client/src/test/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsPluginTest.java
@@ -37,9 +37,12 @@ import net.runelite.api.MenuAction;
 import net.runelite.api.MenuEntry;
 import net.runelite.api.NPC;
 import net.runelite.api.events.MenuEntryAdded;
+import net.runelite.api.events.NpcChanged;
 import net.runelite.api.events.NpcSpawned;
 import net.runelite.client.ui.overlay.OverlayManager;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -136,5 +139,43 @@ public class NpcIndicatorsPluginTest
 		MenuEntry target = new MenuEntry();
 		target.setTarget("<col=0000ff>Goblin"); // blue
 		verify(client).setMenuEntries(new MenuEntry[]{target});
+	}
+
+	@Test
+	public void taggedNpcChanges()
+	{
+		when(npcIndicatorsConfig.getNpcToHighlight()).thenReturn("Joseph");
+
+		npcIndicatorsPlugin.rebuildAllNpcs();
+
+		NPC npc = mock(NPC.class);
+		when(npc.getName()).thenReturn("Joseph");
+		npcIndicatorsPlugin.onNpcSpawned(new NpcSpawned(npc));
+
+		assertTrue(npcIndicatorsPlugin.getHighlightedNpcs().contains(npc));
+
+		when(npc.getName()).thenReturn("Werewolf");
+		npcIndicatorsPlugin.onNpcChanged(new NpcChanged(npc, null));
+
+		assertFalse(npcIndicatorsPlugin.getHighlightedNpcs().contains(npc));
+	}
+
+	@Test
+	public void npcChangesToTagged()
+	{
+		when(npcIndicatorsConfig.getNpcToHighlight()).thenReturn("Werewolf");
+
+		npcIndicatorsPlugin.rebuildAllNpcs();
+
+		NPC npc = mock(NPC.class);
+		when(npc.getName()).thenReturn("Joseph");
+		npcIndicatorsPlugin.onNpcSpawned(new NpcSpawned(npc));
+
+		assertFalse(npcIndicatorsPlugin.getHighlightedNpcs().contains(npc));
+
+		when(npc.getName()).thenReturn("Werewolf");
+		npcIndicatorsPlugin.onNpcChanged(new NpcChanged(npc, null));
+
+		assertTrue(npcIndicatorsPlugin.getHighlightedNpcs().contains(npc));
 	}
 }


### PR DESCRIPTION
This change ensures that tagged NPCs will be tracked throughout any
NpcChanged events, but highlighted NPCs will only display an overlay
when the current NPC name matches the config list.

Fixes runelite/runelite#5161
Closes runelite/runelite#6300