### PR TITLE
ClientUI: Run PluginPanel#onDeactivate when switching panels

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
@@ -959,6 +959,11 @@ public class ClientUI
 
 		int width = panel.getWrappedPanel().getPreferredSize().width;
 		int expandBy = pluginPanel != null ? pluginPanel.getWrappedPanel().getPreferredSize().width - width : width;
+
+		if (pluginPanel != null)
+		{
+			pluginPanel.onDeactivate();
+		}
 		pluginPanel = panel;
 
 		// Expand sidebar

--- a/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
@@ -960,10 +960,12 @@ public class ClientUI
 		int width = panel.getWrappedPanel().getPreferredSize().width;
 		int expandBy = pluginPanel != null ? pluginPanel.getWrappedPanel().getPreferredSize().width - width : width;
 
+		// Deactivate previously active panel
 		if (pluginPanel != null)
 		{
 			pluginPanel.onDeactivate();
 		}
+
 		pluginPanel = panel;
 
 		// Expand sidebar


### PR DESCRIPTION
`onDeactivate()` currently only runs when the plugin panel is explicitly closed, but not when it's implicitly closed from switching to a different panel. This fixes that.

There currently doesn't seem to be any core plugin that actively uses `onDeactivate()`, but there are some plugin hub plugins that are affected by this bug.