### PR TITLE
chat commands: Fix incorrect pet chin ID

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/Pet.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/Pet.java
@@ -67,7 +67,7 @@ enum Pet
 	HERON("Heron", ItemID.HERON),
 	ROCK_GOLEM("Rock golem", ItemID.ROCK_GOLEM),
 	BEAVER("Beaver", ItemID.BEAVER),
-	BABY_CHINCHOMPA("Baby chinchompa", ItemID.BABY_CHINCHOMPA),
+	BABY_CHINCHOMPA("Baby chinchompa", ItemID.BABY_CHINCHOMPA_13324),
 	GIANT_SQUIRREL("Giant squirrel", ItemID.GIANT_SQUIRREL),
 	TANGLEROOT("Tangleroot", ItemID.TANGLEROOT),
 	ROCKY("Rocky", ItemID.ROCKY),


### PR DESCRIPTION
A player remarked that they were unable to see their chin pet whenever invoking `!pets`, despite having the pet registered in their collection log. 

Upon further investigation, it seems that the chin ID used in the `Pet` class points to a red chinchompa, as opposed to the grey chinchompa the collection log uses.

![image](https://user-images.githubusercontent.com/35241874/136715700-2ce3aab4-fce8-43bd-ae5c-46b142007205.png)