### PR TITLE
Group status bars together in Resizeable Classic Layout

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/statusbars/StatusBarsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/statusbars/StatusBarsConfig.java
@@ -100,7 +100,7 @@ public interface StatusBarsConfig extends Config
 	@ConfigItem(
 		keyName = "groupTogether",
 		name = "Left and Right bar grouped",
-		description = "Left and Right bar displayed beside each other on left of inventory",
+		description = "Left and right bar displayed beside each other on left of inventory.",
 		section = resizeableClassicLayout
 	)
 	default boolean groupTogether() {return false;}
@@ -108,18 +108,16 @@ public interface StatusBarsConfig extends Config
 	@ConfigItem(
 		keyName = "overlapPillar",
 		name = "Overlap inventory pillar",
-		description = "Should the right bar overlap the inventory pillar while grouped",
+		description = "Make the right bar overlap the inventory pillar.",
 		section = resizeableClassicLayout
 	)
 	default boolean overlapPillar() {return false;}
 
 	@ConfigSection(
 		name = "Resizable - Classic Layout",
-		description = "All options that swap item menu entries",
+		description = "Options to change the status bar locations when Game client layout is set to Resizeable - Classic Layout.",
 		position = 0,
 		closedByDefault = true
 	)
 	String resizeableClassicLayout = "resizeableClassicLayout";
-
-
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/statusbars/StatusBarsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/statusbars/StatusBarsConfig.java
@@ -98,46 +98,6 @@ public interface StatusBarsConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "barHeight",
-		name = "Height of bars",
-		description = "Height of the status bars in classic mode",
-		section = resizeableClassicLayout
-	)
-	default int barHeight() {return 252;}
-
-	@ConfigItem(
-		keyName = "leftBarXOffset",
-		name = "Left bar X offset",
-		description = "X offset of left bar",
-		section = resizeableClassicLayout
-	)
-	default int leftBarXOffset() {return 45;}
-
-	@ConfigItem(
-		keyName = "rightBarXOffset",
-		name = "Right bar X offset",
-		description = "X offset of right bar in classic mode",
-		section = resizeableClassicLayout
-	)
-	default int rightBarXOffset() {return 43;}
-
-	@ConfigItem(
-		keyName = "leftBarYOffset",
-		name = "Left bar Y offset",
-		description = "Y offset of left bar",
-		section = resizeableClassicLayout
-	)
-	default int leftBarYOffset() {return 0;}
-
-	@ConfigItem(
-		keyName = "rightBarYOffset",
-		name = "Right bar Y offset",
-		description = "Y offset of right bar in classic mode",
-		section = resizeableClassicLayout
-	)
-	default int rightBarYOffset() {return 0;}
-
-	@ConfigItem(
 		keyName = "groupTogether",
 		name = "Left and Right bar grouped",
 		description = "Left and Right bar displayed beside each other on left of inventory",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/statusbars/StatusBarsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/statusbars/StatusBarsConfig.java
@@ -27,6 +27,7 @@ package net.runelite.client.plugins.statusbars;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.ConfigSection;
 import net.runelite.client.config.Units;
 import net.runelite.client.plugins.statusbars.config.BarMode;
 
@@ -95,4 +96,70 @@ public interface StatusBarsConfig extends Config
 	{
 		return 0;
 	}
+
+	@ConfigItem(
+		keyName = "barHeight",
+		name = "Height of bars",
+		description = "Height of the status bars in classic mode",
+		section = resizeableClassicLayout
+	)
+	default int barHeight() {return 252;}
+
+	@ConfigItem(
+		keyName = "leftBarXOffset",
+		name = "Left bar X offset",
+		description = "X offset of left bar",
+		section = resizeableClassicLayout
+	)
+	default int leftBarXOffset() {return 45;}
+
+	@ConfigItem(
+		keyName = "rightBarXOffset",
+		name = "Right bar X offset",
+		description = "X offset of right bar in classic mode",
+		section = resizeableClassicLayout
+	)
+	default int rightBarXOffset() {return 43;}
+
+	@ConfigItem(
+		keyName = "leftBarYOffset",
+		name = "Left bar Y offset",
+		description = "Y offset of left bar",
+		section = resizeableClassicLayout
+	)
+	default int leftBarYOffset() {return 0;}
+
+	@ConfigItem(
+		keyName = "rightBarYOffset",
+		name = "Right bar Y offset",
+		description = "Y offset of right bar in classic mode",
+		section = resizeableClassicLayout
+	)
+	default int rightBarYOffset() {return 0;}
+
+	@ConfigItem(
+		keyName = "groupTogether",
+		name = "Left and Right bar grouped",
+		description = "Left and Right bar displayed beside each other on left of inventory",
+		section = resizeableClassicLayout
+	)
+	default boolean groupTogether() {return false;}
+
+	@ConfigItem(
+		keyName = "overlapPillar",
+		name = "Overlap inventory pillar",
+		description = "Should the right bar overlap the inventory pillar while grouped",
+		section = resizeableClassicLayout
+	)
+	default boolean overlapPillar() {return false;}
+
+	@ConfigSection(
+		name = "Resizable - Classic Layout",
+		description = "All options that swap item menu entries",
+		position = 0,
+		closedByDefault = true
+	)
+	String resizeableClassicLayout = "resizeableClassicLayout";
+
+
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/statusbars/StatusBarsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/statusbars/StatusBarsOverlay.java
@@ -76,6 +76,10 @@ class StatusBarsOverlay extends Overlay
 	private static final Dimension ICON_DIMENSIONS = new Dimension(26, 25);
 	private static final int RESIZED_BOTTOM_OFFSET_Y = 12;
 	private static final int RESIZED_BOTTOM_OFFSET_X = 10;
+	private static final int RESIZED_BOX_GROUP_OFFSET_LEFT_X = 48;
+	private static final int RESIZED_BOX_GROUP_OFFSET_RIGHT_X = 43;
+	private static final int RESIZED_BOX_OVERLAP_OFFSET_LEFT_X = 25;
+	private static final int RESIZED_BOX_OVERLAP_OFFSET_RIGHT_X = 20;
 	private static final int MAX_SPECIAL_ATTACK_VALUE = 100;
 	private static final int MAX_RUN_ENERGY_VALUE = 100;
 
@@ -254,6 +258,22 @@ class StatusBarsOverlay extends Overlay
 			offsetLeftBarY = (location.getY() - RESIZED_BOTTOM_OFFSET_Y - offsetLeft.getY());
 			offsetRightBarX = (location.getX() + RESIZED_BOTTOM_OFFSET_X - offsetRight.getX());
 			offsetRightBarY = (location.getY() - RESIZED_BOTTOM_OFFSET_Y - offsetRight.getY());
+		}
+		else if (curViewport == Viewport.RESIZED_BOX && config.groupTogether() && config.overlapPillar())
+		{
+			height = HEIGHT;
+			offsetLeftBarX = (location.getX() - RESIZED_BOX_OVERLAP_OFFSET_LEFT_X - offsetLeft.getX());
+			offsetLeftBarY = (location.getY() - offsetLeft.getY());
+			offsetRightBarX = (location.getX() - RESIZED_BOX_OVERLAP_OFFSET_RIGHT_X - offsetRight.getX());
+			offsetRightBarY = (location.getY() - offsetRight.getY());
+		}
+		else if (curViewport == Viewport.RESIZED_BOX && config.groupTogether())
+		{
+			height = HEIGHT;
+			offsetLeftBarX = (location.getX() - RESIZED_BOX_GROUP_OFFSET_LEFT_X - offsetLeft.getX());
+			offsetLeftBarY = (location.getY() - offsetLeft.getY());
+			offsetRightBarX = (location.getX() - RESIZED_BOX_GROUP_OFFSET_RIGHT_X - offsetRight.getX());
+			offsetRightBarY = (location.getY() - offsetRight.getY());
 		}
 		else
 		{


### PR DESCRIPTION
Requested here: #14582

Options to have the status bars together on the left, either overlapping the inventory pillar still or off to the side altogether.
![StatusBarsDefault](https://user-images.githubusercontent.com/7642373/151568862-fd73071e-3583-42f7-a2db-d30a9c743247.PNG)
![StatsBarsGrouped](https://user-images.githubusercontent.com/7642373/151568873-9d79612b-4acc-4f54-8ca5-8f78d4d1300e.PNG)
![StatusBarsOverlap](https://user-images.githubusercontent.com/7642373/151569049-9ef09669-e3f8-483f-915e-647449d1ac71.PNG)

