### PR TITLE
KeyListener: Add isEnabledOnLoginScreen() method

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/input/KeyListener.java
+++ b/runelite-client/src/main/java/net/runelite/client/input/KeyListener.java
@@ -26,4 +26,8 @@ package net.runelite.client.input;
 
 public interface KeyListener extends java.awt.event.KeyListener
 {
+	default boolean isEnabledOnLoginScreen()
+	{
+		return false;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/input/KeyManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/input/KeyManager.java
@@ -32,7 +32,6 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 import net.runelite.api.Client;
 import net.runelite.api.GameState;
-import net.runelite.client.util.HotkeyListener;
 
 @Singleton
 public class KeyManager
@@ -133,18 +132,13 @@ public class KeyManager
 			return true;
 		}
 
-		if (!(keyListener instanceof HotkeyListener))
+		final GameState gameState = client.getGameState();
+
+		if (gameState == GameState.LOGIN_SCREEN || gameState == GameState.LOGIN_SCREEN_AUTHENTICATOR)
 		{
-			return true;
+			return keyListener.isEnabledOnLoginScreen();
 		}
 
-		final HotkeyListener hotkeyListener = (HotkeyListener) keyListener;
-
-		if (hotkeyListener.isEnabledOnLogin())
-		{
-			return true;
-		}
-
-		return client.getGameState() != GameState.LOGIN_SCREEN && client.getGameState() != GameState.LOGIN_SCREEN_AUTHENTICATOR;
+		return true;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loginscreen/LoginScreenPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loginscreen/LoginScreenPlugin.java
@@ -184,6 +184,12 @@ public class LoginScreenPlugin extends Plugin implements KeyListener
 	}
 
 	@Override
+	public boolean isEnabledOnLoginScreen()
+	{
+		return true;
+	}
+
+	@Override
 	public void keyTyped(KeyEvent e)
 	{
 	}

--- a/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
@@ -382,7 +382,7 @@ public class ClientUI
 					toggleSidebar();
 				}
 			};
-			sidebarListener.setEnabledOnLogin(true);
+			sidebarListener.setEnabledOnLoginScreen(true);
 			keyManager.registerKeyListener(sidebarListener);
 
 			final HotkeyListener pluginPanelListener = new HotkeyListener(config::panelToggleKey)
@@ -393,7 +393,7 @@ public class ClientUI
 					togglePluginPanel();
 				}
 			};
-			pluginPanelListener.setEnabledOnLogin(true);
+			pluginPanelListener.setEnabledOnLoginScreen(true);
 			keyManager.registerKeyListener(pluginPanelListener);
 
 			// Add mouse listener

--- a/runelite-client/src/main/java/net/runelite/client/util/HotkeyListener.java
+++ b/runelite-client/src/main/java/net/runelite/client/util/HotkeyListener.java
@@ -26,7 +26,6 @@ package net.runelite.client.util;
 
 import java.awt.event.KeyEvent;
 import java.util.function.Supplier;
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import net.runelite.client.config.Keybind;
@@ -42,8 +41,13 @@ public abstract class HotkeyListener implements KeyListener
 	private boolean isConsumingTyped = false;
 
 	@Setter
-	@Getter
-	private boolean isEnabledOnLogin = false;
+	private boolean enabledOnLoginScreen;
+
+	@Override
+	public boolean isEnabledOnLoginScreen()
+	{
+		return enabledOnLoginScreen;
+	}
 
 	@Override
 	public void keyTyped(KeyEvent e)


### PR DESCRIPTION
This commit moves login screen handling out of the KeyManager into the
KeyListener interface so it does not need any knowledge of
HotkeyListener's implementation.