### PR TITLE
timers: remove corruption cooldown on configchange

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersPlugin.java
@@ -689,6 +689,7 @@ public class TimersPlugin extends Plugin
 			removeGameTimer(RESURRECT_THRALL_COOLDOWN);
 			removeGameTimer(SHADOW_VEIL_COOLDOWN);
 			removeGameTimer(WARD_OF_ARCEUUS_COOLDOWN);
+			removeGameTimer(CORRUPTION_COOLDOWN);
 		}
 
 		if (!config.showAntiPoison())


### PR DESCRIPTION
Currently the cooldown timer for corruption spells is not removed when disabling the "show arceuus cooldowns" config setting.