### PR TITLE
clientui: Support Linux WM layout

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
@@ -71,6 +71,7 @@ import javax.swing.Box;
 import javax.swing.Icon;
 import javax.swing.ImageIcon;
 import javax.swing.JButton;
+import javax.swing.JDialog;
 import javax.swing.JEditorPane;
 import javax.swing.JFrame;
 import javax.swing.JMenuBar;
@@ -525,6 +526,13 @@ public class ClientUI
 				}
 				else
 				{
+					if (OSType.getOSType() == OSType.Linux)
+					{
+						// FlatLaf explicitly checks this property when checking for custom window decorations on Linux
+						JDialog.setDefaultLookAndFeelDecorated(true);
+						JFrame.setDefaultLookAndFeelDecorated(true);
+					}
+
 					frame.setUndecorated(true);
 					rp.setWindowDecorationStyle(JRootPane.FRAME);
 				}


### PR DESCRIPTION
On Linux, FlatLaf will support both yielding window layout to the window manager (for maximizing, edge snapping, etc.) as well as displaying a decorated frame or dialog window only if the following are set:

```
JFrame.setDefaultLookAndFeelDecorated(true);
JDialog.setDefaultLookAndFeelDecorated(true);
```

While these properties are usually already covered by our setting the client frame to be undecorated and the root panel to be decorated as a frame, [FlatLaf explicitly checks these properties][1], so they must be set to take effect in Linux. For reference, [FlatLaf's demo program also sets these properties][2] and also creates a window which can be layouted by the window manager.

[1]: https://github.com/JFormDesigner/FlatLaf/blob/3.2.5/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatNativeLinuxLibrary.java#L101-L104
[2]:https://github.com/JFormDesigner/FlatLaf/blob/3.3/flatlaf-demo/src/main/java/com/formdev/flatlaf/demo/FlatLafDemo.java#L63-L68