### PR TITLE
change herblore level needed to make compost to 22 in skill calculator

### DIFF
--- a/runelite-client/src/main/resources/net/runelite/client/plugins/skillcalculator/skill_herblore.json
+++ b/runelite-client/src/main/resources/net/runelite/client/plugins/skillcalculator/skill_herblore.json
@@ -61,7 +61,7 @@
       "xp": 6.3
     },
     {
-      "level": 21,
+      "level": 22,
       "icon": 6472,
       "name": "Compost Potion (3)",
       "xp": 60


### PR DESCRIPTION
To be consistent with the [update from 20 June 2019](https://secure.runescape.com/m=news/wilderness-updates-and-dmm-summer-finals?oldschool=1), the Herblore skill calculator has been changed to show that a Compost Potion requires level 22 to make.

Fixes #10768