### PR TITLE
music: improve volume slider percentage calculation

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/music/MusicPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/music/MusicPlugin.java
@@ -517,9 +517,7 @@ public class MusicPlugin extends Plugin
 			track.setOnMouseRepeatListener((JavaScriptCallback) ev ->
 			{
 				int value = channel.getValue();
-				int percent = (int) Math.round((value * 100.0 / channel.getMax()));
-
-				sliderTooltip = new Tooltip(channel.getName() + ": " + percent + "%");
+				sliderTooltip = new Tooltip(channel.getName() + ": " + getPercentage(value) + "%");
 			});
 			track.setOnClickListener((JavaScriptCallback) this::click);
 			track.setHasListener(true);
@@ -556,13 +554,20 @@ public class MusicPlugin extends Plugin
 			level = Ints.constrainToRange(level, 0, channel.max);
 			channel.setLevel(level);
 
-			int percent = (int) Math.round((level * 100.0 / channel.getMax()));
-			sliderTooltip = new Tooltip(channel.getName() + ": " + percent + "%");
+			sliderTooltip = new Tooltip(channel.getName() + ": " + getPercentage(level) + "%");
 		}
 
 		protected int getWidth()
 		{
 			return track.getWidth() - SLIDER_HANDLE_SIZE;
+		}
+
+		protected int getPercentage(int level)
+		{
+			// when handle position is converted to level, level is floored
+			// to convert back to position, we take the ceil
+			double position = Math.ceil((double) level / channel.max * getWidth());
+			return (int) Math.round(position * 100 / getWidth());
 		}
 	}
 


### PR DESCRIPTION
When Granular Volume Sliders is enabled in the Music plugin, a percentage overlay appears on the volume sliders. Currently, there are two compounding rounding errors when this percentage is calculated, leading to inconsistent percentage indications.

The sliders can be set to 97 positions (0-96). As the slider is incremented from the 0 position, the following percentages are indicated: 0%, 1%, 2%, 2%, 4%, . . . This trend continues throughout the volume range. In total, 14 indications are doubled (i.e. indicating 2% on two adjacent and different volume positions), and 18 percentages are skipped (i.e. skipping from 2% to 4% on adjacent positions).

Here is a chart of the current percentage indications:

<img width="669" alt="image" src="https://github.com/runelite/runelite/assets/6306331/72768ecf-d4f3-4455-9552-3e31b7bcf869">

This PR implements a new percentage calculation which provides more smooth and linear percentage indications. Here is a chart of the new percentage indications:

<img width="669" alt="image" src="https://github.com/runelite/runelite/assets/6306331/564edeac-d56c-403d-9009-7db76e6fedac">
 
Rather than doubling 14 values and skipping 18 values, the new calculation doubles 0 values and skips 4 (12%, 37%, 62%, 87%). There are 97 possible slider positions, and 101 indicatable percentages. Therefore, skipping 4 values is the most linear possible result.

Here are the results in-game. Note the old version skips 3%, while the new version does not:

https://github.com/runelite/runelite/assets/6306331/4d5ef880-5321-43e3-8f34-8a2430ddb9b2


https://github.com/runelite/runelite/assets/6306331/a6c7ee58-b633-4f38-901a-c21768109c0b

