### PR TITLE
Blast mine: update changed varbits

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/Varbits.java
+++ b/runelite-api/src/main/java/net/runelite/api/Varbits.java
@@ -369,11 +369,11 @@ public final class Varbits
 	/**
 	 * Blast Mine
 	 */
-	public static final int BLAST_MINE_COAL = 4924;
-	public static final int BLAST_MINE_GOLD = 4925;
-	public static final int BLAST_MINE_MITHRIL = 4926;
-	public static final int BLAST_MINE_ADAMANTITE = 4921;
-	public static final int BLAST_MINE_RUNITE = 4922;
+	public static final int BLAST_MINE_COAL = 10698;
+	public static final int BLAST_MINE_GOLD = 10699;
+	public static final int BLAST_MINE_MITHRIL = 10700;
+	public static final int BLAST_MINE_ADAMANTITE = 10701;
+	public static final int BLAST_MINE_RUNITE = 10702;
 
 	/**
 	 * Raids


### PR DESCRIPTION
Update Varbits for the ore counts changed on May 8th, 2024. This fixes the ore overlay for the blast mine plugin.

Before:
![image 1](https://github.com/runelite/runelite/assets/1499878/ad3b8bcd-dffe-4b7f-b82e-6f11fcaada23)

After: 
![java_nNqTz9vrHZ](https://github.com/runelite/runelite/assets/1499878/b2ef2a5a-2b7c-4ef8-8017-1a4618943142)

Inventory:
![image](https://github.com/runelite/runelite/assets/1499878/93e747cb-3980-4d82-9e24-238c5ee688f9)
