### PR TITLE
Item Charges: Add notification for Amulet of Chemistry

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemcharges/ItemChargeConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemcharges/ItemChargeConfig.java
@@ -453,4 +453,16 @@ public interface ItemChargeConfig extends Config
 	{
 		return true;
 	}
+
+	@ConfigItem(
+		keyName = "amuletOfChemistryNotification",
+		name = "Amulet of Chemistry Notification",
+		description = "Send a notification when an Amulet of Chemistry breaks",
+		position = 33,
+		section = notificationSection
+	)
+	default boolean amuletOfChemistryNotification()
+	{
+		return true;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemcharges/ItemChargePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemcharges/ItemChargePlugin.java
@@ -310,6 +310,11 @@ public class ItemChargePlugin extends Plugin
 			}
 			else if (amuletOfChemistryBreakMatcher.find())
 			{
+				if (config.amuletOfChemistryNotification())
+				{
+					notifier.notify("Your Amulet of Chemistry has crumbled to dust.");
+				}
+
 				updateAmuletOfChemistryCharges(MAX_AMULET_OF_CHEMISTRY_CHARGES);
 			}
 			else if (amuletOfBountyCheckMatcher.find())


### PR DESCRIPTION
It's useful to know when the Amulet of Chemistry breaks when making potions since it improves output, yet only has 5 charges and breaks frequently.
I've tested both states for the config in-game and it's working.