### PR TITLE
MenuEntrySwapperPlugin: Added Trade swap for MenuEntries with a non-conformed "Talk-to" option.

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -212,6 +212,8 @@ public class MenuEntrySwapperPlugin extends Plugin
 		swap("talk-to", "repairs", config::swapDarkMage);
 		// make sure assignment swap is higher priority than trade swap for slayer masters
 		swap("talk-to", "assignment", config::swapAssignment);
+		// Thora the Barkeep's (and likely a few other NPCs) Menu Entry option has a space instead of a dash
+		swap("talk to", "trade", config::swapTrade);
 		swap("talk-to", "trade", config::swapTrade);
 		swap("talk-to", "trade-with", config::swapTrade);
 		swap("talk-to", "shop", config::swapTrade);


### PR DESCRIPTION
Some NPCs have a non-conformed "Talk-to" option. Therefore by adding a swap for the non-conformant option, "Talk to", NPCs such as "Thora the Barkeep" will now have a proper Trade menu entry swap for the left-click position.

Resolved #14591 