### PR TITLE
GroundMarker: update points before label tile and check if tile is still marked

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/groundmarkers/GroundMarkerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/groundmarkers/GroundMarkerPlugin.java
@@ -357,12 +357,13 @@ public class GroundMarkerPlugin extends Plugin
 			.value(Optional.ofNullable(existing.getLabel()).orElse(""))
 			.onDone((input) ->
 			{
+				Collection<GroundMarkerPoint> updatedPoints = getPoints(regionId);
 				input = Strings.emptyToNull(input);
 
 				GroundMarkerPoint newPoint = new GroundMarkerPoint(regionId, worldPoint.getRegionX(), worldPoint.getRegionY(), client.getPlane(), existing.getColor(), input);
-				points.remove(searchPoint);
-				points.add(newPoint);
-				savePoints(regionId, points);
+				updatedPoints.remove(searchPoint);
+				updatedPoints.add(newPoint);
+				savePoints(regionId, updatedPoints);
 
 				loadPoints();
 			})

--- a/runelite-client/src/main/java/net/runelite/client/plugins/groundmarkers/GroundMarkerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/groundmarkers/GroundMarkerPlugin.java
@@ -358,6 +358,10 @@ public class GroundMarkerPlugin extends Plugin
 			.onDone((input) ->
 			{
 				Collection<GroundMarkerPoint> updatedPoints = getPoints(regionId);
+				if (!updatedPoints.contains(searchPoint))
+				{
+					return;
+				}
 				input = Strings.emptyToNull(input);
 
 				GroundMarkerPoint newPoint = new GroundMarkerPoint(regionId, worldPoint.getRegionX(), worldPoint.getRegionY(), client.getPlane(), existing.getColor(), input);


### PR DESCRIPTION
Fixes #14182

1st commit: Gets the points inside the lambda expression, so it's up to date with the changes made while label dialog is opened.

2nd commit: When fixing this issue, I found out that you can still label a tile even if you unmark it while label dialog is opened (resulting in marking it and adding a label).