### PR TITLE
bank tags: clear remembered search when the active tag tab is clicked

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/banktags/tabs/TabInterface.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/banktags/tabs/TabInterface.java
@@ -406,6 +406,7 @@ public class TabInterface
 				if (tab.equals(activeTab))
 				{
 					bankSearch.reset(true);
+					rememberedSearch = "";
 
 					clientThread.invokeLater(() -> client.runScript(ScriptID.MESSAGE_LAYER_CLOSE, 0, 0));
 				}


### PR DESCRIPTION
This fixes an issue where the tab would reactivate if you clicked the active tab while the withdraw-x dialog was open. This was caused by the handling for withdraw-x, which activates the tab again a tick after the withdraw-x dialog is closed.