### PR TITLE
widgetid: fix LMS INFO

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/widgets/WidgetID.java
+++ b/runelite-api/src/main/java/net/runelite/api/widgets/WidgetID.java
@@ -857,7 +857,7 @@ public class WidgetID
 
 	static class Lms
 	{
-		static final int INFO = 2;
+		static final int INFO = 3;
 	}
 
 	static class LmsKDA


### PR DESCRIPTION
Fixes an issue reported in discord. Child 2 is a layer for LMS.

https://gyazo.com/5042fd2149e1575454fad7c4fbe129f3
![java_1AEjXA8o6e](https://user-images.githubusercontent.com/22979513/73378071-aa17ee00-4285-11ea-9b77-6c998e8802a2.png)
