### PR TITLE
overlay manager: revalidate overlays on profile change

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayManager.java
@@ -129,7 +129,11 @@ public class OverlayManager
 	{
 		synchronized (this)
 		{
-			overlays.forEach(this::loadOverlay);
+			overlays.forEach((o) ->
+			{
+				loadOverlay(o);
+				o.revalidate();
+			});
 		}
 		rebuildOverlayLayers();
 	}


### PR DESCRIPTION
Per https://github.com/runelite/runelite/discussions/17346

WidgetOverlays need to be revalidated so the moved widget can be moved back to its original position.