### PR TITLE
Mining: Add Mining/Not Mining Overlay to Dense Essence

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/mining/MiningOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/mining/MiningOverlay.java
@@ -28,6 +28,7 @@ import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Graphics2D;
 import javax.inject.Inject;
+import net.runelite.api.AnimationID;
 import net.runelite.api.Client;
 import net.runelite.api.MenuAction;
 import net.runelite.api.Skill;
@@ -71,7 +72,7 @@ class MiningOverlay extends OverlayPanel
 		}
 
 		Pickaxe pickaxe = plugin.getPickaxe();
-		if (pickaxe != null && pickaxe.matchesMiningAnimation(client.getLocalPlayer()))
+		if (pickaxe != null && (pickaxe.matchesMiningAnimation(client.getLocalPlayer()) || client.getLocalPlayer().getAnimation() == AnimationID.DENSE_ESSENCE_CHIPPING))
 		{
 			panelComponent.getChildren().add(TitleComponent.builder()
 				.text("Mining")


### PR DESCRIPTION
Mining overlay for dense runestones [Mining / Not Mining] #12320

Needed additional way to start a MiningSession as mining dense essence doesn't have a chat message when you succeed.
Added check for addition animation as mining dense essence using multiple animations.