### PR TITLE
loottracker: Added the ability to split the group loot tracker by current session and aggregate data

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerBox.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerBox.java
@@ -411,7 +411,7 @@ class LootTrackerBox extends JPanel
 	{
 		title.setLayout(new BoxLayout(title, BoxLayout.X_AXIS));
 		title.setBorder(new EmptyBorder(5, 7, 5, 7));
-		title.setBackground(ColorScheme.DARKER_GRAY_COLOR.darker());
+		title.setBackground(ColorScheme.DARKER_GRAY_COLOR);
 
 		JLabel titleLabel = new JLabel();
 		titleLabel.setText(titleText);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerConfig.java
@@ -148,4 +148,14 @@ public interface LootTrackerConfig extends Config
 	{
 		return true;
 	}
+
+	@ConfigItem(
+		keyName = "splitLootGroup",
+		name = "Split group loot section",
+		description = "Split the group loot tracker by current session and aggregate data."
+	)
+	default boolean splitGroupLoot()
+	{
+		return false;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
@@ -375,6 +375,11 @@ public class LootTrackerPlugin extends Plugin
 			ignoredItems = Text.fromCSV(config.getIgnoredItems());
 			ignoredEvents = Text.fromCSV(config.getIgnoredEvents());
 			SwingUtilities.invokeLater(panel::updateIgnoredRecords);
+
+			if (event.getKey().equals("splitLootGroup"))
+			{
+				panel.rebuild();
+			}
 		}
 	}
 

--- a/runelite-client/src/test/java/net/runelite/client/plugins/loottracker/LootTrackerBoxTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/loottracker/LootTrackerBoxTest.java
@@ -29,15 +29,21 @@ import net.runelite.api.ItemID;
 import net.runelite.client.game.ItemManager;
 import net.runelite.http.api.loottracker.LootRecordType;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import org.junit.Before;
 import org.junit.Test;
 import static org.mockito.Mockito.mock;
 
 public class LootTrackerBoxTest
 {
-	@Test
-	public void testAddKill()
+	private LootTrackerBox lootTrackerBox;
+	private LootTrackerItem[] items;
+	private LootTrackerRecord lootTrackerRecord;
+
+	@Before
+	public void before()
 	{
-		LootTrackerBox lootTrackerBox = new LootTrackerBox(
+		lootTrackerBox = new LootTrackerBox(
 			mock(ItemManager.class),
 			"Theatre of Blood",
 			LootRecordType.EVENT,
@@ -46,26 +52,48 @@ public class LootTrackerBoxTest
 			LootTrackerPriceType.GRAND_EXCHANGE,
 			false,
 			null, null,
+			false,
+			false,
 			false);
 
-		LootTrackerItem[] items = new LootTrackerItem[]{
+		items = new LootTrackerItem[]{
 			new LootTrackerItem(ItemID.CLUE_SCROLL_MEDIUM, "Clue scroll (medium)", 1, 0, 0, false),
 			new LootTrackerItem(ItemID.CLUE_SCROLL_MEDIUM_3602, "Clue scroll (medium)", 1, 0, 0, false),
 			new LootTrackerItem(ItemID.GRACEFUL_HOOD_13579, "Graceful hood", 1, 0, 0, false),
 		};
-		LootTrackerRecord lootTrackerRecord = new LootTrackerRecord(
+
+		lootTrackerRecord = new LootTrackerRecord(
 			"Theatre of Blood",
 			null,
 			LootRecordType.EVENT,
 			items,
 			42
 		);
+	}
 
-		lootTrackerBox.addKill(lootTrackerRecord);
+	@Test
+	public void testAddSessionKill()
+	{
+
+		lootTrackerBox.addKill(lootTrackerRecord, true);
 
 		assertEquals(Arrays.asList(
 			new LootTrackerItem(ItemID.CLUE_SCROLL_MEDIUM, "Clue scroll (medium)", 2, 0, 0, false),
 			new LootTrackerItem(ItemID.GRACEFUL_HOOD_13579, "Graceful hood", 1, 0, 0, false)
-		), lootTrackerBox.getItems());
+		), lootTrackerBox.getSessionItems());
+		assertTrue(lootTrackerBox.getAggregateItems().isEmpty());
+	}
+
+	@Test
+	public void testAddAggregateKill()
+	{
+
+		lootTrackerBox.addKill(lootTrackerRecord, false);
+
+		assertTrue(lootTrackerBox.getSessionItems().isEmpty());
+		assertEquals(Arrays.asList(
+			new LootTrackerItem(ItemID.CLUE_SCROLL_MEDIUM, "Clue scroll (medium)", 2, 0, 0, false),
+			new LootTrackerItem(ItemID.GRACEFUL_HOOD_13579, "Graceful hood", 1, 0, 0, false)
+		), lootTrackerBox.getAggregateItems());
 	}
 }


### PR DESCRIPTION
This PR adds the config option "Split group loot section" in the loot tracker plugin (default false).
When enabled, it allows users to quickly see the total amount of loot obtained vs the previous aggregate data. Example: 

![image](https://user-images.githubusercontent.com/33374903/124395034-eb5cca80-dccf-11eb-8bdd-14a3e859c1d7.png)

New menu option:
![image](https://user-images.githubusercontent.com/33374903/124395146-71791100-dcd0-11eb-843d-0e2eedb5e40a.png)



While the "Show each kill separately view" does allow a user see what has been obtained this session it's hard to get the total value gained as the number of kills go up.

All comments/feedback/suggestion welcome.