### PR TITLE
Mining plugin: Update ore-vein respawn timers

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/mining/MiningRocksOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/mining/MiningRocksOverlay.java
@@ -42,8 +42,8 @@ import net.runelite.client.ui.overlay.components.ProgressPieComponent;
 class MiningRocksOverlay extends Overlay
 {
 	// Range of Motherlode vein respawn time - not 100% confirmed but based on observation
-	static final int ORE_VEIN_MAX_RESPAWN_TIME = 277; // Game ticks
-	private static final int ORE_VEIN_MIN_RESPAWN_TIME = 150; // Game ticks
+	static final int ORE_VEIN_MAX_RESPAWN_TIME = 100; // Game ticks
+	private static final int ORE_VEIN_MIN_RESPAWN_TIME = 53; // Game ticks
 	private static final float ORE_VEIN_RANDOM_PERCENT_THRESHOLD = (float) ORE_VEIN_MIN_RESPAWN_TIME / ORE_VEIN_MAX_RESPAWN_TIME;
 
 	static final int DAEYALT_MAX_RESPAWN_TIME = 110; // Game ticks


### PR DESCRIPTION
Close #16512

Relevant information regarding the updated min/max respawn timers can be found in the issue above.