### PR TITLE
Added config to disable calibration overlay

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/npcunaggroarea/NpcAggroAreaConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npcunaggroarea/NpcAggroAreaConfig.java
@@ -139,4 +139,15 @@ public interface NpcAggroAreaConfig extends Config
 	{
 		return false;
 	}
+
+	@ConfigItem(
+		keyName = "disableCalibrationOverlay",
+		name = "Disable calibration overlay",
+		description = "Enable to stop showing the calibration overlay.",
+		position = 9
+	)
+	default boolean disableCalibrationOverlay()
+	{
+		return false;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/npcunaggroarea/NpcAggroAreaPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npcunaggroarea/NpcAggroAreaPlugin.java
@@ -150,7 +150,9 @@ public class NpcAggroAreaPlugin extends Plugin
 	protected void startUp() throws Exception
 	{
 		overlayManager.add(overlay);
-		overlayManager.add(notWorkingOverlay);
+		if (!config.disableCalibrationOverlay()) {
+			overlayManager.add(notWorkingOverlay);
+		}
 		npcNamePatterns = NAME_SPLITTER.splitToList(config.npcNamePatterns());
 		recheckActive();
 	}
@@ -159,7 +161,9 @@ public class NpcAggroAreaPlugin extends Plugin
 	protected void shutDown() throws Exception
 	{
 		removeTimer();
-		overlayManager.remove(overlay);
+		if (!config.disableCalibrationOverlay()) {
+			overlayManager.remove(overlay);
+		}
 		overlayManager.remove(notWorkingOverlay);
 		Arrays.fill(safeCenters, null);
 		lastPlayerLocation = null;
@@ -408,6 +412,12 @@ public class NpcAggroAreaPlugin extends Plugin
 				npcNamePatterns = NAME_SPLITTER.splitToList(config.npcNamePatterns());
 				recheckActive();
 				break;
+			case "disableCalibrationOverlay":
+				if (event.getNewValue() == null) {
+					overlayManager.add(notWorkingOverlay);
+				} else {
+					overlayManager.remove(notWorkingOverlay);
+				}
 		}
 	}
 


### PR DESCRIPTION
I read some messages on discord discussing some config for the NpcAggroAreaNotWorkingOverlay.
I think this should be a fairly simple fix.