### PR TITLE
Opponent Info plugin: add toggle to only show boss health overlay

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/opponentinfo/OpponentInfoConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/opponentinfo/OpponentInfoConfig.java
@@ -65,13 +65,13 @@ public interface OpponentInfoConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "onlyShowBossHealthOverlay",
-		name = "Only show boss health overlay",
-		description = "Hides this plugin's additional health overlay; only modifies the in-game setting 'boss health overlay'",
+		keyName = "showOpponentHealthOverlay",
+		name = "Show opponent health overlay",
+		description = "Shows a health bar overlay when a boss health overlay is not present",
 		position = 4
 	)
-	default boolean onlyShowBossHealthOverlay()
+	default boolean showOpponentHealthOverlay()
 	{
-		return false;
+		return true;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/opponentinfo/OpponentInfoConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/opponentinfo/OpponentInfoConfig.java
@@ -63,4 +63,15 @@ public interface OpponentInfoConfig extends Config
 	{
 		return false;
 	}
+
+	@ConfigItem(
+		keyName = "onlyShowBossHealthOverlay",
+		name = "Only show boss health overlay",
+		description = "Hides this plugin's additional health overlay; only modifies the in-game setting 'boss health overlay'",
+		position = 4
+	)
+	default boolean onlyShowBossHealthOverlay()
+	{
+		return false;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/opponentinfo/OpponentInfoOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/opponentinfo/OpponentInfoOverlay.java
@@ -140,8 +140,8 @@ class OpponentInfoOverlay extends OverlayPanel
 		}
 
 		// The in-game hp hud is more accurate than our overlay and duplicates all of the information on it,
-		// so hide ours if it is visible.
-		if (opponentName == null || hasHpHud(opponent))
+		// so hide ours if it is visible, or if our overlay is toggled off.
+		if (opponentName == null || hasHpHud(opponent) || opponentInfoConfig.onlyShowBossHealthOverlay())
 		{
 			return null;
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/opponentinfo/OpponentInfoOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/opponentinfo/OpponentInfoOverlay.java
@@ -141,7 +141,7 @@ class OpponentInfoOverlay extends OverlayPanel
 
 		// The in-game hp hud is more accurate than our overlay and duplicates all of the information on it,
 		// so hide ours if it is visible, or if our overlay is toggled off.
-		if (opponentName == null || hasHpHud(opponent) || opponentInfoConfig.onlyShowBossHealthOverlay())
+		if (opponentName == null || hasHpHud(opponent) || !opponentInfoConfig.showOpponentHealthOverlay())
 		{
 			return null;
 		}


### PR DESCRIPTION
Allows the Opponent Info plugin's custom health overlay to be toggled off, so that only the in-game setting 'boss health overlay' is affected.

Use case is I want to have both exact health amounts and percentage displayed on boss health bars (below), but I do not want the custom overlay displayed for non-boss monsters or players.
 ![image](https://github.com/runelite/runelite/assets/55075114/d7f12eac-426a-4898-a37d-19dcb9c6d6f7)

This is the overlay that is being made toggleable (example of an NPC and a player): 
![image](https://github.com/runelite/runelite/assets/55075114/4d5bcb2b-3e39-4ba0-810c-7bb0793c6166)
![image](https://github.com/runelite/runelite/assets/55075114/15a54af4-9b6d-4e97-b03e-a255389bc52a)

This overlay is unaffected, can still be toggled on/off independent of the new config:
![image](https://github.com/runelite/runelite/assets/55075114/9bffd970-9158-4528-97b7-6ca853e18112)
