### PR TITLE
screenshot: Add option to disable death screenshots in LMS

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotConfig.java
@@ -180,10 +180,22 @@ public interface ScreenshotConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "ignoreLMSDeaths",
+		name = "Ignore deaths in Last Man Standing",
+		description = "Configures whether or not the Screenshot Deaths option ignores deaths in Last Man Standing.",
+		position = 11,
+		section = whatSection
+	)
+	default boolean ignoreLMSDeaths()
+	{
+		return false;
+	}
+
+	@ConfigItem(
 		keyName = "friendDeath",
 		name = "Screenshot Friend Deaths",
 		description = "Configures whether or not screenshots are automatically taken when friends or friends chat members die.",
-		position = 11,
+		position = 12,
 		section = whatSection
 	)
 	default boolean screenshotFriendDeath()
@@ -195,7 +207,7 @@ public interface ScreenshotConfig extends Config
 		keyName = "clanDeath",
 		name = "Screenshot Clan Deaths",
 		description = "Configures whether or not screenshots are automatically taken when clan members die.",
-		position = 12,
+		position = 13,
 		section = whatSection
 	)
 	default boolean screenshotClanDeath()
@@ -207,7 +219,7 @@ public interface ScreenshotConfig extends Config
 		keyName = "duels",
 		name = "Screenshot Duels",
 		description = "Configures whether or not screenshots are automatically taken of the duel end screen.",
-		position = 13,
+		position = 14,
 		section = whatSection
 	)
 	default boolean screenshotDuels()
@@ -220,7 +232,7 @@ public interface ScreenshotConfig extends Config
 		name = "Screenshot Valuable drops",
 		description = "Configures whether or not screenshots are automatically taken when you receive a valuable drop.<br>"
 			+ "Requires 'Loot drop notifications' to be enabled in the RuneScape settings.",
-		position = 14,
+		position = 15,
 		section = whatSection
 	)
 	default boolean screenshotValuableDrop()
@@ -233,7 +245,7 @@ public interface ScreenshotConfig extends Config
 		name = "Valuable Threshold",
 		description = "The minimum value to save screenshots of valuable drops.<br>"
 			+ "Requires 'Minimum item value needed for loot notification' to be set to a lesser or equal value in the RuneScape settings.",
-		position = 15,
+		position = 16,
 		section = whatSection
 	)
 	default int valuableDropThreshold()
@@ -246,7 +258,7 @@ public interface ScreenshotConfig extends Config
 		name = "Screenshot Untradeable drops",
 		description = "Configures whether or not screenshots are automatically taken when you receive an untradeable drop.<br>"
 			+ "Requires 'Untradeable loot notifications' to be enabled in the RuneScape settings.",
-		position = 16,
+		position = 17,
 		section = whatSection
 	)
 	default boolean screenshotUntradeableDrop()
@@ -258,7 +270,7 @@ public interface ScreenshotConfig extends Config
 		keyName = "ccKick",
 		name = "Screenshot Kicks from FC",
 		description = "Take a screenshot when you kick a user from a friends chat.",
-		position = 17,
+		position = 18,
 		section = whatSection
 	)
 	default boolean screenshotKick()
@@ -270,7 +282,7 @@ public interface ScreenshotConfig extends Config
 		keyName = "baHighGamble",
 		name = "Screenshot BA high gambles",
 		description = "Take a screenshot of your reward from a high gamble at Barbarian Assault.",
-		position = 18,
+		position = 19,
 		section = whatSection
 	)
 	default boolean screenshotHighGamble()
@@ -283,7 +295,7 @@ public interface ScreenshotConfig extends Config
 		name = "Screenshot collection log entries",
 		description = "Take a screenshot when completing an entry in the collection log.<br>"
 			+ "Requires 'Collection log - New addition notification' to be enabled in the RuneScape settings.",
-		position = 19,
+		position = 20,
 		section = whatSection
 	)
 	default boolean screenshotCollectionLogEntries()
@@ -295,7 +307,7 @@ public interface ScreenshotConfig extends Config
 		keyName = "combatAchievements",
 		name = "Screenshot combat achievements",
 		description = "Take a screenshot when completing a combat achievement task.",
-		position = 20,
+		position = 21,
 		section = whatSection
 	)
 	default boolean screenshotCombatAchievements()
@@ -307,7 +319,7 @@ public interface ScreenshotConfig extends Config
 		keyName = "wildernessLootChest",
 		name = "Screenshot wilderness loot chest",
 		description = "Take a screenshot when opening wilderness loot chest.",
-		position = 21,
+		position = 22,
 		section = whatSection
 	)
 	default boolean screenshotWildernessLootChest()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
@@ -52,6 +52,7 @@ import net.runelite.api.SpriteID;
 import net.runelite.api.VarClientStr;
 import net.runelite.api.Varbits;
 import net.runelite.api.annotations.Component;
+import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.ActorDeath;
 import net.runelite.api.events.ChatMessage;
 import net.runelite.api.events.GameTick;
@@ -93,6 +94,7 @@ public class ScreenshotPlugin extends Plugin
 	private static final Map<Integer, String> CHEST_LOOT_EVENTS = ImmutableMap.of(12127, "The Gauntlet");
 	private static final int GAUNTLET_REGION = 7512;
 	private static final int CORRUPTED_GAUNTLET_REGION = 7768;
+	private static final Set<Integer> LAST_MAN_STANDING_REGIONS = ImmutableSet.of(13658, 13659, 13160, 13914, 13915, 13916, 13918, 13919, 13920, 14174, 14175, 14176, 14430, 14431, 14432);
 	private static final Pattern NUMBER_PATTERN = Pattern.compile("([0-9]+)");
 	private static final Pattern LEVEL_UP_PATTERN = Pattern.compile(".*Your ([a-zA-Z]+) (?:level is|are)? now (\\d+)\\.");
 	private static final Pattern LEVEL_UP_MESSAGE_PATTERN = Pattern.compile("Congratulations, you've (just advanced your (?<skill>[a-zA-Z]+) level\\. You are now level (?<level>\\d+)|reached the highest possible (?<skill99>[a-zA-Z]+) level of 99)\\.");
@@ -298,7 +300,11 @@ public class ScreenshotPlugin extends Plugin
 			Player player = (Player) actor;
 			if (player == client.getLocalPlayer() && config.screenshotPlayerDeath())
 			{
-				takeScreenshot("Death", SD_DEATHS);
+				final int regionID = WorldPoint.fromLocalInstance(client, client.getLocalPlayer().getLocalLocation()).getRegionID();
+				if (!(config.ignoreLMSDeaths() && LAST_MAN_STANDING_REGIONS.contains(regionID)))
+				{
+					takeScreenshot("Death", SD_DEATHS);
+				}
 			}
 			else if (player != client.getLocalPlayer()
 				&& player.getCanvasTilePoly() != null


### PR DESCRIPTION
Adds an option to ignore deaths in Last Man Standing even when the "Screenshot deaths" option is enabled.