### PR TITLE
inventorygrid: re-add a delay to showing the overlay

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/inventorygrid/InventoryGridConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/inventorygrid/InventoryGridConfig.java
@@ -27,6 +27,7 @@ package net.runelite.client.plugins.inventorygrid;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.Units;
 
 @ConfigGroup("inventorygrid")
 public interface InventoryGridConfig extends Config
@@ -59,5 +60,16 @@ public interface InventoryGridConfig extends Config
 	default boolean showHighlight()
 	{
 		return true;
+	}
+
+	@ConfigItem(
+		keyName = "dragDelay",
+		name = "Drag delay",
+		description = "Time to wait after an item press before the overlay is enabled"
+	)
+	@Units(Units.MILLISECONDS)
+	default int dragDelay()
+	{
+		return 0;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/inventorygrid/InventoryGridOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/inventorygrid/InventoryGridOverlay.java
@@ -34,6 +34,7 @@ import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.image.BufferedImage;
 import net.runelite.api.Client;
+import net.runelite.api.Constants;
 import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.api.widgets.WidgetItem;
@@ -92,7 +93,9 @@ class InventoryGridOverlay extends Overlay
 			initialMousePoint = mousePoint;
 		}
 
-		if (draggedItem.getId() == -1 || !hoverActive && initialMousePoint.distance(mousePoint) < DISTANCE_TO_ACTIVATE_HOVER)
+		if (draggedItem.getId() == -1
+			|| client.getItemPressedDuration() < config.dragDelay() / Constants.CLIENT_TICK_LENGTH
+			|| !hoverActive && initialMousePoint.distance(mousePoint) < DISTANCE_TO_ACTIVATE_HOVER)
 		{
 			return null;
 		}


### PR DESCRIPTION
If a player for example tries to drop an entire inventory quickly with the overlay turned on, the inventory grid will flash for each small mouse movement if the left mouse key is held down. This change mitigates the issue by adding a delay option that controls the amount of time the user has to wait after pressing it before enabling any overlay functionality. Showing the grid still requires the mouse to be moved ~5px away from the first clicked position.

This delay just delays the activation of the overlay, as the the delay countdown is started upon item press rather than the exit this ~5px range. Making it respect the exit is needlessly complex as desired functionality is reached with the current changeset.

Closes #10269