### PR TITLE
Cannon: fix reclaimed cannon initial cball counter

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonPlugin.java
@@ -39,6 +39,7 @@ import net.runelite.api.GameObject;
 import net.runelite.api.GameState;
 import net.runelite.api.InventoryID;
 import net.runelite.api.Item;
+import net.runelite.api.ItemContainer;
 import net.runelite.api.ItemID;
 import static net.runelite.api.ObjectID.CANNON_BASE;
 import net.runelite.api.Player;
@@ -301,6 +302,23 @@ public class CannonPlugin extends Plugin
 			cannonPlaced = true;
 			addCounter();
 			cballsLeft = 0;
+
+			final ItemContainer inventory = client.getItemContainer(InventoryID.INVENTORY);
+			if (inventory != null)
+			{
+				int invCballs = inventory.count(ItemID.GRANITE_CANNONBALL) > 0
+						? inventory.count(ItemID.GRANITE_CANNONBALL)
+						: inventory.count(ItemID.CANNONBALL);
+				// Cannonballs are always forcibly loaded after the furnace is added. If the player has more than
+				// the max number of cannon balls in their inventory, the cannon will always be fully filled.
+				// This is preferable to using the proceeding "You load the cannon with x cannon balls" message
+				// since it will show a lower number of cannon balls if the cannon is already partially-filled
+				// prior to being placed.
+				if (invCballs >= MAX_CBALLS)
+				{
+					cballsLeft = MAX_CBALLS;
+				}
+			}
 		}
 
 		if (event.getMessage().contains("You pick up the cannon")

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonPlugin.java
@@ -384,6 +384,15 @@ public class CannonPlugin extends Plugin
 			}
 		}
 
+		if (event.getMessage().startsWith("Your cannon contains"))
+		{
+			Matcher m = NUMBER_PATTERN.matcher(event.getMessage());
+			if (m.find())
+			{
+				cballsLeft = Integer.parseInt(m.group());
+			}
+		}
+
 		if (event.getMessage().startsWith("You unload your cannon and receive Cannonball")
 			|| event.getMessage().startsWith("You unload your cannon and receive Granite cannonball"))
 		{

--- a/runelite-client/src/test/java/net/runelite/client/plugins/cannon/CannonPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/cannon/CannonPluginTest.java
@@ -105,6 +105,18 @@ public class CannonPluginTest
 	}
 
 	@Test
+	public void addWrongTypeOfCannonballs()
+	{
+		final ChatMessage message = new ChatMessage();
+		message.setType(ChatMessageType.GAMEMESSAGE);
+		message.setMessage("Your cannon contains 20 x Cannonball.<br>You can only add cannonballs of the same kind.");
+
+		plugin.onChatMessage(message);
+
+		assertEquals(20, plugin.getCballsLeft());
+	}
+
+	@Test
 	public void addMaxCannonballs()
 	{
 		final ItemContainer inventory = mock(ItemContainer.class);

--- a/runelite-client/src/test/java/net/runelite/client/plugins/cannon/CannonPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/cannon/CannonPluginTest.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) 2021, Alexsuperfly <alexsuperfly@users.noreply.github.com>
+ * Copyright (c) 2021, Jordan Atwood <nightfirecat@protonmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.cannon;
+
+import com.google.inject.Guice;
+import com.google.inject.testing.fieldbinder.Bind;
+import com.google.inject.testing.fieldbinder.BoundFieldModule;
+import javax.inject.Inject;
+import net.runelite.api.ChatMessageType;
+import net.runelite.api.Client;
+import net.runelite.api.InventoryID;
+import net.runelite.api.ItemContainer;
+import net.runelite.api.ItemID;
+import net.runelite.api.events.ChatMessage;
+import net.runelite.client.Notifier;
+import net.runelite.client.game.ItemManager;
+import net.runelite.client.ui.overlay.OverlayManager;
+import net.runelite.client.ui.overlay.infobox.InfoBoxManager;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CannonPluginTest
+{
+
+	@Inject
+	private CannonPlugin plugin;
+
+	@Mock
+	@Bind
+	private CannonConfig config;
+
+	@Mock
+	@Bind
+	private CannonOverlay cannonOverlay;
+
+	@Mock
+	@Bind
+	private CannonSpotOverlay cannonSpotOverlay;
+
+	@Mock
+	@Bind
+	private InfoBoxManager infoBoxManager;
+
+	@Mock
+	@Bind
+	private Notifier notifier;
+
+	@Mock
+	@Bind
+	private ItemManager itemManager;
+
+	@Mock
+	@Bind
+	private Client client;
+
+	@Mock
+	@Bind
+	private OverlayManager overlayManager;
+
+	private static final ChatMessage ADD_FURNACE = new ChatMessage();
+
+	@BeforeClass
+	public static void chatMessageSetup()
+	{
+		ADD_FURNACE.setType(ChatMessageType.SPAM);
+		ADD_FURNACE.setMessage("You add the furnace.");
+	}
+
+	@Before
+	public void before()
+	{
+		Guice.createInjector(BoundFieldModule.of(this)).injectMembers(this);
+	}
+
+	@Test
+	public void addMaxCannonballs()
+	{
+		final ItemContainer inventory = mock(ItemContainer.class);
+		when(client.getItemContainer(InventoryID.INVENTORY)).thenReturn(inventory);
+		when(inventory.count(ItemID.CANNONBALL)).thenReturn(100);
+		when(inventory.count(ItemID.GRANITE_CANNONBALL)).thenReturn(0);
+
+		plugin.onChatMessage(ADD_FURNACE);
+		assertTrue(plugin.isCannonPlaced());
+
+		assertEquals(30, plugin.getCballsLeft());
+
+		plugin.onChatMessage(loadCannonballs(30));
+		assertEquals(30, plugin.getCballsLeft());
+	}
+
+	@Test
+	public void addNotMaxCannonballs()
+	{
+		final ItemContainer inventory = mock(ItemContainer.class);
+		when(client.getItemContainer(InventoryID.INVENTORY)).thenReturn(inventory);
+		when(inventory.count(ItemID.GRANITE_CANNONBALL)).thenReturn(12);
+
+		plugin.onChatMessage(ADD_FURNACE);
+		assertTrue(plugin.isCannonPlaced());
+
+		assertEquals(0, plugin.getCballsLeft());
+
+		plugin.onChatMessage(loadCannonballs(12));
+		assertEquals(12, plugin.getCballsLeft());
+	}
+
+	@Test
+	public void addReclaimedCannonballs()
+	{
+		final ItemContainer inventory = mock(ItemContainer.class);
+		when(client.getItemContainer(InventoryID.INVENTORY)).thenReturn(inventory);
+		when(inventory.count(ItemID.CANNONBALL)).thenReturn(1250);
+
+		plugin.onChatMessage(ADD_FURNACE);
+		assertTrue(plugin.isCannonPlaced());
+
+		assertEquals(30, plugin.getCballsLeft());
+
+		plugin.onChatMessage(loadCannonballs(18));
+		assertEquals(30, plugin.getCballsLeft());
+	}
+
+	private static ChatMessage loadCannonballs(final int numCannonballs)
+	{
+		final ChatMessage message = new ChatMessage();
+		message.setType(ChatMessageType.GAMEMESSAGE);
+
+		// Cannons use the same chat message for loading cannonballs regardless of whether they're normal or granite.
+		if (numCannonballs == 1)
+		{
+			message.setMessage("You load the cannon with one cannonball.");
+		}
+		else
+		{
+			message.setMessage(String.format("You load the cannon with %s cannonballs.", numCannonballs));
+		}
+
+		return message;
+	}
+
+}


### PR DESCRIPTION
A cannon that has been destroyed with cannon balls loaded
will still have them loaded when reclaimed.  This commit
does a diff of the inventory on the first message that says 
you are loading the cannon.  If the diff and inventory 
after that message both have cannon balls in them, then
we know the maximum amount possible were stored so set 
the counter to max.

Fixes #13105