### PR TITLE
Add screenshot subdirectories

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/util/ImageCapture.java
+++ b/runelite-client/src/main/java/net/runelite/client/util/ImageCapture.java
@@ -25,6 +25,7 @@
  */
 package net.runelite.client.util;
 
+import com.google.common.base.Strings;
 import java.awt.Toolkit;
 import java.awt.TrayIcon;
 import java.awt.datatransfer.Clipboard;
@@ -40,6 +41,7 @@ import java.text.SimpleDateFormat;
 import java.util.Base64;
 import java.util.Date;
 import java.util.EnumSet;
+import javax.annotation.Nullable;
 import javax.imageio.ImageIO;
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -80,10 +82,11 @@ public class ImageCapture
 	 *
 	 * @param screenshot BufferedImage to capture.
 	 * @param fileName Filename to use, without file extension.
+	 * @param subDir Directory within the player screenshots dir to store the captured screenshot to.
 	 * @param notify Send a notification to the system tray when the image is captured.
 	 * @param imageUploadStyle which method to use to upload the screenshot (Imgur or directly to clipboard).
 	 */
-	public void takeScreenshot(BufferedImage screenshot, String fileName, boolean notify, ImageUploadStyle imageUploadStyle)
+	public void takeScreenshot(BufferedImage screenshot, String fileName, @Nullable String subDir, boolean notify, ImageUploadStyle imageUploadStyle)
 	{
 		if (client.getGameState() == GameState.LOGIN_SCREEN)
 		{
@@ -106,6 +109,12 @@ public class ImageCapture
 			{
 				playerDir += "-League";
 			}
+
+			if (!Strings.isNullOrEmpty(subDir))
+			{
+				playerDir += File.separator + subDir;
+			}
+
 			playerFolder = new File(SCREENSHOT_DIR, playerDir);
 		}
 		else
@@ -155,6 +164,20 @@ public class ImageCapture
 		{
 			log.warn("error writing screenshot", ex);
 		}
+	}
+
+	/**
+	 * Saves a screenshot of the client window to the screenshot folder as a PNG,
+	 * and optionally uploads it to an image-hosting service.
+	 *
+	 * @param screenshot BufferedImage to capture.
+	 * @param fileName Filename to use, without file extension.
+	 * @param notify Send a notification to the system tray when the image is captured.
+	 * @param imageUploadStyle which method to use to upload the screenshot (Imgur or directly to clipboard).
+	 */
+	public void takeScreenshot(BufferedImage screenshot, String fileName, boolean notify, ImageUploadStyle imageUploadStyle)
+	{
+		takeScreenshot(screenshot, fileName, null, notify, imageUploadStyle);
 	}
 
 	/**


### PR DESCRIPTION
This PR expands the ImageCapture util to allow a parameter to specify a subdirectory where, within a player's screenshots directory, the captured image will be stored, and extends the screenshot plugin to utilize this added functionality.

Closes runelite/runelite#8711
Closes runelite/runelite#8813
Closes runelite/runelite#10204