### PR TITLE
Canonicalize ItemManager price lookup IDs

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/game/ItemManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/game/ItemManager.java
@@ -290,18 +290,20 @@ public class ItemManager
 	 */
 	public int getItemPrice(int itemID, boolean ignoreUntradeableMap)
 	{
-		if (itemID == ItemID.COINS_995)
+		final int realId = canonicalize(itemID);
+
+		if (realId == ItemID.COINS_995)
 		{
 			return 1;
 		}
-		if (itemID == ItemID.PLATINUM_TOKEN)
+		if (realId == ItemID.PLATINUM_TOKEN)
 		{
 			return 1000;
 		}
 
 		if (!ignoreUntradeableMap)
 		{
-			UntradeableItemMapping p = UntradeableItemMapping.map(ItemVariationMapping.map(itemID));
+			UntradeableItemMapping p = UntradeableItemMapping.map(ItemVariationMapping.map(realId));
 			if (p != null)
 			{
 				return getItemPrice(p.getPriceID()) * p.getQuantity();
@@ -309,7 +311,7 @@ public class ItemManager
 		}
 
 		int price = 0;
-		for (int mappedID : ItemMapping.map(itemID))
+		for (int mappedID : ItemMapping.map(realId))
 		{
 			ItemPrice ip = itemPrices.get(mappedID);
 			if (ip != null)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/examine/ExaminePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/examine/ExaminePlugin.java
@@ -29,7 +29,6 @@ import com.google.common.cache.CacheBuilder;
 import java.time.Instant;
 import java.util.ArrayDeque;
 import java.util.Deque;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.regex.Pattern;
 import javax.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
@@ -91,9 +90,6 @@ public class ExaminePlugin extends Plugin
 
 	@Inject
 	private ChatMessageManager chatMessageManager;
-
-	@Inject
-	private ScheduledExecutorService executor;
 
 	@Subscribe
 	public void onGameStateChanged(GameStateChanged event)
@@ -219,7 +215,7 @@ public class ExaminePlugin extends Plugin
 			if (itemComposition != null)
 			{
 				final int id = itemManager.canonicalize(itemComposition.getId());
-				executor.submit(() -> getItemPrice(id, itemComposition, itemQuantity));
+				getItemPrice(id, itemComposition, itemQuantity);
 			}
 		}
 		else

--- a/runelite-client/src/main/java/net/runelite/client/plugins/examine/ExaminePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/examine/ExaminePlugin.java
@@ -211,12 +211,7 @@ public class ExaminePlugin extends Plugin
 			}
 
 			itemComposition = itemManager.getItemComposition(itemId);
-
-			if (itemComposition != null)
-			{
-				final int id = itemManager.canonicalize(itemComposition.getId());
-				getItemPrice(id, itemComposition, itemQuantity);
-			}
+			getItemPrice(itemComposition.getId(), itemComposition, itemQuantity);
 		}
 		else
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemprices/ItemPricesOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemprices/ItemPricesOverlay.java
@@ -188,7 +188,7 @@ class ItemPricesOverlay extends Overlay
 
 	private String getItemStackValueText(Item item)
 	{
-		int id = item.getId();
+		int id = itemManager.canonicalize(item.getId());
 		int qty = item.getQuantity();
 
 		// Special case for coins and platinum tokens
@@ -202,11 +202,6 @@ class ItemPricesOverlay extends Overlay
 		}
 
 		ItemComposition itemDef = itemManager.getItemComposition(id);
-		if (itemDef.getNote() != -1)
-		{
-			id = itemDef.getLinkedNoteId();
-			itemDef = itemManager.getItemComposition(id);
-		}
 
 		// Only check prices for things with store prices
 		if (itemDef.getPrice() <= 0)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
@@ -798,8 +798,7 @@ public class LootTrackerPlugin extends Plugin
 	private LootTrackerItem buildLootTrackerItem(int itemId, int quantity)
 	{
 		final ItemComposition itemComposition = itemManager.getItemComposition(itemId);
-		final int realItemId = itemComposition.getNote() != -1 ? itemComposition.getLinkedNoteId() : itemId;
-		final int gePrice = itemManager.getItemPrice(realItemId);
+		final int gePrice = itemManager.getItemPrice(itemId);
 		final int haPrice = Math.round(itemComposition.getPrice() * Constants.HIGH_ALCHEMY_MULTIPLIER);
 		final boolean ignored = ignoredItems.contains(itemComposition.getName());
 

--- a/runelite-client/src/test/java/net/runelite/client/plugins/examine/ExaminePluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/examine/ExaminePluginTest.java
@@ -30,6 +30,7 @@ import com.google.inject.testing.fieldbinder.BoundFieldModule;
 import javax.inject.Inject;
 import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
+import net.runelite.api.ItemComposition;
 import net.runelite.api.ItemID;
 import net.runelite.api.MenuAction;
 import net.runelite.api.events.ChatMessage;
@@ -82,6 +83,7 @@ public class ExaminePluginTest
 	public void testItem()
 	{
 		when(client.getWidget(anyInt(), anyInt())).thenReturn(mock(Widget.class));
+		when(itemManager.getItemComposition(anyInt())).thenReturn(mock(ItemComposition.class));
 
 		MenuOptionClicked menuOptionClicked = new MenuOptionClicked();
 		menuOptionClicked.setMenuOption("Examine");
@@ -100,6 +102,7 @@ public class ExaminePluginTest
 	public void testLargeStacks()
 	{
 		when(client.getWidget(anyInt(), anyInt())).thenReturn(mock(Widget.class));
+		when(itemManager.getItemComposition(anyInt())).thenReturn(mock(ItemComposition.class));
 
 		MenuOptionClicked menuOptionClicked = new MenuOptionClicked();
 		menuOptionClicked.setMenuOption("Examine");

--- a/runelite-client/src/test/java/net/runelite/client/plugins/examine/ExaminePluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/examine/ExaminePluginTest.java
@@ -27,7 +27,6 @@ package net.runelite.client.plugins.examine;
 import com.google.inject.Guice;
 import com.google.inject.testing.fieldbinder.Bind;
 import com.google.inject.testing.fieldbinder.BoundFieldModule;
-import java.util.concurrent.ScheduledExecutorService;
 import javax.inject.Inject;
 import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
@@ -72,10 +71,6 @@ public class ExaminePluginTest
 	@Mock
 	@Bind
 	ItemManager itemManager;
-
-	@Mock
-	@Bind
-	ScheduledExecutorService scheduledExecutorService;
 
 	@Before
 	public void before()


### PR DESCRIPTION
This ensures returned item prices are accurate even for noted item IDs. (This fixes a bug in the recently-added [NPC and PVP kill chat message feature](https://github.com/runelite/runelite/pull/10035))

Closes #11616