### PR TITLE
Fix flicker when clicking tray icon click on macOS when client is already focused

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/util/SwingUtil.java
+++ b/runelite-client/src/main/java/net/runelite/client/util/SwingUtil.java
@@ -184,7 +184,7 @@ public class SwingUtil
 			@Override
 			public void mouseClicked(MouseEvent e)
 			{
-				if (OSType.getOSType() == OSType.MacOS)
+				if (OSType.getOSType() == OSType.MacOS && !frame.isFocused())
 				{
 					// On macOS, frame.setVisible(true) only restores focus when the visibility was previously false.
 					// The frame's visibility is not set to false when the window loses focus, so we set it manually.


### PR DESCRIPTION
After https://github.com/runelite/runelite/pull/14543, clicking the tray icon on macOS when the client is focused results in a flicker. The flicker is due to the visibility change required to correctly restore focus, but there's no reason to run that when the client is already focused.

Sorry for not catching this before submitting the last PR.