### PR TITLE
client: add an option to completely disable window chrome

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/config/RuneLiteConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/RuneLiteConfig.java
@@ -30,6 +30,7 @@ import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
 import net.runelite.api.Constants;
 import net.runelite.client.Notifier;
+import net.runelite.client.ui.ClientUI;
 import net.runelite.client.ui.ContainableFrame;
 import net.runelite.client.ui.overlay.components.ComponentConstants;
 import net.runelite.client.util.OSType;
@@ -128,9 +129,9 @@ public interface RuneLiteConfig extends Config
 		position = 15,
 		section = windowSettings
 	)
-	default boolean enableCustomChrome()
+	default ClientUI.ChromeMode enableCustomChrome()
 	{
-		return OSType.getOSType() == OSType.Windows;
+		return OSType.getOSType() == OSType.Windows ? ClientUI.ChromeMode.CUSTOM : ClientUI.ChromeMode.SYSTEM;
 	}
 
 	@Range(

--- a/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
@@ -111,6 +111,13 @@ import org.pushingpixels.substance.internal.utils.SubstanceTitlePaneUtilities;
 @Singleton
 public class ClientUI
 {
+	public enum ChromeMode
+	{
+		CUSTOM,
+		SYSTEM,
+		NONE;
+	}
+
 	private static final String CONFIG_GROUP = "runelite";
 	private static final String CONFIG_CLIENT_BOUNDS = "clientBounds";
 	private static final String CONFIG_CLIENT_MAXIMIZED = "clientMaximized";
@@ -452,8 +459,9 @@ public class ClientUI
 			mouseManager.registerMouseListener(mouseListener);
 
 			// Decorate window with custom chrome and titlebar if needed
-			withTitleBar = config.enableCustomChrome();
-			frame.setUndecorated(withTitleBar);
+			final ChromeMode chromeMode = config.enableCustomChrome();
+			withTitleBar = chromeMode == ChromeMode.CUSTOM;
+			frame.setUndecorated(chromeMode != ChromeMode.SYSTEM);
 
 			if (withTitleBar)
 			{


### PR DESCRIPTION
Currently you can choose between having the custom RuneLite window chrome and a system window chrome. This PR changes the option to instead have three possible values:
- `CUSTOM`: Behaves the same as `Enable custom window chrome: true`.
- `SYSTEM`: Same as `Enable custom window chrome: false`.
- `NONE`: A hybrid between the two previous values where we inform that we will be drawing our own window chrome yet behave as if the system is drawing them. Leading to a complete removal of borders.

## Motivation
On Linux it's common to be able to move a window by win+lclick drag and resize by win+rclick drag, this can also be had on Windows with third-party tools (i.e. AltSnap). I have also configured the window manager I use to draw one pixel borders on almost all windows. This means that the custom window chrome is undesired for me as it doesn't fit with the theme I have and also wastes space.

While I could disable the custom window chrome this has the undesired effect of any time the client resizes the window (i.e. sidebar opening/closing) the window moves up 18 pixels due to what seems to be a bug with OpenJDK but I didn't look further into it. I also prefer a titlebar-less window on Windows, though there a slight border would be preferrable over none.

## Possible Issues / Conserns
- The changes were tested to work as expected on Windows and Linux. MacOS was not tested but should work without any additional issues.
- On Windows the game seems to ignore Alt+F4 so the "only" way to close the window is through the taskbar which could lead to confusion for *some* users, though this is not really related to these changes.
- The configuration option still has the same description and title as previously and should maybe be updated to reflect the changes. Which I can do but I'd first like feedback on the current changes.
- The configuration option does not migrate previous settings and resets the value to the default.
