### PR TITLE
Add PluginMessage event

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/events/PluginMessage.java
+++ b/runelite-client/src/main/java/net/runelite/client/events/PluginMessage.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2023, jocopa3
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.events;
+
+import java.util.Collections;
+import java.util.Map;
+import lombok.NonNull;
+import lombok.Value;
+import net.runelite.client.plugins.Plugin;
+
+@Value
+public class PluginMessage
+{
+    private final Plugin source;
+    private final String messageName;
+    private final Map<String, Object> messageData;
+
+    public PluginMessage(@NonNull final Plugin source, @NonNull final String messageName)
+    {
+        this.source = source;
+        this.messageName = messageName;
+        messageData = Collections.emptyMap();
+    }
+
+    public PluginMessage(@NonNull final Plugin source, @NonNull final String messageName, @NonNull final Map<String, Object> data)
+    {
+        this.source = source;
+        this.messageName = messageName;
+        this.messageData = Map.copyOf(data);
+    }
+}

--- a/runelite-client/src/main/java/net/runelite/client/events/PluginMessage.java
+++ b/runelite-client/src/main/java/net/runelite/client/events/PluginMessage.java
@@ -6,10 +6,10 @@
  * modification, are permitted provided that the following conditions are met:
  *
  * 1. Redistributions of source code must retain the above copyright notice, this
- *    list of conditions and the following disclaimer.
+ *	list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
+ *	this list of conditions and the following disclaimer in the documentation
+ *	and/or other materials provided with the distribution.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
@@ -30,24 +30,25 @@ import lombok.NonNull;
 import lombok.Value;
 import net.runelite.client.plugins.Plugin;
 
+
 @Value
 public class PluginMessage
 {
-    private final Plugin source;
-    private final String messageName;
-    private final Map<String, Object> messageData;
+	private final Plugin source;
+	private final String messageName;
+	private final Map<String, Object> messageData;
 
-    public PluginMessage(@NonNull final Plugin source, @NonNull final String messageName)
-    {
-        this.source = source;
-        this.messageName = messageName;
-        messageData = Collections.emptyMap();
-    }
+	public PluginMessage(@NonNull final Plugin source, @NonNull final String messageName)
+	{
+		this.source = source;
+		this.messageName = messageName;
+		messageData = Collections.emptyMap();
+	}
 
-    public PluginMessage(@NonNull final Plugin source, @NonNull final String messageName, @NonNull final Map<String, Object> data)
-    {
-        this.source = source;
-        this.messageName = messageName;
-        this.messageData = Map.copyOf(data);
-    }
+	public PluginMessage(@NonNull final Plugin source, @NonNull final String messageName, @NonNull final Map<String, Object> data)
+	{
+		this.source = source;
+		this.messageName = messageName;
+		this.messageData = Map.copyOf(data);
+	}
 }


### PR DESCRIPTION
A simple way for plugins to communicate over the `EventBus` while allowing listeners to know the source plugin and filter by `messageName`. While it's already possible to do this by e.g. posting/subscribing to String, HashMap, etc., providing a proper object for EventBus communication simplifies the problem and makes it possible to identify the event source.

This makes no attempt to verify objects in the data map are visible to other classloaders.

### Example Usage

**Event Posting:**
```java
Map<String, Object> data = new HashMap<>();
data.put("location", new WorldPoint(x, y, plane));
eventBus.post(new PluginMessage(this, "example:doThing", data));
```

**Subscriber:**
```java
@Subscribe
public void onPluginMessage(PluginMessage message)
{
    String messageName = message.getMessageName();
    if (!messageName.startsWith("example:"))
    {
        return;
    }

    String command = messageName.substring(messageName.indexOf(':') + 1);
    if (command.equals("doThing"))
    {
        WorldPoint location = (WorldPoint) message.getMessageData().get("location");
        doThing(location);
    }
}
```