### PR TITLE
plugins: Fix plugin list label color hover change effect

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/PluginListItem.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/PluginListItem.java
@@ -31,6 +31,7 @@ import java.awt.Dimension;
 import java.awt.GridLayout;
 import java.awt.MouseInfo;
 import java.awt.Point;
+import java.awt.event.HierarchyEvent;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.awt.image.BufferedImage;
@@ -49,12 +50,16 @@ import javax.swing.border.EmptyBorder;
 import lombok.Getter;
 import net.runelite.client.externalplugins.ExternalPluginManifest;
 import net.runelite.client.ui.ColorScheme;
+import static net.runelite.client.ui.ColorScheme.BRAND_ORANGE;
 import net.runelite.client.ui.PluginPanel;
 import net.runelite.client.util.ImageUtil;
 import net.runelite.client.util.SwingUtil;
 
 class PluginListItem extends JPanel implements SearchablePlugin
 {
+	private static final Color DEFAULT_COLOR = Color.WHITE;
+	private static final Color HOVER_COLOR = BRAND_ORANGE;
+
 	private static final ImageIcon CONFIG_ICON;
 	private static final ImageIcon CONFIG_ICON_HOVER;
 	private static final ImageIcon ON_STAR;
@@ -109,7 +114,7 @@ class PluginListItem extends JPanel implements SearchablePlugin
 		setPreferredSize(new Dimension(PluginPanel.PANEL_WIDTH, 20));
 
 		JLabel nameLabel = new JLabel(pluginConfig.getName());
-		nameLabel.setForeground(Color.WHITE);
+		nameLabel.setForeground(DEFAULT_COLOR);
 
 		if (!pluginConfig.getDescription().isEmpty())
 		{
@@ -244,8 +249,6 @@ class PluginListItem extends JPanel implements SearchablePlugin
 
 		label.addMouseListener(new MouseAdapter()
 		{
-			private Color lastForeground;
-
 			@Override
 			public void mouseClicked(MouseEvent mouseEvent)
 			{
@@ -258,14 +261,23 @@ class PluginListItem extends JPanel implements SearchablePlugin
 			@Override
 			public void mouseEntered(MouseEvent mouseEvent)
 			{
-				lastForeground = label.getForeground();
-				label.setForeground(ColorScheme.BRAND_ORANGE);
+				label.setForeground(HOVER_COLOR);
 			}
 
 			@Override
 			public void mouseExited(MouseEvent mouseEvent)
 			{
-				label.setForeground(lastForeground);
+				label.setForeground(DEFAULT_COLOR);
+			}
+		});
+		// ensure label color is reset when it is hidden (as that could cause mouseExited not to occur)
+		label.addHierarchyListener(e ->
+		{
+			if (e.getChanged() == label
+				&& (e.getChangeFlags() & HierarchyEvent.SHOWING_CHANGED) != 0
+				&& !label.isShowing())
+			{
+				label.setForeground(DEFAULT_COLOR);
 			}
 		});
 	}


### PR DESCRIPTION
The label hover effect has long since had a persistent issue where it was possible under some circumstances for it to have its color become stuck in the hovered state, and would not change back even if hovered thereafter. This was actually two separate issues. The first being that the label's previous color was stored when hovered and later changed back when the mouse exited its area. This normally would not be problematic except that the second was that it was possible to leave a label stuck in its hover state by causing it to be removed from the listing while being hovered, such as by typing into the search field while hovering some plugin label. Because plugin labels are never recreated, only re-added to their container, this means the label's `mouseExited()` body would never run, and the label would remain in its hovered color permanently.

This commit addresses both of these issues by defining a concrete default and hovered color (rather than saving the starting color to a variable in the mouse adapter) and by adding a hierarchy listener to reset to the default color when a label is hidden.

Fixes #15761