### PR TITLE
Update Task.java: Fix the Lizard Slayer overlay

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/Task.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/Task.java
@@ -123,7 +123,7 @@ enum Task
 	KURASK("Kurask", ItemID.KURASK),
 	ROGUES("Rogues", ItemID.ROGUE_MASK, "Rogue"),
 	LESSER_DEMONS("Lesser demons", ItemID.LESSER_DEMON_MASK),
-	LIZARDS("Lizards", ItemID.DESERT_LIZARD, "Desert lizard", "Sulphur lizard", "Small lizard", "Lizard"),
+	LIZARDS("Lizards", ItemID.DESERT_LIZARD, 4, ItemID.ICE_COOLER, "Desert lizard", "Small lizard", "Lizard"),
 	LIZARDMEN("Lizardmen", ItemID.LIZARDMAN_FANG, "Lizardman"),
 	MINIONS_OF_SCABARAS("Minions of scabaras", ItemID.GOLDEN_SCARAB, "Scarab swarm", "Locust rider", "Scarab mage"),
 	MINOTAURS("Minotaurs", ItemID.ENSOULED_MINOTAUR_HEAD),


### PR DESCRIPTION
Added the ice cooler item overlay to the lizards weakness. Sulphur lizard has been remove from the list because it is already present in the task list (further down) and is NOT vulnerable to ice cooler.

Related to Issue [#10646](https://github.com/runelite/runelite/issues/10646)