### PR TITLE
NPC Aggression Timer: Clarify NPC names config description

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/npcunaggroarea/NpcAggroAreaConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npcunaggroarea/NpcAggroAreaConfig.java
@@ -53,7 +53,7 @@ public interface NpcAggroAreaConfig extends Config
 	@ConfigItem(
 		keyName = "npcUnaggroNames",
 		name = "NPC names",
-		description = "Enter names of NPCs where you wish to use this plugin",
+		description = "Enter the names of NPCs, separated by commas, in the presence of which you would like to see NPC aggression timers.<br>You can use wildcards e.g. *wyvern, *dragon to have the timers show in the presence of all wyverns and dragons.",
 		position = 2
 	)
 	default String npcNamePatterns()


### PR DESCRIPTION
From personal experience, I found it confusing what I had to input in this configuration to have the plugin work as expected. I found it in [the wiki](https://github.com/runelite/runelite/wiki/NPC-Aggression-Timer#npc-names), and decided to copy the text there to the description so it's easier to find without having to open a wiki page.