### PR TITLE
Add auto rejoin functionality to party plugin

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/party/PartyConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/party/PartyConfig.java
@@ -72,11 +72,22 @@ public interface PartyConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "autoJoinPreviousParty",
+		name = "Auto join previous party",
+		description = "Automatically join your previous party on login. Will not automatically rejoin if you manually leave the party.",
+		position = 4
+	)
+	default boolean autoJoinPreviousParty()
+	{
+		return false;
+	}
+
+	@ConfigItem(
 		keyName = "pingHotkey",
 		name = "Ping hotkey",
 		description = "Key to hold to send a tile ping.<br>"
 			+ "To ping, hold the ping hotkey down and click on the tile you want to ping.",
-		position = 4
+		position = 5
 	)
 	default Keybind pingHotkey()
 	{
@@ -87,7 +98,7 @@ public interface PartyConfig extends Config
 		keyName = "memberColor",
 		name = "Self-Color",
 		description = "Which color you will appear as in the party panel and tile pings.",
-		position = 5
+		position = 6
 	)
 	Color memberColor();
 
@@ -95,7 +106,7 @@ public interface PartyConfig extends Config
 		keyName = "memberColor",
 		name = "",
 		description = "",
-		position = 5
+		position = 7
 	)
 	void setMemberColor(Color newMemberColor);
 
@@ -196,4 +207,25 @@ public interface PartyConfig extends Config
 		hidden = true
 	)
 	void setPreviousPartyId(String id);
+
+
+	@ConfigItem(
+		keyName = "skipAutoJoinPreviousParty",
+		name = "",
+		description = "",
+		hidden = true
+	)
+	default boolean skipAutoJoinPreviousParty()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		keyName = "skipAutoJoinPreviousParty",
+		name = "",
+		description = "",
+		hidden = true
+	)
+	void setSkipAutoJoinPreviousParty(boolean skip);
+
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/party/PartyPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/party/PartyPanel.java
@@ -138,6 +138,8 @@ class PartyPanel extends PluginPanel
 				if (result == JOptionPane.YES_OPTION)
 				{
 					plugin.leaveParty();
+					// disable auto joining the previous party if the player manually leaves.
+					config.setSkipAutoJoinPreviousParty(true);
 				}
 			}
 			else
@@ -221,7 +223,7 @@ class PartyPanel extends PluginPanel
 		else if (plugin.getPartyDataMap().size() <= 1)
 		{
 			partyEmptyPanel.setContent("Party created", "You can now invite friends!<br/>" +
-					"Your party passphrase is: " + party.getPartyPassphrase() + ".");
+				"Your party passphrase is: " + party.getPartyPassphrase() + ".");
 			add(partyEmptyPanel);
 		}
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/party/PartyPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/party/PartyPlugin.java
@@ -305,6 +305,18 @@ public class PartyPlugin extends Plugin
 			lastLogout = Instant.now();
 		}
 
+		if (event.getGameState() == GameState.LOGGED_IN)
+		{
+			// Check to see if the player has opted into auto joining their previous party
+			if (!party.isInParty() &&
+				config.autoJoinPreviousParty() &&
+				!config.skipAutoJoinPreviousParty() &&
+				config.previousPartyId() != null)
+			{
+				party.changeParty(config.previousPartyId());
+			}
+		}
+
 		checkStateChanged(false);
 	}
 
@@ -600,6 +612,12 @@ public class PartyPlugin extends Plugin
 		if (event.getPartyId() != null)
 		{
 			config.setPreviousPartyId(event.getPassphrase());
+
+			// Need to disable the skip flag here, as if the player leaves the party manually we disable it.
+			if (config.autoJoinPreviousParty())
+			{
+				config.setSkipAutoJoinPreviousParty(false);
+			}
 		}
 
 		SwingUtilities.invokeLater(panel::removeAllMembers);


### PR DESCRIPTION
Add the option for players to opt into automatically rejoining their previous party upon login. This is useful for groups of friends that frequently play together, and don't want to remember to rejoin their party every time they launch the game. 

Summary of changes: 

- Adds a config option for the user to opt into automatically rejoining their previous party. 
- Adds a hidden config option to track if automatic party rejoining should be skipped. Upon the user manually leaving the party through the leave button, this flag is set to true. Upon joining a party again, this flag is set back to false.
- Adds checks on the `onGameStateChanged` event to check 1. If the game state is `LOGGED_IN` 2. If the player is not currently in a party 3. If the player has a previous party ID 4. If the player has opted into automatically rejoining their previous party 5. If automatically rejoining the previous party has not been disabled due to the player manually leaving the party. 
  - If all checks are successful, a call is made to `party.changeParty()` with the user's previous party ID.
