### PR TITLE
Update world map tooltip positions to stay within the world map

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/worldmap/WorldMapOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/worldmap/WorldMapOverlay.java
@@ -339,16 +339,27 @@ public class WorldMapOverlay extends Overlay
 			return;
 		}
 
-		drawPoint = new Point(drawPoint.getX() + TOOLTIP_OFFSET_WIDTH, drawPoint.getY() + TOOLTIP_OFFSET_HEIGHT);
-
 		final Rectangle bounds = new Rectangle(0, 0, client.getCanvasWidth(), client.getCanvasHeight());
 		final Shape mapArea = getWorldMapClipArea(bounds);
+
 		graphics.setClip(mapArea);
 		graphics.setColor(JagexColors.TOOLTIP_BACKGROUND);
 		graphics.setFont(FontManager.getRunescapeFont());
 		FontMetrics fm = graphics.getFontMetrics();
 		int width = rows.stream().map(fm::stringWidth).max(Integer::compareTo).get();
 		int height = fm.getHeight();
+
+		// Make sure the tooltip stays within the world map
+		Rectangle worldMapBounds = client.getWidget(WidgetInfo.WORLD_MAP_VIEW).getBounds();
+		int drawPointX = drawPoint.getX();
+		int tooltipWidth = width + TOOLTIP_PADDING_WIDTH * 2;
+		int worldMapRightBoundary = (int) (worldMapBounds.getX() + worldMapBounds.getWidth());
+		if (drawPointX + tooltipWidth > worldMapRightBoundary)
+		{
+			drawPointX = worldMapRightBoundary - tooltipWidth;
+		}
+
+		drawPoint = new Point(drawPointX + TOOLTIP_OFFSET_WIDTH, drawPoint.getY() + TOOLTIP_OFFSET_HEIGHT);
 
 		Rectangle tooltipRect = new Rectangle(drawPoint.getX() - TOOLTIP_PADDING_WIDTH, drawPoint.getY() - TOOLTIP_PADDING_HEIGHT, width + TOOLTIP_PADDING_WIDTH * 2, height * rows.size() + TOOLTIP_PADDING_HEIGHT * 2);
 		graphics.fillRect((int) tooltipRect.getX(), (int) tooltipRect.getY(), (int) tooltipRect.getWidth(), (int) tooltipRect.getHeight());


### PR DESCRIPTION
Resolves #14760 

This is my first contribution to RuneLite. Any critiques on style consistency with the project is welcome.

![screenshot](https://user-images.githubusercontent.com/33209567/185772179-c934021d-6877-4430-92e6-317900d058d7.png)