### PR TITLE
Ground Items: Add notification by value config option

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
@@ -328,10 +328,21 @@ public interface GroundItemsConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "notifyOverValue",
+		name = "Notify > Value",
+		description = "Configures the start price for being notified of an item drop",
+		position = 25
+	)
+	default int getNotifyOverValue()
+	{
+		return 0;
+	}
+
+	@ConfigItem(
 		keyName = "onlyShowLoot",
 		name = "Only show loot",
 		description = "Only shows drops from NPCs and players",
-		position = 25
+		position = 26
 	)
 	default boolean onlyShowLoot()
 	{
@@ -342,7 +353,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "doubleTapDelay",
 		name = "Delay for double-tap ALT to hide",
 		description = "Decrease this number if you accidentally hide ground items often. (0 = Disabled)",
-		position = 26
+		position = 27
 	)
 	@Units(Units.MILLISECONDS)
 	default int doubleTapDelay()
@@ -354,7 +365,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "collapseEntries",
 		name = "Collapse ground item menu entries",
 		description = "Collapses ground item menu entries together and appends count",
-		position = 27
+		position = 28
 	)
 	default boolean collapseEntries()
 	{
@@ -365,7 +376,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "groundItemTimers",
 		name = "Show despawn timers",
 		description = "Shows despawn timers for items you've dropped and received as loot",
-		position = 28
+		position = 29
 	)
 	default boolean groundItemTimers()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
@@ -662,8 +662,7 @@ public class GroundItemsPlugin extends Plugin
 		{
 			notificationStringBuilder.append(" x ").append(item.getQuantity());
 
-
-			if (item.getQuantity() > (int) Character.MAX_VALUE)
+			if (item.getQuantity() >= (int) Character.MAX_VALUE)
 			{
 				notificationStringBuilder.append(" (Lots!)");
 			}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
@@ -31,6 +31,7 @@ import com.google.common.collect.EvictingQueue;
 import com.google.inject.Provides;
 import java.awt.Color;
 import java.awt.Rectangle;
+import static java.lang.Boolean.FALSE;
 import static java.lang.Boolean.TRUE;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -242,7 +243,9 @@ public class GroundItemsPlugin extends Plugin
 		{
 			notifyHighlightedItem(groundItem);
 		}
-		else if (highlightedColor != null && (!config.onlyShowLoot() || groundItem.isMine()) && getGroundItemConfigValue(groundItem) > config.getNotifyOverValue())
+		else if (FALSE.equals(hiddenItems.getUnchecked(groundItem.getName()))
+			&& (!config.onlyShowLoot() || groundItem.isMine())
+			&& getGroundItemConfigValue(groundItem) > config.getNotifyOverValue())
 		{
 			notifyValuableItem(groundItem);
 		}


### PR DESCRIPTION
Pretty much does the title

![image](https://user-images.githubusercontent.com/29030969/75202381-e96c1a00-571f-11ea-8670-9bf1e2e2195b.png)

This also fixes a bug in the notification where it should have displayed `Lots` but was instead display 65535

![image](https://user-images.githubusercontent.com/29030969/75203248-8039d600-5722-11ea-8a29-90902ee9babe.png)