### PR TITLE
spec counter plugin: fix other NPC hitsplats affecting specs

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/specialcounter/SpecialCounterPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/specialcounter/SpecialCounterPlugin.java
@@ -61,7 +61,7 @@ public class SpecialCounterPlugin extends Plugin
 {
 	private int currentWorld = -1;
 	private int specialPercentage = -1;
-	private boolean specialUsed;
+	private NPC specedNPC;
 
 	private SpecialWeapon specialWeapon;
 	private final Set<Integer> interactedNpcIds = new HashSet<>();
@@ -129,7 +129,11 @@ public class SpecialCounterPlugin extends Plugin
 		this.specialPercentage = specialPercentage;
 		this.specialWeapon = usedSpecialWeapon();
 
-		specialUsed = true;
+		Actor interacting = client.getLocalPlayer().getInteracting();
+		if (interacting instanceof NPC)
+		{
+			specedNPC = (NPC) interacting;
+		}
 	}
 
 	@Subscribe
@@ -152,9 +156,9 @@ public class SpecialCounterPlugin extends Plugin
 			addInteracting(interactingId);
 		}
 
-		if (specialUsed)
+		if (specedNPC == hitsplatApplied.getActor())
 		{
-			specialUsed = false;
+			specedNPC = null;
 
 			if (specialWeapon != null)
 			{
@@ -188,6 +192,12 @@ public class SpecialCounterPlugin extends Plugin
 	public void onNpcDespawned(NpcDespawned npcDespawned)
 	{
 		NPC actor = npcDespawned.getNpc();
+
+		// if the NPC despawns before the hitsplat is shown
+		if (specedNPC == actor)
+		{
+			specedNPC = null;
+		}
 
 		if (actor.isDead() && interactedNpcIds.contains(actor.getId()))
 		{


### PR DESCRIPTION
The spec plugin uses the first hitsplat after you spec. This adds some validation to at least make sure the NPC the hitsplat is on is the same one you speced.