### PR TITLE
Add an option to show the average amount for a loot source in the loot tracker

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerBox.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerBox.java
@@ -222,6 +222,7 @@ class LootTrackerBox extends JPanel
 		if (kills > 1)
 		{
 			subTitleLabel.setText("x " + kills);
+			subTitleLabel.setToolTipText(QuantityFormatter.formatNumber(totalPrice / kills) + " gp (average)");
 		}
 
 		validate();


### PR DESCRIPTION
I've found myself manually calculating the average anyway out of curiousity.

This adds a tooltip to the number of kills label so that the average can be seen.

For those who'd prefer, it also allows the total GP to be replaced with the average value.
The tooltip will show the option not selected.