### PR TITLE
questlist: Update quest list tab index

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/questlist/QuestListPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/questlist/QuestListPlugin.java
@@ -165,7 +165,7 @@ public class QuestListPlugin extends Plugin
 
 	private boolean isOnQuestTab()
 	{
-		return client.getVarbitValue(Varbits.QUEST_TAB) == 0 && client.getVarcIntValue(VarClientInt.INVENTORY_TAB) == 2;
+		return client.getVarbitValue(Varbits.QUEST_TAB) == 1 && client.getVarcIntValue(VarClientInt.INVENTORY_TAB) == 2;
 	}
 
 	private boolean isChatboxOpen()


### PR DESCRIPTION
Close #16176

Currently, the method to check whether the quest list tab is open is testing the incorrect tab index (presumably since the addition of the Character Summary tab). This causes the search input chatbox to close on any varbit or varClientInt update while viewing the quest list, where the expected behavior is the inverse.