### PR TITLE
HotColdSolver: Simplify temperature change filtering, improve temperature change narrowing

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdSolver.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdSolver.java
@@ -25,7 +25,6 @@
  */
 package net.runelite.client.plugins.cluescrolls.clues.hotcold;
 
-import com.google.common.annotations.VisibleForTesting;
 import java.awt.Rectangle;
 import java.util.Set;
 import javax.annotation.Nonnull;
@@ -94,76 +93,32 @@ public class HotColdSolver
 			switch (temperatureChange)
 			{
 				case COLDER:
-					// eliminate spots that are absolutely warmer
-					possibleLocations.removeIf(entry -> isFirstPointCloserRect(worldPoint, lastWorldPoint, entry.getRect()));
+					// eliminate spots that are warmer
+					possibleLocations.removeIf(location ->
+					{
+						final WorldPoint locationPoint = location.getWorldPoint();
+						return locationPoint.distanceTo2D(worldPoint) < locationPoint.distanceTo2D(lastWorldPoint);
+					});
 					break;
 				case WARMER:
-					// eliminate spots that are absolutely colder
-					possibleLocations.removeIf(entry -> isFirstPointCloserRect(lastWorldPoint, worldPoint, entry.getRect()));
+					// eliminate spots that are colder
+					possibleLocations.removeIf(location ->
+					{
+						final WorldPoint locationPoint = location.getWorldPoint();
+						return locationPoint.distanceTo2D(worldPoint) > locationPoint.distanceTo2D(lastWorldPoint);
+					});
 					break;
 				case SAME:
-					// eliminate spots which are absolutely colder or warmer (as they would not yield a SAME temperature change)
-					possibleLocations.removeIf(entry ->
-						isFirstPointCloserRect(worldPoint, lastWorldPoint, entry.getRect())
-						|| isFirstPointCloserRect(lastWorldPoint, worldPoint, entry.getRect()));
+					// eliminate spots which are colder or warmer (as they would not yield a SAME temperature change)
+					possibleLocations.removeIf(location ->
+					{
+						final WorldPoint locationPoint = location.getWorldPoint();
+						return locationPoint.distanceTo2D(worldPoint) != locationPoint.distanceTo2D(lastWorldPoint);
+					});
 			}
 		}
 
 		lastWorldPoint = worldPoint;
 		return getPossibleLocations();
-	}
-
-	/**
-	 * Determines whether the first point passed is closer to each corner of the given rectangle than the second point.
-	 *
-	 * @param firstPoint  First point to test. Return result will be relating to this point's location.
-	 * @param secondPoint Second point to test
-	 * @param rect        Rectangle, whose corner points will be compared to the first and second points passed
-	 * @return {@code true} if {@code firstPoint} is closer to each of {@code rect}'s four corner points than
-	 *         {@code secondPoint}, {@code false} otherwise.
-	 * @see WorldPoint#distanceTo2D
-	 */
-	@VisibleForTesting
-	static boolean isFirstPointCloserRect(final WorldPoint firstPoint, final WorldPoint secondPoint, final Rectangle rect)
-	{
-		final WorldPoint nePoint = new WorldPoint((rect.x + rect.width), (rect.y + rect.height), 0);
-
-		if (!isFirstPointCloser(firstPoint, secondPoint, nePoint))
-		{
-			return false;
-		}
-
-		final WorldPoint sePoint = new WorldPoint((rect.x + rect.width), rect.y, 0);
-
-		if (!isFirstPointCloser(firstPoint, secondPoint, sePoint))
-		{
-			return false;
-		}
-
-		final WorldPoint nwPoint = new WorldPoint(rect.x, (rect.y + rect.height), 0);
-
-		if (!isFirstPointCloser(firstPoint, secondPoint, nwPoint))
-		{
-			return false;
-		}
-
-		final WorldPoint swPoint = new WorldPoint(rect.x, rect.y, 0);
-		return (isFirstPointCloser(firstPoint, secondPoint, swPoint));
-	}
-
-	/**
-	 * Determines whether the first point passed is closer to the given point of comparison than the second point.
-	 *
-	 * @param firstPoint  First point to test. Return result will be relating to this point's location.
-	 * @param secondPoint Second point to test
-	 * @param worldPoint  Point to compare to the first and second points passed
-	 * @return {@code true} if {@code firstPoint} is closer to {@code worldPoint} than {@code secondPoint},
-	 *         {@code false} otherwise.
-	 * @see WorldPoint#distanceTo2D
-	 */
-	@VisibleForTesting
-	static boolean isFirstPointCloser(final WorldPoint firstPoint, final WorldPoint secondPoint, final WorldPoint worldPoint)
-	{
-		return firstPoint.distanceTo2D(worldPoint) < secondPoint.distanceTo2D(worldPoint);
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdSolver.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdSolver.java
@@ -93,19 +93,19 @@ public class HotColdSolver
 			switch (temperatureChange)
 			{
 				case COLDER:
-					// eliminate spots that are warmer
+					// eliminate spots that are warmer or same temperature
 					possibleLocations.removeIf(location ->
 					{
 						final WorldPoint locationPoint = location.getWorldPoint();
-						return locationPoint.distanceTo2D(worldPoint) < locationPoint.distanceTo2D(lastWorldPoint);
+						return locationPoint.distanceTo2D(worldPoint) <= locationPoint.distanceTo2D(lastWorldPoint);
 					});
 					break;
 				case WARMER:
-					// eliminate spots that are colder
+					// eliminate spots that are colder or same temperature
 					possibleLocations.removeIf(location ->
 					{
 						final WorldPoint locationPoint = location.getWorldPoint();
-						return locationPoint.distanceTo2D(worldPoint) > locationPoint.distanceTo2D(lastWorldPoint);
+						return locationPoint.distanceTo2D(worldPoint) >= locationPoint.distanceTo2D(lastWorldPoint);
 					});
 					break;
 				case SAME:

--- a/runelite-client/src/test/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdSolverTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdSolverTest.java
@@ -25,16 +25,11 @@
 package net.runelite.client.plugins.cluescrolls.clues.hotcold;
 
 import com.google.common.collect.Sets;
-import java.awt.Rectangle;
 import java.util.EnumSet;
 import java.util.Set;
 import java.util.stream.Collectors;
-import static junit.framework.TestCase.assertTrue;
 import net.runelite.api.coords.WorldPoint;
-import static net.runelite.client.plugins.cluescrolls.clues.hotcold.HotColdSolver.isFirstPointCloser;
-import static net.runelite.client.plugins.cluescrolls.clues.hotcold.HotColdSolver.isFirstPointCloserRect;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import org.junit.Test;
 
@@ -182,34 +177,6 @@ public class HotColdSolverTest
 			Sets.immutableEnumSet(HotColdLocation.ZEAH_SULPHR_MINE));
 	}
 
-	@Test
-	public void testIsFirstPointCloserRect()
-	{
-		assertFalse(isFirstPointCloserRect(new WorldPoint(0, 0, 0), new WorldPoint(0, 0, 0), new Rectangle(0, 0, 1, 1)));
-		assertFalse(isFirstPointCloserRect(new WorldPoint(1, 0, 0), new WorldPoint(5, 0, 0), new Rectangle(2, 1, 5, 5)));
-		assertFalse(isFirstPointCloserRect(new WorldPoint(1, 0, 0), new WorldPoint(0, 0, 0), new Rectangle(2, 0, 1, 2)));
-		assertFalse(isFirstPointCloserRect(new WorldPoint(0, 0, 0), new WorldPoint(1, 1, 1), new Rectangle(2, 2, 2, 2)));
-		assertFalse(isFirstPointCloserRect(new WorldPoint(0, 0, 0), new WorldPoint(4, 4, 4), new Rectangle(1, 1, 2, 2)));
-		assertFalse(isFirstPointCloserRect(new WorldPoint(3, 2, 0), new WorldPoint(1, 5, 0), new Rectangle(0, 0, 4, 4)));
-
-		assertTrue(isFirstPointCloserRect(new WorldPoint(1, 1, 0), new WorldPoint(0, 1, 0), new Rectangle(2, 0, 3, 2)));
-		assertTrue(isFirstPointCloserRect(new WorldPoint(4, 4, 0), new WorldPoint(1, 1, 0), new Rectangle(3, 3, 2, 2)));
-		assertTrue(isFirstPointCloserRect(new WorldPoint(3, 2, 0), new WorldPoint(7, 0, 0), new Rectangle(1, 3, 4, 2)));
-
-	}
-
-	@Test
-	public void testIsFirstPointCloser()
-	{
-		assertFalse(isFirstPointCloser(new WorldPoint(0, 0, 0), new WorldPoint(0, 0, 0), new WorldPoint(0, 0, 0)));
-		assertFalse(isFirstPointCloser(new WorldPoint(0, 0, 0), new WorldPoint(0, 0, 1), new WorldPoint(0, 0, 0)));
-		assertFalse(isFirstPointCloser(new WorldPoint(1, 0, 0), new WorldPoint(0, 0, 0), new WorldPoint(1, 1, 0)));
-		assertFalse(isFirstPointCloser(new WorldPoint(2, 2, 0), new WorldPoint(0, 0, 0), new WorldPoint(1, 1, 0)));
-
-		assertTrue(isFirstPointCloser(new WorldPoint(1, 0, 0), new WorldPoint(0, 0, 0), new WorldPoint(2, 0, 0)));
-		assertTrue(isFirstPointCloser(new WorldPoint(1, 1, 0), new WorldPoint(1, 0, 0), new WorldPoint(2, 2, 0)));
-		assertTrue(isFirstPointCloser(new WorldPoint(1, 1, 1), new WorldPoint(0, 1, 0), new WorldPoint(1, 1, 0)));
-	}
 
 	/**
 	 * Tests a hot-cold solver by signalling a test point, temperature, and temperature change to it and asserting the

--- a/runelite-client/src/test/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdSolverTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdSolverTest.java
@@ -177,6 +177,33 @@ public class HotColdSolverTest
 			Sets.immutableEnumSet(HotColdLocation.ZEAH_SULPHR_MINE));
 	}
 
+	@Test
+	public void testBeginnerCowFieldNarrowing()
+	{
+		// Start with Cow field north of Lumbridge and Northeast of Al Kharid mine locations remaining
+		final Set<HotColdLocation> startingLocations = EnumSet.of(
+			HotColdLocation.LUMBRIDGE_COW_FIELD,
+			HotColdLocation.NORTHEAST_OF_AL_KHARID_MINE
+		);
+		HotColdSolver solver = new HotColdSolver(startingLocations);
+
+		assertEquals(startingLocations, solver.signal(new WorldPoint(3313, 3208, 0), HotColdTemperature.WARM, null));
+		assertEquals(Sets.immutableEnumSet(HotColdLocation.LUMBRIDGE_COW_FIELD), solver.signal(new WorldPoint(3312, 3208, 0), HotColdTemperature.WARM, HotColdTemperatureChange.WARMER));
+	}
+
+	@Test
+	public void testBeginnerDraynorWheatFieldNarrowing()
+	{
+		// Start with Wheat field next to Draynor Village and Atop Ice Mountain locations remaining
+		final Set<HotColdLocation> startingLocations = EnumSet.of(
+			HotColdLocation.DRAYNOR_WHEAT_FIELD,
+			HotColdLocation.ICE_MOUNTAIN
+		);
+		HotColdSolver solver = new HotColdSolver(startingLocations);
+
+		assertEquals(startingLocations, solver.signal(new WorldPoint(3148, 3415, 0), HotColdTemperature.WARM, null));
+		assertEquals(Sets.immutableEnumSet(HotColdLocation.DRAYNOR_WHEAT_FIELD), solver.signal(new WorldPoint(3148, 3416, 0), HotColdTemperature.WARM, HotColdTemperatureChange.COLDER));
+	}
 
 	/**
 	 * Tests a hot-cold solver by signalling a test point, temperature, and temperature change to it and asserting the


### PR DESCRIPTION
While mostly correct, the narrowing which occurred for colder and warmer
temperature changes was previously too lenient and did not filter out
locations which were previously the same distance away. This PR
expands that filtering to remove any same-distance locations from
consideration for these cases and adds minimal test cases (from ingame
tests) to validate their behavior.