### PR TITLE
idle notifier: LOOKING_INTO animation is now handled

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
@@ -291,6 +291,7 @@ public class IdleNotifierPlugin extends Plugin
 			/* Misc */
 			case PISCARILIUS_CRANE_REPAIR:
 			case HOME_MAKE_TABLET:
+			case LOOKING_INTO:
 			case SAND_COLLECTION:
 				resetTimers();
 				lastAnimation = animation;


### PR DESCRIPTION
Closes https://github.com/runelite/runelite/issues/13504

Animation LOOKING_INTO is added to the list of animation who can trigger the notifier. Hence, the jug filling action can trigger the notifier.