### PR TITLE
Add !cats command, showing traded cats, obtained runes and lost kittens

### DIFF
--- a/http-api/src/main/java/net/runelite/http/api/chat/Cats.java
+++ b/http-api/src/main/java/net/runelite/http/api/chat/Cats.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2021, Cyborger1
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.http.api.chat;
+
+import lombok.Data;
+
+@Data
+public class Cats
+{
+	private int catsTraded;
+	private int runesObtained;
+	private int lostKittens;
+}

--- a/http-api/src/main/java/net/runelite/http/api/chat/ChatClient.java
+++ b/http-api/src/main/java/net/runelite/http/api/chat/ChatClient.java
@@ -362,4 +362,54 @@ public class ChatClient
 			throw new IOException(ex);
 		}
 	}
+
+	public boolean sumbitCats(String username, int catsTraded, int runesObtained, int lostKittens) throws IOException
+	{
+		HttpUrl url = RuneLiteAPI.getApiBase().newBuilder()
+			.addPathSegment("chat")
+			.addPathSegment("cats")
+			.addQueryParameter("name", username)
+			.addQueryParameter("catsTraded", Integer.toString(catsTraded))
+			.addQueryParameter("runesObtained", Integer.toString(runesObtained))
+			.addQueryParameter("lostKittens", Integer.toString(lostKittens))
+			.build();
+
+		Request request = new Request.Builder()
+			.post(RequestBody.create(null, new byte[0]))
+			.url(url)
+			.build();
+
+		try (Response response = client.newCall(request).execute())
+		{
+			return response.isSuccessful();
+		}
+	}
+
+	public Cats getCats(String username) throws IOException
+	{
+		HttpUrl url = RuneLiteAPI.getApiBase().newBuilder()
+			.addPathSegment("chat")
+			.addPathSegment("cats")
+			.addQueryParameter("name", username)
+			.build();
+
+		Request request = new Request.Builder()
+			.url(url)
+			.build();
+
+		try (Response response = client.newCall(request).execute())
+		{
+			if (!response.isSuccessful())
+			{
+				throw new IOException("Unable to look up cats!");
+			}
+
+			InputStream in = response.body().byteStream();
+			return RuneLiteAPI.GSON.fromJson(new InputStreamReader(in, StandardCharsets.UTF_8), Cats.class);
+		}
+		catch (JsonParseException ex)
+		{
+			throw new IOException(ex);
+		}
+	}
 }

--- a/http-service/src/main/java/net/runelite/http/service/chat/ChatController.java
+++ b/http-service/src/main/java/net/runelite/http/service/chat/ChatController.java
@@ -29,6 +29,7 @@ import com.google.common.cache.CacheBuilder;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import net.runelite.http.api.chat.Cats;
 import net.runelite.http.api.chat.Duels;
 import net.runelite.http.api.chat.LayoutRoom;
 import net.runelite.http.api.chat.Task;
@@ -222,6 +223,36 @@ public class ChatController
 			throw new NotFoundException();
 		}
 		return duels;
+	}
+
+	@PostMapping("/cats")
+	public void submitCats(@RequestParam String name,
+							@RequestParam int catsTraded,
+							@RequestParam int runesObtained,
+							@RequestParam int lostKittens)
+	{
+		if (catsTraded < 0 || runesObtained < 0 || lostKittens < 0)
+		{
+			return;
+		}
+
+		Cats cats = new Cats();
+		cats.setCatsTraded(catsTraded);
+		cats.setRunesObtained(runesObtained);
+		cats.setLostKittens(lostKittens);
+
+		chatService.setCats(name, cats);
+	}
+
+	@GetMapping("/cats")
+	public Cats getCats(@RequestParam String name)
+	{
+		Cats cats = chatService.getCats(name);
+		if (cats == null)
+		{
+			throw new NotFoundException();
+		}
+		return cats;
 	}
 
 	@PostMapping("/layout")

--- a/http-service/src/main/java/net/runelite/http/service/chat/ChatService.java
+++ b/http-service/src/main/java/net/runelite/http/service/chat/ChatService.java
@@ -30,6 +30,7 @@ import com.google.common.collect.ImmutableMap;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
+import net.runelite.http.api.chat.Cats;
 import net.runelite.http.api.chat.LayoutRoom;
 import net.runelite.http.api.chat.Task;
 import net.runelite.http.api.chat.Duels;
@@ -199,6 +200,44 @@ public class ChatService
 		try (Jedis jedis = jedisPool.getResource())
 		{
 			jedis.hmset(key, duelsMap);
+			jedis.expire(key, (int) EXPIRE.getSeconds());
+		}
+	}
+
+	public Cats getCats(String name)
+	{
+		Map<String, String> map;
+
+		try (Jedis jedis = jedisPool.getResource())
+		{
+			map = jedis.hgetAll("cats." + name);
+		}
+
+		if (map.isEmpty())
+		{
+			return null;
+		}
+
+		Cats cats = new Cats();
+		cats.setCatsTraded(Integer.parseInt(map.get("catsTraded")));
+		cats.setRunesObtained(Integer.parseInt(map.get("runesObtained")));
+		cats.setLostKittens(Integer.parseInt(map.get("lostKittens")));
+		return cats;
+	}
+
+	public void setCats(String name, Cats cats)
+	{
+		Map<String, String> catsMap = ImmutableMap.<String, String>builderWithExpectedSize(3)
+			.put("catsTraded", Integer.toString(cats.getCatsTraded()))
+			.put("runesObtained", Integer.toString(cats.getCatsTraded()))
+			.put("lostKittens", Integer.toString(cats.getLostKittens()))
+			.build();
+
+		String key = "cats." + name;
+
+		try (Jedis jedis = jedisPool.getResource())
+		{
+			jedis.hmset(key, catsMap);
 			jedis.expire(key, (int) EXPIRE.getSeconds());
 		}
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsConfig.java
@@ -179,6 +179,17 @@ public interface ChatCommandsConfig extends Config
 
 	@ConfigItem(
 		position = 13,
+		keyName = "cats",
+		name = "Cats Command",
+		description = "Configures whether the Cats command is enabled<br> !cats"
+	)
+	default boolean cats()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		position = 14,
 		keyName = "clearSingleWord",
 		name = "Clear Single Word",
 		description = "Enable hot key to clear single word at a time"
@@ -189,7 +200,7 @@ public interface ChatCommandsConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 14,
+		position = 15,
 		keyName = "clearEntireChatBox",
 		name = "Clear Chat Box",
 		description = "Enable hotkey to clear entire chat box"

--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
@@ -230,6 +230,7 @@ public class ChatCommandsPlugin extends Plugin
 		chatCommandManager.unregisterCommand(GC_COMMAND_STRING);
 		chatCommandManager.unregisterCommand(DUEL_ARENA_COMMAND);
 		chatCommandManager.unregisterCommand(SOUL_WARS_ZEAL_COMMAND);
+		chatCommandManager.unregisterCommand(CATS_TRADED_COMMAND);
 	}
 
 	@Provides


### PR DESCRIPTION
Adding this as a draft until I can figure out how to test the command properly. I mostly followed the way `!duels` got implemented for the http-service part.

Adds "kc" tracking for Cats traded at West Ardougne, Death Runes obtained from said trading and kittens lost from not feeding/stroking. The `!cats` command would display this information to other players.

This also may or may not need some tests implemented.