### PR TITLE
worldmap: add Wilderness Slayer Cave entrances

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldmap/DungeonLocation.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldmap/DungeonLocation.java
@@ -200,6 +200,8 @@ enum DungeonLocation
 	WHITE_WOLF_TUNNEL_W("White Wolf Tunnel", new WorldPoint(2819, 3484, 0)),
 	WILDERNESS_AGILITY("Wilderness Agility Course Dungeon", new WorldPoint(3004, 3963, 0)),
 	WILDERNESS_GOD_WARS("Wilderness God Wars Dungeon", new WorldPoint(3016, 3739, 0)),
+	WILDERNESS_SLAYER_CAVE_NORTH("Wilderness Slayer Cave", new WorldPoint(3292, 3746, 0)),
+	WILDERNESS_SLAYER_CAVE_SOUTH("Wilderness Slayer Cave", new WorldPoint(3259, 3666, 0)),
 	WITCHAVEN("Witchaven Dungeon", new WorldPoint(2695, 3283, 0)),
 	WIZARDS_GUILD("Wizards' Guild basement", new WorldPoint(2593, 3085, 0)),
 	WIZARDS_TOWER("Wizards' Tower basement", new WorldPoint(3103, 3162, 0)),


### PR DESCRIPTION
Adds worldmap tooltips for the North and South entrances to the new Wilderness Slayer Cave.

![image](https://user-images.githubusercontent.com/54762282/97341080-fe72ed00-185a-11eb-9710-745712d776c0.png)

![image](https://user-images.githubusercontent.com/54762282/97341106-0599fb00-185b-11eb-8a91-962b496574ec.png)

