### PR TITLE
item stats overlay - Limit bank widgets to item containers

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatOverlay.java
@@ -98,7 +98,7 @@ public class ItemStatOverlay extends Overlay
 				|| group == WidgetInfo.EQUIPMENT.getGroupId()
 				|| group == WidgetInfo.EQUIPMENT_INVENTORY_ITEMS_CONTAINER.getGroupId()
 				|| (config.showStatsInBank()
-					&& (group == WidgetInfo.BANK_ITEM_CONTAINER.getGroupId()
+					&& ((group == WidgetInfo.BANK_ITEM_CONTAINER.getGroupId() && child == WidgetInfo.BANK_ITEM_CONTAINER.getChildId())
 						|| group == WidgetInfo.BANK_INVENTORY_ITEMS_CONTAINER.getGroupId()))))
 		{
 			return null;


### PR DESCRIPTION
Fixes #11563

This also fixes the unintended feature where hovering over a bank tab with an item set as its image would display the item stats.

Before:
![Cbm7TO7QZ6](https://user-images.githubusercontent.com/29030969/82041862-b91c8380-965d-11ea-8691-5ada6c687c2c.gif)

After:
![7J4qeMZv01](https://user-images.githubusercontent.com/29030969/82041755-8a9ea880-965d-11ea-89bb-e5efbc3dfd0f.gif)
