### PR TITLE
ChatCommands - Add support for hours in !pb

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
@@ -601,6 +601,20 @@ public class ChatCommandsPlugin extends Plugin
 		return Double.parseDouble(timeString);
 	}
 
+	@VisibleForTesting
+	static String secondsToTimeString(double seconds)
+	{
+		int hours = (int) (Math.floor(seconds) / 3600);
+		int minutes = (int) (Math.floor(seconds / 60) % 60);
+		seconds = seconds % 60;
+
+		String timeString = hours > 0 ? String.format("%d:%02d:", hours, minutes) : String.format("%d:", minutes);
+
+		// If the seconds is an integer, it is ambiguous if the pb is a precise
+		// pb or not. So we always show it without the trailing .00.
+		return timeString + (Math.floor(seconds) == seconds ? String.format("%02d", (int) seconds) : String.format("%05.2f", seconds));
+	}
+
 	private void matchPb(Matcher matcher)
 	{
 		double seconds = timeStringToSeconds(matcher.group("pb"));
@@ -1101,22 +1115,13 @@ public class ChatCommandsPlugin extends Plugin
 			return;
 		}
 
-		int minutes = (int) (Math.floor(pb) / 60);
-		double seconds = pb % 60;
-
-		// If the seconds is an integer, it is ambiguous if the pb is a precise
-		// pb or not. So we always show it without the trailing .00.
-		final String time = Math.floor(seconds) == seconds ?
-			String.format("%d:%02d", minutes, (int) seconds) :
-			String.format("%d:%05.2f", minutes, seconds);
-
 		String response = new ChatMessageBuilder()
 			.append(ChatColorType.HIGHLIGHT)
 			.append(search)
 			.append(ChatColorType.NORMAL)
 			.append(" personal best: ")
 			.append(ChatColorType.HIGHLIGHT)
-			.append(time)
+			.append(secondsToTimeString(pb))
 			.build();
 
 		log.debug("Setting response {}", response);

--- a/runelite-client/src/test/java/net/runelite/client/plugins/chatcommands/ChatCommandsPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/chatcommands/ChatCommandsPluginTest.java
@@ -1019,6 +1019,15 @@ public class ChatCommandsPluginTest
 	}
 
 	@Test
+	public void testSecondsToTimeString()
+	{
+		assertEquals("0:03.60", ChatCommandsPlugin.secondsToTimeString(3.6));
+		assertEquals("0:03", ChatCommandsPlugin.secondsToTimeString(3));
+		assertEquals("1:23:45.60", ChatCommandsPlugin.secondsToTimeString(5025.6));
+		assertEquals("8:00:00", ChatCommandsPlugin.secondsToTimeString(60 * 60 * 8));
+	}
+
+	@Test
 	public void testCounters()
 	{
 		final String[] log = {


### PR DESCRIPTION
This fixes #15122.

!pb will now format the time as:
- M:SS
- M:SS.mm
- H:MM:SS
- H:MM:SS.mm