### PR TITLE
npcunaggroarea: split color config depending on timer status

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/npcunaggroarea/NpcAggroAreaConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npcunaggroarea/NpcAggroAreaConfig.java
@@ -25,6 +25,7 @@
 package net.runelite.client.plugins.npcunaggroarea;
 
 import java.awt.Color;
+import net.runelite.client.config.Alpha;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
@@ -83,21 +84,34 @@ public interface NpcAggroAreaConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "npcUnaggroAreaColor",
-		name = "Area lines colour",
-		description = "Choose colour to use for marking NPC unaggressive area",
+		keyName = "npcAggroAreaColor",
+		name = "Aggressive colour",
+		description = "Choose colour to use for marking NPC unaggressive area when NPCs are aggressive",
 		position = 5
 	)
+	@Alpha
 	default Color aggroAreaColor()
 	{
-		return Color.YELLOW;
+		return new Color(0x64FFFF00, true);
+	}
+
+	@ConfigItem(
+		keyName = "npcUnaggroAreaColor",
+		name = "Unaggressive colour",
+		description = "Choose colour to use for marking NPC unaggressive area after NPCs have lost aggression",
+		position = 6
+	)
+	@Alpha
+	default Color unaggroAreaColor()
+	{
+		return new Color(0xFFFF00);
 	}
 
 	@ConfigItem(
 		keyName = "notifyExpire",
 		name = "Notify Expiration",
 		description = "Send a notifcation when the unaggressive timer expires",
-		position = 6
+		position = 7
 	)
 	default boolean notifyExpire()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/npcunaggroarea/NpcAggroAreaOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npcunaggroarea/NpcAggroAreaOverlay.java
@@ -76,15 +76,11 @@ class NpcAggroAreaOverlay extends Overlay
 			return null;
 		}
 
-		Color outlineColor = config.aggroAreaColor();
+		Color outlineColor = config.unaggroAreaColor();
 		AggressionTimer timer = plugin.getCurrentTimer();
-		if (timer == null || Instant.now().compareTo(timer.getEndTime()) < 0)
+		if (outlineColor == null || timer == null || Instant.now().compareTo(timer.getEndTime()) < 0)
 		{
-			outlineColor = new Color(
-				outlineColor.getRed(),
-				outlineColor.getGreen(),
-				outlineColor.getBlue(),
-				100);
+			outlineColor = config.aggroAreaColor();
 		}
 
 		renderPath(graphics, lines, outlineColor);


### PR DESCRIPTION
This allows you to hide the overlay entirely while NPCs are aggressive, e.g. if you are slaying.