### PR TITLE
feat(grounditems): add item pile (menu entries) sorting

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
@@ -33,6 +33,7 @@ import net.runelite.client.config.Units;
 import net.runelite.client.plugins.grounditems.config.ItemHighlightMode;
 import net.runelite.client.plugins.grounditems.config.MenuHighlightMode;
 import net.runelite.client.plugins.grounditems.config.PriceDisplayMode;
+import net.runelite.client.plugins.grounditems.config.SortedMenuDisplayMode;
 import net.runelite.client.plugins.grounditems.config.ValueCalculationMode;
 
 @ConfigGroup("grounditems")
@@ -117,7 +118,7 @@ public interface GroundItemsConfig extends Config
 	{
 		return false;
 	}
-	
+
 	@ConfigItem(
 		keyName = "highlightTiles",
 		name = "Highlight Tiles",
@@ -371,4 +372,12 @@ public interface GroundItemsConfig extends Config
 	{
 		return false;
 	}
+
+	@ConfigItem(
+		keyName = "sortedMenuDisplayMode",
+		name = "Sorted Menu Display Mode",
+		description = "Configures the sorting method for item pile menu entries (right-click menu)",
+		position = 29
+	)
+	default SortedMenuDisplayMode sortedMenuDisplayMode() { return SortedMenuDisplayMode.HIGHEST; }
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/config/SortedMenuDisplayMode.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/config/SortedMenuDisplayMode.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2020, Ranadeep Polavarapu <https://github.com/RanadeepPolavarapu>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package net.runelite.client.plugins.grounditems.config;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum SortedMenuDisplayMode
+{
+	HA("High Alchemy"), // calc highlight by HA value
+	GE("Grand Exchange"), // calc by GE
+	HIGHEST("Highest"), // use whatever is highest.
+	OFF("Off");
+
+	private final String name;
+
+	@Override
+	public String toString() { return name; }
+}


### PR DESCRIPTION
Adds a new feature to the *Ground Items* plugin to sort the item pile menu entries by **GE**, **HA**, **HIGHEST** (default), and **OFF** options. The highlighting and everything else works as-is as that is untouched.

Behaviour: 
![image](https://user-images.githubusercontent.com/7084995/80316853-43e03000-87ce-11ea-89a5-8a2a129aa773.png)

Config:
![image](https://user-images.githubusercontent.com/7084995/80316202-4b9dd580-87ca-11ea-9dfa-f676d5a3c93a.png)

This behaviour is very useful for PvP'ing and PvM'ing.