### PR TITLE
plugin-panel: stick plugin hub button to bottom of plugin list

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/PluginListPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/PluginListPanel.java
@@ -179,11 +179,11 @@ class PluginListPanel extends PluginPanel
 		externalPluginButton.setBorder(new EmptyBorder(5, 5, 5, 5));
 		externalPluginButton.setLayout(new BorderLayout(0, BORDER_OFFSET));
 		externalPluginButton.addActionListener(l -> muxer.pushState(pluginHubPanelProvider.get()));
+		add(externalPluginButton, BorderLayout.SOUTH);
 
 		JPanel northPanel = new FixedWidthPanel();
 		northPanel.setLayout(new BorderLayout());
 		northPanel.add(mainPanel, BorderLayout.NORTH);
-		northPanel.add(externalPluginButton, BorderLayout.SOUTH);
 
 		scrollPane = new JScrollPane(northPanel);
 		scrollPane.setHorizontalScrollBarPolicy(ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);


### PR DESCRIPTION
Since the plugin hub "isn't a total disaster" I thought it would be neat if you didn't have to scroll so much when accessing it.