### PR TITLE
Timers: Use varbit 5417 to track Prayer enhance status

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/Varbits.java
+++ b/runelite-api/src/main/java/net/runelite/api/Varbits.java
@@ -758,6 +758,13 @@ public final class Varbits
 	 */
 	public static final int MENAPHITE_REMEDY = 14448;
 
+
+	/**
+	 * How many prayer restore cycles from a prayer enhance(cox) remain.
+	 * Gets set to 80 upon drinking a dose,
+	 */
+	public static final int PRAYER_ENHANCE = 5417;
+
 	/**
 	 * How many salt stat boost refreshes the player has remaining.
 	 * This will go down by 1 every 25 ticks (15 seconds) and the player's stats will be restored.
@@ -812,4 +819,6 @@ public final class Varbits
 	 * The assigned boss for boss slayer.
 	 */
 	public static final int SLAYER_TASK_BOSS = 4723;
+
+	public static final int DESERT_HEAT	 = 13137;
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timers/GameTimer.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timers/GameTimer.java
@@ -58,7 +58,7 @@ enum GameTimer
 	VENGEANCE(SpriteID.SPELL_VENGEANCE, GameTimerImageType.SPRITE, "Vengeance", 30, ChronoUnit.SECONDS),
 	EXSUPERANTIFIRE(ItemID.EXTENDED_SUPER_ANTIFIRE4, GameTimerImageType.ITEM, "Extended Super AntiFire", 6, ChronoUnit.MINUTES),
 	OVERLOAD_RAID(ItemID.OVERLOAD_4_20996, GameTimerImageType.ITEM, "Overload", false),
-	PRAYER_ENHANCE(ItemID.PRAYER_ENHANCE_4, GameTimerImageType.ITEM, "Prayer enhance", 290, ChronoUnit.SECONDS, true),
+	PRAYER_ENHANCE(ItemID.PRAYER_ENHANCE_4, GameTimerImageType.ITEM, "Prayer enhance", 480, GAME_TICKS, true),
 	GOD_WARS_ALTAR(SpriteID.SKILL_PRAYER, GameTimerImageType.SPRITE, "God wars altar", 10, ChronoUnit.MINUTES),
 	CHARGE(SpriteID.SPELL_CHARGE, GameTimerImageType.SPRITE, "Charge", false),
 	STAFF_OF_THE_DEAD(ItemID.STAFF_OF_THE_DEAD, GameTimerImageType.ITEM, "Staff of the Dead", 1, ChronoUnit.MINUTES),

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersPlugin.java
@@ -99,7 +99,6 @@ public class TimersPlugin extends Plugin
 	private static final String GOD_WARS_ALTAR_MESSAGE = "you recharge your prayer.";
 	private static final String STAFF_OF_THE_DEAD_SPEC_EXPIRED_MESSAGE = "Your protection fades away";
 	private static final String STAFF_OF_THE_DEAD_SPEC_MESSAGE = "Spirits of deceased evildoers offer you their protection";
-	private static final String PRAYER_ENHANCE_EXPIRED = "<col=ff0000>Your prayer enhance effect has worn off.</col>";
 	private static final String SHADOW_VEIL_MESSAGE = ">Your thieving abilities have been enhanced.</col>";
 	private static final String WARD_OF_ARCEUUS_MESSAGE = ">Your defence against Arceuus magic has been strengthened.</col>";
 	private static final String PICKPOCKET_FAILURE_MESSAGE = "You fail to pick ";
@@ -560,6 +559,22 @@ public class TimersPlugin extends Plugin
 		{
 			updateVarTimer(FARMERS_AFFINITY, event.getValue(), i -> i * 20);
 		}
+
+		if (event.getVarbitId() == Varbits.PRAYER_ENHANCE && config.showPrayerEnhance())
+		{
+			if(event.getValue() == 80)
+			{
+				createGameTimer(PRAYER_ENHANCE);
+			}
+			if(event.getValue() == 0)
+			{
+				removeGameTimer(PRAYER_ENHANCE);
+			}
+			else
+			{
+				updateVarTimer(PRAYER_ENHANCE, event.getValue(), i -> i*6);
+			}
+		}
 	}
 
 	@Subscribe
@@ -786,16 +801,6 @@ public class TimersPlugin extends Plugin
 				removeGameTimer(CANNON);
 				removeGameTimer(CANNON_REPAIR);
 			}
-		}
-
-		if (config.showPrayerEnhance() && message.startsWith("You drink some of your") && message.contains("prayer enhance"))
-		{
-			createGameTimer(PRAYER_ENHANCE);
-		}
-
-		if (config.showPrayerEnhance() && message.equals(PRAYER_ENHANCE_EXPIRED))
-		{
-			removeGameTimer(PRAYER_ENHANCE);
 		}
 
 		if (config.showStaffOfTheDead() && message.contains(STAFF_OF_THE_DEAD_SPEC_MESSAGE))

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersPlugin.java
@@ -562,17 +562,17 @@ public class TimersPlugin extends Plugin
 
 		if (event.getVarbitId() == Varbits.PRAYER_ENHANCE && config.showPrayerEnhance())
 		{
-			if(event.getValue() == 80)
+			if (event.getValue() == 80)
 			{
 				createGameTimer(PRAYER_ENHANCE);
 			}
-			if(event.getValue() == 0)
+			if (event.getValue() == 0)
 			{
 				removeGameTimer(PRAYER_ENHANCE);
 			}
 			else
 			{
-				updateVarTimer(PRAYER_ENHANCE, event.getValue(), i -> i*6);
+				updateVarTimer(PRAYER_ENHANCE, event.getValue(), i -> i * 6);
 			}
 		}
 	}


### PR DESCRIPTION
Change Timer plugin's Prayer enhance potion timer to use Varbits (5417) instead of chat message matches to start/update/remove the timer. Enhancement requested in #16169 .