### PR TITLE
Change Loot tracker "Collapse / Un-collapse All" button tooltip text

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPanel.java
@@ -211,7 +211,7 @@ class LootTrackerPanel extends PluginPanel
 		SwingUtil.removeButtonDecorations(collapseBtn);
 		collapseBtn.setIcon(EXPAND_ICON);
 		collapseBtn.setSelectedIcon(COLLAPSE_ICON);
-		SwingUtil.addModalTooltip(collapseBtn, "Collapse All", "Un-Collapse All");
+		SwingUtil.addModalTooltip(collapseBtn, "Un-Collapse All", "Collapse All");
 		collapseBtn.setBackground(ColorScheme.DARKER_GRAY_COLOR);
 		collapseBtn.setUI(new BasicButtonUI()); // substance breaks the layout
 		collapseBtn.addActionListener(ev -> changeCollapse());


### PR DESCRIPTION
Change the modal text to be the correct action on the collapse button. After looking at the logic I believe that the this change makes the most sense as the button state should be 'on' if all loot boxes are collapsed.

This should resolve #15111 