### PR TITLE
GPU Plugin: Refactor count_prio_offset method to reduce branches

### DIFF
--- a/runelite-client/src/main/resources/net/runelite/client/plugins/gpu/priority_render.glsl
+++ b/runelite-client/src/main/resources/net/runelite/client/plugins/gpu/priority_render.glsl
@@ -70,44 +70,14 @@ int priority_map(int p, int distance, int _min10, int avg1, int avg2, int avg3) 
 // the given adjusted priority
 int count_prio_offset(int priority) {
   int total = 0;
-  switch (priority) {
-    case 17:
-      total += totalMappedNum[16];
-    case 16:
-      total += totalMappedNum[15];
-    case 15:
-      total += totalMappedNum[14];
-    case 14:
-      total += totalMappedNum[13];
-    case 13:
-      total += totalMappedNum[12];
-    case 12:
-      total += totalMappedNum[11];
-    case 11:
-      total += totalMappedNum[10];
-    case 10:
-      total += totalMappedNum[9];
-    case 9:
-      total += totalMappedNum[8];
-    case 8:
-      total += totalMappedNum[7];
-    case 7:
-      total += totalMappedNum[6];
-    case 6:
-      total += totalMappedNum[5];
-    case 5:
-      total += totalMappedNum[4];
-    case 4:
-      total += totalMappedNum[3];
-    case 3:
-      total += totalMappedNum[2];
-    case 2:
-      total += totalMappedNum[1];
-    case 1:
-      total += totalMappedNum[0];
-    case 0:
-      return total;
+  // The previous switch statements supported at most 17 priorities
+  if (priority > 17) {
+    priority = 17;
   }
+  for (int i = 1; i <= priority; i++) {
+    total += totalMappedNum[i-1];
+  }
+  return total;
 }
 
 void get_face(uint localId, modelinfo minfo, int cameraYaw, int cameraPitch,


### PR DESCRIPTION
Fixes #12952

Ported from 117's HD Plugin: https://github.com/RS117/RLHD/pull/212

There's some undefined behavior going on. We observed that Nvidia Turing and Ampere cards were not making it through all the switch case statements, and the return wasn't being hit. By reducing the branches and changing this to a for loop, issues were resolved in the HD Plugin. We believe that this patch may be relevant here as well.

Intellij's complaint about the original code in part lead us to this resolution:

![missing_return_statement](https://user-images.githubusercontent.com/1281388/152928220-e49aa184-25c2-4934-ae5c-213bd1c76bf7.png)

Edit: Some additional fun reading material about undefined/quirky behavior with conditional branching/switch statements in opengl shaders:

- https://www.peterstefek.me/shader-branch.html
- https://stackoverflow.com/a/34208113