### PR TITLE
ChatFilter: Add config section for Filter Lists

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatfilter/ChatFilterConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatfilter/ChatFilterConfig.java
@@ -125,7 +125,7 @@ public interface ChatFilterConfig extends Config
 		keyName = "collapseGameChat",
 		name = "Collapse Game Chat",
 		description = "Collapse duplicate game chat messages into a single line",
-		position = 8
+		position = 9
 	)
 	default boolean collapseGameChat()
 	{
@@ -136,7 +136,7 @@ public interface ChatFilterConfig extends Config
 		keyName = "collapsePlayerChat",
 		name = "Collapse Player Chat",
 		description = "Collapse duplicate player chat messages into a single line",
-		position = 9
+		position = 10
 	)
 	default boolean collapsePlayerChat()
 	{
@@ -147,7 +147,7 @@ public interface ChatFilterConfig extends Config
 		keyName = "maxRepeatedPublicChats",
 		name = "Max repeated public chats",
 		description = "Block player chat message if repeated this many times. 0 is off",
-		position = 10
+		position = 11
 	)
 	default int maxRepeatedPublicChats()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatfilter/ChatFilterConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatfilter/ChatFilterConfig.java
@@ -28,26 +28,25 @@ package net.runelite.client.plugins.chatfilter;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.ConfigSection;
 
 @ConfigGroup("chatfilter")
 public interface ChatFilterConfig extends Config
 {
-	@ConfigItem(
-		keyName = "filterType",
-		name = "Filter type",
-		description = "Configures how the messages are filtered",
-		position = 1
+	@ConfigSection(
+		name = "Filter Lists",
+		description = "Custom Word, Regex, and Username filter lists",
+		position = 0,
+		closedByDefault = true
 	)
-	default ChatFilterType filterType()
-	{
-		return ChatFilterType.CENSOR_WORDS;
-	}
+	String filterLists = "filterLists";
 
 	@ConfigItem(
 		keyName = "filteredWords",
 		name = "Filtered Words",
 		description = "List of filtered words, separated by commas",
-		position = 2
+		position = 1,
+		section = filterLists
 	)
 	default String filteredWords()
 	{
@@ -58,7 +57,8 @@ public interface ChatFilterConfig extends Config
 		keyName = "filteredRegex",
 		name = "Filtered Regex",
 		description = "List of regular expressions to filter, one per line",
-		position = 3
+		position = 2,
+		section = filterLists
 	)
 	default String filteredRegex()
 	{
@@ -69,11 +69,23 @@ public interface ChatFilterConfig extends Config
 		keyName = "filteredNames",
 		name = "Filtered Names",
 		description = "List of filtered names, one per line. Accepts regular expressions",
-		position = 4
+		position = 3,
+		section = filterLists
 	)
 	default String filteredNames()
 	{
 		return "";
+	}
+
+	@ConfigItem(
+		keyName = "filterType",
+		name = "Filter type",
+		description = "Configures how the messages are filtered",
+		position = 4
+	)
+	default ChatFilterType filterType()
+	{
+		return ChatFilterType.CENSOR_WORDS;
 	}
 
 	@ConfigItem(
@@ -113,7 +125,7 @@ public interface ChatFilterConfig extends Config
 		keyName = "collapseGameChat",
 		name = "Collapse Game Chat",
 		description = "Collapse duplicate game chat messages into a single line",
-		position = 9
+		position = 8
 	)
 	default boolean collapseGameChat()
 	{
@@ -124,7 +136,7 @@ public interface ChatFilterConfig extends Config
 		keyName = "collapsePlayerChat",
 		name = "Collapse Player Chat",
 		description = "Collapse duplicate player chat messages into a single line",
-		position = 10
+		position = 9
 	)
 	default boolean collapsePlayerChat()
 	{
@@ -135,7 +147,7 @@ public interface ChatFilterConfig extends Config
 		keyName = "maxRepeatedPublicChats",
 		name = "Max repeated public chats",
 		description = "Block player chat message if repeated this many times. 0 is off",
-		position = 11
+		position = 10
 	)
 	default int maxRepeatedPublicChats()
 	{


### PR DESCRIPTION
The chat filter config can get pretty unruly if you have a lot of word and regex filters. This adds a config section akin to the `Item Lists` section in `Ground Items`.  `Filter type` config is shifted down to be with the rest of the configs.

<img width="243" alt="Screen Shot 2020-06-14 at 6 26 23 PM" src="https://user-images.githubusercontent.com/54762282/84605812-46761200-ae6e-11ea-8803-976b987e110a.png">
