### PR TITLE
Fix for extra op swapping on the deposit box.

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -581,18 +581,21 @@ public class MenuEntrySwapperPlugin extends Plugin
 		// widget ticking and prior to our client tick event. This is because drag start
 		// is what builds the context menu row which is what the eventual click will use
 
+		final int widgetGroupId = WidgetInfo.TO_GROUP(menuEntryAdded.getActionParam1());
+
+		final boolean isDepositBoxPlayerInventory = widgetGroupId == WidgetID.DEPOSIT_BOX_GROUP_ID;
+		final boolean isChambersOfXericStorageUnitPlayerInventory = widgetGroupId == WidgetID.CHAMBERS_OF_XERIC_STORAGE_UNIT_INVENTORY_GROUP_ID;
 		// Swap to shift-click deposit behavior
 		// Deposit- op 1 is the current withdraw amount 1/5/10/x for deposit box interface and chambers of xeric storage unit.
 		// Deposit- op 2 is the current withdraw amount 1/5/10/x for bank interface
 		if (shiftModifier() && config.bankDepositShiftClick() != ShiftDepositMode.OFF
 			&& menuEntryAdded.getType() == MenuAction.CC_OP.getId()
-			&& (menuEntryAdded.getIdentifier() == 2 || menuEntryAdded.getIdentifier() == 1)
+			&& menuEntryAdded.getIdentifier() == (isDepositBoxPlayerInventory || isChambersOfXericStorageUnitPlayerInventory ? 1 : 2)
 			&& (menuEntryAdded.getOption().startsWith("Deposit-") || menuEntryAdded.getOption().startsWith("Store") || menuEntryAdded.getOption().startsWith("Donate")))
 		{
 			ShiftDepositMode shiftDepositMode = config.bankDepositShiftClick();
-			final int widgetGroupId = WidgetInfo.TO_GROUP(menuEntryAdded.getActionParam1());
-			final int opId = widgetGroupId == WidgetID.DEPOSIT_BOX_GROUP_ID ? shiftDepositMode.getIdentifierDepositBox()
-				: widgetGroupId == WidgetID.CHAMBERS_OF_XERIC_STORAGE_UNIT_INVENTORY_GROUP_ID ? shiftDepositMode.getIdentifierChambersStorageUnit()
+			final int opId = isDepositBoxPlayerInventory ? shiftDepositMode.getIdentifierDepositBox()
+				: isChambersOfXericStorageUnitPlayerInventory ? shiftDepositMode.getIdentifierChambersStorageUnit()
 				: shiftDepositMode.getIdentifier();
 			final int actionId = opId >= 6 ? MenuAction.CC_OP_LOW_PRIORITY.getId() : MenuAction.CC_OP.getId();
 			bankModeSwap(actionId, opId);
@@ -605,7 +608,6 @@ public class MenuEntrySwapperPlugin extends Plugin
 			&& menuEntryAdded.getOption().startsWith("Withdraw"))
 		{
 			ShiftWithdrawMode shiftWithdrawMode = config.bankWithdrawShiftClick();
-			final int widgetGroupId = WidgetInfo.TO_GROUP(menuEntryAdded.getActionParam1());
 			final int actionId, opId;
 			if (widgetGroupId == WidgetID.CHAMBERS_OF_XERIC_STORAGE_UNIT_PRIVATE_GROUP_ID || widgetGroupId == WidgetID.CHAMBERS_OF_XERIC_STORAGE_UNIT_SHARED_GROUP_ID)
 			{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/ShiftDepositMode.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/ShiftDepositMode.java
@@ -36,7 +36,7 @@ public enum ShiftDepositMode
 	DEPOSIT_10("Deposit-10", 5, 4, 3),
 	DEPOSIT_X("Deposit-X", 6, 6, 5),
 	DEPOSIT_ALL("Deposit-All", 8, 5, 4),
-	EXTRA_OP("Eat/Wield/Etc.", 9, 0, 0),
+	EXTRA_OP("Eat/Wield/Etc.", 9, 9, 0),
 	OFF("Off", 0, 0, 0);
 
 	private final String name;


### PR DESCRIPTION
This required 2 changes:
- adding the identifier (9) to ShiftDepositMode.
- Updating the swap code to only swap with the entry with the correct identifier. This is necessary because the deposit box can have options with both 1 and 2 identifier, while the regular bank only has one with identifier 2 (not sure on chambers of xeric storage unit as I don't have membership). Not including this change breaks the swap when the deposit box vanilla left-click option has values other than deposit-1.

Tested a few combinations of menu swapper and vanilla bank left-click options, and it seems to work (did not test all combinations since there are a lot).
Did not test that chambers of xeric swap still works, as I don't have membership.