### PR TITLE
Fix slayer infobox disappearing on 0 timeout

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerPlugin.java
@@ -388,11 +388,11 @@ public class SlayerPlugin extends Plugin
 					break;
 				}
 			}
-		}
-
+        }
+        
         if (config.statTimeout() == 0)
-		{
-			return;     // Prevent infobox disappearing when user enters '0' timeout
+        {
+            return;
         }
         
 		if (infoTimer != null)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerPlugin.java
@@ -390,6 +390,11 @@ public class SlayerPlugin extends Plugin
 			}
 		}
 
+        if (config.statTimeout() == 0)
+		{
+			return;     // Prevent infobox disappearing when user enters '0' timeout
+        }
+        
 		if (infoTimer != null)
 		{
 			Duration timeSinceInfobox = Duration.between(infoTimer, Instant.now());


### PR DESCRIPTION
Resolves #10066 by preventing infobox from closing in a manner similar to the cooking plugin (among others).