### PR TITLE
Menu Swapper plugin - essence pouch and bank features

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -584,4 +584,26 @@ public interface MenuEntrySwapperConfig extends Config
 	{
 		return false;
 	}
+
+	@ConfigItem(
+		keyName = "alwaysShiftModifyDeposit",
+		name = "Always shift deposit",
+		description = "Always shift-clicks when clicking on deposit",
+		section = itemSection
+	)
+	default boolean alwaysShiftModifyDeposit()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		keyName = "alwaysShiftModifyWithdraw",
+		name = "Always shift withdraw",
+		description = "Always shift-clicks when clicking on withdraw",
+		section = itemSection
+	)
+	default boolean alwaysShiftModifyWithdraw()
+	{
+		return false;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -562,4 +562,26 @@ public interface MenuEntrySwapperConfig extends Config
 	{
 		return false;
 	}
+
+	@ConfigItem(
+		keyName = "hideEmptyInBank",
+		name = "Hide empty in bank",
+		description = "Always hides empty in bank",
+		section = itemSection
+	)
+	default boolean hideEmptyInBank()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		keyName = "swapEssPouch",
+		name = "Empty essence pouch",
+		description = "Always empty essence pouch in inventory",
+		section = itemSection
+	)
+	default boolean swapEssPouch()
+	{
+		return false;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -345,6 +345,8 @@ public class MenuEntrySwapperPlugin extends Plugin
 		swap("collect-item", "bank", () -> config.swapGEItemCollect() == GEItemCollectMode.BANK);
 		swap("collect-items", "bank", () -> config.swapGEItemCollect() == GEItemCollectMode.BANK);
 
+		swap("fill", "empty", config::swapEssPouch);
+
 		swap("tan 1", "tan all", config::swapTan);
 
 		swapTeleport("varrock teleport", "grand exchange");
@@ -527,7 +529,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 		// Swap to shift-click deposit behavior
 		// Deposit- op 1 is the current withdraw amount 1/5/10/x for deposit box interface
 		// Deposit- op 2 is the current withdraw amount 1/5/10/x for bank interface
-		if (shiftModifier() && config.bankDepositShiftClick() != ShiftDepositMode.OFF
+		if ((shiftModifier() || config.alwaysShiftModifyDeposit()) && config.bankDepositShiftClick() != ShiftDepositMode.OFF
 			&& menuEntryAdded.getType() == MenuAction.CC_OP.getId() && (menuEntryAdded.getIdentifier() == 2 || menuEntryAdded.getIdentifier() == 1)
 			&& menuEntryAdded.getOption().startsWith("Deposit-"))
 		{
@@ -539,7 +541,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 
 		// Swap to shift-click withdraw behavior
 		// Deposit- op 1 is the current withdraw amount 1/5/10/x
-		if (shiftModifier() && config.bankWithdrawShiftClick() != ShiftWithdrawMode.OFF
+		if ((shiftModifier() || config.alwaysShiftModifyWithdraw()) && config.bankWithdrawShiftClick() != ShiftWithdrawMode.OFF
 			&& menuEntryAdded.getType() == MenuAction.CC_OP.getId() && menuEntryAdded.getIdentifier() == 1
 			&& menuEntryAdded.getOption().startsWith("Withdraw-"))
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -560,6 +560,10 @@ public class MenuEntrySwapperPlugin extends Plugin
 
 			if (entry.getType() == entryTypeId && entry.getIdentifier() == entryIdentifier)
 			{
+				if (config.hideEmptyInBank() && entry.getOption().equals("Empty"))
+				{
+					break;
+				}
 				// Raise the priority of the op so it doesn't get sorted later
 				entry.setType(MenuAction.CC_OP.getId());
 


### PR DESCRIPTION
Essence pouch options:
Hide empty in bank
Left-click fill in inventory

Bank features:
Toggle for always shift-modifying deposit
Toggle for always shift-modifying withdraw
