### PR TITLE
Issue#14279: Add Chambers_Of_Xeric_Storage units to InventoryTags 

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/WidgetItemOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/WidgetItemOverlay.java
@@ -46,6 +46,9 @@ import static net.runelite.api.widgets.WidgetID.PLAYER_TRADE_SCREEN_GROUP_ID;
 import static net.runelite.api.widgets.WidgetID.POH_TREASURE_CHEST_INVENTORY_GROUP_ID;
 import static net.runelite.api.widgets.WidgetID.SEED_VAULT_INVENTORY_GROUP_ID;
 import static net.runelite.api.widgets.WidgetID.SHOP_INVENTORY_GROUP_ID;
+import static net.runelite.api.widgets.WidgetID.CHAMBERS_OF_XERIC_STORAGE_UNIT_PRIVATE_GROUP_ID;
+import static net.runelite.api.widgets.WidgetID.CHAMBERS_OF_XERIC_STORAGE_UNIT_SHARED_GROUP_ID;
+import static net.runelite.api.widgets.WidgetID.CHAMBERS_OF_XERIC_STORAGE_UNIT_INVENTORY_GROUP_ID;
 import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.api.widgets.WidgetItem;
 
@@ -129,7 +132,10 @@ public abstract class WidgetItemOverlay extends Overlay
 			DUEL_INVENTORY_OTHER_GROUP_ID,
 			PLAYER_TRADE_SCREEN_GROUP_ID,
 			PLAYER_TRADE_INVENTORY_GROUP_ID,
-			POH_TREASURE_CHEST_INVENTORY_GROUP_ID);
+			POH_TREASURE_CHEST_INVENTORY_GROUP_ID,
+			CHAMBERS_OF_XERIC_STORAGE_UNIT_PRIVATE_GROUP_ID,
+			CHAMBERS_OF_XERIC_STORAGE_UNIT_SHARED_GROUP_ID,
+			CHAMBERS_OF_XERIC_STORAGE_UNIT_INVENTORY_GROUP_ID);
 	}
 
 	protected void showOnBank()


### PR DESCRIPTION
Add Chambers_Of_Xeric_Storage units to WidgetItemOverlay showOnInventory function to make InventoryTagsOverlay plugin correctly display inventory tags when COX storage units are open.

Closes issue #14279  