### PR TITLE
fishingspot: raw karambwanji sprite instead of (cooked) karambwanji

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/game/FishingSpot.java
+++ b/runelite-client/src/main/java/net/runelite/client/game/FishingSpot.java
@@ -88,7 +88,7 @@ public enum FishingSpot
 	KARAMBWAN("Karambwan", ItemID.RAW_KARAMBWAN,
 		FISHING_SPOT_4712, FISHING_SPOT_4713
 	),
-	KARAMBWANJI("Karambwanji, Shrimp", "Karambwanji", ItemID.KARAMBWANJI,
+	KARAMBWANJI("Karambwanji, Shrimp", "Karambwanji", ItemID.RAW_KARAMBWANJI,
 		FISHING_SPOT_4710
 	),
 	SACRED_EEL("Sacred eel", ItemID.SACRED_EEL,


### PR DESCRIPTION
Changed ItemID in Fishing spot enum constant from karambwanji to raw karambwanji. (cooked karambwanji sprite erroneously shows ingame)