### PR TITLE
Add Tooltip to Agility Obstacle Examine

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/agility/AgilityConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/agility/AgilityConfig.java
@@ -283,4 +283,14 @@ public interface AgilityConfig extends Config
 	{
 		return true;
 	}
+
+	@ConfigItem(
+			keyName = "examineTextEnabled",
+			name = "Examine",
+			description = "Show level requirement when examining obstacles",
+			position = 21
+	)
+	default boolean examineTextEnabled() {
+		return true;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/agility/AgilityConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/agility/AgilityConfig.java
@@ -285,10 +285,10 @@ public interface AgilityConfig extends Config
 	}
 
 	@ConfigItem(
-			keyName = "examineTextEnabled",
-			name = "Examine",
-			description = "Show level requirement when examining obstacles",
-			position = 21
+		keyName = "examineTextEnabled",
+		name = "Examine",
+		description = "Show level requirement when examining obstacles",
+		position = 21
 	)
 	default boolean examineTextEnabled() {
 		return true;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/agility/AgilityConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/agility/AgilityConfig.java
@@ -290,7 +290,8 @@ public interface AgilityConfig extends Config
 		description = "Show level requirement when examining obstacles",
 		position = 21
 	)
-	default boolean examineTextEnabled() {
+	default boolean examineTextEnabled()
+	{
 		return true;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/agility/AgilityPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/agility/AgilityPlugin.java
@@ -38,33 +38,18 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
-import net.runelite.api.Client;
-import net.runelite.api.ItemID;
+import net.runelite.api.*;
+
 import static net.runelite.api.ItemID.AGILITY_ARENA_TICKET;
-import net.runelite.api.NPC;
-import net.runelite.api.NullNpcID;
-import net.runelite.api.Player;
 import static net.runelite.api.Skill.AGILITY;
-import net.runelite.api.Tile;
-import net.runelite.api.TileItem;
-import net.runelite.api.TileObject;
+
 import net.runelite.api.coords.WorldPoint;
-import net.runelite.api.events.DecorativeObjectDespawned;
-import net.runelite.api.events.DecorativeObjectSpawned;
-import net.runelite.api.events.GameObjectDespawned;
-import net.runelite.api.events.GameObjectSpawned;
-import net.runelite.api.events.GameStateChanged;
-import net.runelite.api.events.GameTick;
-import net.runelite.api.events.GroundObjectDespawned;
-import net.runelite.api.events.GroundObjectSpawned;
-import net.runelite.api.events.ItemDespawned;
-import net.runelite.api.events.ItemSpawned;
-import net.runelite.api.events.NpcDespawned;
-import net.runelite.api.events.NpcSpawned;
-import net.runelite.api.events.StatChanged;
-import net.runelite.api.events.WallObjectDespawned;
-import net.runelite.api.events.WallObjectSpawned;
+import net.runelite.api.events.*;
 import net.runelite.client.Notifier;
+import net.runelite.client.chat.ChatColorType;
+import net.runelite.client.chat.ChatMessageBuilder;
+import net.runelite.client.chat.ChatMessageManager;
+import net.runelite.client.chat.QueuedMessage;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.events.ConfigChanged;
@@ -128,6 +113,9 @@ public class AgilityPlugin extends Plugin
 
 	@Inject
 	private XpTrackerService xpTrackerService;
+
+	@Inject
+	private ChatMessageManager chatMessageManager;
 
 	@Getter
 	@Setter(AccessLevel.PACKAGE)
@@ -455,5 +443,26 @@ public class AgilityPlugin extends Plugin
 	{
 		NPC npc = npcDespawned.getNpc();
 		npcs.remove(npc);
+	}
+
+	@Subscribe
+	public void onMenuOptionClicked(MenuOptionClicked event){
+		if (!config.examineTextEnabled()){
+			return;
+		}
+		if (event.getMenuAction().equals(MenuAction.EXAMINE_OBJECT)){
+			Obstacles.SHORTCUT_OBSTACLE_IDS.get(event.getId()).stream().findFirst()
+				.ifPresent(element-> {
+					final ChatMessageBuilder message = new ChatMessageBuilder()
+						.append(ChatColorType.HIGHLIGHT)
+						.append(element.getTooltip())
+						.append(ChatColorType.NORMAL);
+
+					chatMessageManager.queue(QueuedMessage.builder()
+						.type(ChatMessageType.ITEM_EXAMINE)
+						.runeLiteFormattedMessage(message.build())
+						.build());
+				});
+		}
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/agility/AgilityPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/agility/AgilityPlugin.java
@@ -446,13 +446,17 @@ public class AgilityPlugin extends Plugin
 	}
 
 	@Subscribe
-	public void onMenuOptionClicked(MenuOptionClicked event){
-		if (!config.examineTextEnabled()){
+	public void onMenuOptionClicked(MenuOptionClicked event)
+	{
+		if (!config.examineTextEnabled())
+		{
 			return;
 		}
-		if (event.getMenuAction().equals(MenuAction.EXAMINE_OBJECT)){
+		if (event.getMenuAction().equals(MenuAction.EXAMINE_OBJECT))
+		{
 			Obstacles.SHORTCUT_OBSTACLE_IDS.get(event.getId()).stream().findFirst()
-				.ifPresent(element-> {
+				.ifPresent(element ->
+				{
 					final ChatMessageBuilder message = new ChatMessageBuilder()
 						.append(ChatColorType.HIGHLIGHT)
 						.append(element.getTooltip())


### PR DESCRIPTION
When encountering an obstacle highlighted in red, I usually go to the wiki to look it up, to see how many levels away I am from using it. I did not know this detail was shown on the map.

Intuitively, I wished that examining the obstacle would give me that context without having to click away to the wiki or open up the map.

This PR implements that feature, re-using the same function which exists to generate the map tooltip.
![image](https://user-images.githubusercontent.com/6597539/205915910-98bf488a-d3af-4f08-b6d0-2931f5d6db64.png)

I also added a config. Not sure why someone would turn this off, but good to give the user an option.

Let me know what you think