### PR TITLE
devtools: Add missing id suffix to named values

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/devtools/VarInspector.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/devtools/VarInspector.java
@@ -258,7 +258,8 @@ class VarInspector extends DevToolsFrame
 				// Example: 4101 collides with 4104-4129
 				client.setVarbitValue(oldVarps2, i, neew);
 
-				final String name = VARBIT_NAMES.getOrDefault(i, Integer.toString(i));
+				String name = VARBIT_NAMES.get(i);
+				name = String.format(name == null ? "%d" : name + "(%d)", i);
 				addVarLog(VarType.VARBIT, name, old, neew);
 			}
 		}
@@ -294,7 +295,8 @@ class VarInspector extends DevToolsFrame
 
 		if (old != neew)
 		{
-			final String name = VARCINT_NAMES.getOrDefault(idx, Integer.toString(idx));
+			String name = VARCINT_NAMES.get(idx);
+			name = String.format(name == null ? "%d" : name + "(%d)", idx);
 			addVarLog(VarType.VARCINT, name, old, neew);
 		}
 	}
@@ -309,7 +311,8 @@ class VarInspector extends DevToolsFrame
 
 		if (!Objects.equals(old, neew))
 		{
-			final String name = VARCSTR_NAMES.getOrDefault(idx, Integer.toString(idx));
+			String name = VARCSTR_NAMES.get(idx);
+			name = String.format(name == null ? "%d" : name + "(%d)", idx);
 			if (old != null)
 			{
 				old = "\"" + old + "\"";


### PR DESCRIPTION
To be consistent with `VarPlayer`, named `Varbit`, `VarClientInt` and `VarClientStr` values now have an integer id suffix in parenthesis. E.g. instead of displaying only `EQUIPPED_WEAPON_TYPE` it is now showing `EQUIPPED_WEAPON_TYPE(357)`