### PR TITLE
KeyManager: Add debug logging

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/input/KeyManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/input/KeyManager.java
@@ -30,10 +30,12 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.inject.Singleton;
+import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.GameState;
 
 @Singleton
+@Slf4j
 public class KeyManager
 {
 	private final Client client;
@@ -50,13 +52,18 @@ public class KeyManager
 	{
 		if (!keyListeners.contains(keyListener))
 		{
+			log.debug("Registering key listener: {}", keyListener);
 			keyListeners.add(keyListener);
 		}
 	}
 
 	public void unregisterKeyListener(KeyListener keyListener)
 	{
-		keyListeners.remove(keyListener);
+		final boolean unregistered = keyListeners.remove(keyListener);
+		if (unregistered)
+		{
+			log.debug("Unregistered key listener: {}", keyListener);
+		}
 	}
 
 	public void processKeyPressed(KeyEvent keyEvent)
@@ -72,6 +79,8 @@ public class KeyManager
 			{
 				continue;
 			}
+
+			log.debug("Processing key pressed {} for key listener {}", keyEvent.paramString(), keyListener);
 
 			keyListener.keyPressed(keyEvent);
 			if (keyEvent.isConsumed())
@@ -95,6 +104,8 @@ public class KeyManager
 				continue;
 			}
 
+			log.debug("Processing key released {} for key listener {}", keyEvent.paramString(), keyListener);
+
 			keyListener.keyReleased(keyEvent);
 			if (keyEvent.isConsumed())
 			{
@@ -116,6 +127,8 @@ public class KeyManager
 			{
 				continue;
 			}
+
+			log.debug("Processing key typed {} for key listener {}", keyEvent.paramString(), keyListener);
 
 			keyListener.keyTyped(keyEvent);
 			if (keyEvent.isConsumed())


### PR DESCRIPTION
We receive numerous support queries regarding unknown or errantly-set
keybinds causing issues during normal gameplay for our users, especially
since the plugin hub has been released and more plugins are able to
register keybinds. This commit adds logging for keybind registration and
activation for ease of troubleshooting.