### PR TITLE
Fix emoji plugin losing chat color

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/emojis/EmojiPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/emojis/EmojiPlugin.java
@@ -40,7 +40,6 @@ import net.runelite.api.events.ChatMessage;
 import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.OverheadTextChanged;
 import net.runelite.client.callback.ClientThread;
-import net.runelite.client.chat.ChatMessageManager;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
@@ -62,9 +61,6 @@ public class EmojiPlugin extends Plugin
 
 	@Inject
 	private ClientThread clientThread;
-
-	@Inject
-	private ChatMessageManager chatMessageManager;
 
 	private int modIconsStart = -1;
 
@@ -145,9 +141,7 @@ public class EmojiPlugin extends Plugin
 			return;
 		}
 
-		messageNode.setRuneLiteFormatMessage(updatedMessage);
-		chatMessageManager.update(messageNode);
-		client.refreshChat();
+		messageNode.setValue(updatedMessage);
 	}
 
 	@Subscribe

--- a/runelite-client/src/test/java/net/runelite/client/plugins/emojis/EmojiPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/emojis/EmojiPluginTest.java
@@ -89,7 +89,7 @@ public class EmojiPluginTest
 
 		emojiPlugin.onChatMessage(chatMessage);
 
-		verify(messageNode).setRuneLiteFormatMessage("<col=ff0000><img=0> <img=0> <img=0></col>");
+		verify(messageNode).setValue("<col=ff0000><img=0> <img=0> <img=0></col>");
 	}
 
 	@Test
@@ -113,7 +113,7 @@ public class EmojiPluginTest
 
 		emojiPlugin.onChatMessage(chatMessage);
 
-		verify(messageNode).setRuneLiteFormatMessage("<img=10>");
+		verify(messageNode).setValue("<img=10>");
 	}
 
 	@Test


### PR DESCRIPTION
Chat messages edited through the emoji plugin would lose their color whenever the chat color cache was rebuilt from changing any chat color because they were `setRuneLiteFormatMessage()` on the message nodes without the `<colNORMAL>` indicator.

![oky1unszdT](https://user-images.githubusercontent.com/45152844/107458345-e54c2e80-6b21-11eb-8d7c-5aafbdae025b.gif)

In this gif, the regular message does not change because it has no runelite format, so the widget's text never gets updated by the reloading of the color cache.

Edit: This is somewhat outdated. We are no longer using runelite formatted messages.