### PR TITLE
Add gold vein respawn timer to mining plugin

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/mining/MiningPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/mining/MiningPlugin.java
@@ -41,11 +41,15 @@ import net.runelite.api.GameObject;
 import net.runelite.api.GameState;
 import static net.runelite.api.HintArrowType.WORLD_POSITION;
 import net.runelite.api.MenuAction;
+import static net.runelite.api.ObjectID.DEPLETED_VEIN;
 import static net.runelite.api.ObjectID.DEPLETED_VEIN_26665;
 import static net.runelite.api.ObjectID.DEPLETED_VEIN_26666;
 import static net.runelite.api.ObjectID.DEPLETED_VEIN_26667;
 import static net.runelite.api.ObjectID.DEPLETED_VEIN_26668;
 import static net.runelite.api.ObjectID.EMPTY_WALL;
+import static net.runelite.api.ObjectID.MINERAL_VEIN;
+import static net.runelite.api.ObjectID.MINERAL_VEIN_5990;
+import static net.runelite.api.ObjectID.MINERAL_VEIN_5991;
 import static net.runelite.api.ObjectID.ORE_VEIN_26661;
 import static net.runelite.api.ObjectID.ORE_VEIN_26662;
 import static net.runelite.api.ObjectID.ORE_VEIN_26663;
@@ -355,12 +359,22 @@ public class MiningPlugin extends Plugin
 				respawns.add(rockRespawn);
 				break;
 			}
+			case DEPLETED_VEIN: // Depleted gold vein
+			{
+				Rock rock = Rock.MINERAL_VEIN;
+				RockRespawn rockRespawn = new RockRespawn(rock, object.getWorldLocation(), Instant.now(), (int) rock.getRespawnTime(region).toMillis(), rock.getZOffset());
+				respawns.add(rockRespawn);
+				break;
+			}
 			case ORE_VEIN_26661: // Motherlode vein
 			case ORE_VEIN_26662: // Motherlode vein
 			case ORE_VEIN_26663: // Motherlode vein
 			case ORE_VEIN_26664: // Motherlode vein
 			case ROCKS_41547: // Barronite vein
 			case ROCKS_41548: // Barronite vein
+			case MINERAL_VEIN: // Arzinian gold vein
+			case MINERAL_VEIN_5990: // Gold vein
+			case MINERAL_VEIN_5991: // Gold vein
 			{
 				// If the vein respawns before the timer is up, remove it
 				final WorldPoint point = object.getWorldLocation();

--- a/runelite-client/src/main/java/net/runelite/client/plugins/mining/Rock.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/mining/Rock.java
@@ -98,7 +98,8 @@ enum Rock
 	TE_SALT(Duration.of(9, GAME_TICKS), 0, ROCKS_33256),
 	BASALT(Duration.of(9, GAME_TICKS), 0, ROCKS_33257),
 	DAEYALT_ESSENCE(Duration.of(MiningRocksOverlay.DAEYALT_MAX_RESPAWN_TIME, GAME_TICKS), 0, DAEYALT_ESSENCE_39095),
-	BARRONITE(Duration.of(89, GAME_TICKS), 140);
+	BARRONITE(Duration.of(89, GAME_TICKS), 140),
+	MINERAL_VEIN(Duration.of(100, GAME_TICKS), 150);
 
 	private static final int WILDERNESS_RESOURCE_AREA = 12605;
 	private static final int MISCELLANIA = 10044;


### PR DESCRIPTION
Add support for ore respawn timers on Mineral veins in [Dondakan's mine](https://oldschool.runescape.wiki/w/Dondakan%27s_mine).

Here is what it looks like:
<img width="657" alt="image" src="https://user-images.githubusercontent.com/2121068/172067630-a0cf2577-6006-408b-a4e1-71ae42c53731.png">