### PR TITLE
XP Tracker: Goal time formatting options

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpGoalTimeType.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpGoalTimeType.java
@@ -26,7 +26,7 @@ package net.runelite.client.plugins.xptracker;
 
 public enum XpGoalTimeType
 {
-    DAYS,
-    HOURS,
-    SHORT
+	DAYS,
+	HOURS,
+	SHORT
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpGoalTimeType.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpGoalTimeType.java
@@ -24,7 +24,8 @@
  */
 package net.runelite.client.plugins.xptracker;
 
-public enum XpGoalTimeType {
+public enum XpGoalTimeType
+{
     DAYS,
     HOURS,
     SHORT

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpGoalTimeType.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpGoalTimeType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Anthony <https://github.com/while-loop>
+ * Copyright (c) 2020, Dasgust <dasgust@gmail.com>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -24,21 +24,8 @@
  */
 package net.runelite.client.plugins.xptracker;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-
-import java.util.function.Function;
-
-import static net.runelite.client.plugins.xptracker.XpInfoBox.TWO_DECIMAL_FORMAT;
-
-@Getter
-@AllArgsConstructor
-public enum XpProgressBarLabel
-{
-	PERCENTAGE((snap) -> TWO_DECIMAL_FORMAT.format(snap.getSkillProgressToGoal()) + "%"),
-	TIME_TO_LEVEL(XpSnapshotSingle::getTimeTillGoal),
-	HOURS_TO_LEVEL(XpSnapshotSingle::getTimeTillGoalHours)
-	;
-
-	private final Function<XpSnapshotSingle, String> valueFunc;
+public enum XpGoalTimeType {
+    DAYS,
+    HOURS,
+    SHORT
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpInfoBox.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpInfoBox.java
@@ -74,7 +74,7 @@ class XpInfoBox extends JPanel
 	private static final String HTML_TOOL_TIP_TEMPLATE =
 		"<html>%s %s done<br/>"
 			+ "%s %s/hr<br/>"
-			+ "%s till goal lvl</html>";
+			+ "%s %s</html>";
 	private static final String HTML_LABEL_TEMPLATE =
 		"<html><body style='color:%s'>%s<span style='color:white'>%s</span></body></html>";
 
@@ -285,13 +285,16 @@ class XpInfoBox extends JPanel
 				progressBar.setPositions(Collections.emptyList());
 			}
 
+			XpProgressBarLabel tooltipLabel = xpTrackerConfig.progressBarTooltipLabel();
+
 			progressBar.setToolTipText(String.format(
 				HTML_TOOL_TIP_TEMPLATE,
 				xpSnapshotSingle.getActionsInSession(),
 				xpSnapshotSingle.getActionType().getLabel(),
 				xpSnapshotSingle.getActionsPerHour(),
 				xpSnapshotSingle.getActionType().getLabel(),
-				xpSnapshotSingle.getTimeTillGoal()));
+				tooltipLabel.getValueFunc().apply(xpSnapshotSingle),
+				tooltipLabel == XpProgressBarLabel.PERCENTAGE ? "of goal" : "till goal lvl"));
 
 			progressBar.setDimmed(skillPaused);
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpSnapshotSingle.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpSnapshotSingle.java
@@ -44,5 +44,6 @@ class XpSnapshotSingle
 	private int actionsRemainingToGoal;
 	private int actionsPerHour;
 	private String timeTillGoal;
+	private String timeTillGoalHours;
 	private String timeTillGoalShort;
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpStateSingle.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpStateSingle.java
@@ -147,7 +147,7 @@ class XpStateSingle
 		return (getXpRemaining() * seconds) / xpGained;
 	}
 
-	private String getTimeTillLevel()
+	private String getTimeTillLevel(XpGoalTimeType goalTimeType)
 	{
 		long remainingSeconds = getSecondsTillLevel();
 		if (remainingSeconds < 0)
@@ -157,48 +157,43 @@ class XpStateSingle
 
 		long durationDays = remainingSeconds / (24 * 60 * 60);
 		long durationHours = (remainingSeconds % (24 * 60 * 60)) / (60 * 60);
+		long durationHoursTotal = remainingSeconds / (60 * 60);
 		long durationMinutes = (remainingSeconds % (60 * 60)) / 60;
 		long durationSeconds = remainingSeconds % 60;
 
-		if (durationDays > 1)
+		switch (goalTimeType)
 		{
-			return String.format("%d days %02d:%02d:%02d", durationDays, durationHours, durationMinutes, durationSeconds);
-		}
-		else if (durationDays == 1)
-		{
-			return String.format("1 day %02d:%02d:%02d", durationHours, durationMinutes, durationSeconds);
-		}
+			case DAYS:
+				if (durationDays > 1)
+				{
+					return String.format("%d days %02d:%02d:%02d", durationDays, durationHours, durationMinutes, durationSeconds);
+				}
+				else if (durationDays == 1)
+				{
+					return String.format("1 day %02d:%02d:%02d", durationHours, durationMinutes, durationSeconds);
+				}
+			case HOURS:
+				if (durationHoursTotal > 1)
+				{
+					return String.format("%d hours %02d:%02d", durationHoursTotal, durationMinutes, durationSeconds);
+				}
+				else if (durationHoursTotal == 1)
+				{
+					return String.format("1 hour %02d:%02d", durationMinutes, durationSeconds);
+				}
+			case SHORT:
+			default:
+				// durationDays = 0 or durationHoursTotal = 0 or goalTimeType = SHORT if we got here.
+				// return time remaining in hh:mm:ss or mm:ss format where hh can be > 24
+				if (durationHoursTotal > 0)
+				{
+					return String.format("%02d:%02d:%02d", durationHoursTotal, durationMinutes, durationSeconds);
+				}
 
-		// durationDays = 0 if we got here.
-		// return time remaining in hh:mm:ss or mm:ss format
-		return getTimeTillLevelShort();
+				// Minutes and seconds will always be present
+				return String.format("%02d:%02d", durationMinutes, durationSeconds);
+		}
 	}
-
-	/**
-	 * Get time to level in `hh:mm:ss` or `mm:ss` format,
-	 * where `hh` can be > 24.
-	 * @return
-	 */
-	private String getTimeTillLevelShort()
-	{
-		long remainingSeconds = getSecondsTillLevel();
-		if (remainingSeconds < 0)
-		{
-			return "\u221e";
-		}
-
-		long durationHours = remainingSeconds / (60 * 60);
-		long durationMinutes = (remainingSeconds % (60 * 60)) / 60;
-		long durationSeconds = remainingSeconds % 60;
-		if (durationHours > 0)
-		{
-			return String.format("%02d:%02d:%02d", durationHours, durationMinutes, durationSeconds);
-		}
-
-		// Minutes and seconds will always be present
-		return String.format("%02d:%02d", durationMinutes, durationSeconds);
-	}
-
 
 	int getXpHr()
 	{
@@ -298,8 +293,9 @@ class XpStateSingle
 			.actionsInSession(getXpAction(actionType).getActions())
 			.actionsRemainingToGoal(getActionsRemaining())
 			.actionsPerHour(getActionsHr())
-			.timeTillGoal(getTimeTillLevel())
-			.timeTillGoalShort(getTimeTillLevelShort())
+			.timeTillGoal(getTimeTillLevel(XpGoalTimeType.DAYS))
+			.timeTillGoalHours(getTimeTillLevel(XpGoalTimeType.HOURS))
+			.timeTillGoalShort(getTimeTillLevel(XpGoalTimeType.SHORT))
 			.startGoalXp(startLevelExp)
 			.endGoalXp(endLevelExp)
 			.build();

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerConfig.java
@@ -180,6 +180,17 @@ public interface XpTrackerConfig extends Config
 
 	@ConfigItem(
 		position = 12,
+		keyName = "progressBarTooltipLabel",
+		name = "Tooltip label",
+		description = "Configures the info box progress bar tooltip to show Time to goal or percentage complete"
+	)
+	default XpProgressBarLabel progressBarTooltipLabel()
+	{
+		return XpProgressBarLabel.TIME_TO_LEVEL;
+	}
+
+	@ConfigItem(
+		position = 13,
 		keyName = "prioritizeRecentXpSkills",
 		name = "Move recently trained skills to top",
 		description = "Configures whether skills should be organized by most recently gained xp"


### PR DESCRIPTION
Add option to display XP goal times in hours rather than days, since some people find it easier to visualize goals that way. This means hours can go above 23 in XP goals. In addition, add an option for showing the current percentage of an XP goal in the progress bar tooltip.

![Preview](https://i.imgur.com/MTNj2v7.png)