### PR TITLE
Add ability to automatically screenshot Barbarian Assault high gamble rewards

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotConfig.java
@@ -236,7 +236,10 @@ public interface ScreenshotConfig extends Config
 		position = 16,
 		section = whatSection
 	)
-	default boolean screenshotHighGamble() { return false; }
+	default boolean screenshotHighGamble()
+	{
+		return false;
+	}
 
 	@ConfigItem(
 		keyName = "hotkey",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotConfig.java
@@ -230,10 +230,19 @@ public interface ScreenshotConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "baHighGamble",
+		name = "Screenshot BA high gambles",
+		description = "Take a screenshot of your reward from a high gamble at Barbarian Assault.",
+		position = 16,
+		section = whatSection
+	)
+	default boolean screenshotHighGamble() { return false; }
+
+	@ConfigItem(
 		keyName = "hotkey",
 		name = "Screenshot hotkey",
 		description = "When you press this key a screenshot will be taken",
-		position = 16
+		position = 17
 	)
 	default Keybind hotkey()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
@@ -645,8 +645,9 @@ public class ScreenshotPlugin extends Plugin
 	 * Parses the Barbarian Assault high gamble reward dialog text into a shortened string for filename usage.
 	 *
 	 * @param text The {@link Widget#getText() text} of the {@link WidgetInfo#DIALOG_SPRITE_TEXT} widget.
-	 * @return Shortened string in the format "(100) Watermelon seed (x50)"
+	 * @return Shortened string in the format "High Gamble(100)"
 	 */
+	@VisibleForTesting
 	static String parseBAHighGambleWidget(final String text)
 	{
 		final Matcher highGambleMatch = BA_HIGH_GAMBLE_REWARD_PATTERN.matcher(text);
@@ -655,7 +656,7 @@ public class ScreenshotPlugin extends Plugin
 			String reward = highGambleMatch.group(1);
 			String gambleCount = highGambleMatch.group(2);
 
-			return String.format("(%s) %s", gambleCount, reward);
+			return String.format("High Gamble(%s)", gambleCount);
 		}
 
 		return "High Gamble(count not found)";

--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
@@ -640,7 +640,7 @@ public class ScreenshotPlugin extends Plugin
 	 * Parses the Barbarian Assault high gamble reward dialog text into a shortened string for filename usage.
 	 *
 	 * @param text The {@link Widget#getText() text} of the {@link WidgetInfo#DIALOG_SPRITE_TEXT} widget.
-	 * @return Shortened string in the format "Watermelon seed (x50)(100)"
+	 * @return Shortened string in the format "(100) Watermelon seed (x50)"
 	 */
 	static String parseBAHighGambleWidget(final String text)
 	{
@@ -650,7 +650,7 @@ public class ScreenshotPlugin extends Plugin
 			String reward = highGambleMatch.group(1);
 			String gambleCount = highGambleMatch.group(2);
 
-			return String.format("%s(%s)", reward, gambleCount);
+			return String.format("(%s) %s", gambleCount, reward);
 		}
 
 		return "High Gamble(count not found)";

--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
@@ -653,7 +653,7 @@ public class ScreenshotPlugin extends Plugin
 		final Matcher highGambleMatch = BA_HIGH_GAMBLE_REWARD_PATTERN.matcher(text);
 		if (highGambleMatch.find())
 		{
-			String gambleCount = highGambleMatch.group(2);
+			String gambleCount = highGambleMatch.group("gambleCount");
 			return String.format("High Gamble(%s)", gambleCount);
 		}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
@@ -653,9 +653,7 @@ public class ScreenshotPlugin extends Plugin
 		final Matcher highGambleMatch = BA_HIGH_GAMBLE_REWARD_PATTERN.matcher(text);
 		if (highGambleMatch.find())
 		{
-			String reward = highGambleMatch.group(1);
 			String gambleCount = highGambleMatch.group(2);
-
 			return String.format("High Gamble(%s)", gambleCount);
 		}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
@@ -640,7 +640,7 @@ public class ScreenshotPlugin extends Plugin
 	 * Parses the Barbarian Assault high gamble reward dialog text into a shortened string for filename usage.
 	 *
 	 * @param text The {@link Widget#getText() text} of the {@link WidgetInfo#DIALOG_SPRITE_TEXT} widget.
-	 * @return Shortened string in the format "Watermelon seed (x50) (100)"
+	 * @return Shortened string in the format "Watermelon seed (x50)(100)"
 	 */
 	static String parseBAHighGambleWidget(final String text)
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
@@ -110,7 +110,7 @@ public class ScreenshotPlugin extends Plugin
 	private static final ImmutableList<String> PET_MESSAGES = ImmutableList.of("You have a funny feeling like you're being followed",
 		"You feel something weird sneaking into your backpack",
 		"You have a funny feeling like you would have been followed");
-	private static final Pattern BA_HIGH_GAMBLE_REWARD_PATTERN = Pattern.compile("(.+)!<br>High level gamble count: <col=7f0000>(.+)</col>");
+	private static final Pattern BA_HIGH_GAMBLE_REWARD_PATTERN = Pattern.compile("(?<reward>.+)!<br>High level gamble count: <col=7f0000>(?<gambleCount>.+)</col>");
 
 	private String clueType;
 	private Integer clueNumber;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
@@ -110,6 +110,7 @@ public class ScreenshotPlugin extends Plugin
 	private static final ImmutableList<String> PET_MESSAGES = ImmutableList.of("You have a funny feeling like you're being followed",
 		"You feel something weird sneaking into your backpack",
 		"You have a funny feeling like you would have been followed");
+	private static final Pattern BA_HIGH_GAMBLE_REWARD_PATTERN = Pattern.compile("(.+)!<br>High level gamble count: <col=7f0000>(.+)</col>");
 
 	private String clueType;
 	private Integer clueNumber;
@@ -238,8 +239,17 @@ public class ScreenshotPlugin extends Plugin
 		}
 		else if (client.getWidget(WidgetInfo.DIALOG_SPRITE_TEXT) != null)
 		{
-			fileName = parseLevelUpWidget(WidgetInfo.DIALOG_SPRITE_TEXT);
-			screenshotSubDir = "Levels";
+			String text = client.getWidget(WidgetInfo.DIALOG_SPRITE_TEXT).getText();
+			if (Text.removeTags(text).contains("High level gamble"))
+			{
+				fileName = parseBAHighGambleWidget(text);
+				screenshotSubDir = "BA High Gambles";
+			}
+			else
+			{
+				fileName = parseLevelUpWidget(WidgetInfo.DIALOG_SPRITE_TEXT);
+				screenshotSubDir = "Levels";
+			}
 		}
 		else if (client.getWidget(WidgetInfo.QUEST_COMPLETED_NAME_TEXT) != null)
 		{
@@ -378,7 +388,7 @@ public class ScreenshotPlugin extends Plugin
 			takeScreenshot(fileName, "Pets");
 		}
 
-		if (config.screenshotBossKills() )
+		if (config.screenshotBossKills())
 		{
 			Matcher m = BOSSKILL_MESSAGE_PATTERN.matcher(chatMessage);
 			if (m.matches())
@@ -456,7 +466,7 @@ public class ScreenshotPlugin extends Plugin
 				break;
 			case LEVEL_UP_GROUP_ID:
 			case DIALOG_SPRITE_GROUP_ID:
-				if (!config.screenshotLevels())
+				if (!(config.screenshotLevels() || config.screenshotHighGamble()))
 				{
 					return;
 				}
@@ -627,11 +637,32 @@ public class ScreenshotPlugin extends Plugin
 	}
 
 	/**
+	 * Parses the Barbarian Assault high gamble reward dialog text into a shortened string for filename usage.
+	 *
+	 * @param text The {@link Widget#getText() text} of the {@link WidgetInfo#DIALOG_SPRITE_TEXT} widget.
+	 * @return Shortened string in the format "Watermelon seed (x50) (100)"
+	 */
+	static String parseBAHighGambleWidget(final String text)
+	{
+		final Matcher highGambleMatch = BA_HIGH_GAMBLE_REWARD_PATTERN.matcher(text);
+		if (highGambleMatch.find())
+		{
+			String reward = highGambleMatch.group(1);
+			String gambleCount = highGambleMatch.group(2);
+
+			return String.format("%s(%s)", reward, gambleCount);
+		}
+
+		return "High Gamble(count not found)";
+	}
+
+
+	/**
 	 * Saves a screenshot of the client window to the screenshot folder as a PNG,
 	 * and optionally uploads it to an image-hosting service.
 	 *
-	 * @param fileName    Filename to use, without file extension.
-	 * @param subDir      Subdirectory to store the captured screenshot in.
+	 * @param fileName Filename to use, without file extension.
+	 * @param subDir   Subdirectory to store the captured screenshot in.
 	 */
 	private void takeScreenshot(String fileName, String subDir)
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
@@ -465,6 +465,11 @@ public class ScreenshotPlugin extends Plugin
 				}
 				break;
 			case LEVEL_UP_GROUP_ID:
+				if (!config.screenshotLevels())
+				{
+					return;
+				}
+				break;
 			case DIALOG_SPRITE_GROUP_ID:
 				if (!(config.screenshotLevels() || config.screenshotHighGamble()))
 				{

--- a/runelite-client/src/test/java/net/runelite/client/plugins/screenshot/ScreenshotPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/screenshot/ScreenshotPluginTest.java
@@ -66,6 +66,7 @@ public class ScreenshotPluginTest
 	private static final String THEATRE_OF_BLOOD_CHEST = "Your completed Theatre of Blood count is: <col=ff0000>73</col>.";
 	private static final String VALUABLE_DROP = "<col=ef1020>Valuable drop: 6 x Bronze arrow (42 coins)</col>";
 	private static final String UNTRADEABLE_DROP = "<col=ef1020>Untradeable drop: Rusty sword";
+	private static final String BA_HIGH_GAMBLE_REWARD = "Raw shark (x 300)!<br>High level gamble count: <col=7f0000>100</col>";
 
 	@Mock
 	@Bind
@@ -257,5 +258,11 @@ public class ScreenshotPluginTest
 		assertEquals("Quest(Recipe for Disaster - Another Cook's Quest)", ScreenshotPlugin.parseQuestCompletedWidget("You have completed Another Cook's Quest!"));
 		assertEquals("Quest(Doric's Quest)", ScreenshotPlugin.parseQuestCompletedWidget("You have completed Doric's Quest!"));
 		assertEquals("Quest(quest not found)", ScreenshotPlugin.parseQuestCompletedWidget("Sins of the Father forgiven!"));
+	}
+
+	@Test
+	public void testBAHighGambleRewardParsing()
+	{
+		assertEquals("High Gamble(100)", ScreenshotPlugin.parseBAHighGambleWidget(BA_HIGH_GAMBLE_REWARD));
 	}
 }


### PR DESCRIPTION
The clan chat I'm in has a game that requires having screenshots for BA high gambles.

I thought this feature might be helpful for others, as well.