### PR TITLE
Add Menu Entry Swaps to NMZ Reward Shop

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -308,6 +308,11 @@ public class MenuEntrySwapperPlugin extends Plugin
 		swap("value", "buy 10", () -> shiftModifier() && config.shopBuy() == BuyMode.BUY_10);
 		swap("value", "buy 50", () -> shiftModifier() && config.shopBuy() == BuyMode.BUY_50);
 
+		//Special case for NMZ reward shop
+		swap("buy-1", "buy-5", () -> shiftModifier() && config.shopBuy() == BuyMode.BUY_5);
+		swap("buy-1", "buy-10", () -> shiftModifier() && config.shopBuy() == BuyMode.BUY_10);
+		swap("buy-1", "buy-50", () -> shiftModifier() && config.shopBuy() == BuyMode.BUY_50);
+
 		swap("value", "sell 1", () -> shiftModifier() && config.shopSell() == SellMode.SELL_1);
 		swap("value", "sell 5", () -> shiftModifier() && config.shopSell() == SellMode.SELL_5);
 		swap("value", "sell 10", () -> shiftModifier() && config.shopSell() == SellMode.SELL_10);


### PR DESCRIPTION
Closes Issue #15302
Updates Menu Entry Swapper to allow change from default "buy-1" to "buy-5", "buy-10", or "buy-50" in NMZ Reward Shop 