### PR TITLE
Add option to only enable inventory viewer when inventory tab is closed

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/inventoryviewer/InventoryViewerConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/inventoryviewer/InventoryViewerConfig.java
@@ -55,4 +55,15 @@ public interface InventoryViewerConfig extends Config
 	{
 		return false;
 	}
+
+	@ConfigItem(
+		keyName = "hideIfInventoryActive",
+		name = "Hidden on inventory tab",
+		description = "Whether or not the overlay is hidden when the inventory tab is open.",
+		position = 2
+	)
+	default boolean hideIfInventoryActive()
+	{
+		return false;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/inventoryviewer/InventoryViewerOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/inventoryviewer/InventoryViewerOverlay.java
@@ -35,6 +35,7 @@ import net.runelite.api.InventoryID;
 import net.runelite.api.Item;
 import net.runelite.api.ItemComposition;
 import net.runelite.api.ItemContainer;
+import net.runelite.api.VarClientInt;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.ui.overlay.OverlayPanel;
 import net.runelite.client.ui.overlay.OverlayPosition;
@@ -49,6 +50,7 @@ class InventoryViewerOverlay extends OverlayPanel
 
 	private final Client client;
 	private final ItemManager itemManager;
+	private final InventoryViewerConfig config;
 	private boolean hidden;
 
 	@Inject
@@ -61,6 +63,7 @@ class InventoryViewerOverlay extends OverlayPanel
 		panelComponent.setOrientation(ComponentOrientation.HORIZONTAL);
 		this.itemManager = itemManager;
 		this.client = client;
+		this.config = config;
 		this.hidden = config.hiddenDefault();
 	}
 
@@ -68,6 +71,11 @@ class InventoryViewerOverlay extends OverlayPanel
 	public Dimension render(Graphics2D graphics)
 	{
 		if (hidden)
+		{
+			return null;
+		}
+
+		if (client.getVar(VarClientInt.INVENTORY_TAB) == 3 && config.hideIfInventoryActive())
 		{
 			return null;
 		}


### PR DESCRIPTION
Added new setting to only show the inventory viewer overlay when the inventory tab is not selected.
Closes #13318