### PR TITLE
XpTracker: Reset per hour rates

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpAction.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpAction.java
@@ -30,6 +30,7 @@ import lombok.Data;
 class XpAction
 {
 	private int actions = 0;
+	private int actionsSinceReset = 0;
 	private boolean actionsHistoryInitialized = false;
 	private int[] actionExps = new int[10];
 	private int actionExpIndex = 0;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpInfoBox.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpInfoBox.java
@@ -135,6 +135,10 @@ class XpInfoBox extends JPanel
 		final JMenuItem resetOthers = new JMenuItem("Reset others");
 		resetOthers.addActionListener(e -> xpTrackerPlugin.resetOtherSkillState(skill));
 
+		// Create reset per hour menu
+		final JMenuItem resetPerHour = new JMenuItem("Reset/hr");
+		resetPerHour.addActionListener(e -> xpTrackerPlugin.resetSkillPerHourState(skill));
+
 		// Create reset others menu
 		pauseSkill.addActionListener(e -> xpTrackerPlugin.pauseSkill(skill, !paused));
 
@@ -144,6 +148,7 @@ class XpInfoBox extends JPanel
 		popupMenu.add(openXpTracker);
 		popupMenu.add(reset);
 		popupMenu.add(resetOthers);
+		popupMenu.add(resetPerHour);
 		popupMenu.add(pauseSkill);
 		popupMenu.add(canvasItem);
 		popupMenu.addPopupMenuListener(new PopupMenuListener()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpPanel.java
@@ -90,6 +90,10 @@ class XpPanel extends PluginPanel
 		final JMenuItem reset = new JMenuItem("Reset All");
 		reset.addActionListener(e -> xpTrackerPlugin.resetAndInitState());
 
+		// Create reset all per hour menu
+		final JMenuItem resetPerHour = new JMenuItem("Reset All/hr");
+		resetPerHour.addActionListener(e -> xpTrackerPlugin.resetAllSkillsPerHourState());
+
 		// Create pause all menu
 		final JMenuItem pauseAll = new JMenuItem("Pause All");
 		pauseAll.addActionListener(e -> xpTrackerPlugin.pauseAllSkills(true));
@@ -104,6 +108,7 @@ class XpPanel extends PluginPanel
 		popupMenu.setBorder(new EmptyBorder(5, 5, 5, 5));
 		popupMenu.add(openXpTracker);
 		popupMenu.add(reset);
+		popupMenu.add(resetPerHour);
 		popupMenu.add(pauseAll);
 		popupMenu.add(unpauseAll);
 		overallPanel.setComponentPopupMenu(popupMenu);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpState.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpState.java
@@ -32,7 +32,7 @@ import net.runelite.api.Skill;
 
 /**
  * Internal state for the XpTrackerPlugin
- *
+ * <p>
  * Note: This class's operations are not currently synchronized.
  * It is intended to be called by the XpTrackerPlugin on the client thread.
  */
@@ -53,7 +53,8 @@ class XpState
 
 	/**
 	 * Resets a single skill
-	 * @param skill Skill to reset
+	 *
+	 * @param skill     Skill to reset
 	 * @param currentXp Current XP to set to, if unknown set to -1
 	 */
 	void resetSkill(Skill skill, long currentXp)
@@ -63,14 +64,25 @@ class XpState
 	}
 
 	/**
+	 * Resets the per hour rates of a single skill
+	 *
+	 * @param skill Skill to reset per hour rates
+	 */
+	void resetSkillPerHour(Skill skill)
+	{
+		xpSkills.get(skill).resetPerHour();
+	}
+
+	/**
 	 * Updates a skill with the current known XP.
 	 * When the result of this operation is XpUpdateResult.UPDATED, the UI should be updated accordingly.
 	 * This is to distinguish events that reload all the skill's current values (such as world hopping)
 	 * and also first-login when the skills are not initialized (the start XP will be -1 in this case).
-	 * @param skill Skill to update
-	 * @param currentXp Current known XP for this skill
+	 *
+	 * @param skill       Skill to update
+	 * @param currentXp   Current known XP for this skill
 	 * @param goalStartXp Possible XP start goal
-	 * @param goalEndXp Possible XP end goal
+	 * @param goalEndXp   Possible XP end goal
 	 * @return Whether or not the skill has been initialized, there was no change, or it has been updated
 	 */
 	XpUpdateResult updateSkill(Skill skill, long currentXp, int goalStartXp, int goalEndXp)
@@ -92,7 +104,7 @@ class XpState
 		else
 		{
 			long startXp = state.getStartXp();
-			int gainedXp = state.getXpGained();
+			int gainedXp = state.getTotalXpGained();
 
 			if (startXp + gainedXp > currentXp)
 			{
@@ -119,8 +131,9 @@ class XpState
 
 	/**
 	 * Updates skill with average actions based on currently interacted NPC.
-	 * @param skill experience gained skill
-	 * @param npc currently interacted NPC
+	 *
+	 * @param skill     experience gained skill
+	 * @param npc       currently interacted NPC
 	 * @param npcHealth health of currently interacted NPC
 	 */
 	void updateNpcExperience(Skill skill, NPC npc, Integer npcHealth, int xpModifier)
@@ -161,8 +174,9 @@ class XpState
 	/**
 	 * Update number of actions performed for skill if last interacted NPC died.
 	 * (eg. amount of kills in this case)
-	 * @param skill skill to update actions for
-	 * @param npc npc that just died
+	 *
+	 * @param skill     skill to update actions for
+	 * @param npc       npc that just died
 	 * @param npcHealth max health of npc that just died
 	 * @return UPDATED in case new kill was successfully added
 	 */
@@ -170,13 +184,13 @@ class XpState
 	{
 		XpStateSingle state = getSkill(skill);
 
-		if (state.getXpGained() <= 0 || npcHealth == null || npc != interactedNPC)
+		if (state.getXpGainedSinceReset() <= 0 || npcHealth == null || npc != interactedNPC)
 		{
 			return XpUpdateResult.NO_CHANGE;
 		}
 
 		final XpAction xpAction = state.getXpAction(XpActionType.ACTOR_HEALTH);
-		xpAction.setActions(xpAction.getActions() + 1);
+		xpAction.setActionsSinceReset(xpAction.getActionsSinceReset() + 1);
 		return xpAction.isActionsHistoryInitialized() ? XpUpdateResult.UPDATED : XpUpdateResult.NO_CHANGE;
 	}
 
@@ -188,7 +202,8 @@ class XpState
 	/**
 	 * Forcefully initialize a skill with a known start XP from the current XP.
 	 * This is used in resetAndInitState by the plugin. It should not result in showing the XP in the UI.
-	 * @param skill Skill to initialize
+	 *
+	 * @param skill     Skill to initialize
 	 * @param currentXp Current known XP for the skill
 	 */
 	void initializeSkill(Skill skill, long currentXp)
@@ -211,6 +226,7 @@ class XpState
 	/**
 	 * Obtain an immutable snapshot of the provided skill
 	 * intended for use with the UI which operates on another thread
+	 *
 	 * @param skill Skill to obtain the snapshot for
 	 * @return An immutable snapshot of the specified skill for this session since first login or last reset
 	 */
@@ -223,6 +239,7 @@ class XpState
 	/**
 	 * Obtain an immutable snapshot of the provided skill
 	 * intended for use with the UI which operates on another thread
+	 *
 	 * @return An immutable snapshot of total information for this session since first login or last reset
 	 */
 	@NonNull

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpState.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpState.java
@@ -24,6 +24,7 @@
  */
 package net.runelite.client.plugins.xptracker;
 
+import java.util.Arrays;
 import java.util.EnumMap;
 import java.util.Map;
 import javax.inject.Inject;
@@ -163,10 +164,7 @@ class XpState
 		else
 		{
 			// So we have a decent average off the bat, lets populate all values with what we see.
-			for (int i = 0; i < action.getActionExps().length; i++)
-			{
-				action.getActionExps()[i] = actionExp;
-			}
+			Arrays.fill(action.getActionExps(), actionExp);
 
 			action.setActionsHistoryInitialized(true);
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpStateSingle.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpStateSingle.java
@@ -54,6 +54,8 @@ class XpStateSingle
 
 	@Setter
 	private long skillTime = 0;
+	@Getter
+	private long lastChangeMillis;
 
 	private int startLevelExp = 0;
 	private int endLevelExp = 0;
@@ -73,6 +75,12 @@ class XpStateSingle
 	long getCurrentXp()
 	{
 		return startXp + getTotalXpGained();
+	}
+
+	void setXpGainedSinceReset(int xpGainedSinceReset)
+	{
+		this.xpGainedSinceReset = xpGainedSinceReset;
+		lastChangeMillis = System.currentTimeMillis();
 	}
 
 	int getTotalXpGained()
@@ -220,7 +228,7 @@ class XpStateSingle
 
 		//reset xp per hour
 		xpGainedBeforeReset += xpGainedSinceReset;
-		xpGainedSinceReset = 0;
+		setXpGainedSinceReset(0);
 		setSkillTime(0);
 	}
 
@@ -264,7 +272,7 @@ class XpStateSingle
 		action.setActionsSinceReset(action.getActionsSinceReset() + 1);
 
 		// Calculate experience gained
-		xpGainedSinceReset = (int) (currentXp - (startXp + xpGainedBeforeReset));
+		setXpGainedSinceReset((int) (currentXp - (startXp + xpGainedBeforeReset)));
 
 		// Determine XP goals, overall has no goals
 		if (skill != Skill.OVERALL)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerConfig.java
@@ -88,6 +88,18 @@ public interface XpTrackerConfig extends Config
 
 	@ConfigItem(
 		position = 4,
+		keyName = "resetSkillRateAfter",
+		name = "Auto reset after",
+		description = "Configures how many minutes passes before resetting a skill's per hour rates while in game and there's no XP, 0 means disabled"
+	)
+	@Units(Units.MINUTES)
+	default int resetSkillRateAfter()
+	{
+		return 0;
+	}
+
+	@ConfigItem(
+		position = 5,
 		keyName = "skillTabOverlayMenuOptions",
 		name = "Add skill tab canvas menu option",
 		description = "Configures whether a menu option to show/hide canvas XP trackers will be added to skills on the skill tab",
@@ -99,7 +111,7 @@ public interface XpTrackerConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 5,
+		position = 6,
 		keyName = "onScreenDisplayMode",
 		name = "On-screen tracker display mode (top)",
 		description = "Configures the information displayed in the first line of on-screen XP overlays",
@@ -111,7 +123,7 @@ public interface XpTrackerConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 6,
+		position = 7,
 		keyName = "onScreenDisplayModeBottom",
 		name = "On-screen tracker display mode (bottom)",
 		description = "Configures the information displayed in the second line of on-screen XP overlays",
@@ -123,7 +135,7 @@ public interface XpTrackerConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 7,
+		position = 8,
 		keyName = "xpPanelLabel1",
 		name = "Top-left XP info label",
 		description = "Configures the information displayed in the top-left of XP info box"
@@ -134,7 +146,7 @@ public interface XpTrackerConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 8,
+		position = 9,
 		keyName = "xpPanelLabel2",
 		name = "Top-right XP info label",
 		description = "Configures the information displayed in the top-right of XP info box"
@@ -146,7 +158,7 @@ public interface XpTrackerConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 9,
+		position = 10,
 		keyName = "xpPanelLabel3",
 		name = "Bottom-left XP info label",
 		description = "Configures the information displayed in the bottom-left of XP info box"
@@ -157,7 +169,7 @@ public interface XpTrackerConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 10,
+		position = 11,
 		keyName = "xpPanelLabel4",
 		name = "Bottom-right XP info label",
 		description = "Configures the information displayed in the bottom-right of XP info box"
@@ -168,7 +180,7 @@ public interface XpTrackerConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 11,
+		position = 12,
 		keyName = "progressBarLabel",
 		name = "Progress bar label",
 		description = "Configures the info box progress bar to show Time to goal or percentage complete"
@@ -179,7 +191,7 @@ public interface XpTrackerConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 12,
+		position = 13,
 		keyName = "progressBarTooltipLabel",
 		name = "Tooltip label",
 		description = "Configures the info box progress bar tooltip to show Time to goal or percentage complete"
@@ -190,7 +202,7 @@ public interface XpTrackerConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 13,
+		position = 14,
 		keyName = "prioritizeRecentXpSkills",
 		name = "Move recently trained skills to top",
 		description = "Configures whether skills should be organized by most recently gained xp"

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerPlugin.java
@@ -120,6 +120,9 @@ public class XpTrackerPlugin extends Plugin
 	@Inject
 	private XpClient xpClient;
 
+	@Inject
+	private XpState xpState;
+
 	private NavigationButton navButton;
 	@Setter(AccessLevel.PACKAGE)
 	@VisibleForTesting
@@ -131,7 +134,6 @@ public class XpTrackerPlugin extends Plugin
 	private long lastXp = 0;
 	private boolean initializeTracker;
 
-	private final XpState xpState = new XpState();
 	private final XpPauseState xpPauseState = new XpPauseState();
 
 	@Provides

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerPlugin.java
@@ -323,6 +323,7 @@ public class XpTrackerPlugin extends Plugin
 	/**
 	 * Reset an individual skill with the client's current known state of the skill
 	 * Will also clear the skill from the UI.
+	 *
 	 * @param skill Skill to reset
 	 */
 	void resetSkillState(Skill skill)
@@ -335,6 +336,7 @@ public class XpTrackerPlugin extends Plugin
 
 	/**
 	 * Reset all skills except for the one provided
+	 *
 	 * @param skill Skill to ignore during reset
 	 */
 	void resetOtherSkillState(Skill skill)
@@ -346,6 +348,29 @@ public class XpTrackerPlugin extends Plugin
 			{
 				resetSkillState(s);
 			}
+		}
+	}
+
+	/**
+	 * Reset the xp gained since last reset of the skill
+	 * Does not clear the skill from the UI.
+	 *
+	 * @param skill Skill to reset per hour rate
+	 */
+	void resetSkillPerHourState(Skill skill)
+	{
+		xpState.resetSkillPerHour(skill);
+	}
+
+	/**
+	 * Reset the xp gained since last reset of all skills including OVERALL
+	 * Does not clear the UI.
+	 */
+	void resetAllSkillsPerHourState()
+	{
+		for (Skill skill : Skill.values())
+		{
+			resetSkillPerHourState(skill);
 		}
 	}
 
@@ -377,7 +402,7 @@ public class XpTrackerPlugin extends Plugin
 		final Actor interacting = client.getLocalPlayer().getInteracting();
 		if (interacting instanceof NPC && COMBAT.contains(skill))
 		{
-			final int xpModifier = worldSetToType(client.getWorldType()).modifier(client);;
+			final int xpModifier = worldSetToType(client.getWorldType()).modifier(client);
 			final NPC npc = (NPC) interacting;
 			xpState.updateNpcExperience(skill, npc, npcManager.getHealth(npc.getId()), xpModifier);
 		}


### PR DESCRIPTION
Add a menu item "Reset/hr" to reset the xp/hr and actions/hr for single skills and "Reset All/hr" to reset xp/hr and actions/hr for all skills including Overall. This option resets the per-hour rates without resetting the UI or total xp or actions this session.

Added configuration option "Auto reset per hour rates after" that resets per hour rates of a skill if xp not gained in that skill for the set number of minutes. This works like "auto pause after". If no XP is gained over that time then all skills are reset including overall. (Fixes #13001)

Single skill:
![reset-per-hour](https://user-images.githubusercontent.com/41110963/117516990-9aac4800-af92-11eb-99f0-1fd08ddbd983.png)

All skills:
![reset-all-per-hour](https://user-images.githubusercontent.com/41110963/117516994-9c760b80-af92-11eb-9a53-ff946359e8bd.png)

Notes
-

Several changes were made in XpState.java to javadoc comments by IntelliJ's formatter.