### PR TITLE
Reset Wintertodt countdown notification on logout or world hop.

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/wintertodt/WintertodtPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/wintertodt/WintertodtPlugin.java
@@ -65,6 +65,7 @@ import net.runelite.api.Player;
 import net.runelite.api.Varbits;
 import net.runelite.api.events.AnimationChanged;
 import net.runelite.api.events.ChatMessage;
+import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.GameTick;
 import net.runelite.api.events.ItemContainerChanged;
 import net.runelite.api.events.VarbitChanged;
@@ -216,6 +217,19 @@ public class WintertodtPlugin extends Plugin
 			}
 
 			previousTimerValue = timerValue;
+		}
+	}
+
+	@Subscribe
+	public void onGameStateChanged(GameStateChanged event)
+	{
+		switch (event.getGameState())
+		{
+			case HOPPING:
+			case LOGGING_IN:
+				previousTimerValue = 0;
+				client.setVarbit(Varbits.WINTERTODT_TIMER, 0);
+				break;
 		}
 	}
 

--- a/runelite-client/src/test/java/net/runelite/client/plugins/wintertodt/WintertodtPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/wintertodt/WintertodtPluginTest.java
@@ -30,7 +30,9 @@ import com.google.inject.testing.fieldbinder.Bind;
 import com.google.inject.testing.fieldbinder.BoundFieldModule;
 import javax.inject.Inject;
 import net.runelite.api.Client;
+import net.runelite.api.GameState;
 import net.runelite.api.Varbits;
+import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.VarbitChanged;
 import net.runelite.client.Notifier;
 import net.runelite.client.chat.ChatMessageManager;
@@ -150,6 +152,40 @@ public class WintertodtPluginTest
 		when(client.getVar(Varbits.WINTERTODT_TIMER)).thenReturn(25);
 
 		wintertodtPlugin.onVarbitChanged(new VarbitChanged());
+		verify(notifier, times(0)).notify("Wintertodt round is about to start");
+	}
+
+	@Test
+	public void matchStartingNotification_shouldNotNotify_whenLoggingIn()
+	{
+		when(config.roundNotification()).thenReturn(5);
+
+		when(client.getVar(Varbits.WINTERTODT_TIMER)).thenReturn(25);
+		wintertodtPlugin.onVarbitChanged(new VarbitChanged());
+
+		when(client.getVar(Varbits.WINTERTODT_TIMER)).thenReturn(0);
+		GameStateChanged event = new GameStateChanged();
+		event.setGameState(GameState.LOGGING_IN);
+		wintertodtPlugin.onGameStateChanged(event);
+		wintertodtPlugin.onVarbitChanged(new VarbitChanged());
+
+		verify(notifier, times(0)).notify("Wintertodt round is about to start");
+	}
+
+	@Test
+	public void matchStartingNotification_shouldNotNotify_whenHoppingWorld()
+	{
+		when(config.roundNotification()).thenReturn(5);
+
+		when(client.getVar(Varbits.WINTERTODT_TIMER)).thenReturn(25);
+		wintertodtPlugin.onVarbitChanged(new VarbitChanged());
+
+		when(client.getVar(Varbits.WINTERTODT_TIMER)).thenReturn(0);
+		GameStateChanged event = new GameStateChanged();
+		event.setGameState(GameState.HOPPING);
+		wintertodtPlugin.onGameStateChanged(event);
+		wintertodtPlugin.onVarbitChanged(new VarbitChanged());
+
 		verify(notifier, times(0)).notify("Wintertodt round is about to start");
 	}
 }


### PR DESCRIPTION
Closes #13468 

Logging out while timer is currently ticking down, the varbit value is saved e.g. 30.
When logging in while wintertodt is running, the varbit is reset to 0, triggering a notification since the **previousTimerValue** was 30.
Issue also occurs when world hopping from a world waiting for wintertodt to a world currently running.

The varbit has to be explicitly set to 0 along with **previousTimerValue** since varbitChanged events are firing continuously, resetting **previousTimerValue** to the varbit value.