### PR TITLE
Enable key remapping in dialogs with a "Click to continue" option

### DIFF
--- a/runelite-api/src/main/interfaces/interfaces.toml
+++ b/runelite-api/src/main/interfaces/interfaces.toml
@@ -258,6 +258,7 @@ sprite2=3
 id=231
 head_model=2
 name=4
+continue=5
 text=6
 
 [dialog_option]
@@ -266,10 +267,12 @@ options=1
 
 [dialog_player]
 id=217
+continue=5
 text=6
 
 [dialog_sprite]
 id=193
+continue=0
 sprite=1
 text=2
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/keyremapping/KeyRemappingListener.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/keyremapping/KeyRemappingListener.java
@@ -99,7 +99,7 @@ class KeyRemappingListener implements KeyListener
 			// In addition to the above checks, the F-key remapping shouldn't
 			// activate when dialogs are open which listen for number keys
 			// to select options
-			if (config.fkeyRemap() && !plugin.isDialogOpen())
+			if (config.fkeyRemap() && (plugin.isClickToContinueVisible() || !plugin.isDialogOpen()))
 			{
 				if (config.f1().matches(e))
 				{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/keyremapping/KeyRemappingPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/keyremapping/KeyRemappingPlugin.java
@@ -163,6 +163,13 @@ public class KeyRemappingPlugin extends Plugin
 		return client.getWidget(ComponentID.DIALOG_OPTION_OPTIONS) != null;
 	}
 
+	boolean isClickToContinueVisible()
+	{
+		return client.getWidget(ComponentID.DIALOG_PLAYER_CONTINUE) != null ||
+				client.getWidget(ComponentID.DIALOG_NPC_CONTINUE) != null ||
+				client.getWidget(ComponentID.DIALOG_SPRITE_CONTINUE) != null;
+	}
+
 	private boolean isHidden(int component)
 	{
 		Widget w = client.getWidget(component);


### PR DESCRIPTION
Closes #16274

Dialogs with a "Click to continue" option don't accept any input other than a mouse click or Space/re-mapped space key.
Therefore it is safe to enable F-key remapping in these types of dialogs.

This MR adds 3 IDs for the "Click to Continue" message NPC, Player, and Sprite dialogs (like received clue scroll dialogs) and checks if one of these is visible while deciding whether to enact a remapped F key.

I think this is safer than the existing MR against this issue as it won't interfere with any dialogs that are expecting alphanumeric input.

This will be really useful for being able to use remapped F-keys to open inventory/gear to access teleports while the received clue dialog is still open.

Short clip of it in action working on 3 types of "Click to continue" dialogs but still remaining disabled for option dialogs:

https://github.com/runelite/runelite/assets/107762963/e7d4080f-0053-4e41-8c64-d59a9031e202

