### PR TITLE
DPS counter change

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/dpscounter/DpsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/dpscounter/DpsConfig.java
@@ -31,11 +31,18 @@ import net.runelite.client.config.ConfigItem;
 @ConfigGroup("dpscounter")
 public interface DpsConfig extends Config
 {
+	enum DisplayChangeMode
+	{
+		ALWAYS,
+		IN_COMBAT,
+		NEVER
+	}
+
 	@ConfigItem(
 		position = 0,
 		keyName = "showDamage",
 		name = "Show damage",
-		description = "Show total damage instead of DPS"
+		description = "Show total damage in addition to DPS"
 	)
 	default boolean showDamage()
 	{
@@ -51,5 +58,38 @@ public interface DpsConfig extends Config
 	default boolean autopause()
 	{
 		return false;
+	}
+
+	@ConfigItem(
+			position = 2,
+			keyName = "resetTracker",
+			name = "Reset",
+			description = "Reset DPS tracker at the start of every boss fight"
+	)
+	default boolean resetTracker()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+			position = 3,
+			keyName = "bossOnly",
+			name = "Boss Only",
+			description = "Only show Damage/DPS on bosses"
+	)
+	default boolean bossOnly()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+			position = 4,
+			keyName = "displayTracker",
+			name = "Display Tracker",
+			description = "Choose when to display the DPS tracker"
+	)
+	default DisplayChangeMode displayTracker()
+	{
+		return DisplayChangeMode.IN_COMBAT;
 	}
 }


### PR DESCRIPTION
Changes/Additions:
- show damage now shows damage + DPS as opposed to showing damage only
- reset option to reset DPS counter at the start of each new boss fight
- boss only option to only track DPS/damage on boss targets
- display tracker option to choose when to display tracker (always, in-combat, never)
- DPS counter pauses when player dies
- added some missing bosses
- changed the fight timer to always show on the overlay instead of being a tool-tip