### PR TITLE
agility plugin: increase number of laps for laps per hour calculation

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/agility/AgilitySession.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/agility/AgilitySession.java
@@ -41,7 +41,7 @@ class AgilitySession
 	private Instant lastLapCompleted;
 	private int totalLaps;
 	private int lapsTillGoal;
-	private final EvictingQueue<Duration> lastLapTimes = EvictingQueue.create(10);
+	private final EvictingQueue<Duration> lastLapTimes = EvictingQueue.create(30);
 	private int lapsPerHour;
 
 	AgilitySession(Courses course)


### PR DESCRIPTION
This commit increases the number of laps used to calculate laps per hour
from 10 to 30.
Resolves: #12125