### PR TITLE
Added nightmare dungeon area to skybox.txt

### DIFF
--- a/runelite-client/src/main/resources/net/runelite/client/plugins/skybox/skybox.txt
+++ b/runelite-client/src/main/resources/net/runelite/client/plugins/skybox/skybox.txt
@@ -965,6 +965,6 @@ R 49 193 51 194
 #8AD2DF
 R 33 79 33 80
 
-//Nightmare dungeon (Morytania underground)
+// Nightmare dungeon (Morytania underground)
 #0a0a0a
 R 58 151 60 153

--- a/runelite-client/src/main/resources/net/runelite/client/plugins/skybox/skybox.txt
+++ b/runelite-client/src/main/resources/net/runelite/client/plugins/skybox/skybox.txt
@@ -215,7 +215,6 @@ R 42 69 43 71
 R 45 68 45 69
 R 49 149 50 149
 R 55 151 56 151
-R 58 151 58 152
 r 39 72
 r 39 156
 r 51 150
@@ -965,3 +964,7 @@ R 49 193 51 194
 // Braindeath Island
 #8AD2DF
 R 33 79 33 80
+
+//Nightmare dungeon (Morytania underground)
+#0a0a0a
+R 58 151 60 153


### PR DESCRIPTION
Added nightmare dungeon area to skybox colors.
Previously (Line 218 originally in skybox.txt) encompassed a tiny room. That line was removed, and the new region encompasses the previously removed region.

The color chosen is #0a0a0a (RGB 10,10,10).

Resolves 1 of 2 in #10771 

![image](https://user-images.githubusercontent.com/42952632/76675535-0ad26000-6580-11ea-8b6e-756f2953ccb9.png)
