### PR TITLE
skybox: add clan hall

### DIFF
--- a/runelite-client/src/main/resources/net/runelite/client/plugins/skybox/skybox.txt
+++ b/runelite-client/src/main/resources/net/runelite/client/plugins/skybox/skybox.txt
@@ -990,6 +990,8 @@ R 49 193 51 194
 // Braindeath Island
 #8AD2DF
 R 33 79 33 80
+// Clan Hall
+r 27 85
 
 // Nightmare dungeon (Morytania underground)
 #0a0a0a


### PR DESCRIPTION
Part of #13644

Set the clan hall region to use the same colour as the GE (and a lot of other overworld places)

Wasn't sure exactly where to put the region in the skybox file, since there are a couple of entries with this specific colour