### PR TITLE
Enhancement: Add Blisterwood Logs to Skill Calculator Plugin

### DIFF
--- a/runelite-client/src/main/resources/net/runelite/client/plugins/skillcalculator/skill_firemaking.json
+++ b/runelite-client/src/main/resources/net/runelite/client/plugins/skillcalculator/skill_firemaking.json
@@ -61,6 +61,12 @@
       "xp": 202.5
     },
     {
+      "level": 62,
+      "icon": 24691,
+      "name": "Blisterwood Logs",
+      "xp": 96
+    },
+    {
       "level": 75,
       "icon": 1513,
       "name": "Magic Logs",

--- a/runelite-client/src/main/resources/net/runelite/client/plugins/skillcalculator/skill_woodcutting.json
+++ b/runelite-client/src/main/resources/net/runelite/client/plugins/skillcalculator/skill_woodcutting.json
@@ -1,6 +1,9 @@
 {
   "bonuses": [
-    { "name": "Lumberjack Outfit (+2.5%)", "value": 0.025 }
+    {
+      "name": "Lumberjack Outfit (+2.5%)",
+      "value": 0.025
+    }
   ],
   "actions": [
     {
@@ -62,6 +65,12 @@
       "icon": 1515,
       "name": "Yew Logs",
       "xp": 175
+    },
+    {
+      "level": 62,
+      "icon": 24691,
+      "name": "Blisterwood Logs",
+      "xp": 76
     },
     {
       "level": 65,

--- a/runelite-client/src/main/resources/net/runelite/client/plugins/skillcalculator/skill_woodcutting.json
+++ b/runelite-client/src/main/resources/net/runelite/client/plugins/skillcalculator/skill_woodcutting.json
@@ -1,9 +1,6 @@
 {
   "bonuses": [
-    {
-      "name": "Lumberjack Outfit (+2.5%)",
-      "value": 0.025
-    }
+    { "name": "Lumberjack Outfit (+2.5%)", "value": 0.025 }
   ],
   "actions": [
     {


### PR DESCRIPTION
Close #12455

Add entries to Woodcutting and Firemaking skills for Blisterwood logs.