### PR TITLE
grandexchange: add right click wiki to item search

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
@@ -90,6 +90,7 @@ import net.runelite.client.ui.DynamicGridLayout;
 import net.runelite.client.ui.FontManager;
 import net.runelite.client.ui.PluginPanel;
 import net.runelite.client.ui.components.ComboBoxListRenderer;
+import net.runelite.client.ui.components.PopupMenu;
 import net.runelite.client.ui.components.colorpicker.ColorPickerManager;
 import net.runelite.client.ui.components.colorpicker.RuneliteColorPicker;
 import net.runelite.client.util.ColorUtil;
@@ -206,7 +207,7 @@ class ConfigPanel extends PluginPanel
 			uninstallItem.addActionListener(ev -> externalPluginManager.remove(mf.getInternalName()));
 		}
 
-		PluginListItem.addLabelPopupMenu(title, pluginConfig.createSupportMenuItem(), uninstallItem);
+		PopupMenu.create(title, null, pluginConfig.createSupportMenuItem(), uninstallItem);
 
 		if (pluginConfig.getPlugin() != null)
 		{
@@ -330,7 +331,7 @@ class ConfigPanel extends PluginPanel
 			JLabel configEntryName = new JLabel(name);
 			configEntryName.setForeground(Color.WHITE);
 			configEntryName.setToolTipText("<html>" + name + ":<br>" + cid.getItem().description() + "</html>");
-			PluginListItem.addLabelPopupMenu(configEntryName, createResetMenuItem(pluginConfig, cid));
+			PopupMenu.create(configEntryName, null, createResetMenuItem(pluginConfig, cid));
 			item.add(configEntryName, BorderLayout.CENTER);
 
 			if (cid.getType() == boolean.class)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/PluginListItem.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/PluginListItem.java
@@ -26,13 +26,8 @@ package net.runelite.client.plugins.config;
 
 import java.awt.BorderLayout;
 import java.awt.Color;
-import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.GridLayout;
-import java.awt.MouseInfo;
-import java.awt.Point;
-import java.awt.event.MouseAdapter;
-import java.awt.event.MouseEvent;
 import java.awt.image.BufferedImage;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -42,14 +37,11 @@ import javax.swing.JButton;
 import javax.swing.JLabel;
 import javax.swing.JMenuItem;
 import javax.swing.JPanel;
-import javax.swing.JPopupMenu;
 import javax.swing.JToggleButton;
-import javax.swing.SwingUtilities;
-import javax.swing.border.EmptyBorder;
 import lombok.Getter;
 import net.runelite.client.externalplugins.ExternalPluginManifest;
-import net.runelite.client.ui.ColorScheme;
 import net.runelite.client.ui.PluginPanel;
+import net.runelite.client.ui.components.PopupMenu;
 import net.runelite.client.util.ImageUtil;
 import net.runelite.client.util.SwingUtil;
 
@@ -163,7 +155,7 @@ class PluginListItem extends JPanel implements SearchablePlugin
 			uninstallItem.addActionListener(ev -> pluginListPanel.getExternalPluginManager().remove(mf.getInternalName()));
 		}
 
-		addLabelPopupMenu(nameLabel, configMenuItem, pluginConfig.createSupportMenuItem(), uninstallItem);
+		PopupMenu.create(nameLabel, null, configMenuItem, pluginConfig.createSupportMenuItem(), uninstallItem);
 		add(nameLabel, BorderLayout.CENTER);
 
 		onOffToggle = new PluginToggleButton();
@@ -213,59 +205,5 @@ class PluginListItem extends JPanel implements SearchablePlugin
 	private void openGroupConfigPanel()
 	{
 		pluginListPanel.openConfigurationPanel(pluginConfig);
-	}
-
-	/**
-	 * Adds a mouseover effect to change the text of the passed label to {@link ColorScheme#BRAND_ORANGE} color, and
-	 * adds the passed menu items to a popup menu shown when the label is clicked.
-	 *
-	 * @param label     The label to attach the mouseover and click effects to
-	 * @param menuItems The menu items to be shown when the label is clicked
-	 */
-	static void addLabelPopupMenu(JLabel label, JMenuItem... menuItems)
-	{
-		final JPopupMenu menu = new JPopupMenu();
-		final Color labelForeground = label.getForeground();
-		menu.setBorder(new EmptyBorder(5, 5, 5, 5));
-
-		for (final JMenuItem menuItem : menuItems)
-		{
-			if (menuItem == null)
-			{
-				continue;
-			}
-
-			// Some machines register mouseEntered through a popup menu, and do not register mouseExited when a popup
-			// menu item is clicked, so reset the label's color when we click one of these options.
-			menuItem.addActionListener(e -> label.setForeground(labelForeground));
-			menu.add(menuItem);
-		}
-
-		label.addMouseListener(new MouseAdapter()
-		{
-			private Color lastForeground;
-
-			@Override
-			public void mouseClicked(MouseEvent mouseEvent)
-			{
-				Component source = (Component) mouseEvent.getSource();
-				Point location = MouseInfo.getPointerInfo().getLocation();
-				SwingUtilities.convertPointFromScreen(location, source);
-				menu.show(source, location.x, location.y);
-			}
-
-			@Override
-			public void mouseEntered(MouseEvent mouseEvent)
-			{
-				lastForeground = label.getForeground();
-				label.setForeground(ColorScheme.BRAND_ORANGE);
-			}
-
-			@Override
-			public void mouseExited(MouseEvent mouseEvent)
-			{
-				label.setForeground(lastForeground);
-			}
-		});
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangeItemPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangeItemPanel.java
@@ -36,11 +36,14 @@ import java.awt.event.MouseEvent;
 import java.util.ArrayList;
 import java.util.List;
 import javax.swing.JLabel;
+import javax.swing.JMenuItem;
 import javax.swing.JPanel;
 import javax.swing.border.CompoundBorder;
 import javax.swing.border.EmptyBorder;
 import net.runelite.client.ui.ColorScheme;
+import net.runelite.client.ui.components.PopupMenu;
 import net.runelite.client.util.AsyncBufferedImage;
+import net.runelite.client.util.LinkBrowser;
 import net.runelite.client.util.QuantityFormatter;
 
 /**
@@ -89,11 +92,18 @@ class GrandExchangeItemPanel extends JPanel
 			@Override
 			public void mouseReleased(MouseEvent e)
 			{
-				GrandExchangePlugin.openGeLink(name, itemID);
+				if (e.getButton() == MouseEvent.BUTTON1)
+				{
+					GrandExchangePlugin.openGeLink(name, itemID);
+				}
 			}
 		};
 
 		addMouseListener(itemPanelMouseListener);
+
+		JMenuItem menuItem = new JMenuItem("Wiki");
+		menuItem.addActionListener(ev -> LinkBrowser.browse("https://oldschool.runescape.wiki/w/" + name.replaceAll(" ", "_")));
+		PopupMenu.create(this, MouseEvent.BUTTON3, menuItem);
 
 		setBorder(new EmptyBorder(5, 5, 5, 0));
 

--- a/runelite-client/src/main/java/net/runelite/client/ui/components/PopupMenu.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/components/PopupMenu.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2018, Daniel Teo <https://github.com/takuyakanbr>
+ * Copyright (c) 2020, Adam Davies <https://github.com/adamdavies001>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.ui.components;
+
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.MouseInfo;
+import java.awt.Point;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import javax.swing.JComponent;
+import javax.swing.JLabel;
+import javax.swing.JMenuItem;
+import javax.swing.JPopupMenu;
+import javax.swing.SwingUtilities;
+import javax.swing.border.EmptyBorder;
+import net.runelite.client.ui.ColorScheme;
+
+public class PopupMenu
+{
+	/**
+	 * Adds the passed menu items to a popup menu shown when the label is clicked, and
+	 * adds a mouseover effect to change the text of a passed label to {@link ColorScheme#BRAND_ORANGE} color
+	 *
+	 * @param component The component to attach the mouseover and click effects to
+	 * @param menuItems The menu items to be shown when the label is clicked
+	 */
+	public static <T extends JComponent> void create(T component, Integer trigger, JMenuItem... menuItems)
+	{
+		final boolean isLabel = component instanceof JLabel;
+		final JPopupMenu menu = new JPopupMenu();
+		menu.setBorder(new EmptyBorder(5, 5, 5, 5));
+
+		for (final JMenuItem menuItem : menuItems)
+		{
+			if (menuItem == null)
+			{
+				continue;
+			}
+
+			// Some machines register mouseEntered through a popup menu, and do not register mouseExited when a popup
+			// menu item is clicked, so reset the label's color when we click one of these options.
+			if (isLabel)
+			{
+				final Color labelForeground = component.getForeground();
+				menuItem.addActionListener(e -> component.setForeground(labelForeground));
+			}
+
+			menu.add(menuItem);
+		}
+
+		component.addMouseListener(new MouseAdapter()
+		{
+			private Color lastForeground;
+
+			@Override
+			public void mouseClicked(MouseEvent mouseEvent)
+			{
+				if (trigger == null || mouseEvent.getButton() == trigger)
+				{
+					Component source = (Component) mouseEvent.getSource();
+					Point location = MouseInfo.getPointerInfo().getLocation();
+					SwingUtilities.convertPointFromScreen(location, source);
+					menu.show(source, location.x, location.y);
+				}
+			}
+
+			@Override
+			public void mouseEntered(MouseEvent mouseEvent)
+			{
+				if (isLabel)
+				{
+					lastForeground = component.getForeground();
+					component.setForeground(ColorScheme.BRAND_ORANGE);
+				}
+			}
+
+			@Override
+			public void mouseExited(MouseEvent mouseEvent)
+			{
+				if (isLabel)
+				{
+					component.setForeground(lastForeground);
+				}
+			}
+		});
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/ui/components/PopupMenu.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/components/PopupMenu.java
@@ -42,10 +42,11 @@ import net.runelite.client.ui.ColorScheme;
 public class PopupMenu
 {
 	/**
-	 * Adds the passed menu items to a popup menu shown when the label is clicked, and
+	 * Adds the passed menu items to a popup menu shown when the component is clicked, and
 	 * adds a mouseover effect to change the text of a passed label to {@link ColorScheme#BRAND_ORANGE} color
 	 *
 	 * @param component The component to attach the mouseover and click effects to
+	 * @param trigger   The MouseEvent.BUTTON to trigger the popup
 	 * @param menuItems The menu items to be shown when the label is clicked
 	 */
 	public static <T extends JComponent> void create(T component, Integer trigger, JMenuItem... menuItems)


### PR DESCRIPTION
Adds a right click popup to the Grand Exchange plugin panel to easily lookup items on the wiki when searching prices.

Refactored some existing code to allow the existing popup functionality to be used anywhere.

Closes #12840