### PR TITLE
fix to 14250, group iron man teleport shared timer

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/AnimationID.java
+++ b/runelite-api/src/main/java/net/runelite/api/AnimationID.java
@@ -187,6 +187,7 @@ public final class AnimationID
 	public static final int DEMONIC_GORILLA_AOE_ATTACK = 7228;
 	public static final int DEMONIC_GORILLA_PRAYER_SWITCH = 7228;
 	public static final int DEMONIC_GORILLA_DEFEND = 7224;
+	public static final int TELEPORT_EMOTE = 714;
 	public static final int BOOK_HOME_TELEPORT_1 = 4847;
 	public static final int BOOK_HOME_TELEPORT_2 = 4850;
 	public static final int BOOK_HOME_TELEPORT_3 = 4853;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersPlugin.java
@@ -452,6 +452,7 @@ public class TimersPlugin extends Plugin
 		{
 			return -1;
 		}
+
 	}
 
 	@Subscribe

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersPlugin.java
@@ -439,9 +439,10 @@ public class TimersPlugin extends Plugin
 		}
 	}
 
+
 	private int getEquipmentItemID(MenuOptionClicked event)
 	{
-		if(EQUIPMENT.getGroupId() == TO_GROUP(event.getParam1()))
+		if (EQUIPMENT.getGroupId() == TO_GROUP(event.getParam1()))
 		{
 			return client.getWidget(
 					TO_GROUP(event.getParam1()),
@@ -452,8 +453,8 @@ public class TimersPlugin extends Plugin
 		{
 			return -1;
 		}
-
 	}
+
 
 	@Subscribe
 	public void onMenuOptionClicked(MenuOptionClicked event)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersPlugin.java
@@ -513,7 +513,8 @@ public class TimersPlugin extends Plugin
 				&& (getEquipmentItemID(event) == ItemID.HARDCORE_GROUP_IRON_HELM
 				|| getEquipmentItemID(event) == ItemID.GROUP_IRON_HELM
 				|| event.getId() == ItemID.HARDCORE_GROUP_IRON_HELM
-				|| event.getId() == ItemID.GROUP_IRON_HELM)) {
+				|| event.getId() == ItemID.GROUP_IRON_HELM))
+		{
 			groupIronTeleport = true;
 			return;
 		}
@@ -975,18 +976,25 @@ public class TimersPlugin extends Plugin
 		}
 
 		if (config.showHomeMinigameTeleports()
-				&& client.getLocalPlayer().getAnimation() == AnimationID.IDLE) {
+				&& client.getLocalPlayer().getAnimation() == AnimationID.IDLE)
+		{
+			if (groupIronTeleport && lastAnimation == AnimationID.TELEPORT_EMOTE)
+			{
+				createGameTimer(HOME_TELEPORT);
+			}
+			
 			if (lastAnimation == AnimationID.BOOK_HOME_TELEPORT_5
 					|| lastAnimation == AnimationID.COW_HOME_TELEPORT_6
-					|| lastAnimation == AnimationID.LEAGUE_HOME_TELEPORT_6) {
-				if (lastTeleportClicked == TeleportWidget.HOME_TELEPORT) {
+					|| lastAnimation == AnimationID.LEAGUE_HOME_TELEPORT_6)
+			{
+				if (lastTeleportClicked == TeleportWidget.HOME_TELEPORT)
+				{
 					createGameTimer(HOME_TELEPORT);
-				} else if (lastTeleportClicked == TeleportWidget.MINIGAME_TELEPORT) {
+				}
+				else if (lastTeleportClicked == TeleportWidget.MINIGAME_TELEPORT)
+				{
 					createGameTimer(MINIGAME_TELEPORT);
 				}
-			}
-			if (groupIronTeleport && lastAnimation == AnimationID.TELEPORT_EMOTE) {
-				createGameTimer(HOME_TELEPORT);
 			}
 		}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersPlugin.java
@@ -439,13 +439,17 @@ public class TimersPlugin extends Plugin
 		}
 	}
 
-	private int getEquipmentItemID(MenuOptionClicked event) {
-		if(EQUIPMENT.getGroupId() == TO_GROUP(event.getParam1())) {
+	private int getEquipmentItemID(MenuOptionClicked event)
+	{
+		if(EQUIPMENT.getGroupId() == TO_GROUP(event.getParam1()))
+		{
 			return client.getWidget(
 					TO_GROUP(event.getParam1()),
 					TO_CHILD(event.getParam1())
 			).getChild(1).getItemId();
-		} else {
+		}
+		else
+		{
 			return -1;
 		}
 	}
@@ -982,7 +986,7 @@ public class TimersPlugin extends Plugin
 			{
 				createGameTimer(HOME_TELEPORT);
 			}
-			
+
 			if (lastAnimation == AnimationID.BOOK_HOME_TELEPORT_5
 					|| lastAnimation == AnimationID.COW_HOME_TELEPORT_6
 					|| lastAnimation == AnimationID.LEAGUE_HOME_TELEPORT_6)


### PR DESCRIPTION
Fix for #14250.

Tested and working. Feedback welcomed!

| Test ID | Description | Expected Results | Actual Results |
| ------- | ----------- | -----------------| ---------------|
| EQUIP_NO_ACTIVE | Teleport from equipment tab, No Active Timer | Teleport, Start Timer | ✅ Teleport, Start Timer |
| EQUIP_ACTIVE | Teleport from equipment tab, Active Timer | Don't Teleport, Don't Reset Timer |  ✅ Don't Teleport, Don't Reset Timer  |
| INV_NO_ACTIVE | Teleport from inventory, No Active Timer | Teleport, Start Timer | ✅ Teleport, Start Timer |
| INV_ACTIVE | Teleport from inventory, Active Timer | Don't Teleport, Don't Reset Timer |  ✅ Don't Teleport, Don't Reset Timer |
| NODE_NO_ACTIVE | Teleport from the Node to the Node, No Active Timer | Don't Teleport, Don't Reset Timer | ✅ Don't Teleport, Don't Reset Timer  |
| HOME_NO_ACTIVE | Teleport with Home Teleport spell, No Active Timer | Teleport, Start Timer | ✅ Teleport, Start Timer |
| VARROCK_NO_ACTIVE | Teleport with Normal (Varrock) Teleport, No Active Timer | Teleport, Don't Start Timer | ✅ Teleport, Don't Start Timer |
| NODE_ACTIVE | Teleport from the Node to the Node, Active Timer | Don't Teleport, Don't Reset Timer | ✅ Don't Teleport, Don't Reset Timer  |
| HOME_ACTIVE | Teleport with Home Teleport spell, Active Timer |  Don't Teleport, Don't Reset Timer | ✅ Don't Teleport, Don't Reset Timer  |
| VARROCK_ACTIVE | Teleport with Normal (Varrock) Teleport, Active Timer | Teleport, Don't Start Timer | ✅ Teleport, Don't Start Timer |


