### PR TITLE
Clamp color picker window position to screen bounds

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
@@ -543,7 +543,7 @@ class ConfigPanel extends PluginPanel
 					colorPickerBtn.getColor(),
 					cid.getItem().name(),
 					alphaHidden);
-				colorPicker.setLocation(getLocationOnScreen());
+				colorPicker.setLocationRelativeTo(colorPickerBtn);
 				colorPicker.setOnColorChange(c ->
 				{
 					colorPickerBtn.setColor(c);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenmarkers/ui/ScreenMarkerPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenmarkers/ui/ScreenMarkerPanel.java
@@ -553,7 +553,7 @@ class ScreenMarkerPanel extends JPanel
 			fillColor.getAlpha() == 0 ? ColorUtil.colorWithAlpha(fillColor, DEFAULT_FILL_OPACITY) : fillColor,
 			marker.getMarker().getName() + " Fill",
 			false);
-		colorPicker.setLocation(getLocationOnScreen());
+		colorPicker.setLocationRelativeTo(this);
 		colorPicker.setOnColorChange(c ->
 		{
 			marker.getMarker().setFill(c);
@@ -570,7 +570,7 @@ class ScreenMarkerPanel extends JPanel
 			marker.getMarker().getColor(),
 			marker.getMarker().getName() + " Border",
 			false);
-		colorPicker.setLocation(getLocationOnScreen());
+		colorPicker.setLocationRelativeTo(this);
 		colorPicker.setOnColorChange(c ->
 		{
 			marker.getMarker().setColor(c);

--- a/runelite-client/src/main/java/net/runelite/client/ui/components/colorpicker/RuneliteColorPicker.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/components/colorpicker/RuneliteColorPicker.java
@@ -28,10 +28,15 @@ package net.runelite.client.ui.components.colorpicker;
 import com.google.common.base.Strings;
 import java.awt.BorderLayout;
 import java.awt.Color;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.GraphicsConfiguration;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.GridLayout;
 import java.awt.Insets;
+import java.awt.Point;
+import java.awt.Rectangle;
 import java.awt.Toolkit;
 import java.awt.Window;
 import java.awt.event.ActionEvent;
@@ -393,6 +398,60 @@ public class RuneliteColorPicker extends JDialog
 
 		colorChange(color);
 		updatePanels();
+	}
+
+	@Override
+	public void setLocationRelativeTo(Component c)
+	{
+		if (this.getOwner() == null)
+		{
+			super.setLocationRelativeTo(c);
+			return;
+		}
+
+		GraphicsConfiguration gc = this.getOwner().getGraphicsConfiguration();
+		Insets insets = Toolkit.getDefaultToolkit().getScreenInsets(gc);
+
+		Rectangle gcBounds = gc.getBounds();
+		gcBounds.setRect(
+			gcBounds.x + insets.left,
+			gcBounds.y + insets.top,
+			gcBounds.width - insets.left - insets.right,
+			gcBounds.height - insets.top - insets.bottom);
+
+		Dimension compSize = c.getSize();
+		Point compLocation = c.getLocationOnScreen();
+		Dimension windowSize = getSize();
+
+		int dx = compLocation.x + ((compSize.width - windowSize.width) / 2);
+		int dy = compLocation.y + ((compSize.height - windowSize.height) / 2);
+
+		// Avoid being placed off the edge of the screen:
+		// bottom
+		if (dy + windowSize.height > gcBounds.y + gcBounds.height)
+		{
+			dy = gcBounds.y + gcBounds.height - windowSize.height;
+		}
+
+		// top
+		if (dy < gcBounds.y)
+		{
+			dy = gcBounds.y;
+		}
+
+		// right
+		if (dx + windowSize.width > gcBounds.x + gcBounds.width)
+		{
+			dx = gcBounds.x + gcBounds.width - windowSize.width;
+		}
+
+		// left
+		if (dx < gcBounds.x)
+		{
+			dx = gcBounds.x;
+		}
+
+		setLocation(dx, dy);
 	}
 
 	/**


### PR DESCRIPTION
`setLocationRelativeTo` should be the correct answer for this problem but the jdk implementation for `Window::setLocationRelativeTo`  neglects to account for toolbar insets.

https://github.com/adoptium/jdk11u/blob/master/src/java.desktop/share/classes/java/awt/Window.java#L3273

https://bugs.openjdk.org/browse/JDK-6297309

Closes #15418 
Closes/supersedes  #15426
Closes/supersedes #7642
