### PR TITLE
Respect setPreferredSize in ImageComponent

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/components/ImageComponent.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/components/ImageComponent.java
@@ -29,24 +29,22 @@ import java.awt.Graphics2D;
 import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.image.BufferedImage;
-import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import net.runelite.client.util.ImageUtil;
 
 @RequiredArgsConstructor
-@Setter
 public class ImageComponent implements LayoutableRenderableEntity
 {
 	private final BufferedImage image;
 
-	@Setter(AccessLevel.NONE)
 	private BufferedImage scaledImage;
 
 	@Getter
 	private final Rectangle bounds = new Rectangle();
 
+	@Setter
 	private Point preferredLocation = new Point();
 
 	@Override
@@ -74,7 +72,8 @@ public class ImageComponent implements LayoutableRenderableEntity
 		{
 			scaledImage = null;
 		}
-		else
+		// skip scaling if not necessary
+		else if (scaledImage == null || preferredSize.width != scaledImage.getWidth() || preferredSize.height != scaledImage.getHeight())
 		{
 			scaledImage = ImageUtil.resizeImage(image, preferredSize.width, preferredSize.height);
 		}

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/components/ImageComponent.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/components/ImageComponent.java
@@ -68,13 +68,15 @@ public class ImageComponent implements LayoutableRenderableEntity
 	@Override
 	public void setPreferredSize(Dimension preferredSize)
 	{
-		if (preferredSize != null && image != null)
+		boolean nulled = preferredSize == null || image == null;
+		boolean sameSize = !nulled && (preferredSize.width == image.getWidth() && preferredSize.height == image.getHeight());
+		if (nulled || sameSize)
 		{
-			scaledImage = ImageUtil.resizeImage(image, preferredSize.width, preferredSize.height);
+			scaledImage = null;
 		}
 		else
 		{
-			scaledImage = null;
+			scaledImage = ImageUtil.resizeImage(image, preferredSize.width, preferredSize.height);
 		}
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/components/ImageComponent.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/components/ImageComponent.java
@@ -29,15 +29,20 @@ import java.awt.Graphics2D;
 import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.image.BufferedImage;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
+import net.runelite.client.util.ImageUtil;
 
 @RequiredArgsConstructor
 @Setter
 public class ImageComponent implements LayoutableRenderableEntity
 {
 	private final BufferedImage image;
+
+	@Setter(AccessLevel.NONE)
+	private BufferedImage scaledImage;
 
 	@Getter
 	private final Rectangle bounds = new Rectangle();
@@ -52,7 +57,8 @@ public class ImageComponent implements LayoutableRenderableEntity
 			return null;
 		}
 
-		graphics.drawImage(image, preferredLocation.x, preferredLocation.y, null);
+		BufferedImage toRender = scaledImage != null ? scaledImage : image;
+		graphics.drawImage(toRender, preferredLocation.x, preferredLocation.y, null);
 		final Dimension dimension = new Dimension(image.getWidth(), image.getHeight());
 		bounds.setLocation(preferredLocation);
 		bounds.setSize(dimension);
@@ -60,8 +66,15 @@ public class ImageComponent implements LayoutableRenderableEntity
 	}
 
 	@Override
-	public void setPreferredSize(Dimension dimension)
+	public void setPreferredSize(Dimension preferredSize)
 	{
-		// Just use image dimensions for now
+		if (preferredSize != null && image != null)
+		{
+			scaledImage = ImageUtil.resizeImage(image, preferredSize.width, preferredSize.height);
+		}
+		else
+		{
+			scaledImage = null;
+		}
 	}
 }


### PR DESCRIPTION
Currently ImageComponent doesn't respect a size passed in via setPreferredSize, which led to some confusion when attempting to fix the size of an ImageComponent in an overlay.

This fix uses the existing ImageUtil to scale the image when setPreferredSize is called, but defers to the original image if it has not been set.