### PR TITLE
party: tie ping duration to system time

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/party/PartyPingOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/party/PartyPingOverlay.java
@@ -75,8 +75,8 @@ class PartyPingOverlay extends Overlay
 
 				renderPing(graphics, next);
 
-				long elapsedTime = System.currentTimeMillis() - next.getCreationTime();
-				next.setAlpha((int) Math.max(0, 255 - (elapsedTime / 4)));
+				long elapsedTimeMillis = (System.nanoTime() - next.getCreationTime()) / 1000000;
+				next.setAlpha((int) Math.max(0, 255 - (elapsedTimeMillis / 4)));
 			}
 		}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/party/PartyPingOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/party/PartyPingOverlay.java
@@ -74,7 +74,9 @@ class PartyPingOverlay extends Overlay
 				}
 
 				renderPing(graphics, next);
-				next.setAlpha(next.getAlpha() - 5);
+
+				long elapsedTime = System.currentTimeMillis() - next.getCreationTime();
+				next.setAlpha((int) Math.max(0, 255 - (elapsedTime / 4)));
 			}
 		}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/party/data/PartyTilePingData.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/party/data/PartyTilePingData.java
@@ -38,4 +38,5 @@ public class PartyTilePingData
 	private final WorldPoint point;
 	private final Color color;
 	private int alpha = 255;
+	private final long creationTime = System.currentTimeMillis();
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/party/data/PartyTilePingData.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/party/data/PartyTilePingData.java
@@ -38,5 +38,5 @@ public class PartyTilePingData
 	private final WorldPoint point;
 	private final Color color;
 	private int alpha = 255;
-	private final long creationTime = System.currentTimeMillis();
+	private final long creationTime = System.nanoTime();
 }


### PR DESCRIPTION
Currently, the ping duration is tied to the current fps. This commit solves this by instead decreasing the ping alpha by checking the elapsed time of when the ping was first created, and the current time.

(Clips are taken at 165fps)
Before:

https://github.com/runelite/runelite/assets/83369117/fe64a31b-5516-4c4f-8b25-3a8f9ffff7fa

After:

https://github.com/runelite/runelite/assets/83369117/67aa6aa3-d64a-408b-9a02-cf2856b41f8f

