### PR TITLE
chatcommands: Add Soul Wars Zeal command (!sw)

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsConfig.java
@@ -168,6 +168,17 @@ public interface ChatCommandsConfig extends Config
 
 	@ConfigItem(
 		position = 12,
+		keyName = "sw",
+		name = "SW Command",
+		description = "Configures whether the Soul Wars Zeal command is enabled<br> !sw"
+	)
+	default boolean sw()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		position = 13,
 		keyName = "clearSingleWord",
 		name = "Clear Single Word",
 		description = "Enable hot key to clear single word at a time"
@@ -178,7 +189,7 @@ public interface ChatCommandsConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 13,
+		position = 14,
 		keyName = "clearEntireChatBox",
 		name = "Clear Chat Box",
 		description = "Enable hotkey to clear entire chat box"

--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
@@ -127,6 +127,7 @@ public class ChatCommandsPlugin extends Plugin
 	private static final String GC_COMMAND_STRING = "!gc";
 	private static final String DUEL_ARENA_COMMAND = "!duels";
 	private static final String LEAGUE_POINTS_COMMAND = "!lp";
+	private static final String SOUL_WARS_ZEAL_COMMAND = "!sw";
 
 	@VisibleForTesting
 	static final int ADV_LOG_EXPLOITS_TEXT_INDEX = 1;
@@ -192,6 +193,7 @@ public class ChatCommandsPlugin extends Plugin
 		chatCommandManager.registerCommandAsync(PB_COMMAND, this::personalBestLookup, this::personalBestSubmit);
 		chatCommandManager.registerCommandAsync(GC_COMMAND_STRING, this::gambleCountLookup, this::gambleCountSubmit);
 		chatCommandManager.registerCommandAsync(DUEL_ARENA_COMMAND, this::duelArenaLookup, this::duelArenaSubmit);
+		chatCommandManager.registerCommandAsync(SOUL_WARS_ZEAL_COMMAND, this::soulWarsZealLookup);
 	}
 
 	@Override
@@ -216,6 +218,7 @@ public class ChatCommandsPlugin extends Plugin
 		chatCommandManager.unregisterCommand(PB_COMMAND);
 		chatCommandManager.unregisterCommand(GC_COMMAND_STRING);
 		chatCommandManager.unregisterCommand(DUEL_ARENA_COMMAND);
+		chatCommandManager.unregisterCommand(SOUL_WARS_ZEAL_COMMAND);
 	}
 
 	@Provides
@@ -1259,6 +1262,16 @@ public class ChatCommandsPlugin extends Plugin
 		minigameLookup(chatMessage, HiscoreSkill.LAST_MAN_STANDING);
 	}
 
+	private void soulWarsZealLookup(ChatMessage chatMessage, String message)
+	{
+		if (!config.sw())
+		{
+			return;
+		}
+
+		minigameLookup(chatMessage, HiscoreSkill.SOUL_WARS_ZEAL);
+	}
+
 	private void minigameLookup(ChatMessage chatMessage, HiscoreSkill minigame)
 	{
 		try
@@ -1292,6 +1305,9 @@ public class ChatCommandsPlugin extends Plugin
 					break;
 				case LEAGUE_POINTS:
 					hiscoreSkill = result.getLeaguePoints();
+					break;
+				case SOUL_WARS_ZEAL:
+					hiscoreSkill = result.getSoulWarsZeal();
 					break;
 				default:
 					log.warn("error looking up {} score: not implemented", minigame.getName().toLowerCase());


### PR DESCRIPTION
Currently many people have been using `!lvl soul_wars_zeal`, which isn't exactly the easiest to type, and due to it being recognized as a skill, the output incorrectly displays it as such. 

This commit adds the `!sw` command to more easily and appopriately display one's Soul Wars Zeal and rank.

![image](https://user-images.githubusercontent.com/54762282/104400289-429f9080-5520-11eb-8340-01a6987f6e6d.png)
