### PR TITLE
cache: transform map label position into world space

### DIFF
--- a/cache/src/main/java/net/runelite/cache/MapImageDumper.java
+++ b/cache/src/main/java/net/runelite/cache/MapImageDumper.java
@@ -1096,13 +1096,9 @@ public class MapImageDumper
 		{
 			int localX = location.getPosition().getX() - region.getBaseX();
 			int localY = location.getPosition().getY() - region.getBaseY();
-			boolean isBridge = (region.getTileSetting(1, localX, localY) & 2) != 0;
 
-			int tileZ = z + (isBridge ? 1 : 0);
-			int localZ = location.getPosition().getZ();
-			if (z != 0 && localZ != tileZ)
+			if (z != location.getPosition().getZ())
 			{
-				// draw all icons on z=0
 				continue;
 			}
 
@@ -1122,8 +1118,8 @@ public class MapImageDumper
 				assert sprite != null;
 
 				blitIcon(img,
-					2 + (drawX * MAP_SCALE) - (sprite.getMaxWidth() / 2),
-					2 + (drawY * MAP_SCALE) - (sprite.getMaxHeight() / 2),
+					(drawX * MAP_SCALE) - (sprite.getMaxWidth() / 2),
+					(drawY * MAP_SCALE) - (sprite.getMaxHeight() / 2),
 					sprite);
 			}
 		}

--- a/cache/src/main/java/net/runelite/cache/MapImageDumper.java
+++ b/cache/src/main/java/net/runelite/cache/MapImageDumper.java
@@ -944,7 +944,8 @@ public class MapImageDumper
 		for (WorldMapElementDefinition element : elements)
 		{
 			AreaDefinition area = areas.getArea(element.getAreaDefinitionId());
-			if (area == null || area.getName() == null || element.getPosition().getZ() != z)
+			Position worldPosition = element.getWorldPosition();
+			if (area == null || area.getName() == null || worldPosition.getZ() != z)
 			{
 				continue;
 			}
@@ -965,9 +966,8 @@ public class MapImageDumper
 					SpriteDefinition sprite = sprites.findSpriteByArchiveName(fontSize.getName(), c);
 					if (sprite.getWidth() != 0 && sprite.getHeight() != 0)
 					{
-						Position position = element.getPosition();
-						int drawX = position.getX() - regionLoader.getLowestX().getBaseX();
-						int drawY = regionLoader.getHighestY().getBaseY() - position.getY() + Region.Y - 2;
+						int drawX = worldPosition.getX() - regionLoader.getLowestX().getBaseX();
+						int drawY = regionLoader.getHighestY().getBaseY() - worldPosition.getY() + Region.Y - 2;
 						blitGlyph(image,
 								(drawX * MAP_SCALE) + advance - (stringWidth / 2),
 								(drawY * MAP_SCALE) + ascent - (font.getAscent() / 2),

--- a/cache/src/main/java/net/runelite/cache/MapImageDumper.java
+++ b/cache/src/main/java/net/runelite/cache/MapImageDumper.java
@@ -1123,6 +1123,31 @@ public class MapImageDumper
 					sprite);
 			}
 		}
+
+		// Draw the intermap link icons which are not stored with the map locations
+		List<WorldMapElementDefinition> elements = worldMapManager.getElements();
+		for (WorldMapElementDefinition element : elements)
+		{
+			AreaDefinition area = areas.getArea(element.getAreaDefinitionId());
+			Position worldPosition = element.getWorldPosition();
+			int regionX = worldPosition.getX() / Region.X;
+			int regionY = worldPosition.getY() / Region.Y;
+
+			if (area == null || area.getName() != null || worldPosition.getZ() != z || regionX != region.getRegionX() || regionY != region.getRegionY())
+			{
+				continue;
+			}
+
+			int localX = worldPosition.getX() - region.getBaseX();
+			int localY = worldPosition.getY() - region.getBaseY();
+			int drawX = drawBaseX + localX;
+			int drawY = drawBaseY + (Region.Y - 1 - localY);
+			SpriteDefinition sprite = sprites.findSprite(area.spriteId, 0);
+			blitIcon(img,
+					(drawX * MAP_SCALE) - (sprite.getMaxWidth() / 2),
+					(drawY * MAP_SCALE) - (sprite.getMaxHeight() / 2),
+					sprite);
+		}
 	}
 
 	private void loadRegions() throws IOException

--- a/cache/src/main/java/net/runelite/cache/WorldMapManager.java
+++ b/cache/src/main/java/net/runelite/cache/WorldMapManager.java
@@ -41,6 +41,7 @@ public class WorldMapManager
 {
 	private final Store store;
 	private final List<WorldMapCompositeDefinition> worldMapCompositeDefinitions = new ArrayList<>();
+	private final List<WorldMapElementDefinition> elements = new ArrayList<>();
 
 	public WorldMapManager(Store store)
 	{
@@ -60,16 +61,15 @@ public class WorldMapManager
 			WorldMapCompositeDefinition composite = worldMapCompositeLoader.load(compositeFile.getContents());
 			worldMapCompositeDefinitions.add(composite);
 		}
-	}
 
-	public List<WorldMapElementDefinition> getElements()
-	{
-		List<WorldMapElementDefinition> elements = new ArrayList<>();
 		for (WorldMapCompositeDefinition compositeDefinition : worldMapCompositeDefinitions)
 		{
 			elements.addAll(compositeDefinition.getWorldMapElementDefinitions());
 		}
+	}
 
+	public List<WorldMapElementDefinition> getElements()
+	{
 		return elements;
 	}
 }

--- a/cache/src/main/java/net/runelite/cache/definitions/WorldMapCompositeDefinition.java
+++ b/cache/src/main/java/net/runelite/cache/definitions/WorldMapCompositeDefinition.java
@@ -25,6 +25,7 @@
 package net.runelite.cache.definitions;
 
 import lombok.Data;
+import net.runelite.cache.region.Position;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -36,4 +37,35 @@ public class WorldMapCompositeDefinition
 	public final Set<MapSquareDefinition> mapSquareDefinitions = new HashSet<>();
 	public final Set<ZoneDefinition> zoneDefinitions = new HashSet<>();
 	public final List<WorldMapElementDefinition> worldMapElementDefinitions = new ArrayList<>();
+
+	public Position calculateWorldOffset(Position position)
+	{
+		int squareX = position.getX() / 64;
+		int squareZ = position.getY() / 64;
+		int zoneX = (position.getX() & 63) / 8;
+		int zoneZ = (position.getY() & 63) / 8;
+		Position offset = null;
+
+		for (MapSquareDefinition mapSquare : mapSquareDefinitions)
+		{
+			if (squareX == mapSquare.sourceSquareX && squareZ == mapSquare.sourceSquareZ)
+			{
+				int shiftX = ((mapSquare.displaySquareX - mapSquare.sourceSquareX) * 64);
+				int shiftZ = ((mapSquare.displaySquareZ - mapSquare.sourceSquareZ) * 64);
+				offset = new Position(shiftX, shiftZ, mapSquare.getMinLevel());
+			}
+		}
+
+		for (ZoneDefinition zone : zoneDefinitions)
+		{
+			if (squareX == zone.sourceSquareX && squareZ == zone.sourceSquareZ && zoneX == zone.sourceZoneX && zoneZ == zone.sourceZoneZ)
+			{
+				int shiftX = ((zone.displaySquareX - zone.sourceSquareX) * 64) + ((zone.displayZoneX - zone.sourceZoneX) * 8);
+				int shiftZ = ((zone.displaySquareZ - zone.sourceSquareZ) * 64) + ((zone.displayZoneY - zone.sourceZoneZ) * 8);
+				offset = new Position(shiftX, shiftZ, zone.getMinLevel());
+			}
+		}
+
+		return offset;
+	}
 }

--- a/cache/src/main/java/net/runelite/cache/definitions/WorldMapElementDefinition.java
+++ b/cache/src/main/java/net/runelite/cache/definitions/WorldMapElementDefinition.java
@@ -31,6 +31,17 @@ import net.runelite.cache.region.Position;
 public class WorldMapElementDefinition
 {
 	public Position position;
+	public Position offset;
 	public int areaDefinitionId;
 	public boolean membersOnly;
+
+	public Position getWorldPosition()
+	{
+		if (offset == null)
+		{
+			return new Position(position.getX(), position.getY(), 0);
+		}
+
+		return new Position(position.getX() + offset.getX(), position.getY() + offset.getY(), offset.getZ());
+	}
 }

--- a/cache/src/main/java/net/runelite/cache/definitions/loaders/WorldMapCompositeLoader.java
+++ b/cache/src/main/java/net/runelite/cache/definitions/loaders/WorldMapCompositeLoader.java
@@ -25,7 +25,9 @@
 package net.runelite.cache.definitions.loaders;
 
 import net.runelite.cache.definitions.WorldMapCompositeDefinition;
+import net.runelite.cache.definitions.WorldMapElementDefinition;
 import net.runelite.cache.io.InputStream;
+import net.runelite.cache.region.Position;
 
 public class WorldMapCompositeLoader
 {
@@ -53,6 +55,15 @@ public class WorldMapCompositeLoader
 		for (int i = 0; i < iconAmount; ++i)
 		{
 			worldMapCompositeDefinition.worldMapElementDefinitions.add(worldMapElementLoader.load(in));
+		}
+
+		// The graphics in the world map are patched together from parts of the map and the position of
+		// the map elements are based on the result of that. This calculates the offset needed to place the element back
+		// into world coordinates.
+		for (WorldMapElementDefinition element : worldMapCompositeDefinition.worldMapElementDefinitions)
+		{
+			Position position = element.getPosition();
+			element.setOffset(worldMapCompositeDefinition.calculateWorldOffset(position));
 		}
 
 		return worldMapCompositeDefinition;


### PR DESCRIPTION
Noticed some labels in underground areas were weird. Turns out the map element positions are not always world coordinates.


Before
![image](https://github.com/runelite/runelite/assets/833253/cebc6ea5-bb10-4e00-a212-8acc2532caea)


After
![Screenshot 2024-04-07 202332](https://github.com/runelite/runelite/assets/833253/2f3b7194-0078-4df3-8353-0274debb5381)
