### PR TITLE
Add additional cooking messages to crowdsourcing + cooking plugins

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/cooking/CookingPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cooking/CookingPlugin.java
@@ -174,9 +174,16 @@ public class CookingPlugin extends Plugin
 
 		if (message.startsWith("You successfully cook")
 			|| message.startsWith("You successfully bake")
+			|| message.startsWith("You successfully fry")
 			|| message.startsWith("You manage to cook")
 			|| message.startsWith("You roast a")
+			|| message.startsWith("You spit-roast")
 			|| message.startsWith("You cook")
+			|| message.startsWith("Eventually the Jubbly")
+			|| message.startsWith("You half-cook")
+			|| message.startsWith("The undead meat is now cooked")
+			|| message.startsWith("The undead chicken is now cooked")
+			|| message.startsWith("You successfully scramble")
 			|| message.startsWith("You dry a piece of meat"))
 		{
 			if (session == null)
@@ -189,6 +196,8 @@ public class CookingPlugin extends Plugin
 
 		}
 		else if (message.startsWith("You accidentally burn")
+			|| message.startsWith("You burn")
+			|| message.startsWith("Unfortunately the Jubbly")
 			|| message.startsWith("You accidentally spoil"))
 		{
 			if (session == null)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/crowdsourcing/cooking/CrowdsourcingCooking.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/crowdsourcing/cooking/CrowdsourcingCooking.java
@@ -85,6 +85,9 @@ public class CrowdsourcingCooking
 			|| message.startsWith("Unfortunately the Jubbly")
 			|| message.startsWith("You accidentally burn")
 			|| message.startsWith("You half-cook")
+			|| message.startsWith("The undead meat is now cooked")
+			|| message.startsWith("The undead chicken is now cooked")
+			|| message.startsWith("You successfully scramble")
 			|| message.startsWith("You accidentally spoil"))
 		{
 			boolean inHosidiusKitchen = false;


### PR DESCRIPTION
Based on my spreadsheet on https://docs.google.com/spreadsheets/d/1UrDkEdgC6dl3DVPn5kQFaT8B5qUdB4YijWARSffCFDY/edit?usp=sharing this should cover all cookable items outside CoX.