### PR TITLE
add more display options for farming contract infobox

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/TimeTrackingConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/TimeTrackingConfig.java
@@ -28,6 +28,7 @@ import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
 import net.runelite.client.config.Units;
+import net.runelite.client.plugins.timetracking.farming.FarmingContractInfoBoxDisplay;
 
 @ConfigGroup("timetracking")
 public interface TimeTrackingConfig extends Config
@@ -74,12 +75,12 @@ public interface TimeTrackingConfig extends Config
 	@ConfigItem(
 		keyName = "farmingContractInfoBox",
 		name = "Show farming contract infobox",
-		description = "Show an infobox of your current farming contract when inside the farming guild",
+		description = "Show an infobox of your current farming contract",
 		position = 4
 	)
-	default boolean farmingContractInfoBox()
+	default FarmingContractInfoBoxDisplay farmingContractInfoBox()
 	{
-		return true;
+		return FarmingContractInfoBoxDisplay.FARMING_GUILD;
 	}
 
 	@ConfigItem(

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/farming/FarmingContractInfoBox.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/farming/FarmingContractInfoBox.java
@@ -111,6 +111,6 @@ class FarmingContractInfoBox extends InfoBox
 	@Override
 	public boolean render()
 	{
-		return config.farmingContractInfoBox();
+		return !config.farmingContractInfoBox().equals(FarmingContractInfoBoxDisplay.NEVER);
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/farming/FarmingContractInfoBoxDisplay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/farming/FarmingContractInfoBoxDisplay.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2020, MMagicala
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package net.runelite.client.plugins.timetracking.farming;
+
+public enum FarmingContractInfoBoxDisplay
+{
+	ALWAYS, NEVER, FARMING_GUILD
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/farming/FarmingContractManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/farming/FarmingContractManager.java
@@ -146,16 +146,19 @@ public class FarmingContractManager
 		if (loc.getRegionID() == FARMING_GUILD_REGION_ID)
 		{
 			handleGuildmasterJaneWidgetDialog();
+		}
+
+		if (config.farmingContractInfoBox().equals(FarmingContractInfoBoxDisplay.ALWAYS)
+			|| (config.farmingContractInfoBox().equals(FarmingContractInfoBoxDisplay.FARMING_GUILD) && loc.getRegionID() == FARMING_GUILD_REGION_ID))
+		{
 			handleInfoBox();
 		}
-		else
+		else if (infoBox != null)
 		{
-			if (infoBox != null)
-			{
-				infoBoxManager.removeInfoBox(infoBox);
-				infoBox = null;
-			}
+			infoBoxManager.removeInfoBox(infoBox);
+			infoBox = null;
 		}
+
 		return oldSummary != summary;
 	}
 


### PR DESCRIPTION
Add the following display settings for the farming contract infobox: always, farming guild (only), never

Needs testing by another contributor

![Screenshot from 2020-07-02 23-47-23](https://user-images.githubusercontent.com/36617521/86440381-2ee8b700-bcbf-11ea-8eb9-e5396d61844b.png)
![Screenshot from 2020-07-02 23-50-37](https://user-images.githubusercontent.com/36617521/86440384-3019e400-bcbf-11ea-952e-446e68550474.png)
