### PR TITLE
special counter: ignore vet'ion hellhounds

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/specialcounter/SpecialCounterPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/specialcounter/SpecialCounterPlugin.java
@@ -72,7 +72,8 @@ public class SpecialCounterPlugin extends Plugin
 {
 	private static final Set<Integer> IGNORED_NPCS = ImmutableSet.of(
 		NpcID.DARK_ENERGY_CORE, NpcID.ZOMBIFIED_SPAWN, NpcID.ZOMBIFIED_SPAWN_8063,
-		NpcID.COMBAT_DUMMY, NpcID.UNDEAD_COMBAT_DUMMY
+		NpcID.COMBAT_DUMMY, NpcID.UNDEAD_COMBAT_DUMMY,
+		NpcID.SKELETON_HELLHOUND_6613, NpcID.GREATER_SKELETON_HELLHOUND
 	);
 	
 	private static final Set<Integer> RESET_ON_LEAVE_INSTANCED_REGIONS = ImmutableSet.of(


### PR DESCRIPTION
Prevents spec counter resetting when attacking a skeleton hellhound spawned by Vet'ion. The hellhounds are spawned at 50% HP, and are required to kill to continue the fight, so the player will continue fighting Vet'ion after they are killed.

It's possible that a player may want to use a spec against the hellhounds, but I'm not aware of any reason for it.