### PR TITLE
Menu Entry Swapper: add climb-up and climb-down swaps for stairs/ladders/etc.

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -787,6 +787,35 @@ public interface MenuEntrySwapperConfig extends Config
 		return false;
 	}
 
+	enum StairsMode
+	{
+		CLIMB,
+		CLIMB_UP,
+		CLIMB_DOWN,
+	}
+
+	@ConfigItem(
+		keyName = "swapStairsLeftClick",
+		name = "Stairs left-click",
+		description = "Swap this option when left-clicking stairs. Also works on ladders.",
+		section = objectSection
+	)
+	default StairsMode swapStairsLeftClick()
+	{
+		return StairsMode.CLIMB;
+	}
+
+	@ConfigItem(
+		keyName = "swapStairsShiftClick",
+		name = "Stairs shift-click",
+		description = "Swap this option when shift-clicking stairs. Also works on ladders.",
+		section = objectSection
+	)
+	default StairsMode swapStairsShiftClick()
+	{
+		return StairsMode.CLIMB;
+	}
+
 	@ConfigItem(
 		keyName = "swapTemporossLeave",
 		name = "Tempoross Leave",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -415,6 +415,9 @@ public class MenuEntrySwapperPlugin extends Plugin
 		swap("eat", "guzzle", config::swapRockCake);
 
 		swap("travel", "dive", config::swapRowboatDive);
+
+		swap("climb", "climb-up", () -> (shiftModifier() ? config.swapStairsShiftClick() : config.swapStairsLeftClick()) == MenuEntrySwapperConfig.StairsMode.CLIMB_UP);
+		swap("climb", "climb-down", () -> (shiftModifier() ? config.swapStairsShiftClick() : config.swapStairsLeftClick()) == MenuEntrySwapperConfig.StairsMode.CLIMB_DOWN);
 	}
 
 	private void swap(String option, String swappedOption, Supplier<Boolean> enabled)


### PR DESCRIPTION
Tested on stairs and ladders. Does not interfere with barbarian assault quick-start swap or volcanic mine pay swap.

Would close #14568 
Closes #3562
Closes #7450
Closes #5247