### PR TITLE
raids: screenshot overlay from client thread

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsPlugin.java
@@ -872,7 +872,7 @@ public class RaidsPlugin extends Plugin
 		@Override
 		public void hotkeyPressed()
 		{
-			screenshotScoutOverlay();
+			clientThread.invoke(RaidsPlugin.this::screenshotScoutOverlay);
 		}
 	};
 


### PR DESCRIPTION
With debug assertions on, the "Screenshot Scout Overlay" keybind sometimes fails for me with a stacktrace saying it should be run on the client thread (I couldn't get it to appear when I went back to try and grab it for this PR, but I will update this if I can get it again).

The offending call chain is `RaidsOverlay#render` -> `RaidsOverlay#shouldShowOverlay` -> `client#getVar`.

Moves the call to the client thread to prevent issues.