### PR TITLE
Remove respawn indicators in instances

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsPlugin.java
@@ -145,9 +145,9 @@ public class NpcIndicatorsPlugin extends Plugin
 	private List<String> highlights = new ArrayList<>();
 
 	/**
-	 * NPC ids marked with the Tag option, index -> composition id
+	 * NPC ids marked with the Tag option
 	 */
-	private final Map<Integer, Integer> npcTags = new HashMap<>();
+	private final Set<Integer> npcTags = new HashSet<>();
 
 	/**
 	 * Tagged NPCs that spawned this tick, which need to be verified that
@@ -294,7 +294,7 @@ public class NpcIndicatorsPlugin extends Plugin
 		}
 
 		final int id = click.getId();
-		final Integer removedId = npcTags.remove(id);
+		final boolean removed = npcTags.remove(id);
 		final NPC[] cachedNPCs = client.getCachedNPCs();
 		final NPC npc = cachedNPCs[id];
 
@@ -303,7 +303,7 @@ public class NpcIndicatorsPlugin extends Plugin
 			return;
 		}
 
-		if (removedId != null)
+		if (removed)
 		{
 			highlightedNpcs.remove(npc);
 			memorizedNpcs.remove(npc.getIndex());
@@ -311,7 +311,7 @@ public class NpcIndicatorsPlugin extends Plugin
 		else
 		{
 			memorizeNpc(npc);
-			npcTags.put(id, npc.getId());
+			npcTags.add(id);
 			highlightedNpcs.add(npc);
 		}
 
@@ -329,8 +329,7 @@ public class NpcIndicatorsPlugin extends Plugin
 			return;
 		}
 
-		Integer taggedId = npcTags.get(npc.getIndex());
-		if (taggedId != null && taggedId == npc.getId())
+		if (npcTags.contains(npc.getIndex()))
 		{
 			memorizeNpc(npc);
 			highlightedNpcs.add(npc);
@@ -476,8 +475,7 @@ public class NpcIndicatorsPlugin extends Plugin
 				continue;
 			}
 
-			Integer taggedId = npcTags.get(npc.getIndex());
-			if (taggedId != null && taggedId == npc.getId())
+			if (npcTags.contains(npc.getIndex()))
 			{
 				highlightedNpcs.add(npc);
 				continue;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsPlugin.java
@@ -431,6 +431,11 @@ public class NpcIndicatorsPlugin extends Plugin
 
 	private void memorizeNpc(NPC npc)
 	{
+		// NPCs in instances have inconsistent indexes, which breaks timer anyway.
+		if (client.isInInstancedRegion())
+		{
+			return;
+		}
 		final int npcIndex = npc.getIndex();
 		memorizedNpcs.putIfAbsent(npcIndex, new MemorizedNpc(npc));
 	}


### PR DESCRIPTION
Removes respawn timer for NPCs in instances. 

As discussed in #11570 respawn timers for NPCs in instances don't currently work with the plugin, and additionally lead to index collisions (which 01f134795d2b1834d4eb4d720a83ef5be6c75ed6 resolved). Removing indicators for NPCs in instances should resolve both the index collisions, and invalid NPC respawn indicators appearing in instances (notable example being mass-tagged inferno NPCs).

If a clean solution is ever found for making death timers work in instances, it may be worth re-opening #11571 