### PR TITLE
Fix rune pouch overlay for 4th/5th runes in leagues

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/runepouch/RunepouchOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/runepouch/RunepouchOverlay.java
@@ -218,6 +218,7 @@ class RunepouchOverlay extends WidgetItemOverlay
 	private void renderGrid(Graphics2D graphics, WidgetItem widgetItem, int[] runeIds, int[] amounts, int numRunes)
 	{
 		final Point location = widgetItem.getCanvasLocation();
+		int runeNum = -1;
 		for (int i = 0; i < NUM_SLOTS; ++i)
 		{
 			final int runeId = runeIds[i];
@@ -228,10 +229,12 @@ class RunepouchOverlay extends WidgetItemOverlay
 				continue;
 			}
 
-			final int iconX = location.getX() + 2 + (i % 2 == 1 ? IMAGE_SIZE + 2 /* pad */ + 2 /* bar offset */ : 0);
+			++runeNum;
+
+			final int iconX = location.getX() + 2 + (runeNum % 2 == 1 ? IMAGE_SIZE + 2 /* pad */ + 2 /* bar offset */ : 0);
 			final int iconY = numRunes > 4 ?
-				location.getY() - 1 + (i / 2) * IMAGE_SIZE :
-				location.getY() + 5 + (i >= 2 ? IMAGE_SIZE + 2 /* pad */ : 0);
+				location.getY() - 1 + (runeNum / 2) * IMAGE_SIZE :
+				location.getY() + 5 + (runeNum >= 2 ? IMAGE_SIZE + 2 /* pad */ : 0);
 
 			BufferedImage image = getRuneImage(runeId);
 			if (image != null)


### PR DESCRIPTION
For the leagues rune pouch extension, the 4th and 5th runes are set in the 5th and 6th rune pouch varbits, respectively.

This pull request updates the `renderGrid` method to allow skipping empty runes, using similar logic to what's in the `renderList` method.

Before:
 <img width="43" alt="pouch-before" src="https://github.com/runelite/runelite/assets/96100526/6e1c1b8f-9246-4487-8bcc-cdd0a3607dac">
<img width="43" alt="pouch-before2" src="https://github.com/runelite/runelite/assets/96100526/fcea4e8d-4b5d-4782-914e-630753d6bab3">

After:
<img width="50" alt="pouch-after" src="https://github.com/runelite/runelite/assets/96100526/c119b13a-db05-43ca-8b1a-883c0632bee9">
<img width="44" alt="pouch-after2" src="https://github.com/runelite/runelite/assets/96100526/6459e04e-ab95-4c79-8cb9-49e894f007a0">
