### PR TITLE
config: fix entering values directly into options with units not working

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
@@ -36,7 +36,6 @@ import java.awt.event.ItemEvent;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.awt.image.BufferedImage;
-import java.text.DecimalFormat;
 import javax.inject.Inject;
 import javax.swing.BorderFactory;
 import javax.swing.ImageIcon;
@@ -262,11 +261,7 @@ class ConfigPanel extends PluginPanel
 				Units units = cid.getUnits();
 				if (units != null)
 				{
-					DecimalFormat df = ((JSpinner.NumberEditor) spinner.getEditor()).getFormat();
-					df.setPositiveSuffix(units.value());
-					df.setNegativeSuffix(units.value());
-					// Force update the spinner to have it add the units initially
-					spinnerTextField.setValue(value);
+					spinnerTextField.setFormatterFactory(new UnitFormatterFactory(units));
 				}
 
 				item.add(spinner, BorderLayout.EAST);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/UnitFormatter.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/UnitFormatter.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2020, Hydrox6 <ikada@protonmail.ch>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.config;
+
+import java.text.ParseException;
+import java.util.HashMap;
+import java.util.Map;
+import javax.swing.JFormattedTextField;
+import lombok.RequiredArgsConstructor;
+import net.runelite.client.config.Units;
+
+final class UnitFormatter extends JFormattedTextField.AbstractFormatter
+{
+	private final String units;
+
+	UnitFormatter(Units units)
+	{
+		this.units = units.value();
+	}
+
+	@Override
+	public Object stringToValue(final String text) throws ParseException
+	{
+		final String trimmedText;
+
+		// Using the spinner controls causes the value to have the unit on the end, so remove it
+		if (text.endsWith(units))
+		{
+			trimmedText = text.substring(0, text.length() - units.length());
+		}
+		else
+		{
+			trimmedText = text;
+		}
+
+		try
+		{
+			return Integer.valueOf(trimmedText);
+		}
+		catch (NumberFormatException e)
+		{
+			throw new ParseException(trimmedText + " is not an integer.", 0);
+		}
+	}
+
+	@Override
+	public String valueToString(final Object value)
+	{
+		return value + units;
+	}
+}
+
+@RequiredArgsConstructor
+final class UnitFormatterFactory extends JFormattedTextField.AbstractFormatterFactory
+{
+	private final Units units;
+	private final Map<JFormattedTextField, JFormattedTextField.AbstractFormatter> formatters = new HashMap<>();
+
+	@Override
+	public JFormattedTextField.AbstractFormatter getFormatter(final JFormattedTextField tf)
+	{
+		return formatters.computeIfAbsent(tf, (key) -> new UnitFormatter(units));
+	}
+}


### PR DESCRIPTION
Currently, trying to enter a value directly into an option with a unit will fail unless the user also inputs the unit.
I was trying to avoid writing a whole AbstractFormatter initially, since it seemed overkill. Evidently, it was the only way to do it properly.

Putting both the Formatter and the Factory in the same file is probably bad. Please let me know how you want it doing

Thanks to Trevor for notifying me of this issue.