### PR TITLE
mlm: remove superfluous config options

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/motherlode/MotherlodeConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/motherlode/MotherlodeConfig.java
@@ -65,31 +65,11 @@ public interface MotherlodeConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "showSack",
-		name = "Show pay-dirt sack",
-		description = "Configures whether the pay-dirt sack is displayed or not."
-	)
-	default boolean showSack()
-	{
-		return true;
-	}
-
-	@ConfigItem(
 		keyName = "showMiningStats",
 		name = "Show mining session stats",
 		description = "Configures whether to display mining session stats"
 	)
 	default boolean showMiningStats()
-	{
-		return true;
-	}
-
-	@ConfigItem(
-		keyName = "showDepositsLeft",
-		name = "Show deposits left",
-		description = "Displays deposits left before sack is full"
-	)
-	default boolean showDepositsLeft()
 	{
 		return true;
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/motherlode/MotherlodePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/motherlode/MotherlodePlugin.java
@@ -86,7 +86,7 @@ import net.runelite.http.api.loottracker.LootRecordType;
 
 @PluginDescriptor(
 	name = "Motherlode Mine",
-	description = "Show helpful information inside the Motherload Mine",
+	description = "Show helpful information inside the Motherlode Mine",
 	tags = {"pay", "dirt", "mining", "mlm", "skilling", "overlay"},
 	enabledByDefault = false
 )


### PR DESCRIPTION
Removes superfluous config options from the MLM plugin. Their usages were removed in https://github.com/runelite/runelite/commit/9ade104d8ef7b9fdc9246b06ae494230913f67a5

Also fixed the MLM plugin's description: it's Motherlode, not Motherload.