### PR TITLE
Fix for explorer ring not updating its charge count on login in sometimes.

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemcharges/ItemChargePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemcharges/ItemChargePlugin.java
@@ -40,12 +40,14 @@ import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
 import net.runelite.api.EquipmentInventorySlot;
+import net.runelite.api.GameState;
 import net.runelite.api.InventoryID;
 import net.runelite.api.Item;
 import net.runelite.api.ItemContainer;
 import net.runelite.api.ItemID;
 import net.runelite.api.Varbits;
 import net.runelite.api.events.ChatMessage;
+import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.ItemContainerChanged;
 import net.runelite.api.events.ScriptCallbackEvent;
 import net.runelite.api.events.VarbitChanged;
@@ -204,6 +206,18 @@ public class ItemChargePlugin extends Plugin
 		infoBoxManager.removeIf(ItemChargeInfobox.class::isInstance);
 		infoboxes.clear();
 		lastCheckTick = -1;
+	}
+
+	@Subscribe
+	public void onGameStateChanged(GameStateChanged e)
+	{
+		// No VarbitChanged event fires on login if the explorer's ring is full (varbit value 0).
+		// So, set the value to 0 when LOGGING_IN. This is before the VarbitChanged event would fire, so if it shouldn't
+		// be 0 it will be updated later.
+		if (e.getGameState() == GameState.LOGGING_IN)
+		{
+			updateExplorerRingCharges(0);
+		}
 	}
 
 	@Subscribe


### PR DESCRIPTION
Fix for explorer ring not updating its charge count on login in some cases (those being that it is currently full and the varbit was last at its full state or it is a fresh login). Likely caused by a regression in 668d99dfef72c900b1c6c7a5ab121863ddb06252.

The reason it was broken was that if the varbit is supposed to be 0 it may not fire varbitchanged on login. Before 668d99d any varbit change could trigger the update code so it would update anyways but afterwards only the explorer ring varbit updating would do that.