### PR TITLE
prayer: update drain rate

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/prayer/PrayerType.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/prayer/PrayerType.java
@@ -33,11 +33,11 @@ import net.runelite.api.SpriteID;
 @Getter
 enum PrayerType
 {
-	THICK_SKIN("Thick Skin", Prayer.THICK_SKIN, "+5% Defence", SpriteID.PRAYER_THICK_SKIN, false, 3),
-	BURST_OF_STRENGTH("Burst of Strength", Prayer.BURST_OF_STRENGTH, "+5% Strength", SpriteID.PRAYER_BURST_OF_STRENGTH, false, 3),
-	CLARITY_OF_THOUGHT("Clarity of Thought", Prayer.CLARITY_OF_THOUGHT, "+5% Attack", SpriteID.PRAYER_CLARITY_OF_THOUGHT, false, 3),
-	SHARP_EYE("Sharp Eye", Prayer.SHARP_EYE, "+5% Ranged", SpriteID.PRAYER_SHARP_EYE, false, 3),
-	MYSTIC_WILL("Mystic Will", Prayer.MYSTIC_WILL, "+5% Magical attack and defence", SpriteID.PRAYER_MYSTIC_WILL, false, 3),
+	THICK_SKIN("Thick Skin", Prayer.THICK_SKIN, "+5% Defence", SpriteID.PRAYER_THICK_SKIN, false, 1),
+	BURST_OF_STRENGTH("Burst of Strength", Prayer.BURST_OF_STRENGTH, "+5% Strength", SpriteID.PRAYER_BURST_OF_STRENGTH, false, 1),
+	CLARITY_OF_THOUGHT("Clarity of Thought", Prayer.CLARITY_OF_THOUGHT, "+5% Attack", SpriteID.PRAYER_CLARITY_OF_THOUGHT, false, 1),
+	SHARP_EYE("Sharp Eye", Prayer.SHARP_EYE, "+5% Ranged", SpriteID.PRAYER_SHARP_EYE, false, 1),
+	MYSTIC_WILL("Mystic Will", Prayer.MYSTIC_WILL, "+5% Magical attack and defence", SpriteID.PRAYER_MYSTIC_WILL, false, 1),
 	ROCK_SKIN("Rock Skin", Prayer.ROCK_SKIN, "+10% Defence", SpriteID.PRAYER_ROCK_SKIN, false, 6),
 	SUPERHUMAN_STRENGTH("Superhuman Strength", Prayer.SUPERHUMAN_STRENGTH, "+10% Strength", SpriteID.PRAYER_SUPERHUMAN_STRENGTH, false, 6),
 	IMPROVED_REFLEXES("Improved Reflexes", Prayer.IMPROVED_REFLEXES, "+10% Attack", SpriteID.PRAYER_IMPROVED_REFLEXES, false, 6),

--- a/runelite-client/src/test/java/net/runelite/client/plugins/prayer/PrayerPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/prayer/PrayerPluginTest.java
@@ -164,11 +164,11 @@ public class PrayerPluginTest
 	{
 		prayerPlugin.setPrayerBonus(42);
 
-		assertTime(PrayerType.THICK_SKIN, "47:31");
-		assertTime(PrayerType.BURST_OF_STRENGTH, "47:31");
-		assertTime(PrayerType.CLARITY_OF_THOUGHT, "47:31");
-		assertTime(PrayerType.SHARP_EYE, "47:31");
-		assertTime(PrayerType.MYSTIC_WILL, "47:31");
+		assertTime(PrayerType.THICK_SKIN, "2:22:33");
+		assertTime(PrayerType.BURST_OF_STRENGTH, "2:22:33");
+		assertTime(PrayerType.CLARITY_OF_THOUGHT, "2:22:33");
+		assertTime(PrayerType.SHARP_EYE, "2:22:33");
+		assertTime(PrayerType.MYSTIC_WILL, "2:22:33");
 		assertTime(PrayerType.ROCK_SKIN, "23:45");
 		assertTime(PrayerType.SUPERHUMAN_STRENGTH, "23:45");
 		assertTime(PrayerType.IMPROVED_REFLEXES, "23:45");


### PR DESCRIPTION
In the [Project Rebalance: Combat Changes](https://secure.runescape.com/m=news/project-rebalance-combat-changes?oldschool=1) update, the prayer drain rate was reduced by 1/3 (from 5 to 1.67 points per minute) for Thick Skin, Burst of Strength and Clarity of Thoughts, Sharp Eye and Mystic Will.