### PR TITLE
Menu Entry Swapper: Gotr barrier swap fix

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -34,8 +34,11 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.LinkedHashMultimap;
 import com.google.common.collect.Multimap;
 import com.google.inject.Provides;
-
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import javax.inject.Inject;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/Swap.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/Swap.java
@@ -24,6 +24,7 @@
  */
 package net.runelite.client.plugins.menuentryswapper;
 
+import java.util.List;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import lombok.Value;
@@ -36,4 +37,5 @@ class Swap
 	private String swappedOption;
 	private Supplier<Boolean> enabled;
 	private boolean strict;
+	private List<Integer> blocklist;
 }


### PR DESCRIPTION
This fixes accidentally leaving through spam clicking, without
having to disable all quick-pass like swaps.

This addresses https://github.com/runelite/runelite/issues/14810