### PR TITLE
item stats: Fix tooltip stab bonus comparison

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatOverlay.java
@@ -281,7 +281,7 @@ public class ItemStatOverlay extends Overlay
 			b.append(buildStatRow("Magic Dmg", currentEquipment.getMdmg(), e.getMdmg(), false, true));
 
 			final StringBuilder abb = new StringBuilder();
-			abb.append(buildStatRow("Stab", currentEquipment.getAspeed(), e.getAspeed(), false, false));
+			abb.append(buildStatRow("Stab", currentEquipment.getAstab(), e.getAstab(), false, false));
 			abb.append(buildStatRow("Slash", currentEquipment.getAslash(), e.getAslash(), false, false));
 			abb.append(buildStatRow("Crush", currentEquipment.getAcrush(), e.getAcrush(), false, false));
 			abb.append(buildStatRow("Magic", currentEquipment.getAmagic(), e.getAmagic(), false, false));


### PR DESCRIPTION
This fixes the bug introduced in commit af00494a which incorrectly
compared the attack speed field and labeled it "Stab" in the item stats
tooltip.

Fixes runelite/runelite#10926