### PR TITLE
XpTracker: Add a toggle for the "Open Wise Old Man" menu option

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpInfoBox.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpInfoBox.java
@@ -155,6 +155,7 @@ class XpInfoBox extends JPanel
 			@Override
 			public void popupMenuWillBecomeVisible(PopupMenuEvent popupMenuEvent)
 			{
+				openXpTracker.setVisible(xpTrackerConfig.wiseOldManOpenOption());
 				canvasItem.setText(xpTrackerPlugin.hasOverlay(skill) ? REMOVE_STATE : ADD_STATE);
 			}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpPanel.java
@@ -39,6 +39,8 @@ import javax.swing.JPanel;
 import javax.swing.JPopupMenu;
 import javax.swing.SwingUtilities;
 import javax.swing.border.EmptyBorder;
+import javax.swing.event.PopupMenuEvent;
+import javax.swing.event.PopupMenuListener;
 import net.runelite.api.Actor;
 import net.runelite.api.Client;
 import net.runelite.api.Skill;
@@ -112,6 +114,24 @@ class XpPanel extends PluginPanel
 		popupMenu.add(resetPerHour);
 		popupMenu.add(pauseAll);
 		popupMenu.add(unpauseAll);
+		popupMenu.addPopupMenuListener(new PopupMenuListener()
+		{
+			@Override
+			public void popupMenuWillBecomeVisible(PopupMenuEvent popupMenuEvent)
+			{
+				openXpTracker.setVisible(xpTrackerConfig.wiseOldManOpenOption());
+			}
+
+			@Override
+			public void popupMenuWillBecomeInvisible(PopupMenuEvent popupMenuEvent)
+			{
+			}
+
+			@Override
+			public void popupMenuCanceled(PopupMenuEvent popupMenuEvent)
+			{
+			}
+		});
 		overallPanel.setComponentPopupMenu(popupMenu);
 
 		final JLabel overallIcon = new JLabel(new ImageIcon(iconManager.getSkillImage(Skill.OVERALL)));

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerConfig.java
@@ -211,4 +211,15 @@ public interface XpTrackerConfig extends Config
 	{
 		return false;
 	}
+
+	@ConfigItem(
+		position = 15,
+		keyName = "wiseOldManOpenOption",
+		name = "Wise Old Man Open Option",
+		description = "Adds an option to open Wise Old Man to the XP info box right-click menu"
+	)
+	default boolean wiseOldManOpenOption()
+	{
+		return true;
+	}
 }


### PR DESCRIPTION
I don't use Wise Old Man nearly enough to want links to it in the Xp Tracker that I can accidentally open, which is something I've done a few times. This PR adds an option to hide the links.

(I'm pretty sure I'm not the only one who has had this issue. It looks like there was even a question about it in the RuneLite discord  about a month ago.)