### PR TITLE
Remove Tithe Farm grown plant timer display

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/tithefarm/TitheFarmPlantOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/tithefarm/TitheFarmPlantOverlay.java
@@ -87,7 +87,7 @@ public class TitheFarmPlantOverlay extends Overlay
 	{
 		for (TitheFarmPlant plant : plugin.getPlants())
 		{
-			if (plant.getState() == TitheFarmPlantState.DEAD)
+			if (plant.getState() == TitheFarmPlantState.DEAD || plant.getState() == TitheFarmPlantState.GROWN)
 			{
 				continue;
 			}


### PR DESCRIPTION
As of May 23, 2024, fully grown Tithe plants no longer decay ([blog post](https://oldschool.runescape.wiki/w/Update:Minigame_Tweaks,_Skilling_Adjustments_%26_more!#Minigame_Improvements:~:text=Fully%2Dgrown%20plants%20in%20Tithe%20Farm%20will%20no%20longer%20decay.)).
This makes the progress circle unnecessary for the fully grown plants.

I've removed it here. 

I considered leaving the pie 100% filled for the grown plant as a way to indicate it was actionable but it did not seem proper and it automatically disappeared eventually. Would be interested to know if there's some way to have a similar way to display that. 