### PR TITLE
Screenshot: Untradeable Drops Screenshots for the Gauntlet

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
@@ -361,17 +361,14 @@ public class ScreenshotPlugin extends Plugin
 			}
 		}
 
-		if (config.screenshotUntradeableDrop()) {
-			if (isInsideGauntlet())
-			{
-				Matcher m = UNTRADEABLE_DROP_PATTERN.matcher(chatMessage);
-				if (m.matches())
-                {
-					String untradeableDropName = m.group(1);
-					String fileName = "Untradeable drop " + untradeableDropName;
-					takeScreenshot(fileName, "Untradeable Drops");
-				}
-			}
+		if (config.screenshotUntradeableDrop() && !isInsideGauntlet()) {
+            Matcher m = UNTRADEABLE_DROP_PATTERN.matcher(chatMessage);
+            if (m.matches())
+            {
+                String untradeableDropName = m.group(1);
+                String fileName = "Untradeable drop " + untradeableDropName;
+                takeScreenshot(fileName, "Untradeable Drops");
+            }
 		}
 
 		if (config.screenshotDuels())

--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
@@ -361,7 +361,8 @@ public class ScreenshotPlugin extends Plugin
 			}
 		}
 
-		if (config.screenshotUntradeableDrop() && !isInsideGauntlet()) {
+		if (config.screenshotUntradeableDrop() && !isInsideGauntlet())
+		{
             Matcher m = UNTRADEABLE_DROP_PATTERN.matcher(chatMessage);
             if (m.matches())
             {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
@@ -364,11 +364,11 @@ public class ScreenshotPlugin extends Plugin
 		if (config.screenshotUntradeableDrop() && !isInsideGauntlet())
 		{
 		    Matcher m = UNTRADEABLE_DROP_PATTERN.matcher(chatMessage);
-		    if (m.matches())
-		    {
-		        String untradeableDropName = m.group(1);
-		        String fileName = "Untradeable drop " + untradeableDropName;
-		        takeScreenshot(fileName, "Untradeable Drops");
+            if (m.matches())
+            {
+                String untradeableDropName = m.group(1);
+                String fileName = "Untradeable drop " + untradeableDropName;
+                takeScreenshot(fileName, "Untradeable Drops");
             }
 		}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
@@ -363,12 +363,12 @@ public class ScreenshotPlugin extends Plugin
 
 		if (config.screenshotUntradeableDrop() && !isInsideGauntlet())
 		{
-            Matcher m = UNTRADEABLE_DROP_PATTERN.matcher(chatMessage);
-            if (m.matches())
-            {
-                String untradeableDropName = m.group(1);
-                String fileName = "Untradeable drop " + untradeableDropName;
-                takeScreenshot(fileName, "Untradeable Drops");
+		    Matcher m = UNTRADEABLE_DROP_PATTERN.matcher(chatMessage);
+		    if (m.matches())
+		    {
+		        String untradeableDropName = m.group(1);
+		        String fileName = "Untradeable drop " + untradeableDropName;
+		        takeScreenshot(fileName, "Untradeable Drops");
             }
 		}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
@@ -365,7 +365,8 @@ public class ScreenshotPlugin extends Plugin
 			if (isInsideGauntlet())
 			{
 				Matcher m = UNTRADEABLE_DROP_PATTERN.matcher(chatMessage);
-				if (m.matches()) {
+				if (m.matches())
+                {
 					String untradeableDropName = m.group(1);
 					String fileName = "Untradeable drop " + untradeableDropName;
 					takeScreenshot(fileName, "Untradeable Drops");

--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
@@ -113,6 +113,8 @@ public class ScreenshotPlugin extends Plugin
 
 	private boolean shouldTakeScreenshot;
 
+	private boolean insideGauntlet = false;
+
 	@Inject
 	private ScreenshotConfig config;
 
@@ -248,6 +250,10 @@ public class ScreenshotPlugin extends Plugin
 		if (player == client.getLocalPlayer() && config.screenshotPlayerDeath())
 		{
 			takeScreenshot("Death", "Deaths");
+			if (insideGauntlet)
+			{
+				insideGauntlet = false;
+			}
 		}
 		else if (player != client.getLocalPlayer() && (player.isClanMember() || player.isFriend()) && config.screenshotFriendDeath() && player.getCanvasTilePoly() != null)
 		{
@@ -357,14 +363,15 @@ public class ScreenshotPlugin extends Plugin
 			}
 		}
 
-		if (config.screenshotUntradeableDrop())
-		{
-			Matcher m = UNTRADEABLE_DROP_PATTERN.matcher(chatMessage);
-			if (m.matches())
+		if (config.screenshotUntradeableDrop()) {
+			if (!insideGauntlet)
 			{
-				String untradeableDropName = m.group(1);
-				String fileName = "Untradeable drop " + untradeableDropName;
-				takeScreenshot(fileName, "Untradeable Drops");
+				Matcher m = UNTRADEABLE_DROP_PATTERN.matcher(chatMessage);
+				if (m.matches()) {
+					String untradeableDropName = m.group(1);
+					String fileName = "Untradeable drop " + untradeableDropName;
+					takeScreenshot(fileName, "Untradeable Drops");
+				}
 			}
 		}
 
@@ -378,6 +385,16 @@ public class ScreenshotPlugin extends Plugin
 				String fileName = "Duel " + result + " (" + count + ")";
 				takeScreenshot(fileName, "Duels");
 			}
+		}
+
+		if (chatMessage.equals("You enter the Gauntlet."))
+		{
+			insideGauntlet = true;
+		}
+
+		if (chatMessage.equals("You leave the Gauntlet."))
+		{
+			insideGauntlet = false;
 		}
 	}
 


### PR DESCRIPTION
Closes #11362 

Removes the screenshotting of untradeable items when within the Gauntlet as it spams screenshots on every untradeable drop.