### PR TITLE
object markers: Add fill color to object markers

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/objectindicators/ColorTileObject.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/objectindicators/ColorTileObject.java
@@ -47,6 +47,6 @@ class ColorTileObject
 	 * Name to highlight for multilocs
 	 */
 	private final String name;
-	private final Color boarderColor;
+	private final Color borderColor;
 	private final Color fillColor;
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/objectindicators/ObjectIndicatorsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/objectindicators/ObjectIndicatorsConfig.java
@@ -94,12 +94,12 @@ public interface ObjectIndicatorsConfig extends Config
 	@Alpha
 	@ConfigItem(
 		position = 4,
-		keyName = "boarderColor",
-		name = "Boarder color",
-		description = "Configures the boarder color of an object marker",
+		keyName = "borderColor",
+		name = "Border color",
+		description = "Configures the border color of an object marker",
 		section = renderStyleSection
 	)
-	default Color boarderColor()
+	default Color borderColor()
 	{
 		return Color.YELLOW;
 	}
@@ -114,7 +114,7 @@ public interface ObjectIndicatorsConfig extends Config
 	)
 	default Color fillColor()
 	{
-		return new Color(255, 255, 0, 0);
+		return new Color(255, 255, 0, 255/12);
 	}
 
 	@ConfigItem(

--- a/runelite-client/src/main/java/net/runelite/client/plugins/objectindicators/ObjectIndicatorsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/objectindicators/ObjectIndicatorsOverlay.java
@@ -46,7 +46,6 @@ import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.OverlayPriority;
 import net.runelite.client.ui.overlay.OverlayUtil;
 import net.runelite.client.ui.overlay.outline.ModelOutlineRenderer;
-import net.runelite.client.util.ColorUtil;
 
 class ObjectIndicatorsOverlay extends Overlay
 {
@@ -75,7 +74,7 @@ class ObjectIndicatorsOverlay extends Overlay
 		for (ColorTileObject colorTileObject : plugin.getObjects())
 		{
 			TileObject object = colorTileObject.getTileObject();
-			Color boarderColor = colorTileObject.getBoarderColor();
+			Color borderColor = colorTileObject.getBorderColor();
 			Color fillColor = colorTileObject.getFillColor();
 
 			if (object.getPlane() != client.getPlane())
@@ -98,10 +97,10 @@ class ObjectIndicatorsOverlay extends Overlay
 				}
 			}
 
-			if (boarderColor == null || !config.rememberObjectColors())
+			if (borderColor == null || !config.rememberObjectColors())
 			{
 				// Fallback to the current config if the object is marked before the addition of multiple colors
-				boarderColor = config.boarderColor();
+				borderColor = config.borderColor();
 			}
 
 			if (fillColor == null || !config.rememberObjectColors())
@@ -111,12 +110,12 @@ class ObjectIndicatorsOverlay extends Overlay
 
 			if (config.highlightHull())
 			{
-				renderConvexHull(graphics, object, boarderColor, fillColor, stroke);
+				renderConvexHull(graphics, object, borderColor, fillColor, stroke);
 			}
 
 			if (config.highlightOutline())
 			{
-				modelOutlineRenderer.drawOutline(object, (int)config.borderWidth(), boarderColor, config.outlineFeather());
+				modelOutlineRenderer.drawOutline(object, (int)config.borderWidth(), borderColor, config.outlineFeather());
 			}
 
 			if (config.highlightClickbox())
@@ -124,7 +123,7 @@ class ObjectIndicatorsOverlay extends Overlay
 				Shape clickbox = object.getClickbox();
 				if (clickbox != null)
 				{
-					OverlayUtil.renderPolygon(graphics, clickbox, boarderColor, fillColor, stroke);
+					OverlayUtil.renderPolygon(graphics, clickbox, borderColor, fillColor, stroke);
 				}
 			}
 
@@ -133,7 +132,7 @@ class ObjectIndicatorsOverlay extends Overlay
 				Polygon tilePoly = object.getCanvasTilePoly();
 				if (tilePoly != null)
 				{
-					OverlayUtil.renderPolygon(graphics, tilePoly, boarderColor, fillColor, stroke);
+					OverlayUtil.renderPolygon(graphics, tilePoly, borderColor, fillColor, stroke);
 				}
 			}
 		}
@@ -141,7 +140,7 @@ class ObjectIndicatorsOverlay extends Overlay
 		return null;
 	}
 
-	private void renderConvexHull(Graphics2D graphics, TileObject object, Color boarderColor, Color fillColor, Stroke stroke)
+	private void renderConvexHull(Graphics2D graphics, TileObject object, Color borderColor, Color fillColor, Stroke stroke)
 	{
 		final Shape polygon;
 		Shape polygon2 = null;
@@ -171,12 +170,12 @@ class ObjectIndicatorsOverlay extends Overlay
 
 		if (polygon != null)
 		{
-			OverlayUtil.renderPolygon(graphics, polygon, boarderColor, fillColor, stroke);
+			OverlayUtil.renderPolygon(graphics, polygon, borderColor, fillColor, stroke);
 		}
 
 		if (polygon2 != null)
 		{
-			OverlayUtil.renderPolygon(graphics, polygon2, boarderColor, fillColor, stroke);
+			OverlayUtil.renderPolygon(graphics, polygon2, borderColor, fillColor, stroke);
 		}
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/objectindicators/ObjectIndicatorsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/objectindicators/ObjectIndicatorsPlugin.java
@@ -295,7 +295,7 @@ public class ObjectIndicatorsPlugin extends Plugin
 				objects.add(new ColorTileObject(object,
 					objectComposition,
 					objectPoint.getName(),
-					objectPoint.getBoarderColor(),
+					objectPoint.getBorderColor(),
 					objectPoint.getFillColor()));
 				break;
 			}
@@ -380,7 +380,7 @@ public class ObjectIndicatorsPlugin extends Plugin
 	{
 		final WorldPoint worldPoint = WorldPoint.fromLocalInstance(client, object.getLocalLocation());
 		final int regionId = worldPoint.getRegionID();
-		final Color boarderColor = config.boarderColor();
+		final Color borderColor = config.borderColor();
 		final Color fillColor = config.fillColor();
 		final ObjectPoint point = new ObjectPoint(
 			object.getId(),
@@ -389,7 +389,7 @@ public class ObjectIndicatorsPlugin extends Plugin
 			worldPoint.getRegionX(),
 			worldPoint.getRegionY(),
 			worldPoint.getPlane(),
-			boarderColor,
+			borderColor,
 			fillColor);
 
 		Set<ObjectPoint> objectPoints = points.computeIfAbsent(regionId, k -> new HashSet<>());
@@ -416,7 +416,7 @@ public class ObjectIndicatorsPlugin extends Plugin
 			objects.add(new ColorTileObject(object,
 				client.getObjectDefinition(object.getId()),
 				name,
-				boarderColor,
+				borderColor,
 				fillColor));
 			log.debug("Marking object: {}", point);
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/objectindicators/ObjectPoint.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/objectindicators/ObjectPoint.java
@@ -41,6 +41,6 @@ class ObjectPoint
 	private int regionX;
 	private int regionY;
 	private int z;
-	private Color boarderColor;
+	private Color borderColor;
 	private Color fillColor;
 }


### PR DESCRIPTION
Add fill color to object markers plugin closes #14843
![Object Marker Config](https://user-images.githubusercontent.com/119808801/208349457-371e5ae8-e651-4ef3-8f6f-f4148a77a7a5.PNG)
![Object Marker Fill](https://user-images.githubusercontent.com/119808801/208349463-c54f9865-8e71-4ed3-a355-68fbaf14eced.PNG)
