### PR TITLE
bank: add responsive refresh for seed vault and group storage

### DIFF
--- a/runelite-api/src/main/interfaces/interfaces.toml
+++ b/runelite-api/src/main/interfaces/interfaces.toml
@@ -730,6 +730,7 @@ id=128
 id=631
 inventory_item_container=1
 title_container=2
+content_container=11
 item_container=15
 item_text=16
 search_button=24

--- a/runelite-api/src/main/java/net/runelite/api/ScriptID.java
+++ b/runelite-api/src/main/java/net/runelite/api/ScriptID.java
@@ -276,6 +276,18 @@ public final class ScriptID
 	public static final int BANKMAIN_SEARCH_REFRESH = 283;
 
 	/**
+	 * Called in an onTimer, determines whether to layout the group storage interface during a search
+	 */
+	@ScriptArguments(integer = 8)
+	public static final int SHARED_BANK_SEARCH_REFRESH = 5277;
+
+	/**
+	 * Called in an onTimer, determines whether to layout the seed vault interface during a search
+	 */
+	@ScriptArguments(integer = 8)
+	public static final int SEED_VAULT_SEARCH_REFRESH = 2867;
+
+	/**
 	 * Called to update the PVP widget (wilderness level/protection)
 	 */
 	@ScriptArguments(integer = 1)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/bank/GroupStorageSearch.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/bank/GroupStorageSearch.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2018, Ron Young <https://github.com/raiyni>
+ * Copyright (c) 2024, PhraZier <https://github.com/phrazier>
+ * All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *     list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package net.runelite.client.plugins.bank;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import net.runelite.api.Client;
+import net.runelite.api.widgets.ComponentID;
+import net.runelite.api.widgets.Widget;
+import net.runelite.client.callback.ClientThread;
+
+@Singleton
+public class GroupStorageSearch
+{
+	private final Client client;
+	private final ClientThread clientThread;
+
+	@Inject
+	private GroupStorageSearch(final Client client, final ClientThread clientThread)
+	{
+		this.client = client;
+		this.clientThread = clientThread;
+	}
+
+	public void layoutGroupStorage()
+	{
+		Widget groupStorageContainer = client.getWidget(ComponentID.GROUP_STORAGE_ITEM_CONTAINER);
+		if (groupStorageContainer == null)
+		{
+			return;
+		}
+
+		Object[] scriptArgs = groupStorageContainer.getOnInvTransmitListener();
+		if (scriptArgs == null)
+		{
+			return;
+		}
+
+		client.createScriptEvent(scriptArgs)
+			.setSource(groupStorageContainer)
+			.run();
+	}
+
+	public void initSearch()
+	{
+		clientThread.invoke(() ->
+		{
+			Widget searchButton = client.getWidget(ComponentID.GROUP_STORAGE_SEARCH_BUTTON);
+			if (searchButton == null || searchButton.isHidden())
+			{
+				return;
+			}
+
+			Object[] searchToggleArgs = searchButton.getOnOpListener();
+			if (searchToggleArgs == null)
+			{
+				return;
+			}
+
+			client.createScriptEvent(searchToggleArgs) // [clientscript,shared_bank_search_toggle]
+				.setOp(1)
+				.run();
+		});
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/bank/SeedVaultSearch.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/bank/SeedVaultSearch.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2018, Ron Young <https://github.com/raiyni>
+ * Copyright (c) 2024, PhraZier <https://github.com/phrazier>
+ * All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *     list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package net.runelite.client.plugins.bank;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import net.runelite.api.Client;
+import net.runelite.api.widgets.ComponentID;
+import net.runelite.api.widgets.Widget;
+import net.runelite.client.callback.ClientThread;
+
+@Singleton
+public class SeedVaultSearch
+{
+	private final Client client;
+	private final ClientThread clientThread;
+
+	@Inject
+	private SeedVaultSearch(final Client client, final ClientThread clientThread)
+	{
+		this.client = client;
+		this.clientThread = clientThread;
+	}
+
+	public void layoutSeedVault()
+	{
+		Widget seedVaultContainer = client.getWidget(ComponentID.SEED_VAULT_CONTENT_CONTAINER);
+		if (seedVaultContainer == null)
+		{
+			return;
+		}
+
+		Object[] scriptArgs = seedVaultContainer.getOnInvTransmitListener();
+		if (scriptArgs == null)
+		{
+			return;
+		}
+
+		client.createScriptEvent(scriptArgs)
+			.setSource(seedVaultContainer)
+			.run();
+	}
+
+	public void initSearch()
+	{
+		clientThread.invoke(() ->
+		{
+			Widget searchButton = client.getWidget(ComponentID.SEED_VAULT_SEARCH_BUTTON);
+			if (searchButton == null || searchButton.isHidden())
+			{
+				return;
+			}
+
+			Object[] searchToggleArgs = searchButton.getOnOpListener();
+			if (searchToggleArgs == null)
+			{
+				return;
+			}
+
+			client.createScriptEvent(searchToggleArgs) // [clientscript,seed_vault_search_toggle]
+				.run();
+		});
+	}
+}


### PR DESCRIPTION
This adds responsive refresh for the group storage and the seed vault, just like what the normal bank already has.
This commit also seperates the searches in to their own class. Just like with what was done with BankSearch