### PR TITLE
slayer: Update initial amount if current amount is higher

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerPlugin.java
@@ -683,7 +683,7 @@ public class SlayerPlugin extends Plugin
 	{
 		taskName = name;
 		amount = amt;
-		initialAmount = initAmt;
+		initialAmount = Math.max(amt, initAmt);
 		taskLocation = location;
 		save();
 		removeCounter();

--- a/runelite-client/src/test/java/net/runelite/client/plugins/slayer/SlayerPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/slayer/SlayerPluginTest.java
@@ -776,6 +776,17 @@ public class SlayerPluginTest
 	}
 
 	@Test
+	public void updateInitialAmount()
+	{
+		Widget npcDialog = mock(Widget.class);
+		when(npcDialog.getText()).thenReturn(TASK_EXISTING);
+		when(client.getWidget(WidgetInfo.DIALOG_NPC_TEXT)).thenReturn(npcDialog);
+		slayerPlugin.onGameTick(new GameTick());
+
+		assertEquals(222, slayerPlugin.getInitialAmount());
+	}
+
+	@Test
 	public void testTaskLookup() throws IOException
 	{
 		net.runelite.http.api.chat.Task task = new net.runelite.http.api.chat.Task();


### PR DESCRIPTION
Prior to this commit it was possible to receive a change or update in
task by playing on mobile or another client, log back in to RuneLite
with incorrect task information saved to config and, once updated via
checking a slayer gem or speaking with a slayer master, having a task
amount greater than the saved initial task length. This updates the
plugin to use the greater of these numbers so that case is no longer
possible.

Closes #11945