### PR TITLE
Add new display formats to the stamina orb

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/runenergy/RunEnergyConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/runenergy/RunEnergyConfig.java
@@ -45,11 +45,31 @@ public interface RunEnergyConfig extends Config
 
 	@ConfigItem(
 		keyName = "replaceOrbText",
-		name = "Replace orb text with run time left",
-		description = "Show the remaining run time (in seconds) next in the energy orb."
+		name = "Orb display",
+		description = "Choose stamina orb display format"
 	)
-	default boolean replaceOrbText()
+	default EnergyDisplayMode runEnergyDisplayMode()
 	{
-		return false;
+		return EnergyDisplayMode.PERCENT;
+	}
+
+	enum EnergyDisplayMode
+	{
+		PERCENT,
+		SECONDS,
+		MINUTES_AND_SECONDS,
+		TICKS;
+
+		@Override
+		public String toString()
+		{
+			switch (this)
+			{
+				case MINUTES_AND_SECONDS:
+					return "MM:SS";
+				default:
+					return name();
+			}
+		}
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/runenergy/RunEnergyOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/runenergy/RunEnergyOverlay.java
@@ -81,15 +81,9 @@ class RunEnergyOverlay extends Overlay
 		{
 			StringBuilder sb = new StringBuilder();
 			sb.append("Weight: ").append(client.getWeight()).append(" kg</br>");
-
-			if (config.replaceOrbText())
-			{
-				sb.append("Run Energy: ").append(client.getEnergy() / 100).append('%');
-			}
-			else
-			{
-				sb.append("Run Time Remaining: ").append(plugin.getEstimatedRunTimeRemaining(false));
-			}
+			sb.append("Current Run Energy: ").append(client.getEnergy() / 100).append("%</br>");
+			sb.append("Estimated Time Remaining: ").append(
+				plugin.getFormattedRunOrbText(RunEnergyConfig.EnergyDisplayMode.MINUTES_AND_SECONDS));
 
 			if (client.getVarbitValue(Varbits.RUN_SLOWED_DEPLETION_ACTIVE) == 0
 				&& plugin.isRingOfEnduranceEquipped()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/runenergy/RunEnergyPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/runenergy/RunEnergyPlugin.java
@@ -175,8 +175,8 @@ public class RunEnergyPlugin extends Plugin
 	{
 		localPlayerRunningToDestination =
 			prevLocalPlayerLocation != null &&
-			client.getLocalDestinationLocation() != null &&
-			prevLocalPlayerLocation.distanceTo(client.getLocalPlayer().getWorldLocation()) > 1;
+				client.getLocalDestinationLocation() != null &&
+				prevLocalPlayerLocation.distanceTo(client.getLocalPlayer().getWorldLocation()) > 1;
 
 		prevLocalPlayerLocation = client.getLocalPlayer().getWorldLocation();
 	}
@@ -184,18 +184,18 @@ public class RunEnergyPlugin extends Plugin
 	@Subscribe
 	public void onScriptPostFired(ScriptPostFired scriptPostFired)
 	{
-		if (scriptPostFired.getScriptId() == ScriptID.ORBS_UPDATE_RUNENERGY && energyConfig.replaceOrbText())
+		if (scriptPostFired.getScriptId() == ScriptID.ORBS_UPDATE_RUNENERGY)
 		{
-			setRunOrbText(getEstimatedRunTimeRemaining(true));
+			setRunOrbText(getFormattedRunOrbText(energyConfig.runEnergyDisplayMode()));
 		}
 	}
 
 	@Subscribe
 	public void onConfigChanged(ConfigChanged event)
 	{
-		if (event.getGroup().equals(RunEnergyConfig.GROUP_NAME) && !energyConfig.replaceOrbText())
+		if (event.getGroup().equals(RunEnergyConfig.GROUP_NAME))
 		{
-			resetRunOrbText();
+			setRunOrbText(getFormattedRunOrbText(energyConfig.runEnergyDisplayMode()));
 		}
 	}
 
@@ -285,7 +285,7 @@ public class RunEnergyPlugin extends Plugin
 		setRunOrbText(Integer.toString(client.getEnergy() / 100));
 	}
 
-	String getEstimatedRunTimeRemaining(boolean inSeconds)
+	int getEstimatedTicksRemaining()
 	{
 		// Calculate the amount of energy lost every tick.
 		// Negative weight has the same depletion effect as 0 kg. >64kg counts as 64kg.
@@ -303,7 +303,7 @@ public class RunEnergyPlugin extends Plugin
 			Integer charges = getRingOfEnduranceCharges();
 			if (charges == null)
 			{
-				return "?";
+				return -1;
 			}
 
 			if (charges >= RING_OF_ENDURANCE_PASSIVE_EFFECT)
@@ -314,18 +314,42 @@ public class RunEnergyPlugin extends Plugin
 
 		// Math.ceil is correct here - only need 1 energy unit to run
 		final double ticksLeft = Math.ceil(client.getEnergy() / (double) energyUnitsLost);
+		return (int) ticksLeft;
+	}
+
+	String getFormattedRunOrbText(RunEnergyConfig.EnergyDisplayMode dispMode)
+	{
+		final int ticksLeft = getEstimatedTicksRemaining();
+
+		if (ticksLeft == -1)
+		{
+			return "Unknown";
+		}
+
 		final double secondsLeft = ticksLeft * Constants.GAME_TICK_LENGTH / 1000.0;
 
 		// Return the text
-		if (inSeconds)
+		if (dispMode == RunEnergyConfig.EnergyDisplayMode.SECONDS)
 		{
 			return (int) Math.floor(secondsLeft) + "s";
 		}
-		else
+		else if (dispMode == RunEnergyConfig.EnergyDisplayMode.PERCENT)
+		{
+			return String.valueOf(client.getEnergy() / 100);
+		}
+		else if (dispMode == RunEnergyConfig.EnergyDisplayMode.TICKS)
+		{
+			return String.valueOf((int) ticksLeft);
+		}
+		else if (dispMode == RunEnergyConfig.EnergyDisplayMode.MINUTES_AND_SECONDS)
 		{
 			final int minutes = (int) Math.floor(secondsLeft / 60.0);
 			final int seconds = (int) Math.floor(secondsLeft - (minutes * 60.0));
 			return minutes + ":" + StringUtils.leftPad(Integer.toString(seconds), 2, "0");
+		}
+		else
+		{
+			throw new RuntimeException("Unexpected value");
 		}
 	}
 

--- a/runelite-client/src/test/java/net/runelite/client/plugins/runenergy/RunEnergyPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/runenergy/RunEnergyPluginTest.java
@@ -149,10 +149,12 @@ public class RunEnergyPluginTest
 		when(equipment.count(RING_OF_ENDURANCE)).thenReturn(1);
 		when(client.getVarbitValue(Varbits.RUN_SLOWED_DEPLETION_ACTIVE)).thenReturn(1);
 		when(client.getEnergy()).thenReturn(10000);
-		assertEquals("300s", runEnergyPlugin.getEstimatedRunTimeRemaining(true));
+		assertEquals("300s",
+			runEnergyPlugin.getFormattedRunOrbText(RunEnergyConfig.EnergyDisplayMode.SECONDS));
 
 		when(client.getVarbitValue(Varbits.RUN_SLOWED_DEPLETION_ACTIVE)).thenReturn(0);
 		when(configManager.getRSProfileConfiguration(RunEnergyConfig.GROUP_NAME, "ringOfEnduranceCharges", Integer.class)).thenReturn(512);
-		assertEquals("1:47", runEnergyPlugin.getEstimatedRunTimeRemaining(false));
+		assertEquals("1:47",
+			runEnergyPlugin.getFormattedRunOrbText(RunEnergyConfig.EnergyDisplayMode.MINUTES_AND_SECONDS));
 	}
 }


### PR DESCRIPTION
This patch adds new display formats to the "Run Energy" plugin `replaceOrbText` config option.

New formats are:
- `percent`, which is the default
- `seconds`, which is the existing option to replace with estimated seconds remaining
- `ticks`, seconds but in game ticks
- `MM:SS`, the above but formatted as MM:SS instead