### PR TITLE
skillcalculator: show material cost for actions that have them

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/game/ItemManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/game/ItemManager.java
@@ -307,6 +307,36 @@ public class ItemManager
 	 */
 	public int getItemPriceWithSource(int itemID, boolean useWikiPrice)
 	{
+		return getItemPrice(itemID, false, useWikiPrice);
+	}
+
+	/**
+	 * Look up an item's price, without canonicalizing the item's ID.
+	 * @see ItemManager#canonicalize
+	 *
+	 * @param itemID canonical item id
+	 * @return item price
+	 */
+	public int getCanonicalItemPrice(int itemID)
+	{
+		return getCanonicalItemPriceWithSource(itemID, runeLiteConfig.useWikiItemPrices());
+	}
+
+	/**
+	 * Look up an item's price, without canonicalizing the item's ID.
+	 * @see ItemManager#canonicalize
+	 *
+	 * @param itemID canonical item id
+	 * @param useWikiPrice use the actively traded/wiki price
+	 * @return item price
+	 */
+	public int getCanonicalItemPriceWithSource(int itemID, boolean useWikiPrice)
+	{
+		return getItemPrice(itemID, true, useWikiPrice);
+	}
+
+	private int getItemPrice(int itemID, boolean idIsCanonical, boolean useWikiPrice)
+	{
 		if (itemID == COINS_995)
 		{
 			return 1;
@@ -316,12 +346,15 @@ public class ItemManager
 			return 1000;
 		}
 
-		ItemComposition itemComposition = getItemComposition(itemID);
-		if (itemComposition.getNote() != -1)
+		if (!idIsCanonical)
 		{
-			itemID = itemComposition.getLinkedNoteId();
+			ItemComposition itemComposition = getItemComposition(itemID);
+			if (itemComposition.getNote() != -1)
+			{
+				itemID = itemComposition.getLinkedNoteId();
+			}
+			itemID = WORN_ITEMS.getOrDefault(itemID, itemID);
 		}
-		itemID = WORN_ITEMS.getOrDefault(itemID, itemID);
 
 		int price = 0;
 
@@ -340,7 +373,7 @@ public class ItemManager
 		{
 			for (final ItemMapping mappedItem : mappedItems)
 			{
-				price += getItemPriceWithSource(mappedItem.getTradeableItem(), useWikiPrice) * mappedItem.getQuantity();
+				price += getItemPrice(mappedItem.getTradeableItem(), idIsCanonical, useWikiPrice) * mappedItem.getQuantity();
 			}
 		}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/SkillCalculator.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/SkillCalculator.java
@@ -39,6 +39,7 @@ import java.text.NumberFormat;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
+import javax.inject.Inject;
 import javax.swing.BorderFactory;
 import javax.swing.Box;
 import javax.swing.JCheckBox;
@@ -83,6 +84,7 @@ class SkillCalculator extends JPanel
 	private int targetXP = Experience.getXpForLevel(targetLevel);
 	private float xpFactor = 1.0f;
 
+	@Inject
 	SkillCalculator(Client client, UICalculatorInputArea uiInput, SpriteManager spriteManager, ItemManager itemManager)
 	{
 		this.client = client;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/SkillCalculator.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/SkillCalculator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2018, Kruithne <kruithne@gmail.com>
  * Copyright (c) 2018, Psikoi <https://github.com/psikoi>
  * All rights reserved.

--- a/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/SkillCalculatorPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/SkillCalculatorPanel.java
@@ -23,7 +23,6 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-
 package net.runelite.client.plugins.skillcalculator;
 
 import java.awt.GridBagConstraints;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/SkillCalculatorPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/SkillCalculatorPanel.java
@@ -29,13 +29,11 @@ package net.runelite.client.plugins.skillcalculator;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.GridLayout;
+import javax.inject.Inject;
 import javax.swing.ImageIcon;
 import javax.swing.JScrollPane;
 import javax.swing.border.EmptyBorder;
-import net.runelite.api.Client;
-import net.runelite.client.game.ItemManager;
 import net.runelite.client.game.SkillIconManager;
-import net.runelite.client.game.SpriteManager;
 import net.runelite.client.ui.ColorScheme;
 import net.runelite.client.ui.PluginPanel;
 import net.runelite.client.ui.components.materialtabs.MaterialTab;
@@ -47,12 +45,14 @@ class SkillCalculatorPanel extends PluginPanel
 	private final SkillIconManager iconManager;
 	private final MaterialTabGroup tabGroup;
 
-	SkillCalculatorPanel(SkillIconManager iconManager, Client client, SpriteManager spriteManager, ItemManager itemManager)
+	@Inject
+	SkillCalculatorPanel(SkillCalculator skillCalculator, SkillIconManager iconManager, UICalculatorInputArea uiInput)
 	{
 		super();
 		getScrollPane().setVerticalScrollBarPolicy(JScrollPane.VERTICAL_SCROLLBAR_ALWAYS);
 
 		this.iconManager = iconManager;
+		uiCalculator = skillCalculator;
 
 		setBorder(new EmptyBorder(10, 10, 10, 10));
 		setLayout(new GridBagLayout());
@@ -68,10 +68,8 @@ class SkillCalculatorPanel extends PluginPanel
 
 		addCalculatorButtons();
 
-		final UICalculatorInputArea uiInput = new UICalculatorInputArea();
 		uiInput.setBorder(new EmptyBorder(15, 0, 15, 0));
 		uiInput.setBackground(ColorScheme.DARK_GRAY_COLOR);
-		uiCalculator = new SkillCalculator(client, uiInput, spriteManager, itemManager);
 
 		add(tabGroup, c);
 		c.gridy++;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/SkillCalculatorPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/SkillCalculatorPlugin.java
@@ -27,10 +27,7 @@ package net.runelite.client.plugins.skillcalculator;
 
 import java.awt.image.BufferedImage;
 import javax.inject.Inject;
-import net.runelite.api.Client;
-import net.runelite.client.game.ItemManager;
-import net.runelite.client.game.SkillIconManager;
-import net.runelite.client.game.SpriteManager;
+import com.google.inject.Provider;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.ClientToolbar;
@@ -45,19 +42,10 @@ import net.runelite.client.util.ImageUtil;
 public class SkillCalculatorPlugin extends Plugin
 {
 	@Inject
-	private Client client;
-
-	@Inject
-	private SkillIconManager skillIconManager;
-
-	@Inject
-	private ItemManager itemManager;
-
-	@Inject
-	private SpriteManager spriteManager;
-
-	@Inject
 	private ClientToolbar clientToolbar;
+
+	@Inject
+	private Provider<SkillCalculatorPanel> uiPanel;
 
 	private NavigationButton uiNavigationButton;
 
@@ -65,13 +53,12 @@ public class SkillCalculatorPlugin extends Plugin
 	protected void startUp() throws Exception
 	{
 		final BufferedImage icon = ImageUtil.loadImageResource(getClass(), "calc.png");
-		final SkillCalculatorPanel uiPanel = new SkillCalculatorPanel(skillIconManager, client, spriteManager, itemManager);
 
 		uiNavigationButton = NavigationButton.builder()
 			.tooltip("Skill Calculator")
 			.icon(icon)
 			.priority(6)
-			.panel(uiPanel)
+			.panel(uiPanel.get())
 			.build();
 
 		clientToolbar.addNavigation(uiNavigationButton);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/UIActionSlot.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/UIActionSlot.java
@@ -33,6 +33,8 @@ import java.awt.GridLayout;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
+import java.util.Arrays;
+import java.util.stream.Collectors;
 import javax.swing.BorderFactory;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
@@ -42,6 +44,7 @@ import javax.swing.border.EmptyBorder;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
+import lombok.experimental.Accessors;
 import net.runelite.client.plugins.skillcalculator.beans.SkillDataEntry;
 import net.runelite.client.ui.ColorScheme;
 import net.runelite.client.ui.FontManager;
@@ -66,6 +69,11 @@ class UIActionSlot extends JPanel
 	@Getter(AccessLevel.PACKAGE)
 	private final SkillDataEntry action;
 	private final JShadowedLabel uiLabelActions;
+
+	@Accessors(fluent = true)
+	@Getter(AccessLevel.PACKAGE)
+	private final boolean hasCosts;
+	private JShadowedLabel uiLabelCosts;
 
 	private final JPanel uiInfo;
 
@@ -117,7 +125,11 @@ class UIActionSlot extends JPanel
 		uiIcon.setPreferredSize(ICON_SIZE);
 		uiIcon.setHorizontalAlignment(JLabel.CENTER);
 
-		uiInfo = new JPanel(new GridLayout(2, 1));
+		hasCosts = action.getMaterials() != null;
+
+		int lines = hasCosts ? 3 : 2;
+
+		uiInfo = new JPanel(new GridLayout(lines, 1));
 		uiInfo.setBackground(ColorScheme.DARKER_GRAY_COLOR);
 		uiInfo.setBorder(new EmptyBorder(0, 5, 0, 0));
 
@@ -130,6 +142,24 @@ class UIActionSlot extends JPanel
 
 		uiInfo.add(uiLabelName);
 		uiInfo.add(uiLabelActions);
+
+		if (hasCosts)
+		{
+			uiLabelCosts = new JShadowedLabel("Unknown");
+			uiLabelCosts.setFont(FontManager.getRunescapeSmallFont());
+			uiLabelCosts.setForeground(ColorScheme.LIGHT_GRAY_COLOR);
+
+			uiInfo.add(uiLabelCosts);
+
+			String tooltip = "<html>" +
+				Arrays.stream(action.getMaterials())
+					.map(m -> m.getAmount() + "x " + m.getName())
+					.collect(Collectors.joining("<br>")
+					) +
+				"</html>";
+
+			setToolTipText(tooltip);
+		}
 
 		add(uiIcon, BorderLayout.LINE_START);
 		add(uiInfo, BorderLayout.CENTER);
@@ -156,6 +186,11 @@ class UIActionSlot extends JPanel
 	void setText(String text)
 	{
 		uiLabelActions.setText(text);
+	}
+
+	void setCosts(String text)
+	{
+		uiLabelCosts.setText(text);
 	}
 
 	private void updateBackground()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/UICalculatorInputArea.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/UICalculatorInputArea.java
@@ -32,12 +32,15 @@ import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
 import javax.swing.border.EmptyBorder;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
 import lombok.Getter;
 import net.runelite.client.ui.ColorScheme;
 import net.runelite.client.ui.FontManager;
 import net.runelite.client.ui.components.FlatTextField;
 
 @Getter
+@Singleton
 class UICalculatorInputArea extends JPanel
 {
 	private final JTextField uiFieldCurrentLevel;
@@ -45,6 +48,7 @@ class UICalculatorInputArea extends JPanel
 	private final JTextField uiFieldTargetLevel;
 	private final JTextField uiFieldTargetXP;
 
+	@Inject
 	UICalculatorInputArea()
 	{
 		setLayout(new GridLayout(2, 2, 7, 7));

--- a/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/UICombinedActionSlot.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/UICombinedActionSlot.java
@@ -42,8 +42,12 @@ import net.runelite.client.ui.components.shadowlabel.JShadowedLabel;
 class UICombinedActionSlot extends JPanel
 {
 	private static final Dimension ICON_SIZE = new Dimension(32, 32);
+	private final JPanel uiInfo;
+	private final GridLayout thinLayout;
+	private final GridLayout thickLayout;
 	private final JShadowedLabel uiLabelActions;
 	private final JShadowedLabel uiLabelTitle;
+	private final JShadowedLabel uiLabelCosts;
 
 	UICombinedActionSlot(SpriteManager spriteManager)
 	{
@@ -61,7 +65,10 @@ class UICombinedActionSlot extends JPanel
 		uiIcon.setHorizontalAlignment(JLabel.CENTER);
 		add(uiIcon, BorderLayout.LINE_START);
 
-		JPanel uiInfo = new JPanel(new GridLayout(2, 1));
+		thinLayout = new GridLayout(2, 1);
+		thickLayout = new GridLayout(3, 1);
+
+		uiInfo = new JPanel(thinLayout);
 		uiInfo.setBackground(ColorScheme.DARKER_GRAY_COLOR);
 
 		uiLabelTitle = new JShadowedLabel("No Action Selected");
@@ -70,6 +77,10 @@ class UICombinedActionSlot extends JPanel
 		uiLabelActions = new JShadowedLabel("Shift-click to select multiple");
 		uiLabelActions.setFont(FontManager.getRunescapeSmallFont());
 		uiLabelActions.setForeground(ColorScheme.LIGHT_GRAY_COLOR);
+
+		uiLabelCosts = new JShadowedLabel("");
+		uiLabelCosts.setFont(FontManager.getRunescapeSmallFont());
+		uiLabelCosts.setForeground(ColorScheme.LIGHT_GRAY_COLOR);
 
 		uiInfo.add(uiLabelTitle);
 		uiInfo.add(uiLabelActions);
@@ -85,5 +96,20 @@ class UICombinedActionSlot extends JPanel
 	void setTitle(String text)
 	{
 		uiLabelTitle.setText(text);
+	}
+
+	void setCosts(String text)
+	{
+		if (text == null)
+		{
+			uiInfo.setLayout(thinLayout);
+			uiInfo.remove(uiLabelCosts);
+		}
+		else
+		{
+			uiInfo.setLayout(thickLayout);
+			uiLabelCosts.setText(text);
+			uiInfo.add(uiLabelCosts);
+		}
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/beans/Material.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/beans/Material.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Kruithne <kruithne@gmail.com>
+ * Copyright (c) 2021, Pristit <https://github.com/pristit>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -25,18 +25,11 @@
 package net.runelite.client.plugins.skillcalculator.beans;
 
 import lombok.Getter;
-import lombok.Setter;
 
 @Getter
-public class SkillDataEntry
+public class Material
 {
+	private int id;
 	private String name;
-	private int level;
-	private double xp;
-	private Integer icon;
-	private Integer sprite;
-	private boolean ignoreBonus;
-	private Material[] materials;
-	@Setter
-	private int cost;
+	private int amount;
 }

--- a/runelite-client/src/main/resources/net/runelite/client/plugins/skillcalculator/skill_prayer.json
+++ b/runelite-client/src/main/resources/net/runelite/client/plugins/skillcalculator/skill_prayer.json
@@ -19,7 +19,24 @@
       "icon": 13447,
       "name": "Ensouled Goblin Head",
       "xp": 130,
-      "ignoreBonus": true
+      "ignoreBonus": true,
+      "materials": [
+        {
+          "id": 13447,
+          "name": "Ensouled Monkey Head",
+          "amount": 1
+        },
+        {
+          "id": 559,
+          "name": "Body rune",
+          "amount": 4
+        },
+        {
+          "id": 561,
+          "name": "Nature rune",
+          "amount": 2
+        }
+      ]
     },
     {
       "level": 1,


### PR DESCRIPTION
Closes #3869
Closes #5096
Closes #13632

Draft for the following reasons:
* I would like feedback on the naming in ff82f5c
* It currently is missing all the materials (it's just a PoC atm)
* The multi-selection box doesn't show cost at all if it's 0 (ie. there was no costs associated with all selected methods). I'm not sure if it should just show as 0 gp in that case instead.
* The materials are displayed in the tooltip, and currently only show the requirements for a single action. It should probably also show the total required for the overall actions, and the combined action display should do the same, but I'm not sure what that should look like. Feedback much appreciated.
* ~~I'm not sure how to deal with materials with variable input (eg. Shade Cremation, Lunar Magic processing spells)~~ I've got a method, it's just not pushed yet.
* There is currently no config for turning this off, and I would like to add one since it's not really useful for all players

How it currently looks:
![image](https://user-images.githubusercontent.com/2979691/121808055-c6d07e00-cc4e-11eb-9e38-fe79718ebddb.png)

