### PR TITLE
Prevent to clear object markers on connection lost

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/objectindicators/ObjectIndicatorsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/objectindicators/ObjectIndicatorsPlugin.java
@@ -208,7 +208,7 @@ public class ObjectIndicatorsPlugin extends Plugin
 			}
 		}
 
-		if (gameStateChanged.getGameState() != GameState.LOGGED_IN)
+		if (gameStateChanged.getGameState() != GameState.LOGGED_IN && gameStateChanged.getGameState() != GameState.CONNECTION_LOST)
 		{
 			objects.clear();
 		}


### PR DESCRIPTION
Closes #12943

On `CONNECTION_LOST` either it reconnects and goes back to `LOGGED_IN` or falls to `LOGIN_SCREEN`, so a clear isn't needed in this transition state.