### PR TITLE
chat commands: fix theatre of blood: entry mode

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
@@ -2161,7 +2161,7 @@ public class ChatCommandsPlugin extends Plugin
 			case "tob sm":
 			case "tob story mode":
 			case "tob story":
-			case "Theatre of Blood: Entry Mode":
+			case "theatre of blood: entry mode":
 			case "tob em":
 			case "tob entry mode":
 			case "tob entry":


### PR DESCRIPTION
Previously the branch was unreachable: the label contained uppercase symbols while the selector is lowercase-only (boss.toLowerCase())