### PR TITLE
metronome: add option to delay metronome sound by x ms from a game tick

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/metronome/MetronomePluginConfiguration.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/metronome/MetronomePluginConfiguration.java
@@ -25,11 +25,13 @@
  */
 package net.runelite.client.plugins.metronome;
 
+import net.runelite.api.Constants;
+import net.runelite.api.SoundEffectVolume;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
 import net.runelite.client.config.Range;
-import net.runelite.api.SoundEffectVolume;
+import net.runelite.client.config.Units;
 
 @ConfigGroup("metronome")
 public interface MetronomePluginConfiguration extends Config
@@ -70,5 +72,19 @@ public interface MetronomePluginConfiguration extends Config
 	default int tockVolume()
 	{
 		return SoundEffectVolume.MUTED;
+	}
+
+	@Range(
+		max = Constants.GAME_TICK_LENGTH
+	)
+	@Units(Units.MILLISECONDS)
+	@ConfigItem(
+		keyName = "soundDelay",
+		name = "Sound delay",
+		description = "Configures the amount of time to delay the metronome sound from a game tick."
+	)
+	default int soundDelay()
+	{
+		return 0;
 	}
 }


### PR DESCRIPTION
Closes #11923. My idea is to use client ticks to keep track of time elapsed from game ticks.

Note that the precision of the delay is dependent on client ticks, which is 20ms intervals. I don't know if there's a more frequent event to monitor. But in an ideal environment, I think this works okay, save for lag. Let me know if I'm on the right track or not.

Negative offset is likely not possible because game ticks have a time variation, so it's hard to tell when negative X ms before a game tick happens, until the game tick actually happens. (So, a workaround using modulus to convert negative offsets won't be helpful.)

This approach is different from a previous approach I found, which doesn't work: #9349