### PR TITLE
screenshot: fix method for naming quest complete screenshots

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
@@ -598,7 +598,7 @@ public class ScreenshotPlugin extends Plugin
 		Matcher quest_match_final = quest_match_1.matches() ? quest_match_1 : quest_match_2;
 		if (!quest_match_final.matches())
 		{
-			return null;
+			return "Quest(quest not found)";
 		}
 
 		String quest = quest_match_final.group("quest");

--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
@@ -582,6 +582,7 @@ public class ScreenshotPlugin extends Plugin
 	 *
 	 * @return Shortened string in the format "Quest(The Corsair Curse)"
 	 */
+	@VisibleForTesting
 	String parseQuestCompletedWidget()
 	{
 		Widget questChild = client.getWidget(WidgetInfo.QUEST_COMPLETED_NAME_TEXT);
@@ -606,11 +607,11 @@ public class ScreenshotPlugin extends Plugin
 
 		if (verb.contains("kind of"))
 		{
-			quest = quest + " partial completion";
+			quest += " partial completion";
 		}
 		else if (verb.contains("completely"))
 		{
-			quest = quest + " II";
+			quest += " II";
 		}
 
 		if (RFD_TAGS.stream().anyMatch((quest + verb)::contains))
@@ -620,7 +621,7 @@ public class ScreenshotPlugin extends Plugin
 
 		if (WORD_QUEST_IN_NAME_TAGS.stream().anyMatch(quest::contains))
 		{
-			quest = quest + " Quest";
+			quest += " Quest";
 		}
 
 		return "Quest(" + quest + ")";

--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
@@ -242,7 +242,7 @@ public class ScreenshotPlugin extends Plugin
 		}
 		else if (client.getWidget(WidgetInfo.QUEST_COMPLETED_NAME_TEXT) != null)
 		{
-			fileName = parseQuestCompletedWidget();
+			fileName = parseQuestCompletedWidget(client.getWidget(WidgetInfo.QUEST_COMPLETED_NAME_TEXT).getText());
 			screenshotSubDir = "Quests";
 		}
 
@@ -583,27 +583,20 @@ public class ScreenshotPlugin extends Plugin
 	 * @return Shortened string in the format "Quest(The Corsair Curse)"
 	 */
 	@VisibleForTesting
-	String parseQuestCompletedWidget()
+	static String parseQuestCompletedWidget(final String text)
 	{
-		Widget questChild = client.getWidget(WidgetInfo.QUEST_COMPLETED_NAME_TEXT);
-		if (questChild == null)
-		{
-			return null;
-		}
-
-		String text = questChild.getText();
 		// "You have completed The Corsair Curse!"
-		Matcher quest_match_1 = QUEST_PATTERN_1.matcher(text);
+		final Matcher questMatch1 = QUEST_PATTERN_1.matcher(text);
 		// "'One Small Favour' completed!"
-		Matcher quest_match_2 = QUEST_PATTERN_2.matcher(text);
-		Matcher quest_match_final = quest_match_1.matches() ? quest_match_1 : quest_match_2;
-		if (!quest_match_final.matches())
+		final Matcher questMatch2 = QUEST_PATTERN_2.matcher(text);
+		final Matcher questMatchFinal = questMatch1.matches() ? questMatch1 : questMatch2;
+		if (!questMatchFinal.matches())
 		{
 			return "Quest(quest not found)";
 		}
 
-		String quest = quest_match_final.group("quest");
-		String verb = quest_match_final.group("verb") != null ? quest_match_final.group("verb") : "";
+		String quest = questMatchFinal.group("quest");
+		String verb = questMatchFinal.group("verb") != null ? questMatchFinal.group("verb") : "";
 
 		if (verb.contains("kind of"))
 		{
@@ -624,7 +617,7 @@ public class ScreenshotPlugin extends Plugin
 			quest += " Quest";
 		}
 
-		return "Quest(" + quest + ")";
+		return "Quest(" + quest + ')';
 	}
 
 	/**

--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
@@ -242,7 +242,8 @@ public class ScreenshotPlugin extends Plugin
 		}
 		else if (client.getWidget(WidgetInfo.QUEST_COMPLETED_NAME_TEXT) != null)
 		{
-			fileName = parseQuestCompletedWidget(client.getWidget(WidgetInfo.QUEST_COMPLETED_NAME_TEXT).getText());
+			String text = client.getWidget(WidgetInfo.QUEST_COMPLETED_NAME_TEXT).getText();
+			fileName = parseQuestCompletedWidget(text);
 			screenshotSubDir = "Quests";
 		}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
@@ -577,9 +577,9 @@ public class ScreenshotPlugin extends Plugin
 	}
 
 	/**
-	 * Parses a WidgetInfo pointing to the second widget of the quest-completed dialog
-	 * into a shortened string for filename usage.
+	 * Parses the passed quest completion dialog text into a shortened string for filename usage.
 	 *
+	 * @param text The {@link Widget#getText() text} of the {@link WidgetInfo#QUEST_COMPLETED_NAME_TEXT} widget.
 	 * @return Shortened string in the format "Quest(The Corsair Curse)"
 	 */
 	@VisibleForTesting

--- a/runelite-client/src/test/java/net/runelite/client/plugins/screenshot/ScreenshotPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/screenshot/ScreenshotPluginTest.java
@@ -38,8 +38,10 @@ import net.runelite.api.events.WidgetLoaded;
 import net.runelite.api.widgets.Widget;
 import static net.runelite.api.widgets.WidgetID.DIALOG_SPRITE_GROUP_ID;
 import static net.runelite.api.widgets.WidgetID.LEVEL_UP_GROUP_ID;
+import static net.runelite.api.widgets.WidgetID.QUEST_COMPLETED_GROUP_ID;
 import static net.runelite.api.widgets.WidgetInfo.DIALOG_SPRITE_TEXT;
 import static net.runelite.api.widgets.WidgetInfo.LEVEL_UP_LEVEL;
+import static net.runelite.api.widgets.WidgetInfo.QUEST_COMPLETED_NAME_TEXT;
 import net.runelite.client.Notifier;
 import net.runelite.client.config.RuneLiteConfig;
 import net.runelite.client.ui.ClientUI;
@@ -109,6 +111,7 @@ public class ScreenshotPluginTest
 		when(screenshotConfig.screenshotLevels()).thenReturn(true);
 		when(screenshotConfig.screenshotValuableDrop()).thenReturn(true);
 		when(screenshotConfig.screenshotUntradeableDrop()).thenReturn(true);
+		when(screenshotConfig.screenshotRewards()).thenReturn(true);
 	}
 
 	@Test
@@ -238,6 +241,146 @@ public class ScreenshotPluginTest
 
 		WidgetLoaded event = new WidgetLoaded();
 		event.setGroupId(DIALOG_SPRITE_GROUP_ID);
+		screenshotPlugin.onWidgetLoaded(event);
+
+		GameTick tick = new GameTick();
+		screenshotPlugin.onGameTick(tick);
+
+		verify(drawManager).requestNextFrameListener(any(Consumer.class));
+	}
+
+	@Test
+	public void testTheCorsairCurseQuestComplete()
+	{
+		Widget questChild = mock(Widget.class);
+		when(client.getWidget(eq(QUEST_COMPLETED_NAME_TEXT))).thenReturn(questChild);
+
+		when(questChild.getText()).thenReturn("You have completed The Corsair Curse!");
+
+		assertEquals("Quest(The Corsair Curse)", screenshotPlugin.parseQuestCompletedWidget());
+
+		WidgetLoaded event = new WidgetLoaded();
+		event.setGroupId(QUEST_COMPLETED_GROUP_ID);
+		screenshotPlugin.onWidgetLoaded(event);
+
+		GameTick tick = new GameTick();
+		screenshotPlugin.onGameTick(tick);
+
+		verify(drawManager).requestNextFrameListener(any(Consumer.class));
+	}
+
+	@Test
+	public void testOneSmallFavourQuestComplete()
+	{
+		Widget questChild = mock(Widget.class);
+		when(client.getWidget(eq(QUEST_COMPLETED_NAME_TEXT))).thenReturn(questChild);
+
+		when(questChild.getText()).thenReturn("'One Small Favour' completed!");
+
+		assertEquals("Quest(One Small Favour)", screenshotPlugin.parseQuestCompletedWidget());
+
+		WidgetLoaded event = new WidgetLoaded();
+		event.setGroupId(QUEST_COMPLETED_GROUP_ID);
+		screenshotPlugin.onWidgetLoaded(event);
+
+		GameTick tick = new GameTick();
+		screenshotPlugin.onGameTick(tick);
+
+		verify(drawManager).requestNextFrameListener(any(Consumer.class));
+	}
+
+	@Test
+	public void testHazeelCultPcQuestComplete()
+	{
+		Widget questChild = mock(Widget.class);
+		when(client.getWidget(eq(QUEST_COMPLETED_NAME_TEXT))).thenReturn(questChild);
+
+		when(questChild.getText()).thenReturn("You have... kind of... completed the Hazeel Cult Quest!");
+
+		assertEquals("Quest(Hazeel Cult partial completion)", screenshotPlugin.parseQuestCompletedWidget());
+
+		WidgetLoaded event = new WidgetLoaded();
+		event.setGroupId(QUEST_COMPLETED_GROUP_ID);
+		screenshotPlugin.onWidgetLoaded(event);
+
+		GameTick tick = new GameTick();
+		screenshotPlugin.onGameTick(tick);
+
+		verify(drawManager).requestNextFrameListener(any(Consumer.class));
+	}
+
+	@Test
+	public void testRagAndBoneManIIQuestComplete()
+	{
+		Widget questChild = mock(Widget.class);
+		when(client.getWidget(eq(QUEST_COMPLETED_NAME_TEXT))).thenReturn(questChild);
+
+		when(questChild.getText()).thenReturn("You have completely completed Rag and Bone Man!");
+
+		assertEquals("Quest(Rag and Bone Man II)", screenshotPlugin.parseQuestCompletedWidget());
+
+		WidgetLoaded event = new WidgetLoaded();
+		event.setGroupId(QUEST_COMPLETED_GROUP_ID);
+		screenshotPlugin.onWidgetLoaded(event);
+
+		GameTick tick = new GameTick();
+		screenshotPlugin.onGameTick(tick);
+
+		verify(drawManager).requestNextFrameListener(any(Consumer.class));
+	}
+
+	@Test
+	public void testRFDCulinaromancerQuestComplete()
+	{
+		Widget questChild = mock(Widget.class);
+		when(client.getWidget(eq(QUEST_COMPLETED_NAME_TEXT))).thenReturn(questChild);
+
+		when(questChild.getText()).thenReturn("Congratulations! You have defeated the Culinaromancer!");
+
+		assertEquals("Quest(Recipe for Disaster - Culinaromancer)", screenshotPlugin.parseQuestCompletedWidget());
+
+		WidgetLoaded event = new WidgetLoaded();
+		event.setGroupId(QUEST_COMPLETED_GROUP_ID);
+		screenshotPlugin.onWidgetLoaded(event);
+
+		GameTick tick = new GameTick();
+		screenshotPlugin.onGameTick(tick);
+
+		verify(drawManager).requestNextFrameListener(any(Consumer.class));
+	}
+
+	@Test
+	public void testRFDAnotherCooksQuestQuestComplete()
+	{
+		Widget questChild = mock(Widget.class);
+		when(client.getWidget(eq(QUEST_COMPLETED_NAME_TEXT))).thenReturn(questChild);
+
+		when(questChild.getText()).thenReturn("You have completed Another Cook's Quest!");
+
+		assertEquals("Quest(Recipe for Disaster - Another Cook's Quest)", screenshotPlugin.parseQuestCompletedWidget());
+
+		WidgetLoaded event = new WidgetLoaded();
+		event.setGroupId(QUEST_COMPLETED_GROUP_ID);
+		screenshotPlugin.onWidgetLoaded(event);
+
+		GameTick tick = new GameTick();
+		screenshotPlugin.onGameTick(tick);
+
+		verify(drawManager).requestNextFrameListener(any(Consumer.class));
+	}
+
+	@Test
+	public void testDoricsQuestQuestComplete()
+	{
+		Widget questChild = mock(Widget.class);
+		when(client.getWidget(eq(QUEST_COMPLETED_NAME_TEXT))).thenReturn(questChild);
+
+		when(questChild.getText()).thenReturn("You have completed Doric's Quest!");
+
+		assertEquals("Quest(Doric's Quest)", screenshotPlugin.parseQuestCompletedWidget());
+
+		WidgetLoaded event = new WidgetLoaded();
+		event.setGroupId(QUEST_COMPLETED_GROUP_ID);
 		screenshotPlugin.onWidgetLoaded(event);
 
 		GameTick tick = new GameTick();

--- a/runelite-client/src/test/java/net/runelite/client/plugins/screenshot/ScreenshotPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/screenshot/ScreenshotPluginTest.java
@@ -38,7 +38,6 @@ import net.runelite.api.events.WidgetLoaded;
 import net.runelite.api.widgets.Widget;
 import static net.runelite.api.widgets.WidgetID.DIALOG_SPRITE_GROUP_ID;
 import static net.runelite.api.widgets.WidgetID.LEVEL_UP_GROUP_ID;
-import static net.runelite.api.widgets.WidgetID.QUEST_COMPLETED_GROUP_ID;
 import static net.runelite.api.widgets.WidgetInfo.DIALOG_SPRITE_TEXT;
 import static net.runelite.api.widgets.WidgetInfo.LEVEL_UP_LEVEL;
 import static net.runelite.api.widgets.WidgetInfo.QUEST_COMPLETED_NAME_TEXT;
@@ -111,7 +110,6 @@ public class ScreenshotPluginTest
 		when(screenshotConfig.screenshotLevels()).thenReturn(true);
 		when(screenshotConfig.screenshotValuableDrop()).thenReturn(true);
 		when(screenshotConfig.screenshotUntradeableDrop()).thenReturn(true);
-		when(screenshotConfig.screenshotRewards()).thenReturn(true);
 	}
 
 	@Test
@@ -258,15 +256,6 @@ public class ScreenshotPluginTest
 		when(questChild.getText()).thenReturn("You have completed The Corsair Curse!");
 
 		assertEquals("Quest(The Corsair Curse)", screenshotPlugin.parseQuestCompletedWidget());
-
-		WidgetLoaded event = new WidgetLoaded();
-		event.setGroupId(QUEST_COMPLETED_GROUP_ID);
-		screenshotPlugin.onWidgetLoaded(event);
-
-		GameTick tick = new GameTick();
-		screenshotPlugin.onGameTick(tick);
-
-		verify(drawManager).requestNextFrameListener(any(Consumer.class));
 	}
 
 	@Test
@@ -278,15 +267,6 @@ public class ScreenshotPluginTest
 		when(questChild.getText()).thenReturn("'One Small Favour' completed!");
 
 		assertEquals("Quest(One Small Favour)", screenshotPlugin.parseQuestCompletedWidget());
-
-		WidgetLoaded event = new WidgetLoaded();
-		event.setGroupId(QUEST_COMPLETED_GROUP_ID);
-		screenshotPlugin.onWidgetLoaded(event);
-
-		GameTick tick = new GameTick();
-		screenshotPlugin.onGameTick(tick);
-
-		verify(drawManager).requestNextFrameListener(any(Consumer.class));
 	}
 
 	@Test
@@ -298,15 +278,6 @@ public class ScreenshotPluginTest
 		when(questChild.getText()).thenReturn("You have... kind of... completed the Hazeel Cult Quest!");
 
 		assertEquals("Quest(Hazeel Cult partial completion)", screenshotPlugin.parseQuestCompletedWidget());
-
-		WidgetLoaded event = new WidgetLoaded();
-		event.setGroupId(QUEST_COMPLETED_GROUP_ID);
-		screenshotPlugin.onWidgetLoaded(event);
-
-		GameTick tick = new GameTick();
-		screenshotPlugin.onGameTick(tick);
-
-		verify(drawManager).requestNextFrameListener(any(Consumer.class));
 	}
 
 	@Test
@@ -318,15 +289,6 @@ public class ScreenshotPluginTest
 		when(questChild.getText()).thenReturn("You have completely completed Rag and Bone Man!");
 
 		assertEquals("Quest(Rag and Bone Man II)", screenshotPlugin.parseQuestCompletedWidget());
-
-		WidgetLoaded event = new WidgetLoaded();
-		event.setGroupId(QUEST_COMPLETED_GROUP_ID);
-		screenshotPlugin.onWidgetLoaded(event);
-
-		GameTick tick = new GameTick();
-		screenshotPlugin.onGameTick(tick);
-
-		verify(drawManager).requestNextFrameListener(any(Consumer.class));
 	}
 
 	@Test
@@ -338,15 +300,6 @@ public class ScreenshotPluginTest
 		when(questChild.getText()).thenReturn("Congratulations! You have defeated the Culinaromancer!");
 
 		assertEquals("Quest(Recipe for Disaster - Culinaromancer)", screenshotPlugin.parseQuestCompletedWidget());
-
-		WidgetLoaded event = new WidgetLoaded();
-		event.setGroupId(QUEST_COMPLETED_GROUP_ID);
-		screenshotPlugin.onWidgetLoaded(event);
-
-		GameTick tick = new GameTick();
-		screenshotPlugin.onGameTick(tick);
-
-		verify(drawManager).requestNextFrameListener(any(Consumer.class));
 	}
 
 	@Test
@@ -358,15 +311,6 @@ public class ScreenshotPluginTest
 		when(questChild.getText()).thenReturn("You have completed Another Cook's Quest!");
 
 		assertEquals("Quest(Recipe for Disaster - Another Cook's Quest)", screenshotPlugin.parseQuestCompletedWidget());
-
-		WidgetLoaded event = new WidgetLoaded();
-		event.setGroupId(QUEST_COMPLETED_GROUP_ID);
-		screenshotPlugin.onWidgetLoaded(event);
-
-		GameTick tick = new GameTick();
-		screenshotPlugin.onGameTick(tick);
-
-		verify(drawManager).requestNextFrameListener(any(Consumer.class));
 	}
 
 	@Test
@@ -378,14 +322,16 @@ public class ScreenshotPluginTest
 		when(questChild.getText()).thenReturn("You have completed Doric's Quest!");
 
 		assertEquals("Quest(Doric's Quest)", screenshotPlugin.parseQuestCompletedWidget());
+	}
 
-		WidgetLoaded event = new WidgetLoaded();
-		event.setGroupId(QUEST_COMPLETED_GROUP_ID);
-		screenshotPlugin.onWidgetLoaded(event);
+	@Test
+	public void testQuestNotFoundQuestComplete()
+	{
+		Widget questChild = mock(Widget.class);
+		when(client.getWidget(eq(QUEST_COMPLETED_NAME_TEXT))).thenReturn(questChild);
 
-		GameTick tick = new GameTick();
-		screenshotPlugin.onGameTick(tick);
+		when(questChild.getText()).thenReturn("Sins of the Father forgiven!");
 
-		verify(drawManager).requestNextFrameListener(any(Consumer.class));
+		assertEquals("Quest(quest not found)", screenshotPlugin.parseQuestCompletedWidget());
 	}
 }

--- a/runelite-client/src/test/java/net/runelite/client/plugins/screenshot/ScreenshotPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/screenshot/ScreenshotPluginTest.java
@@ -40,7 +40,6 @@ import static net.runelite.api.widgets.WidgetID.DIALOG_SPRITE_GROUP_ID;
 import static net.runelite.api.widgets.WidgetID.LEVEL_UP_GROUP_ID;
 import static net.runelite.api.widgets.WidgetInfo.DIALOG_SPRITE_TEXT;
 import static net.runelite.api.widgets.WidgetInfo.LEVEL_UP_LEVEL;
-import static net.runelite.api.widgets.WidgetInfo.QUEST_COMPLETED_NAME_TEXT;
 import net.runelite.client.Notifier;
 import net.runelite.client.config.RuneLiteConfig;
 import net.runelite.client.ui.ClientUI;
@@ -248,90 +247,15 @@ public class ScreenshotPluginTest
 	}
 
 	@Test
-	public void testTheCorsairCurseQuestComplete()
+	public void testQuestParsing()
 	{
-		Widget questChild = mock(Widget.class);
-		when(client.getWidget(eq(QUEST_COMPLETED_NAME_TEXT))).thenReturn(questChild);
-
-		when(questChild.getText()).thenReturn("You have completed The Corsair Curse!");
-
-		assertEquals("Quest(The Corsair Curse)", screenshotPlugin.parseQuestCompletedWidget());
-	}
-
-	@Test
-	public void testOneSmallFavourQuestComplete()
-	{
-		Widget questChild = mock(Widget.class);
-		when(client.getWidget(eq(QUEST_COMPLETED_NAME_TEXT))).thenReturn(questChild);
-
-		when(questChild.getText()).thenReturn("'One Small Favour' completed!");
-
-		assertEquals("Quest(One Small Favour)", screenshotPlugin.parseQuestCompletedWidget());
-	}
-
-	@Test
-	public void testHazeelCultPcQuestComplete()
-	{
-		Widget questChild = mock(Widget.class);
-		when(client.getWidget(eq(QUEST_COMPLETED_NAME_TEXT))).thenReturn(questChild);
-
-		when(questChild.getText()).thenReturn("You have... kind of... completed the Hazeel Cult Quest!");
-
-		assertEquals("Quest(Hazeel Cult partial completion)", screenshotPlugin.parseQuestCompletedWidget());
-	}
-
-	@Test
-	public void testRagAndBoneManIIQuestComplete()
-	{
-		Widget questChild = mock(Widget.class);
-		when(client.getWidget(eq(QUEST_COMPLETED_NAME_TEXT))).thenReturn(questChild);
-
-		when(questChild.getText()).thenReturn("You have completely completed Rag and Bone Man!");
-
-		assertEquals("Quest(Rag and Bone Man II)", screenshotPlugin.parseQuestCompletedWidget());
-	}
-
-	@Test
-	public void testRFDCulinaromancerQuestComplete()
-	{
-		Widget questChild = mock(Widget.class);
-		when(client.getWidget(eq(QUEST_COMPLETED_NAME_TEXT))).thenReturn(questChild);
-
-		when(questChild.getText()).thenReturn("Congratulations! You have defeated the Culinaromancer!");
-
-		assertEquals("Quest(Recipe for Disaster - Culinaromancer)", screenshotPlugin.parseQuestCompletedWidget());
-	}
-
-	@Test
-	public void testRFDAnotherCooksQuestQuestComplete()
-	{
-		Widget questChild = mock(Widget.class);
-		when(client.getWidget(eq(QUEST_COMPLETED_NAME_TEXT))).thenReturn(questChild);
-
-		when(questChild.getText()).thenReturn("You have completed Another Cook's Quest!");
-
-		assertEquals("Quest(Recipe for Disaster - Another Cook's Quest)", screenshotPlugin.parseQuestCompletedWidget());
-	}
-
-	@Test
-	public void testDoricsQuestQuestComplete()
-	{
-		Widget questChild = mock(Widget.class);
-		when(client.getWidget(eq(QUEST_COMPLETED_NAME_TEXT))).thenReturn(questChild);
-
-		when(questChild.getText()).thenReturn("You have completed Doric's Quest!");
-
-		assertEquals("Quest(Doric's Quest)", screenshotPlugin.parseQuestCompletedWidget());
-	}
-
-	@Test
-	public void testQuestNotFoundQuestComplete()
-	{
-		Widget questChild = mock(Widget.class);
-		when(client.getWidget(eq(QUEST_COMPLETED_NAME_TEXT))).thenReturn(questChild);
-
-		when(questChild.getText()).thenReturn("Sins of the Father forgiven!");
-
-		assertEquals("Quest(quest not found)", screenshotPlugin.parseQuestCompletedWidget());
+		assertEquals("Quest(The Corsair Curse)", ScreenshotPlugin.parseQuestCompletedWidget("You have completed The Corsair Curse!"));
+		assertEquals("Quest(One Small Favour)", ScreenshotPlugin.parseQuestCompletedWidget("'One Small Favour' completed!"));
+		assertEquals("Quest(Hazeel Cult partial completion)", ScreenshotPlugin.parseQuestCompletedWidget("You have... kind of... completed the Hazeel Cult Quest!"));
+		assertEquals("Quest(Rag and Bone Man II)", ScreenshotPlugin.parseQuestCompletedWidget("You have completely completed Rag and Bone Man!"));
+		assertEquals("Quest(Recipe for Disaster - Culinaromancer)", ScreenshotPlugin.parseQuestCompletedWidget("Congratulations! You have defeated the Culinaromancer!"));
+		assertEquals("Quest(Recipe for Disaster - Another Cook's Quest)", ScreenshotPlugin.parseQuestCompletedWidget("You have completed Another Cook's Quest!"));
+		assertEquals("Quest(Doric's Quest)", ScreenshotPlugin.parseQuestCompletedWidget("You have completed Doric's Quest!"));
+		assertEquals("Quest(quest not found)", ScreenshotPlugin.parseQuestCompletedWidget("Sins of the Father forgiven!"));
 	}
 }


### PR DESCRIPTION
Closes #5353. See my original post, since I make references to it here.

I wrote an example solution that applies Option 2 to exception #*1*, #*2* and #*5*, Option 2a to exception #*4*, and Option 1 on the other exceptions. This means there are 2 constants and 4 if blocks worth of extra code from the base solution. When I talk simplicity vs accuracy, I made the file 2 constants and 4 if blocks less simple to make 18 names more accurate, but that begs the question: was that effort worth implementing? I chose these exceptions as a proof of concept of what "extra" code means, and they seemed the most simple to handle. (Some exceptions, using option 2, would use ~~dicts~~ maps, which hinders simplicity quite a bit; I wouldn't prefer to use maps.)