### PR TITLE
Roof removal poh fixes

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/roofremoval/RoofRemovalPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/roofremoval/RoofRemovalPlugin.java
@@ -248,9 +248,14 @@ public class RoofRemovalPlugin extends Plugin
 		outer:
 		for (int regionID : client.getMapRegions())
 		{
+			if (configOverrideRegions.contains(regionID))
+			{
+				regionsHaveOverrides = true;
+				break;
+			}
 			for (int z = 0; z < Constants.MAX_Z; z++)
 			{
-				if (overrides.containsKey(regionID << 2 | z) || configOverrideRegions.contains(regionID))
+				if (overrides.containsKey(regionID << 2 | z))
 				{
 					regionsHaveOverrides = true;
 					break outer;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/roofremoval/RoofRemovalPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/roofremoval/RoofRemovalPlugin.java
@@ -99,6 +99,7 @@ public class RoofRemovalPlugin extends Plugin
 	@Override
 	public void startUp() throws IOException
 	{
+		buildConfigOverrides();
 		loadRoofOverrides();
 		clientThread.invoke(() ->
 		{


### PR DESCRIPTION
Related to: https://github.com/runelite/runelite/pull/14529

The first [commit](https://github.com/runelite/runelite/pull/14536/commits/3af75e6752deb963dc9da690d5afe4f442b041e7) fixes an issue where POH roof removal overrides weren't initialized on plugin startUp when configured to do so.

The second [commit](https://github.com/runelite/runelite/pull/14536/commits/99b0a18a4c4c159b5a480c5fb2a069babf33469e) moves the `configOverrideRegions.contains(regionID)` conditional out of the inner for loop, as it's parameter did not change across loop iterations.