### PR TITLE
gpu: add draw distance requires compute shaders

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuPluginConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuPluginConfig.java
@@ -45,7 +45,7 @@ public interface GpuPluginConfig extends Config
 	@ConfigItem(
 		keyName = "drawDistance",
 		name = "Draw Distance",
-		description = "Draw distance",
+		description = "Draw distance. Requires compute shaders to be enabled.",
 		position = 1
 	)
 	default int drawDistance()


### PR DESCRIPTION
Draw distance requires compute shaders to be enabled, so:

1. Move compute shader's config item before draw distance
2. Mention the dependency in draw distance's description