### PR TITLE
Quest List: Keep quest search filter active when input is closed

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/questlist/QuestListPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/questlist/QuestListPlugin.java
@@ -219,6 +219,8 @@ public class QuestListPlugin extends Plugin
 	private void closeSearch()
 	{
 		updateFilter("");
+		questSearchButton.setOnOpListener((JavaScriptCallback) e -> openSearch());
+		questSearchButton.setAction(1, MENU_OPEN);
 		chatboxPanelManager.close();
 		client.playSoundEffect(SoundEffectID.UI_BOOP);
 	}
@@ -233,9 +235,18 @@ public class QuestListPlugin extends Plugin
 			.onChanged(s -> clientThread.invokeLater(() -> updateFilter(s)))
 			.onClose(() ->
 			{
-				clientThread.invokeLater(() -> updateFilter(""));
-				questSearchButton.setOnOpListener((JavaScriptCallback) e -> openSearch());
-				questSearchButton.setAction(1, MENU_OPEN);
+				final int quests = questSet.values().stream()
+					.map(q -> (int) q.stream()
+							.filter(qw -> !qw.getQuest().isHidden())
+							.count())
+					.reduce(0, Integer::sum);
+
+				if (quests == 0)
+				{
+					clientThread.invokeLater(() -> updateFilter(""));
+					questSearchButton.setOnOpListener((JavaScriptCallback) e -> openSearch());
+					questSearchButton.setAction(1, MENU_OPEN);
+				}
 			})
 			.build();
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/questlist/QuestListPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/questlist/QuestListPlugin.java
@@ -170,6 +170,20 @@ public class QuestListPlugin extends Plugin
 	@Subscribe
 	public void onVarbitChanged(VarbitChanged varbitChanged)
 	{
+		checkOpenQuestTab();
+	}
+
+	@Subscribe
+	public void onVarClientIntChanged(VarClientIntChanged varClientIntChanged)
+	{
+		if (varClientIntChanged.getIndex() == VarClientInt.INVENTORY_TAB.getIndex())
+		{
+			checkOpenQuestTab();
+		}
+	}
+
+	private void checkOpenQuestTab()
+	{
 		if (!isOnQuestTab())
 		{
 			updateFilter("");
@@ -179,25 +193,6 @@ public class QuestListPlugin extends Plugin
 			if (isChatboxOpen())
 			{
 				chatboxPanelManager.close();
-			}
-		}
-	}
-
-	@Subscribe
-	public void onVarClientIntChanged(VarClientIntChanged varClientIntChanged)
-	{
-		if (varClientIntChanged.getIndex() == VarClientInt.INVENTORY_TAB.getIndex())
-		{
-			if (!isOnQuestTab())
-			{
-				updateFilter("");
-				questSearchButton.setOnOpListener((JavaScriptCallback) e -> openSearch());
-				questSearchButton.setAction(1, MENU_OPEN);
-
-				if (isChatboxOpen())
-				{
-					chatboxPanelManager.close();
-				}
 			}
 		}
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/questlist/QuestListPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/questlist/QuestListPlugin.java
@@ -170,9 +170,16 @@ public class QuestListPlugin extends Plugin
 	@Subscribe
 	public void onVarbitChanged(VarbitChanged varbitChanged)
 	{
-		if (isChatboxOpen() && !isOnQuestTab())
+		if (!isOnQuestTab())
 		{
-			chatboxPanelManager.close();
+			updateFilter("");
+			questSearchButton.setOnOpListener((JavaScriptCallback) e -> openSearch());
+			questSearchButton.setAction(1, MENU_OPEN);
+
+			if (isChatboxOpen())
+			{
+				chatboxPanelManager.close();
+			}
 		}
 	}
 
@@ -181,9 +188,16 @@ public class QuestListPlugin extends Plugin
 	{
 		if (varClientIntChanged.getIndex() == VarClientInt.INVENTORY_TAB.getIndex())
 		{
-			if (isChatboxOpen() && !isOnQuestTab())
+			if (!isOnQuestTab())
 			{
-				chatboxPanelManager.close();
+				updateFilter("");
+				questSearchButton.setOnOpListener((JavaScriptCallback) e -> openSearch());
+				questSearchButton.setAction(1, MENU_OPEN);
+
+				if (isChatboxOpen())
+				{
+					chatboxPanelManager.close();
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Closes #11078 

Simply keeps the search filter active when closing the input except when the search returns zero results.