### PR TITLE
music: revalidate slider handle on creation

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/music/MusicPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/music/MusicPlugin.java
@@ -563,6 +563,7 @@ public class MusicPlugin extends Plugin
 				handle.setOriginalWidth(16);
 				handle.setOriginalHeight(16);
 				handle.setClickMask(WidgetConfig.DRAG);
+				handle.revalidate();
 
 				handle.setOnMouseRepeatListener((JavaScriptCallback) ev -> hoveredSlider = slider);
 				handle.setHasListener(true);


### PR DESCRIPTION
![bBDH1x70DF](https://user-images.githubusercontent.com/6256228/78573439-a58d2a00-7820-11ea-8ab4-2900f9d55266.gif)

Moving the music plugin's slider handles after their creation causes them to visually jump as shown in the GIF above.

This is because the handle's width is still 0 after its creation in `updateMusicOptions()`, as a call to `revalidate()` is missing after its original width is set. This then causes the slider's computed `newX` value to be incorrect.