### PR TITLE
Hiscore plugin: Update panel to reflect combat level being an estimate when any combat skills are missing

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/hiscore/HiscorePanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/hiscore/HiscorePanel.java
@@ -464,7 +464,22 @@ public class HiscorePanel extends PluginPanel
 						result.getSkill(RANGED).getLevel(),
 						result.getSkill(PRAYER).getLevel()
 					);
-					label.setText(Integer.toString(combatLevel));
+
+					if (result.getSkill(ATTACK).getLevel() == 1 || //Skills not on the hiscores get set to 1
+						result.getSkill(STRENGTH).getLevel() == 1 ||
+						result.getSkill(DEFENCE).getLevel() == 1 ||
+						result.getSkill(HITPOINTS).getLevel() == 1 ||
+						result.getSkill(MAGIC).getLevel() == 1 ||
+						result.getSkill(RANGED).getLevel() == 1 ||
+						result.getSkill(PRAYER).getLevel() == 1)
+					{
+						//Indicate combat level isn't precise if some combat stat is missing from the hiscores
+						label.setText(">= " + Integer.toString(combatLevel));
+					}
+					else
+					{
+						label.setText(Integer.toString(combatLevel));
+					}
 				}
 			}
 			else if ((s = result.getSkill(skill)) != null)


### PR DESCRIPTION
Close #16527 

Since skills don't show up in the hiscores unless they're in the top 2 million, we should indicate to the player that the combat level may be higher than what is shown in the Runelite hiscores panel when any combat skills are missing.

Example: A prayer level of 25 won't show up on the hiscores, but will increase a player's combat level.

![image](https://github.com/runelite/runelite/assets/18014295/e866e142-8f47-485c-9ad3-a4fd94be3517)
