### PR TITLE
slayer: Modify to use RSProfiles Config

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerConfig.java
@@ -32,9 +32,21 @@ import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
 import net.runelite.client.config.Units;
 
-@ConfigGroup("slayer")
+@ConfigGroup(SlayerConfig.GROUP_NAME)
 public interface SlayerConfig extends Config
 {
+	String GROUP_NAME = "slayer";
+
+	// Key names for stored task values
+	String TASK_NAME_KEY = "taskName";
+	String AMOUNT_KEY = "amount";
+	String INIT_AMOUNT_KEY = "initialAmount";
+	String TASK_LOC_KEY = "taskLocation";
+	String STREAK_KEY = "streak";
+	String POINTS_KEY = "points";
+	String EXPEDITIOUS_CHARGES_KEY = "expeditious";
+	String SLAUGHTER_CHARGES_KEY = "slaughter";
+
 	@ConfigItem(
 		position = 1,
 		keyName = "infobox",
@@ -124,148 +136,4 @@ public interface SlayerConfig extends Config
 	{
 		return true;
 	}
-
-	// Stored data
-	@ConfigItem(
-		keyName = "taskName",
-		name = "",
-		description = "",
-		hidden = true
-	)
-	default String taskName()
-	{
-		return "";
-	}
-
-	@ConfigItem(
-		keyName = "taskName",
-		name = "",
-		description = ""
-	)
-	void taskName(String key);
-
-	@ConfigItem(
-		keyName = "amount",
-		name = "",
-		description = "",
-		hidden = true
-	)
-	default int amount()
-	{
-		return -1;
-	}
-
-	@ConfigItem(
-		keyName = "amount",
-		name = "",
-		description = ""
-	)
-	void amount(int amt);
-
-	@ConfigItem(
-		keyName = "initialAmount",
-		name = "",
-		description = "",
-		hidden = true
-	)
-	default int initialAmount()
-	{
-		return -1;
-	}
-	@ConfigItem(
-		keyName = "initialAmount",
-		name = "",
-		description = ""
-	)
-	void initialAmount(int initialAmount);
-
-	@ConfigItem(
-		keyName = "taskLocation",
-		name = "",
-		description = "",
-		hidden = true
-	)
-	default String taskLocation()
-	{
-		return "";
-	}
-
-	@ConfigItem(
-		keyName = "taskLocation",
-		name = "",
-		description = ""
-	)
-	void taskLocation(String key);
-
-	@ConfigItem(
-		keyName = "streak",
-		name = "",
-		description = "",
-		hidden = true
-	)
-	default int streak()
-	{
-		return -1;
-	}
-
-	@ConfigItem(
-		keyName = "streak",
-		name = "",
-		description = ""
-	)
-	void streak(int streak);
-
-	@ConfigItem(
-		keyName = "points",
-		name = "",
-		description = "",
-		hidden = true
-	)
-	default int points()
-	{
-		return -1;
-	}
-
-	@ConfigItem(
-		keyName = "points",
-		name = "",
-		description = ""
-	)
-	void points(int points);
-
-	@ConfigItem(
-		keyName = "expeditious",
-		name = "",
-		description = "",
-		hidden = true
-	)
-	default int expeditious()
-	{
-		return -1;
-	}
-
-	@ConfigItem(
-		keyName = "expeditious",
-		name = "",
-		description = ""
-	)
-	void expeditious(int expeditious);
-
-	@ConfigItem(
-		keyName = "slaughter",
-		name = "",
-		description = "",
-		hidden = true
-	)
-	default int slaughter()
-	{
-		return -1;
-	}
-
-	@ConfigItem(
-		keyName = "slaughter",
-		name = "",
-		description = ""
-	)
-	void slaughter(int slaughter);
 }

--- a/runelite-client/src/test/java/net/runelite/client/plugins/slayer/SlayerPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/slayer/SlayerPluginTest.java
@@ -53,6 +53,7 @@ import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.Notifier;
 import net.runelite.client.chat.ChatCommandManager;
 import net.runelite.client.chat.ChatMessageManager;
+import net.runelite.client.config.ConfigManager;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.ui.overlay.OverlayManager;
 import net.runelite.client.ui.overlay.infobox.InfoBoxManager;
@@ -64,6 +65,7 @@ import org.junit.runner.RunWith;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import org.mockito.Mock;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -136,6 +138,10 @@ public class SlayerPluginTest
 	@Mock
 	@Bind
 	Client client;
+
+	@Mock
+	@Bind
+	ConfigManager configManager;
 
 	@Mock
 	@Bind
@@ -283,7 +289,7 @@ public class SlayerPluginTest
 
 		assertEquals("Vet'ion", slayerPlugin.getTaskName());
 		assertEquals(3, slayerPlugin.getAmount());
-		verify(slayerConfig).points(914);
+		verify(configManager).setRSProfileConfiguration(SlayerConfig.GROUP_NAME, SlayerConfig.POINTS_KEY, 914);
 	}
 
 	@Test
@@ -296,7 +302,7 @@ public class SlayerPluginTest
 
 		assertEquals("Chaos Elemental", slayerPlugin.getTaskName());
 		assertEquals(3, slayerPlugin.getAmount());
-		verify(slayerConfig).points(914);
+		verify(configManager).setRSProfileConfiguration(SlayerConfig.GROUP_NAME, SlayerConfig.POINTS_KEY, 914);
 	}
 
 	@Test
@@ -309,7 +315,7 @@ public class SlayerPluginTest
 
 		assertEquals("Alchemical Hydra", slayerPlugin.getTaskName());
 		assertEquals(35, slayerPlugin.getAmount());
-		verify(slayerConfig).points(724);
+		verify(configManager).setRSProfileConfiguration(SlayerConfig.GROUP_NAME, SlayerConfig.POINTS_KEY, 724);
 	}
 
 	@Test
@@ -440,7 +446,7 @@ public class SlayerPluginTest
 		when(client.getWidget(WidgetInfo.SLAYER_REWARDS_TOPBAR)).thenReturn(rewardBar);
 		slayerPlugin.onGameTick(new GameTick());
 
-		verify(slayerConfig).points(17566);
+		verify(configManager).setRSProfileConfiguration(SlayerConfig.GROUP_NAME, SlayerConfig.POINTS_KEY, 17566);
 	}
 
 	@Test
@@ -449,7 +455,7 @@ public class SlayerPluginTest
 		ChatMessage chatMessageEvent = new ChatMessage(null, GAMEMESSAGE, "Perterter", TASK_ONE, null, 0);
 		slayerPlugin.onChatMessage(chatMessageEvent);
 
-		verify(slayerConfig).streak(1);
+		verify(configManager).setRSProfileConfiguration(SlayerConfig.GROUP_NAME, SlayerConfig.STREAK_KEY, 1);
 		assertEquals("", slayerPlugin.getTaskName());
 		assertEquals(0, slayerPlugin.getAmount());
 	}
@@ -460,7 +466,7 @@ public class SlayerPluginTest
 		ChatMessage chatMessageEvent = new ChatMessage(null, GAMEMESSAGE, "Perterter", TASK_COMPLETE_NO_POINTS, null, 0);
 		slayerPlugin.onChatMessage(chatMessageEvent);
 
-		verify(slayerConfig).streak(3);
+		verify(configManager).setRSProfileConfiguration(SlayerConfig.GROUP_NAME, SlayerConfig.STREAK_KEY, 3);
 		assertEquals("", slayerPlugin.getTaskName());
 		assertEquals(0, slayerPlugin.getAmount());
 	}
@@ -471,10 +477,10 @@ public class SlayerPluginTest
 		ChatMessage chatMessageEvent = new ChatMessage(null, GAMEMESSAGE, "Perterter", TASK_POINTS, null, 0);
 		slayerPlugin.onChatMessage(chatMessageEvent);
 
-		verify(slayerConfig).streak(9);
+		verify(configManager).setRSProfileConfiguration(SlayerConfig.GROUP_NAME, SlayerConfig.STREAK_KEY, 9);
 		assertEquals("", slayerPlugin.getTaskName());
 		assertEquals(0, slayerPlugin.getAmount());
-		verify(slayerConfig).points(18_000);
+		verify(configManager).setRSProfileConfiguration(SlayerConfig.GROUP_NAME, SlayerConfig.POINTS_KEY, 18_000);
 	}
 
 	@Test
@@ -483,10 +489,10 @@ public class SlayerPluginTest
 		ChatMessage chatMessageEvent = new ChatMessage(null, GAMEMESSAGE, "Perterter", TASK_LARGE_STREAK, null, 0);
 		slayerPlugin.onChatMessage(chatMessageEvent);
 
-		verify(slayerConfig).streak(2465);
+		verify(configManager).setRSProfileConfiguration(SlayerConfig.GROUP_NAME, SlayerConfig.STREAK_KEY, 2465);
 		assertEquals("", slayerPlugin.getTaskName());
 		assertEquals(0, slayerPlugin.getAmount());
-		verify(slayerConfig).points(131_071);
+		verify(configManager).setRSProfileConfiguration(SlayerConfig.GROUP_NAME, SlayerConfig.POINTS_KEY, 131_071);
 	}
 
 	@Test
@@ -495,7 +501,7 @@ public class SlayerPluginTest
 		ChatMessage chatMessageEvent = new ChatMessage(null, GAMEMESSAGE, "Perterter", TASK_COMPETE_TURAEL, null, 0);
 		slayerPlugin.onChatMessage(chatMessageEvent);
 
-		verify(slayerConfig).streak(104);
+		verify(configManager).setRSProfileConfiguration(SlayerConfig.GROUP_NAME, SlayerConfig.STREAK_KEY, 104);
 		assertEquals("", slayerPlugin.getTaskName());
 		assertEquals(0, slayerPlugin.getAmount());
 	}
@@ -506,8 +512,8 @@ public class SlayerPluginTest
 		ChatMessage chatMessageEvent = new ChatMessage(null, GAMEMESSAGE, "", TASK_MAX_STREAK, null, 0);
 		slayerPlugin.onChatMessage(chatMessageEvent);
 
-		verify(slayerConfig).streak(16_000);
-		verify(slayerConfig).points(131_071);
+		verify(configManager).setRSProfileConfiguration(SlayerConfig.GROUP_NAME, SlayerConfig.STREAK_KEY, 16000);
+		verify(configManager).setRSProfileConfiguration(SlayerConfig.GROUP_NAME, SlayerConfig.POINTS_KEY, 131_071);
 		assertEquals("", slayerPlugin.getTaskName());
 		assertEquals(0, slayerPlugin.getAmount());
 	}
@@ -518,8 +524,8 @@ public class SlayerPluginTest
 		ChatMessage chatMessageEvent = new ChatMessage(null, GAMEMESSAGE, "", TASK_MAX_POINTS, null, 0);
 		slayerPlugin.onChatMessage(chatMessageEvent);
 
-		verify(slayerConfig).streak(9);
-		verify(slayerConfig).points(131_071);
+		verify(configManager).setRSProfileConfiguration(SlayerConfig.GROUP_NAME, SlayerConfig.STREAK_KEY, 9);
+		verify(configManager).setRSProfileConfiguration(SlayerConfig.GROUP_NAME, SlayerConfig.POINTS_KEY, 131_071);
 		assertEquals("", slayerPlugin.getTaskName());
 		assertEquals(0, slayerPlugin.getAmount());
 	}
@@ -530,8 +536,8 @@ public class SlayerPluginTest
 		ChatMessage chatMessageEvent = new ChatMessage(null, GAMEMESSAGE, "", TASK_WILDERNESS, null, 0);
 		slayerPlugin.onChatMessage(chatMessageEvent);
 
-		verify(slayerConfig).streak(9);
-		verify(slayerConfig).points(18_000);
+		verify(configManager).setRSProfileConfiguration(SlayerConfig.GROUP_NAME, SlayerConfig.STREAK_KEY, 9);
+		verify(configManager).setRSProfileConfiguration(SlayerConfig.GROUP_NAME, SlayerConfig.POINTS_KEY, 18_000);
 		assertEquals("", slayerPlugin.getTaskName());
 		assertEquals(0, slayerPlugin.getAmount());
 	}
@@ -919,7 +925,10 @@ public class SlayerPluginTest
 	@Test
 	public void infoboxNotAddedOnLogin()
 	{
-		when(slayerConfig.taskName()).thenReturn(Task.BLOODVELD.getName());
+		when(slayerPlugin.getStringProfileConfig(SlayerConfig.TASK_NAME_KEY)).thenReturn(Task.BLOODVELD.getName());
+		when(slayerPlugin.getIntProfileConfig(SlayerConfig.AMOUNT_KEY)).thenReturn(50);
+		// Lenient required as this is not called assuming correct plugin logic
+		lenient().when(slayerConfig.showInfobox()).thenReturn(true);
 
 		GameStateChanged loggingIn = new GameStateChanged();
 		loggingIn.setGameState(GameState.LOGGING_IN);


### PR DESCRIPTION
Modifies the Slayer Plugin to use the newly added RSProfiles feature to ConfigManager. This closes #249.

The website actually pulls the info from the old config fields though.
I'm not sure what needs to be done on that end. Someone who knows his way around the rl.net code would have to help with this.
With that said, this shouldn't be merged until the website can support the new config path.