### PR TITLE
[Boosts Information plugin] Allow alerting on fully drained stats

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/boosts/BoostsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/boosts/BoostsConfig.java
@@ -127,7 +127,7 @@ public interface BoostsConfig extends Config
 	@ConfigItem(
 		keyName = "boostThreshold",
 		name = "Boost threshold",
-		description = "The threshold at which boosted levels will be displayed in a different color. A value of 0 will disable the feature.",
+		description = "Number of levels above your base level at which boosted levels will be displayed in a different color.",
 		position = 12
 	)
 	default int boostThreshold()
@@ -138,11 +138,11 @@ public interface BoostsConfig extends Config
 	@ConfigItem(
 		keyName = "notifyOnBoost",
 		name = "Notify on boost threshold",
-		description = "Configures whether or not a notification will be sent for boosted stats.",
+		description = "Configures whether or not a notification will be sent when boosted stats drain to the boost threshold.",
 		position = 13
 	)
 	default Notification notifyOnBoost()
 	{
-		return Notification.ON;
+		return Notification.OFF;
 	}
 }


### PR DESCRIPTION
Currently with this plugin you cannot get notified when your stats fully drain, only when the drain to level + 1. Setting the threshold to 0 disables the feature. This new param will allow the boost threshold to be set to 0 without it disabling the feature, meaning you can get notified when a stat returns to its base level.