### PR TITLE
Fix BA plugin, which was broken in 668d99

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/barbarianassault/BarbarianAssaultPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/barbarianassault/BarbarianAssaultPlugin.java
@@ -155,7 +155,7 @@ public class BarbarianAssaultPlugin extends Plugin
 	@Subscribe
 	public void onVarbitChanged(VarbitChanged event)
 	{
-		if (event.getVarbitId() == Varbits.IN_GAME_BA && event.getValue() == 1)
+		if (event.getVarbitId() == Varbits.IN_GAME_BA && event.getValue() == 0)
 		{
 			currentRound = null;
 


### PR DESCRIPTION
Thanks @Kamielvf 
https://github.com/runelite/runelite/commit/668d99dfef72c900b1c6c7a5ab121863ddb06252 changed it from checking the old varbit value for being 1 to checking the new varbit value for being 1. As a result, `currentRound` was set to null when the wave started, instead of when the previous wave ended. Due to raciness between the varbit change and the widget load, this resulted in either a null or a properly initialized `currentRound` variable value. So, it was broken some waves and not others, randomly.

Closes #15638 