### PR TITLE
Adds right-click options to Configuration side bar

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPlugin.java
@@ -24,29 +24,39 @@
  */
 package net.runelite.client.plugins.config;
 
-import java.awt.image.BufferedImage;
-import javax.inject.Inject;
-import javax.inject.Provider;
-import javax.swing.SwingUtilities;
+import com.google.common.collect.ImmutableMap;
+import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.MenuAction;
 import net.runelite.client.config.ChatColorConfig;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.config.RuneLiteConfig;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.events.OverlayMenuClicked;
+import net.runelite.client.externalplugins.ExternalPluginManager;
+import net.runelite.client.externalplugins.ExternalPluginManifest;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.plugins.PluginInstantiationException;
+import net.runelite.client.plugins.PluginManager;
 import net.runelite.client.ui.ClientToolbar;
 import net.runelite.client.ui.NavigationButton;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayMenuEntry;
 import net.runelite.client.util.ImageUtil;
 
+import javax.inject.Inject;
+import javax.inject.Provider;
+import javax.swing.SwingUtilities;
+import java.awt.image.BufferedImage;
+import java.util.HashSet;
+import java.util.Set;
+
 @PluginDescriptor(
 	name = "Configuration",
 	loadWhenOutdated = true,
 	hidden = true // prevent users from disabling
 )
+@Slf4j
 public class ConfigPlugin extends Plugin
 {
 	@Inject
@@ -64,9 +74,17 @@ public class ConfigPlugin extends Plugin
 	@Inject
 	private ChatColorConfig chatColorConfig;
 
+	@Inject
+	private PluginManager pluginManager;
+
+	@Inject
+	private ExternalPluginManager externalPluginManager;
+
 	private PluginListPanel pluginListPanel;
 
 	private NavigationButton navButton;
+
+	private Set<Plugin> previousEnabledPlugins = new HashSet<>();
 
 	@Override
 	protected void startUp() throws Exception
@@ -90,6 +108,137 @@ public class ConfigPlugin extends Plugin
 			.icon(icon)
 			.priority(0)
 			.panel(pluginListPanel.getMuxer())
+			.popup(ImmutableMap
+					.<String, Runnable>builder()
+					.put("Restore default plugins", () ->
+					{
+						previousEnabledPlugins.clear();
+						for (Plugin plugin : pluginManager.getPlugins())
+						{
+							if (pluginManager.isPluginEnabled(plugin))
+							{
+								previousEnabledPlugins.add(plugin);
+							}
+							PluginDescriptor pluginDescriptor = plugin.getClass().getAnnotation(PluginDescriptor.class);
+							boolean stopPlugin = !pluginDescriptor.enabledByDefault();
+							ExternalPluginManifest manifest = ExternalPluginManager.getExternalPluginManifest(plugin.getClass());
+							if (manifest != null)
+							{
+								if (externalPluginManager.getInstalledExternalPlugins().contains(manifest.getInternalName()))
+								{
+									stopPlugin = true;
+								}
+							}
+							if (stopPlugin)
+							{
+								try
+								{
+									pluginManager.setPluginEnabled(plugin, false);
+									pluginManager.stopPlugin(plugin);
+								} catch (PluginInstantiationException e)
+								{
+									log.warn("Unable to stop {}", plugin.getClass().getSimpleName());
+								}
+							} else if (!pluginManager.isPluginEnabled(plugin))
+							{
+								try
+								{
+									pluginManager.setPluginEnabled(plugin, true);
+									pluginManager.startPlugin(plugin);
+								} catch (PluginInstantiationException e)
+								{
+									log.warn("Unable to start {}", plugin.getClass().getSimpleName());
+								}
+							}
+						}
+					})
+					.put("Disable all plugins", () ->
+					{
+						previousEnabledPlugins.clear();
+						for (Plugin plugin : pluginManager.getPlugins())
+						{
+							if (pluginManager.isPluginEnabled(plugin))
+							{
+								previousEnabledPlugins.add(plugin);
+							}
+							PluginDescriptor pluginDescriptor = plugin.getClass().getAnnotation(PluginDescriptor.class);
+							if (!pluginManager.isPluginEnabled(plugin) || plugin.getName().equalsIgnoreCase("Configuration") || pluginDescriptor.developerPlugin())
+							{
+								continue;
+							}
+							try
+							{
+								pluginManager.setPluginEnabled(plugin, false);
+								pluginManager.stopPlugin(plugin);
+							} catch (PluginInstantiationException e)
+							{
+								log.warn("Unable to stop {}", plugin.getClass().getSimpleName());
+							}
+						}
+						log.debug("Disabled all plugins");
+					})
+					.put("Enable all plugins", () ->
+					{
+						for (Plugin plugin : pluginManager.getPlugins())
+						{
+							if (pluginManager.isPluginEnabled(plugin))
+							{
+								previousEnabledPlugins.add(plugin);
+								continue;
+							}
+							if (plugin.getName().toLowerCase().contains("gpu"))
+							{
+								continue;
+							}
+							try
+							{
+								pluginManager.setPluginEnabled(plugin, true);
+								pluginManager.startPlugin(plugin);
+							} catch (PluginInstantiationException e)
+							{
+								log.warn("Unable to start {}", plugin.getClass().getSimpleName());
+							}
+						}
+						log.debug("Enabled all plugins");
+					})
+					.put("Revert changes", () ->
+					{
+						if (previousEnabledPlugins.isEmpty())
+						{
+							return;
+						}
+						for (Plugin plugin : pluginManager.getPlugins())
+						{
+							if (previousEnabledPlugins.contains(plugin))
+							{
+								if (pluginManager.isPluginEnabled(plugin))
+								{
+									continue;
+								}
+								try
+								{
+									pluginManager.setPluginEnabled(plugin, true);
+									pluginManager.startPlugin(plugin);
+								} catch (PluginInstantiationException e)
+								{
+									log.warn("Unable to start {}", plugin.getClass().getSimpleName());
+								}
+							} else if (pluginManager.isPluginEnabled(plugin))
+							{
+								try
+								{
+									pluginManager.setPluginEnabled(plugin, false);
+									pluginManager.stopPlugin(plugin);
+								} catch (PluginInstantiationException e)
+								{
+									log.warn("Unable to stop {}", plugin.getClass().getSimpleName());
+								}
+							}
+						}
+						previousEnabledPlugins.clear();
+						log.debug("Revert changes applied");
+					})
+					.build())
 			.build();
 
 		clientToolbar.addNavigation(navButton);
@@ -100,7 +249,6 @@ public class ConfigPlugin extends Plugin
 	{
 		clientToolbar.removeNavigation(navButton);
 	}
-
 	@Subscribe
 	public void onOverlayMenuClicked(OverlayMenuClicked overlayMenuClicked)
 	{


### PR DESCRIPTION
Closes #13003 

Based off the issue above, I came up with the concept of right-clicking the side bar wrench (Configuration) so it will appear these options:
- "Restore default plugins" (enable enabledByDefault plugins & disable everything else including external plugins);
- "Disable all plugins" (except Configuration & Dev tools if enabled);
- "Enable all plugins" (except GPU plugins);
- "Revert changes" (this will basically revert the plugin status after using one of the above options to last stored).

I think this is more than just a master switch/using rs=vanilla , specially the "Restore default plugins" option might come in handy on discord #support.

![configoptions](https://user-images.githubusercontent.com/58041466/109054244-9384d600-76d5-11eb-93d6-672f49cf841f.gif)
