### PR TITLE
random events: fix npe on login

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/randomevents/RandomEventPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/randomevents/RandomEventPlugin.java
@@ -118,7 +118,11 @@ public class RandomEventPlugin extends Plugin
 
 		// Check that the npc is interacting with the player and the player isn't interacting with the npc, so
 		// that the notification doesn't fire from talking to other user's randoms
-		if (target != player || player.getInteracting() == source || !(source instanceof NPC) || !EVENT_NPCS.contains(((NPC) source).getId()))
+		if (player == null
+			|| target != player
+			|| player.getInteracting() == source
+			|| !(source instanceof NPC)
+			|| !EVENT_NPCS.contains(((NPC) source).getId()))
 		{
 			return;
 		}


### PR DESCRIPTION
On login, `interactingChanged` fires once with both player and target set to null.