### PR TITLE
Quest Plugin: Fix null filter state bug

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/questlist/QuestListPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/questlist/QuestListPlugin.java
@@ -96,6 +96,7 @@ public class QuestListPlugin extends Plugin
 	@Override
 	protected void startUp()
 	{
+		currentFilterState = QuestState.ALL;
 		clientThread.invoke(this::addQuestButtons);
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/questlist/QuestListPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/questlist/QuestListPlugin.java
@@ -103,6 +103,7 @@ public class QuestListPlugin extends Plugin
 	@Override
 	protected void shutDown()
 	{
+		currentFilterState = null;
 		Widget header = client.getWidget(WidgetInfo.QUESTLIST_BOX);
 		if (header != null)
 		{


### PR DESCRIPTION
Closes #11065 

The problem was 'currentFilterState' was being set on game state change only when logging in.

Fix was to set it on plugin start up to ALL