### PR TITLE
Linux : Force frame to front in clientUI.forceFocus()

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
@@ -760,6 +760,7 @@ public class ClientUI
 				WinUtil.requestForeground(frame);
 				break;
 			default:
+				frame.toFront();
 				frame.requestFocus();
 				break;
 		}


### PR DESCRIPTION
Without `frame.toFront()` the `forceFocus()` method focuses the window, but it remains hidden behind other windows (on Arch linux / Manjaro & Ubuntu 18) which doesn't necessarily match what I think `forceFocus()` should do.

For Linux, I believe `clientUI.forceFocus()` implementation details should match the use case of forcing focus. I used as reference : https://stackoverflow.com/questions/641172/how-to-focus-a-jframe , but believe `setVisible(true)` is not necessary in this case.

Let me know if this change in `forceFocus()` on linux matches the intended usecase! 