### PR TITLE
chat commands: Update clear word and clear line defaults

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsConfig.java
@@ -197,7 +197,7 @@ public interface ChatCommandsConfig extends Config
 	)
 	default Keybind clearSingleWord()
 	{
-		return new Keybind(KeyEvent.VK_W, InputEvent.CTRL_DOWN_MASK);
+		return new Keybind(KeyEvent.VK_BACK_SPACE, InputEvent.CTRL_DOWN_MASK);
 	}
 
 	@ConfigItem(
@@ -208,6 +208,6 @@ public interface ChatCommandsConfig extends Config
 	)
 	default Keybind clearChatBox()
 	{
-		return new Keybind(KeyEvent.VK_BACK_SPACE, InputEvent.CTRL_DOWN_MASK);
+		return Keybind.NOT_SET;
 	}
 }


### PR DESCRIPTION
Ctrl + backspace is an overwhelmingly common keybind for clearing the
word before the cursor. Meanwhile, clearing the current line is not as
common a keybind, so having an unset default is more sensible here for
users to decide for themselves what keybind they would prefer.

Closes #14754