### PR TITLE
cache: Create temporary foldeer when specified

### DIFF
--- a/cache/src/test/java/net/runelite/cache/StoreLocation.java
+++ b/cache/src/test/java/net/runelite/cache/StoreLocation.java
@@ -93,7 +93,7 @@ public class StoreLocation
 
 	public static TemporaryFolder getTemporaryFolder()
 	{
-		return new TemporaryFolder()
+		return new TemporaryFolder(TMP)
 		{
 			@Override
 			public void after()


### PR DESCRIPTION
Prior to this commit, specifying a cache tmpdir via `-Dcache.tmpdir`
would fail if the given path did not already exist. This commit passes
that dir to the constructed TemporaryFolder, which creates that path
even when absent on the filesystem prior to executing
`getTemporaryFolder()`.