### PR TITLE
Travis: Remove deprecated sudo tag, include recommended os tag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: java
-sudo: false
+os: linux
 dist: xenial
 cache:
   directories:


### PR DESCRIPTION
Travis' build config validation complained about these two things. 
Source: [Travis are recommending removing the **sudo** tag.](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration)