### PR TITLE
Screenshot untradeable drops blacklist

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
@@ -109,7 +109,7 @@ public class ScreenshotPlugin extends Plugin
 	private static final Pattern LEVEL_UP_PATTERN = Pattern.compile(".*Your ([a-zA-Z]+) (?:level is|are)? now (\\d+)\\.");
 	private static final Pattern BOSSKILL_MESSAGE_PATTERN = Pattern.compile("Your (.+) kill count is: <col=ff0000>(\\d+)</col>.");
 	private static final Pattern VALUABLE_DROP_PATTERN = Pattern.compile(".*Valuable drop: ([^<>]+?\\(((?:\\d+,?)+) coins\\))(?:</col>)?");
-	private static final Pattern UNTRADEABLE_DROP_PATTERN = Pattern.compile(".*Untradeable drop: ([^<>]+)(?:</col>)?");
+	private static final Pattern UNTRADEABLE_DROP_PATTERN = Pattern.compile(".*Untradeable drop: ((?:\\d+ x )?([^<>]+))(?:</col>)?");
 	private static final Pattern DUEL_END_PATTERN = Pattern.compile("You have now (won|lost) ([0-9,]+) duels?\\.");
 	private static final Pattern QUEST_PATTERN_1 = Pattern.compile(".+?ve\\.*? (?<verb>been|rebuilt|.+?ed)? ?(?:the )?'?(?<quest>.+?)'?(?: [Qq]uest)?[!.]?$");
 	private static final Pattern QUEST_PATTERN_2 = Pattern.compile("'?(?<quest>.+?)'?(?: [Qq]uest)? (?<verb>[a-z]\\w+?ed)?(?: f.*?)?[!.]?$");
@@ -119,6 +119,7 @@ public class ScreenshotPlugin extends Plugin
 	private static final ImmutableList<String> PET_MESSAGES = ImmutableList.of("You have a funny feeling like you're being followed",
 		"You feel something weird sneaking into your backpack",
 		"You have a funny feeling like you would have been followed");
+	private static final ImmutableList<String> EXCLUDED_UNTRADEABLE_DROPS = ImmutableList.of("Hallowed mark", "Serafina's diary", "The butcher", "Arachnids of vampyrium", "The shadow realm", "The wild hunt", "Verzik vitur - patient record", "Apmeken's capture", "Crondis' capture", "Het's capture", "Scabaras' capture", "The wardens");
 	private static final Pattern BA_HIGH_GAMBLE_REWARD_PATTERN = Pattern.compile("(?<reward>.+)!<br>High level gamble count: <col=7f0000>(?<gambleCount>.+)</col>");
 	private static final Set<Integer> REPORT_BUTTON_TLIS = ImmutableSet.of(
 		WidgetID.FIXED_VIEWPORT_GROUP_ID,
@@ -489,9 +490,13 @@ public class ScreenshotPlugin extends Plugin
 			Matcher m = UNTRADEABLE_DROP_PATTERN.matcher(chatMessage);
 			if (m.matches())
 			{
-				String untradeableDropName = m.group(1);
-				String fileName = "Untradeable drop " + untradeableDropName;
-				takeScreenshot(fileName, SD_UNTRADEABLE_DROPS);
+				String nameWithoutQuantity = m.group(2);
+				if (!EXCLUDED_UNTRADEABLE_DROPS.contains(nameWithoutQuantity))
+				{
+					String untradeableDropName = m.group(1);
+					String fileName = "Untradeable drop " + untradeableDropName;
+					takeScreenshot(fileName, SD_UNTRADEABLE_DROPS);
+				}
 			}
 		}
 

--- a/runelite-client/src/test/java/net/runelite/client/plugins/screenshot/ScreenshotPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/screenshot/ScreenshotPluginTest.java
@@ -79,6 +79,8 @@ public class ScreenshotPluginTest
 	private static final String NOT_SO_VALUABLE_DROP = "<col=ef1020>Valuable drop: 6 x Bronze arrow (42 coins)</col>";
 	private static final String VALUABLE_DROP = "<col=ef1020>Valuable drop: Rune scimitar (25,600 coins)</col>";
 	private static final String UNTRADEABLE_DROP = "<col=ef1020>Untradeable drop: Rusty sword";
+	private static final String UNTRADEABLE_DROP_BLACKLISTED_SINGLE = "<col=ef1020>Untradeable drop: Hallowed mark";
+	private static final String UNTRADEABLE_DROP_BLACKLISTED_MULTIPLE = "<col=ef1020>Untradeable drop: 5 x Hallowed mark";
 	private static final String BA_HIGH_GAMBLE_REWARD = "Raw shark (x 300)!<br>High level gamble count: <col=7f0000>100</col>";
 	private static final String HUNTER_LEVEL_2_TEXT = "<col=000080>Congratulations, you've just advanced a Hunter level.<col=000000><br><br>Your Hunter level is now 2.";
 	private static final String COLLECTION_LOG_CHAT = "New item added to your collection log: <col=ef1020>Chompy bird hat</col>";
@@ -257,6 +259,24 @@ public class ScreenshotPluginTest
 		screenshotPlugin.onChatMessage(chatMessageEvent);
 
 		verify(screenshotPlugin).takeScreenshot("Untradeable drop Rusty sword", "Untradeable Drops");
+	}
+
+	@Test
+	public void testBlacklistedSingleUntradeableDrop()
+	{
+		ChatMessage chatMessageEvent = new ChatMessage(null, GAMEMESSAGE, "", UNTRADEABLE_DROP_BLACKLISTED_SINGLE, null, 0);
+		screenshotPlugin.onChatMessage(chatMessageEvent);
+
+		verify(screenshotPlugin, never()).takeScreenshot(anyString(), anyString());
+	}
+
+	@Test
+	public void testBlacklistedMultipleUntradeableDrop()
+	{
+		ChatMessage chatMessageEvent = new ChatMessage(null, GAMEMESSAGE, "", UNTRADEABLE_DROP_BLACKLISTED_MULTIPLE, null, 0);
+		screenshotPlugin.onChatMessage(chatMessageEvent);
+
+		verify(screenshotPlugin, never()).takeScreenshot(anyString(), anyString());
 	}
 
 	@Test


### PR DESCRIPTION
Tested at hallowed sepulchre and in maiden's room. book names from the wiki articles.
I didn't add the mvp toa drops like the big banana because I don't know if they show up as untradeable drops, but they might.

in reference to #15632