### PR TITLE
banktags: null check for no tagtabs

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/banktags/BankTagsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/banktags/BankTagsPlugin.java
@@ -185,6 +185,11 @@ public class BankTagsPlugin extends Plugin implements MouseWheelListener, KeyLis
 	private void removeInvalidTags(final String key)
 	{
 		final String value = configManager.getConfiguration(CONFIG_GROUP, key);
+		if (value == null)
+		{
+			return;
+		}
+
 		String replaced = value.replaceAll("[<>/]", "");
 		if (!value.equals(replaced))
 		{


### PR DESCRIPTION
Fixes issue reported in discord. If a user has no tagtabs, null will be returned from config manager during the first `removeInvalidTags` on line 158.

<details>
<summary>Stacktrace</summary>

```
2019-10-15 14:19:34 [main] WARN  n.r.client.plugins.PluginManager - Unable to start plugin BankTagsPlugin
net.runelite.client.plugins.PluginInstantiationException: java.lang.reflect.InvocationTargetException
    at net.runelite.client.plugins.PluginManager.startPlugin(PluginManager.java:350)
    at net.runelite.client.plugins.PluginManager.startCorePlugins(PluginManager.java:209)
    at net.runelite.client.RuneLite.start(RuneLite.java:339)
    at net.runelite.client.RuneLite.main(RuneLite.java:245)
Caused by: java.lang.reflect.InvocationTargetException: null
    at java.awt.EventQueue.invokeAndWait(EventQueue.java:1349)
    at java.awt.EventQueue.invokeAndWait(EventQueue.java:1324)
    at javax.swing.SwingUtilities.invokeAndWait(SwingUtilities.java:1353)
    at net.runelite.client.plugins.PluginManager.startPlugin(PluginManager.java:322)
    ... 3 common frames omitted
Caused by: java.lang.RuntimeException: java.lang.NullPointerException
    at net.runelite.client.plugins.PluginManager.lambda$startPlugin$3(PluginManager.java:330)
    at java.awt.event.InvocationEvent.dispatch(InvocationEvent.java:301)
    at java.awt.EventQueue.dispatchEventImpl(EventQueue.java:758)
    at java.awt.EventQueue.access$500(EventQueue.java:97)
    at java.awt.EventQueue$3.run(EventQueue.java:709)
    at java.awt.EventQueue$3.run(EventQueue.java:703)
    at java.security.AccessController.doPrivileged(Native Method)
    at java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:74)
    at java.awt.EventQueue.dispatchEvent(EventQueue.java:728)
    at java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:205)
    at java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:116)
    at java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:105)
    at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:101)
    at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:93)
    at java.awt.EventDispatchThread.run(EventDispatchThread.java:82)
Caused by: java.lang.NullPointerException: null
    at net.runelite.client.plugins.banktags.BankTagsPlugin.removeInvalidTags(BankTagsPlugin.java:188)
    at net.runelite.client.plugins.banktags.BankTagsPlugin.cleanConfig(BankTagsPlugin.java:158)
    at net.runelite.client.plugins.banktags.BankTagsPlugin.startUp(BankTagsPlugin.java:148)
    at net.runelite.client.plugins.PluginManager.lambda$startPlugin$3(PluginManager.java:326)
    ... 14 common frames omitted
```
</details>

