### PR TITLE
Slayer plugin: Prevent initial task amount getting an incorrect value when disconnecting.

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerPlugin.java
@@ -257,11 +257,15 @@ public class SlayerPlugin extends Plugin
 	{
 		switch (event.getGameState())
 		{
+			// client (or with CONNECTION_LOST, the server...) will soon zero the slayer varps.
+			// zero task/amount so that this doesn't cause the plugin to reset the task, which
+			// would forget the initial amount. The vars are then resynced shortly after
 			case HOPPING:
 			case LOGGING_IN:
+			case CONNECTION_LOST:
 				taskName = "";
 				amount = 0;
-				loginFlag = true;
+				loginFlag = true; // to reinitialize initialAmount and avoid re-adding the infobox
 				targets.clear();
 				break;
 		}


### PR DESCRIPTION
~~Sets loginflag on connection lost, to prevent initial task amount from being set to the remaining task count when disconnecting and immeditately reconnecting, which seems to re-send the vars just like it does on login~~

Sets `amount` to 0 on `CONNECTION_LOST` to prevent the `initialAmount` from being set to 0 in `updateTask` when the var for the current task amount gets set to 0.

Fixes #16469 