### PR TITLE
Dedupe GameObjectSpawned events when simulating events

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/util/GameEventManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/util/GameEventManager.java
@@ -168,6 +168,7 @@ public class GameEventManager
 
 				Arrays.stream(tile.getGameObjects())
 					.filter(Objects::nonNull)
+					.filter(object -> object.getSceneMinLocation().equals(tile.getSceneLocation()))
 					.forEach(object ->
 					{
 						final GameObjectSpawned objectSpawned = new GameObjectSpawned();


### PR DESCRIPTION
Currently when the `GameEventManager.simulateGameEvents` is simulating `GameObjectSpawned` it does not handle correctly `GameObject`s that span multiple tiles, causing multiple events to be fired for the same object. 