### PR TITLE
itemstats: Add Soul Wars Potion of Power and Bandages

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatChanges.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatChanges.java
@@ -214,6 +214,10 @@ public class ItemStatChanges
 		add(heal(HITPOINTS, 20), PADDLEFISH);
 		add(new GauntletPotion(), EGNIOL_POTION_1, EGNIOL_POTION_2, EGNIOL_POTION_3, EGNIOL_POTION_4);
 
+		// Soul Wars
+		add(combo(2, heal(HITPOINTS, perc(.20, 2)), heal(RUN_ENERGY, 100)), BANDAGES_25202);
+		add(combo(6, boost(ATTACK, perc(.15, 5)), boost(STRENGTH, perc(.15, 5)), boost(DEFENCE, perc(.15, 5)), boost(RANGED, perc(.15, 5)), boost(MAGIC, perc(.15, 5)), heal(PRAYER, perc(.25, 8))), POTION_OF_POWER1, POTION_OF_POWER2, POTION_OF_POWER3, POTION_OF_POWER4);
+
 		log.debug("{} items; {} behaviours loaded", effects.size(), new HashSet<>(effects.values()).size());
 	}
 


### PR DESCRIPTION
The new potions in Soul Wars act as a Super Combat/Range/Magic potion as well as have the prayer restore properties of a Super Restore. The bandages heal 20% + 2 and restore 100% run energy.

![java_sUw9hWqOos](https://user-images.githubusercontent.com/54762282/104062810-1b1b9180-51c9-11eb-8318-11775ce95dfe.png)
