### PR TITLE
Add toggle to hide consumable stat boosts if they wouldn't result in a change

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatConfig.java
@@ -43,6 +43,16 @@ public interface ItemStatConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "hideNoConsumableChanges",
+		name = "Hide tooltips for no changes",
+		description = "Hides tooltips if the consumable would result in no changes"
+	)
+	default boolean hideNoConsumableChange()
+	{
+		return false;
+	}
+
+	@ConfigItem(
 		keyName = "equipmentStats",
 		name = "Enable equipment stats",
 		description = "Enables tooltips for equipment items (combat bonuses, weight, prayer bonuses)"
@@ -135,6 +145,7 @@ public interface ItemStatConfig extends Config
 	{
 		return new Color(0xEEEE33);
 	}
+
 	@ConfigItem(
 		keyName = "colorNoChange",
 		name = "No change",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatOverlay.java
@@ -125,6 +125,10 @@ public class ItemStatOverlay extends Overlay
 
 				for (final StatChange c : statsChanges.getStatChanges())
 				{
+					if (config.hideNoConsumableChange() && c.getPositivity() == Positivity.NO_CHANGE)
+					{
+						continue;
+					}
 					b.append(buildStatChangeString(c));
 				}
 


### PR DESCRIPTION
Issue #10309