### PR TITLE
[#14885] World Switcher - Pin favourite worlds to the top of the panel

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/FixedWidthPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/FixedWidthPanel.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2017, Adam <Adam@sigterm.info>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.worldhopper;
+
+import net.runelite.client.ui.PluginPanel;
+
+import javax.swing.*;
+import java.awt.*;
+
+class FixedWidthPanel extends JPanel
+{
+	@Override
+	public Dimension getPreferredSize()
+	{
+		return new Dimension(PluginPanel.PANEL_WIDTH, super.getPreferredSize().height);
+	}
+
+}


### PR DESCRIPTION
This change splits the World Switcher panel into 2 JScrollPanes - a pane for favourite worlds and a pane for the rest.

The favourite world pane will grow to fit 10 worlds, then a scroll bar appears after that.
The other pane fills the rest of the panel space.
There's a 12 px gap under the favourite worlds pane, so that they're seperated from the rest of the worlds.

![preview](https://user-images.githubusercontent.com/4104309/173947600-1a66e9f4-8aec-45d2-8a40-8117cd0bc5e3.png)

