### PR TITLE
PluginManager: don't duplicate dependency plugins if they already exist

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/PluginManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/PluginManager.java
@@ -320,7 +320,10 @@ public class PluginManager
 
 			for (PluginDependency pluginDependency : pluginDependencies)
 			{
-				graph.putEdge(pluginClazz, pluginDependency.value());
+				if (graph.nodes().contains(pluginDependency.value()))
+				{
+					graph.putEdge(pluginClazz, pluginDependency.value());
+				}
 			}
 		}
 


### PR DESCRIPTION
If you had an external plugin with a PluginDependency on a core plugin
the core plugin would be included in the external `loadPlugins`
dependency graph, which would make it be instantiated twice. Since
external plugins can't depend on other external plugins, and core
plugins are guaranteed to be loaded first with no external dependencies,
we can just exclude dependency edges for nodes outside of the current
load list.