### PR TITLE
Add `EASTFLOOR_SPADE` as a valid spade item in the clue scroll helper overlay

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/ClueScrollOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/ClueScrollOverlay.java
@@ -49,7 +49,9 @@ import net.runelite.client.ui.overlay.components.LineComponent;
 
 public class ClueScrollOverlay extends OverlayPanel
 {
-	private static final ItemRequirement HAS_SPADE = new SingleItemRequirement(SPADE);
+	private static final ItemRequirement HAS_SPADE = new AnyRequirementCollection("Spade", 
+		item(SPADE),
+		item(EASTFLOOR_SPADE));
 	private static final ItemRequirement HAS_LIGHT = new AnyRequirementCollection("Light Source",
 		item(LIT_TORCH),
 		item(LIT_CANDLE),

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/ClueScrollOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/ClueScrollOverlay.java
@@ -40,7 +40,6 @@ import net.runelite.client.plugins.cluescrolls.clues.ClueScroll;
 import net.runelite.client.plugins.cluescrolls.clues.item.AnyRequirementCollection;
 import net.runelite.client.plugins.cluescrolls.clues.item.ItemRequirement;
 import static net.runelite.client.plugins.cluescrolls.clues.item.ItemRequirements.item;
-import net.runelite.client.plugins.cluescrolls.clues.item.SingleItemRequirement;
 import static net.runelite.client.ui.overlay.OverlayManager.OPTION_CONFIGURE;
 import net.runelite.client.ui.overlay.OverlayPanel;
 import net.runelite.client.ui.overlay.OverlayPriority;
@@ -49,7 +48,7 @@ import net.runelite.client.ui.overlay.components.LineComponent;
 
 public class ClueScrollOverlay extends OverlayPanel
 {
-	private static final ItemRequirement HAS_SPADE = new AnyRequirementCollection("Spade", 
+	private static final ItemRequirement HAS_SPADE = new AnyRequirementCollection("Spade",
 		item(SPADE),
 		item(EASTFLOOR_SPADE));
 	private static final ItemRequirement HAS_LIGHT = new AnyRequirementCollection("Light Source",


### PR DESCRIPTION
## Description

The recent update added an item called the `Eastfloor spade` which is functionally equivalent to a spade for the purposes of clue scrolls. This should count as a valid spade item, and not give an error message in the overlay when doing clue scrolls.

## Implementation

This PR broadens the `HAS_SPADE` check to also include the `EASTFLOOR_SPADE` item. This is done similarly to the the `HAS_LIGHT` check below it.

## Sources

- https://oldschool.runescape.wiki/w/Eastfloor_spade