### PR TITLE
Added chat color option for User's own RSN

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/chat/ChatMessageManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/chat/ChatMessageManager.java
@@ -138,7 +138,7 @@ public class ChatMessageManager
 				{
 					usernameColor = isChatboxTransparent ? chatColorConfig.transparentPublicFriendUsernames() : chatColorConfig.opaquePublicFriendUsernames();
 				}
-				if(isUser)
+				if (isUser)
 				{
 					usernameColor = isChatboxTransparent ? chatColorConfig.transparentPlayerUsername() : chatColorConfig.opaquePlayerUsername();
 				}

--- a/runelite-client/src/main/java/net/runelite/client/chat/ChatMessageManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/chat/ChatMessageManager.java
@@ -131,11 +131,16 @@ public class ChatMessageManager
 			case MODCHAT:
 			{
 				String sanitizedUsername = Text.removeTags(chatMessage.getName());
-				boolean isFriend = client.isFriended(sanitizedUsername, true) && !client.getLocalPlayer().getName().equals(sanitizedUsername);
+				boolean isUser = client.getLocalPlayer().getName().equals(sanitizedUsername);
+				boolean isFriend = client.isFriended(sanitizedUsername, true) && !isUser;
 
 				if (isFriend)
 				{
 					usernameColor = isChatboxTransparent ? chatColorConfig.transparentPublicFriendUsernames() : chatColorConfig.opaquePublicFriendUsernames();
+				}
+				if(isUser)
+				{
+					usernameColor = isChatboxTransparent ? chatColorConfig.transparentPlayerUsername() : chatColorConfig.opaquePlayerUsername();
 				}
 				if (usernameColor == null)
 				{

--- a/runelite-client/src/main/java/net/runelite/client/chat/ChatMessageManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/chat/ChatMessageManager.java
@@ -131,18 +131,16 @@ public class ChatMessageManager
 			case MODCHAT:
 			{
 				String sanitizedUsername = Text.removeTags(chatMessage.getName());
-				boolean isUser = client.getLocalPlayer().getName().equals(sanitizedUsername);
-				boolean isFriend = client.isFriended(sanitizedUsername, true) && !isUser;
 
-				if (isFriend)
-				{
-					usernameColor = isChatboxTransparent ? chatColorConfig.transparentPublicFriendUsernames() : chatColorConfig.opaquePublicFriendUsernames();
-				}
-				if (isUser)
+				if (client.getLocalPlayer().getName().equals(sanitizedUsername))
 				{
 					usernameColor = isChatboxTransparent ? chatColorConfig.transparentPlayerUsername() : chatColorConfig.opaquePlayerUsername();
 				}
-				if (usernameColor == null)
+				else if (client.isFriended(sanitizedUsername, true))
+				{
+					usernameColor = isChatboxTransparent ? chatColorConfig.transparentPublicFriendUsernames() : chatColorConfig.opaquePublicFriendUsernames();
+				}
+				else
 				{
 					usernameColor = isChatboxTransparent ? chatColorConfig.transparentUsername() : chatColorConfig.opaqueUsername();
 				}

--- a/runelite-client/src/main/java/net/runelite/client/config/ChatColorConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/ChatColorConfig.java
@@ -314,6 +314,15 @@ public interface ChatColorConfig extends Config
 	Color opaquePublicFriendUsernames();
 
 	@ConfigItem(
+		position = 28,
+		keyName = "opaquePlayerUsername",
+		name = "Your Username",
+		description = "Color of Your Username",
+		section = opaqueSection
+	)
+	Color opaquePlayerUsername();
+
+	@ConfigItem(
 		position = 51,
 		keyName = "transparentPublicChat",
 		name = "Public chat (transparent)",
@@ -579,4 +588,13 @@ public interface ChatColorConfig extends Config
 		section = transparentSection
 	)
 	Color transparentPublicFriendUsernames();
+
+	@ConfigItem(
+		position = 78,
+		keyName = "transparentPlayerUsername",
+		name = "Your Username (transparent)",
+		description = "Color of Your Username (transparent)",
+		section = transparentSection
+	)
+	Color transparentPlayerUsername();
 }

--- a/runelite-client/src/main/java/net/runelite/client/config/ChatColorConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/ChatColorConfig.java
@@ -316,8 +316,8 @@ public interface ChatColorConfig extends Config
 	@ConfigItem(
 		position = 28,
 		keyName = "opaquePlayerUsername",
-		name = "Your Username",
-		description = "Color of Your Username",
+		name = "Your username",
+		description = "Color of your username",
 		section = opaqueSection
 	)
 	Color opaquePlayerUsername();
@@ -592,8 +592,8 @@ public interface ChatColorConfig extends Config
 	@ConfigItem(
 		position = 78,
 		keyName = "transparentPlayerUsername",
-		name = "Your Username (transparent)",
-		description = "Color of Your Username (transparent)",
+		name = "Your username (transparent)",
+		description = "Color of your username (transparent)",
 		section = transparentSection
 	)
 	Color transparentPlayerUsername();


### PR DESCRIPTION
Testing out my first contribution by tackling a simple feature request from #13355 . Options added in 'Chat Color' config for both transparent and opaque.