### PR TITLE
agility: Fix config order

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/agility/AgilityConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/agility/AgilityConfig.java
@@ -203,7 +203,7 @@ public interface AgilityConfig extends Config
 		keyName = "highlightStick",
 		name = "Highlight Stick",
 		description = "Highlight the retrievable stick in the Werewolf Agility Course",
-		position = 13
+		position = 15
 	)
 	default boolean highlightStick()
 	{
@@ -214,7 +214,7 @@ public interface AgilityConfig extends Config
 		keyName = "stickHighlightColor",
 		name = "Stick Highlight Color",
 		description = "Color of highlighted stick",
-		position = 14
+		position = 16
 	)
 	default Color stickHighlightColor()
 	{


### PR DESCRIPTION
Part of the Agility config list is currently mislabeled, resulting in the settings displaying in an incorrect order:
<img width="227" alt="Screen Shot 2020-06-02 at 7 20 51 PM" src="https://user-images.githubusercontent.com/54762282/83579529-7c7ad400-a507-11ea-9de3-e043de08390e.png">

Fixed:
<img width="225" alt="Screen Shot 2020-06-02 at 7 23 54 PM" src="https://user-images.githubusercontent.com/54762282/83579530-7c7ad400-a507-11ea-9d01-4a649e7ced63.png">
