### PR TITLE
gpu: Workaround for forced anti-aliasing

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuPlugin.java
@@ -1078,8 +1078,14 @@ public class GpuPlugin extends Plugin implements DrawCallbacks
 			{
 				shutdownAAFbo();
 
+				// Bind default FBO to check whether anti-aliasing is forced
+				gl.glBindFramebuffer(gl.GL_FRAMEBUFFER, 0);
+				final int forcedAASamples = glGetInteger(gl, gl.GL_SAMPLES);
 				final int maxSamples = glGetInteger(gl, gl.GL_MAX_SAMPLES);
-				final int samples = Math.min(antiAliasingMode.getSamples(), maxSamples);
+				final int samples = forcedAASamples != 0 ? forcedAASamples :
+					Math.min(antiAliasingMode.getSamples(), maxSamples);
+
+				log.debug("AA samples: {}, max samples: {}, forced samples: {}", samples, maxSamples, forcedAASamples);
 
 				initAAFbo(stretchedCanvasWidth, stretchedCanvasHeight, samples);
 


### PR DESCRIPTION
Forced anti-aliasing by the GPU applies multisampling to the default
framebuffer, and when blitting between two multisampled FBOs, the number
of samples in both FBOs has to match.

In order to make sure our anti-aliasing FBO has the same number of
samples as the default FBO, we bind the default FBO and check whether
its number of samples is non-zero. If it is, use this as the number of
samples for our anti-aliasing FBO instead of getting it from the
configured anti-aliasing mode.

This unfortunately still doesn't work with `8x (4xSS, 2xMS)` forced anti-aliasing, but oddly enough works fine with `16x (4xSS, 4xMS)`. All other modes using only multisampling work fine on my Nvidia GTX 970.