### PR TITLE
inventorygrid: use mouse dragged distance to determine if overlay should show

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/inventorygrid/InventoryGridConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/inventorygrid/InventoryGridConfig.java
@@ -27,7 +27,6 @@ package net.runelite.client.plugins.inventorygrid;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
-import net.runelite.client.config.Range;
 
 @ConfigGroup("inventorygrid")
 public interface InventoryGridConfig extends Config
@@ -60,16 +59,5 @@ public interface InventoryGridConfig extends Config
 	default boolean showHighlight()
 	{
 		return true;
-	}
-
-	@ConfigItem(
-		keyName = "dragDelay",
-		name = "Drag Delay",
-		description = "Time in ms to wait after item press before showing grid"
-	)
-	@Range(min = 100)
-	default int dragDelay()
-	{
-		return 100;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/inventorygrid/InventoryGridOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/inventorygrid/InventoryGridOverlay.java
@@ -34,7 +34,6 @@ import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.image.BufferedImage;
 import net.runelite.api.Client;
-import net.runelite.api.Constants;
 import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.api.widgets.WidgetItem;
@@ -46,6 +45,7 @@ import net.runelite.client.ui.overlay.OverlayPosition;
 class InventoryGridOverlay extends Overlay
 {
 	private static final int INVENTORY_SIZE = 28;
+	private static final int DISTANCE_TO_ACTIVATE_HOVER = 5;
 
 	private static final Color HIGHLIGHT = new Color(0, 255, 0, 45);
 	private static final Color GRID = new Color(255, 255, 255, 45);
@@ -53,6 +53,9 @@ class InventoryGridOverlay extends Overlay
 	private final InventoryGridConfig config;
 	private final Client client;
 	private final ItemManager itemManager;
+
+	private Point initialMousePoint;
+	private boolean hoverActive = false;
 
 	@Inject
 	private InventoryGridOverlay(InventoryGridConfig config, Client client, ItemManager itemManager)
@@ -71,9 +74,10 @@ class InventoryGridOverlay extends Overlay
 		final Widget if1DraggingWidget = client.getIf1DraggedWidget();
 		final Widget inventoryWidget = client.getWidget(WidgetInfo.INVENTORY);
 
-		if (if1DraggingWidget == null || if1DraggingWidget != inventoryWidget
-			|| client.getItemPressedDuration() < config.dragDelay() / Constants.CLIENT_TICK_LENGTH)
+		if (if1DraggingWidget == null || if1DraggingWidget != inventoryWidget)
 		{
+			initialMousePoint = null;
+			hoverActive = false;
 			return null;
 		}
 
@@ -84,10 +88,17 @@ class InventoryGridOverlay extends Overlay
 		final int itemId = draggedItem.getId();
 		final Rectangle initialBounds = draggedItem.getCanvasBounds();
 
-		if (itemId == -1)
+		if (initialMousePoint == null)
+		{
+			initialMousePoint = mousePoint;
+		}
+
+		if (itemId == -1 || !hoverActive && initialMousePoint.distance(mousePoint) < DISTANCE_TO_ACTIVATE_HOVER)
 		{
 			return null;
 		}
+
+		hoverActive = true;
 
 		for (int i = 0; i < INVENTORY_SIZE; ++i)
 		{


### PR DESCRIPTION
Replace the time dependant showing of the inventory overlay with a distance based one. An item sprite only follows the mouse if the mouse is held down and dragged ~5 pixels. Thus, the overlay will only show when you are certain to be dragging an item and the time-delay is unnecessary.

Original PR by Jbleezy. Supersedes/Closes #9764