### PR TITLE
[Menu Entry Swapper] Config to swap potion options separately per dose amount

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -147,6 +147,18 @@ public interface MenuEntrySwapperConfig extends Config
 
 	@ConfigItem(
 		position = -2,
+		keyName = "swapPotionDosesSeparately",
+		name = "Swap potion doses separately",
+		description = "Allows separate left and shift-click options for 1, 2, 3, and 4-dose potions",
+		section = itemSection
+	)
+	default boolean swapPotionDosesSeparately()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		position = -2,
 		keyName = "objectLeftClickCustomization",
 		name = "Customizable left and shift click",
 		description = "Allows customization of left-clicks on objects",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -40,6 +40,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -92,6 +93,43 @@ import net.runelite.client.util.Text;
 @Slf4j
 public class MenuEntrySwapperPlugin extends Plugin
 {
+	private static final HashSet<Integer> POTION_IDS = new HashSet<Integer>(Arrays.asList(
+		10000, 10002, 10004, 10925, 10927, 10929, 10931, 113, 11429, 11431, 11433,
+		11435, 11437, 11439, 11441, 11443, 11445, 11447, 11449, 11451, 11453, 11455,
+		11457, 11459, 11461, 11463, 11465, 11467, 11469, 11471, 11477, 11479, 11481,
+		11483, 11485, 11487, 11489, 11491, 11493, 11495, 11497, 11499, 115, 11501,
+		11503, 11505, 11507, 11509, 11511, 11513, 11515, 11517, 11519, 11521, 11523,
+		117, 11722, 11723, 11724, 11725, 11726, 11727, 11728, 11729, 11730, 11731,
+		11732, 11733, 119, 11960, 11962, 121, 123, 125, 12625, 12627, 12629,
+		12631, 12633, 12635, 12695, 12697, 12699, 127, 12701, 129, 131, 133,
+		135, 137, 139, 141, 143, 145, 147, 149, 151, 153, 155,
+		157, 159, 161, 163, 165, 167, 169, 171, 173, 189, 191,
+		193, 20393, 20394, 20395, 20396, 20548, 20549, 20550, 20551, 20697, 20699,
+		20700, 20701, 20702, 20913, 20914, 20915, 20916, 20917, 20918, 20919, 20920,
+		20921, 20922, 20923, 20924, 20925, 20926, 20927, 20928, 20929, 20930, 20931,
+		20932, 20933, 20934, 20935, 20936, 20937, 20938, 20939, 20940, 20941, 20942,
+		20943, 20944, 20945, 20946, 20947, 20948, 20953, 20954, 20955, 20956, 20961,
+		20962, 20963, 20964, 20965, 20966, 20967, 20968, 20969, 20970, 20971, 20972,
+		20985, 20986, 20987, 20988, 20989, 20990, 20991, 20992, 20993, 20994, 20995,
+		20996, 21978, 21981, 21984, 21987, 21994, 21997, 22096, 22209, 22212, 22215,
+		22218, 22221, 22224, 22449, 22452, 22455, 22458, 22461, 22464, 22467, 22470,
+		23543, 23545, 23547, 23549, 23551, 23553, 23555, 23557, 23559, 23561, 23563,
+		23565, 23567, 23569, 23571, 23573, 23575, 23577, 23579, 23581, 23583, 23585,
+		23587, 23589, 23685, 23688, 23691, 23694, 23697, 23700, 23703, 23706, 23709,
+		23712, 23715, 23718, 23721, 23724, 23727, 23730, 23733, 23736, 23739, 23742,
+		23745, 23748, 23751, 23754, 23882, 23883, 23884, 23885, 2428, 2430, 2432,
+		2434, 2436, 2438, 2440, 2442, 2444, 2450, 2452, 2454, 2456, 2458,
+		24598, 24601, 24603, 24605, 24623, 24626, 24629, 24632, 24635, 24638, 24641,
+		24644, 25159, 25160, 25161, 25162, 25203, 25204, 25205, 25206, 25758, 25759,
+		25760, 25761, 26150, 26151, 26152, 26153, 26340, 26342, 26344, 26346, 26350,
+		26353, 26581, 26583, 26585, 26587, 27629, 27632, 27635, 27638, 3008, 3010,
+		3012, 3014, 3016, 3018, 3020, 3022, 3024, 3026, 3028, 3030, 3032,
+		3034, 3036, 3038, 3040, 3042, 3044, 3046, 3408, 3410, 3412, 3414,
+		3416, 3417, 3418, 3419, 4417, 4419, 4421, 4423, 4842, 4844, 4846,
+		4848, 5942, 5943, 5945, 5947, 5949, 5951, 5952, 5954, 5956, 5958,
+		6470, 6472, 6474, 6476, 6685, 6687, 6689, 6691, 9739, 9741, 9743,
+		9745, 9998
+	));
 	private static final String SHIFTCLICK_CONFIG_GROUP = "shiftclick";
 	private static final String ITEM_KEY_PREFIX = "item_";
 	private static final String OBJECT_KEY_PREFIX = "object_";
@@ -430,7 +468,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 
 	private Integer getItemSwapConfig(boolean shift, int itemId)
 	{
-		itemId = ItemVariationMapping.map(itemId);
+		itemId = resolveItemVariant(itemId);
 		String config = configManager.getConfiguration(shift ? SHIFTCLICK_CONFIG_GROUP : MenuEntrySwapperConfig.GROUP, ITEM_KEY_PREFIX + itemId);
 		if (config == null || config.isEmpty())
 		{
@@ -442,19 +480,19 @@ public class MenuEntrySwapperPlugin extends Plugin
 
 	private void setItemSwapConfig(boolean shift, int itemId, int index)
 	{
-		itemId = ItemVariationMapping.map(itemId);
+		itemId = resolveItemVariant(itemId);
 		configManager.setConfiguration(shift ? SHIFTCLICK_CONFIG_GROUP : MenuEntrySwapperConfig.GROUP, ITEM_KEY_PREFIX + itemId, index);
 	}
 
 	private void unsetItemSwapConfig(boolean shift, int itemId)
 	{
-		itemId = ItemVariationMapping.map(itemId);
+		itemId = resolveItemVariant(itemId);
 		configManager.unsetConfiguration(shift ? SHIFTCLICK_CONFIG_GROUP : MenuEntrySwapperConfig.GROUP, ITEM_KEY_PREFIX + itemId);
 	}
 
 	private Integer getWornItemSwapConfig(boolean shift, int itemId)
 	{
-		itemId = ItemVariationMapping.map(itemId);
+		itemId = resolveItemVariant(itemId);
 		String config = configManager.getConfiguration(MenuEntrySwapperConfig.GROUP,
 			(shift ? WORN_ITEM_SHIFT_KEY_PREFIX : WORN_ITEM_KEY_PREFIX) + itemId);
 		if (config == null || config.isEmpty())
@@ -467,14 +505,14 @@ public class MenuEntrySwapperPlugin extends Plugin
 
 	private void setWornItemSwapConfig(boolean shift, int itemId, int index)
 	{
-		itemId = ItemVariationMapping.map(itemId);
+		itemId = resolveItemVariant(itemId);
 		configManager.setConfiguration(MenuEntrySwapperConfig.GROUP,
 			(shift ? WORN_ITEM_SHIFT_KEY_PREFIX : WORN_ITEM_KEY_PREFIX) + itemId, index);
 	}
 
 	private void unsetWornItemSwapConfig(boolean shift, int itemId)
 	{
-		itemId = ItemVariationMapping.map(itemId);
+		itemId = resolveItemVariant(itemId);
 		configManager.unsetConfiguration(MenuEntrySwapperConfig.GROUP,
 			(shift ? WORN_ITEM_SHIFT_KEY_PREFIX : WORN_ITEM_KEY_PREFIX) + itemId);
 	}
@@ -1171,7 +1209,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 				if (w.getIndex() == -1 || w.getItemId() != -1)
 				{
 					final int componentId = w.getId(); // on dynamic components, this is the parent layer id
-					final int itemId = w.getIndex() == -1 ? -1 : ItemVariationMapping.map(w.getItemId());
+					final int itemId = w.getIndex() == -1 ? -1 : resolveItemVariant(w.getItemId());
 					final int identifier = entry.getIdentifier();
 					final Integer leftClick = getUiSwapConfig(false, componentId, itemId);
 					final Integer shiftClick = getUiSwapConfig(true, componentId, itemId);
@@ -1518,7 +1556,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 			if (numActions > 1)
 			{
 				final int componentId = w.getId(); // on dynamic components, this is the parent layer id
-				final int itemId = w.getIndex() == -1 ? -1 : ItemVariationMapping.map(w.getItemId());
+				final int itemId = w.getIndex() == -1 ? -1 : resolveItemVariant(w.getItemId());
 				final Integer op = getUiSwapConfig(shiftModifier(), componentId, itemId);
 				if (op != null && op == menuEntry.getIdentifier())
 				{
@@ -1920,5 +1958,17 @@ public class MenuEntrySwapperPlugin extends Plugin
 	{
 		configManager.unsetConfiguration(MenuEntrySwapperConfig.GROUP,
 			(shift ? UI_SHIFT_KEY_PREFIX : UI_KEY_PREFIX) + componentId + (itemId != -1 ? "_" + itemId : ""));
+	}
+
+	private int resolveItemVariant(int itemId)
+	{
+		if (config.swapPotionDosesSeparately() && POTION_IDS.contains(itemId))
+		{
+			return itemId;
+		}
+		else
+		{
+			return ItemVariationMapping.map(itemId);
+		}
 	}
 }


### PR DESCRIPTION
Currently if you set left- or shift-click options for (for example) Super strength(4), the same options will be applied to Super strength(1) (and 2 and 3). This is not always desirable for several reasons. This PR adds a config to allow users to change this behavior. Currently the relevant item IDs are hardcoded for performance reasons but may be worth the tradeoff to test the item name instead (mainly for forwards compatibility - a RL util function to test if something is a multiple-dose item may be worth implementing as well). The list of bypassed item variant keys with this config is below.

```
['guthix rest', 'serum', 'sanfew serum', 'relicyms balm', 'strength potion', 'attack potion', 'restore potion', 'defence potion', 'prayer potion', 'super attack', 'fishing potion', 'super strength', 'super defence', 'ranging potion', 'zamorak brew', 'antifire potion', 'energy potion', 'super energy', 'super restore', 'agility potion', 'magic potion', 'antidote+', 'antidote++', 'compost potion', 'saradomin brew', 'combat potion', 'hunter potion', 'attack mix', 'antipoison mix', 'relicyms mix', 'strength mix', 'combat mix', 'restore mix', 'energy mix', 'defence mix', 'agility mix', 'prayer mix', 'superattack mix', 'fishing mix', 'super energy mix', 'super str mix', 'magic essence mix', 'super restore mix', 'super def mix', 'antidote+ mix', 'antifire mix', 'ranging mix', 'magic mix', 'hunting mix', 'zamorak mix', 'super ranging', 'super magic potion', 'overload', 'extended antifire mix', 'stamina potion', 'stamina mix', 'super combat potion', 'rejuvenation potion', 'elder', 'elder potion', 'twisted', 'twisted potion', 'kodai', 'kodai potion', 'revitalisation potion', 'prayer enhance', 'super antifire potion', 'super antifire mix', 'extended super antifire', 'extended super antifire mix', 'battlemage potion', 'bastion potion', 'divine super combat potion', 'divine super attack potion', 'divine super strength potion', 'divine super defence potion', 'divine ranging potion', 'divine magic potion', 'egniol potion', 'blighted super restore', 'divine battlemage potion', 'divine bastion potion', 'castlewars brew', 'potion of power', 'antipoison potion', 'ancient brew', 'ancient mix', 'goblin potion', 'forgotten brew']
```

https://github.com/runelite/runelite/assets/24556079/b0a48d1d-e763-431c-8e4a-42c6732a6a8f

