### PR TITLE
achievementdiary: fix fremennik gwd task text

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/FremennikDiaryRequirement.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/FremennikDiaryRequirement.java
@@ -119,7 +119,7 @@ public class FremennikDiaryRequirement extends GenericDiaryRequirement
 			new QuestRequirement(Quest.THE_FREMENNIK_ISLES, true));
 		add("Complete a lap of the Rellekka agility course.",
 			new SkillRequirement(Skill.AGILITY, 80));
-		add("Kill each of the Godwars generals.",
+		add("Kill the generals of Armadyl, Bandos, Saradomin and Zamorak in the God Wars Dungeon.",
 			new SkillRequirement(Skill.AGILITY, 70),
 			new SkillRequirement(Skill.STRENGTH, 70),
 			new SkillRequirement(Skill.HITPOINTS, 70),


### PR DESCRIPTION
Fremennik Elite Diary task at God Wars Dungeon was changed by Jagex (probably due to Nex). I've updated the string for the requirements to display again.
![image](https://user-images.githubusercontent.com/83126316/186495945-8bab7940-3451-4656-b7d9-302305b145e9.png)
