### PR TITLE
devtools: restore button laf on toggle

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/devtools/DevToolsButton.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/devtools/DevToolsButton.java
@@ -27,6 +27,7 @@ package net.runelite.client.plugins.devtools;
 import java.awt.Color;
 import javax.swing.JButton;
 import lombok.Getter;
+import net.runelite.client.ui.ColorScheme;
 
 public class DevToolsButton extends JButton
 {
@@ -50,7 +51,7 @@ public class DevToolsButton extends JButton
 		}
 		else
 		{
-			setBackground(null);
+			setBackground(ColorScheme.DARKER_GRAY_COLOR);
 		}
 	}
 


### PR DESCRIPTION
Currently clicking an active button on the developer tools panel removes its fill color, this PR intends on fixing this so that the buttons retain their original color.