### PR TITLE
Fix Morytania diary cannonball task requirements

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/MorytaniaDiaryRequirement.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/MorytaniaDiaryRequirement.java
@@ -68,8 +68,7 @@ public class MorytaniaDiaryRequirement extends GenericDiaryRequirement
 			new QuestRequirement(Quest.CABIN_FEVER));
 		add("Make a batch of cannonballs at the Port Phasmatys furnace.",
 			new SkillRequirement(Skill.SMITHING, 35),
-			new QuestRequirement(Quest.DWARF_CANNON),
-			new QuestRequirement(Quest.GHOSTS_AHOY, true));
+			new QuestRequirement(Quest.DWARF_CANNON));
 		add("Kill a Fever Spider on Braindeath Island.",
 			new SkillRequirement(Skill.SLAYER, 42),
 			new QuestRequirement(Quest.RUM_DEAL));


### PR DESCRIPTION
Starting Ghosts Ahoy isn't actually required to enter Port Phasmatys or use the furnace. I just completed this task without this requirement:

![image](https://user-images.githubusercontent.com/1474671/175177695-d661ded2-ef52-4df4-8a7f-bb80e3f51452.png)

This matches the lack of a requirement for the thin snail task in the easy diary:

![image](https://user-images.githubusercontent.com/1474671/175177734-97ade606-c42a-40b4-af62-58453b9fdf52.png)