### PR TITLE
clues: make item requirements work with the runepouch

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/game/RunepouchRune.java
+++ b/runelite-client/src/main/java/net/runelite/client/game/RunepouchRune.java
@@ -22,7 +22,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package net.runelite.client.plugins.runepouch;
+package net.runelite.client.game;
 
 
 import com.google.common.collect.ImmutableMap;
@@ -52,7 +52,7 @@ import static net.runelite.api.ItemID.STEAM_RUNE;
 import static net.runelite.api.ItemID.WATER_RUNE;
 import static net.runelite.api.ItemID.WRATH_RUNE;
 
-public enum Runes
+public enum RunepouchRune
 {
 	AIR(1, AIR_RUNE),
 	WATER(2, WATER_RUNE),
@@ -85,25 +85,25 @@ public enum Runes
 	@Setter
 	private BufferedImage image;
 
-	private static final Map<Integer, Runes> runes;
+	private static final Map<Integer, RunepouchRune> runes;
 
 	static
 	{
-		ImmutableMap.Builder<Integer, Runes> builder = new ImmutableMap.Builder<>();
-		for (Runes rune : values())
+		ImmutableMap.Builder<Integer, RunepouchRune> builder = new ImmutableMap.Builder<>();
+		for (RunepouchRune rune : values())
 		{
 			builder.put(rune.getId(), rune);
 		}
 		runes = builder.build();
 	}
 
-	Runes(int id, int itemId)
+	RunepouchRune(int id, int itemId)
 	{
 		this.id = id;
 		this.itemId = itemId;
 	}
 
-	public static Runes getRune(int varbit)
+	public static RunepouchRune getRune(int varbit)
 	{
 		return runes.get(varbit);
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/ClueScrollPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/ClueScrollPlugin.java
@@ -64,6 +64,7 @@ import net.runelite.api.Scene;
 import net.runelite.api.ScriptID;
 import net.runelite.api.Tile;
 import net.runelite.api.TileObject;
+import net.runelite.api.Varbits;
 import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.ChatMessage;
@@ -95,6 +96,7 @@ import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.events.ConfigChanged;
 import net.runelite.client.events.OverlayMenuClicked;
 import net.runelite.client.game.ItemManager;
+import net.runelite.client.game.RunepouchRune;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDependency;
 import net.runelite.client.plugins.PluginDescriptor;
@@ -143,6 +145,12 @@ public class ClueScrollPlugin extends Plugin
 	private static final Color HIGHLIGHT_HOVER_BORDER_COLOR = HIGHLIGHT_BORDER_COLOR.darker();
 	private static final Color HIGHLIGHT_FILL_COLOR = new Color(0, 255, 0, 20);
 	private static final String CLUE_TAG_NAME = "clue";
+	private static final Varbits[] RUNEPOUCH_AMOUNT_VARBITS = {
+		Varbits.RUNE_POUCH_AMOUNT1, Varbits.RUNE_POUCH_AMOUNT2, Varbits.RUNE_POUCH_AMOUNT3
+	};
+	private static final Varbits[] RUNEPOUCH_RUNE_VARBITS = {
+		Varbits.RUNE_POUCH_RUNE1, Varbits.RUNE_POUCH_RUNE2, Varbits.RUNE_POUCH_RUNE3
+	};
 
 	@Getter
 	private ClueScroll clue;
@@ -361,7 +369,36 @@ public class ClueScrollPlugin extends Plugin
 			return;
 		}
 
-		inventoryItems = event.getItemContainer().getItems();
+		if (event.getItemContainer().contains(ItemID.RUNE_POUCH) || event.getItemContainer().contains(ItemID.RUNE_POUCH_L))
+		{
+			// Clone the array so changes aren't passed back to the event.
+			inventoryItems = event.getItemContainer().getItems().clone();
+
+			List<Item> runePouchContents = getRunepouchContents();
+
+			if (!runePouchContents.isEmpty())
+			{
+				for (int i = 0; i < inventoryItems.length; i++)
+				{
+					Item invItem = inventoryItems[i];
+					for (Item rune : runePouchContents)
+					{
+						if (invItem.getId() == rune.getId())
+						{
+							inventoryItems[i] = new Item(invItem.getId(), rune.getQuantity() + invItem.getQuantity());
+							runePouchContents.remove(rune);
+							break;
+						}
+					}
+				}
+
+				inventoryItems = ArrayUtils.addAll(inventoryItems, runePouchContents.toArray(new Item[0]));
+			}
+		}
+		else
+		{
+			inventoryItems = event.getItemContainer().getItems();
+		}
 
 		// Check if item was removed from inventory
 		if (clue != null && clueItemId != null)
@@ -391,6 +428,30 @@ public class ClueScrollPlugin extends Plugin
 				checkClueNPCs(clue, client.getCachedNPCs());
 			}
 		}
+	}
+
+	private List<Item> getRunepouchContents()
+	{
+		List<Item> items = new ArrayList<>();
+		for (int i = 0; i < RUNEPOUCH_AMOUNT_VARBITS.length; i++)
+		{
+			int amount = client.getVar(RUNEPOUCH_AMOUNT_VARBITS[i]);
+			if (amount <= 0)
+			{
+				continue;
+			}
+
+			int varbId = client.getVar(RUNEPOUCH_RUNE_VARBITS[i]);
+			RunepouchRune rune = RunepouchRune.getRune(varbId);
+			if (rune == null)
+			{
+				continue;
+			}
+
+			Item item = new Item(rune.getItemId(), amount);
+			items.add(item);
+		}
+		return items;
 	}
 
 	@Subscribe

--- a/runelite-client/src/main/java/net/runelite/client/plugins/runepouch/RunepouchOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/runepouch/RunepouchOverlay.java
@@ -35,6 +35,7 @@ import net.runelite.api.Point;
 import net.runelite.api.Varbits;
 import net.runelite.api.widgets.WidgetItem;
 import net.runelite.client.game.ItemManager;
+import net.runelite.client.game.RunepouchRune;
 import static net.runelite.client.plugins.runepouch.config.RunePouchOverlayMode.BOTH;
 import static net.runelite.client.plugins.runepouch.config.RunePouchOverlayMode.MOUSE_HOVER;
 import net.runelite.client.ui.FontManager;
@@ -100,7 +101,7 @@ public class RunepouchOverlay extends WidgetItemOverlay
 
 			Varbits runeVarbit = RUNE_VARBITS[i];
 			int runeId = client.getVar(runeVarbit);
-			Runes rune = Runes.getRune(runeId);
+			RunepouchRune rune = RunepouchRune.getRune(runeId);
 			if (rune == null)
 			{
 				continue;
@@ -149,7 +150,7 @@ public class RunepouchOverlay extends WidgetItemOverlay
 		}
 	}
 
-	private BufferedImage getRuneImage(Runes rune)
+	private BufferedImage getRuneImage(RunepouchRune rune)
 	{
 		BufferedImage runeImg = rune.getImage();
 		if (runeImg != null)

--- a/runelite-client/src/test/java/net/runelite/client/plugins/cluescrolls/ClueScrollPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/cluescrolls/ClueScrollPluginTest.java
@@ -30,14 +30,22 @@ import com.google.inject.Inject;
 import com.google.inject.name.Named;
 import com.google.inject.testing.fieldbinder.Bind;
 import com.google.inject.testing.fieldbinder.BoundFieldModule;
+import java.util.Arrays;
+import java.util.List;
 import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
+import net.runelite.api.InventoryID;
+import net.runelite.api.Item;
+import net.runelite.api.ItemContainer;
+import net.runelite.api.ItemID;
 import net.runelite.api.NPC;
 import net.runelite.api.NullObjectID;
 import net.runelite.api.Player;
+import net.runelite.api.Varbits;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.ChatMessage;
 import net.runelite.api.events.GameTick;
+import net.runelite.api.events.ItemContainerChanged;
 import net.runelite.api.events.MenuOptionClicked;
 import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetInfo;
@@ -45,8 +53,11 @@ import net.runelite.client.game.ItemManager;
 import net.runelite.client.plugins.banktags.TagManager;
 import net.runelite.client.plugins.cluescrolls.clues.hotcold.HotColdLocation;
 import net.runelite.client.ui.overlay.OverlayManager;
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -182,5 +193,42 @@ public class ClueScrollPluginTest
 		plugin.onMenuOptionClicked(menuOptionClicked);
 		plugin.onChatMessage(withdrawMessage);
 		assertNull(plugin.getActiveSTASHClue());
+	}
+
+	@Test
+	public void testThatRunepouchIsAddedToInventory()
+	{
+		ItemContainer container = mock(ItemContainer.class);
+		ItemContainerChanged event = new ItemContainerChanged(InventoryID.INVENTORY.getId(), container);
+
+		final Item[] inventory = {
+			new Item(ItemID.COINS_995, 100),
+			new Item(ItemID.MITHRIL_BAR, 1),
+			new Item(ItemID.MITHRIL_BAR, 1),
+			new Item(ItemID.MITHRIL_BAR, 1),
+			new Item(ItemID.SOUL_RUNE, 30),
+			new Item(ItemID.COSMIC_RUNE, 100),
+			new Item(ItemID.RUNE_POUCH, 1),
+			new Item(ItemID.SPADE, 1),
+			new Item(ItemID.CLUE_SCROLL_MASTER, 1)
+		};
+
+		when(container.getItems()).thenReturn(inventory);
+		when(container.contains(ItemID.RUNE_POUCH)).thenReturn(true);
+		when(client.getItemContainer(InventoryID.INVENTORY)).thenReturn(container);
+
+		when(client.getVar(Varbits.RUNE_POUCH_RUNE1)).thenReturn(9); // Cosmic Rune
+		when(client.getVar(Varbits.RUNE_POUCH_AMOUNT1)).thenReturn(20);
+		when(client.getVar(Varbits.RUNE_POUCH_RUNE3)).thenReturn(4); // Fire Rune
+		when(client.getVar(Varbits.RUNE_POUCH_AMOUNT3)).thenReturn(4000);
+
+		plugin.onItemContainerChanged(event);
+
+		assertFalse(Arrays.equals(inventory, plugin.getInventoryItems()));
+
+		List<Item> inventoryList = Arrays.asList(plugin.getInventoryItems());
+
+		assertThat(inventoryList, hasItem(new Item(ItemID.COSMIC_RUNE, 120)));
+		assertThat(inventoryList, hasItem(new Item(ItemID.FIRE_RUNE, 4000)));
 	}
 }


### PR DESCRIPTION
Closes #11319

This makes it so the contents of the Runepouch are added to the inventory items, which allows them to be used in item requirements.