### PR TITLE
ObjectDefinition.decorDisplacement -> wallWidth

### DIFF
--- a/cache/src/main/java/net/runelite/cache/definitions/ObjectDefinition.java
+++ b/cache/src/main/java/net/runelite/cache/definitions/ObjectDefinition.java
@@ -33,7 +33,7 @@ public class ObjectDefinition
 {
 	private int id;
 	private short[] retextureToFind;
-	private int decorDisplacement = 16;
+	private int wallWidth = 16;
 	private boolean isHollow = false;
 	private String name = "null";
 	private int[] objectModels;

--- a/cache/src/main/java/net/runelite/cache/definitions/loaders/ObjectLoader.java
+++ b/cache/src/main/java/net/runelite/cache/definitions/loaders/ObjectLoader.java
@@ -145,7 +145,7 @@ public class ObjectLoader
 		}
 		else if (opcode == 28)
 		{
-			def.setDecorDisplacement(is.readUnsignedByte());
+			def.setWallWidth(is.readUnsignedByte());
 		}
 		else if (opcode == 29)
 		{

--- a/cache/src/main/java/net/runelite/cache/definitions/savers/ObjectSaver.java
+++ b/cache/src/main/java/net/runelite/cache/definitions/savers/ObjectSaver.java
@@ -96,7 +96,7 @@ public class ObjectSaver
 			out.writeByte(27);
 		}
 		out.writeByte(28);
-		out.writeByte(obj.getDecorDisplacement());
+		out.writeByte(obj.getWallWidth());
 		out.writeByte(29);
 		out.writeByte(obj.getAmbient());
 		out.writeByte(39);


### PR DESCRIPTION
The current name is confusing, as it makes it seem it offsets the wall decoration no matter what.

Instead, it's only used to as the offset for decorations that are placed on the opposite side of the wall (location types 5 and 7). Since the value is unused for non-wall objects, `wallWidth` would be the clearest name.