### PR TITLE
discord: Use regions for raiding activity and remove varbit handling

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordGameEventType.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordGameEventType.java
@@ -307,8 +307,8 @@ enum DiscordGameEventType
 	MG_VOLCANIC_MINE("Volcanic Mine", DiscordAreaType.MINIGAMES, 15263, 15262),
 
 	// Raids
-	RAIDS_CHAMBERS_OF_XERIC("Chambers of Xeric", DiscordAreaType.RAIDS, Varbits.IN_RAID),
-	RAIDS_THEATRE_OF_BLOOD("Theatre of Blood", DiscordAreaType.RAIDS, Varbits.THEATRE_OF_BLOOD),
+	RAIDS_CHAMBERS_OF_XERIC("Chambers of Xeric", DiscordAreaType.RAIDS, 12889, 13136, 13137, 13138, 13139, 13140, 13141, 13145, 13393, 13394, 13395, 13396, 13397, 13401),
+	RAIDS_THEATRE_OF_BLOOD("Theatre of Blood", DiscordAreaType.RAIDS, 12611, 12612, 12613, 12867, 12869, 13122, 13123, 13125, 13379),
 
 	// Other
 	REGION_ABYSSAL_AREA("Abyssal Area", DiscordAreaType.REGIONS, 12108),

--- a/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordGameEventType.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordGameEventType.java
@@ -26,16 +26,12 @@
  */
 package net.runelite.client.plugins.discord;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import net.runelite.api.Client;
 import net.runelite.api.Skill;
-import net.runelite.api.Varbits;
 
 @AllArgsConstructor
 @Getter
@@ -430,20 +426,12 @@ enum DiscordGameEventType
 	REGION_WRATH_ALTAR("Wrath Altar", DiscordAreaType.REGIONS, 9291);
 
 	private static final Map<Integer, DiscordGameEventType> FROM_REGION;
-	private static final List<DiscordGameEventType> FROM_VARBITS;
 
 	static
 	{
 		ImmutableMap.Builder<Integer, DiscordGameEventType> regionMapBuilder = new ImmutableMap.Builder<>();
-		ImmutableList.Builder<DiscordGameEventType> fromVarbitsBuilder = ImmutableList.builder();
 		for (DiscordGameEventType discordGameEventType : DiscordGameEventType.values())
 		{
-			if (discordGameEventType.getVarbits() != null)
-			{
-				fromVarbitsBuilder.add(discordGameEventType);
-				continue;
-			}
-
 			if (discordGameEventType.getRegionIds() == null)
 			{
 				continue;
@@ -455,7 +443,6 @@ enum DiscordGameEventType
 			}
 		}
 		FROM_REGION = regionMapBuilder.build();
-		FROM_VARBITS = fromVarbitsBuilder.build();
 	}
 
 	@Nullable
@@ -498,9 +485,6 @@ enum DiscordGameEventType
 	private DiscordAreaType discordAreaType;
 
 	@Nullable
-	private Varbits varbits;
-
-	@Nullable
 	private int[] regionIds;
 
 	DiscordGameEventType(Skill skill)
@@ -539,15 +523,6 @@ enum DiscordGameEventType
 	DiscordGameEventType(String state, int priority)
 	{
 		this(state, priority, true, false, false, true, false);
-	}
-
-	DiscordGameEventType(String areaName, DiscordAreaType areaType, Varbits varbits)
-	{
-		this.state = exploring(areaType, areaName);
-		this.priority = -2;
-		this.discordAreaType = areaType;
-		this.varbits = varbits;
-		this.shouldClear = true;
 	}
 
 	private static String training(final Skill skill)
@@ -608,18 +583,5 @@ enum DiscordGameEventType
 	public static DiscordGameEventType fromRegion(final int regionId)
 	{
 		return FROM_REGION.get(regionId);
-	}
-
-	public static DiscordGameEventType fromVarbit(final Client client)
-	{
-		for (DiscordGameEventType fromVarbit : FROM_VARBITS)
-		{
-			if (client.getVar(fromVarbit.getVarbits()) != 0)
-			{
-				return fromVarbit;
-			}
-		}
-
-		return null;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordPlugin.java
@@ -46,7 +46,6 @@ import net.runelite.api.WorldType;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.StatChanged;
-import net.runelite.api.events.VarbitChanged;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.discord.DiscordService;
 import net.runelite.client.discord.events.DiscordJoinGame;
@@ -205,22 +204,6 @@ public class DiscordPlugin extends Plugin
 		final DiscordGameEventType discordGameEventType = DiscordGameEventType.fromSkill(skill);
 
 		if (discordGameEventType != null && config.showSkillingActivity())
-		{
-			discordState.triggerEvent(discordGameEventType);
-		}
-	}
-
-	@Subscribe
-	public void onVarbitChanged(VarbitChanged event)
-	{
-		if (!config.showRaidingActivity())
-		{
-			return;
-		}
-
-		final DiscordGameEventType discordGameEventType = DiscordGameEventType.fromVarbit(client);
-
-		if (discordGameEventType != null)
 		{
 			discordState.triggerEvent(discordGameEventType);
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/discord/DiscordPlugin.java
@@ -447,6 +447,7 @@ public class DiscordPlugin extends Plugin
 			case DUNGEONS: return config.showDungeonActivity();
 			case MINIGAMES: return config.showMinigameActivity();
 			case REGIONS: return config.showRegionsActivity();
+			case RAIDS: return config.showRaidingActivity();
 		}
 
 		return false;


### PR DESCRIPTION
Currently, after being in a ToB party, Jagex does not properly unset `Varbits.THEATRE_OF_BLOOD` when leaving the Theatre area, only when returning. Since we use that varbit for discord activity, if you were to do a ToB and then leave afterward, your discord activity would continue to show `Theatre of Blood` regardless of your location, until you either log out or return to Ver Sinhaza. 

With that in mind, it is much easier to use the regions for raiding activity rather than the varbits. With those changed, it is no longer necessary to handle varbits within the discord plugin, thus all code related to varbits can be removed.