### PR TITLE
timers: add delayed heal timer for hunter foods

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/timers/GameTimer.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timers/GameTimer.java
@@ -96,6 +96,7 @@ enum GameTimer
 	SILK_DRESSING(ItemID.SILK_DRESSING_2, GameTimerImageType.ITEM, "Silk dressing", 100, GAME_TICKS, true),
 	BLESSED_CRYSTAL_SCARAB(ItemID.BLESSED_CRYSTAL_SCARAB_2, GameTimerImageType.ITEM, "Blessed crystal scarab", 40, GAME_TICKS, true),
 	SPELLBOOK_SWAP(SpriteID.SPELL_SPELLBOOK_SWAP, GameTimerImageType.SPRITE, "Spellbook Reset", 120, ChronoUnit.SECONDS, false),
+	DELAYED_FOOD_HEAL(SpriteID.MINIMAP_ORB_HITPOINTS_ICON, GameTimerImageType.SPRITE, "Delayed Heal", 7, GAME_TICKS, true),
 	;
 
 	@Nullable

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersConfig.java
@@ -363,4 +363,14 @@ public interface TimersConfig extends Config
 	{
 		return true;
 	}
+
+	@ConfigItem(
+		keyName = "showDelayedFoodHeal",
+		name = "Delayed Food Heal",
+		description = "Configures whether the delayed healing from special foods is displayed"
+	)
+	default boolean showDelayedFoodHeal()
+	{
+		return true;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersPlugin.java
@@ -132,6 +132,8 @@ public class TimersPlugin extends Plugin
 	private static final Pattern TZHAAR_WAVE_MESSAGE = Pattern.compile("Wave: (\\d+)");
 	private static final Pattern TZHAAR_PAUSED_MESSAGE = Pattern.compile("The (?:Inferno|Fight Cave) has been paused. You may now log out.");
 
+	private static final Pattern DELAYED_FOOD_HEAL_MESSAGE = Pattern.compile("You eat the (?:larupia|graahk|kyatt|pyre fox|barb-tailed|(?:wild|dashing) kebbit|(?:sun|moon)light antelope) meat.");
+
 	private TimerTimer freezeTimer;
 	private int freezeTime = -1; // time frozen, in game ticks
 
@@ -771,6 +773,11 @@ public class TimersPlugin extends Plugin
 		{
 			removeGameTimer(SPELLBOOK_SWAP);
 		}
+
+		if (!config.showDelayedFoodHeal())
+		{
+			removeGameTimer(DELAYED_FOOD_HEAL);
+		}
 	}
 
 	@Subscribe
@@ -960,6 +967,12 @@ public class TimersPlugin extends Plugin
 		if (message.equals(LIQUID_ADRENALINE_MESSAGE) && config.showLiquidAdrenaline())
 		{
 			createGameTimer(LIQUID_ADRENALINE);
+		}
+
+		final Matcher specialFoodMatcher = DELAYED_FOOD_HEAL_MESSAGE.matcher(message);
+		if (specialFoodMatcher.matches() && config.showDelayedFoodHeal())
+		{
+			createGameTimer(DELAYED_FOOD_HEAL);
 		}
 	}
 


### PR DESCRIPTION
This PR is intended to add the new hunter foods to the timer plugin, however, I would like to hear opinions on how this is ought to be done best.

With 9286d340a75ea73849ee6762a31150655ffa94cc the timer is extremely basic, and I feel this would be the very minimum. 
However, I would like add some information to the infobox such as how much HP the player is expected to receive along with any other effects. Ideally `ItemStatChangesService` would be used, but it relies on the tied HP values to the food (which I was planning to add in #17607 but forgot to ask about) and since the food heals twice, sometimes with different amounts. How's this preferred to be done? 

Otherwise a less clean way is to do the magic inside the TimersPlugin... which is how I've done it for the attached demo.

So really the question I have is: Is a simple timer good or do we want more information with the infobox, and if so which approach is wanted?

<details>
  <summary>Demo simple infobox</summary>

https://github.com/runelite/runelite/assets/50101641/45fdcbf6-8f7a-4447-9420-44b0bcedb020
  
</details>

<details>

  <summary>Demo infobox with more information</summary>
  
https://github.com/runelite/runelite/assets/50101641/47432ab6-30db-40f3-9020-6865549d1992

</details>

I'm a fan of the added information to the infobox tooltip, but if it's not wanted or something that maybe can be revisited later, I'd be OK with that too. Maybe the extra information is not necessary since the infobox would only be present for 7 ticks. Still, just wanted to gather some input. Hence this opening as a draft.

---
#### Additional info:
   - I wasn't able to find any kind of triggers for the items/effects and they aren't even available on the enhanced client, even the 'cure' action on the minimap orbs doesn't recognize the new poison curing food.

   - The timer overwrites any previous delayed foods' secondary heal, meaning eating a cooked 
   moonlight antelope (14 + 12) and then a cooked pyre fox (11 + 8) would result in the timer being reset and 33 HP healed in total (14 + 11 + 8).

   - The timer pauses on interfaces similar to poison.

   - The effect is "saved" to the player i.e. eating a food, logging out before the second heal and logging back in would apply the heal plus any additional effects (again, similar to poison).

Chat messages seem to be the only way to detect the effect.