### PR TITLE
Fix special attack plugin to track npc targets of special attacks to line up with hitsplats

### DIFF
--- a/runelite-client/src/test/java/net/runelite/client/plugins/specialcounter/SpecialCounterPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/specialcounter/SpecialCounterPluginTest.java
@@ -58,12 +58,9 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.*;
+
 import org.mockito.Mock;
-import static org.mockito.Mockito.lenient;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -149,7 +146,9 @@ public class SpecialCounterPluginTest
 	public void testSpecDamage()
 	{
 		Player player = mock(Player.class);
+		NPC target = mock(NPC.class);
 
+		when(player.getInteracting()).thenReturn(target);
 		when(client.getLocalPlayer()).thenReturn(player);
 
 		// spec npc
@@ -162,7 +161,6 @@ public class SpecialCounterPluginTest
 		captor.getValue().run();
 
 		// hit 1
-		NPC target = mock(NPC.class);
 		specialCounterPlugin.onHitsplatApplied(hitsplat(target, Hitsplat.HitsplatType.DAMAGE_ME));
 
 		specialCounterPlugin.onGameTick(new GameTick());
@@ -180,12 +178,23 @@ public class SpecialCounterPluginTest
 		Player player = mock(Player.class);
 
 		when(client.getLocalPlayer()).thenReturn(player);
+		when(player.getInteracting()).thenReturn(target);
 		when(specialCounterConfig.bandosGodswordThreshold()).thenReturn(2);
 		when(specialCounterConfig.thresholdNotification()).thenReturn(true);
 
 		// First special attack
 		when(client.getVar(VarPlayer.SPECIAL_ATTACK_PERCENT)).thenReturn(50);
 		specialCounterPlugin.onVarbitChanged(new VarbitChanged());
+
+		{
+			ArgumentCaptor<Runnable> captor = ArgumentCaptor.forClass(Runnable.class);
+			verify(clientThread).invokeLater(captor.capture());
+			captor.getValue().run();
+
+			// Need to reset the mock since it's used again later to get the runnable
+			reset(clientThread);
+		}
+
 		specialCounterPlugin.onHitsplatApplied(hitsplat(target, Hitsplat.HitsplatType.DAMAGE_ME));
 
 		specialCounterPlugin.onGameTick(new GameTick());
@@ -198,6 +207,13 @@ public class SpecialCounterPluginTest
 		// Second special attack
 		when(client.getVar(VarPlayer.SPECIAL_ATTACK_PERCENT)).thenReturn(0);
 		specialCounterPlugin.onVarbitChanged(new VarbitChanged());
+
+		{
+			ArgumentCaptor<Runnable> captor = ArgumentCaptor.forClass(Runnable.class);
+			verify(clientThread).invokeLater(captor.capture());
+			captor.getValue().run();
+		}
+
 		specialCounterPlugin.onHitsplatApplied(hitsplat(target, Hitsplat.HitsplatType.DAMAGE_ME));
 
 		specialCounterPlugin.onGameTick(new GameTick());
@@ -210,8 +226,10 @@ public class SpecialCounterPluginTest
 	{
 		// Create player
 		Player player = mock(Player.class);
+		NPC target = mock(NPC.class);
 
 		when(client.getLocalPlayer()).thenReturn(player);
+		when(player.getInteracting()).thenReturn(target);
 		when(specialCounterConfig.bandosGodswordThreshold()).thenReturn(3);
 		lenient().when(specialCounterConfig.thresholdNotification()).thenReturn(true);
 
@@ -219,7 +237,15 @@ public class SpecialCounterPluginTest
 		when(client.getVar(VarPlayer.SPECIAL_ATTACK_PERCENT)).thenReturn(50);
 		specialCounterPlugin.onVarbitChanged(new VarbitChanged());
 
-		NPC target = mock(NPC.class);
+		{
+			ArgumentCaptor<Runnable> captor = ArgumentCaptor.forClass(Runnable.class);
+			verify(clientThread).invokeLater(captor.capture());
+			captor.getValue().run();
+
+			// Need to reset the mock since it's used again later to get the runnable
+			reset(clientThread);
+		}
+
 		specialCounterPlugin.onHitsplatApplied(hitsplat(target, Hitsplat.HitsplatType.DAMAGE_ME));
 
 		specialCounterPlugin.onGameTick(new GameTick());
@@ -227,6 +253,13 @@ public class SpecialCounterPluginTest
 		// Second special attack
 		when(client.getVar(VarPlayer.SPECIAL_ATTACK_PERCENT)).thenReturn(0);
 		specialCounterPlugin.onVarbitChanged(new VarbitChanged());
+
+		{
+			ArgumentCaptor<Runnable> captor = ArgumentCaptor.forClass(Runnable.class);
+			verify(clientThread).invokeLater(captor.capture());
+			captor.getValue().run();
+		}
+
 		specialCounterPlugin.onHitsplatApplied(hitsplat(target, Hitsplat.HitsplatType.DAMAGE_ME));
 
 		specialCounterPlugin.onGameTick(new GameTick());


### PR DESCRIPTION
Some followup from https://github.com/runelite/runelite/pull/15338 and https://discord.com/channels/301497432909414422/419891709883973642/1001959649802727426.

As recap, hitsplats would be misattributed when doing a long-range attack that takes `<weapon_cooldown>` ticks to land followed up a special attack (most common by using a trident on olm mage hand followed by bgs on melee hand). This fixes that issue by tracking what NPC the player is interacting with when the special attack occurs, and ensuring that it only looks at hitsplats on that NPC, filtering out the rest.

I didn't test this in any raids, but reproduced the issue on cyclops in catacombs (long range one with trident, then swap to bgs and spec another with hitsplats on the same tick). Confirmed it repros on base runelite and is fixed with the PR.

I think this will also prevent the infobox from prematurely disappearing, which I found to be a common issue in chambers (I think due to swapping between mage and melee hand, though didn't confirm the actual reason; it had to be something that would cause `removeCounters` to be called, which I suspect was the check with `interactedNpcIndexes`); with this change, we would hit the early return from `lastSpecTarget == null`, and it shouldn't disappear until the hand dies.