### PR TITLE
api: add rl object model supplier + animation controller

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/Animation.java
+++ b/runelite-api/src/main/java/net/runelite/api/Animation.java
@@ -35,4 +35,38 @@ public interface Animation
 	 * @return
 	 */
 	int getId();
+
+	/**
+	 * Applies the animation to the model at the specified frame.
+	 * {@link Mesh#cloneColors()} and {@link Mesh#cloneTransparencies()}
+	 * should be called before using this method.
+	 * 
+	 * @param m The model to apply the animation to.
+	 * @param frameId The frame ID (time step) to use from the animation.
+	 *                Must be &lt;= to {@link #getTotalFrames()}.
+	 * @return The transformed model, as a different reference. Some 
+	 * 		   buffers may be shared with the base model, so cloneX 
+	 * 		   should still be called before any mutation.
+	 */
+	Model transformModel(Model m, int frameId);
+
+	/**
+	 * Get the render type for this animation.
+	 * @return
+	 * 
+	 * @see AnimationType
+	 */
+	AnimationType getType();
+
+	/**
+	 * Get the length of each frame in display ticks. Only valid on animations with {@link AnimationType#VARIABLE_FRAME_LENGTH}.
+	 * @return An array containing the client ticks per animation frame.
+	 */
+	int[] getFrameLengths();
+
+	/**
+	 * Get the total amount of frames within this animation.
+	 * @return
+	 */
+	int getTotalFrames();
 }

--- a/runelite-api/src/main/java/net/runelite/api/AnimationType.java
+++ b/runelite-api/src/main/java/net/runelite/api/AnimationType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017, Adam <Adam@sigterm.info>
+ * Copyright (c) 2023, LlemonDuck <napkinorton@gmail.com>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -22,63 +22,28 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+
 package net.runelite.api;
 
-import javax.annotation.Nonnull;
-
 /**
- * Represents the model of an object.
+ * Used to distinguish the types of animations the client can render.
+ * Each type determines its current frame differently.
  */
-public interface Model extends Mesh<Model>, Renderable
+public enum AnimationType
 {
-	int[] getFaceColors1();
-
-	int[] getFaceColors2();
-
-	int[] getFaceColors3();
-
-	int getSceneId();
-	void setSceneId(int sceneId);
-
-	int getBufferOffset();
-	void setBufferOffset(int bufferOffset);
-
-	int getUvBufferOffset();
-	void setUvBufferOffset(int bufferOffset);
-
-	int getBottomY();
-
-	void calculateBoundsCylinder();
-
-	byte[] getFaceRenderPriorities();
-
-	int getRadius();
-	int getDiameter();
 
 	/**
-	 * @see #getAABB(int)
+	 * <p>
+	 * Animations of this type advance their frame ID when it surpasses the current frame length.
+	 * The frame ID is determined by the aggregate sum of frames rendered.
+	 * </p>
+	 * e.g. [1, 2, 3] specifies that client ticks map to the following animation frames: [0, 1, 1, 2, 2, 2].
 	 */
-	@Deprecated
-	void calculateExtreme(int orientation);
+	VARIABLE_FRAME_LENGTH,
 
-	@Nonnull
-	AABB getAABB(int orientation);
+	/**
+	 * Display frame animations simply map client ticks to frame IDs, and may return the same results for different frame IDs.
+	 */
+	DISPLAY_FRAME_INDEXED
 
-	int getXYZMag();
-	boolean isClickable();
-
-	int[] getVertexNormalsX();
-	int[] getVertexNormalsY();
-	int[] getVertexNormalsZ();
-
-	byte getOverrideAmount();
-	byte getOverrideHue();
-	byte getOverrideSaturation();
-	byte getOverrideLuminance();
-
-	byte[] getTextureFaces();
-
-	int[] getTexIndices1();
-	int[] getTexIndices2();
-	int[] getTexIndices3();
 }

--- a/runelite-api/src/main/java/net/runelite/api/Mesh.java
+++ b/runelite-api/src/main/java/net/runelite/api/Mesh.java
@@ -43,25 +43,25 @@ public interface Mesh<T extends Mesh<T>>
 
 	/**
 	 * Rotates this model 90 degrees around the vertical axis.
-	 * {@link ModelData#cloneVertices()} should be called before calling this method
+	 * {@link #cloneVertices()} should be called before calling this method
 	 */
 	T rotateY90Ccw();
 
 	/**
 	 * Rotates this model 180 degrees around the vertical axis.
-	 * {@link ModelData#cloneVertices()} should be called before calling this method
+	 * {@link #cloneVertices()} should be called before calling this method
 	 */
 	T rotateY180Ccw();
 
 	/**
 	 * Rotates this model 270 degrees around the vertical axis.
-	 * {@link ModelData#cloneVertices()} should be called before calling this method
+	 * {@link #cloneVertices()} should be called before calling this method
 	 */
 	T rotateY270Ccw();
 
 	/**
 	 * Offsets this model by the passed amount (1/128ths of a tile).
-	 * {@link ModelData#cloneVertices()} should be called before calling this method
+	 * {@link #cloneVertices()} should be called before calling this method
 	 */
 	T translate(int x, int y, int z);
 
@@ -70,4 +70,27 @@ public interface Mesh<T extends Mesh<T>>
 	 * {@link ModelData#cloneVertices()} should be called before calling this method
 	 */
 	T scale(int x, int y, int z);
+
+	/**
+	 * Clones {@link #getVerticesX()}, {@link #getVerticesY()}, and {@link #getVerticesZ()} so
+	 * they can be safely mutated
+	 */
+	T cloneVertices();
+
+	/**
+	 * Clones {@link ModelData#getFaceColors()} for {@link ModelData} instances, or
+	 * {@link Model#getFaceColors1()}, {@link Model#getFaceColors2()}, and {@link Model#getFaceColors3()}
+	 * for {@link Model} instances, so they can be safely mutated
+	 */
+	T cloneColors();
+
+	/**
+	 * Clones {@link #getFaceTextures()} so they can be safely mutated
+	 */
+	T cloneTextures();
+
+	/**
+	 * Clones {@link #getFaceTransparencies()} so they can be safely mutated
+	 */
+	T cloneTransparencies();
 }

--- a/runelite-api/src/main/java/net/runelite/api/ModelData.java
+++ b/runelite-api/src/main/java/net/runelite/api/ModelData.java
@@ -75,24 +75,4 @@ public interface ModelData extends Mesh<ModelData>, Renderable
 	 */
 	ModelData shallowCopy();
 
-	/**
-	 * Clones {@link #getVerticesX()}, {@link #getVerticesY()}, and {@link #getVerticesZ()} so
-	 * they can be safely mutated
-	 */
-	ModelData cloneVertices();
-
-	/**
-	 * Clones {@link #getFaceColors()} so they can be safely mutated
-	 */
-	ModelData cloneColors();
-
-	/**
-	 * Clones {@link #getFaceTextures()} so they can be safely mutated
-	 */
-	ModelData cloneTextures();
-
-	/**
-	 * Clones {@link #getFaceTransparencies()} so they can be safely mutated
-	 */
-	ModelData cloneTransparencies();
 }

--- a/runelite-api/src/main/java/net/runelite/api/RuneLiteObject.java
+++ b/runelite-api/src/main/java/net/runelite/api/RuneLiteObject.java
@@ -25,6 +25,8 @@
  */
 package net.runelite.api;
 
+import java.util.function.IntConsumer;
+import java.util.function.Supplier;
 import net.runelite.api.coords.LocalPoint;
 
 /**
@@ -114,4 +116,23 @@ public interface RuneLiteObject extends GraphicsObject
 	 * @param drawFrontTilesFirst
 	 */
 	void setDrawFrontTilesFirst(boolean drawFrontTilesFirst);
+
+	/**
+	 * When used, the model supplier will be called on each frame to determine the model to render. This overrides 
+	 * and replaces the {@link #setModel(Model)}, {@link #setAnimation(Animation)}, and {@link #setShouldLoop(boolean)} 
+	 * methods, as well as removes the behaviour of removing the model when the animation ends. Callers must implement
+	 * these behaviours externally, if desired.
+	 * 
+	 * @param modelSupplier Called each frame to determine the model to render for that frame.
+	 */
+	void setModelSupplier(Supplier<Model> modelSupplier);
+
+	/**
+	 * This method can be used to register a callback whenever the RuneLiteObject recognizes a client tick. This
+	 * may not be <em>every</em> client tick if the framerate is lower than the tick rate, but the parameter to
+	 * this method will be the number of client ticks advanced in this frame.
+	 * 
+	 * @param onTickCallback The method to be called each time the RuneLiteObject ticks.
+	 */
+	void setOnTick(IntConsumer onTickCallback);
 }

--- a/runelite-client/src/main/java/net/runelite/client/util/AnimationController.java
+++ b/runelite-client/src/main/java/net/runelite/client/util/AnimationController.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2023, LlemonDuck <napkinorton@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package net.runelite.client.util;
+
+import lombok.Setter;
+import net.runelite.api.Animation;
+import net.runelite.api.AnimationType;
+import net.runelite.api.Client;
+import net.runelite.api.Model;
+
+/**
+ * Can be used to track and apply animations to models. Useful when handling complex RuneLiteObject animations.
+ *
+ * @see net.runelite.api.RuneLiteObject
+ */
+public class AnimationController
+{
+
+	private final Animation animation;
+
+	/**
+	 * Runs a callback when the animation reaches its end.
+	 * For example, can be used to despawn a RuneLiteObject after the animation plays once.
+	 * If unset, the animation will loop instead.
+	 */
+	@Setter
+	private Runnable onFinished;
+
+	private int elapsedTicksThisFrame;
+	private int frameID;
+
+	public AnimationController(Animation animation)
+	{
+		this.animation = animation;
+	}
+
+	public AnimationController(Client client, int animId)
+	{
+		this.animation = client.loadAnimation(animId);
+	}
+
+	public Model transformModel(Model m)
+	{
+		return animation.transformModel(m, this.frameID);
+	}
+
+	public void tick(int ticks)
+	{
+		this.elapsedTicksThisFrame += ticks;
+		if (this.animation.getType() == AnimationType.VARIABLE_FRAME_LENGTH)
+		{
+			int[] frameLengths = this.animation.getFrameLengths();
+			while (this.elapsedTicksThisFrame > frameLengths[this.frameID])
+			{
+				this.elapsedTicksThisFrame -= frameLengths[this.frameID];
+				++this.frameID;
+				if (this.frameID >= this.animation.getTotalFrames())
+				{
+					checkFinished();
+					break;
+				}
+			}
+		}
+		else
+		{
+			this.frameID += ticks;
+			if (this.frameID >= this.animation.getTotalFrames())
+			{
+				checkFinished();
+			}
+		}
+	}
+
+	private void checkFinished()
+	{
+		if (this.onFinished != null)
+		{
+			this.onFinished.run();
+			return;
+		}
+
+		this.frameID = 0;
+		this.elapsedTicksThisFrame = 0;
+	}
+
+}


### PR DESCRIPTION
**Requires corresponding internal changes**

Animations applied to models did not account for scale, leading to problems when applying them to RL objects which needed to be shrunk/enlarged. For example, the Nightmare pet, which uses the same model as the regular Nightmare, but with scale(30, 30, 30).

https://user-images.githubusercontent.com/1868974/222376821-a5352a26-f457-4573-bef6-d8389ae4555d.mp4

This PR gives the ability for plugin developers to supply their own model on each frame, and exposes animation methods to the api as well as an AnimationController to simplify usage.

https://user-images.githubusercontent.com/1868974/222377394-ea1a1224-4d06-491a-9fd8-d0dc28a5ad31.mp4