### PR TITLE
camera: prevent pitch increment with "preserve pitch" enabled

### DIFF
--- a/runelite-client/src/main/scripts/ToplevelCompassOp.rs2asm
+++ b/runelite-client/src/main/scripts/ToplevelCompassOp.rs2asm
@@ -47,11 +47,11 @@ LOOK:
    iconst                 0
    sound_synth           
    iconst                 225
-   sconst                 "lookPreservePitch"
-   runelite_callback     
    iconst                 5
    randominc             
    add                   
+   sconst                 "lookPreservePitch"
+   runelite_callback     
    iload                  1 ; load target angle
    cam_forceangle        
    return                


### PR DESCRIPTION
When clicking the compass, the vanilla camera will jitter randomly within 5 values. With "compassLookPreservePitch" enabled, spam clicking the compass would cause your camera pitch to rise repeatedly by that random jitter. This places the camera pitch restore callback after the random jitter, to eliminate that discrepancy.

Current:
![Camera Pitch Current](https://user-images.githubusercontent.com/1868974/120521083-8b0dfc80-c3a2-11eb-86ff-7106b32f3a15.gif)

Patched:
![Camera Pitch Patched](https://user-images.githubusercontent.com/1868974/120520965-6ca80100-c3a2-11eb-9b30-db8b0c59f43d.gif)