### PR TITLE
slayer: fix checking slayer task from inventory with eternal slayer ring

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerPlugin.java
@@ -493,7 +493,8 @@ public class SlayerPlugin extends Plugin
 	@Subscribe
 	public void onMenuOptionClicked(MenuOptionClicked menuOptionClicked)
 	{
-		if (menuOptionClicked.getMenuAction() == MenuAction.CC_OP && menuOptionClicked.getMenuOption().equals("Check"))
+		if ((menuOptionClicked.getMenuAction() == MenuAction.CC_OP || menuOptionClicked.getMenuAction() == MenuAction.CC_OP_LOW_PRIORITY)
+			&& menuOptionClicked.getMenuOption().equals("Check"))
 		{
 			Widget w = client.getWidget(menuOptionClicked.getParam1());
 			if (w == null)


### PR DESCRIPTION
This PR fixes a bug with the slayer plugin where checking the current task from the inventory using an eternal slayer ring will not add the slayer task infobox, whereas doing the same action using a regular slayer ring or slayer helmet will. Conversely, using the "Check" option (on the eternal slayer ring) from the worn equipment interface will add the slayer task infobox as expected.

The issue behind the discrepancy is that the "Check" option is a different menuAction (`CC_OP_LOW_PRIORITY`) in the inventory, thus failing the first check. This change addresses that by including the menuAction in the conditional statement.