### PR TITLE
add air and death runes to item identification as there are VERY similar

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemidentification/ItemIdentification.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemidentification/ItemIdentification.java
@@ -426,7 +426,11 @@ enum ItemIdentification
 	ZUL_ANDRA_TELEPORT(Type.SCROLL, "Zul-andra", "ZUL", ItemID.ZULANDRA_TELEPORT),
 	KEY_MASTER_TELEPORT(Type.SCROLL, "Key master", "KEY", ItemID.KEY_MASTER_TELEPORT),
 	REVENANT_CAVE_TELEPORT(Type.SCROLL, "Rev cave", "REV", ItemID.REVENANT_CAVE_TELEPORT),
-	WATSON_TELEPORT(Type.SCROLL, "Watson", "WATS", ItemID.WATSON_TELEPORT);
+	WATSON_TELEPORT(Type.SCROLL, "Watson", "WATS", ItemID.WATSON_TELEPORT),
+
+	// Runes
+	AIR_RUNE(Type.RUNE, "Air", "AIR", ItemID.AIR_RUNE),
+	DEATH_RUNE(Type.RUNE, "Death", "DEA", ItemID.DEATH_RUNE);
 
 	final Type type;
 	final String medName;
@@ -487,7 +491,8 @@ enum ItemIdentification
 		POTION(ItemIdentificationConfig::showPotions),
 		IMPLING_JAR(ItemIdentificationConfig::showImplingJars),
 		TABLET(ItemIdentificationConfig::showTablets),
-		SCROLL(ItemIdentificationConfig::showTeleportScrolls);
+		SCROLL(ItemIdentificationConfig::showTeleportScrolls),
+		RUNE(ItemIdentificationConfig::showRunes);
 
 		final Predicate<ItemIdentificationConfig> enabled;
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemidentification/ItemIdentificationConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemidentification/ItemIdentificationConfig.java
@@ -303,4 +303,15 @@ public interface ItemIdentificationConfig extends Config
 	{
 		return false;
 	}
+
+	@ConfigItem(
+		keyName = "showRunes",
+		name = "Runes",
+		description = "Show identification on Runes",
+		section = identificationSection
+	)
+	default boolean showRunes()
+	{
+		return false;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemidentification/ItemIdentificationOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemidentification/ItemIdentificationOverlay.java
@@ -28,16 +28,14 @@ import com.google.inject.Inject;
 import java.awt.Graphics2D;
 import java.awt.Point;
 import java.awt.Rectangle;
-import static net.runelite.api.widgets.WidgetID.GUIDE_PRICE_GROUP_ID;
-import static net.runelite.api.widgets.WidgetID.KEPT_ON_DEATH_GROUP_ID;
-import static net.runelite.api.widgets.WidgetID.LOOTING_BAG_GROUP_ID;
-import static net.runelite.api.widgets.WidgetID.SEED_BOX_GROUP_ID;
-import static net.runelite.api.widgets.WidgetID.KINGDOM_GROUP_ID;
+
 import net.runelite.api.widgets.WidgetItem;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.ui.FontManager;
 import net.runelite.client.ui.overlay.WidgetItemOverlay;
 import net.runelite.client.ui.overlay.components.TextComponent;
+
+import static net.runelite.api.widgets.WidgetID.*;
 
 class ItemIdentificationOverlay extends WidgetItemOverlay
 {
@@ -51,7 +49,7 @@ class ItemIdentificationOverlay extends WidgetItemOverlay
 		this.itemManager = itemManager;
 		showOnInventory();
 		showOnBank();
-		showOnInterfaces(KEPT_ON_DEATH_GROUP_ID, GUIDE_PRICE_GROUP_ID, LOOTING_BAG_GROUP_ID, SEED_BOX_GROUP_ID, KINGDOM_GROUP_ID);
+		showOnInterfaces(KEPT_ON_DEATH_GROUP_ID, GUIDE_PRICE_GROUP_ID, LOOTING_BAG_GROUP_ID, SEED_BOX_GROUP_ID, KINGDOM_GROUP_ID, RUNE_POUCH_GROUP_ID);
 	}
 
 	@Override


### PR DESCRIPTION
I've made an addition to the item identification plugin, air and death runes, these look very very similar to one another and I can see people with poor vision mistaking them, I only included these 2 as they are very close but if you would like me to tag all the other runes so its more consistant then I will, just let me know.