### PR TITLE
fix(npc-indicator): npcOverlayService rebuild in LOGIN_SCREEN game state

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsPlugin.java
@@ -224,6 +224,7 @@ public class NpcIndicatorsPlugin extends Plugin
 			memorizedNpcs.forEach((id, npc) -> npc.setDiedOnTick(-1));
 			lastPlayerLocation = null;
 			skipNextSpawnCheck = true;
+			npcOverlayService.rebuild();
 		}
 	}
 


### PR DESCRIPTION
Closes https://github.com/runelite/runelite/issues/14123

A rebuild seems to do the work when the game state change to the login screen.
Tested on 2 different accounts.