### PR TITLE
CoordinateClue: Fix Isle of Souls enemies

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java
@@ -207,8 +207,8 @@ public class CoordinateClue extends ClueScroll implements TextClueScroll, Locati
 		.put(new WorldPoint(2484, 4016, 0), new CoordinateClueInfo("Northeast corner of the Island of Stone.", ARMADYLEAN_OR_BANDOSIAN_GUARD))
 		.put(new WorldPoint(2222, 3331, 0), new CoordinateClueInfo("Prifddinas, west of the Tower of Voices", ARMADYLEAN_OR_BANDOSIAN_GUARD))
 		.put(new WorldPoint(3560, 3987, 0), new CoordinateClueInfo("Lithkren. Digsite pendant teleport if unlocked, otherwise take rowboat from west of Mushroom Meadow Mushtree.", ARMADYLEAN_OR_BANDOSIAN_GUARD))
-		.put(new WorldPoint(2318, 2954, 0), new CoordinateClueInfo("North-east corner of the Isle of Souls.", ARMADYLEAN_OR_BANDOSIAN_GUARD))
-		.put(new WorldPoint(2094, 2889, 0), new CoordinateClueInfo("West side of the Isle of Souls.", ARMADYLEAN_OR_BANDOSIAN_GUARD))
+		.put(new WorldPoint(2318, 2954, 0), new CoordinateClueInfo("North-east corner of the Isle of Souls.", BANDOSIAN_GUARD))
+		.put(new WorldPoint(2094, 2889, 0), new CoordinateClueInfo("West side of the Isle of Souls.", ARMADYLEAN_GUARD))
 		.put(new WorldPoint(1451, 3509, 0), new CoordinateClueInfo("Ruins of Morra.", ARMADYLEAN_OR_BANDOSIAN_GUARD))
 		// Master
 		.put(new WorldPoint(2178, 3209, 0), new CoordinateClueInfo("South of Iorwerth Camp.", BRASSICAN_MAGE))

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/Enemy.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/Enemy.java
@@ -41,8 +41,12 @@ public enum Enemy
 	ZAMORAK_WIZARD("Zamorak Wizard"),
 	//appears for hard clue coordinate steps not in the wilderness
 	SARADOMIN_WIZARD("Saradomin Wizard"),
-	//appears for elite clue coordinate steps all areas
+	//appears for elite clue coordinate steps in most areas
 	ARMADYLEAN_OR_BANDOSIAN_GUARD("Armadylean OR Bandosian Guard"),
+	//appears for elite clue coordinate steps on the west side of the Isle of Souls
+	ARMADYLEAN_GUARD("Armadylean Guard"),
+	//appears for elite clue coordinate steps on the east side of the Isle of Souls
+	BANDOSIAN_GUARD("Bandosian Guard"),
 	//appears for master clue coordinate and hot cold clues when single-way combat
 	BRASSICAN_MAGE("Brassican Mage"),
 	//appears for master clue coordinate and hot cold clues when multi-way combat


### PR DESCRIPTION
The Isle of Souls only spawns an Armadylean guard at the western
location, and a Bandosian guard at the eastern location.