### PR TITLE
Show ground item expiry in whole seconds

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
@@ -366,7 +366,7 @@ public class GroundItemsOverlay extends Overlay
 					final String timerText;
 					if (groundItemTimers == DespawnTimerMode.SECONDS)
 					{
-						timerText = String.format(" - %.1f", despawnTimeMillis / 1000f);
+						timerText = String.format(" - %.0f", despawnTimeMillis / 1000f);
 					}
 					else // TICKS
 					{


### PR DESCRIPTION
Previously, expiry was shown in tenths of a second. If players need this much precision, ticks are still available.