### PR TITLE
Reset metronome tick count when toggled on.

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/metronome/MetronomePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/metronome/MetronomePlugin.java
@@ -59,7 +59,7 @@ public class MetronomePlugin extends Plugin
 	}
 
 	@Override
-	protected void startUp()
+	protected void shutDown()
 	{
 		tickCounter = 0;
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/metronome/MetronomePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/metronome/MetronomePlugin.java
@@ -57,6 +57,7 @@ public class MetronomePlugin extends Plugin
 	{
 		return configManager.getConfig(MetronomePluginConfiguration.class);
 	}
+
 	@Override
 	protected void startUp()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/metronome/MetronomePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/metronome/MetronomePlugin.java
@@ -57,6 +57,11 @@ public class MetronomePlugin extends Plugin
 	{
 		return configManager.getConfig(MetronomePluginConfiguration.class);
 	}
+	@Override
+	protected void startUp()
+	{
+		tickCounter = 0;
+	}
 
 	@Subscribe
 	public void onGameTick(GameTick tick)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/metronome/MetronomePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/metronome/MetronomePlugin.java
@@ -62,6 +62,7 @@ public class MetronomePlugin extends Plugin
 	protected void shutDown()
 	{
 		tickCounter = 0;
+		shouldTock = false;
 	}
 
 	@Subscribe


### PR DESCRIPTION
When the metronome is set to a high tick count and toggled off, the counter is left paused. When the plugin is resumed, the metronome will 'tick' after the remaining number of game ticks. 

This change resets the counter when it is toggled back on to allow the full # of game ticks set before another 'tick'.