### PR TITLE
menu entry swapper: allow teleport item excludes

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -467,6 +467,17 @@ public interface MenuEntrySwapperConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "teleportItemExcludes",
+		name = "Teleport item excludes",
+		description = "Items excluded from Teleport item swap. Format: (item), (item)",
+		section = itemSection
+	)
+	default String teleportItemExcludes()
+	{
+		return "";
+	}
+
+	@ConfigItem(
 		keyName = "swapTeleToPoh",
 		name = "Tele to POH",
 		description = "Swap Wear with Tele to POH on the construction cape",


### PR DESCRIPTION
Allows some items to be excluded from the "Teleport item" feature of Menu Entry Swapper.

<img width="238" alt="teleport-item-excludes" src="https://user-images.githubusercontent.com/62616086/128409318-bbeebcd3-92d7-4705-81ac-40cebe268935.png">

This swap covers a wide range of equipment, and for some the "teleport" action might be an undesired default, often leading to unintentional teleports.