### PR TITLE
Fix: Loot tracker boxes now remember their collapsed state after being rebuilt

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerBox.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerBox.java
@@ -83,6 +83,7 @@ class LootTrackerBox extends JPanel
 	private long totalPrice;
 	private boolean hideIgnoredItems;
 	private BiConsumer<String, Boolean> onItemToggle;
+	private boolean isGroupBox;
 
 	LootTrackerBox(
 		final ItemManager itemManager,
@@ -92,7 +93,8 @@ class LootTrackerBox extends JPanel
 		final boolean hideIgnoredItems,
 		final LootTrackerPriceType priceType,
 		final boolean showPriceType,
-		final BiConsumer<String, Boolean> onItemToggle)
+		final BiConsumer<String, Boolean> onItemToggle,
+		final boolean isGroupBox)
 	{
 		this.id = id;
 		this.lootRecordType = lootRecordType;
@@ -101,6 +103,7 @@ class LootTrackerBox extends JPanel
 		this.hideIgnoredItems = hideIgnoredItems;
 		this.priceType = priceType;
 		this.showPriceType = showPriceType;
+		this.isGroupBox = isGroupBox;
 
 		setLayout(new BorderLayout(0, 1));
 		setBorder(new EmptyBorder(5, 0, 0, 0));
@@ -231,9 +234,21 @@ class LootTrackerBox extends JPanel
 		repaint();
 		for (LootTrackerRecord rec: records)
 		{
-			if (rec.isShouldCollapseBox())
+			if (isGroupBox)
 			{
-				this.collapse();
+				if (rec.isShouldCollapseGroup())
+				{
+					this.collapse();
+					break;
+				}
+			}
+			else
+			{
+				if ((rec.isShouldCollapseBox()))
+				{
+					this.collapse();
+					break;
+				}
 			}
 		}
 	}
@@ -246,7 +261,15 @@ class LootTrackerBox extends JPanel
 			applyDimmer(false, logTitle);
 			for (LootTrackerRecord rec: records)
 			{
-				rec.setShouldCollapseBox(true);
+				if (isGroupBox)
+				{
+					rec.setShouldCollapseGroup(true);
+				}
+				else
+				{
+					assert (records.size() == 1);
+					rec.setShouldCollapseBox(true);
+				}
 			}
 		}
 	}
@@ -259,7 +282,15 @@ class LootTrackerBox extends JPanel
 			applyDimmer(true, logTitle);
 			for (LootTrackerRecord rec: records)
 			{
-				rec.setShouldCollapseBox(false);
+				if (isGroupBox)
+				{
+					rec.setShouldCollapseGroup(false);
+				}
+				else
+				{
+					assert (records.size() == 1);
+					rec.setShouldCollapseBox(false);
+				}
 			}
 
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerBox.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerBox.java
@@ -78,6 +78,7 @@ class LootTrackerBox extends JPanel
 	private int kills;
 	@Getter
 	private final List<LootTrackerItem> items = new ArrayList<>();
+	private final List<LootTrackerRecord> records = new ArrayList<>();
 
 	private long totalPrice;
 	private boolean hideIgnoredItems;
@@ -186,6 +187,7 @@ class LootTrackerBox extends JPanel
 		}
 
 		kills += record.getKills();
+		records.add(record);
 
 		outer:
 		for (LootTrackerItem item : record.getItems())
@@ -227,6 +229,13 @@ class LootTrackerBox extends JPanel
 
 		validate();
 		repaint();
+		for(LootTrackerRecord rec: records)
+		{
+			if(rec.isShouldCollapseBox())
+			{
+				this.collapse();
+			}
+		}
 	}
 
 	void collapse()
@@ -235,6 +244,10 @@ class LootTrackerBox extends JPanel
 		{
 			itemContainer.setVisible(false);
 			applyDimmer(false, logTitle);
+			for(LootTrackerRecord rec: records)
+			{
+				rec.setShouldCollapseBox(true);
+			}
 		}
 	}
 
@@ -244,6 +257,11 @@ class LootTrackerBox extends JPanel
 		{
 			itemContainer.setVisible(true);
 			applyDimmer(true, logTitle);
+			for(LootTrackerRecord rec: records)
+			{
+				rec.setShouldCollapseBox(false);
+			}
+
 		}
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerBox.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerBox.java
@@ -229,9 +229,9 @@ class LootTrackerBox extends JPanel
 
 		validate();
 		repaint();
-		for(LootTrackerRecord rec: records)
+		for (LootTrackerRecord rec: records)
 		{
-			if(rec.isShouldCollapseBox())
+			if (rec.isShouldCollapseBox())
 			{
 				this.collapse();
 			}
@@ -244,7 +244,7 @@ class LootTrackerBox extends JPanel
 		{
 			itemContainer.setVisible(false);
 			applyDimmer(false, logTitle);
-			for(LootTrackerRecord rec: records)
+			for (LootTrackerRecord rec: records)
 			{
 				rec.setShouldCollapseBox(true);
 			}
@@ -257,7 +257,7 @@ class LootTrackerBox extends JPanel
 		{
 			itemContainer.setVisible(true);
 			applyDimmer(true, logTitle);
-			for(LootTrackerRecord rec: records)
+			for (LootTrackerRecord rec: records)
 			{
 				rec.setShouldCollapseBox(false);
 			}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPanel.java
@@ -500,7 +500,7 @@ class LootTrackerPanel extends PluginPanel
 
 		// Create box
 		final LootTrackerBox box = new LootTrackerBox(itemManager, record.getTitle(), record.getType(), record.getSubTitle(),
-			hideIgnoredItems, config.priceType(), config.showPriceType(), plugin::toggleItem);
+			hideIgnoredItems, config.priceType(), config.showPriceType(), plugin::toggleItem, groupLoot);
 		box.addKill(record);
 
 		// Create popup menu

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerRecord.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerRecord.java
@@ -24,11 +24,11 @@
  */
 package net.runelite.client.plugins.loottracker;
 
+import lombok.Data;
 import lombok.NonNull;
-import lombok.Value;
 import net.runelite.http.api.loottracker.LootRecordType;
 
-@Value
+@Data
 class LootTrackerRecord
 {
 	@NonNull
@@ -37,6 +37,7 @@ class LootTrackerRecord
 	private final LootRecordType type;
 	private final LootTrackerItem[] items;
 	private final int kills;
+	private boolean shouldCollapseBox = false;
 
 	/**
 	 * Checks if this record matches specified id

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerRecord.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerRecord.java
@@ -38,6 +38,7 @@ class LootTrackerRecord
 	private final LootTrackerItem[] items;
 	private final int kills;
 	private boolean shouldCollapseBox = false;
+	private boolean shouldCollapseGroup = false;
 
 	/**
 	 * Checks if this record matches specified id


### PR DESCRIPTION
Fix for issue #11156 Edited the LootTrackerRecord class. Hopefully that is not outside the scope for that class. 