### PR TITLE
timers: add farmer's affinity effect timer

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/Varbits.java
+++ b/runelite-api/src/main/java/net/runelite/api/Varbits.java
@@ -683,7 +683,8 @@ public final class Varbits
 	 */
 	public static final int TELEBLOCK = 4163;
 
-	/**	Farmer's Affinity effect timer
+	/**
+	 * Farmer's Affinity effect timer
 	 * Number of game ticks remaining on Farmer's Affinity effect in intervals of 20; for a value X there are 20 * X game ticks remaining.
 	 * The Farmer's Affinity expires once this reaches 0.
 	 */

--- a/runelite-api/src/main/java/net/runelite/api/Varbits.java
+++ b/runelite-api/src/main/java/net/runelite/api/Varbits.java
@@ -683,6 +683,12 @@ public final class Varbits
 	 */
 	public static final int TELEBLOCK = 4163;
 
+	/**	Farmer's Affinity effect timer
+	 * Number of game ticks remaining on Farmer's Affinity effect in intervals of 20; for a value X there are 20 * X game ticks remaining.
+	 * The Farmer's Affinity expires once this reaches 0.
+	 */
+	public static final int FARMERS_AFFINITY = 11765;
+
 	/**
 	 * How many salt stat boost refreshes the player has remaining.
 	 * This will go down by 1 every 25 ticks (15 seconds) and the player's stats will be restored.

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timers/GameTimer.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timers/GameTimer.java
@@ -88,6 +88,7 @@ enum GameTimer
 	DEATH_CHARGE_COOLDOWN(SpriteID.SPELL_DEATH_CHARGE_DISABLED, GameTimerImageType.SPRITE, "Death charge cooldown", 60, ChronoUnit.SECONDS),
 	CORRUPTION_COOLDOWN(SpriteID.SPELL_GREATER_CORRUPTION_DISABLED, GameTimerImageType.SPRITE, "Corruption cooldown", 30, ChronoUnit.SECONDS),
 	PICKPOCKET_STUN(SpriteID.SKILL_THIEVING, GameTimerImageType.SPRITE, "Stunned", true),
+	FARMERS_AFFINITY(ItemID.GRAIN, GameTimerImageType.ITEM, "Farmer's Affinity", false),
 	SMELLING_SALTS(ItemID.SMELLING_SALTS_2, GameTimerImageType.ITEM, "Smelling salts", true),
 	LIQUID_ADRENALINE(ItemID.LIQUID_ADRENALINE_2, GameTimerImageType.ITEM, "Liquid adrenaline", 150, ChronoUnit.SECONDS, true),
 	SILK_DRESSING(ItemID.SILK_DRESSING_2, GameTimerImageType.ITEM, "Silk dressing", 100, GAME_TICKS, true),

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersConfig.java
@@ -323,4 +323,14 @@ public interface TimersConfig extends Config
 	{
 		return true;
 	}
+
+	@ConfigItem(
+			keyName = "showFarmersAffinity",
+			name = "Farmer's Affinity",
+			description = "Configures whether Farmer's Affinity (Puro-Puro) timer is displayed"
+	)
+	default boolean showFarmersAffinity()
+	{
+		return true;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersConfig.java
@@ -325,9 +325,9 @@ public interface TimersConfig extends Config
 	}
 
 	@ConfigItem(
-			keyName = "showFarmersAffinity",
-			name = "Farmer's Affinity",
-			description = "Configures whether Farmer's Affinity (Puro-Puro) timer is displayed"
+		keyName = "showFarmersAffinity",
+		name = "Farmer's Affinity",
+		description = "Configures whether Farmer's Affinity (Puro-Puro) timer is displayed"
 	)
 	default boolean showFarmersAffinity()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersPlugin.java
@@ -78,7 +78,7 @@ import org.apache.commons.lang3.ArrayUtils;
 @PluginDescriptor(
 	name = "Timers",
 	description = "Show various timers in an infobox",
-	tags = {"combat", "items", "magic", "potions", "prayer", "overlay", "abyssal", "sire", "inferno", "fight", "caves", "cape", "timer", "tzhaar", "thieving", "pickpocket"}
+	tags = {"combat", "items", "magic", "potions", "prayer", "overlay", "abyssal", "sire", "inferno", "fight", "caves", "cape", "timer", "tzhaar", "thieving", "pickpocket", "hunter", "imp"}
 )
 @Slf4j
 public class TimersPlugin extends Plugin
@@ -291,6 +291,19 @@ public class TimersPlugin extends Plugin
 			}
 		}
 
+		if (event.getVarbitId() == Varbits.FARMERS_AFFINITY && config.showFarmersAffinity())
+		{
+			final int farmersAffinityVarb = event.getValue();
+			if (farmersAffinityVarb > 0)
+			{
+				createGameTimer(FARMERS_AFFINITY, Duration.of((farmersAffinityVarb * 20L), RSTimeUnit.GAME_TICKS));
+			}
+			else
+			{
+				removeGameTimer(FARMERS_AFFINITY);
+			}
+		}
+
 		if (event.getVarbitId() == Varbits.IMBUED_HEART_COOLDOWN && config.showImbuedHeart())
 		{
 			final int imbuedHeartCooldownVarb = event.getValue();
@@ -497,6 +510,11 @@ public class TimersPlugin extends Plugin
 		else
 		{
 			createTzhaarTimer();
+		}
+
+		if (!config.showFarmersAffinity())
+		{
+			removeGameTimer(FARMERS_AFFINITY);
 		}
 
 		if (!config.showLiquidAdrenaline())


### PR DESCRIPTION
Enhancement on the timers plugin to add the Farmer's Affinity effect timer (going through wheat faster in Puro-Puro).

![image](https://user-images.githubusercontent.com/83126316/186285395-98957a59-60c1-4d9b-9733-1d8f48343f2b.png)