### PR TITLE
add toggle for visibility of agility course clickboxes

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/agility/AgilityConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/agility/AgilityConfig.java
@@ -33,10 +33,10 @@ import net.runelite.client.config.ConfigItem;
 public interface AgilityConfig extends Config
 {
 	@ConfigItem(
-			keyName = "showClickboxes",
-			name = "Show Clickboxes",
-			description = "Enable/Disable the agility course clickboxes.",
-			position = 0
+		keyName = "showClickboxes",
+		name = "Show Clickboxes",
+		description = "Show agility course obstacle clickboxes",
+		position = 0
 	)
 	default boolean showClickboxes()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/agility/AgilityConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/agility/AgilityConfig.java
@@ -163,4 +163,11 @@ public interface AgilityConfig extends Config
 	{
 		return true;
 	}
+	@ConfigItem(
+			keyName="showAgilityClickboxes",
+			name = "Show Agility Clickboxes",
+			description = "Enable/Disable the agility clickboxes.",
+			position = 13
+	)
+	default boolean showAgilityClickboxes() { return true; }
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/agility/AgilityConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/agility/AgilityConfig.java
@@ -163,13 +163,14 @@ public interface AgilityConfig extends Config
 	{
 		return true;
 	}
+
 	@ConfigItem(
-			keyName = "showAgilityClickboxes",
-			name = "Show Agility Clickboxes",
-			description = "Enable/Disable the agility clickboxes.",
+			keyName = "showAgilityCourseClickboxes",
+			name = "Show Agility Course Clickboxes",
+			description = "Enable/Disable the agility course clickboxes.",
 			position = 13
 	)
-	default boolean showAgilityClickboxes()
+	default boolean showAgilityCourseClickboxes()
 	{
 		return true;
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/agility/AgilityConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/agility/AgilityConfig.java
@@ -33,6 +33,17 @@ import net.runelite.client.config.ConfigItem;
 public interface AgilityConfig extends Config
 {
 	@ConfigItem(
+			keyName = "showClickboxes",
+			name = "Show Clickboxes",
+			description = "Enable/Disable the agility course clickboxes.",
+			position = 0
+	)
+	default boolean showClickboxes()
+	{
+		return true;
+	}
+
+	@ConfigItem(
 		keyName = "showLapCount",
 		name = "Show Lap Count",
 		description = "Enable/disable the lap counter",
@@ -160,17 +171,6 @@ public interface AgilityConfig extends Config
 		position = 12
 	)
 	default boolean showAgilityArenaTimer()
-	{
-		return true;
-	}
-
-	@ConfigItem(
-			keyName = "showAgilityCourseClickboxes",
-			name = "Show Agility Course Clickboxes",
-			description = "Enable/Disable the agility course clickboxes.",
-			position = 13
-	)
-	default boolean showAgilityCourseClickboxes()
 	{
 		return true;
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/agility/AgilityConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/agility/AgilityConfig.java
@@ -164,10 +164,13 @@ public interface AgilityConfig extends Config
 		return true;
 	}
 	@ConfigItem(
-			keyName="showAgilityClickboxes",
+			keyName = "showAgilityClickboxes",
 			name = "Show Agility Clickboxes",
 			description = "Enable/Disable the agility clickboxes.",
 			position = 13
 	)
-	default boolean showAgilityClickboxes() { return true; }
+	default boolean showAgilityClickboxes()
+	{
+		return true;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/agility/AgilityOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/agility/AgilityOverlay.java
@@ -72,7 +72,7 @@ class AgilityOverlay extends Overlay
 		{
 			if (Obstacles.SHORTCUT_OBSTACLE_IDS.containsKey(object.getId()) && !config.highlightShortcuts() ||
 					Obstacles.TRAP_OBSTACLE_IDS.contains(object.getId()) && !config.showTrapOverlay() ||
-					Obstacles.COURSE_OBSTACLE_IDS.contains(object.getId()) && !config.showAgilityCourseClickboxes())
+					Obstacles.COURSE_OBSTACLE_IDS.contains(object.getId()) && !config.showClickboxes())
 			{
 				return;
 			}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/agility/AgilityOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/agility/AgilityOverlay.java
@@ -71,7 +71,8 @@ class AgilityOverlay extends Overlay
 		plugin.getObstacles().forEach((object, obstacle) ->
 		{
 			if (Obstacles.SHORTCUT_OBSTACLE_IDS.containsKey(object.getId()) && !config.highlightShortcuts() ||
-					Obstacles.TRAP_OBSTACLE_IDS.contains(object.getId()) && !config.showTrapOverlay())
+					Obstacles.TRAP_OBSTACLE_IDS.contains(object.getId()) && !config.showTrapOverlay() ||
+					Obstacles.COURSE_OBSTACLE_IDS.contains(object.getId()) && !config.showAgilityClickboxes())
 			{
 				return;
 			}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/agility/AgilityOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/agility/AgilityOverlay.java
@@ -72,7 +72,7 @@ class AgilityOverlay extends Overlay
 		{
 			if (Obstacles.SHORTCUT_OBSTACLE_IDS.containsKey(object.getId()) && !config.highlightShortcuts() ||
 					Obstacles.TRAP_OBSTACLE_IDS.contains(object.getId()) && !config.showTrapOverlay() ||
-					Obstacles.COURSE_OBSTACLE_IDS.contains(object.getId()) && !config.showAgilityClickboxes())
+					Obstacles.COURSE_OBSTACLE_IDS.contains(object.getId()) && !config.showAgilityCourseClickboxes())
 			{
 				return;
 			}


### PR DESCRIPTION
Closes #10556

Adds a toggle to the agility plugin to show or hide agility course clickboxes.