### PR TITLE
Log cancelled buy/sell orders in GE history tracker

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangePlugin.java
@@ -292,7 +292,6 @@ public class GrandExchangePlugin extends Plugin
 			return;
 		}
 
-		// Only interested in offers which are fully bought/sold
 		if (offer.getState() != GrandExchangeOfferState.BOUGHT && offer.getState() != GrandExchangeOfferState.SOLD &&
 			offer.getState() != GrandExchangeOfferState.CANCELLED_BUY && offer.getState() != GrandExchangeOfferState.CANCELLED_SELL)
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangePlugin.java
@@ -293,7 +293,14 @@ public class GrandExchangePlugin extends Plugin
 		}
 
 		// Only interested in offers which are fully bought/sold
-		if (offer.getState() != GrandExchangeOfferState.BOUGHT && offer.getState() != GrandExchangeOfferState.SOLD)
+		if (offer.getState() != GrandExchangeOfferState.BOUGHT && offer.getState() != GrandExchangeOfferState.SOLD &&
+			offer.getState() != GrandExchangeOfferState.CANCELLED_BUY && offer.getState() != GrandExchangeOfferState.CANCELLED_SELL)
+		{
+			return;
+		}
+
+		// Cancelled offers may have been cancelled before buying/selling any items
+		if (offer.getQuantitySold() == 0)
 		{
 			return;
 		}
@@ -305,12 +312,12 @@ public class GrandExchangePlugin extends Plugin
 		}
 
 		// getPrice() is the price of the offer, not necessarily what the item bought at
-		int priceEach = offer.getSpent() / offer.getTotalQuantity();
+		int priceEach = offer.getSpent() / offer.getQuantitySold();
 
 		GrandExchangeTrade grandExchangeTrade = new GrandExchangeTrade();
-		grandExchangeTrade.setBuy(offer.getState() == GrandExchangeOfferState.BOUGHT);
+		grandExchangeTrade.setBuy(offer.getState() == GrandExchangeOfferState.BOUGHT || offer.getState() == GrandExchangeOfferState.CANCELLED_BUY);
 		grandExchangeTrade.setItemId(offer.getItemId());
-		grandExchangeTrade.setQuantity(offer.getTotalQuantity());
+		grandExchangeTrade.setQuantity(offer.getQuantitySold());
 		grandExchangeTrade.setPrice(priceEach);
 
 		log.debug("Submitting trade: {}", grandExchangeTrade);


### PR DESCRIPTION
The Grand Exchange plugin doesn't currently upload any trade history for buy/sell orders that were cancelled after being partially completed. This commit updates the plugin to upload the portion of the trade that was successfully bought/sold prior to the trade being cancelled, so that the Grand Exchange trade history on the RuneLite website will more closely match the in-game history.