### PR TITLE
sponsors: add patreon link

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+patreon: runelite


### PR DESCRIPTION
[Sponsorships](https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/displaying-a-sponsor-button-in-your-repository#displaying-a-sponsor-button-in-your-repository) first needs to be enabled in the repository settings. It will allow for a sidebar link to Patreon:
![image](https://user-images.githubusercontent.com/25151927/98629617-8c4dde00-2319-11eb-8acb-dc7efd3f795b.png)
