### PR TITLE
client util: prevent regex injection in WildcardMatcher

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/util/WildcardMatcher.java
+++ b/runelite-client/src/main/java/net/runelite/client/util/WildcardMatcher.java
@@ -45,8 +45,7 @@ public class WildcardMatcher
 			}
 			else
 			{
-				String replacement = "\\Q" + matcher.group(0) + "\\E";
-				matcher.appendReplacement(buffer, Matcher.quoteReplacement(replacement));
+				matcher.appendReplacement(buffer, Matcher.quoteReplacement(Pattern.quote(matcher.group(0))));
 			}
 		}
 

--- a/runelite-client/src/main/java/net/runelite/client/util/WildcardMatcher.java
+++ b/runelite-client/src/main/java/net/runelite/client/util/WildcardMatcher.java
@@ -45,7 +45,8 @@ public class WildcardMatcher
 			}
 			else
 			{
-				matcher.appendReplacement(buffer, "\\\\Q" + matcher.group(0) + "\\\\E");
+				String replacement = "\\Q" + matcher.group(0) + "\\E";
+				matcher.appendReplacement(buffer, Matcher.quoteReplacement(replacement));
 			}
 		}
 

--- a/runelite-client/src/test/java/net/runelite/client/util/WildcardMatcherTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/util/WildcardMatcherTest.java
@@ -39,5 +39,6 @@ public class WildcardMatcherTest
 		assertFalse(matches("Abyssal whip", "Adamant dagger"));
 		assertTrue(matches("rune*", "Runeite Ore"));
 		assertTrue(matches("Abyssal whip", "Abyssal whip"));
+		assertTrue(matches("string $ with special character", "string $ with special character"));
 	}
 }


### PR DESCRIPTION
Currently if the user is dumb enough to add some special regex characters to the ground items plugin/other places we use the wildcard matcher it can error. The test added will fail on master.