### PR TITLE
Change default font size in FontManager to 12 (Fix panel component line spacing)

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/HotkeyButton.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/HotkeyButton.java
@@ -41,7 +41,7 @@ class HotkeyButton extends JButton
 
 	public HotkeyButton(Keybind value, boolean modifierless)
 	{
-		setFont(FontManager.getDefaultFont().deriveFont(12.f));
+		setFont(FontManager.getDefaultFont());
 		setValue(value);
 		addMouseListener(new MouseAdapter()
 		{

--- a/runelite-client/src/main/java/net/runelite/client/ui/FontManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/FontManager.java
@@ -86,7 +86,7 @@ public class FontManager
 			throw new RuntimeException("Font file not found.", ex);
 		}
 
-		defaultFont = new Font(Font.DIALOG, Font.PLAIN, 16);
-		defaultBoldFont = new Font(Font.DIALOG, Font.BOLD, 16);
+		defaultFont = new Font(Font.DIALOG, Font.PLAIN, 12);
+		defaultBoldFont = new Font(Font.DIALOG, Font.BOLD, 12);
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/ui/components/IconTextField.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/components/IconTextField.java
@@ -191,7 +191,7 @@ public class IconTextField extends JPanel
 			}
 		});
 
-		suggestionButton = createRHSButton(ColorScheme.LIGHT_GRAY_COLOR, ColorScheme.MEDIUM_GRAY_COLOR, FontManager.getDefaultBoldFont());
+		suggestionButton = createRHSButton(ColorScheme.LIGHT_GRAY_COLOR, ColorScheme.MEDIUM_GRAY_COLOR, FontManager.getDefaultBoldFont().deriveFont(16.f));
 		suggestionButton.setText("▾");
 		suggestionButton.addActionListener(e ->
 		{


### PR DESCRIPTION
This fixes the line spacings all interfaces that use the `checkmark` and `x` icons.

The `defaultFont` is only ever used for Falo clues, Skills clues, emote clues, the Barrows plugin and `HotkeyButton`s in the key remapping plugin. All current cases would use a size of 12.

The `defaultBoldFont` was changed as well for consistency and is now derived to a size of `16` in the one place where it was ever used so far, which is the suggestion button on the plugin search bar.

![image](https://user-images.githubusercontent.com/45152844/108933750-adf97980-7619-11eb-9bd8-f959a61d0667.png)

![image](https://user-images.githubusercontent.com/45152844/108933760-b356c400-7619-11eb-9001-071d378fa950.png)
