### PR TITLE
#17049 check chest look tracker bug

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
@@ -958,7 +958,8 @@ public class LootTrackerPlugin extends Plugin
 
 			final int regionID = client.getLocalPlayer().getWorldLocation().getRegionID();
 
-			if(!lastChestChecked.isEmpty() && CHEST_EVENT_TYPES.get(regionID).equals(lastChestChecked)) {
+			if(!lastChestChecked.isEmpty() && CHEST_EVENT_TYPES.get(regionID).equals(lastChestChecked))
+			{
 				lastChestChecked = "";
 				return;
 			}
@@ -1232,7 +1233,8 @@ public class LootTrackerPlugin extends Plugin
 					}
 				}));
 			}
-		} else if(event.getMenuOption().equals("Check")){
+		} else if(event.getMenuOption().equals("Check"))
+		{
 			lastChestChecked =  (Text.removeTags(event.getMenuTarget()));
 		}
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
@@ -354,6 +354,7 @@ public class LootTrackerPlugin extends Plugin
 	private NavigationButton navButton;
 
 	private boolean chestLooted;
+	private String lastChestChecked = "";
 	private boolean lastLoadingIntoInstance;
 	private String lastPickpocketTarget;
 
@@ -954,7 +955,13 @@ public class LootTrackerPlugin extends Plugin
 			|| message.startsWith(ANCIENT_CHEST_LOOTED_MESSAGE)
 			|| LARRAN_LOOTED_PATTERN.matcher(message).matches() || ROGUES_CHEST_PATTERN.matcher(message).matches())
 		{
+
 			final int regionID = client.getLocalPlayer().getWorldLocation().getRegionID();
+
+			if(!lastChestChecked.isEmpty() && CHEST_EVENT_TYPES.get(regionID).equals(lastChestChecked)) {
+				lastChestChecked = "";
+				return;
+			}
 
 			log.debug("Chest loot matched '{}' region {}", message, regionID);
 			if (!CHEST_EVENT_TYPES.containsKey(regionID))
@@ -1225,6 +1232,8 @@ public class LootTrackerPlugin extends Plugin
 					}
 				}));
 			}
+		} else if(event.getMenuOption().equals("Check")){
+			lastChestChecked =  (Text.removeTags(event.getMenuTarget()));
 		}
 	}
 


### PR DESCRIPTION
When checking a chest, onChatMessage in LootTrackerPlugin.java would get called and create the inventory snapshot to get ready for the loot change because the "Open" and "Check" options would use the same starting text (e.g. "You have opened the Grubby Chest"). Any inventory changes after this would cause the LootTracker to increment whatever chest was checked.

I added a check when the "Check" option menu is clicked on to grab the name of the chest that was checked, and compare that to the next chest reward type chat message to make sure it was a chest that was clicked. Tested with the Grubby Chest and Larran's Big Chest.