### PR TITLE
screenshot: add moons of peril chest loot

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
@@ -136,6 +136,7 @@ public class ScreenshotPlugin extends Plugin
 		BARROWS,
 		COX,
 		COX_CM,
+		MOONS_OF_PERIL,
 		TOB,
 		TOB_SM,
 		TOB_HM,
@@ -416,6 +417,17 @@ public class ScreenshotPlugin extends Plugin
 			}
 		}
 
+		if (chatMessage.startsWith("Your Lunar Chest count is"))
+		{
+			Matcher m = NUMBER_PATTERN.matcher(Text.removeTags(chatMessage));
+			if (m.find())
+			{
+				killType = KillType.MOONS_OF_PERIL;
+				killCountNumber = Integer.valueOf(m.group());
+				return;
+			}
+		}
+
 		if (config.screenshotKick() && chatMessage.equals("Your request to kick/ban this user was successful."))
 		{
 			if (kickPlayerName == null)
@@ -538,6 +550,7 @@ public class ScreenshotPlugin extends Plugin
 			case InterfaceID.TOB_REWARD:
 			case InterfaceID.TOA_REWARD:
 			case InterfaceID.BARROWS_REWARD:
+			case InterfaceID.LUNAR_CHEST:
 				if (!config.screenshotRewards())
 				{
 					return;
@@ -659,6 +672,19 @@ public class ScreenshotPlugin extends Plugin
 				}
 
 				fileName = "Barrows(" + killCountNumber + ")";
+				screenshotSubDir = SD_BOSS_KILLS;
+				killType = null;
+				killCountNumber = 0;
+				break;
+			}
+			case InterfaceID.LUNAR_CHEST:
+			{
+				if (killType != KillType.MOONS_OF_PERIL)
+				{
+					return;
+				}
+
+				fileName = "Moons of Peril(" + killCountNumber + ")";
 				screenshotSubDir = SD_BOSS_KILLS;
 				killType = null;
 				killCountNumber = 0;


### PR DESCRIPTION
This change adds the Lunar Chest loot from the Moons of Peril to the list of boss rewards that are screenshotted automatically if the "Screenshot Rewards" option is checked in the plugin config. This closes #17839.

Tested myself with my first moons kc
![image](https://github.com/runelite/runelite/assets/36280738/51c7b5be-b1e9-4fc0-8cbf-4ab0b1b391ac)
