### PR TITLE
worldmap: fix quest icons paint cutoff

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldmap/WorldMapPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldmap/WorldMapPlugin.java
@@ -107,44 +107,46 @@ public class WorldMapPlugin extends Plugin
 
 	static
 	{
+		// Original size of world map icons
+		final int worldMapIconSize = 15;
 		//A size of 17 gives us a buffer when triggering tooltips
-		final int iconBufferSize = 17;
-
+		final int iconOffset = 1;
+		final int iconBufferSize = worldMapIconSize + iconOffset * 2;
 		// Quest icons are a bit bigger than regular icons
 		// A size of 25 aligns the quest icons when converting the world map point to pixel coordinates
 		// The new quest icons must be offset by 5, for a size of 25, to align when drawing on top of the original icon
-		final int questIconBufferSize = 25;
 		final int questIconOffset = 5;
+		final int questIconBufferSize = worldMapIconSize + questIconOffset * 2;
 
 		BLANK_ICON = new BufferedImage(iconBufferSize, iconBufferSize, BufferedImage.TYPE_INT_ARGB);
 
 		FAIRY_TRAVEL_ICON = new BufferedImage(iconBufferSize, iconBufferSize, BufferedImage.TYPE_INT_ARGB);
 		final BufferedImage fairyTravelIcon = ImageUtil.loadImageResource(WorldMapPlugin.class, "fairy_ring_travel.png");
-		FAIRY_TRAVEL_ICON.getGraphics().drawImage(fairyTravelIcon, 1, 1, null);
+		FAIRY_TRAVEL_ICON.getGraphics().drawImage(fairyTravelIcon, iconOffset, iconOffset, null);
 
 		NOPE_ICON = new BufferedImage(iconBufferSize, iconBufferSize, BufferedImage.TYPE_INT_ARGB);
 		final BufferedImage nopeImage = ImageUtil.loadImageResource(WorldMapPlugin.class, "nope_icon.png");
-		NOPE_ICON.getGraphics().drawImage(nopeImage, 1, 1, null);
+		NOPE_ICON.getGraphics().drawImage(nopeImage, iconOffset, iconOffset, null);
 
 		NOT_STARTED_ICON = new BufferedImage(questIconBufferSize, questIconBufferSize, BufferedImage.TYPE_INT_ARGB);
 		final BufferedImage notStartedIcon = ImageUtil.loadImageResource(WorldMapPlugin.class, "quest_not_started_icon.png");
-		NOT_STARTED_ICON.createGraphics().drawImage(notStartedIcon, questIconOffset, questIconOffset, null);
+		NOT_STARTED_ICON.getGraphics().drawImage(notStartedIcon, questIconOffset, questIconOffset, null);
 
 		STARTED_ICON = new BufferedImage(questIconBufferSize, questIconBufferSize, BufferedImage.TYPE_INT_ARGB);
 		final BufferedImage startedIcon = ImageUtil.loadImageResource(WorldMapPlugin.class, "quest_started_icon.png");
-		STARTED_ICON.createGraphics().drawImage(startedIcon, questIconOffset, questIconOffset, null);
+		STARTED_ICON.getGraphics().drawImage(startedIcon, questIconOffset, questIconOffset, null);
 
 		FINISHED_ICON = new BufferedImage(questIconBufferSize, questIconBufferSize, BufferedImage.TYPE_INT_ARGB);
 		final BufferedImage finishedIcon = ImageUtil.loadImageResource(WorldMapPlugin.class, "quest_completed_icon.png");
-		FINISHED_ICON.createGraphics().drawImage(finishedIcon, questIconOffset, questIconOffset, null);
+		FINISHED_ICON.getGraphics().drawImage(finishedIcon, questIconOffset, questIconOffset, null);
 
 		MINING_SITE_ICON = new BufferedImage(iconBufferSize, iconBufferSize, BufferedImage.TYPE_INT_ARGB);
 		final BufferedImage miningSiteIcon = ImageUtil.loadImageResource(WorldMapPlugin.class, "mining_site_icon.png");
-		MINING_SITE_ICON.getGraphics().drawImage(miningSiteIcon, 1, 1, null);
+		MINING_SITE_ICON.getGraphics().drawImage(miningSiteIcon, iconOffset, iconOffset, null);
 
 		ROOFTOP_COURSE_ICON = new BufferedImage(iconBufferSize, iconBufferSize, BufferedImage.TYPE_INT_ARGB);
 		final BufferedImage rooftopCourseIcon = ImageUtil.loadImageResource(WorldMapPlugin.class, "rooftop_course_icon.png");
-		ROOFTOP_COURSE_ICON.getGraphics().drawImage(rooftopCourseIcon, 1, 1, null);
+		ROOFTOP_COURSE_ICON.getGraphics().drawImage(rooftopCourseIcon, iconOffset, iconOffset, null);
 	}
 
 	@Inject


### PR DESCRIPTION
This PR fixes an issue with the quest map icons, in which they are only partially drawn.

The explanation for the numbers 25 and 5 is because the original images are 15x15 pixels, and the new ones 20x20 pixels. Attempting to center these inevatbly causes misalignment. However, with a size of 25x25 and an offset of 5 pixels the icons will align with the original without sacrificing their size. 

It is the smallest possible size.

<br>
<details>
  <summary>Before & After</summary>
  
  ![image](https://github.com/runelite/runelite/assets/50101641/3ff0cea0-9d98-441f-bc7d-86500969fde0)
  
</details>
<br>
Added for future reference
<details>
  <summary>Math</summary>
 $$\newline$$ 

   \$a\doteq\space\text{size image a}\$
   \$b\doteq\space\text{size image b}\$
   \$c\doteq\space\text{required new size}\$

   $$\displaylines{c\cases{\min\limits_{c}f(c|b) \space = |a-b|+\frac{a-b}{2}+\left|\frac{a+b}{2}\right|\space , \space \text{offset}\equiv\left((\frac{a+b}{2}+\left|\frac{a-b}{2}\right|\right)-\left(\frac{a-b}{2}+\left|\frac{a+b}{2}\right|\right))(\text{mod}2) \cr c-(\frac{a+b}{2}-\left|\frac{a-b}{2}\right|)=\frac{\text{offset}}{2}}}$$

</details>