### PR TITLE
widgetid: change sound slider ids

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/widgets/WidgetID.java
+++ b/runelite-api/src/main/java/net/runelite/api/widgets/WidgetID.java
@@ -838,9 +838,9 @@ public class WidgetID
 
 	static class Options
 	{
-		static final int MUSIC_SLIDER = 41;
-		static final int SOUND_EFFECT_SLIDER = 46;
-		static final int AREA_SOUND_SLIDER = 51;
+		static final int MUSIC_SLIDER = 38;
+		static final int SOUND_EFFECT_SLIDER = 44;
+		static final int AREA_SOUND_SLIDER = 50;
 	}
 
 	static class AchievementDiary


### PR DESCRIPTION
They were moved back when the show unlock message option was added