### PR TITLE
Prevent showing both a timer and an uncalibrated info box

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/npcunaggroarea/NpcAggroAreaPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npcunaggroarea/NpcAggroAreaPlugin.java
@@ -464,6 +464,7 @@ public class NpcAggroAreaPlugin extends Plugin
 			safeCenters[0] = null;
 			safeCenters[1] = null;
 			lastPlayerLocation = newLocation;
+			infoBoxManager.removeIf(AggressionTimer.class::isInstance);
 		}
 	}
 


### PR DESCRIPTION
See this [PR](https://github.com/runelite/runelite/pull/18031) for testing context. This change should simply make it so that we don't show both the timer and the uncalibrated info box. 