### PR TITLE
Add bird nest to loot tracker plugin.

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
@@ -188,7 +188,7 @@ public class LootTrackerPlugin extends Plugin
 
 	private static final Pattern PICKPOCKET_REGEX = Pattern.compile("You pick (the )?(?<target>.+)'s? pocket.*");
 
-	private static final Pattern BIRDNEST_REGEX = Pattern.compile("You take (a|an) (.+) out of the bird's nest\\.");
+	private static final Pattern BIRDNEST_REGEX = Pattern.compile("You take an? (.+) out of the bird's nest\\.");
 	private static final String BIRDNEST_EVENT = "Bird nest";
 
 	/*

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
@@ -188,8 +188,8 @@ public class LootTrackerPlugin extends Plugin
 
 	private static final Pattern PICKPOCKET_REGEX = Pattern.compile("You pick (the )?(?<target>.+)'s? pocket.*");
 
-	private static final Pattern BIRDNEST_REGEX = Pattern.compile("You take an? (.+) out of the bird's nest\\.");
 	private static final String BIRDNEST_EVENT = "Bird nest";
+	private static final Set<Integer> BIRDNEST_IDS = ImmutableSet.of(ItemID.BIRD_NEST_5074, ItemID.BIRD_NEST_22798, ItemID.CLUE_NEST_EASY, ItemID.CLUE_NEST_MEDIUM, ItemID.CLUE_NEST_HARD, ItemID.CLUE_NEST_ELITE, ItemID.CLUE_NEST_BEGINNER);
 
 	/*
 	 * This map is used when a pickpocket target has a different name in the chat message than their in-game name.
@@ -661,16 +661,6 @@ public class LootTrackerPlugin extends Plugin
 			return;
 		}
 
-		final Matcher birdNestMatcher = BIRDNEST_REGEX.matcher(message);
-		if (birdNestMatcher.matches())
-		{
-			eventType = BIRDNEST_EVENT;
-			lootRecordType = LootRecordType.EVENT;
-
-			takeInventorySnapshot();
-			return;
-		}
-
 		// Check if message is for a clue scroll reward
 		final Matcher m = CLUE_SCROLL_PATTERN.matcher(Text.removeTags(message));
 		if (m.find())
@@ -760,6 +750,13 @@ public class LootTrackerPlugin extends Plugin
 		if (event.getMenuOption().equals("Open") && SHADE_CHEST_OBJECTS.containsKey(event.getId()))
 		{
 			eventType = SHADE_CHEST_OBJECTS.get(event.getId());
+			lootRecordType = LootRecordType.EVENT;
+			takeInventorySnapshot();
+		}
+
+		if (event.getMenuOption().equals("Search") && BIRDNEST_IDS.contains(event.getId()))
+		{
+			eventType = BIRDNEST_EVENT;
 			lootRecordType = LootRecordType.EVENT;
 			takeInventorySnapshot();
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
@@ -728,6 +728,7 @@ public class LootTrackerPlugin extends Plugin
 			|| HESPORI_EVENT.equals(eventType)
 			|| SEEDPACK_EVENT.equals(eventType)
 			|| CASKET_EVENT.equals(eventType)
+			|| BIRDNEST_EVENT.equals(eventType)
 			|| lootRecordType == LootRecordType.PICKPOCKET)
 		{
 			WorldPoint playerLocation = client.getLocalPlayer().getWorldLocation();

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
@@ -189,7 +189,7 @@ public class LootTrackerPlugin extends Plugin
 	private static final Pattern PICKPOCKET_REGEX = Pattern.compile("You pick (the )?(?<target>.+)'s? pocket.*");
 
 	private static final String BIRDNEST_EVENT = "Bird nest";
-	private static final Set<Integer> BIRDNEST_IDS = ImmutableSet.of(ItemID.BIRD_NEST_5074, ItemID.BIRD_NEST_22798, ItemID.CLUE_NEST_EASY, ItemID.CLUE_NEST_MEDIUM, ItemID.CLUE_NEST_HARD, ItemID.CLUE_NEST_ELITE, ItemID.CLUE_NEST_BEGINNER);
+	private static final Set<Integer> BIRDNEST_IDS = ImmutableSet.of(ItemID.BIRD_NEST, ItemID.BIRD_NEST_5071, ItemID.BIRD_NEST_5072, ItemID.BIRD_NEST_5073, ItemID.BIRD_NEST_5074, ItemID.BIRD_NEST_22798, ItemID.BIRD_NEST_22800);
 
 	/*
 	 * This map is used when a pickpocket target has a different name in the chat message than their in-game name.

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
@@ -188,6 +188,9 @@ public class LootTrackerPlugin extends Plugin
 
 	private static final Pattern PICKPOCKET_REGEX = Pattern.compile("You pick (the )?(?<target>.+)'s? pocket.*");
 
+	private static final Pattern BIRDNEST_REGEX = Pattern.compile("You take (a|an) (.+) out of the bird's nest\\.");
+	private static final String BIRDNEST_EVENT = "Bird nest";
+
 	/*
 	 * This map is used when a pickpocket target has a different name in the chat message than their in-game name.
 	 * Note that if the two NPCs can be found in the same place, there is a chance of race conditions
@@ -653,6 +656,16 @@ public class LootTrackerPlugin extends Plugin
 				eventType = pickpocketTarget;
 				lootRecordType = LootRecordType.PICKPOCKET;
 			}
+
+			takeInventorySnapshot();
+			return;
+		}
+
+		final Matcher birdNestMatcher = BIRDNEST_REGEX.matcher(message);
+		if (birdNestMatcher.matches())
+		{
+			eventType = BIRDNEST_EVENT;
+			lootRecordType = LootRecordType.EVENT;
 
 			takeInventorySnapshot();
 			return;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
@@ -189,7 +189,7 @@ public class LootTrackerPlugin extends Plugin
 	private static final Pattern PICKPOCKET_REGEX = Pattern.compile("You pick (the )?(?<target>.+)'s? pocket.*");
 
 	private static final String BIRDNEST_EVENT = "Bird nest";
-	private static final Set<Integer> BIRDNEST_IDS = ImmutableSet.of(ItemID.BIRD_NEST, ItemID.BIRD_NEST_5071, ItemID.BIRD_NEST_5072, ItemID.BIRD_NEST_5073, ItemID.BIRD_NEST_5074, ItemID.BIRD_NEST_22798, ItemID.BIRD_NEST_22800);
+	private static final Set<Integer> BIRDNEST_IDS = ImmutableSet.of(ItemID.BIRD_NEST, ItemID.BIRD_NEST_5071, ItemID.BIRD_NEST_5072, ItemID.BIRD_NEST_5073, ItemID.BIRD_NEST_5074, ItemID.BIRD_NEST_7413, ItemID.BIRD_NEST_13653, ItemID.BIRD_NEST_22798, ItemID.BIRD_NEST_22800);
 
 	/*
 	 * This map is used when a pickpocket target has a different name in the chat message than their in-game name.


### PR DESCRIPTION
This will track seed bird nests in the loot tracker plugin and ultimately get the data sent to the wiki to further improve their data sets. Inspired from JihadSquad's sheet where he asks people to send him seed data to improve his rates.