### PR TITLE
Add individual value search to bank plugin.

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/bank/BankPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/bank/BankPlugin.java
@@ -83,7 +83,7 @@ public class BankPlugin extends Plugin
 	private static final String SEED_VAULT_TITLE = "Seed Vault";
 
 	private static final String NUMBER_REGEX = "[0-9]+(\\.[0-9]+)?[kmb]?";
-	private static final Pattern VALUE_SEARCH_PATTERN = Pattern.compile("^(?<mode>ge|ha|alch)?" +
+	private static final Pattern VALUE_SEARCH_PATTERN = Pattern.compile("^(?<mode>ge|ha|alch)?" + "(?<individual> i| iv| individual)?" +
 		" *(((?<op>[<>=]|>=|<=) *(?<num>" + NUMBER_REGEX + "))|" +
 		"((?<num1>" + NUMBER_REGEX + ") *- *(?<num2>" + NUMBER_REGEX + ")))$", Pattern.CASE_INSENSITIVE);
 
@@ -424,7 +424,7 @@ public class BankPlugin extends Plugin
 		}
 
 		final ItemComposition itemComposition = itemManager.getItemComposition(itemId);
-		final int qty = itemQuantities.count(itemId);
+		final int qty = matcher.group("individual")!=null ? 1 :itemQuantities.count(itemId);
 		final long gePrice = (long) itemManager.getItemPrice(itemId) * qty;
 		final long haPrice = (long) itemComposition.getHaPrice() * qty;
 


### PR DESCRIPTION
Added additional functionality to bank value search where you can specify with  "i", "iv", or "individual" to search for the individual value of an item. This is particularly useful for when you want to find items with large individual high alch values and want to filter out high quantity items like feathers, arrows, etc. because nobody alchs those.

example usage: 
"ha i > 20k"
"ha iv > 20k"
"ha individual > 20k"

close #12771 