### PR TITLE
added removeGameTimer before creating a new one for sire stun and added

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersPlugin.java
@@ -726,12 +726,15 @@ public class TimersPlugin extends Plugin
 				// Show the countdown when the Sire enters the stunned state.
 				case NpcID.ABYSSAL_SIRE_5887:
 					// not stunned
-					if(stun_flag == 0) {
+					if(stun_flag == 0)
+					{
 						createGameTimer(ABYSSAL_SIRE_STUN);
 						// set flag to stunned
 						stun_flag = 1;
 						break;
-					} else {
+					}
+					else
+					{
 						// remove existing game timer and create a new one
 						removeGameTimer(ABYSSAL_SIRE_STUN);
 						createGameTimer(ABYSSAL_SIRE_STUN);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersPlugin.java
@@ -718,13 +718,27 @@ public class TimersPlugin extends Plugin
 			&& actor instanceof NPC)
 		{
 			int npcId = ((NPC)actor).getId();
+			// keep track of if it's stunned already; 0 = not stunned; 1 = stunned;
+			int stun_flag = 0;
 
 			switch (npcId)
 			{
 				// Show the countdown when the Sire enters the stunned state.
 				case NpcID.ABYSSAL_SIRE_5887:
-					createGameTimer(ABYSSAL_SIRE_STUN);
-					break;
+					// not stunned
+					if(stun_flag == 0) {
+						createGameTimer(ABYSSAL_SIRE_STUN);
+						// set flag to stunned
+						stun_flag = 1;
+						break;
+					} else {
+						// remove existing game timer and create a new one
+						removeGameTimer(ABYSSAL_SIRE_STUN);
+						createGameTimer(ABYSSAL_SIRE_STUN);
+						// keep flag to stunned
+						stun_flag = 1;
+						break;
+					}
 
 				// Hide the countdown if the Sire isn't in the stunned state.
 				// This is necessary because the Sire leaves the stunned
@@ -736,6 +750,8 @@ public class TimersPlugin extends Plugin
 				case NpcID.ABYSSAL_SIRE_5891:
 				case NpcID.ABYSSAL_SIRE_5908:
 					removeGameTimer(ABYSSAL_SIRE_STUN);
+					// set flag back to not stunned
+					stun_flag = 0;
 					break;
 			}
 		}


### PR DESCRIPTION
Addresses #10351 

A bug was introduced where the stun timer disappeared with the sire was stunned again while already stunned. The intended functionality was for the timer to refresh instead.

Added `stun_flag` to keep track of whether or not the sire is already stunned or not. If the flag is 0 then the sire isn't stunned, and if the flag is 1 then the sire is. Then checked on stun flag to see whether or not we needed to remove the current timer or not.