### PR TITLE
max cape teleports swap

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -66,6 +66,11 @@ public interface MenuEntrySwapperConfig extends Config
 	)
 	String uiSection = "ui";
 
+	enum MaxCapeMode{
+		WEAR,
+		TELEPORTS
+	}
+
 	enum ArdougneCloakMode
 	{
 		WEAR,
@@ -486,6 +491,16 @@ public interface MenuEntrySwapperConfig extends Config
 	default KaramjaGlovesMode swapKaramjaGlovesMode()
 	{
 		return KaramjaGlovesMode.WEAR;
+	}
+
+	@ConfigItem(
+			keyName = "swapMaxCape",
+			name = "Max Cape",
+			description = "Swap Wear with Teleport on the Max Cape",
+			section = itemSection
+	)
+	default MaxCapeMode swapMaxCapeMode(){
+		return MaxCapeMode.WEAR;
 	}
 
 	@ConfigItem(

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -66,11 +66,6 @@ public interface MenuEntrySwapperConfig extends Config
 	)
 	String uiSection = "ui";
 
-	enum MaxCapeMode{
-		WEAR,
-		TELEPORTS
-	}
-
 	enum ArdougneCloakMode
 	{
 		WEAR,
@@ -491,16 +486,6 @@ public interface MenuEntrySwapperConfig extends Config
 	default KaramjaGlovesMode swapKaramjaGlovesMode()
 	{
 		return KaramjaGlovesMode.WEAR;
-	}
-
-	@ConfigItem(
-			keyName = "swapMaxCape",
-			name = "Max Cape",
-			description = "Swap Wear with Teleport on the Max Cape",
-			section = itemSection
-	)
-	default MaxCapeMode swapMaxCapeMode(){
-		return MaxCapeMode.WEAR;
 	}
 
 	@ConfigItem(

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -408,6 +408,8 @@ public class MenuEntrySwapperPlugin extends Plugin
 		swap("eat", "guzzle", config::swapRockCake);
 
 		swap("travel", "dive", config::swapRowboatDive);
+
+		swap("wear", "teleports", () -> config.swapMaxCapeMode() == MenuEntrySwapperConfig.MaxCapeMode.TELEPORTS);
 	}
 
 	private void swap(String option, String swappedOption, Supplier<Boolean> enabled)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -361,6 +361,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 		swap("wear", "teleport", config::swapTeleportItem);
 		swap("wield", "teleport", config::swapTeleportItem);
 		swap("wield", "invoke", config::swapTeleportItem);
+		swap("wear", "teleports", config::swapTeleportItem);
 
 		swap("wear", "farm teleport", () -> config.swapArdougneCloakMode() == ArdougneCloakMode.FARM);
 		swap("wear", "monastery teleport", () -> config.swapArdougneCloakMode() == ArdougneCloakMode.MONASTERY);
@@ -408,8 +409,6 @@ public class MenuEntrySwapperPlugin extends Plugin
 		swap("eat", "guzzle", config::swapRockCake);
 
 		swap("travel", "dive", config::swapRowboatDive);
-
-		swap("wear", "teleports", () -> config.swapMaxCapeMode() == MenuEntrySwapperConfig.MaxCapeMode.TELEPORTS);
 	}
 
 	private void swap(String option, String swappedOption, Supplier<Boolean> enabled)


### PR DESCRIPTION
This is related to https://github.com/runelite/runelite/issues/14353
The max cape teleport menu entry wasn't being swapped with wear by the plugin because it has a `Teleports` entry rather than a `Teleport` entry.