### PR TITLE
added option for including tax with GE price

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemprices/ItemPricesConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemprices/ItemPricesConfig.java
@@ -96,4 +96,15 @@ public interface ItemPricesConfig extends Config
 	{
 		return true;
 	}
+
+	@ConfigItem(
+		keyName = "includeTax",
+		name = "Include GE tax",
+		description = "Includes the GE tax when displaying the value of an item and when calculating High Alch profit.",
+		position = 7
+	)
+	default boolean includeTax()
+	{
+		return false;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemprices/ItemPricesOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemprices/ItemPricesOverlay.java
@@ -241,6 +241,10 @@ class ItemPricesOverlay extends Overlay
 		{
 			gePrice = itemManager.getItemPrice(id);
 		}
+		if (config.includeTax())
+		{
+			geprice -= (int)(gePrice * 0.01);
+		}
 		if (config.showHAValue())
 		{
 			haPrice = itemHaPrice;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemprices/ItemPricesOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemprices/ItemPricesOverlay.java
@@ -243,7 +243,7 @@ class ItemPricesOverlay extends Overlay
 		}
 		if (config.includeTax())
 		{
-			gePrice -= (int)(gePrice * 0.01);
+			gePrice -= Math.min((int)(gePrice * 0.01), 5_000_000);
 		}
 		if (config.showHAValue())
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemprices/ItemPricesOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemprices/ItemPricesOverlay.java
@@ -243,7 +243,7 @@ class ItemPricesOverlay extends Overlay
 		}
 		if (config.includeTax())
 		{
-			geprice -= (int)(gePrice * 0.01);
+			gePrice -= (int)(gePrice * 0.01);
 		}
 		if (config.showHAValue())
 		{


### PR DESCRIPTION
Includes an option for the highlight GE value to include the tax put on the item.

## Reasoning:
The purpose of this is to give better insight to a player from a selling perspective, such as on a slayer task. For example, the player receives a drop that goes for 60k on the GE and also alchs for 60k, normally the plugin would display a loss due to the cost of the nature rune. But by taking the GE tax into account the actual amount that the player will make when selling it to the GE will be `60000 - floor(60000 * 0.01) -> 60000 - 600 = 59400`. For a player that micromanages the liquidation of their drops, it might now be more interesting to high alch the item instead of selling it on the GE.

## Limitation:
the current way I implemented the GE tax is very simple and does not take into account the items exempt from GE tax. However, when I look at the list of [exempt items](https://oldschool.runescape.wiki/w/Category:Items_exempt_from_Grand_Exchange_tax), i think that the impact is minimal. It could be made more precise if a look up for this list of items existed so that applying the GE tax can be skipped for these items, but to my knowledge there isn't one.

resolves: https://github.com/runelite/runelite/discussions/15002