### PR TITLE
Optimizations to speed up startup, use less memory

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/externalplugins/ExternalPluginClient.java
+++ b/runelite-client/src/main/java/net/runelite/client/externalplugins/ExternalPluginClient.java
@@ -32,7 +32,6 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.nio.charset.StandardCharsets;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.security.Signature;
@@ -104,7 +103,8 @@ public class ExternalPluginClient
 				throw new VerificationException("Unable to verify external plugin manifest");
 			}
 
-			return gson.fromJson(new String(data, StandardCharsets.UTF_8),
+			return gson.fromJson(
+				new InputStreamReader(new ByteArrayInputStream(data)),
 				new TypeToken<List<ExternalPluginManifest>>()
 				{
 				}.getType());

--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/PluginListPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/PluginListPanel.java
@@ -202,7 +202,7 @@ class PluginListPanel extends PluginPanel
 					PluginDescriptor descriptor = plugin.getClass().getAnnotation(PluginDescriptor.class);
 					Config config = pluginManager.getPluginConfigProxy(plugin);
 					ConfigDescriptor configDescriptor = config == null ? null : configManager.getConfigDescriptor(config);
-					List<String> conflicts = pluginManager.conflictsForPlugin(plugin).stream()
+					List<String> conflicts = pluginManager.conflictsForPlugin(plugin)
 						.map(Plugin::getName)
 						.collect(Collectors.toList());
 


### PR DESCRIPTION
Optimization: prefer passing Streams to functions over passing newly
created Collections.
Optimization: load plugin classes in parallel. Reduces startup time by
~200ms out of 4s startup time on my computer.

My goal with this PR was to improve runelite startup time by using parallel streams. Doing so required some changes in seemingly unrelated files. I also noticed allocations in a few spots that could be switched to serial streams or in one case an iterator.

I tested many of the changes with a simple/stupid `System.currentTimeMillis()` around `pluginManager.load*` functions in `RuneLite.java`. I also simply tested the memory impact with this snippet https://stackoverflow.com/questions/40590414/monitor-java-objects-allocation-deallocation-in-a-specific-method .