### PR TITLE
Prayer: Fixed time remaining text when time was greater than an hour

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/prayer/PrayerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/prayer/PrayerPlugin.java
@@ -361,7 +361,8 @@ public class PrayerPlugin extends Plugin
 
 		LocalTime timeLeft = LocalTime.ofSecondOfDay((long) secondsLeft);
 
-		if (formatForOrb && (timeLeft.getHour() > 0 || timeLeft.getMinute() > 9)) {
+		if (formatForOrb && (timeLeft.getHour() > 0 || timeLeft.getMinute() > 9))
+		{
 			long minutes = Duration.ofSeconds((long) secondsLeft).toMinutes();
 			return String.format("%dm", minutes);
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/prayer/PrayerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/prayer/PrayerPlugin.java
@@ -361,9 +361,13 @@ public class PrayerPlugin extends Plugin
 
 		LocalTime timeLeft = LocalTime.ofSecondOfDay((long) secondsLeft);
 
-		if (formatForOrb && timeLeft.getMinute() > 9)
+		if (formatForOrb && (timeLeft.getHour() > 0 || timeLeft.getMinute() > 9)) {
+			long minutes = Duration.ofSeconds((long) secondsLeft).toMinutes();
+			return String.format("%dm", minutes);
+		}
+		else if (timeLeft.getHour() > 0)
 		{
-			return timeLeft.format(DateTimeFormatter.ofPattern("m")) + "m";
+			return timeLeft.format(DateTimeFormatter.ofPattern("H:mm:ss"));
 		}
 		else
 		{

--- a/runelite-client/src/test/java/net/runelite/client/plugins/prayer/PrayerPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/prayer/PrayerPluginTest.java
@@ -1,0 +1,130 @@
+package net.runelite.client.plugins.prayer;
+
+import com.google.inject.Guice;
+import com.google.inject.testing.fieldbinder.Bind;
+import com.google.inject.testing.fieldbinder.BoundFieldModule;
+import net.runelite.api.*;
+import net.runelite.api.events.ItemContainerChanged;
+import net.runelite.client.game.ItemManager;
+import net.runelite.client.game.SpriteManager;
+import net.runelite.client.ui.overlay.OverlayManager;
+import net.runelite.client.ui.overlay.infobox.InfoBoxManager;
+import net.runelite.http.api.item.ItemEquipmentStats;
+import net.runelite.http.api.item.ItemStats;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import javax.inject.Inject;
+import java.util.concurrent.ScheduledExecutorService;
+
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PrayerPluginTest {
+
+    @Inject
+    private PrayerPlugin prayerPlugin;
+
+    @Mock
+    @Bind
+    private Client client;
+
+    @Mock
+    @Bind
+    private PrayerConfig config;
+
+    @Mock
+    @Bind
+    private OverlayManager overlayManager;
+
+    @Mock
+    @Bind
+    private InfoBoxManager infoBoxManager;
+
+    @Mock
+    @Bind
+    private SpriteManager spriteManager;
+
+    @Mock
+    @Bind
+    private ScheduledExecutorService executor;
+
+    @Mock
+    @Bind
+    private ItemManager itemManager;
+
+    @Before
+    public void before()
+    {
+        Guice.createInjector(BoundFieldModule.of(this)).injectMembers(this);
+    }
+
+    @Test
+    public void testGetEstimatedTimeRemainingOverOneHour() {
+
+        String expectedString = "1:19:12";
+
+        ItemStats itemStats = new ItemStats(false, true, 1, 8,
+                ItemEquipmentStats.builder()
+                        .slot(EquipmentInventorySlot.WEAPON.getSlotIdx())
+                        .prayer(50)
+                        .build());
+
+        ItemContainer itemContainer = mock(ItemContainer.class);
+
+        when(client.isPrayerActive(Prayer.PRESERVE)).thenReturn(true);
+        when(client.getBoostedSkillLevel(Skill.PRAYER)).thenReturn(99);
+        when(client.getItemContainer(InventoryID.EQUIPMENT)).thenReturn(itemContainer);
+        when(itemContainer.getItems()).thenReturn(new Item[]{ new Item(ItemID.TWISTED_BOW, 1)});
+        when(itemManager.getItemStats(anyInt(), anyBoolean())).thenReturn(itemStats);
+
+        prayerPlugin.onItemContainerChanged(new ItemContainerChanged(InventoryID.EQUIPMENT.getId(), itemContainer));
+        String actualString = prayerPlugin.getEstimatedTimeRemaining(false);
+
+        Assert.assertEquals(expectedString, actualString);
+    }
+
+
+    @Test
+    public void testGetEstimatedTimeRemainingUnderOneHour() {
+
+        String expectedString = "29:42";
+
+        ItemContainer itemContainer = mock(ItemContainer.class);
+
+        when(client.isPrayerActive(Prayer.PRESERVE)).thenReturn(true);
+        when(client.getBoostedSkillLevel(Skill.PRAYER)).thenReturn(99);
+        when(client.getItemContainer(InventoryID.EQUIPMENT)).thenReturn(itemContainer);
+        when(itemContainer.getItems()).thenReturn(new Item[]{});
+
+        prayerPlugin.onItemContainerChanged(new ItemContainerChanged(InventoryID.EQUIPMENT.getId(), itemContainer));
+        String actualString = prayerPlugin.getEstimatedTimeRemaining(false);
+
+        Assert.assertEquals(expectedString, actualString);
+    }
+
+    @Test
+    public void testGetEstimatedTimeRemainingFormatForOrb() {
+
+        String expectedString = "29m";
+
+        ItemContainer itemContainer = mock(ItemContainer.class);
+
+        when(client.isPrayerActive(Prayer.PRESERVE)).thenReturn(true);
+        when(client.getBoostedSkillLevel(Skill.PRAYER)).thenReturn(99);
+        when(client.getItemContainer(InventoryID.EQUIPMENT)).thenReturn(itemContainer);
+        when(itemContainer.getItems()).thenReturn(new Item[]{});
+
+        prayerPlugin.onItemContainerChanged(new ItemContainerChanged(InventoryID.EQUIPMENT.getId(), itemContainer));
+        String actualString = prayerPlugin.getEstimatedTimeRemaining(true);
+
+        Assert.assertEquals(expectedString, actualString);
+    }
+}

--- a/runelite-client/src/test/java/net/runelite/client/plugins/prayer/PrayerPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/prayer/PrayerPluginTest.java
@@ -1,3 +1,28 @@
+/*
+ * Copyright (c) 2017, Adam <Adam@sigterm.info>
+ * Copyright (c) 2018, Raqes <j.raqes@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package net.runelite.client.plugins.prayer;
 
 import com.google.inject.Guice;

--- a/runelite-client/src/test/java/net/runelite/client/plugins/prayer/PrayerPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/prayer/PrayerPluginTest.java
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) 2017, Adam <Adam@sigterm.info>
- * Copyright (c) 2018, Raqes <j.raqes@gmail.com>
+ * Copyright (c) 2020, Landy Chan <https://github.com/landychan>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/runelite-client/src/test/java/net/runelite/client/plugins/prayer/PrayerPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/prayer/PrayerPluginTest.java
@@ -52,7 +52,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
-public class PrayerPluginTest {
+public class PrayerPluginTest
+{
 
     @Inject
     private PrayerPlugin prayerPlugin;
@@ -92,7 +93,8 @@ public class PrayerPluginTest {
     }
 
     @Test
-    public void testGetEstimatedTimeRemainingOverOneHour() {
+    public void testGetEstimatedTimeRemainingOverOneHour()
+    {
 
         String expectedString = "1:19:12";
 
@@ -117,7 +119,8 @@ public class PrayerPluginTest {
     }
 
     @Test
-    public void testGetEstimatedTimeRemainingUnderOneHour() {
+    public void testGetEstimatedTimeRemainingUnderOneHour()
+    {
 
         String expectedString = "29:42";
 
@@ -135,7 +138,8 @@ public class PrayerPluginTest {
     }
 
     @Test
-    public void testGetEstimatedTimeRemainingFormatForOrbUnderOneHour() {
+    public void testGetEstimatedTimeRemainingFormatForOrbUnderOneHour()
+    {
 
         String expectedString = "29m";
 
@@ -153,7 +157,8 @@ public class PrayerPluginTest {
     }
 
     @Test
-    public void testGetEstimatedTimeRemainingFormatForOrbOverOneHour() {
+    public void testGetEstimatedTimeRemainingFormatForOrbOverOneHour()
+    {
 
         String expectedString = "79m";
 
@@ -176,4 +181,5 @@ public class PrayerPluginTest {
 
         Assert.assertEquals(expectedString, actualString);
     }
+
 }

--- a/runelite-client/src/test/java/net/runelite/client/plugins/prayer/PrayerPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/prayer/PrayerPluginTest.java
@@ -28,7 +28,15 @@ package net.runelite.client.plugins.prayer;
 import com.google.inject.Guice;
 import com.google.inject.testing.fieldbinder.Bind;
 import com.google.inject.testing.fieldbinder.BoundFieldModule;
-import net.runelite.api.*;
+import java.util.concurrent.ScheduledExecutorService;
+import javax.inject.Inject;
+import net.runelite.api.Client;
+import net.runelite.api.EquipmentInventorySlot;
+import net.runelite.api.InventoryID;
+import net.runelite.api.Item;
+import net.runelite.api.ItemContainer;
+import net.runelite.api.Prayer;
+import net.runelite.api.Skill;
 import net.runelite.api.events.ItemContainerChanged;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.game.SpriteManager;
@@ -36,20 +44,16 @@ import net.runelite.client.ui.overlay.OverlayManager;
 import net.runelite.client.ui.overlay.infobox.InfoBoxManager;
 import net.runelite.http.api.item.ItemEquipmentStats;
 import net.runelite.http.api.item.ItemStats;
-import org.junit.Assert;
+import static org.junit.Assert.assertEquals;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
-
-import javax.inject.Inject;
-import java.util.concurrent.ScheduledExecutorService;
-
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
+import org.mockito.Mock;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class PrayerPluginTest
@@ -95,9 +99,6 @@ public class PrayerPluginTest
 	@Test
 	public void testGetEstimatedTimeRemainingOverOneHour()
 	{
-
-		String expectedString = "1:19:12";
-
 		ItemStats itemStats = new ItemStats(false, true, 1, 8,
 			ItemEquipmentStats.builder()
 				.slot(EquipmentInventorySlot.WEAPON.getSlotIdx())
@@ -109,21 +110,18 @@ public class PrayerPluginTest
 		when(client.isPrayerActive(Prayer.PRESERVE)).thenReturn(true);
 		when(client.getBoostedSkillLevel(Skill.PRAYER)).thenReturn(99);
 		when(client.getItemContainer(InventoryID.EQUIPMENT)).thenReturn(itemContainer);
-		when(itemContainer.getItems()).thenReturn(new Item[]{new Item(ItemID.TWISTED_BOW, 1)});
+		when(itemContainer.getItems()).thenReturn(new Item[]{new Item(99999, 1)});
 		when(itemManager.getItemStats(anyInt(), anyBoolean())).thenReturn(itemStats);
 
 		prayerPlugin.onItemContainerChanged(new ItemContainerChanged(InventoryID.EQUIPMENT.getId(), itemContainer));
 		String actualString = prayerPlugin.getEstimatedTimeRemaining(false);
 
-		Assert.assertEquals(expectedString, actualString);
+		assertEquals("1:19:12", actualString);
 	}
 
 	@Test
 	public void testGetEstimatedTimeRemainingUnderOneHour()
 	{
-
-		String expectedString = "29:42";
-
 		ItemContainer itemContainer = mock(ItemContainer.class);
 
 		when(client.isPrayerActive(Prayer.PRESERVE)).thenReturn(true);
@@ -134,15 +132,12 @@ public class PrayerPluginTest
 		prayerPlugin.onItemContainerChanged(new ItemContainerChanged(InventoryID.EQUIPMENT.getId(), itemContainer));
 		String actualString = prayerPlugin.getEstimatedTimeRemaining(false);
 
-		Assert.assertEquals(expectedString, actualString);
+		assertEquals("29:42", actualString);
 	}
 
 	@Test
 	public void testGetEstimatedTimeRemainingFormatForOrbUnderOneHour()
 	{
-
-		String expectedString = "29m";
-
 		ItemContainer itemContainer = mock(ItemContainer.class);
 
 		when(client.isPrayerActive(Prayer.PRESERVE)).thenReturn(true);
@@ -153,15 +148,12 @@ public class PrayerPluginTest
 		prayerPlugin.onItemContainerChanged(new ItemContainerChanged(InventoryID.EQUIPMENT.getId(), itemContainer));
 		String actualString = prayerPlugin.getEstimatedTimeRemaining(true);
 
-		Assert.assertEquals(expectedString, actualString);
+		assertEquals("29m", actualString);
 	}
 
 	@Test
 	public void testGetEstimatedTimeRemainingFormatForOrbOverOneHour()
 	{
-
-		String expectedString = "79m";
-
 		ItemStats itemStats = new ItemStats(false, true, 1, 8,
 			ItemEquipmentStats.builder()
 				.slot(EquipmentInventorySlot.WEAPON.getSlotIdx())
@@ -173,13 +165,13 @@ public class PrayerPluginTest
 		when(client.isPrayerActive(Prayer.PRESERVE)).thenReturn(true);
 		when(client.getBoostedSkillLevel(Skill.PRAYER)).thenReturn(99);
 		when(client.getItemContainer(InventoryID.EQUIPMENT)).thenReturn(itemContainer);
-		when(itemContainer.getItems()).thenReturn(new Item[]{new Item(ItemID.TWISTED_BOW, 1)});
+		when(itemContainer.getItems()).thenReturn(new Item[]{new Item(99999, 1)});
 		when(itemManager.getItemStats(anyInt(), anyBoolean())).thenReturn(itemStats);
 
 		prayerPlugin.onItemContainerChanged(new ItemContainerChanged(InventoryID.EQUIPMENT.getId(), itemContainer));
 		String actualString = prayerPlugin.getEstimatedTimeRemaining(true);
 
-		Assert.assertEquals(expectedString, actualString);
+		assertEquals("79m", actualString);
 	}
 
 }

--- a/runelite-client/src/test/java/net/runelite/client/plugins/prayer/PrayerPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/prayer/PrayerPluginTest.java
@@ -55,131 +55,131 @@ import static org.mockito.Mockito.when;
 public class PrayerPluginTest
 {
 
-    @Inject
-    private PrayerPlugin prayerPlugin;
+	@Inject
+	private PrayerPlugin prayerPlugin;
 
-    @Mock
-    @Bind
-    private Client client;
+	@Mock
+	@Bind
+	private Client client;
 
-    @Mock
-    @Bind
-    private PrayerConfig config;
+	@Mock
+	@Bind
+	private PrayerConfig config;
 
-    @Mock
-    @Bind
-    private OverlayManager overlayManager;
+	@Mock
+	@Bind
+	private OverlayManager overlayManager;
 
-    @Mock
-    @Bind
-    private InfoBoxManager infoBoxManager;
+	@Mock
+	@Bind
+	private InfoBoxManager infoBoxManager;
 
-    @Mock
-    @Bind
-    private SpriteManager spriteManager;
+	@Mock
+	@Bind
+	private SpriteManager spriteManager;
 
-    @Mock
-    @Bind
-    private ScheduledExecutorService executor;
+	@Mock
+	@Bind
+	private ScheduledExecutorService executor;
 
-    @Mock
-    @Bind
-    private ItemManager itemManager;
+	@Mock
+	@Bind
+	private ItemManager itemManager;
 
-    @Before
-    public void before()
-    {
-        Guice.createInjector(BoundFieldModule.of(this)).injectMembers(this);
-    }
+	@Before
+	public void before()
+	{
+		Guice.createInjector(BoundFieldModule.of(this)).injectMembers(this);
+	}
 
-    @Test
-    public void testGetEstimatedTimeRemainingOverOneHour()
-    {
+	@Test
+	public void testGetEstimatedTimeRemainingOverOneHour()
+	{
 
-        String expectedString = "1:19:12";
+		String expectedString = "1:19:12";
 
-        ItemStats itemStats = new ItemStats(false, true, 1, 8,
-                ItemEquipmentStats.builder()
-                        .slot(EquipmentInventorySlot.WEAPON.getSlotIdx())
-                        .prayer(50)
-                        .build());
+		ItemStats itemStats = new ItemStats(false, true, 1, 8,
+			ItemEquipmentStats.builder()
+				.slot(EquipmentInventorySlot.WEAPON.getSlotIdx())
+				.prayer(50)
+				.build());
 
-        ItemContainer itemContainer = mock(ItemContainer.class);
+		ItemContainer itemContainer = mock(ItemContainer.class);
 
-        when(client.isPrayerActive(Prayer.PRESERVE)).thenReturn(true);
-        when(client.getBoostedSkillLevel(Skill.PRAYER)).thenReturn(99);
-        when(client.getItemContainer(InventoryID.EQUIPMENT)).thenReturn(itemContainer);
-        when(itemContainer.getItems()).thenReturn(new Item[]{ new Item(ItemID.TWISTED_BOW, 1)});
-        when(itemManager.getItemStats(anyInt(), anyBoolean())).thenReturn(itemStats);
+		when(client.isPrayerActive(Prayer.PRESERVE)).thenReturn(true);
+		when(client.getBoostedSkillLevel(Skill.PRAYER)).thenReturn(99);
+		when(client.getItemContainer(InventoryID.EQUIPMENT)).thenReturn(itemContainer);
+		when(itemContainer.getItems()).thenReturn(new Item[]{new Item(ItemID.TWISTED_BOW, 1)});
+		when(itemManager.getItemStats(anyInt(), anyBoolean())).thenReturn(itemStats);
 
-        prayerPlugin.onItemContainerChanged(new ItemContainerChanged(InventoryID.EQUIPMENT.getId(), itemContainer));
-        String actualString = prayerPlugin.getEstimatedTimeRemaining(false);
+		prayerPlugin.onItemContainerChanged(new ItemContainerChanged(InventoryID.EQUIPMENT.getId(), itemContainer));
+		String actualString = prayerPlugin.getEstimatedTimeRemaining(false);
 
-        Assert.assertEquals(expectedString, actualString);
-    }
+		Assert.assertEquals(expectedString, actualString);
+	}
 
-    @Test
-    public void testGetEstimatedTimeRemainingUnderOneHour()
-    {
+	@Test
+	public void testGetEstimatedTimeRemainingUnderOneHour()
+	{
 
-        String expectedString = "29:42";
+		String expectedString = "29:42";
 
-        ItemContainer itemContainer = mock(ItemContainer.class);
+		ItemContainer itemContainer = mock(ItemContainer.class);
 
-        when(client.isPrayerActive(Prayer.PRESERVE)).thenReturn(true);
-        when(client.getBoostedSkillLevel(Skill.PRAYER)).thenReturn(99);
-        when(client.getItemContainer(InventoryID.EQUIPMENT)).thenReturn(itemContainer);
-        when(itemContainer.getItems()).thenReturn(new Item[]{});
+		when(client.isPrayerActive(Prayer.PRESERVE)).thenReturn(true);
+		when(client.getBoostedSkillLevel(Skill.PRAYER)).thenReturn(99);
+		when(client.getItemContainer(InventoryID.EQUIPMENT)).thenReturn(itemContainer);
+		when(itemContainer.getItems()).thenReturn(new Item[]{});
 
-        prayerPlugin.onItemContainerChanged(new ItemContainerChanged(InventoryID.EQUIPMENT.getId(), itemContainer));
-        String actualString = prayerPlugin.getEstimatedTimeRemaining(false);
+		prayerPlugin.onItemContainerChanged(new ItemContainerChanged(InventoryID.EQUIPMENT.getId(), itemContainer));
+		String actualString = prayerPlugin.getEstimatedTimeRemaining(false);
 
-        Assert.assertEquals(expectedString, actualString);
-    }
+		Assert.assertEquals(expectedString, actualString);
+	}
 
-    @Test
-    public void testGetEstimatedTimeRemainingFormatForOrbUnderOneHour()
-    {
+	@Test
+	public void testGetEstimatedTimeRemainingFormatForOrbUnderOneHour()
+	{
 
-        String expectedString = "29m";
+		String expectedString = "29m";
 
-        ItemContainer itemContainer = mock(ItemContainer.class);
+		ItemContainer itemContainer = mock(ItemContainer.class);
 
-        when(client.isPrayerActive(Prayer.PRESERVE)).thenReturn(true);
-        when(client.getBoostedSkillLevel(Skill.PRAYER)).thenReturn(99);
-        when(client.getItemContainer(InventoryID.EQUIPMENT)).thenReturn(itemContainer);
-        when(itemContainer.getItems()).thenReturn(new Item[]{});
+		when(client.isPrayerActive(Prayer.PRESERVE)).thenReturn(true);
+		when(client.getBoostedSkillLevel(Skill.PRAYER)).thenReturn(99);
+		when(client.getItemContainer(InventoryID.EQUIPMENT)).thenReturn(itemContainer);
+		when(itemContainer.getItems()).thenReturn(new Item[]{});
 
-        prayerPlugin.onItemContainerChanged(new ItemContainerChanged(InventoryID.EQUIPMENT.getId(), itemContainer));
-        String actualString = prayerPlugin.getEstimatedTimeRemaining(true);
+		prayerPlugin.onItemContainerChanged(new ItemContainerChanged(InventoryID.EQUIPMENT.getId(), itemContainer));
+		String actualString = prayerPlugin.getEstimatedTimeRemaining(true);
 
-        Assert.assertEquals(expectedString, actualString);
-    }
+		Assert.assertEquals(expectedString, actualString);
+	}
 
-    @Test
-    public void testGetEstimatedTimeRemainingFormatForOrbOverOneHour()
-    {
+	@Test
+	public void testGetEstimatedTimeRemainingFormatForOrbOverOneHour()
+	{
 
-        String expectedString = "79m";
+		String expectedString = "79m";
 
-        ItemStats itemStats = new ItemStats(false, true, 1, 8,
-                ItemEquipmentStats.builder()
-                        .slot(EquipmentInventorySlot.WEAPON.getSlotIdx())
-                        .prayer(50)
-                        .build());
+		ItemStats itemStats = new ItemStats(false, true, 1, 8,
+			ItemEquipmentStats.builder()
+				.slot(EquipmentInventorySlot.WEAPON.getSlotIdx())
+				.prayer(50)
+				.build());
 
-        ItemContainer itemContainer = mock(ItemContainer.class);
+		ItemContainer itemContainer = mock(ItemContainer.class);
 
-        when(client.isPrayerActive(Prayer.PRESERVE)).thenReturn(true);
-        when(client.getBoostedSkillLevel(Skill.PRAYER)).thenReturn(99);
-        when(client.getItemContainer(InventoryID.EQUIPMENT)).thenReturn(itemContainer);
-        when(itemContainer.getItems()).thenReturn(new Item[]{ new Item(ItemID.TWISTED_BOW, 1)});
-        when(itemManager.getItemStats(anyInt(), anyBoolean())).thenReturn(itemStats);
+		when(client.isPrayerActive(Prayer.PRESERVE)).thenReturn(true);
+		when(client.getBoostedSkillLevel(Skill.PRAYER)).thenReturn(99);
+		when(client.getItemContainer(InventoryID.EQUIPMENT)).thenReturn(itemContainer);
+		when(itemContainer.getItems()).thenReturn(new Item[]{new Item(ItemID.TWISTED_BOW, 1)});
+		when(itemManager.getItemStats(anyInt(), anyBoolean())).thenReturn(itemStats);
 
-        prayerPlugin.onItemContainerChanged(new ItemContainerChanged(InventoryID.EQUIPMENT.getId(), itemContainer));
-        String actualString = prayerPlugin.getEstimatedTimeRemaining(true);
+		prayerPlugin.onItemContainerChanged(new ItemContainerChanged(InventoryID.EQUIPMENT.getId(), itemContainer));
+		String actualString = prayerPlugin.getEstimatedTimeRemaining(true);
 
-        Assert.assertEquals(expectedString, actualString);
-    }
+		Assert.assertEquals(expectedString, actualString);
+	}
 
 }

--- a/runelite-client/src/test/java/net/runelite/client/plugins/prayer/PrayerPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/prayer/PrayerPluginTest.java
@@ -91,7 +91,6 @@ public class PrayerPluginTest {
         Assert.assertEquals(expectedString, actualString);
     }
 
-
     @Test
     public void testGetEstimatedTimeRemainingUnderOneHour() {
 
@@ -111,7 +110,7 @@ public class PrayerPluginTest {
     }
 
     @Test
-    public void testGetEstimatedTimeRemainingFormatForOrb() {
+    public void testGetEstimatedTimeRemainingFormatForOrbUnderOneHour() {
 
         String expectedString = "29m";
 
@@ -121,6 +120,31 @@ public class PrayerPluginTest {
         when(client.getBoostedSkillLevel(Skill.PRAYER)).thenReturn(99);
         when(client.getItemContainer(InventoryID.EQUIPMENT)).thenReturn(itemContainer);
         when(itemContainer.getItems()).thenReturn(new Item[]{});
+
+        prayerPlugin.onItemContainerChanged(new ItemContainerChanged(InventoryID.EQUIPMENT.getId(), itemContainer));
+        String actualString = prayerPlugin.getEstimatedTimeRemaining(true);
+
+        Assert.assertEquals(expectedString, actualString);
+    }
+
+    @Test
+    public void testGetEstimatedTimeRemainingFormatForOrbOverOneHour() {
+
+        String expectedString = "79m";
+
+        ItemStats itemStats = new ItemStats(false, true, 1, 8,
+                ItemEquipmentStats.builder()
+                        .slot(EquipmentInventorySlot.WEAPON.getSlotIdx())
+                        .prayer(50)
+                        .build());
+
+        ItemContainer itemContainer = mock(ItemContainer.class);
+
+        when(client.isPrayerActive(Prayer.PRESERVE)).thenReturn(true);
+        when(client.getBoostedSkillLevel(Skill.PRAYER)).thenReturn(99);
+        when(client.getItemContainer(InventoryID.EQUIPMENT)).thenReturn(itemContainer);
+        when(itemContainer.getItems()).thenReturn(new Item[]{ new Item(ItemID.TWISTED_BOW, 1)});
+        when(itemManager.getItemStats(anyInt(), anyBoolean())).thenReturn(itemStats);
 
         prayerPlugin.onItemContainerChanged(new ItemContainerChanged(InventoryID.EQUIPMENT.getId(), itemContainer));
         String actualString = prayerPlugin.getEstimatedTimeRemaining(true);


### PR DESCRIPTION
The current implementation of calculating the time left on prayer only shows minutes remaining. When the time left on prayer was over an hour, it would cut off the hour and only show the minutes left.

I ran into this when I wore high prayer bonus (50+) and used a slow draining prayer (Preserve) with a high Prayer level.

I also added tests for the prayer text formatting :)