### PR TITLE
clientui: apply custom borders when maximizing

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
@@ -656,6 +656,10 @@ public class ClientUI
 				if (configManager.getConfiguration(CONFIG_GROUP, CONFIG_CLIENT_MAXIMIZED) != null)
 				{
 					frame.setExtendedState(JFrame.MAXIMIZED_BOTH);
+					// According to the documentation of JFrame#setExtendedState, if the frame isn't visible, a window
+					// state change event isn't guaranteed to be fired. Since RuneLite's custom chrome borders rely on a
+					// state change listener, borders need to be applied manually when maximizing prior to setVisible
+					applyCustomChromeBorder();
 				}
 			}
 			else


### PR DESCRIPTION
Before the window is made visible, window state change events aren't guaranteed to be fired. This causes RuneLite's custom window chrome borders to not be removed when restoring a maximized window on client startup. It's fixed by manually reapplying borders when restoring the maximized window state for the "Remember client position" setting.

The state change event not being guaranteed when the window isn't visible is mentioned here: https://docs.oracle.com/en/java/javase/11/docs/api/java.desktop/java/awt/Frame.html#setExtendedState(int)

~~I couldn't find any open issues about this.~~

Closes #17499