### PR TITLE
Add toggle between two keys to Key Remapping plugin

### DIFF
--- a/http-api/src/main/java/META-INF/MANIFEST.MF
+++ b/http-api/src/main/java/META-INF/MANIFEST.MF
@@ -1,0 +1,3 @@
+Manifest-Version: 1.0
+Main-Class: net.runelite.client.RuneLite
+

--- a/http-api/src/main/java/META-INF/MANIFEST.MF
+++ b/http-api/src/main/java/META-INF/MANIFEST.MF
@@ -1,3 +1,0 @@
-Manifest-Version: 1.0
-Main-Class: net.runelite.client.RuneLite
-

--- a/runelite-client/src/main/java/net/runelite/client/plugins/keyremapping/KeyRemappingConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/keyremapping/KeyRemappingConfig.java
@@ -254,10 +254,10 @@ public interface KeyRemappingConfig extends Config
 	}
 
 	@ConfigItem(
-			position = 20,
-			keyName = "toggleBetween",
-			name = "Toggle between",
-			description = "Toggle between two keys"
+		position = 20,
+		keyName = "toggleBetween",
+		name = "Toggle between",
+		description = "Toggle between two keys"
 	)
 	default boolean toggle()
 	{
@@ -265,10 +265,10 @@ public interface KeyRemappingConfig extends Config
 	}
 
 	@ConfigItem(
-			position = 21,
-			keyName = "toggleBetweenKeyEvent",
-			name = "Toggle key",
-			description = "The key which will activate the toggle event."
+		position = 21,
+		keyName = "toggleBetweenKeyEvent",
+		name = "Toggle key",
+		description = "The key which will activate the toggle event."
 	)
 	default ModifierlessKeybind toggleKey()
 	{
@@ -276,10 +276,10 @@ public interface KeyRemappingConfig extends Config
 	}
 
 	@ConfigItem(
-			position = 22,
-			keyName = "toggleOne",
-			name = "Toggle one",
-			description = "Toggle one"
+		position = 22,
+		keyName = "toggleOne",
+		name = "Toggle one",
+		description = "Toggle one"
 	)
 	default ModifierlessKeybind toggleOne()
 	{
@@ -287,10 +287,10 @@ public interface KeyRemappingConfig extends Config
 	}
 
 	@ConfigItem(
-			position = 23,
-			keyName = "toggleTwo",
-			name = "toggle two",
-			description = "toggle two"
+		position = 23,
+		keyName = "toggleTwo",
+		name = "toggle two",
+		description = "toggle two"
 	)
 	default ModifierlessKeybind toggleTwo()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/keyremapping/KeyRemappingConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/keyremapping/KeyRemappingConfig.java
@@ -252,4 +252,49 @@ public interface KeyRemappingConfig extends Config
 	{
 		return false;
 	}
+
+	@ConfigItem(
+			position = 20,
+			keyName = "toggleBetween",
+			name = "Toggle between",
+			description = "Toggle between two keys"
+	)
+	default boolean toggle()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+			position = 21,
+			keyName = "toggleBetweenKeyEvent",
+			name = "Toggle key",
+			description = "The key which will activate the toggle event."
+	)
+	default ModifierlessKeybind toggleKey()
+	{
+		return new ModifierlessKeybind(KeyEvent.VK_BACK_QUOTE, 0);
+	}
+
+	@ConfigItem(
+			position = 22,
+			keyName = "toggleOne",
+			name = "Toggle one",
+			description = "Toggle one"
+	)
+	default ModifierlessKeybind toggleOne()
+	{
+		return new ModifierlessKeybind(KeyEvent.VK_F1, 0);
+	}
+
+	@ConfigItem(
+			position = 23,
+			keyName = "toggleTwo",
+			name = "toggle two",
+			description = "toggle two"
+	)
+	default ModifierlessKeybind toggleTwo()
+	{
+		return new ModifierlessKeybind(KeyEvent.VK_F2, 0);
+	}
+
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/keyremapping/KeyRemappingListener.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/keyremapping/KeyRemappingListener.java
@@ -169,14 +169,20 @@ class KeyRemappingListener extends MouseAdapter implements KeyListener
 					e.setKeyCode(KeyEvent.VK_ESCAPE);
 				}
 			}
-			if(config.toggle()) {
-				if(currentToggle == null) {
+			if (config.toggle())
+			{
+				if (currentToggle == null)
+				{
 					currentToggle = config.toggleOne().toString();
 				}
-				if(config.toggleKey().matches(e)){
-					if(currentToggle.equalsIgnoreCase(config.toggleOne().toString())) {
+				if (config.toggleKey().matches(e))
+				{
+					if (currentToggle.equalsIgnoreCase(config.toggleOne().toString()))
+					{
 						e.setKeyCode(config.toggleTwo().getKeyCode());
-					} else {
+					}
+					else
+					{
 						e.setKeyCode(config.toggleOne().getKeyCode());
 					}
 				}
@@ -312,12 +318,17 @@ class KeyRemappingListener extends MouseAdapter implements KeyListener
 					e.setKeyCode(KeyEvent.VK_ESCAPE);
 				}
 			}
-			if(config.toggle()) {
-				if(config.toggleKey().matches(e)){
-					if(currentToggle.equalsIgnoreCase(config.toggleOne().toString())) {
+			if (config.toggle())
+			{
+				if (config.toggleKey().matches(e))
+				{
+					if (currentToggle.equalsIgnoreCase(config.toggleOne().toString()))
+					{
 						e.setKeyCode(config.toggleTwo().getKeyCode());
 						currentToggle = config.toggleTwo().toString();
-					} else {
+					}
+					else
+					{
 						e.setKeyCode(config.toggleOne().getKeyCode());
 						currentToggle = config.toggleOne().toString();
 					}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/keyremapping/KeyRemappingListener.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/keyremapping/KeyRemappingListener.java
@@ -57,6 +57,8 @@ class KeyRemappingListener extends MouseAdapter implements KeyListener
 
 	private final Map<Integer, Integer> modified = new HashMap<>();
 
+	private String currentToggle;
+
 	@Override
 	public void keyTyped(KeyEvent e)
 	{
@@ -167,6 +169,18 @@ class KeyRemappingListener extends MouseAdapter implements KeyListener
 					e.setKeyCode(KeyEvent.VK_ESCAPE);
 				}
 			}
+			if(config.toggle()) {
+				if(currentToggle == null) {
+					currentToggle = config.toggleOne().toString();
+				}
+				if(config.toggleKey().matches(e)){
+					if(currentToggle.equalsIgnoreCase(config.toggleOne().toString())) {
+						e.setKeyCode(config.toggleTwo().getKeyCode());
+					} else {
+						e.setKeyCode(config.toggleOne().getKeyCode());
+					}
+				}
+			}
 
 			switch (e.getKeyCode())
 			{
@@ -219,7 +233,7 @@ class KeyRemappingListener extends MouseAdapter implements KeyListener
 			return;
 		}
 
-		if (plugin.chatboxFocused() && !plugin.isTyping())
+		if (plugin.chatboxFocused() && !plugin.isTyping()) // is this keyreleased meant for doing as long as?? whats the point of removing modified here?
 		{
 			modified.remove(e.getKeyCode());
 
@@ -298,6 +312,17 @@ class KeyRemappingListener extends MouseAdapter implements KeyListener
 					e.setKeyCode(KeyEvent.VK_ESCAPE);
 				}
 			}
+			if(config.toggle()) {
+				if(config.toggleKey().matches(e)){
+					if(currentToggle.equalsIgnoreCase(config.toggleOne().toString())) {
+						e.setKeyCode(config.toggleTwo().getKeyCode());
+						currentToggle = config.toggleTwo().toString();
+					} else {
+						e.setKeyCode(config.toggleOne().getKeyCode());
+						currentToggle = config.toggleOne().toString();
+					}
+				}
+			}
 		}
 		else
 		{
@@ -338,4 +363,5 @@ class KeyRemappingListener extends MouseAdapter implements KeyListener
 		}
 		return mouseEvent;
 	}
+
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/keyremapping/KeyRemappingListener.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/keyremapping/KeyRemappingListener.java
@@ -233,7 +233,7 @@ class KeyRemappingListener extends MouseAdapter implements KeyListener
 			return;
 		}
 
-		if (plugin.chatboxFocused() && !plugin.isTyping()) // is this keyreleased meant for doing as long as?? whats the point of removing modified here?
+		if (plugin.chatboxFocused() && !plugin.isTyping())
 		{
 			modified.remove(e.getKeyCode());
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/keyremapping/KeyRemappingPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/keyremapping/KeyRemappingPlugin.java
@@ -52,7 +52,7 @@ import net.runelite.client.util.ColorUtil;
 @PluginDescriptor(
 	name = "Key Remapping",
 	description = "Allows use of WASD keys for camera movement with 'Press Enter to Chat', and remapping number keys to F-keys",
-	tags = {"enter", "chat", "wasd", "camera"},
+	tags = {"enter", "chat", "wasd", "camera", "toggle"},
 	enabledByDefault = false
 )
 public class KeyRemappingPlugin extends Plugin


### PR DESCRIPTION
Toggling means to use a single key to active one selected key after the other.

There are two configurable keys in total, the key to activate the toggle is also configurable. 

Seemed like a good addition to the Key Remapping plugin. For example, in a large majority of use cases you are switching between two KeyEvents. If you could specify those and toggle between them using a single key it would save some effort. It's disabled by default but I think it would provide some QoL. 