### PR TITLE
Handle CMD+Q inputs correctly on MacOS

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ui/SplashScreen.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/SplashScreen.java
@@ -46,6 +46,7 @@ import javax.swing.plaf.basic.BasicProgressBarUI;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.client.ui.skin.SubstanceRuneLiteLookAndFeel;
 import net.runelite.client.util.ImageUtil;
+import net.runelite.client.util.OSType;
 import org.pushingpixels.substance.internal.SubstanceSynapse;
 
 @Slf4j
@@ -162,6 +163,10 @@ public class SplashScreen extends JFrame implements ActionListener
 	{
 		try
 		{
+			if (OSType.getOSType() == OSType.MacOS)
+			{
+				System.setProperty("apple.eawt.quitStrategy", "CLOSE_ALL_WINDOWS");
+			}
 			SwingUtilities.invokeAndWait(() ->
 			{
 				if (INSTANCE != null)

--- a/runelite-client/src/main/java/net/runelite/client/ui/SplashScreen.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/SplashScreen.java
@@ -203,6 +203,11 @@ public class SplashScreen extends JFrame implements ActionListener
 				return;
 			}
 
+			// The instance sometimes sticks around after disposal.
+			// When it does, the EXIT_ON_CLOSE operation interferes with CMD+Q on MacOS.
+			// To get around this, set DO_NOTHING_ON_CLOSE before disposing.
+			INSTANCE.setDefaultCloseOperation(JFrame.DO_NOTHING_ON_CLOSE);
+
 			INSTANCE.timer.stop();
 			INSTANCE.dispose();
 			INSTANCE = null;


### PR DESCRIPTION
On MacOS, CMD+Q should result in a soft exit, which can allow for user confirmation, rather than a hard exit. Setting the "apple.eawt.quitStrategy" property to "CLOSE_ALL_WINDOWS" accomplishes this. However, the property has to be set before the _AppEventHandler is initialized and reads that property, which happens when SwingUtilities.invokeLater() is first called in SplashScreen.java.

Setting the "apple.eawt.quitStrategy" property to "CLOSE_ALL_WINDOWS" results in a windowClosing event being sent to each JFrame. If any of them handle that by exiting, the program will exit. Otherwise, the program will continue as if CMD+Q was not entered. The current SplashScreen windowClosing handling is EXIT_ON_CLOSE, so change it to DO_NOTHING_ON_CLOSE.

