### PR TITLE
1.6.18

### DIFF
--- a/cache-client/pom.xml
+++ b/cache-client/pom.xml
@@ -29,7 +29,7 @@
 	<parent>
 		<groupId>net.runelite</groupId>
 		<artifactId>runelite-parent</artifactId>
-		<version>1.6.18.1</version>
+		<version>1.6.18.2-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>cache-client</artifactId>

--- a/cache-client/pom.xml
+++ b/cache-client/pom.xml
@@ -29,7 +29,7 @@
 	<parent>
 		<groupId>net.runelite</groupId>
 		<artifactId>runelite-parent</artifactId>
-		<version>1.6.18</version>
+		<version>1.6.18.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>cache-client</artifactId>

--- a/cache-client/pom.xml
+++ b/cache-client/pom.xml
@@ -29,7 +29,7 @@
 	<parent>
 		<groupId>net.runelite</groupId>
 		<artifactId>runelite-parent</artifactId>
-		<version>1.6.18.1-SNAPSHOT</version>
+		<version>1.6.18.1</version>
 	</parent>
 
 	<artifactId>cache-client</artifactId>

--- a/cache-updater/pom.xml
+++ b/cache-updater/pom.xml
@@ -28,7 +28,7 @@
 	<parent>
 		<groupId>net.runelite</groupId>
 		<artifactId>runelite-parent</artifactId>
-		<version>1.6.18.1-SNAPSHOT</version>
+		<version>1.6.18.1</version>
 	</parent>
 	
 	<name>Cache Updater</name>

--- a/cache-updater/pom.xml
+++ b/cache-updater/pom.xml
@@ -28,7 +28,7 @@
 	<parent>
 		<groupId>net.runelite</groupId>
 		<artifactId>runelite-parent</artifactId>
-		<version>1.6.18</version>
+		<version>1.6.18.1-SNAPSHOT</version>
 	</parent>
 	
 	<name>Cache Updater</name>

--- a/cache-updater/pom.xml
+++ b/cache-updater/pom.xml
@@ -28,7 +28,7 @@
 	<parent>
 		<groupId>net.runelite</groupId>
 		<artifactId>runelite-parent</artifactId>
-		<version>1.6.18.1</version>
+		<version>1.6.18.2-SNAPSHOT</version>
 	</parent>
 	
 	<name>Cache Updater</name>

--- a/cache/pom.xml
+++ b/cache/pom.xml
@@ -29,7 +29,7 @@
 	<parent>
 		<groupId>net.runelite</groupId>
 		<artifactId>runelite-parent</artifactId>
-		<version>1.6.18.1</version>
+		<version>1.6.18.2-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>cache</artifactId>

--- a/cache/pom.xml
+++ b/cache/pom.xml
@@ -29,7 +29,7 @@
 	<parent>
 		<groupId>net.runelite</groupId>
 		<artifactId>runelite-parent</artifactId>
-		<version>1.6.18.1-SNAPSHOT</version>
+		<version>1.6.18.1</version>
 	</parent>
 
 	<artifactId>cache</artifactId>

--- a/cache/pom.xml
+++ b/cache/pom.xml
@@ -29,7 +29,7 @@
 	<parent>
 		<groupId>net.runelite</groupId>
 		<artifactId>runelite-parent</artifactId>
-		<version>1.6.18</version>
+		<version>1.6.18.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>cache</artifactId>

--- a/http-api/pom.xml
+++ b/http-api/pom.xml
@@ -28,7 +28,7 @@
 	<parent>
 		<groupId>net.runelite</groupId>
 		<artifactId>runelite-parent</artifactId>
-		<version>1.6.18.1</version>
+		<version>1.6.18.2-SNAPSHOT</version>
 	</parent>
 
 	<name>Web API</name>

--- a/http-api/pom.xml
+++ b/http-api/pom.xml
@@ -28,7 +28,7 @@
 	<parent>
 		<groupId>net.runelite</groupId>
 		<artifactId>runelite-parent</artifactId>
-		<version>1.6.18.1-SNAPSHOT</version>
+		<version>1.6.18.1</version>
 	</parent>
 
 	<name>Web API</name>

--- a/http-api/pom.xml
+++ b/http-api/pom.xml
@@ -28,7 +28,7 @@
 	<parent>
 		<groupId>net.runelite</groupId>
 		<artifactId>runelite-parent</artifactId>
-		<version>1.6.18</version>
+		<version>1.6.18.1-SNAPSHOT</version>
 	</parent>
 
 	<name>Web API</name>

--- a/http-service/pom.xml
+++ b/http-service/pom.xml
@@ -28,7 +28,7 @@
 	<parent>
 		<groupId>net.runelite</groupId>
 		<artifactId>runelite-parent</artifactId>
-		<version>1.6.18</version>
+		<version>1.6.18.1-SNAPSHOT</version>
 	</parent>
 
 	<name>Web Service</name>

--- a/http-service/pom.xml
+++ b/http-service/pom.xml
@@ -28,7 +28,7 @@
 	<parent>
 		<groupId>net.runelite</groupId>
 		<artifactId>runelite-parent</artifactId>
-		<version>1.6.18.1</version>
+		<version>1.6.18.2-SNAPSHOT</version>
 	</parent>
 
 	<name>Web Service</name>

--- a/http-service/pom.xml
+++ b/http-service/pom.xml
@@ -28,7 +28,7 @@
 	<parent>
 		<groupId>net.runelite</groupId>
 		<artifactId>runelite-parent</artifactId>
-		<version>1.6.18.1-SNAPSHOT</version>
+		<version>1.6.18.1</version>
 	</parent>
 
 	<name>Web Service</name>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 
 	<groupId>net.runelite</groupId>
 	<artifactId>runelite-parent</artifactId>
-	<version>1.6.18.1</version>
+	<version>1.6.18.2-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>RuneLite</name>
@@ -60,7 +60,7 @@
 		<url>https://github.com/runelite/runelite</url>
 		<connection>scm:git:git://github.com/runelite/runelite</connection>
 		<developerConnection>scm:git:git@github.com:runelite/runelite</developerConnection>
-		<tag>runelite-parent-1.6.18.1</tag>
+		<tag>HEAD</tag>
 	</scm>
 
 	<developers>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 
 	<groupId>net.runelite</groupId>
 	<artifactId>runelite-parent</artifactId>
-	<version>1.6.18</version>
+	<version>1.6.18.1-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>RuneLite</name>
@@ -60,7 +60,7 @@
 		<url>https://github.com/runelite/runelite</url>
 		<connection>scm:git:git://github.com/runelite/runelite</connection>
 		<developerConnection>scm:git:git@github.com:runelite/runelite</developerConnection>
-		<tag>runelite-parent-1.6.18</tag>
+		<tag>HEAD</tag>
 	</scm>
 
 	<developers>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 
 	<groupId>net.runelite</groupId>
 	<artifactId>runelite-parent</artifactId>
-	<version>1.6.18.1-SNAPSHOT</version>
+	<version>1.6.18.1</version>
 	<packaging>pom</packaging>
 
 	<name>RuneLite</name>
@@ -60,7 +60,7 @@
 		<url>https://github.com/runelite/runelite</url>
 		<connection>scm:git:git://github.com/runelite/runelite</connection>
 		<developerConnection>scm:git:git@github.com:runelite/runelite</developerConnection>
-		<tag>HEAD</tag>
+		<tag>runelite-parent-1.6.18.1</tag>
 	</scm>
 
 	<developers>

--- a/runelite-api/pom.xml
+++ b/runelite-api/pom.xml
@@ -29,7 +29,7 @@
 	<parent>
 		<groupId>net.runelite</groupId>
 		<artifactId>runelite-parent</artifactId>
-		<version>1.6.18.1</version>
+		<version>1.6.18.2-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>runelite-api</artifactId>

--- a/runelite-api/pom.xml
+++ b/runelite-api/pom.xml
@@ -29,7 +29,7 @@
 	<parent>
 		<groupId>net.runelite</groupId>
 		<artifactId>runelite-parent</artifactId>
-		<version>1.6.18</version>
+		<version>1.6.18.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>runelite-api</artifactId>

--- a/runelite-api/pom.xml
+++ b/runelite-api/pom.xml
@@ -29,7 +29,7 @@
 	<parent>
 		<groupId>net.runelite</groupId>
 		<artifactId>runelite-parent</artifactId>
-		<version>1.6.18.1-SNAPSHOT</version>
+		<version>1.6.18.1</version>
 	</parent>
 
 	<artifactId>runelite-api</artifactId>

--- a/runelite-client/pom.xml
+++ b/runelite-client/pom.xml
@@ -29,7 +29,7 @@
 	<parent>
 		<groupId>net.runelite</groupId>
 		<artifactId>runelite-parent</artifactId>
-		<version>1.6.18</version>
+		<version>1.6.18.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>client</artifactId>

--- a/runelite-client/pom.xml
+++ b/runelite-client/pom.xml
@@ -29,7 +29,7 @@
 	<parent>
 		<groupId>net.runelite</groupId>
 		<artifactId>runelite-parent</artifactId>
-		<version>1.6.18.1</version>
+		<version>1.6.18.2-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>client</artifactId>

--- a/runelite-client/pom.xml
+++ b/runelite-client/pom.xml
@@ -29,7 +29,7 @@
 	<parent>
 		<groupId>net.runelite</groupId>
 		<artifactId>runelite-parent</artifactId>
-		<version>1.6.18.1-SNAPSHOT</version>
+		<version>1.6.18.1</version>
 	</parent>
 
 	<artifactId>client</artifactId>

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangePlugin.java
@@ -377,6 +377,13 @@ public class GrandExchangePlugin extends Plugin
 		final int slot = offerEvent.getSlot();
 		final GrandExchangeOffer offer = offerEvent.getOffer();
 
+		if (offer.getState() == GrandExchangeOfferState.EMPTY && client.getGameState() != GameState.LOGGED_IN)
+		{
+			// Trades are cleared by the client during LOGIN_SCREEN/HOPPING/LOGGING_IN, ignore those so we don't
+			// zero and re-submit the trade on login as an update
+			return;
+		}
+
 		log.debug("GE offer updated: state: {}, slot: {}, item: {}, qty: {}, login: {}",
 			offer.getState(), slot, offer.getItemId(), offer.getQuantitySold(), loginBurstGeUpdates);
 

--- a/runelite-client/src/test/java/net/runelite/client/plugins/grandexchange/GrandExchangePluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/grandexchange/GrandExchangePluginTest.java
@@ -33,10 +33,12 @@ import java.util.List;
 import java.util.concurrent.ScheduledExecutorService;
 import javax.inject.Inject;
 import net.runelite.api.Client;
+import net.runelite.api.GameState;
 import net.runelite.api.GrandExchangeOffer;
 import net.runelite.api.GrandExchangeOfferState;
 import net.runelite.api.ItemID;
 import net.runelite.api.WorldType;
+import net.runelite.api.events.GrandExchangeOfferChanged;
 import net.runelite.client.Notifier;
 import net.runelite.client.account.SessionManager;
 import net.runelite.client.config.ConfigManager;
@@ -55,6 +57,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import org.mockito.Mock;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
@@ -217,5 +220,21 @@ public class GrandExchangePluginTest
 		assertEquals(1, trade.getQty());
 		assertEquals(10, trade.getTotal());
 		assertEquals(25, trade.getSpent());
+	}
+
+	@Test
+	public void testHop()
+	{
+		when(client.getGameState()).thenReturn(GameState.HOPPING);
+
+		GrandExchangeOffer grandExchangeOffer = mock(GrandExchangeOffer.class);
+		when(grandExchangeOffer.getState()).thenReturn(GrandExchangeOfferState.EMPTY);
+
+		GrandExchangeOfferChanged grandExchangeOfferChanged = new GrandExchangeOfferChanged();
+		grandExchangeOfferChanged.setOffer(grandExchangeOffer);
+
+		grandExchangePlugin.onGrandExchangeOfferChanged(grandExchangeOfferChanged);
+
+		verify(configManager, never()).unsetConfiguration(anyString(), anyString());
 	}
 }

--- a/runelite-script-assembler-plugin/pom.xml
+++ b/runelite-script-assembler-plugin/pom.xml
@@ -29,7 +29,7 @@
 	<parent>
 		<groupId>net.runelite</groupId>
 		<artifactId>runelite-parent</artifactId>
-		<version>1.6.18.1</version>
+		<version>1.6.18.2-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>script-assembler-plugin</artifactId>

--- a/runelite-script-assembler-plugin/pom.xml
+++ b/runelite-script-assembler-plugin/pom.xml
@@ -29,7 +29,7 @@
 	<parent>
 		<groupId>net.runelite</groupId>
 		<artifactId>runelite-parent</artifactId>
-		<version>1.6.18.1-SNAPSHOT</version>
+		<version>1.6.18.1</version>
 	</parent>
 
 	<artifactId>script-assembler-plugin</artifactId>

--- a/runelite-script-assembler-plugin/pom.xml
+++ b/runelite-script-assembler-plugin/pom.xml
@@ -29,7 +29,7 @@
 	<parent>
 		<groupId>net.runelite</groupId>
 		<artifactId>runelite-parent</artifactId>
-		<version>1.6.18</version>
+		<version>1.6.18.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>script-assembler-plugin</artifactId>


### PR DESCRIPTION
Currently the 2005 Interface chatbox has **neither** the proper "torn page" effect nor is it even the side and top lines of text get cut off frequently.

Please make it **even** like this while having the "unclean" effect. 

I understand we cannot do the torn effect properly but making it like this it still has the 2005 aesthetic while enabling us to be able to read all text in game. 

![EabgYskX0AAG0_k](https://user-images.githubusercontent.com/66905841/84591835-878b0980-ae0f-11ea-952a-0fc439c6ca42.png)