### PR TITLE
Feature - Kingdom of Miscellania notification message

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/Varbits.java
+++ b/runelite-api/src/main/java/net/runelite/api/Varbits.java
@@ -387,9 +387,10 @@ public enum Varbits
 	MULTICOMBAT_AREA(4605),
 
 	/**
-	 * Kingdom Management
+	 * Kingdom of Miscellania Management
+	 * Kingdom Approval is represented as a 7-bit unsigned integer; 127 corresponds to 100% approval
 	 */
-	KINGDOM_FAVOR(72),
+	KINGDOM_APPROVAL(72),
 	KINGDOM_COFFER(74),
 
 	/**

--- a/runelite-client/src/main/java/net/runelite/client/plugins/kingdomofmiscellania/KingdomConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/kingdomofmiscellania/KingdomConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Infinitay <https://github.com/Infinitay>
+ * Copyright (c) 2020, Brandt Hill <https://github.com/BrandtHill>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -24,30 +24,54 @@
  */
 package net.runelite.client.plugins.kingdomofmiscellania;
 
-import java.awt.image.BufferedImage;
-import net.runelite.client.ui.overlay.infobox.Counter;
-import net.runelite.client.util.QuantityFormatter;
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.Range;
 
-public class KingdomCounter extends Counter
+@ConfigGroup(KingdomConfig.CONFIG_GROUP_NAME)
+public interface KingdomConfig extends Config
 {
-	private final KingdomPlugin plugin;
+	String CONFIG_GROUP_NAME = "kingdomofmiscellania";
+	int MAX_COFFER = 7_500_000;
+	int MAX_APPROVAL_PERCENT = 100;
 
-	KingdomCounter(BufferedImage image, KingdomPlugin plugin)
+	@ConfigItem(
+		position = 1,
+		keyName = "sendNotifications",
+		name = "Send Notifications",
+		description = "Send chat notifications upon login showing current estimated coffer and approval"
+	)
+	default boolean shouldSendNotifications()
 	{
-		super(image, plugin, plugin.getApproval());
-		this.plugin = plugin;
+		return false;
 	}
 
-	@Override
-	public String getText()
+	@Range(
+		max = MAX_COFFER
+	)
+	@ConfigItem(
+		position = 2,
+		keyName = "cofferThreshold",
+		name = "Coffer Threshold",
+		description = "Send notifications if coffer is below this value"
+	)
+	default int getCofferThreshold()
 	{
-		return KingdomPlugin.getApprovalPercent(plugin.getApproval()) + "%";
+		return MAX_COFFER;
 	}
 
-	@Override
-	public String getTooltip()
+	@Range(
+		max = MAX_APPROVAL_PERCENT
+	)
+	@ConfigItem(
+		position = 3,
+		keyName = "approvalThreshold",
+		name = "Approval Threshold",
+		description = "Send notifications if approval percentage is below this value"
+	)
+	default int getApprovalThreshold()
 	{
-		return "Approval: " + plugin.getApproval() + "/" + KingdomPlugin.MAX_APPROVAL + "</br>"
-			+ "Coffer: " + QuantityFormatter.quantityToStackSize(plugin.getCoffer());
+		return MAX_APPROVAL_PERCENT;
 	}
 }


### PR DESCRIPTION
I dreamt of an additional feature for the KingdomPlugin several months and finally decided to implement it. Upon login, if the user is managing the kingdom, their coffer and favor will be sent as a chat notification. The values are calculated using the last known coffer and favor values the same way the server calculates them.

![image](https://user-images.githubusercontent.com/38387397/75746310-8100d800-5cdf-11ea-9589-e46159088baf.png)

~~Let me know if I should create a corresponding issue for this feature and amend this PR to close it.~~
closes #10939 

Brandt