### PR TITLE
music: check parent and siblings for null

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/music/MusicPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/music/MusicPlugin.java
@@ -411,13 +411,21 @@ public class MusicPlugin extends Plugin
 			{
 				{
 					Widget handle = slider.getHandle();
-					Widget[] siblings = handle.getParent().getChildren();
-					if (siblings.length < handle.getIndex() || siblings[handle.getIndex()] != handle)
+					Widget parent = handle.getParent();
+					if (parent == null)
 					{
 						continue;
 					}
-					siblings[slider.getTrack().getIndex()] = null;
-					siblings[handle.getIndex()] = null;
+					else
+					{
+						Widget[] siblings = parent.getChildren();
+						if (siblings == null || handle.getIndex() >= siblings.length || siblings[handle.getIndex()] != handle)
+						{
+							continue;
+						}
+						siblings[slider.getTrack().getIndex()] = null;
+						siblings[handle.getIndex()] = null;
+					}
 				}
 
 				Object[] init = icon.getOnLoadListener();
@@ -444,10 +452,18 @@ public class MusicPlugin extends Plugin
 			Widget handle = slider.getHandle();
 			if (handle != null)
 			{
-				Widget[] siblings = handle.getParent().getChildren();
-				if (siblings.length < handle.getIndex() || siblings[handle.getIndex()] != handle)
+				Widget parent = handle.getParent();
+				if (parent == null)
 				{
 					handle = null;
+				}
+				else
+				{
+					Widget[] siblings = parent.getChildren();
+					if (siblings == null || handle.getIndex() >= siblings.length || siblings[handle.getIndex()] != handle)
+					{
+						handle = null;
+					}
 				}
 			}
 			if (handle == null)


### PR DESCRIPTION
```
Gamma1991:
2019-10-24 21:10:25 [Client] WARN  n.runelite.client.eventbus.EventBus - Uncaught exception in event subscriber
java.lang.NullPointerException: null
    at net.runelite.client.plugins.music.MusicPlugin.updateMusicOptions(MusicPlugin.java:445)
    at net.runelite.client.plugins.music.MusicPlugin.applyMusicVolumeConfig(MusicPlugin.java:237)
    at net.runelite.client.plugins.music.MusicPlugin.onVolumeChanged(MusicPlugin.java:205)
    at net.runelite.client.eventbus.EventBus$Subscriber.invoke(EventBus.java:72)
    at net.runelite.client.eventbus.EventBus.post(EventBus.java:218)
    at net.runelite.client.callback.Hooks.post(Hooks.java:164)
    at client.cy(client.java:43538)
    at fu.jp(fu.java:10850)
    at client.gh(client.java:6552)
    at client.yb(client.java:2446)
    at client.as(client.java:1001)
    at bh.o(bh.java:354)
    at bh.run(bh.java:333)
    at java.base/java.lang.Thread.run(Thread.java:834)

latest version from github, music volume plugin died on me
```