### PR TITLE
Fix clan hall ground items despawn timer

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
@@ -78,6 +78,7 @@ public class GroundItemsOverlay extends Overlay
 	private static final Duration DESPAWN_TIME_DROP = Duration.ofMinutes(3);
 	private static final Duration DESPAWN_TIME_TABLE = Duration.ofMinutes(10);
 	private static final int KRAKEN_REGION = 9116;
+	private static final int CLAN_HALL_REGION = 6997;
 	private static final int KBD_NMZ_REGION = 9033;
 	private static final int ZILYANA_REGION = 11602;
 	private static final int GRAARDOR_REGION = 11347;
@@ -456,7 +457,8 @@ public class GroundItemsOverlay extends Overlay
 			}
 			else if (playerRegionID == ZILYANA_REGION || playerRegionID == GRAARDOR_REGION ||
 				playerRegionID == KRIL_TSUTSAROTH_REGION || playerRegionID == KREEARRA_REGION ||
-				playerRegionID == NIGHTMARE_REGION ||  playerRegionID == TEMPOROSS_REGION)
+				playerRegionID == NIGHTMARE_REGION ||  playerRegionID == TEMPOROSS_REGION ||
+				playerRegionID == CLAN_HALL_REGION)
 			{
 				// GWD, Nightmare, and Tempoross instances use the normal despawn timers
 				despawnTime = spawnTime.plus(groundItem.getLootType() == LootType.DROPPED


### PR DESCRIPTION
Clan hall has normal despawn time, not 3000 ticks. Exclude clan hall from default instance despawn time.