### PR TITLE
fishing: prevent false positive session

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/fishing/FishingPlugin.java
@@ -33,6 +33,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import lombok.AccessLevel;
@@ -83,6 +84,9 @@ public class FishingPlugin extends Plugin
 	private static final int TRAWLER_SHIP_REGION_NORMAL = 7499;
 	private static final int TRAWLER_SHIP_REGION_SINKING = 8011;
 	private static final int TRAWLER_TIME_LIMIT_IN_SECONDS = 314;
+
+	private static final Pattern FISHING_CATCH_REGEX = Pattern.compile(
+		"You catch (?:a|an|some) |Your cormorant returns with its catch.|You catch .* Karambwanji");
 
 	private Instant trawlerStartTime;
 
@@ -194,9 +198,7 @@ public class FishingPlugin extends Plugin
 		}
 
 		var message = event.getMessage();
-		if (message.contains("You catch a") || message.contains("You catch some")
-			|| message.equals("Your cormorant returns with its catch.")
-			|| (message.startsWith("You catch") && message.contains("Karambwanji")))
+		if (FISHING_CATCH_REGEX.matcher(message).find())
 		{
 			session.setLastFishCaught(Instant.now());
 			spotOverlay.setHidden(false);

--- a/runelite-client/src/test/java/net/runelite/client/plugins/fishing/FishingPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/fishing/FishingPluginTest.java
@@ -81,6 +81,42 @@ public class FishingPluginTest
 	}
 
 	@Test
+	public void testLobster()
+	{
+		ChatMessage chatMessage = new ChatMessage();
+		chatMessage.setType(ChatMessageType.SPAM);
+		chatMessage.setMessage("You catch a Lobster.");
+
+		fishingPlugin.onChatMessage(chatMessage);
+
+		assertNotNull(fishingPlugin.getSession().getLastFishCaught());
+	}
+
+	@Test
+	public void testAnglerfish()
+	{
+		ChatMessage chatMessage = new ChatMessage();
+		chatMessage.setType(ChatMessageType.SPAM);
+		chatMessage.setMessage("You catch an Anglerfish.");
+
+		fishingPlugin.onChatMessage(chatMessage);
+
+		assertNotNull(fishingPlugin.getSession().getLastFishCaught());
+	}
+
+	@Test
+	public void testCormorant()
+	{
+		ChatMessage chatMessage = new ChatMessage();
+		chatMessage.setType(ChatMessageType.SPAM);
+		chatMessage.setMessage("Your cormorant returns with its catch.");
+
+		fishingPlugin.onChatMessage(chatMessage);
+
+		assertNotNull(fishingPlugin.getSession().getLastFishCaught());
+	}
+
+	@Test
 	public void testKarambwanji()
 	{
 		ChatMessage chatMessage = new ChatMessage();


### PR DESCRIPTION
Adding a space after 'a' prevents chat messages when catching butterflies from passing the check. Butterfly message: "You catch and..."
Fishing message: "You catch a ..."
Fixes https://github.com/runelite/runelite/issues/17597
