### PR TITLE
Make highlighting dead NPCs optional in the NPC indicators plugin.

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsConfig.java
@@ -100,6 +100,17 @@ public interface NpcIndicatorsConfig extends Config
 
 	@ConfigItem(
 		position = 6,
+		keyName = "highlightDeadNPCs",
+		name = "Highlight dead NPCs",
+		description = "Highlight dead NPCs"
+	)
+	default boolean highlightDeadNpcs()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		position = 7,
 		keyName = "showRespawnTimer",
 		name = "Show respawn timer",
 		description = "Show respawn timer of tagged NPCs")

--- a/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsPlugin.java
@@ -260,7 +260,7 @@ public class NpcIndicatorsPlugin extends Plugin
 
 		if (config.highlightMenuNames() &&
 			NPC_MENU_ACTIONS.contains(MenuAction.of(type)) &&
-			highlightedNpcs.stream().anyMatch(npc -> npc.getIndex() == event.getIdentifier()))
+			highlightedNpcs.stream().anyMatch(npc -> npc.getIndex() == event.getIdentifier() && (!npc.isDead() || config.highlightDeadNpcs())))
 		{
 			MenuEntry[] menuEntries = client.getMenuEntries();
 			final MenuEntry menuEntry = menuEntries[menuEntries.length - 1];

--- a/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcMinimapOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcMinimapOverlay.java
@@ -68,11 +68,8 @@ public class NpcMinimapOverlay extends Overlay
 	private void renderNpcOverlay(Graphics2D graphics, NPC actor, String name, Color color)
 	{
 		NPCComposition npcComposition = actor.getTransformedComposition();
-		if (npcComposition == null || !npcComposition.isInteractible())
-		{
-			return;
-		}
-		if (!config.highlightDeadNpcs() && actor.isDead())
+		if (npcComposition == null || !npcComposition.isInteractible()
+			|| (actor.isDead() && !config.highlightDeadNpcs()))
 		{
 			return;
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcMinimapOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcMinimapOverlay.java
@@ -73,6 +73,7 @@ public class NpcMinimapOverlay extends Overlay
 		{
 			return;
 		}
+
 		Point minimapLocation = actor.getMinimapLocation();
 		if (minimapLocation != null)
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcMinimapOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcMinimapOverlay.java
@@ -72,7 +72,10 @@ public class NpcMinimapOverlay extends Overlay
 		{
 			return;
 		}
-
+		if (!config.highlightDeadNpcs() && actor.isDead())
+		{
+			return;
+		}
 		Point minimapLocation = actor.getMinimapLocation();
 		if (minimapLocation != null)
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcSceneOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcSceneOverlay.java
@@ -60,7 +60,7 @@ public class NpcSceneOverlay extends Overlay
 
 	static
 	{
-		((DecimalFormat) TIME_LEFT_FORMATTER).applyPattern("#0.0");
+		((DecimalFormat)TIME_LEFT_FORMATTER).applyPattern("#0.0");
 	}
 
 	private final Client client;
@@ -146,11 +146,8 @@ public class NpcSceneOverlay extends Overlay
 	private void renderNpcOverlay(Graphics2D graphics, NPC actor, Color color)
 	{
 		NPCComposition npcComposition = actor.getTransformedComposition();
-		if (npcComposition == null || !npcComposition.isInteractible())
-		{
-			return;
-		}
-		if (!config.highlightDeadNpcs() && actor.isDead())
+		if (npcComposition == null || !npcComposition.isInteractible()
+			|| (actor.isDead() && !config.highlightDeadNpcs()))
 		{
 			return;
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcSceneOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcSceneOverlay.java
@@ -60,7 +60,7 @@ public class NpcSceneOverlay extends Overlay
 
 	static
 	{
-		((DecimalFormat)TIME_LEFT_FORMATTER).applyPattern("#0.0");
+		((DecimalFormat) TIME_LEFT_FORMATTER).applyPattern("#0.0");
 	}
 
 	private final Client client;
@@ -150,7 +150,10 @@ public class NpcSceneOverlay extends Overlay
 		{
 			return;
 		}
-
+		if (!config.highlightDeadNpcs() && actor.isDead())
+		{
+			return;
+		}
 		switch (config.renderStyle())
 		{
 			case SOUTH_WEST_TILE:

--- a/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcSceneOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcSceneOverlay.java
@@ -151,6 +151,7 @@ public class NpcSceneOverlay extends Overlay
 		{
 			return;
 		}
+
 		switch (config.renderStyle())
 		{
 			case SOUTH_WEST_TILE:


### PR DESCRIPTION
Add a toggle to the NPC indicators plugin that stops NPCs being highlighted if they're dead. Notably, doesn't work until the NPC is actually dead (works post-projectile).

[Video example of plugin in action.](https://streamable.com/34ts1j)