### PR TITLE
clientui: Make "request focus force" work on Linux

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
@@ -783,6 +783,8 @@ public class ClientUI
 				WinUtil.requestForeground(frame);
 				break;
 			default:
+				frame.setVisible(true);
+				frame.toFront();
 				frame.requestFocus();
 				break;
 		}


### PR DESCRIPTION
This makes "Request focus->Force" work on Linux. Previously, the window was never switched to. This fix replicates the behavior of other platforms.

There is another [pending PR](https://github.com/runelite/runelite/pull/15207) for fixing this, but I couldn't get it to work without also setting `setVisible`.

Tested and working on Gnome xorg and Wayland. It works when the window is on the same workspace and not in focus.

I couldn't get it working on Sway, but that is most likely because Sway doesn't support the feature.