### PR TITLE
opponent info: fix hp bar being shown for moons of peril bosses

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/opponentinfo/OpponentInfoOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/opponentinfo/OpponentInfoOverlay.java
@@ -229,7 +229,7 @@ class OpponentInfoOverlay extends OverlayPanel
 		if (settingEnabled && opponent instanceof NPC)
 		{
 			int opponentId = client.getVarpValue(VarPlayer.HP_HUD_NPC_ID);
-			return opponentId != -1 && opponentId == ((NPC) opponent).getId();
+			return opponentId != -1 && opponentId == ((NPC) opponent).getComposition().getId();
 		}
 		return false;
 	}


### PR DESCRIPTION
Closes #17608

Fixes the Opponent Information plugin showing the HP bar of the Moons of Peril bosses