### PR TITLE
keyremapping: permit input to report form

### DIFF
--- a/runelite-api/src/main/interfaces/interfaces.toml
+++ b/runelite-api/src/main/interfaces/interfaces.toml
@@ -671,6 +671,10 @@ points_infobox=3
 [raiding_party]
 id=500
 
+[report_form]
+id=875
+container=0
+
 [resizable_viewport]
 id=161
 resizable_viewport_old_school_box=15

--- a/runelite-client/src/main/java/net/runelite/client/plugins/keyremapping/KeyRemappingPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/keyremapping/KeyRemappingPlugin.java
@@ -114,7 +114,8 @@ public class KeyRemappingPlugin extends Plugin
 	boolean chatboxFocused()
 	{
 		Widget chatboxParent = client.getWidget(ComponentID.CHATBOX_PARENT);
-		if (chatboxParent == null || chatboxParent.getOnKeyListener() == null)
+		Widget reportForm = client.getWidget(ComponentID.REPORT_FORM_CONTAINER);
+		if (chatboxParent == null || chatboxParent.getOnKeyListener() == null || reportForm != null)
 		{
 			return false;
 		}


### PR DESCRIPTION
This PR is intended to fix an issue with the key remapping plugin, where the input remains suspended whilst the report form is open.

Fixes #17789 