### PR TITLE
Added abbreviations of popular items to the !price command

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
@@ -1344,12 +1344,13 @@ public class ChatCommandsPlugin extends Plugin
 
 		MessageNode messageNode = chatMessage.getMessageNode();
 		String search = message.substring(PRICE_COMMAND_STRING.length() + 1);
+		String longItemName = longItemName(search);
 
-		List<ItemPrice> results = itemManager.search(search);
+		List<ItemPrice> results = itemManager.search(longItemName);
 
 		if (!results.isEmpty())
 		{
-			ItemPrice item = retrieveFromList(results, search);
+			ItemPrice item = retrieveFromList(results, longItemName);
 
 			int itemId = item.getId();
 			int itemPrice = runeLiteConfig.useWikiItemPrices() ? itemManager.getWikiPrice(item) : item.getPrice();
@@ -1890,6 +1891,59 @@ public class ChatCommandsPlugin extends Plugin
 	{
 		private final String name;
 		private final HiscoreEndpoint endpoint;
+	}
+
+	private static String longItemName(String item) {
+		switch (item.toUpperCase()) {
+			case "ACB":
+				return "Armadyl crossbow";
+			case "ACP":
+				return "Armadyl chestplate";
+			case "ACS":
+				return "Armadyl chainskirt";
+			case "AGS":
+				return "Armadyl godsword";
+			case "BCP":
+				return "Bandos chestplate";
+			case "BGS":
+				return "Bandos godsword";
+			case "BOWFA":
+				return "Bow of faerdhinen (inactive)";
+			case "BP":
+				return "Toxic blowpipe (empty)";
+			case "BRING":
+				return "Berserker ring";
+			case "DCLAWS":
+				return "Dragon claws";
+			case "DFS":
+				return "Dragonfire shield";
+			case "ELY":
+				return "Elysian spirit shield";
+			case "PEGS":
+				return "Pegasian boots";
+			case "PRIMS":
+				return "Primordial boots";
+			case "RANGERS":
+				return "Ranger boots";
+			case "ROBIN":
+				return "Robin Hood hat";
+			case "ROS":
+				return "Ring of suffering";
+			case "SCYTHE":
+				return "Scythe of vitur (uncharged)";
+			case "SOTD":
+				return "Staff of the dead";
+			case "TBOW":
+				return "Twisted bow";
+			case "WHIP":
+				return "Abyssal whip";
+			case "ZGS":
+				return "Zamorak godsword";
+			case "ZSPEAR":
+				return "Zamorakian spear";
+
+			default: return item;
+		}
 	}
 
 	private static String longBossName(String boss)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
@@ -1893,8 +1893,10 @@ public class ChatCommandsPlugin extends Plugin
 		private final HiscoreEndpoint endpoint;
 	}
 
-	private static String longItemName(String item) {
-		switch (item.toUpperCase()) {
+	private static String longItemName(String item)
+	{
+		switch (item.toUpperCase())
+		{
 			case "ACB":
 				return "Armadyl crossbow";
 			case "ACP":

--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
@@ -1905,13 +1905,20 @@ public class ChatCommandsPlugin extends Plugin
 				return "Armadyl chainskirt";
 			case "AGS":
 				return "Armadyl godsword";
+			case "ANGUISH":
+				return "Necklace of anguish";
+			case "ARCANE":
+				return "Arcane spirit shield";
 			case "BCP":
 				return "Bandos chestplate";
 			case "BGS":
 				return "Bandos godsword";
+			case "BLADE":
+				return "Blade of saeldor (inactive)";
 			case "BOWFA":
 				return "Bow of faerdhinen (inactive)";
 			case "BP":
+			case "BLOWPIPE":
 				return "Toxic blowpipe (empty)";
 			case "BRING":
 				return "Berserker ring";
@@ -1919,24 +1926,50 @@ public class ChatCommandsPlugin extends Plugin
 				return "Dragon claws";
 			case "DFS":
 				return "Dragonfire shield";
+			case "DHCB":
+				return "Dragon hunter crossbow";
+			case "DHL":
+				return "Dragon hunter lance";
+			case "DWH":
+				return "Dragon warhammer";
 			case "ELY":
 				return "Elysian spirit shield";
+			case "FURY":
+				return "Amulet of fury";
+			case "KODAI":
+				return "Kodai wand";
+			case "OCCULT":
+				return "Occult necklace";
 			case "PEGS":
 				return "Pegasian boots";
 			case "PRIMS":
 				return "Primordial boots";
 			case "RANGERS":
 				return "Ranger boots";
+			case "RAPIER":
+				return "Ghrazi rapier";
 			case "ROBIN":
 				return "Robin Hood hat";
 			case "ROS":
+			case "SUFFERING":
 				return "Ring of suffering";
 			case "SCYTHE":
 				return "Scythe of vitur (uncharged)";
+			case "SERP":
+				return "Serpentine helm (uncharged)";
 			case "SOTD":
 				return "Staff of the dead";
+			case "SPECTRAL":
+				return "Spectral spirit shield";
 			case "TBOW":
 				return "Twisted bow";
+			case "TOME":
+				return "Tome of fire (empty)";
+			case "TORM":
+				return "Tormented bracelet";
+			case "TORT":
+			case "TORTURE":
+				return "Amulet of torture";
 			case "WHIP":
 				return "Abyssal whip";
 			case "ZGS":


### PR DESCRIPTION
Close #14517

Added commonly used abbreviations of popular items as input candidates to the `!price` command.

The list of abbreviations included in this PR may be expanded if deemed necessary.