### PR TITLE
Add the ability to merge the raid hp bar overlay with the opponent info overlay

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/Varbits.java
+++ b/runelite-api/src/main/java/net/runelite/api/Varbits.java
@@ -304,6 +304,8 @@ public enum Varbits
 	PERSONAL_POINTS(5422),
 	RAID_PARTY_SIZE(5424),
 
+	RAID_HEALTH_BAR_OVERLAY_VALUE(6099),
+
 	// 0 = raid not started, >0 = raid started
 	RAID_STATE(5425),
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/opponentinfo/OpponentInfoConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/opponentinfo/OpponentInfoConfig.java
@@ -63,4 +63,15 @@ public interface OpponentInfoConfig extends Config
 	{
 		return false;
 	}
+
+	@ConfigItem(
+			keyName = "mergeRaidOverlay",
+			name = "Merge raid health bar overlay",
+			description = "Hides the raid health bar overlay, but adds the info to the existing opponent info",
+			position = 4
+	)
+	default boolean mergeRaidOverlay()
+	{
+		return true;
+	}
 }


### PR DESCRIPTION
## example:

### before:
![image](https://user-images.githubusercontent.com/20537001/94916413-ef448d80-04ae-11eb-8ae0-859cd092b0c2.png)

### after: 
![image](https://user-images.githubusercontent.com/20537001/94916490-0d11f280-04af-11eb-9bef-a008b9eb8b6a.png)


This would essentially close these isssues: https://github.com/runelite/runelite/issues/12283 https://github.com/runelite/runelite/issues/12230 https://github.com/runelite/runelite/issues/12137