### PR TITLE
chat color: add public friends chat usernames recolouring

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/chat/ChatMessageManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/chat/ChatMessageManager.java
@@ -41,6 +41,8 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
+import net.runelite.api.FriendsChatManager;
+import net.runelite.api.FriendsChatMember;
 import net.runelite.api.MessageNode;
 import net.runelite.api.Player;
 import net.runelite.api.Varbits;
@@ -132,10 +134,22 @@ public class ChatMessageManager
 			{
 				String sanitizedUsername = Text.removeTags(chatMessage.getName());
 				boolean isFriend = client.isFriended(sanitizedUsername, true) && !client.getLocalPlayer().getName().equals(sanitizedUsername);
-
 				if (isFriend)
 				{
 					usernameColor = isChatboxTransparent ? chatColorConfig.transparentPublicFriendUsernames() : chatColorConfig.opaquePublicFriendUsernames();
+				}
+				else
+				{
+					final FriendsChatManager friendsChatManager = client.getFriendsChatManager();
+					if (friendsChatManager != null)
+					{
+						FriendsChatMember friendsChatMember = friendsChatManager.findByName(sanitizedUsername);
+						boolean isFriendsChatMember = friendsChatMember != null && !client.getLocalPlayer().getName().equals(sanitizedUsername);
+						if (isFriendsChatMember)
+						{
+							usernameColor = isChatboxTransparent ? chatColorConfig.transparentPublicFriendsChatUsernames() : chatColorConfig.opaquePublicFriendsChatUsernames();
+						}
+					}
 				}
 				if (usernameColor == null)
 				{

--- a/runelite-client/src/main/java/net/runelite/client/config/ChatColorConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/ChatColorConfig.java
@@ -314,6 +314,15 @@ public interface ChatColorConfig extends Config
 	Color opaquePublicFriendUsernames();
 
 	@ConfigItem(
+		position = 28,
+		keyName = "opaquePublicFriendsChatUsernames",
+		name = "Public friends chat usernames",
+		description = "Color of Friends Chat Usernames in Public Chat",
+		section = opaqueSection
+	)
+	Color opaquePublicFriendsChatUsernames();
+
+	@ConfigItem(
 		position = 51,
 		keyName = "transparentPublicChat",
 		name = "Public chat (transparent)",
@@ -579,4 +588,13 @@ public interface ChatColorConfig extends Config
 		section = transparentSection
 	)
 	Color transparentPublicFriendUsernames();
+
+	@ConfigItem(
+		position = 78,
+		keyName = "transparentPublicFriendsChatUsernames",
+		name = "Public friends chat usernames (transparent)",
+		description = "Color of Friends Chat Usernames in Public Chat (transparent)",
+		section = transparentSection
+	)
+	Color transparentPublicFriendsChatUsernames();
 }

--- a/runelite-client/src/test/java/net/runelite/client/chat/ChatMessageManagerTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/chat/ChatMessageManagerTest.java
@@ -31,6 +31,8 @@ import com.google.inject.testing.fieldbinder.BoundFieldModule;
 import java.awt.Color;
 import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
+import net.runelite.api.FriendsChatManager;
+import net.runelite.api.FriendsChatMember;
 import net.runelite.api.MessageNode;
 import net.runelite.api.Player;
 import net.runelite.api.events.ChatMessage;
@@ -144,5 +146,37 @@ public class ChatMessageManagerTest
 		chatMessageManager.onChatMessage(chatMessage);
 
 		verify(messageNode).setName("<col=b20000>" + friendName + "</col>");
+	}
+
+	@Test
+	public void testPublicFriendsChatUsernameRecolouring()
+	{
+		final String localPlayerName = "RuneLite";
+		final String friendsChatMemberName = "Zezima";
+
+		when(chatColorConfig.opaquePublicFriendsChatUsernames()).thenReturn(Color.decode("#ffc307"));
+
+		// Setup message
+		ChatMessage chatMessage = new ChatMessage();
+		chatMessage.setType(ChatMessageType.PUBLICCHAT);
+		chatMessage.setName(friendsChatMemberName);
+
+		MessageNode messageNode = mock(MessageNode.class);
+		chatMessage.setMessageNode(messageNode);
+		when(messageNode.getName()).thenReturn(friendsChatMemberName);
+
+		// Setup friends chat member checking
+		Player localPlayer = mock(Player.class);
+		FriendsChatManager friendsChatManager = mock(FriendsChatManager.class);
+		FriendsChatMember friendsChatMember = mock(FriendsChatMember.class);
+
+		when(client.getFriendsChatManager()).thenReturn(friendsChatManager);
+		when(client.getFriendsChatManager().findByName(friendsChatMemberName)).thenReturn(friendsChatMember);
+		when(client.getLocalPlayer()).thenReturn(localPlayer);
+		when(localPlayer.getName()).thenReturn(localPlayerName);
+
+		chatMessageManager.onChatMessage(chatMessage);
+
+		verify(messageNode).setName("<col=ffc307>" + friendsChatMemberName + "</col>");
 	}
 }


### PR DESCRIPTION
This PR adds the option for players to manage username colors of clan members in the public chat.

Adds a case checking whether the message author is in the player's friends chat for every chat message.

#13309 