### PR TITLE
Float loot tracker groups to top of list when obtaining drop

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPanel.java
@@ -502,7 +502,7 @@ class LootTrackerPanel extends PluginPanel
 			{
 				if (box.matches(record))
 				{
-					//float the matched box to the top of the UI list if it's not already first
+					// float the matched box to the top of the UI list if it's not already first
 					int idx = logsContainer.getComponentZOrder(box);
 					if (idx > 0)
 					{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPanel.java
@@ -504,7 +504,8 @@ class LootTrackerPanel extends PluginPanel
 				{
 					//float the matched box to the top of the UI list if it's not already first
 					int idx = logsContainer.getComponentZOrder(box);
-					if (idx > 0) {
+					if (idx > 0)
+					{
 						logsContainer.remove(idx);
 						logsContainer.add(box, 0);
 					}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPanel.java
@@ -502,9 +502,12 @@ class LootTrackerPanel extends PluginPanel
 			{
 				if (box.matches(record))
 				{
-					//float the matched box to the top of the UI list
-					logsContainer.remove(box);
-					logsContainer.add(box, 0);
+					//float the matched box to the top of the UI list if it's not already first
+					int idx = logsContainer.getComponentZOrder(box);
+					if (idx > 0) {
+						logsContainer.remove(idx);
+						logsContainer.add(box, 0);
+					}
 
 					box.addKill(record);
 					return box;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPanel.java
@@ -502,6 +502,10 @@ class LootTrackerPanel extends PluginPanel
 			{
 				if (box.matches(record))
 				{
+					//float the matched box to the top of the UI list
+					logsContainer.remove(box);
+					logsContainer.add(box, 0);
+
 					box.addKill(record);
 					return box;
 				}


### PR DESCRIPTION
Loot tracker panel now attempts to push the related group box to the top of the panel upon obtaining a drop

Closes #8519