### PR TITLE
devtools: fix exception from widgetInspector

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/devtools/WidgetInspector.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/devtools/WidgetInspector.java
@@ -397,9 +397,14 @@ class WidgetInspector extends DevToolsFrame
 					.reversed()
 					.thenComparingInt(Widget::getId)
 					.reversed())
-				.findFirst().get();
+				.findFirst().orElse(null);
 			x = 4;
 			y = 4;
+		}
+
+		if (parent == null)
+		{
+			return;
 		}
 
 		picker = parent.createChild(-1, WidgetType.GRAPHIC);


### PR DESCRIPTION
Opening the widget inspector whence no widgets exist throws NoSuchElementException, such as from login screen.