### PR TITLE
party: add ping information to descriptions

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/party/PartyConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/party/PartyConfig.java
@@ -52,7 +52,7 @@ public interface PartyConfig extends Config
 	@ConfigItem(
 		keyName = "sounds",
 		name = "Sound on ping",
-		description = "Enables sound notification on party ping",
+		description = "Enables sound notification on party ping.",
 		position = 2
 	)
 	default boolean sounds()
@@ -63,7 +63,7 @@ public interface PartyConfig extends Config
 	@ConfigItem(
 		keyName = "recolorNames",
 		name = "Recolor names",
-		description = "Recolor party members names based on unique color hash",
+		description = "Recolor party members names based on unique color hash.",
 		position = 3
 	)
 	default boolean recolorNames()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/party/PartyConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/party/PartyConfig.java
@@ -40,7 +40,8 @@ public interface PartyConfig extends Config
 	@ConfigItem(
 		keyName = "pings",
 		name = "Pings",
-		description = "Enables party pings",
+		description = "Enables party pings.<br>"
+			+ "To ping, hold the ping hotkey down and click on the tile you want to ping.",
 		position = 1
 	)
 	default boolean pings()
@@ -73,7 +74,8 @@ public interface PartyConfig extends Config
 	@ConfigItem(
 		keyName = "pingHotkey",
 		name = "Ping hotkey",
-		description = "Key to hold to send a tile ping",
+		description = "Key to hold to send a tile ping.<br>"
+			+ "To ping, hold the ping hotkey down and click on the tile you want to ping.",
 		position = 4
 	)
 	default Keybind pingHotkey()


### PR DESCRIPTION
Since we sometimes have multiple people per day ask us how to ping, or tell us that the ping option is broken / does not work for them, this adds a brief explanation to the config descriptions of the party plugin to reduce support traffic.

Because I was editting the config anyway, I uniformized the periods in the config descriptions since some descriptions had periods and others did not. This commit can be changed or dropped if desired.