### PR TITLE
World Map: Update fairy rings enum

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldmap/FairyRingLocation.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldmap/FairyRingLocation.java
@@ -41,6 +41,7 @@ enum FairyRingLocation
 	AKS("AKS", new WorldPoint(2570, 2958, 0)),
 	ALP("ALP", new WorldPoint(2502, 3638, 0)),
 	ALQ("ALQ", new WorldPoint(3598, 3496, 0)),
+	ALR("ALR", new WorldPoint(3059, 4877, 0)),
 	ALS("ALS", new WorldPoint(2643, 3497, 0)),
 	BIP("BIP", new WorldPoint(3409, 3326, 0)),
 	BIQ("BIQ", new WorldPoint(3248, 3095, 0)),

--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldmap/FairyRingLocation.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldmap/FairyRingLocation.java
@@ -33,6 +33,7 @@ enum FairyRingLocation
 {
 	AIQ("AIQ", new WorldPoint(2995, 3112, 0)),
 	AIR("AIR", new WorldPoint(2699, 3249, 0)),
+	// AJQ - Exists in game but not on World Map
 	AJR("AJR", new WorldPoint(2779, 3615, 0)),
 	AJS("AJS", new WorldPoint(2499, 3898, 0)),
 	AKP("AKP", new WorldPoint(3283, 2704, 0)),
@@ -47,11 +48,14 @@ enum FairyRingLocation
 	BIQ("BIQ", new WorldPoint(3248, 3095, 0)),
 	BIS("BIS", new WorldPoint(2635, 3268, 0)),
 	BJP("BJP", new WorldPoint(2264, 2976, 0)),
+	// BJR - Exists in game but not on World Map
 	BJS("BJS", new WorldPoint(2147, 3069, 0)),
 	BKP("BKP", new WorldPoint(2384, 3037, 0)),
+	// BKQ - Exists in game but not on World Map
 	BKR("BKR", new WorldPoint(3468, 3433, 0)),
 	BKS("BKS", new WorldPoint(2411, 4436, 0)),
 	BLP("BLP", new WorldPoint(2432, 5127, 0)),
+	// BLQ - Exists in game but not on World Map
 	BLR("BLR", new WorldPoint(2739, 3353, 0)),
 	BLS("BLS", new WorldPoint(1293, 3495, 0)),
 	CIP("CIP", new WorldPoint(2512, 3886, 0)),
@@ -59,12 +63,15 @@ enum FairyRingLocation
 	CIR("CIR", new WorldPoint(1303, 3762, 0)),
 	CIS("CIS", new WorldPoint(1636, 3869, 0)),
 	CJR("CJR", new WorldPoint(2704, 3578, 0)),
+	// CKP - Exists in game but not on World Map
 	CKR("CKR", new WorldPoint(2800, 3005, 0)),
 	CKS("CKS", new WorldPoint(3446, 3472, 0)),
 	CLP("CLP", new WorldPoint(3081, 3208, 0)),
 	CLR("CLR", new WorldPoint(2737, 2739, 0)),
 	CLS("CLS", new WorldPoint(2681, 3083, 0)),
 	DIP("DIP", new WorldPoint(3036, 4761, 0)),
+	// DIQ - Exists in game but not on World Map
+	// DIR - Exists in game but not on World Map
 	DIS("DIS", new WorldPoint(3109, 3149, 0)),
 	DJP("DJP", new WorldPoint(2657, 3232, 0)),
 	DJR("DJR", new WorldPoint(1452, 3659, 0)),
@@ -73,6 +80,7 @@ enum FairyRingLocation
 	DKS("DKS", new WorldPoint(2743, 3721, 0)),
 	DLQ("DLQ", new WorldPoint(3422, 3018, 0)),
 	DLR("DLR", new WorldPoint(2212, 3101, 0));
+	// DLS - Exists in game but not on World Map
 
 	private final String code;
 	private final WorldPoint location;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldmap/FairyRingLocation.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldmap/FairyRingLocation.java
@@ -31,13 +31,13 @@ import net.runelite.api.coords.WorldPoint;
 @Getter
 enum FairyRingLocation
 {
-	AIR("AIR", new WorldPoint(2699, 3249, 0)),
 	AIQ("AIQ", new WorldPoint(2995, 3112, 0)),
+	AIR("AIR", new WorldPoint(2699, 3249, 0)),
 	AJR("AJR", new WorldPoint(2779, 3615, 0)),
 	AJS("AJS", new WorldPoint(2499, 3898, 0)),
-	AKR("AKR", new WorldPoint(1823, 3539, 0)),
 	AKP("AKP", new WorldPoint(3283, 2704, 0)),
 	AKQ("AKQ", new WorldPoint(2318, 3617, 0)),
+	AKR("AKR", new WorldPoint(1823, 3539, 0)),
 	AKS("AKS", new WorldPoint(2570, 2958, 0)),
 	ALP("ALP", new WorldPoint(2502, 3638, 0)),
 	ALQ("ALQ", new WorldPoint(3598, 3496, 0)),
@@ -54,12 +54,14 @@ enum FairyRingLocation
 	BLR("BLR", new WorldPoint(2739, 3353, 0)),
 	BLS("BLS", new WorldPoint(1293, 3495, 0)),
 	CIP("CIP", new WorldPoint(2512, 3886, 0)),
-	CIR("CIR", new WorldPoint(1303, 3762, 0)),
 	CIQ("CIQ", new WorldPoint(2527, 3129, 0)),
+	CIR("CIR", new WorldPoint(1303, 3762, 0)),
+	CIS("CIS", new WorldPoint(1636, 3869, 0)),
 	CJR("CJR", new WorldPoint(2704, 3578, 0)),
 	CKR("CKR", new WorldPoint(2800, 3005, 0)),
 	CKS("CKS", new WorldPoint(3446, 3472, 0)),
 	CLP("CLP", new WorldPoint(3081, 3208, 0)),
+	CLR("CLR", new WorldPoint(2737, 2739, 0)),
 	CLS("CLS", new WorldPoint(2681, 3083, 0)),
 	DIP("DIP", new WorldPoint(3036, 4761, 0)),
 	DIS("DIS", new WorldPoint(3109, 3149, 0)),
@@ -70,8 +72,6 @@ enum FairyRingLocation
 	DKS("DKS", new WorldPoint(2743, 3721, 0)),
 	DLQ("DLQ", new WorldPoint(3422, 3018, 0)),
 	DLR("DLR", new WorldPoint(2212, 3101, 0)),
-	CIS("CIS", new WorldPoint(1636, 3869, 0)),
-	CLR("CLR", new WorldPoint(2737, 2739, 0)),
 	ZANARIS("Zanaris", new WorldPoint(2411, 4436, 0));
 
 	private final String code;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldmap/FairyRingLocation.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldmap/FairyRingLocation.java
@@ -60,7 +60,7 @@ enum FairyRingLocation
 	CKS("CKS", new WorldPoint(3446, 3472, 0)),
 	CLP("CLP", new WorldPoint(3081, 3208, 0)),
 	CLS("CLS", new WorldPoint(2681, 3083, 0)),
-	DIP("DIP", new WorldPoint(3039, 4757, 0)),
+	DIP("DIP", new WorldPoint(3036, 4761, 0)),
 	DIS("DIS", new WorldPoint(3109, 3149, 0)),
 	DJP("DJP", new WorldPoint(2657, 3232, 0)),
 	DJR("DJR", new WorldPoint(1452, 3659, 0)),

--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldmap/FairyRingLocation.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldmap/FairyRingLocation.java
@@ -50,6 +50,7 @@ enum FairyRingLocation
 	BJS("BJS", new WorldPoint(2147, 3069, 0)),
 	BKP("BKP", new WorldPoint(2384, 3037, 0)),
 	BKR("BKR", new WorldPoint(3468, 3433, 0)),
+	BKS("BKS", new WorldPoint(2411, 4436, 0)),
 	BLP("BLP", new WorldPoint(2432, 5127, 0)),
 	BLR("BLR", new WorldPoint(2739, 3353, 0)),
 	BLS("BLS", new WorldPoint(1293, 3495, 0)),
@@ -71,8 +72,7 @@ enum FairyRingLocation
 	DKR("DKR", new WorldPoint(3126, 3496, 0)),
 	DKS("DKS", new WorldPoint(2743, 3721, 0)),
 	DLQ("DLQ", new WorldPoint(3422, 3018, 0)),
-	DLR("DLR", new WorldPoint(2212, 3101, 0)),
-	ZANARIS("Zanaris", new WorldPoint(2411, 4436, 0));
+	DLR("DLR", new WorldPoint(2212, 3101, 0));
 
 	private final String code;
 	private final WorldPoint location;


### PR DESCRIPTION
The commits in this PR:
- Fix the DIP fairy ring location (it was slightly off)
- Add ~two~ a missing fairy ring~s~ (~the recently added Hosidius Vinery fairy ring and~ the Abyssal Area fairy ring)
- Update the enum to make it easier to keep it in sync with the fairy ring plugin (by alphabetizing the list, un-special-casing Zanaris, and adding comments for missing fairy rings)