### PR TITLE
config: properly handle null defaults

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/config/ConfigManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/ConfigManager.java
@@ -1147,7 +1147,8 @@ public class ConfigManager
 			if (Strings.isNullOrEmpty(valueString))
 			{
 				unsetConfiguration(group.value(), item.keyName());
-			} else
+			}
+			else
 			{
 				setConfiguration(group.value(), item.keyName(), valueString);
 			}

--- a/runelite-client/src/main/java/net/runelite/client/config/ConfigManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/ConfigManager.java
@@ -1144,7 +1144,7 @@ public class ConfigManager
 
 			log.debug("Setting default configuration value for {}.{} to {}", group.value(), item.keyName(), defaultValue);
 
-			setConfiguration(group.value(), item.keyName(), valueString);
+			setConfiguration(group.value(), item.keyName(), valueString == null ? "" : valueString);
 		}
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/config/ConfigManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/ConfigManager.java
@@ -1144,7 +1144,13 @@ public class ConfigManager
 
 			log.debug("Setting default configuration value for {}.{} to {}", group.value(), item.keyName(), defaultValue);
 
-			setConfiguration(group.value(), item.keyName(), valueString == null ? "" : valueString);
+			if (Strings.isNullOrEmpty(valueString))
+			{
+				unsetConfiguration(group.value(), item.keyName());
+			} else
+			{
+				setConfiguration(group.value(), item.keyName(), valueString);
+			}
 		}
 	}
 


### PR DESCRIPTION
If a string config value is null by default, that value will get passed to 
`private void setConfiguration(ConfigData configData, String groupName, String profile, String key, @NonNull String value)`. 
The annotation will result in the following exception:

```
2024-07-03 11:44:17 PDT [AWT-EventQueue-0] ERROR net.runelite.client.RuneLite - Uncaught exception:
java.lang.NullPointerException: value is marked non-null but is null
	at net.runelite.client.config.ConfigManager.setConfiguration(ConfigManager.java:874)
	at net.runelite.client.config.ConfigManager.setConfiguration(ConfigManager.java:917)
	at net.runelite.client.config.ConfigManager.setDefaultConfiguration(ConfigManager.java:1147)
	at net.runelite.client.plugins.config.ConfigPanel.lambda$rebuild$5(ConfigPanel.java:423)
	at java.desktop/javax.swing.AbstractButton.fireActionPerformed(AbstractButton.java:1967)
	at java.desktop/javax.swing.AbstractButton$Handler.actionPerformed(AbstractButton.java:2308)
	at java.desktop/javax.swing.DefaultButtonModel.fireActionPerformed(DefaultButtonModel.java:405)
	at java.desktop/javax.swing.DefaultButtonModel.setPressed(DefaultButtonModel.java:262)
	at java.desktop/javax.swing.plaf.basic.BasicButtonListener.mouseReleased(BasicButtonListener.java:279)
	at java.desktop/java.awt.Component.processMouseEvent(Component.java:6635)
	at java.desktop/javax.swing.JComponent.processMouseEvent(JComponent.java:3342)
	at java.desktop/java.awt.Component.processEvent(Component.java:6400)
	at java.desktop/java.awt.Container.processEvent(Container.java:2263)
	at java.desktop/java.awt.Component.dispatchEventImpl(Component.java:5011)
	at java.desktop/java.awt.Container.dispatchEventImpl(Container.java:2321)
	at java.desktop/java.awt.Component.dispatchEvent(Component.java:4843)
	at java.desktop/java.awt.LightweightDispatcher.retargetMouseEvent(Container.java:4918)
	at java.desktop/java.awt.LightweightDispatcher.processMouseEvent(Container.java:4547)
	at java.desktop/java.awt.LightweightDispatcher.dispatchEvent(Container.java:4488)
	at java.desktop/java.awt.Container.dispatchEventImpl(Container.java:2307)
	at java.desktop/java.awt.Window.dispatchEventImpl(Window.java:2772)
	at java.desktop/java.awt.Component.dispatchEvent(Component.java:4843)
	at java.desktop/java.awt.EventQueue.dispatchEventImpl(EventQueue.java:772)
	at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:721)
	at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:715)
	at java.base/java.security.AccessController.doPrivileged(Native Method)
	at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:85)
	at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:95)
	at java.desktop/java.awt.EventQueue$5.run(EventQueue.java:745)
	at java.desktop/java.awt.EventQueue$5.run(EventQueue.java:743)
	at java.base/java.security.AccessController.doPrivileged(Native Method)
	at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:85)
	at java.desktop/java.awt.EventQueue.dispatchEvent(EventQueue.java:742)
	at java.desktop/java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:203)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:124)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:113)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:109)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:101)
	at java.desktop/java.awt.EventDispatchThread.run(EventDispatchThread.java:90)
```

The exception results in the reset failing. This pull request converts the null value to an empty string to prevent this exception.