### PR TITLE
woodcutting: Remember session stats after timeout

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingOverlay.java
@@ -61,7 +61,7 @@ class WoodcuttingOverlay extends OverlayPanel
 	public Dimension render(Graphics2D graphics)
 	{
 		WoodcuttingSession session = plugin.getSession();
-		if (session == null || !config.showWoodcuttingStats())
+		if (session == null || !session.isActive() || !config.showWoodcuttingStats())
 		{
 			return null;
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingPlugin.java
@@ -181,7 +181,7 @@ public class WoodcuttingPlugin extends Plugin
 
 		if (sinceCut.compareTo(statTimeout) >= 0)
 		{
-			session = null;
+			session.setActive(false);
 			axe = null;
 		}
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingSession.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingSession.java
@@ -28,6 +28,7 @@ import java.time.Duration;
 import java.time.Instant;
 import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.Setter;
 
 class WoodcuttingSession
 {
@@ -42,10 +43,14 @@ class WoodcuttingSession
 	private int bark;
 	@Getter(AccessLevel.PACKAGE)
 	private int barkPerHr;
+	@Getter(AccessLevel.PACKAGE)
+	@Setter(AccessLevel.PACKAGE)
+	private boolean active = true;
 
 	void setLastChopping()
 	{
 		lastChopping = Instant.now();
+		setActive(true);
 	}
 
 	void incrementLogsCut()


### PR DESCRIPTION
idk if we care much about this "feature", but this matches previous behavior, and the behavior which exists in the other skilling plugin overlays.