### PR TITLE
player indicators: highlight party members

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/party/PartyService.java
+++ b/runelite-client/src/main/java/net/runelite/client/party/PartyService.java
@@ -276,6 +276,19 @@ public class PartyService
 		return null;
 	}
 
+	public PartyMember getMemberByDisplayName(final String name)
+	{
+		for (PartyMember member : members)
+		{
+			if (member.isLoggedIn() && name.equals(member.getDisplayName()))
+			{
+				return member;
+			}
+		}
+
+		return null;
+	}
+
 	public List<PartyMember> getMembers()
 	{
 		return Collections.unmodifiableList(members);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/party/PartyStatusOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/party/PartyStatusOverlay.java
@@ -30,7 +30,6 @@ import java.awt.Font;
 import java.awt.FontMetrics;
 import java.awt.Graphics2D;
 import java.awt.image.BufferedImage;
-import java.util.List;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import net.runelite.api.Client;
@@ -103,7 +102,6 @@ class PartyStatusOverlay extends Overlay
 			return null;
 		}
 
-		List<PartyMember> partyMembers = partyService.getMembers();
 		for (Player player : client.getPlayers())
 		{
 			if (!renderSelf && player == client.getLocalPlayer())
@@ -111,7 +109,7 @@ class PartyStatusOverlay extends Overlay
 				continue;
 			}
 
-			PartyMember partyMember = findPartyMember(partyMembers, player);
+			PartyMember partyMember = findPartyMember(player);
 			if (partyMember == null)
 			{
 				continue;
@@ -156,22 +154,14 @@ class PartyStatusOverlay extends Overlay
 		return null;
 	}
 
-	private PartyMember findPartyMember(List<PartyMember> partyMembers, Player p)
+	private PartyMember findPartyMember(Player p)
 	{
 		if (p == null || p.getName() == null)
 		{
 			return null;
 		}
 
-		for (PartyMember partyMember : partyMembers)
-		{
-			if (partyMember.isLoggedIn() && p.getName().equals(partyMember.getDisplayName()))
-			{
-				return partyMember;
-			}
-		}
-
-		return null;
+		return partyService.getMemberByDisplayName(p.getName());
 	}
 
 	// relative to center of model

--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsConfig.java
@@ -66,6 +66,30 @@ public interface PlayerIndicatorsConfig extends Config
 
 	@ConfigItem(
 		position = 2,
+		keyName = "drawPartyMembers",
+		name = "Highlight party members",
+		description = "Configures whether or not party members should be highlighted",
+		section = highlightSection
+	)
+	default boolean highlightPartyMembers()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		position = 3,
+		keyName = "partyMemberNameColor",
+		name = "Party member",
+		description = "Color of party member names",
+		section = highlightSection
+	)
+	default Color getPartyMemberColor()
+	{
+		return new Color(234, 123, 91);
+	}
+
+	@ConfigItem(
+		position = 4,
 		keyName = "drawFriendNames",
 		name = "Highlight friends",
 		description = "Configures whether or not friends should be highlighted",
@@ -77,7 +101,7 @@ public interface PlayerIndicatorsConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 3,
+		position = 5,
 		keyName = "friendNameColor",
 		name = "Friend",
 		description = "Color of friend names",
@@ -89,7 +113,7 @@ public interface PlayerIndicatorsConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 4,
+		position = 6,
 		keyName = "drawClanMemberNames",
 		name = "Highlight friends chat members",
 		description = "Configures if friends chat members should be highlighted",
@@ -101,7 +125,7 @@ public interface PlayerIndicatorsConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 5,
+		position = 7,
 		keyName = "clanMemberColor",
 		name = "Friends chat",
 		description = "Color of friends chat members",
@@ -113,7 +137,7 @@ public interface PlayerIndicatorsConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 6,
+		position = 8,
 		keyName = "drawTeamMemberNames",
 		name = "Highlight team members",
 		description = "Configures whether or not team members should be highlighted",
@@ -125,7 +149,7 @@ public interface PlayerIndicatorsConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 7,
+		position = 9,
 		keyName = "teamMemberColor",
 		name = "Team member",
 		description = "Color of team members",
@@ -137,7 +161,7 @@ public interface PlayerIndicatorsConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 8,
+		position = 10,
 		keyName = "drawClanChatMemberNames",
 		name = "Highlight clan members",
 		description = "Configures whether or not clan members should be highlighted",
@@ -149,7 +173,7 @@ public interface PlayerIndicatorsConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 9,
+		position = 11,
 		keyName = "clanChatMemberColor",
 		name = "Clan member",
 		description = "Color of clan members",
@@ -161,7 +185,7 @@ public interface PlayerIndicatorsConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 10,
+		position = 12,
 		keyName = "drawNonClanMemberNames",
 		name = "Highlight others",
 		description = "Configures whether or not other players should be highlighted",
@@ -173,7 +197,7 @@ public interface PlayerIndicatorsConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 11,
+		position = 13,
 		keyName = "nonClanMemberColor",
 		name = "Others",
 		description = "Color of other players names",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsPlugin.java
@@ -56,6 +56,7 @@ import net.runelite.client.callback.ClientThread;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.game.ChatIconManager;
+import net.runelite.client.party.PartyService;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.OverlayManager;
@@ -96,6 +97,9 @@ public class PlayerIndicatorsPlugin extends Plugin
 
 	@Inject
 	private ClientThread clientThread;
+
+	@Inject
+	private PartyService partyService;
 
 	@Provides
 	PlayerIndicatorsConfig provideConfig(ConfigManager configManager)
@@ -188,7 +192,15 @@ public class PlayerIndicatorsPlugin extends Plugin
 		int image = -1;
 		Color color = null;
 
-		if (player.isFriend() && config.highlightFriends())
+		boolean isPartyMember = partyService.isInParty() &&
+			player.getName() != null &&
+			config.highlightPartyMembers() &&
+			partyService.getMemberByDisplayName(player.getName()) != null;
+		if (isPartyMember)
+		{
+			color = config.getPartyMemberColor();
+		}
+		else if (player.isFriend() && config.highlightFriends())
 		{
 			color = config.getFriendColor();
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsService.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsService.java
@@ -38,6 +38,7 @@ import net.runelite.api.clan.ClanChannelMember;
 import net.runelite.api.clan.ClanRank;
 import net.runelite.api.clan.ClanSettings;
 import net.runelite.api.clan.ClanTitle;
+import net.runelite.client.party.PartyService;
 import net.runelite.client.util.Text;
 
 @Singleton
@@ -45,19 +46,21 @@ public class PlayerIndicatorsService
 {
 	private final Client client;
 	private final PlayerIndicatorsConfig config;
+	private final PartyService partyService;
 
 	@Inject
-	private PlayerIndicatorsService(Client client, PlayerIndicatorsConfig config)
+	private PlayerIndicatorsService(Client client, PlayerIndicatorsConfig config, PartyService partyService)
 	{
 		this.config = config;
 		this.client = client;
+		this.partyService = partyService;
 	}
 
 	public void forEachPlayer(final BiConsumer<Player, Color> consumer)
 	{
 		if (!config.highlightOwnPlayer() && !config.highlightFriendsChat()
 			&& !config.highlightFriends() && !config.highlightOthers()
-			&& !config.highlightClanMembers())
+			&& !config.highlightClanMembers() && !config.highlightPartyMembers())
 		{
 			return;
 		}
@@ -80,6 +83,10 @@ public class PlayerIndicatorsService
 				{
 					consumer.accept(player, config.getOwnPlayerColor());
 				}
+			}
+			else if (partyService.isInParty() && config.highlightPartyMembers() && partyService.getMemberByDisplayName(player.getName()) != null)
+			{
+				consumer.accept(player, config.getPartyMemberColor());
 			}
 			else if (config.highlightFriends() && player.isFriend())
 			{


### PR DESCRIPTION
Adds an option to highlight party members and recolor their names in the minimenu. Places higher priority on party members than all other options, since it is the least likely group for a player to be in, and likely used for short time frames while participating in an activity (raiding/pvming).

Colour chosen was to avoid clash with other existing default colours.

![Screenshot_20220628_035050](https://user-images.githubusercontent.com/1868974/176124174-96ea5207-7778-4a3a-b3c2-73e8f1aa4de5.png)
 