### PR TITLE
LootTracker update for Coffins in Hallowed Sepulchre

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
@@ -576,15 +576,13 @@ public class LootTrackerPlugin extends Plugin
 			return;
 		}
 
-		if (isPlayerWithinMapRegion(HALLOWED_SEPULCHRE_MAP_REGIONS))
+		if (message.equals(COFFIN_LOOTED_MESSAGE) &&
+			isPlayerWithinMapRegion(HALLOWED_SEPULCHRE_MAP_REGIONS))
 		{
-			if (message.equals(COFFIN_LOOTED_MESSAGE))
-			{
-				eventType = HALLOWED_SEPULCHRE_COFFIN_EVENT;
-				lootRecordType = LootRecordType.EVENT;
-				takeInventorySnapshot();
-				return;
-			}
+			eventType = HALLOWED_SEPULCHRE_COFFIN_EVENT;
+			lootRecordType = LootRecordType.EVENT;
+			takeInventorySnapshot();
+			return;
 		}
 
 		if (message.equals(HERBIBOAR_LOOTED_MESSAGE))

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
@@ -691,7 +691,10 @@ public class LootTrackerPlugin extends Plugin
 			|| lootRecordType == LootRecordType.PICKPOCKET)
 		{
 			WorldPoint playerLocation = client.getLocalPlayer().getWorldLocation();
-			Collection<ItemStack> groundItems = lootManager.getItemSpawns(playerLocation);
+			ItemContainer playerInventory = client.getItemContainer(InventoryID.INVENTORY);
+			long playerInventoryCount = Arrays.stream(playerInventory.getItems()).filter(item -> item.getId() != -1).count();
+
+			Collection<ItemStack> groundItems = (playerInventoryCount == 28) ? lootManager.getItemSpawns(playerLocation) : new ArrayList<>();
 
 			processInventoryLoot(eventType, lootRecordType, event.getItemContainer(), groundItems);
 			eventType = null;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
@@ -179,6 +179,11 @@ public class LootTrackerPlugin extends Plugin
 		put(ObjectID.SILVER_CHEST_4130, "Silver key purple").
 		build();
 
+	// Hallow Sepulchre Coffin handling
+	static final String COFFIN_LOOTED_MESSAGE = "You push the coffin lid aside.";
+	static final String HALLOWED_SEPULCHRE_COFFIN_EVENT = "Coffin (Hallowed Sepulchre)";
+	static final Set<Integer> HALLOWED_SEPULCHRE_MAP_REGIONS = ImmutableSet.of(8797, 10077, 9308, 10074, 9050); // one map region per floor
+
 	// Last man standing map regions
 	private static final Set<Integer> LAST_MAN_STANDING_REGIONS = ImmutableSet.of(13658, 13659, 13914, 13915, 13916);
 
@@ -447,7 +452,7 @@ public class LootTrackerPlugin extends Plugin
 	public void onPlayerLootReceived(final PlayerLootReceived playerLootReceived)
 	{
 		// Ignore Last Man Standing player loots
-		if (isAtLMS())
+		if (isPlayerWithinMapRegion(LAST_MAN_STANDING_REGIONS))
 		{
 			return;
 		}
@@ -572,6 +577,17 @@ public class LootTrackerPlugin extends Plugin
 			return;
 		}
 
+		if (isPlayerWithinMapRegion(HALLOWED_SEPULCHRE_MAP_REGIONS))
+		{
+			if (message.equals(COFFIN_LOOTED_MESSAGE))
+			{
+				eventType = HALLOWED_SEPULCHRE_COFFIN_EVENT;
+				lootRecordType = LootRecordType.EVENT;
+				takeInventorySnapshot();
+				return;
+			}
+		}
+
 		if (message.equals(HERBIBOAR_LOOTED_MESSAGE))
 		{
 			if (processHerbiboarHerbSackLoot(event.getTimestamp()))
@@ -668,6 +684,7 @@ public class LootTrackerPlugin extends Plugin
 
 		if (CHEST_EVENT_TYPES.containsValue(eventType)
 			|| SHADE_CHEST_OBJECTS.containsValue(eventType)
+			|| HALLOWED_SEPULCHRE_COFFIN_EVENT.equals(eventType)
 			|| HERBIBOAR_EVENT.equals(eventType)
 			|| HESPORI_EVENT.equals(eventType)
 			|| SEEDPACK_EVENT.equals(eventType)
@@ -895,13 +912,13 @@ public class LootTrackerPlugin extends Plugin
 	}
 
 	/**
-	 * Is player at the Last Man Standing minigame
+	 * Is player currently within the provided map regions
 	 */
-	private boolean isAtLMS()
+	private boolean isPlayerWithinMapRegion(Set<Integer> definedMapRegions)
 	{
 		final int[] mapRegions = client.getMapRegions();
 
-		for (int region : LAST_MAN_STANDING_REGIONS)
+		for (int region : definedMapRegions)
 		{
 			if (ArrayUtils.contains(mapRegions, region))
 			{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
@@ -692,9 +692,7 @@ public class LootTrackerPlugin extends Plugin
 		{
 			WorldPoint playerLocation = client.getLocalPlayer().getWorldLocation();
 			ItemContainer playerInventory = client.getItemContainer(InventoryID.INVENTORY);
-			long playerInventoryCount = Arrays.stream(playerInventory.getItems()).filter(item -> item.getId() != -1).count();
-
-			Collection<ItemStack> groundItems = (playerInventoryCount == 28) ? lootManager.getItemSpawns(playerLocation) : new ArrayList<>();
+			Collection<ItemStack> groundItems = (playerInventory.contains(-1)) ? new ArrayList<>() : lootManager.getItemSpawns(playerLocation);
 
 			processInventoryLoot(eventType, lootRecordType, event.getItemContainer(), groundItems);
 			eventType = null;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
@@ -181,7 +181,6 @@ public class LootTrackerPlugin extends Plugin
 	// Hallow Sepulchre Coffin handling
 	static final String COFFIN_LOOTED_MESSAGE = "You push the coffin lid aside.";
 	static final String HALLOWED_SEPULCHRE_COFFIN_EVENT = "Coffin (Hallowed Sepulchre)";
-	@VisibleForTesting
 	static final Set<Integer> HALLOWED_SEPULCHRE_MAP_REGIONS = ImmutableSet.of(8797, 10077, 9308, 10074, 9050); // one map region per floor
 
 	// Last man standing map regions
@@ -691,8 +690,7 @@ public class LootTrackerPlugin extends Plugin
 			|| lootRecordType == LootRecordType.PICKPOCKET)
 		{
 			WorldPoint playerLocation = client.getLocalPlayer().getWorldLocation();
-			ItemContainer playerInventory = client.getItemContainer(InventoryID.INVENTORY);
-			Collection<ItemStack> groundItems = (playerInventory.contains(-1)) ? new ArrayList<>() : lootManager.getItemSpawns(playerLocation);
+			Collection<ItemStack> groundItems = lootManager.getItemSpawns(playerLocation);
 
 			processInventoryLoot(eventType, lootRecordType, event.getItemContainer(), groundItems);
 			eventType = null;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
@@ -181,6 +181,7 @@ public class LootTrackerPlugin extends Plugin
 	// Hallow Sepulchre Coffin handling
 	static final String COFFIN_LOOTED_MESSAGE = "You push the coffin lid aside.";
 	static final String HALLOWED_SEPULCHRE_COFFIN_EVENT = "Coffin (Hallowed Sepulchre)";
+	@VisibleForTesting
 	static final Set<Integer> HALLOWED_SEPULCHRE_MAP_REGIONS = ImmutableSet.of(8797, 10077, 9308, 10074, 9050); // one map region per floor
 
 	// Last man standing map regions
@@ -916,7 +917,7 @@ public class LootTrackerPlugin extends Plugin
 	/**
 	 * Is player currently within the provided map regions
 	 */
-	private boolean isPlayerWithinMapRegion(Set<Integer> definedMapRegions)
+	boolean isPlayerWithinMapRegion(Set<Integer> definedMapRegions)
 	{
 		final int[] mapRegions = client.getMapRegions();
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
@@ -112,7 +112,6 @@ import net.runelite.http.api.loottracker.LootAggregate;
 import net.runelite.http.api.loottracker.LootRecord;
 import net.runelite.http.api.loottracker.LootRecordType;
 import net.runelite.http.api.loottracker.LootTrackerClient;
-import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.text.WordUtils;
 
 @PluginDescriptor(
@@ -921,9 +920,9 @@ public class LootTrackerPlugin extends Plugin
 	{
 		final int[] mapRegions = client.getMapRegions();
 
-		for (int region : definedMapRegions)
+		for (int region : mapRegions)
 		{
-			if (ArrayUtils.contains(mapRegions, region))
+			if (definedMapRegions.contains(region))
 			{
 				return true;
 			}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
@@ -179,9 +179,9 @@ public class LootTrackerPlugin extends Plugin
 		build();
 
 	// Hallow Sepulchre Coffin handling
-	static final String COFFIN_LOOTED_MESSAGE = "You push the coffin lid aside.";
-	static final String HALLOWED_SEPULCHRE_COFFIN_EVENT = "Coffin (Hallowed Sepulchre)";
-	static final Set<Integer> HALLOWED_SEPULCHRE_MAP_REGIONS = ImmutableSet.of(8797, 10077, 9308, 10074, 9050); // one map region per floor
+	private static final String COFFIN_LOOTED_MESSAGE = "You push the coffin lid aside.";
+	private static final String HALLOWED_SEPULCHRE_COFFIN_EVENT = "Coffin (Hallowed Sepulchre)";
+	private static final Set<Integer> HALLOWED_SEPULCHRE_MAP_REGIONS = ImmutableSet.of(8797, 10077, 9308, 10074, 9050); // one map region per floor
 
 	// Last man standing map regions
 	private static final Set<Integer> LAST_MAN_STANDING_REGIONS = ImmutableSet.of(13658, 13659, 13914, 13915, 13916);
@@ -913,7 +913,7 @@ public class LootTrackerPlugin extends Plugin
 	/**
 	 * Is player currently within the provided map regions
 	 */
-	boolean isPlayerWithinMapRegion(Set<Integer> definedMapRegions)
+	private boolean isPlayerWithinMapRegion(Set<Integer> definedMapRegions)
 	{
 		final int[] mapRegions = client.getMapRegions();
 

--- a/runelite-client/src/test/java/net/runelite/client/plugins/loottracker/LootTrackerPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/loottracker/LootTrackerPluginTest.java
@@ -188,6 +188,7 @@ public class LootTrackerPluginTest
 			when(mockIterator.next()).thenReturn(node).thenReturn(nodeFull);
 			when(messageTable.iterator()).thenReturn(mockIterator);
 			when(client.getMessages()).thenReturn(messageTable);
+
 			LootTrackerPlugin lootTrackerPluginSpy = spy(this.lootTrackerPlugin);
 			doNothing().when(lootTrackerPluginSpy).addLoot(any(), anyInt(), any(), any(Collection.class));
 

--- a/runelite-client/src/test/java/net/runelite/client/plugins/loottracker/LootTrackerPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/loottracker/LootTrackerPluginTest.java
@@ -61,7 +61,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import org.mockito.Mock;
 import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
@@ -122,8 +121,6 @@ public class LootTrackerPluginTest
 	@Bind
 	private ChatMessageManager chatMessageManager;
 
-	LootTrackerPlugin lootTrackerPluginSpy;
-
 	@Before
 	public void setUp()
 	{
@@ -132,29 +129,27 @@ public class LootTrackerPluginTest
 		Player player = mock(Player.class);
 		when(player.getWorldLocation()).thenReturn(new WorldPoint(0, 0, 0));
 		when(client.getLocalPlayer()).thenReturn(player);
-
-		lootTrackerPluginSpy = spy(this.lootTrackerPlugin);
-		doReturn(false).when(lootTrackerPluginSpy).isPlayerWithinMapRegion(LootTrackerPlugin.HALLOWED_SEPULCHRE_MAP_REGIONS);
+		when(client.getMapRegions()).thenReturn(new int[0]);
 	}
 
 	@Test
 	public void testPickPocket()
 	{
 		ChatMessage chatMessage = new ChatMessage(null, ChatMessageType.SPAM, "", "You pick the hero's pocket.", "", 0);
-		lootTrackerPluginSpy.onChatMessage(chatMessage);
+		lootTrackerPlugin.onChatMessage(chatMessage);
 
-		assertEquals("Hero", lootTrackerPluginSpy.eventType);
-		assertEquals(LootRecordType.PICKPOCKET, lootTrackerPluginSpy.lootRecordType);
+		assertEquals("Hero", lootTrackerPlugin.eventType);
+		assertEquals(LootRecordType.PICKPOCKET, lootTrackerPlugin.lootRecordType);
 	}
 
 	@Test
 	public void testFirstClue()
 	{
 		ChatMessage chatMessage = new ChatMessage(null, ChatMessageType.GAMEMESSAGE, "", "You have completed 1 master Treasure Trail.", "", 0);
-		lootTrackerPluginSpy.onChatMessage(chatMessage);
+		lootTrackerPlugin.onChatMessage(chatMessage);
 
-		assertEquals("Clue Scroll (Master)", lootTrackerPluginSpy.eventType);
-		assertEquals(LootRecordType.EVENT, lootTrackerPluginSpy.lootRecordType);
+		assertEquals("Clue Scroll (Master)", lootTrackerPlugin.eventType);
+		assertEquals(LootRecordType.EVENT, lootTrackerPlugin.lootRecordType);
 	}
 
 	private static ItemComposition mockItem(String name)
@@ -193,6 +188,7 @@ public class LootTrackerPluginTest
 			when(mockIterator.next()).thenReturn(node).thenReturn(nodeFull);
 			when(messageTable.iterator()).thenReturn(mockIterator);
 			when(client.getMessages()).thenReturn(messageTable);
+			LootTrackerPlugin lootTrackerPluginSpy = spy(this.lootTrackerPlugin);
 			doNothing().when(lootTrackerPluginSpy).addLoot(any(), anyInt(), any(), any(Collection.class));
 
 			ChatMessage chatMessage = new ChatMessage(null, ChatMessageType.GAMEMESSAGE, "", LootTrackerPlugin.HERBIBOAR_LOOTED_MESSAGE, "", 0);

--- a/runelite-client/src/test/java/net/runelite/client/plugins/loottracker/LootTrackerPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/loottracker/LootTrackerPluginTest.java
@@ -61,6 +61,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import org.mockito.Mock;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
@@ -121,6 +122,8 @@ public class LootTrackerPluginTest
 	@Bind
 	private ChatMessageManager chatMessageManager;
 
+	LootTrackerPlugin lootTrackerPluginSpy;
+
 	@Before
 	public void setUp()
 	{
@@ -129,26 +132,29 @@ public class LootTrackerPluginTest
 		Player player = mock(Player.class);
 		when(player.getWorldLocation()).thenReturn(new WorldPoint(0, 0, 0));
 		when(client.getLocalPlayer()).thenReturn(player);
+
+		lootTrackerPluginSpy = spy(this.lootTrackerPlugin);
+		doReturn(false).when(lootTrackerPluginSpy).isPlayerWithinMapRegion(LootTrackerPlugin.HALLOWED_SEPULCHRE_MAP_REGIONS);
 	}
 
 	@Test
 	public void testPickPocket()
 	{
 		ChatMessage chatMessage = new ChatMessage(null, ChatMessageType.SPAM, "", "You pick the hero's pocket.", "", 0);
-		lootTrackerPlugin.onChatMessage(chatMessage);
+		lootTrackerPluginSpy.onChatMessage(chatMessage);
 
-		assertEquals("Hero", lootTrackerPlugin.eventType);
-		assertEquals(LootRecordType.PICKPOCKET, lootTrackerPlugin.lootRecordType);
+		assertEquals("Hero", lootTrackerPluginSpy.eventType);
+		assertEquals(LootRecordType.PICKPOCKET, lootTrackerPluginSpy.lootRecordType);
 	}
 
 	@Test
 	public void testFirstClue()
 	{
 		ChatMessage chatMessage = new ChatMessage(null, ChatMessageType.GAMEMESSAGE, "", "You have completed 1 master Treasure Trail.", "", 0);
-		lootTrackerPlugin.onChatMessage(chatMessage);
+		lootTrackerPluginSpy.onChatMessage(chatMessage);
 
-		assertEquals("Clue Scroll (Master)", lootTrackerPlugin.eventType);
-		assertEquals(LootRecordType.EVENT, lootTrackerPlugin.lootRecordType);
+		assertEquals("Clue Scroll (Master)", lootTrackerPluginSpy.eventType);
+		assertEquals(LootRecordType.EVENT, lootTrackerPluginSpy.lootRecordType);
 	}
 
 	private static ItemComposition mockItem(String name)
@@ -187,8 +193,6 @@ public class LootTrackerPluginTest
 			when(mockIterator.next()).thenReturn(node).thenReturn(nodeFull);
 			when(messageTable.iterator()).thenReturn(mockIterator);
 			when(client.getMessages()).thenReturn(messageTable);
-
-			LootTrackerPlugin lootTrackerPluginSpy = spy(this.lootTrackerPlugin);
 			doNothing().when(lootTrackerPluginSpy).addLoot(any(), anyInt(), any(), any(Collection.class));
 
 			ChatMessage chatMessage = new ChatMessage(null, ChatMessageType.GAMEMESSAGE, "", LootTrackerPlugin.HERBIBOAR_LOOTED_MESSAGE, "", 0);

--- a/runelite-client/src/test/java/net/runelite/client/plugins/loottracker/LootTrackerPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/loottracker/LootTrackerPluginTest.java
@@ -129,7 +129,6 @@ public class LootTrackerPluginTest
 		Player player = mock(Player.class);
 		when(player.getWorldLocation()).thenReturn(new WorldPoint(0, 0, 0));
 		when(client.getLocalPlayer()).thenReturn(player);
-		when(client.getMapRegions()).thenReturn(new int[0]);
 	}
 
 	@Test


### PR DESCRIPTION
This time leveraging InventorySnapshot, lot less changes required and now benefiting from the recent merge into LootTracker of picking up potential grounditems. I did add an additional check to ensure players inventory has 28 items before trying to grab ground spawns. 

