### PR TITLE
Ctrl-Click to Withdraw-All/Deposit-All from Bank

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/KeyModifierInputListener.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/KeyModifierInputListener.java
@@ -30,7 +30,7 @@ import net.runelite.api.Client;
 import net.runelite.client.callback.ClientThread;
 import net.runelite.client.input.KeyListener;
 
-public class ShiftClickInputListener implements KeyListener
+public class KeyModifierInputListener implements KeyListener
 {
 	@Inject
 	private ClientThread clientThread;
@@ -54,6 +54,11 @@ public class ShiftClickInputListener implements KeyListener
 		{
 			plugin.setShiftModifier(true);
 		}
+
+		if(event.getKeyCode() == KeyEvent.VK_CONTROL)
+		{
+			plugin.setCtrlModifier(true);
+		}
 	}
 
 	@Override
@@ -62,6 +67,11 @@ public class ShiftClickInputListener implements KeyListener
 		if (event.getKeyCode() == KeyEvent.VK_SHIFT)
 		{
 			plugin.setShiftModifier(false);
+		}
+
+		if(event.getKeyCode() == KeyEvent.VK_CONTROL)
+		{
+			plugin.setCtrlModifier(false);
 		}
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -401,4 +401,11 @@ public interface MenuEntrySwapperConfig extends Config
 	{
 		return false;
 	}
+
+	@ConfigItem(
+		keyName = "ctrlClickBankAll",
+		name = "Ctrl-Click Deposit/Withdraw-All",
+		description = "Deposit-All/Withdraw-All with a left click while holding control no matter which 1/5/10/X option is selected."
+	)
+	default boolean ctrlClickBankAll() { return true; }
 }


### PR DESCRIPTION
Closes #10612 

Ctrl-clicking will now swap the left click to Withdraw-All or Deposit-All. Ctrl-click was chosen instead of Shift-click because Shift is used for the Swap Bank Op option (shift-click for eating/wearing/etc).

This is super useful for when you want to alternate between Withdraw-1/5/etc and Withdraw-All quickly without having to select the All button or right click. An example would be if you had a stack of Ava's devices (which I do). I could just left click Ava's Accumulator to withdraw 1 like usual, and then ctrl-click my arrows to withdraw them all. Really simple and helpful QOL change.

Note: I'm not sure why my every line is changed in MenuEntrySwapperConfig. The diff on IDEA only shows the lines that I added. Line endings or tabs weren't changed. Let me know if/how I should fix that.