### PR TITLE
timetracking: Add option to show the soonest completion time of a tab

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/TimeTrackingConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/TimeTrackingConfig.java
@@ -38,6 +38,7 @@ public interface TimeTrackingConfig extends Config
 	String BOTANIST = "botanist";
 	String TIMERS = "timers";
 	String STOPWATCHES = "stopwatches";
+	String PREFER_SOONEST = "preferSoonest";
 
 	@ConfigItem(
 		keyName = "timeFormatMode",
@@ -116,6 +117,17 @@ public interface TimeTrackingConfig extends Config
 	default int timerWarningThreshold()
 	{
 		return 10;
+	}
+
+	@ConfigItem(
+		keyName = PREFER_SOONEST,
+		name = "Prefer soonest completion",
+		description = "When displaying completion times on the overview, prefer showing the soonest any patch will complete.",
+		position = 7
+	)
+	default boolean preferSoonest()
+	{
+		return false;
 	}
 
 	@ConfigItem(

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/TimeTrackingPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/TimeTrackingPlugin.java
@@ -49,6 +49,7 @@ import net.runelite.client.game.ItemManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import static net.runelite.client.plugins.timetracking.TimeTrackingConfig.CONFIG_GROUP;
+import static net.runelite.client.plugins.timetracking.TimeTrackingConfig.PREFER_SOONEST;
 import static net.runelite.client.plugins.timetracking.TimeTrackingConfig.STOPWATCHES;
 import static net.runelite.client.plugins.timetracking.TimeTrackingConfig.TIMERS;
 import net.runelite.client.plugins.timetracking.clocks.ClockManager;
@@ -171,6 +172,10 @@ public class TimeTrackingPlugin extends Plugin
 		else if (clockManager.getStopwatches().isEmpty() && e.getKey().equals(STOPWATCHES))
 		{
 			clockManager.loadStopwatches();
+		}
+		else if (e.getKey().equals(PREFER_SOONEST))
+		{
+			farmingTracker.loadCompletionTimes();
 		}
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/farming/FarmingTracker.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/farming/FarmingTracker.java
@@ -277,7 +277,7 @@ public class FarmingTracker
 	{
 		for (Map.Entry<Tab, Set<FarmingPatch>> tab : farmingWorld.getTabs().entrySet())
 		{
-			long maxCompletionTime = 0;
+			long extremumCompletionTime = config.preferSoonest() ? Long.MAX_VALUE : 0;
 			boolean allUnknown = true;
 			boolean allEmpty = true;
 
@@ -296,7 +296,15 @@ public class FarmingTracker
 					allEmpty = false;
 
 					// update max duration if this patch takes longer to grow
-					maxCompletionTime = Math.max(maxCompletionTime, prediction.getDoneEstimate());
+					if (config.preferSoonest())
+					{
+						extremumCompletionTime = Math.min(extremumCompletionTime, prediction.getDoneEstimate());
+					}
+					else
+					{
+						extremumCompletionTime = Math.max(extremumCompletionTime, prediction.getDoneEstimate());
+					}
+
 				}
 			}
 
@@ -313,7 +321,7 @@ public class FarmingTracker
 				state = SummaryState.EMPTY;
 				completionTime = -1L;
 			}
-			else if (maxCompletionTime <= Instant.now().getEpochSecond())
+			else if (extremumCompletionTime <= Instant.now().getEpochSecond())
 			{
 				state = SummaryState.COMPLETED;
 				completionTime = 0;
@@ -321,7 +329,7 @@ public class FarmingTracker
 			else
 			{
 				state = SummaryState.IN_PROGRESS;
-				completionTime = maxCompletionTime;
+				completionTime = extremumCompletionTime;
 			}
 			summaries.put(tab.getKey(), state);
 			completionTimes.put(tab.getKey(), completionTime);


### PR DESCRIPTION
Closes #9445
Closes #12287

Currently, the overview tab of Time Tracking shows when a group of patches will all complete. This is problematic when you have, say, Hardwood trees or a Redwood tree growing, and want to know roughly when your normal trees will finish to do a run, since they have a much longer growth time. This PR simply adds an option to show the soonest completion, which is more likely to be a better indicator of when the group of patches is finished.

`Dusk the Umbreon` brought this up in Discord, and I thought it was a nice idea, and an easy one to implement.

Also, yes, apparently `extremum` is the collective term for maximum and minimum. I think it's a bit weird too, suggestions very much welcome.