### PR TITLE
Apply game size setting before setting the frame location

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
@@ -649,10 +649,6 @@ public class ClientUI
 						frame.setLocationRelativeTo(frame.getOwner());
 					}
 				}
-				else
-				{
-					frame.setLocationRelativeTo(frame.getOwner());
-				}
 
 				if (configManager.getConfiguration(CONFIG_GROUP, CONFIG_CLIENT_MAXIMIZED) != null)
 				{
@@ -663,14 +659,11 @@ public class ClientUI
 					applyCustomChromeBorder();
 				}
 			}
-			else
-			{
-				frame.setLocationRelativeTo(frame.getOwner());
-			}
 
 			if (!appliedSize)
 			{
 				applyGameSize(true);
+				frame.setLocationRelativeTo(frame.getOwner());
 			}
 
 			// Show frame


### PR DESCRIPTION
Fixes positioning the RuneLite window off-center when game size is set, but "Remember client position" is not.

Before:  
![image](https://github.com/runelite/runelite/assets/7273082/a97d0ac8-c7f6-4ec2-ac00-cf94b8882e86)
After:  
![image](https://github.com/runelite/runelite/assets/7273082/42f64233-d250-4a84-b77d-cdbdf0d3e2ec)
Sidebar is opened after client launch, so technically in these pictures it's not centered.