### PR TITLE
Plugin Hub: Reorder plugin panel and rework the search function

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/externalplugins/ExternalPluginManifest.java
+++ b/runelite-client/src/main/java/net/runelite/client/externalplugins/ExternalPluginManifest.java
@@ -29,6 +29,7 @@ import com.google.common.io.Files;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
+import javax.annotation.Nullable;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import net.runelite.client.RuneLite;
@@ -45,7 +46,9 @@ public class ExternalPluginManifest
 	private String displayName;
 	private String version;
 	private String author;
+	@Nullable
 	private String description;
+	@Nullable
 	private String[] tags;
 	@EqualsAndHashCode.Exclude
 	private URL support;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/PluginHubPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/PluginHubPanel.java
@@ -37,7 +37,9 @@ import java.awt.event.ActionEvent;
 import java.awt.event.KeyEvent;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
@@ -45,7 +47,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Function;
-import java.util.function.ToDoubleFunction;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -85,8 +86,8 @@ import net.runelite.client.ui.components.IconTextField;
 import net.runelite.client.util.ImageUtil;
 import net.runelite.client.util.LinkBrowser;
 import net.runelite.client.util.SwingUtil;
+import net.runelite.client.util.Text;
 import net.runelite.client.util.VerificationException;
-import org.apache.commons.text.similarity.JaroWinklerDistance;
 
 @Slf4j
 @Singleton
@@ -98,7 +99,6 @@ class PluginHubPanel extends PluginPanel
 	private static final ImageIcon CONFIGURE_ICON;
 	private static final ImageIcon CONFIGURE_ICON_HOVER;
 	private static final Pattern SPACES = Pattern.compile(" +");
-	private static final JaroWinklerDistance DISTANCE = new JaroWinklerDistance();
 
 	static
 	{
@@ -119,15 +119,12 @@ class PluginHubPanel extends PluginPanel
 		private static final int HEIGHT = 70;
 		private static final int ICON_WIDTH = 48;
 		private static final int BOTTOM_LINE_HEIGHT = 16;
-		static final float MIN_FILTER_SCORE = .8f;
 
 		private final ExternalPluginManifest manifest;
+		private final List<String> keywords = new ArrayList<>();
 
 		@Getter
 		private final boolean installed;
-
-		@Getter
-		private float filter;
 
 		PluginItem(ExternalPluginManifest newManifest, Collection<Plugin> loadedPlugins, boolean installed)
 		{
@@ -139,6 +136,23 @@ class PluginHubPanel extends PluginPanel
 
 			manifest = newManifest == null ? loaded : newManifest;
 			this.installed = installed;
+
+			if (manifest != null)
+			{
+				Collections.addAll(keywords, SPACES.split(manifest.getDisplayName().toLowerCase()));
+
+				if (manifest.getDescription() != null)
+				{
+					Collections.addAll(keywords, SPACES.split(manifest.getDescription().toLowerCase()));
+				}
+
+				Collections.addAll(keywords, manifest.getAuthor().toLowerCase());
+
+				if (manifest.getTags() != null)
+				{
+					Collections.addAll(keywords, manifest.getTags());
+				}
+			}
 
 			setBackground(ColorScheme.DARKER_GRAY_COLOR);
 			setOpaque(true);
@@ -301,23 +315,6 @@ class PluginHubPanel extends PluginPanel
 						.addComponent(configure, BOTTOM_LINE_HEIGHT, BOTTOM_LINE_HEIGHT, BOTTOM_LINE_HEIGHT)
 						.addComponent(addrm, BOTTOM_LINE_HEIGHT, BOTTOM_LINE_HEIGHT, BOTTOM_LINE_HEIGHT))
 					.addGap(5)));
-		}
-
-		float setFilter(String[] filter)
-		{
-			ToDoubleFunction<String> match = r -> Stream.of(filter)
-				.mapToDouble(l -> Math.pow(DISTANCE.apply(l, r), 2))
-				.max()
-				.orElse(0.D);
-
-			double sim = SPACES.splitAsStream(manifest.getDisplayName()).collect(Collectors.averagingDouble(match)) * 2;
-
-			if (manifest.getTags() != null)
-			{
-				sim += Stream.of(manifest.getTags()).mapToDouble(match).sum();
-			}
-
-			return this.filter = (float) sim;
 		}
 	}
 
@@ -537,8 +534,8 @@ class PluginHubPanel extends PluginPanel
 		{
 			String[] searchArray = SPACES.split(search.toLowerCase());
 			stream = stream
-				.filter(p -> p.setFilter(searchArray) > PluginItem.MIN_FILTER_SCORE)
-				.sorted(Comparator.comparing(PluginItem::getFilter));
+				.filter(p -> Text.matchesSearchTerms(searchArray, p.keywords))
+				.sorted(Comparator.comparing(p -> p.manifest.getDisplayName()));
 		}
 		else
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/PluginHubPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/PluginHubPanel.java
@@ -543,7 +543,7 @@ class PluginHubPanel extends PluginPanel
 		else
 		{
 			stream = stream
-				.sorted(Comparator.comparing(PluginItem::isInstalled));
+				.sorted(Comparator.comparing(PluginItem::isInstalled).thenComparing(p -> p.manifest.getDisplayName()));
 		}
 
 		stream.forEach(mainPanel::add);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/PluginListItem.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/PluginListItem.java
@@ -52,12 +52,9 @@ import net.runelite.client.ui.ColorScheme;
 import net.runelite.client.ui.PluginPanel;
 import net.runelite.client.util.ImageUtil;
 import net.runelite.client.util.SwingUtil;
-import org.apache.commons.text.similarity.JaroWinklerDistance;
 
 class PluginListItem extends JPanel
 {
-	private static final JaroWinklerDistance DISTANCE = new JaroWinklerDistance();
-
 	private static final ImageIcon CONFIG_ICON;
 	private static final ImageIcon CONFIG_ICON_HOVER;
 	private static final ImageIcon ON_STAR;
@@ -68,6 +65,7 @@ class PluginListItem extends JPanel
 	@Getter
 	private final PluginConfigurationDescriptor pluginConfig;
 
+	@Getter
 	private final List<String> keywords = new ArrayList<>();
 
 	private final JToggleButton pinButton;
@@ -200,24 +198,6 @@ class PluginListItem extends JPanel
 	void setPluginEnabled(boolean enabled)
 	{
 		onOffToggle.setSelected(enabled);
-	}
-
-	/**
-	 * Checks if all the search terms in the given list matches at least one keyword.
-	 *
-	 * @return true if all search terms matches at least one keyword, or false if otherwise.
-	 */
-	boolean matchesSearchTerms(String[] searchTerms)
-	{
-		for (String term : searchTerms)
-		{
-			if (keywords.stream().noneMatch((t) -> t.contains(term) ||
-				DISTANCE.apply(t, term) > 0.9))
-			{
-				return false;
-			}
-		}
-		return true;
 	}
 
 	private void openGroupConfigPanel()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/PluginListPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/PluginListPanel.java
@@ -271,7 +271,7 @@ class PluginListPanel extends PluginPanel
 		final String[] searchTerms = text.toLowerCase().split(" ");
 		pluginList.forEach(listItem ->
 		{
-			if (pinned == listItem.isPinned() && listItem.matchesSearchTerms(searchTerms))
+			if (pinned == listItem.isPinned() && Text.matchesSearchTerms(searchTerms, listItem.getKeywords()))
 			{
 				mainPanel.add(listItem);
 			}

--- a/runelite-client/src/main/java/net/runelite/client/util/Text.java
+++ b/runelite-client/src/main/java/net/runelite/client/util/Text.java
@@ -32,12 +32,14 @@ import java.util.Collection;
 import java.util.List;
 import java.util.regex.Pattern;
 import org.apache.commons.text.WordUtils;
+import org.apache.commons.text.similarity.JaroWinklerDistance;
 
 /**
  * A set of utilities to use when dealing with text.
  */
 public class Text
 {
+	private static final JaroWinklerDistance DISTANCE = new JaroWinklerDistance();
 	private static final Pattern TAG_REGEXP = Pattern.compile("<[^>]*>");
 	private static final Splitter COMMA_SPLITTER = Splitter
 		.on(",")
@@ -185,5 +187,23 @@ public class Text
 		}
 
 		return toString;
+	}
+
+	/**
+	 * Checks if all the search terms in the given list matches at least one keyword.
+	 *
+	 * @return true if all search terms matches at least one keyword, or false if otherwise.
+	 */
+	public static boolean matchesSearchTerms(String[] searchTerms, final Collection<String> keywords)
+	{
+		for (String term : searchTerms)
+		{
+			if (keywords.stream().noneMatch((t) -> t.contains(term) ||
+				DISTANCE.apply(t, term) > 0.9))
+			{
+				return false;
+			}
+		}
+		return true;
 	}
 }


### PR DESCRIPTION
1) Changed the panel to sort by display name, not internal name

2) The existing search logic gives basically useless results.

This makes it more in line with how the main plugin panel's search works.