### PR TITLE
Avoid Javadoc cutting off descriptions

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/ChatMessageType.java
+++ b/runelite-api/src/main/java/net/runelite/api/ChatMessageType.java
@@ -117,7 +117,7 @@ public enum ChatMessageType
 	 */
 	MODAUTOTYPER(91),
 	/**
-	 * A game message (ie. when a setting is changed).
+	 * A game message. (ie. when a setting is changed).
 	 */
 	CONSOLE(99),
 	/**

--- a/runelite-api/src/main/java/net/runelite/api/Client.java
+++ b/runelite-api/src/main/java/net/runelite/api/Client.java
@@ -433,7 +433,7 @@ public interface Client extends GameEngine
 	int getMouseCurrentButton();
 
 	/**
-	 * Gets the currently selected tile (ie. last right clicked tile).
+	 * Gets the currently selected tile. (ie. last right clicked tile).
 	 *
 	 * @return the selected tile
 	 */
@@ -1465,8 +1465,8 @@ public interface Client extends GameEngine
 	void setPlayersHidden(boolean state);
 
 	/**
-	 * Sets whether 2D sprites (ie. overhead prayers, PK skull) related to
-	 * the other players are hidden.
+	 * Sets whether 2D sprites related to the other players
+	 * are hidden. (ie. overhead prayers, PK skull).
 	 *
 	 * @param state the new player 2D hidden state
 	 */
@@ -1494,8 +1494,8 @@ public interface Client extends GameEngine
 	void setLocalPlayerHidden(boolean state);
 
 	/**
-	 * Sets whether 2D sprites (ie. overhead prayers, PK skull) related to
-	 * the local player are hidden.
+	 * Sets whether 2D sprites related to the local player
+	 * are hidden. (ie. overhead prayers, PK skull).
 	 *
 	 * @param state new local player 2D hidden state
 	 */
@@ -1509,8 +1509,8 @@ public interface Client extends GameEngine
 	void setNPCsHidden(boolean state);
 
 	/**
-	 * Sets whether 2D sprites (ie. overhead prayers) related to
-	 * the NPCs are hidden.
+	 * Sets whether 2D sprites related to the NPCs
+	 * are hidden. (ie. overhead prayers)
 	 *
 	 * @param state new NPC 2D hidden state
 	 */

--- a/runelite-api/src/main/java/net/runelite/api/HeadIcon.java
+++ b/runelite-api/src/main/java/net/runelite/api/HeadIcon.java
@@ -54,7 +54,7 @@ public enum HeadIcon
 	 */
 	REDEMPTION,
 	/**
-	 * Protect from range and mage (ie. used by Kalphite Queen).
+	 * Protect from range and mage. (ie. used by Kalphite Queen).
 	 */
 	RANGE_MAGE
 }

--- a/runelite-api/src/main/java/net/runelite/api/MenuEntry.java
+++ b/runelite-api/src/main/java/net/runelite/api/MenuEntry.java
@@ -37,7 +37,7 @@ public class MenuEntry
 	 */
 	private String option;
 	/**
-	 * The target of the action (ie. Item or Actor name).
+	 * The target of the action. (ie. Item or Actor name).
 	 * <p>
 	 * If the option does not apply to any target, this field
 	 * will be set to empty string.

--- a/runelite-api/src/main/java/net/runelite/api/MessageNode.java
+++ b/runelite-api/src/main/java/net/runelite/api/MessageNode.java
@@ -58,7 +58,7 @@ public interface MessageNode extends Node
 	void setName(String name);
 
 	/**
-	 * Gets the sender of the message (ie. friends chat name).
+	 * Gets the sender of the message. (ie. friends chat name).
 	 *
 	 * @return the message sender
 	 */

--- a/runelite-api/src/main/java/net/runelite/api/Projectile.java
+++ b/runelite-api/src/main/java/net/runelite/api/Projectile.java
@@ -25,7 +25,7 @@
 package net.runelite.api;
 
 /**
- * Represents a projectile entity (ie. cannonball, arrow).
+ * Represents a projectile entity. (ie. cannonball, arrow).
  */
 public interface Projectile extends Renderable
 {

--- a/runelite-api/src/main/java/net/runelite/api/events/MenuEntryAdded.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/MenuEntryAdded.java
@@ -35,11 +35,11 @@ import lombok.Data;
 public class MenuEntryAdded
 {
 	/**
-	 * The option text added to the menu (ie. "Walk here", "Use").
+	 * The option text added to the menu. (ie. "Walk here", "Use").
 	 */
 	private final String option;
 	/**
-	 * The target of the action (ie. Item or Actor name).
+	 * The target of the action. (ie. Item or Actor name).
 	 * <p>
 	 * If the option does not apply to any target, this field
 	 * will be set to empty string.
@@ -50,7 +50,7 @@ public class MenuEntryAdded
 	 */
 	private final int type;
 	/**
-	 * An identifier value for the target of the action
+	 * An identifier value for the target of the action.
 	 */
 	private final int identifier;
 	/**

--- a/runelite-api/src/main/java/net/runelite/api/events/WorldChanged.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/WorldChanged.java
@@ -27,7 +27,7 @@ package net.runelite.api.events;
 import net.runelite.api.Client;
 
 /**
- * Posted when the game world the client wants to connect to has changed
+ * Posted when the game world the client wants to connect to has changed.
  * This is posted after the world ID and type have updated, but before a new
  * connection is established
  *


### PR DESCRIPTION
Using a period before cases of `(ie.` to avoid including them in summaries