### PR TITLE
menu swapper: Fix duplicate Reset option in bank, Use submenus for ui swaps

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -1089,9 +1089,15 @@ public class MenuEntrySwapperPlugin extends Plugin
 
 					// find highest op from the current menu, post any existing swaps, for inserting Reset
 					int highestOp = 10;
-					for (int i = idx; i >= 0 && entries[i].getWidget() == w; --i)
+					for (int i = idx; i >= 0; --i)
 					{
-						highestOp = entries[i].getIdentifier();
+						final MenuEntry opEntry = entries[i];
+						if (opEntry.getWidget() != w)
+						{
+							continue;
+						}
+
+						highestOp = opEntry.getIdentifier();
 					}
 
 					if (identifier != lowestOp && (leftClick == null || leftClick != identifier))

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -1049,6 +1049,11 @@ public class MenuEntrySwapperPlugin extends Plugin
 
 		final MenuEntry[] entries = event.getMenuEntries();
 		int shiftOff = 0;
+
+		List<MenuEntry> leftClickMenus = new ArrayList<>();
+		List<MenuEntry> shiftClickMenus = new ArrayList<>();
+		String submenuTarget = "";
+
 		for (int idx = entries.length - 1; idx >= 0; --idx)
 		{
 			final MenuEntry entry = entries[idx];
@@ -1102,49 +1107,91 @@ public class MenuEntrySwapperPlugin extends Plugin
 
 					if (identifier != lowestOp && (leftClick == null || leftClick != identifier))
 					{
-						client.createMenuEntry(1 + shiftOff)
-							.setOption("Swap left click " + entry.getOption())
-							.setTarget(entry.getTarget())
+						leftClickMenus.add(client.createMenuEntry(1 + shiftOff)
+							.setOption(entry.getOption())
 							.setType(MenuAction.RUNELITE)
-							.onClick(uiConsumer(entry.getOption(), entry.getTarget(), false, componentId, itemId, identifier));
+							.onClick(uiConsumer(entry.getOption(), entry.getTarget(), false, componentId, itemId, identifier)));
 					}
 
 					if (identifier != lowestOp && (shiftClick == null || shiftClick != identifier))
 					{
-						client.createMenuEntry(1)
-							.setOption("Swap shift click " + entry.getOption())
-							.setTarget(entry.getTarget())
+						shiftClickMenus.add(client.createMenuEntry(1)
+							.setOption(entry.getOption())
 							.setType(MenuAction.RUNELITE)
-							.onClick(uiConsumer(entry.getOption(), entry.getTarget(), true, componentId, itemId, identifier));
+							.onClick(uiConsumer(entry.getOption(), entry.getTarget(), true, componentId, itemId, identifier)));
 						++shiftOff;
 					}
 
-					if (identifier == highestOp && (leftClick != null || shiftClick != null))
+					if (identifier == highestOp)
 					{
-						client.createMenuEntry(1)
-							.setOption("Reset swap")
-							.setTarget(entry.getTarget())
-							.setType(MenuAction.RUNELITE)
-							.onClick(menuEntry ->
-							{
-								final String message = new ChatMessageBuilder()
-									.append("The default left and shift click options for '").append(Text.removeTags(menuEntry.getTarget())).append("' ")
-									.append("have been reset.")
-									.build();
+						if (leftClick != null)
+						{
+							submenuTarget = entry.getTarget();
+							leftClickMenus.add(client.createMenuEntry(1)
+								.setOption("Reset")
+								.setType(MenuAction.RUNELITE)
+								.onClick(menuEntry ->
+								{
+									final String message = new ChatMessageBuilder()
+										.append("The default left click option for '").append(Text.removeTags(entry.getTarget())).append("' ")
+										.append("has been reset.")
+										.build();
 
-								chatMessageManager.queue(QueuedMessage.builder()
-									.type(ChatMessageType.CONSOLE)
-									.runeLiteFormattedMessage(message)
-									.build());
+									chatMessageManager.queue(QueuedMessage.builder()
+										.type(ChatMessageType.CONSOLE)
+										.runeLiteFormattedMessage(message)
+										.build());
 
-								log.debug("Unset ui swap for {}/{}", componentId, menuEntry.getTarget());
+									log.debug("Unset ui left swap for {}/{}", componentId, menuEntry.getTarget());
 
-								unsetUiSwapConfig(false, componentId, itemId);
-								unsetUiSwapConfig(true, componentId, itemId);
-							});
+									unsetUiSwapConfig(false, componentId, itemId);
+								}));
+						}
+
+						if (shiftClick != null)
+						{
+							submenuTarget = entry.getTarget();
+							shiftClickMenus.add(client.createMenuEntry(1)
+								.setOption("Reset")
+								.setType(MenuAction.RUNELITE)
+								.onClick(menuEntry ->
+								{
+									final String message = new ChatMessageBuilder()
+										.append("The default shift click option for '").append(Text.removeTags(entry.getTarget())).append("' ")
+										.append("has been reset.")
+										.build();
+
+									chatMessageManager.queue(QueuedMessage.builder()
+										.type(ChatMessageType.CONSOLE)
+										.runeLiteFormattedMessage(message)
+										.build());
+
+									log.debug("Unset ui shift swap for {}/{}", componentId, menuEntry.getTarget());
+
+									unsetUiSwapConfig(true, componentId, itemId);
+								}));
+						}
 					}
 				}
 			}
+		}
+
+		if (!leftClickMenus.isEmpty())
+		{
+			MenuEntry sub = client.createMenuEntry(2)
+				.setOption("Swap left click")
+				.setTarget(submenuTarget)
+				.setType(MenuAction.RUNELITE_SUBMENU);
+			leftClickMenus.forEach(menu -> menu.setParent(sub));
+		}
+
+		if (!shiftClickMenus.isEmpty())
+		{
+			MenuEntry sub = client.createMenuEntry(1)
+				.setOption("Swap shift click")
+				.setTarget(submenuTarget)
+				.setType(MenuAction.RUNELITE_SUBMENU);
+			shiftClickMenus.forEach(menu -> menu.setParent(sub));
 		}
 	}
 


### PR DESCRIPTION
Because the bank tags plugin adds an "Edit-tags" menu entry which has a
null widget, this causes the highestOp calculation to be incorrect for
all entries prior to it, as the loop effectively `break`s when some menu
entry with a widget not matching that of the current entry's widget is
encountered. This commit fixes this behavior by moving the widget check
inside the loop body and `continue`ing on a non-match rather than
`break`ing.