### PR TITLE
Remove deprecated/default Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: java
-sudo: false
+os: linux
 dist: xenial
 cache:
   directories:


### PR DESCRIPTION
[`sudo` does nothing anymore](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration)
[`os` is linux by default](https://docs.travis-ci.com/user/reference/overview/#for-a-particular-travisyml-configuration) but it would be configure it verbosely