### PR TITLE
chat color: fix usernames not being recoloured if they have an icon

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/chat/ChatMessageManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/chat/ChatMessageManager.java
@@ -54,6 +54,7 @@ import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.events.ConfigChanged;
 import net.runelite.client.ui.JagexColors;
 import net.runelite.client.util.ColorUtil;
+import net.runelite.client.util.Text;
 
 @Singleton
 public class ChatMessageManager
@@ -125,7 +126,8 @@ public class ChatMessageManager
 			case PUBLICCHAT:
 			case MODCHAT:
 			{
-				boolean isFriend = client.isFriended(chatMessage.getName(), true) && !client.getLocalPlayer().getName().equals(chatMessage.getName());
+				String sanitizedUsername = Text.removeTags(chatMessage.getName());
+				boolean isFriend = client.isFriended(sanitizedUsername, true) && !client.getLocalPlayer().getName().equals(sanitizedUsername);
 
 				if (isFriend)
 				{

--- a/runelite-client/src/test/java/net/runelite/client/chat/ChatMessageManagerTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/chat/ChatMessageManagerTest.java
@@ -38,7 +38,6 @@ import net.runelite.client.config.ChatColorConfig;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import static org.mockito.ArgumentMatchers.eq;
 import org.mockito.Mock;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -68,14 +67,14 @@ public class ChatMessageManagerTest
 	}
 
 	@Test
-	public void onChatMessage()
+	public void testMessageRecoloring()
 	{
-		when(chatColorConfig.opaquePublicChat()).thenReturn(Color.decode("#b20000"));
+		when(chatColorConfig.opaqueServerMessage()).thenReturn(Color.decode("#b20000"));
 
 		chatMessageManager.loadColors();
 
 		ChatMessage chatMessage = new ChatMessage();
-		chatMessage.setType(ChatMessageType.PUBLICCHAT);
+		chatMessage.setType(ChatMessageType.GAMEMESSAGE);
 
 		MessageNode messageNode = mock(MessageNode.class);
 		chatMessage.setMessageNode(messageNode);
@@ -83,7 +82,7 @@ public class ChatMessageManagerTest
 		when(messageNode.getValue()).thenReturn("Your dodgy necklace protects you. It has <col=ff0000>1</col> charge left.");
 		chatMessageManager.onChatMessage(chatMessage);
 
-		verify(messageNode).setValue(eq("<col=b20000>Your dodgy necklace protects you. It has <col=ff0000>1<col=b20000> charge left.</col>"));
+		verify(messageNode).setValue("<col=b20000>Your dodgy necklace protects you. It has <col=ff0000>1<col=b20000> charge left.</col>");
 	}
 
 	@Test

--- a/runelite-client/src/test/java/net/runelite/client/chat/ChatMessageManagerTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/chat/ChatMessageManagerTest.java
@@ -32,6 +32,7 @@ import java.awt.Color;
 import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
 import net.runelite.api.MessageNode;
+import net.runelite.api.Player;
 import net.runelite.api.events.ChatMessage;
 import net.runelite.client.config.ChatColorConfig;
 import org.junit.Before;
@@ -83,5 +84,68 @@ public class ChatMessageManagerTest
 		chatMessageManager.onChatMessage(chatMessage);
 
 		verify(messageNode).setValue(eq("<col=b20000>Your dodgy necklace protects you. It has <col=ff0000>1<col=b20000> charge left.</col>"));
+	}
+
+	@Test
+	public void testPublicFriendUsernameRecolouring()
+	{
+		final String localPlayerName = "RuneLite";
+		final String friendName = "Zezima";
+
+		when(chatColorConfig.opaquePublicFriendUsernames()).thenReturn(Color.decode("#b20000"));
+
+		chatMessageManager.loadColors();
+
+		// Setup message
+		ChatMessage chatMessage = new ChatMessage();
+		chatMessage.setType(ChatMessageType.PUBLICCHAT);
+		chatMessage.setName(friendName);
+
+		MessageNode messageNode = mock(MessageNode.class);
+		chatMessage.setMessageNode(messageNode);
+		when(messageNode.getName()).thenReturn(friendName);
+
+		// Setup friend checking
+		Player localPlayer = mock(Player.class);
+
+		when(client.isFriended(friendName, true)).thenReturn(true);
+		when(client.getLocalPlayer()).thenReturn(localPlayer);
+		when(localPlayer.getName()).thenReturn(localPlayerName);
+
+		chatMessageManager.onChatMessage(chatMessage);
+
+		verify(messageNode).setName("<col=b20000>" + friendName + "</col>");
+	}
+
+	@Test
+	public void testPublicIronmanFriendUsernameRecolouring()
+	{
+		final String localPlayerName = "RuneLite";
+		final String friendName = "<img=3>BuddhaPuck";
+		final String sanitizedFriendName = "BuddhaPuck";
+
+		when(chatColorConfig.opaquePublicFriendUsernames()).thenReturn(Color.decode("#b20000"));
+
+		chatMessageManager.loadColors();
+
+		// Setup message
+		ChatMessage chatMessage = new ChatMessage();
+		chatMessage.setType(ChatMessageType.PUBLICCHAT);
+		chatMessage.setName(friendName);
+
+		MessageNode messageNode = mock(MessageNode.class);
+		chatMessage.setMessageNode(messageNode);
+		when(messageNode.getName()).thenReturn(friendName);
+
+		// Setup friend checking
+		Player localPlayer = mock(Player.class);
+
+		when(client.isFriended(sanitizedFriendName, true)).thenReturn(true);
+		when(client.getLocalPlayer()).thenReturn(localPlayer);
+		when(localPlayer.getName()).thenReturn(localPlayerName);
+
+		chatMessageManager.onChatMessage(chatMessage);
+
+		verify(messageNode).setName("<col=b20000>" + friendName + "</col>");
 	}
 }


### PR DESCRIPTION
When checking if a message's sender is your friend for username recolouring, the `ChatMessageManager` fails to account for any icon the sender might have, eg. if they're an ironman or a PMod. This PR rectifies that.

Issue initially reported by `ol long sack` in Discord.