### PR TITLE
timers: add duration and cooldown timers for arceuus spells

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/SpriteID.java
+++ b/runelite-api/src/main/java/net/runelite/api/SpriteID.java
@@ -1209,79 +1209,25 @@ public final class SpriteID
 	public static final int KOUREND_FAVOUR_LOVAKENGJ_ICON = 1244;
 	public static final int KOUREND_FAVOUR_PISCARILIUS_ICON = 1245;
 	public static final int KOUREND_FAVOUR_SHAYZIEN_ICON = 1246;
-	public static final int SPELL_REANIMATE_GOBLIN = 1247;
-	public static final int SPELL_REANIMATE_DEMON = 1248;
-	public static final int SPELL_REANIMATE_DRAGON = 1249;
-	public static final int SPELL_REANIMATE_ELF = 1250;
-	public static final int SPELL_REANIMATE_CHAOS_DRUID = 1251;
-	public static final int SPELL_REANIMATE_TROLL = 1252;
-	public static final int SPELL_REANIMATE_DAGANNOTH = 1253;
-	public static final int SPELL_REANIMATE_OGRE = 1254;
-	public static final int SPELL_REANIMATE_GIANT = 1255;
-	public static final int SPELL_REANIMATE_BEAR = 1256;
-	public static final int SPELL_REANIMATE_SCORPION = 1257;
-	public static final int SPELL_REANIMATE_IMP = 1258;
-	public static final int SPELL_REANIMATE_MINOTAUR = 1259;
-	public static final int SPELL_REANIMATE_UNICORN = 1260;
-	public static final int SPELL_REANIMATE_KALPHITE = 1261;
-	public static final int SPELL_REANIMATE_TZHAAR = 1262;
-	public static final int SPELL_REANIMATE_AVIANSIE = 1263;
-	public static final int SPELL_REANIMATE_MONKEY = 1264;
-	public static final int SPELL_REANIMATE_ABYSSAL_CREATURE = 1265;
-	public static final int SPELL_REANIMATE_HORROR = 1266;
-	public static final int SPELL_REANIMATE_BLOODVELD = 1267;
-	public static final int SPELL_REANIMATE_DOG = 1268;
-	public static final int SPELL_LUMBRIDGE_GRAVEYARD_TELEPORT = 1269;
-	public static final int SPELL_DRAYNOR_MANOR_TELEPORT = 1270;
-	public static final int SPELL_MIND_ALTAR_TELEPORT = 1271;
-	public static final int SPELL_REANIMATE_GOBLIN_DISABLED = 1272;
-	public static final int SPELL_REANIMATE_DEMON_DISABLED = 1273;
-	public static final int SPELL_REANIMATE_DRAGON_DISABLED = 1274;
-	public static final int SPELL_REANIMATE_ELF_DISABLED = 1275;
-	public static final int SPELL_REANIMATE_CHAOS_DRUID_DISABLED = 1276;
-	public static final int SPELL_REANIMATE_TROLL_DISABLED = 1277;
-	public static final int SPELL_REANIMATE_DAGANNOTH_DISABLED = 1278;
-	public static final int SPELL_REANIMATE_OGRE_DISABLED = 1279;
-	public static final int SPELL_REANIMATE_GIANT_DISABLED = 1280;
-	public static final int SPELL_REANIMATE_BEAR_DISABLED = 1281;
-	public static final int SPELL_REANIMATE_SCORPION_DISABLED = 1282;
-	public static final int SPELL_REANIMATE_IMP_DISABLED = 1283;
-	public static final int SPELL_REANIMATE_MINOTAUR_DISABLED = 1284;
-	public static final int SPELL_REANIMATE_UNICORN_DISABLED = 1285;
-	public static final int SPELL_REANIMATE_KALPHITE_DISABLED = 1286;
-	public static final int SPELL_REANIMATE_TZHAAR_DISABLED = 1287;
-	public static final int SPELL_REANIMATE_AVIANSIE_DISABLED = 1288;
-	public static final int SPELL_REANIMATE_MONKEY_DISABLED = 1289;
-	public static final int SPELL_REANIMATE_ABYSSAL_CREATURE_DISABLED = 1290;
-	public static final int SPELL_REANIMATE_HORROR_DISABLED = 1291;
-	public static final int SPELL_REANIMATE_BLOODVELD_DISABLED = 1292;
-	public static final int SPELL_REANIMATE_DOG_DISABLED = 1293;
-	public static final int SPELL_LUMBRIDGE_GRAVEYARD_TELEPORT_DISABLED = 1294;
-	public static final int SPELL_DRAYNOR_MANOR_TELEPORT_DISABLED = 1295;
-	public static final int SPELL_MIND_ALTAR_TELEPORT_DISABLED = 1296;
+	/* Unmapped: 1247~1296 */
 	public static final int QUESTS_PAGE_ICON_PURPLE_KOUREND = 1297;
 	public static final int UNUSED_TAB_QUESTS_GREEN_ACHIEVEMENT_DIARIES = 1298;
 	public static final int TAB_QUESTS_GREEN_ACHIEVEMENT_DIARIES = 1299;
-	public static final int SPELL_RESPAWN_TELEPORT = 1300;
-	public static final int SPELL_SALVE_GRAVEYARD_TELEPORT = 1301;
-	public static final int SPELL_FENKENSTRAINS_CASTLE_TELEPORT = 1302;
-	public static final int SPELL_WEST_ARDOUGNE_TELEPORT = 1303;
-	public static final int SPELL_HARMONY_ISLAND_TELEPORT = 1304;
-	public static final int SPELL_CEMETARY_TELEPORT = 1305;
-	public static final int SPELL_BARROWS_TELEPORT = 1306;
-	public static final int SPELL_APE_ATOLL_TELEPORT = 1307;
-	public static final int SPELL_REANIMATE_CROPS = 1308;
-	/* Unmapped: 1309~1318 */
-	public static final int SPELL_RESPAWN_TELEPORT_DISABLED = 1319;
-	public static final int SPELL_SALVE_GRAVEYARD_TELEPORT_DISABLED = 1320;
-	public static final int SPELL_FENKENSTRAINS_CASTLE_TELEPORT_DISABLED = 1321;
-	public static final int SPELL_WEST_ARDOUGNE_TELEPORT_DISABLED = 1322;
-	public static final int SPELL_HARMONY_ISLAND_TELEPORT_DISABLED = 1323;
-	public static final int SPELL_CEMETARY_TELEPORT_DISABLED = 1324;
-	public static final int SPELL_BARROWS_TELEPORT_DISABLED = 1325;
-	public static final int SPELL_APE_ATOLL_TELEPORT_DISABLED = 1326;
-	public static final int SPELL_REANIMATE_CROPS_DISABLED = 1327;
-	/* Unmapped: 1328~1337 */
+	/* Unmapped: 1300~1305 */
+	public static final int SPELL_WARD_OF_ARCEUUS = 1306;
+	/* Unmapped: 1307~1309 */
+	public static final int SPELL_DEATH_CHARGE = 1310;
+	/* Unmapped: 1311~1314 */
+	public static final int SPELL_SHADOW_VEIL = 1315;
+	/* Unmapped: 1316~1324 */
+	public static final int SPELL_WARD_OF_ARCEUUS_DISABLED = 1325;
+	/* Unmapped: 1326 */
+	public static final int SPELL_GREATER_CORRUPTION_DISABLED = 1327;
+	/* Unmapped: 1328 */
+	public static final int SPELL_DEATH_CHARGE_DISABLED = 1329;
+	/* Unmapped: 1330~1333 */
+	public static final int SPELL_SHADOW_VEIL_DISABLED = 1334;
+	/* Unmapped: 1335~1337 */
 	public static final int WORLD_SWITCHER_WORLD_STAR_BLUE = 1338;
 	public static final int HITSPLAT_DARK_GREEN_VENOM = 1339;
 	public static final int FAIRY_RING_REMOVE_FAVOURITE = 1340;
@@ -1591,8 +1537,12 @@ public final class SpriteID
 	public static final int FRIENDS_CHAT_RANK_TRIPLE_CHEVRON_SERGEANT = 2831;
 	public static final int FRIENDS_CHAT_RANK_DOUBLE_CHEVRON_CORPORAL = 2832;
 	public static final int FRIENDS_CHAT_RANK_SINGLE_CHEVRON_RECRUIT = 2833;
-
+	/* Unmapped: 2834~2857 */
 	public static final int SETTINGS_SLIDER_HANDLE_BLUE = 2858;
 	public static final int SETTINGS_SLIDER_HANDLE_RED = 2859;
 	public static final int SETTINGS_SLIDER_HANDLE_GREEN = 2860;
+	/* Unmapped: 2861~2980 */
+	public static final int SPELL_RESURRECT_SUPERIOR_SKELETON = 2981;
+	/* Unmapped: 2982~2986 */
+	public static final int SPELL_RESURRECT_SUPERIOR_SKELETON_DISABLED = 2987;
 }

--- a/runelite-api/src/main/java/net/runelite/api/Varbits.java
+++ b/runelite-api/src/main/java/net/runelite/api/Varbits.java
@@ -527,6 +527,7 @@ public enum Varbits
 	 * Spell cooldowns
 	 */
 	VENGEANCE_COOLDOWN(2451),
+	CORRUPTION_COOLDOWN(12288),
 
 	/**
 	 * Amount of items in each bank tab

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timers/GameTimer.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timers/GameTimer.java
@@ -76,7 +76,16 @@ enum GameTimer
 	DIVINE_BATTLEMAGE(ItemID.DIVINE_BATTLEMAGE_POTION4, GameTimerImageType.ITEM, "Divine Battlemage", 5, ChronoUnit.MINUTES),
 	ANTIPOISON(ItemID.ANTIPOISON4, GameTimerImageType.ITEM, "Antipoison", false),
 	ANTIVENOM(ItemID.ANTIVENOM4, GameTimerImageType.ITEM, "Anti-venom", false),
-	TELEBLOCK(SpriteID.SPELL_TELE_BLOCK, GameTimerImageType.SPRITE, "Teleblock", true);
+	TELEBLOCK(SpriteID.SPELL_TELE_BLOCK, GameTimerImageType.SPRITE, "Teleblock", true),
+	SHADOW_VEIL(SpriteID.SPELL_SHADOW_VEIL, GameTimerImageType.SPRITE, "Shadow veil", true),
+	RESURRECT_THRALL(SpriteID.SPELL_RESURRECT_SUPERIOR_SKELETON, GameTimerImageType.SPRITE, "Resurrect thrall", false),
+	WARD_OF_ARCEUUS(SpriteID.SPELL_WARD_OF_ARCEUUS, GameTimerImageType.SPRITE, "Ward of Arceuus", true),
+	DEATH_CHARGE(SpriteID.SPELL_DEATH_CHARGE, GameTimerImageType.SPRITE, "Death charge", false),
+	SHADOW_VEIL_COOLDOWN(SpriteID.SPELL_SHADOW_VEIL_DISABLED, GameTimerImageType.SPRITE, "Shadow veil cooldown", 30, ChronoUnit.SECONDS),
+	RESURRECT_THRALL_COOLDOWN(SpriteID.SPELL_RESURRECT_SUPERIOR_SKELETON_DISABLED, GameTimerImageType.SPRITE, "Resurrect thrall cooldown", 12, GAME_TICKS),
+	WARD_OF_ARCEUUS_COOLDOWN(SpriteID.SPELL_WARD_OF_ARCEUUS_DISABLED, GameTimerImageType.SPRITE, "Ward of Arceuus cooldown", 30, ChronoUnit.SECONDS),
+	DEATH_CHARGE_COOLDOWN(SpriteID.SPELL_DEATH_CHARGE_DISABLED, GameTimerImageType.SPRITE, "Death charge cooldown", 60, ChronoUnit.SECONDS),
+	CORRUPTION_COOLDOWN(SpriteID.SPELL_GREATER_CORRUPTION_DISABLED, GameTimerImageType.SPRITE, "Corruption cooldown", 30, ChronoUnit.SECONDS);
 
 	@Nullable
 	private final Duration duration;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersConfig.java
@@ -263,4 +263,24 @@ public interface TimersConfig extends Config
 	{
 		return true;
 	}
+
+	@ConfigItem(
+		keyName = "showArceuus",
+		name = "Arceuus spells duration",
+		description = "Whether to show Arceuus spellbook spell timers"
+	)
+	default boolean showArceuus()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		keyName = "showArceuusCooldown",
+		name = "Arceuus spells cooldown",
+		description = "Whether to show cooldown timers for Arceuus spellbook spells"
+	)
+	default boolean showArceuusCooldown()
+	{
+		return false;
+	}
 }

--- a/runelite-client/src/test/java/net/runelite/client/plugins/timers/TimersPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/timers/TimersPluginTest.java
@@ -30,6 +30,7 @@ import com.google.inject.testing.fieldbinder.Bind;
 import com.google.inject.testing.fieldbinder.BoundFieldModule;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.function.Predicate;
 import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
 import net.runelite.api.Experience;
@@ -37,15 +38,19 @@ import net.runelite.api.InventoryID;
 import net.runelite.api.ItemContainer;
 import net.runelite.api.ItemID;
 import net.runelite.api.Skill;
+import net.runelite.api.Varbits;
 import net.runelite.api.events.ChatMessage;
 import net.runelite.api.events.ItemContainerChanged;
 import net.runelite.api.events.MenuOptionClicked;
 import net.runelite.api.events.StatChanged;
+import net.runelite.api.events.VarbitChanged;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.game.SpriteManager;
 import net.runelite.client.ui.overlay.infobox.InfoBox;
 import net.runelite.client.ui.overlay.infobox.InfoBoxManager;
+import net.runelite.client.util.RSTimeUnit;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -376,6 +381,165 @@ public class TimersPluginTest
 		ElapsedTimer timer = (ElapsedTimer) captor.getValue();
 		assertEquals("00:06", timer.getText());
 	}
+
+	// region Arceuus spells
+	@Test
+	public void testDeathChargeCast()
+	{
+		when(timersConfig.showArceuus()).thenReturn(true);
+		when(client.getRealSkillLevel(Skill.MAGIC)).thenReturn(50);
+		ChatMessage chatMessage = new ChatMessage(null, ChatMessageType.GAMEMESSAGE, "", "<col=6800bf>Upon the death of your next foe, some of your special attack energy will be restored.</col>", "", 0);
+		timersPlugin.onChatMessage(chatMessage);
+
+		ArgumentCaptor<InfoBox> ibcaptor = ArgumentCaptor.forClass(InfoBox.class);
+		verify(infoBoxManager).addInfoBox(ibcaptor.capture());
+		TimerTimer infoBox = (TimerTimer) ibcaptor.getValue();
+		assertEquals(GameTimer.DEATH_CHARGE, infoBox.getTimer());
+		assertEquals(Duration.of(50, RSTimeUnit.GAME_TICKS), infoBox.getDuration());
+	}
+
+	@Test
+	public void testDeathChargeCooldown()
+	{
+		when(timersConfig.showArceuusCooldown()).thenReturn(true);
+		ChatMessage chatMessage = new ChatMessage(null, ChatMessageType.GAMEMESSAGE, "", "<col=6800bf>Upon the death of your next foe, some of your special attack energy will be restored.</col>", "", 0);
+		timersPlugin.onChatMessage(chatMessage);
+
+		ArgumentCaptor<InfoBox> ibcaptor = ArgumentCaptor.forClass(InfoBox.class);
+		verify(infoBoxManager).addInfoBox(ibcaptor.capture());
+		TimerTimer infoBox = (TimerTimer) ibcaptor.getValue();
+		assertEquals(GameTimer.DEATH_CHARGE_COOLDOWN, infoBox.getTimer());
+	}
+
+	@Test
+	public void testDeathChargeRestore()
+	{
+		when(timersConfig.showArceuus()).thenReturn(true);
+
+		ChatMessage chatMessage = new ChatMessage(null, ChatMessageType.GAMEMESSAGE, "", "<col=6800bf>Some of your special attack energy has been restored.</col>", "", 0);
+		timersPlugin.onChatMessage(chatMessage);
+
+		TimerTimer correctInfoBox = new TimerTimer(GameTimer.DEATH_CHARGE, Duration.ofSeconds(1), timersPlugin);
+		TimerTimer incorrectInfoBox = new TimerTimer(GameTimer.WARD_OF_ARCEUUS, Duration.ofSeconds(1), timersPlugin);
+		ArgumentCaptor<Predicate<InfoBox>> prcaptor = ArgumentCaptor.forClass(Predicate.class);
+		verify(infoBoxManager).removeIf(prcaptor.capture());
+		Predicate<InfoBox> pred = prcaptor.getValue();
+		assertTrue(pred.test(correctInfoBox));
+		assertFalse(pred.test(incorrectInfoBox));
+	}
+
+	@Test
+	public void testArceuusWard()
+	{
+		when(timersConfig.showArceuus()).thenReturn(true);
+		when(client.getRealSkillLevel(Skill.MAGIC)).thenReturn(57);
+		ChatMessage chatMessage = new ChatMessage(null, ChatMessageType.GAMEMESSAGE, "", "<col=0000b2>Your defence against Arceuus magic has been strengthened.</col>", "", 0);
+		timersPlugin.onChatMessage(chatMessage);
+
+		ArgumentCaptor<InfoBox> captor = ArgumentCaptor.forClass(InfoBox.class);
+		verify(infoBoxManager).addInfoBox(captor.capture());
+		TimerTimer infoBox = (TimerTimer) captor.getValue();
+		assertEquals(GameTimer.WARD_OF_ARCEUUS, infoBox.getTimer());
+		assertEquals(Duration.of(57, RSTimeUnit.GAME_TICKS), infoBox.getDuration());
+	}
+
+	@Test
+	public void testArceuusWardCooldown()
+	{
+		when(timersConfig.showArceuusCooldown()).thenReturn(true);
+		ChatMessage chatMessage = new ChatMessage(null, ChatMessageType.GAMEMESSAGE, "", "<col=0000b2>Your defence against Arceuus magic has been strengthened.</col>", "", 0);
+		timersPlugin.onChatMessage(chatMessage);
+
+		ArgumentCaptor<InfoBox> captor = ArgumentCaptor.forClass(InfoBox.class);
+		verify(infoBoxManager).addInfoBox(captor.capture());
+		TimerTimer infoBox = (TimerTimer) captor.getValue();
+		assertEquals(GameTimer.WARD_OF_ARCEUUS_COOLDOWN, infoBox.getTimer());
+	}
+
+	@Test
+	public void testCorruptionCooldown()
+	{
+		when(timersConfig.showArceuusCooldown()).thenReturn(true);
+		when(client.getVar(any(Varbits.class))).thenReturn(0);
+		when(client.getVar(Varbits.CORRUPTION_COOLDOWN)).thenReturn(1);
+		timersPlugin.onVarbitChanged(new VarbitChanged());
+
+		ArgumentCaptor<InfoBox> captor = ArgumentCaptor.forClass(InfoBox.class);
+		verify(infoBoxManager).addInfoBox(captor.capture());
+		TimerTimer infoBox = (TimerTimer) captor.getValue();
+		assertEquals(GameTimer.CORRUPTION_COOLDOWN, infoBox.getTimer());
+	}
+
+	@Test
+	public void testShadowVail()
+	{
+		when(timersConfig.showArceuus()).thenReturn(true);
+		when(client.getRealSkillLevel(Skill.MAGIC)).thenReturn(57);
+
+		ChatMessage chatMessage = new ChatMessage(null, ChatMessageType.GAMEMESSAGE, "", "<col=6800bf>Your thieving abilities have been enhanced.</col>", "", 0);
+		timersPlugin.onChatMessage(chatMessage);
+
+		ArgumentCaptor<InfoBox> captor = ArgumentCaptor.forClass(InfoBox.class);
+		verify(infoBoxManager).addInfoBox(captor.capture());
+		TimerTimer infoBox = (TimerTimer) captor.getValue();
+		assertEquals(GameTimer.SHADOW_VEIL, infoBox.getTimer());
+	}
+
+	@Test
+	public void testShadowVailCooldown()
+	{
+		when(timersConfig.showArceuusCooldown()).thenReturn(true);
+
+		ChatMessage chatMessage = new ChatMessage(null, ChatMessageType.GAMEMESSAGE, "", "<col=6800bf>Your thieving abilities have been enhanced.</col>", "", 0);
+		timersPlugin.onChatMessage(chatMessage);
+
+		ArgumentCaptor<InfoBox> captor = ArgumentCaptor.forClass(InfoBox.class);
+		verify(infoBoxManager).addInfoBox(captor.capture());
+		TimerTimer infoBox = (TimerTimer) captor.getValue();
+		assertEquals(GameTimer.SHADOW_VEIL_COOLDOWN, infoBox.getTimer());
+	}
+
+	@Test
+	public void testThrall()
+	{
+		when(timersConfig.showArceuus()).thenReturn(true);
+		when(client.getRealSkillLevel(Skill.MAGIC)).thenReturn(50);
+
+		ChatMessage chatMessage = new ChatMessage(null, ChatMessageType.GAMEMESSAGE, "", "<col=ef0083>You resurrect a greater zombified thrall.</col>", "", 0);
+		timersPlugin.onChatMessage(chatMessage);
+
+		ArgumentCaptor<InfoBox> ibcaptor = ArgumentCaptor.forClass(InfoBox.class);
+		verify(infoBoxManager).addInfoBox(ibcaptor.capture());
+		TimerTimer infoBox = (TimerTimer) ibcaptor.getValue();
+		assertEquals(GameTimer.RESURRECT_THRALL, infoBox.getTimer());
+	}
+
+	@Test
+	public void testThrallCooldown()
+	{
+		when(timersConfig.showArceuusCooldown()).thenReturn(true);
+
+		ChatMessage chatMessage = new ChatMessage(null, ChatMessageType.GAMEMESSAGE, "", "<col=ef0083>You resurrect a greater zombified thrall.</col>", "", 0);
+		timersPlugin.onChatMessage(chatMessage);
+
+		ArgumentCaptor<InfoBox> ibcaptor = ArgumentCaptor.forClass(InfoBox.class);
+		verify(infoBoxManager).addInfoBox(ibcaptor.capture());
+		TimerTimer infoBox = (TimerTimer) ibcaptor.getValue();
+		assertEquals(GameTimer.RESURRECT_THRALL_COOLDOWN, infoBox.getTimer());
+	}
+
+	@Test
+	public void testThrallEnd()
+	{
+		when(timersConfig.showArceuus()).thenReturn(true);
+		when(client.getRealSkillLevel(Skill.MAGIC)).thenReturn(50);
+
+		ChatMessage chatMessage = new ChatMessage(null, ChatMessageType.GAMEMESSAGE, "", "<col=ef0083>Your greater zombified thrall returns to the grave.</col>", "", 0);
+		timersPlugin.onChatMessage(chatMessage);
+
+		verify(infoBoxManager).removeIf(any());
+	}
+	// endregion
 
 	@Test
 	public void testImbuedHeartBoost()


### PR DESCRIPTION
Arceuus spells have two different timers: the duration of the effect, and the cooldown before they can be cast again. There are 5 types of spells (all 9 thrall spells share the same timers):
* Shadow Veil
* Ward of Arceuus
* Death Charge
* Thrall spells
* Corruption (cooldown)

How Ward of Arceuus looks with both options enabled:
![image](https://user-images.githubusercontent.com/2979691/122372185-61370700-cf58-11eb-94d9-a0175c9c29b0.png)

SpriteID also had a lot of bit-rot with the old arceuus spells