### PR TITLE
[POC]Fishing Spots Equipment QOL

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/game/FishingSpot.java
+++ b/runelite-client/src/main/java/net/runelite/client/game/FishingSpot.java
@@ -25,15 +25,25 @@
 package net.runelite.client.game;
 
 import com.google.common.collect.ImmutableMap;
-import java.util.Map;
 import lombok.Getter;
 import net.runelite.api.ItemID;
+import net.runelite.client.plugins.fishing.FishingTools;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
 import static net.runelite.api.NpcID.*;
 
+
+@SuppressWarnings("SpellCheckingInspection")
 @Getter
 public enum FishingSpot
 {
-	SHRIMP("Shrimp, Sardine, Herring, Anchovies", "Anchovies", ItemID.RAW_SHRIMPS,
+	SHRIMP("Net/Bait", "Anchovies", new LinkedHashMap<>(){{
+		put(FishingTools.SMALL_FISHING_NET, new Catches("Shrimp, Anchovies", ItemID.RAW_ANCHOVIES));
+		put(FishingTools.FISHING_ROD, new Catches("Sardines, Herring", ItemID.RAW_HERRING));
+	}},
 		FISHING_SPOT_1514, FISHING_SPOT_1517, FISHING_SPOT_1518,
 		FISHING_SPOT_1521, FISHING_SPOT_1523, FISHING_SPOT_1524,
 		FISHING_SPOT_1525, FISHING_SPOT_1528, FISHING_SPOT_1530,
@@ -41,14 +51,21 @@ public enum FishingSpot
 		FISHING_SPOT_7459, FISHING_SPOT_7462, FISHING_SPOT_7467,
 		FISHING_SPOT_7469, FISHING_SPOT_7947, FISHING_SPOT_10513
 	),
-	LOBSTER("Lobster, Swordfish, Tuna", "Lobster", ItemID.RAW_LOBSTER,
+	LOBSTER("Cage/Harpoon", "Lobster", new LinkedHashMap<>(){{
+		put(FishingTools.LOBSTER_POT, new Catches("Lobster", ItemID.RAW_LOBSTER));
+		put(FishingTools.HARPOON, new Catches("Tuna, Swordfish", ItemID.RAW_SWORDFISH));
+	}},
 		FISHING_SPOT_1510, FISHING_SPOT_1519, FISHING_SPOT_1522,
 		FISHING_SPOT_3914, FISHING_SPOT_5820, FISHING_SPOT_7199,
 		FISHING_SPOT_7460, FISHING_SPOT_7465, FISHING_SPOT_7470,
 		FISHING_SPOT_7946, FISHING_SPOT_9173, FISHING_SPOT_9174,
 		FISHING_SPOT_10515, FISHING_SPOT_10635
 	),
-	SHARK("Shark, Bass", "Shark", ItemID.RAW_SHARK,
+	SHARK("Big Net/Harpoon", "Shark", new LinkedHashMap<>(){
+		{
+			put(FishingTools.HARPOON, new Catches("Shark", ItemID.RAW_SHARK));
+			put(FishingTools.BIG_FISHING_NET, new Catches("Mackerel, Cod, Bass, Misc.", ItemID.RAW_COD));
+		}},
 		FISHING_SPOT_1511, FISHING_SPOT_1520, FISHING_SPOT_3419,
 		FISHING_SPOT_3915, FISHING_SPOT_4476, FISHING_SPOT_4477,
 		FISHING_SPOT_5233, FISHING_SPOT_5234, FISHING_SPOT_5821,
@@ -56,10 +73,16 @@ public enum FishingSpot
 		FISHING_SPOT_8525, FISHING_SPOT_8526, FISHING_SPOT_8527,
 		FISHING_SPOT_9171, FISHING_SPOT_9172, FISHING_SPOT_10514
 	),
-	MONKFISH("Monkfish", ItemID.RAW_MONKFISH,
+	MONKFISH("Net/Harpoon","Monkfish", new LinkedHashMap<>(){{
+		put(FishingTools.SMALL_FISHING_NET, new Catches("Monkfish", ItemID.RAW_MONKFISH));
+		put(FishingTools.HARPOON, new Catches("Tuna, Swordfish", ItemID.RAW_SWORDFISH));
+	}},
 		FISHING_SPOT_4316
 	),
-	SALMON("Salmon, Trout", "Salmon", ItemID.RAW_SALMON,
+	SALMON("Salmon, Trout", "Salmon", new LinkedHashMap<>(){{
+		put(FishingTools.FLY_FISHING_ROD, new Catches("Salmon, Trout, Rainbow Fish", ItemID.RAW_SALMON));
+		put(FishingTools.FISHING_ROD, new Catches("Pike", ItemID.RAW_PIKE));
+	}},
 		ROD_FISHING_SPOT, ROD_FISHING_SPOT_1506, ROD_FISHING_SPOT_1507,
 		ROD_FISHING_SPOT_1508, ROD_FISHING_SPOT_1509, ROD_FISHING_SPOT_1513,
 		ROD_FISHING_SPOT_1515, ROD_FISHING_SPOT_1516, ROD_FISHING_SPOT_1526,
@@ -67,67 +90,116 @@ public enum FishingSpot
 		ROD_FISHING_SPOT_7463, ROD_FISHING_SPOT_7464, ROD_FISHING_SPOT_7468,
 		ROD_FISHING_SPOT_8524
 	),
-	LAVA_EEL("Lava eel", ItemID.LAVA_EEL,
+	LAVA_EEL("Bait (Lava)","Lava Eel", new LinkedHashMap<>(){{
+		put(FishingTools.OILY_FISHING_ROD, new Catches("Lava Eel", ItemID.RAW_LAVA_EEL));
+	}},
 		FISHING_SPOT_4928, FISHING_SPOT_6784
 	),
-	BARB_FISH("Sturgeon, Salmon, Trout", ItemID.LEAPING_STURGEON,
+	BARB_FISH("Use-rod (Barbarian)", "Sturgeon, Salmon, Trout", new LinkedHashMap<>(){{
+		put(FishingTools.BARBARIAN_ROD, new Catches("Leaping Trout, Salmon, Sturgeon", ItemID.LEAPING_STURGEON));
+	}},
 		FISHING_SPOT_1542, FISHING_SPOT_7323
 	),
-	ANGLERFISH("Anglerfish", ItemID.RAW_ANGLERFISH,
+	ANGLERFISH("Bait (Anglerfish)", "Anglerfish", new LinkedHashMap<>(){{
+		put(FishingTools.FISHING_ROD, new Catches("Anglerfish", ItemID.RAW_ANGLERFISH));
+	}},
 		ROD_FISHING_SPOT_6825
 	),
-	MINNOW("Minnow", ItemID.MINNOW,
+	MINNOW("Net (Minnow)", "Minnow", new LinkedHashMap<>(){{
+		put(FishingTools.SMALL_FISHING_NET, new Catches("Minnow", ItemID.MINNOW));
+	}},
 		FISHING_SPOT_7730, FISHING_SPOT_7731, FISHING_SPOT_7732, FISHING_SPOT_7733
 	),
-	HARPOONFISH("Harpoonfish", ItemID.RAW_HARPOONFISH,
+	HARPOONFISH("Tempoross Cove", "Harpoonfish", new LinkedHashMap<>(){{
+		put(FishingTools.HARPOON, new Catches("Harpoonfish", ItemID.HARPOONFISH));
+	}},
 		FISHING_SPOT_10565, FISHING_SPOT_10568, FISHING_SPOT_10569
 	),
-	INFERNAL_EEL("Infernal Eel", ItemID.INFERNAL_EEL,
+	INFERNAL_EEL("Bait (Infernal)", "Infernal Eel", new LinkedHashMap<>(){{
+		put(FishingTools.OILY_FISHING_ROD, new Catches("Infernal Eel", ItemID.INFERNAL_EEL));
+	}},
 		ROD_FISHING_SPOT_7676
 	),
-	KARAMBWAN("Karambwan", ItemID.RAW_KARAMBWAN,
+	KARAMBWAN("Fish (Karambwan)", "Karambwan", new LinkedHashMap<>(){{
+		put(FishingTools.KARAMBWAN_VESSEL, new Catches("Karambwan", ItemID.RAW_KARAMBWAN));
+	}},
 		FISHING_SPOT_4712, FISHING_SPOT_4713
 	),
-	KARAMBWANJI("Karambwanji, Shrimp", "Karambwanji", ItemID.KARAMBWANJI,
+	KARAMBWANJI("Net (Karambwanji)", "Karambwanji", new LinkedHashMap<>(){{
+		put(FishingTools.SMALL_FISHING_NET, new Catches("Karambwanji, Shrimp", ItemID.KARAMBWANJI));
+	}},
 		FISHING_SPOT_4710
 	),
-	SACRED_EEL("Sacred eel", ItemID.SACRED_EEL,
+	SACRED_EEL("Bait (Sacred)", "Sacred eel", new LinkedHashMap<>(){{
+		put(FishingTools.FISHING_ROD, new Catches("Sacred Eel", ItemID.SACRED_EEL));
+	}},
 		FISHING_SPOT_6488
 	),
-	CAVE_EEL("Frog spawn, Cave eel", ItemID.RAW_CAVE_EEL,
+	CAVE_EEL("Net/Bait (Frogspawn)", "Frog Spawn, Cave Eel", new LinkedHashMap<>(){{
+		put(FishingTools.SMALL_FISHING_NET, new Catches("Frog Spawn", ItemID.FROG_SPAWN));
+		put(FishingTools.FISHING_ROD, new Catches("Slimy Eel, Cave Eel", ItemID.RAW_CAVE_EEL));
+	}},
 		FISHING_SPOT_1497, FISHING_SPOT_1498, FISHING_SPOT_1499, FISHING_SPOT_1500
 	),
-	SLIMY_EEL("Slimy eel", ItemID.RAW_SLIMY_EEL,
+	SLIMY_EEL("Bait (Swamp)", "Slimy Eel", new LinkedHashMap<>(){{
+		put(FishingTools.FISHING_ROD, new Catches("Slimy Eel", ItemID.RAW_SLIMY_EEL));
+	}},
 		FISHING_SPOT_2653, FISHING_SPOT_2654, FISHING_SPOT_2655
 	),
-	DARK_CRAB("Dark Crab", ItemID.RAW_DARK_CRAB,
+	DARK_CRAB("Cage/Harpoon (Wilderness)", "Dark Crab", new LinkedHashMap<>(){{
+		put(FishingTools.LOBSTER_POT, new Catches("Dark Crab, Lobster", ItemID.RAW_DARK_CRAB));
+		put(FishingTools.HARPOON, new Catches("Tuna, Swordfish", ItemID.RAW_SWORDFISH));
+	}},
 		FISHING_SPOT_1535, FISHING_SPOT_1536
 	),
-	COMMON_TENCH("Common tench, Bluegill, Greater siren, Mottled eel", "Greater siren", ItemID.COMMON_TENCH,
+	COMMON_TENCH("Catch (Aerial Fishing)", "Aerial Fishing", new LinkedHashMap<>(){{
+		put(FishingTools.CORMORANTS_GLOVE, new Catches("Bluegill, Common Tench, Mottled Eel, Greater Siren", ItemID.COMMON_TENCH));
+	}},
 		FISHING_SPOT_8523
 	),
-	TUTORIAL_SHRIMP("Shrimp", ItemID.RAW_SHRIMPS,
+	TUTORIAL_SHRIMP("Fish (Tutorial Island)", "Shrimp", new LinkedHashMap<>(){{
+		put(FishingTools.SMALL_FISHING_NET, new Catches("Your first catch", ItemID.RAW_SHRIMPS));
+	}},
 		FISHING_SPOT_3317
 	),
-	ETCETERIA_LOBSTER("Lobster", "Lobster (Approval only)", ItemID.RAW_LOBSTER,
+	ETCETERIA_LOBSTER("Cage/Harpoon (Approval only)", "Lobster (Approval only)", new LinkedHashMap<>(){{
+		put(FishingTools.LOBSTER_POT, new Catches("Lobster (Approval only)", ItemID.RAW_LOBSTER));
+		put(FishingTools.HARPOON, new Catches("Tuna, Swordfish (Approval only)", ItemID.RAW_SWORDFISH));
+	}},
 		FISHING_SPOT_3657
 	),
-	QUEST_RUM_DEAL("Sluglings", "Rum deal (Quest)", ItemID.SLUGLINGS,
+	QUEST_RUM_DEAL("Fish (Braindeath Island)", "Rum Deal (Quest)", new LinkedHashMap<>(){{
+		put(FishingTools.FISHBOWL_NET, new Catches("Sluglings, Karamthulhu", ItemID.SLUGLINGS));
+	}},
 		FISHING_SPOT
 	),
-	QUEST_TAI_BWO_WANNAI_TRIO("Karambwan", "Tai Bwo Wannai Trio (Quest)", ItemID.RAW_KARAMBWAN,
+	QUEST_TAI_BWO_WANNAI_TRIO("Fish (Tai Bwo Wannai Trio)", "Tai Bwo Wannai Trio (Quest)", new LinkedHashMap<>(){{
+		put(FishingTools.KARAMBWAN_VESSEL, new Catches("Karambwan", ItemID.RAW_KARAMBWAN));
+	}},
 		FISHING_SPOT_4714
 	),
-	QUEST_FISHING_CONTEST("Giant carp", "Fishing Contest (Quest)", ItemID.GIANT_CARP,
+	QUEST_FISHING_CONTEST("Fish (Hemenster)", "Fishing Contest (Quest)", new LinkedHashMap<>(){{
+		put(FishingTools.FISHING_ROD, new Catches("Giant Carp", ItemID.RAW_GIANT_CARP));
+	}},
 		FISHING_SPOT_4079, FISHING_SPOT_4080, FISHING_SPOT_4081, FISHING_SPOT_4082
 	),
 	;
+
+	private static class Catches{
+		private final String fishName;
+		private final int fishSpriteId;
+
+		Catches(String fish, int spriteId) {
+			this.fishName = fish;
+			this.fishSpriteId = spriteId;
+		}
+	}
 
 	private static final Map<Integer, FishingSpot> SPOTS;
 
 	private final String name;
 	private final String worldMapTooltip;
-	private final int fishSpriteId;
+	private final LinkedHashMap<FishingTools, Catches> catchMap;
 	private final int[] ids;
 
 	static
@@ -145,16 +217,11 @@ public enum FishingSpot
 		SPOTS = builder.build();
 	}
 
-	FishingSpot(String spot, int fishSpriteId, int... ids)
+	FishingSpot(String style, String worldMapTooltip, LinkedHashMap<FishingTools, Catches> catchMap, int... ids)
 	{
-		this(spot, spot, fishSpriteId, ids);
-	}
-
-	FishingSpot(String spot, String worldMapTooltip, int fishSpriteId, int... ids)
-	{
-		this.name = spot;
+		this.name = style;
 		this.worldMapTooltip = worldMapTooltip;
-		this.fishSpriteId = fishSpriteId;
+		this.catchMap = catchMap;
 		this.ids = ids;
 	}
 
@@ -162,4 +229,64 @@ public enum FishingSpot
 	{
 		return SPOTS.get(id);
 	}
+	public boolean isEquippedToFish(Set<FishingTools> usableGear)
+	{
+		for (FishingTools gear : usableGear)
+		{
+			for (FishingTools neededGear : this.catchMap.keySet())
+			{
+				if (gear.equals(neededGear)){
+					return true;
+				}
+			}
+		}
+		return false;
+	}
+	public int getFishSpriteId()
+	{
+		int id = 0;
+		for (Map.Entry<FishingTools, Catches> catchEntry : this.catchMap.entrySet()){
+			if (id == 0) {
+				id = catchEntry.getValue().fishSpriteId;
+			}
+		}
+		return id;
+	}
+	public int getFishSpriteId(Set<FishingTools> usableGear)
+	{
+		int id = 0;
+		for (Map.Entry<FishingTools, Catches> catchEntry : this.catchMap.entrySet()){
+			if (usableGear.contains(catchEntry.getKey()) && id == 0) {
+				id = catchEntry.getValue().fishSpriteId;
+			}
+		}
+		return id;
+	}
+	public String getFishNames(){
+		String str = "";
+		for (Map.Entry<FishingTools, Catches> catchEntry : this.catchMap.entrySet()){
+			str = str.concat(catchEntry.getValue().fishName);
+			str = str.concat(", ");
+		}
+
+		str = str.substring(0, str.length() - 2);
+
+		return str;
+	}
+
+	public String getFishNames(Set<FishingTools> usableGear){
+		String str = "";
+		for (Map.Entry<FishingTools, Catches> catchEntry : this.catchMap.entrySet()){
+			if (usableGear.contains(catchEntry.getKey())){
+				str = str.concat(catchEntry.getValue().fishName);
+				str = str.concat(", ");
+			}
+		}
+		if (!str.equals("")){
+			str = str.substring(0, str.length() - 2);
+		}
+
+		return str;
+	}
+
 }

--- a/runelite-client/src/main/java/net/runelite/client/game/FishingSpot.java
+++ b/runelite-client/src/main/java/net/runelite/client/game/FishingSpot.java
@@ -33,7 +33,7 @@ import static net.runelite.api.NpcID.*;
 @Getter
 public enum FishingSpot
 {
-	SHRIMP("Shrimp, Anchovies", "Anchovies", ItemID.RAW_SHRIMPS,
+	SHRIMP("Shrimp, Sardine, Herring, Anchovies", "Anchovies", ItemID.RAW_SHRIMPS,
 		FISHING_SPOT_1514, FISHING_SPOT_1517, FISHING_SPOT_1518,
 		FISHING_SPOT_1521, FISHING_SPOT_1523, FISHING_SPOT_1524,
 		FISHING_SPOT_1525, FISHING_SPOT_1528, FISHING_SPOT_1530,

--- a/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingConfig.java
@@ -192,4 +192,12 @@ public interface FishingConfig extends Config
 	{
 		return true;
 	}
+
+	@ConfigItem(
+			position = 13,
+			keyName = "onlyEquippedFor",
+			name = "Display only spots you're equipped for",
+			description = "Configures whether only tiles relevant to your fishing gear are displayed."
+	)
+	default boolean onlyEquippedFor(){return false;}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingPlugin.java
@@ -28,11 +28,7 @@ package net.runelite.client.plugins.fishing;
 import com.google.inject.Provides;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import lombok.AccessLevel;
@@ -134,6 +130,7 @@ public class FishingPlugin extends Plugin
 		overlayManager.add(overlay);
 		overlayManager.add(spotOverlay);
 		overlayManager.add(fishingSpotMinimapOverlay);
+		usableGear = new HashSet<>();
 	}
 
 	@Override
@@ -183,8 +180,8 @@ public class FishingPlugin extends Plugin
 		}
 
 		final boolean showOverlays = session.getLastFishCaught() != null
-			|| canPlayerFish(client.getItemContainer(InventoryID.INVENTORY))
-			|| canPlayerFish(client.getItemContainer(InventoryID.EQUIPMENT));
+			|| canPlayerFish(client.getItemContainer(InventoryID.INVENTORY),
+							 client.getItemContainer(InventoryID.EQUIPMENT));
 
 		if (!showOverlays)
 		{
@@ -242,50 +239,58 @@ public class FishingPlugin extends Plugin
 
 		currentSpot = spot;
 	}
+	@Getter
+	private Set<FishingTools> usableGear;
 
-	private boolean canPlayerFish(final ItemContainer itemContainer)
+	private boolean canPlayerFish(final ItemContainer... itemContainer)
 	{
-		if (itemContainer == null)
-		{
-			return false;
-		}
-
-		for (Item item : itemContainer.getItems())
-		{
-			switch (item.getId())
+		usableGear.clear();
+		for(ItemContainer container : itemContainer){
+			if (container == null)
 			{
-				case ItemID.DRAGON_HARPOON:
-				case ItemID.DRAGON_HARPOON_OR:
-				case ItemID.INFERNAL_HARPOON:
-				case ItemID.INFERNAL_HARPOON_UNCHARGED:
-				case ItemID.INFERNAL_HARPOON_UNCHARGED_25367:
-				case ItemID.HARPOON:
-				case ItemID.BARBTAIL_HARPOON:
-				case ItemID.BIG_FISHING_NET:
-				case ItemID.SMALL_FISHING_NET:
-				case ItemID.SMALL_FISHING_NET_6209:
-				case ItemID.FISHING_ROD:
-				case ItemID.FLY_FISHING_ROD:
-				case ItemID.PEARL_BARBARIAN_ROD:
-				case ItemID.PEARL_FISHING_ROD:
-				case ItemID.PEARL_FLY_FISHING_ROD:
-				case ItemID.BARBARIAN_ROD:
-				case ItemID.OILY_FISHING_ROD:
-				case ItemID.LOBSTER_POT:
-				case ItemID.KARAMBWAN_VESSEL:
-				case ItemID.KARAMBWAN_VESSEL_3159:
-				case ItemID.CORMORANTS_GLOVE:
-				case ItemID.CORMORANTS_GLOVE_22817:
-				case ItemID.INFERNAL_HARPOON_OR:
-				case ItemID.TRAILBLAZER_HARPOON:
-				case ItemID.CRYSTAL_HARPOON:
-				case ItemID.CRYSTAL_HARPOON_23864:
-				case ItemID.CRYSTAL_HARPOON_INACTIVE:
-					return true;
+				break;
+			}
+
+			for (Item item : container.getItems())
+			{
+				int itemID = item.getId();
+				switch (itemID)
+				{
+					case ItemID.DRAGON_HARPOON:
+					case ItemID.DRAGON_HARPOON_OR:
+					case ItemID.INFERNAL_HARPOON:
+					case ItemID.INFERNAL_HARPOON_UNCHARGED:
+					case ItemID.INFERNAL_HARPOON_UNCHARGED_25367:
+					case ItemID.HARPOON:
+					case ItemID.BARBTAIL_HARPOON:
+					case ItemID.BIG_FISHING_NET:
+					case ItemID.SMALL_FISHING_NET:
+					case ItemID.SMALL_FISHING_NET_6209:
+					case ItemID.FISHING_ROD:
+					case ItemID.FLY_FISHING_ROD:
+					case ItemID.PEARL_BARBARIAN_ROD:
+					case ItemID.PEARL_FISHING_ROD:
+					case ItemID.PEARL_FLY_FISHING_ROD:
+					case ItemID.BARBARIAN_ROD:
+					case ItemID.OILY_FISHING_ROD:
+					case ItemID.LOBSTER_POT:
+					case ItemID.KARAMBWAN_VESSEL:
+					case ItemID.KARAMBWAN_VESSEL_3159:
+					case ItemID.CORMORANTS_GLOVE:
+					case ItemID.CORMORANTS_GLOVE_22817:
+					case ItemID.INFERNAL_HARPOON_OR:
+					case ItemID.TRAILBLAZER_HARPOON:
+					case ItemID.CRYSTAL_HARPOON:
+					case ItemID.CRYSTAL_HARPOON_23864:
+					case ItemID.CRYSTAL_HARPOON_INACTIVE:
+					case ItemID.FISHBOWL_AND_NET:
+						usableGear.add(FishingTools.getToolType(itemID));
+				}
 			}
 		}
 
-		return false;
+		// If we've got gear, we can fish
+		return usableGear.size() > 0;
 	}
 
 	@Subscribe

--- a/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingSpotOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingSpotOverlay.java
@@ -106,6 +106,10 @@ class FishingSpotOverlay extends Overlay
 				continue;
 			}
 
+			if (config.onlyEquippedFor() && !spot.isEquippedToFish(plugin.getUsableGear())){
+				continue;
+			}
+
 			Color color;
 			if (npc.getGraphic() == GraphicID.FLYING_FISH)
 			{
@@ -162,7 +166,12 @@ class FishingSpotOverlay extends Overlay
 
 			if (config.showSpotIcons())
 			{
-				BufferedImage fishImage = itemManager.getImage(spot.getFishSpriteId());
+				BufferedImage fishImage;
+				if (config.onlyEquippedFor()) {
+					fishImage = itemManager.getImage(spot.getFishSpriteId(plugin.getUsableGear()));
+				} else {
+					fishImage = itemManager.getImage(spot.getFishSpriteId());
+				}
 
 				if (spot == FishingSpot.COMMON_TENCH
 					&& npc.getWorldLocation().distanceTo2D(client.getLocalPlayer().getWorldLocation()) <= ONE_TICK_AERIAL_FISHING)
@@ -182,7 +191,12 @@ class FishingSpotOverlay extends Overlay
 
 			if (config.showSpotNames())
 			{
-				String text = spot.getName();
+				String text;
+				if (config.onlyEquippedFor()){
+					text = spot.getFishNames(plugin.getUsableGear());
+				} else {
+					text = spot.getFishNames();
+				}
 				Point textLocation = npc.getCanvasTextLocation(graphics, text, npc.getLogicalHeight() + 40);
 
 				if (textLocation != null)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingTools.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingTools.java
@@ -1,0 +1,83 @@
+package net.runelite.client.plugins.fishing;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import lombok.Getter;
+import net.runelite.api.ItemID;
+import net.runelite.client.game.FishingSpot;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+@SuppressWarnings("SpellCheckingInspection")
+@Getter
+public enum FishingTools {
+    SMALL_FISHING_NET(
+            ItemID.SMALL_FISHING_NET,
+            ItemID.SMALL_FISHING_NET_6209
+    ),
+    BIG_FISHING_NET(
+            ItemID.BIG_FISHING_NET
+    ),
+    FISHING_ROD(
+            ItemID.FISHING_ROD,
+            ItemID.PEARL_FISHING_ROD
+    ),
+    FLY_FISHING_ROD(
+            ItemID.FLY_FISHING_ROD,
+            ItemID.PEARL_FLY_FISHING_ROD
+    ),
+    OILY_FISHING_ROD(
+            ItemID.OILY_FISHING_ROD,
+            ItemID.OILY_PEARL_FISHING_ROD
+    ),
+    BARBARIAN_ROD(
+            ItemID.BARBARIAN_ROD,
+            ItemID.PEARL_BARBARIAN_ROD
+    ),
+    HARPOON(
+            ItemID.HARPOON,
+            ItemID.BARBTAIL_HARPOON,
+            ItemID.DRAGON_HARPOON,
+            ItemID.DRAGON_HARPOON_OR,
+            ItemID.INFERNAL_HARPOON,
+            ItemID.INFERNAL_HARPOON_OR,
+            ItemID.INFERNAL_HARPOON_UNCHARGED,
+            ItemID.INFERNAL_HARPOON_UNCHARGED_25367,
+            ItemID.CRYSTAL_HARPOON,
+            ItemID.CRYSTAL_HARPOON_23864,
+            ItemID.CRYSTAL_HARPOON_INACTIVE,
+            ItemID.TRAILBLAZER_HARPOON
+    ),
+    LOBSTER_POT(
+            ItemID.LOBSTER_POT
+    ),
+    KARAMBWAN_VESSEL(
+            ItemID.KARAMBWAN_VESSEL,
+            ItemID.KARAMBWAN_VESSEL_3159
+    ),
+    CORMORANTS_GLOVE(
+            ItemID.CORMORANTS_GLOVE,
+            ItemID.CORMORANTS_GLOVE_22817
+    ),
+    FISHBOWL_NET(
+            ItemID.FISHBOWL_AND_NET
+    );
+    @Getter
+    private final ImmutableSet<Integer> tools;
+
+    FishingTools(Integer... itemIDs){this.tools = ImmutableSet.copyOf(itemIDs);}
+
+    public static FishingTools getToolType(Integer itemID)
+    {
+     for (FishingTools toolType : FishingTools.values()){
+         for (Integer toolID : toolType.getTools()){
+             if (toolID.equals(itemID)){
+                 return toolType;
+             }
+         }
+     }
+     // ItemID provided was not a fishing tool
+     return null;
+    }
+}


### PR DESCRIPTION
Provides a toggle for users to only have Fishing Spots appear if they have the necessary equipment to fish.

- Created a new public `FishingTools` enum which holds an ImmutableSet of ItemIDs which fall under that equipment/fishing style type.
- Fishing Plugin maintains a private Set of `FishingTools` enums named `usableGear` which contains the tool categories the player has access to fish with.

- `FishingSpot` enums now contain a LinkedHashMap with `FishingTools` enums as keys and a `Catches` value
L `Catches` is a private class under `FishingSpot.java` which contains a String of the names of catchable fish using that tool as well as the associated fishSpriteID used to render the Icon

- Refactored logic in getting and displaying Fishing Spot names
L When option IS NOT toggled (default) - Fishing spot will concat the names of ALL catchable fish to display over the spot*
L When option IS toggled - Only the names of catchable fish will display

- Refactored logic in getting and displaying Fishing Spot sprites
L When option IS NOT toggled (default) - Fishing spot will display the sprite of the first entry of the LinkedHashMap
L When option IS toggled - Fishing spot will display the sprite of the first entry the user has gear for