### PR TITLE
roof removal: properly account for instances when applying overrides

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/roofremoval/RoofRemovalPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/roofremoval/RoofRemovalPlugin.java
@@ -46,6 +46,7 @@ import static net.runelite.api.Constants.ROOF_FLAG_HOVERED;
 import static net.runelite.api.Constants.ROOF_FLAG_POSITION;
 import net.runelite.api.GameState;
 import net.runelite.api.Tile;
+import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.GameStateChanged;
 import net.runelite.client.callback.ClientThread;
 import net.runelite.client.config.ConfigManager;
@@ -246,14 +247,17 @@ public class RoofRemovalPlugin extends Plugin
 						continue;
 					}
 
-					int regionID = tile.getWorldLocation().getRegionID() << 2 | z;
+					// Properly account for instances shifting worldpoints around
+					final WorldPoint wp = WorldPoint.fromLocalInstance(client, tile.getLocalLocation(), tile.getPlane());
+
+					int regionID = wp.getRegionID() << 2 | z;
 					if (!overrides.containsKey(regionID))
 					{
 						continue;
 					}
 
-					int rx = tile.getWorldLocation().getRegionX();
-					int ry = tile.getWorldLocation().getRegionY();
+					int rx = wp.getRegionX();
+					int ry = wp.getRegionY();
 					long[] region = overrides.get(regionID);
 					if ((region[ry] & (1L << rx)) != 0)
 					{


### PR DESCRIPTION
Since instances shift around real regions to WorldPoints that don't
match, the override system was trying to apply overrides to areas that
don't currently exist.

This will mostly affect quest areas (eg. Harmony Island Church during The Great Brain Robbery, which is where I first heard of this issue), but it will also allow for the POH to receive overrides in the future.