### PR TITLE
Fix cryptic clue to show Iorwerth's correct location before and after…

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/ClueScroll.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/ClueScroll.java
@@ -28,6 +28,7 @@ import java.awt.Graphics2D;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
+import net.runelite.api.Quest;
 import net.runelite.api.Varbits;
 import net.runelite.client.plugins.cluescrolls.ClueScrollPlugin;
 import net.runelite.client.ui.overlay.components.PanelComponent;
@@ -49,6 +50,14 @@ public abstract class ClueScroll
 	@Setter(AccessLevel.PROTECTED)
 	@Getter(AccessLevel.PUBLIC)
 	private Enemy enemy;
+
+	@Setter(AccessLevel.PROTECTED)
+	@Getter(AccessLevel.PUBLIC)
+	private Quest[] questConditions;
+
+	@Setter(AccessLevel.PROTECTED)
+	@Getter(AccessLevel.PUBLIC)
+	private ClueScroll alternateClue;
 
 	public abstract void makeOverlayHint(PanelComponent panelComponent, ClueScrollPlugin plugin);
 


### PR DESCRIPTION
… Song of the Elves completion

Closes #11674

Originally, the cryptic clue only added Iorwerth's location before the
completion of Song of the Elves. The solution text however temporarily
both noted pre-quest and post-quest completion. With some changes in the
base `ClueScroll` class, the `CrypticClue` class has been expanded to add
multiple locations and contain alternate clues based on quest
completion.

These changes attempt to help better represent clues whose NPCs change based on certain quests (e.g. Steve before/after DS2, Iorwerth and Eluned before/after SotE) and clues whose final locations do not take place on the Runescape surface (e.g. Steve in the Asgarnian Ice Dungeon, Genie in the crevice west of Nardah, Eluned in Prifddinas). 

The base `ClueScroll` class has been added with a `Quest` array and a reference to an alternative `ClueScroll`. The `questConditions` `Quest` array contains quests that need to be completed in order for the clue scroll to be valid. For example, the cryptic clue for Lord Iorwerth now contains its post-quest location and quest requirements, and `alternateClue` references his original pre-quest location. This can be ported to anagram clues for the pre-quest and post-quest locations of Steve.

Before SotE completion:
![image](https://user-images.githubusercontent.com/5997708/83340952-a92eb180-a2a3-11ea-9178-fedd380a5a59.png)

After SotE completion:
![ezgif com-optimize](https://user-images.githubusercontent.com/5997708/83341017-59041f00-a2a4-11ea-8106-adcba4776c36.gif)

In addition, RuneLite currently does not put intermediate `ClueScrollWorldMapPoint`s on the Runescape surface for clue scrolls whose final location is elsewhere. Without this, Lord Iorwerth's post-quest location (i.e. the clue scroll icon on the world map) will only appear in the real version of Prifddinas and not on the Runescape surface when viewing the world map. Cryptic clues now support multiple locations to help guide players if the final world point is not on the Runescape Surface (e.g. in the crevice west of Nardah).

Other changes: 
 - The command `::clue` now takes place on a delayed game tick to support on-demand quest progress lookup in `ClueScrollPlugin::findClueScroll()`.
 - Added test to check for clues with alternate clues and multiple locations.

However, these changes come with a few negative/unclear implications for future clue scroll additions.
 - The final location for Cryptic clue scrolls with intermediate locations is always at the end of the array.
 - The more restrictive post-quest clue should be at the head of the linked list with a reference to the less restrictive pre-quest clue.




