### PR TITLE
Clarify how to enter multiple words

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatnotifications/ChatNotificationsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatnotifications/ChatNotificationsConfig.java
@@ -44,7 +44,7 @@ public interface ChatNotificationsConfig extends Config
 		position = 1,
 		keyName = "highlightWordsString",
 		name = "Highlight words",
-		description = "Highlights the following comma-separated words in chat",
+		description = "Highlights the following words in chat, separated by commas",
 		section = highlightLists
 	)
 	default String highlightWordsString()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatnotifications/ChatNotificationsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatnotifications/ChatNotificationsConfig.java
@@ -44,7 +44,7 @@ public interface ChatNotificationsConfig extends Config
 		position = 1,
 		keyName = "highlightWordsString",
 		name = "Highlight words",
-		description = "Highlights the following words in chat",
+		description = "Highlights the following comma-separated words in chat",
 		section = highlightLists
 	)
 	default String highlightWordsString()


### PR DESCRIPTION
A simple non-functional change that should clarify usage.

Clarify that multiple words can be entered in the input box by separating them with commas.