### PR TITLE
loottracker: added bird nests to track type

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
@@ -477,8 +477,8 @@ public class LootTrackerPlugin extends Plugin
 		if (config.npcKillChatMessage())
 		{
 			final String prefix = VOWELS.contains(Character.toLowerCase(name.charAt(0)))
-					? "an"
-					: "a";
+				? "an"
+				: "a";
 
 			lootReceivedChatMessage(items, prefix + ' ' + name);
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
@@ -198,6 +198,7 @@ public class LootTrackerPlugin extends Plugin
 
 	private static final Pattern PICKPOCKET_REGEX = Pattern.compile("You pick (the )?(?<target>.+)'s? pocket.*");
 
+	private static final String BIRDNEST_EVENT = "Bird nest";
 	private static final Set<Integer> BIRDNEST_IDS = ImmutableSet.of(ItemID.BIRD_NEST, ItemID.BIRD_NEST_5071, ItemID.BIRD_NEST_5072, ItemID.BIRD_NEST_5073, ItemID.BIRD_NEST_5074, ItemID.BIRD_NEST_7413, ItemID.BIRD_NEST_13653, ItemID.BIRD_NEST_22798, ItemID.BIRD_NEST_22800);
 
 	// Birdhouses
@@ -476,8 +477,8 @@ public class LootTrackerPlugin extends Plugin
 		if (config.npcKillChatMessage())
 		{
 			final String prefix = VOWELS.contains(Character.toLowerCase(name.charAt(0)))
-				? "an"
-				: "a";
+					? "an"
+					: "a";
 
 			lootReceivedChatMessage(items, prefix + ' ' + name);
 		}
@@ -761,7 +762,7 @@ public class LootTrackerPlugin extends Plugin
 			|| HESPORI_EVENT.equals(eventType)
 			|| SEEDPACK_EVENT.equals(eventType)
 			|| CASKET_EVENT.equals(eventType)
-			|| eventType.contains("Bird nest")
+			|| BIRDNEST_EVENT.equals(eventType)
 			|| eventType.endsWith("Bird House")
 			|| eventType.startsWith("H.A.M. chest")
 			|| lootRecordType == LootRecordType.PICKPOCKET)
@@ -798,32 +799,7 @@ public class LootTrackerPlugin extends Plugin
 
 		if (event.getMenuOption().equals("Search") && BIRDNEST_IDS.contains(event.getId()))
 		{
-			final int eventId = event.getId();
-			switch (eventId)
-			{
-				case 22800:
-					setEvent(LootRecordType.EVENT, "Bird nest (Wyson)");
-					break;
-				case 22798:
-					setEvent(LootRecordType.EVENT, "Bird nest (Seed)");
-					break;
-				case 5074:
-					setEvent(LootRecordType.EVENT, "Bird nest (Ring)");
-					break;
-				case 5070:
-				case 5071:
-				case 5072:
-					setEvent(LootRecordType.EVENT, "Bird nest (Egg)");
-					break;
-				// 5073, 13653
-				case 5073:
-					setEvent(LootRecordType.EVENT, "Bird nest (Old)");
-					break;
-				case 13563:
-					setEvent(LootRecordType.EVENT, "Bird nest (Old v2)");
-					break;
-			}
-
+			setEvent(LootRecordType.EVENT, BIRDNEST_EVENT, event.getId());
 			takeInventorySnapshot();
 		}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
@@ -198,8 +198,7 @@ public class LootTrackerPlugin extends Plugin
 
 	private static final Pattern PICKPOCKET_REGEX = Pattern.compile("You pick (the )?(?<target>.+)'s? pocket.*");
 
-	private static final String BIRDNEST_EVENT = "Bird nest";
-	private static final Set<Integer> BIRDNEST_IDS = ImmutableSet.of(ItemID.BIRD_NEST, ItemID.BIRD_NEST_5071, ItemID.BIRD_NEST_5072, ItemID.BIRD_NEST_5073, ItemID.BIRD_NEST_5074, ItemID.BIRD_NEST_7413, ItemID.BIRD_NEST_13653, ItemID.BIRD_NEST_22798, ItemID.BIRD_NEST_22800);
+	private static final Set<Integer> BIRDNEST_IDS = ImmutableSet.of(ItemID.BIRD_NEST, ItemID.BIRD_NEST_5071, ItemID.BIRD_NEST_5072,ItemID.BIRD_NEST_5073, ItemID.BIRD_NEST_5074, ItemID.BIRD_NEST_7413, ItemID.BIRD_NEST_13653,ItemID.BIRD_NEST_22798, ItemID.BIRD_NEST_22800);
 
 	// Birdhouses
 	private static final Pattern BIRDHOUSE_PATTERN = Pattern.compile("You dismantle and discard the trap, retrieving (?:(?:a|\\d{1,2}) nests?, )?10 dead birds, \\d{1,3} feathers and (\\d,?\\d{1,3}) Hunter XP\\.");
@@ -762,7 +761,7 @@ public class LootTrackerPlugin extends Plugin
 			|| HESPORI_EVENT.equals(eventType)
 			|| SEEDPACK_EVENT.equals(eventType)
 			|| CASKET_EVENT.equals(eventType)
-			|| BIRDNEST_EVENT.equals(eventType)
+			|| eventType.contains("Bird nest")
 			|| eventType.endsWith("Bird House")
 			|| eventType.startsWith("H.A.M. chest")
 			|| lootRecordType == LootRecordType.PICKPOCKET)
@@ -799,7 +798,32 @@ public class LootTrackerPlugin extends Plugin
 
 		if (event.getMenuOption().equals("Search") && BIRDNEST_IDS.contains(event.getId()))
 		{
-			setEvent(LootRecordType.EVENT, BIRDNEST_EVENT);
+			final int eventId = event.getId();
+			switch (eventId)
+			{
+				case 22800:
+					setEvent(LootRecordType.EVENT, "Bird nest (Wyson)");
+					break;
+				case 22798:
+					setEvent(LootRecordType.EVENT, "Bird nest (Seed)");
+					break;
+				case 5074:
+					setEvent(LootRecordType.EVENT, "Bird nest (Ring)");
+					break;
+				case 5070:
+				case 5071:
+				case 5072:
+					setEvent(LootRecordType.EVENT, "Bird nest (Egg)");
+					break;
+				// 5073, 13653
+				case 5073:
+					setEvent(LootRecordType.EVENT, "Bird nest (Old)");
+					break;
+				case 13563:
+					setEvent(LootRecordType.EVENT, "Bird nest (Old v2)");
+					break;
+			}
+
 			takeInventorySnapshot();
 		}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
@@ -198,7 +198,7 @@ public class LootTrackerPlugin extends Plugin
 
 	private static final Pattern PICKPOCKET_REGEX = Pattern.compile("You pick (the )?(?<target>.+)'s? pocket.*");
 
-	private static final Set<Integer> BIRDNEST_IDS = ImmutableSet.of(ItemID.BIRD_NEST, ItemID.BIRD_NEST_5071, ItemID.BIRD_NEST_5072,ItemID.BIRD_NEST_5073, ItemID.BIRD_NEST_5074, ItemID.BIRD_NEST_7413, ItemID.BIRD_NEST_13653,ItemID.BIRD_NEST_22798, ItemID.BIRD_NEST_22800);
+	private static final Set<Integer> BIRDNEST_IDS = ImmutableSet.of(ItemID.BIRD_NEST, ItemID.BIRD_NEST_5071, ItemID.BIRD_NEST_5072, ItemID.BIRD_NEST_5073, ItemID.BIRD_NEST_5074, ItemID.BIRD_NEST_7413, ItemID.BIRD_NEST_13653, ItemID.BIRD_NEST_22798, ItemID.BIRD_NEST_22800);
 
 	// Birdhouses
 	private static final Pattern BIRDHOUSE_PATTERN = Pattern.compile("You dismantle and discard the trap, retrieving (?:(?:a|\\d{1,2}) nests?, )?10 dead birds, \\d{1,3} feathers and (\\d,?\\d{1,3}) Hunter XP\\.");


### PR DESCRIPTION
~~This modifies the current bird nest loot tracking to improve the wiki data sets. Currently, the system combines all types of bird nests and it is tracked under "Bird nest".~~

~~**Changes made:**~~
~~- Wyson nests -> Bird nest (Wyson)~~
~~- Regular nests (miscellania, birdhouses, woodcutting) - Bird nest (Seed)~~
~~- Ring nests -> Bird nest (Ring)~~
~~- Egg nests-> Bird nest (Egg)~~
~~- Empty nests -> Not tracked~~

~~_Note: Historical nests with the ID 5073 and 13563 are tracked with under the -> Bird nest (Old) and (Old v2) respectively for data purposes._~~

Update: This PR modifies the current bird nest loot tracking to include the object id as metadata. 