### PR TITLE
timers: add forinthry surge timer

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/SpriteID.java
+++ b/runelite-api/src/main/java/net/runelite/api/SpriteID.java
@@ -1088,7 +1088,7 @@ public final class SpriteID
 	public static final int GE_NUMBER_FIELD_EDGE_RIGHT = 1125;
 	public static final int GE_CANCEL_OFFER_BUTTON = 1126;
 	public static final int GE_CANCEL_OFFER_BUTTON_HOVERED = 1127;
-	public static final int DIALOG_BONDS_MEMBERSHIP_JEWEL = 1128;
+	public static final int FORINTHRY_SURGE = 1128;
 	public static final int DIALOG_BONDS_MEMBERSHIP_JEWEL_SMALL = 1129;
 	public static final int WORLD_SWITCHER_STAR_FREE = 1130;
 	public static final int WORLD_SWITCHER_STAR_MEMBERS = 1131;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timersandbuffs/GameTimer.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timersandbuffs/GameTimer.java
@@ -103,6 +103,7 @@ enum GameTimer
 	GOADING(ItemID._4DOSEGOADING, GameTimerImageType.ITEM, "Goading potion", false),
 	PRAYER_REGENERATION(ItemID._4DOSE1PRAYER_REGENERATION, GameTimerImageType.ITEM, "Prayer regeneration", false),
 	SURGE_POTION(ItemID._4DOSESURGE, GameTimerImageType.ITEM, "Surge potion", false),
+	FORINTHRY_SURGE(SpriteID.FORINTHRY_SURGE, GameTimerImageType.SPRITE, "Forinthry surge", false),
 	;
 
 	@Nullable

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timersandbuffs/TimersAndBuffsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timersandbuffs/TimersAndBuffsConfig.java
@@ -532,4 +532,15 @@ public interface TimersAndBuffsConfig extends Config
 	{
 		return true;
 	}
+
+	@ConfigItem(
+		keyName = "showForinthrySurge",
+		name = "Forinthry Surge timer",
+		description = "Configures whether forinthry surge timer is displayed",
+		section = miscellaneousSection
+	)
+	default boolean showForinthrySurge()
+	{
+		return true;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timersandbuffs/TimersAndBuffsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timersandbuffs/TimersAndBuffsPlugin.java
@@ -174,8 +174,12 @@ public class TimersAndBuffsPlugin extends Plugin
 	{
 		if (config.showHomeMinigameTeleports())
 		{
-			checkTeleport(VarPlayerID.AIDE_TELE_TIMER);
-			checkTeleport(VarPlayerID.SLUG2_REGIONUID);
+			checkEpochTimer(VarPlayerID.AIDE_TELE_TIMER);
+			checkEpochTimer(VarPlayerID.SLUG2_REGIONUID);
+		}
+		if (config.showForinthrySurge())
+		{
+			checkEpochTimer(VarPlayerID.REVENANT_REWARD_TIMED_BUFF_END);
 		}
 	}
 
@@ -401,12 +405,17 @@ public class TimersAndBuffsPlugin extends Plugin
 
 		if (event.getVarpId() == VarPlayerID.AIDE_TELE_TIMER && config.showHomeMinigameTeleports())
 		{
-			checkTeleport(VarPlayerID.AIDE_TELE_TIMER);
+			checkEpochTimer(VarPlayerID.AIDE_TELE_TIMER);
 		}
 
 		if (event.getVarpId() == VarPlayerID.SLUG2_REGIONUID && config.showHomeMinigameTeleports())
 		{
-			checkTeleport(VarPlayerID.SLUG2_REGIONUID);
+			checkEpochTimer(VarPlayerID.SLUG2_REGIONUID);
+		}
+
+		if (event.getVarpId() == VarPlayerID.REVENANT_REWARD_TIMED_BUFF_END && config.showForinthrySurge())
+		{
+			checkEpochTimer(VarPlayerID.REVENANT_REWARD_TIMED_BUFF_END);
 		}
 
 		if (event.getVarbitId() == VarbitID.STAMINA_ACTIVE
@@ -688,8 +697,17 @@ public class TimersAndBuffsPlugin extends Plugin
 		}
 		else
 		{
-			checkTeleport(VarPlayerID.AIDE_TELE_TIMER);
-			checkTeleport(VarPlayerID.SLUG2_REGIONUID);
+			checkEpochTimer(VarPlayerID.AIDE_TELE_TIMER);
+			checkEpochTimer(VarPlayerID.SLUG2_REGIONUID);
+		}
+
+		if (!config.showForinthrySurge())
+		{
+			removeGameTimer(FORINTHRY_SURGE);
+		}
+		else
+		{
+			checkEpochTimer(VarPlayerID.REVENANT_REWARD_TIMED_BUFF_END);
 		}
 
 		if (!config.showAntiFire())
@@ -1161,34 +1179,38 @@ public class TimersAndBuffsPlugin extends Plugin
 		}
 	}
 
-	private void checkTeleport(@Varp int varPlayer)
+	private void checkEpochTimer(@Varp int varPlayer)
 	{
-		final GameTimer teleport;
+		final GameTimer timer;
 		switch (varPlayer)
 		{
 			case VarPlayerID.AIDE_TELE_TIMER:
-				teleport = HOME_TELEPORT;
+				timer = HOME_TELEPORT;
 				break;
 			case VarPlayerID.SLUG2_REGIONUID:
-				teleport = MINIGAME_TELEPORT;
+				timer = MINIGAME_TELEPORT;
+				break;
+			case VarPlayerID.REVENANT_REWARD_TIMED_BUFF_END:
+				timer = FORINTHRY_SURGE;
 				break;
 			default:
-				// Other var changes are not handled as teleports
+				// Other var changes are not handled as epoch timers
 				return;
 		}
 
-		int lastTeleport = client.getVarpValue(varPlayer);
-		long lastTeleportSeconds = (long) lastTeleport * 60;
-		Instant teleportExpireInstant = Instant.ofEpochSecond(lastTeleportSeconds).plus(teleport.getDuration());
-		Duration remainingTime = Duration.between(Instant.now(), teleportExpireInstant);
+		int varpValue = client.getVarpValue(varPlayer);
+		long epoch = (long) varpValue * 60;
+		Duration effectDuration = timer.getDuration() != null ? timer.getDuration() : Duration.ZERO;
+		Instant timerExpireInstant = Instant.ofEpochSecond(epoch).plus(effectDuration);
+		Duration remainingTime = Duration.between(Instant.now(), timerExpireInstant);
 
 		if (remainingTime.getSeconds() > 0)
 		{
-			createGameTimer(teleport, remainingTime);
+			createGameTimer(timer, remainingTime);
 		}
 		else
 		{
-			removeGameTimer(teleport);
+			removeGameTimer(timer);
 		}
 	}
 


### PR DESCRIPTION
This PR adds a Forinthry surge timer to the Timers plugin.


The sprite chosen for this timer is the one used by the enhanced client, instead of the special skull many might associate with the buff.

<details>
  <summary>Sprite comparison</summary>

Buff sprite (ID 1128, left), skull sprite (ID 526, right)
![image](https://github.com/user-attachments/assets/cca51a54-74e2-4d03-a96a-c91a5f0103b5)

On enhanced client:
![image](https://github.com/user-attachments/assets/b9037a60-dfeb-4ef8-ac53-eba03a4b4c9a)
  
</details>

Ref #16169 