### PR TITLE
loot tracker: show HA prices

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerBox.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerBox.java
@@ -261,7 +261,7 @@ class LootTrackerBox extends JPanel
 				continue;
 			}
 
-			totalPrice += entry.getPrice();
+			totalPrice += entry.getGePrice();
 
 			int quantity = 0;
 			for (final LootTrackerItem i : items)
@@ -277,9 +277,9 @@ class LootTrackerBox extends JPanel
 			if (quantity > 0)
 			{
 				int newQuantity = entry.getQuantity() + quantity;
-				long pricePerItem = entry.getPrice() == 0 ? 0 : (entry.getPrice() / entry.getQuantity());
+				long gePricePerItem = entry.getGePrice() == 0 ? 0 : (entry.getGePrice() / entry.getQuantity());
 
-				items.add(new LootTrackerItem(entry.getId(), entry.getName(), newQuantity, pricePerItem * newQuantity, entry.isIgnored()));
+				items.add(new LootTrackerItem(entry.getId(), entry.getName(), newQuantity, gePricePerItem * newQuantity, entry.isIgnored()));
 			}
 			else
 			{
@@ -287,7 +287,7 @@ class LootTrackerBox extends JPanel
 			}
 		}
 
-		items.sort((i1, i2) -> Long.compare(i2.getPrice(), i1.getPrice()));
+		items.sort((i1, i2) -> Long.compare(i2.getGePrice(), i1.getGePrice()));
 
 		// Calculates how many rows need to be display to fit all items
 		final int rowSize = ((items.size() % ITEMS_PER_ROW == 0) ? 0 : 1) + items.size() / ITEMS_PER_ROW;
@@ -352,8 +352,8 @@ class LootTrackerBox extends JPanel
 	{
 		final String name = item.getName();
 		final int quantity = item.getQuantity();
-		final long price = item.getPrice();
+		final long gePrice = item.getGePrice();
 		final String ignoredLabel = item.isIgnored() ? " - Ignored" : "";
-		return name + " x " + quantity + " (" + QuantityFormatter.quantityToStackSize(price) + ") " + ignoredLabel;
+		return name + " x " + quantity + " (" + QuantityFormatter.quantityToStackSize(gePrice) + ") " + ignoredLabel;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerBox.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerBox.java
@@ -70,6 +70,7 @@ class LootTrackerBox extends JPanel
 	@Getter(AccessLevel.PACKAGE)
 	private final String id;
 	private final LootTrackerPriceType priceType;
+	private final boolean showPriceType;
 
 	@Getter
 	private final List<LootTrackerRecord> records = new ArrayList<>();
@@ -84,6 +85,7 @@ class LootTrackerBox extends JPanel
 		@Nullable final String subtitle,
 		final boolean hideIgnoredItems,
 		final LootTrackerPriceType priceType,
+		final boolean showPriceType,
 		final BiConsumer<String, Boolean> onItemToggle)
 	{
 		this.id = id;
@@ -91,6 +93,7 @@ class LootTrackerBox extends JPanel
 		this.onItemToggle = onItemToggle;
 		this.hideIgnoredItems = hideIgnoredItems;
 		this.priceType = priceType;
+		this.showPriceType = showPriceType;
 
 		setLayout(new BorderLayout(0, 1));
 		setBorder(new EmptyBorder(5, 0, 0, 0));
@@ -184,7 +187,13 @@ class LootTrackerBox extends JPanel
 	{
 		buildItems();
 
-		priceLabel.setText(QuantityFormatter.quantityToStackSize(totalPrice) + " gp");
+		String priceTypeString = " ";
+		if (showPriceType)
+		{
+			priceTypeString = priceType == LootTrackerPriceType.HIGH_ALCHEMY ? "HA: " : "GE: ";
+		}
+
+		priceLabel.setText(priceTypeString + QuantityFormatter.quantityToStackSize(totalPrice) + " gp");
 		priceLabel.setToolTipText(QuantityFormatter.formatNumber(totalPrice) + " gp");
 
 		final long kills = getTotalKills();

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerConfig.java
@@ -60,6 +60,16 @@ public interface LootTrackerConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "showPriceType",
+		name = "Show Price Type",
+		description = "Whether to show a GE: or HA: next to the total values in the tracker"
+	)
+	default boolean showPriceType()
+	{
+		return false;
+	}
+
+	@ConfigItem(
 		keyName = "saveLoot",
 		name = "Submit loot tracker data",
 		description = "Submit loot tracker data (requires being logged in)"

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerConfig.java
@@ -50,6 +50,16 @@ public interface LootTrackerConfig extends Config
 	void setIgnoredItems(String key);
 
 	@ConfigItem(
+		keyName = "priceType",
+		name = "Price Type",
+		description = "What type of price to use for calculating value."
+	)
+	default LootTrackerPriceType priceType()
+	{
+		return LootTrackerPriceType.GRAND_EXCHANGE;
+	}
+
+	@ConfigItem(
 		keyName = "saveLoot",
 		name = "Submit loot tracker data",
 		description = "Submit loot tracker data (requires being logged in)"

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerItem.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerItem.java
@@ -38,7 +38,7 @@ class LootTrackerItem
 	@Getter
 	private final int quantity;
 	@Getter
-	private final long price;
+	private final long gePrice;
 	@Getter
 	@Setter
 	private boolean ignored;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPanel.java
@@ -518,7 +518,8 @@ class LootTrackerPanel extends PluginPanel
 		overallPanel.setVisible(true);
 
 		// Create box
-		final LootTrackerBox box = new LootTrackerBox(itemManager, record.getTitle(), record.getSubTitle(), hideIgnoredItems, plugin::toggleItem);
+		final LootTrackerBox box = new LootTrackerBox(itemManager, record.getTitle(), record.getSubTitle(),
+			hideIgnoredItems, config.priceType(), plugin::toggleItem);
 		box.combine(record);
 
 		// Create popup menu
@@ -594,7 +595,8 @@ class LootTrackerPanel extends PluginPanel
 	private void updateOverall()
 	{
 		long overallKills = 0;
-		long overallGp = 0;
+		long overallGe = 0;
+		long overallHa = 0;
 
 		for (LootTrackerRecord record : records)
 		{
@@ -613,7 +615,8 @@ class LootTrackerPanel extends PluginPanel
 					continue;
 				}
 
-				overallGp += item.getGePrice();
+				overallGe += item.getGePrice();
+				overallHa += item.getHaPrice();
 			}
 
 			if (present > 0)
@@ -623,7 +626,9 @@ class LootTrackerPanel extends PluginPanel
 		}
 
 		overallKillsLabel.setText(htmlLabel("Total count: ", overallKills));
-		overallGpLabel.setText(htmlLabel("Total value: ", overallGp));
+		overallGpLabel.setText(htmlLabel("Total value: ", config.priceType() == LootTrackerPriceType.HIGH_ALCHEMY ? overallHa : overallGe));
+		overallGpLabel.setToolTipText("<html>Total GE price: " + QuantityFormatter.formatNumber(overallGe)
+			+ "<br>Total HA price: " + QuantityFormatter.formatNumber(overallHa) + "</html>");
 		updateCollapseText();
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPanel.java
@@ -519,7 +519,7 @@ class LootTrackerPanel extends PluginPanel
 
 		// Create box
 		final LootTrackerBox box = new LootTrackerBox(itemManager, record.getTitle(), record.getSubTitle(),
-			hideIgnoredItems, config.priceType(), plugin::toggleItem);
+			hideIgnoredItems, config.priceType(), config.showPriceType(), plugin::toggleItem);
 		box.combine(record);
 
 		// Create popup menu
@@ -625,8 +625,14 @@ class LootTrackerPanel extends PluginPanel
 			}
 		}
 
+		String priceType = "";
+		if (config.showPriceType())
+		{
+			priceType = config.priceType() == LootTrackerPriceType.HIGH_ALCHEMY ? "HA " : "GE ";
+		}
+
 		overallKillsLabel.setText(htmlLabel("Total count: ", overallKills));
-		overallGpLabel.setText(htmlLabel("Total value: ", config.priceType() == LootTrackerPriceType.HIGH_ALCHEMY ? overallHa : overallGe));
+		overallGpLabel.setText(htmlLabel("Total " + priceType + "value: ", config.priceType() == LootTrackerPriceType.HIGH_ALCHEMY ? overallHa : overallGe));
 		overallGpLabel.setToolTipText("<html>Total GE price: " + QuantityFormatter.formatNumber(overallGe)
 			+ "<br>Total HA price: " + QuantityFormatter.formatNumber(overallHa) + "</html>");
 		updateCollapseText();

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPanel.java
@@ -613,7 +613,7 @@ class LootTrackerPanel extends PluginPanel
 					continue;
 				}
 
-				overallGp += item.getPrice();
+				overallGp += item.getGePrice();
 			}
 
 			if (present > 0)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
@@ -636,14 +636,14 @@ public class LootTrackerPlugin extends Plugin
 	{
 		final ItemComposition itemComposition = itemManager.getItemComposition(itemId);
 		final int realItemId = itemComposition.getNote() != -1 ? itemComposition.getLinkedNoteId() : itemId;
-		final long price = (long) itemManager.getItemPrice(realItemId) * (long) quantity;
+		final long gePrice = (long) itemManager.getItemPrice(realItemId) * (long) quantity;
 		final boolean ignored = ignoredItems.contains(itemComposition.getName());
 
 		return new LootTrackerItem(
 			itemId,
 			itemComposition.getName(),
 			quantity,
-			price,
+			gePrice,
 			ignored);
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
@@ -54,6 +54,7 @@ import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
+import net.runelite.api.Constants;
 import net.runelite.api.GameState;
 import net.runelite.api.InventoryID;
 import net.runelite.api.ItemComposition;
@@ -637,6 +638,7 @@ public class LootTrackerPlugin extends Plugin
 		final ItemComposition itemComposition = itemManager.getItemComposition(itemId);
 		final int realItemId = itemComposition.getNote() != -1 ? itemComposition.getLinkedNoteId() : itemId;
 		final long gePrice = (long) itemManager.getItemPrice(realItemId) * (long) quantity;
+		final long haPrice = (long) Math.round(itemComposition.getPrice() * Constants.HIGH_ALCHEMY_MULTIPLIER) * (long) quantity;
 		final boolean ignored = ignoredItems.contains(itemComposition.getName());
 
 		return new LootTrackerItem(
@@ -644,6 +646,7 @@ public class LootTrackerPlugin extends Plugin
 			itemComposition.getName(),
 			quantity,
 			gePrice,
+			haPrice,
 			ignored);
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPriceType.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPriceType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Tomas Slusny <slusnucky@gmail.com>
+ * Copyright (c) 2019 Hydrox6 <ikada@protonmail.ch>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -24,24 +24,8 @@
  */
 package net.runelite.client.plugins.loottracker;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.Setter;
-
-@AllArgsConstructor
-class LootTrackerItem
+public enum LootTrackerPriceType
 {
-	@Getter
-	private final int id;
-	@Getter
-	private final String name;
-	@Getter
-	private final int quantity;
-	@Getter
-	private final long gePrice;
-	@Getter
-	private final long haPrice;
-	@Getter
-	@Setter
-	private boolean ignored;
+	GRAND_EXCHANGE,
+	HIGH_ALCHEMY
 }


### PR DESCRIPTION
Closes: #5813
Closes: #7858

Adds an option to use HA values in the loot tracker, along with an option to visually show what type each price is. Also adds both prices to the item tooltips.

![tooltip](https://user-images.githubusercontent.com/2979691/67136688-c1285800-f221-11e9-92de-f12196325fe5.png)
![GE prices with type shown](https://user-images.githubusercontent.com/2979691/67136691-c5ed0c00-f221-11e9-9f02-58c5a05d3ec7.png)
![HA prices with type shown](https://user-images.githubusercontent.com/2979691/67136692-c7b6cf80-f221-11e9-8122-9ae1f6c16415.png)
