### PR TITLE
hiscore: Clicking hiscore links to website

### DIFF
--- a/http-api/src/main/java/net/runelite/http/api/hiscore/HiscoreEndpoint.java
+++ b/http-api/src/main/java/net/runelite/http/api/hiscore/HiscoreEndpoint.java
@@ -32,20 +32,50 @@ import okhttp3.HttpUrl;
 @Getter
 public enum HiscoreEndpoint
 {
-	NORMAL("Normal", "https://services.runescape.com/m=hiscore_oldschool/index_lite.ws"),
-	IRONMAN("Ironman", "https://services.runescape.com/m=hiscore_oldschool_ironman/index_lite.ws"),
-	HARDCORE_IRONMAN("Hardcore Ironman", "https://services.runescape.com/m=hiscore_oldschool_hardcore_ironman/index_lite.ws"),
-	ULTIMATE_IRONMAN("Ultimate Ironman", "https://services.runescape.com/m=hiscore_oldschool_ultimate/index_lite.ws"),
-	DEADMAN("Deadman", "https://services.runescape.com/m=hiscore_oldschool_deadman/index_lite.ws"),
-	LEAGUE("Leagues", "https://services.runescape.com/m=hiscore_oldschool_seasonal/index_lite.ws"),
-	TOURNAMENT("Tournament", "https://services.runescape.com/m=hiscore_oldschool_tournament/index_lite.ws");
+	NORMAL(
+			"Normal",
+			"https://services.runescape.com/m=hiscore_oldschool/index_lite.ws",
+			"https://secure.runescape.com/m=hiscore_oldschool/overall?"
+	),
+	IRONMAN(
+			"Ironman",
+			"https://services.runescape.com/m=hiscore_oldschool_ironman/index_lite.ws",
+			"https://secure.runescape.com/m=hiscore_oldschool_ironman/overall?"
+	),
+	HARDCORE_IRONMAN(
+			"Hardcore Ironman",
+			"https://services.runescape.com/m=hiscore_oldschool_hardcore_ironman/index_lite.ws",
+			"https://secure.runescape.com/m=hiscore_oldschool_hardcore_ironman/overall?"
+	),
+	ULTIMATE_IRONMAN(
+			"Ultimate Ironman",
+			"https://services.runescape.com/m=hiscore_oldschool_ultimate/index_lite.ws",
+			"https://secure.runescape.com/m=hiscore_oldschool_ultimate/overall?"
+	),
+	DEADMAN(
+			"Deadman",
+			"https://services.runescape.com/m=hiscore_oldschool_deadman/index_lite.ws",
+			"https://secure.runescape.com/m=hiscore_oldschool_deadman/overall?"
+	),
+	LEAGUE(
+			"Leagues",
+			"https://services.runescape.com/m=hiscore_oldschool_seasonal/index_lite.ws",
+			"https://secure.runescape.com/m=hiscore_oldschool_seasonal/overall?"
+	),
+	TOURNAMENT(
+			"Tournament",
+			"https://services.runescape.com/m=hiscore_oldschool_tournament/index_lite.ws",
+			"https://secure.runescape.com/m=hiscore_oldschool_tournament/overall?"
+	);
 
 	private final String name;
 	private final HttpUrl hiscoreURL;
+	private final HttpUrl hiscoreBasePageURL;
 
-	HiscoreEndpoint(String name, String hiscoreURL)
+	HiscoreEndpoint(String name, String hiscoreURL, String hiscoreBasePageURL)
 	{
 		this.name = name;
 		this.hiscoreURL = HttpUrl.parse(hiscoreURL);
+		this.hiscoreBasePageURL = HttpUrl.parse(hiscoreBasePageURL);
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/hiscore/HiscorePanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/hiscore/HiscorePanel.java
@@ -45,7 +45,9 @@ import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.swing.ImageIcon;
 import javax.swing.JLabel;
+import javax.swing.JMenuItem;
 import javax.swing.JPanel;
+import javax.swing.JPopupMenu;
 import javax.swing.SwingUtilities;
 import javax.swing.border.EmptyBorder;
 import lombok.extern.slf4j.Slf4j;
@@ -354,25 +356,59 @@ public class HiscorePanel extends PluginPanel
 		boolean totalLabel = skill == OVERALL || skill == null; //overall or combat
 		label.setIconTextGap(totalLabel ? 10 : 4);
 
-		// If skill is null, it's combat level
-		if (skill != null)
-		{
-			MouseAdapter hiscorePanelMouseListener = new MouseAdapter()
-			{
-				@Override
-				public void mouseReleased(MouseEvent e)
-				{
-					plugin.openHiscoreLink(skill, selectedEndPoint, currUsername);
-				}
-			};
-			label.addMouseListener(hiscorePanelMouseListener);
-		}
-
 		JPanel skillPanel = new JPanel();
 		skillPanel.setBackground(ColorScheme.DARKER_GRAY_COLOR);
 		skillPanel.setBorder(new EmptyBorder(2, 0, 2, 0));
 		skillLabels.put(skill, label);
 		skillPanel.add(label);
+
+		// If skill is null, it's combat level
+		if (skill != null)
+		{
+			final JPopupMenu popupMenu = new JPopupMenu();
+			popupMenu.setBorder(new EmptyBorder(5, 5, 5, 5));
+
+			if (skill == CLUE_SCROLL_ALL)
+			{
+				final JMenuItem allHiscore = new JMenuItem("Open " + skill.getName() + " Hiscores");
+				allHiscore.addActionListener(e -> plugin.openHiscoreLink(skill, selectedEndPoint, currUsername));
+
+				final JMenuItem beginnerHiscore = new JMenuItem("Open " + CLUE_SCROLL_BEGINNER.getName() + " Hiscores");
+				beginnerHiscore.addActionListener(e -> plugin.openHiscoreLink(CLUE_SCROLL_BEGINNER, selectedEndPoint, currUsername));
+
+				final JMenuItem easyHiscore = new JMenuItem("Open " + CLUE_SCROLL_EASY.getName() + " Hiscores");
+				easyHiscore.addActionListener(e -> plugin.openHiscoreLink(CLUE_SCROLL_EASY, selectedEndPoint, currUsername));
+
+				final JMenuItem mediumHiscore = new JMenuItem("Open " + CLUE_SCROLL_MEDIUM.getName() + " Hiscores");
+				mediumHiscore.addActionListener(e -> plugin.openHiscoreLink(CLUE_SCROLL_MEDIUM, selectedEndPoint, currUsername));
+
+				final JMenuItem hardHiscore = new JMenuItem("Open " + CLUE_SCROLL_HARD.getName() + " Hiscores");
+				hardHiscore.addActionListener(e -> plugin.openHiscoreLink(CLUE_SCROLL_HARD, selectedEndPoint, currUsername));
+
+				final JMenuItem eliteHiscore = new JMenuItem("Open " + CLUE_SCROLL_ELITE.getName() + " Hiscores");
+				eliteHiscore.addActionListener(e -> plugin.openHiscoreLink(CLUE_SCROLL_ELITE, selectedEndPoint, currUsername));
+
+				final JMenuItem masterHiscore = new JMenuItem("Open " + CLUE_SCROLL_MASTER.getName() + " Hiscores");
+				masterHiscore.addActionListener(e -> plugin.openHiscoreLink(CLUE_SCROLL_MASTER, selectedEndPoint, currUsername));
+
+				popupMenu.add(allHiscore);
+				popupMenu.add(beginnerHiscore);
+				popupMenu.add(easyHiscore);
+				popupMenu.add(mediumHiscore);
+				popupMenu.add(hardHiscore);
+				popupMenu.add(eliteHiscore);
+				popupMenu.add(masterHiscore);
+			}
+			else
+			{
+				final JMenuItem skillHiscore = new JMenuItem("Open " + skill.getName() + " Hiscores");
+				skillHiscore.addActionListener(e -> plugin.openHiscoreLink(skill, selectedEndPoint, currUsername));
+
+				popupMenu.add(skillHiscore);
+			}
+
+			skillPanel.setComponentPopupMenu(popupMenu);
+		}
 
 		return skillPanel;
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/hiscore/HiscorePanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/hiscore/HiscorePanel.java
@@ -136,6 +136,10 @@ public class HiscorePanel extends PluginPanel
 	/* Used to prevent users from switching endpoint tabs while the results are loading */
 	private boolean loading = false;
 
+	// Used to pass the name of the currently looked up player to Hiscore pages
+	// This is only non-null when a player has been successfully been found
+	private String currUsername = null;
+
 	@Inject
 	public HiscorePanel(@Nullable Client client, HiscorePlugin plugin, HiscoreConfig config,
 		NameAutocompleter nameAutocompleter, OkHttpClient okHttpClient)
@@ -350,6 +354,20 @@ public class HiscorePanel extends PluginPanel
 		boolean totalLabel = skill == OVERALL || skill == null; //overall or combat
 		label.setIconTextGap(totalLabel ? 10 : 4);
 
+		// If skill is null, it's combat level
+		if (skill != null)
+		{
+			MouseAdapter hiscorePanelMouseListener = new MouseAdapter()
+			{
+				@Override
+				public void mouseReleased(MouseEvent e)
+				{
+					plugin.openHiscoreLink(skill, selectedEndPoint, currUsername);
+				}
+			};
+			label.addMouseListener(hiscorePanelMouseListener);
+		}
+
 		JPanel skillPanel = new JPanel();
 		skillPanel.setBackground(ColorScheme.DARKER_GRAY_COLOR);
 		skillPanel.setBorder(new EmptyBorder(2, 0, 2, 0));
@@ -422,6 +440,7 @@ public class HiscorePanel extends PluginPanel
 					searchBar.setIcon(IconTextField.Icon.ERROR);
 					searchBar.setEditable(true);
 					loading = false;
+					currUsername = null;
 					return;
 				}
 
@@ -429,6 +448,7 @@ public class HiscorePanel extends PluginPanel
 				searchBar.setIcon(IconTextField.Icon.SEARCH);
 				searchBar.setEditable(true);
 				loading = false;
+				currUsername = searchBar.getText();
 
 				applyHiscoreResult(result);
 			}));

--- a/runelite-client/src/main/java/net/runelite/client/plugins/hiscore/HiscorePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/hiscore/HiscorePlugin.java
@@ -61,6 +61,7 @@ import net.runelite.client.util.LinkBrowser;
 import net.runelite.client.util.Text;
 import net.runelite.http.api.hiscore.HiscoreEndpoint;
 import net.runelite.http.api.hiscore.HiscoreSkill;
+import net.runelite.http.api.hiscore.HiscoreSkillType;
 import org.apache.commons.lang3.ArrayUtils;
 
 @PluginDescriptor(
@@ -269,7 +270,7 @@ public class HiscorePlugin extends Plugin
 		// Hiscore pages after the construction skill are split into their own
 		// section with the additional parameter `category_type=1` being present
 		// and `table` being rebased back to 0 with League Points
-		if (skill.compareTo(HiscoreSkill.CONSTRUCTION) > 0)
+		if (skill.getType() != HiscoreSkillType.SKILL)
 		{
 			skillTable -= HiscoreSkill.LEAGUE_POINTS.ordinal();
 			url += "category_type=1&";

--- a/runelite-client/src/main/java/net/runelite/client/plugins/hiscore/HiscorePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/hiscore/HiscorePlugin.java
@@ -57,8 +57,10 @@ import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.ClientToolbar;
 import net.runelite.client.ui.NavigationButton;
 import net.runelite.client.util.ImageUtil;
+import net.runelite.client.util.LinkBrowser;
 import net.runelite.client.util.Text;
 import net.runelite.http.api.hiscore.HiscoreEndpoint;
+import net.runelite.http.api.hiscore.HiscoreSkill;
 import org.apache.commons.lang3.ArrayUtils;
 
 @PluginDescriptor(
@@ -257,6 +259,30 @@ public class HiscorePlugin extends Plugin
 			}
 			hiscorePanel.lookup(playerName, endpoint);
 		});
+	}
+
+	void openHiscoreLink(HiscoreSkill skill, HiscoreEndpoint endpoint, String user)
+	{
+		String url = endpoint.getHiscoreBasePageURL().toString();
+		int skillTable = skill.ordinal();
+
+		// Hiscore pages after the construction skill are split into their own
+		// section with the additional parameter `category_type=1` being present
+		// and `table` being rebased back to 0 with League Points
+		if (skill.compareTo(HiscoreSkill.CONSTRUCTION) > 0)
+		{
+			skillTable -= HiscoreSkill.LEAGUE_POINTS.ordinal();
+			url += "category_type=1&";
+		}
+
+		url += "table=" + skillTable;
+
+		if (user != null)
+		{
+			url += "&user=" + user;
+		}
+
+		LinkBrowser.browse(url);
 	}
 
 	HiscoreEndpoint getWorldEndpoint()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/hiscore/NameAutocompleter.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/hiscore/NameAutocompleter.java
@@ -242,6 +242,7 @@ class NameAutocompleter implements KeyListener
 			autocompleteName = Arrays.stream(cachedPlayers)
 				.filter(Objects::nonNull)
 				.map(Player::getName)
+				.filter(Objects::nonNull)
 				.filter(n -> pattern.matcher(n).matches())
 				.findFirst();
 		}


### PR DESCRIPTION
Closes #13845 

Currently this PR naively handles the clue scroll leaderboards by only allowing linking to the [Clue Scrolls (all)](https://secure.runescape.com/m=hiscore_oldschool/overall?category_type=1&table=3) page. I'm not sure what would be an elegant solution to this, but I'm open to ideas if it's even deemed important.