### PR TITLE
Add item stats in equipment tab

### DIFF
--- a/http-api/src/main/java/net/runelite/http/api/item/ItemStats.java
+++ b/http-api/src/main/java/net/runelite/http/api/item/ItemStats.java
@@ -30,6 +30,16 @@ import lombok.Value;
 @Value
 public class ItemStats
 {
+	// Unarmed attack speed is 4
+	public static final ItemStats UNARMED = new ItemStats(false, true, 0, 0,
+			ItemEquipmentStats.builder()
+					.aspeed(4)
+					.build());
+
+	public static final ItemStats NOTHING = new ItemStats(false, true, 0, 0,
+			ItemEquipmentStats.builder()
+					.build());
+
 	private boolean quest;
 	private boolean equipable;
 	private double weight;
@@ -53,7 +63,7 @@ public class ItemStats
 		{
 			final ItemEquipmentStats equipment = this.equipment != null
 				? this.equipment
-				: new ItemEquipmentStats.ItemEquipmentStatsBuilder().build();
+				: NOTHING.getEquipment();
 
 			newEquipment = new ItemEquipmentStats.ItemEquipmentStatsBuilder()
 				.slot(equipment.getSlot())
@@ -73,6 +83,50 @@ public class ItemStats
 				.prayer(equipment.getPrayer() - other.equipment.getPrayer())
 				.aspeed(equipment.getAspeed() - other.equipment.getAspeed())
 				.build();
+		}
+		else
+		{
+			newEquipment = equipment;
+		}
+
+		return new ItemStats(quest, equipable, newWeight, 0, newEquipment);
+	}
+
+	public ItemStats add(ItemStats other)
+	{
+		if (other == null)
+		{
+			return this;
+		}
+
+		final double newWeight = weight + other.weight;
+		final ItemEquipmentStats newEquipment;
+
+
+		if (other.equipment != null)
+		{
+			final ItemEquipmentStats equipment = this.equipment != null
+					? this.equipment
+					: NOTHING.getEquipment();
+
+			newEquipment = new ItemEquipmentStats.ItemEquipmentStatsBuilder()
+					.slot(equipment.getSlot())
+					.astab(equipment.getAstab() + other.equipment.getAstab())
+					.aslash(equipment.getAslash() + other.equipment.getAslash())
+					.acrush(equipment.getAcrush() + other.equipment.getAcrush())
+					.amagic(equipment.getAmagic() + other.equipment.getAmagic())
+					.arange(equipment.getArange() + other.equipment.getArange())
+					.dstab(equipment.getDstab() + other.equipment.getDstab())
+					.dslash(equipment.getDslash() + other.equipment.getDslash())
+					.dcrush(equipment.getDcrush() + other.equipment.getDcrush())
+					.dmagic(equipment.getDmagic() + other.equipment.getDmagic())
+					.drange(equipment.getDrange() + other.equipment.getDrange())
+					.str(equipment.getStr() + other.equipment.getStr())
+					.rstr(equipment.getRstr() + other.equipment.getRstr())
+					.mdmg(equipment.getMdmg() + other.equipment.getMdmg())
+					.prayer(equipment.getPrayer() + other.equipment.getPrayer())
+					.aspeed(equipment.getAspeed() + other.equipment.getAspeed())
+					.build();
 		}
 		else
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatConfig.java
@@ -117,7 +117,10 @@ public interface ItemStatConfig extends Config
 			name = "Show Stats in Equipment",
 			description = "Show item stats on equipment tooltip"
 	)
-	default boolean showStatsInEquipment() {return true;}
+	default boolean showStatsInEquipment()
+	{
+		return true;
+	}
 
 	@ConfigItem(
 		keyName = "alwaysShowBaseStats",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatConfig.java
@@ -113,6 +113,13 @@ public interface ItemStatConfig extends Config
 	}
 
 	@ConfigItem(
+			keyName = "showStatsInEquipment",
+			name = "Show Stats in Equipment",
+			description = "Show item stats on equipment tooltip"
+	)
+	default boolean showStatsInEquipment() {return true;}
+
+	@ConfigItem(
 		keyName = "alwaysShowBaseStats",
 		name = "Always Show Base Stats",
 		description = "Always include the base items stats in the tooltip"

--- a/runelite-client/src/test/java/net/runelite/client/plugins/itemstats/ItemStatOverlayTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/itemstats/ItemStatOverlayTest.java
@@ -33,6 +33,7 @@ import net.runelite.api.Client;
 import net.runelite.api.EquipmentInventorySlot;
 import net.runelite.api.InventoryID;
 import net.runelite.api.ItemContainer;
+import net.runelite.api.Item;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.util.Text;
 import net.runelite.http.api.item.ItemEquipmentStats;
@@ -93,6 +94,18 @@ public class ItemStatOverlayTest
 			.arange(110)
 			.aspeed(7)
 			.build());
+	private static final ItemStats DFS = new ItemStats(false, true, 7.257, 8,
+			ItemEquipmentStats.builder()
+			.slot(EquipmentInventorySlot.SHIELD.getSlotIdx())
+			.amagic(-10)
+			.arange(-5)
+			.dstab(20)
+			.dslash(25)
+			.dcrush(22)
+			.dmagic(10)
+			.drange(22)
+			.str(7)
+			.build());
 
 	@Inject
 	ItemStatOverlay overlay;
@@ -121,14 +134,14 @@ public class ItemStatOverlayTest
 	@Test
 	public void testUnarmedAttackSpeed()
 	{
-		assertEquals(ItemStatOverlay.UNARMED.getEquipment().getAspeed(), ABYSSAL_DAGGER.getEquipment().getAspeed());
-		assertEquals(ItemStatOverlay.UNARMED.getEquipment().getAspeed(), KATANA.getEquipment().getAspeed());
-		assertEquals(-1, BLOWPIPE.getEquipment().getAspeed() - ItemStatOverlay.UNARMED.getEquipment().getAspeed());
-		assertEquals(3, HEAVY_BALLISTA.getEquipment().getAspeed() - ItemStatOverlay.UNARMED.getEquipment().getAspeed());
+		assertEquals(ItemStats.UNARMED.getEquipment().getAspeed(), ABYSSAL_DAGGER.getEquipment().getAspeed());
+		assertEquals(ItemStats.UNARMED.getEquipment().getAspeed(), KATANA.getEquipment().getAspeed());
+		assertEquals(-1, BLOWPIPE.getEquipment().getAspeed() - ItemStats.UNARMED.getEquipment().getAspeed());
+		assertEquals(3, HEAVY_BALLISTA.getEquipment().getAspeed() - ItemStats.UNARMED.getEquipment().getAspeed());
 	}
 
 	@Test
-	public void testBuildStatBonusString()
+	public void testEquipItemTooltip()
 	{
 		// Empty equipment (fully unarmed)
 		final ItemContainer equipment = mock(ItemContainer.class);
@@ -137,7 +150,7 @@ public class ItemStatOverlayTest
 		String tooltip;
 		String sanitizedTooltip;
 
-		tooltip = overlay.buildStatBonusString(ABYSSAL_DAGGER);
+		tooltip = overlay.equipItemTooltip(ABYSSAL_DAGGER);
 		sanitizedTooltip = Text.sanitizeMultilineText(tooltip);
 		assertTrue(sanitizedTooltip.contains("Stab: +75"));
 		assertTrue(sanitizedTooltip.contains("Slash: +40"));
@@ -146,7 +159,7 @@ public class ItemStatOverlayTest
 		assertTrue(sanitizedTooltip.contains("Melee Str: +75"));
 		assertFalse(sanitizedTooltip.contains("Speed:"));
 
-		tooltip = overlay.buildStatBonusString(KATANA);
+		tooltip = overlay.equipItemTooltip(KATANA);
 		sanitizedTooltip = Text.sanitizeMultilineText(tooltip);
 		assertTrue(sanitizedTooltip.contains("Stab: +7"));
 		assertTrue(sanitizedTooltip.contains("Slash: +45"));
@@ -157,17 +170,228 @@ public class ItemStatOverlayTest
 		assertTrue(sanitizedTooltip.contains("Melee Str: +40"));
 		assertFalse(sanitizedTooltip.contains("Speed:"));
 
-		tooltip = overlay.buildStatBonusString(BLOWPIPE);
+		tooltip = overlay.equipItemTooltip(BLOWPIPE);
 		sanitizedTooltip = Text.sanitizeMultilineText(tooltip);
 		assertTrue(sanitizedTooltip.contains("Range: +60"));
 		assertTrue(sanitizedTooltip.contains("Range Str: +40"));
 		assertTrue(sanitizedTooltip.contains("Speed: -1"));
 		assertFalse(sanitizedTooltip.contains("Stab:"));
 
-		tooltip = overlay.buildStatBonusString(HEAVY_BALLISTA);
+		tooltip = overlay.equipItemTooltip(HEAVY_BALLISTA);
 		sanitizedTooltip = Text.sanitizeMultilineText(tooltip);
 		assertTrue(sanitizedTooltip.contains("Range: +110"));
 		assertTrue(sanitizedTooltip.contains("Speed: +3"));
 		assertFalse(sanitizedTooltip.contains("Stab:"));
+	}
+
+	@Test
+	public void testEquipItemTooltip_2HBothHandsFull()
+	{
+		// Empty equipment (fully unarmed)
+		final ItemContainer equipment = mock(ItemContainer.class);
+		when(client.getItemContainer(InventoryID.EQUIPMENT)).thenReturn(equipment);
+
+		when(equipment.getItem(EquipmentInventorySlot.WEAPON.getSlotIdx()))
+				.thenReturn(new Item(0, 0));
+		when(itemManager.getItemStats(0, false))
+				.thenReturn(ABYSSAL_DAGGER);
+
+		when(equipment.getItem(EquipmentInventorySlot.SHIELD.getSlotIdx()))
+				.thenReturn(new Item(1, 0));
+		when(itemManager.getItemStats(1, false))
+				.thenReturn(DFS);
+
+		final String tooltip = overlay.equipItemTooltip(BLOWPIPE);
+		final String sanitizedTooltip = Text.sanitizeMultilineText(tooltip);
+
+		// Attack Bonuses
+		assertTrue(sanitizedTooltip.contains("Speed: -1"));
+		assertTrue(sanitizedTooltip.contains("Melee Str: -82"));
+		assertTrue(sanitizedTooltip.contains("Range Str: +40"));
+		assertTrue(sanitizedTooltip.contains("Stab: -75"));
+		assertTrue(sanitizedTooltip.contains("Slash: -40"));
+		assertTrue(sanitizedTooltip.contains("Crush: +4"));
+		assertTrue(sanitizedTooltip.contains("Magic: +9"));
+		assertTrue(sanitizedTooltip.contains("Range: +65"));
+		// Defense Bonuses
+		assertTrue(sanitizedTooltip.contains("Stab: -20"));
+		assertTrue(sanitizedTooltip.contains("Slash: -25"));
+		assertTrue(sanitizedTooltip.contains("Crush: -22"));
+		assertTrue(sanitizedTooltip.contains("Magic: -11"));
+		assertTrue(sanitizedTooltip.contains("Range: -22"));
+	}
+
+	@Test
+	public void testEquipItemTooltip_2HOffHandFull()
+	{
+		// Empty equipment (fully unarmed)
+		final ItemContainer equipment = mock(ItemContainer.class);
+		when(client.getItemContainer(InventoryID.EQUIPMENT)).thenReturn(equipment);
+
+		when(equipment.getItem(EquipmentInventorySlot.WEAPON.getSlotIdx()))
+				.thenReturn(null);
+
+		when(equipment.getItem(EquipmentInventorySlot.SHIELD.getSlotIdx()))
+				.thenReturn(new Item(1, 0));
+		when(itemManager.getItemStats(1, false))
+				.thenReturn(DFS);
+
+		final String tooltip = overlay.equipItemTooltip(BLOWPIPE);
+		final String sanitizedTooltip = Text.sanitizeMultilineText(tooltip);
+
+		// Attack Bonuses
+		assertTrue(sanitizedTooltip.contains("Speed: -1"));
+		assertTrue(sanitizedTooltip.contains("Melee Str: -7"));
+		assertTrue(sanitizedTooltip.contains("Range Str: +40"));
+		assertTrue(sanitizedTooltip.contains("Range: +65"));
+		// Defense Bonuses
+		assertTrue(sanitizedTooltip.contains("Stab: -20"));
+		assertTrue(sanitizedTooltip.contains("Slash: -25"));
+		assertTrue(sanitizedTooltip.contains("Crush: -22"));
+		assertTrue(sanitizedTooltip.contains("Magic: -10"));
+		assertTrue(sanitizedTooltip.contains("Range: -22"));
+	}
+
+	@Test
+	public void testEquipItemTooltip_ShowBaseStats()
+	{
+		when(config.alwaysShowBaseStats()).thenReturn(true);
+
+		// Empty equipment (fully unarmed)
+		final ItemContainer equipment = mock(ItemContainer.class);
+		when(client.getItemContainer(InventoryID.EQUIPMENT)).thenReturn(equipment);
+
+		String tooltip;
+		String sanitizedTooltip;
+
+		tooltip = overlay.equipItemTooltip(ABYSSAL_DAGGER);
+		sanitizedTooltip = Text.sanitizeMultilineText(tooltip);
+		assertTrue(sanitizedTooltip.contains("Stab: 75 (+75)"));
+		assertTrue(sanitizedTooltip.contains("Slash: 40 (+40)"));
+		assertTrue(sanitizedTooltip.contains("Crush: -4 (-4)"));
+		assertEquals(2, StringUtils.countMatches(sanitizedTooltip, "Magic: 1 (+1)")); // Attack and defense
+		assertTrue(sanitizedTooltip.contains("Melee Str: 75 (+75)"));
+		assertTrue(sanitizedTooltip.contains("Speed: 4"));
+
+		tooltip = overlay.equipItemTooltip(KATANA);
+		sanitizedTooltip = Text.sanitizeMultilineText(tooltip);
+		assertTrue(sanitizedTooltip.contains("Stab: 7 (+7)"));
+		assertTrue(sanitizedTooltip.contains("Slash: 45 (+45)"));
+		assertTrue(sanitizedTooltip.contains("Stab: 3 (+3)")); // Defense
+		assertTrue(sanitizedTooltip.contains("Slash: 7 (+7)")); // Defense
+		assertTrue(sanitizedTooltip.contains("Crush: 7 (+7)")); // Defense
+		assertTrue(sanitizedTooltip.contains("Range: -3 (-3)")); // Defense
+		assertTrue(sanitizedTooltip.contains("Melee Str: 40 (+40)"));
+		assertTrue(sanitizedTooltip.contains("Speed: 4"));
+
+		tooltip = overlay.equipItemTooltip(BLOWPIPE);
+		sanitizedTooltip = Text.sanitizeMultilineText(tooltip);
+		assertTrue(sanitizedTooltip.contains("Range: 60 (+60)"));
+		assertTrue(sanitizedTooltip.contains("Range Str: 40 (+40)"));
+		assertTrue(sanitizedTooltip.contains("Speed: 3 (-1)"));
+		assertFalse(sanitizedTooltip.contains("Stab:"));
+
+		tooltip = overlay.equipItemTooltip(HEAVY_BALLISTA);
+		sanitizedTooltip = Text.sanitizeMultilineText(tooltip);
+		assertTrue(sanitizedTooltip.contains("Range: 110 (+110)"));
+		assertTrue(sanitizedTooltip.contains("Speed: 7 (+3)"));
+		assertFalse(sanitizedTooltip.contains("Stab:"));
+	}
+
+	@Test
+	public void testUnequipItemTooltip()
+	{
+		String tooltip = overlay.unequipItemTooltip(ABYSSAL_DAGGER);
+		String sanitizedTooltip = Text.sanitizeMultilineText(tooltip);
+		assertTrue(sanitizedTooltip.contains("Stab: -75"));
+		assertTrue(sanitizedTooltip.contains("Slash: -40"));
+		assertTrue(sanitizedTooltip.contains("Crush: +4"));
+		assertEquals(2, StringUtils.countMatches(sanitizedTooltip, "Magic: -1")); // Attack and defense
+		assertTrue(sanitizedTooltip.contains("Melee Str: -75"));
+		assertFalse(sanitizedTooltip.contains("Speed:"));
+
+		tooltip = overlay.unequipItemTooltip(KATANA);
+		sanitizedTooltip = Text.sanitizeMultilineText(tooltip);
+		assertTrue(sanitizedTooltip.contains("Stab: -7"));
+		assertTrue(sanitizedTooltip.contains("Slash: -45"));
+		assertTrue(sanitizedTooltip.contains("Stab: -3")); // Defense
+		assertTrue(sanitizedTooltip.contains("Slash: -7")); // Defense
+		assertTrue(sanitizedTooltip.contains("Crush: -7")); // Defense
+		assertTrue(sanitizedTooltip.contains("Range: +3")); // Defense
+		assertTrue(sanitizedTooltip.contains("Melee Str: -40"));
+		assertFalse(sanitizedTooltip.contains("Speed:"));
+
+		tooltip = overlay.unequipItemTooltip(BLOWPIPE);
+		sanitizedTooltip = Text.sanitizeMultilineText(tooltip);
+		assertTrue(sanitizedTooltip.contains("Range: -60"));
+		assertTrue(sanitizedTooltip.contains("Range Str: -40"));
+		assertTrue(sanitizedTooltip.contains("Speed: +1"));
+		assertFalse(sanitizedTooltip.contains("Stab:"));
+
+		tooltip = overlay.unequipItemTooltip(HEAVY_BALLISTA);
+		sanitizedTooltip = Text.sanitizeMultilineText(tooltip);
+		assertTrue(sanitizedTooltip.contains("Range: -110"));
+		assertTrue(sanitizedTooltip.contains("Speed: -3"));
+		assertFalse(sanitizedTooltip.contains("Stab:"));
+	}
+
+	@Test
+	public void testUnequipItemTooltip_Weapon()
+	{
+		final String tooltip = overlay.unequipItemTooltip(HEAVY_BALLISTA);
+		final String sanitizedTooltip = Text.sanitizeMultilineText(tooltip);
+		assertTrue(sanitizedTooltip.contains("Range: -110"));
+		assertTrue(sanitizedTooltip.contains("Speed: -3"));
+
+		assertFalse(sanitizedTooltip.contains("Range Str:"));
+		assertFalse(sanitizedTooltip.contains("Stab:"));
+		assertFalse(sanitizedTooltip.contains("Crush:"));
+		assertFalse(sanitizedTooltip.contains("Slash:"));
+		assertFalse(sanitizedTooltip.contains("Magic:"));
+	}
+
+	@Test
+	public void testUnequipItemTooltip_ShowBaseStats()
+	{
+		when(config.alwaysShowBaseStats()).thenReturn(true);
+
+		String tooltip = overlay.unequipItemTooltip(ABYSSAL_DAGGER);
+		String sanitizedTooltip = Text.sanitizeMultilineText(tooltip);
+		assertTrue(sanitizedTooltip.contains("Stab: 75 (-75)"));
+		assertTrue(sanitizedTooltip.contains("Slash: 40 (-40)"));
+		assertTrue(sanitizedTooltip.contains("Crush: -4 (+4)"));
+		assertEquals(2, StringUtils.countMatches(sanitizedTooltip, "Magic: 1 (-1)")); // Attack and defense
+		assertTrue(sanitizedTooltip.contains("Melee Str: 75 (-75)"));
+		assertTrue(sanitizedTooltip.contains("Speed: 4"));
+
+		tooltip = overlay.unequipItemTooltip(KATANA);
+		sanitizedTooltip = Text.sanitizeMultilineText(tooltip);
+		assertTrue(sanitizedTooltip.contains("Stab: 7 (-7)"));
+		assertTrue(sanitizedTooltip.contains("Slash: 45 (-45)"));
+		assertTrue(sanitizedTooltip.contains("Stab: 3 (-3)")); // Defense
+		assertTrue(sanitizedTooltip.contains("Slash: 7 (-7)")); // Defense
+		assertTrue(sanitizedTooltip.contains("Crush: 7 (-7)")); // Defense
+		assertTrue(sanitizedTooltip.contains("Range: -3 (+3)")); // Defense
+		assertTrue(sanitizedTooltip.contains("Melee Str: 40 (-40)"));
+		assertTrue(sanitizedTooltip.contains("Speed: 4"));
+
+		tooltip = overlay.unequipItemTooltip(BLOWPIPE);
+		sanitizedTooltip = Text.sanitizeMultilineText(tooltip);
+		assertTrue(sanitizedTooltip.contains("Range: 60 (-60)"));
+		assertTrue(sanitizedTooltip.contains("Range Str: 40 (-40)"));
+		assertTrue(sanitizedTooltip.contains("Speed: 3 (+1)"));
+		assertFalse(sanitizedTooltip.contains("Stab:"));
+
+
+		tooltip = overlay.unequipItemTooltip(HEAVY_BALLISTA);
+		sanitizedTooltip = Text.sanitizeMultilineText(tooltip);
+		assertTrue(sanitizedTooltip.contains("Range: 110 (-110)"));
+		assertTrue(sanitizedTooltip.contains("Speed: 7 (-3)"));
+
+		assertFalse(sanitizedTooltip.contains("Range Str:"));
+		assertFalse(sanitizedTooltip.contains("Stab:"));
+		assertFalse(sanitizedTooltip.contains("Crush:"));
+		assertFalse(sanitizedTooltip.contains("Slash:"));
+		assertFalse(sanitizedTooltip.contains("Magic:"));
 	}
 }


### PR DESCRIPTION
Resolves #12628 
* Add unit tests for new methods and to test the 2H logic
* Fix and simplify the 2H logic
* Add config option to turn off equipment stats in the equipment tab
* Add javadoc for buildItemTooltip