### PR TITLE
Fix 20ms flash when screen flash notification ends between two flashes

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/Notifier.java
+++ b/runelite-client/src/main/java/net/runelite/client/Notifier.java
@@ -217,6 +217,28 @@ public class Notifier
 
 		FlashNotification flashNotification = runeLiteConfig.flashNotification();
 
+		if (Instant.now().minusMillis(MINIMUM_FLASH_DURATION_MILLIS).isAfter(flashStart))
+		{
+			switch (flashNotification)
+			{
+				case FLASH_TWO_SECONDS:
+				case SOLID_TWO_SECONDS:
+					flashStart = null;
+					return;
+				case SOLID_UNTIL_CANCELLED:
+				case FLASH_UNTIL_CANCELLED:
+					// Any interaction with the client since the notification started will cancel it after the minimum duration
+					if ((client.getMouseIdleTicks() < MINIMUM_FLASH_DURATION_TICKS
+							|| client.getKeyboardIdleTicks() < MINIMUM_FLASH_DURATION_TICKS
+							|| client.getMouseLastPressedMillis() > mouseLastPressedMillis) && clientUI.isFocused())
+					{
+						flashStart = null;
+						return;
+					}
+					break;
+			}
+		}
+
 		if (client.getGameCycle() % 40 >= 20
 			// For solid colour, fall through every time.
 			&& (flashNotification == FlashNotification.FLASH_TWO_SECONDS
@@ -229,29 +251,6 @@ public class Notifier
 		graphics.setColor(FLASH_COLOR);
 		graphics.fill(new Rectangle(client.getCanvas().getSize()));
 		graphics.setColor(color);
-
-		if (!Instant.now().minusMillis(MINIMUM_FLASH_DURATION_MILLIS).isAfter(flashStart))
-		{
-			return;
-		}
-
-		switch (flashNotification)
-		{
-			case FLASH_TWO_SECONDS:
-			case SOLID_TWO_SECONDS:
-				flashStart = null;
-				break;
-			case SOLID_UNTIL_CANCELLED:
-			case FLASH_UNTIL_CANCELLED:
-				// Any interaction with the client since the notification started will cancel it after the minimum duration
-				if ((client.getMouseIdleTicks() < MINIMUM_FLASH_DURATION_TICKS
-					|| client.getKeyboardIdleTicks() < MINIMUM_FLASH_DURATION_TICKS
-					|| client.getMouseLastPressedMillis() > mouseLastPressedMillis) && clientUI.isFocused())
-				{
-					flashStart = null;
-				}
-				break;
-		}
 	}
 
 	private void sendNotification(

--- a/runelite-client/src/main/java/net/runelite/client/Notifier.java
+++ b/runelite-client/src/main/java/net/runelite/client/Notifier.java
@@ -141,7 +141,7 @@ public class Notifier
 		// First check if we are running in launcher
 		this.terminalNotifierAvailable =
 			!Strings.isNullOrEmpty(RuneLiteProperties.getLauncherVersion())
-			&& isTerminalNotifierAvailable();
+				&& isTerminalNotifierAvailable();
 
 		storeIcon();
 	}
@@ -229,8 +229,8 @@ public class Notifier
 				case FLASH_UNTIL_CANCELLED:
 					// Any interaction with the client since the notification started will cancel it after the minimum duration
 					if ((client.getMouseIdleTicks() < MINIMUM_FLASH_DURATION_TICKS
-							|| client.getKeyboardIdleTicks() < MINIMUM_FLASH_DURATION_TICKS
-							|| client.getMouseLastPressedMillis() > mouseLastPressedMillis) && clientUI.isFocused())
+						|| client.getKeyboardIdleTicks() < MINIMUM_FLASH_DURATION_TICKS
+						|| client.getMouseLastPressedMillis() > mouseLastPressedMillis) && clientUI.isFocused())
 					{
 						flashStart = null;
 						return;

--- a/runelite-client/src/main/java/net/runelite/client/Notifier.java
+++ b/runelite-client/src/main/java/net/runelite/client/Notifier.java
@@ -141,7 +141,7 @@ public class Notifier
 		// First check if we are running in launcher
 		this.terminalNotifierAvailable =
 			!Strings.isNullOrEmpty(RuneLiteProperties.getLauncherVersion())
-				&& isTerminalNotifierAvailable();
+			&& isTerminalNotifierAvailable();
 
 		storeIcon();
 	}


### PR DESCRIPTION
Moved the input/timer check to the start of the processFlash method.