### PR TITLE
chatcommands: Don't remove spaces before cleared word

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatKeyboardListener.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatKeyboardListener.java
@@ -71,42 +71,9 @@ public class ChatKeyboardListener implements KeyListener
 					input = input.substring(0, input.length() - 1);
 				}
 
-				// grab OS so that clearing single word behaves like system's default
-				String OS = System.getProperty("os.name").toLowerCase();
-				String tempReplacement;
-
-				if (OS.contains("win")) // windows default ctrl + backspace
-				{
-					// find next word
-					int idx = input.lastIndexOf(' ') + 1;
-					tempReplacement = input.substring(0, idx);
-				}
-				else if (OS.contains("nix") || OS.contains("nux") || OS.contains("aix")) // unix default ctrl + backspace
-				{
-					// find next word
-					int idx = input.lastIndexOf(' ') + 1;
-					tempReplacement = input.substring(0, idx);
-				}
-				else if (OS.contains("mac")) // mac default ctrl + backspace
-				{
-					// find next word
-					int idx = input.lastIndexOf(' ') + 1;
-					tempReplacement = input.substring(0, idx);
-				}
-				else if (OS.contains("sunos")) // solaris default ctrl + backspace
-				{
-					// find next word
-					int idx = input.lastIndexOf(' ') + 1;
-					tempReplacement = input.substring(0, idx);
-				}
-				else // catch all ctrl + backspace
-				{
-					// find next word
-					int idx = input.lastIndexOf(' ') + 1;
-					tempReplacement = input.substring(0, idx);
-				}
-
-				final String replacement = tempReplacement;
+				// find next word
+				int idx = input.lastIndexOf(' ') + 1;
+				final String replacement = input.substring(0, idx);
 
 				clientThread.invoke(() -> applyText(inputTye, replacement));
 			}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatKeyboardListener.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatKeyboardListener.java
@@ -71,17 +71,42 @@ public class ChatKeyboardListener implements KeyListener
 					input = input.substring(0, input.length() - 1);
 				}
 
-				// find next word
-				int idx = input.lastIndexOf(' ');
-				final String replacement;
-				if (idx != -1)
+				// grab OS so that clearing single word behaves like system's default
+				String OS = System.getProperty("os.name").toLowerCase();
+				String tempReplacement;
+
+				if (OS.contains("win")) // windows default ctrl + backspace
 				{
-					replacement = input.substring(0, idx);
+					// find next word
+					int idx = input.lastIndexOf(' ') + 1;
+					tempReplacement = input.substring(0, idx);
 				}
-				else
+				else if (OS.contains("nix") || OS.contains("nux") || OS.contains("aix")) // unix default ctrl + backspace
 				{
-					replacement = "";
+					// find next word
+					int idx = input.lastIndexOf(' ') + 1;
+					tempReplacement = input.substring(0, idx);
 				}
+				else if (OS.contains("mac")) // mac default ctrl + backspace
+				{
+					// find next word
+					int idx = input.lastIndexOf(' ') + 1;
+					tempReplacement = input.substring(0, idx);
+				}
+				else if (OS.contains("sunos")) // solaris default ctrl + backspace
+				{
+					// find next word
+					int idx = input.lastIndexOf(' ') + 1;
+					tempReplacement = input.substring(0, idx);
+				}
+				else // catch all ctrl + backspace
+				{
+					// find next word
+					int idx = input.lastIndexOf(' ') + 1;
+					tempReplacement = input.substring(0, idx);
+				}
+
+				final String replacement = tempReplacement;
 
 				clientThread.invoke(() -> applyText(inputTye, replacement));
 			}


### PR DESCRIPTION
I can only check Ubuntu and Windows which both act the same where
`word1 word2 word3   word4   ` becomes `word1 word2 word3   ` 
(Keeps the trailing spaces after the word)

Using [this stack overflow thread]( https://stackoverflow.com/questions/228477/how-do-i-programmatically-determine-operating-system-in-java) as how to determine the OS