### PR TITLE
Fix Bank tags plugin closing chatbox interfaces on most menu option clicks.

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/banktags/tabs/TabInterface.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/banktags/tabs/TabInterface.java
@@ -78,6 +78,7 @@ import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetConfig;
 import net.runelite.api.widgets.WidgetSizeMode;
 import net.runelite.api.widgets.WidgetType;
+import net.runelite.api.widgets.WidgetUtil;
 import net.runelite.client.callback.ClientThread;
 import net.runelite.client.chat.ChatMessageManager;
 import net.runelite.client.chat.QueuedMessage;
@@ -683,12 +684,18 @@ public class TabInterface
 
 	public void handleClick(MenuOptionClicked event)
 	{
+		// Close the chatbox input when clicking on things in the bank, to mimic how actions like withdrawing
+		// items or changing tabs close the withdraw-x input or the bank search input.
 		if (chatboxPanelManager.getCurrentInput() != null
-			&& event.getMenuAction() != MenuAction.CANCEL
+			&& event.getWidget() != null
 			&& !event.getMenuOption().equals(SCROLL_UP)
 			&& !event.getMenuOption().equals(SCROLL_DOWN))
 		{
-			chatboxPanelManager.close();
+			int interfaceId = WidgetUtil.componentToInterface(event.getWidget().getId());
+			if (interfaceId == InterfaceID.BANK || interfaceId == InterfaceID.BANK_INVENTORY)
+			{
+				chatboxPanelManager.close();
+			}
 		}
 
 		if (event.getMenuOption().startsWith("View tab") || event.getMenuOption().equals("View all items"))


### PR DESCRIPTION
This bug was added in 035d056 by removing a bank widget visible check.

This fix not only prevents the unwanted closes (such as of my transmog plugin which had its input closed regardless of whether the bank was open or not), but also improves the bank tags plugin's behavior, since it no longer closes the chatbox input when doing things like clicking the compass while in the bank.

I also documented the purpose of this piece of code, based off of a conversation with @raiyni in discord.