### PR TITLE
plugin: Added config option to NpcAggroArea for hiding not working warning

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/npcunaggroarea/NpcAggroAreaConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npcunaggroarea/NpcAggroAreaConfig.java
@@ -128,4 +128,15 @@ public interface NpcAggroAreaConfig extends Config
 	{
 		return false;
 	}
+
+	@ConfigItem(
+			keyName = "hideWarning",
+			name = "Hide warning",
+			description = "Hides warning for plugin not working.",
+			position = 9
+	)
+	default boolean hideWarning()
+	{
+		return false;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/npcunaggroarea/NpcAggroAreaConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npcunaggroarea/NpcAggroAreaConfig.java
@@ -130,10 +130,10 @@ public interface NpcAggroAreaConfig extends Config
 	}
 
 	@ConfigItem(
-			keyName = "hideWarning",
-			name = "Hide warning",
-			description = "Hides warning for plugin not working.",
-			position = 9
+		keyName = "hideWarning",
+		name = "Hide warning",
+		description = "Hides warning for plugin not working.",
+		position = 9
 	)
 	default boolean hideWarning()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/npcunaggroarea/NpcAggroAreaNotWorkingOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npcunaggroarea/NpcAggroAreaNotWorkingOverlay.java
@@ -37,6 +37,9 @@ class NpcAggroAreaNotWorkingOverlay extends OverlayPanel
 	private final NpcAggroAreaPlugin plugin;
 
 	@Inject
+	private NpcAggroAreaConfig config;
+
+	@Inject
 	private NpcAggroAreaNotWorkingOverlay(NpcAggroAreaPlugin plugin)
 	{
 		this.plugin = plugin;
@@ -53,7 +56,7 @@ class NpcAggroAreaNotWorkingOverlay extends OverlayPanel
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
-		if (plugin.getSafeCenters()[1] != null)
+		if (config.hideWarning() || plugin.getSafeCenters()[1] != null)
 		{
 			return null;
 		}


### PR DESCRIPTION
Added an option to hide the warning that you have to teleport away or enter a dungeon to make the plugin work. This warning takes a lot of screen size and after using the plugin once you know how to fix it.