### PR TITLE
[TimersConfig] Change Arceuus Spell Cooldown default from false to true

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersConfig.java
@@ -281,7 +281,7 @@ public interface TimersConfig extends Config
 	)
 	default boolean showArceuusCooldown()
 	{
-		return false;
+		return true;
 	}
 
 	@ConfigItem(


### PR DESCRIPTION
Addresses #14866 

Changes the default option of the timer `Arceuus spells cooldown` from `false` -> `true`.

This was the only timer that was by default set to `false`, so it's pretty inconsistent.