### PR TITLE
Adds bank withdraw/deposit swaps for the chambers of xeric storage unit.

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/widgets/WidgetID.java
+++ b/runelite-api/src/main/java/net/runelite/api/widgets/WidgetID.java
@@ -156,6 +156,9 @@ public class WidgetID
 	public static final int HALLOWED_SEPULCHRE_TIMER_GROUP_ID = 668;
 	public static final int BANK_PIN_GROUP_ID = 213;
 	public static final int HEALTH_OVERLAY_BAR_GROUP_ID = 303;
+	public static final int CHAMBERS_OF_XERIC_STORAGE_UNIT_PRIVATE_GROUP_ID = 271;
+	public static final int CHAMBERS_OF_XERIC_STORAGE_UNIT_SHARED_GROUP_ID = 550;
+	public static final int CHAMBERS_OF_XERIC_STORAGE_UNIT_INVENTORY_GROUP_ID = 551;
 
 	static class WorldMap
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -520,14 +520,18 @@ public class MenuEntrySwapperPlugin extends Plugin
 		// is what builds the context menu row which is what the eventual click will use
 
 		// Swap to shift-click deposit behavior
-		// Deposit- op 1 is the current withdraw amount 1/5/10/x for deposit box interface
+		// Deposit- op 1 is the current withdraw amount 1/5/10/x for deposit box interface and chambers of xeric storage unit.
 		// Deposit- op 2 is the current withdraw amount 1/5/10/x for bank interface
 		if (shiftModifier() && config.bankDepositShiftClick() != ShiftDepositMode.OFF
-			&& menuEntryAdded.getType() == MenuAction.CC_OP.getId() && (menuEntryAdded.getIdentifier() == 2 || menuEntryAdded.getIdentifier() == 1)
-			&& menuEntryAdded.getOption().startsWith("Deposit-"))
+			&& menuEntryAdded.getType() == MenuAction.CC_OP.getId()
+			&& (menuEntryAdded.getIdentifier() == 2 || menuEntryAdded.getIdentifier() == 1)
+			&& (menuEntryAdded.getOption().startsWith("Deposit-") || menuEntryAdded.getOption().startsWith("Store") || menuEntryAdded.getOption().startsWith("Donate")))
 		{
 			ShiftDepositMode shiftDepositMode = config.bankDepositShiftClick();
-			final int opId = WidgetInfo.TO_GROUP(menuEntryAdded.getActionParam1()) == WidgetID.DEPOSIT_BOX_GROUP_ID ? shiftDepositMode.getIdentifierDepositBox() : shiftDepositMode.getIdentifier();
+			final int widgetGroupId = WidgetInfo.TO_GROUP(menuEntryAdded.getActionParam1());
+			final int opId = widgetGroupId == WidgetID.DEPOSIT_BOX_GROUP_ID ? shiftDepositMode.getIdentifierDepositBox()
+				: widgetGroupId == WidgetID.CHAMBERS_OF_XERIC_STORAGE_UNIT_INVENTORY_GROUP_ID ? shiftDepositMode.getIdentifierChambersStorageUnit()
+				: shiftDepositMode.getIdentifier();
 			final int actionId = opId >= 6 ? MenuAction.CC_OP_LOW_PRIORITY.getId() : MenuAction.CC_OP.getId();
 			bankModeSwap(actionId, opId);
 		}
@@ -536,11 +540,21 @@ public class MenuEntrySwapperPlugin extends Plugin
 		// Deposit- op 1 is the current withdraw amount 1/5/10/x
 		if (shiftModifier() && config.bankWithdrawShiftClick() != ShiftWithdrawMode.OFF
 			&& menuEntryAdded.getType() == MenuAction.CC_OP.getId() && menuEntryAdded.getIdentifier() == 1
-			&& menuEntryAdded.getOption().startsWith("Withdraw-"))
+			&& menuEntryAdded.getOption().startsWith("Withdraw"))
 		{
 			ShiftWithdrawMode shiftWithdrawMode = config.bankWithdrawShiftClick();
-			final int actionId = shiftWithdrawMode.getMenuAction().getId();
-			final int opId = shiftWithdrawMode.getIdentifier();
+			final int widgetGroupId = WidgetInfo.TO_GROUP(menuEntryAdded.getActionParam1());
+			final int actionId, opId;
+			if (widgetGroupId == WidgetID.CHAMBERS_OF_XERIC_STORAGE_UNIT_PRIVATE_GROUP_ID || widgetGroupId == WidgetID.CHAMBERS_OF_XERIC_STORAGE_UNIT_SHARED_GROUP_ID)
+			{
+				actionId = MenuAction.CC_OP.getId();
+				opId = shiftWithdrawMode.getIdentifierChambersStorageUnit();
+			}
+			else
+			{
+				actionId = shiftWithdrawMode.getMenuAction().getId();
+				opId = shiftWithdrawMode.getIdentifier();
+			}
 			bankModeSwap(actionId, opId);
 		}
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/ShiftDepositMode.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/ShiftDepositMode.java
@@ -31,17 +31,18 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum ShiftDepositMode
 {
-	DEPOSIT_1("Deposit-1", 3, 2),
-	DEPOSIT_5("Deposit-5", 4, 3),
-	DEPOSIT_10("Deposit-10", 5, 4),
-	DEPOSIT_X("Deposit-X", 6, 6),
-	DEPOSIT_ALL("Deposit-All", 8, 5),
-	EXTRA_OP("Eat/Wield/Etc.", 9, 0),
-	OFF("Off", 0, 0);
+	DEPOSIT_1("Deposit-1", 3, 2, 1),
+	DEPOSIT_5("Deposit-5", 4, 3, 2),
+	DEPOSIT_10("Deposit-10", 5, 4, 3),
+	DEPOSIT_X("Deposit-X", 6, 6, 5),
+	DEPOSIT_ALL("Deposit-All", 8, 5, 4),
+	EXTRA_OP("Eat/Wield/Etc.", 9, 0, 0),
+	OFF("Off", 0, 0, 0);
 
 	private final String name;
 	private final int identifier;
 	private final int identifierDepositBox;
+	private final int identifierChambersStorageUnit;
 
 	@Override
 	public String toString()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/ShiftWithdrawMode.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/ShiftWithdrawMode.java
@@ -32,17 +32,20 @@ import net.runelite.api.MenuAction;
 @RequiredArgsConstructor
 public enum ShiftWithdrawMode
 {
-	WITHDRAW_1("Withdraw-1", MenuAction.CC_OP, 2),
-	WITHDRAW_5("Withdraw-5", MenuAction.CC_OP, 3),
-	WITHDRAW_10("Withdraw-10", MenuAction.CC_OP, 4),
-	WITHDRAW_X("Withdraw-X", MenuAction.CC_OP, 5),
-	WITHDRAW_ALL("Withdraw-All", MenuAction.CC_OP_LOW_PRIORITY, 7),
-	WITHDRAW_ALL_BUT_1("Withdraw-All-But-1", MenuAction.CC_OP_LOW_PRIORITY, 8),
-	OFF("Off", MenuAction.UNKNOWN, 0);
+	WITHDRAW_1("Withdraw-1", MenuAction.CC_OP, 2, 1),
+	WITHDRAW_5("Withdraw-5", MenuAction.CC_OP, 3, 2),
+	WITHDRAW_10("Withdraw-10", MenuAction.CC_OP, 4, 3),
+	WITHDRAW_X("Withdraw-X", MenuAction.CC_OP, 5, 5),
+	WITHDRAW_ALL("Withdraw-All", MenuAction.CC_OP_LOW_PRIORITY, 7, 4),
+	// chambers of xeric storage units do not have an "all-but-1" option, so this option will choose "Withdraw-all"
+	// instead when using the storage unit.
+	WITHDRAW_ALL_BUT_1("Withdraw-All-But-1", MenuAction.CC_OP_LOW_PRIORITY, 8, 4),
+	OFF("Off", MenuAction.UNKNOWN, 0, 0);
 
 	private final String name;
 	private final MenuAction menuAction;
 	private final int identifier;
+	private final int identifierChambersStorageUnit;
 
 	@Override
 	public String toString()


### PR DESCRIPTION
Adds withdraw/deposit swaps for the chambers of xeric storage unit. This uses the same config item as the regular bank, and for options which do not correspond to a storage unit option, "all-but-1" becomes "all", "eat/wield/etc." does not perform a swap, and "Withdraw-X" (which withdraws the last set custom quantity in the bank) selects the option named "Withdraw-X" (which opens a dialog).

This would fix issue #11920.