### PR TITLE
Prayer overlay | Customisable Indicator Colours

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/prayer/PrayerBarOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/prayer/PrayerBarOverlay.java
@@ -49,7 +49,6 @@ class PrayerBarOverlay extends Overlay
 {
 	private static final Color BAR_FILL_COLOR = new Color(0, 149, 151);
 	private static final Color BAR_BG_COLOR = Color.black;
-	private static final Color FLICK_HELP_COLOR = Color.white;
 	private static final Dimension PRAYER_BAR_SIZE = new Dimension(30, 5);
 	private static final int HD_PRAYER_BAR_PADDING = 1;
 	private static final BufferedImage HD_FRONT_BAR = ImageUtil.loadImageResource(PrayerPlugin.class, "front.png");
@@ -111,7 +110,7 @@ class PrayerBarOverlay extends Overlay
 
 				final int xOffset = (int) (-Math.cos(t) * halfBarWidth) + halfBarWidth;
 
-				graphics.setColor(FLICK_HELP_COLOR);
+				graphics.setColor(config.prayerFlickColor());
 				// Padding is accounted for in the offset calculation
 				graphics.fillRect(barX + xOffset, barY + HD_PRAYER_BAR_PADDING, 1, barHeight - HD_PRAYER_BAR_PADDING * 2);
 			}
@@ -141,7 +140,7 @@ class PrayerBarOverlay extends Overlay
 
 			final int xOffset = (int) (-Math.cos(t) * barWidth / 2) + barWidth / 2;
 
-			graphics.setColor(FLICK_HELP_COLOR);
+			graphics.setColor(config.prayerFlickColor());
 			graphics.fillRect(barX + xOffset, barY, 1, barHeight);
 		}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/prayer/PrayerConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/prayer/PrayerConfig.java
@@ -24,6 +24,8 @@
  */
 package net.runelite.client.plugins.prayer;
 
+import java.awt.Color;
+import net.runelite.client.config.Alpha;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
@@ -42,8 +44,20 @@ public interface PrayerConfig extends Config
 		return PrayerFlickLocation.NONE;
 	}
 
+	@Alpha
 	@ConfigItem(
 		position = 1,
+		keyName = "prayerFlickColor",
+		name = "Pray flick color",
+		description = "Color of the flick helper on the prayer orb and prayer bar"
+	)
+	default Color prayerFlickColor()
+	{
+		return Color.CYAN;
+	}
+
+	@ConfigItem(
+		position = 2,
 		keyName = "prayerFlickAlwaysOn",
 		name = "Never hide prayer flick helper",
 		description = "Show prayer flick helper regardless of if you're praying or not."
@@ -54,7 +68,7 @@ public interface PrayerConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 2,
+		position = 3,
 		keyName = "prayerIndicator",
 		name = "Boost indicator",
 		description = "Enable infoboxes for prayers."
@@ -65,7 +79,7 @@ public interface PrayerConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 3,
+		position = 4,
 		keyName = "prayerIndicatorOverheads",
 		name = "Overhead indicator",
 		description = "Also enable infoboxes for overheads."
@@ -76,7 +90,7 @@ public interface PrayerConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 4,
+		position = 5,
 		keyName = "showPrayerDoseIndicator",
 		name = "Show prayer dose indicator",
 		description = "Enables the prayer dose indicator."
@@ -86,8 +100,20 @@ public interface PrayerConfig extends Config
 		return true;
 	}
 
+	@Alpha
 	@ConfigItem(
-		position = 5,
+		position = 6,
+		keyName = "prayerDoseOrbStartColor",
+		name = "Dose indicator color",
+		description = "Color of the flashing ring around the prayer orb when a potion should be drank"
+	)
+	default Color prayerDoseOrbStartColor()
+	{
+		return Color.CYAN;
+	}
+
+	@ConfigItem(
+		position = 7,
 		keyName = "showPrayerTooltip",
 		name = "Show prayer orb tooltip",
 		description = "Displays time remaining and prayer bonus as a tooltip on the quick-prayer icon."
@@ -98,7 +124,7 @@ public interface PrayerConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 6,
+		position = 8,
 		keyName = "showPrayerBar",
 		name = "Show prayer bar",
 		description = "Displays prayer bar under HP bar when praying."
@@ -109,7 +135,7 @@ public interface PrayerConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 7,
+		position = 9,
 		keyName = "prayerBarHideIfNotPraying",
 		name = "Hide bar while prayer is inactive",
 		description = "Prayer bar will be hidden while prayers are inactive."
@@ -120,7 +146,7 @@ public interface PrayerConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 8,
+		position = 10,
 		keyName = "prayerBarHideIfNonCombat",
 		name = "Hide bar while out-of-combat",
 		description = "Prayer bar will be hidden while out-of-combat."
@@ -131,7 +157,7 @@ public interface PrayerConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 9,
+		position = 11,
 		keyName = "replaceOrbText",
 		name = "Show time left",
 		description = "Show time remaining of current prayers in the prayer orb."

--- a/runelite-client/src/main/java/net/runelite/client/plugins/prayer/PrayerDoseOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/prayer/PrayerDoseOverlay.java
@@ -50,10 +50,7 @@ import net.runelite.client.util.ColorUtil;
 class PrayerDoseOverlay extends Overlay
 {
 	private static final float PULSE_TIME = 2f * Constants.GAME_TICK_LENGTH;
-
-	private static final Color START_COLOR = new Color(0, 255, 255);
-	private static final Color END_COLOR = new Color(0, 92, 92);
-
+	private static final double DARKEN_FACTOR = 0.36078;
 	private final Client client;
 	private final PrayerPlugin plugin;
 	private final PrayerConfig config;
@@ -148,10 +145,22 @@ class PrayerDoseOverlay extends Overlay
 		final float tickProgress = Math.min(timeSinceLastTick / PULSE_TIME, 1); // Cap between 0 and 1
 		final double t = tickProgress * Math.PI; // Convert to 0 - pi
 
-		graphics.setColor(ColorUtil.colorLerp(START_COLOR, END_COLOR, Math.sin(t)));
+		Color startColor = config.prayerDoseOrbStartColor();
+		graphics.setColor(ColorUtil.colorLerp(
+			startColor,
+			endColor(startColor),
+			Math.sin(t)));
+
 		graphics.setStroke(new BasicStroke(2));
 		graphics.drawOval(orbInnerX, orbInnerY, orbInnerSize, orbInnerSize);
 		return null;
 	}
 
+	private static Color endColor(Color start)
+	{
+		return new Color(Math.max((int) (start.getRed() * DARKEN_FACTOR), 0),
+			Math.max((int) (start.getGreen() * DARKEN_FACTOR), 0),
+			Math.max((int) (start.getBlue() * DARKEN_FACTOR), 0),
+			start.getAlpha());
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/prayer/PrayerFlickOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/prayer/PrayerFlickOverlay.java
@@ -24,7 +24,6 @@
  */
 package net.runelite.client.plugins.prayer;
 
-import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Graphics2D;
 import java.awt.geom.Rectangle2D;
@@ -89,7 +88,7 @@ class PrayerFlickOverlay extends Overlay
 
 		int yOffset = (orbInnerHeight / 2) - (indicatorHeight / 2);
 
-		graphics.setColor(Color.cyan);
+		graphics.setColor(config.prayerFlickColor());
 		graphics.fillRect(orbInnerX + xOffset, orbInnerY + yOffset, 1, indicatorHeight);
 		return null;
 	}


### PR DESCRIPTION
Add ability to change the colour of the 'PrayDoseOverlay' and Pray Flick overlay for colorblindness support and aesthetic reasons.

Since the Prayer dose overlay might be a bit tricky to setup for people initially; I've added 3 new preset colour options along with the default. On-top of this the final option 'Custom' will allow users to create a custom set of colours to fade in and out of.

Colour pickers are below the appropriate places where the settings that enable the colours are to make it intuitive about what option changes what overlay. ( Picture below if you don't understand what I mean )
 
![image](https://user-images.githubusercontent.com/55759474/199685027-6a9552f8-18aa-4a90-ae9b-1626471a8624.png)
