### PR TITLE
Add configuration options to the woodcutting and mining plugin to specify the respawn timer size

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/mining/MiningConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/mining/MiningConfig.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2019, Jan-Willem <jan-willem@datm.nl>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.mining;
+
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.Units;
+
+@ConfigGroup("mining")
+public interface MiningConfig extends Config
+{
+    @ConfigItem(
+            position = 5,
+            keyName = "showRespawnTimers",
+            name = "Show respawn timers",
+            description = "Configures whether to display the respawn timer overlay"
+    )
+    default boolean showRespawnTimers()
+    {
+        return true;
+    }
+
+    @ConfigItem(
+            keyName = "RespawnTimerSize",
+            name = "Size of Respawn timers",
+            description = "Change the size of the Respawn timers",
+            position = 10
+    )
+    @Units(Units.PIXELS)
+    default int RespawnTimerSize()
+    {
+        return 25;
+    }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/mining/MiningOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/mining/MiningOverlay.java
@@ -56,20 +56,23 @@ class MiningOverlay extends Overlay
 	private final Client client;
 	private final MiningPlugin plugin;
 
+	private final MiningConfig config;
+
 	@Inject
-	private MiningOverlay(Client client, MiningPlugin plugin)
+	private MiningOverlay(Client client, MiningPlugin plugin, MiningConfig config)
 	{
 		setPosition(OverlayPosition.DYNAMIC);
 		setLayer(OverlayLayer.ABOVE_SCENE);
 		this.plugin = plugin;
 		this.client = client;
+		this.config = config;
 	}
 
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
 		List<RockRespawn> respawns = plugin.getRespawns();
-		if (respawns.isEmpty())
+		if (respawns.isEmpty() || !config.showRespawnTimers())
 		{
 			return null;
 		}
@@ -113,6 +116,7 @@ class MiningOverlay extends Overlay
 			ProgressPieComponent ppc = new ProgressPieComponent();
 			ppc.setBorderColor(pieBorderColor);
 			ppc.setFill(pieFillColor);
+			ppc.setDiameter(config.RespawnTimerSize());
 			ppc.setPosition(point);
 			ppc.setProgress(percent);
 			ppc.render(graphics);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/mining/MiningPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/mining/MiningPlugin.java
@@ -24,6 +24,7 @@
  */
 package net.runelite.client.plugins.mining;
 
+import com.google.inject.Provides;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
@@ -49,6 +50,7 @@ import net.runelite.api.events.GameObjectSpawned;
 import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.GameTick;
 import net.runelite.api.events.WallObjectSpawned;
+import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
@@ -73,9 +75,19 @@ public class MiningPlugin extends Plugin
 	@Inject
 	private MiningOverlay overlay;
 
+	@Inject
+	private MiningConfig config;
+
 	@Getter(AccessLevel.PACKAGE)
 	private final List<RockRespawn> respawns = new ArrayList<>();
 	private boolean recentlyLoggedIn;
+
+	@Provides
+	MiningConfig getConfig(ConfigManager configManager)
+	{
+		return configManager.getConfig(MiningConfig.class);
+	}
+
 
 	@Override
 	protected void startUp()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingConfig.java
@@ -87,4 +87,16 @@ public interface WoodcuttingConfig extends Config
 	{
 		return true;
 	}
+
+	@ConfigItem(
+			keyName = "RespawnTimerSize",
+			name = "Size of Respawn timers",
+			description = "Change the size of the Respawn timers",
+			position = 10
+	)
+	@Units(Units.PIXELS)
+	default int RespawnTimerSize()
+	{
+		return 25;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingTreesOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingTreesOverlay.java
@@ -122,6 +122,7 @@ class WoodcuttingTreesOverlay extends Overlay
 			ProgressPieComponent ppc = new ProgressPieComponent();
 			ppc.setBorderColor(Color.ORANGE);
 			ppc.setFill(Color.YELLOW);
+			ppc.setDiameter(config.RespawnTimerSize());
 			ppc.setPosition(point);
 			ppc.setProgress(percent);
 			ppc.render(graphics);


### PR DESCRIPTION
Added a new settings option to the mining plugin to enable/disable the respawn timers.

Added size options to the mining and woodcutting plugin to resize the respawn timers.