### PR TITLE
world map overlay: make icons display fully on the map when edge snapped

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/worldmap/WorldMapOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/worldmap/WorldMapOverlay.java
@@ -131,7 +131,24 @@ public class WorldMapOverlay extends Overlay
 
 				if (worldPoint.isSnapToEdge())
 				{
-					if (worldMapRectangle.contains(drawPoint.getX(), drawPoint.getY()))
+					// Get a smaller rect for edge-snapped icons so they display correctly at the edge
+					final Rectangle snappedRect = widget.getBounds();
+					snappedRect.grow(-image.getWidth() / 2, -image.getHeight() / 2);
+
+					final Rectangle unsnappedRect = new Rectangle(snappedRect);
+					if (worldPoint.getImagePoint() != null)
+					{
+						int dx = worldPoint.getImagePoint().getX() - (image.getWidth() / 2);
+						int dy = worldPoint.getImagePoint().getY() - (image.getHeight() / 2);
+						unsnappedRect.translate(dx, dy);
+					}
+					// Make the unsnap rect slightly smaller so a smaller snapped image doesn't cause a freak out
+					if (worldPoint.isCurrentlyEdgeSnapped())
+					{
+						unsnappedRect.grow(-image.getWidth(), -image.getHeight());
+					}
+
+					if (unsnappedRect.contains(drawPoint.getX(), drawPoint.getY()))
 					{
 						if (worldPoint.isCurrentlyEdgeSnapped())
 						{
@@ -141,7 +158,7 @@ public class WorldMapOverlay extends Overlay
 					}
 					else
 					{
-						drawPoint = clipToRectangle(drawPoint, worldMapRectangle);
+						drawPoint = clipToRectangle(drawPoint, snappedRect);
 						if (!worldPoint.isCurrentlyEdgeSnapped())
 						{
 							worldPoint.setCurrentlyEdgeSnapped(true);

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/worldmap/WorldMapOverlayMouseListener.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/worldmap/WorldMapOverlayMouseListener.java
@@ -60,6 +60,12 @@ public class WorldMapOverlayMouseListener extends MouseAdapter
 		if (SwingUtilities.isLeftMouseButton(e) && !worldMapPoints.isEmpty())
 		{
 			Point mousePos = client.getMouseCanvasPosition();
+			final Widget view = client.getWidget(WidgetInfo.WORLD_MAP_VIEW);
+
+			if (view == null)
+			{
+				return e;
+			}
 
 			for (WorldMapPoint worldMapPoint : worldMapPoints)
 			{
@@ -77,6 +83,7 @@ public class WorldMapOverlayMouseListener extends MouseAdapter
 						RenderOverview renderOverview = client.getRenderOverview();
 						renderOverview.setWorldMapPositionTarget(target);
 					}
+					e.consume();
 					return worldMapPoint.onClick(e);
 				}
 			}


### PR DESCRIPTION
Currently, icons snapped to the edge of the world map hang off the edge in a way that looks bad. This PR addresses that by making those icons use a slightly smaller area to position themselves, which keeps them on the map when snapped. This doesn't affect icons that don't snap, as they use a different rect.

This also fixes an issue that arose with icons overlapping the close button, which close the map when clicked. This is due to the overlay being drawn on top of the close button and completely covering it. I fixed this by consuming the mouse click event if an icon is clicked.