### PR TITLE
Fix race between ExternalPluginManager and PluginManager during profile change.

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/externalplugins/ExternalPluginManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/externalplugins/ExternalPluginManager.java
@@ -140,7 +140,13 @@ public class ExternalPluginManager
 	@Subscribe
 	public void onProfileChanged(ProfileChanged profileChanged)
 	{
-		executor.submit(this::refreshPlugins);
+		executor.submit(() ->
+		{
+			// External plugins must be handled first during a profile change, because otherwise PluginManager may try
+			// to enable plugins that are not installed in the new profile.
+			refreshPlugins();
+			pluginManager.refreshPlugins();
+		});
 	}
 
 	private void refreshPlugins()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/PluginManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/PluginManager.java
@@ -69,9 +69,7 @@ import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.config.RuneLiteConfig;
 import net.runelite.client.eventbus.EventBus;
-import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.events.PluginChanged;
-import net.runelite.client.events.ProfileChanged;
 import net.runelite.client.task.Schedule;
 import net.runelite.client.task.ScheduledMethod;
 import net.runelite.client.task.Scheduler;
@@ -119,13 +117,7 @@ public class PluginManager
 		this.sceneTileManager = sceneTileManager;
 	}
 
-	@Subscribe
-	public void onProfileChanged(ProfileChanged profileChanged)
-	{
-		refreshPlugins();
-	}
-
-	private void refreshPlugins()
+	public void refreshPlugins()
 	{
 		loadDefaultPluginConfiguration(null);
 		SwingUtilities.invokeLater(() ->


### PR DESCRIPTION
EPM and PM race to do their profile change work, because they do not use subscriber priority and do their work on different threads. This pull request makes sure that EPM runs before PM so that external plugins that are not installed in the new profile cannot be turned on by PM. If they are turned on by PM, it can cause plugins that do not shut down cleanly to cause issues like leftover infoboxes or overlays, and makes the profile change take longer.