### PR TITLE
achievement diary: remove quest requirement

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/KourendDiaryRequirement.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/KourendDiaryRequirement.java
@@ -41,8 +41,6 @@ public class KourendDiaryRequirement extends GenericDiaryRequirement
 		add("Steal from a Hosidius Food Stall.",
 			new SkillRequirement(Skill.THIEVING, 25),
 			new FavourRequirement(FavourRequirement.Favour.HOSIDIUS, 15));
-		add("Browse the Warrens General Store.",
-			new QuestRequirement(Quest.THE_QUEEN_OF_THIEVES, true));
 		add("Enter your Player Owned House from Hosidius.",
 			new SkillRequirement(Skill.CONSTRUCTION, 25));
 		add("Create a Strength potion in the Lovakengj Pub.",


### PR DESCRIPTION
Closes #14390

Removed the quest requirement for the "Browse the Warrens General Store" task.