### PR TITLE
Use bank title for determining if tag tab menu is active

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/banktags/tabs/TabInterface.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/banktags/tabs/TabInterface.java
@@ -688,7 +688,7 @@ public class TabInterface
 		{
 			entries = createMenuEntry(event, TAG_INVENTORY, event.getTarget(), entries);
 
-			if (activeTab != null)
+			if (activeTab != null && !isTabMenuActive())
 			{
 				entries = createMenuEntry(event, TAG_INVENTORY, ColorUtil.wrapWithColorTag(activeTab.getTag(), HILIGHT_COLOR), entries);
 			}
@@ -700,7 +700,7 @@ public class TabInterface
 		{
 			entries = createMenuEntry(event, TAG_GEAR, event.getTarget(), entries);
 
-			if (activeTab != null)
+			if (activeTab != null && !isTabMenuActive())
 			{
 				entries = createMenuEntry(event, TAG_GEAR, ColorUtil.wrapWithColorTag(activeTab.getTag(), HILIGHT_COLOR), entries);
 			}
@@ -834,7 +834,7 @@ public class TabInterface
 			{
 				MenuEntry entry = entries[entries.length - 1];
 
-				if (draggedWidget.getItemId() > 0 && entry.getOption().equals(VIEW_TAB) && draggedOn.getId() != draggedWidget.getId())
+				if (!isTabMenuActive() && draggedWidget.getItemId() > 0 && entry.getOption().equals(VIEW_TAB) && draggedOn.getId() != draggedWidget.getId())
 				{
 					entry.setOption(TAG_SEARCH + Text.removeTags(entry.getTarget()) + (shiftDown ? VAR_TAG_SUFFIX : ""));
 					entry.setTarget(draggedWidget.getName());

--- a/runelite-client/src/main/java/net/runelite/client/plugins/banktags/tabs/TabInterface.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/banktags/tabs/TabInterface.java
@@ -520,26 +520,7 @@ public class TabInterface
 			return;
 		}
 
-		String str = client.getVar(VarClientStr.INPUT_TEXT);
-
-		if (Strings.isNullOrEmpty(str))
-		{
-			str = "";
-		}
-
-		Widget bankTitle = client.getWidget(WidgetInfo.BANK_TITLE_BAR);
-		if (bankTitle != null && !bankTitle.isHidden() && !str.startsWith(TAG_SEARCH))
-		{
-			str = bankTitle.getText().replaceFirst("Showing items: ", "");
-
-			if (str.startsWith("Tab "))
-			{
-				str = "";
-			}
-		}
-
-		str = Text.standardize(str);
-
+		String str = this.getTrimmedTitle();
 		if (str.startsWith(BankTagsPlugin.TAG_SEARCH))
 		{
 			activateTab(tabManager.find(str.substring(TAG_SEARCH.length())));
@@ -593,6 +574,28 @@ public class TabInterface
 		}
 	}
 
+	private String getTrimmedTitle()
+	{
+		String str = client.getVar(VarClientStr.INPUT_TEXT);
+		if (Strings.isNullOrEmpty(str))
+		{
+			str = "";
+		}
+
+		Widget bankTitle = client.getWidget(WidgetInfo.BANK_TITLE_BAR);
+		if (bankTitle != null && !bankTitle.isHidden() && !str.startsWith(TAG_SEARCH))
+		{
+			str = bankTitle.getText().replaceFirst("Showing items: ", "");
+
+			if (str.startsWith("Tab "))
+			{
+				str = "";
+			}
+		}
+
+		return Text.standardize(str);
+	}
+
 	private void setTabMenuVisible(boolean visible)
 	{
 		for (TagTab t : tabManager.getTabs())
@@ -603,7 +606,8 @@ public class TabInterface
 
 	private boolean isTabMenuActive()
 	{
-		return TAB_MENU.equals(client.getVar(VarClientStr.INPUT_TEXT));
+		String title = getTrimmedTitle();
+		return !Strings.isNullOrEmpty(title) && title.equals(TAB_MENU);
 	}
 
 	public void handleScriptEvent(final ScriptCallbackEvent event)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/banktags/tabs/TabInterface.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/banktags/tabs/TabInterface.java
@@ -410,6 +410,7 @@ public class TabInterface
 
 				if (tab.equals(activeTab))
 				{
+					resetBankTitle();
 					bankSearch.reset(true);
 					rememberedSearch = "";
 
@@ -596,6 +597,15 @@ public class TabInterface
 		return Text.standardize(str);
 	}
 
+	private void resetBankTitle()
+	{
+		// Clear the bank title if leaving tag tab menu
+		if (isTabMenuActive())
+		{
+			client.getWidget(WidgetInfo.BANK_TITLE_BAR).setText("");
+		}
+	}
+
 	private void setTabMenuVisible(boolean visible)
 	{
 		for (TagTab t : tabManager.getTabs())
@@ -743,6 +753,7 @@ public class TabInterface
 			&& event.getMenuOption().equals("Search")
 			&& client.getWidget(WidgetInfo.BANK_SEARCH_BUTTON_BACKGROUND).getSpriteId() != SpriteID.EQUIPMENT_SLOT_SELECTED)
 		{
+			resetBankTitle();
 			activateTab(null);
 			// This ensures that when clicking Search when tab is selected, the search input is opened rather
 			// than client trying to close it first
@@ -752,6 +763,7 @@ public class TabInterface
 		else if (activeTab != null
 			&& event.getMenuOption().startsWith("View tab"))
 		{
+			resetBankTitle();
 			activateTab(null);
 		}
 		else if (activeTab != null
@@ -959,6 +971,7 @@ public class TabInterface
 	{
 		if (activeTab != null && activeTab.getTag().equals(tag))
 		{
+			resetBankTitle();
 			bankSearch.reset(true);
 		}
 

--- a/runelite-client/src/main/scripts/BankSearchLayout.rs2asm
+++ b/runelite-client/src/main/scripts/BankSearchLayout.rs2asm
@@ -968,13 +968,12 @@ LABEL848:
    add                   
    istore                 20
    jump                   LABEL769
-SetTitle:
+LABEL853:
    iconst                 0                  ; Compare variable
    iconst                 0                  ;
    sconst                 "isTabMenuActive"
    runelite_callback     ; skip setting the bank title if the tag tab menu is active
    if_icmpne              FinishBuilding
-LABEL853:
    get_varbit             4170
    iconst                 2
    if_icmpeq              LABEL857


### PR DESCRIPTION
Closes #10954

* Check the bank title when in tag tab menu because the chatbox input can be reset 
* Reset the bank title when leaving the tag tab menu because the script hook relies on bank title to stop the normal bank layout
* Remove the tag options for inventory and item drag because it doesn't make sense to tag items as `tagtabs`
* Fix script that broke from an auto merge