### PR TITLE
add --skip-objects and --skip-icons to MapImageDumper

### DIFF
--- a/cache/src/main/java/net/runelite/cache/MapImageDumper.java
+++ b/cache/src/main/java/net/runelite/cache/MapImageDumper.java
@@ -145,6 +145,8 @@ public class MapImageDumper
 		options.addOption(Option.builder().longOpt("cachedir").hasArg().required().build());
 		options.addOption(Option.builder().longOpt("xteapath").hasArg().required().build());
 		options.addOption(Option.builder().longOpt("outputdir").hasArg().required().build());
+		options.addOption(Option.builder().longOpt("skip-objects").optionalArg(true).build());
+		options.addOption(Option.builder().longOpt("skip-icons").optionalArg(true).build());
 
 		CommandLineParser parser = new DefaultParser();
 		CommandLine cmd;
@@ -162,6 +164,8 @@ public class MapImageDumper
 		final String cacheDirectory = cmd.getOptionValue("cachedir");
 		final String xteaJSONPath = cmd.getOptionValue("xteapath");
 		final String outputDirectory = cmd.getOptionValue("outputdir");
+		final boolean skipObjects = cmd.hasOption("skip-objects");
+		final boolean skipIcons = cmd.hasOption("skip-icons");
 
 		XteaKeyManager xteaKeyManager = new XteaKeyManager();
 		try (FileInputStream fin = new FileInputStream(xteaJSONPath))
@@ -178,6 +182,8 @@ public class MapImageDumper
 			store.load();
 
 			MapImageDumper dumper = new MapImageDumper(store, xteaKeyManager);
+			dumper.setRenderObjects(!skipObjects);
+			dumper.setRenderIcons(!skipIcons);
 			dumper.load();
 
 			for (int i = 0; i < Region.Z; ++i)


### PR DESCRIPTION
I'm building a web tool that requires map tiles but without the icons. I've generated what I need to already, but it shouldn't hurt to have this in the base repo:

Normal:
![image](https://github.com/runelite/runelite/assets/1549353/a08a03e4-d7e3-4ba4-b330-36a1ddd08d70)
No objects or icons:
![image](https://github.com/runelite/runelite/assets/1549353/c75aafcc-b7aa-47ea-91f3-9589ed2fb8c7)
No icons:
![image](https://github.com/runelite/runelite/assets/1549353/d60ec994-9bde-4c32-8fa9-d82d8b19133f)
