### PR TITLE
npc indicators: add list format to config description

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsConfig.java
@@ -174,7 +174,7 @@ public interface NpcIndicatorsConfig extends Config
 		position = 7,
 		keyName = "npcToHighlight",
 		name = "NPCs to Highlight",
-		description = "List of NPC names to highlight<br>Separate entries with commas (,)<br>Click anywhere in plugin to reflect changes"
+		description = "List of NPC names to highlight. Format: (NPC), (NPC)"
 	)
 	default String getNpcToHighlight()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsConfig.java
@@ -174,7 +174,7 @@ public interface NpcIndicatorsConfig extends Config
 		position = 7,
 		keyName = "npcToHighlight",
 		name = "NPCs to Highlight",
-		description = "List of NPC names to highlight"
+		description = "List of NPC names to highlight<br>Separate entries with commas (,)<br>Click anywhere in plugin to reflect changes"
 	)
 	default String getNpcToHighlight()
 	{


### PR DESCRIPTION
Just adds a couple extra lines to the description in the "NPCs to Highlight" text label above the textbox to clarify how to add multiple entries. 
it's sorta redundant information since the wiki gives examples for how to do it, but I was really dumb and never clicked on the wiki button for months. Maybe there are other dumb guys like me.

Replaces this:
![Untitled](https://user-images.githubusercontent.com/9010341/207464271-e4b8275b-a8fa-4060-ab44-52294b1bb349.png)
With this:
![Untitled2](https://user-images.githubusercontent.com/9010341/207465101-a933dd29-e63a-4508-ab56-a295db0a7618.png)
