### PR TITLE
Tree respawn times updated based on wiki info

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/Tree.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/Tree.java
@@ -53,26 +53,27 @@ import static net.runelite.api.ObjectID.WILLOW_10833;
 import static net.runelite.api.ObjectID.YEW;
 import static net.runelite.api.NullObjectID.NULL_10823;
 import static net.runelite.api.ObjectID.YEW_36683;
+import static net.runelite.client.util.RSTimeUnit.GAME_TICKS;
 
 @Getter
 enum Tree
 {
 	REGULAR_TREE(null, TREE, TREE_1277, TREE_1278, TREE_1279, TREE_1280),
-	OAK_TREE(Duration.ofMillis(8500), OAK_TREE_4540, OAK_10820),
-	WILLOW_TREE(Duration.ofMillis(8500), WILLOW, WILLOW_10829, WILLOW_10831, WILLOW_10833),
-	MAPLE_TREE(Duration.ofSeconds(35), MAPLE_TREE_10832, MAPLE_TREE_36681)
+	OAK_TREE(Duration.of(14, GAME_TICKS), OAK_TREE_4540, OAK_10820),
+	WILLOW_TREE(Duration.of(14, GAME_TICKS), WILLOW, WILLOW_10829, WILLOW_10831, WILLOW_10833),
+	MAPLE_TREE(Duration.of(59, GAME_TICKS), MAPLE_TREE_10832, MAPLE_TREE_36681)
 		{
 			@Override
 			Duration getRespawnTime(int region)
 			{
-				return region == MISCELLANIA_REGION ? Duration.ofMillis(8500) : super.respawnTime;
+				return region == MISCELLANIA_REGION ? Duration.of(14, GAME_TICKS) : super.respawnTime;
 			}
 		},
-	TEAK_TREE(Duration.ofMillis(8500), TEAK, TEAK_36686),
-	MAHOGANY_TREE(Duration.ofMillis(8500), MAHOGANY, MAHOGANY_36688),
-	YEW_TREE(Duration.ofMinutes(1), YEW, NULL_10823, YEW_36683),
-	MAGIC_TREE(Duration.ofMinutes(2), MAGIC_TREE_10834, NULL_10835),
-	REDWOOD(Duration.ofMinutes(2), ObjectID.REDWOOD, REDWOOD_29670);
+	TEAK_TREE(Duration.of(15, GAME_TICKS), TEAK, TEAK_36686),
+	MAHOGANY_TREE(Duration.of(14, GAME_TICKS), MAHOGANY, MAHOGANY_36688),
+	YEW_TREE(Duration.of(99, GAME_TICKS), YEW, NULL_10823, YEW_36683),
+	MAGIC_TREE(Duration.of(199, GAME_TICKS), MAGIC_TREE_10834, NULL_10835),
+	REDWOOD(Duration.of(199, GAME_TICKS), ObjectID.REDWOOD, REDWOOD_29670);
 
 	@Nullable
 	private final Duration respawnTime;


### PR DESCRIPTION
Changed respawn times to the wiki values this closes issue 
#14285

Timers now also match the style of the rocks (based on gameticks)

- [Oak](https://oldschool.runescape.wiki/w/Oak)
- [Willow](https://oldschool.runescape.wiki/w/Willow)
- [Maple tree](https://oldschool.runescape.wiki/w/Maple_tree)
- [Teak](https://oldschool.runescape.wiki/w/Teak)
- [Mahogany](https://oldschool.runescape.wiki/w/Mahogany)
- [Yew](https://oldschool.runescape.wiki/w/Yew)
- [Magic tree](https://oldschool.runescape.wiki/w/Magic_tree)
- [Redwood tree](https://oldschool.runescape.wiki/w/Redwood_tree)