### PR TITLE
Security upgrade org.apache.maven:maven-plugin-api from 3.0.5 to 3.2.1

### DIFF
--- a/runelite-script-assembler-plugin/pom.xml
+++ b/runelite-script-assembler-plugin/pom.xml
@@ -46,7 +46,7 @@
 		<dependency>
 			<groupId>org.apache.maven</groupId>
 			<artifactId>maven-plugin-api</artifactId>
-			<version>3.0.5</version>
+			<version>3.2.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.maven.plugin-tools</groupId>


### PR DESCRIPTION
Upgrades Maven from `3.0.5` -> `3.2.1`. Version `3.0.5` includes a critically vulnerable dependency (`plexus-utils` version `2.0.6`). This package is susceptible to a command injection vulnerability because it does not correctly process the contents of double-quoted strings. 

This is [CVE-2017-1000487](https://www.cve.org/CVERecord?id=CVE-2017-1000487).