### PR TITLE
Bank tag tabs extension

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/banktags/BankTagsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/banktags/BankTagsConfig.java
@@ -27,6 +27,7 @@ package net.runelite.client.plugins.banktags;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.Keybind;
 
 @ConfigGroup("banktags")
 public interface BankTagsConfig extends Config
@@ -73,6 +74,17 @@ public interface BankTagsConfig extends Config
 	default boolean preventTagTabDrags()
 	{
 		return false;
+	}
+
+	@ConfigItem(
+		keyName = "toggleKeybind",
+		name = "View All Tabs keybind",
+		description = "Binds a key (combination) to view all tag tabs.",
+		position = 5
+	)
+	default Keybind toggleKeybind()
+	{
+		return Keybind.NOT_SET;
 	}
 
 	@ConfigItem(

--- a/runelite-client/src/main/java/net/runelite/client/plugins/banktags/tabs/MenuIndexes.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/banktags/tabs/MenuIndexes.java
@@ -31,7 +31,7 @@ class MenuIndexes
 	{
 		static final int NEW_TAB = 2;
 		static final int IMPORT_TAB = 3;
-		static final int OPEN_TAB_MENU = 4;
+		static final int OPEN_ALL_TAGS_TAB = 4;
 	}
 
 	static class Tab

--- a/runelite-client/src/main/java/net/runelite/client/plugins/banktags/tabs/TabInterface.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/banktags/tabs/TabInterface.java
@@ -440,6 +440,7 @@ public class TabInterface
 				else
 				{
 					openTag(Text.removeTags(clicked.getName()));
+					scrollTab(tabManager.indexOf(clicked.getName()) - currentTabIndex);
 					// openTag will reset and relayout
 				}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/banktags/tabs/TabManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/banktags/tabs/TabManager.java
@@ -160,7 +160,7 @@ class TabManager
 		return tabs.indexOf(tagTab);
 	}
 
-	private int indexOf(String tag)
+	int indexOf(String tag)
 	{
 		return indexOf(find(tag));
 	}


### PR DESCRIPTION
1. clicking 'view all tag tabs' will now return to regular bank interface if it was already open
2. added a hotkey to view all tag tabs
3. clicking a specific tag tab from the 'view all tag tabs' page will now scroll down to that tab on the sidebar