### PR TITLE
Removes null values from the screenmarkers

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenmarkers/ScreenMarkerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenmarkers/ScreenMarkerPlugin.java
@@ -35,8 +35,8 @@ import java.awt.Rectangle;
 import java.awt.image.BufferedImage;
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.inject.Inject;
@@ -254,11 +254,8 @@ public class ScreenMarkerPlugin extends Plugin
 
 		final List<ScreenMarker> screenMarkerData = gson.fromJson(json, new TypeToken<ArrayList<ScreenMarker>>()
 		{
-			// Intentionally left empty
 		}.getType());
 
-		screenMarkerData.removeAll(Collections.singleton(null));
-
-		return screenMarkerData.stream().map(ScreenMarkerOverlay::new);
+		return screenMarkerData.stream().filter(Objects::nonNull).map(ScreenMarkerOverlay::new);
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenmarkers/ScreenMarkerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenmarkers/ScreenMarkerPlugin.java
@@ -35,6 +35,7 @@ import java.awt.Rectangle;
 import java.awt.image.BufferedImage;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -250,9 +251,13 @@ public class ScreenMarkerPlugin extends Plugin
 		}
 
 		final Gson gson = new Gson();
+
 		final List<ScreenMarker> screenMarkerData = gson.fromJson(json, new TypeToken<ArrayList<ScreenMarker>>()
 		{
+			// Intentionally left empty
 		}.getType());
+
+		screenMarkerData.removeAll(Collections.singleton(null));
 
 		return screenMarkerData.stream().map(ScreenMarkerOverlay::new);
 	}


### PR DESCRIPTION
This should fix part of #10317. I haven't been able to replicate the double calling of `finishCreation`. 