### PR TITLE
objectindicators: deduplicate color suggestions

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/objectindicators/ObjectIndicatorsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/objectindicators/ObjectIndicatorsPlugin.java
@@ -626,9 +626,10 @@ public class ObjectIndicatorsPlugin extends Plugin
 			{
 				for (var p : points)
 				{
-					if (p.getColor() != null)
+					Color c = p.getColor();
+					if (c != null & !colors.contains(c))
 					{
-						colors.add(p.getColor());
+						colors.add(c);
 						if (colors.size() >= 5)
 						{
 							return colors;


### PR DESCRIPTION
Using the same solution as [NpcIndicatorsPlugin.java](https://github.com/runelite/runelite/blob/4700013ffbd089899df9cb675ff53b00d381cae5/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsPlugin.java#L874-L893)


<details>
<summary>Image before</summary>

![before_000](https://github.com/runelite/runelite/assets/962989/114e702d-c5c7-475e-8e4b-9712b0b5884e)


</details>

<details>
<summary>Image after</summary>

![after_000](https://github.com/runelite/runelite/assets/962989/b4e37154-fb06-4180-b3f9-9a28b0b3a84f)

</details>

Fixes #17018