### PR TITLE
UI: Fixed window maximizing over screen boundaries on startup

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
@@ -554,7 +554,7 @@ public class ClientUI
 					{
 						// Make sure that the bounds are correct for the current display.
 						// The method only uses the parameter on OSX so passing null is ok.
-						if (OSType.getOSType() == OSType.MacOS)
+						if (OSType.getOSType() != OSType.MacOS)
 						{
 							frame.setMaximizedBounds(null);
 						}

--- a/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
@@ -552,6 +552,12 @@ public class ClientUI
 
 					if (configManager.getConfiguration(CONFIG_GROUP, CONFIG_CLIENT_MAXIMIZED) != null)
 					{
+						// Make sure that the bounds are correct for the current display.
+						// The method only uses the parameter on OSX so passing null is ok.
+						if (OSType.getOSType() == OSType.MacOS)
+						{
+							frame.setMaximizedBounds(null);
+						}
 						frame.setExtendedState(JFrame.MAXIMIZED_BOTH);
 					}
 				}


### PR DESCRIPTION
Close #12784 

Use the method overridden in ContainableFrame.java to make sure the boundaries are set correctly.