### PR TITLE
MapImageDumper: Fix drawing of sprites on chunk boundary

### DIFF
--- a/cache/src/main/java/net/runelite/cache/MapImageDumper.java
+++ b/cache/src/main/java/net/runelite/cache/MapImageDumper.java
@@ -1507,7 +1507,6 @@ public class MapImageDumper
 							//What is offsetY?
 							int objSizeOffset = Math.max(2, object.getOffsetY());
 							int drawY = (drawBaseY + (Region.Y - objSizeOffset - localY)) * MAP_SCALE;
-
 							if (object.getMapSceneID() != -1)
 							{
 								blitMapDecoration(image, drawX, drawY, object);
@@ -1850,23 +1849,21 @@ public class MapImageDumper
 		float stepSizeHeight = 1 + 1 - scale;
 		float stepSizeWidth = 1 + 1 - scale;
 
-		int ymin = Math.max(0, -y);
-		int ymax = Math.min(displayHeight, dst.getHeight() - y);
-
-		int xmin = Math.max(0, -x);
-		int xmax = Math.min(displayWidth, dst.getWidth() - x);
 
 		float indexX = 0;
 		float indexY = 0;
-		for (int yo = ymin; yo < ymax; yo++)
+		for (int yo = 0; yo < displayHeight; yo++)
 		{
-			for (int xo = xmin; xo < xmax; xo++)
+			for (int xo = 0; xo < displayWidth; xo++)
 			{
-				int index = (int) (indexX) + ((int) (indexY) * (sprite.getWidth()));
-				byte color = sprite.pixelIdx[index];
-				if (color != 0)
+				if (x + xo >= 0 && x + xo < dst.getWidth() && y + yo >= 0 && y + yo < dst.getHeight())
 				{
-					dst.setRGB(x + xo, y + yo, sprite.palette[color & 255] | 0xFF000000);
+					int index = (int) (indexX) + ((int) (indexY) * (sprite.getWidth()));
+					byte color = sprite.pixelIdx[index];
+					if (color != 0)
+					{
+						dst.setRGB(x + xo, y + yo, sprite.palette[color & 255] | 0xFF000000);
+					}
 				}
 				indexX += stepSizeWidth;
 			}


### PR DESCRIPTION
Correctly draw sprites that start outside of the current draw region. Fixes issue noted in https://github.com/runelite/runelite/pull/17948#issuecomment-2251829928