### PR TITLE
Wiki crowd source lockpick messages

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/crowdsourcing/thieving/CrowdsourcingThieving.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/crowdsourcing/thieving/CrowdsourcingThieving.java
@@ -91,8 +91,7 @@ public class CrowdsourcingThieving
 			return false;
 		}
 
-		return inventoryContainer.contains(ItemID.LOCKPICK) ||
-			inventoryContainer.contains(ItemID.LOCKPICK_28415);
+		return inventoryContainer.contains(ItemID.LOCKPICK);
 	}
 
 	private int getArdougneDiary()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/crowdsourcing/thieving/CrowdsourcingThieving.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/crowdsourcing/thieving/CrowdsourcingThieving.java
@@ -47,6 +47,8 @@ public class CrowdsourcingThieving
 	private static final String BLACKJACK_FAIL = "Your blow only glances off the bandit's head.";
 	private static final Pattern PICKPOCKET_SUCCESS = Pattern.compile("You pick .*'s pocket\\.");
 	private static final Pattern PICKPOCKET_FAIL = Pattern.compile("You fail to pick .*'s pocket\\.");
+	private static final String LOCKPICK_SUCCESS = "You manage to pick the lock.";
+	private static final String LOCKPICK_FAIL = "You fail to pick the lock.";
 
 	@Inject
 	private Client client;
@@ -80,6 +82,18 @@ public class CrowdsourcingThieving
 			equipmentContainer.contains(ItemID.MAX_CAPE);
 	}
 
+	private boolean hasLockpick()
+	{
+		ItemContainer inventoryContainer = client.getItemContainer(InventoryID.INVENTORY);
+		if (inventoryContainer == null)
+		{
+			return false;
+		}
+
+		return inventoryContainer.contains(ItemID.LOCKPICK) ||
+			inventoryContainer.contains(ItemID.LOCKPICK_28415);
+	}
+
 	private int getArdougneDiary()
 	{
 		int easy = client.getVarbitValue(Varbits.DIARY_ARDOUGNE_EASY);
@@ -109,6 +123,15 @@ public class CrowdsourcingThieving
 			boolean thievingCape = hasThievingCape();
 			int thievingLevel = client.getBoostedSkillLevel(Skill.THIEVING);
 			PickpocketData data = new PickpocketData(thievingLevel, lastPickpocketTarget, message, location, silence, thievingCape, ardougneDiary);
+			manager.storeEvent(data);
+		}
+
+		if (LOCKPICK_SUCCESS.equals(message) || LOCKPICK_FAIL.equals(message))
+		{
+			WorldPoint location = client.getLocalPlayer().getWorldLocation();
+			int thievingLevel = client.getBoostedSkillLevel(Skill.THIEVING);
+			boolean lockpick = hasLockpick();
+			LockpickData data = new LockpickData(thievingLevel, message, location, lockpick);
 			manager.storeEvent(data);
 		}
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/crowdsourcing/thieving/CrowdsourcingThieving.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/crowdsourcing/thieving/CrowdsourcingThieving.java
@@ -49,6 +49,7 @@ public class CrowdsourcingThieving
 	private static final Pattern PICKPOCKET_FAIL = Pattern.compile("You fail to pick .*'s pocket\\.");
 	private static final String LOCKPICK_SUCCESS = "You manage to pick the lock.";
 	private static final String LOCKPICK_FAIL = "You fail to pick the lock.";
+	private static final String LOCKPICK_TRAP = "You have activated a trap on the lock.";
 
 	@Inject
 	private Client client;
@@ -106,7 +107,8 @@ public class CrowdsourcingThieving
 	@Subscribe
 	public void onChatMessage(ChatMessage event)
 	{
-		if (event.getType() != ChatMessageType.SPAM)
+		ChatMessageType eventType = event.getType();
+		if ((eventType != ChatMessageType.SPAM) && (eventType != ChatMessageType.GAMEMESSAGE))
 		{
 			return;
 		}
@@ -126,7 +128,9 @@ public class CrowdsourcingThieving
 			manager.storeEvent(data);
 		}
 
-		if (LOCKPICK_SUCCESS.equals(message) || LOCKPICK_FAIL.equals(message))
+		if (LOCKPICK_SUCCESS.equals(message)
+			|| LOCKPICK_FAIL.equals(message)
+			|| LOCKPICK_TRAP.equals(message))
 		{
 			WorldPoint location = client.getLocalPlayer().getWorldLocation();
 			int thievingLevel = client.getBoostedSkillLevel(Skill.THIEVING);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/crowdsourcing/thieving/CrowdsourcingThieving.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/crowdsourcing/thieving/CrowdsourcingThieving.java
@@ -79,7 +79,7 @@ public class CrowdsourcingThieving
 
 		return equipmentContainer.contains(ItemID.THIEVING_CAPE) ||
 			equipmentContainer.contains(ItemID.THIEVING_CAPET) ||
-			equipmentContainer.contains(ItemID.MAX_CAPE);
+			equipmentContainer.contains(ItemID.MAX_CAPE_13342);
 	}
 
 	private boolean hasLockpick()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/crowdsourcing/thieving/CrowdsourcingThieving.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/crowdsourcing/thieving/CrowdsourcingThieving.java
@@ -113,10 +113,11 @@ public class CrowdsourcingThieving
 		}
 
 		String message = event.getMessage();
-		if (BLACKJACK_SUCCESS.equals(message)
+		if (eventType == ChatMessageType.SPAM
+			&& (BLACKJACK_SUCCESS.equals(message)
 			|| BLACKJACK_FAIL.equals(message)
 			|| PICKPOCKET_FAIL.matcher(message).matches()
-			|| PICKPOCKET_SUCCESS.matcher(message).matches())
+			|| PICKPOCKET_SUCCESS.matcher(message).matches()) )
 		{
 			WorldPoint location = client.getLocalPlayer().getWorldLocation();
 			int ardougneDiary = getArdougneDiary();
@@ -125,11 +126,13 @@ public class CrowdsourcingThieving
 			int thievingLevel = client.getBoostedSkillLevel(Skill.THIEVING);
 			PickpocketData data = new PickpocketData(thievingLevel, lastPickpocketTarget, message, location, silence, thievingCape, ardougneDiary);
 			manager.storeEvent(data);
+			return;
 		}
 
-		if (LOCKPICK_SUCCESS.equals(message)
+		if (eventType == ChatMessageType.GAMEMESSAGE
+			&& (LOCKPICK_SUCCESS.equals(message)
 			|| LOCKPICK_FAIL.equals(message)
-			|| LOCKPICK_TRAP.equals(message))
+			|| LOCKPICK_TRAP.equals(message)) )
 		{
 			WorldPoint location = client.getLocalPlayer().getWorldLocation();
 			int thievingLevel = client.getBoostedSkillLevel(Skill.THIEVING);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/crowdsourcing/thieving/LockpickData.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/crowdsourcing/thieving/LockpickData.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2024, Weird Gloop <admin@weirdgloop.org>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package net.runelite.client.plugins.crowdsourcing.thieving;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import net.runelite.api.coords.WorldPoint;
+
+@Data
+@AllArgsConstructor
+public class LockpickData
+{
+    private final int level;
+    private final String message;
+    private final WorldPoint location;
+    private final boolean lockpick;
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/crowdsourcing/thieving/LockpickData.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/crowdsourcing/thieving/LockpickData.java
@@ -33,8 +33,8 @@ import net.runelite.api.coords.WorldPoint;
 @AllArgsConstructor
 public class LockpickData
 {
-    private final int level;
-    private final String message;
-    private final WorldPoint location;
-    private final boolean lockpick;
+	private final int level;
+	private final String message;
+	private final WorldPoint location;
+	private final boolean lockpick;
 }


### PR DESCRIPTION
This adds the ability to track skilling success rates for "pick-lock > object" situations where the message is "You manage/fail to pick the lock," such as [Door (Yanille Dungeon)](https://oldschool.runescape.wiki/w/Door_(Yanille_Dungeon)) and [Door (Chaos Druid Tower)](https://oldschool.runescape.wiki/w/Door_(Chaos_Druid_Tower)) and some others. I include a column tracking whether the player has a lockpick or not in case that affects success rate in cases where the lockpick is optional.

This also fixes a minor bug where for pickpockets it was checking whether the player had the inventory version of max cape rather than the worn one.