### PR TITLE
Add 'top up amount' to existing Kingdom of Miscellania overlay

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/kingdomofmiscellania/KingdomCounter.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/kingdomofmiscellania/KingdomCounter.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018, Infinitay <https://github.com/Infinitay>
+ * Copyright (c) 2019, Sophie Buckley <https://github.com/sophiebuckley>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -31,11 +32,13 @@ import net.runelite.client.util.QuantityFormatter;
 public class KingdomCounter extends Counter
 {
 	private final KingdomPlugin plugin;
+	private final KingdomPluginConfiguration config;
 
-	KingdomCounter(BufferedImage image, KingdomPlugin plugin)
+	KingdomCounter(BufferedImage image, KingdomPlugin plugin, KingdomPluginConfiguration config)
 	{
 		super(image, plugin, plugin.getFavor());
 		this.plugin = plugin;
+		this.config = config;
 	}
 
 	@Override
@@ -47,7 +50,10 @@ public class KingdomCounter extends Counter
 	@Override
 	public String getTooltip()
 	{
+		int topUpAmount = config.maxCofferAmount() - plugin.getCoffer();
+
 		return "Favor: " + plugin.getFavor() + "/127" + "</br>"
-			+ "Coffer: " + QuantityFormatter.quantityToStackSize(plugin.getCoffer());
+			+ "Coffer: " + QuantityFormatter.quantityToStackSize(plugin.getCoffer()) + "</br>"
+			+ "Top up: " + topUpAmount;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/kingdomofmiscellania/KingdomPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/kingdomofmiscellania/KingdomPlugin.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018, Infinitay <https://github.com/Infinitay>
+ * Copyright (c) 2019, Sophie Buckley <https://github.com/sophiebuckley>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -26,6 +27,8 @@ package net.runelite.client.plugins.kingdomofmiscellania;
 
 import com.google.common.collect.ImmutableSet;
 import javax.inject.Inject;
+
+import com.google.inject.Provides;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
@@ -35,6 +38,7 @@ import net.runelite.api.VarPlayer;
 import net.runelite.api.Varbits;
 import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.VarbitChanged;
+import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.plugins.Plugin;
@@ -60,6 +64,15 @@ public class KingdomPlugin extends Plugin
 
 	@Inject
 	private ItemManager itemManager;
+
+	@Inject
+	private KingdomPluginConfiguration config;
+
+	@Provides
+	KingdomPluginConfiguration getConfig(ConfigManager configManager)
+	{
+		return configManager.getConfig(KingdomPluginConfiguration.class);
+	}
 
 	@Getter
 	private int favor = 0, coffer = 0;
@@ -106,7 +119,7 @@ public class KingdomPlugin extends Plugin
 	{
 		if (counter == null)
 		{
-			counter = new KingdomCounter(itemManager.getImage(TEAK_CHEST), this);
+			counter = new KingdomCounter(itemManager.getImage(TEAK_CHEST), this, config);
 			infoBoxManager.addInfoBox(counter);
 			log.debug("Added Kingdom Infobox");
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/kingdomofmiscellania/KingdomPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/kingdomofmiscellania/KingdomPlugin.java
@@ -27,7 +27,6 @@ package net.runelite.client.plugins.kingdomofmiscellania;
 
 import com.google.common.collect.ImmutableSet;
 import javax.inject.Inject;
-
 import com.google.inject.Provides;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/kingdomofmiscellania/KingdomPluginConfiguration.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/kingdomofmiscellania/KingdomPluginConfiguration.java
@@ -29,7 +29,7 @@ import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
 
-@ConfigGroup("kingdomtopup")
+@ConfigGroup("kingdomOfMiscellania")
 public interface KingdomPluginConfiguration extends Config
 {
     @ConfigItem
@@ -39,7 +39,8 @@ public interface KingdomPluginConfiguration extends Config
                     description = "Set the max amount of coins that you would like in your coffer",
                     position = 2
             )
-    default int maxCofferAmount() {
+    default int maxCofferAmount()
+    {
         return 750000;
     }
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/kingdomofmiscellania/KingdomPluginConfiguration.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/kingdomofmiscellania/KingdomPluginConfiguration.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2018, Infinitay <https://github.com/Infinitay>
+ * Copyright (c) 2019, Sophie Buckley <https://github.com/sophiebuckley>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.kingdomofmiscellania;
+
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+
+@ConfigGroup("kingdomtopup")
+public interface KingdomPluginConfiguration extends Config
+{
+    @ConfigItem
+            (
+                    keyName = "maxCofferAmount",
+                    name = "Max coffer amount",
+                    description = "Set the max amount of coins that you would like in your coffer",
+                    position = 2
+            )
+    default int maxCofferAmount() {
+        return 750000;
+    }
+}


### PR DESCRIPTION
I often find myself using a calculator to figure out how much to deposit to my coffer on Miscellania, especially if I've not been able to play for a few days. I thought it would be useful to have a top up amount displayed on the existing overlay and have a configurable 'goal' coffer amount.

![Screenshot 2019-11-25 at 14 58 41](https://user-images.githubusercontent.com/6482606/69559901-ba200280-0fa2-11ea-8421-450d49f5512a.png)

The top up amount will change if money is deposited/withdrawn from the coffer and if the user changes the max coffer amount from it's default of 750k.

![Screenshot 2019-11-25 at 14 59 36](https://user-images.githubusercontent.com/6482606/69560049-03705200-0fa3-11ea-91b2-63a273fb0c1d.png)

![Screenshot 2019-11-25 at 14 59 44](https://user-images.githubusercontent.com/6482606/69560058-0703d900-0fa3-11ea-9a04-87728b98e1e5.png)

![Screenshot 2019-11-25 at 15 00 10](https://user-images.githubusercontent.com/6482606/69560065-09663300-0fa3-11ea-8489-de48ecde75ba.png)