### PR TITLE
Add Per-Item Highlights to Ground Items

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemHighlight.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemHighlight.java
@@ -1,0 +1,19 @@
+package net.runelite.client.plugins.grounditems;
+
+import lombok.Getter;
+
+import java.awt.*;
+
+@Getter
+public class GroundItemHighlight
+{
+	private final String name;
+	private final Color color;
+
+	public GroundItemHighlight(String name, Color color)
+	{
+		this.color = color;
+		this.name = name;
+	}
+
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
@@ -350,7 +350,7 @@ public class GroundItemsOverlay extends Overlay
 				drawRectangle(graphics, itemHiddenBox, topItem && mouseInHiddenBox ? Color.RED : color, hidden != null, true);
 
 				// Draw highlight box
-				drawRectangle(graphics, itemHighlightBox, topItem && mouseInHighlightBox ? Color.GREEN : color, highlighted != null, false);
+				drawRectangle(graphics, itemHighlightBox, topItem && mouseInHighlightBox ? Color.GREEN : color, plugin.getItemIsHighlighted(new NamedQuantity(item)), false);
 			}
 
 			// When the hotkey is pressed the hidden/highlight boxes are drawn to the right of the text,

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
@@ -635,6 +635,11 @@ public class GroundItemsPlugin extends Plugin
 		return null;
 	}
 
+	boolean getItemIsHighlighted(NamedQuantity item)
+	{
+		return TRUE.equals(highlightedItems.getUnchecked(item));
+	}
+
 	Color getHidden(NamedQuantity item, int gePrice, int haPrice, boolean isTradeable)
 	{
 		final boolean isExplicitHidden = TRUE.equals(hiddenItems.getUnchecked(item));

--- a/runelite-client/src/test/java/net/runelite/client/plugins/grounditems/GroundItemsPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/grounditems/GroundItemsPluginTest.java
@@ -39,6 +39,7 @@ import net.runelite.api.TileItem;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.ItemSpawned;
 import net.runelite.client.Notifier;
+import net.runelite.client.config.ConfigManager;
 import net.runelite.client.events.ConfigChanged;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.input.KeyManager;
@@ -65,6 +66,10 @@ public class GroundItemsPluginTest
 	@Mock
 	@Bind
 	private MouseManager mouseManager;
+
+	@Mock
+	@Bind
+	private ConfigManager configManager;
 
 	@Mock
 	@Bind


### PR DESCRIPTION
Offers the player more ground item highlight options by enabling them to set a custom highlight color for individual items!

**Instructions**
To set a custom highlight color for an item:

- Shift + Right Click an already highlighted ground item
- Navigate to the "Set highlight color" submenu

Within the submenu, the player can select from the following options:
- "Pick" to choose a new color from the color picker
- "Set color" to choose from one of the top 5 most used highlight colors
- "Reset" to return to the default highlight color and remove the config data for the item

**Images**
![image](https://github.com/runelite/runelite/assets/15053687/d5015037-70d3-4d01-9524-d49b65790f24)
_A few items that players might want to differentiate with highlights_
![image](https://github.com/runelite/runelite/assets/15053687/c35a5cff-1209-4ed8-bcb8-f3a70ecf7abf)
_A look at the "Set highlight color" submenu. The current color is always excluded from the list_
![image](https://github.com/runelite/runelite/assets/15053687/28abcbba-ccb0-47aa-9cc1-6cdb60f6e39f)
_The color picker always defaults to the current color_
![image](https://github.com/runelite/runelite/assets/15053687/9cb4e9a3-0b58-4fd6-9409-05cc70268ddd)
_Lootbeam support!_
![image](https://github.com/runelite/runelite/assets/15053687/99a28171-2e45-4f8e-a4ff-e1d7261a9ae7)
_Valued items + button now displays correctly_

fixes #14233, fixes #12274 