### PR TITLE
[Menu Swapper] Add Take-X Uncharged Cells swap for Guardians of the Rift

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -837,4 +837,23 @@ public interface MenuEntrySwapperConfig extends Config
 	{
 		return false;
 	}
+
+	enum UnchargedCellsMode
+	{
+		TAKE,
+		TAKE_1,
+		TAKE_5,
+		TAKE_10
+	}
+
+	@ConfigItem(
+		keyName = "swapUnchargedCells",
+		name = "Uncharged Cells - Take X",
+		description = "Swap the take option when left-clicking Uncharged Cells in Guardians of the Rift.",
+		section = objectSection
+	)
+	default boolean swapUnchargedCells()
+	{
+		return UnchargedCellsMode.TAKE;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -852,7 +852,7 @@ public interface MenuEntrySwapperConfig extends Config
 		description = "Swap the take option when left-clicking Uncharged Cells in Guardians of the Rift.",
 		section = objectSection
 	)
-	default boolean swapUnchargedCells()
+	default UnchargedCellsMode swapUnchargedCells()
 	{
 		return UnchargedCellsMode.TAKE;
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -848,8 +848,8 @@ public interface MenuEntrySwapperConfig extends Config
 
 	@ConfigItem(
 		keyName = "swapUnchargedCells",
-		name = "Uncharged Cells - Take X",
-		description = "Swap the take option when left-clicking Uncharged Cells in Guardians of the Rift.",
+		name = "Uncharged Cells",
+		description = "Swap the take option for Uncharged Cells in Guardians of the Rift.",
 		section = objectSection
 	)
 	default UnchargedCellsMode swapUnchargedCells()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -420,6 +420,10 @@ public class MenuEntrySwapperPlugin extends Plugin
 		swap("climb", "climb-down", () -> (shiftModifier() ? config.swapStairsShiftClick() : config.swapStairsLeftClick()) == MenuEntrySwapperConfig.StairsMode.CLIMB_DOWN);
 
 		swap("deposit", "deposit-runes", config::swapDepositPool);
+
+		swap("take", "uncharged cells", "take-1", () -> config.swapUnchargedCells() == UnchargedCellsMode.TAKE_1);
+		swap("take", "uncharged cells", "take-5", () -> config.swapUnchargedCells() == UnchargedCellsMode.TAKE_5);
+		swap("take", "uncharged cells", "take-10", () -> config.swapUnchargedCells() == UnchargedCellsMode.TAKE_10);
 	}
 
 	private void swap(String option, String swappedOption, Supplier<Boolean> enabled)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -70,6 +70,7 @@ import static net.runelite.client.plugins.menuentryswapper.MenuEntrySwapperConfi
 import static net.runelite.client.plugins.menuentryswapper.MenuEntrySwapperConfig.KaramjaGlovesMode;
 import static net.runelite.client.plugins.menuentryswapper.MenuEntrySwapperConfig.MorytaniaLegsMode;
 import static net.runelite.client.plugins.menuentryswapper.MenuEntrySwapperConfig.RadasBlessingMode;
+import static net.runelite.client.plugins.menuentryswapper.MenuEntrySwapperConfig.UnchargedCellsMode;
 import net.runelite.client.util.Text;
 
 @PluginDescriptor(


### PR DESCRIPTION
fixes #14788 

Adds the ability to swap the left-click Take option for the Uncharged Cells in Guardians of the Rift.

![image](https://user-images.githubusercontent.com/20365453/160231873-44f06f7e-2efd-4389-b2af-e230ff8480ea.png)
