### PR TITLE
Add accursed sceptre to ranged spec weapons

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/specialcounter/SpecialCounterConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/specialcounter/SpecialCounterConfig.java
@@ -131,4 +131,15 @@ public interface SpecialCounterConfig extends Config
 	{
 		return 0;
 	}
+
+	@ConfigItem(
+		position = 60,
+		keyName = "accursedSceptreThreshold",
+		name = "Accursed sceptre",
+		description = "Threshold for Accursed sceptre (0 to disable)"
+	)
+	default int accursedSceptreThreshold()
+	{
+		return 0;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/specialcounter/SpecialCounterPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/specialcounter/SpecialCounterPlugin.java
@@ -488,8 +488,9 @@ public class SpecialCounterPlugin extends Plugin
 
 	private int getHitDelay(SpecialWeapon specialWeapon, Actor target)
 	{
-		// DORGESHUUN_CROSSBOW is the only ranged wep we support, so everything else is just melee and delay 1
-		if (specialWeapon != SpecialWeapon.DORGESHUUN_CROSSBOW || target == null)
+		// DORGESHUUN_CROSSBOW and ACCURSED_SCEPTRE are the only ranged wep we support, so everything else is just melee and delay 1
+		// In the future with more ranged weapons, we'll add it to the config to differentiate
+		if ((specialWeapon != SpecialWeapon.DORGESHUUN_CROSSBOW && specialWeapon != SpecialWeapon.ACCURSED_SCEPTRE) || target == null)
 			return 1;
 
 		Player player = client.getLocalPlayer();

--- a/runelite-client/src/main/java/net/runelite/client/plugins/specialcounter/SpecialWeapon.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/specialcounter/SpecialWeapon.java
@@ -40,6 +40,7 @@ public enum SpecialWeapon
 	BARRELCHEST_ANCHOR("Barrelchest Anchor", new int[]{ItemID.BARRELCHEST_ANCHOR}, true, (c) -> 0),
 	BONE_DAGGER("Bone Dagger", new int[]{ItemID.BONE_DAGGER, ItemID.BONE_DAGGER_P, ItemID.BONE_DAGGER_P_8876, ItemID.BONE_DAGGER_P_8878}, true, (c) -> 0),
 	DORGESHUUN_CROSSBOW("Dorgeshuun Crossbow", new int[]{ItemID.DORGESHUUN_CROSSBOW}, true, (c) -> 0),
+	ACCURSED_SCEPTRE("Accursed sceptre", new int[]{ItemID.ACCURSED_SCEPTRE, ItemID.ACCURSED_SCEPTRE_A, ItemID.ACCURSED_SCEPTRE_AU, ItemID.ACCURSED_SCEPTRE_U}, false, SpecialCounterConfig::accursedSceptreThreshold),
 	BULWARK("Dinh's Bulwark", new int[]{ItemID.DINHS_BULWARK}, false, SpecialCounterConfig::bulwarkThreshold);
 
 	private final String name;


### PR DESCRIPTION
This PR is just a quick band-aid to allow for tracking of the Accursed Sceptre specs as a ranged weapon. It may not be entirely accurate on the getHitDelay() timing due to the calculation for cycles potentially being different for accursed sceptre vs dorgeshuun crossbow. 