### PR TITLE
Switch the names of source and display zones/squares to reflect usage

### DIFF
--- a/cache/src/main/java/net/runelite/cache/definitions/AbstractWorldMapDataDefinition.java
+++ b/cache/src/main/java/net/runelite/cache/definitions/AbstractWorldMapDataDefinition.java
@@ -31,10 +31,10 @@ public abstract class AbstractWorldMapDataDefinition
 {
 	public int minLevel;
 	public int levels;
-	public int displaySquareX;
-	public int displaySquareZ;
 	public int sourceSquareX;
 	public int sourceSquareZ;
+	public int displaySquareX;
+	public int displaySquareZ;
 	public int groupId;
 	public int fileId;
 }

--- a/cache/src/main/java/net/runelite/cache/definitions/MapSquareDefinition.java
+++ b/cache/src/main/java/net/runelite/cache/definitions/MapSquareDefinition.java
@@ -40,12 +40,12 @@ public class MapSquareDefinition extends AbstractWorldMapDataDefinition
 		else
 		{
 			MapSquareDefinition other = (MapSquareDefinition) obj;
-			return other.sourceSquareX == this.sourceSquareX && other.sourceSquareZ == this.sourceSquareZ;
+			return other.displaySquareX == this.displaySquareX && other.displaySquareZ == this.displaySquareZ;
 		}
 	}
 
 	public int hashCode()
 	{
-		return this.sourceSquareX | this.sourceSquareZ << 8;
+		return this.displaySquareX | this.displaySquareZ << 8;
 	}
 }

--- a/cache/src/main/java/net/runelite/cache/definitions/WorldMapCompositeDefinition.java
+++ b/cache/src/main/java/net/runelite/cache/definitions/WorldMapCompositeDefinition.java
@@ -61,7 +61,7 @@ public class WorldMapCompositeDefinition
 			if (squareX == zone.sourceSquareX && squareZ == zone.sourceSquareZ && zoneX == zone.sourceZoneX && zoneZ == zone.sourceZoneZ)
 			{
 				int shiftX = ((zone.displaySquareX - zone.sourceSquareX) * 64) + ((zone.displayZoneX - zone.sourceZoneX) * 8);
-				int shiftZ = ((zone.displaySquareZ - zone.sourceSquareZ) * 64) + ((zone.displayZoneY - zone.sourceZoneZ) * 8);
+				int shiftZ = ((zone.displaySquareZ - zone.sourceSquareZ) * 64) + ((zone.displayZoneZ - zone.sourceZoneZ) * 8);
 				offset = new Position(shiftX, shiftZ, zone.getMinLevel());
 			}
 		}

--- a/cache/src/main/java/net/runelite/cache/definitions/WorldMapCompositeDefinition.java
+++ b/cache/src/main/java/net/runelite/cache/definitions/WorldMapCompositeDefinition.java
@@ -48,20 +48,20 @@ public class WorldMapCompositeDefinition
 
 		for (MapSquareDefinition mapSquare : mapSquareDefinitions)
 		{
-			if (squareX == mapSquare.sourceSquareX && squareZ == mapSquare.sourceSquareZ)
+			if (squareX == mapSquare.displaySquareX && squareZ == mapSquare.displaySquareZ)
 			{
-				int shiftX = ((mapSquare.displaySquareX - mapSquare.sourceSquareX) * 64);
-				int shiftZ = ((mapSquare.displaySquareZ - mapSquare.sourceSquareZ) * 64);
+				int shiftX = ((mapSquare.sourceSquareX - mapSquare.displaySquareX) * 64);
+				int shiftZ = ((mapSquare.sourceSquareZ - mapSquare.displaySquareZ) * 64);
 				offset = new Position(shiftX, shiftZ, mapSquare.getMinLevel());
 			}
 		}
 
 		for (ZoneDefinition zone : zoneDefinitions)
 		{
-			if (squareX == zone.sourceSquareX && squareZ == zone.sourceSquareZ && zoneX == zone.sourceZoneX && zoneZ == zone.sourceZoneZ)
+			if (squareX == zone.displaySquareX && squareZ == zone.displaySquareZ && zoneX == zone.displayZoneX && zoneZ == zone.displayZoneZ)
 			{
-				int shiftX = ((zone.displaySquareX - zone.sourceSquareX) * 64) + ((zone.displayZoneX - zone.sourceZoneX) * 8);
-				int shiftZ = ((zone.displaySquareZ - zone.sourceSquareZ) * 64) + ((zone.displayZoneZ - zone.sourceZoneZ) * 8);
+				int shiftX = ((zone.sourceSquareX - zone.displaySquareX) * 64) + ((zone.sourceZoneX - zone.displayZoneX) * 8);
+				int shiftZ = ((zone.sourceSquareZ - zone.displaySquareZ) * 64) + ((zone.sourceZoneZ - zone.displayZoneZ) * 8);
 				offset = new Position(shiftX, shiftZ, zone.getMinLevel());
 			}
 		}

--- a/cache/src/main/java/net/runelite/cache/definitions/ZoneDefinition.java
+++ b/cache/src/main/java/net/runelite/cache/definitions/ZoneDefinition.java
@@ -31,10 +31,10 @@ import lombok.ToString;
 @ToString(callSuper = true)
 public class ZoneDefinition extends AbstractWorldMapDataDefinition
 {
-	public int displayZoneX;
-	public int displayZoneZ;
 	public int sourceZoneX;
 	public int sourceZoneZ;
+	public int displayZoneX;
+	public int displayZoneZ;
 
 	public boolean equals(Object obj)
 	{
@@ -45,13 +45,13 @@ public class ZoneDefinition extends AbstractWorldMapDataDefinition
 		else
 		{
 			ZoneDefinition other = (ZoneDefinition) obj;
-			return other.sourceSquareX == this.sourceSquareX && other.sourceSquareZ == this.sourceSquareZ
-					&& other.sourceZoneX == this.sourceZoneX && other.sourceZoneZ == this.sourceZoneZ;
+			return other.displaySquareX == this.displaySquareX && other.displaySquareZ == this.displaySquareZ
+					&& other.displayZoneX == this.displayZoneX && other.displayZoneZ == this.displayZoneZ;
 		}
 	}
 
 	public int hashCode()
 	{
-		return this.sourceSquareX | this.sourceSquareZ << 8 | this.sourceZoneX << 16 | this.sourceZoneZ << 24;
+		return this.displaySquareX | this.displaySquareZ << 8 | this.displayZoneX << 16 | this.displayZoneZ << 24;
 	}
 }

--- a/cache/src/main/java/net/runelite/cache/definitions/ZoneDefinition.java
+++ b/cache/src/main/java/net/runelite/cache/definitions/ZoneDefinition.java
@@ -32,7 +32,7 @@ import lombok.ToString;
 public class ZoneDefinition extends AbstractWorldMapDataDefinition
 {
 	public int displayZoneX;
-	public int displayZoneY;
+	public int displayZoneZ;
 	public int sourceZoneX;
 	public int sourceZoneZ;
 

--- a/cache/src/main/java/net/runelite/cache/definitions/loaders/WorldMapDataLoader.java
+++ b/cache/src/main/java/net/runelite/cache/definitions/loaders/WorldMapDataLoader.java
@@ -42,10 +42,10 @@ public class WorldMapDataLoader
 		MapSquareDefinition mapSquareDefinition = new MapSquareDefinition();
 		mapSquareDefinition.minLevel = in.readUnsignedByte();
 		mapSquareDefinition.levels = in.readUnsignedByte();
-		mapSquareDefinition.displaySquareX = in.readUnsignedShort();
-		mapSquareDefinition.displaySquareZ = in.readUnsignedShort();
 		mapSquareDefinition.sourceSquareX = in.readUnsignedShort();
 		mapSquareDefinition.sourceSquareZ = in.readUnsignedShort();
+		mapSquareDefinition.displaySquareX = in.readUnsignedShort();
+		mapSquareDefinition.displaySquareZ = in.readUnsignedShort();
 		mapSquareDefinition.groupId = in.readBigSmart2();
 		mapSquareDefinition.fileId = in.readBigSmart2();
 
@@ -64,14 +64,14 @@ public class WorldMapDataLoader
 		ZoneDefinition zoneDefinition = new ZoneDefinition();
 		zoneDefinition.minLevel = in.readUnsignedByte();
 		zoneDefinition.levels = in.readUnsignedByte();
-		zoneDefinition.displaySquareX = in.readUnsignedShort();
-		zoneDefinition.displaySquareZ = in.readUnsignedShort();
-		zoneDefinition.displayZoneX = in.readUnsignedByte();
-		zoneDefinition.displayZoneZ = in.readUnsignedByte();
 		zoneDefinition.sourceSquareX = in.readUnsignedShort();
 		zoneDefinition.sourceSquareZ = in.readUnsignedShort();
 		zoneDefinition.sourceZoneX = in.readUnsignedByte();
 		zoneDefinition.sourceZoneZ = in.readUnsignedByte();
+		zoneDefinition.displaySquareX = in.readUnsignedShort();
+		zoneDefinition.displaySquareZ = in.readUnsignedShort();
+		zoneDefinition.displayZoneX = in.readUnsignedByte();
+		zoneDefinition.displayZoneZ = in.readUnsignedByte();
 		zoneDefinition.groupId = in.readBigSmart2();
 		zoneDefinition.fileId = in.readBigSmart2();
 

--- a/cache/src/main/java/net/runelite/cache/definitions/loaders/WorldMapDataLoader.java
+++ b/cache/src/main/java/net/runelite/cache/definitions/loaders/WorldMapDataLoader.java
@@ -67,7 +67,7 @@ public class WorldMapDataLoader
 		zoneDefinition.displaySquareX = in.readUnsignedShort();
 		zoneDefinition.displaySquareZ = in.readUnsignedShort();
 		zoneDefinition.displayZoneX = in.readUnsignedByte();
-		zoneDefinition.displayZoneY = in.readUnsignedByte();
+		zoneDefinition.displayZoneZ = in.readUnsignedByte();
 		zoneDefinition.sourceSquareX = in.readUnsignedShort();
 		zoneDefinition.sourceSquareZ = in.readUnsignedShort();
 		zoneDefinition.sourceZoneX = in.readUnsignedByte();


### PR DESCRIPTION
# Summary
Switch the assignment of `source` and `display` produced by the `WorldMapCompositeDefinition` via renaming to match with the way they are used by Jagex to assemble complex maps. 

# Background
While working on updating maps for the Wiki we found some issues with recreating complex maps using the data exposed in #17694.

Complex maps may be composed of squares (64x64) and zones (8x8) which are picked out by Jagex to make maps like:

- ['Ancient Caverns'](https://github.com/runelite/runelite/assets/72635603/f24551c2-6cf0-4ca8-aa2b-7991377fedf0)
- ['God Wars Dungeon'](https://github.com/runelite/runelite/assets/72635603/720faa6b-a85f-450d-9290-5df6922680b4)
- ['Neypotzli'](https://github.com/runelite/runelite/assets/72635603/07772660-c313-4936-aba2-6330c51c6d9d)

For many of them the zones/squares are displayed where they are sourced, meaning no translation takes place. Using [a script](https://gist.github.com/TWCCarlson/84594849f337d1a5a948f7714740b625) which parses and renders the dumped `mapSquareDefintions` in green and `zoneDefinitions` in red we found that:

Maps which involve no translation are easy to render:
![image](https://github.com/runelite/runelite/assets/72635603/efa86ce0-fe20-4533-a1c8-e8795cfedb28)

Maps which do involve translation seem inaccurate:
![image](https://github.com/runelite/runelite/assets/72635603/a6505645-08f9-4034-87ad-93e43a8376f6)

The fix to this was to treat `sourceSquare`s and `sourceZone`s as `displaySquare`s and `displayZone`s, and vice versa.
![image](https://github.com/runelite/runelite/assets/72635603/31688efb-4b6d-4140-983e-e52ae51961b4)

This means that in RuneLite the variables are named opposite to their usage. We also discovered an inconsistent use of Y/Z that looks more like a typo. PR addresses both.

