### PR TITLE
Adds a new Elite Clue Coordinate direction

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java
@@ -195,7 +195,7 @@ public class CoordinateClue extends ClueScroll implements TextClueScroll, Locati
 		.put(new WorldPoint(2872, 3937, 0), new CoordinateClueInfo("Weiss."))
 		.put(new WorldPoint(2484, 4016, 0), new CoordinateClueInfo("Northeast corner of the Island of Stone."))
 		.put(new WorldPoint(2222, 3331, 0), new CoordinateClueInfo("Prifddinas, west of the Tower of Voices"))
-		.put(new WorldPoint(3560, 3987, 0), new CoordinateClueInfo("Lithkren. If unlocked, Digsite pendant teleport, Otherwise take rowboat directly west of Mushroom Meadow Mushtree."))
+		.put(new WorldPoint(3560, 3987, 0), new CoordinateClueInfo("Lithkren. Digsite pendant teleport if unlocked, otherwise take rowboat from west of Mushroom Meadow Mushtree."))
 		// Master
 		.put(new WorldPoint(2178, 3209, 0), new CoordinateClueInfo("South of Iorwerth Camp."))
 		.put(new WorldPoint(2155, 3100, 0), new CoordinateClueInfo("South of Port Tyras (BJS)."))

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java
@@ -195,7 +195,7 @@ public class CoordinateClue extends ClueScroll implements TextClueScroll, Locati
 		.put(new WorldPoint(2872, 3937, 0), new CoordinateClueInfo("Weiss."))
 		.put(new WorldPoint(2484, 4016, 0), new CoordinateClueInfo("Northeast corner of the Island of Stone."))
 		.put(new WorldPoint(2222, 3331, 0), new CoordinateClueInfo("Prifddinas, west of the Tower of Voices"))
-		.put(new WorldPoint(3560, 3987, 0), new CoordinateClueInfo("Lithkren."))
+		.put(new WorldPoint(3560, 3987, 0), new CoordinateClueInfo("Lithkren. If unlocked, Digsite pendant teleport, Otherwise take rowboat directly west of Mushroom Meadow Mushtree."))
 		// Master
 		.put(new WorldPoint(2178, 3209, 0), new CoordinateClueInfo("South of Iorwerth Camp."))
 		.put(new WorldPoint(2155, 3100, 0), new CoordinateClueInfo("South of Port Tyras (BJS)."))

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java
@@ -195,6 +195,7 @@ public class CoordinateClue extends ClueScroll implements TextClueScroll, Locati
 		.put(new WorldPoint(2872, 3937, 0), new CoordinateClueInfo("Weiss."))
 		.put(new WorldPoint(2484, 4016, 0), new CoordinateClueInfo("Northeast corner of the Island of Stone."))
 		.put(new WorldPoint(2222, 3331, 0), new CoordinateClueInfo("Prifddinas, west of the Tower of Voices"))
+		.put(new WorldPoint(3560, 3987, 0), new CoordinateClueInfo("Lithkren."))
 		// Master
 		.put(new WorldPoint(2178, 3209, 0), new CoordinateClueInfo("South of Iorwerth Camp."))
 		.put(new WorldPoint(2155, 3100, 0), new CoordinateClueInfo("South of Port Tyras (BJS)."))


### PR DESCRIPTION
>25 degrees 48 minutes north
>35 degrees 0 minutes east

#### Before
![before](https://user-images.githubusercontent.com/7683393/81241811-fbe0ba80-8fd0-11ea-9076-979d7be06bf8.png)

#### After
![after](https://user-images.githubusercontent.com/7683393/81241815-fe431480-8fd0-11ea-8598-e52690e34ea1.png)

#### Sanity Spellcheck
https://oldschool.runescape.wiki/w/Lithkren


Note: I couldn't figure out if/how these were organized so I just added it at the end of the elite clues.