### PR TITLE
Add timeout config option to clanchat join/leave message dissappearing.

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/friendschat/FriendsChatConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/friendschat/FriendsChatConfig.java
@@ -107,10 +107,21 @@ public interface FriendsChatConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "joinLeaveTimeout",
+		name = "Join/Leave timeout",
+		description = "Set the timeout duration of join/leave messages. A value of 0 will make the messages permanent.",
+		position = 6
+	)
+	default int joinLeaveTimeout()
+	{
+		return 20;
+	}
+
+	@ConfigItem(
 		keyName = "privateMessageIcons",
 		name = "Private Message Icons",
 		description = "Add rank icons to private messages received from members.",
-		position = 6
+		position = 7
 	)
 	default boolean privateMessageIcons()
 	{
@@ -121,7 +132,7 @@ public interface FriendsChatConfig extends Config
 		keyName = "publicChatIcons",
 		name = "Public Chat Icons",
 		description = "Add rank icons to public chat messages from members.",
-		position = 7
+		position = 8
 	)
 	default boolean publicChatIcons()
 	{
@@ -132,7 +143,7 @@ public interface FriendsChatConfig extends Config
 		keyName = "clanTabChat",
 		name = "Tab Chat",
 		description = "Message friends chat without appending '/' when the friends chat tab is selected.",
-		position = 8
+		position = 9
 	)
 	default boolean friendsChatTabChat()
 	{
@@ -143,7 +154,7 @@ public interface FriendsChatConfig extends Config
 		keyName = "confirmKicks",
 		name = "Confirm Kicks",
 		description = "Shows a chat prompt to confirm kicks",
-		position = 9
+		position = 10
 	)
 	default boolean confirmKicks()
 	{
@@ -154,7 +165,7 @@ public interface FriendsChatConfig extends Config
 		keyName = "showIgnores",
 		name = "Recolor ignored players",
 		description = "Recolor members who are on your ignore list",
-		position = 10
+		position = 11
 	)
 	default boolean showIgnores()
 	{
@@ -165,7 +176,7 @@ public interface FriendsChatConfig extends Config
 		keyName = "showIgnoresColor",
 		name = "Ignored color",
 		description = "Allows you to change the color of the ignored players in your friends chat",
-		position = 11
+		position = 12
 	)
 	default Color showIgnoresColor()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/friendschat/FriendsChatPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/friendschat/FriendsChatPlugin.java
@@ -42,10 +42,10 @@ import java.util.Map;
 import javax.inject.Inject;
 import net.runelite.api.ChatLineBuffer;
 import net.runelite.api.ChatMessageType;
-import net.runelite.api.FriendsChatMember;
-import net.runelite.api.FriendsChatManager;
-import net.runelite.api.FriendsChatRank;
 import net.runelite.api.Client;
+import net.runelite.api.FriendsChatManager;
+import net.runelite.api.FriendsChatMember;
+import net.runelite.api.FriendsChatRank;
 import net.runelite.api.GameState;
 import net.runelite.api.Ignore;
 import net.runelite.api.MessageNode;
@@ -96,7 +96,6 @@ public class FriendsChatPlugin extends Plugin
 	private static final int MAX_CHATS = 10;
 	private static final String TITLE = "FC";
 	private static final String RECENT_TITLE = "Recent FCs";
-	private static final int JOIN_LEAVE_DURATION = 20;
 	private static final int MESSAGE_DELAY = 10;
 
 	@Inject
@@ -315,6 +314,12 @@ public class FriendsChatPlugin extends Plugin
 			return;
 		}
 
+		final int joinLeaveTimeout = config.joinLeaveTimeout();
+		if (joinLeaveTimeout == 0)
+		{
+			return;
+		}
+
 		boolean removed = false;
 
 		for (Iterator<MemberJoinMessage> it = joinMessages.iterator(); it.hasNext(); )
@@ -323,7 +328,7 @@ public class FriendsChatPlugin extends Plugin
 			MessageNode messageNode = joinMessage.getMessageNode();
 			final int createdTick = joinMessage.getTick();
 
-			if (client.getTickCount() > createdTick + JOIN_LEAVE_DURATION)
+			if (client.getTickCount() > createdTick + joinLeaveTimeout)
 			{
 				it.remove();
 


### PR DESCRIPTION
Adds a new config option to the clan chat plugin. 
Allows the user to set the tick delay before a Join/Leave message is removed. 
Setting the delay to 0 stops the messages from being removed. 

closes [#11703](https://github.com/runelite/runelite/issues/11703) 