### PR TITLE
item charges: update amulet of chemistry charges when creating less than 4-dose potions

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemcharges/ItemChargePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemcharges/ItemChargePlugin.java
@@ -84,7 +84,7 @@ public class ItemChargePlugin extends Plugin
 		"Your amulet of chemistry has (\\d) charges? left\\."
 	);
 	private static final Pattern AMULET_OF_CHEMISTRY_USED_PATTERN = Pattern.compile(
-		"Your amulet of chemistry helps you create a (\\d)-dose potion\\. (?:<col=ff0000>)?It has (\\d|one) charges? left\\."
+		"Your amulet of chemistry helps you create a \\d-dose potion\\. (?:<col=ff0000>)?It has (\\d|one) charges? left\\."
 	);
 	private static final Pattern AMULET_OF_CHEMISTRY_BREAK_PATTERN = Pattern.compile(
 		"Your amulet of chemistry helps you create a (\\d)-dose potion\\. (?:<col=ff0000>)?It then crumbles to dust\\."

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemcharges/ItemChargePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemcharges/ItemChargePlugin.java
@@ -84,9 +84,11 @@ public class ItemChargePlugin extends Plugin
 		"Your amulet of chemistry has (\\d) charges? left\\."
 	);
 	private static final Pattern AMULET_OF_CHEMISTRY_USED_PATTERN = Pattern.compile(
-		"Your amulet of chemistry helps you create a 4-dose potion\\. (?:<col=ff0000>)?It has (\\d|one) charges? left\\."
+		"Your amulet of chemistry helps you create a (\\d)-dose potion\\. (?:<col=ff0000>)?It has (\\d|one) charges? left\\."
 	);
-	private static final String AMULET_OF_CHEMISTRY_BREAK_TEXT = "Your amulet of chemistry helps you create a 4-dose potion. <col=ff0000>It then crumbles to dust.</col>";
+	private static final Pattern AMULET_OF_CHEMISTRY_BREAK_PATTERN = Pattern.compile(
+		"Your amulet of chemistry helps you create a (\\d)-dose potion\\. (?:<col=ff0000>)?It then crumbles to dust\\."
+	);
 	private static final Pattern AMULET_OF_BOUNTY_CHECK_PATTERN = Pattern.compile(
 		"Your amulet of bounty has (\\d+) charges? left\\."
 	);
@@ -217,6 +219,7 @@ public class ItemChargePlugin extends Plugin
 			Matcher ringOfForgingCheckMatcher = RING_OF_FORGING_CHECK_PATTERN.matcher(message);
 			Matcher amuletOfChemistryCheckMatcher = AMULET_OF_CHEMISTRY_CHECK_PATTERN.matcher(message);
 			Matcher amuletOfChemistryUsedMatcher = AMULET_OF_CHEMISTRY_USED_PATTERN.matcher(message);
+			Matcher amuletOfChemistryBreakMatcher = AMULET_OF_CHEMISTRY_BREAK_PATTERN.matcher(message);
 			Matcher amuletOfBountyCheckMatcher = AMULET_OF_BOUNTY_CHECK_PATTERN.matcher(message);
 			Matcher amuletOfBountyUsedMatcher = AMULET_OF_BOUNTY_USED_PATTERN.matcher(message);
 
@@ -243,7 +246,7 @@ public class ItemChargePlugin extends Plugin
 			}
 			else if (amuletOfChemistryCheckMatcher.find())
 			{
-				updateAmuletOfChemistyCharges(Integer.parseInt(amuletOfChemistryCheckMatcher.group(1)));
+				updateAmuletOfChemistryCharges(Integer.parseInt(amuletOfChemistryCheckMatcher.group(1)));
 			}
 			else if (amuletOfChemistryUsedMatcher.find())
 			{
@@ -255,11 +258,11 @@ public class ItemChargePlugin extends Plugin
 					charges = Integer.parseInt(match);
 				}
 
-				updateAmuletOfChemistyCharges(charges);
+				updateAmuletOfChemistryCharges(charges);
 			}
-			else if (message.equals(AMULET_OF_CHEMISTRY_BREAK_TEXT))
+			else if (amuletOfChemistryBreakMatcher.find())
 			{
-				updateAmuletOfChemistyCharges(MAX_AMULET_OF_CHEMISTRY_CHARGES);
+				updateAmuletOfChemistryCharges(MAX_AMULET_OF_CHEMISTRY_CHARGES);
 			}
 			else if (amuletOfBountyCheckMatcher.find())
 			{
@@ -432,7 +435,7 @@ public class ItemChargePlugin extends Plugin
 		}
 	}
 
-	private void updateAmuletOfChemistyCharges(final int value)
+	private void updateAmuletOfChemistryCharges(final int value)
 	{
 		config.amuletOfChemistry(value);
 
@@ -545,7 +548,7 @@ public class ItemChargePlugin extends Plugin
 				updateRingOfForgingCharges(MAX_RING_OF_FORGING_CHARGES);
 				break;
 			case "Amulet of chemistry":
-				updateAmuletOfChemistyCharges(MAX_AMULET_OF_CHEMISTRY_CHARGES);
+				updateAmuletOfChemistryCharges(MAX_AMULET_OF_CHEMISTRY_CHARGES);
 				break;
 		}
 	}
@@ -633,7 +636,7 @@ public class ItemChargePlugin extends Plugin
 				return false;
 			}
 
-			final ItemChargeInfobox i = (ItemChargeInfobox)t;
+			final ItemChargeInfobox i = (ItemChargeInfobox) t;
 			return i.getItem() == item && i.getSlot() == slot;
 		});
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemcharges/ItemChargePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemcharges/ItemChargePlugin.java
@@ -87,7 +87,7 @@ public class ItemChargePlugin extends Plugin
 		"Your amulet of chemistry helps you create a \\d-dose potion\\. (?:<col=ff0000>)?It has (\\d|one) charges? left\\."
 	);
 	private static final Pattern AMULET_OF_CHEMISTRY_BREAK_PATTERN = Pattern.compile(
-		"Your amulet of chemistry helps you create a (\\d)-dose potion\\. (?:<col=ff0000>)?It then crumbles to dust\\."
+		"Your amulet of chemistry helps you create a \\d-dose potion\\. (?:<col=ff0000>)?It then crumbles to dust\\."
 	);
 	private static final Pattern AMULET_OF_BOUNTY_CHECK_PATTERN = Pattern.compile(
 		"Your amulet of bounty has (\\d+) charges? left\\."

--- a/runelite-client/src/test/java/net/runelite/client/plugins/itemcharges/ItemChargePluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/itemcharges/ItemChargePluginTest.java
@@ -62,6 +62,15 @@ public class ItemChargePluginTest
 	private static final String USED_RING_OF_FORGING = "You retrieve a bar of iron.";
 	private static final String BREAK_RING_OF_FORGING = "<col=7f007f>Your Ring of Forging has melted.</col>";
 
+	private static final String CHECK_AMULET_OF_CHEMISTRY = "Your amulet of chemistry has 5 charges left.";
+	private static final String CHECK_AMULET_OF_CHEMISTRY_1 = "Your amulet of chemistry has 1 charge left.";
+	private static final String USED_AMULET_OF_CHEMISTRY = "Your amulet of chemistry helps you create a 4-dose potion. It has 4 charges left.";
+	private static final String USED_AMULET_OF_CHEMISTRY_3_DOSES = "Your amulet of chemistry helps you create a 3-dose potion. It has 2 charges left.";
+	private static final String USED_AMULET_OF_CHEMISTRY_2_DOSES = "Your amulet of chemistry helps you create a 2-dose potion. It has one charge left.";
+	private static final String BREAK_AMULET_OF_CHEMISTRY = "Your amulet of chemistry helps you create a 4-dose potion. It then crumbles to dust.";
+	private static final String BREAK_AMULET_OF_CHEMISTRY_3_DOSES = "Your amulet of chemistry helps you create a 3-dose potion. It then crumbles to dust.";
+	private static final String BREAK_AMULET_OF_CHEMISTRY_2_DOSES = "Your amulet of chemistry helps you create a 2-dose potion. It then crumbles to dust.";
+
 	@Mock
 	@Bind
 	private Client client;
@@ -143,5 +152,46 @@ public class ItemChargePluginTest
 		itemChargePlugin.onChatMessage(chatMessage);
 		verify(config).ringOfForging(eq(140));
 		reset(config);
+
+		chatMessage = new ChatMessage(null, ChatMessageType.GAMEMESSAGE, "", CHECK_AMULET_OF_CHEMISTRY, "", 0);
+		itemChargePlugin.onChatMessage(chatMessage);
+		verify(config).amuletOfChemistry(eq(5));
+		reset(config);
+
+		chatMessage = new ChatMessage(null, ChatMessageType.GAMEMESSAGE, "", CHECK_AMULET_OF_CHEMISTRY_1, "", 0);
+		itemChargePlugin.onChatMessage(chatMessage);
+		verify(config).amuletOfChemistry(eq(1));
+		reset(config);
+
+		chatMessage = new ChatMessage(null, ChatMessageType.GAMEMESSAGE, "", USED_AMULET_OF_CHEMISTRY, "", 0);
+		itemChargePlugin.onChatMessage(chatMessage);
+		verify(config).amuletOfChemistry(eq(4));
+		reset(config);
+
+		chatMessage = new ChatMessage(null, ChatMessageType.GAMEMESSAGE, "", USED_AMULET_OF_CHEMISTRY_3_DOSES, "", 0);
+		itemChargePlugin.onChatMessage(chatMessage);
+		verify(config).amuletOfChemistry(eq(2));
+		reset(config);
+
+		chatMessage = new ChatMessage(null, ChatMessageType.GAMEMESSAGE, "", USED_AMULET_OF_CHEMISTRY_2_DOSES, "", 0);
+		itemChargePlugin.onChatMessage(chatMessage);
+		verify(config).amuletOfChemistry(eq(1));
+		reset(config);
+
+		chatMessage = new ChatMessage(null, ChatMessageType.GAMEMESSAGE, "", BREAK_AMULET_OF_CHEMISTRY, "", 0);
+		itemChargePlugin.onChatMessage(chatMessage);
+		verify(config).amuletOfChemistry(eq(5));
+		reset(config);
+
+		chatMessage = new ChatMessage(null, ChatMessageType.GAMEMESSAGE, "", BREAK_AMULET_OF_CHEMISTRY_3_DOSES, "", 0);
+		itemChargePlugin.onChatMessage(chatMessage);
+		verify(config).amuletOfChemistry(eq(5));
+		reset(config);
+
+		chatMessage = new ChatMessage(null, ChatMessageType.GAMEMESSAGE, "", BREAK_AMULET_OF_CHEMISTRY_2_DOSES, "", 0);
+		itemChargePlugin.onChatMessage(chatMessage);
+		verify(config).amuletOfChemistry(eq(5));
+		reset(config);
+
 	}
 }


### PR DESCRIPTION
Closes #11822

Updated the regex for amulet of chemistry to update the amulet's charge count when creating less than 4-dose potions