### PR TITLE
discord: add missing castle wars regionID

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordGameEventType.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordGameEventType.java
@@ -239,7 +239,7 @@ enum DiscordGameEventType
 	MG_BLAST_FURNACE("Blast Furnace", DiscordAreaType.MINIGAMES, 7757),
 	MG_BRIMHAVEN_AGILITY_ARENA("Brimhaven Agility Arena", DiscordAreaType.MINIGAMES, 11157),
 	MG_BURTHORPE_GAMES_ROOM("Burthorpe Games Room", DiscordAreaType.MINIGAMES, 8781),
-	MG_CASTLE_WARS("Castle Wars", DiscordAreaType.MINIGAMES, 9520),
+	MG_CASTLE_WARS("Castle Wars", DiscordAreaType.MINIGAMES, 9520, 9620),
 	MG_CLAN_WARS("Clan Wars", DiscordAreaType.MINIGAMES, 13135, 13134, 13133, 13131, 13130, 13387, 13386),
 	MG_DUEL_ARENA("Duel Arena", DiscordAreaType.MINIGAMES, 13362),
 	MG_FISHING_TRAWLER("Fishing Trawler", DiscordAreaType.MINIGAMES, 7499),


### PR DESCRIPTION
The underground portion of castle wars has a different regionID to the rest of the minigame. This commit adds `9620` to be more accurate when sharing via discord.
<img width="530" alt="Screen Shot 2020-07-06 at 4 04 19 PM" src="https://user-images.githubusercontent.com/54762282/86698591-6fa54080-bfdd-11ea-94ac-2d43cae0e860.png">
<img width="575" alt="Screen Shot 2020-07-06 at 4 03 33 PM" src="https://user-images.githubusercontent.com/54762282/86698804-a11e0c00-bfdd-11ea-9a53-6b4f33adf8b1.png">
