### PR TITLE
world map: Update outdated DBTableID values

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/dbtable/DBTableID.java
+++ b/runelite-api/src/main/java/net/runelite/api/dbtable/DBTableID.java
@@ -30,7 +30,7 @@ public final class DBTableID
 	{
 		int TABLE = 0;
 		int NAME = 2;
-		int MAP_ELEMENT = 14;
-		int MAIN_QUEST = 19;
+		int MAP_ELEMENT = 16;
+		int MAIN_QUEST = 21;
 	}
 }


### PR DESCRIPTION
The World Map Plugin currently throws the following error when you go over a Quest icon on the world map:

```
2024-02-29 11:29:01 GMT [Client] WARN  n.runelite.client.eventbus.EventBus - Uncaught exception in event subscriber
vt: 
	at hn.aw(hn.java:60380)
	at uq.bx(uq.java:222)
	at uq.cc(uq.java:411)
	at uz.aq(uz.java:31)
	at uz.<init>(uz.java:22)
	at lv.om(lv.java:12983)
	at uz.oq(uz.java)
	at client.getDBRowsByValue(client.java:1355)
	at net.runelite.client.plugins.worldmap.WorldMapPlugin.onClientTick(WorldMapPlugin.java:270)
	at net.runelite.client.eventbus.EventBus$Subscriber.invoke(EventBus.java:70)
	at net.runelite.client.eventbus.EventBus.post(EventBus.java:223)
	at net.runelite.client.callback.Hooks.post(Hooks.java:205)
	at client.zp(client.java:62506)
	at client.mg(client.java:3531)
	at client.bb(client.java:1192)
	at bm.ap(bm.java:400)
	at bm.yz(bm.java)
	at bm.run(bm.java:57325)
	at java.base/java.lang.Thread.run(Unknown Source)
Caused by: java.lang.NullPointerException: null
	... 18 common frames omitted
```

This results in the ticks and crosses on Quest icons indicating completion not to render. I believe this is due to the Quest DB having additional columns added, if I were to hazard a guess for the new 'Highlight quest start NPC' feature added to the official client.

The values of MAP_ELEMENT and MAIN_QUEST seemed to be outdated, causing this issue. This PR should resolve this issue.