### PR TITLE
Fix addModalTooltip to show tooltip before interaction

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/util/SwingUtil.java
+++ b/runelite-client/src/main/java/net/runelite/client/util/SwingUtil.java
@@ -297,6 +297,7 @@ public class SwingUtil
 
 	public static void addModalTooltip(AbstractButton button, String on, String off)
 	{
+		button.setToolTipText(off);
 		button.addItemListener(l -> button.setToolTipText(button.isSelected() ? on : off));
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/util/SwingUtil.java
+++ b/runelite-client/src/main/java/net/runelite/client/util/SwingUtil.java
@@ -297,7 +297,7 @@ public class SwingUtil
 
 	public static void addModalTooltip(AbstractButton button, String on, String off)
 	{
-		button.setToolTipText(off);
+		button.setToolTipText(button.isSelected() ? on : off);
 		button.addItemListener(l -> button.setToolTipText(button.isSelected() ? on : off));
 	}
 


### PR DESCRIPTION
Currently any tooltips added using `my_toggle.addModalTooltip()` do not show until after the user has interacted with the button at least once. As a result, most plugins in the plugin list do not show the `pin plugin` or `enable plugin` tooltips. This bug can be reproduced simply by restarting the client and hovering the mouse over a plugin's star icon.

The reason for this is that `addModalTooltip()` looks as follows:

```java
public static void addModalTooltip(AbstractButton button, String on, String off)
{
	button.addItemListener(l -> button.setToolTipText(button.isSelected() ? on : off));
}
```

The listener that we add only sets the tooltip text upon its state changing. If the button remains in its default state without any interaction (off), then the tooltip text doesn't show.

To fix this, I added the line `button.setToolTipText(off);` to set the button's tooltip text to the default state (off, as all toggle buttons initialize to off unless otherwise specified) inside of `addModalTooltip`.

I've tested behavior of the pin  and enable plugin toggles and confirmed that this change works as expected, but I haven't yet confirmed that it works in the loot tracker.
