### PR TITLE
Make minimum overlay size configurable per-overlay

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenmarkers/ScreenMarkerOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenmarkers/ScreenMarkerOverlay.java
@@ -49,6 +49,7 @@ public class ScreenMarkerOverlay extends Overlay
 		setLayer(OverlayLayer.ALWAYS_ON_TOP);
 		setPriority(OverlayPriority.HIGH);
 		setResizable(true);
+		setMinimumSize(16);
 		setResettable(false);
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/Overlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/Overlay.java
@@ -51,6 +51,7 @@ public abstract class Overlay implements LayoutableRenderableEntity
 	private OverlayLayer layer = OverlayLayer.UNDER_WIDGETS;
 	private final List<OverlayMenuEntry> menuEntries = new ArrayList<>();
 	private boolean resizable;
+	private int minimumSize = 32;
 	private boolean resettable = true;
 
 	/**

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayRenderer.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayRenderer.java
@@ -70,7 +70,6 @@ public class OverlayRenderer extends MouseAdapter implements KeyListener
 	private static final int BORDER = 5;
 	private static final int BORDER_TOP = BORDER + 15;
 	private static final int PADDING = 2;
-	private static final int MIN_OVERLAY_SIZE = 32;
 	private static final int OVERLAY_RESIZE_TOLERANCE = 5;
 	private static final Dimension SNAP_CORNER_SIZE = new Dimension(80, 80);
 	private static final Color SNAP_CORNER_COLOR = new Color(0, 255, 255, 50);
@@ -536,8 +535,9 @@ public class OverlayRenderer extends MouseAdapter implements KeyListener
 					// center
 			}
 
-			final int widthOverflow = Math.max(0, MIN_OVERLAY_SIZE - width);
-			final int heightOverflow = Math.max(0, MIN_OVERLAY_SIZE - height);
+			final int minOverlaySize = currentManagedOverlay.getMinimumSize();
+			final int widthOverflow = Math.max(0, minOverlaySize - width);
+			final int heightOverflow = Math.max(0, minOverlaySize - height);
 			final int dx = x - originalX;
 			final int dy = y - originalY;
 
@@ -545,7 +545,7 @@ public class OverlayRenderer extends MouseAdapter implements KeyListener
 			// dimensions and adjust the x/y position accordingly as needed
 			if (widthOverflow > 0)
 			{
-				width = MIN_OVERLAY_SIZE;
+				width = minOverlaySize;
 
 				if (dx > 0)
 				{
@@ -554,7 +554,7 @@ public class OverlayRenderer extends MouseAdapter implements KeyListener
 			}
 			if (heightOverflow > 0)
 			{
-				height = MIN_OVERLAY_SIZE;
+				height = minOverlaySize;
 
 				if (dy > 0)
 				{


### PR DESCRIPTION
Halve the minimum for Screen Marker Overlay (set to 16). Any smaller than 16 makes subsequent resizes impossible because the cursor type never changes from center (move mode). All other overlay types are unchanged from the default (32).

If the reasoning for the original default was the same as above, it might be worthwhile to change the default to 16 as well. And maybe in that case undo most of this commit and just change the original constant to 16, ha.

Fixes #12267 