### PR TITLE
menu entry swapper: add Tempoross leave swap

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -661,4 +661,15 @@ public interface MenuEntrySwapperConfig extends Config
 	{
 		return false;
 	}
+
+	@ConfigItem(
+		keyName = "swapTemporossLeave",
+		name = "Tempoross Leave",
+		description = "Swap Talk-to with Leave after subduing Tempoross",
+		section = npcSection
+	)
+	default boolean swapTemporossLeave()
+	{
+		return true;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -670,6 +670,6 @@ public interface MenuEntrySwapperConfig extends Config
 	)
 	default boolean swapTemporossLeave()
 	{
-		return true;
+		return false;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -131,6 +131,13 @@ public class MenuEntrySwapperPlugin extends Plugin
 		"brimstail"
 	);
 
+	private static final Set<String> TEMPOROSS_NPCS = ImmutableSet.of(
+		"captain dudi",
+		"captain pudi",
+		"first mate deri",
+		"first mate peri"
+	);
+
 	@Inject
 	private Client client;
 
@@ -222,6 +229,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 		swap("talk-to", ESSENCE_MINE_NPCS::contains, "teleport", config::swapEssenceMineTeleport);
 		swap("talk-to", "collect", config::swapCollectMiscellania);
 		swap("talk-to", "deposit-items", config::swapDepositItems);
+		swap("talk-to", TEMPOROSS_NPCS::contains, "leave", config::swapTemporossLeave);
 
 		swap("leave tomb", "quick-leave", config::swapQuickLeave);
 		swap("tomb door", "quick-leave", config::swapQuickLeave);

--- a/runelite-client/src/test/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPluginTest.java
@@ -427,4 +427,34 @@ public class MenuEntrySwapperPluginTest
 			menu("Last-destination (AIQ)", "Fairy ring", MenuAction.GAME_OBJECT_SECOND_OPTION),
 		}, argumentCaptor.getValue());
 	}
+
+	@Test
+	public void testTemporossLeave()
+	{
+		when(config.swapTemporossLeave()).thenReturn(true);
+
+		entries = new MenuEntry[]{
+			menu("Cancel", "", MenuAction.CANCEL),
+			menu("Examine", "Captain Dudi", MenuAction.EXAMINE_OBJECT),
+			menu("Walk here", "", MenuAction.WALK),
+
+			menu("Leave", "Captain Dudi", MenuAction.NPC_SECOND_OPTION),
+			menu("Talk-to", "Captain Dudi", MenuAction.NPC_FIRST_OPTION),
+		};
+
+		menuEntrySwapperPlugin.onClientTick(new ClientTick());
+
+		ArgumentCaptor<MenuEntry[]> argumentCaptor = ArgumentCaptor.forClass(MenuEntry[].class);
+		verify(client).setMenuEntries(argumentCaptor.capture());
+
+		// check the leave is hit first instead of talk-to
+		assertArrayEquals(new MenuEntry[]{
+			menu("Cancel", "", MenuAction.CANCEL),
+			menu("Examine", "Captain Dudi", MenuAction.EXAMINE_OBJECT),
+			menu("Walk here", "", MenuAction.WALK),
+
+			menu("Talk-to", "Captain Dudi", MenuAction.NPC_FIRST_OPTION),
+			menu("Leave", "Captain Dudi", MenuAction.NPC_SECOND_OPTION),
+		}, argumentCaptor.getValue());
+	}
 }

--- a/runelite-client/src/test/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPluginTest.java
@@ -427,34 +427,4 @@ public class MenuEntrySwapperPluginTest
 			menu("Last-destination (AIQ)", "Fairy ring", MenuAction.GAME_OBJECT_SECOND_OPTION),
 		}, argumentCaptor.getValue());
 	}
-
-	@Test
-	public void testTemporossLeave()
-	{
-		when(config.swapTemporossLeave()).thenReturn(true);
-
-		entries = new MenuEntry[]{
-			menu("Cancel", "", MenuAction.CANCEL),
-			menu("Examine", "Captain Dudi", MenuAction.EXAMINE_OBJECT),
-			menu("Walk here", "", MenuAction.WALK),
-
-			menu("Leave", "Captain Dudi", MenuAction.NPC_SECOND_OPTION),
-			menu("Talk-to", "Captain Dudi", MenuAction.NPC_FIRST_OPTION),
-		};
-
-		menuEntrySwapperPlugin.onClientTick(new ClientTick());
-
-		ArgumentCaptor<MenuEntry[]> argumentCaptor = ArgumentCaptor.forClass(MenuEntry[].class);
-		verify(client).setMenuEntries(argumentCaptor.capture());
-
-		// check the leave is hit first instead of talk-to
-		assertArrayEquals(new MenuEntry[]{
-			menu("Cancel", "", MenuAction.CANCEL),
-			menu("Examine", "Captain Dudi", MenuAction.EXAMINE_OBJECT),
-			menu("Walk here", "", MenuAction.WALK),
-
-			menu("Talk-to", "Captain Dudi", MenuAction.NPC_FIRST_OPTION),
-			menu("Leave", "Captain Dudi", MenuAction.NPC_SECOND_OPTION),
-		}, argumentCaptor.getValue());
-	}
 }


### PR DESCRIPTION
After subduing Tempoross, to save some time, most players choose to "Leave" instantly by interacting with one of four NPCs in the cove. I believe swapping the default "Talk-to" with "Leave" would be a minor QOL improvement for the boss.

Some self-asked QA questions:

**Is there a risk that players will leave by accident before the fight is over?**

Nope, because the option to leave early is called "Forfeit", which is not being swapped. So throughout the fight, the left-click option for each NPC is going to be "Talk-to".

**Should this swap be enabled by default?**

In my opinion, yes. I believe in 99% or even more cases players just want to leave the cove once the fight is finished. These NPCs are available outside of the cove should anyone want to learn how to play. There's also plenty of time to talk to the NPCs during the fight.

**Should the swap be limited just to the 4 NPCs, or should it be a general thing?**

I think limiting it makes it safer to enable by default. Although I'm not aware of any other NPCs with a "Talk-to" and "Leave" interactions combo. As of now, the name of the config item reflects the fact that it is limited to Tempoross ("Tempoross Leave"). If it's made more generic, it should probably be called just "Leave".

**How was it tested?**

I've manually tested it during a few Tempoross encounters, with both captains and first mates NPCs. ~Also added a unit test, not sure if it adds value though, as it is quite basic.~ The unit test is gone, after discussing on Discord.