### PR TITLE
Xp Drops: Add option to override standard client xp drop colors

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/experiencedrop/XpDropConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/experiencedrop/XpDropConfig.java
@@ -45,10 +45,18 @@ public interface XpDropConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "standardColor",
+		name = "Standard Color",
+		description = "XP drop color when no prayer is active",
+		position = 1
+	)
+	Color standardColor();
+
+	@ConfigItem(
 		keyName = "meleePrayerColor",
 		name = "Melee Prayer Color",
 		description = "XP drop color when a melee prayer is active",
-		position = 1
+		position = 2
 	)
 	default Color getMeleePrayerColor()
 	{
@@ -59,7 +67,7 @@ public interface XpDropConfig extends Config
 		keyName = "rangePrayerColor",
 		name = "Range Prayer Color",
 		description = "XP drop color when a range prayer is active",
-		position = 2
+		position = 3
 	)
 	default Color getRangePrayerColor()
 	{
@@ -70,7 +78,7 @@ public interface XpDropConfig extends Config
 		keyName = "magePrayerColor",
 		name = "Mage Prayer Color",
 		description = "XP drop color when a mage prayer is active",
-		position = 3
+		position = 4
 	)
 	default Color getMagePrayerColor()
 	{
@@ -81,12 +89,11 @@ public interface XpDropConfig extends Config
 		keyName = "fakeXpDropDelay",
 		name = "Fake Xp Drop delay",
 		description = "Configures how many ticks should pass between fake XP drops, 0 to disable",
-		position = 4
+		position = 5
 	)
 	@Units(Units.TICKS)
 	default int fakeXpDropDelay()
 	{
 		return 0;
 	}
-
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/experiencedrop/XpDropPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/experiencedrop/XpDropPlugin.java
@@ -25,6 +25,7 @@
 package net.runelite.client.plugins.experiencedrop;
 
 import com.google.inject.Provides;
+import java.awt.Color;
 import java.util.Arrays;
 import java.util.EnumMap;
 import java.util.Map;
@@ -151,10 +152,19 @@ public class XpDropPlugin extends Plugin
 
 	private void resetTextColor(Widget widget)
 	{
-		EnumComposition colorEnum = client.getEnum(EnumID.XPDROP_COLORS);
-		int defaultColorId = client.getVar(Varbits.EXPERIENCE_DROP_COLOR);
-		int color = colorEnum.getIntValue(defaultColorId);
-		widget.setTextColor(color);
+		Color standardColor = config.standardColor();
+		if (standardColor != null)
+		{
+			int color = standardColor.getRGB();
+			widget.setTextColor(color);
+		}
+		else
+		{
+			EnumComposition colorEnum = client.getEnum(EnumID.XPDROP_COLORS);
+			int defaultColorId = client.getVar(Varbits.EXPERIENCE_DROP_COLOR);
+			int color = colorEnum.getIntValue(defaultColorId);
+			widget.setTextColor(color);
+		}
 	}
 
 	private void hideSkillIcons(Widget xpdrop)


### PR DESCRIPTION
Adds toggle option for player to choose to override the default client xp drop colors, allowing for more options/variety.

Does not affect the ability to change colors when using prayers.

# Before
![image](https://user-images.githubusercontent.com/71386629/121787592-d607eb00-cbbe-11eb-9ac8-b4cf0671c1fe.png)

# After
![image](https://user-images.githubusercontent.com/71386629/121787600-de602600-cbbe-11eb-897b-4f7ccc99c29b.png)

![image](https://user-images.githubusercontent.com/71386629/121787604-e61fca80-cbbe-11eb-8bc0-24df2acba65a.png)
