### PR TITLE
Remove duplicate Item Count in GroundItem notifs

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
@@ -663,9 +663,6 @@ public class GroundItemsPlugin extends Plugin
 
 		if (item.getQuantity() > 1)
 		{
-			notificationStringBuilder.append(" x ").append(item.getQuantity());
-
-
 			if (item.getQuantity() > (int) Character.MAX_VALUE)
 			{
 				notificationStringBuilder.append(" (Lots!)");
@@ -677,8 +674,7 @@ public class GroundItemsPlugin extends Plugin
 					.append(")");
 			}
 		}
-
-		notificationStringBuilder.append("!");
+		
 		notifier.notify(notificationStringBuilder.toString());
 	}
 


### PR DESCRIPTION
Prevent duplicate quantities in Ground Item Notifications

This resolves #10319 

- The `" x {quantity}"` part of the string was removed, because the `"({quantity})"` style is what is used for text on items on the ground, so this aligns with that style.
- Closing `!` was also removed, because it looked a little odd in the notification text (Also duplicated in the `Lots!` case) - I'm fine with whatever consensus or general preference is here

## Before Changes
![image](https://user-images.githubusercontent.com/5553582/71627617-7633a500-2bc1-11ea-9283-e2f69f2e8eab.png)


## After Changes
![image](https://user-images.githubusercontent.com/5553582/71627558-26ed7480-2bc1-11ea-9ed1-ff64bb591bbf.png)


