### PR TITLE
add precise PB support

### DIFF
--- a/http-api/src/main/java/net/runelite/http/api/chat/ChatClient.java
+++ b/http-api/src/main/java/net/runelite/http/api/chat/ChatClient.java
@@ -179,14 +179,14 @@ public class ChatClient
 		}
 	}
 
-	public boolean submitPb(String username, String boss, int pb) throws IOException
+	public boolean submitPb(String username, String boss, double pb) throws IOException
 	{
 		HttpUrl url = RuneLiteAPI.getApiBase().newBuilder()
 			.addPathSegment("chat")
 			.addPathSegment("pb")
 			.addQueryParameter("name", username)
 			.addQueryParameter("boss", boss)
-			.addQueryParameter("pb", Integer.toString(pb))
+			.addQueryParameter("pb", Double.toString(pb))
 			.build();
 
 		Request request = new Request.Builder()
@@ -200,7 +200,7 @@ public class ChatClient
 		}
 	}
 
-	public int getPb(String username, String boss) throws IOException
+	public double getPb(String username, String boss) throws IOException
 	{
 		HttpUrl url = RuneLiteAPI.getApiBase().newBuilder()
 			.addPathSegment("chat")
@@ -219,7 +219,7 @@ public class ChatClient
 			{
 				throw new IOException("Unable to look up personal best!");
 			}
-			return Integer.parseInt(response.body().string());
+			return Double.parseDouble(response.body().string());
 		}
 	}
 

--- a/http-service/src/main/java/net/runelite/http/service/chat/ChatController.java
+++ b/http-service/src/main/java/net/runelite/http/service/chat/ChatController.java
@@ -173,7 +173,7 @@ public class ChatController
 	}
 
 	@PostMapping("/pb")
-	public void submitPb(@RequestParam String name, @RequestParam String boss, @RequestParam int pb)
+	public void submitPb(@RequestParam String name, @RequestParam String boss, @RequestParam double pb)
 	{
 		if (pb < 0)
 		{
@@ -184,9 +184,9 @@ public class ChatController
 	}
 
 	@GetMapping("/pb")
-	public int getPb(@RequestParam String name, @RequestParam String boss)
+	public double getPb(@RequestParam String name, @RequestParam String boss)
 	{
-		Integer pb = chatService.getPb(name, boss);
+		Double pb = chatService.getPb(name, boss);
 		if (pb == null)
 		{
 			throw new NotFoundException();

--- a/http-service/src/main/java/net/runelite/http/service/chat/ChatService.java
+++ b/http-service/src/main/java/net/runelite/http/service/chat/ChatService.java
@@ -127,21 +127,21 @@ public class ChatService
 		}
 	}
 
-	public Integer getPb(String name, String boss)
+	public Double getPb(String name, String boss)
 	{
 		String value;
 		try (Jedis jedis = jedisPool.getResource())
 		{
 			value = jedis.get("pb." + boss + "." + name);
 		}
-		return value == null ? null : Integer.parseInt(value);
+		return value == null ? null : Double.parseDouble(value);
 	}
 
-	public void setPb(String name, String boss, int pb)
+	public void setPb(String name, String boss, double pb)
 	{
 		try (Jedis jedis = jedisPool.getResource())
 		{
-			jedis.setex("pb." + boss + "." + name, (int) EXPIRE.getSeconds(), Integer.toString(pb));
+			jedis.setex("pb." + boss + "." + name, (int) EXPIRE.getSeconds(), Double.toString(pb));
 		}
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/config/ConfigManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/ConfigManager.java
@@ -754,6 +754,10 @@ public class ConfigManager
 		{
 			return Integer.parseInt(str);
 		}
+		if (type == double.class || type == Double.class)
+		{
+			return Double.parseDouble(str);
+		}
 		if (type == Color.class)
 		{
 			return ColorUtil.fromString(str);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
@@ -96,20 +96,20 @@ public class ChatCommandsPlugin extends Plugin
 {
 	private static final Pattern KILLCOUNT_PATTERN = Pattern.compile("Your (?:completion count for |subdued |completed )?(.+?) (?:(?:kill|harvest|lap|completion) )?(?:count )?is: <col=ff0000>(\\d+)</col>");
 	private static final String COX_TEAM_SIZES = "(?:\\d+(?:\\+|-\\d+)? players|Solo)";
-	private static final Pattern RAIDS_PB_PATTERN = Pattern.compile("<col=ef20ff>Congratulations - your raid is complete!</col><br>Team size: <col=ff0000>" + COX_TEAM_SIZES + "</col> Duration:</col> <col=ff0000>(?<pb>[0-9:]+)</col> \\(new personal best\\)</col>");
-	private static final Pattern RAIDS_DURATION_PATTERN = Pattern.compile("<col=ef20ff>Congratulations - your raid is complete!</col><br>Team size: <col=ff0000>" + COX_TEAM_SIZES + "</col> Duration:</col> <col=ff0000>[0-9:]+</col> Personal best: </col><col=ff0000>(?<pb>[0-9:]+)</col>");
-	private static final Pattern TOB_WAVE_PB_PATTERN = Pattern.compile("^.*Theatre of Blood wave completion time: <col=ff0000>(?<pb>[0-9:]+)</col> \\(Personal best!\\)");
-	private static final Pattern TOB_WAVE_DURATION_PATTERN = Pattern.compile("^.*Theatre of Blood wave completion time: <col=ff0000>[0-9:]+</col><br></col>Personal best: (?<pb>[0-9:]+)");
-	private static final Pattern KILL_DURATION_PATTERN = Pattern.compile("(?i)^(?:Fight |Lap |Challenge |Corrupted challenge )?duration: <col=ff0000>[0-9:]+</col>\\. Personal best: (?:<col=ff0000>)?(?<pb>[0-9:]+)");
-	private static final Pattern NEW_PB_PATTERN = Pattern.compile("(?i)^(?:Fight |Lap |Challenge |Corrupted challenge )?duration: <col=ff0000>(?<pb>[0-9:]+)</col> \\(new personal best\\)");
+	private static final Pattern RAIDS_PB_PATTERN = Pattern.compile("<col=ef20ff>Congratulations - your raid is complete!</col><br>Team size: <col=ff0000>" + COX_TEAM_SIZES + "</col> Duration:</col> <col=ff0000>(?<pb>[0-9:]+(?:\\.[0-9]+)?)</col> \\(new personal best\\)</col>");
+	private static final Pattern RAIDS_DURATION_PATTERN = Pattern.compile("<col=ef20ff>Congratulations - your raid is complete!</col><br>Team size: <col=ff0000>" + COX_TEAM_SIZES + "</col> Duration:</col> <col=ff0000>[0-9:.]+</col> Personal best: </col><col=ff0000>(?<pb>[0-9:]+(?:\\.[0-9]+)?)</col>");
+	private static final Pattern TOB_WAVE_PB_PATTERN = Pattern.compile("^.*Theatre of Blood wave completion time: <col=ff0000>(?<pb>[0-9:]+(?:\\.[0-9]+)?)</col> \\(Personal best!\\)");
+	private static final Pattern TOB_WAVE_DURATION_PATTERN = Pattern.compile("^.*Theatre of Blood wave completion time: <col=ff0000>[0-9:.]+</col><br></col>Personal best: (?<pb>[0-9:]+(?:\\.[0-9]+)?)");
+	private static final Pattern KILL_DURATION_PATTERN = Pattern.compile("(?i)^(?:Fight |Lap |Challenge |Corrupted challenge )?duration: <col=ff0000>[0-9:.]+</col>\\. Personal best: (?:<col=ff0000>)?(?<pb>[0-9:]+(?:\\.[0-9]+)?)");
+	private static final Pattern NEW_PB_PATTERN = Pattern.compile("(?i)^(?:Fight |Lap |Challenge |Corrupted challenge )?duration: <col=ff0000>(?<pb>[0-9:]+(?:\\.[0-9]+)?)</col> \\(new personal best\\)");
 	private static final Pattern DUEL_ARENA_WINS_PATTERN = Pattern.compile("You (were defeated|won)! You have(?: now)? won (\\d+) duels?");
 	private static final Pattern DUEL_ARENA_LOSSES_PATTERN = Pattern.compile("You have(?: now)? lost (\\d+) duels?");
 	private static final Pattern ADVENTURE_LOG_TITLE_PATTERN = Pattern.compile("The Exploits of (.+)");
-	private static final Pattern ADVENTURE_LOG_COX_PB_PATTERN = Pattern.compile("Fastest (?:kill|run)(?: - \\(Team size: " + COX_TEAM_SIZES  + "\\))?: ([0-9:]+)");
+	private static final Pattern ADVENTURE_LOG_COX_PB_PATTERN = Pattern.compile("Fastest (?:kill|run)(?: - \\(Team size: " + COX_TEAM_SIZES  + "\\))?: ([0-9:]+(?:\\.[0-9]+)?)");
 	private static final Pattern ADVENTURE_LOG_BOSS_PB_PATTERN = Pattern.compile("[a-zA-Z]+(?: [a-zA-Z]+)*");
 	private static final Pattern ADVENTURE_LOG_PB_PATTERN = Pattern.compile("(" + ADVENTURE_LOG_BOSS_PB_PATTERN + "(?: - " + ADVENTURE_LOG_BOSS_PB_PATTERN + ")*) (?:" + ADVENTURE_LOG_COX_PB_PATTERN + "( )*)+");
-	private static final Pattern HS_PB_PATTERN = Pattern.compile("Floor (?<floor>\\d) time: <col=ff0000>(?<floortime>[0-9:]+)</col>(?: \\(new personal best\\)|. Personal best: (?<floorpb>[0-9:]+))" +
-		"(?:<br>Overall time: <col=ff0000>(?<otime>[0-9:]+)</col>(?: \\(new personal best\\)|. Personal best: (?<opb>[0-9:]+)))?");
+	private static final Pattern HS_PB_PATTERN = Pattern.compile("Floor (?<floor>\\d) time: <col=ff0000>(?<floortime>[0-9:]+(?:\\.[0-9]+)?)</col>(?: \\(new personal best\\)|. Personal best: (?<floorpb>[0-9:]+(?:\\.[0-9]+)?))" +
+		"(?:<br>Overall time: <col=ff0000>(?<otime>[0-9:]+(?:\\.[0-9]+)?)</col>(?: \\(new personal best\\)|. Personal best: (?<opb>[0-9:]+(?:\\.[0-9]+)?)))?");
 	private static final Pattern HS_KC_FLOOR_PATTERN = Pattern.compile("You have completed Floor (\\d) of the Hallowed Sepulchre! Total completions: <col=ff0000>([0-9,]+)</col>\\.");
 	private static final Pattern HS_KC_GHC_PATTERN = Pattern.compile("You have opened the Grand Hallowed Coffin <col=ff0000>([0-9,]+)</col> times?!");
 
@@ -143,7 +143,7 @@ public class ChatCommandsPlugin extends Plugin
 	private HiscoreEndpoint hiscoreEndpoint; // hiscore endpoint for current player
 	private String lastBossKill;
 	private int lastBossTime = -1;
-	private int lastPb = -1;
+	private double lastPb = -1;
 
 	@Inject
 	private Client client;
@@ -251,14 +251,14 @@ public class ChatCommandsPlugin extends Plugin
 		return killCount == null ? 0 : killCount;
 	}
 
-	private void setPb(String boss, int seconds)
+	private void setPb(String boss, double seconds)
 	{
 		configManager.setRSProfileConfiguration("personalbest", boss.toLowerCase(), seconds);
 	}
 
-	private int getPb(String boss)
+	private double getPb(String boss)
 	{
-		Integer personalBest = configManager.getRSProfileConfiguration("personalbest", boss.toLowerCase(), int.class);
+		Double personalBest = configManager.getRSProfileConfiguration("personalbest", boss.toLowerCase(), double.class);
 		return personalBest == null ? 0 : personalBest;
 	}
 
@@ -412,23 +412,24 @@ public class ChatCommandsPlugin extends Plugin
 		}
 	}
 
-	private static int timeStringToSeconds(String timeString)
+	@VisibleForTesting
+	static double timeStringToSeconds(String timeString)
 	{
 		String[] s = timeString.split(":");
 		if (s.length == 2) // mm:ss
 		{
-			return Integer.parseInt(s[0]) * 60 + Integer.parseInt(s[1]);
+			return Integer.parseInt(s[0]) * 60 + Double.parseDouble(s[1]);
 		}
 		else if (s.length == 3) // h:mm:ss
 		{
-			return Integer.parseInt(s[0]) * 60 * 60 + Integer.parseInt(s[1]) * 60 + Integer.parseInt(s[2]);
+			return Integer.parseInt(s[0]) * 60 * 60 + Integer.parseInt(s[1]) * 60 + Double.parseDouble(s[2]);
 		}
-		return Integer.parseInt(timeString);
+		return Double.parseDouble(timeString);
 	}
 
 	private void matchPb(Matcher matcher)
 	{
-		int seconds = timeStringToSeconds(matcher.group("pb"));
+		double seconds = timeStringToSeconds(matcher.group("pb"));
 		if (lastBossKill != null)
 		{
 			// Most bosses sent boss kill message, and then pb message, so we
@@ -514,13 +515,13 @@ public class ChatCommandsPlugin extends Plugin
 						bossName.equalsIgnoreCase("chambers of xeric challenge mode"))
 					{
 						Matcher mCoxRuns = ADVENTURE_LOG_COX_PB_PATTERN.matcher(mCounterText.group());
-						int bestPbTime = Integer.MAX_VALUE;
+						double bestPbTime = Double.MAX_VALUE;
 						while (mCoxRuns.find())
 						{
 							bestPbTime = Math.min(timeStringToSeconds(mCoxRuns.group(1)), bestPbTime);
 						}
 						// So we don't reset people's already saved PB's if they had one before the update
-						int currentPb = getPb(bossName);
+						double currentPb = getPb(bossName);
 						if (currentPb == 0 || currentPb > bestPbTime)
 						{
 							setPb(bossName, bestPbTime);
@@ -841,7 +842,7 @@ public class ChatCommandsPlugin extends Plugin
 
 		search = longBossName(search);
 
-		final int pb;
+		final double pb;
 		try
 		{
 			pb = chatClient.getPb(player, search);
@@ -852,8 +853,14 @@ public class ChatCommandsPlugin extends Plugin
 			return;
 		}
 
-		int minutes = pb / 60;
-		int seconds = pb % 60;
+		int minutes = (int) (Math.floor(pb) / 60);
+		double seconds = pb % 60;
+
+		// If the seconds is an integer, it is ambiguous if the pb is a precise
+		// pb or not. So we always show it without the trailing .00.
+		final String time = Math.floor(seconds) == seconds ?
+			String.format("%d:%02d", minutes, (int) seconds) :
+			String.format("%d:%05.2f", minutes, seconds);
 
 		String response = new ChatMessageBuilder()
 			.append(ChatColorType.HIGHLIGHT)
@@ -861,7 +868,7 @@ public class ChatCommandsPlugin extends Plugin
 			.append(ChatColorType.NORMAL)
 			.append(" personal best: ")
 			.append(ChatColorType.HIGHLIGHT)
-			.append(String.format("%d:%02d", minutes, seconds))
+			.append(time)
 			.build();
 
 		log.debug("Setting response {}", response);
@@ -876,7 +883,7 @@ public class ChatCommandsPlugin extends Plugin
 		int idx = value.indexOf(' ');
 		final String boss = longBossName(value.substring(idx + 1));
 
-		final int pb = getPb(boss);
+		final double pb = getPb(boss);
 		if (pb <= 0)
 		{
 			return false;

--- a/runelite-client/src/test/java/net/runelite/client/plugins/chatcommands/ChatCommandsPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/chatcommands/ChatCommandsPluginTest.java
@@ -164,7 +164,14 @@ public class ChatCommandsPluginTest
 		chatCommandsPlugin.onChatMessage(chatMessageEvent);
 
 		verify(configManager).setRSProfileConfiguration("killcount", "theatre of blood", 73);
-		verify(configManager).setRSProfileConfiguration("personalbest", "theatre of blood", 37 * 60 + 4);
+		verify(configManager).setRSProfileConfiguration("personalbest", "theatre of blood", 37 * 60 + 4.0);
+
+		// Precise times
+		ChatMessage chatMessagePrecise = new ChatMessage(null, GAMEMESSAGE, "", "Wave 'The Final Challenge' complete! Duration: <col=ff0000>5:04</col><br>Theatre of Blood wave completion time: <col=ff0000>37:04.20</col> (Personal best!)", null, 0);
+		chatCommandsPlugin.onChatMessage(chatMessagePrecise);
+		chatCommandsPlugin.onChatMessage(chatMessageEvent);
+
+		verify(configManager).setRSProfileConfiguration("personalbest", "theatre of blood", 37 * 60 + 4.2);
 	}
 
 	@Test
@@ -177,7 +184,14 @@ public class ChatCommandsPluginTest
 		chatCommandsPlugin.onChatMessage(chatMessageEvent);
 
 		verify(configManager).setRSProfileConfiguration("killcount", "theatre of blood", 73);
-		verify(configManager).setRSProfileConfiguration("personalbest", "theatre of blood", 37 * 60 + 4);
+		verify(configManager).setRSProfileConfiguration("personalbest", "theatre of blood", 37 * 60 + 4.0);
+
+		// Precise times
+		ChatMessage chatMessagePrecise = new ChatMessage(null, GAMEMESSAGE, "", "Wave 'The Final Challenge' complete! Duration: <col=ff0000>5:04</col><br>Theatre of Blood wave completion time: <col=ff0000>38:17.00</col><br></col>Personal best: 37:04.40", null, 0);
+		chatCommandsPlugin.onChatMessage(chatMessagePrecise);
+		chatCommandsPlugin.onChatMessage(chatMessageEvent);
+
+		verify(configManager).setRSProfileConfiguration("personalbest", "theatre of blood", 37 * 60 + 4.4);
 	}
 
 	@Test
@@ -238,6 +252,7 @@ public class ChatCommandsPluginTest
 	public void testPersonalBest()
 	{
 		final String FIGHT_DURATION = "Fight duration: <col=ff0000>2:06</col>. Personal best: 1:19.";
+		final String FIGHT_DURATION_PRECISE = "Fight duration: <col=ff0000>2:06.40</col>. Personal best: 1:19.20.";
 
 		// This sets lastBoss
 		ChatMessage chatMessage = new ChatMessage(null, GAMEMESSAGE, "", "Your Kree'arra kill count is: <col=ff0000>4</col>.", null, 0);
@@ -246,13 +261,20 @@ public class ChatCommandsPluginTest
 		chatMessage = new ChatMessage(null, GAMEMESSAGE, "", FIGHT_DURATION, null, 0);
 		chatCommandsPlugin.onChatMessage(chatMessage);
 
-		verify(configManager).setRSProfileConfiguration("personalbest", "kree'arra", 79);
+		verify(configManager).setRSProfileConfiguration("personalbest", "kree'arra", 79.0);
+
+		// Precise times
+		chatMessage = new ChatMessage(null, GAMEMESSAGE, "", FIGHT_DURATION_PRECISE, null, 0);
+		chatCommandsPlugin.onChatMessage(chatMessage);
+
+		verify(configManager).setRSProfileConfiguration("personalbest", "kree'arra", 79.2);
 	}
 
 	@Test
 	public void testPersonalBestNoTrailingPeriod()
 	{
 		final String FIGHT_DURATION = "Fight duration: <col=ff0000>0:59</col>. Personal best: 0:55";
+		final String FIGHT_DURATION_PRECISE = "Fight duration: <col=ff0000>0:59.20</col>. Personal best: 0:55.40";
 
 		// This sets lastBoss
 		ChatMessage chatMessage = new ChatMessage(null, GAMEMESSAGE, "", "Your Zulrah kill count is: <col=ff0000>4</col>.", null, 0);
@@ -261,13 +283,20 @@ public class ChatCommandsPluginTest
 		chatMessage = new ChatMessage(null, GAMEMESSAGE, "", FIGHT_DURATION, null, 0);
 		chatCommandsPlugin.onChatMessage(chatMessage);
 
-		verify(configManager).setRSProfileConfiguration("personalbest", "zulrah", 55);
+		verify(configManager).setRSProfileConfiguration("personalbest", "zulrah", 55.0);
+
+		// Precise times
+		chatMessage = new ChatMessage(null, GAMEMESSAGE, "", FIGHT_DURATION_PRECISE, null, 0);
+		chatCommandsPlugin.onChatMessage(chatMessage);
+
+		verify(configManager).setRSProfileConfiguration("personalbest", "zulrah", 55.4);
 	}
 
 	@Test
 	public void testNewPersonalBest()
 	{
 		final String NEW_PB = "Fight duration: <col=ff0000>3:01</col> (new personal best).";
+		final String NEW_PB_PRECISE = "Fight duration: <col=ff0000>3:01.40</col> (new personal best).";
 
 		// This sets lastBoss
 		ChatMessage chatMessage = new ChatMessage(null, GAMEMESSAGE, "", "Your Kree'arra kill count is: <col=ff0000>4</col>.", null, 0);
@@ -276,7 +305,13 @@ public class ChatCommandsPluginTest
 		chatMessage = new ChatMessage(null, GAMEMESSAGE, "", NEW_PB, null, 0);
 		chatCommandsPlugin.onChatMessage(chatMessage);
 
-		verify(configManager).setRSProfileConfiguration("personalbest", "kree'arra", 181);
+		verify(configManager).setRSProfileConfiguration("personalbest", "kree'arra", 181.0);
+
+		// Precise times
+		chatMessage = new ChatMessage(null, GAMEMESSAGE, "", NEW_PB_PRECISE, null, 0);
+		chatCommandsPlugin.onChatMessage(chatMessage);
+
+		verify(configManager).setRSProfileConfiguration("personalbest", "kree'arra", 181.4);
 	}
 
 	@Test
@@ -311,6 +346,7 @@ public class ChatCommandsPluginTest
 	public void testAgilityLap()
 	{
 		final String NEW_PB = "Lap duration: <col=ff0000>1:01</col> (new personal best).";
+		final String NEW_PB_PRECISE = "Lap duration: <col=ff0000>1:01.20</col> (new personal best).";
 
 		// This sets lastBoss
 		ChatMessage chatMessage = new ChatMessage(null, GAMEMESSAGE, "", "Your Prifddinas Agility Course lap count is: <col=ff0000>2</col>.", null, 0);
@@ -319,8 +355,14 @@ public class ChatCommandsPluginTest
 		chatMessage = new ChatMessage(null, GAMEMESSAGE, "", NEW_PB, null, 0);
 		chatCommandsPlugin.onChatMessage(chatMessage);
 
-		verify(configManager).setRSProfileConfiguration("personalbest", "prifddinas agility course", 61);
+		verify(configManager).setRSProfileConfiguration("personalbest", "prifddinas agility course", 61.0);
 		verify(configManager).setRSProfileConfiguration("killcount", "prifddinas agility course", 2);
+
+		// Precise times
+		chatMessage = new ChatMessage(null, GAMEMESSAGE, "", NEW_PB_PRECISE, null, 0);
+		chatCommandsPlugin.onChatMessage(chatMessage);
+
+		verify(configManager).setRSProfileConfiguration("personalbest", "prifddinas agility course", 61.2);
 	}
 
 	@Test
@@ -332,8 +374,13 @@ public class ChatCommandsPluginTest
 		chatMessage = new ChatMessage(null, GAMEMESSAGE, "", "Duration: <col=ff0000>104:31</col> (new personal best)", null, 0);
 		chatCommandsPlugin.onChatMessage(chatMessage);
 
-		verify(configManager).setRSProfileConfiguration("personalbest", "tzkal-zuk", 104 * 60 + 31);
+		verify(configManager).setRSProfileConfiguration("personalbest", "tzkal-zuk", 104 * 60 + 31.0);
 		verify(configManager).setRSProfileConfiguration("killcount", "tzkal-zuk", 2);
+
+		// Precise times
+		chatMessage = new ChatMessage(null, GAMEMESSAGE, "", "Duration: <col=ff0000>104:31.20</col> (new personal best)", null, 0);
+		chatCommandsPlugin.onChatMessage(chatMessage);
+		verify(configManager).setRSProfileConfiguration("personalbest", "tzkal-zuk", 104 * 60 + 31.2);
 	}
 
 	@Test
@@ -345,8 +392,13 @@ public class ChatCommandsPluginTest
 		chatMessage = new ChatMessage(null, GAMEMESSAGE, "", "Duration: <col=ff0000>172:18</col>. Personal best: 134:52", null, 0);
 		chatCommandsPlugin.onChatMessage(chatMessage);
 
-		verify(configManager).setRSProfileConfiguration("personalbest", "tzkal-zuk", 134 * 60 + 52);
+		verify(configManager).setRSProfileConfiguration("personalbest", "tzkal-zuk", 134 * 60 + 52.0);
 		verify(configManager).setRSProfileConfiguration("killcount", "tzkal-zuk", 3);
+
+		// Precise times
+		chatMessage = new ChatMessage(null, GAMEMESSAGE, "", "Duration: <col=ff0000>172:18.40</col>. Personal best: 134:52.20", null, 0);
+		chatCommandsPlugin.onChatMessage(chatMessage);
+		verify(configManager).setRSProfileConfiguration("personalbest", "tzkal-zuk", 134 * 60 + 52.2);
 	}
 
 	@Test
@@ -358,8 +410,17 @@ public class ChatCommandsPluginTest
 		chatMessage = new ChatMessage(null, GAMEMESSAGE, "", "Your Grotesque Guardians kill count is: <col=ff0000>179</col>.", null, 0);
 		chatCommandsPlugin.onChatMessage(chatMessage);
 
-		verify(configManager).setRSProfileConfiguration("personalbest", "grotesque guardians", 96);
+		verify(configManager).setRSProfileConfiguration("personalbest", "grotesque guardians", 96.0);
 		verify(configManager).setRSProfileConfiguration("killcount", "grotesque guardians", 179);
+
+		// Precise times
+		chatMessage = new ChatMessage(null, GAMEMESSAGE, "", "Fight duration: <col=ff0000>1:36.40</col> (new personal best)", null, 0);
+		chatCommandsPlugin.onChatMessage(chatMessage);
+
+		chatMessage = new ChatMessage(null, GAMEMESSAGE, "", "Your Grotesque Guardians kill count is: <col=ff0000>179</col>.", null, 0);
+		chatCommandsPlugin.onChatMessage(chatMessage);
+
+		verify(configManager).setRSProfileConfiguration("personalbest", "grotesque guardians", 96.4);
 	}
 
 	@Test
@@ -371,12 +432,21 @@ public class ChatCommandsPluginTest
 		chatMessage = new ChatMessage(null, GAMEMESSAGE, "", "Your Grotesque Guardians kill count is: <col=ff0000>32</col>.", null, 0);
 		chatCommandsPlugin.onChatMessage(chatMessage);
 
-		verify(configManager).setRSProfileConfiguration("personalbest", "grotesque guardians", 2 * 60 + 14);
+		verify(configManager).setRSProfileConfiguration("personalbest", "grotesque guardians", 2 * 60 + 14.0);
 		verify(configManager).setRSProfileConfiguration("killcount", "grotesque guardians", 32);
+
+		// Precise times
+		chatMessage = new ChatMessage(null, GAMEMESSAGE, "", "Fight duration: <col=ff0000>2:41.40</col>. Personal best: 2:14.20", null, 0);
+		chatCommandsPlugin.onChatMessage(chatMessage);
+
+		chatMessage = new ChatMessage(null, GAMEMESSAGE, "", "Your Grotesque Guardians kill count is: <col=ff0000>32</col>.", null, 0);
+		chatCommandsPlugin.onChatMessage(chatMessage);
+
+		verify(configManager).setRSProfileConfiguration("personalbest", "grotesque guardians", 2 * 60 + 14.2);
 	}
 
 	@Test
-	public void testGuantletPersonalBest()
+	public void testGauntletPersonalBest()
 	{
 		ChatMessage chatMessage = new ChatMessage(null, GAMEMESSAGE, "", "Challenge duration: <col=ff0000>10:24</col>. Personal best: 7:59.", null, 0);
 		chatCommandsPlugin.onChatMessage(chatMessage);
@@ -385,11 +455,20 @@ public class ChatCommandsPluginTest
 		chatCommandsPlugin.onChatMessage(chatMessage);
 
 		verify(configManager).setRSProfileConfiguration("killcount", "gauntlet", 124);
-		verify(configManager).setRSProfileConfiguration("personalbest", "gauntlet", 7 * 60 + 59);
+		verify(configManager).setRSProfileConfiguration("personalbest", "gauntlet", 7 * 60 + 59.0);
+
+		// Precise times
+		chatMessage = new ChatMessage(null, GAMEMESSAGE, "", "Challenge duration: <col=ff0000>10:24.20</col>. Personal best: 7:52.40.", null, 0);
+		chatCommandsPlugin.onChatMessage(chatMessage);
+
+		chatMessage = new ChatMessage(null, GAMEMESSAGE, "", "Your Gauntlet completion count is: <col=ff0000>124</col>.", null, 0);
+		chatCommandsPlugin.onChatMessage(chatMessage);
+
+		verify(configManager).setRSProfileConfiguration("personalbest", "gauntlet", 7 * 60 + 52.4);
 	}
 
 	@Test
-	public void testGuantletNewPersonalBest()
+	public void testGauntletNewPersonalBest()
 	{
 		ChatMessage chatMessage = new ChatMessage(null, GAMEMESSAGE, "", "Challenge duration: <col=ff0000>10:24</col> (new personal best).", null, 0);
 		chatCommandsPlugin.onChatMessage(chatMessage);
@@ -397,8 +476,17 @@ public class ChatCommandsPluginTest
 		chatMessage = new ChatMessage(null, GAMEMESSAGE, "", "Your Gauntlet completion count is: <col=ff0000>124</col>.", null, 0);
 		chatCommandsPlugin.onChatMessage(chatMessage);
 
-		verify(configManager).setRSProfileConfiguration("personalbest", "gauntlet", 10 * 60 + 24);
+		verify(configManager).setRSProfileConfiguration("personalbest", "gauntlet", 10 * 60 + 24.0);
 		verify(configManager).setRSProfileConfiguration("killcount", "gauntlet", 124);
+
+		// Precise times
+		chatMessage = new ChatMessage(null, GAMEMESSAGE, "", "Challenge duration: <col=ff0000>10:24.40</col> (new personal best).", null, 0);
+		chatCommandsPlugin.onChatMessage(chatMessage);
+
+		chatMessage = new ChatMessage(null, GAMEMESSAGE, "", "Your Gauntlet completion count is: <col=ff0000>124</col>.", null, 0);
+		chatCommandsPlugin.onChatMessage(chatMessage);
+
+		verify(configManager).setRSProfileConfiguration("personalbest", "gauntlet", 10 * 60 + 24.4);
 	}
 
 	@Test
@@ -411,7 +499,16 @@ public class ChatCommandsPluginTest
 		chatCommandsPlugin.onChatMessage(chatMessage);
 
 		verify(configManager).setRSProfileConfiguration("killcount", "chambers of xeric", 51);
-		verify(configManager).setRSProfileConfiguration("personalbest", "chambers of xeric", 37 * 60 + 4);
+		verify(configManager).setRSProfileConfiguration("personalbest", "chambers of xeric", 37 * 60 + 4.0);
+
+		// Precise times
+		chatMessage = new ChatMessage(null, FRIENDSCHATNOTIFICATION, "", "<col=ef20ff>Congratulations - your raid is complete!</col><br>Team size: <col=ff0000>24+ players</col> Duration:</col> <col=ff0000>37:04.20</col> (new personal best)</col>>", null, 0);
+		chatCommandsPlugin.onChatMessage(chatMessage);
+
+		chatMessage = new ChatMessage(null, GAMEMESSAGE, "", "Your completed Chambers of Xeric count is: <col=ff0000>51</col>.", null, 0);
+		chatCommandsPlugin.onChatMessage(chatMessage);
+
+		verify(configManager).setRSProfileConfiguration("personalbest", "chambers of xeric", 37 * 60 + 4.2);
 	}
 
 	@Test
@@ -424,7 +521,16 @@ public class ChatCommandsPluginTest
 		chatCommandsPlugin.onChatMessage(chatMessage);
 
 		verify(configManager).setRSProfileConfiguration("killcount", "chambers of xeric", 52);
-		verify(configManager).setRSProfileConfiguration("personalbest", "chambers of xeric", 20 * 60 + 19);
+		verify(configManager).setRSProfileConfiguration("personalbest", "chambers of xeric", 20 * 60 + 19.0);
+
+		// Precise times
+		chatMessage = new ChatMessage(null, FRIENDSCHATNOTIFICATION, "", "<col=ef20ff>Congratulations - your raid is complete!</col><br>Team size: <col=ff0000>11-15 players</col> Duration:</col> <col=ff0000>23:25.40</col> Personal best: </col><col=ff0000>20:19.20</col>", null, 0);
+		chatCommandsPlugin.onChatMessage(chatMessage);
+
+		chatMessage = new ChatMessage(null, GAMEMESSAGE, "", "Your completed Chambers of Xeric count is: <col=ff0000>52</col>.", null, 0);
+		chatCommandsPlugin.onChatMessage(chatMessage);
+
+		verify(configManager).setRSProfileConfiguration("personalbest", "chambers of xeric", 20 * 60 + 19.2);
 	}
 
 	@Test
@@ -435,7 +541,7 @@ public class ChatCommandsPluginTest
 		when(advLogWidget.getChild(ChatCommandsPlugin.ADV_LOG_EXPLOITS_TEXT_INDEX)).thenReturn(advLogExploitsTextWidget);
 		when(advLogExploitsTextWidget.getText()).thenReturn("The Exploits of " + PLAYER_NAME);
 		when(client.getWidget(WidgetInfo.ADVENTURE_LOG)).thenReturn(advLogWidget);
-		when(configManager.getRSProfileConfiguration(anyString(), anyString(), any(Class.class))).thenReturn(2224);
+		when(configManager.getRSProfileConfiguration(anyString(), anyString(), any(Class.class))).thenReturn(2224.0);
 
 		WidgetLoaded advLogEvent = new WidgetLoaded();
 		advLogEvent.setGroupId(ADVENTURE_LOG_ID);
@@ -470,14 +576,14 @@ public class ChatCommandsPluginTest
 		chatCommandsPlugin.onWidgetLoaded(countersLogEvent);
 		chatCommandsPlugin.onGameTick(new GameTick());
 
-		verify(configManager).setRSProfileConfiguration("personalbest", "tztok-jad", 38 * 60 + 10);
-		verify(configManager).setRSProfileConfiguration("personalbest", "zulrah", 5 * 60 + 48);
-		verify(configManager).setRSProfileConfiguration("personalbest", "vorkath", 1 * 60 + 21);
-		verify(configManager).setRSProfileConfiguration("personalbest", "grotesque guardians", 2 * 60 + 49);
-		verify(configManager).setRSProfileConfiguration("personalbest", "hespori", 57);
-		verify(configManager).setRSProfileConfiguration("personalbest", "nightmare", 3 * 60 + 30);
-		verify(configManager).setRSProfileConfiguration("personalbest", "chambers of xeric", 24 * 60 + 17);
-		verify(configManager).setRSProfileConfiguration("personalbest", "chambers of xeric challenge mode", 22 * 60 + 15);
+		verify(configManager).setRSProfileConfiguration("personalbest", "tztok-jad", 38 * 60 + 10.0);
+		verify(configManager).setRSProfileConfiguration("personalbest", "zulrah", 5 * 60 + 48.0);
+		verify(configManager).setRSProfileConfiguration("personalbest", "vorkath", 60 + 21.0);
+		verify(configManager).setRSProfileConfiguration("personalbest", "grotesque guardians", 2 * 60 + 49.0);
+		verify(configManager).setRSProfileConfiguration("personalbest", "hespori", 57.0);
+		verify(configManager).setRSProfileConfiguration("personalbest", "nightmare", 3 * 60 + 30.0);
+		verify(configManager).setRSProfileConfiguration("personalbest", "chambers of xeric", 24 * 60 + 17.0);
+		verify(configManager).setRSProfileConfiguration("personalbest", "chambers of xeric challenge mode", 22 * 60 + 15.0);
 	}
 
 	@Test
@@ -522,12 +628,62 @@ public class ChatCommandsPluginTest
 		chatCommandsPlugin.onWidgetLoaded(countersLogEvent);
 		chatCommandsPlugin.onGameTick(new GameTick());
 
-		verify(configManager).setRSProfileConfiguration("personalbest", "tztok-jad", 65 * 60 + 12);
-		verify(configManager).setRSProfileConfiguration("personalbest", "zulrah", 2 * 60 + 55);
-		verify(configManager).setRSProfileConfiguration("personalbest", "vorkath", 1 * 60 + 37);
-		verify(configManager).setRSProfileConfiguration("personalbest", "hespori", 1 * 60 + 42);
-		verify(configManager).setRSProfileConfiguration("personalbest", "chambers of xeric", 21 * 60 + 23);
-		verify(configManager).setRSProfileConfiguration("personalbest", "chambers of xeric challenge mode", 21 * 60 + 26);
+		verify(configManager).setRSProfileConfiguration("personalbest", "tztok-jad", 65 * 60 + 12.0);
+		verify(configManager).setRSProfileConfiguration("personalbest", "zulrah", 2 * 60 + 55.0);
+		verify(configManager).setRSProfileConfiguration("personalbest", "vorkath", 60 + 37.0);
+		verify(configManager).setRSProfileConfiguration("personalbest", "hespori", 60 + 42.0);
+		verify(configManager).setRSProfileConfiguration("personalbest", "chambers of xeric", 21 * 60 + 23.0);
+		verify(configManager).setRSProfileConfiguration("personalbest", "chambers of xeric challenge mode", 21 * 60 + 26.0);
+	}
+
+	@Test
+	public void testAdventurerLogCountersPagePrecise()
+	{
+		Widget advLogWidget = mock(Widget.class);
+		Widget advLogExploitsTextWidget = mock(Widget.class);
+		when(advLogWidget.getChild(ChatCommandsPlugin.ADV_LOG_EXPLOITS_TEXT_INDEX)).thenReturn(advLogExploitsTextWidget);
+		when(advLogExploitsTextWidget.getText()).thenReturn("The Exploits of " + PLAYER_NAME);
+		when(client.getWidget(WidgetInfo.ADVENTURE_LOG)).thenReturn(advLogWidget);
+
+		WidgetLoaded advLogEvent = new WidgetLoaded();
+		advLogEvent.setGroupId(ADVENTURE_LOG_ID);
+		chatCommandsPlugin.onWidgetLoaded(advLogEvent);
+		chatCommandsPlugin.onGameTick(new GameTick());
+
+		String COUNTER_TEXT = "Duel Arena<br>Wins: <col=d0c0b0>12</col><br>Losses: <col=d0c0b0>20</col>" +
+			"<br><br>Last Man Standing<br>Rank: <col=d0c0b0>0</col>" +
+			"<br><br>Treasure Trails<br>Beginner: <col=d0c0b0>1</col><br>Easy: <col=d0c0b0>4</col>" +
+			"<br>Medium: <col=d0c0b0>35</col><br>Hard: <col=d0c0b0>66</col><br>Elite: <col=d0c0b0>2</col>" +
+			"<br>Master: <col=d0c0b0>0</col><br>Rank: <col=d0c0b0>Novice</col>" +
+			"<br><br>Chompy Hunting<br>Kills: <col=d0c0b0>300</col><br>Rank: <col=d0c0b0>Ogre Forester</col>" +
+			"<br><br>Order of the White Knights<br>Rank: <col=d0c0b0>Unrated</col><br>with a kill score of <col=d0c0b0>99</col>" +
+			"<br><br>TzHaar Fight Cave<br>Fastest run: <col=d0c0b0>65:12.00</col>" +
+			"<br><br>Inferno<br>Fastest run: <col=d0c0b0>-</col><br><br>Zulrah<br>" +
+			"Fastest kill: <col=d0c0b0>2:55.20</col><br><br>Vorkath<br>Fastest kill: <col=d0c0b0>1:37.20</col>" +
+			"<br><br>Galvek<br>Fastest kill: <col=d0c0b0>-</col><br><br>Grotesque Guardians<br>" +
+			"Fastest kill: <col=d0c0b0>-</col><br><br>Alchemical Hydra<br>Fastest kill: <col=d0c0b0>-</col>" +
+			"<br><br>Hespori<br>Fastest kill: <col=d0c0b0>1:42.40</col><br><br>Nightmare<br>" +
+			"Fastest kill: <col=d0c0b0>-</col><br><br>The Gauntlet<br>Fastest run: <col=d0c0b0>-</col>" +
+			"<br><br>The Corrupted Gauntlet<br>Fastest run: <col=d0c0b0>-</col><br><br>Fragment of Seren<br>Fastest kill: <col=d0c0b0>-</col>" +
+			"<br><br>Chambers of Xeric<br>Fastest run - (Team size: Solo): <col=d0c0b0>21:23.20</col><br>Fastest run - (Team size: 3 players): <col=d0c0b0>27:16.40</col>" +
+			"<br><br>Chambers of Xeric - Challenge mode<br>Fastest run - (Team size: Solo): <col=d0c0b0>34:30.20</col><br>Fastest run - (Team size: 4 players): <col=d0c0b0>21:26.00</col>" +
+			"<br><br>Barbarian Assault<br>High-level gambles: <col=d0c0b0>0</col><br><br>Fremennik spirits rested: <col=d0c0b0>0</col>";
+
+		Widget countersPage = mock(Widget.class);
+		when(countersPage.getText()).thenReturn(COUNTER_TEXT);
+		when(client.getWidget(WidgetInfo.GENERIC_SCROLL_TEXT)).thenReturn(countersPage);
+
+		WidgetLoaded countersLogEvent = new WidgetLoaded();
+		countersLogEvent.setGroupId(GENERIC_SCROLL_GROUP_ID);
+		chatCommandsPlugin.onWidgetLoaded(countersLogEvent);
+		chatCommandsPlugin.onGameTick(new GameTick());
+
+		verify(configManager).setRSProfileConfiguration("personalbest", "tztok-jad", 65 * 60 + 12.0);
+		verify(configManager).setRSProfileConfiguration("personalbest", "zulrah", 2 * 60 + 55.2);
+		verify(configManager).setRSProfileConfiguration("personalbest", "vorkath", 60 + 37.2);
+		verify(configManager).setRSProfileConfiguration("personalbest", "hespori", 60 + 42.40);
+		verify(configManager).setRSProfileConfiguration("personalbest", "chambers of xeric", 21 * 60 + 23.20);
+		verify(configManager).setRSProfileConfiguration("personalbest", "chambers of xeric challenge mode", 21 * 60 + 26.0);
 	}
 
 	@Test
@@ -580,7 +736,13 @@ public class ChatCommandsPluginTest
 		ChatMessage chatMessage = new ChatMessage(null, GAMEMESSAGE, "", "Floor 1 time: <col=ff0000>1:19</col>. Personal best: 0:28", null, 0);
 		chatCommandsPlugin.onChatMessage(chatMessage);
 
-		verify(configManager).setRSProfileConfiguration("personalbest", "hallowed sepulchre floor 1", 28);
+		verify(configManager).setRSProfileConfiguration("personalbest", "hallowed sepulchre floor 1", 28.0);
+
+		// Precise times
+		chatMessage = new ChatMessage(null, GAMEMESSAGE, "", "Floor 1 time: <col=ff0000>1:19.20</col>. Personal best: 0:28.40", null, 0);
+		chatCommandsPlugin.onChatMessage(chatMessage);
+
+		verify(configManager).setRSProfileConfiguration("personalbest", "hallowed sepulchre floor 1", 28.4);
 	}
 
 	@Test
@@ -589,7 +751,13 @@ public class ChatCommandsPluginTest
 		ChatMessage chatMessage = new ChatMessage(null, GAMEMESSAGE, "", "Floor 2 time: <col=ff0000>0:47</col> (new personal best)", null, 0);
 		chatCommandsPlugin.onChatMessage(chatMessage);
 
-		verify(configManager).setRSProfileConfiguration("personalbest", "hallowed sepulchre floor 2", 47);
+		verify(configManager).setRSProfileConfiguration("personalbest", "hallowed sepulchre floor 2", 47.0);
+
+		// Precise times
+		chatMessage = new ChatMessage(null, GAMEMESSAGE, "", "Floor 2 time: <col=ff0000>0:47.20</col> (new personal best)", null, 0);
+		chatCommandsPlugin.onChatMessage(chatMessage);
+
+		verify(configManager).setRSProfileConfiguration("personalbest", "hallowed sepulchre floor 2", 47.2);
 	}
 
 	@Test
@@ -598,8 +766,15 @@ public class ChatCommandsPluginTest
 		ChatMessage chatMessage = new ChatMessage(null, GAMEMESSAGE, "", "Floor 5 time: <col=ff0000>4:46</col> (new personal best)<br>Overall time: <col=ff0000>9:53</col> (new personal best)<br>", null, 0);
 		chatCommandsPlugin.onChatMessage(chatMessage);
 
-		verify(configManager).setRSProfileConfiguration("personalbest", "hallowed sepulchre floor 5", 4 * 60 + 46);
-		verify(configManager).setRSProfileConfiguration("personalbest", "hallowed sepulchre", 9 * 60 + 53);
+		verify(configManager).setRSProfileConfiguration("personalbest", "hallowed sepulchre floor 5", 4 * 60 + 46.0);
+		verify(configManager).setRSProfileConfiguration("personalbest", "hallowed sepulchre", 9 * 60 + 53.0);
+
+		// Precise times
+		chatMessage = new ChatMessage(null, GAMEMESSAGE, "", "Floor 5 time: <col=ff0000>4:46.20</col> (new personal best)<br>Overall time: <col=ff0000>9:53.40</col> (new personal best)<br>", null, 0);
+		chatCommandsPlugin.onChatMessage(chatMessage);
+
+		verify(configManager).setRSProfileConfiguration("personalbest", "hallowed sepulchre floor 5", 4 * 60 + 46.2);
+		verify(configManager).setRSProfileConfiguration("personalbest", "hallowed sepulchre", 9 * 60 + 53.4);
 	}
 
 	@Test
@@ -608,8 +783,15 @@ public class ChatCommandsPluginTest
 		ChatMessage chatMessage = new ChatMessage(null, GAMEMESSAGE, "", "Floor 5 time: <col=ff0000>3:26</col> (new personal best)<br>Overall time: <col=ff0000>9:17</col>. Personal best: 9:15<br>", null, 0);
 		chatCommandsPlugin.onChatMessage(chatMessage);
 
-		verify(configManager).setRSProfileConfiguration("personalbest", "hallowed sepulchre floor 5", 3 * 60 + 26);
-		verify(configManager).setRSProfileConfiguration("personalbest", "hallowed sepulchre", 9 * 60 + 15);
+		verify(configManager).setRSProfileConfiguration("personalbest", "hallowed sepulchre floor 5", 3 * 60 + 26.0);
+		verify(configManager).setRSProfileConfiguration("personalbest", "hallowed sepulchre", 9 * 60 + 15.0);
+
+		// Precise times
+		chatMessage = new ChatMessage(null, GAMEMESSAGE, "", "Floor 5 time: <col=ff0000>3:26.20</col> (new personal best)<br>Overall time: <col=ff0000>9:17.00</col>. Personal best: 9:15.40<br>", null, 0);
+		chatCommandsPlugin.onChatMessage(chatMessage);
+
+		verify(configManager).setRSProfileConfiguration("personalbest", "hallowed sepulchre floor 5", 3 * 60 + 26.2);
+		verify(configManager).setRSProfileConfiguration("personalbest", "hallowed sepulchre", 9 * 60 + 15.4);
 	}
 
 	@Test
@@ -618,8 +800,15 @@ public class ChatCommandsPluginTest
 		ChatMessage chatMessage = new ChatMessage(null, GAMEMESSAGE, "", "Floor 5 time: <col=ff0000>3:56</col>. Personal best: 3:05<br>Overall time: <col=ff0000>9:14</col>. Personal best: 7:49<br>", null, 0);
 		chatCommandsPlugin.onChatMessage(chatMessage);
 
-		verify(configManager).setRSProfileConfiguration("personalbest", "hallowed sepulchre floor 5", 3 * 60 + 5);
-		verify(configManager).setRSProfileConfiguration("personalbest", "hallowed sepulchre", 7 * 60 + 49);
+		verify(configManager).setRSProfileConfiguration("personalbest", "hallowed sepulchre floor 5", 3 * 60 + 5.0);
+		verify(configManager).setRSProfileConfiguration("personalbest", "hallowed sepulchre", 7 * 60 + 49.0);
+
+		// Precise times
+		chatMessage = new ChatMessage(null, GAMEMESSAGE, "", "Floor 5 time: <col=ff0000>3:56.40</col>. Personal best: 3:05.20<br>Overall time: <col=ff0000>9:14.20</col>. Personal best: 7:49.20<br>", null, 0);
+		chatCommandsPlugin.onChatMessage(chatMessage);
+
+		verify(configManager).setRSProfileConfiguration("personalbest", "hallowed sepulchre floor 5", 3 * 60 + 5.2);
+		verify(configManager).setRSProfileConfiguration("personalbest", "hallowed sepulchre", 7 * 60 + 49.2);
 	}
 
 	@Test
@@ -628,8 +817,15 @@ public class ChatCommandsPluginTest
 		ChatMessage chatMessage = new ChatMessage(null, GAMEMESSAGE, "", "Floor 5 time: <col=ff0000>3:10</col>. Personal best: 3:04<br>Overall time: <col=ff0000>7:47</col> (new personal best)<br>", null, 0);
 		chatCommandsPlugin.onChatMessage(chatMessage);
 
-		verify(configManager).setRSProfileConfiguration("personalbest", "hallowed sepulchre floor 5", 3 * 60 + 4);
-		verify(configManager).setRSProfileConfiguration("personalbest", "hallowed sepulchre", 7 * 60 + 47);
+		verify(configManager).setRSProfileConfiguration("personalbest", "hallowed sepulchre floor 5", 3 * 60 + 4.0);
+		verify(configManager).setRSProfileConfiguration("personalbest", "hallowed sepulchre", 7 * 60 + 47.0);
+
+		// Precise times
+		chatMessage = new ChatMessage(null, GAMEMESSAGE, "", "Floor 5 time: <col=ff0000>3:10.00</col>. Personal best: 3:04.40<br>Overall time: <col=ff0000>7:47.20</col> (new personal best)<br>", null, 0);
+		chatCommandsPlugin.onChatMessage(chatMessage);
+
+		verify(configManager).setRSProfileConfiguration("personalbest", "hallowed sepulchre floor 5", 3 * 60 + 4.4);
+		verify(configManager).setRSProfileConfiguration("personalbest", "hallowed sepulchre", 7 * 60 + 47.2);
 	}
 
 	@Test
@@ -662,8 +858,14 @@ public class ChatCommandsPluginTest
 		chatMessage = new ChatMessage(null, GAMEMESSAGE, "", "Duration: <col=ff0000>21:58</col> (new personal best)", null, 0);
 		chatCommandsPlugin.onChatMessage(chatMessage);
 
-		verify(configManager).setRSProfileConfiguration("personalbest", "tztok-jad", 21 * 60 + 58);
+		verify(configManager).setRSProfileConfiguration("personalbest", "tztok-jad", 21 * 60 + 58.0);
 		verify(configManager).setRSProfileConfiguration("killcount", "tztok-jad", 2);
+
+		// Precise times
+		chatMessage = new ChatMessage(null, GAMEMESSAGE, "", "Duration: <col=ff0000>21:58.40</col> (new personal best)", null, 0);
+		chatCommandsPlugin.onChatMessage(chatMessage);
+
+		verify(configManager).setRSProfileConfiguration("personalbest", "tztok-jad", 21 * 60 + 58.4);
 	}
 
 	@Test
@@ -676,7 +878,13 @@ public class ChatCommandsPluginTest
 		chatCommandsPlugin.onChatMessage(chatMessage);
 
 		verify(configManager).setRSProfileConfiguration("killcount", "TzHaar-Ket-Rak's First Challenge".toLowerCase(), 1);
-		verify(configManager).setRSProfileConfiguration("personalbest", "TzHaar-Ket-Rak's First Challenge".toLowerCase(), 60 + 46);
+		verify(configManager).setRSProfileConfiguration("personalbest", "TzHaar-Ket-Rak's First Challenge".toLowerCase(), 60 + 46.0);
+
+		// Precise times
+		chatMessage = new ChatMessage(null, GAMEMESSAGE, "", "Challenge duration: <col=ff0000>1:46.40</col> (new personal best)", null, 0);
+		chatCommandsPlugin.onChatMessage(chatMessage);
+
+		verify(configManager).setRSProfileConfiguration("personalbest", "TzHaar-Ket-Rak's First Challenge".toLowerCase(), 60 + 46.4);
 	}
 
 	@Test
@@ -689,6 +897,25 @@ public class ChatCommandsPluginTest
 		chatCommandsPlugin.onChatMessage(chatMessage);
 
 		verify(configManager).setRSProfileConfiguration("killcount", "TzHaar-Ket-Rak's First Challenge".toLowerCase(), 3);
-		verify(configManager).setRSProfileConfiguration("personalbest", "TzHaar-Ket-Rak's First Challenge".toLowerCase(), 59);
+		verify(configManager).setRSProfileConfiguration("personalbest", "TzHaar-Ket-Rak's First Challenge".toLowerCase(), 59.0);
+
+		// Precise times
+		chatMessage = new ChatMessage(null, GAMEMESSAGE, "", "Challenge duration: <col=ff0000>1:10.00</col>. Personal best: <col=ff0000>0:59.20</col>", null, 0);
+		chatCommandsPlugin.onChatMessage(chatMessage);
+
+		verify(configManager).setRSProfileConfiguration("personalbest", "TzHaar-Ket-Rak's First Challenge".toLowerCase(), 59.2);
+	}
+
+	@Test
+	public void testTimeStringToSeconds()
+	{
+		final double DELTA = 0.0001;
+
+		// ss
+		assertEquals(55.0, ChatCommandsPlugin.timeStringToSeconds("55.00"), DELTA);
+		// mm:ss
+		assertEquals(6 * 60 + 55.4, ChatCommandsPlugin.timeStringToSeconds("6:55.40"), DELTA);
+		// h:mm:ss
+		assertEquals(2 * 3600 + 50 * 60 + 30.2, ChatCommandsPlugin.timeStringToSeconds("2:50:30.20"), DELTA);
 	}
 }


### PR DESCRIPTION
With the addition of precise PB timings on 24/02, anyone using the new feature wouldn't be able to have their PBs saved, and they wouldn't be able to be shared even if they were saved.

This PR adds support for doubles to be stored in the config, and then uses that support to store and display all PBs as doubles. I also ended up modifying all tests that use PBs, just in case something affects the specific case it was testing, and 2 new tests were added: one for the collection log due to the existing test's size, and one for `timeStringToSeconds`

Additionally, due to precise PBs always being an integer number of ticks, it's possible to mostly know whether a PB was set with or without precise timing, which I have implemented.
In this example, the first lap was with precise timing, and second lap was without. If I hadn't sliced off the end, it would have shown as 1:04.00, which makes it seem much more precise than it actually was.
![record_2021-03-04__11-57-39](https://user-images.githubusercontent.com/2979691/109961059-65108780-7ce1-11eb-853b-b3f6681b66b3.png)
There will be situations in which a non-precise PB will still show `.00` on the end, but in those situations it would be accurate. Maybe if Jagex eventually retire the non-precise PBs, we can shift over to storing the PBs as the ticks they truly are, but until then this will have to do.

I want to note why I chose double over float: it turns out the precision did matter when trying to do basically any maths on real PBs. My Prif course PB is 64.2, and even that ended up acting as 64.199996 when adding the feature mentioned in the paragraph above.
