### PR TITLE
Fix model outline renderer crashing in fixed mode

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/outline/ModelOutlineRenderer.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/outline/ModelOutlineRenderer.java
@@ -450,7 +450,7 @@ public class ModelOutlineRenderer
 		{
 			y3 = clipY2;
 		}
-		if (y1 == y3 || y3 < 0)
+		if (y1 == y3 || y3 < clipY1)
 		{
 			return;
 		}
@@ -459,16 +459,16 @@ public class ModelOutlineRenderer
 		x2 <<= 14;
 		x3 = x1;
 
-		if (y1 < 0)
+		if (y1 < clipY1)
 		{
-			x3 -= y1 * slope3;
-			x1 -= y1 * slope1;
-			y1 = 0;
+			x3 -= (y1 - clipY1) * slope3;
+			x1 -= (y1 - clipY1) * slope1;
+			y1 = clipY1;
 		}
-		if (y2 < 0)
+		if (y2 < clipY1)
 		{
-			x2 -= slope2 * y2;
-			y2 = 0;
+			x2 -= (y2 - clipY1) * slope2;
+			y2 = clipY1;
 		}
 
 		int pixelY = y1;


### PR DESCRIPTION
The model outline renderer can simulate model rasterization on the top 4 pixel lines outside the clip area in fixed mode. The clipped rectangle doesn't allocate memory there which causes a write into negative index in an array which causes the overlay to crash.

Fixes #13864