### PR TITLE
Add calc function to chatcommands plugin

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsConfig.java
@@ -156,7 +156,15 @@ public interface ChatCommandsConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 11,
+			position = 11,
+			keyName = "calc",
+			name = "In-Chat Calculator",
+			description = "Configures whether the Calc command is enabled<br> !calc"
+	)
+	default boolean calc() { return true; }
+
+	@ConfigItem(
+		position = 12,
 		keyName = "clearSingleWord",
 		name = "Clear Single Word",
 		description = "Enable hot key to clear single word at a time"
@@ -167,7 +175,7 @@ public interface ChatCommandsConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 12,
+		position = 13,
 		keyName = "clearEntireChatBox",
 		name = "Clear Chat Box",
 		description = "Enable hotkey to clear entire chat box"

--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsConfig.java
@@ -161,7 +161,10 @@ public interface ChatCommandsConfig extends Config
 			name = "In-Chat Calculator",
 			description = "Configures whether the Calc command is enabled<br> !calc"
 	)
-	default boolean calc() { return true; }
+	default boolean calc()
+	{
+		return true;
+	}
 
 	@ConfigItem(
 		position = 12,

--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
@@ -690,7 +690,7 @@ public class ChatCommandsPlugin extends Plugin
 		{
 			ScriptEngineManager mgr = new ScriptEngineManager();
 			ScriptEngine engine = mgr.getEngineByName("JavaScript");
-            DecimalFormat f = new DecimalFormat("##.#####");
+			DecimalFormat f = new DecimalFormat("##.#####");
 
 			try
 			{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
@@ -27,8 +27,6 @@ package net.runelite.client.plugins.chatcommands;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.inject.Provides;
-
-import java.io.IOError;
 import java.io.IOException;
 import java.text.DecimalFormat;
 import java.util.EnumSet;
@@ -688,7 +686,7 @@ public class ChatCommandsPlugin extends Plugin
 		String message = chatMessage.getMessage();
 		String roundAnswer = "";
 		String calculation = message.replace("!Calc ", "");
-		if(calculation.matches("(-)?\\d+([+-/*]([(]-)?\\d+[)]?)+"))
+		if (calculation.matches("(-)?\\d+([+-/*]([(]-)?\\d+[)]?)+"))
 		{
 			ScriptEngineManager mgr = new ScriptEngineManager();
 			ScriptEngine engine = mgr.getEngineByName("JavaScript");

--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
@@ -27,7 +27,10 @@ package net.runelite.client.plugins.chatcommands;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.inject.Provides;
+
+import java.io.IOError;
 import java.io.IOException;
+import java.text.DecimalFormat;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.concurrent.ScheduledExecutorService;
@@ -680,24 +683,29 @@ public class ChatCommandsPlugin extends Plugin
 		}
 		calculateChatMessage(chatMessage);
 	}
-	private void calculateChatMessage(ChatMessage chatMessage){
+	private void calculateChatMessage(ChatMessage chatMessage)
+	{
 		String message = chatMessage.getMessage();
-		String answer = "";
+		String roundAnswer = "";
 		String calculation = message.replace("!Calc ", "");
-		System.out.println("calc: " + calculation);
-		System.out.println(!calculation.matches("\\d+([+-/*]\\d+)+"));
-		if(calculation.matches("\\d+([+-/*]\\d+)+")){
+		if(calculation.matches("(-)?\\d+([+-/*]([(]-)?\\d+[)]?)+"))
+		{
 			ScriptEngineManager mgr = new ScriptEngineManager();
 			ScriptEngine engine = mgr.getEngineByName("JavaScript");
+            DecimalFormat f = new DecimalFormat("##.#####");
 
-			try {
-				answer = engine.eval(calculation).toString();
-			}catch (ScriptException e){
+			try
+			{
+				String answer = engine.eval(calculation).toString();
+				roundAnswer = f.format(Float.parseFloat(answer));
+			}
+			catch (ScriptException e)
+			{
 				e.printStackTrace();
 			}
 
 			ChatMessageBuilder chatMessageBuilder = new ChatMessageBuilder()
-					.append(calculation + " = " + answer)
+					.append(calculation + " = " + roundAnswer)
 					.append(ChatColorType.HIGHLIGHT);
 
 			String response = chatMessageBuilder.build();


### PR DESCRIPTION
How it's used: https://gyazo.com/91c7cd49a6c74ea94c2afffff96f86b3<img src="https://i.gyazo.com/91c7cd49a6c74ea94c2afffff96f86b3.png"></img>
Would be useful to calculate splits. When combined with !price could be used to calculate bulk prices without having to click out of the game for a calculator.
<b>Pros:</b>
comfortable to use
would speed up some processes
<b>Cons:</b>
more clutter for the client
