### PR TITLE
worldhopper: add Bounty Hunter option to world type filter

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldTypeFilter.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldTypeFilter.java
@@ -36,7 +36,7 @@ enum WorldTypeFilter
 			@Override
 			boolean matches(Set<WorldType> types)
 			{
-				EnumSet<WorldType> normal = EnumSet.of(WorldType.MEMBERS, WorldType.BOUNTY, WorldType.SKILL_TOTAL, WorldType.LAST_MAN_STANDING);
+				EnumSet<WorldType> normal = EnumSet.of(WorldType.MEMBERS, WorldType.SKILL_TOTAL, WorldType.LAST_MAN_STANDING);
 				EnumSet<WorldType> inverse = EnumSet.complementOf(normal);
 				return Sets.intersection(types, inverse).isEmpty();
 			}
@@ -95,6 +95,14 @@ enum WorldTypeFilter
 			boolean matches(Set<WorldType> types)
 			{
 				return types.contains(WorldType.HIGH_RISK);
+			}
+		},
+	BOUNTY_HUNTER
+		{
+			@Override
+			boolean matches(Set<WorldType> types)
+			{
+				return types.contains(WorldType.BOUNTY);
 			}
 		};
 


### PR DESCRIPTION
Adds a Bounty Hunter filter option and removes Bounty Hunter worlds from the "normal" world type filter.

Resolves #17960 