### PR TITLE
ClientUI: Allow hotkey plugin panel toggles on login screen

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
@@ -382,7 +382,6 @@ public class ClientUI
 					toggleSidebar();
 				}
 			};
-
 			sidebarListener.setEnabledOnLogin(true);
 			keyManager.registerKeyListener(sidebarListener);
 
@@ -394,7 +393,7 @@ public class ClientUI
 					togglePluginPanel();
 				}
 			};
-
+			pluginPanelListener.setEnabledOnLogin(true);
 			keyManager.registerKeyListener(pluginPanelListener);
 
 			// Add mouse listener
@@ -412,7 +411,6 @@ public class ClientUI
 					return mouseEvent;
 				}
 			};
-
 			mouseManager.registerMouseListener(mouseListener);
 
 			// Decorate window with custom chrome and titlebar if needed


### PR DESCRIPTION
I'm not sure why this wasn't included with the rest of them, but this is confusing and should be the same for both the sidebar and plugin panel toggles