### PR TITLE
RegenMeter: Add support for Lightbearer

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/regenmeter/RegenMeterPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/regenmeter/RegenMeterPlugin.java
@@ -151,15 +151,14 @@ public class RegenMeterPlugin extends Plugin
 		ItemContainer container = itemContainerChanged.getItemContainer();
 		Item newRing = container.getItem(EquipmentInventorySlot.RING.getSlotIdx());
 
+		specRegenTicks = newRing == null ? 50
+				: newRing.getId() == ItemID.LIGHTBEARER ? 25
+				: 50;
+
 		if (ring != null && ring.getId() == ItemID.LIGHTBEARER)
 		{
-			if (newRing != null && newRing.getId() == ItemID.LIGHTBEARER)
+			if (newRing == null || newRing.getId() != ItemID.LIGHTBEARER)
 			{
-				specRegenTicks = 25;
-			}
-			else
-			{
-				specRegenTicks = 50;
 				ticksSinceSpecRegen = 0;
 			}
 		}
@@ -167,12 +166,7 @@ public class RegenMeterPlugin extends Plugin
 		{
 			if (newRing != null && newRing.getId() == ItemID.LIGHTBEARER)
 			{
-				specRegenTicks = 25;
 				ticksSinceSpecRegen = 0;
-			}
-			else
-			{
-				specRegenTicks = 50;
 			}
 		}
 		ring = newRing;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/regenmeter/RegenMeterPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/regenmeter/RegenMeterPlugin.java
@@ -146,7 +146,11 @@ public class RegenMeterPlugin extends Plugin
 
 			// It's possible to regenerate less than 10 percent special attack energy
 			// E.g. if the player has 92.5/95/97.5 percent and regenerates to 100 percent
-			ticksSinceSpecRegen = (currentSpecialAttackEnergy - specialAttackEnergy) <= 100 ? 0 : ticksSinceSpecRegen;
+			int difference = currentSpecialAttackEnergy - specialAttackEnergy;
+			if (0 < difference && difference <= 100)
+			{
+				ticksSinceSpecRegen = 0;
+			}
 			specialAttackEnergy = currentSpecialAttackEnergy;
 		}
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/regenmeter/RegenMeterPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/regenmeter/RegenMeterPlugin.java
@@ -88,6 +88,7 @@ public class RegenMeterPlugin extends Plugin
 	Item ring = null;
 
 	private int specRegenTicks = 50;
+	private int specialAttackEnergy;
 	private int ticksSinceSpecRegen;
 	private int ticksSinceHPRegen;
 	private boolean wasRapidHeal;
@@ -138,6 +139,16 @@ public class RegenMeterPlugin extends Plugin
 			ticksSinceHPRegen = 0;
 		}
 		wasRapidHeal = isRapidHeal;
+
+		if (ev.getIndex() == VarPlayer.SPECIAL_ATTACK_PERCENT.getId())
+		{
+			int currentSpecialAttackEnergy = client.getVarpValue(VarPlayer.SPECIAL_ATTACK_PERCENT.getId());
+
+			// It's possible to regenerate less than 10 percent special attack energy
+			// E.g. if the player has 92.5/95/97.5 percent and regenerates to 100 percent
+			ticksSinceSpecRegen = (currentSpecialAttackEnergy - specialAttackEnergy) <= 100 ? 0 : ticksSinceSpecRegen;
+			specialAttackEnergy = currentSpecialAttackEnergy;
+		}
 	}
 
 	@Subscribe


### PR DESCRIPTION
Lightbearer ring has a unique mechanic which halves the duration cycle and resets the regeneration cycle for special attacks when equipped or unequipped. This PR adds support for the item's functions to the Regen Meter plugin.

Ref: #15478