### PR TITLE
Add configurable colors for Forestry events.

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingConfig.java
@@ -24,12 +24,10 @@
  */
 package net.runelite.client.plugins.woodcutting;
 
-import net.runelite.client.config.Config;
-import net.runelite.client.config.ConfigGroup;
-import net.runelite.client.config.ConfigItem;
-import net.runelite.client.config.ConfigSection;
-import net.runelite.client.config.Units;
+import net.runelite.client.config.*;
 import net.runelite.client.plugins.woodcutting.config.ClueNestTier;
+import net.runelite.client.config.Alpha;
+import java.awt.Color;
 
 @ConfigGroup("woodcutting")
 public interface WoodcuttingConfig extends Config
@@ -40,6 +38,13 @@ public interface WoodcuttingConfig extends Config
 		position = 10
 	)
 	String forestrySection = "forestry";
+
+	@ConfigSection(
+		name = "Event colors",
+		description = "Color options for forestry events",
+		position = 12
+	)
+	String eventColors = "eventColors";
 
 	@ConfigItem(
 		position = 1,
@@ -299,4 +304,83 @@ public interface WoodcuttingConfig extends Config
 	{
 		return true;
 	}
+
+	@Alpha
+	@ConfigItem(
+		keyName = "growingRootsColor",
+		name = "Growing roots",
+		description = "Color for the glowing roots event",
+		position = 3,
+		section = eventColors
+	)
+	default Color growingRootsColor()
+	{
+		return Color.GREEN;
+	}
+
+	@Alpha
+	@ConfigItem(
+		keyName = "foxTrapColor",
+		name = "Fox trap",
+		description = "Color for the fox trap event",
+		position = 3,
+		section = eventColors
+	)
+	default Color foxTrapColor()
+	{
+		return Color.RED;
+	}
+
+	@Alpha
+	@ConfigItem(
+		keyName = "ritualCircleColor",
+		name = "Ritual circle",
+		description = "Color for the ritual circle event",
+		position = 3,
+		section = eventColors
+	)
+	default Color ritualCircleColor()
+	{
+		return Color.GREEN;
+	}
+
+	@Alpha
+	@ConfigItem(
+		keyName = "beehiveColor",
+		name = "Beehive",
+		description = "Color for the beehive event",
+		position = 3,
+		section = eventColors
+	)
+	default Color beehiveColor()
+	{
+		return Color.GREEN;
+	}
+
+	@Alpha
+	@ConfigItem(
+		keyName = "freakyForesterColor",
+		name = "Freaky Forester",
+		description = "Color for the Forester NPC",
+		position = 3,
+		section = eventColors
+	)
+	default Color freakyForesterColor()
+	{
+		return Color.GREEN;
+	}
+
+	@Alpha
+	@ConfigItem(
+		keyName = "pheasantNestColor",
+		name = "Pheasant nest",
+		description = "Color for the pheasant nest",
+		position = 3,
+		section = eventColors
+	)
+	default Color pheasantNestColor()
+	{
+		return Color.GREEN;
+	}
+
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingSceneOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/woodcutting/WoodcuttingSceneOverlay.java
@@ -107,7 +107,7 @@ class WoodcuttingSceneOverlay extends Overlay
 					continue;
 				}
 
-				Color color = Color.GREEN;
+				Color color = config.growingRootsColor();
 				graphics.setColor(color);
 				graphics.draw(clickbox);
 				graphics.setColor(ColorUtil.colorWithAlpha(color, color.getAlpha() / 5));
@@ -231,7 +231,7 @@ class WoodcuttingSceneOverlay extends Overlay
 			var poly = foxTrap.getCanvasTilePoly();
 			if (poly != null)
 			{
-				OverlayUtil.renderPolygon(graphics, poly, Color.RED);
+				OverlayUtil.renderPolygon(graphics, poly, config.foxTrapColor());
 			}
 		}
 	}
@@ -247,7 +247,7 @@ class WoodcuttingSceneOverlay extends Overlay
 					var poly = nest.getCanvasTilePoly();
 					if (poly != null)
 					{
-						OverlayUtil.renderPolygon(graphics, poly, Color.GREEN);
+						OverlayUtil.renderPolygon(graphics, poly, config.pheasantNestColor());
 					}
 				}
 			}
@@ -258,7 +258,7 @@ class WoodcuttingSceneOverlay extends Overlay
 				var poly = forester.getCanvasTilePoly();
 				if (poly != null)
 				{
-					OverlayUtil.renderPolygon(graphics, poly, Color.GREEN);
+					OverlayUtil.renderPolygon(graphics, poly, config.freakyForesterColor());
 				}
 			}
 		}
@@ -272,7 +272,7 @@ class WoodcuttingSceneOverlay extends Overlay
 			var poly = beehive.getCanvasTilePoly();
 			if (poly != null)
 			{
-				OverlayUtil.renderPolygon(graphics, poly, Color.ORANGE);
+				OverlayUtil.renderPolygon(graphics, poly, config.beehiveColor());
 			}
 		}
 	}
@@ -285,7 +285,7 @@ class WoodcuttingSceneOverlay extends Overlay
 			var poly = solution.getCanvasTilePoly();
 			if (poly != null)
 			{
-				OverlayUtil.renderPolygon(graphics, poly, Color.GREEN);
+				OverlayUtil.renderPolygon(graphics, poly, config.ritualCircleColor());
 			}
 		}
 	}
@@ -324,8 +324,8 @@ class WoodcuttingSceneOverlay extends Overlay
 			}
 
 			LocalPoint centeredLocation = new LocalPoint(
-					minLocation.getX() + treeRespawn.getLenX() * Perspective.LOCAL_HALF_TILE_SIZE,
-					minLocation.getY() + treeRespawn.getLenY() * Perspective.LOCAL_HALF_TILE_SIZE);
+				minLocation.getX() + treeRespawn.getLenX() * Perspective.LOCAL_HALF_TILE_SIZE,
+				minLocation.getY() + treeRespawn.getLenY() * Perspective.LOCAL_HALF_TILE_SIZE);
 			float percent = (now.toEpochMilli() - treeRespawn.getStartTime().toEpochMilli()) / (float) treeRespawn.getRespawnTime();
 			Point point = Perspective.localToCanvas(client, centeredLocation, client.getPlane());
 			if (point == null || percent > 1.0f)


### PR DESCRIPTION
## Customizable Colors for Forestry events

### Current Behavior
- The Woodcutting plugin primarily uses a bright green color for most events.

### Proposed Changes
- Introduce an option for users to configure their own colors for various Forestry events
- This feature enhances user experience by allowing personalization and supports better accessibility

### Example
Below is an example of how the color customization interface looks within the plugin settings

![Example of Color Customization in Woodcutting Plugin](https://github.com/runelite/runelite/assets/108600998/eca640ac-9ee8-4771-86b6-77ef9db809d9)
