### PR TITLE
xp tracker: fix intermediate markers not showing for xp based goal ends

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpInfoBox.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpInfoBox.java
@@ -278,7 +278,7 @@ class XpInfoBox extends JPanel
 			{
 				final List<Integer> positions = new ArrayList<>();
 
-				for (int level = xpSnapshotSingle.getStartLevel() + 1; level < xpSnapshotSingle.getEndLevel(); level++)
+				for (int level = xpSnapshotSingle.getStartLevel() + 1; level <= xpSnapshotSingle.getEndLevel(); level++)
 				{
 					double relativeStartExperience = Experience.getXpForLevel(level) - xpSnapshotSingle.getStartGoalXp();
 					double relativeEndExperience = xpSnapshotSingle.getEndGoalXp() - xpSnapshotSingle.getStartGoalXp();


### PR DESCRIPTION
Closes #13764

Something to note is that this change does not cause a line to the drawn at the right edge of the box when using level-aligned goal ends, which is nice.