### PR TITLE
client: fix rendering issue

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/events/DisplayChanged.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/DisplayChanged.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2022, Macweese <https://github.com/Macweese>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.api.events;
+
+import lombok.Value;
+
+import java.awt.GraphicsDevice;
+
+/**
+ * An event when a new {@link GraphicsDevice} becomes the owner of the application
+ */
+@Value
+public class DisplayChanged
+{
+	GraphicsDevice graphicsDevice;
+}

--- a/runelite-client/src/main/java/net/runelite/client/callback/Hooks.java
+++ b/runelite-client/src/main/java/net/runelite/client/callback/Hooks.java
@@ -24,7 +24,6 @@
  */
 package net.runelite.client.callback;
 
-import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
@@ -388,15 +387,18 @@ public class Hooks implements Callbacks
 		final Image finalImage;
 		if (client.isStretchedEnabled())
 		{
-			GraphicsConfiguration gc = clientUi.getGraphicsConfiguration();
+			GraphicsConfiguration gc = ClientUI.getGraphicsDevice().getDefaultConfiguration();
 			Dimension stretchedDimensions = client.getStretchedDimensions();
 
 			if (lastStretchedDimensions == null || !lastStretchedDimensions.equals(stretchedDimensions)
-				|| (stretchedImage != null && stretchedImage.validate(gc) == VolatileImage.IMAGE_INCOMPATIBLE))
+				|| (stretchedImage != null && stretchedImage.validate(gc) != VolatileImage.IMAGE_OK))
 			{
-				/*
-					Reuse the resulting image instance to avoid creating an extreme amount of objects
-				 */
+				// Only reuse image if it is unsullied else reconstruct new
+				if (stretchedImage != null)
+				{
+					stretchedImage.flush();
+				}
+
 				stretchedImage = gc.createCompatibleVolatileImage(stretchedDimensions.width, stretchedDimensions.height);
 
 				if (stretchedGraphics != null)
@@ -406,12 +408,6 @@ public class Hooks implements Callbacks
 				stretchedGraphics = (Graphics2D) stretchedImage.getGraphics();
 
 				lastStretchedDimensions = stretchedDimensions;
-
-				/*
-					Fill Canvas before drawing stretched image to prevent artifacts.
-				*/
-				graphics.setColor(Color.BLACK);
-				graphics.fillRect(0, 0, client.getCanvas().getWidth(), client.getCanvas().getHeight());
 			}
 
 			stretchedGraphics.setRenderingHint(RenderingHints.KEY_INTERPOLATION,

--- a/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
@@ -72,6 +72,7 @@ import net.runelite.api.Constants;
 import net.runelite.api.GameState;
 import net.runelite.api.Player;
 import net.runelite.api.Point;
+import net.runelite.api.events.DisplayChanged;
 import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetInfo;
@@ -549,6 +550,7 @@ public class ClientUI
 					{
 						frame.repaint();
 						graphicsDevice = gd;
+						eventBus.post(new DisplayChanged(gd));
 
 						log.info("New associated graphics device: {}, {}x{}, {}Hz",
 								gd,

--- a/runelite-client/src/main/java/net/runelite/client/ui/ContainableFrame.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ContainableFrame.java
@@ -32,8 +32,6 @@ import java.awt.GraphicsEnvironment;
 import java.awt.Insets;
 import java.awt.Rectangle;
 import java.awt.Toolkit;
-import java.util.Arrays;
-import java.util.Comparator;
 import javax.swing.JFrame;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
@@ -329,22 +327,6 @@ public class ContainableFrame extends JFrame
 	}
 
 	/**
-	 * Finds the {@link GraphicsConfiguration} of the display the window is currently on. If it's on more than
-	 * one screen, returns the one it's most on (largest area of intersection)
-	 */
-	private GraphicsConfiguration getCurrentDisplayConfiguration()
-	{
-		return Arrays.stream(GraphicsEnvironment.getLocalGraphicsEnvironment().getScreenDevices())
-			.map(GraphicsDevice::getDefaultConfiguration)
-			.max(Comparator.comparingInt(config ->
-			{
-				Rectangle intersection = config.getBounds().intersection(getBounds());
-				return intersection.width * intersection.height;
-			}))
-			.orElseGet(this::getGraphicsConfiguration);
-	}
-
-	/**
 	 * Calculates the bounds of the window area of the screen.
 	 * <p>
 	 * The bounds returned by {@link GraphicsEnvironment#getMaximumWindowBounds} are incorrectly calculated on
@@ -358,7 +340,7 @@ public class ContainableFrame extends JFrame
 			log.trace("Device: {} bounds {}", device, device.getDefaultConfiguration().getBounds());
 		}
 
-		GraphicsConfiguration config = getCurrentDisplayConfiguration();
+		GraphicsConfiguration config = super.getGraphicsConfiguration();
 		// get screen bounds
 		Rectangle bounds = config.getBounds();
 		log.trace("Chosen device: {} bounds {}", config, bounds);


### PR DESCRIPTION

This PR is aimed to fix a rendering issue in the client caused by Stretched Mode which was introduced in f672ef9014d98892ea0fd4c48d3932db173bea2b
For reference to issues see #3422 ,  #11878

Changes include; dismissing any `VolatileImage` which has been restored or is incomplete, addition of a new event to relay information about display changes, improve how the client determines which `GraphicsDevice` it belongs to, fixing VSync in the GPU plugin.

Tested systems
• Windows 10.0.19044.2364, 10.0.19044.2251, 10.0.18362, 7 (Build 7601)
• Ubuntu 20.04 LTS
• MacOS X 10.6

Tested with OpenGL, DD/D3D
Preferably this can be further tested by others.

____

#### Notes

Consider the OS' versions as some are dated and might not be an accurate representation of the userbase.
I found OpenGL manages to retain the bitmap better and continue displaying (correct) information whereas DD/D3D in comparison fails to do the equivalent.

Of possible solutions the proposed introduces minimal connascence, or otherwise serves to inform what I've identified as the problem, should a more comprehensive solution be made.

#### Cause
Cascading failure from changes in VRAM