### PR TITLE
[Player Indicators && Npc Indicators] Follows rules for Entity Hider

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsPlugin.java
@@ -58,7 +58,6 @@ import net.runelite.api.events.NpcChanged;
 import net.runelite.api.events.NpcDespawned;
 import net.runelite.api.events.NpcSpawned;
 import net.runelite.client.callback.ClientThread;
-import net.runelite.client.callback.Hooks;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.events.ConfigChanged;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsPlugin.java
@@ -58,7 +58,9 @@ import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.game.ChatIconManager;
 import net.runelite.client.party.PartyService;
 import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginDependency;
 import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.plugins.entityhider.EntityHiderPlugin;
 import net.runelite.client.ui.overlay.OverlayManager;
 import net.runelite.client.util.ColorUtil;
 
@@ -67,6 +69,7 @@ import net.runelite.client.util.ColorUtil;
 	description = "Highlight players on-screen and/or on the minimap",
 	tags = {"highlight", "minimap", "overlay", "players"}
 )
+@PluginDependency(EntityHiderPlugin.class)
 public class PlayerIndicatorsPlugin extends Plugin
 {
 	private static final String TRADING_WITH_TEXT = "Trading with: ";

--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsService.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsService.java
@@ -39,6 +39,10 @@ import net.runelite.api.clan.ClanRank;
 import net.runelite.api.clan.ClanSettings;
 import net.runelite.api.clan.ClanTitle;
 import net.runelite.client.party.PartyService;
+import net.runelite.client.plugins.PluginDependency;
+import net.runelite.client.plugins.PluginManager;
+import net.runelite.client.plugins.entityhider.EntityHiderConfig;
+import net.runelite.client.plugins.entityhider.EntityHiderPlugin;
 import net.runelite.client.util.Text;
 
 @Singleton
@@ -46,6 +50,15 @@ public class PlayerIndicatorsService
 {
 	private final Client client;
 	private final PlayerIndicatorsConfig config;
+	@Inject
+	private EntityHiderPlugin entityHiderPlugin;
+
+	@Inject
+	private EntityHiderConfig entityHiderConfig;
+
+	@Inject
+	private PluginManager pluginManager;
+
 	private final PartyService partyService;
 
 	@Inject
@@ -54,6 +67,14 @@ public class PlayerIndicatorsService
 		this.config = config;
 		this.client = client;
 		this.partyService = partyService;
+	}
+
+	private boolean shouldRender(boolean state) {
+		if(!pluginManager.isPluginEnabled(entityHiderPlugin))
+		{
+			return true;
+		}
+		return !state;
 	}
 
 	public void forEachPlayer(final BiConsumer<Player, Color> consumer)
@@ -79,7 +100,7 @@ public class PlayerIndicatorsService
 
 			if (player == localPlayer)
 			{
-				if (config.highlightOwnPlayer())
+				if (config.highlightOwnPlayer() && shouldRender(entityHiderConfig.hideLocalPlayer()))
 				{
 					consumer.accept(player, config.getOwnPlayerColor());
 				}
@@ -88,11 +109,11 @@ public class PlayerIndicatorsService
 			{
 				consumer.accept(player, config.getPartyMemberColor());
 			}
-			else if (config.highlightFriends() && player.isFriend())
+			else if (config.highlightFriends() && player.isFriend() && shouldRender(entityHiderConfig.hideFriends()))
 			{
 				consumer.accept(player, config.getFriendColor());
 			}
-			else if (config.highlightFriendsChat() && isFriendsChatMember)
+			else if (config.highlightFriendsChat() && isFriendsChatMember && shouldRender(entityHiderConfig.hideFriendsChatMembers()))
 			{
 				consumer.accept(player, config.getFriendsChatMemberColor());
 			}
@@ -100,11 +121,11 @@ public class PlayerIndicatorsService
 			{
 				consumer.accept(player, config.getTeamMemberColor());
 			}
-			else if (config.highlightClanMembers() && isClanMember)
+			else if (config.highlightClanMembers() && isClanMember && shouldRender(entityHiderConfig.hideClanChatMembers()))
 			{
 				consumer.accept(player, config.getClanMemberColor());
 			}
-			else if (config.highlightOthers() && !isFriendsChatMember && !isClanMember)
+			else if (config.highlightOthers() && !isFriendsChatMember && !isClanMember && shouldRender(entityHiderConfig.hideOthers()))
 			{
 				consumer.accept(player, config.getOthersColor());
 			}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsService.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsService.java
@@ -69,13 +69,9 @@ public class PlayerIndicatorsService
 		this.partyService = partyService;
 	}
 
-	private boolean shouldRender(boolean state)
+	private boolean shouldRender(boolean hidden)
 	{
-		if(!pluginManager.isPluginEnabled(entityHiderPlugin))
-		{
-			return true;
-		}
-		return !state;
+		return !pluginManager.isPluginEnabled(entityHiderPlugin) || !hidden;
 	}
 
 	public void forEachPlayer(final BiConsumer<Player, Color> consumer)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsService.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsService.java
@@ -39,7 +39,6 @@ import net.runelite.api.clan.ClanRank;
 import net.runelite.api.clan.ClanSettings;
 import net.runelite.api.clan.ClanTitle;
 import net.runelite.client.party.PartyService;
-import net.runelite.client.plugins.PluginDependency;
 import net.runelite.client.plugins.PluginManager;
 import net.runelite.client.plugins.entityhider.EntityHiderConfig;
 import net.runelite.client.plugins.entityhider.EntityHiderPlugin;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsService.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsService.java
@@ -69,7 +69,8 @@ public class PlayerIndicatorsService
 		this.partyService = partyService;
 	}
 
-	private boolean shouldRender(boolean state) {
+	private boolean shouldRender(boolean state)
+	{
 		if(!pluginManager.isPluginEnabled(entityHiderPlugin))
 		{
 			return true;

--- a/runelite-client/src/test/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsPluginTest.java
@@ -41,7 +41,6 @@ import net.runelite.api.events.NpcChanged;
 import net.runelite.api.events.NpcSpawned;
 import net.runelite.client.callback.Hooks;
 import net.runelite.client.menus.TestMenuEntry;
-import net.runelite.client.plugins.PluginDependency;
 import net.runelite.client.plugins.PluginManager;
 import net.runelite.client.plugins.entityhider.EntityHiderConfig;
 import net.runelite.client.plugins.entityhider.EntityHiderPlugin;

--- a/runelite-client/src/test/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsPluginTest.java
@@ -39,7 +39,12 @@ import net.runelite.api.NPCComposition;
 import net.runelite.api.events.MenuEntryAdded;
 import net.runelite.api.events.NpcChanged;
 import net.runelite.api.events.NpcSpawned;
+import net.runelite.client.callback.Hooks;
 import net.runelite.client.menus.TestMenuEntry;
+import net.runelite.client.plugins.PluginDependency;
+import net.runelite.client.plugins.PluginManager;
+import net.runelite.client.plugins.entityhider.EntityHiderConfig;
+import net.runelite.client.plugins.entityhider.EntityHiderPlugin;
 import net.runelite.client.ui.overlay.OverlayManager;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -61,11 +66,27 @@ public class NpcIndicatorsPluginTest
 
 	@Mock
 	@Bind
+	private EntityHiderPlugin entityHiderPlugin;
+
+	@Mock
+	@Bind
+	private PluginManager pluginManager;
+
+	@Mock
+	@Bind
 	private ScheduledExecutorService executorService;
 
 	@Mock
 	@Bind
 	private NpcIndicatorsConfig npcIndicatorsConfig;
+
+	@Mock
+	@Bind
+	private EntityHiderConfig config;
+
+	@Mock
+	@Bind
+	private Hooks hooks;
 
 	@Inject
 	private NpcIndicatorsPlugin npcIndicatorsPlugin;


### PR DESCRIPTION
This fixes how Entity Hider configs did not apply for the following plugins

- Player Indicators
- Npc Indicators

![image](https://user-images.githubusercontent.com/72366279/181373648-7a850fbd-ada7-4ac6-bce8-a47ba9328f88.png)