### PR TITLE
Loot tracker plugin - track implings and impling jars

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootReceived.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootReceived.java
@@ -41,4 +41,5 @@ public class LootReceived
 	private int combatLevel;
 	private LootRecordType type;
 	private Collection<ItemStack> items;
+	private int amount;
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPanel.java
@@ -344,7 +344,7 @@ class LootTrackerPanel extends PluginPanel
 	 * Creates a subtitle, adds a new entry and then passes off to the render methods, that will decide
 	 * how to display this new data.
 	 */
-	void add(final String eventName, final LootRecordType type, final int actorLevel, LootTrackerItem[] items)
+	void add(final String eventName, final LootRecordType type, final int actorLevel, LootTrackerItem[] items, int amount)
 	{
 		final String subTitle;
 		if (type == LootRecordType.PICKPOCKET)
@@ -355,7 +355,7 @@ class LootTrackerPanel extends PluginPanel
 		{
 			subTitle = actorLevel > -1 ? "(lvl-" + actorLevel + ")" : "";
 		}
-		final LootTrackerRecord record = new LootTrackerRecord(eventName, subTitle, type, items, 1);
+		final LootTrackerRecord record = new LootTrackerRecord(eventName, subTitle, type, items, amount);
 		sessionRecords.add(record);
 
 		if (hideIgnoredItems && plugin.isEventIgnored(eventName))

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
@@ -469,6 +469,11 @@ public class LootTrackerPlugin extends Plugin
 		addLoot(name, combatLevel, type, items, 1);
 	}
 
+	void addLoot(@NonNull String name, int combatLevel, LootRecordType type, Object metadata, Collection<ItemStack> items, int amount)
+	{
+		addLoot(name, combatLevel, type, items, amount);
+	}
+
 	void addLoot(@NonNull String name, int combatLevel, LootRecordType type, Collection<ItemStack> items, int amount)
 	{
 		final LootTrackerItem[] entries = buildEntries(stack(items));
@@ -929,7 +934,6 @@ public class LootTrackerPlugin extends Plugin
 				.map(e -> new ItemStack(e.getElement(), e.getCount(), client.getLocalPlayer().getLocalLocation()))
 				.collect(Collectors.toList());
 
-			addLoot(event, -1, lootRecordType, metadata, items);
 			final Multiset<Integer> diffr = Multisets.difference(inventorySnapshot, currentInventory);
 			List<ItemStack> itemsr = diffr.entrySet().stream()
 				.map(e -> new ItemStack(e.getElement(), e.getCount(), client.getLocalPlayer().getLocalLocation()))
@@ -943,7 +947,7 @@ public class LootTrackerPlugin extends Plugin
 					amount = i.getQuantity();
 				}
 			}
-			addLoot(event, -1, lootRecordType, items, amount);
+			addLoot(event, -1, lootRecordType, metadata, items, amount);
 
 			inventorySnapshot = null;
 		}


### PR DESCRIPTION
Example:
![example](https://i.gyazo.com/4a1fe4026504cddc802d0877a2a56e93.png)

--

Works with multiple jars per game tick.
Single entry view:
![separate](https://i.gyazo.com/02470975171ba60e93bbd2c2c70aa937.png)
Grouped view:
![grouped](https://i.gyazo.com/1f2516e287f9744d01ce236366a4058c.png)

 #8810