### PR TITLE
Fix MES shift click for Ardougne cloak/Karamja gloves

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -494,7 +494,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 			{
 				entry.setType(MenuAction.RUNELITE.getId());
 
-				if (option.equals(entry.getOption()))
+				if (option != null && option.equals(entry.getOption()))
 				{
 					entry.setOption("* " + option);
 				}


### PR DESCRIPTION
Fixes #10087. If shift click is configured to an option which doesn't exist, `option` is `null` and causes an exception at `option.equals()`. This allows the shift click option to be reset or switched to one that does exist.