### PR TITLE
Use LinkedHashMap for switch jump tables

### DIFF
--- a/cache/src/main/java/net/runelite/cache/definitions/loaders/ScriptLoader.java
+++ b/cache/src/main/java/net/runelite/cache/definitions/loaders/ScriptLoader.java
@@ -24,7 +24,7 @@
  */
 package net.runelite.cache.definitions.loaders;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import net.runelite.cache.definitions.ScriptDefinition;
 import net.runelite.cache.io.InputStream;
@@ -61,7 +61,7 @@ public class ScriptLoader
 
 			for (int i = 0; i < numSwitches; ++i)
 			{
-				switches[i] = new HashMap<>();
+				switches[i] = new LinkedHashMap<>();
 
 				int count = in.readUnsignedShort();
 				while (count-- > 0)

--- a/runelite-client/src/main/scripts/ChatBuilder.rs2asm
+++ b/runelite-client/src/main/scripts/ChatBuilder.rs2asm
@@ -456,28 +456,28 @@ LABEL406:
    sstore                 17 ; message channel
    iload                  11
    switch                
-      1: LABEL409
       2: LABEL409
+      1: LABEL409
+      90: LABEL433
+      91: LABEL433
       3: LABEL457
+      7: LABEL457
       101: LABEL482
       5: LABEL503
       6: LABEL539
-      7: LABEL457
       103: LABEL564
       104: LABEL564
-      9: LABEL606
-      41: LABEL677
-      43: LABEL1061
-      107: LABEL1285
-      44: LABEL896
-      109: LABEL585
       110: LABEL564
-      46: LABEL1200
-      14: LABEL1255
+      109: LABEL585
+      9: LABEL606
       111: LABEL635
       112: LABEL656
-      90: LABEL433
-      91: LABEL433
+      41: LABEL677
+      44: LABEL896
+      43: LABEL1061
+      46: LABEL1200
+      14: LABEL1255
+      107: LABEL1285
    jump                   LABEL1324
 LABEL409:
    sload                  21
@@ -1481,22 +1481,22 @@ LABEL1341:
       1: LABEL1346
       2: LABEL1346
       3: LABEL1346
-      101: LABEL1450
       6: LABEL1346
       7: LABEL1346
-      103: LABEL1493
-      104: LABEL1493
       9: LABEL1346
-      41: LABEL1346
-      106: LABEL1346
-      44: LABEL1346
-      109: LABEL1596
-      110: LABEL1493
-      14: LABEL1536
-      111: LABEL1639
-      112: LABEL1682
       90: LABEL1346
       91: LABEL1346
+      106: LABEL1346
+      41: LABEL1346
+      44: LABEL1346
+      101: LABEL1450
+      103: LABEL1493
+      104: LABEL1493
+      110: LABEL1493
+      14: LABEL1536
+      109: LABEL1596
+      111: LABEL1639
+      112: LABEL1682
    jump                   LABEL1725
 LABEL1346:
    sconst                 "<col=ffffff>"

--- a/runelite-client/src/main/scripts/ChatSplitBuilder.rs2asm
+++ b/runelite-client/src/main/scripts/ChatSplitBuilder.rs2asm
@@ -430,9 +430,9 @@ LABEL369:
    iload                  18
    switch                
       3: LABEL372
-      5: LABEL430
-      6: LABEL401
       7: LABEL372
+      6: LABEL401
+      5: LABEL430
    jump                   LABEL468
 LABEL372:
    iload                  7

--- a/runelite-client/src/main/scripts/FriendUpdate.rs2asm
+++ b/runelite-client/src/main/scripts/FriendUpdate.rs2asm
@@ -192,10 +192,10 @@ LABEL157:
       1: LABEL167
       2: LABEL170
       3: LABEL175
-      4: LABEL190
-      5: LABEL210
       8: LABEL180
       9: LABEL185
+      4: LABEL190
+      5: LABEL210
    jump                   LABEL229
 LABEL167:
    iconst                 0

--- a/runelite-client/src/main/scripts/LayoutResizableStones.rs2asm
+++ b/runelite-client/src/main/scripts/LayoutResizableStones.rs2asm
@@ -14,10 +14,10 @@
    istore                 4
    iload                  1
    switch                
-      1745: LABEL169
-      1129: LABEL149
-      1130: LABEL107
       1131: LABEL9
+      1130: LABEL107
+      1129: LABEL149
+      1745: LABEL169
    jump                   LABEL244
 LABEL9:
    iconst                 10747996
@@ -229,8 +229,8 @@ LABEL180:
    2308                  
    get_varbit             6255
    switch                
-      1: LABEL197
       2: LABEL189
+      1: LABEL197
       3: LABEL205
    jump                   LABEL213
 LABEL189:

--- a/runelite-client/src/main/scripts/PrivateMessage.rs2asm
+++ b/runelite-client/src/main/scripts/PrivateMessage.rs2asm
@@ -30,24 +30,24 @@ LABEL21:
    get_varc_int           5
    switch                
       1: LABEL24
-      2: LABEL47
-      3: LABEL47
       4: LABEL26
       5: LABEL26
+      2: LABEL47
+      3: LABEL47
       6: LABEL47
       7: LABEL111
+      19: LABEL111
       8: LABEL117
       9: LABEL125
-      10: LABEL202
-      11: LABEL260
-      12: LABEL219
-      13: LABEL237
       15: LABEL125
-      16: LABEL266
-      18: LABEL260
-      19: LABEL111
       20: LABEL125
       21: LABEL125
+      10: LABEL202
+      12: LABEL219
+      13: LABEL237
+      11: LABEL260
+      18: LABEL260
+      16: LABEL266
    jump                   LABEL268
 LABEL24:
    return                
@@ -346,13 +346,13 @@ LABEL268:
 LABEL269:
    get_varc_int           5
    switch                
-      16: LABEL274
-      20: LABEL272
-      21: LABEL272
       7: LABEL272
       8: LABEL272
       9: LABEL272
       15: LABEL272
+      20: LABEL272
+      21: LABEL272
+      16: LABEL274
    jump                   LABEL275
 LABEL272:
    return                

--- a/runelite-client/src/main/scripts/SkillTabBuilder.rs2asm
+++ b/runelite-client/src/main/scripts/SkillTabBuilder.rs2asm
@@ -166,10 +166,10 @@ LABEL141:
    iload                  0
    switch                
       0: LABEL144
-      1: LABEL234
       2: LABEL144
-      4: LABEL189
       6: LABEL144
+      4: LABEL189
+      1: LABEL234
    jump                   LABEL278
 LABEL144:
    iconst                 20


### PR DESCRIPTION
This makes the order of cases preserved to what they are defined as in the script file. Since this might cause issues with mapping scripts, this also included ordering the switches in overridden scripts based on the new output.

@abextm 