### PR TITLE
Added tile border width option to the player indicators plugin

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsConfig.java
@@ -230,6 +230,17 @@ public interface PlayerIndicatorsConfig extends Config
 
 	@ConfigItem(
 		position = 11,
+		keyName = "tileBorderWidth",
+		name = "Tile border width",
+		description = "Width of tile border surrounding players, if drawPlayerTiles is checked"
+	)
+	default double tileBorderWidth()
+	{
+		return 2;
+	}
+
+	@ConfigItem(
+		position = 12,
 		keyName = "playerNamePosition",
 		name = "Name position",
 		description = "Configures the position of drawn player names, or if they should be disabled"
@@ -240,7 +251,7 @@ public interface PlayerIndicatorsConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 12,
+		position = 13,
 		keyName = "drawMinimapNames",
 		name = "Draw names on minimap",
 		description = "Configures whether or not minimap names for players with rendered names should be drawn"
@@ -251,7 +262,7 @@ public interface PlayerIndicatorsConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 13,
+		position = 14,
 		keyName = "colorPlayerMenu",
 		name = "Colorize player menu",
 		description = "Color right click menu for players"
@@ -262,7 +273,7 @@ public interface PlayerIndicatorsConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 14,
+		position = 15,
 		keyName = "clanMenuIcons",
 		name = "Show friends chat ranks",
 		description = "Add friends chat rank to right click menu and next to player names"
@@ -273,7 +284,7 @@ public interface PlayerIndicatorsConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 15,
+		position = 16,
 		keyName = "clanchatMenuIcons",
 		name = "Show clan chat ranks",
 		description = "Add clan chat rank to right click menu and next to player names"

--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsTileOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsTileOverlay.java
@@ -28,6 +28,7 @@ package net.runelite.client.plugins.playerindicators;
 import java.awt.Dimension;
 import java.awt.Graphics2D;
 import java.awt.Polygon;
+import java.awt.BasicStroke;
 import javax.inject.Inject;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
@@ -64,7 +65,7 @@ public class PlayerIndicatorsTileOverlay extends Overlay
 
 			if (poly != null)
 			{
-				OverlayUtil.renderPolygon(graphics, poly, decorations.getColor());
+				OverlayUtil.renderPolygon(graphics, poly, decorations.getColor(), new BasicStroke((float) config.tileBorderWidth()));
 			}
 		});
 


### PR DESCRIPTION
This PR adds a config option to the Player Indicators plugin that will control the width of the tile if the user has selected `Draw tiles under players` rather than defaulting to `new BasicStroke(2)`

This is more inline with `Object Markers`, e.g. https://github.com/runelite/runelite/blob/master/runelite-client/src/main/java/net/runelite/client/plugins/objectindicators/ObjectIndicatorsConfig.java#L107-L117

**Old:**
![old](https://github.com/runelite/runelite/assets/33159984/13ee77f7-d6f4-4e00-a1d0-d2229ed9b847)

**New:**
![new](https://github.com/runelite/runelite/assets/33159984/e683a0fb-ab76-4def-a467-505edfee4d73)
