### PR TITLE
barrowsplugin: fix null pointer exception in region check

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/barrows/BarrowsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/barrows/BarrowsPlugin.java
@@ -35,6 +35,7 @@ import net.runelite.api.GameState;
 import net.runelite.api.InventoryID;
 import net.runelite.api.Item;
 import net.runelite.api.ItemContainer;
+import net.runelite.api.Player;
 import net.runelite.api.SpriteID;
 import net.runelite.client.events.ConfigChanged;
 import net.runelite.api.events.GameStateChanged;
@@ -249,6 +250,7 @@ public class BarrowsPlugin extends Plugin
 
 	private boolean isInCrypt()
 	{
-		return client.getLocalPlayer().getWorldLocation().getRegionID() == CRYPT_REGION_ID;
+		Player localPlayer = client.getLocalPlayer();
+		return localPlayer != null && localPlayer.getWorldLocation().getRegionID() == CRYPT_REGION_ID;
 	}
 }


### PR DESCRIPTION
I was doing some smithing in Varrock, when all of a sudden my object indicators disappeared.
The only stacktrace I could find was this:
```
2020-03-31 01:01:39 [Client] WARN  n.runelite.client.eventbus.EventBus - Uncaught exception in event subscriber
java.lang.NullPointerException: null
	at net.runelite.client.plugins.barrows.BarrowsPlugin.isInCrypt(BarrowsPlugin.java:252)
	at net.runelite.client.plugins.barrows.BarrowsPlugin.onGameStateChanged(BarrowsPlugin.java:166)
	at net.runelite.client.eventbus.EventBus$Subscriber.invoke(EventBus.java:73)
	at net.runelite.client.eventbus.EventBus.post(EventBus.java:222)
	at net.runelite.client.callback.Hooks.post(Hooks.java:167)
	at client.oz(client.java:62117)
	at bn.ew(bn.java:1275)
	at client.zl(client.java:2476)
	at client.u(client.java:1114)
	at br.kq(br.java:336)
	at br.run(br.java:315)
	at java.lang.Thread.run(Thread.java:748)
```