### PR TITLE
checkstyle: no trailing whitespace on empty lines

### DIFF
--- a/cache/src/main/java/net/runelite/cache/IndexType.java
+++ b/cache/src/main/java/net/runelite/cache/IndexType.java
@@ -50,12 +50,12 @@ public enum IndexType
 	DBTABLEINDEX(21);
 
 	private int id;
-	
+
 	IndexType(int id)
 	{
 		this.id = id;
 	}
-	
+
 	public int getNumber()
 	{
 		return id;

--- a/cache/src/main/java/net/runelite/cache/definitions/InterfaceDefinition.java
+++ b/cache/src/main/java/net/runelite/cache/definitions/InterfaceDefinition.java
@@ -104,7 +104,7 @@ public class InterfaceDefinition
 	public int[] invTransmitTriggers;
 	public int[] statTransmitTriggers;
 	public boolean hasListener;
-	
+
 	public int menuType;
 	// This is set to a siblings' child id when that widget should get a hover effect when this one is hovered
 	public int hoveredSiblingId;

--- a/cache/src/main/java/net/runelite/cache/definitions/loaders/ItemLoader.java
+++ b/cache/src/main/java/net/runelite/cache/definitions/loaders/ItemLoader.java
@@ -40,7 +40,7 @@ public class ItemLoader
 	{
 		ItemDefinition def = new ItemDefinition(id);
 		InputStream is = new InputStream(b);
-		
+
 		while (true)
 		{
 			int opcode = is.readUnsignedByte();

--- a/cache/src/main/java/net/runelite/cache/fs/ArchiveFiles.java
+++ b/cache/src/main/java/net/runelite/cache/fs/ArchiveFiles.java
@@ -92,7 +92,7 @@ public class ArchiveFiles
 	{
 		return fileMap.get(fileId);
 	}
-	
+
 	public void clear()
 	{
 		files.clear();

--- a/cache/src/main/java/net/runelite/cache/fs/FSFile.java
+++ b/cache/src/main/java/net/runelite/cache/fs/FSFile.java
@@ -99,7 +99,7 @@ public class FSFile
 	{
 		this.contents = contents;
 	}
-	
+
 	public int getSize()
 	{
 		return contents.length;

--- a/cache/src/main/java/net/runelite/cache/util/GZip.java
+++ b/cache/src/main/java/net/runelite/cache/util/GZip.java
@@ -49,14 +49,14 @@ public class GZip
 		{
 			IOUtils.copy(is, os);
 		}
-		
+
 		return bout.toByteArray();
 	}
 
 	public static byte[] decompress(byte[] bytes, int len) throws IOException
 	{
 		ByteArrayOutputStream os = new ByteArrayOutputStream();
-		
+
 		try (InputStream is = new GZIPInputStream(new ByteArrayInputStream(bytes, 0, len)))
 		{
 			IOUtils.copy(is, os);

--- a/cache/src/test/java/net/runelite/cache/ItemManagerTest.java
+++ b/cache/src/test/java/net/runelite/cache/ItemManagerTest.java
@@ -48,7 +48,7 @@ public class ItemManagerTest
 	{
 		File dumpDir = folder.newFolder(),
 			javaDir = folder.newFolder();
-		
+
 		Store store = new Store(StoreLocation.LOCATION);
 		store.load();
 

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -41,7 +41,7 @@
 			<property name="ignoreComments" value="true"/>
 		</module>
 		<module name="RegexpSinglelineJava">
-			<property name="format" value="[^\s]\s+$"/>
+			<property name="format" value=".*\s+$"/>
 			<property name="message" value="No trailing whitespace"/>
 			<property name="ignoreComments" value="true"/>
 		</module>

--- a/runelite-api/src/main/java/net/runelite/api/IndexedSprite.java
+++ b/runelite-api/src/main/java/net/runelite/api/IndexedSprite.java
@@ -54,7 +54,7 @@ public interface IndexedSprite
 
 	int getHeight();
 	void setHeight(int height);
-	
+
 	int getOriginalWidth();
 	void setOriginalWidth(int originalWidth);
 

--- a/runelite-client/src/main/java/net/runelite/client/chat/ChatMessageManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/chat/ChatMessageManager.java
@@ -234,7 +234,7 @@ public class ChatMessageManager
 
 		final String[] stringStack = client.getStringStack();
 		final int stringStackSize = client.getStringStackSize();
-		
+
 		String fromToUsername = stringStack[stringStackSize - 1];
 		if (wrap)
 		{
@@ -829,7 +829,7 @@ public class ChatMessageManager
 
 		// Update the message with RuneLite additions
 		line.setRuneLiteFormatMessage(message.getRuneLiteFormattedMessage());
-		
+
 		if (message.getTimestamp() != 0)
 		{
 			line.setTimestamp(message.getTimestamp());

--- a/runelite-client/src/main/java/net/runelite/client/plugins/blastmine/BlastMineOreCountOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/blastmine/BlastMineOreCountOverlay.java
@@ -68,7 +68,7 @@ class BlastMineOreCountOverlay extends OverlayPanel
 		{
 			return null;
 		}
-		
+
 		if (config.showOreOverlay())
 		{
 			blastMineWidget.setHidden(true);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/fps/FpsDrawListener.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/fps/FpsDrawListener.java
@@ -73,7 +73,7 @@ public class FpsDrawListener implements Runnable
 			: config.maxFps();
 
 		targetDelay = 1000 / Math.max(1, fps);
-		
+
 		sleepDelay = targetDelay;
 
 		for (int i = 0; i < SAMPLE_SIZE; i++)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/fps/FpsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/fps/FpsOverlay.java
@@ -102,7 +102,7 @@ public class FpsOverlay extends Overlay
 		{
 			xOffset += logoutButton.getWidth();
 		}
-		
+
 		final String text = client.getFPS() + FPS_STRING;
 		final int textWidth = graphics.getFontMetrics().stringWidth(text);
 		final int textHeight = graphics.getFontMetrics().getAscent() - graphics.getFontMetrics().getDescent();

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
@@ -142,7 +142,7 @@ public interface GroundItemsConfig extends Config
 	{
 		return false;
 	}
-	
+
 	@ConfigItem(
 		keyName = "highlightTiles",
 		name = "Highlight Tiles",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
@@ -656,7 +656,7 @@ public class GroundItemsPlugin extends Plugin
 				.append(QuantityFormatter.quantityToStackSize(item.getQuantity()))
 				.append(')');
 		}
-		
+
 		notifier.notify(notificationStringBuilder.toString());
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemcharges/ItemChargePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemcharges/ItemChargePlugin.java
@@ -388,7 +388,7 @@ public class ItemChargePlugin extends Plugin
 				{
 					notifier.notify("Your ring of forging has melted.");
 				}
-				
+
 				// This chat message triggers before the used message so add 1 to the max charges to ensure proper sync
 				updateRingOfForgingCharges(MAX_RING_OF_FORGING_CHARGES + 1);
 			}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemidentification/ItemIdentification.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemidentification/ItemIdentification.java
@@ -139,7 +139,7 @@ enum ItemIdentification
 	SITO_FOIL(Type.HERB, "Sito", "SF", ItemID.SITO_FOIL, ItemID.GRIMY_SITO_FOIL),
 	SNAKE_WEED(Type.HERB, "Snake", "SW", ItemID.SNAKE_WEED, ItemID.GRIMY_SNAKE_WEED),
 	VOLENCIA_MOSS(Type.HERB, "Volenc", "V", ItemID.VOLENCIA_MOSS, ItemID.GRIMY_VOLENCIA_MOSS),
-	
+
 	//Logs
 	RED_LOGS(Type.LOGS, "Red", "RED", ItemID.RED_LOGS),
 	GREEN_LOGS(Type.LOGS, "Green", "GRE", ItemID.GREEN_LOGS),

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemprices/ItemPricesOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemprices/ItemPricesOverlay.java
@@ -55,7 +55,7 @@ class ItemPricesOverlay extends Overlay
 	private static final int SEED_VAULT_ITEM_WIDGETID = WidgetInfo.SEED_VAULT_ITEM_CONTAINER.getPackedId();
 	private static final int SEED_VAULT_INVENTORY_ITEM_WIDGETID = WidgetInfo.SEED_VAULT_INVENTORY_ITEMS_CONTAINER.getPackedId();
 	private static final int POH_TREASURE_CHEST_INVENTORY_ITEM_WIDGETID = WidgetInfo.POH_TREASURE_CHEST_INVENTORY_CONTAINER.getPackedId();
-	
+
 	private final Client client;
 	private final ItemPricesConfig config;
 	private final TooltipManager tooltipManager;
@@ -192,7 +192,7 @@ class ItemPricesOverlay extends Overlay
 		{
 			container = client.getItemContainer(InventoryID.SEED_VAULT);
 		}
-		
+
 		if (container == null)
 		{
 			return null;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/nightmarezone/AbsorptionCounter.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/nightmarezone/AbsorptionCounter.java
@@ -56,7 +56,7 @@ public class AbsorptionCounter extends Counter
 			return belowThresholdColor;
 		}
 	}
-	
+
 	@Override
 	public String getTooltip()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/skills/PrayerBonus.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/skills/PrayerBonus.java
@@ -40,7 +40,7 @@ public enum PrayerBonus implements SkillBonus
 	DEMONIC_OFFERING("Demonic Offering (300%)", 3),
 	SACRED_BONE_BURNER("Sacred Bone Burner (300%)", 3),
 	;
-	
+
 	static final PrayerBonus[] BONE_BONUSES = {
 		LIT_GILDED_ALTAR,
 		ECTOFUNTUS,

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timestamp/TimestampPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timestamp/TimestampPlugin.java
@@ -116,7 +116,7 @@ public class TimestampPlugin extends Plugin
 		assert messageNode != null : "chat message build for unknown message";
 
 		String timestamp = generateTimestamp(messageNode.getTimestamp(), ZoneId.systemDefault());
-		
+
 		Color timestampColour = getTimestampColour();
 		if (timestampColour != null)
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/TimeablePanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/TimeablePanel.java
@@ -52,7 +52,7 @@ public class TimeablePanel<T> extends JPanel
 	private static final ImageIcon NOTIFY_ICON = new ImageIcon(ImageUtil.loadImageResource(TimeTrackingPlugin.class, "notify_icon.png"));
 	private static final ImageIcon NOTIFY_SELECTED_ICON = new ImageIcon(ImageUtil.loadImageResource(TimeTrackingPlugin.class, "notify_selected_icon.png"));
 	private static final Rectangle OVERLAY_ICON_BOUNDS;
-	
+
 	static
 	{
 		int width = Constants.ITEM_SPRITE_WIDTH * 2 / 3;
@@ -137,7 +137,7 @@ public class TimeablePanel<T> extends JPanel
 		add(topContainer, BorderLayout.NORTH);
 		add(progress, BorderLayout.SOUTH);
 	}
-	
+
 	public void setOverlayIconImage(BufferedImage overlayImg)
 	{
 		if (overlayImg == null)
@@ -145,7 +145,7 @@ public class TimeablePanel<T> extends JPanel
 			overlayIcon.setIcon(null);
 			return;
 		}
-		
+
 		if (OVERLAY_ICON_BOUNDS.width != overlayImg.getWidth() || OVERLAY_ICON_BOUNDS.height != overlayImg.getHeight())
 		{
 			overlayImg = ImageUtil.resizeImage(overlayImg, OVERLAY_ICON_BOUNDS.width, OVERLAY_ICON_BOUNDS.height);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldmap/TeleportLocationData.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldmap/TeleportLocationData.java
@@ -156,7 +156,7 @@ enum TeleportLocationData
 	OBELISK_50(TeleportType.OTHER, "Obelisk", "50", new WorldPoint(3307, 3916, 0), "obelisk_icon.png"),
 	WILDERNESS_CRABS_TELEPORT(TeleportType.OTHER, "Wilderness crabs teleport", new WorldPoint(3348, 3783, 0), "wilderness_crabs_teleport_icon.png"),
 	CANOE_WILDERNESS(TeleportType.OTHER, "Canoe (No departure)", "35", new WorldPoint(3141, 3796, 0), "transportation_icon.png"),
-	
+
 	// Achievement Diary and Combat Achievements
 	ARDOUGNE_CLOAK_MONASTERY(TeleportType.OTHER, "Ardougne Cloak", "Monastery", new WorldPoint(2606, 3222, 0), "ardougne_cloak_icon.png"),
 	ARDOUGNE_CLOAK_FARM(TeleportType.OTHER, "Ardougne Cloak", "Farm", new WorldPoint(2673, 3375, 0), "ardougne_cloak_icon.png"),

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/outline/ModelOutlineRenderer.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/outline/ModelOutlineRenderer.java
@@ -78,7 +78,7 @@ public class ModelOutlineRenderer
 	private static final int DIRECT_WRITE_OUTLINE_WIDTH_THRESHOLD = 10;
 
 	private final Client client;
-	
+
 	// Vertex positions projected on the screen.
 	private final int[] projectedVerticesX = new int[6500];
 	private final int[] projectedVerticesY = new int[6500];

--- a/runelite-client/src/main/java/net/runelite/client/util/LinkBrowser.java
+++ b/runelite-client/src/main/java/net/runelite/client/util/LinkBrowser.java
@@ -71,7 +71,7 @@ public class LinkBrowser
 				log.debug("Opened url through Desktop#browse to {}", url);
 				return;
 			}
-			
+
 			log.warn("LinkBrowser.browse() could not open {}", url);
 			showMessageBox("Unable to open link. Press 'OK' and the link will be copied to your clipboard.", url);
 		}).start();

--- a/runelite-client/src/test/java/net/runelite/client/OkHttpTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/OkHttpTest.java
@@ -46,7 +46,7 @@ public class OkHttpTest
 {
 	@Rule
 	public TemporaryFolder cacheFolder = new TemporaryFolder();
-	
+
 	@Rule
 	public MockWebServer server = new MockWebServer();
 

--- a/runelite-client/src/test/java/net/runelite/client/ui/overlay/components/TextComponentTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/ui/overlay/components/TextComponentTest.java
@@ -45,13 +45,13 @@ public class TextComponentTest
 {
 	@Mock
 	private Graphics2D graphics;
-	
+
 	@Before
 	public void before()
 	{
 		when(graphics.getFontMetrics()).thenReturn(mock(FontMetrics.class));
 	}
-	
+
 	@Test
 	public void testRender()
 	{
@@ -62,7 +62,7 @@ public class TextComponentTest
 		verify(graphics, times(2)).drawString(eq("test"), anyInt(), anyInt());
 		verify(graphics, atLeastOnce()).setColor(Color.RED);
 	}
-	
+
 	@Test
 	public void testRender2()
 	{
@@ -72,7 +72,7 @@ public class TextComponentTest
 		verify(graphics, times(2)).drawString(eq("test"), anyInt(), anyInt());
 		verify(graphics, atLeastOnce()).setColor(Color.BLUE);
 	}
-	
+
 	@Test
 	public void testRender3()
 	{


### PR DESCRIPTION
Expands the existing CheckStyle rule which detects trailing whitespace to also apply to blank lines.

Could also be split out with something like 
```xml
<module name="RegexpSinglelineJava">
	<property name="format" value="^\s+$"/>
	<property name="message" value="Empty lines should not contain whitespace"/>
	<property name="ignoreComments" value="true"/>
</module>
```