### PR TITLE
Add Civitas Teleport spell (disabled) sprite to SpriteID enum

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/SpriteID.java
+++ b/runelite-api/src/main/java/net/runelite/api/SpriteID.java
@@ -430,7 +430,9 @@ public final class SpriteID
 	public static final int SPELL_WATER_SURGE_DISABLED = 413;
 	public static final int SPELL_EARTH_SURGE_DISABLED = 414;
 	public static final int SPELL_FIRE_SURGE_DISABLED = 415;
-	/* Unmapped: 416, 417, 418 */
+	/* Unmapped: 416 */
+	public static final int SPELL_CIVITAS_ILLA_FORTIS_TELEPORT_DISABLED = 417;
+	/* Unmapped: 418 */
 	public static final int UNKNOWN_STANCE_ICON_1 = 419;
 	public static final int UNKNOWN_STANCE_ICON_2 = 420;
 	public static final int UNKNOWN_STANCE_ICON_3 = 421;


### PR DESCRIPTION
`SpriteID.SPELL_CIVITAS_ILLA_FORTIS_TELEPORT_DISABLED = 417;`

![image](https://github.com/runelite/runelite/assets/11070086/672c6341-bd7b-484c-b6bb-16289b885f4e)
