### PR TITLE
cluescrolls: Fix beginner/master clue step reset

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/ClueScrollPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/ClueScrollPlugin.java
@@ -580,7 +580,7 @@ public class ClueScrollPlugin extends Plugin
 		if (chatDialogClueItem != null
 			&& (chatDialogClueItem.getItemId() == ItemID.CLUE_SCROLL_BEGINNER || chatDialogClueItem.getItemId() == ItemID.CLUE_SCROLL_MASTER))
 		{
-			resetClue(true);
+			resetClue(false);
 		}
 
 		final Widget clueScrollText = client.getWidget(WidgetInfo.CLUE_SCROLL_TEXT);


### PR DESCRIPTION
Commit 36bb7c8401fdd9ae88a185e9e193b4f7183aed54 improved the clue scroll
plugin by resetting the active clue step when a beginner or master clue
item was displayed in the chat dialog when receiving a new step. This
commit caused a new bug, however, in that it became possible to click on
a new clue step while the new step dialog was open such that the new
step dialog persisted through a GameTick due to client-server delay,
causing the saved clue item ID to be lost. This commit fixes that issue
by resetting only the active clue object, but not the recorded clue item
ID, as beginner and master clues only use a single item ID.

Fixes #12565