### PR TITLE
Properly address Grand Exchange price as 'GE' abbreviation instead of 'EX'

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/bank/BankPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/bank/BankPlugin.java
@@ -259,7 +259,7 @@ public class BankPlugin extends Plugin
 
 			if (config.showHA())
 			{
-				strCurrentTab += "EX: ";
+				strCurrentTab += "GE: ";
 			}
 
 			if (config.showExact())

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
@@ -243,7 +243,7 @@ public class GroundItemsOverlay extends Overlay
 			{
 				if (item.getGePrice() > 0)
 				{
-					itemStringBuilder.append(" (EX: ")
+					itemStringBuilder.append(" (GE: ")
 						.append(QuantityFormatter.quantityToStackSize(item.getGePrice()))
 						.append(" gp)");
 				}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemprices/ItemPricesOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemprices/ItemPricesOverlay.java
@@ -245,7 +245,7 @@ class ItemPricesOverlay extends Overlay
 	{
 		if (gePrice > 0)
 		{
-			itemStringBuilder.append("EX: ")
+			itemStringBuilder.append("GE: ")
 				.append(QuantityFormatter.quantityToStackSize((long) gePrice * qty))
 				.append(" gp");
 			if (config.showEA() && qty > 1)


### PR DESCRIPTION
Grand Exchange is addressed as GE everywhere, EX is confusing and can be mistaken for EXperience.

This changes the label placed over items on the ground.