### PR TITLE
cannon: add recommended spots for dagganoths and increase overlay distance

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonOverlay.java
@@ -39,11 +39,10 @@ import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.OverlayPriority;
 import net.runelite.client.ui.overlay.OverlayUtil;
 import net.runelite.client.ui.overlay.components.TextComponent;
+import static net.runelite.client.plugins.cannon.CannonPlugin.MAX_OVERLAY_DISTANCE;
 
 class CannonOverlay extends Overlay
 {
-	private static final int MAX_DISTANCE = 2500;
-
 	private final Client client;
 	private final CannonConfig config;
 	private final CannonPlugin plugin;
@@ -76,7 +75,7 @@ class CannonOverlay extends Overlay
 
 		LocalPoint localLocation = client.getLocalPlayer().getLocalLocation();
 
-		if (localLocation.distanceTo(cannonPoint) <= MAX_DISTANCE)
+		if (localLocation.distanceTo(cannonPoint) <= MAX_OVERLAY_DISTANCE)
 		{
 			Point cannonLoc = Perspective.getCanvasTextLocation(client,
 				graphics,

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonPlugin.java
@@ -72,6 +72,7 @@ import net.runelite.client.ui.overlay.infobox.InfoBoxManager;
 public class CannonPlugin extends Plugin
 {
 	private static final Pattern NUMBER_PATTERN = Pattern.compile("([0-9]+)");
+	static final int MAX_OVERLAY_DISTANCE = 4100;
 	static final int MAX_CBALLS = 30;
 
 	private CannonCounter counter;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonSpotOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonSpotOverlay.java
@@ -43,11 +43,10 @@ import net.runelite.client.game.ItemManager;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.OverlayUtil;
+import static net.runelite.client.plugins.cannon.CannonPlugin.MAX_OVERLAY_DISTANCE;
 
 class CannonSpotOverlay extends Overlay
 {
-	private static final int MAX_DISTANCE = 2350;
-
 	private final Client client;
 	private final CannonPlugin plugin;
 	private final CannonConfig config;
@@ -87,7 +86,7 @@ class CannonSpotOverlay extends Overlay
 			LocalPoint spotPoint = LocalPoint.fromWorld(client, spot);
 			LocalPoint localLocation = client.getLocalPlayer().getLocalLocation();
 
-			if (spotPoint != null && localLocation.distanceTo(spotPoint) <= MAX_DISTANCE)
+			if (spotPoint != null && localLocation.distanceTo(spotPoint) <= MAX_OVERLAY_DISTANCE)
 			{
 				renderCannonSpot(graphics, client, spotPoint, itemManager.getImage(CANNONBALL), Color.RED);
 			}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonSpots.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonSpots.java
@@ -43,7 +43,7 @@ enum CannonSpots
 	BLUE_DRAGON(new WorldPoint(1933, 8973, 1)),
 	BRINE_RAT(new WorldPoint(2707, 10132, 0)),
 	CAVE_HORROR(new WorldPoint(3785, 9460, 0)),
-	DAGGANOTH(new WorldPoint(2524, 10020, 0)),
+	DAGGANOTH(new WorldPoint(2524, 10020, 0), new WorldPoint(2478, 10443, 0), new WorldPoint(2420, 10425, 0)),
 	DARK_BEAST(new WorldPoint(1992, 4655, 0)),
 	DARK_WARRIOR(new WorldPoint(3030, 3632, 0)),
 	DUST_DEVIL(new WorldPoint(3218, 9366, 0)),


### PR DESCRIPTION
Adds two Dagganoth cannon spots in Jormungand's prison which closes #13503 
One spot it to the West and enjoys more low-level Dagganoths which are better due to their nonexistent Ranged defence, and one to the East which is more open and therefore has more targets to shoot at. The positions themselves are relatively optimal in terms of cannon range and respawn positions but may possibly be altered based on more concrete data.

Also took this opportunity to combine the max rendering distance for both cannon overlays (cannonballs left, double-hit spots when the cannon is placed and the optimal positions when the cannon is not placed) which were for some reason separate but almost identical. Also increased the distance itself to somewhere around the maximal distance in which you can also interact with the cannon itself based on some testing (couldn't find it there's a known figure for that).
