### PR TITLE
Add Low/High Energy notifications to idle notifier

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierConfig.java
@@ -27,6 +27,7 @@ package net.runelite.client.plugins.idlenotifier;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.Range;
 import net.runelite.client.config.Units;
 
 @ConfigGroup("idlenotifier")
@@ -111,9 +112,35 @@ public interface IdleNotifierConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "lowEnergy",
+		name = "Low Energy Threshold",
+		description = "The amount of energy points remaining to send a notification at. A value of 100 will disable notification.",
+		position = 8
+	)
+	@Units(Units.PERCENT)
+	@Range(max = 100)
+	default int getLowEnergyThreshold()
+	{
+		return 100;
+	}
+
+	@ConfigItem(
+		keyName = "highEnergy",
+		name = "High Energy Threshold",
+		description = "The amount of energy points reached to send a notification. A value of 0 will disable notification.",
+		position = 9
+	)
+	@Units(Units.PERCENT)
+	@Range(max = 100)
+	default int getHighEnergyThreshold()
+	{
+		return 0;
+	}
+
+	@ConfigItem(
 		keyName = "oxygen",
 		name = "Oxygen Threshold",
-		position = 8,
+		position = 10,
 		description = "The amount of remaining oxygen to send a notification at. A value of 0 will disable notification."
 	)
 	@Units(Units.PERCENT)
@@ -125,7 +152,7 @@ public interface IdleNotifierConfig extends Config
 	@ConfigItem(
 		keyName = "spec",
 		name = "Spec Threshold",
-		position = 9,
+		position = 11,
 		description = "The amount of special attack energy reached to send a notification at. A value of 0 will disable notification."
 	)
 	@Units(Units.PERCENT)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
@@ -93,6 +93,8 @@ public class IdleNotifierPlugin extends Plugin
 	private boolean notifyPosition = false;
 	private boolean notifyHitpoints = true;
 	private boolean notifyPrayer = true;
+	private boolean shouldNotifyLowEnergy = false;
+	private boolean shouldNotifyHighEnergy = false;
 	private boolean notifyOxygen = true;
 	private boolean notifyIdleLogout = true;
 	private boolean notify6HourLogout = true;
@@ -471,6 +473,16 @@ public class IdleNotifierPlugin extends Plugin
 			notifier.notify("[" + local.getName() + "] has low prayer!");
 		}
 
+		if (checkLowEnergy())
+		{
+			notifier.notify("[" + local.getName() + "] has low run energy!");
+		}
+
+		if (checkHighEnergy())
+		{
+			notifier.notify("[" + local.getName() + "] has restored run energy!");
+		}
+
 		if (checkLowOxygen())
 		{
 			notifier.notify("[" + local.getName() + "] has low oxygen!");
@@ -567,6 +579,52 @@ public class IdleNotifierPlugin extends Plugin
 			{
 				notifyPrayer = false;
 			}
+		}
+
+		return false;
+	}
+
+	private boolean checkLowEnergy()
+	{
+		if (config.getLowEnergyThreshold() >= 100)
+		{
+			return false;
+		}
+
+		if (client.getEnergy() <= config.getLowEnergyThreshold())
+		{
+			if (shouldNotifyLowEnergy)
+			{
+				shouldNotifyLowEnergy = false;
+				return true;
+			}
+		}
+		else
+		{
+			shouldNotifyLowEnergy = true;
+		}
+
+		return false;
+	}
+
+	private boolean checkHighEnergy()
+	{
+		if (config.getHighEnergyThreshold() == 0)
+		{
+			return false;
+		}
+
+		if (client.getEnergy() >= config.getHighEnergyThreshold())
+		{
+			if (shouldNotifyHighEnergy)
+			{
+				shouldNotifyHighEnergy = false;
+				return true;
+			}
+		}
+		else
+		{
+			shouldNotifyHighEnergy = true;
 		}
 
 		return false;


### PR DESCRIPTION
This is a redo of PR #3069.

It seems the code was good, the only thing that was outdated would have been the config positions conflicting with other fields added over time.

I took the liberty to add an energy regen notification to accompany the low energy one.

Closes #3057