### PR TITLE
Bank Search: Quantity search query

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/bank/BankPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/bank/BankPlugin.java
@@ -82,7 +82,7 @@ public class BankPlugin extends Plugin
 	private static final String SEED_VAULT_TITLE = "Seed Vault";
 
 	private static final String NUMBER_REGEX = "[0-9]+(\\.[0-9]+)?[kmb]?";
-	private static final Pattern VALUE_SEARCH_PATTERN = Pattern.compile("^(?<mode>ge|ha|alch)?" +
+	private static final Pattern VALUE_SEARCH_PATTERN = Pattern.compile("^(?<mode>qty|ge|ha|alch)?" +
 		" *(((?<op>[<>=]|>=|<=) *(?<num>" + NUMBER_REGEX + "))|" +
 		"((?<num1>" + NUMBER_REGEX + ") *- *(?<num2>" + NUMBER_REGEX + ")))$", Pattern.CASE_INSENSITIVE);
 
@@ -413,13 +413,26 @@ public class BankPlugin extends Plugin
 		final int qty = itemQuantities.count(itemId);
 		final long gePrice = (long) itemManager.getItemPrice(itemId) * qty;
 		final long haPrice = (long) itemComposition.getHaPrice() * qty;
+		final boolean isPlaceholder = itemComposition.getPlaceholderTemplateId() != -1;
 
 		long value = Math.max(gePrice, haPrice);
 
 		final String mode = matcher.group("mode");
 		if (mode != null)
 		{
-			value = mode.toLowerCase().equals("ge") ? gePrice : haPrice;
+			switch (mode.toLowerCase())
+			{
+				case "qty":
+					value = isPlaceholder ? 0 : qty;
+					break;
+				case "ge":
+					value = gePrice;
+					break;
+				case "ha":
+				case "alch":
+					value = haPrice;
+					break;
+			}
 		}
 
 		final String op = matcher.group("op");

--- a/runelite-client/src/test/java/net/runelite/client/plugins/bank/BankPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/bank/BankPluginTest.java
@@ -101,9 +101,15 @@ public class BankPluginTest
 		assertTrue(bankPlugin.valueSearch(itemId, "ha 500k - 20.6m"));
 		assertTrue(bankPlugin.valueSearch(itemId, "ha > 940k"));
 
+		assertTrue(bankPlugin.valueSearch(itemId, "qty=0"));
+		assertTrue(bankPlugin.valueSearch(itemId, "qty<600"));
+
 		assertFalse(bankPlugin.valueSearch(itemId, "<500k"));
 		assertFalse(bankPlugin.valueSearch(itemId, "ha >2m"));
 		assertFalse(bankPlugin.valueSearch(itemId, "ge > 0.02b"));
+
+		assertFalse(bankPlugin.valueSearch(itemId, "qty=1"));
+		assertFalse(bankPlugin.valueSearch(itemId, "qty>30"));
 
 		assertFalse(bankPlugin.valueSearch(itemId, "1000k"));
 	}


### PR DESCRIPTION
Closes: #14814

Added bank search query for item quantities.

Note: Treating placeholders as quantity 0 by checking placeholderTemplateId

Examples:

![image](https://user-images.githubusercontent.com/17418745/161385172-ffc024c2-773d-4286-bf62-f71f7cf346ab.png)

![image](https://user-images.githubusercontent.com/17418745/161385196-d780a241-0d4e-4504-a964-19af54d3b749.png)

4/26 edit: Now using "qty" as the search term rather than "q"
