### PR TITLE
Fishing Plugin: Add Age Timer

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingConfig.java
@@ -68,7 +68,18 @@ public interface FishingConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 3,
+			position = 3,
+			keyName = "showTimers",
+			name = "Display spot age timers",
+			description = "Configures whether timers for fishing spot ages are displayed"
+	)
+	default boolean showSpotTimers()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		position = 4,
 		keyName = "showNames",
 		name = "Display spot names",
 		description = "Configures whether names for fishing spots are displayed"
@@ -83,7 +94,7 @@ public interface FishingConfig extends Config
 		keyName = "overlayColor",
 		name = "Overlay Color",
 		description = "Color of overlays",
-		position = 4
+		position = 5
 	)
 	default Color getOverlayColor()
 	{
@@ -95,7 +106,7 @@ public interface FishingConfig extends Config
 		keyName = "minnowsOverlayColor",
 		name = "Minnows Overlay",
 		description = "Color of overlays for Minnows",
-		position = 5
+		position = 6
 	)
 	default Color getMinnowsOverlayColor()
 	{
@@ -107,7 +118,7 @@ public interface FishingConfig extends Config
 		keyName = "aerialOverlayColor",
 		name = "Aerial Overlay",
 		description = "Color of overlays when 1-tick aerial fishing",
-		position = 6
+		position = 7
 	)
 	default Color getAerialOverlayColor()
 	{
@@ -119,7 +130,7 @@ public interface FishingConfig extends Config
 		keyName = "harpoonfishOverlayColor",
 		name = "Harpoonfish Overlay",
 		description = "Color of overlays for bubbling Harpoonfish spots",
-		position = 6
+		position = 8
 	)
 	default Color getHarpoonfishOverlayColor()
 	{
@@ -127,7 +138,7 @@ public interface FishingConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 7,
+		position = 9,
 		keyName = "statTimeout",
 		name = "Reset stats",
 		description = "The time until fishing session data is reset in minutes."
@@ -139,7 +150,7 @@ public interface FishingConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 8,
+		position = 10,
 		keyName = "showFishingStats",
 		name = "Show Fishing session stats",
 		description = "Display the fishing session stats."
@@ -150,7 +161,7 @@ public interface FishingConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 9,
+		position = 11,
 		keyName = "showMinnowOverlay",
 		name = "Show Minnow Movement overlay",
 		description = "Display the minnow progress pie overlay."
@@ -161,7 +172,7 @@ public interface FishingConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 10,
+		position = 12,
 		keyName = "flyingFishNotification",
 		name = "Flying fish notification",
 		description = "Send a notification when a flying fish spawns on your fishing spot."
@@ -172,7 +183,7 @@ public interface FishingConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 11,
+		position = 13,
 		keyName = "trawlerTimer",
 		name = "Trawler timer in M:SS",
 		description = "Trawler timer will display a more accurate timer in M:SS format."
@@ -183,7 +194,7 @@ public interface FishingConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 12,
+		position = 14,
 		keyName = "trawlerContribution",
 		name = "Trawler contribution",
 		description = "Display the exact number of trawler contribution points gained."

--- a/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingPlugin.java
@@ -96,10 +96,19 @@ public class FishingPlugin extends Plugin
 	private final Map<Integer, MinnowSpot> minnowSpots = new HashMap<>();
 
 	@Getter(AccessLevel.PACKAGE)
+	private final Map<Integer, TimerSpot> timerSpots = new HashMap<>();
+
+	@Getter(AccessLevel.PACKAGE)
 	private final List<NPC> fishingSpots = new ArrayList<>();
 
 	@Getter(AccessLevel.PACKAGE)
 	private FishingSpot currentSpot;
+
+	@Getter(AccessLevel.PACKAGE)
+	private final Duration TIMER_MAX = Duration.ofSeconds(318);
+
+	@Getter(AccessLevel.PACKAGE)
+	private final Duration TIMER_MIN = Duration.ofSeconds(168);
 
 	@Inject
 	private Client client;
@@ -321,6 +330,20 @@ public class FishingPlugin extends Plugin
 					minnowSpots.put(id, new MinnowSpot(npc.getWorldLocation(), Instant.now()));
 				}
 			}
+
+			if (FishingSpot.findSpot(npc.getId()) != FishingSpot.MINNOW &&
+					FishingSpot.findSpot(npc.getId()) != FishingSpot.KARAMBWAN &&
+					FishingSpot.findSpot(npc.getId()) != FishingSpot.ANGLERFISH &&
+					FishingSpot.findSpot(npc.getId()) != FishingSpot.COMMON_TENCH &&
+					config.showSpotTimers()) {
+
+				final int id = npc.getIndex();
+				final TimerSpot timerSpot = timerSpots.get(id);
+
+				if(timerSpot == null || !timerSpot.getLoc().equals(npc.getWorldLocation())) {
+					timerSpots.put(id, new TimerSpot(npc.getWorldLocation(), Instant.now()));
+				}
+			}
 		}
 
 		updateTrawlerTimer();
@@ -352,6 +375,11 @@ public class FishingPlugin extends Plugin
 		if (minnowSpot != null)
 		{
 			log.debug("Minnow spot {} despawned", npc);
+		}
+
+		TimerSpot timerSpot = timerSpots.remove(npc.getIndex());
+		if(timerSpot != null) {
+			log.debug("Timer spot {} despawned", npc);
 		}
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingSpotOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingSpotOverlay.java
@@ -160,6 +160,43 @@ class FishingSpotOverlay extends Overlay
 				}
 			}
 
+			if (FishingSpot.findSpot(npc.getId()) != FishingSpot.MINNOW &&
+					FishingSpot.findSpot(npc.getId()) != FishingSpot.KARAMBWAN &&
+					FishingSpot.findSpot(npc.getId()) != FishingSpot.ANGLERFISH &&
+					FishingSpot.findSpot(npc.getId()) != FishingSpot.COMMON_TENCH &&
+					config.showSpotTimers()) {
+
+				TimerSpot timerSpot = plugin.getTimerSpots().get(npc.getIndex());
+				if (timerSpot != null)
+				{
+					final Duration duration = Duration.between(timerSpot.getTime(), Instant.now());
+
+					if (duration.compareTo(plugin.getTIMER_MIN()) < 0) {
+						color = Color.GREEN;
+					} else if (duration.compareTo(plugin.getTIMER_MAX()) < 0) {
+						color = Color.RED;
+					}
+
+					LocalPoint localPoint = npc.getLocalLocation();
+					Point location = Perspective.localToCanvas(client, localPoint, client.getPlane());
+
+					if (location != null)
+					{
+						ProgressPieComponent pie = new ProgressPieComponent();
+						pie.setFill(color);
+						pie.setBorderColor(color);
+						pie.setPosition(location);
+						pie.setProgress(1 - (duration.compareTo(plugin.getTIMER_MAX()) < 0
+								? (double) duration.toMillis() / plugin.getTIMER_MAX().toMillis()
+								: 1));
+
+						if(duration.compareTo(plugin.getTIMER_MAX()) < 0) {
+							pie.render(graphics);
+						}
+					}
+				}
+			}
+
 			if (config.showSpotIcons())
 			{
 				BufferedImage fishImage = itemManager.getImage(spot.getFishSpriteId());

--- a/runelite-client/src/main/java/net/runelite/client/plugins/fishing/TimerSpot.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/fishing/TimerSpot.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2018, Adam <Adam@sigterm.info>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.fishing;
+
+import java.time.Instant;
+import lombok.AllArgsConstructor;
+import lombok.Value;
+import net.runelite.api.coords.WorldPoint;
+
+@AllArgsConstructor
+@Value
+class TimerSpot
+{
+    private final WorldPoint loc;
+    private final Instant time;
+}


### PR DESCRIPTION
Close #14633 

Add age timers that estimate when a fishing spot will move. Fishing timers are green when < 280 game ticks and red between 280 and 530 game ticks.