### PR TITLE
hitsplats: add missing multihitsplat varients

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/Hitsplat.java
+++ b/runelite-api/src/main/java/net/runelite/api/Hitsplat.java
@@ -53,6 +53,38 @@ public class Hitsplat
 		 */
 		DAMAGE_OTHER,
 		/**
+		 * Taking damage by me (cyan).
+		 */
+		DAMAGE_ME_CYAN,
+		/**
+		 * Taking damage by others (cyan).
+		 */
+		DAMAGE_OTHER_CYAN,
+		/**
+		 * Taking damage by me (orange).
+		 */
+		DAMAGE_ME_ORANGE,
+		/**
+		 * Taking damage by others (orange).
+		 */
+		DAMAGE_OTHER_ORANGE,
+		/**
+		 * Taking damage by me (yellow).
+		 */
+		DAMAGE_ME_YELLOW,
+		/**
+		 * Taking damage by others (yellow).
+		 */
+		DAMAGE_OTHER_YELLOW,
+		/**
+		 * Taking damage by me (white).
+		 */
+		DAMAGE_ME_WHITE,
+		/**
+		 * Taking damage by others (white/black).
+		 */
+		DAMAGE_OTHER_WHITE,
+		/**
 		 * Damage from poison (green).
 		 */
 		POISON,
@@ -88,6 +120,14 @@ public class Hitsplat
 				case 4: return DISEASE;
 				case 5: return VENOM;
 				case 6: return HEAL;
+				case 18: return DAMAGE_ME_CYAN;
+				case 19: return DAMAGE_OTHER_CYAN;
+				case 20: return DAMAGE_ME_ORANGE;
+				case 21: return DAMAGE_OTHER_ORANGE;
+				case 22: return DAMAGE_ME_YELLOW;
+				case 23: return DAMAGE_OTHER_YELLOW;
+				case 24: return DAMAGE_ME_WHITE;
+				case 25: return DAMAGE_OTHER_WHITE;
 			}
 			return null;
 		}
@@ -116,5 +156,37 @@ public class Hitsplat
 		this.hitsplatType = hitsplatType;
 		this.amount = amount;
 		this.disappearsOnGameCycle = disappearsOnGameCycle;
+	}
+
+	public boolean isMine()
+	{
+		switch (this.getHitsplatType())
+		{
+			case BLOCK_ME:
+			case DAMAGE_ME:
+			case DAMAGE_ME_CYAN:
+			case DAMAGE_ME_YELLOW:
+			case DAMAGE_ME_ORANGE:
+			case DAMAGE_ME_WHITE:
+				return true;
+			default:
+				return false;
+		}
+	}
+
+	public boolean isOthers()
+	{
+		switch (this.getHitsplatType())
+		{
+			case BLOCK_OTHER:
+			case DAMAGE_OTHER:
+			case DAMAGE_OTHER_CYAN:
+			case DAMAGE_OTHER_YELLOW:
+			case DAMAGE_OTHER_ORANGE:
+			case DAMAGE_OTHER_WHITE:
+				return true;
+			default:
+				return false;
+		}
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/dpscounter/DpsCounterPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/dpscounter/DpsCounterPlugin.java
@@ -163,38 +163,39 @@ public class DpsCounterPlugin extends Plugin
 
 		Hitsplat hitsplat = hitsplatApplied.getHitsplat();
 
-		switch (hitsplat.getHitsplatType())
+		if (hitsplat.isMine())
 		{
-			case DAMAGE_ME:
-				int hit = hitsplat.getAmount();
-				// Update local member
-				PartyMember localMember = partyService.getLocalMember();
-				// If not in a party, user local player name
-				final String name = localMember == null ? player.getName() : localMember.getName();
-				DpsMember dpsMember = members.computeIfAbsent(name, DpsMember::new);
-				dpsMember.addDamage(hit);
+			int hit = hitsplat.getAmount();
+			// Update local member
+			PartyMember localMember = partyService.getLocalMember();
+			// If not in a party, user local player name
+			final String name = localMember == null ? player.getName() : localMember.getName();
+			DpsMember dpsMember = members.computeIfAbsent(name, DpsMember::new);
+			dpsMember.addDamage(hit);
 
-				// broadcast damage
-				if (localMember != null)
-				{
-					final DpsUpdate specialCounterUpdate = new DpsUpdate(hit);
-					specialCounterUpdate.setMemberId(localMember.getMemberId());
-					wsClient.send(specialCounterUpdate);
-				}
-				// apply to total
-				break;
-			case DAMAGE_OTHER:
-				final int npcId = ((NPC) actor).getId();
-				boolean isBoss = BOSSES.contains(npcId);
-				if (actor != player.getInteracting() && !isBoss)
-				{
-					// only track damage to npcs we are attacking, or is a nearby common boss
-					return;
-				}
-				// apply to total
-				break;
-			default:
+			// broadcast damage
+			if (localMember != null)
+			{
+				final DpsUpdate specialCounterUpdate = new DpsUpdate(hit);
+				specialCounterUpdate.setMemberId(localMember.getMemberId());
+				wsClient.send(specialCounterUpdate);
+			}
+			// apply to total
+		}
+		else if (hitsplat.isOthers())
+		{
+			final int npcId = ((NPC) actor).getId();
+			boolean isBoss = BOSSES.contains(npcId);
+			if (actor != player.getInteracting() && !isBoss)
+			{
+				// only track damage to npcs we are attacking, or is a nearby common boss
 				return;
+			}
+			// apply to total
+		}
+		else
+		{
+			return;
 		}
 
 		unpause();

--- a/runelite-client/src/main/java/net/runelite/client/plugins/specialcounter/SpecialCounterPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/specialcounter/SpecialCounterPlugin.java
@@ -168,7 +168,7 @@ public class SpecialCounterPlugin extends Plugin
 		Hitsplat hitsplat = hitsplatApplied.getHitsplat();
 		Hitsplat.HitsplatType hitsplatType = hitsplat.getHitsplatType();
 		// Ignore all hitsplats other than mine
-		if ((hitsplatType != Hitsplat.HitsplatType.DAMAGE_ME && hitsplatType != Hitsplat.HitsplatType.BLOCK_ME) || target == client.getLocalPlayer())
+		if (!hitsplat.isMine() || target == client.getLocalPlayer())
 		{
 			return;
 		}


### PR DESCRIPTION
I have not tested much, will test more but this should be fairly straightforward. The hitsplats were taken from the cache.

I didn't think this was worth putting in the javadoc but

The cyan hitsplats are used at the nightmare and verzik p1

The yellow hitsplats are use on the nightmare pillars

I have no idea where the white/orange hitsplats are used or if there are any usages I missed for the above two.