### PR TITLE
Remove bounty hunter emblem tier from player name for lookup

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/IconID.java
+++ b/runelite-api/src/main/java/net/runelite/api/IconID.java
@@ -46,7 +46,8 @@ public enum IconID
 	SKULL(9),
 	HARDCORE_IRONMAN(10),
 	NO_ENTRY(11),
-	CHAIN_LINK(12);
+	CHAIN_LINK(12),
+	BOUNTY_HUNTER_EMBLEM(20);
 
 	private final int index;
 

--- a/runelite-client/src/main/java/net/runelite/client/menus/MenuManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/menus/MenuManager.java
@@ -24,6 +24,7 @@
  */
 package net.runelite.client.menus;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
@@ -33,10 +34,12 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
+import net.runelite.api.IconID;
 import net.runelite.api.MenuAction;
 import net.runelite.api.MenuEntry;
 import net.runelite.api.NPCComposition;
@@ -61,6 +64,8 @@ public class MenuManager
 	private static final int IDX_LOWER = 4;
 	private static final int IDX_UPPER = 8;
 
+	private static final Pattern BOUNTY_EMBLEM_TAG_AND_TIER_REGEXP = Pattern.compile(String.format("%s[1-9]0?", IconID.BOUNTY_HUNTER_EMBLEM.toString()));
+
 	private final Client client;
 	private final EventBus eventBus;
 
@@ -71,7 +76,8 @@ public class MenuManager
 	private final Set<String> npcMenuOptions = new HashSet<>();
 
 	@Inject
-	private MenuManager(Client client, EventBus eventBus)
+	@VisibleForTesting
+	MenuManager(Client client, EventBus eventBus)
 	{
 		this.client = client;
 		this.eventBus = eventBus;
@@ -269,7 +275,9 @@ public class MenuManager
 			}
 		}
 
-		String target = event.getMenuTarget();
+		// removes bounty hunter emblem tag and tier from player name, e.g:
+		// "username<img=20>5<col=40ff00>  (level-42)" -> "username<col=40ff00>  (level-42)"
+		String target = BOUNTY_EMBLEM_TAG_AND_TIER_REGEXP.matcher(event.getMenuTarget()).replaceAll("");
 
 		// removes tags and level from player names for example:
 		// <col=ffffff>username<col=40ff00>  (level-42) or <col=ffffff><img=2>username</col>

--- a/runelite-client/src/test/java/net/runelite/client/menus/MenuManagerTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/menus/MenuManagerTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2020, bfmoatbio <bfmoatbio@protonmail.com>
+ * All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *     list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package net.runelite.client.menus;
+
+import com.google.inject.testing.fieldbinder.Bind;
+import net.runelite.api.Client;
+import net.runelite.api.MenuAction;
+import net.runelite.api.events.MenuOptionClicked;
+import net.runelite.api.events.PlayerMenuOptionClicked;
+import net.runelite.client.eventbus.EventBus;
+import net.runelite.client.eventbus.Subscribe;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(MockitoJUnitRunner.class)
+public class MenuManagerTest
+{
+    @Mock
+    @Bind
+    private Client client;
+
+    private final EventBus eventBus = new EventBus();
+    private final MenuManager menuManager = new MenuManager(client, eventBus);
+
+    private MenuManagerTestOnPlayerMenuOptionClicked playerMenuOptionClickedListener;
+
+    @Before
+    public void before()
+    {
+        playerMenuOptionClickedListener = new MenuManagerTestOnPlayerMenuOptionClicked();
+        eventBus.register(playerMenuOptionClickedListener);
+    }
+
+    @After
+    public void after()
+    {
+        eventBus.unregister(playerMenuOptionClickedListener);
+    }
+
+    @Test
+    public void testPlayerMenuOptionClicked()
+    {
+        MenuOptionClicked event = new MenuOptionClicked();
+        event.setMenuAction(MenuAction.RUNELITE);
+        event.setMenuTarget("username<col=40ff00>  (level-42)");
+
+        menuManager.onMenuOptionClicked(event);
+
+        String target = playerMenuOptionClickedListener.lastEvent.getMenuTarget();
+        assertEquals("username", target);
+    }
+
+    @Test
+    public void testPlayerMenuOptionWithBountyHunterEmblemClicked()
+    {
+        MenuOptionClicked event = new MenuOptionClicked();
+        event.setMenuAction(MenuAction.RUNELITE);
+        event.setMenuTarget("username<img=20>5<col=40ff00>  (level-42)");
+
+        menuManager.onMenuOptionClicked(event);
+
+        String target = playerMenuOptionClickedListener.lastEvent.getMenuTarget();
+        assertEquals("username", target);
+    }
+}
+
+class MenuManagerTestOnPlayerMenuOptionClicked
+{
+    public PlayerMenuOptionClicked lastEvent;
+
+    @Subscribe
+    public void onPlayerMenuOptionClicked(PlayerMenuOptionClicked event)
+    {
+        lastEvent = event;
+    }
+}


### PR DESCRIPTION
A player in the wilderness of a bounty hunter world with a bounty hunter
emblem in their inventory will have their name decorated in the player
menu with an emblem icon and the tier of emblem they are carrying. Before
removing any tags, that name will look like this:

<col=ffffff>bfmoatbio<img=20>10<col=00ff>  (level-126)

where "<img=20>10" represents the emblem icon (<img=20>) and tier (10).
removeTags will remove the icon tag but leave the emblem tier, resulting
in an incorrect username returned by getMenuTarget (in the case of the
example, bfmoatbio10).

Before calling removeTags on a player menu target, perform a special
remove of the bounty hunter emblem icon and its tier, if present.

Closes #11440