### PR TITLE
timetracking: add timer warning colors and ability to sort timers.

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/SortOrder.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/SortOrder.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2020, Jake Wilson <https://github.com/jakewilson>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.timetracking;
+
+public enum SortOrder
+{
+	NONE,
+	ASC,
+	DESC
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/TimeTrackingConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/TimeTrackingConfig.java
@@ -95,6 +95,18 @@ public interface TimeTrackingConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "timerWarningThreshold",
+		name = "Timer Warning Threshold",
+		description = "The time at which to change the timer color to the warning color",
+		position = 6
+	)
+	@Units(Units.SECONDS)
+	default int timerWarningThreshold()
+	{
+		return 10;
+	}
+
+	@ConfigItem(
 		keyName = "activeTab",
 		name = "Active Tab",
 		description = "The currently selected tab",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/TimeTrackingConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/TimeTrackingConfig.java
@@ -84,6 +84,17 @@ public interface TimeTrackingConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "sortOrder",
+		name = "Sort Order",
+		description = "The order in which to sort the timers",
+		position = 5
+	)
+	default SortOrder sortOrder()
+	{
+		return SortOrder.NONE;
+	}
+
+	@ConfigItem(
 		keyName = "activeTab",
 		name = "Active Tab",
 		description = "The currently selected tab",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/TimeTrackingPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/TimeTrackingPlugin.java
@@ -230,6 +230,7 @@ public class TimeTrackingPlugin extends Plugin
 		{
 			clockDataChanged = clockManager.checkCompletion();
 			timerOrderChanged = clockManager.checkTimerOrder();
+			clockManager.checkForWarnings();
 		}
 
 		if (unitTime % panel.getUpdateInterval() == 0 || clockDataChanged || timerOrderChanged)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/TimeTrackingPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/TimeTrackingPlugin.java
@@ -224,13 +224,15 @@ public class TimeTrackingPlugin extends Plugin
 		long unitTime = Instant.now().toEpochMilli() / 200;
 
 		boolean clockDataChanged = false;
+		boolean timerOrderChanged = false;
 
 		if (unitTime % 5 == 0)
 		{
 			clockDataChanged = clockManager.checkCompletion();
+			timerOrderChanged = clockManager.checkTimerOrder();
 		}
 
-		if (unitTime % panel.getUpdateInterval() == 0 || clockDataChanged)
+		if (unitTime % panel.getUpdateInterval() == 0 || clockDataChanged || timerOrderChanged)
 		{
 			panel.update();
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/clocks/ClockManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/clocks/ClockManager.java
@@ -161,6 +161,17 @@ public class ClockManager
 		return false;
 	}
 
+	/**
+	 * Sets the warning flag on each timer that should be in the warning state
+	 */
+	public void checkForWarnings()
+	{
+		for (Timer timer : timers)
+		{
+			timer.setWarning(timer.getDisplayTime() <= config.timerWarningThreshold());
+		}
+	}
+
 	public void loadTimers()
 	{
 		final String timersJson = configManager.getConfiguration(TimeTrackingConfig.CONFIG_GROUP, TimeTrackingConfig.TIMERS);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/clocks/ClockManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/clocks/ClockManager.java
@@ -24,10 +24,12 @@
  */
 package net.runelite.client.plugins.timetracking.clocks;
 
+import com.google.common.collect.Comparators;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import com.google.inject.Singleton;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import javax.inject.Inject;
@@ -36,6 +38,7 @@ import joptsimple.internal.Strings;
 import lombok.Getter;
 import net.runelite.client.Notifier;
 import net.runelite.client.config.ConfigManager;
+import net.runelite.client.plugins.timetracking.SortOrder;
 import net.runelite.client.plugins.timetracking.TimeTrackingConfig;
 
 @Singleton
@@ -129,6 +132,33 @@ public class ClockManager
 		}
 
 		return changed;
+	}
+
+	/**
+	 * Checks to ensure the timers are in the correct order.
+	 * If they are not, sort them and rebuild the clock panel
+	 *
+	 * @return whether the timer order was changed or not
+	 */
+	public boolean checkTimerOrder()
+	{
+		SortOrder sortOrder = config.sortOrder();
+		if (sortOrder != SortOrder.NONE)
+		{
+			Comparator<Timer> comparator = Comparator.comparingLong(Timer::getDisplayTime);
+			if (sortOrder == SortOrder.DESC)
+			{
+				comparator = comparator.reversed();
+			}
+
+			if (!Comparators.isInOrder(timers, comparator))
+			{
+				timers.sort(comparator);
+				SwingUtilities.invokeLater(clockTabPanel::rebuild);
+				return true;
+			}
+		}
+		return false;
 	}
 
 	public void loadTimers()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/clocks/ClockPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/clocks/ClockPanel.java
@@ -64,7 +64,7 @@ abstract class ClockPanel extends JPanel
 
 	private final FlatTextField nameInput;
 	private final JToggleButton startPauseButton;
-	private final FlatTextField displayInput;
+	protected final FlatTextField displayInput;
 
 	@Getter
 	private final Clock clock;
@@ -150,6 +150,7 @@ abstract class ClockPanel extends JPanel
 
 				clock.setDuration(Math.max(0, duration));
 				clock.reset();
+				clockManager.checkForWarnings();
 				updateDisplayInput();
 				updateActivityStatus();
 				clockManager.saveTimers();
@@ -199,6 +200,7 @@ abstract class ClockPanel extends JPanel
 		resetButton.addActionListener(e ->
 		{
 			clock.reset();
+			clockManager.checkForWarnings();
 			reset();
 			clockManager.saveToConfig();
 		});
@@ -238,7 +240,7 @@ abstract class ClockPanel extends JPanel
 		boolean isActive = clock.isActive();
 
 		displayInput.setEditable(editable && !isActive);
-		displayInput.getTextField().setForeground(isActive ? ACTIVE_CLOCK_COLOR : INACTIVE_CLOCK_COLOR);
+		displayInput.getTextField().setForeground(getColor());
 		startPauseButton.setToolTipText(isActive ? "Pause " + clockType : "Start " + clockType);
 		startPauseButton.setSelected(isActive);
 
@@ -246,6 +248,11 @@ abstract class ClockPanel extends JPanel
 		{
 			displayInput.getTextField().setForeground(ColorScheme.PROGRESS_ERROR_COLOR.darker());
 		}
+	}
+
+	protected Color getColor()
+	{
+		return clock.isActive() ? ACTIVE_CLOCK_COLOR : INACTIVE_CLOCK_COLOR;
 	}
 
 	static String getFormattedDuration(long duration)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/clocks/Timer.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/clocks/Timer.java
@@ -25,6 +25,7 @@
 package net.runelite.client.plugins.timetracking.clocks;
 
 import java.time.Instant;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
@@ -40,11 +41,16 @@ class Timer extends Clock
 	// the number of seconds remaining on the timer, as of last updated time
 	private long remaining;
 
+	// whether this timer is in the 'warning' state or not
+	@Getter(AccessLevel.NONE)
+	private transient boolean warning;
+
 	Timer(String name, long duration)
 	{
 		super(name);
 		this.duration = duration;
 		this.remaining = duration;
+		this.warning = false;
 	}
 
 	@Override
@@ -66,6 +72,7 @@ class Timer extends Clock
 			if (remaining <= 0)
 			{
 				remaining = duration;
+				warning = false;
 			}
 			lastUpdate = Instant.now().getEpochSecond();
 			active = true;
@@ -95,5 +102,10 @@ class Timer extends Clock
 		active = false;
 		remaining = duration;
 		lastUpdate = Instant.now().getEpochSecond();
+	}
+
+	boolean isWarning()
+	{
+		return warning && (remaining > 0);
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/clocks/TimerPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/clocks/TimerPanel.java
@@ -24,12 +24,16 @@
  */
 package net.runelite.client.plugins.timetracking.clocks;
 
+import java.awt.Color;
 import java.awt.Dimension;
 import javax.swing.JButton;
+import net.runelite.client.ui.ColorScheme;
 import net.runelite.client.util.SwingUtil;
 
 class TimerPanel extends ClockPanel
 {
+	private static final Color WARNING_COLOR = ColorScheme.BRAND_ORANGE;
+
 	TimerPanel(ClockManager clockManager, Timer timer)
 	{
 		super(clockManager, timer, "timer", true);
@@ -41,5 +45,26 @@ class TimerPanel extends ClockPanel
 		deleteButton.setToolTipText("Delete timer");
 		deleteButton.addActionListener(e -> clockManager.removeTimer(timer));
 		rightActions.add(deleteButton);
+	}
+
+	@Override
+	void updateDisplayInput()
+	{
+		super.updateDisplayInput();
+
+		Timer timer = (Timer) getClock();
+		if (timer.isWarning())
+		{
+			displayInput.getTextField().setForeground(getColor());
+		}
+	}
+
+	@Override
+	protected Color getColor()
+	{
+		Timer timer = (Timer) getClock();
+		Color warningColor = timer.isActive() ? WARNING_COLOR : WARNING_COLOR.darker();
+
+		return timer.isWarning() ? warningColor : super.getColor();
 	}
 }


### PR DESCRIPTION
Originally made by @jakewilson 
Rebased, added proposed changes and tested. 
From my testing I fixed a couple of bugs, for example, timer going to 0 and then starting it over would show in warning color even if it was above the warning threshold.
Also when the timer is stopped in a warning state it shows the same color rather than a darker color.

Lets the user sort by ascending or descending time.
Lets the user choose a time for showing a timer warning in orange.
Closes #7240
Supersedes #7361 