### PR TITLE
OverlayManager: Unset stored tooltip overlay location

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayManager.java
@@ -49,6 +49,9 @@ import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.events.ConfigChanged;
 import net.runelite.client.events.OverlayMenuClicked;
 import net.runelite.client.events.PluginChanged;
+import net.runelite.client.events.SessionClose;
+import net.runelite.client.events.SessionOpen;
+import net.runelite.client.ui.overlay.tooltip.TooltipOverlay;
 
 /**
  * Manages state of all game overlays
@@ -112,6 +115,8 @@ public class OverlayManager
 		this.configManager = configManager;
 		this.eventBus = eventBus;
 		this.runeLiteConfig = runeLiteConfig;
+
+		resetTooltipOverlayPosition();
 	}
 
 	@Subscribe
@@ -156,6 +161,18 @@ public class OverlayManager
 				eventBus.post(new OverlayMenuClicked(overlayMenuEntry, overlay));
 			}
 		}
+	}
+
+	@Subscribe
+	public void onSessionOpen(SessionOpen event)
+	{
+		resetTooltipOverlayPosition();
+	}
+
+	@Subscribe
+	public void onSessionClose(SessionClose event)
+	{
+		resetTooltipOverlayPosition();
 	}
 
 	/**
@@ -400,5 +417,13 @@ public class OverlayManager
 	{
 		final String locationKey = overlay.getName() + OVERLAY_CONFIG_PREFERRED_POSITION;
 		return configManager.getConfiguration(RUNELITE_CONFIG_GROUP_NAME, locationKey, OverlayPosition.class);
+	}
+
+	@Deprecated
+	private void resetTooltipOverlayPosition()
+	{
+		configManager.unsetConfiguration(
+			RUNELITE_CONFIG_GROUP_NAME,
+			TooltipOverlay.class.getSimpleName() + OVERLAY_CONFIG_PREFERRED_LOCATION);
 	}
 }


### PR DESCRIPTION
In the past, prior to commit 6df3016bb, the tooltip overlay was errantly
able to be repositioned by the user. While that commit fixes that issue,
users who had already given their tooltip overlay some saved location
will have that issue persist. This commit adds a method, to be removed
at some later time after users will have run it for a while, which
unsets that stored location from their config.

Closes #11643