### PR TITLE
Add alpha channel to relevant color config options

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/config/RuneLiteConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/RuneLiteConfig.java
@@ -367,6 +367,7 @@ public interface RuneLiteConfig extends Config
 		return false;
 	}
 
+	@Alpha
 	@ConfigItem(
 		keyName = "overlayBackgroundColor",
 		name = "Overlay Color",
@@ -374,7 +375,6 @@ public interface RuneLiteConfig extends Config
 		position = 44,
 		section = overlaySettings
 	)
-	@Alpha
 	default Color overlayBackgroundColor()
 	{
 		return ComponentConstants.STANDARD_BACKGROUND_COLOR;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/agility/AgilityConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/agility/AgilityConfig.java
@@ -25,6 +25,7 @@
 package net.runelite.client.plugins.agility;
 
 import java.awt.Color;
+import net.runelite.client.config.Alpha;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
@@ -97,6 +98,7 @@ public interface AgilityConfig extends Config
 		return true;
 	}
 
+	@Alpha
 	@ConfigItem(
 		keyName = "overlayColor",
 		name = "Overlay Color",
@@ -119,6 +121,7 @@ public interface AgilityConfig extends Config
 		return true;
 	}
 
+	@Alpha
 	@ConfigItem(
 		keyName = "markHighlight",
 		name = "Mark Highlight Color",
@@ -141,6 +144,7 @@ public interface AgilityConfig extends Config
 		return true;
 	}
 
+	@Alpha
 	@ConfigItem(
 		keyName = "portalsHighlight",
 		name = "Portals Highlight Color",
@@ -174,6 +178,7 @@ public interface AgilityConfig extends Config
 		return true;
 	}
 
+	@Alpha
 	@ConfigItem(
 		keyName = "trapHighlight",
 		name = "Trap Overlay Color",
@@ -218,6 +223,7 @@ public interface AgilityConfig extends Config
 		return true;
 	}
 
+	@Alpha
 	@ConfigItem(
 		keyName = "stickHighlightColor",
 		name = "Stick Highlight Color",
@@ -241,6 +247,7 @@ public interface AgilityConfig extends Config
 		return true;
 	}
 
+	@Alpha
 	@ConfigItem(
 		keyName = "sepulchreHighlightColor",
 		name = "Projectile Color",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/agility/AgilityOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/agility/AgilityOverlay.java
@@ -45,6 +45,7 @@ import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.OverlayUtil;
+import net.runelite.client.util.ColorUtil;
 
 class AgilityOverlay extends Overlay
 {
@@ -131,11 +132,10 @@ class AgilityOverlay extends Overlay
 					}
 
 					graphics.draw(objectClickbox);
-					graphics.setColor(new Color(configColor.getRed(), configColor.getGreen(), configColor.getBlue(), 50));
+					graphics.setColor(ColorUtil.colorWithAlpha(configColor, configColor.getAlpha() / 5));
 					graphics.fill(objectClickbox);
 				}
 			}
-
 		});
 
 		if (config.highlightMarks() && !marksOfGrace.isEmpty())

--- a/runelite-client/src/main/java/net/runelite/client/plugins/blastmine/BlastMinePluginConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/blastmine/BlastMinePluginConfig.java
@@ -24,6 +24,7 @@
  */
 package net.runelite.client.plugins.blastmine;
 
+import net.runelite.client.config.Alpha;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
@@ -77,6 +78,7 @@ public interface BlastMinePluginConfig extends Config
 		return true;
 	}
 
+	@Alpha
 	@ConfigItem(
 		position = 4,
 		keyName = "hexTimerColor",
@@ -88,6 +90,7 @@ public interface BlastMinePluginConfig extends Config
 		return new Color(217, 54, 0);
 	}
 
+	@Alpha
 	@ConfigItem(
 		position = 5,
 		keyName = "hexWarningColor",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/blastmine/BlastMineRockOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/blastmine/BlastMineRockOverlay.java
@@ -47,6 +47,7 @@ import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.components.ProgressPieComponent;
+import net.runelite.client.util.ColorUtil;
 
 public class BlastMineRockOverlay extends Overlay
 {
@@ -199,7 +200,7 @@ public class BlastMineRockOverlay extends Overlay
 
 					if (poly != null)
 					{
-						graphics.setColor(new Color(color.getRed(), color.getGreen(), color.getBlue(), 100));
+						graphics.setColor(ColorUtil.colorWithAlpha(color, (int) (color.getAlpha() / 2.5)));
 						graphics.fillPolygon(poly);
 					}
 				}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
@@ -89,6 +89,7 @@ import net.runelite.client.ui.ColorScheme;
 import net.runelite.client.ui.DynamicGridLayout;
 import net.runelite.client.ui.FontManager;
 import net.runelite.client.ui.PluginPanel;
+import net.runelite.client.ui.components.ColorJButton;
 import net.runelite.client.ui.components.ComboBoxListRenderer;
 import net.runelite.client.ui.components.colorpicker.ColorPickerManager;
 import net.runelite.client.ui.components.colorpicker.RuneliteColorPicker;
@@ -407,24 +408,23 @@ class ConfigPanel extends PluginPanel
 
 			if (cid.getType() == Color.class)
 			{
-				String existing = configManager.getConfiguration(cd.getGroup().value(), cid.getItem().keyName());
+				Color existing = configManager.getConfiguration(cd.getGroup().value(), cid.getItem().keyName(), Color.class);
 
-				Color existingColor;
-				JButton colorPickerBtn;
+				ColorJButton colorPickerBtn;
+
+				boolean alphaHidden = cid.getAlpha() == null;
 
 				if (existing == null)
 				{
-					existingColor = Color.BLACK;
-					colorPickerBtn = new JButton("Pick a color");
+					colorPickerBtn = new ColorJButton("Pick a color", Color.BLACK);
 				}
 				else
 				{
-					existingColor = ColorUtil.fromString(existing);
-					colorPickerBtn = new JButton(ColorUtil.toHexColor(existingColor).toUpperCase());
+					String colorHex = "#" + (alphaHidden ? ColorUtil.colorToHexCode(existing) : ColorUtil.colorToAlphaHexCode(existing)).toUpperCase();
+					colorPickerBtn = new ColorJButton(colorHex, existing);
 				}
 
 				colorPickerBtn.setFocusable(false);
-				colorPickerBtn.setBackground(existingColor);
 				colorPickerBtn.addMouseListener(new MouseAdapter()
 				{
 					@Override
@@ -432,14 +432,14 @@ class ConfigPanel extends PluginPanel
 					{
 						RuneliteColorPicker colorPicker = colorPickerManager.create(
 							SwingUtilities.windowForComponent(ConfigPanel.this),
-							colorPickerBtn.getBackground(),
+							colorPickerBtn.getColor(),
 							cid.getItem().name(),
-							cid.getAlpha() == null);
+							alphaHidden);
 						colorPicker.setLocation(getLocationOnScreen());
 						colorPicker.setOnColorChange(c ->
 						{
-							colorPickerBtn.setBackground(c);
-							colorPickerBtn.setText(ColorUtil.toHexColor(c).toUpperCase());
+							colorPickerBtn.setColor(c);
+							colorPickerBtn.setText("#" + (alphaHidden ? ColorUtil.colorToHexCode(c) : ColorUtil.colorToAlphaHexCode(c)).toUpperCase());
 						});
 						colorPicker.setOnClose(c -> changeConfiguration(colorPicker, cd, cid));
 						colorPicker.setVisible(true);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/driftnet/DriftNetConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/driftnet/DriftNetConfig.java
@@ -26,6 +26,7 @@
 package net.runelite.client.plugins.driftnet;
 
 import java.awt.Color;
+import net.runelite.client.config.Alpha;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
@@ -84,6 +85,7 @@ public interface DriftNetConfig extends Config
 		return 60;
 	}
 
+	@Alpha
 	@ConfigItem(
 		keyName = "untaggedFishColor",
 		name = "Untagged fish color",
@@ -106,6 +108,7 @@ public interface DriftNetConfig extends Config
 		return true;
 	}
 
+	@Alpha
 	@ConfigItem(
 		keyName = "annetteTagColor",
 		name = "Annette tag color",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingConfig.java
@@ -25,6 +25,7 @@
 package net.runelite.client.plugins.fishing;
 
 import java.awt.Color;
+import net.runelite.client.config.Alpha;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
@@ -77,6 +78,7 @@ public interface FishingConfig extends Config
 		return false;
 	}
 
+	@Alpha
 	@ConfigItem(
 		keyName = "overlayColor",
 		name = "Overlay Color",
@@ -88,6 +90,7 @@ public interface FishingConfig extends Config
 		return Color.CYAN;
 	}
 
+	@Alpha
 	@ConfigItem(
 		keyName = "minnowsOverlayColor",
 		name = "Minnows Overlay Color",
@@ -99,6 +102,7 @@ public interface FishingConfig extends Config
 		return Color.RED;
 	}
 
+	@Alpha
 	@ConfigItem(
 		keyName = "aerialOverlayColor",
 		name = "Aerial Overlay Color",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
@@ -26,6 +26,7 @@
 package net.runelite.client.plugins.grounditems;
 
 import java.awt.Color;
+import net.runelite.client.config.Alpha;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
@@ -219,6 +220,7 @@ public interface GroundItemsConfig extends Config
 		return 0;
 	}
 
+	@Alpha
 	@ConfigItem(
 		keyName = "defaultColor",
 		name = "Default items color",
@@ -230,6 +232,7 @@ public interface GroundItemsConfig extends Config
 		return Color.WHITE;
 	}
 
+	@Alpha
 	@ConfigItem(
 		keyName = "highlightedColor",
 		name = "Highlighted items color",
@@ -241,6 +244,7 @@ public interface GroundItemsConfig extends Config
 		return Color.decode("#AA00FF");
 	}
 
+	@Alpha
 	@ConfigItem(
 		keyName = "hiddenColor",
 		name = "Hidden items color",
@@ -252,6 +256,7 @@ public interface GroundItemsConfig extends Config
 		return Color.GRAY;
 	}
 
+	@Alpha
 	@ConfigItem(
 		keyName = "lowValueColor",
 		name = "Low value items color",
@@ -274,6 +279,7 @@ public interface GroundItemsConfig extends Config
 		return 20000;
 	}
 
+	@Alpha
 	@ConfigItem(
 		keyName = "mediumValueColor",
 		name = "Medium value items color",
@@ -296,6 +302,7 @@ public interface GroundItemsConfig extends Config
 		return 100000;
 	}
 
+	@Alpha
 	@ConfigItem(
 		keyName = "highValueColor",
 		name = "High value items color",
@@ -318,6 +325,7 @@ public interface GroundItemsConfig extends Config
 		return 1000000;
 	}
 
+	@Alpha
 	@ConfigItem(
 		keyName = "insaneValueColor",
 		name = "Insane value items color",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/herbiboars/HerbiboarConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/herbiboars/HerbiboarConfig.java
@@ -25,6 +25,7 @@
 package net.runelite.client.plugins.herbiboars;
 
 import java.awt.Color;
+import net.runelite.client.config.Alpha;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
@@ -54,6 +55,7 @@ public interface HerbiboarConfig extends Config
 		return false;
 	}
 
+	@Alpha
 	@ConfigItem(
 		position = 2,
 		keyName = "colorStart",
@@ -76,6 +78,7 @@ public interface HerbiboarConfig extends Config
 		return true;
 	}
 
+	@Alpha
 	@ConfigItem(
 		position = 4,
 		keyName = "colorTunnel",
@@ -98,6 +101,7 @@ public interface HerbiboarConfig extends Config
 		return true;
 	}
 
+	@Alpha
 	@ConfigItem(
 		position = 6,
 		keyName = "colorGameObject",
@@ -120,6 +124,7 @@ public interface HerbiboarConfig extends Config
 		return true;
 	}
 
+	@Alpha
 	@ConfigItem(
 		position = 8,
 		keyName = "colorTrail",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/herbiboars/HerbiboarOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/herbiboars/HerbiboarOverlay.java
@@ -37,6 +37,7 @@ import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.OverlayUtil;
+import net.runelite.client.util.ColorUtil;
 
 class HerbiboarOverlay extends Overlay
 {
@@ -126,7 +127,7 @@ class HerbiboarOverlay extends Overlay
 			Shape clickbox = object.getClickbox();
 			if (clickbox != null)
 			{
-				Color clickBoxColor = new Color(color.getRed(), color.getGreen(), color.getBlue(), 20);
+				Color clickBoxColor = ColorUtil.colorWithAlpha(color, color.getAlpha() / 12);
 
 				graphics.setColor(color);
 				graphics.draw(clickbox);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/hunter/HunterConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/hunter/HunterConfig.java
@@ -25,6 +25,7 @@
 package net.runelite.client.plugins.hunter;
 
 import java.awt.Color;
+import net.runelite.client.config.Alpha;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
@@ -32,6 +33,7 @@ import net.runelite.client.config.ConfigItem;
 @ConfigGroup("hunterplugin")
 public interface HunterConfig extends Config
 {
+	@Alpha
 	@ConfigItem(
 		position = 1,
 		keyName = "hexColorOpenTrap",
@@ -43,6 +45,7 @@ public interface HunterConfig extends Config
 		return Color.YELLOW;
 	}
 
+	@Alpha
 	@ConfigItem(
 		position = 2,
 		keyName = "hexColorFullTrap",
@@ -54,6 +57,7 @@ public interface HunterConfig extends Config
 		return Color.GREEN;
 	}
 
+	@Alpha
 	@ConfigItem(
 		position = 3,
 		keyName = "hexColorEmptyTrap",
@@ -65,6 +69,7 @@ public interface HunterConfig extends Config
 		return Color.RED;
 	}
 
+	@Alpha
 	@ConfigItem(
 		position = 4,
 		keyName = "hexColorTransTrap",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/hunter/TrapOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/hunter/TrapOverlay.java
@@ -37,6 +37,7 @@ import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.components.ProgressPieComponent;
+import net.runelite.client.util.ColorUtil;
 
 /**
  * Represents the overlay that shows timers on traps that are placed by the
@@ -81,13 +82,13 @@ public class TrapOverlay extends Overlay
 	public void updateConfig()
 	{
 		colorEmptyBorder = config.getEmptyTrapColor();
-		colorEmpty = new Color(colorEmptyBorder.getRed(), colorEmptyBorder.getGreen(), colorEmptyBorder.getBlue(), 100);
+		colorEmpty = ColorUtil.colorWithAlpha(colorEmptyBorder, (int)(colorEmptyBorder.getAlpha() / 2.5));
 		colorFullBorder = config.getFullTrapColor();
-		colorFull = new Color(colorFullBorder.getRed(), colorFullBorder.getGreen(), colorFullBorder.getBlue(), 100);
+		colorFull = ColorUtil.colorWithAlpha(colorFullBorder, (int)(colorFullBorder.getAlpha() / 2.5));
 		colorOpenBorder = config.getOpenTrapColor();
-		colorOpen = new Color(colorOpenBorder.getRed(), colorOpenBorder.getGreen(), colorOpenBorder.getBlue(), 100);
+		colorOpen = ColorUtil.colorWithAlpha(colorOpenBorder, (int)(colorOpenBorder.getAlpha() / 2.5));
 		colorTransBorder = config.getTransTrapColor();
-		colorTrans = new Color(colorTransBorder.getRed(), colorTransBorder.getGreen(), colorTransBorder.getBlue(), 100);
+		colorTrans = ColorUtil.colorWithAlpha(colorTransBorder, (int)(colorTransBorder.getAlpha() / 2.5));
 	}
 
 	/**

--- a/runelite-client/src/main/java/net/runelite/client/plugins/implings/ImplingsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/implings/ImplingsConfig.java
@@ -25,6 +25,7 @@
 package net.runelite.client.plugins.implings;
 
 import java.awt.Color;
+import net.runelite.client.config.Alpha;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
@@ -63,6 +64,7 @@ public interface ImplingsConfig extends Config
 		return ImplingMode.NONE;
 	}
 
+	@Alpha
 	@ConfigItem(
 		position = 2,
 		keyName = "babyColor",
@@ -87,6 +89,7 @@ public interface ImplingsConfig extends Config
 		return ImplingMode.NONE;
 	}
 
+	@Alpha
 	@ConfigItem(
 		position = 4,
 		keyName = "youngColor",
@@ -111,6 +114,7 @@ public interface ImplingsConfig extends Config
 		return ImplingMode.NONE;
 	}
 
+	@Alpha
 	@ConfigItem(
 		position = 6,
 		keyName = "gourmetColor",
@@ -135,6 +139,7 @@ public interface ImplingsConfig extends Config
 		return ImplingMode.NONE;
 	}
 
+	@Alpha
 	@ConfigItem(
 		position = 8,
 		keyName = "earthColor",
@@ -159,6 +164,7 @@ public interface ImplingsConfig extends Config
 		return ImplingMode.NONE;
 	}
 
+	@Alpha
 	@ConfigItem(
 		position = 10,
 		keyName = "essenceColor",
@@ -183,6 +189,7 @@ public interface ImplingsConfig extends Config
 		return ImplingMode.NONE;
 	}
 
+	@Alpha
 	@ConfigItem(
 		position = 12,
 		keyName = "eclecticColor",
@@ -207,6 +214,7 @@ public interface ImplingsConfig extends Config
 		return ImplingMode.NONE;
 	}
 
+	@Alpha
 	@ConfigItem(
 		position = 14,
 		keyName = "natureColor",
@@ -231,6 +239,7 @@ public interface ImplingsConfig extends Config
 		return ImplingMode.NONE;
 	}
 
+	@Alpha
 	@ConfigItem(
 		position = 16,
 		keyName = "magpieColor",
@@ -255,6 +264,7 @@ public interface ImplingsConfig extends Config
 		return ImplingMode.NONE;
 	}
 
+	@Alpha
 	@ConfigItem(
 		position = 18,
 		keyName = "ninjaColor",
@@ -279,6 +289,7 @@ public interface ImplingsConfig extends Config
 		return ImplingMode.NONE;
 	}
 
+	@Alpha
 	@ConfigItem(
 		position = 20,
 		keyName = "crystalColor",
@@ -303,6 +314,7 @@ public interface ImplingsConfig extends Config
 		return ImplingMode.HIGHLIGHT;
 	}
 
+	@Alpha
 	@ConfigItem(
 		position = 22,
 		keyName = "dragonColor",
@@ -327,6 +339,7 @@ public interface ImplingsConfig extends Config
 		return ImplingMode.HIGHLIGHT;
 	}
 
+	@Alpha
 	@ConfigItem(
 		position = 24,
 		keyName = "luckyColor",
@@ -350,6 +363,7 @@ public interface ImplingsConfig extends Config
 		return false;
 	}
 
+	@Alpha
 	@ConfigItem(
 		position = 26,
 		keyName = "spawnColor",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatConfig.java
@@ -144,7 +144,6 @@ public interface ItemStatConfig extends Config
 		return new Color(0x9CEE33);
 	}
 
-
 	@ConfigItem(
 		keyName = "colorBetterCapped",
 		name = "Better (Capped)",
@@ -155,6 +154,7 @@ public interface ItemStatConfig extends Config
 	{
 		return new Color(0xEEEE33);
 	}
+
 	@ConfigItem(
 		keyName = "colorNoChange",
 		name = "No change",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsConfig.java
@@ -95,13 +95,13 @@ public interface NpcIndicatorsConfig extends Config
 	)
 	void setNpcToHighlight(String npcsToHighlight);
 
+	@Alpha
 	@ConfigItem(
 		position = 4,
 		keyName = "npcColor",
 		name = "Highlight Color",
 		description = "Color of the NPC highlight"
 	)
-	@Alpha
 	default Color getHighlightColor()
 	{
 		return Color.CYAN;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcSceneOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcSceneOverlay.java
@@ -48,6 +48,7 @@ import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.OverlayUtil;
+import net.runelite.client.util.ColorUtil;
 import net.runelite.client.util.Text;
 
 public class NpcSceneOverlay extends Overlay
@@ -199,7 +200,7 @@ public class NpcSceneOverlay extends Overlay
 			graphics.setColor(color);
 			graphics.setStroke(new BasicStroke(2));
 			graphics.draw(polygon);
-			graphics.setColor(new Color(color.getRed(), color.getGreen(), color.getBlue(), 20));
+			graphics.setColor(ColorUtil.colorWithAlpha(color, color.getAlpha() / 12));
 			graphics.fill(polygon);
 		}
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/npcunaggroarea/NpcAggroAreaConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npcunaggroarea/NpcAggroAreaConfig.java
@@ -83,25 +83,25 @@ public interface NpcAggroAreaConfig extends Config
 		return false;
 	}
 
+	@Alpha
 	@ConfigItem(
 		keyName = "npcAggroAreaColor",
 		name = "Aggressive colour",
 		description = "Choose colour to use for marking NPC unaggressive area when NPCs are aggressive",
 		position = 5
 	)
-	@Alpha
 	default Color aggroAreaColor()
 	{
 		return new Color(0x64FFFF00, true);
 	}
 
+	@Alpha
 	@ConfigItem(
 		keyName = "npcUnaggroAreaColor",
 		name = "Unaggressive colour",
 		description = "Choose colour to use for marking NPC unaggressive area after NPCs have lost aggression",
 		position = 6
 	)
-	@Alpha
 	default Color unaggroAreaColor()
 	{
 		return new Color(0xFFFF00);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/pyramidplunder/PyramidPlunderConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/pyramidplunder/PyramidPlunderConfig.java
@@ -24,6 +24,7 @@
  */
 package net.runelite.client.plugins.pyramidplunder;
 import java.awt.Color;
+import net.runelite.client.config.Alpha;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
@@ -64,6 +65,7 @@ public interface PyramidPlunderConfig extends Config
 		return 30;
 	}
 
+	@Alpha
 	@ConfigItem(
 		position = 3,
 		keyName = "highlightDoorsColor",
@@ -86,6 +88,7 @@ public interface PyramidPlunderConfig extends Config
 		return true;
 	}
 
+	@Alpha
 	@ConfigItem(
 		position = 5,
 		keyName = "highlightSpeartrapColor",
@@ -108,6 +111,7 @@ public interface PyramidPlunderConfig extends Config
 		return true;
 	}
 
+	@Alpha
 	@ConfigItem(
 		position = 7,
 		keyName = "highlightContainersColor",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/pyramidplunder/PyramidPlunderOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/pyramidplunder/PyramidPlunderOverlay.java
@@ -50,6 +50,7 @@ import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.OverlayUtil;
+import net.runelite.client.util.ColorUtil;
 
 class PyramidPlunderOverlay extends Overlay
 {
@@ -157,8 +158,7 @@ class PyramidPlunderOverlay extends Overlay
 				}
 
 				graphics.draw(objectClickbox);
-				graphics.setColor(new Color(highlightColor.getRed(), highlightColor.getGreen(),
-					highlightColor.getBlue(), 50));
+				graphics.setColor(ColorUtil.colorWithAlpha(highlightColor, highlightColor.getAlpha() / 5));
 				graphics.fill(objectClickbox);
 			}
 		});

--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerConfig.java
@@ -26,6 +26,7 @@
 package net.runelite.client.plugins.slayer;
 
 import java.awt.Color;
+import net.runelite.client.config.Alpha;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
@@ -90,6 +91,7 @@ public interface SlayerConfig extends Config
 		return false;
 	}
 
+	@Alpha
 	@ConfigItem(
 		position = 6,
 		keyName = "targetColor",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/TargetClickboxOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/TargetClickboxOverlay.java
@@ -37,6 +37,7 @@ import net.runelite.api.NPC;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.util.ColorUtil;
 
 public class TargetClickboxOverlay extends Overlay
 {
@@ -77,7 +78,7 @@ public class TargetClickboxOverlay extends Overlay
 			graphics.setColor(color);
 			graphics.setStroke(new BasicStroke(2));
 			graphics.draw(objectClickbox);
-			graphics.setColor(new Color(color.getRed(), color.getGreen(), color.getBlue(), 20));
+			graphics.setColor(ColorUtil.colorWithAlpha(color, color.getAlpha() / 12));
 			graphics.fill(objectClickbox);
 		}
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/tithefarm/TitheFarmPlantOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/tithefarm/TitheFarmPlantOverlay.java
@@ -38,6 +38,7 @@ import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.components.ProgressPieComponent;
+import net.runelite.client.util.ColorUtil;
 
 public class TitheFarmPlantOverlay extends Overlay
 {
@@ -66,17 +67,17 @@ public class TitheFarmPlantOverlay extends Overlay
 		fills.clear();
 
 		final Color colorUnwateredBorder = config.getColorUnwatered();
-		final Color colorUnwatered = new Color(colorUnwateredBorder.getRed(), colorUnwateredBorder.getGreen(), colorUnwateredBorder.getBlue(), 100);
+		final Color colorUnwatered = ColorUtil.colorWithAlpha(colorUnwateredBorder, (int) (colorUnwateredBorder.getAlpha() / 2.5));
 		borders.put(TitheFarmPlantState.UNWATERED, colorUnwateredBorder);
 		fills.put(TitheFarmPlantState.UNWATERED, colorUnwatered);
 
 		final Color colorWateredBorder = config.getColorWatered();
-		final Color colorWatered = new Color(colorWateredBorder.getRed(), colorWateredBorder.getGreen(), colorWateredBorder.getBlue(), 100);
+		final Color colorWatered = ColorUtil.colorWithAlpha(colorWateredBorder, (int) (colorWateredBorder.getAlpha() / 2.5));
 		borders.put(TitheFarmPlantState.WATERED, colorWateredBorder);
 		fills.put(TitheFarmPlantState.WATERED, colorWatered);
 
 		final Color colorGrownBorder = config.getColorGrown();
-		final Color colorGrown = new Color(colorGrownBorder.getRed(), colorGrownBorder.getGreen(), colorGrownBorder.getBlue(), 100);
+		final Color colorGrown = ColorUtil.colorWithAlpha(colorGrownBorder, (int) (colorGrownBorder.getAlpha() / 2.5));
 		borders.put(TitheFarmPlantState.GROWN, colorGrownBorder);
 		fills.put(TitheFarmPlantState.GROWN, colorGrown);
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/tithefarm/TitheFarmPluginConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/tithefarm/TitheFarmPluginConfig.java
@@ -25,6 +25,7 @@
 package net.runelite.client.plugins.tithefarm;
 
 import java.awt.Color;
+import net.runelite.client.config.Alpha;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
@@ -32,6 +33,7 @@ import net.runelite.client.config.ConfigItem;
 @ConfigGroup("tithefarmplugin")
 public interface TitheFarmPluginConfig extends Config
 {
+	@Alpha
 	@ConfigItem(
 		position = 1,
 		keyName = "hexColorUnwatered",
@@ -43,6 +45,7 @@ public interface TitheFarmPluginConfig extends Config
 		return new Color(255, 187, 0);
 	}
 
+	@Alpha
 	@ConfigItem(
 		position = 2,
 		keyName = "hexColorWatered",
@@ -54,6 +57,7 @@ public interface TitheFarmPluginConfig extends Config
 		return new Color(0, 153, 255);
 	}
 
+	@Alpha
 	@ConfigItem(
 		position = 3,
 		keyName = "hexColorGrown",

--- a/runelite-client/src/main/java/net/runelite/client/ui/components/ColorJButton.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/components/ColorJButton.java
@@ -1,16 +1,15 @@
 /*
- * Copyright (c) 2018, Psikoi <https://github.com/psikoi>
- * Copyright (c) 2018, Ron Young <https://github.com/raiyni>
+ * Copyright (c) 2020, Martin H <pilino@posteo.de>
  * All rights reserved.
  *
- *  Redistribution and use in source and binary forms, with or without
- *  modification, are permitted provided that the following conditions are met:
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
  *
  * 1. Redistributions of source code must retain the above copyright notice, this
- *     list of conditions and the following disclaimer.
+ *    list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
- *     this list of conditions and the following disclaimer in the documentation
- *     and/or other materials provided with the distribution.
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
@@ -23,37 +22,61 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-
-package net.runelite.client.ui.components.colorpicker;
+package net.runelite.client.ui.components;
 
 import java.awt.Color;
 import java.awt.Graphics;
-import javax.swing.JPanel;
+import javax.swing.JButton;
 import lombok.Getter;
 
-class PreviewPanel extends JPanel
+public class ColorJButton extends JButton
 {
+	private static final int ALPHA_TEXT_CUTOFF = 120;
 	private static final int CHECKER_SIZE = 10;
 
 	@Getter
 	private Color color;
 
-	void setColor(Color c)
+	public ColorJButton(String text, Color color)
 	{
-		this.color = c;
-		this.paintImmediately(0, 0, this.getWidth(), this.getHeight());
+		super(text);
+
+		// Tell ButtonUI to not paint the background, we do it ourselves.
+		this.setContentAreaFilled(false);
+
+		setColor(color);
+	}
+
+	public void setColor(Color color)
+	{
+		this.color = color;
+
+		// Use perceptive luminance to choose a readable font color
+		// Based on https://stackoverflow.com/a/1855903
+		double lum = (0.299 * color.getRed() + 0.587 * color.getGreen() + 0.114 * color.getBlue()) / 255;
+
+		final Color textColor;
+
+		if (lum > 0.5 || color.getAlpha() < ALPHA_TEXT_CUTOFF)
+		{
+			textColor = Color.BLACK;
+		}
+		else
+		{
+			textColor = Color.WHITE;
+		}
+
+		this.setForeground(textColor);
 	}
 
 	@Override
 	public void paint(Graphics g)
 	{
-		super.paint(g);
-
 		if (this.color.getAlpha() != 255)
 		{
-			for (int x = 0; x < getWidth(); x += CHECKER_SIZE)
+			for (int x = 0; x < this.getWidth(); x += CHECKER_SIZE)
 			{
-				for (int y = 0; y < getHeight(); y += CHECKER_SIZE)
+				for (int y = 0; y < this.getHeight(); y += CHECKER_SIZE)
 				{
 					int val = (x / CHECKER_SIZE + y / CHECKER_SIZE) % 2;
 					g.setColor(val == 0 ? Color.LIGHT_GRAY : Color.WHITE);
@@ -62,7 +85,9 @@ class PreviewPanel extends JPanel
 			}
 		}
 
-		g.setColor(color);
+		g.setColor(this.color);
 		g.fillRect(0, 0, this.getWidth(), this.getHeight());
+
+		super.paint(g);
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayUtil.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayUtil.java
@@ -40,6 +40,7 @@ import net.runelite.api.Perspective;
 import net.runelite.api.Point;
 import net.runelite.api.TileObject;
 import net.runelite.api.coords.LocalPoint;
+import net.runelite.client.util.ColorUtil;
 
 
 /**
@@ -65,7 +66,7 @@ public class OverlayUtil
 	{
 		graphics.setColor(Color.BLACK);
 		graphics.fillOval(mini.getX() - MINIMAP_DOT_RADIUS / 2, mini.getY() - MINIMAP_DOT_RADIUS / 2 + 1, MINIMAP_DOT_RADIUS, MINIMAP_DOT_RADIUS);
-		graphics.setColor(color);
+		graphics.setColor(ColorUtil.colorWithAlpha(color, 0xFF));
 		graphics.fillOval(mini.getX() - MINIMAP_DOT_RADIUS / 2, mini.getY() - MINIMAP_DOT_RADIUS / 2, MINIMAP_DOT_RADIUS, MINIMAP_DOT_RADIUS);
 	}
 
@@ -92,7 +93,7 @@ public class OverlayUtil
 		graphics.setColor(Color.BLACK);
 		graphics.drawString(text, x + 1, y + 1);
 
-		graphics.setColor(color);
+		graphics.setColor(ColorUtil.colorWithAlpha(color, 0xFF));
 		graphics.drawString(text, x, y);
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/components/TextComponent.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/components/TextComponent.java
@@ -32,6 +32,7 @@ import java.awt.Point;
 import java.util.regex.Pattern;
 import lombok.Setter;
 import net.runelite.client.ui.overlay.RenderableEntity;
+import net.runelite.client.util.ColorUtil;
 import net.runelite.client.util.Text;
 
 @Setter
@@ -100,7 +101,7 @@ public class TextComponent implements RenderableEntity
 			}
 
 			// actual text
-			graphics.setColor(color);
+			graphics.setColor(ColorUtil.colorWithAlpha(color, 0xFF));
 			graphics.drawString(text, position.x, position.y);
 		}
 

--- a/runelite-client/src/main/java/net/runelite/client/util/ColorUtil.java
+++ b/runelite-client/src/main/java/net/runelite/client/util/ColorUtil.java
@@ -132,6 +132,24 @@ public class ColorUtil
 	}
 
 	/**
+	 * Gets the same RGB color with the specified alpha value.
+	 *
+	 * @param color The RGB color to use.
+	 * @param alpha The alpha value to use (0-255).
+	 * @return      A Color with the given RGB and alpha.
+	 */
+	public static Color colorWithAlpha(final Color color, int alpha)
+	{
+		if (color.getAlpha() == alpha)
+		{
+			return color;
+		}
+
+		alpha = constrainValue(alpha);
+		return new Color((color.getRGB() & 0x00ffffff) | (alpha << 24), true);
+	}
+
+	/**
 	 * Determines if the passed hex string is an alpha hex color.
 	 *
 	 * @param hex The hex to test.

--- a/runelite-client/src/test/java/net/runelite/client/util/ColorUtilTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/util/ColorUtilTest.java
@@ -24,25 +24,28 @@
  */
 package net.runelite.client.util;
 
+import com.google.common.collect.ImmutableMap;
 import java.awt.Color;
-import java.util.HashMap;
 import java.util.Map;
 import static org.junit.Assert.assertEquals;
 import org.junit.Test;
 
 public class ColorUtilTest
 {
-	private static final Map<Color, String> COLOR_HEXSTRING_MAP = new HashMap<Color, String>()
-	{{
-		put(Color.BLACK, "000000");
-		put(new Color(0x1), "000001");
-		put(new Color(0x100000), "100000");
-		put(Color.RED, "ff0000");
-		put(Color.GREEN, "00ff00");
-		put(Color.BLUE, "0000ff");
-		put(new Color(0xA1B2C3), "a1b2c3");
-		put(Color.WHITE, "ffffff");
-	}};
+	private static final Map<Color, String> COLOR_HEXSTRING_MAP = new ImmutableMap.Builder<Color, String>().
+		put(Color.BLACK, "000000").
+		put(new Color(0x1), "000001").
+		put(new Color(0x100000), "100000").
+		put(Color.RED, "ff0000").
+		put(Color.GREEN, "00ff00").
+		put(Color.BLUE, "0000ff").
+		put(new Color(0xA1B2C3), "a1b2c3").
+		put(Color.WHITE, "ffffff").build();
+
+	private static final Map<Color, String> COLOR_ALPHA_HEXSTRING_MAP = ImmutableMap.of(
+		new Color(0x00000000, true), "00000000",
+		new Color(0xA1B2C3D4, true), "a1b2c3d4"
+	);
 
 	@Test
 	public void colorTag()
@@ -81,6 +84,28 @@ public class ColorUtilTest
 		COLOR_HEXSTRING_MAP.forEach((color, hex) ->
 		{
 			assertEquals("#" + hex, ColorUtil.toHexColor(color));
+		});
+	}
+
+	@Test
+	public void colorWithAlpha()
+	{
+		int[] alpha = {73};
+
+		COLOR_HEXSTRING_MAP.forEach((color, hex) ->
+		{
+			assertEquals(new Color(color.getRed(), color.getGreen(), color.getBlue(), alpha[0]),
+				ColorUtil.colorWithAlpha(color, alpha[0]));
+			alpha[0] += 73;
+			alpha[0] %= 255;
+		});
+
+		COLOR_ALPHA_HEXSTRING_MAP.forEach((color, hex) ->
+		{
+			assertEquals(new Color(color.getRed(), color.getGreen(), color.getBlue(), alpha[0]),
+				ColorUtil.colorWithAlpha(color, alpha[0]));
+			alpha[0] += 73;
+			alpha[0] %= 255;
 		});
 	}
 


### PR DESCRIPTION
Add the ability to configure alpha for various different color config options.

Implement a new ColorJButton to preview colors with alpha in the config sidebar by overlaying them on top of the classic checkerboard pattern.
ColorUtil: Add new methods: `toAlphaHexColor` (yields a colors hex string including alpha), `colorOfAlpha` (change alpha of a given RGB color), and `luminance` (calculate luminance of a color). Also add unit tests for these methods.
OverlayUtil: Remove alpha from minimap dots and text overlays.
TextComponent: Remove alpha from text color.

Closes #12353 