### PR TITLE
deathindicators: add clear option to infobox

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/MenuAction.java
+++ b/runelite-api/src/main/java/net/runelite/api/MenuAction.java
@@ -277,6 +277,10 @@ public enum MenuAction
 	 * a player and have its identifier set to a player index.
 	 */
 	RUNELITE_PLAYER(1503),
+	/**
+	 * Menu action injected by runelite for infobox menu entries
+	 */
+	RUNELITE_INFOBOX(1504),
 
 	/**
 	 * Menu action triggered when the id is not defined in this class.

--- a/runelite-client/src/main/java/net/runelite/client/RuneLite.java
+++ b/runelite-client/src/main/java/net/runelite/client/RuneLite.java
@@ -347,6 +347,7 @@ public class RuneLite
 
 			eventBus.register(partyService.get());
 			eventBus.register(overlayRenderer.get());
+			eventBus.register(infoBoxOverlay.get());
 			eventBus.register(friendsChatManager.get());
 			eventBus.register(itemManager.get());
 			eventBus.register(menuManager.get());

--- a/runelite-client/src/main/java/net/runelite/client/events/InfoBoxMenuClicked.java
+++ b/runelite-client/src/main/java/net/runelite/client/events/InfoBoxMenuClicked.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2020, ThatGamerBlue <thatgamerblue@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.events;
+
+import lombok.Value;
+import net.runelite.client.ui.overlay.OverlayMenuEntry;
+import net.runelite.client.ui.overlay.infobox.InfoBox;
+
+/**
+ * Event fired when a menu option on an {@link InfoBox} is clicked
+ */
+@Value
+public class InfoBoxMenuClicked
+{
+	OverlayMenuEntry entry;
+	InfoBox infoBox;
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/devtools/DevToolsPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/devtools/DevToolsPanel.java
@@ -33,9 +33,11 @@ import javax.inject.Inject;
 import javax.swing.JButton;
 import javax.swing.JPanel;
 import net.runelite.api.Client;
+import net.runelite.api.MenuAction;
 import net.runelite.client.Notifier;
 import net.runelite.client.ui.ColorScheme;
 import net.runelite.client.ui.PluginPanel;
+import net.runelite.client.ui.overlay.OverlayMenuEntry;
 import net.runelite.client.ui.overlay.infobox.Counter;
 import net.runelite.client.ui.overlay.infobox.InfoBoxManager;
 import net.runelite.client.util.ImageUtil;
@@ -166,7 +168,13 @@ class DevToolsPanel extends PluginPanel
 		});
 
 		final JButton newInfoboxBtn = new JButton("Infobox");
-		newInfoboxBtn.addActionListener(e -> infoBoxManager.addInfoBox(new Counter(ImageUtil.getResourceStreamFromClass(getClass(), "devtools_icon.png"), plugin, 42)));
+		newInfoboxBtn.addActionListener(e ->
+		{
+			Counter c = new Counter(ImageUtil.getResourceStreamFromClass(getClass(), "devtools_icon.png"), plugin, 42);
+			c.getMenuEntries().add(new OverlayMenuEntry(MenuAction.RUNELITE_INFOBOX, "Test Option", "DevTools"));
+			infoBoxManager.addInfoBox(c);
+			c.setCount(c.getId());
+		});
 		container.add(newInfoboxBtn);
 
 		final JButton clearInfoboxBtn = new JButton("Clear Infobox");

--- a/runelite-client/src/main/java/net/runelite/client/plugins/devtools/DevToolsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/devtools/DevToolsPlugin.java
@@ -55,14 +55,17 @@ import net.runelite.client.chat.QueuedMessage;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.EventBus;
 import net.runelite.client.eventbus.Subscribe;
+import net.runelite.client.events.InfoBoxMenuClicked;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.ClientToolbar;
 import net.runelite.client.ui.JagexColors;
 import net.runelite.client.ui.NavigationButton;
 import net.runelite.client.ui.overlay.OverlayManager;
+import net.runelite.client.ui.overlay.OverlayMenuEntry;
 import net.runelite.client.util.ColorUtil;
 import net.runelite.client.util.ImageUtil;
+import net.runelite.client.util.Text;
 import org.slf4j.LoggerFactory;
 
 @PluginDescriptor(
@@ -455,6 +458,20 @@ public class DevToolsPlugin extends Plugin
 
 			entry.setTarget(entry.getTarget() + " " + ColorUtil.prependColorTag("(" + info + ")", JagexColors.MENU_TARGET));
 			client.setMenuEntries(entries);
+		}
+	}
+
+	@Subscribe
+	public void onInfoBoxMenuClicked(InfoBoxMenuClicked event)
+	{
+		OverlayMenuEntry entry = event.getEntry();
+		if (entry.getMenuAction() == MenuAction.RUNELITE_INFOBOX &&
+			entry.getOption().equals("Test Option") &&
+			// this would preferably be event.getInfoBox() == infoBox
+			// however we don't store an infobox reference in the plugin
+			Text.removeTags(entry.getTarget()).equals("DevTools"))
+		{
+			client.addChatMessage(ChatMessageType.GAMEMESSAGE, "", "InfoBox clicked with id " + event.getInfoBox().getId(), "");
 		}
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/components/InfoBoxComponent.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/components/InfoBoxComponent.java
@@ -32,9 +32,11 @@ import java.awt.Graphics2D;
 import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.image.BufferedImage;
+import java.util.List;
 import lombok.Getter;
 import lombok.Setter;
 import net.runelite.client.ui.FontManager;
+import net.runelite.client.ui.overlay.OverlayMenuEntry;
 
 @Setter
 public class InfoBoxComponent implements LayoutableRenderableEntity
@@ -44,6 +46,12 @@ public class InfoBoxComponent implements LayoutableRenderableEntity
 
 	@Getter
 	private String tooltip;
+
+	@Getter
+	private List<OverlayMenuEntry> menuEntries;
+
+	@Getter
+	private int parentId = -1;
 
 	@Getter
 	private final Rectangle bounds = new Rectangle();

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/infobox/InfoBox.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/infobox/InfoBox.java
@@ -26,11 +26,15 @@ package net.runelite.client.ui.overlay.infobox;
 
 import java.awt.Color;
 import java.awt.image.BufferedImage;
+import java.util.ArrayList;
+import java.util.List;
 import javax.annotation.Nonnull;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
+import net.runelite.api.annotations.VisibleForDevtools;
 import net.runelite.client.plugins.Plugin;
+import net.runelite.client.ui.overlay.OverlayMenuEntry;
 
 public abstract class InfoBox
 {
@@ -46,6 +50,15 @@ public abstract class InfoBox
 	@Setter(AccessLevel.PACKAGE)
 	private BufferedImage scaledImage;
 
+	/**
+	 * Used to distinguish between infoboxes when clicked.
+	 * Only populated when this InfoBox instance is added to the canvas by calling {@link net.runelite.client.ui.overlay.infobox.InfoBoxManager#addInfoBox(InfoBox)}
+	 */
+	@VisibleForDevtools
+	@Getter
+	@Setter(AccessLevel.PACKAGE)
+	private int id;
+
 	@Getter(AccessLevel.PACKAGE)
 	@Setter
 	private InfoBoxPriority priority;
@@ -53,6 +66,10 @@ public abstract class InfoBox
 	@Getter
 	@Setter
 	private String tooltip;
+
+	@Getter
+	@Setter
+	private List<OverlayMenuEntry> menuEntries = new ArrayList<>();
 
 	public InfoBox(BufferedImage image, @Nonnull Plugin plugin)
 	{


### PR DESCRIPTION
Closes #6410

Adds the ability to add menu entries to infoboxes, mostly copied from relevant code in the overlay renderer and manager.

(The menu option didn't appear on the first click because I missed the shift key)

![demo gif](https://user-images.githubusercontent.com/29176781/84824873-7d882700-b018-11ea-87ef-f82b339e67e2.gif)