### PR TITLE
worldmap: fix invalid description for prifddinas farming patch

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldmap/FarmingPatchLocation.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldmap/FarmingPatchLocation.java
@@ -35,13 +35,13 @@ enum FarmingPatchLocation
 		new WorldPoint(3793, 2836, 0),
 		new WorldPoint(1269, 3730, 0)
 	),
+	ALLOTMENT_FLOWER("Allotment/Flower", new WorldPoint(3289, 6100, 0)),
 	ALLOTMENT_HERB_FLOWER("Allotment/Herb/Flower",
 		new WorldPoint(1809, 3490, 0),
 		new WorldPoint(3598, 3524, 0),
 		new WorldPoint(3052, 3309, 0),
 		new WorldPoint(2810, 3462, 0),
-		new WorldPoint(2663, 3375, 0),
-		new WorldPoint(3289, 6100, 0)
+		new WorldPoint(2663, 3375, 0)
 	),
 	ANIMA_HERB("Anima/Herb", new WorldPoint(1235, 3724, 0)),
 	BELLADONNA("Belladonna", new WorldPoint(3084, 3356, 0)),


### PR DESCRIPTION
This farming patch does not include a herb patch as the tooltip was describing.

![image](https://user-images.githubusercontent.com/35824069/67227747-248bd300-f438-11e9-8f84-855139d7c852.png)

Closes #10111