### PR TITLE
XpTracker: Toggle stats

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpInfoBox.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpInfoBox.java
@@ -29,6 +29,8 @@ package net.runelite.client.plugins.xptracker;
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Dimension;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
 import java.math.RoundingMode;
 import java.text.DecimalFormat;
 import java.util.ArrayList;
@@ -81,20 +83,27 @@ class XpInfoBox extends JPanel
 	private static final String REMOVE_STATE = "Remove from canvas";
 	private static final String ADD_STATE = "Add to canvas";
 
+	private static final EmptyBorder DEFAULT_PROGRESS_WRAPPER_BORDER = new EmptyBorder(0, 7, 7, 7);
+	private static final EmptyBorder COMPACT_PROGRESS_WRAPPER_BORDER = new EmptyBorder(5, 1, 5, 5);
+	private static final int PROGRESS_SKILL_ICON_POSITION = 0;
+
 	// Instance members
 	private final JComponent panel;
 
 	@Getter(AccessLevel.PACKAGE)
 	private final Skill skill;
 
-	/* The tracker's wrapping container */
+	// The tracker's wrapping container
 	private final JPanel container = new JPanel();
 
-	/* Contains the skill icon and the stats panel */
+	// Contains the skill icon and the stats panel
 	private final JPanel headerPanel = new JPanel();
 
-	/* Contains all the skill information (exp gained, per hour, etc) */
+	// Contains all the skill information (exp gained, per hour, etc)
 	private final JPanel statsPanel = new JPanel();
+
+	// Contains progress bar and compact-view icon
+	private final JPanel progressWrapper = new JPanel();
 
 	private final ProgressBar progressBar = new ProgressBar();
 
@@ -182,18 +191,12 @@ class XpInfoBox extends JPanel
 			}
 		});
 
-		JLabel skillIcon = new JLabel(new ImageIcon(iconManager.getSkillImage(skill)));
-		skillIcon.setHorizontalAlignment(SwingConstants.CENTER);
-		skillIcon.setVerticalAlignment(SwingConstants.CENTER);
-		skillIcon.setPreferredSize(new Dimension(35, 35));
-
 		headerPanel.setBackground(ColorScheme.DARKER_GRAY_COLOR);
 		headerPanel.setLayout(new BorderLayout());
 
 		statsPanel.setLayout(new DynamicGridLayout(2, 2));
 		statsPanel.setBackground(ColorScheme.DARKER_GRAY_COLOR);
 		statsPanel.setBorder(new EmptyBorder(9, 2, 9, 2));
-
 
 		topLeftStat.setFont(FontManager.getRunescapeSmallFont());
 		bottomLeftStat.setFont(FontManager.getRunescapeSmallFont());
@@ -205,20 +208,24 @@ class XpInfoBox extends JPanel
 		statsPanel.add(bottomLeftStat);  // bottom left
 		statsPanel.add(bottomRightStat); // bottom right
 
-		headerPanel.add(skillIcon, BorderLayout.WEST);
+		JLabel headerSkillIcon = getSkillIcon(iconManager, skill, 35, 35, false);
+		headerPanel.add(headerSkillIcon, BorderLayout.WEST);
 		headerPanel.add(statsPanel, BorderLayout.CENTER);
 
-		JPanel progressWrapper = new JPanel();
 		progressWrapper.setBackground(ColorScheme.DARKER_GRAY_COLOR);
 		progressWrapper.setLayout(new BorderLayout());
-		progressWrapper.setBorder(new EmptyBorder(0, 7, 7, 7));
+		progressWrapper.setBorder(DEFAULT_PROGRESS_WRAPPER_BORDER);
 
 		progressBar.setMaximumValue(100);
 		progressBar.setBackground(new Color(61, 56, 49));
 		progressBar.setForeground(SkillColor.find(skill).getColor());
 		progressBar.setDimmedText("Paused");
 
-		progressWrapper.add(progressBar, BorderLayout.NORTH);
+		JLabel progressSkillIcon = getSkillIcon(iconManager, skill, 25, 16, true);
+		progressSkillIcon.setVisible(false);
+
+		progressWrapper.add(progressSkillIcon, BorderLayout.WEST, PROGRESS_SKILL_ICON_POSITION);
+		progressWrapper.add(progressBar, BorderLayout.CENTER);
 
 		container.add(headerPanel, BorderLayout.NORTH);
 		container.add(progressWrapper, BorderLayout.SOUTH);
@@ -233,6 +240,21 @@ class XpInfoBox extends JPanel
 		progressBar.addMouseListener(mouseDragEventForwarder);
 		progressBar.addMouseMotionListener(mouseDragEventForwarder);
 
+		// collapse/expand on mouse click
+		final MouseAdapter clickToggleCompact = new MouseAdapter()
+		{
+			@Override
+			public void mouseClicked(MouseEvent e)
+			{
+				if (e.getButton() == MouseEvent.BUTTON1)
+				{
+					toggleCompactView();
+				}
+			}
+		};
+		container.addMouseListener(clickToggleCompact);
+		progressBar.addMouseListener(clickToggleCompact);
+
 		add(container, BorderLayout.NORTH);
 	}
 
@@ -246,6 +268,27 @@ class XpInfoBox extends JPanel
 	void update(boolean updated, boolean paused, XpSnapshotSingle xpSnapshotSingle)
 	{
 		SwingUtilities.invokeLater(() -> rebuildAsync(updated, paused, xpSnapshotSingle));
+	}
+
+	private void toggleCompactView()
+	{
+		final boolean headerPanelVisible = headerPanel.isVisible();
+
+		progressWrapper.setBorder(headerPanelVisible ? COMPACT_PROGRESS_WRAPPER_BORDER : DEFAULT_PROGRESS_WRAPPER_BORDER);
+		headerPanel.setVisible(!headerPanelVisible);
+		progressWrapper.getComponent(PROGRESS_SKILL_ICON_POSITION).setVisible(headerPanelVisible);
+	}
+
+	private static JLabel getSkillIcon(SkillIconManager iconManager, Skill skill, int width, int height, boolean small)
+	{
+		JLabel skillIcon = new JLabel();
+
+		skillIcon.setIcon(new ImageIcon(iconManager.getSkillImage(skill, small)));
+		skillIcon.setPreferredSize(new Dimension(width, height));
+		skillIcon.setHorizontalAlignment(SwingConstants.CENTER);
+		skillIcon.setVerticalAlignment(SwingConstants.CENTER);
+
+		return skillIcon;
 	}
 
 	private void rebuildAsync(boolean updated, boolean skillPaused, XpSnapshotSingle xpSnapshotSingle)


### PR DESCRIPTION
## Overview
Resolves: #12717 

Toggles compact view of XP Info boxes on click.

Single skill toggled:
![toggleOne](https://user-images.githubusercontent.com/4356074/104781745-a2788000-5748-11eb-9d1c-40658d964a76.png)

Multiple skills toggled:
![toggleTwo](https://user-images.githubusercontent.com/4356074/104781746-a2788000-5748-11eb-9587-e85131ff5103.png)

One addition that might be worth while considering is placing the skill icon when toggling stats somewhere on the progress bar? Feel free to let me know if there are some changes you'd like to see.

## Alternatives
The feature request only asked for a stats toggle. Personally I don't think this looks as visually appealing, containing wasted whitespace.

![toggledStats](https://user-images.githubusercontent.com/4356074/104781022-5547de80-5747-11eb-9f88-852efff4e207.png)