### PR TITLE
NPC Indicator Fill Opacity

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsConfig.java
@@ -31,6 +31,7 @@ import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
 import net.runelite.client.config.ConfigSection;
 import net.runelite.client.config.Range;
+import net.runelite.client.util.ColorUtil;
 
 @ConfigGroup("npcindicators")
 public interface NpcIndicatorsConfig extends Config
@@ -131,20 +132,17 @@ public interface NpcIndicatorsConfig extends Config
 		return 0;
 	}
 
+	@Alpha
 	@ConfigItem(
 		position = 7,
-		keyName = "fillOpacity",
-		name = "Fill Opacity",
-		description = "Specify between 0-255 how much opacity the fill for the indicators",
+		keyName = "fillColor",
+		name = "Fill Color",
+		description = "Color for the indicator fills",
 		section = renderStyleSection
 	)
-	@Range(
-		min = 0,
-		max = 255
-	)
-	default int fillOpacity()
+	default Color fillColor()
 	{
-		return 20;
+		return ColorUtil.colorWithAlpha(Color.CYAN, 20);
 	}
 
 	@ConfigItem(

--- a/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsConfig.java
@@ -134,8 +134,8 @@ public interface NpcIndicatorsConfig extends Config
 	@ConfigItem(
 		position = 7,
 		keyName = "fillOpacity",
-		name = "Tile Fill Opacity",
-		description = "Specify between 0-255 how much opacity the inner filling of npc tiles should have.",
+		name = "Fill Opacity",
+		description = "Specify between 0-255 how much opacity the fill for the indicators.",
 		section = renderStyleSection
 	)
 	@Range(

--- a/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsConfig.java
@@ -133,6 +133,22 @@ public interface NpcIndicatorsConfig extends Config
 
 	@ConfigItem(
 		position = 7,
+		keyName = "fillOpacity",
+		name = "Tile Fill Opacity",
+		description = "Specify between 0-255 how much opacity the inner filling of npc tiles should have.",
+		section = renderStyleSection
+	)
+	@Range(
+		min = 0,
+		max = 255
+	)
+	default int fillOpacity()
+	{
+		return 20;
+	}
+
+	@ConfigItem(
+		position = 8,
 		keyName = "npcToHighlight",
 		name = "NPCs to Highlight",
 		description = "List of NPC names to highlight"
@@ -150,7 +166,7 @@ public interface NpcIndicatorsConfig extends Config
 	void setNpcToHighlight(String npcsToHighlight);
 
 	@ConfigItem(
-		position = 8,
+		position = 9,
 		keyName = "drawNames",
 		name = "Draw names above NPC",
 		description = "Configures whether or not NPC names should be drawn above the NPC"
@@ -161,7 +177,7 @@ public interface NpcIndicatorsConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 9,
+		position = 10,
 		keyName = "drawMinimapNames",
 		name = "Draw names on minimap",
 		description = "Configures whether or not NPC names should be drawn on the minimap"
@@ -172,7 +188,7 @@ public interface NpcIndicatorsConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 10,
+		position = 11,
 		keyName = "highlightMenuNames",
 		name = "Highlight menu names",
 		description = "Highlight NPC names in right click menu"
@@ -183,7 +199,7 @@ public interface NpcIndicatorsConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 11,
+		position = 12,
 		keyName = "ignoreDeadNpcs",
 		name = "Ignore dead NPCs",
 		description = "Prevents highlighting NPCs after they are dead"
@@ -194,7 +210,7 @@ public interface NpcIndicatorsConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 12,
+		position = 13,
 		keyName = "deadNpcMenuColor",
 		name = "Dead NPC menu color",
 		description = "Color of the NPC menus for dead NPCs"
@@ -202,7 +218,7 @@ public interface NpcIndicatorsConfig extends Config
 	Color deadNpcMenuColor();
 
 	@ConfigItem(
-		position = 13,
+		position = 14,
 		keyName = "showRespawnTimer",
 		name = "Show respawn timer",
 		description = "Show respawn timer of tagged NPCs")

--- a/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsConfig.java
@@ -135,7 +135,7 @@ public interface NpcIndicatorsConfig extends Config
 		position = 7,
 		keyName = "fillOpacity",
 		name = "Fill Opacity",
-		description = "Specify between 0-255 how much opacity the fill for the indicators.",
+		description = "Specify between 0-255 how much opacity the fill for the indicators",
 		section = renderStyleSection
 	)
 	@Range(

--- a/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcSceneOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcSceneOverlay.java
@@ -209,7 +209,7 @@ public class NpcSceneOverlay extends Overlay
 			graphics.setColor(color);
 			graphics.setStroke(new BasicStroke((float) config.borderWidth()));
 			graphics.draw(polygon);
-			graphics.setColor(ColorUtil.colorWithAlpha(color, 20));
+			graphics.setColor(ColorUtil.colorWithAlpha(color, config.fillOpacity()));
 			graphics.fill(polygon);
 		}
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcSceneOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcSceneOverlay.java
@@ -209,7 +209,7 @@ public class NpcSceneOverlay extends Overlay
 			graphics.setColor(color);
 			graphics.setStroke(new BasicStroke((float) config.borderWidth()));
 			graphics.draw(polygon);
-			graphics.setColor(ColorUtil.colorWithAlpha(color, config.fillOpacity()));
+			graphics.setColor(config.fillColor());
 			graphics.fill(polygon);
 		}
 	}


### PR DESCRIPTION
With the new highlights for interactions added, I started looking into configuring my NPC indicators tile thickness and etc, and realized I wanted a way to make the fill have less opacity. Small config and appropriate access added.