### PR TITLE
Player Indicators Plugin: Fix incorrect coloring in right-click menu entries

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsPlugin.java
@@ -228,12 +228,6 @@ public class PlayerIndicatorsPlugin extends Plugin
 					continue;
 				}
 
-				PlayerIndicatorsService.Decorations decorations = playerIndicatorsService.getDecorations(player);
-				if (decorations == null)
-				{
-					continue;
-				}
-
 				String oldTarget = entry.getTarget();
 				String newTarget = decorateTarget(oldTarget, player);
 
@@ -245,6 +239,10 @@ public class PlayerIndicatorsPlugin extends Plugin
 	private String decorateTarget(String oldTarget, Player player)
 	{
 		PlayerIndicatorsService.Decorations decorations = playerIndicatorsService.getDecorations(player);
+		if (decorations == null)
+		{
+			return oldTarget;
+		}
 
 		// Create a regex to find index of the col tag that precedes the player (if it exists).
 		// All spaces in the player name need to be replaced with \\p{Zs}.

--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsPlugin.java
@@ -246,7 +246,7 @@ public class PlayerIndicatorsPlugin extends Plugin
 
 		// Create a regex to find index of the col tag that precedes the player (if it exists).
 		// All spaces in the player name need to be replaced with \p{Zs} in the regex. \p{Zs} matches all whitespaces.
-		// This is needed since the player name contains regular spaces and the meny entry string contains nbsp in the player's name.
+		// This is needed since the player name contains regular spaces and the menu entry string contains nbsp in the player's name.
 		String regex = "<col=[0-9a-f]{6}>" + player.getName().replaceAll("\\p{Zs}", "\\\\p{Zs}");
 		Matcher matcher = Pattern.compile(regex).matcher(oldTarget);
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsPlugin.java
@@ -245,7 +245,8 @@ public class PlayerIndicatorsPlugin extends Plugin
 		}
 
 		// Create a regex to find index of the col tag that precedes the player (if it exists).
-		// All spaces in the player name need to be replaced with \\p{Zs}.
+		// All spaces in the player name need to be replaced with \p{Zs} in the regex. \p{Zs} matches all whitespaces.
+		// This is needed since the player name contains regular spaces and the meny entry string contains nbsp in the player's name.
 		String regex = "<.{0,10}>" + player.getName().replaceAll("\\p{Zs}", "\\\\p{Zs}");
 		Pattern pattern = Pattern.compile(regex);
 		Matcher matcher = pattern.matcher(oldTarget);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsPlugin.java
@@ -247,9 +247,8 @@ public class PlayerIndicatorsPlugin extends Plugin
 		// Create a regex to find index of the col tag that precedes the player (if it exists).
 		// All spaces in the player name need to be replaced with \p{Zs} in the regex. \p{Zs} matches all whitespaces.
 		// This is needed since the player name contains regular spaces and the meny entry string contains nbsp in the player's name.
-		String regex = "<.{0,10}>" + player.getName().replaceAll("\\p{Zs}", "\\\\p{Zs}");
-		Pattern pattern = Pattern.compile(regex);
-		Matcher matcher = pattern.matcher(oldTarget);
+		String regex = "<col=[0-9a-f]{6}>" + player.getName().replaceAll("\\p{Zs}", "\\\\p{Zs}");
+		Matcher matcher = Pattern.compile(regex).matcher(oldTarget);
 
 		String stringPrecedingDecoration = null;
 		String stringToDecorate = null;


### PR DESCRIPTION
Close #13658

As described in the issue, the right-click menu entries are sometimes incorrectly colored. The first part of the entry is always colored, which works fine when you only right click a person - but is incorrect in some cases. For instance, when a spell or an item is used on another player, the first part of the entry is the spell and item name respectively - which are then colored instead of the player name.

The updated code will now find the specific part of the menu entry that needs to be recolored (and where an icon will potentially added) and update that part.