### PR TITLE
LootTracker support for shade chests; support ground items

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/game/LootManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/game/LootManager.java
@@ -29,6 +29,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ListMultimap;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -402,5 +403,26 @@ public class LootManager
 		}
 
 		return new WorldPoint(x, y, worldLocation.getPlane());
+	}
+
+	/**
+	 * Get the list of items present at the provided WorldPoint that spawned this tick.
+	 *
+	 * @param worldPoint the location in question
+	 * @return the list of item stacks
+	 */
+	public Collection<ItemStack> getItemSpawns(WorldPoint worldPoint)
+	{
+		LocalPoint localPoint = LocalPoint.fromWorld(client, worldPoint);
+		if (localPoint == null)
+		{
+			return Collections.emptyList();
+		}
+
+		final int sceneX = localPoint.getSceneX();
+		final int sceneY = localPoint.getSceneY();
+		final int packed = sceneX << 8 | sceneY;
+		final List<ItemStack> itemStacks = itemSpawns.get(packed);
+		return Collections.unmodifiableList(itemStacks);
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
@@ -69,6 +69,7 @@ import net.runelite.api.ItemContainer;
 import net.runelite.api.ItemID;
 import net.runelite.api.MessageNode;
 import net.runelite.api.NPC;
+import net.runelite.api.ObjectID;
 import net.runelite.api.Player;
 import net.runelite.api.SpriteID;
 import net.runelite.api.coords.WorldPoint;
@@ -151,6 +152,31 @@ public class LootTrackerPlugin extends Plugin
 		put(12127, "The Gauntlet").
 		put(13113, "Larran's small chest").
 		put(13151, "Elven Crystal Chest").
+		build();
+
+	// Shade chest loot handling
+	private static final Pattern SHADE_CHEST_NO_KEY_PATTERN = Pattern.compile("You need a [a-z]+ key with a [a-z]+ trim to open this chest .*");
+	private static final Map<Integer, String> SHADE_CHEST_OBJECTS = new ImmutableMap.Builder<Integer, String>().
+		put(ObjectID.BRONZE_CHEST, "Bronze key red").
+		put(ObjectID.BRONZE_CHEST_4112, "Bronze key brown").
+		put(ObjectID.BRONZE_CHEST_4113, "Bronze key crimson").
+		put(ObjectID.BRONZE_CHEST_4114, "Bronze key black").
+		put(ObjectID.BRONZE_CHEST_4115, "Bronze key purple").
+		put(ObjectID.STEEL_CHEST, "Steel key red").
+		put(ObjectID.STEEL_CHEST_4117, "Steel key brown").
+		put(ObjectID.STEEL_CHEST_4118, "Steel key crimson").
+		put(ObjectID.STEEL_CHEST_4119, "Steel key black").
+		put(ObjectID.STEEL_CHEST_4120, "Steel key purple").
+		put(ObjectID.BLACK_CHEST, "Black key red").
+		put(ObjectID.BLACK_CHEST_4122, "Black key brown").
+		put(ObjectID.BLACK_CHEST_4123, "Black key crimson").
+		put(ObjectID.BLACK_CHEST_4124, "Black key black").
+		put(ObjectID.BLACK_CHEST_4125, "Black key purple").
+		put(ObjectID.SILVER_CHEST, "Silver key red").
+		put(ObjectID.SILVER_CHEST_4127, "Silver key brown").
+		put(ObjectID.SILVER_CHEST_4128, "Silver key crimson").
+		put(ObjectID.SILVER_CHEST_4129, "Silver key black").
+		put(ObjectID.SILVER_CHEST_4130, "Silver key purple").
 		build();
 
 	// Last man standing map regions
@@ -600,28 +626,35 @@ public class LootTrackerPlugin extends Plugin
 				case "beginner":
 					eventType = "Clue Scroll (Beginner)";
 					lootRecordType = LootRecordType.EVENT;
-					break;
+					return;
 				case "easy":
 					eventType = "Clue Scroll (Easy)";
 					lootRecordType = LootRecordType.EVENT;
-					break;
+					return;
 				case "medium":
 					eventType = "Clue Scroll (Medium)";
 					lootRecordType = LootRecordType.EVENT;
-					break;
+					return;
 				case "hard":
 					eventType = "Clue Scroll (Hard)";
 					lootRecordType = LootRecordType.EVENT;
-					break;
+					return;
 				case "elite":
 					eventType = "Clue Scroll (Elite)";
 					lootRecordType = LootRecordType.EVENT;
-					break;
+					return;
 				case "master":
 					eventType = "Clue Scroll (Master)";
 					lootRecordType = LootRecordType.EVENT;
-					break;
+					return;
 			}
+		}
+
+		if (SHADE_CHEST_NO_KEY_PATTERN.matcher(message).matches())
+		{
+			// Player didn't have the key they needed.
+			eventType = null;
+			lootRecordType = null;
 		}
 	}
 
@@ -634,6 +667,7 @@ public class LootTrackerPlugin extends Plugin
 		}
 
 		if (CHEST_EVENT_TYPES.containsValue(eventType)
+			|| SHADE_CHEST_OBJECTS.containsValue(eventType)
 			|| HERBIBOAR_EVENT.equals(eventType)
 			|| HESPORI_EVENT.equals(eventType)
 			|| SEEDPACK_EVENT.equals(eventType)
@@ -661,6 +695,13 @@ public class LootTrackerPlugin extends Plugin
 		if (event.getMenuOption().equals("Take") && event.getId() == ItemID.SEED_PACK)
 		{
 			eventType = SEEDPACK_EVENT;
+			lootRecordType = LootRecordType.EVENT;
+			takeInventorySnapshot();
+		}
+
+		if (event.getMenuOption().equals("Open") && SHADE_CHEST_OBJECTS.containsKey(event.getId()))
+		{
+			eventType = SHADE_CHEST_OBJECTS.get(event.getId());
 			lootRecordType = LootRecordType.EVENT;
 			takeInventorySnapshot();
 		}


### PR DESCRIPTION
This commit makes it so LootTracker tracks items that fall on the floor during an inventory-based loot. This works because ItemSpawned/ItemQuantityChanged events happen before ItemContainerChanged events.

It keeps a running track of items that spawned directly below the player during the current tick, and if that is in the same tick as as an inventory change that correlates to (e.g.) a chest or seed pack event, we include the ground items as part of the loot. I've tested this fairly extensively for crystal chests, with good results.

The shades part is relatively straightforward, and uses the object IDs. The only tricky thing is that unlike seed packs, just clicking "Open" is not sufficient – you need to also have a key in your inventory. The game gives you a message if you fail to have a key, so we match against this. Fixes #8817 