### PR TITLE
Fix open sidebar behaviour and remember panel state

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
@@ -211,6 +211,7 @@ public class ClientUI
 					currentButton.setSelected(false);
 					currentNavButton.setSelected(false);
 					currentButton = null;
+					currentNavButton = null;
 				}
 				else
 				{


### PR DESCRIPTION
Fixes the navigation button not being properly reselected if closed by a mouse click, then closing and opening the sidebar.
This is done by simply removing `currentButton = null;` on L213. This makes the mouse click consistent with the `togglePluginPanel()` method, which does not null either `currentButton` or `currentNavButton`. Having `currentButton` null, but not `currentNavButton` allows the panel to be expanded, but the button cannot be shown as selected due to the lost reference.

Also, when reopening the sidebar, the last used plugin panel will only expand and be reselected if it was already expanded when the side panel was closed.
To do this, a class variable is added to track the state of the side plugin panel when the sidebar is closed. When the sidebar is reopened and this variable is true, the previous plugin panel will be reselected and expanded.
To make this work, however, did require me to take the `setSelected()` calls on the two buttons and copy it across the two parts of the `if (isSidebarOpen)` statement due to the `reopenPanelOnSidebarOpen` check when the sidebar is reopened.