### PR TITLE
Fake XP drop on zero hitsplash

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/experiencedrop/XpDropConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/experiencedrop/XpDropConfig.java
@@ -103,6 +103,9 @@ public interface XpDropConfig extends Config
 		description = "Drops fake XP when hitting a zero in combat, disables other fake XP drops",
 		position = 6
 	)
-	default boolean dropOnZero() { return false; }
+	default boolean dropOnZero()
+	{
+		return false;
+	}
 
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/experiencedrop/XpDropConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/experiencedrop/XpDropConfig.java
@@ -96,4 +96,13 @@ public interface XpDropConfig extends Config
 	{
 		return 0;
 	}
+
+	@ConfigItem(
+		keyName = "dropOnZero",
+		name = "Fake Xp Drop On Zero",
+		description = "Drops fake XP when hitting a zero in combat, disables other fake XP drops",
+		position = 6
+	)
+	default boolean dropOnZero() { return false; }
+
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/experiencedrop/XpDropPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/experiencedrop/XpDropPlugin.java
@@ -202,7 +202,7 @@ public class XpDropPlugin extends Plugin
 
 			final int fakeTickDelay = config.fakeXpDropDelay();
 
-			if (fakeTickDelay == 0 || lastSkill == null) //fakeTickDelay == 0 || lastSkill == null
+			if (fakeTickDelay == 0 || lastSkill == null)
 			{
 				return;
 			}


### PR DESCRIPTION
Close #10658 

When enabled, hitting a 'zero hitsplash' will drop a fake XP drop with value of 2 XP. Enabling this disables fake XP drops on tick value set by user. 

Passing value < 2 to XPDROP_DISABLED script second argument doesn't allow the script to fire, hence the value 2.  
