### PR TITLE
util: Remove unused and unneeded methods

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/util/ColorUtil.java
+++ b/runelite-client/src/main/java/net/runelite/client/util/ColorUtil.java
@@ -131,16 +131,6 @@ public class ColorUtil
 		return String.format("%08x", color.getRGB());
 	}
 
-	static boolean isFullyTransparent(final Color color)
-	{
-		return color.getAlpha() == 0;
-	}
-
-	static boolean isNotFullyTransparent(final Color color)
-	{
-		return !isFullyTransparent(color);
-	}
-
 	/**
 	 * Determines if the passed hex string is an alpha hex color.
 	 *

--- a/runelite-client/src/main/java/net/runelite/client/util/ImageUtil.java
+++ b/runelite-client/src/main/java/net/runelite/client/util/ImageUtil.java
@@ -40,7 +40,6 @@ import java.util.Arrays;
 import java.util.List;
 import javax.imageio.ImageIO;
 import javax.swing.GrayFilter;
-import java.util.function.Predicate;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.IndexedSprite;
@@ -294,21 +293,7 @@ public class ImageUtil
 	 */
 	public static BufferedImage outlineImage(final BufferedImage image, final Color color)
 	{
-		return outlineImage(image, color, ColorUtil::isNotFullyTransparent, false);
-	}
-
-	/**
-	 * Outlines pixels of a BufferedImage with the given color, using a given predicate to colorize
-	 * the given image for outlining.
-	 *
-	 * @param image         The image to be outlined.
-	 * @param color         The color to use for the outline.
-	 * @param fillCondition The predicate to be consumed by {@link #fillImage(BufferedImage, Color, Predicate) fillImage(BufferedImage, Color, Predicate)}
-	 * @return              The BufferedImage with its edges outlined with the given color.
-	 */
-	public static BufferedImage outlineImage(final BufferedImage image, final Color color, final Predicate<Color> fillCondition)
-	{
-		return outlineImage(image, color, fillCondition, false);
+		return outlineImage(image, color, false);
 	}
 
 	/**
@@ -323,23 +308,7 @@ public class ImageUtil
 	 */
 	public static BufferedImage outlineImage(final BufferedImage image, final Color color, final Boolean outlineCorners)
 	{
-		return outlineImage(image, color, ColorUtil::isNotFullyTransparent, outlineCorners);
-	}
-
-	/**
-	 * Outlines pixels of a BufferedImage with the given color, using a given predicate to colorize
-	 * the given image for outlining. Optionally outlines corners in addition to edges.
-	 *
-	 * @param image          The image to be outlined.
-	 * @param color          The color to use for the outline.
-	 * @param fillCondition  The predicate to be consumed by {@link #fillImage(BufferedImage, Color, Predicate) fillImage(BufferedImage, Color, Predicate)}
-	 * @param outlineCorners Whether to draw an outline around corners, or only around edges.
-	 * @return               The BufferedImage with its edges--and optionally, corners--outlined
-	 * 	                     with the given color.
-	 */
-	public static BufferedImage outlineImage(final BufferedImage image, final Color color, final Predicate<Color> fillCondition, final Boolean outlineCorners)
-	{
-		final BufferedImage filledImage = fillImage(image, color, fillCondition);
+		final BufferedImage filledImage = fillImage(image, color);
 		final BufferedImage outlinedImage = new BufferedImage(image.getWidth(), image.getHeight(), BufferedImage.TYPE_INT_ARGB);
 
 		final Graphics2D g2d = outlinedImage.createGraphics();
@@ -399,28 +368,13 @@ public class ImageUtil
 	 */
 	public static BufferedImage fillImage(final BufferedImage image, final Color color)
 	{
-		return fillImage(image, color, ColorUtil::isNotFullyTransparent);
-	}
-
-	/**
-	 * 	Fills pixels of the given image with the given color based on a given fill condition
-	 * 	predicate.
-	 *
-	 * @param image         The image which should have its non-transparent pixels filled.
-	 * @param color         The color with which to fill pixels.
-	 * @param fillCondition The condition on which to fill pixels with the given color.
-	 * @return              The given image with all pixels fulfilling the fill condition predicate
-	 *                      set to the given color.
-	 */
-	static BufferedImage fillImage(final BufferedImage image, final Color color, final Predicate<Color> fillCondition)
-	{
 		final BufferedImage filledImage = new BufferedImage(image.getWidth(), image.getHeight(), BufferedImage.TYPE_INT_ARGB);
 		for (int x = 0; x < filledImage.getWidth(); x++)
 		{
 			for (int y = 0; y < filledImage.getHeight(); y++)
 			{
 				final Color pixelColor = new Color(image.getRGB(x, y), true);
-				if (!fillCondition.test(pixelColor))
+				if (pixelColor.getAlpha() == 0)
 				{
 					continue;
 				}

--- a/runelite-client/src/test/java/net/runelite/client/util/ColorUtilTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/util/ColorUtilTest.java
@@ -28,8 +28,6 @@ import java.awt.Color;
 import java.util.HashMap;
 import java.util.Map;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 
 public class ColorUtilTest
@@ -102,27 +100,5 @@ public class ColorUtilTest
 		{
 			assertEquals(hex, ColorUtil.colorToHexCode(color));
 		});
-	}
-
-	@Test
-	public void isFullyTransparent()
-	{
-		for (Color color : COLOR_HEXSTRING_MAP.keySet())
-		{
-			assertFalse(ColorUtil.isFullyTransparent(color));
-		}
-		assertTrue(ColorUtil.isFullyTransparent(new Color(0, 0, 0, 0)));
-		assertFalse(ColorUtil.isFullyTransparent(new Color(0, 0, 0, 1)));
-	}
-
-	@Test
-	public void isNotFullyTransparent()
-	{
-		for (Color color : COLOR_HEXSTRING_MAP.keySet())
-		{
-			assertTrue(ColorUtil.isNotFullyTransparent(color));
-		}
-		assertFalse(ColorUtil.isNotFullyTransparent(new Color(0, 0, 0, 0)));
-		assertTrue(ColorUtil.isNotFullyTransparent(new Color(0, 0, 0, 1)));
 	}
 }

--- a/runelite-client/src/test/java/net/runelite/client/util/ImageUtilTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/util/ImageUtilTest.java
@@ -35,7 +35,6 @@ import java.awt.image.BufferedImage;
 import java.awt.image.DataBuffer;
 import java.awt.image.DataBufferInt;
 import java.util.Arrays;
-import java.util.function.Predicate;
 import javax.annotation.Nonnull;
 import org.apache.commons.lang3.ArrayUtils;
 import static org.junit.Assert.assertEquals;
@@ -256,11 +255,6 @@ public class ImageUtilTest
 		assertTrue(bufferedImagesEqual(centeredPixel(GRAY), ImageUtil.fillImage(centeredPixel(BLACK), GRAY)));
 		assertTrue(bufferedImagesEqual(solidColor(3, 3, GREEN), ImageUtil.fillImage(solidColor(3, 3, BLACK), GREEN)));
 		assertTrue(bufferedImagesEqual(oneByOne(BLACK_TRANSPARENT), ImageUtil.fillImage(oneByOne(BLACK_TRANSPARENT), WHITE)));
-
-		// fillImage(BufferedImage image, Color color, Predicate<Color> fillCondition)
-		BufferedImage expected = solidColor(CORNER_SIZE, CORNER_SIZE, WHITE);
-		expected.setRGB(0, 0, new Color(0, true).getRGB());
-		assertTrue(bufferedImagesEqual(expected, ImageUtil.fillImage(BLACK_PIXEL_TOP_LEFT, WHITE, ColorUtil::isFullyTransparent)));
 	}
 
 	@Test
@@ -287,39 +281,11 @@ public class ImageUtilTest
 		expected.setRGB(1, 1, new Color(0, true).getRGB());
 		assertTrue(bufferedImagesEqual(expected, ImageUtil.outlineImage(BLACK_PIXEL_TOP_LEFT, WHITE)));
 
-		// outlineImage(BufferedImage image, Color color, Predicate<Color> fillCondition)
-		BufferedImage test = new BufferedImage(CORNER_SIZE, CORNER_SIZE, BufferedImage.TYPE_INT_ARGB);
-		test.setRGB(0, 0, BLACK.getRGB());
-		test.setRGB(1, 0, GRAY.getRGB());
-		expected = test;
-		expected.setRGB(0, 1, BLUE.getRGB());
-		assertTrue(bufferedImagesEqual(expected, ImageUtil.outlineImage(test, BLUE, (color -> color.equals(BLACK)))));
-
 		// outlineImage(BufferedImage image, Color color, Boolean outlineCorners)
 		expected = solidColor(CORNER_SIZE, CORNER_SIZE, WHITE);
 		expected.setRGB(0, 0, BLACK.getRGB());
 		assertTrue(bufferedImagesEqual(expected, ImageUtil.outlineImage(BLACK_PIXEL_TOP_LEFT, WHITE, true)));
 		assertTrue(bufferedImagesEqual(solidColor(3, 3, BLACK), ImageUtil.outlineImage(centeredPixel(BLACK), BLACK, true)));
-
-		// outlineImage(BufferedImage image, Color color, Predicate<Color> fillCondition, Boolean outlineCorners)
-		test = new BufferedImage(5, 5, BufferedImage.TYPE_INT_ARGB);
-		test.setRGB(2, 2, BLACK.getRGB());
-		test.setRGB(1, 2, new Color(50, 50, 50).getRGB());
-		test.setRGB(3, 2, new Color(100, 100, 100).getRGB());
-		test.setRGB(2, 3, new Color(150, 150, 150).getRGB());
-		expected = test;
-		expected.setRGB(2, 1, RED.getRGB());
-		expected.setRGB(3, 1, RED.getRGB());
-		expected.setRGB(4, 1, RED.getRGB());
-		expected.setRGB(4, 2, RED.getRGB());
-		expected.setRGB(1, 3, RED.getRGB());
-		expected.setRGB(3, 3, RED.getRGB());
-		expected.setRGB(4, 3, RED.getRGB());
-		expected.setRGB(1, 4, RED.getRGB());
-		expected.setRGB(2, 4, RED.getRGB());
-		expected.setRGB(3, 4, RED.getRGB());
-		Predicate<Color> testPredicate = (color -> ColorUtil.isNotFullyTransparent(color) && color.getRed() > 75 && color.getGreen() > 75 && color.getBlue() > 75);
-		assertTrue(bufferedImagesEqual(expected, ImageUtil.outlineImage(test, RED, testPredicate, true)));
 	}
 
 	/**


### PR DESCRIPTION
ImageUtil had previously provided a number of image fill and outline
methods which accepted Predicates to control the fill and outline
behavior, but they are not used anywhere in the client or by external
plugins. This commit removes these methods and the
is(Not)?FullyTransparent ColorUtil methods which existed solely as
Predicate defaults for them.