### PR TITLE
achievementdiary: Fix Western Provinces quest requirement

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/WesternDiaryRequirement.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/WesternDiaryRequirement.java
@@ -65,7 +65,7 @@ public class WesternDiaryRequirement extends GenericDiaryRequirement
 		add("Chop and burn some teak logs on Ape Atoll.",
 			new SkillRequirement(Skill.WOODCUTTING, 35),
 			new SkillRequirement(Skill.FIREMAKING, 35),
-			new QuestRequirement(Quest.MONKEY_MADNESS_I));
+			new QuestRequirement(Quest.MONKEY_MADNESS_I, true));
 		add("Complete an intermediate game of Pest Control.",
 			new CombatLevelRequirement(70));
 		add("Travel to the Feldip Hills by Gnome Glider.",


### PR DESCRIPTION
Close #12492 

Changed the requirement for Monkey Madness 1 to simply being started instead of being completed for the task "Chop and burn some teak logs on Ape Atoll" in the Western Provinces Diary.

Before:
![image](https://user-images.githubusercontent.com/50222178/93207037-2ecd5480-f70f-11ea-8ec2-811fb848d156.png)

After:
![image](https://user-images.githubusercontent.com/50222178/93206302-042ecc00-f70e-11ea-8e49-03813f237b4b.png)
