### PR TITLE
Fix MLM vein overlay not displaying on upper level

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/motherlode/MotherlodePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/motherlode/MotherlodePlugin.java
@@ -100,7 +100,7 @@ public class MotherlodePlugin extends Plugin
 	private static final int SACK_LARGE_SIZE = 162;
 	private static final int SACK_SIZE = 81;
 
-	private static final int UPPER_FLOOR_HEIGHT = -500;
+	private static final int UPPER_FLOOR_HEIGHT = -490;
 
 	@Inject
 	private OverlayManager overlayManager;


### PR DESCRIPTION
When standing in front of Mercy on the upper level of MLM, the vein overlay switches from the upper level to the lower level due to the player's tile height being less than -500.
I've adjusted UPPER_FLOOR_HEIGHT to accommodate for this.

I also tested every other tile on the upper level and only the one directly in front of Mercy has this issue.