### PR TITLE
discord: Fix action timeout, add in game time elapsed option

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordConfig.java
@@ -32,27 +32,34 @@ import net.runelite.client.config.Units;
 @ConfigGroup("discord")
 public interface DiscordConfig extends Config
 {
+	enum ElapsedTimeType
+	{
+		IN_GAME,
+		ACTIVITY,
+		HIDDEN
+	}
+
+	@ConfigItem(
+		keyName = "elapsedTime",
+		name = "Elapsed Time",
+		description = "Configures elapsed time shown.",
+		position = 1
+	)
+	default ElapsedTimeType elapsedTimeType()
+	{
+		return ElapsedTimeType.IN_GAME;
+	}
+
 	@ConfigItem(
 		keyName = "actionTimeout",
-		name = "Action timeout",
-		description = "Configures after how long of not updating status will be reset (in minutes)",
-		position = 1
+		name = "Activity timeout",
+		description = "Configures after how long of not updating activity will be reset (in minutes)",
+		position = 2
 	)
 	@Units(Units.MINUTES)
 	default int actionTimeout()
 	{
 		return 5;
-	}
-
-	@ConfigItem(
-		keyName = "hideElapsedTime",
-		name = "Hide elapsed time",
-		description = "Configures if the elapsed time of your activity should be hidden.",
-		position = 2
-	)
-	default boolean hideElapsedTime()
-	{
-		return false;
 	}
 
 	@ConfigItem(

--- a/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordConfig.java
@@ -24,6 +24,7 @@
  */
 package net.runelite.client.plugins.discord;
 
+import lombok.AllArgsConstructor;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
@@ -32,6 +33,7 @@ import net.runelite.client.config.Units;
 @ConfigGroup("discord")
 public interface DiscordConfig extends Config
 {
+	@AllArgsConstructor
 	enum ElapsedTimeType
 	{
 		TOTAL("Total elapsed time"),
@@ -39,11 +41,6 @@ public interface DiscordConfig extends Config
 		HIDDEN("Hide elapsed time");
 
 		private final String value;
-
-		ElapsedTimeType(String value)
-		{
-			this.value = value;
-		}
 
 		@Override
 		public String toString()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordConfig.java
@@ -34,9 +34,22 @@ public interface DiscordConfig extends Config
 {
 	enum ElapsedTimeType
 	{
-		IN_GAME,
-		ACTIVITY,
-		HIDDEN
+		TOTAL("Total elapsed time"),
+		ACTIVITY("Per activity"),
+		HIDDEN("Hide elapsed time");
+
+		private final String value;
+
+		ElapsedTimeType(String value)
+		{
+			this.value = value;
+		}
+
+		@Override
+		public String toString()
+		{
+			return value;
+		}
 	}
 
 	@ConfigItem(
@@ -47,7 +60,7 @@ public interface DiscordConfig extends Config
 	)
 	default ElapsedTimeType elapsedTimeType()
 	{
-		return ElapsedTimeType.IN_GAME;
+		return ElapsedTimeType.ACTIVITY;
 	}
 
 	@ConfigItem(

--- a/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordGameEventType.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordGameEventType.java
@@ -42,8 +42,8 @@ import net.runelite.api.Varbits;
 enum DiscordGameEventType
 {
 
-	IN_GAME("In Game", -3),
-	IN_MENU("In Menu", -3),
+	IN_MENU("In Menu", -3, false, true, true),
+	IN_GAME("In Game", -3, false, false, true),
 	PLAYING_DEADMAN("Playing Deadman Mode", -3),
 	PLAYING_PVP("Playing in a PVP world", -3),
 	TRAINING_ATTACK(Skill.ATTACK),
@@ -453,6 +453,7 @@ enum DiscordGameEventType
 	private int priority;
 	private boolean shouldClear;
 	private boolean shouldTimeout;
+	private boolean shouldRestart;
 
 	@Nullable
 	private DiscordAreaType discordAreaType;
@@ -485,11 +486,18 @@ enum DiscordGameEventType
 		this.shouldClear = true;
 	}
 
-	DiscordGameEventType(String state, int priority)
+	DiscordGameEventType(String state, int priority, boolean shouldClear, boolean shouldTimeout, boolean shouldRestart)
 	{
 		this.state = state;
 		this.priority = priority;
-		this.shouldClear = true;
+		this.shouldClear = shouldClear;
+		this.shouldTimeout = shouldTimeout;
+		this.shouldRestart = shouldRestart;
+	}
+
+	DiscordGameEventType(String state, int priority)
+	{
+		this(state, priority, true, false, false);
 	}
 
 	DiscordGameEventType(String areaName, DiscordAreaType areaType, Varbits varbits)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordGameEventType.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordGameEventType.java
@@ -42,8 +42,8 @@ import net.runelite.api.Varbits;
 enum DiscordGameEventType
 {
 
-	IN_MENU("In Menu", -3, false, true, true),
-	IN_GAME("In Game", -3, false, false, true),
+	IN_MENU("In Menu", -3, true, true, true),
+	IN_GAME("In Game", -3, false, false, false),
 	PLAYING_DEADMAN("Playing Deadman Mode", -3),
 	PLAYING_PVP("Playing in a PVP world", -3),
 	TRAINING_ATTACK(Skill.ATTACK),

--- a/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordGameEventType.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordGameEventType.java
@@ -458,7 +458,7 @@ enum DiscordGameEventType
 	private boolean root;
 
 	/**
-	 * Determines if event should clear other events when triggered
+	 * Determines if event should clear other clearable events when triggered
 	 */
 	private boolean shouldClear;
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordGameEventType.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordGameEventType.java
@@ -42,8 +42,8 @@ import net.runelite.api.Varbits;
 enum DiscordGameEventType
 {
 
-	IN_MENU("In Menu", -3, true, true, true),
-	IN_GAME("In Game", -3, false, false, false),
+	IN_MENU("In Menu", -3, true, true, true, false, true),
+	IN_GAME("In Game", -3, true, false, false, false, true),
 	PLAYING_DEADMAN("Playing Deadman Mode", -3),
 	PLAYING_PVP("Playing in a PVP world", -3),
 	TRAINING_ATTACK(Skill.ATTACK),
@@ -451,9 +451,31 @@ enum DiscordGameEventType
 	private String details;
 
 	private int priority;
+
+	/**
+	 * Marks this event as root event, e.g event that should be used for total time tracking
+	 */
+	private boolean root;
+
+	/**
+	 * Determines if event should clear other events when triggered
+	 */
 	private boolean shouldClear;
+
+	/**
+	 * Determines if event should be processed when it timeouts based on action timeout
+	 */
 	private boolean shouldTimeout;
+
+	/**
+	 * Determines if event start time should be reset when processed
+	 */
 	private boolean shouldRestart;
+
+	/**
+	 * Determines if event should be cleared when processed
+	 */
+	private boolean shouldBeCleared = true;
 
 	@Nullable
 	private DiscordAreaType discordAreaType;
@@ -486,18 +508,20 @@ enum DiscordGameEventType
 		this.shouldClear = true;
 	}
 
-	DiscordGameEventType(String state, int priority, boolean shouldClear, boolean shouldTimeout, boolean shouldRestart)
+	DiscordGameEventType(String state, int priority, boolean shouldClear, boolean shouldTimeout, boolean shouldRestart, boolean shouldBeCleared, boolean root)
 	{
 		this.state = state;
 		this.priority = priority;
 		this.shouldClear = shouldClear;
 		this.shouldTimeout = shouldTimeout;
 		this.shouldRestart = shouldRestart;
+		this.shouldBeCleared = shouldBeCleared;
+		this.root = root;
 	}
 
 	DiscordGameEventType(String state, int priority)
 	{
-		this(state, priority, true, false, false);
+		this(state, priority, true, false, false, true, false);
 	}
 
 	DiscordGameEventType(String areaName, DiscordAreaType areaType, Varbits varbits)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordPlugin.java
@@ -106,7 +106,7 @@ public class DiscordPlugin extends Plugin
 	@Inject
 	private OkHttpClient okHttpClient;
 
-	private Map<Skill, Integer> skillExp = new HashMap<>();
+	private final Map<Skill, Integer> skillExp = new HashMap<>();
 	private NavigationButton discordButton;
 	private boolean loginFlag;
 
@@ -358,11 +358,6 @@ public class DiscordPlugin extends Plugin
 	public void checkForValidStatus()
 	{
 		discordState.checkForTimeout();
-		if (client.getGameState() == GameState.LOGGED_IN)
-		{
-			discordState.triggerEvent(DiscordGameEventType.IN_GAME);
-			checkForAreaUpdate();
-		}
 	}
 
 	private void updatePresence()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordPlugin.java
@@ -129,6 +129,7 @@ public class DiscordPlugin extends Plugin
 			.build();
 
 		clientToolbar.addNavigation(discordButton);
+		resetState();
 		checkForGameStateUpdate();
 		checkForAreaUpdate();
 
@@ -144,7 +145,7 @@ public class DiscordPlugin extends Plugin
 	protected void shutDown() throws Exception
 	{
 		clientToolbar.removeNavigation(discordButton);
-		discordState.reset();
+		resetState();
 		partyService.changeParty(null);
 		wsClient.unregisterMessage(DiscordUserInfo.class);
 	}
@@ -166,7 +167,6 @@ public class DiscordPlugin extends Plugin
 					loginFlag = false;
 					checkForGameStateUpdate();
 				}
-
 				break;
 		}
 
@@ -178,6 +178,7 @@ public class DiscordPlugin extends Plugin
 	{
 		if (event.getGroup().equalsIgnoreCase("discord"))
 		{
+			resetState();
 			checkForGameStateUpdate();
 			checkForAreaUpdate();
 		}
@@ -362,10 +363,13 @@ public class DiscordPlugin extends Plugin
 		discordState.refresh();
 	}
 
+	private void resetState()
+	{
+		discordState.reset();
+	}
+
 	private void checkForGameStateUpdate()
 	{
-		// Game state update does also full reset of discord state
-		discordState.reset();
 		discordState.triggerEvent(client.getGameState() == GameState.LOGGED_IN
 			? DiscordGameEventType.IN_GAME
 			: DiscordGameEventType.IN_MENU);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordPlugin.java
@@ -156,6 +156,7 @@ public class DiscordPlugin extends Plugin
 		switch (event.getGameState())
 		{
 			case LOGIN_SCREEN:
+				resetState();
 				checkForGameStateUpdate();
 				return;
 			case LOGGING_IN:
@@ -165,6 +166,7 @@ public class DiscordPlugin extends Plugin
 				if (loginFlag)
 				{
 					loginFlag = false;
+					resetState();
 					checkForGameStateUpdate();
 				}
 				break;
@@ -356,7 +358,11 @@ public class DiscordPlugin extends Plugin
 	public void checkForValidStatus()
 	{
 		discordState.checkForTimeout();
-		checkForGameStateUpdate();
+		if (client.getGameState() == GameState.LOGGED_IN)
+		{
+			discordState.triggerEvent(DiscordGameEventType.IN_GAME);
+			checkForAreaUpdate();
+		}
 	}
 
 	private void updatePresence()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordPlugin.java
@@ -356,6 +356,7 @@ public class DiscordPlugin extends Plugin
 	public void checkForValidStatus()
 	{
 		discordState.checkForTimeout();
+		checkForGameStateUpdate();
 	}
 
 	private void updatePresence()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordState.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordState.java
@@ -132,7 +132,10 @@ class DiscordState
 
 		event.setUpdated(Instant.now());
 
-		if (event.getType().isShouldClear())
+		// an IN_GAME (or IN_MENU) event should remove all other areas from events
+		// but since events is fully cleared every time before IN_MENU is added,
+		// we will never need to run this on an IN_MENU event trigger
+		if (event.getType().isShouldClear() || event.getType().equals(DiscordGameEventType.IN_GAME))
 		{
 			events.removeIf(e -> e.getType() != eventType && e.getType().isShouldClear());
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordState.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordState.java
@@ -176,10 +176,24 @@ class DiscordState
 			.state(MoreObjects.firstNonNull(state, ""))
 			.details(MoreObjects.firstNonNull(details, ""))
 			.largeImageText(RuneLiteProperties.getTitle() + " v" + versionShortHand)
-			.startTimestamp(config.hideElapsedTime() ? null : event.getStart())
 			.smallImageKey(imageKey)
 			.partyMax(PARTY_MAX)
 			.partySize(party.getMembers().size());
+
+		DiscordConfig.ElapsedTimeType elapsedTimeType = config.elapsedTimeType();
+		if (elapsedTimeType == DiscordConfig.ElapsedTimeType.HIDDEN || event.getType() == DiscordGameEventType.IN_MENU)
+		{
+			presenceBuilder.startTimestamp(null);
+		}
+		else if (elapsedTimeType == DiscordConfig.ElapsedTimeType.IN_GAME &&
+			lastPresence != null && lastPresence.getStartTimestamp() != null)
+		{
+			presenceBuilder.startTimestamp(lastPresence.getStartTimestamp());
+		}
+		else
+		{
+			presenceBuilder.startTimestamp(event.getStart());
+		}
 
 		if (!party.isInParty() || party.isPartyOwner())
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordState.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordState.java
@@ -132,10 +132,10 @@ class DiscordState
 
 		event.setUpdated(Instant.now());
 
-		// an IN_GAME (or IN_MENU) event should remove all other areas from events
+		// An IN_GAME (or IN_MENU) event should remove all other areas from events
 		// but since events is fully cleared every time before IN_MENU is added,
 		// we will never need to run this on an IN_MENU event trigger
-		if (event.getType().isShouldClear() || event.getType().equals(DiscordGameEventType.IN_GAME))
+		if (event.getType().isShouldClear() || event.getType() == DiscordGameEventType.IN_GAME)
 		{
 			events.removeIf(e -> e.getType() != eventType && e.getType().isShouldClear());
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordState.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordState.java
@@ -59,6 +59,7 @@ class DiscordState
 	private final DiscordConfig config;
 	private PartyService party;
 	private DiscordPresence lastPresence;
+	private Instant startTime;
 
 	@Inject
 	private DiscordState(final DiscordService discordService, final DiscordConfig config, final PartyService party)
@@ -76,6 +77,7 @@ class DiscordState
 		discordService.clearPresence();
 		events.clear();
 		lastPresence = null;
+		startTime = null;
 	}
 
 	/**
@@ -181,19 +183,15 @@ class DiscordState
 			.partySize(party.getMembers().size());
 
 		DiscordConfig.ElapsedTimeType elapsedTimeType = config.elapsedTimeType();
-		if (elapsedTimeType == DiscordConfig.ElapsedTimeType.HIDDEN || event.getType() == DiscordGameEventType.IN_MENU)
+		if (elapsedTimeType == DiscordConfig.ElapsedTimeType.HIDDEN)
 		{
-			presenceBuilder.startTimestamp(null);
+			startTime = null;
 		}
-		else if (elapsedTimeType == DiscordConfig.ElapsedTimeType.IN_GAME &&
-			lastPresence != null && lastPresence.getStartTimestamp() != null)
+		else if (elapsedTimeType == DiscordConfig.ElapsedTimeType.ACTIVITY || startTime == null)
 		{
-			presenceBuilder.startTimestamp(lastPresence.getStartTimestamp());
+			startTime = event.getStart();
 		}
-		else
-		{
-			presenceBuilder.startTimestamp(event.getStart());
-		}
+		presenceBuilder.startTimestamp(startTime);
 
 		if (!party.isInParty() || party.isPartyOwner())
 		{

--- a/runelite-client/src/test/java/net/runelite/client/plugins/discord/DiscordStateTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/discord/DiscordStateTest.java
@@ -80,7 +80,7 @@ public class DiscordStateTest
 	public void testStatusTimeout()
 	{
 		when(discordConfig.actionTimeout()).thenReturn(0);
-		when(discordConfig.hideElapsedTime()).thenReturn(false);
+		when(discordConfig.elapsedTimeType()).thenReturn(DiscordConfig.ElapsedTimeType.HIDDEN);
 
 		discordState.triggerEvent(DiscordGameEventType.IN_MENU);
 		verify(discordService).updatePresence(any(DiscordPresence.class));

--- a/runelite-client/src/test/java/net/runelite/client/plugins/discord/DiscordStateTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/discord/DiscordStateTest.java
@@ -77,10 +77,10 @@ public class DiscordStateTest
 	}
 
 	@Test
-	public void testStatusTimeout()
+	public void testStatusReset()
 	{
-		when(discordConfig.actionTimeout()).thenReturn(0);
-		when(discordConfig.elapsedTimeType()).thenReturn(DiscordConfig.ElapsedTimeType.HIDDEN);
+		when(discordConfig.actionTimeout()).thenReturn(-1);
+		when(discordConfig.elapsedTimeType()).thenReturn(DiscordConfig.ElapsedTimeType.ACTIVITY);
 
 		discordState.triggerEvent(DiscordGameEventType.IN_MENU);
 		verify(discordService).updatePresence(any(DiscordPresence.class));
@@ -90,5 +90,18 @@ public class DiscordStateTest
 		verify(discordService, times(2)).updatePresence(captor.capture());
 		List<DiscordPresence> captured = captor.getAllValues();
 		assertNull(captured.get(captured.size() - 1).getEndTimestamp());
+	}
+
+	@Test
+	public void testStatusTimeout()
+	{
+		when(discordConfig.actionTimeout()).thenReturn(-1);
+		when(discordConfig.elapsedTimeType()).thenReturn(DiscordConfig.ElapsedTimeType.ACTIVITY);
+
+		discordState.triggerEvent(DiscordGameEventType.TRAINING_AGILITY);
+		verify(discordService).updatePresence(any(DiscordPresence.class));
+
+		discordState.checkForTimeout();
+		verify(discordService, times(1)).clearPresence();
 	}
 }

--- a/runelite-client/src/test/java/net/runelite/client/plugins/discord/DiscordStateTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/discord/DiscordStateTest.java
@@ -35,6 +35,7 @@ import net.runelite.api.Client;
 import net.runelite.client.discord.DiscordPresence;
 import net.runelite.client.discord.DiscordService;
 import net.runelite.client.ws.PartyService;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import org.junit.Before;
 import org.junit.Test;
@@ -103,5 +104,27 @@ public class DiscordStateTest
 
 		discordState.checkForTimeout();
 		verify(discordService, times(1)).clearPresence();
+	}
+
+	@Test
+	public void testAreaChange()
+	{
+		when(discordConfig.elapsedTimeType()).thenReturn(DiscordConfig.ElapsedTimeType.TOTAL);
+
+		// Start with state of IN_GAME
+		ArgumentCaptor<DiscordPresence> captor = ArgumentCaptor.forClass(DiscordPresence.class);
+		discordState.triggerEvent(DiscordGameEventType.IN_GAME);
+		verify(discordService, times(1)).updatePresence(captor.capture());
+		assertEquals(DiscordGameEventType.IN_GAME.getState(), captor.getValue().getState());
+
+		// IN_GAME -> CITY
+		discordState.triggerEvent(DiscordGameEventType.CITY_VARROCK);
+		verify(discordService, times(2)).updatePresence(captor.capture());
+		assertEquals(DiscordGameEventType.CITY_VARROCK.getState(), captor.getValue().getState());
+
+		// CITY -> IN_GAME
+		discordState.triggerEvent(DiscordGameEventType.IN_GAME);
+		verify(discordService, times(3)).updatePresence(captor.capture());
+		assertEquals(DiscordGameEventType.IN_GAME.getState(), captor.getValue().getState());
 	}
 }


### PR DESCRIPTION
Fixed the discord plugin's action timeout to match expected behavior and clear the activity from presence. Previously if there was only an event removed (such as training herblore), then the presence was not updated. Updating with the current game state fixes this.

I've also added an option to show total time in game rather than time elapsed performing the current activity. This option is the default.
Closes #12438 