### PR TITLE
npcaggro: fix unintended loss of calibration

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/npcunaggroarea/AggressionTimer.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npcunaggroarea/AggressionTimer.java
@@ -29,22 +29,17 @@ import java.awt.image.BufferedImage;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
-import lombok.Getter;
-import lombok.Setter;
-import net.runelite.client.plugins.Plugin;
 import net.runelite.client.ui.overlay.infobox.Timer;
 
 class AggressionTimer extends Timer
 {
-	@Getter
-	@Setter
-	private boolean visible;
+	private final NpcAggroAreaPlugin plugin;
 
-	AggressionTimer(Duration duration, BufferedImage image, Plugin plugin, boolean visible)
+	AggressionTimer(Duration duration, BufferedImage image, NpcAggroAreaPlugin plugin)
 	{
 		super(duration.toMillis(), ChronoUnit.MILLIS, image, plugin);
 		setTooltip("Time until NPCs become unaggressive");
-		this.visible = visible;
+		this.plugin = plugin;
 	}
 
 	@Override
@@ -63,6 +58,6 @@ class AggressionTimer extends Timer
 	@Override
 	public boolean render()
 	{
-		return visible && super.render();
+		return plugin.shouldDisplayTimer() && super.render();
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/npcunaggroarea/NpcAggroAreaOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npcunaggroarea/NpcAggroAreaOverlay.java
@@ -84,8 +84,7 @@ class NpcAggroAreaOverlay extends Overlay
 		}
 
 		Color outlineColor = config.unaggroAreaColor();
-		AggressionTimer timer = plugin.getCurrentTimer();
-		if (outlineColor == null || timer == null || Instant.now().compareTo(timer.getEndTime()) < 0)
+		if (outlineColor == null || (plugin.getEndTime() != null && Instant.now().isBefore(plugin.getEndTime())))
 		{
 			outlineColor = config.aggroAreaColor();
 		}


### PR DESCRIPTION
After using 8ad5977ad5ef61ea84cb89a89956402e951b013f for a while, I noticed that the plugin would lose calibration seemingly at random. Given I was sitting at Redwoods, this didn't make sense. I want to give some context as to what was happening and why, baked permanently into the commit history:

The plugin requires that a few things exist when it saves data, or else it assumes that something went wrong and it resets the config. One of these things is that the infobox object exists.
Usually, this is fine, as one is created on login with the stored duration, as long as said duration is not negative.
However, if the user stood in the same area for 10 minutes and then logged out somehow (either manually or through AFK), upon logging back in the config would not create a new infobox as the stored duration is negative.
Either toggling the plugin or restarting the client at this point would clear the reference to the old Infobox, and a new one would not be created on login due to the aforementioned negative duration.
If the plugin was toggled, the calibration is instantly lost, and the user now sees the tutorial overlay.
If the client was restarted, it would appear as if the plugin is working fine, and it would fix itself if the player moved far enough. If they just logged out, however, it would clear its config.
Either way, in most situations, the user is now forced to recalibrate the plugin when they've done nothing wrong, only commited the heinous crime of XP wasting.

Most of this was due to how the plugin tracked the aggro time, which was through its infobox. This really shouldn't be how it does it, and so now it keeps track of the time separately, and doesn't rely on the creation of the infobox to block the saving of data.