### PR TITLE
Add region filter to world quick-hopping

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/RegionFilterMode.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/RegionFilterMode.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2019, Liam Edwards <http://github.com/Spedwards>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.worldhopper;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import net.runelite.http.api.worlds.WorldRegion;
+
+@NoArgsConstructor
+@AllArgsConstructor
+public enum RegionFilterMode
+{
+	NONE,
+	AUSTRALIA(WorldRegion.AUSTRALIA),
+	GERMANY(WorldRegion.GERMANY),
+	UNITED_KINGDOM(WorldRegion.UNITED_KINGDOM)
+		{
+			@Override
+			public String toString()
+			{
+				return "U.K.";
+			}
+		},
+	UNITED_STATES(WorldRegion.UNITED_STATES_OF_AMERICA)
+		{
+			@Override
+			public String toString()
+			{
+				return "USA";
+			}
+		};
+
+	@Getter
+	private WorldRegion region;
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldHopperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldHopperConfig.java
@@ -71,10 +71,21 @@ public interface WorldHopperConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "quickHopRegionFilter",
+		name = "Quick-hop to specific region only",
+		description = "Limit quick-hopping to worlds of a specific region",
+		position = 3
+	)
+	default RegionFilterMode quickHopRegionFilter()
+	{
+		return RegionFilterMode.NONE;
+	}
+
+	@ConfigItem(
 		keyName = "showSidebar",
 		name = "Show world hopper sidebar",
 		description = "Show sidebar containing all worlds that mimics in-game interface",
-		position = 3
+		position = 4
 	)
 	default boolean showSidebar()
 	{
@@ -85,7 +96,7 @@ public interface WorldHopperConfig extends Config
 		keyName = "ping",
 		name = "Show world ping",
 		description = "Shows ping to each game world",
-		position = 4
+		position = 5
 	)
 	default boolean ping()
 	{
@@ -96,7 +107,7 @@ public interface WorldHopperConfig extends Config
 		keyName = "showMessage",
 		name = "Show world hop message in chat",
 		description = "Shows what world is being hopped to in the chat",
-		position = 5
+		position = 6
 	)
 	default boolean showWorldHopMessage()
 	{
@@ -107,7 +118,7 @@ public interface WorldHopperConfig extends Config
 		keyName = "menuOption",
 		name = "Show Hop-to menu option",
 		description = "Adds Hop-to menu option to the friends list and clan members list",
-		position = 6
+		position = 7
 	)
 	default boolean menuOption()
 	{
@@ -118,7 +129,7 @@ public interface WorldHopperConfig extends Config
 		keyName = "subscriptionFilter",
 		name = "Show subscription types",
 		description = "Only show free worlds, member worlds, or both types of worlds in sidebar",
-		position = 7
+		position = 8
 	)
 	default SubscriptionFilterMode subscriptionFilter()
 	{
@@ -129,7 +140,7 @@ public interface WorldHopperConfig extends Config
 		keyName = "displayPing",
 		name = "Display current ping",
 		description = "Displays ping to current game world",
-		position = 7
+		position = 9
 	)
 	default boolean displayPing()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldHopperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldHopperConfig.java
@@ -72,7 +72,7 @@ public interface WorldHopperConfig extends Config
 
 	@ConfigItem(
 		keyName = "quickHopRegionFilter",
-		name = "Quick-hop to specific region only",
+		name = "Quick-hop region",
 		description = "Limit quick-hopping to worlds of a specific region",
 		position = 3
 	)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldHopperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldHopperPlugin.java
@@ -560,6 +560,12 @@ public class WorldHopperPlugin extends Plugin
 
 			world = worlds.get(worldIdx);
 
+			// Check world region if filter is enabled
+			if (config.quickHopRegionFilter() != RegionFilterMode.NONE && world.getRegion() != config.quickHopRegionFilter().getRegion())
+			{
+				continue;
+			}
+
 			EnumSet<WorldType> types = world.getTypes().clone();
 
 			types.remove(WorldType.BOUNTY);


### PR DESCRIPTION
This enhancement will add an option to the World Hopper plugin that will limit the quick-hop feature to worlds of a given region.