### PR TITLE
Add Jewellery Box to Menu Entry Swapper

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -234,7 +234,7 @@ public interface MenuEntrySwapperConfig extends Config
 
 	@ConfigItem(
 		keyName = "swapJewelleryBox",
-		name = "Jewelry Box",
+		name = "Jewellery Box",
 		description = "Swap Teleport Menu with previous destination on Jewellery Box"
 	)
 	default boolean swapJewelleryBox()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -233,9 +233,9 @@ public interface MenuEntrySwapperConfig extends Config
 	}
 
 	@ConfigItem(
-			keyName = "swapJewelleryBox",
-			name = "Jewelry Box",
-			description = "Swap Teleport Menu with previous destination on Jewellery Box"
+		keyName = "swapJewelleryBox",
+		name = "Jewelry Box",
+		description = "Swap Teleport Menu with previous destination on Jewellery Box"
 	)
 	default boolean swapJewelleryBox()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -233,6 +233,16 @@ public interface MenuEntrySwapperConfig extends Config
 	}
 
 	@ConfigItem(
+			keyName = "swapJewelleryBox",
+			name = "Jewelry Box",
+			description = "Swap Teleport Menu with previous destination on Jewellery Box"
+	)
+	default boolean swapJewelleryBox()
+	{
+		return false;
+	}
+
+	@ConfigItem(
 		keyName = "swapPrivate",
 		name = "Private",
 		description = "Swap Shared with Private on the Chambers of Xeric storage units."

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -584,6 +584,35 @@ public class MenuEntrySwapperPlugin extends Plugin
 			swap("spellbook", option, target, index);
 			swap("perks", option, target, index);
 		}
+		else if (config.swapJewelleryBox() && option.equals("teleport menu"))
+		{
+			swap("duel arena", option, target, index);
+			swap("castle wars", option, target, index);
+			swap("clan wars", option, target, index);
+			swap("burthorpe", option, target, index);
+			swap("barbarian outpost", option, target, index);
+			swap("corporeal beast", option, target, index);
+			swap("tears of guthix", option, target, index);
+			swap("wintertodt camp", option, target, index);
+			swap("warriors' guild", option, target, index);
+			swap("champions' guild", option, target, index);
+			swap("monastery", option, target, index);
+			swap("ranging guild", option, target, index);
+			swap("fishing guild", option, target, index);
+			swap("mining guild", option, target, index);
+			swap("crafting guild", option, target, index);
+			swap("cooking guild", option, target, index);
+			swap("woodcutting guild", option, target, index);
+			swap("farming guild", option, target, index);
+			swap("miscellania", option, target, index);
+			swap("grand exchange", option, target, index);
+			swap("falador park", option, target, index);
+			swap("dondakan's rock", option, target, index);
+			swap("edgeville", option, target, index);
+			swap("karamja", option, target, index);
+			swap("draynor village", option, target, index);
+			swap("al kharid", option, target, index);
+		}
 		else if (config.swapPrivate() && option.equals("shared"))
 		{
 			swap("private", option, target, index);


### PR DESCRIPTION
Closes #10393 . Swaps "Teleport Menu" with the most recently traveled destination when hovering over the Jewellery Box in a player owned house.