### PR TITLE
Fixed slayer kill counter and added 1 click teleport for Gem mine

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -723,6 +723,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 		{
 			swap("rub", option, target, index);
 			swap("teleport", option, target, index);
+			swap("gem mine", option, target, index);
 		}
 		else if (option.equals("wield"))
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/opponentinfo/OpponentInfoOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/opponentinfo/OpponentInfoOverlay.java
@@ -40,6 +40,7 @@ import net.runelite.api.Player;
 import net.runelite.api.Varbits;
 import net.runelite.client.game.HiscoreManager;
 import net.runelite.client.game.NPCManager;
+import net.runelite.client.plugins.slayer.SlayerPlugin;
 import net.runelite.client.ui.overlay.Overlay;
 import static net.runelite.client.ui.overlay.OverlayManager.OPTION_CONFIGURE;
 import net.runelite.client.ui.overlay.OverlayMenuEntry;
@@ -115,6 +116,7 @@ class OpponentInfoOverlay extends Overlay
 			if (opponent instanceof NPC)
 			{
 				lastMaxHealth = npcManager.getHealth(((NPC) opponent).getId());
+				SlayerPlugin.saveMonsHealth = lastMaxHealth;
 			}
 			else if (opponent instanceof Player)
 			{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerPlugin.java
@@ -202,6 +202,8 @@ public class SlayerPlugin extends Plugin
 
 	@Getter(AccessLevel.PACKAGE)
 	private int points;
+	
+	public static Integer saveMonsHealth;
 
 	private TaskCounter counter;
 	private int cachedXp = -1;
@@ -540,17 +542,29 @@ public class SlayerPlugin extends Plugin
 			return;
 		}
 
-		final Task task = Task.getTask(taskName);
 
-		// null tasks are technically valid, it only means they arent explicitly defined in the Task enum
-		// allow them through so that if there is a task capture failure the counter will still work
-		final int taskKillExp = task != null ? task.getExpectedKillExp() : 0;
+		/* these are old comments
+		null tasks are technically valid, it only means they arent explicitly defined in the Task enum
+		allow them through so that if there is a task capture failure the counter will still work
 
-		// Only count exp gain as a kill if the task either has no expected exp for a kill, or if the exp gain is equal
-		// to the expected exp gain for the task.
-		if (taskKillExp == 0 || taskKillExp == slayerExp - cachedXp)
+		Only count exp gain as a kill if the task either has no expected exp for a kill, or if the exp gain is equal
+		to the expected exp gain for the task. */
+
+
+		// Get monster max health from public static variable to divide and get accurate kill count
+		if (amount > 1 && slayerExp >= (saveMonsHealth - (saveMonsHealth / 10)))
 		{
+			amount -= (slayerExp - cachedXp) / (saveMonsHealth - (saveMonsHealth / 10));
 			killedOne();
+		}
+		else if (amount > 1)
+		{
+			amount--;
+			killedOne();
+		}
+		else if (amount == 1)
+		{
+			amount--;
 		}
 
 		cachedXp = slayerExp;
@@ -582,7 +596,6 @@ public class SlayerPlugin extends Plugin
 			return;
 		}
 
-		amount--;
 		if (doubleTroubleExtraKill())
 		{
 			amount--;


### PR DESCRIPTION
slayer kill counter was bugged when you kill 2 slayer monsters at the same time in multi combat. For example when you barrage Nechs.