### PR TITLE
time tracking: add persistent notifications

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/TimeTrackingConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/TimeTrackingConfig.java
@@ -67,6 +67,17 @@ public interface TimeTrackingConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "persistentNotifications",
+		name = "Persistent notifications",
+		description = "Continue to notify you on login until timer is cleared",
+		position = 3
+	)
+	default boolean persistentNotifications()
+	{
+		return false;
+	}
+
+	@ConfigItem(
 		keyName = "farmingContractInfoBox",
 		name = "Show farming contract infobox",
 		description = "Show an infobox of your current farming contract when inside the farming guild",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/TimeTrackingNotifier.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/TimeTrackingNotifier.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2021, molo-pl <https://github.com/molo-pl>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.timetracking;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import net.runelite.api.ChatMessageType;
+import net.runelite.client.Notifier;
+import net.runelite.client.chat.ChatColorType;
+import net.runelite.client.chat.ChatMessageBuilder;
+import net.runelite.client.chat.ChatMessageManager;
+import net.runelite.client.chat.QueuedMessage;
+
+@Singleton
+public class TimeTrackingNotifier
+{
+	@Inject
+	private Notifier notifier;
+	@Inject
+	private ChatMessageManager chatMessageManager;
+
+	/**
+	 * @param notification notification to send
+	 * @param onLogin      whether this notification is sent on player log-in as part of persistent notifications
+	 */
+	public void notify(String notification, boolean onLogin)
+	{
+		if (onLogin)
+		{
+			// to be less annoying we'll just send a highlight chat message
+			final String message = new ChatMessageBuilder()
+				.append(ChatColorType.HIGHLIGHT)
+				.append(notification)
+				.build();
+
+			chatMessageManager.queue(
+				QueuedMessage.builder()
+					.type(ChatMessageType.CONSOLE)
+					.runeLiteFormattedMessage(message)
+					.build());
+		}
+		else
+		{
+			notifier.notify(notification);
+		}
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/clocks/ClockManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/clocks/ClockManager.java
@@ -36,10 +36,10 @@ import javax.inject.Inject;
 import javax.swing.SwingUtilities;
 import joptsimple.internal.Strings;
 import lombok.Getter;
-import net.runelite.client.Notifier;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.plugins.timetracking.SortOrder;
 import net.runelite.client.plugins.timetracking.TimeTrackingConfig;
+import net.runelite.client.plugins.timetracking.TimeTrackingNotifier;
 
 @Singleton
 public class ClockManager
@@ -51,7 +51,7 @@ public class ClockManager
 	private TimeTrackingConfig config;
 
 	@Inject
-	private Notifier notifier;
+	private TimeTrackingNotifier notifier;
 
 	@Inject
 	private Gson gson;
@@ -109,21 +109,23 @@ public class ClockManager
 
 	/**
 	 * Checks if any timers have completed, and send notifications if required.
+	 * @param onLogin whether this check is performed on player login as part of persistent notifications
 	 */
-	public boolean checkCompletion()
+	public boolean checkCompletion(boolean onLogin)
 	{
 		boolean changed = false;
 
 		for (Timer timer : timers)
 		{
-			if (timer.isActive() && timer.getDisplayTime() == 0)
+			// if this is an 'on-login' check, we send notifications even if player was previously notified
+			if ((onLogin || timer.isActive()) && timer.getDisplayTime() == 0)
 			{
 				timer.pause();
 				changed = true;
 
 				if (config.timerNotification())
 				{
-					notifier.notify("[" + timer.getName() + "] has finished counting down.");
+					notifier.notify("[" + timer.getName() + "] has finished counting down.", onLogin);
 				}
 
 				if (timer.isLoop())

--- a/runelite-client/src/test/java/net/runelite/client/plugins/timetracking/farming/FarmingContractManagerTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/timetracking/farming/FarmingContractManagerTest.java
@@ -35,10 +35,12 @@ import javax.inject.Inject;
 import net.runelite.api.Client;
 import net.runelite.api.Varbits;
 import net.runelite.client.Notifier;
+import net.runelite.client.chat.ChatMessageManager;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.plugins.timetracking.SummaryState;
 import net.runelite.client.plugins.timetracking.TimeTrackingConfig;
+import net.runelite.client.plugins.timetracking.TimeTrackingNotifier;
 import net.runelite.client.ui.overlay.infobox.InfoBoxManager;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -80,6 +82,14 @@ public class FarmingContractManagerTest
 	@Mock
 	@Bind
 	private Notifier notifier;
+
+	@Mock
+	@Bind
+	private ChatMessageManager chatMessageManager;
+
+	@Mock
+	@Bind
+	private TimeTrackingNotifier timeTrackingNotifier;
 
 	@Mock
 	@Bind

--- a/runelite-client/src/test/java/net/runelite/client/plugins/timetracking/farming/FarmingTrackerTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/timetracking/farming/FarmingTrackerTest.java
@@ -35,11 +35,13 @@ import net.runelite.api.Player;
 import net.runelite.api.Varbits;
 import net.runelite.api.WorldType;
 import net.runelite.client.Notifier;
+import net.runelite.client.chat.ChatMessageManager;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.config.RuneScapeProfile;
 import net.runelite.client.config.RuneScapeProfileType;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.plugins.timetracking.TimeTrackingConfig;
+import net.runelite.client.plugins.timetracking.TimeTrackingNotifier;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -79,6 +81,14 @@ public class FarmingTrackerTest
 	@Bind
 	private Notifier notifier;
 
+	@Mock
+	@Bind
+	private ChatMessageManager chatMessageManager;
+
+	@Mock
+	@Bind
+	private TimeTrackingNotifier timeTrackingNotifier;
+
 	@Before
 	public void before()
 	{
@@ -107,7 +117,7 @@ public class FarmingTrackerTest
 		);
 		FarmingPatch patch = region.getPatches()[4];
 		patch.setRegion(region);
-		farmingTracker.sendNotification(runeScapeProfile, patchPrediction, patch);
+		farmingTracker.sendNotification(runeScapeProfile, patchPrediction, patch, false);
 	}
 
 	@Test
@@ -125,8 +135,8 @@ public class FarmingTrackerTest
 		);
 		FarmingPatch patch = region.getPatches()[3];
 		patch.setRegion(region);
-		farmingTracker.sendNotification(runeScapeProfile, patchPrediction, patch);
+		farmingTracker.sendNotification(runeScapeProfile, patchPrediction, patch, false);
 
-		verify(notifier).notify("Your Ranarr is ready to harvest in Ardougne.");
+		verify(timeTrackingNotifier).notify("Your Ranarr is ready to harvest in Ardougne.", false);
 	}
 }


### PR DESCRIPTION
Adding a possibility to make time tracking notifications persistent / "sticky".

<img width="241" alt="screenshot-2" src="https://user-images.githubusercontent.com/62616086/142888966-0f8dbd56-6e8b-46e1-9ca7-75f5546fb94a.png">

Currently, notifications for birdhouses, farm patches and timers are once-off, and only get triggered at at a specific moment. This means that:

1) If the RL client is turned off at that time, no notification will be sent.
2) It's easy to forget about actioning a notification if it is triggered at an inconvenient time.

Having persistent notifications enabled, notifications for completed timers (farm patch ready for harvesting, bird house ready for collecting, timer counted down to 0) will continue to re-occur upon every login until actioned. Not as notifications, but rather highlight chat messages. This is done similarly to e.g. daily task indicators.

<img width="520" alt="screenshot-1" src="https://user-images.githubusercontent.com/62616086/142888253-fba4172b-c2ef-4018-b96c-c23858b03aeb.png">