### PR TITLE
Bank Quantity Feature

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/banktags/BankTagsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/banktags/BankTagsConfig.java
@@ -24,6 +24,8 @@
  */
 package net.runelite.client.plugins.banktags;
 
+import java.awt.Color;
+import net.runelite.client.config.Alpha;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
@@ -51,6 +53,40 @@ public interface BankTagsConfig extends Config
 	default boolean rememberTab()
 	{
 		return true;
+	}
+
+	@ConfigItem(
+		keyName = "useQuantityFeature",
+		name = "Use Quantities",
+		description = "Display an overlay of the quantity of items for the tag.",
+		position = 3
+	)
+	default boolean useQuantityFeature()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		keyName = "autoSetQuantity",
+		name = "Auto set Quantity",
+		description = "Automatically set quantities when tagging your inventory.",
+		position = 4
+	)
+	default boolean autoSetQuantity()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		keyName = "quantityOverlayColor",
+		name = "Color of Quantity",
+		description = "Configures the color of the quantity overlay.",
+		position = 5
+	)
+	@Alpha
+	default Color quantityOverlayColor()
+	{
+		return Color.yellow;
 	}
 
 	@ConfigItem(

--- a/runelite-client/src/main/java/net/runelite/client/plugins/banktags/TagManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/banktags/TagManager.java
@@ -51,6 +51,7 @@ import net.runelite.client.util.Text;
 public class TagManager
 {
 	static final String ITEM_KEY_PREFIX = "item_";
+	static final String ITEM_QUANTITY_KEY_PREFIX = "itemQuantity_";
 	private final ConfigManager configManager;
 	private final ItemManager itemManager;
 	private final ClueScrollService clueScrollService;
@@ -79,6 +80,19 @@ public class TagManager
 		return config;
 	}
 
+	public String getQuantityOfItemForTag(String tag, int itemId, boolean variation)
+	{
+		itemId = getItemId(itemId, variation);
+
+		String config = configManager.getConfiguration(CONFIG_GROUP, ITEM_QUANTITY_KEY_PREFIX + itemId + "." + tag);
+		if (config == null)
+		{
+			return "";
+		}
+
+		return config;
+	}
+
 	Collection<String> getTags(int itemId, boolean variation)
 	{
 		return new LinkedHashSet<>(Text.fromCSV(getTagString(itemId, variation).toLowerCase()));
@@ -96,6 +110,21 @@ public class TagManager
 		{
 			configManager.setConfiguration(CONFIG_GROUP, ITEM_KEY_PREFIX + itemId, tags);
 		}
+	}
+
+	public void setTagItemQuantity(String tag, int itemId, String input)
+	{
+		itemId = getItemId(itemId, false);
+
+		if (Strings.isNullOrEmpty(input))
+		{
+			configManager.unsetConfiguration(CONFIG_GROUP, ITEM_QUANTITY_KEY_PREFIX + itemId + "." + tag);
+		}
+		else
+		{
+			configManager.setConfiguration(CONFIG_GROUP, ITEM_QUANTITY_KEY_PREFIX + itemId + "." + tag, input);
+		}
+
 	}
 
 	public void addTags(int itemId, final Collection<String> t, boolean variation)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/banktags/tabs/TabInterface.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/banktags/tabs/TabInterface.java
@@ -36,6 +36,7 @@ import java.awt.datatransfer.StringSelection;
 import java.awt.datatransfer.UnsupportedFlavorException;
 import java.awt.event.MouseWheelEvent;
 import java.io.IOException;
+import java.text.ParseException;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
@@ -91,6 +92,7 @@ import static net.runelite.client.plugins.banktags.tabs.MenuIndexes.NewTab;
 import static net.runelite.client.plugins.banktags.tabs.MenuIndexes.Tab;
 import net.runelite.client.ui.JagexColors;
 import net.runelite.client.util.ColorUtil;
+import net.runelite.client.util.QuantityFormatter;
 import net.runelite.client.util.Text;
 
 @Singleton
@@ -108,6 +110,7 @@ public class TabInterface
 	private static final String VIEW_TAB = "View tag tab";
 	private static final String RENAME_TAB = "Rename tag tab";
 	private static final String CHANGE_ICON = "Change icon";
+	private static final String EDIT_QUANTITY = "Edit-quantity";
 	private static final String REMOVE_TAG = "Remove-tag";
 	private static final String TAG_GEAR = "Tag-equipment";
 	private static final String TAG_INVENTORY = "Tag-inventory";
@@ -191,6 +194,11 @@ public class TabInterface
 		return activeTab != null;
 	}
 
+	public TagTab getActiveTagTab()
+	{
+		return activeTab;
+	}
+
 	public void init()
 	{
 		if (isHidden())
@@ -258,6 +266,30 @@ public class TabInterface
 				for (Integer item : items)
 				{
 					tagManager.addTag(item, activeTab.getTag(), false);
+
+					if (config.autoSetQuantity())
+					{
+						int quantity = 0;
+						for (Item containerItem : container.getItems())
+						{
+							if (containerItem == null)
+							{
+								continue;
+							}
+
+							if (containerItem.getId() == item)
+							{
+								quantity += containerItem.getQuantity();
+							}
+						}
+
+						//Don't auto tag items of a quantity of 1
+						if (quantity > 1)
+						{
+							tagManager.setTagItemQuantity(activeTab.getTag(), item, String.valueOf(quantity));
+						}
+
+					}
 				}
 
 				openTag(activeTab.getTag());
@@ -633,6 +665,11 @@ public class TabInterface
 			&& event.getActionParam1() == WidgetInfo.BANK_ITEM_CONTAINER.getId()
 			&& event.getOption().equals("Examine"))
 		{
+			if (config.useQuantityFeature())
+			{
+				entries = createMenuEntry(event, EDIT_QUANTITY + " (" + activeTab.getTag() + ")", event.getTarget(), entries);
+			}
+
 			entries = createMenuEntry(event, REMOVE_TAG + " (" + activeTab.getTag() + ")", event.getTarget(), entries);
 			client.setMenuEntries(entries);
 		}
@@ -714,6 +751,56 @@ public class TabInterface
 			final int itemId = item.getId();
 			tagManager.removeTag(itemId, activeTab.getTag());
 			bankSearch.search(InputType.SEARCH, TAG_SEARCH + activeTab.getTag(), true);
+		}
+		else if (activeTab != null
+			&& event.getWidgetId() == WidgetInfo.BANK_ITEM_CONTAINER.getId()
+			&& event.getMenuAction() == MenuAction.RUNELITE
+			&& event.getMenuOption().startsWith(EDIT_QUANTITY))
+		{
+			// Add "edit-quantity" menu entry to all items in bank while tab is selected
+			event.consume();
+			final ItemComposition item = getItem(event.getActionParam());
+			final int itemId = item.getId();
+			final ItemComposition itemComposition = itemManager.getItemComposition(itemId);
+			final String name = itemComposition.getName();
+
+			final String initialValue = tagManager.getQuantityOfItemForTag(activeTab.getTag(), itemId, false);
+
+			chatboxPanelManager.openTextInput(name + " quantity:<br>(enter blank to reset)")
+				.addCharValidator(FILTERED_CHARS)
+				.value(initialValue)
+				.onDone((newValue) ->
+					clientThread.invoke(() ->
+					{
+
+						// Set quantity
+						try
+						{
+							//Convert stack supported input to quantity
+							long stackSizeToQuantity = QuantityFormatter.parseQuantity(newValue.trim());
+
+							//Convert value to stack string (Ex. 10K)
+							String finalStackSizeString = QuantityFormatter.quantityToStackSize(stackSizeToQuantity);
+
+							//A value of > 0 is valid. A value 0 or less will unset the config
+							if (stackSizeToQuantity > 0)
+							{
+								tagManager.setTagItemQuantity(activeTab.getTag(), itemId, String.valueOf(finalStackSizeString));
+							}
+							else
+							{
+								tagManager.setTagItemQuantity(activeTab.getTag(), itemId, null);
+							}
+						}
+						catch (NumberFormatException | ParseException ex)
+						{
+							//Unset due to invalid or empty input.
+							tagManager.setTagItemQuantity(activeTab.getTag(), itemId, null);
+						}
+
+					}))
+				.build();
+
 		}
 		else if (event.getMenuAction() == MenuAction.RUNELITE
 			&& ((event.getWidgetId() == WidgetInfo.BANK_DEPOSIT_INVENTORY.getId() && event.getMenuOption().equals(TAG_INVENTORY))
@@ -798,7 +885,7 @@ public class TabInterface
 		{
 			return;
 		}
-		
+
 		if (client.getVar(Varbits.BANK_REARRANGE_MODE) == 0)
 		{
 			tabManager.swap(source.getName(), dest.getName());

--- a/runelite-client/src/main/java/net/runelite/client/plugins/banktags/tabs/TabQuantityOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/banktags/tabs/TabQuantityOverlay.java
@@ -1,0 +1,63 @@
+package net.runelite.client.plugins.banktags.tabs;
+
+import java.awt.Color;
+import java.awt.Graphics2D;
+import javax.inject.Inject;
+import net.runelite.api.Client;
+import net.runelite.api.Point;
+import net.runelite.api.widgets.WidgetItem;
+import net.runelite.client.game.ItemManager;
+import net.runelite.client.plugins.banktags.BankTagsConfig;
+import net.runelite.client.plugins.banktags.TagManager;
+import net.runelite.client.ui.FontManager;
+import net.runelite.client.ui.overlay.WidgetItemOverlay;
+
+public class TabQuantityOverlay extends WidgetItemOverlay
+{
+	private final Client client;
+
+	@Inject
+	private ItemManager itemManager;
+
+	@Inject
+	private TabInterface tabInterface;
+
+	@Inject
+	private TagManager tagManager;
+
+	@Inject
+	private BankTagsConfig bankTagsConfig;
+
+	@Inject
+	TabQuantityOverlay(Client client, TabInterface tabInterface, TagManager tagManager, BankTagsConfig bankTagsConfig)
+	{
+		this.client = client;
+		this.tabInterface = tabInterface;
+		this.tagManager = tagManager;
+		this.bankTagsConfig = bankTagsConfig;
+		showOnBank();
+	}
+
+	@Override
+	public void renderItemOverlay(Graphics2D graphics, int itemId, WidgetItem itemWidget)
+	{
+
+		if (!bankTagsConfig.useQuantityFeature() || tabInterface.getActiveTagTab() == null)
+		{
+			return;
+		}
+
+		String configValue = tagManager.getQuantityOfItemForTag(tabInterface.getActiveTagTab().getTag(), itemId, false);
+
+		graphics.setFont(FontManager.getRunescapeSmallFont());
+		Point location = itemWidget.getCanvasLocation();
+
+		graphics.setColor(Color.black);
+		graphics.drawString("" + configValue, location.getX() + 2,
+			location.getY() + 21 + (graphics.getFontMetrics().getHeight() - 1));
+
+		graphics.setColor(bankTagsConfig.quantityOverlayColor());
+		graphics.drawString("" + configValue, location.getX() + 1,
+			location.getY() + 20 + (graphics.getFontMetrics().getHeight() - 1));
+	}
+}


### PR DESCRIPTION
When doing a specific activity such as fighting a boss, you may set up an inventory with your gear, 10 sharks, 4 prayer potions, and 2 stamina potions. Bank tag tabs are great for tagging the inventory, but often times you forget how many potions or quantities of items to bring with you.

This PR adds the functionality to set quantities to items in bank tag tabs so you no longer forget.
(Note: Setting the quantity of an item to blank or 0 removes the quantity overlay of that item)

This is a new PR of the original PR #10972 due to some mistakes with my fork.