### PR TITLE
Removed duplicate quantity on notification

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
@@ -89,7 +89,6 @@ import static net.runelite.client.plugins.grounditems.config.MenuHighlightMode.N
 import static net.runelite.client.plugins.grounditems.config.MenuHighlightMode.OPTION;
 import net.runelite.client.ui.overlay.OverlayManager;
 import net.runelite.client.util.ColorUtil;
-import net.runelite.client.util.QuantityFormatter;
 import net.runelite.client.util.Text;
 
 @PluginDescriptor(

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
@@ -650,18 +650,14 @@ public class GroundItemsPlugin extends Plugin
 
 		if (item.getQuantity() > 1)
 		{
-			notificationStringBuilder.append(" x ").append(item.getQuantity());
-
 
 			if (item.getQuantity() > (int) Character.MAX_VALUE)
 			{
-				notificationStringBuilder.append(" (Lots!)");
+				notificationStringBuilder.append(" x Lots");
 			}
 			else
 			{
-				notificationStringBuilder.append(" (")
-					.append(QuantityFormatter.quantityToStackSize(item.getQuantity()))
-					.append(")");
+				notificationStringBuilder.append(" x ").append(item.getQuantity());
 			}
 		}
 


### PR DESCRIPTION
Prevent duplicate quantities in Ground Item Notifications

This fixes #10319 as PR  #10526 doesn't look like it is being worked on currently.

The format for notifications is now is now 
`[{player}] received a highlighted drop: {name} x {quantity}!`