### PR TITLE
Loot shade anim

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/GraphicID.java
+++ b/runelite-api/src/main/java/net/runelite/api/GraphicID.java
@@ -32,6 +32,7 @@ public class GraphicID
 	public static final int GREY_BUBBLE_TELEPORT = 86;
 	public static final int ENTANGLE = 179;
 	public static final int SNARE = 180;
+	public static final int SHADE_DROP_ANIM = 188;
 	public static final int BIND = 181;
 	public static final int ICE_RUSH = 361;
 	public static final int ICE_BURST = 363;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
@@ -63,6 +63,7 @@ import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
 import net.runelite.api.GameState;
+import net.runelite.api.GraphicID;
 import net.runelite.api.GraphicsObject;
 import net.runelite.api.InventoryID;
 import net.runelite.api.ItemComposition;
@@ -876,7 +877,7 @@ public class LootTrackerPlugin extends Plugin
 	private void onGraphicsObjectCreated(GraphicsObjectCreated event)
 	{
 		final GraphicsObject object = event.getGraphicsObject();
-		if (object.getId() == 188)
+		if (object.getId() == GraphicID.SHADE_DROP_ANIM)
 		{
 			WorldPoint dropLocation = WorldPoint.fromLocal(client, object.getLocation());
 			Collection<ItemStack> items = lootManager.getItemSpawns(dropLocation);


### PR DESCRIPTION
This PR is for tracking the keys and coins obtained from burning shade remains.

The event type is set when the player uses an item on the Funeral Pyre which already has pyre logs loaded. It will perform a RegEx match to find the type of remains used. The loot is added when the game detects the shade drop animation (ie. smoke puff) that occurs on the stone stand. 

**Screenshots of Loot Tracker**
<img width="230" alt="Screen Shot 2021-05-19 at 8 03 43 PM" src="https://user-images.githubusercontent.com/18219349/118899723-6400f680-b8dd-11eb-87e1-c81c0d292190.png">

<img width="230" alt="Screen Shot 2021-05-19 at 8 02 58 PM" src="https://user-images.githubusercontent.com/18219349/118899688-492e8200-b8dd-11eb-8057-d3382925c976.png">

**Graphic Objects for Funeral Pyre:**
FUNERAL_PYRE_4094 = Regular pyre logs
FUNERAL_PYRE_4095 = Oak pyre logs;
FUNERAL_PYRE_4096 = Willow pyre logs
FUNERAL_PYRE_4097 = Maple pyre logs
FUNERAL_PYRE_4098 = Yew pyre logs
FUNERAL_PYRE_4099 = Magic pyre logs
FUNERAL_PYRE_9006 = Teak pyre logs
FUNERAL_PYRE_9007 = Mahogany pyre logs
FUNERAL_PYRE_21271 = Arctic pyre logs
FUNERAL_PYRE_25265 = Redwood pyre logs