### PR TITLE
Add Long Bone to Construction Calculator

### DIFF
--- a/runelite-client/src/main/resources/net/runelite/client/plugins/skillcalculator/skill_construction.json
+++ b/runelite-client/src/main/resources/net/runelite/client/plugins/skillcalculator/skill_construction.json
@@ -409,6 +409,12 @@
       "xp": 210
     },
     {
+      "level": 30,
+      "icon": 10977,
+      "name": "Curved Bone",
+      "xp": 6750
+    },
+    {
       "level": 31,
       "icon": 8110,
       "name": "Carved Oak Bench",

--- a/runelite-client/src/main/resources/net/runelite/client/plugins/skillcalculator/skill_construction.json
+++ b/runelite-client/src/main/resources/net/runelite/client/plugins/skillcalculator/skill_construction.json
@@ -61,12 +61,6 @@
       "xp": 58
     },
     {
-      "level": 1,
-      "icon": 10976,
-      "name": "Long Bone",
-      "xp": 4500
-    },
-    {
       "level": 2,
       "icon": 8316,
       "name": "Brown Rug",
@@ -407,6 +401,12 @@
       "icon": 8032,
       "name": "Oak Bed",
       "xp": 210
+    },
+    {
+      "level": 30,
+      "icon": 10976,
+      "name": "Long Bone",
+      "xp": 4500
     },
     {
       "level": 30,

--- a/runelite-client/src/main/resources/net/runelite/client/plugins/skillcalculator/skill_construction.json
+++ b/runelite-client/src/main/resources/net/runelite/client/plugins/skillcalculator/skill_construction.json
@@ -61,6 +61,12 @@
       "xp": 58
     },
     {
+      "level": 1,
+      "icon": 10976,
+      "name": "Long Bone",
+      "xp": 4500
+    },
+    {
       "level": 2,
       "icon": 8316,
       "name": "Brown Rug",


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
I cannot calculate how many Long Bones I need for my next Construction level with the RuneLite calculator

**Describe the solution you'd like**
I'd like to be able to know how many Long Bones I need for my next construction level.

**Describe alternatives you've considered**
I looked up how much xp long bones give, the amount of xp I need to level, and I know how to do basic division.

**Long Bone Details**
_Level:_ **1** (There is no construction requirement for Death to the Dorgeshuun or any of its prerequisite quests)
_Category:_ **Miscellaneous**
_Planks:_ **N/A**
_Count:_ **1**
_XP:_ **4500**

I completely accept if this isn't the kind of thing that y'all want on your skill calculator, but it _is_ a method of training construction.