### PR TITLE
Ground item despawn warning

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
@@ -32,6 +32,7 @@ import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
 import net.runelite.client.config.ConfigSection;
 import net.runelite.client.config.Keybind;
+import net.runelite.client.config.Range;
 import net.runelite.client.config.Units;
 import net.runelite.client.plugins.grounditems.config.DespawnTimerMode;
 import net.runelite.client.plugins.grounditems.config.HighlightTier;
@@ -73,7 +74,7 @@ public interface GroundItemsConfig extends Config
 
 	@ConfigItem(
 		keyName = "hiddenItems",
-		name = "Hidden Items",
+		name = "Hidden items",
 		description = "Configures hidden ground items. Format: (item), (item)",
 		position = 1,
 		section = itemLists
@@ -92,7 +93,7 @@ public interface GroundItemsConfig extends Config
 
 	@ConfigItem(
 		keyName = "showHighlightedOnly",
-		name = "Show Highlighted items only",
+		name = "Show highlighted items only",
 		description = "Configures whether or not to draw items only on your highlighted list",
 		position = 2
 	)
@@ -114,7 +115,7 @@ public interface GroundItemsConfig extends Config
 
 	@ConfigItem(
 		keyName = "showMenuItemQuantities",
-		name = "Show Menu Item Quantities",
+		name = "Show menu item quantities",
 		description = "Configures whether or not to show the item quantities in the menu",
 		position = 4
 	)
@@ -125,7 +126,7 @@ public interface GroundItemsConfig extends Config
 
 	@ConfigItem(
 		keyName = "recolorMenuHiddenItems",
-		name = "Recolor Menu Hidden Items",
+		name = "Recolor menu hidden items",
 		description = "Configures whether or not hidden items in right-click menu will be recolored",
 		position = 5
 	)
@@ -136,7 +137,7 @@ public interface GroundItemsConfig extends Config
 
 	@ConfigItem(
 		keyName = "deprioritizeHiddenItems",
-		name = "Deprioritize Menu Hidden Items",
+		name = "Deprioritize menu hidden items",
 		description = "Depriotizies the menu options for items which are hidden, requiring a right click to pick up.",
 		position = 5
 	)
@@ -147,7 +148,7 @@ public interface GroundItemsConfig extends Config
 
 	@ConfigItem(
 		keyName = "highlightTiles",
-		name = "Highlight Tiles",
+		name = "Highlight tiles",
 		description = "Configures whether or not to highlight tiles containing ground items",
 		position = 6
 	)
@@ -158,7 +159,7 @@ public interface GroundItemsConfig extends Config
 
 	@ConfigItem(
 		keyName = "notifyHighlightedDrops",
-		name = "Notify for Highlighted drops",
+		name = "Notify for highlighted drops",
 		description = "Configures whether or not to notify for drops on your highlighted list",
 		position = 7
 	)
@@ -180,7 +181,7 @@ public interface GroundItemsConfig extends Config
 
 	@ConfigItem(
 		keyName = "priceDisplayMode",
-		name = "Price Display Mode",
+		name = "Price display mode",
 		description = "Configures which price types are shown alongside ground item name",
 		position = 9
 	)
@@ -191,7 +192,7 @@ public interface GroundItemsConfig extends Config
 
 	@ConfigItem(
 		keyName = "itemHighlightMode",
-		name = "Item Highlight Mode",
+		name = "Item highlight mode",
 		description = "Configures how ground items will be highlighted",
 		position = 10
 	)
@@ -202,7 +203,7 @@ public interface GroundItemsConfig extends Config
 
 	@ConfigItem(
 		keyName = "menuHighlightMode",
-		name = "Menu Highlight Mode",
+		name = "Menu highlight mode",
 		description = "Configures what to highlight in right-click menu",
 		position = 11
 	)
@@ -213,7 +214,7 @@ public interface GroundItemsConfig extends Config
 
 	@ConfigItem(
 		keyName = "highlightValueCalculation",
-		name = "Highlight Value Calculation",
+		name = "Highlight value calculation",
 		description = "Configures which coin value is used to determine highlight color",
 		position = 12
 	)
@@ -397,7 +398,7 @@ public interface GroundItemsConfig extends Config
 
 	@ConfigItem(
 		keyName = "groundItemTimers",
-		name = "Despawn timer",
+		name = "Despawn timer style",
 		description = "Shows despawn timers for items you've dropped and received as loot",
 		position = 28
 	)
@@ -406,11 +407,25 @@ public interface GroundItemsConfig extends Config
 		return DespawnTimerMode.OFF;
 	}
 
+	@Range(
+		max = 90
+	)
+	@ConfigItem(
+		keyName = "despawnTimer",
+		name = "Despawn timer",
+		description = "Time remaining before a red despawn warning triggers. Max of 90 seconds. 0 to disable",
+		position = 29
+	)
+	default int despawnTimer()
+	{
+		return 45;
+	}
+
 	@ConfigItem(
 		keyName = "textOutline",
-		name = "Text Outline",
+		name = "Text outline",
 		description = "Use an outline around text instead of a text shadow",
-		position = 29
+		position = 30
 	)
 	default boolean textOutline()
 	{
@@ -421,7 +436,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "showLootbeamForHighlighted",
 		name = "Highlighted item lootbeams",
 		description = "Configures lootbeams to show for all highlighted items.",
-		position = 30
+		position = 31
 	)
 	default boolean showLootbeamForHighlighted()
 	{
@@ -432,7 +447,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "showLootbeamTier",
 		name = "Lootbeam tier",
 		description = "Configures which price tiers will trigger a lootbeam",
-		position = 31
+		position = 32
 	)
 	default HighlightTier showLootbeamTier()
 	{
@@ -441,9 +456,9 @@ public interface GroundItemsConfig extends Config
 
 	@ConfigItem(
 		keyName = "lootbeamStyle",
-		name = "Lootbeam Style",
+		name = "Lootbeam style",
 		description = "Style of lootbeam to use",
-		position = 32
+		position = 33
 	)
 	default Lootbeam.Style lootbeamStyle()
 	{
@@ -454,7 +469,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "hotkey",
 		name = "Hotkey",
 		description = "Configures the hotkey used by the Ground Items plugin",
-		position = 33
+		position = 34
 	)
 	default Keybind hotkey()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
@@ -31,6 +31,7 @@ import java.awt.FontMetrics;
 import java.awt.Graphics2D;
 import java.awt.Polygon;
 import java.awt.Rectangle;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.AbstractMap.SimpleEntry;
 import java.util.ArrayList;
@@ -70,6 +71,8 @@ public class GroundItemsOverlay extends Overlay
 	private static final int RECTANGLE_SIZE = 8;
 	private static final Color PUBLIC_TIMER_COLOR = Color.YELLOW;
 	private static final Color PRIVATE_TIMER_COLOR = Color.GREEN;
+	private static final Color DESPAWN_TIMER_COLOR = Color.RED;
+	private static final Duration DESPAWN_WARNING = Duration.ofSeconds(30);
 	private static final int TIMER_OVERLAY_DIAMETER = 10;
 
 	private final Client client;
@@ -409,6 +412,7 @@ public class GroundItemsOverlay extends Overlay
 		}
 
 		final Instant now = Instant.now();
+		final Instant warningTime = spawnTime.plus(groundItem.getDespawnTime().minus(DESPAWN_WARNING));
 		final Instant despawnTime = spawnTime.plus(groundItem.getDespawnTime());
 
 		if (groundItem.isPrivate())
@@ -427,9 +431,13 @@ public class GroundItemsOverlay extends Overlay
 		{
 			return PRIVATE_TIMER_COLOR;
 		}
-		if (despawnTime.isAfter(now))
+		if (warningTime.isAfter(now))
 		{
 			return PUBLIC_TIMER_COLOR;
+		}
+		if (despawnTime.isAfter(now))
+		{
+			return DESPAWN_TIMER_COLOR;
 		}
 
 		return null;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
@@ -412,14 +412,19 @@ public class GroundItemsOverlay extends Overlay
 		}
 
 		final Instant now = Instant.now();
-		final Instant warningTime = spawnTime.plus(groundItem.getDespawnTime().minus(DESPAWN_WARNING));
+		final Instant warningTime = spawnTime.plus(groundItem.getDespawnTime().minus(Duration.ofSeconds(config.despawnTimer())));
 		final Instant despawnTime = spawnTime.plus(groundItem.getDespawnTime());
 
 		if (groundItem.isPrivate())
 		{
-			if (despawnTime.isAfter(now))
+			if (warningTime.isAfter(now))
 			{
 				return PRIVATE_TIMER_COLOR;
+			}
+
+			if (despawnTime.isAfter(now))
+			{
+				return DESPAWN_TIMER_COLOR;
 			}
 
 			return null;


### PR DESCRIPTION
Adds a red "despawn warning" colour to the ground item despawn timer.

![image](https://github.com/user-attachments/assets/0f0fe7da-db81-4787-a966-36c378eb512e)
![image](https://github.com/user-attachments/assets/323c2d53-f92d-4b1d-8cbd-9daca5263611)
![image](https://github.com/user-attachments/assets/6066bbab-9d0b-4032-ac76-54f6b6150510)

Works with all despawn timer styles
![image](https://github.com/user-attachments/assets/d0b44ac4-0d94-4722-a661-354e9743cbfe)

Customisable duration
![image](https://github.com/user-attachments/assets/3d56f32f-e4ea-456c-b0a6-da62bf698181)
