### PR TITLE
antidrag: Enable shift-antidrag in PvP regardless of onShiftOnly config

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/antidrag/AntiDragConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/antidrag/AntiDragConfig.java
@@ -46,7 +46,7 @@ public interface AntiDragConfig extends Config
 	@ConfigItem(
 		keyName = "onShiftOnly",
 		name = "On Shift Only",
-		description = "Configures whether to only adjust the delay while holding shift. Required for anti drag in PvP scenarios.",
+		description = "Configures whether to only adjust the delay while holding shift in non-PvP scenarios. Shift is required in PvP regardless of this config setting",
 		position = 2
 	)
 	default boolean onShiftOnly()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/antidrag/AntiDragPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/antidrag/AntiDragPlugin.java
@@ -112,7 +112,7 @@ public class AntiDragPlugin extends Plugin implements KeyListener
 	@Override
 	public void keyPressed(KeyEvent e)
 	{
-		if (e.getKeyCode() == KeyEvent.VK_SHIFT && config.onShiftOnly())
+		if (e.getKeyCode() == KeyEvent.VK_SHIFT && (inPvp || config.onShiftOnly()))
 		{
 			setDragDelay();
 			held = true;
@@ -122,7 +122,7 @@ public class AntiDragPlugin extends Plugin implements KeyListener
 	@Override
 	public void keyReleased(KeyEvent e)
 	{
-		if (e.getKeyCode() == KeyEvent.VK_SHIFT && config.onShiftOnly())
+		if (e.getKeyCode() == KeyEvent.VK_SHIFT && (inPvp || config.onShiftOnly()))
 		{
 			resetDragDelay();
 			held = false;


### PR DESCRIPTION
Currently you need to enable shift-antidrag globally to use the plugin in PvP at all.
This PR instead makes it so shift is still required in PvP, but it is always enabled regardless of the PvM setting.