### PR TITLE
party: toggleable party stats overlay

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/party/PartyConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/party/PartyConfig.java
@@ -33,6 +33,17 @@ import net.runelite.client.config.ConfigItem;
 public interface PartyConfig extends Config
 {
 	String GROUP = "party";
+	
+	@ConfigItem(
+		keyName = "partyStatsOverlay",
+		name = "Party Stats Overlay",
+		description = "Displays party members' health and prayer as an overlay.",
+		position = 0
+	)
+	default boolean partyStatsOverlay()
+	{
+		return true;
+	}
 
 	@ConfigItem(
 		keyName = "pings",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/party/PartyPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/party/PartyPlugin.java
@@ -181,6 +181,7 @@ public class PartyPlugin extends Plugin
 
 		clientToolbar.addNavigation(navButton);
 
+		partyStatsOverlay.setEnabled(config.partyStatsOverlay());
 		overlayManager.add(partyStatsOverlay);
 		overlayManager.add(partyPingOverlay);
 		wsClient.registerMessage(SkillUpdate.class);
@@ -253,6 +254,8 @@ public class PartyPlugin extends Plugin
 	{
 		if (event.getGroup().equals(PartyConfig.GROUP))
 		{
+			partyStatsOverlay.setEnabled(config.partyStatsOverlay());
+			
 			final PartyMember localMember = party.getLocalMember();
 
 			if (localMember != null)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/party/PartyStatsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/party/PartyStatsOverlay.java
@@ -33,6 +33,7 @@ import java.awt.Rectangle;
 import java.util.Map;
 import java.util.UUID;
 import javax.inject.Inject;
+import lombok.Setter;
 import net.runelite.api.MenuAction;
 import net.runelite.client.plugins.party.data.PartyData;
 import net.runelite.client.ui.overlay.OverlayMenuEntry;
@@ -53,6 +54,9 @@ public class PartyStatsOverlay extends OverlayPanel
 	private final PartyPlugin plugin;
 	private final PartyService party;
 	private final PartyConfig config;
+	
+	@Setter
+	private boolean enabled = true;
 
 	@Inject
 	private PartyStatsOverlay(final PartyPlugin plugin, final PartyService party, final PartyConfig config)
@@ -70,7 +74,7 @@ public class PartyStatsOverlay extends OverlayPanel
 	public Dimension render(Graphics2D graphics)
 	{
 		final Map<UUID, PartyData> partyDataMap = plugin.getPartyDataMap();
-		if (partyDataMap.isEmpty())
+		if (partyDataMap.isEmpty() || !enabled)
 		{
 			return null;
 		}


### PR DESCRIPTION
The party plugin provides features that extend beyond the stats overlay, but does not provide the option to turn off the stats overlay. In large groups (depending on UI scaling), the stats overlay can take up an unnecessarily large portion of the screen.

Adds the ability to disable the stats overlay while keeping the other party features (tile marking, non-party plugin features like raid layout sharing, world map, etc.)