### PR TITLE
Menu Entry Swapper: using bones on Phials or the altar is always at the top of the menu

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -750,9 +750,18 @@ public class MenuEntrySwapperPlugin extends Plugin
 				swap("teleport", option, target, index);
 			}
 		}
-		else if (config.swapBones() && option.equals("bury"))
+		else if (config.swapBones())
 		{
-			swap("use", option, target, index);
+			if (option.equals("bury"))
+			{
+				swap("use", option, target, index);
+			}
+			else if (option.equals("use") && (target.contains("bones -> phials") || target.contains("bones -> altar")))
+			{
+				// Move this entry to the top so the user doesn't accidentally use bones on players nearby
+				MenuEntry[] menuEntries = client.getMenuEntries();
+				swap(optionIndexes, menuEntries, index, menuEntries.length - 1);
+			}
 		}
 		else if (option.equals("collect to inventory") || option.startsWith("collect-note") || option.startsWith("collect-item"))
 		{


### PR DESCRIPTION
When using bones on Phials to un-note bones, or using bones on an altar, always put these options at the top of the menu if the "Bury" plugin configuration is on. I was training Prayer this weekend, and was getting annoyed when I would try to perform these actions and players were getting in the way (the house party worlds are generally very busy).

Using bones on Phials with the Bury configuration disabled:
![phials-bury-off](https://user-images.githubusercontent.com/844064/77861764-a26cbb00-71dc-11ea-8a66-8541d425f22b.png)

Using bones on Phials with the Bury configuration enabled:
![phials-bury-on](https://user-images.githubusercontent.com/844064/77861793-ce883c00-71dc-11ea-8107-210fc84db479.png)

Using bones on an altar with the Bury configuration disabled:
![altar-bury-off](https://user-images.githubusercontent.com/844064/77861795-d6e07700-71dc-11ea-9b7c-8fa82e6dd96a.png)

Using bones on an altar with the Bury configuration enabled:
![altar-bury-on](https://user-images.githubusercontent.com/844064/77861799-de078500-71dc-11ea-89dd-765c37bb4481.png)