### PR TITLE
CombatLevel: Properly removes combat skills from tooltip when they are maxed

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/combatlevel/CombatLevelOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/combatlevel/CombatLevelOverlay.java
@@ -110,17 +110,17 @@ class CombatLevelOverlay extends Overlay
 
 		if ((attackLevel + strengthLevel + meleeNeed) <= Experience.MAX_REAL_LEVEL * 2)
 		{
-			sb.append(meleeNeed).append(" ").append(attackLevel < Experience.MAX_REAL_LEVEL ? "Attack" : "")
-					.append((attackLevel < Experience.MAX_REAL_LEVEL && strengthLevel < Experience.MAX_REAL_LEVEL) ?
-							"/" : "")
-					.append(strengthLevel < Experience.MAX_REAL_LEVEL ? "Strength" : "").append("</br>");
+			sb.append(meleeNeed).append(" ")
+				.append(attackLevel < Experience.MAX_REAL_LEVEL ? "Attack" : "")
+				.append((attackLevel < Experience.MAX_REAL_LEVEL && strengthLevel < Experience.MAX_REAL_LEVEL) ? "/" : "")
+				.append(strengthLevel < Experience.MAX_REAL_LEVEL ? "Strength" : "").append("</br>");
 		}
 		if ((hitpointsLevel + defenceLevel + hpDefNeed) <= Experience.MAX_REAL_LEVEL * 2)
 		{
-			sb.append(hpDefNeed).append(" ").append(defenceLevel < Experience.MAX_REAL_LEVEL ? "Defence" : "")
-					.append((defenceLevel < Experience.MAX_REAL_LEVEL && hitpointsLevel < Experience.MAX_REAL_LEVEL) ?
-							"/" : "")
-					.append(hitpointsLevel < Experience.MAX_REAL_LEVEL ? "Hitpoints" : "").append("</br>");
+			sb.append(hpDefNeed).append(" ")
+				.append(defenceLevel < Experience.MAX_REAL_LEVEL ? "Defence" : "")
+				.append((defenceLevel < Experience.MAX_REAL_LEVEL && hitpointsLevel < Experience.MAX_REAL_LEVEL) ? "/" : "")
+				.append(hitpointsLevel < Experience.MAX_REAL_LEVEL ? "Hitpoints" : "").append("</br>");
 		}
 		if ((rangeLevel + rangeNeed) <= Experience.MAX_REAL_LEVEL)
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/combatlevel/CombatLevelOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/combatlevel/CombatLevelOverlay.java
@@ -110,11 +110,17 @@ class CombatLevelOverlay extends Overlay
 
 		if ((attackLevel + strengthLevel + meleeNeed) <= Experience.MAX_REAL_LEVEL * 2)
 		{
-			sb.append(meleeNeed).append(" Attack/Strength</br>");
+			sb.append(meleeNeed).append(" ").append(attackLevel < Experience.MAX_REAL_LEVEL ? "Attack" : "")
+					.append((attackLevel < Experience.MAX_REAL_LEVEL && strengthLevel < Experience.MAX_REAL_LEVEL) ?
+							"/" : "")
+					.append(strengthLevel < Experience.MAX_REAL_LEVEL ? "Strength" : "").append("</br>");
 		}
 		if ((hitpointsLevel + defenceLevel + hpDefNeed) <= Experience.MAX_REAL_LEVEL * 2)
 		{
-			sb.append(hpDefNeed).append(" Defence/Hitpoints</br>");
+			sb.append(hpDefNeed).append(" ").append(defenceLevel < Experience.MAX_REAL_LEVEL ? "Defence" : "")
+					.append((defenceLevel < Experience.MAX_REAL_LEVEL && hitpointsLevel < Experience.MAX_REAL_LEVEL) ?
+							"/" : "")
+					.append(hitpointsLevel < Experience.MAX_REAL_LEVEL ? "Hitpoints" : "").append("</br>");
 		}
 		if ((rangeLevel + rangeNeed) <= Experience.MAX_REAL_LEVEL)
 		{


### PR DESCRIPTION
Removes Attack/Strength/Defence/Hitpoints from showing in the "Next combat level:" tooltip when that individual skill is maxed instead of just when the pairs (Att/Str, Def/HP) are maxed.