### PR TITLE
Reset spec counter when leaving instanced fights

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/specialcounter/SpecialCounterPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/specialcounter/SpecialCounterPlugin.java
@@ -43,7 +43,9 @@ import net.runelite.api.ItemContainer;
 import net.runelite.api.NPC;
 import net.runelite.api.NpcID;
 import net.runelite.api.VarPlayer;
+import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.GameStateChanged;
+import net.runelite.api.events.GameTick;
 import net.runelite.api.events.HitsplatApplied;
 import net.runelite.api.events.InteractingChanged;
 import net.runelite.api.events.NpcDespawned;
@@ -72,11 +74,19 @@ public class SpecialCounterPlugin extends Plugin
 		NpcID.DARK_ENERGY_CORE, NpcID.ZOMBIFIED_SPAWN, NpcID.ZOMBIFIED_SPAWN_8063,
 		NpcID.COMBAT_DUMMY, NpcID.UNDEAD_COMBAT_DUMMY
 	);
+	
+	private static final Set<Integer> RESET_ON_LEAVE_INSTANCED_REGIONS = ImmutableSet.of(
+			9023, // vorkath
+			5536 // hydra
+	);
 
 	private int currentWorld;
 	private int specialPercentage;
 	private Actor lastSpecTarget;
 	private int lastSpecTick;
+
+	private int previousRegion;
+	private boolean wasInInstance;
 
 	private SpecialWeapon specialWeapon;
 	private final Set<Integer> interactedNpcIds = new HashSet<>();
@@ -128,6 +138,31 @@ public class SpecialCounterPlugin extends Plugin
 	{
 		removeCounters();
 		wsClient.unregisterMessage(SpecialCounterUpdate.class);
+	}
+	
+	@Subscribe
+	public void onGameTick(GameTick event)
+	{
+		if (client.getGameState() != GameState.LOGGED_IN)
+		{
+			return;
+		}
+		
+		assert client.getLocalPlayer() != null;
+		int currentRegion = WorldPoint.fromLocalInstance(client, client.getLocalPlayer().getLocalLocation()).getRegionID();
+		boolean inInstance = client.isInInstancedRegion();
+		
+		// if the player left the region/instance and was fighting boss that resets, reset specs
+		if (currentRegion != previousRegion || (wasInInstance && !inInstance))
+		{
+			if (RESET_ON_LEAVE_INSTANCED_REGIONS.contains(previousRegion))
+			{
+				removeCounters();
+			}
+		}
+		
+		previousRegion = currentRegion;
+		wasInInstance = inInstance;
 	}
 
 	@Subscribe


### PR DESCRIPTION
When leaving Vorkath or Alchemical Hydra fights, the spec counter does not reset, despite the boss resetting their stats. This could cause the spec counter to add the player's next trip spec to that, giving an inaccurate total spec count. This clears that counter when leaving the vork + hydra region instances.

Needs to be tested at hydra, since I don't have access to that fight to test myself. Drafted until then.