### PR TITLE
worldmap:Update world map tooltip positions to stay within the world map

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/worldmap/WorldMapOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/worldmap/WorldMapOverlay.java
@@ -339,8 +339,6 @@ public class WorldMapOverlay extends Overlay
 			return;
 		}
 
-		drawPoint = new Point(drawPoint.getX() + TOOLTIP_OFFSET_WIDTH, drawPoint.getY() + TOOLTIP_OFFSET_HEIGHT);
-
 		final Rectangle bounds = new Rectangle(0, 0, client.getCanvasWidth(), client.getCanvasHeight());
 		final Shape mapArea = getWorldMapClipArea(bounds);
 		graphics.setClip(mapArea);
@@ -349,6 +347,17 @@ public class WorldMapOverlay extends Overlay
 		FontMetrics fm = graphics.getFontMetrics();
 		int width = rows.stream().map(fm::stringWidth).max(Integer::compareTo).get();
 		int height = fm.getHeight();
+
+		// Make sure the tooltip stays within the world map
+		Rectangle worldMapBounds = client.getWidget(WidgetInfo.WORLD_MAP_VIEW).getBounds();
+		int drawPointX = drawPoint.getX();
+		int tooltipWidth = width + TOOLTIP_PADDING_WIDTH * 2;
+		int worldMapRightBoundary = (int) (worldMapBounds.getX() + worldMapBounds.getWidth());
+		if (drawPointX + tooltipWidth > worldMapRightBoundary)
+		{
+			drawPointX = worldMapRightBoundary - tooltipWidth;
+		}
+		drawPoint = new Point(drawPointX + TOOLTIP_OFFSET_WIDTH, drawPoint.getY() + TOOLTIP_OFFSET_HEIGHT);
 
 		Rectangle tooltipRect = new Rectangle(drawPoint.getX() - TOOLTIP_PADDING_WIDTH, drawPoint.getY() - TOOLTIP_PADDING_HEIGHT, width + TOOLTIP_PADDING_WIDTH * 2, height * rows.size() + TOOLTIP_PADDING_HEIGHT * 2);
 		graphics.fillRect((int) tooltipRect.getX(), (int) tooltipRect.getY(), (int) tooltipRect.getWidth(), (int) tooltipRect.getHeight());


### PR DESCRIPTION
Resolves issue #14760

This is a duplicate of my previous PR #15529. I inadvertently did some serious damage to my fork of RuneLite so I nuked it and started it from scratch.

![image](https://user-images.githubusercontent.com/33209567/206312940-09232cc7-35b9-49fe-9212-a651b4585acc.png)
