### PR TITLE
chat filter: Ignore character accents for matching

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/util/Text.java
+++ b/runelite-client/src/main/java/net/runelite/client/util/Text.java
@@ -32,6 +32,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.text.WordUtils;
 import org.apache.commons.text.similarity.JaroWinklerDistance;
 
@@ -232,5 +233,19 @@ public class Text
 			}
 		}
 		return true;
+	}
+
+	/**
+	 * Strips diacritics and other accent marks from a string.
+	 *
+	 * @return A copy of the passed string, with all character accents and diacritics removed.
+	 */
+	public static String stripDiacritics(String str)
+	{
+		final String normalized = StringUtils.stripAccents(str);
+
+		assert normalized.length() == str.length() : String.format("Normalized string \"%s\" is not the same length as input string \"%s\"}", normalized, str);
+
+		return normalized;
 	}
 }

--- a/runelite-client/src/test/java/net/runelite/client/plugins/chatfilter/ChatFilterPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/chatfilter/ChatFilterPluginTest.java
@@ -187,6 +187,36 @@ public class ChatFilterPluginTest
 	}
 
 	@Test
+	public void testFilterUnicode()
+	{
+		when(chatFilterConfig.filterType()).thenReturn(ChatFilterType.CENSOR_WORDS);
+		when(chatFilterConfig.filteredWords()).thenReturn("filterme");
+
+		chatFilterPlugin.updateFilteredPatterns();
+		assertEquals("plëäsë ******** plügïn", chatFilterPlugin.censorMessage("Blue", "plëäsë fïltërmë plügïn"));
+	}
+
+	@Test
+	public void testUnicodeFiltersUnicode()
+	{
+		when(chatFilterConfig.filterType()).thenReturn(ChatFilterType.CENSOR_WORDS);
+		when(chatFilterConfig.filteredWords()).thenReturn("plëäsë");
+
+		chatFilterPlugin.updateFilteredPatterns();
+		assertEquals("****** fïltërmë plügïn", chatFilterPlugin.censorMessage("Blue", "plëäsë fïltërmë plügïn"));
+	}
+
+	@Test
+	public void testMixedUnicodeFiltersUnicode()
+	{
+		when(chatFilterConfig.filterType()).thenReturn(ChatFilterType.CENSOR_WORDS);
+		when(chatFilterConfig.filteredWords()).thenReturn("plëäsë, filterme");
+
+		chatFilterPlugin.updateFilteredPatterns();
+		assertEquals("****** ******** plügïn", chatFilterPlugin.censorMessage("Blue", "plëäsë fïltërmë plügïn"));
+	}
+
+	@Test
 	public void testMessageFromFriendIsFiltered()
 	{
 		when(chatFilterConfig.filterFriends()).thenReturn(true);

--- a/runelite-client/src/test/java/net/runelite/client/util/TextTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/util/TextTest.java
@@ -73,4 +73,14 @@ public class TextTest
 		assertEquals("mR  nAmE", Text.toJagexName("--__--mR_-nAmE__  --"));
 		assertEquals("Mind    the     gap", Text.toJagexName("Mind_-_-the-- __gap"));
 	}
+
+	@Test
+	public void stripDiacritics()
+	{
+		assertEquals("Bjorn", Text.stripDiacritics("Björn"));
+		assertEquals("please", Text.stripDiacritics("plëäsë"));
+		assertEquals("inertia", Text.stripDiacritics("ïnertïå"));
+		assertEquals("whole", Text.stripDiacritics("whóle"));
+		assertEquals("C¯at", Text.stripDiacritics("C¯ät"));
+	}
 }


### PR DESCRIPTION
This lets plain latin-character filters to match messages with accents
and diacritics which are not easily typed on all keyboard layouts.

This PR fixes a bug which was present in #14363 where `Text.stripDiacritics()` also stripped raw diacritic characters from input strings, meaning that the resulting string could be of a different length. This is now guaranteed as part of the method's execution and has a new test which covers this case.

Fixes #13097