### PR TITLE
Special counter: Convert percent based specials and bug fixes

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/SpriteID.java
+++ b/runelite-api/src/main/java/net/runelite/api/SpriteID.java
@@ -1282,7 +1282,8 @@ public final class SpriteID
 	public static final int EMOTE_SMOOTH_DANCE_LOCKED = 1355;
 	public static final int EMOTE_CRAZY_DANCE_LOCKED = 1356;
 	public static final int EMOTE_PREMIER_SHIELD_LOCKED = 1357;
-	/* Unmapped: 1358~1359 */
+	/* Unmapped: 1359 */
+	public static final int HITSPLAT_BLUE_MISS = 1358;
 	public static final int HITSPLAT_GREEN_POISON = 1360;
 	/* Unmapped: 1361~1363 */
 	public static final int BOUNTY_HUNTER_SKIP_TARGET = 1364;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/specialcounter/SpecialCounter.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/specialcounter/SpecialCounter.java
@@ -34,6 +34,7 @@ import net.runelite.client.ui.overlay.infobox.Counter;
 
 class SpecialCounter extends Counter
 {
+	@Getter(AccessLevel.PACKAGE)
 	private final SpecialWeapon weapon;
 	private final SpecialCounterConfig config;
 	@Getter(AccessLevel.PACKAGE)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/specialcounter/SpecialCounterConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/specialcounter/SpecialCounterConfig.java
@@ -81,21 +81,10 @@ public interface SpecialCounterConfig extends Config
 	@ConfigItem(
 		position = 10,
 		keyName = "dragonWarhammerThreshold",
-		name = "Dragon Warhammer",
-		description = "Threshold for Dragon Warhammer (0 to disable)"
+		name = "Defence Percentage",
+		description = "Threshold for Dragon Warhammer/Elder maul's percentage drain (0 to disable)"
 	)
-	default int dragonWarhammerThreshold()
-	{
-		return 0;
-	}
-
-	@ConfigItem(
-		position = 15,
-		keyName = "elderMaulThreshold",
-		name = "Elder Maul",
-		description = "Threshold for Elder Maul (0 to disable)"
-	)
-	default int elderMaulThreshold()
+	default int defencePercentageThreshold()
 	{
 		return 0;
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/specialcounter/SpecialCounterPercentage.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/specialcounter/SpecialCounterPercentage.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2024, 1Defence>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.specialcounter;
+
+import lombok.Getter;
+import net.runelite.client.ui.overlay.infobox.InfoBox;
+
+import java.awt.*;
+import java.awt.image.BufferedImage;
+
+class SpecialCounterPercentage extends InfoBox
+{
+	private SpecialCounter dwhCounter;
+	private SpecialCounter maulCounter;
+
+	private int zeroCount;
+
+	private final SpecialCounterConfig config;
+
+	@Getter
+	private double defenceDrainPercentage;
+
+	SpecialCounterPercentage(BufferedImage image, SpecialCounterPlugin plugin, SpecialCounterConfig config, SpecialCounter initialCounter, int initialHit)
+	{
+		super(image, plugin);
+		this.config = config;
+		setCounter(initialCounter, initialHit);
+	}
+
+	public void setCounter(SpecialCounter counter, int initialHit)
+	{
+		switch (counter.getWeapon())
+		{
+			case DRAGON_WARHAMMER:
+				dwhCounter = counter;
+				break;
+			case ELDER_MAUL:
+				maulCounter = counter;
+				break;
+		}
+
+		if (initialHit == 0)
+		{
+			incrementZeros();
+		}
+
+		recalculateSpecs();
+	}
+
+	public void recalculateSpecs()
+	{
+		int currentDefence = 100;
+		if (dwhCounter != null && dwhCounter.getCount() > 0)
+		{
+			currentDefence *= Math.pow(0.7, dwhCounter.getCount());
+		}
+		if (maulCounter != null && maulCounter.getCount() > 0)
+		{
+			currentDefence *= Math.pow(0.65, maulCounter.getCount());
+		}
+		defenceDrainPercentage = 100 - (currentDefence * Math.pow(0.95, zeroCount));
+	}
+
+	public void incrementZeros()
+	{
+		zeroCount++;
+	}
+
+	@Override
+	public String getTooltip()
+	{
+		return "Opponents defence has been reduced by " + getText() + ".";
+	}
+
+	@Override
+	public Color getTextColor()
+	{
+		int threshold = config.defencePercentageThreshold();
+		if (threshold > 0)
+		{
+			return defenceDrainPercentage >= threshold ? Color.GREEN : Color.RED;
+		}
+		return Color.WHITE;
+	}
+
+	@Override
+	public String getText()
+	{
+		return (int) defenceDrainPercentage + "%";
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/specialcounter/SpecialCounterPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/specialcounter/SpecialCounterPlugin.java
@@ -104,10 +104,6 @@ public class SpecialCounterPlugin extends Plugin
 			NpcID.TEKTON_ENRAGED,
 			NpcID.TEKTON_ENRAGED_7544
 	);
-	private static final Set<SpecialWeapon> PERCENTAGE_INFOBOXES = ImmutableSet.of(
-			SpecialWeapon.DRAGON_WARHAMMER,
-			SpecialWeapon.ELDER_MAUL
-	);
 
 	private int currentWorld;
 	private int specialPercentage;
@@ -257,7 +253,7 @@ public class SpecialCounterPlugin extends Plugin
 		}
 
 		//due to fringe cases with thrall distance changing hitsplat order, hitsplat should only be used in cases where we cannot reliably verify the hit from xp
-		boolean splatCheckRequired = (specialWeapon != SpecialWeapon.ELDER_MAUL && specialWeapon != SpecialWeapon.DRAGON_WARHAMMER);
+		boolean splatCheckRequired = !specialWeapon.isPercentageHandle();
 
 		if (splatCheckRequired)
 		{
@@ -531,7 +527,7 @@ public class SpecialCounterPlugin extends Plugin
 	private void updateCounter(SpecialWeapon specialWeapon, String name, int hit)
 	{
 		SpecialCounter counter = specialCounter[specialWeapon.ordinal()];
-		boolean isDefenceCounter = PERCENTAGE_INFOBOXES.contains(specialWeapon);
+		boolean isDefenceCounter = specialWeapon.isPercentageHandle();
 		if (counter == null)
 		{
 			counter = new SpecialCounter(itemManager.getImage(specialWeapon.getItemID()[0]), this, config,
@@ -596,7 +592,7 @@ public class SpecialCounterPlugin extends Plugin
 	{
 		int threshold = weapon.getThreshold().apply(config);
 		String message = "";
-		if (PERCENTAGE_INFOBOXES.contains(weapon) && specialCounterPercentage.getDefenceDrainPercentage() >= threshold)
+		if (weapon.isPercentageHandle() && specialCounterPercentage.getDefenceDrainPercentage() >= threshold)
 		{
 			message = "Defence Percentage threshold reached!";
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/specialcounter/SpecialWeapon.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/specialcounter/SpecialWeapon.java
@@ -65,7 +65,8 @@ public enum SpecialWeapon
 		new int[]{ItemID.ELDER_MAUL, ItemID.ELDER_MAUL_OR},
 		false, true,
 		(distance) -> 50, //The hitsplat is applied 2t after spec unlike most melee weapons
-		SpecialCounterConfig::defencePercentageThreshold);
+		SpecialCounterConfig::defencePercentageThreshold),
+	SEERCULL("Seercull", new int[]{ItemID.SEERCULL}, true, false, (d) -> 46 + (d * 5), (c) -> 0);
 
 	private final String name;
 	private final int[] itemID;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/specialcounter/SpecialWeapon.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/specialcounter/SpecialWeapon.java
@@ -33,7 +33,7 @@ import net.runelite.api.ItemID;
 @Getter
 public enum SpecialWeapon
 {
-	DRAGON_WARHAMMER("Dragon Warhammer", new int[]{ItemID.DRAGON_WARHAMMER, ItemID.DRAGON_WARHAMMER_CR}, false, SpecialCounterConfig::dragonWarhammerThreshold),
+	DRAGON_WARHAMMER("Dragon Warhammer", new int[]{ItemID.DRAGON_WARHAMMER, ItemID.DRAGON_WARHAMMER_CR}, false, SpecialCounterConfig::defencePercentageThreshold),
 	ARCLIGHT("Arclight", new int[]{ItemID.ARCLIGHT}, false, SpecialCounterConfig::arclightThreshold),
 	DARKLIGHT("Darklight", new int[]{ItemID.DARKLIGHT}, false, SpecialCounterConfig::darklightThreshold),
 	BANDOS_GODSWORD("Bandos Godsword", new int[]{ItemID.BANDOS_GODSWORD, ItemID.BANDOS_GODSWORD_OR}, true, SpecialCounterConfig::bandosGodswordThreshold),
@@ -65,8 +65,7 @@ public enum SpecialWeapon
 		new int[]{ItemID.ELDER_MAUL, ItemID.ELDER_MAUL_OR},
 		false,
 		(distance) -> 50, //The hitsplat is applied 2t after spec unlike most melee weapons
-		SpecialCounterConfig::elderMaulThreshold),
-	SEERCULL("Seercull", new int[]{ItemID.SEERCULL}, true, (d) -> 46 + (d * 5), (c) -> 0);
+		SpecialCounterConfig::defencePercentageThreshold);
 
 	private final String name;
 	private final int[] itemID;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/specialcounter/SpecialWeapon.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/specialcounter/SpecialWeapon.java
@@ -33,43 +33,44 @@ import net.runelite.api.ItemID;
 @Getter
 public enum SpecialWeapon
 {
-	DRAGON_WARHAMMER("Dragon Warhammer", new int[]{ItemID.DRAGON_WARHAMMER, ItemID.DRAGON_WARHAMMER_CR}, false, SpecialCounterConfig::defencePercentageThreshold),
-	ARCLIGHT("Arclight", new int[]{ItemID.ARCLIGHT}, false, SpecialCounterConfig::arclightThreshold),
-	DARKLIGHT("Darklight", new int[]{ItemID.DARKLIGHT}, false, SpecialCounterConfig::darklightThreshold),
-	BANDOS_GODSWORD("Bandos Godsword", new int[]{ItemID.BANDOS_GODSWORD, ItemID.BANDOS_GODSWORD_OR}, true, SpecialCounterConfig::bandosGodswordThreshold),
-	BARRELCHEST_ANCHOR("Barrelchest Anchor", new int[]{ItemID.BARRELCHEST_ANCHOR}, true, (c) -> 0),
-	BONE_DAGGER("Bone Dagger", new int[]{ItemID.BONE_DAGGER, ItemID.BONE_DAGGER_P, ItemID.BONE_DAGGER_P_8876, ItemID.BONE_DAGGER_P_8878}, true, (c) -> 0),
+	DRAGON_WARHAMMER("Dragon Warhammer", new int[]{ItemID.DRAGON_WARHAMMER, ItemID.DRAGON_WARHAMMER_CR}, false, true, SpecialCounterConfig::defencePercentageThreshold),
+	ARCLIGHT("Arclight", new int[]{ItemID.ARCLIGHT}, false, false, SpecialCounterConfig::arclightThreshold),
+	DARKLIGHT("Darklight", new int[]{ItemID.DARKLIGHT}, false, false, SpecialCounterConfig::darklightThreshold),
+	BANDOS_GODSWORD("Bandos Godsword", new int[]{ItemID.BANDOS_GODSWORD, ItemID.BANDOS_GODSWORD_OR}, true, false, SpecialCounterConfig::bandosGodswordThreshold),
+	BARRELCHEST_ANCHOR("Barrelchest Anchor", new int[]{ItemID.BARRELCHEST_ANCHOR}, true, false, (c) -> 0),
+	BONE_DAGGER("Bone Dagger", new int[]{ItemID.BONE_DAGGER, ItemID.BONE_DAGGER_P, ItemID.BONE_DAGGER_P_8876, ItemID.BONE_DAGGER_P_8878}, true, false, (c) -> 0),
 	DORGESHUUN_CROSSBOW(
 		"Dorgeshuun Crossbow",
 		new int[]{ItemID.DORGESHUUN_CROSSBOW},
-		true,
+		true, false,
 		(distance) -> 60 + distance * 3,
 		(c) -> 0
 	),
-	BULWARK("Dinh's Bulwark", new int[]{ItemID.DINHS_BULWARK}, false, SpecialCounterConfig::bulwarkThreshold),
+	BULWARK("Dinh's Bulwark", new int[]{ItemID.DINHS_BULWARK}, false, false, SpecialCounterConfig::bulwarkThreshold),
 	ACCURSED_SCEPTRE(
 		"Accursed Sceptre",
 		new int[]{ItemID.ACCURSED_SCEPTRE, ItemID.ACCURSED_SCEPTRE_A},
-		false,
+		false, false,
 		(distance) -> 46 + distance * 10,
 		(c) -> 0
 	),
 	TONALZTICS_OF_RALOS(
 		"Tonalztics of Ralos",
 		new int[]{ItemID.TONALZTICS_OF_RALOS},
-		false,
+		false, false,
 		(distance) -> 50, //The hitsplat is always applied 2t after spec regardless of distance
 		(c) -> 0
 	),
 	ELDER_MAUL("Elder Maul",
 		new int[]{ItemID.ELDER_MAUL, ItemID.ELDER_MAUL_OR},
-		false,
+		false, true,
 		(distance) -> 50, //The hitsplat is applied 2t after spec unlike most melee weapons
 		SpecialCounterConfig::defencePercentageThreshold);
 
 	private final String name;
 	private final int[] itemID;
 	private final boolean damage;
+	private final boolean percentageHandle;
 	/**
 	 * Accepts an int representing distance in tiles to the target, and returns an int representing client cycles of
 	 * delay until the hitsplat is applied.
@@ -86,9 +87,9 @@ public enum SpecialWeapon
 	private final Function<Integer, Integer> clientCycleHitDelay;
 	private final Function<SpecialCounterConfig, Integer> threshold;
 
-	SpecialWeapon(final String name, final int[] itemID, final boolean damage, final Function<SpecialCounterConfig, Integer> threshold)
+	SpecialWeapon(final String name, final int[] itemID, final boolean damage, final boolean percentageHandle, final Function<SpecialCounterConfig, Integer> threshold)
 	{
-		this(name, itemID, damage, (distance) -> 0, threshold);
+		this(name, itemID, damage, percentageHandle, (distance) -> 0, threshold);
 	}
 
 	/**


### PR DESCRIPTION
- Converts Elder Maul/Dragon Warhammer counters to a combined percent drained infobox

- FIxes Elder maul occasionally showing or missing a hit when a thrall is a specific distance

- Tracks 0 Hitsplats on tekton for the hammer, maul and bgs
Maul/Hammer drain 5%
BGS drains a flat 10



Current Behavior

https://github.com/runelite/runelite/assets/63735241/185bcbd4-4452-47f1-9857-23108269a1b4



New Behavior

https://github.com/runelite/runelite/assets/63735241/18c50be3-341d-41e0-859d-69eb7fe6fb44



