### PR TITLE
Adds the option to disable the precise combat level display in the Combat Level plugin

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/combatlevel/CombatLevelConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/combatlevel/CombatLevelConfig.java
@@ -42,11 +42,11 @@ public interface CombatLevelConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "showAccurateCombatLevel",
-		name = "Show accurate combat level",
-		description = "Displays your combat level with precise decimals."
+		keyName = "showPreciseCombatLevel",
+		name = "Show precise combat level",
+		description = "Displays your combat level with accurate decimals."
 	)
-	default boolean showAccurateCombatLevel()
+	default boolean showPreciseCombatLevel()
 	{
 		return true;
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/combatlevel/CombatLevelConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/combatlevel/CombatLevelConfig.java
@@ -42,6 +42,16 @@ public interface CombatLevelConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "showAccurateCombatLevel",
+		name = "Show accurate combat level",
+		description = "Displays your combat level with precise decimals."
+	)
+	default boolean showAccurateCombatLevel()
+	{
+		return true;
+	}
+
+	@ConfigItem(
 		keyName = "wildernessAttackLevelRange",
 		name = "Show level range in wilderness",
 		description = "Displays a PVP-world-like attack level range in the wilderness"

--- a/runelite-client/src/main/java/net/runelite/client/plugins/combatlevel/CombatLevelPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/combatlevel/CombatLevelPlugin.java
@@ -125,7 +125,7 @@ public class CombatLevelPlugin extends Plugin
 		}
 
 		Widget combatLevelWidget = client.getWidget(WidgetInfo.COMBAT_LEVEL);
-		if (combatLevelWidget == null)
+		if (combatLevelWidget == null || !config.showPreciseCombatLevel())
 		{
 			return;
 		}


### PR DESCRIPTION
Personally, I like the functions that the Combat level plugin provides, but I much prefer to see a rounded combat level. This is of course a small QOL feature, that I don't think will hurt the plugin as it doesn't have many configs available currently. 