### PR TITLE
achievementdiary: fix castle wars task's requirements

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/ArdougneDiaryRequirement.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/ArdougneDiaryRequirement.java
@@ -128,7 +128,7 @@ public class ArdougneDiaryRequirement extends GenericDiaryRequirement
 			new SkillRequirement(Skill.FARMING, 85));
 		add("Complete a lap of Ardougne's rooftop agility course.",
 			new SkillRequirement(Skill.AGILITY, 90));
-		add("Cast Ice Barrage on another player within Castlewars.",
+		add("Cast Ice Barrage on another player within Castle Wars.",
 			new SkillRequirement(Skill.MAGIC, 94),
 			new QuestRequirement(Quest.DESERT_TREASURE));
 	}


### PR DESCRIPTION
Ardougne Elite Diary task at Castle Wars was changed by Jagex at some point. I've updated the string for the requirements to display again.
![image](https://user-images.githubusercontent.com/83126316/186437633-654fd1bf-727b-4196-9c58-57b3e8b08d70.png)

