### PR TITLE
Add more plugin search tags

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/bank/BankPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/bank/BankPlugin.java
@@ -70,7 +70,7 @@ import net.runelite.client.util.QuantityFormatter;
 @PluginDescriptor(
 	name = "Bank",
 	description = "Modifications to the banking interface",
-	tags = {"grand", "exchange", "high", "alchemy", "prices", "deposit"}
+	tags = {"grand", "exchange", "high", "alchemy", "prices", "deposit", "pin"}
 )
 @Slf4j
 public class BankPlugin extends Plugin

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemidentification/ItemIdentificationPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemidentification/ItemIdentificationPlugin.java
@@ -34,6 +34,7 @@ import net.runelite.client.ui.overlay.OverlayManager;
 @PluginDescriptor(
 	name = "Item Identification",
 	description = "Show identifying text over items with difficult to distinguish sprites",
+	tags = {"abbreviations", "labels", "seeds", "herbs", "saplings", "seedlings"},
 	enabledByDefault = false
 )
 public class ItemIdentificationPlugin extends Plugin


### PR DESCRIPTION
Add some more related keywords to the item identifications plugin. Open to suggestions for others to add, was considering if it's worth adding all the other kinds of items that the plugin can label for example.
Also add the keyword "pin" to the bank plugin to help find the Keyboard Bankpin feature.

Closes #13291