### PR TITLE
achievement diary: fix prospector task

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/FaladorDiaryRequirement.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/diaries/FaladorDiaryRequirement.java
@@ -90,7 +90,7 @@ public class FaladorDiaryRequirement extends GenericDiaryRequirement
 			new SkillRequirement(Skill.SLAYER, 72));
 		add("Complete a lap of the Falador rooftop agility course.",
 			new SkillRequirement(Skill.AGILITY, 50));
-		add("Enter the mining guild wearing full prospector.",
+		add("Enter the mining guild wearing a Prospector helmet.",
 			new SkillRequirement(Skill.MINING, 60));
 		add("Kill the Blue Dragon under the Heroes' Guild.",
 			new QuestRequirement(Quest.HEROES_QUEST));


### PR DESCRIPTION
> Changed the Diary task in Motherlode Mine to require just the Helmet, instead of the entire outfit.

Post-fix:
![image](https://github.com/runelite/runelite/assets/7929021/aead5b97-22d4-4f69-8820-25838204b63a)
