### PR TITLE
screenshot: Fix BA high gamble toggle

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
@@ -242,13 +242,19 @@ public class ScreenshotPlugin extends Plugin
 			String text = client.getWidget(WidgetInfo.DIALOG_SPRITE_TEXT).getText();
 			if (Text.removeTags(text).contains("High level gamble"))
 			{
-				fileName = parseBAHighGambleWidget(text);
-				screenshotSubDir = "BA High Gambles";
+				if (config.screenshotHighGamble())
+				{
+					fileName = parseBAHighGambleWidget(text);
+					screenshotSubDir = "BA High Gambles";
+				}
 			}
 			else
 			{
-				fileName = parseLevelUpWidget(WidgetInfo.DIALOG_SPRITE_TEXT);
-				screenshotSubDir = "Levels";
+				if (config.screenshotLevels())
+				{
+					fileName = parseLevelUpWidget(WidgetInfo.DIALOG_SPRITE_TEXT);
+					screenshotSubDir = "Levels";
+				}
 			}
 		}
 		else if (client.getWidget(WidgetInfo.QUEST_COMPLETED_NAME_TEXT) != null)

--- a/runelite-client/src/test/java/net/runelite/client/plugins/screenshot/ScreenshotPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/screenshot/ScreenshotPluginTest.java
@@ -53,6 +53,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import org.mockito.Mock;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -67,6 +68,7 @@ public class ScreenshotPluginTest
 	private static final String VALUABLE_DROP = "<col=ef1020>Valuable drop: 6 x Bronze arrow (42 coins)</col>";
 	private static final String UNTRADEABLE_DROP = "<col=ef1020>Untradeable drop: Rusty sword";
 	private static final String BA_HIGH_GAMBLE_REWARD = "Raw shark (x 300)!<br>High level gamble count: <col=7f0000>100</col>";
+	private static final String HUNTER_LEVEL_2_TEXT = "<col=000080>Congratulations, you've just advanced a Hunter level.<col=000000><br><br>Your Hunter level is now 2.";
 
 	@Mock
 	@Bind
@@ -233,7 +235,7 @@ public class ScreenshotPluginTest
 		Widget levelChild = mock(Widget.class);
 		when(client.getWidget(eq(DIALOG_SPRITE_TEXT))).thenReturn(levelChild);
 
-		when(levelChild.getText()).thenReturn("<col=000080>Congratulations, you've just advanced a Hunter level.<col=000000><br><br>Your Hunter level is now 2.");
+		when(levelChild.getText()).thenReturn(HUNTER_LEVEL_2_TEXT);
 
 		assertEquals("Hunter(2)", screenshotPlugin.parseLevelUpWidget(DIALOG_SPRITE_TEXT));
 
@@ -264,5 +266,43 @@ public class ScreenshotPluginTest
 	public void testBAHighGambleRewardParsing()
 	{
 		assertEquals("High Gamble(100)", ScreenshotPlugin.parseBAHighGambleWidget(BA_HIGH_GAMBLE_REWARD));
+	}
+
+	@Test
+	public void testLevelUpScreenshotsDisabled()
+	{
+		// Level up dialogs use the same widget interface as BA high gamble results
+		when(screenshotConfig.screenshotLevels()).thenReturn(false);
+		when(screenshotConfig.screenshotHighGamble()).thenReturn(true);
+		Widget dialogChild = mock(Widget.class);
+		when(dialogChild.getText()).thenReturn(HUNTER_LEVEL_2_TEXT);
+		when(client.getWidget(DIALOG_SPRITE_TEXT)).thenReturn(dialogChild);
+
+		WidgetLoaded event = new WidgetLoaded();
+		event.setGroupId(DIALOG_SPRITE_GROUP_ID);
+		screenshotPlugin.onWidgetLoaded(event);
+
+		screenshotPlugin.onGameTick(new GameTick());
+
+		verify(drawManager, times(0)).requestNextFrameListener(any(Consumer.class));
+	}
+
+	@Test
+	public void testBAHighGambleScreenshotsDisabled()
+	{
+		// BA high gamble results use the same widget interface as level up dialogs
+		when(screenshotConfig.screenshotLevels()).thenReturn(true);
+		when(screenshotConfig.screenshotHighGamble()).thenReturn(false);
+		Widget dialogChild = mock(Widget.class);
+		when(dialogChild.getText()).thenReturn(BA_HIGH_GAMBLE_REWARD);
+		when(client.getWidget(DIALOG_SPRITE_TEXT)).thenReturn(dialogChild);
+
+		WidgetLoaded event = new WidgetLoaded();
+		event.setGroupId(DIALOG_SPRITE_GROUP_ID);
+		screenshotPlugin.onWidgetLoaded(event);
+
+		screenshotPlugin.onGameTick(new GameTick());
+
+		verify(drawManager, times(0)).requestNextFrameListener(any(Consumer.class));
 	}
 }


### PR DESCRIPTION
Because both level up dialogs and BA high gambles use the same widget
interface, commit 40f032bede826714ad431f912889f6a527fcd0c9 caused BA
high gambles and some level up dialogs to trigger screenshots if either
config was enabled in the config, as that would set a flag to capture a
screenshot on the next game tick based on the widget text. This commit
adds config checks to the DIALOG_SPRITE_TEXT branch to ensure the
appropriate config flag must be set for a screenshot to be captured.

Fixes #12339