### PR TITLE
CrowdsourcingDialogue enhancements

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/crowdsourcing/dialogue/CrowdsourcingDialogue.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/crowdsourcing/dialogue/CrowdsourcingDialogue.java
@@ -64,7 +64,7 @@ public class CrowdsourcingDialogue
 		{
 			clientThread.invokeLater(this::handlePlayerDialogueOptions);
 		}
-		else if (event.getGroupId() == WidgetInfo.DIALOG_NPC_TEXT.getGroupId())
+		else if (event.getGroupId() == WidgetID.DIALOG_NPC_GROUP_ID)
 		{
 			clientThread.invokeLater(this::handleNpcDialogue);
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/crowdsourcing/dialogue/CrowdsourcingDialogue.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/crowdsourcing/dialogue/CrowdsourcingDialogue.java
@@ -63,10 +63,12 @@ public class CrowdsourcingDialogue
 		if (event.getGroupId() == WidgetID.DIALOG_OPTION_GROUP_ID)
 		{
 			clientThread.invokeLater(this::handlePlayerDialogueOptions);
-		} else if (event.getGroupId() == WidgetInfo.DIALOG_NPC_TEXT.getGroupId())
+		}
+		else if (event.getGroupId() == WidgetInfo.DIALOG_NPC_TEXT.getGroupId())
 		{
 			clientThread.invokeLater(this::handleNpcDialogue);
-		} else if (event.getGroupId() == WidgetID.DIALOG_PLAYER_GROUP_ID)
+		}
+		else if (event.getGroupId() == WidgetID.DIALOG_PLAYER_GROUP_ID)
 		{
 			clientThread.invokeLater(this::handlePlayerDialogue);
 		}


### PR DESCRIPTION
Checking on `CrowdsourcingDialogue` class I came across the following:
- A lot of unnecessary checks are being done every tick which can be replaced with `onWidgetLoaded` event;
- Empty strings in `playerDialogueOptions` are being sent to the wiki (to be exact, the last 2 widget children are the swords near the title text which are assumed to be dialogue options);

Also, after these changes it will be possible for plugins to modify any of the concerning widgets (`playerDialogueOptions `, `npcDialogue` and `playerDialogue`) without resulting in sending wrong information to the wiki. (e.g. #13306)