### PR TITLE
worldmap: add Mahogany Homes and Soul Wars minigame locations

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldmap/MinigameLocation.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldmap/MinigameLocation.java
@@ -75,7 +75,9 @@ enum MinigameLocation
 	MAHOGANY_HOMES_ARDOUGNE("Mahogany Homes", new WorldPoint(2634, 3295, 0)),
 	MAHOGANY_HOMES_FALADOR("Mahogany Homes", new WorldPoint(2989, 3363, 0)),
 	MAHOGANY_HOMES_HOSIDIUS("Mahogany Homes", new WorldPoint(1780, 3623, 0)),
-	MAHOGANY_HOMES_VARROCK("Mahogany Homes", new WorldPoint(3240, 3471, 0));
+	MAHOGANY_HOMES_VARROCK("Mahogany Homes", new WorldPoint(3240, 3471, 0)),
+	SOUL_WARS("Soul Wars", new WorldPoint(2209, 2855, 0)),
+	SOUL_WARS_EDGEVILLE_PORTAL("Soul Wars", new WorldPoint(3082, 3474, 0));
 
 	private final String tooltip;
 	private final WorldPoint location;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldmap/MinigameLocation.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldmap/MinigameLocation.java
@@ -71,7 +71,11 @@ enum MinigameLocation
 	CATAPULT_ROOM("Catapult Room", new WorldPoint(2842, 3545, 0)),
 	SHOT_PUT_ROOM("Shot Put Room", new WorldPoint(2863, 3550, 0)),
 	HALLOWED_SEPULCHRE("Hallowed Sepulchre", new WorldPoint(3653, 3386, 1)),
-	THE_GAUNTLET("The Gauntlet", new WorldPoint(3223, 12505, 1));
+	THE_GAUNTLET("The Gauntlet", new WorldPoint(3223, 12505, 1)),
+	MAHOGANY_HOMES_ARDOUGNE("Mahogany Homes", new WorldPoint(2634, 3295, 0)),
+	MAHOGANY_HOMES_FALADOR("Mahogany Homes", new WorldPoint(2989, 3363, 0)),
+	MAHOGANY_HOMES_HOSIDIUS("Mahogany Homes", new WorldPoint(1780, 3623, 0)),
+	MAHOGANY_HOMES_VARROCK("Mahogany Homes", new WorldPoint(3240, 3471, 0));
 
 	private final String tooltip;
 	private final WorldPoint location;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldmap/TransportationPointLocation.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldmap/TransportationPointLocation.java
@@ -192,6 +192,7 @@ enum TransportationPointLocation
 	MUSHTREE_TAR_SWAMP("Mushtree", new WorldPoint(3676, 3755, 0)),
 	MUSHTREE_VERDANT_VALLEY("Mushtree", new WorldPoint(3757, 3756, 0)),
 	MYTHS_GUILD_PORTAL("Portal to Guilds", new WorldPoint(2456, 2856, 0)),
+	SOUL_WARS_PORTAL("Portal to Edgeville/Ferox Enclave", new WorldPoint(2204, 2858, 0)),
 	TRAIN_KELDAGRIM("Railway Station", new WorldPoint(2941, 10179, 0)),
 	WILDERNESS_LEVER_ARDOUGNE("Wilderness Lever to Deserted Keep", new WorldPoint(2559, 3309, 0), new WorldPoint(3154, 3924, 0)),
 	WILDERNESS_LEVER_EDGEVILLE("Wilderness Lever to Deserted Keep", new WorldPoint(3088, 3474, 0), new WorldPoint(3154, 3924, 0)),


### PR DESCRIPTION
Adds Mahogany Homes minigame locations (Falador, Varrock, Hosidius, and Ardougne) to the world map

EDIT 1/11/21: Adds Soul Wars minigame and teleport locations

![image](https://user-images.githubusercontent.com/54762282/104262207-2b47a100-5455-11eb-8148-2ee8225fb264.png)

![image](https://user-images.githubusercontent.com/54762282/104262220-34387280-5455-11eb-958b-2bc33645d468.png)

![image](https://user-images.githubusercontent.com/54762282/104262225-38649000-5455-11eb-9f0a-3201e79cd581.png)


![java_URVZ4PE7nC](https://user-images.githubusercontent.com/54762282/91624609-4961a880-e96f-11ea-9f0c-dd60ea5cce58.png)
![java_QuZLyTojkR](https://user-images.githubusercontent.com/54762282/91624610-49fa3f00-e96f-11ea-98e7-720b172b0c12.png)
![java_ZVyw16DkHi](https://user-images.githubusercontent.com/54762282/91624611-49fa3f00-e96f-11ea-9a59-229b712cd77d.png)
![java_9P2rCGiqnq](https://user-images.githubusercontent.com/54762282/91624612-49fa3f00-e96f-11ea-9fb7-541f216b738a.png)



