### PR TITLE
plugin manager: don't load builtin externals from hub

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/externalplugins/ExternalPluginManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/externalplugins/ExternalPluginManager.java
@@ -38,6 +38,7 @@ import java.net.URL;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
@@ -143,6 +144,15 @@ public class ExternalPluginManager
 			return;
 		}
 
+		Set<String> builtinExternalClasses = new HashSet<>();
+		if (builtinExternals != null)
+		{
+			for (Class<? extends Plugin> pluginClass : builtinExternals)
+			{
+				builtinExternalClasses.add(pluginClass.getName());
+			}
+		}
+
 		Multimap<ExternalPluginManifest, Plugin> loadedExternalPlugins = HashMultimap.create();
 		for (Plugin p : pluginManager.getPlugins())
 		{
@@ -192,6 +202,12 @@ public class ExternalPluginManager
 					ExternalPluginManifest manifest = manifests.get(name);
 					if (manifest != null)
 					{
+						if (Arrays.stream(manifest.getPlugins()).anyMatch(builtinExternalClasses::contains))
+						{
+							log.debug("Skipping loading [{}] from hub as a conflicting builtin external is present", manifest.getInternalName());
+							continue;
+						}
+
 						externalPlugins.add(manifest);
 
 						manifest.getJarFile().setLastModified(now.toEpochMilli());


### PR DESCRIPTION
As a utility to plugin hub developers, this PR prevents built-in external plugins (as provided to ExternalPluginManager#loadBuiltin) from conflicting with their installed hub version, if any of the fully-qualified class names match.

This makes no changes to the behaviour of the ExternalPluginManager when *not* using loadBuiltin.