### PR TITLE
loottracker plugin: fix typo

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerConfig.java
@@ -82,7 +82,7 @@ public interface LootTrackerConfig extends Config
 	@ConfigItem(
 		keyName = "syncPanel",
 		name = "Synchronize panel contents",
-		description = "Synchronize you local loot tracker with your online (requires being logged in). This means" +
+		description = "Synchronize your local loot tracker with your online (requires being logged in). This means" +
 			" that panel is filled with portion of your remote data on startup and deleting data in panel deletes them" +
 			" also on server."
 	)


### PR DESCRIPTION
Fix typo in the syncPanel ConfigItem of the loottracker plugin.