### PR TITLE
interfacestyles: update widget bounds before every render

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/ScriptID.java
+++ b/runelite-api/src/main/java/net/runelite/api/ScriptID.java
@@ -235,12 +235,6 @@ public final class ScriptID
 	public static final int QUESTLIST_PROGRESS_LIST_SHOW = 1354;
 
 	/**
-	 * Procedure called when the toplevel interface is resized
-	 */
-	@ScriptArguments(integer = 2)
-	public static final int TOPLEVEL_RESIZE = 909;
-
-	/**
 	 * Called when the friends list is updated
 	 * <ul>
 	 * <li> int (WidgetID) Friends list "full container" </li>

--- a/runelite-client/src/main/java/net/runelite/client/plugins/interfacestyles/InterfaceStylesPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/interfacestyles/InterfaceStylesPlugin.java
@@ -33,20 +33,19 @@ import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.GameState;
 import net.runelite.api.HealthBar;
-import net.runelite.api.ScriptID;
 import net.runelite.api.SpriteID;
 import net.runelite.api.SpritePixels;
 import net.runelite.api.events.BeforeMenuRender;
+import net.runelite.api.events.BeforeRender;
+import net.runelite.client.events.ConfigChanged;
 import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.PostHealthBar;
 import net.runelite.api.events.ScriptCallbackEvent;
-import net.runelite.api.events.ScriptPostFired;
 import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.callback.ClientThread;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
-import net.runelite.client.events.ConfigChanged;
 import net.runelite.client.game.SpriteManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
@@ -120,12 +119,9 @@ public class InterfaceStylesPlugin extends Plugin
 	}
 
 	@Subscribe
-	public void onScriptPostFired(ScriptPostFired scriptPostFired)
+	public void onBeforeRender(BeforeRender event)
 	{
-		if (scriptPostFired.getScriptId() == ScriptID.TOPLEVEL_RESIZE)
-		{
-			adjustWidgetDimensions();
-		}
+		adjustWidgetDimensions();
 	}
 
 	@Subscribe


### PR DESCRIPTION
this reverts commit abaf45092b9f20d1068698da3ed726db6b35bce2

We need to run this every frame because the client can update the widget
bounds cache without calling [proc,toplevel_resize]. This is easily
reproducible by resizing the client in fixed mode, which causes the
the tli to be revalidated, but because its in fixed mode it doesn't run
the resize listener because the bounds don't actually change.

We use BeforeRender instead of ClientTick because ClientTick is posted
before cs2s are evaluated each tick, so if [proc,toplevel_resize] (or
any other cs2 that can touch these widgets) is called the widget would
be in the vanilla position for the next frame.

Closes #11149