### PR TITLE
time tracking: fix birdhouse notification buttons not doing anything

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/TimeTrackingConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/TimeTrackingConfig.java
@@ -42,6 +42,7 @@ public interface TimeTrackingConfig extends Config
 	String STOPWATCHES = "stopwatches";
 	String PREFER_SOONEST = "preferSoonest";
 	String NOTIFY = "notify";
+	String BIRDHOUSE_NOTIFY = "birdHouseNotification";
 
 	@ConfigItem(
 		keyName = "timeFormatMode",
@@ -61,17 +62,6 @@ public interface TimeTrackingConfig extends Config
 		position = 2
 	)
 	default boolean timerNotification()
-	{
-		return false;
-	}
-
-	@ConfigItem(
-		keyName = "birdHouseNotification",
-		name = "Bird house notification",
-		description = "Notify you when all bird houses are full",
-		position = 3
-	)
-	default boolean birdHouseNotification()
 	{
 		return false;
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/hunter/BirdHouseTabPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/hunter/BirdHouseTabPanel.java
@@ -31,24 +31,29 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import net.runelite.api.ItemID;
+import net.runelite.client.config.ConfigManager;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.plugins.timetracking.TabContentPanel;
 import net.runelite.client.plugins.timetracking.TimeTrackingConfig;
 import net.runelite.client.plugins.timetracking.TimeablePanel;
 import net.runelite.client.ui.ColorScheme;
 import net.runelite.client.ui.DynamicGridLayout;
+import javax.swing.JToggleButton;
 
 public class BirdHouseTabPanel extends TabContentPanel
 {
 	private static final Color COMPLETED_COLOR = ColorScheme.PROGRESS_COMPLETE_COLOR.darker();
 
+	private final ConfigManager configManager;
 	private final ItemManager itemManager;
 	private final BirdHouseTracker birdHouseTracker;
 	private final TimeTrackingConfig config;
 	private final List<TimeablePanel<BirdHouseSpace>> spacePanels;
 
-	BirdHouseTabPanel(ItemManager itemManager, BirdHouseTracker birdHouseTracker, TimeTrackingConfig config)
+	BirdHouseTabPanel(ConfigManager configManager, ItemManager itemManager, BirdHouseTracker birdHouseTracker,
+		TimeTrackingConfig config)
 	{
+		this.configManager = configManager;
 		this.itemManager = itemManager;
 		this.birdHouseTracker = birdHouseTracker;
 		this.config = config;
@@ -71,6 +76,17 @@ public class BirdHouseTabPanel extends TabContentPanel
 				first = false;
 				panel.setBorder(null);
 			}
+
+			JToggleButton toggleNotify = panel.getNotifyButton();
+
+			toggleNotify.addActionListener(e ->
+			{
+				if (configManager.getRSProfileKey() != null)
+				{
+					configManager.setRSProfileConfiguration(TimeTrackingConfig.CONFIG_GROUP, TimeTrackingConfig.BIRDHOUSE_NOTIFY, toggleNotify.isSelected());
+				}
+				spacePanels.forEach(p -> p.getNotifyButton().setSelected(toggleNotify.isSelected()));
+			});
 		}
 	}
 
@@ -84,6 +100,9 @@ public class BirdHouseTabPanel extends TabContentPanel
 	public void update()
 	{
 		long unixNow = Instant.now().getEpochSecond();
+
+		boolean notifications = Boolean.TRUE
+			.equals(configManager.getRSProfileConfiguration(TimeTrackingConfig.CONFIG_GROUP, TimeTrackingConfig.BIRDHOUSE_NOTIFY, boolean.class));
 
 		for (TimeablePanel<BirdHouseSpace> panel : spacePanels)
 		{
@@ -112,6 +131,8 @@ public class BirdHouseTabPanel extends TabContentPanel
 				panel.getIcon().setToolTipText(birdHouse.getName());
 				panel.getProgress().setVisible(true);
 			}
+
+			panel.getNotifyButton().setSelected(notifications);
 
 			panel.getProgress().setForeground(state.getColor().darker());
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/hunter/BirdHouseTracker.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/hunter/BirdHouseTracker.java
@@ -84,7 +84,7 @@ public class BirdHouseTracker
 
 	public BirdHouseTabPanel createBirdHouseTabPanel()
 	{
-		return new BirdHouseTabPanel(itemManager, this, config);
+		return new BirdHouseTabPanel(configManager, itemManager, this, config);
 	}
 
 	public void loadFromConfig()
@@ -180,7 +180,7 @@ public class BirdHouseTracker
 			summary = SummaryState.COMPLETED;
 			completionTime = 0;
 
-			if (config.birdHouseNotification())
+			if (Boolean.TRUE.equals(configManager.getRSProfileConfiguration(TimeTrackingConfig.CONFIG_GROUP, TimeTrackingConfig.BIRDHOUSE_NOTIFY, boolean.class)))
 			{
 				notifier.notify("Your bird houses are ready to be dismantled.");
 			}


### PR DESCRIPTION
Closes #13262
Closes #13270

This moves the birdhouse notifications over to the notify buttons in the panel, instead of using a config option.