### PR TITLE
BankPlugin: avoid keyboard input going to input text

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/bank/BankPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/bank/BankPlugin.java
@@ -238,12 +238,15 @@ public class BankPlugin extends Plugin
 
 					log.debug("Bank pin keypress");
 
-					final String input = client.getVar(VarClientStr.CHATBOX_TYPED_TEXT);
+					final String chatboxTypedText = client.getVar(VarClientStr.CHATBOX_TYPED_TEXT);
+					final String inputText = client.getVar(VarClientStr.INPUT_TEXT);
 					clientThread.invokeLater(() ->
 					{
 						// reset chatbox input to avoid pin going to chatbox..
-						client.setVar(VarClientStr.CHATBOX_TYPED_TEXT, input);
+						client.setVar(VarClientStr.CHATBOX_TYPED_TEXT, chatboxTypedText);
 						client.runScript(ScriptID.CHAT_PROMPT_INIT);
+						client.setVar(VarClientStr.INPUT_TEXT, inputText);
+						client.runScript(ScriptID.CHAT_TEXT_INPUT_REBUILD, "");
 
 						client.runScript(onOpListener);
 					});


### PR DESCRIPTION
Closes #12923 

Chose the "When the bank pin interface is open, the digit keys should not be able to type into the chat" behavior to follow the same existing logic applied to chatbox/public chat. 