### PR TITLE
attack styles: fix auto retaliate race condition

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/attackstyles/AttackStylesPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/attackstyles/AttackStylesPlugin.java
@@ -133,8 +133,8 @@ public class AttackStylesPlugin extends Plugin
 		{
 			updateWidgetsToHide(false);
 			processWidgets();
+			hideWidget(client.getWidget(ComponentID.COMBAT_AUTO_RETALIATE), false);
 		});
-		hideWidget(client.getWidget(ComponentID.COMBAT_AUTO_RETALIATE), false);
 		warnedSkills.clear();
 	}
 


### PR DESCRIPTION
This PR fixes a bug with the Attack Styles plugin, where the 'Auto Retaliate' widget remains hidden on plugin shutdown if the option to hide it is enabled.