### PR TITLE
idle notifier: add crystal felling axe (inactive) animation

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/AnimationID.java
+++ b/runelite-api/src/main/java/net/runelite/api/AnimationID.java
@@ -57,6 +57,7 @@ public final class AnimationID
 	public static final int WOODCUTTING_2H_RUNE = 10070;
 	public static final int WOODCUTTING_2H_DRAGON = 10071;
 	public static final int WOODCUTTING_2H_CRYSTAL = 10072;
+	public static final int WOODCUTTING_2H_CRYSTAL_INACTIVE = 10073;
 	public static final int WOODCUTTING_2H_3A = 10074;
 	public static final int CONSUMING = 829; // consuming consumables
 	public static final int FIREMAKING = 733;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
@@ -159,6 +159,7 @@ public class IdleNotifierPlugin extends Plugin
 			case WOODCUTTING_2H_RUNE:
 			case WOODCUTTING_2H_DRAGON:
 			case WOODCUTTING_2H_CRYSTAL:
+			case WOODCUTTING_2H_CRYSTAL_INACTIVE:
 			case WOODCUTTING_2H_3A:
 			case BLISTERWOOD_JUMP_SCARE:
 			/* Firemaking */

--- a/runelite-client/src/main/java/net/runelite/client/plugins/wintertodt/WintertodtPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/wintertodt/WintertodtPlugin.java
@@ -44,6 +44,7 @@ import static net.runelite.api.AnimationID.WOODCUTTING_2H_ADAMANT;
 import static net.runelite.api.AnimationID.WOODCUTTING_2H_BLACK;
 import static net.runelite.api.AnimationID.WOODCUTTING_2H_BRONZE;
 import static net.runelite.api.AnimationID.WOODCUTTING_2H_CRYSTAL;
+import static net.runelite.api.AnimationID.WOODCUTTING_2H_CRYSTAL_INACTIVE;
 import static net.runelite.api.AnimationID.WOODCUTTING_2H_DRAGON;
 import static net.runelite.api.AnimationID.WOODCUTTING_2H_IRON;
 import static net.runelite.api.AnimationID.WOODCUTTING_2H_MITHRIL;
@@ -444,6 +445,7 @@ public class WintertodtPlugin extends Plugin
 			case WOODCUTTING_2H_RUNE:
 			case WOODCUTTING_2H_DRAGON:
 			case WOODCUTTING_2H_CRYSTAL:
+			case WOODCUTTING_2H_CRYSTAL_INACTIVE:
 			case WOODCUTTING_2H_3A:
 				setActivity(WintertodtActivity.WOODCUTTING);
 				break;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingPlugin.java
@@ -46,6 +46,7 @@ import static net.runelite.api.AnimationID.WOODCUTTING_2H_ADAMANT;
 import static net.runelite.api.AnimationID.WOODCUTTING_2H_BLACK;
 import static net.runelite.api.AnimationID.WOODCUTTING_2H_BRONZE;
 import static net.runelite.api.AnimationID.WOODCUTTING_2H_CRYSTAL;
+import static net.runelite.api.AnimationID.WOODCUTTING_2H_CRYSTAL_INACTIVE;
 import static net.runelite.api.AnimationID.WOODCUTTING_2H_DRAGON;
 import static net.runelite.api.AnimationID.WOODCUTTING_2H_IRON;
 import static net.runelite.api.AnimationID.WOODCUTTING_2H_MITHRIL;
@@ -110,7 +111,7 @@ public class WoodcuttingPlugin extends Plugin
 		WOODCUTTING_INFERNAL, WOODCUTTING_3A_AXE, WOODCUTTING_CRYSTAL, WOODCUTTING_TRAILBLAZER,
 		WOODCUTTING_2H_BRONZE, WOODCUTTING_2H_IRON, WOODCUTTING_2H_STEEL, WOODCUTTING_2H_BLACK,
 		WOODCUTTING_2H_MITHRIL, WOODCUTTING_2H_ADAMANT, WOODCUTTING_2H_RUNE, WOODCUTTING_2H_DRAGON,
-		WOODCUTTING_2H_CRYSTAL, WOODCUTTING_2H_3A
+		WOODCUTTING_2H_CRYSTAL, WOODCUTTING_2H_CRYSTAL_INACTIVE, WOODCUTTING_2H_3A
 	);
 
 	private static final Pattern WOOD_CUT_PATTERN = Pattern.compile("You get (?:some|an)[\\w ]+(?:logs?|mushrooms)\\.");


### PR DESCRIPTION
The crystal felling axe (inactive) uses a different animation id than the charged one for some reason, as outlined in: #17218
Please also refer to that issue for a picture of the animation id. 