### PR TITLE
grounditems: add broken arrow/glass to default hidden

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
@@ -78,7 +78,7 @@ public interface GroundItemsConfig extends Config
 	)
 	default String getHiddenItems()
 	{
-		return "Vial, Ashes, Coins, Bones, Bucket, Jug, Seaweed";
+		return "Vial, Ashes, Coins, Bones, Bucket, Jug, Seaweed, Broken arrow, Broken glass";
 	}
 
 	@ConfigItem(


### PR DESCRIPTION
These two items are displayed by default (via "don't hide untradeables"). They are not quite useful for anything and clutter the screen, especially at Ferox Enclave.