### PR TITLE
item stats: Fix Ring of the gods (i) detection

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/potions/PrayerPotion.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/potions/PrayerPotion.java
@@ -30,6 +30,7 @@ import net.runelite.api.InventoryID;
 import net.runelite.api.Item;
 import net.runelite.api.ItemContainer;
 import net.runelite.api.ItemID;
+import net.runelite.client.game.ItemVariationMapping;
 import net.runelite.client.plugins.itemstats.StatBoost;
 import static net.runelite.client.plugins.itemstats.stats.Stats.PRAYER;
 
@@ -65,14 +66,15 @@ public class PrayerPotion extends StatBoost
 			Item cape = equipContainer.getItem(CAPE_SLOT);
 			Item ring = equipContainer.getItem(RING_SLOT);
 
-			hasHolyWrench = ring != null && ring.getId() == ItemID.RING_OF_THE_GODS_I;
+			hasHolyWrench = ring != null && ItemVariationMapping.getVariations(ItemID.RING_OF_THE_GODS)
+				.stream()
+				.filter(itemId -> itemId != ItemID.RING_OF_THE_GODS) // remove non-imbued rotg; it does not have the wrench effect
+				.anyMatch(itemId -> itemId == ring.getId());
 			if (cape != null)
 			{
 				int capeId = cape.getId();
-				hasHolyWrench |= capeId == ItemID.PRAYER_CAPE;
-				hasHolyWrench |= capeId == ItemID.PRAYER_CAPET;
-				hasHolyWrench |= capeId == ItemID.MAX_CAPE;
-				hasHolyWrench |= capeId == ItemID.MAX_CAPE_13342;
+				hasHolyWrench |= ItemVariationMapping.getVariations(ItemID.PRAYER_CAPE).contains(capeId);
+				hasHolyWrench |= ItemVariationMapping.getVariations(ItemID.MAX_CAPE).contains(capeId);
 			}
 		}
 		if (!hasHolyWrench)
@@ -84,10 +86,8 @@ public class PrayerPotion extends StatBoost
 				{
 					int item = itemStack.getId();
 					hasHolyWrench = item == ItemID.HOLY_WRENCH;
-					hasHolyWrench |= item == ItemID.PRAYER_CAPE;
-					hasHolyWrench |= item == ItemID.PRAYER_CAPET;
-					hasHolyWrench |= item == ItemID.MAX_CAPE;
-					hasHolyWrench |= item == ItemID.MAX_CAPE_13342;
+					hasHolyWrench |= ItemVariationMapping.getVariations(ItemID.PRAYER_CAPE).contains(item);
+					hasHolyWrench |= ItemVariationMapping.getVariations(ItemID.MAX_CAPE).contains(item);
 
 					if (hasHolyWrench)
 					{

--- a/runelite-client/src/test/java/net/runelite/client/plugins/itemstats/ItemStatEffectTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/itemstats/ItemStatEffectTest.java
@@ -28,6 +28,10 @@ package net.runelite.client.plugins.itemstats;
 import com.google.common.collect.ImmutableMap;
 import java.util.Map;
 import net.runelite.api.Client;
+import net.runelite.api.EquipmentInventorySlot;
+import net.runelite.api.InventoryID;
+import net.runelite.api.Item;
+import net.runelite.api.ItemContainer;
 import net.runelite.api.ItemID;
 import net.runelite.api.Skill;
 import static org.junit.Assert.assertEquals;
@@ -36,6 +40,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import static org.mockito.ArgumentMatchers.any;
 import org.mockito.Mock;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import org.mockito.junit.MockitoJUnitRunner;
 
@@ -239,6 +244,25 @@ public class ItemStatEffectTest
 		assertEquals(24, skillChange(Skill.PRAYER, 99, 99, ambrosia));
 		assertEquals(10, skillChange(Skill.PRAYER, 99, 113, ambrosia));
 		assertEquals(0, skillChange(Skill.PRAYER, 99, 123, ambrosia));
+	}
+
+	@Test
+	public void prayerRestoreVariants()
+	{
+		final ItemContainer equipment = mock(ItemContainer.class);
+		when(client.getItemContainer(InventoryID.EQUIPMENT)).thenReturn(equipment);
+
+		final Effect ppot = new ItemStatChanges().get(ItemID.PRAYER_POTION2);
+
+		// no holy wrench boost for non-imbued ring equipped
+		when(equipment.getItem(EquipmentInventorySlot.RING.getSlotIdx())).thenReturn(new Item(ItemID.RING_OF_THE_GODS, 1));
+		assertEquals(31, skillChange(Skill.PRAYER, 99, 0, ppot));
+
+		for (final int ring : new int[] { ItemID.RING_OF_THE_GODS_I, ItemID.RING_OF_THE_GODS_I_25252, ItemID.RING_OF_THE_GODS_I_26764 })
+		{
+			when(equipment.getItem(EquipmentInventorySlot.RING.getSlotIdx())).thenReturn(new Item(ring, 1));
+			assertEquals(33, skillChange(Skill.PRAYER, 99, 0, ppot));
+		}
 	}
 
 	private int skillChange(Skill skill, int maxValue, int currentValue, Effect effect)


### PR DESCRIPTION
Previously, PrayerPotion only checked for the nightmare zone imbue version of the Ring of the gods, and did not include the soul wars and pvp arena variants. This commit updates it to use ItemVariationMapping to ensure other variants are included.