### PR TITLE
camera: increase maximum value for outer zoom limt

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/camera/CameraConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/camera/CameraConfig.java
@@ -33,7 +33,7 @@ import net.runelite.client.config.Range;
 public interface CameraConfig extends Config
 {
 	int OUTER_LIMIT_MIN = -400;
-	int OUTER_LIMIT_MAX = 400;
+	int OUTER_LIMIT_MAX = 1200;
 	/**
 	 * The largest (most zoomed in) value that can be used without the client crashing.
 	 *


### PR DESCRIPTION
Zooming out only breaks at when the limit is expanded by 1260 or more (resets to fully zoomed in if you try to zoom out more), so I don't see a reason to limit it at 400.
