### PR TITLE
Fix ScreenshotPlugin Kingdom of Miscellania double screenshot

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
@@ -451,7 +451,6 @@ public class ScreenshotPlugin extends Plugin
 			case KINGDOM_GROUP_ID:
 			{
 				fileName = "Kingdom " + LocalDate.now();
-				takeScreenshot(fileName);
 				break;
 			}
 			case CHAMBERS_OF_XERIC_REWARD_GROUP_ID:


### PR DESCRIPTION
closes #10183 
Fixed ScreenshotPlugin so that checking Kingdom of Miscellania does result in double screenshots.