### PR TITLE
loot tracker: Fix chest re-opening detection

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
@@ -341,6 +341,7 @@ public class LootTrackerPlugin extends Plugin
 	private NavigationButton navButton;
 
 	private boolean chestLooted;
+	private boolean lastLoadingIntoInstance;
 	private String lastPickpocketTarget;
 
 	private List<String> ignoredItems = new ArrayList<>();
@@ -593,8 +594,10 @@ public class LootTrackerPlugin extends Plugin
 	@Subscribe
 	public void onGameStateChanged(final GameStateChanged event)
 	{
-		if (event.getGameState() == GameState.LOADING && !client.isInInstancedRegion())
+		final boolean inInstancedRegion = client.isInInstancedRegion();
+		if (event.getGameState() == GameState.LOADING && inInstancedRegion != lastLoadingIntoInstance)
 		{
+			lastLoadingIntoInstance = inInstancedRegion;
 			chestLooted = false;
 		}
 	}
@@ -689,12 +692,7 @@ public class LootTrackerPlugin extends Plugin
 				chestLooted = true;
 				break;
 			case (WidgetID.THEATRE_OF_BLOOD_GROUP_ID):
-				if (chestLooted)
-				{
-					return;
-				}
-				int region = WorldPoint.fromLocalInstance(client, client.getLocalPlayer().getLocalLocation()).getRegionID();
-				if (region != THEATRE_OF_BLOOD_REGION && region != THEATRE_OF_BLOOD_LOBBY)
+				if (chestLooted || !inTobChestRegion())
 				{
 					return;
 				}
@@ -1226,6 +1224,13 @@ public class LootTrackerPlugin extends Plugin
 		int herbloreLevel = client.getBoostedSkillLevel(Skill.HERBLORE);
 		addLoot(HERBIBOAR_EVENT, -1, LootRecordType.EVENT, herbloreLevel, herbs);
 		return true;
+	}
+
+	@VisibleForTesting
+	boolean inTobChestRegion()
+	{
+		int region = WorldPoint.fromLocalInstance(client, client.getLocalPlayer().getLocalLocation()).getRegionID();
+		return region == THEATRE_OF_BLOOD_REGION || region == THEATRE_OF_BLOOD_LOBBY;
 	}
 
 	void toggleItem(String name, boolean ignore)

--- a/runelite-client/src/test/java/net/runelite/client/plugins/loottracker/LootTrackerPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/loottracker/LootTrackerPluginTest.java
@@ -38,6 +38,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import javax.inject.Inject;
 import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
+import net.runelite.api.GameState;
 import net.runelite.api.InventoryID;
 import net.runelite.api.Item;
 import net.runelite.api.ItemComposition;
@@ -50,6 +51,7 @@ import net.runelite.api.Skill;
 import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.ChatMessage;
+import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.ItemContainerChanged;
 import net.runelite.api.events.WidgetLoaded;
 import net.runelite.api.widgets.WidgetID;
@@ -75,6 +77,7 @@ import static org.mockito.ArgumentMatchers.isNull;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
@@ -419,6 +422,104 @@ public class LootTrackerPluginTest
 
 		verify(lootTrackerPlugin).addLoot("Reward pool (Tempoross)", -1, LootRecordType.EVENT, 69, Arrays.asList(
 			new ItemStack(ItemID.TOME_OF_WATER_EMPTY, 1, null)
+		));
+	}
+
+	@Test
+	public void testReopenChestInInstance()
+	{
+		LootTrackerPlugin spyPlugin = Mockito.spy(lootTrackerPlugin);
+		// Make sure we don't execute addLoot, so we don't have to mock LootTrackerPanel and everything else also
+		doNothing().when(spyPlugin).addLoot(anyString(), anyInt(), any(LootRecordType.class), isNull(), anyCollection());
+		doReturn(true).when(spyPlugin).inTobChestRegion();
+
+		final GameStateChanged loading = new GameStateChanged();
+		loading.setGameState(GameState.LOADING);
+
+		ItemContainer itemContainer = mock(ItemContainer.class);
+		when(itemContainer.getItems()).thenReturn(new Item[]{
+			new Item(ItemID.SCYTHE_OF_VITUR_UNCHARGED, 1)
+		});
+		when(client.getItemContainer(InventoryID.THEATRE_OF_BLOOD_CHEST)).thenReturn(itemContainer);
+
+		when(client.isInInstancedRegion()).thenReturn(true);
+		spyPlugin.onGameStateChanged(loading);
+
+		WidgetLoaded widgetLoaded = new WidgetLoaded();
+		widgetLoaded.setGroupId(WidgetID.THEATRE_OF_BLOOD_GROUP_ID);
+		spyPlugin.onWidgetLoaded(widgetLoaded);
+
+		verify(spyPlugin).addLoot("Theatre of Blood", -1, LootRecordType.EVENT, null, Collections.singletonList(
+			new ItemStack(ItemID.SCYTHE_OF_VITUR_UNCHARGED, 1, null)
+		));
+	}
+
+	@Test
+	public void testReopenChestOutsideOfInstance()
+	{
+		LootTrackerPlugin spyPlugin = Mockito.spy(lootTrackerPlugin);
+		// Make sure we don't execute addLoot, so we don't have to mock LootTrackerPanel and everything else also
+		doNothing().when(spyPlugin).addLoot(anyString(), anyInt(), any(LootRecordType.class), isNull(), anyCollection());
+		doReturn(true).when(spyPlugin).inTobChestRegion();
+
+		final GameStateChanged loading = new GameStateChanged();
+		loading.setGameState(GameState.LOADING);
+
+		ItemContainer itemContainer = mock(ItemContainer.class);
+		when(itemContainer.getItems()).thenReturn(new Item[]{
+			new Item(ItemID.SCYTHE_OF_VITUR_UNCHARGED, 1)
+		});
+		when(client.getItemContainer(InventoryID.THEATRE_OF_BLOOD_CHEST)).thenReturn(itemContainer);
+
+		when(client.isInInstancedRegion()).thenReturn(false);
+		spyPlugin.onGameStateChanged(loading);
+
+		WidgetLoaded widgetLoaded = new WidgetLoaded();
+		widgetLoaded.setGroupId(WidgetID.THEATRE_OF_BLOOD_GROUP_ID);
+		spyPlugin.onWidgetLoaded(widgetLoaded);
+
+		verify(spyPlugin).addLoot("Theatre of Blood", -1, LootRecordType.EVENT, null, Collections.singletonList(
+			new ItemStack(ItemID.SCYTHE_OF_VITUR_UNCHARGED, 1, null)
+		));
+	}
+
+	@Test
+	public void testOpenInstancedAreaChestAfterNonInstancedAreaChest()
+	{
+		LootTrackerPlugin spyPlugin = Mockito.spy(lootTrackerPlugin);
+		// Make sure we don't execute addLoot, so we don't have to mock LootTrackerPanel and everything else also
+		doNothing().when(spyPlugin).addLoot(anyString(), anyInt(), any(LootRecordType.class), isNull(), anyCollection());
+		doReturn(true).when(spyPlugin).inTobChestRegion();
+
+		final GameStateChanged loading = new GameStateChanged();
+		loading.setGameState(GameState.LOADING);
+
+		ItemContainer itemContainer = mock(ItemContainer.class);
+		when(itemContainer.getItems()).thenReturn(new Item[]{
+			new Item(ItemID.SCYTHE_OF_VITUR_UNCHARGED, 1)
+		});
+		when(client.getItemContainer(InventoryID.THEATRE_OF_BLOOD_CHEST)).thenReturn(itemContainer);
+
+		when(client.isInInstancedRegion()).thenReturn(false);
+		spyPlugin.onGameStateChanged(loading);
+
+		WidgetLoaded widgetLoaded = new WidgetLoaded();
+		widgetLoaded.setGroupId(WidgetID.THEATRE_OF_BLOOD_GROUP_ID);
+		spyPlugin.onWidgetLoaded(widgetLoaded);
+
+		verify(spyPlugin).addLoot("Theatre of Blood", -1, LootRecordType.EVENT, null, Collections.singletonList(
+			new ItemStack(ItemID.SCYTHE_OF_VITUR_UNCHARGED, 1, null)
+		));
+
+		when(itemContainer.getItems()).thenReturn(new Item[]{
+			new Item(ItemID.SANGUINESTI_STAFF_UNCHARGED, 1)
+		});
+		when(client.isInInstancedRegion()).thenReturn(true);
+		spyPlugin.onGameStateChanged(loading);
+		spyPlugin.onWidgetLoaded(widgetLoaded);
+
+		verify(spyPlugin).addLoot("Theatre of Blood", -1, LootRecordType.EVENT, null, Collections.singletonList(
+			new ItemStack(ItemID.SANGUINESTI_STAFF_UNCHARGED, 1, null)
 		));
 	}
 }


### PR DESCRIPTION
Presently, it is possible to have loot from Theatre of Blood not be captured by the loot tracker by looting the lobby chest for one run and looting inside of the theatre for the following run, because `chestLooted` would never be reset. (because all game state changes to LOADING would be within the theatre, which is instanced) This commit changes that behavior to track the previous instanced state and reset `chestLooted` whenever outside of an instanced area like before, but additionally when entering an instance from a non-instanced area.