### PR TITLE
add menu swap support for grand exchange offer withdraw

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/GEItemCollectMode.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/GEItemCollectMode.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2019, Rami <https://github.com/Rami-J>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.menuentryswapper;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum GEItemCollectMode
+{
+	DEFAULT("Default"),
+	ITEMS("Collect-items"),
+	NOTES("Collect-notes"),
+	BANK("Bank");
+
+	private final String name;
+
+	@Override
+	public String toString()
+	{
+		return name;
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -361,4 +361,14 @@ public interface MenuEntrySwapperConfig extends Config
 	{
 		return false;
 	}
+
+	@ConfigItem(
+		keyName = "swapGEItemCollect",
+		name = "GE Item Collect",
+		description = "Swap Collect-notes, Collect-items, or Bank options from GE offer"
+	)
+	default GEItemCollectMode swapGEItemCollect()
+	{
+		return GEItemCollectMode.DEFAULT;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2018, Adam <Adam@sigterm.info>
  * Copyright (c) 2018, Kamiel
+ * Copyright (c) 2019, Rami <https://github.com/Rami-J>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -40,7 +41,6 @@ import net.runelite.api.MenuAction;
 import net.runelite.api.MenuEntry;
 import net.runelite.api.NPC;
 import net.runelite.api.events.ClientTick;
-import net.runelite.client.events.ConfigChanged;
 import net.runelite.api.events.FocusChanged;
 import net.runelite.api.events.MenuOpened;
 import net.runelite.api.events.MenuOptionClicked;
@@ -50,6 +50,7 @@ import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.callback.ClientThread;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
+import net.runelite.client.events.ConfigChanged;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.game.ItemVariationMapping;
 import net.runelite.client.input.KeyManager;
@@ -646,6 +647,24 @@ public class MenuEntrySwapperPlugin extends Plugin
 		else if (config.swapBones() && option.equals("bury"))
 		{
 			swap("use", option, target, index);
+		}
+		else if (option.equals("collect to inventory") || option.startsWith("collect-note") || option.startsWith("collect-item"))
+		{
+			switch (config.swapGEItemCollect())
+			{
+				case ITEMS:
+					swap("collect-items", option, target, index);
+					swap("collect-item", option, target, index);
+					break;
+				case NOTES:
+					swap("collect-notes", option, target, index);
+					swap("collect-note", option, target, index);
+					break;
+				case BANK:
+					swap("collect to bank", option, target, index);
+					swap("bank", option, target, index);
+					break;
+			}
 		}
 
 		if (shiftModifier && config.swapTeleportSpell())


### PR DESCRIPTION
closes #10434 

Adds an additional feature to the Menu Entry Swapper plugin allowing the user to choose the default item withdrawal from a GE offer (Notes, items, or bank).

![1](https://user-images.githubusercontent.com/44623786/70873382-92a5cf80-1f7b-11ea-8c5e-6f8d24fa7244.png)
![2](https://user-images.githubusercontent.com/44623786/70873383-933e6600-1f7b-11ea-935c-ce64d053e2c9.png)
![3](https://user-images.githubusercontent.com/44623786/70873385-933e6600-1f7b-11ea-9275-0b7bdc985a1a.png)
