### PR TITLE
Revert Shift Anti-Drag and Disable in PvP Scenarios

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/Varbits.java
+++ b/runelite-api/src/main/java/net/runelite/api/Varbits.java
@@ -563,7 +563,17 @@ public enum Varbits
 	TWISTED_LEAGUE_RELIC_2(10050),
 	TWISTED_LEAGUE_RELIC_3(10051),
 	TWISTED_LEAGUE_RELIC_4(10052),
-	TWISTED_LEAGUE_RELIC_5(10053);
+	TWISTED_LEAGUE_RELIC_5(10053),
+
+	/**
+	 * Whether the Special Attack orb is disabled due to being in a PvP area
+	 *
+	 * 0 = Enabled (player is not in PvP)
+	 * 1 = Disabled (player in in PvP)
+	 *
+	 * @see <a href="https://oldschool.runescape.wiki/w/Minimap#Special_attack_orb">The OSRS Wiki's Minimap page</a>
+	 */
+	PVP_SPEC_ORB(8121);
 
 	/**
 	 * The raw varbit ID.

--- a/runelite-client/src/main/java/net/runelite/client/plugins/antidrag/AntiDragConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/antidrag/AntiDragConfig.java
@@ -29,7 +29,7 @@ import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
 
-@ConfigGroup("antiDrag")
+@ConfigGroup(AntiDragPlugin.CONFIG_GROUP)
 public interface AntiDragConfig extends Config
 {
 	@ConfigItem(
@@ -41,5 +41,16 @@ public interface AntiDragConfig extends Config
 	default int dragDelay()
 	{
 		return Constants.GAME_TICK_LENGTH / Constants.CLIENT_TICK_LENGTH; // one game tick
+	}
+
+	@ConfigItem(
+		keyName = "onShiftOnly",
+		name = "On Shift Only",
+		description = "Configures whether to only adjust the delay while holding shift. Required for anti drag in PvP scenarios.",
+		position = 2
+	)
+	default boolean onShiftOnly()
+	{
+		return true;
 	}
 }


### PR DESCRIPTION
The changes made reflect the exact same sentiments stated by @dekvall  [in PR #10870](https://github.com/runelite/runelite/pull/10870).

The following features have been reverted/added to the anti-drag plugin:
- **Shift Anti-Drag** plugin has been reverted back to original **Anti Drag**
- _Shift Only_ anti-drag still remains an option.
- Any form of anti-drag is disabled in PvP scenarios. (Detected by the spec orb enabling/disabling). Including in PvP worlds and wilderness.
- Anti drag is enabled for banking.

With the addition of removing all forms of anti-drag for PvP scenarios, I believe this sufficiently solves the issue/uproar in the PvP community that caused the plugin to get reverted in the first place.

Example on a PvP world:
![rDJcg9x](https://user-images.githubusercontent.com/11031776/76924529-99a6eb80-68a4-11ea-8061-b23fd1684b17.gif)