### PR TITLE
chat: Add chat notification for Jagex broadcast

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatnotifications/ChatNotificationsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatnotifications/ChatNotificationsConfig.java
@@ -97,4 +97,15 @@ public interface ChatNotificationsConfig extends Config
 	{
 		return false;
 	}
+
+	@ConfigItem(
+		position = 6,
+		keyName = "notifyOnBroadcast",
+		name = "Notify on broadcast",
+		description = "Notifies you whenever you receive a broadcast message"
+	)
+	default boolean notifyOnBroadcast()
+	{
+		return false;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatnotifications/ChatNotificationsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatnotifications/ChatNotificationsPlugin.java
@@ -144,6 +144,22 @@ public class ChatNotificationsPlugin extends Plugin
 					notifier.notify(chatMessage.getMessage());
 				}
 				break;
+			case BROADCAST:
+				if (config.notifyOnBroadcast())
+				{
+					// Some broadcasts have links attached, notated by `|` followed by a number, while others contain color tags.
+					// We don't want to see either in the printed notification.
+					String broadcast = chatMessage.getMessage();
+
+					int urlTokenIndex = broadcast.lastIndexOf('|');
+					if (urlTokenIndex != -1)
+					{
+						broadcast = broadcast.substring(0, urlTokenIndex);
+					}
+
+					notifier.notify(Text.removeFormattingTags(broadcast));
+				}
+				break;
 			case CONSOLE:
 				// Don't notify for notification messages
 				if (chatMessage.getName().equals(RuneLiteProperties.getTitle()))

--- a/runelite-client/src/main/java/net/runelite/client/plugins/emojis/EmojiPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/emojis/EmojiPlugin.java
@@ -26,7 +26,6 @@ package net.runelite.client.plugins.emojis;
 
 import java.awt.image.BufferedImage;
 import java.util.Arrays;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
@@ -46,6 +45,7 @@ import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.util.ImageUtil;
+import net.runelite.client.util.Text;
 
 @PluginDescriptor(
 	name = "Emojis",
@@ -55,7 +55,6 @@ import net.runelite.client.util.ImageUtil;
 @Slf4j
 public class EmojiPlugin extends Plugin
 {
-	private static final Pattern TAG_REGEXP = Pattern.compile("<[^>]*>");
 	private static final Pattern WHITESPACE_REGEXP = Pattern.compile("[\\s\\u00A0]");
 
 	@Inject
@@ -179,7 +178,7 @@ public class EmojiPlugin extends Plugin
 		for (int i = 0; i < messageWords.length; i++)
 		{
 			// Remove tags except for <lt> and <gt>
-			final String trigger = removeTags(messageWords[i]);
+			final String trigger = Text.removeFormattingTags(messageWords[i]);
 			final Emoji emoji = Emoji.getEmoji(trigger);
 
 			if (emoji == null)
@@ -200,30 +199,5 @@ public class EmojiPlugin extends Plugin
 		}
 
 		return Strings.join(messageWords, " ");
-	}
-
-	/**
-	 * Remove tags, except for &lt;lt&gt; and &lt;gt&gt;
-	 *
-	 * @return
-	 */
-	private static String removeTags(String str)
-	{
-		StringBuffer stringBuffer = new StringBuffer();
-		Matcher matcher = TAG_REGEXP.matcher(str);
-		while (matcher.find())
-		{
-			matcher.appendReplacement(stringBuffer, "");
-			String match = matcher.group(0);
-			switch (match)
-			{
-				case "<lt>":
-				case "<gt>":
-					stringBuffer.append(match);
-					break;
-			}
-		}
-		matcher.appendTail(stringBuffer);
-		return stringBuffer.toString();
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/util/Text.java
+++ b/runelite-client/src/main/java/net/runelite/client/util/Text.java
@@ -30,6 +30,7 @@ import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
 import java.util.Collection;
 import java.util.List;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.apache.commons.text.WordUtils;
 import org.apache.commons.text.similarity.JaroWinklerDistance;
@@ -81,6 +82,32 @@ public class Text
 	public static String removeTags(String str)
 	{
 		return TAG_REGEXP.matcher(str).replaceAll("");
+	}
+
+	/**
+	 * Remove tags from the given string, except for &lt;lt&gt; and &lt;gt&gt;
+	 *
+	 * @param str The string to remove formatting tags from.
+	 * @return The given string with all formatting tags removed from it.
+	 */
+	public static String removeFormattingTags(String str)
+	{
+		StringBuffer stringBuffer = new StringBuffer();
+		Matcher matcher = TAG_REGEXP.matcher(str);
+		while (matcher.find())
+		{
+			matcher.appendReplacement(stringBuffer, "");
+			String match = matcher.group(0);
+			switch (match)
+			{
+				case "<lt>":
+				case "<gt>":
+					stringBuffer.append(match);
+					break;
+			}
+		}
+		matcher.appendTail(stringBuffer);
+		return stringBuffer.toString();
 	}
 
 	/**

--- a/runelite-client/src/test/java/net/runelite/client/util/TextTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/util/TextTest.java
@@ -39,7 +39,21 @@ public class TextTest
 		assertEquals("Not so much.", Text.removeTags("<col=FFFFFF This is a very special message.</col>Not so much."));
 		assertEquals("Use Item -> Man", Text.removeTags("Use Item -> Man"));
 		assertEquals("a < b", Text.removeTags("a < b"));
+		assertEquals("a  b", Text.removeTags("a <lt> b"));
 		assertEquals("Remove no tags", Text.removeTags("Remove no tags"));
 	}
 
+	@Test
+	public void removeFormattingTags()
+	{
+		assertEquals("Test", Text.removeFormattingTags("<col=FFFFFF>Test</col>"));
+		assertEquals("Test", Text.removeFormattingTags("<img=1><s>Test</s>"));
+		assertEquals("Zezima  (level-126)", Text.removeFormattingTags("<col=ffffff><img=2>Zezima<col=00ffff>  (level-126)"));
+		assertEquals("", Text.removeFormattingTags("<colrandomtext test>"));
+		assertEquals("Not so much.", Text.removeFormattingTags("<col=FFFFFF This is a very special message.</col>Not so much."));
+		assertEquals("Use Item -> Man", Text.removeFormattingTags("Use Item -> Man"));
+		assertEquals("a < b", Text.removeFormattingTags("a < b"));
+		assertEquals("a <lt> b", Text.removeFormattingTags("a <lt> b"));
+		assertEquals("Remove no tags", Text.removeFormattingTags("Remove no tags"));
+	}
 }


### PR DESCRIPTION
Adds a chat notification option for Jagex broadcasts. 

There are times when you might not be paying attention to your client and/or chat, and Jagex sends out a broadcast. This ensures you don't miss any potentially important information, official Twitch streams, etc.
<img width="479" alt="Screen Shot 2020-06-04 at 9 49 46 AM" src="https://user-images.githubusercontent.com/54762282/83826005-d5ce3900-a6a8-11ea-8085-3fcfede1b306.png">
![2020-06-04_19-37-42 copy](https://user-images.githubusercontent.com/54762282/83826063-f9917f00-a6a8-11ea-8eb6-b5ed3be4483b.png)
