### PR TITLE
cluescrolls: update location text for Gallow medium anagram clue

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java
@@ -414,7 +414,7 @@ public class AnagramClue extends ClueScroll implements NpcClueScroll, ObjectClue
 			.text("LOW LAG")
 			.npc("Gallow")
 			.location(new WorldPoint(1805, 3566, 0))
-			.area("Vinery in the Great Kourend")
+			.area("Vinery southeast of Hosidius")
 			.question("How many vine patches can you find in this vinery?")
 			.answer("12")
 			.build(),


### PR DESCRIPTION
closes #16331,

kept location text as `southeast` to be more consistent with the other anagram clue location text. Could change to south-east, let me know.