### PR TITLE
Fix NPC Util Wall beast transition

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/game/NpcUtil.java
+++ b/runelite-client/src/main/java/net/runelite/client/game/NpcUtil.java
@@ -138,6 +138,7 @@ public class NpcUtil
 			case NpcID.ENT_7234:
 			case NpcID.HOPELESS_CREATURE:
 			case NpcID.HOPELESS_CREATURE_1073:
+			case NpcID.WALL_BEAST:
 				return false;
 			// These NPCs have no attack options, but are the dead and uninteractable form of otherwise attackable NPCs,
 			// thus should not be considered alive.


### PR DESCRIPTION
Close #15683

Stop wall beast/hole in the wall from disappearing when dying NPCs are hidden in Entity Hider