### PR TITLE
Ground items: Do not show high alchemy value by default.

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
@@ -184,7 +184,7 @@ public interface GroundItemsConfig extends Config
 	)
 	default PriceDisplayMode priceDisplayMode()
 	{
-		return PriceDisplayMode.BOTH;
+		return PriceDisplayMode.GE;
 	}
 
 	@ConfigItem(


### PR DESCRIPTION
The high alchemy value is not nearly as useful as the grand exchange value. Afaict, HA value is only useful for people who presently have high alchemy runes in the inventory. It's not really useful for ironmen because GE value often is higher than or tracks the HA value.