### PR TITLE
Add potion dosages to Item Identification plugin

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemidentification/ItemIdentification.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemidentification/ItemIdentification.java
@@ -25,7 +25,6 @@
 package net.runelite.client.plugins.itemidentification;
 
 import com.google.common.collect.ImmutableMap;
-
 import java.util.ArrayList;
 import java.util.Map;
 import net.runelite.api.ItemID;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemidentification/ItemIdentification.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemidentification/ItemIdentification.java
@@ -25,6 +25,8 @@
 package net.runelite.client.plugins.itemidentification;
 
 import com.google.common.collect.ImmutableMap;
+
+import java.util.ArrayList;
 import java.util.Map;
 import net.runelite.api.ItemID;
 
@@ -228,16 +230,43 @@ enum ItemIdentification
 	}
 
 	private static final Map<Integer, ItemIdentification> itemIdentifications;
+	private static final ArrayList<Integer> fourDose;
+	private static final ArrayList<Integer> threeDose;
+	private static final ArrayList<Integer> twoDose;
+	private static final ArrayList<Integer> oneDose;
 
 	static
 	{
 		ImmutableMap.Builder<Integer, ItemIdentification> builder = new ImmutableMap.Builder<>();
+		fourDose = new ArrayList<>();
+		threeDose = new ArrayList<>();
+		twoDose = new ArrayList<>();
+		oneDose = new ArrayList<>();
 
 		for (ItemIdentification i : values())
 		{
+			int j = 4;
 			for (int id : i.itemIDs)
 			{
 				builder.put(id, i);
+				if (i.type == Type.POTION)
+				{
+					switch (j)
+					{
+						case 4:
+							fourDose.add(id);
+							break;
+						case 3:
+							threeDose.add(id);
+							break;
+						case 2:
+							twoDose.add(id);
+							break;
+						case 1:
+							oneDose.add(id);
+					}
+				}
+				j--;
 			}
 		}
 
@@ -247,6 +276,33 @@ enum ItemIdentification
 	static ItemIdentification get(int id)
 	{
 		return itemIdentifications.get(id);
+	}
+
+	static int getDosage(int id)
+	{
+		if (fourDose.contains(id))
+		{
+			return 4;
+		}
+
+		else if (threeDose.contains(id))
+		{
+			return 3;
+		}
+
+		else if (twoDose.contains(id))
+		{
+			return 2;
+		}
+
+		else if (oneDose.contains(id))
+		{
+			return 1;
+		}
+		else
+		{
+			return 0;
+		}
 	}
 
 	enum Type

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemidentification/ItemIdentificationConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemidentification/ItemIdentificationConfig.java
@@ -115,6 +115,16 @@ public interface ItemIdentificationConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "showPotionsDosage",
+		name = "Potions Dosage",
+		description = "Show dosages of Potions"
+	)
+	default boolean showPotionsDosage()
+	{
+		return false;
+	}
+
+	@ConfigItem(
 		keyName = "showImplingJars",
 		name = "Impling jars",
 		description = "Show identification on Impling jars"

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemidentification/ItemIdentificationOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemidentification/ItemIdentificationOverlay.java
@@ -96,7 +96,7 @@ class ItemIdentificationOverlay extends WidgetItemOverlay
 				}
 				break;
 			case POTION:
-				if (!config.showPotions())
+				if (!config.showPotions() && !config.showPotionsDosage())
 				{
 					return;
 				}
@@ -110,10 +110,10 @@ class ItemIdentificationOverlay extends WidgetItemOverlay
 		}
 
 		graphics.setFont(FontManager.getRunescapeSmallFont());
-		renderText(graphics, itemWidget.getCanvasBounds(), iden);
+		renderText(graphics, itemWidget.getCanvasBounds(), iden, itemId);
 	}
 
-	private void renderText(Graphics2D graphics, Rectangle bounds, ItemIdentification iden)
+	private void renderText(Graphics2D graphics, Rectangle bounds, ItemIdentification iden, int itemId)
 	{
 		final TextComponent textComponent = new TextComponent();
 		textComponent.setPosition(new Point(bounds.x - 1, bounds.y + bounds.height - 1));
@@ -126,6 +126,18 @@ class ItemIdentificationOverlay extends WidgetItemOverlay
 			case MEDIUM:
 				textComponent.setText(iden.medName);
 				break;
+		}
+		if (config.showPotionsDosage() && iden.type == ItemIdentification.Type.POTION)
+		{
+			final TextComponent textComponentDoses = new TextComponent();
+			textComponentDoses.setPosition(new Point(bounds.x + 23, bounds.y + bounds.height - 22));
+			textComponentDoses.setColor(config.textColor());
+			textComponentDoses.setText("(" + ItemIdentification.getDosage(itemId) + ")");
+			textComponentDoses.render(graphics);
+			if (!config.showPotions())
+			{
+				textComponent.setText("");
+			}
 		}
 		textComponent.render(graphics);
 	}


### PR DESCRIPTION
Adds dosage text to potion icons to better distinguish between visually similar doses. Some people may find it useful, most notably for differentiating between (3) and (4) doses.

https://imgur.com/a/DWdxe2r

Please review code thoroughly as I feel the method I went with is rather janky, and something is telling me there is a better solution lol.