### PR TITLE
Add pickpockets to loot tracker

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootEvent.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootEvent.java
@@ -53,6 +53,16 @@ enum LootEvent
 	KINGDOM_OF_MISCELLANIA("Kingdom of Miscellania"),
 	LARRANS_CHEST_BIG("Larran's big chest"),
 	LARRANS_CHEST_SMALL("Larran's small chest"),
+	// Pickpocket-able NPCs who give loot other than coin pouches
+	PICKPOCKET_BANDIT("Bandit (Pickpocket)"),
+	PICKPOCKET_CAVE_GOBLIN("Cave Goblin (Pickpocket)"),
+	PICKPOCKET_ELF("Elf (Pickpocket)"),
+	PICKPOCKET_GNOME("Gnome (Pickpocket)"),
+	PICKPOCKET_HAM_MEMBER("H.A.M. Member (Pickpocket)"),
+	PICKPOCKET_HERO("Hero (Pickpocket)"),
+	PICKPOCKET_MASTER_FARMER("Master Farmer (Pickpocket)"),
+	PICKPOCKET_ROGUE("Rogue (Pickpocket)"),
+	PICKPOCKET_TZHAAR_HUR("TzHaar-Hur (Pickpocket)"),
 	THEATRE_OF_BLOOD("Theatre of Blood");
 
 	@Getter
@@ -66,9 +76,23 @@ enum LootEvent
 		13151, LootEvent.ELVEN_CRYSTAL_CHEST
 	);
 
+	static final Map<String, LootEvent> PICKPOCKET_EVENT_LOOKUP_TABLE = ImmutableMap.<String, LootEvent>builder()
+		.put("Master Farmer", PICKPOCKET_MASTER_FARMER)
+		.put("Martin", PICKPOCKET_MASTER_FARMER)
+		.put("TzHaar-Hur", PICKPOCKET_TZHAAR_HUR)
+		.put("Elf", PICKPOCKET_ELF)
+		.put("Hero", PICKPOCKET_HERO)
+		.put("Gnome", PICKPOCKET_GNOME)
+		.put("Bandit", PICKPOCKET_BANDIT)
+		.put("Cave Goblin", PICKPOCKET_CAVE_GOBLIN)
+		.put("Rogue", PICKPOCKET_ROGUE)
+		.put("H.A.M. Member", PICKPOCKET_HAM_MEMBER)
+		.build();
+
 	static final List<LootEvent> DIRECT_TO_INVENTORY_EVENTS = ImmutableList.<LootEvent>builder()
 		.add(HERBIBOAR, HESPORI, GAUNTLET)
 		.addAll(CHEST_EVENT_LOOKUP_TABLE.values())
+		.addAll(PICKPOCKET_EVENT_LOOKUP_TABLE.values())
 		.build();
 
 	static final Map<String, LootEvent> CLUE_SCROLL_LOOKUP_TABLE = ImmutableMap.<String, LootEvent>builder()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootEvent.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootEvent.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2018, Psikoi <https://github.com/psikoi>
+ * Copyright (c) 2018, Adam <Adam@sigterm.info>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.loottracker;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import java.util.List;
+import java.util.Map;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+enum LootEvent
+{
+	BARROWS("Barrows"),
+	BRIMSTONE_CHEST("Brimstone Chest"),
+	CHAMBERS_OF_XERIC("Chambers of Xeric"),
+	CLUE_SCROLL_BEGINNER("Clue Scroll (Beginner)"),
+	CLUE_SCROLL_EASY("Clue Scroll (Easy)"),
+	CLUE_SCROLL_MEDIUM("Clue Scroll (Medium)"),
+	CLUE_SCROLL_HARD("Clue Scroll (Hard)"),
+	CLUE_SCROLL_ELITE("Clue Scroll (Elite)"),
+	CLUE_SCROLL_MASTER("Clue Scroll (Master)"),
+	CRYSTAL_CHEST("Crystal Chest"),
+	ELVEN_CRYSTAL_CHEST("Elven Crystal Chest"),
+	FISHING_TRAWLER("Fishing Trawler"),
+	GAUNTLET("The Gauntlet"),
+	HESPORI("Hespori"),
+	HERBIBOAR("Herbiboar"),
+	KINGDOM_OF_MISCELLANIA("Kingdom of Miscellania"),
+	LARRANS_CHEST_BIG("Larran's big chest"),
+	LARRANS_CHEST_SMALL("Larran's small chest"),
+	THEATRE_OF_BLOOD("Theatre of Blood");
+
+	@Getter
+	private final String name;
+
+	static final Map<Integer, LootEvent> CHEST_EVENT_LOOKUP_TABLE = ImmutableMap.of(
+		5179, LootEvent.BRIMSTONE_CHEST,
+		11573, LootEvent.CRYSTAL_CHEST,
+		12093, LootEvent.LARRANS_CHEST_BIG,
+		13113, LootEvent.LARRANS_CHEST_SMALL,
+		13151, LootEvent.ELVEN_CRYSTAL_CHEST
+	);
+
+	static final List<LootEvent> DIRECT_TO_INVENTORY_EVENTS = ImmutableList.<LootEvent>builder()
+		.add(HERBIBOAR, HESPORI, GAUNTLET)
+		.addAll(CHEST_EVENT_LOOKUP_TABLE.values())
+		.build();
+
+	static final Map<String, LootEvent> CLUE_SCROLL_LOOKUP_TABLE = ImmutableMap.<String, LootEvent>builder()
+		.put("beginner", CLUE_SCROLL_BEGINNER)
+		.put("easy", CLUE_SCROLL_EASY)
+		.put("medium", CLUE_SCROLL_MEDIUM)
+		.put("hard", CLUE_SCROLL_HARD)
+		.put("elite", CLUE_SCROLL_ELITE)
+		.put("master", CLUE_SCROLL_MASTER)
+		.build();
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
@@ -25,6 +25,7 @@
  */
 package net.runelite.client.plugins.loottracker;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.HashMultiset;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
@@ -170,7 +171,8 @@ public class LootTrackerPlugin extends Plugin
 
 	private LootTrackerPanel panel;
 	private NavigationButton navButton;
-	private LootEvent mostRecentEvent;
+	@VisibleForTesting
+	LootEvent mostRecentEvent;
 	private boolean chestLooted;
 	private String lastPickpocketTarget;
 

--- a/runelite-client/src/test/java/net/runelite/client/plugins/loottracker/LootTrackerPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/loottracker/LootTrackerPluginTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2020, Adam <Adam@sigterm.info>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.loottracker;
+
+import com.google.inject.Guice;
+import com.google.inject.testing.fieldbinder.Bind;
+import com.google.inject.testing.fieldbinder.BoundFieldModule;
+import java.util.concurrent.ScheduledExecutorService;
+import javax.inject.Inject;
+import net.runelite.api.ChatMessageType;
+import net.runelite.api.Client;
+import net.runelite.api.Player;
+import net.runelite.api.coords.WorldPoint;
+import net.runelite.api.events.ChatMessage;
+import net.runelite.client.game.SpriteManager;
+import net.runelite.client.ui.overlay.infobox.InfoBoxManager;
+import static org.junit.Assert.assertEquals;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class LootTrackerPluginTest
+{
+	@Mock
+	@Bind
+	private ScheduledExecutorService scheduledExecutorService;
+
+	@Mock
+	@Bind
+	private Client client;
+
+	@Mock
+	@Bind
+	private SpriteManager spriteManager;
+
+	@Mock
+	@Bind
+	private InfoBoxManager infoBoxManager;
+
+	@Inject
+	private LootTrackerPlugin lootTrackerPlugin;
+
+	@Mock
+	@Bind
+	private LootTrackerConfig lootTrackerConfig;
+
+	@Before
+	public void setUp()
+	{
+		Guice.createInjector(BoundFieldModule.of(this)).injectMembers(this);
+	}
+
+	@Test
+	public void testPickPocket()
+	{
+		Player player = mock(Player.class);
+		when(player.getWorldLocation()).thenReturn(new WorldPoint(0, 0, 0));
+		when(client.getLocalPlayer()).thenReturn(player);
+
+		//ChatMessage chatMessage = new ChatMessage(null, ChatMessageType.SPAM, "", "You pick the paladin's pocket.", "", 0);
+		ChatMessage chatMessage = new ChatMessage(null, ChatMessageType.SPAM, "", "You pick the hero's pocket.", "", 0);
+		lootTrackerPlugin.onChatMessage(chatMessage);
+
+		assertEquals(LootEvent.PICKPOCKET_HERO, lootTrackerPlugin.mostRecentEvent);
+	}
+}


### PR DESCRIPTION
Suggested a few times in the past (e.g. https://github.com/runelite/runelite/issues/5033).

I thought this would be a good addition to the loot tracker. It was something I found myself wanting when thieving master farmers. It seems to have been a bit polarizing in the past, so I've put it behind a config flag by default.

Possibly extensible to cover loot from all types of thieving (stalls, chests, etc). Let me know if there are any improvements needed