### PR TITLE
Shift-Click to Withdraw-All/Deposit-All

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -383,16 +383,6 @@ public interface MenuEntrySwapperConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "swapBankOp",
-		name = "Swap Bank Op",
-		description = "Swaps the extra menu option in banks (Wield, Eat, etc.) when holding shift"
-	)
-	default boolean swapBankOp()
-	{
-		return false;
-	}
-
-	@ConfigItem(
 		keyName = "swapNpcContact",
 		name = "NPC Contact",
 		description = "Swap NPC Contact with last contacted NPC when shift-clicking"
@@ -400,5 +390,25 @@ public interface MenuEntrySwapperConfig extends Config
 	default boolean swapNpcContact()
 	{
 		return false;
+	}
+
+	@ConfigItem(
+		keyName = "bankWithdrawShiftClick",
+		name = "Bank Withdraw Shift-Click",
+		description = "Swaps the behavior of shift-click when withdrawing from bank."
+	)
+	default ShiftWithdrawMode bankWithdrawShiftClick()
+	{
+		return ShiftWithdrawMode.OFF;
+	}
+
+	@ConfigItem(
+		keyName = "bankDepositShiftClick",
+		name = "Bank Deposit Shift-Click",
+		description = "Swaps the behavior of shift-click when depositing to bank."
+	)
+	default ShiftDepositMode bankDepositShiftClick()
+	{
+		return ShiftDepositMode.OFF;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/ShiftDepositMode.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/ShiftDepositMode.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2020, Zach <https://github.com/zacharydwaller>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.menuentryswapper;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import net.runelite.api.MenuAction;
+
+@Getter
+@RequiredArgsConstructor
+public enum ShiftDepositMode
+{
+	DEPOSIT_1("Deposit-1", MenuAction.CC_OP, 3),
+	DEPOSIT_5("Deposit-5", MenuAction.CC_OP, 4),
+	DEPOSIT_10("Deposit-10", MenuAction.CC_OP, 5),
+	DEPOSIT_X("Deposit-X", MenuAction.CC_OP_LOW_PRIORITY, 6),
+	DEPOSIT_ALL("Deposit-All", MenuAction.CC_OP_LOW_PRIORITY, 8),
+	EXTRA_OP("Eat/Wield/Etc.", MenuAction.CC_OP_LOW_PRIORITY, 9),
+	OFF("Off", MenuAction.UNKNOWN, 0);
+
+	private final String name;
+	private final MenuAction menuAction;
+	private final int identifier;
+
+	@Override
+	public String toString()
+	{
+		return name;
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/ShiftWithdrawMode.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/ShiftWithdrawMode.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2020, Zach <https://github.com/zacharydwaller>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.menuentryswapper;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import net.runelite.api.MenuAction;
+
+@Getter
+@RequiredArgsConstructor
+public enum ShiftWithdrawMode
+{
+	WITHDRAW_1("Withdraw-1", MenuAction.CC_OP, 2),
+	WITHDRAW_5("Withdraw-5", MenuAction.CC_OP, 3),
+	WITHDRAW_10("Withdraw-10", MenuAction.CC_OP, 4),
+	WITHDRAW_X("Withdraw-X", MenuAction.CC_OP, 5),
+	WITHDRAW_ALL("Withdraw-All", MenuAction.CC_OP_LOW_PRIORITY, 7),
+	WITHDRAW_ALL_BUT_1("Withdraw-All-But-1", MenuAction.CC_OP_LOW_PRIORITY, 8),
+	OFF("Off", MenuAction.UNKNOWN, 0);
+
+	private final String name;
+	private final MenuAction menuAction;
+	private final int identifier;
+
+	@Override
+	public String toString()
+	{
+		return name;
+	}
+}

--- a/runelite-client/src/test/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPluginTest.java
@@ -303,14 +303,14 @@ public class MenuEntrySwapperPluginTest
 	}
 
 	@Test
-	public void testBankExtraOp()
+	public void testShiftWithdraw()
 	{
-		when(config.swapBankOp()).thenReturn(true);
+		when(config.bankDepositShiftClick()).thenReturn(ShiftDepositMode.EXTRA_OP);
 		menuEntrySwapperPlugin.setShiftModifier(true);
 
 		entries = new MenuEntry[]{
 			menu("Cancel", "", MenuAction.CANCEL),
-			menu("Weild", "Abyssal whip", MenuAction.CC_OP_LOW_PRIORITY, 9),
+			menu("Wield", "Abyssal whip", MenuAction.CC_OP_LOW_PRIORITY, 9),
 			menu("Deposit-1", "Abyssal whip", MenuAction.CC_OP, 2),
 		};
 
@@ -329,7 +329,40 @@ public class MenuEntrySwapperPluginTest
 		assertArrayEquals(new MenuEntry[]{
 			menu("Cancel", "", MenuAction.CANCEL),
 			menu("Deposit-1", "Abyssal whip", MenuAction.CC_OP, 2),
-			menu("Weild", "Abyssal whip", MenuAction.CC_OP, 9),
+			menu("Wield", "Abyssal whip", MenuAction.CC_OP, 9),
+		}, argumentCaptor.getValue());
+	}
+
+	@Test
+	public void testShiftDeposit()
+	{
+		when(config.bankDepositShiftClick()).thenReturn(ShiftDepositMode.DEPOSIT_ALL);
+		menuEntrySwapperPlugin.setShiftModifier(true);
+
+		entries = new MenuEntry[]{
+			menu("Cancel", "", MenuAction.CANCEL),
+			menu("Wield", "Rune arrow", MenuAction.CC_OP_LOW_PRIORITY, 9),
+			menu("Deposit-All", "Rune arrow", MenuAction.CC_OP_LOW_PRIORITY, 8),
+			menu("Deposit-1", "Rune arrow", MenuAction.CC_OP, 2),
+		};
+
+		menuEntrySwapperPlugin.onMenuEntryAdded(new MenuEntryAdded(
+			"Deposit-1",
+			"Rune arrow",
+			MenuAction.CC_OP.getId(),
+			2,
+			-1,
+			-1
+		));
+
+		ArgumentCaptor<MenuEntry[]> argumentCaptor = ArgumentCaptor.forClass(MenuEntry[].class);
+		verify(client).setMenuEntries(argumentCaptor.capture());
+
+		assertArrayEquals(new MenuEntry[]{
+			menu("Cancel", "", MenuAction.CANCEL),
+			menu("Wield", "Rune arrow", MenuAction.CC_OP_LOW_PRIORITY, 9),
+			menu("Deposit-1", "Rune arrow", MenuAction.CC_OP, 2),
+			menu("Deposit-All", "Rune arrow", MenuAction.CC_OP, 8),
 		}, argumentCaptor.getValue());
 	}
 }


### PR DESCRIPTION
Closes #10612

Ctrl-clicking will now swap the left click to Withdraw-All or Deposit-All. Ctrl-click was chosen instead of Shift-click because Shift is used for the Swap Bank Op option (shift-click for eating/wearing/etc).

This is super useful for when you want to alternate between Withdraw-1/5/etc and Withdraw-All quickly without having to select the All button or right click. An example would be if you had a stack of Ava's devices (which I do). I could just left click Ava's Accumulator to withdraw 1 like usual, and then ctrl-click my arrows to withdraw them all. Really simple and helpful QOL change.