### PR TITLE
Add option to flash taskbar

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/Notifier.java
+++ b/runelite-client/src/main/java/net/runelite/client/Notifier.java
@@ -208,6 +208,11 @@ public class Notifier
 			mouseLastPressedMillis = client.getMouseLastPressedMillis();
 		}
 
+		if (runeLiteConfig.notificationFlashTaskbar())
+		{
+			clientUI.flashTaskbar();
+		}
+
 		log.debug(message);
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/config/RuneLiteConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/RuneLiteConfig.java
@@ -297,6 +297,18 @@ public interface RuneLiteConfig extends Config
 	}
 
 	@ConfigItem(
+			keyName = "notificationFlashTaskbar",
+			name = "Flash Taskbar",
+			description = "Flash the taskbar when notifications are displayed",
+			position = 29,
+			section = notificationSettings
+	)
+	default boolean notificationFlashTaskbar()
+	{
+		return false;
+	}
+
+	@ConfigItem(
 		keyName = "fontType",
 		name = "Dynamic Overlay Font",
 		description = "Configures what font type is used for in-game overlays such as player name, ground items, etc.",

--- a/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
@@ -42,6 +42,7 @@ import java.awt.GraphicsDevice;
 import java.awt.GraphicsEnvironment;
 import java.awt.LayoutManager;
 import java.awt.Rectangle;
+import java.awt.Taskbar;
 import java.awt.Toolkit;
 import java.awt.TrayIcon;
 import java.awt.desktop.QuitStrategy;
@@ -788,6 +789,13 @@ public class ClientUI
 		}
 
 		giveClientFocus();
+	}
+
+	/**
+	 * Request user attention to the window (flash the taskbar)
+	 */
+	public void flashTaskbar() {
+		Taskbar.getTaskbar().requestWindowUserAttention(frame);
 	}
 
 	/**


### PR DESCRIPTION
Add the option for notifications to flash the task bar. This is different from requesting focus as it will not change what window is currently focused, just flash the taskbar.

This makes it easier to see at a glance which RuneLite windows have a notification without stacking up multiple tray notifications if you are playing on many accounts at once.

I have tested on Windows 10, but I am not totally clear of the behavior of [requestWindowUserAttention](https://docs.oracle.com/javase%2F9%2Fdocs%2Fapi%2F%2F/java/awt/Taskbar.html#requestWindowUserAttention-java.awt.Window-) on other platforms.

![flash taskbar](https://github.com/runelite/runelite/assets/7608429/8e3bc3a9-4bb6-4d0d-a4d0-70288baf1389)
![image](https://github.com/runelite/runelite/assets/7608429/1d57cd27-71d7-430b-97fb-3b48f67481fa)
