### PR TITLE
fix(twitch): use login name in place of unrenderable display names

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/twitch/TwitchPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/twitch/TwitchPlugin.java
@@ -172,7 +172,7 @@ public class TwitchPlugin extends Plugin implements TwitchListener
 	}
 
 	@Override
-	public void privmsg(Map<String, String> tags, String message)
+	public void privmsg(String source, Map<String, String> tags, String message)
 	{
 		if (client.getGameState() != GameState.LOGGED_IN)
 		{
@@ -180,7 +180,8 @@ public class TwitchPlugin extends Plugin implements TwitchListener
 		}
 
 		String displayName = tags.get("display-name");
-		addChatMessage(displayName, message);
+		String name = source.equalsIgnoreCase(displayName) ? displayName : source;
+		addChatMessage(name, message);
 	}
 
 	@Override

--- a/runelite-client/src/main/java/net/runelite/client/plugins/twitch/irc/TwitchIRCClient.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/twitch/irc/TwitchIRCClient.java
@@ -122,7 +122,8 @@ public class TwitchIRCClient extends Thread implements AutoCloseable
 						send("PONG", message.getArguments()[0]);
 						break;
 					case "PRIVMSG":
-						twitchListener.privmsg(message.getTags(),
+						twitchListener.privmsg(message.getSource().substring(0, message.getSource().indexOf('!')),
+							message.getTags(),
 							message.getArguments()[1]);
 						break;
 					case "ROOMSTATE":

--- a/runelite-client/src/main/java/net/runelite/client/plugins/twitch/irc/TwitchListener.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/twitch/irc/TwitchListener.java
@@ -28,7 +28,7 @@ import java.util.Map;
 
 public interface TwitchListener
 {
-	void privmsg(Map<String, String> tags, String message);
+	void privmsg(String source, Map<String, String> tags, String message);
 
 	void roomstate(Map<String, String> tags);
 


### PR DESCRIPTION
Twitch display names can contain characters outsize of `a-zA-Z0-9_ `. For such special names, we fallback to the user's login name to avoid `?`. (note: this PR does not tackle the problem of nonalphanumeric message content)

Before:
![image](https://user-images.githubusercontent.com/8106344/213950896-78f67e68-7a9b-4978-aec5-7aa547f4bc84.png)

After:
![image](https://user-images.githubusercontent.com/8106344/213950457-7929812b-2803-49a5-a94e-fe770f9267a3.png)

