### PR TITLE
Add varrock armour smelting tracking

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/smelting/SmeltingPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/smelting/SmeltingPlugin.java
@@ -103,6 +103,13 @@ public class SmeltingPlugin extends Plugin
 			}
 			session.increaseBarsSmelted();
 		}
+		else if (event.getMessage().startsWith("The Varrock platebody enabled you to smelt your next ore")) {
+			if (session == null)
+			{
+				session = new SmeltingSession();
+			}
+			session.increaseBarsSmelted();
+		}
 		else if (event.getMessage().endsWith(" to form 8 cannonballs."))
 		{
 			cannonBallsMade = 8;

--- a/runelite-client/src/test/java/net/runelite/client/plugins/smelting/SmeltingPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/smelting/SmeltingPluginTest.java
@@ -46,6 +46,7 @@ public class SmeltingPluginTest
 	private static final String SMELT_CANNONBALL_DOUBLE_AMMO_MOULD = "The molten metal cools slowly to form 8 cannonballs.";
 	private static final String SMELT_CANNONBALL_DONE_MESSAGE = "You remove the cannonballs from the mould";
 	private static final String SMELT_BAR = "You retrieve a bar of steel.";
+	private static final String SMELT_BAR_VARROCK_PLATEBODY = "The Varrock platebody enabled you to smelt your next ore simultaneously";
 
 	@Inject
 	SmeltingPlugin smeltingPlugin;
@@ -103,5 +104,18 @@ public class SmeltingPluginTest
 		SmeltingSession smeltingSession = smeltingPlugin.getSession();
 		assertNotNull(smeltingSession);
 		assertEquals(1, smeltingSession.getBarsSmelted());
+	}
+
+	@Test
+	public void testBarsVarrockPlatebody()
+	{
+		ChatMessage chatMessageExtra = new ChatMessage(null, ChatMessageType.SPAM, "", SMELT_BAR_VARROCK_PLATEBODY, "", 0);
+		smeltingPlugin.onChatMessage(chatMessageExtra);
+		ChatMessage chatMessageNormal = new ChatMessage(null, ChatMessageType.SPAM, "", SMELT_BAR, "", 0);
+		smeltingPlugin.onChatMessage(chatMessageNormal);
+
+		SmeltingSession smeltingSession = smeltingPlugin.getSession();
+		assertNotNull(smeltingSession);
+		assertEquals(2, smeltingSession.getBarsSmelted());
 	}
 }


### PR DESCRIPTION
A buddy of mine realized that during our smelting grind we were not tracking the number of bars that we smelted with our Varrock platebody.  This commit (which is my first time contributing to this community 😄 ) adds that functionality to the smelting tracker. 