### PR TITLE
xptracker: add "reset paused" menu entry

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpPanel.java
@@ -93,6 +93,10 @@ class XpPanel extends PluginPanel
 		final JMenuItem resetPerHour = new JMenuItem("Reset All/hr");
 		resetPerHour.addActionListener(e -> xpTrackerPlugin.resetAllSkillsPerHourState());
 
+		// Create reset all per hour menu
+		final JMenuItem resetPaused = new JMenuItem("Reset Paused");
+		resetPaused.addActionListener(e -> xpTrackerPlugin.resetPausedSkillsState());
+
 		// Create pause all menu
 		final JMenuItem pauseAll = new JMenuItem("Pause All");
 		pauseAll.addActionListener(e -> xpTrackerPlugin.pauseAllSkills(true));
@@ -108,6 +112,7 @@ class XpPanel extends PluginPanel
 		popupMenu.add(openXpTracker);
 		popupMenu.add(reset);
 		popupMenu.add(resetPerHour);
+		popupMenu.add(resetPaused);
 		popupMenu.add(pauseAll);
 		popupMenu.add(unpauseAll);
 		overallPanel.setComponentPopupMenu(popupMenu);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerPlugin.java
@@ -376,6 +376,17 @@ public class XpTrackerPlugin extends Plugin
 		}
 	}
 
+	/**
+	 * Reset the xp gained on only PAUSED skills
+	 * Does not clear the UI.
+	 */
+	void resetPausedSkillsState()
+	{
+		Arrays.stream(Skill.values())
+			.filter(xpPauseState::isPaused)
+			.forEach(this::resetSkillState);
+	}
+
 	@Subscribe
 	public void onStatChanged(StatChanged statChanged)
 	{


### PR DESCRIPTION
Allows players to reset their paused skills only, removing skills that they are no longer working on without resetting the skills still being trained. Useful for reducing clutter when you forget to reset the panel between activities.

![ezgif com-gif-maker](https://user-images.githubusercontent.com/1868974/141399351-4b4f46ba-2800-40b0-aa1a-ca74a06bf5aa.gif)