### PR TITLE
Adding option to quick hop between favorites

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldHopperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldHopperConfig.java
@@ -82,10 +82,21 @@ public interface WorldHopperConfig extends Config
 	}
 
 	@ConfigItem(
+			keyName = "favoriteHop",
+			name = "Quick-hop Favorites",
+			description = "Quick-hop between favorite Worlds instead of normal quick-hop",
+			position = 4
+	)
+	default boolean favoriteHop()
+	{
+		return false;
+	}
+
+	@ConfigItem(
 		keyName = "showSidebar",
 		name = "Show world switcher sidebar",
 		description = "Show sidebar containing all worlds that mimics in-game interface",
-		position = 4
+		position = 5
 	)
 	default boolean showSidebar()
 	{
@@ -96,7 +107,7 @@ public interface WorldHopperConfig extends Config
 		keyName = "ping",
 		name = "Show world ping",
 		description = "Shows ping to each game world",
-		position = 5
+		position = 6
 	)
 	default boolean ping()
 	{
@@ -107,7 +118,7 @@ public interface WorldHopperConfig extends Config
 		keyName = "showMessage",
 		name = "Show world hop message in chat",
 		description = "Shows what world is being hopped to in the chat",
-		position = 6
+		position = 7
 	)
 	default boolean showWorldHopMessage()
 	{
@@ -118,7 +129,7 @@ public interface WorldHopperConfig extends Config
 		keyName = "menuOption",
 		name = "Show Hop-to menu option",
 		description = "Adds Hop-to menu option to the friends list and friends chat members list",
-		position = 7
+		position = 8
 	)
 	default boolean menuOption()
 	{
@@ -129,7 +140,7 @@ public interface WorldHopperConfig extends Config
 		keyName = "subscriptionFilter",
 		name = "Show subscription types",
 		description = "Only show free worlds, member worlds, or both types of worlds in sidebar",
-		position = 8
+		position = 9
 	)
 	default SubscriptionFilterMode subscriptionFilter()
 	{
@@ -140,7 +151,7 @@ public interface WorldHopperConfig extends Config
 		keyName = "displayPing",
 		name = "Display current ping",
 		description = "Displays ping to current game world",
-		position = 9
+		position = 10
 	)
 	default boolean displayPing()
 	{


### PR DESCRIPTION
Closes #12238

Adding config option to quick-hop between worlds marked as "favorite" instead of incrementing or decrementing by 1 for quick hop