### PR TITLE
attack styles: add test for swap between bludgeon and bow

### DIFF
--- a/runelite-client/src/test/java/net/runelite/client/plugins/attackstyles/AttackStylesPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/attackstyles/AttackStylesPluginTest.java
@@ -33,6 +33,7 @@ import net.runelite.api.Client;
 import net.runelite.api.Skill;
 import net.runelite.api.VarPlayer;
 import net.runelite.api.Varbits;
+import net.runelite.api.events.WidgetHiddenChanged;
 import net.runelite.client.events.ConfigChanged;
 import net.runelite.api.events.VarbitChanged;
 import net.runelite.api.widgets.Widget;
@@ -43,8 +44,11 @@ import static org.junit.Assert.assertTrue;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import org.mockito.junit.MockitoJUnitRunner;
 
@@ -167,6 +171,60 @@ public class AttackStylesPluginTest
 			WidgetInfo.COMBAT_STYLE_ONE));
 		assertFalse(attackPlugin.getHiddenWidgets().get(WeaponType.TYPE_4,
 			WidgetInfo.COMBAT_STYLE_THREE));
+	}
+
+	/*
+	 * Verify that the defensive style is hidden when switching from bludgeon to bow
+	 */
+	@Test
+	public void testHiddenLongrange()
+	{
+		final ArgumentCaptor<Boolean> captor = ArgumentCaptor.forClass(Boolean.class);
+		final ConfigChanged warnForAttackEvent = new ConfigChanged();
+		warnForAttackEvent.setGroup("attackIndicator");
+		warnForAttackEvent.setKey("warnForDefensive");
+		warnForAttackEvent.setNewValue("true");
+		attackPlugin.onConfigChanged(warnForAttackEvent);
+
+		// verify there is a warned skill
+		Set<Skill> warnedSkills = attackPlugin.getWarnedSkills();
+		assertTrue(warnedSkills.contains(Skill.DEFENCE));
+
+		// Set up mock widget for strength and longrange
+		final Widget widget = mock(Widget.class);
+		when(client.getWidget(WidgetInfo.COMBAT_STYLE_FOUR)).thenReturn(widget);
+
+		// Set up hidden changed event
+		final WidgetHiddenChanged widgetHiddenChanged = new WidgetHiddenChanged();
+		widgetHiddenChanged.setWidget(widget);
+		when(widget.getId()).thenReturn(WidgetInfo.COMBAT_STYLE_FOUR.getPackedId());
+
+		// Enable hiding widgets
+		final ConfigChanged hideWidgetEvent = new ConfigChanged();
+		hideWidgetEvent.setGroup("attackIndicator");
+		hideWidgetEvent.setKey("removeWarnedStyles");
+		hideWidgetEvent.setNewValue("true");
+		attackPlugin.onConfigChanged(hideWidgetEvent);
+		when(attackConfig.removeWarnedStyles()).thenReturn(true);
+
+		// equip bludgeon on player
+		when(client.getVar(Varbits.EQUIPPED_WEAPON_TYPE)).thenReturn(WeaponType.TYPE_26.ordinal());
+		attackPlugin.onVarbitChanged(new VarbitChanged());
+		attackPlugin.onWidgetHiddenChanged(widgetHiddenChanged);
+
+		// verify that the agressive style style widget is showing
+		verify(widget, atLeastOnce()).setHidden(captor.capture());
+		assertFalse(captor.getValue());
+
+		// equip bow on player
+		// the equipped weaopn varbit will change after the hiddenChanged event has been dispatched
+		attackPlugin.onWidgetHiddenChanged(widgetHiddenChanged);
+		when(client.getVar(Varbits.EQUIPPED_WEAPON_TYPE)).thenReturn(WeaponType.TYPE_3.ordinal());
+		attackPlugin.onVarbitChanged(new VarbitChanged());
+
+		// verify that the longrange attack style widget is now hidden
+		verify(widget, atLeastOnce()).setHidden(captor.capture());
+		assertTrue(captor.getValue());
 	}
 
 	private boolean isAtkHidden()


### PR DESCRIPTION
When swapping between bludgeon and bow, `onWidgetHiddenChanged` is called before the weapon varbit is set. Since that varbit determines which widgets should be hidden we would like to make sure the widget is set to hidden even after a varbit change.

This should probably have been a part of #9578, but it's here now :slightly_smiling_face: 