### PR TITLE
Fix a flaky test

### DIFF
--- a/cache/src/main/java/net/runelite/cache/script/assembler/ScriptWriter.java
+++ b/cache/src/main/java/net/runelite/cache/script/assembler/ScriptWriter.java
@@ -26,6 +26,7 @@ package net.runelite.cache.script.assembler;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -267,7 +268,7 @@ public class ScriptWriter extends rs2asmBaseListener
 				continue;
 			}
 
-			Map<Integer, Integer> map = maps[index++] = new HashMap<>();
+			Map<Integer, Integer> map = maps[index++] = new LinkedHashMap<>();
 
 			for (LookupCase scase : lswitch.getCases())
 			{


### PR DESCRIPTION
A flaky test is found in this project and this PR proposes to fix it.

1. How to reproduce the flaky test
- The project is built and tested under `javaJDK8`.
- The tool used for the flaky test detection is [NonDex](https://github.com/TestingResearchIllinois/NonDex).
- I ran `mvn -pl cache edu.illinois:nondex-maven-plugin:1.1.2:nondex -Dtest=AssemblerTest`, which produced

> testAssemble\[0\](net.runelite.cache.script.assembler.AssemblerTest)  Time elapsed: 0.114 sec  <<< FAILURE!
> org.junit.ComparisonFailure: expected:<...
> [3: LABEL20
>  5: LABEL54
>  6: LABEL54
>  7: LABEL3]
> jump            ...> but was:<...
> [5: LABEL54
>  3: LABEL20
>  7: LABEL3
>  6: LABEL54]
>  jump            ...>

2. Why the tests failed
- In the failed test, the method `assemble` of class `Assembler` is used to assemble an `Instructions` into a `ScriptDefinition`, which calls another method `buildSwitches` from the class `ScriptWriter` that returns a `Map`. This map, implemented as `HashMap` is iterated when `disassemble` is called in the test. However, `HashMap` does not preserve the order of the elements in it, causing the test to be flaky.

3. The changes made
- In `buildSwitches`, the implementation of `Map` is changed to `LinkedHashMap`, which preserves the order of the elements.