### PR TITLE
League Chat Icons: Rename plugin

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/leaguechaticons/LeagueChatIconsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/leaguechaticons/LeagueChatIconsPlugin.java
@@ -58,7 +58,7 @@ import net.runelite.http.api.worlds.WorldResult;
 import net.runelite.http.api.worlds.WorldType;
 
 @PluginDescriptor(
-	name = "Chat League Icons",
+	name = "League Chat Icons",
 	description = "Changes the chat icon for players on league worlds",
 	enabledByDefault = false
 )


### PR DESCRIPTION
**Changes:**
- Rename plugin from `Chat League Icons` to `League Chat Icons`