### PR TITLE
Add check for wilderness task location

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerPlugin.java
@@ -381,6 +381,17 @@ public class SlayerPlugin extends Plugin
 				String name = mAssign.group("name");
 				int amount = Integer.parseInt(mAssign.group("amount"));
 				String location = mAssign.group("location");
+
+				if (location == null)
+				{
+					Widget npcName = client.getWidget(WidgetInfo.DIALOG_NPC_NAME);
+
+					if (npcName != null && npcName.getText().equals("Krystilia"))
+					{
+						location = "Wilderness";
+					}
+				}
+
 				setTask(name, amount, amount, location);
 			}
 			else if (mAssignFirst.find())


### PR DESCRIPTION
This is a fix for #14351.
This code sets the location to "Wilderness" if the npc name of the task giver is "Krystilia".
![wildy](https://user-images.githubusercontent.com/10135839/146436262-93d0c9f2-b4f3-4b90-abe6-fc738e58e875.gif)