### PR TITLE
Fix NPC aggression timer not enabling properly when on a slayer task

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/npcunaggroarea/NpcAggroAreaPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npcunaggroarea/NpcAggroAreaPlugin.java
@@ -322,7 +322,7 @@ public class NpcAggroAreaPlugin extends Plugin
 		checkAreaNpcs(client.getCachedNPCs());
 	}
 
-	@Subscribe
+	@Subscribe(priority = -1) // run after slayer plugin so targets has time to populate
 	public void onNpcSpawned(NpcSpawned event)
 	{
 		if (config.alwaysActive())


### PR DESCRIPTION
Bug behavior:
When on a slayer task the "NPC Aggression Timer" should become active if the config "Show on slayer task" is enabled. This has been observed to only work sporadically, unless the user manually disabled and re-enabled the option while on task.

Expected behavior:
When on a slayer task the "NPC Aggression Timer" should consistently become active when "Show on slayer task" is enabled.

Issue found:
NPC aggression timer was receiving NPC spawn events before slayer plugin was, so the target check was failing. Changing the priority in NPC aggression timer fixed the issue.