### PR TITLE
Added Advisor Ghrim Collect swap to Menu Entry Swapper

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -564,12 +564,12 @@ public interface MenuEntrySwapperConfig extends Config
 	}
 
 	@ConfigItem(
-			keyName = "swapCollectMiscellenia",
-			name = "Miscellenia",
-			description = "Swap Talk-to with Collect for Advisor Ghrim",
-			section = npcSection
+		keyName = "swapCollectMiscellania",
+		name = "Miscellania",
+		description = "Swap Talk-to with Collect for Advisor Ghrim",
+		section = npcSection
 	)
-	default boolean swapCollectMiscellenia()
+	default boolean swapCollectMiscellania()
 	{
 		return false;
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -562,4 +562,15 @@ public interface MenuEntrySwapperConfig extends Config
 	{
 		return false;
 	}
+
+	@ConfigItem(
+			keyName = "swapCollectMiscellenia",
+			name = "Miscellenia",
+			description = "Swap Talk-to with Collect for Advisor Ghrim",
+			section = npcSection
+	)
+	default boolean swapCollectMiscellenia()
+	{
+		return false;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -208,6 +208,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 		swap("talk-to", "enchant", config::swapEnchant);
 		swap("talk-to", "start-minigame", config::swapStartMinigame);
 		swap("talk-to", ESSENCE_MINE_NPCS::contains, "teleport", config::swapEssenceMineTeleport);
+		swap("talk-to", "collect", config::swapCollectMiscellenia);
 
 		swap("leave tomb", "quick-leave", config::swapQuickLeave);
 		swap("tomb door", "quick-leave", config::swapQuickLeave);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -208,7 +208,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 		swap("talk-to", "enchant", config::swapEnchant);
 		swap("talk-to", "start-minigame", config::swapStartMinigame);
 		swap("talk-to", ESSENCE_MINE_NPCS::contains, "teleport", config::swapEssenceMineTeleport);
-		swap("talk-to", "collect", config::swapCollectMiscellenia);
+		swap("talk-to", "collect", config::swapCollectMiscellania);
 
 		swap("leave tomb", "quick-leave", config::swapQuickLeave);
 		swap("tomb door", "quick-leave", config::swapQuickLeave);


### PR DESCRIPTION
## Changes/Additions
* Added Menu Entry Swapper configuration for Advisor Ghrim on Miscellenia (swap talk-to with collect)
    * default is false
## Testing

### Previous/default behaviour
Note the option is disabled and talk-to option is shown on hover
![image](https://user-images.githubusercontent.com/20750727/85920433-235c5100-b8b7-11ea-96ad-bbef5b052a97.png)

### New behaviour (when option enabled)
Note the option is enabled and collect option is shown on hover
![image](https://user-images.githubusercontent.com/20750727/85920423-07f14600-b8b7-11ea-961f-20bc5e87e7ff.png)

Closes #11905 