### PR TITLE
ImageCapture: only append space when filename isnt empty

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/util/ImageCapture.java
+++ b/runelite-client/src/main/java/net/runelite/client/util/ImageCapture.java
@@ -115,7 +115,7 @@ public class ImageCapture
 
 		playerFolder.mkdirs();
 
-		fileName +=  " " + format(new Date());
+		fileName += (fileName.isEmpty() ? "" : " ") + format(new Date());
 
 		try
 		{


### PR DESCRIPTION
if a screenshot was manually taken there is no filename passed to the capture function causing the appended space meant to separate the date from a filename to be the first character in the filename.

fixes #10800 