### PR TITLE
xptracker: add one-tick delay to tracker initialization

### DIFF
--- a/runelite-client/src/test/java/net/runelite/client/plugins/xptracker/XpTrackerPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/xptracker/XpTrackerPluginTest.java
@@ -103,6 +103,7 @@ public class XpTrackerPluginTest
 		when(client.getSkillExperience(Skill.ATTACK)).thenReturn(42);
 		// Initialize tracker
 		xpTrackerPlugin.onGameTick(new GameTick());
+		xpTrackerPlugin.onGameTick(new GameTick());
 
 		// Gain attack xp
 		StatChanged statChanged = new StatChanged(
@@ -118,6 +119,7 @@ public class XpTrackerPluginTest
 		// Flag initialization of tracker
 		xpTrackerPlugin.onGameStateChanged(gameStateChanged);
 		// Initialize tracker
+		xpTrackerPlugin.onGameTick(new GameTick());
 		xpTrackerPlugin.onGameTick(new GameTick());
 
 		// Start at 42 xp, gain of 58 xp, offline gain of 41900 xp - offset start XP: 42 + 41900


### PR DESCRIPTION
Adds a one tick delay to XP Tracker initialization to prevent the tracker from erroneously showing an account's total as having been gained if logging into high-population areas. 

This should close #17910 