### PR TITLE
Fishing Plugin: Ensure `setLastFishCaught` is called when catching Karambwanjis

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingPlugin.java
@@ -85,7 +85,7 @@ public class FishingPlugin extends Plugin
 	private static final int TRAWLER_SHIP_REGION_NORMAL = 7499;
 	private static final int TRAWLER_SHIP_REGION_SINKING = 8011;
 	private static final int TRAWLER_TIME_LIMIT_IN_SECONDS = 314;
-	private static final Pattern CAUGHT_KARAMBWANJI_MESSAGE = Pattern.compile("You catch (\\d+) Karambwanji.");
+	private static final Pattern CAUGHT_FISH_MESSAGE = Pattern.compile("You catch (?:a|some|\\d+ Karambwanji\\.)");
 
 	private Instant trawlerStartTime;
 
@@ -197,10 +197,9 @@ public class FishingPlugin extends Plugin
 		}
 
 		String message = event.getMessage();
-		Matcher m = CAUGHT_KARAMBWANJI_MESSAGE.matcher(message);
+		Matcher m = CAUGHT_FISH_MESSAGE.matcher(message);
 
-		if (message.contains("You catch a") || message.contains("You catch some") ||
-			message.equals("Your cormorant returns with its catch.") || m.matches())
+		if (message.equals("Your cormorant returns with its catch.") || m.find())
 		{
 			session.setLastFishCaught(Instant.now());
 			spotOverlay.setHidden(false);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingPlugin.java
@@ -33,6 +33,8 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import lombok.AccessLevel;
@@ -83,6 +85,7 @@ public class FishingPlugin extends Plugin
 	private static final int TRAWLER_SHIP_REGION_NORMAL = 7499;
 	private static final int TRAWLER_SHIP_REGION_SINKING = 8011;
 	private static final int TRAWLER_TIME_LIMIT_IN_SECONDS = 314;
+	private static final Pattern CAUGHT_KARAMBWANJI_MESSAGE = Pattern.compile("You catch (\\d+) Karambwanji.");
 
 	private Instant trawlerStartTime;
 
@@ -193,15 +196,18 @@ public class FishingPlugin extends Plugin
 			return;
 		}
 
-		if (event.getMessage().contains("You catch a") || event.getMessage().contains("You catch some") ||
-			event.getMessage().equals("Your cormorant returns with its catch."))
+		String message = event.getMessage();
+		Matcher m = CAUGHT_KARAMBWANJI_MESSAGE.matcher(message);
+
+		if (message.contains("You catch a") || message.contains("You catch some") ||
+			message.equals("Your cormorant returns with its catch.") || m.matches())
 		{
 			session.setLastFishCaught(Instant.now());
 			spotOverlay.setHidden(false);
 			fishingSpotMinimapOverlay.setHidden(false);
 		}
 
-		if (event.getMessage().equals("A flying fish jumps up and eats some of your minnows!") && config.flyingFishNotification())
+		if (message.equals("A flying fish jumps up and eats some of your minnows!") && config.flyingFishNotification())
 		{
 			notifier.notify("A flying fish is eating your minnows!");
 		}


### PR DESCRIPTION
Fixes #17087 (see issue for my reproduction + screenshot)

The message displayed while catching Karambwanjis is slightly different from the other fishing related messages, meaning that it was possible to get into a state where the fishing overlay wouldn't appear even though you were actively fishing for Karambwanjis. This was happening because `lastFishCaught` was never set (and the overlay requires `lastFishCaught` to be set in order to appear).

This PR fixes that issue. I can now approach a Karambwanji spot with a full inventory, start fishing, and see the fishing overlay appear as soon as the first XP drop appears.

~Notably, the "Caught fish" message isn't quite right - it is only taking into account actions taken, but one action can result in a variable amount of karambwanjis being caught at once (depending on fishing level). Fixing that is a larger change so I've left it out for now, but I'm happy to give it a shot if people would like it done.~ I've received confirmation that we are intentionally tracking actions [here](https://github.com/runelite/runelite/issues/17087#issuecomment-1787494910).