### PR TITLE
clues: Fix capitalization for Dark Mage anagram

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java
@@ -230,7 +230,7 @@ public class AnagramClue extends ClueScroll implements TextClueScroll, NpcClueSc
 			.build(),
 		AnagramClue.builder()
 			.text("DEKAGRAM")
-			.npc("Dark mage")
+			.npc("Dark Mage")
 			.location(new WorldPoint(3039, 4835, 0))
 			.area("Centre of the Abyss")
 			.question("How many rifts are found here in the abyss?")

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java
@@ -231,7 +231,7 @@ public class AnagramClue extends ClueScroll implements TextClueScroll, NpcClueSc
 		AnagramClue.builder()
 			.text("DEKAGRAM")
 			.npc("Dark Mage")
-			.location(new WorldPoint(3039, 4835, 0))
+			.location(new WorldPoint(3039, 4834, 0))
 			.area("Centre of the Abyss")
 			.question("How many rifts are found here in the abyss?")
 			.answer("13")


### PR DESCRIPTION
It seems like the capitalization changed at some point, likely after GotR.

![image](https://user-images.githubusercontent.com/45152844/167315127-29e15451-4838-4782-880b-2b107c061c72.png)