### PR TITLE
Added suffix to screenshot folder when on tournament world

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/util/ImageCapture.java
+++ b/runelite-client/src/main/java/net/runelite/client/util/ImageCapture.java
@@ -127,6 +127,10 @@ public class ImageCapture
 			{
 				playerDir += "-League";
 			}
+			else if (worldTypes.contains(WorldType.TOURNAMENT))
+			{
+				playerDir += "-Tournament";
+			}
 
 			if (!Strings.isNullOrEmpty(subDir))
 			{


### PR DESCRIPTION
#7840
Unrestricted/Beta worlds are the same as Tournament worlds - this change saves screenshots in different folder when a user is on such a world.