### PR TITLE
Added duplicate SpriteID to inform about usecase.

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/SpriteID.java
+++ b/runelite-api/src/main/java/net/runelite/api/SpriteID.java
@@ -312,6 +312,7 @@ public final class SpriteID
 	public static final int COMBAT_STYLE_BUTTON_NARROW_SELECTED = 294;
 	public static final int COMBAT_STYLE_BUTTON_THIN = 295;
 	public static final int COMBAT_STYLE_BUTTON_THIN_SELECTED = 296;
+	public static final int BANK_BACKGROUND = 297;
 	public static final int DIALOG_BACKGROUND = 297;
 	/* Unmapped: 298 */
 	public static final int RS2_YELLOW_CLICK_ANIMATION_1 = 299;


### PR DESCRIPTION
public static final int BANK_BACKGROUND = 297;
BANK_BACKGROUND corresponds to: DIALOG_BACKGROUND;
But was unclear during development.