### PR TITLE
screenshots: Add doom death screenshots

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
@@ -51,11 +51,13 @@ import net.runelite.api.ScriptID;
 import net.runelite.api.VarClientStr;
 import net.runelite.api.annotations.Component;
 import net.runelite.api.events.ActorDeath;
+import net.runelite.api.events.AnimationChanged;
 import net.runelite.api.events.ChatMessage;
 import net.runelite.api.events.GameTick;
 import net.runelite.api.events.ScriptCallbackEvent;
 import net.runelite.api.events.ScriptPreFired;
 import net.runelite.api.events.WidgetLoaded;
+import net.runelite.api.gameval.AnimationID;
 import net.runelite.api.gameval.InterfaceID;
 import net.runelite.api.gameval.SpriteID;
 import net.runelite.api.gameval.VarbitID;
@@ -311,6 +313,23 @@ public class ScreenshotPlugin extends Plugin
 				takeScreenshot("Death " + player.getName(), SD_DEATHS);
 			}
 		}
+	}
+
+	@Subscribe
+	public void onAnimationChanged(AnimationChanged animationChanged)
+	{
+		Actor actor = animationChanged.getActor();
+		if (actor instanceof Player)
+		{
+			Player player = (Player) actor;
+			if (player == client.getLocalPlayer()
+				&& player.getAnimation() == AnimationID.HUMAN_DOOM_SCORPION_01_PLAYER_DEATH_01
+				&& config.screenshotPlayerDeath())
+			{
+				takeScreenshot("Death", SD_DEATHS);
+			}
+		}
+
 	}
 
 	@Subscribe

--- a/runelite-client/src/test/java/net/runelite/client/plugins/screenshot/ScreenshotPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/screenshot/ScreenshotPluginTest.java
@@ -33,11 +33,14 @@ import static net.runelite.api.ChatMessageType.GAMEMESSAGE;
 import static net.runelite.api.ChatMessageType.TRADE;
 import net.runelite.api.Client;
 import net.runelite.api.ScriptID;
+import net.runelite.api.Player;
 import net.runelite.api.VarClientStr;
+import net.runelite.api.events.AnimationChanged;
 import net.runelite.api.events.ChatMessage;
 import net.runelite.api.events.GameTick;
 import net.runelite.api.events.ScriptPreFired;
 import net.runelite.api.events.WidgetLoaded;
+import net.runelite.api.gameval.AnimationID;
 import net.runelite.api.gameval.InterfaceID;
 import net.runelite.api.gameval.VarbitID;
 import net.runelite.api.widgets.Widget;
@@ -540,6 +543,22 @@ public class ScreenshotPluginTest
 		screenshotPlugin.onWidgetLoaded(widgetLoaded);
 
 		verify(screenshotPlugin).takeScreenshot("Loot key", "Wilderness Loot Chest");
+	}
+
+	@Test
+	public void testDoomDeath()
+	{
+		when(screenshotConfig.screenshotPlayerDeath()).thenReturn(true);
+
+		Player player = mock(Player.class);
+		when(player.getAnimation()).thenReturn(AnimationID.HUMAN_DOOM_SCORPION_01_PLAYER_DEATH_01);
+		when(client.getLocalPlayer()).thenReturn(player);
+
+		AnimationChanged animationChanged = new AnimationChanged();
+		animationChanged.setActor(player);
+		screenshotPlugin.onAnimationChanged(animationChanged);
+
+		verify(screenshotPlugin).takeScreenshot("Death", "Deaths");
 	}
 
 	@Test


### PR DESCRIPTION
resolves #17831 

Accidentally closed #18051 by force updating my change out of the source branch

Checks if the player enters the animation for a doom death and triggers a screenshot.

Tested with a death via doom manually:

![Death 2024-07-15_21-52-18](https://github.com/user-attachments/assets/120789d3-3f11-43f1-a43f-cbcc327ebacc)
