### PR TITLE
Tears of Guthix - Display experience skill icon

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/tearsofguthix/TearsOfGuthixConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/tearsofguthix/TearsOfGuthixConfig.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2020, TheStonedTurtle <https://github.com/TheStonedTurtle>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.tearsofguthix;
+
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+
+@ConfigGroup("tearsofguthix")
+public interface TearsOfGuthixConfig extends Config
+{
+	@ConfigItem(
+		keyName = "displaySkillIcon",
+		name = "Display Skill Icon",
+		description = "Displays the skill which you will receive TOG experience for on top of Juna"
+	)
+	default boolean displaySkillIcon()
+	{
+		return true;
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/tearsofguthix/TearsOfGuthixOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/tearsofguthix/TearsOfGuthixOverlay.java
@@ -69,6 +69,11 @@ class TearsOfGuthixOverlay extends Overlay
 	{
 		plugin.getStreams().forEach((object, timer) ->
 		{
+			if (object.getWorldLocation().distanceTo(client.getLocalPlayer().getWorldLocation()) >= MAX_ICON_DISTANCE)
+			{
+				return;
+			}
+
 			final Point position = object.getCanvasLocation(100);
 
 			if (position == null)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/tearsofguthix/TearsOfGuthixOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/tearsofguthix/TearsOfGuthixOverlay.java
@@ -27,25 +27,39 @@ package net.runelite.client.plugins.tearsofguthix;
 import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
 import java.time.Duration;
 import java.time.Instant;
 import javax.inject.Inject;
+import net.runelite.api.Client;
 import net.runelite.api.Point;
+import net.runelite.api.coords.LocalPoint;
+import net.runelite.api.coords.WorldPoint;
+import net.runelite.client.game.SkillIconManager;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.OverlayUtil;
 import net.runelite.client.ui.overlay.components.ProgressPieComponent;
 
 class TearsOfGuthixOverlay extends Overlay
 {
 	private static final Color CYAN_ALPHA = new Color(Color.CYAN.getRed(), Color.CYAN.getGreen(), Color.CYAN.getBlue(), 100);
 	private static final Duration MAX_TIME = Duration.ofSeconds(9);
+	private static final WorldPoint JUNA_LOCATION = new WorldPoint(3252, 9517, 2);
+	private static final int MAX_ICON_DISTANCE = 15;
 	private final TearsOfGuthixPlugin plugin;
+	private final TearsOfGuthixConfig config;
+	private final SkillIconManager skillIconManager;
+	private final Client client;
 
 	@Inject
-	private TearsOfGuthixOverlay(TearsOfGuthixPlugin plugin)
+	private TearsOfGuthixOverlay(TearsOfGuthixPlugin plugin, TearsOfGuthixConfig config, SkillIconManager skillIconManager, Client client)
 	{
 		this.plugin = plugin;
+		this.config = config;
+		this.skillIconManager = skillIconManager;
+		this.client = client;
 		setPosition(OverlayPosition.DYNAMIC);
 		setLayer(OverlayLayer.ABOVE_SCENE);
 	}
@@ -76,6 +90,20 @@ class TearsOfGuthixOverlay extends Overlay
 			progressPie.render(graphics);
 		});
 
+		drawSkillOverlay(graphics);
+
 		return null;
+	}
+
+	// Draws the skill which will receive experience from TOG on Juna
+	private void drawSkillOverlay(final Graphics2D graphics)
+	{
+		if (!config.displaySkillIcon() || client.getLocalPlayer().getWorldLocation().distanceTo(JUNA_LOCATION) >= MAX_ICON_DISTANCE)
+		{
+			return;
+		}
+
+		final BufferedImage icon = skillIconManager.getSkillImage(plugin.getTearsOfGuthixSkill());
+		OverlayUtil.renderImageLocation(client, graphics, LocalPoint.fromWorld(client, JUNA_LOCATION), icon, 40);
 	}
 }

--- a/runelite-client/src/test/java/net/runelite/client/plugins/tearsofguthix/TearsOfGuthixTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/tearsofguthix/TearsOfGuthixTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2020, TheStonedTurtle <https://github.com/TheStonedTurtle>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.tearsofguthix;
+
+import net.runelite.api.Skill;
+import static net.runelite.client.plugins.tearsofguthix.TearsOfGuthixPlugin.TOG_SKILLS;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class TearsOfGuthixTest
+{
+	@Test
+	public void verifyTogSkillsArray()
+	{
+		// Ensure each skill, excluding overall, has been included
+		for (final Skill skill : Skill.values())
+		{
+			if (skill == Skill.OVERALL)
+			{
+				continue;
+			}
+
+			assertTrue("TOG_SKILLS contains skill: " + skill, TOG_SKILLS.contains(skill));
+		}
+
+		assertEquals("Each skill is only included once", Skill.values().length - 1, TOG_SKILLS.size());
+	}
+}


### PR DESCRIPTION
Adds a new config option (defaults to true) that displays the skill which will receive the tears of guthix experience on top of Juna.

![image](https://user-images.githubusercontent.com/29030969/80863520-dd299f00-8c31-11ea-9b7a-b1a49d456aae.png)


I've also added a separate commit to only render the timers for the tears if the local player is within range. This is currently checking 15 tiles (max player render distance), let me know if this should be changed to match the agility plugin.

Before:
![image](https://user-images.githubusercontent.com/29030969/80863561-2b3ea280-8c32-11ea-864d-d8bb957149fd.png)

After: 
![image](https://user-images.githubusercontent.com/29030969/80863541-fe8a8b00-8c31-11ea-8c73-8d787ae506e7.png)

