### PR TITLE
timetracking: change label for harvestable farming patches

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/farming/FarmingTabPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/farming/FarmingTabPanel.java
@@ -195,7 +195,7 @@ public class FarmingTabPanel extends TabContentPanel
 				switch (prediction.getCropState())
 				{
 					case HARVESTABLE:
-						panel.getEstimate().setText("Done");
+						panel.getEstimate().setText("Harvestable");
 						break;
 					case GROWING:
 						if (prediction.getDoneEstimate() < unixNow)


### PR DESCRIPTION
this fixes: #14672

make a visual distinction between harvestable and done