### PR TITLE
npc health: add zombie health

### DIFF
--- a/runelite-client/src/main/resources/npc_health.json
+++ b/runelite-client/src/main/resources/npc_health.json
@@ -1160,5 +1160,6 @@
 	"Alchemical Hydra_426": 1100,
 	"Undead Druid_105": 140,
 	"Temple Spider_75": 70,
-	"Sarachnis_318": 400
+	"Sarachnis_318": 400,
+	"Zombie_44": 40
 }


### PR DESCRIPTION
Closes #10119 

### Issue
Level 44 zombie health was missing from npc_health.json.
hitpointsDisplayStyle() displayed as percentage because hitpoints value was null.