### PR TITLE
special counter: Add special weapon null check

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/specialcounter/SpecialCounterPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/specialcounter/SpecialCounterPlugin.java
@@ -180,7 +180,7 @@ public class SpecialCounterPlugin extends Plugin
 	@Subscribe
 	public void onGameTick(GameTick event)
 	{
-		if (lastSpecHitsplat != null)
+		if (specialWeapon != null && lastSpecHitsplat != null)
 		{
 			if (lastSpecHitsplat.getAmount() > 0)
 			{


### PR DESCRIPTION
`specialAttackHit()` expects all its arguments to be non-null, so the
passed special weapon must be null-checked before being passed to it.
This fixes a frequent NPE caused by using any special attack weapon not
defined in the SpecialWeapon enum.