### PR TITLE
npcaggro: remove hint hiding option

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/npcunaggroarea/NpcAggroAreaConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npcunaggroarea/NpcAggroAreaConfig.java
@@ -94,21 +94,10 @@ public interface NpcAggroAreaConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "npcUnaggroShowNotWorkingOverlay",
-		name = "Hide overlay hint",
-		description = "Hide overlay hint if plugin is enabled in unsupported area",
-		position = 6
-	)
-	default boolean hideOverlayHint()
-	{
-		return false;
-	}
-
-	@ConfigItem(
 		keyName = "notifyExpire",
 		name = "Notify Expiration",
 		description = "Send a notifcation when the unaggressive timer expires",
-		position = 7
+		position = 6
 	)
 	default boolean notifyExpire()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/npcunaggroarea/NpcAggroAreaNotWorkingOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npcunaggroarea/NpcAggroAreaNotWorkingOverlay.java
@@ -35,13 +35,11 @@ import net.runelite.client.ui.overlay.components.LineComponent;
 class NpcAggroAreaNotWorkingOverlay extends OverlayPanel
 {
 	private final NpcAggroAreaPlugin plugin;
-	private final NpcAggroAreaConfig config;
 
 	@Inject
-	private NpcAggroAreaNotWorkingOverlay(NpcAggroAreaPlugin plugin, NpcAggroAreaConfig config)
+	private NpcAggroAreaNotWorkingOverlay(NpcAggroAreaPlugin plugin)
 	{
 		this.plugin = plugin;
-		this.config = config;
 
 		panelComponent.getChildren().add(LineComponent.builder()
 			.left("Unaggressive NPC timers will start working when you teleport far away or enter a dungeon.")
@@ -55,7 +53,7 @@ class NpcAggroAreaNotWorkingOverlay extends OverlayPanel
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
-		if (!plugin.isActive() || plugin.getSafeCenters()[1] != null || config.hideOverlayHint())
+		if (!plugin.isActive() || plugin.getSafeCenters()[1] != null)
 		{
 			return null;
 		}


### PR DESCRIPTION
Ever since this "feature" was merged, users have been getting confused when the plugin magically doesn't work. The hint isn't a tutorial overlay, it's an integral part of user feedback. Hiding it permanently should never have been merged in the first place; a user should either get the plugin to work by following the instructions, or turn the plugin off.