### PR TITLE
Ignore unattackable NPCs

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/npcunaggroarea/NpcAggroAreaPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npcunaggroarea/NpcAggroAreaPlugin.java
@@ -288,7 +288,7 @@ public class NpcAggroAreaPlugin extends Plugin
 
 		for (String pattern : npcNamePatterns)
 		{
-			if (WildcardMatcher.matches(pattern, npcName))
+			if (npc.getCombatLevel() != 0 && WildcardMatcher.matches(pattern, npcName))
 			{
 				return true;
 			}


### PR DESCRIPTION
In Falador, there's a duck named "Drake". If you have the Drake enemy in your patterns list, it'll trigger whenever you are near the Falador park. I assume this will also help fix other false positive matches due to accidental name collisions with non-attackable NPCs.

![image](https://github.com/runelite/runelite/assets/12002072/2296d0b7-ed2a-42e0-8c60-9ff63b2506fa)
