### PR TITLE
fix some typos and enum namings

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/Actor.java
+++ b/runelite-api/src/main/java/net/runelite/api/Actor.java
@@ -60,7 +60,7 @@ public interface Actor extends Renderable
 	 * Examples of interaction include:
 	 * <ul>
 	 *     <li>A monster focusing an Actor to attack</li>
-	 *     <li>Targetting a player to trade</li>
+	 *     <li>Targeting a player to trade</li>
 	 *     <li>Following a player</li>
 	 * </ul>
 	 *

--- a/runelite-api/src/main/java/net/runelite/api/AnimationID.java
+++ b/runelite-api/src/main/java/net/runelite/api/AnimationID.java
@@ -55,9 +55,9 @@ public final class AnimationID
 	public static final int COOKING_RANGE = 896;
 	public static final int COOKING_WINE = 7529;
 	public static final int FLETCHING_BOW_CUTTING = 1248;
-	public static final int HUNTER_LAY_BOXTRAP_BIRDSNARE = 5208; //same for laying bird snares and box traps
-	public static final int HUNTER_LAY_DEADFALLTRAP = 5212; //setting up deadfall trap
-	public static final int HUNTER_LAY_NETTRAP = 5215; //setting up net trap
+	public static final int HUNTER_LAY_BOX_TRAP_BIRD_SNARE = 5208; //same for laying bird snares and box traps
+	public static final int HUNTER_LAY_DEADFALL_TRAP = 5212; //setting up deadfall trap
+	public static final int HUNTER_LAY_NET_TRAP = 5215; //setting up net trap
 	public static final int HUNTER_LAY_MANIACAL_MONKEY_BOULDER_TRAP = 7259; // setting up maniacal monkey boulder trap
 	public static final int HUNTER_CHECK_BIRD_SNARE = 5207;
 	public static final int HUNTER_CHECK_BOX_TRAP = 5212;
@@ -83,10 +83,10 @@ public final class AnimationID
 	public static final int FLETCHING_ATTACH_BOLT_TIPS_TO_RUNE_BOLT = 8478;
 	public static final int FLETCHING_ATTACH_BOLT_TIPS_TO_DRAGON_BOLT = 8479;
 	public static final int FLETCHING_ATTACH_HEADS = 8480;
-	public static final int FLETCHING_ATTACH_FEATHERS_TO_ARROWSHAFT = 8481;
+	public static final int FLETCHING_ATTACH_FEATHERS_TO_ARROW_SHAFT = 8481;
 	public static final int GEM_CUTTING_OPAL = 890;
 	public static final int GEM_CUTTING_JADE = 891;
-	public static final int GEM_CUTTING_REDTOPAZ = 892;
+	public static final int GEM_CUTTING_RED_TOPAZ = 892;
 	public static final int GEM_CUTTING_SAPPHIRE = 888;
 	public static final int GEM_CUTTING_EMERALD = 889;
 	public static final int GEM_CUTTING_RUBY = 887;
@@ -98,7 +98,7 @@ public final class AnimationID
 	public static final int CRAFTING_POTTERS_WHEEL = 883;
 	public static final int CRAFTING_POTTERY_OVEN = 24975;
 	public static final int SMITHING_SMELTING = 899;
-	public static final int SMITHING_CANNONBALL = 827; //cball smithing uses this and SMITHING_SMELTING
+	public static final int SMITHING_CANNONBALL = 827; //cannonball smithing uses this and SMITHING_SMELTING
 	public static final int SMITHING_ANVIL = 898;
 	public static final int FISHING_BIG_NET = 620;
 	public static final int FISHING_NET = 621;
@@ -167,7 +167,7 @@ public final class AnimationID
 	public static final int MINING_MOTHERLODE_TRAILBLAZER = 8786; // Same animation as Infernal pickaxe (or)
 	public static final int DENSE_ESSENCE_CHIPPING = 7201;
 	public static final int DENSE_ESSENCE_CHISELING = 7202;
-	public static final int HERBLORE_POTIONMAKING = 363; //used for both herb and secondary
+	public static final int HERBLORE_POTION_MAKING = 363; //used for both herb and secondary
 	public static final int MAGIC_CHARGING_ORBS = 726;
 	public static final int MAGIC_MAKE_TABLET = 4068;
 	public static final int MAGIC_ENCHANTING_JEWELRY = 931;

--- a/runelite-api/src/main/java/net/runelite/api/Constants.java
+++ b/runelite-api/src/main/java/net/runelite/api/Constants.java
@@ -91,7 +91,7 @@ public class Constants
 	 * The number of milliseconds in a client tick.
 	 * <p>
 	 * This is the length of a single frame when the client is running at
-	 * the maximum framerate of 50 fps.
+	 * the maximum frame rate of 50 fps.
 	 */
 	public static final int CLIENT_TICK_LENGTH = 20;
 

--- a/runelite-api/src/main/java/net/runelite/api/EnumID.java
+++ b/runelite-api/src/main/java/net/runelite/api/EnumID.java
@@ -33,5 +33,5 @@ public final class EnumID
 {
 	public static final int MUSIC_TRACK_NAMES = 812;
 	public static final int MUSIC_TRACK_IDS = 819;
-	public static final int XPDROP_COLORS = 1169;
+	public static final int XP_DROP_COLORS = 1169;
 }

--- a/runelite-api/src/main/java/net/runelite/api/InventoryID.java
+++ b/runelite-api/src/main/java/net/runelite/api/InventoryID.java
@@ -40,7 +40,7 @@ public enum InventoryID
 	/**
 	 * The other trade inventory.
 	 */
-	TRADEOTHER(90 | 0x8000),
+	TRADE_OTHER(90 | 0x8000),
 	/**
 	 * Standard player inventory.
 	 */

--- a/runelite-client/src/main/java/net/runelite/client/plugins/experiencedrop/XpDropPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/experiencedrop/XpDropPlugin.java
@@ -151,7 +151,7 @@ public class XpDropPlugin extends Plugin
 
 	private void resetTextColor(Widget widget)
 	{
-		EnumComposition colorEnum = client.getEnum(EnumID.XPDROP_COLORS);
+		EnumComposition colorEnum = client.getEnum(EnumID.XP_DROP_COLORS);
 		int defaultColorId = client.getVar(Varbits.EXPERIENCE_DROP_COLOR);
 		int color = colorEnum.getIntValue(defaultColorId);
 		widget.setTextColor(color);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
@@ -148,7 +148,7 @@ public class IdleNotifierPlugin extends Plugin
 			/* Crafting(Gem Cutting, Glassblowing, Spinning, Battlestaves, Pottery) */
 			case GEM_CUTTING_OPAL:
 			case GEM_CUTTING_JADE:
-			case GEM_CUTTING_REDTOPAZ:
+			case GEM_CUTTING_RED_TOPAZ:
 			case GEM_CUTTING_SAPPHIRE:
 			case GEM_CUTTING_EMERALD:
 			case GEM_CUTTING_RUBY:
@@ -174,7 +174,7 @@ public class IdleNotifierPlugin extends Plugin
 			case FLETCHING_STRING_MAPLE_LONGBOW:
 			case FLETCHING_STRING_YEW_LONGBOW:
 			case FLETCHING_STRING_MAGIC_LONGBOW:
-			case FLETCHING_ATTACH_FEATHERS_TO_ARROWSHAFT:
+			case FLETCHING_ATTACH_FEATHERS_TO_ARROW_SHAFT:
 			case FLETCHING_ATTACH_HEADS:
 			case FLETCHING_ATTACH_BOLT_TIPS_TO_BRONZE_BOLT:
 			case FLETCHING_ATTACH_BOLT_TIPS_TO_IRON_BROAD_BOLT:
@@ -252,7 +252,7 @@ public class IdleNotifierPlugin extends Plugin
 			case MINING_MOTHERLODE_TRAILBLAZER:
 			/* Herblore */
 			case HERBLORE_PESTLE_AND_MORTAR:
-			case HERBLORE_POTIONMAKING:
+			case HERBLORE_POTION_MAKING:
 			case HERBLORE_MAKE_TAR:
 			/* Magic */
 			case MAGIC_CHARGING_ORBS:


### PR DESCRIPTION
With this commit there will be fixed some typos and enum names (using refactor function) in runelite-api folder