### PR TITLE
World Map: adjusted the height of tooltip text to match vanilla tooltips

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/worldmap/WorldMapOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/worldmap/WorldMapOverlay.java
@@ -55,6 +55,7 @@ public class WorldMapOverlay extends Overlay
 	private static final int TOOLTIP_OFFSET_WIDTH = 5;
 	private static final int TOOLTIP_PADDING_HEIGHT = 1;
 	private static final int TOOLTIP_PADDING_WIDTH = 2;
+	private static final int TOOLTIP_TEXT_OFFSET_HEIGHT = -2;
 
 	private static final Splitter TOOLTIP_SPLITTER = Splitter.on("<br>").trimResults().omitEmptyStrings();
 
@@ -290,7 +291,7 @@ public class WorldMapOverlay extends Overlay
 		graphics.setColor(JagexColors.TOOLTIP_TEXT);
 		for (int i = 0; i < rows.size(); i++)
 		{
-			graphics.drawString(rows.get(i), drawPoint.getX(), drawPoint.getY() + (i + 1) * height);
+			graphics.drawString(rows.get(i), drawPoint.getX(), drawPoint.getY() + TOOLTIP_TEXT_OFFSET_HEIGHT + (i + 1) * height);
 		}
 	}
 


### PR DESCRIPTION
Current behaviour: 
![image](https://user-images.githubusercontent.com/11140337/90986023-d4116480-e577-11ea-85d1-8c64551809ab.png)

New behaviour:
![image](https://user-images.githubusercontent.com/11140337/90986026-dbd10900-e577-11ea-9d7e-979d49d0a76b.png)

Vanilla behaviour for reference:
![image](https://user-images.githubusercontent.com/11140337/90986032-e5f30780-e577-11ea-844d-b276dda5f0cd.png)
