### PR TITLE
animsmoothing: add Demonbane spells, windmills to blocklist

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/AnimationID.java
+++ b/runelite-api/src/main/java/net/runelite/api/AnimationID.java
@@ -324,6 +324,7 @@ public final class AnimationID
 
 	// Arceuus spellbook
 	public static final int MAGIC_ARCEUUS_RESURRECT_CROPS = 7118;
+	public static final int MAGIC_ARCEUUS_DEMONBANE = 8977;    // Shared by all 3 Demonbane spells
 
 	// Battlestaff Crafting
 	public static final int CRAFTING_BATTLESTAVES = 7531;

--- a/runelite-api/src/main/java/net/runelite/api/AnimationID.java
+++ b/runelite-api/src/main/java/net/runelite/api/AnimationID.java
@@ -364,5 +364,8 @@ public final class AnimationID
 	public static final int VIGGORAS_CHAINMACE_IDLE = 244;
 
 	public static final int MLM_WATER_WHEEL_SPINNING = 1051;
+	public static final int HARMONY_ISLAND_WINDMILL_SPINNING = 5857;
+	public static final int GWENITH_WINDMILL_SPINNING = 6495;
+	public static final int LITHKREN_GENERATOR_SPINNING = 7898;
 	public static final int GIANTS_FOUNDRY_WATER_WHEEL_SPINNING = 9450;
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/animsmoothing/AnimationSmoothingPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/animsmoothing/AnimationSmoothingPlugin.java
@@ -77,6 +77,9 @@ public class AnimationSmoothingPlugin extends Plugin
 			case AnimationID.VIGGORAS_CHAINMACE_IDLE:
 
 			case AnimationID.MLM_WATER_WHEEL_SPINNING:
+			case AnimationID.HARMONY_ISLAND_WINDMILL_SPINNING:
+			case AnimationID.GWENITH_WINDMILL_SPINNING:
+			case AnimationID.LITHKREN_GENERATOR_SPINNING:
 			case AnimationID.GIANTS_FOUNDRY_WATER_WHEEL_SPINNING:
 
 			case AnimationID.MAGIC_ARCEUUS_DEMONBANE:

--- a/runelite-client/src/main/java/net/runelite/client/plugins/animsmoothing/AnimationSmoothingPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/animsmoothing/AnimationSmoothingPlugin.java
@@ -78,6 +78,8 @@ public class AnimationSmoothingPlugin extends Plugin
 
 			case AnimationID.MLM_WATER_WHEEL_SPINNING:
 			case AnimationID.GIANTS_FOUNDRY_WATER_WHEEL_SPINNING:
+
+			case AnimationID.MAGIC_ARCEUUS_DEMONBANE:
 				return false;
 
 			default:


### PR DESCRIPTION
Addresses what animations from #16371 I was personally able to verify were still problematic with animation smoothing enabled:
- Harmony Island and Gwenith windmills
- Lithkren generator 
- All 3 Arceuus spellbook Demonbane spells.