### PR TITLE
TextComponent: Draw outline using one axis offset at a time

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/components/TextComponent.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/components/TextComponent.java
@@ -60,15 +60,19 @@ public class TextComponent implements RenderableEntity
 				final String textWithoutCol = Text.removeTags(textSplitOnCol);
 				final String colColor = textSplitOnCol.substring(textSplitOnCol.indexOf("=") + 1, textSplitOnCol.indexOf(">"));
 
-				// shadow
 				graphics.setColor(Color.BLACK);
-				graphics.drawString(textWithoutCol, x + 1, position.y + 1);
 
 				if (outline)
 				{
-					graphics.drawString(textWithoutCol, x - 1, position.y - 1);
-					graphics.drawString(textWithoutCol, x - 1, position.y + 1);
-					graphics.drawString(textWithoutCol, x + 1, position.y - 1);
+					graphics.drawString(textWithoutCol, x, position.y + 1);
+					graphics.drawString(textWithoutCol, x, position.y - 1);
+					graphics.drawString(textWithoutCol, x + 1, position.y);
+					graphics.drawString(textWithoutCol, x - 1, position.y);
+				}
+				else
+				{
+					// shadow
+					graphics.drawString(textWithoutCol, x + 1, position.y + 1);
 				}
 
 				// actual text
@@ -80,15 +84,19 @@ public class TextComponent implements RenderableEntity
 		}
 		else
 		{
-			// shadow
 			graphics.setColor(Color.BLACK);
-			graphics.drawString(text, position.x + 1, position.y + 1);
 
 			if (outline)
 			{
-				graphics.drawString(text, position.x - 1, position.y - 1);
-				graphics.drawString(text, position.x - 1, position.y + 1);
-				graphics.drawString(text, position.x + 1, position.y - 1);
+				graphics.drawString(text, position.x, position.y + 1);
+				graphics.drawString(text, position.x, position.y - 1);
+				graphics.drawString(text, position.x + 1, position.y);
+				graphics.drawString(text, position.x - 1, position.y);
+			}
+			else
+			{
+				// shadow
+				graphics.drawString(text, position.x + 1, position.y + 1);
 			}
 
 			// actual text


### PR DESCRIPTION
This commit prevents fonts with thin and angled glyphs from having gaps
between the characters and their outline by offsetting outline draws in
one direction exclusively.