### PR TITLE
Add @SafeVarargs to ExternalPluginManager.loadBuiltin

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/externalplugins/ExternalPluginManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/externalplugins/ExternalPluginManager.java
@@ -26,7 +26,6 @@ package net.runelite.client.externalplugins;
 
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
 import com.google.common.hash.Hashing;
 import com.google.common.hash.HashingInputStream;
@@ -36,6 +35,7 @@ import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
@@ -117,7 +117,7 @@ public class ExternalPluginManager
 		if (builtinExternals != null)
 		{
 			// builtin external's don't actually have a manifest or a separate classloader...
-			pluginManager.loadPlugins(Lists.newArrayList(builtinExternals), null);
+			pluginManager.loadPlugins(Arrays.stream(builtinExternals), null);
 		}
 	}
 
@@ -310,7 +310,7 @@ public class ExternalPluginManager
 						clazzes.add(cl.loadClass(className));
 					}
 
-					List<Plugin> newPlugins2 = newPlugins = pluginManager.loadPlugins(clazzes, null);
+					List<Plugin> newPlugins2 = newPlugins = pluginManager.loadPlugins(clazzes.stream(), null);
 					if (!startup)
 					{
 						pluginManager.loadDefaultPluginConfiguration(newPlugins);
@@ -422,6 +422,7 @@ public class ExternalPluginManager
 		return null;
 	}
 
+	@SafeVarargs
 	public static void loadBuiltin(Class<? extends Plugin>... plugins)
 	{
 		boolean assertsEnabled = false;

--- a/runelite-client/src/test/java/net/runelite/client/plugins/PluginManagerTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/PluginManagerTest.java
@@ -40,8 +40,10 @@ import java.io.PrintWriter;
 import java.lang.reflect.Method;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Stream;
 import net.runelite.api.Client;
 import net.runelite.client.RuneLite;
 import net.runelite.client.RuneLiteModule;
@@ -145,6 +147,38 @@ public class PluginManagerTest
 			.filter(pd -> !pd.developerPlugin())
 			.count();
 		assertEquals(expected, plugins.size());
+	}
+
+	@PluginDescriptor(
+		name = "TestExtendsPlugin",
+		loadWhenOutdated = true
+	)
+	static class TestPluginChild extends Plugin
+	{
+		public TestPluginChild()
+		{
+		}
+	}
+
+	@PluginDescriptor(
+		name = "TestExtendsExtendsPlugin",
+		loadWhenOutdated = true
+	)
+	static class TestPluginGrandChild extends TestPluginChild
+	{
+		public TestPluginGrandChild()
+		{
+		}
+	}
+
+	@Test
+	public void testLoadSubSubClassOfPlugin() throws Exception
+	{
+		PluginManager pluginManager = new PluginManager(false, false, null, null, null, null);
+		pluginManager.setOutdated(true);
+
+		List<Plugin> loaded = pluginManager.loadPlugins(Stream.of(TestPluginGrandChild.class), null);
+		assertEquals(1, loaded.size());
 	}
 
 	@Test


### PR DESCRIPTION
Fixes warning "Unchecked generics array creation for varargs parameter" on
loadBuiltin. This warning is trying to prevent a RuntimeException which
happens iff the varargs are modified in a particular way. Varargs are not
modified, which is guaranteed by PluginManager.loadPlugins using a Stream.

Change loadPlugins to take a Stream of Plugins. Saves a few allocations.

Allow loading of plugins that are not direct subclasses of Plugin, but
subclasses of subclasses of Plugin, etc. (fix in loadPlugins) and add a
test case that this works

Fix an iterator invalidation bug in PluginManager.topologicalSort.
Graph.sucessors is an iterator; removing nodes while iterating throws
a concurrentModificationException. Fix: add an allocation.

Fill out existing javadocs for topologicalSort