### PR TITLE
Plugin: Menu entry swap for Travel/Dive on rowboat in Fossil Island

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -650,4 +650,15 @@ public interface MenuEntrySwapperConfig extends Config
 	{
 		return false;
 	}
+
+	@ConfigItem(
+			keyName = "swapRowboatDive",
+			name = "Fossil Island Rowboat Dive",
+			description = "Swap Travel with Dive on the rowboat found on the small island north-east of Fossil Island",
+			section = objectSection
+	)
+	default boolean swapRowboatDive()
+	{
+		return false;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -373,6 +373,8 @@ public class MenuEntrySwapperPlugin extends Plugin
 		swapTeleport("teleport to house", "outside");
 
 		swap("eat", "guzzle", config::swapRockCake);
+
+		swap("travel", "dive", config::swapRowboatDive);
 	}
 
 	private void swap(String option, String swappedOption, Supplier<Boolean> enabled)


### PR DESCRIPTION
Close #13232

Adds a Menu Entry Swap option for the Fossil Island Rowboat. Swaps the Travel option with Dive.