### PR TITLE
item prices: always show tooltip when alching if option is enabled

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemprices/ItemPricesConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemprices/ItemPricesConfig.java
@@ -89,7 +89,7 @@ public interface ItemPricesConfig extends Config
 	@ConfigItem(
 		keyName = "showWhileAlching",
 		name = "Show prices while alching",
-		description = "Show the price overlay while using High Alchemy",
+		description = "Show the price overlay while using High Alchemy. Takes priority over \"Hide tooltips on Inventory Items\"",
 		position = 6
 	)
 	default boolean showWhileAlching()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemprices/ItemPricesOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemprices/ItemPricesOverlay.java
@@ -93,12 +93,13 @@ class ItemPricesOverlay extends Overlay
 		final MenuAction action = MenuAction.of(menuEntry.getType());
 		final int widgetId = menuEntry.getParam1();
 		final int groupId = WidgetInfo.TO_GROUP(widgetId);
+		final boolean isAlching = menuEntry.getOption().equals("Cast") && menuEntry.getTarget().contains("High Level Alchemy");
 
 		// Tooltip action type handling
 		switch (action)
 		{
 			case ITEM_USE_ON_WIDGET:
-				if (!config.showWhileAlching() || !menuEntry.getOption().equals("Cast") || !menuEntry.getTarget().contains("High Level Alchemy"))
+				if (!config.showWhileAlching() || !isAlching)
 				{
 					break;
 				}
@@ -118,7 +119,7 @@ class ItemPricesOverlay extends Overlay
 							return null;
 						}
 					case WidgetID.INVENTORY_GROUP_ID:
-						if (config.hideInventory())
+						if (config.hideInventory() && !(config.showWhileAlching() && isAlching))
 						{
 							return null;
 						}


### PR DESCRIPTION
Closes #11172 

If the "Show prices while alching" option is enabled, the tooltip will always show while alching.

Works the same as the picture in the issue: https://i.imgur.com/DXKtwNn.png