### PR TITLE
PluginManager: try/catch Throwable all the plugin startup stuff

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/externalplugins/ExternalPluginManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/externalplugins/ExternalPluginManager.java
@@ -305,7 +305,11 @@ public class ExternalPluginManager
 						});
 					}
 				}
-				catch (Exception e)
+				catch (ThreadDeath e)
+				{
+					throw e;
+				}
+				catch (Throwable e)
 				{
 					log.warn("Unable to start or load external plugin \"{}\"", manifest.getInternalName(), e);
 					if (newPlugins != null)


### PR DESCRIPTION
If you loaded an external plugin that throws LinkageErrors it could cause the client not to start