### PR TITLE
Add ability to display > 5 xp globes to XpGlobes plugin

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesConfig.java
@@ -31,7 +31,7 @@ import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
 import net.runelite.client.config.Units;
 
-@ConfigGroup("xpglobes")
+@ConfigGroup(XpGlobesPlugin.CONFIG_GROUP)
 public interface XpGlobesConfig extends Config
 {
 	@ConfigItem(
@@ -181,6 +181,17 @@ public interface XpGlobesConfig extends Config
 	default int xpOrbDuration()
 	{
 		return 10;
+	}
+
+	@ConfigItem(
+			keyName = "maxOrbs",
+			name = "Maximum orbs",
+			description = "Set the max number of orbs to be displayed",
+			position = 13
+	)
+	default int maxOrbCount()
+	{
+		return 5;
 	}
 
 	@ConfigItem(

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xpglobes/XpGlobesPlugin.java
@@ -40,6 +40,7 @@ import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.StatChanged;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
+import net.runelite.client.events.ConfigChanged;
 import net.runelite.client.events.OverlayMenuClicked;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDependency;
@@ -57,7 +58,8 @@ import net.runelite.client.ui.overlay.OverlayManager;
 @PluginDependency(XpTrackerPlugin.class)
 public class XpGlobesPlugin extends Plugin
 {
-	private static final int MAXIMUM_SHOWN_GLOBES = 5;
+	private static int MAXIMUM_SHOWN_GLOBES = 5;
+	protected static final String CONFIG_GROUP = "xpglobes";
 
 	private XpGlobe[] globeCache = new XpGlobe[Skill.values().length - 1]; //overall does not trigger xp change event
 
@@ -89,6 +91,17 @@ public class XpGlobesPlugin extends Plugin
 	protected void shutDown() throws Exception
 	{
 		overlayManager.remove(overlay);
+	}
+
+	@Subscribe
+	public void onConfigChanged(ConfigChanged event) {
+		if (event.getGroup().equals(CONFIG_GROUP)) {
+			switch (event.getKey()) {
+				case "maxOrbs":
+					MAXIMUM_SHOWN_GLOBES = config.maxOrbCount();
+					break;
+			}
+		}
 	}
 
 	@Subscribe


### PR DESCRIPTION
Closes #14159

Add config item to set maximum number of xp globes to display, and edit plugin file to update constant on config change.