### PR TITLE
Additional elite clue information

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java
@@ -164,7 +164,7 @@ public class CoordinateClue extends ClueScroll implements TextClueScroll, Locati
 		// Elite
 		.put(new WorldPoint(2357, 3151, 0), new CoordinateClueInfo("Lletya."))
 		.put(new WorldPoint(3587, 3180, 0), new CoordinateClueInfo("Meiyerditch."))
-		.put(new WorldPoint(2820, 3078, 0), new CoordinateClueInfo("Tai Bwo Wannai. Hardwood Grove."))
+		.put(new WorldPoint(2820, 3078, 0), new CoordinateClueInfo("Tai Bwo Wannai. Hardwood Grove. 100 Trading sticks needed to enter"))
 		.put(new WorldPoint(3811, 3060, 0), new CoordinateClueInfo("Small island north-east of Mos Le'Harmless.", true, Varbits.FIRE_PIT_MOS_LE_HARMLESS))
 		.put(new WorldPoint(2180, 3282, 0), new CoordinateClueInfo("North of Iorwerth Camp."))
 		.put(new WorldPoint(2870, 2997, 0), new CoordinateClueInfo("North-east corner in Shilo Village."))

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java
@@ -164,7 +164,7 @@ public class CoordinateClue extends ClueScroll implements TextClueScroll, Locati
 		// Elite
 		.put(new WorldPoint(2357, 3151, 0), new CoordinateClueInfo("Lletya."))
 		.put(new WorldPoint(3587, 3180, 0), new CoordinateClueInfo("Meiyerditch."))
-		.put(new WorldPoint(2820, 3078, 0), new CoordinateClueInfo("Tai Bwo Wannai. Hardwood Grove. 100 Trading sticks needed to enter."))
+		.put(new WorldPoint(2820, 3078, 0), new CoordinateClueInfo("Tai Bwo Wannai. Hardwood Grove. 100 Trading sticks or elite Karamja diary completion is needed to enter."))
 		.put(new WorldPoint(3811, 3060, 0), new CoordinateClueInfo("Small island north-east of Mos Le'Harmless.", true, Varbits.FIRE_PIT_MOS_LE_HARMLESS))
 		.put(new WorldPoint(2180, 3282, 0), new CoordinateClueInfo("North of Iorwerth Camp."))
 		.put(new WorldPoint(2870, 2997, 0), new CoordinateClueInfo("North-east corner in Shilo Village."))

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java
@@ -164,7 +164,7 @@ public class CoordinateClue extends ClueScroll implements TextClueScroll, Locati
 		// Elite
 		.put(new WorldPoint(2357, 3151, 0), new CoordinateClueInfo("Lletya."))
 		.put(new WorldPoint(3587, 3180, 0), new CoordinateClueInfo("Meiyerditch."))
-		.put(new WorldPoint(2820, 3078, 0), new CoordinateClueInfo("Tai Bwo Wannai. Hardwood Grove. 100 Trading sticks needed to enter"))
+		.put(new WorldPoint(2820, 3078, 0), new CoordinateClueInfo("Tai Bwo Wannai. Hardwood Grove. 100 Trading sticks needed to enter."))
 		.put(new WorldPoint(3811, 3060, 0), new CoordinateClueInfo("Small island north-east of Mos Le'Harmless.", true, Varbits.FIRE_PIT_MOS_LE_HARMLESS))
 		.put(new WorldPoint(2180, 3282, 0), new CoordinateClueInfo("North of Iorwerth Camp."))
 		.put(new WorldPoint(2870, 2997, 0), new CoordinateClueInfo("North-east corner in Shilo Village."))


### PR DESCRIPTION
For Tai Bwo Wannai Elite Clue specified 100 trading sticks are required to enter the hardwood area.