### PR TITLE
Chat Notifications: Fixed highlighting messages that end with a period.

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatnotifications/ChatNotificationsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatnotifications/ChatNotificationsPlugin.java
@@ -120,8 +120,8 @@ public class ChatNotificationsPlugin extends Plugin
 				.map(this::quoteAndIgnoreColor) // regex escape and ignore nested colors in the target message
 				.collect(Collectors.joining("|"));
 			// To match <word> \b doesn't work due to <> not being in \w,
-			// so match \b or \s
-			highlightMatcher = Pattern.compile("(?:\\b|(?<=\\s))(" + joined + ")(?:\\b|(?=\\s))", Pattern.CASE_INSENSITIVE);
+			// so match \b or \s, as well as \A and \z for beginning and end of input respectively
+			highlightMatcher = Pattern.compile("(?:\\b|(?<=\\s)|\\A)(?:" + joined + ")(?:\\b|(?=\\s)|\\z)", Pattern.CASE_INSENSITIVE);
 		}
 	}
 

--- a/runelite-client/src/test/java/net/runelite/client/plugins/chatnotifications/ChatNotificationsPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/chatnotifications/ChatNotificationsPluginTest.java
@@ -114,6 +114,25 @@ public class ChatNotificationsPluginTest
 	}
 
 	@Test
+	public void testMatchEntireMessage()
+	{
+		when(config.highlightWordsString()).thenReturn(".Your divine potion effect is about to expire.");
+
+		String message = ".Your divine potion effect is about to expire.";
+		MessageNode messageNode = mock(MessageNode.class);
+		when(messageNode.getValue()).thenReturn(message);
+
+		ChatMessage chatMessage = new ChatMessage();
+		chatMessage.setType(ChatMessageType.PUBLICCHAT);
+		chatMessage.setMessageNode(messageNode);
+
+		chatNotificationsPlugin.startUp(); // load highlight config
+		chatNotificationsPlugin.onChatMessage(chatMessage);
+
+		verify(messageNode).setValue("<colHIGHLIGHT>.Your divine potion effect is about to expire.<colNORMAL>");
+	}
+
+	@Test
 	public void testFullStop()
 	{
 		when(config.highlightWordsString()).thenReturn("test");


### PR DESCRIPTION
Closes #12524 

Fixes highlight message matcher to correctly match messages that end in a `.`