### PR TITLE
docs: update explanation of Varbits.PVP_SPEC_ORB

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/Varbits.java
+++ b/runelite-api/src/main/java/net/runelite/api/Varbits.java
@@ -675,12 +675,14 @@ public final class Varbits
 	public static final int WIKI_ENTITY_LOOKUP = 10113;
 
 	/**
-	 * Whether the Special Attack orb is disabled due to being in a PvP area
+	 * Whether the player is in a PvP area
 	 * <p>
-	 * 0 = Enabled (player is not in PvP)
-	 * 1 = Disabled (player is in PvP)
+	 * 0 = Player is not in PvP area
+	 * 1 = Player is in PvP area
 	 *
-	 * @see <a href="https://oldschool.runescape.wiki/w/Minimap#Special_attack_orb">The OSRS Wiki's Minimap page</a>
+	 * @apiNote The name of this varbit comes from historical behavior where
+	 * the special attack orb would be disabled in PvP, but this was changed
+	 * on 2023-03-09 due to Poll 78. Yet, the varbit still updates as before.
 	 */
 	public static final int PVP_SPEC_ORB = 8121;
 

--- a/runelite-api/src/main/java/net/runelite/api/Varbits.java
+++ b/runelite-api/src/main/java/net/runelite/api/Varbits.java
@@ -679,8 +679,8 @@ public final class Varbits
 	 * <p>
 	 * 0 = Player is not in PvP area
 	 * 1 = Player is in PvP area
-	 *
-	 * @apiNote The name of this varbit comes from historical behavior where
+	 * <p>
+	 * Note: The name of this varbit comes from historical behavior where
 	 * the special attack orb would be disabled in PvP, but this was changed
 	 * on 2023-03-09 due to Poll 78. Yet, the varbit still updates as before.
 	 */


### PR DESCRIPTION
With [Poll 78](https://oldschool.runescape.wiki/w/Update:Even_More_Poll_78_Changes), the special attack orb is [no longer hidden](https://github.com/Joshua-F/cs2-scripts/commit/07331f5cc86cda8af2e2a42eaee24b4543d37168#diff-5452a23d06fba4601158b625323e5a8f3222e605c48789835aed2b8faafc9347) in PvP. 

However:

* The varbit value [does](https://i.imgur.com/YNUvPzE.png) still update as in the past
* The varbit [is](https://github.com/Joshua-F/cs2-scripts/blob/master/scripts/%5Bproc,magic_spellbook_redraw%5D.cs2#L115) still used elsewhere in cs2

This PR updates the javadocs for the varbit to reflect this information
