### PR TITLE
Add arms kit type

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/kit/KitType.java
+++ b/runelite-api/src/main/java/net/runelite/api/kit/KitType.java
@@ -42,6 +42,7 @@ public enum KitType
 	WEAPON(3),
 	TORSO(4),
 	SHIELD(5),
+	ARMS(6),
 	LEGS(7),
 	HAIR(8),
 	HANDS(9),


### PR DESCRIPTION
The arms slot is a slot similar to jaws in that no item can be equipped there, but it affects the player's appearance, namely when certain "sleeveless" items are equipped, such as d'hide bodies and chainbodies, making the arms appear like they do when nothing is equipped in the torso slot. Most torso slot items (platebodies, etc) remove the arms. I found this out by examining `PlayerComposition::getEquipmentIds`.

I would like this added for a plugin I'm working on. Happy to provide more info / tests if that helps. Not entirely sure how to test this, though.