### PR TITLE
MenuEntrySwapper: added dive-swap for rowboat

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -280,6 +280,17 @@ public interface MenuEntrySwapperConfig extends Config
 	}
 
 	@ConfigItem(
+			keyName = "swapDive",
+			name = "Dive",
+			description = "Swap Travel with Dive for the rowboat on Fossil Island.",
+			section = objectSection
+	)
+	default boolean swapDive()
+	{
+		return false;
+	}
+
+	@ConfigItem(
 		keyName = "swapExchange",
 		name = "Exchange",
 		description = "Swap Talk-to with Exchange on NPC<br>Example: Grand Exchange Clerk, Tool Leprechaun, Void Knight",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -235,6 +235,8 @@ public class MenuEntrySwapperPlugin extends Plugin
 		swap("talk-to", "collect", config::swapCollectMiscellania);
 		swap("talk-to", "deposit-items", config::swapDepositItems);
 		swap("talk-to", TEMPOROSS_NPCS::contains, "leave", config::swapTemporossLeave);
+		
+		swap("travel", "rowboat", "dive", config::swapDive);
 
 		swap("leave tomb", "quick-leave", config::swapQuickLeave);
 		swap("tomb door", "quick-leave", config::swapQuickLeave);


### PR DESCRIPTION
Adds option to swap "Travel" to "Dive" when using the rowboat on Fossil Island. I find it useful for doing tasks such as glassblowing underwater to gather seaweed spores. 
![image](https://user-images.githubusercontent.com/28101878/140581476-89157ba9-a2fb-4ca8-a776-05f055ca7ab4.png)
![image](https://user-images.githubusercontent.com/28101878/140581582-61588ad2-db86-418c-b79d-19ef84a7b2c4.png)
