### PR TITLE
Fixed custom notification sounds.

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/Notifier.java
+++ b/runelite-client/src/main/java/net/runelite/client/Notifier.java
@@ -471,11 +471,11 @@ public class Notifier
 				return;
 			}
 		}
-
-		// Using loop instead of start + setFramePosition prevents a the clip
+		// Using loop instead of start + setFramePosition prevents the clip
 		// from not being played sometimes, presumably a race condition in the
 		// underlying line driver
-		clip.loop(1);
+		clip.setFramePosition(0);
+		clip.loop(0);
 	}
 
 	private boolean tryLoadNotification()


### PR DESCRIPTION
This is relative to my own system (Linux), I'm unaware if this behaviour was different on other platforms.

Previously the first notification was played twice, and subsequent calls were mute.