### PR TITLE
tooltips: add config to ignore bad varc value

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/mousehighlight/MouseHighlightConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/mousehighlight/MouseHighlightConfig.java
@@ -63,4 +63,15 @@ public interface MouseHighlightConfig extends Config
 	{
 		return false;
 	}
+
+	@ConfigItem(
+		position = 3,
+		keyName = "forceTooltip",
+		name = "Force Tooltips",
+		description = "Forces tooltips to be shown even if the client says a tooltip is being shown"
+	)
+	default boolean forceTooltip()
+	{
+		return false;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/mousehighlight/MouseHighlightOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/mousehighlight/MouseHighlightOverlay.java
@@ -166,7 +166,7 @@ class MouseHighlightOverlay extends Overlay
 
 		// If this varc is set, a tooltip is already being displayed
 		int tooltipDisplayed = client.getVarcIntValue(VarClientInt.TOOLTIP_VISIBLE);
-		if (tooltipDisplayed == 1)
+		if (tooltipDisplayed == 1 && !config.forceTooltip())
 		{
 			return null;
 		}


### PR DESCRIPTION
Fixes issue #17267 by ignoring a bad varc that is set within the client. This option is off by default and can be enabled if the user wants to ensure that the tooltip is always shown.