### PR TITLE
Ground Items: Add option to adjust the opacity of highlighted tiles

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
@@ -127,11 +127,8 @@ public interface GroundItemsConfig extends Config
 		description = "Configures whether or not hidden items in right-click menu will be recolored",
 		position = 5
 	)
-	default boolean recolorMenuHiddenItems()
-	{
-		return false;
-	}
-	
+	default boolean recolorMenuHiddenItems() { return false; }
+
 	@ConfigItem(
 		keyName = "highlightTiles",
 		name = "Highlight Tiles",
@@ -149,6 +146,7 @@ public interface GroundItemsConfig extends Config
 		description = "Configures whether or not to notify for drops on your highlighted list",
 		position = 7
 	)
+
 	default boolean notifyHighlightedDrops()
 	{
 		return false;
@@ -239,17 +237,23 @@ public interface GroundItemsConfig extends Config
 		description = "Configures the color for highlighted items",
 		position = 15
 	)
-	default Color highlightedColor()
-	{
-		return Color.decode("#AA00FF");
-	}
+	default Color highlightedColor() { return Color.decode("#AA00FF"); }
+
+	@ConfigItem(
+		keyName = "tileOpacity",
+		name = "Tile Opacity",
+		description = "Adjusts the opacity of highlighted tiles",
+		position = 16
+	)
+
+	default int tileOpacity() { return  0;}
 
 	@Alpha
 	@ConfigItem(
 		keyName = "hiddenColor",
 		name = "Hidden items",
 		description = "Configures the color for hidden items in right-click menu and when holding ALT",
-		position = 16
+		position = 17
 	)
 	default Color hiddenColor()
 	{
@@ -261,7 +265,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "lowValueColor",
 		name = "Low value items",
 		description = "Configures the color for low value items",
-		position = 17
+		position = 18
 	)
 	default Color lowValueColor()
 	{
@@ -272,7 +276,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "lowValuePrice",
 		name = "Low value price",
 		description = "Configures the start price for low value items",
-		position = 18
+		position = 19
 	)
 	default int lowValuePrice()
 	{
@@ -284,7 +288,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "mediumValueColor",
 		name = "Medium value items",
 		description = "Configures the color for medium value items",
-		position = 19
+		position = 20
 	)
 	default Color mediumValueColor()
 	{
@@ -295,7 +299,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "mediumValuePrice",
 		name = "Medium value price",
 		description = "Configures the start price for medium value items",
-		position = 20
+		position = 21
 	)
 	default int mediumValuePrice()
 	{
@@ -307,7 +311,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "highValueColor",
 		name = "High value items",
 		description = "Configures the color for high value items",
-		position = 21
+		position = 22
 	)
 	default Color highValueColor()
 	{
@@ -318,7 +322,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "highValuePrice",
 		name = "High value price",
 		description = "Configures the start price for high value items",
-		position = 22
+		position = 23
 	)
 	default int highValuePrice()
 	{
@@ -330,7 +334,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "insaneValueColor",
 		name = "Insane value items",
 		description = "Configures the color for insane value items",
-		position = 23
+		position = 24
 	)
 	default Color insaneValueColor()
 	{
@@ -341,7 +345,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "insaneValuePrice",
 		name = "Insane value price",
 		description = "Configures the start price for insane value items",
-		position = 24
+		position = 25
 	)
 	default int insaneValuePrice()
 	{
@@ -352,7 +356,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "onlyShowLoot",
 		name = "Only show loot",
 		description = "Only shows drops from NPCs and players",
-		position = 25
+		position = 26
 	)
 	default boolean onlyShowLoot()
 	{
@@ -363,7 +367,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "doubleTapDelay",
 		name = "Double-tap delay",
 		description = "Delay for the double-tap ALT to hide ground items. 0 to disable.",
-		position = 26
+		position = 27
 	)
 	@Units(Units.MILLISECONDS)
 	default int doubleTapDelay()
@@ -375,7 +379,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "collapseEntries",
 		name = "Collapse ground item menu",
 		description = "Collapses ground item menu entries together and appends count",
-		position = 27
+		position = 28
 	)
 	default boolean collapseEntries()
 	{
@@ -386,7 +390,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "groundItemTimers",
 		name = "Despawn timer",
 		description = "Shows despawn timers for items you've dropped and received as loot",
-		position = 28
+		position = 29
 	)
 	default DespawnTimerMode groundItemTimers()
 	{
@@ -397,7 +401,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "textOutline",
 		name = "Text Outline",
 		description = "Use an outline around text instead of a text shadow",
-		position = 29
+		position = 30
 	)
 	default boolean textOutline()
 	{
@@ -408,7 +412,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "showLootbeamForHighlighted",
 		name = "Highlighted item lootbeams",
 		description = "Configures lootbeams to show for all highlighted items.",
-		position = 30
+		position = 31
 	)
 	default boolean showLootbeamForHighlighted()
 	{
@@ -419,7 +423,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "showLootbeamTier",
 		name = "Lootbeam tier",
 		description = "Configures which price tiers will trigger a lootbeam",
-		position = 31
+		position = 32
 	)
 	default HighlightTier showLootbeamTier()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
@@ -221,6 +221,15 @@ public class GroundItemsOverlay extends Overlay
 			{
 				final Polygon poly = Perspective.getCanvasTilePoly(client, groundPoint, item.getHeight());
 
+				int alpha = config.tileOpacity();
+
+				if (alpha > 100)
+				{
+					alpha = 100;
+				}
+				graphics.setColor(new Color(color.getRed(), color.getGreen(), color.getBlue(), alpha));
+				graphics.fillPolygon(poly);
+
 				if (poly != null)
 				{
 					OverlayUtil.renderPolygon(graphics, poly, color);
@@ -456,7 +465,7 @@ public class GroundItemsOverlay extends Overlay
 			}
 			else if (playerRegionID == ZILYANA_REGION || playerRegionID == GRAARDOR_REGION ||
 				playerRegionID == KRIL_TSUTSAROTH_REGION || playerRegionID == KREEARRA_REGION ||
-				playerRegionID == NIGHTMARE_REGION ||  playerRegionID == TEMPOROSS_REGION)
+				playerRegionID == NIGHTMARE_REGION || playerRegionID == TEMPOROSS_REGION)
 			{
 				// GWD, Nightmare, and Tempoross instances use the normal despawn timers
 				despawnTime = spawnTime.plus(groundItem.getLootType() == LootType.DROPPED


### PR DESCRIPTION
This option allows one to change the opacity of the entire tile when one has the Highlight Tiles option selected. 

Related to #13918 
![preview1](https://user-images.githubusercontent.com/35181312/126844449-e81136c8-c9b4-4696-8a52-209d2cd6cf06.png)
![preview2](https://user-images.githubusercontent.com/35181312/126844653-45c0e1a7-9b33-49f4-bcee-d799617b4890.png)
