### PR TITLE
MenuEntrySwapper: add take to light swap for dropped logs in MenuEntrySwapper

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -145,6 +145,17 @@ public interface MenuEntrySwapperConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "swapDroppedLogs",
+		name = "Dropped Logs",
+		description = "Swap Light with Take on Dropped Logs",
+		section = itemSection
+	)
+	default boolean swapDroppedLogs()
+	{
+		return false;
+	}
+
+	@ConfigItem(
 		keyName = "swapBattlestaves",
 		name = "Battlestaff",
 		description = "Swap Wield with Use on Battlestaves without orbs",
@@ -356,7 +367,7 @@ public interface MenuEntrySwapperConfig extends Config
 	@ConfigItem(
 		keyName = "swapPortalNexus",
 		name = "Portal Nexus",
-		description =  "Swap Teleport options with Teleport Menu on the Portal Nexus",
+		description = "Swap Teleport options with Teleport Menu on the Portal Nexus",
 		section = objectSection
 	)
 	default boolean swapPortalNexus()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -350,6 +350,8 @@ public class MenuEntrySwapperPlugin extends Plugin
 
 		swap("clean", "use", config::swapHerbs);
 
+		swap("take", "light", config::swapDroppedLogs);
+
 		swap("read", "recite-prayer", config::swapPrayerBook);
 
 		swap("collect-note", "collect-item", () -> config.swapGEItemCollect() == GEItemCollectMode.ITEMS);

--- a/runelite-client/src/test/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPluginTest.java
@@ -305,6 +305,35 @@ public class MenuEntrySwapperPluginTest
 	}
 
 	@Test
+	public void testDroppedLogs()
+	{
+		when(config.swapDroppedLogs()).thenReturn(true);
+
+		entries = new MenuEntry[]{
+			menu("Cancel", "", MenuAction.CANCEL),
+			menu("Examine", "Logs", MenuAction.EXAMINE_OBJECT),
+			menu("Walk here", "", MenuAction.WALK),
+
+			menu("Light", "Logs", MenuAction.GAME_OBJECT_SECOND_OPTION),
+			menu("Take", "Logs", MenuAction.GAME_OBJECT_FIRST_OPTION),
+		};
+
+		menuEntrySwapperPlugin.onClientTick(new ClientTick());
+
+		ArgumentCaptor<MenuEntry[]> argumentCaptor = ArgumentCaptor.forClass(MenuEntry[].class);
+		verify(client).setMenuEntries(argumentCaptor.capture());
+
+		assertArrayEquals(new MenuEntry[]{
+			menu("Cancel", "", MenuAction.CANCEL),
+			menu("Examine", "Logs", MenuAction.EXAMINE_OBJECT),
+			menu("Walk here", "", MenuAction.WALK),
+
+			menu("Take", "Logs", MenuAction.GAME_OBJECT_FIRST_OPTION),
+			menu("Light", "Logs", MenuAction.GAME_OBJECT_SECOND_OPTION),
+		}, argumentCaptor.getValue());
+	}
+
+	@Test
 	public void testShiftWithdraw()
 	{
 		when(config.bankDepositShiftClick()).thenReturn(ShiftDepositMode.EXTRA_OP);


### PR DESCRIPTION
Tested by checking menu entries on dropped logs with config true and false

Closes #13369

![droppedLogsOff](https://user-images.githubusercontent.com/22460398/112754632-f60a1400-8faa-11eb-97f8-89943b7d50a5.png)

![droppedLogsOn](https://user-images.githubusercontent.com/22460398/112754647-04583000-8fab-11eb-8234-cabc7f7bf4df.png)
