### PR TITLE
Mining plugin: Improvement of ore-vein respawn timers in mlm

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/mining/MiningPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/mining/MiningPlugin.java
@@ -117,7 +117,7 @@ public class MiningPlugin extends Plugin
 	@Getter(AccessLevel.PACKAGE)
 	private final List<RockRespawn> respawns = new ArrayList<>();
 
-	private final List<SpawnedOreVein> spawnedOreVeins = new ArrayList<SpawnedOreVein>();
+	private final List<SpawnedOreVein> spawnedOreVeins = new ArrayList<>();
 
 	private boolean recentlyLoggedIn;
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/mining/MiningPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/mining/MiningPlugin.java
@@ -416,7 +416,7 @@ public class MiningPlugin extends Plugin
 			}
 		}
 	}
-	
+
 	/**
 	 * Returns the SpawnedOreVein on coordinates (x,y) from the List spawnedOreVeins.
 	 *
@@ -445,7 +445,7 @@ public class MiningPlugin extends Plugin
 	 */
 	private void clearExpiredSpawnedOreVeins()
 	{
-		final long limit = 63*1000;
+		final long limit = 63 * 1000;
 		spawnedOreVeins.removeIf(spawnedOreVein ->
 		{
 			return System.currentTimeMillis() - spawnedOreVein.getSpawnTime() > limit;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/mining/MiningPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/mining/MiningPlugin.java
@@ -204,6 +204,7 @@ public class MiningPlugin extends Plugin
 	public void onGameTick(GameTick gameTick)
 	{
 		clearExpiredRespawns();
+		clearExpiredSpawnedOreVeins();
 		recentlyLoggedIn = false;
 
 		if (session == null || session.getLastMined() == null)
@@ -433,5 +434,21 @@ public class MiningPlugin extends Plugin
 			}
 		}
 		return null;
+	}
+
+	/**
+	 * If a SpawnedOreVein's spawnTime was long ago, it indicates that the player is no longer near the wall object,
+	 * and it should no longer be tracked. The SpawnedOreVeins are cleared if more than 63 seconds has passed
+	 * since its spawnTime. 63 seconds is the max amount of time needed for the ore-vein to spawn after its last tracked
+	 * spawn time in a SpawnedOreVein object. If more than 63 seconds has passed, it indicates that the player
+	 * is no longer near the wall object, and it should no longer be tracked.
+	 */
+	private void clearExpiredSpawnedOreVeins()
+	{
+		final long limit = 63*1000;
+		spawnedOreVeins.removeIf(spawnedOreVein ->
+		{
+			return System.currentTimeMillis() - spawnedOreVein.getSpawnTime() > limit;
+		});
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/mining/MiningRocksOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/mining/MiningRocksOverlay.java
@@ -27,6 +27,7 @@ package net.runelite.client.plugins.mining;
 import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Graphics2D;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
 import javax.inject.Inject;
@@ -38,13 +39,12 @@ import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.components.ProgressPieComponent;
+import static net.runelite.client.util.RSTimeUnit.GAME_TICKS;
 
 class MiningRocksOverlay extends Overlay
 {
 	// Range of Motherlode vein respawn time - not 100% confirmed but based on observation
 	static final int ORE_VEIN_MAX_RESPAWN_TIME = 100; // Game ticks
-	private static final int ORE_VEIN_MIN_RESPAWN_TIME = 53; // Game ticks
-	private static final float ORE_VEIN_RANDOM_PERCENT_THRESHOLD = (float) ORE_VEIN_MIN_RESPAWN_TIME / ORE_VEIN_MAX_RESPAWN_TIME;
 
 	static final int DAEYALT_MAX_RESPAWN_TIME = 110; // Game ticks
 	private static final int DAEYALT_MIN_RESPAWN_TIME = 91; // Game ticks
@@ -107,7 +107,7 @@ class MiningRocksOverlay extends Overlay
 			Color pieBorderColor = Color.ORANGE;
 
 			// Recolour pie on motherlode veins or Lovakite ore during the portion of the timer where they may respawn
-			if ((rock == Rock.ORE_VEIN && percent > ORE_VEIN_RANDOM_PERCENT_THRESHOLD)
+			if ((rock == Rock.ORE_VEIN && percent > ((float) (rockRespawn.getRespawnTime() - (int) Duration.of(5, GAME_TICKS).toMillis()) / (float) rockRespawn.getRespawnTime()))
 				|| (rock == Rock.DAEYALT_ESSENCE && percent > DAEYALT_RANDOM_PERCENT_THRESHOLD)
 				|| (rock == Rock.LOVAKITE && percent > LOVAKITE_ORE_RANDOM_PERCENT_THRESHOLD))
 			{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/mining/SpawnedOreVein.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/mining/SpawnedOreVein.java
@@ -1,0 +1,18 @@
+package net.runelite.client.plugins.mining;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class SpawnedOreVein
+{
+	private final int x;
+	private final int y;
+	private long spawnTime; // spawn time of ore vein in milliseconds
+
+	public void setSpawnTime(long spawnTime)
+	{
+		this.spawnTime = spawnTime;
+	}
+}


### PR DESCRIPTION
The Mining plugin now keeps track of spawn events for the ore-veins in mlm and stores the spawn times. It uses these stored spawn times to calculate the respawn time for each individual wall. It is accurate within 5 ticks. 

I also made the pie timer green during the last 5 ticks of the animation, to indicate that it is about to spawn. From my own testing, it seems like the ore-vein respawns either exactly when the timer turns green - or exactly when the timer is done. But maybe it can respawn within that window as well.

This is an improvement on issue #16512, which was first solved by pr #16534.