### PR TITLE
Mining: Add session stats

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/mining/MiningConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/mining/MiningConfig.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2020, Jordan Zomerlei <https://github.com/JZomerlei>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.mining;
+
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.Units;
+
+@ConfigGroup("mining")
+public interface MiningConfig extends Config
+{
+	@ConfigItem(
+		keyName = "statTimeout",
+		name = "Reset stats",
+		description = "Duration the mining indicator and session stats are displayed before being reset"
+	)
+	@Units(Units.MINUTES)
+	default int statTimeout()
+	{
+		return 5;
+	}
+
+	@ConfigItem(
+		keyName = "showMiningStats",
+		name = "Show session stats",
+		description = "Configures whether to display mining session stats"
+	)
+	default boolean showMiningStats()
+	{
+		return true;
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/mining/MiningOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/mining/MiningOverlay.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2020, Jordan Zomerlei <https://github.com/JZomerlei>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.mining;
+
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Graphics2D;
+import javax.inject.Inject;
+import net.runelite.api.Client;
+import net.runelite.api.MenuAction;
+import net.runelite.api.Skill;
+import net.runelite.client.plugins.xptracker.XpTrackerService;
+import static net.runelite.client.ui.overlay.OverlayManager.OPTION_CONFIGURE;
+import net.runelite.client.ui.overlay.OverlayMenuEntry;
+import net.runelite.client.ui.overlay.OverlayPanel;
+import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.components.LineComponent;
+import net.runelite.client.ui.overlay.components.TitleComponent;
+
+class MiningOverlay extends OverlayPanel
+{
+	static final String MINING_RESET = "Reset";
+
+	private final Client client;
+	private final MiningPlugin plugin;
+	private final MiningConfig config;
+	private final XpTrackerService xpTrackerService;
+
+	@Inject
+	private MiningOverlay(final Client client, final MiningPlugin plugin, final MiningConfig config, XpTrackerService xpTrackerService)
+	{
+		super(plugin);
+		setPosition(OverlayPosition.TOP_LEFT);
+		this.client = client;
+		this.plugin = plugin;
+		this.config = config;
+		this.xpTrackerService = xpTrackerService;
+		getMenuEntries().add(new OverlayMenuEntry(MenuAction.RUNELITE_OVERLAY_CONFIG, OPTION_CONFIGURE, "Mining overlay"));
+		getMenuEntries().add(new OverlayMenuEntry(MenuAction.RUNELITE_OVERLAY, MINING_RESET, "Mining overlay"));
+	}
+
+	@Override
+	public Dimension render(Graphics2D graphics)
+	{
+		MiningSession session = plugin.getSession();
+		if (session == null || session.getLastMined() == null || !config.showMiningStats())
+		{
+			return null;
+		}
+
+		Pickaxe pickaxe = plugin.getPickaxe();
+		if (pickaxe != null && pickaxe.matchesMiningAnimation(client.getLocalPlayer()))
+		{
+			panelComponent.getChildren().add(TitleComponent.builder()
+				.text("Mining")
+				.color(Color.GREEN)
+				.build());
+		}
+		else
+		{
+			panelComponent.getChildren().add(TitleComponent.builder()
+				.text("NOT mining")
+				.color(Color.RED)
+				.build());
+		}
+
+		int actions = xpTrackerService.getActions(Skill.MINING);
+		if (actions > 0)
+		{
+			panelComponent.getChildren().add(LineComponent.builder()
+				.left("Total mined:")
+				.right(Integer.toString(actions))
+				.build());
+
+			if (actions > 2)
+			{
+				panelComponent.getChildren().add(LineComponent.builder()
+					.left("Mined/hr:")
+					.right(Integer.toString(xpTrackerService.getActionsHr(Skill.MINING)))
+					.build());
+			}
+		}
+
+		return super.render(graphics);
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/mining/MiningPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/mining/MiningPlugin.java
@@ -71,7 +71,7 @@ public class MiningPlugin extends Plugin
 	private OverlayManager overlayManager;
 
 	@Inject
-	private MiningOverlay overlay;
+	private MiningRocksOverlay rocksOverlay;
 
 	@Getter(AccessLevel.PACKAGE)
 	private final List<RockRespawn> respawns = new ArrayList<>();
@@ -80,13 +80,13 @@ public class MiningPlugin extends Plugin
 	@Override
 	protected void startUp()
 	{
-		overlayManager.add(overlay);
+		overlayManager.add(rocksOverlay);
 	}
 
 	@Override
 	protected void shutDown() throws Exception
 	{
-		overlayManager.remove(overlay);
+		overlayManager.remove(rocksOverlay);
 		respawns.clear();
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/mining/MiningRocksOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/mining/MiningRocksOverlay.java
@@ -39,7 +39,7 @@ import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.components.ProgressPieComponent;
 
-class MiningOverlay extends Overlay
+class MiningRocksOverlay extends Overlay
 {
 	// Range of Motherlode vein respawn time - not 100% confirmed but based on observation
 	static final int ORE_VEIN_MAX_RESPAWN_TIME = 277; // Game ticks
@@ -61,7 +61,7 @@ class MiningOverlay extends Overlay
 	private final MiningPlugin plugin;
 
 	@Inject
-	private MiningOverlay(Client client, MiningPlugin plugin)
+	private MiningRocksOverlay(Client client, MiningPlugin plugin)
 	{
 		setPosition(OverlayPosition.DYNAMIC);
 		setLayer(OverlayLayer.ABOVE_SCENE);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/mining/MiningSession.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/mining/MiningSession.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2020, Jordan Zomerlei <https://github.com/JZomerlei>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.mining;
+
+import java.time.Instant;
+import lombok.Getter;
+
+class MiningSession
+{
+	@Getter
+	private Instant lastMined;
+
+	void setLastMined()
+	{
+		lastMined = Instant.now();
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/mining/Pickaxe.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/mining/Pickaxe.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2020, Jordan Zomerlei <https://github.com/JZomerlei>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.mining;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import static net.runelite.api.AnimationID.MINING_3A_PICKAXE;
+import static net.runelite.api.AnimationID.MINING_ADAMANT_PICKAXE;
+import static net.runelite.api.AnimationID.MINING_BLACK_PICKAXE;
+import static net.runelite.api.AnimationID.MINING_BRONZE_PICKAXE;
+import static net.runelite.api.AnimationID.MINING_CRYSTAL_PICKAXE;
+import static net.runelite.api.AnimationID.MINING_DRAGON_PICKAXE;
+import static net.runelite.api.AnimationID.MINING_DRAGON_PICKAXE_OR;
+import static net.runelite.api.AnimationID.MINING_DRAGON_PICKAXE_UPGRADED;
+import static net.runelite.api.AnimationID.MINING_GILDED_PICKAXE;
+import static net.runelite.api.AnimationID.MINING_INFERNAL_PICKAXE;
+import static net.runelite.api.AnimationID.MINING_IRON_PICKAXE;
+import static net.runelite.api.AnimationID.MINING_MITHRIL_PICKAXE;
+import static net.runelite.api.AnimationID.MINING_RUNE_PICKAXE;
+import static net.runelite.api.AnimationID.MINING_STEEL_PICKAXE;
+import static net.runelite.api.ItemID.ADAMANT_PICKAXE;
+import static net.runelite.api.ItemID.BLACK_PICKAXE;
+import static net.runelite.api.ItemID.BRONZE_PICKAXE;
+import static net.runelite.api.ItemID.CRYSTAL_PICKAXE;
+import static net.runelite.api.ItemID.DRAGON_PICKAXE;
+import static net.runelite.api.ItemID.DRAGON_PICKAXEOR;
+import static net.runelite.api.ItemID.DRAGON_PICKAXE_12797;
+import static net.runelite.api.ItemID.GILDED_PICKAXE;
+import static net.runelite.api.ItemID.INFERNAL_PICKAXE;
+import static net.runelite.api.ItemID.IRON_PICKAXE;
+import static net.runelite.api.ItemID.MITHRIL_PICKAXE;
+import static net.runelite.api.ItemID.RUNE_PICKAXE;
+import static net.runelite.api.ItemID.STEEL_PICKAXE;
+import static net.runelite.api.ItemID._3RD_AGE_PICKAXE;
+import net.runelite.api.Player;
+
+@AllArgsConstructor
+@Getter
+enum Pickaxe
+{
+	BRONZE(MINING_BRONZE_PICKAXE, BRONZE_PICKAXE),
+	IRON(MINING_IRON_PICKAXE, IRON_PICKAXE),
+	STEEL(MINING_STEEL_PICKAXE, STEEL_PICKAXE),
+	BLACK(MINING_BLACK_PICKAXE, BLACK_PICKAXE),
+	MITHRIL(MINING_MITHRIL_PICKAXE, MITHRIL_PICKAXE),
+	ADAMANT(MINING_ADAMANT_PICKAXE, ADAMANT_PICKAXE),
+	RUNE(MINING_RUNE_PICKAXE, RUNE_PICKAXE),
+	GILDED(MINING_GILDED_PICKAXE, GILDED_PICKAXE),
+	DRAGON(MINING_DRAGON_PICKAXE, DRAGON_PICKAXE),
+	DRAGON_OR(MINING_DRAGON_PICKAXE_OR, DRAGON_PICKAXEOR),
+	DRAGON_UPGRADED(MINING_DRAGON_PICKAXE_UPGRADED, DRAGON_PICKAXE_12797),
+	INFERNAL(MINING_INFERNAL_PICKAXE, INFERNAL_PICKAXE),
+	THIRDAGE(MINING_3A_PICKAXE, _3RD_AGE_PICKAXE),
+	CRYSTAL(MINING_CRYSTAL_PICKAXE, CRYSTAL_PICKAXE);
+
+	private final int animId;
+	private final int itemId;
+
+	private static final Map<Integer, Pickaxe> PICKAXE_ANIM_IDS;
+
+	static
+	{
+		ImmutableMap.Builder<Integer, Pickaxe> builder = new ImmutableMap.Builder<>();
+
+		for (Pickaxe pickaxe : values())
+		{
+			builder.put(pickaxe.animId, pickaxe);
+		}
+
+		PICKAXE_ANIM_IDS = builder.build();
+	}
+
+	boolean matchesMiningAnimation(final Player player)
+	{
+		return player != null && animId == player.getAnimation();
+	}
+
+	static Pickaxe fromAnimation(int animId)
+	{
+		return PICKAXE_ANIM_IDS.get(animId);
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/mining/Rock.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/mining/Rock.java
@@ -72,7 +72,7 @@ enum Rock
 				return region == MINING_GUILD ? Duration.of(100, GAME_TICKS) : super.respawnTime;
 			}
 		},
-	LOVAKITE(Duration.of(MiningOverlay.LOVAKITE_ORE_MAX_RESPAWN_TIME, GAME_TICKS), 0, ROCKS_28596, ROCKS_28597),
+	LOVAKITE(Duration.of(MiningRocksOverlay.LOVAKITE_ORE_MAX_RESPAWN_TIME, GAME_TICKS), 0, ROCKS_28596, ROCKS_28597),
 	ADAMANTITE(Duration.of(400, GAME_TICKS), 0, ROCKS_11374, ROCKS_11375, ROCKS_36208)
 		{
 			@Override
@@ -89,7 +89,7 @@ enum Rock
 				return region == MINING_GUILD ? Duration.of(600, GAME_TICKS) : super.respawnTime;
 			}
 		},
-	ORE_VEIN(Duration.of(MiningOverlay.ORE_VEIN_MAX_RESPAWN_TIME, GAME_TICKS), 150),
+	ORE_VEIN(Duration.of(MiningRocksOverlay.ORE_VEIN_MAX_RESPAWN_TIME, GAME_TICKS), 150),
 	AMETHYST(Duration.of(125, GAME_TICKS), 120),
 	ASH_VEIN(Duration.of(50, GAME_TICKS), 0, ASH_PILE),
 	GEM_ROCK(Duration.of(100, GAME_TICKS), 0, ROCKS_11380, ROCKS_11381),
@@ -97,7 +97,7 @@ enum Rock
 	EFH_SALT(Duration.of(9, GAME_TICKS), 0, ROCKS_33255),
 	TE_SALT(Duration.of(9, GAME_TICKS), 0, ROCKS_33256),
 	BASALT(Duration.of(9, GAME_TICKS), 0, ROCKS_33257),
-	DAEYALT_ESSENCE(Duration.of(MiningOverlay.DAEYALT_MAX_RESPAWN_TIME, GAME_TICKS), 0, DAEYALT_ESSENCE_39095);
+	DAEYALT_ESSENCE(Duration.of(MiningRocksOverlay.DAEYALT_MAX_RESPAWN_TIME, GAME_TICKS), 0, DAEYALT_ESSENCE_39095);
 
 	private static final int WILDERNESS_RESOURCE_AREA = 12605;
 	private static final int MISCELLANIA = 10044;

--- a/runelite-client/src/test/java/net/runelite/client/plugins/mining/MiningPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/mining/MiningPluginTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2020, Jordan Zomerlei <https://github.com/JZomerlei>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.mining;
+
+import com.google.inject.Guice;
+import com.google.inject.testing.fieldbinder.Bind;
+import com.google.inject.testing.fieldbinder.BoundFieldModule;
+import javax.inject.Inject;
+import net.runelite.api.ChatMessageType;
+import net.runelite.api.Client;
+import net.runelite.api.events.ChatMessage;
+import net.runelite.client.ui.overlay.OverlayManager;
+import static org.junit.Assert.assertNotNull;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class MiningPluginTest
+{
+	@Inject
+	MiningPlugin miningPlugin;
+
+	@Mock
+	@Bind
+	MiningConfig miningConfig;
+
+	@Mock
+	@Bind
+	Client client;
+
+	@Mock
+	@Bind
+	MiningOverlay miningOverlay;
+
+	@Mock
+	@Bind
+	MiningRocksOverlay miningRocksOverlay;
+
+	@Mock
+	@Bind
+	OverlayManager overlayManager;
+
+	@Before
+	public void before()
+	{
+		Guice.createInjector(BoundFieldModule.of(this)).injectMembers(this);
+	}
+
+	@Test
+	public void testClay()
+	{
+		testMessage("You manage to mine some clay.");
+	}
+
+	@Test
+	public void testIron()
+	{
+		testMessage("You manage to mine some iron.");
+	}
+
+	@Test
+	public void testSandstone()
+	{
+		testMessage("You manage to quarry some sandstone.");
+	}
+
+	@Test
+	public void testGranite()
+	{
+		testMessage("You manage to quarry some granite.");
+	}
+
+	@Test
+	public void testOpal()
+	{
+		testMessage("You just mined an Opal!");
+	}
+
+	@Test
+	public void testJade()
+	{
+		testMessage("You just mined a piece of Jade!");
+	}
+
+	@Test
+	public void testRedTopaz()
+	{
+		testMessage("You just mined a Red Topaz!");
+	}
+
+	@Test
+	public void testSapphire()
+	{
+		testMessage("You just mined a Sapphire!");
+	}
+
+	@Test
+	public void testEmerald()
+	{
+		testMessage("You just mined an Emerald!");
+	}
+
+	@Test
+	public void testRuby()
+	{
+		testMessage("You just mined a Ruby!");
+	}
+
+	@Test
+	public void testDiamond()
+	{
+		testMessage("You just mined a Diamond!");
+	}
+
+	private void testMessage(String gameMessage)
+	{
+		ChatMessage chatMessage = new ChatMessage(null, ChatMessageType.SPAM, "", gameMessage, "", 0);
+		miningPlugin.onChatMessage(chatMessage);
+		assertNotNull(miningPlugin.getSession());
+	}
+}


### PR DESCRIPTION
Rename MiningOverlay to MiningRocksOverlay to match how other plugins with session stats do it. (Woodcutting for example)
Create a new MiningOverlay to track session stats & state of mining or idle.

MiningPluginTest is created. 

I only have 75 mining and am not sure if I have all the onChat message mining.  (Ess/Pure Ess do not have on chat messages)

I watched youtube videos to find the lines for gem rocks & quarry mining.

I don't know how useful mining/not mining is but I added it because it was a why not type of thing.

When mining:
![image](https://user-images.githubusercontent.com/14265490/86027968-4e51bc80-b9ff-11ea-99c2-e52d457baf27.png)

When not mining:
![image](https://user-images.githubusercontent.com/14265490/86028243-a983af00-b9ff-11ea-9f37-ca2054ac0450.png)

