### PR TITLE
[chat commands]: Added !pb sledding

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
@@ -115,6 +115,11 @@ public class ChatCommandsPlugin extends Plugin
 	private static final Pattern RAIDS_DURATION_PATTERN = Pattern.compile("<col=ef20ff>Congratulations - your raid is complete!</col><br>Team size: <col=ff0000>" + TEAM_SIZES + "</col> Duration:</col> <col=ff0000>[0-9:.]+</col> Personal best: </col><col=ff0000>(?<pb>[0-9:]+(?:\\.[0-9]+)?)</col>");
 	private static final Pattern KILL_DURATION_PATTERN = Pattern.compile("(?i)(?:(?:Fight |Lap |Challenge |Corrupted challenge )?duration:|Subdued in|(?<!total )completion time:) <col=[0-9a-f]{6}>[0-9:.]+</col>\\. Personal best: (?:<col=ff0000>)?(?<pb>[0-9:]+(?:\\.[0-9]+)?)");
 	private static final Pattern NEW_PB_PATTERN = Pattern.compile("(?i)(?:(?:Fight |Lap |Challenge |Corrupted challenge )?duration:|Subdued in|(?<!total )completion time:) <col=[0-9a-f]{6}>(?<pb>[0-9:]+(?:\\.[0-9]+)?)</col> \\(new personal best\\)");
+
+	private static final Pattern SLEDDING_PB_PATTERN = Pattern.compile("(?i)(?:You completed the race in: <col=[0-9a-f]{6}>[0-9:.]+</col>. |New )personal best: (?:<col=[0-9a-z]{6}>)?(?<pb>[0-9:]+(?:\\.[0-9]+)?)");
+
+	private static final String SLEDDING_COMPLETION_MESSAGE = "You land softly in a pile of snow at the bottom of the slope.";
+
 	private static final Pattern DUEL_ARENA_WINS_PATTERN = Pattern.compile("You (were defeated|won)! You have(?: now)? won ([\\d,]+|one) duels?");
 	private static final Pattern DUEL_ARENA_LOSSES_PATTERN = Pattern.compile("You have(?: now)? lost ([\\d,]+|one) duels?");
 	private static final Pattern ADVENTURE_LOG_TITLE_PATTERN = Pattern.compile("The Exploits of (.+)");
@@ -553,6 +558,19 @@ public class ChatCommandsPlugin extends Plugin
 		if (matcher.find())
 		{
 			matchPb(matcher);
+		}
+
+		matcher = SLEDDING_PB_PATTERN.matcher(message);
+		if (matcher.find())
+		{
+			matchPb(matcher);
+		}
+
+		if (message.equals(SLEDDING_COMPLETION_MESSAGE) && lastPb > -1)
+		{
+			setPb("Sledding", lastPb);
+			lastPb = -1;
+			lastTeamSize = null;
 		}
 
 		matcher = HS_PB_PATTERN.matcher(message);

--- a/runelite-client/src/test/java/net/runelite/client/plugins/chatcommands/ChatCommandsPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/chatcommands/ChatCommandsPluginTest.java
@@ -1360,4 +1360,36 @@ public class ChatCommandsPluginTest
 		verify(configManager).setRSProfileConfiguration("personalbest", "tombs of amascut entry mode", 20 * 60 + 31.);
 		verify(configManager).setRSProfileConfiguration("personalbest", "tombs of amascut entry mode 2 players", 20 * 60 + 31.);
 	}
+
+	@Test
+	public void testFirstSleddingPb()
+	{
+		// This for some reason publishes:
+		// "New personal best: <col=[0-9a-f]{6}>1:23</col>" for the first race, then "You completed the race in: <col=[0-9a-f]{6}>1:23</col>. Personal best: 1:23" subsequently.
+		// We can only tell it's sledding (and not one of the many other races) by the subsequent chat message "You land softly in a pile of snow at the bottom of the slope."
+
+		ChatMessage chatMessage = new ChatMessage(null, GAMEMESSAGE, "", "New personal best: <col=ef1020>1:05</col>", null, 0);
+		chatCommandsPlugin.onChatMessage(chatMessage);
+
+		chatMessage = new ChatMessage(null, GAMEMESSAGE, "", "You land softly in a pile of snow at the bottom of the slope.", null, 0);
+		chatCommandsPlugin.onChatMessage(chatMessage);
+
+		verify(configManager).setRSProfileConfiguration("personalbest", "Sledding".toLowerCase(), 65.0);
+	}
+
+	@Test
+	public void testSubsequentSleddingPb()
+	{
+		// This for some reason publishes:
+		// "New personal best: <col=[0-9a-f]{6}>1:23</col>" for the first race, then "You completed the race in: <col=[0-9a-f]{6}>1:23</col>. Personal best: 1:23" subsequently.
+		// We can only tell it's sledding (and not one of the many other races) by the subsequent chat message "You land softly in a pile of snow at the bottom of the slope."
+
+		ChatMessage chatMessage = new ChatMessage(null, GAMEMESSAGE, "", "You completed the race in: <col=ef1020>1:23</col>. Personal best: 1:05", null, 0);
+		chatCommandsPlugin.onChatMessage(chatMessage);
+
+		chatMessage = new ChatMessage(null, GAMEMESSAGE, "", "You land softly in a pile of snow at the bottom of the slope.", null, 0);
+		chatCommandsPlugin.onChatMessage(chatMessage);
+
+		verify(configManager).setRSProfileConfiguration("personalbest", "Sledding".toLowerCase(), 65.0);
+	}
 }


### PR DESCRIPTION
Sledding is very odd in that it gives the messages backwards, and the completion message is a static string:
![image](https://github.com/runelite/runelite/assets/842695/84208af5-12f8-4ab5-8649-be26b38246e9)

and for subsequent (non PB runs):
![image](https://github.com/runelite/runelite/assets/842695/84d28c8c-f8f1-4f99-a900-2e01bfc346c5)

then when you're back to PB:
![image](https://github.com/runelite/runelite/assets/842695/4e46b51d-283a-489c-904e-27d2fba1f5d7)

