### PR TITLE
Add Unit support to Config

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/config/ConfigManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/ConfigManager.java
@@ -455,7 +455,8 @@ public class ConfigManager
 				m.getDeclaredAnnotation(ConfigItem.class),
 				m.getReturnType(),
 				m.getDeclaredAnnotation(Range.class),
-				m.getDeclaredAnnotation(Alpha.class)
+				m.getDeclaredAnnotation(Alpha.class),
+				m.getDeclaredAnnotation(Units.class)
 			))
 			.sorted((a, b) -> ComparisonChain.start()
 				.compare(a.getItem().position(), b.getItem().position())

--- a/runelite-client/src/main/java/net/runelite/client/config/RuneLiteConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/RuneLiteConfig.java
@@ -268,10 +268,11 @@ public interface RuneLiteConfig extends Config
 
 	@ConfigItem(
 		keyName = "infoBoxSize",
-		name = "Infobox size (px)",
+		name = "Infobox size",
 		description = "Configures the size of each infobox in pixels",
 		position = 42
 	)
+	@Units(Units.PIXELS)
 	default int infoBoxSize()
 	{
 		return 35;

--- a/runelite-client/src/main/java/net/runelite/client/config/Units.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/Units.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Adam <Adam@sigterm.info>
+ * Copyright (c) 2020, Hydrox6 <ikada@protonmail.ch>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -24,14 +24,26 @@
  */
 package net.runelite.client.config;
 
-import lombok.Value;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
-@Value
-public class ConfigItemDescriptor
+/**
+ * Used with ConfigItem, defines what units are shown to the side of the box.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+@Documented
+public @interface Units
 {
-	private final ConfigItem item;
-	private final Class<?> type;
-	private final Range range;
-	private final Alpha alpha;
-	private final Units units;
+	String MILLISECONDS = "ms";
+	String MINUTES = " mins";
+	String PERCENT = "%";
+	String PIXELS = "px";
+	String SECONDS = "s";
+	String TICKS = " ticks";
+
+	String value();
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/agility/AgilityConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/agility/AgilityConfig.java
@@ -28,6 +28,7 @@ import java.awt.Color;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.Units;
 
 @ConfigGroup("agility")
 public interface AgilityConfig extends Config
@@ -56,10 +57,11 @@ public interface AgilityConfig extends Config
 
 	@ConfigItem(
 		keyName = "lapTimeout",
-		name = "Hide Lap Count (minutes)",
+		name = "Hide Lap Count",
 		description = "Time until the lap counter hides/resets",
 		position = 2
 	)
+	@Units(Units.MINUTES)
 	default int lapTimeout()
 	{
 		return 5;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
@@ -36,6 +36,7 @@ import java.awt.event.ItemEvent;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.awt.image.BufferedImage;
+import java.text.DecimalFormat;
 import javax.inject.Inject;
 import javax.swing.BorderFactory;
 import javax.swing.ImageIcon;
@@ -66,6 +67,7 @@ import net.runelite.client.config.ConfigManager;
 import net.runelite.client.config.Keybind;
 import net.runelite.client.config.ModifierlessKeybind;
 import net.runelite.client.config.Range;
+import net.runelite.client.config.Units;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.events.ExternalPluginsChanged;
 import net.runelite.client.events.PluginChanged;
@@ -255,6 +257,16 @@ class ConfigPanel extends PluginPanel
 				JFormattedTextField spinnerTextField = ((JSpinner.DefaultEditor) editor).getTextField();
 				spinnerTextField.setColumns(SPINNER_FIELD_WIDTH);
 				spinner.addChangeListener(ce -> changeConfiguration(spinner, cd, cid));
+
+				Units units = cid.getUnits();
+				if (units != null)
+				{
+					DecimalFormat df = ((JSpinner.NumberEditor) spinner.getEditor()).getFormat();
+					df.setPositiveSuffix(units.value());
+					df.setNegativeSuffix(units.value());
+					// Force update the spinner to have it add the units initially
+					spinnerTextField.setValue(value);
+				}
 
 				item.add(spinner, BorderLayout.EAST);
 			}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cooking/CookingConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cooking/CookingConfig.java
@@ -28,6 +28,7 @@ package net.runelite.client.plugins.cooking;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.Units;
 
 @ConfigGroup("cooking")
 public interface CookingConfig extends Config
@@ -35,9 +36,10 @@ public interface CookingConfig extends Config
 	@ConfigItem(
 		position = 1,
 		keyName = "statTimeout",
-		name = "Reset stats (minutes)",
+		name = "Reset stats",
 		description = "Configures the time until the session resets and the overlay is hidden (0 = Disable feature)"
 	)
+	@Units(Units.MINUTES)
 	default int statTimeout()
 	{
 		return 5;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordConfig.java
@@ -27,16 +27,18 @@ package net.runelite.client.plugins.discord;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.Units;
 
 @ConfigGroup("discord")
 public interface DiscordConfig extends Config
 {
 	@ConfigItem(
 		keyName = "actionTimeout",
-		name = "Action timeout (minutes)",
+		name = "Action timeout",
 		description = "Configures after how long of not updating status will be reset (in minutes)",
 		position = 1
 	)
+	@Units(Units.MINUTES)
 	default int actionTimeout()
 	{
 		return 5;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/experiencedrop/XpDropConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/experiencedrop/XpDropConfig.java
@@ -28,6 +28,7 @@ import java.awt.Color;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.Units;
 
 @ConfigGroup("xpdrop")
 public interface XpDropConfig extends Config
@@ -82,6 +83,7 @@ public interface XpDropConfig extends Config
 		description = "Configures how many ticks should pass between fake XP drops, 0 to disable",
 		position = 4
 	)
+	@Units(Units.TICKS)
 	default int fakeXpDropDelay()
 	{
 		return 0;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingConfig.java
@@ -28,6 +28,7 @@ import java.awt.Color;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.Units;
 
 @ConfigGroup("fishing")
 public interface FishingConfig extends Config
@@ -112,9 +113,10 @@ public interface FishingConfig extends Config
 	@ConfigItem(
 		position = 7,
 		keyName = "statTimeout",
-		name = "Reset stats (minutes)",
+		name = "Reset stats",
 		description = "The time until fishing session data is reset in minutes."
 	)
+	@Units(Units.MINUTES)
 	default int statTimeout()
 	{
 		return 5;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
@@ -29,6 +29,7 @@ import java.awt.Color;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.Units;
 import net.runelite.client.plugins.grounditems.config.ItemHighlightMode;
 import net.runelite.client.plugins.grounditems.config.MenuHighlightMode;
 import net.runelite.client.plugins.grounditems.config.PriceDisplayMode;
@@ -343,6 +344,7 @@ public interface GroundItemsConfig extends Config
 		description = "Decrease this number if you accidentally hide ground items often. (0 = Disabled)",
 		position = 26
 	)
+	@Units(Units.MILLISECONDS)
 	default int doubleTapDelay()
 	{
 		return 250;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierConfig.java
@@ -27,6 +27,7 @@ package net.runelite.client.plugins.idlenotifier;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.Units;
 
 @ConfigGroup("idlenotifier")
 public interface IdleNotifierConfig extends Config
@@ -77,10 +78,11 @@ public interface IdleNotifierConfig extends Config
 
 	@ConfigItem(
 		keyName = "timeout",
-		name = "Idle Notification Delay (ms)",
+		name = "Idle Notification Delay",
 		description = "The notification delay after the player is idle",
 		position = 5
 	)
+	@Units(Units.MILLISECONDS)
 	default int getIdleNotificationDelay()
 	{
 		return 5000;
@@ -114,6 +116,7 @@ public interface IdleNotifierConfig extends Config
 		position = 8,
 		description = "The amount of remaining oxygen to send a notification at. A value of 0 will disable notification."
 	)
+	@Units(Units.PERCENT)
 	default int getOxygenThreshold()
 	{
 		return 0;
@@ -125,6 +128,7 @@ public interface IdleNotifierConfig extends Config
 		position = 9,
 		description = "The amount of spec energy reached to send a notification at. A value of 0 will disable notification."
 	)
+	@Units(Units.PERCENT)
 	default int getSpecEnergyThreshold()
 	{
 		return 0;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/motherlode/MotherlodeConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/motherlode/MotherlodeConfig.java
@@ -28,6 +28,7 @@ package net.runelite.client.plugins.motherlode;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.Units;
 
 @ConfigGroup("motherlode")
 public interface MotherlodeConfig extends Config
@@ -54,9 +55,10 @@ public interface MotherlodeConfig extends Config
 
 	@ConfigItem(
 		keyName = "statTimeout",
-		name = "Reset stats (minutes)",
+		name = "Reset stats",
 		description = "Configures the time until statistics are reset"
 	)
+	@Units(Units.MINUTES)
 	default int statTimeout()
 	{
 		return 5;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/regenmeter/RegenMeterConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/regenmeter/RegenMeterConfig.java
@@ -27,6 +27,7 @@ package net.runelite.client.plugins.regenmeter;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.Units;
 
 @ConfigGroup("regenmeter")
 public interface RegenMeterConfig extends Config
@@ -60,9 +61,10 @@ public interface RegenMeterConfig extends Config
 
 	@ConfigItem(
 		keyName = "notifyBeforeHpRegenDuration",
-		name = "Hitpoint Regen Notification (seconds)",
+		name = "Hitpoint Regen Notification",
 		description = "Notify approximately when your next hitpoint is about to regen. A value of 0 will disable notification."
 	)
+	@Units(Units.SECONDS)
 	default int getNotifyBeforeHpRegenSeconds()
 	{
 		return 0;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerConfig.java
@@ -29,6 +29,7 @@ import java.awt.Color;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.Units;
 
 @ConfigGroup("slayer")
 public interface SlayerConfig extends Config
@@ -69,9 +70,10 @@ public interface SlayerConfig extends Config
 	@ConfigItem(
 		position = 4,
 		keyName = "statTimeout",
-		name = "InfoBox Expiry (minutes)",
+		name = "InfoBox Expiry",
 		description = "Set the time until the InfoBox expires"
 	)
+	@Units(Units.MINUTES)
 	default int statTimeout()
 	{
 		return 5;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/smelting/SmeltingConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/smelting/SmeltingConfig.java
@@ -27,6 +27,7 @@ package net.runelite.client.plugins.smelting;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.Units;
 
 @ConfigGroup("smelting")
 public interface SmeltingConfig extends Config
@@ -34,9 +35,10 @@ public interface SmeltingConfig extends Config
 	@ConfigItem(
 		position = 1,
 		keyName = "statTimeout",
-		name = "Reset stats (minutes)",
+		name = "Reset stats",
 		description = "The time it takes for the current smelting session to be reset"
 	)
+	@Units(Units.MINUTES)
 	default int statTimeout()
 	{
 		return 5;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/stretchedmode/StretchedModeConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/stretchedmode/StretchedModeConfig.java
@@ -28,6 +28,7 @@ package net.runelite.client.plugins.stretchedmode;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.Units;
 
 @ConfigGroup("stretchedmode")
 public interface StretchedModeConfig extends Config
@@ -64,9 +65,10 @@ public interface StretchedModeConfig extends Config
 
 	@ConfigItem(
 		keyName = "scalingFactor",
-		name = "Resizable Scaling (%)",
+		name = "Resizable Scaling",
 		description = "In resizable mode, the game is reduced in size this much before it's stretched."
 	)
+	@Units(Units.PERCENT)
 	default int scalingFactor()
 	{
 		return 50;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/TimeTrackingConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/TimeTrackingConfig.java
@@ -27,6 +27,7 @@ package net.runelite.client.plugins.timetracking;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.Units;
 
 @ConfigGroup("timetracking")
 public interface TimeTrackingConfig extends Config
@@ -72,10 +73,11 @@ public interface TimeTrackingConfig extends Config
 
 	@ConfigItem(
 		keyName = "defaultTimerMinutes",
-		name = "Default Time (Minutes)",
+		name = "Default Time",
 		description = "The default time for the timer in minutes",
 		position = 4
 	)
+	@Units(Units.MINUTES)
 	default int defaultTimerMinutes()
 	{
 		return 5;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/wintertodt/WintertodtConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/wintertodt/WintertodtConfig.java
@@ -30,6 +30,7 @@ import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
 import net.runelite.client.config.Range;
+import net.runelite.client.config.Units;
 import net.runelite.client.plugins.wintertodt.config.WintertodtNotifyMode;
 
 @ConfigGroup("wintertodt")
@@ -66,6 +67,7 @@ public interface WintertodtConfig extends Config
 	@Range(
 		max = 60
 	)
+	@Units(Units.SECONDS)
 	default int roundNotification()
 	{
 		return 5;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingConfig.java
@@ -27,6 +27,7 @@ package net.runelite.client.plugins.woodcutting;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.Units;
 
 @ConfigGroup("woodcutting")
 public interface WoodcuttingConfig extends Config
@@ -34,9 +35,10 @@ public interface WoodcuttingConfig extends Config
 	@ConfigItem(
 		position = 1,
 		keyName = "statTimeout",
-		name = "Reset stats (minutes)",
+		name = "Reset stats",
 		description = "Configures the time until statistic is reset. Also configures when tree indicator is hidden"
 	)
+	@Units(Units.MINUTES)
 	default int statTimeout()
 	{
 		return 5;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesConfig.java
@@ -29,6 +29,7 @@ import net.runelite.client.config.Alpha;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.Units;
 
 @ConfigGroup("xpglobes")
 public interface XpGlobesConfig extends Config
@@ -141,6 +142,7 @@ public interface XpGlobesConfig extends Config
 		description = "Change the stroke width of the progress arc",
 		position = 9
 	)
+	@Units(Units.PIXELS)
 	default int progressArcStrokeWidth()
 	{
 		return 2;
@@ -152,6 +154,7 @@ public interface XpGlobesConfig extends Config
 		description = "Change the size of the xp orbs",
 		position = 10
 	)
+	@Units(Units.PIXELS)
 	default int xpOrbSize()
 	{
 		return 40;
@@ -163,6 +166,7 @@ public interface XpGlobesConfig extends Config
 		description = "Change the duration the xp orbs are visible",
 		position = 11
 	)
+	@Units(Units.SECONDS)
 	default int xpOrbDuration()
 	{
 		return 10;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerConfig.java
@@ -28,6 +28,7 @@ import lombok.AllArgsConstructor;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.Units;
 
 @ConfigGroup("xpTracker")
 public interface XpTrackerConfig extends Config
@@ -87,6 +88,7 @@ public interface XpTrackerConfig extends Config
 		name = "Auto pause after",
 		description = "Configures how many minutes passes before pausing a skill while in game and there's no XP, 0 means disabled"
 	)
+	@Units(Units.MINUTES)
 	default int pauseSkillAfter()
 	{
 		return 0;


### PR DESCRIPTION
Adds an annotation (like `@Range`) to specify the units to be displayed in the box. This should lessen confusion on certain config items that have their units hidden by length or by being in the tooltip.
![image](https://user-images.githubusercontent.com/2979691/73141622-08728000-407e-11ea-97a3-8da1675a8b34.png)
![image](https://user-images.githubusercontent.com/2979691/73141626-11635180-407e-11ea-80c6-970115a5a62b.png)
