### PR TITLE
LootTracker: Add option to hide loot under a certain value

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerConfig.java
@@ -148,4 +148,13 @@ public interface LootTrackerConfig extends Config
 	{
 		return true;
 	}
+
+	@ConfigItem(
+		keyName = "hideLootUnderACertainValue",
+		name = "Hide under value",
+		description = "Hides all loot that is under the specified value.",
+		section = ignored
+	)
+
+	default int ignoreLootBasedOnACertainValue() {return 0; }
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerItem.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerItem.java
@@ -51,4 +51,5 @@ class LootTrackerItem
 	{
 		return (long) haPrice * quantity;
 	}
+
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
@@ -1072,6 +1072,7 @@ public class LootTrackerPlugin extends Plugin
 	{
 		return itemStacks.stream()
 			.map(itemStack -> buildLootTrackerItem(itemStack.getId(), itemStack.getQuantity()))
+			.filter(lootTrackerItem -> lootTrackerItem.getTotalGePrice() > config.ignoreLootBasedOnACertainValue())
 			.toArray(LootTrackerItem[]::new);
 	}
 


### PR DESCRIPTION
closes #13953 

This adds a new option under ignores entries to hide items that are under a certain value. When the Loot Tracker is building entries, it now filters and only adds items that are above the specified value.