### PR TITLE
timers: add world placed to cannon timer tooltip

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersPlugin.java
@@ -518,7 +518,8 @@ public class TimersPlugin extends Plugin
 
 		if (config.showCannon() && (event.getMessage().equals(CANNON_FURNACE_MESSAGE) || event.getMessage().contains(CANNON_REPAIR_MESSAGE)))
 		{
-			createGameTimer(CANNON);
+			TimerTimer cannonTimer = createGameTimer(CANNON);
+			cannonTimer.setTooltip(cannonTimer.getTooltip() + " - World " + client.getWorld());
 		}
 
 		if (config.showCannon() && event.getMessage().equals(CANNON_PICKUP_MESSAGE))


### PR DESCRIPTION
Closes #3700
Notes the world on which the cannon was placed in its timer tooltip.

![2020-09-22-085615_162x80_scrot](https://user-images.githubusercontent.com/66925241/93833536-68024900-fc68-11ea-99a9-3d13fbcb6e8d.png)
