### PR TITLE
Add toggle to remove spellbook tooltips

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/mousehighlight/MouseHighlightConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/mousehighlight/MouseHighlightConfig.java
@@ -55,11 +55,11 @@ public interface MouseHighlightConfig extends Config
 
 	@ConfigItem(
 		position = 2,
-		keyName = "spellbookTooltip",
+		keyName = "disableSpellbooktooltip",
 		name = "Disable Spellbook Tooltips",
 		description = "Disable Spellbook Tooltips so they don't cover descriptions"
 	)
-	default boolean spellbookTooltip()
+	default boolean disableSpellbooktooltip()
 	{
 		return false;
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/mousehighlight/MouseHighlightConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/mousehighlight/MouseHighlightConfig.java
@@ -52,4 +52,15 @@ public interface MouseHighlightConfig extends Config
 	{
 		return true;
 	}
+
+	@ConfigItem(
+			position = 2,
+			keyName = "spellbookTooltip",
+			name = "Disable Spellbook Tooltips",
+			description = "Disable Spellbook Tooltips so they don't cover descriptions"
+	)
+	default boolean spellbookTooltip()
+	{
+		return false;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/mousehighlight/MouseHighlightConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/mousehighlight/MouseHighlightConfig.java
@@ -54,10 +54,10 @@ public interface MouseHighlightConfig extends Config
 	}
 
 	@ConfigItem(
-			position = 2,
-			keyName = "spellbookTooltip",
-			name = "Disable Spellbook Tooltips",
-			description = "Disable Spellbook Tooltips so they don't cover descriptions"
+		position = 2,
+		keyName = "spellbookTooltip",
+		name = "Disable Spellbook Tooltips",
+		description = "Disable Spellbook Tooltips so they don't cover descriptions"
 	)
 	default boolean spellbookTooltip()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/mousehighlight/MouseHighlightOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/mousehighlight/MouseHighlightOverlay.java
@@ -33,6 +33,7 @@ import net.runelite.api.MenuAction;
 import net.runelite.api.MenuEntry;
 import net.runelite.api.VarClientInt;
 import net.runelite.api.widgets.Widget;
+import net.runelite.api.widgets.WidgetID;
 import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayPosition;
@@ -112,6 +113,11 @@ class MouseHighlightOverlay extends Overlay
 		}
 
 		if (!config.chatboxTooltip() && groupId == WidgetInfo.CHATBOX.getGroupId())
+		{
+			return null;
+		}
+
+		if (config.spellbookTooltip() && groupId == WidgetID.SPELLBOOK_GROUP_ID)
 		{
 			return null;
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/mousehighlight/MouseHighlightOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/mousehighlight/MouseHighlightOverlay.java
@@ -117,7 +117,7 @@ class MouseHighlightOverlay extends Overlay
 			return null;
 		}
 
-		if (config.spellbookTooltip() && groupId == WidgetID.SPELLBOOK_GROUP_ID)
+		if (config.disableSpellbooktooltip() && groupId == WidgetID.SPELLBOOK_GROUP_ID)
 		{
 			return null;
 		}


### PR DESCRIPTION
Closes #8634

Adding a config option to disable spell book tooltips.