### PR TITLE
friendschat: remove user count after leaving chat channel

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/friendschat/FriendsChatPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/friendschat/FriendsChatPlugin.java
@@ -289,11 +289,17 @@ public class FriendsChatPlugin extends Plugin
 			{
 				chatTitleWidget.setText(TITLE + " (" + friendsChatManager.getCount() + "/100)");
 			}
-			else if (config.recentChats() && chatList.getChildren() == null && !Strings.isNullOrEmpty(owner.getText()))
+			else if (chatList.getChildren() == null && !Strings.isNullOrEmpty(owner.getText()))
 			{
-				chatTitleWidget.setText(RECENT_TITLE);
-
-				loadFriendsChats();
+				if (config.recentChats())
+				{
+					chatTitleWidget.setText(RECENT_TITLE);
+					loadFriendsChats();
+				}
+				else
+				{
+					chatTitleWidget.setText(TITLE);
+				}
 			}
 		}
 


### PR DESCRIPTION
Noticed that the user count for friends chats didn't get removed if the user doesn't have `Recent Chats` enabled.