### PR TITLE
Add "Reset others" option to grouped loot boxes in the Loot Tracker plugin

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPanel.java
@@ -94,6 +94,9 @@ class LootTrackerPanel extends PluginPanel
 	private static final String RESET_ONE_WARNING_TEXT =
 		"This will delete one kill.";
 
+	private static final String RESET_OTHERS_WARNING_TEXT =
+			"This will permanently delete all loot except \"%s\".";
+
 	// When there is no loot, display this
 	private final PluginErrorPanel errorPanel = new PluginErrorPanel();
 
@@ -616,6 +619,47 @@ class LootTrackerPanel extends PluginPanel
 		});
 
 		popupMenu.add(reset);
+
+		// Create reset others menu (grouped loot only)
+		final JMenuItem resetOthers = new JMenuItem("Reset others");
+		resetOthers.addActionListener(e ->
+		{
+			final int result = JOptionPane.showOptionDialog(box, String.format(RESET_OTHERS_WARNING_TEXT, box.getId()),
+					"Are you sure?", JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE,
+					null, new String[]{"Yes", "No"}, "No");
+
+			if (result != JOptionPane.YES_OPTION)
+			{
+				return;
+			}
+
+			Predicate<LootTrackerRecord> match = r -> !r.matches(record.getTitle(), record.getType());
+
+			sessionRecords.removeIf(match);
+			aggregateRecords.removeIf(match);
+
+			List<LootTrackerBox> removedBoxes = boxes
+					.stream()
+					.filter((b) -> !b.getLootRecordType().equals(box.getLootRecordType()) && !b.getId().equals(box.getId()))
+					.collect(Collectors.toList());
+
+			boxes.clear();
+			boxes.add(box);
+			updateOverall();
+			logsContainer.removeAll();
+			logsContainer.add(box);
+			logsContainer.revalidate();
+
+			// Without loot being grouped we have no way to identify single kills to be deleted
+			if (groupLoot)
+			{
+				removedBoxes.forEach((b) -> plugin.removeLootConfig(b.getLootRecordType(), b.getId()));
+			}
+		});
+
+		if (groupLoot) {
+			popupMenu.add(resetOthers);
+		}
 
 		// Create details menu
 		final JMenuItem details = new JMenuItem("View details");


### PR DESCRIPTION
Adds a new menu entry titled "Reset others" to `LootTrackerBox` when the grouped loot display option is selected. Selecting this option should:
1. Ask the user to confirm whether they would like to reset all loot except the selected box
2. Remove all entries of other tracked loot from the session & aggregated trackers as well as UI state

Related discussion:
* https://github.com/runelite/runelite/discussions/15877
* https://github.com/runelite/runelite/discussions/14947

Related open issues: N/a

Related open PRs: N/a

Image(s):
![plugin](https://user-images.githubusercontent.com/6581665/204044079-3d6adbb5-ca10-492d-85d9-6bb011c27d75.png)
