### PR TITLE
ClientUI: Fix panel toggle after closing with click

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
@@ -206,7 +206,6 @@ public class ClientUI
 					currentButton.setSelected(false);
 					currentNavButton.setSelected(false);
 					currentButton = null;
-					currentNavButton = null;
 				}
 				else
 				{


### PR DESCRIPTION
This commit ensures the previously-active plugin panel can be reopened
with the plugin panel toggle hotkey after being closed via mouse click.

Fixes #11886