### PR TITLE
gpu: display device and driver being used during plugin startup

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuPlugin.java
@@ -328,6 +328,24 @@ public class GpuPlugin extends Plugin implements DrawCallbacks
 
 				invokeOnMainThread(() ->
 				{
+					try
+					{
+						// Get and display the device and driver used by the GPU plugin
+						GLDrawable dummyDrawable = GLDrawableFactory.getFactory(GLProfile.getDefault())
+							.createDummyDrawable(GLProfile.getDefaultDevice(), true, new GLCapabilities(GLProfile.getDefault()), null);
+						dummyDrawable.setRealized(true);
+						GLContext versionContext = dummyDrawable.createContext(null);
+						versionContext.makeCurrent();
+						GL versionGL = versionContext.getGL();
+						log.info("Using device: {}", versionGL.glGetString(GL.GL_RENDERER));
+						log.info("Using driver: {}", versionGL.glGetString(GL.GL_VERSION));
+						versionContext.destroy();
+					}
+					catch (Exception ex)
+					{
+						log.warn("error checking device and driver version", ex);
+					}
+
 					GLProfile glProfile = GLProfile.get(GLProfile.GL4);
 
 					GLCapabilities glCaps = new GLCapabilities(glProfile);


### PR DESCRIPTION
Currently it's not easy to tell exactly what GPU is being used by the plugin in multi-GPU systems. This becomes a problem when the dGPU decides to not do any work, and forces the iGPU to do GPU rendering. Whenever someone comes into the support channel with performance issues with the GPU plugin, we just have to guess whether it's actually a real performance problem, or if it's just on the iGPU that has no/bad drivers. This change should help with that.

Since it uses the GPU's default profile, it shouldn't have any compatibility issues as long as the GPU isn't from the 90s, and it will always run before it would fail to get an OpenGL 4 profile (tested that this happens on my i5 2nd gen craptop)

This may also help to narrow down potential driver-based issues, since `GL_VERSION` spits out the driver version.

Along with the help to those of us who provide support, it gives a way for users to tell if they've set up their GPU selection correctly; if I pass `DRI_PRIME=1` to the program, I don't actually know if it's using my dGPU without enabling debug and trawling through the thousands of lines that spits out.

I have tested this on the following systems:
* Main Linux computer (RX 580, no iGPU)
* Windows Craptop (i5 2nd gen, no dGPU, doesn't have OpenGL 4 profile)
* Linux Gamning laptop (Ryzen 5 4th gen with Renoir iGPU, RX 5600M dGPU)
* QEMU/KVM Windows 10 VM (no GPU passthrough, actually gives driver info before failing to load OpenGL 4 profile)
* GF's Linux computer (RX 6600, no iGPU)

Extra testing:
* valid Intel iGPU on Mac (Thanks Gamma)
* Nvidia 3060 (Thanks Gamma)
* Intel iGPU & Nvidia dGPU (Thanks Hexagon & Pharros)

Would be nice to have someone test the following, but it's probably not needed:

* Intel iGPU & AMD dGPU
* no iGPU & Nvidia dGPU

Either way, I'm confident that if it can load the libraries, it will log these lines.