### PR TITLE
woodcutting: Add redwood tree at farming guild

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/Tree.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/Tree.java
@@ -29,6 +29,7 @@ import java.time.Duration;
 import java.util.Map;
 import javax.annotation.Nullable;
 import lombok.Getter;
+import net.runelite.api.NullObjectID;
 import net.runelite.api.ObjectID;
 import static net.runelite.api.ObjectID.MAGIC_TREE_10834;
 import static net.runelite.api.NullObjectID.NULL_10835;
@@ -79,7 +80,7 @@ enum Tree
 	MAHOGANY_TREE(Duration.of(14, GAME_TICKS), MAHOGANY, MAHOGANY_36688, MAHOGANY_40760),
 	YEW_TREE(Duration.of(99, GAME_TICKS), YEW, NULL_10823, YEW_36683, YEW_40756),
 	MAGIC_TREE(Duration.of(199, GAME_TICKS), MAGIC_TREE_10834, NULL_10835),
-	REDWOOD(Duration.of(199, GAME_TICKS), ObjectID.REDWOOD, REDWOOD_29670);
+	REDWOOD(Duration.of(199, GAME_TICKS), ObjectID.REDWOOD, REDWOOD_29670, NullObjectID.NULL_34633, NullObjectID.NULL_34635, NullObjectID.NULL_34637, NullObjectID.NULL_34639, ObjectID.REDWOOD_TREE_34284, ObjectID.REDWOOD_TREE_34286, ObjectID.REDWOOD_TREE_34288, ObjectID.REDWOOD_TREE_34290);
 
 	@Nullable
 	private final Duration respawnTime;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingTreesOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingTreesOverlay.java
@@ -88,7 +88,8 @@ class WoodcuttingTreesOverlay extends Overlay
 		{
 			if (treeObject.getWorldLocation().distanceTo(client.getLocalPlayer().getWorldLocation()) <= 12)
 			{
-				// Check if this is a redwood tree at the farming patch
+				// Redwood trees at the farming guild are multilocs rather than global objects synced for all players
+				// so we must handle them here rather than relying on GameObjectSpawned events
 				final ObjectComposition treeComp = client.getObjectDefinition(treeObject.getId());
 				if (treeComp.getImpostorIds() != null && Tree.findTree(treeComp.getImpostor().getId()) == null)
 				{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingTreesOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingTreesOverlay.java
@@ -34,6 +34,7 @@ import java.util.List;
 import javax.inject.Inject;
 import net.runelite.api.Client;
 import net.runelite.api.GameObject;
+import net.runelite.api.ObjectComposition;
 import net.runelite.api.Perspective;
 import net.runelite.api.Point;
 import net.runelite.api.coords.LocalPoint;
@@ -87,6 +88,12 @@ class WoodcuttingTreesOverlay extends Overlay
 		{
 			if (treeObject.getWorldLocation().distanceTo(client.getLocalPlayer().getWorldLocation()) <= 12)
 			{
+				// Check if this is a redwood tree at the farming patch
+				final ObjectComposition treeComp = client.getObjectDefinition(treeObject.getId());
+				if (treeComp.getImpostorIds() != null && Tree.findTree(treeComp.getImpostor().getId()) == null)
+				{
+					continue;
+				}
 				OverlayUtil.renderImageLocation(client, graphics, treeObject.getLocalLocation(), itemManager.getImage(axe.getItemId()), 120);
 			}
 		}


### PR DESCRIPTION
I tested that this draws the axes in a similar fashion to the woodcutting guild trees. I tested various combinations of turning the plugin on/off and confirming that axes still draw.

In the trees enum, the null object IDs are the 4 choppable spots' imposter objects and then the real object IDs are the corresponding choppable objects.

Closes #7404