### PR TITLE
Chambers plugin - custom item overlay for rooms

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsConfig.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018, Kamiel
+ * Copyright (c) 2020, Truth Forger <https://github.com/Blackberry0Pie>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -207,5 +208,27 @@ public interface RaidsConfig extends Config
 	default ImageUploadStyle uploadScreenshot()
 	{
 		return ImageUploadStyle.CLIPBOARD;
+	}
+
+	@ConfigItem(
+			position = 17,
+			keyName = "showRecommendedItems",
+			name = "Show recommended items",
+			description = "Adds overlay with recommended items to scouter"
+	)
+	default boolean showRecommendedItems()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+			position = 18,
+			keyName = "recommendedItems",
+			name = "Recommended items",
+			description = "User-set recommended items in the form: [muttadiles,ice barrage,zamorak godsword],[tekton,elder maul], ..."
+	)
+	default String recommendedItems()
+	{
+		return "";
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsOverlay.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018, Kamiel
+ * Copyright (c) 2020, Truth Forger <https://github.com/Blackberry0Pie>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -28,13 +29,21 @@ import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.FontMetrics;
 import java.awt.Graphics2D;
+import java.awt.Point;
+import java.awt.image.BufferedImage;
+import java.util.HashSet;
+import java.util.Set;
 import javax.inject.Inject;
 import lombok.Getter;
 import net.runelite.api.ClanMemberManager;
 import net.runelite.api.Client;
 import static net.runelite.api.MenuAction.RUNELITE_OVERLAY;
 import static net.runelite.api.MenuAction.RUNELITE_OVERLAY_CONFIG;
+
+import net.runelite.api.SpriteID;
 import net.runelite.api.Varbits;
+import net.runelite.client.game.ItemManager;
+import net.runelite.client.game.SpriteManager;
 import net.runelite.client.game.WorldService;
 import net.runelite.client.plugins.raids.solver.Room;
 import static net.runelite.client.ui.overlay.OverlayManager.OPTION_CONFIGURE;
@@ -43,8 +52,12 @@ import net.runelite.client.ui.overlay.OverlayPanel;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.OverlayPriority;
 import net.runelite.client.ui.overlay.components.ComponentConstants;
+import net.runelite.client.ui.overlay.components.ComponentOrientation;
+import net.runelite.client.ui.overlay.components.ImageComponent;
 import net.runelite.client.ui.overlay.components.LineComponent;
+import net.runelite.client.ui.overlay.components.PanelComponent;
 import net.runelite.client.ui.overlay.components.TitleComponent;
+import net.runelite.client.util.ImageUtil;
 import net.runelite.http.api.worlds.World;
 import net.runelite.http.api.worlds.WorldRegion;
 import net.runelite.http.api.worlds.WorldResult;
@@ -54,19 +67,35 @@ public class RaidsOverlay extends OverlayPanel
 	private static final int OLM_PLANE = 0;
 	static final String BROADCAST_ACTION = "Broadcast layout";
 	static final String SCREENSHOT_ACTION = "Screenshot";
+	private static final int BORDER_OFFSET = 2;
+	private static final int ICON_SIZE = 32;
+	private static final int SMALL_ICON_SIZE = 21;
+	//might need to edit these if they are not standard
+	private static final int TITLE_COMPONENT_HEIGHT = 20;
+	private static final int LINE_COMPONENT_HEIGHT = 16;
 
 	private Client client;
 	private RaidsPlugin plugin;
 	private RaidsConfig config;
 
+	private final ItemManager itemManager;
+	private final SpriteManager spriteManager;
+	private final PanelComponent panelImages = new PanelComponent();
+
 	@Getter
 	private boolean scoutOverlayShown = false;
+
+	@Getter
+	private int width;
+
+	@Getter
+	private int height;
 
 	@Inject
 	private WorldService worldService;
 
 	@Inject
-	private RaidsOverlay(Client client, RaidsPlugin plugin, RaidsConfig config)
+	private RaidsOverlay(Client client, RaidsPlugin plugin, RaidsConfig config, ItemManager itemManager, SpriteManager spriteManager)
 	{
 		super(plugin);
 		setPosition(OverlayPosition.TOP_LEFT);
@@ -74,6 +103,8 @@ public class RaidsOverlay extends OverlayPanel
 		this.client = client;
 		this.plugin = plugin;
 		this.config = config;
+		this.itemManager = itemManager;
+		this.spriteManager = spriteManager;
 		getMenuEntries().add(new OverlayMenuEntry(RUNELITE_OVERLAY_CONFIG, OPTION_CONFIGURE, "Raids overlay"));
 		getMenuEntries().add(new OverlayMenuEntry(RUNELITE_OVERLAY, BROADCAST_ACTION, "Raids overlay"));
 		getMenuEntries().add(new OverlayMenuEntry(RUNELITE_OVERLAY, SCREENSHOT_ACTION, "Raids overlay"));
@@ -136,6 +167,11 @@ public class RaidsOverlay extends OverlayPanel
 				.build());
 		}
 
+		Set<Integer> imageIds = new HashSet<>();
+		FontMetrics metrics = graphics.getFontMetrics();
+		int roomWidth = 0;
+		int temp = 0;
+
 		for (Room layoutRoom : plugin.getRaid().getLayout().getRooms())
 		{
 			int position = layoutRoom.getPosition();
@@ -144,6 +180,12 @@ public class RaidsOverlay extends OverlayPanel
 			if (room == null)
 			{
 				continue;
+			}
+
+			temp = metrics.stringWidth(room.getName());
+			if (temp > roomWidth)
+			{
+				roomWidth = temp;
 			}
 
 			color = Color.WHITE;
@@ -161,30 +203,40 @@ public class RaidsOverlay extends OverlayPanel
 						color = Color.RED;
 					}
 
-					String name = room == RaidRoom.UNKNOWN_COMBAT ? "Unknown" : room.getName();
+					String bossName = room.getName();
+					String bossNameLC = bossName.toLowerCase();
+					if (config.showRecommendedItems())
+					{
+						if (plugin.getRecommendedItemsList().get(bossNameLC) != null)
+							imageIds.addAll(plugin.getRecommendedItemsList().get(bossNameLC));
+					}
 
 					panelComponent.getChildren().add(LineComponent.builder()
-						.left(room.getType().getName())
-						.right(name)
+						.left(config.showRecommendedItems() ? "" : room.getType().getName())
+						.right(bossName)
 						.rightColor(color)
 						.build());
 
 					break;
 
 				case PUZZLE:
-					if (plugin.getRoomWhitelist().contains(room.getName().toLowerCase()))
+					String puzzleName = room.getName();
+					String puzzleNameLC = puzzleName.toLowerCase();
+					if (plugin.getRecommendedItemsList().get(puzzleNameLC) != null)
+						imageIds.addAll(plugin.getRecommendedItemsList().get(puzzleNameLC));
+					if (plugin.getRoomWhitelist().contains(puzzleNameLC))
 					{
 						color = Color.GREEN;
 					}
-					else if (plugin.getRoomBlacklist().contains(room.getName().toLowerCase()))
+					else if (plugin.getRoomBlacklist().contains(puzzleNameLC))
 					{
 						color = Color.RED;
 					}
 
-					name = room == RaidRoom.UNKNOWN_PUZZLE ? "Unknown" : room.getName();
+					String name = room == RaidRoom.UNKNOWN_PUZZLE ? "Unknown" : puzzleName;
 
 					panelComponent.getChildren().add(LineComponent.builder()
-						.left(room.getType().getName())
+						.left(config.showRecommendedItems() ? "" : room.getType().getName())
 						.right(name)
 						.rightColor(color)
 						.build());
@@ -192,7 +244,41 @@ public class RaidsOverlay extends OverlayPanel
 			}
 		}
 
-		return super.render(graphics);
+		//add recommended items
+		Dimension panelDims = super.render(graphics);
+		width = (int) panelDims.getWidth();
+		height = (int) panelDims.getHeight();
+		if (config.showRecommendedItems() && imageIds.size() > 0)
+		{
+			panelImages.getChildren().clear();
+			Integer[] idArray = imageIds.toArray(new Integer[0]);
+			int imagesVerticalOffset = TITLE_COMPONENT_HEIGHT + (config.ccDisplay() ? LINE_COMPONENT_HEIGHT : 0) - BORDER_OFFSET;
+			int imagesMaxHeight = height - BORDER_OFFSET - imagesVerticalOffset;
+			boolean smallImages = false;
+
+			panelImages.setPreferredLocation(new Point(0, imagesVerticalOffset));
+			panelImages.setBackgroundColor(null);
+			panelImages.setWrap(true);
+			panelImages.setPreferredSize(new Dimension(2 * ICON_SIZE, 0));
+			if (2 * imagesMaxHeight / ICON_SIZE < idArray.length)
+			{
+				smallImages = true;
+				panelImages.setPreferredSize(new Dimension(3 * SMALL_ICON_SIZE, 0));
+			}
+
+			panelImages.setOrientation(ComponentOrientation.HORIZONTAL);
+			for (Integer e : idArray)
+			{
+				final BufferedImage image = getImage(e, smallImages);
+				if (image != null)
+				{
+					panelImages.getChildren().add(new ImageComponent(image));
+				}
+			}
+
+			panelImages.render(graphics);
+		}
+		return panelDims;
 	}
 
 	private boolean shouldShowOverlay()
@@ -223,5 +309,21 @@ public class RaidsOverlay extends OverlayPanel
 		}
 
 		return plugin.getRaidPartyID() != -1 && config.scoutOverlayAtBank();
+	}
+
+	private BufferedImage getImage(int id, boolean small)
+	{
+		BufferedImage bim;
+		if (id != SpriteID.SPELL_ICE_BARRAGE)
+			bim = itemManager.getImage(id);
+		else
+			bim = spriteManager.getSprite(id, 0);
+		if (bim == null)
+			return null;
+		if (!small)
+			return ImageUtil.resizeCanvas(bim, ICON_SIZE, ICON_SIZE);
+		if (id != SpriteID.SPELL_ICE_BARRAGE)
+			return ImageUtil.resizeImage(bim, SMALL_ICON_SIZE, SMALL_ICON_SIZE);
+		return ImageUtil.resizeCanvas(bim, SMALL_ICON_SIZE, SMALL_ICON_SIZE);
 	}
 }

--- a/runelite-client/src/test/java/net/runelite/client/plugins/raids/RaidsPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/raids/RaidsPluginTest.java
@@ -116,6 +116,7 @@ public class RaidsPluginTest
 		when(raidsConfig.blacklistedRooms()).thenReturn("");
 		when(raidsConfig.whitelistedRotations()).thenReturn("");
 		when(raidsConfig.whitelistedLayouts()).thenReturn("");
+		when(raidsConfig.recommendedItems()).thenReturn("");
 	}
 
 	@Test


### PR DESCRIPTION
example config:
![config](https://i.gyazo.com/9a16209e188b6db940b387681eba31da.png)
example image:
![items](https://i.gyazo.com/636604e6bea39bed4e325da91144c4a6.png)

If there are too many items to fit in the overlay, the image size is scaled down:
![scaled-down items](https://i.gyazo.com/e13eea23ee685d216894c1841ef578e2.png)

Split-off and updated from:
#6092 