### PR TITLE
Add support for Forestry events and additional tree tracking

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/AnimationID.java
+++ b/runelite-api/src/main/java/net/runelite/api/AnimationID.java
@@ -179,9 +179,9 @@ public final class AnimationID
 	public static final int MAGIC_ENCHANTING_AMULET_2 = 720; // emerald, jade, dragonstone
 	public static final int MAGIC_ENCHANTING_AMULET_3 = 721; // ruby, topaz, onyx, zenyte
 	public static final int MAGIC_ENCHANTING_BOLTS = 4462;
-	public static final int BURYING_BONES = 827;
+	public static final int BURYING_BONES = 827; // Also used for Struggling Sapling Forestry event
 	public static final int USING_GILDED_ALTAR = 3705;
-	public static final int LOOKING_INTO = 832; // Generic animation used for filling water vessels, Shades of Mort'ton, etc.
+	public static final int LOOKING_INTO = 832; // Generic animation used for filling water vessels, Shades of Mort'ton, pollinating flower bushes
 	public static final int DIG = 830;
 	public static final int DEMONIC_GORILLA_MAGIC_ATTACK = 7225;
 	public static final int DEMONIC_GORILLA_MELEE_ATTACK = 7226;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingConfig.java
@@ -171,7 +171,7 @@ public interface WoodcuttingConfig extends Config
 		position = 20,
 		keyName = "highlightGlowingRoots",
 		name = "Highlight glowing roots",
-		description = "Highlights glowing roots during Rising Roots events",
+		description = "Highlights glowing roots during the Rising Roots event",
 		section = forestrySection
 	)
 	default boolean highlightGlowingRoots()
@@ -183,10 +183,22 @@ public interface WoodcuttingConfig extends Config
 		position = 21,
 		keyName = "highlightMulch",
 		name = "Highlight mulch ingredients",
-		description = "Highlights mulch ingredients during Struggling Sapling events",
+		description = "Highlights mulch ingredients during the Struggling Sapling event",
 		section = forestrySection
 	)
 	default boolean highlightMulch()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		position = 22,
+		keyName = "highlightLeprechaun",
+		name = "Highlight leprechaun",
+		description = "Highlights the leprechaun during the Leprechaun event",
+		section = forestrySection
+	)
+	default boolean highlightLeprechaun()
 	{
 		return true;
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingConfig.java
@@ -109,6 +109,17 @@ public interface WoodcuttingConfig extends Config
 	}
 
 	@ConfigItem(
+		position = 7,
+		keyName = "showChoppingCount",
+		name = "Show chopping count",
+		description = "Configures whether to display the number of people actively chopping a tree"
+	)
+	default boolean showChoppingCount()
+	{
+		return true;
+	}
+
+	@ConfigItem(
 		position = 10,
 		keyName = "forestryLeprechaunNotification",
 		name = "Leprechaun notification",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingPlugin.java
@@ -61,7 +61,6 @@ import net.runelite.api.events.GameObjectSpawned;
 import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.GameTick;
 import net.runelite.api.events.ItemSpawned;
-import net.runelite.api.events.NpcChanged;
 import net.runelite.api.events.NpcDespawned;
 import net.runelite.api.events.NpcSpawned;
 import net.runelite.api.events.PlayerDespawned;
@@ -524,15 +523,6 @@ public class WoodcuttingPlugin extends Plugin
 		if (bushes.contains(event.getNpc()))
 		{
 			bushes.remove(event.getNpc());
-		}
-	}
-
-	@Subscribe
-	public void onNpcChanged(final NpcChanged event)
-	{
-		if (event.getOld().getId() == NpcID.FLOWERING_BUSH)
-		{
-//			bushes.clear();
 		}
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingPlugin.java
@@ -615,30 +615,34 @@ public class WoodcuttingPlugin extends Plugin
 		// Orientation: N=1024, E=1536, S=0, W=512, where we would filter tile loc N = y+1, E= x+1, S=y-1, W=x-1
 		int orientation = actor.getCurrentOrientation();
 		WorldPoint actorLocation = actor.getWorldLocation();
-		Optional<Map.Entry<GameObject, Set<Player>>> closestTreeEntry = treeMap.entrySet().stream().filter((entry) -> {
-			GameObject tree = entry.getKey();
-			WorldPoint treeLocation = tree.getWorldLocation();
-			switch (findClosestDirection(orientation))
+		Optional<Map.Entry<GameObject, Set<Player>>> closestTreeEntry = treeMap.entrySet().stream().filter((entry) ->
 			{
-				case 'N': // North, filter out trees that are not north of us
-					return treeLocation.getY() > actorLocation.getY();
-				case 'E': // East, filter out trees that are not east of us
-					return treeLocation.getX() > actorLocation.getX();
-				case 'S': // South, filter out trees that are not south of us
-					return treeLocation.getY() < actorLocation.getY();
-				case 'W': // West, filter out trees that are not west of us
-					return treeLocation.getX() < actorLocation.getX();
+				GameObject tree = entry.getKey();
+				WorldPoint treeLocation = tree.getWorldLocation();
+				switch (findClosestDirection(orientation))
+				{
+					case 'N': // North, filter out trees that are not north of us
+						return treeLocation.getY() > actorLocation.getY();
+					case 'E': // East, filter out trees that are not east of us
+						return treeLocation.getX() > actorLocation.getX();
+					case 'S': // South, filter out trees that are not south of us
+						return treeLocation.getY() < actorLocation.getY();
+					case 'W': // West, filter out trees that are not west of us
+						return treeLocation.getX() < actorLocation.getX();
+				}
+				log.debug("Orientation {} not found", orientation);
+				return false;
 			}
-			log.debug("Orientation {} not found", orientation);
-			return false;
-		}).sorted((entry1, entry2) -> {
-			// Get closest tree with relation to our player's location
-			GameObject tree1 = entry1.getKey();
-			GameObject tree2 = entry2.getKey();
-			WorldPoint treeLocation1 = tree1.getWorldLocation();
-			WorldPoint treeLocation2 = tree2.getWorldLocation();
-			return actorLocation.distanceTo(treeLocation1) - actorLocation.distanceTo(treeLocation2);
-		}).findFirst();
+		).sorted((entry1, entry2) ->
+			{
+				// Get closest tree with relation to our player's location
+				GameObject tree1 = entry1.getKey();
+				GameObject tree2 = entry2.getKey();
+				WorldPoint treeLocation1 = tree1.getWorldLocation();
+				WorldPoint treeLocation2 = tree2.getWorldLocation();
+				return actorLocation.distanceTo(treeLocation1) - actorLocation.distanceTo(treeLocation2);
+			}
+		).findFirst();
 
 		if (closestTreeEntry.isPresent())
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingPlugin.java
@@ -24,13 +24,17 @@
  */
 package net.runelite.client.plugins.woodcutting;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.inject.Provides;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Pattern;
 import javax.annotation.Nullable;
@@ -39,6 +43,8 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.Actor;
+import net.runelite.api.AnimationID;
 import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
 import net.runelite.api.GameObject;
@@ -55,8 +61,11 @@ import net.runelite.api.events.GameObjectSpawned;
 import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.GameTick;
 import net.runelite.api.events.ItemSpawned;
+import net.runelite.api.events.NpcChanged;
 import net.runelite.api.events.NpcDespawned;
 import net.runelite.api.events.NpcSpawned;
+import net.runelite.api.events.PlayerDespawned;
+import net.runelite.api.events.PlayerSpawned;
 import net.runelite.client.Notifier;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
@@ -108,18 +117,27 @@ public class WoodcuttingPlugin extends Plugin
 
 	@Getter
 	private final Set<GameObject> treeObjects = new HashSet<>();
+	@Getter
+	private final Map<GameObject, Set<Player>> treeMap = new HashMap<>();
+	private final Map<Player, GameObject> playerMap = new HashMap<>();
 
 	@Getter(AccessLevel.PACKAGE)
 	private final List<GameObject> roots = new ArrayList<>();
-	private final List<NPC> flowers = new ArrayList<>();
 	@Getter(AccessLevel.PACKAGE)
 	private final List<GameObject> saplingIngredients = new ArrayList<>(5);
 	@Getter(AccessLevel.PACKAGE)
 	private final GameObject[] saplingOrder = new GameObject[3];
+	private int saplingIngredientsStage;
+
+	@Getter
+	private final Set<NPC> bushes = new HashSet<>();
+	private NPC lastBushPollinated;
+	private boolean sentBushNotification; // Workaround
 
 	@Getter(AccessLevel.PACKAGE)
 	private final List<TreeRespawn> respawns = new ArrayList<>();
 	private boolean recentlyLoggedIn;
+	private int previousPlane;
 	private int currentPlane;
 	private ClueNestTier clueTierSpawned;
 
@@ -144,9 +162,12 @@ public class WoodcuttingPlugin extends Plugin
 		respawns.clear();
 		treeObjects.clear();
 		roots.clear();
-		flowers.clear();
 		saplingIngredients.clear();
 		Arrays.fill(saplingOrder, null);
+		bushes.clear();
+		treeMap.clear();
+		playerMap.clear();
+		saplingIngredients.clear();
 		session = null;
 		axe = null;
 		clueTierSpawned = null;
@@ -158,6 +179,14 @@ public class WoodcuttingPlugin extends Plugin
 		recentlyLoggedIn = false;
 		clueTierSpawned = null;
 		currentPlane = client.getPlane();
+		if (previousPlane != currentPlane)
+		{
+			// Only clear values because sometimes the trees are still there when changing planes (Top of Seer's Bank)
+			treeMap.values().stream().forEach(Set::clear);
+			playerMap.clear();
+			bushes.clear();
+			previousPlane = currentPlane;
+		}
 
 		respawns.removeIf(TreeRespawn::isExpired);
 
@@ -250,6 +279,12 @@ public class WoodcuttingPlugin extends Plugin
 		GameObject gameObject = event.getGameObject();
 		Tree tree = Tree.findTree(gameObject.getId());
 
+		if (tree != null)
+		{
+			log.debug("Tree {} spawned at {}", tree, gameObject.getLocalLocation());
+			treeMap.put(gameObject, new HashSet<>());
+		}
+
 		if (tree == Tree.REDWOOD)
 		{
 			treeObjects.add(gameObject);
@@ -262,6 +297,10 @@ public class WoodcuttingPlugin extends Plugin
 				if (roots.isEmpty() && config.forestryRisingRootsNotification())
 				{
 					notifier.notify("A Rising Roots Forestry event spawned!");
+				}
+				if (gameObject.getId() == ObjectID.TREE_ROOTS_47483)
+				{
+					client.setHintArrow(gameObject.getLocalLocation());
 				}
 
 				roots.add(gameObject);
@@ -286,6 +325,10 @@ public class WoodcuttingPlugin extends Plugin
 			case ObjectID.SPLINTERED_BARK:
 				saplingIngredients.add(gameObject);
 				break;
+			case ObjectID.THRIVING_SAPLING:
+			case ObjectID.THRIVING_SAPLING_47489:
+			case ObjectID.THRIVING_SAPLING_47492:
+				client.clearHintArrow();
 		}
 	}
 
@@ -297,6 +340,12 @@ public class WoodcuttingPlugin extends Plugin
 		Tree tree = Tree.findTree(object.getId());
 		if (tree != null)
 		{
+			// Group chopping
+			if (treeMap.containsKey(object))
+			{
+				treeMap.remove(object);
+			}
+
 			if (tree.getRespawnTime() != null && !recentlyLoggedIn && currentPlane == object.getPlane())
 			{
 				log.debug("Adding respawn timer for {} tree at {}", tree, object.getLocalLocation());
@@ -316,8 +365,10 @@ public class WoodcuttingPlugin extends Plugin
 
 		switch (object.getId())
 		{
+			case ObjectID.TREE_ROOTS_47483:
+				// Glowing tree root despawned
+				client.clearHintArrow();
 			case ObjectID.TREE_ROOTS:
-			case ObjectID.TREE_ROOTS_47483: // glowing roots
 				roots.remove(object);
 				break;
 			case ObjectID.ROTTING_LEAVES:
@@ -331,6 +382,7 @@ public class WoodcuttingPlugin extends Plugin
 				if (saplingIngredients.isEmpty())
 				{
 					Arrays.fill(saplingOrder, null);
+					client.clearHintArrow();
 					log.debug("Struggling Sapling event is over");
 				}
 				break;
@@ -349,12 +401,19 @@ public class WoodcuttingPlugin extends Plugin
 				roots.clear();
 				saplingIngredients.clear();
 				Arrays.fill(saplingOrder, null);
+				treeMap.clear();
+				playerMap.clear();
+				bushes.clear();
+				saplingIngredients.clear();
+				client.clearHintArrow();
+				sentBushNotification = false;
 				break;
 			case LOGGED_IN:
 				// After login trees that are depleted will be changed,
 				// wait for the next game tick before watching for
 				// trees to despawn
 				recentlyLoggedIn = true;
+				sentBushNotification = false;
 				break;
 		}
 	}
@@ -362,6 +421,83 @@ public class WoodcuttingPlugin extends Plugin
 	@Subscribe
 	public void onAnimationChanged(final AnimationChanged event)
 	{
+		// Group chopping
+		if (event.getActor() instanceof Player)
+		{
+			Player player = (Player) event.getActor();
+			if (isWoodcutting(player) && !treeMap.isEmpty())
+			{
+				// Now we have to find the closest tree to the player that we are facing
+				// Orientation: N=1024, E=1536, S=0, W=512, where we would filter tile loc N = y+1, E= x+1, S=y-1, W=x-1
+				GameObject closestTree = findClosestFacingTree(player);
+				if (closestTree == null)
+				{
+					return;
+				}
+				playerMap.put(player, closestTree);
+				Set<Player> choppers = treeMap.getOrDefault(closestTree, ImmutableSet.of());
+				choppers.add(player);
+				treeMap.put(closestTree, choppers);
+//				log.debug("There is now {} people chopping {}", choppers.size(), closestTree);
+			}
+			else if (player.getAnimation() == AnimationID.LOOKING_INTO && event.getActor().getInteracting() != null)
+			{
+				if (bushes.size() == 2 && !bushes.contains(event.getActor().getInteracting()))
+				{
+					bushes.clear();
+					client.clearHintArrow();
+				}
+				else if (bushes.size() < 2 && !bushes.contains(event.getActor().getInteracting()))
+				{
+					bushes.add((NPC) event.getActor().getInteracting());
+					if (bushes.size() == 1)
+					{
+						client.setHintArrow((NPC) event.getActor().getInteracting());
+					}
+				}
+				if (player == client.getLocalPlayer())
+				{
+					lastBushPollinated = (NPC) event.getActor().getInteracting();
+					if (bushes.size() > 0)
+					{
+						NPC nextBush = bushes.stream().filter(npc -> npc != lastBushPollinated).findFirst().orElse(null);
+						if (nextBush != null)
+						{
+							client.setHintArrow(nextBush.getLocalLocation());
+						}
+					}
+				}
+			}
+			else if (player.getAnimation() == -1)
+			{
+				if (!playerMap.isEmpty() && playerMap.containsKey(player))
+				{
+					GameObject tree = playerMap.get(player);
+					playerMap.remove(player);
+					if (treeMap.containsKey(tree))
+					{
+						Set<Player> choppers = treeMap.getOrDefault(tree, ImmutableSet.of());
+						choppers.remove(player);
+						treeMap.put(tree, choppers);
+//						log.debug("There is now {} people chopping {}", choppers.size(), tree);
+					}
+				}
+			}
+			else if (player == client.getLocalPlayer() && player.getAnimation() == AnimationID.BURYING_BONES && player.getInteracting() == null)
+			{
+				if (foundIngredientOrder())
+				{
+					// First three steps are okay and we want to render the hint arrow above the sapling ingredients
+					// The fourth step is adding it to the sapling's mulch, so for now we don't need a hint arrow for it
+					client.setHintArrow(saplingOrder[saplingIngredientsStage++].getLocalLocation());
+					if (saplingIngredientsStage == 3)
+					{
+						saplingIngredientsStage = 0;
+					}
+				}
+			}
+		}
+
 		Player local = client.getLocalPlayer();
 
 		if (event.getActor() != local)
@@ -383,16 +519,16 @@ public class WoodcuttingPlugin extends Plugin
 		NPC npc = event.getNpc();
 		if (npc.getId() == NpcID.FLOWERING_BUSH)
 		{
-			if (flowers.isEmpty() && config.forestryFloweringTreeNotification())
+			if (!sentBushNotification && config.forestryFloweringTreeNotification())
 			{
 				notifier.notify("A Flowering Tree Forestry event spawned!");
+				sentBushNotification = true;
 			}
-
-			flowers.add(npc);
 		}
 		else if (npc.getId() == NpcID.WOODCUTTING_LEPRECHAUN && config.forestryLeprechaunNotification())
 		{
 			notifier.notify("A Leprechaun event spawned!");
+			client.setHintArrow(npc);
 		}
 	}
 
@@ -400,6 +536,149 @@ public class WoodcuttingPlugin extends Plugin
 	public void onNpcDespawned(NpcDespawned event)
 	{
 		NPC npc = event.getNpc();
-		flowers.remove(npc);
+
+		switch (npc.getId())
+		{
+			case NpcID.WOODCUTTING_LEPRECHAUN:
+				client.clearHintArrow();
+				break;
+			case NpcID.FRIENDLY_BEES:
+				bushes.clear();
+				client.clearHintArrow();
+				lastBushPollinated = null;
+				sentBushNotification = false;
+				break;
+		}
+
+		if (bushes.contains(event.getNpc()))
+		{
+			bushes.remove(event.getNpc());
+		}
+	}
+
+	@Subscribe
+	public void onNpcChanged(final NpcChanged event)
+	{
+		if (event.getOld().getId() == NpcID.FLOWERING_BUSH)
+		{
+			bushes.clear();
+			client.clearHintArrow();
+		}
+	}
+
+	@Subscribe
+	public void onPlayerDespawned(final PlayerDespawned event)
+	{
+		GameObject tree = playerMap.get(event.getPlayer());
+		if (playerMap.containsKey(event.getPlayer()))
+		{
+			playerMap.remove(event.getPlayer());
+			if (treeMap.containsKey(tree))
+			{
+				Set<Player> choppers = treeMap.getOrDefault(tree, ImmutableSet.of());
+				choppers.remove(event.getPlayer());
+				treeMap.put(tree, choppers);
+			}
+		}
+	}
+
+	@Subscribe
+	public void onPlayerSpawned(final PlayerSpawned event)
+	{
+//		log.debug("Tree map size: {}", treeMap.size());
+		Player player = event.getPlayer();
+		if (isWoodcutting(player) && !treeMap.isEmpty())
+		{
+			// Now we have to find the closest tree to the player that we are facing
+			// Orientation: N=1024, E=1536, S=0, W=512, where we would filter tile loc N = y+1, E= x+1, S=y-1, W=x-1
+			GameObject closestTree = findClosestFacingTree(player);
+			if (closestTree == null)
+			{
+				return;
+			}
+			playerMap.put(player, closestTree);
+			Set<Player> choppers = treeMap.getOrDefault(closestTree, ImmutableSet.of());
+			choppers.add(player);
+			treeMap.put(closestTree, choppers);
+//				log.debug("There is now {} people chopping {}", choppers.size(), closestTree);
+		}
+	}
+
+	private boolean isWoodcutting(Actor actor)
+	{
+		return Axe.findAxeByAnimId(actor.getAnimation()) != null;
+	}
+
+	private GameObject findClosestFacingTree(Actor actor)
+	{
+		// First we filter out all trees whose tile is not in the direction we are facing
+		// Orientation: N=1024, E=1536, S=0, W=512, where we would filter tile loc N = y+1, E= x+1, S=y-1, W=x-1
+		int orientation = actor.getCurrentOrientation();
+		WorldPoint actorLocation = actor.getWorldLocation();
+		Optional<Map.Entry<GameObject, Set<Player>>> closestTreeEntry = treeMap.entrySet().stream().filter((entry) -> {
+			GameObject tree = entry.getKey();
+			WorldPoint treeLocation = tree.getWorldLocation();
+			switch (findClosestDirection(orientation))
+			{
+				case 'N': // North, filter out trees that are not north of us
+					return treeLocation.getY() > actorLocation.getY();
+				case 'E': // East, filter out trees that are not east of us
+					return treeLocation.getX() > actorLocation.getX();
+				case 'S': // South, filter out trees that are not south of us
+					return treeLocation.getY() < actorLocation.getY();
+				case 'W': // West, filter out trees that are not west of us
+					return treeLocation.getX() < actorLocation.getX();
+			}
+			log.debug("Orientation {} not found", orientation);
+			return false;
+		}).sorted((entry1, entry2) -> {
+			// Get closest tree with relation to our player's location
+			GameObject tree1 = entry1.getKey();
+			GameObject tree2 = entry2.getKey();
+			WorldPoint treeLocation1 = tree1.getWorldLocation();
+			WorldPoint treeLocation2 = tree2.getWorldLocation();
+			return actorLocation.distanceTo(treeLocation1) - actorLocation.distanceTo(treeLocation2);
+		}).findFirst();
+
+		if (closestTreeEntry.isPresent())
+		{
+//			log.debug("Closest tree is {}", closestTreeEntry.get().getKey().getWorldLocation());
+			return closestTreeEntry.get().getKey();
+		}
+		else
+		{
+			log.debug("No closest tree found");
+			return null;
+		}
+	}
+
+	private char findClosestDirection(int orientation)
+	{
+		// Orientation: N=1024, E=1536, S=0, W=512, where we would filter tile loc N = y+1, E= x+1, S=y-1, W=x-1
+		if (orientation >= 768 && orientation < 1280)
+		{
+			return 'N';
+		}
+		else if (orientation >= 1280 && orientation < 1792)
+		{
+			return 'E';
+		}
+		else if (orientation >= 1792 || orientation < 256)
+		{
+			return 'S';
+		}
+		else if (orientation >= 256 && orientation < 768)
+		{
+			return 'W';
+		}
+		else
+		{
+			return 'X';
+		}
+	}
+
+	private boolean foundIngredientOrder()
+	{
+		return saplingOrder[0] != null && saplingOrder[1] != null && saplingOrder[2] != null;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingPlugin.java
@@ -428,7 +428,6 @@ public class WoodcuttingPlugin extends Plugin
 				playerMap.put(player, closestTree);
 				int choppers = treeMap.getOrDefault(closestTree, 0) + 1;
 				treeMap.put(closestTree, choppers);
-//				log.debug("There is now {} people chopping {}", choppers.size(), closestTree);
 			}
 			else if (player.getAnimation() == AnimationID.LOOKING_INTO && event.getActor().getInteracting() != null)
 			{
@@ -451,7 +450,6 @@ public class WoodcuttingPlugin extends Plugin
 					{
 						int choppers = treeMap.getOrDefault(tree, 1) - 1;
 						treeMap.put(tree, choppers);
-//						log.debug("There is now {} people chopping {}", choppers.size(), tree);
 					}
 				}
 			}
@@ -544,7 +542,6 @@ public class WoodcuttingPlugin extends Plugin
 	@Subscribe
 	public void onPlayerSpawned(final PlayerSpawned event)
 	{
-//		log.debug("Tree map size: {}", treeMap.size());
 		Player player = event.getPlayer();
 		if (isWoodcutting(player) && !treeMap.isEmpty())
 		{
@@ -558,7 +555,6 @@ public class WoodcuttingPlugin extends Plugin
 			playerMap.put(player, closestTree);
 			int choppers = treeMap.getOrDefault(closestTree, 0) + 1;
 			treeMap.put(closestTree, choppers);
-//				log.debug("There is now {} people chopping {}", choppers.size(), closestTree);
 		}
 	}
 
@@ -604,7 +600,6 @@ public class WoodcuttingPlugin extends Plugin
 
 		if (closestTreeEntry.isPresent())
 		{
-//			log.debug("Closest tree is {}", closestTreeEntry.get().getKey().getWorldLocation());
 			return closestTreeEntry.get().getKey();
 		}
 		else

--- a/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingPlugin.java
@@ -130,7 +130,6 @@ public class WoodcuttingPlugin extends Plugin
 
 	@Getter(AccessLevel.PACKAGE)
 	private final Set<NPC> bushes = new HashSet<>();
-	private NPC lastBushPollinated;
 	private boolean sentBushNotification; // Workaround
 
 	@Getter(AccessLevel.PACKAGE)
@@ -166,7 +165,6 @@ public class WoodcuttingPlugin extends Plugin
 		bushes.clear();
 		treeMap.clear();
 		playerMap.clear();
-		saplingIngredients.clear();
 		session = null;
 		axe = null;
 		clueTierSpawned = null;
@@ -297,10 +295,6 @@ public class WoodcuttingPlugin extends Plugin
 				{
 					notifier.notify("A Rising Roots Forestry event spawned!");
 				}
-				if (gameObject.getId() == ObjectID.TREE_ROOTS_47483)
-				{
-					client.setHintArrow(gameObject.getLocalLocation());
-				}
 
 				roots.add(gameObject);
 				break;
@@ -324,10 +318,6 @@ public class WoodcuttingPlugin extends Plugin
 			case ObjectID.SPLINTERED_BARK:
 				saplingIngredients.add(gameObject);
 				break;
-			case ObjectID.THRIVING_SAPLING:
-			case ObjectID.THRIVING_SAPLING_47489:
-			case ObjectID.THRIVING_SAPLING_47492:
-				client.clearHintArrow();
 		}
 	}
 
@@ -364,10 +354,8 @@ public class WoodcuttingPlugin extends Plugin
 
 		switch (object.getId())
 		{
-			case ObjectID.TREE_ROOTS_47483:
-				// Glowing tree root despawned
-				client.clearHintArrow();
 			case ObjectID.TREE_ROOTS:
+			case ObjectID.TREE_ROOTS_47483:
 				roots.remove(object);
 				break;
 			case ObjectID.ROTTING_LEAVES:
@@ -381,7 +369,6 @@ public class WoodcuttingPlugin extends Plugin
 				if (saplingIngredients.isEmpty())
 				{
 					Arrays.fill(saplingOrder, null);
-					client.clearHintArrow();
 					log.debug("Struggling Sapling event is over");
 				}
 				break;
@@ -404,7 +391,6 @@ public class WoodcuttingPlugin extends Plugin
 				playerMap.clear();
 				bushes.clear();
 				saplingIngredients.clear();
-				client.clearHintArrow();
 				sentBushNotification = false;
 				break;
 			case LOGGED_IN:
@@ -443,27 +429,10 @@ public class WoodcuttingPlugin extends Plugin
 				if (bushes.size() == 2 && !bushes.contains(event.getActor().getInteracting()))
 				{
 					bushes.clear();
-					client.clearHintArrow();
 				}
 				else if (bushes.size() < 2 && !bushes.contains(event.getActor().getInteracting()))
 				{
 					bushes.add((NPC) event.getActor().getInteracting());
-					if (bushes.size() == 1)
-					{
-						client.setHintArrow((NPC) event.getActor().getInteracting());
-					}
-				}
-				if (player == client.getLocalPlayer())
-				{
-					lastBushPollinated = (NPC) event.getActor().getInteracting();
-					if (bushes.size() > 0)
-					{
-						NPC nextBush = bushes.stream().filter(npc -> npc != lastBushPollinated).findFirst().orElse(null);
-						if (nextBush != null)
-						{
-							client.setHintArrow(nextBush.getLocalLocation());
-						}
-					}
 				}
 			}
 			else if (player.getAnimation() == -1)
@@ -484,9 +453,6 @@ public class WoodcuttingPlugin extends Plugin
 			{
 				if (foundIngredientOrder())
 				{
-					// First three steps are okay and we want to render the hint arrow above the sapling ingredients
-					// The fourth step is adding it to the sapling's mulch, so for now we don't need a hint arrow for it
-					client.setHintArrow(saplingOrder[saplingIngredientsStage++].getLocalLocation());
 					if (saplingIngredientsStage == 3)
 					{
 						saplingIngredientsStage = 0;
@@ -525,7 +491,6 @@ public class WoodcuttingPlugin extends Plugin
 		else if (npc.getId() == NpcID.WOODCUTTING_LEPRECHAUN && config.forestryLeprechaunNotification())
 		{
 			notifier.notify("A Leprechaun event spawned!");
-			client.setHintArrow(npc);
 		}
 	}
 
@@ -537,12 +502,9 @@ public class WoodcuttingPlugin extends Plugin
 		switch (npc.getId())
 		{
 			case NpcID.WOODCUTTING_LEPRECHAUN:
-				client.clearHintArrow();
 				break;
 			case NpcID.FRIENDLY_BEES:
 				bushes.clear();
-				client.clearHintArrow();
-				lastBushPollinated = null;
 				sentBushNotification = false;
 				break;
 		}
@@ -559,7 +521,6 @@ public class WoodcuttingPlugin extends Plugin
 		if (event.getOld().getId() == NpcID.FLOWERING_BUSH)
 		{
 			bushes.clear();
-			client.clearHintArrow();
 		}
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingTreesOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingTreesOverlay.java
@@ -33,7 +33,6 @@ import java.awt.Shape;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import javax.inject.Inject;
 import net.runelite.api.Actor;
 import net.runelite.api.Client;
@@ -41,7 +40,6 @@ import net.runelite.api.GameObject;
 import net.runelite.api.ObjectComposition;
 import net.runelite.api.ObjectID;
 import net.runelite.api.Perspective;
-import net.runelite.api.Player;
 import net.runelite.api.Point;
 import net.runelite.api.coords.LocalPoint;
 import net.runelite.client.game.ItemManager;
@@ -275,12 +273,12 @@ class WoodcuttingTreesOverlay extends Overlay
 			return;
 		}
 
-		for (Map.Entry<GameObject, Set<Player>> treeEntry : plugin.getTreeMap().entrySet())
+		for (Map.Entry<GameObject, Integer> treeEntry : plugin.getTreeMap().entrySet())
 		{
-			if (!treeEntry.getValue().isEmpty())
+			int choppers = treeEntry.getValue();
+			if (choppers > 0)
 			{
-				Point point = Perspective.getCanvasTextLocation(client, graphics, treeEntry.getKey().getLocalLocation(), String.valueOf(treeEntry.getValue().size()), 0);
-				int choppers = treeEntry.getValue().size();
+				Point point = Perspective.getCanvasTextLocation(client, graphics, treeEntry.getKey().getLocalLocation(), String.valueOf(choppers), 0);
 				Color color;
 				if (choppers >= 10)
 				{
@@ -298,8 +296,8 @@ class WoodcuttingTreesOverlay extends Overlay
 				{
 					color = Color.RED;
 				}
-				OverlayUtil.renderTextLocation(graphics, point, String.valueOf(treeEntry.getValue().size()), color);
-//				OverlayUtil.renderTileOverlay(graphics, treeEntry.getKey(), String.valueOf(treeEntry.getValue().size()), color);
+				OverlayUtil.renderTextLocation(graphics, point, String.valueOf(choppers), color);
+//				OverlayUtil.renderTileOverlay(graphics, treeEntry.getKey(), String.valueOf(choppers), color);
 			}
 		}
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingTreesOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingTreesOverlay.java
@@ -32,12 +32,16 @@ import java.awt.Graphics2D;
 import java.awt.Shape;
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import javax.inject.Inject;
+import net.runelite.api.Actor;
 import net.runelite.api.Client;
 import net.runelite.api.GameObject;
 import net.runelite.api.ObjectComposition;
 import net.runelite.api.ObjectID;
 import net.runelite.api.Perspective;
+import net.runelite.api.Player;
 import net.runelite.api.Point;
 import net.runelite.api.coords.LocalPoint;
 import net.runelite.client.game.ItemManager;
@@ -88,6 +92,9 @@ class WoodcuttingTreesOverlay extends Overlay
 		{
 			return;
 		}
+
+		renderGrouping(graphics);
+		renderBushes(graphics);
 
 		if (config.highlightGlowingRoots())
 		{
@@ -243,8 +250,8 @@ class WoodcuttingTreesOverlay extends Overlay
 			}
 
 			LocalPoint centeredLocation = new LocalPoint(
-					minLocation.getX() + treeRespawn.getLenX() * Perspective.LOCAL_HALF_TILE_SIZE,
-					minLocation.getY() + treeRespawn.getLenY() * Perspective.LOCAL_HALF_TILE_SIZE);
+				minLocation.getX() + treeRespawn.getLenX() * Perspective.LOCAL_HALF_TILE_SIZE,
+				minLocation.getY() + treeRespawn.getLenY() * Perspective.LOCAL_HALF_TILE_SIZE);
 			float percent = (now.toEpochMilli() - treeRespawn.getStartTime().toEpochMilli()) / (float) treeRespawn.getRespawnTime();
 			Point point = Perspective.localToCanvas(client, centeredLocation, client.getPlane());
 			if (point == null || percent > 1.0f)
@@ -258,6 +265,55 @@ class WoodcuttingTreesOverlay extends Overlay
 			ppc.setPosition(point);
 			ppc.setProgress(percent);
 			ppc.render(graphics);
+		}
+	}
+
+	private void renderGrouping(Graphics2D graphics)
+	{
+		if (plugin.getTreeMap() == null || plugin.getTreeMap().isEmpty())
+		{
+			return;
+		}
+
+		for (Map.Entry<GameObject, Set<Player>> treeEntry : plugin.getTreeMap().entrySet())
+		{
+			if (!treeEntry.getValue().isEmpty())
+			{
+				Point point = Perspective.getCanvasTextLocation(client, graphics, treeEntry.getKey().getLocalLocation(), String.valueOf(treeEntry.getValue().size()), 0);
+				int choppers = treeEntry.getValue().size();
+				Color color;
+				if (choppers >= 10)
+				{
+					color = Color.GREEN;
+				}
+				else if (choppers >= 7)
+				{
+					color = Color.YELLOW;
+				}
+				else if (choppers >= 4)
+				{
+					color = Color.ORANGE;
+				}
+				else
+				{
+					color = Color.RED;
+				}
+				OverlayUtil.renderTextLocation(graphics, point, String.valueOf(treeEntry.getValue().size()), color);
+//				OverlayUtil.renderTileOverlay(graphics, treeEntry.getKey(), String.valueOf(treeEntry.getValue().size()), color);
+			}
+		}
+	}
+
+	private void renderBushes(Graphics2D graphics)
+	{
+		if (plugin.getBushes() == null || plugin.getBushes().isEmpty())
+		{
+			return;
+		}
+
+		for (Actor bush : plugin.getBushes())
+		{
+			OverlayUtil.renderActorOverlay(graphics, bush, "", Color.GREEN);
 		}
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingTreesOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingTreesOverlay.java
@@ -80,13 +80,13 @@ class WoodcuttingTreesOverlay extends Overlay
 	{
 		renderAxes(graphics);
 		renderTimers(graphics);
+		renderGrouping(graphics);
 		renderForestryEvents(graphics);
 		return null;
 	}
 
 	private void renderForestryEvents(Graphics2D graphics)
 	{
-		renderGrouping(graphics);
 		renderBushes(graphics);
 
 		if (config.highlightGlowingRoots())
@@ -263,17 +263,16 @@ class WoodcuttingTreesOverlay extends Overlay
 
 	private void renderGrouping(Graphics2D graphics)
 	{
-		if (plugin.getTreeMap() == null || plugin.getTreeMap().isEmpty())
-		{
-			return;
-		}
-
 		for (Map.Entry<GameObject, Integer> treeEntry : plugin.getTreeMap().entrySet())
 		{
 			int choppers = treeEntry.getValue();
 			if (choppers > 0)
 			{
 				Point point = Perspective.getCanvasTextLocation(client, graphics, treeEntry.getKey().getLocalLocation(), String.valueOf(choppers), 0);
+				if (point == null)
+				{
+					return;
+				}
 				Color color;
 				if (choppers >= 10)
 				{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingTreesOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingTreesOverlay.java
@@ -311,7 +311,6 @@ class WoodcuttingTreesOverlay extends Overlay
 					color = Color.RED;
 				}
 				OverlayUtil.renderTextLocation(graphics, point, String.valueOf(choppers), color);
-//				OverlayUtil.renderTileOverlay(graphics, treeEntry.getKey(), String.valueOf(choppers), color);
 			}
 		}
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingTreesOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingTreesOverlay.java
@@ -86,11 +86,6 @@ class WoodcuttingTreesOverlay extends Overlay
 
 	private void renderForestryEvents(Graphics2D graphics)
 	{
-		if (plugin.getSession() == null)
-		{
-			return;
-		}
-
 		renderGrouping(graphics);
 		renderBushes(graphics);
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingTreesOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingTreesOverlay.java
@@ -26,6 +26,7 @@
  */
 package net.runelite.client.plugins.woodcutting;
 
+import java.awt.BasicStroke;
 import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Graphics2D;
@@ -53,11 +54,12 @@ import net.runelite.client.util.ColorUtil;
 
 class WoodcuttingTreesOverlay extends Overlay
 {
-	private static final Color ROTTING_LEAVES = new Color(179, 0, 0);
-	private static final Color GREEN_LEAVES = new Color(0, 179, 0);
-	private static final Color DROPPINGS = new Color(120, 88, 76);
-	private static final Color WILD_MUSHROOMS = new Color(220, 220, 220);
-	private static final Color SPLINTERED_BARK = new Color(0, 0, 179);
+	private static final Color ROTTING_LEAVES_COLOR = new Color(179, 0, 0);
+	private static final Color GREEN_LEAVES_COLOR = new Color(0, 179, 0);
+	private static final Color DROPPINGS_COLOR = new Color(120, 88, 76);
+	private static final Color WILD_MUSHROOMS_COLOR = new Color(220, 220, 220);
+	private static final Color SPLINTERED_BARK_COLOR = new Color(0, 0, 179);
+	private static final Color LEPRECHAUN_COLOR = new Color(169, 219, 134);
 
 	private final Client client;
 	private final WoodcuttingConfig config;
@@ -80,7 +82,10 @@ class WoodcuttingTreesOverlay extends Overlay
 	{
 		renderAxes(graphics);
 		renderTimers(graphics);
-		renderGrouping(graphics);
+		if (config.showChoppingCount())
+		{
+			renderGrouping(graphics);
+		}
 		renderForestryEvents(graphics);
 		return null;
 	}
@@ -127,25 +132,25 @@ class WoodcuttingTreesOverlay extends Overlay
 				{
 					case ObjectID.ROTTING_LEAVES:
 						letter = 'R';
-						color = ROTTING_LEAVES;
+						color = ROTTING_LEAVES_COLOR;
 						break;
 					case ObjectID.GREEN_LEAVES:
 						letter = 'G';
-						color = GREEN_LEAVES;
+						color = GREEN_LEAVES_COLOR;
 						break;
 					case ObjectID.DROPPINGS:
 						letter = 'D';
-						color = DROPPINGS;
+						color = DROPPINGS_COLOR;
 						break;
 					case ObjectID.WILD_MUSHROOMS:
 					case ObjectID.WILD_MUSHROOMS_47497:
 					case ObjectID.WILD_MUSHROOMS_47498:
 						letter = 'M';
-						color = WILD_MUSHROOMS;
+						color = WILD_MUSHROOMS_COLOR;
 						break;
 					case ObjectID.SPLINTERED_BARK:
 						letter = 'B';
-						color = SPLINTERED_BARK;
+						color = SPLINTERED_BARK_COLOR;
 						break;
 					default:
 						continue;
@@ -193,6 +198,21 @@ class WoodcuttingTreesOverlay extends Overlay
 					OverlayUtil.renderTextLocation(graphics, textLocation, text, Color.WHITE);
 				}
 			}
+		}
+
+		if (config.highlightLeprechaun() && plugin.getLeprechaun() != null)
+		{
+			Shape convexHull = plugin.getLeprechaun().getConvexHull();
+			if (convexHull == null)
+			{
+				return;
+			}
+
+			graphics.setColor(LEPRECHAUN_COLOR);
+			graphics.setStroke(new BasicStroke(2));
+			graphics.draw(convexHull);
+			graphics.setColor(ColorUtil.colorWithAlpha(LEPRECHAUN_COLOR, LEPRECHAUN_COLOR.getAlpha() / 5));
+			graphics.fill(convexHull);
 		}
 	}
 


### PR DESCRIPTION
# Forestry Events
Added support for various Forestry events in the form of `HintArrow` overlays or tile highlights and labels to help make the events easier or as a QoL

## Rising Roots
- Will display a `HintArrow` on the glowing root
### Additional Comments
- Maybe support for highlighting the regular roots would be nice because they tend to spawn a few seconds before the glowing root

## Flowering Tree
- Will display a `HintArrow` and highlight the two active flowers to be pollinated

### Implementation
1. Checks to see if a player successfully pollinates a flower bush
2. Highlight the respective pollinated bush
- We only keep track of two active bushes

### Potential Issues
- Because I changed how we're tracking the flowering bushes, I had to modify how spawn notification's are sent. That's why there also a _workaround_ with a variable to track whether or not an event was already sent. I haven't tested this because it was getting late. Please test to make sure there are no issues, otherwise I will check when I wake up.
	- Also, this may cause issues where two of the same Flowering Tree event spawns right next to one another. If they are both active and close enough, the second event's spawning won't trigger a notification. Currently, notifications are sent on spawn, and cleared once the bee NPC despawns.

## Struggling Sapling
- Will display a `HintArrow` and highlight on the necessary ingredients and their order
- Will display a label on the tile indicating the order in which it should be added to the mulch

### Implementation
1. Get all of the spawned related events' `GameObject`s such as `Rotting leaves`, etc
	- Used to reference the GameObject and to highlight it
2. Listen to the chat to see which ingredient _the sapling seems to love_" and at what order

### Potential Issues
- As you may have noticed in a TODO comment, there was an issue where the last step wasn't tracked. Though originally it was because I didn't realize there are multiple id's for `Wild mushrooms`. It should be resolved.
- Rarely it wouldn't track ingredients properly. I believe it was because I wasn't properly clearing the variables. With little testing, it seems resolved, but further testing would be appreciated, and a second eye on how I handled clearing the variables in the code.

## Leprechaun
- Will display a `HintArrow` above the leprechaun

# Additional Changes
## # Players Chopping a Tree
- Will display a label on the base of the tree with the respective number

### Implementation
1. Have a map for tree that will keep track of how many players are chopping a tree
2. Have a map for `Player`s that will keep track of which tree a player is chopping
- I use two maps here to potentially speed up code at the cost of allocating an additional map for players. This way instead of counting all the players chopping the tree, we can simply reference the size of the set in the tree map.
4. When a `Player` is chopping a tree, find the closest tree they are facing* and track it accordingly
5. When a `Player` has _spawned_ and they are chopping a tree, find the closest tree they are facing* and track it accordingly
	- Primarily for when a player logins in or walks to a new area where a player is already chopping down a tree, it'll track it.
	- Also helps in cases when you change planes and players get despawned, but the `GameObject` stays. For example, if you go to the top of the bank at Seer's Village, the trees will still be rendered.
6. Loop through all the trees within the tree map and display the respective label of the number of people chopping that given tree
	- Color coded where it'll stay green once it reaches the maximum number of players required for the maximum bonus

_*Closest tree is calculated by distance and orientation of the player_

### Potential Issues
- I've seen some times where the overlay stays. I've also seen times where it automatically fixes itself.
- There might be some issues when first loading into a region and people are already are chopping. Although, this might be resolved. It'd be nice if someone could test it to make sure they don't have the same error.
- I'm reconsidering the signature for the treemap. I think it would be time and space efficient to instead simply use `Set<Integer>` (set of player ids) instead of `Set<Player>`