### PR TITLE
Corrected Gnome Stronghold dungeon Bloodvelds cannon location.

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonSpots.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonSpots.java
@@ -33,7 +33,7 @@ import net.runelite.api.coords.WorldPoint;
 public enum CannonSpots
 {
 
-	BLOODVELDS(new WorldPoint(2439, 9821, 0), new WorldPoint(2448, 9821, 0), new WorldPoint(2472, 9833, 0), new WorldPoint(2453, 9817, 0)),
+	BLOODVELDS(new WorldPoint(2439, 9821, 0), new WorldPoint(2448, 9821, 0), new WorldPoint(2472, 9832, 0), new WorldPoint(2453, 9817, 0)),
 	FIRE_GIANTS(new WorldPoint(2393, 9782, 0), new WorldPoint(2412, 9776, 0), new WorldPoint(2401, 9780, 0)),
 	ABERRANT_SPECTRES(new WorldPoint(2456, 9791, 0)),
 	HELLHOUNDS(new WorldPoint(2431, 9776, 0), new WorldPoint(2413, 9786, 0), new WorldPoint(2783, 9686, 0), new WorldPoint(3198, 10071, 0)),


### PR DESCRIPTION
Closes Issue #11027 