### PR TITLE
LayoutResizableStones: fix bad script merge

### DIFF
--- a/runelite-client/src/main/scripts/LayoutResizableStones.rs2asm
+++ b/runelite-client/src/main/scripts/LayoutResizableStones.rs2asm
@@ -43,7 +43,7 @@ LABEL9:
    sconst                 "forceStackStones" ; push event name
    runelite_callback     ; invoke callback
    iconst                 0                  ; if 0 is returned, continue normal layout
-   jump                   LABEL49
+   if_icmpeq              LABEL49
 LABEL29:
    iconst                 0
    iload                  3


### PR DESCRIPTION
Closes #10846 

The script updater didn't merge correctly and causes the script to always skip our feature. 