### PR TITLE
client: update various wordings to use "signed in/out" for RL accounts

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/account/SessionManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/account/SessionManager.java
@@ -186,7 +186,7 @@ public class SessionManager
 		}
 		catch (IOException ex)
 		{
-			log.warn("Unable to logout of session", ex);
+			log.warn("Unable to sign out of session", ex);
 		}
 
 		accountSession = null; // No more account
@@ -225,7 +225,7 @@ public class SessionManager
 	@Subscribe
 	public void onLoginResponse(LoginResponse loginResponse)
 	{
-		log.debug("Now logged in as {}", loginResponse.getUsername());
+		log.debug("Now signed in as {}", loginResponse.getUsername());
 
 		AccountSession session = getAccountSession();
 		session.setUsername(loginResponse.getUsername());

--- a/runelite-client/src/main/java/net/runelite/client/plugins/account/AccountPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/account/AccountPlugin.java
@@ -75,14 +75,14 @@ public class AccountPlugin extends Plugin
 		loginButton = NavigationButton.builder()
 			.tab(false)
 			.icon(LOGIN_IMAGE)
-			.tooltip("Log in to RuneLite")
+			.tooltip("Sign in to RuneLite")
 			.onClick(this::loginClick)
 			.build();
 
 		logoutButton = NavigationButton.builder()
 			.tab(false)
 			.icon(LOGOUT_IMAGE)
-			.tooltip("Log out of RuneLite")
+			.tooltip("Sign out of RuneLite")
 			.onClick(this::logoutClick)
 			.build();
 
@@ -113,7 +113,7 @@ public class AccountPlugin extends Plugin
 	private void logoutClick()
 	{
 		if (JOptionPane.YES_OPTION == JOptionPane.showConfirmDialog(null,
-			"Are you sure you want to log out from RuneLite?", "Logout Confirmation",
+			"Are you sure you want to sign out of RuneLite?", "Sign Out Confirmation",
 			JOptionPane.YES_NO_OPTION))
 		{
 			executor.execute(sessionManager::logout);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/info/InfoPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/info/InfoPanel.java
@@ -184,7 +184,7 @@ public class InfoPanel extends PluginPanel
 		syncPanel = buildLinkPanel(IMPORT_ICON, "Import signed-out", "settings", () ->
 		{
 			final int result = JOptionPane.showOptionDialog(syncPanel,
-				"<html>This will overwrite your settings with settings from your local profile, which<br/>is the profile used when not logged into RuneLite with a RuneLite account.</html>",
+				"<html>This will overwrite your settings with settings from your local profile, which<br/>is the profile used when not signed into RuneLite with a RuneLite account.</html>",
 				"Are you sure?", JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE,
 				null, new String[]{"Yes", "No"}, "No");
 
@@ -298,14 +298,14 @@ public class InfoPanel extends PluginPanel
 		{
 			emailLabel.setContentType("text/plain");
 			emailLabel.setText(name);
-			loggedLabel.setText("Logged in as");
+			loggedLabel.setText("Signed in as");
 			actionsContainer.add(syncPanel, 0);
 		}
 		else
 		{
 			emailLabel.setContentType("text/html");
-			emailLabel.setText("<a href=\"" + RUNELITE_LOGIN + "\">Login</a> to sync settings to the cloud.");
-			loggedLabel.setText("Not logged in");
+			emailLabel.setText("<a href=\"" + RUNELITE_LOGIN + "\">Sign in</a> to sync settings to the cloud.");
+			loggedLabel.setText("Not signed in");
 			actionsContainer.remove(syncPanel);
 		}
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerConfig.java
@@ -92,7 +92,7 @@ public interface LootTrackerConfig extends Config
 	@ConfigItem(
 		keyName = "syncPanel",
 		name = "Synchronize panel contents",
-		description = "Synchronize your local loot tracker with your server data (requires being logged in).<br/>" +
+		description = "Synchronize your local loot tracker with your server data (requires being signed in).<br/>" +
 			" This means the panel is filled with portions of your remote data on startup<br/>" +
 			" and deleting data in the panel also deletes it on the server."
 	)


### PR DESCRIPTION
A couple of months ago (217a5425d408dd22ab0ccf1f6e902886647cc342), the wording of the import button was changed to refer to the `signed-out` account. The rest of the client still refers to the user being `logged in` to a RL account however. This changes that to standardise the wording onto `signed in/out` instead of `logged in/out`.

This PR only changes the user-facing text; If desired, I could also update variables and functions, or even the web addresses used for signing in and out.