### PR TITLE
Added a world counter optional overlay

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldcount/WorldCountConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldcount/WorldCountConfig.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2017, Levi <me@levischuck.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.worldcount;
+
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+
+@ConfigGroup(WorldCountPlugin.CONFIG_GROUP_KEY)
+public interface WorldCountConfig extends Config
+{
+	@ConfigItem(
+		keyName = "showWorld",
+		name = "Show world count",
+		description = "",
+		position = 1
+	)
+	default boolean showWorld()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+			keyName = "drawWorldCount",
+			name = "Draw World count indicator",
+			description = "Show a number in the corner for the current world count",
+			position = 2
+	)
+	default boolean drawWorldCount()
+	{
+		return true;
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldcount/WorldCountListener.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldcount/WorldCountListener.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2017, Levi <me@levischuck.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.worldcount;
+
+import javax.inject.Inject;
+
+public class WorldCountListener implements Runnable
+{
+	private final WorldCountConfig config;
+
+	@Inject
+	private WorldCountListener(WorldCountConfig config)
+	{
+		this.config = config;
+		reloadConfig();
+	}
+
+	void reloadConfig()
+	{
+	}
+
+	@Override
+	public void run()
+	{
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldcount/WorldCountOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldcount/WorldCountOverlay.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2017, Levi <me@levischuck.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.worldcount;
+
+import javax.inject.Inject;
+import java.awt.*;
+import net.runelite.api.Client;
+import net.runelite.api.Point;
+import net.runelite.api.widgets.Widget;
+import net.runelite.api.widgets.WidgetInfo;
+import net.runelite.client.game.WorldService;
+import net.runelite.client.ui.overlay.*;
+
+public class WorldCountOverlay extends Overlay
+{
+	private static final int Y_OFFSET = 20;
+	private static final int X_OFFSET = 1;
+	private static final String WORLDCOUNT_STRING = " players in world ";
+	private final WorldCountConfig config;
+	private final Client client;
+
+	@Inject
+	private WorldService worldService;
+
+	@Inject
+	private WorldCountOverlay(WorldCountConfig config, Client client)
+	{
+		this.config = config;
+		this.client = client;
+		setLayer(OverlayLayer.ABOVE_WIDGETS);
+		setPriority(OverlayPriority.HIGH);
+		setPosition(OverlayPosition.DYNAMIC);
+	}
+
+	@Override
+	public Dimension render(Graphics2D graphics)
+	{
+		if (!config.drawWorldCount())
+		{
+			return null;
+		}
+
+		// On resizable bottom line mode the logout button is at the top right, so offset the overlay
+		// to account for it
+		Widget logoutButton = client.getWidget(WidgetInfo.RESIZABLE_MINIMAP_LOGOUT_BUTTON);
+		int xOffset = X_OFFSET;
+		if (logoutButton != null && !logoutButton.isHidden())
+		{
+			xOffset += logoutButton.getWidth();
+		}
+
+		int worldCount = worldService.getWorlds().findWorld(client.getWorld()).getPlayers();
+		final String text = config.showWorld() ? worldCount + WORLDCOUNT_STRING + client.getWorld() : worldCount + WORLDCOUNT_STRING;
+
+		final int textWidth = graphics.getFontMetrics().stringWidth(text);
+		final int textHeight = graphics.getFontMetrics().getAscent() - graphics.getFontMetrics().getDescent();
+
+		final int width = (int) client.getRealDimensions().getWidth();
+		final Point point = new Point(width - textWidth - xOffset, textHeight + Y_OFFSET);
+		OverlayUtil.renderTextLocation(graphics, point, text, Color.YELLOW);
+
+		return null;
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldcount/WorldCountPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldcount/WorldCountPlugin.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2017, Levi <me@levischuck.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.worldcount;
+
+import com.google.inject.Inject;
+import com.google.inject.Provides;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.eventbus.Subscribe;
+import net.runelite.client.events.ConfigChanged;
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.ui.DrawManager;
+import net.runelite.client.ui.overlay.OverlayManager;
+
+@PluginDescriptor(
+	name = "World count",
+	description = "Show current world count",
+	tags = {"world count", "player count", "overlay"},
+	enabledByDefault = false
+)
+public class WorldCountPlugin extends Plugin
+{
+	static final String CONFIG_GROUP_KEY = "worldcount";
+
+	@Inject
+	private OverlayManager overlayManager;
+
+	@Inject
+	private WorldCountOverlay overlay;
+
+	@Inject
+	private WorldCountListener drawListener;
+
+	@Inject
+	private DrawManager drawManager;
+
+	@Provides
+	WorldCountConfig provideConfig(ConfigManager configManager)
+	{
+		return configManager.getConfig(WorldCountConfig.class);
+	}
+
+	@Subscribe
+	public void onConfigChanged(ConfigChanged event)
+	{
+		if (event.getGroup().equals(CONFIG_GROUP_KEY))
+		{
+			drawListener.reloadConfig();
+		}
+	}
+
+	@Override
+	protected void startUp() throws Exception
+	{
+		overlayManager.add(overlay);
+		drawManager.registerEveryFrameListener(drawListener);
+		drawListener.reloadConfig();
+	}
+
+	@Override
+	protected void shutDown() throws Exception
+	{
+		overlayManager.remove(overlay);
+		drawManager.unregisterEveryFrameListener(drawListener);
+	}
+}


### PR DESCRIPTION
I created a simple overlay plugin basing it's logic from the FPS Counter overlay plugin. This was inspired from the feature request [runelite/issues/9555](https://github.com/runelite/runelite/issues/9555).