### PR TITLE
KeyRemapping: Add space as an option to remap.

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/keyremapping/KeyRemappingConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/keyremapping/KeyRemappingConfig.java
@@ -241,4 +241,15 @@ public interface KeyRemappingConfig extends Config
 	{
 		return new ModifierlessKeybind(KeyEvent.VK_ESCAPE, 0);
 	}
+
+	@ConfigItem(
+		position = 20,
+		keyName = "space",
+		name = "Space",
+		description = "The key which will replace {Space}."
+	)
+	default ModifierlessKeybind space()
+	{
+		return new ModifierlessKeybind(KeyEvent.VK_SPACE, 0);
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/keyremapping/KeyRemappingConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/keyremapping/KeyRemappingConfig.java
@@ -246,7 +246,7 @@ public interface KeyRemappingConfig extends Config
 		position = 20,
 		keyName = "space",
 		name = "Space",
-		description = "The key which will replace {Space}."
+		description = "The key which will replace {Space} when dialogs are open."
 	)
 	default ModifierlessKeybind space()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/keyremapping/KeyRemappingListener.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/keyremapping/KeyRemappingListener.java
@@ -156,6 +156,11 @@ class KeyRemappingListener implements KeyListener
 				}
 			}
 
+			if (plugin.isDialogOpen() && config.space().matches(e))
+			{
+				mappedKeyCode = KeyEvent.VK_SPACE;
+			}
+
 			if (mappedKeyCode != KeyEvent.VK_UNDEFINED && mappedKeyCode != e.getKeyCode())
 			{
 				final char keyChar = e.getKeyChar();


### PR DESCRIPTION
Hi I wanted to be able to remap space in the KeyMapping plugin when you are talking to NPCs. So I added this as an option in the KeyMapping plugin. Also added an option for remapping shift for dropping items. I did this because I am using a splitted keyboard and my space button is actually on the right side of the keyboard which makes it awkward to hold in space whilst talking to NPCs.