### PR TITLE
Add a flag to prevent the new strip-accents feature in Chat Filter Plugin

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatfilter/ChatFilterPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatfilter/ChatFilterPlugin.java
@@ -321,7 +321,8 @@ public class ChatFilterPlugin extends Plugin
 	{
 		String strippedMessage = jagexPrintableCharMatcher.retainFrom(message)
 			.replace('\u00A0', ' ');
-		String strippedAccents = StringUtils.stripAccents(strippedMessage);
+		boolean shouldStripAccents = !strippedMessage.contains("(?U)");
+		String strippedAccents = shouldStripAccents ? StringUtils.stripAccents(strippedMessage) : strippedMessage;
 		assert strippedMessage.length() == strippedAccents.length();
 
 		if (username != null && shouldFilterByName(username))


### PR DESCRIPTION
There was a new feature added 1 month ago to the chat filter that prevents any filter from being able to distinguish between accented characters (eg ë and e are treated as the same). This pull request adds the option to specify a regex flag (?U) that prevents the stripping of accented characters.