### PR TITLE
ground markers: show existing label when labelling a marker

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/groundmarkers/GroundMarkerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/groundmarkers/GroundMarkerPlugin.java
@@ -34,6 +34,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
 import lombok.AccessLevel;
@@ -313,20 +314,21 @@ public class GroundMarkerPlugin extends Plugin
 		WorldPoint worldPoint = WorldPoint.fromLocalInstance(client, localPoint);
 		final int regionId = worldPoint.getRegionID();
 
+		GroundMarkerPoint searchPoint = new GroundMarkerPoint(regionId, worldPoint.getRegionX(), worldPoint.getRegionY(), client.getPlane(), null, null);
+		Collection<GroundMarkerPoint> points = getPoints(regionId);
+		GroundMarkerPoint existing = points.stream()
+			.filter(p -> p.equals(searchPoint))
+			.findFirst().orElse(null);
+		if (existing == null)
+		{
+			return;
+		}
+
 		chatboxPanelManager.openTextInput("Tile label")
+			.value(Optional.ofNullable(existing.getLabel()).orElse(""))
 			.onDone((input) ->
 			{
 				input = Strings.emptyToNull(input);
-
-				GroundMarkerPoint searchPoint = new GroundMarkerPoint(regionId, worldPoint.getRegionX(), worldPoint.getRegionY(), client.getPlane(), null, null);
-				Collection<GroundMarkerPoint> points = getPoints(regionId);
-				GroundMarkerPoint existing = points.stream()
-					.filter(p -> p.equals(searchPoint))
-					.findFirst().orElse(null);
-				if (existing == null)
-				{
-					return;
-				}
 
 				GroundMarkerPoint newPoint = new GroundMarkerPoint(regionId, worldPoint.getRegionX(), worldPoint.getRegionY(), client.getPlane(), existing.getColor(), input);
 				points.remove(searchPoint);


### PR DESCRIPTION
Currently, labelling a ground marker will give the user an empty box. This is problematic if they just want to slightly change what's there, if they've got a lot of text in there. I personally ran into this issue making markers for Hydra that had instructions in them, and while that is quite an extreme example, it would be nice if the information wasn't cleared out.

Aside from that, the only functionality that changes with this PR is the existing point is always looked up (which is very very minor overhead if the user decides not to enter anything), and the user is now unable to try to label a marker that does not exist.