### PR TITLE
Add option to disable tag tab UI sound

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/banktags/BankTagsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/banktags/BankTagsConfig.java
@@ -76,6 +76,17 @@ public interface BankTagsConfig extends Config
 	}
 
 	@ConfigItem(
+			keyName = "enableTagTabSound",
+			name = "Enable tag tab UI sound",
+			description = "Enables a UI feedback sound when a tag tab is selected.",
+			position = 5
+	)
+	default boolean enableTagTabSound()
+	{
+		return true;
+	}
+
+	@ConfigItem(
 		keyName = "position",
 		name = "",
 		description = "",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/banktags/tabs/TabInterface.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/banktags/tabs/TabInterface.java
@@ -433,7 +433,10 @@ public class TabInterface
 					// openTag will reset and relayout
 				}
 
-				client.playSoundEffect(SoundEffectID.UI_BOOP);
+				if (config.enableTagTabSound())
+				{
+					client.playSoundEffect(SoundEffectID.UI_BOOP);
+				}
 				break;
 			case Tab.CHANGE_ICON:
 				final String tag = Text.removeTags(event.getOpbase());


### PR DESCRIPTION
Adds a simple configuration item in the Bank Tags plugin which allows the UI sound to be disabled.

The default behavior remains the same.