### PR TITLE
Optimizations to scene loading when using the GPU plugin.

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuFloatBuffer.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuFloatBuffer.java
@@ -37,6 +37,11 @@ class GpuFloatBuffer
 		buffer.put(texture).put(u).put(v).put(pad);
 	}
 
+	public void put(float[] src)
+	{
+		buffer.put(src);
+	}
+
 	void flip()
 	{
 		buffer.flip();
@@ -47,15 +52,26 @@ class GpuFloatBuffer
 		buffer.clear();
 	}
 
-	void ensureCapacity(int size)
+	void ensureCapacity(int requestedRemaining)
 	{
-		while (buffer.remaining() < size)
+		int capacity = buffer.capacity();
+		final int position = buffer.position();
+		if ((capacity - position) < requestedRemaining)
 		{
-			FloatBuffer newB = allocateDirect(buffer.capacity() * 2);
+			do {
+				capacity *= 2;
+			}
+			while ((capacity - position) < requestedRemaining);
+			FloatBuffer newB = allocateDirect(capacity);
 			buffer.flip();
 			newB.put(buffer);
 			buffer = newB;
 		}
+	}
+
+	public int limit()
+	{
+		return buffer.limit();
 	}
 
 	FloatBuffer getBuffer()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuIntBuffer.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuIntBuffer.java
@@ -42,6 +42,11 @@ class GpuIntBuffer
 		buffer.put(x).put(y).put(z).put(c);
 	}
 
+	public void put(int[] src)
+	{
+		buffer.put(src);
+	}
+
 	void flip()
 	{
 		buffer.flip();
@@ -52,15 +57,26 @@ class GpuIntBuffer
 		buffer.clear();
 	}
 
-	void ensureCapacity(int size)
+	void ensureCapacity(int requestedRemaining)
 	{
-		while (buffer.remaining() < size)
+		int capacity = buffer.capacity();
+		final int position = buffer.position();
+		if ((capacity - position) < requestedRemaining)
 		{
-			IntBuffer newB = allocateDirect(buffer.capacity() * 2);
+			do {
+				capacity *= 2;
+			}
+			while ((capacity - position) < requestedRemaining);
+			IntBuffer newB = allocateDirect(capacity);
 			buffer.flip();
 			newB.put(buffer);
 			buffer = newB;
 		}
+	}
+
+	public int limit()
+	{
+		return buffer.limit();
 	}
 
 	IntBuffer getBuffer()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuPlugin.java
@@ -1364,14 +1364,11 @@ public class GpuPlugin extends Plugin implements DrawCallbacks
 		vertexBuffer.flip();
 		uvBuffer.flip();
 
-		IntBuffer vertexBuffer = this.vertexBuffer.getBuffer();
-		FloatBuffer uvBuffer = this.uvBuffer.getBuffer();
-
 		gl.glBindBuffer(gl.GL_ARRAY_BUFFER, bufferId);
-		gl.glBufferData(gl.GL_ARRAY_BUFFER, vertexBuffer.limit() * Integer.BYTES, vertexBuffer, gl.GL_STATIC_COPY);
+		gl.glBufferData(gl.GL_ARRAY_BUFFER, vertexBuffer.limit() * Integer.BYTES, vertexBuffer.getBuffer(), gl.GL_STATIC_COPY);
 
 		gl.glBindBuffer(gl.GL_ARRAY_BUFFER, uvBufferId);
-		gl.glBufferData(gl.GL_ARRAY_BUFFER, uvBuffer.limit() * Float.BYTES, uvBuffer, gl.GL_STATIC_COPY);
+		gl.glBufferData(gl.GL_ARRAY_BUFFER, uvBuffer.limit() * Float.BYTES, uvBuffer.getBuffer(), gl.GL_STATIC_COPY);
 
 		gl.glBindBuffer(gl.GL_ARRAY_BUFFER, 0);
 
@@ -1523,11 +1520,7 @@ public class GpuPlugin extends Plugin implements DrawCallbacks
 				int faces = Math.min(MAX_TRIANGLE, model.getTrianglesCount());
 				vertexBuffer.ensureCapacity(12 * faces);
 				uvBuffer.ensureCapacity(12 * faces);
-				int len = 0;
-				for (int i = 0; i < faces; ++i)
-				{
-					len += sceneUploader.pushFace(model, i, false, vertexBuffer, uvBuffer, 0, 0, 0, 0);
-				}
+				int len = SceneUploader.pushModel(model, faces, false, vertexBuffer, uvBuffer);
 
 				GpuIntBuffer b = bufferForTriangles(faces);
 
@@ -1559,7 +1552,7 @@ public class GpuPlugin extends Plugin implements DrawCallbacks
 			return false;
 		}
 
-		targetBufferOffset += sceneUploader.pushFace(model, face, true, vertexBuffer, uvBuffer, modelX, modelY, modelZ, modelOrientation);
+		targetBufferOffset += SceneUploader.pushFace(model, face, true, vertexBuffer, uvBuffer, modelX, modelY, modelZ, modelOrientation);
 		return true;
 	}
 


### PR DESCRIPTION
Optimizations include:
- Loop hoisting.
- Iterating over all tiles in a scene once rather than twice.
- Aggregate model vertex and uv data into primitive arrays before copying to buffers.
- Avoid creating temporary buffers in Buffer.ensureCapacity().

A small test indicates that scenes are loaded ~33% quicker, from 48 to 32 milliseconds on my hardware.