### PR TITLE
Adds vanity options to woodcutting and mining plugins' overlay

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/mining/MiningConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/mining/MiningConfig.java
@@ -25,18 +25,18 @@
  */
 package net.runelite.client.plugins.mining;
 
-import net.runelite.client.config.Config;
-import net.runelite.client.config.ConfigGroup;
-import net.runelite.client.config.ConfigItem;
-import net.runelite.client.config.Units;
+import net.runelite.client.config.*;
+
+import java.awt.*;
 
 @ConfigGroup("mining")
 public interface MiningConfig extends Config
 {
 	@ConfigItem(
-		keyName = "statTimeout",
-		name = "Reset stats",
-		description = "Duration the mining indicator and session stats are displayed before being reset"
+			position = 1,
+			keyName = "statTimeout",
+			name = "Reset stats",
+			description = "Duration the mining indicator and session stats are displayed before being reset"
 	)
 	@Units(Units.MINUTES)
 	default int statTimeout()
@@ -45,12 +45,84 @@ public interface MiningConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "showMiningStats",
-		name = "Show session stats",
-		description = "Configures whether to display mining session stats"
+			position = 2,
+			keyName = "showMiningStats",
+			name = "Show session stats",
+			description = "Configures whether to display mining session stats"
 	)
 	default boolean showMiningStats()
 	{
 		return true;
+	}
+
+	@ConfigSection(
+			name = "Graphics Settings",
+			description = "Overlay Graphics settings",
+			position = 10
+	)
+	String visualSection = "Graphics";
+
+	@Alpha
+	@ConfigItem(
+			position = 11,
+			keyName = "hexColorRockOverlay",
+			name = "Overlay color",
+			description = "Color of the rock overlay",
+			section = visualSection
+	)
+	default Color getRockOverlayColor()
+	{
+		return Color.YELLOW;
+	}
+
+	@Alpha
+	@ConfigItem(
+			position = 12,
+			keyName = "hexColorRockOverlayOutline",
+			name = "Overlay outline color",
+			description = "Color of the rock outline overlay",
+			section = visualSection
+	)
+	default Color getRockOverlayOutlineColor()
+	{
+		return Color.ORANGE;
+	}
+
+	@Alpha
+	@ConfigItem(
+			position = 13,
+			keyName = "hexColorRockOverlayMLM",
+			name = "MLM Overlay color",
+			description = "Color of the rock overlay (Motherload Mine, Lovakite)",
+			section = visualSection
+	)
+	default Color getRockOverlayColorMLM()
+	{
+		return new Color(0, 100, 0);
+	}
+
+	@Alpha
+	@ConfigItem(
+			position = 14,
+			keyName = "hexColorRockOutlineOverlayMLM",
+			name = "MLM Overlay outline color",
+			description = "Color of the outline for the rock overlay (Motherload Mine, Lovakite)",
+			section = visualSection
+	)
+	default Color getRockOverlayOutlineColorMLM()
+	{
+		return Color.GREEN;
+	}
+
+	@ConfigItem(
+			position = 15,
+			keyName = "getRockOverlayDiameter",
+			name = "Rock overlay diameter",
+			description = "Adjust the size of the rock overlay",
+			section = visualSection
+	)
+	default int getRockOverlayDiameter()
+	{
+		return 25;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/mining/MiningRocksOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/mining/MiningRocksOverlay.java
@@ -34,10 +34,12 @@ import net.runelite.api.Client;
 import net.runelite.api.Perspective;
 import net.runelite.api.Point;
 import net.runelite.api.coords.LocalPoint;
+import net.runelite.client.plugins.hunter.HunterConfig;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.components.ProgressPieComponent;
+import net.runelite.client.plugins.mining.MiningPlugin;
 
 class MiningRocksOverlay extends Overlay
 {
@@ -54,19 +56,21 @@ class MiningRocksOverlay extends Overlay
 	private static final int LOVAKITE_ORE_MIN_RESPAWN_TIME = 50; // Game ticks
 	private static final float LOVAKITE_ORE_RANDOM_PERCENT_THRESHOLD = (float) LOVAKITE_ORE_MIN_RESPAWN_TIME / LOVAKITE_ORE_MAX_RESPAWN_TIME;
 
-	private static final Color DARK_GREEN = new Color(0, 100, 0);
+	//private static final Color DARK_GREEN = config;
 	private static final int MOTHERLODE_UPPER_FLOOR_HEIGHT = -500;
 
 	private final Client client;
 	private final MiningPlugin plugin;
+	private final MiningConfig config;
 
 	@Inject
-	private MiningRocksOverlay(Client client, MiningPlugin plugin)
+	private MiningRocksOverlay(Client client, MiningPlugin plugin, MiningConfig config)
 	{
 		setPosition(OverlayPosition.DYNAMIC);
 		setLayer(OverlayLayer.ABOVE_SCENE);
 		this.plugin = plugin;
 		this.client = client;
+		this.config = config;
 	}
 
 	@Override
@@ -103,21 +107,22 @@ class MiningRocksOverlay extends Overlay
 				continue;
 			}
 
-			Color pieFillColor = Color.YELLOW;
-			Color pieBorderColor = Color.ORANGE;
+			Color pieFillColor = config.getRockOverlayColor();
+			Color pieBorderColor = config.getRockOverlayOutlineColor();
 
 			// Recolour pie on motherlode veins or Lovakite ore during the portion of the timer where they may respawn
 			if ((rock == Rock.ORE_VEIN && percent > ORE_VEIN_RANDOM_PERCENT_THRESHOLD)
-				|| (rock == Rock.DAEYALT_ESSENCE && percent > DAEYALT_RANDOM_PERCENT_THRESHOLD)
-				|| (rock == Rock.LOVAKITE && percent > LOVAKITE_ORE_RANDOM_PERCENT_THRESHOLD))
+					|| (rock == Rock.DAEYALT_ESSENCE && percent > DAEYALT_RANDOM_PERCENT_THRESHOLD)
+					|| (rock == Rock.LOVAKITE && percent > LOVAKITE_ORE_RANDOM_PERCENT_THRESHOLD))
 			{
-				pieFillColor = Color.GREEN;
-				pieBorderColor = DARK_GREEN;
+				pieFillColor = config.getRockOverlayColorMLM();//Color.GREEN;
+				pieBorderColor = config.getRockOverlayOutlineColorMLM();//DARK_GREEN;
 			}
 
 			ProgressPieComponent ppc = new ProgressPieComponent();
 			ppc.setBorderColor(pieBorderColor);
 			ppc.setFill(pieFillColor);
+			ppc.setDiameter(config.getRockOverlayDiameter());
 			ppc.setPosition(point);
 			ppc.setProgress(percent);
 			ppc.render(graphics);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingConfig.java
@@ -24,19 +24,18 @@
  */
 package net.runelite.client.plugins.woodcutting;
 
-import net.runelite.client.config.Config;
-import net.runelite.client.config.ConfigGroup;
-import net.runelite.client.config.ConfigItem;
-import net.runelite.client.config.Units;
+import net.runelite.client.config.*;
+
+import java.awt.*;
 
 @ConfigGroup("woodcutting")
 public interface WoodcuttingConfig extends Config
 {
 	@ConfigItem(
-		position = 1,
-		keyName = "statTimeout",
-		name = "Reset stats",
-		description = "Configures the time until statistic is reset. Also configures when tree indicator is hidden"
+			position = 1,
+			keyName = "statTimeout",
+			name = "Reset stats",
+			description = "Configures the time until statistic is reset. Also configures when tree indicator is hidden"
 	)
 	@Units(Units.MINUTES)
 	default int statTimeout()
@@ -45,10 +44,10 @@ public interface WoodcuttingConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 2,
-		keyName = "showNestNotification",
-		name = "Bird nest notification",
-		description = "Configures whether to notify you of a bird nest spawn"
+			position = 2,
+			keyName = "showNestNotification",
+			name = "Bird nest notification",
+			description = "Configures whether to notify you of a bird nest spawn"
 	)
 	default boolean showNestNotification()
 	{
@@ -56,10 +55,10 @@ public interface WoodcuttingConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 3,
-		keyName = "showWoodcuttingStats",
-		name = "Show session stats",
-		description = "Configures whether to display woodcutting session stats"
+			position = 3,
+			keyName = "showWoodcuttingStats",
+			name = "Show session stats",
+			description = "Configures whether to display woodcutting session stats"
 	)
 	default boolean showWoodcuttingStats()
 	{
@@ -67,10 +66,10 @@ public interface WoodcuttingConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 4,
-		keyName = "showRedwoods",
-		name = "Show Redwood trees",
-		description = "Configures whether to show a indicator for redwood trees"
+			position = 4,
+			keyName = "showRedwoods",
+			name = "Show Redwood trees",
+			description = "Configures whether to show a indicator for redwood trees"
 	)
 	default boolean showRedwoodTrees()
 	{
@@ -78,13 +77,60 @@ public interface WoodcuttingConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 5,
-		keyName = "showRespawnTimers",
-		name = "Show respawn timers",
-		description = "Configures whether to display the respawn timer overlay"
+			position = 5,
+			keyName = "showRespawnTimers",
+			name = "Show respawn timers",
+			description = "Configures whether to display the respawn timer overlay"
 	)
 	default boolean showRespawnTimers()
 	{
 		return true;
 	}
+
+
+	@ConfigSection(
+			name = "Graphics Settings",
+			description = "Overlay graphics settings",
+			position = 10
+	)
+	String visualSection = "Graphics";
+
+	@Alpha
+	@ConfigItem(
+			position = 11,
+			keyName = "hexColorTreeOverlay",
+			name = "Overlay color",
+			description = "Color of the tree overlay",
+			section = visualSection
+	)
+	default Color getTreeOverlayColor()
+	{
+		return Color.YELLOW;
+	}
+
+	@Alpha
+	@ConfigItem(
+			position = 12,
+			keyName = "hexColorTreeOverlayOutline",
+			name = "Overlay outline color",
+			description = "Color of the tree stump outline overlay",
+			section = visualSection
+	)
+	default Color getTreeOverlayOutlineColor()
+	{
+		return Color.ORANGE;
+	}
+
+	@ConfigItem(
+			position = 13,
+			keyName = "getTreeOverlayDiameter",
+			name = "Overlay diameter",
+			description = "Adjust the size of the tree stump overlay",
+			section = visualSection
+	)
+	default int getTreeOverlayDiameter()
+	{
+		return 25;
+	}
+
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingTreesOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingTreesOverlay.java
@@ -120,8 +120,9 @@ class WoodcuttingTreesOverlay extends Overlay
 			}
 
 			ProgressPieComponent ppc = new ProgressPieComponent();
-			ppc.setBorderColor(Color.ORANGE);
-			ppc.setFill(Color.YELLOW);
+			ppc.setBorderColor(config.getTreeOverlayOutlineColor());
+			ppc.setFill(config.getTreeOverlayColor());
+			ppc.setDiameter(config.getTreeOverlayDiameter());
 			ppc.setPosition(point);
 			ppc.setProgress(percent);
 			ppc.render(graphics);


### PR DESCRIPTION
This change will let you choose color, opacity, and diameter of pie circles in the woodcutting and mining plugins to keep them more in line with other plugins that allow similar functionality.