### PR TITLE
xp tracker: add option to sort skills by most recently gained xp

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpInfoBox.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpInfoBox.java
@@ -253,12 +253,7 @@ class XpInfoBox extends JPanel
 
 			if (xpTrackerConfig.prioritizeRecentXpSkills())
 			{
-				int index = panel.getComponentZOrder(this);
-				if (index > 0)
-				{
-					panel.remove(this);
-					panel.add(this, 0);
-				}
+				panel.setComponentZOrder(this, 0);
 			}
 
 			paused = skillPaused;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpInfoBox.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpInfoBox.java
@@ -245,23 +245,20 @@ class XpInfoBox extends JPanel
 	{
 		if (updated)
 		{
+			if (getParent() != panel)
+			{
+				panel.add(this);
+				panel.revalidate();
+			}
+
 			if (xpTrackerConfig.prioritizeRecentXpSkills())
 			{
-				if (getParent() != panel)
-				{
-					panel.add(this, 0);
-				}
-				else
+				int index = panel.getComponentZOrder(this);
+				if (index > 0)
 				{
 					panel.remove(this);
 					panel.add(this, 0);
 				}
-				panel.revalidate();
-			}
-			else if (getParent() != panel)
-			{
-				panel.add(this);
-				panel.revalidate();
 			}
 
 			paused = skillPaused;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpInfoBox.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpInfoBox.java
@@ -245,7 +245,20 @@ class XpInfoBox extends JPanel
 	{
 		if (updated)
 		{
-			if (getParent() != panel)
+			if (xpTrackerConfig.prioritizeRecentXpSkills())
+			{
+				if (getParent() != panel)
+				{
+					panel.add(this, 0);
+				}
+				else
+				{
+					panel.remove(this);
+					panel.add(this, 0);
+				}
+				panel.revalidate();
+			}
+			else if (getParent() != panel)
 			{
 				panel.add(this);
 				panel.revalidate();

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerConfig.java
@@ -177,4 +177,15 @@ public interface XpTrackerConfig extends Config
 	{
 		return XpProgressBarLabel.PERCENTAGE;
 	}
+
+	@ConfigItem(
+		position = 12,
+		keyName = "prioritizeRecentXpSkills",
+		name = "Move recently trained skills to top",
+		description = "Configures whether skills should be organized by most recently gained xp"
+	)
+	default boolean prioritizeRecentXpSkills()
+	{
+		return false;
+	}
 }


### PR DESCRIPTION
Closes #11766 

Adds a toggle that, when enabled, moves skills to the top of the xp tracker if xp has been earned.