### PR TITLE
Update Lizardman suggested cannon spot

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonSpots.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonSpots.java
@@ -59,7 +59,7 @@ enum CannonSpots
 	ICE_WARRIOR(new WorldPoint(2955, 3876, 0)),
 	KALPHITE(new WorldPoint(3307, 9528, 0)),
 	LESSER_DEMON(new WorldPoint(2838, 9559, 0), new WorldPoint(3163, 10114, 0)),
-	LIZARDMEN(new WorldPoint(1500, 3703, 0)),
+	LIZARDMEN(new WorldPoint(1507, 3705, 0)),
 	LIZARDMEN_SHAMAN(new WorldPoint(1423, 3715, 0)),
 	MAGIC_AXE(new WorldPoint(3190, 3960, 0)),
 	MAMMOTH(new WorldPoint(3168, 3595, 0)),


### PR DESCRIPTION
Fixes #14184 
New suggested cannon spot shown in the picture below, as well as two spawn points on cannon double hit spots marked near cannon and the old suggested cannon spot marked for reference.
![image](https://user-images.githubusercontent.com/24608301/134988925-73e1f2eb-a6ae-4c3a-8eb1-806092bae64a.png)
