### PR TITLE
Disable fuzzy search if GE search event consumed

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangePlugin.java
@@ -638,7 +638,7 @@ public class GrandExchangePlugin extends Plugin
 
 		GrandExchangeSearchMode searchMode = config.geSearchMode();
 		final String input = client.getVar(VarClientStr.INPUT_TEXT);
-		if (searchMode == GrandExchangeSearchMode.DEFAULT || input.isEmpty())
+		if (searchMode == GrandExchangeSearchMode.DEFAULT || input.isEmpty() || event.isConsumed())
 		{
 			return;
 		}


### PR DESCRIPTION
fixes #14499.

This allows for other plugins, such as Bank Tags, to take priority over fuzzy searching of results. Presumably most cases of the grand exchange search event being consumed will be due to another activity having explicit mutation of the results, which then would mean fuzzy search wouldn't make sense to be applied.