### PR TITLE
Allow users to show more/less information in Skill Tracker info boxes

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpPanel.java
@@ -190,6 +190,11 @@ class XpPanel extends PluginPanel
 		infoBoxes.forEach((skill, xpInfoBox) -> xpInfoBox.reset());
 	}
 
+	void relayoutInfoBoxes()
+	{
+		infoBoxes.forEach((skill, xpInfoBox) -> xpInfoBox.relayoutStatsPanel());
+	}
+
 	void resetSkill(Skill skill)
 	{
 		XpInfoBox xpInfoBox = infoBoxes.get(skill);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpPanelLabel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpPanelLabel.java
@@ -28,11 +28,14 @@ import java.util.function.Function;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import net.runelite.client.util.QuantityFormatter;
+import org.apache.commons.lang3.StringUtils;
 
 @Getter
 @AllArgsConstructor
 public enum XpPanelLabel
 {
+	NONE(null, unused -> StringUtils.EMPTY),
+
 	TIME_TO_LEVEL("TTL", XpSnapshotSingle::getTimeTillGoalShort),
 
 	XP_GAINED("XP Gained", snap -> format(snap.getXpGainedInSession())),
@@ -55,6 +58,10 @@ public enum XpPanelLabel
 	 */
 	public String getActionKey(XpSnapshotSingle snapshot)
 	{
+		if (this == NONE)
+		{
+			return StringUtils.EMPTY;
+		}
 		String actionKey = key;
 		if (snapshot.getActionType() == XpActionType.ACTOR_HEALTH)
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerConfig.java
@@ -137,8 +137,8 @@ public interface XpTrackerConfig extends Config
 	@ConfigItem(
 		position = 8,
 		keyName = "xpPanelLabel1",
-		name = "Top-left XP info label",
-		description = "Configures the information displayed in the top-left of XP info box"
+		name = "1st XP info label",
+		description = "Configures the information displayed in the first XP info box"
 	)
 	default XpPanelLabel xpPanelLabel1()
 	{
@@ -148,8 +148,8 @@ public interface XpTrackerConfig extends Config
 	@ConfigItem(
 		position = 9,
 		keyName = "xpPanelLabel2",
-		name = "Top-right XP info label",
-		description = "Configures the information displayed in the top-right of XP info box"
+		name = "2nd XP info label",
+		description = "Configures the information displayed in the second XP info box"
 	)
 
 	default XpPanelLabel xpPanelLabel2()
@@ -160,8 +160,8 @@ public interface XpTrackerConfig extends Config
 	@ConfigItem(
 		position = 10,
 		keyName = "xpPanelLabel3",
-		name = "Bottom-left XP info label",
-		description = "Configures the information displayed in the bottom-left of XP info box"
+		name = "3rd XP info label",
+		description = "Configures the information displayed in the third XP info box"
 	)
 	default XpPanelLabel xpPanelLabel3()
 	{
@@ -171,8 +171,8 @@ public interface XpTrackerConfig extends Config
 	@ConfigItem(
 		position = 11,
 		keyName = "xpPanelLabel4",
-		name = "Bottom-right XP info label",
-		description = "Configures the information displayed in the bottom-right of XP info box"
+		name = "4th XP info label",
+		description = "Configures the information displayed in the fourth XP info box"
 	)
 	default XpPanelLabel xpPanelLabel4()
 	{
@@ -181,6 +181,39 @@ public interface XpTrackerConfig extends Config
 
 	@ConfigItem(
 		position = 12,
+		keyName = "xpPanelLabel5",
+		name = "5th XP info label",
+		description = "Configures the information displayed in the fifth XP info box"
+	)
+	default XpPanelLabel xpPanelLabel5()
+	{
+		return XpPanelLabel.NONE;
+	}
+
+	@ConfigItem(
+		position = 13,
+		keyName = "xpPanelLabel6",
+		name = "6th XP info label",
+		description = "Configures the information displayed in the sixth XP info box"
+	)
+	default XpPanelLabel xpPanelLabel6()
+	{
+		return XpPanelLabel.NONE;
+	}
+
+	@ConfigItem(
+		position = 14,
+		keyName = "xpPanelLabel7",
+		name = "7th XP info label",
+		description = "Configures the information displayed in the seventh XP info box"
+	)
+	default XpPanelLabel xpPanelLabel7()
+	{
+		return XpPanelLabel.NONE;
+	}
+
+	@ConfigItem(
+		position = 15,
 		keyName = "progressBarLabel",
 		name = "Progress bar label",
 		description = "Configures the info box progress bar to show Time to goal or percentage complete"
@@ -191,7 +224,7 @@ public interface XpTrackerConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 13,
+		position = 16,
 		keyName = "progressBarTooltipLabel",
 		name = "Tooltip label",
 		description = "Configures the info box progress bar tooltip to show Time to goal or percentage complete"
@@ -202,7 +235,7 @@ public interface XpTrackerConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 14,
+		position = 17,
 		keyName = "prioritizeRecentXpSkills",
 		name = "Move recently trained skills to top",
 		description = "Configures whether skills should be organized by most recently gained xp"
@@ -213,7 +246,7 @@ public interface XpTrackerConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 15,
+		position = 18,
 		keyName = "wiseOldManOpenOption",
 		name = "Wise Old Man Option",
 		description = "Adds an option to the XP info box right-click menu to open Wise Old Man"

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerPlugin.java
@@ -59,6 +59,7 @@ import static net.runelite.api.widgets.WidgetInfo.TO_GROUP;
 import net.runelite.client.callback.ClientThread;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
+import net.runelite.client.events.ConfigChanged;
 import net.runelite.client.game.NPCManager;
 import net.runelite.client.game.SkillIconManager;
 import net.runelite.client.plugins.Plugin;
@@ -369,6 +370,12 @@ public class XpTrackerPlugin extends Plugin
 			xpState.resetSkillPerHour(skill);
 		}
 		xpState.resetOverallPerHour();
+	}
+
+	@Subscribe
+	public void onConfigChanged(ConfigChanged event)
+	{
+		xpPanel.relayoutInfoBoxes();
 	}
 
 	@Subscribe


### PR DESCRIPTION
Allows users to select between 0 to 7 (the number of unique `XpPanelInfo`s available) info labels in the XP Tracker tab.

Adds `XpPanelInfo.NONE` to allow users to omit slots completely.

Example all seven info labels:

![image](https://github.com/runelite/runelite/assets/6396799/740a3f05-7e3d-4b28-ab4e-a44555e2df0d) ![image](https://github.com/runelite/runelite/assets/6396799/1103bc89-c5d0-4874-81e5-64075553a493)

Example for regular four info labels:
![image](https://github.com/runelite/runelite/assets/6396799/3a2b00ab-3dcc-449e-a4fb-1affcab79421) ![image](https://github.com/runelite/runelite/assets/6396799/b7fdb5df-e1f3-4d11-bb31-1bcbc6576a5b)

One info label in the middle of the config:
![image](https://github.com/runelite/runelite/assets/6396799/e105b95d-ad68-44e6-b47b-cf6630f34b5a) ![image](https://github.com/runelite/runelite/assets/6396799/49dd6751-7b73-4a5b-bd16-0caf4a177689)

And of course no labels:
![image](https://github.com/runelite/runelite/assets/6396799/295edf8b-2a32-49cf-94ae-13b4773f8a93) ![image](https://github.com/runelite/runelite/assets/6396799/a0687716-7320-4ddb-9c96-8642a995d335)
