### PR TITLE
Added a setting to hide members items on f2p worlds.

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/bank/BankConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/bank/BankConfig.java
@@ -119,4 +119,15 @@ public interface BankConfig extends Config
 	{
 		return false;
 	}
+
+	@ConfigItem(
+			keyName = "hideMembersItems",
+			name = "Hide members items",
+			description = "Hides all members items in the bank on f2p worlds",
+			position = 9
+	)
+	default boolean hideMembersItems()
+	{
+		return false;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/bank/BankPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/bank/BankPlugin.java
@@ -65,10 +65,13 @@ import net.runelite.client.callback.ClientThread;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.game.ItemManager;
+import net.runelite.client.game.WorldService;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.plugins.banktags.tabs.BankSearch;
 import net.runelite.client.util.QuantityFormatter;
+import net.runelite.http.api.worlds.WorldResult;
+import net.runelite.http.api.worlds.WorldType;
 
 @PluginDescriptor(
 	name = "Bank",
@@ -108,6 +111,9 @@ public class BankPlugin extends Plugin
 
 	@Inject
 	private ItemManager itemManager;
+
+    @Inject
+    private WorldService worldService;
 
 	@Inject
 	private BankConfig config;
@@ -180,6 +186,22 @@ public class BankPlugin extends Plugin
 		String[] stringStack = client.getStringStack();
 		int intStackSize = client.getIntStackSize();
 		int stringStackSize = client.getStringStackSize();
+
+		WorldResult worlds = worldService.getWorlds();
+		if (config.hideMembersItems() && !worlds.findWorld(client.getWorld()).getTypes().contains(WorldType.MEMBERS))
+		{
+			Widget itemContainer = client.getWidget(WidgetID.BANK_GROUP_ID, 12);
+			if (itemContainer != null) {
+				Widget[] children = itemContainer.getDynamicChildren();
+				for (int i = 0; i < children.length; i++) {
+					int realItemId = itemManager.canonicalize(children[i].getItemId());
+					ItemComposition itemComposition = itemManager.getItemComposition(realItemId);
+					if (itemComposition.isMembers()){
+						children[i].setOpacity(200);
+					}
+				}
+			}
+		}
 
 		switch (event.getEventName())
 		{


### PR DESCRIPTION
This pull request isn't quite done yet, but it does show what I want it to do.
The pull request adds a new setting to the bank plugin, off by default, that allows users to 'hide' members items when the player is on a f2p world.

Hide might not be the right word here, as it only changes the transparency.
Some bit of the code could do with some improvement and I hope you can give me some advice on this.

Examples:
- Currently this code runs very often, but I couldn't find a handler that covered all the situations the code should run other than where I implemented it now.
- If you turn the setting 'on' it updates correctly if you are already in the bank, but turning it 'off' requires closing the bank interface and re-opening it.
- The code that checks whether an item is members only, and whether a world is members only feel bloated, but I can't find a way to find this information more directly.