### PR TITLE
Improve readability of texts inside infoboxes with outline and/or background

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/config/RuneLiteConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/RuneLiteConfig.java
@@ -329,10 +329,34 @@ public interface RuneLiteConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "infoBoxTextWithOutline",
+		name = "Outline on infobox texts",
+		description = "Toggles the infobox texts to be displayed with an outline for better readability",
+		position = 41,
+		section = overlaySettings
+	)
+	default boolean infoBoxTextWithOutline()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		keyName = "infoBoxTextWithBackground",
+		name = "Background on infobox texts",
+		description = "Toggles the infobox texts to be displayed with a transparent background for better readability",
+		position = 42,
+		section = overlaySettings
+	)
+	default boolean infoBoxTextWithBackground()
+	{
+		return false;
+	}
+
+	@ConfigItem(
 		keyName = "infoBoxSize",
 		name = "Infobox size",
 		description = "Configures the size of each infobox in pixels",
-		position = 42,
+		position = 43,
 		section = overlaySettings
 	)
 	@Units(Units.PIXELS)
@@ -345,7 +369,7 @@ public interface RuneLiteConfig extends Config
 		keyName = "overlayBackgroundColor",
 		name = "Overlay Color",
 		description = "Configures the background color of infoboxes and overlays",
-		position = 43,
+		position = 44,
 		section = overlaySettings
 	)
 	@Alpha
@@ -358,7 +382,7 @@ public interface RuneLiteConfig extends Config
 		keyName = "blockExtraMouseButtons",
 		name = "Block Extra Mouse Buttons",
 		description = "Blocks extra mouse buttons (4 and above)",
-		position = 44
+		position = 45
 	)
 	default boolean blockExtraMouseButtons()
 	{
@@ -369,7 +393,7 @@ public interface RuneLiteConfig extends Config
 		keyName = "sidebarToggleKey",
 		name = "Sidebar Toggle Key",
 		description = "The key that will toggle the sidebar (accepts modifiers)",
-		position = 45,
+		position = 46,
 		section = windowSettings
 	)
 	default Keybind sidebarToggleKey()
@@ -381,7 +405,7 @@ public interface RuneLiteConfig extends Config
 		keyName = "panelToggleKey",
 		name = "Plugin Panel Toggle Key",
 		description = "The key that will toggle the current or last opened plugin panel (accepts modifiers)",
-		position = 46,
+		position = 47,
 		section = windowSettings
 	)
 	default Keybind panelToggleKey()

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/components/BackgroundComponent.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/components/BackgroundComponent.java
@@ -47,24 +47,11 @@ public class BackgroundComponent implements RenderableEntity
 	private Color backgroundColor = ComponentConstants.STANDARD_BACKGROUND_COLOR;
 	private Rectangle rectangle = new Rectangle();
 	private boolean fill = true;
+	private boolean border = true;
 
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
-		Color outsideStrokeColor = new Color(
-			(int) (backgroundColor.getRed() * OUTER_COLOR_OFFSET),
-			(int) (backgroundColor.getGreen() * OUTER_COLOR_OFFSET),
-			(int) (backgroundColor.getBlue() * OUTER_COLOR_OFFSET),
-			Math.min(255, (int) (backgroundColor.getAlpha() * ALPHA_COLOR_OFFSET))
-		);
-
-		Color insideStrokeColor = new Color(
-			Math.min(255, (int) (backgroundColor.getRed() * INNER_COLOR_OFFSET)),
-			Math.min(255, (int) (backgroundColor.getGreen() * INNER_COLOR_OFFSET)),
-			Math.min(255, (int) (backgroundColor.getBlue() * INNER_COLOR_OFFSET)),
-			Math.min(255, (int) (backgroundColor.getAlpha() * ALPHA_COLOR_OFFSET))
-		);
-
 		// Render background
 		if (fill)
 		{
@@ -72,20 +59,37 @@ public class BackgroundComponent implements RenderableEntity
 			graphics.fill(rectangle);
 		}
 
-		// Render outside stroke
-		final Rectangle outsideStroke = new Rectangle();
-		outsideStroke.setLocation(rectangle.x, rectangle.y);
-		outsideStroke.setSize(rectangle.width - BORDER_OFFSET / 2, rectangle.height - BORDER_OFFSET / 2);
-		graphics.setColor(outsideStrokeColor);
-		graphics.draw(outsideStroke);
+		if (border)
+		{
+			Color outsideStrokeColor = new Color(
+				(int) (backgroundColor.getRed() * OUTER_COLOR_OFFSET),
+				(int) (backgroundColor.getGreen() * OUTER_COLOR_OFFSET),
+				(int) (backgroundColor.getBlue() * OUTER_COLOR_OFFSET),
+				Math.min(255, (int) (backgroundColor.getAlpha() * ALPHA_COLOR_OFFSET))
+			);
 
-		// Render inside stroke
-		final Rectangle insideStroke = new Rectangle();
-		insideStroke.setLocation(rectangle.x + BORDER_OFFSET / 2, rectangle.y + BORDER_OFFSET / 2);
-		insideStroke.setSize(rectangle.width - BORDER_OFFSET - BORDER_OFFSET / 2,
+			Color insideStrokeColor = new Color(
+				Math.min(255, (int) (backgroundColor.getRed() * INNER_COLOR_OFFSET)),
+				Math.min(255, (int) (backgroundColor.getGreen() * INNER_COLOR_OFFSET)),
+				Math.min(255, (int) (backgroundColor.getBlue() * INNER_COLOR_OFFSET)),
+				Math.min(255, (int) (backgroundColor.getAlpha() * ALPHA_COLOR_OFFSET))
+			);
+
+			// Render outside stroke
+			final Rectangle outsideStroke = new Rectangle();
+			outsideStroke.setLocation(rectangle.x, rectangle.y);
+			outsideStroke.setSize(rectangle.width - BORDER_OFFSET / 2, rectangle.height - BORDER_OFFSET / 2);
+			graphics.setColor(outsideStrokeColor);
+			graphics.draw(outsideStroke);
+
+			// Render inside stroke
+			final Rectangle insideStroke = new Rectangle();
+			insideStroke.setLocation(rectangle.x + BORDER_OFFSET / 2, rectangle.y + BORDER_OFFSET / 2);
+			insideStroke.setSize(rectangle.width - BORDER_OFFSET - BORDER_OFFSET / 2,
 				rectangle.height - BORDER_OFFSET - BORDER_OFFSET / 2);
-		graphics.setColor(insideStrokeColor);
-		graphics.draw(insideStroke);
+			graphics.setColor(insideStrokeColor);
+			graphics.draw(insideStroke);
+		}
 
 		return new Dimension(rectangle.getSize());
 	}

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/components/InfoBoxComponent.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/components/InfoBoxComponent.java
@@ -54,6 +54,7 @@ public class InfoBoxComponent implements LayoutableRenderableEntity
 	private String text;
 	private Color color = Color.WHITE;
 	private boolean outline = false;
+	private boolean textBackground = false;
 	private Color backgroundColor = ComponentConstants.STANDARD_BACKGROUND_COLOR;
 	private BufferedImage image;
 	@Getter
@@ -93,6 +94,19 @@ public class InfoBoxComponent implements LayoutableRenderableEntity
 		// Render caption
 		if (!Strings.isNullOrEmpty(text))
 		{
+			if (textBackground)
+			{
+				final int textHeight = graphics.getFontMetrics().getHeight();
+				final BackgroundComponent textBackgroundComponent = new BackgroundComponent();
+				textBackgroundComponent.setBackgroundColor(new Color(0, 0, 0, 90));
+				textBackgroundComponent.setBorder(false);
+				// The numbers here are a reference to the border on the background, which is a const of 2.
+				// We put the background on the inner border to make it a little bit more prettier, hence starting 1 px
+				// from the edge.
+				textBackgroundComponent.setRectangle(new Rectangle(1, size - textHeight - 2, size - 2, textHeight + 1));
+				textBackgroundComponent.render(graphics);
+			}
+
 			final TextComponent textComponent = new TextComponent();
 			textComponent.setColor(color);
 			textComponent.setText(text);

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/components/InfoBoxComponent.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/components/InfoBoxComponent.java
@@ -53,6 +53,7 @@ public class InfoBoxComponent implements LayoutableRenderableEntity
 	private Dimension preferredSize = new Dimension(DEFAULT_SIZE, DEFAULT_SIZE);
 	private String text;
 	private Color color = Color.WHITE;
+	private boolean outline = false;
 	private Color backgroundColor = ComponentConstants.STANDARD_BACKGROUND_COLOR;
 	private BufferedImage image;
 	@Getter
@@ -95,6 +96,7 @@ public class InfoBoxComponent implements LayoutableRenderableEntity
 			final TextComponent textComponent = new TextComponent();
 			textComponent.setColor(color);
 			textComponent.setText(text);
+			textComponent.setOutline(outline);
 			textComponent.setPosition(new Point(baseX + ((size - metrics.stringWidth(text)) / 2), baseY + size - SEPARATOR));
 			textComponent.render(graphics);
 		}

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/infobox/InfoBoxOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/infobox/InfoBoxOverlay.java
@@ -131,6 +131,7 @@ public class InfoBoxOverlay extends OverlayPanel
 			infoBoxComponent.setPreferredSize(new Dimension(config.infoBoxSize(), config.infoBoxSize()));
 			infoBoxComponent.setBackgroundColor(config.overlayBackgroundColor());
 			infoBoxComponent.setInfoBox(box);
+			infoBoxComponent.setOutline(config.infoBoxTextWithOutline());
 			panelComponent.getChildren().add(infoBoxComponent);
 		}
 

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/infobox/InfoBoxOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/infobox/InfoBoxOverlay.java
@@ -132,6 +132,7 @@ public class InfoBoxOverlay extends OverlayPanel
 			infoBoxComponent.setBackgroundColor(config.overlayBackgroundColor());
 			infoBoxComponent.setInfoBox(box);
 			infoBoxComponent.setOutline(config.infoBoxTextWithOutline());
+			infoBoxComponent.setTextBackground(config.infoBoxTextWithBackground());
 			panelComponent.getChildren().add(infoBoxComponent);
 		}
 


### PR DESCRIPTION
A littlebit outdated, see https://github.com/runelite/runelite/pull/12083#issuecomment-655442844 for newer information

---

When I've been playing in NMZ, I have to struggle a little bit to read how many absorption points I have left.
I saw that you recently added an update with some outlined text and took that chance to add that same functionality to the info boxes, but also explicitly on the NMZ plugin.

Some pictures:  
**Before:**  
![Screenshot from 2020-07-08 03-33-31](https://user-images.githubusercontent.com/8125386/86894350-38c94a80-c103-11ea-9fb2-8fa32ad397be.png)

**After:**  
![Screenshot from 2020-07-08 03-46-35](https://user-images.githubusercontent.com/8125386/86894359-3ff05880-c103-11ea-8dcd-2e5108ecfc6c.png)

Did not think about taking pictures when there was 100+ points left, but I think it's even harder to read then (without the outline).

Hope this little change is taken into consideration. 

*Maybe the info boxes can get a setting in Runelite in general in the future, opt-in for outline in all info boxes. Who knows*