### PR TITLE
Raids: rotations whitelist fix

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/raids/Raid.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/raids/Raid.java
@@ -26,15 +26,19 @@ package net.runelite.client.plugins.raids;
 
 import java.util.ArrayList;
 import java.util.List;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.Setter;
 import net.runelite.client.plugins.raids.solver.Layout;
 import net.runelite.client.plugins.raids.solver.Room;
 
 public class Raid
 {
+	@Setter(AccessLevel.PACKAGE)
 	@Getter
-	private final RaidRoom[] rooms = new RaidRoom[16];
+	private RaidRoom[] rooms = new RaidRoom[16];
 
+	@Setter(AccessLevel.PACKAGE)
 	@Getter
 	private Layout layout;
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsOverlay.java
@@ -101,14 +101,6 @@ public class RaidsOverlay extends Overlay
 			.color(color)
 			.build());
 
-		int bossMatches = 0;
-		int bossCount = 0;
-
-		if (config.enableRotationWhitelist())
-		{
-			bossMatches = plugin.getRotationMatches();
-		}
-
 		for (Room layoutRoom : plugin.getRaid().getLayout().getRooms())
 		{
 			int position = layoutRoom.getPosition();
@@ -124,13 +116,12 @@ public class RaidsOverlay extends Overlay
 			switch (room.getType())
 			{
 				case COMBAT:
-					bossCount++;
 					if (plugin.getRoomWhitelist().contains(room.getName().toLowerCase()))
 					{
 						color = Color.GREEN;
 					}
 					else if (plugin.getRoomBlacklist().contains(room.getName().toLowerCase())
-							|| config.enableRotationWhitelist() && bossCount > bossMatches)
+							|| config.enableRotationWhitelist() && !plugin.getRotationMatches())
 					{
 						color = Color.RED;
 					}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsPlugin.java
@@ -24,6 +24,7 @@
  */
 package net.runelite.client.plugins.raids;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 import com.google.inject.Binder;
 import com.google.inject.Provides;
@@ -40,7 +41,9 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
@@ -155,6 +158,7 @@ public class RaidsPlugin extends Plugin
 	@Getter
 	private final Set<String> layoutWhitelist = new HashSet<String>();
 
+	@Setter(AccessLevel.PACKAGE)
 	@Getter
 	private Raid raid;
 
@@ -401,7 +405,8 @@ public class RaidsPlugin extends Plugin
 		}
 	}
 
-	private void updateLists()
+	@VisibleForTesting
+	void updateLists()
 	{
 		updateList(roomWhitelist, config.whitelistedRooms());
 		updateList(roomBlacklist, config.blacklistedRooms());

--- a/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsPlugin.java
@@ -30,9 +30,11 @@ import com.google.inject.Provides;
 import java.io.IOException;
 import java.text.DecimalFormat;
 import java.time.Instant;
-import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -96,7 +98,7 @@ public class RaidsPlugin extends Plugin
 	private static final String RAID_COMPLETE_MESSAGE = "Congratulations - your raid is complete!";
 	private static final DecimalFormat DECIMAL_FORMAT = new DecimalFormat("###.##");
 	private static final DecimalFormat POINTS_FORMAT = new DecimalFormat("#,###");
-	private static final Pattern ROTATION_REGEX = Pattern.compile("\\[(.*?)]");
+	private static final Pattern ROTATION_REGEX = Pattern.compile("\\[(.*?)\\]");
 	private static final String LAYOUT_COMMAND = "!layout";
 
 	@Inject
@@ -142,16 +144,16 @@ public class RaidsPlugin extends Plugin
 	private ScheduledExecutorService scheduledExecutorService;
 
 	@Getter
-	private final ArrayList<String> roomWhitelist = new ArrayList<>();
+	private final Set<String> roomWhitelist = new HashSet<String>();
 
 	@Getter
-	private final ArrayList<String> roomBlacklist = new ArrayList<>();
+	private final Set<String> roomBlacklist = new HashSet<String>();
 
 	@Getter
-	private final ArrayList<String> rotationWhitelist = new ArrayList<>();
+	private final Set<String> rotationWhitelist = new HashSet<String>();
 
 	@Getter
-	private final ArrayList<String> layoutWhitelist = new ArrayList<>();
+	private final Set<String> layoutWhitelist = new HashSet<String>();
 
 	@Getter
 	private Raid raid;
@@ -407,7 +409,7 @@ public class RaidsPlugin extends Plugin
 		updateList(layoutWhitelist, config.whitelistedLayouts());
 	}
 
-	private void updateList(ArrayList<String> list, String input)
+	private void updateList(Collection<String> list, String input)
 	{
 		list.clear();
 
@@ -416,12 +418,7 @@ public class RaidsPlugin extends Plugin
 			Matcher m = ROTATION_REGEX.matcher(input);
 			while (m.find())
 			{
-				String rotation = m.group(1).toLowerCase();
-
-				if (!list.contains(rotation))
-				{
-					list.add(rotation);
-				}
+				list.add(m.group(1).toLowerCase().replaceAll("\\s|\"", ""));
 			}
 		}
 		else
@@ -430,7 +427,7 @@ public class RaidsPlugin extends Plugin
 		}
 	}
 
-	int getRotationMatches()
+	boolean getRotationMatches()
 	{
 		RaidRoom[] combatRooms = raid.getCombatRooms();
 		String rotation = Arrays.stream(combatRooms)
@@ -438,7 +435,7 @@ public class RaidsPlugin extends Plugin
 			.map(String::toLowerCase)
 			.collect(Collectors.joining(","));
 
-		return rotationWhitelist.contains(rotation) ? combatRooms.length : 0;
+		return rotationWhitelist.contains(rotation);
 	}
 
 	private Point findLobbyBase()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/raids/solver/Room.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/raids/solver/Room.java
@@ -24,16 +24,17 @@
  */
 package net.runelite.client.plugins.raids.solver;
 
+import com.google.common.annotations.VisibleForTesting;
 import lombok.Getter;
 import lombok.Setter;
 
 public class Room
 {
 	@Getter
-	private final int position;
+	private int position;
 
 	@Getter
-	private final char symbol;
+	private char symbol;
 
 	@Getter
 	@Setter
@@ -43,7 +44,8 @@ public class Room
 	@Setter
 	private Room previous;
 
-	Room(int position, char symbol)
+	@VisibleForTesting
+	public Room(int position, char symbol)
 	{
 		this.position = position;
 		this.symbol = symbol;

--- a/runelite-client/src/test/java/net/runelite/client/plugins/raids/RaidsPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/raids/RaidsPluginTest.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright (c) 2019, Alexsuperfly <github.com/Alexsuperfly>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.raids;
+
+import com.google.inject.Guice;
+import com.google.inject.Inject;
+import com.google.inject.testing.fieldbinder.Bind;
+import com.google.inject.testing.fieldbinder.BoundFieldModule;
+import net.runelite.api.Client;
+import net.runelite.client.config.ChatColorConfig;
+import net.runelite.client.config.RuneLiteConfig;
+import net.runelite.client.plugins.raids.solver.Layout;
+import net.runelite.client.plugins.raids.solver.Room;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import java.util.concurrent.ScheduledExecutorService;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RaidsPluginTest
+{
+	@Mock
+	@Bind
+	private Client client;
+
+	@Mock
+	@Bind
+	ScheduledExecutorService executor;
+
+	@Mock
+	@Bind
+	ChatColorConfig chatColorConfig;
+
+	@Mock
+	@Bind
+	RuneLiteConfig runeliteConfig;
+
+	@Mock
+	@Bind
+	RaidsConfig raidsConfig;
+
+	@Inject
+	RaidsPlugin raidsPlugin;
+
+	@Before
+	public void before()
+	{
+		Guice.createInjector(BoundFieldModule.of(this)).injectMembers(this);
+		when(raidsConfig.whitelistedRooms()).thenReturn("");
+		when(raidsConfig.blacklistedRooms()).thenReturn("");
+		when(raidsConfig.whitelistedRotations()).thenReturn("");
+		when(raidsConfig.whitelistedLayouts()).thenReturn("");
+	}
+
+	@Test
+	public void testRotationWhitelistSpaces()
+	{
+		when(raidsConfig.whitelistedRotations()).thenReturn("[Muttadiles, Tekton, Mystics]");
+		raidsPlugin.updateLists();
+		final RaidRoom[] raidRooms = new RaidRoom[]{RaidRoom.MUTTADILES, RaidRoom.TEKTON, RaidRoom.MYSTICS};
+		Layout raidLayout = new Layout();
+		raidLayout.add(new Room(0, 'c'));
+		raidLayout.add(new Room(1, 'c'));
+		raidLayout.add(new Room(2, 'c'));
+		raidsPlugin.setRaid(new Raid());
+		raidsPlugin.getRaid().setRooms(raidRooms);
+		raidsPlugin.getRaid().setLayout(raidLayout);
+
+		assertTrue(raidsPlugin.getRotationMatches());
+	}
+
+	@Test
+	public void testRotationWhitelistQuotes()
+	{
+		when(raidsConfig.whitelistedRotations()).thenReturn("[\"Muttadiles\",\"Tekton\",\"Mystics\"]");
+		raidsPlugin.updateLists();
+		final RaidRoom[] raidRooms = new RaidRoom[]{RaidRoom.MUTTADILES, RaidRoom.TEKTON, RaidRoom.MYSTICS};
+		Layout raidLayout = new Layout();
+		raidLayout.add(new Room(0, 'c'));
+		raidLayout.add(new Room(1, 'c'));
+		raidLayout.add(new Room(2, 'c'));
+		raidsPlugin.setRaid(new Raid());
+		raidsPlugin.getRaid().setRooms(raidRooms);
+		raidsPlugin.getRaid().setLayout(raidLayout);
+
+		assertTrue(raidsPlugin.getRotationMatches());
+	}
+
+	@Test
+	public void testRotationWhitelistSpacesAndQuotes()
+	{
+		when(raidsConfig.whitelistedRotations()).thenReturn("[\"Muttadiles\", \"Tekton\", \"Mystics\"]");
+		raidsPlugin.updateLists();
+		final RaidRoom[] raidRooms = new RaidRoom[]{RaidRoom.MUTTADILES, RaidRoom.TEKTON, RaidRoom.MYSTICS};
+		Layout raidLayout = new Layout();
+		raidLayout.add(new Room(0, 'c'));
+		raidLayout.add(new Room(1, 'c'));
+		raidLayout.add(new Room(2, 'c'));
+		raidsPlugin.setRaid(new Raid());
+		raidsPlugin.getRaid().setRooms(raidRooms);
+		raidsPlugin.getRaid().setLayout(raidLayout);
+
+		assertTrue(raidsPlugin.getRotationMatches());
+	}
+
+	@Test
+	public void testRotationWhitelistGarbled()
+	{
+		when(raidsConfig.whitelistedRotations()).thenReturn("  [\"Mu   tta    di    les\"   ,    \"   Te   kt   on\"  ,  \"Mysti   cs\"   ]   ");
+		raidsPlugin.updateLists();
+		final RaidRoom[] raidRooms = new RaidRoom[]{RaidRoom.MUTTADILES, RaidRoom.TEKTON, RaidRoom.MYSTICS};
+		Layout raidLayout = new Layout();
+		raidLayout.add(new Room(0, 'c'));
+		raidLayout.add(new Room(1, 'c'));
+		raidLayout.add(new Room(2, 'c'));
+		raidsPlugin.setRaid(new Raid());
+		raidsPlugin.getRaid().setRooms(raidRooms);
+		raidsPlugin.getRaid().setLayout(raidLayout);
+
+		assertTrue(raidsPlugin.getRotationMatches());
+	}
+
+	@Test
+	public void testLargeRotationWhitelist()
+	{
+		when(raidsConfig.whitelistedRotations()).thenReturn("[\"Muttadiles\",\"Tekton\",\"Mystics\"], " +
+				"[\"Vespula\", \"guardians\", \"muttadiles\", \"tekton\"], " +
+				"[\"muttadiles\",\"guardians\", \"vespula\"], " +
+				"[vanguards,mystics,tekton,muttadiles]," +
+				"[vasa, vanguards, mystics, tekton]," +
+				"[guardians ,mystics,  SHAMANS,  muttadiles]," +
+				"[shamans, mystics, guardians, vasa]," +
+				"[vasa,guardians,mystics,shamans]," +
+				"[shamans,muttadiles,vanguards,vespula]," +
+				"[mystics,tekton,muttadiles,guardians]");
+		raidsPlugin.updateLists();
+
+		final RaidRoom[] raidRooms1 = new RaidRoom[]{RaidRoom.MUTTADILES, RaidRoom.TEKTON, RaidRoom.MYSTICS};
+		Layout raidLayout1 = new Layout();
+		raidLayout1.add(new Room(0, 'c'));
+		raidLayout1.add(new Room(1, 'c'));
+		raidLayout1.add(new Room(2, 'c'));
+		raidsPlugin.setRaid(new Raid());
+		raidsPlugin.getRaid().setRooms(raidRooms1);
+		raidsPlugin.getRaid().setLayout(raidLayout1);
+		assertTrue(raidsPlugin.getRotationMatches());
+
+		final RaidRoom[] raidRooms2 = new RaidRoom[]{RaidRoom.VASA, RaidRoom.VANGUARDS, RaidRoom.MYSTICS, RaidRoom.TEKTON};
+		Layout raidLayout2 = new Layout();
+		raidLayout2.add(new Room(0, 'c'));
+		raidLayout2.add(new Room(1, 'c'));
+		raidLayout2.add(new Room(2, 'c'));
+		raidLayout2.add(new Room(3, 'c'));
+		raidsPlugin.setRaid(new Raid());
+		raidsPlugin.getRaid().setRooms(raidRooms2);
+		raidsPlugin.getRaid().setLayout(raidLayout2);
+		assertTrue(raidsPlugin.getRotationMatches());
+
+		final RaidRoom[] raidRooms3 = new RaidRoom[]{RaidRoom.SHAMANS, RaidRoom.MUTTADILES, RaidRoom.VANGUARDS, RaidRoom.VESPULA};
+		Layout raidLayout3 = new Layout();
+		raidLayout3.add(new Room(0, 'c'));
+		raidLayout3.add(new Room(1, 'c'));
+		raidLayout3.add(new Room(2, 'c'));
+		raidLayout3.add(new Room(3, 'c'));
+		raidsPlugin.setRaid(new Raid());
+		raidsPlugin.getRaid().setRooms(raidRooms3);
+		raidsPlugin.getRaid().setLayout(raidLayout3);
+		assertTrue(raidsPlugin.getRotationMatches());
+
+		final RaidRoom[] raidRooms4 = new RaidRoom[]{RaidRoom.MUTTADILES, RaidRoom.GUARDIANS, RaidRoom.VESPULA};
+		Layout raidLayout4 = new Layout();
+		raidLayout4.add(new Room(0, 'c'));
+		raidLayout4.add(new Room(1, 'c'));
+		raidLayout4.add(new Room(2, 'c'));
+		raidsPlugin.setRaid(new Raid());
+		raidsPlugin.getRaid().setRooms(raidRooms4);
+		raidsPlugin.getRaid().setLayout(raidLayout4);
+		assertTrue(raidsPlugin.getRotationMatches());
+	}
+
+	@Test
+	public void testRotationWhitelistBackwards()
+	{
+		when(raidsConfig.whitelistedRotations()).thenReturn("[muttadiles, tekton, mystics]");
+		raidsPlugin.updateLists();
+		final RaidRoom[] raidRooms = new RaidRoom[]{RaidRoom.MYSTICS, RaidRoom.TEKTON, RaidRoom.MUTTADILES};
+		Layout raidLayout = new Layout();
+		raidLayout.add(new Room(0, 'c'));
+		raidLayout.add(new Room(1, 'c'));
+		raidLayout.add(new Room(2, 'c'));
+		raidsPlugin.setRaid(new Raid());
+		raidsPlugin.getRaid().setRooms(raidRooms);
+		raidsPlugin.getRaid().setLayout(raidLayout);
+
+		assertFalse(raidsPlugin.getRotationMatches());
+	}
+}


### PR DESCRIPTION
fce1b9518d4665e0a24996fc30481730beff63db caused configs with a space between boss names to not evaluate as equal when comparing them to the scouted rotation.

This pr culls that whitespace and any quotation marks, which during testing appeared around the boss names for me after a client restart.

Also comes with some fancy new tests to attempt to not have it break like that again.