### PR TITLE
clues: dynamic viggora location

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/Varbits.java
+++ b/runelite-api/src/main/java/net/runelite/api/Varbits.java
@@ -830,4 +830,11 @@ public final class Varbits
 	public static final int DISABLE_LEVEL_UP_INTERFACE = 9452;
 
 	public static final int PRAYERBOOK = 14826;
+
+	/**
+	 * During and after Curse of the Empty Lord, Viggora can be located in one of three locations,
+	 * which is uniquely and permanently set for each player.
+	 * This varbit determines which location he will appear in, which is useful for a master clue step.
+	 */
+	public static final int VIGGORA_LOCATION = 815;
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/ClueScrollPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/ClueScrollPlugin.java
@@ -561,7 +561,7 @@ public class ClueScrollPlugin extends Plugin
 
 		if (clue instanceof LocationsClueScroll)
 		{
-			final WorldPoint[] locations = ((LocationsClueScroll) clue).getLocations();
+			final WorldPoint[] locations = ((LocationsClueScroll) clue).getLocations(this);
 
 			if (locations.length > 0)
 			{
@@ -587,7 +587,7 @@ public class ClueScrollPlugin extends Plugin
 
 		if (clue instanceof LocationClueScroll)
 		{
-			final WorldPoint[] locations = ((LocationClueScroll) clue).getLocations();
+			final WorldPoint[] locations = ((LocationClueScroll) clue).getLocations(this);
 			final boolean npcHintArrowMarked = client.getHintArrowNpc() != null && npcsToMark.contains(client.getHintArrowNpc());
 
 			if (!npcHintArrowMarked)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java
@@ -29,6 +29,7 @@ import java.awt.Color;
 import java.awt.Graphics2D;
 import java.util.List;
 import javax.annotation.Nullable;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import net.runelite.api.NPC;
@@ -773,6 +774,7 @@ public class AnagramClue extends ClueScroll implements NpcClueScroll, ObjectClue
 
 	private final String text;
 	private final String npc;
+	@Getter(AccessLevel.PRIVATE)
 	private final WorldPoint location;
 	private final String area;
 	@Nullable
@@ -781,6 +783,12 @@ public class AnagramClue extends ClueScroll implements NpcClueScroll, ObjectClue
 	private final String answer;
 	@Builder.Default
 	private final int objectId = -1;
+
+	@Override
+	public WorldPoint getLocation(ClueScrollPlugin plugin)
+	{
+		return location;
+	}
 
 	@Override
 	public void makeOverlayHint(PanelComponent panelComponent, ClueScrollPlugin plugin)
@@ -813,7 +821,7 @@ public class AnagramClue extends ClueScroll implements NpcClueScroll, ObjectClue
 	@Override
 	public void makeWorldOverlayHint(Graphics2D graphics, ClueScrollPlugin plugin)
 	{
-		if (!getLocation().isInScene(plugin.getClient()))
+		if (!getLocation(plugin).isInScene(plugin.getClient()))
 		{
 			return;
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CipherClue.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CipherClue.java
@@ -29,6 +29,7 @@ import java.awt.Color;
 import java.awt.Graphics2D;
 import java.util.List;
 import javax.annotation.Nullable;
+import lombok.AccessLevel;
 import lombok.Getter;
 import net.runelite.api.NPC;
 import net.runelite.api.NPCComposition;
@@ -67,6 +68,7 @@ public class CipherClue extends ClueScroll implements NpcClueScroll, LocationClu
 
 	private final String text;
 	private final int npcId;
+	@Getter(AccessLevel.PRIVATE)
 	private final WorldPoint location;
 	private final String area;
 	@Nullable
@@ -97,6 +99,12 @@ public class CipherClue extends ClueScroll implements NpcClueScroll, LocationClu
 		this.area = area;
 		this.question = question;
 		this.answer = answer;
+	}
+
+	@Override
+	public WorldPoint getLocation(ClueScrollPlugin plugin)
+	{
+		return location;
 	}
 
 	@Override

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java
@@ -29,6 +29,7 @@ import java.awt.Color;
 import java.awt.Graphics2D;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NonNull;
 import net.runelite.api.Varbits;
@@ -250,6 +251,7 @@ public class CoordinateClue extends ClueScroll implements LocationClueScroll
 		.build();
 
 	private final String text;
+	@Getter(AccessLevel.PRIVATE)
 	private final WorldPoint location;
 	/**
 	 * For regions which are mirrored, the location of the the clue in the mirrored region.
@@ -274,7 +276,13 @@ public class CoordinateClue extends ClueScroll implements LocationClueScroll
 	}
 
 	@Override
-	public WorldPoint[] getLocations()
+	public WorldPoint getLocation(ClueScrollPlugin plugin)
+	{
+		return location;
+	}
+
+	@Override
+	public WorldPoint[] getLocations(ClueScrollPlugin plugin)
 	{
 		if (mirrorLocation != null)
 		{
@@ -311,7 +319,7 @@ public class CoordinateClue extends ClueScroll implements LocationClueScroll
 	@Override
 	public void makeWorldOverlayHint(Graphics2D graphics, ClueScrollPlugin plugin)
 	{
-		for (WorldPoint worldPoint : getLocations())
+		for (WorldPoint worldPoint : getLocations(plugin))
 		{
 			LocalPoint localLocation = LocalPoint.fromWorld(plugin.getClient(), worldPoint);
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java
@@ -269,7 +269,7 @@ public class CrypticClue extends ClueScroll implements NpcClueScroll, ObjectClue
 		new CrypticClue("Thanks, Grandma!", "Tynan", new WorldPoint(1836, 3786, 0), "Tynan can be found in the north-east corner of Port Piscarilius."),
 		new CrypticClue("In a town where everyone has perfect vision, seek some locked drawers in a house that sits opposite a workshop.", "Chicken", DRAWERS_25766, new WorldPoint(2709, 3478, 0), "The Seers' Village house south of the Elemental Workshop entrance. Kill any Chicken to obtain a key."),
 		new CrypticClue("Search the crates in East Ardougne's general store.", CRATE_357, new WorldPoint(2615, 3291, 0), "Located south of the Ardougne church."),
-		new CrypticClue("Come brave adventurer, your sense is on fire. If you talk to me, it's an old god you desire.", "Viggora", null, "Speak to Viggora while wearing a ring of visibility and a Ghostspeak amulet."),
+		new CrypticClue("Come brave adventurer, your sense is on fire. If you talk to me, it's an old god you desire.", "Viggora", -1, CrypticClue::getViggoraLocation, "Speak to Viggora while wearing a ring of visibility and a Ghostspeak amulet.", null),
 		new CrypticClue("2 musical birds. Dig in front of the spinning light.", new WorldPoint(2671, 10396, 0), "Dig in front of the spinning light in Ping and Pong's room inside the Iceberg"),
 		new CrypticClue("Search the wheelbarrow in Rimmington mine.", WHEELBARROW_9625, new WorldPoint(2978, 3239, 0), "The Rimmington mining site is located north of Rimmington."),
 		new CrypticClue("Belladonna, my dear. If only I had gloves, then I could hold you at last.", "Tool Leprechaun", new WorldPoint(3088, 3357, 0), "Talk to Tool Leprechaun at Draynor Manor."),
@@ -335,6 +335,10 @@ public class CrypticClue extends ClueScroll implements NpcClueScroll, ObjectClue
 		new CrypticClue("Try not to let yourself be dazzled when you search these drawers.", DRAWERS_350, new WorldPoint(2561, 3323, 0), "Search the western drawers in Jimmy Dazzler's home near the East Ardougne Rat Pits."),
 		new CrypticClue("The Big High War God left his mark on this place.", new WorldPoint(3572, 4372, 0), "Dig anywhere in Yu'biusk. Fairy ring BLQ.")
 	);
+
+	private static final WorldPoint VIGGORA_ROGUES_CASTLE = new WorldPoint(3295, 3934, 1);
+	private static final WorldPoint VIGGORA_SLAYER_TOWER = new WorldPoint(3447, 3547, 1);
+	private static final WorldPoint VIGGORA_EDGEVILLE_DUNGEON = new WorldPoint(3121, 9995, 0);
 
 	private final String text;
 	private final String npc;
@@ -407,6 +411,7 @@ public class CrypticClue extends ClueScroll implements NpcClueScroll, ObjectClue
 	}
 
 	@Nullable
+	@Override
 	public WorldPoint getLocation(ClueScrollPlugin plugin)
 	{
 		return locationProvider == null ? null : locationProvider.apply(plugin);
@@ -525,5 +530,25 @@ public class CrypticClue extends ClueScroll implements NpcClueScroll, ObjectClue
 	public int[] getConfigKeys()
 	{
 		return new int[]{text.hashCode()};
+	}
+
+	private static WorldPoint getViggoraLocation(ClueScrollPlugin plugin)
+	{
+		int varb = plugin.getClient().getVarbitValue(Varbits.VIGGORA_LOCATION);
+		switch (varb)
+		{
+			case 1:
+				return VIGGORA_ROGUES_CASTLE;
+
+			case 2:
+				return VIGGORA_SLAYER_TOWER;
+
+			case 3:
+				return VIGGORA_EDGEVILLE_DUNGEON;
+
+			default:
+				log.warn("Unknown viggora location for unexpected varb value {}", varb);
+				return null;
+		}
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import lombok.AccessLevel;
 import lombok.Getter;
 import net.runelite.api.Client;
 import static net.runelite.api.EquipmentInventorySlot.AMMO;
@@ -230,6 +231,7 @@ public class EmoteClue extends ClueScroll implements LocationClueScroll
 	private final String locationName;
 	@Nullable
 	private final STASHUnit stashUnit;
+	@Getter(AccessLevel.PRIVATE)
 	private final WorldPoint location;
 	private final Emote firstEmote;
 	private final Emote secondEmote;
@@ -262,6 +264,12 @@ public class EmoteClue extends ClueScroll implements LocationClueScroll
 		this(text, locationName, stashUnit, location, firstEmote, secondEmote, itemRequirements);
 		setRequiresLight(true);
 		setFirePitVarbitId(firePitVarbitId);
+	}
+
+	@Override
+	public WorldPoint getLocation(ClueScrollPlugin plugin)
+	{
+		return location;
 	}
 
 	@Override

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/FairyRingClue.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/FairyRingClue.java
@@ -38,7 +38,6 @@ import net.runelite.client.ui.overlay.components.LineComponent;
 import net.runelite.client.ui.overlay.components.PanelComponent;
 import net.runelite.client.ui.overlay.components.TitleComponent;
 
-@Getter
 public class FairyRingClue extends ClueScroll implements LocationClueScroll
 {
 	static final List<FairyRingClue> CLUES = ImmutableList.of(
@@ -54,6 +53,7 @@ public class FairyRingClue extends ClueScroll implements LocationClueScroll
 		new FairyRingClue("D K S 2 3 1 0", new WorldPoint(2747, 3720, 0))
 	);
 
+	@Getter
 	private final String text;
 	private final WorldPoint location;
 
@@ -62,6 +62,12 @@ public class FairyRingClue extends ClueScroll implements LocationClueScroll
 		this.text = text;
 		this.location = location;
 		setRequiresSpade(true);
+	}
+
+	@Override
+	public WorldPoint getLocation(ClueScrollPlugin plugin)
+	{
+		return location;
 	}
 
 	@Override
@@ -84,7 +90,7 @@ public class FairyRingClue extends ClueScroll implements LocationClueScroll
 	@Override
 	public void makeWorldOverlayHint(Graphics2D graphics, ClueScrollPlugin plugin)
 	{
-		LocalPoint localLocation = LocalPoint.fromWorld(plugin.getClient(), getLocation());
+		LocalPoint localLocation = LocalPoint.fromWorld(plugin.getClient(), getLocation(plugin));
 
 		if (localLocation == null)
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/HotColdClue.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/HotColdClue.java
@@ -34,6 +34,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
+import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -70,6 +71,7 @@ public class HotColdClue extends ClueScroll implements LocationClueScroll, Locat
 	private final String text;
 	private final String npc;
 	private final String solution;
+	@Getter(AccessLevel.PRIVATE)
 	private final WorldPoint npcLocation;
 	@Nullable
 	private HotColdSolver hotColdSolver;
@@ -102,7 +104,13 @@ public class HotColdClue extends ClueScroll implements LocationClueScroll, Locat
 	}
 
 	@Override
-	public WorldPoint[] getLocations()
+	public WorldPoint getLocation(ClueScrollPlugin plugin)
+	{
+		return location;
+	}
+
+	@Override
+	public WorldPoint[] getLocations(ClueScrollPlugin plugin)
 	{
 		if (hotColdSolver == null)
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/LocationClueScroll.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/LocationClueScroll.java
@@ -25,14 +25,15 @@
 package net.runelite.client.plugins.cluescrolls.clues;
 
 import net.runelite.api.coords.WorldPoint;
+import net.runelite.client.plugins.cluescrolls.ClueScrollPlugin;
 
 public interface LocationClueScroll
 {
-	WorldPoint getLocation();
+	WorldPoint getLocation(ClueScrollPlugin plugin);
 
-	default WorldPoint[] getLocations()
+	default WorldPoint[] getLocations(ClueScrollPlugin plugin)
 	{
-		WorldPoint location = getLocation();
+		WorldPoint location = getLocation(plugin);
 		return location == null ? new WorldPoint[0] : new WorldPoint[]{location};
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/LocationsClueScroll.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/LocationsClueScroll.java
@@ -25,10 +25,11 @@
 package net.runelite.client.plugins.cluescrolls.clues;
 
 import net.runelite.api.coords.WorldPoint;
+import net.runelite.client.plugins.cluescrolls.ClueScrollPlugin;
 
 public interface LocationsClueScroll
 {
 	void reset();
 
-	WorldPoint[] getLocations();
+	WorldPoint[] getLocations(ClueScrollPlugin plugin);
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/MapClue.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/MapClue.java
@@ -28,6 +28,7 @@ import com.google.common.collect.ImmutableList;
 import java.awt.Color;
 import java.awt.Graphics2D;
 import java.util.List;
+import lombok.AccessLevel;
 import lombok.Getter;
 import static net.runelite.api.ItemID.*;
 import net.runelite.api.ObjectComposition;
@@ -95,6 +96,7 @@ public class MapClue extends ClueScroll implements ObjectClueScroll
 	);
 
 	private final int itemId;
+	@Getter(AccessLevel.PRIVATE)
 	private final WorldPoint location;
 	private final int objectId;
 	private final String description;
@@ -116,6 +118,12 @@ public class MapClue extends ClueScroll implements ObjectClueScroll
 		this.objectId = objectId;
 		this.description = description;
 		setRequiresSpade(objectId == -1);
+	}
+
+	@Override
+	public WorldPoint getLocation(ClueScrollPlugin plugin)
+	{
+		return location;
 	}
 
 	@Override

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/MusicClue.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/MusicClue.java
@@ -106,7 +106,7 @@ public class MusicClue extends ClueScroll implements NpcClueScroll, LocationClue
 	}
 
 	@Override
-	public WorldPoint getLocation()
+	public WorldPoint getLocation(ClueScrollPlugin plugin)
 	{
 		return LOCATION;
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/ThreeStepCrypticClue.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/ThreeStepCrypticClue.java
@@ -160,17 +160,17 @@ public class ThreeStepCrypticClue extends ClueScroll implements ObjectClueScroll
 	}
 
 	@Override
-	public WorldPoint getLocation()
+	public WorldPoint getLocation(ClueScrollPlugin plugin)
 	{
 		return null;
 	}
 
 	@Override
-	public WorldPoint[] getLocations()
+	public WorldPoint[] getLocations(ClueScrollPlugin plugin)
 	{
 		return clueSteps.stream()
 			.filter(s -> !s.getValue())
-			.map(s -> s.getKey().getLocation())
+			.map(s -> s.getKey().getLocation(plugin))
 			.filter(Objects::nonNull)
 			.toArray(WorldPoint[]::new);
 	}

--- a/runelite-client/src/test/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClueTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClueTest.java
@@ -24,14 +24,45 @@
  */
 package net.runelite.client.plugins.cluescrolls.clues;
 
+import net.runelite.api.Client;
+import net.runelite.api.Varbits;
+import net.runelite.client.plugins.cluescrolls.ClueScrollPlugin;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import static org.mockito.Mockito.when;
+import org.mockito.junit.MockitoJUnitRunner;
 
+@RunWith(MockitoJUnitRunner.class)
 public class CrypticClueTest
 {
+	@Mock
+	private ClueScrollPlugin plugin;
+
+	@Mock
+	private Client client;
+
 	@Test
 	public void forTextEmptyString()
 	{
 		assertNull(CrypticClue.forText(""));
+	}
+
+	@Test
+	public void forViggoraLocations()
+	{
+		when(plugin.getClient()).thenReturn(client);
+		when(client.getVarbitValue(Varbits.VIGGORA_LOCATION)).thenReturn(0, 1, 2, 3, 4);
+
+		CrypticClue clue = CrypticClue.forText("Come brave adventurer, your sense is on fire. If you talk to me, it's an old god you desire.");
+		assert clue != null;
+
+		assertNull(clue.getLocation(plugin));
+		assertNotNull(clue.getLocation(plugin));
+		assertNotNull(clue.getLocation(plugin));
+		assertNotNull(clue.getLocation(plugin));
+		assertNull(clue.getLocation(plugin));
 	}
 }

--- a/runelite-client/src/test/java/net/runelite/client/plugins/cluescrolls/clues/ThreeStepCrypticClueTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/cluescrolls/clues/ThreeStepCrypticClueTest.java
@@ -25,6 +25,8 @@
 package net.runelite.client.plugins.cluescrolls.clues;
 
 import com.google.common.base.Joiner;
+import net.runelite.api.Client;
+import net.runelite.api.Varbits;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.client.plugins.cluescrolls.ClueScrollPlugin;
 import net.runelite.client.util.Text;
@@ -33,6 +35,7 @@ import static org.junit.Assert.assertNull;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import static org.mockito.Mockito.when;
 import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -40,6 +43,9 @@ public class ThreeStepCrypticClueTest
 {
 	@Mock
 	private ClueScrollPlugin plugin;
+
+	@Mock
+	private Client client;
 
 	@Test
 	public void forTextEmptyString()
@@ -50,6 +56,9 @@ public class ThreeStepCrypticClueTest
 	@Test
 	public void nonNullLocations()
 	{
+		when(plugin.getClient()).thenReturn(client);
+		when(client.getVarbitValue(Varbits.VIGGORA_LOCATION)).thenReturn(1);
+
 		final String clueText = Joiner.on("<br><br>").join(CrypticClue.CLUES.stream().map(CrypticClue::getText).toArray());
 		final ThreeStepCrypticClue clue = ThreeStepCrypticClue.forText(Text.sanitizeMultilineText(clueText).toLowerCase(), clueText);
 

--- a/runelite-client/src/test/java/net/runelite/client/plugins/cluescrolls/clues/ThreeStepCrypticClueTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/cluescrolls/clues/ThreeStepCrypticClueTest.java
@@ -26,13 +26,21 @@ package net.runelite.client.plugins.cluescrolls.clues;
 
 import com.google.common.base.Joiner;
 import net.runelite.api.coords.WorldPoint;
+import net.runelite.client.plugins.cluescrolls.ClueScrollPlugin;
 import net.runelite.client.util.Text;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 
+@RunWith(MockitoJUnitRunner.class)
 public class ThreeStepCrypticClueTest
 {
+	@Mock
+	private ClueScrollPlugin plugin;
+
 	@Test
 	public void forTextEmptyString()
 	{
@@ -46,7 +54,7 @@ public class ThreeStepCrypticClueTest
 		final ThreeStepCrypticClue clue = ThreeStepCrypticClue.forText(Text.sanitizeMultilineText(clueText).toLowerCase(), clueText);
 
 		assertNotNull(clue);
-		for (final WorldPoint location : clue.getLocations())
+		for (final WorldPoint location : clue.getLocations(plugin))
 		{
 			assertNotNull(location);
 		}


### PR DESCRIPTION
Adds support for dynamic locations in the LocationClueScroll and LocationsClueScroll types, by exposing a ClueScrollPlugin instance as a parameter.

Also uses this to determine Viggora's location by varbit 815 and show the appropriate one.

Closes runelite#2142