### PR TITLE
Update Cannon Plugin to use Varplayer Instead of Chat Messages

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/VarPlayer.java
+++ b/runelite-api/src/main/java/net/runelite/api/VarPlayer.java
@@ -39,6 +39,7 @@ import lombok.Getter;
 @Getter
 public enum VarPlayer
 {
+	CANNON_AMMO(3),
 	ATTACK_STYLE(43),
 	QUEST_POINTS(101),
 	IS_POISONED(102),

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonPlugin.java
@@ -30,7 +30,6 @@ import java.awt.Color;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.inject.Inject;
 import lombok.Getter;
@@ -43,22 +42,20 @@ import net.runelite.api.GameState;
 import net.runelite.api.GraphicID;
 import net.runelite.api.InventoryID;
 import net.runelite.api.Item;
-import net.runelite.api.ItemContainer;
 import net.runelite.api.ItemID;
 import net.runelite.api.MenuAction;
 import net.runelite.api.ObjectID;
 import net.runelite.api.Player;
-import net.runelite.api.Projectile;
+import net.runelite.api.VarPlayer;
 import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.coords.WorldArea;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.ChatMessage;
 import net.runelite.api.events.GameObjectSpawned;
 import net.runelite.api.events.GameStateChanged;
-import net.runelite.api.events.GameTick;
 import net.runelite.api.events.ItemContainerChanged;
 import net.runelite.api.events.MenuOptionClicked;
-import net.runelite.api.events.ProjectileMoved;
+import net.runelite.api.events.VarbitChanged;
 import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.Notifier;
@@ -90,7 +87,6 @@ public class CannonPlugin extends Plugin
 	);
 
 	private CannonCounter counter;
-	private boolean skipProjectileCheckThisTick;
 	private boolean cannonBallNotificationSent;
 	private WorldPoint clickedCannonLocation;
 	private boolean firstCannonLoad;
@@ -165,7 +161,6 @@ public class CannonPlugin extends Plugin
 		cannonBallNotificationSent = false;
 		cballsLeft = 0;
 		removeCounter();
-		skipProjectileCheckThisTick = false;
 		spotPoints.clear();
 	}
 
@@ -278,7 +273,7 @@ public class CannonPlugin extends Plugin
 			}
 		}
 	}
-	
+
 	@Subscribe
 	public void onMenuOptionClicked(MenuOptionClicked event)
 	{
@@ -309,33 +304,14 @@ public class CannonPlugin extends Plugin
 	}
 
 	@Subscribe
-	public void onProjectileMoved(ProjectileMoved event)
+	public void onVarbitChanged(VarbitChanged varbitChanged)
 	{
-		Projectile projectile = event.getProjectile();
+		cballsLeft = client.getVarpValue(VarPlayer.CANNON_AMMO.getId());
 
-		if (CANNONBALL_PROJECTILE_IDS.contains(projectile.getId()) && cannonPosition != null && cannonWorld == client.getWorld())
+		if (config.showCannonNotifications() && !cannonBallNotificationSent && cballsLeft > 0 && config.lowWarningThreshold() >= cballsLeft)
 		{
-			WorldPoint projectileLoc = WorldPoint.fromLocal(client, projectile.getX1(), projectile.getY1(), client.getPlane());
-
-			//Check to see if projectile x,y is 0 else it will continuously decrease while ball is flying.
-			if (cannonPosition.contains(projectileLoc) && projectile.getX() == 0 && projectile.getY() == 0)
-			{
-				// When there's a chat message about cannon reloaded/unloaded/out of ammo,
-				// the message event runs before the projectile event. However they run
-				// in the opposite order on the server. So if both fires in the same tick,
-				// we don't want to update the cannonball counter if it was set to a specific
-				// amount.
-				if (!skipProjectileCheckThisTick)
-				{
-					cballsLeft--;
-
-					if (config.showCannonNotifications() && !cannonBallNotificationSent && cballsLeft > 0 && config.lowWarningThreshold() >= cballsLeft)
-					{
-						notifier.notify(String.format("Your cannon has %d cannon balls remaining!", cballsLeft));
-						cannonBallNotificationSent = true;
-					}
-				}
-			}
+			notifier.notify(String.format("Your cannon has %d cannon balls remaining!", cballsLeft));
+			cannonBallNotificationSent = true;
 		}
 	}
 
@@ -351,32 +327,13 @@ public class CannonPlugin extends Plugin
 		{
 			cannonPlaced = true;
 			addCounter();
-			cballsLeft = 0;
 			firstCannonLoad = true;
-
-			final ItemContainer inventory = client.getItemContainer(InventoryID.INVENTORY);
-			if (inventory != null)
-			{
-				int invCballs = inventory.count(ItemID.GRANITE_CANNONBALL) > 0
-						? inventory.count(ItemID.GRANITE_CANNONBALL)
-						: inventory.count(ItemID.CANNONBALL);
-				// Cannonballs are always forcibly loaded after the furnace is added. If the player has more than
-				// the max number of cannon balls in their inventory, the cannon will always be fully filled.
-				// This is preferable to using the proceeding "You load the cannon with x cannon balls" message
-				// since it will show a lower number of cannon balls if the cannon is already partially-filled
-				// prior to being placed.
-				if (invCballs >= MAX_CBALLS)
-				{
-					cballsLeft = MAX_CBALLS;
-				}
-			}
 		}
 		else if (event.getMessage().contains("You pick up the cannon")
 			|| event.getMessage().contains("Your cannon has decayed. Speak to Nulodion to get a new one!")
 			|| event.getMessage().contains("Your cannon has been destroyed!"))
 		{
 			cannonPlaced = false;
-			cballsLeft = 0;
 			removeCounter();
 			cannonPosition = null;
 		}
@@ -410,81 +367,19 @@ public class CannonPlugin extends Plugin
 				clickedCannonLocation = null;
 			}
 
-			Matcher m = NUMBER_PATTERN.matcher(event.getMessage());
-			if (m.find())
-			{
-				// The cannon will usually refill to MAX_CBALLS, but if the
-				// player didn't have enough cannonballs in their inventory,
-				// it could fill up less than that. Filling the cannon to
-				// cballsLeft + amt is not always accurate though because our
-				// counter doesn't decrease if the player has been too far away
-				// from the cannon due to the projectiels not being in memory,
-				// so our counter can be higher than it is supposed to be.
-				int amt = Integer.valueOf(m.group());
-				if (cballsLeft + amt >= MAX_CBALLS)
-				{
-					skipProjectileCheckThisTick = true;
-					cballsLeft = MAX_CBALLS;
-				}
-				else
-				{
-					cballsLeft += amt;
-				}
-			}
-			else if (event.getMessage().equals("You load the cannon with one cannonball."))
-			{
-				if (cballsLeft + 1 >= MAX_CBALLS)
-				{
-					skipProjectileCheckThisTick = true;
-					cballsLeft = MAX_CBALLS;
-				}
-				else
-				{
-					cballsLeft++;
-				}
-			}
-
 			cannonBallNotificationSent = false;
 		}
 		else if (event.getMessage().contains("Your cannon is out of ammo!"))
 		{
-			skipProjectileCheckThisTick = true;
-
-			// If the player was out of range of the cannon, some cannonballs
-			// may have been used without the client knowing, so having this
-			// extra check is a good idea.
-			cballsLeft = 0;
-
 			if (config.showCannonNotifications())
 			{
 				notifier.notify("Your cannon is out of ammo!");
 			}
 		}
-		else if (event.getMessage().startsWith("Your cannon contains"))
-		{
-			Matcher m = NUMBER_PATTERN.matcher(event.getMessage());
-			if (m.find())
-			{
-				cballsLeft = Integer.parseInt(m.group());
-			}
-		}
-		else if (event.getMessage().startsWith("You unload your cannon and receive Cannonball")
-			|| event.getMessage().startsWith("You unload your cannon and receive Granite cannonball"))
-		{
-			skipProjectileCheckThisTick = true;
-
-			cballsLeft = 0;
-		}
 		else if (event.getMessage().equals("This isn't your cannon!") || event.getMessage().equals("This is not your cannon."))
 		{
 			clickedCannonLocation = null;
 		}
-	}
-
-	@Subscribe
-	public void onGameTick(GameTick event)
-	{
-		skipProjectileCheckThisTick = false;
 	}
 
 	Color getStateColor()
@@ -507,6 +402,9 @@ public class CannonPlugin extends Plugin
 		{
 			return;
 		}
+
+		// Update the cannonball count here for when the cannon is placed for the first time
+		cballsLeft = client.getVarpValue(VarPlayer.CANNON_AMMO.getId());
 
 		counter = new CannonCounter(itemManager.getImage(ItemID.CANNONBALL), this);
 		counter.setTooltip("Cannonballs");

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonPlugin.java
@@ -77,14 +77,8 @@ import net.runelite.client.ui.overlay.infobox.InfoBoxManager;
 @Slf4j
 public class CannonPlugin extends Plugin
 {
-	private static final Pattern NUMBER_PATTERN = Pattern.compile("([0-9]+)");
 	static final int MAX_OVERLAY_DISTANCE = 4100;
 	static final int MAX_CBALLS = 30;
-
-	private static final Set<Integer> CANNONBALL_PROJECTILE_IDS = ImmutableSet.of(
-		GraphicID.CANNONBALL, GraphicID.GRANITE_CANNONBALL,
-		GraphicID.CANNONBALL_OR, GraphicID.GRANITE_CANNONBALL_OR
-	);
 
 	private CannonCounter counter;
 	private boolean cannonBallNotificationSent;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonPlugin.java
@@ -24,13 +24,10 @@
  */
 package net.runelite.client.plugins.cannon;
 
-import com.google.common.collect.ImmutableSet;
 import com.google.inject.Provides;
 import java.awt.Color;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
-import java.util.regex.Pattern;
 import javax.inject.Inject;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -39,7 +36,6 @@ import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
 import net.runelite.api.GameObject;
 import net.runelite.api.GameState;
-import net.runelite.api.GraphicID;
 import net.runelite.api.InventoryID;
 import net.runelite.api.Item;
 import net.runelite.api.ItemID;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonPlugin.java
@@ -296,12 +296,15 @@ public class CannonPlugin extends Plugin
 	@Subscribe
 	public void onVarbitChanged(VarbitChanged varbitChanged)
 	{
-		cballsLeft = client.getVarpValue(VarPlayer.CANNON_AMMO.getId());
-
-		if (config.showCannonNotifications() && !cannonBallNotificationSent && cballsLeft > 0 && config.lowWarningThreshold() >= cballsLeft)
+		if (varbitChanged.getIndex() == VarPlayer.CANNON_AMMO.getId())
 		{
-			notifier.notify(String.format("Your cannon has %d cannon balls remaining!", cballsLeft));
-			cannonBallNotificationSent = true;
+			cballsLeft = client.getVarpValue(VarPlayer.CANNON_AMMO.getId());
+
+			if (config.showCannonNotifications() && !cannonBallNotificationSent && cballsLeft > 0 && config.lowWarningThreshold() >= cballsLeft)
+			{
+				notifier.notify(String.format("Your cannon has %d cannon balls remaining!", cballsLeft));
+				cannonBallNotificationSent = true;
+			}
 		}
 	}
 

--- a/runelite-client/src/test/java/net/runelite/client/plugins/cannon/CannonPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/cannon/CannonPluginTest.java
@@ -39,7 +39,6 @@ import net.runelite.client.game.ItemManager;
 import net.runelite.client.ui.overlay.OverlayManager;
 import net.runelite.client.ui.overlay.infobox.InfoBoxManager;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import org.junit.Before;
 import org.junit.Test;
@@ -97,7 +96,8 @@ public class CannonPluginTest
 	}
 
 	@Test
-	public void testAmmoCountOnPlace() {
+	public void testAmmoCountOnPlace()
+	{
 		ChatMessage ADD_FURNACE = new ChatMessage();
 		ADD_FURNACE.setType(ChatMessageType.SPAM);
 		ADD_FURNACE.setMessage("You add the furnace.");
@@ -116,7 +116,8 @@ public class CannonPluginTest
 	}
 
 	@Test
-	public void testCannonInfoBox() {
+	public void testCannonInfoBox()
+	{
 		when(config.showInfobox()).thenReturn(true);
 
 		ChatMessage ADD_FURNACE = new ChatMessage();
@@ -129,8 +130,10 @@ public class CannonPluginTest
 		assertEquals(0, plugin.getCballsLeft());
 		verify(infoBoxManager).addInfoBox(any(CannonCounter.class));
 	}
+
 	@Test
-	public void testThresholdNotificationShouldNotify() {
+	public void testThresholdNotificationShouldNotify()
+	{
 		when(config.showCannonNotifications()).thenReturn(true);
 		when(config.lowWarningThreshold()).thenReturn(10);
 
@@ -143,7 +146,8 @@ public class CannonPluginTest
 	}
 
 	@Test
-	public void testThresholdNotificationShouldNotifyOnce() {
+	public void testThresholdNotificationShouldNotifyOnce()
+	{
 		when(config.showCannonNotifications()).thenReturn(true);
 		when(config.lowWarningThreshold()).thenReturn(10);
 
@@ -168,7 +172,8 @@ public class CannonPluginTest
 	}
 
 	@Test
-	public void testThresholdNotificationsShouldNotNotify() {
+	public void testThresholdNotificationsShouldNotNotify()
+	{
 		when(config.showCannonNotifications()).thenReturn(true);
 		when(config.lowWarningThreshold()).thenReturn(0);
 
@@ -181,7 +186,8 @@ public class CannonPluginTest
 	}
 
 	@Test
-	public void testCannonOutOfAmmo() {
+	public void testCannonOutOfAmmo()
+	{
 		when(config.showCannonNotifications()).thenReturn(true);
 		ChatMessage cannonOutOfAmmo = new ChatMessage(null, ChatMessageType.GAMEMESSAGE, "", "Your cannon is out of ammo!", "", 0);
 

--- a/runelite-client/src/test/java/net/runelite/client/plugins/cannon/CannonPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/cannon/CannonPluginTest.java
@@ -41,6 +41,7 @@ import net.runelite.client.ui.overlay.infobox.InfoBoxManager;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import static org.mockito.ArgumentMatchers.any;
@@ -89,6 +90,14 @@ public class CannonPluginTest
 	@Bind
 	private OverlayManager overlayManager;
 
+	private static final VarbitChanged cannonAmmoChanged = new VarbitChanged();
+
+	@BeforeClass
+	public static void cannonVarpSetup()
+	{
+		cannonAmmoChanged.setIndex(VarPlayer.CANNON_AMMO.getId());
+	}
+
 	@Before
 	public void before()
 	{
@@ -105,13 +114,13 @@ public class CannonPluginTest
 		plugin.onChatMessage(ADD_FURNACE);
 		assertTrue(plugin.isCannonPlaced());
 
-		plugin.onVarbitChanged(new VarbitChanged());
+		plugin.onVarbitChanged(cannonAmmoChanged);
 		assertEquals(0, plugin.getCballsLeft());
 
 		// Some time passes...
 
 		when(client.getVarpValue(VarPlayer.CANNON_AMMO.getId())).thenReturn(30);
-		plugin.onVarbitChanged(new VarbitChanged());
+		plugin.onVarbitChanged(cannonAmmoChanged);
 		assertEquals(30, plugin.getCballsLeft());
 	}
 
@@ -138,9 +147,9 @@ public class CannonPluginTest
 		when(config.lowWarningThreshold()).thenReturn(10);
 
 		when(client.getVarpValue(VarPlayer.CANNON_AMMO.getId())).thenReturn(30);
-		plugin.onVarbitChanged(new VarbitChanged());
+		plugin.onVarbitChanged(cannonAmmoChanged);
 		when(client.getVarpValue(VarPlayer.CANNON_AMMO.getId())).thenReturn(10);
-		plugin.onVarbitChanged(new VarbitChanged());
+		plugin.onVarbitChanged(cannonAmmoChanged);
 
 		verify(notifier, times(1)).notify("Your cannon has 10 cannon balls remaining!");
 	}
@@ -152,21 +161,21 @@ public class CannonPluginTest
 		when(config.lowWarningThreshold()).thenReturn(10);
 
 		when(client.getVarpValue(VarPlayer.CANNON_AMMO.getId())).thenReturn(15);
-		plugin.onVarbitChanged(new VarbitChanged());
+		plugin.onVarbitChanged(cannonAmmoChanged);
 		when(client.getVarpValue(VarPlayer.CANNON_AMMO.getId())).thenReturn(14);
-		plugin.onVarbitChanged(new VarbitChanged());
+		plugin.onVarbitChanged(cannonAmmoChanged);
 		when(client.getVarpValue(VarPlayer.CANNON_AMMO.getId())).thenReturn(13);
-		plugin.onVarbitChanged(new VarbitChanged());
+		plugin.onVarbitChanged(cannonAmmoChanged);
 		when(client.getVarpValue(VarPlayer.CANNON_AMMO.getId())).thenReturn(12);
-		plugin.onVarbitChanged(new VarbitChanged());
+		plugin.onVarbitChanged(cannonAmmoChanged);
 		when(client.getVarpValue(VarPlayer.CANNON_AMMO.getId())).thenReturn(11);
-		plugin.onVarbitChanged(new VarbitChanged());
+		plugin.onVarbitChanged(cannonAmmoChanged);
 		when(client.getVarpValue(VarPlayer.CANNON_AMMO.getId())).thenReturn(10);
-		plugin.onVarbitChanged(new VarbitChanged());
+		plugin.onVarbitChanged(cannonAmmoChanged);
 		when(client.getVarpValue(VarPlayer.CANNON_AMMO.getId())).thenReturn(9);
-		plugin.onVarbitChanged(new VarbitChanged());
+		plugin.onVarbitChanged(cannonAmmoChanged);
 		when(client.getVarpValue(VarPlayer.CANNON_AMMO.getId())).thenReturn(8);
-		plugin.onVarbitChanged(new VarbitChanged());
+		plugin.onVarbitChanged(cannonAmmoChanged);
 
 		verify(notifier, times(1)).notify("Your cannon has 10 cannon balls remaining!");
 	}
@@ -178,9 +187,9 @@ public class CannonPluginTest
 		when(config.lowWarningThreshold()).thenReturn(0);
 
 		when(client.getVarpValue(VarPlayer.CANNON_AMMO.getId())).thenReturn(30);
-		plugin.onVarbitChanged(new VarbitChanged());
+		plugin.onVarbitChanged(cannonAmmoChanged);
 		when(client.getVarpValue(VarPlayer.CANNON_AMMO.getId())).thenReturn(10);
-		plugin.onVarbitChanged(new VarbitChanged());
+		plugin.onVarbitChanged(cannonAmmoChanged);
 
 		verify(notifier, times(0)).notify("Your cannon has 10 cannon balls remaining!");
 	}


### PR DESCRIPTION
VarPlayer `3` holds the player's current cannon ammo count. Previously, this VarPlayer could not be used as it did not provide cannon ammo count. This has since changed and is once again correctly providing the current ammo count. Related tests located in CannonPluginTest have been modified to accommodate these changes and pass accordingly.

I have tested these changes to the best of my abilities.

Disclaimer: This is my first time contributing to the RuneLite repo and my first time writing tests for a plugin. Please let me know if you find any issues or if there are any areas that can be improved. Thank you :)