### PR TITLE
Clear boss timer info box on log/hop + added configuration

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/bosstimer/BossTimersConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/bosstimer/BossTimersConfig.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2017, Adam <Adam@sigterm.info>
+ * Copyright (c) 2018, Joris K <kjorisje@gmail.com>
+ * Copyright (c) 2018, Lasse <cronick@zytex.dk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -24,30 +25,21 @@
  */
 package net.runelite.client.plugins.bosstimer;
 
-import java.awt.image.BufferedImage;
-import java.time.temporal.ChronoUnit;
-import net.runelite.client.plugins.Plugin;
-import net.runelite.client.ui.overlay.infobox.Timer;
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
 
-class RespawnTimer extends Timer
+@ConfigGroup("bosstimer")
+public interface BossTimersConfig extends Config
 {
-	private final Boss boss;
-	private final int world;
-
-	public RespawnTimer(Boss boss, int world, BufferedImage bossImage, Plugin plugin)
+	@ConfigItem(
+		position = 0,
+		keyName = "showWorldTimers",
+		name = "Show timers for all worlds",
+		description = "Configures if the timers for each world are shown"
+	)
+	default boolean showWorldTimers()
 	{
-		super(boss.getSpawnTime().toMillis(), ChronoUnit.MILLIS, bossImage, plugin);
-		this.boss = boss;
-		this.world = world;
-	}
-
-	public Boss getBoss()
-	{
-		return boss;
-	}
-
-	public int getWorld()
-	{
-		return world;
+		return false;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/bosstimer/BossTimersOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/bosstimer/BossTimersOverlay.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2018, Joris K <kjorisje@gmail.com>
+ * Copyright (c) 2018, Lasse <cronick@zytex.dk>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.bosstimer;
+
+import net.runelite.api.Client;
+import net.runelite.client.ui.overlay.Overlay;
+import net.runelite.client.ui.overlay.OverlayMenuEntry;
+import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.components.LineComponent;
+import net.runelite.client.ui.overlay.components.PanelComponent;
+import net.runelite.client.ui.overlay.components.TitleComponent;
+
+import javax.inject.Inject;
+import java.awt.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+
+import static net.runelite.api.MenuAction.RUNELITE_OVERLAY_CONFIG;
+import static net.runelite.client.ui.overlay.OverlayManager.OPTION_CONFIGURE;
+
+class BossTimersOverlay extends Overlay
+{
+	private final Client client;
+	private final BossTimersPlugin plugin;
+	private final BossTimersConfig config;
+	private final PanelComponent panelComponent = new PanelComponent();
+
+	@Inject
+	private BossTimersOverlay(Client client, BossTimersPlugin plugin, BossTimersConfig config)
+	{
+		super(plugin);
+		setPosition(OverlayPosition.TOP_LEFT);
+		this.client = client;
+		this.plugin = plugin;
+		this.config = config;
+		getMenuEntries().add(new OverlayMenuEntry(RUNELITE_OVERLAY_CONFIG, OPTION_CONFIGURE, "Boss timer overlay"));
+	}
+
+	@Override
+	public Dimension render(Graphics2D graphics)
+	{
+		BossTimersSession session = plugin.getSession();
+		if (!config.showWorldTimers() || session == null || session.isEmpty())
+		{
+			return null;
+		}
+
+		panelComponent.getChildren().clear();
+		Iterator<HashMap.Entry<String, ArrayList<RespawnTimer>>> mapIterator = session.getWorldsMap().entrySet().iterator();
+
+		while (mapIterator.hasNext())
+		{
+			final HashMap.Entry<String, ArrayList<RespawnTimer>> entry = mapIterator.next();
+
+			panelComponent.getChildren().add(TitleComponent.builder()
+					.text(entry.getKey())
+					.build());
+
+			Iterator<RespawnTimer> valueIterator = entry.getValue().iterator();
+
+			while (valueIterator.hasNext())
+			{
+				final RespawnTimer respawnTimer = valueIterator.next();
+
+				if (respawnTimer.cull())
+				{
+					valueIterator.remove();
+
+					if (entry.getValue().size() == 0)
+					{
+						mapIterator.remove();
+					}
+				}
+				else
+				{
+					panelComponent.getChildren().add(LineComponent.builder()
+							.left("World " + respawnTimer.getWorld())
+							.right(respawnTimer.getText())
+							.build());
+				}
+			}
+		}
+
+		return panelComponent.render(graphics);
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/bosstimer/BossTimersSession.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/bosstimer/BossTimersSession.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2017, Adam <Adam@sigterm.info>
+ * Copyright (c) 2018, Joris K <kjorisje@gmail.com>
+ * Copyright (c) 2018, Lasse <cronick@zytex.dk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -24,30 +25,27 @@
  */
 package net.runelite.client.plugins.bosstimer;
 
-import java.awt.image.BufferedImage;
-import java.time.temporal.ChronoUnit;
-import net.runelite.client.plugins.Plugin;
-import net.runelite.client.ui.overlay.infobox.Timer;
+import lombok.AccessLevel;
+import lombok.Getter;
 
-class RespawnTimer extends Timer
+import java.util.ArrayList;
+import java.util.HashMap;
+
+class BossTimersSession
 {
-	private final Boss boss;
-	private final int world;
+	@Getter(AccessLevel.PACKAGE)
+	private HashMap<String, ArrayList<RespawnTimer>> worldsMap = new HashMap<>();
 
-	public RespawnTimer(Boss boss, int world, BufferedImage bossImage, Plugin plugin)
+	boolean isEmpty()
 	{
-		super(boss.getSpawnTime().toMillis(), ChronoUnit.MILLIS, bossImage, plugin);
-		this.boss = boss;
-		this.world = world;
+		return worldsMap.isEmpty();
 	}
 
-	public Boss getBoss()
+	void addBossTimer(String bossName, RespawnTimer respawnTimer)
 	{
-		return boss;
-	}
+		worldsMap.computeIfAbsent(bossName, k -> new ArrayList<>());
 
-	public int getWorld()
-	{
-		return world;
+		ArrayList<RespawnTimer> timers = worldsMap.get(bossName);
+		timers.add(respawnTimer);
 	}
 }


### PR DESCRIPTION
Addresses issues #10620 and #7196.

Respawn timers are cleared from the infoBoxManager on log out or hopping.

Configuration was added to display an overlay instead of infoboxes. The overlay uses a session to track kills of bosses across different worlds. The session tracks kills for NPCs with a hashmap from the name to an ArrayList of RespawnTimers. An additional integer was added to the respawn timer class to store the world in which the timer is counting.