### PR TITLE
client: Remove shaded jar minimizing

### DIFF
--- a/runelite-client/pom.xml
+++ b/runelite-client/pom.xml
@@ -326,51 +326,9 @@
 							<goal>shade</goal>
 						</goals>
 						<configuration>
-							<minimizeJar>true</minimizeJar>
-
 							<shadedArtifactAttached>true</shadedArtifactAttached>
 							<shadedClassifierName>shaded</shadedClassifierName>
 
-							<filters>
-								<!-- include runtime apis -->
-								<filter>
-									<!-- net.runelite:client-patch and net.runelite:api -->
-									<artifact>net.runelite:*</artifact>
-									<includes>
-										<include>**</include>
-									</includes>
-								</filter>
-								<filter>
-									<artifact>net.runelite.pushingpixels:*</artifact>
-									<includes>
-										<include>**</include>
-									</includes>
-								</filter>
-								<filter>
-									<artifact>com.google.guava:*</artifact>
-									<includes>
-										<include>**</include>
-									</includes>
-								</filter>
-								<filter>
-									<artifact>ch.qos.logback:*</artifact>
-									<includes>
-										<include>**</include>
-									</includes>
-								</filter>
-								<filter>
-									<artifact>net.runelite.jogl:*</artifact>
-									<includes>
-										<include>**</include>
-									</includes>
-								</filter>
-								<filter>
-									<artifact>net.runelite.gluegen:*</artifact>
-									<includes>
-										<include>**</include>
-									</includes>
-								</filter>
-							</filters>
 							<transformers>
 								<transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
 									<mainClass>net.runelite.client.RuneLite</mainClass>


### PR DESCRIPTION
After the addition of runelite-jshell, some of its dependencies are not
preserved during jar minimization, causing the shell dev tool to fail on
some systems. This change ensures all dependencies are preserved in the
resulting shaded jar. This change results in a roughly 2Mb larger output
shaded jar.

For reference, this error happened on my machine at runtime prior to this change:
```
client.log snippet</summary>2021-02-26 13:38:40 [AWT-EventQueue-0] DEBUG n.r.c.plugins.devtools.DevToolsPanel - Shell is not supported
com.google.inject.ProvisionException: Unable to provision, see the following errors:

1) Error injecting constructor, java.lang.InternalError: Cannot find TokenMakerFactory: org.fife.ui.rsyntaxtextarea.DefaultTokenMakerFactory  
  at net.runelite.client.plugins.devtools.ShellFrame.<init>(Unknown Source)  
  at net.runelite.client.plugins.devtools.ShellFrame.class(Unknown Source)  
  while locating net.runelite.client.plugins.devtools.ShellFrame

1 error
	at com.google.inject.internal.InjectorImpl$2.get(InjectorImpl.java:1028)
	at com.google.inject.internal.InjectorImpl.getInstance(InjectorImpl.java:1054)
	at net.runelite.client.plugins.devtools.DevToolsPanel.createOptionsPanel(DevToolsPanel.java:182)
	at net.runelite.client.plugins.devtools.DevToolsPanel.<init>(DevToolsPanel.java:91)
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:490)
	at com.google.inject.internal.DefaultConstructionProxyFactory$ReflectiveProxy.newInstance(DefaultConstructionProxyFactory.java:126)
	at com.google.inject.internal.ConstructorInjector.provision(ConstructorInjector.java:111)
	at com.google.inject.internal.ConstructorInjector.construct(ConstructorInjector.java:90)
	at com.google.inject.internal.ConstructorBindingImpl$Factory.get(ConstructorBindingImpl.java:268)
	at com.google.inject.internal.InjectorImpl$2$1.call(InjectorImpl.java:1019)
	at com.google.inject.internal.InjectorImpl.callInContext(InjectorImpl.java:1085)
	at com.google.inject.internal.InjectorImpl$2.get(InjectorImpl.java:1015)
	at com.google.inject.internal.InjectorImpl.getInstance(InjectorImpl.java:1054)
	at net.runelite.client.plugins.devtools.DevToolsPlugin.startUp(DevToolsPlugin.java:201)
	at net.runelite.client.plugins.PluginManager.startPlugin(PluginManager.java:385)
	at net.runelite.client.plugins.PluginManager.lambda$startPlugins$2(PluginManager.java:244)
	at java.desktop/java.awt.event.InvocationEvent.dispatch(InvocationEvent.java:303)
	at java.desktop/java.awt.EventQueue.dispatchEventImpl(EventQueue.java:770)
	at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:721)
	at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:715)
	at java.base/java.security.AccessController.doPrivileged(Native Method)
	at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:85)
	at java.desktop/java.awt.EventQueue.dispatchEvent(EventQueue.java:740)
	at java.desktop/java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:203)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:124)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:113)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:109)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:101)
	at java.desktop/java.awt.EventDispatchThread.run(EventDispatchThread.java:90)
Caused by: java.lang.InternalError: Cannot find TokenMakerFactory: org.fife.ui.rsyntaxtextarea.DefaultTokenMakerFactory
	at org.fife.ui.rsyntaxtextarea.TokenMakerFactory.getDefaultInstance(TokenMakerFactory.java:63)
	at org.fife.ui.rsyntaxtextarea.RSyntaxDocument.setTokenMakerFactory(RSyntaxDocument.java:577)
	at org.fife.ui.rsyntaxtextarea.RSyntaxDocument.<init>(RSyntaxDocument.java:117)
	at org.fife.ui.rsyntaxtextarea.RSyntaxDocument.<init>(RSyntaxDocument.java:100)
	at org.fife.ui.rsyntaxtextarea.RSyntaxTextArea.createDefaultModel(RSyntaxTextArea.java:696)
	at java.desktop/javax.swing.JTextArea.<init>(JTextArea.java:203)
	at java.desktop/javax.swing.JTextArea.<init>(JTextArea.java:135)
	at org.fife.ui.rtextarea.RTextAreaBase.<init>(RTextAreaBase.java:81)
	at org.fife.ui.rtextarea.RTextArea.<init>(RTextArea.java:188)
	at org.fife.ui.rsyntaxtextarea.RSyntaxTextArea.<init>(RSyntaxTextArea.java:351)
	at net.runelite.jshell.ShellPanel.<init>(ShellPanel.java:125)
	at net.runelite.client.plugins.devtools.ShellFrame$RLShellPanel.<init>(ShellFrame.java:70)
	at net.runelite.client.plugins.devtools.ShellFrame$RLShellPanel.<init>(ShellFrame.java:64)
	at net.runelite.client.plugins.devtools.ShellFrame.<init>(ShellFrame.java:42)
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:490)
	at com.google.inject.internal.DefaultConstructionProxyFactory$ReflectiveProxy.newInstance(DefaultConstructionProxyFactory.java:126)
	at com.google.inject.internal.ConstructorInjector.provision(ConstructorInjector.java:111)
	at com.google.inject.internal.ConstructorInjector.construct(ConstructorInjector.java:90)
	at com.google.inject.internal.ConstructorBindingImpl$Factory.get(ConstructorBindingImpl.java:268)
	at com.google.inject.internal.ProviderToInternalFactoryAdapter$1.call(ProviderToInternalFactoryAdapter.java:46)
	at com.google.inject.internal.InjectorImpl.callInContext(InjectorImpl.java:1092)
	at com.google.inject.internal.ProviderToInternalFactoryAdapter.get(ProviderToInternalFactoryAdapter.java:40)
	at com.google.inject.internal.SingletonScope$1.get(SingletonScope.java:194)
	at com.google.inject.internal.InternalFactoryToProviderAdapter.get(InternalFactoryToProviderAdapter.java:41)
	at com.google.inject.internal.InjectorImpl$2$1.call(InjectorImpl.java:1019)
	at com.google.inject.internal.InjectorImpl.callInContext(InjectorImpl.java:1092)
	at com.google.inject.internal.InjectorImpl$2.get(InjectorImpl.java:1015)
	... 31 common frames omitted
```