### PR TITLE
Arceuus Prayer Spell Bonus added

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/skills/PrayerBonus.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/skills/PrayerBonus.java
@@ -37,7 +37,8 @@ public enum PrayerBonus implements SkillBonus
 	MORYTANIA_DIARY_3_SHADES("Morytania Diary 3 Shades(150%)", 0.5f),
 	BONECRUSHER("Bonecrusher (50%)", -0.5f),
 	SINISTER_OFFERING("Sinister Offering (300%)", 2),
-	DEMONIC_OFFERING("Demonic Offering (300%)", 2);
+	DEMONIC_OFFERING("Demonic Offering (300%)", 2),
+	SACRED_BONE_BURNER("Sacred Bone Burner (300%)", 2);
 
 	private final String name;
 	private final float value;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/skills/PrayerBonus.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/skills/PrayerBonus.java
@@ -36,7 +36,8 @@ public enum PrayerBonus implements SkillBonus
 	CHAOS_ALTAR("Chaos Altar (700%)", 6),
 	MORYTANIA_DIARY_3_SHADES("Morytania Diary 3 Shades(150%)", 0.5f),
 	BONECRUSHER("Bonecrusher (50%)", -0.5f),
-	;
+	SINISTER_OFFERING("Sinister Offering (300%)", 2),
+	DEMONIC_OFFERING("Demonic Offering (300%)", 2);
 
 	private final String name;
 	private final float value;


### PR DESCRIPTION
Added Arceuus offering spells (Demonic Offering and Sinister Offering) to Prayer Bonus calc. Each method offers 300% bonus.

EDIT: Sacred Bone Burner added as well.

This addition fulfills the suggestion here:
https://github.com/runelite/runelite/discussions/15231