### PR TITLE
npcaggro: always show tutorial overlay if plugin is not calibrated

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/npcunaggroarea/NpcAggroAreaNotWorkingOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npcunaggroarea/NpcAggroAreaNotWorkingOverlay.java
@@ -42,7 +42,7 @@ class NpcAggroAreaNotWorkingOverlay extends OverlayPanel
 		this.plugin = plugin;
 
 		panelComponent.getChildren().add(LineComponent.builder()
-			.left("Unaggressive NPC timers will start working when you teleport far away or enter a dungeon.")
+			.left("Unaggressive NPC timers require calibration. Teleport far away or enter a dungeon, then run until this overlay disappears.")
 			.build());
 
 		setPriority(OverlayPriority.LOW);
@@ -53,7 +53,7 @@ class NpcAggroAreaNotWorkingOverlay extends OverlayPanel
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
-		if (!plugin.isActive() || plugin.getSafeCenters()[1] != null)
+		if (plugin.getSafeCenters()[1] != null)
 		{
 			return null;
 		}


### PR DESCRIPTION
Currently, the tutorial overlay is hidden when no tracked NPC is in range. This makes knowing whether the plugin has been calibrated very annoying unless the user has `Always active` enabled. By making it always visible when not calibrated, the user can be sure when they've done it correctly, and easily prepare for it before the long trek to Sand Crabs. 
I've also updated the message to be more specific for what the user should do, though I have no idea why they need to do anything more than teleport/enter a cave to fix it as it wasn't reproducible during testing.

If the user does not want to see the overlay all the time, they can turn off the plugin; it wasn't calibrated before, so they lose out on nothing by turning it off.