### PR TITLE
client: fix mouse tooltip below canvas height

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/tooltip/TooltipOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/tooltip/TooltipOverlay.java
@@ -96,7 +96,7 @@ public class TooltipOverlay extends Overlay
 		final int tooltipX = Math.min(canvasWidth - prevBounds.width, mouseCanvasPosition.getX());
 		final int tooltipY = runeLiteConfig.tooltipPosition() == TooltipPositionType.ABOVE_CURSOR
 			? Math.max(0, mouseCanvasPosition.getY() - prevBounds.height)
-			: Math.min(canvasHeight - prevBounds.height, mouseCanvasPosition.getY() + UNDER_OFFSET);
+			: Math.min(canvasHeight - prevBounds.height - UNDER_OFFSET, mouseCanvasPosition.getY() + UNDER_OFFSET);
 
 		final Rectangle newBounds = new Rectangle(tooltipX, tooltipY, 0, 0);
 


### PR DESCRIPTION
When a tall tooltip is rendered using the "Under cursor" tooltip position, the bottom of the window is cut-off. This change removes the `UNDER_OFFSET` value from the canvas height calculation to ensure it is always displayed.

Before:

<img src="https://user-images.githubusercontent.com/4160975/152913097-6132a323-0fd4-4d89-a1da-e67d6b288c5c.png" width="250"/> <img src="https://user-images.githubusercontent.com/4160975/152913103-62f6fb67-37fd-4dca-8180-881783cc8821.png" width="250"/>

After:
<img src="https://user-images.githubusercontent.com/4160975/152913117-b47d963d-0832-4c9f-9ff2-d35750a676f6.png" width="250"/> <img src="https://user-images.githubusercontent.com/4160975/152913124-1cad1cce-1a83-45be-8c1a-6374501f0bc4.png" width="250"/>
