### PR TITLE
Chat commands: add colour override fix to pet cmd output message

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
@@ -1194,7 +1194,9 @@ public class ChatCommandsPlugin extends Plugin
 			return;
 		}
 
-		ChatMessageBuilder responseBuilder = new ChatMessageBuilder().append("Pets: ")
+		ChatMessageBuilder responseBuilder = new ChatMessageBuilder()
+			.append(ChatColorType.NORMAL)
+			.append("Pets: ")
 			.append("(" + playerPetList.size() + ")");
 
 		// Append pets that the player owns
@@ -1211,7 +1213,8 @@ public class ChatCommandsPlugin extends Plugin
 
 		log.debug("Setting response {}", response);
 		final MessageNode messageNode = chatMessage.getMessageNode();
-		messageNode.setValue(response);
+		messageNode.setRuneLiteFormatMessage(response);
+		chatMessageManager.update(messageNode);
 		client.refreshChat();
 	}
 


### PR DESCRIPTION
Close #13916 

Change messageNode `setValue` to `setRuneLiteFormatMessage` to correctly accept colour overrides

**Screenshot**
![image](https://user-images.githubusercontent.com/35241874/126491487-c5c58669-9214-4967-99ad-aaa67e8f7e0c.png)

