### PR TITLE
Pluginhub/filter optimization

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/PluginHubPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/PluginHubPanel.java
@@ -463,7 +463,7 @@ class PluginHubPanel extends PluginPanel
 	private List<PluginItem> plugins = null;
 	private PluginHubManifest.ManifestFull lastManifest;
 	private final Timer filterTimer;
-	private static final int FILTER_DELAY = 250; // in milliseconds
+	private static final int FILTER_DELAY = 400; // in milliseconds
 
 	@Inject
 	PluginHubPanel(

--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/PluginHubPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/PluginHubPanel.java
@@ -35,6 +35,7 @@ import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.Graphics;
 import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
 import java.awt.event.KeyEvent;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
@@ -69,6 +70,7 @@ import javax.swing.KeyStroke;
 import javax.swing.LayoutStyle;
 import javax.swing.ScrollPaneConstants;
 import javax.swing.SwingUtilities;
+import javax.swing.Timer;
 import javax.swing.border.EmptyBorder;
 import javax.swing.border.LineBorder;
 import javax.swing.event.DocumentEvent;
@@ -460,6 +462,8 @@ class PluginHubPanel extends PluginPanel
 	private final JPanel mainPanel;
 	private List<PluginItem> plugins = null;
 	private PluginHubManifest.ManifestFull lastManifest;
+	private final Timer filterTimer;
+	private static final int FILTER_DELAY = 250; // in milliseconds
 
 	@Inject
 	PluginHubPanel(
@@ -500,19 +504,28 @@ class PluginHubPanel extends PluginPanel
 			@Override
 			public void insertUpdate(DocumentEvent e)
 			{
-				filter();
+				filterTimer.restart();
 			}
 
 			@Override
 			public void removeUpdate(DocumentEvent e)
 			{
-				filter();
+				filterTimer.restart();
 			}
 
 			@Override
 			public void changedUpdate(DocumentEvent e)
 			{
+				filterTimer.restart();
+			}
+		});
+		filterTimer = new Timer(FILTER_DELAY, new ActionListener()
+		{
+			@Override
+			public void actionPerformed(ActionEvent e)
+			{
 				filter();
+				filterTimer.stop();
 			}
 		});
 


### PR DESCRIPTION
fixes: #16333

Adds a resetting swing timer to delay calling `filter()` from changes in the search bar to limit delays in partially typed searches from being filtered.
![pluginhub](https://github.com/runelite/runelite/assets/20033077/3ec4af4f-025d-4a43-b74f-c155f4509837)
