### PR TITLE
Add max cape menu entries

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -440,9 +440,23 @@ public interface MenuEntrySwapperConfig extends Config
 
 	enum Teleports
 	{
-		HOME("Home", ComponentID.ADVENTURE_LOG_OPTIONS, 6, 0),
+		WARRIORS_GUILD("Warrior's Guild", ComponentID.ADVENTURE_LOG_OPTIONS, 0),
+		FISHING_GUILD("Fishing Guild", ComponentID.ADVENTURE_LOG_OPTIONS, 1),
 		CRAFTING_GUILD("Crafting Guild", ComponentID.ADVENTURE_LOG_OPTIONS, 2),
-		WARRIORS_GUILD("Warriors' Guild", ComponentID.ADVENTURE_LOG_OPTIONS, 0),
+		FARMING_GUILD("Farming Guild", ComponentID.ADVENTURE_LOG_OPTIONS, 3),
+		OTTOS_GROTTO("Otto's Grotto", ComponentID.ADVENTURE_LOG_OPTIONS, 4),
+		RED_CHINS("Red Chinchompas", ComponentID.ADVENTURE_LOG_OPTIONS, 5, 1),
+		BLACK_CHINS("Black Chinchompas", ComponentID.ADVENTURE_LOG_OPTIONS, 5, 2),
+		HUNTER_GUILD("Hunter Guild", ComponentID.ADVENTURE_LOG_OPTIONS, 5, 3),
+		HOME("Home", ComponentID.ADVENTURE_LOG_OPTIONS, 6, 0),
+		RIMMINGTON("Rimmington", ComponentID.ADVENTURE_LOG_OPTIONS, 6, 1),
+		TAVERLEY("Taverley", ComponentID.ADVENTURE_LOG_OPTIONS, 6, 2),
+		POLLNIVNEACH("Pollnivneach", ComponentID.ADVENTURE_LOG_OPTIONS, 6, 3),
+		HOSIDIUS("Hosidius", ComponentID.ADVENTURE_LOG_OPTIONS, 6, 4),
+		RELLEKA("Rellekka", ComponentID.ADVENTURE_LOG_OPTIONS, 6, 5),
+		BRIMHAVEN("Brimhaven", ComponentID.ADVENTURE_LOG_OPTIONS, 6, 6),
+		YANILLE("Yanille", ComponentID.ADVENTURE_LOG_OPTIONS, 6, 7),
+		PRIFDDINAS("Prifddinas", ComponentID.ADVENTURE_LOG_OPTIONS, 6, 8),
 		;
 
 		final String name;
@@ -453,7 +467,7 @@ public interface MenuEntrySwapperConfig extends Config
 			this.name = name;
 			this.id = id;
 			this.ops = new int[ops.length];
-			System.arraycopy(ops, 0,this.ops, 0, ops.length);
+			System.arraycopy(ops, 0, this.ops, 0, ops.length);
 		}
 
 		@Override

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -24,6 +24,9 @@
  */
 package net.runelite.client.plugins.menuentryswapper;
 
+import java.util.Collections;
+import java.util.Set;
+import net.runelite.api.widgets.ComponentID;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
@@ -433,6 +436,41 @@ public interface MenuEntrySwapperConfig extends Config
 	default boolean teleportSubmenus()
 	{
 		return false;
+	}
+
+	enum Teleports
+	{
+		HOME("Home", ComponentID.ADVENTURE_LOG_OPTIONS, 6, 0),
+		CRAFTING_GUILD("Crafting Guild", ComponentID.ADVENTURE_LOG_OPTIONS, 2),
+		WARRIORS_GUILD("Warriors' Guild", ComponentID.ADVENTURE_LOG_OPTIONS, 0),
+		;
+
+		final String name;
+		final int id;
+		final int []ops;
+		Teleports(String name, int id, int ...ops)
+		{
+			this.name = name;
+			this.id = id;
+			this.ops = new int[ops.length];
+			System.arraycopy(ops, 0,this.ops, 0, ops.length);
+		}
+
+		@Override
+		public String toString()
+		{
+			return name;
+		}
+	}
+	@ConfigItem(
+		keyName = "teleportShorthands",
+		name = "Non submenu teleports",
+		description = "TODO",
+		section = itemSection
+	)
+	default Set<Teleports> teleportShorthands()
+	{
+		return Collections.emptySet();
 	}
 
 	@ConfigItem(

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/TeleportSwap.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/TeleportSwap.java
@@ -25,7 +25,9 @@
 package net.runelite.client.plugins.menuentryswapper;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 class TeleportSwap
 {
@@ -34,12 +36,28 @@ class TeleportSwap
 	String option;
 	List<TeleportSub> subs = new ArrayList<>();
 
+	Set<TeleportSub> shorthands = new HashSet<>();
+
 	TeleportSwap addSub(String option, Runnable r)
 	{
 		var sub = new TeleportSub();
 		sub.option = option;
 		sub.execute = r;
 		subs.add(sub);
+		return this;
+	}
+
+	void clearShorthands()
+	{
+		shorthands.clear();
+	}
+
+	TeleportSwap addOption(String option, Runnable r)
+	{
+		var sub = new TeleportSub();
+		sub.option = option;
+		sub.execute = r;
+		shorthands.add(sub);
 		return this;
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/TeleportSwap.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/TeleportSwap.java
@@ -25,9 +25,9 @@
 package net.runelite.client.plugins.menuentryswapper;
 
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.TreeSet;
 
 class TeleportSwap
 {
@@ -36,7 +36,7 @@ class TeleportSwap
 	String option;
 	List<TeleportSub> subs = new ArrayList<>();
 
-	Set<TeleportSub> shorthands = new HashSet<>();
+	Set<TeleportSub> shorthands = new TreeSet<>();
 
 	TeleportSwap addSub(String option, Runnable r)
 	{
@@ -74,8 +74,14 @@ class TeleportSwap
 	}
 }
 
-class TeleportSub
+class TeleportSub implements Comparable<TeleportSub>
 {
 	String option;
 	Runnable execute;
+
+	@Override
+	public int compareTo(TeleportSub other)
+	{
+		return option.compareTo(other.option);
+	}
 }


### PR DESCRIPTION
This patch adds "shorthands" for max cape teleports, an example can be seen below. 
![image](https://github.com/user-attachments/assets/fcac6898-e757-4b87-b578-431cfc23d400)
