### PR TITLE
prayer: fix dragging prayers when plugin is disabled

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/prayer/PrayerReorder.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/prayer/PrayerReorder.java
@@ -118,6 +118,7 @@ class PrayerReorder
 	{
 		reordering = false;
 		clearPrayerTabMenus();
+		clientThread.invokeLater(() -> rebuildPrayers(false));
 		clientThread.invokeLater(this::redrawPrayers);
 	}
 


### PR DESCRIPTION
When prayer reordering is enabled and the prayer plugin gets disabled, the ``drag`` and ``drag on`` flag are not removed on plugin shutdown. Thus, the prayers remain draggable.

Before:
https://github.com/runelite/runelite/assets/7929021/7af73acb-74a5-4187-bc80-af0d370dbf2c

After:
https://github.com/runelite/runelite/assets/7929021/7efc3527-ec39-4178-8399-417c1469d146

Alternatively add something like this and invokeLater it on shutDown on the clientThread:

```
	if (isInterfaceOpen(InterfaceID.PRAYER))
	{
		var prayerbook = client.getVarbitValue(Varbits.PRAYERBOOK);
		var prayerBookEnum = getPrayerBookEnum(prayerbook);
		var prayerIds = defaultPrayerOrder(prayerBookEnum);
		for (int prayerId : prayerIds)
		{
			var prayerObjId = prayerBookEnum.getIntValue(prayerId);
			var prayerObj = client.getItemDefinition(prayerObjId);
			var prayerWidget = client.getWidget(prayerObj.getIntValue(ParamID.OC_PRAYER_COMPONENT));

			assert prayerWidget != null;

			int widgetConfig = prayerWidget.getClickMask();
			// remove drag flag
			widgetConfig &= ~DRAG;
			// remove drag on flag
			widgetConfig &= ~DRAG_ON;
			prayerWidget.setClickMask(widgetConfig);
		}
	}
```