### PR TITLE
Fix misspelled enum 

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/MenuAction.java
+++ b/runelite-api/src/main/java/net/runelite/api/MenuAction.java
@@ -231,7 +231,7 @@ public enum MenuAction
 	PLAYER_FIFTH_OPTION(48),
 	PLAYER_SIXTH_OPTION(49),
 	PLAYER_SEVENTH_OPTION(50),
-	PLAYER_EIGTH_OPTION(51),
+	PLAYER_EIGHTH_OPTION(51),
 
 	/**
 	 * Menu action for normal priority child component actions.
@@ -306,6 +306,9 @@ public enum MenuAction
 	UNKNOWN(-1);
 
 	public static final int MENU_ACTION_DEPRIORITIZE_OFFSET = 2000;
+
+	@Deprecated
+	public static final MenuAction PLAYER_EIGTH_OPTION = MenuAction.PLAYER_EIGHTH_OPTION;
 
 	private static final Map<Integer, MenuAction> map = new HashMap<>();
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsPlugin.java
@@ -33,7 +33,7 @@ import net.runelite.api.FriendsChatRank;
 import static net.runelite.api.FriendsChatRank.UNRANKED;
 import net.runelite.api.MenuAction;
 import static net.runelite.api.MenuAction.ITEM_USE_ON_PLAYER;
-import static net.runelite.api.MenuAction.PLAYER_EIGTH_OPTION;
+import static net.runelite.api.MenuAction.PLAYER_EIGHTH_OPTION;
 import static net.runelite.api.MenuAction.PLAYER_FIFTH_OPTION;
 import static net.runelite.api.MenuAction.PLAYER_FIRST_OPTION;
 import static net.runelite.api.MenuAction.PLAYER_FOURTH_OPTION;
@@ -147,7 +147,7 @@ public class PlayerIndicatorsPlugin extends Plugin
 				|| type == PLAYER_FIFTH_OPTION
 				|| type == PLAYER_SIXTH_OPTION
 				|| type == PLAYER_SEVENTH_OPTION
-				|| type == PLAYER_EIGTH_OPTION
+				|| type == PLAYER_EIGHTH_OPTION
 				|| type == RUNELITE_PLAYER)
 			{
 				Player[] players = client.getCachedPlayers();


### PR DESCRIPTION
Resolves #15892

After this is shipped we should eventually let these library owners know, and then remove this deprecation, and leave only the properly spelled ENUM