### PR TITLE
world switcher: use a sticky table header

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldSwitcherPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldSwitcherPanel.java
@@ -37,11 +37,12 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.ScrollPaneConstants;
 import javax.swing.SwingUtilities;
 import lombok.AccessLevel;
 import lombok.Setter;
 import net.runelite.client.ui.ColorScheme;
-import net.runelite.client.ui.DynamicGridLayout;
 import net.runelite.client.ui.PluginPanel;
 import net.runelite.http.api.worlds.World;
 import net.runelite.http.api.worlds.WorldType;
@@ -75,17 +76,24 @@ class WorldSwitcherPanel extends PluginPanel
 
 	WorldSwitcherPanel(WorldHopperPlugin plugin)
 	{
+		super(false);
+
 		this.plugin = plugin;
 
 		setBorder(null);
-		setLayout(new DynamicGridLayout(0, 1));
+		setLayout(new BorderLayout());
 
 		JPanel headerContainer = buildHeader();
 
 		listContainer.setLayout(new GridLayout(0, 1));
 
-		add(headerContainer);
-		add(listContainer);
+		JScrollPane scrollPane = new JScrollPane(listContainer);
+		scrollPane.setHorizontalScrollBarPolicy(ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
+
+		add(headerContainer, BorderLayout.NORTH);
+		add(scrollPane, BorderLayout.CENTER);
+
+		revalidate();
 	}
 
 	void switchCurrentHighlight(int newWorld, int lastWorld)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldTableRow.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldTableRow.java
@@ -42,6 +42,7 @@ import javax.swing.border.EmptyBorder;
 import lombok.AccessLevel;
 import lombok.Getter;
 import net.runelite.client.ui.FontManager;
+import net.runelite.client.ui.PluginPanel;
 import net.runelite.client.util.ImageUtil;
 import net.runelite.http.api.worlds.World;
 import net.runelite.http.api.worlds.WorldRegion;
@@ -57,6 +58,8 @@ class WorldTableRow extends JPanel
 	private static final int WORLD_COLUMN_WIDTH = 60;
 	private static final int PLAYERS_COLUMN_WIDTH = 40;
 	private static final int PING_COLUMN_WIDTH = 35;
+
+	private static final int ROW_HEIGHT = 24;
 
 	private static final Color CURRENT_WORLD = new Color(66, 227, 17);
 	private static final Color DANGEROUS_WORLD = new Color(251, 62, 62);
@@ -102,6 +105,7 @@ class WorldTableRow extends JPanel
 
 		setLayout(new BorderLayout());
 		setBorder(new EmptyBorder(2, 0, 2, 0));
+		setPreferredSize(new Dimension(PluginPanel.PANEL_WIDTH, ROW_HEIGHT));
 
 		addMouseListener(new MouseAdapter()
 		{


### PR DESCRIPTION
Use a sticky table header for the World Switcher.

Before:

[before.webm](https://user-images.githubusercontent.com/2388657/219901216-3193e955-45ce-475e-baa6-859ed1650c72.webm)


After:

[after.webm](https://user-images.githubusercontent.com/2388657/219901226-0bfd6c68-9afc-4c22-88c1-545c95733ced.webm)


(It's been a while since I've done Swing. Let me know if there is a better way to do this to possibly get rid of the `setPreferredSize` and `revalidate`!)

