### PR TITLE
Added GPU plugin option to hide the UI

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuPlugin.java
@@ -67,6 +67,7 @@ import net.runelite.api.Texture;
 import net.runelite.api.TextureProvider;
 import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.hooks.DrawCallbacks;
+import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.callback.ClientThread;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
@@ -1102,7 +1103,11 @@ public class GpuPlugin extends Plugin implements DrawCallbacks
 		tempUvOffset = 0;
 
 		// Texture on UI
-		drawUi(canvasHeight, canvasWidth);
+		// Hide UI handling - show UI if client is not logged in so the Login UI can still be used, show UI if Message of the Day is open
+		if (!config.hideUi() || client.getGameState() != GameState.LOGGED_IN || client.getWidget(WidgetInfo.LOGIN_CLICK_TO_PLAY_SCREEN_MESSAGE_OF_THE_DAY) != null)
+		{
+			drawUi(canvasHeight, canvasWidth);
+		}
 
 		glDrawable.swapBuffers();
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuPluginConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuPluginConfig.java
@@ -96,4 +96,12 @@ public interface GpuPluginConfig extends Config
 	{
 		return 0;
 	}
+
+	@ConfigItem(
+		keyName = "hideUi",
+		name = "Hide UI",
+		description = "Hide the User Interface.",
+		position = 6
+	)
+	default boolean hideUi() { return false; }
 }


### PR DESCRIPTION
Closes #10803

Added a feature to hide the UI, which is very nice for taking screenshots or recording video footage. There's currently ways to hide the minimap and minimize UI panels, but not any way that I know of to hide the entire UI.

This updates the GPU plugin and adds an option to Hide UI. The user suggested that a keyboard shortcut - I'll wait for feedback too see whether or not that should be implemented. World of Warcraft uses Alt-Z, this shortcut isn't used elsewhere in Runelite but Alt isn't used for many non-development shortcuts if I'm not mistaken.

Config Option successfully hides UI in-game:
![1](https://user-images.githubusercontent.com/9663394/75201155-87f67c00-571c-11ea-9803-935df41ee301.PNG)

![2](https://user-images.githubusercontent.com/9663394/75201156-8af16c80-571c-11ea-9438-204c7cb5b302.PNG)

Also, it doesn't hide the UI if the user isn't logged in or the Message of the Day screen is present - so the user can actually log into the game if the option is enabled.
![3](https://user-images.githubusercontent.com/9663394/75201172-98a6f200-571c-11ea-8539-958ec868024e.PNG)
