### PR TITLE
Key Mapping Plugin and authenticator

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/input/KeyManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/input/KeyManager.java
@@ -145,6 +145,6 @@ public class KeyManager
 			return true;
 		}
 
-		return client.getGameState() != GameState.LOGIN_SCREEN;
+		return client.getGameState() != GameState.LOGIN_SCREEN && client.getGameState() != GameState.LOGIN_SCREEN_AUTHENTICATOR;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/keyremapping/KeyRemappingListener.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/keyremapping/KeyRemappingListener.java
@@ -33,7 +33,6 @@ import java.util.Map;
 import java.util.Set;
 import javax.inject.Inject;
 import net.runelite.api.Client;
-import net.runelite.api.GameState;
 import net.runelite.api.VarClientStr;
 import net.runelite.client.callback.ClientThread;
 import net.runelite.client.input.KeyListener;
@@ -68,7 +67,7 @@ class KeyRemappingListener implements KeyListener
 	@Override
 	public void keyPressed(KeyEvent e)
 	{
-		if (client.getGameState() == GameState.LOGIN_SCREEN || !plugin.chatboxFocused())
+		if (!plugin.chatboxFocused())
 		{
 			return;
 		}

--- a/runelite-client/src/test/java/net/runelite/client/plugins/keyremapping/KeyRemappingListenerTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/keyremapping/KeyRemappingListenerTest.java
@@ -30,7 +30,6 @@ import com.google.inject.testing.fieldbinder.BoundFieldModule;
 import java.awt.event.KeyEvent;
 import javax.inject.Inject;
 import net.runelite.api.Client;
-import net.runelite.api.GameState;
 import net.runelite.client.config.ModifierlessKeybind;
 import org.junit.Before;
 import org.junit.Test;
@@ -64,8 +63,6 @@ public class KeyRemappingListenerTest
 	public void setUp()
 	{
 		Guice.createInjector(BoundFieldModule.of(this)).injectMembers(this);
-
-		when(client.getGameState()).thenReturn(GameState.LOGGED_IN);
 	}
 
 	@Test


### PR DESCRIPTION
Closes #12045

Adding change to allow authenticator use with Key Remap Plugin. Currently the functionality is only prevented on the Login Screen and not the authenticator screen as well