### PR TITLE
Change thin progress bar to have darker background for the unfinished portion

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ui/components/ThinProgressBar.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/components/ThinProgressBar.java
@@ -61,7 +61,7 @@ public class ThinProgressBar extends JPanel
 	public void setForeground(Color color)
 	{
 		super.setForeground(color);
-		setBackground(color.darker());
+		setBackground(color.darker().darker());
 	}
 
 	public void setMaximumValue(int maximumValue)


### PR DESCRIPTION
Closes #8262

The color of the green progress bar in the farming tab, for instance, has too little contrast between the "filled" and "unfilled" parts of the progress bar.

Currently the contrasts are 1.86:1 (measured with [this tool](https://webaim.org/resources/contrastchecker/)) and the [accessibility guidelines](https://www.w3.org/TR/WCAG20/) for the web require a contrast ratio of 3:1 or 4.5:1 depending on the content

I think the background of the unfinished portion of the bar should be a darker color.

Preview here (before and after): 
![contrast](https://user-images.githubusercontent.com/7868899/84965950-d8338880-b0d5-11ea-820f-ab3f60fe03a9.png)

Adding another `darker()` would make it look like this, which IMO is too dark. 👇 
![contrast 2](https://user-images.githubusercontent.com/7868899/84966010-fc8f6500-b0d5-11ea-989e-272133210016.png)
