### PR TITLE
rl-client: Prevent chat inputs from taking keys from the worldmap search

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/game/chatbox/ChatboxItemSearch.java
+++ b/runelite-client/src/main/java/net/runelite/client/game/chatbox/ChatboxItemSearch.java
@@ -184,6 +184,11 @@ public class ChatboxItemSearch extends ChatboxTextInput
 	@Override
 	public void keyPressed(KeyEvent ev)
 	{
+		if (!chatboxPanelManager.shouldTakeInput())
+		{
+			return;
+		}
+
 		switch (ev.getKeyCode())
 		{
 			case KeyEvent.VK_ENTER:

--- a/runelite-client/src/main/java/net/runelite/client/game/chatbox/ChatboxPanelManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/game/chatbox/ChatboxPanelManager.java
@@ -199,4 +199,12 @@ public class ChatboxPanelManager
 	{
 		return client.getWidget(WidgetInfo.CHATBOX_CONTAINER);
 	}
+
+	public boolean shouldTakeInput()
+	{
+		// the search box on the world map can be focused, and chat input goes there, even
+		// though the chatbox still has its key listener.
+		Widget worldMapSearch = client.getWidget(WidgetInfo.WORLD_MAP_SEARCH);
+		return worldMapSearch == null || client.getVar(VarClientInt.WORLD_MAP_SEARCH_FOCUSED) != 1;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/game/chatbox/ChatboxTextInput.java
+++ b/runelite-client/src/main/java/net/runelite/client/game/chatbox/ChatboxTextInput.java
@@ -609,6 +609,11 @@ public class ChatboxTextInput extends ChatboxInput implements KeyListener, Mouse
 	@Override
 	public void keyTyped(KeyEvent e)
 	{
+		if (!chatboxPanelManager.shouldTakeInput())
+		{
+			return;
+		}
+
 		char c = e.getKeyChar();
 		if (charValidator.test(c))
 		{
@@ -628,6 +633,11 @@ public class ChatboxTextInput extends ChatboxInput implements KeyListener, Mouse
 	@Override
 	public void keyPressed(KeyEvent ev)
 	{
+		if (!chatboxPanelManager.shouldTakeInput())
+		{
+			return;
+		}
+
 		int code = ev.getKeyCode();
 		if (ev.isControlDown())
 		{

--- a/runelite-client/src/main/java/net/runelite/client/game/chatbox/ChatboxTextMenuInput.java
+++ b/runelite-client/src/main/java/net/runelite/client/game/chatbox/ChatboxTextMenuInput.java
@@ -178,6 +178,11 @@ public class ChatboxTextMenuInput extends ChatboxInput implements KeyListener
 	@Override
 	public void keyTyped(KeyEvent e)
 	{
+		if (!chatboxPanelManager.shouldTakeInput())
+		{
+			return;
+		}
+
 		char c = e.getKeyChar();
 
 		if (c == '\033')
@@ -198,6 +203,11 @@ public class ChatboxTextMenuInput extends ChatboxInput implements KeyListener
 	@Override
 	public void keyPressed(KeyEvent e)
 	{
+		if (!chatboxPanelManager.shouldTakeInput())
+		{
+			return;
+		}
+
 		if (e.getKeyCode() == KeyEvent.VK_ESCAPE)
 		{
 			e.consume();

--- a/runelite-client/src/main/java/net/runelite/client/plugins/wiki/WikiSearchChatboxTextInput.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/wiki/WikiSearchChatboxTextInput.java
@@ -253,6 +253,11 @@ public class WikiSearchChatboxTextInput extends ChatboxTextInput
 	@Override
 	public void keyPressed(KeyEvent ev)
 	{
+		if (!chatboxPanelManager.shouldTakeInput())
+		{
+			return;
+		}
+
 		switch (ev.getKeyCode())
 		{
 			case KeyEvent.VK_UP:


### PR DESCRIPTION
Closes #11996 

KeyRemapping has this check too, and [proc,keypress_permit] has similar, though not identical one.