### PR TITLE
regen-timer: fix spec regen desync

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/regenmeter/RegenMeterPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/regenmeter/RegenMeterPlugin.java
@@ -84,6 +84,7 @@ public class RegenMeterPlugin extends Plugin
 
 	private int ticksSinceSpecRegen;
 	private int ticksSinceHPRegen;
+	private int previousSpecPercentage;
 
 	private boolean wearingLightbearer;
 
@@ -112,6 +113,7 @@ public class RegenMeterPlugin extends Plugin
 		{
 			ticksSinceHPRegen = -2; // For some reason this makes this accurate
 			ticksSinceSpecRegen = 0;
+			previousSpecPercentage = getCurrentSpecAmount();
 		}
 	}
 
@@ -141,6 +143,14 @@ public class RegenMeterPlugin extends Plugin
 		{
 			ticksSinceHPRegen = 0;
 		}
+		if (ev.getVarpId() == VarPlayer.SPECIAL_ATTACK_PERCENT)
+		{
+			if (previousSpecPercentage < getCurrentSpecAmount())
+			{
+				ticksSinceSpecRegen = 0;
+			}
+			previousSpecPercentage = getCurrentSpecAmount();
+		}
 	}
 
 	@Subscribe
@@ -148,7 +158,7 @@ public class RegenMeterPlugin extends Plugin
 	{
 		final int ticksPerSpecRegen = wearingLightbearer ? SPEC_REGEN_TICKS / 2 : SPEC_REGEN_TICKS;
 
-		if (client.getVarpValue(VarPlayer.SPECIAL_ATTACK_PERCENT) == 1000)
+		if (getCurrentSpecAmount() == 1000)
 		{
 			// The recharge doesn't tick when at 100%
 			ticksSinceSpecRegen = 0;
@@ -193,5 +203,10 @@ public class RegenMeterPlugin extends Plugin
 		final int ticksBeforeHPRegen = ticksPerHPRegen - ticksSinceHPRegen;
 		final int notifyTick = (int) Math.ceil(config.getNotifyBeforeHpRegenSeconds() * 1000d / Constants.GAME_TICK_LENGTH);
 		return ticksBeforeHPRegen == notifyTick;
+	}
+
+	private int getCurrentSpecAmount()
+	{
+		return client.getVarpValue(VarPlayer.SPECIAL_ATTACK_PERCENT);
 	}
 }


### PR DESCRIPTION
Current issues with the spec regen overlay:

1. If one regens to 100% spec from a source that isn't natural regen, and instantly specs, it will desync. (e.g. energy transfer, death charge)
2. If one has an encounter that pauses spec regen, it will desync. (e.g. in-between waves in the colosseum)

This change will correct the desync between the spec regen indicator and the actual spec regen after 1 regen cycle. 

This change technically regresses NMZ spec regen with power surge, due to it not resetting the spec regen timer.