### PR TITLE
raids:  allow "unknown" to evaluate to both unknown room types

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsPlugin.java
@@ -421,7 +421,18 @@ public class RaidsPlugin extends Plugin
 	private void updateList(Collection<String> list, String input)
 	{
 		list.clear();
-		list.addAll(Text.fromCSV(input.toLowerCase()));
+		for (String s : Text.fromCSV(input.toLowerCase()))
+		{
+			if (s.equals("unknown"))
+			{
+				list.add("unknown (combat)");
+				list.add("unknown (puzzle)");
+			}
+			else
+			{
+				list.add(s);
+			}
+		}
 	}
 
 	boolean getRotationMatches()


### PR DESCRIPTION
match the white/blacklisted room against a lax contains check on the room name itself which allows the old way of specifying a unknown room to still function for people as expected when highlighting it on the overlay