### PR TITLE
Fixing NPE in slayer plugin when updating the counter.

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerPlugin.java
@@ -647,7 +647,7 @@ public class SlayerPlugin extends Plugin
 		// save changed value
 		setProfileConfig(SlayerConfig.AMOUNT_KEY, amount);
 
-		if (!config.showInfobox())
+		if (!config.showInfobox() || Task.getTask(taskName) == null)
 		{
 			return;
 		}

--- a/runelite-client/src/test/java/net/runelite/client/plugins/slayer/SlayerPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/slayer/SlayerPluginTest.java
@@ -639,6 +639,39 @@ public class SlayerPluginTest
 	}
 
 	@Test
+	public void testXpDropWithNoKnownTask()
+	{
+		final Player player = mock(Player.class);
+		when(player.getLocalLocation()).thenReturn(new LocalPoint(0, 0));
+		when(client.getLocalPlayer()).thenReturn(player);
+		lenient().when(slayerConfig.showInfobox()).thenReturn(true);
+
+		StatChanged statChanged = new StatChanged(
+				Skill.SLAYER,
+				100,
+				2,
+				2
+		);
+
+		slayerPlugin.onStatChanged(statChanged);
+
+		slayerPlugin.setTaskName("");
+		slayerPlugin.setAmount(98);
+
+		assert Task.getTask("") == null;
+
+		statChanged = new StatChanged(
+				Skill.SLAYER,
+				110,
+				2,
+				2
+		);
+		slayerPlugin.onStatChanged(statChanged);
+
+		assertEquals(97, slayerPlugin.getAmount());
+	}
+
+	@Test
 	public void testJadTaskKill()
 	{
 		final Player player = mock(Player.class);


### PR DESCRIPTION
Fixes #14542 

In an edge case where runelite has no record of a slayer task but a
monster is killed giving slayer XP, don't update the counter because we
don't know anything about the slayer task at hand.
