### PR TITLE
puzzle solver: add setting to increase the amount of steps displayed

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/puzzlesolver/PuzzleSolverConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/puzzlesolver/PuzzleSolverConfig.java
@@ -28,6 +28,7 @@ package net.runelite.client.plugins.puzzlesolver;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.Range;
 
 @ConfigGroup("puzzlesolver")
 public interface PuzzleSolverConfig extends Config
@@ -60,5 +61,19 @@ public interface PuzzleSolverConfig extends Config
 	default boolean drawDots()
 	{
 		return false;
+	}
+
+	@Range(
+		min = 1,
+		max = 7
+	)
+	@ConfigItem(
+		keyName = "stepsDisplayed",
+		name = "Steps Displayed",
+		description = "The amount of steps displayed when solving a sliding puzzle"
+	)
+	default int getStepsDisplayed()
+	{
+		return 3;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/puzzlesolver/PuzzleSolverConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/puzzlesolver/PuzzleSolverConfig.java
@@ -65,7 +65,7 @@ public interface PuzzleSolverConfig extends Config
 
 	@Range(
 		min = 1,
-		max = 7
+		max = 5
 	)
 	@ConfigItem(
 		keyName = "stepsDisplayed",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/puzzlesolver/PuzzleSolverOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/puzzlesolver/PuzzleSolverOverlay.java
@@ -220,7 +220,7 @@ public class PuzzleSolverOverlay extends Overlay
 								graphics.setColor(Color.YELLOW);
 
 								// Display the next 4 steps
-								for (int i = 1; i < 5; i++)
+								for (int i = 1; i <= config.getStepsDisplayed(); i++)
 								{
 									int j = solver.getPosition() + i;
 
@@ -259,7 +259,7 @@ public class PuzzleSolverOverlay extends Overlay
 								int lastBlankY = currentMove.getEmptyPiece() / DIMENSION;
 
 								// Display the next 3 steps
-								for (int i = 1; i < 4; i++)
+								for (int i = 1; i <= config.getStepsDisplayed(); i++)
 								{
 									int j = solver.getPosition() + i;
 


### PR DESCRIPTION
I know that displaying more than the current 3/4 steps can result in overlap, but I figured it would be nice to give players the option to have more. I had to cap it at 5 because going any higher results in a negative value for the dot size and I was not comfortable changing any of that code as I'm extremely new to this. I _did_ test changing `DOT_MARKER_SIZE - i * 3` from a 3 to a 2 which allows up to 7 steps to be displayed, but wanted to start with just 5 steps for now.