### PR TITLE
Fixing the colour of "Your damage" in the corp cave

### DIFF
--- a/runelite-client/pom.xml
+++ b/runelite-client/pom.xml
@@ -114,6 +114,11 @@
 			<version>1.2</version>
 		</dependency>
 		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-math3</artifactId>
+			<version>3.6.1</version>
+		</dependency>
+		<dependency>
 			<groupId>net.runelite.archive-patcher</groupId>
 			<artifactId>archive-patcher-applier</artifactId>
 			<version>1.2</version>


### PR DESCRIPTION
Currently, the indicator to show whether the player can receive loot doesn't scale well as teams exceed 4 or more. Dividing the damage dealt by the number of players gives you the average damage dealt, not the minimum damage required to get the loot. This damage required is often significantly greater than that average damage.

These updates make the indicator turn green if there's a reasonable (i.e. greater than 1 in 200) chance that you'll receive the loot, while also displaying this probability of that for the benefit of the player. This works for any number of players.