### PR TITLE
Separate Wintertodt Notification Options

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/wintertodt/WintertodtConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/wintertodt/WintertodtConfig.java
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2018, terminatusx <jbfleischman@gmail.com>
  * Copyright (c) 2018, Adam <Adam@sigterm.info>
+ * Copyright (c) 2020, loldudester <HannahRyanster@gmail.com>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -31,24 +32,13 @@ import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
 import net.runelite.client.config.Range;
 import net.runelite.client.config.Units;
-import net.runelite.client.plugins.wintertodt.config.WintertodtNotifyMode;
+import net.runelite.client.plugins.wintertodt.config.WintertodtNotifyDamage;
 
 @ConfigGroup("wintertodt")
 public interface WintertodtConfig extends Config
 {
 	@ConfigItem(
 		position = 1,
-		keyName = "notifyCondition",
-		name = "Notify When",
-		description = "Configures when to send notifications"
-	)
-	default WintertodtNotifyMode notifyCondition()
-	{
-		return WintertodtNotifyMode.ONLY_WHEN_INTERRUPTED;
-	}
-
-	@ConfigItem(
-		position = 2,
 		keyName = "damageNotificationColor",
 		name = "Damage Notification Color",
 		description = "Color of damage notification text in chat"
@@ -59,7 +49,7 @@ public interface WintertodtConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 3,
+		position = 2,
 		keyName = "roundNotification",
 		name = "Wintertodt round notification",
 		description = "Notifies you before the round starts (in seconds)"
@@ -71,5 +61,71 @@ public interface WintertodtConfig extends Config
 	default int roundNotification()
 	{
 		return 5;
+	}
+
+	@ConfigItem(
+		position = 3,
+		keyName = "notifyCold",
+		name = "Ambient Damage Notification",
+		description = "Notifies when hit by the Wintertodt's ambient cold damage"
+	)
+	default WintertodtNotifyDamage notifyCold()
+	{
+		return WintertodtNotifyDamage.INTERRUPT;
+	}
+
+	@ConfigItem(
+		position = 4,
+		keyName = "notifySnowfall",
+		name = "Snowfall Damage Notification",
+		description = "Notifies when hit by the Wintertodt's snowfall attack"
+	)
+	default WintertodtNotifyDamage notifySnowfall()
+	{
+		return WintertodtNotifyDamage.INTERRUPT;
+	}
+
+	@ConfigItem(
+		position = 5,
+		keyName = "notifyBrazierDamage",
+		name = "Brazier Damage Notification",
+		description = "Notifies when hit by the brazier breaking"
+	)
+	default WintertodtNotifyDamage notifyBrazierDamage()
+	{
+		return WintertodtNotifyDamage.INTERRUPT;
+	}
+
+	@ConfigItem(
+		position = 6,
+		keyName = "notifyFullInv",
+		name = "Full Inventory Notification",
+		description = "Notifies when your inventory fills up with bruma roots"
+	)
+	default boolean notifyFullInv()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		position = 7,
+		keyName = "notifyEmptyInv",
+		name = "Empty Inventory Notification",
+		description = "Notifies when you run out of bruma roots"
+	)
+	default boolean notifyEmptyInv()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		position = 8,
+		keyName = "notifyBrazierOut",
+		name = "Brazier Extinguish Notification",
+		description = "Notifies when the brazier goes out"
+	)
+	default boolean notifyBrazierOut()
+	{
+		return true;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/wintertodt/WintertodtPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/wintertodt/WintertodtPlugin.java
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2018, terminatusx <jbfleischman@gmail.com>
  * Copyright (c) 2018, Adam <Adam@sigterm.info>
+ * Copyright (c) 2020, loldudester <HannahRyanster@gmail.com>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -69,6 +70,9 @@ import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.plugins.wintertodt.config.WintertodtNotifyDamage;
+import static net.runelite.client.plugins.wintertodt.config.WintertodtNotifyDamage.ALWAYS;
+import static net.runelite.client.plugins.wintertodt.config.WintertodtNotifyDamage.INTERRUPT;
 import net.runelite.client.ui.overlay.OverlayManager;
 import net.runelite.client.util.ColorUtil;
 
@@ -290,7 +294,6 @@ public class WintertodtPlugin extends Plugin
 		}
 
 		boolean wasInterrupted = false;
-		boolean wasDamaged = false;
 		boolean neverNotify = false;
 
 		switch (interruptType)
@@ -298,7 +301,6 @@ public class WintertodtPlugin extends Plugin
 			case COLD:
 			case BRAZIER:
 			case SNOWFALL:
-				wasDamaged = true;
 
 				// Recolor message for damage notification
 				messageNode.setRuneLiteFormatMessage(ColorUtil.wrapWithColorTag(messageNode.getValue(), config.damageNotificationColor()));
@@ -327,23 +329,28 @@ public class WintertodtPlugin extends Plugin
 		if (!neverNotify)
 		{
 			boolean shouldNotify = false;
-
-			switch (config.notifyCondition())
+			switch (interruptType)
 			{
-				case ONLY_WHEN_INTERRUPTED:
-					if (wasInterrupted)
-					{
-						shouldNotify = true;
-					}
+				case COLD:
+					WintertodtNotifyDamage notify = config.notifyCold();
+					shouldNotify = notify == ALWAYS || (notify == INTERRUPT && wasInterrupted);
 					break;
-				case WHEN_DAMAGED:
-					if (wasDamaged)
-					{
-						shouldNotify = true;
-					}
+				case SNOWFALL:
+					notify = config.notifySnowfall();
+					shouldNotify = notify == ALWAYS || (notify == INTERRUPT && wasInterrupted);
 					break;
-				case EITHER:
-					shouldNotify = true;
+				case BRAZIER:
+					notify = config.notifyBrazierDamage();
+					shouldNotify = notify == ALWAYS || (notify == INTERRUPT && wasInterrupted);
+					break;
+				case INVENTORY_FULL:
+					shouldNotify = config.notifyFullInv();
+					break;
+				case OUT_OF_ROOTS:
+					shouldNotify = config.notifyEmptyInv();
+					break;
+				case BRAZIER_WENT_OUT:
+					shouldNotify = config.notifyBrazierOut();
 					break;
 			}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/wintertodt/config/WintertodtNotifyDamage.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/wintertodt/config/WintertodtNotifyDamage.java
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) 2018, terminatusx <jbfleischman@gmail.com>
- * Copyright (c) 2018, Adam <Adam@sigterm.info>
+ * Copyright (c) 2020, loldudester <HannahRyanster@gmail.com>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -30,12 +29,11 @@ import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
-public enum WintertodtNotifyMode
+public enum WintertodtNotifyDamage
 {
-	NONE("None"),
-	WHEN_DAMAGED("Damage Taken"),
-	ONLY_WHEN_INTERRUPTED("Action Interrupted"),
-	EITHER("Either");
+	OFF("Off"),
+	INTERRUPT("On Interrupt"),
+	ALWAYS("Always");
 
 	private final String name;
 


### PR DESCRIPTION
I've separated the notification options for the different Wintertodt events, as well as making the damage event notifications a choice between always notifying, and only notifying on interrupts (which now check for idle as well as woodcutting).

![java_kgmKnU4PWo](https://user-images.githubusercontent.com/7504779/73129369-eb847100-3fd9-11ea-9561-5b06666ba5a3.png)

Supersedes #10535