### PR TITLE
Make it easier to expand/close config sections.

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
@@ -318,7 +318,7 @@ class ConfigPanel extends PluginPanel
 			final MouseAdapter adapter = new MouseAdapter()
 			{
 				@Override
-				public void mouseClicked(MouseEvent e)
+				public void mousePressed(MouseEvent e)
 				{
 					toggleSection(csd, sectionToggle, sectionContents);
 				}


### PR DESCRIPTION
Currently you must mouse up on the exact same pixel as you mouse down, unless you are clicking the tiny ">" or "v" button. This makes it hard to open or close these sections.