### PR TITLE
reportbutton: Add ability to track total login time

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/reportbutton/ReportButtonConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/reportbutton/ReportButtonConfig.java
@@ -50,4 +50,14 @@ public interface ReportButtonConfig extends Config
 	{
 		return TimeFormat.TIME_12H;
 	}
+
+	@ConfigItem(
+			keyName = "useTotalLoginTime",
+			name = "Show total time logged in",
+			description = "Only reset the login timer when RuneLite is closed."
+	)
+	default boolean useTotalLoginTime()
+	{
+		return false;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/reportbutton/ReportButtonConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/reportbutton/ReportButtonConfig.java
@@ -50,14 +50,4 @@ public interface ReportButtonConfig extends Config
 	{
 		return TimeFormat.TIME_12H;
 	}
-
-	@ConfigItem(
-			keyName = "useTotalLoginTime",
-			name = "Show total time logged in",
-			description = "Only reset the login timer when RuneLite is closed."
-	)
-	default boolean useTotalLoginTime()
-	{
-		return false;
-	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/reportbutton/ReportButtonPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/reportbutton/ReportButtonPlugin.java
@@ -66,7 +66,6 @@ public class ReportButtonPlugin extends Plugin
 	private DateTimeFormatter timeFormat;
 	private Instant loginTime;
 	private int ticksSinceLogin;
-	private int totalTicks = 0;
 	private boolean ready;
 
 	@Inject
@@ -131,7 +130,6 @@ public class ReportButtonPlugin extends Plugin
 	public void onGameTick(GameTick tick)
 	{
 		ticksSinceLogin++;
-		totalTicks++;
 
 		if (config.time() == TimeStyle.GAME_TICKS)
 		{
@@ -184,6 +182,9 @@ public class ReportButtonPlugin extends Plugin
 			case LOGIN_TIME:
 				reportButton.setText(getLoginTime());
 				break;
+			case TOTAL_LOGIN_TIME:
+				reportButton.setText(getTotalTimeLoggedIn());
+				break;
 			case IDLE_TIME:
 				reportButton.setText(getIdleTime());
 				break;
@@ -209,7 +210,14 @@ public class ReportButtonPlugin extends Plugin
 			return "Report";
 		}
 
-		Duration duration = config.useTotalLoginTime() ? Duration.ofMillis((long) totalTicks * Constants.GAME_TICK_LENGTH) : Duration.between(loginTime, Instant.now());
+		Duration duration = Duration.between(loginTime, Instant.now());
+		LocalTime time = LocalTime.ofSecondOfDay(duration.getSeconds());
+		return time.format(DateTimeFormatter.ofPattern("HH:mm:ss"));
+	}
+
+	private String getTotalTimeLoggedIn()
+	{
+		Duration duration = Duration.ofMillis((long) client.getTickCount() * Constants.GAME_TICK_LENGTH);
 		LocalTime time = LocalTime.ofSecondOfDay(duration.getSeconds());
 		return time.format(DateTimeFormatter.ofPattern("HH:mm:ss"));
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/reportbutton/ReportButtonPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/reportbutton/ReportButtonPlugin.java
@@ -183,7 +183,7 @@ public class ReportButtonPlugin extends Plugin
 				reportButton.setText(getLoginTime());
 				break;
 			case TOTAL_LOGIN_TIME:
-				reportButton.setText(getTotalTimeLoggedIn());
+				reportButton.setText(getTotalLoginTime());
 				break;
 			case IDLE_TIME:
 				reportButton.setText(getIdleTime());
@@ -215,7 +215,7 @@ public class ReportButtonPlugin extends Plugin
 		return time.format(DateTimeFormatter.ofPattern("HH:mm:ss"));
 	}
 
-	private String getTotalTimeLoggedIn()
+	private String getTotalLoginTime()
 	{
 		Duration duration = Duration.ofMillis((long) client.getTickCount() * Constants.GAME_TICK_LENGTH);
 		LocalTime time = LocalTime.ofSecondOfDay(duration.getSeconds());

--- a/runelite-client/src/main/java/net/runelite/client/plugins/reportbutton/ReportButtonPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/reportbutton/ReportButtonPlugin.java
@@ -66,6 +66,7 @@ public class ReportButtonPlugin extends Plugin
 	private DateTimeFormatter timeFormat;
 	private Instant loginTime;
 	private int ticksSinceLogin;
+	private int totalTicks = 0;
 	private boolean ready;
 
 	@Inject
@@ -130,6 +131,7 @@ public class ReportButtonPlugin extends Plugin
 	public void onGameTick(GameTick tick)
 	{
 		ticksSinceLogin++;
+		totalTicks++;
 
 		if (config.time() == TimeStyle.GAME_TICKS)
 		{
@@ -207,7 +209,7 @@ public class ReportButtonPlugin extends Plugin
 			return "Report";
 		}
 
-		Duration duration = Duration.between(loginTime, Instant.now());
+		Duration duration = config.useTotalLoginTime() ? Duration.ofMillis((long) totalTicks * Constants.GAME_TICK_LENGTH) : Duration.between(loginTime, Instant.now());
 		LocalTime time = LocalTime.ofSecondOfDay(duration.getSeconds());
 		return time.format(DateTimeFormatter.ofPattern("HH:mm:ss"));
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/reportbutton/TimeStyle.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/reportbutton/TimeStyle.java
@@ -28,6 +28,7 @@ public enum TimeStyle
 {
 	DATE("Date"),
 	LOGIN_TIME("Login Timer"),
+	TOTAL_LOGIN_TIME("Total Login Time"),
 	UTC("UTC Time"),
 	JAGEX("Jagex HQ Time"),
 	LOCAL_TIME("Local Time"),


### PR DESCRIPTION
~Shows total time logged in while RuneLite is open. Useful for when world hopping, the logged in time won't reset now. Defaults to off so the new behavior will not be jarring to existing users.~

Adds separate "Total Login Time" tracker to the Report Abuse button. This records all the time the user has played while RuneLite is open, kind of like Apple's ScreenTime.