### PR TITLE
Corner only tile indicators for tile indicators plugin.

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/tileindicators/TileIndicatorsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/tileindicators/TileIndicatorsConfig.java
@@ -106,6 +106,18 @@ public interface TileIndicatorsConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "destinationTileCornersOnly",
+		name = "Corners only",
+		description = "Draw only the corners of the destination tile.",
+		position = 5,
+		section = destinationTile
+	)
+	default boolean destinationTileCornersOnly()
+	{
+		return false;
+	}
+
+	@ConfigItem(
 		keyName = "highlightHoveredTile",
 		name = "Highlight hovered tile",
 		description = "Highlights tile player is hovering with mouse",
@@ -156,6 +168,18 @@ public interface TileIndicatorsConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "hoveredTileCornersOnly",
+		name = "Corners only",
+		description = "Draw only the corners of the hovered tile.",
+		position = 5,
+		section = hoveredTile
+	)
+	default boolean hoveredTileCornersOnly()
+	{
+		return false;
+	}
+
+	@ConfigItem(
 		keyName = "highlightCurrentTile",
 		name = "Highlight true tile",
 		description = "Highlights true tile player is on as seen by server",
@@ -203,5 +227,17 @@ public interface TileIndicatorsConfig extends Config
 	default double currentTileBorderWidth()
 	{
 		return 2;
+	}
+
+	@ConfigItem(
+		keyName = "currentTileCornersOnly",
+		name = "Corners only",
+		description = "Draw only the corners of the current tile.",
+		position = 5,
+		section = currentTile
+	)
+	default boolean currentTileCornersOnly()
+	{
+		return false;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/tileindicators/TileIndicatorsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/tileindicators/TileIndicatorsOverlay.java
@@ -63,13 +63,13 @@ public class TileIndicatorsOverlay extends Overlay
 			// If we have tile "selected" render it
 			if (client.getSelectedSceneTile() != null)
 			{
-				renderTile(graphics, client.getSelectedSceneTile().getLocalLocation(), config.highlightHoveredColor(), config.hoveredTileBorderWidth(), config.hoveredTileFillColor());
+				renderTile(graphics, client.getSelectedSceneTile().getLocalLocation(), config.highlightHoveredColor(), config.hoveredTileBorderWidth(), config.hoveredTileFillColor(), config.hoveredTileCornersOnly());
 			}
 		}
 
 		if (config.highlightDestinationTile())
 		{
-			renderTile(graphics, client.getLocalDestinationLocation(), config.highlightDestinationColor(), config.destinationTileBorderWidth(), config.destinationTileFillColor());
+			renderTile(graphics, client.getLocalDestinationLocation(), config.highlightDestinationColor(), config.destinationTileBorderWidth(), config.destinationTileFillColor(), config.destinationTileCornersOnly());
 		}
 
 		if (config.highlightCurrentTile())
@@ -86,13 +86,13 @@ public class TileIndicatorsOverlay extends Overlay
 				return null;
 			}
 
-			renderTile(graphics, playerPosLocal, config.highlightCurrentColor(), config.currentTileBorderWidth(), config.currentTileFillColor());
+			renderTile(graphics, playerPosLocal, config.highlightCurrentColor(), config.currentTileBorderWidth(), config.currentTileFillColor(), config.currentTileCornersOnly());
 		}
 
 		return null;
 	}
 
-	private void renderTile(final Graphics2D graphics, final LocalPoint dest, final Color color, final double borderWidth, final Color fillColor)
+	private void renderTile(final Graphics2D graphics, final LocalPoint dest, final Color color, final double borderWidth, final Color fillColor, boolean cornersOnly)
 	{
 		if (dest == null)
 		{
@@ -106,6 +106,13 @@ public class TileIndicatorsOverlay extends Overlay
 			return;
 		}
 
-		OverlayUtil.renderPolygon(graphics, poly, color, fillColor, new BasicStroke((float) borderWidth));
+		if (cornersOnly)
+		{
+			OverlayUtil.renderPolygonCorners(graphics, poly, color, fillColor, new BasicStroke((float) borderWidth));
+		}
+		else
+		{
+			OverlayUtil.renderPolygon(graphics, poly, color, fillColor, new BasicStroke((float) borderWidth));
+		}
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayUtil.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayUtil.java
@@ -68,6 +68,33 @@ public class OverlayUtil
 		graphics.setStroke(originalStroke);
 	}
 
+	public static void renderPolygonCorners(Graphics2D graphics, Polygon poly, Color color, Color fillColor, Stroke borderStroke)
+	{
+		graphics.setColor(color);
+		final Stroke originalStroke = graphics.getStroke();
+		graphics.setStroke(borderStroke);
+
+		int divisor = 7;
+		for (int i = 0; i < poly.npoints; i++)
+		{
+			int ptx = poly.xpoints[i];
+			int pty = poly.ypoints[i];
+			int prev = (i - 1) < 0 ? (poly.npoints - 1) : (i - 1);
+			int next = (i + 1) > (poly.npoints - 1) ? 0 : (i + 1);
+			int ptxN = ((poly.xpoints[next]) - ptx) / divisor + ptx;
+			int ptyN = ((poly.ypoints[next]) - pty) / divisor + pty;
+			int ptxP = ((poly.xpoints[prev]) - ptx) / divisor + ptx;
+			int ptyP = ((poly.ypoints[prev]) - pty) / divisor + pty;
+			graphics.drawLine(ptx, pty, ptxN, ptyN);
+			graphics.drawLine(ptx, pty, ptxP, ptyP);
+		}
+
+		graphics.setColor(fillColor);
+		graphics.fill(poly);
+
+		graphics.setStroke(originalStroke);
+	}
+
 	public static void renderMinimapLocation(Graphics2D graphics, Point mini, Color color)
 	{
 		graphics.setColor(Color.BLACK);


### PR DESCRIPTION
![image](https://github.com/runelite/runelite/assets/41499327/7d5d52b3-173b-4576-b131-9b2158faade2)

Adds a checkbox to the config for each of the 3 tiles that the plugin can indicate, which causes that tile to be highlighted with corners only instead of the entire outline. This reduces the visual clutter of the tile indicators while still clearly marking the tile.

based on #16857
