### PR TITLE
Added "Preset World Cycle List" to the RuneLite world hopper 

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldHopperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldHopperConfig.java
@@ -146,4 +146,20 @@ public interface WorldHopperConfig extends Config
 	{
 		return false;
 	}
+
+	@ConfigItem(
+		keyName = "presetWorldCycleList",
+		name = "Preset World Cycle List",
+		description = "Set a custom world cycle list to hop between too<br>Separate each world by commas<br>Example: 428,415,etc...",
+		position = 10
+	)
+	default String presetWorldCycleList() { return ""; }
+
+	@ConfigItem(
+			keyName = "blade",
+			name = "Blade",
+			description = "Blade",
+			position = 11
+	)
+	default String blade() { return "Nino & chat are my sensei"; }
 }


### PR DESCRIPTION
Added the "Preset World Cycle List" option to the worldhopper.
Originally made by "losingticks" for BlueLite.

You can enter a list of worlds separated by a comma which you can then loop through.

See screenshot below.
![image](https://user-images.githubusercontent.com/52164618/104507245-c0c66a80-55e6-11eb-9469-8218ef9a534c.png)
