### PR TITLE
Add Menu Entry Swapper option for "Pet" stray dog instead of "Shoo-away"

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -431,4 +431,14 @@ public interface MenuEntrySwapperConfig extends Config
 	{
 		return true;
 	}
+
+	@ConfigItem(
+			keyName = "swapPetStray",
+			name = "Pet Stray",
+			description = "Swap Shoo-away with Pet for stray dogs"
+	)
+	default boolean swapPetStray()
+	{
+		return true;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -771,6 +771,8 @@ public class MenuEntrySwapperPlugin extends Plugin
 					swap("bank", option, target, index);
 					break;
 			}
+		} else if (target.contains("stray dog") && option.equals("shoo-away") && config.swapPetStray()) {
+			swap("pet", option, target, index);
 		}
 
 		if (shiftModifier && config.swapTeleportSpell())


### PR DESCRIPTION
Add option to menu entry swapper plugin to swap "Shoo-away" with "Pet" for the default left-click on Stray dogs.