### PR TITLE
Add duplicate chat options to chatfilter

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatfilter/ChatFilterConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatfilter/ChatFilterConfig.java
@@ -108,4 +108,26 @@ public interface ChatFilterConfig extends Config
 	{
 		return false;
 	}
+
+	@ConfigItem(
+		keyName = "collapseGameChat",
+		name = "Collapse Game Chat",
+		description = "Collapse duplicate game chat messages into a single line",
+		position = 9
+	)
+	default boolean collapseGameChat()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		keyName = "collapsePlayerChat",
+		name = "Collapse Player Chat",
+		description = "Collapse duplicate player chat messages into a single line",
+		position = 10
+	)
+	default boolean collapsePlayerChat()
+	{
+		return false;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatfilter/ChatFilterConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatfilter/ChatFilterConfig.java
@@ -130,4 +130,15 @@ public interface ChatFilterConfig extends Config
 	{
 		return false;
 	}
+
+	@ConfigItem(
+		keyName = "maxRepeatedPublicChats",
+		name = "Max repeated public chats",
+		description = "Block player chat message if repeated this many times. 0 is off",
+		position = 11
+	)
+	default int maxRepeatedPublicChats()
+	{
+		return 0;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatfilter/ChatFilterPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatfilter/ChatFilterPlugin.java
@@ -28,23 +28,36 @@ package net.runelite.client.plugins.chatfilter;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.CharMatcher;
 import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableSet;
 import com.google.inject.Provides;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 import javax.inject.Inject;
 import net.runelite.api.ChatMessageType;
+import static net.runelite.api.ChatMessageType.ENGINE;
+import static net.runelite.api.ChatMessageType.GAMEMESSAGE;
+import static net.runelite.api.ChatMessageType.ITEM_EXAMINE;
+import static net.runelite.api.ChatMessageType.MODCHAT;
+import static net.runelite.api.ChatMessageType.NPC_EXAMINE;
+import static net.runelite.api.ChatMessageType.OBJECT_EXAMINE;
+import static net.runelite.api.ChatMessageType.PUBLICCHAT;
+import static net.runelite.api.ChatMessageType.SPAM;
 import net.runelite.api.Client;
 import net.runelite.api.MessageNode;
 import net.runelite.api.Player;
-import net.runelite.client.events.ConfigChanged;
+import net.runelite.api.events.ChatMessage;
 import net.runelite.api.events.OverheadTextChanged;
 import net.runelite.api.events.ScriptCallbackEvent;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
+import net.runelite.client.events.ConfigChanged;
 import net.runelite.client.game.ClanManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
@@ -66,9 +79,37 @@ public class ChatFilterPlugin extends Plugin
 	@VisibleForTesting
 	static final String CENSOR_MESSAGE = "Hey, everyone, I just tried to say something very silly!";
 
+	private static final Set<ChatMessageType> COLLAPSIBLE_MESSAGETYPES = ImmutableSet.of(
+		ENGINE,
+		GAMEMESSAGE,
+		ITEM_EXAMINE,
+		NPC_EXAMINE,
+		OBJECT_EXAMINE,
+		SPAM,
+		PUBLICCHAT,
+		MODCHAT
+	);
+
 	private final CharMatcher jagexPrintableCharMatcher = Text.JAGEX_PRINTABLE_CHAR_MATCHER;
 	private final List<Pattern> filteredPatterns = new ArrayList<>();
 	private final List<Pattern> filteredNamePatterns = new ArrayList<>();
+
+	private static class Duplicate
+	{
+		int messageId;
+		int count;
+	}
+
+	private final LinkedHashMap<String, Duplicate> duplicateChatCache = new LinkedHashMap<String, Duplicate>()
+	{
+		private static final int MAX_ENTRIES = 100;
+
+		@Override
+		protected boolean removeEldestEntry(Map.Entry<String, Duplicate> eldest)
+		{
+			return size() > MAX_ENTRIES;
+		}
+	};
 
 	@Inject
 	private Client client;
@@ -96,6 +137,7 @@ public class ChatFilterPlugin extends Plugin
 	protected void shutDown() throws Exception
 	{
 		filteredPatterns.clear();
+		duplicateChatCache.clear();
 		client.refreshChat();
 	}
 
@@ -109,10 +151,18 @@ public class ChatFilterPlugin extends Plugin
 
 		int[] intStack = client.getIntStack();
 		int intStackSize = client.getIntStackSize();
-		int messageType = intStack[intStackSize - 2];
-		int messageId = intStack[intStackSize - 1];
+		String[] stringStack = client.getStringStack();
+		int stringStackSize = client.getStringStackSize();
+
+		final int messageType = intStack[intStackSize - 2];
+		final int messageId = intStack[intStackSize - 1];
+		String message = stringStack[stringStackSize - 1];
 
 		ChatMessageType chatMessageType = ChatMessageType.of(messageType);
+		final MessageNode messageNode = client.getMessages().get(messageId);
+		final String name = messageNode.getName();
+		int duplicateCount = 0;
+		boolean blockMessage = false;
 
 		// Only filter public chat and private messages
 		switch (chatMessageType)
@@ -123,32 +173,34 @@ public class ChatFilterPlugin extends Plugin
 			case PRIVATECHAT:
 			case MODPRIVATECHAT:
 			case FRIENDSCHAT:
+				if (shouldFilterPlayerMessage(name))
+				{
+					message = censorMessage(name, message);
+					blockMessage = message == null;
+				}
 				break;
 			case LOGINLOGOUTNOTIFICATION:
 				if (config.filterLogin())
 				{
-					// Block the message
-					intStack[intStackSize - 3] = 0;
+					blockMessage = true;
 				}
-				return;
-			default:
-				return;
+				break;
 		}
 
-		MessageNode messageNode = client.getMessages().get(messageId);
-		String name = messageNode.getName();
-		if (!shouldFilterPlayerMessage(name))
+		boolean shouldCollapse = chatMessageType == PUBLICCHAT || chatMessageType == MODCHAT
+			? config.collapsePlayerChat()
+			: COLLAPSIBLE_MESSAGETYPES.contains(chatMessageType) && config.collapseGameChat();
+		if (!blockMessage && shouldCollapse)
 		{
-			return;
+			Duplicate duplicateCacheEntry = duplicateChatCache.get(name + ":" + message);
+			if (duplicateCacheEntry != null)
+			{
+				blockMessage = duplicateCacheEntry.messageId != messageId;
+				duplicateCount = duplicateCacheEntry.count;
+			}
 		}
 
-		String[] stringStack = client.getStringStack();
-		int stringStackSize = client.getStringStackSize();
-
-		String message = stringStack[stringStackSize - 1];
-		String censoredMessage = censorMessage(name, message);
-
-		if (censoredMessage == null)
+		if (blockMessage)
 		{
 			// Block the message
 			intStack[intStackSize - 3] = 0;
@@ -156,7 +208,12 @@ public class ChatFilterPlugin extends Plugin
 		else
 		{
 			// Replace the message
-			stringStack[stringStackSize - 1] = censoredMessage;
+			if (duplicateCount > 1)
+			{
+				message += " (" + duplicateCount + ")";
+			}
+
+			stringStack[stringStackSize - 1] = message;
 		}
 	}
 
@@ -176,6 +233,25 @@ public class ChatFilterPlugin extends Plugin
 		}
 
 		event.getActor().setOverheadText(message);
+	}
+
+	@Subscribe
+	public void onChatMessage(ChatMessage chatMessage)
+	{
+		if (COLLAPSIBLE_MESSAGETYPES.contains(chatMessage.getType()))
+		{
+			// remove and re-insert into map to move to end of list
+			final String key = chatMessage.getName() + ":" + chatMessage.getMessage();
+			Duplicate duplicate = duplicateChatCache.remove(key);
+			if (duplicate == null)
+			{
+				duplicate = new Duplicate();
+			}
+
+			duplicate.count++;
+			duplicate.messageId = chatMessage.getMessageNode().getId();
+			duplicateChatCache.put(key, duplicate);
+		}
 	}
 
 	boolean shouldFilterPlayerMessage(String playerName)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatfilter/ChatFilterPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatfilter/ChatFilterPlugin.java
@@ -195,7 +195,9 @@ public class ChatFilterPlugin extends Plugin
 			Duplicate duplicateCacheEntry = duplicateChatCache.get(name + ":" + message);
 			if (duplicateCacheEntry != null)
 			{
-				blockMessage = duplicateCacheEntry.messageId != messageId;
+				blockMessage = duplicateCacheEntry.messageId != messageId ||
+					((chatMessageType == PUBLICCHAT || chatMessageType == MODCHAT) &&
+						config.maxRepeatedPublicChats() > 0 && duplicateCacheEntry.count > config.maxRepeatedPublicChats());
 				duplicateCount = duplicateCacheEntry.count;
 			}
 		}

--- a/runelite-client/src/test/java/net/runelite/client/plugins/chatfilter/ChatFilterPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/chatfilter/ChatFilterPluginTest.java
@@ -34,6 +34,7 @@ import net.runelite.api.Client;
 import net.runelite.api.IterableHashTable;
 import net.runelite.api.MessageNode;
 import net.runelite.api.Player;
+import net.runelite.api.events.ChatMessage;
 import net.runelite.api.events.ScriptCallbackEvent;
 import net.runelite.client.game.ClanManager;
 import static net.runelite.client.plugins.chatfilter.ChatFilterPlugin.CENSOR_MESSAGE;
@@ -105,6 +106,13 @@ public class ChatFilterPluginTest
 	{
 		MessageNode node = mock(MessageNode.class);
 		when(node.getName()).thenReturn(sender);
+		return node;
+	}
+
+	private MessageNode mockMessageNode(int id)
+	{
+		MessageNode node = mock(MessageNode.class);
+		when(node.getId()).thenReturn(id);
 		return node;
 	}
 
@@ -321,5 +329,43 @@ public class ChatFilterPluginTest
 		ScriptCallbackEvent event = createCallbackEvent("Adam", "please filterme plugin", ChatMessageType.PUBLICCHAT);
 		chatFilterPlugin.onScriptCallbackEvent(event);
 		assertEquals(CENSOR_MESSAGE, client.getStringStack()[client.getStringStackSize() - 1]);
+	}
+
+	@Test
+	public void testDuplicateChatFiltered()
+	{
+		when(chatFilterConfig.collapseGameChat()).thenReturn(true);
+		chatFilterPlugin.onChatMessage(new ChatMessage(mockMessageNode(0), ChatMessageType.GAMEMESSAGE, null, "testMessage", null, 0));
+		ScriptCallbackEvent event = createCallbackEvent(null, "testMessage", ChatMessageType.GAMEMESSAGE);
+		chatFilterPlugin.onScriptCallbackEvent(event);
+
+		assertEquals(0, client.getIntStack()[client.getIntStackSize() - 3]);
+	}
+
+	@Test
+	public void testNoDuplicate()
+	{
+		when(chatFilterConfig.collapseGameChat()).thenReturn(true);
+		chatFilterPlugin.onChatMessage(new ChatMessage(mockMessageNode(1), ChatMessageType.GAMEMESSAGE, null, "testMessage", null, 0));
+		ScriptCallbackEvent event = createCallbackEvent(null, "testMessage", ChatMessageType.GAMEMESSAGE);
+		chatFilterPlugin.onScriptCallbackEvent(event);
+
+		assertEquals(1, client.getIntStack()[client.getIntStackSize() - 3]);
+		assertEquals("testMessage", client.getStringStack()[client.getStringStackSize() - 1]);
+	}
+
+	@Test
+	public void testDuplicateChatCount()
+	{
+		when(chatFilterConfig.collapseGameChat()).thenReturn(true);
+		chatFilterPlugin.onChatMessage(new ChatMessage(mockMessageNode(4), ChatMessageType.GAMEMESSAGE, null, "testMessage", null, 0));
+		chatFilterPlugin.onChatMessage(new ChatMessage(mockMessageNode(3), ChatMessageType.GAMEMESSAGE, null, "testMessage", null, 0));
+		chatFilterPlugin.onChatMessage(new ChatMessage(mockMessageNode(2), ChatMessageType.GAMEMESSAGE, null, "testMessage", null, 0));
+		chatFilterPlugin.onChatMessage(new ChatMessage(mockMessageNode(1), ChatMessageType.GAMEMESSAGE, null, "testMessage", null, 0));
+		ScriptCallbackEvent event = createCallbackEvent(null, "testMessage", ChatMessageType.GAMEMESSAGE);
+		chatFilterPlugin.onScriptCallbackEvent(event);
+
+		assertEquals(1, client.getIntStack()[client.getIntStackSize() - 3]);
+		assertEquals("testMessage (4)", client.getStringStack()[client.getStringStackSize() - 1]);
 	}
 }

--- a/runelite-client/src/test/java/net/runelite/client/plugins/chatfilter/ChatFilterPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/chatfilter/ChatFilterPluginTest.java
@@ -368,4 +368,18 @@ public class ChatFilterPluginTest
 		assertEquals(1, client.getIntStack()[client.getIntStackSize() - 3]);
 		assertEquals("testMessage (4)", client.getStringStack()[client.getStringStackSize() - 1]);
 	}
+
+	@Test
+	public void publicChatFilteredOnDuplicate()
+	{
+		when(chatFilterConfig.collapsePlayerChat()).thenReturn(true);
+		when(chatFilterConfig.maxRepeatedPublicChats()).thenReturn(2);
+		chatFilterPlugin.onChatMessage(new ChatMessage(mockMessageNode(1), ChatMessageType.PUBLICCHAT, "testName", "testMessage", null, 0));
+		chatFilterPlugin.onChatMessage(new ChatMessage(mockMessageNode(1), ChatMessageType.PUBLICCHAT, "testName", "testMessage", null, 0));
+		chatFilterPlugin.onChatMessage(new ChatMessage(mockMessageNode(1), ChatMessageType.PUBLICCHAT, "testName", "testMessage", null, 0));
+		ScriptCallbackEvent event = createCallbackEvent("testName", "testMessage", ChatMessageType.PUBLICCHAT);
+		chatFilterPlugin.onScriptCallbackEvent(event);
+
+		assertEquals(0, client.getIntStack()[client.getIntStackSize() - 3]);
+	}
 }


### PR DESCRIPTION
A few things to note:

1. I decided to use a cache for keeping count of the messages
- This allows it to count more than just the chat buffer length, so if you are logged in for many hours, message counts can go into the hundreds or thousands with no problem
- This also prevents modification of the chat buffer itself, so it will retain all of the chat history. This means if the plugin is turned off after consolidating the chats, the chat will go back to normal
- To prevent this cache from growing unbounded, I added a configurable max size. I defaulted to 500, however this is left up to the user. This size corresponds to unique messages, not total messages.

2. Public chat consolidation is configurable
- Only the "spammy" message types are consolidated by default: ENGINE, GAMEMESSAGE, NPC_EXAMINE, OBJECT_EXAMINE, SPAM.
- PUBLICCHAT is configurable on/off, default off

3. Public chat can be hidden after X amount of duplicates
- If the player so chooses, they can filter out messages if they are repeated a bunch. I tested this out in world 1 and had great success. After a bit of standing around the GE, the duplicate messages were filtered out and only regular conversation was left