### PR TITLE
hiscore: correctly look up ironmen players from chat message or self lookup

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/hiscore/HiscorePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/hiscore/HiscorePlugin.java
@@ -190,6 +190,7 @@ public class HiscorePlugin extends Plugin
 			&& event.getMenuOption().equals(LOOKUP))
 		{
 			final String target;
+			HiscoreEndpoint endpoint = HiscoreEndpoint.NORMAL;
 			if (event.getMenuAction() == MenuAction.RUNELITE_PLAYER)
 			{
 				// The player id is included in the event, so we can use that to get the player name,
@@ -204,10 +205,13 @@ public class HiscorePlugin extends Plugin
 			}
 			else
 			{
+				// Determine proper endpoint from player name.
+				// TODO: look at target's world and determine if tournament/dmm endpoint should be used instead.
+				endpoint = findHiscoreEndpointFromPlayerName(event.getMenuTarget());
 				target = Text.removeTags(event.getMenuTarget());
 			}
 
-			lookupPlayer(target, HiscoreEndpoint.NORMAL);
+			lookupPlayer(target, endpoint);
 		}
 	}
 
@@ -294,6 +298,27 @@ public class HiscorePlugin extends Plugin
 				case HARDCORE_IRONMAN:
 					return HiscoreEndpoint.HARDCORE_IRONMAN;
 			}
+		}
+		return HiscoreEndpoint.NORMAL;
+	}
+
+	private HiscoreEndpoint findHiscoreEndpointFromPlayerName(String name)
+	{
+		if (name.contains(IconID.IRONMAN.toString()))
+		{
+			return HiscoreEndpoint.IRONMAN;
+		}
+		if (name.contains(IconID.ULTIMATE_IRONMAN.toString()))
+		{
+			return HiscoreEndpoint.ULTIMATE_IRONMAN;
+		}
+		if (name.contains(IconID.HARDCORE_IRONMAN.toString()))
+		{
+			return HiscoreEndpoint.HARDCORE_IRONMAN;
+		}
+		if (name.contains(IconID.LEAGUE.toString()))
+		{
+			return HiscoreEndpoint.LEAGUE;
 		}
 		return HiscoreEndpoint.NORMAL;
 	}

--- a/runelite-client/src/test/java/net/runelite/client/plugins/hiscore/HiscorePanelTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/hiscore/HiscorePanelTest.java
@@ -25,17 +25,22 @@
 package net.runelite.client.plugins.hiscore;
 
 import static net.runelite.client.plugins.hiscore.HiscorePanel.formatLevel;
+import net.runelite.http.api.hiscore.HiscoreEndpoint;
 import okhttp3.OkHttpClient;
 import static org.junit.Assert.assertEquals;
 import org.junit.Test;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class HiscorePanelTest
 {
 	@Test
 	public void testConstructor()
 	{
-		new HiscorePanel(null, mock(HiscoreConfig.class), mock(NameAutocompleter.class), mock(OkHttpClient.class));
+		HiscorePlugin plugin = mock(HiscorePlugin.class);
+		when(plugin.getWorldEndpoint()).thenReturn(HiscoreEndpoint.NORMAL);
+		new HiscorePanel(null, plugin, mock(HiscoreConfig.class),
+			mock(NameAutocompleter.class), mock(OkHttpClient.class));
 	}
 
 	@Test


### PR DESCRIPTION
Currently, when using the shortcut to lookup yourself on the hiscores (double clicking the magnifying glass), the normal account tab is used no matter what was set before.

Earlier, a conversation was had on Discord about getting this to also work off of chat message, since the information is available. The PR now covers this.