### PR TITLE
Ground Markers: Add toggling for Import/Export and a Clear option

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/groundmarkers/GroundMarkerConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/groundmarkers/GroundMarkerConfig.java
@@ -36,6 +36,7 @@ public interface GroundMarkerConfig extends Config
 {
 	String GROUND_MARKER_CONFIG_GROUP = "groundMarker";
 	String SHOW_IMPORT_EXPORT_KEY_NAME = "showImportExport";
+	String SHOW_CLEAR_KEY_NAME = "showClear";
 
 	@Alpha
 	@ConfigItem(
@@ -76,5 +77,15 @@ public interface GroundMarkerConfig extends Config
 	default boolean showImportExport()
 	{
 		return true;
+	}
+
+	@ConfigItem(
+		keyName = SHOW_CLEAR_KEY_NAME,
+		name = "Show Clear option",
+		description = "Show the Clear option on the minimap right-click menu, which deletes all currently loaded markers"
+	)
+	default boolean showClear()
+	{
+		return false;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/groundmarkers/GroundMarkerConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/groundmarkers/GroundMarkerConfig.java
@@ -31,9 +31,12 @@ import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
 
-@ConfigGroup("groundMarker")
+@ConfigGroup(GroundMarkerConfig.GROUND_MARKER_CONFIG_GROUP)
 public interface GroundMarkerConfig extends Config
 {
+	String GROUND_MARKER_CONFIG_GROUP = "groundMarker";
+	String SHOW_IMPORT_EXPORT_KEY_NAME = "showImportExport";
+
 	@Alpha
 	@ConfigItem(
 		keyName = "markerColor",
@@ -63,5 +66,15 @@ public interface GroundMarkerConfig extends Config
 	default boolean drawTileOnMinimmap()
 	{
 		return false;
+	}
+
+	@ConfigItem(
+		keyName = SHOW_IMPORT_EXPORT_KEY_NAME,
+		name = "Show Import/Export options",
+		description = "Show the Import/Export options on the minimap right-click menu"
+	)
+	default boolean showImportExport()
+	{
+		return true;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/groundmarkers/GroundMarkerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/groundmarkers/GroundMarkerPlugin.java
@@ -195,6 +195,10 @@ public class GroundMarkerPlugin extends Plugin
 		{
 			sharingManager.addImportExportMenuOptions();
 		}
+		if (config.showClear())
+		{
+			sharingManager.addClearMenuOption();
+		}
 		loadPoints();
 		eventBus.register(sharingManager);
 	}
@@ -288,13 +292,19 @@ public class GroundMarkerPlugin extends Plugin
 	public void onConfigChanged(ConfigChanged event)
 	{
 		if (event.getGroup().equals(GroundMarkerConfig.GROUND_MARKER_CONFIG_GROUP)
-			&& event.getKey().equals(GroundMarkerConfig.SHOW_IMPORT_EXPORT_KEY_NAME))
+			&& (event.getKey().equals(GroundMarkerConfig.SHOW_IMPORT_EXPORT_KEY_NAME)
+				|| event.getKey().equals(GroundMarkerConfig.SHOW_CLEAR_KEY_NAME)))
 		{
+			// Maintain consistent menu option order by removing everything then adding according to config
 			sharingManager.removeMenuOptions();
 
 			if (config.showImportExport())
 			{
 				sharingManager.addImportExportMenuOptions();
+			}
+			if (config.showClear())
+			{
+				sharingManager.addClearMenuOption();
 			}
 		}
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/groundmarkers/GroundMarkerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/groundmarkers/GroundMarkerPlugin.java
@@ -54,6 +54,7 @@ import net.runelite.api.events.MenuOptionClicked;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.EventBus;
 import net.runelite.client.eventbus.Subscribe;
+import net.runelite.client.events.ConfigChanged;
 import net.runelite.client.game.chatbox.ChatboxPanelManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
@@ -190,7 +191,10 @@ public class GroundMarkerPlugin extends Plugin
 	{
 		overlayManager.add(overlay);
 		overlayManager.add(minimapOverlay);
-		sharingManager.addMenuOptions();
+		if (config.showImportExport())
+		{
+			sharingManager.addImportExportMenuOptions();
+		}
 		loadPoints();
 		eventBus.register(sharingManager);
 	}
@@ -277,6 +281,21 @@ public class GroundMarkerPlugin extends Plugin
 		else if (option.equals(LABEL))
 		{
 			labelTile(target);
+		}
+	}
+
+	@Subscribe
+	public void onConfigChanged(ConfigChanged event)
+	{
+		if (event.getGroup().equals(GroundMarkerConfig.GROUND_MARKER_CONFIG_GROUP)
+			&& event.getKey().equals(GroundMarkerConfig.SHOW_IMPORT_EXPORT_KEY_NAME))
+		{
+			sharingManager.removeMenuOptions();
+
+			if (config.showImportExport())
+			{
+				sharingManager.addImportExportMenuOptions();
+			}
 		}
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/groundmarkers/GroundMarkerSharingManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/groundmarkers/GroundMarkerSharingManager.java
@@ -79,7 +79,7 @@ class GroundMarkerSharingManager
 		this.gson = gson;
 	}
 
-	void addMenuOptions()
+	void addImportExportMenuOptions()
 	{
 		menuManager.addManagedCustomMenu(EXPORT_MARKERS_OPTION);
 		menuManager.addManagedCustomMenu(IMPORT_MARKERS_OPTION);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/groundmarkers/GroundMarkerSharingManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/groundmarkers/GroundMarkerSharingManager.java
@@ -59,6 +59,7 @@ class GroundMarkerSharingManager
 {
 	private static final WidgetMenuOption EXPORT_MARKERS_OPTION = new WidgetMenuOption("Export", "Ground Markers", WORLD_MAP_OPTION);
 	private static final WidgetMenuOption IMPORT_MARKERS_OPTION = new WidgetMenuOption("Import", "Ground Markers", WORLD_MAP_OPTION);
+	private static final WidgetMenuOption CLEAR_MARKERS_OPTION = new WidgetMenuOption("Clear", "Ground Markers", WORLD_MAP_OPTION);
 
 	private final GroundMarkerPlugin plugin;
 	private final Client client;
@@ -85,10 +86,16 @@ class GroundMarkerSharingManager
 		menuManager.addManagedCustomMenu(IMPORT_MARKERS_OPTION);
 	}
 
+	void addClearMenuOption()
+	{
+		menuManager.addManagedCustomMenu(CLEAR_MARKERS_OPTION);
+	}
+
 	void removeMenuOptions()
 	{
 		menuManager.removeManagedCustomMenu(EXPORT_MARKERS_OPTION);
 		menuManager.removeManagedCustomMenu(IMPORT_MARKERS_OPTION);
+		menuManager.removeManagedCustomMenu(CLEAR_MARKERS_OPTION);
 	}
 
 	private boolean widgetMenuClickedEquals(final WidgetMenuOptionClicked event, final WidgetMenuOption target)
@@ -113,6 +120,10 @@ class GroundMarkerSharingManager
 		else if (widgetMenuClickedEquals(event, IMPORT_MARKERS_OPTION))
 		{
 			promptForImport();
+		}
+		else if (widgetMenuClickedEquals(event, CLEAR_MARKERS_OPTION))
+		{
+			promptForClear();
 		}
 	}
 
@@ -231,6 +242,41 @@ class GroundMarkerSharingManager
 		log.debug("Reloading points after import");
 		plugin.loadPoints();
 		sendChatMessage(importPoints.size() + " ground markers were imported from the clipboard.");
+	}
+
+	private void promptForClear()
+	{
+		int[] regions = client.getMapRegions();
+		if (regions == null)
+		{
+			return;
+		}
+
+		long numActivePoints = Arrays.stream(regions)
+			.mapToLong(regionId -> plugin.getPoints(regionId).size())
+			.sum();
+
+		if (numActivePoints == 0)
+		{
+			sendChatMessage("You have no ground markers to clear.");
+			return;
+		}
+
+		chatboxPanelManager.openTextMenuInput("Are you sure you want to clear the<br>" + numActivePoints + " currently loaded ground markers?")
+			.option("Yes", () ->
+			{
+				for (int regionId : regions)
+				{
+					plugin.savePoints(regionId, null);
+				}
+
+				plugin.loadPoints();
+				sendChatMessage(numActivePoints + " ground marker"
+					+ (numActivePoints == 1 ? " was cleared." : "s were cleared."));
+
+			})
+			.option("No", Runnables::doNothing)
+			.build();
 	}
 
 	private void sendChatMessage(final String message)


### PR DESCRIPTION
As per a requested feature on the Runelite Discord

The changes in GroundMarkerSharingManager to prevent duplicate adding of the menu options are likely unnecessary. The underlying LinkedHashMultimap in MenuManager seems to handle that correctly. Should this particular piece of the PR be added "just in case" or should it be dropped?