### PR TITLE
Render Ground Items tile overlay at correct height

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/Perspective.java
+++ b/runelite-api/src/main/java/net/runelite/api/Perspective.java
@@ -365,6 +365,20 @@ public class Perspective
 	}
 
 	/**
+	 * Calculates a tile polygon from offset worldToScreen() points.
+	 *
+	 * @param client the game client
+	 * @param localLocation local location of the tile
+	 * @param zOffset offset from ground plane
+	 * @return a {@link Polygon} on screen corresponding to the given
+	 * localLocation.
+	 */
+	public static Polygon getCanvasTilePoly(@Nonnull Client client, @Nonnull LocalPoint localLocation, int zOffset)
+	{
+		return getCanvasTileAreaPoly(client, localLocation, 1, zOffset);
+	}
+
+	/**
 	 * Returns a polygon representing an area.
 	 *
 	 * @param client the game client
@@ -373,6 +387,24 @@ public class Perspective
 	 * @return a polygon representing the tiles in the area
 	 */
 	public static Polygon getCanvasTileAreaPoly(@Nonnull Client client, @Nonnull LocalPoint localLocation, int size)
+	{
+		return getCanvasTileAreaPoly(client, localLocation, size, 0);
+	}
+
+	/**
+	 * Returns a polygon representing an area.
+	 *
+	 * @param client the game client
+	 * @param localLocation the center location of the AoE
+	 * @param size the size of the area (ie. 3x3 AoE evaluates to size 3)
+	 * @param zOffset offset from ground plane
+	 * @return a polygon representing the tiles in the area
+	 */
+	public static Polygon getCanvasTileAreaPoly(
+		@Nonnull Client client,
+		@Nonnull LocalPoint localLocation,
+		int size,
+		int zOffset)
 	{
 		final int plane = client.getPlane();
 
@@ -404,10 +436,10 @@ public class Perspective
 			tilePlane = plane + 1;
 		}
 
-		final int swHeight = getHeight(client, swX, swY, tilePlane);
-		final int nwHeight = getHeight(client, nwX, nwY, tilePlane);
-		final int neHeight = getHeight(client, neX, neY, tilePlane);
-		final int seHeight = getHeight(client, seX, seY, tilePlane);
+		final int swHeight = getHeight(client, swX, swY, tilePlane) - zOffset;
+		final int nwHeight = getHeight(client, nwX, nwY, tilePlane) - zOffset;
+		final int neHeight = getHeight(client, neX, neY, tilePlane) - zOffset;
+		final int seHeight = getHeight(client, seX, seY, tilePlane) - zOffset;
 
 		Point p1 = localToCanvas(client, swX, swY, swHeight);
 		Point p2 = localToCanvas(client, nwX, nwY, nwHeight);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
@@ -210,7 +210,7 @@ public class GroundItemsOverlay extends Overlay
 
 			if (config.highlightTiles())
 			{
-				final Polygon poly = Perspective.getCanvasTilePoly(client, groundPoint);
+				final Polygon poly = Perspective.getCanvasTilePoly(client, groundPoint, item.getHeight());
 
 				if (poly != null)
 				{


### PR DESCRIPTION
Added `zOffset` argument for `Perspective.getCanvasTilePoly` and `Perspective.getCanvasTileAreaPoly` to allow Ground Items to render the tile overlay at the correct height (for example tables).
![image](https://user-images.githubusercontent.com/7273082/94951253-9d225d00-04ec-11eb-83e2-1c35219bb5d1.png)
