### PR TITLE
Fix Nightmare Zone Overload timer and notification

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/nightmarezone/NightmareZonePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/nightmarezone/NightmareZonePlugin.java
@@ -136,6 +136,8 @@ public class NightmareZonePlugin extends Plugin
 				resetPointsPerHour();
 			}
 
+			overloadNotificationSend = false;
+
 			return;
 		}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/nightmarezone/NightmareZonePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/nightmarezone/NightmareZonePlugin.java
@@ -89,6 +89,7 @@ public class NightmareZonePlugin extends Plugin
 		overlayManager.add(overlay);
 		overlay.removeAbsorptionCounter();
 
+		absorptionNotificationSend = true;
 		overloadNotificationSend = false;
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersPlugin.java
@@ -121,6 +121,7 @@ public class TimersPlugin extends Plugin
 
 	static final int FIGHT_CAVES_REGION_ID = 9551;
 	static final int INFERNO_REGION_ID = 9043;
+	private static final int NMZ_MAP_REGION_ID = 9033;
 	private static final Pattern TZHAAR_WAVE_MESSAGE = Pattern.compile("Wave: (\\d+)");
 	private static final String TZHAAR_DEFEATED_MESSAGE = "You have been defeated!";
 	private static final Pattern TZHAAR_COMPLETE_MESSAGE = Pattern.compile("Your (TzTok-Jad|TzKal-Zuk) kill count is:");
@@ -718,6 +719,11 @@ public class TimersPlugin extends Plugin
 		return client.getMapRegions() != null && ArrayUtils.contains(client.getMapRegions(), INFERNO_REGION_ID);
 	}
 
+	private boolean isInNightmareZone()
+	{
+		return client.getLocalPlayer() != null && client.getLocalPlayer().getWorldLocation().getPlane() > 0 && ArrayUtils.contains(client.getMapRegions(), NMZ_MAP_REGION_ID);
+	}
+
 	private void createTzhaarTimer()
 	{
 		removeTzhaarTimer();
@@ -783,6 +789,11 @@ public class TimersPlugin extends Plugin
 		switch (gameStateChanged.getGameState())
 		{
 			case LOADING:
+				if (!isInNightmareZone())
+				{
+					removeGameTimer(OVERLOAD);
+				}
+
 				if (tzhaarTimer != null && !isInFightCaves() && !isInInferno())
 				{
 					removeTzhaarTimer();


### PR DESCRIPTION
Close #12493 

The timers plugin was not checking to see if the player was still inside NMZ, causing the timer to stay when the player left or hopped worlds. Now checks to see if the player is inside the NMZ region.

For the nightmarezone plugin, `overloadNotificationSend = true` when the player drinks an Overload potion. When the player leaves NMZ before the Overload expires and re-enters, `overloadNotificationSend` is still `true`. This results in the notification still being sent based on when the potion was drunk in the previous NMZ instance. Now sets `overloadNotificationSend` to `false` upon leaving.