### PR TITLE
menu swapper: remove construction restriction

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -525,13 +525,6 @@ public class MenuEntrySwapperPlugin extends Plugin
 						continue;
 					}
 
-					if ("Build".equals(actions[actionIdx])
-						|| "Remove".equals(actions[actionIdx]))
-					{
-						// https://secure.runescape.com/m=news/third-party-client-guidelines?oldschool=1
-						continue;
-					}
-
 					final MenuAction menuAction = OBJECT_MENU_TYPES.get(actionIdx);
 					if (menuAction != currentAction)
 					{


### PR DESCRIPTION
This PR enables swapping construction related actions, as this is [no longer disallowed](https://secure.runescape.com/m=news/undead-pirates-tweaks-varlamore-cas--more?oldschool=1) by Jagex.