### PR TITLE
xpdrops: Fix white xp drop text recolors

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/experiencedrop/XpDropPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/experiencedrop/XpDropPlugin.java
@@ -114,7 +114,7 @@ public class XpDropPlugin extends Plugin
 				.skip(1) // skip text
 				.mapToInt(Widget::getSpriteId);
 
-		int color = -1;
+		int color = 0;
 
 		switch (prayer)
 		{
@@ -142,7 +142,7 @@ public class XpDropPlugin extends Plugin
 				break;
 		}
 
-		if (color != -1)
+		if (color != 0)
 		{
 			text.setTextColor(color);
 		}


### PR DESCRIPTION
Selecting #FFFFFF as a prayer color yields an RGB value of -1. Since all
values will be negative numbers, 0 should be used as an "unset" value
instead.