### PR TITLE
Bank Plugin: fixed a NPE when opening and closing the bank too quickly

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/bank/BankPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/bank/BankPlugin.java
@@ -232,23 +232,26 @@ public class BankPlugin extends Plugin
 			final Widget[] children = bankItemContainer.getChildren();
 			long geTotal = 0, haTotal = 0;
 
-			log.debug("Computing bank price of {} items", bankContainer.size());
-
-			// The first components are the bank items, followed by tabs etc. There are always 816 components regardless
-			// of bank size, but we only need to check up to the bank size.
-			for (int i = 0; i < bankContainer.size(); ++i)
+			if (children != null)
 			{
-				Widget child = children[i];
-				if (child != null && !child.isSelfHidden() && child.getItemId() > -1)
-				{
-					final int alchPrice = getHaPrice(child.getItemId());
-					geTotal += (long) itemManager.getItemPrice(child.getItemId()) * child.getItemQuantity();
-					haTotal += (long) alchPrice * child.getItemQuantity();
-				}
-			}
+				log.debug("Computing bank price of {} items", bankContainer.size());
 
-			Widget bankTitle = client.getWidget(WidgetInfo.BANK_TITLE_BAR);
-			bankTitle.setText(bankTitle.getText() + createValueText(geTotal, haTotal));
+				// The first components are the bank items, followed by tabs etc. There are always 816 components regardless
+				// of bank size, but we only need to check up to the bank size.
+				for (int i = 0; i < bankContainer.size(); ++i)
+				{
+					Widget child = children[i];
+					if (child != null && !child.isSelfHidden() && child.getItemId() > -1)
+					{
+						final int alchPrice = getHaPrice(child.getItemId());
+						geTotal += (long) itemManager.getItemPrice(child.getItemId()) * child.getItemQuantity();
+						haTotal += (long) alchPrice * child.getItemQuantity();
+					}
+				}
+
+				Widget bankTitle = client.getWidget(WidgetInfo.BANK_TITLE_BAR);
+				bankTitle.setText(bankTitle.getText() + createValueText(geTotal, haTotal));
+			}
 		}
 		else if (event.getScriptId() == ScriptID.BANKMAIN_SEARCH_REFRESH)
 		{


### PR DESCRIPTION
Fixes the following NPE:

```
2020-08-15 02:26:10 [Client] WARN  n.runelite.client.eventbus.EventBus - Uncaught exception in event subscriber
java.lang.NullPointerException: null
	at net.runelite.client.plugins.bank.BankPlugin.onScriptPostFired(BankPlugin.java:241)
	at net.runelite.client.eventbus.EventBus$Subscriber.invoke(EventBus.java:73)
	at net.runelite.client.eventbus.EventBus.post(EventBus.java:222)
	at net.runelite.client.callback.Hooks.post(Hooks.java:165)
	at client.wf(client.java:55513)
	at ar.o(ar.java:154)
	at bz.m(bz.java:97)
	at client.up(client.java:2959)
	at client.y(client.java:907)
	at bn.fm(bn.java:358)
	at bn.run(bn.java:337)
	at java.base/java.lang.Thread.run(Thread.java:832)
```

Occurs when you close the bank **immediately** upon opening it.

You can reproduce it by holding down your close interface hotkey as you open the bank.