### PR TITLE
Expose AsyncBufferedImage loaded

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/util/AsyncBufferedImage.java
+++ b/runelite-client/src/main/java/net/runelite/client/util/AsyncBufferedImage.java
@@ -33,9 +33,12 @@ import javax.swing.JButton;
 import javax.swing.JComponent;
 import javax.swing.JLabel;
 
+import lombok.Getter;
+
 public class AsyncBufferedImage extends BufferedImage
 {
 	private final List<Runnable> listeners = new ArrayList<>();
+	@Getter
 	private boolean loaded;
 
 	public AsyncBufferedImage(int width, int height, int imageType)


### PR DESCRIPTION
Functionality like this is currently broken because there's no way to tell if the image was loaded instantly or if it will be filled in later. If the image was instantly loaded the onLoaded runnable will never get called.

This change enables checking to see if the image was instantly loaded, and if not the developer can subscribe to onLoaded. 

<img width="732" alt="image" src="https://github.com/runelite/runelite/assets/12495920/7ce274ac-59cb-486b-ba03-79a880e0672a">
