### PR TITLE
grandexchange: fuzzy with prefix + jarowinkler

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/FuzzySearchScorer.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/FuzzySearchScorer.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2023, LlemonDuck <napkinorton@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package net.runelite.client.plugins.grandexchange;
+
+import java.util.function.ToDoubleFunction;
+import javax.inject.Singleton;
+import net.runelite.api.ItemComposition;
+import org.apache.commons.text.similarity.JaroWinklerDistance;
+import org.apache.commons.text.similarity.SimilarityScore;
+
+@Singleton
+public class FuzzySearchScorer
+{
+
+	// can be swapped, but i found jaro-winkler to do well considering the variable length of inputs
+	// whereas levenshtein biases toward strings of same len, regardless of overlap
+	private final SimilarityScore<Double> baseAlgorithm = new JaroWinklerDistance();
+
+	public Double score(String query, String itemName)
+	{
+		query = query.toLowerCase().replace('-', ' ');
+		itemName = itemName.toLowerCase().replace('-', ' ');
+
+		// we raise the score for items that share a prefix with the query
+		int prefixLen = 0;
+		int maxLen = Math.min(query.length(), itemName.length());
+		while (prefixLen < maxLen && query.charAt(prefixLen) == itemName.charAt(prefixLen))
+		{
+			prefixLen++;
+		}
+		double prefixScore = ((double) prefixLen) / query.length() - 0.25;
+
+		// and also raise the score for string "closeness"
+		double proximityScore = baseAlgorithm.apply(query, itemName) - 0.25;
+		return prefixScore + proximityScore;
+	}
+
+	public ToDoubleFunction<ItemComposition> comparator(String query)
+	{
+		// We do this so that for example the items "Anti-venom ..." are still at the top
+		// when searching "anti venom"
+		return item -> score(
+			query.toLowerCase().replace('-', ' '),
+			item.getName().toLowerCase().replace('-', ' ')
+		);
+	}
+
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangePlugin.java
@@ -45,14 +45,12 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.EnumSet;
 import java.util.Enumeration;
 import java.util.List;
-import java.util.Locale;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.function.ToIntFunction;
+import java.util.function.ToDoubleFunction;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import javax.inject.Inject;
@@ -111,7 +109,6 @@ import net.runelite.http.api.ge.GrandExchangeTrade;
 import net.runelite.http.api.item.ItemStats;
 import net.runelite.http.api.worlds.WorldType;
 import org.apache.commons.lang3.time.DurationFormatUtils;
-import org.apache.commons.text.similarity.FuzzyScore;
 
 @PluginDescriptor(
 	name = "Grand Exchange",
@@ -134,7 +131,6 @@ public class GrandExchangePlugin extends Plugin
 
 	private static final int MAX_RESULT_COUNT = 250;
 
-	private static final FuzzyScore FUZZY = new FuzzyScore(Locale.ENGLISH);
 	private static final Color FUZZY_HIGHLIGHT_COLOR = new Color(0x800000);
 
 	private static final int MAX_TRADE_HISTORY = 1024;
@@ -192,6 +188,9 @@ public class GrandExchangePlugin extends Plugin
 	private ScheduledExecutorService scheduledExecutorService;
 
 	@Inject
+	private FuzzySearchScorer fuzzySearchScorer;
+
+	@Inject
 	private GrandExchangeClient grandExchangeClient;
 	private int lastLoginTick;
 
@@ -200,49 +199,6 @@ public class GrandExchangePlugin extends Plugin
 	private String machineUuid;
 	private long lastAccount;
 	private int tradeSeq;
-
-	/**
-	 * Logic from {@link org.apache.commons.text.similarity.FuzzyScore}
-	 */
-	@VisibleForTesting
-	static List<Integer> findFuzzyIndices(String term, String query)
-	{
-		List<Integer> indices = new ArrayList<>();
-
-		// fuzzy logic is case insensitive. We normalize the Strings to lower
-		// case right from the start. Turning characters to lower case
-		// via Character.toLowerCase(char) is unfortunately insufficient
-		// as it does not accept a locale.
-		final String termLowerCase = term.toLowerCase();
-		final String queryLowerCase = query.toLowerCase();
-
-		// the position in the term which will be scanned next for potential
-		// query character matches
-		int termIndex = 0;
-
-		for (int queryIndex = 0; queryIndex < queryLowerCase.length(); queryIndex++)
-		{
-			final char queryChar = queryLowerCase.charAt(queryIndex);
-
-			boolean termCharacterMatchFound = false;
-			for (; termIndex < termLowerCase.length()
-					&& !termCharacterMatchFound; termIndex++)
-			{
-				final char termChar = termLowerCase.charAt(termIndex);
-
-				if (queryChar == termChar)
-				{
-					indices.add(termIndex);
-
-					// we can leave the nested loop. Every character in the
-					// query can match at most one character in the term.
-					termCharacterMatchFound = true;
-				}
-			}
-		}
-
-		return indices;
-	}
 
 	private SavedOffer getOffer(int slot)
 	{
@@ -692,7 +648,7 @@ public class GrandExchangePlugin extends Plugin
 		{
 			return;
 		}
-		String input = client.getVarcStrValue(VarClientStr.INPUT_TEXT);
+		String input = client.getVarcStrValue(VarClientStr.INPUT_TEXT).toLowerCase();
 
 		String underlineTag = "<u=" + ColorUtil.colorToHexCode(FUZZY_HIGHLIGHT_COLOR) + ">";
 
@@ -703,33 +659,23 @@ public class GrandExchangePlugin extends Plugin
 		for (int i = 0; i < resultCount; i++)
 		{
 			Widget itemNameWidget = children[i * 3 + 1];
-			String itemName = itemNameWidget.getText();
+			String itemName = itemNameWidget.getText(); // preserve case in underlined string
+			String itemNameLower = itemName.toLowerCase(); // but match case-insensitive
 
-			List<Integer> indices;
-			String otherName = itemName.replace('-', ' ');
-			if (!itemName.contains("-") || FUZZY.fuzzyScore(itemName, input) >= FUZZY.fuzzyScore(otherName, input))
+			int sharedPrefixLen = 0;
+			int maxLen = Math.min(input.length(), itemName.length());
+			while (sharedPrefixLen < maxLen && input.charAt(sharedPrefixLen) == itemNameLower.charAt(sharedPrefixLen))
 			{
-				indices = findFuzzyIndices(itemName, input);
-			}
-			else
-			{
-				indices = findFuzzyIndices(otherName, input);
-			}
-			Collections.reverse(indices);
-
-			StringBuilder newItemName = new StringBuilder(itemName);
-			for (int index : indices)
-			{
-				if (itemName.charAt(index) == ' ' || itemName.charAt(index) == '-')
-				{
-					continue;
-				}
-
-				newItemName.insert(index + 1, "</u>");
-				newItemName.insert(index, underlineTag);
+				sharedPrefixLen++;
 			}
 
-			itemNameWidget.setText(newItemName.toString());
+			if (sharedPrefixLen > 0)
+			{
+				StringBuilder newItemName = new StringBuilder(itemName);
+				newItemName.insert(sharedPrefixLen, "</u>");
+				newItemName.insert(0, underlineTag);
+				itemNameWidget.setText(newItemName.toString());
+			}
 		}
 	}
 
@@ -780,23 +726,12 @@ public class GrandExchangePlugin extends Plugin
 
 		if (resultCount == 0)
 		{
-			// We do this so that for example the items "Anti-venom ..." are still at the top
-			// when searching "anti venom"
-			ToIntFunction<ItemComposition> getScore = item ->
-			{
-				int score = FUZZY.fuzzyScore(item.getName(), input);
-				if (item.getName().contains("-"))
-				{
-					return Math.max(FUZZY.fuzzyScore(item.getName().replace('-', ' '), input), score);
-				}
-				return score;
-			};
-
+			ToDoubleFunction<ItemComposition> comparator = fuzzySearchScorer.comparator(input);
 			List<Integer> ids = IntStream.range(0, client.getItemCount())
 					.mapToObj(itemManager::getItemComposition)
 					.filter(item -> item.isTradeable() && item.getNote() == -1)
-					.filter(item -> getScore.applyAsInt(item) > 0)
-					.sorted(Comparator.comparingInt(getScore).reversed()
+					.filter(item -> comparator.applyAsDouble(item) > 0)
+					.sorted(Comparator.comparingDouble(comparator).reversed()
 						.thenComparing(ItemComposition::getName))
 					.limit(MAX_RESULT_COUNT)
 					.map(ItemComposition::getId)

--- a/runelite-client/src/test/java/net/runelite/client/plugins/grandexchange/GrandExchangePluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/grandexchange/GrandExchangePluginTest.java
@@ -28,10 +28,8 @@ import com.google.gson.Gson;
 import com.google.inject.Guice;
 import com.google.inject.testing.fieldbinder.Bind;
 import com.google.inject.testing.fieldbinder.BoundFieldModule;
-import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ScheduledExecutorService;
 import javax.inject.Inject;
@@ -54,7 +52,6 @@ import net.runelite.client.config.RuneLiteConfig;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.input.KeyManager;
 import net.runelite.client.input.MouseManager;
-import static net.runelite.client.plugins.grandexchange.GrandExchangePlugin.findFuzzyIndices;
 import net.runelite.client.ui.ClientToolbar;
 import net.runelite.http.api.ge.GrandExchangeTrade;
 import static org.junit.Assert.assertEquals;
@@ -139,14 +136,6 @@ public class GrandExchangePluginTest
 	{
 		Guice.createInjector(BoundFieldModule.of(this)).injectMembers(this);
 		when(client.getWorldType()).thenReturn(EnumSet.noneOf(WorldType.class));
-	}
-
-	@Test
-	public void testFindFuzzyIndices()
-	{
-		List<Integer> fuzzyIndices = findFuzzyIndices("Ancestral robe bottom", "obby");
-		// r<u>ob</u>e <u>b</u>ottom
-		assertEquals(Arrays.asList(11, 12, 15), fuzzyIndices);
 	}
 
 	@Test


### PR DESCRIPTION
Replaces the GE plugin's fuzzy search with a new algorithm: a weighted score between the shared prefix length of the query and item names, and the Jaro-Winkler proximity score. The previous algorithm checked for the length of subsequence in the item name relative to the query.

## Prior behaviour:
![](https://cdn.discordapp.com/attachments/419891709883973642/1143589991516213339/image.png)
![image](https://github.com/runelite/runelite/assets/1868974/136098d3-3da9-420d-a92b-d53524819607)

## New behaviour:
![image](https://github.com/runelite/runelite/assets/1868974/44f54772-6ca9-4903-b871-5e117526389f)
![image](https://github.com/runelite/runelite/assets/1868974/6a2220ce-90e3-4481-9286-dd2cd9548b0e)
