### PR TITLE
Make config section toggle more resistant to mouse movement

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
@@ -314,10 +314,27 @@ class ConfigPanel extends PluginPanel
 			// Add listeners to each part of the header so that it's easier to toggle them
 			final MouseAdapter adapter = new MouseAdapter()
 			{
+				boolean isClicking = false;
+
 				@Override
-				public void mouseClicked(MouseEvent e)
+				public void mousePressed(MouseEvent e)
 				{
-					toggleSection(csd, sectionToggle, sectionContents);
+					isClicking = true;
+				}
+
+				@Override
+				public void mouseExited(MouseEvent e)
+				{
+					isClicking = false;
+				}
+
+				@Override
+				public void mouseReleased(MouseEvent e)
+				{
+					if (isClicking)
+					{
+						toggleSection(csd, sectionToggle, sectionContents);
+					}
 				}
 			};
 			sectionToggle.addActionListener(actionEvent -> toggleSection(csd, sectionToggle, sectionContents));


### PR DESCRIPTION
Previously the config panel section toggles would only expand/collapse if you clicked down and up without moving your mouse a single pixel. This makes it behave closer to a normal button.