### PR TITLE
notifier: make cancelling flash more reliable when switching windows

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/Notifier.java
+++ b/runelite-client/src/main/java/net/runelite/client/Notifier.java
@@ -116,6 +116,7 @@ public class Notifier
 	private final String appName;
 	private final Path notifyIconPath;
 	private boolean terminalNotifierAvailable;
+	private boolean readyToCancelFlash;
 	private Instant flashStart;
 	private long mouseLastPressedMillis;
 	private long lastClipMTime = CLIP_MTIME_UNLOADED;
@@ -239,6 +240,14 @@ public class Notifier
 			return;
 		}
 
+		// Any interaction with the client since the notification started will cancel it after the minimum duration
+		if ((client.getMouseIdleTicks() < MINIMUM_FLASH_DURATION_TICKS
+			|| client.getKeyboardIdleTicks() < MINIMUM_FLASH_DURATION_TICKS
+			|| client.getMouseLastPressedMillis() > mouseLastPressedMillis) && clientUI.isFocused())
+		{
+			readyToCancelFlash = true;
+		}
+
 		if (Instant.now().minusMillis(MINIMUM_FLASH_DURATION_MILLIS).isAfter(flashStart))
 		{
 			switch (flashNotification)
@@ -246,15 +255,14 @@ public class Notifier
 				case FLASH_TWO_SECONDS:
 				case SOLID_TWO_SECONDS:
 					flashStart = null;
+					readyToCancelFlash = false;
 					return;
 				case SOLID_UNTIL_CANCELLED:
 				case FLASH_UNTIL_CANCELLED:
-					// Any interaction with the client since the notification started will cancel it after the minimum duration
-					if ((client.getMouseIdleTicks() < MINIMUM_FLASH_DURATION_TICKS
-						|| client.getKeyboardIdleTicks() < MINIMUM_FLASH_DURATION_TICKS
-						|| client.getMouseLastPressedMillis() > mouseLastPressedMillis) && clientUI.isFocused())
+					if (readyToCancelFlash)
 					{
 						flashStart = null;
+						readyToCancelFlash = false;
 						return;
 					}
 					break;


### PR DESCRIPTION
This fixes the scenario where the flash notification keeps running because the user switched windows within the 2-second minimum flash duration, despite having already interacted with the client since the flash notification started.

This bug was introduced in 99fd6278e63516d0089a3a8e904737cc075fdab5 when the condition was added that the client must be focused to cancel the notification. It happens because `processFlash` only begins to check for interaction with the client once 2 seconds have passed since the flash notification began so if you interact with the client during the first two seconds of the flash notification then switch windows it will keep flashing.

I've resolved this by bringing the interaction check forwards and having it set a flag `readyToCancelFlash` indicating that an interaction which is eligible to cancel the flash notification has happened. It is then this flag which is checked in place of where the interaction check used to be.