### PR TITLE
Add all other pearl rod animations

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/AnimationID.java
+++ b/runelite-api/src/main/java/net/runelite/api/AnimationID.java
@@ -121,8 +121,11 @@ public final class AnimationID
 	public static final int FISHING_BAREHAND_CAUGHT_TUNA_1 = 6710;
 	public static final int FISHING_BAREHAND_CAUGHT_TUNA_2 = 6711;
 	public static final int FISHING_PEARL_ROD = 8188;
-	public static final int FISHING_PEARL_FLY_ROD = 8192;
-	public static final int FISHING_PEARL_BARBARIAN_ROD = 8193;
+	public static final int FISHING_PEARL_FLY_ROD = 8189;
+	public static final int FISHING_PEARL_BARBARIAN_ROD = 8190;
+	public static final int FISHING_PEARL_ROD_2 = 8191;
+	public static final int FISHING_PEARL_FLY_ROD_2 = 8192;
+	public static final int FISHING_PEARL_BARBARIAN_ROD_2 = 8193;
 	public static final int FISHING_PEARL_OILY_ROD = 6932;
 	public static final int MINING_BRONZE_PICKAXE = 625;
 	public static final int MINING_IRON_PICKAXE = 626;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingOverlay.java
@@ -73,6 +73,9 @@ class FishingOverlay extends OverlayPanel
 		AnimationID.FISHING_PEARL_ROD,
 		AnimationID.FISHING_PEARL_FLY_ROD,
 		AnimationID.FISHING_PEARL_BARBARIAN_ROD,
+		AnimationID.FISHING_PEARL_ROD_2,
+		AnimationID.FISHING_PEARL_FLY_ROD_2,
+		AnimationID.FISHING_PEARL_BARBARIAN_ROD_2,
 		AnimationID.FISHING_PEARL_OILY_ROD);
 
 	private final Client client;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
@@ -205,6 +205,9 @@ public class IdleNotifierPlugin extends Plugin
 			case FISHING_PEARL_ROD:
 			case FISHING_PEARL_FLY_ROD:
 			case FISHING_PEARL_BARBARIAN_ROD:
+			case FISHING_PEARL_ROD_2:
+			case FISHING_PEARL_FLY_ROD_2:
+			case FISHING_PEARL_BARBARIAN_ROD_2:
 			case FISHING_PEARL_OILY_ROD:
 			/* Mining(Normal) */
 			case MINING_BRONZE_PICKAXE:


### PR DESCRIPTION
Closes #11575

There are 2 animations for each pearl rod (except Oily). Usually it
seems that only one is used when actually fishing, which were the ones
present before this commit. However, it seems that Jagex is not
consistent about what animations are used, as Anglerfish fishing uses
the other animation of the normal pearl rod. Given that the other two
exist, and they're technically usable (and can be used as the starting
animation), it's only a matter of time before Jagex accidentally gets
them the wrong way round again, so this is a pre-emptive measure. It
also means that the UI won't show "Not Fishing" for a split second when
casting out.