### PR TITLE
Respect "Show precise combat level" config on character summary tab

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/combatlevel/CombatLevelPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/combatlevel/CombatLevelPlugin.java
@@ -163,7 +163,7 @@ public class CombatLevelPlugin extends Plugin
 	public void onScriptPreFired(ScriptPreFired scriptPreFired)
 	{
 		final int scriptId = scriptPreFired.getScriptId();
-		if (scriptId != ScriptID.ACCOUNT_SUMMARY_TEXT_FORMAT && scriptId != ScriptID.ACCOUNT_SUMMARY_SECTION_FORMAT)
+		if (scriptId != ScriptID.ACCOUNT_SUMMARY_TEXT_FORMAT && scriptId != ScriptID.ACCOUNT_SUMMARY_SECTION_FORMAT || !config.showPreciseCombatLevel())
 		{
 			return;
 		}


### PR DESCRIPTION
Fixes #16971

This was an oversight I should have caught in my original PR. Sorry.