### PR TITLE
fix object walk here swap with multilocs

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -1581,7 +1581,15 @@ public class MenuEntrySwapperPlugin extends Plugin
 
 			if (OBJECT_MENU_TYPES.contains(type))
 			{
-				final int objectId = menuEntry.getIdentifier();
+				// Get multiloc id
+				int objectId = menuEntry.getIdentifier();
+				ObjectComposition objectComposition = client.getObjectDefinition(objectId);
+				if (objectComposition.getImpostorIds() != null)
+				{
+					objectComposition = objectComposition.getImpostor();
+					objectId = objectComposition.getId();
+				}
+
 				final boolean shift = shiftModifier();
 				Integer customOption = getObjectSwapConfig(shift, objectId);
 				if ((customOption == null && shift && config.objectShiftClickWalkHere())


### PR DESCRIPTION
Fixes the issue of walk here being unswappable for things with multilocs such as the pyramid plunder sarcophagus or the hole in the lumbridge basement.

Copy-paste of code from the regular object swaps to the walk here object swaps.