### PR TITLE
Adding ignore pets configuration to NPC Indicators

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsConfig.java
@@ -247,4 +247,16 @@ public interface NpcIndicatorsConfig extends Config
 	{
 		return false;
 	}
+
+	@ConfigItem(
+		position = 14,
+		keyName = "ignorePets",
+		name = "Ignore pets",
+		description = "Excludes pets from being highlighted"
+	)
+	default boolean ignorePets()
+	{
+		return true;
+	}
+
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsPlugin.java
@@ -315,7 +315,7 @@ public class NpcIndicatorsPlugin extends Plugin
 
 			if (removed)
 			{
-				if (!highlightMatchesNPCName(npc.getName()))
+				if (!shouldHighlightNpc(npc))
 				{
 					highlightedNpcs.remove(npc);
 					memorizedNpcs.remove(npc.getIndex());
@@ -360,7 +360,7 @@ public class NpcIndicatorsPlugin extends Plugin
 			return;
 		}
 
-		if (highlightMatchesNPCName(npcName))
+		if (shouldHighlightNpc(npc))
 		{
 			highlightedNpcs.put(npc, highlightedNpc(npc));
 			if (!client.isInInstancedRegion())
@@ -398,7 +398,7 @@ public class NpcIndicatorsPlugin extends Plugin
 		}
 
 		if (npcTags.contains(npc.getIndex())
-			|| highlightMatchesNPCName(npcName))
+			|| shouldHighlightNpc(npc))
 		{
 			highlightedNpcs.put(npc, highlightedNpc(npc));
 		}
@@ -536,7 +536,7 @@ public class NpcIndicatorsPlugin extends Plugin
 				continue;
 			}
 
-			if (highlightMatchesNPCName(npcName))
+			if (shouldHighlightNpc(npc))
 			{
 				if (!client.isInInstancedRegion())
 				{
@@ -551,6 +551,16 @@ public class NpcIndicatorsPlugin extends Plugin
 		}
 
 		npcOverlayService.rebuild();
+	}
+
+	private boolean shouldHighlightNpc(NPC npc)
+	{
+		return highlightMatchesNPCName(npc.getName()) && shouldHighlightIfPet(npc);
+	}
+
+	private boolean shouldHighlightIfPet(NPC npc)
+	{
+		return !config.ignorePets() || !npc.getComposition().isFollower();
 	}
 
 	private boolean highlightMatchesNPCName(String npcName)

--- a/runelite-client/src/test/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsPluginTest.java
@@ -182,4 +182,20 @@ public class NpcIndicatorsPluginTest
 
 		assertTrue(npcIndicatorsPlugin.getHighlightedNpcs().containsKey(npc));
 	}
+
+	@Test
+	public void ignorePets()
+	{
+		when(npcIndicatorsConfig.getNpcToHighlight()).thenReturn("*cano");
+		when(npcIndicatorsConfig.ignorePets()).thenReturn(true);
+		npcIndicatorsPlugin.rebuild();
+
+		NPCComposition smolcanoComp = mock(NPCComposition.class);
+		when(smolcanoComp.isFollower()).thenReturn(true);
+		NPC smolcano = mock(NPC.class);
+		when(smolcano.getName()).thenReturn("Smolcano");
+		when(smolcano.getComposition()).thenReturn(smolcanoComp);
+		npcIndicatorsPlugin.onNpcSpawned(new NpcSpawned(smolcano));
+		assertFalse(npcIndicatorsPlugin.getHighlightedNpcs().containsKey(smolcano));
+	}
 }


### PR DESCRIPTION
## Summary

This change adds the option to exclude pets from NPC indicators

- on (Default) - Exclude all pets from NPC Indicators.
- off - Don't exclude any pets. This maintains parity with how NPC indicators currently works.

The reasoning for this is to exclude overloaded npc matches. For example, `* dragon` matches all dragons, but this includes `Prince black dragon`.

## Screenshots

For the actual highlighting, I added `*chaos*,*cano` to my "NPCs to highlight" list and stood next to a random pet chaos elemental with my Smolcano.

#### Off

![Off](https://i.imgur.com/6C8vOtl.png)

#### On

![On](https://i.imgur.com/DD34lre.png)
