### PR TITLE
screenshot: add a seperate config option for LMS

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotConfig.java
@@ -133,10 +133,21 @@ public interface ScreenshotConfig extends Config
 	}
 
 	@ConfigItem(
+			keyName = "lmskills",
+			name = "Screenshot LMS Kills",
+			description = "Configures whether or not screenshots are automatically taken of LMS kills",
+			position = 9
+	)
+	default boolean screenshotLMSKills()
+	{
+		return false;
+	}
+
+	@ConfigItem(
 		keyName = "boss",
 		name = "Screenshot Boss Kills",
 		description = "Configures whether or not screenshots are automatically taken of boss kills",
-		position = 9
+		position = 10
 	)
 	default boolean screenshotBossKills()
 	{
@@ -147,7 +158,7 @@ public interface ScreenshotConfig extends Config
 		keyName = "playerDeath",
 		name = "Screenshot Deaths",
 		description = "Configures whether or not screenshots are automatically taken when you die.",
-		position = 10
+		position = 11
 	)
 	default boolean screenshotPlayerDeath()
 	{
@@ -158,7 +169,7 @@ public interface ScreenshotConfig extends Config
 		keyName = "friendDeath",
 		name = "Screenshot Friend Deaths",
 		description = "Configures whether or not screenshots are automatically taken when friends or clan members die.",
-		position = 11
+		position = 12
 	)
 	default boolean screenshotFriendDeath()
 	{
@@ -169,7 +180,7 @@ public interface ScreenshotConfig extends Config
 		keyName = "duels",
 		name = "Screenshot Duels",
 		description = "Configures whether or not screenshots are automatically taken of the duel end screen.",
-		position = 12
+		position = 13
 	)
 	default boolean screenshotDuels()
 	{
@@ -180,7 +191,7 @@ public interface ScreenshotConfig extends Config
 		keyName = "valuableDrop",
 		name = "Screenshot Valuable drops",
 		description = "Configures whether or not screenshots are automatically taken when you receive a valuable drop.",
-		position = 13
+		position = 14
 	)
 	default boolean screenshotValuableDrop()
 	{
@@ -191,7 +202,7 @@ public interface ScreenshotConfig extends Config
 		keyName = "untradeableDrop",
 		name = "Screenshot Untradeable drops",
 		description = "Configures whether or not screenshots are automatically taken when you receive an untradeable drop.",
-		position = 14
+		position = 15
 	)
 	default boolean screenshotUntradeableDrop()
 	{
@@ -202,7 +213,7 @@ public interface ScreenshotConfig extends Config
 		keyName = "ccKick",
 		name = "Screenshot Kicks from CC",
 		description = "Take a screenshot when you kick a user from a clan chat.",
-		position = 15
+		position = 16
 	)
 	default boolean screenshotCcKick()
 	{
@@ -213,7 +224,7 @@ public interface ScreenshotConfig extends Config
 		keyName = "hotkey",
 		name = "Screenshot hotkey",
 		description = "When you press this key a screenshot will be taken",
-		position = 16
+		position = 17
 	)
 	default Keybind hotkey()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
@@ -27,6 +27,7 @@ package net.runelite.client.plugins.screenshot;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.inject.Provides;
 import java.awt.Graphics;
 import java.awt.Image;
@@ -34,6 +35,7 @@ import java.awt.image.BufferedImage;
 import java.lang.reflect.InvocationTargetException;
 import java.time.LocalDate;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Consumer;
 import java.util.regex.Matcher;
@@ -83,6 +85,7 @@ import net.runelite.client.util.ImageCapture;
 import net.runelite.client.util.ImageUtil;
 import net.runelite.client.util.LinkBrowser;
 import net.runelite.client.util.Text;
+import org.apache.commons.lang3.ArrayUtils;
 
 @PluginDescriptor(
 	name = "Screenshot",
@@ -102,6 +105,7 @@ public class ScreenshotPlugin extends Plugin
 	private static final Pattern VALUABLE_DROP_PATTERN = Pattern.compile(".*Valuable drop: ([^<>]+)(?:</col>)?");
 	private static final Pattern UNTRADEABLE_DROP_PATTERN = Pattern.compile(".*Untradeable drop: ([^<>]+)(?:</col>)?");
 	private static final Pattern DUEL_END_PATTERN = Pattern.compile("You have now (won|lost) ([0-9]+) duels?\\.");
+	private static final Set<Integer> LAST_MAN_STANDING_REGIONS = ImmutableSet.of(13617, 13658, 13659, 13660, 13914, 13915, 13916);
 	private static final ImmutableList<String> PET_MESSAGES = ImmutableList.of("You have a funny feeling like you're being followed",
 		"You feel something weird sneaking into your backpack",
 		"You have a funny feeling like you would have been followed");
@@ -267,7 +271,15 @@ public class ScreenshotPlugin extends Plugin
 	@Subscribe
 	public void onPlayerLootReceived(final PlayerLootReceived playerLootReceived)
 	{
-		if (config.screenshotKills())
+		if (config.screenshotKills() && !isAtLMS())
+		{
+			final Player player = playerLootReceived.getPlayer();
+			final String name = player.getName();
+			String fileName = "Kill " + name;
+			takeScreenshot(fileName, "PvP Kills");
+		}
+
+		if (config.screenshotLMSKills() && isAtLMS())
 		{
 			final Player player = playerLootReceived.getPlayer();
 			final String name = player.getName();
@@ -275,6 +287,8 @@ public class ScreenshotPlugin extends Plugin
 			takeScreenshot(fileName, "PvP Kills");
 		}
 	}
+
+
 
 	@Subscribe
 	public void onScriptCallbackEvent(ScriptCallbackEvent e)
@@ -646,6 +660,20 @@ public class ScreenshotPlugin extends Plugin
 			&& this.client.getMapRegions().length > 0
 			&& (this.client.getMapRegions()[0] == GAUNTLET_REGION
 			|| this.client.getMapRegions()[0] == CORRUPTED_GAUNTLET_REGION);
+	}
+
+	boolean isAtLMS()
+	{
+		final int[] mapRegions = client.getMapRegions();
+
+		for (int region : LAST_MAN_STANDING_REGIONS)
+		{
+			if (ArrayUtils.contains(mapRegions, region))
+			{
+				return true;
+			}
+		}
+		return false;
 	}
 
 	@VisibleForTesting


### PR DESCRIPTION
Adds a seperate config option to the screenshot plugin for LMS kills. These changes would prevent LMS kill screenshots from being taken when only the PVP option is selected.