### PR TITLE
Add new utility methods for checking if world points are inside world areas

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/coords/WorldArea.java
+++ b/runelite-api/src/main/java/net/runelite/api/coords/WorldArea.java
@@ -152,6 +152,26 @@ public class WorldArea
 	}
 
 	/**
+	 * Checks whether a tile is contained within the area and in the same plane.
+	 *
+	 * @return {@code true} if the tile is contained within the bounds of this area, {@code false} otherwise.
+	 */
+	public boolean contains(WorldPoint worldPoint)
+	{
+		return distanceTo(worldPoint) == 0;
+	}
+
+	/**
+	 * Checks whether a tile is contained within the area while ignoring the plane.
+	 *
+	 * @return {@code true} if the tile is contained within the bounds of this area regardless of plane, {@code false} otherwise.
+	 */
+	public boolean contains2D(WorldPoint worldPoint)
+	{
+		return distanceTo2D(worldPoint) == 0;
+	}
+
+	/**
 	 * Checks whether this area is within melee distance of another.
 	 * <p>
 	 * Melee distance is exactly 1 tile, so this method computes and returns

--- a/runelite-api/src/main/java/net/runelite/api/coords/WorldPoint.java
+++ b/runelite-api/src/main/java/net/runelite/api/coords/WorldPoint.java
@@ -406,4 +406,40 @@ public class WorldPoint
 		}
 		return worldPoint;
 	}
+
+	/**
+	 * Checks whether this tile is located within any of the given areas.
+	 *
+	 * @param worldAreas areas to check within
+	 * @return {@code true} if any area contains this point, {@code false} otherwise.
+	 */
+	public boolean isInArea(WorldArea... worldAreas)
+	{
+		for (WorldArea area : worldAreas)
+		{
+			if (area.contains(this))
+			{
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Checks whether this tile is located within any of the given areas, disregarding any plane differences.
+	 *
+	 * @param worldAreas areas to check within
+	 * @return {@code true} if any area contains this point, {@code false} otherwise.
+	 */
+	public boolean isInArea2D(WorldArea... worldAreas)
+	{
+		for (WorldArea area : worldAreas)
+		{
+			if (area.contains2D(this))
+			{
+				return true;
+			}
+		}
+		return false;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/npcunaggroarea/NpcAggroAreaPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npcunaggroarea/NpcAggroAreaPlugin.java
@@ -248,7 +248,7 @@ public class NpcAggroAreaPlugin extends Plugin
 
 	private static boolean isInWilderness(WorldPoint location)
 	{
-		return WILDERNESS_ABOVE_GROUND.distanceTo2D(location) == 0 || WILDERNESS_UNDERGROUND.distanceTo2D(location) == 0;
+		return location.isInArea2D(WILDERNESS_ABOVE_GROUND, WILDERNESS_UNDERGROUND);
 	}
 
 	private boolean isNpcMatch(NPC npc)


### PR DESCRIPTION
These utility methods are useful in plugins both for the hub and runelite. I swapped out one of the old ways it was done in the NpcAggroAreaPlugin as an example. I ran some unit tests and the methods seem to functionally be the same as the distance == 0 checks.