### PR TITLE
clues: highlight the last clue's STASH until items are deposited back

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/ClueScrollPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/ClueScrollPlugin.java
@@ -217,6 +217,10 @@ public class ClueScrollPlugin extends Plugin
 
 	private final TextComponent textComponent = new TextComponent();
 
+	@Getter
+	private EmoteClue activeSTASHClue;
+	private EmoteClue clickedSTASHClue;
+
 	@Provides
 	ClueScrollConfig getConfig(ConfigManager configManager)
 	{
@@ -264,9 +268,11 @@ public class ClueScrollPlugin extends Plugin
 			return;
 		}
 
+		String message = event.getMessage();
+
 		if (clue instanceof HotColdClue)
 		{
-			if (((HotColdClue) clue).update(event.getMessage(), this))
+			if (((HotColdClue) clue).update(message, this))
 			{
 				worldMapPointsSet = false;
 			}
@@ -274,7 +280,7 @@ public class ClueScrollPlugin extends Plugin
 
 		if (clue instanceof SkillChallengeClue)
 		{
-			String text = Text.removeTags(event.getMessage());
+			String text = Text.removeTags(message);
 			if (text.equals("Skill challenge completed.") ||
 				text.equals("You have completed your master level challenge!") ||
 				text.startsWith("You have completed Charlie's task,") ||
@@ -282,6 +288,19 @@ public class ClueScrollPlugin extends Plugin
 			{
 				((SkillChallengeClue) clue).setChallengeCompleted(true);
 			}
+		}
+
+		if (message.endsWith(" the STASH unit."))
+		{
+			if (clue instanceof EmoteClue && clickedSTASHClue != null && message.equals("You withdraw your items from the STASH unit."))
+			{
+				activeSTASHClue = clickedSTASHClue;
+			}
+			else if (message.equals("You deposit your items into the STASH unit."))
+			{
+				activeSTASHClue = null;
+			}
+			clickedSTASHClue = null;
 		}
 	}
 
@@ -300,7 +319,11 @@ public class ClueScrollPlugin extends Plugin
 	@Subscribe
 	public void onMenuOptionClicked(final MenuOptionClicked event)
 	{
-		if (event.getMenuOption() != null && event.getMenuOption().equals("Read"))
+		if (event.getMenuOption() == null)
+		{
+			return;
+		}
+		if (event.getMenuOption().equals("Read"))
 		{
 			final ItemComposition itemComposition = itemManager.getItemComposition(event.getId());
 
@@ -308,6 +331,14 @@ public class ClueScrollPlugin extends Plugin
 			{
 				clueItemId = itemComposition.getId();
 				updateClue(MapClue.forItemId(clueItemId));
+			}
+		}
+		else if (event.getMenuOption().equals("Search")	&& clue instanceof EmoteClue)
+		{
+			EmoteClue emoteClue = (EmoteClue) clue;
+			if (emoteClue.getStashUnit() != null && emoteClue.getStashUnit().getObjectId() == event.getId())
+			{
+				clickedSTASHClue = emoteClue;
 			}
 		}
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/ClueScrollWorldOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/ClueScrollWorldOverlay.java
@@ -29,6 +29,7 @@ import java.awt.Dimension;
 import java.awt.Graphics2D;
 import javax.inject.Inject;
 import net.runelite.client.plugins.cluescrolls.clues.ClueScroll;
+import net.runelite.client.plugins.cluescrolls.clues.EmoteClue;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
@@ -59,6 +60,12 @@ public class ClueScrollWorldOverlay extends Overlay
 		if (clue != null)
 		{
 			clue.makeWorldOverlayHint(graphics, plugin);
+		}
+
+		EmoteClue activeSTASHClue = plugin.getActiveSTASHClue();
+		if (activeSTASHClue != null && activeSTASHClue != clue)
+		{
+			activeSTASHClue.makeSTASHOverlay(graphics, plugin);
 		}
 
 		return null;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java
@@ -311,6 +311,11 @@ public class EmoteClue extends ClueScroll implements TextClueScroll, LocationClu
 			OverlayUtil.renderTileOverlay(plugin.getClient(), graphics, localPoint, plugin.getEmoteImage(), Color.ORANGE);
 		}
 
+		makeSTASHOverlay(graphics, plugin);
+	}
+
+	public void makeSTASHOverlay(Graphics2D graphics, ClueScrollPlugin plugin)
+	{
 		if (stashUnit != null)
 		{
 			final WorldPoint[] worldPoints = stashUnit.getWorldPoints();

--- a/runelite-client/src/test/java/net/runelite/client/plugins/cluescrolls/ClueScrollPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/cluescrolls/ClueScrollPluginTest.java
@@ -33,10 +33,12 @@ import com.google.inject.testing.fieldbinder.BoundFieldModule;
 import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
 import net.runelite.api.NPC;
+import net.runelite.api.NullObjectID;
 import net.runelite.api.Player;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.ChatMessage;
 import net.runelite.api.events.GameTick;
+import net.runelite.api.events.MenuOptionClicked;
 import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.game.ItemManager;
@@ -45,6 +47,8 @@ import net.runelite.client.plugins.cluescrolls.clues.hotcold.HotColdLocation;
 import net.runelite.client.ui.overlay.OverlayManager;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -167,5 +171,48 @@ public class ClueScrollPluginTest
 		// scene
 		verify(client, times(++clueSetupHintArrowClears)).clearHintArrow();
 		verify(client, times(1)).setHintArrow(any(WorldPoint.class));
+	}
+
+	@Test
+	public void testSTASHMarkerPersistence()
+	{
+		when(client.getCachedNPCs()).thenReturn(new NPC[] {});
+
+		// Set up emote clue
+		final Widget clueWidget = mock(Widget.class);
+		when(clueWidget.getText()).thenReturn("Spin in the Varrock Castle courtyard. Equip a black axe, a coif and a ruby ring.");
+		when(client.getWidget(WidgetInfo.CLUE_SCROLL_TEXT)).thenReturn(clueWidget);
+		plugin.onGameTick(new GameTick());
+
+		// Simulate clicking on the STASH
+		MenuOptionClicked menuOptionClicked = new MenuOptionClicked();
+		menuOptionClicked.setMenuOption("Search");
+		menuOptionClicked.setMenuTarget("<col=ffff>STASH unit (easy)");
+		menuOptionClicked.setId(NullObjectID.NULL_28983);
+		plugin.onMenuOptionClicked(menuOptionClicked);
+
+		// Check that the STASH is stored after withdrawing
+		ChatMessage withdrawMessage = new ChatMessage();
+		withdrawMessage.setType(ChatMessageType.GAMEMESSAGE);
+		withdrawMessage.setMessage("You withdraw your items from the STASH unit.");
+		plugin.onChatMessage(withdrawMessage);
+		assertNotNull(plugin.getActiveSTASHClue());
+
+		// Complete the step and get a new step, check that the clue is stored for rendering
+		when(clueWidget.getText()).thenReturn("Talk to the bartender of the Rusty Anchor in Port Sarim.");
+		plugin.onGameTick(new GameTick());
+		assertNotNull(plugin.getActiveSTASHClue());
+
+		// Simulate depositing the emote items, make sure it's cleared the stored clue
+		ChatMessage depositMessage = new ChatMessage();
+		depositMessage.setType(ChatMessageType.GAMEMESSAGE);
+		depositMessage.setMessage("You deposit your items into the STASH unit.");
+		plugin.onChatMessage(depositMessage);
+		assertNull(plugin.getActiveSTASHClue());
+
+		// Make sure that the STASH won't get re-marked if it's not part of the active clue.
+		plugin.onMenuOptionClicked(menuOptionClicked);
+		plugin.onChatMessage(withdrawMessage);
+		assertNull(plugin.getActiveSTASHClue());
 	}
 }


### PR DESCRIPTION
Closes #12254

Doing this with MenuOptionClicked and ChatMessage means that the overlay will persist even when the clue scroll ends and gives you a casket.