### PR TITLE
timetracking: add configuration for displaying time in 12 hour format

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/OverviewTabPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/OverviewTabPanel.java
@@ -146,7 +146,7 @@ class OverviewTabPanel extends TabContentPanel
 				}
 				else
 				{
-					panel.updateStatus("Ready " + getFormattedEstimate(duration, config.estimateRelative()), Color.GRAY);
+					panel.updateStatus("Ready " + getFormattedEstimate(duration, config.timeFormatMode()), Color.GRAY);
 				}
 				break;
 			}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/TabContentPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/TabContentPanel.java
@@ -26,6 +26,7 @@ package net.runelite.client.plugins.timetracking;
 
 import java.awt.Dimension;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.time.format.TextStyle;
 import java.time.temporal.ChronoUnit;
 import java.util.Locale;
@@ -33,6 +34,9 @@ import javax.swing.JPanel;
 
 public abstract class TabContentPanel extends JPanel
 {
+	private static final DateTimeFormatter DATETIME_FORMATTER_24H = DateTimeFormatter.ofPattern("HH:mm");
+	private static final DateTimeFormatter DATETIME_FORMATTER_12H = DateTimeFormatter.ofPattern("h:mm a");
+
 	/**
 	 * Gets the update interval of this panel, in units of 200 milliseconds
 	 * (the plugin panel checks if its contents should be updated every 200 ms;
@@ -48,9 +52,11 @@ public abstract class TabContentPanel extends JPanel
 		return super.getPreferredSize();
 	}
 
-	public static String getFormattedEstimate(long remainingSeconds, boolean useRelativeTime)
+	public static String getFormattedEstimate(long remainingSeconds, TimeFormatMode mode)
 	{
-		if (useRelativeTime)
+		DateTimeFormatter formatter = getDateTimeFormatter(mode);
+
+		if (formatter == null)
 		{
 			StringBuilder sb = new StringBuilder("in ");
 			long duration = (remainingSeconds + 59) / 60;
@@ -80,8 +86,23 @@ public abstract class TabContentPanel extends JPanel
 			{
 				sb.append(endTime.getDayOfWeek().getDisplayName(TextStyle.FULL, Locale.getDefault())).append(" ");
 			}
-			sb.append(String.format("at %d:%02d", endTime.getHour(), endTime.getMinute()));
+			sb.append("at ");
+			sb.append(formatter.format(endTime));
+
 			return sb.toString();
+		}
+	}
+
+	private static DateTimeFormatter getDateTimeFormatter(TimeFormatMode mode)
+	{
+		switch (mode)
+		{
+			case ABSOLUTE_12H:
+				return DATETIME_FORMATTER_12H;
+			case ABSOLUTE_24H:
+				return DATETIME_FORMATTER_24H;
+			default:
+				return null;
 		}
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/TimeFormatMode.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/TimeFormatMode.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2020, Hydrox6 <ikada@protonmail.ch>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.timetracking;
+
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public enum TimeFormatMode
+{
+	RELATIVE("Relative"),
+	ABSOLUTE_12H("12 Hour"),
+	ABSOLUTE_24H("24 Hour");
+
+	private final String name;
+
+	@Override
+	public String toString()
+	{
+		return name;
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/TimeTrackingConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/TimeTrackingConfig.java
@@ -39,14 +39,14 @@ public interface TimeTrackingConfig extends Config
 	String STOPWATCHES = "stopwatches";
 
 	@ConfigItem(
-		keyName = "estimateRelative",
-		name = "Show relative time",
-		description = "Show amount of time remaining instead of completion time",
+		keyName = "timeFormatMode",
+		name = "Time format",
+		description = "What format to display times in",
 		position = 1
 	)
-	default boolean estimateRelative()
+	default TimeFormatMode timeFormatMode()
 	{
-		return false;
+		return TimeFormatMode.ABSOLUTE_24H;
 	}
 
 	@ConfigItem(

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/farming/FarmingContractInfoBox.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/farming/FarmingContractInfoBox.java
@@ -83,7 +83,7 @@ class FarmingContractInfoBox extends InfoBox
 				break;
 			case IN_PROGRESS:
 				contractDescription = "Ready " + TabContentPanel.getFormattedEstimate(manager.getCompletionTime() - Instant.now().getEpochSecond(),
-					config.estimateRelative());
+					config.timeFormatMode());
 				contractColor = Color.GRAY;
 				break;
 			case EMPTY:

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/farming/FarmingTabPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/farming/FarmingTabPanel.java
@@ -168,7 +168,7 @@ public class FarmingTabPanel extends TabContentPanel
 						}
 						else
 						{
-							panel.getEstimate().setText("Done " + getFormattedEstimate(prediction.getDoneEstimate() - unixNow, config.estimateRelative()));
+							panel.getEstimate().setText("Done " + getFormattedEstimate(prediction.getDoneEstimate() - unixNow, config.timeFormatMode()));
 						}
 						break;
 					case DISEASED:

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/hunter/BirdHouseTabPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/hunter/BirdHouseTabPanel.java
@@ -136,7 +136,7 @@ public class BirdHouseTabPanel extends TabContentPanel
 					else
 					{
 						panel.getProgress().setValue((int) (BirdHouseTracker.BIRD_HOUSE_DURATION - remainingTime));
-						panel.getEstimate().setText("Done " + getFormattedEstimate(remainingTime, config.estimateRelative()));
+						panel.getEstimate().setText("Done " + getFormattedEstimate(remainingTime, config.timeFormatMode()));
 					}
 					break;
 				default:


### PR DESCRIPTION
Closes #4896

Closes #4959
Closes #7449
Closes #7612

I've always assumed that the locale of the OS set the time format before, but I can't find evidence of that. Even if that was the case, relying on the OS screws over those users who want to go against the norm for their locale.

![12](https://user-images.githubusercontent.com/2979691/90064365-93495e00-dce2-11ea-933a-be3fff05b7dc.gif)