### PR TITLE
drift net fishing: add plugin

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/Varbits.java
+++ b/runelite-api/src/main/java/net/runelite/api/Varbits.java
@@ -458,7 +458,35 @@ public enum Varbits
 	 * The varbit that stores the oxygen percentage for player
 	 */
 	OXYGEN_LEVEL(5811),
-	
+
+	/**
+	 * Drift net status
+	 *
+	 * Expected values
+	 *  0 = Unset
+	 *  1 = Set up
+	 *  2 = Caught some fish
+	 *  3 = Full
+	 */
+	NORTH_NET_STATUS(5812),
+	SOUTH_NET_STATUS(5814),
+
+	/**
+	 * Drift net catch count
+	 */
+	NORTH_NET_CATCH_COUNT(5813),
+	SOUTH_NET_CATCH_COUNT(5815),
+
+	/**
+	 * Drift net collect interface
+	 *
+	 * Expected values:
+	 *  0 = Not open
+	 *  1 = North interface open
+	 *  2 = South interface open
+	 */
+	DRIFT_NET_COLLECT(5933),
+
 	/**
 	 * Corp beast damage
 	 */

--- a/runelite-client/src/main/java/net/runelite/client/plugins/driftnet/DriftNet.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/driftnet/DriftNet.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2020, dekvall <https://github.com/dekvall>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.driftnet;
+
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+import net.runelite.api.GameObject;
+import net.runelite.api.Varbits;
+
+@Data
+@RequiredArgsConstructor
+class DriftNet
+{
+	private final int objectId;
+	private final Varbits statusVarbit;
+	private final Varbits countVarbit;
+
+	private GameObject net;
+	private DriftNetStatus status;
+	private int count;
+
+	String getFormattedCountText()
+	{
+		return status != DriftNetStatus.UNSET ? count + "/10" : "";
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/driftnet/DriftNetConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/driftnet/DriftNetConfig.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2020, dekvall <https://github.com/dekvall>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.driftnet;
+
+import java.awt.Color;
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.Range;
+import net.runelite.client.config.Units;
+
+@ConfigGroup(DriftNetPlugin.CONFIG_GROUP)
+public interface DriftNetConfig extends Config
+{
+	@ConfigItem(
+		position = 1,
+		keyName = "showNetStatus",
+		name = "Show net status",
+		description = "Show net status and fish count"
+	)
+	default boolean showNetStatus()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		position = 2,
+		keyName = "countColor",
+		name = "Fish count color",
+		description = "Color of the fish count text"
+	)
+	default Color countColor()
+	{
+		return Color.WHITE;
+	}
+
+	@ConfigItem(
+		position = 3,
+		keyName = "highlightUntaggedFish",
+		name = "Highlight untagged fish",
+		description = "Highlight the untagged fish"
+	)
+	default boolean highlightUntaggedFish()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		position = 4,
+		keyName = "timeoutDelay",
+		name = "Tagged timeout",
+		description = "Time required for a tag to expire"
+	)
+	@Range(
+		min = 1,
+		max = 60
+	)
+	@Units(Units.TICKS)
+	default int timeoutDelay()
+	{
+		return 10;
+	}
+
+	@ConfigItem(
+		keyName = "untaggedFishColor",
+		name = "Untagged fish color",
+		description = "Color of untagged fish",
+		position = 5
+	)
+	default Color untaggedFishColor()
+	{
+		return Color.CYAN;
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/driftnet/DriftNetOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/driftnet/DriftNetOverlay.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2020, dekvall <https://github.com/dekvall>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.driftnet;
+
+import java.awt.Dimension;
+import java.awt.Graphics2D;
+import java.awt.Shape;
+import javax.inject.Inject;
+import net.runelite.api.NPC;
+import net.runelite.api.Point;
+import net.runelite.client.ui.overlay.Overlay;
+import net.runelite.client.ui.overlay.OverlayLayer;
+import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.OverlayPriority;
+import net.runelite.client.ui.overlay.OverlayUtil;
+
+class DriftNetOverlay extends Overlay
+{
+	private final DriftNetConfig config;
+	private final DriftNetPlugin plugin;
+
+	@Inject
+	private DriftNetOverlay(DriftNetConfig config, DriftNetPlugin plugin)
+	{
+		this.config = config;
+		this.plugin = plugin;
+		setPosition(OverlayPosition.DYNAMIC);
+		setPriority(OverlayPriority.LOW);
+		setLayer(OverlayLayer.ABOVE_SCENE);
+	}
+
+	@Override
+	public Dimension render(Graphics2D graphics)
+	{
+		if (!plugin.isInDriftNetArea())
+		{
+			return null;
+		}
+
+		if (config.highlightUntaggedFish())
+		{
+			renderFish(graphics);
+		}
+		if (config.showNetStatus())
+		{
+			renderNets(graphics);
+		}
+
+		return null;
+	}
+
+	private void renderFish(Graphics2D graphics)
+	{
+		for (NPC fish : plugin.getFish())
+		{
+			if (!plugin.getTaggedFish().containsKey(fish))
+			{
+				OverlayUtil.renderActorOverlay(graphics, fish, "", config.untaggedFishColor());
+			}
+		}
+	}
+
+	private void renderNets(Graphics2D graphics)
+	{
+		for (DriftNet net : plugin.getNETS())
+		{
+			final Shape polygon = net.getNet().getConvexHull();
+
+			if (polygon != null)
+			{
+				OverlayUtil.renderPolygon(graphics, polygon, net.getStatus().getColor());
+			}
+
+			String text = net.getFormattedCountText();
+			Point textLocation = net.getNet().getCanvasTextLocation(graphics, text, 0);
+			if (textLocation != null)
+			{
+				OverlayUtil.renderTextLocation(graphics, textLocation, text, config.countColor());
+			}
+		}
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/driftnet/DriftNetPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/driftnet/DriftNetPlugin.java
@@ -1,0 +1,298 @@
+/*
+ * Copyright (c) 2020, dekvall <https://github.com/dekvall>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.driftnet;
+
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Provides;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.inject.Inject;
+import lombok.Getter;
+import net.runelite.api.Actor;
+import net.runelite.api.ChatMessageType;
+import net.runelite.api.Client;
+import net.runelite.api.GameObject;
+import net.runelite.api.GameState;
+import net.runelite.api.NPC;
+import net.runelite.api.NpcID;
+import net.runelite.api.NullObjectID;
+import net.runelite.api.Player;
+import net.runelite.api.Varbits;
+import net.runelite.api.coords.WorldPoint;
+import net.runelite.api.events.ChatMessage;
+import net.runelite.api.events.GameObjectDespawned;
+import net.runelite.api.events.GameObjectSpawned;
+import net.runelite.api.events.GameStateChanged;
+import net.runelite.api.events.GameTick;
+import net.runelite.api.events.InteractingChanged;
+import net.runelite.api.events.NpcDespawned;
+import net.runelite.api.events.NpcSpawned;
+import net.runelite.api.events.VarbitChanged;
+import net.runelite.client.callback.ClientThread;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.eventbus.Subscribe;
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.ui.overlay.OverlayManager;
+
+@PluginDescriptor(
+	name = "Drift Net",
+	description = "Display information about drift nets",
+	tags = {"hunter", "fishing", "drift", "net"},
+	enabledByDefault = false
+)
+public class DriftNetPlugin extends Plugin
+{
+	static final String CONFIG_GROUP = "driftnet";
+	private static final int UNDERWATER_REGION = 15008;
+	private static final String CHAT_PRODDING_FISH  = "You prod at the shoal of fish to scare it.";
+
+	@Inject
+	private Client client;
+
+	@Inject
+	private ClientThread clientThread;
+
+	@Inject
+	private DriftNetConfig config;
+
+	@Inject
+	private OverlayManager overlayManager;
+
+	@Inject
+	private DriftNetOverlay overlay;
+
+	@Getter
+	private Set<NPC> fish = new HashSet<>();
+	@Getter
+	private Map<NPC, Integer> taggedFish = new HashMap<>();
+	@Getter
+	private final List<DriftNet> NETS = ImmutableList.of(
+		new DriftNet(NullObjectID.NULL_31433, Varbits.NORTH_NET_STATUS, Varbits.NORTH_NET_CATCH_COUNT),
+		new DriftNet(NullObjectID.NULL_31434, Varbits.SOUTH_NET_STATUS, Varbits.SOUTH_NET_CATCH_COUNT));
+
+	@Getter
+	private boolean inDriftNetArea;
+	private boolean armInteraction;
+
+	@Provides
+	DriftNetConfig provideConfig(ConfigManager configManager)
+	{
+		return configManager.getConfig(DriftNetConfig.class);
+	}
+
+	@Override
+	protected void startUp()
+	{
+		overlayManager.add(overlay);
+
+		if (client.getGameState() == GameState.LOGGED_IN)
+		{
+			clientThread.invokeLater(() ->
+			{
+				inDriftNetArea = checkArea();
+				updateDriftNetVarbits();
+			});
+		}
+	}
+
+	@Override
+	protected void shutDown()
+	{
+		overlayManager.remove(overlay);
+		reset();
+	}
+
+	@Subscribe
+	public void onGameStateChanged(GameStateChanged event)
+	{
+		switch (event.getGameState())
+		{
+			case LOGIN_SCREEN:
+			case HOPPING:
+			case LOADING:
+				reset();
+				break;
+			case LOGGED_IN:
+				inDriftNetArea = checkArea();
+				updateDriftNetVarbits();
+				break;
+		}
+	}
+
+	private void reset()
+	{
+		fish.clear();
+		taggedFish.clear();
+		armInteraction = false;
+		inDriftNetArea = false;
+	}
+
+	@Subscribe
+	public void onVarbitChanged(VarbitChanged event)
+	{
+		updateDriftNetVarbits();
+	}
+
+	private void updateDriftNetVarbits()
+	{
+		if (!inDriftNetArea)
+		{
+			return;
+		}
+
+		for (DriftNet net : NETS)
+		{
+			DriftNetStatus status = DriftNetStatus.of(client.getVar(net.getStatusVarbit()));
+			int count = client.getVar(net.getCountVarbit());
+
+			net.setStatus(status);
+			net.setCount(count);
+		}
+
+		// When you collect any loot, all tags become invalidated
+		if (client.getVar(Varbits.DRIFT_NET_COLLECT) != 0)
+		{
+			taggedFish.clear();
+		}
+	}
+
+	@Subscribe
+	public void onInteractingChanged(InteractingChanged event)
+	{
+		if (armInteraction
+			&& event.getSource() == client.getLocalPlayer()
+			&& event.getTarget() instanceof NPC
+			&& ((NPC) event.getTarget()).getId() == NpcID.FISH_SHOAL)
+		{
+			tagFish(event.getTarget());
+			armInteraction = false;
+		}
+	}
+
+	@Subscribe
+	public void onGameTick(GameTick tick)
+	{
+		if (!inDriftNetArea)
+		{
+			return;
+		}
+
+		final int currentTickCount = client.getTickCount();
+		taggedFish.entrySet().removeIf(entry -> entry.getValue() + config.timeoutDelay() < currentTickCount);
+
+		armInteraction = false;
+	}
+
+	@Subscribe
+	public void onChatMessage(ChatMessage event)
+	{
+		if (!inDriftNetArea)
+		{
+			return;
+		}
+
+		if (event.getType() == ChatMessageType.SPAM && event.getMessage().equals(CHAT_PRODDING_FISH))
+		{
+			Actor target = client.getLocalPlayer().getInteracting();
+
+			if (target instanceof NPC && ((NPC) target).getId() == NpcID.FISH_SHOAL)
+			{
+				tagFish(target);
+			}
+			else
+			{
+				// If the fish is on an adjacent tile, the interaction change happens after
+				// the chat message is sent, so we arm it
+				armInteraction = true;
+			}
+		}
+	}
+
+	private void tagFish(Actor fish)
+	{
+		NPC fishTarget = (NPC) fish;
+		taggedFish.put(fishTarget, client.getTickCount());
+	}
+
+	@Subscribe
+	public void onNpcSpawned(NpcSpawned event)
+	{
+		final NPC npc = event.getNpc();
+		if (npc.getId() == NpcID.FISH_SHOAL)
+		{
+			fish.add(npc);
+		}
+	}
+
+	@Subscribe
+	public void onNpcDespawned(NpcDespawned event)
+	{
+		final NPC npc = event.getNpc();
+		fish.remove(npc);
+	}
+
+	@Subscribe
+	public void onGameObjectSpawned(GameObjectSpawned event)
+	{
+		GameObject object = event.getGameObject();
+		for (DriftNet net : NETS)
+		{
+			if (net.getObjectId() == object.getId())
+			{
+				net.setNet(object);
+			}
+		}
+	}
+
+	@Subscribe
+	public void onGameObjectDespawned(GameObjectDespawned event)
+	{
+		GameObject object = event.getGameObject();
+		for (DriftNet net : NETS)
+		{
+			if (net.getObjectId() == object.getId())
+			{
+				net.setNet(null);
+			}
+		}
+	}
+
+	private boolean checkArea()
+	{
+		final Player localPlayer = client.getLocalPlayer();
+		if (localPlayer == null || !client.isInInstancedRegion())
+		{
+			return false;
+		}
+
+		final WorldPoint point = WorldPoint.fromLocalInstance(client, localPlayer.getLocalLocation());
+		return point.getRegionID() == UNDERWATER_REGION;
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/driftnet/DriftNetStatus.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/driftnet/DriftNetStatus.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2020, dekvall <https://github.com/dekvall>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.driftnet;
+
+import java.awt.Color;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+enum DriftNetStatus
+{
+	UNSET(Color.YELLOW),
+	SET(Color.GREEN),
+	CATCH(Color.GREEN),
+	FULL(Color.RED);
+
+	private final Color color;
+
+	static DriftNetStatus of(int varbitValue)
+	{
+		switch (varbitValue)
+		{
+			case 0:
+				return UNSET;
+			case 1:
+				return SET;
+			case 2:
+				return CATCH;
+			case 3:
+				return FULL;
+			default:
+				return null;
+		}
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -417,8 +417,18 @@ public interface MenuEntrySwapperConfig extends Config
 		name = "Essence Mine Teleport",
 		description = "Swaps Talk-To with Teleport for Wizard Distentor and Aubury."
 	)
-	default boolean swapEssenceMineTeleport() 
+	default boolean swapEssenceMineTeleport()
 	{
 		return false;
+	}
+
+	@ConfigItem(
+		keyName = "swapNets",
+		name = "Nets",
+		description = "Swap Talk-to with Nets on Annette"
+	)
+	default boolean swapNets()
+	{
+		return true;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -471,6 +471,11 @@ public class MenuEntrySwapperPlugin extends Plugin
 				swap("help", option, target, index);
 			}
 
+			if (config.swapNets())
+			{
+				swap("nets", option, target, index);
+			}
+
 			if (config.swapDarkMage())
 			{
 				swap("repairs", option, target, index);


### PR DESCRIPTION
This will add a plugin which shows the status of your nets and highlights any fish you haven't tagged.
![drift-net-plugin](https://user-images.githubusercontent.com/25151927/75198364-b1d19200-5760-11ea-82bc-64ab3ad2e350.png)

Closes #9731
Supersedes/Closes #10139