### PR TITLE
Revert "Change Anti-Drag plugin to work only with SHIFT"

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/antidrag/AntiDragConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/antidrag/AntiDragConfig.java
@@ -29,7 +29,7 @@ import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
 
-@ConfigGroup("antiDrag")
+@ConfigGroup(AntiDragPlugin.CONFIG_GROUP)
 public interface AntiDragConfig extends Config
 {
 	@ConfigItem(
@@ -41,5 +41,16 @@ public interface AntiDragConfig extends Config
 	default int dragDelay()
 	{
 		return Constants.GAME_TICK_LENGTH / Constants.CLIENT_TICK_LENGTH; // one game tick
+	}
+
+	@ConfigItem(
+		keyName = "onShiftOnly",
+		name = "On Shift Only",
+		description = "Configures whether to only adjust the delay while holding shift",
+		position = 2
+	)
+	default boolean onShiftOnly()
+	{
+		return true;
 	}
 }


### PR DESCRIPTION
This reverts commit 3a5e39160760cef8f943ae5703ed89db71e8caab.
and makes it work as expected within the bank interface.

I propose that we revert the shift only anti drag limitation.

The main arguments against the old behavior were as I can see
 - There was complaints from the pk community as it was making switching easier
 - No other client had this functionality
 - Blurry guidelines in what is allowed from Jagex

With [Jagex's statement](https://secure.runescape.com/m=news/another-message-about-unofficial-clients?oldschool=1) there are no longer any blurred lines (ish) in what is and isn't allowed
in 3rd party plugins. General anti-drag is not on that list. Along with the fact that RuneLite is the most used 3rd party client for OSRS, I believe that we no longer need to follow what other clients have and have not included. I strongly believe that we are able to create our own sensible stance.

The old behavior can be emulated through a clever use of shift-click configuration and sticky keys. So if we want to impose a hard limit on "anti-drag" in which it's only supposed to be used for dropping items, we also need to disable any shift-click configurations when the the anti-drag plugin is active.

As mentioned in https://github.com/runelite/runelite/issues/3200#issuecomment-391830420, #10262 or #9974 the current implementation hinders the gameplay for players with disabilities. And it's not even a hard limit, it's just a major annoyance if you have to set a custom shift-click configuration on every item in the game. If you are PKing you probably have a set amount of items you like switching between so adding shift-click configurations
to those is trivial and will not take long.

We now also have shift anti-drag available in the bank interface, an interface where you can neither drop items nor do any player killing.

We need to make a change, in one direction or the other. Either, we revert the plugin to the old behavior where the shift requirement was configurable or we make a change in when and where shift-click modifications should work. It doesn't make any sense to have an implementation that can be worked around this easily.