### PR TITLE
Fix NPE on resetting configs with null default value

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/config/ConfigManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/ConfigManager.java
@@ -660,6 +660,7 @@ public class ConfigManager
 		return str;
 	}
 
+	@Nullable
 	static String objectToString(Object object)
 	{
 		if (object instanceof Color)
@@ -703,7 +704,7 @@ public class ConfigManager
 		{
 			return Long.toString(((Duration) object).toMillis());
 		}
-		return object.toString();
+		return object == null ? null : object.toString();
 	}
 
 	@Subscribe(priority = 100)

--- a/runelite-client/src/test/java/net/runelite/client/config/ConfigManagerTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/config/ConfigManagerTest.java
@@ -118,6 +118,18 @@ public class ConfigManagerTest
 
 		TestConfig conf = manager.getConfig(TestConfig.class);
 		ConfigDescriptor descriptor = manager.getConfigDescriptor(conf);
-		Assert.assertEquals(1, descriptor.getItems().size());
+		Assert.assertEquals(2, descriptor.getItems().size());
+	}
+
+	@Test
+	public void testResetNullDefaultConfig()
+	{
+		TestConfig conf = manager.getConfig(TestConfig.class);
+		ConfigDescriptor descriptor = manager.getConfigDescriptor(conf);
+		conf.nullDefaultKey("new value");
+
+		manager.unsetConfiguration(descriptor.getGroup().value(), "nullDefaultKey");
+		manager.setDefaultConfiguration(conf, false);
+		Assert.assertNull(conf.nullDefaultKey());
 	}
 }

--- a/runelite-client/src/test/java/net/runelite/client/config/TestConfig.java
+++ b/runelite-client/src/test/java/net/runelite/client/config/TestConfig.java
@@ -43,4 +43,21 @@ public interface TestConfig extends Config
 		description = "value"
 	)
 	void key(String key);
+
+	@ConfigItem(
+			keyName = "nullDefaultKey",
+			name = "Key Name",
+			description = "value"
+	)
+	void nullDefaultKey(String key);
+
+	@ConfigItem(
+			keyName = "nullDefaultKey",
+			name = "Key Name",
+			description = "value"
+	)
+	default String nullDefaultKey()
+	{
+		return null;
+	}
 }


### PR DESCRIPTION
None of the @Alpha default methods currently return null, so I changed the one in CannonConfig.java to replicate the exception.  Default method returning null behaves as though there is no default method, in both cases of individual reset and plugin-wide reset.

Fixes #12226