### PR TITLE
change hs kc patterns to match values greater than 999

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
@@ -110,8 +110,8 @@ public class ChatCommandsPlugin extends Plugin
 	private static final Pattern ADVENTURE_LOG_PB_PATTERN = Pattern.compile("(" + ADVENTURE_LOG_BOSS_PB_PATTERN + "(?: - " + ADVENTURE_LOG_BOSS_PB_PATTERN + ")*) (?:" + ADVENTURE_LOG_COX_PB_PATTERN + "( )*)+");
 	private static final Pattern HS_PB_PATTERN = Pattern.compile("Floor (?<floor>\\d) time: <col=ff0000>(?<floortime>[0-9:]+)</col>(?: \\(new personal best\\)|. Personal best: (?<floorpb>[0-9:]+))" +
 		"(?:<br>Overall time: <col=ff0000>(?<otime>[0-9:]+)</col>(?: \\(new personal best\\)|. Personal best: (?<opb>[0-9:]+)))?");
-	private static final Pattern HS_KC_FLOOR_PATTERN = Pattern.compile("You have completed Floor (\\d) of the Hallowed Sepulchre! Total completions: <col=ff0000>(\\d+)</col>\\.");
-	private static final Pattern HS_KC_GHC_PATTERN = Pattern.compile("You have opened the Grand Hallowed Coffin <col=ff0000>(\\d+)</col> times?!");
+	private static final Pattern HS_KC_FLOOR_PATTERN = Pattern.compile("You have completed Floor (\\d) of the Hallowed Sepulchre! Total completions: <col=ff0000>([0-9,]+)</col>\\.");
+	private static final Pattern HS_KC_GHC_PATTERN = Pattern.compile("You have opened the Grand Hallowed Coffin <col=ff0000>([0-9,]+)</col> times?!");
 
 	private static final String TOTAL_LEVEL_COMMAND_STRING = "!total";
 	private static final String PRICE_COMMAND_STRING = "!price";
@@ -394,14 +394,14 @@ public class ChatCommandsPlugin extends Plugin
 		if (matcher.find())
 		{
 			int floor = Integer.parseInt(matcher.group(1));
-			int kc = Integer.parseInt(matcher.group(2));
+			int kc = Integer.parseInt(matcher.group(2).replaceAll(",",""));
 			setKc("Hallowed Sepulchre Floor " + floor, kc);
 		}
 
 		matcher = HS_KC_GHC_PATTERN.matcher(message);
 		if (matcher.find())
 		{
-			int kc = Integer.parseInt(matcher.group(1));
+			int kc = Integer.parseInt(matcher.group(1).replaceAll(",",""));
 			setKc("Hallowed Sepulchre", kc);
 		}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
@@ -394,14 +394,14 @@ public class ChatCommandsPlugin extends Plugin
 		if (matcher.find())
 		{
 			int floor = Integer.parseInt(matcher.group(1));
-			int kc = Integer.parseInt(matcher.group(2).replaceAll(",",""));
+			int kc = Integer.parseInt(matcher.group(2).replaceAll(",", ""));
 			setKc("Hallowed Sepulchre Floor " + floor, kc);
 		}
 
 		matcher = HS_KC_GHC_PATTERN.matcher(message);
 		if (matcher.find())
 		{
-			int kc = Integer.parseInt(matcher.group(1).replaceAll(",",""));
+			int kc = Integer.parseInt(matcher.group(1).replaceAll(",", ""));
 			setKc("Hallowed Sepulchre", kc);
 		}
 

--- a/runelite-client/src/test/java/net/runelite/client/plugins/chatcommands/ChatCommandsPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/chatcommands/ChatCommandsPluginTest.java
@@ -635,19 +635,19 @@ public class ChatCommandsPluginTest
 	@Test
 	public void testHsFloorKc()
 	{
-		ChatMessage chatMessage = new ChatMessage(null, GAMEMESSAGE, "", "You have completed Floor 5 of the Hallowed Sepulchre! Total completions: <col=ff0000>81</col>.", null, 0);
+		ChatMessage chatMessage = new ChatMessage(null, GAMEMESSAGE, "", "You have completed Floor 5 of the Hallowed Sepulchre! Total completions: <col=ff0000>1,114</col>.", null, 0);
 		chatCommandsPlugin.onChatMessage(chatMessage);
 
-		verify(configManager).setRSProfileConfiguration("killcount", "hallowed sepulchre floor 5", 81);
+		verify(configManager).setRSProfileConfiguration("killcount", "hallowed sepulchre floor 5", 1114);
 	}
 
 	@Test
 	public void testHsGhcKc()
 	{
-		ChatMessage chatMessage = new ChatMessage(null, GAMEMESSAGE, "", "You have opened the Grand Hallowed Coffin <col=ff0000>36</col> times!", null, 0);
+		ChatMessage chatMessage = new ChatMessage(null, GAMEMESSAGE, "", "You have opened the Grand Hallowed Coffin <col=ff0000>1,542</col> times!", null, 0);
 		chatCommandsPlugin.onChatMessage(chatMessage);
 
-		verify(configManager).setRSProfileConfiguration("killcount", "hallowed sepulchre", 36);
+		verify(configManager).setRSProfileConfiguration("killcount", "hallowed sepulchre", 1542);
 	}
 
 	@Test


### PR DESCRIPTION
This PR changes the capture groups for the the Hallowed Sepulchre kc patterns to match values that contain commas, and then strips those commas before invoking setKc. 