### PR TITLE
clientUI: show if the client is in safe-mode in the window title

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
@@ -164,7 +164,7 @@ public class ClientUI
 		this.clientThreadProvider = clientThreadProvider;
 		this.eventBus = eventBus;
 		this.safeMode = safeMode;
-		this.title = title;
+		this.title = title + (safeMode ? " (safe mode)" : "");
 	}
 
 	@Subscribe


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2979691/149824064-1f3824ed-8c60-4570-bc11-dc0b9843d531.png)
A simple change to let the user know if they're running the client in safe mode, similar to how other applications display it (e.g.  
[LibreOffice](https://user-images.githubusercontent.com/2979691/149822381-c8071303-f45e-450e-8a5f-23946cd821b6.png)). This will help with users in #support who swear they've ran the client in safe mode, but have screwed it up somehow. 
