### PR TITLE
Music Plugin: Reapply ambient sounds on shutdown

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/music/MusicPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/music/MusicPlugin.java
@@ -215,6 +215,18 @@ public class MusicPlugin extends Plugin
 			shuttingDown = true;
 			teardownMusicOptions();
 		});
+
+		if (musicConfig.muteAmbientSounds())
+		{
+			clientThread.invoke(() ->
+			{
+				// Reload the scene to reapply ambient sounds
+				if (client.getGameState() == GameState.LOGGED_IN)
+				{
+					client.setGameState(GameState.LOADING);
+				}
+			});
+		}
 	}
 
 	@Provides


### PR DESCRIPTION
When muteAmbientSounds is enabled the game state should be reset to Loading to reload the Ambient Sounds that were cleared.