### PR TITLE
Added menu entry swapper option for entering the corrupted gauntlet.

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -431,4 +431,14 @@ public interface MenuEntrySwapperConfig extends Config
 	{
 		return true;
 	}
+
+	@ConfigItem(
+		keyName = "swapGauntlet",
+		name = "Corrupted Gauntlet",
+		description = "Swap Enter with Enter-corrupted when entering The Gauntlet"
+	)
+	default boolean swapGauntlet()
+	{
+		return false;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -636,6 +636,10 @@ public class MenuEntrySwapperPlugin extends Plugin
 		{
 			swap("empty", option, target, index);
 		}
+		else if (config.swapGauntlet() && option.equals("enter") && target.equals("the gauntlet"))
+		{
+			swap("enter-corrupted", option, target, index);
+		}
 		else if (config.swapQuick() && option.equals("enter"))
 		{
 			swap("quick-enter", option, target, index);


### PR DESCRIPTION
Provides the option to swap Enter with Enter-corrupted when entering The Gauntlet.

![image](https://user-images.githubusercontent.com/33374903/79565136-0ff26580-807e-11ea-8711-3f45a21a0d6c.png)