### PR TITLE
player-indicators: don't decorate non-player custom menu options

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/MenuAction.java
+++ b/runelite-api/src/main/java/net/runelite/api/MenuAction.java
@@ -272,6 +272,11 @@ public enum MenuAction
 	 * Menu action for configuring runelite overlays.
 	 */
 	RUNELITE_OVERLAY_CONFIG(1502),
+	/**
+	 * Menu action injected by runelite for menu items which target
+	 * a player and have its identifier set to a player index.
+	 */
+	RUNELITE_PLAYER(1503),
 
 	/**
 	 * Menu action triggered when the id is not defined in this class.

--- a/runelite-client/src/main/java/net/runelite/client/menus/MenuManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/menus/MenuManager.java
@@ -253,9 +253,10 @@ public class MenuManager
 	@Subscribe
 	public void onMenuOptionClicked(MenuOptionClicked event)
 	{
-		if (event.getMenuAction() != MenuAction.RUNELITE)
+		if (event.getMenuAction() != MenuAction.RUNELITE
+			&& event.getMenuAction() != MenuAction.RUNELITE_PLAYER)
 		{
-			return; // not a player menu
+			return; // not a managed widget option or custom player option
 		}
 
 		int widgetId = event.getWidgetId();
@@ -294,7 +295,7 @@ public class MenuManager
 	{
 		client.getPlayerOptions()[playerOptionIndex] = menuText;
 		client.getPlayerOptionsPriorities()[playerOptionIndex] = true;
-		client.getPlayerMenuTypes()[playerOptionIndex] = MenuAction.RUNELITE.getId();
+		client.getPlayerMenuTypes()[playerOptionIndex] = MenuAction.RUNELITE_PLAYER.getId();
 
 		playerMenuIndexMap.put(playerOptionIndex, menuText);
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsPlugin.java
@@ -124,7 +124,7 @@ public class PlayerIndicatorsPlugin extends Plugin
 				|| type == PLAYER_SIXTH_OPTION.getId()
 				|| type == PLAYER_SEVENTH_OPTION.getId()
 				|| type == PLAYER_EIGTH_OPTION.getId()
-				|| type == RUNELITE.getId())
+				|| type == RUNELITE_PLAYER.getId())
 			{
 				Player[] players = client.getCachedPlayers();
 				Player player = null;

--- a/runelite-client/src/test/java/net/runelite/client/menus/MenuManagerTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/menus/MenuManagerTest.java
@@ -67,7 +67,7 @@ public class MenuManagerTest
 	public void testPlayerMenuOptionClicked()
 	{
 		MenuOptionClicked event = new MenuOptionClicked();
-		event.setMenuAction(MenuAction.RUNELITE);
+		event.setMenuAction(MenuAction.RUNELITE_PLAYER);
 		event.setMenuTarget("username<col=40ff00>  (level-42)");
 
 		menuManager.onMenuOptionClicked(event);
@@ -82,7 +82,7 @@ public class MenuManagerTest
 	public void testPlayerMenuOptionWithBountyHunterEmblemClicked()
 	{
 		MenuOptionClicked event = new MenuOptionClicked();
-		event.setMenuAction(MenuAction.RUNELITE);
+		event.setMenuAction(MenuAction.RUNELITE_PLAYER);
 		event.setMenuTarget("username<img=20>5<col=40ff00>  (level-42)");
 
 		menuManager.onMenuOptionClicked(event);


### PR DESCRIPTION
Fixes #11448 which appeared because of https://github.com/runelite/runelite/commit/087b2ac9695778464962f6d28b02db7c2e3ae9cd. The issue is that custom menu entries of type RUNELITE are decorated even if they aren't related to a player.

To fix the issue, the MenuAction.RUNELITE menu type is split into RUNELITE and RUNELITE_PLAYER. With RUNELITE_PLAYER being assigned to player options only, the Player Indicators plugin should no longer try to decorate general menu entries such as Edit-tags, and also not the right-click Lookup in chat or other menu entries that aren't player options.

Why this issue wasn't observed before https://github.com/runelite/runelite/commit/087b2ac9695778464962f6d28b02db7c2e3ae9cd: 
The plugin was changed in that commit to use the ClientTick event instead of MenuEntryAdded for going through the menu entries. Custom menu entries don't post a corresponding MenuEntryAdded event when they are added to the menu, so the plugin would not decorate them.