### PR TITLE
worldhopper: Add High Risk option to world filter.

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldTypeFilter.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldTypeFilter.java
@@ -88,6 +88,14 @@ enum WorldTypeFilter
 			{
 				return types.contains(WorldType.SKILL_TOTAL);
 			}
+		},
+	HIGH_RISK
+		{
+			@Override
+			boolean matches(Set<WorldType> types)
+			{
+				return types.contains(WorldType.HIGH_RISK);
+			}
 		};
 
 	abstract boolean matches(Set<WorldType> types);


### PR DESCRIPTION
Adds an option to filter high risk worlds to the worldhopper plugin.