### PR TITLE
xpglobes: add option to keep all globes on screen until oldest expires

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesConfig.java
@@ -171,4 +171,15 @@ public interface XpGlobesConfig extends Config
 	{
 		return 10;
 	}
+
+	@ConfigItem(
+		keyName = "expireAtSameTime",
+		name = "Expire at the same time",
+		description = "Make all orbs expire at the same time",
+		position = 12
+	)
+	default boolean expireAtSameTime()
+	{
+		return false;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesPlugin.java
@@ -156,7 +156,21 @@ public class XpGlobesPlugin extends Plugin
 		{
 			Instant expireTime = Instant.now()
 				.minusSeconds(config.xpOrbDuration());
-			xpGlobes.removeIf(globe -> globe.getTime().isBefore(expireTime));
+			if (config.expireAtSameTime())
+			{
+				Instant latest = xpGlobes.stream()
+					.max(Comparator.comparing(XpGlobe::getTime))
+					.map(XpGlobe::getTime)
+					.get();
+				if (latest.isBefore(expireTime))
+				{
+					xpGlobes.clear();
+				}
+			}
+			else
+			{
+				xpGlobes.removeIf(globe -> globe.getTime().isBefore(expireTime));
+			}
 		}
 	}
 


### PR DESCRIPTION
Currently, XP Globes get removed as soon as they reach the timeout time. This PR adds an option that makes it so XP Globes only get removed when the newest globe reaches the timeout time.