### PR TITLE
chat-types: add npc_say chattype

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/ChatMessageType.java
+++ b/runelite-api/src/main/java/net/runelite/api/ChatMessageType.java
@@ -190,6 +190,10 @@ public enum ChatMessageType
 	 */
 	MESBOX(115),
 	/**
+	 * Chat type for some npcs overhead text
+	 */
+	NPC_SAY(116),
+	/**
 	 * An unknown message type.
 	 */
 	UNKNOWN(-1);


### PR DESCRIPTION
With the release of While Guthix Sleeps a new ChatMessageType has appeared and it's used for some, newer, npcs speech such as:
* Nex
* Surok Magis