### PR TITLE
object markers: add fill color to object markers

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/objectindicators/ColorTileObject.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/objectindicators/ColorTileObject.java
@@ -52,6 +52,7 @@ class ColorTileObject
 	 * Name to highlight for multilocs
 	 */
 	private final String name;
-	private final Color color;
+	private final Color borderColor;
+	private final Color fillColor;
 	byte highlightFlags;
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/objectindicators/ObjectIndicatorsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/objectindicators/ObjectIndicatorsConfig.java
@@ -94,7 +94,7 @@ public interface ObjectIndicatorsConfig extends Config
 	@Alpha
 	@ConfigItem(
 		position = 4,
-		keyName = "borderColor",
+		keyName = "markerColor",
 		name = "Border color",
 		description = "Configures the border color of an object marker",
 		section = renderStyleSection

--- a/runelite-client/src/main/java/net/runelite/client/plugins/objectindicators/ObjectIndicatorsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/objectindicators/ObjectIndicatorsConfig.java
@@ -94,18 +94,31 @@ public interface ObjectIndicatorsConfig extends Config
 	@Alpha
 	@ConfigItem(
 		position = 4,
-		keyName = "markerColor",
-		name = "Marker color",
-		description = "Configures the color of object marker",
+		keyName = "borderColor",
+		name = "Border color",
+		description = "Configures the border color of an object marker",
 		section = renderStyleSection
 	)
-	default Color markerColor()
+	default Color borderColor()
 	{
 		return Color.YELLOW;
 	}
 
+	@Alpha
 	@ConfigItem(
 		position = 5,
+		keyName = "fillColor",
+		name = "Fill color",
+		description = "Configures the fill color of an object marker",
+		section = renderStyleSection
+	)
+	default Color fillColor()
+	{
+		return new Color(255, 255, 0, 0);
+	}
+
+	@ConfigItem(
+		position = 6,
 		keyName = "borderWidth",
 		name = "Border Width",
 		description = "Width of the marked object border",
@@ -117,7 +130,7 @@ public interface ObjectIndicatorsConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 6,
+		position = 7,
 		keyName = "outlineFeather",
 		name = "Outline feather",
 		description = "Specify between 0-4 how much of the model outline should be faded",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/objectindicators/ObjectIndicatorsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/objectindicators/ObjectIndicatorsOverlay.java
@@ -50,7 +50,6 @@ import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.OverlayPriority;
 import net.runelite.client.ui.overlay.OverlayUtil;
 import net.runelite.client.ui.overlay.outline.ModelOutlineRenderer;
-import net.runelite.client.util.ColorUtil;
 
 class ObjectIndicatorsOverlay extends Overlay
 {
@@ -90,7 +89,8 @@ class ObjectIndicatorsOverlay extends Overlay
 		for (ColorTileObject obj : objects)
 		{
 			TileObject object = obj.getTileObject();
-			Color color = obj.getColor();
+			Color borderColor = obj.getBorderColor();
+			Color fillColor = obj.getFillColor();
 
 			if (object.getPlane() != client.getPlane())
 			{
@@ -112,21 +112,26 @@ class ObjectIndicatorsOverlay extends Overlay
 				}
 			}
 
-			if (color == null)
+			if (borderColor == null)
 			{
 				// Fallback to the current config if the object is marked before the addition of multiple colors
-				color = config.markerColor();
+				borderColor = config.borderColor();
+			}
+
+			if (fillColor == null)
+			{
+				fillColor = config.fillColor();
 			}
 
 			final var flags = obj.getHighlightFlags() != 0 ? obj.getHighlightFlags() : defaultFlags;
 			if ((flags & HF_HULL) != 0)
 			{
-				renderConvexHull(graphics, object, color, stroke);
+				renderConvexHull(graphics, object, borderColor, fillColor, stroke);
 			}
 
 			if ((flags & HF_OUTLINE) != 0)
 			{
-				modelOutlineRenderer.drawOutline(object, (int)config.borderWidth(), color, config.outlineFeather());
+				modelOutlineRenderer.drawOutline(object, (int)config.borderWidth(), borderColor, config.outlineFeather());
 			}
 
 			if ((flags & HF_CLICKBOX) != 0)
@@ -134,8 +139,7 @@ class ObjectIndicatorsOverlay extends Overlay
 				Shape clickbox = object.getClickbox();
 				if (clickbox != null)
 				{
-					Color clickBoxColor = ColorUtil.colorWithAlpha(color, color.getAlpha() / 12);
-					OverlayUtil.renderPolygon(graphics, clickbox, color, clickBoxColor, stroke);
+					OverlayUtil.renderPolygon(graphics, clickbox, borderColor, fillColor, stroke);
 				}
 			}
 
@@ -144,8 +148,7 @@ class ObjectIndicatorsOverlay extends Overlay
 				Polygon tilePoly = object.getCanvasTilePoly();
 				if (tilePoly != null)
 				{
-					Color tileColor = ColorUtil.colorWithAlpha(color, color.getAlpha() / 12);
-					OverlayUtil.renderPolygon(graphics, tilePoly, color, tileColor, stroke);
+					OverlayUtil.renderPolygon(graphics, tilePoly, borderColor, fillColor, stroke);
 				}
 			}
 		}
@@ -153,7 +156,7 @@ class ObjectIndicatorsOverlay extends Overlay
 		return null;
 	}
 
-	private void renderConvexHull(Graphics2D graphics, TileObject object, Color color, Stroke stroke)
+	private void renderConvexHull(Graphics2D graphics, TileObject object, Color borderColor, Color fillColor, Stroke stroke)
 	{
 		final Shape polygon;
 		Shape polygon2 = null;
@@ -183,12 +186,12 @@ class ObjectIndicatorsOverlay extends Overlay
 
 		if (polygon != null)
 		{
-			OverlayUtil.renderPolygon(graphics, polygon, color, stroke);
+			OverlayUtil.renderPolygon(graphics, polygon, borderColor, fillColor, stroke);
 		}
 
 		if (polygon2 != null)
 		{
-			OverlayUtil.renderPolygon(graphics, polygon2, color, stroke);
+			OverlayUtil.renderPolygon(graphics, polygon2, borderColor, fillColor, stroke);
 		}
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/objectindicators/ObjectPoint.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/objectindicators/ObjectPoint.java
@@ -44,7 +44,8 @@ class ObjectPoint
 	private int regionX;
 	private int regionY;
 	private int z;
-	private Color color;
+	private Color borderColor;
+	private Color fillColor;
 	// highlight options
 	private Boolean hull;
 	private Boolean outline;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/objectindicators/ObjectPoint.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/objectindicators/ObjectPoint.java
@@ -26,6 +26,8 @@
 package net.runelite.client.plugins.objectindicators;
 
 import java.awt.Color;
+
+import com.google.gson.annotations.SerializedName;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -44,6 +46,7 @@ class ObjectPoint
 	private int regionX;
 	private int regionY;
 	private int z;
+	@SerializedName("color")
 	private Color borderColor;
 	private Color fillColor;
 	// highlight options


### PR DESCRIPTION
Add fill color to object markers plugin closes #14843 
![Object Marker Fill](https://github.com/runelite/runelite/assets/119808801/d1f08463-751b-4432-b004-1d0058d5fb30)
![Object Marker Config](https://github.com/runelite/runelite/assets/119808801/28127720-eaac-4ae2-bec5-77b386c03ddf)
![Object Marker Menu 1](https://github.com/runelite/runelite/assets/119808801/fe7ea392-8bdf-40ee-9dc3-8d46f875f50f)
![Object Marker Menu 2](https://github.com/runelite/runelite/assets/119808801/867aeacb-e240-4427-8bd5-08964d94d668)
