### PR TITLE
Add Maven Assembly plugin to pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -263,6 +263,29 @@
 					</execution>
 				</executions>
 			</plugin>
+			<plugin>
+				<artifactId>maven-assembly-plugin</artifactId>
+				<version>3.3.0</version>
+				<configuration>
+					<descriptorRefs>
+						<descriptorRef>jar-with-dependencies</descriptorRef>
+					</descriptorRefs>
+					<archive>
+						<manifest>
+							<mainClass>net.runelite.client.RuneLite</mainClass>
+						</manifest>
+					</archive>
+				</configuration>
+				<executions>
+					<execution>
+						<id>make-assembly</id> <!-- this is used for inheritance merges -->
+						<phase>package</phase> <!-- bind to the packaging phase -->
+						<goals>
+							<goal>single</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 		<pluginManagement>
 			<plugins>


### PR DESCRIPTION
Add Maven assembly plugin to Runelite.

This adds an extra step when creating the Runelite Jar file. The extra step creates a "fat" jar i.e. a jar which contains runelite and all of its dependencies.

This will allow developers to easily run Runelite locally from the generated jar following a build.