### PR TITLE
Adds a flash notification setting for 1 singular flash (one tick)

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/Notifier.java
+++ b/runelite-client/src/main/java/net/runelite/client/Notifier.java
@@ -229,7 +229,8 @@ public class Notifier
 					return;
 				case FLASH_TWO_SECONDS:
 				case SOLID_TWO_SECONDS:
-					if (Instant.now().minusMillis(FLASH_DURATION_TWO_SECONDS).isAfter(flashStart)) {
+					if (Instant.now().minusMillis(FLASH_DURATION_TWO_SECONDS).isAfter(flashStart))
+					{
 						flashStart = null;
 						return;
 					}

--- a/runelite-client/src/main/java/net/runelite/client/Notifier.java
+++ b/runelite-client/src/main/java/net/runelite/client/Notifier.java
@@ -225,7 +225,7 @@ public class Notifier
 			switch (flashNotification)
 			{
 				case FLASH_ONE_TICK:
-					flashStart=null;
+					flashStart = null;
 					return;
 				case FLASH_TWO_SECONDS:
 				case SOLID_TWO_SECONDS:

--- a/runelite-client/src/main/java/net/runelite/client/Notifier.java
+++ b/runelite-client/src/main/java/net/runelite/client/Notifier.java
@@ -98,7 +98,8 @@ public class Notifier
 		.build();
 
 	// Notifier properties
-	private static final int MINIMUM_FLASH_DURATION_MILLIS = 2000;
+	private static final int MINIMUM_FLASH_DURATION_MILLIS = 600;
+	private static final int FLASH_DURATION_TWO_SECONDS = 2000;
 	private static final int MINIMUM_FLASH_DURATION_TICKS = MINIMUM_FLASH_DURATION_MILLIS / Constants.CLIENT_TICK_LENGTH;
 
 	private static final String appName = RuneLiteProperties.getTitle();
@@ -217,14 +218,21 @@ public class Notifier
 			return;
 		}
 
+		// If minimum flash duration has surpassed
 		if (Instant.now().minusMillis(MINIMUM_FLASH_DURATION_MILLIS).isAfter(flashStart))
 		{
+
 			switch (flashNotification)
 			{
+				case FLASH_ONE_TICK:
+					flashStart=null;
+					return;
 				case FLASH_TWO_SECONDS:
 				case SOLID_TWO_SECONDS:
-					flashStart = null;
-					return;
+					if (Instant.now().minusMillis(FLASH_DURATION_TWO_SECONDS).isAfter(flashStart)) {
+						flashStart = null;
+						return;
+					}
 				case SOLID_UNTIL_CANCELLED:
 				case FLASH_UNTIL_CANCELLED:
 					// Any interaction with the client since the notification started will cancel it after the minimum duration
@@ -242,7 +250,8 @@ public class Notifier
 		if (client.getGameCycle() % 40 >= 20
 			// For solid colour, fall through every time.
 			&& (flashNotification == FlashNotification.FLASH_TWO_SECONDS
-			|| flashNotification == FlashNotification.FLASH_UNTIL_CANCELLED))
+			|| flashNotification == FlashNotification.FLASH_UNTIL_CANCELLED
+			|| flashNotification == FlashNotification.FLASH_ONE_TICK))
 		{
 			return;
 		}

--- a/runelite-client/src/main/java/net/runelite/client/config/FlashNotification.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/FlashNotification.java
@@ -32,6 +32,7 @@ import lombok.RequiredArgsConstructor;
 public enum FlashNotification
 {
 	DISABLED("Off"),
+	FLASH_ONE_TICK("Flash for 1 tick"),
 	FLASH_TWO_SECONDS("Flash for 2 seconds"),
 	SOLID_TWO_SECONDS("Solid for 2 seconds"),
 	FLASH_UNTIL_CANCELLED("Flash until cancelled"),


### PR DESCRIPTION
As per the title, this change adds a new menu option for the flash notification setting to only be a singular tick long.

Fixes #12765 