### PR TITLE
Time tracking: Hide nonfunctional notification icons on the birdhouse panel

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/TimeablePanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/TimeablePanel.java
@@ -89,6 +89,7 @@ public class TimeablePanel<T> extends JPanel
 		ImageIcon notifyIcon = new ImageIcon(ImageUtil.loadImageResource(TimeTrackingPlugin.class, "notify_icon.png"));
 		ImageIcon notifySelectedIcon = new ImageIcon(ImageUtil.loadImageResource(TimeTrackingPlugin.class, "notify_selected_icon.png"));
 
+		notifyButton.setVisible(false);
 		notifyButton.setPreferredSize(new Dimension(30, 16));
 		notifyButton.setBorder(new EmptyBorder(0, 0, 0, 10));
 		notifyButton.setIcon(notifyIcon);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/farming/FarmingTabPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/farming/FarmingTabPanel.java
@@ -235,6 +235,7 @@ public class FarmingTabPanel extends TabContentPanel
 			boolean notifyEnabled = Boolean.TRUE
 				.equals(configManager.getRSProfileConfiguration(TimeTrackingConfig.CONFIG_GROUP, configKey, Boolean.class));
 
+			toggleNotify.setVisible(true);
 			toggleNotify.setSelected(notifyEnabled);
 		}
 	}


### PR DESCRIPTION
Fixes #13262 
These were erroneously included in my notification PR so for now I'm just fixing this in lieu of figuring out an appropriate UI for the single birdhouse notification config. 