### PR TITLE
Add PMD Supression for Music Plugin Changes

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/music/MusicPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/music/MusicPlugin.java
@@ -308,6 +308,7 @@ public class MusicPlugin extends Plugin
 	}
 
 	@Subscribe
+	@SuppressWarnings("PMD.UnconditionalIfStatement")  //TODO: Remove PMD Supression
 	public void onVolumeChanged(VolumeChanged volumeChanged)
 	{
 		if (false)
@@ -317,6 +318,7 @@ public class MusicPlugin extends Plugin
 	}
 
 	@Subscribe
+	@SuppressWarnings("PMD.UnconditionalIfStatement") //TODO: Remove PMD Supression
 	public void onConfigChanged(ConfigChanged configChanged)
 	{
 		if (configChanged.getGroup().equals(MusicConfig.GROUP))


### PR DESCRIPTION
Resolve the unhelpful PMD errors breaking the build despite being a minor issue. This patch simply adds a `SuppressWarning` annotation to the two problematic methods which were altered within the `net.runelite.client.plugins.music.MusicPlugin` class in commit 56055a07d48f1da72c2ad1c906cba594432577f8. The suppression approach should be temporary, so a TODO comment was added to make it easier to find the annotations for a more permanent fix in the future.