### PR TITLE
clues: fix NO OWNER anagram location

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java
@@ -476,7 +476,7 @@ public class AnagramClue extends ClueScroll implements NpcClueScroll, ObjectClue
 		AnagramClue.builder()
 			.text("NO OWNER")
 			.npc("Oronwen")
-			.location(new WorldPoint(1162, 3178, 0))
+			.location(new WorldPoint(2326, 3178, 0))
 			.area("Lletya Seamstress shop in Lletya")
 			.question("What is the minimum amount of quest points required to reach Lletya?")
 			.answer("20")


### PR DESCRIPTION
They updated the map so now everyone can see the incorrect coordinates

Fixes #17616 

![image](https://github.com/runelite/runelite/assets/41973452/93cb1080-962c-458b-ac05-2e9a2e5819b5)
