### PR TITLE
MaterialTabGroup tab switching optimization

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ui/components/materialtabs/MaterialTabGroup.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/components/materialtabs/MaterialTabGroup.java
@@ -110,10 +110,12 @@ public class MaterialTabGroup extends JPanel
 		// If the display is available, switch from the old to the new display
 		if (display != null)
 		{
+			display.setVisible(false);
 			display.removeAll();
 			display.add(selectedTab.getContent());
 			display.revalidate();
 			display.repaint();
+			display.setVisible(true);
 		}
 
 		// Unselected all other tabs


### PR DESCRIPTION
We had some complaints from users saying that switching between tabs in the Flipping-Utilities plugin was really slow. After looking at some videos and trying to replicate the issue, it was obvious this was because of the number of panels in either tab. More specifically, because the issue was only there when switching FROM a tab with a lot of panels and not vice versa, we figured most of the time cost was in removing the old tab's contents, not drawing the new ones.

We figured we would try to optimize the method which handles switching tabs and try to make it remove the tab contents faster. Turns out if you set the main display to invisible first and then remove its contents, the time to remove the contents is drastically cut down.

Not sure why this works lol, maybe some java swing expert can comment :)

Here are a couple of videos demonstrating the improvement.

before: https://www.youtube.com/watch?v=IzBdnwzWBVk

after: https://www.youtube.com/watch?v=nam_1MyG34Q