### PR TITLE
item prices plugin: added hover to show inventory/equipment total GE value

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/bank/BankPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/bank/BankPlugin.java
@@ -174,7 +174,7 @@ public class BankPlugin extends Plugin
 		switch (event.getEventName())
 		{
 			case "setBankTitle":
-				final ContainerPrices prices = bankCalculation.calculate(getBankTabItems());
+				final ContainerPrices prices = bankCalculation.calculate(getBankTabItems(), false);
 				if (prices == null)
 				{
 					return;
@@ -312,7 +312,7 @@ public class BankPlugin extends Plugin
 			return;
 		}
 
-		final ContainerPrices prices = seedVaultCalculation.calculate(getSeedVaultItems());
+		final ContainerPrices prices = seedVaultCalculation.calculate(getSeedVaultItems(), false);
 		if (prices == null)
 		{
 			return;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/bank/ContainerPrices.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/bank/ContainerPrices.java
@@ -27,7 +27,7 @@ package net.runelite.client.plugins.bank;
 import lombok.Value;
 
 @Value
-class ContainerPrices
+public class ContainerPrices
 {
 	private long gePrice;
 	private long highAlchPrice;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemprices/ItemPricesConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemprices/ItemPricesConfig.java
@@ -32,10 +32,10 @@ import net.runelite.client.config.ConfigItem;
 public interface ItemPricesConfig extends Config
 {
 	@ConfigItem(
-		keyName = "showGEPrice",
-		name = "Show Grand Exchange Prices",
-		description = "Grand exchange prices should be shown on tooltips",
-		position = 1
+			keyName = "showGEPrice",
+			name = "Show Grand Exchange Prices",
+			description = "Grand exchange prices should be shown on tooltips",
+			position = 1
 	)
 	default boolean showGEPrice()
 	{
@@ -43,10 +43,10 @@ public interface ItemPricesConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "showHAValue",
-		name = "Show High Alchemy Values",
-		description = "High Alchemy values should be shown on tooltips",
-		position = 2
+			keyName = "showHAValue",
+			name = "Show High Alchemy Values",
+			description = "High Alchemy values should be shown on tooltips",
+			position = 2
 	)
 	default boolean showHAValue()
 	{
@@ -54,43 +54,50 @@ public interface ItemPricesConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "showEA",
-		name = "Show Price Each on Stacks",
-		description = "The price/value of each item should be shown on stacks",
-		position = 3
+			keyName = "showInventoryTotalValue",
+			name = "Show Inventory Total GE Value",
+			description = "Hovering over inventory icon will show total GE value",
+			position = 3
 	)
-	default boolean showEA()
-	{
-		return true;
-	}
+	default boolean showInventoryTotalValue() { return true; }
 
 	@ConfigItem(
-		keyName = "hideInventory",
-		name = "Hide Tooltips on Inventory Items",
-		description = "Tooltips should be hidden on items in the inventory",
-		position = 4
+			keyName = "showEquipmentTotalValue",
+			name = "Show Equipment Total GE Value",
+			description = "Hovering over equipment icon will show total GE value",
+			position = 4
 	)
-	default boolean hideInventory()
-	{
-		return true;
-	}
+	default boolean showEquipmentTotalValue() { return true; }
 
 	@ConfigItem(
-		keyName = "showAlchProfit",
-		name = "Show High Alchemy Profit",
-		description = "Show the profit from casting high alchemy on items",
-		position = 5
+			keyName = "showEA",
+			name = "Show Price Each on Stacks",
+			description = "The price/value of each item should be shown on stacks",
+			position = 5
 	)
-	default boolean showAlchProfit()
-	{
-		return false;
-	}
+	default boolean showEA() { return true; }
 
 	@ConfigItem(
-		keyName = "showWhileAlching",
-		name = "Show prices while alching",
-		description = "Show the price overlay while using High Alchemy",
-		position = 6
+			keyName = "hideInventory",
+			name = "Hide Tooltips on Inventory Items",
+			description = "Tooltips should be hidden on items in the inventory",
+			position = 6
+	)
+	default boolean hideInventory() { return true; }
+
+	@ConfigItem(
+			keyName = "showAlchProfit",
+			name = "Show High Alchemy Profit",
+			description = "Show the profit from casting high alchemy on items",
+			position = 7
+	)
+	default boolean showAlchProfit() { return false; }
+
+	@ConfigItem(
+			keyName = "showWhileAlching",
+			name = "Show prices while alching",
+			description = "Show the price overlay while using High Alchemy",
+			position = 8
 	)
 	default boolean showWhileAlching()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemprices/ItemPricesConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemprices/ItemPricesConfig.java
@@ -32,10 +32,10 @@ import net.runelite.client.config.ConfigItem;
 public interface ItemPricesConfig extends Config
 {
 	@ConfigItem(
-			keyName = "showGEPrice",
-			name = "Show Grand Exchange Prices",
-			description = "Grand exchange prices should be shown on tooltips",
-			position = 1
+		keyName = "showGEPrice",
+		name = "Show Grand Exchange Prices",
+		description = "Grand exchange prices should be shown on tooltips",
+		position = 1
 	)
 	default boolean showGEPrice()
 	{
@@ -43,10 +43,10 @@ public interface ItemPricesConfig extends Config
 	}
 
 	@ConfigItem(
-			keyName = "showHAValue",
-			name = "Show High Alchemy Values",
-			description = "High Alchemy values should be shown on tooltips",
-			position = 2
+		keyName = "showHAValue",
+		name = "Show High Alchemy Values",
+		description = "High Alchemy values should be shown on tooltips",
+		position = 2
 	)
 	default boolean showHAValue()
 	{
@@ -54,50 +54,50 @@ public interface ItemPricesConfig extends Config
 	}
 
 	@ConfigItem(
-			keyName = "showInventoryTotalValue",
-			name = "Show Inventory Total GE Value",
-			description = "Hovering over inventory icon will show total GE value",
-			position = 3
+		keyName = "showInventoryTotalValue",
+		name = "Show Inventory Total GE Value",
+		description = "Hovering over inventory icon will show total GE value",
+		position = 3
 	)
 	default boolean showInventoryTotalValue() { return true; }
 
 	@ConfigItem(
-			keyName = "showEquipmentTotalValue",
-			name = "Show Equipment Total GE Value",
-			description = "Hovering over equipment icon will show total GE value",
-			position = 4
+		keyName = "showEquipmentTotalValue",
+		name = "Show Equipment Total GE Value",
+		description = "Hovering over equipment icon will show total GE value",
+		position = 4
 	)
 	default boolean showEquipmentTotalValue() { return true; }
 
 	@ConfigItem(
-			keyName = "showEA",
-			name = "Show Price Each on Stacks",
-			description = "The price/value of each item should be shown on stacks",
-			position = 5
+		keyName = "showEA",
+		name = "Show Price Each on Stacks",
+		description = "The price/value of each item should be shown on stacks",
+		position = 5
 	)
 	default boolean showEA() { return true; }
 
 	@ConfigItem(
-			keyName = "hideInventory",
-			name = "Hide Tooltips on Inventory Items",
-			description = "Tooltips should be hidden on items in the inventory",
-			position = 6
+		keyName = "hideInventory",
+		name = "Hide Tooltips on Inventory Items",
+		description = "Tooltips should be hidden on items in the inventory",
+		position = 6
 	)
 	default boolean hideInventory() { return true; }
 
 	@ConfigItem(
-			keyName = "showAlchProfit",
-			name = "Show High Alchemy Profit",
-			description = "Show the profit from casting high alchemy on items",
-			position = 7
+		keyName = "showAlchProfit",
+		name = "Show High Alchemy Profit",
+		description = "Show the profit from casting high alchemy on items",
+		position = 7
 	)
 	default boolean showAlchProfit() { return false; }
 
 	@ConfigItem(
-			keyName = "showWhileAlching",
-			name = "Show prices while alching",
-			description = "Show the price overlay while using High Alchemy",
-			position = 8
+		keyName = "showWhileAlching",
+		name = "Show prices while alching",
+		description = "Show the price overlay while using High Alchemy",
+		position = 8
 	)
 	default boolean showWhileAlching()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemprices/ItemPricesConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemprices/ItemPricesConfig.java
@@ -59,7 +59,10 @@ public interface ItemPricesConfig extends Config
 		description = "Hovering over inventory icon will show total GE value",
 		position = 3
 	)
-	default boolean showInventoryTotalValue() { return true; }
+	default boolean showInventoryTotalValue()
+	{
+		return true;
+	}
 
 	@ConfigItem(
 		keyName = "showEquipmentTotalValue",
@@ -67,7 +70,10 @@ public interface ItemPricesConfig extends Config
 		description = "Hovering over equipment icon will show total GE value",
 		position = 4
 	)
-	default boolean showEquipmentTotalValue() { return true; }
+	default boolean showEquipmentTotalValue()
+	{
+		return true;
+	}
 
 	@ConfigItem(
 		keyName = "showEA",
@@ -75,7 +81,10 @@ public interface ItemPricesConfig extends Config
 		description = "The price/value of each item should be shown on stacks",
 		position = 5
 	)
-	default boolean showEA() { return true; }
+	default boolean showEA()
+	{
+		return true;
+	}
 
 	@ConfigItem(
 		keyName = "hideInventory",
@@ -83,7 +92,10 @@ public interface ItemPricesConfig extends Config
 		description = "Tooltips should be hidden on items in the inventory",
 		position = 6
 	)
-	default boolean hideInventory() { return true; }
+	default boolean hideInventory()
+	{
+		return true;
+	}
 
 	@ConfigItem(
 		keyName = "showAlchProfit",
@@ -91,7 +103,10 @@ public interface ItemPricesConfig extends Config
 		description = "Show the profit from casting high alchemy on items",
 		position = 7
 	)
-	default boolean showAlchProfit() { return false; }
+	default boolean showAlchProfit()
+	{
+		return false;
+	}
 
 	@ConfigItem(
 		keyName = "showWhileAlching",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemprices/ItemPricesOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemprices/ItemPricesOverlay.java
@@ -40,6 +40,8 @@ import net.runelite.api.MenuEntry;
 import net.runelite.api.widgets.WidgetID;
 import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.game.ItemManager;
+import net.runelite.client.plugins.bank.ContainerCalculation;
+import net.runelite.client.plugins.bank.ContainerPrices;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.tooltip.Tooltip;
@@ -64,6 +66,9 @@ class ItemPricesOverlay extends Overlay
 	private final ItemPricesConfig config;
 	private final TooltipManager tooltipManager;
 	private final StringBuilder itemStringBuilder = new StringBuilder();
+
+	@Inject
+	private ContainerCalculation containerCalculation;
 
 	@Inject
 	ItemManager itemManager;
@@ -177,43 +182,9 @@ class ItemPricesOverlay extends Overlay
 		}
 
 		Item[] items = container.getItems();
+		ContainerPrices prices = containerCalculation.calculate(items, true);
 
-		int id, qty = 0;
-		long total = 0;
-
-		for (Item item : items)
-		{
-			id = item.getId();
-			qty = item.getQuantity();
-
-			if (id == ItemID.COINS_995)
-			{
-				total += qty;
-				continue;
-			}
-			else if (id == ItemID.PLATINUM_TOKEN)
-			{
-				total += qty * 1000;
-				continue;
-			}
-
-			ItemComposition itemDef = itemManager.getItemComposition(id);
-			if (itemDef.getNote() != -1)
-			{
-				id = itemDef.getLinkedNoteId();
-				itemDef = itemManager.getItemComposition(id);
-			}
-
-			// Only check prices for things with store prices
-			if (itemDef.getPrice() <= 0)
-			{
-				continue;
-			}
-
-			total += (long) itemManager.getItemPrice(id) * qty;
-		}
-
-		return QuantityFormatter.quantityToStackSize(total);
+		return QuantityFormatter.quantityToStackSize(prices.getGePrice());
 	}
 
 	private String makeValueTooltip(MenuEntry menuEntry)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemprices/ItemPricesOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemprices/ItemPricesOverlay.java
@@ -37,7 +37,6 @@ import net.runelite.api.ItemContainer;
 import net.runelite.api.ItemID;
 import net.runelite.api.MenuAction;
 import net.runelite.api.MenuEntry;
-import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetID;
 import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.game.ItemManager;
@@ -98,6 +97,7 @@ class ItemPricesOverlay extends Overlay
 		final MenuAction action = MenuAction.of(menuEntry.getType());
 		final int widgetId = menuEntry.getParam1();
 		final int groupId = WidgetInfo.TO_GROUP(widgetId);
+
 		// Tooltip action type handling
 		switch (action)
 		{
@@ -160,7 +160,7 @@ class ItemPricesOverlay extends Overlay
 						final String text = makeValueTooltip(menuEntry);
 						if (text != null)
 						{
-							tooltipManager.add(new Tooltip(ColorUtil.wrapWithColorTag(text, new Color(238, 238, 238))));
+							tooltipManager.add(new Tooltip(ColorUtil.prependColorTag(text, new Color(238, 238, 238))));
 						}
 						break;
 				}
@@ -208,11 +208,6 @@ class ItemPricesOverlay extends Overlay
 			}
 
 			total += (long) itemManager.getItemPrice(id) * qty;
-		}
-
-		if (total < 1000)
-		{
-			return String.valueOf(total);
 		}
 
 		return QuantityFormatter.quantityToStackSize(total);
@@ -316,13 +311,13 @@ class ItemPricesOverlay extends Overlay
 		if (gePrice > 0)
 		{
 			itemStringBuilder.append("EX: ")
-					.append(QuantityFormatter.quantityToStackSize((long) gePrice * qty))
-					.append(" gp");
+				.append(QuantityFormatter.quantityToStackSize((long) gePrice * qty))
+				.append(" gp");
 			if (config.showEA() && qty > 1)
 			{
 				itemStringBuilder.append(" (")
-						.append(QuantityFormatter.quantityToStackSize(gePrice))
-						.append(" ea)");
+					.append(QuantityFormatter.quantityToStackSize(gePrice))
+					.append(" ea)");
 			}
 		}
 		if (haValue > 0)
@@ -333,13 +328,13 @@ class ItemPricesOverlay extends Overlay
 			}
 
 			itemStringBuilder.append("HA: ")
-					.append(QuantityFormatter.quantityToStackSize((long) haValue * qty))
-					.append(" gp");
+				.append(QuantityFormatter.quantityToStackSize((long) haValue * qty))
+				.append(" gp");
 			if (config.showEA() && qty > 1)
 			{
 				itemStringBuilder.append(" (")
-						.append(QuantityFormatter.quantityToStackSize(haValue))
-						.append(" ea)");
+					.append(QuantityFormatter.quantityToStackSize(haValue))
+					.append(" ea)");
 			}
 		}
 
@@ -349,13 +344,13 @@ class ItemPricesOverlay extends Overlay
 
 			itemStringBuilder.append("</br>");
 			itemStringBuilder.append("HA Profit: ")
-					.append(ColorUtil.wrapWithColorTag(String.valueOf((long) haProfit * qty), haColor))
-					.append(" gp");
+				.append(ColorUtil.wrapWithColorTag(String.valueOf((long) haProfit * qty), haColor))
+				.append(" gp");
 			if (config.showEA() && qty > 1)
 			{
 				itemStringBuilder.append(" (")
-						.append(ColorUtil.wrapWithColorTag(String.valueOf(haProfit), haColor))
-						.append(" ea)");
+					.append(ColorUtil.wrapWithColorTag(String.valueOf(haProfit), haColor))
+					.append(" ea)");
 			}
 		}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemprices/ItemPricesOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemprices/ItemPricesOverlay.java
@@ -128,15 +128,15 @@ class ItemPricesOverlay extends Overlay
 
 						if (config.showInventoryTotalValue() &&
 								(widgetId == RESIZABLE_INVENTORY_TAB_WIDGETID ||
-								 widgetId == FIXED_INVENTORY_TAB_WIDGETID ||
-								 widgetId == RESIZABLE_BOTTOM_LINE_INVENTORY_TAB_WIDGETID))
+								widgetId == FIXED_INVENTORY_TAB_WIDGETID ||
+								widgetId == RESIZABLE_BOTTOM_LINE_INVENTORY_TAB_WIDGETID))
 						{
 							container = client.getItemContainer(InventoryID.INVENTORY);
 						}
 						else if (config.showEquipmentTotalValue() &&
 								(widgetId == RESIZABLE_EQUIPMENT_TAB_WIDGETID ||
-								 widgetId == FIXED_EQUIPMENT_TAB_WIDGETID ||
-								 widgetId == RESIZABLE_BOTTOM_LINE_EQUIPMENT_TAB_WIDGETID))
+								widgetId == FIXED_EQUIPMENT_TAB_WIDGETID ||
+								widgetId == RESIZABLE_BOTTOM_LINE_EQUIPMENT_TAB_WIDGETID))
 						{
 							container = client.getItemContainer(InventoryID.EQUIPMENT);
 						}
@@ -169,7 +169,8 @@ class ItemPricesOverlay extends Overlay
 		return null;
 	}
 
-	private String makeTotalValueTooltip(ItemContainer container) {
+	private String makeTotalValueTooltip(ItemContainer container)
+	{
 		if (container == null)
 		{
 			return "0";
@@ -180,7 +181,8 @@ class ItemPricesOverlay extends Overlay
 		int id, qty = 0;
 		long total = 0;
 
-		for (Item item : items) {
+		for (Item item : items)
+		{
 			id = item.getId();
 			qty = item.getQuantity();
 
@@ -188,7 +190,8 @@ class ItemPricesOverlay extends Overlay
 			{
 				total += qty;
 				continue;
-			} else if (id == ItemID.PLATINUM_TOKEN)
+			}
+			else if (id == ItemID.PLATINUM_TOKEN)
 			{
 				total += qty * 1000;
 				continue;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemprices/ItemPricesOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemprices/ItemPricesOverlay.java
@@ -145,9 +145,9 @@ class ItemPricesOverlay extends Overlay
 							return null;
 						}
 
-						final String totalText = getContainerTotalValueText(container);
+						final String totalText = makeTotalValueTooltip(container);
 						tooltipManager.add(new Tooltip("GE Total: " + ColorUtil.wrapWithColorTag(totalText, Color.GREEN) + " gp"));
-						break;
+						return null;
 					case WidgetID.INVENTORY_GROUP_ID:
 						if (config.hideInventory())
 						{
@@ -169,7 +169,7 @@ class ItemPricesOverlay extends Overlay
 		return null;
 	}
 
-	private String getContainerTotalValueText(ItemContainer container) {
+	private String makeTotalValueTooltip(ItemContainer container) {
 		if (container == null)
 		{
 			return "0";

--- a/runelite-client/src/test/java/net/runelite/client/plugins/bank/ContainerCalculationTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/bank/ContainerCalculationTest.java
@@ -84,7 +84,7 @@ public class ContainerCalculationTest
 		when(itemManager.getItemPrice(ItemID.ABYSSAL_WHIP))
 			.thenReturn(3); // 1b * 3 overflows
 
-		final ContainerPrices prices = containerCalculation.calculate(items);
+		final ContainerPrices prices = containerCalculation.calculate(items, false);
 		assertNotNull(prices);
 
 		assertTrue(prices.getHighAlchPrice() > Integer.MAX_VALUE);


### PR DESCRIPTION
When hovering over either the inventory or equipment icon, it will display a tooltip with their respective total GE value.

A bit of redundancy with my function - makeTotalValueTooltip()
and the existing function - getItemStackValueText()

Not sure if it should be handled differently or not^^^

Let me know of your thoughts.

Alex