### PR TITLE
chat commands: fix off-by-one team size for out-of-order toa pb

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
@@ -2588,6 +2588,7 @@ public class ChatCommandsPlugin extends Plugin
 			Math.min(client.getVarbitValue(Varbits.TOA_MEMBER_2_HEALTH), 1) +
 			Math.min(client.getVarbitValue(Varbits.TOA_MEMBER_3_HEALTH), 1) +
 			Math.min(client.getVarbitValue(Varbits.TOA_MEMBER_4_HEALTH), 1) +
+			Math.min(client.getVarbitValue(Varbits.TOA_MEMBER_5_HEALTH), 1) +
 			Math.min(client.getVarbitValue(Varbits.TOA_MEMBER_6_HEALTH), 1) +
 			Math.min(client.getVarbitValue(Varbits.TOA_MEMBER_7_HEALTH), 1);
 	}


### PR DESCRIPTION
`ChatCommandsPlugin#toaTeamSize` excluded `TOA_MEMBER_5_HEALTH`
