### PR TITLE
Improve combat levels for unranked skills

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/Experience.java
+++ b/runelite-api/src/main/java/net/runelite/api/Experience.java
@@ -152,6 +152,14 @@ public class Experience
 		int defenceLevel, int hitpointsLevel, int magicLevel,
 		int rangeLevel, int prayerLevel)
 	{
+		attackLevel = Math.max(attackLevel, 1);
+		strengthLevel = Math.max(strengthLevel, 1);
+		defenceLevel = Math.max(defenceLevel, 1);
+		hitpointsLevel = Math.max(hitpointsLevel, 10);
+		magicLevel = Math.max(magicLevel, 1);
+		rangeLevel = Math.max(rangeLevel, 1);
+		prayerLevel = Math.max(prayerLevel, 1);
+
 		double base = 0.25 * (defenceLevel + hitpointsLevel + (prayerLevel / 2));
 
 		double typeContribution = getMeleeRangeOrMagicCombatLevelContribution(attackLevel, strengthLevel, magicLevel, rangeLevel);


### PR DESCRIPTION
Fixes #2025 and generally makes estimates on combat skills more accurate, by assuming combat skills are at least the minimum possible level.

Example for completely unranked player:
Before: ![2023-04-22-144227_223x400_scrot](https://user-images.githubusercontent.com/11549963/233762996-0b210947-a2b9-40de-b538-cffb2a70ef8a.png)
After: ![2023-04-22-144233_228x328_scrot](https://user-images.githubusercontent.com/11549963/233762994-c1353069-bb8d-4b28-a78c-e11b9553d742.png)

Example for a partially ranked player:
Before: ![2023-04-22-144255_224x395_scrot](https://user-images.githubusercontent.com/11549963/233762993-8a16817d-a164-43ef-b605-e1588d6e47d7.png)
After: ![2023-04-22-144301_227x323_scrot](https://user-images.githubusercontent.com/11549963/233762991-aa7bd992-aae0-4691-bd17-bc16693caeec.png)
