### PR TITLE
party: disable location updates inside instances

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/party/PartyPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/party/PartyPlugin.java
@@ -306,6 +306,11 @@ public class PartyPlugin extends Plugin
 	public void onGameStateChanged(GameStateChanged event)
 	{
 		checkStateChanged(false);
+
+		if (event.getGameState() == GameState.LOGGED_IN)
+		{
+			sendLocationUpdate();
+		}
 	}
 
 	@Subscribe
@@ -337,7 +342,7 @@ public class PartyPlugin extends Plugin
 	)
 	public void shareLocation()
 	{
-		if (client.getGameState() != GameState.LOGGED_IN)
+		if (client.getGameState() != GameState.LOGGED_IN || client.isInInstancedRegion())
 		{
 			return;
 		}
@@ -460,6 +465,28 @@ public class PartyPlugin extends Plugin
 	{
 		clientThread.invokeLater(() -> checkStateChanged(true));
 		lastLocation = null;
+	}
+
+	private void sendLocationUpdate()
+	{
+		final PartyMember localMember = party.getLocalMember();
+
+		if (localMember == null)
+		{
+			return;
+		}
+
+		if (client.isInInstancedRegion())
+		{
+			// send a blank worldpoint to remove the player from the world map
+			final WorldPoint blankWorldPoint = new WorldPoint(0, 0, 0);
+			party.send(new LocationUpdate(blankWorldPoint));
+		}
+		else
+		{
+			final WorldPoint worldPoint = client.getLocalPlayer().getWorldLocation();
+			party.send(new LocationUpdate(worldPoint));
+		}
 	}
 
 	private void checkStateChanged(boolean forceSend)


### PR DESCRIPTION
This pull request disables player location updates while inside instances as the only use of the party member location is the world map. The idea behind this is to reduce CPU load on the party service since most parties (assumption) are likely being formed for raiding.