### PR TITLE
Special attack counter notifications

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/specialcounter/SpecialCounter.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/specialcounter/SpecialCounter.java
@@ -24,6 +24,7 @@
  */
 package net.runelite.client.plugins.specialcounter;
 
+import java.awt.Color;
 import java.awt.image.BufferedImage;
 import java.util.HashMap;
 import java.util.Map;
@@ -34,13 +35,15 @@ import net.runelite.client.ui.overlay.infobox.Counter;
 class SpecialCounter extends Counter
 {
 	private final SpecialWeapon weapon;
+	private final SpecialCounterConfig config;
 	@Getter(AccessLevel.PACKAGE)
 	private final Map<String, Integer> partySpecs = new HashMap<>();
 
-	SpecialCounter(BufferedImage image, SpecialCounterPlugin plugin, int hitValue, SpecialWeapon weapon)
+	SpecialCounter(BufferedImage image, SpecialCounterPlugin plugin, SpecialCounterConfig config, int hitValue, SpecialWeapon weapon)
 	{
 		super(image, plugin, hitValue);
 		this.weapon = weapon;
+		this.config = config;
 	}
 
 	void addHits(double hit)
@@ -89,5 +92,17 @@ class SpecialCounter extends Counter
 		{
 			return weapon.getName() + " special has hit " + hitValue + " total.";
 		}
+	}
+
+	@Override
+	public Color getTextColor()
+	{
+		int threshold = weapon.getThreshold().apply(config);
+		if (threshold > 0)
+		{
+			int count = getCount();
+			return count >= threshold ? Color.GREEN : Color.RED;
+		}
+		return super.getTextColor();
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/specialcounter/SpecialCounterConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/specialcounter/SpecialCounterConfig.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2020, Dylan <dylanhe@umich.edu>
+ * Copyright (c) 2020, Jacob <jgozon@umich.edu>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.specialcounter;
+
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+
+@ConfigGroup("specialcounter")
+public interface SpecialCounterConfig extends Config
+{
+	@ConfigItem(
+		position = 0,
+		keyName = "thresholdNotification",
+		name = "Threshold Notifications",
+		description = "Sends a notification when your special attack counter exceeds the threshold"
+	)
+	default boolean thresholdNotification()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		position = 1,
+		keyName = "dragonWarhammerThreshold",
+		name = "Dragon Warhammer",
+		description = "Threshold for Dragon Warhammer (0 to disable)"
+	)
+	default int dragonWarhammerThreshold()
+	{
+		return 0;
+	}
+
+	@ConfigItem(
+		position = 2,
+		keyName = "arclightThreshold",
+		name = "Arclight",
+		description = "Threshold for Arclight (0 to disable)"
+	)
+	default int arclightThreshold()
+	{
+		return 0;
+	}
+
+	@ConfigItem(
+		position = 3,
+		keyName = "darklightThreshold",
+		name = "Darklight",
+		description = "Threshold for Darklight (0 to disable)"
+	)
+	default int darklightThreshold()
+	{
+		return 0;
+	}
+
+	@ConfigItem(
+		position = 4,
+		keyName = "bandosGodswordThreshold",
+		name = "Bandos Godsword",
+		description = "Threshold for Bandos Godsword (0 to disable)"
+	)
+	default int bandosGodswordThreshold()
+	{
+		return 0;
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/specialcounter/SpecialWeapon.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/specialcounter/SpecialWeapon.java
@@ -24,6 +24,7 @@
  */
 package net.runelite.client.plugins.specialcounter;
 
+import java.util.function.Function;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import net.runelite.api.ItemID;
@@ -32,13 +33,14 @@ import net.runelite.api.ItemID;
 @Getter
 enum SpecialWeapon
 {
-	DRAGON_WARHAMMER("Dragon Warhammer", ItemID.DRAGON_WARHAMMER, false),
-	ARCLIGHT("Arclight", ItemID.ARCLIGHT, false),
-	DARKLIGHT("Darklight", ItemID.DARKLIGHT, false),
-	BANDOS_GODSWORD("Bandos Godsword", ItemID.BANDOS_GODSWORD, true),
-	BANDOS_GODSWORD_OR("Bandos Godsword", ItemID.BANDOS_GODSWORD_OR, true);
+	DRAGON_WARHAMMER("Dragon Warhammer", ItemID.DRAGON_WARHAMMER, false, SpecialCounterConfig::dragonWarhammerThreshold),
+	ARCLIGHT("Arclight", ItemID.ARCLIGHT, false, SpecialCounterConfig::arclightThreshold),
+	DARKLIGHT("Darklight", ItemID.DARKLIGHT, false, SpecialCounterConfig::darklightThreshold),
+	BANDOS_GODSWORD("Bandos Godsword", ItemID.BANDOS_GODSWORD, true, SpecialCounterConfig::bandosGodswordThreshold),
+	BANDOS_GODSWORD_OR("Bandos Godsword", ItemID.BANDOS_GODSWORD_OR, true, SpecialCounterConfig::bandosGodswordThreshold);
 
 	private final String name;
 	private final int itemID;
 	private final boolean damage;
+	private final Function<SpecialCounterConfig, Integer> threshold;
 }


### PR DESCRIPTION
Close #12568

Add feature to existing special attack counter plugin which allows users to set a threshold and receive a notification when it is met.
For example, if a user sets their Bandos Godsword threshold to two, after two special attacks with the Bandos Godsword, they will receive a notification.