### PR TITLE
MenuEntrySwapper: Group Iron Storage shift deposit

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/widgets/WidgetID.java
+++ b/runelite-api/src/main/java/net/runelite/api/widgets/WidgetID.java
@@ -171,6 +171,7 @@ public final class WidgetID
 	public static final int GRAVESTONE_GROUP_ID = 672;
 	public static final int POH_TREASURE_CHEST_INVENTORY_GROUP_ID = 674;
 	public static final int GROUP_IRON_GROUP_ID = 726;
+	public static final int GROUP_STORAGE_INVENTORY_GROUP_ID = 725;
 	public static final int GROUP_STORAGE_GROUP_ID = 724;
 
 	static class WorldMap

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -602,17 +602,19 @@ public class MenuEntrySwapperPlugin extends Plugin
 
 		final boolean isDepositBoxPlayerInventory = widgetGroupId == WidgetID.DEPOSIT_BOX_GROUP_ID;
 		final boolean isChambersOfXericStorageUnitPlayerInventory = widgetGroupId == WidgetID.CHAMBERS_OF_XERIC_STORAGE_UNIT_INVENTORY_GROUP_ID;
+		final boolean isGroupStoragePlayerInventory = widgetGroupId == WidgetID.GROUP_STORAGE_INVENTORY_GROUP_ID;
 		// Swap to shift-click deposit behavior
 		// Deposit- op 1 is the current withdraw amount 1/5/10/x for deposit box interface and chambers of xeric storage unit.
 		// Deposit- op 2 is the current withdraw amount 1/5/10/x for bank interface
 		if (shiftModifier() && config.bankDepositShiftClick() != ShiftDepositMode.OFF
 			&& menuEntryAdded.getType() == MenuAction.CC_OP.getId()
-			&& menuEntryAdded.getIdentifier() == (isDepositBoxPlayerInventory || isChambersOfXericStorageUnitPlayerInventory ? 1 : 2)
+			&& menuEntryAdded.getIdentifier() == (isDepositBoxPlayerInventory || isGroupStoragePlayerInventory || isChambersOfXericStorageUnitPlayerInventory ? 1 : 2)
 			&& (menuEntryAdded.getOption().startsWith("Deposit-") || menuEntryAdded.getOption().startsWith("Store") || menuEntryAdded.getOption().startsWith("Donate")))
 		{
 			ShiftDepositMode shiftDepositMode = config.bankDepositShiftClick();
 			final int opId = isDepositBoxPlayerInventory ? shiftDepositMode.getIdentifierDepositBox()
 				: isChambersOfXericStorageUnitPlayerInventory ? shiftDepositMode.getIdentifierChambersStorageUnit()
+				: isGroupStoragePlayerInventory ? shiftDepositMode.getIdentifierGroupStorage()
 				: shiftDepositMode.getIdentifier();
 			final MenuAction action = opId >= 6 ? MenuAction.CC_OP_LOW_PRIORITY : MenuAction.CC_OP;
 			bankModeSwap(action, opId);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/ShiftDepositMode.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/ShiftDepositMode.java
@@ -31,17 +31,18 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum ShiftDepositMode
 {
-	DEPOSIT_1("Deposit-1", 3, 2, 1),
-	DEPOSIT_5("Deposit-5", 4, 3, 2),
-	DEPOSIT_10("Deposit-10", 5, 4, 3),
-	DEPOSIT_X("Deposit-X", 6, 6, 5),
-	DEPOSIT_ALL("Deposit-All", 8, 5, 4),
-	EXTRA_OP("Eat/Wield/Etc.", 9, 9, 0),
-	OFF("Off", 0, 0, 0);
+	DEPOSIT_1("Deposit-1", 3, 2, 1, 1),
+	DEPOSIT_5("Deposit-5", 4, 3, 3, 2),
+	DEPOSIT_10("Deposit-10", 5, 4, 4, 3),
+	DEPOSIT_X("Deposit-X", 6, 6, 5, 5),
+	DEPOSIT_ALL("Deposit-All", 8, 5, 7, 4),
+	EXTRA_OP("Eat/Wield/Etc.", 9, 9, 0, 0),
+	OFF("Off", 0, 0, 0, 0);
 
 	private final String name;
 	private final int identifier;
 	private final int identifierDepositBox;
+	private final int identifierGroupStorage;
 	private final int identifierChambersStorageUnit;
 
 	@Override


### PR DESCRIPTION
This adds the shift-deposit functionality to the group storage inventory in the menu entry swapper plugin.