### PR TITLE
Fix menu entry swapper removing attack option on Bee Swarm 

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/game/NpcUtil.java
+++ b/runelite-client/src/main/java/net/runelite/client/game/NpcUtil.java
@@ -86,6 +86,7 @@ public class NpcUtil
 			case NpcID.SMALL_LIZARD:
 			case NpcID.SMALL_LIZARD_463:
 			case NpcID.GROWTHLING:
+			case NpcID.BEE_SWARM:
 			// These NPCs die, but transform into forms which are attackable or interactable, so it would be jarring for
 			// them to be considered dead when reaching 0hp.
 			case NpcID.KALPHITE_QUEEN_963:


### PR DESCRIPTION
Bee swarm does not actually die, just relocates and becomes invisible and not attackable. This PR prevents it from being considered dead when it becomes attackable again. This fixes #17617 