### PR TITLE
Disable bank search hotkey while entering search query

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/bank/BankPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/bank/BankPlugin.java
@@ -126,6 +126,12 @@ public class BankPlugin extends Plugin
 					return;
 				}
 
+				Widget chatboxFullInput = client.getWidget(WidgetInfo.CHATBOX_FULL_INPUT);
+				if (chatboxFullInput != null && !chatboxFullInput.isHidden())
+				{
+					return;
+				}
+
 				log.debug("Search hotkey pressed");
 
 				bankSearch.initSearch();


### PR DESCRIPTION
Closes #13608 

Players that reenter the hotkey to reset the search query may be inconvenienced as it will now require pressing Enter -> hotkey to reset the search query, one extra keypress.