### PR TITLE
Remove Tree Gnome Village requirement from Hard Western Provinces diary task

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/WesternDiaryRequirement.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/WesternDiaryRequirement.java
@@ -122,8 +122,7 @@ public class WesternDiaryRequirement extends GenericDiaryRequirement
 			new SkillRequirement(Skill.MAGIC, 64),
 			new QuestRequirement(Quest.RECIPE_FOR_DISASTER, true));
 		add("Pickpocket a Gnome.",
-			new SkillRequirement(Skill.THIEVING, 75),
-			new QuestRequirement(Quest.TREE_GNOME_VILLAGE));
+			new SkillRequirement(Skill.THIEVING, 75));
 
 		// ELITE
 		add("Fletch a Magic Longbow in Tirannwn.",


### PR DESCRIPTION
Both RuneLite and the Wiki had it wrong for a while that Tree Gnome Village is required to pickpocket gnomes. There's plenty of them roaming around in the Stronghold that can be pickpocketed just fine without the quest being completed and having only 75 thieving.