### PR TITLE
screenshot: add required rs settings to descriptions

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotConfig.java
@@ -218,7 +218,8 @@ public interface ScreenshotConfig extends Config
 	@ConfigItem(
 		keyName = "valuableDrop",
 		name = "Screenshot Valuable drops",
-		description = "Configures whether or not screenshots are automatically taken when you receive a valuable drop.",
+		description = "Configures whether or not screenshots are automatically taken when you receive a valuable drop.<br>"
+			+ "Requires 'Loot drop notifications' to be enabled in the RuneScape settings.",
 		position = 14,
 		section = whatSection
 	)
@@ -230,7 +231,8 @@ public interface ScreenshotConfig extends Config
 	@ConfigItem(
 		keyName = "valuableDropThreshold",
 		name = "Valuable Threshold",
-		description = "The minimum value to save screenshots of valuable drops.",
+		description = "The minimum value to save screenshots of valuable drops.<br>"
+			+ "Requires 'Minimum item value needed for loot notification' to be set to a lesser or equal value in the RuneScape settings.",
 		position = 15,
 		section = whatSection
 	)
@@ -242,7 +244,8 @@ public interface ScreenshotConfig extends Config
 	@ConfigItem(
 		keyName = "untradeableDrop",
 		name = "Screenshot Untradeable drops",
-		description = "Configures whether or not screenshots are automatically taken when you receive an untradeable drop.",
+		description = "Configures whether or not screenshots are automatically taken when you receive an untradeable drop.<br>"
+			+ "Requires 'Untradeable loot notifications' to be enabled in the RuneScape settings.",
 		position = 16,
 		section = whatSection
 	)
@@ -278,7 +281,8 @@ public interface ScreenshotConfig extends Config
 	@ConfigItem(
 		keyName = "collectionLogEntries",
 		name = "Screenshot collection log entries",
-		description = "Take a screenshot when completing an entry in the collection log",
+		description = "Take a screenshot when completing an entry in the collection log.<br>"
+			+ "Requires 'Collection log - New addition notification' to be enabled in the RuneScape settings.",
 		position = 19,
 		section = whatSection
 	)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotConfig.java
@@ -35,7 +35,7 @@ public interface ScreenshotConfig extends Config
 {
 	@ConfigSection(
 		name = "What to Screenshot",
-		description = "All the options that select what to screenshot",
+		description = "All the options that select what to screenshot.",
 		position = 99
 	)
 	String whatSection = "what";
@@ -43,7 +43,7 @@ public interface ScreenshotConfig extends Config
 	@ConfigItem(
 		keyName = "includeFrame",
 		name = "Include Client Frame",
-		description = "Configures whether or not the client frame is included in screenshots",
+		description = "Configures whether or not the client frame is included in screenshots.",
 		position = 0
 	)
 	default boolean includeFrame()
@@ -54,7 +54,7 @@ public interface ScreenshotConfig extends Config
 	@ConfigItem(
 		keyName = "displayDate",
 		name = "Display Date",
-		description = "Configures whether or not the report button shows the date the screenshot was taken",
+		description = "Configures whether or not the report button shows the date the screenshot was taken.",
 		position = 1
 	)
 	default boolean displayDate()
@@ -65,7 +65,7 @@ public interface ScreenshotConfig extends Config
 	@ConfigItem(
 		keyName = "notifyWhenTaken",
 		name = "Notify When Taken",
-		description = "Configures whether or not you are notified when a screenshot has been taken",
+		description = "Configures whether or not you are notified when a screenshot has been taken.",
 		position = 2
 	)
 	default boolean notifyWhenTaken()
@@ -76,7 +76,7 @@ public interface ScreenshotConfig extends Config
 	@ConfigItem(
 		keyName = "copyToClipboard",
 		name = "Copy to clipboard",
-		description = "Copies the saved screenshot to clipboard",
+		description = "Copies the saved screenshot to clipboard.",
 		position = 4
 	)
 	default boolean copyToClipboard()
@@ -87,7 +87,7 @@ public interface ScreenshotConfig extends Config
 	@ConfigItem(
 		keyName = "hotkey",
 		name = "Screenshot hotkey",
-		description = "When you press this key a screenshot will be taken",
+		description = "When you press this key a screenshot will be taken.",
 		position = 4
 	)
 	default Keybind hotkey()
@@ -98,7 +98,7 @@ public interface ScreenshotConfig extends Config
 	@ConfigItem(
 		keyName = "rewards",
 		name = "Screenshot Rewards",
-		description = "Configures whether screenshots are taken of clues, barrows, and quest completion",
+		description = "Configures whether screenshots are taken of clues, barrows, and quest completion.",
 		position = 3,
 		section = whatSection
 	)
@@ -110,7 +110,7 @@ public interface ScreenshotConfig extends Config
 	@ConfigItem(
 		keyName = "levels",
 		name = "Screenshot Levels",
-		description = "Configures whether screenshots are taken of level ups",
+		description = "Configures whether screenshots are taken of level ups.",
 		position = 4,
 		section = whatSection
 	)
@@ -122,7 +122,7 @@ public interface ScreenshotConfig extends Config
 	@ConfigItem(
 		keyName = "kingdom",
 		name = "Screenshot Kingdom Reward",
-		description = "Configures whether screenshots are taken of Kingdom Reward",
+		description = "Configures whether screenshots are taken of Kingdom Reward.",
 		position = 5,
 		section = whatSection
 	)
@@ -134,7 +134,7 @@ public interface ScreenshotConfig extends Config
 	@ConfigItem(
 		keyName = "pets",
 		name = "Screenshot Pet",
-		description = "Configures whether screenshots are taken of receiving pets",
+		description = "Configures whether screenshots are taken of receiving pets.",
 		position = 6,
 		section = whatSection
 	)
@@ -146,7 +146,7 @@ public interface ScreenshotConfig extends Config
 	@ConfigItem(
 		keyName = "kills",
 		name = "Screenshot PvP Kills",
-		description = "Configures whether or not screenshots are automatically taken of PvP kills",
+		description = "Configures whether or not screenshots are automatically taken of PvP kills.",
 		position = 8,
 		section = whatSection
 	)
@@ -158,7 +158,7 @@ public interface ScreenshotConfig extends Config
 	@ConfigItem(
 		keyName = "boss",
 		name = "Screenshot Boss Kills",
-		description = "Configures whether or not screenshots are automatically taken of boss kills",
+		description = "Configures whether or not screenshots are automatically taken of boss kills.",
 		position = 9,
 		section = whatSection
 	)
@@ -294,7 +294,7 @@ public interface ScreenshotConfig extends Config
 	@ConfigItem(
 		keyName = "combatAchievements",
 		name = "Screenshot combat achievements",
-		description = "Take a screenshot when completing a combat achievement task",
+		description = "Take a screenshot when completing a combat achievement task.",
 		position = 20,
 		section = whatSection
 	)
@@ -306,7 +306,7 @@ public interface ScreenshotConfig extends Config
 	@ConfigItem(
 		keyName = "wildernessLootChest",
 		name = "Screenshot wilderness loot chest",
-		description = "Take a screenshot when opening wilderness loot chest",
+		description = "Take a screenshot when opening wilderness loot chest.",
 		position = 21,
 		section = whatSection
 	)


### PR DESCRIPTION
Adds the required ingame settings to the config descriptions of the screenshot plugin to reduce support traffic.

Because I was editting the config anyway, I uniformized the periods in the config descriptions since some descriptions had periods and others did not. This commit can be changed or dropped if desired.