### PR TITLE
twitch: add timestamps to messages

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/twitch/TwitchPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/twitch/TwitchPlugin.java
@@ -170,6 +170,7 @@ public class TwitchPlugin extends Plugin implements TwitchListener, ChatboxInput
 			.sender("Twitch")
 			.name(sender)
 			.runeLiteFormattedMessage(chatMessage)
+			.timestamp((int) (System.currentTimeMillis() / 1000))
 			.build());
 	}
 


### PR DESCRIPTION
Currently, the Twitch plugin doesn't assign timestamps to messages, which looks weird alongside in-game messages