### PR TITLE
widgets: add WidgetEventManager

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/game/WidgetEventManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/game/WidgetEventManager.java
@@ -1,0 +1,280 @@
+/*
+ * Copyright (c) 2021 LlemonDuck
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package net.runelite.client.game;
+
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Consumer;
+import javax.inject.Singleton;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.ScriptEvent;
+import net.runelite.api.widgets.JavaScriptCallback;
+import net.runelite.api.widgets.Widget;
+
+@Singleton
+@Slf4j
+@SuppressWarnings("unused")
+public class WidgetEventManager
+{
+
+	private static class MultiCallbackDelegator implements JavaScriptCallback
+	{
+		private final Set<JavaScriptCallback> delegates = new LinkedHashSet<>();
+
+		public void add(JavaScriptCallback callback)
+		{
+			delegates.add(callback);
+		}
+
+		public void remove(JavaScriptCallback callback)
+		{
+			delegates.remove(callback);
+		}
+
+		@Override
+		public void run(ScriptEvent event)
+		{
+			delegates.forEach(callback ->
+			{
+				try
+				{
+					callback.run(event);
+				}
+				catch (Exception e)
+				{
+					log.error("Unhandled error during widget callback", e);
+				}
+			});
+		}
+	}
+
+	private final Map<Integer, MultiCallbackDelegator> clickListeners = new HashMap<>();
+	private final Map<Integer, MultiCallbackDelegator> dialogAbortListeners = new HashMap<>();
+	private final Map<Integer, MultiCallbackDelegator> dragCompleteListeners = new HashMap<>();
+	private final Map<Integer, MultiCallbackDelegator> dragListeners = new HashMap<>();
+	private final Map<Integer, MultiCallbackDelegator> holdListeners = new HashMap<>();
+	private final Map<Integer, MultiCallbackDelegator> keyListeners = new HashMap<>();
+	private final Map<Integer, MultiCallbackDelegator> mouseLeaveListeners = new HashMap<>();
+	private final Map<Integer, MultiCallbackDelegator> mouseOverListeners = new HashMap<>();
+	private final Map<Integer, MultiCallbackDelegator> mouseRepeatListeners = new HashMap<>();
+	private final Map<Integer, MultiCallbackDelegator> opListeners = new HashMap<>();
+	private final Map<Integer, MultiCallbackDelegator> releaseListeners = new HashMap<>();
+	private final Map<Integer, MultiCallbackDelegator> targetEnterListeners = new HashMap<>();
+	private final Map<Integer, MultiCallbackDelegator> targetLeaveListeners = new HashMap<>();
+	private final Map<Integer, MultiCallbackDelegator> timerListeners = new HashMap<>();
+	private final Map<Integer, MultiCallbackDelegator> varTransmitListeners = new HashMap<>();
+
+	private MultiCallbackDelegator createDelegator(Consumer<Object[]> eventSetter)
+	{
+		MultiCallbackDelegator[] newDelegator = {new MultiCallbackDelegator()};
+		eventSetter.accept(newDelegator);
+		return newDelegator[0];
+	}
+
+	public void addOnClickListener(@NonNull Widget w, @NonNull JavaScriptCallback callback)
+	{
+		clickListeners.computeIfAbsent(w.getId(), id -> createDelegator(w::setOnClickListener))
+				.add(callback);
+	}
+
+	public void addOnDialogAbortListener(@NonNull Widget w, @NonNull JavaScriptCallback callback)
+	{
+		dialogAbortListeners.computeIfAbsent(w.getId(), id -> createDelegator(w::setOnDialogAbortListener))
+				.add(callback);
+	}
+
+	public void addOnDragCompleteListener(@NonNull Widget w, @NonNull JavaScriptCallback callback)
+	{
+		dragCompleteListeners.computeIfAbsent(w.getId(), id -> createDelegator(w::setOnDragCompleteListener))
+				.add(callback);
+	}
+
+	public void addOnDragListener(@NonNull Widget w, @NonNull JavaScriptCallback callback)
+	{
+		dragListeners.computeIfAbsent(w.getId(), id -> createDelegator(w::setOnDragListener))
+				.add(callback);
+	}
+
+	public void addOnHoldListener(@NonNull Widget w, @NonNull JavaScriptCallback callback)
+	{
+		holdListeners.computeIfAbsent(w.getId(), id -> createDelegator(w::setOnHoldListener))
+				.add(callback);
+	}
+
+	public void addOnKeyListener(@NonNull Widget w, @NonNull JavaScriptCallback callback)
+	{
+		keyListeners.computeIfAbsent(w.getId(), id -> createDelegator(w::setOnKeyListener))
+				.add(callback);
+	}
+
+	public void addOnMouseLeaveListener(@NonNull Widget w, @NonNull JavaScriptCallback callback)
+	{
+		mouseLeaveListeners.computeIfAbsent(w.getId(), id -> createDelegator(w::setOnMouseLeaveListener))
+				.add(callback);
+	}
+
+	public void addOnMouseOverListener(@NonNull Widget w, @NonNull JavaScriptCallback callback)
+	{
+		mouseOverListeners.computeIfAbsent(w.getId(), id -> createDelegator(w::setOnMouseOverListener))
+				.add(callback);
+	}
+
+	public void addOnMouseRepeatListener(@NonNull Widget w, @NonNull JavaScriptCallback callback)
+	{
+		mouseRepeatListeners.computeIfAbsent(w.getId(), id -> createDelegator(w::setOnMouseRepeatListener))
+				.add(callback);
+	}
+
+	public void addOnOpListener(@NonNull Widget w, @NonNull JavaScriptCallback callback)
+	{
+		opListeners.computeIfAbsent(w.getId(), id -> createDelegator(w::setOnOpListener))
+				.add(callback);
+	}
+
+	public void addOnReleaseListener(@NonNull Widget w, @NonNull JavaScriptCallback callback)
+	{
+		releaseListeners.computeIfAbsent(w.getId(), id -> createDelegator(w::setOnReleaseListener))
+				.add(callback);
+	}
+
+	public void addOnTargetEnterListener(@NonNull Widget w, @NonNull JavaScriptCallback callback)
+	{
+		targetEnterListeners.computeIfAbsent(w.getId(), id -> createDelegator(w::setOnTargetEnterListener))
+				.add(callback);
+	}
+
+	public void addOnTargetLeaveListener(@NonNull Widget w, @NonNull JavaScriptCallback callback)
+	{
+		targetLeaveListeners.computeIfAbsent(w.getId(), id -> createDelegator(w::setOnTargetLeaveListener))
+				.add(callback);
+	}
+
+	public void addOnTimerListener(@NonNull Widget w, @NonNull JavaScriptCallback callback)
+	{
+		timerListeners.computeIfAbsent(w.getId(), id -> createDelegator(w::setOnTimerListener))
+				.add(callback);
+	}
+
+	public void addOnVarTransmitListener(@NonNull Widget w, @NonNull JavaScriptCallback callback)
+	{
+		varTransmitListeners.computeIfAbsent(w.getId(), id -> createDelegator(w::setOnVarTransmitListener))
+				.add(callback);
+	}
+
+	public void removeOnClickListener(@NonNull Widget w, @NonNull JavaScriptCallback callback)
+	{
+		clickListeners.computeIfAbsent(w.getId(), id -> createDelegator(w::setOnClickListener))
+				.remove(callback);
+	}
+
+	public void removeOnDialogAbortListener(@NonNull Widget w, @NonNull JavaScriptCallback callback)
+	{
+		dialogAbortListeners.computeIfAbsent(w.getId(), id -> createDelegator(w::setOnDialogAbortListener))
+				.remove(callback);
+	}
+
+	public void removeOnDragCompleteListener(@NonNull Widget w, @NonNull JavaScriptCallback callback)
+	{
+		dragCompleteListeners.computeIfAbsent(w.getId(), id -> createDelegator(w::setOnDragCompleteListener))
+				.remove(callback);
+	}
+
+	public void removeOnDragListener(@NonNull Widget w, @NonNull JavaScriptCallback callback)
+	{
+		dragListeners.computeIfAbsent(w.getId(), id -> createDelegator(w::setOnDragListener))
+				.remove(callback);
+	}
+
+	public void removeOnHoldListener(@NonNull Widget w, @NonNull JavaScriptCallback callback)
+	{
+		holdListeners.computeIfAbsent(w.getId(), id -> createDelegator(w::setOnHoldListener))
+				.remove(callback);
+	}
+
+	public void removeOnKeyListener(@NonNull Widget w, @NonNull JavaScriptCallback callback)
+	{
+		keyListeners.computeIfAbsent(w.getId(), id -> createDelegator(w::setOnKeyListener))
+				.remove(callback);
+	}
+
+	public void removeOnMouseLeaveListener(@NonNull Widget w, @NonNull JavaScriptCallback callback)
+	{
+		mouseLeaveListeners.computeIfAbsent(w.getId(), id -> createDelegator(w::setOnMouseLeaveListener))
+				.remove(callback);
+	}
+
+	public void removeOnMouseOverListener(@NonNull Widget w, @NonNull JavaScriptCallback callback)
+	{
+		mouseOverListeners.computeIfAbsent(w.getId(), id -> createDelegator(w::setOnMouseOverListener))
+				.remove(callback);
+	}
+
+	public void removeOnMouseRepeatListener(@NonNull Widget w, @NonNull JavaScriptCallback callback)
+	{
+		mouseRepeatListeners.computeIfAbsent(w.getId(), id -> createDelegator(w::setOnMouseRepeatListener))
+				.remove(callback);
+	}
+
+	public void removeOnOpListener(@NonNull Widget w, @NonNull JavaScriptCallback callback)
+	{
+		opListeners.computeIfAbsent(w.getId(), id -> createDelegator(w::setOnOpListener))
+				.remove(callback);
+	}
+
+	public void removeOnReleaseListener(@NonNull Widget w, @NonNull JavaScriptCallback callback)
+	{
+		releaseListeners.computeIfAbsent(w.getId(), id -> createDelegator(w::setOnReleaseListener))
+				.remove(callback);
+	}
+
+	public void removeOnTargetEnterListener(@NonNull Widget w, @NonNull JavaScriptCallback callback)
+	{
+		targetEnterListeners.computeIfAbsent(w.getId(), id -> createDelegator(w::setOnTargetEnterListener))
+				.remove(callback);
+	}
+
+	public void removeOnTargetLeaveListener(@NonNull Widget w, @NonNull JavaScriptCallback callback)
+	{
+		targetLeaveListeners.computeIfAbsent(w.getId(), id -> createDelegator(w::setOnTargetLeaveListener))
+				.remove(callback);
+	}
+
+	public void removeOnTimerListener(@NonNull Widget w, @NonNull JavaScriptCallback callback)
+	{
+		timerListeners.computeIfAbsent(w.getId(), id -> createDelegator(w::setOnTimerListener))
+				.remove(callback);
+	}
+
+	public void removeOnVarTransmitListener(@NonNull Widget w, @NonNull JavaScriptCallback callback)
+	{
+		varTransmitListeners.computeIfAbsent(w.getId(), id -> createDelegator(w::setOnVarTransmitListener))
+				.remove(callback);
+	}
+
+}

--- a/runelite-client/src/test/java/net/runelite/client/game/WidgetEventManagerTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/game/WidgetEventManagerTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2021 LlemonDuck
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package net.runelite.client.game;
+
+import net.runelite.api.ScriptEvent;
+import net.runelite.api.widgets.JavaScriptCallback;
+import net.runelite.api.widgets.Widget;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+@RunWith(MockitoJUnitRunner.class)
+public class WidgetEventManagerTest
+{
+
+	@Mock
+	Widget widget;
+
+	@Captor
+	ArgumentCaptor<JavaScriptCallback> widgetListenerCaptor;
+
+	@Mock
+	JavaScriptCallback callback1;
+
+	@Mock
+	JavaScriptCallback callback2;
+
+	@Mock
+	ScriptEvent event;
+
+	private WidgetEventManager widgetEventManager;
+
+	@Before
+	public void init()
+	{
+		widgetEventManager = new WidgetEventManager();
+		initMocks(this);
+	}
+
+	@Test
+	public void shouldInvokeAllListenersOnAnEvent()
+	{
+		// given two listeners
+		widgetEventManager.addOnClickListener(widget, callback1);
+		widgetEventManager.addOnClickListener(widget, callback2);
+
+		// when event is fired
+		verify(widget).setOnClickListener(widgetListenerCaptor.capture());
+		JavaScriptCallback widgetListener = widgetListenerCaptor.getValue();
+		widgetListener.run(event);
+
+		// then both listeners should be invoked
+		verify(callback1, times(1)).run(event);
+		verify(callback2, times(1)).run(event);
+	}
+
+	@Test
+	public void shouldNotThrowWhenListenersThrow()
+	{
+		// given two listeners that throw
+		widgetEventManager.addOnClickListener(widget, callback1);
+		widgetEventManager.addOnClickListener(widget, callback2);
+		doThrow(RuntimeException.class).when(callback1).run(event);
+		doThrow(RuntimeException.class).when(callback2).run(event);
+
+		// when event is fired
+		verify(widget).setOnClickListener(widgetListenerCaptor.capture());
+		JavaScriptCallback widgetListener = widgetListenerCaptor.getValue();
+		widgetListener.run(event);
+
+		// then both listeners should be invoked
+		verify(callback1, times(1)).run(event);
+		verify(callback2, times(1)).run(event);
+	}
+
+	@Test
+	public void shouldNotCallRemovedListeners()
+	{
+		// given a listener that is removed
+		widgetEventManager.addOnClickListener(widget, callback1);
+		widgetEventManager.removeOnClickListener(widget, callback1);
+
+		// when event is fired
+		verify(widget).setOnClickListener(widgetListenerCaptor.capture());
+		JavaScriptCallback widgetListener = widgetListenerCaptor.getValue();
+		widgetListener.run(event);
+
+		// then the listener should not be invoked
+		verify(callback1, never()).run(event);
+	}
+
+	@Test
+	public void shouldNotInvokeListenersOnOtherEvents()
+	{
+		// given listeners on different events
+		widgetEventManager.addOnClickListener(widget, callback1);
+		widgetEventManager.addOnDialogAbortListener(widget, callback2);
+
+		// when event is fired
+		verify(widget).setOnClickListener(widgetListenerCaptor.capture());
+		JavaScriptCallback widgetListener = widgetListenerCaptor.getValue();
+		widgetListener.run(event);
+
+		// then only the listener on the click event should be invoked
+		verify(callback1, times(1)).run(event);
+		verify(callback2, never()).run(event);
+	}
+
+}


### PR DESCRIPTION
The WidgetEventManager enables multiple event listeners to be listening to the same event, without overwriting each other. The underlying widgets only allow a single listener to be registered, so this manager registers itself, then delegates the events to sub-listeners.

I did not update existing call-sites to use this manager; that can be done on a when-needed basis.

The reason for this addition is to resolve an issue I ran into with my hub plugin ToG Indicator, which conflicts with Skills Progress Bars when both are installed and enabled, by attempting to listen to the same widget events. If this PR is merged, I will update ToG Indicators to use this delegator, and will reach out to the maintainer of Skills Progress Bars to do the same.