### PR TITLE
agility: Fix prif portal highlighting

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/agility/AgilityOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/agility/AgilityOverlay.java
@@ -109,9 +109,16 @@ class AgilityOverlay extends Overlay
 						configColor = config.getMarkColor();
 					}
 
-					if (config.highlightPortals() && Obstacles.PORTAL_OBSTACLE_IDS.contains(object.getId()))
+					if (Obstacles.PORTAL_OBSTACLE_IDS.contains(object.getId()))
 					{
-						configColor = config.getPortalsColor();
+						if (config.highlightPortals())
+						{
+							configColor = config.getPortalsColor();
+						}
+						else
+						{
+							return;
+						}
 					}
 
 					if (objectClickbox.contains(mousePosition.getX(), mousePosition.getY()))


### PR DESCRIPTION
Previously they would be highlighted with graphics.setColor(configColor) when config.highlightPortals was set to false.

<img width="356" alt="Screen Shot 2020-08-01 at 7 05 17 PM" src="https://user-images.githubusercontent.com/54762282/89111981-cfe7a080-d42a-11ea-9934-1a41841e2140.png">
 
Closes #12269 