### PR TITLE
woodcutting: fix inaccurate despawn events

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingPlugin.java
@@ -103,6 +103,7 @@ public class WoodcuttingPlugin extends Plugin
 	@Getter(AccessLevel.PACKAGE)
 	private final List<TreeRespawn> respawns = new ArrayList<>();
 	private boolean recentlyLoggedIn;
+	private int currentPlane;
 
 	@Provides
 	WoodcuttingConfig getConfig(ConfigManager configManager)
@@ -144,6 +145,7 @@ public class WoodcuttingPlugin extends Plugin
 	public void onGameTick(GameTick gameTick)
 	{
 		recentlyLoggedIn = false;
+		currentPlane = client.getPlane();
 
 		respawns.removeIf(TreeRespawn::isExpired);
 
@@ -204,7 +206,7 @@ public class WoodcuttingPlugin extends Plugin
 		Tree tree = Tree.findTree(object.getId());
 		if (tree != null)
 		{
-			if (tree.getRespawnTime() != null && !recentlyLoggedIn)
+			if (tree.getRespawnTime() != null && !recentlyLoggedIn && currentPlane == object.getPlane())
 			{
 				Point max = object.getSceneMaxLocation();
 				Point min = object.getSceneMinLocation();


### PR DESCRIPTION
game objects only update when the player can see them on their current plane
track the previous onGameTick player plane to ignore any despawn event that does not occur on that same plane

the server only spawns and despawns objects on your current plane
so when you go down stairs you get hit with all the changes that happened while you were gone, this means any tree that has been chopped while you were upstairs gets a fresh new despawn event.  
this pr accounts for that by only allowing the plugin to act on those events if you have been on that plane for a tick already

fixes #10449 