### PR TITLE
grand exchange: Fix slot detail panels with wrapped text

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangeOfferSlot.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangeOfferSlot.java
@@ -23,7 +23,6 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-
 package net.runelite.client.plugins.grandexchange;
 
 import java.awt.BorderLayout;
@@ -37,6 +36,8 @@ import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
 import java.awt.image.BufferedImage;
 import javax.annotation.Nullable;
+import javax.swing.Box;
+import javax.swing.BoxLayout;
 import javax.swing.ImageIcon;
 import javax.swing.JLabel;
 import javax.swing.JMenuItem;
@@ -86,7 +87,7 @@ public class GrandExchangeOfferSlot extends JPanel
 	{
 		final BufferedImage rightArrow = ImageUtil.alphaOffset(ImageUtil.loadImageResource(GrandExchangeOfferSlot.class, "/util/arrow_right.png"), 0.25f);
 		RIGHT_ARROW_ICON = new ImageIcon(rightArrow);
-		LEFT_ARROW_ICON	= new ImageIcon(ImageUtil.flipImage(rightArrow, true, false));
+		LEFT_ARROW_ICON = new ImageIcon(ImageUtil.flipImage(rightArrow, true, false));
 	}
 
 	/**
@@ -184,10 +185,19 @@ public class GrandExchangeOfferSlot extends JPanel
 
 		JPanel offerDetails = new JPanel();
 		offerDetails.setBackground(ColorScheme.DARKER_GRAY_COLOR);
-		offerDetails.setLayout(new GridLayout(2, 1));
+		offerDetails.setLayout(new BoxLayout(offerDetails, BoxLayout.PAGE_AXIS));
+		offerDetails.setPreferredSize(new Dimension(0, 45));
 
-		offerDetails.add(itemPrice);
-		offerDetails.add(offerSpent);
+		JPanel offerDetailsWrapper = new JPanel();
+		offerDetailsWrapper.setBackground(ColorScheme.DARKER_GRAY_COLOR);
+		offerDetailsWrapper.setLayout(new BoxLayout(offerDetailsWrapper, BoxLayout.PAGE_AXIS));
+
+		offerDetailsWrapper.add(itemPrice);
+		offerDetailsWrapper.add(offerSpent);
+
+		offerDetails.add(Box.createVerticalGlue());
+		offerDetails.add(offerDetailsWrapper);
+		offerDetails.add(Box.createVerticalGlue());
 
 		detailsCard.add(offerDetails, BorderLayout.CENTER);
 		detailsCard.add(switchDetailsViewIcon, BorderLayout.EAST);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangeOfferSlot.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangeOfferSlot.java
@@ -61,6 +61,7 @@ import net.runelite.client.util.QuantityFormatter;
 
 public class GrandExchangeOfferSlot extends JPanel
 {
+	private static final int PANEL_HEIGHT = 45;
 	private static final String FACE_CARD = "FACE_CARD";
 	private static final String DETAILS_CARD = "DETAILS_CARD";
 
@@ -136,7 +137,7 @@ public class GrandExchangeOfferSlot extends JPanel
 
 		itemIcon.setVerticalAlignment(JLabel.CENTER);
 		itemIcon.setHorizontalAlignment(JLabel.CENTER);
-		itemIcon.setPreferredSize(new Dimension(45, 45));
+		itemIcon.setPreferredSize(new Dimension(45, PANEL_HEIGHT));
 
 		itemName.setForeground(Color.WHITE);
 		itemName.setVerticalAlignment(JLabel.BOTTOM);
@@ -150,7 +151,7 @@ public class GrandExchangeOfferSlot extends JPanel
 		switchFaceViewIcon.setIcon(RIGHT_ARROW_ICON);
 		switchFaceViewIcon.setVerticalAlignment(JLabel.CENTER);
 		switchFaceViewIcon.setHorizontalAlignment(JLabel.CENTER);
-		switchFaceViewIcon.setPreferredSize(new Dimension(30, 45));
+		switchFaceViewIcon.setPreferredSize(new Dimension(30, PANEL_HEIGHT));
 
 		JPanel offerFaceDetails = new JPanel();
 		offerFaceDetails.setBackground(ColorScheme.DARKER_GRAY_COLOR);
@@ -181,12 +182,12 @@ public class GrandExchangeOfferSlot extends JPanel
 		switchDetailsViewIcon.setIcon(LEFT_ARROW_ICON);
 		switchDetailsViewIcon.setVerticalAlignment(JLabel.CENTER);
 		switchDetailsViewIcon.setHorizontalAlignment(JLabel.CENTER);
-		switchDetailsViewIcon.setPreferredSize(new Dimension(30, 45));
+		switchDetailsViewIcon.setPreferredSize(new Dimension(30, PANEL_HEIGHT));
 
 		JPanel offerDetails = new JPanel();
 		offerDetails.setBackground(ColorScheme.DARKER_GRAY_COLOR);
 		offerDetails.setLayout(new BoxLayout(offerDetails, BoxLayout.PAGE_AXIS));
-		offerDetails.setPreferredSize(new Dimension(0, 45));
+		offerDetails.setPreferredSize(new Dimension(0, PANEL_HEIGHT));
 
 		JPanel offerDetailsWrapper = new JPanel();
 		offerDetailsWrapper.setBackground(ColorScheme.DARKER_GRAY_COLOR);


### PR DESCRIPTION
Previously, the offer slot panel's detail view displayed the item price and spent amounts in separate labels wrapped by a grid layout panel which caused unusual unwanted behavior when some items had a spent amount which wrapped to two lines. (this would be the case when buying or selling items totaling about 10 million gp or more) This commit changes these items to be wrapped by a box layout panel, which is then centered vertically within another box layout panel with vertical glue spacers.

This bug technically affects the face card as well, but is unlikely to ever appear as the numbers there are processed by
`QuantityFormatter.quantityToRSDecimalStack()`, and are thusly shortened significantly from their raw number values. (eg. `123_456_789` becomes `123.5M`)

| Before | After |
|:----------:|:-------:|
| ![Grand Exchange plugin offers panel, showing unusually small offer panels collapsed to the bottom of the sidebar panel](https://user-images.githubusercontent.com/2199511/227754991-725a7c2f-c93c-403c-ab12-ff047ed11173.png) | ![The same offers panel, but with offer panels having their ordinary size and even alignment within the sidebar panel](https://user-images.githubusercontent.com/2199511/227754994-0498c212-e03c-45f8-ba0e-a27ea2a8e7b5.png) |
| ![Grand exchange offers panel, showing unusually small offer details panels collapsed to the bottom of the sidebar, with one panel being slightly larger on account of having two lines of text](https://user-images.githubusercontent.com/2199511/227784332-4a6ed60f-04d3-45df-8d2f-217e33334737.png) | ![The same offers panel, but with offer details panels having uniform size and even alignment within the sidebar panel](https://user-images.githubusercontent.com/2199511/227784475-523dfd3f-20d6-4a04-92b2-3c700c36fb28.png) |