### PR TITLE
npcaggro: fix typo in Notify Expiration description

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/npcunaggroarea/NpcAggroAreaConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npcunaggroarea/NpcAggroAreaConfig.java
@@ -110,7 +110,7 @@ public interface NpcAggroAreaConfig extends Config
 	@ConfigItem(
 		keyName = "notifyExpire",
 		name = "Notify Expiration",
-		description = "Send a notifcation when the unaggressive timer expires",
+		description = "Send a notification when the unaggressive timer expires",
 		position = 7
 	)
 	default boolean notifyExpire()


### PR DESCRIPTION
Before:
![before](https://github.com/runelite/runelite/assets/962989/4c930ad5-3f8f-4301-b1f7-4855d60d7296)

After:
![after](https://github.com/runelite/runelite/assets/962989/4595499c-0668-4990-bf82-82852ae80dc8)
