### PR TITLE
exp calc: Allow input of gp/exp to estimate costs.

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/SkillCalculator.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/SkillCalculator.java
@@ -119,6 +119,12 @@ class SkillCalculator extends JPanel
 			uiInput.getUiFieldTargetXP().requestFocusInWindow();
 		});
 
+		uiInput.getUiGoldPerXP().addActionListener(e ->
+		{
+			onFieldGoldPerXPUpdated();
+			uiInput.getUiGoldNeeded().requestFocusInWindow();
+		});
+
 		uiInput.getUiFieldTargetLevel().addActionListener(e -> onFieldTargetLevelUpdated());
 		uiInput.getUiFieldTargetXP().addActionListener(e -> onFieldTargetXPUpdated());
 
@@ -127,6 +133,7 @@ class SkillCalculator extends JPanel
 		uiInput.getUiFieldCurrentXP().addFocusListener(buildFocusAdapter(e -> onFieldCurrentXPUpdated()));
 		uiInput.getUiFieldTargetLevel().addFocusListener(buildFocusAdapter(e -> onFieldTargetLevelUpdated()));
 		uiInput.getUiFieldTargetXP().addFocusListener(buildFocusAdapter(e -> onFieldTargetXPUpdated()));
+		uiInput.getUiGoldPerXP().addFocusListener(buildFocusAdapter(e -> onFieldGoldPerXPUpdated()));
 	}
 
 	void openCalculator(CalculatorType calculatorType)
@@ -382,7 +389,13 @@ class SkillCalculator extends JPanel
 		uiInput.setCurrentXPInput(cXP);
 		uiInput.setTargetLevelInput(targetLevel);
 		uiInput.setTargetXPInput(tXP);
-		uiInput.setNeededXP(nXP + " XP required to reach target XP");
+		uiInput.setNeededXP(nXP);
+		int gpPerXP = uiInput.getGoldPerXP();
+		if (gpPerXP > 0)
+		{
+			final String totalGP = String.format("%,d", (targetXP - currentXP) * gpPerXP);
+			uiInput.setGoldNeeded(totalGP);
+		}
 		calculate();
 	}
 
@@ -417,6 +430,11 @@ class SkillCalculator extends JPanel
 	{
 		targetXP = enforceXPBounds(uiInput.getTargetXPInput());
 		targetLevel = Experience.getLevelForXp(targetXP);
+		updateInputFields();
+	}
+
+	private void onFieldGoldPerXPUpdated()
+	{
 		updateInputFields();
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/UICalculatorInputArea.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/UICalculatorInputArea.java
@@ -44,14 +44,20 @@ class UICalculatorInputArea extends JPanel
 	private final JTextField uiFieldCurrentXP;
 	private final JTextField uiFieldTargetLevel;
 	private final JTextField uiFieldTargetXP;
+	private final JTextField uiFieldNeededXP;
+	private final JTextField uiGoldPerXP;
+	private final JTextField uiGoldNeeded;
 
 	UICalculatorInputArea()
 	{
-		setLayout(new GridLayout(2, 2, 7, 7));
+		setLayout(new GridLayout(4, 2, 7, 7));
 		uiFieldCurrentLevel = addComponent("Current Level");
 		uiFieldCurrentXP = addComponent("Current Experience");
 		uiFieldTargetLevel = addComponent("Target Level");
 		uiFieldTargetXP = addComponent("Target Experience");
+		uiFieldNeededXP = addComponent("Needed Experience");
+		uiGoldPerXP = addComponent("GP/XP");
+		uiGoldNeeded = addComponent("GP Needed");
 	}
 
 	int getCurrentLevelInput()
@@ -96,7 +102,27 @@ class UICalculatorInputArea extends JPanel
 
 	void setNeededXP(Object value)
 	{
-		uiFieldTargetXP.setToolTipText((String) value);
+		setInput(uiFieldNeededXP, value);
+	}
+
+	int getGoldPerXP()
+	{
+		return getInput(uiGoldPerXP);
+	}
+
+	void setGoldPerXP(Object value)
+	{
+		setInput(uiGoldPerXP, value);
+	}
+
+	int getGoldNeeded()
+	{
+		return getInput(uiGoldNeeded);
+	}
+
+	void setGoldNeeded(Object value)
+	{
+		setInput(uiGoldNeeded, value);
 	}
 
 	private int getInput(JTextField field)


### PR DESCRIPTION
I often found myself copying numbers out of the exp calculator in order to estimate the costs for various skilling methods. 
I thought I would submit this in case this type of feature was desired upstream. If it is I think it might be nice to calculate the gp/exp on the fly based on the users choice of action and current going GE rates, but am not sure the best way of doing that.