### PR TITLE
[Menu Swapper] Swap "Deposit" with "Deposit-runes" for the Deposit pool in Guardians of the Rift.

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -826,4 +826,15 @@ public interface MenuEntrySwapperConfig extends Config
 	{
 		return false;
 	}
+
+	@ConfigItem(
+		keyName = "swapDepositPool",
+		name = "Deposit Pool - Only Runes",
+		description = "Swap Deposit with Deposit Runes on the Deposit Pool in Guardians of the Rift.",
+		section = objectSection
+	)
+	default boolean swapDepositPool()
+	{
+		return false;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -418,6 +418,8 @@ public class MenuEntrySwapperPlugin extends Plugin
 
 		swap("climb", "climb-up", () -> (shiftModifier() ? config.swapStairsShiftClick() : config.swapStairsLeftClick()) == MenuEntrySwapperConfig.StairsMode.CLIMB_UP);
 		swap("climb", "climb-down", () -> (shiftModifier() ? config.swapStairsShiftClick() : config.swapStairsLeftClick()) == MenuEntrySwapperConfig.StairsMode.CLIMB_DOWN);
+
+		swap("deposit", "deposit-runes", config::swapDepositPool);
 	}
 
 	private void swap(String option, String swappedOption, Supplier<Boolean> enabled)


### PR DESCRIPTION
fixes  #14787

Not a lot to it. 👍🏼 Simple add ability to swap "Deposit" with "Deposit-runes" on the Deposit pool in Guardians of the Rift. I think this should be the default. 