### PR TITLE
TimeTracking: Return shortened weekdays in doneEstimates

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/TabContentPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/TabContentPanel.java
@@ -77,7 +77,7 @@ public abstract class TabContentPanel extends JPanel
 			LocalDateTime currentTime = LocalDateTime.now();
 			if (endTime.getDayOfWeek() != currentTime.getDayOfWeek())
 			{
-				sb.append(endTime.getDayOfWeek().getDisplayName(TextStyle.FULL, Locale.getDefault())).append(" ");
+				sb.append(endTime.getDayOfWeek().getDisplayName(TextStyle.SHORT, Locale.getDefault())).append(" ");
 			}
 			sb.append("at ");
 			sb.append(formatter.format(endTime));


### PR DESCRIPTION
Use `TextStyle.SHORT` to avoid pushing notification icons off of the panel.
![java_VYte9y3Fi5](https://user-images.githubusercontent.com/7504779/107431544-820ccd00-6b1e-11eb-9831-3eaf5d1ad4b3.png)
![java_IJXfOWftXW](https://user-images.githubusercontent.com/7504779/107431557-85a05400-6b1e-11eb-84b2-7508f96584fe.png)
