### PR TITLE
idle notifier: LOOKING_INTO animation is now handled + test modified

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
@@ -291,6 +291,7 @@ public class IdleNotifierPlugin extends Plugin
 			/* Misc */
 			case PISCARILIUS_CRANE_REPAIR:
 			case HOME_MAKE_TABLET:
+			case LOOKING_INTO:
 			case SAND_COLLECTION:
 				resetTimers();
 				lastAnimation = animation;

--- a/runelite-client/src/test/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPluginTest.java
@@ -62,6 +62,8 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class IdleNotifierPluginTest
 {
+	private static final int DUMMY_ANIM = -2;
+
 	@Mock
 	@Bind
 	private Client client;
@@ -153,7 +155,7 @@ public class IdleNotifierPluginTest
 		animationChanged.setActor(player);
 		plugin.onAnimationChanged(animationChanged);
 		plugin.onGameTick(new GameTick());
-		when(player.getAnimation()).thenReturn(AnimationID.DEATH);
+		when(player.getAnimation()).thenReturn(DUMMY_ANIM);
 		plugin.onAnimationChanged(animationChanged);
 		plugin.onGameTick(new GameTick());
 		when(player.getAnimation()).thenReturn(AnimationID.IDLE);

--- a/runelite-client/src/test/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPluginTest.java
@@ -153,7 +153,7 @@ public class IdleNotifierPluginTest
 		animationChanged.setActor(player);
 		plugin.onAnimationChanged(animationChanged);
 		plugin.onGameTick(new GameTick());
-		when(player.getAnimation()).thenReturn(AnimationID.LOOKING_INTO);
+		when(player.getAnimation()).thenReturn(AnimationID.DEATH);
 		plugin.onAnimationChanged(animationChanged);
 		plugin.onGameTick(new GameTick());
 		when(player.getAnimation()).thenReturn(AnimationID.IDLE);


### PR DESCRIPTION
Closes https://github.com/runelite/runelite/issues/13504

Animation LOOKING_INTO is added to the list of animation who can trigger the notifier. Hence, the jug filling action can trigger the notifier.

The test has been changed with a Death animation instead of the `LOOKING_INTO` one.