### PR TITLE
Filter "FRIENDSCHATNOTIFICATION" message type to correctly filter CoX messages

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatfilter/ChatFilterPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatfilter/ChatFilterPlugin.java
@@ -216,6 +216,7 @@ public class ChatFilterPlugin extends Plugin
 				break;
 			case GAMEMESSAGE:
 			case ENGINE:
+			case FRIENDSCHATNOTIFICATION:
 			case ITEM_EXAMINE:
 			case NPC_EXAMINE:
 			case OBJECT_EXAMINE:


### PR DESCRIPTION
Closes #14313

CoX messages are of type `FRIENDSCHATNOTIFICATION`, adding this to the switch for game chat filtering will allow CoX messages such as party invite and raid seed drops to be filtered correctly


https://github.com/runelite/runelite/assets/107762963/c64b0384-ef35-4a74-9702-0384f46272ea

