### PR TITLE
cannon: adding cannon spot for warped creatures, tested as 55k slayer xp/hr

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonSpots.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonSpots.java
@@ -72,6 +72,7 @@ enum CannonSpots
 	SPIDER(new WorldPoint(3169, 3886, 0)),
 	SUQAHS(new WorldPoint(2114, 3943, 0)),
 	TROLLS(new WorldPoint(2401, 3856, 0), new WorldPoint(1242, 3517, 0)),
+	WARPED_CREATURES(new WorldPoint(1490, 4263, 1)),
 	ZOMBIE(new WorldPoint(3172, 3677, 0));
 
 	@Getter


### PR DESCRIPTION
Adding the following cannon spot for warped creatures.

![image](https://github.com/runelite/runelite/assets/87079399/7ee9886e-ce85-4f3b-9f15-3998f3898c69)

Personal testing has returned 55k slayer xp/hour using this spot.