### PR TITLE
chatcommands: handle league accounts properly

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/IconID.java
+++ b/runelite-api/src/main/java/net/runelite/api/IconID.java
@@ -47,7 +47,8 @@ public enum IconID
 	HARDCORE_IRONMAN(10),
 	NO_ENTRY(11),
 	CHAIN_LINK(12),
-	BOUNTY_HUNTER_EMBLEM(20);
+	BOUNTY_HUNTER_EMBLEM(20),
+	LEAGUE(22);
 
 	private final int index;
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
@@ -1457,7 +1457,7 @@ public class ChatCommandsPlugin extends Plugin
 			}
 		}
 
-		// Get ironman status from their icon in chat
+		// Get ironman status from their icon in chat, this handles leagues too
 		HiscoreEndpoint endpoint = getHiscoreEndpointByName(chatMessage.getName());
 		return new HiscoreLookup(player, endpoint);
 	}
@@ -1517,19 +1517,23 @@ public class ChatCommandsPlugin extends Plugin
 	{
 		if (name.contains(IconID.IRONMAN.toString()))
 		{
-			return toEndPoint(AccountType.IRONMAN);
+			return HiscoreEndpoint.IRONMAN;
 		}
 		else if (name.contains(IconID.ULTIMATE_IRONMAN.toString()))
 		{
-			return toEndPoint(AccountType.ULTIMATE_IRONMAN);
+			return HiscoreEndpoint.ULTIMATE_IRONMAN;
 		}
 		else if (name.contains(IconID.HARDCORE_IRONMAN.toString()))
 		{
-			return toEndPoint(AccountType.HARDCORE_IRONMAN);
+			return HiscoreEndpoint.HARDCORE_IRONMAN;
+		}
+		else if (name.contains(IconID.LEAGUE.toString()))
+		{
+			return HiscoreEndpoint.LEAGUE;
 		}
 		else
 		{
-			return toEndPoint(AccountType.NORMAL);
+			return HiscoreEndpoint.NORMAL;
 		}
 	}
 


### PR DESCRIPTION
Closes #12722

Currently !lvl only worked in public/mod chat if you were on a league world with the person who sent it. Adds broad support for the other cases.