### PR TITLE
Add true blood rune to rc calculator

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/skills/RunecraftAction.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/skills/RunecraftAction.java
@@ -27,6 +27,7 @@ package net.runelite.client.plugins.skillcalculator.skills;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import net.runelite.api.ItemID;
+import net.runelite.client.game.ItemManager;
 
 @AllArgsConstructor
 @Getter
@@ -65,7 +66,22 @@ public enum RunecraftAction implements ItemSkillAction
 	NATURE_RUNE(ItemID.NATURE_RUNE, 44, 9, false, true),
 	LAW_RUNE(ItemID.LAW_RUNE, 54, 9.5f, false, true),
 	DEATH_RUNE(ItemID.DEATH_RUNE, 65, 10, false, true),
-	BLOOD_RUNE(ItemID.BLOOD_RUNE, 77, 24.425f, true),
+	ZEAH_BLOOD_RUNE(ItemID.BLOOD_RUNE, 77, 24.425f, true)
+	{
+		@Override
+		public String getName(final ItemManager itemManager)
+		{
+			return "Blood Rune (Zeah)";
+		}
+	},
+	TRUE_BLOOD_RUNE(ItemID.BLOOD_RUNE, 77, 10.5f, false)
+	{
+		@Override
+		public String getName(final ItemManager itemManager)
+		{
+			return "Blood Rune (True Altar)";
+		}
+	},
 	SOUL_RUNE(ItemID.SOUL_RUNE, 90, 30.325f, true),
 	WRATH_RUNE(ItemID.WRATH_RUNE, 95, 8, false),
 	;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/skills/RunecraftAction.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/skills/RunecraftAction.java
@@ -71,7 +71,7 @@ public enum RunecraftAction implements ItemSkillAction
 		@Override
 		public String getName(final ItemManager itemManager)
 		{
-			return "Blood Rune (Zeah)";
+			return "Blood rune (Zeah)";
 		}
 	},
 	TRUE_BLOOD_RUNE(ItemID.BLOOD_RUNE, 77, 10.5f, false)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/skills/RunecraftAction.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/skills/RunecraftAction.java
@@ -79,7 +79,7 @@ public enum RunecraftAction implements ItemSkillAction
 		@Override
 		public String getName(final ItemManager itemManager)
 		{
-			return "Blood Rune (True Altar)";
+			return "Blood rune (True Altar)";
 		}
 	},
 	SOUL_RUNE(ItemID.SOUL_RUNE, 90, 30.325f, true),


### PR DESCRIPTION
Add entry for true blood altar to the SkillCalculator plugin. 

Blood runes crafted at the true blood altar give significantly less xp than ones crafted at the zeah blood altar. Add a nameOverride field to RunecraftAction so users can distinguish between old zeah blood rune xp and true blood altar xp

I can provide a before and after screenshot if that would help reviewing this PR