### PR TITLE
api: correct imcando hammer construction animation

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/AnimationID.java
+++ b/runelite-api/src/main/java/net/runelite/api/AnimationID.java
@@ -206,7 +206,7 @@ public final class AnimationID
 	public static final int LEAGUE_HOME_TELEPORT_6 = 8807;
 
 	public static final int CONSTRUCTION = 3676;
-	public static final int CONSTRUCTION_IMCANDO = 8192;
+	public static final int CONSTRUCTION_IMCANDO = 8912;
 	public static final int SAND_COLLECTION = 895;
 	public static final int PISCARILIUS_CRANE_REPAIR = 7199;
 	public static final int HOME_MAKE_TABLET = 4067;


### PR DESCRIPTION
While working on something tangentially related, I noticed that the animationID for doing construction with the Imcando Hammer was wrong. I don't think Jagex changed the animation recently, so it's likely my fault from when I added it, sorry.