### PR TITLE
Blast Furnace: Use border color for clickbox overlay fills

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/blastfurnace/BlastFurnaceClickBoxOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/blastfurnace/BlastFurnaceClickBoxOverlay.java
@@ -111,7 +111,7 @@ class BlastFurnaceClickBoxOverlay extends Overlay
 					graphics.setColor(color);
 				}
 				graphics.draw(objectClickbox);
-				graphics.setColor(new Color(0xFF, 0, 0, 20));
+				graphics.setColor(new Color(color.getRed(), color.getGreen(), color.getBlue(), 20));
 				graphics.fill(objectClickbox);
 			}
 		}


### PR DESCRIPTION
Previously, all clickbox overlays had a red translucent fill, even if the boundary is green and should symbolise a "good" state.
Now, use the same color as the border but with alpha for the fill.