### PR TITLE
gpu: Allow plugin subclass for external plugins

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/PluginDescriptor.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/PluginDescriptor.java
@@ -26,7 +26,6 @@ package net.runelite.client.plugins;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
-import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -34,7 +33,6 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 @Documented
-@Inherited
 public @interface PluginDescriptor
 {
 	String name();

--- a/runelite-client/src/main/java/net/runelite/client/plugins/PluginDescriptor.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/PluginDescriptor.java
@@ -26,6 +26,7 @@ package net.runelite.client.plugins;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -33,6 +34,7 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 @Documented
+@Inherited
 public @interface PluginDescriptor
 {
 	String name();

--- a/runelite-client/src/main/java/net/runelite/client/plugins/PluginManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/PluginManager.java
@@ -254,7 +254,7 @@ public class PluginManager
 				continue;
 			}
 
-			if (clazz.getSuperclass() != Plugin.class)
+			if (!Plugin.class.isAssignableFrom(clazz))
 			{
 				log.warn("Class {} has plugin descriptor, but is not a plugin", clazz);
 				continue;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/PluginManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/PluginManager.java
@@ -247,7 +247,7 @@ public class PluginManager
 
 			if (pluginDescriptor == null)
 			{
-				if (clazz.getSuperclass() == Plugin.class)
+				if (Plugin.class.isAssignableFrom(clazz))
 				{
 					log.warn("Class {} is a plugin, but has no plugin descriptor", clazz);
 				}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuPlugin.java
@@ -1108,7 +1108,10 @@ public class GpuPlugin extends Plugin implements DrawCallbacks
 		drawManager.processDrawComplete(this::screenshot);
 	}
 
-	protected void setUniforms() {}
+	protected void setUniforms()
+	{
+		
+	}
 
 	private void drawUi(final int canvasHeight, final int canvasWidth)
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuPlugin.java
@@ -130,11 +130,11 @@ public class GpuPlugin extends Plugin implements DrawCallbacks
 
 	private Canvas canvas;
 	private JAWTWindow jawtWindow;
-	private GL4 gl;
+	protected GL4 gl;
 	private GLContext glContext;
 	private GLDrawable glDrawable;
 
-	private int glProgram;
+	protected int glProgram;
 	private int glVertexShader;
 	private int glGeomShader;
 	private int glFragmentShader;
@@ -490,7 +490,7 @@ public class GpuPlugin extends Plugin implements DrawCallbacks
 		initUniforms();
 	}
 
-	private void initUniforms()
+	protected void initUniforms()
 	{
 		uniProjectionMatrix = gl.glGetUniformLocation(glProgram, "projectionMatrix");
 		uniBrightness = gl.glGetUniformLocation(glProgram, "brightness");
@@ -1021,6 +1021,8 @@ public class GpuPlugin extends Plugin implements DrawCallbacks
 			gl.glUniform1f(uniBrightness, (float) textureProvider.getBrightness());
 			gl.glUniform1f(uniSmoothBanding, config.smoothBanding() ? 0f : 1f);
 
+			setUniforms();
+
 			for (int id = 0; id < textures.length; ++id)
 			{
 				Texture texture = textures[id];
@@ -1105,6 +1107,8 @@ public class GpuPlugin extends Plugin implements DrawCallbacks
 
 		drawManager.processDrawComplete(this::screenshot);
 	}
+
+	protected void setUniforms() {}
 
 	private void drawUi(final int canvasHeight, final int canvasWidth)
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuPlugin.java
@@ -483,9 +483,9 @@ public class GpuPlugin extends Plugin implements DrawCallbacks
 		glUiVertexShader = gl.glCreateShader(gl.GL_VERTEX_SHADER);
 		glUiFragmentShader = gl.glCreateShader(gl.GL_FRAGMENT_SHADER);
 		GLUtil.loadShaders(gl, glUiProgram, glUiVertexShader, -1, glUiFragmentShader,
-			inputStreamToString(getClass().getResourceAsStream("vertui.glsl")),
+			inputStreamToString(GpuPlugin.class.getResourceAsStream("vertui.glsl")),
 			null,
-			inputStreamToString(getClass().getResourceAsStream("fragui.glsl")));
+			inputStreamToString(GpuPlugin.class.getResourceAsStream("fragui.glsl")));
 
 		initUniforms();
 	}


### PR DESCRIPTION
Change in the plugin manager to allow plugin subclasses
Modify the gpu plugin to accommodate subclasses
This allows external plugins to use custom shaders