### PR TITLE
Keyremapping prompt customizations

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/keyremapping/KeyRemappingConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/keyremapping/KeyRemappingConfig.java
@@ -24,6 +24,7 @@
  */
 package net.runelite.client.plugins.keyremapping;
 
+import java.awt.Color;
 import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
 import net.runelite.client.config.Config;
@@ -31,6 +32,7 @@ import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
 import net.runelite.client.config.ConfigSection;
 import net.runelite.client.config.ModifierlessKeybind;
+import net.runelite.client.plugins.keyremapping.config.PromptText;
 
 @ConfigGroup("keyremapping")
 public interface KeyRemappingConfig extends Config
@@ -48,6 +50,13 @@ public interface KeyRemappingConfig extends Config
 		position = 1
 	)
 	String fKeySection = "fKeys";
+
+	@ConfigSection(
+		name = "Chat Prompt",
+		description = "Settings for customizing the chat prompt",
+		position = 2
+	)
+	String chatPromptSection = "chatPrompt";
 
 	@ConfigItem(
 		position = 1,
@@ -297,5 +306,29 @@ public interface KeyRemappingConfig extends Config
 	default ModifierlessKeybind control()
 	{
 		return new ModifierlessKeybind(KeyEvent.VK_UNDEFINED, InputEvent.CTRL_DOWN_MASK);
+	}
+
+	@ConfigItem(
+		keyName = "promptText",
+		name = "Prompt Text",
+		description = "Changes the text shown which prompts the user to start chatting.",
+		position = 22,
+		section = chatPromptSection
+	)
+	default PromptText promptText()
+	{
+		return PromptText.PRESS_ENTER_TO_CHAT;
+	}
+
+	@ConfigItem(
+		keyName = "promptColor",
+		name = "Prompt Color",
+		description = "Changes the color of the chat prompt text.",
+		position = 23,
+		section = chatPromptSection
+	)
+	default Color promptColor()
+	{
+		return Color.BLACK;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/keyremapping/KeyRemappingPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/keyremapping/KeyRemappingPlugin.java
@@ -56,8 +56,6 @@ import net.runelite.client.util.ColorUtil;
 )
 public class KeyRemappingPlugin extends Plugin
 {
-	private static final String PRESS_ENTER_TO_CHAT = "Press Enter to Chat...";
-
 	@Inject
 	private Client client;
 
@@ -69,6 +67,9 @@ public class KeyRemappingPlugin extends Plugin
 
 	@Inject
 	private KeyRemappingListener inputListener;
+
+	@Inject
+	private KeyRemappingConfig config;
 
 	@Getter(AccessLevel.PACKAGE)
 	@Setter(AccessLevel.PACKAGE)
@@ -162,7 +163,7 @@ public class KeyRemappingPlugin extends Plugin
 				Widget chatboxInput = client.getWidget(WidgetInfo.CHATBOX_INPUT);
 				if (chatboxInput != null && !typing)
 				{
-					setChatboxWidgetInput(chatboxInput, PRESS_ENTER_TO_CHAT);
+					setChatboxWidgetInput(chatboxInput, ColorUtil.wrapWithColorTag(config.promptText().toString(), config.promptColor()));
 				}
 				break;
 			case "blockChatInput":
@@ -181,7 +182,7 @@ public class KeyRemappingPlugin extends Plugin
 		Widget chatboxInput = client.getWidget(WidgetInfo.CHATBOX_INPUT);
 		if (chatboxInput != null)
 		{
-			setChatboxWidgetInput(chatboxInput, PRESS_ENTER_TO_CHAT);
+			setChatboxWidgetInput(chatboxInput, ColorUtil.wrapWithColorTag(config.promptText().toString(), config.promptColor()));
 		}
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/keyremapping/config/PromptText.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/keyremapping/config/PromptText.java
@@ -31,14 +31,14 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum PromptText
 {
-    PRESS_ENTER_TO_CHAT("Press Enter to Chat..."),
-    ASTERISK("*");
+	PRESS_ENTER_TO_CHAT("Press Enter to Chat..."),
+	ASTERISK("*");
 
-    private final String name;
+	private final String name;
 
-    @Override
-    public String toString()
-    {
-        return name;
-    }
+	@Override
+	public String toString()
+	{
+		return name;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/keyremapping/config/PromptText.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/keyremapping/config/PromptText.java
@@ -1,0 +1,20 @@
+package net.runelite.client.plugins.keyremapping.config;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum PromptText
+{
+    PRESS_ENTER_TO_CHAT("Press Enter to Chat..."),
+    ASTERISK("*");
+
+    private final String name;
+
+    @Override
+    public String toString()
+    {
+        return name;
+    }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/keyremapping/config/PromptText.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/keyremapping/config/PromptText.java
@@ -1,3 +1,27 @@
+/*
+ * Copyright (c) 2023, Macica2 <https://github.com/macica2>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package net.runelite.client.plugins.keyremapping.config;
 
 import lombok.Getter;


### PR DESCRIPTION
This update allows users to toggle the prompt text of the Key Remapping plugin between "Press Enter to Chat..." and "*". It also lets the user change the color of this prompt text, which currently is black on opaque chat boxes or white on transparent ones.

This was created based on a user request from [this Reddit comment](https://www.reddit.com/r/2007scape/comments/14f8q32/have_a_good_idea_for_a_rl_plugin_ill_make_it_for/jp08j7b/?context=3). The user mentioned that when he first suggested the idea, he got pushback because users might get confused if they completely hide the prompt text and later can't remember why they can't type. Because of this, I simply made it a toggle instead of a free form text field or a checkbox to hide it entirely. This was years ago, so if we aren't as concerned with that anymore, I can change it to a text field.

This is my first update for RuneLite so please let me know if I should change anything!