### PR TITLE
Added "Bag full of gems" to Loot Tracker.

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
@@ -266,6 +266,10 @@ public class LootTrackerPlugin extends Plugin
 
 	private static final String WINTERTODT_SUPPLY_CRATE_EVENT = "Supply crate (Wintertodt)";
 
+	private static final String BAG_FULL_OF_GEMS_EVENT = "Bag full of gems (Percy)";
+	private static final String BAG_FULL_OF_GEMS_24853_EVENT = "Bag full of gems (Belona)";
+	private static final String BAG_FULL_OF_GEMS_25537_EVENT = "Bag full of gems (Dusuri)";
+
 	// Soul Wars
 	private static final String SPOILS_OF_WAR_EVENT = "Spoils of war";
 	private static final Set<Integer> SOUL_WARS_REGIONS = ImmutableSet.of(8493, 8749, 9005);
@@ -1204,6 +1208,15 @@ public class LootTrackerPlugin extends Plugin
 				{
 					case ItemID.CASKET:
 						onInvChange(collectInvItems(LootRecordType.EVENT, CASKET_EVENT));
+						break;
+					case ItemID.BAG_FULL_OF_GEMS:
+						onInvChange(collectInvAndGroundItems(LootRecordType.EVENT, BAG_FULL_OF_GEMS_EVENT));
+						break;
+					case ItemID.BAG_FULL_OF_GEMS_24853:
+						onInvChange(collectInvAndGroundItems(LootRecordType.EVENT, BAG_FULL_OF_GEMS_24853_EVENT));
+						break;
+					case ItemID.BAG_FULL_OF_GEMS_25537:
+						onInvChange(collectInvAndGroundItems(LootRecordType.EVENT, BAG_FULL_OF_GEMS_25537_EVENT));
 						break;
 					case ItemID.SUPPLY_CRATE:
 					case ItemID.EXTRA_SUPPLY_CRATE:

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
@@ -266,9 +266,9 @@ public class LootTrackerPlugin extends Plugin
 
 	private static final String WINTERTODT_SUPPLY_CRATE_EVENT = "Supply crate (Wintertodt)";
 
-	private static final String BAG_FULL_OF_GEMS_EVENT = "Bag full of gems (Percy)";
-	private static final String BAG_FULL_OF_GEMS_24853_EVENT = "Bag full of gems (Belona)";
-	private static final String BAG_FULL_OF_GEMS_25537_EVENT = "Bag full of gems (Dusuri)";
+	private static final String BAG_FULL_OF_GEMS_PERCY_EVENT = "Bag full of gems (Percy)";
+	private static final String BAG_FULL_OF_GEMS_BELONA_EVENT = "Bag full of gems (Belona)";
+	private static final String BAG_FULL_OF_GEMS_DUSURI_EVENT = "Bag full of gems (Dusuri)";
 
 	// Soul Wars
 	private static final String SPOILS_OF_WAR_EVENT = "Spoils of war";
@@ -1210,13 +1210,13 @@ public class LootTrackerPlugin extends Plugin
 						onInvChange(collectInvItems(LootRecordType.EVENT, CASKET_EVENT));
 						break;
 					case ItemID.BAG_FULL_OF_GEMS:
-						onInvChange(collectInvAndGroundItems(LootRecordType.EVENT, BAG_FULL_OF_GEMS_EVENT));
+						onInvChange(collectInvAndGroundItems(LootRecordType.EVENT, BAG_FULL_OF_GEMS_PERCY_EVENT));
 						break;
 					case ItemID.BAG_FULL_OF_GEMS_24853:
-						onInvChange(collectInvAndGroundItems(LootRecordType.EVENT, BAG_FULL_OF_GEMS_24853_EVENT));
+						onInvChange(collectInvAndGroundItems(LootRecordType.EVENT, BAG_FULL_OF_GEMS_BELONA_EVENT));
 						break;
 					case ItemID.BAG_FULL_OF_GEMS_25537:
-						onInvChange(collectInvAndGroundItems(LootRecordType.EVENT, BAG_FULL_OF_GEMS_25537_EVENT));
+						onInvChange(collectInvAndGroundItems(LootRecordType.EVENT, BAG_FULL_OF_GEMS_DUSURI_EVENT));
 						break;
 					case ItemID.SUPPLY_CRATE:
 					case ItemID.EXTRA_SUPPLY_CRATE:


### PR DESCRIPTION
There are three different ItemIDs for the item "Bag full of gems". The wiki page only has percentages from a moderately sized sample of bags from one of the three sources. I asked in the OSRS Wiki Discord server if this was something that could be crowdsourced, as well as if the three bags should have separate drop tables, and it was suggested that this might be functionality worth adding to Loot Tracker.

Here's the wiki page for Bag full of gems: [Link to wiki page.](https://oldschool.runescape.wiki/w/Bag_full_of_gems)

I've added that functionality. The three different bags will now show up in Loot Tracker as "Bag full of gems (Dusuri)", "Bag full of gems (Percy)", and "Bag full of gems (Belona)".

![Bagfullofgemsloottracker](https://github.com/user-attachments/assets/afc12082-db27-4370-8769-b5fc86766e51)
