### PR TITLE
Fix anisotropic filtering resetting to 0 after GPU plugin was restarted

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuPlugin.java
@@ -489,6 +489,8 @@ public class GpuPlugin extends Plugin implements DrawCallbacks
 			modelBuffer = null;
 			modelBufferUnordered = null;
 
+			lastAnisotropicFilteringLevel = -1;
+
 			// force main buffer provider rebuild to turn off alpha channel
 			client.resizeCanvas();
 		});


### PR DESCRIPTION
Fixed #12652  by resetting the lastAnisotropicFiltering value to the default on startup when shutting down the gpu plugin.

This is my first contribution to runelite 😄 