### PR TITLE
tithe farm: remove unused config

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/tithefarm/TitheFarmPlantOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/tithefarm/TitheFarmPlantOverlay.java
@@ -75,11 +75,6 @@ public class TitheFarmPlantOverlay extends Overlay
 		final Color colorWatered = ColorUtil.colorWithAlpha(colorWateredBorder, (int) (colorWateredBorder.getAlpha() / 2.5));
 		borders.put(TitheFarmPlantState.WATERED, colorWateredBorder);
 		fills.put(TitheFarmPlantState.WATERED, colorWatered);
-
-		final Color colorGrownBorder = config.getColorGrown();
-		final Color colorGrown = ColorUtil.colorWithAlpha(colorGrownBorder, (int) (colorGrownBorder.getAlpha() / 2.5));
-		borders.put(TitheFarmPlantState.GROWN, colorGrownBorder);
-		fills.put(TitheFarmPlantState.GROWN, colorGrown);
 	}
 
 	@Override

--- a/runelite-client/src/main/java/net/runelite/client/plugins/tithefarm/TitheFarmPluginConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/tithefarm/TitheFarmPluginConfig.java
@@ -56,16 +56,4 @@ public interface TitheFarmPluginConfig extends Config
 	{
 		return new Color(0, 153, 255);
 	}
-
-	@Alpha
-	@ConfigItem(
-		position = 3,
-		keyName = "hexColorGrown",
-		name = "Grown plant",
-		description = "Color of grown plant timer"
-	)
-	default Color getColorGrown()
-	{
-		return new Color(0, 217, 0);
-	}
 }


### PR DESCRIPTION
The pie timer on fully grown plants was removed in #17931 so this config option doesn't do anything anymore.