### PR TITLE
KeyListener: Release held keys when client focus is lost

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/input/KeyListener.java
+++ b/runelite-client/src/main/java/net/runelite/client/input/KeyListener.java
@@ -30,4 +30,8 @@ public interface KeyListener extends java.awt.event.KeyListener
 	{
 		return false;
 	}
+
+	default void focusLost()
+	{
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/input/KeyManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/input/KeyManager.java
@@ -33,6 +33,9 @@ import javax.inject.Singleton;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.GameState;
+import net.runelite.api.events.FocusChanged;
+import net.runelite.client.eventbus.EventBus;
+import net.runelite.client.eventbus.Subscribe;
 
 @Singleton
 @Slf4j
@@ -41,9 +44,10 @@ public class KeyManager
 	private final Client client;
 
 	@Inject
-	private KeyManager(@Nullable final Client client)
+	private KeyManager(@Nullable final Client client, final EventBus eventBus)
 	{
 		this.client = client;
+		eventBus.register(this);
 	}
 
 	private final List<KeyListener> keyListeners = new CopyOnWriteArrayList<>();
@@ -156,5 +160,17 @@ public class KeyManager
 		}
 
 		return true;
+	}
+
+	@Subscribe
+	private void onFocusChanged(FocusChanged event)
+	{
+		if (!event.isFocused())
+		{
+			for (KeyListener keyListener : keyListeners)
+			{
+				keyListener.focusLost();
+			}
+		}
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
@@ -58,10 +58,10 @@ import java.awt.desktop.QuitStrategy;
 import java.awt.event.ComponentAdapter;
 import java.awt.event.ComponentEvent;
 import java.awt.event.KeyEvent;
-import java.awt.event.KeyListener;
 import java.awt.event.MouseEvent;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
+import java.awt.event.WindowFocusListener;
 import java.awt.image.BufferedImage;
 import java.time.Duration;
 import java.util.ArrayDeque;
@@ -120,6 +120,7 @@ import net.runelite.client.events.ConfigChanged;
 import net.runelite.client.input.MouseAdapter;
 import net.runelite.client.input.MouseListener;
 import net.runelite.client.input.MouseManager;
+import net.runelite.client.input.KeyListener;
 import net.runelite.client.ui.laf.RuneLiteLAF;
 import net.runelite.client.ui.laf.RuneLiteRootPaneUI;
 import net.runelite.client.util.HotkeyListener;
@@ -499,6 +500,23 @@ public class ClientUI
 					}
 				});
 			KeyboardFocusManager.getCurrentKeyboardFocusManager().addKeyEventDispatcher(this::dispatchWindowKeyEvent);
+
+			frame.addWindowFocusListener(new WindowFocusListener()
+			{
+				@Override
+				public void windowGainedFocus(WindowEvent e)
+				{
+				}
+
+				@Override
+				public void windowLostFocus(WindowEvent e)
+				{
+					for (KeyListener keyListener : keyListeners)
+					{
+						keyListener.focusLost();
+					}
+				}
+			});
 
 			// Add mouse listener
 			final MouseListener mouseListener = new MouseAdapter()

--- a/runelite-client/src/main/java/net/runelite/client/util/HotkeyListener.java
+++ b/runelite-client/src/main/java/net/runelite/client/util/HotkeyListener.java
@@ -50,6 +50,19 @@ public abstract class HotkeyListener implements KeyListener
 	}
 
 	@Override
+	public void focusLost()
+	{
+		if (!isPressed)
+		{
+			return;
+		}
+
+		isPressed = false;
+		isConsumingTyped = false;
+		hotkeyReleased();
+	}
+
+	@Override
 	public void keyTyped(KeyEvent e)
 	{
 		if (isConsumingTyped)


### PR DESCRIPTION
Adds overridable focusLost to keyListener and implements it in both ClientUI and KeyManager.

Resolves https://github.com/runelite/runelite/issues/16242