### PR TITLE
player indicators: show fc/cc ranks on friends in minimenu

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsPlugin.java
@@ -207,15 +207,6 @@ public class PlayerIndicatorsPlugin extends Plugin
 		else if (player.isFriendsChatMember() && config.highlightFriendsChat())
 		{
 			color = config.getFriendsChatMemberColor();
-
-			if (config.showFriendsChatRanks())
-			{
-				FriendsChatRank rank = playerIndicatorsService.getFriendsChatRank(player);
-				if (rank != UNRANKED)
-				{
-					image = chatIconManager.getIconNumber(rank);
-				}
-			}
 		}
 		else if (player.getTeam() > 0 && client.getLocalPlayer().getTeam() == player.getTeam() && config.highlightTeamMembers())
 		{
@@ -224,19 +215,27 @@ public class PlayerIndicatorsPlugin extends Plugin
 		else if (player.isClanMember() && config.highlightClanMembers())
 		{
 			color = config.getClanMemberColor();
-
-			if (config.showClanChatRanks())
-			{
-				ClanTitle clanTitle = playerIndicatorsService.getClanTitle(player);
-				if (clanTitle != null)
-				{
-					image = chatIconManager.getIconNumber(clanTitle);
-				}
-			}
 		}
 		else if (!player.isFriendsChatMember() && !player.isClanMember() && config.highlightOthers())
 		{
 			color = config.getOthersColor();
+		}
+
+		if (player.isFriendsChatMember() && config.showFriendsChatRanks())
+		{
+			FriendsChatRank rank = playerIndicatorsService.getFriendsChatRank(player);
+			if (rank != UNRANKED)
+			{
+				image = chatIconManager.getIconNumber(rank);
+			}
+		}
+		if (player.isClanMember() && config.showClanChatRanks() && image == -1)
+		{
+			ClanTitle clanTitle = playerIndicatorsService.getClanTitle(player);
+			if (clanTitle != null)
+			{
+				image = chatIconManager.getIconNumber(clanTitle);
+			}
 		}
 
 		if (image == -1 && color == null)


### PR DESCRIPTION
Current behaviour will fail to pull clan ranks for the minimenu when a player is in a higher-priority recoloring group (friends/party members), despite the player names overlay correctly displaying both. This PR just rearranges the rank image selection to be independent of colour selection.

Current behaviour:

![image](https://user-images.githubusercontent.com/1868974/176555944-28ed5889-5437-41a4-8a52-5e5d41c5275d.png)

With PR:

![image](https://user-images.githubusercontent.com/1868974/176555964-8a031d20-5f53-4eca-97dd-8fb3ab41fa32.png)

