### PR TITLE
Add drop shadow to status bar numbers

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/statusbars/BarRenderer.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/statusbars/BarRenderer.java
@@ -112,10 +112,16 @@ class BarRenderer
 			if (config.enableSkillIcon())
 			{
 				graphics.drawImage(icon, x + ICON_AND_COUNTER_OFFSET_X + PADDING, y + ICON_AND_COUNTER_OFFSET_Y - icon.getWidth(null), null);
+				graphics.setColor(Color.BLACK);
+				graphics.drawString(counterText, x + centerText + PADDING + 1, y + SKILL_ICON_HEIGHT + 1);
+				graphics.setColor(Color.WHITE);
 				graphics.drawString(counterText, x + centerText + PADDING, y + SKILL_ICON_HEIGHT);
 			}
 			else
 			{
+				graphics.setColor(Color.BLACK);
+				graphics.drawString(counterText, x + centerText + PADDING + 1, y + COUNTER_ICON_HEIGHT + 1);
+				graphics.setColor(Color.WHITE);
 				graphics.drawString(counterText, x + centerText + PADDING, y + COUNTER_ICON_HEIGHT);
 			}
 		}


### PR DESCRIPTION
Close #13271 

Added a 1px drop shadow to the numbers on the status bar plugin. Here's how it looks:

![image](https://user-images.githubusercontent.com/22329530/110860712-1dfb3700-828b-11eb-91dc-6cd6345a1390.png)

