### PR TITLE
splash: Stop grabbing focus for the splash screen

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ui/SplashScreen.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/SplashScreen.java
@@ -129,6 +129,7 @@ public class SplashScreen extends JFrame implements ActionListener
 		timer.setRepeats(true);
 		timer.start();
 
+		setAutoRequestFocus(false);
 		setVisible(true);
 	}
 


### PR DESCRIPTION
This has been bugging me for a while, but I never thought to fix it. Focus is still grabbed when the client window opens.