### PR TITLE
objectindicators: Correctly match template plane

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/objectindicators/ObjectIndicatorsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/objectindicators/ObjectIndicatorsPlugin.java
@@ -326,7 +326,7 @@ public class ObjectIndicatorsPlugin extends Plugin implements KeyListener
 		{
 			if (worldPoint.getRegionX() == objectPoint.getRegionX()
 					&& worldPoint.getRegionY() == objectPoint.getRegionY()
-					&& object.getPlane() == objectPoint.getZ())
+					&& worldPoint.getPlane() == objectPoint.getZ())
 			{
 				// Transform object to get the name which matches against what we've stored
 				if (objectPoint.getName().equals(getObjectComposition(object.getId()).getName()))
@@ -423,7 +423,7 @@ public class ObjectIndicatorsPlugin extends Plugin implements KeyListener
 			regionId,
 			worldPoint.getRegionX(),
 			worldPoint.getRegionY(),
-			client.getPlane());
+			worldPoint.getPlane());
 
 		Set<ObjectPoint> objectPoints = points.computeIfAbsent(regionId, k -> new HashSet<>());
 


### PR DESCRIPTION
poh and cox instances use a different plane in their source chunks than
the destination chunks, which made this unable to remove the objectPoint
in most poh wallkits. This also makes it so if you add a dungeon to your
poh it won't destroy your markers

Fixes #10371