### PR TITLE
Party Plugin: added "navigate to pinged tile" option

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/party/PartyConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/party/PartyConfig.java
@@ -69,10 +69,21 @@ public interface PartyConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "navigateToPingedTile",
+		name = "Navigate to pinged tile",
+		description = "Navigate to tile after sending a tile ping",
+		position = 4
+	)
+	default boolean navigateToPingedTile()
+	{
+		return false;
+	}
+
+	@ConfigItem(
 		keyName = "pingHotkey",
 		name = "Ping hotkey",
 		description = "Key to hold to send a tile ping",
-		position = 4
+		position = 5
 	)
 	default Keybind pingHotkey()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/party/PartyPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/party/PartyPlugin.java
@@ -50,6 +50,7 @@ import net.runelite.api.Player;
 import net.runelite.api.Skill;
 import net.runelite.api.SoundEffectID;
 import net.runelite.api.Tile;
+import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.CommandExecuted;
 import net.runelite.api.events.FocusChanged;
@@ -292,7 +293,10 @@ public class PartyPlugin extends Plugin
 			return;
 		}
 
-		event.consume();
+		if (!config.navigateToPingedTile()) {
+			event.consume();
+		}
+
 		final TilePing tilePing = new TilePing(selectedSceneTile.getWorldLocation());
 		party.send(tilePing);
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/party/PartyPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/party/PartyPlugin.java
@@ -50,7 +50,6 @@ import net.runelite.api.Player;
 import net.runelite.api.Skill;
 import net.runelite.api.SoundEffectID;
 import net.runelite.api.Tile;
-import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.CommandExecuted;
 import net.runelite.api.events.FocusChanged;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/party/PartyPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/party/PartyPlugin.java
@@ -292,7 +292,8 @@ public class PartyPlugin extends Plugin
 			return;
 		}
 
-		if (!config.navigateToPingedTile()) {
+		if (!config.navigateToPingedTile())
+		{
 			event.consume();
 		}
 


### PR DESCRIPTION
Added a "navigate to pinged tile" setting to party plugin. When this option is enabled, the user will navigate (walk/run) to the tile they pinged rather than having to click the same tile again after pinging.

Sample clip:
![ezgif com-gif-maker](https://user-images.githubusercontent.com/13453364/175207843-361cadf5-964c-490a-881f-4bcde4c50c8e.gif)
