### PR TITLE
New Plugin Search Terms & Quality-of-life upgrade to PluginHub Navigation and UX

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/Plugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/Plugin.java
@@ -70,4 +70,5 @@ public abstract class Plugin implements Module
 	{
 		return getClass().getAnnotation(PluginDescriptor.class).name();
 	}
+
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/Plugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/Plugin.java
@@ -70,5 +70,4 @@ public abstract class Plugin implements Module
 	{
 		return getClass().getAnnotation(PluginDescriptor.class).name();
 	}
-
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
@@ -74,7 +74,6 @@ import javax.swing.border.MatteBorder;
 import javax.swing.event.ChangeListener;
 import javax.swing.text.JTextComponent;
 
-import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.client.config.ConfigDescriptor;
@@ -187,18 +186,19 @@ class ConfigPanel extends PluginPanel
 		topPanelBackButton.setPreferredSize(new Dimension(22, 0));
 		topPanelBackButton.setBorder(new EmptyBorder(0, 0, 0, 5));
 		topPanelBackButton.addActionListener(e ->
-        {
+		{
 			// ConfigPanel has a common rootMuxer for both PluginListPanel and PluginHubPanel
 			// So we now use the common rootMuxer to pop the state, for muxer ConfigPanel is currently presenting.
 			if (rootMuxer != null)
 			{
 				rootMuxer.popState();
-			} else
+			}
+			else
 			{
 				// For the odd case ConfigPanel is presented but rootMuxer is not set
 				log.error("ConfigPanel missing rootMuxer. Must use SetRootMuxer(..) to set the presenting muxer, before pushState.");
 			}
-        });
+		});
 		topPanelBackButton.setToolTipText("Back");
 		topPanel.add(topPanelBackButton, BorderLayout.WEST);
 
@@ -437,13 +437,16 @@ class ConfigPanel extends PluginPanel
 
 		JButton backButton = new JButton("Back");
 		backButton.addActionListener(e ->
-        {
-			if (rootMuxer != null) {
+		{
+			if (rootMuxer != null)
+			{
 				rootMuxer.popState();
-			} else {
+			}
+			else
+			{
 				pluginList.getMuxer().popState();
 			}
-        });
+		});
 		mainPanel.add(backButton);
 
 		revalidate();
@@ -769,9 +772,12 @@ class ConfigPanel extends PluginPanel
 		if (pluginManager.getPlugins().stream()
 			.noneMatch(p -> p == this.pluginConfig.getPlugin()))
 		{
-			if (rootMuxer != null) {
+			if (rootMuxer != null)
+			{
 				rootMuxer.popState();
-			} else {
+			}
+			else
+			{
 				pluginList.getMuxer().popState();
 			}
 		}
@@ -803,7 +809,8 @@ class ConfigPanel extends PluginPanel
 	}
 
 	@Override
-	public void onActivate() {
+	public void onActivate()
+	{
 		// Rebuild the panel when it is activated to ensure that the configuration is up-to-date
 		// This is necessary because the ConfigPanel can be opened by both
 		// the PluginListPanel and the PluginHubPanel

--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
@@ -74,6 +74,7 @@ import javax.swing.border.MatteBorder;
 import javax.swing.event.ChangeListener;
 import javax.swing.text.JTextComponent;
 
+import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.client.config.ConfigDescriptor;
@@ -187,9 +188,14 @@ class ConfigPanel extends PluginPanel
 		topPanelBackButton.setBorder(new EmptyBorder(0, 0, 0, 5));
 		topPanelBackButton.addActionListener(e ->
         {
-			if (rootMuxer != null) {
+			// ConfigPanel has a common rootMuxer for both PluginListPanel and PluginHubPanel
+			// So we now use the common rootMuxer to pop the state, for muxer ConfigPanel is currently presenting.
+			if (rootMuxer != null)
+			{
 				rootMuxer.popState();
-			} else {
+			} else
+			{
+				// For the odd case ConfigPanel is presented but rootMuxer is not set
 				log.error("ConfigPanel missing rootMuxer. Must use SetRootMuxer(..) to set the presenting muxer, before pushState.");
 			}
         });
@@ -798,6 +804,9 @@ class ConfigPanel extends PluginPanel
 
 	@Override
 	public void onActivate() {
+		// Rebuild the panel when it is activated to ensure that the configuration is up-to-date
+		// This is necessary because the ConfigPanel can be opened by both
+		// the PluginListPanel and the PluginHubPanel
 		SwingUtilities.invokeLater(this::rebuild);
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
@@ -187,8 +187,8 @@ class ConfigPanel extends PluginPanel
 		topPanelBackButton.setBorder(new EmptyBorder(0, 0, 0, 5));
 		topPanelBackButton.addActionListener(e ->
 		{
-			// ConfigPanel has a common rootMuxer for both PluginListPanel and PluginHubPanel
-			// So we now use the common rootMuxer to pop the state, for muxer ConfigPanel is currently presenting.
+			// ConfigPanel has a rootMuxer variable for PluginListPanel and PluginHubPanel to set.
+			// So we now use the rootMuxer to pop the state, for the muxer ConfigPanel is currently presenting from.
 			if (rootMuxer != null)
 			{
 				rootMuxer.popState();

--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/PluginHubPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/PluginHubPanel.java
@@ -32,7 +32,6 @@ import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
 import com.google.common.html.HtmlEscapers;
 import com.google.inject.Inject;
-import com.google.inject.name.Named;
 
 import java.awt.*;
 import java.awt.event.ActionEvent;
@@ -715,7 +714,7 @@ class PluginHubPanel extends PluginPanel
 		}, 0, reloadInterval, TimeUnit.SECONDS);
 
 		log.info("Hub constructor was called.");
-    }
+	}
 
 	private void reloadPluginList()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/PluginHubPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/PluginHubPanel.java
@@ -868,8 +868,9 @@ class PluginHubPanel extends PluginPanel
 
 			revalidate();
 
-			// plugin is highlighted if user is the plugin's ConfigPanel
-			// and the user navigates back to PluginHubPanel.
+			// plugin is highlighted if user visited ConfigPanel,
+			// we scroll back to the plugin when user navigates back to PluginHubPanel.
+			// Set in PluginHubPanel::openConfigurationPanel
 			if (highlightedPlugin != null)
 			{
 				ScrollToPlugin(highlightedPlugin);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/PluginListItem.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/PluginListItem.java
@@ -208,12 +208,14 @@ class PluginListItem extends JPanel implements SearchablePlugin
 	}
 
 	@Override
-	public boolean isPluginEnabled() {
+	public boolean isPluginEnabled()
+	{
 		return onOffToggle.isSelected();
 	}
 
 	@Override
-	public boolean isInstalled() {
+	public boolean isInstalled()
+	{
 		// plugin list items are by definition installed.
 		return true;
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/PluginListItem.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/PluginListItem.java
@@ -207,6 +207,17 @@ class PluginListItem extends JPanel implements SearchablePlugin
 		onOffToggle.setSelected(enabled);
 	}
 
+	@Override
+	public boolean isPluginEnabled() {
+		return onOffToggle.isSelected();
+	}
+
+	@Override
+	public boolean isInstalled() {
+		// plugin list items are by definition installed.
+		return true;
+	}
+
 	private void openGroupConfigPanel()
 	{
 		pluginListPanel.openConfigurationPanel(pluginConfig);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/PluginListPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/PluginListPanel.java
@@ -72,8 +72,8 @@ import net.runelite.client.util.Text;
 @Singleton
 class PluginListPanel extends PluginPanel
 {
-	private static final String RUNELITE_GROUP_NAME = RuneLiteConfig.class.getAnnotation(ConfigGroup.class).value();
-	private static final String PINNED_PLUGINS_CONFIG_KEY = "pinnedPlugins";
+	protected static final String RUNELITE_GROUP_NAME = RuneLiteConfig.class.getAnnotation(ConfigGroup.class).value();
+	protected static final String PINNED_PLUGINS_CONFIG_KEY = "pinnedPlugins";
 	private static final ImmutableList<String> CATEGORY_TAGS = ImmutableList.of(
 		"Combat",
 		"Chat",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/PluginListPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/PluginListPanel.java
@@ -82,7 +82,10 @@ class PluginListPanel extends PluginPanel
 		"Notification",
 		"Plugin Hub",
 		"Skilling",
-		"XP"
+		"XP",
+		"Enabled",
+		"Disabled",
+		"Pinned"
 	);
 
 	private final ConfigManager configManager;
@@ -287,11 +290,13 @@ class PluginListPanel extends PluginPanel
 		}
 	}
 
+
 	void openConfigurationPanel(PluginConfigurationDescriptor plugin)
 	{
 		ConfigPanel panel = configPanelProvider.get();
+		panel.setRootMuxer(muxer);
 		panel.init(plugin);
-		muxer.pushState(this);
+//		muxer.pushState(this);
 		muxer.pushState(panel);
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/PluginListPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/PluginListPanel.java
@@ -72,7 +72,9 @@ import net.runelite.client.util.Text;
 @Singleton
 class PluginListPanel extends PluginPanel
 {
+	// Protected because PluginHubPanel needs to access these for the search bar
 	protected static final String RUNELITE_GROUP_NAME = RuneLiteConfig.class.getAnnotation(ConfigGroup.class).value();
+	// Protected because PluginHubPanel needs to access these for the search bar
 	protected static final String PINNED_PLUGINS_CONFIG_KEY = "pinnedPlugins";
 	private static final ImmutableList<String> CATEGORY_TAGS = ImmutableList.of(
 		"Combat",
@@ -83,9 +85,9 @@ class PluginListPanel extends PluginPanel
 		"Plugin Hub",
 		"Skilling",
 		"XP",
-		"Enabled",
-		"Disabled",
-		"Pinned"
+		"Enabled", // Special search term for enabled plugins
+		"Disabled", // Special search term for disabled plugins
+		"Pinned" // Special search term for pinned plugins
 	);
 
 	private final ConfigManager configManager;
@@ -294,9 +296,11 @@ class PluginListPanel extends PluginPanel
 	void openConfigurationPanel(PluginConfigurationDescriptor plugin)
 	{
 		ConfigPanel panel = configPanelProvider.get();
-		panel.setRootMuxer(muxer);
 		panel.init(plugin);
-//		muxer.pushState(this);
+
+		// ConfigPanel has a common rootMuxer for both PluginListPanel and PluginHubPanel
+		// So we need to switch over the rootMuxer to PluginListPanel's muxer
+		panel.setRootMuxer(muxer);
 		muxer.pushState(panel);
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/PluginSearch.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/PluginSearch.java
@@ -44,14 +44,19 @@ public class PluginSearch
 
 	public static <T extends SearchablePlugin> List<T> search(Collection<T> searchablePlugins, String query)
 	{
+		// split the query into lower-case search terms
 		ArrayList<String> search_terms = Lists.newArrayList(SPLITTER.split(query.toLowerCase()));
 
+		// Search for plugins that are installed and enabled.
+		// Remove the terms' first occurrence if found, we don't literally want plugins named "Enabled".
 		if (search_terms.remove("enabled")) {
 			searchablePlugins = searchablePlugins.stream()
 				.filter(SearchablePlugin::isPluginEnabled)
 				.filter(SearchablePlugin::isInstalled)
 				.collect(Collectors.toList());
 		}
+		// Search for plugins that are installed and disabled.
+		// Remove the terms' first occurrence if found, we don't literally want plugins named "Disabled".
 		if (search_terms.remove("disabled"))
 		{
 			searchablePlugins = searchablePlugins.stream()
@@ -59,6 +64,8 @@ public class PluginSearch
 				.filter(SearchablePlugin::isInstalled)
 				.collect(Collectors.toList());
 		}
+		// Search for plugins that are installed.
+		// Remove the terms' first occurrence if found, we don't literally want plugins named "Installed".
 		if (search_terms.remove("installed"))
 		{
 			searchablePlugins = searchablePlugins.stream()
@@ -66,6 +73,16 @@ public class PluginSearch
 				.collect(Collectors.toList());
 		}
 
+		// Search for plugins that are not installed.
+		// Remove the terms' first occurrence if found, we don't literally want plugins named "Not Installed".
+		if (search_terms.remove("not-installed"))
+		{
+			searchablePlugins = searchablePlugins.stream()
+				.filter(plugin -> !plugin.isInstalled())
+				.collect(Collectors.toList());
+		}
+
+		// Search for plugins that are pinned.
 		if (search_terms.remove("pinned") || search_terms.remove("starred"))
 		{
 			searchablePlugins = searchablePlugins.stream()
@@ -73,6 +90,7 @@ public class PluginSearch
 				.collect(Collectors.toList());
 		}
 
+		// search for plugins that match the search terms
 		return searchablePlugins.stream()
 			.filter(plugin -> Text.matchesSearchTerms(search_terms, plugin.getKeywords()))
 			.sorted(comparator(query))

--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/PluginSearch.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/PluginSearch.java
@@ -49,7 +49,8 @@ public class PluginSearch
 
 		// Search for plugins that are installed and enabled.
 		// Remove the terms' first occurrence if found, we don't literally want plugins named "Enabled".
-		if (search_terms.remove("enabled")) {
+		if (search_terms.remove("enabled"))
+		{
 			searchablePlugins = searchablePlugins.stream()
 				.filter(SearchablePlugin::isPluginEnabled)
 				.filter(SearchablePlugin::isInstalled)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/SearchablePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/SearchablePlugin.java
@@ -32,8 +32,9 @@ public interface SearchablePlugin
 
 	List<String> getKeywords();
 
-	default boolean isPinned()
-	{
-		return false;
-	}
+	boolean isPluginEnabled();
+
+	boolean isInstalled();
+
+	boolean isPinned();
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/TopLevelConfigPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/TopLevelConfigPanel.java
@@ -171,15 +171,4 @@ class TopLevelConfigPanel extends PluginPanel
 		pluginListPanel.openConfigurationPanel(name);
 	}
 
-	public void openConfigurationPanel(Plugin plugin)
-	{
-		tabGroup.select(pluginListPanelTab);
-		pluginListPanel.openConfigurationPanel(plugin);
-	}
-
-	public void openWithFilter(String filter)
-	{
-		tabGroup.select(pluginListPanelTab);
-		pluginListPanel.openWithFilter(filter);
-	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/TopLevelConfigPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/TopLevelConfigPanel.java
@@ -49,7 +49,7 @@ class TopLevelConfigPanel extends PluginPanel
 
 	private final EventBus eventBus;
 	private final PluginListPanel pluginListPanel;
-	private final MaterialTab pluginListPanelTab;
+    private final MaterialTab pluginListPanelTab;
 
 	private boolean active = false;
 	private PluginPanel current;
@@ -60,7 +60,7 @@ class TopLevelConfigPanel extends PluginPanel
 		EventBus eventBus,
 		PluginListPanel pluginListPanel,
 		ProfilePanel profilePanel,
-		Provider<PluginHubPanel> pluginHubPanelProvider
+		PluginHubPanel pluginHubPanel
 	)
 	{
 		super(false);
@@ -84,7 +84,7 @@ class TopLevelConfigPanel extends PluginPanel
 
 		addTab(profilePanel, "profile_icon.png", "Profiles");
 
-		addTab(pluginHubPanelProvider, "plugin_hub_icon.png", "Plugin Hub");
+        addTab(pluginHubPanel.getMuxer(), "plugin_hub_icon.png", "Plugin Hub");
 
 		tabGroup.select(pluginListPanelTab);
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/TopLevelConfigPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/TopLevelConfigPanel.java
@@ -34,7 +34,6 @@ import javax.swing.ImageIcon;
 import javax.swing.JPanel;
 import javax.swing.border.EmptyBorder;
 import net.runelite.client.eventbus.EventBus;
-import net.runelite.client.plugins.Plugin;
 import net.runelite.client.ui.PluginPanel;
 import net.runelite.client.ui.components.materialtabs.MaterialTab;
 import net.runelite.client.ui.components.materialtabs.MaterialTabGroup;
@@ -49,7 +48,7 @@ class TopLevelConfigPanel extends PluginPanel
 
 	private final EventBus eventBus;
 	private final PluginListPanel pluginListPanel;
-    private final MaterialTab pluginListPanelTab;
+	private final MaterialTab pluginListPanelTab;
 
 	private boolean active = false;
 	private PluginPanel current;
@@ -84,7 +83,7 @@ class TopLevelConfigPanel extends PluginPanel
 
 		addTab(profilePanel, "profile_icon.png", "Profiles");
 
-        addTab(pluginHubPanel.getMuxer(), "plugin_hub_icon.png", "Plugin Hub");
+		addTab(pluginHubPanel.getMuxer(), "plugin_hub_icon.png", "Plugin Hub");
 
 		tabGroup.select(pluginListPanelTab);
 	}

--- a/runelite-client/src/test/java/net/runelite/client/plugins/config/PluginSearchTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/config/PluginSearchTest.java
@@ -28,6 +28,9 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import jdk.jshell.spi.ExecutionControl;
+import lombok.SneakyThrows;
 import org.junit.Before;
 import org.junit.Test;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -108,6 +111,18 @@ public class PluginSearchTest
 		public List<String> getKeywords()
 		{
 			return keywords;
+		}
+
+		@SneakyThrows
+		@Override
+		public boolean isPluginEnabled() {
+			throw new ExecutionControl.NotImplementedException("LOUIS HACK");
+		}
+
+		@SneakyThrows
+		@Override
+		public boolean isInstalled() {
+			throw new ExecutionControl.NotImplementedException("LOUIS HACK");
 		}
 	}
 }

--- a/runelite-client/src/test/java/net/runelite/client/plugins/config/PluginSearchTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/config/PluginSearchTest.java
@@ -139,12 +139,14 @@ public class PluginSearchTest
 		}
 
 		@Override
-		public boolean isPluginEnabled() {
+		public boolean isPluginEnabled()
+		{
 			return enabled;
 		}
 
 		@Override
-		public boolean isInstalled() {
+		public boolean isInstalled()
+		{
 			return installed;
 		}
 

--- a/runelite-client/src/test/java/net/runelite/client/plugins/config/PluginSearchTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/config/PluginSearchTest.java
@@ -47,10 +47,10 @@ public class PluginSearchTest
 	public void setUp()
 	{
 		plugins = new HashMap<>();
-		plugins.put("Discord", new TestSearchablePlugin("Discord", false, "action", "activity", "external", "integration", "status"));
-		plugins.put("Emojis", new TestSearchablePlugin("Emojis", true, "replaces", "common", "emoticons"));
-		plugins.put("Grand Exchange", new TestSearchablePlugin("Grand Exchange", true, "external", "integration", "notifications", "panel", "prices", "trade"));
-		plugins.put("Status Bars", new TestSearchablePlugin("Status Bars", false, "Draws", "status", "bars"));
+		plugins.put("Discord", new TestSearchablePlugin("Discord", false, true, true, "action", "activity", "external", "integration", "status"));
+		plugins.put("Emojis", new TestSearchablePlugin("Emojis", true, false, false, "replaces", "common", "emoticons"));
+		plugins.put("Grand Exchange", new TestSearchablePlugin("Grand Exchange", true, false, false, "external", "integration", "notifications", "panel", "prices", "trade"));
+		plugins.put("Status Bars", new TestSearchablePlugin("Status Bars", false, false, true, "Draws", "status", "bars"));
 	}
 
 	@Test
@@ -82,17 +82,44 @@ public class PluginSearchTest
 		assertThat(results, contains(plugins.get("Grand Exchange"), plugins.get("Discord")));
 	}
 
+	@Test
+	public void searchFiltersByEnabled()
+	{
+		List<SearchablePlugin> results = PluginSearch.search(plugins.values(), "enabled");
+		assertThat(results, contains(plugins.get("Discord")));
+	}
+
+	@Test
+	public void searchFiltersByDisabled()
+	{
+		List<SearchablePlugin> results = PluginSearch.search(plugins.values(), "disabled");
+		assertThat(results, contains(plugins.get("Status Bars")));
+	}
+
+	@Test
+	public void searchFiltersByInstalled()
+	{
+		List<SearchablePlugin> results = PluginSearch.search(plugins.values(), "installed");
+		assertThat(results, contains(plugins.get("Discord"), plugins.get("Status Bars")));
+	}
+
+
+
 	private static class TestSearchablePlugin implements SearchablePlugin
 	{
 		private final String name;
 		private final boolean pinned;
 		private final List<String> keywords;
+		private final boolean enabled;
+		private final boolean installed;
 
-		public TestSearchablePlugin(String name, boolean pinned, String... keywords)
+		public TestSearchablePlugin(String name, boolean pinned, boolean enabled, boolean installed, String... keywords)
 		{
 			this.name = name;
 			this.pinned = pinned;
 			this.keywords = Arrays.asList(keywords);
+			this.enabled = enabled;
+			this.installed = installed;
 		}
 
 		@Override
@@ -113,16 +140,20 @@ public class PluginSearchTest
 			return keywords;
 		}
 
-		@SneakyThrows
 		@Override
 		public boolean isPluginEnabled() {
-			throw new ExecutionControl.NotImplementedException("LOUIS HACK");
+			return enabled;
 		}
 
-		@SneakyThrows
 		@Override
 		public boolean isInstalled() {
-			throw new ExecutionControl.NotImplementedException("LOUIS HACK");
+			return installed;
+		}
+
+		@Override
+		public String toString()
+		{
+			return name;
 		}
 	}
 }

--- a/runelite-client/src/test/java/net/runelite/client/plugins/config/PluginSearchTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/config/PluginSearchTest.java
@@ -29,8 +29,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import jdk.jshell.spi.ExecutionControl;
-import lombok.SneakyThrows;
 import org.junit.Before;
 import org.junit.Test;
 import static org.hamcrest.MatcherAssert.assertThat;


### PR DESCRIPTION
# New Search Terms!
## PluginList
Search plugins by "enabled", "disabled", "pinned" or "starred". Implemented in PluginSearch.java
## PluginHub
Search plugins by "enabled", "disabled", "installed", "not-installed", "pinned" or "starred". Implemented in PluginSearch.java

# Quality of life updates to PluginHub

- ConfigPanels opened in PluginHub now has correct back button navigation; does not go back to PluginListPanel, but correctly back into PluginHubPanel. Implemented by giving PluginHubPanel a Multiplexer, and provides itself with ConfigPanel. 
- PluginHub lazy refreshes on interval, default is refresh every 120 seconds/2 minutes. Can be controlled using VM options. 
  `-Drunelite.pluginhub.reloadinterval=<seconds>`
  
  In addition, PluginHubPanel will remember the plugin and scrolls plugin list view back into pre-refresh location. 
- Persistent PluginHubPanel state, now a singleton. 

## Minor changes
- In PluginHubPanel, Plugins without configuration will hide the "Config"(gear) button.
- Multiple ConfigPanels for the same plugin can be active, that is when ConfigPanel is opened in PluginListPanel and PluginHubPanel for the same plugin. ConfigPanel now rebuilds onActivate to maintain the latest version.


# Demo
https://github.com/runelite/runelite/assets/1916460/6f49a2af-5d81-41d4-b01b-121c4eede284

https://github.com/runelite/runelite/assets/1916460/3ba0300e-3dec-41d2-8d1c-01216d557038

https://github.com/runelite/runelite/assets/1916460/80ef25ca-4deb-45b9-b807-ca4eb26be5b1

https://github.com/runelite/runelite/assets/1916460/5ddb5614-a577-483c-8952-21a1fbe4b880

https://github.com/runelite/runelite/assets/1916460/e79f20b2-076e-4771-94ce-b6262ec0472b

https://github.com/runelite/runelite/assets/1916460/f518477a-9518-4a77-ac25-ffea2c48a74f

# Comparison With Current Version
https://github.com/runelite/runelite/assets/1916460/96f72e1f-7f9e-4793-84e1-8dacade57b84


