### PR TITLE
Add checkbox for allowing notification sending for boosted stats.

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/boosts/BoostsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/boosts/BoostsConfig.java
@@ -111,4 +111,12 @@ public interface BoostsConfig extends Config
 	{
 		return 0;
 	}
+
+	@ConfigItem(
+		keyName = "enableBoostNotificationSending",
+		name = "Enable boost notification sending",
+		description = "Configures whether or not a notification will be sent for boosted stats.",
+		position = 7
+	)
+	default boolean enableBoostNotificationSending() { return true; }
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/boosts/BoostsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/boosts/BoostsConfig.java
@@ -103,8 +103,8 @@ public interface BoostsConfig extends Config
 
 	@ConfigItem(
 		keyName = "boostThreshold",
-		name = "Boost Amount Threshold",
-		description = "The amount of levels boosted to send a notification at. A value of 0 will disable notification.",
+		name = "Boost amount threshold",
+		description = "The amount of levels boosted to display then in different color. A value of 0 will disable the feature.",
 		position = 6
 	)
 	default int boostThreshold()
@@ -113,12 +113,12 @@ public interface BoostsConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "enableBoostNotificationSending",
-		name = "Enable boost notification sending",
+		keyName = "notifyOnBoost",
+		name = "Notify on boost threshold",
 		description = "Configures whether or not a notification will be sent for boosted stats.",
 		position = 7
 	)
-	default boolean enableBoostNotificationSending()
+	default boolean notifyOnBoost()
 	{
 		return true;
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/boosts/BoostsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/boosts/BoostsConfig.java
@@ -118,5 +118,8 @@ public interface BoostsConfig extends Config
 		description = "Configures whether or not a notification will be sent for boosted stats.",
 		position = 7
 	)
-	default boolean enableBoostNotificationSending() { return true; }
+	default boolean enableBoostNotificationSending()
+	{
+		return true;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/boosts/BoostsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/boosts/BoostsPlugin.java
@@ -208,9 +208,8 @@ public class BoostsPlugin extends Plugin
 		updateBoostedStats();
 
 		int boostThreshold = config.boostThreshold();
-		boolean enableBoostNotification = config.enableBoostNotificationSending();
 
-		if (boostThreshold != 0 && enableBoostNotification)
+		if (boostThreshold != 0 && config.notifyOnBoost())
 		{
 			int real = client.getRealSkillLevel(skill);
 			int lastBoost = last - real;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/boosts/BoostsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/boosts/BoostsPlugin.java
@@ -215,8 +215,6 @@ public class BoostsPlugin extends Plugin
 			int real = client.getRealSkillLevel(skill);
 			int lastBoost = last - real;
 			int boost = cur - real;
-			System.out.println("Time: " + System.currentTimeMillis() + ",  lastBoost: " + lastBoost + ", curBoost: " + boost);
-			System.out.println((boost <= boostThreshold) + " and " + (boostThreshold < lastBoost));
 			if (boost <= boostThreshold && boostThreshold < lastBoost)
 			{
 				notifier.notify(skill.getName() + " level is getting low!");

--- a/runelite-client/src/main/java/net/runelite/client/plugins/boosts/BoostsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/boosts/BoostsPlugin.java
@@ -208,12 +208,15 @@ public class BoostsPlugin extends Plugin
 		updateBoostedStats();
 
 		int boostThreshold = config.boostThreshold();
+		boolean enableBoostNotification = config.enableBoostNotificationSending();
 
-		if (boostThreshold != 0)
+		if (boostThreshold != 0 && enableBoostNotification)
 		{
 			int real = client.getRealSkillLevel(skill);
 			int lastBoost = last - real;
 			int boost = cur - real;
+			System.out.println("Time: " + System.currentTimeMillis() + ",  lastBoost: " + lastBoost + ", curBoost: " + boost);
+			System.out.println((boost <= boostThreshold) + " and " + (boostThreshold < lastBoost));
 			if (boost <= boostThreshold && boostThreshold < lastBoost)
 			{
 				notifier.notify(skill.getName() + " level is getting low!");


### PR DESCRIPTION
Closes #11665 

I have added a checkbox in the Boosts Information plugin to enable/disable notification sending. A value of 0 will still disable notification.