### PR TITLE
Hide prayer flick indicator when minimap is hidden

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/prayer/PrayerFlickOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/prayer/PrayerFlickOverlay.java
@@ -63,14 +63,8 @@ class PrayerFlickOverlay extends Overlay
 			return null;
 		}
 
-		// Prayer orb widget will be hidden when minimap is hidden
-		Widget prayerOrb = client.getWidget(WidgetInfo.MINIMAP_PRAYER_ORB);
-		if (prayerOrb == null || prayerOrb.isHidden()) {
-			return null;
-		}
-
 		Widget xpOrb = client.getWidget(WidgetInfo.MINIMAP_QUICK_PRAYER_ORB);
-		if (xpOrb == null)
+		if (xpOrb == null || xpOrb.isHidden())
 		{
 			return null;
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/prayer/PrayerFlickOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/prayer/PrayerFlickOverlay.java
@@ -63,6 +63,12 @@ class PrayerFlickOverlay extends Overlay
 			return null;
 		}
 
+		// Prayer orb widget will be hidden when minimap is hidden
+		Widget prayerOrb = client.getWidget(WidgetInfo.MINIMAP_PRAYER_ORB);
+		if (prayerOrb == null || prayerOrb.isHidden()) {
+			return null;
+		}
+
 		Widget xpOrb = client.getWidget(WidgetInfo.MINIMAP_QUICK_PRAYER_ORB);
 		if (xpOrb == null)
 		{


### PR DESCRIPTION
This fixes it, but I don't know about the difference between MINIMAP_PRAYER_ORB and MINIMAP_QUICK_PRAYER_ORB.

Fixes #11133