### PR TITLE
UI Component: color slider resized to fit knob at max rgba values

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ui/components/colorpicker/ColorValueSlider.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/components/colorpicker/ColorValueSlider.java
@@ -98,7 +98,7 @@ public class ColorValueSlider extends JPanel
 		super.paint(g);
 
 		g.setColor(TRACK_COLOR);
-		g.fillRect(0, this.getHeight() / 2 - 2, this.getWidth() - KNOB_WIDTH, 5);
+		g.fillRect(0, this.getHeight() / 2 - 2, ColorUtil.MAX_RGB_VALUE + KNOB_WIDTH * 2, 5);
 
 		g.setColor(KNOB_COLOR);
 		g.fillRect(value - KNOB_WIDTH / 2, this.getHeight() / 2 - KNOB_HEIGHT / 2, KNOB_WIDTH, KNOB_HEIGHT);

--- a/runelite-client/src/main/java/net/runelite/client/ui/components/colorpicker/RuneliteColorPicker.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/components/colorpicker/RuneliteColorPicker.java
@@ -65,7 +65,7 @@ public class RuneliteColorPicker extends JDialog
 {
 	static final String CONFIG_GROUP = "colorpicker";
 
-	private final static int FRAME_WIDTH = 400;
+	private final static int FRAME_WIDTH = 410;
 	private final static int FRAME_HEIGHT = 380;
 	private final static int TONE_PANEL_SIZE = 160;
 


### PR DESCRIPTION
Existing behaviour:
![image](https://user-images.githubusercontent.com/11140337/90347279-2b1eb300-e027-11ea-9c67-38e753e1e0db.png)

New behaviour:
![image](https://user-images.githubusercontent.com/11140337/90347494-c2383a80-e028-11ea-8fc9-6fe2e639cd1e.png)

Not sure if the 2 pixels extra on either side of the slider track are desired, perhaps people would prefer it if the knob bottomed and topped out.