### PR TITLE
client: add sessionfile and config arguments

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/RuneLite.java
+++ b/runelite-client/src/main/java/net/runelite/client/RuneLite.java
@@ -177,10 +177,12 @@ public class RuneLite
 		final OptionParser parser = new OptionParser();
 		parser.accepts("developer-mode", "Enable developer tools");
 		parser.accepts("debug", "Show extra debugging output");
-		parser.accepts("sessionfile", "Use a specified session file")
+
+		final ArgumentAcceptingOptionSpec<File> sessionfile = parser.accepts("sessionfile", "Use a specified session file")
 			.withRequiredArg().defaultsTo(DEFAULT_SESSION_FILE)
 			.withValuesConvertedBy(new FileConverter());
-		parser.accepts("config", "Use a specified config file")
+
+		final ArgumentAcceptingOptionSpec<File> configfile = parser.accepts("config", "Use a specified config file")
 			.withRequiredArg().defaultsTo(DEFAULT_CONFIG_FILE)
 			.withValuesConvertedBy(new FileConverter());
 
@@ -251,9 +253,6 @@ public class RuneLite
 				}
 			}
 
-			File sessionfile = (File) options.valueOf("sessionfile");
-			File configfile = (File) options.valueOf("config");
-
 			PROFILES_DIR.mkdirs();
 
 			final long start = System.currentTimeMillis();
@@ -261,8 +260,8 @@ public class RuneLite
 			injector = Guice.createInjector(new RuneLiteModule(
 				clientLoader,
 				developerMode,
-				sessionfile,
-				configfile));
+				options.valueOf(sessionfile),
+				options.valueOf(configfile)));
 
 			injector.getInstance(RuneLite.class).start();
 
@@ -392,13 +391,11 @@ public class RuneLite
 			}
 		}
 
-		@Override
 		public Class<? extends File> valueType()
 		{
 			return null;
 		}
 
-		@Override
 		public String valuePattern()
 		{
 			return null;

--- a/runelite-client/src/main/java/net/runelite/client/RuneLiteModule.java
+++ b/runelite-client/src/main/java/net/runelite/client/RuneLiteModule.java
@@ -61,17 +61,23 @@ public class RuneLiteModule extends AbstractModule
 
 	private final Supplier<Applet> clientLoader;
 	private final boolean developerMode;
+	private final File sessionfile;
+	private final File config;
 
-	public RuneLiteModule(Supplier<Applet> clientLoader, boolean developerMode)
+	public RuneLiteModule(Supplier<Applet> clientLoader, boolean developerMode, File sessionfile, File config)
 	{
 		this.clientLoader = clientLoader;
 		this.developerMode = developerMode;
+		this.sessionfile = sessionfile;
+		this.config = config;
 	}
 
 	@Override
 	protected void configure()
 	{
 		bindConstant().annotatedWith(Names.named("developerMode")).to(developerMode);
+		bind(File.class).annotatedWith(Names.named("sessionfile")).toInstance(sessionfile);
+		bind(File.class).annotatedWith(Names.named("config")).toInstance(config);
 		bind(ScheduledExecutorService.class).toInstance(new ExecutorServiceExceptionLogger(Executors.newSingleThreadScheduledExecutor()));
 		bind(OkHttpClient.class).toInstance(RuneLiteAPI.CLIENT.newBuilder()
 			.cache(new Cache(new File(RuneLite.CACHE_DIR, "okhttp"), MAX_OKHTTP_CACHE_SIZE))

--- a/runelite-client/src/main/java/net/runelite/client/config/ConfigManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/ConfigManager.java
@@ -61,6 +61,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
+import javax.inject.Named;
 import javax.inject.Singleton;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.coords.WorldPoint;
@@ -77,7 +78,6 @@ import net.runelite.http.api.config.Configuration;
 @Slf4j
 public class ConfigManager
 {
-	private static final String SETTINGS_FILE_NAME = "settings.properties";
 	private static final DateFormat TIME_FORMAT = new SimpleDateFormat("yyyy-MM-dd_HH-mm-ss");
 
 	@Inject
@@ -92,11 +92,15 @@ public class ConfigManager
 	private final ConfigInvocationHandler handler = new ConfigInvocationHandler(this);
 	private final Properties properties = new Properties();
 	private final Map<String, String> pendingChanges = new HashMap<>();
+	private final File settingsFileInput;
 
 	@Inject
-	public ConfigManager(ScheduledExecutorService scheduledExecutorService)
+	public ConfigManager(
+		@Named("config") File config,
+		ScheduledExecutorService scheduledExecutorService)
 	{
 		this.executor = scheduledExecutorService;
+		this.settingsFileInput = config;
 		this.propertiesFile = getPropertiesFile();
 
 		executor.scheduleWithFixedDelay(this::sendConfig, 30, 30, TimeUnit.SECONDS);
@@ -125,7 +129,7 @@ public class ConfigManager
 
 	private File getLocalPropertiesFile()
 	{
-		return new File(RuneLite.RUNELITE_DIR, SETTINGS_FILE_NAME);
+		return settingsFileInput;
 	}
 
 	private File getPropertiesFile()
@@ -138,7 +142,7 @@ public class ConfigManager
 		else
 		{
 			File profileDir = new File(RuneLite.PROFILES_DIR, session.getUsername().toLowerCase());
-			return new File(profileDir, SETTINGS_FILE_NAME);
+			return new File(profileDir, RuneLite.DEFAULT_CONFIG_FILE);
 		}
 	}
 
@@ -331,7 +335,7 @@ public class ConfigManager
 
 		parent.mkdirs();
 
-		File tempFile = new File(parent, SETTINGS_FILE_NAME + ".tmp");
+		File tempFile = new File(parent, RuneLite.DEFAULT_CONFIG_FILE + ".tmp");
 
 		try (FileOutputStream out = new FileOutputStream(tempFile))
 		{

--- a/runelite-client/src/test/java/net/runelite/client/config/ConfigManagerTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/config/ConfigManagerTest.java
@@ -27,11 +27,14 @@ package net.runelite.client.config;
 import com.google.inject.Guice;
 import com.google.inject.testing.fieldbinder.Bind;
 import com.google.inject.testing.fieldbinder.BoundFieldModule;
+import java.io.File;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.UUID;
 import java.util.concurrent.ScheduledExecutorService;
 import javax.inject.Inject;
+import javax.inject.Named;
+import net.runelite.client.RuneLite;
 import net.runelite.client.account.AccountSession;
 import net.runelite.client.eventbus.EventBus;
 import org.junit.Assert;
@@ -55,6 +58,14 @@ public class ConfigManagerTest
 	@Mock
 	@Bind
 	RuneLiteConfig runeliteConfig;
+
+	@Bind
+	@Named("sessionfile")
+	File sessionfile = new File(RuneLite.RUNELITE_DIR, RuneLite.DEFAULT_SESSION_FILE);
+
+	@Bind
+	@Named("config")
+	File config = new File(RuneLite.RUNELITE_DIR, RuneLite.DEFAULT_CONFIG_FILE);
 
 	@Inject
 	ConfigManager manager;

--- a/runelite-client/src/test/java/net/runelite/client/plugins/PluginManagerTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/PluginManagerTest.java
@@ -48,9 +48,9 @@ import java.util.Set;
 import net.runelite.api.Client;
 import net.runelite.client.RuneLite;
 import net.runelite.client.RuneLiteModule;
-import net.runelite.client.eventbus.EventBus;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigItem;
+import net.runelite.client.eventbus.EventBus;
 import static org.junit.Assert.assertEquals;
 import org.junit.Before;
 import org.junit.Rule;
@@ -83,7 +83,9 @@ public class PluginManagerTest
 	public void before() throws IOException
 	{
 		Injector injector = Guice.createInjector(Modules
-			.override(new RuneLiteModule(() -> null, true))
+			.override(new RuneLiteModule(() -> null, true,
+				new File(RuneLite.RUNELITE_DIR, RuneLite.DEFAULT_SESSION_FILE),
+				new File(RuneLite.RUNELITE_DIR, RuneLite.DEFAULT_CONFIG_FILE)))
 			.with(BoundFieldModule.of(this)));
 
 		RuneLite.setInjector(injector);
@@ -144,7 +146,9 @@ public class PluginManagerTest
 	{
 		List<Module> modules = new ArrayList<>();
 		modules.add(new GraphvizModule());
-		modules.add(new RuneLiteModule(() -> null, true));
+		modules.add(new RuneLiteModule(() -> null, true,
+			new File(RuneLite.RUNELITE_DIR, RuneLite.DEFAULT_SESSION_FILE),
+			new File(RuneLite.RUNELITE_DIR, RuneLite.DEFAULT_CONFIG_FILE)));
 
 		PluginManager pluginManager = new PluginManager(true, null, null, null, null, null);
 		pluginManager.loadCorePlugins();

--- a/runelite-client/src/test/java/net/runelite/client/plugins/loottracker/LootTrackerPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/loottracker/LootTrackerPluginTest.java
@@ -27,16 +27,14 @@ package net.runelite.client.plugins.loottracker;
 import com.google.inject.Guice;
 import com.google.inject.testing.fieldbinder.Bind;
 import com.google.inject.testing.fieldbinder.BoundFieldModule;
-import java.io.File;
 import java.util.concurrent.ScheduledExecutorService;
 import javax.inject.Inject;
-import javax.inject.Named;
 import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
 import net.runelite.api.Player;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.ChatMessage;
-import net.runelite.client.RuneLite;
+import net.runelite.client.account.SessionManager;
 import net.runelite.client.game.SpriteManager;
 import net.runelite.client.ui.overlay.infobox.InfoBoxManager;
 import net.runelite.http.api.loottracker.LootRecordType;
@@ -75,13 +73,9 @@ public class LootTrackerPluginTest
 	@Bind
 	private LootTrackerConfig lootTrackerConfig;
 
+	@Mock
 	@Bind
-	@Named("sessionfile")
-	File sessionfile = new File(RuneLite.RUNELITE_DIR, RuneLite.DEFAULT_SESSION_FILE);
-
-	@Bind
-	@Named("config")
-	File config = new File(RuneLite.RUNELITE_DIR, RuneLite.DEFAULT_CONFIG_FILE);
+	private SessionManager sessionManager;
 
 	@Before
 	public void setUp()

--- a/runelite-client/src/test/java/net/runelite/client/plugins/loottracker/LootTrackerPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/loottracker/LootTrackerPluginTest.java
@@ -27,13 +27,16 @@ package net.runelite.client.plugins.loottracker;
 import com.google.inject.Guice;
 import com.google.inject.testing.fieldbinder.Bind;
 import com.google.inject.testing.fieldbinder.BoundFieldModule;
+import java.io.File;
 import java.util.concurrent.ScheduledExecutorService;
 import javax.inject.Inject;
+import javax.inject.Named;
 import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
 import net.runelite.api.Player;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.ChatMessage;
+import net.runelite.client.RuneLite;
 import net.runelite.client.game.SpriteManager;
 import net.runelite.client.ui.overlay.infobox.InfoBoxManager;
 import net.runelite.http.api.loottracker.LootRecordType;
@@ -71,6 +74,14 @@ public class LootTrackerPluginTest
 	@Mock
 	@Bind
 	private LootTrackerConfig lootTrackerConfig;
+
+	@Bind
+	@Named("sessionfile")
+	File sessionfile = new File(RuneLite.RUNELITE_DIR, RuneLite.DEFAULT_SESSION_FILE);
+
+	@Bind
+	@Named("config")
+	File config = new File(RuneLite.RUNELITE_DIR, RuneLite.DEFAULT_CONFIG_FILE);
 
 	@Before
 	public void setUp()

--- a/runelite-client/src/test/java/net/runelite/client/plugins/motherlode/MotherlodePluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/motherlode/MotherlodePluginTest.java
@@ -27,8 +27,10 @@ package net.runelite.client.plugins.motherlode;
 import com.google.inject.Guice;
 import com.google.inject.testing.fieldbinder.Bind;
 import com.google.inject.testing.fieldbinder.BoundFieldModule;
+import java.io.File;
 import java.util.concurrent.ScheduledExecutorService;
 import javax.inject.Inject;
+import javax.inject.Named;
 import net.runelite.api.Client;
 import net.runelite.api.GameState;
 import net.runelite.api.InventoryID;
@@ -39,6 +41,7 @@ import net.runelite.api.Varbits;
 import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.ItemContainerChanged;
 import net.runelite.api.events.VarbitChanged;
+import net.runelite.client.RuneLite;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -86,6 +89,14 @@ public class MotherlodePluginTest
 	@Mock
 	@Bind
 	private ScheduledExecutorService scheduledExecutorService;
+
+	@Bind
+	@Named("sessionfile")
+	File sessionfile = new File(RuneLite.RUNELITE_DIR, RuneLite.DEFAULT_SESSION_FILE);
+
+	@Bind
+	@Named("config")
+	File config = new File(RuneLite.RUNELITE_DIR, RuneLite.DEFAULT_CONFIG_FILE);
 
 	@Before
 	public void before()

--- a/runelite-client/src/test/java/net/runelite/client/plugins/motherlode/MotherlodePluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/motherlode/MotherlodePluginTest.java
@@ -27,10 +27,8 @@ package net.runelite.client.plugins.motherlode;
 import com.google.inject.Guice;
 import com.google.inject.testing.fieldbinder.Bind;
 import com.google.inject.testing.fieldbinder.BoundFieldModule;
-import java.io.File;
 import java.util.concurrent.ScheduledExecutorService;
 import javax.inject.Inject;
-import javax.inject.Named;
 import net.runelite.api.Client;
 import net.runelite.api.GameState;
 import net.runelite.api.InventoryID;
@@ -41,7 +39,7 @@ import net.runelite.api.Varbits;
 import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.ItemContainerChanged;
 import net.runelite.api.events.VarbitChanged;
-import net.runelite.client.RuneLite;
+import net.runelite.client.ui.overlay.OverlayManager;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -90,13 +88,9 @@ public class MotherlodePluginTest
 	@Bind
 	private ScheduledExecutorService scheduledExecutorService;
 
+	@Mock
 	@Bind
-	@Named("sessionfile")
-	File sessionfile = new File(RuneLite.RUNELITE_DIR, RuneLite.DEFAULT_SESSION_FILE);
-
-	@Bind
-	@Named("config")
-	File config = new File(RuneLite.RUNELITE_DIR, RuneLite.DEFAULT_CONFIG_FILE);
+	private OverlayManager overlayManager;
 
 	@Before
 	public void before()

--- a/runelite-client/src/test/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsPluginTest.java
@@ -27,14 +27,12 @@ package net.runelite.client.plugins.npchighlight;
 import com.google.inject.Guice;
 import com.google.inject.testing.fieldbinder.Bind;
 import com.google.inject.testing.fieldbinder.BoundFieldModule;
-import java.io.File;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.ScheduledExecutorService;
 import javax.inject.Inject;
-import javax.inject.Named;
 import net.runelite.api.Client;
-import net.runelite.client.RuneLite;
+import net.runelite.client.ui.overlay.OverlayManager;
 import static org.junit.Assert.assertEquals;
 import org.junit.Before;
 import org.junit.Test;
@@ -61,13 +59,9 @@ public class NpcIndicatorsPluginTest
 	@Inject
 	private NpcIndicatorsPlugin npcIndicatorsPlugin;
 
+	@Mock
 	@Bind
-	@Named("sessionfile")
-	File sessionfile = new File(RuneLite.RUNELITE_DIR, RuneLite.DEFAULT_SESSION_FILE);
-
-	@Bind
-	@Named("config")
-	File config = new File(RuneLite.RUNELITE_DIR, RuneLite.DEFAULT_CONFIG_FILE);
+	private OverlayManager overlayManager;
 
 	@Before
 	public void setUp()

--- a/runelite-client/src/test/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsPluginTest.java
@@ -27,11 +27,14 @@ package net.runelite.client.plugins.npchighlight;
 import com.google.inject.Guice;
 import com.google.inject.testing.fieldbinder.Bind;
 import com.google.inject.testing.fieldbinder.BoundFieldModule;
+import java.io.File;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.ScheduledExecutorService;
 import javax.inject.Inject;
+import javax.inject.Named;
 import net.runelite.api.Client;
+import net.runelite.client.RuneLite;
 import static org.junit.Assert.assertEquals;
 import org.junit.Before;
 import org.junit.Test;
@@ -57,6 +60,14 @@ public class NpcIndicatorsPluginTest
 
 	@Inject
 	private NpcIndicatorsPlugin npcIndicatorsPlugin;
+
+	@Bind
+	@Named("sessionfile")
+	File sessionfile = new File(RuneLite.RUNELITE_DIR, RuneLite.DEFAULT_SESSION_FILE);
+
+	@Bind
+	@Named("config")
+	File config = new File(RuneLite.RUNELITE_DIR, RuneLite.DEFAULT_CONFIG_FILE);
 
 	@Before
 	public void setUp()

--- a/runelite-client/src/test/java/net/runelite/client/plugins/raids/RaidsPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/raids/RaidsPluginTest.java
@@ -28,9 +28,7 @@ import com.google.inject.Guice;
 import com.google.inject.Inject;
 import com.google.inject.testing.fieldbinder.Bind;
 import com.google.inject.testing.fieldbinder.BoundFieldModule;
-import java.io.File;
 import java.util.concurrent.ScheduledExecutorService;
-import javax.inject.Named;
 import net.runelite.api.Client;
 import net.runelite.api.InventoryID;
 import net.runelite.api.Item;
@@ -38,17 +36,18 @@ import net.runelite.api.ItemContainer;
 import net.runelite.api.ItemID;
 import net.runelite.api.events.WidgetLoaded;
 import net.runelite.api.widgets.WidgetID;
-import net.runelite.client.RuneLite;
+import net.runelite.client.Notifier;
 import net.runelite.client.chat.ChatMessageManager;
 import net.runelite.client.chat.QueuedMessage;
 import net.runelite.client.config.ChatColorConfig;
 import net.runelite.client.config.RuneLiteConfig;
 import net.runelite.client.game.ItemManager;
+import net.runelite.client.ui.overlay.OverlayManager;
+import net.runelite.client.util.ImageCapture;
+import net.runelite.client.ws.PartyService;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import net.runelite.client.Notifier;
-import net.runelite.client.util.ImageCapture;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -101,13 +100,13 @@ public class RaidsPluginTest
 	@Inject
 	RaidsPlugin raidsPlugin;
 
+	@Mock
 	@Bind
-	@Named("sessionfile")
-	File sessionfile = new File(RuneLite.RUNELITE_DIR, RuneLite.DEFAULT_SESSION_FILE);
+	private PartyService partyService;
 
+	@Mock
 	@Bind
-	@Named("config")
-	File config = new File(RuneLite.RUNELITE_DIR, RuneLite.DEFAULT_CONFIG_FILE);
+	private OverlayManager overlayManager;
 
 	@Before
 	public void before()

--- a/runelite-client/src/test/java/net/runelite/client/plugins/raids/RaidsPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/raids/RaidsPluginTest.java
@@ -28,7 +28,9 @@ import com.google.inject.Guice;
 import com.google.inject.Inject;
 import com.google.inject.testing.fieldbinder.Bind;
 import com.google.inject.testing.fieldbinder.BoundFieldModule;
+import java.io.File;
 import java.util.concurrent.ScheduledExecutorService;
+import javax.inject.Named;
 import net.runelite.api.Client;
 import net.runelite.api.InventoryID;
 import net.runelite.api.Item;
@@ -36,6 +38,7 @@ import net.runelite.api.ItemContainer;
 import net.runelite.api.ItemID;
 import net.runelite.api.events.WidgetLoaded;
 import net.runelite.api.widgets.WidgetID;
+import net.runelite.client.RuneLite;
 import net.runelite.client.chat.ChatMessageManager;
 import net.runelite.client.chat.QueuedMessage;
 import net.runelite.client.config.ChatColorConfig;
@@ -97,6 +100,14 @@ public class RaidsPluginTest
 
 	@Inject
 	RaidsPlugin raidsPlugin;
+
+	@Bind
+	@Named("sessionfile")
+	File sessionfile = new File(RuneLite.RUNELITE_DIR, RuneLite.DEFAULT_SESSION_FILE);
+
+	@Bind
+	@Named("config")
+	File config = new File(RuneLite.RUNELITE_DIR, RuneLite.DEFAULT_CONFIG_FILE);
 
 	@Before
 	public void before()

--- a/runelite-client/src/test/java/net/runelite/client/plugins/screenshot/ScreenshotPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/screenshot/ScreenshotPluginTest.java
@@ -27,9 +27,11 @@ package net.runelite.client.plugins.screenshot;
 import com.google.inject.Guice;
 import com.google.inject.testing.fieldbinder.Bind;
 import com.google.inject.testing.fieldbinder.BoundFieldModule;
+import java.io.File;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Consumer;
 import javax.inject.Inject;
+import javax.inject.Named;
 import static net.runelite.api.ChatMessageType.GAMEMESSAGE;
 import net.runelite.api.Client;
 import net.runelite.api.events.ChatMessage;
@@ -41,6 +43,7 @@ import static net.runelite.api.widgets.WidgetID.LEVEL_UP_GROUP_ID;
 import static net.runelite.api.widgets.WidgetInfo.DIALOG_SPRITE_TEXT;
 import static net.runelite.api.widgets.WidgetInfo.LEVEL_UP_LEVEL;
 import net.runelite.client.Notifier;
+import net.runelite.client.RuneLite;
 import net.runelite.client.config.RuneLiteConfig;
 import net.runelite.client.ui.ClientUI;
 import net.runelite.client.ui.DrawManager;
@@ -96,6 +99,14 @@ public class ScreenshotPluginTest
 	@Mock
 	@Bind
 	ScheduledExecutorService service;
+
+	@Bind
+	@Named("sessionfile")
+	File sessionfile = new File(RuneLite.RUNELITE_DIR, RuneLite.DEFAULT_SESSION_FILE);
+
+	@Bind
+	@Named("config")
+	File configfile = new File(RuneLite.RUNELITE_DIR, RuneLite.DEFAULT_CONFIG_FILE);
 
 	@Before
 	public void before()

--- a/runelite-client/src/test/java/net/runelite/client/plugins/screenshot/ScreenshotPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/screenshot/ScreenshotPluginTest.java
@@ -27,11 +27,9 @@ package net.runelite.client.plugins.screenshot;
 import com.google.inject.Guice;
 import com.google.inject.testing.fieldbinder.Bind;
 import com.google.inject.testing.fieldbinder.BoundFieldModule;
-import java.io.File;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Consumer;
 import javax.inject.Inject;
-import javax.inject.Named;
 import static net.runelite.api.ChatMessageType.GAMEMESSAGE;
 import net.runelite.api.Client;
 import net.runelite.api.events.ChatMessage;
@@ -43,10 +41,10 @@ import static net.runelite.api.widgets.WidgetID.LEVEL_UP_GROUP_ID;
 import static net.runelite.api.widgets.WidgetInfo.DIALOG_SPRITE_TEXT;
 import static net.runelite.api.widgets.WidgetInfo.LEVEL_UP_LEVEL;
 import net.runelite.client.Notifier;
-import net.runelite.client.RuneLite;
 import net.runelite.client.config.RuneLiteConfig;
 import net.runelite.client.ui.ClientUI;
 import net.runelite.client.ui.DrawManager;
+import net.runelite.client.ui.overlay.OverlayManager;
 import static org.junit.Assert.assertEquals;
 import org.junit.Before;
 import org.junit.Test;
@@ -100,13 +98,9 @@ public class ScreenshotPluginTest
 	@Bind
 	ScheduledExecutorService service;
 
+	@Mock
 	@Bind
-	@Named("sessionfile")
-	File sessionfile = new File(RuneLite.RUNELITE_DIR, RuneLite.DEFAULT_SESSION_FILE);
-
-	@Bind
-	@Named("config")
-	File configfile = new File(RuneLite.RUNELITE_DIR, RuneLite.DEFAULT_CONFIG_FILE);
+	private OverlayManager overlayManager;
 
 	@Before
 	public void before()


### PR DESCRIPTION
budget profiles

The behavior of this is as follows:
input file is relative to the RL dir unless an absolute path or a path that starts with "./" or ".\"
The --config arg does nothing if the user is logged into runelite (it keeps the current behavior of putting the config in the rl/profile dir)