### PR TITLE
Add Brimhaven cart to Travel menu entry swapper plugin

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -526,6 +526,10 @@ public class MenuEntrySwapperPlugin extends Plugin
 		{
 			swap("travel", option, target, index);
 		}
+		else if (config.swapTravel() && option.equals("board") && target.contains("cart"))
+		{
+			swap("pay-fare", option, target, index);
+		}
 		else if (config.swapHarpoon() && option.equals("cage"))
 		{
 			swap("harpoon", option, target, index);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -526,7 +526,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 		{
 			swap("travel", option, target, index);
 		}
-		else if (config.swapTravel() && option.equals("board") && target.contains("cart"))
+		else if (config.swapTravel() && option.equals("board") && target.equals("travel cart"))
 		{
 			swap("pay-fare", option, target, index);
 		}


### PR DESCRIPTION
This update swaps the options for Board (slow) and Pay-Fare (fast) on the Brimhaven cart, if the Travel menu entry swapper plugin setting is on.