### PR TITLE
Add woodcutting clickboxes

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/Tree.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/Tree.java
@@ -57,10 +57,10 @@ import static net.runelite.api.ObjectID.YEW_36683;
 @Getter
 enum Tree
 {
-	REGULAR_TREE(null, TREE, TREE_1277, TREE_1278, TREE_1279, TREE_1280),
-	OAK_TREE(Duration.ofMillis(8500), ObjectID.OAK_TREE, OAK_TREE_4540, OAK_10820),
-	WILLOW_TREE(Duration.ofMillis(8500), WILLOW, WILLOW_10829, WILLOW_10831, WILLOW_10833),
-	MAPLE_TREE(Duration.ofSeconds(35), ObjectID.MAPLE_TREE, MAPLE_TREE_10832, MAPLE_TREE_36681)
+	REGULAR_TREE(1, null, TREE, TREE_1277, TREE_1278, TREE_1279, TREE_1280),
+	OAK_TREE(15, Duration.ofMillis(8500), ObjectID.OAK_TREE, OAK_TREE_4540, OAK_10820),
+	WILLOW_TREE(30, Duration.ofMillis(8500), WILLOW, WILLOW_10829, WILLOW_10831, WILLOW_10833),
+	MAPLE_TREE(45, Duration.ofSeconds(35), ObjectID.MAPLE_TREE, MAPLE_TREE_10832, MAPLE_TREE_36681)
 		{
 			@Override
 			Duration getRespawnTime(int region)
@@ -68,18 +68,20 @@ enum Tree
 				return region == MISCELLANIA_REGION ? Duration.ofMillis(8500) : super.respawnTime;
 			}
 		},
-	TEAK_TREE(Duration.ofMillis(8500), TEAK, TEAK_36686),
-	MAHOGANY_TREE(Duration.ofMillis(8500), MAHOGANY, MAHOGANY_36688),
-	YEW_TREE(Duration.ofMinutes(1), YEW, NULL_10823, YEW_36683),
-	MAGIC_TREE(Duration.ofMinutes(2), MAGIC_TREE_10834, NULL_10835),
-	REDWOOD(Duration.ofMinutes(2), ObjectID.REDWOOD, REDWOOD_29670);
+	TEAK_TREE(35, Duration.ofMillis(8500), TEAK, TEAK_36686),
+	MAHOGANY_TREE(50, Duration.ofMillis(8500), MAHOGANY, MAHOGANY_36688),
+	YEW_TREE(60, Duration.ofMinutes(1), YEW, NULL_10823, YEW_36683),
+	MAGIC_TREE(75, Duration.ofMinutes(2), MAGIC_TREE_10834, NULL_10835),
+	REDWOOD(90, Duration.ofMinutes(2), ObjectID.REDWOOD, REDWOOD_29670);
 
+	private final int level;
 	@Nullable
 	private final Duration respawnTime;
 	private final int[] treeIds;
 
-	Tree(Duration respawnTime, int... treeIds)
+	Tree(int level, Duration respawnTime, int... treeIds)
 	{
+		this.level = level;
 		this.respawnTime = respawnTime;
 		this.treeIds = treeIds;
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingClickboxOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingClickboxOverlay.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2018, Adam <Adam@sigterm.info>
+ * Copyright (c) 2018, Cas <https://github.com/casvandongen>
+ * Copyright (c) 2020, Carl <https://github.com/CarlOlson>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.woodcutting;
+
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Graphics2D;
+import java.awt.Shape;
+import javax.inject.Inject;
+import net.runelite.api.Client;
+import net.runelite.api.Point;
+import net.runelite.api.Skill;
+import net.runelite.api.coords.LocalPoint;
+import net.runelite.client.ui.overlay.Overlay;
+import net.runelite.client.ui.overlay.OverlayLayer;
+import net.runelite.client.ui.overlay.OverlayPosition;
+
+class WoodcuttingClickboxOverlay extends Overlay
+{
+	private static final int MAX_DISTANCE = 2350;
+	private static final Color TREE_HIGH_LEVEL_COLOR = Color.ORANGE;
+	private static final int OVERLAY_ALPHA = 50;
+
+	private final Client client;
+	private final WoodcuttingPlugin plugin;
+	private final WoodcuttingConfig config;
+
+	@Inject
+	private WoodcuttingClickboxOverlay(Client client, WoodcuttingPlugin plugin, WoodcuttingConfig config)
+	{
+		super(plugin);
+		setPosition(OverlayPosition.DYNAMIC);
+		setLayer(OverlayLayer.ABOVE_SCENE);
+		this.client = client;
+		this.plugin = plugin;
+		this.config = config;
+	}
+
+	@Override
+	public Dimension render(Graphics2D graphics)
+	{
+		if (!config.showClickboxes())
+		{
+			return null;
+		}
+
+		LocalPoint playerLocation = client.getLocalPlayer().getLocalLocation();
+		Point mousePosition = client.getMouseCanvasPosition();
+		int woodcuttingLevel = client.getRealSkillLevel(Skill.WOODCUTTING);
+
+		plugin.getTreeObjects().forEach((object) ->
+		{
+			Tree tree = Tree.findTree(object.getId());
+
+			if (tree != null
+				&& tree != Tree.REGULAR_TREE
+				&& object.getPlane() == client.getPlane()
+				&& object.getLocalLocation().distanceTo(playerLocation) < MAX_DISTANCE)
+			{
+				Shape objectClickbox = object.getClickbox();
+				if (objectClickbox != null)
+				{
+					Color configColor = tree.getLevel() <= woodcuttingLevel ? config.getOverlayColor() : TREE_HIGH_LEVEL_COLOR;
+
+					if (objectClickbox.contains(mousePosition.getX(), mousePosition.getY()))
+					{
+						graphics.setColor(configColor.darker());
+					}
+					else
+					{
+						graphics.setColor(configColor);
+					}
+
+					graphics.draw(objectClickbox);
+					graphics.setColor(new Color(configColor.getRed(), configColor.getGreen(), configColor.getBlue(), OVERLAY_ALPHA));
+					graphics.fill(objectClickbox);
+				}
+			}
+
+		});
+
+		return null;
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingConfig.java
@@ -24,6 +24,7 @@
  */
 package net.runelite.client.plugins.woodcutting;
 
+import java.awt.Color;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
@@ -86,5 +87,27 @@ public interface WoodcuttingConfig extends Config
 	default boolean showRespawnTimers()
 	{
 		return true;
+	}
+
+	@ConfigItem(
+		position = 6,
+		keyName = "showClickboxes",
+		name = "Show Clickboxes",
+		description = "Show tree clickboxes"
+	)
+	default boolean showClickboxes()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		keyName = "overlayColor",
+		name = "Overlay Color",
+		description = "Color of tree overlay",
+		position = 7
+	)
+	default Color getOverlayColor()
+	{
+		return Color.GREEN;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingPlugin.java
@@ -90,6 +90,9 @@ public class WoodcuttingPlugin extends Plugin
 	private WoodcuttingTreesOverlay treesOverlay;
 
 	@Inject
+	private WoodcuttingClickboxOverlay clickboxOverlay;
+
+	@Inject
 	private WoodcuttingConfig config;
 
 	@Getter
@@ -119,6 +122,7 @@ public class WoodcuttingPlugin extends Plugin
 	{
 		overlayManager.add(overlay);
 		overlayManager.add(treesOverlay);
+		overlayManager.add(clickboxOverlay);
 	}
 
 	@Override
@@ -126,6 +130,7 @@ public class WoodcuttingPlugin extends Plugin
 	{
 		overlayManager.remove(overlay);
 		overlayManager.remove(treesOverlay);
+		overlayManager.remove(clickboxOverlay);
 		respawns.clear();
 		treeObjects.clear();
 		session = null;
@@ -201,10 +206,7 @@ public class WoodcuttingPlugin extends Plugin
 		GameObject gameObject = event.getGameObject();
 		Tree tree = Tree.findTree(gameObject.getId());
 
-		if (tree == Tree.REDWOOD)
-		{
-			treeObjects.add(gameObject);
-		}
+		treeObjects.add(gameObject);
 	}
 
 	@Subscribe
@@ -228,10 +230,7 @@ public class WoodcuttingPlugin extends Plugin
 				respawns.add(treeRespawn);
 			}
 
-			if (tree == Tree.REDWOOD)
-			{
-				treeObjects.remove(event.getGameObject());
-			}
+			treeObjects.remove(event.getGameObject());
 		}
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingTreesOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingTreesOverlay.java
@@ -46,6 +46,8 @@ import net.runelite.client.ui.overlay.components.ProgressPieComponent;
 
 class WoodcuttingTreesOverlay extends Overlay
 {
+	private static final int MAX_REDWOOD_INDICATOR_DISTANCE = 12;
+
 	private final Client client;
 	private final WoodcuttingConfig config;
 	private final ItemManager itemManager;
@@ -85,7 +87,9 @@ class WoodcuttingTreesOverlay extends Overlay
 
 		for (GameObject treeObject : plugin.getTreeObjects())
 		{
-			if (treeObject.getWorldLocation().distanceTo(client.getLocalPlayer().getWorldLocation()) <= 12)
+			Tree tree = Tree.findTree(treeObject.getId());
+			if (tree == Tree.REDWOOD
+				&& treeObject.getWorldLocation().distanceTo(client.getLocalPlayer().getWorldLocation()) <= MAX_REDWOOD_INDICATOR_DISTANCE)
 			{
 				OverlayUtil.renderImageLocation(client, graphics, treeObject.getLocalLocation(), itemManager.getImage(axe.getItemId()), 120);
 			}


### PR DESCRIPTION
This adds click boxes to trees, similar to the agility plugin. I searched, but couldn't find any references to this being a rejected feature.

I based this off the agility plugin code, so I used the existing copyright and added my name to the new file. (I didn't see how to handle copyright notices in the docs/wiki...)

![2020-10-06_22-29-20](https://user-images.githubusercontent.com/6601628/95210176-2f489f00-0826-11eb-80c7-9770d2b55f80.jpg)