### PR TITLE
Add a check for if chat is focused to consume key typed events

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/keyremapping/KeyRemappingListener.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/keyremapping/KeyRemappingListener.java
@@ -59,7 +59,7 @@ class KeyRemappingListener implements KeyListener
 	public void keyTyped(KeyEvent e)
 	{
 		char keyChar = e.getKeyChar();
-		if (keyChar != KeyEvent.CHAR_UNDEFINED && blockedChars.contains(keyChar))
+		if (keyChar != KeyEvent.CHAR_UNDEFINED && blockedChars.contains(keyChar) && plugin.chatboxFocused())
 		{
 			e.consume();
 		}


### PR DESCRIPTION
Fixes #11578 

This PR makes it so that when keys are remapped and pressed. They still fire the unmapped key press when the chatbox is not focused.

This allows players to "pre-press" menu options by holding them down before the menu is opened. 