### PR TITLE
report button: Don't reset login time on connection lost

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/reportbutton/ReportButtonPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/reportbutton/ReportButtonPlugin.java
@@ -112,7 +112,6 @@ public class ReportButtonPlugin extends Plugin
 		{
 			case LOGGING_IN:
 			case HOPPING:
-			case CONNECTION_LOST:
 				ready = true;
 				break;
 			case LOGGED_IN:


### PR DESCRIPTION
You still 6-hour log even if you lose connection and re-connect without going to the login screen.