### PR TITLE
Enable "in wilderness only" option for highlighting other players 

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/HighlightOthersOptions.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/HighlightOthersOptions.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2019, Jordan Atwood <nightfirecat@protonmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.playerindicators;
+
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public enum HighlightOthersOptions
+{
+
+	ALWAYS("Always"),
+	NEVER("Never"),
+	ONLY_IN_WILDERNESS("Only in wilderness");
+
+	private final String name;
+
+	@Override
+	public String toString()
+	{
+		return name;
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsConfig.java
@@ -164,12 +164,12 @@ public interface PlayerIndicatorsConfig extends Config
 		position = 10,
 		keyName = "drawNonClanMemberNames",
 		name = "Highlight others",
-		description = "Configures whether or not other players should be highlighted",
+		description = "Configures in which case other players should be highlighted",
 		section = highlightSection
 	)
-	default boolean highlightOthers()
+	default HighlightOthersOptions highlightOthers()
 	{
-		return false;
+		return HighlightOthersOptions.NEVER;
 	}
 
 	@ConfigItem(

--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsPlugin.java
@@ -46,6 +46,7 @@ import static net.runelite.api.MenuAction.SPELL_CAST_ON_PLAYER;
 import static net.runelite.api.MenuAction.WALK;
 import net.runelite.api.MenuEntry;
 import net.runelite.api.Player;
+import net.runelite.api.Varbits;
 import net.runelite.api.clan.ClanTitle;
 import net.runelite.api.events.ClientTick;
 import net.runelite.client.config.ConfigManager;
@@ -53,6 +54,8 @@ import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.game.ChatIconManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
+import static net.runelite.client.plugins.playerindicators.HighlightOthersOptions.ALWAYS;
+import static net.runelite.client.plugins.playerindicators.HighlightOthersOptions.ONLY_IN_WILDERNESS;
 import net.runelite.client.ui.overlay.OverlayManager;
 import net.runelite.client.util.ColorUtil;
 
@@ -212,7 +215,8 @@ public class PlayerIndicatorsPlugin extends Plugin
 				}
 			}
 		}
-		else if (!player.isFriendsChatMember() && !player.isClanMember() && config.highlightOthers())
+		else if (!player.isFriendsChatMember() && !player.isClanMember() && (config.highlightOthers() == ALWAYS ||
+			(config.highlightOthers() == ONLY_IN_WILDERNESS && client.getVar(Varbits.IN_WILDERNESS) == 1)))
 		{
 			color = config.getOthersColor();
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsService.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsService.java
@@ -33,11 +33,15 @@ import net.runelite.api.FriendsChatManager;
 import net.runelite.api.FriendsChatMember;
 import net.runelite.api.FriendsChatRank;
 import net.runelite.api.Player;
+import net.runelite.api.Varbits;
 import net.runelite.api.clan.ClanChannel;
 import net.runelite.api.clan.ClanChannelMember;
 import net.runelite.api.clan.ClanRank;
 import net.runelite.api.clan.ClanSettings;
 import net.runelite.api.clan.ClanTitle;
+import static net.runelite.client.plugins.playerindicators.HighlightOthersOptions.ALWAYS;
+import static net.runelite.client.plugins.playerindicators.HighlightOthersOptions.NEVER;
+import static net.runelite.client.plugins.playerindicators.HighlightOthersOptions.ONLY_IN_WILDERNESS;
 import net.runelite.client.util.Text;
 
 @Singleton
@@ -56,7 +60,7 @@ public class PlayerIndicatorsService
 	public void forEachPlayer(final BiConsumer<Player, Color> consumer)
 	{
 		if (!config.highlightOwnPlayer() && !config.highlightFriendsChat()
-			&& !config.highlightFriends() && !config.highlightOthers()
+			&& !config.highlightFriends() && !(config.highlightOthers() == NEVER)
 			&& !config.highlightClanMembers())
 		{
 			return;
@@ -97,7 +101,8 @@ public class PlayerIndicatorsService
 			{
 				consumer.accept(player, config.getClanMemberColor());
 			}
-			else if (config.highlightOthers() && !isFriendsChatMember && !isClanMember)
+			else if ((config.highlightOthers() == ALWAYS || (config.highlightOthers() == ONLY_IN_WILDERNESS
+				&& client.getVar(Varbits.IN_WILDERNESS) == 1)) && !isFriendsChatMember && !isClanMember)
 			{
 				consumer.accept(player, config.getOthersColor());
 			}


### PR DESCRIPTION
Similar request in #3684 The difference here is that not every player indication will appear whether or not the player is in the wilderness.

I created the option in such a way that clan members, friends, etc still show up despite of being in the wilderness.
The wilderness check is focused just on the "highlight others".
This way, users do not have to turn off the highlight others checkbox every time they enter or leave the wilderness.