### PR TITLE
Add 6 hour log notification configuration

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierConfig.java
@@ -91,10 +91,22 @@ public interface IdleNotifierConfig extends Config
 	}
 
 	@ConfigItem(
+			keyName = "sixhourlogwarningdelay",
+			name = "Six Hour Logout Warning Time",
+			description = "The number of minutes before a six hour logout to send a notification at. A value of 0 will disable notification.",
+			position = 6
+	)
+	@Units(Units.MINUTES)
+	default int getSixHourLogoutWarningTime()
+	{
+		return 20;
+	}
+
+	@ConfigItem(
 		keyName = "hitpoints",
 		name = "Hitpoints Threshold",
 		description = "The amount of hitpoints to send a notification at. A value of 0 will disable notification.",
-		position = 6
+		position = 7
 	)
 	default int getHitpointsThreshold()
 	{
@@ -105,7 +117,7 @@ public interface IdleNotifierConfig extends Config
 		keyName = "prayer",
 		name = "Prayer Threshold",
 		description = "The amount of prayer points to send a notification at. A value of 0 will disable notification.",
-		position = 7
+		position = 8
 	)
 	default int getPrayerThreshold()
 	{
@@ -116,7 +128,7 @@ public interface IdleNotifierConfig extends Config
 		keyName = "lowEnergy",
 		name = "Low Energy Threshold",
 		description = "The amount of energy points remaining to send a notification at. A value of 100 will disable notification.",
-		position = 8
+		position = 9
 	)
 	@Units(Units.PERCENT)
 	@Range(max = 100)
@@ -129,7 +141,7 @@ public interface IdleNotifierConfig extends Config
 		keyName = "highEnergy",
 		name = "High Energy Threshold",
 		description = "The amount of energy points reached to send a notification. A value of 0 will disable notification.",
-		position = 9
+		position = 10
 	)
 	@Units(Units.PERCENT)
 	@Range(max = 100)
@@ -141,7 +153,7 @@ public interface IdleNotifierConfig extends Config
 	@ConfigItem(
 		keyName = "oxygen",
 		name = "Oxygen Threshold",
-		position = 10,
+		position = 11,
 		description = "The amount of remaining oxygen to send a notification at. A value of 0 will disable notification."
 	)
 	@Units(Units.PERCENT)
@@ -153,7 +165,7 @@ public interface IdleNotifierConfig extends Config
 	@ConfigItem(
 		keyName = "spec",
 		name = "Spec Threshold",
-		position = 11,
+		position = 12,
 		description = "The amount of special attack energy reached to send a notification at. A value of 0 will disable notification."
 	)
 	@Units(Units.PERCENT)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
@@ -72,7 +72,7 @@ public class IdleNotifierPlugin extends Plugin
 	private static final int COMBAT_WARNING_CLIENT_TICKS = COMBAT_WARNING_MILLIS / Constants.CLIENT_TICK_LENGTH;
 
 	private static final int HIGHEST_MONSTER_ATTACK_SPEED = 8; // Except Scarab Mage, but they are with other monsters
-	private static final Duration SIX_HOUR_LOGOUT_WARNING_AFTER_DURATION = Duration.ofMinutes(340);
+	private static final int SIX_HOURS_MINS = 360;
 
 	private static final String FISHING_SPOT = "Fishing spot";
 
@@ -101,7 +101,7 @@ public class IdleNotifierPlugin extends Plugin
 	private boolean notify6HourLogout = true;
 	private int lastSpecEnergy = 1000;
 	private int lastCombatCountdown = 0;
-	private Instant sixHourWarningTime;
+	private Instant logInTime;
 	private boolean ready;
 	private boolean lastInteractWasCombat;
 	private static final int BUFF_BAR_NOT_DISPLAYED = -1;
@@ -115,8 +115,7 @@ public class IdleNotifierPlugin extends Plugin
 	@Override
 	protected void startUp()
 	{
-		// can't tell when 6hr will be if enabled while already logged in
-		sixHourWarningTime = null;
+		logInTime = null;
 	}
 
 	@Subscribe
@@ -457,7 +456,7 @@ public class IdleNotifierPlugin extends Plugin
 			case LOGGED_IN:
 				if (ready)
 				{
-					sixHourWarningTime = Instant.now().plus(SIX_HOUR_LOGOUT_WARNING_AFTER_DURATION);
+					logInTime = Instant.now();
 					ready = false;
 					resetTimers();
 				}
@@ -816,12 +815,19 @@ public class IdleNotifierPlugin extends Plugin
 
 	private boolean check6hrLogout()
 	{
-		if (sixHourWarningTime == null)
+		if (logInTime == null)
 		{
 			return false;
 		}
 
-		if (Instant.now().compareTo(sixHourWarningTime) >= 0)
+		if (config.getSixHourLogoutWarningTime() == 0)
+		{
+			return false;
+		}
+
+		final Instant warningTime = logInTime.plus(
+				Duration.ofMinutes(SIX_HOURS_MINS - config.getSixHourLogoutWarningTime()));
+		if (Instant.now().compareTo(warningTime) >= 0)
 		{
 			if (notify6HourLogout)
 			{


### PR DESCRIPTION
Addresses #17890

### Overview
Adds a configurable option to the Idle Notifier plugin for how many minutes prior to the 6 hour logout the user wants to be notified, with a value of 0 disabling the notification.

For example, a value of 20 will alert the user 20 minutes before forced logout (or 5 hours 40 mins of login time).

### Testing
- Set value to 359 mins and verified alert appeared after 1 min logged in