### PR TITLE
Add option to hide npc aggro lines when out of combat. SupahSoftware

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/npcunaggroarea/NpcAggroAreaConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npcunaggroarea/NpcAggroAreaConfig.java
@@ -117,4 +117,15 @@ public interface NpcAggroAreaConfig extends Config
 	{
 		return false;
 	}
+
+	@ConfigItem(
+		keyName = "hideIfOutOfCombat",
+		name = "Hide when out of combat",
+		description = "Hides unaggressive area lines when out of combat.",
+		position = 8
+	)
+	default boolean hideIfOutOfCombat()
+	{
+		return false;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/npcunaggroarea/NpcAggroAreaOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npcunaggroarea/NpcAggroAreaOverlay.java
@@ -34,6 +34,7 @@ import java.time.Instant;
 import javax.inject.Inject;
 import net.runelite.api.Client;
 import net.runelite.api.Perspective;
+import net.runelite.api.Player;
 import net.runelite.api.Point;
 import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.geometry.Geometry;
@@ -66,6 +67,12 @@ class NpcAggroAreaOverlay extends Overlay
 	public Dimension render(Graphics2D graphics)
 	{
 		if (!plugin.isActive() || plugin.getSafeCenters()[1] == null)
+		{
+			return null;
+		}
+
+		final Player localPlayer = client.getLocalPlayer();
+		if (localPlayer.getHealthScale() == -1 && config.hideIfOutOfCombat())
 		{
 			return null;
 		}


### PR DESCRIPTION
This adds a toggle setting in the NPC Aggression Timer plugin to hide the aggro lines when not in combat.