### PR TITLE
object-markers: fix highlights not showing after restart of plugin

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/objectindicators/ObjectIndicatorsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/objectindicators/ObjectIndicatorsPlugin.java
@@ -116,10 +116,16 @@ public class ObjectIndicatorsPlugin extends Plugin
 		return configManager.getConfig(ObjectIndicatorsConfig.class);
 	}
 
+	private static boolean reloadMapPointsOnStartup = false;
+
 	@Override
 	protected void startUp()
 	{
 		overlayManager.add(overlay);
+		if (reloadMapPointsOnStartup){
+			reloadMapPoints();
+			reloadMapPointsOnStartup = false;
+		}
 	}
 
 	@Override
@@ -128,6 +134,7 @@ public class ObjectIndicatorsPlugin extends Plugin
 		overlayManager.remove(overlay);
 		points.clear();
 		objects.clear();
+		reloadMapPointsOnStartup = true;
 	}
 
 	@Subscribe
@@ -195,17 +202,7 @@ public class ObjectIndicatorsPlugin extends Plugin
 		if (gameState == GameState.LOADING)
 		{
 			// Reload points with new map regions
-
-			points.clear();
-			for (int regionId : client.getMapRegions())
-			{
-				// load points for region
-				final Set<ObjectPoint> regionPoints = loadPoints(regionId);
-				if (regionPoints != null)
-				{
-					points.put(regionId, regionPoints);
-				}
-			}
+			reloadMapPoints();
 		}
 
 		if (gameStateChanged.getGameState() != GameState.LOGGED_IN && gameStateChanged.getGameState() != GameState.CONNECTION_LOST)
@@ -276,6 +273,19 @@ public class ObjectIndicatorsPlugin extends Plugin
 		}
 
 		markObject(objectDefinition, name, object);
+	}
+
+	private void reloadMapPoints(){
+		points.clear();
+		for (int regionId : client.getMapRegions())
+		{
+			// load points for region
+			final Set<ObjectPoint> regionPoints = loadPoints(regionId);
+			if (regionPoints != null)
+			{
+				points.put(regionId, regionPoints);
+			}
+		}
 	}
 
 	private void checkObjectPoints(TileObject object)


### PR DESCRIPTION
Adds flag that triggers points reload on startup of the plugin. This flag is only set when the shutdown function is called which in turn is only called when the user disables the plugin. This way the points are only reloaded when the user restarts the app.

fixes #14090
