### PR TITLE
Add 'remove all' button into the screen marker plugin

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenmarkers/ScreenMarkerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenmarkers/ScreenMarkerPlugin.java
@@ -253,6 +253,17 @@ public class ScreenMarkerPlugin extends Plugin
 		updateConfig();
 	}
 
+	public void deleteAllMarkers()
+	{
+		for(ScreenMarkerOverlay screenMarker : screenMarkers) {
+			overlayManager.remove(screenMarker);
+			overlayManager.resetOverlay(screenMarker);
+		}
+		screenMarkers.clear();
+		pluginPanel.rebuild();
+		updateConfig();
+	}
+
 	void resizeMarker(Point point)
 	{
 		drawingScreenMarker = true;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenmarkers/ScreenMarkerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenmarkers/ScreenMarkerPlugin.java
@@ -255,7 +255,8 @@ public class ScreenMarkerPlugin extends Plugin
 
 	public void deleteAllMarkers()
 	{
-		for(ScreenMarkerOverlay screenMarker : screenMarkers) {
+		for(ScreenMarkerOverlay screenMarker : screenMarkers)
+		{
 			overlayManager.remove(screenMarker);
 			overlayManager.resetOverlay(screenMarker);
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenmarkers/ui/ScreenMarkerPluginPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenmarkers/ui/ScreenMarkerPluginPanel.java
@@ -28,6 +28,7 @@ package net.runelite.client.plugins.screenmarkers.ui;
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Dimension;
+import java.awt.FlowLayout;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.event.MouseAdapter;
@@ -36,6 +37,7 @@ import java.awt.image.BufferedImage;
 import javax.swing.Box;
 import javax.swing.ImageIcon;
 import javax.swing.JLabel;
+import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.border.EmptyBorder;
 import lombok.Getter;
@@ -50,6 +52,8 @@ public class ScreenMarkerPluginPanel extends PluginPanel
 {
 	private static final ImageIcon ADD_ICON;
 	private static final ImageIcon ADD_HOVER_ICON;
+	private static final ImageIcon REMOVE_ALL_ICON;
+	private static final ImageIcon REMOVE_ALL_HOVER_ICON;
 
 	private static final Color DEFAULT_BORDER_COLOR = Color.GREEN;
 	private static final Color DEFAULT_FILL_COLOR = new Color(0, 255, 0, 0);
@@ -57,9 +61,11 @@ public class ScreenMarkerPluginPanel extends PluginPanel
 	private static final int DEFAULT_BORDER_THICKNESS = 3;
 
 	private final JLabel addMarker = new JLabel(ADD_ICON);
+	private final JLabel removeAllMarkers = new JLabel(REMOVE_ALL_ICON);
 	private final JLabel title = new JLabel();
 	private final PluginErrorPanel noMarkersPanel = new PluginErrorPanel();
 	private final JPanel markerView = new JPanel(new GridBagLayout());
+	private final JPanel markerControls = new JPanel(new FlowLayout());
 
 	private final ScreenMarkerPlugin plugin;
 
@@ -78,8 +84,11 @@ public class ScreenMarkerPluginPanel extends PluginPanel
 	static
 	{
 		final BufferedImage addIcon = ImageUtil.loadImageResource(ScreenMarkerPlugin.class, "add_icon.png");
+		final BufferedImage removeAllIcon = ImageUtil.loadImageResource(ScreenMarkerPlugin.class, "cancel_icon.png");
 		ADD_ICON = new ImageIcon(addIcon);
 		ADD_HOVER_ICON = new ImageIcon(ImageUtil.alphaOffset(addIcon, 0.53f));
+		REMOVE_ALL_ICON = new ImageIcon(removeAllIcon);
+		REMOVE_ALL_HOVER_ICON = new ImageIcon(ImageUtil.alphaOffset(removeAllIcon, 0.53f));
 	}
 
 	public ScreenMarkerPluginPanel(ScreenMarkerPlugin screenMarkerPlugin)
@@ -96,7 +105,10 @@ public class ScreenMarkerPluginPanel extends PluginPanel
 		title.setForeground(Color.WHITE);
 
 		northPanel.add(title, BorderLayout.WEST);
-		northPanel.add(addMarker, BorderLayout.EAST);
+		markerControls.add(removeAllMarkers);
+		markerControls.add(Box.createRigidArea(new Dimension(1, 0)));
+		markerControls.add(addMarker);
+		northPanel.add(markerControls, BorderLayout.EAST);
 
 		JPanel centerPanel = new JPanel(new BorderLayout());
 		centerPanel.setBackground(ColorScheme.DARK_GRAY_COLOR);
@@ -140,6 +152,35 @@ public class ScreenMarkerPluginPanel extends PluginPanel
 			public void mouseExited(MouseEvent mouseEvent)
 			{
 				addMarker.setIcon(ADD_ICON);
+			}
+		});
+
+		removeAllMarkers.setToolTipText("Remove all screen markers");
+		removeAllMarkers.addMouseListener(new MouseAdapter()
+		{
+			@Override
+			public void mousePressed(MouseEvent mouseEvent)
+			{
+				int confirm = JOptionPane.showConfirmDialog(ScreenMarkerPluginPanel.this,
+					"Are you sure you want to permanently delete ALL screen markers?",
+					"Warning", JOptionPane.OK_CANCEL_OPTION);
+
+				if (confirm == 0)
+				{
+					plugin.deleteAllMarkers();
+				}
+			}
+
+			@Override
+			public void mouseEntered(MouseEvent mouseEvent)
+			{
+				removeAllMarkers.setIcon(REMOVE_ALL_HOVER_ICON);
+			}
+
+			@Override
+			public void mouseExited(MouseEvent mouseEvent)
+			{
+				removeAllMarkers.setIcon(REMOVE_ALL_ICON);
 			}
 		});
 


### PR DESCRIPTION
This provides a single button to remove all the screen markers from the screen marker plugin.