### PR TITLE
implings: conditionally include current world in notification

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/implings/ImplingsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/implings/ImplingsConfig.java
@@ -383,4 +383,15 @@ public interface ImplingsConfig extends Config
 	{
 		return false;
 	}
+
+	@ConfigItem(
+		position = 28,
+		keyName = "showworld",
+		name = "Include current world",
+		description = "Configures whether or not the current world is included in the notification message"
+	)
+	default boolean showWorld()
+	{
+		return false;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/implings/ImplingsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/implings/ImplingsPlugin.java
@@ -28,6 +28,7 @@ import com.google.inject.Provides;
 import java.awt.Color;
 import java.util.function.Function;
 import javax.inject.Inject;
+import net.runelite.api.Client;
 import net.runelite.api.NPC;
 import net.runelite.api.events.NpcChanged;
 import net.runelite.api.events.NpcSpawned;
@@ -62,6 +63,9 @@ public class ImplingsPlugin extends Plugin
 
 	@Inject
 	private NpcOverlayService npcOverlayService;
+
+	@Inject
+	private Client client;
 
 	public final Function<NPC, HighlightedNpc> isTarget = (npc) ->
 	{
@@ -116,14 +120,7 @@ public class ImplingsPlugin extends Plugin
 	{
 		NPC npc = npcSpawned.getNpc();
 		Impling impling = Impling.findImpling(npc.getId());
-
-		if (impling != null)
-		{
-			if (showImplingType(impling.getImplingType()) == ImplingsConfig.ImplingMode.NOTIFY)
-			{
-				notifier.notify(impling.getImplingType().getName() + " impling is in the area");
-			}
-		}
+		notify(impling);
 	}
 
 	@Subscribe
@@ -131,12 +128,21 @@ public class ImplingsPlugin extends Plugin
 	{
 		NPC npc = npcCompositionChanged.getNpc();
 		Impling impling = Impling.findImpling(npc.getId());
+		notify(impling);
+	}
 
+	private void notify(final Impling impling)
+	{
 		if (impling != null)
 		{
 			if (showImplingType(impling.getImplingType()) == ImplingsConfig.ImplingMode.NOTIFY)
 			{
-				notifier.notify(impling.getImplingType().getName() + " impling is in the area");
+				String msg = impling.getImplingType().getName() + " impling is in the area";
+				if (config.showWorld())
+				{
+					msg += String.format(" (World: %d)", client.getWorld());
+				}
+				notifier.notify(msg);
 			}
 		}
 	}


### PR DESCRIPTION
Closes: https://github.com/runelite/runelite/issues/14899

- Adds configuration to the Implings plugin to include current world in the notification (i.e.: `(World: 467)`). 
- Consolidates logic from `onNpcSpawned` and `onNpcChanged` methods into one, `notify`. 

Feel free to close this if it's not wanted, haven't seen any requests for this besides that one issue linked above. 