### PR TITLE
music: add option to mute pet sounds

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/SoundEffectID.java
+++ b/runelite-api/src/main/java/net/runelite/api/SoundEffectID.java
@@ -96,4 +96,14 @@ public final class SoundEffectID
 	public final static int TOWN_CRIER_BELL_DONG = 3817;
 	public final static int TOWN_CRIER_SHOUT_SQUEAK = 3816;
 
+	// Pet sounds
+	public final static int CAT_HISS = 333;
+	public final static int SNAKELING_METAMORPHOSIS = 794;
+	public final static int CLOCKWORK_CAT_CLICK_CLICK = 941;
+	public final static int PET_WALKING_THUMP = 3834;
+	public final static int PET_KREEARRA_WING_FLAP = 3882;
+	public final static int ELECTRIC_HYDRA_IN = 4118;
+	public final static int ELECTRIC_HYDRA_OUT = 4132;
+	public final static int IKKLE_HYDRA_RIGHT_FOOT_STOMP = 4112;
+	public final static int IKKLE_HYDRA_LEFT_FOOT_STOMP = 4134;
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/music/MusicConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/music/MusicConfig.java
@@ -87,6 +87,17 @@ public interface MusicConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "mutePetSounds",
+		name = "Mute pet sounds",
+		description = "Mute the sounds of noise-making pets",
+		position = 5
+	)
+	default boolean mutePetSounds()
+	{
+		return false;
+	}
+
+	@ConfigItem(
 		keyName = "musicVolume",
 		name = "",
 		description = "",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/music/MusicPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/music/MusicPlugin.java
@@ -117,6 +117,18 @@ public class MusicPlugin extends Plugin
 		SoundEffectID.PRAYER_DEACTIVE_VWOOP
 	);
 
+	private static final Set<Integer> PET_SOUNDS = ImmutableSet.of(
+		SoundEffectID.CAT_HISS,
+		SoundEffectID.SNAKELING_METAMORPHOSIS,
+		SoundEffectID.CLOCKWORK_CAT_CLICK_CLICK,
+		SoundEffectID.PET_WALKING_THUMP,
+		SoundEffectID.PET_KREEARRA_WING_FLAP,
+		SoundEffectID.ELECTRIC_HYDRA_IN,
+		SoundEffectID.ELECTRIC_HYDRA_OUT,
+		SoundEffectID.IKKLE_HYDRA_RIGHT_FOOT_STOMP,
+		SoundEffectID.IKKLE_HYDRA_LEFT_FOOT_STOMP
+	);
+
 	@Inject
 	private Client client;
 
@@ -644,16 +656,27 @@ public class MusicPlugin extends Plugin
 		{
 			areaSoundEffectPlayed.consume();
 		}
-		else if (source instanceof NPC
-			&& musicConfig.muteNpcAreaSounds())
+		else if (source instanceof NPC)
 		{
-			areaSoundEffectPlayed.consume();
+			if (musicConfig.muteNpcAreaSounds())
+			{
+				areaSoundEffectPlayed.consume();
+			}
+			else if (PET_SOUNDS.contains(areaSoundEffectPlayed.getSoundId()) && musicConfig.mutePetSounds())
+			{
+				areaSoundEffectPlayed.consume();
+			}
 		}
-		else if (source == null
-			&& !SOURCELESS_PLAYER_SOUNDS.contains(soundId)
-			&& musicConfig.muteEnvironmentAreaSounds())
+		else if (source == null)
 		{
-			areaSoundEffectPlayed.consume();
+			if (!SOURCELESS_PLAYER_SOUNDS.contains(soundId) && musicConfig.muteEnvironmentAreaSounds())
+			{
+				areaSoundEffectPlayed.consume();
+			}
+			else if (PET_SOUNDS.contains(soundId) && musicConfig.mutePetSounds())
+			{
+				areaSoundEffectPlayed.consume();
+			}
 		}
 	}
 


### PR DESCRIPTION
It is currently only possible to mute pet sounds (e.g., Pet general graardor stomp, electric hydra idle sound, etc.) via `Mute NPCs' area sounds`. However, that option turns off _all_ NPC sounds, which can be disadvantageous in places like ToB, CoX, or any other activities where game mechanics are closely tied to area sounds.

This commit introduces the option to disable pet sounds, so you never have to hear the  _thump thump thump_ of an undeserved Bandos pet again, while still retaining the advantages of enabled area sounds.

Pet sound behavior for some is slightly different when a pet is placed in a PoH menagerie compared to having it as a follower. For example, Jagex removed the sounds from the pet Kree'arra wing flap and the Electric Hydra idle animation—but only while they are following you or another player. The sounds still play when they are free-roaming in a PoH. Other pets, like Pet general graardor and Skotos, still have sounds when they walk regardless of whether they are a follower or free roaming. This commit does not take into account the fact that many pets can make noise when interacting with a scratching post, as I deemed this willing behavior (get rid of the scratching post if you don't want pets interacting with it).