### PR TITLE
Clue Scroll: Improve Captain Bruce clue location and clue hint.

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java
@@ -759,8 +759,8 @@ public class AnagramClue extends ClueScroll implements NpcClueScroll, ObjectClue
 		AnagramClue.builder()
 			.text("BRUCIE CATNAP")
 			.npc("Captain Bruce")
-			.location(new WorldPoint(1520, 3558, 0))
-			.area("Graveyard of Heroes")
+			.location(new WorldPoint(1529, 3567, 0))
+			.area("East of Shayzien Graveyard")
 			.build(),
 		AnagramClue.builder()
 			.text("UESNKRL NRIEDDO")


### PR DESCRIPTION
Another clue, `TWENTY CURE IRON` uses "Shayzien Graveyard", and I think it's clearer that way than "Graveyard of Heroes".

This also fixes his location to be more accurate (world hopped through 3 world, he is in the northeast room each time).

Fixes #16860