### PR TITLE
api: add rl object post-animation transform

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/Mesh.java
+++ b/runelite-api/src/main/java/net/runelite/api/Mesh.java
@@ -43,25 +43,25 @@ public interface Mesh<T extends Mesh<T>>
 
 	/**
 	 * Rotates this model 90 degrees around the vertical axis.
-	 * {@link ModelData#cloneVertices()} should be called before calling this method
+	 * {@link #cloneVertices()} should be called before calling this method
 	 */
 	T rotateY90Ccw();
 
 	/**
 	 * Rotates this model 180 degrees around the vertical axis.
-	 * {@link ModelData#cloneVertices()} should be called before calling this method
+	 * {@link #cloneVertices()} should be called before calling this method
 	 */
 	T rotateY180Ccw();
 
 	/**
 	 * Rotates this model 270 degrees around the vertical axis.
-	 * {@link ModelData#cloneVertices()} should be called before calling this method
+	 * {@link #cloneVertices()} should be called before calling this method
 	 */
 	T rotateY270Ccw();
 
 	/**
 	 * Offsets this model by the passed amount (1/128ths of a tile).
-	 * {@link ModelData#cloneVertices()} should be called before calling this method
+	 * {@link #cloneVertices()} should be called before calling this method
 	 */
 	T translate(int x, int y, int z);
 
@@ -70,4 +70,27 @@ public interface Mesh<T extends Mesh<T>>
 	 * {@link ModelData#cloneVertices()} should be called before calling this method
 	 */
 	T scale(int x, int y, int z);
+
+	/**
+	 * Clones {@link #getVerticesX()}, {@link #getVerticesY()}, and {@link #getVerticesZ()} so
+	 * they can be safely mutated
+	 */
+	T cloneVertices();
+
+	/**
+	 * Clones {@link ModelData#getFaceColors()} for {@link ModelData} instances, or
+	 * {@link Model#getFaceColors1()}, {@link Model#getFaceColors2()}, and {@link Model#getFaceColors3()}
+	 * for {@link Model} instances, so they can be safely mutated
+	 */
+	T cloneColors();
+
+	/**
+	 * Clones {@link #getFaceTextures()} so they can be safely mutated
+	 */
+	T cloneTextures();
+
+	/**
+	 * Clones {@link #getFaceTransparencies()} so they can be safely mutated
+	 */
+	T cloneTransparencies();
 }

--- a/runelite-api/src/main/java/net/runelite/api/Model.java
+++ b/runelite-api/src/main/java/net/runelite/api/Model.java
@@ -29,7 +29,7 @@ import javax.annotation.Nonnull;
 /**
  * Represents the model of an object.
  */
-public interface Model extends Mesh, Renderable
+public interface Model extends Mesh<Model>, Renderable
 {
 	int[] getFaceColors1();
 

--- a/runelite-api/src/main/java/net/runelite/api/ModelData.java
+++ b/runelite-api/src/main/java/net/runelite/api/ModelData.java
@@ -75,24 +75,4 @@ public interface ModelData extends Mesh<ModelData>, Renderable
 	 */
 	ModelData shallowCopy();
 
-	/**
-	 * Clones {@link #getVerticesX()}, {@link #getVerticesY()}, and {@link #getVerticesZ()} so
-	 * they can be safely mutated
-	 */
-	ModelData cloneVertices();
-
-	/**
-	 * Clones {@link #getFaceColors()} so they can be safely mutated
-	 */
-	ModelData cloneColors();
-
-	/**
-	 * Clones {@link #getFaceTextures()} so they can be safely mutated
-	 */
-	ModelData cloneTextures();
-
-	/**
-	 * Clones {@link #getFaceTransparencies()} so they can be safely mutated
-	 */
-	ModelData cloneTransparencies();
 }

--- a/runelite-api/src/main/java/net/runelite/api/RuneLiteObject.java
+++ b/runelite-api/src/main/java/net/runelite/api/RuneLiteObject.java
@@ -25,6 +25,7 @@
  */
 package net.runelite.api;
 
+import java.util.function.Function;
 import net.runelite.api.coords.LocalPoint;
 
 /**
@@ -114,4 +115,14 @@ public interface RuneLiteObject extends GraphicsObject
 	 * @param drawFrontTilesFirst
 	 */
 	void setDrawFrontTilesFirst(boolean drawFrontTilesFirst);
+
+	/**
+	 * A callback that supplies the model after it has been transformed by the current animation, taking back the 
+	 * result of the passed lambda as the new model to be rendered. The input to this lambda is the model
+	 * immediately after the animation is applied, which shares face transparencies, face indices, and textures with 
+	 * the source model, but has distinct vertices. If the shared properties will be mutated, the corresponding cloneX 
+	 * method should be called first.
+	 * @param onModelAnimated The model transformer to apply after the animation.
+	 */
+	void setOnModelAnimated(Function<Model, Model> onModelAnimated);
 }


### PR DESCRIPTION
**Requires corresponding internal changes.**

Animations applied to models did not account for scale, leading to problems when applying them to RL objects which needed to be shrunk/enlarged. For example, the Nightmare pet, which uses the same model as the regular Nightmare, but with scale(30, 30, 30).

https://user-images.githubusercontent.com/1868974/222376821-a5352a26-f457-4573-bef6-d8389ae4555d.mp4

This PR gives the ability for plugin developers to modify the model after it has been passed through the animation transform, allowing arbitrary further modifications.

https://user-images.githubusercontent.com/1868974/222377394-ea1a1224-4d06-491a-9fd8-d0dc28a5ad31.mp4

Example caller code remains simple: 
```java
LocalPoint playerLoc = client.getLocalPlayer().getLocalLocation();
LocalPoint spawnLoc = new LocalPoint(playerLoc.getX() + 128, playerLoc.getY());

RuneLiteObject rlObj = client.createRuneLiteObject();
rlObj.setLocation(spawnLoc, client.getPlane());
rlObj.setModel(client.loadModelData(39196).cloneVertices().light());

rlObj.setAnimation(client.loadAnimation(8593));
rlObj.setOnModelAnimated(m ->
{
	m.scale(30, 30, 30);
	return m;
});

rlObj.setShouldLoop(true);
rlObj.setActive(true);
```