### PR TITLE
twitch: prepend oauth prefix to token if missing

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/twitch/TwitchPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/twitch/TwitchPlugin.java
@@ -113,7 +113,8 @@ public class TwitchPlugin extends Plugin implements TwitchListener
 				channel = "#" + channel;
 			}
 			String token = twitchConfig.oauthToken().trim();
-			if (!token.startsWith("oauth:")) {
+			if (!token.startsWith("oauth:"))
+			{
 				token = "oauth:" + token;
 			}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/twitch/TwitchPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/twitch/TwitchPlugin.java
@@ -112,13 +112,17 @@ public class TwitchPlugin extends Plugin implements TwitchListener
 			{
 				channel = "#" + channel;
 			}
+			String token = twitchConfig.oauthToken().trim();
+			if (!token.startsWith("oauth:")) {
+				token = "oauth:" + token;
+			}
 
 			log.debug("Connecting to Twitch as {}", twitchConfig.username());
 
 			twitchIRCClient = new TwitchIRCClient(
 				this,
 				twitchConfig.username(),
-				twitchConfig.oauthToken(),
+				token,
 				channel
 			);
 			twitchIRCClient.start();


### PR DESCRIPTION
The `oauth:` prefix is [required](https://dev.twitch.tv/docs/irc/authenticate-bot/#sending-the-pass-and-nick-messages) by twitch. Sometimes users don't include it, which leads to support requests (for example these two from the past month):
* https://discord.com/channels/301497432909414422/442492468307427330/1164687514859216896
* https://discord.com/channels/301497432909414422/334801290645209099/1160017867929047110

