### PR TITLE
Highlight missing Kourend Library books in side panel

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/kourendlibrary/BookPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/kourendlibrary/BookPanel.java
@@ -75,8 +75,8 @@ class BookPanel extends JPanel
 		this.location.setText(location);
 	}
 
-	void setIsTarget(boolean target)
+	void setBookColor(boolean target, boolean playerContainsBook)
 	{
-		location.setForeground(target ? Color.GREEN : Color.WHITE);
+		location.setForeground(target ? Color.GREEN : (playerContainsBook ? Color.WHITE : Color.RED));
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/kourendlibrary/BookPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/kourendlibrary/BookPanel.java
@@ -77,6 +77,20 @@ class BookPanel extends JPanel
 
 	void setBookColor(boolean target, boolean playerContainsBook)
 	{
-		location.setForeground(target ? Color.GREEN : (playerContainsBook ? Color.WHITE : Color.RED));
+		if (target)
+		{
+			location.setForeground(Color.GREEN);
+		}
+		else
+		{
+			if (playerContainsBook)
+			{
+				location.setForeground(Color.WHITE);
+			}
+			else
+			{
+				location.setForeground(Color.RED);
+			}
+		}
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/kourendlibrary/KourendLibraryPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/kourendlibrary/KourendLibraryPanel.java
@@ -55,6 +55,7 @@ class KourendLibraryPanel extends PluginPanel
 	private static final ImageIcon RESET_CLICK_ICON;
 
 	private final KourendLibraryConfig config;
+	private final KourendLibraryPlugin plugin;
 	private final Library library;
 
 	private final HashMap<Book, BookPanel> bookPanels = new HashMap<>();
@@ -67,11 +68,12 @@ class KourendLibraryPanel extends PluginPanel
 	}
 
 	@Inject
-	KourendLibraryPanel(KourendLibraryConfig config, Library library)
+	KourendLibraryPanel(KourendLibraryConfig config, Library library, KourendLibraryPlugin plugin)
 	{
 		super();
 
 		this.config = config;
+		this.plugin = plugin;
 		this.library = library;
 	}
 
@@ -129,7 +131,7 @@ class KourendLibraryPanel extends PluginPanel
 			Book customerBook = library.getCustomerBook();
 			for (Map.Entry<Book, BookPanel> b : bookPanels.entrySet())
 			{
-				b.getValue().setIsTarget(customerBook == b.getKey());
+				b.getValue().setBookColor(customerBook == b.getKey(), plugin.doesPlayerContainBook(b.getKey()));
 			}
 
 			HashMap<Book, HashSet<String>> bookLocations = new HashMap<>();

--- a/runelite-client/src/main/java/net/runelite/client/plugins/kourendlibrary/KourendLibraryPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/kourendlibrary/KourendLibraryPlugin.java
@@ -302,6 +302,7 @@ public class KourendLibraryPlugin extends Plugin
 	public void onItemContainerChanged(ItemContainerChanged itemContainerChangedEvent)
 	{
 		updatePlayerBooks();
+		panel.update();
 	}
 
 	@Subscribe

--- a/runelite-client/src/main/java/net/runelite/client/plugins/kourendlibrary/KourendLibraryPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/kourendlibrary/KourendLibraryPlugin.java
@@ -321,6 +321,11 @@ public class KourendLibraryPlugin extends Plugin
 
 	boolean doesPlayerContainBook(Book book)
 	{
+		if (playerBooks == null)
+		{
+			return false;
+		}
+
 		return playerBooks.contains(book);
 	}
 


### PR DESCRIPTION
Adds feature request #10418.

Here is a screenshot of this code in action:
![Screenshot_1](https://user-images.githubusercontent.com/1471542/70585996-f30bca00-1b93-11ea-9600-3a6fb51edeb8.png)

It highlights the requested book green, books in your inventory white, and books not in your inventory red.

I could easily add a togglable config setting for whether to enable the coloring or not, but I'm not sure if that's necessary. The coloring does make the panel look a little busier but it's not that bad IMO.