### PR TITLE
bank: Display GE/HA price on item sprite via hotkey

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/bank/BankConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/bank/BankConfig.java
@@ -108,7 +108,7 @@ public interface BankConfig extends Config
 	@ConfigItem(
 		keyName = "showPriceOnItemKeybind",
 		name = "Price on Item shortcut",
-		description = "Keyboard shortcut for showing GE/HA value on item",
+		description = "Keyboard shortcut for initiating GE/HA values on item",
 		position = 7
 	)
 	default Keybind showItemPriceKeybind()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/bank/BankConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/bank/BankConfig.java
@@ -96,7 +96,7 @@ public interface BankConfig extends Config
 	@Alpha
 	@ConfigItem(
 		keyName = "haPerItemColor",
-		name = "Color for High alchemy price on Item",
+		name = "Color for high alchemy price on Item",
 		description = "Configures the color for high alchemy value shown on the item",
 		position = 6
 	)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/bank/BankConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/bank/BankConfig.java
@@ -25,8 +25,10 @@
  */
 package net.runelite.client.plugins.bank;
 
+import java.awt.Color;
 import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
+import net.runelite.client.config.Alpha;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
@@ -38,7 +40,7 @@ public interface BankConfig extends Config
 	@ConfigItem(
 		keyName = "showGE",
 		name = "Show Grand Exchange price",
-		description = "Show grand exchange price total (GE)",
+		description = "Show Grand Exchange price total (GE)",
 		position = 1
 	)
 	default boolean showGE()
@@ -47,10 +49,33 @@ public interface BankConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "showGEPerItem",
+		name = "Show Grand Exchange price on Item",
+		description = "Show Grand Exchange price total (GE) on the item. When GE and HA are both enabled, greater of the two is shown.",
+		position = 2
+	)
+	default boolean showGEPerItem()
+	{
+		return false;
+	}
+
+	@Alpha
+	@ConfigItem(
+		keyName = "gePerItemColor",
+		name = "Color for Grand Exchange price on Item",
+		description = "Configures the color for Grand Exchange value shown on the item",
+		position = 3
+	)
+	default Color gePerItemColor()
+	{
+		return Color.ORANGE;
+	}
+
+	@ConfigItem(
 		keyName = "showHA",
 		name = "Show high alchemy price",
 		description = "Show high alchemy price total (HA)",
-		position = 2
+		position = 4
 	)
 	default boolean showHA()
 	{
@@ -58,10 +83,44 @@ public interface BankConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "showHAPerItem",
+		name = "Show high alchemy price on Item",
+		description = "Show high alchemy price total (HA) on the item. When GE and HA are both enabled, greater of the two is shown.",
+		position = 5
+	)
+	default boolean showHAPerItem()
+	{
+		return false;
+	}
+
+	@Alpha
+	@ConfigItem(
+		keyName = "haPerItemColor",
+		name = "Color for High alchemy price on Item",
+		description = "Configures the color for high alchemy value shown on the item",
+		position = 6
+	)
+	default Color haPerItemColor()
+	{
+		return Color.CYAN;
+	}
+
+	@ConfigItem(
+		keyName = "showPriceOnItemKeybind",
+		name = "Price on Item shortcut",
+		description = "Keyboard shortcut for showing GE/HA value on item",
+		position = 7
+	)
+	default Keybind showItemPriceKeybind()
+	{
+		return new Keybind(KeyEvent.VK_UNDEFINED, InputEvent.ALT_DOWN_MASK);
+	}
+
+	@ConfigItem(
 		keyName = "showExact",
 		name = "Show exact bank value",
 		description = "Show exact bank value",
-		position = 3
+		position = 8
 	)
 	default boolean showExact()
 	{
@@ -72,7 +131,7 @@ public interface BankConfig extends Config
 		keyName = "rightClickBankInventory",
 		name = "Disable left click bank inventory",
 		description = "Configures whether the bank inventory button will bank your inventory on left click",
-		position = 4
+		position = 9
 	)
 	default boolean rightClickBankInventory()
 	{
@@ -83,7 +142,7 @@ public interface BankConfig extends Config
 		keyName = "rightClickBankEquip",
 		name = "Disable left click bank equipment",
 		description = "Configures whether the bank equipment button will bank your equipment on left click",
-		position = 5
+		position = 10
 	)
 	default boolean rightClickBankEquip()
 	{
@@ -94,7 +153,7 @@ public interface BankConfig extends Config
 		keyName = "rightClickBankLoot",
 		name = "Disable left click bank looting bag",
 		description = "Configures whether the bank looting bag button will bank your looting bag contents on left click",
-		position = 6
+		position = 11
 	)
 	default boolean rightClickBankLoot()
 	{
@@ -105,7 +164,7 @@ public interface BankConfig extends Config
 		keyName = "rightClickPlaceholders",
 		name = "Disable left click placeholders button",
 		description = "Configures whether the placeholders button will be toggled on left click",
-		position = 7
+		position = 12
 	)
 	default boolean rightClickPlaceholders()
 	{
@@ -116,7 +175,7 @@ public interface BankConfig extends Config
 		keyName = "seedVaultValue",
 		name = "Show seed vault value",
 		description = "Adds the total value of all seeds inside the seed vault to the title",
-		position = 8
+		position = 13
 	)
 	default boolean seedVaultValue()
 	{
@@ -127,7 +186,7 @@ public interface BankConfig extends Config
 		keyName = "bankPinKeyboard",
 		name = "Keyboard Bankpin",
 		description = "Allows using the keyboard keys for bank pin input",
-		position = 9
+		position = 14
 	)
 	default boolean bankPinKeyboard()
 	{
@@ -138,7 +197,7 @@ public interface BankConfig extends Config
 		keyName = "searchKeybind",
 		name = "Search Shortcut",
 		description = "Keyboard shortcut for initiating a bank or seed vault search",
-		position = 10
+		position = 15
 	)
 	default Keybind searchKeybind()
 	{
@@ -149,7 +208,7 @@ public interface BankConfig extends Config
 		keyName = "blockJagexAccountAd",
 		name = "Block Jagex Account popup",
 		description = "Blocks the weekly reminder to migrate to a Jagex account",
-		position = 11
+		position = 16
 	)
 	default boolean blockJagexAccountAd()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/bank/BankOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/bank/BankOverlay.java
@@ -1,0 +1,89 @@
+package net.runelite.client.plugins.bank;
+
+import com.google.inject.Inject;
+import net.runelite.api.ItemID;
+import net.runelite.api.widgets.WidgetItem;
+import net.runelite.client.game.ItemManager;
+import net.runelite.client.ui.FontManager;
+import net.runelite.client.ui.overlay.WidgetItemOverlay;
+import net.runelite.client.ui.overlay.components.TextComponent;
+
+import java.awt.*;
+import net.runelite.client.util.QuantityFormatter;
+
+public class BankOverlay extends WidgetItemOverlay
+{
+
+	private final BankConfig config;
+	private final BankPlugin plugin;
+	private final ItemManager itemManager;
+
+	@Inject
+	BankOverlay(BankConfig config, ItemManager itemManager, BankPlugin plugin)
+	{
+		this.config = config;
+		this.plugin = plugin;
+		this.itemManager = itemManager;
+		showOnBank();
+	}
+
+	@Override
+	public void renderItemOverlay(Graphics2D graphics, int itemId, WidgetItem widgetItem)
+	{
+		graphics.setFont(FontManager.getRunescapeSmallFont());
+		renderText(graphics, widgetItem.getCanvasBounds(), widgetItem);
+	}
+
+
+	private void renderText(Graphics2D graphics, Rectangle bounds, WidgetItem iden)
+	{
+		if (plugin.isHotKeyPressed())
+		{
+			long gePrice = 0, haPrice = 0, priceToShow;
+			String priceText = "";
+			final net.runelite.client.ui.overlay.components.TextComponent textComponent = new TextComponent();
+			// Positions text in the middle of the items bounds
+			textComponent.setPosition(new Point(bounds.x - 1, (bounds.y + bounds.height / 2) + 5));
+
+			if (config.showGEPerItem())
+			{
+				haPrice = getHaPrice(iden.getId());
+			}
+
+			if (config.showHAPerItem())
+			{
+				gePrice = itemManager.getItemPrice(iden.getId());
+			}
+
+			// Show greater of HA/GE price on item
+			priceToShow = Math.max(haPrice, gePrice);
+
+			if (haPrice > gePrice)
+			{
+				textComponent.setColor(config.haPerItemColor());
+			}
+			else
+			{
+				textComponent.setColor(config.gePerItemColor());
+			}
+
+			priceText += QuantityFormatter.quantityToStackSize(priceToShow * iden.getQuantity());
+
+			textComponent.setText(priceText);
+			textComponent.render(graphics);
+		}
+	}
+
+	private int getHaPrice(int itemId)
+	{
+		switch (itemId)
+		{
+			case ItemID.COINS_995:
+				return 1;
+			case ItemID.PLATINUM_TOKEN:
+				return 1000;
+			default:
+				return itemManager.getItemComposition(itemId).getHaPrice();
+		}
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/bank/BankOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/bank/BankOverlay.java
@@ -41,7 +41,7 @@ public class BankOverlay extends WidgetItemOverlay
 		{
 			long gePrice = 0, haPrice = 0, priceToShow;
 			String priceText = "";
-			final net.runelite.client.ui.overlay.components.TextComponent textComponent = new TextComponent();
+			final TextComponent textComponent = new TextComponent();
 			// Positions text in the middle of the items bounds
 			textComponent.setPosition(new Point(bounds.x - 1, (bounds.y + bounds.height / 2) + 5));
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/bank/BankOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/bank/BankOverlay.java
@@ -45,12 +45,12 @@ public class BankOverlay extends WidgetItemOverlay
 			// Positions text in the middle of the items bounds
 			textComponent.setPosition(new Point(bounds.x - 1, (bounds.y + bounds.height / 2) + 5));
 
-			if (config.showGEPerItem())
+			if (config.showHAPerItem())
 			{
 				haPrice = getHaPrice(iden.getId());
 			}
 
-			if (config.showHAPerItem())
+			if (config.showGEPerItem())
 			{
 				gePrice = itemManager.getItemPrice(iden.getId());
 			}
@@ -67,10 +67,13 @@ public class BankOverlay extends WidgetItemOverlay
 				textComponent.setColor(config.gePerItemColor());
 			}
 
-			priceText += QuantityFormatter.quantityToStackSize(priceToShow * iden.getQuantity());
+			if (priceToShow > 0)
+			{
+				priceText += QuantityFormatter.quantityToStackSize(priceToShow * iden.getQuantity());
 
-			textComponent.setText(priceText);
-			textComponent.render(graphics);
+				textComponent.setText(priceText);
+				textComponent.render(graphics);
+			}
 		}
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/bank/BankPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/bank/BankPlugin.java
@@ -193,7 +193,8 @@ public class BankPlugin extends Plugin
 				}
 			}
 
-			if (keybindItemPrice.matches(e)) {
+			if (keybindItemPrice.matches(e))
+			{
 				setHotKeyPressed(true);
 			}
 		}
@@ -486,7 +487,6 @@ public class BankPlugin extends Plugin
 
 		return itemContainer.getItems();
 	}
-
 
 	@VisibleForTesting
 	boolean valueSearch(final int itemId, final String str)

--- a/runelite-client/src/test/java/net/runelite/client/plugins/bank/BankPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/bank/BankPluginTest.java
@@ -37,6 +37,7 @@ import net.runelite.api.ItemComposition;
 import net.runelite.api.ItemContainer;
 import net.runelite.api.ItemID;
 import net.runelite.client.game.ItemManager;
+import net.runelite.client.ui.overlay.OverlayManager;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -65,6 +66,14 @@ public class BankPluginTest
 
 	@Inject
 	private BankPlugin bankPlugin;
+
+	@Mock
+	@Bind
+	private OverlayManager overlayManager;
+
+	@Mock
+	@Bind
+	private BankOverlay bankOverlay;
 
 	@Before
 	public void before()


### PR DESCRIPTION
Extends Bank Plugin to allow Grand Exchange and/or High Alchemy price on Items in bank when holding a hotkey
Colour of Grand Exhange and High Alchemy text is configurable.
Hotkey is also configurable.

Preview:
![java_T7LNmVMU1P](https://github.com/user-attachments/assets/fcaa1405-691a-4b38-8c25-01b0312d3a94)
