### PR TITLE
DevTools: Add Movement Flags DevTools Plugin.

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/devtools/DevToolsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/devtools/DevToolsOverlay.java
@@ -35,6 +35,7 @@ import java.awt.Rectangle;
 import java.awt.Shape;
 import java.awt.geom.Rectangle2D;
 import java.util.List;
+import java.util.Set;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import net.runelite.api.Client;
@@ -114,7 +115,7 @@ class DevToolsOverlay extends Overlay
 			renderNpcs(graphics);
 		}
 
-		if (plugin.getGroundItems().isActive() || plugin.getGroundObjects().isActive() || plugin.getGameObjects().isActive() || plugin.getWalls().isActive() || plugin.getDecorations().isActive() || plugin.getTileLocation().isActive())
+		if (plugin.getGroundItems().isActive() || plugin.getGroundObjects().isActive() || plugin.getGameObjects().isActive() || plugin.getWalls().isActive() || plugin.getDecorations().isActive() || plugin.getTileLocation().isActive() || plugin.getMovementFlags().isActive())
 		{
 			renderTileObjects(graphics);
 		}
@@ -235,6 +236,11 @@ class DevToolsOverlay extends Overlay
 				{
 					renderTileTooltip(graphics, tile);
 				}
+
+				if (plugin.getMovementFlags().isActive())
+				{
+					renderMovementInfo(graphics, tile);
+				}
 			}
 		}
 	}
@@ -245,6 +251,35 @@ class DevToolsOverlay extends Overlay
 		if (poly != null && poly.contains(client.getMouseCanvasPosition().getX(), client.getMouseCanvasPosition().getY()))
 		{
 			toolTipManager.add(new Tooltip("World Location: " + tile.getWorldLocation().getX() + ", " + tile.getWorldLocation().getY() + ", " + client.getPlane()));
+			OverlayUtil.renderPolygon(graphics, poly, GREEN);
+		}
+	}
+
+	private void renderMovementInfo(Graphics2D graphics, Tile tile)
+	{
+		Polygon poly = Perspective.getCanvasTilePoly(client, tile.getLocalLocation());
+
+		if (poly == null || !poly.contains(client.getMouseCanvasPosition().getX(), client.getMouseCanvasPosition().getY()))
+		{
+			return;
+		}
+
+		if (client.getCollisionMaps() != null)
+		{
+			int[][] flags = client.getCollisionMaps()[client.getPlane()].getFlags();
+			int data = flags[tile.getSceneLocation().getX()][tile.getSceneLocation().getY()];
+
+			Set<MovementFlag> movementFlags = MovementFlag.getSetFlags(data);
+
+			if (movementFlags.isEmpty())
+			{
+				toolTipManager.add(new Tooltip("No movement flags"));
+			}
+			else
+			{
+				movementFlags.forEach(flag -> toolTipManager.add(new Tooltip(flag.toString())));
+			}
+
 			OverlayUtil.renderPolygon(graphics, poly, GREEN);
 		}
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/devtools/DevToolsPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/devtools/DevToolsPanel.java
@@ -112,6 +112,7 @@ class DevToolsPanel extends PluginPanel
 
 		container.add(plugin.getLineOfSight());
 		container.add(plugin.getValidMovement());
+		container.add(plugin.getMovementFlags());
 		container.add(plugin.getInteracting());
 		container.add(plugin.getExamine());
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/devtools/DevToolsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/devtools/DevToolsPlugin.java
@@ -129,6 +129,7 @@ public class DevToolsPlugin extends Plugin
 	private DevToolsButton chunkBorders;
 	private DevToolsButton mapSquares;
 	private DevToolsButton validMovement;
+	private DevToolsButton movementFlags;
 	private DevToolsButton lineOfSight;
 	private DevToolsButton cameraPosition;
 	private DevToolsButton worldMapLocation;
@@ -175,6 +176,7 @@ public class DevToolsPlugin extends Plugin
 
 		lineOfSight = new DevToolsButton("Line Of Sight");
 		validMovement = new DevToolsButton("Valid Movement");
+		movementFlags = new DevToolsButton("Movement Flags");
 		interacting = new DevToolsButton("Interacting");
 		examine = new DevToolsButton("Examine");
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/devtools/MovementFlag.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/devtools/MovementFlag.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2020, Pratted <https://github.com/Pratted>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.devtools;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import net.runelite.api.CollisionDataFlag;
+
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * An enum that binds a name to each movement flag.
+ *
+ * @see CollisionDataFlag
+ */
+@AllArgsConstructor
+enum MovementFlag
+{
+	BLOCK_MOVEMENT_NORTH_WEST(CollisionDataFlag.BLOCK_MOVEMENT_NORTH_WEST),
+	BLOCK_MOVEMENT_NORTH(CollisionDataFlag.BLOCK_MOVEMENT_NORTH),
+	BLOCK_MOVEMENT_NORTH_EAST(CollisionDataFlag.BLOCK_MOVEMENT_NORTH_EAST),
+	BLOCK_MOVEMENT_EAST(CollisionDataFlag.BLOCK_MOVEMENT_EAST),
+	BLOCK_MOVEMENT_SOUTH_EAST(CollisionDataFlag.BLOCK_MOVEMENT_SOUTH_EAST),
+	BLOCK_MOVEMENT_SOUTH(CollisionDataFlag.BLOCK_MOVEMENT_SOUTH),
+	BLOCK_MOVEMENT_SOUTH_WEST(CollisionDataFlag.BLOCK_MOVEMENT_SOUTH_WEST),
+	BLOCK_MOVEMENT_WEST(CollisionDataFlag.BLOCK_MOVEMENT_WEST),
+
+	BLOCK_MOVEMENT_OBJECT(CollisionDataFlag.BLOCK_MOVEMENT_OBJECT),
+	BLOCK_MOVEMENT_FLOOR_DECORATION(CollisionDataFlag.BLOCK_MOVEMENT_FLOOR_DECORATION),
+	BLOCK_MOVEMENT_FLOOR(CollisionDataFlag.BLOCK_MOVEMENT_FLOOR),
+	BLOCK_MOVEMENT_FULL(CollisionDataFlag.BLOCK_MOVEMENT_FULL);
+
+	@Getter
+	private int flag;
+
+	/**
+	 * @param collisionData The tile collision flags.
+	 * @return The set of {@link MovementFlag}s that have been set.
+	 */
+	public static Set<MovementFlag> getSetFlags(int collisionData)
+	{
+		return Arrays.stream(values())
+			.filter(movementFlag -> (movementFlag.flag & collisionData) > 0)
+			.collect(Collectors.toSet());
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/devtools/MovementFlag.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/devtools/MovementFlag.java
@@ -64,7 +64,7 @@ enum MovementFlag
 	public static Set<MovementFlag> getSetFlags(int collisionData)
 	{
 		return Arrays.stream(values())
-			.filter(movementFlag -> (movementFlag.flag & collisionData) > 0)
+			.filter(movementFlag -> (movementFlag.flag & collisionData) != 0)
 			.collect(Collectors.toSet());
 	}
 }


### PR DESCRIPTION
Background: I created this tool to assist a Hallowed Sepulchre plugin (in progress) and I thought it might be useful to others.

This plugin highlights the tile the player is currently hovering over and displays the movement flags above it. The movement flags can be useful for pathfinding and other debugging purposes.

<img width="762" alt="Screen Shot 2020-08-26 at 2 03 54 PM" src="https://user-images.githubusercontent.com/19481676/91341554-a9a5ee00-e7a7-11ea-9c15-7094b48fed2f.png">
<img width="762" alt="Screen Shot 2020-08-26 at 2 04 07 PM" src="https://user-images.githubusercontent.com/19481676/91341546-a7439400-e7a7-11ea-9734-4d82c19c9e07.png">
<img width="762" alt="Screen Shot 2020-08-26 at 2 04 26 PM" src="https://user-images.githubusercontent.com/19481676/91341522-9e52c280-e7a7-11ea-8f2d-c372dede0865.png">
<img width="762" alt="Screen Shot 2020-08-26 at 2 04 36 PM" src="https://user-images.githubusercontent.com/19481676/91341507-9b57d200-e7a7-11ea-8933-a936ef0cd153.png">