### PR TITLE
Add Plugin with timer and readiness indicator for nature rune chest thieving

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/naturerunechest/NatureRuneChestConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/naturerunechest/NatureRuneChestConfig.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2017, Robin Weymans <Robin.weymans@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.naturerunechest;
+
+import java.awt.Color;
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+
+@ConfigGroup("naturerunechestconfig")
+public interface NatureRuneChestConfig extends Config
+{
+	@ConfigItem(
+			position = 1,
+			keyName = "hexColorEmptyChest",
+			name = "Empty chest",
+			description = "Color of empty chest timer"
+	)
+	default Color getEmptyChestColor()
+	{
+		return Color.BLUE;
+	}
+
+	@ConfigItem(
+			position = 2,
+			keyName = "hexColorFullChest",
+			name = "Full chest",
+			description = "Color of full chest indicator"
+	)
+	default Color getFullChestColor()
+	{
+		return Color.GREEN;
+	}
+
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/naturerunechest/NatureRuneChestConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/naturerunechest/NatureRuneChestConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Robin Weymans <Robin.weymans@gmail.com>
+ * Copyright (c) 2020, Travis Earley <travis.earley96@gmail.com>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/runelite-client/src/main/java/net/runelite/client/plugins/naturerunechest/NatureRuneChestOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/naturerunechest/NatureRuneChestOverlay.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2018, Infinitay <https://github.com/Infinitay>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.naturerunechest;
+
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Graphics2D;
+import java.time.Duration;
+import java.time.Instant;
+import javax.inject.Inject;
+import net.runelite.api.Client;
+import net.runelite.api.Perspective;
+import net.runelite.api.coords.LocalPoint;
+import net.runelite.client.ui.overlay.Overlay;
+import net.runelite.client.ui.overlay.OverlayLayer;
+import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.components.ProgressPieComponent;
+
+class NatureRuneChestOverlay extends Overlay
+{
+	private static final Duration DOWN_TIME = Duration.ofSeconds(8);
+	private final Client client;
+	private final NatureRuneChestPlugin plugin;
+	private final NatureRuneChestConfig config;
+	private Color colorFull, colorFullBorder;
+	private Color colorEmpty, colorEmptyBorder;
+
+	@Inject
+	private NatureRuneChestOverlay(NatureRuneChestPlugin plugin, Client client, NatureRuneChestConfig config)
+	{
+		this.plugin = plugin;
+		this.client = client;
+		this.config = config;
+
+		setPosition(OverlayPosition.DYNAMIC);
+		setLayer(OverlayLayer.ABOVE_SCENE);
+	}
+
+	public void updateConfig()
+	{
+		colorEmptyBorder = config.getEmptyChestColor();
+		colorEmpty = new Color(colorEmptyBorder.getRed(), colorEmptyBorder.getGreen(), colorEmptyBorder.getBlue(), 100);
+		colorFullBorder = config.getFullChestColor();
+		colorFull = new Color(colorFullBorder.getRed(), colorFullBorder.getGreen(), colorFullBorder.getBlue(), 100);
+	}
+
+	@Override
+	public Dimension render(Graphics2D graphics)
+	{
+		if (plugin.getChest() == null)
+		{
+			return null;
+		}
+
+		final LocalPoint localLoc = LocalPoint.fromWorld(client, plugin.getChest().getWorldLocation());
+		if (localLoc == null)
+		{
+			return null;
+		}
+		net.runelite.api.Point loc = Perspective.localToCanvas(client, localLoc, client.getPlane());
+		if (loc == null)
+		{
+			return null;
+		}
+		final ProgressPieComponent progressPie = new ProgressPieComponent();
+		int empty = plugin.getState();
+
+		updateConfig();
+
+		if (empty == 2)
+		{
+			progressPie.setDiameter(60);
+			progressPie.setFill(colorEmpty);
+			progressPie.setBorderColor(colorEmptyBorder);
+			progressPie.setPosition(loc);
+
+			final Duration duration = Duration.between(plugin.getStart(), Instant.now());
+			progressPie.setProgress(1 - (duration.compareTo(DOWN_TIME) < 0
+					? (double) duration.toMillis() / DOWN_TIME.toMillis()
+					: 1));
+
+			progressPie.render(graphics);
+		}
+
+		if (empty == 1)
+		{
+			progressPie.setDiameter(0);
+
+			progressPie.render(graphics);
+		}
+
+		if (empty == 0)
+		{
+			progressPie.setDiameter(60);
+			progressPie.setFill(colorFull);
+			progressPie.setBorderColor(colorFullBorder);
+			progressPie.setPosition(loc);
+			progressPie.setProgress(100);
+
+			progressPie.render(graphics);
+		}
+
+		return null;
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/naturerunechest/NatureRuneChestOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/naturerunechest/NatureRuneChestOverlay.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Infinitay <https://github.com/Infinitay>
+ * Copyright (c) 2020, Travis Earley <travis.earley96@gmail.com>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/runelite-client/src/main/java/net/runelite/client/plugins/naturerunechest/NatureRuneChestPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/naturerunechest/NatureRuneChestPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Adam <Adam@sigterm.info>
+ * Copyright (c) 2020, Travis Earley <travis.earley96@gmail.com>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -82,13 +82,15 @@ public class NatureRuneChestPlugin extends Plugin
 	}
 
 	@Override
-	protected void startUp() {
+	protected void startUp()
+	{
 		overlayManager.add(overlay);
 		overlay.updateConfig();
 	}
 
 	@Override
-	protected void shutDown() {
+	protected void shutDown()
+	{
 		overlayManager.remove(overlay);
 	}
 
@@ -126,16 +128,20 @@ public class NatureRuneChestPlugin extends Plugin
 		}
 
 		//chest is being opened
-		if (object.getId() == 11743) {
-			if (NRC_REGIONS.contains(client.getLocalPlayer().getWorldLocation().getRegionID())) {
+		if (object.getId() == 11743)
+		{
+			if (NRC_REGIONS.contains(client.getLocalPlayer().getWorldLocation().getRegionID()))
+			{
 				chest = object;
 				state = 1;
 			}
 		}
 
 		//chest is ready to steal from
-		if (object.getId() == 11736) {
-			if (NRC_REGIONS.contains(client.getLocalPlayer().getWorldLocation().getRegionID())) {
+		if (object.getId() == 11736)
+		{
+			if (NRC_REGIONS.contains(client.getLocalPlayer().getWorldLocation().getRegionID()))
+			{
 				chest = object;
 				state = 0;
 			}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/naturerunechest/NatureRuneChestPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/naturerunechest/NatureRuneChestPlugin.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2019, Adam <Adam@sigterm.info>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.naturerunechest;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.inject.Provides;
+import java.time.Instant;
+import java.util.Set;
+import javax.inject.Inject;
+import lombok.AccessLevel;
+import lombok.Getter;
+import net.runelite.api.Client;
+import net.runelite.api.GameObject;
+import net.runelite.api.GameState;
+import net.runelite.api.events.GameObjectSpawned;
+import net.runelite.api.events.GameStateChanged;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.eventbus.Subscribe;
+import net.runelite.client.events.ConfigChanged;
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.ui.overlay.OverlayManager;
+
+@PluginDescriptor(
+		name = "Nature Rune Chest",
+		description = "Show when nature rune chest is ready to be looted again",
+		tags = {"overlay", "skilling", "timers"},
+		enabledByDefault = false
+)
+
+public class NatureRuneChestPlugin extends Plugin
+{
+	private static final Set<Integer> NRC_REGIONS = ImmutableSet.of(10547, 10291, 10553, 12093);
+
+	@Inject
+	private Client client;
+
+	@Inject
+	private OverlayManager overlayManager;
+
+	@Inject
+	private NatureRuneChestOverlay overlay;
+
+	@Inject
+	private NatureRuneChestConfig config;
+
+	@Getter(AccessLevel.PACKAGE)
+	private GameObject chest;
+
+	@Getter(AccessLevel.PACKAGE)
+	private Instant start;
+
+	@Getter(AccessLevel.PACKAGE)
+	private int state;
+
+	@Provides
+	NatureRuneChestConfig provideConfig(ConfigManager configManager)
+	{
+		return configManager.getConfig(NatureRuneChestConfig.class);
+	}
+
+	@Override
+	protected void startUp() {
+		overlayManager.add(overlay);
+		overlay.updateConfig();
+	}
+
+	@Override
+	protected void shutDown() {
+		overlayManager.remove(overlay);
+	}
+
+	@Subscribe
+	public void onGameStateChanged(GameStateChanged event)
+	{
+		switch (event.getGameState())
+		{
+			case LOGIN_SCREEN:
+			case HOPPING:
+			case LOADING:
+				chest = null;
+		}
+	}
+
+	@Subscribe
+	public void onGameObjectSpawned(GameObjectSpawned event)
+	{
+		if (client.getGameState() != GameState.LOGGED_IN)
+		{
+			return;
+		}
+
+		GameObject object = event.getGameObject();
+
+		// Chest has been looted and is waiting to restock
+		if (object.getId() == 11740)
+		{
+			if (NRC_REGIONS.contains(client.getLocalPlayer().getWorldLocation().getRegionID()))
+			{
+				chest = object;
+				state = 2;
+				start = Instant.now();
+			}
+		}
+
+		//chest is being opened
+		if (object.getId() == 11743) {
+			if (NRC_REGIONS.contains(client.getLocalPlayer().getWorldLocation().getRegionID())) {
+				chest = object;
+				state = 1;
+			}
+		}
+
+		//chest is ready to steal from
+		if (object.getId() == 11736) {
+			if (NRC_REGIONS.contains(client.getLocalPlayer().getWorldLocation().getRegionID())) {
+				chest = object;
+				state = 0;
+			}
+		}
+	}
+
+	@Subscribe
+	public void onConfigChanged(ConfigChanged event)
+	{
+		if (event.getGroup().equals("naturerunechestplugin"))
+		{
+			overlay.updateConfig();
+		}
+	}
+}


### PR DESCRIPTION
Closes #3924

 Creates a new UI element that count down how long until the [nature rune theiving chests](https://oldschool.runescape.wiki/w/Chest_(nature_runes) can be looted again. Also shows a solid color when the chest is ready to be looted.

Both colors are customizable in the config