### PR TITLE
xp tracker: show TTG instead of TTL when a goal has been set

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpPanelLabel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpPanelLabel.java
@@ -33,7 +33,7 @@ import net.runelite.client.util.QuantityFormatter;
 @AllArgsConstructor
 public enum XpPanelLabel
 {
-	TIME_TO_LEVEL("TTL", XpSnapshotSingle::getTimeTillGoalShort),
+	TIME_TO_LEVEL("", XpSnapshotSingle::getTimeTillGoalShort),
 
 	XP_GAINED("XP Gained", snap -> format(snap.getXpGainedInSession())),
 	XP_HOUR("XP/hr", snap -> format(snap.getXpPerHour())),
@@ -55,6 +55,11 @@ public enum XpPanelLabel
 	 */
 	public String getActionKey(XpSnapshotSingle snapshot)
 	{
+		if (this == TIME_TO_LEVEL)
+		{
+			return snapshot.isHasGoal() ? "TTG" : "TTL";
+		}
+
 		String actionKey = key;
 		if (snapshot.getActionType() == XpActionType.ACTOR_HEALTH)
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpSnapshotSingle.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpSnapshotSingle.java
@@ -46,4 +46,5 @@ class XpSnapshotSingle
 	private String timeTillGoal;
 	private String timeTillGoalHours;
 	private String timeTillGoalShort;
+	private boolean hasGoal;
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpStateSingle.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpStateSingle.java
@@ -61,6 +61,8 @@ class XpStateSingle
 	private int startLevelExp = 0;
 	private int endLevelExp = 0;
 
+	private boolean hasGoal = false;
+
 	XpStateSingle(Skill skill, long startXp)
 	{
 		this.skill = skill;
@@ -294,6 +296,8 @@ class XpStateSingle
 			{
 				endLevelExp = goalEndXp;
 			}
+
+			hasGoal = goalEndXp != -1;
 		}
 
 		return true;
@@ -327,6 +331,7 @@ class XpStateSingle
 			.timeTillGoalShort(getTimeTillLevel(XpGoalTimeType.SHORT))
 			.startGoalXp(startLevelExp)
 			.endGoalXp(endLevelExp)
+			.hasGoal(hasGoal)
 			.build();
 	}
 }


### PR DESCRIPTION
A small change to show `TTG` for "Time to Goal" when a skill has a goal set.