### PR TITLE
High alch value and profit to GE buy interface

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangeConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangeConfig.java
@@ -68,6 +68,17 @@ public interface GrandExchangeConfig extends Config
 
 	@ConfigItem(
 		position = 4,
+		keyName = "showHighAlchValue",
+		name = "Enable high alch values",
+		description = "Shows the high alch value and profit on the GE buy interface"
+	)
+	default boolean showHighAlchValue()
+	{
+		return true;
+	}
+	
+	@ConfigItem(
+		position = 5,
 		keyName = "enableGeLimits",
 		name = "Enable GE Limits on GE",
 		description = "Shows the GE Limits on the GE"
@@ -78,7 +89,7 @@ public interface GrandExchangeConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 5,
+		position = 6,
 		keyName = "enableGELimitReset",
 		name = "Enable GE Limit Reset Timer",
 		description = "Shows when GE Trade limits reset (H:MM)"
@@ -90,7 +101,7 @@ public interface GrandExchangeConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 6,
+		position = 7,
 		keyName = "showTotal",
 		name = "Show GE total",
 		description = "Display the total value of all trades at the top of the GE interface"
@@ -101,7 +112,7 @@ public interface GrandExchangeConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 7,
+		position = 8,
 		keyName = "showExact",
 		name = "Show exact total value",
 		description = "When enabled along with the ‘Show GE total’ option, the unabbreviated value will be displayed"
@@ -112,7 +123,7 @@ public interface GrandExchangeConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 8,
+		position = 9,
 		keyName = "highlightSearchMatch",
 		name = "Highlight Search Match",
 		description = "Highlights the search match with an underline"
@@ -123,7 +134,7 @@ public interface GrandExchangeConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 9,
+		position = 10,
 		keyName = "geSearchMode",
 		name = "Search Mode",
 		description = "The search mode to use for the GE<br>"

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangePlugin.java
@@ -62,6 +62,7 @@ import net.runelite.api.GameState;
 import net.runelite.api.GrandExchangeOffer;
 import net.runelite.api.GrandExchangeOfferState;
 import net.runelite.api.ItemComposition;
+import net.runelite.api.ItemID;
 import net.runelite.api.MenuAction;
 import net.runelite.api.MenuEntry;
 import net.runelite.api.ScriptID;
@@ -874,6 +875,16 @@ public class GrandExchangePlugin extends Plugin
 			if (price > 0)
 			{
 				text += "<br>Actively traded price: " + QuantityFormatter.formatNumber(price);
+			}
+		}
+		
+		if (config.showHighAlchValue())
+		{
+			final int highAlchValue = client.getItemDefinition(itemId).getHaPrice();
+			final int profit = highAlchValue - (itemManager.getItemPriceWithSource(itemId, true) + itemManager.getItemPriceWithSource(ItemID.NATURE_RUNE, true));
+			if (highAlchValue > 0)
+			{
+				text += "<br>High alch value: " + QuantityFormatter.formatNumber(highAlchValue) + " (" + (profit > 0 ? "+" : "") + profit + ")";
 			}
 		}
 


### PR DESCRIPTION
Adds high alch value and profit to the GE buy interface below the actively traded price on the grandexchange plugin. The profit thats in the brackets is calculated including the nature rune price so it shows how much you would make if you buy the item with the actively traded price and high alch it.
![image](https://user-images.githubusercontent.com/62447014/135064482-8d096eb6-3bc7-406f-8cf3-8144f12edc6d.png)