### PR TITLE
loot tracker: track lunar chest & fortis colosseum & hunters' loot sacks

### DIFF
--- a/runelite-api/src/main/interfaces/interfaces.toml
+++ b/runelite-api/src/main/interfaces/interfaces.toml
@@ -365,6 +365,9 @@ bank_container=78
 interface_container=79
 inventory_container=83
 
+[fortis_colosseum_reward]
+id=864
+
 [fossil_island_oxygen_bar]
 id=609
 bar=1

--- a/runelite-api/src/main/interfaces/interfaces.toml
+++ b/runelite-api/src/main/interfaces/interfaces.toml
@@ -526,6 +526,9 @@ logout_button=6
 id=81
 looting_bag_inventory=5
 
+[lunar_chest]
+id=868
+
 [minigames]
 id=160
 teleport_button=30

--- a/runelite-api/src/main/java/net/runelite/api/InventoryID.java
+++ b/runelite-api/src/main/java/net/runelite/api/InventoryID.java
@@ -104,7 +104,11 @@ public enum InventoryID
 	/**
 	 * Reward chest for Moons of Peril
 	 */
-	LUNAR_CHEST(847);
+	LUNAR_CHEST(847),
+	/**
+	 * Reward chest for the Fortis Colosseum
+	 */
+	FORTIS_COLOSSEUM_REWARD_CHEST(843);
 
 	private final int id;
 

--- a/runelite-api/src/main/java/net/runelite/api/InventoryID.java
+++ b/runelite-api/src/main/java/net/runelite/api/InventoryID.java
@@ -100,7 +100,11 @@ public enum InventoryID
 	/**
 	 * TOA reward chest
 	 */
-	TOA_REWARD_CHEST(811);
+	TOA_REWARD_CHEST(811),
+	/**
+	 * Reward chest for Moons of Peril
+	 */
+	LUNAR_CHEST(847);
 
 	private final int id;
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
@@ -1231,6 +1231,24 @@ public class LootTrackerPlugin extends Plugin
 					case ItemID.ORE_PACK_27693:
 						onInvChange(collectInvItems(LootRecordType.EVENT, ORE_PACK_VM_EVENT));
 						break;
+					//Hunters loot sacks are stackable and multiple can be opened in one tick.
+					//This provides an accurate count of how many were opened for each event
+					case ItemID.HUNTERS_LOOT_SACK:
+					case ItemID.HUNTERS_LOOT_SACK_BASIC:
+					case ItemID.HUNTERS_LOOT_SACK_TIER_1:
+					case ItemID.HUNTERS_LOOT_SACK_TIER_2:
+					case ItemID.HUNTERS_LOOT_SACK_TIER_3:
+						final int itemId = event.getItemId();
+						onInvChange((((invItems, groundItems, removedItems) ->
+						{
+							int cnt = removedItems.count(itemId);
+							if (cnt > 0)
+							{
+								String name = itemManager.getItemComposition(itemId).getMembersName();
+								addLoot(name, -1, LootRecordType.EVENT, null, invItems, cnt);
+							}
+						})));
+						break;
 				}
 			}
 			else if (event.getMenuOption().equals("Loot") && IMPLING_JARS.contains(event.getItemId()))

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
@@ -892,6 +892,10 @@ public class LootTrackerPlugin extends Plugin
 				container = client.getItemContainer(InventoryID.WILDERNESS_LOOT_CHEST);
 				chestLooted = true;
 				break;
+			case InterfaceID.LUNAR_CHEST:
+				event = "Lunar Chest";
+				container = client.getItemContainer(InventoryID.LUNAR_CHEST);
+				break;
 			default:
 				return;
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
@@ -896,6 +896,15 @@ public class LootTrackerPlugin extends Plugin
 				event = "Lunar Chest";
 				container = client.getItemContainer(InventoryID.LUNAR_CHEST);
 				break;
+			case InterfaceID.FORTIS_COLOSSEUM_REWARD:
+				if (chestLooted)
+				{
+					return;
+				}
+				event = "Fortis Colosseum";
+				container = client.getItemContainer(InventoryID.FORTIS_COLOSSEUM_REWARD_CHEST);
+				chestLooted = true;
+				break;
 			default:
 				return;
 		}


### PR DESCRIPTION
Perilous Moons unlocks the Moons of Peril which give rewards from the Lunar Chest
Fortis Colosseum doesn't have a fancy name for its reward chest
Hunters' loot is tracked per tier since they have different loot tables