### PR TITLE
Fix topological sort Concurrent Modification Exception

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/PluginManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/PluginManager.java
@@ -631,11 +631,14 @@ public class PluginManager
 	/**
 	 * Topologically sort a graph. Uses Kahn's algorithm.
 	 *
-	 * @param graph
-	 * @param <T>
-	 * @return
+	 * @param graph - A directed graph
+	 * @param <T>   - The type of the item contained in the nodes of the graph
+	 * @return - A topologically sorted list corresponding to graph.
+	 * <p>
+	 * Multiple invocations with the same arguments may return lists that are not equal.
 	 */
-	private <T> List<T> topologicalSort(Graph<T> graph)
+	@VisibleForTesting
+	static <T> List<T> topologicalSort(Graph<T> graph)
 	{
 		MutableGraph<T> graphCopy = Graphs.copyOf(graph);
 		List<T> l = new ArrayList<>();
@@ -650,7 +653,7 @@ public class PluginManager
 
 			l.add(n);
 
-			for (T m : graphCopy.successors(n))
+			for (T m : new HashSet<>(graphCopy.successors(n)))
 			{
 				graphCopy.removeEdge(n, m);
 				if (graphCopy.inDegree(m) == 0)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/PluginManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/PluginManager.java
@@ -26,7 +26,6 @@ package net.runelite.client.plugins;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
-import com.google.common.collect.Lists;
 import com.google.common.graph.Graph;
 import com.google.common.graph.GraphBuilder;
 import com.google.common.graph.Graphs;
@@ -320,8 +319,7 @@ public class PluginManager
 				continue;
 			}
 
-			Class<Plugin> pluginClass = (Class<Plugin>) clazz;
-			graph.addNode(pluginClass);
+			graph.addNode((Class<Plugin>) clazz);
 		}
 
 		// Build plugin graph
@@ -333,7 +331,7 @@ public class PluginManager
 			{
 				if (graph.nodes().contains(pluginDependency.value()))
 				{
-					graph.putEdge(pluginClazz, pluginDependency.value());
+					graph.putEdge(pluginDependency.value(), pluginClazz);
 				}
 			}
 		}
@@ -344,7 +342,6 @@ public class PluginManager
 		}
 
 		List<Class<? extends Plugin>> sortedPlugins = topologicalSort(graph);
-		sortedPlugins = Lists.reverse(sortedPlugins);
 
 		int loaded = 0;
 		List<Plugin> newPlugins = new ArrayList<>();

--- a/runelite-client/src/test/java/net/runelite/client/plugins/PluginManagerTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/PluginManagerTest.java
@@ -24,6 +24,8 @@
  */
 package net.runelite.client.plugins;
 
+import com.google.common.graph.GraphBuilder;
+import com.google.common.graph.MutableGraph;
 import com.google.common.reflect.ClassPath;
 import com.google.common.reflect.ClassPath.ClassInfo;
 import com.google.inject.Guice;
@@ -40,6 +42,7 @@ import java.io.PrintWriter;
 import java.lang.reflect.Method;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import net.runelite.api.Client;
@@ -51,6 +54,7 @@ import net.runelite.client.eventbus.EventBus;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -208,4 +212,23 @@ public class PluginManagerTest
 		}
 	}
 
+	@Test
+	public void testTopologicalSort()
+	{
+		MutableGraph<Integer> graph = GraphBuilder
+			.directed()
+			.build();
+
+		graph.addNode(1);
+		graph.addNode(2);
+		graph.addNode(3);
+
+		graph.putEdge(1, 2);
+		graph.putEdge(1, 3);
+
+		List<Integer> sorted = PluginManager.topologicalSort(graph);
+
+		assertTrue(sorted.indexOf(1) < sorted.indexOf(2));
+		assertTrue(sorted.indexOf(1) < sorted.indexOf(3));
+	}
 }


### PR DESCRIPTION
This PR has 2 commits. The first is a minimal change which reproduces the concurrent modification exception (CME) I mentioned in #14552 on my machine (openjdk 17 and 11). The second is a fix which prevents the CME from happening by making a new hashset in every iteration in `topologicalSort`.

Code formerly built a directed graph, topologically sorted it then reversed
the sorted list. This is mathematically equivalent to reversing the edge
direction in the directed graph. Changing the edge direction (and removing
the call to Lists.reverse) causes a CMEin the topologicalSort function

Copy pasted log tail including stacktrace:
```
2022-02-04 20:04:16 [main] DEBUG n.r.client.config.ConfigManager - Loading configuration value groundMarker.rememberTileColors: true
2022-02-04 20:04:16 [main] INFO  n.r.client.account.SessionManager - No session file exists
2022-02-04 20:04:16 [main] ERROR net.runelite.client.RuneLite - Failure during startup
java.util.ConcurrentModificationException: null
	at java.base/java.util.HashMap$HashIterator.nextNode(HashMap.java:1597)
	at java.base/java.util.HashMap$EntryIterator.next(HashMap.java:1630)
	at java.base/java.util.HashMap$EntryIterator.next(HashMap.java:1628)
	at com.google.common.graph.DirectedGraphConnections$2$1.computeNext(DirectedGraphConnections.java:145)
	at com.google.common.collect.AbstractIterator.tryToComputeNext(AbstractIterator.java:145)
	at com.google.common.collect.AbstractIterator.hasNext(AbstractIterator.java:140)
	at net.runelite.client.plugins.PluginManager.topologicalSort(PluginManager.java:651)
	at net.runelite.client.plugins.PluginManager.loadPlugins(PluginManager.java:345)
	at net.runelite.client.plugins.PluginManager.loadCorePlugins(PluginManager.java:275)
	at net.runelite.client.RuneLite.start(RuneLite.java:323)
	at net.runelite.client.RuneLite.main(RuneLite.java:257)
2022-02-04 20:04:17 [Client] DEBUG client-patch - Game state changed: UNKNOWN
2022-02-04 20:04:18 [Client] DEBUG client-patch - Game state changed: LOGIN_SCREEN
```