### PR TITLE
Add Camera Cycle to camera plugin

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/camera/CameraConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/camera/CameraConfig.java
@@ -28,6 +28,7 @@ import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
 import net.runelite.client.config.Range;
+import net.runelite.client.config.Units;
 
 @ConfigGroup("zoom") // using the old plugin's group name
 public interface CameraConfig extends Config
@@ -201,5 +202,28 @@ public interface CameraConfig extends Config
 	default boolean preserveYaw()
 	{
 		return false;
+	}
+
+	@ConfigItem(
+		keyName = "compassMultipleClickCycle",
+		name = "Multiple clicks on compass ",
+		description = "Cycle between Look North, South, East, and West by clicking on compass in rapid succession",
+		position = 15
+	)
+	default boolean compassMultipleClickCycle()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		keyName = "compassMultipleClickTimeout",
+		name = "Multiple click timeout",
+		description = "Configure how quickly the compass resets to \"Look North\" after the last click",
+		position = 16
+	)
+	@Units(Units.SECONDS)
+	default int compassMultipleClickTimeout()
+	{
+		return 2;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/camera/CameraPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/camera/CameraPlugin.java
@@ -89,7 +89,7 @@ public class CameraPlugin extends Plugin implements KeyListener, MouseListener
 	private static final String DEFAULT_LEFT_CLICK_OPTION = LOOK_NORTH;
 	private int lastUpdatedTick = 0;
 	private String currentLeftClickOption;
-	private String[] options = new String[]{LOOK_NORTH, LOOK_SOUTH, LOOK_EAST, LOOK_WEST};
+	private final String[] options = {LOOK_NORTH, LOOK_SOUTH, LOOK_EAST, LOOK_WEST};
 
 	private boolean controlDown;
 	// flags used to store the mousedown states


### PR DESCRIPTION
The idea with this functionality is that multiple repeated clicks would cycle the camera through the cardinal directions. Two quick clicks would reset to Look South, three to Look East, etc. The timeout that determines how quickly these clicks need to be is configurable (mouse vs tablet users could enjoy different values)

This is off by default. It shouldn't conflict with the Compass options `compassLook` functionality, but just extend it. The order will continue to be `North, South, East, West` however if East is the current top menu entry the menu will show `East, West, North, South` to prevent duplicate menu entries.

Closes https://github.com/runelite/runelite/issues/10731 particularly this comment https://github.com/runelite/runelite/issues/10731#issuecomment-582265261