### PR TITLE
ground items: Add option to show only the highest price

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
@@ -258,6 +258,28 @@ public class GroundItemsOverlay extends Overlay
 						.append(" gp)");
 				}
 			}
+			else if (config.priceDisplayMode() == PriceDisplayMode.HIGHEST)
+			{
+				final int ge = item.getGePrice();
+				final int ha = item.getHaPrice();
+				if (ge == ha)
+				{
+					itemStringBuilder
+						.append(" (GE/HA: ")
+						.append(QuantityFormatter.quantityToStackSize(ge))
+						.append(" gp)");
+				} else if (ge > ha) {
+					itemStringBuilder
+						.append(" (GE: ")
+						.append(QuantityFormatter.quantityToStackSize(ge))
+						.append(" gp)");
+				} else {
+					itemStringBuilder
+						.append(" (HA: ")
+						.append(QuantityFormatter.quantityToStackSize(ha))
+						.append(" gp)");
+				}
+			}
 			else if (config.priceDisplayMode() != PriceDisplayMode.OFF)
 			{
 				final int price = config.priceDisplayMode() == PriceDisplayMode.GE

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/config/PriceDisplayMode.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/config/PriceDisplayMode.java
@@ -34,6 +34,7 @@ public enum PriceDisplayMode
 	HA("High Alchemy"),
 	GE("Grand Exchange"),
 	BOTH("Both"),
+	HIGHEST("Highest"),
 	OFF("Off");
 
 	private final String name;


### PR DESCRIPTION
Most of the time, I'm only interested in whichever is the higher of the two.