### PR TITLE
Add check for isMovable when tracking current hovered overlay

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayRenderer.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayRenderer.java
@@ -369,7 +369,7 @@ public class OverlayRenderer extends MouseAdapter
 					graphics.setPaint(paint);
 				}
 
-				if (!client.isMenuOpen() && !client.getSpellSelected() && bounds.contains(mousePosition))
+				if (!client.isMenuOpen() && !client.getSpellSelected() && bounds.contains(mousePosition) && overlay.isMovable())
 				{
 					curHoveredOverlay = overlay;
 					overlay.onMouseOver();


### PR DESCRIPTION
Fixes behavior where slayer or farming contract info boxes could not be dragged if snapped to top left corner.