### PR TITLE
worldmap: Add Ferox Enclave canoe location

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldmap/TransportationPointLocation.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldmap/TransportationPointLocation.java
@@ -139,6 +139,7 @@ enum TransportationPointLocation
 	CANOE_CHAMPIONSGUILD("Canoe", new WorldPoint(3202, 3344, 0)),
 	CANOE_EDGEVILLE("Canoe", new WorldPoint(3130, 3509, 0)),
 	CANOE_LUMBRIDGE("Canoe", new WorldPoint(3241, 3238, 0)),
+	CANOE_FEROXENCLAVE("Canoe", new WorldPoint(3155, 3630, 0)),
 
 	//Gnome Gliders
 	GNOME_GLIDER_KHARID("Gnome Glider", new WorldPoint(3278, 3213, 0)),


### PR DESCRIPTION
Adds new canoe location in Ferox Enclave to world map

<img width="175" alt="Screen Shot 2020-07-16 at 9 50 47 AM" src="https://user-images.githubusercontent.com/54762282/87679272-fb3f6f80-c749-11ea-9f8e-ce04e99cfe8b.png">
