### PR TITLE
Add dodgy necklace protection to pickpocket stun timer

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersPlugin.java
@@ -124,6 +124,7 @@ public class TimersPlugin extends Plugin
 	private static final String RESURRECT_THRALL_DISAPPEAR_MESSAGE_END = " thrall returns to the grave.</col>";
 	private static final String WARD_OF_ARCEUUS_MESSAGE = ">Your defence against Arceuus magic has been strengthened.</col>";
 	private static final String PICKPOCKET_FAILURE_MESSAGE = "You fail to pick the ";
+	private static final String DODGY_NECKLACE_PROTECTION_MESSAGE = "Your dodgy necklace protects you.";
 
 	private static final Pattern TELEBLOCK_PATTERN = Pattern.compile("A Tele Block spell has been cast on you(?: by .+)?\\. It will expire in (?<mins>\\d+) minutes?(?:, (?<secs>\\d+) seconds?)?\\.");
 	private static final Pattern DIVINE_POTION_PATTERN = Pattern.compile("You drink some of your divine (.+) potion\\.");
@@ -506,6 +507,11 @@ public class TimersPlugin extends Plugin
 		if (event.getType() != ChatMessageType.SPAM && event.getType() != ChatMessageType.GAMEMESSAGE)
 		{
 			return;
+		}
+
+		if (message.contains(DODGY_NECKLACE_PROTECTION_MESSAGE))
+		{
+			removeGameTimer(PICKPOCKET_STUN);
 		}
 
 		if (message.contains(PICKPOCKET_FAILURE_MESSAGE) && config.showPickpocketStun() && message.contains("pocket"))


### PR DESCRIPTION
Currently the pickpocket stun timer does not take the dodgy necklace protect into consideration. If you fail to pickpocket but get saved by the dodgy necklace, the timer indicator still shows up.

This change makes it so that when the dodgy necklace protection message shows up, the pickpocket stun timer started previously is removed.

![Pickpocket stun change demo](https://user-images.githubusercontent.com/10135839/145228397-c35122f8-d681-4f58-a4bc-a3e2c4df4842.gif)

Notice that the indicator only shows up when failing to pickpocket and no dodgy necklace protection.
