### PR TITLE
Adds click position indicators into the prayer bar

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/prayer/PrayerBarOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/prayer/PrayerBarOverlay.java
@@ -63,7 +63,7 @@ class PrayerBarOverlay extends Overlay
 	private boolean debounce;
 	private int xoffsetOn;
 	private int xoffsetOff;
-	private int drawRectThistick;
+	private int rectCounter;
 
 	@Inject
 	private PrayerBarOverlay(final Client client, final PrayerConfig config, final PrayerPlugin plugin)
@@ -146,23 +146,24 @@ class PrayerBarOverlay extends Overlay
 			final int xOffset = (int) (-Math.cos(t) * barWidth / 2) + barWidth / 2;
 
 			if(config.showPrayerBarHelper()) {
-				if (this.client.getMouseCurrentButton() == 1 && this.drawRectThistick < 2 && !this.debounce) {
+				if (this.client.getMouseCurrentButton() == 1 && this.rectCounter < 2 && !this.debounce) {
 					this.debounce = true;
-					if (this.drawRectThistick == 1) {
+					if (this.rectCounter == 1) {
 						this.xoffsetOn = xOffset;
-						++this.drawRectThistick;
+						++this.rectCounter;
 					} else {
 						this.xoffsetOff = xOffset;
-						++this.drawRectThistick;
+						++this.rectCounter;
 					}
 				} else if (this.client.getMouseCurrentButton() != 1) {
 					this.debounce = false;
 				}
-
-				graphics.setColor(Color.red);
-				graphics.fillRect(barX + this.xoffsetOn, barY, 1, barHeight);
-				graphics.setColor(Color.blue);
-				graphics.fillRect(barX + this.xoffsetOff, barY, 1, barHeight);
+				if(rectCounter != 0) {
+					graphics.setColor(Color.red);
+					graphics.fillRect(barX + this.xoffsetOn, barY, 1, barHeight);
+					graphics.setColor(Color.blue);
+					graphics.fillRect(barX + this.xoffsetOff, barY, 1, barHeight);
+				}
 
 
 			}
@@ -178,6 +179,8 @@ class PrayerBarOverlay extends Overlay
 	{
 		final Player localPlayer = client.getLocalPlayer();
 		showingPrayerBar = true;
+		this.rectCounter = 0;
+		this.debounce = false;
 
 		if (localPlayer == null)
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/prayer/PrayerBarOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/prayer/PrayerBarOverlay.java
@@ -60,6 +60,10 @@ class PrayerBarOverlay extends Overlay
 	private final PrayerPlugin plugin;
 
 	private boolean showingPrayerBar;
+	private boolean debounce;
+	private int xoffsetOn;
+	private int xoffsetOff;
+	private int drawRectThistick;
 
 	@Inject
 	private PrayerBarOverlay(final Client client, final PrayerConfig config, final PrayerPlugin plugin)
@@ -103,8 +107,8 @@ class PrayerBarOverlay extends Overlay
 			graphics.drawImage(HD_FRONT_BAR.getSubimage(0, 0, progressFill, barHeight), barX, barY, progressFill, barHeight, null);
 
 			if ((plugin.isPrayersActive() || config.prayerFlickAlwaysOn())
-				&& (config.prayerFlickLocation().equals(PrayerFlickLocation.PRAYER_BAR)
-				|| config.prayerFlickLocation().equals(PrayerFlickLocation.BOTH)))
+					&& (config.prayerFlickLocation().equals(PrayerFlickLocation.PRAYER_BAR)
+					|| config.prayerFlickLocation().equals(PrayerFlickLocation.BOTH)))
 			{
 				final double t = plugin.getTickProgress();
 				final int halfBarWidth = (barWidth / 2) - HD_PRAYER_BAR_PADDING;
@@ -134,12 +138,34 @@ class PrayerBarOverlay extends Overlay
 		graphics.fillRect(barX, barY, progressFill, barHeight);
 
 		if ((plugin.isPrayersActive() || config.prayerFlickAlwaysOn())
-			&& (config.prayerFlickLocation().equals(PrayerFlickLocation.PRAYER_BAR)
-			|| config.prayerFlickLocation().equals(PrayerFlickLocation.BOTH)))
+				&& (config.prayerFlickLocation().equals(PrayerFlickLocation.PRAYER_BAR)
+				|| config.prayerFlickLocation().equals(PrayerFlickLocation.BOTH)))
 		{
 			double t = plugin.getTickProgress();
 
 			final int xOffset = (int) (-Math.cos(t) * barWidth / 2) + barWidth / 2;
+
+			if(config.showPrayerBarHelper()) {
+				if (this.client.getMouseCurrentButton() == 1 && this.drawRectThistick < 2 && !this.debounce) {
+					this.debounce = true;
+					if (this.drawRectThistick == 1) {
+						this.xoffsetOn = xOffset;
+						++this.drawRectThistick;
+					} else {
+						this.xoffsetOff = xOffset;
+						++this.drawRectThistick;
+					}
+				} else if (this.client.getMouseCurrentButton() != 1) {
+					this.debounce = false;
+				}
+
+				graphics.setColor(Color.red);
+				graphics.fillRect(barX + this.xoffsetOn, barY, 1, barHeight);
+				graphics.setColor(Color.blue);
+				graphics.fillRect(barX + this.xoffsetOff, barY, 1, barHeight);
+
+
+			}
 
 			graphics.setColor(FLICK_HELP_COLOR);
 			graphics.fillRect(barX + xOffset, barY, 1, barHeight);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/prayer/PrayerConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/prayer/PrayerConfig.java
@@ -114,6 +114,8 @@ public interface PrayerConfig extends Config
 		name = "Hide bar while prayer is inactive",
 		description = "Prayer bar will be hidden while prayers are inactive."
 	)
+
+
 	default boolean hideIfNotPraying()
 	{
 		return true;
@@ -136,8 +138,19 @@ public interface PrayerConfig extends Config
 		name = "Replace orb text with prayer time left",
 		description = "Show time remaining of current prayers in the prayer orb."
 	)
+	default boolean showPrayerBarHelper() { return false; }
+	@ConfigItem(
+			position = 10,
+			keyName = "showPrayerBarFlickHelper",
+			name = "Shows click indicator for prayer bar",
+			description = "Prayer bar will display flags when clicked to show tick timing."
+
+	)
+
+
 	default boolean replaceOrbText()
 	{
 		return false;
 	}
+
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/prayer/PrayerFlickOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/prayer/PrayerFlickOverlay.java
@@ -89,7 +89,7 @@ class PrayerFlickOverlay extends Overlay
 
 		int yOffset = (orbInnerHeight / 2) - (indicatorHeight / 2);
 
-		graphics.setColor(Color.cyan);
+		graphics.setColor(Color.red);
 		graphics.fillRect(orbInnerX + xOffset, orbInnerY + yOffset, 1, indicatorHeight);
 
 		return new Dimension((int) bounds.getWidth(), (int) bounds.getHeight());


### PR DESCRIPTION
Useful when 1tick flicking without another tick reference such as metronome or xp drops. 
