### PR TITLE
loot tracker: Add muddy chest

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
@@ -181,6 +181,7 @@ public class LootTrackerPlugin extends Plugin
 		put(7827, "Dark Chest").
 		put(13117, "Rogues' Chest").
 		put(13156, "Chest (Ancient Vault)").
+		put(12348, "Muddy Chest").
 		build();
 
 	// Chests opened with keys from slayer tasks


### PR DESCRIPTION
![image](https://github.com/runelite/runelite/assets/53493631/d090c9e7-2c0f-46d7-9ccc-c1dfcbf2f314)
Should hopefully also work for the rare blighted items.