### PR TITLE
Disable compute shaders automatically on compilation failure

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuPlugin.java
@@ -486,9 +486,17 @@ public class GpuPlugin extends Plugin implements DrawCallbacks
 
 		if (useComputeShaders)
 		{
-			glComputeProgram = COMPUTE_PROGRAM.compile(gl, template);
-			glSmallComputeProgram = SMALL_COMPUTE_PROGRAM.compile(gl, template);
-			glUnorderedComputeProgram = UNORDERED_COMPUTE_PROGRAM.compile(gl, template);
+			try
+			{
+				glComputeProgram = COMPUTE_PROGRAM.compile(gl, template);
+				glSmallComputeProgram = SMALL_COMPUTE_PROGRAM.compile(gl, template);
+				glUnorderedComputeProgram = UNORDERED_COMPUTE_PROGRAM.compile(gl, template);
+			}
+			catch (ShaderException e)
+			{
+				log.warn("Failed to compile compute shaders, disabling", e);
+				useComputeShaders = false;
+			}
 		}
 
 		initUniforms();


### PR DESCRIPTION
Imo this is nice thing to do so we do not have to tell people to try and disable compute shaders in case their GPU plugin is not working.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>