### PR TITLE
Brimhaven and Ardougne travel options added to menu entry swapper

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -207,6 +207,8 @@ public class MenuEntrySwapperPlugin extends Plugin
 		swap("talk-to", "miscellania", config::swapTravel);
 		swap("talk-to", "follow", config::swapTravel);
 		swap("talk-to", "transport", config::swapTravel);
+		swap("talk-to", "brimhaven", config::swapTravel);
+		swap("talk-to", "ardougne", config::swapTravel);
 		swap("talk-to", "pay", config::swapPay);
 		swapContains("talk-to", alwaysTrue(), "pay (", config::swapPay);
 		swap("talk-to", "decant", config::swapDecant);


### PR DESCRIPTION
This updates the menu entry swapper plugin to include swapping `Brimhaven` and `Ardougne` with `Talk-to` as part of the `Travel` option/config.

Rimmington is unfortunately a bit of a second-class citizen. I figured both Brimhaven and Ardougne options are more commonly used and therefore worthwhile prioritising over Rimmington. Brimhaven is prioritised over Ardougne when travelling from Rimmington.

Closes https://github.com/runelite/runelite/issues/11264