### PR TITLE
Do not remove the active profile when signing out of runelite.

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/config/ConfigManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/ConfigManager.java
@@ -275,10 +275,18 @@ public class ConfigManager
 	{
 		configClient.setUuid(null);
 
-		// remove the remote profiles
+		// remove the remote profiles if they are not active.
+		// if the active profile is removed there will be no active profile.
 		try (ProfileManager.Lock lock = profileManager.lock())
 		{
-			lock.getProfiles().removeIf(p -> !p.isInternal() && p.isSync());
+			lock.getProfiles().removeIf(p -> !p.isInternal() && p.isSync() && p.getId() != profile.getId());
+
+			if (profile.isSync())
+			{
+				log.info("Disabling sync for: {} due to sign-out.", profile.getName());
+				profile.setSync(false);
+			}
+
 			lock.dirty();
 		}
 	}


### PR DESCRIPTION
Currently, if you sign out of runelite while the active profile is synced, the active profile will be removed, but will remain inside `ConfigManager.profile`. This results in 2 weird behaviors:
1. If `ConfigManager#sendConfig` is called (such as when you duplicate a profile), the previously active profile will be unexpectedly regenerated as non-synced, but still not mark it active in profiles.json despite being marked with an orange bar in the profiles list.
2. Because there is no active profile, the client will generate a "default" profile on next start.

This PR addresses these issues by marking the current profile as unsynced instead of removing it. This seems to work fine if you sign in again later - it gets marked as synced again.

EDIT: I'm not sure if this is correct, since having a non-synced profile with the same ID as a synced profile would cause it to take precedence over the remote profile's settings, which is probably undesirable. Maybe a new profile with a different ID should be generated instead?