### PR TITLE
runelite-client: Allow extending plugin class

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/PluginManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/PluginManager.java
@@ -326,14 +326,14 @@ public class PluginManager
 
 			if (pluginDescriptor == null)
 			{
-				if (clazz.getSuperclass() == Plugin.class)
+				if (Plugin.class.isAssignableFrom(clazz))
 				{
 					log.warn("Class {} is a plugin, but has no plugin descriptor", clazz);
 				}
 				continue;
 			}
 
-			if (clazz.getSuperclass() != Plugin.class)
+			if (!Plugin.class.isAssignableFrom(clazz))
 			{
 				log.warn("Class {} has plugin descriptor, but is not a plugin", clazz);
 				continue;


### PR DESCRIPTION
This pull request change will allow plugin developers to make super classes for plugins. Currently Runelite won't load a plugin that doesn't directly extend the `net.runelite.client.plugins.Plugin` class, this change will allow the plugin to extend any class that is assignable from said Plugin class.


This would help plugin developers by allowing them to create abstract classes that contain common things their plugins would contain. This would allow different plugin "Types".

For example, you could create a abstract class like this

```
public abstract class TestPluginType extends Plugin {
    @Override
    protected void startUp() {
        log.info("TestPluginType started!");
    }

    @Override
    protected void shutDown() {
        log.info("TestPluginType stopped!");
    }
}
```

Then you could extend this class with your own plugin like
`public class XpTrackerPlugin extends TestPluginType`

Examples of different abstract plugin classes you could create would be something like
* PanelPlugin: This could contain some boilerplate code for having a Panel
* UIPlugin: Plugin with some boilerplate for UI code
* SkillingPlugin: Contains some things that all other skilling plugins require, like built-in xp tracking, inventory tracking, logging etc