### PR TITLE
Fix screenshots for level 99 messages with level-up dialogs disabled

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
@@ -104,8 +104,7 @@ public class ScreenshotPlugin extends Plugin
 	private static final int CORRUPTED_GAUNTLET_REGION = 7768;
 	private static final Pattern NUMBER_PATTERN = Pattern.compile("([0-9]+)");
 	private static final Pattern LEVEL_UP_PATTERN = Pattern.compile(".*Your ([a-zA-Z]+) (?:level is|are)? now (\\d+)\\.");
-	private static final Pattern LEVEL_UP_MESSAGE_PATTERN = Pattern.compile("Congratulations, you've just advanced your ([a-zA-Z]+) level. You are now level (\\d+)\\.");
-	private static final Pattern LEVEL_UP_MESSAGE_PATTERN_99 = Pattern.compile("Congratulations, you've reached the highest possible ([a-zA-Z]+) level of 99.");
+	private static final Pattern LEVEL_UP_MESSAGE_PATTERN = Pattern.compile("Congratulations, you've (?:just advanced your ([a-zA-Z]+) level\\. You are now level (\\d+)|reached the highest possible ([a-zA-Z]+) level of (99))\\.");
 	private static final Pattern BOSSKILL_MESSAGE_PATTERN = Pattern.compile("Your (.+) kill count is: <col=ff0000>(\\d+)</col>.");
 	private static final Pattern VALUABLE_DROP_PATTERN = Pattern.compile(".*Valuable drop: ([^<>]+?\\(((?:\\d+,?)+) coins\\))(?:</col>)?");
 	private static final Pattern UNTRADEABLE_DROP_PATTERN = Pattern.compile(".*Untradeable drop: ([^<>]+)(?:</col>)?");
@@ -523,20 +522,11 @@ public class ScreenshotPlugin extends Plugin
 		if (client.getVarbitValue(Varbits.DISABLE_LEVEL_UP_INTERFACE) == 1 && config.screenshotLevels())
 		{
 			Matcher m = LEVEL_UP_MESSAGE_PATTERN.matcher(chatMessage);
-			if (m.find())
+			if (m.matches())
 			{
-				String skillName = StringUtils.capitalize(m.group(1));
-				String skillLevel = m.group(2);
+				String skillName = StringUtils.capitalize(m.group(1) != null ? m.group(1) : m.group(3));
+				String skillLevel = m.group(2) != null ? m.group(2) : m.group(4);
 				String fileName = skillName + "(" + skillLevel + ")";
-				String screenshotSubDir = "Levels";
-				takeScreenshot(fileName, screenshotSubDir);
-			}
-
-			Matcher m99 = LEVEL_UP_MESSAGE_PATTERN_99.matcher(chatMessage);
-			if (m99.find())
-			{
-				String skillName = StringUtils.capitalize(m99.group(1));
-				String fileName = skillName + "(99)";
 				String screenshotSubDir = "Levels";
 				takeScreenshot(fileName, screenshotSubDir);
 			}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
@@ -105,6 +105,7 @@ public class ScreenshotPlugin extends Plugin
 	private static final Pattern NUMBER_PATTERN = Pattern.compile("([0-9]+)");
 	private static final Pattern LEVEL_UP_PATTERN = Pattern.compile(".*Your ([a-zA-Z]+) (?:level is|are)? now (\\d+)\\.");
 	private static final Pattern LEVEL_UP_MESSAGE_PATTERN = Pattern.compile("Congratulations, you've just advanced your ([a-zA-Z]+) level. You are now level (\\d+)\\.");
+	private static final Pattern LEVEL_UP_MESSAGE_PATTERN_99 = Pattern.compile("Congratulations, you've reach the highest possible ([a-zA-Z]+) level of 99.");
 	private static final Pattern BOSSKILL_MESSAGE_PATTERN = Pattern.compile("Your (.+) kill count is: <col=ff0000>(\\d+)</col>.");
 	private static final Pattern VALUABLE_DROP_PATTERN = Pattern.compile(".*Valuable drop: ([^<>]+?\\(((?:\\d+,?)+) coins\\))(?:</col>)?");
 	private static final Pattern UNTRADEABLE_DROP_PATTERN = Pattern.compile(".*Untradeable drop: ([^<>]+)(?:</col>)?");
@@ -527,6 +528,14 @@ public class ScreenshotPlugin extends Plugin
 				String skillName = StringUtils.capitalize(m.group(1));
 				String skillLevel = m.group(2);
 				String fileName = skillName + "(" + skillLevel + ")";
+				String screenshotSubDir = "Levels";
+				takeScreenshot(fileName, screenshotSubDir);
+			}
+
+			Matcher m99 = LEVEL_UP_MESSAGE_PATTERN_99.matcher(chatMessage);
+			if (m99.find()) {
+				String skillName = StringUtils.capitalize(m99.group(1));
+				String fileName = skillName + "(99)";
 				String screenshotSubDir = "Levels";
 				takeScreenshot(fileName, screenshotSubDir);
 			}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
@@ -105,7 +105,7 @@ public class ScreenshotPlugin extends Plugin
 	private static final Pattern NUMBER_PATTERN = Pattern.compile("([0-9]+)");
 	private static final Pattern LEVEL_UP_PATTERN = Pattern.compile(".*Your ([a-zA-Z]+) (?:level is|are)? now (\\d+)\\.");
 	private static final Pattern LEVEL_UP_MESSAGE_PATTERN = Pattern.compile("Congratulations, you've just advanced your ([a-zA-Z]+) level. You are now level (\\d+)\\.");
-	private static final Pattern LEVEL_UP_MESSAGE_PATTERN_99 = Pattern.compile("Congratulations, you've reach the highest possible ([a-zA-Z]+) level of 99.");
+	private static final Pattern LEVEL_UP_MESSAGE_PATTERN_99 = Pattern.compile("Congratulations, you've reached the highest possible ([a-zA-Z]+) level of 99.");
 	private static final Pattern BOSSKILL_MESSAGE_PATTERN = Pattern.compile("Your (.+) kill count is: <col=ff0000>(\\d+)</col>.");
 	private static final Pattern VALUABLE_DROP_PATTERN = Pattern.compile(".*Valuable drop: ([^<>]+?\\(((?:\\d+,?)+) coins\\))(?:</col>)?");
 	private static final Pattern UNTRADEABLE_DROP_PATTERN = Pattern.compile(".*Untradeable drop: ([^<>]+)(?:</col>)?");

--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
@@ -104,7 +104,7 @@ public class ScreenshotPlugin extends Plugin
 	private static final int CORRUPTED_GAUNTLET_REGION = 7768;
 	private static final Pattern NUMBER_PATTERN = Pattern.compile("([0-9]+)");
 	private static final Pattern LEVEL_UP_PATTERN = Pattern.compile(".*Your ([a-zA-Z]+) (?:level is|are)? now (\\d+)\\.");
-	private static final Pattern LEVEL_UP_MESSAGE_PATTERN = Pattern.compile("Congratulations, you've (?:just advanced your ([a-zA-Z]+) level\\. You are now level (\\d+)|reached the highest possible ([a-zA-Z]+) level of (99))\\.");
+	private static final Pattern LEVEL_UP_MESSAGE_PATTERN = Pattern.compile("Congratulations, you've (just advanced your (?<skill>[a-zA-Z]+) level\\. You are now level (?<level>\\d+)|reached the highest possible (?<skill99>[a-zA-Z]+) level of 99)\\.");
 	private static final Pattern BOSSKILL_MESSAGE_PATTERN = Pattern.compile("Your (.+) kill count is: <col=ff0000>(\\d+)</col>.");
 	private static final Pattern VALUABLE_DROP_PATTERN = Pattern.compile(".*Valuable drop: ([^<>]+?\\(((?:\\d+,?)+) coins\\))(?:</col>)?");
 	private static final Pattern UNTRADEABLE_DROP_PATTERN = Pattern.compile(".*Untradeable drop: ([^<>]+)(?:</col>)?");
@@ -524,8 +524,8 @@ public class ScreenshotPlugin extends Plugin
 			Matcher m = LEVEL_UP_MESSAGE_PATTERN.matcher(chatMessage);
 			if (m.matches())
 			{
-				String skillName = StringUtils.capitalize(m.group(1) != null ? m.group(1) : m.group(3));
-				String skillLevel = m.group(2) != null ? m.group(2) : m.group(4);
+				String skillName = StringUtils.capitalize(m.group("skill") != null ? m.group("skill") : m.group("skill99"));
+				String skillLevel = m.group("level") != null ? m.group("level") : "99";
 				String fileName = skillName + "(" + skillLevel + ")";
 				String screenshotSubDir = "Levels";
 				takeScreenshot(fileName, screenshotSubDir);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
@@ -533,7 +533,8 @@ public class ScreenshotPlugin extends Plugin
 			}
 
 			Matcher m99 = LEVEL_UP_MESSAGE_PATTERN_99.matcher(chatMessage);
-			if (m99.find()) {
+			if (m99.find())
+			{
 				String skillName = StringUtils.capitalize(m99.group(1));
 				String fileName = skillName + "(99)";
 				String screenshotSubDir = "Levels";

--- a/runelite-client/src/test/java/net/runelite/client/plugins/screenshot/ScreenshotPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/screenshot/ScreenshotPluginTest.java
@@ -82,6 +82,7 @@ public class ScreenshotPluginTest
 	private static final String BA_HIGH_GAMBLE_REWARD = "Raw shark (x 300)!<br>High level gamble count: <col=7f0000>100</col>";
 	private static final String HUNTER_LEVEL_2_TEXT = "<col=000080>Congratulations, you've just advanced a Hunter level.<col=000000><br><br>Your Hunter level is now 2.";
 	private static final String CRAFTING_LEVEL_96_MESSAGE = "Congratulations, you've just advanced your Crafting level. You are now level 96.";
+	private static final String STRENGTH_LEVEL_99_MESSAGE = "Congratulations, you've reached the highest possible Strength level of 99.";
 	private static final String COLLECTION_LOG_CHAT = "New item added to your collection log: <col=ef1020>Chompy bird hat</col>";
 
 	@Mock
@@ -349,6 +350,23 @@ public class ScreenshotPluginTest
 		screenshotPlugin.onChatMessage(chatMessageEvent);
 
 		verify(screenshotPlugin).takeScreenshot("Crafting(96)", "Levels");
+		reset(screenshotPlugin);
+
+		when(client.getVarbitValue(Varbits.DISABLE_LEVEL_UP_INTERFACE)).thenReturn(0);
+
+		screenshotPlugin.onChatMessage(chatMessageEvent);
+		verify(screenshotPlugin, never()).takeScreenshot(anyString(), anyString());
+	}
+
+	@Test
+	public void testStrengthLevel99NoInterface()
+	{
+		when(client.getVarbitValue(Varbits.DISABLE_LEVEL_UP_INTERFACE)).thenReturn(1);
+
+		ChatMessage chatMessageEvent = new ChatMessage(null, GAMEMESSAGE, "", STRENGTH_LEVEL_99_MESSAGE, null, 0);
+		screenshotPlugin.onChatMessage(chatMessageEvent);
+
+		verify(screenshotPlugin).takeScreenshot("Strength(99)", "Levels");
 		reset(screenshotPlugin);
 
 		when(client.getVarbitValue(Varbits.DISABLE_LEVEL_UP_INTERFACE)).thenReturn(0);


### PR DESCRIPTION
#17152

When level-up dialogs are disabled, we check chat messages to capture screenshots for level ups. However, the chat message displayed for level 99 level ups is slightly different than non-99s, meaning we weren't taking screenshots for 99 level ups.

This PR adds a pattern to capture the 99 message, and checks for it after checking for the non-99 pattern.