### PR TITLE
Add potatoes to menu entry swapper

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -228,6 +228,17 @@ public interface MenuEntrySwapperConfig extends Config
 	{
 		return false;
 	}
+	
+	@ConfigItem(
+	keyName = "swapPotatoes",
+	name = "Potatoes",
+	description = "Swap Eat with Use on Raw, Baked, and Butter Potatoes",
+	section = itemSection
+	)
+	default boolean swapPotatoes()
+	{
+		return false;
+	}
 
 	@ConfigItem(
 		keyName = "swapHerbs",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -409,6 +409,10 @@ public class MenuEntrySwapperPlugin extends Plugin
 		swap("wield", "battlestaff", "use", config::swapBattlestaves);
 
 		swap("clean", "use", config::swapHerbs);
+		
+		swap("eat", "potato", "use", config::swapPotatoes);
+		swap("eat", "baked potato", "use", config::swapPotatoes);
+		swap("eat", "potato with butter", "use", config::swapPotatoes);
 
 		swap("read", "recite-prayer", config::swapPrayerBook);
 


### PR DESCRIPTION
Thought this might be convenient to add to the Menu Entry Swapper to make raw, baked, and buttered potatoes a left-click "use" for making high healing potatoes, like tuna potatoes