### PR TITLE
party: spelling generatePassphrase

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/party/PartyService.java
+++ b/runelite-client/src/main/java/net/runelite/client/party/PartyService.java
@@ -90,7 +90,7 @@ public class PartyService
 		eventBus.register(this);
 	}
 
-	public String generatePasspharse()
+	public String generatePassphrase()
 	{
 		assert client.isClientThread();
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/party/PartyPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/party/PartyPanel.java
@@ -144,7 +144,7 @@ class PartyPanel extends PluginPanel
 			else
 			{
 				// Create party
-				clientThread.invokeLater(() -> party.changeParty(party.generatePasspharse()));
+				clientThread.invokeLater(() -> party.changeParty(party.generatePassphrase()));
 			}
 		});
 


### PR DESCRIPTION
Method was named incorrectly, `generatePasspharse` -> `generatePassphrase`.

~~In case any hub plugins are using this method, this adds a deprecated shim method of the original name.~~ It is not used by any hub plugins.