### PR TITLE
Fix kourend elite diary requirement for blood runes task

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/KourendDiaryRequirement.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/KourendDiaryRequirement.java
@@ -107,7 +107,7 @@ public class KourendDiaryRequirement extends GenericDiaryRequirement
 			new QuestRequirement(Quest.DREAM_MENTOR));
 
 		//ELITE
-		add("Craft one or more Blood runes from Essence.",
+		add("Craft one or more Blood runes from Dark essence fragments.",
 			new SkillRequirement(Skill.RUNECRAFT, 77),
 			new SkillRequirement(Skill.MINING, 38),
 			new SkillRequirement(Skill.CRAFTING, 38),


### PR DESCRIPTION
Probably due to the recent change that the true blood altar now exist, the requirement for the Elite Kourend & Kebos task for crafting blood runes was missing. The sentence got changed so I fix it.

Before:
![kourend_elite_before](https://user-images.githubusercontent.com/83126316/174399313-32e7bfca-b5c6-4010-a891-74c62136b4f1.jpg)
 
After
![kourend_elite_after](https://user-images.githubusercontent.com/83126316/174399320-190ce2f6-22a6-4333-9400-0e3813f73e8f.jpg)