### PR TITLE
antidrag: fix onShiftOnly not being respected when opening the bank

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/antidrag/AntiDragPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/antidrag/AntiDragPlugin.java
@@ -70,6 +70,7 @@ public class AntiDragPlugin extends Plugin implements KeyListener
 	private KeyManager keyManager;
 
 	private boolean inPvp;
+	private boolean held;
 
 	@Provides
 	AntiDragConfig getConfig(ConfigManager configManager)
@@ -114,6 +115,7 @@ public class AntiDragPlugin extends Plugin implements KeyListener
 		if (e.getKeyCode() == KeyEvent.VK_SHIFT && config.onShiftOnly())
 		{
 			setDragDelay();
+			held = true;
 		}
 	}
 
@@ -123,6 +125,7 @@ public class AntiDragPlugin extends Plugin implements KeyListener
 		if (e.getKeyCode() == KeyEvent.VK_SHIFT && config.onShiftOnly())
 		{
 			resetDragDelay();
+			held = false;
 		}
 	}
 
@@ -133,6 +136,7 @@ public class AntiDragPlugin extends Plugin implements KeyListener
 		{
 			if (config.onShiftOnly() || inPvp)
 			{
+				held = false;
 				clientThread.invoke(this::resetDragDelay);
 			}
 			else
@@ -168,6 +172,7 @@ public class AntiDragPlugin extends Plugin implements KeyListener
 	{
 		if (!focusChanged.isFocused())
 		{
+			held = false;
 			clientThread.invoke(this::resetDragDelay);
 		}
 		else if (!inPvp && !config.onShiftOnly())
@@ -179,7 +184,7 @@ public class AntiDragPlugin extends Plugin implements KeyListener
 	@Subscribe
 	public void onWidgetLoaded(WidgetLoaded widgetLoaded)
 	{
-		if (widgetLoaded.getGroupId() == WidgetID.BANK_GROUP_ID)
+		if (widgetLoaded.getGroupId() == WidgetID.BANK_GROUP_ID && (!config.onShiftOnly() || held))
 		{
 			setBankDragDelay(config.dragDelay());
 		}


### PR DESCRIPTION
Currently, when opening the bank with `On Shift Only` enabled, delay is applied even if shift is not being held down.

Thanks to `Cholby` in the Discord for finding and reporting this 