### PR TITLE
Rebuild split PM box on history clear and login message removal

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/ScriptID.java
+++ b/runelite-api/src/main/java/net/runelite/api/ScriptID.java
@@ -48,10 +48,10 @@ public final class ScriptID
 	public static final int CHATBOX_INPUT = 96;
 
 	/**
-	 * Rebuilds the chatbox
+	 * Rebuilds the chatbox and the Split PM box.
 	 */
 	@ScriptArguments()
-	public static final int BUILD_CHATBOX = 216;
+	public static final int SPLITPM_CHANGED = 83;
 
 	/**
 	 * Opens the Private Message chat interface

--- a/runelite-client/src/main/java/net/runelite/client/plugins/chathistory/ChatHistoryPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chathistory/ChatHistoryPlugin.java
@@ -333,7 +333,7 @@ public class ChatHistoryPlugin extends Plugin implements KeyListener
 
 		if (removed)
 		{
-			clientThread.invoke(() -> client.runScript(ScriptID.BUILD_CHATBOX));
+			clientThread.invoke(() -> client.runScript(ScriptID.SPLITPM_CHANGED));
 		}
 
 		clearMessageQueue(tab);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/friendschat/FriendsChatPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/friendschat/FriendsChatPlugin.java
@@ -350,7 +350,7 @@ public class FriendsChatPlugin extends Plugin
 
 		if (removed)
 		{
-			clientThread.invoke(() -> client.runScript(ScriptID.BUILD_CHATBOX));
+			clientThread.invoke(() -> client.runScript(ScriptID.SPLITPM_CHANGED));
 		}
 	}
 


### PR DESCRIPTION
When the "Clear Messages" option was used or whenever a login/logout notification message was removed, BUILD_CHATBOX was run which only rebuilds the chatbox.
By running SPLITPM_CHANGED instead, both the chatbox and the split PM box are rebuilt.