### PR TITLE
Added .DS_Store to .gitignore for ease of access and security concerns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ project.properties
 .classpath
 .vscode
 .factorypath
+.DS_Store


### PR DESCRIPTION
.DS_Store is an invisible file created on MacOS that stores metadata about the files. They are similar to temp files like pycache or .vscode where they differ from programmer to programmer. This PR adds .DS_Store to .gitignore in order to make the coding environment more user-friendly for Macs and less cluttered for non-Mac users who have no use for all of these files.

It is also a safety thing, as shown below with this quote.
"Back in 2015, a .DS_Store file was exploited and used to gain access to an admin portal of the TCL Corporation, a multinational Chinese electronics company. The entire backend and database of the application were exposed to anyone that accessed the .DS_Store file." - Quote taken from [this link](https://buildthis.com/ds_store-files-and-why-you-should-know-about-them/)