### PR TITLE
ground items: make loot beams work with only show loot

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
@@ -392,6 +392,13 @@ public class GroundItemsPlugin extends Plugin
 				}
 			}
 		}
+
+		// Since the loot can potentially be over multiple tiles, make sure to process lootbeams on all those tiles
+		items.stream()
+			.map(ItemStack::getLocation)
+			.map(l -> WorldPoint.fromLocal(client, l))
+			.distinct()
+			.forEach(this::handleLootbeam);
 	}
 
 	private GroundItem buildGroundItem(final Tile tile, final TileItem item)


### PR DESCRIPTION
Closes #13934

Currently, if `Only show loot` is enabled, loot beams won't show up until the item pile changes on the floor. This is due to a race; when the item spawns, it's not been decided whether it's your loot or not. As a result, if the player has `Only show loot` enabled, they won't get a loot beam. Also making the plugin handle the lootbeams in the `lootReceived()` function causes them to get set correctly, as by this point the loot's owner has been decided.