### PR TITLE
Game Notifications to check if game is loading

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/Notifier.java
+++ b/runelite-client/src/main/java/net/runelite/client/Notifier.java
@@ -230,7 +230,8 @@ public class Notifier
 	{
 		FlashNotification flashNotification = runeLiteConfig.flashNotification();
 
-		if (flashStart == null || client.getGameState() != GameState.LOGGED_IN
+		if (flashStart == null
+			|| (client.getGameState() != GameState.LOGGED_IN && client.getGameState() != GameState.LOADING)
 			|| flashNotification == FlashNotification.DISABLED)
 		{
 			flashStart = null;


### PR DESCRIPTION
Include GameState.LOADING when checking to see if flashNotification should be nulled. Resolves issue where notifications being sent during a screen transition such as a teleport are being nulled too early.