### PR TITLE
slayer: include zygomites in task weakness config tooltip

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerConfig.java
@@ -139,7 +139,7 @@ public interface SlayerConfig extends Config
 		position = 9,
 		keyName = "weaknessPrompt",
 		name = "Show Monster Weakness",
-		description = "Show an overlay on a monster when it is weak enough to finish off (Only Lizards, Gargoyles & Rockslugs)"
+		description = "Show an overlay on a monster when it is weak enough to finish off (Only Lizards, Gargoyles, Rockslugs & Zygomites)"
 	)
 	default boolean weaknessPrompt()
 	{


### PR DESCRIPTION
Adds zygomites to the config option description for target weaknesses in the slayer plugin.