### PR TITLE
Add "scorched" Lletya regionID recognition to TimeTracking and Discord plugins

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordGameEventType.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordGameEventType.java
@@ -121,7 +121,7 @@ enum DiscordGameEventType
 	CITY_JATIZSO("Jatizso" , DiscordAreaType.CITIES, 9531),
 	CITY_KELDAGRIM("Keldagrim" , DiscordAreaType.CITIES, 11423, 11422, 11679, 11678),
 	CITY_LANDS_END("Land's End", DiscordAreaType.CITIES, 5941),
-	CITY_LLETYA("Lletya" , DiscordAreaType.CITIES, 9265),
+	CITY_LLETYA("Lletya" , DiscordAreaType.CITIES, 9265, 11103),
 	CITY_LOVAKENGJ_HOUSE("Lovakengj" , DiscordAreaType.CITIES, 5692, 5691, 5947, 6203, 6202, 5690, 5946),
 	CITY_LUMBRIDGE("Lumbridge" , DiscordAreaType.CITIES, 12850),
 	CITY_LUNAR_ISLE("Lunar Isle" , DiscordAreaType.CITIES, 8253, 8252, 8509, 8508),

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/farming/FarmingWorld.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/farming/FarmingWorld.java
@@ -193,7 +193,7 @@ class FarmingWorld
 
 		add(new FarmingRegion("Lletya", 9265,
 			new FarmingPatch("", Varbits.FARMING_4771, PatchImplementation.FRUIT_TREE)
-		));
+		), 11103);
 
 		add(new FarmingRegion("Lumbridge", 12851,
 			new FarmingPatch("", Varbits.FARMING_4771, PatchImplementation.HOPS)


### PR DESCRIPTION
Fixes https://github.com/runelite/runelite/issues/12787. 

From the issue:
> I am far enough along in Song of the Elves that Lletya has been attacked, and is "scorched". Without completing the quest, I have planted a palm tree in the fruit tree patch there, but it is not timed in the Time Tracking plugin.
> [...] when passing through the tree entrance to Lletya, your character is warped from region 9265 on the left side, to region 11103 on the right side.

This patch adds recognition for region 11103, so that players who are partially through Song of the Elves still have their fruit tree timers accurately tracked.