### PR TITLE
crowdsourcing: check for null ptr for username

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/crowdsourcing/dialogue/CrowdsourcingDialogue.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/crowdsourcing/dialogue/CrowdsourcingDialogue.java
@@ -136,8 +136,9 @@ public class CrowdsourcingDialogue
 	@Subscribe
 	public void onChatMessage(ChatMessage chatMessage)
 	{
-		if (chatMessage.getType() == ChatMessageType.DIALOG
-		|| chatMessage.getType() == ChatMessageType.MESBOX)
+		if ((chatMessage.getType() == ChatMessageType.DIALOG
+			|| chatMessage.getType() == ChatMessageType.MESBOX)
+			&& client.getLocalPlayer().getName() != null)
 		{
 			ChatMessageData data = new ChatMessageData(sanitize(chatMessage.getMessage()), chatMessage.getType());
 			manager.storeEvent(data);


### PR DESCRIPTION
Checks for a null pointer for logged in player's name
otherwise preserves the current behavior of sanitize() 
fixes #18111