### PR TITLE
Entity Hider: update "hide pets" label for clarity

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/entityhider/EntityHiderConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/entityhider/EntityHiderConfig.java
@@ -147,7 +147,7 @@ public interface EntityHiderConfig extends Config
 	@ConfigItem(
 		position = 11,
 		keyName = "hidePets",
-		name = "Hide Pets",
+		name = "Hide Other Players' Pets",
 		description = "Configures whether or not other player pets are hidden"
 	)
 	default boolean hidePets()


### PR DESCRIPTION
Edited 'Hide Pets' name to 'Hide Other Players' Pets' to be more clear that it does not hide your own pet