### PR TITLE
Change to use github link instead of email

### DIFF
--- a/runelite-client/src/test/java/net/runelite/client/plugins/woodcutting/WoodcuttingPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/woodcutting/WoodcuttingPluginTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Jordan Zomerlei <jordan@zomerlei.com>
+ * Copyright (c) 2020, Jordan Zomerlei <https://github.com/JZomerlei>
  * Copyright (c) 2019, Adam <Adam@sigterm.info>
  * All rights reserved.
  *


### PR DESCRIPTION
I would rather my github profile be linked instead of my email.