### PR TITLE
Add Fill Option for Inventory Tags

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/inventorytags/InventoryTagsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/inventorytags/InventoryTagsConfig.java
@@ -28,20 +28,74 @@ import java.awt.Color;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.ConfigSection;
+import net.runelite.client.config.Range;
 
-@ConfigGroup("inventorytags")
+@ConfigGroup(InventoryTagsConfig.GROUP)
 public interface InventoryTagsConfig extends Config
 {
-	enum DisplayMode
-	{
-		OUTLINE,
-		UNDERLINE
-	}
-
 	String GROUP = "inventorytags";
+
+	@ConfigSection(
+		name = "Tag display mode",
+		description = "How tags are displayed in the inventory",
+		position = 0
+	)
+	String tagStyleSection = "tagStyleSection";
 
 	@ConfigItem(
 		position = 0,
+		keyName = "showTagOutline",
+		name = "Outline",
+		description = "Configures whether or not item tags show be outlined",
+		section = tagStyleSection
+	)
+	default boolean showTagOutline()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		position = 1,
+		keyName = "tagUnderline",
+		name = "Underline",
+		description = "Configures whether or not item tags should be underlined",
+		section = tagStyleSection
+	)
+	default boolean showTagUnderline()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		position = 2,
+		keyName = "tagFill",
+		name = "Fill",
+		description = "Configures whether or not item tags should be filled",
+		section = tagStyleSection
+	)
+	default boolean showTagFill()
+	{
+		return false;
+	}
+
+	@Range(
+		max = 255
+	)
+	@ConfigItem(
+		position = 3,
+		keyName = "fillOpacity",
+		name = "Fill opacity",
+		description = "Configures the opacity of the tag \"Fill\"",
+		section = tagStyleSection
+	)
+	default int fillOpacity()
+	{
+		return 50;
+	}
+
+	@ConfigItem(
+		position = 1,
 		keyName = "groupColor1",
 		name = "Group 1 Color",
 		description = "Color of the Tag"
@@ -52,7 +106,7 @@ public interface InventoryTagsConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 1,
+		position = 2,
 		keyName = "groupColor2",
 		name = "Group 2 Color",
 		description = "Color of the Tag"
@@ -63,7 +117,7 @@ public interface InventoryTagsConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 2,
+		position = 3,
 		keyName = "groupColor3",
 		name = "Group 3 Color",
 		description = "Color of the Tag"
@@ -74,7 +128,7 @@ public interface InventoryTagsConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 3,
+		position = 4,
 		keyName = "groupColor4",
 		name = "Group 4 Color",
 		description = "Color of the Tag"
@@ -85,7 +139,7 @@ public interface InventoryTagsConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 4,
+		position = 5,
 		keyName = "groupColor5",
 		name = "Group 5 Color",
 		description = "Color of the Tag"
@@ -96,7 +150,7 @@ public interface InventoryTagsConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 5,
+		position = 6,
 		keyName = "groupColor6",
 		name = "Group 6 Color",
 		description = "Color of the Tag"
@@ -104,16 +158,5 @@ public interface InventoryTagsConfig extends Config
 	default Color getGroup6Color()
 	{
 		return new Color(0, 255, 255);
-	}
-
-	@ConfigItem(
-		position = 6,
-		keyName = "displayMode",
-		name = "Display mode",
-		description = "How tags are displayed in the inventory"
-	)
-	default DisplayMode getDisplayMode()
-	{
-		return DisplayMode.OUTLINE;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/inventorytags/InventoryTagsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/inventorytags/InventoryTagsOverlay.java
@@ -24,21 +24,26 @@
  */
 package net.runelite.client.plugins.inventorytags;
 
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
 import java.awt.Color;
 import java.awt.Graphics2D;
+import java.awt.Image;
 import java.awt.Rectangle;
 import java.awt.image.BufferedImage;
 import javax.inject.Inject;
 import net.runelite.api.widgets.WidgetItem;
 import net.runelite.client.game.ItemManager;
-import net.runelite.client.plugins.inventorytags.InventoryTagsConfig.DisplayMode;
 import net.runelite.client.ui.overlay.WidgetItemOverlay;
+import net.runelite.client.util.ColorUtil;
+import net.runelite.client.util.ImageUtil;
 
 public class InventoryTagsOverlay extends WidgetItemOverlay
 {
 	private final ItemManager itemManager;
 	private final InventoryTagsPlugin plugin;
 	private final InventoryTagsConfig config;
+	private final Cache<Long, Image> fillCache;
 
 	@Inject
 	private InventoryTagsOverlay(ItemManager itemManager, InventoryTagsPlugin plugin, InventoryTagsConfig config)
@@ -48,6 +53,10 @@ public class InventoryTagsOverlay extends WidgetItemOverlay
 		this.config = config;
 		showOnEquipment();
 		showOnInventory();
+		fillCache = CacheBuilder.newBuilder()
+			.concurrencyLevel(1)
+			.maximumSize(32)
+			.build();
 	}
 
 	@Override
@@ -57,16 +66,22 @@ public class InventoryTagsOverlay extends WidgetItemOverlay
 		if (group != null)
 		{
 			final Color color = plugin.getGroupNameColor(group);
-			final DisplayMode displayMode = config.getDisplayMode();
 			if (color != null)
 			{
 				Rectangle bounds = widgetItem.getCanvasBounds();
-				if (displayMode == DisplayMode.OUTLINE)
+				if (config.showTagOutline())
 				{
 					final BufferedImage outline = itemManager.getItemOutline(itemId, widgetItem.getQuantity(), color);
 					graphics.drawImage(outline, (int) bounds.getX(), (int) bounds.getY(), null);
 				}
-				else
+
+				if (config.showTagFill())
+				{
+					final Image image = getFillImage(color, widgetItem.getId(), widgetItem.getQuantity());
+					graphics.drawImage(image, (int) bounds.getX(), (int) bounds.getY(), null);
+				}
+
+				if (config.showTagUnderline())
 				{
 					int heightOffSet = (int) bounds.getY() + (int) bounds.getHeight() + 2;
 					graphics.setColor(color);
@@ -74,5 +89,23 @@ public class InventoryTagsOverlay extends WidgetItemOverlay
 				}
 			}
 		}
+	}
+
+	private Image getFillImage(Color color, int itemId, int qty)
+	{
+		long key = (((long) itemId) << 32) | qty;
+		Image image = fillCache.getIfPresent(key);
+		if (image == null)
+		{
+			final Color fillColor = ColorUtil.colorWithAlpha(color, config.fillOpacity());
+			image = ImageUtil.fillImage(itemManager.getImage(itemId, qty, false), fillColor);
+			fillCache.put(key, image);
+		}
+		return image;
+	}
+
+	void invalidateCache()
+	{
+		fillCache.invalidateAll();
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/inventorytags/InventoryTagsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/inventorytags/InventoryTagsPlugin.java
@@ -39,6 +39,7 @@ import net.runelite.api.events.WidgetMenuOptionClicked;
 import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
+import net.runelite.client.events.ConfigChanged;
 import net.runelite.client.menus.MenuManager;
 import net.runelite.client.menus.WidgetMenuOption;
 import net.runelite.client.plugins.Plugin;
@@ -145,6 +146,15 @@ public class InventoryTagsPlugin extends Plugin
 		removeInventoryMenuOptions();
 		overlayManager.remove(overlay);
 		editorMode = false;
+	}
+
+	@Subscribe
+	public void onConfigChanged(ConfigChanged configChanged)
+	{
+		if (configChanged.getGroup().equals(InventoryTagsConfig.GROUP))
+		{
+			overlay.invalidateCache();
+		}
 	}
 
 	@Subscribe

--- a/runelite-client/src/main/java/net/runelite/client/util/ImageUtil.java
+++ b/runelite-client/src/main/java/net/runelite/client/util/ImageUtil.java
@@ -395,8 +395,9 @@ public class ImageUtil
 		{
 			for (int y = 0; y < filledImage.getHeight(); y++)
 			{
-				final Color pixelColor = new Color(image.getRGB(x, y), true);
-				if (pixelColor.getAlpha() == 0)
+				int pixel = image.getRGB(x, y);
+				int a = pixel >>> 24;
+				if (a == 0)
 				{
 					continue;
 				}


### PR DESCRIPTION
Closes #12518

Includes a spinner for alpha values from 0-255

Looks like this at 100:
![filled tags](https://i.imgur.com/1qWhu0D.png)