### PR TITLE
Convert party names to lower case upon text entry

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/party/PartyPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/party/PartyPanel.java
@@ -33,6 +33,7 @@ import java.awt.Toolkit;
 import java.awt.datatransfer.Clipboard;
 import java.awt.datatransfer.StringSelection;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import javax.swing.BoxLayout;
 import javax.swing.JButton;
@@ -159,7 +160,7 @@ class PartyPanel extends PluginPanel
 					null,
 					null,
 					"");
-				s = s.toLowerCase()
+				s = s.toLowerCase(Locale.US)
 
 				if (s == null)
 				{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/party/PartyPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/party/PartyPanel.java
@@ -159,6 +159,7 @@ class PartyPanel extends PluginPanel
 					null,
 					null,
 					"");
+				s = s.toLowerCase()
 
 				if (s == null)
 				{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/party/PartyPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/party/PartyPanel.java
@@ -160,7 +160,7 @@ class PartyPanel extends PluginPanel
 					null,
 					null,
 					"");
-				s = s.toLowerCase(Locale.US)
+				s = s.toLowerCase(Locale.US);
 
 				if (s == null)
 				{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/party/PartyPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/party/PartyPanel.java
@@ -160,12 +160,13 @@ class PartyPanel extends PluginPanel
 					null,
 					null,
 					"");
-				s = s.toLowerCase(Locale.US);
 
 				if (s == null)
 				{
 					return;
 				}
+
+				s = s.toLowerCase(Locale.US);
 
 				for (int i = 0; i < s.length(); ++i)
 				{


### PR DESCRIPTION
There is a long-standing issue where OSRS capitalizes the first letter of a message, so users join parties with incorrect capitalization.

https://github.com/TheStonedTurtle/party-panel/issues/27

The current solution is all users just agree to always use all lower case party names, but this is very confusing. We should just standardize that in Runelite by converting everything to lower case.

Then when this is merged I can propagate that change to https://github.com/TheStonedTurtle/party-panel/pull/35
