### PR TITLE
worldmap: use correct bounds for tooltip hit checking

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/worldmap/WorldMapOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/worldmap/WorldMapOverlay.java
@@ -130,7 +130,7 @@ public class WorldMapOverlay extends Overlay
 		Area currentClip = null;
 
 		Point mousePos = client.getMouseCanvasPosition();
-		if (!canvasViewArea.contains(mousePos.getX(), mousePos.getY()))
+		if (!mapViewArea.contains(mousePos.getX(), mousePos.getY()))
 		{
 			mousePos = null;
 		}


### PR DESCRIPTION
Fixes #13895