### PR TITLE
attack styles: fix npe when fetching enum

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/attackstyles/AttackStylesPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/attackstyles/AttackStylesPlugin.java
@@ -345,6 +345,11 @@ public class AttackStylesPlugin extends Plugin
 
 	private void updateWidgetsToHide(boolean enabled)
 	{
+		if (equippedWeaponTypeVarbit == -1)
+		{
+			return;
+		}
+
 		AttackStyle[] attackStyles = getWeaponTypeStyles(equippedWeaponTypeVarbit);
 
 		// Iterate over attack styles

--- a/runelite-client/src/test/java/net/runelite/client/plugins/attackstyles/AttackStylesPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/attackstyles/AttackStylesPluginTest.java
@@ -104,12 +104,8 @@ public class AttackStylesPluginTest
 		EnumComposition typeEnum = mock(EnumComposition.class);
 		when(typeEnum.getIntVals()).thenReturn(STYLE_STRUCT_IDS);
 
-		EnumComposition empty = mock(EnumComposition.class);
-		when(empty.getIntVals()).thenReturn(new int[0]);
-
 		when(client.getEnum(EnumID.WEAPON_STYLES)).thenReturn(stylesEnum);
 		when(client.getEnum(TYPE_ENUM_ID)).thenReturn(typeEnum);
-		when(client.getEnum(0)).thenReturn(empty);
 
 		int i = 0;
 		for (int styleStructId : STYLE_STRUCT_IDS)


### PR DESCRIPTION
This PR fixes a NPE, this would occur on shutdown if the equipped weapon var hasn't been set yet (e.g. player has not logged in yet) ; and is still `-1`.

The test for "empty" enum is also removed since it can't happen now.