### PR TITLE
MenuEntrySwapper: Add Soul Wars Bandage and Potion Table

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/BandageTableMode.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/BandageTableMode.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2018, Ethan <http://github.com/shmeeps>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.menuentryswapper;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum BandageTableMode
+{
+	TAKE_FROM("Take-from"),
+	TAKE_1("Take-1"),
+	TAKE_5("Take-5"),
+	TAKE_10("Take-10");
+
+	private final String name;
+
+	@Override
+	public String toString()
+	{
+		return name;
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -162,12 +162,12 @@ public interface MenuEntrySwapperConfig extends Config
 	@ConfigItem(
 		keyName = "swapBandageTableSoulWars",
 		name = "Bandage Table",
-		description = "Configurable Swap for Bandage Table in Soul Wars.",
+		description = "Configurable Swap for the Bandage Table in Soul Wars.",
 		section = objectSection
 	)
-	default BandageTableMode swapBandageTableSoulWars()
+	default SoulWarsTablesMode swapBandageTableSoulWars()
 	{
-		return BandageTableMode.TAKE_10;
+		return SoulWarsTablesMode.TAKE_10;
 	}
 
 	@ConfigItem(
@@ -234,6 +234,17 @@ public interface MenuEntrySwapperConfig extends Config
 	default boolean swapPrayerBook()
 	{
 		return false;
+	}
+
+	@ConfigItem(
+			keyName = "swapPotionTableSoulWars",
+			name = "Potion Table",
+			description = "Configurable Swap for the Potion of Power Table in Soul Wars.",
+			section = objectSection
+	)
+	default SoulWarsTablesMode swapPotionTableSoulWars()
+	{
+		return SoulWarsTablesMode.TAKE_10;
 	}
 
 	@ConfigItem(

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -160,6 +160,17 @@ public interface MenuEntrySwapperConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "swapBandageTableSoulWars",
+		name = "Bandage Table",
+		description = "Configurable Swap for Bandage Table in Soul Wars.",
+		section = objectSection
+	)
+	default BandageTableMode swapBandageTableSoulWars()
+	{
+		return BandageTableMode.TAKE_10;
+	}
+
+	@ConfigItem(
 		keyName = "swapBanker",
 		name = "Bank",
 		description = "Swap Talk-to with Bank on Bank NPC<br>Example: Banker",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -244,7 +244,7 @@ public interface MenuEntrySwapperConfig extends Config
 	)
 	default SoulWarsTablesMode swapPotionTableSoulWars()
 	{
-		return SoulWarsTablesMode.TAKE_10;
+		return SoulWarsTablesMode.TAKE_1;
 	}
 
 	@ConfigItem(

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -268,9 +268,13 @@ public class MenuEntrySwapperPlugin extends Plugin
 		swap("enter", "portal", "build mode", () -> config.swapHomePortal() == HouseMode.BUILD_MODE);
 		swap("enter", "portal", "friend's house", () -> config.swapHomePortal() == HouseMode.FRIENDS_HOUSE);
 
-		swap("take-from", "bandage table", "take-1", () -> config.swapBandageTableSoulWars() == BandageTableMode.TAKE_1 );
-		swap("take-from", "bandage table", "take-5", () -> config.swapBandageTableSoulWars() == BandageTableMode.TAKE_5 );
-		swap("take-from", "bandage table", "take-10", () -> config.swapBandageTableSoulWars() == BandageTableMode.TAKE_10 );
+		swap("take-from", "bandage table", "take-1", () -> config.swapBandageTableSoulWars() == SoulWarsTablesMode.TAKE_1 );
+		swap("take-from", "bandage table", "take-5", () -> config.swapBandageTableSoulWars() == SoulWarsTablesMode.TAKE_5 );
+		swap("take-from", "bandage table", "take-10", () -> config.swapBandageTableSoulWars() == SoulWarsTablesMode.TAKE_10 );
+
+		swap("take-from", "potion of power table", "take-1", () -> config.swapPotionTableSoulWars() == SoulWarsTablesMode.TAKE_1 );
+		swap("take-from", "potion of power table", "take-5", () -> config.swapPotionTableSoulWars() == SoulWarsTablesMode.TAKE_5 );
+		swap("take-from", "potion of power table", "take-10", () -> config.swapPotionTableSoulWars() == SoulWarsTablesMode.TAKE_10 );
 
 		swap("view", "add-house", () -> config.swapHouseAdvertisement() == HouseAdvertisementMode.ADD_HOUSE);
 		swap("view", "visit-last", () -> config.swapHouseAdvertisement() == HouseAdvertisementMode.VISIT_LAST);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -268,6 +268,10 @@ public class MenuEntrySwapperPlugin extends Plugin
 		swap("enter", "portal", "build mode", () -> config.swapHomePortal() == HouseMode.BUILD_MODE);
 		swap("enter", "portal", "friend's house", () -> config.swapHomePortal() == HouseMode.FRIENDS_HOUSE);
 
+		swap("take-from", "bandage table", "take-1", () -> config.swapBandageTableSoulWars() == BandageTableMode.TAKE_1 );
+		swap("take-from", "bandage table", "take-5", () -> config.swapBandageTableSoulWars() == BandageTableMode.TAKE_5 );
+		swap("take-from", "bandage table", "take-10", () -> config.swapBandageTableSoulWars() == BandageTableMode.TAKE_10 );
+
 		swap("view", "add-house", () -> config.swapHouseAdvertisement() == HouseAdvertisementMode.ADD_HOUSE);
 		swap("view", "visit-last", () -> config.swapHouseAdvertisement() == HouseAdvertisementMode.VISIT_LAST);
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/SoulWarsTablesMode.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/SoulWarsTablesMode.java
@@ -29,7 +29,7 @@ import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
-public enum BandageTableMode
+public enum SoulWarsTablesMode
 {
 	TAKE_FROM("Take-from"),
 	TAKE_1("Take-1"),


### PR DESCRIPTION
Resolves [suggestion] #14525 - adds configurable bandage table and potion of power table options from Soul Wars to MenuEntrySwapper, defaulting to take-10 for bandage table and take-1 for potion table. 

Added: 

SoulWarsTablesMode.java - Enum including the four entry options [take-from, take-1, take-5, take-10] for configurable menu choices for both bandage and potion tables. 

Modified: 

MenuEntrySwapperConfig.java - Add two entries to the config under Object Swaps to allow user to select top choice, defaulted to take-10 for Bandage Table and take-1 Potion Table. 

MenuEntrySwapperPlugin.java - Add six lines to perform the actual swaps. 

This is my first PR to the main RuneLite client, please let me know if I need to change anything. Thanks! 
