### PR TITLE
Add ground markers world map drawing

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/groundmarkers/GroundMarkerConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/groundmarkers/GroundMarkerConfig.java
@@ -70,6 +70,16 @@ public interface GroundMarkerConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "drawOnWorldmap",
+		name = "Draw tiles on world map",
+		description = "Configures whether marked tiles should be drawn on world map"
+	)
+	default boolean drawTileOnWorldmap()
+	{
+		return false;
+	}
+
+	@ConfigItem(
 		keyName = SHOW_IMPORT_EXPORT_KEY_NAME,
 		name = "Show Import/Export options",
 		description = "Show the Import/Export options on the minimap right-click menu"

--- a/runelite-client/src/main/java/net/runelite/client/plugins/groundmarkers/GroundMarkerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/groundmarkers/GroundMarkerPlugin.java
@@ -94,6 +94,9 @@ public class GroundMarkerPlugin extends Plugin
 	private GroundMarkerMinimapOverlay minimapOverlay;
 
 	@Inject
+	private GroundMarkerWorldmapOverlay worldmapOverlay;
+
+	@Inject
 	private ChatboxPanelManager chatboxPanelManager;
 
 	@Inject
@@ -140,7 +143,7 @@ public class GroundMarkerPlugin extends Plugin
 	{
 		points.clear();
 
-		int[] regions = client.getMapRegions();
+		int[] regions = getMarkerRegions();
 
 		if (regions == null)
 		{
@@ -155,6 +158,13 @@ public class GroundMarkerPlugin extends Plugin
 			Collection<ColorTileMarker> colorTileMarkers = translateToColorTileMarker(regionPoints);
 			points.addAll(colorTileMarkers);
 		}
+	}
+
+	private int[] getMarkerRegions()
+	{
+		final String prefix = ConfigManager.getWholeKey(CONFIG_GROUP, null, REGION_PREFIX);
+		List<String> keys = configManager.getConfigurationKeys(prefix);
+		return keys.stream().map(k -> k.substring(prefix.length())).mapToInt(Integer::parseInt).toArray();
 	}
 
 	/**
@@ -188,6 +198,7 @@ public class GroundMarkerPlugin extends Plugin
 	{
 		overlayManager.add(overlay);
 		overlayManager.add(minimapOverlay);
+		overlayManager.add(worldmapOverlay);
 		if (config.showImportExport())
 		{
 			sharingManager.addImportExportMenuOptions();
@@ -206,6 +217,7 @@ public class GroundMarkerPlugin extends Plugin
 		eventBus.unregister(sharingManager);
 		overlayManager.remove(overlay);
 		overlayManager.remove(minimapOverlay);
+		overlayManager.remove(worldmapOverlay);
 		sharingManager.removeMenuOptions();
 		points.clear();
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/groundmarkers/GroundMarkerWorldmapOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/groundmarkers/GroundMarkerWorldmapOverlay.java
@@ -1,0 +1,99 @@
+package net.runelite.client.plugins.groundmarkers;
+
+import com.google.inject.Inject;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Graphics2D;
+import java.awt.Rectangle;
+import java.awt.geom.Area;
+import net.runelite.api.Client;
+import net.runelite.api.Point;
+import net.runelite.api.coords.WorldPoint;
+import net.runelite.api.widgets.Widget;
+import net.runelite.api.widgets.WidgetInfo;
+import net.runelite.client.ui.overlay.Overlay;
+import net.runelite.client.ui.overlay.OverlayLayer;
+import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.OverlayPriority;
+import net.runelite.client.ui.overlay.worldmap.WorldMapOverlay;
+
+public class GroundMarkerWorldmapOverlay extends Overlay
+{
+	private final Client client;
+	private final GroundMarkerConfig config;
+	private final GroundMarkerPlugin plugin;
+
+	@Inject
+	private WorldMapOverlay worldMapOverlay;
+
+	@Inject
+	GroundMarkerWorldmapOverlay(Client client, GroundMarkerConfig config, GroundMarkerPlugin plugin)
+	{
+		this.client = client;
+		this.config = config;
+		this.plugin = plugin;
+
+		setPosition(OverlayPosition.DYNAMIC);
+		setPriority(OverlayPriority.LOW);
+		setLayer(OverlayLayer.MANUAL);
+		drawAfterLayer(WidgetInfo.WORLD_MAP_VIEW);
+	}
+
+	@Override
+	public Dimension render(Graphics2D graphics)
+	{
+		if (config.drawTileOnWorldmap())
+		{
+			drawWorldMap(graphics);
+		}
+
+		return null;
+	}
+
+	private void drawWorldMap(Graphics2D graphics)
+	{
+		final Widget worldMapView = client.getWidget(WidgetInfo.WORLD_MAP_VIEW);
+		if (worldMapView == null)
+		{
+			return;
+		}
+
+		final Rectangle bounds = worldMapView.getBounds();
+		if (bounds == null)
+		{
+			return;
+		}
+
+		final Area mapClipArea = worldMapOverlay.getWorldMapClipArea(bounds);
+
+		for (ColorTileMarker marker : plugin.getPoints())
+		{
+			drawTile(graphics, marker.getWorldPoint(), marker.getColor(), mapClipArea);
+		}
+	}
+
+	private void drawTile(Graphics2D graphics, WorldPoint point, Color color, Area mapClipArea)
+	{
+		final Point start = worldMapOverlay.mapWorldPointToGraphicsPoint(point);
+		final Point end = worldMapOverlay.mapWorldPointToGraphicsPoint(point.dx(1).dy(-1));
+
+		if (start == null || end == null)
+		{
+			return;
+		}
+
+		int x = start.getX();
+		int y = start.getY();
+		final int width = end.getX() - x;
+		final int height = end.getY() - y;
+		x -= width / 2;
+		if (!mapClipArea.contains(x, y))
+		{
+			return;
+		}
+		y -= height / 2;
+
+		graphics.setColor(color);
+		graphics.drawRect(x, y, width, height);
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/worldmap/WorldMapOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/worldmap/WorldMapOverlay.java
@@ -297,7 +297,7 @@ public class WorldMapOverlay extends Overlay
 	 * @return              An {@link Area} representing <code>baseRectangle</code>, with the area
 	 *                      of visible widgets overlaying the world map clipped from it.
 	 */
-	private Area getWorldMapClipArea(Rectangle baseRectangle)
+	public Area getWorldMapClipArea(Rectangle baseRectangle)
 	{
 		final Widget overview = client.getWidget(WidgetInfo.WORLD_MAP_OVERVIEW_MAP);
 		final Widget surfaceSelector = client.getWidget(WidgetInfo.WORLD_MAP_SURFACE_SELECTOR);


### PR DESCRIPTION
Adds a config option to draw ground markers on the world map.  
![world map illustration](https://user-images.githubusercontent.com/53493631/157510427-a5db62c7-9e60-49a5-a355-600f1c559ab1.png)  
![config option](https://user-images.githubusercontent.com/53493631/157510518-53fc54ef-1abc-4c7a-9bb7-4b85ec06eafe.png)


