### PR TITLE
Add level and XP difference fields in skill calculator

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/UICalculatorInputArea.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/UICalculatorInputArea.java
@@ -44,14 +44,18 @@ class UICalculatorInputArea extends JPanel
 	private final JTextField uiFieldCurrentXP;
 	private final JTextField uiFieldTargetLevel;
 	private final JTextField uiFieldTargetXP;
+	private final JTextField uiFieldXPDifference;
+	private final JTextField uiFieldLevelDifference;
 
 	UICalculatorInputArea()
 	{
-		setLayout(new GridLayout(2, 2, 7, 7));
+		setLayout(new GridLayout(3, 3, 7, 7));
 		uiFieldCurrentLevel = addComponent("Current Level");
 		uiFieldCurrentXP = addComponent("Current Experience");
 		uiFieldTargetLevel = addComponent("Target Level");
 		uiFieldTargetXP = addComponent("Target Experience");
+		uiFieldLevelDifference = addComponent("Level Difference");
+		uiFieldXPDifference = addComponent("Experience Difference");
 	}
 
 	int getCurrentLevelInput()
@@ -92,6 +96,26 @@ class UICalculatorInputArea extends JPanel
 	void setTargetXPInput(Object value)
 	{
 		setInput(uiFieldTargetXP, value);
+	}
+
+	int getXPDifferenceInput()
+	{
+		return getInput(uiFieldXPDifference);
+	}
+
+	void setXPDifferenceInput(Object value)
+	{
+		setInput(uiFieldXPDifference, value);
+	}
+
+	int getLevelDifferenceInput()
+	{
+		return getInput(uiFieldLevelDifference);
+	}
+
+	void setLevelDifferenceInput(Object value)
+	{
+		setInput(uiFieldLevelDifference, value);
 	}
 
 	private int getInput(JTextField field)


### PR DESCRIPTION
I often have to calculate the difference in XP manually when trying to perform more complex, situational calculations myself. I noticed there were similar PR's a while back such as this one: #9283 
 which was a response to #9260 but from reading the replies it was never merged and didn't have functionality to edit the fields as you can the other fields.

Difference changes update the target, and vice versa. Maybe a more appropriate name is due rather than 'Level difference' and 'Experience difference' but I just called it as is. Others I've seen were 'Remaining levels' and 'Remaining Experience' which may also be suitable.

![ezgif-7-caf93fff8a5c](https://user-images.githubusercontent.com/7211424/78797475-a7392800-79af-11ea-9e8c-6ff1385456ce.gif)
