### PR TITLE
Fix check for menu entry type for copy to clipboard not working on friend messages

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/chathistory/ChatHistoryPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chathistory/ChatHistoryPlugin.java
@@ -264,9 +264,7 @@ public class ChatHistoryPlugin extends Plugin implements KeyListener
 		}
 		else if (COPY_TO_CLIPBOARD.equals(menuOption) && !Strings.isNullOrEmpty(currentMessage))
 		{
-			currentMessage = currentMessage.replaceAll("<gt>","╩").replaceAll("<lt>","╔");
-			currentMessage = Text.removeTags(currentMessage).replaceAll("╩",">").replaceAll("╔","<");
-			final StringSelection stringSelection = new StringSelection(currentMessage);
+			final StringSelection stringSelection = new StringSelection(Text.removeTags(currentMessage));
 			Toolkit.getDefaultToolkit().getSystemClipboard().setContents(stringSelection, null);
 		}
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/chathistory/ChatHistoryPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chathistory/ChatHistoryPlugin.java
@@ -193,7 +193,7 @@ public class ChatHistoryPlugin extends Plugin implements KeyListener
 		// Use second entry as first one can be walk here with transparent chatbox
 		final MenuEntry entry = event.getMenuEntries()[event.getMenuEntries().length - 2];
 
-		if (entry.getType() != MenuAction.CC_OP_LOW_PRIORITY.getId())
+		if (entry.getType() != MenuAction.CC_OP_LOW_PRIORITY.getId() && entry.getType() != MenuAction.RUNELITE.getId())
 		{
 			return;
 		}
@@ -264,7 +264,9 @@ public class ChatHistoryPlugin extends Plugin implements KeyListener
 		}
 		else if (COPY_TO_CLIPBOARD.equals(menuOption) && !Strings.isNullOrEmpty(currentMessage))
 		{
-			final StringSelection stringSelection = new StringSelection(Text.removeTags(currentMessage));
+		    currentMessage = currentMessage.replaceAll("<gt>","╩").replaceAll("<lt>","╔");
+            currentMessage = Text.removeTags(currentMessage).replaceAll("╩",">").replaceAll("╔","<");
+			final StringSelection stringSelection = new StringSelection(currentMessage);
 			Toolkit.getDefaultToolkit().getSystemClipboard().setContents(stringSelection, null);
 		}
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/chathistory/ChatHistoryPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chathistory/ChatHistoryPlugin.java
@@ -264,8 +264,8 @@ public class ChatHistoryPlugin extends Plugin implements KeyListener
 		}
 		else if (COPY_TO_CLIPBOARD.equals(menuOption) && !Strings.isNullOrEmpty(currentMessage))
 		{
-		    currentMessage = currentMessage.replaceAll("<gt>","╩").replaceAll("<lt>","╔");
-            currentMessage = Text.removeTags(currentMessage).replaceAll("╩",">").replaceAll("╔","<");
+			currentMessage = currentMessage.replaceAll("<gt>","╩").replaceAll("<lt>","╔");
+			currentMessage = Text.removeTags(currentMessage).replaceAll("╩",">").replaceAll("╔","<");
 			final StringSelection stringSelection = new StringSelection(currentMessage);
 			Toolkit.getDefaultToolkit().getSystemClipboard().setContents(stringSelection, null);
 		}


### PR DESCRIPTION
Fixes bug with menu option not appearing on friend's messages
Allows copying of the "<" and ">" characters