### PR TITLE
Make Highlight value take priority over other value thresholds

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
@@ -433,6 +433,11 @@ public class GroundItemsPlugin extends Plugin
 		// Cache colors
 		priceChecks.clear();
 
+		if (config.getHighlightOverValue() > 0)
+		{
+			priceChecks.put(config.getHighlightOverValue(), config.highlightedColor());
+		}
+
 		if (config.insaneValuePrice() > 0)
 		{
 			priceChecks.put(config.insaneValuePrice(), config.insaneValueColor());
@@ -451,11 +456,6 @@ public class GroundItemsPlugin extends Plugin
 		if (config.lowValuePrice() > 0)
 		{
 			priceChecks.put(config.lowValuePrice(), config.lowValueColor());
-		}
-
-		if (config.getHighlightOverValue() > 0)
-		{
-			priceChecks.put(config.getHighlightOverValue(), config.highlightedColor());
 		}
 	}
 


### PR DESCRIPTION
Closes #10840

Previously the Low/Medium/High/Insane threshold highlighting would take priority over the Highlight threshold highlighting. This simply puts Highlight at the top of the list, giving it priority.

Example:
My High value is 250k and Insane value is 1000k: An Abyssal Whip (2400k) it'll be highlighted as Insane, a Blessed D'hide Body (600k) will be highlighted as High.
If I set my Highlight threshold to 500k, the Blessed D'hide Body will now be highlighted with the Highlight color.