### PR TITLE
Fix restored window size when client is fullscreen

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
@@ -41,6 +41,8 @@ import java.awt.LayoutManager;
 import java.awt.Rectangle;
 import java.awt.Toolkit;
 import java.awt.TrayIcon;
+import java.awt.event.ComponentAdapter;
+import java.awt.event.ComponentEvent;
 import java.awt.event.MouseEvent;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
@@ -357,6 +359,16 @@ public class ClientUI
 					{
 						shutdownClient();
 					}
+				}
+			});
+
+			frame.addComponentListener(new ComponentAdapter()
+			{
+				@Override
+				public void componentResized(ComponentEvent e)
+				{
+					// Manually call setSize to force the frame to respect it's minimum size after restore
+					frame.setSize(frame.getSize());
 				}
 			});
 

--- a/runelite-client/src/main/java/net/runelite/client/ui/ContainableFrame.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ContainableFrame.java
@@ -157,6 +157,7 @@ public class ContainableFrame extends JFrame
 	{
 		if (isFullScreen())
 		{
+			revalidateMinimumSize();
 			return;
 		}
 
@@ -215,12 +216,12 @@ public class ContainableFrame extends JFrame
 	 */
 	public void contractBy(final int value)
 	{
+		revalidateMinimumSize();
 		if (isFullScreen())
 		{
 			return;
 		}
 
-		revalidateMinimumSize();
 		final Rectangle screenBounds = getGraphicsConfiguration().getBounds();
 		final boolean wasCloseToLeftEdge = Math.abs(getX() - screenBounds.getX()) <= SCREEN_EDGE_CLOSE_DISTANCE;
 		int newWindowX = getX();


### PR DESCRIPTION
Fixes #2612 and related to #3574

Currently, when the plugin panel or sidebar is shown while the client is fullscreen, and the client is restored, the updated size of the client is not respected.

This pull request makes two changes to fix this issue. First, `revalidateMinimumSize()` is moved in the `expandBy()` and `contractBy()` functions to be called before the return path when the client is maximized. This should guarantee that the minimum size is still captured in all situations.

Second, the client size is manually set when the window is restored. When the window is restored, it's set back to it's size before it was maximized regardless of the minimum size, so the size has to be manually set. Since the `setSize()` function respects the frames minimum size, I just call `setSize()` with the frames current size and it works as desired.

Alternatively, the onResize listener could check for whether the frame state was previously maximized and is now not maximized, but the current approach seems a bit simpler. I'm not sure which one would necessarily be better.

Also, I'm not exactly sure if adding the component listener should be done in ClientUI or the ContainableFrame class, so I'd be interested in getting feedback there.