### PR TITLE
Fixes mta alchemy room widgets ids.

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/mta/alchemy/AlchemyRoom.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/mta/alchemy/AlchemyRoom.java
@@ -79,8 +79,8 @@ public class AlchemyRoom extends MTARoom
 
 	private static final int IMAGE_Z_OFFSET = 150;
 	private static final int NUM_CUPBOARDS = 8;
-	private static final int INFO_ITEM_START = 8;
-	private static final int INFO_POINT_START = 13;
+	private static final int INFO_ITEM_START = 7;
+	private static final int INFO_POINT_START = 12;
 	private static final int INFO_LENGTH = 5;
 	private static final int BEST_POINTS = 30;
 


### PR DESCRIPTION
the plugin used to use 8-12 for names and 13-17 for points, but it should actually use 7-11 and 12-16. This fixes the issue of leather boots not being highlighted when they are the highest value item (as they use ids 7 and 12), as well as the cupboard not resetting when leather boots become the highest valued item.

Fixes #13787