### PR TITLE
Add 'flash once' option to flash notifications

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/Notifier.java
+++ b/runelite-client/src/main/java/net/runelite/client/Notifier.java
@@ -247,6 +247,10 @@ public class Notifier
 			return;
 		}
 
+		if (flashNotification == FlashNotification.FLASH_ONCE) {
+			flashStart = null;
+		}
+
 		final Color color = graphics.getColor();
 		graphics.setColor(runeLiteConfig.notificationFlashColor());
 		graphics.fill(new Rectangle(client.getCanvas().getSize()));

--- a/runelite-client/src/main/java/net/runelite/client/config/FlashNotification.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/FlashNotification.java
@@ -32,6 +32,7 @@ import lombok.RequiredArgsConstructor;
 public enum FlashNotification
 {
 	DISABLED("Off"),
+	FLASH_ONCE("Flash once"),
 	FLASH_TWO_SECONDS("Flash for 2 seconds"),
 	SOLID_TWO_SECONDS("Solid for 2 seconds"),
 	FLASH_UNTIL_CANCELLED("Flash until cancelled"),


### PR DESCRIPTION
This allows for a "Flash once" flash notification option. I'm not sure if it flash a bit too quickly but I'm also not sure how I would go about slowing it down so that the duration of the flash is a bit longer.

Fixes #12765 