### PR TITLE
Extended widget support for showOnInventory

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/widgets/WidgetID.java
+++ b/runelite-api/src/main/java/net/runelite/api/widgets/WidgetID.java
@@ -160,6 +160,8 @@ public class WidgetID
 	public static final int CHAMBERS_OF_XERIC_STORAGE_UNIT_PRIVATE_GROUP_ID = 271;
 	public static final int CHAMBERS_OF_XERIC_STORAGE_UNIT_SHARED_GROUP_ID = 550;
 	public static final int CHAMBERS_OF_XERIC_STORAGE_UNIT_INVENTORY_GROUP_ID = 551;
+	public static final int DUEL_INVENTORY_GROUP_ID = 421;
+	public static final int DUEL_INVENTORY_OTHER_GROUP_ID = 481;
 
 	static class WorldMap
 	{

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/WidgetItemOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/WidgetItemOverlay.java
@@ -44,6 +44,10 @@ import static net.runelite.api.widgets.WidgetID.GUIDE_PRICES_INVENTORY_GROUP_ID;
 import static net.runelite.api.widgets.WidgetID.INVENTORY_GROUP_ID;
 import static net.runelite.api.widgets.WidgetID.SEED_VAULT_INVENTORY_GROUP_ID;
 import static net.runelite.api.widgets.WidgetID.SHOP_INVENTORY_GROUP_ID;
+import static net.runelite.api.widgets.WidgetID.DUEL_INVENTORY_GROUP_ID;
+import static net.runelite.api.widgets.WidgetID.DUEL_INVENTORY_OTHER_GROUP_ID;
+import static net.runelite.api.widgets.WidgetID.PLAYER_TRADE_SCREEN_GROUP_ID;
+import static net.runelite.api.widgets.WidgetID.PLAYER_TRADE_INVENTORY_GROUP_ID;
 import static net.runelite.api.widgets.WidgetInfo.BANK_CONTENT_CONTAINER;
 import static net.runelite.api.widgets.WidgetInfo.BANK_TAB_CONTAINER;
 import static net.runelite.api.widgets.WidgetInfo.TO_GROUP;
@@ -138,7 +142,11 @@ public abstract class WidgetItemOverlay extends Overlay
 			GUIDE_PRICES_INVENTORY_GROUP_ID,
 			EQUIPMENT_INVENTORY_GROUP_ID,
 			INVENTORY_GROUP_ID,
-			SEED_VAULT_INVENTORY_GROUP_ID);
+			SEED_VAULT_INVENTORY_GROUP_ID,
+			DUEL_INVENTORY_GROUP_ID,
+			DUEL_INVENTORY_OTHER_GROUP_ID,
+			PLAYER_TRADE_SCREEN_GROUP_ID,
+			PLAYER_TRADE_INVENTORY_GROUP_ID);
 	}
 
 	protected void showOnBank()


### PR DESCRIPTION
This adds widget overlay support for inventory in both trading screen and duelarena screen for plugins such as **[Inventory Tags]** and **[Item Charges]**.

![image](https://user-images.githubusercontent.com/1779288/95306847-330d0d80-0888-11eb-9986-33636f906c9b.png)
![image](https://user-images.githubusercontent.com/1779288/95306859-37392b00-0888-11eb-8fb7-f00a06374968.png)


Fixes: #12584