### PR TITLE
config: add ability to reset single config items

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
@@ -226,6 +226,15 @@ class ConfigPanel extends PluginPanel
 			configEntryName.setToolTipText("<html>" + name + ":<br>" + cid.getItem().description() + "</html>");
 			item.add(configEntryName, BorderLayout.CENTER);
 
+			JMenuItem resetItem = new JMenuItem("Reset");
+			resetItem.addActionListener(l ->
+			{
+				configManager.setDefaultConfiguration(pluginConfig.getConfig(), cid.getItem());
+				rebuild();
+			});
+
+			PluginListItem.addLabelPopupMenu(configEntryName, resetItem);
+
 			if (cid.getType() == boolean.class)
 			{
 				JCheckBox checkbox = new JCheckBox();


### PR DESCRIPTION
I couldn't find an associated issue for this, but this fixes people's frustration with resetting the entire config for chat colors to undo 1 erroneously changed color. 