### PR TITLE
Update Skill Calculator - Making Pyre Logs Firemaking Skilling Actions

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/skills/FiremakingAction.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/skills/FiremakingAction.java
@@ -37,8 +37,8 @@ import net.runelite.client.game.ItemManager;
 public enum FiremakingAction implements ItemSkillAction
 {
 	SACRED_OIL_2(ItemID.SACRED_OIL2, "Applying Sacred oil(2)", 1, 10, FiremakingMethod.SACRED_OIL),
-	SACRED_OIL_3(ItemID.SACRED_OIL3, "Applying Sacred oil(3)", 1, 12, FiremakingMethod.SACRED_OIL),
-	SACRED_OIL_4(ItemID.SACRED_OIL4, "Applying Sacred oil(4)", 1, 16, FiremakingMethod.SACRED_OIL),
+	SACRED_OIL_3(ItemID.SACRED_OIL3, "Applying Sacred oil(3)", 1, 15, FiremakingMethod.SACRED_OIL),
+	SACRED_OIL_4(ItemID.SACRED_OIL4, "Applying Sacred oil(4)", 1, 20, FiremakingMethod.SACRED_OIL),
 	ACHEY_TREE_LOGS(ItemID.ACHEY_TREE_LOGS, 1, 40, FiremakingMethod.NORMAL_LOGS),
 	LOGS(ItemID.LOGS, 1, 40, FiremakingMethod.NORMAL_LOGS),
 	PYRE_LOGS(ItemID.PYRE_LOGS, 5, 50, FiremakingMethod.PYRE_LOGS),


### PR DESCRIPTION
Update Skill Calculator Firemaking XP of "Making Pyre Logs" actions to be a flat 5 XP per dose of Sacred Oil consumed, instead of a variable rate based on how many doses are in the vial.
In line with [31 July 2024 Update](https://secure.runescape.com/m=news/a=13/qol-improvements--further-deadman-armageddon-tweaks?oldschool=1)