### PR TITLE
cluescroll plugin: Clear stale location clue hint arrows 

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/ClueScrollPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/ClueScrollPlugin.java
@@ -396,14 +396,17 @@ public class ClueScrollPlugin extends Plugin
 		if (clue instanceof LocationClueScroll)
 		{
 			final WorldPoint[] locations = ((LocationClueScroll) clue).getLocations();
+			final boolean npcHintArrowMarked = client.getHintArrowNpc() != null && npcsToMark.contains(client.getHintArrowNpc());
+
+			if (!npcHintArrowMarked)
+			{
+				client.clearHintArrow();
+			}
 
 			for (WorldPoint location : locations)
 			{
 				// Only set the location hint arrow if we do not already have more accurate location
-				if (location.isInScene(client)
-					&& config.displayHintArrows()
-					&& (client.getHintArrowNpc() == null
-					|| !npcsToMark.contains(client.getHintArrowNpc())))
+				if (location.isInScene(client) && config.displayHintArrows() && !npcHintArrowMarked)
 				{
 					client.setHintArrow(location);
 				}


### PR DESCRIPTION
Location clue scrolls added a hint arrow when the player was nearby one
of the clue's locations. It did not, however clear that arrow if the
locations were changed and the previously-set hint arrow location was no
longer marked. This commit updates this behavior to clear the active
hint arrow should that be the case. (and if no NPC hint arrows are set)

Fixes runelite/runelite#10370