### PR TITLE
chat commands: update dt2 boss commands

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
@@ -2467,11 +2467,14 @@ public class ChatCommandsPlugin extends Plugin
 
 			// Desert Treasure 2 bosses
 			case "the leviathan":
+			case "levi":
 				return "Leviathan";
 			case "duke":
 				return "Duke Sucellus";
 			case "the whisperer":
 				return "Whisperer";
+			case "vard":
+				return "Vardorvis";
 
 			default:
 				return WordUtils.capitalize(boss);


### PR DESCRIPTION
This change updates the boss commands to display capitalized, to match the highscores boss capitalization, as well as add some other shorthand names for bosses.