### PR TITLE
spec counter: make accursed sceptre instantly send hit

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/specialcounter/SpecialCounterPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/specialcounter/SpecialCounterPlugin.java
@@ -224,7 +224,7 @@ public class SpecialCounterPlugin extends Plugin
 
 		final int tickCount = client.getTickCount();
 
-		if (specialWeapon == SpecialWeapon.ELDER_MAUL)
+		if (specialWeapon == SpecialWeapon.ELDER_MAUL || specialWeapon == SpecialWeapon.ACCURSED_SCEPTRE)
 		{
 			// We do not wait for the hitsplat and instead go immediately
 			specialAttackHit(specialWeapon, lastSpecHpChange ? 1 : 0, lastSpecTarget);


### PR DESCRIPTION
The accursed sceptre's projectile is very slow, which makes it susceptible to being wrong when the player also has a thrall up. Making it instantly send the hit like how the elder maul does would fix this.