### PR TITLE
regeneration meter: fix post-update lightbearer equip behavior

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/regenmeter/RegenMeterPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/regenmeter/RegenMeterPlugin.java
@@ -130,7 +130,9 @@ public class RegenMeterPlugin extends Plugin
 			return;
 		}
 
-		ticksSinceSpecRegen = 0;
+		// Lightbearer switch preserves time until next spec regen if <25 ticks remain
+		// If unequipping Lightbearer, this will always evaluate to 0
+		ticksSinceSpecRegen = Math.max(0, ticksSinceSpecRegen - 25);
 		wearingLightbearer = hasLightbearer;
 	}
 


### PR DESCRIPTION
Close #17677 

Updated regeneration meter plugin to align plugin behavior with in-game behavior after today's game update. Now, when equipping Lightbearer, if less than 15 seconds remain until the next spec regen, the special attack regeneration meter will correctly reflect that the time until next spec regen is preserved as opposed to being set to 15s.


