### PR TITLE
screenshot: don't take a screenshot while the Notifier is flashing

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/Notifier.java
+++ b/runelite-client/src/main/java/net/runelite/client/Notifier.java
@@ -507,4 +507,9 @@ public class Notifier
 		}
 		return false;
 	}
+
+	public boolean isFlashing()
+	{
+		return flashStart != null;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotOverlay.java
@@ -40,6 +40,7 @@ import java.util.function.Consumer;
 import javax.inject.Inject;
 import net.runelite.api.Client;
 import net.runelite.api.MainBufferProvider;
+import net.runelite.client.Notifier;
 import net.runelite.client.ui.DrawManager;
 import net.runelite.client.ui.FontManager;
 import net.runelite.client.ui.overlay.Overlay;
@@ -55,11 +56,12 @@ class ScreenshotOverlay extends Overlay
 	private final Client client;
 	private final DrawManager drawManager;
 	private final ScreenshotPlugin plugin;
+	private final Notifier notifier;
 
 	private final Queue<Consumer<Image>> consumers = new ConcurrentLinkedQueue<>();
 
 	@Inject
-	private ScreenshotOverlay(Client client, DrawManager drawManager, ScreenshotPlugin plugin)
+	private ScreenshotOverlay(Client client, DrawManager drawManager, ScreenshotPlugin plugin, Notifier notifier)
 	{
 		setPosition(OverlayPosition.DYNAMIC);
 		setPriority(OverlayPriority.HIGH);
@@ -67,12 +69,13 @@ class ScreenshotOverlay extends Overlay
 		this.client = client;
 		this.drawManager = drawManager;
 		this.plugin = plugin;
+		this.notifier = notifier;
 	}
 
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
-		if (consumers.isEmpty())
+		if (consumers.isEmpty() || notifier.isFlashing())
 		{
 			return null;
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
@@ -72,6 +72,7 @@ import static net.runelite.api.widgets.WidgetID.LEVEL_UP_GROUP_ID;
 import static net.runelite.api.widgets.WidgetID.QUEST_COMPLETED_GROUP_ID;
 import static net.runelite.api.widgets.WidgetID.THEATRE_OF_BLOOD_REWARD_GROUP_ID;
 import net.runelite.api.widgets.WidgetInfo;
+import net.runelite.client.Notifier;
 import static net.runelite.client.RuneLite.SCREENSHOT_DIR;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
@@ -188,6 +189,9 @@ public class ScreenshotPlugin extends Plugin
 
 	@Inject
 	private ImageCapture imageCapture;
+
+	@Inject
+	private Notifier notifier;
 
 	@Getter(AccessLevel.PACKAGE)
 	private BufferedImage reportButton;


### PR DESCRIPTION
Close #12309

This change adds isFlashing() to the Notifier class and has the ScreenShotOverlay only take screenshots when the Notifier isn't flashing.