### PR TITLE
fix barrows drop rate coloring

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/barrows/BarrowsBrotherSlainOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/barrows/BarrowsBrotherSlainOverlay.java
@@ -87,7 +87,7 @@ public class BarrowsBrotherSlainOverlay extends OverlayPanel
 		panelComponent.getChildren().add(LineComponent.builder()
 				.left("Potential")
 				.right(rewardPercent != 0 ? rewardPercent + "%" : "0%")
-				.rightColor(rewardPercent >= 73.0f && rewardPercent <= 88.0f ? Color.GREEN : rewardPercent < 65.6f ? Color.WHITE : Color.YELLOW)
+				.rightColor(rewardPercent >= 75.6f && rewardPercent <= 88.0f ? Color.GREEN : rewardPercent < 63.0f ? Color.WHITE : Color.YELLOW)
 				.build());
 
 		return super.render(graphics);


### PR DESCRIPTION
The coloring for the loot potential on the main barrows table is incorrect.  I assume it was meant to turn yellow when death runes were added to the loot potential, green when blood runes were added, and white again for bolt racks.  But the numbers are off by just a bit.  See wiki percentages:
https://oldschool.runescape.wiki/w/Chest_(Barrows)#Main_table