### PR TITLE
Barrows prayer infobox fix

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/barrows/BarrowsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/barrows/BarrowsPlugin.java
@@ -77,7 +77,6 @@ public class BarrowsPlugin extends Plugin
 	private static final int CRYPT_REGION_ID = 14231;
 
 	private LoopTimer barrowsPrayerDrainTimer;
-	private boolean wasInCrypt = false;
 
 	@Getter
 	private Widget puzzleAnswer;
@@ -128,7 +127,6 @@ public class BarrowsPlugin extends Plugin
 		overlayManager.remove(barrowsOverlay);
 		overlayManager.remove(brotherOverlay);
 		puzzleAnswer = null;
-		wasInCrypt = false;
 		stopPrayerDrainTimer();
 
 		// Restore widgets
@@ -157,18 +155,14 @@ public class BarrowsPlugin extends Plugin
 	@Subscribe
 	public void onGameStateChanged(GameStateChanged event)
 	{
-		if (event.getGameState() == GameState.LOADING)
-		{
-			wasInCrypt = isInCrypt();
-		}
-		else if (event.getGameState() == GameState.LOGGED_IN)
+		if (event.getGameState() == GameState.LOGGED_IN)
 		{
 			boolean isInCrypt = isInCrypt();
-			if (wasInCrypt && !isInCrypt)
+			if (!isInCrypt && barrowsPrayerDrainTimer != null)
 			{
 				stopPrayerDrainTimer();
 			}
-			else if (!wasInCrypt && isInCrypt)
+			else if (isInCrypt && barrowsPrayerDrainTimer == null)
 			{
 				startPrayerDrainTimer();
 			}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/barrows/BarrowsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/barrows/BarrowsPlugin.java
@@ -233,6 +233,10 @@ public class BarrowsPlugin extends Plugin
 	{
 		if (config.showPrayerDrainTimer())
 		{
+			if (barrowsPrayerDrainTimer != null)
+			{
+				stopPrayerDrainTimer();
+			}
 			final LoopTimer loopTimer = new LoopTimer(
 				PRAYER_DRAIN_INTERVAL_MS,
 				ChronoUnit.MILLIS,


### PR DESCRIPTION
I believe the problem is because the checking for when to add/remove the prayer infobox can only be done on the single gamestate change of going into or out of the crypt.  This can lead to some sort of condition where it somehow did not satisfy the requirement to remove an infobox when it should have and then never can until another one is added, causing the reference to the original infobox to be lost.  

The first commit checks that when adding a timer, if one is already present, to remove it before adding a new one to prevent loss of references.

The second commit changes the logic of determining when to add or remove an infobox to every game state change and only caring about where the player currently is and the current status of the prayer infobox.  

I believe with this second commit the first one becomes obsolete but i left both of them in there so that if you wish to not mess with the current logic i can just drop the second commit and still have the fix for lost references in the PR

this should fix #10902