### PR TITLE
Rellekka NPCs travel destinations added to menu entry swapper

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -199,6 +199,10 @@ public class MenuEntrySwapperPlugin extends Plugin
 		swap("talk-to", "jatizso", config::swapTravel);
 		swap("talk-to", "neitiznot", config::swapTravel);
 		swap("talk-to", "rellekka", config::swapTravel);
+		swap("talk-to", "ungael", config::swapTravel);
+		swap("talk-to", "pirate's cove", config::swapTravel);
+		swap("talk-to", "waterbirth island", config::swapTravel);
+		swap("talk-to", "miscellania", config::swapTravel);
 		swap("talk-to", "follow", config::swapTravel);
 		swap("talk-to", "transport", config::swapTravel);
 		swap("talk-to", "pay", config::swapPay);


### PR DESCRIPTION
> The ‘Travel’ options for some NPCs in Rellekka will now list the relevant destinations 

https://secure.runescape.com/m=news/a=13/darker-graceful-and-other-changes?oldschool=1

This pull request adds `Ungael`, `Waterbirth Island`, `Pirate's Cove`, and `Miscellania` as menu options that are now toggled by the Travel config in the Menu Entry Swapper plugin.

![image](https://user-images.githubusercontent.com/11140337/90173592-96088980-dd9c-11ea-8f12-17cf6820dbf3.png)

![image](https://user-images.githubusercontent.com/11140337/90174667-41660e00-dd9e-11ea-8d5d-54932ae834eb.png)

![image](https://user-images.githubusercontent.com/11140337/90174826-7b371480-dd9e-11ea-9f1a-30c44ab3e53d.png)

![image](https://user-images.githubusercontent.com/11140337/90174843-825e2280-dd9e-11ea-8d6c-1a05c1fb6aea.png)


