### PR TITLE
Draft: Show account session name on logout tooltip

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/account/AccountPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/account/AccountPlugin.java
@@ -83,10 +83,14 @@ public class AccountPlugin extends Plugin
 			.onClick(this::loginClick)
 			.build();
 
+		final String signOutSuffix = sessionManager.getAccountSession() != null
+				? " (" + sessionManager.getAccountSession().getUsername() + ")"
+				: "";
+
 		logoutButton = NavigationButton.builder()
 			.tab(false)
 			.icon(LOGOUT_IMAGE)
-			.tooltip("Sign out of RuneLite")
+			.tooltip(String.format("Sign out of RuneLite%s", signOutSuffix))
 			.onClick(this::logoutClick)
 			.build();
 


### PR DESCRIPTION
## What does this do and why?

If you have multiple instances of runelite running it's not quite clear what you're signing out of. This adds the username of the session to the signout in the top right.

| Before | After |
|--------|--------|
| ![rl1](https://github.com/runelite/runelite/assets/3660408/8101a27c-d4b9-4935-84fd-7d687b11154e) | |
 

The reason it's still a Draft is because this was a very quick POC and I did not validate if it works.  I still need to test it but haven't got time to setup the full project and run it locally yet.