### PR TITLE
Add option to display combat levels in Player Indicators plugin

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsConfig.java
@@ -273,4 +273,26 @@ public interface PlayerIndicatorsConfig extends Config
 	{
 		return true;
 	}
+
+	@ConfigItem(
+		position = 16,
+		keyName = "showCombatLevels",
+		name = "Show combat levels",
+		description = "Configures whether or not players' combat levels should be shown in non-PvP areas"
+	)
+	default boolean showCombatLevels()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		position = 17,
+		keyName = "combatLevelType",
+		name = "Combat level type",
+		description = "Which format to use when displaying combat levels"
+	)
+	default PlayerLevelType combatLevelType()
+	{
+		return PlayerLevelType.LONG;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerLevelType.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerLevelType.java
@@ -1,0 +1,24 @@
+package net.runelite.client.plugins.playerindicators;
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public enum PlayerLevelType
+{
+	LONG("Long", " (Level-"),
+	SHORT("Short", " (Lvl-"),
+	LEVEL_ONLY("Level only", " (");
+
+	private final String type;
+	private final String levelString;
+
+	@Override
+	public String toString()
+	{
+		return type;
+	}
+
+	public String getLevelString()
+	{
+		return levelString;
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayUtil.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayUtil.java
@@ -103,6 +103,30 @@ public class OverlayUtil
 		graphics.drawString(text, x, y);
 	}
 
+	public static void renderBiColorTextLocation(Graphics2D graphics, Point txtLoc, String text1, String text2, Color color1, Color color2)
+	{
+		if (Strings.isNullOrEmpty(text1) || Strings.isNullOrEmpty(text2))
+		{
+			return;
+		}
+
+		int x = txtLoc.getX();
+		int y = txtLoc.getY();
+
+		graphics.setColor(Color.BLACK);
+		graphics.drawString(text1, x + 1, y + 1);
+
+		graphics.setColor(ColorUtil.colorWithAlpha(color1, 0xFF));
+		graphics.drawString(text1, x, y);
+
+		int xOffset = graphics.getFontMetrics().stringWidth(text1);
+		graphics.setColor(Color.BLACK);
+		graphics.drawString(text2, x + xOffset + 1, y + 1);
+
+		graphics.setColor(ColorUtil.colorWithAlpha(color2, 0xFF));
+		graphics.drawString(text2, x + xOffset, y);
+	}
+
 	public static void renderImageLocation(Client client, Graphics2D graphics, LocalPoint localPoint, BufferedImage image, int zOffset)
 	{
 		Point imageLocation = Perspective.getCanvasImageLocation(client, localPoint, image, zOffset);


### PR DESCRIPTION
Closes #6567, supersedes #8216

Example:
![image](https://user-images.githubusercontent.com/18340303/189534854-0459ece3-49dd-4836-9490-2727ac00b655.png)

Currently does not allow combat levels to be shown when the player is in a PvP area, so as to avoid issues with the

> Offers additional information about other players, with the purpose of scouting PvP targets

guideline. This may require additional condition checks should the current implementation not suffice (Currently, combat levels will still be shown if player is in a safe area that borders PvP areas, such as the Wilderness ditch or Ferox Enclave.).