### PR TITLE
Chambers plugin - list of highlighted rooms, option to hide raids with blacklisted rooms

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsConfig.java
@@ -226,7 +226,7 @@ public interface RaidsConfig extends Config
 	@ConfigItem(
 			position = 20,
 			keyName = "highlightColor",
-			name = "Required room color",
+			name = "Highlighted room color",
 			description = "The color of highlighted rooms"
 	)
 	default Color highlightColor()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsConfig.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018, Kamiel
+ * Copyright (c) 2020, Truth Forger <https://github.com/Blackberry0Pie>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -29,6 +30,8 @@ import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
 import net.runelite.client.config.Keybind;
 import net.runelite.client.util.ImageUploadStyle;
+
+import java.awt.Color;
 
 @ConfigGroup("raids")
 public interface RaidsConfig extends Config
@@ -207,5 +210,38 @@ public interface RaidsConfig extends Config
 	default ImageUploadStyle uploadScreenshot()
 	{
 		return ImageUploadStyle.CLIPBOARD;
+	}
+
+	@ConfigItem(
+			position = 19,
+			keyName = "requiredRooms",
+			name = "Required rooms",
+			description = "Display required rooms in a different color on the overlay. Separate with comma (full name)"
+	)
+	default String requiredRooms()
+	{
+		return "";
+	}
+
+	@ConfigItem(
+			position = 20,
+			keyName = "requiredColor",
+			name = "Required room color",
+			description = "The color of required rooms"
+	)
+	default Color requiredColor()
+	{
+		return Color.MAGENTA;
+	}
+
+	@ConfigItem(
+			position = 21,
+			keyName = "hideBlacklist",
+			name = "Hide blacklisted raids",
+			description = "Completely hides raids with blacklisted rooms or missing required rooms"
+	)
+	default boolean hideBlacklisted()
+	{
+		return false;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsConfig.java
@@ -214,22 +214,22 @@ public interface RaidsConfig extends Config
 
 	@ConfigItem(
 			position = 19,
-			keyName = "requiredRooms",
-			name = "Required rooms",
-			description = "Display required rooms in a different color on the overlay. Separate with comma (full name)"
+			keyName = "highlightedRooms",
+			name = "Highlighted rooms",
+			description = "Display highlighted rooms in a different color on the overlay. Separate with comma (full name)"
 	)
-	default String requiredRooms()
+	default String highlightedRooms()
 	{
 		return "";
 	}
 
 	@ConfigItem(
 			position = 20,
-			keyName = "requiredColor",
+			keyName = "highlightColor",
 			name = "Required room color",
-			description = "The color of required rooms"
+			description = "The color of highlighted rooms"
 	)
-	default Color requiredColor()
+	default Color highlightColor()
 	{
 		return Color.MAGENTA;
 	}
@@ -237,10 +237,21 @@ public interface RaidsConfig extends Config
 	@ConfigItem(
 			position = 21,
 			keyName = "hideBlacklist",
-			name = "Hide blacklisted raids",
-			description = "Completely hides raids with blacklisted rooms or missing required rooms"
+			name = "Hide raids containing blacklisted rooms",
+			description = "Completely hides raids containing blacklisted room(s)"
 	)
 	default boolean hideBlacklisted()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+			position = 22,
+			keyName = "hideMissingHighlighted",
+			name = "Hide raids missing highlighted rooms",
+			description = "Completely hides raids missing highlighted room(s)"
+	)
+	default boolean hideMissingHighlighted()
 	{
 		return false;
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsConfig.java
@@ -226,7 +226,7 @@ public interface RaidsConfig extends Config
 	@ConfigItem(
 			position = 20,
 			keyName = "highlightColor",
-			name = "Highlighted room color",
+			name = "Highlight color",
 			description = "The color of highlighted rooms"
 	)
 	default Color highlightColor()
@@ -237,7 +237,7 @@ public interface RaidsConfig extends Config
 	@ConfigItem(
 			position = 21,
 			keyName = "hideBlacklist",
-			name = "Hide raids containing blacklisted rooms",
+			name = "Hide raids with blacklisted",
 			description = "Completely hides raids containing blacklisted room(s)"
 	)
 	default boolean hideBlacklisted()
@@ -248,7 +248,7 @@ public interface RaidsConfig extends Config
 	@ConfigItem(
 			position = 22,
 			keyName = "hideMissingHighlighted",
-			name = "Hide raids missing highlighted rooms",
+			name = "Hide raids missing highlighted",
 			description = "Completely hides raids missing highlighted room(s)"
 	)
 	default boolean hideMissingHighlighted()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsOverlay.java
@@ -98,7 +98,7 @@ public class RaidsOverlay extends OverlayPanel
 			color = Color.RED;
 		}
 
-		boolean blacklisted = false;
+		boolean hide = false;
 		HashSet<String> roomNames = new HashSet();
 		for (Room layoutRoom : plugin.getRaid().getLayout().getRooms())
 		{
@@ -111,26 +111,26 @@ public class RaidsOverlay extends OverlayPanel
 			}
 			roomNames.add(room.getName().toLowerCase());
 
-			if (plugin.getRoomBlacklist().contains(room.getName().toLowerCase()))
+			if (config.hideBlacklisted() && plugin.getRoomBlacklist().contains(room.getName().toLowerCase()))
 			{
-				blacklisted = true;
+				hide = true;
 				break;
 			}
 		}
 
-		if (!blacklisted)
+		if (!hide && config.hideMissingHighlighted())
 		{
-			for (String requiredRoom : plugin.getRoomRequiredlist())
+			for (String requiredRoom : plugin.getRoomHighlightedList())
 			{
 				if (!roomNames.contains(requiredRoom))
 				{
-					blacklisted = true;
+					hide = true;
 					break;
 				}
 			}
 		}
 
-		if (config.hideBlacklisted() && blacklisted)
+		if (hide)
 		{
 			panelComponent.getChildren().add(TitleComponent.builder()
 					.text("Bad Raid!")
@@ -206,9 +206,9 @@ public class RaidsOverlay extends OverlayPanel
 					}
 
 					String name = room == RaidRoom.UNKNOWN_COMBAT ? "Unknown" : room.getName();
-					if (plugin.getRoomRequiredlist().contains(room.getName().toLowerCase()))
+					if (plugin.getRoomHighlightedList().contains(room.getName().toLowerCase()))
 					{
-						color = config.requiredColor();
+						color = config.highlightColor();
 					}
 
 					panelComponent.getChildren().add(LineComponent.builder()
@@ -230,9 +230,9 @@ public class RaidsOverlay extends OverlayPanel
 					}
 
 					name = room == RaidRoom.UNKNOWN_PUZZLE ? "Unknown" : room.getName();
-					if (plugin.getRoomRequiredlist().contains(room.getName().toLowerCase()))
+					if (plugin.getRoomHighlightedList().contains(room.getName().toLowerCase()))
 					{
-						color = config.requiredColor();
+						color = config.highlightColor();
 					}
 
 					panelComponent.getChildren().add(LineComponent.builder()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsPlugin.java
@@ -187,7 +187,7 @@ public class RaidsPlugin extends Plugin
 	private final Set<String> roomBlacklist = new HashSet<String>();
 
 	@Getter
-	private final Set<String> roomRequiredlist = new HashSet<String>();
+	private final Set<String> roomHighlightedList = new HashSet<String>();
 
 	@Getter
 	private final Set<String> rotationWhitelist = new HashSet<String>();
@@ -572,7 +572,7 @@ public class RaidsPlugin extends Plugin
 	{
 		updateList(roomWhitelist, config.whitelistedRooms());
 		updateList(roomBlacklist, config.blacklistedRooms());
-		updateList(roomRequiredlist, config.requiredRooms());
+		updateList(roomHighlightedList, config.highlightedRooms());
 		updateList(layoutWhitelist, config.whitelistedLayouts());
 
 		// Update rotation whitelist

--- a/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsPlugin.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018, Kamiel
+ * Copyright (c) 2020, Truth Forger <https://github.com/Blackberry0Pie>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -184,6 +185,9 @@ public class RaidsPlugin extends Plugin
 
 	@Getter
 	private final Set<String> roomBlacklist = new HashSet<String>();
+
+	@Getter
+	private final Set<String> roomRequiredlist = new HashSet<String>();
 
 	@Getter
 	private final Set<String> rotationWhitelist = new HashSet<String>();
@@ -568,6 +572,7 @@ public class RaidsPlugin extends Plugin
 	{
 		updateList(roomWhitelist, config.whitelistedRooms());
 		updateList(roomBlacklist, config.blacklistedRooms());
+		updateList(roomRequiredlist, config.requiredRooms());
 		updateList(layoutWhitelist, config.whitelistedLayouts());
 
 		// Update rotation whitelist

--- a/runelite-client/src/test/java/net/runelite/client/plugins/raids/RaidsPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/raids/RaidsPluginTest.java
@@ -114,7 +114,7 @@ public class RaidsPluginTest
 		Guice.createInjector(BoundFieldModule.of(this)).injectMembers(this);
 		when(raidsConfig.whitelistedRooms()).thenReturn("");
 		when(raidsConfig.blacklistedRooms()).thenReturn("");
-		when(raidsConfig.requiredRooms()).thenReturn("");
+		when(raidsConfig.highlightedRooms()).thenReturn("");
 		when(raidsConfig.whitelistedRotations()).thenReturn("");
 		when(raidsConfig.whitelistedLayouts()).thenReturn("");
 	}

--- a/runelite-client/src/test/java/net/runelite/client/plugins/raids/RaidsPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/raids/RaidsPluginTest.java
@@ -114,6 +114,7 @@ public class RaidsPluginTest
 		Guice.createInjector(BoundFieldModule.of(this)).injectMembers(this);
 		when(raidsConfig.whitelistedRooms()).thenReturn("");
 		when(raidsConfig.blacklistedRooms()).thenReturn("");
+		when(raidsConfig.requiredRooms()).thenReturn("");
 		when(raidsConfig.whitelistedRotations()).thenReturn("");
 		when(raidsConfig.whitelistedLayouts()).thenReturn("");
 	}


### PR DESCRIPTION
example config:
![config](https://i.gyazo.com/c3b330403100e55b1938882f49d353fc.png)
example highlighted room:
![highlighted room](https://i.gyazo.com/f9c664b772a64e1245a5ee08b17bc087.png)
example hidden scout:
![hidden scout](https://i.gyazo.com/b4e0be785cff067768ace64972b8739f.png)

Split-off and updated from:
#6092 
