### PR TITLE
ground items: remove Highlight > value, add Notify >= Tier

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
@@ -30,6 +30,7 @@ import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
 import net.runelite.client.config.Units;
+import net.runelite.client.plugins.grounditems.config.HighlightTier;
 import net.runelite.client.plugins.grounditems.config.ItemHighlightMode;
 import net.runelite.client.plugins.grounditems.config.MenuHighlightMode;
 import net.runelite.client.plugins.grounditems.config.PriceDisplayMode;
@@ -141,10 +142,21 @@ public interface GroundItemsConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "notifyTier",
+		name = "Notify >= Tier",
+		description = "Configures what tier of highlight will cause a drop",
+		position = 8
+	)
+	default HighlightTier notifyTier()
+	{
+		return HighlightTier.OFF;
+	}
+
+	@ConfigItem(
 		keyName = "priceDisplayMode",
 		name = "Price Display Mode",
 		description = "Configures what price types are shown alongside of ground item name",
-		position = 8
+		position = 9
 	)
 	default PriceDisplayMode priceDisplayMode()
 	{
@@ -155,7 +167,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "itemHighlightMode",
 		name = "Item Highlight Mode",
 		description = "Configures how ground items will be highlighted",
-		position = 9
+		position = 10
 	)
 	default ItemHighlightMode itemHighlightMode()
 	{
@@ -166,7 +178,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "menuHighlightMode",
 		name = "Menu Highlight Mode",
 		description = "Configures what to highlight in right-click menu",
-		position = 10
+		position = 11
 	)
 	default MenuHighlightMode menuHighlightMode()
 	{
@@ -177,7 +189,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "highlightValueCalculation",
 		name = "Highlight Value Calculation",
 		description = "Configures which coin value is used to determine highlight color",
-		position = 11
+		position = 12
 	)
 	default ValueCalculationMode valueCalculationMode()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
@@ -185,17 +185,6 @@ public interface GroundItemsConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "highlightOverValue2",
-		name = "Highlight > Value",
-		description = "Configures highlighted ground items over either GE or HA value",
-		position = 12
-	)
-	default int getHighlightOverValue()
-	{
-		return 0;
-	}
-
-	@ConfigItem(
 		keyName = "hideUnderValue",
 		name = "Hide < Value",
 		description = "Configures hidden ground items under both GE and HA value",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
@@ -431,10 +431,6 @@ public class GroundItemsPlugin extends Plugin
 
 		// Cache colors
 		ImmutableList.Builder<PriceHighlight> priceCheckBuilder = ImmutableList.builder();
-		if (config.getHighlightOverValue() > 0)
-		{
-			priceCheckBuilder.add(new PriceHighlight(config.getHighlightOverValue(), config.highlightedColor()));
-		}
 
 		if (config.insaneValuePrice() > 0)
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
@@ -242,12 +242,7 @@ public class GroundItemsPlugin extends Plugin
 			// The spawn time remains set at the oldest spawn
 		}
 
-		boolean shouldNotify = !config.onlyShowLoot() && config.highlightedColor().equals(getHighlighted(
-			new NamedQuantity(groundItem),
-			groundItem.getGePrice(),
-			groundItem.getHaPrice()));
-
-		if (config.notifyHighlightedDrops() && shouldNotify)
+		if (!config.onlyShowLoot())
 		{
 			notifyHighlightedItem(groundItem);
 		}
@@ -370,12 +365,7 @@ public class GroundItemsPlugin extends Plugin
 			{
 				groundItem.setLootType(lootType);
 
-				boolean shouldNotify = config.onlyShowLoot() && config.highlightedColor().equals(getHighlighted(
-					new NamedQuantity(groundItem),
-					groundItem.getGePrice(),
-					groundItem.getHaPrice()));
-
-				if (config.notifyHighlightedDrops() && shouldNotify)
+				if (config.onlyShowLoot())
 				{
 					notifyHighlightedItem(groundItem);
 				}
@@ -645,6 +635,16 @@ public class GroundItemsPlugin extends Plugin
 
 	private void notifyHighlightedItem(GroundItem item)
 	{
+		boolean shouldNotifyHighlighted = config.highlightedColor().equals(getHighlighted(
+			new NamedQuantity(item),
+			item.getGePrice(),
+			item.getHaPrice()));
+
+		if (!config.notifyHighlightedDrops() || !shouldNotifyHighlighted)
+		{
+			return;
+		}
+
 		final Player local = client.getLocalPlayer();
 		final StringBuilder notificationStringBuilder = new StringBuilder()
 			.append("[")

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
@@ -32,6 +32,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.inject.Provides;
 import java.awt.Color;
 import java.awt.Rectangle;
+import static java.lang.Boolean.FALSE;
 import static java.lang.Boolean.TRUE;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -80,12 +81,12 @@ import net.runelite.client.input.KeyManager;
 import net.runelite.client.input.MouseManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.plugins.grounditems.config.HighlightTier;
 import static net.runelite.client.plugins.grounditems.config.ItemHighlightMode.OVERLAY;
 import net.runelite.client.plugins.grounditems.config.MenuHighlightMode;
 import static net.runelite.client.plugins.grounditems.config.MenuHighlightMode.BOTH;
 import static net.runelite.client.plugins.grounditems.config.MenuHighlightMode.NAME;
 import static net.runelite.client.plugins.grounditems.config.MenuHighlightMode.OPTION;
-import net.runelite.client.plugins.grounditems.config.ValueCalculationMode;
 import net.runelite.client.ui.overlay.OverlayManager;
 import net.runelite.client.util.ColorUtil;
 import net.runelite.client.util.QuantityFormatter;
@@ -562,29 +563,12 @@ public class GroundItemsPlugin extends Plugin
 			return null;
 		}
 
-		ValueCalculationMode mode = config.valueCalculationMode();
+		final int price = getValueByMode(gePrice, haPrice);
 		for (PriceHighlight highlight : priceChecks)
 		{
-			switch (mode)
+			if (price > highlight.getPrice())
 			{
-				case GE:
-					if (gePrice > highlight.getPrice())
-					{
-						return highlight.getColor();
-					}
-					break;
-				case HA:
-					if (haPrice > highlight.getPrice())
-					{
-						return highlight.getColor();
-					}
-					break;
-				default: // case HIGHEST
-					if (gePrice > highlight.getPrice() || haPrice > highlight.getPrice())
-					{
-						return highlight.getColor();
-					}
-					break;
+				return highlight.getColor();
 			}
 		}
 
@@ -631,12 +615,26 @@ public class GroundItemsPlugin extends Plugin
 
 	private void notifyHighlightedItem(GroundItem item)
 	{
-		boolean shouldNotifyHighlighted = config.highlightedColor().equals(getHighlighted(
-			new NamedQuantity(item),
-			item.getGePrice(),
-			item.getHaPrice()));
+		final boolean shouldNotifyHighlighted = config.notifyHighlightedDrops() &&
+			config.highlightedColor().equals(getHighlighted(
+				new NamedQuantity(item),
+				item.getGePrice(),
+				item.getHaPrice()));
 
-		if (!config.notifyHighlightedDrops() || !shouldNotifyHighlighted)
+		final boolean shouldNotifyTier = config.notifyTier() != HighlightTier.OFF &&
+			getValueByMode(item.getGePrice(), item.getHaPrice()) > config.notifyTier().getValueFromTier(config) &&
+			FALSE.equals(hiddenItems.getUnchecked(new NamedQuantity(item)));
+
+		final String dropType;
+		if (shouldNotifyHighlighted)
+		{
+			dropType = "highlighted";
+		}
+		else if (shouldNotifyTier)
+		{
+			dropType = "valuable";
+		}
+		else
 		{
 			return;
 		}
@@ -645,7 +643,9 @@ public class GroundItemsPlugin extends Plugin
 		final StringBuilder notificationStringBuilder = new StringBuilder()
 			.append("[")
 			.append(local.getName())
-			.append("] received a highlighted drop: ")
+			.append("] received a ")
+			.append(dropType)
+			.append(" drop: ")
 			.append(item.getName());
 
 		if (item.getQuantity() > 1)
@@ -667,6 +667,19 @@ public class GroundItemsPlugin extends Plugin
 
 		notificationStringBuilder.append("!");
 		notifier.notify(notificationStringBuilder.toString());
+	}
+
+	private int getValueByMode(int gePrice, int haPrice)
+	{
+		switch (config.valueCalculationMode())
+		{
+			case GE:
+				return gePrice;
+			case HA:
+				return haPrice;
+			default: // Highest
+				return Math.max(gePrice, haPrice);
+		}
 	}
 
 	@Subscribe

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/config/HighlightTier.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/config/HighlightTier.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2020, Hydrox6 <ikada@protonmail.ch>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.grounditems.config;
+
+import net.runelite.client.plugins.grounditems.GroundItemsConfig;
+
+public enum HighlightTier
+{
+	OFF,
+	LOW,
+	MEDIUM,
+	HIGH,
+	INSANE;
+
+	public int getValueFromTier(GroundItemsConfig config)
+	{
+		switch (this)
+		{
+			case LOW:
+				return config.lowValuePrice();
+			case MEDIUM:
+				return config.mediumValuePrice();
+			case HIGH:
+				return config.highValuePrice();
+			case INSANE:
+				return config.insaneValuePrice();
+			default:
+				throw new UnsupportedOperationException();
+		}
+	}
+}


### PR DESCRIPTION
Closes #9241
Closes #10961

Highlighted items should serve a specific purpose imo: for items you're specifically looking for. With `Highlight > value`, it turned the Highlighted items into another value tier, with the only difference between it and the low->insane values was that it provided notifications.

With the recent change to how the tiers are ordered, and the confusion around it, there seems to be a big desire for notifications by an item's value (a fixed version of the old functionality)