### PR TITLE
Check player animation to update fishing status

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/AnimationID.java
+++ b/runelite-api/src/main/java/net/runelite/api/AnimationID.java
@@ -103,6 +103,14 @@ public final class AnimationID
 	public static final int FISHING_CRUSHING_INFERNAL_EELS = 7553;
 	public static final int FISHING_CUTTING_SACRED_EELS = 7151;
 	public static final int FISHING_BAREHAND = 6709;
+	public static final int FISHING_BAREHAND_WINDUP_1 = 6703;
+	public static final int FISHING_BAREHAND_WINDUP_2 = 6704;
+	public static final int FISHING_BAREHAND_CAUGHT_SHARK_1 = 6705;
+	public static final int FISHING_BAREHAND_CAUGHT_SHARK_2 = 6706;
+	public static final int FISHING_BAREHAND_CAUGHT_SWORDFISH_1 = 6707;
+	public static final int FISHING_BAREHAND_CAUGHT_SWORDFISH_2 = 6708;
+	public static final int FISHING_BAREHAND_CAUGHT_TUNA_1 = 6710;
+	public static final int FISHING_BAREHAND_CAUGHT_TUNA_2 = 6711;
 	public static final int MINING_BRONZE_PICKAXE = 625;
 	public static final int MINING_IRON_PICKAXE = 626;
 	public static final int MINING_STEEL_PICKAXE = 627;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingOverlay.java
@@ -27,7 +27,10 @@ package net.runelite.client.plugins.fishing;
 import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Graphics2D;
+import java.util.Set;
 import javax.inject.Inject;
+import com.google.common.collect.ImmutableSet;
+import net.runelite.api.AnimationID;
 import net.runelite.api.Client;
 import net.runelite.api.GraphicID;
 import static net.runelite.api.MenuAction.RUNELITE_OVERLAY;
@@ -46,6 +49,28 @@ class FishingOverlay extends Overlay
 {
 	private static final String FISHING_SPOT = "Fishing spot";
 	static final String FISHING_RESET = "Reset";
+
+	private static final Set<Integer> FISHING_ANIMATIONS = ImmutableSet.of(
+		AnimationID.FISHING_BARBTAIL_HARPOON,
+		AnimationID.FISHING_BAREHAND,
+		AnimationID.FISHING_BAREHAND_CAUGHT_SHARK_1,
+		AnimationID.FISHING_BAREHAND_CAUGHT_SHARK_2,
+		AnimationID.FISHING_BAREHAND_CAUGHT_SWORDFISH_1,
+		AnimationID.FISHING_BAREHAND_CAUGHT_SWORDFISH_2,
+		AnimationID.FISHING_BAREHAND_CAUGHT_TUNA_1,
+		AnimationID.FISHING_BAREHAND_CAUGHT_TUNA_2,
+		AnimationID.FISHING_BAREHAND_WINDUP_1,
+		AnimationID.FISHING_BAREHAND_WINDUP_2,
+		AnimationID.FISHING_BIG_NET,
+		AnimationID.FISHING_CAGE,
+		AnimationID.FISHING_CRYSTAL_HARPOON,
+		AnimationID.FISHING_DRAGON_HARPOON,
+		AnimationID.FISHING_HARPOON,
+		AnimationID.FISHING_INFERNAL_HARPOON,
+		AnimationID.FISHING_KARAMBWAN,
+		AnimationID.FISHING_NET,
+		AnimationID.FISHING_OILY_ROD,
+		AnimationID.FISHING_POLE_CAST);
 
 	private final Client client;
 	private final FishingPlugin plugin;
@@ -78,7 +103,8 @@ class FishingOverlay extends Overlay
 		panelComponent.getChildren().clear();
 		if (client.getLocalPlayer().getInteracting() != null
 			&& client.getLocalPlayer().getInteracting().getName().contains(FISHING_SPOT)
-			&& client.getLocalPlayer().getInteracting().getGraphic() != GraphicID.FLYING_FISH)
+			&& client.getLocalPlayer().getInteracting().getGraphic() != GraphicID.FLYING_FISH
+			&& FISHING_ANIMATIONS.contains(client.getLocalPlayer().getAnimation()))
 		{
 			panelComponent.getChildren().add(TitleComponent.builder()
 				.text("Fishing")


### PR DESCRIPTION
closes #10900 

In render method, provide additional check to see if `WidgetInfo.LEVEL_UP` widget is loaded.

------
This solution works in all cases whereupon leveling up Fishing does NOT unlock new fish.
In the cases where you do unlock fish, there is a second dialogue describing which new fish you can catch. If you click through the level up dialogue, the fishing status will resolve to "Fishing" as if the second dialogue wasn't there. For other skills (Cooking, Mining) when you unlock something upon leveling up, a widget with groupId `DIALOG_SPRITE_GROUP_ID`, 193, is loaded, which would enable checking against presence of `WidgetInfo.DIALOG_SPRITE` to determine if player was in 'unlock new stuff' dialogue. However, when unlocking Fishing, the loaded groupId is 11, which is not assigned to anything in `WidgetID.java`, and a WidgetInfo.DIALOG_SPRITE widget is never present while leveling up Fishing.

If this solution isn't satisfactory, I can provide an additional check against the player's animationId versus an immutable set of all fishing animations, which would work, but it's just a little heavy-handed.

Brandt