### PR TITLE
Add a Toggle to the Status Bars w/ a Delay to show only in Combat

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/statusbars/StatusBarsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/statusbars/StatusBarsConfig.java
@@ -27,11 +27,14 @@ package net.runelite.client.plugins.statusbars;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.Units;
 import net.runelite.client.plugins.statusbars.config.BarMode;
 
-@ConfigGroup("statusbars")
+@ConfigGroup(StatusBarsConfig.GROUP)
 public interface StatusBarsConfig extends Config
 {
+	String GROUP = "statusbars";
+
 	@ConfigItem(
 		keyName = "enableCounter",
 		name = "Show counters",
@@ -80,5 +83,16 @@ public interface StatusBarsConfig extends Config
 	default BarMode rightBarMode()
 	{
 		return BarMode.PRAYER;
+	}
+
+	@ConfigItem(
+		keyName = "hideAfterCombatDelay",
+		name = "Hide after combat delay",
+		description = "Amount of ticks before hiding status bars after no longer in combat. 0 = always show status bars."
+	)
+	@Units(Units.TICKS)
+	default int hideAfterCombatDelay()
+	{
+		return 0;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/statusbars/StatusBarsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/statusbars/StatusBarsOverlay.java
@@ -80,6 +80,7 @@ class StatusBarsOverlay extends Overlay
 	private static final int MAX_RUN_ENERGY_VALUE = 100;
 
 	private final Client client;
+	private final StatusBarsPlugin plugin;
 	private final StatusBarsConfig config;
 	private final ItemStatChangesService itemStatService;
 	private final SpriteManager spriteManager;
@@ -94,11 +95,12 @@ class StatusBarsOverlay extends Overlay
 	private final Map<BarMode, BarRenderer> barRenderers = new EnumMap<>(BarMode.class);
 
 	@Inject
-	private StatusBarsOverlay(Client client, StatusBarsConfig config, SkillIconManager skillIconManager, ItemStatChangesService itemstatservice, SpriteManager spriteManager)
+	private StatusBarsOverlay(Client client, StatusBarsPlugin plugin, StatusBarsConfig config, SkillIconManager skillIconManager, ItemStatChangesService itemstatservice, SpriteManager spriteManager)
 	{
 		setPosition(OverlayPosition.DYNAMIC);
 		setLayer(OverlayLayer.ABOVE_WIDGETS);
 		this.client = client;
+		this.plugin = plugin;
 		this.config = config;
 		this.itemStatService = itemstatservice;
 		this.spriteManager = spriteManager;
@@ -216,6 +218,11 @@ class StatusBarsOverlay extends Overlay
 	@Override
 	public Dimension render(Graphics2D g)
 	{
+		if (!plugin.isBarsDisplayed())
+		{
+			return null;
+		}
+
 		Viewport curViewport = null;
 		Widget curWidget = null;
 


### PR DESCRIPTION
**Duplicate of #7445 due to Orphaned Source branch.** 

Upon many emails and several requests to fix the review suggestions made by @Nightfirecat in #7445 , I came back to clean up those review items in hopes to have this merged into a release for all those people that have asked.

_Duplicate PR content:_
This is to only show the Status Bars only when in Combat, and hides it based on the delay set.
Closes #7436
Toggle Demo: https://gyazo.com/ee277e5f0d4bfad598a7a1049d972a67
Delay Demo: https://gyazo.com/421e2a4a725725f1b7b5e62f96a6a8a3