### PR TITLE
Notifier: Disable flash notification when off is selected

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/Notifier.java
+++ b/runelite-client/src/main/java/net/runelite/client/Notifier.java
@@ -208,13 +208,14 @@ public class Notifier
 
 	public void processFlash(final Graphics2D graphics)
 	{
-		if (flashStart == null || client.getGameState() != GameState.LOGGED_IN)
+		FlashNotification flashNotification = runeLiteConfig.flashNotification();
+
+		if (flashStart == null || client.getGameState() != GameState.LOGGED_IN
+			|| flashNotification == FlashNotification.DISABLED)
 		{
 			flashStart = null;
 			return;
 		}
-
-		FlashNotification flashNotification = runeLiteConfig.flashNotification();
 
 		if (Instant.now().minusMillis(MINIMUM_FLASH_DURATION_MILLIS).isAfter(flashStart))
 		{


### PR DESCRIPTION
I didn't see a bug reported for this so I decided to make a fix it myself.

When the "Flash Notification" setting is set to "Flash until cancelled" or "Solid until cancelled" and the notification goes off, changing the setting to "Off" keeps the notification solid even if you move your mouse or click in the game window panel.

This fix simply disables any flash notification currently active if the setting is changed to off.