### PR TITLE
fix MTA Telekenic Room removing hint arrows too early

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/mta/telekinetic/TelekineticRoom.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/mta/telekinetic/TelekineticRoom.java
@@ -193,7 +193,7 @@ public class TelekineticRoom extends MTARoom
 	{
 		NPC npc = event.getNpc();
 
-		if (npc.getId() == NpcID.MAZE_GUARDIAN)
+		if (npc.getId() == NpcID.MAZE_GUARDIAN || npc.getId() == MAZE_GUARDIAN_MOVING)
 		{
 			guardian = npc;
 		}
@@ -204,7 +204,7 @@ public class TelekineticRoom extends MTARoom
 	{
 		NPC npc = event.getNpc();
 
-		if (npc == guardian)
+		if (npc == guardian || npc.getId() == MAZE_GUARDIAN_MOVING)
 		{
 			guardian = null;
 		}


### PR DESCRIPTION
Fixes #15741
Assign the guardian's NPC to the moving maze guardian to prevent clearing of hint arrows and clearing of the moves during onGameTick that was doing checking guarding being null. 