### PR TITLE
Party: Auto-join last party session upon logon

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/party/PartyConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/party/PartyConfig.java
@@ -69,10 +69,21 @@ public interface PartyConfig extends Config
 	}
 
 	@ConfigItem(
+			keyName = "autoJoinLastParty",
+			name = "Auto-join last party",
+			description = "Automatically join the last party at log on",
+			position = 4
+	)
+	default boolean autoJoinLastParty()
+	{
+		return true;
+	}
+
+	@ConfigItem(
 		keyName = "pingHotkey",
 		name = "Ping hotkey",
 		description = "Key to hold to send a tile ping",
-		position = 4
+		position = 5
 	)
 	default Keybind pingHotkey()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/party/PartyPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/party/PartyPlugin.java
@@ -301,6 +301,13 @@ public class PartyPlugin extends Plugin
 	public void onGameStateChanged(GameStateChanged event)
 	{
 		checkStateChanged(false);
+		GameState state = event.getGameState();
+		if (state == GameState.LOGGED_IN)
+		{
+			if (config.autoJoinLastParty()) {
+				party.changeParty(config.previousPartyId());
+			}
+		}
 	}
 
 	@Subscribe

--- a/runelite-client/src/main/java/net/runelite/client/plugins/party/PartyPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/party/PartyPlugin.java
@@ -304,7 +304,7 @@ public class PartyPlugin extends Plugin
 		GameState state = event.getGameState();
 		if (state == GameState.LOGGED_IN)
 		{
-			if (config.autoJoinLastParty()) {
+			if (config.autoJoinLastParty() && !Strings.isNullOrEmpty(config.previousPartyId()) && !party.isInParty()) {
 				party.changeParty(config.previousPartyId());
 			}
 		}


### PR DESCRIPTION
It can be a little bit tedious to rejoin party when logging in, this should automatically allow to rejoin the previously joined party in the config upon login. 