### PR TITLE
Fix issue #12934: Correctly format large platinum token GP values

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemprices/ItemPricesOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemprices/ItemPricesOverlay.java
@@ -198,7 +198,7 @@ class ItemPricesOverlay extends Overlay
 		}
 		else if (id == ItemID.PLATINUM_TOKEN)
 		{
-			return QuantityFormatter.formatNumber(qty * 1000) + " gp";
+			return QuantityFormatter.formatNumber(qty * 1000L) + " gp";
 		}
 
 		ItemComposition itemDef = itemManager.getItemComposition(id);


### PR DESCRIPTION
This PR fixes the platinum token formatting by forcing an implicit cast to `long` using a `long` literal. This should resolve the issue where values of `qty * 1000` exceeding the maximum value of an `int` would format as "-1,000 gp".

These changes were tested by forcing `qty` to `Integer.MAX_VALUE` and verifying the output within the client:
![java_w76L6Pf1pq](https://user-images.githubusercontent.com/34242340/102101108-3aa4e180-3df8-11eb-89d5-bf93de4f1cf1.png)

Closes #12934.