### PR TITLE
fishing, mining, smelting plugins: account for extra 'item' received from effects

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/events/XpTrackerSkillReset.java
+++ b/runelite-client/src/main/java/net/runelite/client/events/XpTrackerSkillReset.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2021, Tal <https://github.com/talsk>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.events;
+
+import lombok.Value;
+import net.runelite.api.Skill;
+
+@Value
+public class XpTrackerSkillReset
+{
+	public enum ResetType {
+		ACTIONS,
+		ACTIONS_PER_HR,
+	}
+	ResetType resetType;
+	Skill skill;
+}

--- a/runelite-client/src/main/java/net/runelite/client/events/XpTrackerSkillReset.java
+++ b/runelite-client/src/main/java/net/runelite/client/events/XpTrackerSkillReset.java
@@ -30,10 +30,12 @@ import net.runelite.api.Skill;
 @Value
 public class XpTrackerSkillReset
 {
-	public enum ResetType {
+	public enum ResetType
+	{
 		ACTIONS,
 		ACTIONS_PER_HR,
 	}
+
 	ResetType resetType;
 	Skill skill;
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingConfig.java
@@ -130,7 +130,7 @@ public interface FishingConfig extends Config
 		position = 7,
 		keyName = "statTimeout",
 		name = "Session stats timeout",
-		description = "Timeout after which fishing session stats is hidden."
+		description = "Timeout after which Fishing session stats are hidden."
 	)
 	@Units(Units.MINUTES)
 	default int statTimeout()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingConfig.java
@@ -129,8 +129,8 @@ public interface FishingConfig extends Config
 	@ConfigItem(
 		position = 7,
 		keyName = "statTimeout",
-		name = "Reset stats",
-		description = "The time until fishing session data is reset in minutes."
+		name = "Session stats timeout",
+		description = "Timeout after which fishing session stats is hidden."
 	)
 	@Units(Units.MINUTES)
 	default int statTimeout()
@@ -151,6 +151,17 @@ public interface FishingConfig extends Config
 
 	@ConfigItem(
 		position = 9,
+		keyName = "includeExtraFish",
+		name = "Include extra fish caught",
+		description = "Include extra fish caught via Rada's Blessing and Spirit Flakes in session stats."
+	)
+	default boolean includeExtraFish()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		position = 10,
 		keyName = "showMinnowOverlay",
 		name = "Show Minnow Movement overlay",
 		description = "Display the minnow progress pie overlay."
@@ -161,7 +172,7 @@ public interface FishingConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 10,
+		position = 11,
 		keyName = "flyingFishNotification",
 		name = "Flying fish notification",
 		description = "Send a notification when a flying fish spawns on your fishing spot."
@@ -172,7 +183,7 @@ public interface FishingConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 11,
+		position = 12,
 		keyName = "trawlerTimer",
 		name = "Trawler timer in M:SS",
 		description = "Trawler timer will display a more accurate timer in M:SS format."
@@ -183,7 +194,7 @@ public interface FishingConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 12,
+		position = 13,
 		keyName = "trawlerContribution",
 		name = "Trawler contribution",
 		description = "Display the exact number of trawler contribution points gained."

--- a/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingOverlay.java
@@ -127,16 +127,20 @@ class FishingOverlay extends OverlayPanel
 		int actions = xpTrackerService.getActions(Skill.FISHING);
 		if (actions > 0)
 		{
-			StringBuilder caughtFish = new StringBuilder(Integer.toString(plugin.getSession().getFishCaught()));
+			FishingSession session = plugin.getSession();
+			StringBuilder caughtFish = new StringBuilder(Integer.toString(session.getFishCaught()));
 			float fishHrMultiplier = 1;
 			if (config.includeExtraFish())
 			{
 				caughtFish
 					.append(" (+ ")
-					.append(plugin.getSession().getExtraFishCaught())
+					.append(session.getExtraFishCaught())
 					.append(")");
 
-				fishHrMultiplier += ((float) plugin.getSession().getExtraFishCaughtSinceHrReset()) / actions;
+				if (session.getFishCaughtSinceHrReset() > 0)
+				{
+					fishHrMultiplier += ((float) session.getExtraFishCaughtSinceHrReset()) / session.getFishCaughtSinceHrReset();
+				}
 			}
 
 			panelComponent.getChildren().add(LineComponent.builder()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingOverlay.java
@@ -127,16 +127,28 @@ class FishingOverlay extends OverlayPanel
 		int actions = xpTrackerService.getActions(Skill.FISHING);
 		if (actions > 0)
 		{
+			StringBuilder caughtFish = new StringBuilder(Integer.toString(plugin.getSession().getFishCaught()));
+			float fishHrMultiplier = 1;
+			if (config.includeExtraFish())
+			{
+				caughtFish
+					.append(" (+ ")
+					.append(plugin.getSession().getExtraFishCaught())
+					.append(")");
+
+				fishHrMultiplier += ((float) plugin.getSession().getExtraFishCaughtSinceHrReset()) / actions;
+			}
+
 			panelComponent.getChildren().add(LineComponent.builder()
 				.left("Caught fish:")
-				.right(Integer.toString(actions))
+				.right(caughtFish.toString())
 				.build());
 
 			if (actions > 2)
 			{
 				panelComponent.getChildren().add(LineComponent.builder()
 					.left("Fish/hr:")
-					.right(Integer.toString(xpTrackerService.getActionsHr(Skill.FISHING)))
+					.right(Integer.toString((int) (fishHrMultiplier * ((float) xpTrackerService.getActionsHr(Skill.FISHING)))))
 					.build());
 			}
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingOverlay.java
@@ -101,7 +101,8 @@ class FishingOverlay extends OverlayPanel
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
-		if (!config.showFishingStats() || plugin.getSession().getLastFishCaught() == null)
+		FishingSession session = plugin.getSession();
+		if (!config.showFishingStats() || session.getLastFishCaught() == null)
 		{
 			return null;
 		}
@@ -127,13 +128,11 @@ class FishingOverlay extends OverlayPanel
 		int actions = xpTrackerService.getActions(Skill.FISHING);
 		if (actions > 0)
 		{
-			FishingSession session = plugin.getSession();
 			StringBuilder caughtFish = new StringBuilder(Integer.toString(session.getFishCaught()));
 			float fishHrMultiplier = 1;
 			if (config.includeExtraFish())
 			{
-				caughtFish
-					.append(" (+ ")
+				caughtFish.append(" (+ ")
 					.append(session.getExtraFishCaught())
 					.append(")");
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingPlugin.java
@@ -210,6 +210,7 @@ public class FishingPlugin extends Plugin
 		{
 			session.setLastFishCaught(Instant.now());
 			session.increaseFishCaught(1);
+			session.increaseFishCaughtSinceHrReset(1);
 			spotOverlay.setHidden(false);
 			fishingSpotMinimapOverlay.setHidden(false);
 		}
@@ -380,7 +381,9 @@ public class FishingPlugin extends Plugin
 		log.debug("Got skill reset for skill {}", event.getSkill());
 		if (event.getSkill() == Skill.FISHING)
 		{
-			session.setExtraFishCaughtSinceHrReset(0); // Both types reset actions per hour.
+			// Both types reset actions per hour.
+			session.setFishCaughtSinceHrReset(0);
+			session.setExtraFishCaughtSinceHrReset(0);
 			if (event.getResetType() == XpTrackerSkillReset.ResetType.ACTIONS)
 			{
 				session.setFishCaught(0);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingPlugin.java
@@ -378,7 +378,6 @@ public class FishingPlugin extends Plugin
 	@Subscribe
 	public void onXpTrackerSkillReset(XpTrackerSkillReset event)
 	{
-		log.debug("Got skill reset for skill {}", event.getSkill());
 		if (event.getSkill() == Skill.FISHING)
 		{
 			// Both types reset actions per hour.

--- a/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingPlugin.java
@@ -48,6 +48,7 @@ import net.runelite.api.ItemContainer;
 import net.runelite.api.ItemID;
 import net.runelite.api.MenuAction;
 import net.runelite.api.NPC;
+import net.runelite.api.Skill;
 import net.runelite.api.Varbits;
 import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.events.ChatMessage;
@@ -65,6 +66,7 @@ import net.runelite.client.Notifier;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.events.OverlayMenuClicked;
+import net.runelite.client.events.XpTrackerSkillReset;
 import net.runelite.client.game.FishingSpot;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDependency;
@@ -207,6 +209,7 @@ public class FishingPlugin extends Plugin
 			event.getMessage().equals("Your cormorant returns with its catch."))
 		{
 			session.setLastFishCaught(Instant.now());
+			session.increaseFishCaught(1);
 			spotOverlay.setHidden(false);
 			fishingSpotMinimapOverlay.setHidden(false);
 		}
@@ -214,6 +217,12 @@ public class FishingPlugin extends Plugin
 		if (event.getMessage().equals("A flying fish jumps up and eats some of your minnows!") && config.flyingFishNotification())
 		{
 			notifier.notify("A flying fish is eating your minnows!");
+		}
+
+		if (event.getMessage().endsWith("enabled you to catch an extra fish."))
+		{
+			session.increaseExtraFishCaught(1);
+			session.increaseExtraFishCaughtSinceHrReset(1);
 		}
 	}
 
@@ -362,6 +371,21 @@ public class FishingPlugin extends Plugin
 		{
 			trawlerStartTime = Instant.now();
 			log.debug("Trawler session started");
+		}
+	}
+
+	@Subscribe
+	public void onXpTrackerSkillReset(XpTrackerSkillReset event)
+	{
+		log.debug("Got skill reset for skill {}", event.getSkill());
+		if (event.getSkill() == Skill.FISHING)
+		{
+			session.setExtraFishCaughtSinceHrReset(0); // Both types reset actions per hour.
+			if (event.getResetType() == XpTrackerSkillReset.ResetType.ACTIONS)
+			{
+				session.setFishCaught(0);
+				session.setExtraFishCaught(0);
+			}
 		}
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingSession.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingSession.java
@@ -37,6 +37,10 @@ class FishingSession
 
 	@Getter(AccessLevel.PACKAGE)
 	@Setter
+	private int fishCaughtSinceHrReset;
+
+	@Getter(AccessLevel.PACKAGE)
+	@Setter
 	private int extraFishCaught;
 
 	@Getter(AccessLevel.PACKAGE)
@@ -51,6 +55,11 @@ class FishingSession
 	public void increaseFishCaught(int amount)
 	{
 		fishCaught += amount;
+	}
+
+	public void increaseFishCaughtSinceHrReset(int amount)
+	{
+		fishCaughtSinceHrReset += amount;
 	}
 
 	public void increaseExtraFishCaught(int amount)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingSession.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingSession.java
@@ -25,12 +25,41 @@
 package net.runelite.client.plugins.fishing;
 
 import java.time.Instant;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
 
 class FishingSession
 {
-	@Getter
+	@Getter(AccessLevel.PACKAGE)
+	@Setter
+	private int fishCaught;
+
+	@Getter(AccessLevel.PACKAGE)
+	@Setter
+	private int extraFishCaught;
+
+	@Getter(AccessLevel.PACKAGE)
+	@Setter
+	private int extraFishCaughtSinceHrReset;
+
+	@Getter(AccessLevel.PACKAGE)
 	@Setter
 	private Instant lastFishCaught;
+
+
+	public void increaseFishCaught(int amount)
+	{
+		fishCaught += amount;
+	}
+
+	public void increaseExtraFishCaught(int amount)
+	{
+		extraFishCaught += amount;
+	}
+
+	public void increaseExtraFishCaughtSinceHrReset(int amount)
+	{
+		extraFishCaughtSinceHrReset += amount;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/mining/MiningConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/mining/MiningConfig.java
@@ -34,9 +34,10 @@ import net.runelite.client.config.Units;
 public interface MiningConfig extends Config
 {
 	@ConfigItem(
+		position = 1,
 		keyName = "statTimeout",
 		name = "Reset stats",
-		description = "Duration the mining indicator and session stats are displayed before being reset"
+		description = "Timeout after which Mining session stats are hidden"
 	)
 	@Units(Units.MINUTES)
 	default int statTimeout()
@@ -45,11 +46,23 @@ public interface MiningConfig extends Config
 	}
 
 	@ConfigItem(
+		position = 2,
 		keyName = "showMiningStats",
 		name = "Show session stats",
-		description = "Configures whether to display mining session stats"
+		description = "Configures whether to display Mining session stats"
 	)
 	default boolean showMiningStats()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		position = 3,
+		keyName = "includeExtraOres",
+		name = "Include extra ores mined",
+		description = "Include extra ores mined via Varrock Armour effect in session stats."
+	)
+	default boolean includeExtraOres()
 	{
 		return true;
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/mining/MiningOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/mining/MiningOverlay.java
@@ -66,7 +66,7 @@ class MiningOverlay extends OverlayPanel
 	public Dimension render(Graphics2D graphics)
 	{
 		MiningSession session = plugin.getSession();
-		if (session == null || session.getLastMined() == null || !config.showMiningStats())
+		if (session.getLastMined() == null || !config.showMiningStats())
 		{
 			return null;
 		}
@@ -90,16 +90,28 @@ class MiningOverlay extends OverlayPanel
 		int actions = xpTrackerService.getActions(Skill.MINING);
 		if (actions > 0)
 		{
+			StringBuilder oresMined = new StringBuilder(Integer.toString(session.getOresMined()));
+			float actionsHrMultiplier = 1;
+			if (config.includeExtraOres())
+			{
+				oresMined.append(" (+")
+					.append(session.getExtraOresMined())
+					.append(")");
+				if (session.getOresMinedSinceHrReset() > 0)
+				{
+					actionsHrMultiplier += ((float) session.getExtraOresMinedSinceHrReset() / session.getOresMinedSinceHrReset());
+				}
+			}
 			panelComponent.getChildren().add(LineComponent.builder()
 				.left("Total mined:")
-				.right(Integer.toString(actions))
+				.right(oresMined.toString())
 				.build());
 
 			if (actions > 2)
 			{
 				panelComponent.getChildren().add(LineComponent.builder()
 					.left("Mined/hr:")
-					.right(Integer.toString(xpTrackerService.getActionsHr(Skill.MINING)))
+					.right(Integer.toString((int) (actionsHrMultiplier * ((float) xpTrackerService.getActionsHr(Skill.MINING)))))
 					.build());
 			}
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/mining/MiningSession.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/mining/MiningSession.java
@@ -25,15 +25,49 @@
 package net.runelite.client.plugins.mining;
 
 import java.time.Instant;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.Setter;
 
 class MiningSession
 {
-	@Getter
+	@Getter(AccessLevel.PACKAGE)
+	@Setter
 	private Instant lastMined;
 
-	void setLastMined()
+	@Getter(AccessLevel.PACKAGE)
+	@Setter
+	private int oresMined;
+
+	@Getter(AccessLevel.PACKAGE)
+	@Setter
+	private int oresMinedSinceHrReset;
+
+	@Getter(AccessLevel.PACKAGE)
+	@Setter
+	private int extraOresMined;
+
+	@Getter(AccessLevel.PACKAGE)
+	@Setter
+	private int extraOresMinedSinceHrReset;
+
+	void increaseOresMined(int amount)
 	{
-		lastMined = Instant.now();
+		oresMined += amount;
+	}
+
+	void increaseOresMinedSinceHrReset(int amount)
+	{
+		oresMinedSinceHrReset += amount;
+	}
+
+	void increaseExtraOresMined(int amount)
+	{
+		extraOresMined += amount;
+	}
+
+	void increaseExtraOresMinedSinceHrReset(int amount)
+	{
+		extraOresMinedSinceHrReset += amount;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/smelting/SmeltingConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/smelting/SmeltingConfig.java
@@ -35,12 +35,23 @@ public interface SmeltingConfig extends Config
 	@ConfigItem(
 		position = 1,
 		keyName = "statTimeout",
-		name = "Reset stats",
-		description = "The time it takes for the current smelting session to be reset"
+		name = "Session stats stats",
+		description = "Timeout after which Smithing session stats are hidden"
 	)
 	@Units(Units.MINUTES)
 	default int statTimeout()
 	{
 		return 5;
+	}
+
+	@ConfigItem(
+		position = 2,
+		keyName = "includeExtraBars",
+		name = "Include extra bars smelted",
+		description = "Include extra bars smelted via Varrock Armour effect in session stats."
+	)
+	default boolean includeExtraBars()
+	{
+		return true;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/smelting/SmeltingConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/smelting/SmeltingConfig.java
@@ -36,7 +36,7 @@ public interface SmeltingConfig extends Config
 		position = 1,
 		keyName = "statTimeout",
 		name = "Session stats stats",
-		description = "Timeout after which Smithing session stats are hidden"
+		description = "Timeout after which Smelting session stats are hidden"
 	)
 	@Units(Units.MINUTES)
 	default int statTimeout()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/smelting/SmeltingOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/smelting/SmeltingOverlay.java
@@ -94,7 +94,7 @@ class SmeltingOverlay extends OverlayPanel
 		int actions = xpTrackerService.getActions(Skill.SMITHING);
 		if (actions > 0)
 		{
-			if (plugin.getSession().getBarsSmelted() > 0)
+			if (session.getBarsSmelted() > 0)
 			{
 				StringBuilder barsSmelted = new StringBuilder(Integer.toString(session.getBarsSmelted()));
 				if (config.includeExtraBars())
@@ -109,7 +109,7 @@ class SmeltingOverlay extends OverlayPanel
 					.build());
 			}
 
-			if (plugin.getSession().getCannonBallsSmelted() > 0)
+			if (session.getCannonBallsSmelted() > 0)
 			{
 				panelComponent.getChildren().add(LineComponent.builder()
 					.left("Cannonballs:")
@@ -119,17 +119,17 @@ class SmeltingOverlay extends OverlayPanel
 
 			if (actions > 2)
 			{
-				float smithHrMultiplier = 1;
+				float actionsHrMultiplier = 1;
 				if (config.includeExtraBars())
 				{
 					if (session.getBarsSmeltedSinceHrReset() > 0)
 					{
-						smithHrMultiplier += ((float) session.getExtraBarsSmeltedSinceHrReset() / session.getBarsSmeltedSinceHrReset());
+						actionsHrMultiplier += ((float) session.getExtraBarsSmeltedSinceHrReset() / session.getBarsSmeltedSinceHrReset());
 					}
 				}
 				panelComponent.getChildren().add(LineComponent.builder()
 					.left("Actions/hr:")
-					.right(Integer.toString((int) (smithHrMultiplier * ((float) xpTrackerService.getActionsHr(Skill.SMITHING)))))
+					.right(Integer.toString((int) (actionsHrMultiplier * ((float) xpTrackerService.getActionsHr(Skill.SMITHING)))))
 					.build());
 			}
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/smelting/SmeltingSession.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/smelting/SmeltingSession.java
@@ -27,27 +27,58 @@ package net.runelite.client.plugins.smelting;
 import java.time.Instant;
 import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.Setter;
 
 class SmeltingSession
 {
 	@Getter(AccessLevel.PACKAGE)
+	@Setter
 	private int barsSmelted;
 
 	@Getter(AccessLevel.PACKAGE)
+	@Setter
+	private int barsSmeltedSinceHrReset;
+
+	@Getter(AccessLevel.PACKAGE)
+	@Setter
+	private int extraBarsSmelted;
+
+	@Getter(AccessLevel.PACKAGE)
+	@Setter
+	private int extraBarsSmeltedSinceHrReset;
+
+	@Getter(AccessLevel.PACKAGE)
+	@Setter
 	private int cannonBallsSmelted;
 
 	@Getter(AccessLevel.PACKAGE)
+	@Setter
 	private Instant lastItemSmelted;
 
-	void increaseBarsSmelted()
+	void increaseBarsSmelted(int amount)
 	{
-		barsSmelted++;
+		barsSmelted += amount;
 		lastItemSmelted = Instant.now();
 	}
 
-	void increaseCannonBallsSmelted()
+	void increaseBarsSmeltedSinceHrReset(int amount)
 	{
-		cannonBallsSmelted += 4;
+		barsSmeltedSinceHrReset += amount;
+	}
+
+	void increaseExtraBarsSmelted(int amount)
+	{
+		extraBarsSmelted += amount;
+	}
+
+	void increaseExtraBarsSmeltedSinceHrReset(int amount)
+	{
+		extraBarsSmeltedSinceHrReset += amount;
+	}
+
+	void increaseCannonBallsSmelted(int amount)
+	{
+		cannonBallsSmelted += amount;
 		lastItemSmelted = Instant.now();
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerPlugin.java
@@ -60,7 +60,9 @@ import net.runelite.api.events.StatChanged;
 import net.runelite.api.widgets.WidgetID;
 import static net.runelite.api.widgets.WidgetInfo.TO_GROUP;
 import net.runelite.client.config.ConfigManager;
+import net.runelite.client.eventbus.EventBus;
 import net.runelite.client.eventbus.Subscribe;
+import net.runelite.client.events.XpTrackerSkillReset;
 import net.runelite.client.game.NPCManager;
 import net.runelite.client.game.SkillIconManager;
 import net.runelite.client.plugins.Plugin;
@@ -122,6 +124,9 @@ public class XpTrackerPlugin extends Plugin
 
 	@Inject
 	private XpState xpState;
+
+	@Inject
+	private EventBus eventBus;
 
 	private NavigationButton navButton;
 	@Setter(AccessLevel.PACKAGE)
@@ -320,6 +325,11 @@ public class XpTrackerPlugin extends Plugin
 		xpPanel.resetAllInfoBoxes();
 		xpPanel.updateTotal(new XpSnapshotSingle.XpSnapshotSingleBuilder().build());
 		overlayManager.removeIf(e -> e instanceof XpInfoBoxOverlay);
+		for (Skill s : Skill.values())
+		{
+			eventBus.post(new XpTrackerSkillReset(XpTrackerSkillReset.ResetType.ACTIONS, s));
+			eventBus.post(new XpTrackerSkillReset(XpTrackerSkillReset.ResetType.ACTIONS_PER_HR, s));
+		}
 	}
 
 	/**
@@ -334,6 +344,7 @@ public class XpTrackerPlugin extends Plugin
 		xpState.resetSkill(skill, currentXp);
 		xpPanel.resetSkill(skill);
 		removeOverlay(skill);
+		eventBus.post(new XpTrackerSkillReset(XpTrackerSkillReset.ResetType.ACTIONS, skill));
 	}
 
 	/**
@@ -362,6 +373,7 @@ public class XpTrackerPlugin extends Plugin
 	void resetSkillPerHourState(Skill skill)
 	{
 		xpState.resetSkillPerHour(skill);
+		eventBus.post(new XpTrackerSkillReset(XpTrackerSkillReset.ResetType.ACTIONS_PER_HR, skill));
 	}
 
 	/**

--- a/runelite-client/src/test/java/net/runelite/client/plugins/fishing/FishingPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/fishing/FishingPluginTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2021, Tal <https://github.com/talsk>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.fishing;
+
+import com.google.inject.Guice;
+import com.google.inject.testing.fieldbinder.Bind;
+import com.google.inject.testing.fieldbinder.BoundFieldModule;
+import javax.inject.Inject;
+import net.runelite.api.ChatMessageType;
+import net.runelite.api.Client;
+import net.runelite.api.Skill;
+import net.runelite.api.events.ChatMessage;
+import net.runelite.client.Notifier;
+import net.runelite.client.events.XpTrackerSkillReset;
+import net.runelite.client.ui.overlay.OverlayManager;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class FishingPluginTest
+{
+	static private final String ANGLERFISH_CAUGHT_MESSAGE = "You catch an anglerfish.";
+	static private final String EXTRA_FISH_CAUGHT_MESSAGE = "The spirit flakes enabled you to catch an extra fish.";
+
+	@Inject
+	FishingPlugin fishingPlugin;
+
+	@Mock
+	@Bind
+	FishingConfig config;
+
+	@Mock
+	@Bind
+	FishingOverlay fishingOverlay;
+
+	@Mock
+	@Bind
+	OverlayManager overlayManager;
+
+	@Mock
+	@Bind
+	Client client;
+
+	@Mock
+	@Bind
+	Notifier notifier;
+
+	@Mock
+	@Bind
+	FishingSpotOverlay fishingSpotOverlay;
+
+	@Mock
+	@Bind
+	FishingSpotMinimapOverlay fishingSpotMinimapOverlay;
+
+
+	@Before
+	public void before()
+	{
+		Guice.createInjector(BoundFieldModule.of(this)).injectMembers(this);
+	}
+
+	@Test
+	public void testFish()
+	{
+		ChatMessage anglerCaughtMessage = new ChatMessage(null, ChatMessageType.SPAM, "", ANGLERFISH_CAUGHT_MESSAGE, "", 0);
+		fishingPlugin.onChatMessage(anglerCaughtMessage);
+
+		assertSessionStats(1, 1, 0, 0);
+	}
+
+	@Test
+	public void testExtraFish()
+	{
+		ChatMessage anglerCaughtMessage = new ChatMessage(null, ChatMessageType.SPAM, "", ANGLERFISH_CAUGHT_MESSAGE, "", 0);
+		ChatMessage extraFishCaughtMessage = new ChatMessage(null, ChatMessageType.SPAM, "", EXTRA_FISH_CAUGHT_MESSAGE, "", 0);
+		fishingPlugin.onChatMessage(anglerCaughtMessage);
+		fishingPlugin.onChatMessage(extraFishCaughtMessage);
+
+		assertSessionStats(1, 1, 1, 1);
+	}
+
+	@Test
+	public void testFishingSkillReset()
+	{
+		ChatMessage anglerCaughtMessage = new ChatMessage(null, ChatMessageType.SPAM, "", ANGLERFISH_CAUGHT_MESSAGE, "", 0);
+		ChatMessage extraFishCaughtMessage = new ChatMessage(null, ChatMessageType.SPAM, "", EXTRA_FISH_CAUGHT_MESSAGE, "", 0);
+
+		fishingPlugin.onChatMessage(anglerCaughtMessage);
+		fishingPlugin.onChatMessage(anglerCaughtMessage);
+		fishingPlugin.onChatMessage(extraFishCaughtMessage);
+
+		XpTrackerSkillReset magicResetEvent = new XpTrackerSkillReset(XpTrackerSkillReset.ResetType.ACTIONS, Skill.MAGIC);
+		fishingPlugin.onXpTrackerSkillReset(magicResetEvent);
+		assertSessionStats(2, 2, 1, 1);
+
+		XpTrackerSkillReset fishingResetEvent = new XpTrackerSkillReset(XpTrackerSkillReset.ResetType.ACTIONS, Skill.FISHING);
+		fishingPlugin.onXpTrackerSkillReset(fishingResetEvent);
+		assertSessionStats(0, 0, 0, 0);
+	}
+
+	@Test
+	public void testFishingSkillHrReset()
+	{
+		ChatMessage anglerCaughtMessage = new ChatMessage(null, ChatMessageType.SPAM, "", ANGLERFISH_CAUGHT_MESSAGE, "", 0);
+		ChatMessage extraFishCaughtMessage = new ChatMessage(null, ChatMessageType.SPAM, "", EXTRA_FISH_CAUGHT_MESSAGE, "", 0);
+
+		fishingPlugin.onChatMessage(anglerCaughtMessage);
+		fishingPlugin.onChatMessage(anglerCaughtMessage);
+		fishingPlugin.onChatMessage(extraFishCaughtMessage);
+
+		XpTrackerSkillReset magicHrResetEvent = new XpTrackerSkillReset(XpTrackerSkillReset.ResetType.ACTIONS_PER_HR, Skill.MAGIC);
+		fishingPlugin.onXpTrackerSkillReset(magicHrResetEvent);
+		assertSessionStats(2, 2, 1, 1);
+
+		XpTrackerSkillReset fishingHrResetEvent = new XpTrackerSkillReset(XpTrackerSkillReset.ResetType.ACTIONS_PER_HR, Skill.FISHING);
+		fishingPlugin.onXpTrackerSkillReset(fishingHrResetEvent);
+		assertSessionStats(2, 0, 1, 0);
+	}
+
+	void assertSessionStats(int amountFished, int amountFishedSinceReset, int amountExtraFished, int amountExtraFishedSinceReset)
+	{
+		assertNotNull(fishingPlugin.getSession().getLastFishCaught());
+		assertEquals(fishingPlugin.getSession().getFishCaught(), amountFished);
+		assertEquals(fishingPlugin.getSession().getFishCaughtSinceHrReset(), amountFishedSinceReset);
+		assertEquals(fishingPlugin.getSession().getExtraFishCaught(), amountExtraFished);
+		assertEquals(fishingPlugin.getSession().getExtraFishCaughtSinceHrReset(), amountExtraFishedSinceReset);
+	}
+}

--- a/runelite-client/src/test/java/net/runelite/client/plugins/smelting/SmeltingPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/smelting/SmeltingPluginTest.java
@@ -29,7 +29,9 @@ import com.google.inject.testing.fieldbinder.Bind;
 import com.google.inject.testing.fieldbinder.BoundFieldModule;
 import javax.inject.Inject;
 import net.runelite.api.ChatMessageType;
+import net.runelite.api.Skill;
 import net.runelite.api.events.ChatMessage;
+import net.runelite.client.events.XpTrackerSkillReset;
 import net.runelite.client.ui.overlay.OverlayManager;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -44,6 +46,7 @@ public class SmeltingPluginTest
 {
 	private static final String SMELT_CANNONBALL = "You remove the cannonballs from the mould";
 	private static final String SMELT_BAR = "You retrieve a bar of steel.";
+	private static final String SMELT_EXTRA_BAR = "The Varrock platebody enabled you to smelt your next ore simultaneously.";
 
 	@Inject
 	SmeltingPlugin smeltingPlugin;
@@ -72,9 +75,7 @@ public class SmeltingPluginTest
 		ChatMessage chatMessage = new ChatMessage(null, ChatMessageType.SPAM, "", SMELT_CANNONBALL, "", 0);
 		smeltingPlugin.onChatMessage(chatMessage);
 
-		SmeltingSession smeltingSession = smeltingPlugin.getSession();
-		assertNotNull(smeltingSession);
-		assertEquals(4, smeltingSession.getCannonBallsSmelted());
+		assertSessionStats(0, 0, 0, 0, 4);
 	}
 
 	@Test
@@ -83,8 +84,65 @@ public class SmeltingPluginTest
 		ChatMessage chatMessage = new ChatMessage(null, ChatMessageType.SPAM, "", SMELT_BAR, "", 0);
 		smeltingPlugin.onChatMessage(chatMessage);
 
-		SmeltingSession smeltingSession = smeltingPlugin.getSession();
-		assertNotNull(smeltingSession);
-		assertEquals(1, smeltingSession.getBarsSmelted());
+		assertSessionStats(1, 1, 0, 0, 0);
+	}
+
+	@Test
+	public void testExtraBars()
+	{
+		ChatMessage barMessage = new ChatMessage(null, ChatMessageType.SPAM, "", SMELT_BAR, "", 0);
+		ChatMessage extraBarMessage = new ChatMessage(null, ChatMessageType.SPAM, "", SMELT_EXTRA_BAR, "", 0);
+		smeltingPlugin.onChatMessage(barMessage);
+		smeltingPlugin.onChatMessage(extraBarMessage);
+
+		assertSessionStats(1, 1, 1, 1, 0);
+	}
+
+	@Test
+	public void testSmeltingSkillReset()
+	{
+		ChatMessage barMessage = new ChatMessage(null, ChatMessageType.SPAM, "", SMELT_BAR, "", 0);
+		ChatMessage extraBarMessage = new ChatMessage(null, ChatMessageType.SPAM, "", SMELT_EXTRA_BAR, "", 0);
+
+		smeltingPlugin.onChatMessage(barMessage);
+		smeltingPlugin.onChatMessage(barMessage);
+		smeltingPlugin.onChatMessage(extraBarMessage);
+
+		XpTrackerSkillReset magicResetEvent = new XpTrackerSkillReset(XpTrackerSkillReset.ResetType.ACTIONS, Skill.MAGIC);
+		smeltingPlugin.onXpTrackerSkillReset(magicResetEvent);
+		assertSessionStats(2, 2, 1, 1, 0);
+
+		XpTrackerSkillReset smeltingResetEvent = new XpTrackerSkillReset(XpTrackerSkillReset.ResetType.ACTIONS, Skill.SMITHING);
+		smeltingPlugin.onXpTrackerSkillReset(smeltingResetEvent);
+		assertSessionStats(0, 0, 0, 0, 0);
+	}
+
+	@Test
+	public void testSmeltingSkillHrReset()
+	{
+		ChatMessage barMessage = new ChatMessage(null, ChatMessageType.SPAM, "", SMELT_BAR, "", 0);
+		ChatMessage extraBarMessage = new ChatMessage(null, ChatMessageType.SPAM, "", SMELT_EXTRA_BAR, "", 0);
+
+		smeltingPlugin.onChatMessage(barMessage);
+		smeltingPlugin.onChatMessage(barMessage);
+		smeltingPlugin.onChatMessage(extraBarMessage);
+
+		XpTrackerSkillReset magicHrResetEvent = new XpTrackerSkillReset(XpTrackerSkillReset.ResetType.ACTIONS_PER_HR, Skill.MAGIC);
+		smeltingPlugin.onXpTrackerSkillReset(magicHrResetEvent);
+		assertSessionStats(2, 2, 1, 1, 0);
+
+		XpTrackerSkillReset smeltingHrResetEvent = new XpTrackerSkillReset(XpTrackerSkillReset.ResetType.ACTIONS_PER_HR, Skill.SMITHING);
+		smeltingPlugin.onXpTrackerSkillReset(smeltingHrResetEvent);
+		assertSessionStats(2, 0, 1, 0, 0);
+	}
+
+	void assertSessionStats(int amountSmelted, int amountSmeltedSinceReset, int amountExtraSmelted, int amountExtraSmeltedSinceReset, int amountCannonballs)
+	{
+		assertNotNull(smeltingPlugin.getSession().getLastItemSmelted());
+		assertEquals(smeltingPlugin.getSession().getBarsSmelted(), amountSmelted);
+		assertEquals(smeltingPlugin.getSession().getBarsSmeltedSinceHrReset(), amountSmeltedSinceReset);
+		assertEquals(smeltingPlugin.getSession().getExtraBarsSmelted(), amountExtraSmelted);
+		assertEquals(smeltingPlugin.getSession().getExtraBarsSmeltedSinceHrReset(), amountExtraSmeltedSinceReset);
+		assertEquals(smeltingPlugin.getSession().getCannonBallsSmelted(), amountCannonballs);
 	}
 }


### PR DESCRIPTION
Fixes #14156, which also brought to light the same issue in both the Mining and Smelting plugins which then were also fixed here.
In order for overlay to be always correct it was necessary to expose more information from the xp-tracker plugin. I opted to do it via an event that fires whenever the user clicks one of the 5 reset buttons in the plugin, which then resets the relevant skill's session counters.

Few thoughts:
- Right now the default configuration for including the extra item is turned on, maybe it would be better it to not suddenly change for people when the client updates.
- I don't really like how I handled type conversions when calculating the multiplier to actions/hr in the plugins' overlay since the calculation must be in floating point and then later converted to an integer. A different approach would be most welcome.
- Originally I wanted to test the whole process of the user resetting the xp-tracker, to the overlaying displaying the correct information (actions, extra actions and actions/hr). However I was unable to figure out how to test bootstrap the overlay manager and test what data is displayed in new overlays, so the unit-tests are sub-par, but I tested the relevant actions manually as well.