### PR TITLE
Update to skill calculator "action" plurals

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/SkillCalculator.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/SkillCalculator.java
@@ -365,7 +365,7 @@ class SkillCalculator extends JPanel
 
 	private String formatXPActionString(double xp, int actionCount, String expExpression)
 	{
-		return XP_FORMAT.format(xp) + expExpression + NumberFormat.getIntegerInstance().format(actionCount) + (actionCount > 1 ? " actions" : " action");
+		return XP_FORMAT.format(xp) + expExpression + NumberFormat.getIntegerInstance().format(actionCount) + (actionCount == 1 ? " action" : " actions");
 	}
 
 	private void updateInputFields()


### PR DESCRIPTION
Update skill calculators to correctly show plurals of action as "0 actions", "1 action", "2 actions", "3 actions", etc.
Old behavior showed "0 action", "1 action", "2 actions", etc
