### PR TITLE
loot tracker: Add Supply crate (Wintertodt)

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
@@ -237,6 +237,9 @@ public class LootTrackerPlugin extends Plugin
 
 	private static final String CASKET_EVENT = "Casket";
 
+	// Wintertodt
+	private static final String WT_SUPPLY_CRATE_EVENT = "Supply crate (Wintertodt)";
+
 	// Soul Wars
 	private static final String SPOILS_OF_WAR_EVENT = "Spoils of war";
 	private static final Set<Integer> SOUL_WARS_REGIONS = ImmutableSet.of(8493, 8749, 9005);
@@ -800,6 +803,7 @@ public class LootTrackerPlugin extends Plugin
 		else if (SEEDPACK_EVENT.equals(eventType)
 			|| CASKET_EVENT.equals(eventType)
 			|| BIRDNEST_EVENT.equals(eventType)
+			|| WT_SUPPLY_CRATE_EVENT.equals(eventType)
 			|| SPOILS_OF_WAR_EVENT.equals(eventType)
 			|| TEMPOROSS_EVENT.equals(eventType)
 			|| TEMPOROSS_CASKET_EVENT.equals(eventType))
@@ -840,6 +844,12 @@ public class LootTrackerPlugin extends Plugin
 		if (event.getMenuOption().equals("Open") && event.getId() == ItemID.CASKET)
 		{
 			setEvent(LootRecordType.EVENT, CASKET_EVENT);
+			takeInventorySnapshot();
+		}
+
+		if (event.getMenuOption().equals("Open") && (event.getId() == ItemID.SUPPLY_CRATE || event.getId() == ItemID.EXTRA_SUPPLY_CRATE))
+		{
+			setEvent(LootRecordType.EVENT, WT_SUPPLY_CRATE_EVENT);
 			takeInventorySnapshot();
 		}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
@@ -237,8 +237,7 @@ public class LootTrackerPlugin extends Plugin
 
 	private static final String CASKET_EVENT = "Casket";
 
-	// Wintertodt
-	private static final String WT_SUPPLY_CRATE_EVENT = "Supply crate (Wintertodt)";
+	private static final String WINTERTODT_SUPPLY_CRATE_EVENT = "Supply crate (Wintertodt)";
 
 	// Soul Wars
 	private static final String SPOILS_OF_WAR_EVENT = "Spoils of war";
@@ -789,6 +788,7 @@ public class LootTrackerPlugin extends Plugin
 			|| HALLOWED_SEPULCHRE_COFFIN_EVENT.equals(eventType)
 			|| HERBIBOAR_EVENT.equals(eventType)
 			|| HESPORI_EVENT.equals(eventType)
+			|| WINTERTODT_SUPPLY_CRATE_EVENT.equals(eventType)
 			|| eventType.endsWith("Bird House")
 			|| eventType.startsWith("H.A.M. chest")
 			|| lootRecordType == LootRecordType.PICKPOCKET)
@@ -803,7 +803,6 @@ public class LootTrackerPlugin extends Plugin
 		else if (SEEDPACK_EVENT.equals(eventType)
 			|| CASKET_EVENT.equals(eventType)
 			|| BIRDNEST_EVENT.equals(eventType)
-			|| WT_SUPPLY_CRATE_EVENT.equals(eventType)
 			|| SPOILS_OF_WAR_EVENT.equals(eventType)
 			|| TEMPOROSS_EVENT.equals(eventType)
 			|| TEMPOROSS_CASKET_EVENT.equals(eventType))
@@ -849,7 +848,7 @@ public class LootTrackerPlugin extends Plugin
 
 		if (event.getMenuOption().equals("Open") && (event.getId() == ItemID.SUPPLY_CRATE || event.getId() == ItemID.EXTRA_SUPPLY_CRATE))
 		{
-			setEvent(LootRecordType.EVENT, WT_SUPPLY_CRATE_EVENT);
+			setEvent(LootRecordType.EVENT, WINTERTODT_SUPPLY_CRATE_EVENT);
 			takeInventorySnapshot();
 		}
 


### PR DESCRIPTION
Adds loot tracking for Supply crate from Wintertodt

![image](https://user-images.githubusercontent.com/1575003/121826040-8b43ad00-cc6a-11eb-84eb-7461b68a26ee.png)

![image](https://user-images.githubusercontent.com/1575003/121826036-8848bc80-cc6a-11eb-923f-8a129c0941d3.png)

Closes #5824
Closes #5883