### PR TITLE
clues: Identify Charlie the Tramp and Falo the Bard clues from chat messages

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/ClueScrollPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/ClueScrollPlugin.java
@@ -976,10 +976,15 @@ public class ClueScrollPlugin extends Plugin
 		final String text = Text.sanitizeMultilineText(rawText).toLowerCase();
 
 		final SkillChallengeClue skillChallengeClue = SkillChallengeClue.forChatboxText(sender, text);
-
 		if (skillChallengeClue != null)
 		{
 			return skillChallengeClue;
+		}
+
+		final FaloTheBardClue faloTheBardClue = FaloTheBardClue.forChatboxText(sender, text);
+		if (faloTheBardClue != null)
+		{
+			return faloTheBardClue;
 		}
 
 		return null;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/ClueScrollPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/ClueScrollPlugin.java
@@ -51,7 +51,6 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
-import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
 import net.runelite.api.EnumComposition;
 import net.runelite.api.EnumID;
@@ -291,44 +290,58 @@ public class ClueScrollPlugin extends Plugin
 	@Subscribe
 	public void onChatMessage(ChatMessage event)
 	{
-		if (event.getType() != ChatMessageType.GAMEMESSAGE && event.getType() != ChatMessageType.SPAM)
+		switch (event.getType())
 		{
-			return;
-		}
-
-		String message = event.getMessage();
-
-		if (clue instanceof HotColdClue)
-		{
-			if (((HotColdClue) clue).update(message, this))
+			case GAMEMESSAGE:
+			case SPAM:
 			{
-				worldMapPointsSet = false;
-			}
-		}
+				String message = event.getMessage();
 
-		if (clue instanceof SkillChallengeClue)
-		{
-			String text = Text.removeTags(message);
-			if (text.equals("Skill challenge completed.") ||
-				text.equals("You have completed your master level challenge!") ||
-				text.startsWith("You have completed Charlie's task,") ||
-				text.equals("You have completed this challenge scroll."))
-			{
-				((SkillChallengeClue) clue).setChallengeCompleted(true);
-			}
-		}
+				if (clue instanceof HotColdClue)
+				{
+					if (((HotColdClue) clue).update(message, this))
+					{
+						worldMapPointsSet = false;
+					}
+				}
 
-		if (message.endsWith(" the STASH unit."))
-		{
-			if (clue instanceof EmoteClue && clickedSTASHClue != null && message.equals("You withdraw your items from the STASH unit."))
-			{
-				activeSTASHClue = clickedSTASHClue;
+				if (clue instanceof SkillChallengeClue)
+				{
+					String text = Text.removeTags(message);
+					if (text.equals("Skill challenge completed.") ||
+						text.equals("You have completed your master level challenge!") ||
+						text.startsWith("You have completed Charlie's task,") ||
+						text.equals("You have completed this challenge scroll."))
+					{
+						((SkillChallengeClue) clue).setChallengeCompleted(true);
+					}
+				}
+
+				if (message.endsWith(" the STASH unit."))
+				{
+					if (clue instanceof EmoteClue && clickedSTASHClue != null && message.equals("You withdraw your items from the STASH unit."))
+					{
+						activeSTASHClue = clickedSTASHClue;
+					}
+					else if (message.equals("You deposit your items into the STASH unit."))
+					{
+						activeSTASHClue = null;
+					}
+					clickedSTASHClue = null;
+				}
+				break;
 			}
-			else if (message.equals("You deposit your items into the STASH unit."))
+			case DIALOG:
 			{
-				activeSTASHClue = null;
+				String[] senderAndMessage = event.getMessage().split("\\|", 2);
+				final ClueScroll npcChatClue = findNpcChatClueScroll(senderAndMessage[0], senderAndMessage[1]);
+
+				if (npcChatClue != null)
+				{
+					updateClue(npcChatClue);
+				}
+				break;
 			}
-			clickedSTASHClue = null;
 		}
 	}
 
@@ -953,6 +966,20 @@ public class ClueScrollPlugin extends Plugin
 		if (fairyRingClue != null)
 		{
 			return fairyRingClue;
+		}
+
+		return null;
+	}
+
+	private static ClueScroll findNpcChatClueScroll(String sender, String rawText)
+	{
+		final String text = Text.sanitizeMultilineText(rawText).toLowerCase();
+
+		final SkillChallengeClue skillChallengeClue = SkillChallengeClue.forChatboxText(sender, text);
+
+		if (skillChallengeClue != null)
+		{
+			return skillChallengeClue;
 		}
 
 		return null;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/FaloTheBardClue.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/FaloTheBardClue.java
@@ -28,6 +28,8 @@ import com.google.common.collect.ImmutableList;
 import java.awt.Color;
 import java.awt.Graphics2D;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import javax.annotation.Nonnull;
 import lombok.Getter;
 import net.runelite.api.Item;
@@ -50,6 +52,7 @@ import net.runelite.client.ui.overlay.components.TitleComponent;
 @Getter
 public class FaloTheBardClue extends ClueScroll implements NpcClueScroll
 {
+	private static final Pattern CLUE_TEXT_PREFIX = Pattern.compile("^(?:Okay, )?here goes\\.\\.\\. ", Pattern.CASE_INSENSITIVE);
 	static final List<FaloTheBardClue> CLUES = ImmutableList.of(
 		new FaloTheBardClue("A blood red weapon, a strong curved sword, found on the island of primate lords.", any("Dragon scimitar", item(ItemID.DRAGON_SCIMITAR), item(ItemID.DRAGON_SCIMITAR_ORNAMENT))),
 		new FaloTheBardClue("A book that preaches of some great figure, lending strength, might and vigour.", any("Any completed god book", item(ItemID.SARADOMINBOOK_COMPLETE), item(ItemID.GUTHIXBOOK_COMPLETE), item(ItemID.ZAMORAKBOOK_COMPLETE), item(ItemID.ARMADYLBOOK_COMPLETE), item(ItemID.BANDOSBOOK_COMPLETE), item(ItemID.ZAROSBOOK_COMPLETE), item(ItemID.LEAGUE_3_BOOK_SARADOMIN), item(ItemID.LEAGUE_3_BOOK_GUTHIX), item(ItemID.LEAGUE_3_BOOK_ZAMORAK), item(ItemID.LEAGUE_3_BOOK_ARMADYL), item(ItemID.LEAGUE_3_BOOK_BANDOS), item(ItemID.LEAGUE_3_BOOK_ZAROS))),
@@ -179,5 +182,21 @@ public class FaloTheBardClue extends ClueScroll implements NpcClueScroll
 		}
 
 		return null;
+	}
+
+	public static FaloTheBardClue forChatboxText(String sender, String dialogText)
+	{
+		if (!FALO_THE_BARD.equals(sender))
+		{
+			return null;
+		}
+
+		final Matcher matcher = CLUE_TEXT_PREFIX.matcher(dialogText);
+		if (!matcher.find())
+		{
+			return null;
+		}
+
+		return forText(dialogText.substring(matcher.end()));
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/SkillChallengeClue.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/SkillChallengeClue.java
@@ -31,6 +31,7 @@ import java.awt.Graphics2D;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
+import javax.annotation.Nullable;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
@@ -174,14 +175,45 @@ public class SkillChallengeClue extends ClueScroll implements NpcClueScroll, Nam
 
 	static final List<SkillChallengeClue> CLUES = ImmutableList.of(
 		// Charlie Tasks
-		new SkillChallengeClue(ChallengeType.CHARLIE, "i need to give charlie a cooked pike.", item(ItemID.PIKE)),
-		new SkillChallengeClue(ChallengeType.CHARLIE, "i need to give charlie a cooked trout.", item(ItemID.TROUT)),
-		new SkillChallengeClue(ChallengeType.CHARLIE, "i need to give charlie a leather body.", item(ItemID.LEATHER_ARMOUR)),
-		new SkillChallengeClue(ChallengeType.CHARLIE, "i need to give charlie some leather chaps.", item(ItemID.LEATHER_CHAPS)),
-		new SkillChallengeClue(ChallengeType.CHARLIE, "i need to give charlie a raw herring.", item(ItemID.RAW_HERRING)),
-		new SkillChallengeClue(ChallengeType.CHARLIE, "i need to give charlie a raw trout.", item(ItemID.RAW_TROUT)),
-		new SkillChallengeClue(ChallengeType.CHARLIE, "i need to give charlie a piece of iron ore.", item(ItemID.IRON_ORE)),
-		new SkillChallengeClue(ChallengeType.CHARLIE, "i need to give charlie one iron dagger.", item(ItemID.IRON_DAGGER)),
+		new SkillChallengeClue(ChallengeType.CHARLIE,
+			"i need to give charlie a cooked pike.",
+			"I really need a cooked pike.",
+			item(ItemID.PIKE)),
+		new SkillChallengeClue(
+			ChallengeType.CHARLIE,
+			"i need to give charlie a cooked trout.",
+			"I really need a cooked trout.",
+			item(ItemID.TROUT)),
+		new SkillChallengeClue(
+			ChallengeType.CHARLIE,
+			"i need to give charlie a leather body.",
+			"I really need a leather body.",
+			item(ItemID.LEATHER_ARMOUR)),
+		new SkillChallengeClue(
+			ChallengeType.CHARLIE,
+			"i need to give charlie some leather chaps.",
+			"I really need some leather chaps.",
+			item(ItemID.LEATHER_CHAPS)),
+		new SkillChallengeClue(
+			ChallengeType.CHARLIE,
+			"i need to give charlie a raw herring.",
+			"I really need a raw herring.",
+			item(ItemID.RAW_HERRING)),
+		new SkillChallengeClue(
+			ChallengeType.CHARLIE,
+			"i need to give charlie a raw trout.",
+			"I really need a raw trout.",
+			item(ItemID.RAW_TROUT)),
+		new SkillChallengeClue(
+			ChallengeType.CHARLIE,
+			"i need to give charlie a piece of iron ore.",
+			"I really need a piece of iron ore.",
+			item(ItemID.IRON_ORE)),
+		new SkillChallengeClue(
+			ChallengeType.CHARLIE,
+			"i need to give charlie one iron dagger.",
+			"I really need an iron dagger.",
+			item(ItemID.IRON_DAGGER)),
 		// Elite Sherlock Tasks
 		new SkillChallengeClue("Equip a Dragon Scimitar.", true, any("Any Dragon Scimitar", item(ItemID.DRAGON_SCIMITAR), item(ItemID.DRAGON_SCIMITAR_ORNAMENT))),
 		new SkillChallengeClue("Enchant some Dragonstone Jewellery.", "enchant a piece of dragonstone jewellery.",
@@ -270,6 +302,8 @@ public class SkillChallengeClue extends ClueScroll implements NpcClueScroll, Nam
 
 	private final ChallengeType type;
 	private final String challenge;
+	@Nullable
+	private final String chatboxChallenge;
 	private final String rawChallenge;
 	private final String returnText;
 	private final ItemRequirement[] itemRequirements;
@@ -281,13 +315,14 @@ public class SkillChallengeClue extends ClueScroll implements NpcClueScroll, Nam
 	private boolean challengeCompleted;
 
 	// Charlie Tasks
-	private SkillChallengeClue(ChallengeType challengeType, String clueText, SingleItemRequirement returnItem)
+	private SkillChallengeClue(ChallengeType challengeType, String clueText, String chatboxChallenge, SingleItemRequirement returnItem)
 	{
 		Preconditions.checkArgument(challengeType == ChallengeType.CHARLIE);
 		this.type = challengeType;
 		this.challenge = "";
 		this.rawChallenge = clueText;
 		this.returnText = clueText;
+		this.chatboxChallenge = chatboxChallenge;
 		this.itemRequirements = new ItemRequirement[0];
 		this.returnItem = returnItem;
 		this.challengeCompleted = true;
@@ -331,6 +366,7 @@ public class SkillChallengeClue extends ClueScroll implements NpcClueScroll, Nam
 	{
 		this.type = ChallengeType.SHERLOCK;
 		this.challenge = challenge;
+		this.chatboxChallenge = null;
 		this.rawChallenge = rawChallenge;
 		this.itemRequirements = itemRequirements;
 		this.challengeCompleted = false;
@@ -476,6 +512,28 @@ public class SkillChallengeClue extends ClueScroll implements NpcClueScroll, Nam
 			else if (text.equals(clue.rawChallenge))
 			{
 				clue.setChallengeCompleted(false);
+				return clue;
+			}
+		}
+		return null;
+	}
+
+	public static SkillChallengeClue forChatboxText(String sender, String dialogText)
+	{
+		if (!ChallengeType.CHARLIE.getName().equals(sender))
+		{
+			return null;
+		}
+
+		for (SkillChallengeClue clue : CLUES)
+		{
+			if (clue.getChatboxChallenge() == null)
+			{
+				continue;
+			}
+
+			if (clue.getChatboxChallenge().equalsIgnoreCase(dialogText))
+			{
 				return clue;
 			}
 		}


### PR DESCRIPTION
When receiving these clue steps, the held clue changes text to indicate what the player should do/show them. This PR adds the ability for the clue plugin to proactively update the active clue based on that chatbox text instead of requiring the user to read the clue scroll itself.

Closes #10613