### PR TITLE
xp globes: account for progress arc width when deciding overlay bounds

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesOverlay.java
@@ -63,6 +63,7 @@ public class XpGlobesOverlay extends Overlay
 	private static final int MINIMUM_STEP = 10;
 	private static final int PROGRESS_RADIUS_START = 90;
 	private static final int PROGRESS_RADIUS_REMAINDER = 0;
+	private static final int PROGRESS_BACKGROUND_SIZE = 5;
 	private static final int TOOLTIP_RECT_SIZE_X = 150;
 	private static final Color DARK_OVERLAY_COLOR = new Color(0, 0, 0, 180);
 	static final String FLIP_ACTION = "Flip";
@@ -108,31 +109,34 @@ public class XpGlobesOverlay extends Overlay
 			return null;
 		}
 
-		int curDrawPosition = 0;
+		// The progress arc is drawn either side of the perimeter of the background. This value accounts for that
+		// when calculating draw positions and overall size of the overlay
+		final int progressArcOffset = (int) Math.ceil(Math.max(PROGRESS_BACKGROUND_SIZE, config.progressArcStrokeWidth()) / 2.0);
+		int curDrawPosition = progressArcOffset;
 		for (final XpGlobe xpGlobe : xpGlobes)
 		{
 			int startXp = xpTrackerService.getStartGoalXp(xpGlobe.getSkill());
 			int goalXp = xpTrackerService.getEndGoalXp(xpGlobe.getSkill());
 			if (config.alignOrbsVertically())
 			{
-				renderProgressCircle(graphics, xpGlobe, startXp, goalXp, 0, curDrawPosition, getBounds());
+				renderProgressCircle(graphics, xpGlobe, startXp, goalXp, progressArcOffset, curDrawPosition, getBounds());
 			}
 			else
 			{
-				renderProgressCircle(graphics, xpGlobe, startXp, goalXp, curDrawPosition, 0, getBounds());
+				renderProgressCircle(graphics, xpGlobe, startXp, goalXp, curDrawPosition, progressArcOffset, getBounds());
 			}
 			curDrawPosition += MINIMUM_STEP + config.xpOrbSize();
 		}
 
 		// Get length of markers
-		final int markersLength = (queueSize * (config.xpOrbSize())) + ((MINIMUM_STEP) * (queueSize - 1));
+		final int markersLength = (queueSize * (config.xpOrbSize() + progressArcOffset)) + ((MINIMUM_STEP) * (queueSize - 1));
 		if (config.alignOrbsVertically())
 		{
-			return new Dimension(config.xpOrbSize(), markersLength);
+			return new Dimension(config.xpOrbSize() + progressArcOffset * 2, markersLength);
 		}
 		else
 		{
-			return new Dimension(markersLength, config.xpOrbSize());
+			return new Dimension(markersLength, config.xpOrbSize() + progressArcOffset * 2);
 		}
 	}
 
@@ -184,7 +188,7 @@ public class XpGlobesOverlay extends Overlay
 			x, y,
 			config.xpOrbSize(), config.xpOrbSize(),
 			PROGRESS_RADIUS_REMAINDER, radiusToGoalXp,
-			5,
+			PROGRESS_BACKGROUND_SIZE,
 			config.progressOrbOutLineColor()
 		);
 		drawProgressArc(


### PR DESCRIPTION
Currently, the xp's bounds do not account for the progress arc, as it is drawn either side of the perimeter of the background circle. This PR addresses that.

On `master`:
![record_2021-08-27__16-10-01](https://user-images.githubusercontent.com/2979691/131157747-1937e376-8148-4dc7-9a9c-019a3c86967d.png)

With this PR:
![record_2021-08-27__16-09-48](https://user-images.githubusercontent.com/2979691/131157751-2e6b1d7a-060c-4b47-93b0-f6c17334e033.png)

This also fixes the progress arc being drawn off-screen or interfering with other overlays when the progress arc size is excessively high (shown here with 20px):
![image](https://user-images.githubusercontent.com/2979691/131158653-e4d67d67-b97b-4a05-9880-be49a9de484a.png)
![record_2021-08-27__16-11-34](https://user-images.githubusercontent.com/2979691/131157760-ea8e5c88-00ae-4ce0-ad69-932dbf356b4b.png)
