### PR TITLE
Option to snap volume changes to a specified percentage

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/music/MusicConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/music/MusicConfig.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2019, Adam <Adam@sigterm.info>
+ * Copyright (c) 2020, Shingyx <https://github.com/Shingyx>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -84,6 +85,17 @@ public interface MusicConfig extends Config
 	default boolean mutePrayerSounds()
 	{
 		return false;
+	}
+
+	@ConfigItem(
+		keyName = "volumeSnapMode",
+		name = "Snap volume",
+		description = "Snap volume changes to the specified percentage increment",
+		position = 5
+	)
+	default VolumeSnapMode volumeSnapMode()
+	{
+		return VolumeSnapMode.OFF;
 	}
 
 	@ConfigItem(

--- a/runelite-client/src/main/java/net/runelite/client/plugins/music/MusicPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/music/MusicPlugin.java
@@ -2,6 +2,7 @@
  * Copyright (c) 2019, Anthony Chen <https://github.com/achencoms>
  * Copyright (c) 2019, Adam <Adam@sigterm.info>
  * Copyright (c) 2020, Sean Dewar <https://github.com/seandewar>
+ * Copyright (c) 2020, Shingyx <https://github.com/Shingyx>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -571,7 +572,7 @@ public class MusicPlugin extends Plugin
 
 				JavaScriptCallback move = ev ->
 				{
-					int newVal = ((ev.getMouseX() - MusicSlider.PADDING - (slider.getHandle().getWidth() / 2)) * slider.getMax())
+					double newVal = ((ev.getMouseX() - MusicSlider.PADDING - (slider.getHandle().getWidth() / 2.0)) * slider.getMax())
 						/ slider.getWidth();
 					if (newVal < 0)
 					{
@@ -582,8 +583,10 @@ public class MusicPlugin extends Plugin
 						newVal = slider.getMax();
 					}
 
+					newVal = musicConfig.volumeSnapMode().snapVolume(newVal, slider.getMax());
+
 					// We store +1 so we can tell the difference between 0 and muted
-					slider.getSetter().accept(musicConfig, newVal + 1);
+					slider.getSetter().accept(musicConfig, (int) Math.round(newVal) + 1);
 					applyMusicVolumeConfig();
 				};
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/music/VolumeSnapMode.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/music/VolumeSnapMode.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2020, Shingyx <https://github.com/Shingyx>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.music;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum VolumeSnapMode
+{
+	OFF("Off", -1),
+	NEAREST_5_PERCENT("Nearest 5%", 5),
+	NEAREST_10_PERCENT("Nearest 10%", 10),
+	NEAREST_25_PERCENT("Nearest 25%", 25);
+
+	private final String name;
+	private final int snapPercentage;
+
+	@Override
+	public String toString()
+	{
+		return name;
+	}
+
+	public double snapVolume(double value, double max)
+	{
+		if (snapPercentage <= 0)
+		{
+			return value;
+		}
+
+		final double percent = value / max * 100.0;
+		final double snappedPercent = Math.round(percent / snapPercentage) * snapPercentage;
+		return snappedPercent / 100.0 * max;
+	}
+}


### PR DESCRIPTION
Adds support for snapping volume changes to 5, 10, or 25 percent increments. Defaults to OFF to match current behavior. This makes it easier to change the three sliders to have the exact same volume value.

Closes https://github.com/runelite/runelite/issues/10811.