### PR TITLE
minimap: restore map dots on config reset

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/minimap/MinimapPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/minimap/MinimapPlugin.java
@@ -122,6 +122,7 @@ public class MinimapPlugin extends Plugin
 			return;
 		}
 
+		restoreOriginalDots();
 		replaceMapDots();
 	}
 


### PR DESCRIPTION
This PR fixes an issue where changes to config settings from resetting would not be reflected in the plugin.

<details>
  <summary>Issue demo</summary>

https://github.com/runelite/runelite/assets/50101641/de38aaeb-8392-4239-9db1-a7c997edf85d
  
</details>