### PR TITLE
Chat Timestamps: Add third colour for Split PM timestamps

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/timestamp/TimestampConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timestamp/TimestampConfig.java
@@ -35,25 +35,33 @@ public interface TimestampConfig extends Config
 	String GROUP = "timestamp";
 
 	@ConfigItem(
-		keyName = "opaqueTimestamp",
-		name = "Timestamps (opaque)",
+		keyName = "opaqueChatboxTimestamp",
+		name = "Timestamps (opaque chatbox)",
 		position = 1,
-		description = "Colour of Timestamps from the Timestamps plugin (opaque)"
+		description = "Colour of Timestamps from the Timestamps plugin (opaque chatbox)"
 	)
-	Color opaqueTimestamp();
+	Color opaqueChatboxTimestamp();
 
 	@ConfigItem(
-		keyName = "transparentTimestamp",
-		name = "Timestamps (transparent)",
+		keyName = "transparentChatboxTimestamp",
+		name = "Timestamps (transparent chatbox)",
 		position = 2,
-		description = "Colour of Timestamps from the Timestamps plugin (transparent)"
+		description = "Colour of Timestamps from the Timestamps plugin (transparent chatbox)"
 	)
-	Color transparentTimestamp();
+	Color transparentChatboxTimestamp();
+
+	@ConfigItem(
+		keyName = "splitPMTimestamp",
+		name = "Timestamps (split PM box)",
+		position = 3,
+		description = "Colour of Timestamps from the Timestamps plugin (split PM box)"
+	)
+	Color splitPMTimestamp();
 
 	@ConfigItem(
 		keyName = "format",
 		name = "Timestamp Format",
-		position = 3,
+		position = 4,
 		description = "Customize your timestamp format by using the following characters<br>" +
 			"'yyyy' : year<br>" +
 			"'MM' : month<br>" +

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timestamp/TimestampPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timestamp/TimestampPlugin.java
@@ -95,8 +95,9 @@ public class TimestampPlugin extends Plugin
 				case "format":
 					updateFormatter();
 					break;
-				case "opaqueTimestamp":
-				case "transparentTimestamp":
+				case "opaqueChatboxTimestamp":
+				case "transparentChatboxTimestamp":
+				case "splitPMTimestamp":
 					clientThread.invokeLater(() -> client.runScript(ScriptID.SPLITPM_CHANGED));
 					break;
 			}
@@ -128,9 +129,21 @@ public class TimestampPlugin extends Plugin
 
 	private Color getTimestampColour()
 	{
+		boolean isSplitPM = client.getIntStack()[client.getIntStackSize() - 2] == 1;
 		boolean isChatboxTransparent = client.isResized() && client.getVarbitValue(Varbits.TRANSPARENT_CHATBOX) == 1;
 
-		return isChatboxTransparent ? config.transparentTimestamp() : config.opaqueTimestamp();
+		if (isSplitPM)
+		{
+			return config.splitPMTimestamp();
+		}
+		else if (isChatboxTransparent)
+		{
+			return config.transparentChatboxTimestamp();
+		}
+		else
+		{
+			return config.opaqueChatboxTimestamp();
+		}
 	}
 
 	String generateTimestamp(int timestamp, ZoneId zoneId)


### PR DESCRIPTION
Close #17649

Add a third colour to the Chat Timestamps plugin and apply it to messages in the split PM box.