### PR TITLE
npc indicators: Track respawns only for dead NPCs

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsPlugin.java
@@ -376,7 +376,7 @@ public class NpcIndicatorsPlugin extends Plugin
 	{
 		final NPC npc = npcDespawned.getNpc();
 
-		if (memorizedNpcs.containsKey(npc.getIndex()))
+		if (memorizedNpcs.containsKey(npc.getIndex()) && npcUtil.isDying(npc))
 		{
 			despawnedNpcsThisTick.add(npc);
 		}


### PR DESCRIPTION
Some NPCs such as Giant Mole have mechanics where they can spawn in a
predictable location, but also move in a large distance (possibly beyond
that which the server transmits to the player) to cause despawn events
during their fight. Previously, this would cause a respawn indicator to
appear at their spawn location each time such a despawn occurred. This
commit changes that behavior to only affect NPCs which are dead at the
time of despawning.