### PR TITLE
cannon: Add Bloodveld cannon spot in Meiyerditch Laboratory

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonSpots.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonSpots.java
@@ -33,7 +33,7 @@ import net.runelite.api.coords.WorldPoint;
 enum CannonSpots
 {
 
-	BLOODVELDS(new WorldPoint(2439, 9821, 0), new WorldPoint(2448, 9821, 0), new WorldPoint(2472, 9832, 0), new WorldPoint(2453, 9817, 0)),
+	BLOODVELDS(new WorldPoint(2439, 9821, 0), new WorldPoint(2448, 9821, 0), new WorldPoint(2472, 9832, 0), new WorldPoint(2453, 9817, 0), new WorldPoint(3597, 9743, 0)),
 	FIRE_GIANTS(new WorldPoint(2393, 9782, 0), new WorldPoint(2412, 9776, 0), new WorldPoint(2401, 9780, 0), new WorldPoint(3047, 10340, 0)),
 	ABERRANT_SPECTRES(new WorldPoint(2456, 9791, 0)),
 	HELLHOUNDS(new WorldPoint(2431, 9776, 0), new WorldPoint(2413, 9786, 0), new WorldPoint(2783, 9686, 0), new WorldPoint(3198, 10071, 0)),


### PR DESCRIPTION
Since the Sins of the Father quest release there is a new efficient spot to do Bloodveld tasks (assuming not alt barraging) since it's in multicombat and you can use a cannon. This adds the cannon spot as seen in the video from the Skilling Discord: https://www.youtube.com/watch?v=JfN29yq5U7Y

<img width="750" alt="Screen Shot 2020-07-07 at 1 04 51 PM" src="https://user-images.githubusercontent.com/54762282/86824997-dfa6db80-c05c-11ea-9707-46f3ca5b33dc.png">
