### PR TITLE
Prevent HotkeyListener from consuming input on login screen

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
@@ -384,6 +384,7 @@ public class ClientUI
 				}
 			};
 
+			sidebarListener.setEnabledOnLogin(true);
 			keyManager.registerKeyListener(sidebarListener);
 
 			// Add mouse listener

--- a/runelite-client/src/main/java/net/runelite/client/util/HotkeyListener.java
+++ b/runelite-client/src/main/java/net/runelite/client/util/HotkeyListener.java
@@ -26,7 +26,9 @@ package net.runelite.client.util;
 
 import java.awt.event.KeyEvent;
 import java.util.function.Supplier;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import lombok.Setter;
 import net.runelite.client.config.Keybind;
 import net.runelite.client.input.KeyListener;
 
@@ -38,6 +40,10 @@ public abstract class HotkeyListener implements KeyListener
 	private boolean isPressed = false;
 
 	private boolean isConsumingTyped = false;
+
+	@Setter
+	@Getter
+	private boolean isEnabledOnLogin = false;
 
 	@Override
 	public void keyTyped(KeyEvent e)


### PR DESCRIPTION
This prvent HotkeyListener from running on login screen without being
explicitely enabled to do so.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>