### PR TITLE
GrandExchangePlugin: Add Option for Notifications on Finished Transactions Only

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangeConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangeConfig.java
@@ -47,12 +47,23 @@ public interface GrandExchangeConfig extends Config
 	@ConfigItem(
 		position = 2,
 		keyName = "enableNotifications",
-		name = "Enable Notifications",
+		name = "Notify on offer update",
 		description = "Configures whether to enable notifications when an offer updates"
 	)
 	default boolean enableNotifications()
 	{
 		return true;
+	}
+
+	@ConfigItem(
+		position = 2,
+		keyName = "notifyOnOfferComplete",
+		name = "Notify on offer complete",
+		description = "Configures whether to enable notifications when an offer completes"
+	)
+	default boolean notifyOnOfferComplete()
+	{
+		return false;
 	}
 
 	@ConfigItem(

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangePlugin.java
@@ -561,16 +561,20 @@ public class GrandExchangePlugin extends Plugin
 	@Subscribe
 	public void onChatMessage(ChatMessage event)
 	{
-		if (!this.config.enableNotifications() || event.getType() != ChatMessageType.GAMEMESSAGE)
+		if (event.getType() != ChatMessageType.GAMEMESSAGE)
 		{
 			return;
 		}
 
 		String message = Text.removeTags(event.getMessage());
 
-		if (message.startsWith("Grand Exchange:"))
+		if (message.startsWith("Grand Exchange:") && config.enableNotifications())
 		{
-			this.notifier.notify(message);
+			notifier.notify(message);
+		}
+		else if (message.startsWith("Grand Exchange: Finished") && config.notifyOnOfferComplete())
+		{
+			notifier.notify(message);
 		}
 	}
 

--- a/runelite-client/src/test/java/net/runelite/client/plugins/grandexchange/GrandExchangePluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/grandexchange/GrandExchangePluginTest.java
@@ -35,6 +35,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ScheduledExecutorService;
 import javax.inject.Inject;
+import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
 import net.runelite.api.GameState;
 import net.runelite.api.GrandExchangeOffer;
@@ -42,6 +43,7 @@ import net.runelite.api.GrandExchangeOfferState;
 import net.runelite.api.ItemComposition;
 import net.runelite.api.ItemID;
 import net.runelite.api.WorldType;
+import net.runelite.api.events.ChatMessage;
 import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.GrandExchangeOfferChanged;
 import net.runelite.client.Notifier;
@@ -325,5 +327,33 @@ public class GrandExchangePluginTest
 		assertEquals(1000, trade.getOffer());
 		assertEquals(2, trade.getSlot());
 		assertTrue(trade.isLogin());
+	}
+
+	@Test
+	public void testNotifyPartial()
+	{
+		when(grandExchangeConfig.enableNotifications()).thenReturn(true);
+
+		ChatMessage chatMessage = new ChatMessage();
+		chatMessage.setType(ChatMessageType.GAMEMESSAGE);
+		chatMessage.setMessage("<col=006060>Grand Exchange: Bought 200 / 80,000 x Acorn.</col>");
+
+		grandExchangePlugin.onChatMessage(chatMessage);
+
+		verify(notifier).notify(anyString());
+	}
+
+	@Test
+	public void testNotifyComplete()
+	{
+		when(grandExchangeConfig.notifyOnOfferComplete()).thenReturn(true);
+
+		ChatMessage chatMessage = new ChatMessage();
+		chatMessage.setType(ChatMessageType.GAMEMESSAGE);
+		chatMessage.setMessage("<col=006000>Grand Exchange: Finished buying 1 x Acorn.</col>");
+
+		grandExchangePlugin.onChatMessage(chatMessage);
+
+		verify(notifier).notify(anyString());
 	}
 }


### PR DESCRIPTION
## Context:
This pull request adds a new configuration option to the Grand Exchange plugin that allows users to specify whether they want to receive notifications for all transactions, or only for those transactions that have finished. 

## Changes:

Added a new configuration option onlyFinishedTransactions in the Grand Exchange plugin configuration. This option defaults to false, preserving the current behaviour of the plugin by default.
Updated the onChatMessage function to check the onlyFinishedTransactions configuration option. If it's true, notifications will only be sent for chat messages that start with "Grand Exchange: Finished buying" or "Grand Exchange: Finished selling".

## Benefits:

Users can now reduce the number of notifications they receive from the Grand Exchange plugin by choosing to only be notified when transactions are completed.
This change improves the usability of the Grand Exchange plugin, making it more user-friendly and customizable.

## Testing:

The changes have been tested locally and work as expected. When the onlyFinishedTransactions option is enabled, the user only receives notifications for completed transactions. When it's disabled, the user receives notifications for all transactions.

Please review the changes and let me know if you have any feedback or questions.