### PR TITLE
Item Stats: Fixed heal from Castle Wars bandages with CW Bracelet

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/special/CastleWarsBandage.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/special/CastleWarsBandage.java
@@ -48,7 +48,7 @@ public class CastleWarsBandage implements Effect
 	);
 
 	private static final double BASE_HP_PERC = .10;
-	private static final double BRACELET_HP_PERC = .50;
+	private static final double BRACELET_HP_PERC = .15;
 
 	@Override
 	public StatsChanges calculate(Client client)


### PR DESCRIPTION
Castle Wars bandages heal amount increases **by** 50% when the bracelet effect is on.

Currently, the plugin incorrectly calculates it as 50% of the total hitpoints level.