### PR TITLE
events: mark ConfigChanged's newValue as nullable

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/events/ConfigChanged.java
+++ b/runelite-client/src/main/java/net/runelite/client/events/ConfigChanged.java
@@ -60,5 +60,6 @@ public class ConfigChanged
 	/**
 	 * The new value of the entry, null if the entry has been unset.
 	 */
+	@Nullable
 	private String newValue;
 }


### PR DESCRIPTION
As the comment already explained, this value is null when a single config is unset/reset
