### PR TITLE
banktags: Fix bank scroll height with separators hidden

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/banktags/BankTagsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/banktags/BankTagsPlugin.java
@@ -551,8 +551,7 @@ public class BankTagsPlugin extends Plugin implements MouseWheelListener
 
 		final Widget bankItemContainer = client.getWidget(WidgetInfo.BANK_ITEM_CONTAINER);
 		int itemContainerHeight = bankItemContainer.getHeight();
-		// add a second row of height here to allow users to scroll down when the last row is partially visible
-		int adjustedScrollHeight = (items / ITEMS_PER_ROW) * ITEM_VERTICAL_SPACING + ITEM_VERTICAL_SPACING;
+		final int adjustedScrollHeight = (Math.max(0, items - 1) / ITEMS_PER_ROW) * ITEM_VERTICAL_SPACING + ITEM_VERTICAL_SPACING;
 		itemContainer.setScrollHeight(Math.max(adjustedScrollHeight, itemContainerHeight));
 
 		final int itemContainerScroll = bankItemContainer.getScrollY();

--- a/runelite-client/src/main/java/net/runelite/client/plugins/banktags/BankTagsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/banktags/BankTagsPlugin.java
@@ -99,6 +99,7 @@ public class BankTagsPlugin extends Plugin implements MouseWheelListener
 	private static final int ITEM_VERTICAL_SPACING = 36;
 	private static final int ITEM_HORIZONTAL_SPACING = 48;
 	private static final int ITEM_ROW_START = 51;
+	private static final int ITEM_CONTAINER_BOTTOM_PADDING = 4;
 
 	private static final int MAX_RESULT_COUNT = 250;
 
@@ -551,7 +552,7 @@ public class BankTagsPlugin extends Plugin implements MouseWheelListener
 
 		final Widget bankItemContainer = client.getWidget(WidgetInfo.BANK_ITEM_CONTAINER);
 		int itemContainerHeight = bankItemContainer.getHeight();
-		final int adjustedScrollHeight = (Math.max(0, items - 1) / ITEMS_PER_ROW) * ITEM_VERTICAL_SPACING + ITEM_VERTICAL_SPACING;
+		final int adjustedScrollHeight = (Math.max(0, items - 1) / ITEMS_PER_ROW) * ITEM_VERTICAL_SPACING + ITEM_VERTICAL_SPACING + ITEM_CONTAINER_BOTTOM_PADDING;
 		itemContainer.setScrollHeight(Math.max(adjustedScrollHeight, itemContainerHeight));
 
 		final int itemContainerScroll = bankItemContainer.getScrollY();


### PR DESCRIPTION
Prior to this change, an extra row of empty space was added to tag tabs
with items reaching the end of a row (ie. multiples of 8) which led to
scroll behavior not matching vanilla for tabs with enough items to
require scrolling. This change fixes this behavior to add extra scroll
height only when a new row is started.

In addition to the 36 pixels of height allotted to each bank item row,
an additional 4 pixels of height exists at the bottom of the bank item
container. This change ensures that a bank tag scrolled to the bottom
will have its items displaying at the exact same y values as that of a
normal bank tag.

Fixes #13676