### PR TITLE
menu entry swapper: Add ash scatter swap

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -767,4 +767,15 @@ public interface MenuEntrySwapperConfig extends Config
 	{
 		return false;
 	}
+
+	@ConfigItem(
+		keyName = "swapAshes",
+		name = "Ashes",
+		description = "Swap Scatter with Use on ashes",
+		section = itemSection
+	)
+	default boolean swapAshes()
+	{
+		return false;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -374,6 +374,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 		swap("wear", "burgh teleport", () -> config.swapMorytaniaLegsMode() == MorytaniaLegsMode.BURGH_DE_ROTT);
 
 		swap("bury", "use", config::swapBones);
+		swap("scatter", "use", config::swapAshes);
 
 		swap("wield", "battlestaff", "use", config::swapBattlestaves);
 


### PR DESCRIPTION
Similar to the bones entry, this swap will prevent accidental scattering
of demonic ashes for players who wish not to gain prayer experience, or
wish to save them to sell or offer at a later time.