### PR TITLE
ChatNotificationsPlugin: Added support for regular expression highlights

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatnotifications/ChatNotificationsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatnotifications/ChatNotificationsConfig.java
@@ -28,12 +28,44 @@ package net.runelite.client.plugins.chatnotifications;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.ConfigSection;
 
 @ConfigGroup("chatnotification")
 public interface ChatNotificationsConfig extends Config
 {
+	@ConfigSection(
+		name = "Highlight Lists",
+		description = "Custom single word and regex filter lists",
+		position = 0
+	)
+	String highlightLists = "highlightLists";
+
 	@ConfigItem(
-		position = 0,
+		position = 1,
+		keyName = "highlightWordsString",
+		name = "Highlight words",
+		description = "Highlights the following words in chat",
+		section = highlightLists
+	)
+	default String highlightWordsString()
+	{
+		return "";
+	}
+
+	@ConfigItem(
+		position = 2,
+		keyName = "highlightRegexString",
+		name = "Highlight Regex",
+		description = "Highlights the following regular expressions in chat, one per line",
+		section = highlightLists
+	)
+	default String highlightRegexString()
+	{
+		return "";
+	}
+
+	@ConfigItem(
+		position = 1,
 		keyName = "highlightOwnName",
 		name = "Highlight own name",
 		description = "Highlights any instance of your username in chat"
@@ -41,17 +73,6 @@ public interface ChatNotificationsConfig extends Config
 	default boolean highlightOwnName()
 	{
 		return true;
-	}
-
-	@ConfigItem(
-		position = 1,
-		keyName = "highlightWordsString",
-		name = "Highlight words",
-		description = "Highlights the following words in chat"
-	)
-	default String highlightWordsString()
-	{
-		return "";
 	}
 
 	@ConfigItem(

--- a/runelite-client/src/test/java/net/runelite/client/plugins/chatnotifications/ChatNotificationsPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/chatnotifications/ChatNotificationsPluginTest.java
@@ -82,6 +82,8 @@ public class ChatNotificationsPluginTest
 	public void before()
 	{
 		Guice.createInjector(BoundFieldModule.of(this)).injectMembers(this);
+		when(config.highlightRegexString()).thenReturn("");
+		when(config.highlightWordsString()).thenReturn("");
 	}
 
 	@Test
@@ -100,6 +102,42 @@ public class ChatNotificationsPluginTest
 		chatNotificationsPlugin.onChatMessage(chatMessage);
 
 		verify(messageNode).setValue("<colHIGHLIGHT>Deathbeam<colNORMAL>, <colHIGHLIGHT>Deathbeam<colNORMAL> OSRS");
+	}
+
+	@Test
+	public void testRegexMultiplePatternsMessage()
+	{
+		when(config.highlightRegexString()).thenReturn("brandie+\ntest");
+
+		MessageNode messageNode = mock(MessageNode.class);
+		when(messageNode.getValue()).thenReturn("brandieeee testing");
+
+		ChatMessage chatMessage = new ChatMessage();
+		chatMessage.setType(ChatMessageType.PUBLICCHAT);
+		chatMessage.setMessageNode(messageNode);
+
+		chatNotificationsPlugin.startUp();
+		chatNotificationsPlugin.onChatMessage(chatMessage);
+
+		verify(messageNode).setValue("<colHIGHLIGHT>brandieeee<colNORMAL> <colHIGHLIGHT>test<colNORMAL>ing");
+	}
+
+	@Test
+	public void testRegexMultiplePatternsWithOnlyOneMatch()
+	{
+		when(config.highlightRegexString()).thenReturn("brandie+\nwillNotMatch");
+
+		MessageNode messageNode = mock(MessageNode.class);
+		when(messageNode.getValue()).thenReturn("brandieeee testing");
+
+		ChatMessage chatMessage = new ChatMessage();
+		chatMessage.setType(ChatMessageType.PUBLICCHAT);
+		chatMessage.setMessageNode(messageNode);
+
+		chatNotificationsPlugin.startUp();
+		chatNotificationsPlugin.onChatMessage(chatMessage);
+
+		verify(messageNode).setValue("<colHIGHLIGHT>brandieeee<colNORMAL> testing");
 	}
 
 	@Test
@@ -179,7 +217,7 @@ public class ChatNotificationsPluginTest
 	}
 
 	@Test
-	public void testPreceedingColor()
+	public void testPrecedingColor()
 	{
 		when(config.highlightWordsString()).thenReturn("you. It");
 
@@ -239,10 +277,10 @@ public class ChatNotificationsPluginTest
 	public void highlightListTest()
 	{
 		when(config.highlightWordsString()).thenReturn("this,is, a                   , test, ");
-		final List<String> higlights = Text.fromCSV(config.highlightWordsString());
-		assertEquals(4, higlights.size());
+		final List<String> highlights = Text.fromCSV(config.highlightWordsString());
+		assertEquals(4, highlights.size());
 
-		final Iterator<String> iterator = higlights.iterator();
+		final Iterator<String> iterator = highlights.iterator();
 		assertEquals("this", iterator.next());
 		assertEquals("is", iterator.next());
 		assertEquals("a", iterator.next());


### PR DESCRIPTION
- Added config field for regular expressions to highlight in style with ChatFilterPlugin
- Rearranged config order to follow ChatFilterPlugin style with the lists in their own section at the start
- ~~Currently no tests for regexp available~~
- Overlapping regexp is currently undefined behavior although one will guaranteed be highlighted


![image](https://user-images.githubusercontent.com/10778583/104660651-44f01f00-56c7-11eb-93da-81787f2ac72a.png)
