### PR TITLE
Feature: Added overwrite color feature for coins

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
@@ -458,4 +458,23 @@ public interface GroundItemsConfig extends Config
 	{
 		return Keybind.ALT;
 	}
+
+	@ConfigItem(
+			keyName = "showGoldenCoins",
+			name = "Golden Coins",
+			description = "Overrides the color of coins to yellow (golden)",
+			position = 34
+	)
+	default boolean showGoldenCoins() { return false; }
+
+	@ConfigItem(
+			keyName = "GoldenCoinsMin",
+			name = "Golden Coins min value",
+			description = "Configures the amount of gp needed for Golden Coins to activate",
+			position = 35
+	)
+	default int GoldenCoinsMin()
+	{
+		return 0;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
@@ -216,7 +216,22 @@ public class GroundItemsOverlay extends Overlay
 				}
 			}
 
-			final Color color = plugin.getItemColor(highlighted, hidden);
+			Color color = null;
+			if (config.showGoldenCoins())
+			{
+				if (item.getQuantity() >= config.GoldenCoinsMin() && item.getItemId() == 995)
+				{
+					color = plugin.getItemColor(new Color(255, 255,0), hidden);
+				}
+				else
+				{
+					color = plugin.getItemColor(highlighted, hidden);
+				}
+			}
+			else
+			{
+				color = plugin.getItemColor(highlighted, hidden);
+			}
 
 			if (config.highlightTiles())
 			{


### PR DESCRIPTION
The Golden Coins feature will overwrite the color of gp ("GOLD" pieces) and will only activate if it has the specified amount or more. This is very useful as coins are very often toggled on and off because some npcs drop small amount of it and blocks the screen, while others might have an amount you want to pick up. Its also one of the most iconic and game defining items that deserves a gold color.