### PR TITLE
music: use vanilla's volume percentage conversion

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/music/MusicPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/music/MusicPlugin.java
@@ -748,7 +748,7 @@ public class MusicPlugin extends Plugin
 			s.update();
 			s.getChannel().setWindowSlider(s);
 		}
-		
+
 		if (ev.getScriptId() == ScriptID.TOPLEVEL_REDRAW && musicConfig.granularSliders())
 		{
 			// we have to set the var to our value so toplevel_redraw doesn't try to set
@@ -857,11 +857,12 @@ public class MusicPlugin extends Plugin
 				windowSlider.update();
 			}
 		}
-		
+
 		public void updateVar()
 		{
 			int val = getValue();
-			client.getVarps()[this.var.getId()] = val * 100 / this.max;
+			int varVal = Math.round((float) val / (max / 100.f));
+			client.getVarps()[this.var.getId()] = varVal;
 		}
 
 		public void shutDown()


### PR DESCRIPTION
Fixes #13881

This may also fix #13817 if it caused by thrashing the music player as I suspect, but I am unsure as I still don't have a reproducer for that bug.