### PR TITLE
Portal nexus menu entry swapper

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -332,12 +332,15 @@ public interface MenuEntrySwapperConfig extends Config
 	}
 
 	@ConfigItem(
-			keyName= "swapPortalNexus",
-			name = "Portal Nexus",
-			description =  "Swap Left Click option with Teleport Menu",
-			section = objectSection
+		keyName= "swapPortalNexus",
+		name = "Portal Nexus",
+		description =  "Swap Left Click option with Teleport Menu",
+		section = objectSection
 	)
-	default boolean swapPortalNexus() { return false; }
+	default boolean swapPortalNexus()
+	{
+		return false;
+	}
 
 	@ConfigItem(
 		keyName = "swapPrivate",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -332,6 +332,14 @@ public interface MenuEntrySwapperConfig extends Config
 	}
 
 	@ConfigItem(
+			keyName= "swapPortalNexus",
+			name = "Portal Nexus",
+			description =  "Swap Left Click option with Teleport Menu",
+			section = objectSection
+	)
+	default boolean swapPortalNexus() { return false; }
+
+	@ConfigItem(
 		keyName = "swapPrivate",
 		name = "Private",
 		description = "Swap Shared with Private on the Chambers of Xeric storage units.",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -332,7 +332,7 @@ public interface MenuEntrySwapperConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName= "swapPortalNexus",
+		keyName = "swapPortalNexus",
 		name = "Portal Nexus",
 		description =  "Swap Left Click option with Teleport Menu",
 		section = objectSection

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -334,7 +334,7 @@ public interface MenuEntrySwapperConfig extends Config
 	@ConfigItem(
 		keyName = "swapPortalNexus",
 		name = "Portal Nexus",
-		description =  "Swap Left Click option with Teleport Menu",
+		description =  "Swap Teleport options with Teleport Menu on the Portal Nexus",
 		section = objectSection
 	)
 	default boolean swapPortalNexus()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -304,41 +304,14 @@ public class MenuEntrySwapperPlugin extends Plugin
 		swap("teleport menu", "draynor village", config::swapJewelleryBox);
 		swap("teleport menu", "al kharid", config::swapJewelleryBox);
 
-		swap("grand exchange", "teleport menu", config::swapPortalNexus);
-		swap("varrock", "teleport menu", config::swapPortalNexus);
-		swap("lumbridge grave'", "teleport menu", config::swapPortalNexus);
-		swap("draynor manor", "teleport menu", config::swapPortalNexus);
-		swap("battlefront", "teleport menu", config::swapPortalNexus);
-		swap("mind altar", "teleport menu", config::swapPortalNexus);
-		swap("lumbridge", "teleport menu", config::swapPortalNexus);
-		swap("falador", "teleport menu", config::swapPortalNexus);
-		swap("salve graveyard", "teleport menu", config::swapPortalNexus);
-		swap("camelot", "teleport menu", config::swapPortalNexus);
-		swap("seers' village", "teleport menu", config::swapPortalNexus);
-		swap("fenken' castle", "teleport menu", config::swapPortalNexus);
-		swap("east ardougne", "teleport menu", config::swapPortalNexus);
-		swap("watchtower", "teleport menu", config::swapPortalNexus);
-		swap("yanille", "teleport menu", config::swapPortalNexus);
-		swap("senntisten", "teleport menu", config::swapPortalNexus);
-		swap("west ardougne", "teleport menu", config::swapPortalNexus);
-		swap("marim", "teleport menu", config::swapPortalNexus);
-		swap("harmony island", "teleport menu", config::swapPortalNexus);
-		swap("kharyll", "teleport menu", config::swapPortalNexus);
-		swap("lunar isle", "teleport menu", config::swapPortalNexus);
-		swap("kourend castle", "teleport menu", config::swapPortalNexus);
-		swap("the forgotten cemetery", "teleport menu", config::swapPortalNexus);
-		swap("waterbirth island", "teleport menu", config::swapPortalNexus);
-		swap("barrows", "teleport menu", config::swapPortalNexus);
-		swap("carrallangar", "teleport menu", config::swapPortalNexus);
-		swap("fishing guild", "teleport menu", config::swapPortalNexus);
-		swap("catherby", "teleport menu", config::swapPortalNexus);
-		swap("annakarl", "teleport menu", config::swapPortalNexus);
-		swap("ape atoll dungeon", "teleport menu", config::swapPortalNexus);
-		swap("ghorrok", "teleport menu", config::swapPortalNexus);
-		swap("troll stronghold", "teleport menu", config::swapPortalNexus);
-		swap("weiss", "teleport menu", config::swapPortalNexus);
-
-
+		Arrays.asList(
+				"grand exchange", "varrock", "lumbridge grave'", "draynor manor", "battlefront", "mind altar",
+				"lumbridge", "falador", "salve graveyard", "camelot", "seers' village", "fenken' castle",
+				"east ardougne", "watchtower", "yanille", "senntisten", "west ardougne", "marim", "harmony island",
+				"kharyll", "lunar isle", "kourend castle", "the forgotten cemetery", "waterbirth island", "barrows",
+				"carrallangar", "fishing guild", "catherby", "annakarl", "ape atoll dungeon", "ghorrok",
+				"troll stronghold", "weiss"
+			).forEach(location -> swap(location, "teleport menu", config::swapPortalNexus));
 
 		swap("shared", "private", config::swapPrivate);
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -310,7 +310,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 			"grand exchange", "great kourend", "harmony island", "kharyrll", "lumbridge", "lumbridge graveyard",
 			"lunar isle", "marim", "mind altar", "salve graveyard", "seers' village", "senntisten", "troll stronghold",
 			"varrock", "watchtower", "waterbirth island", "weiss", "west ardougne", "yanille"
-		).forEach(location -> swap(location, "teleport menu", config::swapPortalNexus));
+		).forEach(location -> swap(location, "portal nexus", "teleport menu", config::swapPortalNexus));
 
 		swap("shared", "private", config::swapPrivate);
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -304,6 +304,42 @@ public class MenuEntrySwapperPlugin extends Plugin
 		swap("teleport menu", "draynor village", config::swapJewelleryBox);
 		swap("teleport menu", "al kharid", config::swapJewelleryBox);
 
+		swap("grand exchange", "teleport menu", config::swapPortalNexus);
+		swap("varrock", "teleport menu", config::swapPortalNexus);
+		swap("lumbridge grave'", "teleport menu", config::swapPortalNexus);
+		swap("draynor manor", "teleport menu", config::swapPortalNexus);
+		swap("battlefront", "teleport menu", config::swapPortalNexus);
+		swap("mind altar", "teleport menu", config::swapPortalNexus);
+		swap("lumbridge", "teleport menu", config::swapPortalNexus);
+		swap("falador", "teleport menu", config::swapPortalNexus);
+		swap("salve graveyard", "teleport menu", config::swapPortalNexus);
+		swap("camelot", "teleport menu", config::swapPortalNexus);
+		swap("seers' village", "teleport menu", config::swapPortalNexus);
+		swap("fenken' castle", "teleport menu", config::swapPortalNexus);
+		swap("east ardougne", "teleport menu", config::swapPortalNexus);
+		swap("watchtower", "teleport menu", config::swapPortalNexus);
+		swap("yanille", "teleport menu", config::swapPortalNexus);
+		swap("senntisten", "teleport menu", config::swapPortalNexus);
+		swap("west ardougne", "teleport menu", config::swapPortalNexus);
+		swap("marim", "teleport menu", config::swapPortalNexus);
+		swap("harmony island", "teleport menu", config::swapPortalNexus);
+		swap("kharyll", "teleport menu", config::swapPortalNexus);
+		swap("lunar isle", "teleport menu", config::swapPortalNexus);
+		swap("kourend castle", "teleport menu", config::swapPortalNexus);
+		swap("the forgotten cemetery", "teleport menu", config::swapPortalNexus);
+		swap("waterbirth island", "teleport menu", config::swapPortalNexus);
+		swap("barrows", "teleport menu", config::swapPortalNexus);
+		swap("carrallangar", "teleport menu", config::swapPortalNexus);
+		swap("fishing guild", "teleport menu", config::swapPortalNexus);
+		swap("catherby", "teleport menu", config::swapPortalNexus);
+		swap("annakarl", "teleport menu", config::swapPortalNexus);
+		swap("ape atoll dungeon", "teleport menu", config::swapPortalNexus);
+		swap("ghorrok", "teleport menu", config::swapPortalNexus);
+		swap("troll stronghold", "teleport menu", config::swapPortalNexus);
+		swap("weiss", "teleport menu", config::swapPortalNexus);
+
+
+
 		swap("shared", "private", config::swapPrivate);
 
 		swap("pick", "pick-lots", config::swapPick);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -305,13 +305,12 @@ public class MenuEntrySwapperPlugin extends Plugin
 		swap("teleport menu", "al kharid", config::swapJewelleryBox);
 
 		Arrays.asList(
-				"grand exchange", "varrock", "lumbridge grave'", "draynor manor", "battlefront", "mind altar",
-				"lumbridge", "falador", "salve graveyard", "camelot", "seers' village", "fenken' castle",
-				"east ardougne", "watchtower", "yanille", "senntisten", "west ardougne", "marim", "harmony island",
-				"kharyll", "lunar isle", "kourend castle", "the forgotten cemetery", "waterbirth island", "barrows",
-				"carrallangar", "fishing guild", "catherby", "annakarl", "ape atoll dungeon", "ghorrok",
-				"troll stronghold", "weiss"
-			).forEach(location -> swap(location, "teleport menu", config::swapPortalNexus));
+			"annakarl", "ape atoll dungeon", "ardougne", "barrows", "battlefront", "camelot", "carrallangar",
+			"catherby", "cemetery", "draynor manor", "falador", "fenkenstrain's castle", "fishing guild", "ghorrock",
+			"grand exchange", "great kourend", "harmony island", "kharyrll", "lumbridge", "lumbridge graveyard",
+			"lunar isle", "marim", "mind altar", "salve graveyard", "seers' village", "senntisten", "troll stronghold",
+			"varrock", "watchtower", "waterbirth island", "weiss", "west ardougne", "yanille"
+		).forEach(location -> swap(location, "teleport menu", config::swapPortalNexus));
 
 		swap("shared", "private", config::swapPrivate);
 


### PR DESCRIPTION
Attempt at implementing the suggestion from #11267.

This has been done by implementing a config setting in the Menu Entry Swapper UI which, if activated, will swap any set Left Click teleport for the Teleport Menu option.

Not sure if this is the most efficient way to do it so happy for feedback!