### PR TITLE
http-api: remove unused fields from NPCInfo

### DIFF
--- a/http-api/src/main/java/net/runelite/http/api/npc/NpcInfo.java
+++ b/http-api/src/main/java/net/runelite/http/api/npc/NpcInfo.java
@@ -29,7 +29,5 @@ import lombok.Data;
 @Data
 public class NpcInfo
 {
-	private String name;
-	private int combat;
 	private int hitpoints;
 }


### PR DESCRIPTION
These fields are never used. If we need this information we can get it from the client's cache

I intend to include the `name` field in the non-`.min` versions of this for easier debugging.