### PR TITLE
Add Filter Violators config option to chat filter plugin

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatfilter/ChatFilterConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatfilter/ChatFilterConfig.java
@@ -175,4 +175,15 @@ public interface ChatFilterConfig extends Config
 	{
 		return false;
 	}
+
+	@ConfigItem(
+			keyName = "filterUsersMessagesAfterViolation",
+			name = "Filter Violators",
+			description = "Filter a player's future messages if they violate a configured filter",
+			position = 14
+	)
+	default boolean filterUsersMessagesAfterViolation()
+	{
+		return true;
+	}
 }

--- a/runelite-client/src/test/java/net/runelite/client/plugins/chatfilter/ChatFilterPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/chatfilter/ChatFilterPluginTest.java
@@ -464,4 +464,19 @@ public class ChatFilterPluginTest
 		String message = chatFilterPlugin.censorMessage("Adam", "start f<lt>ilte<gt>r end");
 		assertEquals("start ******** end", message);
 	}
+
+	@Test
+	public void testFilterUsersMessagesAfterViolation()
+	{
+		when(chatFilterConfig.filterUsersMessagesAfterViolation()).thenReturn(true);
+		when(chatFilterConfig.filterType()).thenReturn(ChatFilterType.REMOVE_MESSAGE);
+		when(chatFilterConfig.filteredRegex()).thenReturn("remote infernal service");
+		chatFilterPlugin.updateFilteredPatterns();
+
+		// matches filter
+		chatFilterPlugin.onScriptCallbackEvent(createCallbackEvent("offenderName", "remote infernal service", ChatMessageType.PUBLICCHAT));
+		// doesn't match filter, but blocked due to prior violation
+		chatFilterPlugin.onScriptCallbackEvent(createCallbackEvent("offenderName", "we have the best prices", ChatMessageType.PUBLICCHAT));
+		assertEquals(0, client.getIntStack()[client.getIntStackSize() - 3]);
+	}
 }


### PR DESCRIPTION
Related to this discussion where a similar feature is requested: https://github.com/runelite/runelite/discussions/17021

The feature adds a configuration option that when enabled would filter out all messages from a user after one of their messages is found to match an existing filter.

### Implementation notes:
So this PR deviates slightly from the suggested feature and doesn't use a count of violations. There doesn't seem to be an easy way to accurately count how many times a user sent a message that got filtered without accidentally double counting messages. It's possibly noteworthy that the ignored users only exist in memory and won't persist. Modifying the config with the `configManager` is awkward because there is already a list of patterns used to ignore users that would ideally be used but they're patterns not usernames and the UI wouldn't immediately show config changes. If using a separate list of users in the config, storing the usernames would possibly really pollute the config so I think it's best avoided.