### PR TITLE
Consolidate 'logged out/in' messages to a single 'hopped worlds' message

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatfilter/ChatFilterConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatfilter/ChatFilterConfig.java
@@ -122,6 +122,18 @@ public interface ChatFilterConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "showHopMessage",
+		name = "Hopped Worlds Message",
+		description = "Should the logged in/out messages be replaced with a single 'player has hopped worlds' message?"
+			+ "<br/>This config option will be ignored if you are also filtering Logged In/Out Messages",
+		position = 8
+	)
+	default boolean showHopMessage()
+	{
+		return false;
+	}
+
+	@ConfigItem(
 		keyName = "collapseGameChat",
 		name = "Collapse Game Chat",
 		description = "Collapse duplicate game chat messages into a single line",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatfilter/FriendStatus.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatfilter/FriendStatus.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2020, TheStonedTurtle <https://github.com/TheStonedTurtle>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.chatfilter;
+
+import lombok.Value;
+
+@Value
+public class FriendStatus
+{
+	int tick;
+	int world;
+}

--- a/runelite-client/src/test/java/net/runelite/client/plugins/chatfilter/ChatFilterPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/chatfilter/ChatFilterPluginTest.java
@@ -36,6 +36,7 @@ import net.runelite.api.MessageNode;
 import net.runelite.api.Player;
 import net.runelite.api.events.ChatMessage;
 import net.runelite.api.events.ScriptCallbackEvent;
+import net.runelite.client.chat.ChatMessageManager;
 import net.runelite.client.game.FriendChatManager;
 import static net.runelite.client.plugins.chatfilter.ChatFilterPlugin.CENSOR_MESSAGE;
 import static org.junit.Assert.assertEquals;
@@ -60,6 +61,10 @@ public class ChatFilterPluginTest
 	@Mock
 	@Bind
 	private ChatFilterConfig chatFilterConfig;
+
+	@Mock
+	@Bind
+	private ChatMessageManager chatMessageManager;
 
 	@Mock
 	@Bind


### PR DESCRIPTION
Not sure if there's a better way to check when someones login status changes as the chat messages are delayed.

![image](https://user-images.githubusercontent.com/29030969/85944267-57049e80-b8ea-11ea-8f96-675d20c26dd2.png)

This also suppresses log in/out messages if they logged back in to the same world within the 10 tick timeframe.
