### PR TITLE
Add settings to xp tracker to improve on-screen canvas display options

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpInfoBoxOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpInfoBoxOverlay.java
@@ -25,11 +25,7 @@
  */
 package net.runelite.client.plugins.xptracker;
 
-import java.awt.Color;
-import java.awt.Dimension;
-import java.awt.Graphics2D;
-import java.awt.Point;
-import java.awt.Rectangle;
+import java.awt.*;
 import java.awt.image.BufferedImage;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -103,40 +99,56 @@ class XpInfoBoxOverlay extends OverlayPanel
 		final String bottomRightNum = config.onScreenDisplayModeBottom().getValueFunc().apply(snapshot);
 
 		final LineComponent xpLineBottom = LineComponent.builder()
-				.left(bottomLeftStr + ":")
-				.right(bottomRightNum)
-				.build();
+					.left(bottomLeftStr + ":")
+					.right(bottomRightNum)
+					.build();
 
 		final SplitComponent xpSplit = SplitComponent.builder()
-				.first(xpLine)
-				.second(xpLineBottom)
-				.orientation(ComponentOrientation.VERTICAL)
-				.build();
+					.first(xpLine)
+					.second(xpLineBottom)
+					.orientation(ComponentOrientation.VERTICAL)
+					.build();
 
-		final ImageComponent imageComponent = new ImageComponent(icon);
+		BufferedImage xpIcon;
+		if (config.onScreenDisplayOneLine()){
+			//Shrink image by half to make one-line display smaller.
+			Image shrunkIcon = icon.getScaledInstance(icon.getWidth()/2, icon.getHeight()/2, Image.SCALE_DEFAULT);
+			xpIcon = new BufferedImage(shrunkIcon.getWidth(null), shrunkIcon.getHeight(null), BufferedImage.TYPE_INT_ARGB);
+
+			// Draw the shrunk image on to the buffered xp image
+			Graphics2D bGr = xpIcon.createGraphics();
+			bGr.drawImage(shrunkIcon, 0, 0, null);
+			bGr.dispose();
+		}
+		else {
+			xpIcon = icon;
+		}
+
+		final ImageComponent imageComponent = new ImageComponent(xpIcon);
 		final SplitComponent iconXpSplit = SplitComponent.builder()
 				.first(imageComponent)
-				.second(xpSplit)
+				.second(config.onScreenDisplayOneLine() ? xpLine : xpSplit)
 				.orientation(ComponentOrientation.HORIZONTAL)
 				.gap(new Point(XP_AND_ICON_GAP, 0))
 				.build();
 
 		iconXpSplitPanel.getChildren().add(iconXpSplit);
-
-		final ProgressBarComponent progressBarComponent = new ProgressBarComponent();
-
-		progressBarComponent.setBackgroundColor(new Color(61, 56, 49));
-		progressBarComponent.setForegroundColor(SkillColor.find(skill).getColor());
-
-		progressBarComponent.setLeftLabel(String.valueOf(snapshot.getStartLevel()));
-		progressBarComponent.setRightLabel(snapshot.getEndGoalXp() == Experience.MAX_SKILL_XP
-			? "200M"
-			: String.valueOf(snapshot.getEndLevel()));
-
-		progressBarComponent.setValue(snapshot.getSkillProgressToGoal());
-
 		panelComponent.getChildren().add(iconXpSplitPanel);
-		panelComponent.getChildren().add(progressBarComponent);
+
+		if (config.onScreenDisplayProgressBar()) {
+			final ProgressBarComponent progressBarComponent = new ProgressBarComponent();
+
+			progressBarComponent.setBackgroundColor(new Color(61, 56, 49));
+			progressBarComponent.setForegroundColor(SkillColor.find(skill).getColor());
+
+			progressBarComponent.setLeftLabel(String.valueOf(snapshot.getStartLevel()));
+			progressBarComponent.setRightLabel(snapshot.getEndGoalXp() == Experience.MAX_SKILL_XP
+					? "200M"
+					: String.valueOf(snapshot.getEndLevel()));
+
+			progressBarComponent.setValue(snapshot.getSkillProgressToGoal());
+			panelComponent.getChildren().add(progressBarComponent);
+		}
 
 		return super.render(graphics);
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerConfig.java
@@ -113,7 +113,7 @@ public interface XpTrackerConfig extends Config
 	@ConfigItem(
 		position = 6,
 		keyName = "onScreenDisplayMode",
-		name = "On-screen tracker display mode (top)",
+		name = "Tracker display mode (top)",
 		description = "Configures the information displayed in the first line of on-screen XP overlays",
 		section = overlaySection
 	)
@@ -125,7 +125,7 @@ public interface XpTrackerConfig extends Config
 	@ConfigItem(
 		position = 7,
 		keyName = "onScreenDisplayModeBottom",
-		name = "On-screen tracker display mode (bottom)",
+		name = "Tracker display mode (bottom)",
 		description = "Configures the information displayed in the second line of on-screen XP overlays",
 		section = overlaySection
 	)
@@ -135,7 +135,31 @@ public interface XpTrackerConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 8,
+			position = 8,
+			keyName = "onScreenDisplayProgressBar",
+			name = "Display xp progress bar",
+			description = "Toggles the xp progress bar tracker display on the on-screen canvas",
+			section = overlaySection
+	)
+	default boolean onScreenDisplayProgressBar()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+			position = 9,
+			keyName = "onScreenDisplayOneLine",
+			name = "Simple view (one-line)",
+			description = "Toggles the on screen trackers to display on one line",
+			section = overlaySection
+	)
+	default boolean onScreenDisplayOneLine()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		position = 10,
 		keyName = "xpPanelLabel1",
 		name = "Top-left XP info label",
 		description = "Configures the information displayed in the top-left of XP info box"
@@ -146,7 +170,7 @@ public interface XpTrackerConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 9,
+		position = 11,
 		keyName = "xpPanelLabel2",
 		name = "Top-right XP info label",
 		description = "Configures the information displayed in the top-right of XP info box"
@@ -158,7 +182,7 @@ public interface XpTrackerConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 10,
+		position = 12,
 		keyName = "xpPanelLabel3",
 		name = "Bottom-left XP info label",
 		description = "Configures the information displayed in the bottom-left of XP info box"
@@ -169,7 +193,7 @@ public interface XpTrackerConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 11,
+		position = 13,
 		keyName = "xpPanelLabel4",
 		name = "Bottom-right XP info label",
 		description = "Configures the information displayed in the bottom-right of XP info box"
@@ -180,7 +204,7 @@ public interface XpTrackerConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 12,
+		position = 14,
 		keyName = "progressBarLabel",
 		name = "Progress bar label",
 		description = "Configures the info box progress bar to show Time to goal or percentage complete"
@@ -191,7 +215,7 @@ public interface XpTrackerConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 13,
+		position = 15,
 		keyName = "progressBarTooltipLabel",
 		name = "Tooltip label",
 		description = "Configures the info box progress bar tooltip to show Time to goal or percentage complete"
@@ -202,7 +226,7 @@ public interface XpTrackerConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 14,
+		position = 16,
 		keyName = "prioritizeRecentXpSkills",
 		name = "Move recently trained skills to top",
 		description = "Configures whether skills should be organized by most recently gained xp"


### PR DESCRIPTION
This addresses #9206

Add setting for displaying the progress bar on the on-screen xp tracker,
allowing users to not display the progress bar to reduce on-screen
clutter.

Similarly, added setting to only display one line of the xp tracker
on-screen, allowing users to tweak their display to their liking.