### PR TITLE
Add notification BEFORE nmz overload expires

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/nightmarezone/NightmareZoneConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/nightmarezone/NightmareZoneConfig.java
@@ -28,6 +28,8 @@ import java.awt.Color;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.Range;
+import net.runelite.client.config.Units;
 
 @ConfigGroup("nightmareZone")
 public interface NightmareZoneConfig extends Config
@@ -98,11 +100,27 @@ public interface NightmareZoneConfig extends Config
 		return true;
 	}
 
+	@Range(
+		min = 0,
+		max = 300
+	)
+	@ConfigItem(
+		keyName = "overloadearlywarningseconds",
+		name = "Overload early warning",
+		description = "You will be notified this many seconds before your overload potion expires",
+		position = 7
+	)
+	@Units(Units.SECONDS)
+	default int overloadEarlyWarningSeconds()
+	{
+		return 10;
+	}
+
 	@ConfigItem(
 		keyName = "absorptionnotification",
 		name = "Absorption notification",
 		description = "Toggles notifications when your absorption points gets below your threshold",
-		position = 7
+		position = 8
 	)
 	default boolean absorptionNotification()
 	{
@@ -113,7 +131,7 @@ public interface NightmareZoneConfig extends Config
 		keyName = "absorptionthreshold",
 		name = "Absorption Threshold",
 		description = "The amount of absorption points to send a notification at",
-		position = 8
+		position = 9
 	)
 	default int absorptionThreshold()
 	{
@@ -124,7 +142,7 @@ public interface NightmareZoneConfig extends Config
 		keyName = "absorptioncoloroverthreshold",
 		name = "Color above threshold",
 		description = "Configures the color for the absorption widget when above the threshold",
-		position = 9
+		position = 10
 	)
 	default Color absorptionColorAboveThreshold()
 	{
@@ -135,7 +153,7 @@ public interface NightmareZoneConfig extends Config
 		keyName = "absorptioncolorbelowthreshold",
 		name = "Color below threshold",
 		description = "Configures the color for the absorption widget when below the threshold",
-		position = 10
+		position = 11
 	)
 	default Color absorptionColorBelowThreshold()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/nightmarezone/NightmareZonePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/nightmarezone/NightmareZonePlugin.java
@@ -55,6 +55,7 @@ public class NightmareZonePlugin extends Plugin
 {
 	private static final int[] NMZ_MAP_REGION = {9033};
 	private static final Duration HOUR = Duration.ofHours(1);
+	private static final Duration OVERLOAD_DURATION = Duration.ofMinutes(5);
 
 	@Inject
 	private Notifier notifier;
@@ -73,18 +74,22 @@ public class NightmareZonePlugin extends Plugin
 
 	@Getter
 	private int pointsPerHour;
-	
+
 	private Instant nmzSessionStartTime;
 
 	// This starts as true since you need to get
 	// above the threshold before sending notifications
 	private boolean absorptionNotificationSend = true;
+	private boolean overloadNotificationSend = false;
+	private Instant lastOverload;
 
 	@Override
 	protected void startUp() throws Exception
 	{
 		overlayManager.add(overlay);
 		overlay.removeAbsorptionCounter();
+
+		overloadNotificationSend = false;
 	}
 
 	@Override
@@ -138,6 +143,11 @@ public class NightmareZonePlugin extends Plugin
 			checkAbsorption();
 		}
 
+		if (overloadNotificationSend && config.overloadNotification() && config.overloadEarlyWarningSeconds() > 0)
+		{
+			checkOverload();
+		}
+
 		if (config.moveOverlay())
 		{
 			pointsPerHour = calculatePointsPerHour();
@@ -147,8 +157,9 @@ public class NightmareZonePlugin extends Plugin
 	@Subscribe
 	public void onChatMessage(ChatMessage event)
 	{
-		if (event.getType() != ChatMessageType.GAMEMESSAGE
-				|| !isInNightmareZone())
+		if (!isInNightmareZone()
+			|| (event.getType() != ChatMessageType.GAMEMESSAGE
+			&& event.getType() != ChatMessageType.SPAM))
 		{
 			return;
 		}
@@ -156,6 +167,9 @@ public class NightmareZonePlugin extends Plugin
 		String msg = Text.removeTags(event.getMessage()); //remove color
 		if (msg.contains("The effects of overload have worn off, and you feel normal again."))
 		{
+			// Prevents notification from being sent after overload expiry, if the user disables and re-enables warnings
+			overloadNotificationSend = false;
+
 			if (config.overloadNotification())
 			{
 				notifier.notify("Your overload has worn off");
@@ -191,6 +205,21 @@ public class NightmareZonePlugin extends Plugin
 					notifier.notify(msg);
 				}
 			}
+		}
+		else if (msg.contains("You drink some of your overload potion."))
+		{
+			lastOverload = Instant.now();  // Save time of last overload
+			overloadNotificationSend = true;  // Queue up a overload notification once time threshold is reached
+		}
+	}
+
+	private void checkOverload()
+	{
+		if (Instant.now().isAfter(lastOverload.plus(OVERLOAD_DURATION).
+			minus(Duration.ofSeconds(config.overloadEarlyWarningSeconds()))))
+		{
+			notifier.notify("Your overload potion is about to expire!");
+			overloadNotificationSend = false;
 		}
 	}
 


### PR DESCRIPTION
Addressing feature request #4279

Currently there is no option to display notifications BEFORE an overload potion expires in nmz, either in the Nightmare Zone plugin or NMZ Utilies plugin.

Proposed change in nightmarezone plugin:
* Config option for adjusting how early to output notification

