### PR TITLE
gpu: add warning message to compute shaders option

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuPluginConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuPluginConfig.java
@@ -101,6 +101,7 @@ public interface GpuPluginConfig extends Config
 		keyName = "useComputeShaders",
 		name = "Compute Shaders",
 		description = "Offloads face sorting to GPU, enabling extended draw distance. Requires plugin restart.",
+		warning = "This feature requires OpenGL 4.3 to use. Please check that your GPU supports this.\nRestart the plugin for changes to take effect.",
 		position = 6
 	)
 	default boolean useComputeShaders()


### PR DESCRIPTION
Closes #11387

Adding a warning should hopefully make it more clear to users what this feature requires, and that they need to restart the plugin.

The plugin being able to restart itself would be better, but until then this should help.