### PR TITLE
xpdrop: hide skill icons after recolor

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/experiencedrop/XpDropPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/experiencedrop/XpDropPlugin.java
@@ -97,15 +97,10 @@ public class XpDropPlugin extends Plugin
 		// child 0 is the xpdrop text, everything else are sprite ids for skills
 		final Widget text = children[0];
 
-		if (config.hideSkillIcons())
-		{
-			// keep only text
-			Arrays.fill(children, 1, children.length, null);
-		}
-
 		PrayerType prayer = getActivePrayerType();
 		if (prayer == null)
 		{
+			hideSkillIcons(xpdrop);
 			resetTextColor(text);
 			return;
 		}
@@ -152,6 +147,8 @@ public class XpDropPlugin extends Plugin
 		{
 			resetTextColor(text);
 		}
+
+		hideSkillIcons(xpdrop);
 	}
 
 	private void resetTextColor(Widget widget)
@@ -160,6 +157,16 @@ public class XpDropPlugin extends Plugin
 		int defaultColorId = client.getVar(Varbits.EXPERIENCE_DROP_COLOR);
 		int color = colorEnum.getIntValue(defaultColorId);
 		widget.setTextColor(color);
+	}
+
+	private void hideSkillIcons(Widget xpdrop)
+	{
+		if (config.hideSkillIcons())
+		{
+			Widget[] children = xpdrop.getChildren();
+			// keep only text
+			Arrays.fill(children, 1, children.length, null);
+		}
 	}
 
 	private PrayerType getActivePrayerType()


### PR DESCRIPTION
Thix fixes a bug caused by 6c6238d60f41c98aee2bb8b08ded040351e7ef27 where if Hide Skill Icons is enabled and an XP drop to be recolored due to prayer fires, the Widget array is filled with nulls which causes anyMatch to throw an NPE.