### PR TITLE
inventoryviewer: Add a keybind toggle to hide the overlay.

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/inventoryviewer/InventoryViewerConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/inventoryviewer/InventoryViewerConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 AWPH-I
+ * Copyright (c) 2020, Matthew C <Chapman.L.Matthew@gmail.com>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -24,61 +24,35 @@
  */
 package net.runelite.client.plugins.inventoryviewer;
 
-import com.google.inject.Provides;
-import javax.inject.Inject;
-import net.runelite.client.config.ConfigManager;
-import net.runelite.client.input.KeyManager;
-import net.runelite.client.plugins.Plugin;
-import net.runelite.client.plugins.PluginDescriptor;
-import net.runelite.client.ui.overlay.OverlayManager;
-import net.runelite.client.util.HotkeyListener;
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.Keybind;
 
-@PluginDescriptor(
-	name = "Inventory Viewer",
-	description = "Add an overlay showing the contents of your inventory",
-	tags = {"alternate", "items", "overlay", "second"},
-	enabledByDefault = false
-)
-public class InventoryViewerPlugin extends Plugin
+@ConfigGroup(InventoryViewerConfig.GROUP)
+public interface InventoryViewerConfig extends Config
 {
-	@Inject
-	private InventoryViewerConfig config;
+	String GROUP = "inventoryViewer";
 
-	@Inject
-	private InventoryViewerOverlay overlay;
-
-	@Inject
-	private OverlayManager overlayManager;
-
-	@Inject
-	private KeyManager keyManager;
-
-	@Provides
-	InventoryViewerConfig getConfig(ConfigManager configManager)
+	@ConfigItem(
+		keyName = "toggleKeybind",
+		name = "Toggle Overlay",
+		description = "Binds a key (combination) to toggle the overlay.",
+		position = 0
+	)
+	default Keybind toggleKeybind()
 	{
-		return configManager.getConfig(InventoryViewerConfig.class);
+		return Keybind.NOT_SET;
 	}
 
-	@Override
-	public void startUp()
+	@ConfigItem(
+		keyName = "hiddenDefault",
+		name = "Hidden by default",
+		description = "Whether or not the overlay is hidden by default.",
+		position = 1
+	)
+	default boolean hiddenDefault()
 	{
-		overlayManager.add(overlay);
-		keyManager.registerKeyListener(hotkeyListener);
+		return false;
 	}
-
-	@Override
-	public void shutDown()
-	{
-		overlayManager.remove(overlay);
-		keyManager.unregisterKeyListener(hotkeyListener);
-	}
-
-	private final HotkeyListener hotkeyListener = new HotkeyListener(() -> config.toggleKeybind())
-	{
-		@Override
-		public void hotkeyPressed()
-		{
-			overlay.toggle();
-		}
-	};
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/inventoryviewer/InventoryViewerOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/inventoryviewer/InventoryViewerOverlay.java
@@ -49,9 +49,10 @@ class InventoryViewerOverlay extends OverlayPanel
 
 	private final Client client;
 	private final ItemManager itemManager;
+	private boolean hidden;
 
 	@Inject
-	private InventoryViewerOverlay(Client client, ItemManager itemManager)
+	private InventoryViewerOverlay(Client client, ItemManager itemManager, InventoryViewerConfig config)
 	{
 		setPosition(OverlayPosition.BOTTOM_RIGHT);
 		panelComponent.setWrap(true);
@@ -60,11 +61,17 @@ class InventoryViewerOverlay extends OverlayPanel
 		panelComponent.setOrientation(ComponentOrientation.HORIZONTAL);
 		this.itemManager = itemManager;
 		this.client = client;
+		this.hidden = config.hiddenDefault();
 	}
 
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
+		if (hidden)
+		{
+			return null;
+		}
+
 		final ItemContainer itemContainer = client.getItemContainer(InventoryID.INVENTORY);
 
 		if (itemContainer == null)
@@ -101,5 +108,10 @@ class InventoryViewerOverlay extends OverlayPanel
 	{
 		ItemComposition itemComposition = itemManager.getItemComposition(item.getId());
 		return itemManager.getImage(item.getId(), item.getQuantity(), itemComposition.isStackable());
+	}
+
+	protected void toggle()
+	{
+		hidden = !hidden;
 	}
 }


### PR DESCRIPTION
Closes #12298
Also possibly closes #4148

Added a toggle for the Inventory Viewer plugin's overlay. Added a toggle which hides the overlay on start, this is off by default.