### PR TITLE
Menu Entry Swapper: Swap Construction Cape Wear with Tele to POH

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -425,7 +425,10 @@ public interface MenuEntrySwapperConfig extends Config
 			description = "Swap Wear with Teleport to POH on the Construction Cape",
 			section = itemSection
 	)
-	default boolean swapConstructionCapeToPOH() { return false; }
+	default boolean swapConstructionCapeToPOH()
+	{
+		return false;
+	}
 
 	@ConfigItem(
 		keyName = "swapAbyssTeleport",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -420,6 +420,14 @@ public interface MenuEntrySwapperConfig extends Config
 	}
 
 	@ConfigItem(
+			keyName = "swapConstructionCapeToPOH",
+			name = "Construction Cape",
+			description = "Swap Wear with Teleport to POH on the Construction Cape",
+			section = itemSection
+	)
+	default boolean swapConstructionCapeToPOH() { return false; }
+
+	@ConfigItem(
 		keyName = "swapAbyssTeleport",
 		name = "Teleport to Abyss",
 		description = "Swap Talk-to with Teleport for the Mage of Zamorak",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -344,6 +344,8 @@ public class MenuEntrySwapperPlugin extends Plugin
 		swap("wield", "teleport", config::swapTeleportItem);
 		swap("wield", "invoke", config::swapTeleportItem);
 
+		swap("wear", "tele to poh", config::swapConstructionCapeToPOH);
+
 		swap("bury", "use", config::swapBones);
 
 		swap("wield", "battlestaff", "use", config::swapBattlestaves);


### PR DESCRIPTION
Allows for a left-click "Tele to POH" for the construction cape without interfering with regular "Teleport Item" functionality.