### PR TITLE
Only draw Motherlode Mine rockfalls on the same floor as the player

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/motherlode/MotherlodeSceneOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/motherlode/MotherlodeSceneOverlay.java
@@ -115,7 +115,10 @@ class MotherlodeSceneOverlay extends Overlay
 				LocalPoint location = rock.getLocalLocation();
 				if (localLocation.distanceTo(location) <= MAX_DISTANCE)
 				{
-					renderRock(graphics, rock);
+					if (plugin.isUpstairs(localLocation) == plugin.isUpstairs(location))
+					{
+						renderRock(graphics, rock);
+					}
 				}
 			}
 		}


### PR DESCRIPTION
This PR will only render red boxes around rockfalls that are on the same floor as the player. This is in line with the icons drawn on the mining veins. 