### PR TITLE
Menu Entry Swapper: Add Barbarian Assault scroll use-swap

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -661,4 +661,15 @@ public interface MenuEntrySwapperConfig extends Config
 	{
 		return false;
 	}
+
+	@ConfigItem(
+		keyName = "swapBarbarianAssaultScroll",
+		name = "Barbarian Assault scroll",
+		description = "Swap Read with Use on the Barbarian Assault recruitment scroll",
+		section = itemSection
+	)
+	default boolean swapBarbarianAssaultScroll()
+	{
+		return false;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -375,6 +375,8 @@ public class MenuEntrySwapperPlugin extends Plugin
 		swap("eat", "guzzle", config::swapRockCake);
 
 		swap("travel", "dive", config::swapRowboatDive);
+
+		swap("read", "scroll", "use", config::swapBarbarianAssaultScroll);
 	}
 
 	private void swap(String option, String swappedOption, Supplier<Boolean> enabled)


### PR DESCRIPTION
The default left-click option is "Read" which is pretty useless. This makes the left-click option "Use".