### PR TITLE
ground items: add Nightmare instance to normal despawn timers

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
@@ -81,6 +81,7 @@ public class GroundItemsOverlay extends Overlay
 	private static final int GRAARDOR_REGION = 11347;
 	private static final int KRIL_TSUTSAROTH_REGION = 11603;
 	private static final int KREEARRA_REGION = 11346;
+	private static final int NIGHTMARE_REGION = 15515;
 
 	private final Client client;
 	private final GroundItemsPlugin plugin;
@@ -447,9 +448,9 @@ public class GroundItemsOverlay extends Overlay
 				}
 			}
 			else if (playerRegionID == ZILYANA_REGION || playerRegionID == GRAARDOR_REGION ||
-				playerRegionID == KRIL_TSUTSAROTH_REGION || playerRegionID == KREEARRA_REGION)
+				playerRegionID == KRIL_TSUTSAROTH_REGION || playerRegionID == KREEARRA_REGION || playerRegionID == NIGHTMARE_REGION)
 			{
-				// GWD instances use the normal despawn timers
+				// GWD and Nightmare instances use the normal despawn timers
 				despawnTime = spawnTime.plus(groundItem.getLootType() == LootType.DROPPED
 					? DESPAWN_TIME_DROP
 					: DESPAWN_TIME_LOOT);


### PR DESCRIPTION
Adds the Nightmare instance to the ground items instance whitelist as dropped/spawned items do not stay on the ground indefinitely.

Before:
![java_HxQ5Gezj2D](https://user-images.githubusercontent.com/54762282/106080015-4d435380-60e4-11eb-9551-9ef100b103ba.png)
After:
![java_jKjd59PE7j](https://user-images.githubusercontent.com/54762282/106080017-4ddbea00-60e4-11eb-8b3c-2081addf9a25.png)

