### PR TITLE
Shades of Mort'ton loot tracking and minigame location

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
@@ -186,6 +186,11 @@ public class LootTrackerPlugin extends Plugin
 		put(ObjectID.SILVER_CHEST_4128, "Silver key crimson").
 		put(ObjectID.SILVER_CHEST_4129, "Silver key black").
 		put(ObjectID.SILVER_CHEST_4130, "Silver key purple").
+		put(ObjectID.GOLD_CHEST, "Gold key red").
+		put(ObjectID.GOLD_CHEST_41213, "Gold key brown").
+		put(ObjectID.GOLD_CHEST_41214, "Gold key crimson").
+		put(ObjectID.GOLD_CHEST_41215, "Gold key black").
+		put(ObjectID.GOLD_CHEST_41216, "Gold key purple").
 		build();
 
 	// Hallow Sepulchre Coffin handling

--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldmap/MinigameLocation.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldmap/MinigameLocation.java
@@ -55,6 +55,7 @@ enum MinigameLocation
 	PYRAMID_PLUNDER("Pyramid Plunder", new WorldPoint(3288, 2787, 0)),
 	RANGING_GUILD("Ranging Guild", new WorldPoint(2671, 3419, 0)),
 	ROGUES_DEN("Rogues' Den", new WorldPoint(2905, 3537, 0)),
+	SHADES_OF_MORTTON("Shades of Mort'ton", new WorldPoint(3505, 3315, 0)),
 	SORCERESSS_GARDEN("Sorceress's Garden", new WorldPoint(3285, 3180, 0)),
 	TROUBLE_BREWING("Trouble Brewing", new WorldPoint(3811, 3021, 0)),
 	VOLCANIC_MINE("Volcanic Mine", new WorldPoint(3812, 3810, 0)),


### PR DESCRIPTION
Adds loot tracking for new Gold keys in Shades of Mort'ton
![java_zrL3kEZrdB](https://user-images.githubusercontent.com/54762282/106026864-51498400-6098-11eb-986c-fe39ccad7b91.png)
Also adds missing minigame icon label
![image](https://user-images.githubusercontent.com/54762282/106026994-73db9d00-6098-11eb-9e16-6c2792d6dfa3.png)
