### PR TITLE
profiles panel: add tooltip to duplicate button and new/import profile button explaining why it's disabled

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/ProfilePanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/ProfilePanel.java
@@ -298,7 +298,9 @@ class ProfilePanel extends PluginPanel
 			}
 
 			addButton.setEnabled(!limited);
+			addButton.setToolTipText(limited ? "disabled - at " + MAX_PROFILES + " profile limit" : null);
 			importButton.setEnabled(!limited);
+			importButton.setToolTipText(limited ? "disabled - at " + MAX_PROFILES + " profile limit" : null);
 
 			profilesList.revalidate();
 		});
@@ -395,7 +397,7 @@ class ProfilePanel extends PluginPanel
 				btns.add(rename);
 
 				JButton clone = new JButton(CLONE_ICON);
-				clone.setToolTipText("Duplicate profile");
+				clone.setToolTipText("Duplicate profile" + (limited ? " (disabled - at " + MAX_PROFILES + " profile limit)" : ""));
 				SwingUtil.removeButtonDecorations(clone);
 				clone.addActionListener(ev -> cloneProfile(profile));
 				clone.setEnabled(!limited);


### PR DESCRIPTION
I didn't realize why it had randomly disabled itself for me, a tooltip will help people understand that they should delete some of their profiles