### PR TITLE
Sort ground item menu entries by GE price

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
@@ -341,7 +341,6 @@ public interface GroundItemsConfig extends Config
 		name = "High value price",
 		description = "Configures the start price for high value items",
 		position = 23
-		position = 22
 	)
 	default int highValuePrice()
 	{
@@ -354,7 +353,6 @@ public interface GroundItemsConfig extends Config
 		name = "Insane value items",
 		description = "Configures the color for insane value items",
 		position = 24
-		position = 23
 	)
 	default Color insaneValueColor()
 	{
@@ -366,7 +364,6 @@ public interface GroundItemsConfig extends Config
 		name = "Insane value price",
 		description = "Configures the start price for insane value items",
 		position = 25
-		position = 24
 	)
 	default int insaneValuePrice()
 	{
@@ -378,7 +375,6 @@ public interface GroundItemsConfig extends Config
 		name = "Only show loot",
 		description = "Only shows drops from NPCs and players",
 		position = 26
-		position = 25
 	)
 	default boolean onlyShowLoot()
 	{
@@ -390,7 +386,6 @@ public interface GroundItemsConfig extends Config
 		name = "Double-tap delay",
 		description = "Delay for the double-tap ALT to hide ground items. 0 to disable.",
 		position = 27
-		position = 26
 	)
 	@Units(Units.MILLISECONDS)
 	default int doubleTapDelay()
@@ -403,7 +398,6 @@ public interface GroundItemsConfig extends Config
 		name = "Collapse ground item menu",
 		description = "Collapses ground item menu entries together and appends count",
 		position = 28
-		position = 27
 	)
 	default boolean collapseEntries()
 	{
@@ -415,7 +409,6 @@ public interface GroundItemsConfig extends Config
 		name = "Despawn timer",
 		description = "Shows despawn timers for items you've dropped and received as loot",
 		position = 29
-		position = 28
 	)
 	default DespawnTimerMode groundItemTimers()
 	{
@@ -427,7 +420,6 @@ public interface GroundItemsConfig extends Config
 		name = "Text Outline",
 		description = "Use an outline around text instead of a text shadow",
 		position = 30
-		position = 29
 	)
 	default boolean textOutline()
 	{
@@ -439,7 +431,6 @@ public interface GroundItemsConfig extends Config
 		name = "Highlighted item lootbeams",
 		description = "Configures lootbeams to show for all highlighted items.",
 		position = 31
-		position = 30
 	)
 	default boolean showLootbeamForHighlighted()
 	{
@@ -451,7 +442,6 @@ public interface GroundItemsConfig extends Config
 		name = "Lootbeam tier",
 		description = "Configures which price tiers will trigger a lootbeam",
 		position = 32
-		position = 31
 	)
 	default HighlightTier showLootbeamTier()
 	{
@@ -463,7 +453,6 @@ public interface GroundItemsConfig extends Config
 		name = "Lootbeam Style",
 		description = "Style of lootbeam to use",
 		position = 33
-		position = 32
 	)
 	default Lootbeam.Style lootbeamStyle()
 	{
@@ -475,7 +464,6 @@ public interface GroundItemsConfig extends Config
 		name = "Hotkey",
 		description = "Configures the hotkey used by the Ground Items plugin",
 		position = 34
-		position = 33
 	)
 	default Keybind hotkey()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
@@ -186,12 +186,23 @@ public interface GroundItemsConfig extends Config
 	{
 		return PriceDisplayMode.BOTH;
 	}
+	
+	@ConfigItem(
+		keyName = "sortByGEPrice",
+		name = "Sort by GE price",
+		description = "Sorts ground items by GE price, instead of alch value",
+		position = 10
+	)
+	default boolean sortByGEPrice()
+	{
+		return false;
+	}
 
 	@ConfigItem(
 		keyName = "itemHighlightMode",
 		name = "Item Highlight Mode",
 		description = "Configures how ground items will be highlighted",
-		position = 10
+		position = 11
 	)
 	default ItemHighlightMode itemHighlightMode()
 	{
@@ -202,7 +213,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "menuHighlightMode",
 		name = "Menu Highlight Mode",
 		description = "Configures what to highlight in right-click menu",
-		position = 11
+		position = 12
 	)
 	default MenuHighlightMode menuHighlightMode()
 	{
@@ -213,7 +224,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "highlightValueCalculation",
 		name = "Highlight Value Calculation",
 		description = "Configures which coin value is used to determine highlight color",
-		position = 12
+		position = 13
 	)
 	default ValueCalculationMode valueCalculationMode()
 	{
@@ -224,7 +235,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "hideUnderValue",
 		name = "Hide under value",
 		description = "Configures hidden ground items under both GE and HA value",
-		position = 13
+		position = 14
 	)
 	default int getHideUnderValue()
 	{
@@ -236,7 +247,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "defaultColor",
 		name = "Default items",
 		description = "Configures the color for default, non-highlighted items",
-		position = 14
+		position = 15
 	)
 	default Color defaultColor()
 	{
@@ -248,7 +259,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "highlightedColor",
 		name = "Highlighted items",
 		description = "Configures the color for highlighted items",
-		position = 15
+		position = 16
 	)
 	default Color highlightedColor()
 	{
@@ -260,7 +271,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "hiddenColor",
 		name = "Hidden items",
 		description = "Configures the color for hidden items in right-click menu and when holding ALT",
-		position = 16
+		position = 17
 	)
 	default Color hiddenColor()
 	{
@@ -272,7 +283,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "lowValueColor",
 		name = "Low value items",
 		description = "Configures the color for low value items",
-		position = 17
+		position = 18
 	)
 	default Color lowValueColor()
 	{
@@ -283,7 +294,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "lowValuePrice",
 		name = "Low value price",
 		description = "Configures the start price for low value items",
-		position = 18
+		position = 19
 	)
 	default int lowValuePrice()
 	{
@@ -295,7 +306,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "mediumValueColor",
 		name = "Medium value items",
 		description = "Configures the color for medium value items",
-		position = 19
+		position = 20
 	)
 	default Color mediumValueColor()
 	{
@@ -306,7 +317,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "mediumValuePrice",
 		name = "Medium value price",
 		description = "Configures the start price for medium value items",
-		position = 20
+		position = 21
 	)
 	default int mediumValuePrice()
 	{
@@ -318,7 +329,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "highValueColor",
 		name = "High value items",
 		description = "Configures the color for high value items",
-		position = 21
+		position = 22
 	)
 	default Color highValueColor()
 	{
@@ -329,6 +340,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "highValuePrice",
 		name = "High value price",
 		description = "Configures the start price for high value items",
+		position = 23
 		position = 22
 	)
 	default int highValuePrice()
@@ -341,6 +353,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "insaneValueColor",
 		name = "Insane value items",
 		description = "Configures the color for insane value items",
+		position = 24
 		position = 23
 	)
 	default Color insaneValueColor()
@@ -352,6 +365,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "insaneValuePrice",
 		name = "Insane value price",
 		description = "Configures the start price for insane value items",
+		position = 25
 		position = 24
 	)
 	default int insaneValuePrice()
@@ -363,6 +377,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "onlyShowLoot",
 		name = "Only show loot",
 		description = "Only shows drops from NPCs and players",
+		position = 26
 		position = 25
 	)
 	default boolean onlyShowLoot()
@@ -374,6 +389,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "doubleTapDelay",
 		name = "Double-tap delay",
 		description = "Delay for the double-tap ALT to hide ground items. 0 to disable.",
+		position = 27
 		position = 26
 	)
 	@Units(Units.MILLISECONDS)
@@ -386,6 +402,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "collapseEntries",
 		name = "Collapse ground item menu",
 		description = "Collapses ground item menu entries together and appends count",
+		position = 28
 		position = 27
 	)
 	default boolean collapseEntries()
@@ -397,6 +414,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "groundItemTimers",
 		name = "Despawn timer",
 		description = "Shows despawn timers for items you've dropped and received as loot",
+		position = 29
 		position = 28
 	)
 	default DespawnTimerMode groundItemTimers()
@@ -408,6 +426,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "textOutline",
 		name = "Text Outline",
 		description = "Use an outline around text instead of a text shadow",
+		position = 30
 		position = 29
 	)
 	default boolean textOutline()
@@ -419,6 +438,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "showLootbeamForHighlighted",
 		name = "Highlighted item lootbeams",
 		description = "Configures lootbeams to show for all highlighted items.",
+		position = 31
 		position = 30
 	)
 	default boolean showLootbeamForHighlighted()
@@ -430,6 +450,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "showLootbeamTier",
 		name = "Lootbeam tier",
 		description = "Configures which price tiers will trigger a lootbeam",
+		position = 32
 		position = 31
 	)
 	default HighlightTier showLootbeamTier()
@@ -441,6 +462,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "lootbeamStyle",
 		name = "Lootbeam Style",
 		description = "Style of lootbeam to use",
+		position = 33
 		position = 32
 	)
 	default Lootbeam.Style lootbeamStyle()
@@ -452,6 +474,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "hotkey",
 		name = "Hotkey",
 		description = "Configures the hotkey used by the Ground Items plugin",
+		position = 34
 		position = 33
 	)
 	default Keybind hotkey()
@@ -459,3 +482,4 @@ public interface GroundItemsConfig extends Config
 		return Keybind.ALT;
 	}
 }
+

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
@@ -47,6 +47,8 @@ import java.util.Queue;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import javax.inject.Inject;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -241,16 +243,14 @@ public class GroundItemsPlugin extends Plugin
 
 		GroundItem groundItem = buildGroundItem(tile, item);
 		GroundItem existing = collectedGroundItems.get(tile.getWorldLocation(), item.getId());
-		if (existing != null)
-		{
+		if (existing == null) {
+			collectedGroundItems.put(tile.getWorldLocation(), item.getId(), groundItem);
+		}
+		else {
 			existing.setQuantity(existing.getQuantity() + groundItem.getQuantity());
 			// The spawn time remains set at the oldest spawn
 		}
-		else
-		{
-			collectedGroundItems.put(tile.getWorldLocation(), item.getId(), groundItem);
-		}
-
+		
 		if (!config.onlyShowLoot())
 		{
 			notifyHighlightedItem(groundItem);
@@ -354,7 +354,37 @@ public class GroundItemsPlugin extends Plugin
 		}
 
 		Collections.reverse(newEntries);
-
+		
+		newEntries.sort((a, b) ->
+		{
+			final MenuAction aMenuType = a.getEntry().getType();
+			if (aMenuType == MenuAction.GROUND_ITEM_FIRST_OPTION || aMenuType == MenuAction.GROUND_ITEM_SECOND_OPTION || aMenuType == MenuAction.GROUND_ITEM_THIRD_OPTION
+				|| aMenuType == MenuAction.GROUND_ITEM_FOURTH_OPTION || aMenuType == MenuAction.GROUND_ITEM_FIFTH_OPTION || aMenuType == MenuAction.EXAMINE_ITEM_GROUND
+				|| aMenuType == MenuAction.WALK)
+			{
+				final MenuAction bMenuType = b.getEntry().getType();
+				if (bMenuType == MenuAction.GROUND_ITEM_FIRST_OPTION || bMenuType == MenuAction.GROUND_ITEM_SECOND_OPTION || bMenuType == MenuAction.GROUND_ITEM_THIRD_OPTION
+					|| bMenuType == MenuAction.GROUND_ITEM_FOURTH_OPTION || bMenuType == MenuAction.GROUND_ITEM_FIFTH_OPTION || bMenuType == MenuAction.EXAMINE_ITEM_GROUND
+					|| bMenuType == MenuAction.WALK)
+				{
+					final MenuEntry aEntry = a.getEntry();
+					final int aId = aEntry.getIdentifier();
+					final int aQuantity = getCollapsedItemQuantity(aId, aEntry.getTarget());
+					
+					final MenuEntry bEntry = b.getEntry();
+					final int bId = bEntry.getIdentifier();
+					final int bQuantity = getCollapsedItemQuantity(bId, bEntry.getTarget());
+					
+					if (config.sortByGEPrice())
+					{
+						return (getGePriceFromItemId(aId) * aQuantity) - (getGePriceFromItemId(bId) * bQuantity);
+					}
+				}
+			}
+			
+			return 0;
+		});
+		
 		client.setMenuEntries(newEntries.stream().map(e ->
 		{
 			final MenuEntry entry = e.getEntry();
@@ -366,6 +396,46 @@ public class GroundItemsPlugin extends Plugin
 
 			return entry;
 		}).toArray(MenuEntry[]::new));
+	}
+	
+	private int getGePriceFromItemId(final int itemId)
+	{
+		final ItemComposition itemComposition = itemManager.getItemComposition(itemId);
+		final int realItemId = itemComposition.getNote() != -1 ? itemComposition.getLinkedNoteId() : itemId;
+		
+		return itemManager.getItemPrice(realItemId);
+	}
+	
+	private boolean isItemIdHidden(final int itemId, final int quantity)
+	{
+		final ItemComposition itemComposition = itemManager.getItemComposition(itemId);
+		final int realItemId = itemComposition.getNote() != -1 ? itemComposition.getLinkedNoteId() : itemId;
+		final int alchPrice = itemManager.getItemComposition(realItemId).getHaPrice() * quantity;
+		final int gePrice = itemManager.getItemPrice(realItemId) * quantity;
+		
+		return getHidden(new NamedQuantity(itemComposition.getName(), quantity), gePrice, alchPrice, itemComposition.isTradeable()) != null;
+	}
+	
+	private int getCollapsedItemQuantity(final int itemId, final String item)
+	{
+		final ItemComposition itemComposition = itemManager.getItemComposition(itemId);
+		final boolean itemNameIncludesQuantity = Pattern.compile("\\(\\d+\\)").matcher(itemComposition.getName()).find();
+		
+		final Matcher matcher = Pattern.compile("\\((\\d+)\\)").matcher(item);
+		int matches = 0;
+		String lastMatch = "1";
+		while (matcher.find())
+		{
+			// so that "Prayer Potion (4)" returns 1 instead of 4 and "Coins (25)" returns 25 instead of 1
+			if (!itemNameIncludesQuantity || matches >= 1)
+			{
+				lastMatch = matcher.group(1);
+			}
+			
+			matches++;
+		}
+		
+		return Integer.parseInt(lastMatch);
 	}
 
 	private void lootReceived(Collection<ItemStack> items, LootType lootType)


### PR DESCRIPTION
Reorders ground item menu entries so that the most expensive items are at the top of the pile, and least expensive at the bottom.
![image](https://user-images.githubusercontent.com/24503018/181422267-55e5fc9d-74d0-4fea-bdc0-fbf7142052e6.png)
