### PR TITLE
Add option to Screenshot plugin for new collection log entries

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotConfig.java
@@ -256,7 +256,7 @@ public interface ScreenshotConfig extends Config
 	@ConfigItem(
 		keyName = "collectionLogEntries",
 		name = "Screenshot collection log entries",
-		description = "Configures whether or not screenshots are automatically taken of new collection log entries",
+		description = "Take a screenshot when completing an entry in the collection log",
 		position = 18,
 		section = whatSection
 	)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotConfig.java
@@ -254,10 +254,22 @@ public interface ScreenshotConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "collectionLogEntries",
+		name = "Screenshot collection log entries",
+		description = "Configures whether or not screenshots are automatically taken of new collection log entries",
+		position = 18,
+		section = whatSection
+	)
+	default boolean screenshotCollectionLogEntries()
+	{
+		return true;
+	}
+
+	@ConfigItem(
 		keyName = "hotkey",
 		name = "Screenshot hotkey",
 		description = "When you press this key a screenshot will be taken",
-		position = 18
+		position = 19
 	)
 	default Keybind hotkey()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
@@ -456,6 +456,13 @@ public class ScreenshotPlugin extends Plugin
 				takeScreenshot(fileName, "Duels");
 			}
 		}
+
+		if (config.screenshotCollectionLogEntries() && chatMessage.startsWith("New item added to your collection log: "))
+		{
+			String entry = chatMessage.substring(51, chatMessage.length() - 6);
+			String fileName = "Collection log: " + entry;
+			takeScreenshot(fileName, "Collection Log");
+		}
 	}
 
 	@Subscribe

--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
@@ -95,6 +95,7 @@ import net.runelite.client.util.Text;
 @Slf4j
 public class ScreenshotPlugin extends Plugin
 {
+	private static final String COLLECTION_LOG_TEXT = "New item added to your collection log: ";
 	private static final String CHEST_LOOTED_MESSAGE = "You find some treasure in the chest!";
 	private static final Map<Integer, String> CHEST_LOOT_EVENTS = ImmutableMap.of(12127, "The Gauntlet");
 	private static final int GAUNTLET_REGION = 7512;
@@ -457,10 +458,10 @@ public class ScreenshotPlugin extends Plugin
 			}
 		}
 
-		if (config.screenshotCollectionLogEntries() && chatMessage.startsWith("New item added to your collection log: "))
+		if (config.screenshotCollectionLogEntries() && chatMessage.startsWith(COLLECTION_LOG_TEXT))
 		{
-			String entry = chatMessage.substring(51, chatMessage.length() - 6);
-			String fileName = "Collection log: " + entry;
+			String entry = Text.removeTags(chatMessage).substring(COLLECTION_LOG_TEXT.length());
+			String fileName = "Collection log (" + entry + ")";
 			takeScreenshot(fileName, "Collection Log");
 		}
 	}


### PR DESCRIPTION
Closes #13673

Takes a screenshot when the new collection log entry `ChatMessage` appears 

(e.g. `Chat message type GAMEMESSAGE: New item added to your collection log: <col=ff0000>Partial note</col>`)

![image](https://user-images.githubusercontent.com/18340303/119244976-88f6a300-bb43-11eb-8429-0349e73ae2f1.png)
