### PR TITLE
Scene uploader optimizations

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuFloatBuffer.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuFloatBuffer.java
@@ -37,6 +37,11 @@ class GpuFloatBuffer
 		buffer.put(texture).put(u).put(v).put(pad);
 	}
 
+	public void put(float[] src)
+	{
+		buffer.put(src);
+	}
+
 	void flip()
 	{
 		buffer.flip();

--- a/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuFloatBuffer.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuFloatBuffer.java
@@ -52,11 +52,17 @@ class GpuFloatBuffer
 		buffer.clear();
 	}
 
-	void ensureCapacity(int size)
+	void ensureCapacity(int requestedRemaining)
 	{
-		while (buffer.remaining() < size)
+		int capacity = buffer.capacity();
+		final int position = buffer.position();
+		if ((capacity - position) < requestedRemaining)
 		{
-			FloatBuffer newB = allocateDirect(buffer.capacity() * 2);
+			do {
+				capacity *= 2;
+			}
+			while ((capacity - position) < requestedRemaining);
+			FloatBuffer newB = allocateDirect(capacity);
 			buffer.flip();
 			newB.put(buffer);
 			buffer = newB;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuFloatBuffer.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuFloatBuffer.java
@@ -58,7 +58,8 @@ class GpuFloatBuffer
 		final int position = buffer.position();
 		if ((capacity - position) < requestedRemaining)
 		{
-			do {
+			do
+			{
 				capacity *= 2;
 			}
 			while ((capacity - position) < requestedRemaining);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuIntBuffer.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuIntBuffer.java
@@ -42,6 +42,11 @@ class GpuIntBuffer
 		buffer.put(x).put(y).put(z).put(c);
 	}
 
+	public void put(int[] src)
+	{
+		buffer.put(src);
+	}
+
 	void flip()
 	{
 		buffer.flip();

--- a/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuIntBuffer.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuIntBuffer.java
@@ -63,7 +63,8 @@ class GpuIntBuffer
 		final int position = buffer.position();
 		if ((capacity - position) < requestedRemaining)
 		{
-			do {
+			do
+			{
 				capacity *= 2;
 			}
 			while ((capacity - position) < requestedRemaining);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuIntBuffer.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuIntBuffer.java
@@ -57,11 +57,17 @@ class GpuIntBuffer
 		buffer.clear();
 	}
 
-	void ensureCapacity(int size)
+	void ensureCapacity(int requestedRemaining)
 	{
-		while (buffer.remaining() < size)
+		int capacity = buffer.capacity();
+		final int position = buffer.position();
+		if ((capacity - position) < requestedRemaining)
 		{
-			IntBuffer newB = allocateDirect(buffer.capacity() * 2);
+			do {
+				capacity *= 2;
+			}
+			while ((capacity - position) < requestedRemaining);
+			IntBuffer newB = allocateDirect(capacity);
 			buffer.flip();
 			newB.put(buffer);
 			buffer = newB;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/gpu/SceneUploader.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/gpu/SceneUploader.java
@@ -44,6 +44,10 @@ import net.runelite.api.WallObject;
 @Singleton
 class SceneUploader
 {
+
+	private static final int[] TWELVE_ZERO_INTS = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+	private static final float[] TWELVE_ZERO_FLOATS = { 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f };
+
 	@Inject
 	private Client client;
 
@@ -412,9 +416,7 @@ class SceneUploader
 				}
 				else
 				{
-					uvBuffer.put(0, 0, 0, 0f);
-					uvBuffer.put(0, 0, 0, 0f);
-					uvBuffer.put(0, 0, 0, 0f);
+					uvBuffer.put(TWELVE_ZERO_FLOATS);
 				}
 			}
 		}
@@ -508,15 +510,11 @@ class SceneUploader
 		}
 		else if (color3 == -2)
 		{
-			vertexBuffer.put(0, 0, 0, 0);
-			vertexBuffer.put(0, 0, 0, 0);
-			vertexBuffer.put(0, 0, 0, 0);
+			vertexBuffer.put(TWELVE_ZERO_INTS);
 
 			if (padUvs || faceTextures != null)
 			{
-				uvBuffer.put(0, 0, 0, 0f);
-				uvBuffer.put(0, 0, 0, 0f);
-				uvBuffer.put(0, 0, 0, 0f);
+				uvBuffer.put(TWELVE_ZERO_FLOATS);
 			}
 			return 3;
 		}
@@ -594,9 +592,7 @@ class SceneUploader
 			}
 			else
 			{
-				uvBuffer.put(0f, 0f, 0f, 0f);
-				uvBuffer.put(0f, 0f, 0f, 0f);
-				uvBuffer.put(0f, 0f, 0f, 0f);
+				uvBuffer.put(TWELVE_ZERO_FLOATS);
 			}
 		}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/gpu/SceneUploader.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/gpu/SceneUploader.java
@@ -45,9 +45,6 @@ import net.runelite.api.WallObject;
 class SceneUploader
 {
 
-	private static final int[] TWELVE_ZERO_INTS = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
-	private static final float[] TWELVE_ZERO_FLOATS = { 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f };
-
 	@Inject
 	private Client client;
 
@@ -323,7 +320,9 @@ class SceneUploader
 				}
 				else
 				{
-					uvBuffer.put(TWELVE_ZERO_FLOATS);
+					uvBuffer.put(0.0f, 0.0f, 0.0f, 0.0f);
+					uvBuffer.put(0.0f, 0.0f, 0.0f, 0.0f);
+					uvBuffer.put(0.0f, 0.0f, 0.0f, 0.0f);
 				}
 			}
 		}
@@ -381,11 +380,15 @@ class SceneUploader
 			}
 			else if (color3 == -2)
 			{
-				vertexBuffer.put(TWELVE_ZERO_INTS);
+				vertexBuffer.put(0, 0, 0, 0);
+				vertexBuffer.put(0, 0, 0, 0);
+				vertexBuffer.put(0, 0, 0, 0);
 
 				if (faceTextures != null)
 				{
-					uvBuffer.put(TWELVE_ZERO_FLOATS);
+					uvBuffer.put(0.0f, 0.0f, 0.0f, 0.0f);
+					uvBuffer.put(0.0f, 0.0f, 0.0f, 0.0f);
+					uvBuffer.put(0.0f, 0.0f, 0.0f, 0.0f);
 				}
 				len += 3;
 				continue;
@@ -458,11 +461,15 @@ class SceneUploader
 		}
 		else if (color3 == -2)
 		{
-			vertexBuffer.put(TWELVE_ZERO_INTS);
+			vertexBuffer.put(0, 0, 0, 0);
+			vertexBuffer.put(0, 0, 0, 0);
+			vertexBuffer.put(0, 0, 0, 0);
 
 			if (padUvs || faceTextures != null)
 			{
-				uvBuffer.put(TWELVE_ZERO_FLOATS);
+				uvBuffer.put(0.0f, 0.0f, 0.0f, 0.0f);
+				uvBuffer.put(0.0f, 0.0f, 0.0f, 0.0f);
+				uvBuffer.put(0.0f, 0.0f, 0.0f, 0.0f);
 			}
 			return 3;
 		}
@@ -563,7 +570,9 @@ class SceneUploader
 		}
 		else
 		{
-			uvBuffer.put(TWELVE_ZERO_FLOATS);
+			uvBuffer.put(0.0f, 0.0f, 0.0f, 0.0f);
+			uvBuffer.put(0.0f, 0.0f, 0.0f, 0.0f);
+			uvBuffer.put(0.0f, 0.0f, 0.0f, 0.0f);
 		}
 	}
 }


### PR DESCRIPTION
Optimize SceneUploader.upload(Scene scene)
- Remove the reset(Tile tile) codepath, a single iteration over the tiles is sufficient.
- Create an uploadModel() method optimized for static models.
- Modify the Buffer.ensureCapacity() methods to avoid allocating intermediate buffers.

Some quick testing indicates a 10-20% improvement in initial scene load time.