### PR TITLE
WIP: Add Inventory Value Tracker 

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/inventoryvalue/InventoryValueConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/inventoryvalue/InventoryValueConfig.java
@@ -8,27 +8,32 @@ import net.runelite.client.config.ConfigItem;
 public interface InventoryValueConfig extends Config
 {
 	@ConfigItem(
-			keyName = "useHaValue",
-			name = "Use High Alchemy Value",
-			description = "Calculate inventory value with High Alchemy. By default, the inventory value is calculated using GE price."
+		keyName = "useHaValue",
+		name = "Use High Alchemy Value",
+		description = "Calculate inventory value with High Alchemy. By default, the inventory value is calculated using GE price."
 	)
-	default boolean useHighAlchemyValue() {
+	default boolean useHighAlchemyValue()
+	{
 		return false;
 	}
 
 	@ConfigItem(
-			keyName = "ignoreCoins",
-			name = "Ignore Coins",
-			description = "Ignore coins in inventory. By default, the inventory value includes coins."
+		keyName = "ignoreCoins",
+		name = "Ignore Coins",
+		description = "Ignore coins in inventory. By default, the inventory value includes coins."
 	)
-	default boolean ignoreCoins() {
+	default boolean ignoreCoins()
+	{
 		return false;
 	}
 
 	@ConfigItem(
-			keyName = "ignoreItems",
-			name = "Ignore Items",
-			description = "Ignore particular items in inventory. By default, no items are ignored."
+		keyName = "ignoreItems",
+		name = "Ignore Items",
+		description = "Ignore particular items in inventory. By default, no items are ignored."
 	)
-	default String ignoreItems() { return ""; }
+	default String ignoreItems()
+	{
+		return "";
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/inventoryvalue/InventoryValueConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/inventoryvalue/InventoryValueConfig.java
@@ -5,31 +5,30 @@ import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
 
 @ConfigGroup("inventoryValue")
-public interface InventoryValueConfig extends Config {
-    @ConfigItem(
-            keyName = "useHaValue",
-            name = "Use High Alchemy Value",
-            description = "Calculate inventory value with High Alchemy. By default, the inventory value is calculated using GE price."
-    )
-    default boolean useHighAlchemyValue() {
-        return false;
-    }
+public interface InventoryValueConfig extends Config
+{
+	@ConfigItem(
+			keyName = "useHaValue",
+			name = "Use High Alchemy Value",
+			description = "Calculate inventory value with High Alchemy. By default, the inventory value is calculated using GE price."
+	)
+	default boolean useHighAlchemyValue() {
+		return false;
+	}
 
-    @ConfigItem(
-            keyName = "ignoreCoins",
-            name = "Ignore Coins",
-            description = "Ignore coins in inventory. By default, the inventory value includes coins."
-    )
-    default boolean ignoreCoins() {
-        return false;
-    }
+	@ConfigItem(
+			keyName = "ignoreCoins",
+			name = "Ignore Coins",
+			description = "Ignore coins in inventory. By default, the inventory value includes coins."
+	)
+	default boolean ignoreCoins() {
+		return false;
+	}
 
-    @ConfigItem(
-            keyName = "ignoreItems",
-            name = "Ignore Items",
-            description = "Ignore particular items in inventory. By default, no items are ignored."
-    )
-    default String ignoreItems() {
-        return "";
-    }
+	@ConfigItem(
+			keyName = "ignoreItems",
+			name = "Ignore Items",
+			description = "Ignore particular items in inventory. By default, no items are ignored."
+	)
+	default String ignoreItems() { return ""; }
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/inventoryvalue/InventoryValueConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/inventoryvalue/InventoryValueConfig.java
@@ -1,0 +1,35 @@
+package net.runelite.client.plugins.inventoryvalue;
+
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+
+@ConfigGroup("inventoryValue")
+public interface InventoryValueConfig extends Config {
+    @ConfigItem(
+            keyName = "useHaValue",
+            name = "Use High Alchemy Value",
+            description = "Calculate inventory value with High Alchemy. By default, the inventory value is calculated using GE price."
+    )
+    default boolean useHighAlchemyValue()
+    {
+        return false;
+    }
+
+    @ConfigItem(
+            keyName = "ignoreCoins",
+            name = "Ignore Coins",
+            description = "Ignore coins in inventory. By default, the inventory value includes coins."
+    )
+    default boolean ignoreCoins()
+    {
+        return false;
+    }
+
+    @ConfigItem(
+            keyName = "ignoreItems",
+            name = "Ignore Items",
+            description = "Ignore particular items in inventory. By default, no items are ignored."
+    )
+    default String ignoreItems() { return ""; }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/inventoryvalue/InventoryValueConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/inventoryvalue/InventoryValueConfig.java
@@ -11,8 +11,7 @@ public interface InventoryValueConfig extends Config {
             name = "Use High Alchemy Value",
             description = "Calculate inventory value with High Alchemy. By default, the inventory value is calculated using GE price."
     )
-    default boolean useHighAlchemyValue()
-    {
+    default boolean useHighAlchemyValue() {
         return false;
     }
 
@@ -21,8 +20,7 @@ public interface InventoryValueConfig extends Config {
             name = "Ignore Coins",
             description = "Ignore coins in inventory. By default, the inventory value includes coins."
     )
-    default boolean ignoreCoins()
-    {
+    default boolean ignoreCoins() {
         return false;
     }
 
@@ -31,5 +29,7 @@ public interface InventoryValueConfig extends Config {
             name = "Ignore Items",
             description = "Ignore particular items in inventory. By default, no items are ignored."
     )
-    default String ignoreItems() { return ""; }
+    default String ignoreItems() {
+        return "";
+    }
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/inventoryvalue/InventoryValueOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/inventoryvalue/InventoryValueOverlay.java
@@ -14,43 +14,43 @@ import java.awt.Graphics2D;
 
 
 public class InventoryValueOverlay extends Overlay {
-    private Long inventoryValue;
-    private final InventoryValueConfig inventoryValueConfig;
-    private final PanelComponent panelComponent = new PanelComponent();
+	private Long inventoryValue;
+	private final InventoryValueConfig inventoryValueConfig;
+	private final PanelComponent panelComponent = new PanelComponent();
 
-    @Inject
-    private InventoryValueOverlay(InventoryValueConfig config) {
-        setPosition(OverlayPosition.ABOVE_CHATBOX_RIGHT);
-        this.inventoryValue = 0L;
-        this.inventoryValueConfig = config;
-    }
+	@Inject
+	private InventoryValueOverlay(InventoryValueConfig config) {
+		setPosition(OverlayPosition.ABOVE_CHATBOX_RIGHT);
+		this.inventoryValue = 0L;
+		this.inventoryValueConfig = config;
+	}
 
-    @Override
-    public Dimension render(Graphics2D graphics) {
-        String titleText = "Inventory Value";
-        String valueString = inventoryValueConfig.useHighAlchemyValue() ? "HA Price:" : "GE Price:";
+	@Override
+	public Dimension render(Graphics2D graphics) {
+		String titleText = "Inventory Value";
+		String valueString = inventoryValueConfig.useHighAlchemyValue() ? "HA Price:" : "GE Price:";
 
-        panelComponent.getChildren().clear();
+		panelComponent.getChildren().clear();
 
-        panelComponent.getChildren().add(TitleComponent.builder()
-                .text(titleText)
-                .color(Color.GREEN)
-                .build());
+		panelComponent.getChildren().add(TitleComponent.builder()
+				.text(titleText)
+				.color(Color.GREEN)
+				.build());
 
-        panelComponent.setPreferredSize(new Dimension(
-                graphics.getFontMetrics().stringWidth(titleText) + 30,
-                0
-        ));
+		panelComponent.setPreferredSize(new Dimension(
+				graphics.getFontMetrics().stringWidth(titleText) + 30,
+				0
+		));
 
-        panelComponent.getChildren().add(LineComponent.builder()
-                .left(valueString)
-                .right(Long.toString(inventoryValue))
-                .build());
+		panelComponent.getChildren().add(LineComponent.builder()
+				.left(valueString)
+				.right(Long.toString(inventoryValue))
+				.build());
 
-        return panelComponent.render(graphics);
-    }
+		return panelComponent.render(graphics);
+	}
 
-    public void updateInventoryValue(final long newValue) {
-        SwingUtilities.invokeLater(() -> inventoryValue = newValue);
-    }
+	public void updateInventoryValue(final long newValue) {
+		SwingUtilities.invokeLater(() -> inventoryValue = newValue);
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/inventoryvalue/InventoryValueOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/inventoryvalue/InventoryValueOverlay.java
@@ -13,44 +13,48 @@ import java.awt.Dimension;
 import java.awt.Graphics2D;
 
 
-public class InventoryValueOverlay extends Overlay {
+public class InventoryValueOverlay extends Overlay
+{
 	private Long inventoryValue;
 	private final InventoryValueConfig inventoryValueConfig;
 	private final PanelComponent panelComponent = new PanelComponent();
 
 	@Inject
-	private InventoryValueOverlay(InventoryValueConfig config) {
+	private InventoryValueOverlay(InventoryValueConfig config)
+	{
 		setPosition(OverlayPosition.ABOVE_CHATBOX_RIGHT);
 		this.inventoryValue = 0L;
 		this.inventoryValueConfig = config;
 	}
 
 	@Override
-	public Dimension render(Graphics2D graphics) {
+	public Dimension render(Graphics2D graphics)
+	{
 		String titleText = "Inventory Value";
 		String valueString = inventoryValueConfig.useHighAlchemyValue() ? "HA Price:" : "GE Price:";
 
 		panelComponent.getChildren().clear();
 
 		panelComponent.getChildren().add(TitleComponent.builder()
-				.text(titleText)
-				.color(Color.GREEN)
-				.build());
+			.text(titleText)
+			.color(Color.GREEN)
+			.build());
 
 		panelComponent.setPreferredSize(new Dimension(
-				graphics.getFontMetrics().stringWidth(titleText) + 30,
-				0
+			graphics.getFontMetrics().stringWidth(titleText) + 30,
+			0
 		));
 
 		panelComponent.getChildren().add(LineComponent.builder()
-				.left(valueString)
-				.right(Long.toString(inventoryValue))
-				.build());
+			.left(valueString)
+			.right(Long.toString(inventoryValue))
+			.build());
 
 		return panelComponent.render(graphics);
 	}
 
-	public void updateInventoryValue(final long newValue) {
+	public void updateInventoryValue(final long newValue)
+	{
 		SwingUtilities.invokeLater(() -> inventoryValue = newValue);
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/inventoryvalue/InventoryValueOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/inventoryvalue/InventoryValueOverlay.java
@@ -1,0 +1,56 @@
+package net.runelite.client.plugins.inventoryvalue;
+
+import net.runelite.client.ui.overlay.Overlay;
+import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.components.LineComponent;
+import net.runelite.client.ui.overlay.components.PanelComponent;
+import net.runelite.client.ui.overlay.components.TitleComponent;
+
+import javax.inject.Inject;
+import javax.swing.SwingUtilities;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Graphics2D;
+
+
+public class InventoryValueOverlay extends Overlay {
+    private Long inventoryValue;
+    private final InventoryValueConfig inventoryValueConfig;
+    private final PanelComponent panelComponent = new PanelComponent();
+
+    @Inject
+    private InventoryValueOverlay(InventoryValueConfig config) {
+        setPosition(OverlayPosition.ABOVE_CHATBOX_RIGHT);
+        this.inventoryValue = 0L;
+        this.inventoryValueConfig = config;
+    }
+
+    @Override
+    public Dimension render(Graphics2D graphics) {
+        String titleText = "Inventory Value";
+        String valueString = inventoryValueConfig.useHighAlchemyValue() ? "HA Price:" : "GE Price:";
+
+        panelComponent.getChildren().clear();
+
+        panelComponent.getChildren().add(TitleComponent.builder()
+                .text(titleText)
+                .color(Color.GREEN)
+                .build());
+
+        panelComponent.setPreferredSize(new Dimension(
+                graphics.getFontMetrics().stringWidth(titleText) + 30,
+                0
+        ));
+
+        panelComponent.getChildren().add(LineComponent.builder()
+                .left(valueString)
+                .right(Long.toString(inventoryValue))
+                .build());
+
+        return panelComponent.render(graphics);
+    }
+
+    public void updateInventoryValue(final long newValue) {
+        SwingUtilities.invokeLater(() -> inventoryValue = newValue);
+    }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/inventoryvalue/InventoryValuePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/inventoryvalue/InventoryValuePlugin.java
@@ -25,15 +25,20 @@ import java.util.stream.LongStream;
 @PluginDescriptor(name = "Inventory Value Tracker")
 @Slf4j
 public class InventoryValuePlugin extends Plugin {
-    @Inject private Client client;
+    @Inject
+    private Client client;
 
-    @Inject private InventoryValueConfig config;
+    @Inject
+    private InventoryValueConfig config;
 
-    @Inject private ItemManager itemManager;
+    @Inject
+    private ItemManager itemManager;
 
-    @Inject private OverlayManager overlayManager;
+    @Inject
+    private OverlayManager overlayManager;
 
-    @Inject private InventoryValueOverlay overlay;
+    @Inject
+    private InventoryValueOverlay overlay;
 
     @Override
     protected void startUp() throws Exception {
@@ -46,7 +51,8 @@ public class InventoryValuePlugin extends Plugin {
     }
 
     @Subscribe
-    public void onGameStateChanged(GameStateChanged gameStateChanged) {}
+    public void onGameStateChanged(GameStateChanged gameStateChanged) {
+    }
 
     @Subscribe
     public void onItemContainerChanged(ItemContainerChanged event) {
@@ -76,13 +82,14 @@ public class InventoryValuePlugin extends Plugin {
         ItemComposition itemComposition = itemManager.getItemComposition(itemId);
         String itemName = itemComposition.getName();
 
-        if ((itemId == ItemID.COINS_995 && config.ignoreCoins()) || ignoredItems.contains(itemName.toLowerCase())) return 0;
+        if ((itemId == ItemID.COINS_995 && config.ignoreCoins()) || ignoredItems.contains(itemName.toLowerCase()))
+            return 0;
         return (long) item.getQuantity() * (config.useHighAlchemyValue() ?
                 itemComposition.getHaPrice() : itemManager.getItemPrice(item.getId()));
     }
 
     @Provides
-    InventoryValueConfig provideConfig(ConfigManager configManager){
+    InventoryValueConfig provideConfig(ConfigManager configManager) {
         return configManager.getConfig(InventoryValueConfig.class);
     }
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/inventoryvalue/InventoryValuePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/inventoryvalue/InventoryValuePlugin.java
@@ -24,7 +24,8 @@ import java.util.stream.LongStream;
 
 @PluginDescriptor(name = "Inventory Value Tracker")
 @Slf4j
-public class InventoryValuePlugin extends Plugin {
+public class InventoryValuePlugin extends Plugin
+{
 	@Inject
 	private Client client;
 
@@ -41,55 +42,66 @@ public class InventoryValuePlugin extends Plugin {
 	private InventoryValueOverlay overlay;
 
 	@Override
-	protected void startUp() throws Exception {
+	protected void startUp() throws Exception
+	{
 		overlayManager.add(overlay);
 	}
 
 	@Override
-	protected void shutDown() throws Exception {
+	protected void shutDown() throws Exception
+	{
 		overlayManager.remove(overlay);
 	}
 
 	@Subscribe
-	public void onGameStateChanged(GameStateChanged gameStateChanged) {
+	public void onGameStateChanged(GameStateChanged gameStateChanged)
+	{
 	}
 
 	@Subscribe
-	public void onItemContainerChanged(ItemContainerChanged event) {
-		if (event.getContainerId() == InventoryID.INVENTORY.getId()) {
+	public void onItemContainerChanged(ItemContainerChanged event)
+	{
+		if (event.getContainerId() == InventoryID.INVENTORY.getId())
+		{
 			long inventoryValue;
 			List<String> ignoredItems = buildIgnoredItemsList();
 
 			ItemContainer container = client.getItemContainer(InventoryID.INVENTORY);
-			if (container != null) {
+			if (container != null)
+			{
 				Item[] items = container.getItems();
 				inventoryValue = Arrays.stream(items).parallel().flatMapToLong(item ->
-						LongStream.of(calculateItemValue(item, ignoredItems))).sum();
+					LongStream.of(calculateItemValue(item, ignoredItems))).sum();
 
 				overlay.updateInventoryValue(inventoryValue);
 			}
 		}
 	}
 
-	public List<String> buildIgnoredItemsList() {
+	public List<String> buildIgnoredItemsList()
+	{
 		List<String> ignoredItemsList = Arrays.asList(config.ignoreItems().toLowerCase().split("[,;]"));
 		ignoredItemsList.replaceAll(String::trim);
 		return ignoredItemsList;
 	}
 
-	public long calculateItemValue(Item item, List<String> ignoredItems) {
+	public long calculateItemValue(Item item, List<String> ignoredItems)
+	{
 		int itemId = item.getId();
 		ItemComposition itemComposition = itemManager.getItemComposition(itemId);
 		String itemName = itemComposition.getName();
 
 		if ((itemId == ItemID.COINS_995 && config.ignoreCoins()) || ignoredItems.contains(itemName.toLowerCase()))
+		{
 			return 0;
+		}
 		return (long) item.getQuantity() * (config.useHighAlchemyValue() ?
-				itemComposition.getHaPrice() : itemManager.getItemPrice(item.getId()));
+			itemComposition.getHaPrice() : itemManager.getItemPrice(item.getId()));
 	}
 
 	@Provides
-	InventoryValueConfig provideConfig(ConfigManager configManager) {
+	InventoryValueConfig provideConfig(ConfigManager configManager)
+	{
 		return configManager.getConfig(InventoryValueConfig.class);
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/inventoryvalue/InventoryValuePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/inventoryvalue/InventoryValuePlugin.java
@@ -1,0 +1,88 @@
+package net.runelite.client.plugins.inventoryvalue;
+
+import com.google.inject.Provides;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.Client;
+import net.runelite.api.InventoryID;
+import net.runelite.api.Item;
+import net.runelite.api.ItemComposition;
+import net.runelite.api.ItemContainer;
+import net.runelite.api.ItemID;
+import net.runelite.api.events.GameStateChanged;
+import net.runelite.api.events.ItemContainerChanged;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.eventbus.Subscribe;
+import net.runelite.client.game.ItemManager;
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.ui.overlay.OverlayManager;
+
+import javax.inject.Inject;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.LongStream;
+
+@PluginDescriptor(name = "Inventory Value Tracker")
+@Slf4j
+public class InventoryValuePlugin extends Plugin {
+    @Inject private Client client;
+
+    @Inject private InventoryValueConfig config;
+
+    @Inject private ItemManager itemManager;
+
+    @Inject private OverlayManager overlayManager;
+
+    @Inject private InventoryValueOverlay overlay;
+
+    @Override
+    protected void startUp() throws Exception {
+        overlayManager.add(overlay);
+    }
+
+    @Override
+    protected void shutDown() throws Exception {
+        overlayManager.remove(overlay);
+    }
+
+    @Subscribe
+    public void onGameStateChanged(GameStateChanged gameStateChanged) {}
+
+    @Subscribe
+    public void onItemContainerChanged(ItemContainerChanged event) {
+        if (event.getContainerId() == InventoryID.INVENTORY.getId()) {
+            long inventoryValue;
+            List<String> ignoredItems = buildIgnoredItemsList();
+
+            ItemContainer container = client.getItemContainer(InventoryID.INVENTORY);
+            if (container != null) {
+                Item[] items = container.getItems();
+                inventoryValue = Arrays.stream(items).parallel().flatMapToLong(item ->
+                        LongStream.of(calculateItemValue(item, ignoredItems))).sum();
+
+                overlay.updateInventoryValue(inventoryValue);
+            }
+        }
+    }
+
+    public List<String> buildIgnoredItemsList() {
+        List<String> ignoredItemsList = Arrays.asList(config.ignoreItems().toLowerCase().split("[,;]"));
+        ignoredItemsList.replaceAll(String::trim);
+        return ignoredItemsList;
+    }
+
+    public long calculateItemValue(Item item, List<String> ignoredItems) {
+        int itemId = item.getId();
+        ItemComposition itemComposition = itemManager.getItemComposition(itemId);
+        String itemName = itemComposition.getName();
+
+        if ((itemId == ItemID.COINS_995 && config.ignoreCoins()) || ignoredItems.contains(itemName.toLowerCase())) return 0;
+        return (long) item.getQuantity() * (config.useHighAlchemyValue() ?
+                itemComposition.getHaPrice() : itemManager.getItemPrice(item.getId()));
+    }
+
+    @Provides
+    InventoryValueConfig provideConfig(ConfigManager configManager){
+        return configManager.getConfig(InventoryValueConfig.class);
+    }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/inventoryvalue/InventoryValuePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/inventoryvalue/InventoryValuePlugin.java
@@ -25,71 +25,71 @@ import java.util.stream.LongStream;
 @PluginDescriptor(name = "Inventory Value Tracker")
 @Slf4j
 public class InventoryValuePlugin extends Plugin {
-    @Inject
-    private Client client;
+	@Inject
+	private Client client;
 
-    @Inject
-    private InventoryValueConfig config;
+	@Inject
+	private InventoryValueConfig config;
 
-    @Inject
-    private ItemManager itemManager;
+	@Inject
+	private ItemManager itemManager;
 
-    @Inject
-    private OverlayManager overlayManager;
+	@Inject
+	private OverlayManager overlayManager;
 
-    @Inject
-    private InventoryValueOverlay overlay;
+	@Inject
+	private InventoryValueOverlay overlay;
 
-    @Override
-    protected void startUp() throws Exception {
-        overlayManager.add(overlay);
-    }
+	@Override
+	protected void startUp() throws Exception {
+		overlayManager.add(overlay);
+	}
 
-    @Override
-    protected void shutDown() throws Exception {
-        overlayManager.remove(overlay);
-    }
+	@Override
+	protected void shutDown() throws Exception {
+		overlayManager.remove(overlay);
+	}
 
-    @Subscribe
-    public void onGameStateChanged(GameStateChanged gameStateChanged) {
-    }
+	@Subscribe
+	public void onGameStateChanged(GameStateChanged gameStateChanged) {
+	}
 
-    @Subscribe
-    public void onItemContainerChanged(ItemContainerChanged event) {
-        if (event.getContainerId() == InventoryID.INVENTORY.getId()) {
-            long inventoryValue;
-            List<String> ignoredItems = buildIgnoredItemsList();
+	@Subscribe
+	public void onItemContainerChanged(ItemContainerChanged event) {
+		if (event.getContainerId() == InventoryID.INVENTORY.getId()) {
+			long inventoryValue;
+			List<String> ignoredItems = buildIgnoredItemsList();
 
-            ItemContainer container = client.getItemContainer(InventoryID.INVENTORY);
-            if (container != null) {
-                Item[] items = container.getItems();
-                inventoryValue = Arrays.stream(items).parallel().flatMapToLong(item ->
-                        LongStream.of(calculateItemValue(item, ignoredItems))).sum();
+			ItemContainer container = client.getItemContainer(InventoryID.INVENTORY);
+			if (container != null) {
+				Item[] items = container.getItems();
+				inventoryValue = Arrays.stream(items).parallel().flatMapToLong(item ->
+						LongStream.of(calculateItemValue(item, ignoredItems))).sum();
 
-                overlay.updateInventoryValue(inventoryValue);
-            }
-        }
-    }
+				overlay.updateInventoryValue(inventoryValue);
+			}
+		}
+	}
 
-    public List<String> buildIgnoredItemsList() {
-        List<String> ignoredItemsList = Arrays.asList(config.ignoreItems().toLowerCase().split("[,;]"));
-        ignoredItemsList.replaceAll(String::trim);
-        return ignoredItemsList;
-    }
+	public List<String> buildIgnoredItemsList() {
+		List<String> ignoredItemsList = Arrays.asList(config.ignoreItems().toLowerCase().split("[,;]"));
+		ignoredItemsList.replaceAll(String::trim);
+		return ignoredItemsList;
+	}
 
-    public long calculateItemValue(Item item, List<String> ignoredItems) {
-        int itemId = item.getId();
-        ItemComposition itemComposition = itemManager.getItemComposition(itemId);
-        String itemName = itemComposition.getName();
+	public long calculateItemValue(Item item, List<String> ignoredItems) {
+		int itemId = item.getId();
+		ItemComposition itemComposition = itemManager.getItemComposition(itemId);
+		String itemName = itemComposition.getName();
 
-        if ((itemId == ItemID.COINS_995 && config.ignoreCoins()) || ignoredItems.contains(itemName.toLowerCase()))
-            return 0;
-        return (long) item.getQuantity() * (config.useHighAlchemyValue() ?
-                itemComposition.getHaPrice() : itemManager.getItemPrice(item.getId()));
-    }
+		if ((itemId == ItemID.COINS_995 && config.ignoreCoins()) || ignoredItems.contains(itemName.toLowerCase()))
+			return 0;
+		return (long) item.getQuantity() * (config.useHighAlchemyValue() ?
+				itemComposition.getHaPrice() : itemManager.getItemPrice(item.getId()));
+	}
 
-    @Provides
-    InventoryValueConfig provideConfig(ConfigManager configManager) {
-        return configManager.getConfig(InventoryValueConfig.class);
-    }
+	@Provides
+	InventoryValueConfig provideConfig(ConfigManager configManager) {
+		return configManager.getConfig(InventoryValueConfig.class);
+	}
 }

--- a/runelite-client/src/test/java/net/runelite/client/plugins/inventoryvalue/InventoryValuePluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/inventoryvalue/InventoryValuePluginTest.java
@@ -1,0 +1,152 @@
+package net.runelite.client.plugins.inventoryvalue;
+
+import com.google.inject.Guice;
+import com.google.inject.testing.fieldbinder.Bind;
+import com.google.inject.testing.fieldbinder.BoundFieldModule;
+import net.runelite.api.Client;
+import net.runelite.api.Item;
+import net.runelite.api.ItemComposition;
+import net.runelite.api.ItemContainer;
+import net.runelite.api.ItemID;
+import net.runelite.client.game.ItemManager;
+import net.runelite.client.ui.overlay.OverlayManager;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import javax.inject.Inject;
+import java.io.File;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class InventoryValuePluginTest {
+    @Mock
+    @Bind
+    private Client client;
+
+    @Mock
+    @Bind
+    private ItemManager itemManager;
+
+    @Mock
+    @Bind
+    private InventoryValueConfig config;
+
+    @Mock
+    @Bind
+    private OverlayManager overlayManager;
+
+    @Mock
+    @Bind
+    private ScheduledExecutorService executor;
+
+    @Mock
+    private File file;
+
+
+    @Inject
+    InventoryValuePlugin inventoryValuePlugin;
+
+    @Mock
+    ItemContainer itemContainer;
+
+    @Mock
+    ItemComposition itemComposition;
+
+    Item coins;
+    Item testItem;
+
+    String ignoredItemsConfig;
+    List<String> ignoredItemsList;
+    int itemId;
+    int quantity;
+
+    @Before
+    public void before() {
+        Guice.createInjector(BoundFieldModule.of(this)).injectMembers(this);
+    }
+
+    @Test
+    public void testBuildIgnoredItemsList() {
+        // split on comma, ignore leading whitespace
+        String ignoreItemsString = "foo, bar";
+        when(config.ignoreItems()).thenReturn(ignoreItemsString);
+
+        assertEquals(Arrays.asList("foo", "bar"), inventoryValuePlugin.buildIgnoredItemsList());
+
+        // split on comma or semicolon, ignore trailing whitespace
+        String ignoreItemsStringWithSemicolon = "foo,bar;baz ";
+        when(config.ignoreItems()).thenReturn(ignoreItemsStringWithSemicolon);
+
+        assertEquals(Arrays.asList("foo", "bar", "baz"), inventoryValuePlugin.buildIgnoredItemsList());
+
+        String ignoreItemsStringWithCasing = "FOo, BaR; BAZ";
+        when(config.ignoreItems()).thenReturn(ignoreItemsStringWithCasing);
+
+        assertEquals(Arrays.asList("foo", "bar", "baz"), inventoryValuePlugin.buildIgnoredItemsList());
+    }
+
+    public void coinsValueTestSetup() {
+        itemId = ItemID.COINS_995;
+        quantity = 3201;
+        coins = new Item(itemId, quantity);
+        ignoredItemsList = Collections.emptyList();
+
+        when(itemComposition.getName()).thenReturn("Coins");
+        when(itemManager.getItemPrice(itemId)).thenReturn(1);
+        when(itemManager.getItemComposition(itemId)).thenReturn(itemComposition);
+    }
+
+    @Test
+    public void testCoinsIgnoredWhenIgnoreCoinsIsSet() {
+        coinsValueTestSetup();
+
+        when(config.ignoreCoins()).thenReturn(true);
+
+        assertEquals(0, inventoryValuePlugin.calculateItemValue(coins, ignoredItemsList));
+    }
+
+    @Test
+    public void testCoinsNotIgnoredWhenIgnoreCoinsIsNotSet() {
+        coinsValueTestSetup();
+
+        when(config.ignoreCoins()).thenReturn(false);
+
+        assertEquals(quantity, inventoryValuePlugin.calculateItemValue(coins, ignoredItemsList));
+    }
+
+    public void ignoreItemTestSetup(int itemId, String itemName, int itemValue) {
+        quantity = 1;
+        testItem = new Item(itemId, quantity);
+        ignoredItemsConfig = "Bottomless compost bucket, Leather chaps";
+        ignoredItemsList = Arrays.asList("bottomless compost bucket", "leather chaps");
+
+        when(itemComposition.getName()).thenReturn(itemName);
+        when(itemManager.getItemPrice(itemId)).thenReturn(itemValue);
+        when(itemManager.getItemComposition(itemId)).thenReturn(itemComposition);
+    }
+
+    @Test
+    public void testItemNotIgnoredWhenNotInIgnoredItems() {
+        int testItemValue = 40000000;
+        ignoreItemTestSetup(ItemID.SARADOMIN_GODSWORD, "Saradomin godsword", testItemValue);
+
+        assertEquals(testItemValue, inventoryValuePlugin.calculateItemValue(testItem, ignoredItemsList));
+    }
+
+    @Test
+    public void testItemIgnoredWhenInIgnoredItems() {
+        int testItemValue = 300000;
+        ignoreItemTestSetup(ItemID.BOTTOMLESS_COMPOST_BUCKET, "Bottomless compost bucket", testItemValue);
+
+        assertEquals(0, inventoryValuePlugin.calculateItemValue(testItem, ignoredItemsList));
+    }
+}

--- a/runelite-client/src/test/java/net/runelite/client/plugins/inventoryvalue/InventoryValuePluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/inventoryvalue/InventoryValuePluginTest.java
@@ -27,7 +27,8 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
-public class InventoryValuePluginTest {
+public class InventoryValuePluginTest
+{
 	@Mock
 	@Bind
 	private Client client;
@@ -70,12 +71,14 @@ public class InventoryValuePluginTest {
 	int quantity;
 
 	@Before
-	public void before() {
+	public void before()
+	{
 		Guice.createInjector(BoundFieldModule.of(this)).injectMembers(this);
 	}
 
 	@Test
-	public void testBuildIgnoredItemsList() {
+	public void testBuildIgnoredItemsList()
+	{
 		// split on comma, ignore leading whitespace
 		String ignoreItemsString = "foo, bar";
 		when(config.ignoreItems()).thenReturn(ignoreItemsString);
@@ -94,7 +97,8 @@ public class InventoryValuePluginTest {
 		assertEquals(Arrays.asList("foo", "bar", "baz"), inventoryValuePlugin.buildIgnoredItemsList());
 	}
 
-	public void coinsValueTestSetup() {
+	public void coinsValueTestSetup()
+	{
 		itemId = ItemID.COINS_995;
 		quantity = 3201;
 		coins = new Item(itemId, quantity);
@@ -106,7 +110,8 @@ public class InventoryValuePluginTest {
 	}
 
 	@Test
-	public void testCoinsIgnoredWhenIgnoreCoinsIsSet() {
+	public void testCoinsIgnoredWhenIgnoreCoinsIsSet()
+	{
 		coinsValueTestSetup();
 
 		when(config.ignoreCoins()).thenReturn(true);
@@ -115,7 +120,8 @@ public class InventoryValuePluginTest {
 	}
 
 	@Test
-	public void testCoinsNotIgnoredWhenIgnoreCoinsIsNotSet() {
+	public void testCoinsNotIgnoredWhenIgnoreCoinsIsNotSet()
+	{
 		coinsValueTestSetup();
 
 		when(config.ignoreCoins()).thenReturn(false);
@@ -123,7 +129,8 @@ public class InventoryValuePluginTest {
 		assertEquals(quantity, inventoryValuePlugin.calculateItemValue(coins, ignoredItemsList));
 	}
 
-	public void ignoreItemTestSetup(int itemId, String itemName, int itemValue) {
+	public void ignoreItemTestSetup(int itemId, String itemName, int itemValue)
+	{
 		quantity = 1;
 		testItem = new Item(itemId, quantity);
 		ignoredItemsConfig = "Bottomless compost bucket, Leather chaps";
@@ -135,7 +142,8 @@ public class InventoryValuePluginTest {
 	}
 
 	@Test
-	public void testItemNotIgnoredWhenNotInIgnoredItems() {
+	public void testItemNotIgnoredWhenNotInIgnoredItems()
+	{
 		int testItemValue = 40000000;
 		ignoreItemTestSetup(ItemID.SARADOMIN_GODSWORD, "Saradomin godsword", testItemValue);
 
@@ -143,7 +151,8 @@ public class InventoryValuePluginTest {
 	}
 
 	@Test
-	public void testItemIgnoredWhenInIgnoredItems() {
+	public void testItemIgnoredWhenInIgnoredItems()
+	{
 		int testItemValue = 300000;
 		ignoreItemTestSetup(ItemID.BOTTOMLESS_COMPOST_BUCKET, "Bottomless compost bucket", testItemValue);
 

--- a/runelite-client/src/test/java/net/runelite/client/plugins/inventoryvalue/InventoryValuePluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/inventoryvalue/InventoryValuePluginTest.java
@@ -28,125 +28,125 @@ import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class InventoryValuePluginTest {
-    @Mock
-    @Bind
-    private Client client;
+	@Mock
+	@Bind
+	private Client client;
 
-    @Mock
-    @Bind
-    private ItemManager itemManager;
+	@Mock
+	@Bind
+	private ItemManager itemManager;
 
-    @Mock
-    @Bind
-    private InventoryValueConfig config;
+	@Mock
+	@Bind
+	private InventoryValueConfig config;
 
-    @Mock
-    @Bind
-    private OverlayManager overlayManager;
+	@Mock
+	@Bind
+	private OverlayManager overlayManager;
 
-    @Mock
-    @Bind
-    private ScheduledExecutorService executor;
+	@Mock
+	@Bind
+	private ScheduledExecutorService executor;
 
-    @Mock
-    private File file;
+	@Mock
+	private File file;
 
 
-    @Inject
-    InventoryValuePlugin inventoryValuePlugin;
+	@Inject
+	InventoryValuePlugin inventoryValuePlugin;
 
-    @Mock
-    ItemContainer itemContainer;
+	@Mock
+	ItemContainer itemContainer;
 
-    @Mock
-    ItemComposition itemComposition;
+	@Mock
+	ItemComposition itemComposition;
 
-    Item coins;
-    Item testItem;
+	Item coins;
+	Item testItem;
 
-    String ignoredItemsConfig;
-    List<String> ignoredItemsList;
-    int itemId;
-    int quantity;
+	String ignoredItemsConfig;
+	List<String> ignoredItemsList;
+	int itemId;
+	int quantity;
 
-    @Before
-    public void before() {
-        Guice.createInjector(BoundFieldModule.of(this)).injectMembers(this);
-    }
+	@Before
+	public void before() {
+		Guice.createInjector(BoundFieldModule.of(this)).injectMembers(this);
+	}
 
-    @Test
-    public void testBuildIgnoredItemsList() {
-        // split on comma, ignore leading whitespace
-        String ignoreItemsString = "foo, bar";
-        when(config.ignoreItems()).thenReturn(ignoreItemsString);
+	@Test
+	public void testBuildIgnoredItemsList() {
+		// split on comma, ignore leading whitespace
+		String ignoreItemsString = "foo, bar";
+		when(config.ignoreItems()).thenReturn(ignoreItemsString);
 
-        assertEquals(Arrays.asList("foo", "bar"), inventoryValuePlugin.buildIgnoredItemsList());
+		assertEquals(Arrays.asList("foo", "bar"), inventoryValuePlugin.buildIgnoredItemsList());
 
-        // split on comma or semicolon, ignore trailing whitespace
-        String ignoreItemsStringWithSemicolon = "foo,bar;baz ";
-        when(config.ignoreItems()).thenReturn(ignoreItemsStringWithSemicolon);
+		// split on comma or semicolon, ignore trailing whitespace
+		String ignoreItemsStringWithSemicolon = "foo,bar;baz ";
+		when(config.ignoreItems()).thenReturn(ignoreItemsStringWithSemicolon);
 
-        assertEquals(Arrays.asList("foo", "bar", "baz"), inventoryValuePlugin.buildIgnoredItemsList());
+		assertEquals(Arrays.asList("foo", "bar", "baz"), inventoryValuePlugin.buildIgnoredItemsList());
 
-        String ignoreItemsStringWithCasing = "FOo, BaR; BAZ";
-        when(config.ignoreItems()).thenReturn(ignoreItemsStringWithCasing);
+		String ignoreItemsStringWithCasing = "FOo, BaR; BAZ";
+		when(config.ignoreItems()).thenReturn(ignoreItemsStringWithCasing);
 
-        assertEquals(Arrays.asList("foo", "bar", "baz"), inventoryValuePlugin.buildIgnoredItemsList());
-    }
+		assertEquals(Arrays.asList("foo", "bar", "baz"), inventoryValuePlugin.buildIgnoredItemsList());
+	}
 
-    public void coinsValueTestSetup() {
-        itemId = ItemID.COINS_995;
-        quantity = 3201;
-        coins = new Item(itemId, quantity);
-        ignoredItemsList = Collections.emptyList();
+	public void coinsValueTestSetup() {
+		itemId = ItemID.COINS_995;
+		quantity = 3201;
+		coins = new Item(itemId, quantity);
+		ignoredItemsList = Collections.emptyList();
 
-        when(itemComposition.getName()).thenReturn("Coins");
-        when(itemManager.getItemPrice(itemId)).thenReturn(1);
-        when(itemManager.getItemComposition(itemId)).thenReturn(itemComposition);
-    }
+		when(itemComposition.getName()).thenReturn("Coins");
+		when(itemManager.getItemPrice(itemId)).thenReturn(1);
+		when(itemManager.getItemComposition(itemId)).thenReturn(itemComposition);
+	}
 
-    @Test
-    public void testCoinsIgnoredWhenIgnoreCoinsIsSet() {
-        coinsValueTestSetup();
+	@Test
+	public void testCoinsIgnoredWhenIgnoreCoinsIsSet() {
+		coinsValueTestSetup();
 
-        when(config.ignoreCoins()).thenReturn(true);
+		when(config.ignoreCoins()).thenReturn(true);
 
-        assertEquals(0, inventoryValuePlugin.calculateItemValue(coins, ignoredItemsList));
-    }
+		assertEquals(0, inventoryValuePlugin.calculateItemValue(coins, ignoredItemsList));
+	}
 
-    @Test
-    public void testCoinsNotIgnoredWhenIgnoreCoinsIsNotSet() {
-        coinsValueTestSetup();
+	@Test
+	public void testCoinsNotIgnoredWhenIgnoreCoinsIsNotSet() {
+		coinsValueTestSetup();
 
-        when(config.ignoreCoins()).thenReturn(false);
+		when(config.ignoreCoins()).thenReturn(false);
 
-        assertEquals(quantity, inventoryValuePlugin.calculateItemValue(coins, ignoredItemsList));
-    }
+		assertEquals(quantity, inventoryValuePlugin.calculateItemValue(coins, ignoredItemsList));
+	}
 
-    public void ignoreItemTestSetup(int itemId, String itemName, int itemValue) {
-        quantity = 1;
-        testItem = new Item(itemId, quantity);
-        ignoredItemsConfig = "Bottomless compost bucket, Leather chaps";
-        ignoredItemsList = Arrays.asList("bottomless compost bucket", "leather chaps");
+	public void ignoreItemTestSetup(int itemId, String itemName, int itemValue) {
+		quantity = 1;
+		testItem = new Item(itemId, quantity);
+		ignoredItemsConfig = "Bottomless compost bucket, Leather chaps";
+		ignoredItemsList = Arrays.asList("bottomless compost bucket", "leather chaps");
 
-        when(itemComposition.getName()).thenReturn(itemName);
-        when(itemManager.getItemPrice(itemId)).thenReturn(itemValue);
-        when(itemManager.getItemComposition(itemId)).thenReturn(itemComposition);
-    }
+		when(itemComposition.getName()).thenReturn(itemName);
+		when(itemManager.getItemPrice(itemId)).thenReturn(itemValue);
+		when(itemManager.getItemComposition(itemId)).thenReturn(itemComposition);
+	}
 
-    @Test
-    public void testItemNotIgnoredWhenNotInIgnoredItems() {
-        int testItemValue = 40000000;
-        ignoreItemTestSetup(ItemID.SARADOMIN_GODSWORD, "Saradomin godsword", testItemValue);
+	@Test
+	public void testItemNotIgnoredWhenNotInIgnoredItems() {
+		int testItemValue = 40000000;
+		ignoreItemTestSetup(ItemID.SARADOMIN_GODSWORD, "Saradomin godsword", testItemValue);
 
-        assertEquals(testItemValue, inventoryValuePlugin.calculateItemValue(testItem, ignoredItemsList));
-    }
+		assertEquals(testItemValue, inventoryValuePlugin.calculateItemValue(testItem, ignoredItemsList));
+	}
 
-    @Test
-    public void testItemIgnoredWhenInIgnoredItems() {
-        int testItemValue = 300000;
-        ignoreItemTestSetup(ItemID.BOTTOMLESS_COMPOST_BUCKET, "Bottomless compost bucket", testItemValue);
+	@Test
+	public void testItemIgnoredWhenInIgnoredItems() {
+		int testItemValue = 300000;
+		ignoreItemTestSetup(ItemID.BOTTOMLESS_COMPOST_BUCKET, "Bottomless compost bucket", testItemValue);
 
-        assertEquals(0, inventoryValuePlugin.calculateItemValue(testItem, ignoredItemsList));
-    }
+		assertEquals(0, inventoryValuePlugin.calculateItemValue(testItem, ignoredItemsList));
+	}
 }


### PR DESCRIPTION
Original plugin by @wikiworm: https://github.com/wikiworm/InventoryValue

Inventory Value 

Displays the current inventory value in an overlay.

Configuration options:
ignoreCoins -- coins will no longer be shown in total value
useHaValue -- use the high alchemy value of an item instead of the GE price
ignoreItems -- list of item names, case-insensitive, delimited by either comma or semicolon

![image](https://user-images.githubusercontent.com/5294864/102701144-eea3d380-4221-11eb-9b66-bbb6d91408b3.png)

Allows a user to see value fluctuation in a farm run, supplies used vs drops gained, and many other scenarios.

![image](https://user-images.githubusercontent.com/5294864/102701170-33c80580-4222-11eb-92f3-a1efebc0e8a8.png)


With the addition of the ignoreItems configuration, items in your inventory used for a kill which are not consumable can be ignored, allowing an easier tally of the overall gp gain from a trip.
![image](https://user-images.githubusercontent.com/5294864/102701261-2b23ff00-4223-11eb-97c6-0ccc197d2896.png)

![image](https://user-images.githubusercontent.com/5294864/102701219-a802a900-4222-11eb-9aa7-6d5424ca0d47.png)
