### PR TITLE
fix crystal pickaxe inactive not counting #13515

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/SkillChallengeClue.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/SkillChallengeClue.java
@@ -107,7 +107,8 @@ public class SkillChallengeClue extends ClueScroll implements NpcClueScroll, Nam
 		item(ItemID.INFERNAL_AXE_UNCHARGED_25371),
 		item(ItemID.GILDED_AXE),
 		item(ItemID._3RD_AGE_AXE),
-		item(ItemID.CRYSTAL_AXE)
+		item(ItemID.CRYSTAL_AXE),
+		item(ItemID.CRYSTAL_AXE_INACTIVE)
 	);
 
 	private static final AnyRequirementCollection ANY_HARPOON = any("Harpoon",
@@ -119,7 +120,8 @@ public class SkillChallengeClue extends ClueScroll implements NpcClueScroll, Nam
 		item(ItemID.INFERNAL_HARPOON_OR),
 		item(ItemID.INFERNAL_HARPOON_UNCHARGED),
 		item(ItemID.INFERNAL_HARPOON_UNCHARGED_25367),
-		item(ItemID.CRYSTAL_HARPOON)
+		item(ItemID.CRYSTAL_HARPOON),
+		item(ItemID.CRYSTAL_HARPOON_INACTIVE)
 	);
 
 	private static final Set<SkillChallengeClue> CLUES = ImmutableSet.of(

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/SkillChallengeClue.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/SkillChallengeClue.java
@@ -87,7 +87,8 @@ public class SkillChallengeClue extends ClueScroll implements NpcClueScroll, Nam
 		item(ItemID.INFERNAL_PICKAXE_UNCHARGED_25369),
 		item(ItemID.GILDED_PICKAXE),
 		item(ItemID._3RD_AGE_PICKAXE),
-		item(ItemID.CRYSTAL_PICKAXE)
+		item(ItemID.CRYSTAL_PICKAXE),
+		item(ItemID.CRYSTAL_PICKAXE_INACTIVE)
 	);
 
 	private static final AnyRequirementCollection ANY_AXE = any("Any Axe",


### PR DESCRIPTION
The inactive version of the crystal pickaxe doesn't count as a pickaxe during Charlie the Tramp task to mine an iron ore.

This should fix that by adding the inactive version as an item in the requirement collection for pickaxes.

Fixes #13515