### PR TITLE
fishing: make overlay colors configurable

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingConfig.java
@@ -24,6 +24,7 @@
  */
 package net.runelite.client.plugins.fishing;
 
+import java.awt.Color;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
@@ -76,7 +77,40 @@ public interface FishingConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 4,
+		keyName = "overlayColor",
+		name = "Overlay Color",
+		description = "Color of overlays",
+		position = 4
+	)
+	default Color getOverlayColor()
+	{
+		return Color.CYAN;
+	}
+
+	@ConfigItem(
+		keyName = "minnowsOverlayColor",
+		name = "Minnows Overlay Color",
+		description = "Color of overlays for Minnows",
+		position = 5
+	)
+	default Color getMinnowsOverlayColor()
+	{
+		return Color.RED;
+	}
+
+	@ConfigItem(
+		keyName = "aerialOverlayColor",
+		name = "Aerial Overlay Color",
+		description = "Color of overlays when 1-tick aerial fishing",
+		position = 6
+	)
+	default Color getAerialOverlayColor()
+	{
+		return Color.GREEN;
+	}
+
+	@ConfigItem(
+		position = 7,
 		keyName = "statTimeout",
 		name = "Reset stats (minutes)",
 		description = "The time until fishing session data is reset in minutes."
@@ -87,7 +121,7 @@ public interface FishingConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 5,
+		position = 8,
 		keyName = "showFishingStats",
 		name = "Show Fishing session stats",
 		description = "Display the fishing session stats."
@@ -98,7 +132,7 @@ public interface FishingConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 6,
+		position = 9,
 		keyName = "showMinnowOverlay",
 		name = "Show Minnow Movement overlay",
 		description = "Display the minnow progress pie overlay."
@@ -109,7 +143,7 @@ public interface FishingConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 7,
+		position = 10,
 		keyName = "trawlerNotification",
 		name = "Trawler activity notification",
 		description = "Send a notification when fishing trawler activity drops below 15%."
@@ -120,7 +154,7 @@ public interface FishingConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 8,
+		position = 11,
 		keyName = "trawlerTimer",
 		name = "Trawler timer in MM:SS",
 		description = "Trawler Timer will display a more accurate timer in MM:SS format."

--- a/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingSpotMinimapOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingSpotMinimapOverlay.java
@@ -76,7 +76,9 @@ class FishingSpotMinimapOverlay extends Overlay
 				continue;
 			}
 
-			Color color = npc.getGraphic() == GraphicID.FLYING_FISH ? Color.RED : Color.CYAN;
+			Color color = npc.getGraphic() == GraphicID.FLYING_FISH
+				? config.getMinnowsOverlayColor()
+				: config.getOverlayColor();
 
 			net.runelite.api.Point minimapLocation = npc.getMinimapLocation();
 			if (minimapLocation != null)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingSpotOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingSpotOverlay.java
@@ -107,15 +107,15 @@ class FishingSpotOverlay extends Overlay
 			Color color;
 			if (npc.getGraphic() == GraphicID.FLYING_FISH)
 			{
-				color = Color.RED;
+				color = config.getMinnowsOverlayColor();
 			}
 			else if (spot == FishingSpot.COMMON_TENCH && npc.getWorldLocation().distanceTo2D(client.getLocalPlayer().getWorldLocation()) <= ONE_TICK_AERIAL_FISHING)
 			{
-				color = Color.GREEN;
+				color = config.getAerialOverlayColor();
 			}
 			else
 			{
-				color = Color.CYAN;
+				color = config.getOverlayColor();
 			}
 
 			if (spot == FishingSpot.MINNOW && config.showMinnowOverlay())
@@ -156,12 +156,12 @@ class FishingSpotOverlay extends Overlay
 
 			if (config.showSpotIcons())
 			{
-				BufferedImage fishImage = itemManager.getImage(spot.getFishSpriteId());;
+				BufferedImage fishImage = itemManager.getImage(spot.getFishSpriteId());
 
 				if (spot == FishingSpot.COMMON_TENCH
 					&& npc.getWorldLocation().distanceTo2D(client.getLocalPlayer().getWorldLocation()) <= ONE_TICK_AERIAL_FISHING)
 				{
-					fishImage = ImageUtil.outlineImage(itemManager.getImage(spot.getFishSpriteId()), Color.GREEN);
+					fishImage = ImageUtil.outlineImage(itemManager.getImage(spot.getFishSpriteId()), color);
 				}
 
 				if (fishImage != null)


### PR DESCRIPTION
For some people, the default cyan color on fishing spots blends in with the water surrounding it.

![image](https://user-images.githubusercontent.com/8920674/66942177-c4b4b700-f048-11e9-855b-1f582ecc33bf.png)

This makes the colors in the Fishing plugin configurable so you can change them according to your liking.