### PR TITLE
runelite: fix login screen mute button bounds

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
@@ -425,6 +425,32 @@ public class ClientUI
 						mouseEvent.consume();
 					}
 
+					// Workaround for login screen mute button hitbox size
+					if ((client instanceof Client) && ((Client) client).getGameState() == GameState.LOGIN_SCREEN)
+					{
+						final Canvas canvas = ((Client) client).getCanvas();
+						if (canvas != null)
+						{
+							int clientShift = (Constants.GAME_FIXED_WIDTH - canvas.getWidth()) / 2;
+							Rectangle fixedClientRect = new Rectangle(Constants.GAME_FIXED_SIZE);
+
+							// Click position in relation to fixed size client
+							java.awt.Point clickedClientPoint = mouseEvent.getPoint();
+							clickedClientPoint.translate(clientShift, 0);
+
+							Rectangle nextWorldButton = new Rectangle(canvas.getWidth() - 70, (canvas.getHeight() - 40) / 2, 70, 40);
+
+							if ((clickedClientPoint.getX() > Constants.GAME_FIXED_WIDTH - 50) && (clickedClientPoint.getY() > Constants.GAME_FIXED_HEIGHT - 50))
+							{
+								if ( !fixedClientRect.contains(clickedClientPoint) && !nextWorldButton.contains(mouseEvent.getPoint()))
+								{
+									mouseEvent.consume();
+								}
+							}
+						}
+
+					}
+
 					return mouseEvent;
 				}
 			};


### PR DESCRIPTION
Does a pretty good job of fixing the login screen mute button clickbox. Ideally we'd just null any clicks outside the fixed client but this isn't possible because the world select buttons stray outside and can't just break those. This change nulls any clicks that are in the box between the top left of the mute button and the corner of the client with exceptions for the mute button itself and the area in which the nextt-page button in the world select screen will be positioned.

Without being able to determing if we're in the world select screen we can't avoid having the small clickbox always present where the next page of world select button goes, but this fixes the majority of the area.

Fixes [3923](https://github.com/runelite/runelite/issues/3923)