### PR TITLE
Revises when dps overlay is shown

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/dpscounter/DpsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/dpscounter/DpsOverlay.java
@@ -95,15 +95,14 @@ class DpsOverlay extends OverlayPanel
 	public Dimension render(Graphics2D graphics)
 	{
 		Map<String, DpsMember> dpsMembers = dpsCounterPlugin.getMembers();
-		if (dpsMembers.isEmpty())
-		{
-			return null;
-		}
-
 		boolean inParty = !partyService.getMembers().isEmpty();
 		boolean showDamage = dpsConfig.showDamage();
 		DpsMember total = dpsCounterPlugin.getTotal();
 		boolean paused = total.isPaused();
+		if (dpsMembers.isEmpty() && total.getStart() == total.getEnd())
+		{
+			return null;
+		}
 
 		final String title = (inParty ? "Party " : "") + (showDamage ? "Damage" : "DPS") + (paused ? " (paused)" : "");
 		panelComponent.getChildren().add(
@@ -135,7 +134,7 @@ class DpsOverlay extends OverlayPanel
 			{
 				DpsMember self = dpsMembers.get(player.getName());
 
-				if (self != null && total.getDamage() > self.getDamage())
+				if (self == null || total.getDamage() > self.getDamage())
 				{
 					panelComponent.getChildren().add(
 						LineComponent.builder()


### PR DESCRIPTION
The dps counters total will change if other players are attacking a boss without showing the overlay, change to show total dmg done if it has started tracking dmg by other players. This change was in favor of having it start tracking when the local player attacked as cases where grouping there would be cases of other players dealing first damage, which would want to be tracked.