### PR TITLE
screen-markers: Scroll down to new marker

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenmarkers/ui/ScreenMarkerPluginPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenmarkers/ui/ScreenMarkerPluginPanel.java
@@ -30,6 +30,7 @@ import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
+import java.awt.Rectangle;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.awt.image.BufferedImage;
@@ -206,5 +207,7 @@ public class ScreenMarkerPluginPanel extends PluginPanel
 			plugin.setMouseListenerEnabled(true);
 			plugin.setCreatingScreenMarker(true);
 		}
+
+		scrollRectToVisible(new Rectangle(getX(), getHeight(), getWidth(), getHeight()));
 	}
 }


### PR DESCRIPTION
New screen markers are not visible unless you scroll down in the plugin panel when added while there are already more than 7 existing ones. This change scrolls down in the list for you. The behaviour is unchanged for less than 7 markers.

PS: using the height as the y-coordinate in the `scrollRectToVisible` is **not** a typo.

Before | After
:-:|:-:
![before](https://user-images.githubusercontent.com/53493631/136233155-79ddc187-8ee8-4cab-98be-0e120a5c4c5a.gif) | ![after](https://user-images.githubusercontent.com/53493631/136227977-081325f9-4631-4d97-9d23-5458536782ae.gif) 
