### PR TITLE
Chat Timestamps: Add a third colour for Split PM messages

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/timestamp/TimestampConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timestamp/TimestampConfig.java
@@ -35,34 +35,42 @@ public interface TimestampConfig extends Config
 	String GROUP = "timestamp";
 
 	@ConfigItem(
-		keyName = "opaqueTimestamp",
-		name = "Timestamps (opaque)",
-		position = 1,
-		description = "Colour of Timestamps from the Timestamps plugin (opaque)"
+			keyName = "opaqueChatboxTimestamp",
+			name = "Timestamps (opaque chatbox)",
+			position = 1,
+			description = "Colour of Timestamps from the Timestamps plugin (opaque chatbox)"
 	)
-	Color opaqueTimestamp();
+	Color opaqueChatboxTimestamp();
 
 	@ConfigItem(
-		keyName = "transparentTimestamp",
-		name = "Timestamps (transparent)",
-		position = 2,
-		description = "Colour of Timestamps from the Timestamps plugin (transparent)"
+			keyName = "transparentChatboxTimestamp",
+			name = "Timestamps (transparent chatbox)",
+			position = 2,
+			description = "Colour of Timestamps from the Timestamps plugin (transparent chatbox)"
 	)
-	Color transparentTimestamp();
+	Color transparentChatboxTimestamp();
 
 	@ConfigItem(
-		keyName = "format",
-		name = "Timestamp Format",
-		position = 3,
-		description = "Customize your timestamp format by using the following characters<br>" +
-			"'yyyy' : year<br>" +
-			"'MM' : month<br>" +
-			"'dd' : day<br>" +
-			"'HH' : hour in 24 hour format<br>" +
-			"'hh' : hour in 12 hour format<br>" +
-			"'mm' : minute<br>" +
-			"'ss' : second<br>" +
-			"'a'  : AM/PM"
+			keyName = "splitPMTimestamp",
+			name = "Timestamps (split PM box)",
+			position = 3,
+			description = "Colour of Timestamps from the Timestamps plugin (split PM box)"
+	)
+	Color splitPMTimestamp();
+
+	@ConfigItem(
+			keyName = "format",
+			name = "Timestamp Format",
+			position = 4,
+			description = "Customize your timestamp format by using the following characters<br>" +
+					"'yyyy' : year<br>" +
+					"'MM' : month<br>" +
+					"'dd' : day<br>" +
+					"'HH' : hour in 24 hour format<br>" +
+					"'hh' : hour in 12 hour format<br>" +
+					"'mm' : minute<br>" +
+					"'ss' : second<br>" +
+					"'a'  : AM/PM"
 	)
 	default String timestampFormat()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timestamp/TimestampPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timestamp/TimestampPlugin.java
@@ -48,10 +48,10 @@ import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.util.ColorUtil;
 
 @PluginDescriptor(
-	name = "Chat Timestamps",
-	description = "Add timestamps to chat messages",
-	tags = {"timestamp"},
-	enabledByDefault = false
+		name = "Chat Timestamps",
+		description = "Add timestamps to chat messages",
+		tags = {"timestamp"},
+		enabledByDefault = false
 )
 public class TimestampPlugin extends Plugin
 {
@@ -95,8 +95,9 @@ public class TimestampPlugin extends Plugin
 				case "format":
 					updateFormatter();
 					break;
-				case "opaqueTimestamp":
-				case "transparentTimestamp":
+				case "opaqueChatboxTimestamp":
+				case "transparentChatboxTimestamp":
+				case "splitPMTimestamp":
 					clientThread.invokeLater(() -> client.runScript(ScriptID.SPLITPM_CHANGED));
 					break;
 			}
@@ -128,15 +129,27 @@ public class TimestampPlugin extends Plugin
 
 	private Color getTimestampColour()
 	{
+		boolean isSplitPM = client.getIntStack()[client.getIntStackSize() - 2] == 1;
 		boolean isChatboxTransparent = client.isResized() && client.getVarbitValue(Varbits.TRANSPARENT_CHATBOX) == 1;
 
-		return isChatboxTransparent ? config.transparentTimestamp() : config.opaqueTimestamp();
+		if (isSplitPM)
+		{
+			return config.splitPMTimestamp();
+		}
+		else if (isChatboxTransparent)
+		{
+			return config.transparentChatboxTimestamp();
+		}
+		else
+		{
+			return config.opaqueChatboxTimestamp();
+		}
 	}
 
 	String generateTimestamp(int timestamp, ZoneId zoneId)
 	{
 		final ZonedDateTime time = ZonedDateTime.ofInstant(
-			Instant.ofEpochSecond(timestamp), zoneId);
+				Instant.ofEpochSecond(timestamp), zoneId);
 
 		return formatter.format(Date.from(time.toInstant()));
 	}


### PR DESCRIPTION
Close #17649

Add a third colour to the Chat Timestamps plugin and apply it to messages in the split PM box.