### PR TITLE
Clarify Boosts Information Tooltip

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/boosts/BoostsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/boosts/BoostsConfig.java
@@ -104,7 +104,7 @@ public interface BoostsConfig extends Config
 	@ConfigItem(
 		keyName = "boostThreshold",
 		name = "Boost amount threshold",
-		description = "The amount of levels boosted to display then in different color. A value of 0 will disable the feature.",
+		description = "The threshold at which boosted levels will be displayed in a different color. A value of 0 will disable the feature.",
 		position = 6
 	)
 	default int boostThreshold()


### PR DESCRIPTION
Clarify & remove typo from the tooltip for "Boost amount threshold"