### PR TITLE
api: correct pearl fly fishing and barbarian rod animations

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/AnimationID.java
+++ b/runelite-api/src/main/java/net/runelite/api/AnimationID.java
@@ -113,8 +113,8 @@ public final class AnimationID
 	public static final int FISHING_BAREHAND_CAUGHT_TUNA_1 = 6710;
 	public static final int FISHING_BAREHAND_CAUGHT_TUNA_2 = 6711;
 	public static final int FISHING_PEARL_ROD = 8188;
-	public static final int FISHING_PEARL_FLY_ROD = 8189;
-	public static final int FISHING_PEARL_BARBARIAN_ROD = 8190;
+	public static final int FISHING_PEARL_FLY_ROD = 8192;
+	public static final int FISHING_PEARL_BARBARIAN_ROD = 8193;
 	public static final int FISHING_PEARL_OILY_ROD = 6932;
 	public static final int MINING_BRONZE_PICKAXE = 625;
 	public static final int MINING_IRON_PICKAXE = 626;


### PR DESCRIPTION
So, each of these rods have 2 animation IDs, with one of them showing the casting of the rod. This casting animation is used by the normal and oily rods. **However**, for whatever reason, the Fly fishing and Barbarian rods both use the non-casting animation whilst active.

Thanks to `Kaan` on the Discord for reporting this.