### PR TITLE
Fix integer overflow on ItemPrices price text

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemprices/ItemPricesOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemprices/ItemPricesOverlay.java
@@ -229,12 +229,12 @@ class ItemPricesOverlay extends Overlay
 		return null;
 	}
 
-	private String stackValueText(long qty, long gePrice, long haValue, long haProfit)
+	private String stackValueText(int qty, int gePrice, int haValue, int haProfit)
 	{
 		if (gePrice > 0)
 		{
 			itemStringBuilder.append("EX: ")
-				.append(QuantityFormatter.quantityToStackSize(gePrice * qty))
+				.append(QuantityFormatter.quantityToStackSize((long) gePrice * qty))
 				.append(" gp");
 			if (config.showEA() && qty > 1)
 			{
@@ -251,7 +251,7 @@ class ItemPricesOverlay extends Overlay
 			}
 
 			itemStringBuilder.append("HA: ")
-				.append(QuantityFormatter.quantityToStackSize(haValue * qty))
+				.append(QuantityFormatter.quantityToStackSize((long) haValue * qty))
 				.append(" gp");
 			if (config.showEA() && qty > 1)
 			{
@@ -267,7 +267,7 @@ class ItemPricesOverlay extends Overlay
 
 			itemStringBuilder.append("</br>");
 			itemStringBuilder.append("HA Profit: ")
-				.append(ColorUtil.wrapWithColorTag(String.valueOf(haProfit * qty), haColor))
+				.append(ColorUtil.wrapWithColorTag(String.valueOf((long) haProfit * qty), haColor))
 				.append(" gp");
 			if (config.showEA() && qty > 1)
 			{
@@ -289,7 +289,7 @@ class ItemPricesOverlay extends Overlay
 		return haPrice - gePrice - natureRunePrice;
 	}
 
-	private static Color haProfitColor(long haProfit)
+	private static Color haProfitColor(int haProfit)
 	{
 		return haProfit >= 0 ? Color.GREEN : Color.RED;
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemprices/ItemPricesOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemprices/ItemPricesOverlay.java
@@ -231,10 +231,13 @@ class ItemPricesOverlay extends Overlay
 
 	private String stackValueText(int qty, int gePrice, int haValue, int haProfit)
 	{
+		final long geStackPrice = ((long) gePrice) * qty;
+		final long haStackPrice = ((long) haValue) * qty;
+
 		if (gePrice > 0)
 		{
 			itemStringBuilder.append("EX: ")
-				.append(QuantityFormatter.quantityToStackSize(gePrice * qty))
+				.append(QuantityFormatter.quantityToStackSize(geStackPrice))
 				.append(" gp");
 			if (config.showEA() && qty > 1)
 			{
@@ -250,8 +253,9 @@ class ItemPricesOverlay extends Overlay
 				itemStringBuilder.append("</br>");
 			}
 
+
 			itemStringBuilder.append("HA: ")
-				.append(QuantityFormatter.quantityToStackSize(haValue * qty))
+				.append(QuantityFormatter.quantityToStackSize(haStackPrice))
 				.append(" gp");
 			if (config.showEA() && qty > 1)
 			{
@@ -267,7 +271,7 @@ class ItemPricesOverlay extends Overlay
 
 			itemStringBuilder.append("</br>");
 			itemStringBuilder.append("HA Profit: ")
-				.append(ColorUtil.wrapWithColorTag(String.valueOf(haProfit * qty), haColor))
+				.append(ColorUtil.wrapWithColorTag(String.valueOf(haStackPrice), haColor))
 				.append(" gp");
 			if (config.showEA() && qty > 1)
 			{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemprices/ItemPricesOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemprices/ItemPricesOverlay.java
@@ -229,15 +229,12 @@ class ItemPricesOverlay extends Overlay
 		return null;
 	}
 
-	private String stackValueText(int qty, int gePrice, int haValue, int haProfit)
+	private String stackValueText(long qty, long gePrice, long haValue, long haProfit)
 	{
-		final long geStackPrice = ((long) gePrice) * qty;
-		final long haStackPrice = ((long) haValue) * qty;
-
 		if (gePrice > 0)
 		{
 			itemStringBuilder.append("EX: ")
-				.append(QuantityFormatter.quantityToStackSize(geStackPrice))
+				.append(QuantityFormatter.quantityToStackSize(gePrice * qty))
 				.append(" gp");
 			if (config.showEA() && qty > 1)
 			{
@@ -255,7 +252,7 @@ class ItemPricesOverlay extends Overlay
 
 
 			itemStringBuilder.append("HA: ")
-				.append(QuantityFormatter.quantityToStackSize(haStackPrice))
+				.append(QuantityFormatter.quantityToStackSize(haValue * qty))
 				.append(" gp");
 			if (config.showEA() && qty > 1)
 			{
@@ -271,7 +268,7 @@ class ItemPricesOverlay extends Overlay
 
 			itemStringBuilder.append("</br>");
 			itemStringBuilder.append("HA Profit: ")
-				.append(ColorUtil.wrapWithColorTag(String.valueOf(haStackPrice), haColor))
+				.append(ColorUtil.wrapWithColorTag(String.valueOf(haProfit * qty), haColor))
 				.append(" gp");
 			if (config.showEA() && qty > 1)
 			{
@@ -293,7 +290,7 @@ class ItemPricesOverlay extends Overlay
 		return haPrice - gePrice - natureRunePrice;
 	}
 
-	private static Color haProfitColor(int haProfit)
+	private static Color haProfitColor(long haProfit)
 	{
 		return haProfit >= 0 ? Color.GREEN : Color.RED;
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemprices/ItemPricesOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemprices/ItemPricesOverlay.java
@@ -250,7 +250,6 @@ class ItemPricesOverlay extends Overlay
 				itemStringBuilder.append("</br>");
 			}
 
-
 			itemStringBuilder.append("HA: ")
 				.append(QuantityFormatter.quantityToStackSize(haValue * qty))
 				.append(" gp");


### PR DESCRIPTION
Stack prices for the ItemPrices plugin are calculated with 32-bit integers. If the stack price was over 2.147 bil (such as if you had multiple tbows or something) it would overflow and display a negative number. This fixes that by just casting the item price to a long int before calculating the stack price.

This issue is also present in the Examine plugin, which I've created another pull request for.

This fixes a related issue pointed out in: #10443