### PR TITLE
Add RuneliteObject as an option for the ModelOutlineRenderer

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/outline/ModelOutlineRenderer.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/outline/ModelOutlineRenderer.java
@@ -49,6 +49,7 @@ import net.runelite.api.NPCComposition;
 import net.runelite.api.Perspective;
 import net.runelite.api.Player;
 import net.runelite.api.Renderable;
+import net.runelite.api.RuneLiteObject;
 import net.runelite.api.TileObject;
 import net.runelite.api.WallObject;
 import net.runelite.api.coords.LocalPoint;
@@ -1166,6 +1167,20 @@ public class ModelOutlineRenderer
 			{
 				drawModelOutline(model, lp.getX(), lp.getY(), graphicsObject.getZ(),
 					0, outlineWidth, color, feather);
+			}
+		}
+	}
+
+	public void drawOutline(RuneLiteObject runeLiteObject, int outlineWidth, Color color, int feather)
+	{
+		LocalPoint lp = runeLiteObject.getLocation();
+		if (lp != null)
+		{
+			Model model = runeLiteObject.getModel();
+			if (model != null)
+			{
+				drawModelOutline(model, lp.getX(), lp.getY(), runeLiteObject.getZ(),
+					runeLiteObject.getOrientation(), outlineWidth, color, feather);
 			}
 		}
 	}


### PR DESCRIPTION
This allows for the RuneliteObject's orientation to be considered when rendering a model's outline.

Previously a RuneliteObject could be passed in as a GraphicsObject, but this would not consider the orientation.

Before:

<img width="254" alt="runeliteObjectHighlightBefore" src="https://user-images.githubusercontent.com/29153234/228393662-6a91df60-5bdf-4b6a-a7b2-682fe0b82125.png">

After:

<img width="343" alt="runeliteObjectHighlightAfter" src="https://user-images.githubusercontent.com/29153234/228393565-96eb317f-b04f-4f84-8e63-5b7dacb70a48.png">
