### PR TITLE
chat filter: add MODAUTOTYPER to filter

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatfilter/ChatFilterPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatfilter/ChatFilterPlugin.java
@@ -184,6 +184,7 @@ public class ChatFilterPlugin extends Plugin
 			case PUBLICCHAT:
 			case MODCHAT:
 			case AUTOTYPER:
+			case MODAUTOTYPER:
 			case PRIVATECHAT:
 			case MODPRIVATECHAT:
 			case FRIENDSCHAT:


### PR DESCRIPTION
Sadly I can't confirm if ``MODAUTOTYPER`` is actually used in the game or not. Assuming that it indeed is, I suspect that it should also be filtered since ``AUTOTYPER`` is filtered.