### PR TITLE
npc indicators: remove tags from minimap npc name

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcMinimapOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcMinimapOverlay.java
@@ -36,6 +36,7 @@ import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.OverlayUtil;
+import net.runelite.client.util.Text;
 
 public class NpcMinimapOverlay extends Overlay
 {
@@ -56,7 +57,7 @@ public class NpcMinimapOverlay extends Overlay
 	{
 		for (NPC npc : plugin.getHighlightedNpcs())
 		{
-			renderNpcOverlay(graphics, npc, npc.getName(), config.getHighlightColor());
+			renderNpcOverlay(graphics, npc, Text.removeTags(npc.getName()), config.getHighlightColor());
 		}
 
 		return null;


### PR DESCRIPTION
Some NPCs have color tags to make them look like objects rather than NPCs, like the Totems at Nightmare. With the `Draw names on minimap` setting enabled, the colors tags are visible for tagged NPCs on the minimap, thus it is necessary to strip those tags.

Before:
![image](https://user-images.githubusercontent.com/54762282/106076960-a4462a00-60de-11eb-8808-488332d19712.png)
After:
![java_wZi69HHaye](https://user-images.githubusercontent.com/54762282/106076887-7c56c680-60de-11eb-8f0c-cde89292913f.png)
