### PR TITLE
Fix antivenom timers expiring too early

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersPlugin.java
@@ -121,7 +121,7 @@ public class TimersPlugin extends Plugin
 	private static final String LIQUID_ADRENALINE_MESSAGE = "You drink some of the potion, reducing the energy cost of your special attacks.</col>";
 
 	private static final Pattern DIVINE_POTION_PATTERN = Pattern.compile("You drink some of your divine (.+) potion\\.");
-	private static final int VENOM_VALUE_CUTOFF = -40; // Antivenom < -40 <= Antipoison < 0
+	private static final int VENOM_VALUE_CUTOFF = -38; // Antivenom < -38 <= Antipoison < 0
 	private static final int POISON_TICK_LENGTH = 30;
 
 	static final int FIGHT_CAVES_REGION_ID = 9551;


### PR DESCRIPTION
The anti-venom timers currently expire too early. Fix based on these lines https://github.com/Joshua-F/cs2-scripts/blob/0286ddf0dfbd37f0abfc16afcad34270c65891d2/scripts/%5Bproc%2Cbuff_bar_get_value%5D.cs2#L64-L71

**Before:**

- Anti-venom: 

https://user-images.githubusercontent.com/96100526/209685333-dabfd164-e312-4660-9a6e-a3a12d332f49.mp4

- Anti-venom+: 

https://user-images.githubusercontent.com/96100526/209685470-8111522d-83e5-4f75-b787-5d093bf8e3f2.mp4

**After:**

- Anti-venom: 

https://user-images.githubusercontent.com/96100526/209685711-cc2fe758-14c7-46b6-9734-f35918eefb59.mp4

- Anti-venom+:

https://user-images.githubusercontent.com/96100526/209685660-e2d49c82-316a-432d-a24d-0c660180e0ca.mp4