### PR TITLE
[bug] barrows coloring not aligning with drop table

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/barrows/BarrowsBrotherSlainOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/barrows/BarrowsBrotherSlainOverlay.java
@@ -87,7 +87,7 @@ public class BarrowsBrotherSlainOverlay extends OverlayPanel
 		panelComponent.getChildren().add(LineComponent.builder()
 				.left("Potential")
 				.right(rewardPercent != 0 ? rewardPercent + "%" : "0%")
-				.rightColor(client.getVar(Varbits.BARROWS_REWARD_POTENTIAL >= 756f && client.getVar(Varbits.BARROWS_REWARD_POTENTIAL <= 880f ? Color.GREEN : client.getVar(Varbits.BARROWS_REWARD_POTENTIAL < 631f ? Color.WHITE : Color.YELLOW)
+				.rightColor(client.getVar(Varbits.BARROWS_REWARD_POTENTIAL) >= 756f && client.getVar(Varbits.BARROWS_REWARD_POTENTIAL) <= 880f ? Color.GREEN : client.getVar(Varbits.BARROWS_REWARD_POTENTIAL) < 631f ? Color.WHITE : Color.YELLOW)
 				.build());
 
 		return super.render(graphics);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/barrows/BarrowsBrotherSlainOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/barrows/BarrowsBrotherSlainOverlay.java
@@ -83,8 +83,8 @@ public class BarrowsBrotherSlainOverlay extends OverlayPanel
 				.build());
 		}
 
-		float rewardPotential = client.getVar(Varbits.BARROWS_REWARD_POTENTIAL);
-		float rewardPercent = client.getVar(Varbits.BARROWS_REWARD_POTENTIAL) / 10.12f;
+		float rewardPotential = client.getVar(Varbits.BARROWS_REWARD_POTENTIAL) + client.getVar(Varbits.BARROWS_KILLED_AHRIM) + client.getVar(Varbits.BARROWS_KILLED_DHAROK) + client.getVar(Varbits.BARROWS_KILLED_GUTHAN) + client.getVar(Varbits.BARROWS_KILLED_KARIL) + client.getVar(Varbits.BARROWS_KILLED_TORAG) + client.getVar(Varbits.BARROWS_KILLED_VERAC);
+		float rewardPercent = rewardPotential / 10.12f;
 		panelComponent.getChildren().add(LineComponent.builder()
 				.left("Potential")
 				.right(rewardPercent != 0 ? rewardPercent + "%" : "0%")

--- a/runelite-client/src/main/java/net/runelite/client/plugins/barrows/BarrowsBrotherSlainOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/barrows/BarrowsBrotherSlainOverlay.java
@@ -87,7 +87,7 @@ public class BarrowsBrotherSlainOverlay extends OverlayPanel
 		panelComponent.getChildren().add(LineComponent.builder()
 				.left("Potential")
 				.right(rewardPercent != 0 ? rewardPercent + "%" : "0%")
-				.rightColor(rewardPercent >= 74.7f && rewardPercent <= 86.96 ? Color.GREEN : rewardPercent < 62.35f ? Color.WHITE : Color.YELLOW)
+				.rightColor(client.getVar(Varbits.BARROWS_REWARD_POTENTIAL >= 756f && client.getVar(Varbits.BARROWS_REWARD_POTENTIAL <= 880f ? Color.GREEN : client.getVar(Varbits.BARROWS_REWARD_POTENTIAL < 631f ? Color.WHITE : Color.YELLOW)
 				.build());
 
 		return super.render(graphics);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/barrows/BarrowsBrotherSlainOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/barrows/BarrowsBrotherSlainOverlay.java
@@ -83,11 +83,12 @@ public class BarrowsBrotherSlainOverlay extends OverlayPanel
 				.build());
 		}
 
+		float rewardPotential = client.getVar(Varbits.BARROWS_REWARD_POTENTIAL);
 		float rewardPercent = client.getVar(Varbits.BARROWS_REWARD_POTENTIAL) / 10.12f;
 		panelComponent.getChildren().add(LineComponent.builder()
 				.left("Potential")
 				.right(rewardPercent != 0 ? rewardPercent + "%" : "0%")
-				.rightColor(client.getVar(Varbits.BARROWS_REWARD_POTENTIAL) >= 756f && client.getVar(Varbits.BARROWS_REWARD_POTENTIAL) <= 880f ? Color.GREEN : client.getVar(Varbits.BARROWS_REWARD_POTENTIAL) < 631f ? Color.WHITE : Color.YELLOW)
+				.rightColor(rewardPotential >= 756f && rewardPotential <= 880f ? Color.GREEN : rewardPotential < 631f ? Color.WHITE : Color.YELLOW)
 				.build());
 
 		return super.render(graphics);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/barrows/BarrowsBrotherSlainOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/barrows/BarrowsBrotherSlainOverlay.java
@@ -83,11 +83,11 @@ public class BarrowsBrotherSlainOverlay extends OverlayPanel
 				.build());
 		}
 
-		float rewardPercent = client.getVar(Varbits.BARROWS_REWARD_POTENTIAL) / 10.0f;
+		float rewardPercent = client.getVar(Varbits.BARROWS_REWARD_POTENTIAL) / 10.12f;
 		panelComponent.getChildren().add(LineComponent.builder()
 				.left("Potential")
 				.right(rewardPercent != 0 ? rewardPercent + "%" : "0%")
-				.rightColor(rewardPercent >= 75.6f && rewardPercent <= 88.0f ? Color.GREEN : rewardPercent < 63.0f ? Color.WHITE : Color.YELLOW)
+				.rightColor(rewardPercent >= 74.7f && rewardPercent <= 86.96 ? Color.GREEN : rewardPercent < 62.35f ? Color.WHITE : Color.YELLOW)
 				.build());
 
 		return super.render(graphics);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/barrows/BarrowsBrotherSlainOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/barrows/BarrowsBrotherSlainOverlay.java
@@ -87,7 +87,7 @@ public class BarrowsBrotherSlainOverlay extends OverlayPanel
 		panelComponent.getChildren().add(LineComponent.builder()
 				.left("Potential")
 				.right(rewardPercent != 0 ? rewardPercent + "%" : "0%")
-				.rightColor(rewardPercent >= 73.0f && rewardPercent <= 88.0f ? Color.GREEN : rewardPercent < 65.6f ? Color.WHITE : Color.YELLOW)
+				.rightColor(rewardPercent >= 75.6f && rewardPercent <= 88.0f ? Color.GREEN : rewardPercent < 63.0f ? Color.WHITE : Color.YELLOW)
 				.build());
 
 		return super.render(graphics);


### PR DESCRIPTION
This will make the coloring work as follows.  I believe this was the intended solution?
WHITE pre death rune
YELLOW include death runes
GREEN include blood runes
YELLOW include bolt racks

see drop table rates
https://oldschool.runescape.wiki/w/Chest_(Barrows)#Main_table