### PR TITLE
chat commands: fix !lvl toa expert

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
@@ -2178,6 +2178,7 @@ public class ChatCommandsPlugin extends Plugin
 			case "toa entry":
 			case "toa entry mode":
 				return "Tombs of Amascut Entry Mode";
+			case "tombs of amascut: expert mode":
 			case "toa expert":
 			case "toa expert mode":
 				return "Tombs of Amascut Expert Mode";


### PR DESCRIPTION
Fixes commands such as "!lvl toa expert" by adding tombs of amascut: expert mode to longBossName.

findHiscoreSkill checks ```if (longBossName(skill.getName()).equalsIgnoreCase(s))``` but HiscoreSkill.java only contains the names with a colon, while ```s = longBossName(search)``` by definition does not contain any colons. This PR makes sure this check doesn't fail.