### PR TITLE
loottracker: Track seeds sent to seed box 

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
@@ -136,6 +136,9 @@ public class LootTrackerPlugin extends Plugin
 	private static final String HERBIBOAR_EVENT = "Herbiboar";
 	private static final Pattern HERBIBOAR_HERB_SACK_PATTERN = Pattern.compile(".+(Grimy .+?) herb.+");
 
+	// Master Farmer loot handling
+	private static final Pattern MASTER_FARMER_SEED_BOX_PATTERN = Pattern.compile("The following stolen loot gets added to your seed box: (.+?) x (\\d+)\\.");
+
 	// Seed Pack loot handling
 	private static final String SEEDPACK_EVENT = "Seed pack";
 
@@ -694,6 +697,13 @@ public class LootTrackerPlugin extends Plugin
 			return;
 		}
 
+		Matcher seedBoxMatcher = MASTER_FARMER_SEED_BOX_PATTERN.matcher(message);
+		if (seedBoxMatcher.matches())
+		{
+			processMasterFarmerSeedBoxLoot(seedBoxMatcher);
+			return;
+		}
+
 		final Matcher pickpocketMatcher = PICKPOCKET_REGEX.matcher(message);
 		if (pickpocketMatcher.matches())
 		{
@@ -973,6 +983,16 @@ public class LootTrackerPlugin extends Plugin
 		return true;
 	}
 
+	private boolean processMasterFarmerSeedBoxLoot(Matcher matcher)
+	{
+		int quantityStolen = Integer.parseInt(matcher.group(2));
+		List<ItemStack> seeds = Collections.singletonList(new ItemStack(itemManager.search(matcher.group(1)).get(0).getId(), quantityStolen, client.getLocalPlayer().getLocalLocation()));
+
+		int thievingLevelLevel = client.getBoostedSkillLevel(Skill.THIEVING);
+		addLoot(lastPickpocketTarget, -1, LootRecordType.PICKPOCKET, thievingLevelLevel, seeds);
+		return true;
+	}
+
 	void toggleItem(String name, boolean ignore)
 	{
 		final Set<String> ignoredItemSet = new LinkedHashSet<>(ignoredItems);
@@ -1110,3 +1130,4 @@ public class LootTrackerPlugin extends Plugin
 				.build());
 	}
 }
+

--- a/runelite-client/src/test/java/net/runelite/client/plugins/loottracker/LootTrackerPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/loottracker/LootTrackerPluginTest.java
@@ -161,6 +161,29 @@ public class LootTrackerPluginTest
 	}
 
 	@Test
+	public void testPickPocketToSeedBox()
+	{
+		when(client.getBoostedSkillLevel(Skill.THIEVING)).thenReturn(42);
+
+		final ItemPrice seedPrice = new ItemPrice();
+		seedPrice.setId(5318);
+		seedPrice.setName("Potato seed");
+		when(itemManager.search("Potato seed")).thenReturn(Collections.singletonList(seedPrice));
+
+		LootTrackerPlugin lootTrackerPluginSpy = spy(this.lootTrackerPlugin);
+		doNothing().when(lootTrackerPluginSpy).addLoot(any(), anyInt(), any(), any(), any());
+
+
+		ChatMessage chatMessage = new ChatMessage(null, ChatMessageType.SPAM, "", "The following stolen loot gets added to your seed box: Potato seed x 3.", "", 0);
+		lootTrackerPluginSpy.onChatMessage(chatMessage);
+
+
+		verify(lootTrackerPluginSpy).addLoot(null, -1, LootRecordType.PICKPOCKET, 42, Arrays.asList(
+				new ItemStack(5318, 3, null)
+		));
+	}
+
+	@Test
 	public void testFirstClue()
 	{
 		ChatMessage chatMessage = new ChatMessage(null, ChatMessageType.GAMEMESSAGE, "", "You have completed 1 master Treasure Trail.", "", 0);


### PR DESCRIPTION
When pickpocketing a master farmer with an open seed sack seeds sent to seed box are not tracked by loot tracker. This commit adds support for reading those chat messages when
pick pocketed seeds go to the seed box.

Close #11290