### PR TITLE
chatcommands: cg shorthand for corrupted gauntlet

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
@@ -2008,6 +2008,7 @@ public class ChatCommandsPlugin extends Plugin
 			case "cgaunt":
 			case "cgauntlet":
 			case "the corrupted gauntlet":
+			case "cg":
 				return "Corrupted Gauntlet";
 
 			// The Nightmare


### PR DESCRIPTION
Adds `cg` as a shorthand for Corrupted Gauntlet, for `!kc cg` and `!pb cg`. As Corrupted Gauntlet becomes a better moneymaker and more popular, I think this is a good addition and not likely to be confusing.

The wiki also considers `cg` to be shorthand for the Corrupted Gauntlet, via a redirect page.

https://oldschool.runescape.wiki/w/Cg