### PR TITLE
inventorytags: Add colors of equipped items to Inventory Tag submenu

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/inventorytags/InventoryTagsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/inventorytags/InventoryTagsPlugin.java
@@ -37,6 +37,8 @@ import javax.swing.SwingUtilities;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.InventoryID;
+import static net.runelite.api.InventoryID.EQUIPMENT;
+import static net.runelite.api.InventoryID.INVENTORY;
 import net.runelite.api.Item;
 import net.runelite.api.ItemContainer;
 import net.runelite.api.KeyCode;
@@ -186,8 +188,8 @@ public class InventoryTagsPlugin extends Plugin
 					.setType(MenuAction.RUNELITE_SUBMENU);
 
 				Set<Color> invEquipmentColors = new HashSet<>();
-				invEquipmentColors.addAll(invColors());
-				invEquipmentColors.addAll(equipmentColors());
+				invEquipmentColors.addAll(getColorsFromItemContainer(INVENTORY));
+				invEquipmentColors.addAll(getColorsFromItemContainer(EQUIPMENT));
 				for (Color color : invEquipmentColors)
 				{
 					if (tag == null || !tag.color.equals(color))
@@ -238,17 +240,7 @@ public class InventoryTagsPlugin extends Plugin
 		}
 	}
 
-	private List<Color> invColors()
-	{
-		return getTagsFromItemContainer(InventoryID.INVENTORY);
-	}
-
-	private List<Color> equipmentColors()
-	{
-		return getTagsFromItemContainer(InventoryID.EQUIPMENT);
-	}
-
-	private List<Color> getTagsFromItemContainer(InventoryID inventoryID)
+	private List<Color> getColorsFromItemContainer(InventoryID inventoryID)
 	{
 		List<Color> colors = new ArrayList<>();
 		ItemContainer container = client.getItemContainer(inventoryID);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/inventorytags/InventoryTagsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/inventorytags/InventoryTagsPlugin.java
@@ -29,7 +29,9 @@ import com.google.inject.Provides;
 import java.applet.Applet;
 import java.awt.Color;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import javax.inject.Inject;
 import javax.swing.SwingUtilities;
 import lombok.extern.slf4j.Slf4j;
@@ -183,7 +185,10 @@ public class InventoryTagsPlugin extends Plugin
 					.setTarget(entry.getTarget())
 					.setType(MenuAction.RUNELITE_SUBMENU);
 
-				for (Color color : invColors())
+				Set<Color> invEquipmentColors = new HashSet<>();
+				invEquipmentColors.addAll(invColors());
+				invEquipmentColors.addAll(equipmentColors());
+				for (Color color : invEquipmentColors)
 				{
 					if (tag == null || !tag.color.equals(color))
 					{
@@ -235,8 +240,18 @@ public class InventoryTagsPlugin extends Plugin
 
 	private List<Color> invColors()
 	{
+		return getTagsFromItemContainer(InventoryID.INVENTORY);
+	}
+
+	private List<Color> equipmentColors()
+	{
+		return getTagsFromItemContainer(InventoryID.EQUIPMENT);
+	}
+
+	private List<Color> getTagsFromItemContainer(InventoryID inventoryID)
+	{
 		List<Color> colors = new ArrayList<>();
-		ItemContainer container = client.getItemContainer(InventoryID.INVENTORY);
+		ItemContainer container = client.getItemContainer(inventoryID);
 		for (Item item : container.getItems())
 		{
 			Tag tag = getTag(item.getId());


### PR DESCRIPTION
Before this, the sub-menu to add tags when you shift-click on an item only pulled up colors of tagged inventory items, and not colors of tagged equipped items. Now it will consider both inventory and equipped item tags.