### PR TITLE
Time Tracking: Add right click menu to reset farming patches

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/farming/FarmingTabPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/farming/FarmingTabPanel.java
@@ -33,6 +33,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import javax.swing.JLabel;
+import javax.swing.JMenuItem;
+import javax.swing.JPopupMenu;
 import javax.swing.border.EmptyBorder;
 import net.runelite.api.ItemID;
 import net.runelite.client.game.ItemManager;
@@ -102,6 +104,31 @@ public class FarmingTabPanel extends TabContentPanel
 				c.gridy++;
 				lastImpl = patch.getImplementation();
 			}
+
+			// Use the existing popup menu or create a new one
+			JPopupMenu popupMenu = p.getComponentPopupMenu();
+			if (popupMenu == null)
+			{
+				popupMenu = new JPopupMenu();
+				popupMenu.setBorder(new EmptyBorder(5, 5, 5, 5));
+				p.setComponentPopupMenu(popupMenu);
+			}
+
+			// Create reset menu
+			JMenuItem reset = new JMenuItem("Reset");
+			reset.addActionListener(e ->
+			{
+				farmingTracker.resetData(p.getTimeable().getRegion(), p.getTimeable().getVarbit());
+
+				itemManager.getImage(Produce.WEEDS.getItemID()).addTo(p.getIcon());
+				p.getIcon().setToolTipText("Unknown state");
+				p.getProgress().setMaximumValue(0);
+				p.getProgress().setValue(0);
+				p.getProgress().setVisible(false);
+				p.getEstimate().setText("Unknown");
+				p.getProgress().setBackground(null);
+			});
+			popupMenu.add(reset);
 
 			patchPanels.add(p);
 			add(p, c);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/farming/FarmingTracker.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/farming/FarmingTracker.java
@@ -76,6 +76,16 @@ public class FarmingTracker
 	}
 
 	/**
+	 * Resets the tracker for a given patch.
+	 */
+	public void resetData(FarmingRegion region, Varbits patchVarbits)
+	{
+		String group = TimeTrackingConfig.CONFIG_GROUP + "." + client.getUsername() + "." + region.getRegionID();
+		configManager.unsetConfiguration(group, Integer.toString(patchVarbits.getId()));
+		updateCompletionTime();
+	}
+
+	/**
 	 * Updates tracker data for the current region. Returns true if any data was changed.
 	 */
 	public boolean updateData(WorldPoint location)
@@ -176,6 +186,7 @@ public class FarmingTracker
 				}
 				catch (NumberFormatException e)
 				{
+					// ignore
 				}
 			}
 		}


### PR DESCRIPTION
Add a right click menu to reset farming patches in time tracking. 

Useful for when you collect a crop on mobile and you don't want to go back to check it so it doesn't show "Ready" when it's not.