### PR TITLE
Add more area mute options

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/music/MusicConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/music/MusicConfig.java
@@ -32,11 +32,45 @@ import net.runelite.client.config.ConfigItem;
 public interface MusicConfig extends Config
 {
 	@ConfigItem(
+		keyName = "muteOwnAreaSounds",
+		name = "Mute player area sounds",
+		description = "Mute area sounds caused by yourself",
+		position = 0
+	)
+	default boolean muteOwnAreaSounds()
+	{
+		return false;
+	}
+
+	@ConfigItem(
 		keyName = "muteOtherAreaSounds",
-		name = "Mute others' area sounds",
-		description = "Mute area sounds caused from other players"
+		name = "Mute other players' area sounds",
+		description = "Mute area sounds caused by other players",
+		position = 1
 	)
 	default boolean muteOtherAreaSounds()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		keyName = "muteOtherAreaNPCSounds",
+		name = "Mute NPCs' area sounds",
+		description = "Mute area sounds caused by NPCs",
+		position = 2
+	)
+	default boolean muteNpcAreaSounds()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		keyName = "muteOtherAreaEnvironmentSounds",
+		name = "Mute environment area sounds",
+		description = "Mute area sounds caused by neither NPCs nor players",
+		position = 3
+	)
+	default boolean muteEnvironmentAreaSounds()
 	{
 		return false;
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/music/MusicPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/music/MusicPlugin.java
@@ -40,6 +40,7 @@ import lombok.Setter;
 import net.runelite.api.Actor;
 import net.runelite.api.Client;
 import net.runelite.api.GameState;
+import net.runelite.api.NPC;
 import net.runelite.api.Player;
 import net.runelite.api.ScriptID;
 import net.runelite.api.SoundEffectID;
@@ -557,9 +558,24 @@ public class MusicPlugin extends Plugin
 	public void onAreaSoundEffectPlayed(AreaSoundEffectPlayed areaSoundEffectPlayed)
 	{
 		Actor source = areaSoundEffectPlayed.getSource();
-		if (source != client.getLocalPlayer()
+		if (source == client.getLocalPlayer()
+			&& musicConfig.muteOwnAreaSounds())
+		{
+			areaSoundEffectPlayed.consume();
+		}
+		else if (source != client.getLocalPlayer()
 			&& source instanceof Player
 			&& musicConfig.muteOtherAreaSounds())
+		{
+			areaSoundEffectPlayed.consume();
+		}
+		else if (source instanceof NPC
+			&& musicConfig.muteNpcAreaSounds())
+		{
+			areaSoundEffectPlayed.consume();
+		}
+		else if (source == null
+			&& musicConfig.muteEnvironmentAreaSounds())
 		{
 			areaSoundEffectPlayed.consume();
 		}


### PR DESCRIPTION
Closes #10176 

I noticed that area sounds can be created by players, npcs, or neither, so I added the option to mute each independently (as well as the player them-self), as opposed to just other players.

This is my first contribution here (and to any open source project in general!) so please roast me if necessary!