### PR TITLE
Add configurability to the Idle Notifier plugin.

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/Notifier.java
+++ b/runelite-client/src/main/java/net/runelite/client/Notifier.java
@@ -96,7 +96,8 @@ public class Notifier
 		.build();
 
 	// Notifier properties
-	private static final Color FLASH_COLOR = new Color(255, 0, 0, 70);
+
+	public static Color FLASH_COLOR = new Color(255, 0, 0, 70);
 	private static final int MINIMUM_FLASH_DURATION_MILLIS = 2000;
 	private static final int MINIMUM_FLASH_DURATION_TICKS = MINIMUM_FLASH_DURATION_MILLIS / Constants.CLIENT_TICK_LENGTH;
 

--- a/runelite-client/src/main/java/net/runelite/client/Notifier.java
+++ b/runelite-client/src/main/java/net/runelite/client/Notifier.java
@@ -96,8 +96,7 @@ public class Notifier
 		.build();
 
 	// Notifier properties
-
-	public static Color FLASH_COLOR = new Color(255, 0, 0, 70);
+	public static  Color FLASH_COLOR = new Color(255, 0, 0, 70);
 	private static final int MINIMUM_FLASH_DURATION_MILLIS = 2000;
 	private static final int MINIMUM_FLASH_DURATION_TICKS = MINIMUM_FLASH_DURATION_MILLIS / Constants.CLIENT_TICK_LENGTH;
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierConfig.java
@@ -31,6 +31,8 @@ import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
 
+import java.awt.*;
+
 @ConfigGroup("idlenotifier")
 public interface IdleNotifierConfig extends Config
 {
@@ -135,84 +137,12 @@ public interface IdleNotifierConfig extends Config
 
 	@Alpha
 	@ConfigItem(
-			keyName = "animationidleflashcolor",
-			name = "Idle Animation Color",
-			description = "Color of flash notification after the player is idle",
-			position = 10
+		keyName = "notificationFlashColor",
+		name = "Notification Flash Color",
+		description = "Changes the color of the notification flashes.",
+		position = 10
 	)
-	default Color getAnimationIdleFlashColor()
-	{
-		return Notifier.FLASH_COLOR;
-	}
-
-	@Alpha
-	@ConfigItem(
-			keyName = "logoutidleflashcolor",
-			name = "Idle Logout Color",
-			description = "Color of flash notification when the player is about to be logged out",
-			position = 11
-	)
-	default Color getLogoutIdleFlashColor()
-	{
-		return Notifier.FLASH_COLOR;
-	}
-
-	@Alpha
-	@ConfigItem(
-			keyName = "combatidleflashcolor",
-			name = "Combat Idle Color",
-			description = "Color of flash notification after the player is out of combat",
-			position = 12
-	)
-	default Color getCombatIdleFlashColor()
-	{
-		return Notifier.FLASH_COLOR;
-	}
-
-	@Alpha
-	@ConfigItem(
-			keyName = "hitpointsflashcolor",
-			name = "Hitpoints Color",
-			description = "Color of flash notification after hitpoints reach the threshold",
-			position = 13
-	)
-	default Color getHitpointsFlashColor()
-	{
-		return Notifier.FLASH_COLOR;
-	}
-
-	@Alpha
-	@ConfigItem(
-			keyName = "prayerflashcolor",
-			name = "Prayer Color",
-			description = "Color of flash notification after prayer points reach the threshold",
-			position = 14
-	)
-	default Color getPrayerFlashColor()
-	{
-		return Notifier.FLASH_COLOR;
-	}
-
-	@Alpha
-	@ConfigItem(
-			keyName = "Oxygenflashcolor",
-			name = "Oxygen Color",
-			description = "Color of flash notification after oxygen level reach the threshold",
-			position = 15
-	)
-	default Color getOxygenFlashColor()
-	{
-		return Notifier.FLASH_COLOR;
-	}
-
-	@Alpha
-	@ConfigItem(
-			keyName = "Energyflashcolor",
-			name = "Energy Color",
-			description = "Color of flash notification after energy percentage reach the threshold",
-			position = 16
-	)
-	default Color getEnergyFlashColor()
+	default Color getNotificationFlashColor()
 	{
 		return Notifier.FLASH_COLOR;
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierConfig.java
@@ -24,6 +24,9 @@
  */
 package net.runelite.client.plugins.idlenotifier;
 
+import java.awt.Color;
+import net.runelite.client.Notifier;
+import net.runelite.client.config.Alpha;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
@@ -111,8 +114,8 @@ public interface IdleNotifierConfig extends Config
 	@ConfigItem(
 		keyName = "oxygen",
 		name = "Oxygen Notification Threshold",
-		position = 8,
-		description = "The amount of remaining oxygen to send a notification at. A value of 0 will disable notification."
+		description = "The amount of remaining oxygen to send a notification at. A value of 0 will disable notification.",
+		position = 8
 	)
 	default int getOxygenThreshold()
 	{
@@ -122,11 +125,95 @@ public interface IdleNotifierConfig extends Config
 	@ConfigItem(
 		keyName = "spec",
 		name = "Special Attack Energy Notification Threshold",
-		position = 9,
-		description = "The amount of spec energy reached to send a notification at. A value of 0 will disable notification."
+		description = "The amount of spec energy reached to send a notification at. A value of 0 will disable notification.",
+		position = 9
 	)
 	default int getSpecEnergyThreshold()
 	{
 		return 0;
+	}
+
+	@Alpha
+	@ConfigItem(
+			keyName = "animationidleflashcolor",
+			name = "Idle Animation Color",
+			description = "Color of flash notification after the player is idle",
+			position = 10
+	)
+	default Color getAnimationIdleFlashColor()
+	{
+		return Notifier.FLASH_COLOR;
+	}
+
+	@Alpha
+	@ConfigItem(
+			keyName = "logoutidleflashcolor",
+			name = "Idle Logout Color",
+			description = "Color of flash notification when the player is about to be logged out",
+			position = 11
+	)
+	default Color getLogoutIdleFlashColor()
+	{
+		return Notifier.FLASH_COLOR;
+	}
+
+	@Alpha
+	@ConfigItem(
+			keyName = "combatidleflashcolor",
+			name = "Combat Idle Color",
+			description = "Color of flash notification after the player is out of combat",
+			position = 12
+	)
+	default Color getCombatIdleFlashColor()
+	{
+		return Notifier.FLASH_COLOR;
+	}
+
+	@Alpha
+	@ConfigItem(
+			keyName = "hitpointsflashcolor",
+			name = "Hitpoints Color",
+			description = "Color of flash notification after hitpoints reach the threshold",
+			position = 13
+	)
+	default Color getHitpointsFlashColor()
+	{
+		return Notifier.FLASH_COLOR;
+	}
+
+	@Alpha
+	@ConfigItem(
+			keyName = "prayerflashcolor",
+			name = "Prayer Color",
+			description = "Color of flash notification after prayer points reach the threshold",
+			position = 14
+	)
+	default Color getPrayerFlashColor()
+	{
+		return Notifier.FLASH_COLOR;
+	}
+
+	@Alpha
+	@ConfigItem(
+			keyName = "Oxygenflashcolor",
+			name = "Oxygen Color",
+			description = "Color of flash notification after oxygen level reach the threshold",
+			position = 15
+	)
+	default Color getOxygenFlashColor()
+	{
+		return Notifier.FLASH_COLOR;
+	}
+
+	@Alpha
+	@ConfigItem(
+			keyName = "Energyflashcolor",
+			name = "Energy Color",
+			description = "Color of flash notification after energy percentage reach the threshold",
+			position = 16
+	)
+	default Color getEnergyFlashColor()
+	{
+		return Notifier.FLASH_COLOR;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
@@ -26,6 +26,7 @@
 package net.runelite.client.plugins.idlenotifier;
 
 import com.google.inject.Provides;
+import java.awt.Color;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Arrays;
@@ -377,6 +378,13 @@ public class IdleNotifierPlugin extends Plugin
 	{
 		final Player local = client.getLocalPlayer();
 		final Duration waitDuration = Duration.ofMillis(config.getIdleNotificationDelay());
+		final Color animationIdleFlashColor = config.getAnimationIdleFlashColor();
+		final Color logoutIdleFlashColor = config.getLogoutIdleFlashColor();
+		final Color combatIdleFlashColor = config.getCombatIdleFlashColor();
+		final Color hitpointsFlashColor = config.getHitpointsFlashColor();
+		final Color prayerFlashColor = config.getPrayerFlashColor();
+		final Color oxygenFlashColor = config.getOxygenFlashColor();
+		final Color energyFlashColor = config.getEnergyFlashColor();
 		lastCombatCountdown = Math.max(lastCombatCountdown - 1, 0);
 
 		if (client.getGameState() != GameState.LOGGED_IN
@@ -391,21 +399,25 @@ public class IdleNotifierPlugin extends Plugin
 
 		if (config.logoutIdle() && checkIdleLogout())
 		{
+			Notifier.FLASH_COLOR = logoutIdleFlashColor;
 			notifier.notify("[" + local.getName() + "] is about to log out from idling too long!");
 		}
 
 		if (check6hrLogout())
 		{
+			Notifier.FLASH_COLOR = logoutIdleFlashColor;
 			notifier.notify("[" + local.getName() + "] is about to log out from being online for 6 hours!");
 		}
 
 		if (config.animationIdle() && checkAnimationIdle(waitDuration, local))
 		{
+			Notifier.FLASH_COLOR = animationIdleFlashColor;
 			notifier.notify("[" + local.getName() + "] is now idle!");
 		}
 
 		if (config.movementIdle() && checkMovementIdle(waitDuration, local))
 		{
+			Notifier.FLASH_COLOR = animationIdleFlashColor;
 			notifier.notify("[" + local.getName() + "] has stopped moving!");
 		}
 
@@ -413,31 +425,37 @@ public class IdleNotifierPlugin extends Plugin
 		{
 			if (lastInteractWasCombat)
 			{
+				Notifier.FLASH_COLOR = combatIdleFlashColor;
 				notifier.notify("[" + local.getName() + "] is now out of combat!");
 			}
 			else
 			{
+				Notifier.FLASH_COLOR = animationIdleFlashColor;
 				notifier.notify("[" + local.getName() + "] is now idle!");
 			}
 		}
 
 		if (checkLowHitpoints())
 		{
+			Notifier.FLASH_COLOR = hitpointsFlashColor;
 			notifier.notify("[" + local.getName() + "] has low hitpoints!");
 		}
 
 		if (checkLowPrayer())
 		{
+			Notifier.FLASH_COLOR = prayerFlashColor;
 			notifier.notify("[" + local.getName() + "] has low prayer!");
 		}
 
 		if (checkLowOxygen())
 		{
+			Notifier.FLASH_COLOR = oxygenFlashColor;
 			notifier.notify("[" + local.getName() + "] has low oxygen!");
 		}
 
 		if (checkFullSpecEnergy())
 		{
+			Notifier.FLASH_COLOR = energyFlashColor;
 			notifier.notify("[" + local.getName() + "] has restored spec energy!");
 		}
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
@@ -378,13 +378,8 @@ public class IdleNotifierPlugin extends Plugin
 	{
 		final Player local = client.getLocalPlayer();
 		final Duration waitDuration = Duration.ofMillis(config.getIdleNotificationDelay());
-		final Color animationIdleFlashColor = config.getAnimationIdleFlashColor();
-		final Color logoutIdleFlashColor = config.getLogoutIdleFlashColor();
-		final Color combatIdleFlashColor = config.getCombatIdleFlashColor();
-		final Color hitpointsFlashColor = config.getHitpointsFlashColor();
-		final Color prayerFlashColor = config.getPrayerFlashColor();
-		final Color oxygenFlashColor = config.getOxygenFlashColor();
-		final Color energyFlashColor = config.getEnergyFlashColor();
+		final Color notificationFlashColor = config.getNotificationFlashColor();
+		Notifier.FLASH_COLOR = notificationFlashColor;
 		lastCombatCountdown = Math.max(lastCombatCountdown - 1, 0);
 
 		if (client.getGameState() != GameState.LOGGED_IN
@@ -399,25 +394,21 @@ public class IdleNotifierPlugin extends Plugin
 
 		if (config.logoutIdle() && checkIdleLogout())
 		{
-			Notifier.FLASH_COLOR = logoutIdleFlashColor;
 			notifier.notify("[" + local.getName() + "] is about to log out from idling too long!");
 		}
 
 		if (check6hrLogout())
 		{
-			Notifier.FLASH_COLOR = logoutIdleFlashColor;
 			notifier.notify("[" + local.getName() + "] is about to log out from being online for 6 hours!");
 		}
 
 		if (config.animationIdle() && checkAnimationIdle(waitDuration, local))
 		{
-			Notifier.FLASH_COLOR = animationIdleFlashColor;
 			notifier.notify("[" + local.getName() + "] is now idle!");
 		}
 
 		if (config.movementIdle() && checkMovementIdle(waitDuration, local))
 		{
-			Notifier.FLASH_COLOR = animationIdleFlashColor;
 			notifier.notify("[" + local.getName() + "] has stopped moving!");
 		}
 
@@ -425,37 +416,31 @@ public class IdleNotifierPlugin extends Plugin
 		{
 			if (lastInteractWasCombat)
 			{
-				Notifier.FLASH_COLOR = combatIdleFlashColor;
 				notifier.notify("[" + local.getName() + "] is now out of combat!");
 			}
 			else
 			{
-				Notifier.FLASH_COLOR = animationIdleFlashColor;
 				notifier.notify("[" + local.getName() + "] is now idle!");
 			}
 		}
 
 		if (checkLowHitpoints())
 		{
-			Notifier.FLASH_COLOR = hitpointsFlashColor;
 			notifier.notify("[" + local.getName() + "] has low hitpoints!");
 		}
 
 		if (checkLowPrayer())
 		{
-			Notifier.FLASH_COLOR = prayerFlashColor;
 			notifier.notify("[" + local.getName() + "] has low prayer!");
 		}
 
 		if (checkLowOxygen())
 		{
-			Notifier.FLASH_COLOR = oxygenFlashColor;
 			notifier.notify("[" + local.getName() + "] has low oxygen!");
 		}
 
 		if (checkFullSpecEnergy())
 		{
-			Notifier.FLASH_COLOR = energyFlashColor;
 			notifier.notify("[" + local.getName() + "] has restored spec energy!");
 		}
 	}


### PR DESCRIPTION
This commit offers the user to customize the color of their flashing screen notification depending the context in which it is triggered.
![image](https://user-images.githubusercontent.com/40346808/73121457-57b69480-3f48-11ea-9b9a-912cc9798163.png)

Fixes #10761