### PR TITLE
[MacOS] Closing the side panel doesn't resize the game. #16503

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/util/OSXUtil.java
+++ b/runelite-client/src/main/java/net/runelite/client/util/OSXUtil.java
@@ -25,8 +25,10 @@
 package net.runelite.client.util;
 
 import com.apple.eawt.Application;
+import com.apple.eawt.FullScreenAdapter;
 import com.apple.eawt.FullScreenUtilities;
 import javax.swing.JFrame;
+import com.apple.eawt.event.FullScreenEvent;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -36,7 +38,7 @@ import lombok.extern.slf4j.Slf4j;
 public class OSXUtil
 {
 	/**
-	 * Enables the osx native fullscreen if running on a mac.
+	 * Enables the osx native fullscreen if running on a Mac.
 	 *
 	 * @param gui The gui to enable the fullscreen on.
 	 */
@@ -44,6 +46,22 @@ public class OSXUtil
 	{
 		if (OSType.getOSType() == OSType.MacOS)
 		{
+			FullScreenUtilities.addFullScreenListenerTo(gui, new FullScreenAdapter()
+			{
+				@Override
+				public void windowEnteredFullScreen(FullScreenEvent e)
+				{
+					log.debug("Window entered fullscreen mode--setting extended state to {}", JFrame.MAXIMIZED_BOTH);
+					gui.setExtendedState(JFrame.MAXIMIZED_BOTH);
+				}
+
+				@Override
+				public void windowExitedFullScreen(FullScreenEvent e)
+				{
+					log.debug("Window exited fullscreen mode--setting extended state to {}", JFrame.NORMAL);
+					gui.setExtendedState(JFrame.NORMAL);
+				}
+			});
 			FullScreenUtilities.setWindowCanFullScreen(gui, true);
 			log.debug("Enabled fullscreen on macOS");
 		}


### PR DESCRIPTION
Fixes: https://github.com/runelite/runelite/issues/16503

Tested on Ventura 13.4 --

The problem was within `ContainableFrame.java:contractBy`

At the top exists a check `isFullScreen()` which was returning `false` because the `getExtendedState()` call was returning state `0` (NORMAL -- aka not fullscreen) even when we were in full-screen mode on MacOS.

I'm not really sure why this happens. The extended state wasn't being set correctly on Mac devices and I assume its some Apple integration issue with Java Swing. I'm not an expert on this stuff.

Anyways,

What I did to fix it added a full-screen listener to the window which sets the extended state accordingly. Currently, this is only being done when the client is running on MacOS!

**Demonstration:**

https://github.com/runelite/runelite/assets/12455749/67fdab50-753a-456a-a12b-235650588627
