### PR TITLE
RuneLiteConfig: Name in Title bar change

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/config/RuneLiteConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/RuneLiteConfig.java
@@ -180,9 +180,9 @@ public interface RuneLiteConfig extends Config
 		position = 19,
 		section = windowSettings
 	)
-	default boolean usernameInTitle()
+	default TitleConfig usernameInTitle()
 	{
-		return true;
+		return TitleConfig.ALWAYS;
 	}
 
 	@ConfigItem(

--- a/runelite-client/src/main/java/net/runelite/client/config/TitleConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/TitleConfig.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2021, Zom
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package net.runelite.client.config;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum TitleConfig
+{
+	OFF("Off"),
+	ALWAYS("Always"),
+	ONLY_WHEN_LOGGED_IN("While Logged In");
+
+	private final String name;
+
+	@Override
+	public String toString()
+	{
+		return name;
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
@@ -76,6 +76,7 @@ import net.runelite.client.callback.ClientThread;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.config.ExpandResizeType;
 import net.runelite.client.config.RuneLiteConfig;
+import net.runelite.client.config.TitleConfig;
 import net.runelite.client.config.WarningOnExit;
 import net.runelite.client.eventbus.EventBus;
 import net.runelite.client.eventbus.Subscribe;
@@ -268,8 +269,23 @@ public class ClientUI
 	@Subscribe
 	public void onGameStateChanged(final GameStateChanged event)
 	{
-		if (event.getGameState() != GameState.LOGGED_IN || !(client instanceof Client) || !config.usernameInTitle())
+		if (event.getGameState() == GameState.LOGIN_SCREEN && config.usernameInTitle() == TitleConfig.ONLY_WHEN_LOGGED_IN && client instanceof Client)
 		{
+			final ClientThread clientThread = clientThreadProvider.get();
+
+			clientThread.invokeLater(() ->
+			{
+				frame.setTitle(title);
+				return true;
+			});
+		}
+
+		if (event.getGameState() != GameState.LOGGED_IN || !(client instanceof Client))
+		{
+			return;
+		}
+
+		if (config.usernameInTitle() != TitleConfig.ALWAYS && config.usernameInTitle() != TitleConfig.ONLY_WHEN_LOGGED_IN) {
 			return;
 		}
 
@@ -1049,7 +1065,7 @@ public class ClientUI
 			frame.setOpacity(((float) config.windowOpacity()) / 100.0f);
 		}
 
-		if (config.usernameInTitle() && (client instanceof Client))
+		if ((config.usernameInTitle() ==  TitleConfig.ONLY_WHEN_LOGGED_IN || config.usernameInTitle() ==  TitleConfig.ALWAYS) && (client instanceof Client))
 		{
 			final Player player = ((Client)client).getLocalPlayer();
 


### PR DESCRIPTION
Adds config option to set show username when logged in only, for ever (once logged in, old behavior maintained) or off (same behavior as before)