### PR TITLE
idle notifier: add specimen cleaning animation ids

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/AnimationID.java
+++ b/runelite-api/src/main/java/net/runelite/api/AnimationID.java
@@ -261,6 +261,8 @@ public final class AnimationID
 	public static final int CHURN_MILK_SHORT = 2793;
 	public static final int CHURN_MILK_MEDIUM = 2794;
 	public static final int CHURN_MILK_LONG = 2795;
+	public static final int CLEANING_SPECIMENS_1 = 6217;
+	public static final int CLEANING_SPECIMENS_2 = 6459;
 
 	// Ectofuntus animations
 	public static final int ECTOFUNTUS_FILL_SLIME_BUCKET = 4471;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
@@ -337,6 +337,8 @@ public class IdleNotifierPlugin extends Plugin
 			case CHURN_MILK_SHORT:
 			case CHURN_MILK_MEDIUM:
 			case CHURN_MILK_LONG:
+			case CLEANING_SPECIMENS_1:
+			case CLEANING_SPECIMENS_2:
 			case LOOKING_INTO:
 				resetTimers();
 				lastAnimation = animation;


### PR DESCRIPTION
Like all of these obscure activities, they have intricate animations, which these ones sometimes factor in the `-1` idle animation.

Because of this using `1000ms` will sometimes trigger while you are still cleaning, bumping this to `2000ms` resolves that problem. I do believe this sometimes happens with mining related notifs, which the user is often told to increase their delay, so I assume it's fine that these require said longer delay.

Unlike something like the dairy* churns, these animations seem to be not based on time, but something else (maybe what reward you get). e.g. I've seen these animations be both short and long, both of them have had the `-1` anim happen inbetween them, so I just gave them `_1` and `_2` names respectively

I just overlayed discord on the bottom-right corner to show when the client pulls focus due to the idle notification, as well so the animation order can be seen, in case it's a pattern I'm not noticing.

1000ms:
[github-has-a-10mb-limit-on-uploads](https://i.nuuls.com/4WbBg.gif) 

2000ms:
[github-has-a-10mb-limit-on-uploads_2](https://i.nuuls.com/qefiq.gif)


Honestly probably could use a test written by someone who knows what they're doing (aka not me)
