### PR TITLE
Add shift click option to teleport spells with multiple locations

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -311,4 +311,14 @@ public interface MenuEntrySwapperConfig extends Config
 	{
 		return true;
 	}
+
+	@ConfigItem(
+		keyName = "swapTeleportSpell",
+		name = "Shift-click teleport spells",
+		description = "Swap teleport spells that have a second destination on shift"
+	)
+	default boolean swapTeleportSpell()
+	{
+		return false;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -604,6 +604,38 @@ public class MenuEntrySwapperPlugin extends Plugin
 		{
 			swap("use", option, target, index);
 		}
+
+		if (shiftModifier && config.swapTeleportSpell())
+		{
+			if (target.equals("varrock teleport"))
+			{
+				swapTeleport(target, option, "grand exchange", index);
+			}
+			else if (target.equals("camelot teleport"))
+			{
+				swapTeleport(target, option, "seers'", index);
+			}
+			else if (target.equals("watchtower teleport"))
+			{
+				swapTeleport(target, option, "yanille", index);
+			}
+			else if (target.equals("teleport to house"))
+			{
+				swapTeleport(target, option, "outside", index);
+			}
+		}
+	}
+
+	private void swapTeleport(String target, String option, String optionA, int index)
+	{
+		if (option.equals("cast"))
+		{
+			swap(optionA, option, target, index);
+		}
+		else if (option.equals(optionA))
+		{
+			swap("cast", option, target, index);
+		}
 	}
 
 	private static boolean shouldSwapPickpocket(String target)

--- a/runelite-client/src/test/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPluginTest.java
@@ -42,6 +42,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import static org.mockito.ArgumentMatchers.any;
 import org.mockito.Mock;
+import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -207,6 +208,59 @@ public class MenuEntrySwapperPluginTest
 			menu("Pay (south)", "Kragen", MenuAction.NPC_FOURTH_OPTION),
 			menu("Talk-to", "Kragen", MenuAction.NPC_FIRST_OPTION),
 			menu("Pay (north)", "Kragen", MenuAction.NPC_THIRD_OPTION),
+		}, argumentCaptor.getValue());
+	}
+
+	@Test
+	public void testTeleport()
+	{
+		when(config.swapTeleportSpell()).thenReturn(true);
+		menuEntrySwapperPlugin.setShiftModifier(true);
+
+		// Cast -> Grand Exchange
+		entries = new MenuEntry[]{
+			menu("Cancel", "", MenuAction.CANCEL),
+
+			menu("Configure", "Varrock Teleport", MenuAction.WIDGET_THIRD_OPTION),
+			menu("Grand Exchange", "Varrock Teleport", MenuAction.WIDGET_SECOND_OPTION),
+			menu("Cast", "Varrock Teleport", MenuAction.WIDGET_FIRST_OPTION),
+		};
+
+		menuEntrySwapperPlugin.onClientTick(new ClientTick());
+
+		ArgumentCaptor<MenuEntry[]> argumentCaptor = ArgumentCaptor.forClass(MenuEntry[].class);
+		verify(client).setMenuEntries(argumentCaptor.capture());
+
+		assertArrayEquals(new MenuEntry[]{
+			menu("Cancel", "", MenuAction.CANCEL),
+
+			menu("Configure", "Varrock Teleport", MenuAction.WIDGET_THIRD_OPTION),
+			menu("Cast", "Varrock Teleport", MenuAction.WIDGET_FIRST_OPTION),
+			menu("Grand Exchange", "Varrock Teleport", MenuAction.WIDGET_SECOND_OPTION),
+		}, argumentCaptor.getValue());
+
+		clearInvocations(client);
+
+		// Grand Exchange -> Cast
+		entries = new MenuEntry[]{
+			menu("Cancel", "", MenuAction.CANCEL),
+
+			menu("Configure", "Varrock Teleport", MenuAction.WIDGET_THIRD_OPTION),
+			menu("Cast", "Varrock Teleport", MenuAction.WIDGET_SECOND_OPTION),
+			menu("Grand Exchange", "Varrock Teleport", MenuAction.WIDGET_FIRST_OPTION),
+		};
+
+		menuEntrySwapperPlugin.onClientTick(new ClientTick());
+
+		argumentCaptor = ArgumentCaptor.forClass(MenuEntry[].class);
+		verify(client).setMenuEntries(argumentCaptor.capture());
+
+		assertArrayEquals(new MenuEntry[]{
+			menu("Cancel", "", MenuAction.CANCEL),
+
+			menu("Configure", "Varrock Teleport", MenuAction.WIDGET_THIRD_OPTION),
+			menu("Grand Exchange", "Varrock Teleport", MenuAction.WIDGET_FIRST_OPTION),
+			menu("Cast", "Varrock Teleport", MenuAction.WIDGET_SECOND_OPTION),
 		}, argumentCaptor.getValue());
 	}
 }


### PR DESCRIPTION
## what this PR does

This PR adds a new option to the menu entry swapper plugin what when enabled adds shift click functionality to teleport spells with multiple options. Idea from #9992. This is almost a duplicate pr as #4031 exists however their solution only swapped one way whereas this one swaps both ways and that PR did not include the house teleport. 

## How to test

Enable the option and test that the following teleports swap correctly when shift clicking them. Test they work in both directions (i.e change your default and ensure it still swaps the option when shift is held) 

- [ ] Varrock tele/GE tele
- [ ] Camelot tele/Seers
- [ ] Yannille/watchtower
- [ ] Teleport to house/outside

Closes  #9992

