### PR TITLE
bank tags: fix npe on shutdown

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/banktags/tabs/TabInterface.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/banktags/tabs/TabInterface.java
@@ -407,8 +407,12 @@ public class TabInterface
 		activeTab = null;
 
 		upButton = downButton = newTab = scrollComponent = null;
-		parent.deleteAllChildren();
-		parent = null;
+
+		if (parent != null)
+		{
+			parent.deleteAllChildren();
+			parent = null;
+		}
 
 		tabManager.clear();
 	}


### PR DESCRIPTION
This fixes a NPE which occurs on shutdown for the bank tags plugin.

If the `parent` widget in `TabInterface` is null (e.g. bank has not been accessed yet), calling `.deleteAllChildren` results in NPE.

Fixes #17771 