### PR TITLE
Loot Tracker: Removes CoX Duplicate Tracking Events

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
@@ -368,7 +368,7 @@ public class LootTrackerPlugin extends Plugin
 	@Subscribe
 	public void onGameStateChanged(final GameStateChanged event)
 	{
-		if (event.getGameState() == GameState.LOADING)
+		if (event.getGameState() == GameState.LOADING && !client.isInInstancedRegion())
 		{
 			chestLooted = false;
 		}


### PR DESCRIPTION
Closes #11114 .

Seeing as this is something only one individual seems to come across, it's very hard to test whether or not this FULLY works to resolve the duplicate problem, though I don't believe this additional check is going to hurt any.

Logistics behind the reasoning on why this should fix it:
- CoX and ToB are the only two chest-related tracking events that get scanned through, currently.
- CoX and ToB are both 'Instanced Regions'
- Whenever you leave CoX or ToB, you are no longer in an instanced region and it should flag the loading gamestate event, which is what the prior check solely relied on to reset the chestLooted variable.

I doubt you anyone _should_ be able to get a duplicate entry past this.. but.. here this is.

I HAVE tested that it works in CoX by doing a completion and it does successfully still track the loot there.