### PR TITLE
Add fairy ring tests

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/fairyring/FairyRings.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/fairyring/FairyRings.java
@@ -64,8 +64,8 @@ public enum FairyRings
 	// C
 	CIP("(Island) Miscellania"),
 	CIQ("North-west of Yanille"),
-	CIS("North of the Arceuus Library"),
 	CIR("North-east of the Farming Guild", "mount karuulm konar"),
+	CIS("North of the Arceuus Library"),
 	CJR("Sinclair Mansion", "falo bard"),
 	CKP("Cosmic entity's plane"),
 	CKR("South of Tai Bwo Wannai Village"),
@@ -76,8 +76,8 @@ public enum FairyRings
 
 	// D
 	DIP("(Sire Boss) Abyssal Nexus"),
-	DIR("Gorak's Plane"),
 	DIQ("Player-owned house", "poh home"),
+	DIR("Gorak's Plane"),
 	DIS("Wizards' Tower"),
 	DJP("Tower of Life"),
 	DJR("Chasm of Fire"),

--- a/runelite-client/src/test/java/net/runelite/client/plugins/fairyring/FairyRingTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/fairyring/FairyRingTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2024, testing <96100526+testing-ongithub@users.noreply.github.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.fairyring;
+
+import java.util.stream.Stream;
+import static org.apache.commons.lang3.ArrayUtils.isSorted;
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+
+public class FairyRingTest
+{
+	@Test
+	public void testFairyRingsAlphabetized()
+	{
+		assertTrue(isSorted(Stream.of(FairyRings.values()).map(FairyRings::name).toArray(String[]::new)));
+	}
+}

--- a/runelite-client/src/test/java/net/runelite/client/plugins/worldmap/FairyRingLocationTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/worldmap/FairyRingLocationTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2024, testing <96100526+testing-ongithub@users.noreply.github.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.worldmap;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import net.runelite.client.plugins.fairyring.FairyRings;
+import static org.apache.commons.lang3.ArrayUtils.isSorted;
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+
+public class FairyRingLocationTest
+{
+	@Test
+	public void testFairyRingsAlphabetized()
+	{
+		assertTrue(isSorted(Stream.of(FairyRingLocation.values()).map(FairyRingLocation::name).toArray(String[]::new)));
+	}
+
+	@Test
+	public void testFairyRingsInFairyRingPlugin()
+	{
+		Set<String> fairyRings = Stream.of(FairyRings.values()).map(FairyRings::name).collect(Collectors.toSet());
+
+		for (FairyRingLocation r : FairyRingLocation.values())
+		{
+			assertTrue(r.name() + " is not in fairy ring plugin's enum", fairyRings.contains(r.getCode()));
+		}
+	}
+}


### PR DESCRIPTION
This PR adds tests for alphabetization of fairy rings to the world map and fairy ring plugins, and it adds a test that all fairy rings in the world map plugin are also in the fairy ring plugin. Because some fairy rings don't appear on the world map, it's not possible (unless I'm missing something) to test that the fairy plugin's fairy rings are in the world map plugin.

I left adding the new Varlamore fairy ring out of this PR because there are already two open PRs that do that. 😄 