### PR TITLE
Add configurable color and opacity to the notificaion flash (#10761)

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/Notifier.java
+++ b/runelite-client/src/main/java/net/runelite/client/Notifier.java
@@ -98,7 +98,6 @@ public class Notifier
 		.build();
 
 	// Notifier properties
-	private static final Color FLASH_COLOR = new Color(255, 0, 0, 70);
 	private static final int MINIMUM_FLASH_DURATION_MILLIS = 2000;
 	private static final int MINIMUM_FLASH_DURATION_TICKS = MINIMUM_FLASH_DURATION_MILLIS / Constants.CLIENT_TICK_LENGTH;
 
@@ -226,7 +225,7 @@ public class Notifier
 		}
 
 		final Color color = graphics.getColor();
-		graphics.setColor(FLASH_COLOR);
+		graphics.setColor(runeLiteConfig.notificationFlashColor());
 		graphics.fill(new Rectangle(client.getCanvas().getSize()));
 		graphics.setColor(color);
 

--- a/runelite-client/src/main/java/net/runelite/client/config/RuneLiteConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/RuneLiteConfig.java
@@ -256,6 +256,19 @@ public interface RuneLiteConfig extends Config
 		return false;
 	}
 
+	@Alpha
+	@ConfigItem(
+		keyName = "notificationFlashColor",
+		name = "Notification Flash Color",
+		description = "Sets the color of the notification flashes.",
+		position = 26,
+		section = notificationSettings
+	)
+	default Color notificationFlashColor()
+	{
+		return new Color(255, 0, 0, 70);
+	}
+
 	@ConfigItem(
 		keyName = "fontType",
 		name = "Dynamic Overlay Font",


### PR DESCRIPTION
This change adds a configuration option to the 'RuneLite' settings under 'Notification Settings' that allows users to set the color and opacity of notification flashes.

Fixes #10761