### PR TITLE
npcaggro: half-calibration nonsense

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/npcunaggroarea/NpcAggroAreaNotWorkingOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npcunaggroarea/NpcAggroAreaNotWorkingOverlay.java
@@ -53,7 +53,7 @@ class NpcAggroAreaNotWorkingOverlay extends OverlayPanel
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
-		if (plugin.getSafeCenters()[1] != null)
+		if (plugin.getSafeCenters()[0] != null && plugin.getSafeCenters()[1] != null)
 		{
 			return null;
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/npcunaggroarea/NpcAggroAreaOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npcunaggroarea/NpcAggroAreaOverlay.java
@@ -66,7 +66,7 @@ class NpcAggroAreaOverlay extends Overlay
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
-		if (!plugin.isActive() || plugin.getSafeCenters()[1] == null)
+		if (!plugin.isActive() || plugin.getSafeCenters()[0] == null || plugin.getSafeCenters()[1] == null)
 		{
 			return null;
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/npcunaggroarea/NpcAggroAreaPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npcunaggroarea/NpcAggroAreaPlugin.java
@@ -167,6 +167,7 @@ public class NpcAggroAreaPlugin extends Plugin
 		loggingIn = false;
 		npcNamePatterns = null;
 		active = false;
+		notifyOnce = false;
 
 		Arrays.fill(linesToDisplay, null);
 	}
@@ -498,7 +499,7 @@ public class NpcAggroAreaPlugin extends Plugin
 				safeCenters[0] = null;
 				safeCenters[1] = null;
 				lastPlayerLocation = null;
-				endTime = null;
+				removeTimer();
 				break;
 		}
 	}


### PR DESCRIPTION
Currently it's possible to half-calibrate the plugin, getting only one of the boxes working. If you half calibrate it, log out, then log back in with the plugin active (i.e. in an area with an NPC its tracking, or with Always active on), it'll throw an error every game tick.

The first commit protects against the error directly: `notifyOnce` wasn't being cleared when it should have.
The second commit protects against half-calibrations by not showing the scene overlay and keeping the tutorial overlay visible until both centres are set.

Hopefully this will also make less users confused about the calibration. *Hopefully*