### PR TITLE
Menu Entry Swapper: Add configurable house teleport swap options

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -24,6 +24,7 @@
  */
 package net.runelite.client.plugins.menuentryswapper;
 
+import lombok.RequiredArgsConstructor;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
@@ -612,10 +613,38 @@ public interface MenuEntrySwapperConfig extends Config
 		return true;
 	}
 
+	@RequiredArgsConstructor
+	enum HouseTeleportMode
+	{
+		CAST("Cast"),
+		OUTSIDE("Outside"),
+		GROUP_CHOOSE("Group: Choose"),
+		GROUP_PREVIOUS("Group: Previous");
+
+		private final String name;
+
+		@Override
+		public String toString()
+		{
+			return name;
+		}
+	}
+
+	@ConfigItem(
+		keyName = "swapHouseTeleportSpell",
+		name = "House teleport",
+		description = "Swap house teleport spell to a different destination on shift",
+		section = uiSection
+	)
+	default HouseTeleportMode swapHouseTeleportSpell()
+	{
+		return HouseTeleportMode.OUTSIDE;
+	}
+
 	@ConfigItem(
 		keyName = "swapTeleportSpell",
 		name = "Shift-click teleport spells",
-		description = "Swap teleport spells that have a second destination on shift",
+		description = "Swap teleport spells that have a second destination, except for teleport to house, on shift",
 		section = uiSection
 	)
 	default boolean swapTeleportSpell()
@@ -659,8 +688,7 @@ public interface MenuEntrySwapperConfig extends Config
 	@ConfigItem(
 		keyName = "swapGEAbort",
 		name = "GE Abort",
-		description = "Swap abort offer on Grand Exchange offers when shift-clicking"
-		,
+		description = "Swap abort offer on Grand Exchange offers when shift-clicking",
 		section = uiSection
 	)
 	default boolean swapGEAbort()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -423,7 +423,11 @@ public class MenuEntrySwapperPlugin extends Plugin
 		swapTeleport("varrock teleport", "grand exchange");
 		swapTeleport("camelot teleport", "seers'");
 		swapTeleport("watchtower teleport", "yanille");
-		swapTeleport("teleport to house", "outside");
+
+		swapHouseTeleport("cast", () -> shiftModifier() && config.swapHouseTeleportSpell() == MenuEntrySwapperConfig.HouseTeleportMode.CAST);
+		swapHouseTeleport("outside", () -> shiftModifier() && config.swapHouseTeleportSpell() == MenuEntrySwapperConfig.HouseTeleportMode.OUTSIDE);
+		swapHouseTeleport("group: choose", () -> shiftModifier() && config.swapHouseTeleportSpell() == MenuEntrySwapperConfig.HouseTeleportMode.GROUP_CHOOSE);
+		swapHouseTeleport("group: previous", () -> shiftModifier() && config.swapHouseTeleportSpell() == MenuEntrySwapperConfig.HouseTeleportMode.GROUP_PREVIOUS);
 
 		swap("eat", "guzzle", config::swapRockCake);
 
@@ -457,6 +461,12 @@ public class MenuEntrySwapperPlugin extends Plugin
 	{
 		swap("cast", option, swappedOption, () -> shiftModifier() && config.swapTeleportSpell());
 		swap(swappedOption, option, "cast", () -> shiftModifier() && config.swapTeleportSpell());
+	}
+
+	private void swapHouseTeleport(String swappedOption, Supplier<Boolean> enabled)
+	{
+		swap("cast", "teleport to house", swappedOption, enabled);
+		swap("outside", "teleport to house", swappedOption, enabled);
 	}
 
 	@Subscribe


### PR DESCRIPTION
Closes: #14813

Added new picklist in the UI section of the Menu Entry Swapper plugin to control what destination 'teleport to house' should take.

This is needed because Jagex added new right-click teleport options for group ironmen.

The new picklist of options can only be utilized if the 'shift-click teleport spells' checkbox is also checked*

GIM teleport example:
![shiftClickGIMtele](https://user-images.githubusercontent.com/17418745/161442990-02f29dc6-ff7e-47c6-b588-35acf651803a.gif)

Non-GIM teleport example:
![nonGimExample](https://user-images.githubusercontent.com/17418745/161442996-554b6f1e-59e4-43b4-8089-b34c82c62e63.gif)

