### PR TITLE
timers: add tombs of amascut consumables

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/Varbits.java
+++ b/runelite-api/src/main/java/net/runelite/api/Varbits.java
@@ -676,4 +676,19 @@ public final class Varbits
 	 * 101 &lt;= Teleblock active, remaining ticks of blocking effect
 	 */
 	public static final int TELEBLOCK = 4163;
+
+	/**
+	 * How many salt stat boost refreshes the player has remaining.
+	 * This will go down by 1 every 25 ticks (15 seconds) and the player's stats will be restored.
+	 * Set to 32 upon crushing salts.
+	 */
+	public static final int SMELLING_SALTS_REFRESHES_REMAINING = 14344;
+
+	/**
+	 * If the player has liquid adrenaline buff active
+	 * <p>
+	 * 0 = inactive
+	 * 1 = active
+	 */
+	public static final int LIQUID_ADERNALINE_ACTIVE = 14361;
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timers/GameTimer.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timers/GameTimer.java
@@ -87,7 +87,11 @@ enum GameTimer
 	WARD_OF_ARCEUUS_COOLDOWN(SpriteID.SPELL_WARD_OF_ARCEUUS_DISABLED, GameTimerImageType.SPRITE, "Ward of Arceuus cooldown", 30, ChronoUnit.SECONDS),
 	DEATH_CHARGE_COOLDOWN(SpriteID.SPELL_DEATH_CHARGE_DISABLED, GameTimerImageType.SPRITE, "Death charge cooldown", 60, ChronoUnit.SECONDS),
 	CORRUPTION_COOLDOWN(SpriteID.SPELL_GREATER_CORRUPTION_DISABLED, GameTimerImageType.SPRITE, "Corruption cooldown", 30, ChronoUnit.SECONDS),
-	PICKPOCKET_STUN(SpriteID.SKILL_THIEVING, GameTimerImageType.SPRITE, "Stunned", true)
+	PICKPOCKET_STUN(SpriteID.SKILL_THIEVING, GameTimerImageType.SPRITE, "Stunned", true),
+	SMELLING_SALTS(ItemID.SMELLING_SALTS_2, GameTimerImageType.ITEM, "Smelling salts", 8, ChronoUnit.MINUTES, true),
+	LIQUID_ADRENALINE(ItemID.LIQUID_ADRENALINE_2, GameTimerImageType.ITEM, "Liquid adrenaline", 30, ChronoUnit.SECONDS, true),
+	SILK_DRESSING(ItemID.SILK_DRESSING_2, GameTimerImageType.ITEM, "Silk dressing", 57, ChronoUnit.SECONDS, true),
+	BLESSED_CRYSTAL_SCARAB(ItemID.BLESSED_CRYSTAL_SCARAB_2, GameTimerImageType.ITEM, "Blessed crystal scarab", 21600, ChronoUnit.MILLIS, true),
 	;
 
 	@Nullable

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersConfig.java
@@ -293,4 +293,34 @@ public interface TimersConfig extends Config
 	{
 		return true;
 	}
+
+	@ConfigItem(
+		keyName = "showLiquidAdrenaline",
+		name = "Liquid adrenaline timer",
+		description = "Configures whether liquid adrenaline timer is displayed"
+	)
+	default boolean showLiquidAdrenaline()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		keyName = "showSilkDressing",
+		name = "Silk dressing timer",
+		description = "Configures whether silk dressing timer is displayed"
+	)
+	default boolean showSilkDressing()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		keyName = "showBlessedCrystalScarab",
+		name = "Blessed crystal scarab timer",
+		description = "Configures whether blessed crystal scarab timer is displayed"
+	)
+	default boolean showBlessedCrystalScarab()
+	{
+		return true;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersPlugin.java
@@ -116,10 +116,15 @@ public class TimersPlugin extends Plugin
 	private static final String PICKPOCKET_FAILURE_MESSAGE = "You fail to pick the ";
 	private static final String DODGY_NECKLACE_PROTECTION_MESSAGE = "Your dodgy necklace protects you.";
 	private static final String SHADOW_VEIL_PROTECTION_MESSAGE = "Your attempt to steal goes unnoticed.";
+	private static final String SMELLING_SALTS_MESSAGE = "You crush the salts. Your heart rate increases.";
+	private static final String LIQUID_ADRENALINE_MESSAGE = "You drink some of the potion, reducing the energy cost of your special attacks.</col>";
+	private static final String SILK_DRESSING_MESSAGE = "You quickly apply the dressing to your wounds.";
+	private static final String BLESSED_CRYSTAL_SCARAB_MESSAGE = "You crack the crystal in your hand.";
 
 	private static final Pattern DIVINE_POTION_PATTERN = Pattern.compile("You drink some of your divine (.+) potion\\.");
 	private static final int VENOM_VALUE_CUTOFF = -40; // Antivenom < -40 <= Antipoison < 0
 	private static final int POISON_TICK_LENGTH = 30;
+	private static final int SMELLING_SALTS_TICK_LENGTH = 25;
 
 	static final int FIGHT_CAVES_REGION_ID = 9551;
 	static final int INFERNO_REGION_ID = 9043;
@@ -189,6 +194,31 @@ public class TimersPlugin extends Plugin
 		{
 			removeGameTimer(OVERLOAD_RAID);
 			removeGameTimer(PRAYER_ENHANCE);
+		}
+
+		if (event.getVarbitId() == Varbits.SMELLING_SALTS_REFRESHES_REMAINING && config.showOverload())
+		{
+			if (event.getValue() > 0)
+			{
+				Duration duration = Duration.ofMillis((long) Constants.GAME_TICK_LENGTH * (event.getValue() * SMELLING_SALTS_TICK_LENGTH));
+				createGameTimer(SMELLING_SALTS, duration);
+			}
+			else
+			{
+				removeGameTimer(SMELLING_SALTS);
+			}
+		}
+
+		if (event.getVarbitId() == Varbits.LIQUID_ADERNALINE_ACTIVE && config.showLiquidAdrenaline())
+		{
+			if (event.getValue() == 1)
+			{
+				createGameTimer(LIQUID_ADRENALINE);
+			}
+			else
+			{
+				removeGameTimer(LIQUID_ADRENALINE);
+			}
 		}
 
 		if (event.getVarbitId() == Varbits.VENGEANCE_COOLDOWN && config.showVengeance())
@@ -385,6 +415,7 @@ public class TimersPlugin extends Plugin
 		{
 			removeGameTimer(OVERLOAD);
 			removeGameTimer(OVERLOAD_RAID);
+			removeGameTimer(SMELLING_SALTS);
 		}
 
 		if (!config.showPrayerEnhance())
@@ -467,6 +498,21 @@ public class TimersPlugin extends Plugin
 		else
 		{
 			createTzhaarTimer();
+		}
+
+		if (!config.showLiquidAdrenaline())
+		{
+			removeGameTimer(LIQUID_ADRENALINE);
+		}
+
+		if (!config.showSilkDressing())
+		{
+			removeGameTimer(SILK_DRESSING);
+		}
+
+		if (!config.showBlessedCrystalScarab())
+		{
+			removeGameTimer(BLESSED_CRYSTAL_SCARAB);
 		}
 	}
 
@@ -572,17 +618,38 @@ public class TimersPlugin extends Plugin
 			removeGameTimer(EXANTIFIRE);
 		}
 
-		if (config.showOverload() && message.startsWith("You drink some of your") && message.contains("overload"))
+		if (config.showOverload())
 		{
-			if (client.getVarbitValue(Varbits.IN_RAID) == 1)
+			if (message.startsWith("You drink some of your") && message.contains("overload"))
 			{
-				createGameTimer(OVERLOAD_RAID);
+				if (client.getVarbitValue(Varbits.IN_RAID) == 1)
+				{
+					createGameTimer(OVERLOAD_RAID);
+				}
+				else
+				{
+					createGameTimer(OVERLOAD);
+				}
 			}
-			else
+			else if (message.equals(SMELLING_SALTS_MESSAGE))
 			{
-				createGameTimer(OVERLOAD);
+				createGameTimer(SMELLING_SALTS);
 			}
+		}
 
+		if (config.showLiquidAdrenaline() && message.equals(LIQUID_ADRENALINE_MESSAGE))
+		{
+			createGameTimer(LIQUID_ADRENALINE);
+		}
+
+		if (config.showSilkDressing() && message.equals(SILK_DRESSING_MESSAGE))
+		{
+			createGameTimer(SILK_DRESSING);
+		}
+
+		if (config.showBlessedCrystalScarab() && message.equals(BLESSED_CRYSTAL_SCARAB_MESSAGE))
+		{
+			createGameTimer(BLESSED_CRYSTAL_SCARAB);
 		}
 
 		if (config.showCannon())


### PR DESCRIPTION
Adds timers for the following buffs/effects, enabled by default:

- Smelling salts (overloads)
- Liquid adrenaline
- Silk dressing
- Blessed crystal scarab