### PR TITLE
idlenotifier: add Varlamore-related animations

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/AnimationID.java
+++ b/runelite-api/src/main/java/net/runelite/api/AnimationID.java
@@ -292,6 +292,7 @@ public final class AnimationID
 	public static final int CHURN_MILK_LONG = 2795;
 	public static final int CLEANING_SPECIMENS_1 = 6217;
 	public static final int CLEANING_SPECIMENS_2 = 6459;
+	public static final int SACRIFICE_BLESSED_BONE_SHARDS = 11002;
 	public static final int MAKING_SUNFIRE_WINE = 11095;
 
 	// Ectofuntus animations

--- a/runelite-api/src/main/java/net/runelite/api/AnimationID.java
+++ b/runelite-api/src/main/java/net/runelite/api/AnimationID.java
@@ -292,7 +292,7 @@ public final class AnimationID
 	public static final int CHURN_MILK_LONG = 2795;
 	public static final int CLEANING_SPECIMENS_1 = 6217;
 	public static final int CLEANING_SPECIMENS_2 = 6459;
-	public static final int SACRIFICE_BLESSED_BONE_SHARDS = 11002;
+	public static final int SACRIFICE_BLESSED_BONE_SHARDS = 11102;
 	public static final int MAKING_SUNFIRE_WINE = 11095;
 	public static final int THIEVING_VARLAMORE_STEALING_VALUABLES = 11075;
 

--- a/runelite-api/src/main/java/net/runelite/api/AnimationID.java
+++ b/runelite-api/src/main/java/net/runelite/api/AnimationID.java
@@ -294,6 +294,7 @@ public final class AnimationID
 	public static final int CLEANING_SPECIMENS_2 = 6459;
 	public static final int SACRIFICE_BLESSED_BONE_SHARDS = 11002;
 	public static final int MAKING_SUNFIRE_WINE = 11095;
+	public static final int THIEVING_VARLAMORE_STEALING_VALUABLES = 11075;
 
 	// Ectofuntus animations
 	public static final int ECTOFUNTUS_FILL_SLIME_BUCKET = 4471;

--- a/runelite-api/src/main/java/net/runelite/api/AnimationID.java
+++ b/runelite-api/src/main/java/net/runelite/api/AnimationID.java
@@ -147,6 +147,7 @@ public final class AnimationID
 	public static final int CRAFTING_POTTERS_WHEEL = 883;
 	public static final int CRAFTING_POTTERY_OVEN = 24975;
 	public static final int CRAFTING_LOOM = 2270;
+	public static final int CRAFTING_CRUSH_BLESSED_BONES = 11099;
 	public static final int SMITHING_SMELTING = 899;
 	public static final int SMITHING_CANNONBALL = 827; //cball smithing uses this and SMITHING_SMELTING
 	public static final int SMITHING_ANVIL = 898;
@@ -291,6 +292,7 @@ public final class AnimationID
 	public static final int CHURN_MILK_LONG = 2795;
 	public static final int CLEANING_SPECIMENS_1 = 6217;
 	public static final int CLEANING_SPECIMENS_2 = 6459;
+	public static final int MAKING_SUNFIRE_WINE = 11095;
 
 	// Ectofuntus animations
 	public static final int ECTOFUNTUS_FILL_SLIME_BUCKET = 4471;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
@@ -377,6 +377,7 @@ public class IdleNotifierPlugin extends Plugin
 			case CLEANING_SPECIMENS_1:
 			case CLEANING_SPECIMENS_2:
 			case LOOKING_INTO:
+			case SACRIFICE_BLESSED_BONE_SHARDS:
 			case MAKING_SUNFIRE_WINE:
 				resetTimers();
 				lastAnimation = animation;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
@@ -229,7 +229,8 @@ public class IdleNotifierPlugin extends Plugin
 			case CRAFTING_LEATHER:
 			case CRAFTING_POTTERS_WHEEL:
 			case CRAFTING_POTTERY_OVEN:
-			/* Fletching(Cutting, Stringing, Adding feathers and heads) */
+			case CRAFTING_CRUSH_BLESSED_BONES:
+				/* Fletching(Cutting, Stringing, Adding feathers and heads) */
 			case FLETCHING_BOW_CUTTING:
 			case FLETCHING_STRING_NORMAL_SHORTBOW:
 			case FLETCHING_STRING_OAK_SHORTBOW:
@@ -376,6 +377,7 @@ public class IdleNotifierPlugin extends Plugin
 			case CLEANING_SPECIMENS_1:
 			case CLEANING_SPECIMENS_2:
 			case LOOKING_INTO:
+			case MAKING_SUNFIRE_WINE:
 				resetTimers();
 				lastAnimation = animation;
 				lastAnimating = Instant.now();

--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
@@ -379,6 +379,7 @@ public class IdleNotifierPlugin extends Plugin
 			case LOOKING_INTO:
 			case SACRIFICE_BLESSED_BONE_SHARDS:
 			case MAKING_SUNFIRE_WINE:
+			case THIEVING_VARLAMORE_STEALING_VALUABLES:
 				resetTimers();
 				lastAnimation = animation;
 				lastAnimating = Instant.now();

--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
@@ -230,7 +230,7 @@ public class IdleNotifierPlugin extends Plugin
 			case CRAFTING_POTTERS_WHEEL:
 			case CRAFTING_POTTERY_OVEN:
 			case CRAFTING_CRUSH_BLESSED_BONES:
-				/* Fletching(Cutting, Stringing, Adding feathers and heads) */
+			/* Fletching(Cutting, Stringing, Adding feathers and heads) */
 			case FLETCHING_BOW_CUTTING:
 			case FLETCHING_STRING_NORMAL_SHORTBOW:
 			case FLETCHING_STRING_OAK_SHORTBOW:


### PR DESCRIPTION
Adds animations for the following to idlenotifier:
- Crushing blessed bones
- Making sunfire wines
- Sacrificing bone shards to the libation bowl
- Searching wealthy citizens' houses for valuables (Varlamore thieving)