### PR TITLE
surefire: set locale to en_US

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -197,7 +197,7 @@
 				<version>2.22.2</version>
 				<configuration>
 					<enableAssertions>true</enableAssertions>
-					<argLine>-Xmx512m</argLine>
+					<argLine>-Xmx512m -Duser.language=en -Duser.region=US</argLine>
 					<systemProperties>
 						<glslang.path>${glslang.path}</glslang.path>
 					</systemProperties>


### PR DESCRIPTION
Fixes i.a. the ChatCommandsPluginTest.testSecondsToTimeString test failure (expected:<0:03[.]60> but was:<0:03[,]60>) for non-en locales by setting the locale for the surefire plugin to en_US.

All credit goes to Adam, Ron, and NFC.