### PR TITLE
Item Stats: Fix Anglerfish boost heal in wilderness

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/food/Anglerfish.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/food/Anglerfish.java
@@ -25,21 +25,36 @@
 package net.runelite.client.plugins.itemstats.food;
 
 import net.runelite.api.Client;
+import net.runelite.api.Varbits;
 import net.runelite.client.plugins.itemstats.FoodBase;
+
+import javax.inject.Inject;
 
 public class Anglerfish extends FoodBase
 {
+	@Inject
+	private Client client;
+
 	public Anglerfish()
 	{
-		setBoost(true);
+
 	}
 
 	@Override
 	public int heals(Client client)
 	{
 		int maxHP = getStat().getMaximum(client);
-
 		int C;
+
+		if (client.getVar(Varbits.IN_WILDERNESS) == 1)
+		{
+			setBoost(false);
+		}
+		else
+		{
+			setBoost(true);
+		}
+
 		if (maxHP <= 24)
 		{
 			C = 2;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/food/Anglerfish.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/food/Anglerfish.java
@@ -28,18 +28,8 @@ import net.runelite.api.Client;
 import net.runelite.api.Varbits;
 import net.runelite.client.plugins.itemstats.FoodBase;
 
-import javax.inject.Inject;
-
 public class Anglerfish extends FoodBase
 {
-	@Inject
-	private Client client;
-
-	public Anglerfish()
-	{
-
-	}
-
 	@Override
 	public int heals(Client client)
 	{


### PR DESCRIPTION
Fixes tooltip bug with anglerfish showing that a boosted heal is possible in the wilderness when it's not.