### PR TITLE
ground items plugin: turn double tap to hide off by default

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
@@ -347,7 +347,7 @@ public interface GroundItemsConfig extends Config
 	@Units(Units.MILLISECONDS)
 	default int doubleTapDelay()
 	{
-		return 250;
+		return 0;
 	}
 
 	@ConfigItem(


### PR DESCRIPTION
Too many people trigger this on accident without knowing it is a feature. I think it is reasonable for people to have to set a delay to turn on the feature.