### PR TITLE
Fix incorrect named value when storing FlatStorage caches

### DIFF
--- a/cache/src/main/java/net/runelite/cache/fs/flat/FlatStorage.java
+++ b/cache/src/main/java/net/runelite/cache/fs/flat/FlatStorage.java
@@ -220,7 +220,7 @@ public class FlatStorage implements Storage
 				br.printf("revision=%d\n", idx.getRevision());
 				br.printf("compression=%d\n", idx.getCompression());
 				br.printf("crc=%d\n", idx.getCrc());
-				br.printf("named=%b\n", idx.getCompression());
+				br.printf("named=%b\n", idx.isNamed());
 
 				idx.getArchives().sort(Comparator.comparing(Archive::getArchiveId));
 				for (Archive archive : idx.getArchives())


### PR DESCRIPTION
When saving FlatStorage indices the index `named` value writes the value of the index compression instead of the `isNamed` value.