### PR TITLE
ClientUI: Add support for changing window opacity.

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/config/RuneLiteConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/RuneLiteConfig.java
@@ -103,11 +103,26 @@ public interface RuneLiteConfig extends Config
 		return true;
 	}
 
+	@Range(
+		min = 10,
+		max = 100
+	)
+	@ConfigItem(
+		keyName = "uiWindowOpacity",
+		name = "Window opacity",
+		description = "Set the windows opacity. Requires \"Enable custom window chrome\" to be enabled.",
+		position = 16
+	)
+	default int windowOpacity()
+	{
+		return 100;
+	}
+
 	@ConfigItem(
 		keyName = "gameAlwaysOnTop",
 		name = "Enable client always on top",
 		description = "The game will always be on the top of the screen",
-		position = 16
+		position = 17
 	)
 	default boolean gameAlwaysOnTop()
 	{
@@ -118,7 +133,7 @@ public interface RuneLiteConfig extends Config
 		keyName = "warningOnExit",
 		name = "Display warning on exit",
 		description = "Toggles a warning popup when trying to exit the client",
-		position = 17
+		position = 18
 	)
 	default WarningOnExit warningOnExit()
 	{
@@ -129,7 +144,7 @@ public interface RuneLiteConfig extends Config
 		keyName = "usernameInTitle",
 		name = "Show display name in title",
 		description = "Toggles displaying of local player's display name in client title",
-		position = 18
+		position = 19
 	)
 	default boolean usernameInTitle()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
@@ -979,7 +979,7 @@ public class ClientUI
 			return;
 		}
 
-		// Update window opacity iff the frame is undecorated, translucency capable and not fullscreen
+		// Update window opacity if the frame is undecorated, translucency capable and not fullscreen
 		if (frame.isUndecorated() &&
 			frame.getGraphicsConfiguration().isTranslucencyCapable() &&
 			frame.getGraphicsConfiguration().getDevice().getFullScreenWindow() == null)

--- a/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
@@ -161,25 +161,11 @@ public class ClientUI
 	@Subscribe
 	public void onConfigChanged(ConfigChanged event)
 	{
-		if (!event.getGroup().equals("runelite") ||
+		if (!event.getGroup().equals(CONFIG_GROUP) ||
 			event.getKey().equals(CONFIG_CLIENT_MAXIMIZED) ||
 			event.getKey().equals(CONFIG_CLIENT_BOUNDS))
 		{
 			return;
-		}
-
-		// Update window opacity iff the frame is undecorated, translucency capable and not fullscreen
-		if (event.getGroup().equals(CONFIG_GROUP) && event.getKey().equals("uiWindowOpacity"))
-		{
-			SwingUtilities.invokeLater(() ->
-			{
-				if (frame.isUndecorated() &&
-					frame.getGraphicsConfiguration().isTranslucencyCapable() &&
-					frame.getGraphicsConfiguration().getDevice().getFullScreenWindow() == null)
-				{
-					frame.setOpacity((float) Integer.parseInt(event.getNewValue()) / 100.0f);
-				}
-			});
 		}
 
 		SwingUtilities.invokeLater(() -> updateFrameConfig(event.getKey().equals("lockWindowSize")));
@@ -430,13 +416,6 @@ public class ClientUI
 			// Decorate window with custom chrome and titlebar if needed
 			withTitleBar = config.enableCustomChrome();
 			frame.setUndecorated(withTitleBar);
-
-			if (frame.isUndecorated() &&
-				frame.getGraphicsConfiguration().isTranslucencyCapable() &&
-				frame.getGraphicsConfiguration().getDevice().getFullScreenWindow() == null)
-			{
-				frame.setOpacity(((float) config.windowOpacity()) / 100.0f);
-			}
 
 			if (withTitleBar)
 			{
@@ -998,6 +977,14 @@ public class ClientUI
 		if (frame == null)
 		{
 			return;
+		}
+
+		// Update window opacity iff the frame is undecorated, translucency capable and not fullscreen
+		if (frame.isUndecorated() &&
+			frame.getGraphicsConfiguration().isTranslucencyCapable() &&
+			frame.getGraphicsConfiguration().getDevice().getFullScreenWindow() == null)
+		{
+			frame.setOpacity(((float) config.windowOpacity()) / 100.0f);
 		}
 
 		if (config.usernameInTitle() && (client instanceof Client))

--- a/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
@@ -168,6 +168,20 @@ public class ClientUI
 			return;
 		}
 
+		// Update window opacity iff the frame is undecorated, translucency capable and not fullscreen
+		if (event.getGroup().equals(CONFIG_GROUP) && event.getKey().equals("uiWindowOpacity"))
+		{
+			SwingUtilities.invokeLater(() ->
+			{
+				if (frame.isUndecorated() &&
+					frame.getGraphicsConfiguration().isTranslucencyCapable() &&
+					frame.getGraphicsConfiguration().getDevice().getFullScreenWindow() == null)
+				{
+					frame.setOpacity((float) Integer.parseInt(event.getNewValue()) / 100.0f);
+				}
+			});
+		}
+
 		SwingUtilities.invokeLater(() -> updateFrameConfig(event.getKey().equals("lockWindowSize")));
 	}
 
@@ -416,6 +430,13 @@ public class ClientUI
 			// Decorate window with custom chrome and titlebar if needed
 			withTitleBar = config.enableCustomChrome();
 			frame.setUndecorated(withTitleBar);
+
+			if (frame.isUndecorated() &&
+				frame.getGraphicsConfiguration().isTranslucencyCapable() &&
+				frame.getGraphicsConfiguration().getDevice().getFullScreenWindow() == null)
+			{
+				frame.setOpacity(((float) config.windowOpacity()) / 100.0f);
+			}
 
 			if (withTitleBar)
 			{


### PR DESCRIPTION
Uses JFrames builtin setOpacity method to set window opacity. Requires  the frame to be undecorated and thus requires the custom window chrome option to be enabled.

Adds a new config entry to the RuneLite config group.
The opacity is limited from 10-100% as anything below 10% would make it near impossible to change it back.

Only tested on Windows, but the implementation avoids setting the window opacity if it is not supported by the system.

Screenshots:

100% opacity
![a20vgW36Jt](https://user-images.githubusercontent.com/1338340/82126877-dbbeb180-97af-11ea-885e-0ceaff5a30e3.png)

75% opacity
![FNKwdnyOJG](https://user-images.githubusercontent.com/1338340/82126881-e37e5600-97af-11ea-81c6-a5dec3cb1c4e.png)

10% opacity
![uugVD6EboK](https://user-images.githubusercontent.com/1338340/82126886-e711dd00-97af-11ea-8611-9424b4e98dd2.png)
