### PR TITLE
Prevents the roof removal plugin from getting a null value on start

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/roofremoval/RoofRemovalPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/roofremoval/RoofRemovalPlugin.java
@@ -106,8 +106,8 @@ public class RoofRemovalPlugin extends Plugin
 			if (client.getGameState() == GameState.LOGGED_IN)
 			{
 				performRoofRemoval();
+				client.getScene().setRoofRemovalMode(buildRoofRemovalFlags());
 			}
-			client.getScene().setRoofRemovalMode(buildRoofRemovalFlags());
 		});
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/roofremoval/RoofRemovalPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/roofremoval/RoofRemovalPlugin.java
@@ -105,8 +105,8 @@ public class RoofRemovalPlugin extends Plugin
 		{
 			if (client.getGameState() == GameState.LOGGED_IN)
 			{
-				performRoofRemoval();
 				client.getScene().setRoofRemovalMode(buildRoofRemovalFlags());
+				performRoofRemoval();
 			}
 		});
 	}


### PR DESCRIPTION
Moved getScene() inside of the if-case on start to make sure it's not null and making sure the value is set first, before we call performRoofRemoval().
Closes #17504