### PR TITLE
Item Stats: Added option to show item stats only while bank interface is open

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatConfig.java
@@ -113,6 +113,16 @@ public interface ItemStatConfig extends Config
 	}
 
 	@ConfigItem(
+			keyName = "showStatsOnlyInBank",
+			name = "Show Stats Only In Bank",
+			description = "Show item stats only on items when bank is open."
+	)
+	default boolean showStatsOnlyInBank()
+	{
+		return true;
+	}
+
+	@ConfigItem(
 		keyName = "alwaysShowBaseStats",
 		name = "Always Show Base Stats",
 		description = "Always include the base items stats in the tooltip"

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatConfig.java
@@ -119,7 +119,7 @@ public interface ItemStatConfig extends Config
 	)
 	default boolean showStatsOnlyInBank()
 	{
-		return true;
+		return false;
 	}
 
 	@ConfigItem(

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatOverlay.java
@@ -117,8 +117,8 @@ public class ItemStatOverlay extends Overlay
 		{
 			itemId = widget.getItemId();
 		}
-		else if ((group == WidgetInfo.BANK_INVENTORY_ITEMS_CONTAINER.getGroupId()
-				|| group == WidgetInfo.BANK_ITEM_CONTAINER.getGroupId()) && config.showStatsOnlyInBank())
+		else if (group == WidgetInfo.BANK_INVENTORY_ITEMS_CONTAINER.getGroupId()
+				|| (group == WidgetInfo.BANK_ITEM_CONTAINER.getGroupId() && config.showStatsInBank()) && config.showStatsOnlyInBank())
 		{
 			itemId = widget.getItemId();
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatOverlay.java
@@ -117,9 +117,8 @@ public class ItemStatOverlay extends Overlay
 		{
 			itemId = widget.getItemId();
 		}
-		else if((group == WidgetInfo.BANK_INVENTORY_ITEMS_CONTAINER.getGroupId() ||
-				group == WidgetInfo.BANK_ITEM_CONTAINER.getGroupId())
-			 	&& config.showStatsOnlyInBank())
+		else if ((group == WidgetInfo.BANK_INVENTORY_ITEMS_CONTAINER.getGroupId()
+				|| group == WidgetInfo.BANK_ITEM_CONTAINER.getGroupId()) && config.showStatsOnlyInBank())
 		{
 			itemId = widget.getItemId();
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatOverlay.java
@@ -100,9 +100,9 @@ public class ItemStatOverlay extends Overlay
 		final int group = WidgetInfo.TO_GROUP(widget.getId());
 		int itemId = -1;
 
-		if (group == WidgetInfo.EQUIPMENT.getGroupId() ||
+		if ((group == WidgetInfo.EQUIPMENT.getGroupId() ||
 			// For bank worn equipment, check widget parent to differentiate from normal bank items
-			(group == WidgetID.BANK_GROUP_ID && widget.getParentId() == WidgetInfo.BANK_EQUIPMENT_CONTAINER.getId()))
+			(group == WidgetID.BANK_GROUP_ID && widget.getParentId() == WidgetInfo.BANK_EQUIPMENT_CONTAINER.getId())) && !config.showStatsOnlyInBank())
 		{
 			final Widget widgetItem = widget.getChild(1);
 			if (widgetItem != null)
@@ -110,10 +110,16 @@ public class ItemStatOverlay extends Overlay
 				itemId = widgetItem.getItemId();
 			}
 		}
-		else if (widget.getId() == WidgetInfo.INVENTORY.getId()
+		else if ((widget.getId() == WidgetInfo.INVENTORY.getId()
 			|| group == WidgetInfo.EQUIPMENT_INVENTORY_ITEMS_CONTAINER.getGroupId()
 			|| widget.getId() == WidgetInfo.BANK_ITEM_CONTAINER.getId() && config.showStatsInBank()
-			|| group == WidgetInfo.BANK_INVENTORY_ITEMS_CONTAINER.getGroupId() && config.showStatsInBank())
+			|| group == WidgetInfo.BANK_INVENTORY_ITEMS_CONTAINER.getGroupId() && config.showStatsInBank()) && !config.showStatsOnlyInBank())
+		{
+			itemId = widget.getItemId();
+		}
+		else if((group == WidgetInfo.BANK_INVENTORY_ITEMS_CONTAINER.getGroupId() ||
+				group == WidgetInfo.BANK_ITEM_CONTAINER.getGroupId())
+			 	&& config.showStatsOnlyInBank())
 		{
 			itemId = widget.getItemId();
 		}


### PR DESCRIPTION
Added option to show item stats only while bank interface is open.

Example of what this does:

![java_HAchtpwMrd](https://user-images.githubusercontent.com/19385793/184615207-360053b5-1c88-4e87-b3ce-e94bbd789b6a.gif)
