### PR TITLE
Fix searching in view all tag tabs

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/banktags/tabs/TabInterface.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/banktags/tabs/TabInterface.java
@@ -245,7 +245,7 @@ public class TabInterface
 		}
 		else if (event.getScriptId() == ScriptID.BANKMAIN_SEARCH_TOGGLE)
 		{
-			if (activeTab != null)
+			if (activeTab != null || tagTabActive)
 			{
 				// close the active tab when search is pressed
 				closeTag(false);


### PR DESCRIPTION
Currently when viewing all available tags (by right clicking the + in the upper left corner and pressing `view all tags`) searching the bank breaks, this is due to it only closing the tag if there's an "active" tag. The view all tag tabs is a special type of tag and needs to be checked separately.
