### PR TITLE
plugin hub: always wrap description text

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/PluginHubPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/PluginHubPanel.java
@@ -157,8 +157,8 @@ class PluginHubPanel extends PluginPanel
 			version.setFont(FontManager.getRunescapeSmallFont());
 			version.setToolTipText(manifest.getVersion());
 
-			JLabel description = new JLabel(manifest.getDescription());
-			description.setToolTipText(manifest.getDescription());
+			// wrap in HTML to avoid text ellipsis
+			JLabel description = new JLabel("<html>" + manifest.getDescription() + "</html>");
 
 			JLabel icon = new JLabel();
 			icon.setHorizontalAlignment(JLabel.CENTER);


### PR DESCRIPTION
To avoid the odd behavior where the jlabel only sometimes wraps,
the text is now wrapped in html which always wraps. The tooltip
can now also be removed.

The other way I've read about is to use  a jtextarea, but this approach should be fine.