### PR TITLE
loot tracker: add ea display to tooltips

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerBox.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerBox.java
@@ -375,8 +375,19 @@ class LootTrackerBox extends JPanel
 		final long gePrice = item.getTotalGePrice();
 		final long haPrice = item.getTotalHaPrice();
 		final String ignoredLabel = item.isIgnored() ? " - Ignored" : "";
-		return "<html>" + name + " x " + quantity + ignoredLabel
-			+ "<br>GE: " + QuantityFormatter.quantityToStackSize(gePrice)
-			+ "<br>HA: " + QuantityFormatter.quantityToStackSize(haPrice) + "</html>";
+		final StringBuilder sb = new StringBuilder("<html>");
+		sb.append(name).append(" x ").append(QuantityFormatter.formatNumber(quantity)).append(ignoredLabel);
+		sb.append("<br>GE: ").append(QuantityFormatter.quantityToStackSize(gePrice));
+		if (quantity > 1)
+		{
+			sb.append(" (").append(QuantityFormatter.quantityToStackSize(item.getGePrice())).append(" ea)");
+		}
+		sb.append("<br>HA: ").append(QuantityFormatter.quantityToStackSize(haPrice));
+		if (quantity > 1)
+		{
+			sb.append(" (").append(QuantityFormatter.quantityToStackSize(item.getHaPrice())).append(" ea)");
+		}
+		sb.append("</html>");
+		return sb.toString();
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerBox.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerBox.java
@@ -50,6 +50,7 @@ import javax.swing.SwingConstants;
 import javax.swing.border.EmptyBorder;
 import lombok.AccessLevel;
 import lombok.Getter;
+import net.runelite.api.ItemID;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.ui.ColorScheme;
 import net.runelite.client.ui.FontManager;
@@ -377,11 +378,24 @@ class LootTrackerBox extends JPanel
 		final String ignoredLabel = item.isIgnored() ? " - Ignored" : "";
 		final StringBuilder sb = new StringBuilder("<html>");
 		sb.append(name).append(" x ").append(QuantityFormatter.formatNumber(quantity)).append(ignoredLabel);
+		if (item.getId() == ItemID.COINS_995)
+		{
+			sb.append("</html>");
+			return sb.toString();
+		}
+
 		sb.append("<br>GE: ").append(QuantityFormatter.quantityToStackSize(gePrice));
 		if (quantity > 1)
 		{
 			sb.append(" (").append(QuantityFormatter.quantityToStackSize(item.getGePrice())).append(" ea)");
 		}
+
+		if (item.getId() == ItemID.PLATINUM_TOKEN)
+		{
+			sb.append("</html>");
+			return sb.toString();
+		}
+
 		sb.append("<br>HA: ").append(QuantityFormatter.quantityToStackSize(haPrice));
 		if (quantity > 1)
 		{


### PR DESCRIPTION
![record_2021-08-27__22-54-50](https://user-images.githubusercontent.com/2979691/131196200-f1e0dc8c-07d3-4c3e-9192-27547d3f3aed.png)
Also removes the unnecessary HA line for Coins and Platinum, along with the GE line for Coins
![record_2021-08-27__22-54-58](https://user-images.githubusercontent.com/2979691/131196203-a3575b9d-8967-4f82-ab3c-46e76ed8836f.png)
