### PR TITLE
woodcutting: prevent division by zero, wait until 3 logs cut for hourly rate

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingSession.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingSession.java
@@ -70,9 +70,10 @@ class WoodcuttingSession
 		bark += num;
 
 		Duration elapsed = Duration.between(start, Instant.now());
-		if (!elapsed.isZero())
+		long elapsedMs = elapsed.toMillis();
+		if (elapsedMs > 0)
 		{
-			barkPerHr = (int) ((double) bark * Duration.ofHours(1).toMillis() / elapsed.toMillis());
+			barkPerHr = (int) ((double) bark * Duration.ofHours(1).toMillis() / elapsedMs);
 		}
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingSession.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingSession.java
@@ -59,7 +59,7 @@ class WoodcuttingSession
 
 		Duration elapsed = Duration.between(start, Instant.now());
 		long elapsedMs = elapsed.toMillis();
-		if (elapsedMs > 0)
+		if (logsCut >= 3 && elapsedMs > 0)
 		{
 			logsPerHr = (int) ((double) logsCut * Duration.ofHours(1).toMillis() / elapsedMs);
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingSession.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingSession.java
@@ -58,9 +58,10 @@ class WoodcuttingSession
 		++logsCut;
 
 		Duration elapsed = Duration.between(start, Instant.now());
-		if (!elapsed.isZero())
+		long elapsedMs = elapsed.toMillis();
+		if (elapsedMs > 0)
 		{
-			logsPerHr = (int) ((double) logsCut * Duration.ofHours(1).toMillis() / elapsed.toMillis());
+			logsPerHr = (int) ((double) logsCut * Duration.ofHours(1).toMillis() / elapsedMs);
 		}
 	}
 


### PR DESCRIPTION
A division by zero occurs in the calculation of the number of logs/bark cut per hour in the Woodcutting plugin if 0 < `elapsed` < 1ms for `elapsed` the time since the creation of the `WoodcuttingSession`, because `elapsed` is not zero, thus the condition is true, but the calculation uses the value converted to milliseconds, which is zero on the first action (a few thousand nanoseconds).

This results in the following visible bug:
<img width="155" alt="Screenshot 2024-02-13 at 12 32 04" src="https://github.com/runelite/runelite/assets/4353030/193b8931-5371-45b7-9c5b-697f0dfea62e">

This PR fixes this by only updating `logsPerHr`,`barkPerHr`,  if at least one millisecond has passed since the creation of the `WoodcuttingSession`, i.e. on the second action, since the session is created after the first log/bark.