### PR TITLE
party: getMemberByDisplayName search by jagex name

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/party/PartyService.java
+++ b/runelite-client/src/main/java/net/runelite/client/party/PartyService.java
@@ -55,6 +55,7 @@ import net.runelite.client.party.messages.PartyMessage;
 import net.runelite.client.party.events.UserJoin;
 import net.runelite.client.party.events.UserPart;
 import net.runelite.client.party.messages.UserSync;
+import net.runelite.client.util.Text;
 import static net.runelite.client.util.Text.JAGEX_PRINTABLE_CHAR_MATCHER;
 
 @Slf4j
@@ -278,9 +279,10 @@ public class PartyService
 
 	public PartyMember getMemberByDisplayName(final String name)
 	{
+		String sanitized = Text.removeTags(Text.toJagexName(name));
 		for (PartyMember member : members)
 		{
-			if (member.isLoggedIn() && name.equals(member.getDisplayName()))
+			if (member.isLoggedIn() && sanitized.equals(member.getDisplayName()))
 			{
 				return member;
 			}


### PR DESCRIPTION
Fixes a bug with players containing dashes failing to be rendered by both the PartyStatusOverlay and the PartyIndicatorsOverlay, as the name being searched for was not sanitized in the same manner as was stored by the StatusUpdate#characterName field.

![image](https://user-images.githubusercontent.com/1868974/176973817-b3511910-e05d-4b31-b3c5-f426ba57646e.png)
