### PR TITLE
slayer: display wilderness slayer task streak

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerPlugin.java
@@ -109,6 +109,9 @@ public class SlayerPlugin extends Plugin
 	private static final Pattern TASK_STRING_VALIDATION = Pattern.compile("[^a-zA-Z0-9' -]");
 	private static final int TASK_STRING_MAX_LENGTH = 50;
 
+	// Task streak
+	private static final int KRYSTILIA_SLAYER_MASTER = 7;
+
 	@Inject
 	private Client client;
 
@@ -324,7 +327,7 @@ public class SlayerPlugin extends Plugin
 		{
 			clientThread.invokeLater(this::updateTask);
 		}
-		else if (varbitId == VarbitID.SLAYER_POINTS || varbitId == VarbitID.SLAYER_TASKS_COMPLETED)
+		else if (varbitId == VarbitID.SLAYER_POINTS || varbitId == VarbitID.SLAYER_TASKS_COMPLETED || varbitId == VarbitID.SLAYER_WILDERNESS_TASKS_COMPLETED)
 		{
 			// points and streaks are in the counter's tooltip, so require a rebuild if it changes
 			if (counter != null)
@@ -623,8 +626,11 @@ public class SlayerPlugin extends Plugin
 				+ " " + initialAmount;
 		}
 
+		final int streak = client.getVarbitValue(VarbitID.SLAYER_MASTER) == KRYSTILIA_SLAYER_MASTER
+			? client.getVarbitValue(VarbitID.SLAYER_WILDERNESS_TASKS_COMPLETED)
+			: client.getVarbitValue(VarbitID.SLAYER_TASKS_COMPLETED);
 		counter = new TaskCounter(taskImg, this, amount);
-		counter.setTooltip(String.format(taskTooltip, capsString(taskName), client.getVarbitValue(VarbitID.SLAYER_POINTS), client.getVarbitValue(VarbitID.SLAYER_TASKS_COMPLETED)));
+		counter.setTooltip(String.format(taskTooltip, capsString(taskName), client.getVarbitValue(VarbitID.SLAYER_POINTS),  streak));
 
 		infoBoxManager.addInfoBox(counter);
 	}


### PR DESCRIPTION
Displays the wilderness slayer task streak if the player has a wilderness slayer task.

Spiritual creatures wildy task:
runelite/master
![image](https://github.com/runelite/runelite/assets/7929021/8f1e6cbb-1616-4668-9c7e-77f5ef93fc5c)

runelite/krystilia-task-streak
![image](https://github.com/runelite/runelite/assets/7929021/96fdfecc-5eca-47f9-a172-b511faf4cac4)

Closes #7329