### PR TITLE
devtools: highlight current region in locations tool inside instances

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/devtools/LocationOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/devtools/LocationOverlay.java
@@ -64,6 +64,8 @@ public class LocationOverlay extends OverlayPanel
 
 		if (client.isInInstancedRegion())
 		{
+			regionID = WorldPoint.fromLocalInstance(client, localPoint).getRegionID();
+
 			panelComponent.getChildren().add(LineComponent.builder()
 				.left("Instance")
 				.build());


### PR DESCRIPTION
When not in instanced regions, the Location devtool highlights the map region including your player as green:

![image](https://user-images.githubusercontent.com/1868974/188776013-26d7f9f6-6d14-46f7-a193-3a5be9026613.png)

This does not currently work in instances since the player region id is not transformed to its corresponding map region.

When in an instance, this PR normalizes the region ID for highlighting to use non-instance regions.