### PR TITLE
slayer: Fix initial amount when task changes

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerPlugin.java
@@ -405,7 +405,7 @@ public class SlayerPlugin extends Plugin
 			else if (!Objects.equals(taskName, this.taskName) || !Objects.equals(taskLocation, this.taskLocation))
 			{
 				log.debug("Task change: {}x {} at {}", amount, taskName, taskLocation);
-				setTask(taskName, amount, initialAmount, taskLocation, true);
+				setTask(taskName, amount, amount, taskLocation, true);
 			}
 			else if (amount != this.amount)
 			{
@@ -604,7 +604,7 @@ public class SlayerPlugin extends Plugin
 	{
 		taskName = name;
 		amount = amt;
-		initialAmount = Math.max(amt, initAmt);
+		initialAmount = initAmt;
 		taskLocation = location;
 		save();
 		removeCounter();


### PR DESCRIPTION
This is most commonly encountered when players are assigned a Tzhaar task, but elect to upgrade it to a Jad or Zuk task. When this happens, the SLAYER_TASK_SIZE and SLAYER_TASK_CREATURE varps are set when starting the assignment dialog, and are later changed after opting in to the task change. The plugin had code which would preserve the previous initial amount (as of 1dbf432377f4b0355117b25ecde66915456b0ff8) but should no longer be needed as we can update it directly from var changes as opposed to tracking it ourselves.

Fixes #16470