### PR TITLE
KourendLibrary: Add Dark Manuscript toggle and disabled showing Varlamore Envoy

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/kourendlibrary/KourendLibraryConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/kourendlibrary/KourendLibraryConfig.java
@@ -60,6 +60,16 @@ public interface KourendLibraryConfig extends Config
 	)
 	default boolean hideVarlamoreEnvoy()
 	{
+		return true;
+	}
+
+	@ConfigItem(
+		keyName = "hideDarkManuscript",
+		name = "Hide Dark Manuscript",
+		description = "Whether to hide Dark Manuscripts"
+	)
+	default boolean hideDarkManuscript()
+	{
 		return false;
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/kourendlibrary/KourendLibraryOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/kourendlibrary/KourendLibraryOverlay.java
@@ -127,7 +127,8 @@ class KourendLibraryOverlay extends Overlay
 					bookIsKnown = true;
 				}
 
-				if (book == Book.VARLAMORE_ENVOY && config.hideVarlamoreEnvoy())
+				if (book == Book.VARLAMORE_ENVOY && config.hideVarlamoreEnvoy()
+					|| book != null && book.isDarkManuscript() && config.hideDarkManuscript())
 				{
 					continue;
 				}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/kourendlibrary/KourendLibraryOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/kourendlibrary/KourendLibraryOverlay.java
@@ -127,7 +127,7 @@ class KourendLibraryOverlay extends Overlay
 					bookIsKnown = true;
 				}
 
-				if (book == Book.VARLAMORE_ENVOY && config.hideVarlamoreEnvoy()
+				if (book == Book.VARLAMORE_ENVOY && !plugin.showVarlamoreEnvoy()
 					|| book != null && book.isDarkManuscript() && config.hideDarkManuscript())
 				{
 					continue;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/kourendlibrary/KourendLibraryPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/kourendlibrary/KourendLibraryPanel.java
@@ -89,7 +89,7 @@ class KourendLibraryPanel extends PluginPanel
 		c.gridy = 0;
 		Stream.of(Book.values())
 			.filter(b -> !b.isDarkManuscript())
-			.filter(b -> !config.hideVarlamoreEnvoy() || b != Book.VARLAMORE_ENVOY)
+			.filter(b -> plugin.showVarlamoreEnvoy() || b != Book.VARLAMORE_ENVOY)
 			.sorted(Comparator.comparing(Book::getShortName))
 			.forEach(b ->
 			{


### PR DESCRIPTION
Closes Issue #10296 
 - Added a toggle in the Kourend Library plugin to enable/disable the overlay for Dark Manuscripts.
 - Added a method call in the overlay renderer that checks to see if the player is actively on "The Depths of Despair" quest, and only displays overlays for Harlamore Envoy if they are (the book will not actually spawn if the player is not on the quest).

I understand that my implementation may be a little ham fisted here (the quality of some of the code in this project is a little intimidating), and that there is a lot of action right now on the Kourend Library plugin, I just wanted to take a crack at this.  I am very open to peer review.