### PR TITLE
Update special attack counter to exclude all hits on olm mage hand

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/specialcounter/SpecialCounterPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/specialcounter/SpecialCounterPlugin.java
@@ -87,7 +87,8 @@ public class SpecialCounterPlugin extends Plugin
 		NpcID.ZOMBIFIED_SPAWN, NpcID.ZOMBIFIED_SPAWN_8063, // vorkath
 		NpcID.COMBAT_DUMMY, NpcID.UNDEAD_COMBAT_DUMMY, // poh
 		NpcID.SKELETON_HELLHOUND_6613, NpcID.GREATER_SKELETON_HELLHOUND, // vetion
-		NpcID.SPAWN, NpcID.SCION // abyssal sire
+		NpcID.SPAWN, NpcID.SCION, // abyssal sire
+		NpcID.GREAT_OLM_RIGHT_CLAW, NpcID.GREAT_OLM_RIGHT_CLAW_7553 // olm mage hand
 	);
 
 	private int currentWorld;


### PR DESCRIPTION
Some truncated discussion in discord starting here: https://discord.com/channels/301497432909414422/419891709883973642/996904476973748414.

It's possible for the plugin to mis-identify 2 attack hitsplats from the same player, if one is a long-range attack followed by a melee special attack. Example here: https://www.twitch.tv/videos/1530201934?t=3h4m25s, which is a sang on the mage hand from far away, followed by a bgs on the melee hand. Those hitsplats land on the same tick, with the sang hitting a 30 and the bgs hitting 0, but the plugin shows it as a 30 from the bgs.

This commit doesn't fix the underlying issue, but at least prevents it in chambers by excluding all hitsplats on the mage hand from being considered. Not sure where else this is likely to occur. Some discussion in https://discord.com/channels/301497432909414422/419891709883973642/996907345214967878 and subsequent messages about a way to better track the attacks, but not needed for this fix.

I haven't actually done a run with these changes to confirm they work/don't break anything. Happy to do that if wanted for regs, probably not cm.