### PR TITLE
Correct medium Western diary requirement

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/WesternDiaryRequirement.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/WesternDiaryRequirement.java
@@ -78,7 +78,7 @@ public class WesternDiaryRequirement extends GenericDiaryRequirement
 		add("Make a Chocolate Bomb at the Grand Tree.",
 			new SkillRequirement(Skill.COOKING, 42));
 		add("Complete a delivery for the Gnome Restaurant.",
-			new SkillRequirement(Skill.COOKING, 42));
+			new SkillRequirement(Skill.COOKING, 29));
 		add("Turn your small crystal seed into a Crystal saw.",
 			new QuestRequirement(Quest.THE_EYES_OF_GLOUPHRIE));
 		add("Mine some Gold ore underneath the Grand Tree.",


### PR DESCRIPTION
You only need 29 cooking to complete the Gnome Restaurant tutorial. You can cancel tasks if you do not have the level required to cook the requested food.