### PR TITLE
OverlayRenderer: prevent moving DYNAMIC and TOOLTIP overlays

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayRenderer.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayRenderer.java
@@ -213,29 +213,7 @@ public class OverlayRenderer extends MouseAdapter implements KeyListener
 
 		for (Overlay overlay : overlays)
 		{
-			OverlayPosition overlayPosition = overlay.getPosition();
-
-			if (overlay.getPreferredPosition() != null)
-			{
-				overlayPosition = overlay.getPreferredPosition();
-			}
-
-			if (!isResizeable)
-			{
-				// On fixed mode, ABOVE_CHATBOX_RIGHT is in the same location as
-				// BOTTOM_RIGHT and CANVAS_TOP_RIGHT is same as TOP_RIGHT.
-				// Just use BOTTOM_RIGHT and TOP_RIGHT to prevent overlays from
-				// drawing over each other.
-				switch (overlayPosition)
-				{
-					case CANVAS_TOP_RIGHT:
-						overlayPosition = OverlayPosition.TOP_RIGHT;
-						break;
-					case ABOVE_CHATBOX_RIGHT:
-						overlayPosition = OverlayPosition.BOTTOM_RIGHT;
-						break;
-				}
-			}
+			final OverlayPosition overlayPosition = getCorrectedOverlayPosition(overlay);
 
 			if (overlayPosition == OverlayPosition.DYNAMIC || overlayPosition == OverlayPosition.TOOLTIP)
 			{
@@ -333,6 +311,13 @@ public class OverlayRenderer extends MouseAdapter implements KeyListener
 		{
 			for (Overlay overlay : overlayManager.getOverlays())
 			{
+				final OverlayPosition overlayPosition = getCorrectedOverlayPosition(overlay);
+
+				if (overlayPosition == OverlayPosition.DYNAMIC || overlayPosition == OverlayPosition.TOOLTIP)
+				{
+					continue;
+				}
+
 				if (overlay.getBounds().contains(mousePoint))
 				{
 					if (SwingUtilities.isRightMouseButton(mouseEvent))
@@ -510,6 +495,35 @@ public class OverlayRenderer extends MouseAdapter implements KeyListener
 
 		final Dimension dimension = MoreObjects.firstNonNull(overlayDimension, new Dimension());
 		overlay.getBounds().setSize(dimension);
+	}
+
+	private OverlayPosition getCorrectedOverlayPosition(final Overlay overlay)
+	{
+		OverlayPosition overlayPosition = overlay.getPosition();
+
+		if (overlay.getPreferredPosition() != null)
+		{
+			overlayPosition = overlay.getPreferredPosition();
+		}
+
+		if (!isResizeable)
+		{
+			// On fixed mode, ABOVE_CHATBOX_RIGHT is in the same location as
+			// BOTTOM_RIGHT and CANVAS_TOP_RIGHT is same as TOP_RIGHT.
+			// Just use BOTTOM_RIGHT and TOP_RIGHT to prevent overlays from
+			// drawing over each other.
+			switch (overlayPosition)
+			{
+				case CANVAS_TOP_RIGHT:
+					overlayPosition = OverlayPosition.TOP_RIGHT;
+					break;
+				case ABOVE_CHATBOX_RIGHT:
+					overlayPosition = OverlayPosition.BOTTOM_RIGHT;
+					break;
+			}
+		}
+
+		return overlayPosition;
 	}
 
 	private boolean shouldInvalidateBounds()


### PR DESCRIPTION
prevent moving DYNAMIC and TOOLTIP overlays as these are not intended to be able to be moved.  

This fixes an issue where the Mouse Tooltips plugins tooltip can be accidentally moved and cannot be returned to its normal position 

[video showing them being moved on release](https://streamable.com/v4xav)
getting your cursor into a position where its rendering and you could be dragging another overlay at the same time seemed to be the best way to "start it",  from there the tooltips bounding box would be visible in one of the snap corners and you could then drag it anywhere you wanted