### PR TITLE
Timers: Add Saturated Heart

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/timers/GameTimer.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timers/GameTimer.java
@@ -56,6 +56,7 @@ enum GameTimer
 	ICEBLITZ(SpriteID.SPELL_ICE_BLITZ, GameTimerImageType.SPRITE, "Ice blitz", GraphicID.ICE_BLITZ, 24, GAME_TICKS, true),
 	ICEBARRAGE(SpriteID.SPELL_ICE_BARRAGE, GameTimerImageType.SPRITE, "Ice barrage", GraphicID.ICE_BARRAGE, 32, GAME_TICKS, true),
 	IMBUEDHEART(ItemID.IMBUED_HEART, GameTimerImageType.ITEM, "Imbued heart", 420, ChronoUnit.SECONDS, true),
+	SATURATEDHEART(ItemID.SATURATED_HEART, GameTimerImageType.ITEM, "Saturated heart", 300, ChronoUnit.SECONDS, true),
 	VENGEANCE(SpriteID.SPELL_VENGEANCE, GameTimerImageType.SPRITE, "Vengeance", 30, ChronoUnit.SECONDS),
 	EXSUPERANTIFIRE(ItemID.EXTENDED_SUPER_ANTIFIRE4, GameTimerImageType.ITEM, "Extended Super AntiFire", 6, ChronoUnit.MINUTES),
 	OVERLOAD_RAID(ItemID.OVERLOAD_4_20996, GameTimerImageType.ITEM, "Overload", 5, ChronoUnit.MINUTES, true),

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersPlugin.java
@@ -302,7 +302,7 @@ public class TimersPlugin extends Plugin
 					createGameTimer(SATURATEDHEART, Duration.of(10L * imbuedHeartCooldownVarb, RSTimeUnit.GAME_TICKS));
 					imbuedHeartTimerActive = true;
 				}
-            } else if (playerInventory != null && (playerInventory.contains(ItemID.IMBUED_HEART))) {
+            } else {
 				if (imbuedHeartCooldownVarb == 0) {
 					removeGameTimer(IMBUEDHEART);
 					imbuedHeartTimerActive = false;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersPlugin.java
@@ -291,20 +291,27 @@ public class TimersPlugin extends Plugin
 			}
 		}
 
-		if (event.getVarbitId() == Varbits.IMBUED_HEART_COOLDOWN && config.showImbuedHeart())
-		{
-			final int imbuedHeartCooldownVarb = event.getValue();
-			if (imbuedHeartCooldownVarb == 0)
-			{
-				removeGameTimer(IMBUEDHEART);
-				imbuedHeartTimerActive = false;
-			}
-			else if (!imbuedHeartTimerActive)
-			{
-				createGameTimer(IMBUEDHEART, Duration.of(10L * imbuedHeartCooldownVarb, RSTimeUnit.GAME_TICKS));
-				imbuedHeartTimerActive = true;
-			}
-		}
+        if (event.getVarbitId() == Varbits.IMBUED_HEART_COOLDOWN && config.showImbuedHeart()) {
+            final int imbuedHeartCooldownVarb = event.getValue();
+            ItemContainer playerInventory = client.getItemContainer(InventoryID.INVENTORY);
+            if (playerInventory != null && (playerInventory.contains(ItemID.SATURATED_HEART))) {
+				if (imbuedHeartCooldownVarb == 0) {
+					removeGameTimer(SATURATEDHEART);
+					imbuedHeartTimerActive = false;
+				} else if (!imbuedHeartTimerActive) {
+					createGameTimer(SATURATEDHEART, Duration.of(10L * imbuedHeartCooldownVarb, RSTimeUnit.GAME_TICKS));
+					imbuedHeartTimerActive = true;
+				}
+            } else if (playerInventory != null && (playerInventory.contains(ItemID.IMBUED_HEART))) {
+				if (imbuedHeartCooldownVarb == 0) {
+					removeGameTimer(IMBUEDHEART);
+					imbuedHeartTimerActive = false;
+				} else if (!imbuedHeartTimerActive) {
+					createGameTimer(IMBUEDHEART, Duration.of(10L * imbuedHeartCooldownVarb, RSTimeUnit.GAME_TICKS));
+					imbuedHeartTimerActive = true;
+				}
+            }
+        }
 
 		if (event.getVarpId() == VarPlayer.LAST_HOME_TELEPORT.getId() && config.showHomeMinigameTeleports())
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersPlugin.java
@@ -291,18 +291,18 @@ public class TimersPlugin extends Plugin
 			}
 		}
 
-        if (event.getVarbitId() == Varbits.IMBUED_HEART_COOLDOWN && config.showImbuedHeart()) {
-            final int imbuedHeartCooldownVarb = event.getValue();
-            ItemContainer playerInventory = client.getItemContainer(InventoryID.INVENTORY);
-            if (playerInventory != null && (playerInventory.contains(ItemID.SATURATED_HEART))) {
-				if (imbuedHeartCooldownVarb == 0) {
-					removeGameTimer(SATURATEDHEART);
-					imbuedHeartTimerActive = false;
+		if (event.getVarbitId() == Varbits.IMBUED_HEART_COOLDOWN && config.showImbuedHeart()) {
+			final int imbuedHeartCooldownVarb = event.getValue();
+			ItemContainer playerInventory = client.getItemContainer(InventoryID.INVENTORY);
+			if (playerInventory != null && (playerInventory.contains(ItemID.SATURATED_HEART))) {
+			if (imbuedHeartCooldownVarb == 0) {
+				removeGameTimer(SATURATEDHEART);
+				imbuedHeartTimerActive = false;
 				} else if (!imbuedHeartTimerActive) {
 					createGameTimer(SATURATEDHEART, Duration.of(10L * imbuedHeartCooldownVarb, RSTimeUnit.GAME_TICKS));
 					imbuedHeartTimerActive = true;
 				}
-            } else {
+			} else {
 				if (imbuedHeartCooldownVarb == 0) {
 					removeGameTimer(IMBUEDHEART);
 					imbuedHeartTimerActive = false;
@@ -310,8 +310,8 @@ public class TimersPlugin extends Plugin
 					createGameTimer(IMBUEDHEART, Duration.of(10L * imbuedHeartCooldownVarb, RSTimeUnit.GAME_TICKS));
 					imbuedHeartTimerActive = true;
 				}
-            }
-        }
+			}
+		}
 
 		if (event.getVarpId() == VarPlayer.LAST_HOME_TELEPORT.getId() && config.showHomeMinigameTeleports())
 		{


### PR DESCRIPTION
Replaces the imbued heart overlay with a saturated heart if the player has one in their inventory.

![image](https://user-images.githubusercontent.com/88600811/212564341-933e97ab-05ac-4837-9689-a58c25cdbded.png)
