### PR TITLE
cooking: fix sinew not registering as cooked

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/cooking/CookingPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cooking/CookingPlugin.java
@@ -176,7 +176,8 @@ public class CookingPlugin extends Plugin
 			|| message.startsWith("You successfully bake")
 			|| message.startsWith("You manage to cook")
 			|| message.startsWith("You roast a")
-			|| message.startsWith("You cook"))
+			|| message.startsWith("You cook")
+			|| message.startsWith("You dry a piece of meat"))
 		{
 			if (session == null)
 			{

--- a/runelite-client/src/test/java/net/runelite/client/plugins/cooking/CookingPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/cooking/CookingPluginTest.java
@@ -59,7 +59,8 @@ public class CookingPluginTest
 		"You cook the karambwan. It looks delicious.",
 		"You roast a lobster.",
 		"You cook a bass.",
-		"You successfully bake a tasty garden pie."
+		"You successfully bake a tasty garden pie.",
+		"You dry a piece of meat and extract the sinew."
 	};
 
 	@Inject


### PR DESCRIPTION
Successfully cooking raw beef into sinew didn't count in the cooking
counter. Added the chat message for successfully cooking sinew to
CookingPlugin.

Close #12090 