### PR TITLE
ChatboxTextInput: Improve open selection left/right handling

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/game/chatbox/ChatboxTextInput.java
+++ b/runelite-client/src/main/java/net/runelite/client/game/chatbox/ChatboxTextInput.java
@@ -753,11 +753,25 @@ public class ChatboxTextInput extends ChatboxInput implements KeyListener, Mouse
 				return;
 			case KeyEvent.VK_LEFT:
 				ev.consume();
-				newPos--;
+				if (cursorStart != cursorEnd)
+				{
+					newPos = cursorStart;
+				}
+				else
+				{
+					newPos--;
+				}
 				break;
 			case KeyEvent.VK_RIGHT:
 				ev.consume();
-				newPos++;
+				if (cursorStart != cursorEnd)
+				{
+					newPos = cursorEnd;
+				}
+				else
+				{
+					newPos++;
+				}
 				break;
 			case KeyEvent.VK_UP:
 				ev.consume();


### PR DESCRIPTION
Previously, when pressing left or right without Shift pressed, the
cursor would end up one character left or right of the start of the
selection, which is not expected behavior compared to how most programs
handle this case. This commit changes this behavior to place the cursor
at the start or end of the selection when pressing left or right,
respectively, when a selection is active.