### PR TITLE
loot tracker: reset panel when logging in/out of RL account

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPanel.java
@@ -398,6 +398,18 @@ class LootTrackerPanel extends PluginPanel
 	}
 
 	/**
+	 * Removes the records from then panel
+	 */
+	void removeRecords()
+	{
+		records.clear();
+		rebuild();
+		add(errorPanel);
+		actionsContainer.setVisible(false);
+		overallPanel.setVisible(false);
+	}
+
+	/**
 	 * Changes grouping mode of panel
 	 *
 	 * @param group if loot should be grouped or not

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
@@ -76,7 +76,6 @@ import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.events.NpcLootReceived;
 import net.runelite.client.events.PlayerLootReceived;
 import net.runelite.client.events.SessionClose;
-import net.runelite.client.events.SessionOpen;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.game.ItemStack;
 import net.runelite.client.game.SpriteManager;
@@ -91,6 +90,7 @@ import net.runelite.http.api.loottracker.GameItem;
 import net.runelite.http.api.loottracker.LootRecord;
 import net.runelite.http.api.loottracker.LootRecordType;
 import net.runelite.http.api.loottracker.LootTrackerClient;
+import net.runelite.http.api.ws.messages.LoginResponse;
 import org.apache.commons.lang3.ArrayUtils;
 
 @PluginDescriptor(
@@ -207,7 +207,7 @@ public class LootTrackerPlugin extends Plugin
 	}
 
 	@Subscribe
-	public void onSessionOpen(SessionOpen sessionOpen)
+	public void onLoginResponse(LoginResponse loginResponse)
 	{
 		AccountSession accountSession = sessionManager.getAccountSession();
 		if (accountSession.getUuid() != null)


### PR DESCRIPTION
The workaround for resyncing when switching RL accounts was to switch the plugin off and on again. This uses that same behavior when switching accounts instead.

Closes #7896 