### PR TITLE
timer plugin: overhaul handling Imbued Heart cooldown

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/Varbits.java
+++ b/runelite-api/src/main/java/net/runelite/api/Varbits.java
@@ -530,6 +530,13 @@ public enum Varbits
 	CORRUPTION_COOLDOWN(12288),
 
 	/**
+	 * Imbued Heart cooldown
+	 * Number of game tick remaining on cooldown in intervals of 10; for a value X there are 10 * X game ticks remaining.
+	 * The heart regains its power once this reaches 0.
+	 */
+	IMBUED_HEART_COOLDOWN(5361),
+
+	/**
 	 * Amount of items in each bank tab
 	 */
 	BANK_TAB_ONE_COUNT(4171),


### PR DESCRIPTION
Found a nice little Varbit (5361) that gets sent to the client in intervals of 6 containing remaining Imbued Heart cooldown time.
So instead of utilizing the menu entry coupled with the actual Magic boost to figure out when the player started the boost (which introduced an issue of "forgetting" remaining time when logging off or hopping worlds), it's switched to using information from the Varbit (which has a nice side-effect of "remembering" cooldown between logins).
Also fixes the bug of using the Heart while in the bank

Technically it would be a little cleaner to simply re-create the timer every 6 seconds, but for the sake of performance I simply saved a reference.

Closes #14091