### PR TITLE
mousehighlight: make "drop" not show when interface tooltips are off

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/mousehighlight/MouseHighlightOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/mousehighlight/MouseHighlightOverlay.java
@@ -61,6 +61,7 @@ class MouseHighlightOverlay extends Overlay
 		MenuAction.ITEM_FOURTH_OPTION,
 		MenuAction.ITEM_FIFTH_OPTION,
 		MenuAction.ITEM_USE,
+		MenuAction.ITEM_DROP,
 		MenuAction.WIDGET_FIRST_OPTION,
 		MenuAction.WIDGET_SECOND_OPTION,
 		MenuAction.WIDGET_THIRD_OPTION,


### PR DESCRIPTION
Currently, since Drop isn't part of the known Widget Menu Actions list, it'll skip over checking if the user wants to display tooltips on the interface.

Thanks to `neekz` on Discord for reporting this.