### PR TITLE
xp globes: scale icon while respecting aspect ratio

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesOverlay.java
@@ -268,15 +268,13 @@ public class XpGlobesOverlay extends Overlay
 		}
 
 		final int size = orbSize - config.progressArcStrokeWidth();
-		final int width = (int) (size * GLOBE_ICON_RATIO);
-		final int height = (int) (size * GLOBE_ICON_RATIO);
-
-		if (width <= 0 || height <= 0)
+		final int scaledIconSize = (int) (size * GLOBE_ICON_RATIO);
+		if (scaledIconSize <= 0)
 		{
 			return null;
 		}
 
-		icon = ImageUtil.resizeImage(icon, width, height);
+		icon = ImageUtil.resizeImage(icon, scaledIconSize, scaledIconSize, true);
 
 		xpGlobe.setSkillIcon(icon);
 		xpGlobe.setSize(orbSize);

--- a/runelite-client/src/main/java/net/runelite/client/util/ImageUtil.java
+++ b/runelite-client/src/main/java/net/runelite/client/util/ImageUtil.java
@@ -209,7 +209,38 @@ public class ImageUtil
 	 */
 	public static BufferedImage resizeImage(final BufferedImage image, final int newWidth, final int newHeight)
 	{
-		final Image resized = image.getScaledInstance(newWidth, newHeight, Image.SCALE_SMOOTH);
+		return resizeImage(image, newWidth, newHeight, false);
+	}
+
+	/**
+	 * Re-size a BufferedImage to the given dimensions.
+	 *
+	 * @param image the BufferedImage.
+	 * @param newWidth The width to set the BufferedImage to.
+	 * @param newHeight The height to set the BufferedImage to.
+	 * @param preserveAspectRatio Whether to preserve the original image's aspect ratio. When {@code true}, the image
+	 *                               will be scaled to have a maximum of {@code newWidth} width and {@code newHeight}
+	 *                               height.
+	 * @return The BufferedImage with the specified dimensions
+	 */
+	public static BufferedImage resizeImage(final BufferedImage image, final int newWidth, final int newHeight, final boolean preserveAspectRatio)
+	{
+		final Image resized;
+		if (preserveAspectRatio)
+		{
+			if (image.getWidth() > image.getHeight())
+			{
+				resized = image.getScaledInstance(newWidth, -1, Image.SCALE_SMOOTH);
+			}
+			else
+			{
+				resized = image.getScaledInstance(-1, newHeight, Image.SCALE_SMOOTH);
+			}
+		}
+		else
+		{
+			resized = image.getScaledInstance(newWidth, newHeight, Image.SCALE_SMOOTH);
+		}
 		return ImageUtil.bufferedImageFromImage(resized);
 	}
 


### PR DESCRIPTION
Currently the scaling does not look good, as it just forces the image into the size of the orb, not respecting the aspect ratio
![image](https://user-images.githubusercontent.com/2979691/112340317-569e0600-8cb8-11eb-9eb4-3425021509c7.png)
![image](https://user-images.githubusercontent.com/2979691/112342952-9b2aa100-8cba-11eb-9397-ebd6adebdf0a.png)


This PR streamlines the code a lot (not sure why the old code even defined width and height given the values were always the exact same), while also correcting the scaling so it actually looks good. This is done through an interesting feature of `Image.getScaledInstance` whereby giving a negative value for either width or height will result in it using a value that keeps the aspect ratio for the image. 
![record_2021-03-24__15-34-19](https://user-images.githubusercontent.com/2979691/112340641-a54ba000-8cb8-11eb-984e-8801a8f776af.png)
