### PR TITLE
Chat commands - add duplicate pets support

### DIFF
--- a/http-service/src/main/java/net/runelite/http/service/chat/ChatService.java
+++ b/http-service/src/main/java/net/runelite/http/service/chat/ChatService.java
@@ -234,6 +234,7 @@ public class ChatService
 
 	public int[] getPetList(String name)
 	{
+		//  Use HSET instead of SET for !pets
 		Set<String> pets;
 		try (Jedis jedis = jedisPool.getResource())
 		{
@@ -252,6 +253,7 @@ public class ChatService
 
 	public void setPetList(String name, int[] petList)
 	{
+		//  Use HSET instead of SET for !pets
 		String[] pets = Arrays.stream(petList).mapToObj(Integer::toString).toArray(String[]::new);
 		String key = "pets." + name;
 		try (Jedis jedis = jedisPool.getResource())


### PR DESCRIPTION
Closes #13923 

Change Redis storage type from `SET` to `HSET`

Add duplicate pets support to the `!pets` chat command