### PR TITLE
chat commands: add calvarion aliases

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
@@ -1966,6 +1966,10 @@ public class ChatCommandsPlugin extends Plugin
 			case "vetion":
 				return "Vet'ion";
 
+			case "calvarion":
+			case "calv":
+				return "Calvar'ion";
+
 			case "vene":
 				return "Venenatis";
 


### PR DESCRIPTION
Adds aliases so Calvar'ion kill count can be checked without apostrophes like Vet'ion.