### PR TITLE
achievement diary: update ardy picklock task

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/ArdougneDiaryRequirement.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/ArdougneDiaryRequirement.java
@@ -114,7 +114,7 @@ public class ArdougneDiaryRequirement extends GenericDiaryRequirement
 			new SkillRequirement(Skill.FISHING, 81),
 			new SkillRequirement(Skill.COOKING, 91)
 		);
-		add("Attempt to picklock the door to the basement of Yanille Agility Dungeon.",
+		add("Picklock the door to the basement of Yanille Agility Dungeon.",
 			new SkillRequirement(Skill.THIEVING, 82));
 		add("Pickpocket a Hero.",
 			new SkillRequirement(Skill.THIEVING, 80));


### PR DESCRIPTION
As noted in #16761 - the `attempt to` has been removed from the tasks in this diary, so this one needs to be updated as well.


before:
![image](https://github.com/runelite/runelite/assets/41973452/2f995471-5887-4d01-9ab9-34563c7f4786)

after:
![image](https://github.com/runelite/runelite/assets/41973452/257b5733-f2e2-4317-bf0e-8631cc315608)
