### PR TITLE
Revert "opponentinfo: add opponent's opponent for npcs"

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/opponentinfo/OpponentInfoConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/opponentinfo/OpponentInfoConfig.java
@@ -54,17 +54,6 @@ public interface OpponentInfoConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "showOpponentsOpponent",
-		name = "Show opponent's opponent",
-		description = "Toggle showing opponent's opponent if within a multi-combat area",
-		position = 2
-	)
-	default boolean showOpponentsOpponent()
-	{
-		return true;
-	}
-
-	@ConfigItem(
 		keyName = "showOpponentsInMenu",
 		name = "Show opponents in menu",
 		description = "Marks opponents names in the menu which you are attacking or are attacking you (NPC only)",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/opponentinfo/OpponentInfoOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/opponentinfo/OpponentInfoOverlay.java
@@ -37,7 +37,6 @@ import net.runelite.api.Client;
 import static net.runelite.api.MenuAction.RUNELITE_OVERLAY_CONFIG;
 import net.runelite.api.NPC;
 import net.runelite.api.Player;
-import net.runelite.api.Varbits;
 import net.runelite.client.game.HiscoreManager;
 import net.runelite.client.game.NPCManager;
 import net.runelite.client.ui.overlay.Overlay;
@@ -69,7 +68,6 @@ class OpponentInfoOverlay extends Overlay
 	private int lastRatio = 0;
 	private int lastHealthScale = 0;
 	private String opponentName;
-	private String opponentsOpponentName;
 
 	@Inject
 	private OpponentInfoOverlay(
@@ -127,17 +125,6 @@ class OpponentInfoOverlay extends Overlay
 						lastMaxHealth = hp;
 					}
 				}
-			}
-
-			final Actor opponentsOpponent = opponent.getInteracting();
-			if (opponent instanceof NPC && opponentsOpponent != null
-				&& (opponentsOpponent != client.getLocalPlayer() || client.getVar(Varbits.MULTICOMBAT_AREA) == 1))
-			{
-				opponentsOpponentName = Text.removeTags(opponentsOpponent.getName());
-			}
-			else
-			{
-				opponentsOpponentName = null;
 			}
 		}
 
@@ -216,16 +203,6 @@ class OpponentInfoOverlay extends Overlay
 			}
 
 			panelComponent.getChildren().add(progressBarComponent);
-		}
-
-		// Opponents opponent
-		if (opponentsOpponentName != null && opponentInfoConfig.showOpponentsOpponent())
-		{
-			panelWidth = Math.max(panelWidth, fontMetrics.stringWidth(opponentsOpponentName) + ComponentConstants.STANDARD_BORDER + ComponentConstants.STANDARD_BORDER);
-			panelComponent.setPreferredSize(new Dimension(panelWidth, 0));
-			panelComponent.getChildren().add(TitleComponent.builder()
-				.text(opponentsOpponentName)
-				.build());
 		}
 
 		return panelComponent.render(graphics);


### PR DESCRIPTION
This seems to be against the rules again
> Indicates which player an NPC is focused on

https://secure.runescape.com/m=news/a=13/another-message-about-unofficial-clients?oldschool=1

reverts commit 34f94e973c18627a3d7f20faf8160647b87c09c9.
