### PR TITLE
Wrong achievement requirement (Karamja hard: Kill a metal dragon)

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/KaramjaDiaryRequirement.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/KaramjaDiaryRequirement.java
@@ -120,10 +120,7 @@ public class KaramjaDiaryRequirement extends GenericDiaryRequirement
 			new CombatLevelRequirement(100),
 			new SkillRequirement(Skill.SLAYER, 50),
 			new QuestRequirement(Quest.SHILO_VILLAGE));
-		add("Kill a metal dragon in Brimhaven Dungeon.",
-			new SkillRequirement(Skill.AGILITY, 12),
-			new SkillRequirement(Skill.WOODCUTTING, 34));
-
+		
 		// ELITE
 		add("Craft 56 Nature runes at once.",
 			new SkillRequirement(Skill.RUNECRAFT, 91));


### PR DESCRIPTION
Closes#9808

The current skill requirements are not actual requirements for the diary but merely an optional route. In addition to this, both of the current so called skill requirements are already in possession of a player doing this part of the diary due to previous requirements. Finally, the current skill requirements can be eschewed by using tradingsticks.