### PR TITLE
banktags: don't allow colon in tagtab names

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/banktags/BankTagsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/banktags/BankTagsPlugin.java
@@ -233,7 +233,7 @@ public class BankTagsPlugin extends Plugin implements MouseWheelListener
 			return;
 		}
 
-		String replaced = value.replaceAll("[<>/]", "");
+		String replaced = value.replaceAll("[<>:/]", "");
 		if (!value.equals(replaced))
 		{
 			replaced = Text.toCSV(Text.fromCSV(replaced));

--- a/runelite-client/src/main/java/net/runelite/client/plugins/banktags/tabs/TabInterface.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/banktags/tabs/TabInterface.java
@@ -97,7 +97,7 @@ import net.runelite.client.util.Text;
 @Singleton
 public class TabInterface
 {
-	public static final IntPredicate FILTERED_CHARS = c -> "</>".indexOf(c) == -1;
+	public static final IntPredicate FILTERED_CHARS = c -> "</>:".indexOf(c) == -1;
 
 	private static final Color HILIGHT_COLOR = JagexColors.MENU_TARGET;
 	private static final String SCROLL_UP = "Scroll up";


### PR DESCRIPTION
The config server replaces periods in keys with colons. When the config is downloaded by the client, the colon is then replaced with a period.

Closes #10500 