### PR TITLE
Timer plugin support gim helm teleport

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/AnimationID.java
+++ b/runelite-api/src/main/java/net/runelite/api/AnimationID.java
@@ -205,6 +205,7 @@ public final class AnimationID
 	public static final int LEAGUE_HOME_TELEPORT_5 = 8805;
 	public static final int LEAGUE_HOME_TELEPORT_6 = 8807;
 	public static final int RAID_LIGHT_ANIMATION = 3101;
+	public static final int GROUP_IRON_HELM_TELEPORT = 714;
 
 	public static final int CONSTRUCTION = 3676;
 	public static final int CONSTRUCTION_IMCANDO = 8912;

--- a/runelite-api/src/main/java/net/runelite/api/AnimationID.java
+++ b/runelite-api/src/main/java/net/runelite/api/AnimationID.java
@@ -205,7 +205,7 @@ public final class AnimationID
 	public static final int LEAGUE_HOME_TELEPORT_5 = 8805;
 	public static final int LEAGUE_HOME_TELEPORT_6 = 8807;
 	public static final int RAID_LIGHT_ANIMATION = 3101;
-	public static final int GROUP_IRON_HELM_TELEPORT = 714;
+	public static final int GENERIC_TELEPORT = 714;
 
 	public static final int CONSTRUCTION = 3676;
 	public static final int CONSTRUCTION_IMCANDO = 8912;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersPlugin.java
@@ -492,8 +492,6 @@ public class TimersPlugin extends Plugin
 		{
 			lastTeleportClicked = teleportWidget;
 		}
-		
-		event.setMenuAction(MenuAction.ITEM_FIRST_OPTION);
 	}
 
 	@Subscribe

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersPlugin.java
@@ -146,7 +146,7 @@ public class TimersPlugin extends Plugin
 	private int lastAnimation;
 	private boolean widgetHiddenChangedOnPvpWorld;
 	private ElapsedTimer tzhaarTimer;
-	private boolean gimHelmTeleportClicked;
+	private boolean gimHelmTeleportClickedLast;
 
 	@Inject
 	private ItemManager itemManager;
@@ -482,12 +482,13 @@ public class TimersPlugin extends Plugin
 		}
 
 		TeleportWidget teleportWidget = TeleportWidget.of(event.getParam1());
-		if (teleportWidget != null) {
+		if (teleportWidget != null)
+		{
 			lastTeleportClicked = teleportWidget;
 		}
 
 		// check for Group Iron Man Helm Teleport
-		gimHelmTeleportClicked = event.getMenuOption().contains("Teleport")
+		gimHelmTeleportClickedLast = event.getMenuOption().contains("Teleport")
 				&& event.getMenuTarget().toLowerCase(Locale.ROOT).contains("group iron helm");
 	}
 
@@ -940,16 +941,13 @@ public class TimersPlugin extends Plugin
 			return;
 		}
 
-		log.info("lastTeleportClicked: " + lastTeleportClicked);
-
 		if (config.showHomeMinigameTeleports()
 			&& client.getLocalPlayer().getAnimation() == AnimationID.IDLE
 			&& (lastAnimation == AnimationID.BOOK_HOME_TELEPORT_5
 			|| lastAnimation == AnimationID.COW_HOME_TELEPORT_6
-			|| lastAnimation == AnimationID.LEAGUE_HOME_TELEPORT_6
-			|| lastAnimation == AnimationID.GENERIC_TELEPORT))
+			|| lastAnimation == AnimationID.LEAGUE_HOME_TELEPORT_6))
 		{
-			if (lastTeleportClicked == TeleportWidget.HOME_TELEPORT || gimHelmTeleportClicked)
+			if (lastTeleportClicked == TeleportWidget.HOME_TELEPORT)
 			{
 				createGameTimer(HOME_TELEPORT);
 			}
@@ -957,6 +955,15 @@ public class TimersPlugin extends Plugin
 			{
 				createGameTimer(MINIGAME_TELEPORT);
 			}
+		}
+
+		// group ironman helm teleport
+		if (config.showHomeMinigameTeleports()
+			&& client.getLocalPlayer().getAnimation() == AnimationID.IDLE
+			&& lastAnimation == AnimationID.GENERIC_TELEPORT
+			&& gimHelmTeleportClickedLast)
+		{
+			createGameTimer(HOME_TELEPORT);
 		}
 
 		if (config.showDFSSpecial() && lastAnimation == AnimationID.DRAGONFIRE_SHIELD_SPECIAL)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersPlugin.java
@@ -488,6 +488,11 @@ public class TimersPlugin extends Plugin
 			teleportWidget = TeleportWidget.HOME_TELEPORT;
 		}
 
+		log.info("EventId: " + event.getId());
+		log.info("Param0: " + event.getParam0());
+		log.info("Param1 : " + event.getParam1());
+		log.info("ActionParam: " + event.getActionParam());
+
 		if (teleportWidget != null)
 		{
 			lastTeleportClicked = teleportWidget;
@@ -948,11 +953,12 @@ public class TimersPlugin extends Plugin
 			&& (lastAnimation == AnimationID.BOOK_HOME_TELEPORT_5
 			|| lastAnimation == AnimationID.COW_HOME_TELEPORT_6
 			|| lastAnimation == AnimationID.LEAGUE_HOME_TELEPORT_6
-			|| lastAnimation == AnimationID.GROUP_IRON_HELM_TELEPORT))
+			|| lastAnimation == AnimationID.GENERIC_TELEPORT))
 		{
 			if (lastTeleportClicked == TeleportWidget.HOME_TELEPORT)
 			{
 				createGameTimer(HOME_TELEPORT);
+				lastTeleportClicked = null;
 			}
 			else if (lastTeleportClicked == TeleportWidget.MINIGAME_TELEPORT)
 			{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersPlugin.java
@@ -488,11 +488,6 @@ public class TimersPlugin extends Plugin
 			teleportWidget = TeleportWidget.HOME_TELEPORT;
 		}
 
-		log.info("EventId: " + event.getId());
-		log.info("Param0: " + event.getParam0());
-		log.info("Param1 : " + event.getParam1());
-		log.info("ActionParam: " + event.getActionParam());
-
 		if (teleportWidget != null)
 		{
 			lastTeleportClicked = teleportWidget;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersPlugin.java
@@ -482,8 +482,11 @@ public class TimersPlugin extends Plugin
 
 		TeleportWidget teleportWidget = TeleportWidget.of(event.getParam1());
 		// check for Group Iron Man Helm Teleport
+		final ItemContainer itemContainer = client.getItemContainer(InventoryID.EQUIPMENT);
+		final int helmId = itemContainer.getItems()[EquipmentInventorySlot.HEAD.getSlotIdx()].getId();
 		if (event.getMenuOption().contains("Teleport")
-				&& event.getMenuTarget().toLowerCase(Locale.ROOT).contains("group iron helm"))
+			&& (helmId == ItemID.GROUP_IRON_HELM
+			|| helmId == ItemID.HARDCORE_GROUP_IRON_HELM))
 		{
 			teleportWidget = TeleportWidget.HOME_TELEPORT;
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersPlugin.java
@@ -29,28 +29,16 @@ package net.runelite.client.plugins.timers;
 import com.google.inject.Provides;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
-import net.runelite.api.Actor;
-import net.runelite.api.AnimationID;
-import net.runelite.api.ChatMessageType;
-import net.runelite.api.Client;
-import net.runelite.api.Constants;
-import net.runelite.api.EquipmentInventorySlot;
-import net.runelite.api.InventoryID;
-import net.runelite.api.Item;
-import net.runelite.api.ItemContainer;
-import net.runelite.api.ItemID;
+import net.runelite.api.*;
+
 import static net.runelite.api.ItemID.FIRE_CAPE;
 import static net.runelite.api.ItemID.INFERNAL_CAPE;
-import net.runelite.api.NPC;
-import net.runelite.api.NpcID;
-import net.runelite.api.Player;
-import net.runelite.api.Skill;
-import net.runelite.api.VarPlayer;
-import net.runelite.api.Varbits;
+
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.ActorDeath;
 import net.runelite.api.events.AnimationChanged;
@@ -493,10 +481,19 @@ public class TimersPlugin extends Plugin
 		}
 
 		TeleportWidget teleportWidget = TeleportWidget.of(event.getParam1());
+		// check for Group Iron Man Helm Teleport
+		if (event.getMenuOption().contains("Teleport")
+				&& event.getMenuTarget().toLowerCase(Locale.ROOT).contains("group iron helm"))
+		{
+			teleportWidget = TeleportWidget.HOME_TELEPORT;
+		}
+
 		if (teleportWidget != null)
 		{
 			lastTeleportClicked = teleportWidget;
 		}
+		
+		event.setMenuAction(MenuAction.ITEM_FIRST_OPTION);
 	}
 
 	@Subscribe
@@ -952,7 +949,8 @@ public class TimersPlugin extends Plugin
 			&& client.getLocalPlayer().getAnimation() == AnimationID.IDLE
 			&& (lastAnimation == AnimationID.BOOK_HOME_TELEPORT_5
 			|| lastAnimation == AnimationID.COW_HOME_TELEPORT_6
-			|| lastAnimation == AnimationID.LEAGUE_HOME_TELEPORT_6))
+			|| lastAnimation == AnimationID.LEAGUE_HOME_TELEPORT_6
+			|| lastAnimation == AnimationID.GROUP_IRON_HELM_TELEPORT))
 		{
 			if (lastTeleportClicked == TeleportWidget.HOME_TELEPORT)
 			{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersPlugin.java
@@ -482,19 +482,14 @@ public class TimersPlugin extends Plugin
 
 		TeleportWidget teleportWidget = TeleportWidget.of(event.getParam1());
 		// check for Group Iron Man Helm Teleport
-		final ItemContainer itemContainer = client.getItemContainer(InventoryID.EQUIPMENT);
-		final int helmId = itemContainer.getItems()[EquipmentInventorySlot.HEAD.getSlotIdx()].getId();
 		if (event.getMenuOption().contains("Teleport")
-			&& (helmId == ItemID.GROUP_IRON_HELM
-			|| helmId == ItemID.HARDCORE_GROUP_IRON_HELM))
+			&& event.getMenuTarget().toLowerCase(Locale.ROOT).contains("group iron helm"))
 		{
 			teleportWidget = TeleportWidget.HOME_TELEPORT;
 		}
 
-		if (teleportWidget != null)
-		{
-			lastTeleportClicked = teleportWidget;
-		}
+		log.info("menuOptionClicked");
+		lastTeleportClicked = teleportWidget;
 	}
 
 	@Subscribe
@@ -946,6 +941,8 @@ public class TimersPlugin extends Plugin
 			return;
 		}
 
+		log.info("lastTeleportClicked: " + lastTeleportClicked);
+
 		if (config.showHomeMinigameTeleports()
 			&& client.getLocalPlayer().getAnimation() == AnimationID.IDLE
 			&& (lastAnimation == AnimationID.BOOK_HOME_TELEPORT_5
@@ -956,7 +953,6 @@ public class TimersPlugin extends Plugin
 			if (lastTeleportClicked == TeleportWidget.HOME_TELEPORT)
 			{
 				createGameTimer(HOME_TELEPORT);
-				lastTeleportClicked = null;
 			}
 			else if (lastTeleportClicked == TeleportWidget.MINIGAME_TELEPORT)
 			{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersPlugin.java
@@ -146,6 +146,7 @@ public class TimersPlugin extends Plugin
 	private int lastAnimation;
 	private boolean widgetHiddenChangedOnPvpWorld;
 	private ElapsedTimer tzhaarTimer;
+	private boolean gimHelmTeleportClicked;
 
 	@Inject
 	private ItemManager itemManager;
@@ -481,15 +482,13 @@ public class TimersPlugin extends Plugin
 		}
 
 		TeleportWidget teleportWidget = TeleportWidget.of(event.getParam1());
-		// check for Group Iron Man Helm Teleport
-		if (event.getMenuOption().contains("Teleport")
-			&& event.getMenuTarget().toLowerCase(Locale.ROOT).contains("group iron helm"))
-		{
-			teleportWidget = TeleportWidget.HOME_TELEPORT;
+		if (teleportWidget != null) {
+			lastTeleportClicked = teleportWidget;
 		}
 
-		log.info("menuOptionClicked");
-		lastTeleportClicked = teleportWidget;
+		// check for Group Iron Man Helm Teleport
+		gimHelmTeleportClicked = event.getMenuOption().contains("Teleport")
+				&& event.getMenuTarget().toLowerCase(Locale.ROOT).contains("group iron helm");
 	}
 
 	@Subscribe
@@ -950,7 +949,7 @@ public class TimersPlugin extends Plugin
 			|| lastAnimation == AnimationID.LEAGUE_HOME_TELEPORT_6
 			|| lastAnimation == AnimationID.GENERIC_TELEPORT))
 		{
-			if (lastTeleportClicked == TeleportWidget.HOME_TELEPORT)
+			if (lastTeleportClicked == TeleportWidget.HOME_TELEPORT || gimHelmTeleportClicked)
 			{
 				createGameTimer(HOME_TELEPORT);
 			}


### PR DESCRIPTION
This will create a `TimerTimer` with `GameTimer` enum value `HOME_TELEPORT` after the user successfully uses the `Teleport` on the `Group iron helm` or the `Hardcore group iron helm`. This item's teleport timer is the same as home teleport timer.  This PR is in response to https://github.com/runelite/runelite/issues/14250

This has been tested and appears to be working.