### PR TITLE
item prices: fix for a few issues with the item prices plugin

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemprices/ItemPricesOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemprices/ItemPricesOverlay.java
@@ -302,7 +302,8 @@ class ItemPricesOverlay extends Overlay
 
 	private int calculateHAProfit(int haPrice, int gePrice)
 	{
-		return haPrice - gePrice;
+		int natureRunePrice = itemManager.getItemPrice(ItemID.NATURE_RUNE);
+		return haPrice - gePrice - natureRunePrice;
 	}
 
 	private static Color haProfitColor(int haProfit)


### PR DESCRIPTION
Closes #14393 

"Show High Alchemy Profit" no longer depends on "Show Grand Exchange Prices" and "Show High Alchemy Values" to be checked to display.