### PR TITLE
Blackjacking plugin that highlights black-jackable NPCs based on their current state

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/blackjack/BlackjackConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/blackjack/BlackjackConfig.java
@@ -1,6 +1,5 @@
 package net.runelite.client.plugins.blackjack;
 
-import net.runelite.api.NPC;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/blackjack/BlackjackConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/blackjack/BlackjackConfig.java
@@ -1,0 +1,60 @@
+package net.runelite.client.plugins.blackjack;
+
+import net.runelite.api.NPC;
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+
+import java.awt.Color;
+
+@ConfigGroup("blackjack")
+public interface BlackjackConfig extends Config {
+    @ConfigItem(
+            keyName = "renderStyle",
+            name = "Highlight Style",
+            description = "Highlight setting",
+            position = 1
+    )
+    default BlackjackRenderStyle renderStyle()
+    {
+        return BlackjackRenderStyle.HULL;
+    }
+
+    @ConfigItem(
+            keyName = "npcToBlackjack",
+            name = "NPC to Blackjack",
+            description = "Select the NPC you will be Blackjacking",
+            position = 2
+    )
+    default BlackjackNPCs npcToBlackjack()
+    {
+        return BlackjackNPCs.BANDIT;
+    }
+
+    @ConfigItem(
+            keyName = "awakeStateColor",
+            name = "Awake State Color",
+            description = "Change the color of the awake state highlight",
+            position = 3
+    )
+    default Color awakeStateColor() {return Color.ORANGE;}
+
+    @ConfigItem(
+            keyName = "knockedOutStateColor",
+            name = "Knocked-Out State Color",
+            description = "Change the color of the knocked-out state highlight",
+            position = 4
+    )
+    default Color knockedOutStateColor() {return Color.GREEN;}
+
+    @ConfigItem(
+            keyName = "statusText",
+            name = "Draw status text above NPCs",
+            description = "Configures whether or not to write if the target NPC is awake or knocked out",
+            position = 5
+    )
+    default boolean statusText()
+    {
+        return false;
+    }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/blackjack/BlackjackNPCs.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/blackjack/BlackjackNPCs.java
@@ -1,0 +1,6 @@
+package net.runelite.client.plugins.blackjack;
+
+public enum BlackjackNPCs {
+    BANDIT,
+    MENAPHITE_THUG
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/blackjack/BlackjackOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/blackjack/BlackjackOverlay.java
@@ -1,0 +1,91 @@
+package net.runelite.client.plugins.blackjack;
+
+import net.runelite.api.Client;
+import net.runelite.api.NPC;
+import net.runelite.api.NPCComposition;
+import net.runelite.api.Perspective;
+import net.runelite.api.Point;
+import net.runelite.api.coords.LocalPoint;
+import net.runelite.client.plugins.npchighlight.NpcIndicatorsConfig;
+import net.runelite.client.plugins.npchighlight.NpcIndicatorsPlugin;
+import net.runelite.client.ui.overlay.Overlay;
+import net.runelite.client.ui.overlay.OverlayLayer;
+import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.OverlayUtil;
+import net.runelite.client.util.Text;
+
+import javax.inject.Inject;
+import java.awt.*;
+
+public class BlackjackOverlay extends Overlay {
+    private final Client client;
+    private final BlackjackConfig config;
+    private final BlackjackPlugin plugin;
+
+    @Inject
+    BlackjackOverlay(Client client, BlackjackConfig config, BlackjackPlugin plugin) {
+        this.client = client;
+        this.config = config;
+        this.plugin = plugin;
+        setPosition(OverlayPosition.DYNAMIC);
+        setLayer(OverlayLayer.ABOVE_SCENE);
+    }
+
+    @Override
+    public Dimension render(Graphics2D graphics) {
+        for (NPC npc : plugin.getHighlightedNpcs())
+        {
+            renderNpcOverlay(graphics, npc, plugin.getHighlightColor());
+        }
+        return null;
+    }
+
+    private void renderNpcOverlay(Graphics2D graphics, NPC actor, Color color)
+    {
+        NPCComposition npcComposition = actor.getTransformedComposition();
+        if (npcComposition == null || !npcComposition.isInteractible())
+        {
+            return;
+        }
+
+        switch (config.renderStyle())
+        {
+            case TILE:
+                int size = npcComposition.getSize();
+                LocalPoint lp = actor.getLocalLocation();
+                Polygon tilePoly = Perspective.getCanvasTileAreaPoly(client, lp, size);
+
+                renderPoly(graphics, color, tilePoly);
+                break;
+
+            case HULL:
+                Shape objectClickbox = actor.getConvexHull();
+
+                renderPoly(graphics, color, objectClickbox);
+                break;
+        }
+
+        if (config.statusText() && actor.getName() != null)
+        {
+            String npcName = Text.removeTags(actor.getName());
+            Point textLocation = actor.getCanvasTextLocation(graphics, npcName, actor.getLogicalHeight() + 40);
+
+            if (textLocation != null)
+            {
+                OverlayUtil.renderTextLocation(graphics, textLocation, npcName, color);
+            }
+        }
+    }
+
+    private void renderPoly(Graphics2D graphics, Color color, Shape polygon)
+    {
+        if (polygon != null)
+        {
+            graphics.setColor(color);
+            graphics.setStroke(new BasicStroke(2));
+            graphics.draw(polygon);
+            graphics.setColor(new Color(color.getRed(), color.getGreen(), color.getBlue(), 20));
+            graphics.fill(polygon);
+        }
+    }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/blackjack/BlackjackOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/blackjack/BlackjackOverlay.java
@@ -6,8 +6,6 @@ import net.runelite.api.NPCComposition;
 import net.runelite.api.Perspective;
 import net.runelite.api.Point;
 import net.runelite.api.coords.LocalPoint;
-import net.runelite.client.plugins.npchighlight.NpcIndicatorsConfig;
-import net.runelite.client.plugins.npchighlight.NpcIndicatorsPlugin;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
@@ -72,7 +70,7 @@ public class BlackjackOverlay extends Overlay {
 
             if (textLocation != null)
             {
-                OverlayUtil.renderTextLocation(graphics, textLocation, npcName, color);
+                OverlayUtil.renderTextLocation(graphics, textLocation, plugin.statusText(), color);
             }
         }
     }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/blackjack/BlackjackPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/blackjack/BlackjackPlugin.java
@@ -1,5 +1,6 @@
 package net.runelite.client.plugins.blackjack;
 
+import com.google.inject.Provides;
 import lombok.AccessLevel;
 import lombok.Getter;
 import net.runelite.api.ChatMessageType;
@@ -8,16 +9,15 @@ import net.runelite.api.GameState;
 import net.runelite.api.NPC;
 import net.runelite.api.events.*;
 import net.runelite.client.callback.ClientThread;
+import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.events.ConfigChanged;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.OverlayManager;
 import net.runelite.client.util.WildcardMatcher;
-import org.apache.commons.lang3.RandomUtils;
-
 import javax.inject.Inject;
-import java.awt.*;
+import java.awt.Color;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -59,6 +59,12 @@ public class BlackjackPlugin extends Plugin {
 
     private String highlight = "";
     private long nextKnockOutTick = 0;
+
+    @Provides
+    BlackjackConfig provideConfig(ConfigManager configManager)
+    {
+        return configManager.getConfig(BlackjackConfig.class);
+    }
 
     @Override
     protected void startUp() throws Exception
@@ -189,5 +195,9 @@ public class BlackjackPlugin extends Plugin {
                 continue outer;
             }
         }
+    }
+
+    public String statusText() {
+        return isKnockedOut() ? "Knocked-out" : "Awake";
     }
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/blackjack/BlackjackPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/blackjack/BlackjackPlugin.java
@@ -28,7 +28,6 @@ import java.util.Set;
 )
 public class BlackjackPlugin extends Plugin {
     private static final String SUCCESS_BLACKJACK = "You smack the bandit over the head and render them unconscious.";
-    private static final String FAILED_BLACKJACK = "Your blow only glances off the bandit's head.";
 
     @Inject
     private BlackjackConfig blackjackConfig;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/blackjack/BlackjackPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/blackjack/BlackjackPlugin.java
@@ -1,0 +1,193 @@
+package net.runelite.client.plugins.blackjack;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import net.runelite.api.ChatMessageType;
+import net.runelite.api.Client;
+import net.runelite.api.GameState;
+import net.runelite.api.NPC;
+import net.runelite.api.events.*;
+import net.runelite.client.callback.ClientThread;
+import net.runelite.client.eventbus.Subscribe;
+import net.runelite.client.events.ConfigChanged;
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.ui.overlay.OverlayManager;
+import net.runelite.client.util.WildcardMatcher;
+import org.apache.commons.lang3.RandomUtils;
+
+import javax.inject.Inject;
+import java.awt.*;
+import java.util.HashSet;
+import java.util.Set;
+
+@PluginDescriptor(
+        name = "Blackjack",
+        description = "Help show whether a blackjack target is knocked out or not",
+        tags = {"blackjack", "thieve", "thieving"}
+)
+public class BlackjackPlugin extends Plugin {
+    private static final String SUCCESS_BLACKJACK = "You smack the bandit over the head and render them unconscious.";
+    private static final String FAILED_BLACKJACK = "Your blow only glances off the bandit's head.";
+
+    @Inject
+    private BlackjackConfig blackjackConfig;
+
+    @Inject
+    private BlackjackOverlay blackjackOverlay;
+
+    @Inject
+    private OverlayManager overlayManager;
+
+    @Inject
+    private ClientThread clientThread;
+
+    @Inject
+    private Client client;
+
+    /**
+     * NPCs to highlight
+     */
+    @Getter(AccessLevel.PACKAGE)
+    private final Set<NPC> highlightedNpcs = new HashSet<>();
+
+    /**
+     * Stores state of if NPC is knocked out or not.
+     */
+    @Getter(AccessLevel.PACKAGE)
+    private boolean knockedOut = false;
+
+    private String highlight = "";
+    private long nextKnockOutTick = 0;
+
+    @Override
+    protected void startUp() throws Exception
+    {
+        overlayManager.add(blackjackOverlay);
+        highlight = npcToHighlight();
+        clientThread.invoke(() ->
+        {
+            rebuildAllNpcs();
+        });
+    }
+
+    @Override
+    protected void shutDown() throws Exception
+    {
+        overlayManager.remove(blackjackOverlay);
+        highlightedNpcs.clear();
+    }
+
+    @Subscribe
+    public void onGameStateChanged(GameStateChanged event)
+    {
+        if (event.getGameState() == GameState.LOGIN_SCREEN ||
+                event.getGameState() == GameState.HOPPING)
+        {
+            highlightedNpcs.clear();
+        }
+    }
+
+    @Subscribe
+    private void onConfigChanged(ConfigChanged event) {
+
+        if (!event.getGroup().equals("blackjack")) {
+            return;
+        }
+
+        highlight = npcToHighlight();
+        rebuildAllNpcs();
+    }
+
+    @Subscribe
+    public void onNpcSpawned(NpcSpawned npcSpawned)
+    {
+        final NPC npc = npcSpawned.getNpc();
+        final String npcName = npc.getName();
+
+        if (npcName == null)
+        {
+            return;
+        }
+
+        if (WildcardMatcher.matches(highlight, npcName))
+        {
+            highlightedNpcs.add(npc);
+        }
+    }
+
+    @Subscribe
+    public void onNpcDespawned(NpcDespawned npcDespawned)
+    {
+        final NPC npc = npcDespawned.getNpc();
+
+        highlightedNpcs.remove(npc);
+    }
+
+    @Subscribe
+    public void onGameTick(GameTick event)
+    {
+        if (client.getTickCount() >= nextKnockOutTick)
+        {
+            knockedOut = false;
+        }
+    }
+
+    @Subscribe
+    public void onChatMessage(ChatMessage event)
+    {
+        final String msg = event.getMessage();
+
+        if (event.getType() == ChatMessageType.SPAM && msg.equals(SUCCESS_BLACKJACK))
+        {
+            knockedOut = true;
+            nextKnockOutTick = client.getTickCount() + 4;
+        }
+    }
+
+    public Color getHighlightColor() {
+        return knockedOut ? blackjackConfig.knockedOutStateColor() : blackjackConfig.awakeStateColor();
+    }
+
+    private String npcToHighlight()
+    {
+        switch (blackjackConfig.npcToBlackjack()) {
+            case BANDIT:
+                return "Bandit";
+            case MENAPHITE_THUG:
+                return "Menaphite Thug";
+            default:
+                throw new IllegalStateException("Unexpected value: " + blackjackConfig.npcToBlackjack());
+        }
+    }
+
+    private void rebuildAllNpcs()
+    {
+        highlightedNpcs.clear();
+
+        if (client.getGameState() != GameState.LOGGED_IN &&
+                client.getGameState() != GameState.LOADING)
+        {
+            // NPCs are still in the client after logging out,
+            // but we don't want to highlight those.
+            return;
+        }
+
+        outer:
+        for (NPC npc : client.getNpcs())
+        {
+            final String npcName = npc.getName();
+
+            if (npcName == null)
+            {
+                continue;
+            }
+
+            if (WildcardMatcher.matches(highlight, npcName))
+            {
+                highlightedNpcs.add(npc);
+                continue outer;
+            }
+        }
+    }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/blackjack/BlackjackRenderStyle.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/blackjack/BlackjackRenderStyle.java
@@ -1,0 +1,8 @@
+package net.runelite.client.plugins.blackjack;
+
+public enum BlackjackRenderStyle
+{
+    OFF,
+    TILE,
+    HULL
+}


### PR DESCRIPTION
This addresses #11196 

This plugin will correctly highlight either the tile/hull of the NPC based on its current blackjacking state (awake vs knocked-out), even if the NPCs animation didn't properly update and it is still standing up even though it is "knocked out".

This is my first attempt at a PR to this project and am new to Java development in general, so definitely am not aware of any "best-practices". I re-used some a lot of the overlay code from the NPCIndicator plugin, so there may be a better way to re-use. Would love any and all feedback!