### PR TITLE
Add per-NPC highlight settings

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcHighlight.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcHighlight.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2020, Jesse Serrao <jesseserrao@hotmail.co.uk>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.npchighlight;
+
+import java.awt.Color;
+import lombok.Value;
+
+/*
+	Designates the highlight settings of a specific NPC.
+ */
+@Value
+public class NpcHighlight
+{
+	private Color color;
+	private Boolean renderTile;
+	private Boolean renderHull;
+	private Boolean renderSouthWestTile;
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsPlugin.java
@@ -38,6 +38,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import javax.inject.Inject;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -88,6 +90,15 @@ public class NpcIndicatorsPlugin extends Plugin
 	private static final String TAG_ALL = "Tag-All";
 	private static final String UNTAG_ALL = "Un-tag-All";
 
+	// The character used to split NPC config variables
+	private static final String HIGHLIGHT_CONFIG_SPLITTER = ":";
+
+	private static final String HIGHLIGHT_CONFIG_TILE = "tile"; // Tile highlight style
+	private static final String HIGHLIGHT_CONFIG_SOUTH_WEST_TILE = "sw"; // South west tile highlight style
+	private static final String HIGHLIGHT_CONFIG_HULL = "hull"; // Hull highlight style
+
+	private static final Pattern HIGHLIGHT_CONFIG_RGB = Pattern.compile("^([rgb])([0-9]{1,3})$");
+
 	private static final Set<MenuAction> NPC_MENU_ACTIONS = ImmutableSet.of(MenuAction.NPC_FIRST_OPTION, MenuAction.NPC_SECOND_OPTION,
 		MenuAction.NPC_THIRD_OPTION, MenuAction.NPC_FOURTH_OPTION, MenuAction.NPC_FIFTH_OPTION, MenuAction.SPELL_CAST_ON_NPC,
 		MenuAction.ITEM_USE_ON_NPC);
@@ -117,7 +128,7 @@ public class NpcIndicatorsPlugin extends Plugin
 	 * NPCs to highlight
 	 */
 	@Getter(AccessLevel.PACKAGE)
-	private final Set<NPC> highlightedNpcs = new HashSet<>();
+	private final HashMap<NPC, NpcHighlight> highlightedNpcs = new HashMap<>();
 
 	/**
 	 * Dead NPCs that should be displayed with a respawn indicator if the config is on.
@@ -257,7 +268,7 @@ public class NpcIndicatorsPlugin extends Plugin
 				color = config.deadNpcMenuColor();
 			}
 
-			if (color == null && highlightedNpcs.contains(npc) && config.highlightMenuNames() && (!npc.isDead() || !config.ignoreDeadNpcs()))
+			if (color == null && highlightedNpcs.containsKey(npc) && config.highlightMenuNames() && (!npc.isDead() || !config.ignoreDeadNpcs()))
 			{
 				color = config.getHighlightColor();
 			}
@@ -341,7 +352,6 @@ public class NpcIndicatorsPlugin extends Plugin
 		if (click.getMenuOption().equals(TAG) || click.getMenuOption().equals(UNTAG))
 		{
 			final boolean removed = npcTags.remove(id);
-
 			if (removed)
 			{
 				highlightedNpcs.remove(npc);
@@ -354,7 +364,10 @@ public class NpcIndicatorsPlugin extends Plugin
 					memorizeNpc(npc);
 					npcTags.add(id);
 				}
-				highlightedNpcs.add(npc);
+				highlightedNpcs.put(npc, new NpcHighlight(config.getHighlightColor(),
+					config.highlightTile(),
+					config.highlightHull(),
+					config.highlightSouthWestTile()));
 			}
 		}
 		else
@@ -364,6 +377,83 @@ public class NpcIndicatorsPlugin extends Plugin
 		}
 
 		click.consume();
+	}
+
+	/**
+	 * Builds an appropriate NpcHighlight object from given NPC and string
+	 */
+	private NpcHighlight buildNpcHighlight(NPC npc, String highlightString)
+	{
+		String splitHighlight[] = highlightString.split(HIGHLIGHT_CONFIG_SPLITTER);
+		String highlightNpcName = splitHighlight[0];
+		if (splitHighlight.length == 0 || !WildcardMatcher.matches(highlightNpcName, npc.getName()))
+		{
+			return null;
+		}
+
+		Boolean customHighlightColourDefined = false;
+		Boolean customHighlightStylesDefined = false;
+		int redHighlight = 0;
+		int greenHighlight = 0;
+		int blueHighlight = 0;
+		Boolean tileHighlight = false;
+		Boolean swHighlight = false;
+		Boolean hullHighlight = false;
+
+		for (String highlightVar : splitHighlight)
+		{
+			highlightVar = highlightVar.trim().toLowerCase();
+
+			Matcher matcher = HIGHLIGHT_CONFIG_RGB.matcher(highlightVar);
+			if (matcher.matches())
+			{
+				int matchColorValue = Integer.parseInt(matcher.group(2));
+				switch (matcher.group(1))
+				{
+					case "r":
+						redHighlight = matchColorValue;
+						break;
+					case "g":
+						greenHighlight = matchColorValue;
+						break;
+					case "b":
+						blueHighlight = matchColorValue;
+						break;
+				}
+				customHighlightColourDefined = true;
+				continue;
+			}
+
+			if (highlightVar.equals(HIGHLIGHT_CONFIG_TILE))
+			{
+				tileHighlight = true;
+				customHighlightStylesDefined = true;
+			}
+			else if (highlightVar.equals(HIGHLIGHT_CONFIG_SOUTH_WEST_TILE))
+			{
+				swHighlight = true;
+				customHighlightStylesDefined = true;
+			}
+			else if (highlightVar.equals(HIGHLIGHT_CONFIG_HULL))
+			{
+				hullHighlight = true;
+				customHighlightStylesDefined = true;
+			}
+		}
+
+		Color highlightColor = config.getHighlightColor();
+		if (customHighlightColourDefined)
+		{
+			highlightColor = new Color(redHighlight, greenHighlight, blueHighlight);
+		}
+		if (!customHighlightStylesDefined)
+		{
+			tileHighlight = config.highlightTile();
+			hullHighlight = config.highlightHull();
+			swHighlight = config.highlightSouthWestTile();
+		}
+
+		return new NpcHighlight(highlightColor, tileHighlight, hullHighlight, swHighlight);
 	}
 
 	@Subscribe
@@ -380,16 +470,22 @@ public class NpcIndicatorsPlugin extends Plugin
 		if (npcTags.contains(npc.getIndex()))
 		{
 			memorizeNpc(npc);
-			highlightedNpcs.add(npc);
+			highlightedNpcs.put(npc, new NpcHighlight(
+				config.getHighlightColor(),
+				config.highlightTile(),
+				config.highlightHull(),
+				config.highlightSouthWestTile()
+			));
 			spawnedNpcsThisTick.add(npc);
 			return;
 		}
 
 		for (String highlight : highlights)
 		{
-			if (WildcardMatcher.matches(highlight, npcName))
+			NpcHighlight npcHighlight = buildNpcHighlight(npc, highlight);
+			if (npcHighlight != null)
 			{
-				highlightedNpcs.add(npc);
+				highlightedNpcs.put(npc, npcHighlight);
 				if (!client.isInInstancedRegion())
 				{
 					memorizeNpc(npc);
@@ -409,7 +505,6 @@ public class NpcIndicatorsPlugin extends Plugin
 		{
 			despawnedNpcsThisTick.add(npc);
 		}
-
 		highlightedNpcs.remove(npc);
 	}
 
@@ -541,19 +636,25 @@ public class NpcIndicatorsPlugin extends Plugin
 
 			if (npcTags.contains(npc.getIndex()))
 			{
-				highlightedNpcs.add(npc);
+				highlightedNpcs.put(npc, new NpcHighlight(
+					config.getHighlightColor(),
+					config.highlightTile(),
+					config.highlightHull(),
+					config.highlightSouthWestTile()
+				));
 				continue;
 			}
 
 			for (String highlight : highlights)
 			{
-				if (WildcardMatcher.matches(highlight, npcName))
+				NpcHighlight npcHighlight = buildNpcHighlight(npc, highlight);
+				if (npcHighlight != null)
 				{
 					if (!client.isInInstancedRegion())
 					{
 						memorizeNpc(npc);
 					}
-					highlightedNpcs.add(npc);
+					highlightedNpcs.put(npc, npcHighlight);
 					continue outer;
 				}
 			}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcMinimapOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcMinimapOverlay.java
@@ -28,6 +28,7 @@ package net.runelite.client.plugins.npchighlight;
 import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Graphics2D;
+import java.util.Map;
 import javax.inject.Inject;
 import net.runelite.api.Client;
 import net.runelite.api.NPC;
@@ -57,16 +58,19 @@ public class NpcMinimapOverlay extends Overlay
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
-		for (NPC npc : plugin.getHighlightedNpcs())
+		for (Map.Entry<NPC, NpcHighlight> entrySet : plugin.getHighlightedNpcs().entrySet())
 		{
-			renderNpcOverlay(graphics, npc, npc.getName(), config.getHighlightColor());
+			renderNpcOverlay(graphics, entrySet.getKey(), entrySet.getValue());
 		}
 
 		return null;
 	}
 
-	private void renderNpcOverlay(Graphics2D graphics, NPC actor, String name, Color color)
+	private void renderNpcOverlay(Graphics2D graphics, NPC actor, NpcHighlight npcHighlight)
 	{
+		Color color = npcHighlight.getColor();
+		String name = actor.getName();
+
 		NPCComposition npcComposition = actor.getTransformedComposition();
 		if (npcComposition == null || !npcComposition.isInteractible()
 			|| (actor.isDead() && config.ignoreDeadNpcs()))

--- a/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcSceneOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcSceneOverlay.java
@@ -35,6 +35,7 @@ import java.text.DecimalFormat;
 import java.text.NumberFormat;
 import java.time.Instant;
 import java.util.Locale;
+import java.util.Map;
 import javax.inject.Inject;
 import net.runelite.api.Client;
 import net.runelite.api.Constants;
@@ -85,9 +86,9 @@ public class NpcSceneOverlay extends Overlay
 			plugin.getDeadNpcsToDisplay().forEach((id, npc) -> renderNpcRespawn(npc, graphics));
 		}
 
-		for (NPC npc : plugin.getHighlightedNpcs())
+		for (Map.Entry<NPC, NpcHighlight> entrySet : plugin.getHighlightedNpcs().entrySet())
 		{
-			renderNpcOverlay(graphics, npc, config.getHighlightColor());
+			renderNpcOverlay(graphics, entrySet.getKey(), entrySet.getValue());
 		}
 
 		return null;
@@ -143,8 +144,10 @@ public class NpcSceneOverlay extends Overlay
 		}
 	}
 
-	private void renderNpcOverlay(Graphics2D graphics, NPC actor, Color color)
+	private void renderNpcOverlay(Graphics2D graphics, NPC actor, NpcHighlight npcHighlight)
 	{
+		Color color = npcHighlight.getColor();
+
 		NPCComposition npcComposition = actor.getTransformedComposition();
 		if (npcComposition == null || !npcComposition.isInteractible()
 			|| (actor.isDead() && config.ignoreDeadNpcs()))
@@ -152,13 +155,13 @@ public class NpcSceneOverlay extends Overlay
 			return;
 		}
 
-		if (config.highlightHull())
+		if (npcHighlight.getRenderHull())
 		{
 			Shape objectClickbox = actor.getConvexHull();
 			renderPoly(graphics, color, objectClickbox);
 		}
 
-		if (config.highlightTile())
+		if (npcHighlight.getRenderTile())
 		{
 			int size = npcComposition.getSize();
 			LocalPoint lp = actor.getLocalLocation();
@@ -167,7 +170,7 @@ public class NpcSceneOverlay extends Overlay
 			renderPoly(graphics, color, tilePoly);
 		}
 
-		if (config.highlightSouthWestTile())
+		if (npcHighlight.getRenderSouthWestTile())
 		{
 			int size = npcComposition.getSize();
 			LocalPoint lp = actor.getLocalLocation();


### PR DESCRIPTION
Allows you to provide NPC-specific color and highlight styles by appending variables to the NPCs name in the "NPCs to Highlight" config option. Example input: "Banker:r255:g255:hull:tile" would highlight all NPCs named "Banker" yellow using the "Hull" and "Tile" highlighting styles.

Video demonstration [here](https://streamable.com/0zbjlw).