### PR TITLE
Party: Add option to automatically join the previous party on startup of the RuneLite client

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/party/PartyConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/party/PartyConfig.java
@@ -179,6 +179,18 @@ public interface PartyConfig extends Config
 	}
 
 	@ConfigItem(
+		section = SECTION_STATUS_OVERLAY,
+		keyName = "joinPreviousPartyOnStartup",
+		name = "Join previous party on startup",
+		description = "Join the previous party on startup of the runelite client.",
+		position = 107
+	)
+	default boolean joinPreviousPartyOnStartup()
+	{
+		return false;
+	}
+
+	@ConfigItem(
 		keyName = "previousPartyId",
 		name = "",
 		description = "",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/party/PartyPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/party/PartyPlugin.java
@@ -204,6 +204,11 @@ public class PartyPlugin extends Plugin
 		wsClient.registerMessage(StatusUpdate.class);
 		// Delay sync so the eventbus can register prior to the sync response
 		SwingUtilities.invokeLater(this::requestSync);
+
+		if (config.joinPreviousPartyOnStartup() &&  && !config.previousPartyId().isEmpty())
+		{
+			party.changeParty(config.previousPartyId());
+		}		
 	}
 
 	@Override

--- a/runelite-client/src/main/java/net/runelite/client/plugins/party/PartyPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/party/PartyPlugin.java
@@ -64,6 +64,7 @@ import net.runelite.client.callback.ClientThread;
 import net.runelite.client.chat.ChatMessageManager;
 import net.runelite.client.chat.QueuedMessage;
 import net.runelite.client.config.ConfigManager;
+import net.runelite.client.discord.events.DiscordReady;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.events.ConfigChanged;
 import net.runelite.client.events.PartyChanged;
@@ -203,7 +204,7 @@ public class PartyPlugin extends Plugin
 		wsClient.registerMessage(LocationUpdate.class);
 		wsClient.registerMessage(StatusUpdate.class);
 		// Delay sync so the eventbus can register prior to the sync response
-		SwingUtilities.invokeLater(this::requestSync);	
+		SwingUtilities.invokeLater(this::requestSync);
 	}
 
 	@Override
@@ -390,11 +391,16 @@ public class PartyPlugin extends Plugin
 			final UserSync userSync = new UserSync();
 			party.send(userSync);
 		}
+	}
 
+	@Subscribe
+	public void onDiscordReady(final DiscordReady event)
+	{
+		log.info("discord is ready");
 		if (!party.isInParty() && config.joinPreviousPartyOnStartup() && !config.previousPartyId().isEmpty())
 		{
 			party.changeParty(config.previousPartyId());
-		}	
+		}
 	}
 
 	@Subscribe

--- a/runelite-client/src/main/java/net/runelite/client/plugins/party/PartyPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/party/PartyPlugin.java
@@ -396,7 +396,6 @@ public class PartyPlugin extends Plugin
 	@Subscribe
 	public void onDiscordReady(final DiscordReady event)
 	{
-		log.info("discord is ready");
 		if (!party.isInParty() && config.joinPreviousPartyOnStartup() && !config.previousPartyId().isEmpty())
 		{
 			party.changeParty(config.previousPartyId());

--- a/runelite-client/src/main/java/net/runelite/client/plugins/party/PartyPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/party/PartyPlugin.java
@@ -203,12 +203,7 @@ public class PartyPlugin extends Plugin
 		wsClient.registerMessage(LocationUpdate.class);
 		wsClient.registerMessage(StatusUpdate.class);
 		// Delay sync so the eventbus can register prior to the sync response
-		SwingUtilities.invokeLater(this::requestSync);
-
-		if (config.joinPreviousPartyOnStartup() && !config.previousPartyId().isEmpty())
-		{
-			party.changeParty(config.previousPartyId());
-		}		
+		SwingUtilities.invokeLater(this::requestSync);	
 	}
 
 	@Override
@@ -395,6 +390,11 @@ public class PartyPlugin extends Plugin
 			final UserSync userSync = new UserSync();
 			party.send(userSync);
 		}
+
+		if (!party.isInParty() && config.joinPreviousPartyOnStartup() && !config.previousPartyId().isEmpty())
+		{
+			party.changeParty(config.previousPartyId());
+		}	
 	}
 
 	@Subscribe

--- a/runelite-client/src/main/java/net/runelite/client/plugins/party/PartyPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/party/PartyPlugin.java
@@ -205,7 +205,7 @@ public class PartyPlugin extends Plugin
 		// Delay sync so the eventbus can register prior to the sync response
 		SwingUtilities.invokeLater(this::requestSync);
 
-		if (config.joinPreviousPartyOnStartup() &&  && !config.previousPartyId().isEmpty())
+		if (config.joinPreviousPartyOnStartup() && !config.previousPartyId().isEmpty())
 		{
 			party.changeParty(config.previousPartyId());
 		}		


### PR DESCRIPTION
Add an option to the Party plugin to automatically join the previous party on startup of the RuneLite client