### PR TITLE
chatfilter: add CONSOLE to collapsible message types

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatfilter/ChatFilterPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatfilter/ChatFilterPlugin.java
@@ -41,6 +41,7 @@ import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 import javax.inject.Inject;
 import net.runelite.api.ChatMessageType;
+import static net.runelite.api.ChatMessageType.CONSOLE;
 import static net.runelite.api.ChatMessageType.ENGINE;
 import static net.runelite.api.ChatMessageType.GAMEMESSAGE;
 import static net.runelite.api.ChatMessageType.ITEM_EXAMINE;
@@ -88,6 +89,7 @@ public class ChatFilterPlugin extends Plugin
 		NPC_EXAMINE,
 		OBJECT_EXAMINE,
 		SPAM,
+		CONSOLE,
 		PUBLICCHAT,
 		MODCHAT
 	);
@@ -199,6 +201,7 @@ public class ChatFilterPlugin extends Plugin
 			case NPC_EXAMINE:
 			case OBJECT_EXAMINE:
 			case SPAM:
+			case CONSOLE:
 				if (config.filterGameChat())
 				{
 					message = censorMessage(null, message);


### PR DESCRIPTION
Added CONSOLE to the list of collapsible message types so that when the "Collapse Game Chat" option is turned on in the Chat Filter plugin, repetitive RuneLite notifications such as "You are now idle!" will also be collapsed.

Before:
![Before](https://user-images.githubusercontent.com/29353990/133798901-13b72dad-afd1-4b49-96e2-1805f09b23a8.png)

After:
![After](https://user-images.githubusercontent.com/29353990/133798923-de607e63-35b8-4eb2-9067-dba3e8e87438.PNG)


