### PR TITLE
wiki: Add config option to enable/disable the wiki lookup button 

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/wiki/WikiConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/wiki/WikiConfig.java
@@ -41,4 +41,16 @@ public interface WikiConfig extends Config
 	{
 		return false;
 	}
+
+	@ConfigItem(
+		keyName = "showWikiMinimapButton",
+		name = "Show wiki button under minimap",
+		description = "Shows the wiki lookup button under the minimap.<br>"
+			+ "Overrides 'Show Wiki entity lookup' in the RuneScape settings.",
+		position = 2
+	)
+	default boolean showWikiMinimapButton()
+	{
+		return true;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/wiki/WikiPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/wiki/WikiPlugin.java
@@ -182,6 +182,11 @@ public class WikiPlugin extends Plugin
 			vanilla.setHidden(true);
 		}
 
+		if (!config.showWikiMinimapButton())
+		{
+			return;
+		}
+
 		icon = wikiBannerParent.createChild(0, WidgetType.GRAPHIC);
 		icon.setSpriteId(SpriteID.WIKI_DESELECTED);
 		icon.setOriginalX(0);


### PR DESCRIPTION
Allows for the ability to use the wiki DPS calculator button while still hiding the wiki lookup button under the minimap.

Should close #17523 