### PR TITLE
Add new Yu'biusk fairy ring

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/fairyring/FairyRings.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/fairyring/FairyRings.java
@@ -54,6 +54,7 @@ public enum FairyRings
 	BKR("Mort Myre Swamp, south of Canifis"),
 	BKS("Zanaris"),
 	BLP("TzHaar area"),
+	BLQ("Yu'biusk"),
 	BLR("Legends' Guild"),
 
 	// C


### PR DESCRIPTION
The Land of the Goblins quest introduced a new fairy ring. The fairy ring plugin currently displays it as an invalid location, so this PR fixes that.