### PR TITLE
overlaypanel: clear on start render

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayPanel.java
@@ -96,15 +96,18 @@ public abstract class OverlayPanel extends Overlay
 			panelComponent.setBackgroundColor(getPreferredColor());
 		}
 
-		final Dimension dimension = panelComponent.render(graphics);
-
-		if (clearChildren)
+		try
 		{
-			panelComponent.getChildren().clear();
+			return panelComponent.render(graphics);
 		}
-
-		panelComponent.setPreferredSize(oldSize);
-		panelComponent.setBackgroundColor(oldBackgroundColor);
-		return dimension;
+		finally
+		{
+			if (clearChildren)
+			{
+				panelComponent.getChildren().clear();
+			}
+			panelComponent.setPreferredSize(oldSize);
+			panelComponent.setBackgroundColor(oldBackgroundColor);
+		}
 	}
 }


### PR DESCRIPTION
The ordering of when the panel children are cleared may have caused an OOM crash for users today when one of the fortis-colosseum plugin overlays threw an error while rendering.

If an overlay throws while rendering, the panel component children are never cleared. After enough failed renders in a row, these elements would never be cleared, and therefore never garbage collected. Also, a failed render could render components multiple times if the exception is not thrown on a later render call.