### PR TITLE
Fix minimap rect drawing

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayUtil.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayUtil.java
@@ -35,6 +35,8 @@ import java.awt.RenderingHints;
 import java.awt.Shape;
 import java.awt.Stroke;
 import java.awt.image.BufferedImage;
+import java.util.Arrays;
+import java.util.List;
 import net.runelite.api.Actor;
 import net.runelite.api.Client;
 import net.runelite.api.Perspective;
@@ -81,9 +83,13 @@ public class OverlayUtil
 	{
 		double angle = client.getMapAngle() * UNIT;
 
+		List<Integer> exceptions = Arrays.asList(1, 3);
+		int a = exceptions.contains(width) ? 0 : 1;
+		int b = exceptions.contains(height) ? 2 : 1;
+
 		graphics.setColor(color);
 		graphics.rotate(angle, center.getX(), center.getY());
-		graphics.drawRect(center.getX() - width / 2 + 1, center.getY() - height / 2 - 1, width - 1, height - 1);
+		graphics.drawRect(center.getX() - width / 2 + a, center.getY() - height / 2 - b, width - 1, height - 1);
 		graphics.rotate(-angle, center.getX(), center.getY());
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayUtil.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayUtil.java
@@ -35,8 +35,6 @@ import java.awt.RenderingHints;
 import java.awt.Shape;
 import java.awt.Stroke;
 import java.awt.image.BufferedImage;
-import java.util.Arrays;
-import java.util.List;
 import net.runelite.api.Actor;
 import net.runelite.api.Client;
 import net.runelite.api.Perspective;
@@ -83,9 +81,8 @@ public class OverlayUtil
 	{
 		double angle = client.getMapAngle() * UNIT;
 
-		List<Integer> exceptions = Arrays.asList(1, 3);
-		int a = exceptions.contains(width) ? 0 : 1;
-		int b = exceptions.contains(height) ? 2 : 1;
+		int a = (width % 2 == 0) ? 1 : 0;
+		int b = (height % 2 == 0)? 1 : 2;
 
 		graphics.setColor(color);
 		graphics.rotate(angle, center.getX(), center.getY());

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayUtil.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayUtil.java
@@ -83,8 +83,8 @@ public class OverlayUtil
 
 		graphics.setColor(color);
 		graphics.rotate(angle, center.getX(), center.getY());
-		graphics.drawRect(center.getX() - width / 2, center.getY() - height / 2, width, height);
-		graphics.rotate(-angle , center.getX(), center.getY());
+		graphics.drawRect(center.getX() - width / 2 + 1, center.getY() - height / 2 - 1, width - 1, height - 1);
+		graphics.rotate(-angle, center.getX(), center.getY());
 	}
 
 	public static void renderTextLocation(Graphics2D graphics, Point txtLoc, String text, Color color)


### PR DESCRIPTION
The `Ground Markers` plugin is using the following to draw a minimap square:
```java
OverlayUtil.renderMinimapRect(client, graphics, posOnMinimap, 4, 4, color);
```
However, this results in a 5x5 square rather than a 4x4 square at a slightly wrong position.
This fix solves this by slightly changing the `renderMinimapRect` function in `OverlayUtil.java`.

| Before | After |
|:-:|:-:|
| ![before](https://user-images.githubusercontent.com/53493631/134926499-197640af-dc76-4b59-84f5-31893d17aba4.png) | ![after](https://user-images.githubusercontent.com/53493631/134926526-96f108dd-58d1-4840-869a-eb6ffe73284a.png) |