### PR TITLE
screenshots plugin: Add feature to automatically take screenshots for high value hitsplats and escapes at low hp.

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotConfig.java
@@ -275,4 +275,40 @@ public interface ScreenshotConfig extends Config
 	{
 		return Keybind.NOT_SET;
 	}
+
+	@ConfigItem(
+		keyName = "takeHitsplatShots",
+		name = "Screenshot High Hitting Hitsplats",
+		description = "Configures whether or not screenshots are automatically taken when you hit a high damage hitsplat.",
+		position = 20,
+		section = whatSection
+	)
+	default boolean takeHitsplatShots() { return false; }
+
+	@ConfigItem(
+		keyName = "hitsplatMin",
+		name = "Hitsplat Minimum",
+		description = "The minimum value to save screenshots of hitsplats.",
+		position = 21,
+		section = whatSection
+	)
+	default int hitsplatMin() {return 50; }
+
+	@ConfigItem(
+		keyName = "takeEscapeShots",
+		name = "Screenshot when escaping",
+		description = "Configures whether or not screenshots are automatically taken when you click a teleport tab with low hp.",
+		position = 22,
+		section = whatSection
+	)
+	default boolean takeEscapeShots() { return false; }
+
+	@ConfigItem(
+		keyName = "escapeMax",
+		name = "Escape Max HP",
+		description = "The maximum HP value to save screenshots when teleporting.",
+		position = 23,
+		section = whatSection
+	)
+	default int escapeMax() { return 5; }
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotConfig.java
@@ -283,7 +283,10 @@ public interface ScreenshotConfig extends Config
 		position = 20,
 		section = whatSection
 	)
-	default boolean takeHitsplatShots() { return false; }
+	default boolean takeHitsplatShots()
+	{
+		return false;
+	}
 
 	@ConfigItem(
 		keyName = "hitsplatMin",
@@ -292,7 +295,10 @@ public interface ScreenshotConfig extends Config
 		position = 21,
 		section = whatSection
 	)
-	default int hitsplatMin() {return 50; }
+	default int hitsplatMin()
+	{
+		return 50;
+	}
 
 	@ConfigItem(
 		keyName = "takeEscapeShots",
@@ -301,7 +307,10 @@ public interface ScreenshotConfig extends Config
 		position = 22,
 		section = whatSection
 	)
-	default boolean takeEscapeShots() { return false; }
+	default boolean takeEscapeShots()
+	{
+		return false;
+	}
 
 	@ConfigItem(
 		keyName = "escapeMax",
@@ -310,5 +319,8 @@ public interface ScreenshotConfig extends Config
 		position = 23,
 		section = whatSection
 	)
-	default int escapeMax() { return 5; }
+	default int escapeMax()
+	{
+		return 4;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
@@ -317,17 +317,21 @@ public class ScreenshotPlugin extends Plugin
 	}
 
 	@Subscribe
-	public void onHitsplatApplied(HitsplatApplied hitsplatApplied) {
-		if (config.takeHitsplatShots()) {
+	public void onHitsplatApplied(HitsplatApplied hitsplatApplied)
+	{
+		if (config.takeHitsplatShots())
+		{
 			Actor actor = hitsplatApplied.getActor();
 			if (!(actor instanceof NPC))
 			{
 				return;
 			}
 			Hitsplat hitsplat = hitsplatApplied.getHitsplat();
-			if (hitsplat.isMine()) {
+			if (hitsplat.isMine())
+			{
 				int number = hitsplat.getAmount();
-				if (number >= config.hitsplatMin()) {
+				if (number >= config.hitsplatMin())
+				{
 					String fileName = "Hitsplat " + number + " on " + actor.getName();
 					takeScreenshot(fileName, SD_HITSPLATS);
 				}
@@ -338,7 +342,8 @@ public class ScreenshotPlugin extends Plugin
 	@Subscribe
 	public void onMenuOptionClicked(final MenuOptionClicked menuOptionClicked)
 	{
-		if (config.takeEscapeShots()) {
+		if (config.takeEscapeShots())
+		{
 			String optionText = menuOptionClicked.getMenuOption();
 			if (optionText == null)
 			{


### PR DESCRIPTION
Add feature to automatically take a screenshot (if enabled) when dealing a high "hitsplat" of damage on opponent and above threshold.  Ex. Take a screenshot if you hit a NPC with a 50 or higher damage.

Add feature to automatically take a screenshot (if enabled) when clicking a teleport tablet and under a specified HP.  Ex.  Take a screenshot if you click a teleport tablet and you have 5 or less HP left.