### PR TITLE
Add item requirement filtering for skill challenge clues

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/ClueScrollPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/ClueScrollPlugin.java
@@ -1156,6 +1156,18 @@ public class ClueScrollPlugin extends Plugin
 
 			return mapClue.getObjectId() == -1 && itemId == ItemID.SPADE;
 		}
+		else if (c instanceof SkillChallengeClue)
+		{
+			SkillChallengeClue challengeClue = (SkillChallengeClue) c;
+
+			for (ItemRequirement ir : challengeClue.getItemRequirements())
+			{
+				if (ir.fulfilledBy(itemId))
+				{
+					return true;
+				}
+			}
+		}
 
 		return false;
 	}


### PR DESCRIPTION
Skill challenge clues, although they have item requirements, are not currently filtered by the `clue` bank tag.

A more proper fix might be to create an interface for clue scrolls to implement, like `ItemRequiringClueScroll` or something. Let me know if you'd prefer that.