### PR TITLE
Fix integer overflow on Examine plugin price text

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/examine/ExaminePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/examine/ExaminePlugin.java
@@ -328,8 +328,8 @@ public class ExaminePlugin extends Plugin
 		// quantity is at least 1
 		quantity = Math.max(1, quantity);
 		int itemCompositionPrice = itemComposition.getPrice();
-		final int gePrice = itemManager.getItemPrice(id);
-		final int alchPrice = itemCompositionPrice <= 0 ? 0 : Math.round(itemCompositionPrice * Constants.HIGH_ALCHEMY_MULTIPLIER);
+		final long gePrice = itemManager.getItemPrice(id);
+		final long alchPrice = itemCompositionPrice <= 0 ? 0 : Math.round(itemCompositionPrice * Constants.HIGH_ALCHEMY_MULTIPLIER);
 
 		if (gePrice > 0 || alchPrice > 0)
 		{


### PR DESCRIPTION
Stack prices for the Examine plugin are calculated with 32-bit integers. If the stack price was over 2.147 bil (such as if you had multiple tbows or something) it would overflow and display a negative number. This fixes that by just casting the item price to a long int before calculating the stack price.

This issue is also present in the ItemPrices plugin, which I've created another pull request for.

This Fixes: #10443