### PR TITLE
widget-overlay: make encounter health bar moveable

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/widgets/WidgetID.java
+++ b/runelite-api/src/main/java/net/runelite/api/widgets/WidgetID.java
@@ -155,6 +155,7 @@ public class WidgetID
 	public static final int COUNTERS_LOG_GROUP_ID = 625;
 	public static final int GAUNTLET_TIMER_GROUP_ID = 637;
 	public static final int BANK_PIN_GROUP_ID = 213;
+	public static final int ENCOUNTER_HEALTH_BAR_GROUP_ID = 303;
 
 	static class WorldMap
 	{
@@ -929,5 +930,10 @@ public class WidgetID
 	static class BankPin
 	{
 		static final int CONTAINER = 0;
+	}
+
+	static class EncounterHealthBar
+	{
+		static final int CONTAINER = 6;
 	}
 }

--- a/runelite-api/src/main/java/net/runelite/api/widgets/WidgetID.java
+++ b/runelite-api/src/main/java/net/runelite/api/widgets/WidgetID.java
@@ -155,7 +155,7 @@ public class WidgetID
 	public static final int COUNTERS_LOG_GROUP_ID = 625;
 	public static final int GAUNTLET_TIMER_GROUP_ID = 637;
 	public static final int BANK_PIN_GROUP_ID = 213;
-	public static final int ENCOUNTER_HEALTH_BAR_GROUP_ID = 303;
+	public static final int HEALTH_OVERLAY_BAR_GROUP_ID = 303;
 
 	static class WorldMap
 	{

--- a/runelite-api/src/main/java/net/runelite/api/widgets/WidgetInfo.java
+++ b/runelite-api/src/main/java/net/runelite/api/widgets/WidgetInfo.java
@@ -548,7 +548,9 @@ public enum WidgetInfo
 
 	SKILLS_CONTAINER(WidgetID.SKILLS_GROUP_ID, WidgetID.Skills.CONTAINER),
 
-	GAUNTLET_TIMER_CONTAINER(WidgetID.GAUNTLET_TIMER_GROUP_ID, WidgetID.GauntletTimer.CONTAINER);
+	GAUNTLET_TIMER_CONTAINER(WidgetID.GAUNTLET_TIMER_GROUP_ID, WidgetID.GauntletTimer.CONTAINER),
+
+	ENCOUNTER_HEALTH_BAR(WidgetID.ENCOUNTER_HEALTH_BAR_GROUP_ID, WidgetID.EncounterHealthBar.CONTAINER);
 
 	private final int groupId;
 	private final int childId;

--- a/runelite-api/src/main/java/net/runelite/api/widgets/WidgetInfo.java
+++ b/runelite-api/src/main/java/net/runelite/api/widgets/WidgetInfo.java
@@ -550,7 +550,7 @@ public enum WidgetInfo
 
 	GAUNTLET_TIMER_CONTAINER(WidgetID.GAUNTLET_TIMER_GROUP_ID, WidgetID.GauntletTimer.CONTAINER),
 
-	ENCOUNTER_HEALTH_BAR(WidgetID.ENCOUNTER_HEALTH_BAR_GROUP_ID, WidgetID.EncounterHealthBar.CONTAINER);
+	HEALTH_OVERLAY_BAR(WidgetID.HEALTH_OVERLAY_BAR_GROUP_ID, WidgetID.EncounterHealthBar.CONTAINER);
 
 	private final int groupId;
 	private final int childId;

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/WidgetOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/WidgetOverlay.java
@@ -59,7 +59,7 @@ public class WidgetOverlay extends Overlay
 		.put(WidgetInfo.LMS_INFO, OverlayPosition.TOP_RIGHT)
 		.put(WidgetInfo.LMS_KDA, OverlayPosition.TOP_RIGHT)
 		.put(WidgetInfo.GAUNTLET_TIMER_CONTAINER, OverlayPosition.TOP_LEFT)
-		.put(WidgetInfo.ENCOUNTER_HEALTH_BAR, OverlayPosition.TOP_CENTER)
+		.put(WidgetInfo.HEALTH_OVERLAY_BAR, OverlayPosition.TOP_CENTER)
 		.build();
 
 	public static Collection<WidgetOverlay> createOverlays(final Client client)

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/WidgetOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/WidgetOverlay.java
@@ -59,6 +59,7 @@ public class WidgetOverlay extends Overlay
 		.put(WidgetInfo.LMS_INFO, OverlayPosition.TOP_RIGHT)
 		.put(WidgetInfo.LMS_KDA, OverlayPosition.TOP_RIGHT)
 		.put(WidgetInfo.GAUNTLET_TIMER_CONTAINER, OverlayPosition.TOP_LEFT)
+		.put(WidgetInfo.ENCOUNTER_HEALTH_BAR, OverlayPosition.TOP_CENTER)
 		.build();
 
 	public static Collection<WidgetOverlay> createOverlays(final Client client)


### PR DESCRIPTION
Allows the new toggleable health bar widget used for various boss encounters (nightmare, cox) to be moveable.

Closes #12020

![image](https://user-images.githubusercontent.com/66518222/85172581-ae16cd80-b271-11ea-87aa-daf852388885.png)
