### PR TITLE
ground items: Highlight stackable ground items already in inventory

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
@@ -425,4 +425,27 @@ public interface GroundItemsConfig extends Config
 	{
 		return HighlightTier.HIGH;
 	}
+
+	@ConfigItem(
+			keyName = "highlightStackable",
+			name = "Highlight stackable in inventory",
+			description = "Highlight stackable ground items already in inventory",
+			position = 32
+	)
+	default boolean highlightStackable()
+	{
+		return false;
+	}
+
+	@Alpha
+	@ConfigItem(
+			keyName = "highlightStackableColor",
+			name = "Highlight stackable",
+			description = "Configures the color for highlighted stackable items",
+			position = 33
+	)
+	default Color highlightStackableColor()
+	{
+		return Color.decode("#FFFDE500");
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
@@ -199,8 +199,8 @@ public class GroundItemsOverlay extends Overlay
 				continue;
 			}
 
-			final Color highlighted = plugin.getHighlighted(new NamedQuantity(item), item.getGePrice(), item.getHaPrice());
-			final Color hidden = plugin.getHidden(new NamedQuantity(item), item.getGePrice(), item.getHaPrice(), item.isTradeable());
+			final Color highlighted = plugin.getHighlighted(item);
+			final Color hidden = plugin.getHidden(item);
 
 			if (highlighted == null && !plugin.isHotKeyPressed())
 			{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
@@ -500,10 +500,8 @@ public class GroundItemsPlugin extends Plugin
 			GroundItem groundItem = collectedGroundItems.get(worldPoint, itemId);
 			int quantity = groundItem.getQuantity();
 
-			final int gePrice = groundItem.getGePrice();
-			final int haPrice = groundItem.getHaPrice();
-			final Color hidden = getHidden(new NamedQuantity(groundItem.getName(), quantity), gePrice, haPrice, groundItem.isTradeable());
-			final Color highlighted = getHighlighted(new NamedQuantity(groundItem.getName(), quantity), gePrice, haPrice);
+			final Color hidden = getHidden(groundItem);
+			final Color highlighted = getHighlighted(groundItem);
 			final Color color = getItemColor(highlighted, hidden);
 			final boolean canBeRecolored = highlighted != null || (hidden != null && config.recolorMenuHiddenItems());
 
@@ -569,8 +567,12 @@ public class GroundItemsPlugin extends Plugin
 		config.setHighlightedItem(Text.toCSV(highlightedItemSet));
 	}
 
-	Color getHighlighted(NamedQuantity item, int gePrice, int haPrice)
+	Color getHighlighted(GroundItem groundItem)
 	{
+		final NamedQuantity item = new NamedQuantity(groundItem);
+		final int gePrice = groundItem.getGePrice();
+		final int haPrice = groundItem.getHaPrice();
+
 		if (TRUE.equals(highlightedItems.getUnchecked(item)))
 		{
 			return config.highlightedColor();
@@ -591,11 +593,22 @@ public class GroundItemsPlugin extends Plugin
 			}
 		}
 
+		final ItemContainer inventory = client.getItemContainer(InventoryID.INVENTORY);
+		if (config.highlightStackable() && groundItem.isStackable() && inventory.contains(groundItem.getItemId()))
+		{
+			return config.highlightStackableColor();
+		}
+
 		return null;
 	}
 
-	Color getHidden(NamedQuantity item, int gePrice, int haPrice, boolean isTradeable)
+	Color getHidden(GroundItem groundItem)
 	{
+		final NamedQuantity item = new NamedQuantity(groundItem);
+		final int gePrice = groundItem.getGePrice();
+		final int haPrice = groundItem.getHaPrice();
+		final boolean isTradeable = groundItem.isTradeable();
+
 		final boolean isExplicitHidden = TRUE.equals(hiddenItems.getUnchecked(item));
 		final boolean isExplicitHighlight = TRUE.equals(highlightedItems.getUnchecked(item));
 		final boolean canBeHidden = gePrice > 0 || isTradeable || !config.dontHideUntradeables();


### PR DESCRIPTION
### Highlight stackable ground items already in inventory
Less time is spent looking throught the loot and all these items are free to pick up while plenty of space is still kept for big ticket items or alchables. Goes well with afk combat sessions.

### Notes:
- I'm assuming that majority of ground item users don't have min-maxed hidden/highligted item lists.
- I tried rebasing previous pull #13858 but I must have made a mistake somewhere and it all blew up in my face, sorry for that.