### PR TITLE
MenuEntrySwapper: added use-swap for battlestaves

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -145,6 +145,17 @@ public interface MenuEntrySwapperConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "swapBattlestaves",
+		name = "Battlestaff",
+		description = "Swap Wield with Use on Battlestaves without orbs",
+		section = itemSection
+	)
+	default boolean swapBattlestaves()
+	{
+		return false;
+	}
+
+	@ConfigItem(
 		keyName = "swapPrayerBook",
 		name = "Recite-Prayer",
 		description = "Swap Read with Recite-prayer on the Prayer Book from The Great Brain Robbery quest",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -334,6 +334,8 @@ public class MenuEntrySwapperPlugin extends Plugin
 
 		swap("bury", "use", config::swapBones);
 
+		swap("wield", "battlestaff", "use", config::swapBattlestaves);
+
 		swap("clean", "use", config::swapHerbs);
 
 		swap("read", "recite-prayer", config::swapPrayerBook);


### PR DESCRIPTION
Adds the option to swap Use with Wield on battlestaves with no orbs in a similar vein to bury bones / clean herbs

![image](https://user-images.githubusercontent.com/10778583/106665604-d1934c00-65a6-11eb-9dff-7534e3629da7.png)
![image](https://user-images.githubusercontent.com/10778583/106665647-dd7f0e00-65a6-11eb-8b06-20174a8bbba3.png)
