### PR TITLE
Display tagtabs tab correctly

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/banktags/tabs/TabInterface.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/banktags/tabs/TabInterface.java
@@ -114,7 +114,7 @@ public class TabInterface
 	private static final String REMOVE_TAG = "Remove-tag";
 	private static final String TAG_GEAR = "Tag-equipment";
 	private static final String TAG_INVENTORY = "Tag-inventory";
-	private static final String TAB_MENU_KEY = "tagtabs";
+	private static final String TAB_MENU_KEY = "tagtabs>";
 	private static final String OPEN_TAB_MENU = "View tag tabs";
 	private static final int TAB_HEIGHT = 40;
 	private static final int TAB_WIDTH = 39;


### PR DESCRIPTION
Fixes #17263  

The tab to display all the tag tabs is internally called "tagtabs".

If you make a tag tab with the same name ("tagtabs"), then go into the "View tag tabs" menu, then click the "tagtabs" tag icon it will act as if you already had the "tagtabs" tab open and just close it.

To fix this I added an extra character to the internal tag tabs name, I chose ">" because it is unable to be typed into the text box when you create a new tag tab.

I know this is a very minor issue but this is my first PR for runelite. I welcome any feedback and sorry if I got something wrong.