### PR TITLE
config-client: allow setting config server url via system properties

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/RuneLiteModule.java
+++ b/runelite-client/src/main/java/net/runelite/client/RuneLiteModule.java
@@ -178,6 +178,14 @@ public class RuneLiteModule extends AbstractModule
 	}
 
 	@Provides
+	@Named("runelite.config-service.base")
+	HttpUrl provideConfigServiceBase(@Named("runelite.api.base") String s)
+	{
+		final String prop = System.getProperty("runelite.config-service.url");
+		return HttpUrl.get(Strings.isNullOrEmpty(prop) ? s : prop);
+	}
+
+	@Provides
 	@Named("runelite.session")
 	HttpUrl provideSession(@Named("runelite.session") String s)
 	{

--- a/runelite-client/src/main/java/net/runelite/client/config/ConfigClient.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/ConfigClient.java
@@ -60,7 +60,7 @@ public class ConfigClient
 	private UUID uuid;
 
 	@Inject
-	private ConfigClient(OkHttpClient client, @Named("runelite.api.base") HttpUrl apiBase)
+	private ConfigClient(OkHttpClient client, @Named("runelite.config-service.base") HttpUrl apiBase)
 	{
 		this.client = client;
 		this.apiBase = apiBase;


### PR DESCRIPTION
This pull requests adds a new system property called `runelite.config-service.url` which allows setting a custom remote config server. If this property is not present the `runelite.api.base` is used instead.