### PR TITLE
Add Boolean to ConfigSection for Development Mode Only Rendering

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/config/ConfigSection.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/ConfigSection.java
@@ -40,4 +40,6 @@ public @interface ConfigSection
 	int position();
 
 	boolean closedByDefault() default false;
+
+	boolean developmentModeOnly() default false;
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
@@ -47,6 +47,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import javax.inject.Inject;
+import javax.inject.Named;
 import javax.inject.Provider;
 import javax.swing.BorderFactory;
 import javax.swing.BoxLayout;
@@ -149,6 +150,8 @@ class ConfigPanel extends PluginPanel
 
 	private PluginConfigurationDescriptor pluginConfig = null;
 
+	private final boolean developerMode;
+
 	@Inject
 	private ConfigPanel(
 		PluginListPanel pluginList,
@@ -156,7 +159,8 @@ class ConfigPanel extends PluginPanel
 		PluginManager pluginManager,
 		ExternalPluginManager externalPluginManager,
 		ColorPickerManager colorPickerManager,
-		Provider<NotificationPanel> notificationPanelProvider
+		Provider<NotificationPanel> notificationPanelProvider,
+		@Named("developerMode") final boolean developerMode
 	)
 	{
 		super(false);
@@ -167,6 +171,7 @@ class ConfigPanel extends PluginPanel
 		this.externalPluginManager = externalPluginManager;
 		this.colorPickerManager = colorPickerManager;
 		this.notificationPanelProvider = notificationPanelProvider;
+		this.developerMode = developerMode;
 
 		setLayout(new BorderLayout());
 		setBackground(ColorScheme.DARK_GRAY_COLOR);
@@ -275,6 +280,12 @@ class ConfigPanel extends PluginPanel
 		for (ConfigSectionDescriptor csd : cd.getSections())
 		{
 			ConfigSection cs = csd.getSection();
+
+			if (cs.developmentModeOnly() && !developerMode)
+			{
+				continue;
+			}
+
 			final boolean isOpen = sectionExpandStates.getOrDefault(csd, !cs.closedByDefault());
 
 			final JPanel section = new JPanel();


### PR DESCRIPTION
Added a boolean in the ConfigSection to render this section only in development mode. This feature is useful for displaying configs in Development Mode allowing for easier plugin debugging.