### PR TITLE
xptracker: prevent negative values with hide maxed

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerPlugin.java
@@ -396,6 +396,8 @@ public class XpTrackerPlugin extends Plugin
 
 		if (xpTrackerConfig.hideMaxed() && currentLevel >= Experience.MAX_REAL_LEVEL)
 		{
+			xpPanel.resetSkill(skill);
+			removeOverlay(skill);
 			return;
 		}
 


### PR DESCRIPTION
When I maxed Firemaking with a goal of 99, the XP tracker showed me unexpected values in the sidebar related to my goal, rather than progressing to a lvl 99 -> lvl 100 progress bar:

![image](https://user-images.githubusercontent.com/1868974/215993733-1876ca6d-a07d-41ae-a744-96b5c91df897.png)

I believe this occurred because I have "Hide maxed skills" enabled in the config, although it's difficult to recreate even with devtools.

This PR removes the skill in question from the side panel and overlays upon reaching 99, respecting the "hide maxed skills" option.