### PR TITLE
Fix: Bracelet of Clay in Trahaearn Mine

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemcharges/ItemChargePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemcharges/ItemChargePlugin.java
@@ -138,6 +138,7 @@ public class ItemChargePlugin extends Plugin
 	);
 	private static final String BLOOD_ESSENCE_ACTIVATE_TEXT = "You activate the blood essence.";
 	private static final String BRACELET_OF_CLAY_USE_TEXT = "You manage to mine some clay.";
+	private static final String BRACELET_OF_CLAY_USE_TEXT_TRAHAEARN = "You manage to mine some soft clay.";
 	private static final String BRACELET_OF_CLAY_BREAK_TEXT = "Your bracelet of clay crumbles to dust.";
 	private static final Pattern BRACELET_OF_CLAY_CHECK_PATTERN = Pattern.compile(
 		"You can mine (\\d{1,2}) more pieces? of soft clay before your bracelet crumbles to dust\\."
@@ -450,7 +451,7 @@ public class ItemChargePlugin extends Plugin
 			{
 				updateBraceletOfClayCharges(Integer.parseInt(braceletOfClayCheckMatcher.group(1)));
 			}
-			else if (message.equals(BRACELET_OF_CLAY_USE_TEXT))
+			else if (message.equals(BRACELET_OF_CLAY_USE_TEXT) || message.equals(BRACELET_OF_CLAY_USE_TEXT_TRAHAEARN))
 			{
 				final ItemContainer equipment = client.getItemContainer(InventoryID.EQUIPMENT);
 


### PR DESCRIPTION
Fixed issue where charge was not decrementing-
Mining soft-clay in Trahaearn mine will give you 2x soft-clay at the cost of 1 charge from the Bracelet of Clay. The fix now reflects this.

fixes #15221 