### PR TITLE
regen meter: remove unneeded spec orb highlight

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/regenmeter/RegenMeterOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/regenmeter/RegenMeterOverlay.java
@@ -34,7 +34,6 @@ import java.awt.Stroke;
 import java.awt.geom.Arc2D;
 import javax.inject.Inject;
 import net.runelite.api.Client;
-import net.runelite.api.VarPlayer;
 import net.runelite.api.annotations.Component;
 import net.runelite.api.widgets.ComponentID;
 import net.runelite.api.widgets.Widget;
@@ -46,7 +45,6 @@ class RegenMeterOverlay extends Overlay
 {
 	private static final Color HITPOINTS_COLOR = brighter(0x9B0703);
 	private static final Color SPECIAL_COLOR = brighter(0x1E95B0);
-	private static final Color OVERLAY_COLOR = new Color(255, 255, 255, 60);
 	private static final double DIAMETER = 26D;
 	private static final int OFFSET = 27;
 
@@ -83,21 +81,6 @@ class RegenMeterOverlay extends Overlay
 
 		if (config.showSpecial())
 		{
-			if (client.getVarpValue(VarPlayer.SPECIAL_ATTACK_ENABLED) == 1)
-			{
-				final Widget widget = client.getWidget(ComponentID.MINIMAP_SPEC_ORB);
-
-				if (widget != null && !widget.isHidden())
-				{
-					final Rectangle bounds = widget.getBounds();
-					g.setColor(RegenMeterOverlay.OVERLAY_COLOR);
-					g.fillOval(
-						bounds.x + OFFSET,
-						bounds.y + (int) (bounds.height / 2 - (DIAMETER) / 2),
-						(int) DIAMETER, (int) DIAMETER);
-				}
-			}
-
 			renderRegen(g, ComponentID.MINIMAP_SPEC_ORB, plugin.getSpecialPercentage(), SPECIAL_COLOR);
 		}
 


### PR DESCRIPTION
Close #17679 

As outlined in the issue, previously the "Show Spec. Attack regen" config option also controlled a medium-opacity white overlay on the special attack orb when selected. After discussing in the Discord, we determined the reason for this behavior and the desired solution. The orb was introduced in [this 03/08/2018 update](https://oldschool.runescape.wiki/w/Update:Tournament_Worlds:_Theatre_of_Blood_rewards) but wasn't made clickable until [this 03/07/2019 update](https://oldschool.runescape.wiki/w/Update:QoL_and_W45_Changes) a year later. In the meantime, we can see that there was [no indication](https://www.youtube.com/watch?v=fqucirw76Bk&t=370s) from the orb about whether your special attack was selected, so this overlay was added to RuneLite. Now that there is a built-in highlight, this PR removes that overlay.


Shown below: spec regen setting no longer has additional overlay
![image](https://github.com/runelite/runelite/assets/22895001/6c3e6ef7-7221-496a-aae3-f4abdee1a3de)