### PR TITLE
slayer: add troll npc name variations

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/Task.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/Task.java
@@ -166,7 +166,7 @@ enum Task
 	THE_LEVIATHAN("The Leviathan", ItemID.LILVIATHAN),
 	THE_WHISPERER("The Whisperer", ItemID.WISP),
 	THERMONUCLEAR_SMOKE_DEVIL("The Thermonuclear Smoke Devil", ItemID.PET_SMOKE_DEVIL),
-	TROLLS("Trolls", ItemID.TROLL_GUARD, "Dad", "Arrg"),
+	TROLLS("Trolls", ItemID.TROLL_GUARD, "Dad", "Arrg", "Stick", "Kraka", "Pee Hat", "Rock", "Twig", "Berry"),
 	TUROTH("Turoth", ItemID.TUROTH),
 	TZHAAR("Tzhaar", ItemID.ENSOULED_TZHAAR_HEAD),
 	VAMPYRES("Vampyres", ItemID.STAKE, "Vyrewatch", "Vampire"),


### PR DESCRIPTION
This PR adds alternative troll NPC names to troll tasks:

- [Berry](https://oldschool.runescape.wiki/w/Berry)
- [Kraka](https://oldschool.runescape.wiki/w/Kraka)
- [Pee Hat](https://oldschool.runescape.wiki/w/Pee_Hat)
- [Rock](https://oldschool.runescape.wiki/w/Rock_(Troll))
- [Stick](https://oldschool.runescape.wiki/w/Stick)
- [Twig](https://oldschool.runescape.wiki/w/Twig)