### PR TITLE
world map: added the ability to hide already completed quests from the world map

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/ScriptID.java
+++ b/runelite-api/src/main/java/net/runelite/api/ScriptID.java
@@ -411,4 +411,7 @@ public final class ScriptID
 
 	@ScriptArguments(integer = 9)
 	public static final int WORLDMAP_LOADMAP = 1712;
+
+	@ScriptArguments(integer = 2)
+	public static final int REMOVE_WORLDMAP_ICON = 50001;
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldmap/WorldMapConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldmap/WorldMapConfig.java
@@ -306,4 +306,15 @@ public interface WorldMapConfig extends Config
 	{
 		return true;
 	}
+
+	@ConfigItem(
+			keyName = WorldMapPlugin.CONFIG_KEY_HIDE_COMPLETED_QUEST_ICONS,
+			name = "Hide completed quest icons",
+			description = "Hides all of the icons of the quests you've completed on the minimap",
+			position = 26
+	)
+	default boolean hideCompletedQuestIcons()
+	{
+		return true;
+	}
 }

--- a/runelite-client/src/main/scripts/RemoveWorldMapIcon.rs2asm
+++ b/runelite-client/src/main/scripts/RemoveWorldMapIcon.rs2asm
@@ -1,0 +1,13 @@
+.id                 50001
+.int_stack_count    2
+.int_var_count      2
+.string_stack_count 1
+.string_var_count   1
+
+
+iload                   0                     ; Should be the first parameter that we get from runScript, the value should be a MapElementConfig ID. (The ID can be found by using WorldMapIcon.getType())
+iload                   1                     ; Should be the second parameter that we get from runScript, the value should be a boolean (I'm guessing that would just be an int value where 0 = false and 1 = true)
+worldmap_disableelement
+
+sconst                  "removeWorldMapIcon"
+runelite_callback


### PR DESCRIPTION
Changes made:
* Added a new config option to the WorldMap plugin, which allows the player to hide the quest icon for already completed quests.
* Added a new rs2asm script `RemoveWorldMapIcon.rs2asm` with ID = `500001`, which was also added to ScriptID