### PR TITLE
Add Anisotropic Filtering 

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GLUtil.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GLUtil.java
@@ -31,11 +31,18 @@ class GLUtil
 	private static final int ERR_LEN = 1024;
 
 	private static final int[] buf = new int[1];
+	private static final float[] fbuf = new float[1];
 
 	static int glGetInteger(GL4 gl, int pname)
 	{
 		gl.glGetIntegerv(pname, buf, 0);
 		return buf[0];
+	}
+
+	static float glGetFloat(GL4 gl, int pname)
+	{
+		gl.glGetFloatv(pname, fbuf, 0);
+		return fbuf[0];
 	}
 
 	static int glGetShader(GL4 gl, int shader, int pname)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuPlugin.java
@@ -243,6 +243,7 @@ public class GpuPlugin extends Plugin implements DrawCallbacks
 	private int lastStretchedCanvasWidth;
 	private int lastStretchedCanvasHeight;
 	private AntiAliasingMode lastAntiAliasingMode;
+	private int lastAnisotropicFilteringLevel = -1;
 
 	private int centerX;
 	private int centerY;
@@ -1104,6 +1105,15 @@ public class GpuPlugin extends Plugin implements DrawCallbacks
 			int renderCanvasHeight = canvasHeight;
 			int renderViewportHeight = viewportHeight;
 			int renderViewportWidth = viewportWidth;
+
+			// Setup anisotropic filtering
+			final int anisotropicFilteringLevel = config.anisotropicFilteringLevel();
+
+			if (textureArrayId != -1 && lastAnisotropicFilteringLevel != anisotropicFilteringLevel)
+			{
+				textureManager.setAnisotropicFilteringLevel(textureArrayId, anisotropicFilteringLevel, gl);
+				lastAnisotropicFilteringLevel = anisotropicFilteringLevel;
+			}
 
 			if (client.isStretchedEnabled())
 			{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuPluginConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuPluginConfig.java
@@ -117,7 +117,7 @@ public interface GpuPluginConfig extends Config
 		keyName = "anisotropicFilteringLevel",
 		name = "Anisotropic Filtering",
 		description = "Configures the anisotropic filtering level.",
-		position = 6
+		position = 7
 	)
 	default int anisotropicFilteringLevel()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuPluginConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuPluginConfig.java
@@ -108,4 +108,19 @@ public interface GpuPluginConfig extends Config
 	{
 		return true;
 	}
+
+	@Range(
+		min = 0,
+		max = 16
+	)
+	@ConfigItem(
+		keyName = "anisotropicFilteringLevel",
+		name = "Anisotropic Filtering",
+		description = "Configures the anisotropic filtering level.",
+		position = 6
+	)
+	default int anisotropicFilteringLevel()
+	{
+		return 0;
+	}
 }


### PR DESCRIPTION
Closes #7212 

Zoomed in video example [with](https://imgur.com/YatSjYw) and [without](https://imgur.com/yfeynlP) anisotropic filtering

Example images
Left side has anisotropic filtering disabled. Right is 16x anisotropic filtering 
![](https://i.imgur.com/Fp5g9Aw.png)
![](https://i.imgur.com/PR4Zihn.png)