### PR TITLE
Give "Always on top" more granular options

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/config/AlwaysOnTop.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/AlwaysOnTop.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2021, Chunderbolt <https://github.com/chunderbolt>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package net.runelite.client.config;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum AlwaysOnTop
+{
+	OFF("Off"),
+	WINDOWED_ONLY("Windowed only"),
+	FULL_SCREEN_ONLY("Full screen only"),
+	ALWAYS("Always");
+
+	private final String type;
+
+	@Override
+	public String toString()
+	{
+		return type;
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/config/RuneLiteConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/RuneLiteConfig.java
@@ -156,9 +156,9 @@ public interface RuneLiteConfig extends Config
 		position = 17,
 		section = windowSettings
 	)
-	default boolean gameAlwaysOnTop()
+	default AlwaysOnTop gameAlwaysOnTop()
 	{
-		return false;
+		return AlwaysOnTop.OFF;
 	}
 
 	@ConfigItem(

--- a/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
@@ -42,6 +42,8 @@ import java.awt.LayoutManager;
 import java.awt.Rectangle;
 import java.awt.Toolkit;
 import java.awt.TrayIcon;
+import java.awt.event.ComponentEvent;
+import java.awt.event.ComponentListener;
 import java.awt.event.MouseEvent;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
@@ -142,6 +144,7 @@ public class ClientUI
 	private JButton sidebarNavigationJButton;
 	private Dimension lastClientSize;
 	private Cursor defaultCursor;
+	private boolean listenerAdded;
 
 	@Inject
 	private ClientUI(
@@ -1058,7 +1061,25 @@ public class ClientUI
 
 		if (frame.isAlwaysOnTopSupported())
 		{
-			frame.setAlwaysOnTop(config.gameAlwaysOnTop());
+			updateAlwaysOnTop();
+
+			if (!listenerAdded)
+			{
+				frame.addComponentListener(new ComponentListener()
+										   {
+											   @Override
+											   public void componentResized(ComponentEvent e)
+											   {
+												   updateAlwaysOnTop();
+												   log.debug("Updated AlwaysOnTop: " + frame.isAlwaysOnTop());
+											   }
+											   @Override public void componentMoved(ComponentEvent e) { }
+											   @Override public void componentShown(ComponentEvent e) { }
+											   @Override public void componentHidden(ComponentEvent e) { }
+										   }
+				);
+				listenerAdded = true;
+			}
 		}
 
 		if (updateResizable)
@@ -1130,6 +1151,25 @@ public class ClientUI
 
 			configManager.unsetConfiguration(CONFIG_GROUP, CONFIG_CLIENT_MAXIMIZED);
 			configManager.setConfiguration(CONFIG_GROUP, CONFIG_CLIENT_BOUNDS, bounds);
+		}
+	}
+
+	private void updateAlwaysOnTop()
+	{
+		switch (config.gameAlwaysOnTop())
+		{
+			case OFF:
+				frame.setAlwaysOnTop(false);
+				break;
+			case WINDOWED_ONLY:
+				frame.setAlwaysOnTop((frame.getExtendedState() & Frame.MAXIMIZED_BOTH) != Frame.MAXIMIZED_BOTH);
+				break;
+			case FULL_SCREEN_ONLY:
+				frame.setAlwaysOnTop((frame.getExtendedState() & Frame.MAXIMIZED_BOTH) == Frame.MAXIMIZED_BOTH);
+				break;
+			case ALWAYS:
+				frame.setAlwaysOnTop(true);
+				break;
 		}
 	}
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/59027738/146445786-0eb4e3db-855b-43ab-8c48-a13bef1d0aa0.png)

I like to have runelite be always-on-top if windowed, but it's a bit annoying if I want to maximise it and can't get to anything that was previously behind it.

Added a "Full screen only" option, but I can't imagine anyone actually using it.