### PR TITLE
Use Netty HTTP client in http-api

### DIFF
--- a/http-api/pom.xml
+++ b/http-api/pom.xml
@@ -45,6 +45,19 @@
 			<artifactId>okhttp</artifactId>
 			<version>3.7.0</version>
 		</dependency>
+		<!-- https://mvnrepository.com/artifact/io.projectreactor.netty/reactor-netty -->
+		<dependency>
+			<groupId>io.projectreactor.netty</groupId>
+			<artifactId>reactor-netty</artifactId>
+			<version>0.9.9.RELEASE</version>
+		</dependency>
+		<!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-databind -->
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+			<version>2.11.1</version>
+		</dependency>
+
 		<dependency>
 			<groupId>com.google.code.gson</groupId>
 			<artifactId>gson</artifactId>
@@ -63,11 +76,16 @@
 			<artifactId>commons-csv</artifactId>
 			<version>1.4</version>
 		</dependency>
-
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 			<version>4.12</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.projectreactor</groupId>
+			<artifactId>reactor-test</artifactId>
+			<version>3.3.7.RELEASE</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/http-api/src/main/java/net/runelite/http/api/RuneLiteAPI.java
+++ b/http-api/src/main/java/net/runelite/http/api/RuneLiteAPI.java
@@ -108,7 +108,8 @@ public class RuneLiteAPI
 			.headers(headers -> headers.add("User-Agent", userAgent));
 	}
 
-	public static HttpClient getBaseClient() {
+	public static HttpClient getBaseClient()
+	{
 		return BASE_CLIENT;
 	}
 

--- a/http-api/src/main/java/net/runelite/http/api/RuneLiteAPI.java
+++ b/http-api/src/main/java/net/runelite/http/api/RuneLiteAPI.java
@@ -37,6 +37,7 @@ import okhttp3.Request;
 import okhttp3.Response;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import reactor.netty.http.client.HttpClient;
 
 public class RuneLiteAPI
 {
@@ -56,6 +57,8 @@ public class RuneLiteAPI
 	private static final Properties properties = new Properties();
 	private static String version;
 	private static int rsVersion;
+
+	private static final HttpClient BASE_CLIENT;
 
 	static
 	{
@@ -96,6 +99,17 @@ public class RuneLiteAPI
 				}
 			})
 			.build();
+
+
+		final String prop = System.getProperty("runelite.http-service.url");
+		final String url = prop != null && !prop.isEmpty() ? prop : BASE + "/runelite-" + getVersion();
+		BASE_CLIENT = HttpClient.create()
+			.baseUrl(url)
+			.headers(headers -> headers.add("User-Agent", userAgent));
+	}
+
+	public static HttpClient getBaseClient() {
+		return BASE_CLIENT;
 	}
 
 	public static HttpUrl getSessionBase()

--- a/http-api/src/main/java/net/runelite/http/api/RuneLiteClient.java
+++ b/http-api/src/main/java/net/runelite/http/api/RuneLiteClient.java
@@ -1,0 +1,129 @@
+package net.runelite.http.api;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.QueryStringEncoder;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.function.Function;
+import lombok.extern.slf4j.Slf4j;
+import reactor.core.publisher.Mono;
+import reactor.netty.ByteBufMono;
+import reactor.netty.http.client.HttpClient;
+import reactor.netty.http.client.HttpClientResponse;
+import reactor.util.retry.Retry;
+import reactor.util.retry.RetryBackoffSpec;
+
+/**
+ * Base client for RuneLite API, capable of synchronous and asynchronous network calls.
+ * Incorporates an exponential backoff strategy with jitter.
+ */
+@Slf4j
+public class RuneLiteClient
+{
+	private final HttpClient client;
+	private final String endpoint;
+	private final RetryBackoffSpec retryStrategy;
+
+	private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+	private static final RetryBackoffSpec DEFAULT_RETRY_STRATEGY = Retry.backoff(5, Duration.ofSeconds(2))
+		.onRetryExhaustedThrow((retry, signal) -> new IOException(signal.failure()));
+
+	protected RuneLiteClient(HttpClient client, String endpoint)
+	{
+		this(client, endpoint, DEFAULT_RETRY_STRATEGY);
+	}
+
+	protected RuneLiteClient(HttpClient client, String endpoint, RetryBackoffSpec retryStrategy)
+	{
+		this.endpoint = endpoint;
+		this.client = client
+			.doOnRequest((req, con) -> log.debug(String.format("Built URL: %S", req.fullPath())))
+			.doOnRequestError((req, e) -> log.warn(String.format("API request error: %s", e.getMessage())))
+			.doOnResponseError((req, e) -> log.warn(String.format("API response error: %s", e.getMessage())));
+		this.retryStrategy = retryStrategy.onRetryExhaustedThrow((retry, signal) -> new IOException(signal.failure()));
+	}
+
+	protected <T> RequestBuilder<T> get(Class<T> clazz)
+	{
+		return new RequestBuilder<>(endpoint, uri -> request(client.get(), uri, clazz));
+	}
+
+	protected <T> RequestBuilder<T> post(Class<T> clazz)
+	{
+		return new RequestBuilder<>(endpoint, uri -> request(client.post(), uri, clazz));
+	}
+
+	private <T> Mono<T> request(HttpClient.ResponseReceiver<?> receiver, URI uri, Class<T> clazz)
+	{
+		return receiver.uri(uri.toString())
+			.responseSingle(RuneLiteClient::processResponse)
+			.retryWhen(retryStrategy.doBeforeRetry(signal -> log.debug("Retrying")))
+			.flatMap(bytes -> toMono(bytes, clazz));
+	}
+
+	protected static <T> Mono<T> toMono(byte[] bytes, Class<T> clazz)
+	{
+		System.out.println(Arrays.toString(bytes));
+		return Mono.fromCallable(() -> OBJECT_MAPPER.readValue(bytes, clazz));
+	}
+
+	private static Mono<byte[]> processResponse(HttpClientResponse response, ByteBufMono bytes)
+	{
+		if (response.status() != HttpResponseStatus.OK)
+		{
+			return Mono.error(new IOException(response.status().reasonPhrase()));
+		}
+		return bytes.asByteArray();
+	}
+
+	public long getRetryMaxAttempts()
+	{
+		return DEFAULT_RETRY_STRATEGY.maxAttempts;
+	}
+
+	public Duration getRetryMinBackoff()
+	{
+		return DEFAULT_RETRY_STRATEGY.minBackoff;
+	}
+
+	public double getRetryJitterFactor()
+	{
+		return DEFAULT_RETRY_STRATEGY.jitterFactor;
+	}
+
+	protected static class RequestBuilder<T>
+	{
+
+		private QueryStringEncoder query;
+		private final Function<URI, Mono<T>> executor;
+
+		public RequestBuilder(String endpoint, Function<URI, Mono<T>> executor)
+		{
+			this.query = new QueryStringEncoder(endpoint);
+			this.executor = executor;
+		}
+
+		public RequestBuilder<T> queryParam(String field, String value)
+		{
+			query.addParam(field, value);
+			return this;
+		}
+
+		public Mono<T> retrieve()
+		{
+			try
+			{
+				return executor.apply(query.toUri());
+			}
+			catch (URISyntaxException e)
+			{
+				return Mono.error(e);
+			}
+
+		}
+	}
+}

--- a/http-api/src/main/java/net/runelite/http/api/worlds/World.java
+++ b/http-api/src/main/java/net/runelite/http/api/worlds/World.java
@@ -24,23 +24,29 @@
  */
 package net.runelite.http.api.worlds;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import java.util.EnumSet;
 import lombok.Builder;
 import lombok.Value;
 
 @Value
 @Builder
+@JsonDeserialize(builder = World.WorldBuilder.class)
 public class World
 {
-	private int id;
-	private EnumSet<WorldType> types;
-	private String address;
-	private String activity;
-	private int location;
-	private int players;
+	int id;
+	EnumSet<WorldType> types;
+	String address;
+	String activity;
+	int location;
+	int players;
 
 	public WorldRegion getRegion()
 	{
 		return WorldRegion.valueOf(location);
 	}
+
+	@JsonPOJOBuilder(withPrefix = "")
+	public static class WorldBuilder {}
 }

--- a/http-api/src/main/java/net/runelite/http/api/worlds/World.java
+++ b/http-api/src/main/java/net/runelite/http/api/worlds/World.java
@@ -48,5 +48,7 @@ public class World
 	}
 
 	@JsonPOJOBuilder(withPrefix = "")
-	public static class WorldBuilder {}
+	public static class WorldBuilder
+	{
+	}
 }

--- a/http-api/src/main/java/net/runelite/http/api/worlds/WorldClient.java
+++ b/http-api/src/main/java/net/runelite/http/api/worlds/WorldClient.java
@@ -51,7 +51,7 @@ public class WorldClient extends RuneLiteClient
 	 * The result can be handled as a {@link Future} if desired:
 	 *
 	 * <pre> {@code lookupWorldsAsync().toFuture;} </pre>
-	 * <p>
+	 *
 	 * Similarly, the {@link Future} will throw a {@link java.util.concurrent.ExecutionException}, wrapping
 	 * the {@link IOException} on error.
 	 *

--- a/http-api/src/main/java/net/runelite/http/api/worlds/WorldResult.java
+++ b/http-api/src/main/java/net/runelite/http/api/worlds/WorldResult.java
@@ -24,21 +24,18 @@
  */
 package net.runelite.http.api.worlds;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import java.util.List;
+import lombok.Builder;
+import lombok.Value;
 
+@Value
+@Builder
+@JsonDeserialize(builder = WorldResult.WorldResultBuilder.class)
 public class WorldResult
 {
-	private List<World> worlds;
-
-	public List<World> getWorlds()
-	{
-		return worlds;
-	}
-
-	public void setWorlds(List<World> worlds)
-	{
-		this.worlds = worlds;
-	}
+	List<World> worlds;
 
 	public World findWorld(int worldNum)
 	{
@@ -51,4 +48,7 @@ public class WorldResult
 		}
 		return null;
 	}
+
+	@JsonPOJOBuilder(withPrefix = "")
+	public static class WorldResultBuilder {}
 }

--- a/http-api/src/main/java/net/runelite/http/api/worlds/WorldResult.java
+++ b/http-api/src/main/java/net/runelite/http/api/worlds/WorldResult.java
@@ -50,5 +50,7 @@ public class WorldResult
 	}
 
 	@JsonPOJOBuilder(withPrefix = "")
-	public static class WorldResultBuilder {}
+	public static class WorldResultBuilder
+	{
+	}
 }

--- a/http-api/src/test/java/net/runelite/http/api/RuneLiteClientTest.java
+++ b/http-api/src/test/java/net/runelite/http/api/RuneLiteClientTest.java
@@ -1,0 +1,79 @@
+package net.runelite.http.api;
+
+import java.io.IOException;
+import java.time.Duration;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import reactor.netty.http.client.HttpClient;
+import reactor.test.StepVerifier;
+import reactor.util.retry.Retry;
+
+public class RuneLiteClientTest
+{
+
+	public final MockWebServer server = new MockWebServer();
+	private HttpClient httpClient;
+
+	@Rule
+	public final ExpectedException exception = ExpectedException.none();
+
+	@Before
+	public void before() throws IOException
+	{
+		server.start();
+		httpClient = HttpClient.create().baseUrl(server.url("/").toString()).port(server.getPort());
+	}
+
+	@After
+	public void after() throws IOException
+	{
+		server.shutdown();
+	}
+
+	@Test()
+	public void retriesExhausted()
+	{
+		RuneLiteClient client = new RuneLiteClient(httpClient, "/", Retry.backoff(5, Duration.ofMillis(10)));
+
+		// enqueue expected retry responses + 1 (initial request)
+		for (long i = 0; i < client.getRetryMaxAttempts() + 1; i++)
+		{
+			server.enqueue(new MockResponse().setResponseCode(500));
+		}
+
+		StepVerifier.create(client.get(String.class).retrieve())
+			.expectError(IOException.class)
+			.verify();
+
+		Assert.assertEquals(client.getRetryMaxAttempts() + 1, server.getRequestCount());
+	}
+
+	@Test()
+	public void retryUntil200()
+	{
+		RuneLiteClient client = new RuneLiteClient(httpClient, "/", Retry.backoff(5, Duration.ofMillis(10)));
+
+		server.enqueue(new MockResponse().setResponseCode(500));
+		server.enqueue(new MockResponse().setResponseCode(500));
+		server.enqueue(new MockResponse().setResponseCode(200));
+
+		StepVerifier.create(client.get(String.class).retrieve())
+			.expectComplete()
+			.verify();
+
+		Assert.assertEquals(3, server.getRequestCount());
+	}
+
+	@Test
+	public void emptyResponseNonNull() throws IOException
+	{
+		server.enqueue(new MockResponse().setBody("").setResponseCode(200));
+
+	}
+}

--- a/http-api/src/test/java/net/runelite/http/api/worlds/WordClientTest.java
+++ b/http-api/src/test/java/net/runelite/http/api/worlds/WordClientTest.java
@@ -1,0 +1,57 @@
+package net.runelite.http.api.worlds;
+
+import java.io.IOException;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import reactor.netty.http.client.HttpClient;
+
+public class WordClientTest
+{
+	private final MockWebServer server = new MockWebServer();
+	private WorldClient client;
+
+	private static final String expected =
+		"{\"worlds\":[{\"id\":385,\"types\":[\"SKILL_TOTAL\"],\"address\":\"oldschool85.runescape.com\"," +
+			"\"activity\":\"750 skill total\",\"location\":0,\"players\":80}]}";
+
+	@Rule
+	public final ExpectedException exception = ExpectedException.none();
+
+	@Before
+	public void before() throws IOException
+	{
+		server.start();
+		client = WorldClient.create(HttpClient.create().baseUrl(server.url("/").toString()).port(server.getPort()));
+	}
+
+	@After
+	public void after() throws IOException
+	{
+		server.shutdown();
+	}
+
+	@Test
+	public void expectedResponse() throws IOException
+	{
+		server.enqueue(new MockResponse().setBody(expected).setResponseCode(200));
+		WorldResult result = client.lookupWorlds();
+		Assert.assertEquals(1, result.getWorlds().size());
+
+		World world = result.getWorlds().get(0);
+
+		Assert.assertEquals(385, world.getId());
+		Assert.assertTrue(world.getTypes().contains(WorldType.SKILL_TOTAL));
+		Assert.assertEquals("oldschool85.runescape.com", world.getAddress());
+		Assert.assertEquals("750 skill total", world.getActivity());
+		Assert.assertEquals(0, world.getLocation());
+		Assert.assertEquals(80, world.getPlayers());
+	}
+
+
+}

--- a/runelite-client/src/main/java/net/runelite/client/game/WorldService.java
+++ b/runelite-client/src/main/java/net/runelite/client/game/WorldService.java
@@ -65,7 +65,7 @@ public class WorldService
 	{
 		this.client = client;
 		this.scheduledExecutorService = scheduledExecutorService;
-		this.worldClient = new WorldClient(okHttpClient);
+		this.worldClient = WorldClient.create();
 		this.eventBus = eventBus;
 
 		scheduledExecutorService.scheduleWithFixedDelay(RunnableExceptionLogger.wrap(this::tick), 0, WORLD_FETCH_TIMER, TimeUnit.MINUTES);

--- a/runelite-client/src/main/java/net/runelite/client/rs/WorldSupplier.java
+++ b/runelite-client/src/main/java/net/runelite/client/rs/WorldSupplier.java
@@ -58,7 +58,7 @@ class WorldSupplier implements Supplier<World>
 
 		try
 		{
-			List<World> newWorlds = new WorldClient(okHttpClient)
+			List<World> newWorlds = WorldClient.create()
 				.lookupWorlds()
 				.getWorlds()
 				.stream()


### PR DESCRIPTION
This PR introduces a base RuneLiteClient using the Netty client. It uses this new RuneLiteClient to implement WorldClient, as an example.

RuneLiteClient takes responsibility for all network calls and deserialization. Before, each client did its own deserialized with GSON. This simplifies logic within each client class (see WorldClient example). It also implements a retry strategy in case of network failure.

Of course, changing a single client to use Netty will not make much of a difference, but once all clients inherit from RuneLiteClient and have async support, it can improve performance throughout the application.

It preserves the previous synchronous API, so nobody is forced to use the async option.

Thoughts?

supersedes #12051