### PR TITLE
runelite: Upgrade mockito and add mockito-inline

### DIFF
--- a/runelite-client/pom.xml
+++ b/runelite-client/pom.xml
@@ -271,7 +271,13 @@
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>
-			<version>3.1.0</version>
+			<version>4.2.0</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-inline</artifactId>
+			<version>4.2.0</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
I've been adding unit tests to AnagramClues, and it requires static method mocking (we should ideally just refactor out the static methods so they are standard mockable, but OverlayUtil is ingrained in many plugins).

Luckily, Mockito v3.4+ provides static mocking ability, assuming we use mockito-inline.

In this PR, we upgrade `mockito-core` to 4.2 and add `mockito-inline:4.2` as a test dependency.