### PR TITLE
idle notifier: prevent six hour notif on enable

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
@@ -110,6 +110,13 @@ public class IdleNotifierPlugin extends Plugin
 		return configManager.getConfig(IdleNotifierConfig.class);
 	}
 
+	@Override
+	protected void startUp() throws Exception
+	{
+		// can't tell when 6hr will be if enabled while already logged in
+		sixHourWarningTime = null;
+	}
+
 	@Subscribe
 	public void onAnimationChanged(AnimationChanged event)
 	{


### PR DESCRIPTION
Six hour notification could trigger incorrectly when the plugin was enabled if the player disabled -> logged out -> logged in -> enabled, since the notification timer was not reset.

![image](https://user-images.githubusercontent.com/1868974/120834103-968f2e00-c530-11eb-8717-92611a2bcd91.png)
