### PR TITLE
Volume control for RuneLite custom notification sound (Notify.java)

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/Notifier.java
+++ b/runelite-client/src/main/java/net/runelite/client/Notifier.java
@@ -51,6 +51,7 @@ import javax.inject.Singleton;
 import javax.sound.sampled.AudioInputStream;
 import javax.sound.sampled.AudioSystem;
 import javax.sound.sampled.Clip;
+import javax.sound.sampled.FloatControl;
 import javax.sound.sampled.LineUnavailableException;
 import javax.sound.sampled.UnsupportedAudioFileException;
 import lombok.Getter;
@@ -476,6 +477,12 @@ public class Notifier
 				return;
 			}
 		}
+
+		// converts user controlled linear volume ranging 1-100 to exponential decibel gains
+		float volume = runeLiteConfig.notificationVolume() / 100f;
+		float gainDB = (float) Math.log10(volume) * 20;
+		FloatControl gainControl = (FloatControl) clip.getControl(FloatControl.Type.MASTER_GAIN);
+		gainControl.setValue(gainDB);
 
 		// Using loop instead of start + setFramePosition prevents the clip
 		// from not being played sometimes, presumably a race condition in the

--- a/runelite-client/src/main/java/net/runelite/client/config/RuneLiteConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/RuneLiteConfig.java
@@ -234,11 +234,28 @@ public interface RuneLiteConfig extends Config
 		return Notifier.NativeCustomOff.NATIVE;
 	}
 
+	@Range(
+		min = 0,
+		max = 100
+	)
+	@ConfigItem(
+		keyName = "notificationVolume",
+		name = "Notification volume",
+		description = "Configures the volume of custom notifications (does not control native volume).",
+		position = 24,
+		section = notificationSettings
+	)
+	@Units(Units.PERCENT)
+	default int notificationVolume()
+	{
+		return 100;
+	}
+
 	@ConfigItem(
 		keyName = "notificationTimeout",
 		name = "Notification timeout",
 		description = "How long notification will be shown in milliseconds. A value of 0 will make it use the system configuration. (Linux only)",
-		position = 24,
+		position = 25,
 		section = notificationSettings
 	)
 	@Units(Units.MILLISECONDS)
@@ -251,7 +268,7 @@ public interface RuneLiteConfig extends Config
 		keyName = "notificationGameMessage",
 		name = "Game message notifications",
 		description = "Adds a notification message to the chatbox",
-		position = 25,
+		position = 26,
 		section = notificationSettings
 	)
 	default boolean enableGameMessageNotification()
@@ -263,7 +280,7 @@ public interface RuneLiteConfig extends Config
 		keyName = "flashNotification",
 		name = "Flash",
 		description = "Flashes the game frame as a notification",
-		position = 26,
+		position = 27,
 		section = notificationSettings
 	)
 	default FlashNotification flashNotification()
@@ -275,7 +292,7 @@ public interface RuneLiteConfig extends Config
 		keyName = "notificationFocused",
 		name = "Send notifications when focused",
 		description = "Toggles all notifications for when the client is focused",
-		position = 27,
+		position = 28,
 		section = notificationSettings
 	)
 	default boolean sendNotificationsWhenFocused()
@@ -288,7 +305,7 @@ public interface RuneLiteConfig extends Config
 		keyName = "notificationFlashColor",
 		name = "Notification Flash",
 		description = "Sets the color of the notification flashes.",
-		position = 28,
+		position = 29,
 		section = notificationSettings
 	)
 	default Color notificationFlashColor()


### PR DESCRIPTION
- Volume control for runelite custom notification sound. 
using javax.sound.sampled.FloatControl (only controls custom notification sound, not native)
- Added config to RuneliteConfig.java
 user can control notification volume in Runelite client configuration


Changes to the config marked with red sqare:
![image](https://github.com/runelite/runelite/assets/1916460/77b1491e-edad-4481-9203-26768d264638)
