### PR TITLE
Added a menu entry swapper option for the Portal Nexus

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -93,6 +93,16 @@ public interface MenuEntrySwapperConfig extends Config
 	}
 
 	@ConfigItem(
+			keyName = "swapNexus",
+			name = "Portal Nexus",
+			description = "Swap Left-click option with Teleport Menu"
+	)
+	default boolean swapNexus()
+	{
+		return false;
+	}
+
+	@ConfigItem(
 		keyName = "swapContract",
 		name = "Contract",
 		description = "Swap Talk-to with Contract on Guildmaster Jane"

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -754,6 +754,12 @@ public class MenuEntrySwapperPlugin extends Plugin
 		{
 			swap("use", option, target, index);
 		}
+
+		else if (config.swapNexus() && target.equals("portal nexus"))
+		{
+			swap("teleport menu", option, target, index);
+		}
+
 		else if (option.equals("collect to inventory") || option.startsWith("collect-note") || option.startsWith("collect-item"))
 		{
 			switch (config.swapGEItemCollect())


### PR DESCRIPTION
Added a menu entry swapper option for the Portal Nexus, enabling left-click teleport menu, alongside shift / right-click saved destination teleport, which is not currently possible.