### PR TITLE
raid plugin: fix plugin not reseting in niche case

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/VarPlayer.java
+++ b/runelite-api/src/main/java/net/runelite/api/VarPlayer.java
@@ -54,6 +54,15 @@ public enum VarPlayer
 	SPECIAL_ATTACK_PERCENT(300),
 	SPECIAL_ATTACK_ENABLED(301),
 
+	/**
+	 * The ID of the party. This Var is only set in the raid bank area and the raid lobby
+	 *
+	 * This gets set to -1 when the raid starts. This is first set when the first player of the clan forms a party
+	 * on the recruiting board and it changes again when the first person actually enters the raid.
+	 *
+	 * -1 : Not in a party or in the middle of an ongoing raid
+	 * Anything else : This means that your clan has a raid party being formed and has not started yet
+	 */
 	IN_RAID_PARTY(1427),
 
 	NMZ_REWARD_POINTS(1060),

--- a/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsOverlay.java
@@ -222,6 +222,6 @@ public class RaidsOverlay extends OverlayPanel
 			}
 		}
 
-		return plugin.isInRaidParty() && config.scoutOverlayAtBank();
+		return plugin.getRaidPartyID() != -1 && config.scoutOverlayAtBank();
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsPlugin.java
@@ -199,11 +199,14 @@ public class RaidsPlugin extends Plugin
 	@Getter
 	private boolean inRaidChambers;
 
-	// if the player is in a raid party or not
-	// This will be set when someone in the clan chat clicks the "make party button on the raids widget
-	// It will be reset when the raid ends but not if they leave the raid while it has not started yet
+	/*
+	 * if the player is in a raid party or not
+	 * This will be set when someone in the clan chat clicks the "make party" button on the raids widget
+	 * It will change again when someone from your clan enters the raid to generate it
+	 * It will be reset when the raid starts but not if they leave the raid while it has not started yet
+	 */
 	@Getter
-	private boolean inRaidParty;
+	private int raidPartyID;
 
 	private boolean chestOpened;
 	private RaidsTimer timer;
@@ -301,21 +304,20 @@ public class RaidsPlugin extends Plugin
 	@Subscribe
 	public void onVarbitChanged(VarbitChanged event)
 	{
-		boolean tempInParty = client.getVar(VarPlayer.IN_RAID_PARTY) != -1;
+		int tempPartyID = client.getVar(VarPlayer.IN_RAID_PARTY);
 		boolean tempInRaid = client.getVar(Varbits.IN_RAID) == 1;
 
 		// if the player's party state has changed
-		if (tempInParty != inRaidParty)
+		if (tempPartyID != raidPartyID)
 		{
-			// if the player is no longer in a party then reset
-			if (!tempInParty
-				&& loggedIn
+			// if the player is outside of a raid when the party state changed
+			if (loggedIn
 				&& !tempInRaid)
 			{
 				reset();
 			}
 
-			inRaidParty = tempInParty;
+			raidPartyID = tempPartyID;
 		}
 
 		// if the player's raid state has changed
@@ -449,7 +451,7 @@ public class RaidsPlugin extends Plugin
 			}
 			else
 			{
-				if (!inRaidParty)
+				if (raidPartyID == -1)
 				{
 					reset();
 				}


### PR DESCRIPTION
steps to reproduce:
start a raid on account 1
scout another raid in the same world on account 2
leave the raid on account 1 and it will not reset correctly


Also, this case did not happen consistently because in order to happen the raid party varp had to get set before the first game tick after you loaded outside of the raid. This seemed pretty random so ti was hard to test but the bug never happened after testing for like 10 mins on this branch so it is probably fine.

clip of bug happening which is how we knew how to reproduce the bug https://clips.twitch.tv/ResoluteElegantDolphinYouDontSay