### PR TITLE
QuestList: Add setting to remember last filter state

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/questlist/QuestListConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/questlist/QuestListConfig.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2021, Cyborger1
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.questlist;
+
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+
+@ConfigGroup(QuestListPlugin.CONFIG_GROUP)
+public interface QuestListConfig extends Config
+{
+	@ConfigItem(
+		position = 1,
+		keyName = QuestListPlugin.REMEMBER_LAST_FILTER_STATE_KEY,
+		name = "Remember last filter state",
+		description = "Remember the last quest list filter state (Show All, Show Completed, etc.)"
+	)
+	default boolean rememberLastFilterState()
+	{
+		return false;
+	}
+}


### PR DESCRIPTION
Resolves #13956.

This is opt-in, the config for it is off by default.

I chose to use RSProfiles to save the state per account, but I can change it to a regular hidden config field to save it globally if anyone feel this is a better option.