### PR TITLE
Ground Items: Show ground item text on mouse hover

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
@@ -100,10 +100,21 @@ public interface GroundItemsConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "showOnMouseHover",
+		name = "Show items on mouse hover",
+		description = "Configures whether or not to draw items when your mouse is hovering over the host tile",
+		position = 3
+	)
+	default boolean showOnMouseHover()
+	{
+		return false;
+	}
+
+	@ConfigItem(
 		keyName = "dontHideUntradeables",
 		name = "Do not hide untradeables",
 		description = "Configures whether or not untradeable items ignore hiding under settings",
-		position = 3
+		position = 4
 	)
 	default boolean dontHideUntradeables()
 	{
@@ -114,7 +125,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "showMenuItemQuantities",
 		name = "Show Menu Item Quantities",
 		description = "Configures whether or not to show the item quantities in the menu",
-		position = 4
+		position = 5
 	)
 	default boolean showMenuItemQuantities()
 	{
@@ -125,7 +136,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "recolorMenuHiddenItems",
 		name = "Recolor Menu Hidden Items",
 		description = "Configures whether or not hidden items in right-click menu will be recolored",
-		position = 5
+		position = 6
 	)
 	default boolean recolorMenuHiddenItems()
 	{
@@ -136,7 +147,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "deprioritizeHiddenItems",
 		name = "Deprioritize Menu Hidden Items",
 		description = "Depriotizies the menu options for items which are hidden, requiring a right click to pick up.",
-		position = 5
+		position = 7
 	)
 	default boolean deprioritizeHiddenItems()
 	{
@@ -147,7 +158,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "highlightTiles",
 		name = "Highlight Tiles",
 		description = "Configures whether or not to highlight tiles containing ground items",
-		position = 6
+		position = 8
 	)
 	default boolean highlightTiles()
 	{
@@ -158,7 +169,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "notifyHighlightedDrops",
 		name = "Notify for Highlighted drops",
 		description = "Configures whether or not to notify for drops on your highlighted list",
-		position = 7
+		position = 9
 	)
 	default boolean notifyHighlightedDrops()
 	{
@@ -169,7 +180,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "notifyTier",
 		name = "Notify tier",
 		description = "Configures which price tiers will trigger a notification on drop",
-		position = 8
+		position = 10
 	)
 	default HighlightTier notifyTier()
 	{
@@ -180,7 +191,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "priceDisplayMode",
 		name = "Price Display Mode",
 		description = "Configures which price types are shown alongside ground item name",
-		position = 9
+		position = 11
 	)
 	default PriceDisplayMode priceDisplayMode()
 	{
@@ -191,7 +202,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "itemHighlightMode",
 		name = "Item Highlight Mode",
 		description = "Configures how ground items will be highlighted",
-		position = 10
+		position = 12
 	)
 	default ItemHighlightMode itemHighlightMode()
 	{
@@ -202,7 +213,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "menuHighlightMode",
 		name = "Menu Highlight Mode",
 		description = "Configures what to highlight in right-click menu",
-		position = 11
+		position = 13
 	)
 	default MenuHighlightMode menuHighlightMode()
 	{
@@ -213,7 +224,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "highlightValueCalculation",
 		name = "Highlight Value Calculation",
 		description = "Configures which coin value is used to determine highlight color",
-		position = 12
+		position = 14
 	)
 	default ValueCalculationMode valueCalculationMode()
 	{
@@ -224,7 +235,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "hideUnderValue",
 		name = "Hide under value",
 		description = "Configures hidden ground items under both GE and HA value",
-		position = 13
+		position = 15
 	)
 	default int getHideUnderValue()
 	{
@@ -236,7 +247,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "defaultColor",
 		name = "Default items",
 		description = "Configures the color for default, non-highlighted items",
-		position = 14
+		position = 16
 	)
 	default Color defaultColor()
 	{
@@ -248,7 +259,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "highlightedColor",
 		name = "Highlighted items",
 		description = "Configures the color for highlighted items",
-		position = 15
+		position = 17
 	)
 	default Color highlightedColor()
 	{
@@ -260,7 +271,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "hiddenColor",
 		name = "Hidden items",
 		description = "Configures the color for hidden items in right-click menu and when holding ALT",
-		position = 16
+		position = 18
 	)
 	default Color hiddenColor()
 	{
@@ -272,7 +283,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "lowValueColor",
 		name = "Low value items",
 		description = "Configures the color for low value items",
-		position = 17
+		position = 19
 	)
 	default Color lowValueColor()
 	{
@@ -283,7 +294,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "lowValuePrice",
 		name = "Low value price",
 		description = "Configures the start price for low value items",
-		position = 18
+		position = 20
 	)
 	default int lowValuePrice()
 	{
@@ -295,7 +306,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "mediumValueColor",
 		name = "Medium value items",
 		description = "Configures the color for medium value items",
-		position = 19
+		position = 21
 	)
 	default Color mediumValueColor()
 	{
@@ -306,7 +317,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "mediumValuePrice",
 		name = "Medium value price",
 		description = "Configures the start price for medium value items",
-		position = 20
+		position = 22
 	)
 	default int mediumValuePrice()
 	{
@@ -318,7 +329,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "highValueColor",
 		name = "High value items",
 		description = "Configures the color for high value items",
-		position = 21
+		position = 23
 	)
 	default Color highValueColor()
 	{
@@ -329,7 +340,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "highValuePrice",
 		name = "High value price",
 		description = "Configures the start price for high value items",
-		position = 22
+		position = 24
 	)
 	default int highValuePrice()
 	{
@@ -341,7 +352,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "insaneValueColor",
 		name = "Insane value items",
 		description = "Configures the color for insane value items",
-		position = 23
+		position = 25
 	)
 	default Color insaneValueColor()
 	{
@@ -352,7 +363,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "insaneValuePrice",
 		name = "Insane value price",
 		description = "Configures the start price for insane value items",
-		position = 24
+		position = 26
 	)
 	default int insaneValuePrice()
 	{
@@ -363,7 +374,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "onlyShowLoot",
 		name = "Only show loot",
 		description = "Only shows drops from NPCs and players",
-		position = 25
+		position = 27
 	)
 	default boolean onlyShowLoot()
 	{
@@ -374,7 +385,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "doubleTapDelay",
 		name = "Double-tap delay",
 		description = "Delay for the double-tap ALT to hide ground items. 0 to disable.",
-		position = 26
+		position = 28
 	)
 	@Units(Units.MILLISECONDS)
 	default int doubleTapDelay()
@@ -386,7 +397,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "collapseEntries",
 		name = "Collapse ground item menu",
 		description = "Collapses ground item menu entries together and appends count",
-		position = 27
+		position = 29
 	)
 	default boolean collapseEntries()
 	{
@@ -397,7 +408,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "groundItemTimers",
 		name = "Despawn timer",
 		description = "Shows despawn timers for items you've dropped and received as loot",
-		position = 28
+		position = 30
 	)
 	default DespawnTimerMode groundItemTimers()
 	{
@@ -408,7 +419,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "textOutline",
 		name = "Text Outline",
 		description = "Use an outline around text instead of a text shadow",
-		position = 29
+		position = 31
 	)
 	default boolean textOutline()
 	{
@@ -419,7 +430,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "showLootbeamForHighlighted",
 		name = "Highlighted item lootbeams",
 		description = "Configures lootbeams to show for all highlighted items.",
-		position = 30
+		position = 32
 	)
 	default boolean showLootbeamForHighlighted()
 	{
@@ -430,7 +441,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "showLootbeamTier",
 		name = "Lootbeam tier",
 		description = "Configures which price tiers will trigger a lootbeam",
-		position = 31
+		position = 33
 	)
 	default HighlightTier showLootbeamTier()
 	{
@@ -441,7 +452,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "lootbeamStyle",
 		name = "Lootbeam Style",
 		description = "Style of lootbeam to use",
-		position = 32
+		position = 34
 	)
 	default Lootbeam.Style lootbeamStyle()
 	{
@@ -452,7 +463,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "hotkey",
 		name = "Hotkey",
 		description = "Configures the hotkey used by the Ground Items plugin",
-		position = 33
+		position = 35
 	)
 	default Keybind hotkey()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
@@ -185,16 +185,18 @@ public class GroundItemsOverlay extends Overlay
 		plugin.setHiddenBoxBounds(null);
 		plugin.setHighlightBoxBounds(null);
 
-		final boolean onlyShowLoot = config.onlyShowLoot();
 		final DespawnTimerMode groundItemTimers = config.groundItemTimers();
 		final boolean outline = config.textOutline();
 
 		for (GroundItem item : groundItemList)
 		{
 			final LocalPoint groundPoint = LocalPoint.fromWorld(client, item.getLocation());
+			final LocalPoint mouseTileLocation = client.getSelectedSceneTile().getLocalLocation();
 
 			if (groundPoint == null || localLocation.distanceTo(groundPoint) > MAX_DISTANCE
-				|| (onlyShowLoot && !item.isMine()))
+				|| (config.onlyShowLoot() && !item.isMine())
+				|| (config.showOnMouseHover() && mouseTileLocation != null
+					&& !(groundPoint.distanceTo(mouseTileLocation) == 0)))
 			{
 				continue;
 			}


### PR DESCRIPTION
Closes: #14798

Added new configurable setting to the Ground Items plugin that allows the user to display ground item text only when their mouse is hovering over the tile the item is on.

[Change in action (imgur gif)](https://i.imgur.com/UpVzLgo.mp4)

As of the first commit, having this new setting checked will block all ground items from showing regardless of value (unless you hover over the tile it's on*)


