### PR TITLE
chat message manager: make sender recoloring use messageNode

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/chat/ChatMessageManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/chat/ChatMessageManager.java
@@ -150,7 +150,7 @@ public class ChatMessageManager
 			messageNode.setName(ColorUtil.wrapWithColorTag(messageNode.getName(), usernameColor));
 		}
 
-		String sender = chatMessage.getSender();
+		String sender = messageNode.getSender();
 		if (senderColor != null && !Strings.isNullOrEmpty(sender))
 		{
 			messageNode.setSender(ColorUtil.wrapWithColorTag(sender, senderColor));


### PR DESCRIPTION
This fixes the recent issue of clan chat rank icons not showing if the channel name was recoloured. What happened was the Chat Message Manager was using the event's field for the channel name, which isn't updated with changes from the Clan Chat Plugin, and was therefore overwriting the icon that was added.