### PR TITLE
wintertodt: Add idle overlay to Wintertodt Plugin

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/wintertodt/WintertodtConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/wintertodt/WintertodtConfig.java
@@ -32,6 +32,7 @@ import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
 import net.runelite.client.config.Range;
 import net.runelite.client.config.Units;
+import net.runelite.client.config.Alpha;
 import net.runelite.client.plugins.wintertodt.config.WintertodtNotifyDamage;
 
 @ConfigGroup("wintertodt")
@@ -50,6 +51,29 @@ public interface WintertodtConfig extends Config
 
 	@ConfigItem(
 		position = 1,
+		keyName = "showIdleOverlay",
+		name = "Show Idle Overlay",
+		description = "Toggles the idle color overlay"
+	)
+	default boolean showIdleOverlay()
+	{
+		return false;
+	}
+
+	@Alpha
+	@ConfigItem(
+		position = 2,
+		keyName = "idleOverlayColor",
+		name = "Idle Overlay Color",
+		description = "Color of idle overlay"
+	)
+	default Color idleOverlayColor()
+	{
+		return new Color(0, 255, 255, 70);
+	}
+
+	@ConfigItem(
+		position = 3,
 		keyName = "damageNotificationColor",
 		name = "Damage Notification",
 		description = "Color of damage notification text in chat"
@@ -60,7 +84,7 @@ public interface WintertodtConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 2,
+		position = 4,
 		keyName = "roundNotification",
 		name = "Round notification",
 		description = "Notifies you before the round starts (in seconds)"
@@ -75,7 +99,7 @@ public interface WintertodtConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 3,
+		position = 5,
 		keyName = "notifyCold",
 		name = "Ambient Damage Notification",
 		description = "Notifies when hit by the Wintertodt's ambient cold damage"
@@ -86,7 +110,7 @@ public interface WintertodtConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 4,
+		position = 6,
 		keyName = "notifySnowfall",
 		name = "Snowfall Damage Notification",
 		description = "Notifies when hit by the Wintertodt's snowfall attack"
@@ -97,7 +121,7 @@ public interface WintertodtConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 5,
+		position = 7,
 		keyName = "notifyBrazierDamage",
 		name = "Brazier Damage Notification",
 		description = "Notifies when hit by the brazier breaking"
@@ -108,7 +132,7 @@ public interface WintertodtConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 6,
+		position = 8,
 		keyName = "notifyFullInv",
 		name = "Full Inventory Notification",
 		description = "Notifies when your inventory fills up with bruma roots"
@@ -119,7 +143,7 @@ public interface WintertodtConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 7,
+		position = 9,
 		keyName = "notifyEmptyInv",
 		name = "Empty Inventory Notification",
 		description = "Notifies when you run out of bruma roots"
@@ -130,7 +154,7 @@ public interface WintertodtConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 8,
+		position = 10,
 		keyName = "notifyBrazierOut",
 		name = "Brazier Extinguish Notification",
 		description = "Notifies when the brazier goes out"

--- a/runelite-client/src/main/java/net/runelite/client/plugins/wintertodt/WintertodtIdleOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/wintertodt/WintertodtIdleOverlay.java
@@ -25,52 +25,54 @@
  */
 package net.runelite.client.plugins.wintertodt;
 
-import java.awt.*;
 import javax.inject.Inject;
-
-import static net.runelite.api.MenuAction.RUNELITE_OVERLAY_CONFIG;
-import static net.runelite.client.ui.overlay.OverlayManager.OPTION_CONFIGURE;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Graphics2D;
+import java.awt.Rectangle;
 
 import net.runelite.api.Client;
-import net.runelite.client.ui.overlay.OverlayMenuEntry;
 import net.runelite.client.ui.overlay.OverlayPanel;
 import net.runelite.client.ui.overlay.OverlayPosition;
-import net.runelite.client.ui.overlay.components.LineComponent;
-import net.runelite.client.ui.overlay.components.TitleComponent;
 
-class WintertodtIdleOverlay extends OverlayPanel {
-    private final WintertodtPlugin plugin;
-    private final WintertodtConfig wintertodtConfig;
-    private final Client client;
+class WintertodtIdleOverlay extends OverlayPanel
+{
+	private final WintertodtPlugin plugin;
+	private final WintertodtConfig wintertodtConfig;
+	private final Client client;
 
-    @Inject
-    private WintertodtIdleOverlay(WintertodtPlugin plugin, WintertodtConfig wintertodtConfig, Client client) {
-        super(plugin);
-        this.plugin = plugin;
-        this.wintertodtConfig = wintertodtConfig;
-        this.client = client;
-        setPosition(OverlayPosition.DYNAMIC);
-        getMenuEntries().add(new OverlayMenuEntry(RUNELITE_OVERLAY_CONFIG, OPTION_CONFIGURE, "Wintertodt idle overlay"));
-    }
+	@Inject
+	private WintertodtIdleOverlay(WintertodtPlugin plugin, WintertodtConfig wintertodtConfig, Client client)
+	{
+		super(plugin);
+		this.plugin = plugin;
+		this.wintertodtConfig = wintertodtConfig;
+		this.client = client;
+		setPosition(OverlayPosition.DYNAMIC);
+	}
 
-    @Override
-    public Dimension getPreferredSize() {
-        return client.getCanvas().getSize();
-    }
+	@Override
+	public Dimension getPreferredSize()
+	{
+		return client.getCanvas().getSize();
+	}
 
-    @Override
-    public Dimension render(Graphics2D graphics) {
-        if (!plugin.isInWintertodt() || !wintertodtConfig.showIdleOverlay() || plugin.getPreviousTimerValue() > wintertodtConfig.roundNotification()) {
-            return null;
-        }
+	@Override
+	public Dimension render(Graphics2D graphics)
+	{
+		if (!plugin.isInWintertodt() || !wintertodtConfig.showIdleOverlay() || plugin.getPreviousTimerValue() > wintertodtConfig.roundNotification())
+		{
+			return null;
+		}
 
-        if (plugin.getCurrentActivity() == WintertodtActivity.IDLE) {
-            final Color color = graphics.getColor();
-            graphics.setColor(wintertodtConfig.idleOverlayColor());
-            graphics.fill(new Rectangle(client.getCanvas().getSize()));
-            graphics.setColor(color);
-        }
+		if (plugin.getCurrentActivity() == WintertodtActivity.IDLE)
+		{
+			final Color color = graphics.getColor();
+			graphics.setColor(wintertodtConfig.idleOverlayColor());
+			graphics.fill(new Rectangle(client.getCanvas().getSize()));
+			graphics.setColor(color);
+		}
 
-        return super.render(graphics);
-    }
+		return super.render(graphics);
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/wintertodt/WintertodtIdleOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/wintertodt/WintertodtIdleOverlay.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2021, roflmuffin <shortguy014@gmail.com>
+ * Copyright (c) 2018, Adam <Adam@sigterm.info>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.wintertodt;
+
+import java.awt.*;
+import javax.inject.Inject;
+
+import static net.runelite.api.MenuAction.RUNELITE_OVERLAY_CONFIG;
+import static net.runelite.client.ui.overlay.OverlayManager.OPTION_CONFIGURE;
+
+import net.runelite.api.Client;
+import net.runelite.client.ui.overlay.OverlayMenuEntry;
+import net.runelite.client.ui.overlay.OverlayPanel;
+import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.components.LineComponent;
+import net.runelite.client.ui.overlay.components.TitleComponent;
+
+class WintertodtIdleOverlay extends OverlayPanel {
+    private final WintertodtPlugin plugin;
+    private final WintertodtConfig wintertodtConfig;
+    private final Client client;
+
+    @Inject
+    private WintertodtIdleOverlay(WintertodtPlugin plugin, WintertodtConfig wintertodtConfig, Client client) {
+        super(plugin);
+        this.plugin = plugin;
+        this.wintertodtConfig = wintertodtConfig;
+        this.client = client;
+        setPosition(OverlayPosition.DYNAMIC);
+        getMenuEntries().add(new OverlayMenuEntry(RUNELITE_OVERLAY_CONFIG, OPTION_CONFIGURE, "Wintertodt idle overlay"));
+    }
+
+    @Override
+    public Dimension getPreferredSize() {
+        return client.getCanvas().getSize();
+    }
+
+    @Override
+    public Dimension render(Graphics2D graphics) {
+        if (!plugin.isInWintertodt() || !wintertodtConfig.showIdleOverlay() || plugin.getPreviousTimerValue() > wintertodtConfig.roundNotification()) {
+            return null;
+        }
+
+        if (plugin.getCurrentActivity() == WintertodtActivity.IDLE) {
+            final Color color = graphics.getColor();
+            graphics.setColor(wintertodtConfig.idleOverlayColor());
+            graphics.fill(new Rectangle(client.getCanvas().getSize()));
+            graphics.setColor(color);
+        }
+
+        return super.render(graphics);
+    }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/wintertodt/WintertodtPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/wintertodt/WintertodtPlugin.java
@@ -103,6 +103,9 @@ public class WintertodtPlugin extends Plugin
 	private WintertodtOverlay overlay;
 
 	@Inject
+	private WintertodtIdleOverlay idleOverlay;
+
+	@Inject
 	private WintertodtConfig config;
 
 	@Inject
@@ -128,6 +131,7 @@ public class WintertodtPlugin extends Plugin
 
 	private Instant lastActionTime;
 
+	@Getter(AccessLevel.PACKAGE)
 	private int previousTimerValue;
 
 	@Provides
@@ -141,12 +145,14 @@ public class WintertodtPlugin extends Plugin
 	{
 		reset();
 		overlayManager.add(overlay);
+		overlayManager.add(idleOverlay);
 	}
 
 	@Override
 	protected void shutDown() throws Exception
 	{
 		overlayManager.remove(overlay);
+		overlayManager.remove(idleOverlay);
 		reset();
 	}
 


### PR DESCRIPTION
This PR adds a new "Idle Overlay" option to the Wintertodt plugin, that when enabled, will color the entire screen in a low opacity colored overlay (similar to how "flash screen" notifier works) when your character is in Wintertodt & idle.

Useful for when your fletching is interrupted and you don't want to be spammed with notifications, but still want an easy way to tell at a glance that you are interrupted.

![image](https://user-images.githubusercontent.com/4160975/137626831-eff97591-d2af-47f3-80f3-7bad4d3e7f3a.png)

