### PR TITLE
clientui: setResizable after setVisible

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
@@ -488,7 +488,7 @@ public class ClientUI
 			}
 
 			// Update config
-			updateFrameConfig(true);
+			updateFrameConfig(false);
 
 			// Create hide sidebar button
 
@@ -596,6 +596,8 @@ public class ClientUI
 
 			// Show frame
 			frame.setVisible(true);
+			// On macos setResizable needs to be called after setVisible
+			frame.setResizable(!config.lockWindowSize());
 			frame.toFront();
 			requestFocus();
 			log.info("Showing frame {}", frame);


### PR DESCRIPTION
Prevents an issue with clients being resizable with toolbar-less means in some environments (e.g. double clicking title bar on macos).

Honestly I'm not entirely sure why this is ignored if the window isn't visible, rather than being propagated to the window manager when the window is shown, but I guess Swing isn't that smart (like always).

I originally found the information on [this SO answer](https://stackoverflow.com/a/14884056) and it seemed to resolve the issue. The original author seems similarly unsure about its internal mechanisms.

Closes #14235