### PR TITLE
Reposition top center snap corner in Resizable Mode

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayRenderer.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayRenderer.java
@@ -810,7 +810,7 @@ public class OverlayRenderer extends MouseAdapter implements KeyListener
 			viewportOffset + BORDER_TOP);
 
 		final Point topCenterPoint = new Point(
-			viewportOffset + viewportBounds.width / 2,
+			isResizeable ? viewportOffset + (int)client.getRealDimensions().getWidth() / 2 : viewportOffset + viewportBounds.width / 2,
 			viewportOffset + BORDER
 		);
 


### PR DESCRIPTION
## Issue
The top center snap corner is misaligned in Resizable Mode. It is positioned to the left of the character instead of above the character in Fixed Mode.

## Change
Reposition the top center snap corner so it is aligned with the character when in Resizable Mode

## Testing
Locally tested

## Screenshots
Before: 
![image](https://user-images.githubusercontent.com/5412232/95672339-d003cb00-0b54-11eb-8572-30f708fca6e7.png)
After:
![image](https://user-images.githubusercontent.com/5412232/95672344-da25c980-0b54-11eb-805d-e7a4f1e30910.png)

