### PR TITLE
Fix toJagexName removing double spaces in some cases

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/util/Text.java
+++ b/runelite-client/src/main/java/net/runelite/client/util/Text.java
@@ -130,7 +130,7 @@ public class Text
 	 */
 	public static String toJagexName(String str)
 	{
-		return CharMatcher.ascii().retainFrom(str.replace('\u00A0', ' ')).replaceAll("[_-]+", " ").trim();
+		return CharMatcher.ascii().retainFrom(str.replaceAll("[\u00A0_-]", " ")).trim();
 	}
 
 	/**

--- a/runelite-client/src/test/java/net/runelite/client/util/TextTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/util/TextTest.java
@@ -56,4 +56,21 @@ public class TextTest
 		assertEquals("a <lt> b", Text.removeFormattingTags("a <lt> b"));
 		assertEquals("Remove no tags", Text.removeFormattingTags("Remove no tags"));
 	}
+
+	@Test
+	public void toJagexName()
+	{
+		assertEquals("lab rat", Text.toJagexName("lab rat"));
+		assertEquals("lab rat", Text.toJagexName("-lab_rat"));
+		assertEquals("lab rat", Text.toJagexName("  lab-rat__"));
+		assertEquals("lab rat", Text.toJagexName("lab\u00A0rat\u00A0\u00A0"));
+		assertEquals("Test Man", Text.toJagexName("蹔Test\u00A0蹔Man"));
+		assertEquals("Test Boy", Text.toJagexName(" Te⓲st\u00A0B⓲oy⓲ "));
+		assertEquals("mR  nAmE", Text.toJagexName("mR  nAmE"));
+		assertEquals("mR  nAmE", Text.toJagexName("mR__nAmE"));
+		assertEquals("mR  nAmE", Text.toJagexName("mR--nAmE"));
+		assertEquals("mR  nAmE", Text.toJagexName("-_ mR\u00A0-nAmE _-"));
+		assertEquals("mR  nAmE", Text.toJagexName("--__--mR_-nAmE__  --"));
+		assertEquals("Mind    the     gap", Text.toJagexName("Mind_-_-the-- __gap"));
+	}
 }


### PR DESCRIPTION
**Note:** A blank character in this context represents any of a space (either normal or non-breaking), `_` or `-`. I am also replacing spaces with `+` in this message because GitHub markdown appears to delete extra spaces in their one-liner code blocks.

While the game does not allow players to enter names containing trailing/leading blank characters or multiple blank characters in a row, there are seemingly ways around that (such as the infamous `+Spacehack`, but also `0++Crazy++0` (notice the double spaces). Trailing and leading blanks are currently handled correctly in all cases, but there are issues with blanks inside of the name.

Taking `Crazy` as an example here, in Jagex's database it would be distinct from, say `0+Crazy+0`, and any of the blanks should be able to be substituted to any other blank and it would count as an equivalent name. For example, `0__Crazy--0` is the same as `0++Crazy++0`.

The current implementation of `toJagexName()` will correctly keep `0++Crazy++0` the way it is, it will also, for example, correctly convert `0+_Crazy-+0` to the same. However, unbroken strings of `_`s and `-`s are incorrectly converted to single spaces. `0--Crazy--0` incorrectly becomes `0+Crazy+0`, which is not an equivalent username.

This PR corrects the functionality of the method and adds tests to ensure it performs as expected.