### PR TITLE
spec-counter: handle thralls and venge conflicts

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/specialcounter/SpecialCounterPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/specialcounter/SpecialCounterPlugin.java
@@ -163,6 +163,27 @@ public class SpecialCounterPlugin extends Plugin
 	@Subscribe
 	public void onGameTick(GameTick event)
 	{
+		if (client.getGameState() != GameState.LOGGED_IN)
+		{
+			return;
+		}
+
+		assert client.getLocalPlayer() != null;
+		int currentRegion = WorldPoint.fromLocalInstance(client, client.getLocalPlayer().getLocalLocation()).getRegionID();
+		boolean inInstance = client.isInInstancedRegion();
+
+		// if the player left the region/instance and was fighting boss that resets, reset specs
+		if (currentRegion != previousRegion || (wasInInstance && !inInstance))
+		{
+			if (RESET_ON_LEAVE_INSTANCED_REGIONS.contains(previousRegion))
+			{
+				removeCounters();
+			}
+		}
+
+		previousRegion = currentRegion;
+		wasInInstance = inInstance;
+
 		if (this.specialWeapon == null)
 		{
 			reset();
@@ -224,22 +245,6 @@ public class SpecialCounterPlugin extends Plugin
 	{
 		if (event.getGameState() == GameState.LOGGED_IN)
 		{
-			assert client.getLocalPlayer() != null;
-			int currentRegion = WorldPoint.fromLocalInstance(client, client.getLocalPlayer().getLocalLocation()).getRegionID();
-			boolean inInstance = client.isInInstancedRegion();
-
-			// if the player left the region/instance and was fighting boss that resets, reset specs
-			if (currentRegion != previousRegion || (wasInInstance && !inInstance))
-			{
-				if (RESET_ON_LEAVE_INSTANCED_REGIONS.contains(previousRegion))
-				{
-					removeCounters();
-				}
-			}
-
-			previousRegion = currentRegion;
-			wasInInstance = inInstance;
-
 			if (currentWorld == -1)
 			{
 				currentWorld = client.getWorld();
@@ -300,7 +305,6 @@ public class SpecialCounterPlugin extends Plugin
 	{
 		Actor target = hitsplatApplied.getActor();
 		Hitsplat hitsplat = hitsplatApplied.getHitsplat();
-
 		// Ignore all hitsplats other than mine
 		if (!hitsplat.isMine() || target == client.getLocalPlayer())
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/specialcounter/SpecialCounterPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/specialcounter/SpecialCounterPlugin.java
@@ -151,6 +151,16 @@ public class SpecialCounterPlugin extends Plugin
 	}
 
 	@Subscribe
+	public void onScriptPostFired(ScriptPostFired event)
+	{
+		if (event.getScriptId() == ScriptID.TOB_HUD_SOTETSEG_FADE)
+		{
+			log.debug("Resetting spec counter as sotetseg maze script was ran");
+			removeCounters();
+		}
+	}
+
+	@Subscribe
 	public void onGameTick(GameTick event)
 	{
 		if (this.specialWeapon == null)

--- a/runelite-client/src/test/java/net/runelite/client/plugins/specialcounter/SpecialCounterPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/specialcounter/SpecialCounterPluginTest.java
@@ -33,6 +33,7 @@ import java.awt.image.BufferedImage;
 import net.runelite.api.Actor;
 import net.runelite.api.Client;
 import net.runelite.api.EquipmentInventorySlot;
+import net.runelite.api.GameState;
 import net.runelite.api.Hitsplat;
 import net.runelite.api.InventoryID;
 import net.runelite.api.Item;
@@ -41,6 +42,8 @@ import net.runelite.api.ItemID;
 import net.runelite.api.NPC;
 import net.runelite.api.Player;
 import net.runelite.api.VarPlayer;
+import net.runelite.api.coords.LocalPoint;
+import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.GameTick;
 import net.runelite.api.events.HitsplatApplied;
 import net.runelite.api.events.InteractingChanged;
@@ -116,6 +119,15 @@ public class SpecialCounterPluginTest
 	{
 		Guice.createInjector(BoundFieldModule.of(this)).injectMembers(this);
 
+		when(client.getGameState()).thenReturn(GameState.LOGGED_IN);
+
+		Player player = mock(Player.class);
+		when(client.getLocalPlayer()).thenReturn(player);
+
+		when(client.getBaseX()).thenReturn(0);
+		when(client.getBaseY()).thenReturn(0);
+		when(player.getLocalLocation()).thenReturn(new LocalPoint(0, 0));
+
 		when(specialCounterConfig.infobox()).thenReturn(true);
 
 		// Set up spec weapon
@@ -153,9 +165,7 @@ public class SpecialCounterPluginTest
 	public void testSpecDamage()
 	{
 		NPC target = mock(NPC.class);
-
-		Player player = mock(Player.class);
-		when(client.getLocalPlayer()).thenReturn(player);
+		Player player = client.getLocalPlayer();
 
 		// Tick 1: Spec NPC
 		when(client.getTickCount()).thenReturn(1);
@@ -178,9 +188,7 @@ public class SpecialCounterPluginTest
 	public void testSpecBlock()
 	{
 		NPC target = mock(NPC.class);
-
-		Player player = mock(Player.class);
-		when(client.getLocalPlayer()).thenReturn(player);
+		Player player = client.getLocalPlayer();
 
 		// Tick 1: Spec NPC
 		when(client.getTickCount()).thenReturn(1);
@@ -206,9 +214,7 @@ public class SpecialCounterPluginTest
 	public void testUnaggro()
 	{
 		NPC target = mock(NPC.class);
-
-		Player player = mock(Player.class);
-		when(client.getLocalPlayer()).thenReturn(player);
+		Player player = client.getLocalPlayer();
 
 		// Tick 1: Attack NPC
 		when(client.getTickCount()).thenReturn(1);
@@ -240,8 +246,7 @@ public class SpecialCounterPluginTest
 		NPC targetA = mock(NPC.class);
 		NPC targetB = mock(NPC.class);
 
-		Player player = mock(Player.class);
-		when(client.getLocalPlayer()).thenReturn(player);
+		Player player = client.getLocalPlayer();
 		when(specialCounterConfig.bandosGodswordThreshold()).thenReturn(15);
 		lenient().when(specialCounterConfig.thresholdNotification()).thenReturn(true);
 
@@ -284,8 +289,7 @@ public class SpecialCounterPluginTest
 		when(targetB.getId()).thenReturn(1);
 		when(targetB.getIndex()).thenReturn(1);
 
-		Player player = mock(Player.class);
-		when(client.getLocalPlayer()).thenReturn(player);
+		Player player = client.getLocalPlayer();
 
 		// Tick 0: Reset
 		when(client.getTickCount()).thenReturn(0);
@@ -326,8 +330,7 @@ public class SpecialCounterPluginTest
 		NPC target = mock(NPC.class);
 
 		// Create player
-		Player player = mock(Player.class);
-		when(client.getLocalPlayer()).thenReturn(player);
+		Player player = client.getLocalPlayer();
 		when(specialCounterConfig.bandosGodswordThreshold()).thenReturn(25);
 		when(specialCounterConfig.thresholdNotification()).thenReturn(true);
 
@@ -379,8 +382,7 @@ public class SpecialCounterPluginTest
 		NPC target = mock(NPC.class);
 
 		// Create player
-		Player player = mock(Player.class);
-		when(client.getLocalPlayer()).thenReturn(player);
+		Player player = client.getLocalPlayer();
 		when(specialCounterConfig.bandosGodswordThreshold()).thenReturn(25);
 		lenient().when(specialCounterConfig.thresholdNotification()).thenReturn(true);
 

--- a/runelite-client/src/test/java/net/runelite/client/plugins/specialcounter/SpecialCounterPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/specialcounter/SpecialCounterPluginTest.java
@@ -43,7 +43,6 @@ import net.runelite.api.NPC;
 import net.runelite.api.Player;
 import net.runelite.api.VarPlayer;
 import net.runelite.api.coords.LocalPoint;
-import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.GameTick;
 import net.runelite.api.events.HitsplatApplied;
 import net.runelite.api.events.InteractingChanged;


### PR DESCRIPTION
This PR updates the Spec Counter Plugin to:

1. Fix thralls being confused for spec hits - predominantly an issue when a DWH spec didn't land but is reported to have OR a BGS spec lands but is reported as a 1-3.
2. Fix vengeance being confused for spec hits*
3. Transmits 0 hits

* Vengeance can still rarely be confused if it is closer to the original expected damage due to scaling than the true hitsplat.

This obviously is not perfect, the only way to do that would be to get rates for every scaled boss (done for ToB but not CoX), but it gets the plugin closer to being more accurate while eliminating a pretty common issue at Xarpus.