### PR TITLE
Prayer: Add delay for flick helper and bar

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/prayer/PrayerBarOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/prayer/PrayerBarOverlay.java
@@ -159,13 +159,14 @@ class PrayerBarOverlay extends Overlay
 			return;
 		}
 
-		if (config.hideIfNotPraying() && !plugin.isPrayersActive())
+		PrayerConfig.PrayerBarVisibility visibility = config.barVisibility();
+		if (visibility == PrayerConfig.PrayerBarVisibility.PRAYER_ACTIVE && !plugin.isPrayersActive())
 		{
 			showingPrayerBar = false;
 			return;
 		}
 
-		if (config.hideIfOutOfCombat() && localPlayer.getHealthScale() == -1)
+		if (visibility == PrayerConfig.PrayerBarVisibility.IN_COMBAT && localPlayer.getHealthScale() == -1)
 		{
 			showingPrayerBar = false;
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/prayer/PrayerBarOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/prayer/PrayerBarOverlay.java
@@ -60,6 +60,7 @@ class PrayerBarOverlay extends Overlay
 	private final PrayerPlugin plugin;
 
 	private int prayerBarTicksLeft = 0;
+	private int prayerFlickTicksLeft = 0;
 
 	@Inject
 	private PrayerBarOverlay(final Client client, final PrayerConfig config, final PrayerPlugin plugin)
@@ -102,7 +103,7 @@ class PrayerBarOverlay extends Overlay
 			// Use a sub-image to create the same effect the HD Health Bar has
 			graphics.drawImage(HD_FRONT_BAR.getSubimage(0, 0, progressFill, barHeight), barX, barY, progressFill, barHeight, null);
 
-			if ((plugin.isPrayersActive() || config.prayerFlickAlwaysOn())
+			if ((plugin.isPrayersActive() || config.prayerFlickAlwaysOn() || prayerFlickTicksLeft > 0)
 				&& (config.prayerFlickLocation().equals(PrayerFlickLocation.PRAYER_BAR)
 				|| config.prayerFlickLocation().equals(PrayerFlickLocation.BOTH)))
 			{
@@ -133,7 +134,7 @@ class PrayerBarOverlay extends Overlay
 		graphics.setColor(BAR_FILL_COLOR);
 		graphics.fillRect(barX, barY, progressFill, barHeight);
 
-		if ((plugin.isPrayersActive() || config.prayerFlickAlwaysOn())
+		if ((plugin.isPrayersActive() || config.prayerFlickAlwaysOn() || prayerFlickTicksLeft > 0)
 			&& (config.prayerFlickLocation().equals(PrayerFlickLocation.PRAYER_BAR)
 			|| config.prayerFlickLocation().equals(PrayerFlickLocation.BOTH)))
 		{
@@ -150,6 +151,8 @@ class PrayerBarOverlay extends Overlay
 
 	void onTick()
 	{
+		prayerFlickTicksLeft = plugin.getFlickHelperTicksLeft();
+
 		final Player localPlayer = client.getLocalPlayer();
 		if (localPlayer == null)
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/prayer/PrayerBarOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/prayer/PrayerBarOverlay.java
@@ -59,7 +59,7 @@ class PrayerBarOverlay extends Overlay
 	private final PrayerConfig config;
 	private final PrayerPlugin plugin;
 
-	private boolean showingPrayerBar;
+	private int prayerBarTicksLeft = 0;
 
 	@Inject
 	private PrayerBarOverlay(final Client client, final PrayerConfig config, final PrayerPlugin plugin)
@@ -76,7 +76,7 @@ class PrayerBarOverlay extends Overlay
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
-		if (!config.showPrayerBar() || !showingPrayerBar)
+		if (!config.showPrayerBar() || prayerBarTicksLeft <= 0)
 		{
 			return null;
 		}
@@ -151,24 +151,25 @@ class PrayerBarOverlay extends Overlay
 	void onTick()
 	{
 		final Player localPlayer = client.getLocalPlayer();
-		showingPrayerBar = true;
-
 		if (localPlayer == null)
 		{
-			showingPrayerBar = false;
+			--prayerBarTicksLeft;
 			return;
 		}
 
 		PrayerConfig.PrayerBarVisibility visibility = config.barVisibility();
 		if (visibility == PrayerConfig.PrayerBarVisibility.PRAYER_ACTIVE && !plugin.isPrayersActive())
 		{
-			showingPrayerBar = false;
+			--prayerBarTicksLeft;
 			return;
 		}
 
 		if (visibility == PrayerConfig.PrayerBarVisibility.IN_COMBAT && localPlayer.getHealthScale() == -1)
 		{
-			showingPrayerBar = false;
+			--prayerBarTicksLeft;
+			return;
 		}
+
+		prayerBarTicksLeft = 1 + config.barHideDelay();
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/prayer/PrayerConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/prayer/PrayerConfig.java
@@ -72,7 +72,19 @@ public interface PrayerConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 2,
+			position = 2,
+			keyName = "prayerFlickHideDelay",
+			name = "Flick helper hide delay",
+			description = "How many ticks to wait before hiding the prayer flick helper"
+	)
+	@Units(Units.TICKS)
+	default int flickHideDelay()
+	{
+		return 0;
+	}
+
+	@ConfigItem(
+		position = 3,
 		keyName = "prayerIndicator",
 		name = "Boost indicator",
 		description = "Enable infoboxes for prayers."
@@ -83,7 +95,7 @@ public interface PrayerConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 3,
+		position = 4,
 		keyName = "prayerIndicatorOverheads",
 		name = "Overhead indicator",
 		description = "Also enable infoboxes for overheads."
@@ -94,7 +106,7 @@ public interface PrayerConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 4,
+		position = 5,
 		keyName = "showPrayerDoseIndicator",
 		name = "Show prayer dose indicator",
 		description = "Enables the prayer dose indicator."
@@ -105,7 +117,7 @@ public interface PrayerConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 5,
+		position = 6,
 		keyName = "showPrayerTooltip",
 		name = "Show prayer orb tooltip",
 		description = "Displays time remaining and prayer bonus as a tooltip on the quick-prayer icon."
@@ -116,7 +128,7 @@ public interface PrayerConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 6,
+		position = 7,
 		keyName = "showPrayerBar",
 		name = "Show prayer bar",
 		description = "Displays prayer bar under HP bar when praying."
@@ -127,7 +139,7 @@ public interface PrayerConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 7,
+		position = 8,
 		keyName = "prayerBarVisibility",
 		name = "Bar Visibility",
 		description = "When the prayer bar should be visible"
@@ -138,7 +150,7 @@ public interface PrayerConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 8,
+		position = 9,
 		keyName = "prayerBarHideDelay",
 		name = "Bar Hide Delay",
 		description = "How many ticks to wait before hiding the prayer bar"
@@ -150,7 +162,7 @@ public interface PrayerConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 9,
+		position = 10,
 		keyName = "replaceOrbText",
 		name = "Show time left",
 		description = "Show time remaining of current prayers in the prayer orb."

--- a/runelite-client/src/main/java/net/runelite/client/plugins/prayer/PrayerConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/prayer/PrayerConfig.java
@@ -28,6 +28,7 @@ import lombok.AllArgsConstructor;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.Units;
 
 @ConfigGroup("prayer")
 public interface PrayerConfig extends Config
@@ -138,6 +139,18 @@ public interface PrayerConfig extends Config
 
 	@ConfigItem(
 		position = 8,
+		keyName = "prayerBarHideDelay",
+		name = "Bar Hide Delay",
+		description = "How many ticks to wait before hiding the prayer bar"
+	)
+	@Units(Units.TICKS)
+	default int barHideDelay()
+	{
+		return 0;
+	}
+
+	@ConfigItem(
+		position = 9,
 		keyName = "replaceOrbText",
 		name = "Show time left",
 		description = "Show time remaining of current prayers in the prayer orb."

--- a/runelite-client/src/main/java/net/runelite/client/plugins/prayer/PrayerConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/prayer/PrayerConfig.java
@@ -24,6 +24,7 @@
  */
 package net.runelite.client.plugins.prayer;
 
+import lombok.AllArgsConstructor;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
@@ -31,6 +32,22 @@ import net.runelite.client.config.ConfigItem;
 @ConfigGroup("prayer")
 public interface PrayerConfig extends Config
 {
+	@AllArgsConstructor
+	enum PrayerBarVisibility
+	{
+		ALWAYS("Always"),
+		IN_COMBAT("In combat"),
+		PRAYER_ACTIVE("Prayer active");
+
+		private final String value;
+
+		@Override
+		public String toString()
+		{
+			return value;
+		}
+	}
+
 	@ConfigItem(
 		position = 0,
 		keyName = "prayerFlickLocation",
@@ -110,28 +127,17 @@ public interface PrayerConfig extends Config
 
 	@ConfigItem(
 		position = 7,
-		keyName = "prayerBarHideIfNotPraying",
-		name = "Hide bar while prayer is inactive",
-		description = "Prayer bar will be hidden while prayers are inactive."
+		keyName = "prayerBarVisibility",
+		name = "Bar Visibility",
+		description = "When the prayer bar should be visible"
 	)
-	default boolean hideIfNotPraying()
+	default PrayerBarVisibility barVisibility()
 	{
-		return true;
+		return PrayerBarVisibility.PRAYER_ACTIVE;
 	}
 
 	@ConfigItem(
 		position = 8,
-		keyName = "prayerBarHideIfNonCombat",
-		name = "Hide bar while out-of-combat",
-		description = "Prayer bar will be hidden while out-of-combat."
-	)
-	default boolean hideIfOutOfCombat()
-	{
-		return false;
-	}
-
-	@ConfigItem(
-		position = 9,
 		keyName = "replaceOrbText",
 		name = "Show time left",
 		description = "Show time remaining of current prayers in the prayer orb."

--- a/runelite-client/src/main/java/net/runelite/client/plugins/prayer/PrayerFlickOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/prayer/PrayerFlickOverlay.java
@@ -29,6 +29,9 @@ import java.awt.Dimension;
 import java.awt.Graphics2D;
 import java.awt.geom.Rectangle2D;
 import javax.inject.Inject;
+
+import lombok.AccessLevel;
+import lombok.Getter;
 import net.runelite.api.Client;
 import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetInfo;
@@ -41,6 +44,9 @@ class PrayerFlickOverlay extends Overlay
 	private final Client client;
 	private final PrayerConfig config;
 	private final PrayerPlugin plugin;
+
+	@Getter(AccessLevel.PACKAGE)
+	private int prayerFlickTicksLeft = 0;
 
 	@Inject
 	private PrayerFlickOverlay(Client client, PrayerConfig config, PrayerPlugin plugin)
@@ -56,7 +62,7 @@ class PrayerFlickOverlay extends Overlay
 	public Dimension render(Graphics2D graphics)
 	{
 		// If there are no prayers active or flick location is set to the prayer bar we don't require the flick helper
-		if ((!plugin.isPrayersActive() && !config.prayerFlickAlwaysOn())
+		if ((!plugin.isPrayersActive() && !config.prayerFlickAlwaysOn() && prayerFlickTicksLeft <= 0)
 			|| config.prayerFlickLocation().equals(PrayerFlickLocation.NONE)
 			|| config.prayerFlickLocation().equals(PrayerFlickLocation.PRAYER_BAR))
 		{
@@ -93,5 +99,16 @@ class PrayerFlickOverlay extends Overlay
 		graphics.fillRect(orbInnerX + xOffset, orbInnerY + yOffset, 1, indicatorHeight);
 
 		return new Dimension((int) bounds.getWidth(), (int) bounds.getHeight());
+	}
+
+	void onTick()
+	{
+		if (!plugin.isPrayersActive() && !config.prayerFlickAlwaysOn())
+		{
+			--prayerFlickTicksLeft;
+			return;
+		}
+
+		prayerFlickTicksLeft = 1 + config.flickHideDelay();
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/prayer/PrayerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/prayer/PrayerPlugin.java
@@ -162,6 +162,10 @@ public class PrayerPlugin extends Plugin
 		if (!config.prayerFlickLocation().equals(PrayerFlickLocation.NONE))
 		{
 			startOfLastTick = Instant.now();
+			if (config.flickHideDelay() > 0)
+			{
+				flickOverlay.onTick();
+			}
 		}
 
 		if (config.showPrayerDoseIndicator())
@@ -380,5 +384,10 @@ public class PrayerPlugin extends Plugin
 		{
 			return timeLeft.format(DateTimeFormatter.ofPattern("m:ss"));
 		}
+	}
+
+	int getFlickHelperTicksLeft()
+	{
+		return flickOverlay.getPrayerFlickTicksLeft();
 	}
 }


### PR DESCRIPTION
I've added a config option to delay the hiding of the prayer plugin's flick helper and bar. I've also replaced two very similar boolean config options with an enum config option.  
Closes #14414