### PR TITLE
achievement diary: add 30 Constr. req. to crane repair task

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/KourendDiaryRequirement.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/KourendDiaryRequirement.java
@@ -62,7 +62,8 @@ public class KourendDiaryRequirement extends GenericDiaryRequirement
 		add("Enter the Farming Guild.",
 			new SkillRequirement(Skill.FARMING, 45));
 		add("Repair a Piscarilius crane.",
-			new SkillRequirement(Skill.CRAFTING, 30));
+			new SkillRequirement(Skill.CRAFTING, 30),
+			new SkillRequirement(Skill.CONSTRUCTION, 30));
 		add("Catch a Bluegill on Molch Island.",
 			new SkillRequirement(Skill.FISHING, 43),
 			new SkillRequirement(Skill.HUNTER, 35));


### PR DESCRIPTION
Repairing the fishing cranes in Port Piscarilius requires 30 Construction in addition to 30 Crafting. I think this requirement was added in the course of removing Kourend Favor.

This PR adds the missing requirement to the Achievement Diary requirements plugin.