### PR TITLE
gpu: regions: add various underground areas

### DIFF
--- a/runelite-client/src/main/resources/net/runelite/client/plugins/gpu/regions/regions.txt
+++ b/runelite-client/src/main/resources/net/runelite/client/plugins/gpu/regions/regions.txt
@@ -286,3 +286,25 @@ r 37 148
 // viyeldi caves
 n
 r 37 73
+
+// baba yaga's hut
+n
+m 38 72
+C 2 4 2 5
+
+// vyre mines
+n
+m 37 72
+C 1 1 3 3
+
+// jiggig
+n
+R 38 146 38 147
+
+// smoke devil dungeon
+n
+R 36 147 37 147
+
+// observatory dungeon
+n
+r 36 146

--- a/runelite-client/src/main/resources/net/runelite/client/plugins/gpu/regions/regions.txt
+++ b/runelite-client/src/main/resources/net/runelite/client/plugins/gpu/regions/regions.txt
@@ -278,3 +278,11 @@ C 6 3 7 4
 n
 R 46 78 47 79
 r 47 77
+
+// castle wars underground
+n
+r 37 148
+
+// viyeldi caves
+n
+r 37 73


### PR DESCRIPTION
Adds GPU regions for the following:
- Castle Wars underground/lobbies
- Viyeldi caves
- Baba Yaga's hut
- Vyre mines
- Jiggig
- Smoke Devil Dungeon
- Observatory Dungeon