### PR TITLE
[Wiki Plugin] Wiki search keyboard shortcut & KeyListener priority mechanism

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/input/KeyListener.java
+++ b/runelite-client/src/main/java/net/runelite/client/input/KeyListener.java
@@ -26,8 +26,20 @@ package net.runelite.client.input;
 
 public interface KeyListener extends java.awt.event.KeyListener
 {
+	enum Priority {
+		HIGH,
+		MEDIUM,
+		NONE,
+		LOW
+	}
+
 	default boolean isEnabledOnLoginScreen()
 	{
 		return false;
+	}
+
+	default Priority getPriority()
+	{
+		return Priority.NONE;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/bank/BankPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/bank/BankPlugin.java
@@ -138,6 +138,11 @@ public class BankPlugin extends Plugin
 		public void keyReleased(KeyEvent e)
 		{
 		}
+
+		@Override
+		public Priority getPriority() {
+			return Priority.HIGH;
+		}
 	};
 
 	@Provides

--- a/runelite-client/src/main/java/net/runelite/client/plugins/wiki/WikiConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/wiki/WikiConfig.java
@@ -27,6 +27,10 @@ package net.runelite.client.plugins.wiki;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.Keybind;
+
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
 
 @ConfigGroup(WikiPlugin.CONFIG_GROUP_KEY)
 public interface WikiConfig extends Config
@@ -40,5 +44,27 @@ public interface WikiConfig extends Config
 	default boolean leftClickSearch()
 	{
 		return false;
+	}
+
+	@ConfigItem(
+			keyName = "searchShortcut",
+			name = "Enable Search Shortcut",
+			description = "Enables keyboard shortcut for initiating a wiki search",
+			position = 2
+	)
+	default boolean searchShortcut()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+			keyName = "searchKeybinding",
+			name = "Search Shortcut",
+			description = "Keyboard shortcut for initiating a wiki search",
+			position = 3
+	)
+	default Keybind searchKeybinding()
+	{
+		return new Keybind(KeyEvent.VK_F, InputEvent.CTRL_DOWN_MASK);
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/wiki/WikiPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/wiki/WikiPlugin.java
@@ -25,6 +25,8 @@
 package net.runelite.client.plugins.wiki;
 
 import com.google.inject.Provides;
+
+import java.awt.event.KeyEvent;
 import java.util.Arrays;
 import java.util.stream.Stream;
 import javax.inject.Inject;
@@ -56,6 +58,8 @@ import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.events.ConfigChanged;
 import net.runelite.client.game.ItemManager;
+import net.runelite.client.input.KeyListener;
+import net.runelite.client.input.KeyManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.JagexColors;
@@ -90,6 +94,9 @@ public class WikiPlugin extends Plugin
 	private ItemManager itemManager;
 
 	@Inject
+	private KeyManager keyManager;
+
+	@Inject
 	private Provider<WikiSearchChatboxTextInput> wikiSearchChatboxTextInputProvider;
 
 	private Widget icon;
@@ -107,14 +114,45 @@ public class WikiPlugin extends Plugin
 	@Override
 	public void startUp()
 	{
+
+		keyManager.registerKeyListener(searchHotkeyListener);
 		clientThread.invokeLater(this::addWidgets);
 	}
 
 	@Override
 	public void shutDown()
 	{
+		keyManager.unregisterKeyListener(searchHotkeyListener);
 		clientThread.invokeLater(this::removeWidgets);
 	}
+
+	private final KeyListener searchHotkeyListener = new KeyListener()
+	{
+		@Override
+		public void keyTyped(KeyEvent e)
+		{
+		}
+
+		@Override
+		public void keyPressed(KeyEvent e)
+		{
+			if (!config.searchShortcut())
+				return;
+
+			if (config.searchKeybinding().matches(e))
+			{
+				log.debug("Wiki Search hotkey pressed");
+
+				openSearchInput();
+				e.consume();
+			}
+		}
+
+		@Override
+		public void keyReleased(KeyEvent e)
+		{
+		}
+	};
 
 	private void removeWidgets()
 	{

--- a/runelite-client/src/test/java/net/runelite/client/input/KeyManagerTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/input/KeyManagerTest.java
@@ -1,0 +1,269 @@
+package net.runelite.client.input;
+
+import java.awt.event.KeyEvent;
+import java.util.*;
+
+import com.google.inject.testing.fieldbinder.Bind;
+import net.runelite.api.Client;
+import org.junit.Test;
+import org.mockito.Mock;
+
+import static org.junit.Assert.assertEquals;
+
+public class KeyManagerTest {
+
+    @Mock
+    @Bind
+    private Client client;
+
+    @Test
+    public void testRegistrationOrder()
+    {
+        KeyManager keyManager = new KeyManager(client);
+
+        KeyListener keyListenerA = new KeyListener() {
+            @Override
+            public void keyTyped(KeyEvent e) {
+            }
+
+            @Override
+            public void keyPressed(KeyEvent e) {
+            }
+
+            @Override
+            public void keyReleased(KeyEvent e) {
+            }
+        };
+
+        KeyListener keyListenerB = new KeyListener() {
+            @Override
+            public void keyTyped(KeyEvent e) {
+            }
+
+            @Override
+            public void keyPressed(KeyEvent e) {
+            }
+
+            @Override
+            public void keyReleased(KeyEvent e) {
+            }
+        };
+
+        keyManager.registerKeyListener(keyListenerA);
+        keyManager.registerKeyListener(keyListenerB);
+
+        Iterator<KeyListener> iterator = keyManager.keyListenerMap.values().iterator();
+
+        for (KeyListener keyListener : Arrays.asList(keyListenerA, keyListenerB)) {
+            assertEquals(iterator.next(), keyListener);
+        }
+    }
+
+
+    @Test
+    public void testPriorityOrder()
+    {
+        KeyManager keyManager = new KeyManager(client);
+
+        KeyListener keyListenerNone = new KeyListener() {
+            @Override
+            public void keyTyped(KeyEvent e) {
+            }
+
+            @Override
+            public void keyPressed(KeyEvent e) {
+            }
+
+            @Override
+            public void keyReleased(KeyEvent e) {
+            }
+
+            @Override
+            public Priority getPriority() {
+                return Priority.NONE;
+            }
+        };
+
+        KeyListener keyListenerLow = new KeyListener() {
+            @Override
+            public void keyTyped(KeyEvent e) {
+            }
+
+            @Override
+            public void keyPressed(KeyEvent e) {
+            }
+
+            @Override
+            public void keyReleased(KeyEvent e) {
+            }
+
+            @Override
+            public Priority getPriority() {
+                return Priority.LOW;
+            }
+        };
+
+        KeyListener keyListenerMedium = new KeyListener() {
+            @Override
+            public void keyTyped(KeyEvent e) {
+            }
+
+            @Override
+            public void keyPressed(KeyEvent e) {
+            }
+
+            @Override
+            public void keyReleased(KeyEvent e) {
+            }
+
+            @Override
+            public Priority getPriority() {
+                return Priority.MEDIUM;
+            }
+        };
+
+        KeyListener keyListenerHigh = new KeyListener() {
+            @Override
+            public void keyTyped(KeyEvent e) {
+            }
+
+            @Override
+            public void keyPressed(KeyEvent e) {
+            }
+
+            @Override
+            public void keyReleased(KeyEvent e) {
+            }
+
+            @Override
+            public Priority getPriority() {
+                return Priority.HIGH;
+            }
+        };
+
+        keyManager.registerKeyListener(keyListenerNone);
+        keyManager.registerKeyListener(keyListenerMedium);
+        keyManager.registerKeyListener(keyListenerHigh);
+        keyManager.registerKeyListener(keyListenerLow);
+
+        Iterator<KeyListener> iterator = keyManager.keyListenerMap.values().iterator();
+
+        for (KeyListener keyListener : Arrays.asList(keyListenerHigh, keyListenerMedium, keyListenerNone, keyListenerLow)) {
+            assertEquals(iterator.next(), keyListener);
+        }
+    }
+
+
+    @Test
+    public void testPriorityAndLoadOrder()
+    {
+        KeyManager keyManager = new KeyManager(client);
+
+        KeyListener keyListenerNone = new KeyListener() {
+            @Override
+            public void keyTyped(KeyEvent e) {
+            }
+
+            @Override
+            public void keyPressed(KeyEvent e) {
+            }
+
+            @Override
+            public void keyReleased(KeyEvent e) {
+            }
+
+            @Override
+            public Priority getPriority() {
+                return Priority.NONE;
+            }
+        };
+
+        KeyListener keyListenerLow = new KeyListener() {
+            @Override
+            public void keyTyped(KeyEvent e) {
+            }
+
+            @Override
+            public void keyPressed(KeyEvent e) {
+            }
+
+            @Override
+            public void keyReleased(KeyEvent e) {
+            }
+
+            @Override
+            public Priority getPriority() {
+                return Priority.LOW;
+            }
+        };
+
+        KeyListener keyListenerMediumA = new KeyListener() {
+            @Override
+            public void keyTyped(KeyEvent e) {
+            }
+
+            @Override
+            public void keyPressed(KeyEvent e) {
+            }
+
+            @Override
+            public void keyReleased(KeyEvent e) {
+            }
+
+            @Override
+            public Priority getPriority() {
+                return Priority.MEDIUM;
+            }
+        };
+
+        KeyListener keyListenerMediumB = new KeyListener() {
+            @Override
+            public void keyTyped(KeyEvent e) {
+            }
+
+            @Override
+            public void keyPressed(KeyEvent e) {
+            }
+
+            @Override
+            public void keyReleased(KeyEvent e) {
+            }
+
+            @Override
+            public Priority getPriority() {
+                return Priority.MEDIUM;
+            }
+        };
+
+        KeyListener keyListenerHigh = new KeyListener() {
+            @Override
+            public void keyTyped(KeyEvent e) {
+            }
+
+            @Override
+            public void keyPressed(KeyEvent e) {
+            }
+
+            @Override
+            public void keyReleased(KeyEvent e) {
+            }
+
+            @Override
+            public Priority getPriority() {
+                return Priority.HIGH;
+            }
+        };
+
+        keyManager.registerKeyListener(keyListenerNone);
+        keyManager.registerKeyListener(keyListenerMediumA);
+        keyManager.registerKeyListener(keyListenerHigh);
+        keyManager.registerKeyListener(keyListenerMediumB);
+        keyManager.registerKeyListener(keyListenerLow);
+
+        Iterator<KeyListener> iterator = keyManager.keyListenerMap.values().iterator();
+
+        for (KeyListener keyListener : Arrays.asList(keyListenerHigh, keyListenerMediumA, keyListenerMediumB, keyListenerNone, keyListenerLow)) {
+            assertEquals(iterator.next(), keyListener);
+        }
+    }
+}


### PR DESCRIPTION
Have added the ability to enable and customize a keyboard shortcut to open wiki search.
In order to safely do this and not override the existing bank search shortcut, I have introduced a KeyListener priority mechanism.

By default every keyListener has the same priority (`NONE`) meaning they are serviced in the order they were registered. This can now be customized by implementing the `KeyListener::getPriority` method to return a different `KeyListener::Priority` value. KeyListeners are then serviced in order of priority (`HIGH`, `MEDIUM`, `NONE`, `LOW`) followed by registration order.

![image](https://user-images.githubusercontent.com/20365453/161512630-9fcdb251-ed2f-4907-9570-55958bb7e3eb.png)
