### PR TITLE
Sort plugin search results with better text matches higher in search results

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/PluginListItem.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/PluginListItem.java
@@ -53,7 +53,7 @@ import net.runelite.client.ui.PluginPanel;
 import net.runelite.client.util.ImageUtil;
 import net.runelite.client.util.SwingUtil;
 
-class PluginListItem extends JPanel
+class PluginListItem extends JPanel implements SearchablePlugin
 {
 	private static final ImageIcon CONFIG_ICON;
 	private static final ImageIcon CONFIG_ICON_HOVER;
@@ -183,7 +183,14 @@ class PluginListItem extends JPanel
 		}
 	}
 
-	boolean isPinned()
+	@Override
+	public String getSearchableName()
+	{
+		return pluginConfig.getName();
+	}
+
+	@Override
+	public boolean isPinned()
 	{
 		return pinButton.isSelected();
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/PluginListPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/PluginListPanel.java
@@ -262,31 +262,9 @@ class PluginListPanel extends PluginPanel
 	private void onSearchBarChanged()
 	{
 		final String text = searchBar.getText();
-
 		pluginList.forEach(mainPanel::remove);
-
-		showMatchingPlugins(true, text);
-		showMatchingPlugins(false, text);
-
+		PluginSearch.search(pluginList, text).forEach(mainPanel::add);
 		revalidate();
-	}
-
-	private void showMatchingPlugins(boolean pinned, String text)
-	{
-		if (text.isEmpty())
-		{
-			pluginList.stream().filter(item -> pinned == item.isPinned()).forEach(mainPanel::add);
-			return;
-		}
-
-		final String[] searchTerms = text.toLowerCase().split(" ");
-		pluginList.forEach(listItem ->
-		{
-			if (pinned == listItem.isPinned() && Text.matchesSearchTerms(searchTerms, listItem.getKeywords()))
-			{
-				mainPanel.add(listItem);
-			}
-		});
 	}
 
 	void openConfigurationPanel(String configGroup)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/PluginSearch.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/PluginSearch.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2020, Jack Hodkinson <https://github.com/jrhodkinson>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.config;
+
+import com.google.common.base.Splitter;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+import net.runelite.client.util.Text;
+import org.apache.commons.lang3.StringUtils;
+
+public class PluginSearch
+{
+	private static final Splitter SPLITTER = Splitter.on(" ").trimResults().omitEmptyStrings();
+
+	public static <T extends SearchablePlugin> List<T> search(Collection<T> searchablePlugins, String query)
+	{
+		return searchablePlugins.stream()
+			.filter(plugin -> Text.matchesSearchTerms(SPLITTER.split(query.toLowerCase()), plugin.getKeywords()))
+			.sorted(comparator(query))
+			.collect(Collectors.toList());
+	}
+
+	private static Comparator<SearchablePlugin> comparator(String query)
+	{
+		if (StringUtils.isBlank(query))
+		{
+			return Comparator.nullsLast(Comparator.comparing(SearchablePlugin::isPinned, Comparator.nullsLast(Comparator.reverseOrder())))
+				.thenComparing(SearchablePlugin::getSearchableName, Comparator.nullsLast(Comparator.naturalOrder()));
+		}
+		Iterable<String> queryPieces = SPLITTER.split(query.toLowerCase());
+		return Comparator.nullsLast(Comparator.comparing((SearchablePlugin sp) -> query.equalsIgnoreCase(sp.getSearchableName()), Comparator.reverseOrder()))
+			.thenComparing(sp ->
+			{
+				if (sp.getSearchableName() == null)
+				{
+					return 0L;
+				}
+				return stream(SPLITTER.split(sp.getSearchableName()))
+					.filter(piece -> stream(queryPieces).anyMatch(qp -> containsOrIsContainedBy(piece.toLowerCase(), qp)))
+					.count();
+			}, Comparator.reverseOrder())
+			.thenComparing(sp ->
+			{
+				if (sp.getKeywords() == null)
+				{
+					return 0L;
+				}
+				return stream(sp.getKeywords())
+					.filter(piece -> stream(queryPieces).anyMatch(qp -> containsOrIsContainedBy(piece.toLowerCase(), qp)))
+					.count();
+			}, Comparator.reverseOrder())
+			.thenComparing(SearchablePlugin::isPinned, Comparator.nullsLast(Comparator.reverseOrder()))
+			.thenComparing(SearchablePlugin::getSearchableName, Comparator.nullsLast(Comparator.naturalOrder()));
+	}
+
+	private static Stream<String> stream(Iterable<String> iterable)
+	{
+		return StreamSupport.stream(iterable.spliterator(), false);
+	}
+
+	private static boolean containsOrIsContainedBy(String a, String b)
+	{
+		return a.contains(b) || b.contains(a);
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/SearchablePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/SearchablePlugin.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2020, Jack Hodkinson <https://github.com/jrhodkinson>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.config;
+
+import java.util.List;
+
+public interface SearchablePlugin
+{
+	String getSearchableName();
+
+	List<String> getKeywords();
+
+	default boolean isPinned()
+	{
+		return false;
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/util/Text.java
+++ b/runelite-client/src/main/java/net/runelite/client/util/Text.java
@@ -221,7 +221,7 @@ public class Text
 	 *
 	 * @return true if all search terms matches at least one keyword, or false if otherwise.
 	 */
-	public static boolean matchesSearchTerms(String[] searchTerms, final Collection<String> keywords)
+	public static boolean matchesSearchTerms(Iterable<String> searchTerms, final Collection<String> keywords)
 	{
 		for (String term : searchTerms)
 		{

--- a/runelite-client/src/test/java/net/runelite/client/plugins/config/PluginSearchTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/config/PluginSearchTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2020, Jack Hodkinson <https://github.com/jrhodkinson>
+ * All rights reserved
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.config;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+
+public class PluginSearchTest
+{
+	private Map<String, SearchablePlugin> plugins;
+
+	@Before
+	public void setUp()
+	{
+		plugins = new HashMap<>();
+		plugins.put("Discord", new TestSearchablePlugin("Discord", false, "action", "activity", "external", "integration", "status"));
+		plugins.put("Emojis", new TestSearchablePlugin("Emojis", true, "replaces", "common", "emoticons"));
+		plugins.put("Grand Exchange", new TestSearchablePlugin("Grand Exchange", true, "external", "integration", "notifications", "panel", "prices", "trade"));
+		plugins.put("Status Bars", new TestSearchablePlugin("Status Bars", false, "Draws", "status", "bars"));
+	}
+
+	@Test
+	public void emptyQueryReturnsPluginsInAlphabeticalOrderWithPinnedItemsFirst()
+	{
+		List<SearchablePlugin> results = PluginSearch.search(plugins.values(), " ");
+		assertThat(results, containsInAnyOrder(plugins.values().toArray(new SearchablePlugin[] {})));
+	}
+
+	@Test
+	public void searchReturnsMatchingPlugins()
+	{
+		List<SearchablePlugin> results = PluginSearch.search(plugins.values(), "sTATus");
+		assertThat(results, hasSize(2));
+		assertThat(results, containsInAnyOrder(plugins.get("Discord"), plugins.get("Status Bars")));
+	}
+
+	@Test
+	public void searchOrdersItemsWithMatchesInTitleFirst()
+	{
+		List<SearchablePlugin> results = PluginSearch.search(plugins.values(), "STATUS");
+		assertThat(results.get(0), equalTo(plugins.get("Status Bars")));
+	}
+
+	@Test
+	public void searchOrdersPinnedItemsFirstIfThereAreNoExactMatches()
+	{
+		List<SearchablePlugin> results = PluginSearch.search(plugins.values(), "integrat");
+		assertThat(results, contains(plugins.get("Grand Exchange"), plugins.get("Discord")));
+	}
+
+	private static class TestSearchablePlugin implements SearchablePlugin
+	{
+		private final String name;
+		private final boolean pinned;
+		private final List<String> keywords;
+
+		public TestSearchablePlugin(String name, boolean pinned, String... keywords)
+		{
+			this.name = name;
+			this.pinned = pinned;
+			this.keywords = Arrays.asList(keywords);
+		}
+
+		@Override
+		public String getSearchableName()
+		{
+			return name;
+		}
+
+		@Override
+		public boolean isPinned()
+		{
+			return pinned;
+		}
+
+		@Override
+		public List<String> getKeywords()
+		{
+			return keywords;
+		}
+	}
+}


### PR DESCRIPTION
Resolves https://github.com/runelite/runelite/issues/11520

- Introduce `SearchablePlugin` and extract plugin search code to `PluginSearch`, which is now used by both internal and external plugin searches
- Order search results using a few heuristics such that exact or close text matches occur higher up in the results

I tried using JaroWinklerDistance but it didn't have very good results, probably due to the varying name-length of plugins, so I settled on more human heuristics.

![Screenshot 2020-09-01 at 20 50 39](https://user-images.githubusercontent.com/1873155/91899266-cd2fd380-ec94-11ea-854d-bdf4080ce4ec.png)
![Screenshot 2020-09-01 at 20 51 24](https://user-images.githubusercontent.com/1873155/91899349-ee90bf80-ec94-11ea-981e-1563e3fe98ab.png)
![Screenshot 2020-09-01 at 20 52 34](https://user-images.githubusercontent.com/1873155/91899437-1122d880-ec95-11ea-8944-2e99bd83ea85.png)