### PR TITLE
Reclassify teleport sfx as other players' area effects instead of environmental area effects

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/music/MusicPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/music/MusicPlugin.java
@@ -564,7 +564,7 @@ public class MusicPlugin extends Plugin
 	public void onAreaSoundEffectPlayed(AreaSoundEffectPlayed areaSoundEffectPlayed)
 	{
 		Actor source = areaSoundEffectPlayed.getSource();
-		int soundID = areaSoundEffectPlayed.getSoundId();
+		int soundId = areaSoundEffectPlayed.getSoundId();
 		if (source == client.getLocalPlayer()
 			&& musicConfig.muteOwnAreaSounds())
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/music/MusicPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/music/MusicPlugin.java
@@ -78,6 +78,10 @@ import net.runelite.client.plugins.PluginDescriptor;
 )
 public class MusicPlugin extends Plugin
 {
+	private static final Set<Integer> SOURCELESS_PLAYER_SOUNDS = ImmutableSet.of(
+		SoundEffectID.TELEPORT_VWOOP
+	);
+
 	@Inject
 	private Client client;
 
@@ -98,10 +102,6 @@ public class MusicPlugin extends Plugin
 	private Collection<Widget> tracks;
 
 	private MusicState currentMusicFilter = MusicState.ALL;
-
-	private static final Set<Integer> SOURCELESS_PLAYER_SOUNDS = ImmutableSet.of(
-		SoundEffectID.TELEPORT_VWOOP
-	);
 
 	@Override
 	protected void startUp()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/music/MusicPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/music/MusicPlugin.java
@@ -25,10 +25,12 @@
  */
 package net.runelite.client.plugins.music;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.inject.Provides;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
+import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.function.ToIntFunction;
 import java.util.stream.Collectors;
@@ -96,6 +98,10 @@ public class MusicPlugin extends Plugin
 	private Collection<Widget> tracks;
 
 	private MusicState currentMusicFilter = MusicState.ALL;
+
+	private static final Set<Integer> SOURCELESS_PLAYER_SOUNDS = ImmutableSet.of(
+		SoundEffectID.TELEPORT_VWOOP
+	);
 
 	@Override
 	protected void startUp()
@@ -565,8 +571,8 @@ public class MusicPlugin extends Plugin
 			areaSoundEffectPlayed.consume();
 		}
 		else if (source != client.getLocalPlayer()
-			&& (source instanceof Player || soundID == 200)    //200 is the teleport sound effect ID. this exception
-			&& musicConfig.muteOtherAreaSounds())              //exists because teleport's source actor is always null.
+			&& (source instanceof Player || SOURCELESS_PLAYER_SOUNDS.contains(soundID))
+			&& musicConfig.muteOtherAreaSounds())
 		{
 			areaSoundEffectPlayed.consume();
 		}
@@ -576,7 +582,7 @@ public class MusicPlugin extends Plugin
 			areaSoundEffectPlayed.consume();
 		}
 		else if (source == null
-			&& soundID != 200
+			&& !SOURCELESS_PLAYER_SOUNDS.contains(soundID)
 			&& musicConfig.muteEnvironmentAreaSounds())
 		{
 			areaSoundEffectPlayed.consume();

--- a/runelite-client/src/main/java/net/runelite/client/plugins/music/MusicPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/music/MusicPlugin.java
@@ -571,7 +571,7 @@ public class MusicPlugin extends Plugin
 			areaSoundEffectPlayed.consume();
 		}
 		else if (source != client.getLocalPlayer()
-			&& (source instanceof Player || SOURCELESS_PLAYER_SOUNDS.contains(soundID))
+			&& (source instanceof Player || (source == null && SOURCELESS_PLAYER_SOUNDS.contains(soundId)))
 			&& musicConfig.muteOtherAreaSounds())
 		{
 			areaSoundEffectPlayed.consume();
@@ -582,7 +582,7 @@ public class MusicPlugin extends Plugin
 			areaSoundEffectPlayed.consume();
 		}
 		else if (source == null
-			&& !SOURCELESS_PLAYER_SOUNDS.contains(soundID)
+			&& !SOURCELESS_PLAYER_SOUNDS.contains(soundId)
 			&& musicConfig.muteEnvironmentAreaSounds())
 		{
 			areaSoundEffectPlayed.consume();

--- a/runelite-client/src/main/java/net/runelite/client/plugins/music/MusicPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/music/MusicPlugin.java
@@ -558,14 +558,15 @@ public class MusicPlugin extends Plugin
 	public void onAreaSoundEffectPlayed(AreaSoundEffectPlayed areaSoundEffectPlayed)
 	{
 		Actor source = areaSoundEffectPlayed.getSource();
+		int soundID = areaSoundEffectPlayed.getSoundId();
 		if (source == client.getLocalPlayer()
 			&& musicConfig.muteOwnAreaSounds())
 		{
 			areaSoundEffectPlayed.consume();
 		}
 		else if (source != client.getLocalPlayer()
-			&& source instanceof Player
-			&& musicConfig.muteOtherAreaSounds())
+			&& (source instanceof Player || soundID == 200)    //200 is the teleport sound effect ID. this exception
+			&& musicConfig.muteOtherAreaSounds())              //exists because teleport's source actor is always null.
 		{
 			areaSoundEffectPlayed.consume();
 		}
@@ -575,6 +576,7 @@ public class MusicPlugin extends Plugin
 			areaSoundEffectPlayed.consume();
 		}
 		else if (source == null
+			&& soundID != 200
 			&& musicConfig.muteEnvironmentAreaSounds())
 		{
 			areaSoundEffectPlayed.consume();


### PR DESCRIPTION
resolves #10248

This will also mute teleports cast by the player, as there is no simple way to tell who created the sound without a source. Note that using a mounted amulet of glory still makes the teleport sounds, even if every possible selection is muted.

Perhaps you'd rather have teleports be environmental sfx anyway? This seemed like a better place to put them, though.