### PR TITLE
mes: custom swaps for dizana's quiver ammo slot

### DIFF
--- a/runelite-api/src/main/interfaces/interfaces.toml
+++ b/runelite-api/src/main/interfaces/interfaces.toml
@@ -291,6 +291,7 @@ emote_scrollbar=4
 id=387
 inventory_item_container=0
 cape=16
+dizanas_quiver_item_container=28
 
 [equipment_bonuses]
 id=84

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -1202,9 +1202,10 @@ public class MenuEntrySwapperPlugin extends Plugin
 				}
 
 				final int interId = WidgetUtil.componentToInterface(w.getId());
-				if (interId == InterfaceID.INVENTORY || interId == InterfaceID.EQUIPMENT)
+				if (interId == InterfaceID.INVENTORY || (interId == InterfaceID.EQUIPMENT && w.getId() != ComponentID.EQUIPMENT_DIZANAS_QUIVER_ITEM_CONTAINER))
 				{
 					// inventory and worn items have their own swap systems
+					// other than dizanas quiver, since it's not actually an inventory slot but some static widgets
 					continue;
 				}
 
@@ -1556,7 +1557,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 			&& w != null && (w.getIndex() == -1 || w.getItemId() != -1)
 			&& w.getActions() != null
 			&& WidgetUtil.componentToInterface(w.getId()) != InterfaceID.INVENTORY
-			&& WidgetUtil.componentToInterface(w.getId()) != InterfaceID.EQUIPMENT)
+			&& (WidgetUtil.componentToInterface(w.getId()) != InterfaceID.EQUIPMENT || w.getId() == ComponentID.EQUIPMENT_DIZANAS_QUIVER_ITEM_CONTAINER))
 		{
 			// fast check to avoid hitting config on components with single ops
 			if ((index > 0 && menuEntries[index - 1].getWidget() == w) ||


### PR DESCRIPTION
Dizana's quiver adds a new ammo slot to the equipment tab, but:
* this slot is not actually part of the equipment inventory container, and
* probably because of that, the widgets are implemented differently as a couple nested static widgets

As a result, the existing equipment tab custom tab functionality does not recognize it as a valid swap target. However, it can be handled as a normal ui swap by just excluding it from the inventory interface id preconditions.