### PR TITLE
Added hallowed sepulchre floors into the agility calculator

### DIFF
--- a/runelite-client/src/main/resources/net/runelite/client/plugins/skillcalculator/skill_agility.json
+++ b/runelite-client/src/main/resources/net/runelite/client/plugins/skillcalculator/skill_agility.json
@@ -79,6 +79,12 @@
       "xp": 571
     },
     {
+      "level": 52,
+      "icon": 11849,
+      "name": "Hallowed Sepulchre Floor 1",
+      "xp": 575
+    },
+    {
       "level": 60,
       "icon": 11849,
       "name": "Seers' Village Rooftop",
@@ -91,10 +97,22 @@
       "xp": 730
     },
     {
+      "level": 62,
+      "icon": 11849,
+      "name": "Hallowed Sepulchre Floor 2",
+      "xp": 925
+    },
+    {
       "level": 70,
       "icon": 11849,
       "name": "Pollnivneach Rooftop",
       "xp": 890
+    },
+    {
+      "level": 72,
+      "icon": 11849,
+      "name": "Hallowed Sepulchre Floor 3",
+      "xp": 1500
     },
     {
       "level": 75,
@@ -109,10 +127,22 @@
       "xp": 780
     },
     {
+      "level": 82,
+      "icon": 11849,
+      "name": "Hallowed Sepulchre Floor 4",
+      "xp": 2700
+    },
+    {
       "level": 90,
       "icon": 11849,
       "name": "Ardougne Rooftop",
       "xp": 793
+    },
+    {
+      "level": 92,
+      "icon": 11849,
+      "name": "Hallowed Sepulchre Floor 5",
+      "xp": 6000
     }
   ]
 }

--- a/runelite-client/src/main/resources/net/runelite/client/plugins/skillcalculator/skill_agility.json
+++ b/runelite-client/src/main/resources/net/runelite/client/plugins/skillcalculator/skill_agility.json
@@ -80,7 +80,7 @@
     },
     {
       "level": 52,
-      "icon": 11849,
+      "icon": 24736,
       "name": "Hallowed Sepulchre Floor 1",
       "xp": 575
     },
@@ -98,7 +98,7 @@
     },
     {
       "level": 62,
-      "icon": 11849,
+      "icon": 24736,
       "name": "Hallowed Sepulchre Floor 2",
       "xp": 925
     },
@@ -110,7 +110,7 @@
     },
     {
       "level": 72,
-      "icon": 11849,
+      "icon": 24736,
       "name": "Hallowed Sepulchre Floor 3",
       "xp": 1500
     },
@@ -128,7 +128,7 @@
     },
     {
       "level": 82,
-      "icon": 11849,
+      "icon": 24736,
       "name": "Hallowed Sepulchre Floor 4",
       "xp": 2700
     },
@@ -140,7 +140,7 @@
     },
     {
       "level": 92,
-      "icon": 11849,
+      "icon": 24736,
       "name": "Hallowed Sepulchre Floor 5",
       "xp": 6000
     }


### PR DESCRIPTION
This merge adds each hallowed sepulchre agility course into the agility calculator by floor, not sure how we would go about making "combined" run when a person completes floors from 1-5 in one go, not sure if that needs to be handled? Icon might need to be changed so happy to take suggestions