### PR TITLE
Fix overlays not updating their size, position, and location when changing profiles if no plugins changed.

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayManager.java
@@ -47,6 +47,7 @@ import net.runelite.client.config.ConfigManager;
 import net.runelite.client.config.RuneLiteConfig;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.events.ConfigChanged;
+import net.runelite.client.events.ProfileChanged;
 
 /**
  * Manages state of all game overlays
@@ -121,6 +122,16 @@ public class OverlayManager
 		}
 
 		overlays.forEach(this::updateOverlayConfig);
+	}
+
+	@Subscribe
+	public void onProfileChanged(ProfileChanged event)
+	{
+		synchronized (this)
+		{
+			overlays.forEach(this::loadOverlay);
+		}
+		rebuildOverlayLayers();
 	}
 
 	/**


### PR DESCRIPTION
I just copied the contents of onPluginChanged into onProfileChanged.

This fix only applies when both profiles have the same plugins and therefore no PluginChanged events happen.

How to replicate:
1. create 2 "new profile"s.
2. move, resize, or change snap point of an overlay in one of the profiles.
4. switch between the 2 profile and observe that the infobox does not change position/size.
5. disable any plugin in one of the 2 profiles.
6. observe that the infobox properly moves/resizes when changing profiles.