### PR TITLE
Require client focus for "until cancelled" notifications cancelling

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/Notifier.java
+++ b/runelite-client/src/main/java/net/runelite/client/Notifier.java
@@ -195,9 +195,9 @@ public class Notifier
 			case SOLID_UNTIL_CANCELLED:
 			case FLASH_UNTIL_CANCELLED:
 				// Any interaction with the client since the notification started will cancel it after the minimum duration
-				if (client.getMouseIdleTicks() < MINIMUM_FLASH_DURATION_TICKS
+				if ((client.getMouseIdleTicks() < MINIMUM_FLASH_DURATION_TICKS
 					|| client.getKeyboardIdleTicks() < MINIMUM_FLASH_DURATION_TICKS
-					|| client.getMouseLastPressedMillis() > mouseLastPressedMillis)
+					|| client.getMouseLastPressedMillis() > mouseLastPressedMillis) && clientUI.isFocused())
 				{
 					flashStart = null;
 				}


### PR DESCRIPTION
Makes it so moving the mouse over the window doesn't cancel notifications (Ie you're moving mouse from right to left monitor without noticing notification, so you end up cancelling unintentionally)