### PR TITLE
Reduce repetitiveness in HTTP clients + Add tests

### DIFF
--- a/http-api/src/main/java/net/runelite/http/api/RuneLiteApiClient.java
+++ b/http-api/src/main/java/net/runelite/http/api/RuneLiteApiClient.java
@@ -229,7 +229,7 @@ public class RuneLiteApiClient
 	{
 		Request request = requestBuilder
 			.url(urlInterceptor.apply(baseUrl.newBuilder()
-				.addPathSegment(endpoint)
+				.addPathSegments(endpoint)
 				.build()))
 			.build();
 
@@ -356,6 +356,8 @@ public class RuneLiteApiClient
 				.newBuilder()
 				.header("User-Agent", createUserAgent())
 				.build();
+
+			log.debug(String.format("Built URL: %s", request.url().toString()));
 
 			Response response = chain.proceed(request);
 

--- a/http-api/src/main/java/net/runelite/http/api/RuneLiteApiClient.java
+++ b/http-api/src/main/java/net/runelite/http/api/RuneLiteApiClient.java
@@ -1,0 +1,373 @@
+/*
+ * Copyright (c) 2020, Ugnius <https://github.com/UgiR>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.http.api;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonParseException;
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import okhttp3.Call;
+import okhttp3.Callback;
+import okhttp3.HttpUrl;
+import okhttp3.Interceptor;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+
+@Slf4j
+public class RuneLiteApiClient
+{
+	private final OkHttpClient client;
+	private final HttpUrl baseUrl;
+	private final String endpoint;
+
+	protected static final HttpUrl API_BASE_URL;
+	protected static final HttpUrl STATIC_BASE_URL;
+	private static final Gson GSON;
+
+	protected static final MediaType MEDIA_TYPE_JSON = MediaType.parse("application/json");
+	protected static final String AUTH_HEADER = "RUNELITE-AUTH";
+	protected static final String MACHINEID_HEADER = "RUNELITE-MACHINEID";
+
+	static
+	{
+		API_BASE_URL = createApiBaseUrl();
+		STATIC_BASE_URL = createStaticBaseUrl();
+		GSON = new Gson();
+	}
+
+	/**
+	 * @param clientBuilder A builder for an {@link OkHttpClient}.
+	 * @param endpoint      API endpoint to query.
+	 */
+	public RuneLiteApiClient(OkHttpClient.Builder clientBuilder, String endpoint)
+	{
+		this(clientBuilder, API_BASE_URL, endpoint);
+	}
+
+	/**
+	 * @param clientBuilder A builder for an {@link OkHttpClient}.
+	 * @param baseUrl       Base URL of API.
+	 * @param endpoint      API endpoint to query.
+	 */
+	public RuneLiteApiClient(OkHttpClient.Builder clientBuilder, HttpUrl baseUrl, String endpoint)
+	{
+		Objects.requireNonNull(baseUrl, "Base URL must not be null.");
+		Objects.requireNonNull(endpoint, "Provided endpoint must not be null.");
+		this.client = clientBuilder
+			.pingInterval(30, TimeUnit.SECONDS)
+			.addInterceptor(new RuneLiteInterceptor())
+			.build();
+		this.baseUrl = baseUrl;
+		this.endpoint = endpoint;
+	}
+
+	/**
+	 * Synchronously send a GET request.
+	 * {@code urlInterceptor} defaults to no-op.
+	 *
+	 * @see RuneLiteApiClient#get_(Function)
+	 */
+	protected Response get_() throws IOException
+	{
+		return get_(Function.identity());
+	}
+
+	/**
+	 * Synchronously send a GET request with changes to the URL.
+	 *
+	 * @param urlInterceptor A {@link Function} to mutate the built URL.
+	 * @return The {@link Response} to the request.
+	 * @throws IOException if the request is not successful.
+	 */
+	protected Response get_(Function<HttpUrl, HttpUrl> urlInterceptor) throws IOException
+	{
+		return request(new Request.Builder().get(), urlInterceptor);
+	}
+
+	/**
+	 * Asynchronously send a GET request.
+	 * {@code urlInterceptor} defaults to no-op.
+	 *
+	 * @see RuneLiteApiClient#getAsync_(Function)
+	 */
+	protected CompletableFuture<Response> getAsync_()
+	{
+		return getAsync_(Function.identity());
+	}
+
+	/**
+	 * Asynchronously send a GET request with changes to the URL.
+	 *
+	 * @param urlInterceptor A {@link Function} to mutate the built URL.
+	 * @return A {@link CompletableFuture} containing the {@link Response}. If the request fails,
+	 * the future completes exceptionally.
+	 */
+	protected CompletableFuture<Response> getAsync_(Function<HttpUrl, HttpUrl> urlInterceptor)
+	{
+		return requestAsync(new Request.Builder().get(), urlInterceptor);
+	}
+
+	/**
+	 * Synchronously send a POST request with changes to the URL.
+	 *
+	 * @param body           The {@link RequestBody} to include with the request.
+	 * @param urlInterceptor A {@link Function} to mutate the built URL.
+	 * @return The {@link Response} to the request.
+	 * @throws IOException if the request is not successful.
+	 */
+	protected Response post_(RequestBody body, Function<HttpUrl, HttpUrl> urlInterceptor) throws IOException
+	{
+		return request(new Request.Builder().post(body), urlInterceptor);
+	}
+
+	/**
+	 * Asynchronously send a POST request.
+	 * {@code urlInterceptor} defaults to no-op.
+	 *
+	 * @see RuneLiteApiClient#postAsync_(RequestBody, Function)
+	 */
+	protected CompletableFuture<Response> postAsync_(RequestBody body)
+	{
+		return postAsync_(body, Function.identity());
+	}
+
+	/**
+	 * Asynchronously send a POST request with changes to the URL.
+	 *
+	 * @param body           The {@link RequestBody} to include with the request.
+	 * @param urlInterceptor A {@link Function} to mutate the built URL.
+	 * @return A {@link CompletableFuture} containing the {@link Response}. If the request fails,
+	 * the future completes exceptionally.
+	 */
+	protected CompletableFuture<Response> postAsync_(RequestBody body, Function<HttpUrl, HttpUrl> urlInterceptor)
+	{
+		return requestAsync(new Request.Builder().post(body), urlInterceptor);
+	}
+
+	/**
+	 * Synchronously send a PUT request with changes to the URL.
+	 *
+	 * @param body           The {@link RequestBody} to include with the request.
+	 * @param urlInterceptor A {@link Function} to mutate the built URL.
+	 * @return The {@link Response} to the request.
+	 * @throws IOException if the request is not successful.
+	 */
+	protected Response put_(RequestBody body, Function<HttpUrl, HttpUrl> urlInterceptor) throws IOException
+	{
+		return request(new Request.Builder().put(body), urlInterceptor);
+	}
+
+	/**
+	 * Asynchronously send a PUT request with changes to the URL.
+	 *
+	 * @param body           The {@link RequestBody} to include with the request.
+	 * @param urlInterceptor A {@link Function} to mutate the built URL.
+	 * @return A {@link CompletableFuture} containing the {@link Response}. If the request fails,
+	 * the future completes exceptionally.
+	 */
+	protected CompletableFuture<Response> putAsync_(RequestBody body, Function<HttpUrl, HttpUrl> urlInterceptor)
+	{
+		return requestAsync(new Request.Builder().put(body), urlInterceptor);
+	}
+
+	/**
+	 * Synchronously send a DELETE request with changes to the URL.
+	 *
+	 * @param urlInterceptor A {@link Function} to mutate the built URL.
+	 * @return The {@link Response} to the request.
+	 * @throws IOException if the request is not successful.
+	 */
+	protected Response delete_(Function<HttpUrl, HttpUrl> urlInterceptor) throws IOException
+	{
+		return request(new Request.Builder().delete(), urlInterceptor);
+	}
+
+	/**
+	 * Asynchronously send a DELETE request with changes to the URL.
+	 *
+	 * @param urlInterceptor A {@link Function} to mutate the built URL.
+	 * @return A {@link CompletableFuture} containing the {@link Response}. If the request fails,
+	 * the future completes exceptionally.
+	 */
+	protected CompletableFuture<Response> deleteAsync_(Function<HttpUrl, HttpUrl> urlInterceptor)
+	{
+		return requestAsync(new Request.Builder().delete(), urlInterceptor);
+	}
+
+	private CompletableFuture<Response> requestAsync(Request.Builder requestBuilder, Function<HttpUrl, HttpUrl> urlInterceptor)
+	{
+		Request request = requestBuilder
+			.url(urlInterceptor.apply(baseUrl.newBuilder()
+				.addPathSegment(endpoint)
+				.build()))
+			.build();
+
+		OkHttpFutureResponse response = new OkHttpFutureResponse();
+		Call call = client.newCall(request);
+		call.enqueue(response);
+
+		return response.getFuture();
+	}
+
+	private Response request(Request.Builder requestBuilder, Function<HttpUrl, HttpUrl> urlInterceptor) throws IOException
+	{
+		Request request = requestBuilder
+			.url(urlInterceptor.apply(baseUrl.newBuilder()
+				.addPathSegments(endpoint)
+				.build()))
+			.build();
+
+		return client.newCall(request).execute();
+	}
+
+	/**
+	 * Deserializes the JSON body of a {@link Response} into the provided {@link Type}.
+	 * This method will always close the response body to avoid resource leaks.
+	 *
+	 * @param response The {@link Response} containing the body.
+	 * @param type     The {@link Type} to deserialize to.
+	 * @return The deserialized object.
+	 * @throws IOException if the body cannot be deserialized.
+	 */
+	protected static <T> T bodyToObject(Response response, Type type) throws IOException
+	{
+		try
+		{
+			return GSON.fromJson(response.body().charStream(), type);
+		}
+		catch (JsonParseException e)
+		{
+			throw new IOException(e);
+		}
+		finally
+		{
+			response.body().close();
+		}
+	}
+
+	/**
+	 * Deserializes the JSON body of a {@link Response} into the provided {@link Type} and
+	 * wrap it in a {@link CompletableFuture}.
+	 * This method will always close the response body to avoid resource leaks.
+	 *
+	 * @param response The {@link Response} containing the body.
+	 * @param type     The {@link Type} to deserialize to.
+	 * @return A {@link CompletableFuture} containing the deserialized object. If the response body cannot
+	 * by deserialized, the future will complete exceptionally.
+	 */
+	protected static <T> CompletableFuture<T> bodyToObjectFuture(Response response, Type type)
+	{
+		try
+		{
+			T t = bodyToObject(response, type);
+			return CompletableFuture.completedFuture(t);
+		}
+		catch (IOException e)
+		{
+			CompletableFuture<T> failed = new CompletableFuture<>();
+			failed.completeExceptionally(e);
+			return failed;
+		}
+	}
+
+	protected static <T> String objectToJson(T t)
+	{
+		return GSON.toJson(t);
+	}
+
+	private static String createUserAgent()
+	{
+		return RuneLiteAPI.userAgent;
+	}
+
+	private static HttpUrl createApiBaseUrl()
+	{
+		return RuneLiteAPI.getApiBase();
+	}
+
+	private static HttpUrl createStaticBaseUrl()
+	{
+		return RuneLiteAPI.getStaticBase();
+	}
+
+	private static class OkHttpFutureResponse implements Callback
+	{
+
+		@Getter
+		private final CompletableFuture<Response> future;
+
+		public OkHttpFutureResponse()
+		{
+			this.future = new CompletableFuture<>();
+		}
+
+		@Override
+		public void onFailure(Call call, IOException e)
+		{
+			log.warn("API client error", e);
+			future.completeExceptionally(e);
+		}
+
+		@Override
+		public void onResponse(Call call, Response response)
+		{
+			future.complete(response);
+		}
+	}
+
+	private static class RuneLiteInterceptor implements Interceptor
+	{
+
+		@Override
+		public Response intercept(Chain chain) throws IOException
+		{
+			Request request = chain.request()
+				.newBuilder()
+				.header("User-Agent", createUserAgent())
+				.build();
+
+			Response response = chain.proceed(request);
+
+			// TODO: retry on failure
+			if (!response.isSuccessful())
+			{
+				log.warn(String.format("(%s) API response error: %s", response.request().url(), response.message()));
+				response.close();
+				throw new IOException(String.format("%d: %s", response.code(), response.message()));
+			}
+
+			return response;
+		}
+	}
+}

--- a/http-api/src/main/java/net/runelite/http/api/RuneLiteApiClient.java
+++ b/http-api/src/main/java/net/runelite/http/api/RuneLiteApiClient.java
@@ -237,7 +237,15 @@ public class RuneLiteApiClient
 		Call call = client.newCall(request);
 		call.enqueue(response);
 
-		return response.getFuture();
+		return response.getFuture()
+			.whenComplete((r, e) ->
+			{
+				// Ensure response is closed in case exception
+				if (e != null)
+				{
+					r.body().close();
+				}
+			});
 	}
 
 	private Response request(Request.Builder requestBuilder, Function<HttpUrl, HttpUrl> urlInterceptor) throws IOException

--- a/http-api/src/main/java/net/runelite/http/api/chat/ChatClient.java
+++ b/http-api/src/main/java/net/runelite/http/api/chat/ChatClient.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018, Adam <Adam@sigterm.info>
+ * Copyright (c) 2020, Ugnius <https://github.com/UgiR>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -24,341 +25,197 @@
  */
 package net.runelite.http.api.chat;
 
-import com.google.gson.JsonParseException;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import lombok.AllArgsConstructor;
-import net.runelite.http.api.RuneLiteAPI;
-import okhttp3.HttpUrl;
+import net.runelite.http.api.RuneLiteApiClient;
 import okhttp3.OkHttpClient;
-import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
 
-@AllArgsConstructor
-public class ChatClient
+public class ChatClient extends RuneLiteApiClient
 {
-	private final OkHttpClient client;
+	private final static String ENDPOINT = "chat";
+	private final static RequestBody EMPTY_BODY = RequestBody.create(null, new byte[0]);
+
+	public ChatClient(OkHttpClient client)
+	{
+		super(client.newBuilder(), ENDPOINT);
+	}
 
 	public boolean submitKc(String username, String boss, int kc) throws IOException
 	{
-		HttpUrl url = RuneLiteAPI.getApiBase().newBuilder()
-			.addPathSegment("chat")
+		Response response = post_(EMPTY_BODY, url -> url.newBuilder()
 			.addPathSegment("kc")
 			.addQueryParameter("name", username)
 			.addQueryParameter("boss", boss)
 			.addQueryParameter("kc", Integer.toString(kc))
-			.build();
+			.build()
+		);
 
-		Request request = new Request.Builder()
-			.post(RequestBody.create(null, new byte[0]))
-			.url(url)
-			.build();
-
-		try (Response response = client.newCall(request).execute())
-		{
-			return response.isSuccessful();
-		}
+		response.close();
+		return response.isSuccessful();
 	}
 
 	public int getKc(String username, String boss) throws IOException
 	{
-		HttpUrl url = RuneLiteAPI.getApiBase().newBuilder()
-			.addPathSegment("chat")
+		Response response = get_(url -> url.newBuilder()
 			.addPathSegment("kc")
 			.addQueryParameter("name", username)
 			.addQueryParameter("boss", boss)
-			.build();
+			.build()
+		);
 
-		Request request = new Request.Builder()
-			.url(url)
-			.build();
-
-		try (Response response = client.newCall(request).execute())
-		{
-			if (!response.isSuccessful())
-			{
-				throw new IOException("Unable to look up killcount!");
-			}
-			return Integer.parseInt(response.body().string());
-		}
+		return Integer.parseInt(response.body().string());
 	}
 
 	public boolean submitQp(String username, int qp) throws IOException
 	{
-		HttpUrl url = RuneLiteAPI.getApiBase().newBuilder()
-			.addPathSegment("chat")
+		Response response = post_(EMPTY_BODY, url -> url.newBuilder()
 			.addPathSegment("qp")
 			.addQueryParameter("name", username)
 			.addQueryParameter("qp", Integer.toString(qp))
-			.build();
+			.build()
+		);
 
-		Request request = new Request.Builder()
-			.post(RequestBody.create(null, new byte[0]))
-			.url(url)
-			.build();
-
-		try (Response response = client.newCall(request).execute())
-		{
-			return response.isSuccessful();
-		}
+		response.close();
+		return response.isSuccessful();
 	}
 
 	public int getQp(String username) throws IOException
 	{
-		HttpUrl url = RuneLiteAPI.getApiBase().newBuilder()
-			.addPathSegment("chat")
+		Response response = get_(url -> url.newBuilder()
 			.addPathSegment("qp")
 			.addQueryParameter("name", username)
-			.build();
+			.build()
+		);
 
-		Request request = new Request.Builder()
-			.url(url)
-			.build();
-
-		try (Response response = client.newCall(request).execute())
-		{
-			if (!response.isSuccessful())
-			{
-				throw new IOException("Unable to look up quest points!");
-			}
-			return Integer.parseInt(response.body().string());
-		}
+		return Integer.parseInt(response.body().string());
 	}
 
 	public boolean submitTask(String username, String task, int amount, int initialAmount, String location) throws IOException
 	{
-		HttpUrl url = RuneLiteAPI.getApiBase().newBuilder()
-			.addPathSegment("chat")
+		Response response = post_(EMPTY_BODY, url -> url.newBuilder()
 			.addPathSegment("task")
 			.addQueryParameter("name", username)
 			.addQueryParameter("task", task)
 			.addQueryParameter("amount", Integer.toString(amount))
 			.addQueryParameter("initialAmount", Integer.toString(initialAmount))
 			.addQueryParameter("location", location)
-			.build();
+			.build()
+		);
 
-		Request request = new Request.Builder()
-			.post(RequestBody.create(null, new byte[0]))
-			.url(url)
-			.build();
-
-		try (Response response = client.newCall(request).execute())
-		{
-			return response.isSuccessful();
-		}
+		response.close();
+		return response.isSuccessful();
 	}
 
 	public Task getTask(String username) throws IOException
 	{
-		HttpUrl url = RuneLiteAPI.getApiBase().newBuilder()
-			.addPathSegment("chat")
+		Response response = get_(url -> url.newBuilder()
 			.addPathSegment("task")
 			.addQueryParameter("name", username)
-			.build();
+			.build()
+		);
 
-		Request request = new Request.Builder()
-			.url(url)
-			.build();
-
-		try (Response response = client.newCall(request).execute())
-		{
-			if (!response.isSuccessful())
-			{
-				throw new IOException("Unable to look up task!");
-			}
-
-			InputStream in = response.body().byteStream();
-			return RuneLiteAPI.GSON.fromJson(new InputStreamReader(in), Task.class);
-		}
-		catch (JsonParseException ex)
-		{
-			throw new IOException(ex);
-		}
+		return bodyToObject(response, Task.class);
 	}
 
 	public boolean submitPb(String username, String boss, int pb) throws IOException
 	{
-		HttpUrl url = RuneLiteAPI.getApiBase().newBuilder()
-			.addPathSegment("chat")
+		Response response = post_(EMPTY_BODY, url -> url.newBuilder()
 			.addPathSegment("pb")
 			.addQueryParameter("name", username)
 			.addQueryParameter("boss", boss)
 			.addQueryParameter("pb", Integer.toString(pb))
-			.build();
+			.build()
+		);
 
-		Request request = new Request.Builder()
-			.post(RequestBody.create(null, new byte[0]))
-			.url(url)
-			.build();
-
-		try (Response response = client.newCall(request).execute())
-		{
-			return response.isSuccessful();
-		}
+		response.close();
+		return response.isSuccessful();
 	}
 
 	public int getPb(String username, String boss) throws IOException
 	{
-		HttpUrl url = RuneLiteAPI.getApiBase().newBuilder()
-			.addPathSegment("chat")
+		Response response = get_(url -> url.newBuilder()
 			.addPathSegment("pb")
 			.addQueryParameter("name", username)
 			.addQueryParameter("boss", boss)
-			.build();
+			.build()
+		);
 
-		Request request = new Request.Builder()
-			.url(url)
-			.build();
-
-		try (Response response = client.newCall(request).execute())
-		{
-			if (!response.isSuccessful())
-			{
-				throw new IOException("Unable to look up personal best!");
-			}
-			return Integer.parseInt(response.body().string());
-		}
+		return Integer.parseInt(response.body().string());
 	}
 
 	public boolean submitGc(String username, int gc) throws IOException
 	{
-		HttpUrl url = RuneLiteAPI.getApiBase().newBuilder()
-			.addPathSegment("chat")
+		Response response = post_(EMPTY_BODY, url -> url.newBuilder()
 			.addPathSegment("gc")
 			.addQueryParameter("name", username)
 			.addQueryParameter("gc", Integer.toString(gc))
-			.build();
+			.build()
+		);
 
-		Request request = new Request.Builder()
-			.post(RequestBody.create(null, new byte[0]))
-			.url(url)
-			.build();
-
-		try (Response response = client.newCall(request).execute())
-		{
-			return response.isSuccessful();
-		}
+		response.close();
+		return response.isSuccessful();
 	}
 
 	public int getGc(String username) throws IOException
 	{
-		HttpUrl url = RuneLiteAPI.getApiBase().newBuilder()
-			.addPathSegment("chat")
+		Response response = get_(url -> url.newBuilder()
 			.addPathSegment("gc")
 			.addQueryParameter("name", username)
-			.build();
+			.build()
+		);
 
-		Request request = new Request.Builder()
-			.url(url)
-			.build();
-
-		try (Response response = client.newCall(request).execute())
-		{
-			if (!response.isSuccessful())
-			{
-				throw new IOException("Unable to look up gamble count!");
-			}
-			return Integer.parseInt(response.body().string());
-		}
+		return Integer.parseInt(response.body().string());
 	}
 
 	public boolean submitDuels(String username, int wins, int losses, int winningStreak, int losingStreak) throws IOException
 	{
-		HttpUrl url = RuneLiteAPI.getApiBase().newBuilder()
-			.addPathSegment("chat")
+		Response response = post_(EMPTY_BODY, url -> url.newBuilder()
 			.addPathSegment("duels")
 			.addQueryParameter("name", username)
 			.addQueryParameter("wins", Integer.toString(wins))
 			.addQueryParameter("losses", Integer.toString(losses))
 			.addQueryParameter("winningStreak", Integer.toString(winningStreak))
 			.addQueryParameter("losingStreak", Integer.toString(losingStreak))
-			.build();
+			.build()
+		);
 
-		Request request = new Request.Builder()
-			.post(RequestBody.create(null, new byte[0]))
-			.url(url)
-			.build();
-
-		try (Response response = client.newCall(request).execute())
-		{
-			return response.isSuccessful();
-		}
+		response.close();
+		return response.isSuccessful();
 	}
 
 	public Duels getDuels(String username) throws IOException
 	{
-		HttpUrl url = RuneLiteAPI.getApiBase().newBuilder()
-			.addPathSegment("chat")
+		Response response = get_(url -> url.newBuilder()
 			.addPathSegment("duels")
 			.addQueryParameter("name", username)
-			.build();
+			.build()
+		);
 
-		Request request = new Request.Builder()
-			.url(url)
-			.build();
-
-		try (Response response = client.newCall(request).execute())
-		{
-			if (!response.isSuccessful())
-			{
-				throw new IOException("Unable to look up duels!");
-			}
-
-			InputStream in = response.body().byteStream();
-			return RuneLiteAPI.GSON.fromJson(new InputStreamReader(in), Duels.class);
-		}
-		catch (JsonParseException ex)
-		{
-			throw new IOException(ex);
-		}
+		return bodyToObject(response, Duels.class);
 	}
 
 	public boolean submitLayout(String username, LayoutRoom[] rooms) throws IOException
 	{
-		HttpUrl url = RuneLiteAPI.getApiBase().newBuilder()
-			.addPathSegment("chat")
+		RequestBody body = RequestBody.create(MEDIA_TYPE_JSON, objectToJson(rooms));
+		Response response = post_(body, url -> url.newBuilder()
 			.addPathSegment("layout")
 			.addQueryParameter("name", username)
-			.build();
+			.build()
+		);
 
-		Request request = new Request.Builder()
-			.post(RequestBody.create(RuneLiteAPI.JSON, RuneLiteAPI.GSON.toJson(rooms)))
-			.url(url)
-			.build();
-
-		try (Response response = client.newCall(request).execute())
-		{
-			return response.isSuccessful();
-		}
+		response.close();
+		return response.isSuccessful();
 	}
 
 	public LayoutRoom[] getLayout(String username) throws IOException
 	{
-		HttpUrl url = RuneLiteAPI.getApiBase().newBuilder()
-			.addPathSegment("chat")
+		Response response = get_(url -> url.newBuilder()
 			.addPathSegment("layout")
 			.addQueryParameter("name", username)
-			.build();
+			.build()
+		);
 
-		Request request = new Request.Builder()
-			.url(url)
-			.build();
-
-		try (Response response = client.newCall(request).execute())
-		{
-			if (!response.isSuccessful())
-			{
-				throw new IOException("Unable to look up layout!");
-			}
-
-			InputStream in = response.body().byteStream();
-			return RuneLiteAPI.GSON.fromJson(new InputStreamReader(in), LayoutRoom[].class);
-		}
-		catch (JsonParseException ex)
-		{
-			throw new IOException(ex);
-		}
+		return bodyToObject(response, LayoutRoom[].class);
 	}
 }

--- a/http-api/src/main/java/net/runelite/http/api/feed/FeedClient.java
+++ b/http-api/src/main/java/net/runelite/http/api/feed/FeedClient.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018, Lotto <https://github.com/devLotto>
+ * Copyright (c) 2020, Ugnius <https://github.com/UgiR>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -24,50 +25,21 @@
  */
 package net.runelite.http.api.feed;
 
-import com.google.gson.JsonParseException;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import net.runelite.http.api.RuneLiteAPI;
-import okhttp3.HttpUrl;
+import net.runelite.http.api.RuneLiteApiClient;
 import okhttp3.OkHttpClient;
-import okhttp3.Request;
-import okhttp3.Response;
 
-@Slf4j
-@RequiredArgsConstructor
-public class FeedClient
+public class FeedClient extends RuneLiteApiClient
 {
-	private final OkHttpClient client;
+	private static final String ENDPOINT = "feed.js";
+
+	public FeedClient(OkHttpClient client)
+	{
+		super(client.newBuilder(), ENDPOINT);
+	}
 
 	public FeedResult lookupFeed() throws IOException
 	{
-		HttpUrl url = RuneLiteAPI.getApiBase().newBuilder()
-			.addPathSegment("feed.js")
-			.build();
-
-		log.debug("Built URI: {}", url);
-
-		Request request = new Request.Builder()
-			.url(url)
-			.build();
-
-		try (Response response = client.newCall(request).execute())
-		{
-			if (!response.isSuccessful())
-			{
-				log.debug("Error looking up feed: {}", response);
-				return null;
-			}
-
-			InputStream in = response.body().byteStream();
-			return RuneLiteAPI.GSON.fromJson(new InputStreamReader(in), FeedResult.class);
-		}
-		catch (JsonParseException ex)
-		{
-			throw new IOException(ex);
-		}
+		return bodyToObject(get_(), FeedResult.class);
 	}
 }

--- a/http-api/src/main/java/net/runelite/http/api/loottracker/LootTrackerClient.java
+++ b/http-api/src/main/java/net/runelite/http/api/loottracker/LootTrackerClient.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018, Adam <Adam@sigterm.info>
+ * Copyright (c) 2020, Ugnius <https://github.com/UgiR>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -24,132 +25,77 @@
  */
 package net.runelite.http.api.loottracker;
 
-import com.google.gson.Gson;
-import com.google.gson.JsonParseException;
 import com.google.gson.reflect.TypeToken;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
+import java.lang.reflect.Type;
 import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import net.runelite.http.api.RuneLiteAPI;
-import static net.runelite.http.api.RuneLiteAPI.JSON;
-import okhttp3.Call;
-import okhttp3.Callback;
-import okhttp3.HttpUrl;
+import net.runelite.http.api.RuneLiteApiClient;
+import okhttp3.Interceptor;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
 
 @Slf4j
-@AllArgsConstructor
-public class LootTrackerClient
+public class LootTrackerClient extends RuneLiteApiClient
 {
-	private static final Gson GSON = RuneLiteAPI.GSON;
+	private final static String ENDPOINT = "loottracker";
+	private static final Type typeToken;
 
-	private final OkHttpClient client;
-	private final UUID uuid;
+	static
+	{
+		typeToken = new TypeToken<List<LootAggregate>>()
+		{
+		}.getType();
+	}
+
+	public LootTrackerClient(OkHttpClient client, UUID uuid)
+	{
+		super(client.newBuilder().addInterceptor(new LootTrackerClientInterceptor(uuid)), ENDPOINT);
+	}
 
 	public CompletableFuture<Void> submit(Collection<LootRecord> lootRecords)
 	{
-		CompletableFuture<Void> future = new CompletableFuture<>();
-
-		HttpUrl url = RuneLiteAPI.getApiBase().newBuilder()
-			.addPathSegment("loottracker")
-			.build();
-
-		Request request = new Request.Builder()
-			.header(RuneLiteAPI.RUNELITE_AUTH, uuid.toString())
-			.post(RequestBody.create(JSON, GSON.toJson(lootRecords)))
-			.url(url)
-			.build();
-
-		client.newCall(request).enqueue(new Callback()
-		{
-			@Override
-			public void onFailure(Call call, IOException e)
-			{
-				log.warn("unable to submit loot", e);
-				future.completeExceptionally(e);
-			}
-
-			@Override
-			public void onResponse(Call call, Response response)
-			{
-				log.debug("Submitted loot");
-				response.close();
-				future.complete(null);
-			}
-		});
-
-		return future;
+		return postAsync_(RequestBody.create(MEDIA_TYPE_JSON, objectToJson(lootRecords)))
+			.thenCompose(response -> bodyToObjectFuture(response, Void.class));
 	}
 
 	public Collection<LootAggregate> get() throws IOException
 	{
-		HttpUrl url = RuneLiteAPI.getApiBase().newBuilder()
-			.addPathSegment("loottracker")
-			.build();
-
-		Request request = new Request.Builder()
-			.header(RuneLiteAPI.RUNELITE_AUTH, uuid.toString())
-			.url(url)
-			.build();
-
-		try (Response response = client.newCall(request).execute())
-		{
-			if (!response.isSuccessful())
-			{
-				log.debug("Error looking up loot: {}", response);
-				return null;
-			}
-
-			InputStream in = response.body().byteStream();
-			return RuneLiteAPI.GSON.fromJson(new InputStreamReader(in), new TypeToken<List<LootAggregate>>()
-			{
-			}.getType());
-		}
-		catch (JsonParseException ex)
-		{
-			throw new IOException(ex);
-		}
+		return bodyToObject(get_(), typeToken);
 	}
 
-	public void delete(String eventId)
+	public CompletableFuture<Void> delete(String eventId)
 	{
-		HttpUrl.Builder builder = RuneLiteAPI.getApiBase().newBuilder()
-			.addPathSegment("loottracker");
-
-		if (eventId != null)
+		return deleteAsync_(url ->
 		{
-			builder.addQueryParameter("eventId", eventId);
+			if (eventId != null)
+			{
+				return url.newBuilder().addQueryParameter("eventId", eventId).build();
+			}
+			return url;
+		}).thenCompose(response -> bodyToObjectFuture(response, Void.class));
+	}
+
+	@RequiredArgsConstructor
+	private static class LootTrackerClientInterceptor implements Interceptor
+	{
+		private final UUID uuid;
+
+		@Override
+		public Response intercept(Chain chain) throws IOException
+		{
+			Request request = chain.request()
+				.newBuilder()
+				.header(AUTH_HEADER, uuid.toString())
+				.build();
+
+			return chain.proceed(request);
 		}
-
-		Request request = new Request.Builder()
-			.header(RuneLiteAPI.RUNELITE_AUTH, uuid.toString())
-			.delete()
-			.url(builder.build())
-			.build();
-
-		client.newCall(request).enqueue(new Callback()
-		{
-			@Override
-			public void onFailure(Call call, IOException e)
-			{
-				log.warn("unable to delete loot", e);
-			}
-
-			@Override
-			public void onResponse(Call call, Response response)
-			{
-				log.debug("Deleted loot");
-				response.close();
-			}
-		});
 	}
 }

--- a/http-api/src/main/java/net/runelite/http/api/osbuddy/OSBGrandExchangeClient.java
+++ b/http-api/src/main/java/net/runelite/http/api/osbuddy/OSBGrandExchangeClient.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018, AeonLucid <https://github.com/AeonLucid>
+ * Copyright (c) 2020, Ugnius <https://github.com/UgiR>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -24,51 +25,23 @@
  */
 package net.runelite.http.api.osbuddy;
 
-import com.google.gson.JsonParseException;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import lombok.AllArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import net.runelite.http.api.RuneLiteAPI;
-import okhttp3.HttpUrl;
+import net.runelite.http.api.RuneLiteApiClient;
 import okhttp3.OkHttpClient;
-import okhttp3.Request;
-import okhttp3.Response;
 
-@Slf4j
-@AllArgsConstructor
-public class OSBGrandExchangeClient
+public class OSBGrandExchangeClient extends RuneLiteApiClient
 {
-	private final OkHttpClient client;
+	private static final String ENDPOINT = "osb/ge";
+
+	public OSBGrandExchangeClient(OkHttpClient client)
+	{
+		super(client.newBuilder(), ENDPOINT);
+	}
 
 	public OSBGrandExchangeResult lookupItem(int itemId) throws IOException
 	{
-		final HttpUrl url = RuneLiteAPI.getApiBase().newBuilder()
-			.addPathSegment("osb")
-			.addPathSegment("ge")
+		return bodyToObject(get_(url -> url.newBuilder()
 			.addQueryParameter("itemId", Integer.toString(itemId))
-			.build();
-
-		log.debug("Built URI: {}", url);
-
-		final Request request = new Request.Builder()
-			.url(url)
-			.build();
-
-		try (final Response response = client.newCall(request).execute())
-		{
-			if (!response.isSuccessful())
-			{
-				throw new IOException("Error looking up item id: " + response);
-			}
-
-			final InputStream in = response.body().byteStream();
-			return RuneLiteAPI.GSON.fromJson(new InputStreamReader(in), OSBGrandExchangeResult.class);
-		}
-		catch (JsonParseException ex)
-		{
-			throw new IOException(ex);
-		}
+			.build()), OSBGrandExchangeResult.class);
 	}
 }

--- a/http-api/src/main/java/net/runelite/http/api/worlds/WorldClient.java
+++ b/http-api/src/main/java/net/runelite/http/api/worlds/WorldClient.java
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2017, Adam <Adam@sigterm.info>
  * Copyright (c) 2018, Lotto <https://github.com/devLotto>
+ * Copyright (c) 2020, Ugnius <https://github.com/UgiR>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -25,50 +26,21 @@
  */
 package net.runelite.http.api.worlds;
 
-import com.google.gson.JsonParseException;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import net.runelite.http.api.RuneLiteAPI;
-import okhttp3.HttpUrl;
+import net.runelite.http.api.RuneLiteApiClient;
 import okhttp3.OkHttpClient;
-import okhttp3.Request;
-import okhttp3.Response;
 
-@Slf4j
-@RequiredArgsConstructor
-public class WorldClient
+public class WorldClient extends RuneLiteApiClient
 {
-	private final OkHttpClient client;
+	private final static String ENDPOINT = "worlds.js";
+
+	public WorldClient(OkHttpClient client)
+	{
+		super(client.newBuilder(), ENDPOINT);
+	}
 
 	public WorldResult lookupWorlds() throws IOException
 	{
-		HttpUrl url = RuneLiteAPI.getApiBase().newBuilder()
-			.addPathSegment("worlds.js")
-			.build();
-
-		log.debug("Built URI: {}", url);
-
-		Request request = new Request.Builder()
-			.url(url)
-			.build();
-
-		try (Response response = client.newCall(request).execute())
-		{
-			if (!response.isSuccessful())
-			{
-				log.debug("Error looking up worlds: {}", response);
-				throw new IOException("unsuccessful response looking up worlds");
-			}
-
-			InputStream in = response.body().byteStream();
-			return RuneLiteAPI.GSON.fromJson(new InputStreamReader(in), WorldResult.class);
-		}
-		catch (JsonParseException ex)
-		{
-			throw new IOException(ex);
-		}
+		return bodyToObject(get_(), WorldResult.class);
 	}
 }

--- a/http-api/src/test/java/net/runelite/http/api/AbstractApiClientTest.java
+++ b/http-api/src/test/java/net/runelite/http/api/AbstractApiClientTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2020, Ugnius <https://github.com/UgiR>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.http.api;
+
+import java.io.IOException;
+import okhttp3.Interceptor;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Protocol;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.rules.ExpectedException;
+
+public abstract class AbstractApiClientTest
+{
+	public final MockWebServer server = new MockWebServer();
+	protected OkHttpClient.Builder testClient;
+
+	@Rule
+	public final ExpectedException exception = ExpectedException.none();
+
+	@Before
+	public void before() throws IOException
+	{
+		server.start();
+		testClient = new OkHttpClient.Builder()
+			.addInterceptor(chain ->
+			{
+				Request request = chain.request()
+					.newBuilder()
+					.url(server.url("/"))
+					.build();
+
+				return chain.proceed(request);
+			});
+	}
+
+	@After
+	public void after() throws IOException
+	{
+		server.shutdown();
+	}
+
+	// Captures the request at this interceptor stage and short circuits the response by returning a dummy response
+	public static class CaptureRequestInterceptor implements Interceptor
+	{
+
+		private Request request;
+
+		@Override
+		public Response intercept(Chain chain) throws IOException
+		{
+			this.request = chain.request().newBuilder().build();
+			return new Response.Builder()
+				.body(ResponseBody.create(MediaType.parse("application/json"), ""))
+				.code(200)
+				.protocol(Protocol.HTTP_2)
+				.request(chain.request())
+				.build();
+		}
+
+		public Request getRequest()
+		{
+			return request;
+		}
+	}
+}

--- a/http-api/src/test/java/net/runelite/http/api/RuneLiteApiClientTest.java
+++ b/http-api/src/test/java/net/runelite/http/api/RuneLiteApiClientTest.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2020, Ugnius <https://github.com/UgiR>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.http.api;
+
+import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import lombok.Builder;
+import lombok.Value;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Protocol;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class RuneLiteApiClientTest
+{
+
+	public final MockWebServer server = new MockWebServer();
+	private OkHttpClient.Builder testClient;
+
+	@Rule
+	public final ExpectedException exception = ExpectedException.none();
+
+	@Before
+	public void before() throws IOException
+	{
+		server.start();
+		testClient = new OkHttpClient.Builder()
+			.addInterceptor(chain -> {
+				Request request = chain.request()
+					.newBuilder()
+					.url(server.url("/"))
+					.build();
+
+				return chain.proceed(request);
+			});
+	}
+
+	@After
+	public void after() throws IOException
+	{
+		server.shutdown();
+	}
+
+	@Test
+	public void gsonParseLombok() throws IOException
+	{
+		// Create a json response
+		String json = "{\"a\": 2, \"b\": \"hello\"}";
+		Response response = new Response.Builder()
+			.protocol(Protocol.HTTP_2)
+			.code(200)
+			.request(new Request.Builder().url(server.url("/")).build())
+			.body(ResponseBody.create(MediaType.parse("application/json"), json))
+			.build();
+
+		TestLombokClass t = RuneLiteApiClient.bodyToObject(response, TestLombokClass.class);
+		Assert.assertEquals(2, t.getA());
+		Assert.assertEquals("hello", t.getB());
+	}
+
+	@Test
+	public void gsonParseVoid() throws IOException
+	{
+		// Create a json response
+		String json = "";
+		Response response = new Response.Builder()
+			.protocol(Protocol.HTTP_2)
+			.code(200)
+			.request(new Request.Builder().url(server.url("/")).build())
+			.body(ResponseBody.create(MediaType.parse("application/json"), json))
+			.build();
+
+		Void v = RuneLiteApiClient.bodyToObject(response, Void.class);
+	}
+
+	@Test
+	public void noResponseAsync()
+	{
+		RuneLiteApiClient client = new RuneLiteApiClient(testClient, "/");
+		CompletableFuture<Response> response = client.getAsync_();
+
+		Assert.assertEquals(0, server.getRequestCount());
+		Assert.assertFalse(response.isDone());
+	}
+
+	@Test
+	public void expected200() throws IOException
+	{
+		server.enqueue(new MockResponse().setBody("Hello world!").setResponseCode(200));
+		RuneLiteApiClient client = new RuneLiteApiClient(testClient, "/");
+		Response response = client.get_();
+
+		Assert.assertEquals(200, response.code());
+		Assert.assertEquals("Hello world!", response.body().string());
+	}
+
+	@Test
+	public void badResponseThrowsIOException() throws IOException
+	{
+		server.enqueue(new MockResponse().setResponseCode(500));
+
+		RuneLiteApiClient client = new RuneLiteApiClient(testClient, "/");
+		exception.expect(IOException.class);
+		exception.expectMessage("500");
+		client.get_();
+	}
+
+	@Test
+	public void malformedJsonThrowsIOException() throws IOException
+	{
+		server.enqueue(new MockResponse().setResponseCode(200).setBody("{\"a: 2, \"b\": \"hello\"}"));
+
+		RuneLiteApiClient client = new RuneLiteApiClient(testClient, "/");
+
+		exception.expect(IOException.class);
+		RuneLiteApiClient.bodyToObject(client.get_(), TestLombokClass.class);
+	}
+
+	@Test
+	public void malformedJsonCompletesExceptionally() throws ExecutionException, InterruptedException
+	{
+		server.enqueue(new MockResponse().setResponseCode(200).setBody("{\"a: 2, \"b\": \"hello\"}"));
+
+		RuneLiteApiClient client = new RuneLiteApiClient(testClient, "/");
+
+		exception.expect(ExecutionException.class);
+		client.getAsync_()
+			.thenCompose(resp -> RuneLiteApiClient.bodyToObjectFuture(resp, TestLombokClass.class))
+			.get();
+	}
+
+	@Value
+	@Builder
+	private static class TestLombokClass
+	{
+		int a;
+		String b;
+	}
+}

--- a/http-api/src/test/java/net/runelite/http/api/account/AccountClientTest.java
+++ b/http-api/src/test/java/net/runelite/http/api/account/AccountClientTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2020, Ugnius <https://github.com/UgiR>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.http.api.account;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.UUID;
+import net.runelite.http.api.AbstractApiClientTest;
+import okhttp3.HttpUrl;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class AccountClientTest extends AbstractApiClientTest
+{
+	@Test
+	public void loginCorrectUrl() throws IOException
+	{
+		CaptureRequestInterceptor captureRequest = new CaptureRequestInterceptor();
+		AccountClient accountClient = new AccountClient(new OkHttpClient.Builder().addInterceptor(captureRequest).build());
+		UUID uuid = UUID.randomUUID();
+		accountClient.setUuid(uuid);
+
+		accountClient.login();
+
+		Request request = captureRequest.getRequest();
+
+		Assert.assertEquals("GET", request.method());
+
+		HttpUrl url = request.url();
+		List<String> pathSegments = url.pathSegments();
+		Assert.assertTrue(url.host().contains("api.runelite"));
+		Assert.assertTrue(pathSegments.get(0).contains("runelite"));
+		Assert.assertEquals("account", pathSegments.get(1));
+		Assert.assertEquals("login", pathSegments.get(2));
+		Assert.assertEquals(uuid.toString(), url.queryParameter("uuid"));
+
+	}
+
+	@Test
+	public void logoutCorrectUrl() throws IOException
+	{
+		CaptureRequestInterceptor captureRequest = new CaptureRequestInterceptor();
+		AccountClient accountClient = new AccountClient(new OkHttpClient.Builder().addInterceptor(captureRequest).build());
+
+		accountClient.logout();
+
+		Request request = captureRequest.getRequest();
+
+		Assert.assertEquals("GET", request.method());
+
+		HttpUrl url = request.url();
+		List<String> pathSegments = url.pathSegments();
+		Assert.assertTrue(url.host().contains("api.runelite"));
+		Assert.assertTrue(pathSegments.get(0).contains("runelite"));
+		Assert.assertEquals("account", pathSegments.get(1));
+		Assert.assertEquals("logout", pathSegments.get(2));
+	}
+
+	@Test
+	public void logoutUuidInHeader() throws IOException, InterruptedException
+	{
+		server.enqueue(new MockResponse().setResponseCode(200));
+		AccountClient accountClient = new AccountClient(testClient.build());
+		UUID uuid = UUID.randomUUID();
+		accountClient.setUuid(uuid);
+
+		accountClient.logout();
+
+		RecordedRequest request = server.takeRequest();
+		Assert.assertEquals(uuid.toString(), request.getHeader("RUNELITE-AUTH"));
+	}
+}

--- a/http-api/src/test/java/net/runelite/http/api/chat/ChatClientTest.java
+++ b/http-api/src/test/java/net/runelite/http/api/chat/ChatClientTest.java
@@ -1,0 +1,365 @@
+/*
+ * Copyright (c) 2020, Ugnius <https://github.com/UgiR>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.http.api.chat;
+
+import java.io.IOException;
+import java.util.List;
+import net.runelite.http.api.AbstractApiClientTest;
+import okhttp3.HttpUrl;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ChatClientTest extends AbstractApiClientTest
+{
+	@Test
+	public void submitKcCorrectUrl() throws IOException
+	{
+		CaptureRequestInterceptor captureRequest = new CaptureRequestInterceptor();
+		ChatClient chatClient = new ChatClient(new OkHttpClient.Builder().addInterceptor(captureRequest).build());
+
+		chatClient.submitKc("Zezima", "Goblin", 64);
+		Request request = captureRequest.getRequest();
+		Assert.assertEquals("POST", request.method());
+
+		HttpUrl url = request.url();
+		List<String> pathSegments = url.pathSegments();
+
+		Assert.assertTrue(url.host().contains("api.runelite"));
+		Assert.assertEquals(3, pathSegments.size());
+		Assert.assertTrue(pathSegments.get(0).contains("runelite"));
+		Assert.assertEquals("chat", pathSegments.get(1));
+		Assert.assertEquals("kc", pathSegments.get(2));
+
+		Assert.assertEquals("Zezima", url.queryParameter("name"));
+		Assert.assertEquals("Goblin", url.queryParameter("boss"));
+		Assert.assertEquals("64", url.queryParameter("kc"));
+	}
+
+	@Test
+	public void getKcCorrectUrl() throws IOException
+	{
+		CaptureRequestInterceptor captureRequest = new CaptureRequestInterceptor();
+		ChatClient chatClient = new ChatClient(new OkHttpClient.Builder().addInterceptor(captureRequest).build());
+
+		exception.expect(NumberFormatException.class);
+		chatClient.getKc("Zezima", "myBoss");
+		Request request = captureRequest.getRequest();
+		Assert.assertEquals("GET", request.method());
+
+		HttpUrl url = request.url();
+		List<String> pathSegments = url.pathSegments();
+
+		Assert.assertTrue(url.host().contains("api.runelite"));
+		Assert.assertEquals(3, pathSegments.size());
+		Assert.assertTrue(pathSegments.get(0).contains("runelite"));
+		Assert.assertEquals("chat", pathSegments.get(1));
+		Assert.assertEquals("kc", pathSegments.get(2));
+
+		Assert.assertEquals("Zezima", url.queryParameter("name"));
+		Assert.assertEquals("myBoss", url.queryParameter("boss"));
+	}
+
+	@Test
+	public void submitQpCorrectUrl() throws IOException
+	{
+		CaptureRequestInterceptor captureRequest = new CaptureRequestInterceptor();
+		ChatClient chatClient = new ChatClient(new OkHttpClient.Builder().addInterceptor(captureRequest).build());
+
+		chatClient.submitQp("Zezima", 64);
+		Request request = captureRequest.getRequest();
+		Assert.assertEquals("POST", request.method());
+
+		HttpUrl url = request.url();
+		List<String> pathSegments = url.pathSegments();
+
+		Assert.assertTrue(url.host().contains("api.runelite"));
+		Assert.assertEquals(3, pathSegments.size());
+		Assert.assertTrue(pathSegments.get(0).contains("runelite"));
+		Assert.assertEquals("chat", pathSegments.get(1));
+		Assert.assertEquals("qp", pathSegments.get(2));
+
+		Assert.assertEquals("Zezima", url.queryParameter("name"));
+		Assert.assertEquals("64", url.queryParameter("qp"));
+	}
+
+	@Test
+	public void getQpCorrectUrl() throws IOException
+	{
+		CaptureRequestInterceptor captureRequest = new CaptureRequestInterceptor();
+		ChatClient chatClient = new ChatClient(new OkHttpClient.Builder().addInterceptor(captureRequest).build());
+
+		exception.expect(NumberFormatException.class);
+		chatClient.getQp("Zezima");
+		Request request = captureRequest.getRequest();
+		Assert.assertEquals("GET", request.method());
+
+		HttpUrl url = request.url();
+		List<String> pathSegments = url.pathSegments();
+
+		Assert.assertTrue(url.host().contains("api.runelite"));
+		Assert.assertEquals(3, pathSegments.size());
+		Assert.assertTrue(pathSegments.get(0).contains("runelite"));
+		Assert.assertEquals("chat", pathSegments.get(1));
+		Assert.assertEquals("qp", pathSegments.get(2));
+
+		Assert.assertEquals("Zezima", url.queryParameter("name"));
+	}
+
+	@Test
+	public void submitTaskCorrectUrl() throws IOException
+	{
+		CaptureRequestInterceptor captureRequest = new CaptureRequestInterceptor();
+		ChatClient chatClient = new ChatClient(new OkHttpClient.Builder().addInterceptor(captureRequest).build());
+
+		chatClient.submitTask("Zezima", "myTask", 64, 128, "myLocation");
+		Request request = captureRequest.getRequest();
+		Assert.assertEquals("POST", request.method());
+
+		HttpUrl url = request.url();
+		List<String> pathSegments = url.pathSegments();
+
+		Assert.assertTrue(url.host().contains("api.runelite"));
+		Assert.assertEquals(3, pathSegments.size());
+		Assert.assertTrue(pathSegments.get(0).contains("runelite"));
+		Assert.assertEquals("chat", pathSegments.get(1));
+		Assert.assertEquals("task", pathSegments.get(2));
+
+		Assert.assertEquals("Zezima", url.queryParameter("name"));
+		Assert.assertEquals("myTask", url.queryParameter("task"));
+		Assert.assertEquals("64", url.queryParameter("amount"));
+		Assert.assertEquals("128", url.queryParameter("initialAmount"));
+		Assert.assertEquals("myLocation", url.queryParameter("location"));
+	}
+
+	@Test
+	public void getTaskCorrectUrl() throws IOException
+	{
+		CaptureRequestInterceptor captureRequest = new CaptureRequestInterceptor();
+		ChatClient chatClient = new ChatClient(new OkHttpClient.Builder().addInterceptor(captureRequest).build());
+
+		chatClient.getTask("Zezima");
+		Request request = captureRequest.getRequest();
+		Assert.assertEquals("GET", request.method());
+
+		HttpUrl url = request.url();
+		List<String> pathSegments = url.pathSegments();
+
+		Assert.assertTrue(url.host().contains("api.runelite"));
+		Assert.assertEquals(3, pathSegments.size());
+		Assert.assertTrue(pathSegments.get(0).contains("runelite"));
+		Assert.assertEquals("chat", pathSegments.get(1));
+		Assert.assertEquals("task", pathSegments.get(2));
+
+		Assert.assertEquals("Zezima", url.queryParameter("name"));
+	}
+
+	@Test
+	public void submitPbCorrectUrl() throws IOException
+	{
+		CaptureRequestInterceptor captureRequest = new CaptureRequestInterceptor();
+		ChatClient chatClient = new ChatClient(new OkHttpClient.Builder().addInterceptor(captureRequest).build());
+
+		chatClient.submitPb("Zezima", "myBoss", 64);
+		Request request = captureRequest.getRequest();
+		Assert.assertEquals("POST", request.method());
+
+		HttpUrl url = request.url();
+		List<String> pathSegments = url.pathSegments();
+
+		Assert.assertTrue(url.host().contains("api.runelite"));
+		Assert.assertEquals(3, pathSegments.size());
+		Assert.assertTrue(pathSegments.get(0).contains("runelite"));
+		Assert.assertEquals("chat", pathSegments.get(1));
+		Assert.assertEquals("pb", pathSegments.get(2));
+
+		Assert.assertEquals("Zezima", url.queryParameter("name"));
+		Assert.assertEquals("myBoss", url.queryParameter("boss"));
+		Assert.assertEquals("64", url.queryParameter("pb"));
+	}
+
+	@Test
+	public void getPbCorrectUrl() throws IOException
+	{
+		CaptureRequestInterceptor captureRequest = new CaptureRequestInterceptor();
+		ChatClient chatClient = new ChatClient(new OkHttpClient.Builder().addInterceptor(captureRequest).build());
+
+		exception.expect(NumberFormatException.class);
+		chatClient.getPb("Zezima", "myBoss");
+		Request request = captureRequest.getRequest();
+		Assert.assertEquals("GET", request.method());
+
+		HttpUrl url = request.url();
+		List<String> pathSegments = url.pathSegments();
+
+		Assert.assertTrue(url.host().contains("api.runelite"));
+		Assert.assertEquals(3, pathSegments.size());
+		Assert.assertTrue(pathSegments.get(0).contains("runelite"));
+		Assert.assertEquals("chat", pathSegments.get(1));
+		Assert.assertEquals("pb", pathSegments.get(2));
+
+		Assert.assertEquals("Zezima", url.queryParameter("name"));
+		Assert.assertEquals("myBoss", url.queryParameter("boss"));
+	}
+
+	@Test
+	public void submitGcCorrectUrl() throws IOException
+	{
+		CaptureRequestInterceptor captureRequest = new CaptureRequestInterceptor();
+		ChatClient chatClient = new ChatClient(new OkHttpClient.Builder().addInterceptor(captureRequest).build());
+
+		chatClient.submitGc("Zezima", 64);
+		Request request = captureRequest.getRequest();
+		Assert.assertEquals("POST", request.method());
+
+		HttpUrl url = request.url();
+		List<String> pathSegments = url.pathSegments();
+
+		Assert.assertTrue(url.host().contains("api.runelite"));
+		Assert.assertEquals(3, pathSegments.size());
+		Assert.assertTrue(pathSegments.get(0).contains("runelite"));
+		Assert.assertEquals("chat", pathSegments.get(1));
+		Assert.assertEquals("gc", pathSegments.get(2));
+
+		Assert.assertEquals("Zezima", url.queryParameter("name"));
+		Assert.assertEquals("64", url.queryParameter("gc"));
+	}
+
+	@Test
+	public void getGcCorrectUrl() throws IOException
+	{
+		CaptureRequestInterceptor captureRequest = new CaptureRequestInterceptor();
+		ChatClient chatClient = new ChatClient(new OkHttpClient.Builder().addInterceptor(captureRequest).build());
+
+		exception.expect(NumberFormatException.class);
+		chatClient.getGc("Zezima");
+		Request request = captureRequest.getRequest();
+		Assert.assertEquals("GET", request.method());
+
+		HttpUrl url = request.url();
+		List<String> pathSegments = url.pathSegments();
+
+		Assert.assertTrue(url.host().contains("api.runelite"));
+		Assert.assertEquals(3, pathSegments.size());
+		Assert.assertTrue(pathSegments.get(0).contains("runelite"));
+		Assert.assertEquals("chat", pathSegments.get(1));
+		Assert.assertEquals("gc", pathSegments.get(2));
+
+		Assert.assertEquals("Zezima", url.queryParameter("name"));
+	}
+
+	@Test
+	public void submitDuelsCorrectUrl() throws IOException
+	{
+		CaptureRequestInterceptor captureRequest = new CaptureRequestInterceptor();
+		ChatClient chatClient = new ChatClient(new OkHttpClient.Builder().addInterceptor(captureRequest).build());
+
+		chatClient.submitDuels("Zezima", 64, 128, 256, 512);
+		Request request = captureRequest.getRequest();
+		Assert.assertEquals("POST", request.method());
+
+		HttpUrl url = request.url();
+		List<String> pathSegments = url.pathSegments();
+
+		Assert.assertTrue(url.host().contains("api.runelite"));
+		Assert.assertEquals(3, pathSegments.size());
+		Assert.assertTrue(pathSegments.get(0).contains("runelite"));
+		Assert.assertEquals("chat", pathSegments.get(1));
+		Assert.assertEquals("duels", pathSegments.get(2));
+
+		Assert.assertEquals("Zezima", url.queryParameter("name"));
+		Assert.assertEquals("64", url.queryParameter("wins"));
+		Assert.assertEquals("128", url.queryParameter("losses"));
+		Assert.assertEquals("256", url.queryParameter("winningStreak"));
+		Assert.assertEquals("512", url.queryParameter("losingStreak"));
+	}
+
+	@Test
+	public void getDuelsCorrectUrl() throws IOException
+	{
+		CaptureRequestInterceptor captureRequest = new CaptureRequestInterceptor();
+		ChatClient chatClient = new ChatClient(new OkHttpClient.Builder().addInterceptor(captureRequest).build());
+
+		chatClient.getDuels("Zezima");
+		Request request = captureRequest.getRequest();
+		Assert.assertEquals("GET", request.method());
+
+		HttpUrl url = request.url();
+		List<String> pathSegments = url.pathSegments();
+
+		Assert.assertTrue(url.host().contains("api.runelite"));
+		Assert.assertEquals(3, pathSegments.size());
+		Assert.assertTrue(pathSegments.get(0).contains("runelite"));
+		Assert.assertEquals("chat", pathSegments.get(1));
+		Assert.assertEquals("duels", pathSegments.get(2));
+
+		Assert.assertEquals("Zezima", url.queryParameter("name"));
+	}
+
+	@Test
+	public void submitLayoutCorrectUrl() throws IOException
+	{
+		CaptureRequestInterceptor captureRequest = new CaptureRequestInterceptor();
+		ChatClient chatClient = new ChatClient(new OkHttpClient.Builder().addInterceptor(captureRequest).build());
+
+		chatClient.submitLayout("Zezima", new LayoutRoom[0]);
+		Request request = captureRequest.getRequest();
+		Assert.assertEquals("POST", request.method());
+
+		HttpUrl url = request.url();
+		List<String> pathSegments = url.pathSegments();
+
+		Assert.assertTrue(url.host().contains("api.runelite"));
+		Assert.assertEquals(3, pathSegments.size());
+		Assert.assertTrue(pathSegments.get(0).contains("runelite"));
+		Assert.assertEquals("chat", pathSegments.get(1));
+		Assert.assertEquals("layout", pathSegments.get(2));
+
+		Assert.assertEquals("Zezima", url.queryParameter("name"));
+	}
+
+	@Test
+	public void getLayoutCorrectUrl() throws IOException
+	{
+		CaptureRequestInterceptor captureRequest = new CaptureRequestInterceptor();
+		ChatClient chatClient = new ChatClient(new OkHttpClient.Builder().addInterceptor(captureRequest).build());
+
+		chatClient.getLayout("Zezima");
+		Request request = captureRequest.getRequest();
+		Assert.assertEquals("GET", request.method());
+
+		HttpUrl url = request.url();
+		List<String> pathSegments = url.pathSegments();
+
+		Assert.assertTrue(url.host().contains("api.runelite"));
+		Assert.assertEquals(3, pathSegments.size());
+		Assert.assertTrue(pathSegments.get(0).contains("runelite"));
+		Assert.assertEquals("chat", pathSegments.get(1));
+		Assert.assertEquals("layout", pathSegments.get(2));
+
+		Assert.assertEquals("Zezima", url.queryParameter("name"));
+	}
+}

--- a/http-api/src/test/java/net/runelite/http/api/config/ConfigClientTest.java
+++ b/http-api/src/test/java/net/runelite/http/api/config/ConfigClientTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2020, Ugnius <https://github.com/UgiR>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.http.api.config;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.UUID;
+import net.runelite.http.api.AbstractApiClientTest;
+import okhttp3.HttpUrl;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ConfigClientTest extends AbstractApiClientTest
+{
+	@Test
+	public void correctSetUrlBuilt() throws IOException
+	{
+		CaptureRequestInterceptor captureRequest = new CaptureRequestInterceptor();
+		ConfigClient configClient = new ConfigClient(new OkHttpClient.Builder().addInterceptor(captureRequest).build(),
+			UUID.randomUUID());
+
+		configClient.set("thisKey", "").join();
+
+		Request request = captureRequest.getRequest();
+		HttpUrl builtUrl = request.url();
+		Assert.assertEquals("PUT", request.method());
+
+		Assert.assertTrue(builtUrl.host().contains("api.runelite"));
+
+		List<String> pathSegments = builtUrl.pathSegments();
+		Assert.assertEquals(3, pathSegments.size());
+		Assert.assertTrue(pathSegments.get(0).contains("runelite"));
+		Assert.assertEquals("config", pathSegments.get(1));
+		Assert.assertEquals("thisKey", pathSegments.get(2));
+	}
+
+	@Test
+	public void correctUnsetUrlBuilt() throws IOException
+	{
+		CaptureRequestInterceptor captureRequest = new CaptureRequestInterceptor();
+		ConfigClient configClient = new ConfigClient(new OkHttpClient.Builder().addInterceptor(captureRequest).build(),
+			UUID.randomUUID());
+
+		configClient.unset("thisKey").join();
+
+		Request request = captureRequest.getRequest();
+		HttpUrl builtUrl = request.url();
+		Assert.assertEquals("DELETE", request.method());
+
+		Assert.assertTrue(builtUrl.host().contains("api.runelite"));
+
+		List<String> pathSegments = builtUrl.pathSegments();
+		Assert.assertEquals(3, pathSegments.size());
+		Assert.assertTrue(pathSegments.get(0).contains("runelite"));
+		Assert.assertEquals("config", pathSegments.get(1));
+		Assert.assertEquals("thisKey", pathSegments.get(2));
+	}
+
+	@Test
+	public void correctGetUrlBuilt() throws IOException
+	{
+		CaptureRequestInterceptor captureRequest = new CaptureRequestInterceptor();
+		ConfigClient configClient = new ConfigClient(new OkHttpClient.Builder().addInterceptor(captureRequest).build(),
+			UUID.randomUUID());
+
+		configClient.get();
+
+		Request request = captureRequest.getRequest();
+		HttpUrl builtUrl = request.url();
+		Assert.assertEquals("GET", request.method());
+
+		Assert.assertTrue(builtUrl.host().contains("api.runelite"));
+
+		List<String> pathSegments = builtUrl.pathSegments();
+		Assert.assertEquals(2, pathSegments.size());
+		Assert.assertTrue(pathSegments.get(0).contains("runelite"));
+		Assert.assertEquals("config", pathSegments.get(1));
+	}
+
+	@Test
+	public void uuidInHeader() throws IOException, InterruptedException
+	{
+		server.enqueue(new MockResponse().setResponseCode(200));
+		UUID uuid = UUID.randomUUID();
+		ConfigClient configClient = new ConfigClient(testClient.build(), uuid);
+
+		configClient.get();
+
+		RecordedRequest request = server.takeRequest();
+		Assert.assertEquals(uuid.toString(), request.getHeader("RUNELITE-AUTH"));
+	}
+}

--- a/http-api/src/test/java/net/runelite/http/api/examine/ExamineClientTest.java
+++ b/http-api/src/test/java/net/runelite/http/api/examine/ExamineClientTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2020, Ugnius <https://github.com/UgiR>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.http.api.examine;
+
+import net.runelite.http.api.AbstractApiClientTest;
+import okhttp3.HttpUrl;
+import okhttp3.OkHttpClient;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.List;
+
+public class ExamineClientTest extends AbstractApiClientTest
+{
+	@Test
+	public void correctObjectUrlBuilt()
+	{
+		CaptureRequestInterceptor captureRequest = new CaptureRequestInterceptor();
+		ExamineClient examineClient = new ExamineClient(new OkHttpClient.Builder()
+			.addInterceptor(captureRequest)
+			.build());
+
+		examineClient.submitObject(512, "").join();
+
+		HttpUrl builtUrl = captureRequest.getRequest().url();
+		Assert.assertTrue(builtUrl.host().contains("api.runelite"));
+
+		List<String> pathSegments = builtUrl.pathSegments();
+		Assert.assertEquals(4, pathSegments.size());
+
+		Assert.assertTrue(pathSegments.get(0).contains("runelite"));
+		Assert.assertEquals("examine", pathSegments.get(1));
+		Assert.assertEquals("object", pathSegments.get(2));
+		Assert.assertEquals("512", pathSegments.get(3));
+	}
+
+	@Test
+	public void correctNpcUrlBuilt()
+	{
+		CaptureRequestInterceptor captureRequest = new CaptureRequestInterceptor();
+		ExamineClient examineClient = new ExamineClient(new OkHttpClient.Builder()
+			.addInterceptor(captureRequest)
+			.build());
+
+		examineClient.submitNpc(256, "").join();
+
+		HttpUrl builtUrl = captureRequest.getRequest().url();
+		Assert.assertTrue(builtUrl.host().contains("api.runelite"));
+
+		List<String> pathSegments = builtUrl.pathSegments();
+		Assert.assertEquals(4, pathSegments.size());
+
+		Assert.assertTrue(pathSegments.get(0).contains("runelite"));
+		Assert.assertEquals("examine", pathSegments.get(1));
+		Assert.assertEquals("npc", pathSegments.get(2));
+		Assert.assertEquals("256", pathSegments.get(3));
+	}
+
+	@Test
+	public void correctItemUrlBuilt()
+	{
+		CaptureRequestInterceptor captureRequest = new CaptureRequestInterceptor();
+		ExamineClient examineClient = new ExamineClient(new OkHttpClient.Builder()
+			.addInterceptor(captureRequest)
+			.build());
+
+		examineClient.submitItem(128, "").join();
+
+		HttpUrl builtUrl = captureRequest.getRequest().url();
+		Assert.assertTrue(builtUrl.host().contains("api.runelite"));
+
+		List<String> pathSegments = builtUrl.pathSegments();
+		Assert.assertEquals(4, pathSegments.size());
+
+		Assert.assertTrue(pathSegments.get(0).contains("runelite"));
+		Assert.assertEquals("examine", pathSegments.get(1));
+		Assert.assertEquals("item", pathSegments.get(2));
+		Assert.assertEquals("128", pathSegments.get(3));
+	}
+
+	@Test
+	public void correctPostBody() throws InterruptedException
+	{
+		server.enqueue(new MockResponse().setResponseCode(200));
+
+		ExamineClient examineClient = new ExamineClient(testClient.build());
+		examineClient.submitItem(13, "Hello world!").join();
+
+		RecordedRequest request = server.takeRequest();
+		Assert.assertTrue(request.getHeader("Content-Type").contains("text/plain"));
+		Assert.assertEquals("Hello world!", request.getBody().readUtf8());
+	}
+}

--- a/http-api/src/test/java/net/runelite/http/api/feed/FeedClientTest.java
+++ b/http-api/src/test/java/net/runelite/http/api/feed/FeedClientTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2020, Ugnius <https://github.com/UgiR>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.http.api.feed;
+
+import java.io.IOException;
+import java.util.List;
+import net.runelite.http.api.AbstractApiClientTest;
+import okhttp3.HttpUrl;
+import okhttp3.OkHttpClient;
+import okhttp3.mockwebserver.MockResponse;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class FeedClientTest extends AbstractApiClientTest
+{
+	private final static String expectedJson = "{\n" +
+		"  \"items\": [\n" +
+		"    {\n" +
+		"      \"type\": \"BLOG_POST\",\n" +
+		"      \"title\": \"1.6.21 Release\",\n" +
+		"      \"content\": \"Pyramid Plunder plugin, Ground Items text outlines, NPC Indicator highlight style toggles\",\n" +
+		"      \"url\": \"https://runelite.net/blog/show/2020-06-25-1.6.21-Release\",\n" +
+		"      \"timestamp\": 1593079200000\n" +
+		"    }\n" +
+		"  ]\n" +
+		"}";
+
+	@Test
+	public void correctUrlBuilt() throws IOException
+	{
+		CaptureRequestInterceptor captureRequest = new CaptureRequestInterceptor();
+		FeedClient feedClient = new FeedClient(new OkHttpClient.Builder()
+			.addInterceptor(captureRequest)
+			.build());
+
+		feedClient.lookupFeed();
+
+		HttpUrl builtUrl = captureRequest.getRequest().url();
+
+		Assert.assertTrue(builtUrl.host().contains("api.runelite"));
+
+		List<String> pathSegments = builtUrl.pathSegments();
+		Assert.assertEquals(2, pathSegments.size());
+		Assert.assertTrue(pathSegments.get(0).contains("runelite"));
+		Assert.assertEquals("feed.js", pathSegments.get(1));
+	}
+
+	@Test
+	public void expectedResponse() throws IOException
+	{
+		server.enqueue(new MockResponse().setResponseCode(200).setBody(expectedJson));
+		FeedClient feedClient = new FeedClient(testClient.build());
+
+		FeedResult result = feedClient.lookupFeed();
+		Assert.assertEquals(1, result.getItems().size());
+
+		FeedItem item = result.getItems().get(0);
+		Assert.assertEquals(FeedItemType.BLOG_POST, item.getType());
+		Assert.assertEquals("1.6.21 Release", item.getTitle());
+		Assert.assertTrue(item.getContent().startsWith("Pyramid Plunder"));
+		Assert.assertTrue(item.getUrl().startsWith("https://runelite.net/blog"));
+		Assert.assertEquals(1593079200000L, item.getTimestamp());
+	}
+}

--- a/http-api/src/test/java/net/runelite/http/api/ge/GrandExchangeClientTest.java
+++ b/http-api/src/test/java/net/runelite/http/api/ge/GrandExchangeClientTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2020, Ugnius <https://github.com/UgiR>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.http.api.ge;
+
+import java.io.IOException;
+import java.util.List;
+import net.runelite.http.api.AbstractApiClientTest;
+import okhttp3.HttpUrl;
+import okhttp3.OkHttpClient;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class GrandExchangeClientTest extends AbstractApiClientTest
+{
+	@Test
+	public void correctUrlBuilt() throws IOException
+	{
+		CaptureRequestInterceptor captureRequest = new CaptureRequestInterceptor();
+		GrandExchangeClient geClient = new GrandExchangeClient(new OkHttpClient.Builder()
+			.addInterceptor(captureRequest)
+			.build());
+
+		geClient.submit(new GrandExchangeTrade()).join();
+
+		HttpUrl builtUrl = captureRequest.getRequest().url();
+
+		Assert.assertTrue(builtUrl.host().contains("api.runelite"));
+
+		List<String> pathSegments = builtUrl.pathSegments();
+		Assert.assertEquals(2, pathSegments.size());
+		Assert.assertTrue(pathSegments.get(0).contains("runelite"));
+		Assert.assertEquals("ge", pathSegments.get(1));
+	}
+
+	@Test
+	public void correctPostBody() throws IOException, InterruptedException
+	{
+		server.enqueue(new MockResponse().setResponseCode(200));
+
+		GrandExchangeTrade trade = new GrandExchangeTrade();
+		trade.setItemId(5024);
+		trade.setOffer(50);
+		trade.setTotal(100);
+
+		GrandExchangeClient geClient = new GrandExchangeClient(testClient.build());
+
+		geClient.submit(trade).join();
+
+		RecordedRequest request = server.takeRequest();
+
+		String expected = "{\"buy\":false,\"cancel\":false,\"login\":false,\"itemId\":5024,\"qty\":0," +
+			"\"dqty\":0,\"total\":100,\"spent\":0,\"dspent\":0,\"offer\":50,\"slot\":0}";
+		Assert.assertEquals(expected, request.getBody().readUtf8());
+	}
+}

--- a/http-api/src/test/java/net/runelite/http/api/item/ItemClientTest.java
+++ b/http-api/src/test/java/net/runelite/http/api/item/ItemClientTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2020, Ugnius <https://github.com/UgiR>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.http.api.item;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import net.runelite.http.api.AbstractApiClientTest;
+import okhttp3.HttpUrl;
+import okhttp3.OkHttpClient;
+import okhttp3.mockwebserver.MockResponse;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ItemClientTest extends AbstractApiClientTest
+{
+	private final static String expectedJsonPrice = "[{\"id\":2,\"name\":\"Cannonball\"," +
+		"\"price\":174,\"time\":{\"seconds\":1593993600,\"nanos\":0}}]";
+
+	private final static String expectedJsonStats = "{\"0\":{\"quest\":true,\"weight\":16.0, \"ge_limit\":2000," +
+		"\"equipable\":true}}";
+
+	@Test
+	public void correctPricesUrlBuilt() throws IOException
+	{
+		CaptureRequestInterceptor captureRequest = new CaptureRequestInterceptor();
+		ItemClient itemClient = new ItemClient(new OkHttpClient.Builder().addInterceptor(captureRequest).build());
+
+		itemClient.getPrices();
+
+		HttpUrl builtUrl = captureRequest.getRequest().url();
+
+		Assert.assertTrue(builtUrl.host().contains("api.runelite"));
+
+		List<String> pathSegments = builtUrl.pathSegments();
+		Assert.assertEquals(3, pathSegments.size());
+		Assert.assertTrue(pathSegments.get(0).contains("runelite"));
+		Assert.assertEquals("item", pathSegments.get(1));
+		Assert.assertEquals("prices.js", pathSegments.get(2));
+	}
+
+	@Test
+	public void correctStatsUrlBuilt() throws IOException
+	{
+		CaptureRequestInterceptor captureRequest = new CaptureRequestInterceptor();
+		ItemClient itemClient = new ItemClient(new OkHttpClient.Builder().addInterceptor(captureRequest).build());
+
+		itemClient.getStats();
+
+		HttpUrl builtUrl = captureRequest.getRequest().url();
+
+		Assert.assertTrue(builtUrl.host().contains("static.runelite"));
+
+		List<String> pathSegments = builtUrl.pathSegments();
+		Assert.assertEquals(2, pathSegments.size());
+		Assert.assertEquals("item", pathSegments.get(0));
+		Assert.assertEquals("stats.ids.min.json", pathSegments.get(1));
+	}
+
+	@Test
+	public void expectedResponsePrices() throws IOException
+	{
+		server.enqueue(new MockResponse().setResponseCode(200).setBody(expectedJsonPrice));
+		ItemClient client = new ItemClient(testClient.build());
+
+		ItemPrice[] prices = client.getPrices();
+
+		Assert.assertEquals(1, prices.length);
+		Assert.assertEquals(2, prices[0].getId());
+		Assert.assertEquals("Cannonball", prices[0].getName());
+		Assert.assertEquals(174, prices[0].getPrice());
+		Assert.assertEquals(1593993600, prices[0].getTime().getEpochSecond());
+	}
+
+	@Test
+	public void expectedResponseStats() throws IOException
+	{
+		server.enqueue(new MockResponse().setResponseCode(200).setBody(expectedJsonStats));
+		ItemClient client = new ItemClient(testClient.build());
+
+		Map<Integer, ItemStats> stats = client.getStats();
+
+		Assert.assertEquals(1, stats.size());
+		Assert.assertTrue(stats.containsKey(0));
+		Assert.assertTrue(stats.get(0).isQuest());
+		Assert.assertEquals(16.0, stats.get(0).getWeight(), 0.0);
+		Assert.assertEquals(2000, stats.get(0).getGeLimit());
+		Assert.assertTrue(stats.get(0).isEquipable());
+	}
+}

--- a/http-api/src/test/java/net/runelite/http/api/loottracker/LootTrackerClientTest.java
+++ b/http-api/src/test/java/net/runelite/http/api/loottracker/LootTrackerClientTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2020, Ugnius <https://github.com/UgiR>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.http.api.loottracker;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.UUID;
+import net.runelite.http.api.AbstractApiClientTest;
+import okhttp3.HttpUrl;
+import okhttp3.OkHttpClient;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class LootTrackerClientTest extends AbstractApiClientTest
+{
+
+	@Test
+	public void correctUrlBuilt()
+	{
+		CaptureRequestInterceptor captureRequest = new CaptureRequestInterceptor();
+		LootTrackerClient lootClient = new LootTrackerClient(new OkHttpClient.Builder()
+			.addInterceptor(captureRequest)
+			.build(), UUID.randomUUID());
+
+		lootClient.delete("2056").join();
+
+		HttpUrl builtUrl = captureRequest.getRequest().url();
+
+		Assert.assertTrue(builtUrl.host().contains("api.runelite"));
+
+		List<String> pathSegments = builtUrl.pathSegments();
+		Assert.assertEquals(2, pathSegments.size());
+		Assert.assertTrue(pathSegments.get(0).contains("runelite"));
+		Assert.assertEquals("loottracker", pathSegments.get(1));
+
+		Assert.assertEquals("2056", builtUrl.queryParameter("eventId"));
+	}
+
+	@Test
+	public void uuidInHeader() throws IOException, InterruptedException
+	{
+		server.enqueue(new MockResponse().setResponseCode(200));
+		UUID uuid = UUID.randomUUID();
+		LootTrackerClient lootClient = new LootTrackerClient(testClient.build(), uuid);
+
+		lootClient.get();
+
+		RecordedRequest request = server.takeRequest();
+		Assert.assertEquals(uuid.toString(), request.getHeader("RUNELITE-AUTH"));
+	}
+}

--- a/http-api/src/test/java/net/runelite/http/api/osbuddy/OSBGrandExchangeClientTest.java
+++ b/http-api/src/test/java/net/runelite/http/api/osbuddy/OSBGrandExchangeClientTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2020, Ugnius <https://github.com/UgiR>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.http.api.osbuddy;
+
+import java.io.IOException;
+import java.util.List;
+import net.runelite.http.api.AbstractApiClientTest;
+import okhttp3.HttpUrl;
+import okhttp3.OkHttpClient;
+import okhttp3.mockwebserver.MockResponse;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class OSBGrandExchangeClientTest extends AbstractApiClientTest
+{
+	private static final String expectedJson =
+		"{\"item_id\":1434,\"buy_average\":29552,\"sell_average\":29491,\"overall_average\":29501,\"last_update\":" +
+			"{\"seconds\":1594056267,\"nanos\":0}}";
+
+	@Test
+	public void expectedResponse() throws IOException
+	{
+		server.enqueue(new MockResponse().setBody(expectedJson).setResponseCode(200));
+		OSBGrandExchangeClient client = new OSBGrandExchangeClient(testClient.build());
+		OSBGrandExchangeResult result = client.lookupItem(0);
+
+		Assert.assertEquals(1434, result.getItem_id());
+		Assert.assertEquals(29552, result.getBuy_average());
+		Assert.assertEquals(29491, result.getSell_average());
+		Assert.assertEquals(29501, result.getOverall_average());
+		Assert.assertEquals(1594056267, result.getLast_update().getEpochSecond());
+	}
+
+	@Test
+	public void correctUrlBuilt() throws IOException
+	{
+		CaptureRequestInterceptor captureRequest = new CaptureRequestInterceptor();
+		OSBGrandExchangeClient osbClient = new OSBGrandExchangeClient(new OkHttpClient.Builder()
+			.addInterceptor(captureRequest).build());
+
+		osbClient.lookupItem(1024);
+
+		HttpUrl builtUrl = captureRequest.getRequest().url();
+		List<String> pathSegments = builtUrl.pathSegments();
+
+		Assert.assertEquals(3, pathSegments.size());
+		Assert.assertEquals("osb", pathSegments.get(1));
+		Assert.assertEquals("ge", pathSegments.get(2));
+
+		Assert.assertEquals("1024", builtUrl.queryParameter("itemId"));
+	}
+}

--- a/http-api/src/test/java/net/runelite/http/api/worlds/WorldClientTest.java
+++ b/http-api/src/test/java/net/runelite/http/api/worlds/WorldClientTest.java
@@ -25,51 +25,24 @@
 package net.runelite.http.api.worlds;
 
 import java.io.IOException;
-import okhttp3.OkHttpClient;
-import okhttp3.Request;
+import net.runelite.http.api.AbstractApiClientTest;
 import okhttp3.mockwebserver.MockResponse;
-import okhttp3.mockwebserver.MockWebServer;
-import org.junit.After;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 
-public class WorldClientTest
+public class WorldClientTest extends AbstractApiClientTest
 {
-	private final MockWebServer server = new MockWebServer();
-	private OkHttpClient testClient;
+
 
 	private static final String expectedJson =
 		"{\"worlds\":[{\"id\":385,\"types\":[\"SKILL_TOTAL\"],\"address\":" +
 			"\"oldschool85.runescape.com\",\"activity\":\"750 skill total\",\"location\":0,\"players\":95}]}";
 
-	@Before
-	public void before() throws IOException
-	{
-		server.start();
-		testClient = new OkHttpClient.Builder()
-			.addInterceptor(chain -> {
-				Request request = chain.request()
-					.newBuilder()
-					.url(server.url("/"))
-					.build();
-
-				return chain.proceed(request);
-			})
-			.build();
-	}
-
-	@After
-	public void after() throws IOException
-	{
-		server.shutdown();
-	}
-
 	@Test
 	public void expectedResponse() throws IOException
 	{
 		server.enqueue(new MockResponse().setBody(expectedJson).setResponseCode(200));
-		WorldClient client = new WorldClient(testClient);
+		WorldClient client = new WorldClient(testClient.build());
 		WorldResult result = client.lookupWorlds();
 
 		Assert.assertEquals(1, result.getWorlds().size());

--- a/http-api/src/test/java/net/runelite/http/api/worlds/WorldClientTest.java
+++ b/http-api/src/test/java/net/runelite/http/api/worlds/WorldClientTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2020, Ugnius <https://github.com/UgiR>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.http.api.worlds;
+
+import java.io.IOException;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class WorldClientTest
+{
+	private final MockWebServer server = new MockWebServer();
+	private OkHttpClient testClient;
+
+	private static final String expectedJson =
+		"{\"worlds\":[{\"id\":385,\"types\":[\"SKILL_TOTAL\"],\"address\":" +
+			"\"oldschool85.runescape.com\",\"activity\":\"750 skill total\",\"location\":0,\"players\":95}]}";
+
+	@Before
+	public void before() throws IOException
+	{
+		server.start();
+		testClient = new OkHttpClient.Builder()
+			.addInterceptor(chain -> {
+				Request request = chain.request()
+					.newBuilder()
+					.url(server.url("/"))
+					.build();
+
+				return chain.proceed(request);
+			})
+			.build();
+	}
+
+	@After
+	public void after() throws IOException
+	{
+		server.shutdown();
+	}
+
+	@Test
+	public void expectedResponse() throws IOException
+	{
+		server.enqueue(new MockResponse().setBody(expectedJson).setResponseCode(200));
+		WorldClient client = new WorldClient(testClient);
+		WorldResult result = client.lookupWorlds();
+
+		Assert.assertEquals(1, result.getWorlds().size());
+
+		World world = result.getWorlds().get(0);
+
+		Assert.assertEquals(385, world.getId());
+		Assert.assertTrue(world.getTypes().contains(WorldType.SKILL_TOTAL));
+		Assert.assertEquals("oldschool85.runescape.com", world.getAddress());
+		Assert.assertEquals("750 skill total", world.getActivity());
+		Assert.assertEquals(WorldRegion.UNITED_STATES_OF_AMERICA, WorldRegion.valueOf(world.getLocation()));
+		Assert.assertEquals(95, world.getPlayers());
+	}
+}

--- a/http-api/src/test/java/net/runelite/http/api/xp/XpClientTest.java
+++ b/http-api/src/test/java/net/runelite/http/api/xp/XpClientTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright (c) 2018, Adam <Adam@sigterm.info>
  * Copyright (c) 2020, Ugnius <https://github.com/UgiR>
  * All rights reserved.
  *
@@ -25,24 +24,32 @@
  */
 package net.runelite.http.api.xp;
 
-import java.util.concurrent.CompletableFuture;
-import lombok.extern.slf4j.Slf4j;
-import net.runelite.http.api.RuneLiteApiClient;
+import java.util.List;
+import net.runelite.http.api.AbstractApiClientTest;
+import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
+import org.junit.Assert;
+import org.junit.Test;
 
-@Slf4j
-public class XpClient extends RuneLiteApiClient
+public class XpClientTest extends AbstractApiClientTest
 {
-	private static final String ENDPOINT = "xp/update";
-
-	public XpClient(OkHttpClient client)
+	@Test
+	public void correctUrlBuilt()
 	{
-		super(client.newBuilder(), ENDPOINT);
-	}
+		CaptureRequestInterceptor captureRequest = new CaptureRequestInterceptor();
+		XpClient xpClient = new XpClient(new OkHttpClient.Builder().addInterceptor(captureRequest).build());
 
-	public CompletableFuture<Void> update(String username)
-	{
-		return getAsync_(url -> url.newBuilder().addQueryParameter("username", username).build())
-			.thenCompose(response -> bodyToObjectFuture(response, Void.class));
+		xpClient.update("Zezima").join();
+
+		HttpUrl builtUrl = captureRequest.getRequest().url();
+		List<String> pathSegments = builtUrl.pathSegments();
+
+		Assert.assertEquals(3, pathSegments.size());
+		Assert.assertEquals("xp", pathSegments.get(1));
+		Assert.assertEquals("update", pathSegments.get(2));
+
+		Assert.assertEquals("Zezima", builtUrl.queryParameter("username"));
+
+
 	}
 }

--- a/http-api/src/test/java/net/runelite/http/api/xtea/XteaClientTest.java
+++ b/http-api/src/test/java/net/runelite/http/api/xtea/XteaClientTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2020, Ugnius <https://github.com/UgiR>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.http.api.xtea;
+
+import java.io.IOException;
+import java.util.List;
+import net.runelite.http.api.AbstractApiClientTest;
+import okhttp3.HttpUrl;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class XteaClientTest extends AbstractApiClientTest
+{
+	@Test
+	public void submitCorrectUrl()
+	{
+		CaptureRequestInterceptor captureRequest = new CaptureRequestInterceptor();
+		XteaClient xteaClient = new XteaClient(new OkHttpClient.Builder().addInterceptor(captureRequest).build());
+		xteaClient.submit(new XteaRequest()).join();
+
+		Request request = captureRequest.getRequest();
+		Assert.assertEquals("POST", request.method());
+
+		HttpUrl url = request.url();
+		List<String> pathSegments = url.pathSegments();
+
+		Assert.assertTrue(url.host().contains("api.runelite"));
+		Assert.assertEquals(2, pathSegments.size());
+		Assert.assertTrue(pathSegments.get(0).contains("runelite"));
+		Assert.assertEquals("xtea", pathSegments.get(1));
+	}
+
+	@Test
+	public void getCorrectUrl() throws IOException
+	{
+		CaptureRequestInterceptor captureRequest = new CaptureRequestInterceptor();
+		XteaClient xteaClient = new XteaClient(new OkHttpClient.Builder().addInterceptor(captureRequest).build());
+		xteaClient.get(5);
+
+		Request request = captureRequest.getRequest();
+		Assert.assertEquals("GET", request.method());
+
+		HttpUrl url = request.url();
+		List<String> pathSegments = url.pathSegments();
+
+		Assert.assertTrue(url.host().contains("api.runelite"));
+		Assert.assertEquals(3, pathSegments.size());
+		Assert.assertTrue(pathSegments.get(0).contains("runelite"));
+		Assert.assertEquals("xtea", pathSegments.get(1));
+		Assert.assertEquals("5", pathSegments.get(2));
+	}
+}

--- a/runelite-client/src/test/java/net/runelite/client/plugins/PluginManagerTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/PluginManagerTest.java
@@ -52,17 +52,14 @@ import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigItem;
 import net.runelite.client.eventbus.EventBus;
 import okhttp3.OkHttpClient;
-import okhttp3.Request;
 import static org.junit.Assert.assertEquals;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
-import static org.mockito.ArgumentMatchers.any;
 import org.mockito.Mock;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -87,9 +84,10 @@ public class PluginManagerTest
 	@Before
 	public void before() throws IOException
 	{
-		OkHttpClient okHttpClient = mock(OkHttpClient.class);
-		when(okHttpClient.newCall(any(Request.class)))
-			.thenThrow(new RuntimeException("in plugin manager test"));
+		OkHttpClient okHttpClient = new OkHttpClient.Builder().addInterceptor(chain ->
+		{
+			throw new IOException("in plugin manager test");
+		}).build();
 
 		Injector injector = Guice.createInjector(Modules
 			.override(new RuneLiteModule(okHttpClient, () -> null, true, false,


### PR DESCRIPTION
This PR consolidates much of the repeated logic in each client into one base class.

* Method signatures remain the same except if a client's method is async and returns void, it now returns CompletableFuture<Void>.

* Originally I wanted to move all the 'properties' logic from RuneLiteAPI into RuneLiteApiClient, but it looks like there are references to RuneLiteAPI across a lot of other modules, so I did not touch it.

* HiscoreClient was not changed. I will leave this for a separate PR. There exists an enum for all hiscore URL's, but the client also exposes a lookup method taking an arbitrary URL (it looks like maybe for testing purposes?).. I would like to fix this as well so the lookup URL's are limited to the enum URL values.. slightly more involved.

Let me know how it looks..thanks.