### PR TITLE
loot tracking for the Supply crates from Mahogany Homes

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
@@ -246,6 +246,9 @@ public class LootTrackerPlugin extends Plugin
 	private static final String TEMPOROSS_LOOT_STRING = "You found some loot: ";
 	private static final int TEMPOROSS_REGION = 12588;
 
+	// Mahogany Homes
+	private static final String MAHOGANY_CRATE_EVENT = "Supply crate (Mahogany Homes)";
+
 	private static final Set<Character> VOWELS = ImmutableSet.of('a', 'e', 'i', 'o', 'u');
 
 	@Inject
@@ -806,6 +809,11 @@ public class LootTrackerPlugin extends Plugin
 			processInventoryLoot(eventType, lootRecordType, metadata, event.getItemContainer(), Collections.emptyList());
 			resetEvent();
 		}
+
+		if (MAHOGANY_CRATE_EVENT.equals(eventType))
+		{
+			processInventoryLoot(eventType, lootRecordType, metadata, event.getItemContainer(), Collections.emptyList());
+		}
 	}
 
 	@Subscribe
@@ -851,6 +859,11 @@ public class LootTrackerPlugin extends Plugin
 		if (event.getMenuOption().equals("Open") && event.getId() == ItemID.CASKET_25590)
 		{
 			setEvent(LootRecordType.EVENT, TEMPOROSS_CASKET_EVENT);
+			takeInventorySnapshot();
+		}
+		if (event.getMenuOption().equals("Open") && event.getId() == ItemID.SUPPLY_CRATE_24884)
+		{
+			setEvent(LootRecordType.EVENT, MAHOGANY_CRATE_EVENT);
 			takeInventorySnapshot();
 		}
 	}


### PR DESCRIPTION
Tracking supply crates from Mahogany Homes opened with the Open menu option.

Note: This will not track crates opened with the Open-All menu options. That option opens all the crates on the same tick and rewards the player in one go.

![unknown-1](https://user-images.githubusercontent.com/18219349/117229832-c809c200-ade9-11eb-9969-f51efd9ba00c.png)

