### PR TITLE
loottracker: Use real skill level for Tempoross loot metadata

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
@@ -766,7 +766,7 @@ public class LootTrackerPlugin extends Plugin
 
 		if (regionID == TEMPOROSS_REGION && message.startsWith(TEMPOROSS_LOOT_STRING))
 		{
-			setEvent(LootRecordType.EVENT, TEMPOROSS_EVENT, client.getBoostedSkillLevel(Skill.FISHING));
+			setEvent(LootRecordType.EVENT, TEMPOROSS_EVENT, client.getRealSkillLevel(Skill.FISHING));
 			takeInventorySnapshot();
 		}
 	}

--- a/runelite-client/src/test/java/net/runelite/client/plugins/loottracker/LootTrackerPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/loottracker/LootTrackerPluginTest.java
@@ -366,7 +366,7 @@ public class LootTrackerPluginTest
 		Player player = mock(Player.class);
 		when(client.getLocalPlayer()).thenReturn(player);
 		when(client.getLocalPlayer().getWorldLocation()).thenReturn(new WorldPoint(3153, 2833, 0));
-		when(client.getBoostedSkillLevel(Skill.FISHING)).thenReturn(69);
+		when(client.getRealSkillLevel(Skill.FISHING)).thenReturn(69);
 
 		LootTrackerPlugin lootTrackerPluginSpy = spy(this.lootTrackerPlugin);
 		doNothing().when(lootTrackerPluginSpy).addLoot(any(), anyInt(), any(), any(), any(Collection.class));


### PR DESCRIPTION
Per request by the Wiki, it turns out the Tempoross reward pool does not take into account boosted level when deciding loot, so getRealSkillLevel should be used for metadata instead.