### PR TITLE
Restrict wintertodt start notifs to wt regions

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/wintertodt/WintertodtPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/wintertodt/WintertodtPlugin.java
@@ -89,6 +89,7 @@ import net.runelite.client.util.ColorUtil;
 public class WintertodtPlugin extends Plugin
 {
 	private static final int WINTERTODT_REGION = 6462;
+	private static final int WINTERTODT_CAMP_REGION = 6461;
 
 	@Inject
 	private Notifier notifier;
@@ -129,6 +130,7 @@ public class WintertodtPlugin extends Plugin
 	private Instant lastActionTime;
 
 	private int previousTimerValue;
+	private boolean notifiedOutsideWt;
 
 	@Provides
 	WintertodtConfig getConfig(ConfigManager configManager)
@@ -158,6 +160,7 @@ public class WintertodtPlugin extends Plugin
 		numKindling = 0;
 		currentActivity = WintertodtActivity.IDLE;
 		lastActionTime = null;
+		notifiedOutsideWt = false;
 	}
 
 	private boolean isInWintertodtRegion()
@@ -167,6 +170,16 @@ public class WintertodtPlugin extends Plugin
 			return client.getLocalPlayer().getWorldLocation().getRegionID() == WINTERTODT_REGION;
 		}
 
+		return false;
+	}
+	
+	private boolean isInCampRegion()
+	{
+		if (client.getLocalPlayer() != null)
+		{
+			return client.getLocalPlayer().getWorldLocation().getRegionID() == WINTERTODT_CAMP_REGION;
+		}
+		
 		return false;
 	}
 
@@ -201,6 +214,7 @@ public class WintertodtPlugin extends Plugin
 		int timerValue = client.getVar(Varbits.WINTERTODT_TIMER);
 		if (timerValue != previousTimerValue)
 		{
+			
 			int timeToNotify = config.roundNotification();
 			if (timeToNotify > 0)
 			{
@@ -211,7 +225,14 @@ public class WintertodtPlugin extends Plugin
 
 				if (prevTimeInSeconds > timeToNotify && timeInSeconds <= timeToNotify)
 				{
-					notifier.notify("Wintertodt round is about to start");
+					// runelite/runelite#13626
+					// prevent repeat notifs outside wintertodt
+					boolean outsideWt = !isInWintertodtRegion() && !isInCampRegion();
+					if (!(outsideWt && notifiedOutsideWt))
+					{
+						notifier.notify("Wintertodt round is about to start");
+					}
+					notifiedOutsideWt = outsideWt;
 				}
 			}
 


### PR DESCRIPTION
Varbit `WINTERTODT_TIMER(7980)` is checked to send the player notifications on wintertodt round starts, but this varbit is set in lots of locations around the world that are not wintertodt, causing extraneous start notifications. This limits the notifications to only fire when the player is at wintertodt.

After playing and leaving Wintertodt, I received round start notifications multiple times, including while bank standing at the GE, fishing at Otto's Grotto, and training agility. At no point between these notifications did I revisit the wintertodt area.

From the [varbit map here](https://mejrs.github.io/osrs.html?varbit=7980&m=-1&z=0&p=0&x=2084&y=3647), we can see that the varbit is set *everywhere*, even when not in use. I was unable to find, in my rudimentary look, any other references to/uses of the varbit. 

I am not entirely happy with this approach to solve the problem, since players restocking at their POH/some other location could miss out on notifications. However, I was unable to come up with a better alternative.

I could also use some pointers on how to properly update the unit test, if my current attempt isn't great (I suspect it isn't).