### PR TITLE
feat: optionally highlight others in pvp areas

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/HighlightOtherPlayers.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/HighlightOtherPlayers.java
@@ -5,14 +5,14 @@ import lombok.AllArgsConstructor;
 @AllArgsConstructor
 public enum HighlightOtherPlayers
 {
-    DISABLED("Disabled"),
-    EVERYWHERE("Everywhere"),
-    ONLYPVP("Only in PvP");
-    private final String option;
+        DISABLED("Disabled"),
+        EVERYWHERE("Everywhere"),
+        ONLYPVP("Only in PvP");
+        private final String option;
 
-    @Override
-    public String toString()
-    {
-        return option;
-    }
+        @Override
+        public String toString()
+        {
+            return option;
+        }
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/HighlightOtherPlayers.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/HighlightOtherPlayers.java
@@ -3,16 +3,14 @@ package net.runelite.client.plugins.playerindicators;
 import lombok.AllArgsConstructor;
 
 @AllArgsConstructor
-public enum HighlightOtherPlayers
-{
-        DISABLED("Disabled"),
-        EVERYWHERE("Everywhere"),
-        ONLYPVP("Only in PvP");
-        private final String option;
+public enum HighlightOtherPlayers {
+    DISABLED("Disabled"),
+    EVERYWHERE("Everywhere"),
+    ONLYPVP("Only in PvP");
+    private final String option;
 
-        @Override
-        public String toString()
-        {
-            return option;
-        }
+    @Override
+    public String toString() {
+        return option;
+    }
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/HighlightOtherPlayers.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/HighlightOtherPlayers.java
@@ -3,14 +3,16 @@ package net.runelite.client.plugins.playerindicators;
 import lombok.AllArgsConstructor;
 
 @AllArgsConstructor
-public enum HighlightOtherPlayers {
+public enum HighlightOtherPlayers
+{
 	DISABLED("Disabled"),
 	EVERYWHERE("Everywhere"),
 	ONLYPVP("Only in PvP");
 	private final String option;
 
 	@Override
-	public String toString() {
+	public String toString()
+	{
 		return option;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/HighlightOtherPlayers.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/HighlightOtherPlayers.java
@@ -3,7 +3,8 @@ package net.runelite.client.plugins.playerindicators;
 import lombok.AllArgsConstructor;
 
 @AllArgsConstructor
-public enum HighlightOtherPlayers {
+public enum HighlightOtherPlayers
+{
     DISABLED("Disabled"),
     EVERYWHERE("Everywhere"),
     ONLYPVP("Only in PvP");

--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/HighlightOtherPlayers.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/HighlightOtherPlayers.java
@@ -8,7 +8,6 @@ public enum HighlightOtherPlayers
     DISABLED("Disabled"),
     EVERYWHERE("Everywhere"),
     ONLYPVP("Only in PvP");
-
     private final String option;
 
     @Override

--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/HighlightOtherPlayers.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/HighlightOtherPlayers.java
@@ -4,13 +4,13 @@ import lombok.AllArgsConstructor;
 
 @AllArgsConstructor
 public enum HighlightOtherPlayers {
-    DISABLED("Disabled"),
-    EVERYWHERE("Everywhere"),
-    ONLYPVP("Only in PvP");
-    private final String option;
+	DISABLED("Disabled"),
+	EVERYWHERE("Everywhere"),
+	ONLYPVP("Only in PvP");
+	private final String option;
 
-    @Override
-    public String toString() {
-        return option;
-    }
+	@Override
+	public String toString() {
+		return option;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/HighlightOtherPlayers.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/HighlightOtherPlayers.java
@@ -1,0 +1,18 @@
+package net.runelite.client.plugins.playerindicators;
+
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public enum HighlightOtherPlayers {
+    DISABLED("Disabled"),
+    EVERYWHERE("Everywhere"),
+    ONLYPVP("Only in PvP");
+
+    private final String option;
+
+    @Override
+    public String toString()
+    {
+        return option;
+    }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsConfig.java
@@ -191,7 +191,8 @@ public interface PlayerIndicatorsConfig extends Config
 		description = "Configures whether or not other players should be highlighted",
 		section = highlightSection
 	)
-	default HighlightOtherPlayers highlightOthers() {
+	default HighlightOtherPlayers highlightOthers()
+	{
 		return HighlightOtherPlayers.DISABLED;
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsConfig.java
@@ -191,9 +191,8 @@ public interface PlayerIndicatorsConfig extends Config
 		description = "Configures whether or not other players should be highlighted",
 		section = highlightSection
 	)
-	default boolean highlightOthers()
-	{
-		return false;
+	default HighlightOtherPlayers highlightOthers() {
+		return HighlightOtherPlayers.DISABLED;
 	}
 
 	@ConfigItem(

--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsPlugin.java
@@ -30,6 +30,8 @@ import javax.inject.Inject;
 import lombok.Value;
 import net.runelite.api.Client;
 import net.runelite.api.FriendsChatRank;
+import net.runelite.api.*;
+
 import static net.runelite.api.FriendsChatRank.UNRANKED;
 import net.runelite.api.MenuAction;
 import static net.runelite.api.MenuAction.ITEM_USE_ON_PLAYER;
@@ -192,6 +194,9 @@ public class PlayerIndicatorsPlugin extends Plugin
 		int image = -1;
 		Color color = null;
 
+		boolean inWilderness = client.getVarbitValue(Varbits.IN_WILDERNESS) == 1;
+		boolean inPvp = client.getVarbitValue(Varbits.PVP_SPEC_ORB) == 1;
+
 		boolean isPartyMember = partyService.isInParty() &&
 			player.getName() != null &&
 			config.highlightPartyMembers() &&
@@ -216,7 +221,11 @@ public class PlayerIndicatorsPlugin extends Plugin
 		{
 			color = config.getClanMemberColor();
 		}
-		else if (!player.isFriendsChatMember() && !player.isClanMember() && !config.highlightOthers().equals(HighlightOtherPlayers.DISABLED))
+		else if (config.highlightOthers().equals(HighlightOtherPlayers.EVERYWHERE) && !player.isFriendsChatMember() && !player.isClanMember())
+		{
+			color = config.getOthersColor();
+		}
+		else if (config.highlightOthers().equals(HighlightOtherPlayers.ONLYPVP) && (inPvp || inWilderness) && !player.isFriendsChatMember() && !player.isClanMember())
 		{
 			color = config.getOthersColor();
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsPlugin.java
@@ -216,7 +216,7 @@ public class PlayerIndicatorsPlugin extends Plugin
 		{
 			color = config.getClanMemberColor();
 		}
-		else if (!player.isFriendsChatMember() && !player.isClanMember() && config.highlightOthers())
+		else if (!player.isFriendsChatMember() && !player.isClanMember() && !config.highlightOthers().equals(HighlightOtherPlayers.DISABLED))
 		{
 			color = config.getOthersColor();
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsService.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsService.java
@@ -60,7 +60,7 @@ public class PlayerIndicatorsService
 	public void forEachPlayer(final BiConsumer<Player, Color> consumer)
 	{
 		if (!config.highlightOwnPlayer() && !config.highlightFriendsChat()
-			&& !config.highlightFriends() && !config.highlightOthers()
+			&& !config.highlightFriends() && config.highlightOthers().equals(HighlightOtherPlayers.DISABLED)
 			&& !config.highlightClanMembers() && !config.highlightPartyMembers())
 		{
 			return;
@@ -112,7 +112,11 @@ public class PlayerIndicatorsService
 			{
 				consumer.accept(player, config.getClanMemberColor());
 			}
-			else if (config.highlightOthers() && !isFriendsChatMember && !isClanMember)
+			else if (config.highlightOthers().equals(HighlightOtherPlayers.EVERYWHERE) && !isFriendsChatMember && !isClanMember)
+			{
+				consumer.accept(player, config.getOthersColor());
+			}
+			else if (config.highlightOthers().equals(HighlightOtherPlayers.ONLYPVP) && (inPvp || inWilderness) && !isFriendsChatMember && !isClanMember)
 			{
 				consumer.accept(player, config.getOthersColor());
 			}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerNameLocation.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerNameLocation.java
@@ -29,7 +29,6 @@ import lombok.AllArgsConstructor;
 @AllArgsConstructor
 public enum PlayerNameLocation
 {
-
 	DISABLED("Disabled"),
 	ABOVE_HEAD("Above head"),
 	MODEL_CENTER("Center of model"),


### PR DESCRIPTION
Added a dropdown menu to the highlight others feature of the 'player indicator' plugin.

Previously it was only possible to highlight all the other players. Not dependent on whether you're in a PvP area or not.

Now it is possible to only enable it whilst being in PvP or the wilderness via this new feature.

The dropdown menu holds three enum values:

"Disabled" -> There will be no highlighting of other players.
"Everywhere" -> All other players will be highlighted. Just like it previously did. (Before it was a simple boolean toggle)
"Only in PvP" (NEW) -> Other players will only be highlighted whilst you are in a PvP area.