### PR TITLE
Fix: amulet of chemistry notify message 

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemcharges/ItemChargePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemcharges/ItemChargePlugin.java
@@ -307,7 +307,7 @@ public class ItemChargePlugin extends Plugin
 			}
 			else if (amuletOfChemistryBreakMatcher.find())
 			{
-				notifier.notify(config.amuletOfChemistryNotification(), "Your Amulet of Chemistry has crumbled to dust.");
+				notifier.notify(config.amuletOfChemistryNotification(), "Your amulet of chemistry has crumbled to dust.");
 
 				updateAmuletOfChemistryCharges(MAX_AMULET_OF_CHEMISTRY_CHARGES);
 			}


### PR DESCRIPTION
the notify message for amulet of chemistry running out of charges has two letters capitalized where they should not be. 
![image](https://github.com/user-attachments/assets/b6a428c1-915d-4a06-91a1-b463c2912932)

This commit fixes that, bringing the message in line with how amulet of chemistry is referred to by jagex.