### PR TITLE
Fixed typo in account plugin

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/account/AccountPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/account/AccountPlugin.java
@@ -113,7 +113,7 @@ public class AccountPlugin extends Plugin
 	private void logoutClick()
 	{
 		if (JOptionPane.YES_OPTION == JOptionPane.showConfirmDialog(null,
-			"Are you sure you want to logout from RuneLite?", "Logout Confirmation",
+			"Are you sure you want to log out from RuneLite?", "Logout Confirmation",
 			JOptionPane.YES_NO_OPTION))
 		{
 			executor.execute(sessionManager::logout);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/account/AccountPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/account/AccountPlugin.java
@@ -75,14 +75,14 @@ public class AccountPlugin extends Plugin
 		loginButton = NavigationButton.builder()
 			.tab(false)
 			.icon(LOGIN_IMAGE)
-			.tooltip("Login to RuneLite")
+			.tooltip("Log in to RuneLite")
 			.onClick(this::loginClick)
 			.build();
 
 		logoutButton = NavigationButton.builder()
 			.tab(false)
 			.icon(LOGOUT_IMAGE)
-			.tooltip("Logout of RuneLite")
+			.tooltip("Log out of RuneLite")
 			.onClick(this::logoutClick)
 			.build();
 


### PR DESCRIPTION
There's a typo in the tooltip text for the login button from the account plugin. Namely it uses `login` instead of `log in`, and `login` is only a noun, not a verb. It reads to me like the verb is the intended usage here. This PR switches `login` and `logout` to `log in` and `log out`.

Article describing difference: https://grammarist.com/spelling/log-in-login/