### PR TITLE
chat notifications: allow to limit notifications by message type

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatnotifications/ChatNotificationsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatnotifications/ChatNotificationsConfig.java
@@ -99,6 +99,17 @@ public interface ChatNotificationsConfig extends Config
 
 	@ConfigItem(
 		position = 4,
+		keyName = "notifyFor",
+		name = "Notify for",
+		description = "For which highlights to send notifications"
+	)
+	default ChatNotificationsScope notifyFor()
+	{
+		return ChatNotificationsScope.ALL_MESSAGES;
+	}
+
+	@ConfigItem(
+		position = 5,
 		keyName = "notifyOnTrade",
 		name = "Notify on trade",
 		description = "Notifies you whenever you are traded"
@@ -109,7 +120,7 @@ public interface ChatNotificationsConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 5,
+		position = 6,
 		keyName = "notifyOnDuel",
 		name = "Notify on duel",
 		description = "Notifies you whenever you are challenged to a duel"
@@ -120,7 +131,7 @@ public interface ChatNotificationsConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 6,
+		position = 7,
 		keyName = "notifyOnBroadcast",
 		name = "Notify on broadcast",
 		description = "Notifies you whenever you receive a broadcast message"
@@ -131,7 +142,7 @@ public interface ChatNotificationsConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 7,
+		position = 8,
 		keyName = "notifyOnPM",
 		name = "Notify on private message",
 		description = "Notifies you whenever you receive a private message"

--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatnotifications/ChatNotificationsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatnotifications/ChatNotificationsPlugin.java
@@ -40,7 +40,6 @@ import java.util.regex.PatternSyntaxException;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
 import javax.inject.Named;
-import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
 import net.runelite.api.MessageNode;
 import net.runelite.api.events.ChatMessage;
@@ -248,13 +247,7 @@ public class ChatNotificationsPlugin extends Plugin
 				final String replacement = "<col" + ChatColorType.HIGHLIGHT.name() + "><u>" + username + "</u>" + closeColor;
 				messageNode.setValue(matcher.replaceAll(replacement));
 				update = true;
-				if (config.notifyOnOwnName() && (chatMessage.getType() == ChatMessageType.PUBLICCHAT
-					|| chatMessage.getType() == ChatMessageType.PRIVATECHAT
-					|| chatMessage.getType() == ChatMessageType.FRIENDSCHAT
-					|| chatMessage.getType() == ChatMessageType.MODCHAT
-					|| chatMessage.getType() == ChatMessageType.MODPRIVATECHAT
-					|| chatMessage.getType() == ChatMessageType.CLAN_CHAT
-					|| chatMessage.getType() == ChatMessageType.CLAN_GUEST_CHAT))
+				if (config.notifyOnOwnName() && ChatNotificationsScope.PLAYER_CHAT.getMessageTypes().contains(chatMessage.getType()))
 				{
 					sendNotification(chatMessage);
 				}
@@ -312,7 +305,7 @@ public class ChatNotificationsPlugin extends Plugin
 		if (matchesHighlight)
 		{
 			messageNode.setValue(nodeValue);
-			if (config.notifyOnHighlight())
+			if (config.notifyOnHighlight() && config.notifyFor().getMessageTypes().contains(chatMessage.getType()))
 			{
 				sendNotification(chatMessage);
 			}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatnotifications/ChatNotificationsScope.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatnotifications/ChatNotificationsScope.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2021, molo-pl <https://github.com/molo-pl>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.chatnotifications;
+
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.Set;
+import net.runelite.api.ChatMessageType;
+
+public enum ChatNotificationsScope
+{
+	ALL_MESSAGES(
+		Collections.unmodifiableSet(EnumSet.allOf(ChatMessageType.class))
+	),
+	PLAYER_CHAT(
+		Collections.unmodifiableSet(EnumSet.of(
+			ChatMessageType.MODCHAT,
+			ChatMessageType.PUBLICCHAT,
+			ChatMessageType.PRIVATECHAT,
+			ChatMessageType.MODPRIVATECHAT,
+			ChatMessageType.FRIENDSCHAT,
+			ChatMessageType.CLAN_CHAT,
+			ChatMessageType.CLAN_GUEST_CHAT
+		))
+	);
+
+	private final Set<ChatMessageType> messageTypes;
+
+	ChatNotificationsScope(Set<ChatMessageType> messageTypes)
+	{
+		this.messageTypes = messageTypes;
+	}
+
+	public Set<ChatMessageType> getMessageTypes()
+	{
+		return messageTypes;
+	}
+}


### PR DESCRIPTION
Currently chat notifications for highlighted phrases are triggered for all message types, including player chat (public, private, clan chat etc.) and game messages (e.g. a message after receiving a drop).

This change allows users to choose whether they'd like to be notified for all highlights, or only for the ones which occurred in player chat.

<img width="240" alt="notify-for-player-chat" src="https://user-images.githubusercontent.com/62616086/128422095-293b2004-f0ac-4843-87bd-68fe66205ebe.png">

An example use case: for composite player names, others often mention the player by partial name (e.g. full username `HCIM Awesome` may be simply referred to as `Awesome` in clan chat). This means the feature "notify on own name" is not usable, and requires usage of the "notify on highlight" feature, which in turn would produce notifications for more messages than intended (e.g. `HCIM Awesome received a drop`).