### PR TITLE
Allowing anti-drag key to be configurable

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/antidrag/AntiDragConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/antidrag/AntiDragConfig.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018, DennisDeV <https://github.com/DevDennis>
+ * Copyright (c) 2019, Pinibot <https://github.com/Pinibot>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -24,10 +25,13 @@
  */
 package net.runelite.client.plugins.antidrag;
 
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
 import net.runelite.api.Constants;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.ModifierlessKeybind;
 
 @ConfigGroup("antiDrag")
 public interface AntiDragConfig extends Config
@@ -41,5 +45,16 @@ public interface AntiDragConfig extends Config
 	default int dragDelay()
 	{
 		return Constants.GAME_TICK_LENGTH / Constants.CLIENT_TICK_LENGTH; // one game tick
+	}
+
+	@ConfigItem(
+		keyName = "hotkey",
+		name = "Hotkey",
+		description = "Configures the key required to be held to prevent dragging.",
+		position = 2
+	)
+	default ModifierlessKeybind hotkey()
+	{
+		return new ModifierlessKeybind(KeyEvent.VK_SHIFT, InputEvent.SHIFT_DOWN_MASK);
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/antidrag/AntiDragPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/antidrag/AntiDragPlugin.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018, DennisDeV <https://github.com/DevDennis>
+ * Copyright (c) 2018, Pinibot <https://github.com/Pinibot>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -31,17 +32,17 @@ import net.runelite.api.Client;
 import net.runelite.api.events.FocusChanged;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
-import net.runelite.client.input.KeyListener;
 import net.runelite.client.input.KeyManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.util.HotkeyListener;
 
 @PluginDescriptor(
-	name = "Shift Anti Drag",
+	name = "Anti Drag",
 	description = "Prevent dragging an item for a specified delay",
 	tags = {"antidrag", "delay", "inventory", "items"}
 )
-public class AntiDragPlugin extends Plugin implements KeyListener
+public class AntiDragPlugin extends Plugin
 {
 	private static final int DEFAULT_DELAY = 5;
 
@@ -63,39 +64,34 @@ public class AntiDragPlugin extends Plugin implements KeyListener
 	@Override
 	protected void startUp() throws Exception
 	{
-		keyManager.registerKeyListener(this);
+		keyManager.registerKeyListener(hotkeyListener);
 	}
 
 	@Override
 	protected void shutDown() throws Exception
 	{
 		client.setInventoryDragDelay(DEFAULT_DELAY);
-		keyManager.unregisterKeyListener(this);
+		keyManager.unregisterKeyListener(hotkeyListener);
 	}
 
-	@Override
-	public void keyTyped(KeyEvent e)
+	private final HotkeyListener hotkeyListener = new HotkeyListener(() -> config.hotkey())
 	{
-
-	}
-
-	@Override
-	public void keyPressed(KeyEvent e)
-	{
-		if (e.getKeyCode() == KeyEvent.VK_SHIFT)
+		@Override
+		public void hotkeyPressed()
 		{
 			client.setInventoryDragDelay(config.dragDelay());
 		}
-	}
 
-	@Override
-	public void keyReleased(KeyEvent e)
-	{
-		if (e.getKeyCode() == KeyEvent.VK_SHIFT)
+		@Override
+		public void keyReleased(KeyEvent e)
 		{
-			client.setInventoryDragDelay(DEFAULT_DELAY);
+			super.keyReleased(e);
+			if (config.hotkey().matches(e))
+			{
+				client.setInventoryDragDelay(DEFAULT_DELAY);
+			}
 		}
-	}
+	};
 
 	@Subscribe
 	public void onFocusChanged(FocusChanged focusChanged)


### PR DESCRIPTION
Currently the plugin only supports the shift key for increasing the drag delay but this isn't ideal as shift is often bound to "shift to drop", meaning that items can be accidently dropped if this option is enabled.

I've added a new ModiferlessKeybind config option to allow the user to choose any key that they wish to be used in place of shift.