### PR TITLE
metronome: add independent volume configuration

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/metronome/MetronomePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/metronome/MetronomePlugin.java
@@ -68,7 +68,7 @@ public class MetronomePlugin extends Plugin
 
 		if (++tickCounter % config.tickCount() == 0)
 		{
-			// As playSoundEffect only uses the volume argument when the in-game volume is muted, sound effect volume
+			// As playSoundEffect only uses the volume argument when the in-game volume isn't muted, sound effect volume
 			// needs to be set to the value desired for ticks or tocks and afterwards reset to the previous value.
 			int previousVolume = client.getSoundEffectVolume();
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/metronome/MetronomePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/metronome/MetronomePlugin.java
@@ -27,7 +27,6 @@ package net.runelite.client.plugins.metronome;
 
 import com.google.inject.Provides;
 import javax.inject.Inject;
-import net.runelite.api.SoundEffectVolume;
 import net.runelite.api.Client;
 import net.runelite.api.SoundEffectID;
 import net.runelite.api.events.GameTick;
@@ -69,14 +68,23 @@ public class MetronomePlugin extends Plugin
 
 		if (++tickCounter % config.tickCount() == 0)
 		{
-			if (config.enableTock() && shouldTock)
+			// As playSoundEffect only uses the volume argument when the in-game volume is muted, sound effect volume
+			// needs to be set to the value desired for ticks or tocks and afterwards reset to the previous value.
+			int previousVolume = client.getSoundEffectVolume();
+
+			if (shouldTock && config.tockVolume() > 0)
 			{
-				client.playSoundEffect(SoundEffectID.GE_DECREMENT_PLOP, SoundEffectVolume.MEDIUM_HIGH);
+				client.setSoundEffectVolume(config.tockVolume());
+				client.playSoundEffect(SoundEffectID.GE_DECREMENT_PLOP, config.tockVolume());
 			}
-			else
+			else if (config.tickVolume() > 0)
 			{
-				client.playSoundEffect(SoundEffectID.GE_INCREMENT_PLOP, SoundEffectVolume.MEDIUM_HIGH);
+				client.setSoundEffectVolume(config.tickVolume());
+				client.playSoundEffect(SoundEffectID.GE_INCREMENT_PLOP, config.tickVolume());
 			}
+
+			client.setSoundEffectVolume(previousVolume);
+
 			shouldTock = !shouldTock;
 		}
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/metronome/MetronomePluginConfiguration.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/metronome/MetronomePluginConfiguration.java
@@ -28,29 +28,47 @@ package net.runelite.client.plugins.metronome;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.Range;
+import net.runelite.api.SoundEffectVolume;
 
 @ConfigGroup("metronome")
 public interface MetronomePluginConfiguration extends Config
 {
+	int VOLUME_MAX = SoundEffectVolume.HIGH;
+
 	@ConfigItem(
 		keyName = "tickCount",
 		name = "Tick count",
-		description = "Configures the tick on which a sound will be played",
-		position = 2
+		description = "Configures the tick on which a sound will be played."
 	)
 	default int tickCount()
 	{
 		return 1;
 	}
 
-	@ConfigItem(
-		keyName = "enableTock",
-		name = "Enable tock (alternating) sound",
-		description = "Toggles whether to play two alternating sounds",
-		position = 3
+	@Range(
+		max = VOLUME_MAX
 	)
-	default boolean enableTock()
+	@ConfigItem(
+		keyName = "tickVolume",
+		name = "Tick volume",
+		description = "Configures the volume of the tick sound. A value of 0 will disable tick sounds."
+	)
+	default int tickVolume()
 	{
-		return false;
+		return SoundEffectVolume.MEDIUM_HIGH;
+	}
+
+	@Range(
+		max = VOLUME_MAX
+	)
+	@ConfigItem(
+		keyName = "tockVolume",
+		name = "Tock volume",
+		description = "Configures the volume of the tock sound. A value of 0 will disable tock sounds."
+	)
+	default int tockVolume()
+	{
+		return SoundEffectVolume.MUTED;
 	}
 }


### PR DESCRIPTION
Closes #10347. Without setting and resetting the client sound effect volume as implemented, the sound effect is only played at the configured volume when sound effects are muted in-game.