### PR TITLE
Menu Entry Swapper: Add swap for tob supply chests

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -752,6 +752,17 @@ public interface MenuEntrySwapperConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "tobSupplyChestBuy",
+		name = "TOB Supply Chest Shift-Click",
+		description = "Swaps the Buy options with Value on items in shops when shift is held.",
+		section = uiSection
+	)
+	default TobChestBuyMode tobSupplyChestBuy()
+	{
+		return TobChestBuyMode.OFF;
+	}
+
+	@ConfigItem(
 		keyName = "swapEssenceMineTeleport",
 		name = "Essence Mine Teleport",
 		description = "Swaps Talk-To with Teleport for NPCs which teleport you to the essence mine",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -381,6 +381,10 @@ public class MenuEntrySwapperPlugin extends Plugin
 		swap("value", "sell 10", () -> shiftModifier() && config.shopSell() == SellMode.SELL_10);
 		swap("value", "sell 50", () -> shiftModifier() && config.shopSell() == SellMode.SELL_50);
 
+		swap("value", "buy-1", () -> shiftModifier() && config.tobSupplyChestBuy() == TobChestBuyMode.BUY_1);
+		swap("value", "buy-all", () -> shiftModifier() && config.tobSupplyChestBuy() == TobChestBuyMode.BUY_ALL);
+		swap("value", "buy-x", () -> shiftModifier() && config.tobSupplyChestBuy() == TobChestBuyMode.BUY_X);
+
 		swap("wear", "tele to poh", config::swapTeleToPoh);
 
 		swap("wear", "rub", config::swapTeleportItem);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/TobChestBuyMode.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/TobChestBuyMode.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2022, OsrsCommits <107307382+osrscommits@users.noreply.github.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.menuentryswapper;
+
+public enum TobChestBuyMode
+{
+	OFF,
+	BUY_1,
+	BUY_ALL,
+	BUY_X,
+}


### PR DESCRIPTION
Adds a new swap for tob chests. This was suspected to not automatically work the same as other stores due to the hyphen in the options (https://discord.com/channels/301497432909414422/301497432909414422/889618417156489257 for initial discussion).

Attached a video that shows the functionality. In the video, there's an extra dropdown option on the config for buy-5; I removed that afterwards as there isn't an option for that in the chest (at least not in this one; I thought there was, but maybe it's only on the second chest? I didn't actually check yet, and if it turns out there is, can add it afterwards).

https://user-images.githubusercontent.com/107307382/173491427-3da01454-f8ce-4dda-ba58-0058f36380af.mp4

Also attached some pictures of the options in the chest.

<img width="679" alt="mes-tob-chest-ss-1" src="https://user-images.githubusercontent.com/107307382/173491652-bbd13a43-05eb-43df-a04e-5671fa81aaf0.png">
<img width="592" alt="mes-tob-chest-ss-2" src="https://user-images.githubusercontent.com/107307382/173491653-fcbba437-5bcd-494b-81e9-8b22f11f49e4.png">
<img width="593" alt="mes-tob-chest-ss-3" src="https://user-images.githubusercontent.com/107307382/173491655-87054235-25ec-4e07-9d8f-0d685b073dde.png">

 