### PR TITLE
Fix CombatLevel from showing impossible level requirements

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/combatlevel/CombatLevelOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/combatlevel/CombatLevelOverlay.java
@@ -110,23 +110,23 @@ class CombatLevelOverlay extends Overlay
 		StringBuilder sb = new StringBuilder();
 		sb.append(ColorUtil.wrapWithColorTag("Next combat level:</br>", COMBAT_LEVEL_COLOUR));
 
-		if ((attackLevel + strengthLevel) < Experience.MAX_REAL_LEVEL * 2)
+		if ((attackLevel + strengthLevel + meleeneed) < Experience.MAX_REAL_LEVEL * 2)
 		{
 			sb.append(meleeNeed).append(" Attack/Strength</br>");
 		}
-		if ((hitpointsLevel + defenceLevel) < Experience.MAX_REAL_LEVEL * 2)
+		if ((hitpointsLevel + defenceLevel + hpDefNeed) < Experience.MAX_REAL_LEVEL * 2)
 		{
 			sb.append(hpDefNeed).append(" Defence/Hitpoints</br>");
 		}
-		if (rangeLevel < Experience.MAX_REAL_LEVEL)
+		if (rangeLevel + rangeNeed < Experience.MAX_REAL_LEVEL)
 		{
 			sb.append(rangeNeed).append(" Ranged</br>");
 		}
-		if (magicLevel < Experience.MAX_REAL_LEVEL)
+		if (magicLevel + magicNeed < Experience.MAX_REAL_LEVEL)
 		{
 			sb.append(magicNeed).append(" Magic</br>");
 		}
-		if (prayerLevel < Experience.MAX_REAL_LEVEL)
+		if (prayerLevel + prayerNeed < Experience.MAX_REAL_LEVEL)
 		{
 			sb.append(prayerNeed).append(" Prayer");
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/combatlevel/CombatLevelOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/combatlevel/CombatLevelOverlay.java
@@ -110,7 +110,7 @@ class CombatLevelOverlay extends Overlay
 		StringBuilder sb = new StringBuilder();
 		sb.append(ColorUtil.wrapWithColorTag("Next combat level:</br>", COMBAT_LEVEL_COLOUR));
 
-		if ((attackLevel + strengthLevel + meleeneed) < Experience.MAX_REAL_LEVEL * 2)
+		if ((attackLevel + strengthLevel + meleeNeed) < Experience.MAX_REAL_LEVEL * 2)
 		{
 			sb.append(meleeNeed).append(" Attack/Strength</br>");
 		}

--- a/runelite-client/src/test/java/net/runelite/client/plugins/combatlevel/CombatLevelOverlayTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/combatlevel/CombatLevelOverlayTest.java
@@ -74,6 +74,6 @@ public class CombatLevelOverlayTest
 		when(client.getRealSkillLevel(Skill.RANGED)).thenReturn(99);
 		when(client.getRealSkillLevel(Skill.PRAYER)).thenReturn(94);
 
-		assertEquals("<col=ff981f>Next combat level:</br></col>4 Defence/Hitpoints</br>8 Prayer", combatLevelOverlay.getLevelsUntilTooltip());
+		assertEquals("<col=ff981f>Next combat level:</br></col>4 Defence/Hitpoints", combatLevelOverlay.getLevelsUntilTooltip());
 	}
 }

--- a/runelite-client/src/test/java/net/runelite/client/plugins/combatlevel/CombatLevelOverlayTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/combatlevel/CombatLevelOverlayTest.java
@@ -74,6 +74,6 @@ public class CombatLevelOverlayTest
 		when(client.getRealSkillLevel(Skill.RANGED)).thenReturn(99);
 		when(client.getRealSkillLevel(Skill.PRAYER)).thenReturn(94);
 
-		assertEquals("<col=ff981f>Next combat level:</br></col>4 Defence/Hitpoints", combatLevelOverlay.getLevelsUntilTooltip());
+		assertEquals("<col=ff981f>Next combat level:</br></col>4 Prayer", combatLevelOverlay.getLevelsUntilTooltip());
 	}
 }


### PR DESCRIPTION
Fixes an issue where it shows impossible requirements to get the next combat level, for example I have 90 range, and it tells me I need 27 more range levels to get a combat level, clearly not possible.