### PR TITLE
Add support for left-click gem mine with Karamja Gloves with Menu Swapper

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -723,6 +723,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 		{
 			swap("rub", option, target, index);
 			swap("teleport", option, target, index);
+			swap("gem mine", option, target, index);
 		}
 		else if (option.equals("wield"))
 		{


### PR DESCRIPTION
Right now Menu Entry Swapper "Teleport Item" doesn't allow left-clicking on the Karamja gloves for quick trips to the Gem Mine. This change will add this function to the gloves.