### PR TITLE
TimersPlugin Liquid Adrenaline

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersPlugin.java
@@ -118,6 +118,7 @@ public class TimersPlugin extends Plugin
 	private static final String SHADOW_VEIL_PROTECTION_MESSAGE = "Your attempt to steal goes unnoticed.";
 	private static final String SILK_DRESSING_MESSAGE = "You quickly apply the dressing to your wounds.";
 	private static final String BLESSED_CRYSTAL_SCARAB_MESSAGE = "You crack the crystal in your hand.";
+	private static final String LIQUID_ADRENALINE_MESSAGE = "You drink some of the potion, reducing the energy cost of your special attacks.</col>";
 
 	private static final Pattern DIVINE_POTION_PATTERN = Pattern.compile("You drink some of your divine (.+) potion\\.");
 	private static final int VENOM_VALUE_CUTOFF = -40; // Antivenom < -40 <= Antipoison < 0
@@ -859,6 +860,11 @@ public class TimersPlugin extends Plugin
 		if (message.equals(BLESSED_CRYSTAL_SCARAB_MESSAGE) && config.showBlessedCrystalScarab())
 		{
 			createGameTimer(BLESSED_CRYSTAL_SCARAB);
+		}
+
+		if (message.equals(LIQUID_ADRENALINE_MESSAGE) && config.showLiquidAdrenaline())
+		{
+			createGameTimer(LIQUID_ADRENALINE);
 		}
 	}
 


### PR DESCRIPTION
OnChatMessage to support Liquid Adrenaline because the varbit alone won't track the reset of the timer.

The varbit tracks if Liquid Adrenaline is active but does not track the length left.

Using both Varbit & Chat message will cover both.