### PR TITLE
agility: fix falador course

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/agility/Courses.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/agility/Courses.java
@@ -42,7 +42,7 @@ enum Courses
 	CANIFIS(240.0, 13878, new WorldPoint(3510, 3485, 0)),
 	APE_ATOLL(580.0, 11050, new WorldPoint(2770, 2747, 0)),
 	SHAYZIEN_ADVANCED(507.5, 5944, new WorldPoint(1522, 3625, 0)),
-	FALADOR(586, 12084, new WorldPoint(3029, 3332, 0)),
+	FALADOR(586, 12084, new WorldPoint(3029, 3332, 0), new WorldPoint(3029, 3333, 0), new WorldPoint(3029, 3334, 0), new WorldPoint(3029, 3335, 0)),
 	WILDERNESS(571.4, 11837, new WorldPoint(2994, 3933, 0)),
 	WEREWOLF(730.0, 14234, new WorldPoint(3528, 9873, 0)),
 	SEERS(570.0, 10806, new WorldPoint(2704, 3464, 0)),


### PR DESCRIPTION
There are 4 different tiles you can exit the course from, only the furthest-south tile was listed, causing the lap tracker to only work when you landed on that tile.
