### PR TITLE
Show users remaining buttons to solve light box

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/puzzlesolver/PuzzleSolverPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/puzzlesolver/PuzzleSolverPlugin.java
@@ -276,7 +276,16 @@ public class PuzzleSolverPlugin extends Plugin
 			}
 			else
 			{
-				title.setText("Light box - Solution: unknown");
+				String remainingButtons = "";
+				for (int i = 0; i < Combination.values().length; i++) {
+					if (changes[i] == null) {
+						remainingButtons += Combination.values()[i];
+					}
+				}
+				if (remainingButtons == "") {
+					remainingButtons = "Any";
+				}
+				title.setText("Light box - Press: " + remainingButtons);
 			}
 		}
 	}


### PR DESCRIPTION
Displaying "Solution: unknown" can make it seem like the solver doesn't know how to find the solution. Displaying remaining buttons to press alleviates that problem and makes it clear to the user how to get the solution.