### PR TITLE
Remove lvl 15 requirment from fishing trawler task in ardy easy diary

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/ArdougneDiaryRequirement.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/ArdougneDiaryRequirement.java
@@ -42,8 +42,6 @@ public class ArdougneDiaryRequirement extends GenericDiaryRequirement
 			new SkillRequirement(Skill.THIEVING, 5));
 		add("Enter the Combat Training Camp north of W. Ardougne.",
 			new QuestRequirement(Quest.BIOHAZARD));
-		add("Go out fishing on the Fishing Trawler.",
-			new SkillRequirement(Skill.FISHING, 15));
 
 		// MEDIUM
 		add("Enter the Unicorn pen in Ardougne zoo using Fairy rings.",


### PR DESCRIPTION
Remove lvl 15 requirment from fishing trawler task in ardy easy diary

Closes #13476