### PR TITLE
Add Fill Opacity with Tile Color Config Option to Ground Markers Plugin

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/groundmarkers/GroundMarkerConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/groundmarkers/GroundMarkerConfig.java
@@ -97,4 +97,14 @@ public interface GroundMarkerConfig extends Config
 	{
 		return 50;
 	}
+
+	@ConfigItem(
+		keyName = "fillOpacityWithTileColor",
+		name = "Fill Opacity with Tile Color",
+		description = "Use the color of the tile as the color for its opacity"
+	)
+	default boolean fillOpacityWithTileColor()
+	{
+		return false;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/groundmarkers/GroundMarkerOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/groundmarkers/GroundMarkerOverlay.java
@@ -114,7 +114,15 @@ public class GroundMarkerOverlay extends Overlay
 		Polygon poly = Perspective.getCanvasTilePoly(client, lp);
 		if (poly != null)
 		{
-			OverlayUtil.renderPolygon(graphics, poly, color, new Color(0, 0, 0, config.fillOpacity()), borderStroke);
+			if (config.fillOpacityWithTileColor())
+			{
+				OverlayUtil.renderPolygon(graphics, poly, color, new Color(
+					color.getRed(), color.getGreen(), color.getBlue(), config.fillOpacity()), borderStroke);
+			}
+			else
+			{
+				OverlayUtil.renderPolygon(graphics, poly, color, new Color(0, 0, 0, config.fillOpacity()), borderStroke);
+			}
 		}
 
 		if (!Strings.isNullOrEmpty(label))


### PR DESCRIPTION
This change adds the option to fill a ground marker's tile with the color of the tile instead of only being black.

"Fill Opacity with Tile Color" turned off and "Fill Opacity" set to 50:
<img width="141" alt="opacity1" src="https://user-images.githubusercontent.com/77599829/219815266-589869d4-269a-4e71-8ae2-0f7daf7bed29.png">

"Fill Opacity with Tile Color" turned on and "Fill Opacity" set to 50:
<img width="131" alt="opacity2" src="https://user-images.githubusercontent.com/77599829/219815352-0501782b-8e67-4fa4-9c6e-2d402d6220a1.png">
