### PR TITLE
runenergy: Fix flickering replaced run energy orb text

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/runenergy/RunEnergyConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/runenergy/RunEnergyConfig.java
@@ -28,7 +28,7 @@ import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
 
-@ConfigGroup("runenergy")
+@ConfigGroup(RunEnergyPlugin.CONFIG_GROUP)
 public interface RunEnergyConfig extends Config
 {
 	@ConfigItem(

--- a/runelite-client/src/main/java/net/runelite/client/plugins/runenergy/RunEnergyPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/runenergy/RunEnergyPlugin.java
@@ -40,6 +40,7 @@ import static net.runelite.api.ItemID.*;
 import net.runelite.api.Skill;
 import net.runelite.api.Varbits;
 import net.runelite.api.coords.WorldPoint;
+import net.runelite.api.events.BeforeRender;
 import net.runelite.client.events.ConfigChanged;
 import net.runelite.api.events.GameTick;
 import net.runelite.api.widgets.Widget;
@@ -169,7 +170,13 @@ public class RunEnergyPlugin extends Plugin
 			prevLocalPlayerLocation.distanceTo(client.getLocalPlayer().getWorldLocation()) > 1;
 
 		prevLocalPlayerLocation = client.getLocalPlayer().getWorldLocation();
+	}
 
+	@Subscribe
+	public void onBeforeRender(BeforeRender beforeRender)
+	{
+		// This text is also set by the client script for updating the orbs,
+		// set the text before every frame is drawn to prevent flicker.
 		if (energyConfig.replaceOrbText())
 		{
 			setRunOrbText(getEstimatedRunTimeRemaining(true));


### PR DESCRIPTION
If a frame is rendered in between the orb text being set by the client script and the plugin's `onGameTick` replacing the text, the text will flicker.
Fixed by setting the run energy orb text before a frame is rendered, inspired by c56c26f.

Reported by emerald000
Continued from #14559 with fixed review comment:
- Only compute the remaining time once per tick since it cannot change more frequently anyway