### PR TITLE
xptracker: account for relic modifiers when tracking kills left

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/Varbits.java
+++ b/runelite-api/src/main/java/net/runelite/api/Varbits.java
@@ -563,13 +563,14 @@ public enum Varbits
 	WINTERTODT_TIMER(7980),
 
 	/**
-	 * Twisted league
+	 * League relics
 	 */
-	TWISTED_LEAGUE_RELIC_1(10049),
-	TWISTED_LEAGUE_RELIC_2(10050),
-	TWISTED_LEAGUE_RELIC_3(10051),
-	TWISTED_LEAGUE_RELIC_4(10052),
-	TWISTED_LEAGUE_RELIC_5(10053),
+	LEAGUE_RELIC_1(10049),
+	LEAGUE_RELIC_2(10050),
+	LEAGUE_RELIC_3(10051),
+	LEAGUE_RELIC_4(10052),
+	LEAGUE_RELIC_5(10053),
+	LEAGUE_RELIC_6(11696),
 
 	/**
 	 * Whether the Special Attack orb is disabled due to being in a PvP area

--- a/runelite-client/src/main/java/net/runelite/client/plugins/regenmeter/RegenMeterPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/regenmeter/RegenMeterPlugin.java
@@ -57,7 +57,7 @@ public class RegenMeterPlugin extends Plugin
 	private static final int SPEC_REGEN_TICKS = 50;
 	private static final int NORMAL_HP_REGEN_TICKS = 100;
 
-	private static final int TWISTED_LEAGUE_ENDLESS_ENDURANCE_RELIC = 2;
+	private static final int TRAILBLAZER_LEAGUE_FLUID_STRIKES_RELIC = 2;
 
 	@Inject
 	private Client client;
@@ -144,7 +144,7 @@ public class RegenMeterPlugin extends Plugin
 			ticksPerHPRegen /= 2;
 		}
 
-		if (client.getVar(Varbits.TWISTED_LEAGUE_RELIC_1) == TWISTED_LEAGUE_ENDLESS_ENDURANCE_RELIC)
+		if (client.getVar(Varbits.LEAGUE_RELIC_3) == TRAILBLAZER_LEAGUE_FLUID_STRIKES_RELIC)
 		{
 			ticksPerHPRegen /= 4;
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerPlugin.java
@@ -377,7 +377,7 @@ public class XpTrackerPlugin extends Plugin
 		final Actor interacting = client.getLocalPlayer().getInteracting();
 		if (interacting instanceof NPC && COMBAT.contains(skill))
 		{
-			final int xpModifier = worldSetToType(client.getWorldType()).getXpModifier();
+			final int xpModifier = worldSetToType(client.getWorldType()).modifier(client);;
 			final NPC npc = (NPC) interacting;
 			xpState.updateNpcExperience(skill, npc, npcManager.getHealth(npc.getId()), xpModifier);
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpWorldType.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpWorldType.java
@@ -24,20 +24,47 @@
  */
 package net.runelite.client.plugins.xptracker;
 
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import net.runelite.api.Client;
+import net.runelite.api.Varbits;
 import net.runelite.api.WorldType;
 
-@Getter
-@RequiredArgsConstructor
 enum XpWorldType
 {
-	NORMAL(1),
-	TOURNEY(1),
-	DMM(5),
-	LEAGUE(5);
+	NORMAL,
+	TOURNEY,
+	DMM
+	{
+		@Override
+		int modifier(Client client)
+		{
+			return 5;
+		}
+	},
+	LEAGUE
+	{
+		@Override
+		int modifier(Client client)
+		{
+			if (client.getVar(Varbits.LEAGUE_RELIC_6) != 0)
+			{
+				return 16;
+			}
+			if (client.getVar(Varbits.LEAGUE_RELIC_4) != 0)
+			{
+				return 12;
+			}
+			if (client.getVar(Varbits.LEAGUE_RELIC_2) != 0)
+			{
+				return 8;
+			}
+			return 5;
+		}
+	};
 
-	private final int xpModifier;
+	int modifier(Client client)
+	{
+		return 1;
+	}
 
 	static XpWorldType of(WorldType type)
 	{


### PR DESCRIPTION
The varbits are gathered from [\[proc, league_relics_draw_selections\]](https://github.com/RuneStar/cs2-scripts/blob/1c404f9e5b31ba09661f7f1fbc6af90dbf30f867/scripts/%5Bproc%2Cleague_relics_draw_selections%5D.cs2#L72-L87) and verified with my first three selected.

This also replaces the Endless Endurance HP regeneration modifier from twisted league with fluid strikes from trailblazer.