### PR TITLE
chatfilter: Add collapse chat message option

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatfilter/ChatFilterConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatfilter/ChatFilterConfig.java
@@ -25,6 +25,7 @@
  */
 package net.runelite.client.plugins.chatfilter;
 
+import java.awt.Color;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
@@ -96,5 +97,27 @@ public interface ChatFilterConfig extends Config
 	default boolean filterLogin()
 	{
 		return false;
+	}
+	
+	@ConfigItem(
+		keyName = "collapseChatMessages",
+		name = "Collapse chat messages",
+		description = "Collapses chat messages together and appends count",
+		position = 7
+	)
+	default boolean collapseChatMessages()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		keyName = "chatMessageCountColor",
+		name = "Collapsed chat message count color",
+		description = "Color of the appended count on collapsed chat messages",
+		position = 8
+	)
+	default Color chatMessageCountColor()
+	{
+		return Color.decode("#FF00FF");
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatfilter/ChatFilterPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatfilter/ChatFilterPlugin.java
@@ -297,7 +297,10 @@ public class ChatFilterPlugin extends Plugin
 		{
 			for (MessageNode m : b.getLines())
 			{
-				if (m == null) continue;
+				if (m == null)
+				{
+					continue;
+				}
 				if (isEqual(m, node))
 				{
 					return m;
@@ -309,12 +312,10 @@ public class ChatFilterPlugin extends Plugin
 
 	private boolean isEqual(MessageNode oldNode, MessageNode newNode)
 	{
-		if (oldNode.getId() == newNode.getId()) return false;
-		if (!oldNode.getType().equals(newNode.getType())) return false;
-		if (!Objects.equals(oldNode.getSender(), newNode.getSender())) return false;
-		if (!oldNode.getName().equals(newNode.getName())) return false;
-		if (!stripMessageQuantity(oldNode.getValue()).equals(newNode.getValue())) return false;
-		return true;
+		return oldNode.getId() != newNode.getId() && oldNode.getType().equals(newNode.getType()) &&
+			Objects.equals(oldNode.getSender(), newNode.getSender()) &&
+			oldNode.getName().equals(newNode.getName()) &&
+			stripMessageQuantity(oldNode.getValue()).equals(newNode.getValue());
 	}
 
 	private String stripMessageQuantity(String message)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatfilter/ChatFilterPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatfilter/ChatFilterPlugin.java
@@ -315,7 +315,7 @@ public class ChatFilterPlugin extends Plugin
 		return oldNode.getId() != newNode.getId() && oldNode.getType().equals(newNode.getType()) &&
 			Objects.equals(oldNode.getSender(), newNode.getSender()) &&
 			oldNode.getName().equals(newNode.getName()) &&
-			stripMessageQuantity(oldNode.getValue()).equals(newNode.getValue());
+			Text.removeTags(stripMessageQuantity(oldNode.getValue())).equals(newNode.getValue());
 	}
 
 	private String stripMessageQuantity(String message)
@@ -351,6 +351,7 @@ public class ChatFilterPlugin extends Plugin
 		{
 			start += (MESSAGE_QUANTITY_FORMAT_PREFIX + hexCol + MESSAGE_QUANTITY_PREFIX).length();
 			String quantity = message.substring(start, end);
+			quantity = Text.removeTags(quantity);
 			return Integer.parseInt(quantity);
 		}
 		return 1;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatfilter/ChatFilterPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatfilter/ChatFilterPlugin.java
@@ -322,7 +322,7 @@ public class ChatFilterPlugin extends Plugin
 		return oldNode.getId() != newNode.getId() && oldNode.getType().equals(newNode.getType()) &&
 			Objects.equals(oldNode.getSender(), newNode.getSender()) &&
 			oldNode.getName().equals(newNode.getName()) &&
-			Text.removeTags(stripMessageQuantity(oldNode.getValue())).equals(newNode.getValue());
+			Text.removeStyleTags(stripMessageQuantity(oldNode.getValue())).equals(newNode.getValue());
 	}
 
 	private String stripMessageQuantity(String message)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatfilter/ChatFilterPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatfilter/ChatFilterPlugin.java
@@ -322,7 +322,7 @@ public class ChatFilterPlugin extends Plugin
 		return oldNode.getId() != newNode.getId() && oldNode.getType().equals(newNode.getType()) &&
 			Objects.equals(oldNode.getSender(), newNode.getSender()) &&
 			oldNode.getName().equals(newNode.getName()) &&
-			Text.removeStyleTags(stripMessageQuantity(oldNode.getValue())).equals(newNode.getValue());
+			Text.removeStyleTags(stripMessageQuantity(oldNode.getValue())).equals(Text.removeStyleTags(newNode.getValue()));
 	}
 
 	private String stripMessageQuantity(String message)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatfilter/ChatFilterPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatfilter/ChatFilterPlugin.java
@@ -29,9 +29,7 @@ import com.google.common.base.CharMatcher;
 import com.google.common.base.Splitter;
 import com.google.inject.Provides;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -275,32 +273,26 @@ public class ChatFilterPlugin extends Plugin
 
 	private void collapseDuplicateMessages(MessageNode node)
 	{
-		Map<Integer, ChatLineBuffer> chatLineMap = client.getChatLineMap();
-
-		MessageNode oldNode = findMessage(chatLineMap.values(), node);
+		MessageNode oldNode = findMessage(node);
 		if (oldNode == null)
 		{
 			return;
 		}
 		node.setValue(addMessageQuantity(oldNode.getValue()));
-		for (ChatLineBuffer b : chatLineMap.values())
+		for (ChatLineBuffer b : client.getChatLineMap().values())
 		{
 			b.removeMessageNode(oldNode);
 		}
 		client.refreshChat();
 	}
 
-	private MessageNode findMessage(Collection<ChatLineBuffer> chatLineBufferCollection, MessageNode node)
+	private MessageNode findMessage(MessageNode node)
 	{
-		for (ChatLineBuffer b : chatLineBufferCollection)
+		for (ChatLineBuffer b : client.getChatLineMap().values())
 		{
 			for (MessageNode m : b.getLines())
 			{
-				if (m == null)
-				{
-					continue;
-				}
-				if (isEqual(m, node))
+				if (m != null && isEqual(m, node))
 				{
 					return m;
 				}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatfilter/ChatFilterPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatfilter/ChatFilterPlugin.java
@@ -322,10 +322,10 @@ public class ChatFilterPlugin extends Plugin
 		Color col = config.chatMessageCountColor();
 		String hexCol = String.format("%02x%02x%02x", col.getRed(), col.getGreen(), col.getBlue());
 		if (message.contains(MESSAGE_QUANTITY_FORMAT_PREFIX + hexCol + MESSAGE_QUANTITY_PREFIX) &&
-		    message.endsWith(MESSAGE_QUANTITY_FORMAT_SUFFIX))
+			message.endsWith(MESSAGE_QUANTITY_FORMAT_SUFFIX))
 		{
 			return message.substring(0, message.lastIndexOf(MESSAGE_QUANTITY_FORMAT_PREFIX +
-					         hexCol + MESSAGE_QUANTITY_PREFIX));
+				hexCol + MESSAGE_QUANTITY_PREFIX));
 		}
 		return message;
 	}
@@ -337,7 +337,7 @@ public class ChatFilterPlugin extends Plugin
 		Color col = config.chatMessageCountColor();
 		String hexCol = String.format("%02x%02x%02x", col.getRed(), col.getGreen(), col.getBlue());
 		return message + MESSAGE_QUANTITY_FORMAT_PREFIX + hexCol + MESSAGE_QUANTITY_PREFIX +
-		       quantity + MESSAGE_QUANTITY_FORMAT_SUFFIX;
+			quantity + MESSAGE_QUANTITY_FORMAT_SUFFIX;
 	}
 
 	private int findMessageQuantity(String message)

--- a/runelite-client/src/main/java/net/runelite/client/util/Text.java
+++ b/runelite-client/src/main/java/net/runelite/client/util/Text.java
@@ -30,6 +30,7 @@ import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
 import java.util.Collection;
 import java.util.List;
+import java.util.reges.Matcher;
 import java.util.regex.Pattern;
 import org.apache.commons.text.WordUtils;
 
@@ -79,6 +80,32 @@ public class Text
 	public static String removeTags(String str)
 	{
 		return TAG_REGEXP.matcher(str).replaceAll("");
+	}
+	
+	/**
+	 * Removes all tags from the given string, except for &lt;lt&gt; and &lt;gt&gt;
+	 *
+	 * @param str The string to remove style tags from.
+	 * @return The given string with style tags removed from it.
+	 */
+	public static String removeStyleTags(String str)
+	{
+		StringBuffer stringBuffer = new StringBuffer();
+		Matcher matcher = TAG_REGEXP.matcher(str);
+		while (matcher.find())
+		{
+			matcher.appendReplacement(stringBuffer, "");
+			String match = matcher.group(0);
+			switch (match)
+			{
+				case "<lt>":
+				case "<gt>":
+					stringBuffer.append(match);
+					break;
+			}
+		}
+		matcher.appendTail(stringBuffer);
+		return stringBuffer.toString();
 	}
 
 	/**

--- a/runelite-client/src/main/java/net/runelite/client/util/Text.java
+++ b/runelite-client/src/main/java/net/runelite/client/util/Text.java
@@ -30,7 +30,7 @@ import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
 import java.util.Collection;
 import java.util.List;
-import java.util.reges.Matcher;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.apache.commons.text.WordUtils;
 


### PR DESCRIPTION
Option to collapse duplicate chat messages and add a coloured count at the end of the message.

![illustration](https://user-images.githubusercontent.com/33559295/72261674-8e6de000-3615-11ea-99b6-e624af21a5c7.png)

![animation](https://user-images.githubusercontent.com/33559295/72260933-25d23380-3614-11ea-874b-59f4db961d99.gif)

The count formatting (e.g. "x 2") follows the format of the collapsed menu entries in the ground items plugin.

RegEx can probably benefit my implementation, but I would need some help to formulate an expression.

If someone has a better implementation feel free to PR and merge that instead.