### PR TITLE
Change `showSidebar` option name to 'Show world switcher sidebar' to match sidebar icon label

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldHopperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldHopperConfig.java
@@ -83,7 +83,7 @@ public interface WorldHopperConfig extends Config
 
 	@ConfigItem(
 		keyName = "showSidebar",
-		name = "Show world hopper sidebar",
+		name = "Show world switcher sidebar",
 		description = "Show sidebar containing all worlds that mimics in-game interface",
 		position = 4
 	)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldHopperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldHopperPlugin.java
@@ -94,7 +94,7 @@ import org.apache.commons.lang3.ArrayUtils;
 @PluginDescriptor(
 	name = "World Hopper",
 	description = "Allows you to quickly hop worlds",
-	tags = {"ping"}
+	tags = {"ping", "switcher"}
 )
 @Slf4j
 public class WorldHopperPlugin extends Plugin


### PR DESCRIPTION
Simple change of the `showSidebar` option name from 'Show world hopper sidebar' to 'Show world switcher sidebar' to match the the actual World Switcher icon on the sidebar.

Closes #6777 