### PR TITLE
Roof Removal: Add toggle for removing roofs in POH

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/roofremoval/RoofRemovalConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/roofremoval/RoofRemovalConfig.java
@@ -27,28 +27,27 @@ package net.runelite.client.plugins.roofremoval;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.ConfigSection;
 
 @ConfigGroup(RoofRemovalConfig.CONFIG_GROUP)
 public interface RoofRemovalConfig extends Config
 {
 	String CONFIG_GROUP = "roofremoval";
 
-	@ConfigItem(
-		keyName = "removePosition",
-		name = "Player's position",
-		description = "Remove roofs above the player's position"
+	@ConfigSection(
+		name = "Locations",
+		description = "Always remove roofs in these locations",
+		position = 4
 	)
-	default boolean removePosition()
-	{
-		return true;
-	}
+	String locationsSection = "Locations";
 
 	@ConfigItem(
-		keyName = "removeHovered",
-		name = "Hovered tile",
-		description = "Remove roofs above the hovered tile"
+		keyName = "removeBetween",
+		name = "Between camera & player",
+		description = "Remove roofs between the camera and the player at low camera angles",
+		position = 0
 	)
-	default boolean removeHovered()
+	default boolean removeBetween()
 	{
 		return true;
 	}
@@ -56,7 +55,8 @@ public interface RoofRemovalConfig extends Config
 	@ConfigItem(
 		keyName = "removeDestination",
 		name = "Destination tile",
-		description = "Remove roofs above the destination tile"
+		description = "Remove roofs above the destination tile",
+		position = 1
 	)
 	default boolean removeDestination()
 	{
@@ -64,12 +64,36 @@ public interface RoofRemovalConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "removeBetween",
-		name = "Between camera & player",
-		description = "Remove roofs between the camera and the player at low camera angles"
+		keyName = "removeHovered",
+		name = "Hovered tile",
+		description = "Remove roofs above the hovered tile",
+		position = 2
 	)
-	default boolean removeBetween()
+	default boolean removeHovered()
 	{
 		return true;
+	}
+
+	@ConfigItem(
+		keyName = "removePosition",
+		name = "Player's position",
+		description = "Remove roofs above the player's position",
+		position = 3
+	)
+	default boolean removePosition()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		keyName = "removePoh",
+		name = "Player-owned houses",
+		description = "Remove roofs in player-owned houses",
+		position = 5,
+		section = locationsSection
+	)
+	default boolean removePoh()
+	{
+		return false;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/roofremoval/RoofRemovalPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/roofremoval/RoofRemovalPlugin.java
@@ -128,6 +128,10 @@ public class RoofRemovalPlugin extends Plugin
 		if (e.getGameState() == GameState.LOGGED_IN)
 		{
 			performRoofRemoval();
+
+			// The game state changes when the player enters or exits a POH, so use this time to check if POH roofs
+			// should be removed.
+			client.getScene().setRoofRemovalMode(buildRoofRemovalFlags());
 		}
 	}
 
@@ -144,6 +148,11 @@ public class RoofRemovalPlugin extends Plugin
 
 	private int buildRoofRemovalFlags()
 	{
+		if (config.removePoh() && inPoh())
+		{
+			return 0;
+		}
+
 		int roofRemovalMode = 0;
 		if (config.removePosition())
 		{
@@ -180,7 +189,9 @@ public class RoofRemovalPlugin extends Plugin
 		{
 			final InputStreamReader data = new InputStreamReader(in, StandardCharsets.UTF_8);
 			//CHECKSTYLE:OFF
-			final Type type = new TypeToken<Map<Integer, List<FlaggedArea>>>() {}.getType();
+			final Type type = new TypeToken<Map<Integer, List<FlaggedArea>>>()
+			{
+			}.getType();
 			//CHECKSTYLE:ON
 			Map<Integer, List<FlaggedArea>> parsed = gson.fromJson(data, type);
 			overrides.clear();
@@ -267,5 +278,23 @@ public class RoofRemovalPlugin extends Plugin
 			}
 		}
 		log.debug("Roof override duration: {}", sw.stop());
+	}
+
+	private boolean inPoh()
+	{
+		if (client.getLocalPlayer() == null)
+		{
+			return false;
+		}
+
+		int POH_REGION_X1 = 1792;
+		int POH_REGION_X2 = 2047;
+		int POH_REGION_Y1 = 5696;
+		int POH_REGION_Y2 = 5823;
+
+		int x = WorldPoint.fromLocalInstance(client, client.getLocalPlayer().getLocalLocation()).getX();
+		int y = WorldPoint.fromLocalInstance(client, client.getLocalPlayer().getLocalLocation()).getY();
+
+		return POH_REGION_X1 <= x && x <= POH_REGION_X2 && POH_REGION_Y1 <= y && y <= POH_REGION_Y2;
 	}
 }


### PR DESCRIPTION
First contribution, so let me know if I should do anything differently. 

Changes to config:

- Add section for locations in which to always remove roofs. Currently POH is the only option, but this allows for other locations to be added in the future, like the Grand Exchange.
- Add toggle to always remove POH roofs
- Explictly set the order of existing config options. The order of previously existing options is not changed.

Changes to plugin:

- Add ability to always remove roofs when in POHs. Also fixes the issue where roofs are shown while in POH dungeons. 

Closes https://github.com/runelite/runelite/issues/13891
