### PR TITLE
Change Farming growing progress colour

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/farming/CropState.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/farming/CropState.java
@@ -34,8 +34,8 @@ import net.runelite.client.ui.ColorScheme;
 public enum CropState
 {
 	HARVESTABLE(ColorScheme.PROGRESS_COMPLETE_COLOR),
-	GROWING(ColorScheme.PROGRESS_COMPLETE_COLOR),
-	DISEASED(ColorScheme.PROGRESS_INPROGRESS_COLOR),
+	GROWING(ColorScheme.PROGRESS_INPROGRESS_COLOR),
+	DISEASED(ColorScheme.PROGRESS_ERROR_COLOR),
 	DEAD(ColorScheme.PROGRESS_ERROR_COLOR);
 
 	private final Color color;


### PR DESCRIPTION
I think that green Complete and green In-progress colours can be hard to distinguish at a glance what has finished growing.
So cheap dirty win, swap Diseased to red and set Growing to yellow.

Could add additional In-progress colour into runelite-client/src/main/java/net/runelite/client/ui/ColorScheme.java to achieve same end result.

Thanks.