### PR TITLE
update discord links to use a link that starts users in #welcome

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Here are the guidelines we'd like you to follow:
 
 ## <a name="question"></a> Got a Question or Problem?
 
-If you have questions about how to contribute to runelite, please join our [Discord](https://discord.gg/mePCs8U) server.
+If you have questions about how to contribute to runelite, please join our [Discord](https://discord.gg/ArdAhnN) server.
 
 ## <a name="issue"></a> Found an Issue?
 
@@ -131,4 +131,4 @@ To ensure consistency throughout the source code, review our [code conventions](
 
 
 [github]: https://github.com/runelite/runelite
-[discord]: https://discord.gg/mePCs8U
+[discord]: https://discord.gg/ArdAhnN

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 ![](https://runelite.net/img/logo.png)
-# runelite [![CI](https://github.com/runelite/runelite/workflows/CI/badge.svg)](https://github.com/runelite/runelite/actions?query=workflow%3ACI+branch%3Amaster) [![Discord](https://img.shields.io/discord/301497432909414422.svg)](https://discord.gg/mePCs8U)
+# runelite [![CI](https://github.com/runelite/runelite/workflows/CI/badge.svg)](https://github.com/runelite/runelite/actions?query=workflow%3ACI+branch%3Amaster) [![Discord](https://img.shields.io/discord/301497432909414422.svg)](https://discord.gg/ArdAhnN)
 
 RuneLite is a free, open source OldSchool RuneScape client.
 
-If you have any questions, please join our IRC channel on [irc.rizon.net #runelite](http://qchat.rizon.net/?channels=runelite&uio=d4) or alternatively our [Discord](https://discord.gg/mePCs8U) server.
+If you have any questions, please join our IRC channel on [irc.rizon.net #runelite](http://qchat.rizon.net/?channels=runelite&uio=d4) or alternatively our [Discord](https://discord.gg/ArdAhnN) server.
 
 ## Project Layout
 

--- a/runelite-client/src/main/resources/net/runelite/client/runelite.properties
+++ b/runelite-client/src/main/resources/net/runelite/client/runelite.properties
@@ -1,7 +1,7 @@
 runelite.title=RuneLite
 runelite.version=${project.version}
 runelite.discord.appid=409416265891971072
-runelite.discord.invite=https://discord.gg/R4BQ8tU
+runelite.discord.invite=https://discord.gg/ArdAhnN
 runelite.github.link=https://github.com/runelite
 runelite.wiki.link=https://github.com/runelite/runelite/wiki
 runelite.patreon.link=https://www.patreon.com/runelite


### PR DESCRIPTION
Currently, the client's Discord link goes to #runelite, which means that people don't directly see the rules and general information provided in #welcome. The PR also updates the README and CONTRIBUTING files, which are still using the really old original invite.

Counterpart PR at runelite/runelite.net#400 to change the website's Discord link