### PR TITLE
OpponentInformation: Add config to always display overlay regardless of in-game HP HUD configuration

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/opponentinfo/OpponentInfoConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/opponentinfo/OpponentInfoConfig.java
@@ -63,4 +63,15 @@ public interface OpponentInfoConfig extends Config
 	{
 		return false;
 	}
+
+	@ConfigItem(
+		keyName = "alwaysDisplayInfo",
+		name = "Always display info",
+		description = "Always display the opponent info overlay, regardless of in-game HP HUD configuration",
+		position = 4
+	)
+	default boolean alwaysDisplayInfo()
+	{
+		return false;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/opponentinfo/OpponentInfoOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/opponentinfo/OpponentInfoOverlay.java
@@ -218,12 +218,15 @@ class OpponentInfoOverlay extends OverlayPanel
 		return super.render(graphics);
 	}
 
-	private boolean shouldShowOverlay(Actor opponent) {
-		if (opponentName == null) {
+	private boolean shouldShowOverlay(Actor opponent)
+	{
+		if (opponentName == null)
+		{
 			return false;
 		}
 
-		if (opponentInfoConfig.alwaysDisplayInfo()) {
+		if (opponentInfoConfig.alwaysDisplayInfo())
+		{
 			return true;
 		}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/opponentinfo/OpponentInfoOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/opponentinfo/OpponentInfoOverlay.java
@@ -140,9 +140,7 @@ class OpponentInfoOverlay extends OverlayPanel
 			}
 		}
 
-		// The in-game hp hud is more accurate than our overlay and duplicates all of the information on it,
-		// so hide ours if it is visible.
-		if (opponentName == null || hasHpHud(opponent))
+		if (!shouldShowOverlay(opponent))
 		{
 			return null;
 		}
@@ -218,6 +216,20 @@ class OpponentInfoOverlay extends OverlayPanel
 		}
 
 		return super.render(graphics);
+	}
+
+	private boolean shouldShowOverlay(Actor opponent) {
+		if (opponentName == null) {
+			return false;
+		}
+
+		if (opponentInfoConfig.alwaysDisplayInfo()) {
+			return true;
+		}
+
+		// The in-game hp hud is more accurate than our overlay and duplicates all of the information on it,
+		// so hide ours if it is visible, unless the config explicitly overrides.
+		return !hasHpHud(opponent);
 	}
 
 	/**


### PR DESCRIPTION
Adds a new config for always display the opponent information overlay, ignoring the configuration of the in-game HP HUD.

This is currently very useful in ToA, where Jagex only shows the hitpoints of each boss, and not their percentages. Having the Opponent Information overlay also show percentages is useful for bosses that proc specials at certain thresholds (lots of them).

This was suggested by me in Discord without any comments, so I went ahead and made a pull request to elicit some discussion. I'm open to changing the config name to whatever sounds best.

Discord message: https://discord.com/channels/301497432909414422/301497432909414422/1014023583573479424

I've tested this manually in ToA to confirm both the overlay and the boss hud appear when this is checked. If unchecked, the boss hud takes precedent, as before.