### PR TITLE
crowdsourcing plugin: Fix NullReferenceException in CrowdsourcingDialogue sanitize function

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/crowdsourcing/dialogue/CrowdsourcingDialogue.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/crowdsourcing/dialogue/CrowdsourcingDialogue.java
@@ -25,7 +25,9 @@
 
 package net.runelite.client.plugins.crowdsourcing.dialogue;
 
+import java.util.ArrayList;
 import javax.inject.Inject;
+import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
 import net.runelite.api.events.ChatMessage;
@@ -35,9 +37,11 @@ import net.runelite.api.widgets.Widget;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.plugins.crowdsourcing.CrowdsourcingManager;
 
+@Slf4j
 public class CrowdsourcingDialogue
 {
 	private static final String USERNAME_TOKEN = "%USERNAME%";
+	private static final String NON_BREAKING_SPACE = " ";
 
 	@Inject
 	private Client client;
@@ -54,7 +58,14 @@ public class CrowdsourcingDialogue
 	private String sanitize(String dialogue)
 	{
 		String username = client.getLocalPlayer().getName();
-		return dialogue.replaceAll(" ", " ").replaceAll(username, USERNAME_TOKEN);
+
+		if (username == null)
+		{
+			log.debug("Received null player name.  Skipping dialogue sanitization and returning null instead.");
+			return null;
+		}
+
+		return dialogue.replaceAll(NON_BREAKING_SPACE, " ").replaceAll(username, USERNAME_TOKEN);
 	}
 
 	@Subscribe
@@ -71,14 +82,12 @@ public class CrowdsourcingDialogue
 
 		// If we were not in a conversation, but now one of these widgets is not null, we have started a conversation.
 		// Else if we were in a conversation, but now there is no widget, we have left the conversation.
-		if (!inDialogue && (npcDialogueTextWidget != null || playerDialogueTextWidget != null || playerDialogueOptionsWidget != null
-			|| spriteTextWidget != null || doubleSpriteTextWidget != null))
+		if (!inDialogue && (npcDialogueTextWidget != null || playerDialogueTextWidget != null || playerDialogueOptionsWidget != null || spriteTextWidget != null || doubleSpriteTextWidget != null))
 		{
 			inDialogue = true;
 			manager.storeEvent(new StartEndData(true));
 		}
-		else if (inDialogue && npcDialogueTextWidget == null && playerDialogueTextWidget == null
-			&& playerDialogueOptionsWidget == null && spriteTextWidget == null && doubleSpriteTextWidget == null)
+		else if (inDialogue && npcDialogueTextWidget == null && playerDialogueTextWidget == null && playerDialogueOptionsWidget == null && spriteTextWidget == null && doubleSpriteTextWidget == null)
 		{
 			inDialogue = false;
 			manager.storeEvent(new StartEndData(false));
@@ -89,58 +98,81 @@ public class CrowdsourcingDialogue
 		{
 			lastDialogueText = npcDialogueTextWidget.getText();
 			String npcName = client.getWidget(ComponentID.DIALOG_NPC_NAME).getText();
-			NpcDialogueData data = new NpcDialogueData(sanitize(lastDialogueText), npcName);
-			manager.storeEvent(data);
+			String sanitizedLastDialogueText = sanitize(lastDialogueText);
+			if (sanitizedLastDialogueText != null)
+			{
+				NpcDialogueData data = new NpcDialogueData(sanitizedLastDialogueText, npcName);
+				manager.storeEvent(data);
+			}
 		}
 
 		if (playerDialogueTextWidget != null && !playerDialogueTextWidget.getText().equals(lastDialogueText))
 		{
 			lastDialogueText = playerDialogueTextWidget.getText();
-			PlayerDialogueData data = new PlayerDialogueData(sanitize(lastDialogueText));
-			manager.storeEvent(data);
+			String sanitizedLastDialogueText = sanitize(lastDialogueText);
+			if (sanitizedLastDialogueText != null)
+			{
+				PlayerDialogueData data = new PlayerDialogueData(sanitizedLastDialogueText);
+				manager.storeEvent(data);
+			}
 		}
 
 		if (playerDialogueOptionsWidget != null && playerDialogueOptionsWidget.getChildren() != dialogueOptions)
 		{
 			lastDialogueText = null;
 			dialogueOptions = playerDialogueOptionsWidget.getChildren();
-			String[] optionsText = new String[dialogueOptions.length];
-			for (int i = 0; i < dialogueOptions.length; i++)
+			ArrayList<String> optionsText = new ArrayList<>();
+			for (Widget dialogueOption : dialogueOptions)
 			{
-				optionsText[i] = sanitize(dialogueOptions[i].getText());
+				String sanitizedDialogueOptionText = sanitize(dialogueOption.getText());
+				if (sanitizedDialogueOptionText != null)
+				{
+					optionsText.add(sanitizedDialogueOptionText);
+				}
 			}
-			DialogueOptionsData data = new DialogueOptionsData(optionsText);
+			DialogueOptionsData data = new DialogueOptionsData(optionsText.toArray(String[]::new));
 			manager.storeEvent(data);
 		}
 
-		if (spriteWidget != null && spriteTextWidget != null && (!spriteTextWidget.getText().equals(lastDialogueText)
-			|| spriteWidget.getItemId() != lastItemId1))
+		if (spriteWidget != null && spriteTextWidget != null && (!spriteTextWidget.getText().equals(lastDialogueText) || spriteWidget.getItemId() != lastItemId1))
 		{
 			lastItemId1 = spriteWidget.getItemId();
 			lastDialogueText = spriteTextWidget.getText();
-			SpriteTextData data = new SpriteTextData(sanitize(lastDialogueText), lastItemId1);
-			manager.storeEvent(data);
+			String sanitizedLastDialogueText = sanitize(lastDialogueText);
+			if (sanitizedLastDialogueText != null)
+			{
+				SpriteTextData data = new SpriteTextData(sanitizedLastDialogueText, lastItemId1);
+				manager.storeEvent(data);
+			}
 		}
 
-		if (doubleSprite1Widget != null && doubleSpriteTextWidget != null && (!doubleSpriteTextWidget.getText().equals(lastDialogueText)
-			|| doubleSprite1Widget.getItemId() != lastItemId1 || doubleSprite2Widget.getItemId() != lastItemId2))
+		if (doubleSprite1Widget != null && doubleSpriteTextWidget != null && (!doubleSpriteTextWidget.getText().equals(lastDialogueText) || doubleSprite1Widget.getItemId() != lastItemId1 || doubleSprite2Widget.getItemId() != lastItemId2))
 		{
 			lastItemId1 = doubleSprite1Widget.getItemId();
 			lastItemId2 = doubleSprite2Widget.getItemId();
 			lastDialogueText = doubleSpriteTextWidget.getText();
-			DoubleSpriteTextData data = new DoubleSpriteTextData(sanitize(lastDialogueText), lastItemId1, lastItemId2);
-			manager.storeEvent(data);
+			String sanitizedLastDialogueText = sanitize(lastDialogueText);
+			if (sanitizedLastDialogueText != null)
+			{
+				DoubleSpriteTextData data = new DoubleSpriteTextData(sanitizedLastDialogueText, lastItemId1, lastItemId2);
+				manager.storeEvent(data);
+			}
 		}
 	}
 
 	@Subscribe
 	public void onChatMessage(ChatMessage chatMessage)
 	{
-		if (chatMessage.getType() == ChatMessageType.DIALOG
-		|| chatMessage.getType() == ChatMessageType.MESBOX)
+		if (chatMessage.getType() != ChatMessageType.DIALOG && chatMessage.getType() != ChatMessageType.MESBOX)
 		{
-			ChatMessageData data = new ChatMessageData(sanitize(chatMessage.getMessage()), chatMessage.getType());
-			manager.storeEvent(data);
+			return;
 		}
+		String sanitizedChatMessageText = sanitize(chatMessage.getMessage());
+		if (sanitizedChatMessageText == null)
+		{
+			return;
+		}
+		ChatMessageData data = new ChatMessageData(sanitizedChatMessageText, chatMessage.getType());
+		manager.storeEvent(data);
 	}
 }

--- a/runelite-client/src/test/java/net/runelite/client/plugins/crowdsourcing/dialogue/CrowdsourcingDialogueTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/crowdsourcing/dialogue/CrowdsourcingDialogueTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2023, fox091 <https://github.com/fox091>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package net.runelite.client.plugins.crowdsourcing.dialogue;
+
+import com.google.inject.Guice;
+import com.google.inject.testing.fieldbinder.Bind;
+import com.google.inject.testing.fieldbinder.BoundFieldModule;
+import javax.inject.Inject;
+import net.runelite.api.ChatMessageType;
+import net.runelite.api.Client;
+import net.runelite.api.Player;
+import net.runelite.api.events.ChatMessage;
+import net.runelite.client.plugins.crowdsourcing.CrowdsourcingManager;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CrowdsourcingDialogueTest
+{
+	private static final String USERNAME_TOKEN = "%USERNAME%";
+
+	private static final String NON_BREAKING_SPACE = " ";
+
+	@Inject
+	CrowdsourcingDialogue crowdsourcingDialogue;
+
+	@Mock
+	@Bind
+	private Client client;
+
+	@Mock
+	@Bind
+	private CrowdsourcingManager manager;
+
+	@Before
+	public void before()
+	{
+		Guice.createInjector(BoundFieldModule.of(this)).injectMembers(this);
+	}
+
+	@Test
+	public void testOnChatMessageUnsupportedChatMessage()
+	{
+		String chatMessageText = "Howdy!";
+		ChatMessageType chatMessageType = ChatMessageType.WELCOME;
+		ChatMessage chatMessage = new ChatMessage(null, chatMessageType, "", chatMessageText, "", 0);
+		crowdsourcingDialogue.onChatMessage(chatMessage);
+
+		verifyNoInteractions(client);
+		verifyNoInteractions(manager);
+	}
+
+	@Test
+	public void testOnChatMessageSupportedChatMessages()
+	{
+		Player localPlayer = mock(Player.class);
+		when(client.getLocalPlayer()).thenReturn(localPlayer);
+		when(localPlayer.getName()).thenReturn("Playername!");
+
+		String dialogChatMessageText = "I am a dialogue message!";
+		ChatMessageType dialogChatMessageType = ChatMessageType.DIALOG;
+		ChatMessage dialogChatMessage = new ChatMessage(null, dialogChatMessageType, "", dialogChatMessageText, "", 0);
+		crowdsourcingDialogue.onChatMessage(dialogChatMessage);
+
+		String mesBoxChatMessageText = "I am a mesbox message!";
+		ChatMessageType mesBoxChatMessageType = ChatMessageType.MESBOX;
+		ChatMessage mesBoxChatMessage = new ChatMessage(null, mesBoxChatMessageType, "", mesBoxChatMessageText, "", 0);
+		crowdsourcingDialogue.onChatMessage(mesBoxChatMessage);
+
+		verify(client, times(2)).getLocalPlayer();
+		verify(localPlayer, times(2)).getName();
+		verify(manager).storeEvent(new ChatMessageData(dialogChatMessageText, dialogChatMessageType));
+		verify(manager).storeEvent(new ChatMessageData(mesBoxChatMessageText, mesBoxChatMessageType));
+	}
+
+	@Test
+	public void testOnChatMessageReplacesNBSPAndUsername()
+	{
+		Player localPlayer = mock(Player.class);
+		when(client.getLocalPlayer()).thenReturn(localPlayer);
+		String playerName = "MyCoolPlayerName";
+		when(localPlayer.getName()).thenReturn(playerName);
+
+		String baseChatMessageText = ": My non-breaking-spaces should be replaced with regular spaces!";
+		String goodChatMessageText = USERNAME_TOKEN + baseChatMessageText;
+		String badChatMessageText = goodChatMessageText.replaceAll(" ", NON_BREAKING_SPACE);
+		ChatMessageType chatMessageType = ChatMessageType.DIALOG;
+		ChatMessage chatMessage = new ChatMessage(null, chatMessageType, "", badChatMessageText, "", 0);
+		crowdsourcingDialogue.onChatMessage(chatMessage);
+
+		verify(client).getLocalPlayer();
+		verify(localPlayer).getName();
+		verify(manager).storeEvent(new ChatMessageData(goodChatMessageText, chatMessageType));
+	}
+
+	@Test
+	public void testOnChatMessageNullPlayerName()
+	{
+		Player localPlayer = mock(Player.class);
+		when(client.getLocalPlayer()).thenReturn(localPlayer);
+		when(localPlayer.getName()).thenReturn(null);
+
+		String chatMessageText = "My player name is null!";
+		ChatMessageType chatMessageType = ChatMessageType.DIALOG;
+		ChatMessage chatMessage = new ChatMessage(null, chatMessageType, "", chatMessageText, "", 0);
+		crowdsourcingDialogue.onChatMessage(chatMessage);
+
+		verify(client).getLocalPlayer();
+		verify(localPlayer).getName();
+		verifyNoInteractions(manager);
+	}
+}


### PR DESCRIPTION
Add a guard clause for a null username before attempting to sanitize the dialogue message. If the username is null, explicitly return null instead of the message, as it cannot be sanitized.

Change all uses of sanitize() to only store data in CrowdsourcingManager if the sanitized message is not null.

If username is null, a NullReferenceException will be thrown when attempting to use the username as the pattern for replacement, causing a client crash.

This fixes an inconsistent crash I have been getting for quite a while, with the following stack trace:
```
java.lang.NullPointerException: Cannot invoke "String.isEmpty()" because "this.pattern" is null
	at java.base/java.util.regex.Pattern.<init>(Pattern.java:1428)
	at java.base/java.util.regex.Pattern.compile(Pattern.java:1069)
	at java.base/java.lang.String.replaceAll(String.java:2944)
	at net.runelite.client.plugins.crowdsourcing.dialogue.CrowdsourcingDialogue.sanitize(CrowdsourcingDialogue.java:57)
	at net.runelite.client.plugins.crowdsourcing.dialogue.CrowdsourcingDialogue.onChatMessage(CrowdsourcingDialogue.java:142)
	at net.runelite.client.eventbus.EventBus$Subscriber.invoke(EventBus.java:70)
	at net.runelite.client.eventbus.EventBus.post(EventBus.java:223)
	at net.runelite.client.callback.Hooks.post(Hooks.java:194)
	at dh.ah(dh.java:48047)
	at ob.at(ov.java:19)
	at client.jt(client.java:46947)
	at client.hm(client.java:3033)
	at client.bp(client.java:1161)
	at bm.an(bm.java:394)
	at bm.ov(bm.java)
	at bm.run(bm.java:33867)
	at java.base/java.lang.Thread.run(Thread.java:840)
```

I added a test for `onChatMessage` that reproduces the problem.  I also added some test cases to cover all of the `onChatMessage` and `sanitize` code.