### PR TITLE
achievementdiary: Update Runecraft task texts to match latest ingame texts

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/ArdougneDiaryRequirement.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/ArdougneDiaryRequirement.java
@@ -105,7 +105,7 @@ public class ArdougneDiaryRequirement extends GenericDiaryRequirement
 		add("Smith a Dragon sq shield in West Ardougne.",
 			new SkillRequirement(Skill.SMITHING, 60),
 			new QuestRequirement(Quest.LEGENDS_QUEST));
-		add("Craft some Death runes.",
+		add("Craft some Death runes from Essence.",
 			new SkillRequirement(Skill.RUNECRAFT, 65),
 			new QuestRequirement(Quest.MOURNINGS_END_PART_II));
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/FaladorDiaryRequirement.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/FaladorDiaryRequirement.java
@@ -106,7 +106,7 @@ public class FaladorDiaryRequirement extends GenericDiaryRequirement
 			new QuestRequirement(Quest.GRIM_TALES));
 
 		// ELITE
-		add("Craft 252 Air Runes simultaneously.",
+		add("Craft 252 Air Runes simultaneously from Essence.",
 			new SkillRequirement(Skill.RUNECRAFT, 88));
 		add("Purchase a White 2h Sword from Sir Vyvin.",
 			new QuestRequirement(Quest.WANTED));

--- a/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/FaladorDiaryRequirement.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/FaladorDiaryRequirement.java
@@ -84,7 +84,7 @@ public class FaladorDiaryRequirement extends GenericDiaryRequirement
 			new SkillRequirement(Skill.MAGIC, 37));
 
 		// HARD
-		add("Craft 140 Mind runes simultaneously.",
+		add("Craft 140 Mind runes simultaneously from Essence.",
 			new SkillRequirement(Skill.RUNECRAFT, 56));
 		add("Change your family crest to the Saradomin symbol.",
 			new SkillRequirement(Skill.PRAYER, 70));

--- a/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/FremennikDiaryRequirement.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/FremennikDiaryRequirement.java
@@ -111,7 +111,7 @@ public class FremennikDiaryRequirement extends GenericDiaryRequirement
 			new QuestRequirement(Quest.THE_GIANT_DWARF, true));
 
 		// ELITE
-		add("Craft 56 astral runes at once.",
+		add("Craft 56 astral runes at once from Essence.",
 			new SkillRequirement(Skill.RUNECRAFT, 82),
 			new QuestRequirement(Quest.LUNAR_DIPLOMACY));
 		add("Create a dragonstone amulet in the Neitiznot furnace.",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/KaramjaDiaryRequirement.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/KaramjaDiaryRequirement.java
@@ -96,7 +96,7 @@ public class KaramjaDiaryRequirement extends GenericDiaryRequirement
 		);
 
 		// HARD
-		add("Craft some nature runes.",
+		add("Craft some nature runes from Essence.",
 			new SkillRequirement(Skill.RUNECRAFT, 44),
 			new QuestRequirement(Quest.RUNE_MYSTERIES));
 		add("Cook a karambwan thoroughly.",
@@ -122,7 +122,7 @@ public class KaramjaDiaryRequirement extends GenericDiaryRequirement
 			new QuestRequirement(Quest.SHILO_VILLAGE));
 
 		// ELITE
-		add("Craft 56 Nature runes at once.",
+		add("Craft 56 Nature runes at once from Essence.",
 			new SkillRequirement(Skill.RUNECRAFT, 91));
 		add("Check the health of a palm tree in Brimhaven.",
 			new SkillRequirement(Skill.FARMING, 68));

--- a/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/KourendDiaryRequirement.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/KourendDiaryRequirement.java
@@ -110,7 +110,7 @@ public class KourendDiaryRequirement extends GenericDiaryRequirement
 			new QuestRequirement(Quest.DREAM_MENTOR));
 
 		//ELITE
-		add("Craft one or more Blood runes.",
+		add("Craft one or more Blood runes from Essence.",
 			new SkillRequirement(Skill.RUNECRAFT, 77),
 			new SkillRequirement(Skill.MINING, 38),
 			new SkillRequirement(Skill.CRAFTING, 38),

--- a/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/LumbridgeDiaryRequirement.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/LumbridgeDiaryRequirement.java
@@ -43,7 +43,7 @@ public class LumbridgeDiaryRequirement extends GenericDiaryRequirement
 			new SkillRequirement(Skill.SLAYER, 7));
 		add("Have Sedridor teleport you to the Essence Mine.",
 			new QuestRequirement(Quest.RUNE_MYSTERIES));
-		add("Craft some water runes.",
+		add("Craft some water runes from Essence.",
 			new SkillRequirement(Skill.RUNECRAFT, 5),
 			new QuestRequirement(Quest.RUNE_MYSTERIES));
 		add("Chop and burn some oak logs in Lumbridge.",
@@ -94,7 +94,7 @@ public class LumbridgeDiaryRequirement extends GenericDiaryRequirement
 		add("Squeeze past the jutting wall on your way to the cosmic altar.",
 			new SkillRequirement(Skill.AGILITY, 46),
 			new QuestRequirement(Quest.LOST_CITY));
-		add("Craft 56 Cosmic runes simultaneously.",
+		add("Craft 56 Cosmic runes simultaneously from Essence.",
 			new SkillRequirement(Skill.RUNECRAFT, 59),
 			new QuestRequirement(Quest.LOST_CITY));
 		add("Travel from Lumbridge to Edgeville on a Waka Canoe.",
@@ -128,7 +128,7 @@ public class LumbridgeDiaryRequirement extends GenericDiaryRequirement
 			new SkillRequirement(Skill.WOODCUTTING, 75));
 		add("Smith an Adamant platebody down Draynor sewer.",
 			new SkillRequirement(Skill.SMITHING, 88));
-		add("Craft 140 or more Water runes at once.",
+		add("Craft 140 or more Water runes at once from Essence.",
 			new SkillRequirement(Skill.RUNECRAFT, 76),
 			new QuestRequirement(Quest.RUNE_MYSTERIES));
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/VarrockDiaryRequirement.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/VarrockDiaryRequirement.java
@@ -46,7 +46,7 @@ public class VarrockDiaryRequirement extends GenericDiaryRequirement
 			new SkillRequirement(Skill.AGILITY, 13));
 		add("Spin a bowl on the pottery wheel and fire it in the oven in Barb Village.",
 			new SkillRequirement(Skill.CRAFTING, 8));
-		add("Craft some Earth runes.",
+		add("Craft some Earth runes from Essence.",
 			new SkillRequirement(Skill.RUNECRAFT, 9));
 		add("Catch some trout in the River Lum at Barbarian Village.",
 			new SkillRequirement(Skill.FISHING, 20));
@@ -112,7 +112,7 @@ public class VarrockDiaryRequirement extends GenericDiaryRequirement
 			new SkillRequirement(Skill.SMITHING, 89),
 			new SkillRequirement(Skill.FLETCHING, 81),
 			new QuestRequirement(Quest.THE_TOURIST_TRAP));
-		add("Craft 100 or more earth runes simultaneously.",
+		add("Craft 100 or more earth runes simultaneously from Essence.",
 			new SkillRequirement(Skill.RUNECRAFT, 78),
 			new QuestRequirement(Quest.RUNE_MYSTERIES));
 	}


### PR DESCRIPTION
All diary steps involving runecraft now specify that the runes must be crafted from Essence rather than the cores dropped by the new golems.
Tested in game.

Closes #13480