### PR TITLE
chat commands: add commonly used aliases

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
@@ -2463,6 +2463,7 @@ public class ChatCommandsPlugin extends Plugin
 			// Tempoross
 			case "fishingtodt":
 			case "fishtodt":
+			case "temp":
 				return "Tempoross";
 
 			// Phantom Muspah

--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
@@ -2017,6 +2017,7 @@ public class ChatCommandsPlugin extends Plugin
 			case "bando":
 			case "bandos":
 			case "graardor":
+			case "graar":
 				return "General Graardor";
 
 			// dks

--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
@@ -2262,7 +2262,6 @@ public class ChatCommandsPlugin extends Plugin
 
 			// The Gauntlet
 			case "gaunt":
-			case "gauntlet":
 			case "the gauntlet":
 				return "Gauntlet";
 


### PR DESCRIPTION
This PR...
- Adds the ``temp`` alias for ``Tempoross``.
  - Currently Tempoross only has somewhat obscure aliases like ``fishtodt``. Everyone I know refers to it as ``temp``.
- Adds the ``graar`` alias for ``General Graardor``.
  - This is probably the second most used alias for him (after ``bandos``). Feel free to correct me if I'm crazy.
- Removes the ``gauntlet`` alias for ``Gauntlet``.
  - An alias that's the same as the longBossName except for its capitalization is superfluous.