### PR TITLE
Add ability to specify worlds to skip when quick-hopping

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldHopperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldHopperConfig.java
@@ -146,4 +146,23 @@ public interface WorldHopperConfig extends Config
 	{
 		return false;
 	}
+
+	@ConfigItem(
+		keyName = "skippedWorlds",
+		name = "Skipped Worlds",
+		description = "Configures worlds to skip when quick-hopping. Format: (world),",
+		position = 10
+	)
+	default String getSkippedWorlds()
+	{
+		return "";
+	}
+
+	@ConfigItem(
+		keyName = "skippedWorlds",
+		name = "",
+		description = ""
+	)
+	void setSkippedWorlds(String key);
+
 }


### PR DESCRIPTION
Issue #12941 

Added a text box to the world hopper config where users can list comma-separated world numbers to skip when quick-hopping.