### PR TITLE
Refactor QuantityFormatter so method names and javadocs are more clear.

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/ammo/AmmoCounter.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/ammo/AmmoCounter.java
@@ -46,7 +46,7 @@ class AmmoCounter extends Counter
 	@Override
 	public String getText()
 	{
-		return QuantityFormatter.quantityToRSDecimalStack(getCount());
+		return QuantityFormatter.quantityToSIStack(getCount());
 	}
 
 	@Override

--- a/runelite-client/src/main/java/net/runelite/client/plugins/bank/BankPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/bank/BankPlugin.java
@@ -299,7 +299,7 @@ public class BankPlugin extends Plugin
 			}
 			else
 			{
-				stringBuilder.append(QuantityFormatter.quantityToStackSize(gePrice));
+				stringBuilder.append(QuantityFormatter.quantityToPreciseSIStack(gePrice));
 			}
 			stringBuilder.append(')');
 		}
@@ -319,7 +319,7 @@ public class BankPlugin extends Plugin
 			}
 			else
 			{
-				stringBuilder.append(QuantityFormatter.quantityToStackSize(haPrice));
+				stringBuilder.append(QuantityFormatter.quantityToPreciseSIStack(haPrice));
 			}
 			stringBuilder.append(')');
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/blastfurnace/BlastFurnaceCofferOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/blastfurnace/BlastFurnaceCofferOverlay.java
@@ -77,7 +77,7 @@ class BlastFurnaceCofferOverlay extends OverlayPanel
 
 			panelComponent.getChildren().add(LineComponent.builder()
 				.left("Coffer:")
-				.right(QuantityFormatter.quantityToStackSize(coffer) + " gp")
+				.right(QuantityFormatter.quantityToSIStack(coffer) + " gp")
 				.build());
 
 			if (config.showCofferTime())

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangeOfferSlot.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangeOfferSlot.java
@@ -214,8 +214,8 @@ public class GrandExchangeOfferSlot extends JPanel
 				|| newOffer.getState() == GrandExchangeOfferState.CANCELLED_BUY;
 
 			String offerState = (buying ? "Bought " : "Sold ")
-				+ QuantityFormatter.quantityToRSDecimalStack(newOffer.getQuantitySold()) + " / "
-				+ QuantityFormatter.quantityToRSDecimalStack(newOffer.getTotalQuantity());
+				+ QuantityFormatter.quantityToPreciseSIStack(newOffer.getQuantitySold()) + " / "
+				+ QuantityFormatter.quantityToPreciseSIStack(newOffer.getTotalQuantity());
 
 			offerInfo.setText(offerState);
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangePlugin.java
@@ -768,7 +768,7 @@ public class GrandExchangePlugin extends Plugin
 		}
 		else
 		{
-			titleBuilder.append(QuantityFormatter.quantityToStackSize(total));
+			titleBuilder.append(QuantityFormatter.quantityToPreciseSIStack(total));
 		}
 
 		titleBuilder.append(')');

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
@@ -234,7 +234,7 @@ public class GroundItemsOverlay extends Overlay
 				else
 				{
 					itemStringBuilder.append(" (")
-						.append(QuantityFormatter.quantityToStackSize(item.getQuantity()))
+						.append(QuantityFormatter.quantityToPreciseSIStack(item.getQuantity()))
 						.append(")");
 				}
 			}
@@ -244,14 +244,14 @@ public class GroundItemsOverlay extends Overlay
 				if (item.getGePrice() > 0)
 				{
 					itemStringBuilder.append(" (GE: ")
-						.append(QuantityFormatter.quantityToStackSize(item.getGePrice()))
+						.append(QuantityFormatter.quantityToPreciseSIStack(item.getGePrice()))
 						.append(" gp)");
 				}
 
 				if (item.getHaPrice() > 0)
 				{
 					itemStringBuilder.append(" (HA: ")
-						.append(QuantityFormatter.quantityToStackSize(item.getHaPrice()))
+						.append(QuantityFormatter.quantityToPreciseSIStack(item.getHaPrice()))
 						.append(" gp)");
 				}
 			}
@@ -265,7 +265,7 @@ public class GroundItemsOverlay extends Overlay
 				{
 					itemStringBuilder
 						.append(" (")
-						.append(QuantityFormatter.quantityToStackSize(price))
+						.append(QuantityFormatter.quantityToPreciseSIStack(price))
 						.append(" gp)");
 				}
 			}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
@@ -656,7 +656,7 @@ public class GroundItemsPlugin extends Plugin
 			else
 			{
 				notificationStringBuilder.append(" (")
-					.append(QuantityFormatter.quantityToStackSize(item.getQuantity()))
+					.append(QuantityFormatter.quantityToPreciseSIStack(item.getQuantity()))
 					.append(")");
 			}
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemprices/ItemPricesOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemprices/ItemPricesOverlay.java
@@ -240,12 +240,12 @@ class ItemPricesOverlay extends Overlay
 		if (gePrice > 0)
 		{
 			itemStringBuilder.append("GE: ")
-				.append(QuantityFormatter.quantityToStackSize((long) gePrice * qty))
+				.append(QuantityFormatter.quantityToPreciseSIStack((long) gePrice * qty))
 				.append(" gp");
 			if (config.showEA() && qty > 1)
 			{
 				itemStringBuilder.append(" (")
-					.append(QuantityFormatter.quantityToStackSize(gePrice))
+					.append(QuantityFormatter.quantityToPreciseSIStack(gePrice))
 					.append(" ea)");
 			}
 		}
@@ -257,12 +257,12 @@ class ItemPricesOverlay extends Overlay
 			}
 
 			itemStringBuilder.append("HA: ")
-				.append(QuantityFormatter.quantityToStackSize((long) haValue * qty))
+				.append(QuantityFormatter.quantityToPreciseSIStack((long) haValue * qty))
 				.append(" gp");
 			if (config.showEA() && qty > 1)
 			{
 				itemStringBuilder.append(" (")
-					.append(QuantityFormatter.quantityToStackSize(haValue))
+					.append(QuantityFormatter.quantityToPreciseSIStack(haValue))
 					.append(" ea)");
 			}
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatPlugin.java
@@ -340,7 +340,7 @@ public class ItemStatPlugin extends Plugin
 
 		createSeparator(invContainer, invContainer.getHeight() - 40);
 
-		final String coinText = "You have " + QuantityFormatter.quantityToStackSize(getCurrentGP())
+		final String coinText = "You have " + QuantityFormatter.quantityToPreciseSIStack(getCurrentGP())
 			+ (getCurrentGP() == 1 ? " coin." : " coins.");
 
 		final Widget coinWidget = createText(invContainer, coinText, FontID.PLAIN_12, ORANGE_TEXT,

--- a/runelite-client/src/main/java/net/runelite/client/plugins/kingdomofmiscellania/KingdomCounter.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/kingdomofmiscellania/KingdomCounter.java
@@ -48,6 +48,6 @@ public class KingdomCounter extends Counter
 	public String getTooltip()
 	{
 		return "Favor: " + plugin.getFavor() + "/127" + "</br>"
-			+ "Coffer: " + QuantityFormatter.quantityToStackSize(plugin.getCoffer());
+			+ "Coffer: " + QuantityFormatter.quantityToPreciseSIStack(plugin.getCoffer());
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerBox.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerBox.java
@@ -230,7 +230,7 @@ class LootTrackerBox extends JPanel
 			priceTypeString = priceType == LootTrackerPriceType.HIGH_ALCHEMY ? "HA: " : "GE: ";
 		}
 
-		priceLabel.setText(priceTypeString + QuantityFormatter.quantityToStackSize(totalPrice) + " gp");
+		priceLabel.setText(priceTypeString + QuantityFormatter.quantityToPreciseSIStack(totalPrice) + " gp");
 		priceLabel.setToolTipText(QuantityFormatter.formatNumber(totalPrice) + " gp");
 
 		final long kills = getTotalKills();
@@ -376,7 +376,7 @@ class LootTrackerBox extends JPanel
 		final long haPrice = item.getTotalHaPrice();
 		final String ignoredLabel = item.isIgnored() ? " - Ignored" : "";
 		return "<html>" + name + " x " + quantity + ignoredLabel
-			+ "<br>GE: " + QuantityFormatter.quantityToStackSize(gePrice)
-			+ "<br>HA: " + QuantityFormatter.quantityToStackSize(haPrice) + "</html>";
+			+ "<br>GE: " + QuantityFormatter.quantityToPreciseSIStack(gePrice)
+			+ "<br>HA: " + QuantityFormatter.quantityToPreciseSIStack(haPrice) + "</html>";
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPanel.java
@@ -660,7 +660,7 @@ class LootTrackerPanel extends PluginPanel
 
 	private static String htmlLabel(String key, long value)
 	{
-		final String valueStr = QuantityFormatter.quantityToStackSize(value);
+		final String valueStr = QuantityFormatter.quantityToPreciseSIStack(value);
 		return String.format(HTML_LABEL_TEMPLATE, ColorUtil.toHexColor(ColorScheme.LIGHT_GRAY_COLOR), key, valueStr);
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
@@ -1053,7 +1053,7 @@ public class LootTrackerPlugin extends Plugin
 			.append("You've killed ")
 			.append(name)
 			.append(" for ")
-			.append(QuantityFormatter.quantityToStackSize(getTotalPrice(items)))
+			.append(QuantityFormatter.quantityToPreciseSIStack(getTotalPrice(items)))
 			.append(" loot.")
 			.build();
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpInfoBox.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpInfoBox.java
@@ -331,7 +331,7 @@ class XpInfoBox extends JPanel
 
 	static String htmlLabel(String key, int value)
 	{
-		String valueStr = QuantityFormatter.quantityToRSDecimalStack(value, true);
+		String valueStr = QuantityFormatter.quantityToPreciseSIStack(value);
 		return htmlLabel(key, valueStr);
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpPanelLabel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpPanelLabel.java
@@ -66,6 +66,6 @@ public enum XpPanelLabel
 
 	private static String format(int val)
 	{
-		return QuantityFormatter.quantityToRSDecimalStack(val, true);
+		return QuantityFormatter.quantityToPreciseSIStack(val);
 	}
 }

--- a/runelite-client/src/test/java/net/runelite/client/util/QuantityFormatterTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/util/QuantityFormatterTest.java
@@ -40,74 +40,75 @@ public class QuantityFormatterTest
 	}
 
 	@Test
-	public void quantityToRSDecimalStackSize()
+	public void quantityToPreciseSISize()
 	{
-		assertEquals("0", QuantityFormatter.quantityToRSDecimalStack(0));
-		assertEquals("8500", QuantityFormatter.quantityToRSDecimalStack(8_500));
-		assertEquals("10K", QuantityFormatter.quantityToRSDecimalStack(10_000));
-		assertEquals("21.7K", QuantityFormatter.quantityToRSDecimalStack(21_700));
-		assertEquals("100K", QuantityFormatter.quantityToRSDecimalStack(100_000));
-		assertEquals("100.3K", QuantityFormatter.quantityToRSDecimalStack(100_300));
-		assertEquals("1M", QuantityFormatter.quantityToRSDecimalStack(1_000_000));
-		assertEquals("8.4M", QuantityFormatter.quantityToRSDecimalStack(8_450_000));
-		assertEquals("10M", QuantityFormatter.quantityToRSDecimalStack(10_000_000));
-		assertEquals("12.8M", QuantityFormatter.quantityToRSDecimalStack(12_800_000));
-		assertEquals("100M", QuantityFormatter.quantityToRSDecimalStack(100_000_000));
-		assertEquals("250.1M", QuantityFormatter.quantityToRSDecimalStack(250_100_000));
-		assertEquals("1B", QuantityFormatter.quantityToRSDecimalStack(1_000_000_000));
-		assertEquals("1.5B", QuantityFormatter.quantityToRSDecimalStack(1500_000_000));
-		assertEquals("2.1B", QuantityFormatter.quantityToRSDecimalStack(Integer.MAX_VALUE));
+		assertEquals("0", QuantityFormatter.quantityToPreciseSIStack(0));
+		assertEquals("999", QuantityFormatter.quantityToPreciseSIStack(999));
+		assertEquals("1000", QuantityFormatter.quantityToPreciseSIStack(1000));
+		assertEquals("9450", QuantityFormatter.quantityToPreciseSIStack(9450));
+		assertEquals("14.5K", QuantityFormatter.quantityToPreciseSIStack(14_500));
+		assertEquals("99.9K", QuantityFormatter.quantityToPreciseSIStack(99_920));
+		assertEquals("100K", QuantityFormatter.quantityToPreciseSIStack(100_000));
+		assertEquals("10M", QuantityFormatter.quantityToPreciseSIStack(10_000_000));
+		assertEquals("2.147B", QuantityFormatter.quantityToPreciseSIStack(Integer.MAX_VALUE));
+		assertEquals("100B", QuantityFormatter.quantityToPreciseSIStack(100_000_000_000L));
 	}
 
 	@Test
-	public void quantityToStackSize()
+	public void quantityToSIStackSize()
 	{
-		assertEquals("0", QuantityFormatter.quantityToStackSize(0));
-		assertEquals("999", QuantityFormatter.quantityToStackSize(999));
-		assertEquals("1,000", QuantityFormatter.quantityToStackSize(1000));
-		assertEquals("9,450", QuantityFormatter.quantityToStackSize(9450));
-		assertEquals("14.5K", QuantityFormatter.quantityToStackSize(14_500));
-		assertEquals("99.9K", QuantityFormatter.quantityToStackSize(99_920));
-		assertEquals("100K", QuantityFormatter.quantityToStackSize(100_000));
-		assertEquals("10M", QuantityFormatter.quantityToStackSize(10_000_000));
-		assertEquals("2.14B", QuantityFormatter.quantityToStackSize(Integer.MAX_VALUE));
-		assertEquals("100B", QuantityFormatter.quantityToStackSize(100_000_000_000L));
-
-		assertEquals("0", QuantityFormatter.quantityToStackSize(-0));
-		assertEquals("-400", QuantityFormatter.quantityToStackSize(-400));
-		assertEquals("-400K", QuantityFormatter.quantityToStackSize(-400_000));
-		assertEquals("-40M", QuantityFormatter.quantityToStackSize(-40_000_000));
-		assertEquals("-2.14B", QuantityFormatter.quantityToStackSize(Integer.MIN_VALUE));
-		assertEquals("-400B", QuantityFormatter.quantityToStackSize(-400_000_000_000L));
+		assertEquals("0", QuantityFormatter.quantityToSIStack(0));
+		assertEquals("8500", QuantityFormatter.quantityToSIStack(8_500, 0));
+		assertEquals("8500", QuantityFormatter.quantityToSIStack(8_500, 1));
+		assertEquals("10K", QuantityFormatter.quantityToSIStack(10_000, 1));
+		assertEquals("10K", QuantityFormatter.quantityToSIStack(10_000, 2));
+		assertEquals("10.1K", QuantityFormatter.quantityToSIStack(10_100, 1));
+		assertEquals("10.1K", QuantityFormatter.quantityToSIStack(10_100, 2));
+		assertEquals("21.7K", QuantityFormatter.quantityToSIStack(21_700, 0));
+		assertEquals("21.7K", QuantityFormatter.quantityToSIStack(21_700, 3));
+		assertEquals("100K", QuantityFormatter.quantityToSIStack(100_000, 1));
+		assertEquals("100.3K", QuantityFormatter.quantityToSIStack(100_310, 1));
+		assertEquals("1M", QuantityFormatter.quantityToSIStack(1_000_000, 0));
+		assertEquals("1M", QuantityFormatter.quantityToSIStack(1_000_000, 1));
+		assertEquals("1M", QuantityFormatter.quantityToSIStack(1_000_000, 2));
+		assertEquals("8.45M", QuantityFormatter.quantityToSIStack(8_450_000, 2));
+		assertEquals("8.451M", QuantityFormatter.quantityToSIStack(8_451_000, 3));
+		assertEquals("10M", QuantityFormatter.quantityToSIStack(10_000_000, 0));
+		assertEquals("10M", QuantityFormatter.quantityToSIStack(10_000_000, 1));
+		assertEquals("10M", QuantityFormatter.quantityToSIStack(10_000_000, 2));
+		assertEquals("12.8M", QuantityFormatter.quantityToSIStack(12_800_000, 1));
+		assertEquals("12.85M", QuantityFormatter.quantityToSIStack(12_850_000, 2));
+		assertEquals("12.851M", QuantityFormatter.quantityToSIStack(12_851_000, 3));
+		assertEquals("100M", QuantityFormatter.quantityToSIStack(100_000_000, 0));
+		assertEquals("100M", QuantityFormatter.quantityToSIStack(100_000_000, 1));
+		assertEquals("100M", QuantityFormatter.quantityToSIStack(100_000_000, 2));
+		assertEquals("250.1M", QuantityFormatter.quantityToSIStack(250_100_000, 1));
+		assertEquals("250.1M", QuantityFormatter.quantityToSIStack(250_100_000, 3));
+		assertEquals("250.151M", QuantityFormatter.quantityToSIStack(250_151_000, 3));
+		assertEquals("1B", QuantityFormatter.quantityToSIStack(1_000_000_000, 1));
+		assertEquals("1.5B", QuantityFormatter.quantityToSIStack(1500_000_000, 1));
+		assertEquals("1.5B", QuantityFormatter.quantityToSIStack(1500_000_000, 2));
+		assertEquals("1.55B", QuantityFormatter.quantityToSIStack(1550_000_000, 2));
+		assertEquals("1.55B", QuantityFormatter.quantityToSIStack(1550_000_000, 3));
+		assertEquals("2.147B", QuantityFormatter.quantityToSIStack(Integer.MAX_VALUE, 3));
 	}
 
 	@Test
-	public void quantityToPreciseStackSize()
+	public void quantityToRSStackSize()
 	{
-		assertEquals("0", QuantityFormatter.quantityToRSDecimalStack(0));
-		assertEquals("8500", QuantityFormatter.quantityToRSDecimalStack(8_500, true));
-		assertEquals("10K", QuantityFormatter.quantityToRSDecimalStack(10_000, true));
-		assertEquals("21.7K", QuantityFormatter.quantityToRSDecimalStack(21_710, true));
-		assertEquals("100K", QuantityFormatter.quantityToRSDecimalStack(100_000, true));
-		assertEquals("100.3K", QuantityFormatter.quantityToRSDecimalStack(100_310, true));
-		assertEquals("1M", QuantityFormatter.quantityToRSDecimalStack(1_000_000, true));
-		assertEquals("8.45M", QuantityFormatter.quantityToRSDecimalStack(8_450_000, true));
-		assertEquals("8.451M", QuantityFormatter.quantityToRSDecimalStack(8_451_000, true));
-		assertEquals("10M", QuantityFormatter.quantityToRSDecimalStack(10_000_000, true));
-		assertEquals("12.8M", QuantityFormatter.quantityToRSDecimalStack(12_800_000, true));
-		assertEquals("12.85M", QuantityFormatter.quantityToRSDecimalStack(12_850_000, true));
-		assertEquals("12.851M", QuantityFormatter.quantityToRSDecimalStack(12_851_000, true));
-		assertEquals("100M", QuantityFormatter.quantityToRSDecimalStack(100_000_000, true));
-		assertEquals("250.1M", QuantityFormatter.quantityToRSDecimalStack(250_100_000, true));
-		assertEquals("250.151M", QuantityFormatter.quantityToRSDecimalStack(250_151_000, true));
-		assertEquals("1B", QuantityFormatter.quantityToRSDecimalStack(1_000_000_000, true));
-		assertEquals("1.5B", QuantityFormatter.quantityToRSDecimalStack(1500_000_000, true));
-		assertEquals("1.55B", QuantityFormatter.quantityToRSDecimalStack(1550_000_000, true));
-		assertEquals("2.147B", QuantityFormatter.quantityToRSDecimalStack(Integer.MAX_VALUE, true));
+		assertEquals("0", QuantityFormatter.quantityToRSStack(0));
+		assertEquals("1111", QuantityFormatter.quantityToRSStack(1111));
+		assertEquals("101K", QuantityFormatter.quantityToRSStack(101_000));
+		assertEquals("1011K", QuantityFormatter.quantityToRSStack(1_011_000));
+		assertEquals("9999K", QuantityFormatter.quantityToRSStack(9_999_999));
+		assertEquals("10M", QuantityFormatter.quantityToRSStack(10_000_000));
+		assertEquals("100M", QuantityFormatter.quantityToRSStack(100_000_000));
+		assertEquals("100M", QuantityFormatter.quantityToRSStack(100_111_111));
+		assertEquals("2147M", QuantityFormatter.quantityToRSStack(Integer.MAX_VALUE));
 	}
 
 	@Test
-	public void stackSizeToQuantity() throws ParseException
+	public void stackToQuantity() throws ParseException
 	{
 		assertEquals(0, QuantityFormatter.parseQuantity("0"));
 		assertEquals(907, QuantityFormatter.parseQuantity("907"));
@@ -116,11 +117,6 @@ public class QuantityFormatterTest
 		assertEquals(10_500, QuantityFormatter.parseQuantity("10.5K"));
 		assertEquals(33_560_000, QuantityFormatter.parseQuantity("33.56M"));
 		assertEquals(2_000_000_000, QuantityFormatter.parseQuantity("2B"));
-
-		assertEquals(0, QuantityFormatter.parseQuantity("-0"));
-		assertEquals(-400, QuantityFormatter.parseQuantity("-400"));
-		assertEquals(-400_000, QuantityFormatter.parseQuantity("-400k"));
-		assertEquals(-40_543_000, QuantityFormatter.parseQuantity("-40.543M"));
 
 		try
 		{


### PR DESCRIPTION
Summary of changes:
- changed quantityToRSDecimalStack to quantityToSIStack, which takes in a parameter for level of precision and doesn't match in-game stack behavior. replaced quantityToStackSize with quantityToPreciseSIStack, which overloads quantityToSIStack and specifies thousandths precision (so in most places prices are now more precise to an additional decimal point; behavior for XP panels [already 3 digits precision] and infoboxes [1 digit precision, to avoid overflowing the box] was not changed)
- added quantityToRSStack, which follows in-game stack behavior (e.g. 2147M instead of 2.147B and no decimal precision).
- removed support for negative stacks, as I don't think they're used anywhere (not calculating any price differences AFAIK)
- improved some of the docs
![changes](https://cdn.discordapp.com/attachments/433728523568676895/765408145035755550/QuantityFormatterComparisons.png)