### PR TITLE
chat notification: Apply notifyOnOwnName when player-mentioned only

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatnotifications/ChatNotificationsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatnotifications/ChatNotificationsConfig.java
@@ -58,7 +58,7 @@ public interface ChatNotificationsConfig extends Config
 		position = 2,
 		keyName = "notifyOnOwnName",
 		name = "Notify on own name",
-		description = "Notifies you whenever your name is mentioned"
+		description = "Notifies you whenever someone mentions you by name"
 	)
 	default boolean notifyOnOwnName()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatnotifications/ChatNotificationsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatnotifications/ChatNotificationsPlugin.java
@@ -34,6 +34,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
+import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
 import net.runelite.api.MessageNode;
 import net.runelite.api.events.ChatMessage;
@@ -186,8 +187,11 @@ public class ChatNotificationsPlugin extends Plugin
 			{
 				messageNode.setValue(matcher.replaceAll(usernameReplacer));
 				update = true;
-
-				if (config.notifyOnOwnName())
+				if (config.notifyOnOwnName() && (chatMessage.getType() == ChatMessageType.PUBLICCHAT
+					|| chatMessage.getType() == ChatMessageType.PRIVATECHAT
+					|| chatMessage.getType() == ChatMessageType.FRIENDSCHAT
+					|| chatMessage.getType() == ChatMessageType.MODCHAT
+					|| chatMessage.getType() == ChatMessageType.MODPRIVATECHAT))
 				{
 					sendNotification(chatMessage);
 				}


### PR DESCRIPTION
In an attempt to curb notification spam during PVM and other activities, this commit changes the behavior of notifyOnOwnName so that it only notifies the user when their name is mentioned in public, private, friendschat, modchat, or modprivatechat rather than every single time their name is mentioned.

Currently, if you want to be notified when someone mentions you by name, you are subject to notification inundation while doing PVM or other activities during which your name is mentioned regularly:
![2020-06-11_02-35-03 copy](https://user-images.githubusercontent.com/54762282/84360180-b303bf00-ab97-11ea-9ee8-90cda3a8cb50.png)

closes #10710