### PR TITLE
Add 'RangeDouble' annotation type (@Range, but for doubles)

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/config/ConfigManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/ConfigManager.java
@@ -1018,6 +1018,7 @@ public class ConfigManager
 				m.getDeclaredAnnotation(ConfigItem.class),
 				m.getGenericReturnType(),
 				m.getDeclaredAnnotation(Range.class),
+				m.getDeclaredAnnotation(RangeDouble.class),
 				m.getDeclaredAnnotation(Alpha.class),
 				m.getDeclaredAnnotation(Units.class)
 			))

--- a/runelite-client/src/main/java/net/runelite/client/config/RangeDouble.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/RangeDouble.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Adam <Adam@sigterm.info>
+ * Copyright (c) 2018, Adam <Adam@sigterm.info>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -24,34 +24,23 @@
  */
 package net.runelite.client.config;
 
-import java.lang.reflect.Type;
-import lombok.Value;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
-@Value
-public class ConfigItemDescriptor implements ConfigObject
+/**
+ * Used with ConfigItem, describes valid double range for a config item.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+@Documented
+public @interface RangeDouble 
 {
-	private final ConfigItem item;
-	private final Type type;
-	private final Range range;
-	private final RangeDouble rangeDouble;
-	private final Alpha alpha;
-	private final Units units;
-
-	@Override
-	public String key()
-	{
-		return item.keyName();
-	}
-
-	@Override
-	public String name()
-	{
-		return item.name();
-	}
-
-	@Override
-	public int position()
-	{
-		return item.position();
-	}
+    double min() default 0;
+    
+    double max() default Double.MAX_VALUE;
+    
+    double step() default 0.1;
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
@@ -87,6 +87,7 @@ import net.runelite.client.config.Keybind;
 import net.runelite.client.config.ModifierlessKeybind;
 import net.runelite.client.config.Notification;
 import net.runelite.client.config.Range;
+import net.runelite.client.config.RangeDouble;
 import net.runelite.client.config.Units;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.events.ExternalPluginsChanged;
@@ -484,7 +485,17 @@ class ConfigPanel extends PluginPanel
 	{
 		double value = MoreObjects.firstNonNull(configManager.getConfiguration(cd.getGroup().value(), cid.getItem().keyName(), double.class), 0d);
 
-		SpinnerModel model = new SpinnerNumberModel(value, 0, Double.MAX_VALUE, 0.1);
+		RangeDouble rangeDouble = cid.getRangeDouble();
+		double min = 0.0, max = Double.MAX_VALUE, step = 0.1;
+		
+		if (rangeDouble != null) 
+		{
+			min = rangeDouble.min();
+			max = rangeDouble.max();
+			step = rangeDouble.step();
+		}
+		
+		SpinnerModel model = new SpinnerNumberModel(value, min, max, step);
 		JSpinner spinner = new JSpinner(model);
 		Component editor = spinner.getEditor();
 		JFormattedTextField spinnerTextField = ((JSpinner.DefaultEditor) editor).getTextField();


### PR DESCRIPTION
Adds the @RangeDouble annotation for 'ConfigItem'. This also enables negative values in Double spinners when 'min' is negative.