### PR TITLE
Add party persistence config and ability to join by party id.

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/party/PartyConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/party/PartyConfig.java
@@ -99,4 +99,23 @@ public interface PartyConfig extends Config
 	{
 		return false;
 	}
+
+	@ConfigItem(
+		keyName = "previousPartyId",
+		name = "",
+		description = "",
+		hidden = true
+	)
+	default String previousPartyId()
+	{
+		return "";
+	}
+
+	@ConfigItem(
+		keyName = "previousPartyId",
+		name = "",
+		description = "",
+		hidden = true
+	)
+	void setPreviousPartyId(String id);
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/party/PartyPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/party/PartyPlugin.java
@@ -66,8 +66,8 @@ import net.runelite.client.config.ConfigManager;
 import net.runelite.client.discord.DiscordService;
 import net.runelite.client.discord.events.DiscordJoinRequest;
 import net.runelite.client.eventbus.Subscribe;
-import net.runelite.client.events.OverlayMenuClicked;
 import net.runelite.client.events.ConfigChanged;
+import net.runelite.client.events.OverlayMenuClicked;
 import net.runelite.client.events.PartyChanged;
 import net.runelite.client.events.PartyMemberAvatar;
 import net.runelite.client.plugins.Plugin;
@@ -584,6 +584,11 @@ public class PartyPlugin extends Plugin
 		partyDataMap.clear();
 		pendingTilePings.clear();
 		worldMapManager.removeIf(PartyWorldMapPoint.class::isInstance);
+
+		if (event.getPartyId() != null)
+		{
+			config.setPreviousPartyId(String.valueOf(event.getPartyId()));
+		}
 
 		SwingUtilities.invokeLater(() ->
 		{


### PR DESCRIPTION
I've seen requests in the discord to be able to persist parties between sessions so this PR adds that and since you need a party uuid to join a party, I also added the option to join a party by id and a button to copy your current parties id.

[gif of it in action.
](https://cdn.discordapp.com/attachments/836283317036122192/897990216948785272/Animation11.gif)

It's hard to see that I am copy pasting the uuid into the plugin search but its meant to show that after I had left and rejoined, the party id was the same.