### PR TITLE
Add fortis colosseum glory value to varplayer enum

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/VarPlayer.java
+++ b/runelite-api/src/main/java/net/runelite/api/VarPlayer.java
@@ -240,4 +240,9 @@ public final class VarPlayer
 	 * Assigned slayer task location. The mapping of value to name can be found in {@link EnumID#SLAYER_TASK_LOCATION}
 	 */
 	public static final int SLAYER_TASK_LOCATION = 2096;
+
+	/**
+	 * The maximum glory achieved in the Fortis Colosseum minigame
+	 */
+	public static final int FORTIS_COLOSSEUM_GLORY = 4130;
 }


### PR DESCRIPTION
VarPlayer 4130 tracks the personal glory value of the player and is updated upon finishing a colosseum run. 

![image](https://github.com/runelite/runelite/assets/97203666/201404f7-a57d-420f-b45c-af26d0f9fc4a)
