### PR TITLE
Shows NPC Aggression timer for slayer tasks #8507

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/npcunaggroarea/NpcAggroAreaConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npcunaggroarea/NpcAggroAreaConfig.java
@@ -117,4 +117,15 @@ public interface NpcAggroAreaConfig extends Config
 	{
 		return false;
 	}
+
+	@ConfigItem(
+		keyName = "autoShowSlayerTaskAggroTimer",
+		name = "Show timer for current slayer task",
+		description = "Will automatically show the NPC Aggression Timer for the current task",
+		position = 8
+	)
+	default boolean autoShowSlayerTaskAggroTimer()
+	{
+		return false;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerPlugin.java
@@ -79,6 +79,7 @@ import net.runelite.client.chat.ChatCommandManager;
 import net.runelite.client.chat.ChatMessageBuilder;
 import net.runelite.client.chat.ChatMessageManager;
 import net.runelite.client.config.ConfigManager;
+import net.runelite.client.eventbus.EventBus;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.events.ChatInput;
 import net.runelite.client.events.ConfigChanged;
@@ -88,6 +89,8 @@ import net.runelite.client.plugins.PluginDependency;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.plugins.npchighlight.NpcIndicatorsPlugin;
 import net.runelite.client.plugins.npchighlight.NpcIndicatorsService;
+import net.runelite.client.plugins.slayer.events.SlayerTaskEndsEvent;
+import net.runelite.client.plugins.slayer.events.SlayerTaskIsSetEvent;
 import net.runelite.client.ui.overlay.OverlayManager;
 import net.runelite.client.ui.overlay.infobox.InfoBoxManager;
 import net.runelite.client.util.ColorUtil;
@@ -176,6 +179,9 @@ public class SlayerPlugin extends Plugin
 
 	@Inject
 	private NpcIndicatorsService npcIndicatorsService;
+
+	@Inject
+	private EventBus eventBus;
 
 	@Getter(AccessLevel.PACKAGE)
 	private final List<NPC> targets = new ArrayList<>();
@@ -475,6 +481,17 @@ public class SlayerPlugin extends Plugin
 					setProfileConfig(SlayerConfig.POINTS_KEY, points);
 				}
 			}
+			if (taskName == null || taskName.equals(""))
+			{
+				eventBus.post(new SlayerTaskEndsEvent());
+			}
+			else
+			{
+				Task task = Task.getTask(taskName);
+				eventBus.post(new SlayerTaskEndsEvent(task));
+			}
+
+
 
 			setTask("", 0, 0);
 			return;
@@ -730,6 +747,10 @@ public class SlayerPlugin extends Plugin
 		rebuildTargetNames(task);
 		rebuildTargetList();
 		npcIndicatorsService.rebuild();
+		if (task != null)
+		{
+			eventBus.post(new SlayerTaskIsSetEvent(task));
+		}
 	}
 
 	private void addCounter()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/Task.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/Task.java
@@ -35,7 +35,7 @@ import lombok.Getter;
 import net.runelite.api.ItemID;
 
 @Getter
-enum Task
+public enum Task
 {
 	//<editor-fold desc="Enums">
 	ABERRANT_SPECTRES("Aberrant spectres", ItemID.ABERRANT_SPECTRE, "Spectre"),

--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/events/SlayerTaskBaseEvent.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/events/SlayerTaskBaseEvent.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2021 FatFingers23
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package net.runelite.client.plugins.slayer.events;
+
+import net.runelite.client.plugins.slayer.Task;
+
+public class SlayerTaskBaseEvent
+{
+
+	/**
+	 * The slayer task sent from the event
+	 */
+	public Task slayerTask;
+
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/events/SlayerTaskEndsEvent.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/events/SlayerTaskEndsEvent.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2021 FatFingers23
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.slayer.events;
+
+import lombok.Value;
+import net.runelite.client.plugins.slayer.Task;
+
+/**
+ * This event ends once a slayer task has been completed
+ */
+@Value
+public class SlayerTaskEndsEvent extends SlayerTaskBaseEvent
+{
+	public SlayerTaskEndsEvent(Task slayerTask)
+	{
+		this.slayerTask = slayerTask;
+	}
+
+	public SlayerTaskEndsEvent()
+	{
+
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/events/SlayerTaskIsSetEvent.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/events/SlayerTaskIsSetEvent.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2021 FatFingers23
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package net.runelite.client.plugins.slayer.events;
+
+import lombok.Value;
+import net.runelite.client.plugins.slayer.Task;
+
+/**
+ * This event fires whenever a slayer task is set inside of the slayer plugin. This can be on login, new task, check gem, and more.
+ */
+@Value
+public class SlayerTaskIsSetEvent extends SlayerTaskBaseEvent
+{
+	public SlayerTaskIsSetEvent(Task slayerTask)
+	{
+		this.slayerTask = slayerTask;
+	}
+}

--- a/runelite-client/src/test/java/net/runelite/client/plugins/npcunaggroarea/NpcAggroAreaPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/npcunaggroarea/NpcAggroAreaPluginTest.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright (c) 2021 FatFingers23
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.npcunaggroarea;
+
+import com.google.inject.Guice;
+import com.google.inject.Inject;
+import com.google.inject.testing.fieldbinder.Bind;
+import com.google.inject.testing.fieldbinder.BoundFieldModule;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import net.runelite.api.Client;
+import net.runelite.api.NPC;
+import net.runelite.api.NPCComposition;
+import net.runelite.api.Player;
+import net.runelite.api.events.NpcSpawned;
+import net.runelite.client.Notifier;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.game.ItemManager;
+import net.runelite.client.plugins.slayer.Task;
+import net.runelite.client.plugins.slayer.events.SlayerTaskEndsEvent;
+import net.runelite.client.plugins.slayer.events.SlayerTaskIsSetEvent;
+import net.runelite.client.ui.overlay.OverlayManager;
+import net.runelite.client.ui.overlay.infobox.InfoBoxManager;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class NpcAggroAreaPluginTest
+{
+
+	private static final String NPC_NAME_PATTERNS_FROM_CONFIG = "Moss Giant, Iron Dragon";
+
+	private static final List<String> NPC_NAME_PATTERNS_ARRAY = Arrays.asList("Moss Giant", "Iron Dragon");
+
+	private static final List<String> EXPECTED_FOSSIL_ISLAND_WYVERNS_TASK_PATTERNS = Arrays.asList("*fossil island wyvern*", "*ancient wyvern*", "*long-tailed wyvern*", "*spitting wyvern*", "*taloned wyvern*");
+
+	@Inject
+	private NpcAggroAreaPlugin npcAggroAreaPlugin;
+
+	@Bind
+	@Mock
+	private Client client;
+
+	@Bind
+	@Mock
+	private NpcAggroAreaConfig config;
+
+	@Bind
+	@Mock
+	private OverlayManager overlayManager;
+
+	@Bind
+	@Mock
+	private ItemManager itemManager;
+
+	@Bind
+	@Mock
+	private InfoBoxManager infoBoxManager;
+
+	@Bind
+	@Mock
+	private ConfigManager configManager;
+
+	@Bind
+	@Mock
+	private Notifier notifier;
+
+	@Before
+	public void before()
+	{
+		Guice.createInjector(BoundFieldModule.of(this)).injectMembers(this);
+	}
+
+	@Test
+	public void testNewSlayerTask() throws Exception
+	{
+
+		SlayerTaskIsSetEvent slayerTaskIsSetEventTrolls = new SlayerTaskIsSetEvent(Task.FOSSIL_ISLAND_WYVERNS);
+		when(config.npcNamePatterns()).thenReturn(NPC_NAME_PATTERNS_FROM_CONFIG);
+		when(config.autoShowSlayerTaskAggroTimer()).thenReturn(true);
+		when(client.getCachedNPCs()).thenReturn(new NPC[]{});
+		npcAggroAreaPlugin.startUp();
+		npcAggroAreaPlugin.onSlayerTaskIsSetEvent(slayerTaskIsSetEventTrolls);
+
+		List<String> npcNamePatterns = npcAggroAreaPlugin.getNpcNamePatterns();
+		for (String target : EXPECTED_FOSSIL_ISLAND_WYVERNS_TASK_PATTERNS)
+		{
+			assertTrue(npcNamePatterns.contains(target));
+		}
+		assertTrue(npcNamePatterns.containsAll(NPC_NAME_PATTERNS_ARRAY));
+	}
+
+	@Test
+	public void testNewSlayerTaskWithConfigTurnedOff() throws Exception
+	{
+
+		SlayerTaskIsSetEvent slayerTaskIsSetEventTrolls = new SlayerTaskIsSetEvent(Task.FOSSIL_ISLAND_WYVERNS);
+		when(config.npcNamePatterns()).thenReturn(NPC_NAME_PATTERNS_FROM_CONFIG);
+		when(config.autoShowSlayerTaskAggroTimer()).thenReturn(false);
+		when(client.getCachedNPCs()).thenReturn(new NPC[]{});
+		npcAggroAreaPlugin.startUp();
+		npcAggroAreaPlugin.onSlayerTaskIsSetEvent(slayerTaskIsSetEventTrolls);
+
+		List<String> npcNamePatterns = npcAggroAreaPlugin.getNpcNamePatterns();
+		for (String target : EXPECTED_FOSSIL_ISLAND_WYVERNS_TASK_PATTERNS)
+		{
+			assertFalse(npcNamePatterns.contains(target));
+		}
+		assertTrue(npcNamePatterns.containsAll(NPC_NAME_PATTERNS_ARRAY));
+	}
+
+	@Test
+	public void testAgroTurnsActiveForSlayerTask() throws Exception
+	{
+
+		SlayerTaskIsSetEvent slayerTaskIsSetEventTrolls = new SlayerTaskIsSetEvent(Task.FOSSIL_ISLAND_WYVERNS);
+		when(config.npcNamePatterns()).thenReturn(NPC_NAME_PATTERNS_FROM_CONFIG);
+		when(config.autoShowSlayerTaskAggroTimer()).thenReturn(true);
+		when(config.alwaysActive()).thenReturn(false);
+
+		NPC npc = mock(NPC.class);
+		NPCComposition npcComposition = mock(NPCComposition.class);
+		when(npcComposition.getName()).thenReturn("Ancient wyvern");
+		when(npcComposition.getCombatLevel()).thenReturn(210);
+		when(npc.getTransformedComposition()).thenReturn(npcComposition);
+		when(client.getCachedNPCs()).thenReturn(new NPC[]{
+			npc
+		});
+
+		Player player = mock(Player.class);
+		when(player.getCombatLevel()).thenReturn(99);
+		when(client.getLocalPlayer()).thenReturn(player);
+		NpcSpawned npcSpawnedMockEvent = new NpcSpawned(npc);
+
+		npcAggroAreaPlugin.startUp();
+		npcAggroAreaPlugin.onSlayerTaskIsSetEvent(slayerTaskIsSetEventTrolls);
+		assertFalse(npcAggroAreaPlugin.isActive());
+		npcAggroAreaPlugin.onNpcSpawned(npcSpawnedMockEvent);
+		assertTrue(npcAggroAreaPlugin.isActive());
+	}
+
+	@Test
+	public void testSlayerTaskEnded() throws Exception
+	{
+
+		SlayerTaskEndsEvent slayerTaskEndsEvent = new SlayerTaskEndsEvent(Task.TROLLS);
+
+		when(config.npcNamePatterns()).thenReturn(NPC_NAME_PATTERNS_FROM_CONFIG);
+		when(client.getCachedNPCs()).thenReturn(new NPC[]{});
+		npcAggroAreaPlugin.startUp();
+
+		List<String> npcPatternAndSlayerTask = new ArrayList<>();
+		npcPatternAndSlayerTask.addAll(EXPECTED_FOSSIL_ISLAND_WYVERNS_TASK_PATTERNS);
+		npcPatternAndSlayerTask.addAll(NPC_NAME_PATTERNS_ARRAY);
+		npcAggroAreaPlugin.setNpcNamePatterns(npcPatternAndSlayerTask);
+		npcAggroAreaPlugin.setSlayerTaskList(EXPECTED_FOSSIL_ISLAND_WYVERNS_TASK_PATTERNS);
+
+
+		npcAggroAreaPlugin.onSlayerTaskEndsEvent(slayerTaskEndsEvent);
+
+		List<String> npcNamePatterns = npcAggroAreaPlugin.getNpcNamePatterns();
+		for (String target : EXPECTED_FOSSIL_ISLAND_WYVERNS_TASK_PATTERNS)
+		{
+			assertFalse(npcNamePatterns.contains(target));
+		}
+		assertEquals(0, npcAggroAreaPlugin.getSlayerTaskList().size());
+		assertTrue(npcNamePatterns.containsAll(NPC_NAME_PATTERNS_ARRAY));
+	}
+
+	@Test
+	public void newSlayerTaskToReplaceOldOne() throws Exception
+	{
+
+		SlayerTaskIsSetEvent secondSlayerTaskIsSetEventTrolls = new SlayerTaskIsSetEvent(Task.TROLLS);
+
+		when(config.npcNamePatterns()).thenReturn(NPC_NAME_PATTERNS_FROM_CONFIG);
+		when(config.autoShowSlayerTaskAggroTimer()).thenReturn(true);
+		when(client.getCachedNPCs()).thenReturn(new NPC[]{});
+		npcAggroAreaPlugin.startUp();
+
+		List<String> npcPatternAndSlayerTask = new ArrayList<>();
+		npcPatternAndSlayerTask.addAll(EXPECTED_FOSSIL_ISLAND_WYVERNS_TASK_PATTERNS);
+		npcPatternAndSlayerTask.addAll(NPC_NAME_PATTERNS_ARRAY);
+		npcAggroAreaPlugin.setNpcNamePatterns(npcPatternAndSlayerTask);
+		npcAggroAreaPlugin.setSlayerTaskList(EXPECTED_FOSSIL_ISLAND_WYVERNS_TASK_PATTERNS);
+
+		npcAggroAreaPlugin.onSlayerTaskIsSetEvent(secondSlayerTaskIsSetEventTrolls);
+
+		List<String> npcNamePatterns = npcAggroAreaPlugin.getNpcNamePatterns();
+		for (String target : EXPECTED_FOSSIL_ISLAND_WYVERNS_TASK_PATTERNS)
+		{
+			assertFalse(npcNamePatterns.contains(target));
+		}
+
+		assertEquals(3, npcAggroAreaPlugin.getSlayerTaskList().size());
+		assertTrue(npcNamePatterns.containsAll(NPC_NAME_PATTERNS_ARRAY));
+	}
+
+}


### PR DESCRIPTION
This adds a new config option inside of the NPC Aggression Timer named "Show timer for current slayer task" when selected it will display the timer for the current slayer task NPCs. The aggression timer works finding the target using the same logic as the Slayer Plugin. I move the logic to a shared util. I hope this was an okay location to place it. If not please direct me to the best location for the shared logic. This does not add the slayer NPC to the config NPC list but holds its own check inside of the NPC Aggression Timer plugin. 

This also solves #8507