### PR TITLE
Add support for new isle of souls chests

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
@@ -145,7 +145,8 @@ public class LootTrackerPlugin extends Plugin
 	// Chest loot handling
 	private static final String CHEST_LOOTED_MESSAGE = "You find some treasure in the chest!";
 	private static final Pattern LARRAN_LOOTED_PATTERN = Pattern.compile("You have opened Larran's (big|small) chest .*");
-	private static final String STONE_CHEST_LOOTED_MESSAGE = "You steal some loot from the chest.";
+	// Used by Stone Chest, Isle of Souls chest, Dark Chest
+	private static final String OTHER_CHEST_LOOTED_MESSAGE = "You steal some loot from the chest.";
 	private static final String DORGESH_KAAN_CHEST_LOOTED_MESSAGE = "You find treasure inside!";
 	private static final String GRUBBY_CHEST_LOOTED_MESSAGE = "You have opened the Grubby Chest";
 	private static final Pattern HAM_CHEST_LOOTED_PATTERN = Pattern.compile("Your (?<key>[a-z]+) key breaks in the lock.*");
@@ -161,6 +162,8 @@ public class LootTrackerPlugin extends Plugin
 		put(10835, "Dorgesh-Kaan Chest").
 		put(10834, "Dorgesh-Kaan Chest").
 		put(7323, "Grubby Chest").
+		put(8593, "Isle of Souls Chest").
+		put(7827, "Dark Chest").
 		build();
 
 	// Shade chest loot handling
@@ -630,7 +633,7 @@ public class LootTrackerPlugin extends Plugin
 
 		final String message = event.getMessage();
 
-		if (message.equals(CHEST_LOOTED_MESSAGE) || message.equals(STONE_CHEST_LOOTED_MESSAGE)
+		if (message.equals(CHEST_LOOTED_MESSAGE) || message.equals(OTHER_CHEST_LOOTED_MESSAGE)
 			|| message.equals(DORGESH_KAAN_CHEST_LOOTED_MESSAGE) || message.startsWith(GRUBBY_CHEST_LOOTED_MESSAGE)
 			|| LARRAN_LOOTED_PATTERN.matcher(message).matches())
 		{


### PR DESCRIPTION
They have the same description and behavior as stone chest. From melky test:

```
2021-02-03 13:54:03 [Client] DEBUG n.r.c.p.l.LootTrackerPlugin - Tick: 417
2021-02-03 13:54:04 [Client] DEBUG client-patch - Chat message type SPAM: You manage to unlock the chest.
2021-02-03 13:54:04 [Client] DEBUG n.r.c.p.l.LootTrackerPlugin - Tick: 418
2021-02-03 13:54:04 [Client] DEBUG client-patch - Chat message type SPAM: You steal some loot from the chest.
2021-02-03 13:54:04 [Client] DEBUG n.r.c.p.l.LootTrackerPlugin - Received icc: [Item(id=12791, quantity=1), Item(id=13068, quantity=1), Item(id=13222, quantity=1), Item(id=13069, quantity=1), Item(id=5698, quantity=1), Item(id=6705, quantity=1), Item(id=6705, quantity=1), Item(id=6705, quantity=1), Item(id=6705, quantity=1), Item(id=6705, quantity=1), Item(id=6705, quantity=1), Item(id=6705, quantity=1), Item(id=228, quantity=2), Item(id=12631, quantity=1), Item(id=11953, quantity=1), Item(id=1523, quantity=1), Item(id=1523, quantity=1), Item(id=1355, quantity=1), Item(id=314, quantity=121), Item(id=1621, quantity=1), Item(id=2510, quantity=8)] tick: 418
```