### PR TITLE
Inventory Viewer: Hide inventory viewer when bank interface opens

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/inventoryviewer/InventoryViewerOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/inventoryviewer/InventoryViewerOverlay.java
@@ -36,6 +36,7 @@ import net.runelite.api.Item;
 import net.runelite.api.ItemComposition;
 import net.runelite.api.ItemContainer;
 import net.runelite.api.VarClientInt;
+import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.ui.overlay.OverlayPanel;
 import net.runelite.client.ui.overlay.OverlayPosition;
@@ -75,7 +76,8 @@ class InventoryViewerOverlay extends OverlayPanel
 			return null;
 		}
 
-		if (client.getVar(VarClientInt.INVENTORY_TAB) == 3 && config.hideIfInventoryActive())
+		if ((client.getVar(VarClientInt.INVENTORY_TAB) == 3 || client.getWidget(WidgetInfo.BANK_CONTAINER) != null)
+			 && config.hideIfInventoryActive())
 		{
 			return null;
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/inventoryviewer/InventoryViewerOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/inventoryviewer/InventoryViewerOverlay.java
@@ -77,7 +77,7 @@ class InventoryViewerOverlay extends OverlayPanel
 		}
 
 		if ((client.getVar(VarClientInt.INVENTORY_TAB) == 3 || client.getWidget(WidgetInfo.BANK_CONTAINER) != null)
-			 && config.hideIfInventoryActive())
+				&& config.hideIfInventoryActive())
 		{
 			return null;
 		}


### PR DESCRIPTION
Fixes issue where inventory viewer still shows on the bank interface being open if the configurable setting "Hidden on inventory tab" is checked