### PR TITLE
specialcounter: add accursed sceptre

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/specialcounter/SpecialCounterPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/specialcounter/SpecialCounterPlugin.java
@@ -488,8 +488,7 @@ public class SpecialCounterPlugin extends Plugin
 
 	private int getHitDelay(SpecialWeapon specialWeapon, Actor target)
 	{
-		// DORGESHUUN_CROSSBOW is the only ranged wep we support, so everything else is just melee and delay 1
-		if (specialWeapon != SpecialWeapon.DORGESHUUN_CROSSBOW || target == null)
+		if (target == null)
 			return 1;
 
 		Player player = client.getLocalPlayer();
@@ -505,13 +504,13 @@ public class SpecialCounterPlugin extends Plugin
 			return 1;
 
 		final int distance = targetArea.distanceTo(playerWp);
-		// Dorgeshuun special attack projectile, anim delay, and hitsplat is 60 + distance * 3 with the projectile
-		// starting at 41 cycles. Since we are computing the delay when the spec var changes, and not when the
-		// projectile first moves, this should be 60 and not 19
-		final int cycles = 60 + distance * 3;
-		// The server performs no rounding and instead delays (cycles / 30) cycles from the next cycle
-		final int serverCycles = (cycles / 30) + 1;
-		log.debug("Projectile distance {} cycles {} server cycles {}", distance, cycles, serverCycles);
+		final int serverCycles = specialWeapon.getHitDelay(distance);
+
+		if (serverCycles != 1)
+		{
+			log.debug("Projectile distance {} server cycles {}", distance, serverCycles);
+		}
+
 		return serverCycles;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/specialcounter/SpecialWeapon.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/specialcounter/SpecialWeapon.java
@@ -39,11 +39,61 @@ public enum SpecialWeapon
 	BANDOS_GODSWORD("Bandos Godsword", new int[]{ItemID.BANDOS_GODSWORD, ItemID.BANDOS_GODSWORD_OR}, true, SpecialCounterConfig::bandosGodswordThreshold),
 	BARRELCHEST_ANCHOR("Barrelchest Anchor", new int[]{ItemID.BARRELCHEST_ANCHOR}, true, (c) -> 0),
 	BONE_DAGGER("Bone Dagger", new int[]{ItemID.BONE_DAGGER, ItemID.BONE_DAGGER_P, ItemID.BONE_DAGGER_P_8876, ItemID.BONE_DAGGER_P_8878}, true, (c) -> 0),
-	DORGESHUUN_CROSSBOW("Dorgeshuun Crossbow", new int[]{ItemID.DORGESHUUN_CROSSBOW}, true, (c) -> 0),
-	BULWARK("Dinh's Bulwark", new int[]{ItemID.DINHS_BULWARK}, false, SpecialCounterConfig::bulwarkThreshold);
+	DORGESHUUN_CROSSBOW(
+		"Dorgeshuun Crossbow",
+		new int[]{ItemID.DORGESHUUN_CROSSBOW},
+		true,
+		(distance) -> 60 + distance * 3,
+		(c) -> 0
+	),
+	BULWARK("Dinh's Bulwark", new int[]{ItemID.DINHS_BULWARK}, false, SpecialCounterConfig::bulwarkThreshold),
+	ACCURSED_SCEPTRE(
+		"Accursed Sceptre",
+		new int[]{ItemID.ACCURSED_SCEPTRE, ItemID.ACCURSED_SCEPTRE_A},
+		false,
+		(distance) -> 46 + distance * 10,
+		(c) -> 0
+	),
+	;
 
 	private final String name;
 	private final int[] itemID;
 	private final boolean damage;
+	/**
+	 * Accepts an int representing distance in tiles to the target, and returns an int representing client cycles of
+	 * delay until the hitsplat is applied.
+	 * <p>
+	 * For melee weapons, the returned value is always {@code 0}, as they have no delay. Calculating this delay can be
+	 * done by extrapolating the difference between the cycle the projectile is created and the cycle it ends for
+	 * various distances. In practice, projectiles are created at the same time special attack energy is drained for
+	 * special attacks, so the difference can be taken between the cycle a player's special attack drains and the end
+	 * cycle of the created projectile.
+	 * <p>
+	 * For example, a dorgeshuun crossbow will have its projectile end 63 cycles after a spec at distance 1, 66 at
+	 * distance 2, etc. Hence, we can extrapolate its formula to be {@code int cycles = 60 + distance * 3}.
+	 */
+	private final Function<Integer, Integer> clientCycleHitDelay;
 	private final Function<SpecialCounterConfig, Integer> threshold;
+
+	SpecialWeapon(final String name, final int[] itemID, final boolean damage, final Function<SpecialCounterConfig, Integer> threshold)
+	{
+		this(name, itemID, damage, (distance) -> 0, threshold);
+	}
+
+	/**
+	 * Gets the server cycle delay between special attack energy dropping and a hitsplat being applied to the target.
+	 * This will be {@code 1} for all melee weapons.
+	 *
+	 * @param distance Distance from the target in tiles
+	 * @return Number of server cycles (game ticks) delay for the special attack hitsplat to be applied
+	 */
+	public int getHitDelay(final int distance)
+	{
+		// Convert the client cycles of delay to server cycles delay. The server performs no rounding, so this is
+		// simply (cycles / 30).
+		final int serverCyclesDelay = getClientCycleHitDelay().apply(distance) / 30;
+
+		// All attacks have one server cycle of additional delay beyond any projectile travel time for the weapon.
+		return serverCyclesDelay + 1;
+	}
 }

--- a/runelite-client/src/test/java/net/runelite/client/plugins/specialcounter/SpecialWeaponTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/specialcounter/SpecialWeaponTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2023, Jordan Atwood <nightfirecat@nightfirec.at>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.specialcounter;
+
+import static net.runelite.client.plugins.specialcounter.SpecialWeapon.*;
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+
+public class SpecialWeaponTest
+{
+	@Test
+	public void verifyMeleeWeaponHitDelay()
+	{
+		assertRangeDelayEquals(1, DRAGON_WARHAMMER, 1);
+		assertRangeDelayEquals(1, ARCLIGHT, 1);
+		assertRangeDelayEquals(1, DARKLIGHT, 1);
+		assertRangeDelayEquals(1, BANDOS_GODSWORD, 1);
+		assertRangeDelayEquals(1, BARRELCHEST_ANCHOR, 1);
+		assertRangeDelayEquals(1, BONE_DAGGER, 1);
+		assertRangeDelayEquals(1, BULWARK, 1);
+	}
+
+	@Test
+	public void verifyDorgeshuunCrossbowHitDelay()
+	{
+		assertRangeDelayEquals(3, DORGESHUUN_CROSSBOW, 1);
+		assertRangeDelayEquals(3, DORGESHUUN_CROSSBOW, 2);
+		assertRangeDelayEquals(3, DORGESHUUN_CROSSBOW, 3);
+		assertRangeDelayEquals(3, DORGESHUUN_CROSSBOW, 4);
+		assertRangeDelayEquals(3, DORGESHUUN_CROSSBOW, 5);
+		assertRangeDelayEquals(3, DORGESHUUN_CROSSBOW, 6);
+		assertRangeDelayEquals(3, DORGESHUUN_CROSSBOW, 7);
+	}
+
+	@Test
+	public void verifyAccursedSceptreHitDelay()
+	{
+		assertRangeDelayEquals(2, ACCURSED_SCEPTRE, 1);
+		assertRangeDelayEquals(3, ACCURSED_SCEPTRE, 2);
+		assertRangeDelayEquals(3, ACCURSED_SCEPTRE, 3);
+		assertRangeDelayEquals(3, ACCURSED_SCEPTRE, 4);
+		assertRangeDelayEquals(4, ACCURSED_SCEPTRE, 5);
+		assertRangeDelayEquals(4, ACCURSED_SCEPTRE, 6);
+		assertRangeDelayEquals(4, ACCURSED_SCEPTRE, 7);
+		assertRangeDelayEquals(5, ACCURSED_SCEPTRE, 8);
+		assertRangeDelayEquals(5, ACCURSED_SCEPTRE, 9);
+	}
+
+	private static void assertRangeDelayEquals(final int expected, final SpecialWeapon specialWeapon, final int range)
+	{
+		assertEquals(expected, specialWeapon.getHitDelay(range));
+	}
+}


### PR DESCRIPTION
Closes #16516 

Adds support for Accursed Sceptre & Accursed Sceptre (a) in the Special Attack Counter plugin. Tested at all ranges (1-9 tiles).