### PR TITLE
Compact party overlay

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/party/PartyConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/party/PartyConfig.java
@@ -160,18 +160,6 @@ public interface PartyConfig extends Config
 	}
 
 	@ConfigItem(
-		section = SECTION_STATUS_OVERLAY,
-		keyName = "statusOverlayCompact",
-		name = "Compact Status Display",
-		description = "Show above activated status overlays in a smaller and stacked format.",
-		position = 12
-	)
-	default boolean statusOverlayCompact()
-	{
-		return false;
-	}
-
-	@ConfigItem(
 		keyName = "previousPartyId",
 		name = "",
 		description = "",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/party/PartyConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/party/PartyConfig.java
@@ -160,6 +160,18 @@ public interface PartyConfig extends Config
 	}
 
 	@ConfigItem(
+		section = SECTION_STATUS_OVERLAY,
+		keyName = "statusOverlayCompact",
+		name = "Compact Status Display",
+		description = "Show above activated status overlays in a smaller and stacked format.",
+		position = 12
+	)
+	default boolean statusOverlayCompact()
+	{
+		return false;
+	}
+
+	@ConfigItem(
 		keyName = "previousPartyId",
 		name = "",
 		description = "",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/party/PartyStatusOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/party/PartyStatusOverlay.java
@@ -57,10 +57,8 @@ class PartyStatusOverlay extends Overlay
 	private static final Color COLOR_HEALTH_MIN = Color.red;
 	private static final Color COLOR_PRAYER = new Color(50, 200, 200);
 	private static final Color COLOR_STAMINA = new Color(160, 124, 72);
-	private static final Color COLOR_SPEC = new Color(200, 200, 0);
-	private static final Font OVERLAY_FONT = FontManager.getRunescapeBoldFont().deriveFont(20f);
-	private static final Font COMPACT_OVERLAY_FONT = FontManager.getRunescapeBoldFont().deriveFont(16f);
-	private static final int OFFSET = 25;
+	private static final Color COLOR_SPEC = new Color(225, 225, 0);
+	private static final Font OVERLAY_FONT = FontManager.getRunescapeBoldFont().deriveFont(16f);
 
 	private final Client client;
 	private final SpriteManager spriteManager;
@@ -74,8 +72,6 @@ class PartyStatusOverlay extends Overlay
 	private boolean renderSpec = false;
 	private boolean renderVeng = false;
 	private boolean renderSelf = false;
-	private boolean compactDisplay = false;
-	private int activeDisplays = 0;
 
 	@Inject
 	private PartyStatusOverlay(
@@ -124,14 +120,7 @@ class PartyStatusOverlay extends Overlay
 			}
 
 			int renderIx = 0;
-			if (compactDisplay)
-			{
-				graphics.setFont(COMPACT_OVERLAY_FONT);
-			}
-			else
-			{
-				graphics.setFont(OVERLAY_FONT);
-			}
+			graphics.setFont(OVERLAY_FONT);
 			if (renderHealth)
 			{
 				double healthRatio = Math.min(1.0, (double) partyData.getHitpoints() / partyData.getMaxHitpoints());
@@ -173,78 +162,19 @@ class PartyStatusOverlay extends Overlay
 		return partyService.getMemberByDisplayName(p.getName());
 	}
 
-	// relative to center of model
-	private Point getRenderOffsets(int renderIx)
-	{
-		if (this.activeDisplays < 3)
-		{
-			int ySgn = renderIx == 0 ? -1 : 1;
-			return new Point(0, ySgn * OFFSET);
-		}
-		else if (this.activeDisplays == 3)
-		{
-			if (renderIx == 0)
-			{
-				return new Point(0, -OFFSET);
-			}
-			else if (renderIx == 1)
-			{
-				return new Point(-OFFSET, OFFSET);
-			}
-			else
-			{
-				return new Point(OFFSET, OFFSET);
-			}
-		}
-		else
-		{
-			int sgn = renderIx < 2 ? -1 : 1;
-			if (renderIx == 0 || renderIx == 3)
-			{
-				return new Point(0, sgn * OFFSET);
-			}
-			else
-			{
-				return new Point(sgn * OFFSET, 0);
-			}
-		}
-	}
-
 	private void renderPlayerOverlay(Graphics2D graphics, Player player, String text, Color color, int renderIx)
 	{
-		Point point;
-		Point textPoint = null;
-		FontMetrics fm = graphics.getFontMetrics();
-
-		if (compactDisplay)
-		{
-			point = Perspective.localToCanvas(client, player.getLocalLocation(), client.getPlane(), player.getLogicalHeight());
-			int zOffset = 0;
-
-			if (point != null)
-			{
-				int size = fm.getHeight();
-				zOffset += size * renderIx;
-				textPoint = new Point(point.getX() + size + 5, point.getY() + zOffset);
-			}
-		}
-		else
-		{
-			point = Perspective.localToCanvas(client, player.getLocalLocation(), client.getPlane(), player.getLogicalHeight() / 2);
-			Point off = getRenderOffsets(renderIx);
-			if (point != null)
-			{
-				int textWidthOffset = fm.stringWidth(text) / 2;
-				int textHeightOffset = fm.getHeight() / 2;
-				textPoint = new Point(point.getX() + off.getX() - textWidthOffset, point.getY() + off.getY() + textHeightOffset);
-			}
-		}
+		Point point = Perspective.localToCanvas(client, player.getLocalLocation(), client.getPlane(), player.getLogicalHeight());
 
 		if (point != null)
 		{
+			FontMetrics fm = graphics.getFontMetrics();
+			int size = fm.getHeight();
+			int zOffset = size * renderIx;
+
 			OverlayUtil.renderTextLocation(
 				graphics,
-				textPoint,
+				new Point(point.getX() + size + 5, point.getY() + zOffset),
 				text,
 				color
 			);
@@ -268,12 +198,5 @@ class PartyStatusOverlay extends Overlay
 		this.renderSpec = config.statusOverlaySpec();
 		this.renderVeng = config.statusOverlayVeng();
 		this.renderSelf = config.statusOverlayRenderSelf();
-		this.compactDisplay = config.statusOverlayCompact();
-
-		this.activeDisplays =
-			(renderHealth ? 1 : 0) +
-				(renderPrayer ? 1 : 0) +
-				(renderStamina ? 1 : 0) +
-				(renderSpec ? 1 : 0);
 	}
 }


### PR DESCRIPTION
The following is what this PR would change:
+ Adds an option to display the party info (hp, prayer, stam, spec) with smaller font, stacked, and offset from the player as to avoid being covered by hitsplats/hp bar
+ Changes the color used to identify special attack percent to yellow, as more players associate special attack with energy transfer and having multiple components of the overlay set to green is confusing
+ Changes the overlay layer to under widgets to show hitpoints above hitsplats when using the diamond shape

![java_BWfVgM9anm](https://user-images.githubusercontent.com/107762640/176833016-17761cfd-9834-45b9-af74-09221dd8571d.gif)

