### PR TITLE
tileindicators: add option to hide true tile when not moving

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/AnimationID.java
+++ b/runelite-api/src/main/java/net/runelite/api/AnimationID.java
@@ -206,6 +206,8 @@ public final class AnimationID
 	public static final int LEAGUE_HOME_TELEPORT_6 = 8807;
 	public static final int RAID_LIGHT_ANIMATION = 3101;
 
+	public static final int STANDING = 808;
+
 	public static final int CONSTRUCTION = 3676;
 	public static final int CONSTRUCTION_IMCANDO = 8912;
 	public static final int SAND_COLLECTION = 895;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/tileindicators/TileIndicatorsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/tileindicators/TileIndicatorsConfig.java
@@ -125,10 +125,21 @@ public interface TileIndicatorsConfig extends Config
 	}
 
 	@ConfigItem(
+			keyName = "highlightCurrentTileOnlyWhileMoving",
+			name = "Show true tile only while moving",
+			description = "Only highlights true tile when moving. When standing true tile will not appear.",
+			position = 9
+	)
+	default boolean highlightCurrentTileOnlyWhileMoving()
+	{
+		return false;
+	}
+
+	@ConfigItem(
 		keyName = "currentTileBorderWidth",
 		name = "True tile border width",
 		description = "Width of the true tile marker border",
-		position = 9
+		position = 10
 	)
 	default double currentTileBorderWidth()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/tileindicators/TileIndicatorsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/tileindicators/TileIndicatorsOverlay.java
@@ -29,9 +29,10 @@ import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Graphics2D;
 import java.awt.Polygon;
+import java.util.Objects;
 import javax.inject.Inject;
-import net.runelite.api.Client;
-import net.runelite.api.Perspective;
+
+import net.runelite.api.*;
 import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.client.ui.overlay.Overlay;
@@ -74,6 +75,11 @@ public class TileIndicatorsOverlay extends Overlay
 
 		if (config.highlightCurrentTile())
 		{
+			final int currentMovementState = Objects.requireNonNull(client.getLocalPlayer()).getPoseAnimation();
+			if (config.highlightCurrentTileOnlyWhileMoving() && currentMovementState == AnimationID.STANDING)
+			{
+				return null;
+			}
 			final WorldPoint playerPos = client.getLocalPlayer().getWorldLocation();
 			if (playerPos == null)
 			{


### PR DESCRIPTION
Closes #14032 

Provides an option in the TileIndicator plugin that hides the true tile when not moving.