### PR TITLE
timetracking: update panel on compost action

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/TimeTrackingPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/TimeTrackingPanel.java
@@ -43,6 +43,7 @@ import javax.swing.border.EmptyBorder;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.plugins.timetracking.clocks.ClockManager;
+import net.runelite.client.plugins.timetracking.farming.CompostTracker;
 import net.runelite.client.plugins.timetracking.farming.FarmingContractManager;
 import net.runelite.client.plugins.timetracking.farming.FarmingNextTickPanel;
 import net.runelite.client.plugins.timetracking.farming.FarmingTracker;
@@ -70,7 +71,7 @@ class TimeTrackingPanel extends PluginPanel
 
 	@Inject
 	TimeTrackingPanel(ItemManager itemManager, TimeTrackingConfig config, FarmingTracker farmingTracker,
-		BirdHouseTracker birdHouseTracker, ClockManager clockManager,
+		BirdHouseTracker birdHouseTracker, ClockManager clockManager, CompostTracker compostTracker,
 		FarmingContractManager farmingContractManager, ConfigManager configManager,
 		@Named("developerMode") boolean developerMode)
 	{
@@ -104,6 +105,8 @@ class TimeTrackingPanel extends PluginPanel
 		{
 			addTab(Tab.TIME_OFFSET, new FarmingNextTickPanel(farmingTracker, config, configManager));
 		}
+
+		compostTracker.onCompostAction(this::update);
 	}
 
 	private void addTab(Tab tab, TabContentPanel tabContentPanel)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/farming/CompostTracker.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/farming/CompostTracker.java
@@ -93,6 +93,8 @@ public class CompostTracker
 	private final FarmingWorld farmingWorld;
 	private final ConfigManager configManager;
 
+	private Runnable onCompostActionCallback = null;
+
 	@VisibleForTesting
 	final Map<FarmingPatch, PendingCompost> pendingCompostActions = new HashMap<>();
 
@@ -198,6 +200,10 @@ public class CompostTracker
 			{
 				setCompostState(pc.getFarmingPatch(), compostUsed);
 				pendingCompostActions.remove(pc.getFarmingPatch());
+				if (onCompostActionCallback != null)
+				{
+					onCompostActionCallback.run();
+				}
 			});
 	}
 
@@ -288,6 +294,11 @@ public class CompostTracker
 		}
 
 		return null;
+	}
+
+	public void onCompostAction(Runnable r)
+	{
+		onCompostActionCallback = r;
 	}
 
 }


### PR DESCRIPTION
Updates the side panel when a player composts/inspects a patch, rather than waiting for the side panel to update itself. This should help prevent confusion on whether the compost was applied in the interval between composting and the panel updating (up to 5 mins).

It seems more obvious to inject the TimeTrackingPanel into the CompostTracker, but this introduced a circular dependency, so I opted to use this callback-style update instead.