### PR TITLE
Inferno timer improvements

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/timers/ElapsedTimer.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timers/ElapsedTimer.java
@@ -55,7 +55,7 @@ class ElapsedTimer extends InfoBox
 		}
 
 		Duration time = Duration.between(startTime, lastTime == null ? Instant.now() : lastTime);
-		final String formatString = time.toHours() > 0 ? "HH:mm" : "mm:ss";
+		final String formatString = "mm:ss";
 		return DurationFormatUtils.formatDuration(time.toMillis(), formatString, true);
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersPlugin.java
@@ -119,8 +119,8 @@ public class TimersPlugin extends Plugin
 	private static final int VENOM_VALUE_CUTOFF = -40; // Antivenom < -40 <= Antipoison < 0
 	private static final int POISON_TICK_LENGTH = 30;
 
-	private static final int FIGHT_CAVES_REGION_ID = 9551;
-	private static final int INFERNO_REGION_ID = 9043;
+	static final int FIGHT_CAVES_REGION_ID = 9551;
+	static final int INFERNO_REGION_ID = 9043;
 	private static final Pattern TZHAAR_WAVE_MESSAGE = Pattern.compile("Wave: (\\d+)");
 	private static final String TZHAAR_DEFEATED_MESSAGE = "You have been defeated!";
 	private static final Pattern TZHAAR_COMPLETE_MESSAGE = Pattern.compile("Your (TzTok-Jad|TzKal-Zuk) kill count is:");
@@ -679,7 +679,16 @@ public class TimersPlugin extends Plugin
 				int wave = Integer.parseInt(matcher.group(1));
 				if (wave == 1)
 				{
-					config.tzhaarStartTime(now);
+					if (isInInferno())
+					{
+						// The first wave message of the inferno comes six seconds after the ingame timer starts counting
+						config.tzhaarStartTime(now.minus(Duration.ofSeconds(6)));
+					}
+					else
+					{
+						config.tzhaarStartTime(now);
+					}
+
 					createTzhaarTimer();
 				}
 			}

--- a/runelite-client/src/test/java/net/runelite/client/plugins/timers/ElapsedTimerTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/timers/ElapsedTimerTest.java
@@ -48,13 +48,13 @@ public class ElapsedTimerTest
 		assertEquals("05:00", timerText(fiveMinutesAgo, null));
 		assertEquals("55:00", timerText(oneHourAgo, fiveMinutesAgo));
 		assertEquals("59:55", timerText(oneHourAgo, fiveSecondsAgo));
-		assertEquals("01:00", timerText(oneHourAgo, now));
-		assertEquals("01:00", timerText(oneHourAgo, null));
-		assertEquals("04:00", timerText(fiveHoursAgo, oneHourAgo));
-		assertEquals("04:55", timerText(fiveHoursAgo, fiveMinutesAgo));
-		assertEquals("04:59", timerText(fiveHoursAgo, fiveSecondsAgo));
-		assertEquals("05:00", timerText(fiveHoursAgo, now));
-		assertEquals("05:00", timerText(fiveHoursAgo, null));
+		assertEquals("60:00", timerText(oneHourAgo, now));
+		assertEquals("60:00", timerText(oneHourAgo, null));
+		assertEquals("240:00", timerText(fiveHoursAgo, oneHourAgo));
+		assertEquals("295:00", timerText(fiveHoursAgo, fiveMinutesAgo));
+		assertEquals("299:55", timerText(fiveHoursAgo, fiveSecondsAgo));
+		assertEquals("300:00", timerText(fiveHoursAgo, now));
+		assertEquals("300:00", timerText(fiveHoursAgo, null));
 	}
 
 	private static String timerText(final Instant startTime, final Instant lastTime)


### PR DESCRIPTION
Closes #12401

Fixed inferno timer being 10 ticks (6 seconds) behind. Timer now starts at `00:06` once `Wave 1` message is displayed.

Elapsed timer now displays in `mm:ss` to be better inline with the ingame timer.