### PR TITLE
timers: make thrall timer use boosted magic level

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersPlugin.java
@@ -711,7 +711,7 @@ public class TimersPlugin extends Plugin
 			}
 			else if (message.contains(RESURRECT_THRALL_MESSAGE_START) && message.endsWith(RESURRECT_THRALL_MESSAGE_END))
 			{
-				createGameTimer(RESURRECT_THRALL, duration);
+				createGameTimer(RESURRECT_THRALL, Duration.of(client.getBoostedSkillLevel(Skill.MAGIC), RSTimeUnit.GAME_TICKS));
 			}
 			else if (message.contains(RESURRECT_THRALL_DISAPPEAR_MESSAGE_START) && message.endsWith(RESURRECT_THRALL_DISAPPEAR_MESSAGE_END))
 			{

--- a/runelite-client/src/test/java/net/runelite/client/plugins/timers/TimersPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/timers/TimersPluginTest.java
@@ -503,7 +503,7 @@ public class TimersPluginTest
 	public void testThrall()
 	{
 		when(timersConfig.showArceuus()).thenReturn(true);
-		when(client.getRealSkillLevel(Skill.MAGIC)).thenReturn(50);
+		when(client.getBoostedSkillLevel(Skill.MAGIC)).thenReturn(60);
 
 		ChatMessage chatMessage = new ChatMessage(null, ChatMessageType.GAMEMESSAGE, "", "<col=ef0083>You resurrect a greater zombified thrall.</col>", "", 0);
 		timersPlugin.onChatMessage(chatMessage);
@@ -512,6 +512,7 @@ public class TimersPluginTest
 		verify(infoBoxManager).addInfoBox(ibcaptor.capture());
 		TimerTimer infoBox = (TimerTimer) ibcaptor.getValue();
 		assertEquals(GameTimer.RESURRECT_THRALL, infoBox.getTimer());
+		assertEquals(Duration.of(60, RSTimeUnit.GAME_TICKS), infoBox.getDuration());
 	}
 
 	@Test


### PR DESCRIPTION
turns out that thrall spells are seemingly the only arceuus spell with a
magic-level based duration that uses the boosted level, at least out of
the ones we have timers for