### PR TITLE
GPU: Fix xBR scaling on M1 macs

### DIFF
--- a/runelite-client/src/main/resources/net/runelite/client/plugins/gpu/scale/xbr_lv2_frag.glsl
+++ b/runelite-client/src/main/resources/net/runelite/client/plugins/gpu/scale/xbr_lv2_frag.glsl
@@ -90,11 +90,8 @@ vec4 wd(vec4 a, vec4 b, vec4 c, vec4 d, vec4 e, vec4 f, vec4 g, vec4 h)
 {
     return (df(a,b) + df(a,c) + df(d,e) + df(d,f) + 4.0*df(g,h));
 }
-
-vec4 weighted_distance(vec4 a, vec4 b, vec4 c, vec4 d, vec4 e, vec4 f, vec4 g, vec4 h, vec4 i, vec4 j, vec4 k, vec4 l)
-{
-    return (df(a,b) + df(a,c) + df(d,e) + df(d,f) + df(i,j) + df(k,l) + 2.0*df(g,h));
-}
+// This is a macro because a function behaves differently between Apple Silicon Macs vs other platforms.
+#define weighted_distance(a,b,c,d,e,f,g,h,i,j,k,l) (df(a,b) + df(a,c) + df(d,e) + df(d,f) + df(i,j) + df(k,l) + 2.0*df(g,h))
 
 float c_df(vec3 c1, vec3 c2)
 {


### PR DESCRIPTION
After some debugging of the xBR shaders, I found out that `weighted_distance` was returning different values between M1 macs and Windows.

I checked that all the input values were the same, but not the output. I decided to inline the function and that seems to have fixed it.

I don't exactly know _why_ this happens, but likely some bug in apple's glsl compiler.

<img width="1678" alt="image" src="https://user-images.githubusercontent.com/240493/208311158-29adb97e-849b-4358-b4a6-61c1c8e398d7.png">
