### PR TITLE
player-indicators: fix right-click menu targets expanding forever

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsPlugin.java
@@ -96,6 +96,11 @@ public class PlayerIndicatorsPlugin extends Plugin
 	@Subscribe
 	public void onClientTick(ClientTick clientTick)
 	{
+		if (client.isMenuOpen())
+		{
+			return;
+		}
+
 		MenuEntry[] menuEntries = client.getMenuEntries();
 		boolean modified = false;
 


### PR DESCRIPTION
Fixes the right-click menu targets expanding forever if clan rank or color decoration is enabled in the plugin. 

Menu entries don't get cleared while the menu is open, which was resulting in colors and ranks getting prepended on every client tick.

(The bug can be observed in-game by enabling 'Show clan ranks' and disabling 'Colorize player menu')