### PR TITLE
chat-history: fix plugin not clearing history

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/chathistory/ChatHistoryPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chathistory/ChatHistoryPlugin.java
@@ -254,7 +254,8 @@ public class ChatHistoryPlugin extends Plugin implements KeyListener
 	{
 		final String menuOption = event.getMenuOption();
 
-		if (CLEAR_HISTORY.equals(menuOption))
+		// The menu option for clear history is "<col=ffff00>Public:</col> Clear history"
+		if (menuOption.endsWith(CLEAR_HISTORY))
 		{
 			clearChatboxHistory(ChatboxTab.of(event.getWidgetId()));
 		}


### PR DESCRIPTION
closes #11730

The cleanup commit in the previous PR accidentally switched `.contains` to `.equals`