### PR TITLE
SkillCalculator: Added support for 4 dose potions, fixed invalid 3 dose potions

### DIFF
--- a/runelite-client/src/main/resources/net/runelite/client/plugins/skillcalculator/skill_herblore.json
+++ b/runelite-client/src/main/resources/net/runelite/client/plugins/skillcalculator/skill_herblore.json
@@ -361,6 +361,12 @@
       "xp": 82.5
     },
     {
+      "level": 84,
+      "icon": 11951,
+      "name": "Extended Antifire (4)",
+      "xp": 110
+    },
+    {
       "level": 86,
       "icon": 24635,
       "name": "Divine bastion potion(4)",
@@ -379,6 +385,12 @@
       "xp": 90
     },
     {
+      "level": 87,
+      "icon": 12905,
+      "name": "Anti-venom(4)",
+      "xp": 120
+    },
+    {
       "level": 90,
       "icon": 12695,
       "name": "Super Combat Potion(4)",
@@ -386,14 +398,14 @@
     },
     {
       "level": 92,
-      "icon": 21981,
-      "name": "Super Antifire (3)",
+      "icon": 21978,
+      "name": "Super Antifire (4)",
       "xp": 130
     },
     {
       "level": 94,
-      "icon": 12915,
-      "name": "Anti-venom+(3)",
+      "icon": 12913,
+      "name": "Anti-venom+(4)",
       "xp": 125
     },
     {


### PR DESCRIPTION
- Added 4 dose **Extended Antifires** and **Anti-venoms** to the herblore skill calculator. These potions are able and often are made using 4 doses at a time.

- **Super Antifires** and **Anti-venom+'s** can not be made using 3 doses at a time, so were fixed to display the right potion dose (4).
![image](https://user-images.githubusercontent.com/32379779/99916886-b6ac7d80-2cc1-11eb-94c7-111b9f2f808f.png)
