### PR TITLE
slayer: cancel task on inferno fail

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerPlugin.java
@@ -108,8 +108,7 @@ public class SlayerPlugin extends Plugin
 	private static final String CHAT_GEM_COMPLETE_MESSAGE = "You need something new to hunt.";
 	private static final Pattern CHAT_COMPLETE_MESSAGE = Pattern.compile("You've completed (?:at least )?(?<tasks>[\\d,]+) (?:Wilderness )?tasks?(?: and received \\d+ points, giving you a total of (?<points>[\\d,]+)| and reached the maximum amount of Slayer points \\((?<points2>[\\d,]+)\\))?");
 	private static final String CHAT_CANCEL_MESSAGE = "Your task has been cancelled.";
-	private static final String CHAT_CANCEL_MESSAGE_JAD = "You no longer have a slayer task as you left the fight cave.";
-	private static final String CHAT_CANCEL_MESSAGE_ZUK = "You no longer have a slayer task as you left the Inferno.";
+	private static final Pattern CHAT_CANCEL_MESSAGE_JAD_ZUK = Pattern.compile("You no longer have a slayer task(?: as you left the (?:fight cave|Inferno))?\\.");
 	private static final String CHAT_SUPERIOR_MESSAGE = "A superior foe has appeared...";
 	private static final String CHAT_BRACELET_SLAUGHTER = "Your bracelet of slaughter prevents your slayer";
 	private static final String CHAT_BRACELET_EXPEDITIOUS = "Your expeditious bracelet helps you progress your";
@@ -494,7 +493,7 @@ public class SlayerPlugin extends Plugin
 			return;
 		}
 
-		if (chatMsg.equals(CHAT_GEM_COMPLETE_MESSAGE) || chatMsg.equals(CHAT_CANCEL_MESSAGE) || chatMsg.equals(CHAT_CANCEL_MESSAGE_JAD) || chatMsg.equals(CHAT_CANCEL_MESSAGE_ZUK))
+		if (chatMsg.equals(CHAT_GEM_COMPLETE_MESSAGE) || chatMsg.equals(CHAT_CANCEL_MESSAGE) || CHAT_CANCEL_MESSAGE_JAD_ZUK.matcher(chatMsg).matches())
 		{
 			setTask("", 0, 0);
 			return;

--- a/runelite-client/src/test/java/net/runelite/client/plugins/slayer/SlayerPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/slayer/SlayerPluginTest.java
@@ -119,6 +119,10 @@ public class SlayerPluginTest
 	private static final String TASK_COMPLETE = "You need something new to hunt.";
 	private static final String TASK_CANCELED = "Your task has been cancelled.";
 
+	private static final String TASK_CANCELED_LEFT_FIGHT_CAVES = "You no longer have a slayer task as you left the fight cave.";
+	private static final String TASK_CANCELED_LEFT_INFERNO = "You no longer have a slayer task as you left the Inferno.";
+	private static final String TASK_CANCELED_FAILED_INFERNO = "You no longer have a slayer task.";
+
 	private static final String SUPERIOR_MESSAGE = "A superior foe has appeared...";
 
 	private static final String BRACLET_SLAUGHTER = "Your bracelet of slaughter prevents your slayer count from decreasing. It has 9 charges left.";
@@ -561,6 +565,45 @@ public class SlayerPluginTest
 		slayerPlugin.setAmount(42);
 
 		ChatMessage chatMessageEvent = new ChatMessage(null, GAMEMESSAGE, "Perterter", TASK_CANCELED, null, 0);
+		slayerPlugin.onChatMessage(chatMessageEvent);
+
+		assertEquals("", slayerPlugin.getTaskName());
+		assertEquals(0, slayerPlugin.getAmount());
+	}
+
+	@Test
+	public void testCancelledOnFightCaveLeave()
+	{
+		slayerPlugin.setTaskName("cows");
+		slayerPlugin.setAmount(42);
+
+		ChatMessage chatMessageEvent = new ChatMessage(null, GAMEMESSAGE, "Perterter", TASK_CANCELED_LEFT_FIGHT_CAVES, null, 0);
+		slayerPlugin.onChatMessage(chatMessageEvent);
+
+		assertEquals("", slayerPlugin.getTaskName());
+		assertEquals(0, slayerPlugin.getAmount());
+	}
+
+	@Test
+	public void testCancelledOnInfernoLeave()
+	{
+		slayerPlugin.setTaskName("cows");
+		slayerPlugin.setAmount(42);
+
+		ChatMessage chatMessageEvent = new ChatMessage(null, GAMEMESSAGE, "Perterter", TASK_CANCELED_LEFT_INFERNO, null, 0);
+		slayerPlugin.onChatMessage(chatMessageEvent);
+
+		assertEquals("", slayerPlugin.getTaskName());
+		assertEquals(0, slayerPlugin.getAmount());
+	}
+
+	@Test
+	public void testCancelledOnInfernoFail()
+	{
+		slayerPlugin.setTaskName("cows");
+		slayerPlugin.setAmount(42);
+
+		ChatMessage chatMessageEvent = new ChatMessage(null, GAMEMESSAGE, "Perterter", TASK_CANCELED_FAILED_INFERNO, null, 0);
 		slayerPlugin.onChatMessage(chatMessageEvent);
 
 		assertEquals("", slayerPlugin.getTaskName());


### PR DESCRIPTION
When dying in the Inferno with a Zuk task (and only 1 remaining), your task is cancelled. However, the Slayer plugin still tracks that your task is ongoing.

The plugin rightfully recognizes players *leaving* the Inferno and the Fight Caves, but there is a distinct, less specific message that appears when failing the Inferno: `You no longer have a slayer task.`

![image](https://user-images.githubusercontent.com/1868974/208018777-9179ce86-394b-4cb3-93e9-19d15cf171b3.png)

This commit generalizes the message check to merge the three possible messages (two original, one new) into a regex.

I have not confirmed whether this message appears when failing the Fight Caves. I also do not know for certain whether this message could appear from anything else, but if so it probably has the same effect.