### PR TITLE
Notifications: Set app name when using notify-send on Linux

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/Notifier.java
+++ b/runelite-client/src/main/java/net/runelite/client/Notifier.java
@@ -314,6 +314,8 @@ public class Notifier
 		commands.add("notify-send");
 		commands.add(title);
 		commands.add(message);
+		commands.add("-a");
+		commands.add(SHELL_ESCAPE.escape(appName));
 		commands.add("-i");
 		commands.add(SHELL_ESCAPE.escape(notifyIconPath.toAbsolutePath().toString()));
 		commands.add("-u");


### PR DESCRIPTION
If a notification is sent while the screen is locked in GNOME, GNOME shows "notify-send" as the app name instead of "RuneLite". Usually a notification will have the title/description, but since it shows in the lock screen, it instead shows the app name for privacy reasons. I assume this may be also the case for other desktop environments / display managers.

To reproduce: start runeline, go to dev tools, press Notification, then immediately lock the screen and wait a few seconds. When looking at the lock screen, it says "notify-send" instead of "RuneLite".
