### PR TITLE
itemstats: Fix unarmed attack speed

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatOverlay.java
@@ -48,10 +48,10 @@ import net.runelite.http.api.item.ItemStats;
 
 public class ItemStatOverlay extends Overlay
 {
-	// Unarmed attack speed is 6
+	// Unarmed attack speed is 4
 	private static final ItemStats UNARMED = new ItemStats(false, true, 0, 0,
 		ItemEquipmentStats.builder()
-			.aspeed(6)
+			.aspeed(4)
 			.build());
 
 	@Inject


### PR DESCRIPTION
Since the writing of this plugin, the wiki has changed the format for
weapon attack speeds[1] and now displays weapon attack speeds in length
of game ticks. Hence, since unarmed attacks are at the rate of once
every 4 game ticks, this commit updates our definition of the unarmed
attack accordingly.

[1] https://oldschool.runescape.wiki/w/Unarmed?diff=8467472&oldid=7810087