### PR TITLE
corp: Add toggle for dark energy core highlighting.

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/corp/CoreOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/corp/CoreOverlay.java
@@ -40,19 +40,26 @@ class CoreOverlay extends Overlay
 {
 	private final Client client;
 	private final CorpPlugin corpPlugin;
+	private final CorpConfig config;
 
 	@Inject
-	private CoreOverlay(Client client, CorpPlugin corpPlugin)
+	private CoreOverlay(Client client, CorpPlugin corpPlugin, CorpConfig corpConfig)
 	{
 		setPosition(OverlayPosition.DYNAMIC);
 		setLayer(OverlayLayer.ABOVE_SCENE);
 		this.client = client;
 		this.corpPlugin = corpPlugin;
+		this.config = corpConfig;
 	}
 
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
+		if (!config.markDarkCore())
+		{
+			return null;
+		}
+
 		NPC core = corpPlugin.getCore();
 		if (core != null)
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/corp/CorpConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/corp/CorpConfig.java
@@ -52,5 +52,4 @@ public interface CorpConfig extends Config
 	{
 		return true;
 	}
-
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/corp/CorpConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/corp/CorpConfig.java
@@ -43,7 +43,7 @@ public interface CorpConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "showDarkCore",
+		keyName = "markDarkCore",
 		name = "Mark dark core",
 		description = "Marks the dark energy core.",
 		position = 1

--- a/runelite-client/src/main/java/net/runelite/client/plugins/corp/CorpConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/corp/CorpConfig.java
@@ -35,10 +35,22 @@ public interface CorpConfig extends Config
 		keyName = "showDamage",
 		name = "Show damage overlay",
 		description = "Show total damage overlay",
-		position = 2
+		position = 0
 	)
 	default boolean showDamage()
 	{
 		return true;
 	}
+
+	@ConfigItem(
+		keyName = "showDarkCore",
+		name = "Mark dark core",
+		description = "Marks the dark energy core.",
+		position = 1
+	)
+	default boolean markDarkCore()
+	{
+		return true;
+	}
+
 }


### PR DESCRIPTION
Closes #12452
Adds a config option to toggle core highlighting. Enabled by default. 