### PR TITLE
Add config to increase agility clickbox draw distance

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/agility/AgilityConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/agility/AgilityConfig.java
@@ -54,10 +54,21 @@ public interface AgilityConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "extendDrawDistance",
+		name = "Extend Clickbox Draw Distances",
+		description = "Show agility course and obstacle clickboxes from further away",
+		position = 1
+	)
+	default boolean extendDrawDistance()
+	{
+		return false;
+	}
+
+	@ConfigItem(
 		keyName = "showLapCount",
 		name = "Show Lap Count",
 		description = "Enable/disable the lap counter",
-		position = 1
+		position = 2
 	)
 	default boolean showLapCount()
 	{
@@ -68,7 +79,7 @@ public interface AgilityConfig extends Config
 		keyName = "lapTimeout",
 		name = "Hide Lap Count",
 		description = "Time until the lap counter hides/resets",
-		position = 2
+		position = 3
 	)
 	@Units(Units.MINUTES)
 	default int lapTimeout()
@@ -80,7 +91,7 @@ public interface AgilityConfig extends Config
 		keyName = "lapsToLevel",
 		name = "Show Laps Until Goal",
 		description = "Show number of laps remaining until next goal is reached.",
-		position = 3
+		position = 4
 	)
 	default boolean lapsToLevel()
 	{
@@ -91,7 +102,7 @@ public interface AgilityConfig extends Config
 		keyName = "lapsPerHour",
 		name = "Show Laps Per Hour",
 		description = "Shows how many laps you can expect to complete per hour.",
-		position = 4
+		position = 5
 	)
 	default boolean lapsPerHour()
 	{
@@ -103,7 +114,7 @@ public interface AgilityConfig extends Config
 		keyName = "overlayColor",
 		name = "Overlay Color",
 		description = "Color of Agility overlay",
-		position = 5
+		position = 6
 	)
 	default Color getOverlayColor()
 	{
@@ -114,7 +125,7 @@ public interface AgilityConfig extends Config
 		keyName = "highlightMarks",
 		name = "Highlight Marks of Grace",
 		description = "Enable/disable the highlighting of retrievable Marks of Grace",
-		position = 6
+		position = 7
 	)
 	default boolean highlightMarks()
 	{
@@ -126,7 +137,7 @@ public interface AgilityConfig extends Config
 		keyName = "markHighlight",
 		name = "Mark Highlight Color",
 		description = "Color of highlighted Marks of Grace",
-		position = 7
+		position = 8
 	)
 	default Color getMarkColor()
 	{
@@ -137,7 +148,7 @@ public interface AgilityConfig extends Config
 		keyName = "highlightPortals",
 		name = "Highlight Portals",
 		description = "Enable/disable the highlighting of Prifddinas portals",
-		position = 8
+		position = 9
 	)
 	default boolean highlightPortals()
 	{
@@ -149,7 +160,7 @@ public interface AgilityConfig extends Config
 		keyName = "portalsHighlight",
 		name = "Portals Color",
 		description = "Color of highlighted Prifddinas portals",
-		position = 9
+		position = 10
 	)
 	default Color getPortalsColor()
 	{
@@ -160,7 +171,7 @@ public interface AgilityConfig extends Config
 		keyName = "highlightShortcuts",
 		name = "Highlight Agility Shortcuts",
 		description = "Enable/disable the highlighting of Agility shortcuts",
-		position = 10
+		position = 11
 	)
 	default boolean highlightShortcuts()
 	{
@@ -171,7 +182,7 @@ public interface AgilityConfig extends Config
 		keyName = "trapOverlay",
 		name = "Show Trap Overlay",
 		description = "Enable/disable the highlighting of traps on Agility courses",
-		position = 11
+		position = 12
 	)
 	default boolean showTrapOverlay()
 	{
@@ -183,7 +194,7 @@ public interface AgilityConfig extends Config
 		keyName = "trapHighlight",
 		name = "Trap Overlay Color",
 		description = "Color of Agility trap overlay",
-		position = 12
+		position = 13
 	)
 	default Color getTrapColor()
 	{
@@ -194,7 +205,7 @@ public interface AgilityConfig extends Config
 		keyName = "agilityArenaNotifier",
 		name = "Agility Arena notifier",
 		description = "Notify on ticket location change in Agility Arena",
-		position = 13
+		position = 14
 	)
 	default boolean notifyAgilityArena()
 	{
@@ -205,7 +216,7 @@ public interface AgilityConfig extends Config
 		keyName = "agilityArenaTimer",
 		name = "Agility Arena timer",
 		description = "Configures whether Agility Arena timer is displayed",
-		position = 14
+		position = 15
 	)
 	default boolean showAgilityArenaTimer()
 	{
@@ -216,7 +227,7 @@ public interface AgilityConfig extends Config
 		keyName = "highlightStick",
 		name = "Highlight Stick",
 		description = "Highlight the retrievable stick in the Werewolf Agility Course",
-		position = 15
+		position = 16
 	)
 	default boolean highlightStick()
 	{
@@ -228,7 +239,7 @@ public interface AgilityConfig extends Config
 		keyName = "stickHighlightColor",
 		name = "Stick Highlight Color",
 		description = "Color of highlighted stick",
-		position = 16
+		position = 17
 	)
 	default Color stickHighlightColor()
 	{
@@ -239,7 +250,7 @@ public interface AgilityConfig extends Config
 		keyName = "highlightSepulchreNpcs",
 		name = "Highlight Projectiles",
 		description = "Highlights arrows and swords in the Sepulchre",
-		position = 17,
+		position = 18,
 		section = sepulchreSection
 	)
 	default boolean highlightSepulchreNpcs()
@@ -252,7 +263,7 @@ public interface AgilityConfig extends Config
 		keyName = "sepulchreHighlightColor",
 		name = "Projectile Color",
 		description = "Overlay color for arrows and swords",
-		position = 18,
+		position = 19,
 		section = sepulchreSection
 	)
 	default Color sepulchreHighlightColor()
@@ -264,7 +275,7 @@ public interface AgilityConfig extends Config
 		keyName = "highlightSepulchreObstacles",
 		name = "Highlight Obstacles",
 		description = "Highlights pillars and stairs in the Sepulchre",
-		position = 19,
+		position = 20,
 		section = sepulchreSection
 	)
 	default boolean highlightSepulchreObstacles()
@@ -276,7 +287,7 @@ public interface AgilityConfig extends Config
 		keyName = "highlightSepulchreSkilling",
 		name = "Highlight Skill Challenges",
 		description = "Highlights skilling challenges in the Sepulchre",
-		position = 20,
+		position = 21,
 		section = sepulchreSection
 	)
 	default boolean highlightSepulchreSkilling()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/agility/AgilityOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/agility/AgilityOverlay.java
@@ -37,6 +37,7 @@ import net.runelite.api.Client;
 import net.runelite.api.NPC;
 import net.runelite.api.Point;
 import net.runelite.api.Tile;
+import net.runelite.api.TileObject;
 import net.runelite.api.coords.LocalPoint;
 import net.runelite.client.game.AgilityShortcut;
 import net.runelite.client.ui.overlay.Overlay;
@@ -76,62 +77,28 @@ class AgilityOverlay extends Overlay
 		plugin.getObstacles().forEach((object, obstacle) ->
 		{
 			if (Obstacles.SHORTCUT_OBSTACLE_IDS.containsKey(object.getId()) && !config.highlightShortcuts() ||
-					Obstacles.TRAP_OBSTACLE_IDS.contains(object.getId()) && !config.showTrapOverlay() ||
-					Obstacles.OBSTACLE_IDS.contains(object.getId()) && !config.showClickboxes() ||
-					Obstacles.SEPULCHRE_OBSTACLE_IDS.contains(object.getId()) && !config.highlightSepulchreObstacles() ||
-					Obstacles.SEPULCHRE_SKILL_OBSTACLE_IDS.contains(object.getId()) && !config.highlightSepulchreSkilling())
+				Obstacles.TRAP_OBSTACLE_IDS.contains(object.getId()) && !config.showTrapOverlay() ||
+				Obstacles.OBSTACLE_IDS.contains(object.getId()) && !config.showClickboxes() ||
+				Obstacles.SEPULCHRE_OBSTACLE_IDS.contains(object.getId()) && !config.highlightSepulchreObstacles() ||
+				Obstacles.SEPULCHRE_SKILL_OBSTACLE_IDS.contains(object.getId()) && !config.highlightSepulchreSkilling())
 			{
 				return;
 			}
 
 			Tile tile = obstacle.getTile();
-			if (tile.getPlane() == client.getPlane()
-				&& object.getLocalLocation().distanceTo(playerLocation) < MAX_DISTANCE)
+			if (config.extendDrawDistance())
 			{
-				// This assumes that the obstacle is not clickable.
-				if (Obstacles.TRAP_OBSTACLE_IDS.contains(object.getId()))
+				if (tile.getPlane() == client.getPlane())
 				{
-					Polygon polygon = object.getCanvasTilePoly();
-					if (polygon != null)
-					{
-						OverlayUtil.renderPolygon(graphics, polygon, config.getTrapColor());
-					}
-					return;
+					renderClickboxes(graphics, object, obstacle, mousePosition, marksOfGrace);
 				}
-				Shape objectClickbox = object.getClickbox();
-				if (objectClickbox != null)
+			}
+			else
+			{
+				if (tile.getPlane() == client.getPlane()
+					&& object.getLocalLocation().distanceTo(playerLocation) < MAX_DISTANCE)
 				{
-					AgilityShortcut agilityShortcut = obstacle.getShortcut();
-					Color configColor = agilityShortcut == null || agilityShortcut.getLevel() <= plugin.getAgilityLevel() ? config.getOverlayColor() : SHORTCUT_HIGH_LEVEL_COLOR;
-					if (config.highlightMarks() && !marksOfGrace.isEmpty())
-					{
-						configColor = config.getMarkColor();
-					}
-
-					if (Obstacles.PORTAL_OBSTACLE_IDS.contains(object.getId()))
-					{
-						if (config.highlightPortals())
-						{
-							configColor = config.getPortalsColor();
-						}
-						else
-						{
-							return;
-						}
-					}
-
-					if (objectClickbox.contains(mousePosition.getX(), mousePosition.getY()))
-					{
-						graphics.setColor(configColor.darker());
-					}
-					else
-					{
-						graphics.setColor(configColor);
-					}
-
-					graphics.draw(objectClickbox);
-					graphics.setColor(ColorUtil.colorWithAlpha(configColor, configColor.getAlpha() / 5));
-					graphics.fill(objectClickbox);
+					renderClickboxes(graphics, object, obstacle, mousePosition, marksOfGrace);
 				}
 			}
 		});
@@ -166,17 +133,83 @@ class AgilityOverlay extends Overlay
 		return null;
 	}
 
+	private void renderClickboxes(Graphics2D graphics, TileObject object, Obstacle obstacle,
+								  Point mousePosition, List<Tile> marksOfGrace)
+	{
+		// This assumes that the obstacle is not clickable.
+		if (Obstacles.TRAP_OBSTACLE_IDS.contains(object.getId()))
+		{
+			Polygon polygon = object.getCanvasTilePoly();
+			if (polygon != null)
+			{
+				OverlayUtil.renderPolygon(graphics, polygon, config.getTrapColor());
+			}
+			return;
+		}
+		Shape objectClickbox = object.getClickbox();
+		if (objectClickbox != null)
+		{
+			AgilityShortcut agilityShortcut = obstacle.getShortcut();
+			Color configColor = agilityShortcut == null
+				|| agilityShortcut.getLevel() <= plugin.getAgilityLevel() ? config.getOverlayColor() : SHORTCUT_HIGH_LEVEL_COLOR;
+			if (config.highlightMarks() && !marksOfGrace.isEmpty())
+			{
+				configColor = config.getMarkColor();
+			}
+
+			if (Obstacles.PORTAL_OBSTACLE_IDS.contains(object.getId()))
+			{
+				if (config.highlightPortals())
+				{
+					configColor = config.getPortalsColor();
+				}
+				else
+				{
+					return;
+				}
+			}
+
+			if (objectClickbox.contains(mousePosition.getX(), mousePosition.getY()))
+			{
+				graphics.setColor(configColor.darker());
+			}
+			else
+			{
+				graphics.setColor(configColor);
+			}
+
+			graphics.draw(objectClickbox);
+			graphics.setColor(ColorUtil.colorWithAlpha(configColor, configColor.getAlpha() / 5));
+			graphics.fill(objectClickbox);
+		}
+	}
+
 	private void highlightTile(Graphics2D graphics, LocalPoint playerLocation, Tile tile, Color color)
 	{
-		if (tile.getPlane() == client.getPlane() && tile.getItemLayer() != null
-			&& tile.getLocalLocation().distanceTo(playerLocation) < MAX_DISTANCE)
+		if (config.extendDrawDistance())
 		{
-			final Polygon poly = tile.getItemLayer().getCanvasTilePoly();
-
-			if (poly != null)
+			if (tile.getPlane() == client.getPlane() && tile.getItemLayer() != null)
 			{
-				OverlayUtil.renderPolygon(graphics, poly, color);
+				highlightTileOverlay(graphics, tile, color);
 			}
+		}
+		else
+		{
+			if (tile.getPlane() == client.getPlane() && tile.getItemLayer() != null
+				&& tile.getLocalLocation().distanceTo(playerLocation) < MAX_DISTANCE)
+			{
+				highlightTileOverlay(graphics, tile, color);
+			}
+		}
+	}
+
+	private void highlightTileOverlay(Graphics2D graphics, Tile tile, Color color)
+	{
+		final Polygon poly = tile.getItemLayer().getCanvasTilePoly();
+
+		if (poly != null)
+		{
+			OverlayUtil.renderPolygon(graphics, poly, color);
 		}
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/agility/AgilityOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/agility/AgilityOverlay.java
@@ -133,6 +133,35 @@ class AgilityOverlay extends Overlay
 		return null;
 	}
 
+	private void highlightTile(Graphics2D graphics, LocalPoint playerLocation, Tile tile, Color color)
+	{
+		if (config.extendDrawDistance())
+		{
+			if (tile.getPlane() == client.getPlane() && tile.getItemLayer() != null)
+			{
+				highlightTileOverlay(graphics, tile, color);
+			}
+		}
+		else
+		{
+			if (tile.getPlane() == client.getPlane() && tile.getItemLayer() != null
+				&& tile.getLocalLocation().distanceTo(playerLocation) < MAX_DISTANCE)
+			{
+				highlightTileOverlay(graphics, tile, color);
+			}
+		}
+	}
+
+	private void highlightTileOverlay(Graphics2D graphics, Tile tile, Color color)
+	{
+		final Polygon poly = tile.getItemLayer().getCanvasTilePoly();
+
+		if (poly != null)
+		{
+			OverlayUtil.renderPolygon(graphics, poly, color);
+		}
+	}
+
 	private void renderClickboxes(Graphics2D graphics, TileObject object, Obstacle obstacle,
 								  Point mousePosition, List<Tile> marksOfGrace)
 	{
@@ -181,35 +210,6 @@ class AgilityOverlay extends Overlay
 			graphics.draw(objectClickbox);
 			graphics.setColor(ColorUtil.colorWithAlpha(configColor, configColor.getAlpha() / 5));
 			graphics.fill(objectClickbox);
-		}
-	}
-
-	private void highlightTile(Graphics2D graphics, LocalPoint playerLocation, Tile tile, Color color)
-	{
-		if (config.extendDrawDistance())
-		{
-			if (tile.getPlane() == client.getPlane() && tile.getItemLayer() != null)
-			{
-				highlightTileOverlay(graphics, tile, color);
-			}
-		}
-		else
-		{
-			if (tile.getPlane() == client.getPlane() && tile.getItemLayer() != null
-				&& tile.getLocalLocation().distanceTo(playerLocation) < MAX_DISTANCE)
-			{
-				highlightTileOverlay(graphics, tile, color);
-			}
-		}
-	}
-
-	private void highlightTileOverlay(Graphics2D graphics, Tile tile, Color color)
-	{
-		final Polygon poly = tile.getItemLayer().getCanvasTilePoly();
-
-		if (poly != null)
-		{
-			OverlayUtil.renderPolygon(graphics, poly, color);
 		}
 	}
 }


### PR DESCRIPTION
Re-implements https://github.com/runelite/runelite/pull/6697 which was reverted due to performance concerns. Since then, performance improvements have minimized this.

As a safeguard, I added a configuration toggle (defaults to off) for this feature for those that might struggle with the extended draw distance, particularly in areas like Isafdar. In my own testing with a modern PC, I saw about a 15% reduction in FPS.

I think this is very valuable for those wanting to make agility easier to manage as a side-monitor task.

---

Copied from https://github.com/runelite/runelite/pull/15453 after branch migration.

Closes #1360