### PR TITLE
Bank: Add config to disable left click search

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/bank/BankConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/bank/BankConfig.java
@@ -99,10 +99,21 @@ public interface BankConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "rightClickSearch",
+		name = "Disable left click search",
+		description = "Configures whether the search button will perform a search on left click",
+		position = 7
+	)
+	default boolean rightClickSearch()
+	{
+		return false;
+	}
+
+	@ConfigItem(
 		keyName = "seedVaultValue",
 		name = "Show seed vault value",
 		description = "Adds the total value of all seeds inside the seed vault to the title",
-		position = 7
+		position = 8
 	)
 	default boolean seedVaultValue()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/bank/BankPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/bank/BankPlugin.java
@@ -86,6 +86,7 @@ public class BankPlugin extends Plugin
 	private static final String DEPOSIT_INVENTORY = "Deposit inventory";
 	private static final String DEPOSIT_LOOT = "Deposit loot";
 	private static final String SEED_VAULT_TITLE = "Seed Vault";
+	private static final String SEARCH = "Search";
 
 	private static final String NUMBER_REGEX = "[0-9]+(\\.[0-9]+)?[kmb]?";
 	private static final Pattern VALUE_SEARCH_PATTERN = Pattern.compile("^(?<mode>ge|ha|alch)?" +
@@ -144,7 +145,8 @@ public class BankPlugin extends Plugin
 		{
 			if ((entry.getOption().equals(DEPOSIT_WORN) && config.rightClickBankEquip())
 				|| (entry.getOption().equals(DEPOSIT_INVENTORY) && config.rightClickBankInventory())
-				|| (entry.getOption().equals(DEPOSIT_LOOT) && config.rightClickBankLoot()))
+				|| (entry.getOption().equals(DEPOSIT_LOOT) && config.rightClickBankLoot())
+				|| (entry.getOption().equals(SEARCH) && config.rightClickSearch()))
 			{
 				event.setForceRightClick(true);
 				return;
@@ -157,7 +159,8 @@ public class BankPlugin extends Plugin
 	{
 		if ((event.getOption().equals(DEPOSIT_WORN) && config.rightClickBankEquip())
 			|| (event.getOption().equals(DEPOSIT_INVENTORY) && config.rightClickBankInventory())
-			|| (event.getOption().equals(DEPOSIT_LOOT) && config.rightClickBankLoot()))
+			|| (event.getOption().equals(DEPOSIT_LOOT) && config.rightClickBankLoot())
+			|| (event.getOption().equals(SEARCH) && config.rightClickSearch()))
 		{
 			forceRightClickFlag = true;
 		}


### PR DESCRIPTION
**Changes:**
- Adds a config to the Bank Plugin to disable left click search

**Problem it solves:**
When banking quickly using 'Deposit Inventory' button it is easy to miss click the 'Search' button. This causes the search interface to open and resets the selected bank tab to default (all). You then have to cancel the search and re-select the tab you were working in to continue banking. 

**Solution:**
Disable left click on search button and force it to be a right click with menu. Implemented similarly to the other 'disable left click' options in the Bank Plugin.

How it looks in-game:
![SS of left click menu](https://i.imgur.com/zQqDvB7.png)

New config item (_highlighted_):
![SS of new config option](https://i.imgur.com/Wiiq1jI.png)


