### PR TITLE
Add support for transparent right-click menu 

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/Client.java
+++ b/runelite-api/src/main/java/net/runelite/api/Client.java
@@ -1713,7 +1713,19 @@ public interface Client extends GameEngine
 
 	EnumComposition getEnum(int id);
 
-	void draw2010Menu();
+	/**
+	 * Draws a menu in the 2010 interface style.
+	 *
+	 * @param alpha background transparency of the menu
+	 */
+	void draw2010Menu(int alpha);
+
+	/**
+	 * Draws a menu in the OSRS interface style.
+	 *
+	 * @param alpha background transparency of the menu
+	 */
+	void drawOriginalMenu(int alpha);
 
 	void resetHealthBarCaches();
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/interfacestyles/InterfaceStylesConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/interfacestyles/InterfaceStylesConfig.java
@@ -29,6 +29,7 @@ package net.runelite.client.plugins.interfacestyles;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.Range;
 
 @ConfigGroup("interfaceStyles")
 public interface InterfaceStylesConfig extends Config
@@ -81,5 +82,18 @@ public interface InterfaceStylesConfig extends Config
 	default boolean alwaysStack()
 	{
 		return false;
+	}
+
+	@Range(
+		max = 255
+	)
+	@ConfigItem(
+		keyName = "menuAlpha",
+		name = "Menu alpha",
+		description = "Configures the transparency of the right-click menu"
+	)
+	default int menuAlpha()
+	{
+		return 255;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/interfacestyles/InterfaceStylesPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/interfacestyles/InterfaceStylesPlugin.java
@@ -175,7 +175,12 @@ public class InterfaceStylesPlugin extends Plugin
 	{
 		if (config.hdMenu())
 		{
-			client.draw2010Menu();
+			client.draw2010Menu(config.menuAlpha());
+			event.consume();
+		}
+		else if (config.menuAlpha() != 255)
+		{
+			client.drawOriginalMenu(config.menuAlpha());
 			event.consume();
 		}
 	}


### PR DESCRIPTION
When playing with stretched mode on the right click menu can take up a lot of space.
This works on both the normal and 2010 menu.

Normal:
![transparent-clicks](https://user-images.githubusercontent.com/25151927/80782487-b22e4500-8b76-11ea-893f-6f2a54be166f.gif)

2010:
![hq-transparent-clicks](https://user-images.githubusercontent.com/25151927/80782493-b9555300-8b76-11ea-92a1-0d8142fe1a9a.gif)

Both gifs are with 50% transparency.

Depends on !113

Closes #10501