### PR TITLE
fix(sec): upgrade mysql:mysql-connector-java to 8.0.28

### DIFF
--- a/cache-updater/pom.xml
+++ b/cache-updater/pom.xml
@@ -22,8 +22,7 @@
  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
--->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+--><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>net.runelite</groupId>
@@ -58,7 +57,7 @@
 		<dependency>
 			<groupId>mysql</groupId>
 			<artifactId>mysql-connector-java</artifactId>
-			<version>5.1.45</version>
+			<version>8.0.28</version>
 		</dependency>
 		<dependency>
 			<groupId>net.runelite</groupId>


### PR DESCRIPTION
### What happened？
There are 4 security vulnerabilities found in mysql:mysql-connector-java 5.1.45
- [CVE-2022-21363](https://www.oscs1024.com/hd/CVE-2022-21363)
- [CVE-2021-2471](https://www.oscs1024.com/hd/CVE-2021-2471)
- [CVE-2018-3258](https://www.oscs1024.com/hd/CVE-2018-3258)
- [CVE-2019-2692](https://www.oscs1024.com/hd/CVE-2019-2692)


### What did I do？
Upgrade mysql:mysql-connector-java from 5.1.45 to 8.0.28 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS