### PR TITLE
Update itemstats plugin to check for two handed interactions

### DIFF
--- a/http-api/src/main/java/net/runelite/http/api/item/ItemEquipmentStats.java
+++ b/http-api/src/main/java/net/runelite/http/api/item/ItemEquipmentStats.java
@@ -24,6 +24,7 @@
  */
 package net.runelite.http.api.item;
 
+import com.google.gson.annotations.SerializedName;
 import lombok.Builder;
 import lombok.Value;
 
@@ -32,6 +33,9 @@ import lombok.Value;
 public class ItemEquipmentStats
 {
 	private int slot;
+
+	@SerializedName("is_2h")
+	private boolean isTwoHanded;
 
 	private int astab;
 	private int aslash;

--- a/http-api/src/main/java/net/runelite/http/api/item/ItemEquipmentStats.java
+++ b/http-api/src/main/java/net/runelite/http/api/item/ItemEquipmentStats.java
@@ -34,7 +34,7 @@ public class ItemEquipmentStats
 {
 	private int slot;
 
-	@SerializedName("is_2h")
+	@SerializedName("is2h")
 	private boolean isTwoHanded;
 
 	private int astab;
@@ -55,4 +55,3 @@ public class ItemEquipmentStats
 	private int prayer;
 	private int aspeed;
 }
-

--- a/runelite-client/src/test/java/net/runelite/client/plugins/itemstats/ItemStatOverlayTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/itemstats/ItemStatOverlayTest.java
@@ -56,6 +56,7 @@ public class ItemStatOverlayTest
 	private static final ItemStats ABYSSAL_DAGGER = new ItemStats(false, true, 0.453, 8,
 		ItemEquipmentStats.builder()
 			.slot(EquipmentInventorySlot.WEAPON.getSlotIdx())
+			.isTwoHanded(false)
 			.astab(75)
 			.aslash(40)
 			.acrush(-4)
@@ -67,6 +68,7 @@ public class ItemStatOverlayTest
 	private static final ItemStats KATANA = new ItemStats(false, true, 0, 8,
 		ItemEquipmentStats.builder()
 			.slot(EquipmentInventorySlot.WEAPON.getSlotIdx())
+			.isTwoHanded(true)
 			.astab(7)
 			.aslash(45)
 			.dstab(3)
@@ -79,6 +81,7 @@ public class ItemStatOverlayTest
 	private static final ItemStats BLOWPIPE = new ItemStats(false, true, 0, 0,
 		ItemEquipmentStats.builder()
 			.slot(EquipmentInventorySlot.WEAPON.getSlotIdx())
+			.isTwoHanded(true)
 			.arange(60)
 			.rstr(40)
 			.aspeed(3)
@@ -86,6 +89,7 @@ public class ItemStatOverlayTest
 	private static final ItemStats HEAVY_BALLISTA = new ItemStats(false, true, 4, 8,
 		ItemEquipmentStats.builder()
 			.slot(EquipmentInventorySlot.WEAPON.getSlotIdx())
+			.isTwoHanded(true)
 			.arange(110)
 			.aspeed(7)
 			.build());


### PR DESCRIPTION
Adds some logic to account for two handed weapon interactions when hovering over items to get stat changes with the itemstats plugin. Requires runelite/runelite-wiki-scrapper to be updated with this [pull request](https://github.com/runelite/runelite-wiki-scraper/pull/14) to have the functionality work properly. Without this, the old behaviour remains.

Examples:
![001_unarmed_to_1h](https://user-images.githubusercontent.com/45152844/87721076-e384dd00-c783-11ea-8938-dc1425392ad0.png)
![002_1h_to_1h_and_shield](https://user-images.githubusercontent.com/45152844/87721086-e5e73700-c783-11ea-8fcf-b1d70467554f.png)

Switching to 2h accounts for shield removal:
![003_1h_and_shield_2h](https://user-images.githubusercontent.com/45152844/87721110-eb448180-c783-11ea-8164-27ae7e24ee7a.png)

Switching to shield accounts for main hand being two handed:
![004_2h_to_shield](https://user-images.githubusercontent.com/45152844/87721113-ec75ae80-c783-11ea-8bf9-24be5e0aebaa.png)

Equipping a 2h with only a shield:
![005_shield_to_2h](https://user-images.githubusercontent.com/45152844/87721119-ee3f7200-c783-11ea-95a4-4ca0eb15df68.png)