### PR TITLE
skill calc: clear combined action slot on skill change

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/SkillCalculator.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/SkillCalculator.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright (c) 2018, Kruithne <kruithne@gmail.com>
  * Copyright (c) 2018, Psikoi <https://github.com/psikoi>
  * All rights reserved.
@@ -128,6 +128,9 @@ class SkillCalculator extends JPanel
 
 		// Clear the search bar
 		searchBar.setText(null);
+
+		// Clear the combined action slots
+		clearCombinedSlots();
 
 		// Add in checkboxes for available skill bonuses.
 		renderBonusOptions();


### PR DESCRIPTION
It doesn't make much sense to combine actions across skills.