### PR TITLE
idle notifier: add cow milking & diary churning animation ids

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/AnimationID.java
+++ b/runelite-api/src/main/java/net/runelite/api/AnimationID.java
@@ -258,6 +258,9 @@ public final class AnimationID
 	public static final int HOME_MAKE_TABLET = 4067;
 	public static final int DRAGONFIRE_SHIELD_SPECIAL = 6696;
 	public static final int MILKING_COW = 2305;
+	public static final int CHURN_MILK_SHORT = 2793;
+	public static final int CHURN_MILK_MEDIUM = 2794;
+	public static final int CHURN_MILK_LONG = 2795;
 
 	// Ectofuntus animations
 	public static final int ECTOFUNTUS_FILL_SLIME_BUCKET = 4471;

--- a/runelite-api/src/main/java/net/runelite/api/AnimationID.java
+++ b/runelite-api/src/main/java/net/runelite/api/AnimationID.java
@@ -257,6 +257,7 @@ public final class AnimationID
 	public static final int PISCARILIUS_CRANE_REPAIR = 7199;
 	public static final int HOME_MAKE_TABLET = 4067;
 	public static final int DRAGONFIRE_SHIELD_SPECIAL = 6696;
+	public static final int MILKING_COW = 2305;
 
 	// Ectofuntus animations
 	public static final int ECTOFUNTUS_FILL_SLIME_BUCKET = 4471;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
@@ -333,6 +333,7 @@ public class IdleNotifierPlugin extends Plugin
 			case PISCARILIUS_CRANE_REPAIR:
 			case HOME_MAKE_TABLET:
 			case SAND_COLLECTION:
+			case MILKING_COW:
 			case LOOKING_INTO:
 				resetTimers();
 				lastAnimation = animation;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
@@ -334,6 +334,9 @@ public class IdleNotifierPlugin extends Plugin
 			case HOME_MAKE_TABLET:
 			case SAND_COLLECTION:
 			case MILKING_COW:
+			case CHURN_MILK_SHORT:
+			case CHURN_MILK_MEDIUM:
+			case CHURN_MILK_LONG:
 			case LOOKING_INTO:
 				resetTimers();
 				lastAnimation = animation;


### PR DESCRIPTION
Depending on what you use as an ingredient will change the time it takes to churn, and subsequently a separate animation ID

```
2793 milk->cream
2793 butter->cheese
2793 cream->butter
2794 milk->butter
2794 cream->cheese
2795 milk->cheese
```

With manual counting you receive your item from `2793` after 4 seconds, `2794` takes 8 seconds, and `2795` takes 12 seconds, so they've been named accordingly to what polar pulled during [discord discussion](https://discord.com/channels/301497432909414422/419891709883973642/1190148661506736152)


I split the commits up if we want to split them, otherwise I gave the PR a reasonable commit name

Fixes #17310 


<details>
  <summary>milking</summary>

![java_2023-12-28_22-49-20](https://github.com/runelite/runelite/assets/41973452/d82b4ada-322e-4db4-8740-d94107a0d505)

</details>

<details>
  <summary>2793(short) milk->cream</summary>

![java_2023-12-29_00-05-59](https://github.com/runelite/runelite/assets/41973452/c5f5195d-c1e7-4c7e-9a5a-bb81cb4ad24e)

</details>

<details>
  <summary>2794(medium) milk->butter</summary>

![java_2023-12-29_00-07-39](https://github.com/runelite/runelite/assets/41973452/524bb5fa-70ff-4010-9378-cf6abaa14e17)

</details>

<details>
  <summary>2795(long) milk->cheese</summary>

![java_2023-12-29_00-03-20](https://github.com/runelite/runelite/assets/41973452/e04be634-bb69-4ff8-9432-4a53246082ac)

</details>