### PR TITLE
Add Tonalztics spec to spec counter plugin

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/specialcounter/SpecialWeapon.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/specialcounter/SpecialWeapon.java
@@ -54,7 +54,12 @@ public enum SpecialWeapon
 		(distance) -> 46 + distance * 10,
 		(c) -> 0
 	),
-	;
+	TONALZTICS_OF_RALOS(
+		"Tonalztics of Ralos",
+		new int[]{ItemID.TONALZTICS_OF_RALOS},
+		false,
+		(distance) -> 50, //The hitsplat is always applied 2t after spec regardless of distance
+		(c) -> 0);
 
 	private final String name;
 	private final int[] itemID;


### PR DESCRIPTION
Adds tonalztics to the spec counter plugin, after testing the spec always applies the hitsplat 2t after speccing regardless of distance, which means it will never queue before a mage or range thrall (which will always be at least 2t later and if they're both 2t the npc action is always processed first) so the last hitsplat logic still works, except for melee thralls (which is also true for dorgeshuun crossbow and accursed scepter, which both additionally can be incorrect on mage and range thralls if you bow/cast from max distance) 