### PR TITLE
Update to SpecialCounterPlugin to support Tekton spec misses

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/specialcounter/SpecialCounterPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/specialcounter/SpecialCounterPlugin.java
@@ -212,7 +212,8 @@ public class SpecialCounterPlugin extends Plugin
 				&& (specialWeapon == ELDER_MAUL || specialWeapon == DRAGON_WARHAMMER || specialWeapon == BANDOS_GODSWORD)
 				&& (lastSpecTarget.getId() == NpcID.TEKTON || lastSpecTarget.getId() == NpcID.TEKTON_7541 || lastSpecTarget.getId() == NpcID.TEKTON_7542 || lastSpecTarget.getId() == NpcID.TEKTON_7545 || lastSpecTarget.getId() == NpcID.TEKTON_ENRAGED || lastSpecTarget.getId() == NpcID.TEKTON_ENRAGED_7544))
 			{
-				specialAttackHit(specialWeapon, 0, lastSpecTarget);
+				int hit = specialWeapon == BANDOS_GODSWORD ? 10 : 0;
+				specialAttackHit(specialWeapon, hit, lastSpecTarget);
 			}
 
 			specialWeapon = null;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/specialcounter/SpecialCounterPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/specialcounter/SpecialCounterPlugin.java
@@ -33,6 +33,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.Objects;
 import javax.inject.Inject;
 import javax.inject.Named;
 import lombok.AccessLevel;
@@ -71,6 +72,9 @@ import net.runelite.client.party.WSClient;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import static net.runelite.client.plugins.specialcounter.SpecialWeapon.TONALZTICS_OF_RALOS;
+import static net.runelite.client.plugins.specialcounter.SpecialWeapon.BANDOS_GODSWORD;
+import static net.runelite.client.plugins.specialcounter.SpecialWeapon.DRAGON_WARHAMMER;
+import static net.runelite.client.plugins.specialcounter.SpecialWeapon.ELDER_MAUL;
 import net.runelite.client.ui.overlay.OverlayManager;
 import net.runelite.client.ui.overlay.infobox.InfoBoxManager;
 import net.runelite.client.util.ImageUtil;
@@ -201,6 +205,14 @@ public class SpecialCounterPlugin extends Plugin
 			{
 				int hit = specialWeapon == TONALZTICS_OF_RALOS ? specialAttackHits : getHit(specialWeapon, lastSpecHitsplat);
 				specialAttackHit(specialWeapon, hit, lastSpecTarget);
+			} else if (lastSpecHitsplat.getAmount() == 0
+					&& (specialWeapon == ELDER_MAUL || specialWeapon == DRAGON_WARHAMMER || specialWeapon == BANDOS_GODSWORD)
+					&& Objects.requireNonNull(lastSpecTarget.getName()).contains("Tekton"))
+					//Condition to call specialAttackHit when a spec from EM, DWH or BGS is missed on Tekton
+				    //as the defence is drained by 5% on a miss from EM/DWH and -10 defence on BGS miss.
+					//Sending the 0 will support the Party Defense Tracker Plugin
+			{
+				specialAttackHit(specialWeapon, 0, lastSpecTarget);
 			}
 
 			specialWeapon = null;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/specialcounter/SpecialCounterPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/specialcounter/SpecialCounterPlugin.java
@@ -210,7 +210,7 @@ public class SpecialCounterPlugin extends Plugin
 			//Sending the 0 will support the Party Defense Tracker Plugin
 			else if (lastSpecHitsplat.getAmount() == 0
 				&& (specialWeapon == ELDER_MAUL || specialWeapon == DRAGON_WARHAMMER || specialWeapon == BANDOS_GODSWORD)
-				&& lastSpecTarget.getName() != null && lastSpecTarget.getName().contains("Tekton"))
+				&& (lastSpecTarget.getId() == NpcID.TEKTON || lastSpecTarget.getId() == NpcID.TEKTON_7541 || lastSpecTarget.getId() == NpcID.TEKTON_7542 || lastSpecTarget.getId() == NpcID.TEKTON_7545 || lastSpecTarget.getId() == NpcID.TEKTON_ENRAGED || lastSpecTarget.getId() == NpcID.TEKTON_ENRAGED_7544))
 			{
 				specialAttackHit(specialWeapon, 0, lastSpecTarget);
 			}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/specialcounter/SpecialCounterPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/specialcounter/SpecialCounterPlugin.java
@@ -205,12 +205,13 @@ public class SpecialCounterPlugin extends Plugin
 			{
 				int hit = specialWeapon == TONALZTICS_OF_RALOS ? specialAttackHits : getHit(specialWeapon, lastSpecHitsplat);
 				specialAttackHit(specialWeapon, hit, lastSpecTarget);
-			} else if (lastSpecHitsplat.getAmount() == 0
-					&& (specialWeapon == ELDER_MAUL || specialWeapon == DRAGON_WARHAMMER || specialWeapon == BANDOS_GODSWORD)
-					&& Objects.requireNonNull(lastSpecTarget.getName()).contains("Tekton"))
-					//Condition to call specialAttackHit when a spec from EM, DWH or BGS is missed on Tekton
-					//as the defence is drained by 5% on a miss from EM/DWH and -10 defence on BGS miss.
-					//Sending the 0 will support the Party Defense Tracker Plugin
+			}
+			//Condition to call specialAttackHit when a spec from EM, DWH or BGS is missed on Tekton
+			//as the defence is drained by 5% on a miss from EM/DWH and -10 defence on BGS miss.
+			//Sending the 0 will support the Party Defense Tracker Plugin
+			else if (lastSpecHitsplat.getAmount() == 0
+				&& (specialWeapon == ELDER_MAUL || specialWeapon == DRAGON_WARHAMMER || specialWeapon == BANDOS_GODSWORD)
+				&& Objects.requireNonNull(lastSpecTarget.getName()).contains("Tekton"))
 			{
 				specialAttackHit(specialWeapon, 0, lastSpecTarget);
 			}
@@ -518,19 +519,27 @@ public class SpecialCounterPlugin extends Plugin
 	private int getHitDelay(SpecialWeapon specialWeapon, Actor target)
 	{
 		if (target == null)
+		{
 			return 1;
+		}
 
 		Player player = client.getLocalPlayer();
 		if (player == null)
+		{
 			return 1;
+		}
 
 		WorldPoint playerWp = player.getWorldLocation();
 		if (playerWp == null)
+		{
 			return 1;
+		}
 
 		WorldArea targetArea = target.getWorldArea();
 		if (targetArea == null)
+		{
 			return 1;
+		}
 
 		final int distance = targetArea.distanceTo(playerWp);
 		final int serverCycles = specialWeapon.getHitDelay(distance);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/specialcounter/SpecialCounterPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/specialcounter/SpecialCounterPlugin.java
@@ -411,7 +411,7 @@ public class SpecialCounterPlugin extends Plugin
 	{
 		if (developerMode && commandExecuted.getCommand().equalsIgnoreCase("spec"))
 		{
-			playerInfoDrops.add(createSpecInfoDrop(SpecialWeapon.BANDOS_GODSWORD, 42, client.getLocalPlayer().getId()));
+			playerInfoDrops.add(createSpecInfoDrop(BANDOS_GODSWORD, 42, client.getLocalPlayer().getId()));
 		}
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/specialcounter/SpecialCounterPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/specialcounter/SpecialCounterPlugin.java
@@ -329,7 +329,10 @@ public class SpecialCounterPlugin extends Plugin
 
 		if (config.infobox())
 		{
-			updateCounter(specialWeapon, null, hit);
+			if (hit != 0) //do not update the infobox if a DWH or EM spec is missed on Tekton
+			{
+				updateCounter(specialWeapon, null, hit);
+			}
 		}
 
 		if (party.isInParty())
@@ -398,7 +401,10 @@ public class SpecialCounterPlugin extends Plugin
 			{
 				if (config.infobox())
 				{
-					updateCounter(event.getWeapon(), name, event.getHit());
+					if (event.getHit() != 0) //do not update the infobox if a DWH or EM spec is missed on Tekton
+					{
+						updateCounter(event.getWeapon(), name, event.getHit());
+					}
 				}
 			}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/specialcounter/SpecialCounterPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/specialcounter/SpecialCounterPlugin.java
@@ -209,7 +209,7 @@ public class SpecialCounterPlugin extends Plugin
 					&& (specialWeapon == ELDER_MAUL || specialWeapon == DRAGON_WARHAMMER || specialWeapon == BANDOS_GODSWORD)
 					&& Objects.requireNonNull(lastSpecTarget.getName()).contains("Tekton"))
 					//Condition to call specialAttackHit when a spec from EM, DWH or BGS is missed on Tekton
-					// as the defence is drained by 5% on a miss from EM/DWH and -10 defence on BGS miss.
+					//as the defence is drained by 5% on a miss from EM/DWH and -10 defence on BGS miss.
 					//Sending the 0 will support the Party Defense Tracker Plugin
 			{
 				specialAttackHit(specialWeapon, 0, lastSpecTarget);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/specialcounter/SpecialCounterPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/specialcounter/SpecialCounterPlugin.java
@@ -209,7 +209,7 @@ public class SpecialCounterPlugin extends Plugin
 					&& (specialWeapon == ELDER_MAUL || specialWeapon == DRAGON_WARHAMMER || specialWeapon == BANDOS_GODSWORD)
 					&& Objects.requireNonNull(lastSpecTarget.getName()).contains("Tekton"))
 					//Condition to call specialAttackHit when a spec from EM, DWH or BGS is missed on Tekton
-				    //as the defence is drained by 5% on a miss from EM/DWH and -10 defence on BGS miss.
+					// as the defence is drained by 5% on a miss from EM/DWH and -10 defence on BGS miss.
 					//Sending the 0 will support the Party Defense Tracker Plugin
 			{
 				specialAttackHit(specialWeapon, 0, lastSpecTarget);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/specialcounter/SpecialCounterPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/specialcounter/SpecialCounterPlugin.java
@@ -33,7 +33,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.Objects;
 import javax.inject.Inject;
 import javax.inject.Named;
 import lombok.AccessLevel;
@@ -211,7 +210,7 @@ public class SpecialCounterPlugin extends Plugin
 			//Sending the 0 will support the Party Defense Tracker Plugin
 			else if (lastSpecHitsplat.getAmount() == 0
 				&& (specialWeapon == ELDER_MAUL || specialWeapon == DRAGON_WARHAMMER || specialWeapon == BANDOS_GODSWORD)
-				&& Objects.requireNonNull(lastSpecTarget.getName()).contains("Tekton"))
+				&& lastSpecTarget.getName() != null && lastSpecTarget.getName().contains("Tekton"))
 			{
 				specialAttackHit(specialWeapon, 0, lastSpecTarget);
 			}


### PR DESCRIPTION
Adding a condition to call specialAttackHit when a spec from Elder Maul, DWH or BGS is missed on Tekton as the defence is drained by 5% on a miss from EM/DWH and -10 defence on a BGS miss.

Sending the 0 will support the Party Defense Tracker Plugin which is currently already prepared to handle this condition.