### PR TITLE
Thieving plugin chests

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/thieving/ChestOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/thieving/ChestOverlay.java
@@ -1,0 +1,215 @@
+package net.runelite.client.plugins.thieving;
+
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Graphics2D;
+import java.util.Map;
+import javax.inject.Inject;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.Client;
+import net.runelite.api.Perspective;
+import net.runelite.api.coords.LocalPoint;
+import net.runelite.api.coords.WorldPoint;
+import net.runelite.client.game.ItemManager;
+import net.runelite.client.ui.overlay.Overlay;
+import net.runelite.client.ui.overlay.OverlayLayer;
+import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.components.ProgressPieComponent;
+import net.runelite.client.util.ColorUtil;
+
+/**
+ * Represents the overlay that shows timers on chests that have been plundered by the player.
+ */
+@Slf4j
+public class ChestOverlay extends Overlay
+{
+	private final Client client;
+	private final ThievingPlugin plugin;
+	private final ThievingConfig config;
+
+	private final ItemManager itemManager;
+
+	/**
+	 * Colors
+	 */
+	private Color colorPlundered, colorPlunderedBorder;
+	private Color colorFull, colorFullBorder;
+	private Color colorTrans, colorTransBorder;
+
+
+	/**
+	 * Overlay settings
+	 */
+	private final int MAX_DRAW_DISTANCE = 2350;
+	private ChestReadyIndicator chestReadyIndicator;
+
+	@Getter
+	@AllArgsConstructor
+	public enum ChestReadyIndicator
+	{
+		ICON("Icon"),
+		CIRCLE("Circle"),
+		NONE("No indicator");
+
+		private final String name;
+
+		@Override
+		public String toString()
+		{
+			return getName();
+		}
+	}
+
+	@Inject
+	ChestOverlay(Client client, ThievingPlugin plugin, ThievingConfig config, ItemManager itemManager)
+	{
+		setPosition(OverlayPosition.DYNAMIC);
+		setLayer(OverlayLayer.ABOVE_SCENE);
+		this.client = client;
+		this.plugin = plugin;
+		this.config = config;
+		this.itemManager = itemManager;
+	}
+
+	/**
+	 * Updates the timer colors.
+	 */
+	public void updateConfig()
+	{
+		colorPlunderedBorder = config.getPlunderedChestColor();
+		colorPlundered = ColorUtil.colorWithAlpha(colorPlunderedBorder, (int) (colorPlunderedBorder.getAlpha() / 2.5));
+		colorFullBorder = config.getFullChestColor();
+		colorFull = ColorUtil.colorWithAlpha(colorFullBorder, (int) (colorFullBorder.getAlpha() / 2.5));
+		colorTransBorder = config.getTransChestColor();
+		colorTrans = ColorUtil.colorWithAlpha(colorTransBorder, (int) (colorTransBorder.getAlpha() / 2.5));
+		chestReadyIndicator = config.getChestReadyIndicator();
+	}
+
+	@Override
+	public Dimension render(Graphics2D graphics)
+	{
+		updateConfig();
+		drawTimers(graphics);
+		return null;
+	}
+
+	/**
+	 * Iterates over all the active chests in the plugin, and draws a circle or a timer on the chest, depending on state
+	 */
+	private void drawTimers(Graphics2D graphics)
+	{
+		for (Map.Entry<WorldPoint, ThievableChest.ActiveChest> entry : plugin.getActiveChests().entrySet())
+		{
+			ThievableChest.ActiveChest activeChest = entry.getValue();
+
+			int chestPlane = activeChest.getObject().getPlane();
+			if (chestPlane != client.getPlane())
+			{
+				continue;
+			}
+
+			if (client.getLocalPlayer().getWorldLocation().getRegionID() != activeChest.getRegionID())
+			{
+				continue;
+			}
+
+			if (client.getLocalPlayer().getLocalLocation().distanceTo(activeChest.getObject().getLocalLocation()) > MAX_DRAW_DISTANCE)
+			{
+				continue;
+			}
+
+			switch (activeChest.getState())
+			{
+				case READY:
+					switch (chestReadyIndicator)
+					{
+						case ICON:
+							drawIconOnChest(graphics, activeChest);
+							break;
+						case CIRCLE:
+							drawCircleOnChest(graphics, activeChest, colorFull, colorFullBorder);
+							break;
+						default:
+							break;
+					}
+					break;
+				case TRANS:
+					drawCircleOnChest(graphics, activeChest, colorTrans, colorTransBorder);
+					break;
+				case PLUNDERED:
+					drawTimerOnChest(graphics, activeChest, colorPlundered, colorPlunderedBorder);
+					break;
+			}
+		}
+	}
+
+	/**
+	 * Draws a timer on a given chest
+	 */
+	private void drawTimerOnChest(Graphics2D graphics, ThievableChest.ActiveChest chest, Color fill, Color border)
+	{
+		LocalPoint localPoint = LocalPoint.fromWorld(client, chest.getObject().getWorldLocation());
+		if (localPoint == null)
+		{
+			return;
+		}
+
+		net.runelite.api.Point loc = Perspective.localToCanvas(client, localPoint, client.getPlane());
+		if (loc == null)
+		{
+			return;
+		}
+		double timeLeft = 1 - chest.getRemainingTime();
+
+		ProgressPieComponent pie = new ProgressPieComponent();
+		pie.setFill(fill);
+		pie.setBorderColor(border);
+		pie.setPosition(loc);
+		pie.setProgress(timeLeft);
+		pie.render(graphics);
+	}
+
+	/**
+	 * Draws a circle on a given chest
+	 */
+	private void drawCircleOnChest(Graphics2D graphics, ThievableChest.ActiveChest chest, Color fill, Color border)
+	{
+		if (chest.getObject().getWorldLocation().getPlane() != client.getPlane())
+		{
+			return;
+		}
+		LocalPoint localLoc = LocalPoint.fromWorld(client, chest.getObject().getWorldLocation());
+		if (localLoc == null)
+		{
+			return;
+		}
+		net.runelite.api.Point loc = Perspective.localToCanvas(client, localLoc, client.getPlane());
+
+		ProgressPieComponent pie = new ProgressPieComponent();
+		pie.setFill(fill);
+		pie.setBorderColor(border);
+		pie.setPosition(loc);
+		pie.setProgress(1);
+		pie.render(graphics);
+	}
+
+	private void drawIconOnChest(Graphics2D graphics, ThievableChest.ActiveChest chest)
+	{
+		if (chest.getObject().getWorldLocation().getPlane() != client.getPlane())
+		{
+			return;
+		}
+		LocalPoint localLoc = LocalPoint.fromWorld(client, chest.getObject().getWorldLocation());
+		if (localLoc == null)
+		{
+			return;
+		}
+		net.runelite.api.Point loc = Perspective.localToCanvas(client, localLoc, client.getPlane());
+		if (loc != null)
+		{
+			graphics.drawImage(itemManager.getImage(chest.getIconID()), loc.getX(), loc.getY(), null);
+		}
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/thieving/ChestOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/thieving/ChestOverlay.java
@@ -10,13 +10,16 @@ import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.Perspective;
+import net.runelite.api.Point;
 import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.OverlayUtil;
 import net.runelite.client.ui.overlay.components.ProgressPieComponent;
+import net.runelite.client.util.AsyncBufferedImage;
 import net.runelite.client.util.ColorUtil;
 
 /**
@@ -209,7 +212,8 @@ public class ChestOverlay extends Overlay
 		net.runelite.api.Point loc = Perspective.localToCanvas(client, localLoc, client.getPlane());
 		if (loc != null)
 		{
-			graphics.drawImage(itemManager.getImage(chest.getIconID()), loc.getX(), loc.getY(), null);
+			AsyncBufferedImage img = itemManager.getImage(chest.getIconID());
+			OverlayUtil.renderImageLocation(client, graphics, chest.getObject().getLocalLocation(), img, 0);
 		}
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/thieving/ThievableChest.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/thieving/ThievableChest.java
@@ -1,0 +1,182 @@
+package net.runelite.client.plugins.thieving;
+
+import java.time.Duration;
+import java.time.Instant;
+import lombok.Getter;
+import lombok.Setter;
+import net.runelite.api.GameObject;
+import net.runelite.api.ItemID;
+import net.runelite.api.coords.WorldPoint;
+
+/**
+ * ThievableChest represents a chest that the player can loot. This class contains an array of these chests that will
+ * be enabled for timers.
+ */
+public class ThievableChest
+{
+
+
+	@Getter
+	private final WorldPoint location;
+
+	@Getter
+	private final int chestIcon;
+
+	@Getter
+	private final Duration resetTime;
+
+	public ThievableChest(WorldPoint loc, int chestIcon, Duration resetTime)
+	{
+		this.location = loc;
+		this.chestIcon = chestIcon;
+		this.resetTime = resetTime;
+	}
+
+	/**
+	 * If a new chest needs to be added, simply add it to trackedChests
+	 */
+	public final static ThievableChest[] trackedChests = {
+		// Chest (10 Coints)
+		new ThievableChest(new WorldPoint(2673, 3307, 0), ItemID.COINS, Duration.ofSeconds((long) 3.5)), //Ardougne east of food stall
+		new ThievableChest(new WorldPoint(2612, 3314, 1), ItemID.COINS, Duration.ofSeconds((long) 3.5)), //Ardougne south of northern bank
+
+		new ThievableChest(new WorldPoint(3188, 3962, 0), ItemID.COINS, Duration.ofSeconds((long) 3.5)), //Relekka southwest house
+		new ThievableChest(new WorldPoint(3189, 3962, 0), ItemID.COINS, Duration.ofSeconds((long) 3.5)), //Relekka southwest house
+		new ThievableChest(new WorldPoint(3193, 3962, 0), ItemID.COINS, Duration.ofSeconds((long) 3.5)), //Relekka southwest house
+
+		new ThievableChest(new WorldPoint(2630, 3655, 1), ItemID.COINS, Duration.ofSeconds((long) 3.5)), //Relekka southwest house
+
+		new ThievableChest(new WorldPoint(3044, 3957, 0), ItemID.COINS, Duration.ofSeconds((long) 3.5)), // Pirate's Hideout
+		new ThievableChest(new WorldPoint(3044, 3951, 0), ItemID.COINS, Duration.ofSeconds((long) 3.5)), // Pirate's Hideout
+
+		// Nature Rune
+		new ThievableChest(new WorldPoint(2671, 3301, 1), ItemID.NATURE_RUNE, Duration.ofSeconds(8)), //Ardougne east of food stall
+		new ThievableChest(new WorldPoint(2614, 3314, 1), ItemID.NATURE_RUNE, Duration.ofSeconds(8)), //Ardougne south of northern bank
+		new ThievableChest(new WorldPoint(2668, 3693, 1), ItemID.NATURE_RUNE, Duration.ofSeconds(8)), //Relekka north of longhouse
+		new ThievableChest(new WorldPoint(3042, 3949, 0), ItemID.NATURE_RUNE, Duration.ofSeconds(8)), // Pirate's Hideout
+
+		// Isle of Souls
+		new ThievableChest(new WorldPoint(2139, 9299, 0), ItemID.DARK_KEY, Duration.ofSeconds(0)), //Relekka north of longhouse
+
+		// Chest (50 Coins)
+		new ThievableChest(new WorldPoint(2671, 3299, 1), ItemID.COINS, Duration.ofSeconds(50)), // Ardougne east of food stall
+		new ThievableChest(new WorldPoint(2035, 4649, 0), ItemID.COINS, Duration.ofSeconds(50)), // Mourner Tunnels
+		new ThievableChest(new WorldPoint(3040, 3949, 0), ItemID.COINS, Duration.ofSeconds(50)), // Pirate's Hideout
+
+		// Steel Arrowtips
+		new ThievableChest(new WorldPoint(2038, 4649, 0), ItemID.STEEL_ARROWTIPS, Duration.ofSeconds(75)), // Mourner Tunnels
+		new ThievableChest(new WorldPoint(2650, 3659, 0), ItemID.STEEL_ARROWTIPS, Duration.ofSeconds(75)), // Ardougne Swensen's house
+		new ThievableChest(new WorldPoint(2639, 3424, 0), ItemID.STEEL_ARROWTIPS, Duration.ofSeconds(75)), // Hemenster
+
+		// Dorgesh-Kaan Average
+		// * Floor 1
+		new ThievableChest(new WorldPoint(2749, 5328, 0), ItemID.OIL_LANTERN, Duration.ofSeconds(90)), // South of Teggak
+		new ThievableChest(new WorldPoint(2639, 5324, 0), ItemID.OIL_LANTERN, Duration.ofSeconds(90)), // South of Teggak
+		new ThievableChest(new WorldPoint(2746, 5295, 0), ItemID.OIL_LANTERN, Duration.ofSeconds(90)), // Southwest market
+		new ThievableChest(new WorldPoint(2743, 5253, 0), ItemID.OIL_LANTERN, Duration.ofSeconds(90)), // South of range
+		new ThievableChest(new WorldPoint(2695, 5304, 0), ItemID.OIL_LANTERN, Duration.ofSeconds(90)), // West of Ur-meg
+		// * Floor 2
+		new ThievableChest(new WorldPoint(2743, 5327, 1), ItemID.OIL_LANTERN, Duration.ofSeconds(90)), // South of Nursery
+		new ThievableChest(new WorldPoint(2743, 5324, 1), ItemID.OIL_LANTERN, Duration.ofSeconds(90)), // South of Nursery
+		new ThievableChest(new WorldPoint(2731, 5373, 1), ItemID.OIL_LANTERN, Duration.ofSeconds(90)), // Above range
+		new ThievableChest(new WorldPoint(2707, 5275, 1), ItemID.OIL_LANTERN, Duration.ofSeconds(90)), // Above wire machine
+		new ThievableChest(new WorldPoint(2696, 5315, 1), ItemID.OIL_LANTERN, Duration.ofSeconds(90)), // South of Ferns
+		new ThievableChest(new WorldPoint(2694, 5342, 1), ItemID.OIL_LANTERN, Duration.ofSeconds(90)), // North of Ferns
+		// * Floor 3
+		new ThievableChest(new WorldPoint(2746, 5350, 2), ItemID.OIL_LANTERN, Duration.ofSeconds(90)), // Zanik's bedroom
+		new ThievableChest(new WorldPoint(2743, 5350, 2), ItemID.OIL_LANTERN, Duration.ofSeconds(90)), // Zanik's bedroom
+		new ThievableChest(new WorldPoint(2737, 5295, 2), ItemID.OIL_LANTERN, Duration.ofSeconds(90)), // North of attic Goblins
+		new ThievableChest(new WorldPoint(2697, 5289, 2), ItemID.OIL_LANTERN, Duration.ofSeconds(90)), // Southwest
+		new ThievableChest(new WorldPoint(2696, 5300, 2), ItemID.OIL_LANTERN, Duration.ofSeconds(90)), // West
+		new ThievableChest(new WorldPoint(2706, 5364, 2), ItemID.OIL_LANTERN, Duration.ofSeconds(90)), // Northwest
+
+		// Blood Runes
+		new ThievableChest(new WorldPoint(2586, 9734, 0), ItemID.BLOOD_RUNE, Duration.ofSeconds(120)), // Chaos Druid Tower
+		new ThievableChest(new WorldPoint(2586, 9737, 0), ItemID.BLOOD_RUNE, Duration.ofSeconds(120)), // Chaos Druid Tower
+
+		// Stone Chest
+		new ThievableChest(new WorldPoint(1300, 10089, 0), ItemID.XERICIAN_FABRIC, Duration.ofSeconds(0)), // Lizardman Temple
+		new ThievableChest(new WorldPoint(1302, 10087, 0), ItemID.XERICIAN_FABRIC, Duration.ofSeconds(0)), // Lizardman Temple
+		new ThievableChest(new WorldPoint(1300, 10085, 0), ItemID.XERICIAN_FABRIC, Duration.ofSeconds(0)), // Lizardman Temple
+
+		// Ardougne Castle
+		new ThievableChest(new WorldPoint(2588, 3302, 1), ItemID.COINS, Duration.ofSeconds(500)), // Ardougne Castle (North)
+		new ThievableChest(new WorldPoint(2588, 3291, 1), ItemID.COINS, Duration.ofSeconds(500)), // Ardougne Castle (South)
+
+		// Dorgesh-Kaan Rich
+		// * Floor 2
+		new ThievableChest(new WorldPoint(2731, 5378, 1), ItemID.SAPPHIRE, Duration.ofSeconds(300)), // Above range
+		new ThievableChest(new WorldPoint(2700, 5348, 1), ItemID.SAPPHIRE, Duration.ofSeconds(300)), // Southwest of Council chamber
+		new ThievableChest(new WorldPoint(2703, 5348, 1), ItemID.SAPPHIRE, Duration.ofSeconds(300)), // Southwest of Council chamber
+		// * Floor 3
+		new ThievableChest(new WorldPoint(2731, 5368, 2), ItemID.SAPPHIRE, Duration.ofSeconds(300)), // Above Ur-tag
+		new ThievableChest(new WorldPoint(2734, 5368, 2), ItemID.SAPPHIRE, Duration.ofSeconds(300)), // Above Ur-tag
+		new ThievableChest(new WorldPoint(2745, 5359, 2), ItemID.SAPPHIRE, Duration.ofSeconds(300)), // North of Zanik's bedroom
+		new ThievableChest(new WorldPoint(2737, 5284, 2), ItemID.SAPPHIRE, Duration.ofSeconds(300)), // Attic goblins
+		new ThievableChest(new WorldPoint(2739, 5261, 2), ItemID.SAPPHIRE, Duration.ofSeconds(300)), // Southeast of kitchen Attic
+
+		// Rogues' Castle chest
+		new ThievableChest(new WorldPoint(3283, 3946, 0), ItemID.DRAGONSTONE, Duration.ofSeconds(10)), // N - left
+		new ThievableChest(new WorldPoint(3287, 3946, 0), ItemID.DRAGONSTONE, Duration.ofSeconds(10)), // N - right
+		new ThievableChest(new WorldPoint(3297, 3940, 0), ItemID.DRAGONSTONE, Duration.ofSeconds(10)), // NE
+	};
+
+	/**
+	 * ActiveChest represents a chest that is currently being tracked for timer updates
+	 */
+	public static class ActiveChest
+	{
+		@Getter
+		@Setter
+		private Instant startTime;
+
+		@Getter
+		@Setter
+		private Duration timerDuration;
+
+		@Getter
+		@Setter
+		private GameObject object;
+
+		@Getter
+		@Setter
+		private int RegionID;
+
+		@Getter
+		@Setter
+		private int iconID;
+
+		@Getter
+		@Setter
+		private State state;
+
+
+		enum State
+		{
+			READY,
+			PLUNDERED,
+			TRANS,
+		}
+
+		public ActiveChest(Instant startTime, Duration timerDuration, GameObject object, int regionID, int iconID, State state)
+		{
+			this.startTime = startTime;
+			this.timerDuration = timerDuration;
+			this.object = object;
+			this.RegionID = regionID;
+			this.iconID = iconID;
+			this.state = state;
+		}
+
+		public double getRemainingTime()
+		{
+			if (timerDuration == null)
+			{
+				return 1;
+			}
+			Duration duration = Duration.between(startTime, Instant.now());
+			return duration.compareTo(timerDuration) < 0 ? (double) duration.toMillis() / timerDuration.toMillis() : 1;
+		}
+	}
+
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/thieving/ThievingConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/thieving/ThievingConfig.java
@@ -13,8 +13,8 @@ public interface ThievingConfig extends Config
 	@ConfigItem(
 		position = 1,
 		keyName = "chestReadyIcon",
-		name = "Ready chest",
-		description = "How to indicate a ready chest"
+		name = "Ready Indicator",
+		description = "What indication should display for a chest that is ready to loot"
 	)
 	default ChestOverlay.ChestReadyIndicator getChestReadyIndicator()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/thieving/ThievingConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/thieving/ThievingConfig.java
@@ -1,0 +1,59 @@
+package net.runelite.client.plugins.thieving;
+
+import java.awt.Color;
+import net.runelite.client.config.Alpha;
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+
+@ConfigGroup("thievingplugin")
+public interface ThievingConfig extends Config
+{
+
+	@ConfigItem(
+		position = 1,
+		keyName = "chestReadyIcon",
+		name = "Ready chest",
+		description = "How to indicate a ready chest"
+	)
+	default ChestOverlay.ChestReadyIndicator getChestReadyIndicator()
+	{
+		return ChestOverlay.ChestReadyIndicator.ICON;
+	}
+
+	@Alpha
+	@ConfigItem(
+		position = 2,
+		keyName = "hexColorFullChest",
+		name = "Full chest",
+		description = "Color of full chest timer"
+	)
+	default Color getFullChestColor()
+	{
+		return Color.GREEN;
+	}
+
+	@Alpha
+	@ConfigItem(
+		position = 3,
+		keyName = "hexColorPlunderedChest",
+		name = "Plundered chest",
+		description = "Color of plundered chest timer"
+	)
+	default Color getPlunderedChestColor()
+	{
+		return Color.RED;
+	}
+
+	@Alpha
+	@ConfigItem(
+		position = 4,
+		keyName = "hexColorTransTrap",
+		name = "Transitioning chest",
+		description = "Color of transitioning chest timer"
+	)
+	default Color getTransChestColor()
+	{
+		return Color.ORANGE;
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/thieving/ThievingConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/thieving/ThievingConfig.java
@@ -18,7 +18,7 @@ public interface ThievingConfig extends Config
 	)
 	default ChestOverlay.ChestReadyIndicator getChestReadyIndicator()
 	{
-		return ChestOverlay.ChestReadyIndicator.ICON;
+		return ChestOverlay.ChestReadyIndicator.NONE;
 	}
 
 	@Alpha

--- a/runelite-client/src/main/java/net/runelite/client/plugins/thieving/ThievingPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/thieving/ThievingPlugin.java
@@ -1,0 +1,140 @@
+package net.runelite.client.plugins.thieving;
+
+import com.google.inject.Provides;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import javax.inject.Inject;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.Client;
+import net.runelite.api.GameObject;
+import net.runelite.api.coords.LocalPoint;
+import net.runelite.api.coords.WorldPoint;
+import net.runelite.api.events.GameObjectSpawned;
+import net.runelite.api.events.GameTick;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.eventbus.Subscribe;
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.ui.overlay.OverlayManager;
+
+@Slf4j
+@PluginDescriptor(
+	name = "Thieving",
+	description = "Show the state of your plundered chests",
+	tags = {"overlay", "skilling", "timers"}
+)
+public class ThievingPlugin extends Plugin
+{
+
+	@Inject
+	private Client client;
+
+	@Inject
+	private ThievingConfig config;
+
+	@Inject
+	private OverlayManager overlayManager;
+
+	@Inject
+	private ChestOverlay overlay;
+
+	private static final HashMap<WorldPoint, ThievableChest> timedChests = new HashMap<>();
+
+	@Getter
+	private final HashMap<WorldPoint, ThievableChest.ActiveChest> activeChests = new HashMap<>();
+
+	@Override
+	protected void startUp() throws Exception
+	{
+		initMaps();
+		overlayManager.add(overlay);
+		overlay.updateConfig();
+	}
+
+	@Override
+	protected void shutDown() throws Exception
+	{
+		overlayManager.remove(overlay);
+	}
+
+	@Subscribe
+	public void onGameObjectSpawned(GameObjectSpawned event)
+	{
+		final GameObject gameObject = event.getGameObject();
+
+		ThievableChest chest = timedChests.get(gameObject.getWorldLocation());
+		if (chest != null)
+		{
+			switch (gameObject.getId())
+			{
+				case 11740:
+				case 11741:
+					log.debug("Adding chest to active chest collection, {} total", activeChests.size());
+					activeChests.put(gameObject.getWorldLocation(), new ThievableChest.ActiveChest(Instant.now(), chest.getResetTime(), gameObject, gameObject.getWorldLocation().getRegionID(), chest.getChestIcon(), ThievableChest.ActiveChest.State.PLUNDERED));
+					break;
+				case 11743:
+					log.debug("Adding chest to active chest collection, {} total", activeChests.size());
+					activeChests.put(gameObject.getWorldLocation(), new ThievableChest.ActiveChest(Instant.now(), chest.getResetTime(), gameObject, gameObject.getWorldLocation().getRegionID(), chest.getChestIcon(), ThievableChest.ActiveChest.State.TRANS));
+					break;
+				default:
+					log.debug("Adding chest to active chest collection, {} total", activeChests.size());
+					activeChests.put(gameObject.getWorldLocation(), new ThievableChest.ActiveChest(Instant.now(), chest.getResetTime(), gameObject, gameObject.getWorldLocation().getRegionID(), chest.getChestIcon(), ThievableChest.ActiveChest.State.READY));
+					break;
+
+			}
+		}
+	}
+
+	@Subscribe
+	public void onGameTick(GameTick event)
+	{
+		// Check if all chests are still there, and remove the ones that are not.
+		Iterator<Map.Entry<WorldPoint, ThievableChest.ActiveChest>> it = activeChests.entrySet().iterator();
+		while (it.hasNext())
+		{
+			Map.Entry<WorldPoint, ThievableChest.ActiveChest> entry = it.next();
+			ThievableChest.ActiveChest chest = entry.getValue();
+			WorldPoint world = entry.getKey();
+			LocalPoint local = LocalPoint.fromWorld(client, world);
+
+			Instant expire = Instant.now();
+			if (chest.getTimerDuration() != null)
+			{
+				expire = Instant.now().minus(chest.getTimerDuration().multipliedBy(2));
+			}
+
+			// Not within the client's viewport
+			if (local == null)
+			{
+				// Cull very old chests
+				if (chest.getStartTime().isBefore(expire))
+				{
+					log.debug("Chest removed from active chest collection due to timeout, {} left", activeChests.size());
+					it.remove();
+				}
+			}
+		}
+	}
+
+	/**
+	 * initMaps pulls the array of tracked chests and adds them to the relevant HashMap
+	 */
+	public void initMaps()
+	{
+		for (ThievableChest chest : ThievableChest.trackedChests)
+		{
+			timedChests.put(chest.getLocation(), chest);
+		}
+	}
+
+	@Provides
+	ThievingConfig provideConfig(ConfigManager configManager)
+	{
+		return configManager.getConfig(ThievingConfig.class);
+	}
+
+
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/thieving/ThievingPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/thieving/ThievingPlugin.java
@@ -10,9 +10,11 @@ import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.GameObject;
+import net.runelite.api.GameState;
 import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.GameObjectSpawned;
+import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.GameTick;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
@@ -72,16 +74,21 @@ public class ThievingPlugin extends Plugin
 			{
 				case 11740:
 				case 11741:
-					log.debug("Adding chest to active chest collection, {} total", activeChests.size());
-					activeChests.put(gameObject.getWorldLocation(), new ThievableChest.ActiveChest(Instant.now(), chest.getResetTime(), gameObject, gameObject.getWorldLocation().getRegionID(), chest.getChestIcon(), ThievableChest.ActiveChest.State.PLUNDERED));
+					ThievableChest.ActiveChest oldChestInfo = activeChests.put(gameObject.getWorldLocation(), new ThievableChest.ActiveChest(Instant.now(), chest.getResetTime(), gameObject, gameObject.getWorldLocation().getRegionID(), chest.getChestIcon(), ThievableChest.ActiveChest.State.PLUNDERED));
+					log.debug("Added chest to active chest collection, {} total", activeChests.size());
+					// If we are adding a new plundered chest, but there already exists a timer, it is most likely we have added the same chest
+					if (oldChestInfo != null && oldChestInfo.getState() == ThievableChest.ActiveChest.State.PLUNDERED) {
+						activeChests.put(gameObject.getWorldLocation(), oldChestInfo);
+						log.info("Re-added old chest to active chest collection, {} total", activeChests.size());
+					}
 					break;
 				case 11743:
-					log.debug("Adding chest to active chest collection, {} total", activeChests.size());
 					activeChests.put(gameObject.getWorldLocation(), new ThievableChest.ActiveChest(Instant.now(), chest.getResetTime(), gameObject, gameObject.getWorldLocation().getRegionID(), chest.getChestIcon(), ThievableChest.ActiveChest.State.TRANS));
+					log.debug("Added chest to active chest collection, {} total", activeChests.size());
 					break;
 				default:
-					log.debug("Adding chest to active chest collection, {} total", activeChests.size());
 					activeChests.put(gameObject.getWorldLocation(), new ThievableChest.ActiveChest(Instant.now(), chest.getResetTime(), gameObject, gameObject.getWorldLocation().getRegionID(), chest.getChestIcon(), ThievableChest.ActiveChest.State.READY));
+					log.debug("Added chest to active chest collection, {} total", activeChests.size());
 					break;
 
 			}


### PR DESCRIPTION
### Overview
This PR adds the framework for a Thieving plugin, and adds a timer overlay to all thievable chests as it's first feature.

I have seen #11127 and it's relevant PluginHub plugin but it does not cover any of the other chests that are thievable (and has quite a few bugs as well). This PR has a similar scope to the Motherlode and Hunter plugins, and is built in a similar fashion. This plugin can be built upon to include overlays for other Thieving targets such as stalls.

There is config for the colors of the timers, as well as a setting to indicate whether a chest is full with an Icon or a full timer. The default setting is to not indicate a 'ready' chest with anything, as this is the least obtrusive way of adding this plugin (nothing changes unless you actually interact with the chests).

### Visuals
<details>
<summary>Basic Timer</summary>

![Timer](https://user-images.githubusercontent.com/30102971/220263908-1ac6f8e7-eea8-4a6c-8259-da91b38340cb.gif)

</details>

<details>
<summary>Longer timers are persisted (very useful for 5min+ chests)</summary>

![Persistence](https://user-images.githubusercontent.com/30102971/220263947-43bcd3ff-04cb-4200-8c70-6373e97e2753.gif)

</details>

<details>
<summary>Different "ready" indicators</summary>

![Indicators](https://user-images.githubusercontent.com/30102971/220263998-97ff4a85-7839-4717-91e7-25be205f9cfd.gif)


</details>
