### PR TITLE
MenuManager: Add menu entries in insert order

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/menus/MenuManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/menus/MenuManager.java
@@ -90,9 +90,9 @@ public class MenuManager
 		managedMenuOptions.remove(customMenuOption.getWidgetId(), customMenuOption);
 	}
 
-	private boolean menuContainsCustomMenu(WidgetMenuOption customMenuOption)
+	private static boolean menuContainsCustomMenu(MenuEntry[] menuEntries, WidgetMenuOption customMenuOption)
 	{
-		for (MenuEntry menuEntry : client.getMenuEntries())
+		for (MenuEntry menuEntry : menuEntries)
 		{
 			String option = menuEntry.getOption();
 			String target = menuEntry.getTarget();
@@ -115,23 +115,36 @@ public class MenuManager
 
 		int widgetId = event.getActionParam1();
 		Collection<WidgetMenuOption> options = managedMenuOptions.get(widgetId);
+		if (options.isEmpty())
+		{
+			return;
+		}
 
+		MenuEntry[] menuEntries = client.getMenuEntries();
+
+		MenuEntry[] newMenuEntries = Arrays.copyOf(menuEntries, menuEntries.length + options.size());
+		// Menu entries are sorted with higher-index entries appearing toward the top of the minimenu, so insert older
+		// managed menu entries at higher indices and work backward for newer entries so newly-added entries appear at
+		// the bottom
+		int insertIdx = newMenuEntries.length - 1;
 		for (WidgetMenuOption currentMenu : options)
 		{
-			if (!menuContainsCustomMenu(currentMenu))//Don't add if we have already added it to this widget
+			// Exit if we've inserted the managed menu entries already
+			if (menuContainsCustomMenu(menuEntries, currentMenu))
 			{
-				MenuEntry[] menuEntries = client.getMenuEntries();
-				menuEntries = Arrays.copyOf(menuEntries, menuEntries.length + 1);
-
-				MenuEntry menuEntry = menuEntries[menuEntries.length - 1] = new MenuEntry();
-				menuEntry.setOption(currentMenu.getMenuOption());
-				menuEntry.setParam1(widgetId);
-				menuEntry.setTarget(currentMenu.getMenuTarget());
-				menuEntry.setType(MenuAction.RUNELITE.getId());
-
-				client.setMenuEntries(menuEntries);
+				return;
 			}
+
+			MenuEntry menuEntry = new MenuEntry();
+			menuEntry.setOption(currentMenu.getMenuOption());
+			menuEntry.setParam1(widgetId);
+			menuEntry.setTarget(currentMenu.getMenuTarget());
+			menuEntry.setType(MenuAction.RUNELITE.getId());
+
+			newMenuEntries[insertIdx--] = menuEntry;
 		}
+
+		client.setMenuEntries(newMenuEntries);
 	}
 
 	public void addPlayerMenuItem(String menuText)

--- a/runelite-client/src/test/java/net/runelite/client/menus/MenuManagerTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/menus/MenuManagerTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2021, Jordan Atwood <nightfirecat@protonmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.menus;
+
+import com.google.inject.Guice;
+import com.google.inject.testing.fieldbinder.Bind;
+import com.google.inject.testing.fieldbinder.BoundFieldModule;
+import javax.inject.Inject;
+import net.runelite.api.Client;
+import net.runelite.api.MenuAction;
+import static net.runelite.api.MenuAction.CC_OP;
+import static net.runelite.api.MenuAction.RUNELITE;
+import net.runelite.api.MenuEntry;
+import net.runelite.api.events.MenuEntryAdded;
+import static net.runelite.api.widgets.WidgetInfo.WORLD_MAP_OPTION;
+import net.runelite.client.util.Text;
+import static org.junit.Assert.assertArrayEquals;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mock;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.stubbing.Answer;
+
+@RunWith(MockitoJUnitRunner.class)
+public class MenuManagerTest
+{
+	private static final MenuEntry CANCEL = new MenuEntry();
+
+	@Inject
+	private MenuManager menuManager;
+
+	@Mock
+	@Bind
+	private Client client;
+
+	private MenuEntry[] clientMenuEntries = {CANCEL};
+
+	@BeforeClass
+	public static void beforeClass()
+	{
+		CANCEL.setOption("Cancel");
+		CANCEL.setType(MenuAction.CANCEL.getId());
+		CANCEL.setParam1(WORLD_MAP_OPTION.getPackedId());
+	}
+
+	@Before
+	public void before()
+	{
+		Guice.createInjector(BoundFieldModule.of(this)).injectMembers(this);
+
+		doAnswer((Answer<Void>) invocationOnMock ->
+		{
+			clientMenuEntries = invocationOnMock.getArgument(0, MenuEntry[].class);
+			return null;
+		}).when(client).setMenuEntries(ArgumentMatchers.any(MenuEntry[].class));
+		when(client.getMenuEntries()).thenAnswer((Answer<MenuEntry[]>) invocationMock -> clientMenuEntries);
+	}
+
+	@Test
+	public void testManagedMenuOrder()
+	{
+		final MenuEntry first = new MenuEntry();
+		final MenuEntry second = new MenuEntry();
+		final MenuEntry third = new MenuEntry();
+		first.setOption("Test");
+		first.setTarget("First Entry");
+		first.setParam1(WORLD_MAP_OPTION.getPackedId());
+		first.setType(RUNELITE.getId());
+		second.setOption("Test");
+		second.setTarget("Second Entry");
+		second.setParam1(WORLD_MAP_OPTION.getPackedId());
+		second.setType(RUNELITE.getId());
+		third.setOption("Test");
+		third.setTarget("Third Entry");
+		third.setParam1(WORLD_MAP_OPTION.getPackedId());
+		third.setType(RUNELITE.getId());
+		menuManager.addManagedCustomMenu(new WidgetMenuOption(first.getOption(), first.getTarget(), WORLD_MAP_OPTION));
+		menuManager.addManagedCustomMenu(new WidgetMenuOption(second.getOption(), second.getTarget(), WORLD_MAP_OPTION));
+		menuManager.addManagedCustomMenu(new WidgetMenuOption(third.getOption(), third.getTarget(), WORLD_MAP_OPTION));
+
+		menuManager.onMenuEntryAdded(new MenuEntryAdded(
+			CANCEL.getOption(),
+			CANCEL.getTarget(),
+			CC_OP.getId(),
+			CANCEL.getIdentifier(),
+			CANCEL.getParam0(),
+			CANCEL.getParam1()));
+
+		ArgumentCaptor<MenuEntry[]> captor = ArgumentCaptor.forClass(MenuEntry[].class);
+		verify(client, atLeastOnce()).setMenuEntries(captor.capture());
+
+		final MenuEntry[] resultMenuEntries = captor.getValue();
+		// Strip color tags from menu options before array comparison
+		for (MenuEntry resultEntry : resultMenuEntries)
+		{
+			final String resultTarget = resultEntry.getTarget();
+			if (resultTarget != null)
+			{
+				resultEntry.setTarget(Text.removeTags(resultEntry.getTarget()));
+			}
+		}
+
+		assertArrayEquals(new MenuEntry[]{CANCEL, third, second, first}, resultMenuEntries);
+	}
+}


### PR DESCRIPTION
This ensures that entries added via MenuManager are added in insert order, with newly-added managed menu entries being placed lower in the menu than older ones.

For instance, with #13124 applied and all other plugins disabled, this changes the behavior from what is shown on master when opening the minimenu of the world map widget:

```
Floating World Map
Fullscreen World Map
Clear Ground Markers
Import Ground Markers
Export Ground Markers
Cancel
```

to what would be expected, given the entries are added in the order: (Export, Import, Clear)

```
Floating World Map
Fullscreen World Map
Export Ground Markers
Import Ground Markers
Clear Ground Markers
Cancel
```