### PR TITLE
Improve drift net plugin

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/driftnet/DriftNet.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/driftnet/DriftNet.java
@@ -25,10 +25,13 @@
  */
 package net.runelite.client.plugins.driftnet;
 
+import java.util.Set;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
+import lombok.Setter;
 import net.runelite.api.GameObject;
 import net.runelite.api.Varbits;
+import net.runelite.api.coords.WorldPoint;
 
 @Data
 @RequiredArgsConstructor
@@ -37,10 +40,23 @@ class DriftNet
 	private final int objectId;
 	private final Varbits statusVarbit;
 	private final Varbits countVarbit;
+	private final Set<WorldPoint> adjacentTiles;
 
 	private GameObject net;
 	private DriftNetStatus status;
 	private int count;
+	@Setter
+	private DriftNetStatus prevTickStatus;
+
+	// Nets that are not accepting fish are those currently not accepting, or those which were not
+	// accepting in the previous tick. (When a fish shoal is 2 tiles adjacent to a drift net and is
+	// moving to a net that is just being setup it will be denied even though the net is currently
+	// in the CATCHING status)
+	boolean isNotAcceptingFish()
+	{
+		return (status != DriftNetStatus.CATCH && status != DriftNetStatus.SET) ||
+			(prevTickStatus != DriftNetStatus.CATCH && prevTickStatus != DriftNetStatus.SET);
+	}
 
 	String getFormattedCountText()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/driftnet/DriftNetConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/driftnet/DriftNetConfig.java
@@ -76,12 +76,12 @@ public interface DriftNetConfig extends Config
 	)
 	@Range(
 		min = 1,
-		max = 60
+		max = 100
 	)
 	@Units(Units.TICKS)
 	default int timeoutDelay()
 	{
-		return 10;
+		return 60;
 	}
 
 	@ConfigItem(

--- a/runelite-client/src/main/java/net/runelite/client/plugins/driftnet/DriftNetConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/driftnet/DriftNetConfig.java
@@ -94,4 +94,26 @@ public interface DriftNetConfig extends Config
 	{
 		return Color.CYAN;
 	}
+
+	@ConfigItem(
+		keyName = "tagAnnette",
+		name = "Tag Annette when no nets in inventory",
+		description = "Tag Annette when no nets in inventory",
+		position = 6
+	)
+	default boolean tagAnnetteWhenNoNets()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		keyName = "annetteTagColor",
+		name = "Annette tag color",
+		description = "Color of Annette tag",
+		position = 7
+	)
+	default Color annetteTagColor()
+	{
+		return Color.RED;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/driftnet/DriftNetOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/driftnet/DriftNetOverlay.java
@@ -28,6 +28,7 @@ import java.awt.Dimension;
 import java.awt.Graphics2D;
 import java.awt.Shape;
 import javax.inject.Inject;
+import net.runelite.api.GameObject;
 import net.runelite.api.NPC;
 import net.runelite.api.Point;
 import net.runelite.client.ui.overlay.Overlay;
@@ -67,6 +68,10 @@ class DriftNetOverlay extends Overlay
 		{
 			renderNets(graphics);
 		}
+		if (config.tagAnnetteWhenNoNets())
+		{
+			renderAnnette(graphics);
+		}
 
 		return null;
 	}
@@ -99,6 +104,15 @@ class DriftNetOverlay extends Overlay
 			{
 				OverlayUtil.renderTextLocation(graphics, textLocation, text, config.countColor());
 			}
+		}
+	}
+
+	private void renderAnnette(Graphics2D graphics)
+	{
+		GameObject annette = plugin.getAnnette();
+		if (annette != null && !plugin.isDriftNetsInInventory())
+		{
+			OverlayUtil.renderPolygon(graphics, annette.getConvexHull(), config.annetteTagColor());
 		}
 	}
 }


### PR DESCRIPTION
Changes to drift net plugin:
- Only untag fish shoal when tick timeout reached or fish shoal is adjacent to a drift net that is not catching fish (= full or unset). 
You can still sometimes have a shoal that is shown as tagged while it is actually not, this rarely happens so I'm not able to determine how this happens. After the tick timeout it will still become untagged.
- Add option to highlight Annette when no more drift nets are left in inventory.

I don't have a lot of experience with Java so any feedback is appreciated!