### PR TITLE
ConfigPlugin: Expand RuneLite plugin tags

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPlugin.java
@@ -73,7 +73,8 @@ public class ConfigPlugin extends Plugin
 	{
 		pluginListPanel = pluginListPanelProvider.get();
 		pluginListPanel.addFakePlugin(new PluginConfigurationDescriptor(
-				"RuneLite", "RuneLite client settings", new String[]{"client"},
+				"RuneLite", "RuneLite client settings",
+				new String[]{"client", "notification", "size", "position", "window", "chrome", "focus", "font", "overlay", "tooltip", "infobox"},
 				null, runeLiteConfig, configManager.getConfigDescriptor(runeLiteConfig)
 			),
 			new PluginConfigurationDescriptor(


### PR DESCRIPTION
This commit adds a number of related tags to the RuneLite configuration
in order to make it more easily discoverable as many users are not able
to find the settings it contains via search.

Closes runelite/runelite#8491