### PR TITLE
Add clarity to Hide Random Events description

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/entityhider/EntityHiderConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/entityhider/EntityHiderConfig.java
@@ -202,8 +202,8 @@ public interface EntityHiderConfig extends Config
 	@ConfigItem(
 		position = 16,
 		keyName = "hideRandomEvents",
-		name = "Hide Random Events",
-		description = "Configures whether or not Random events are hidden"
+		name = "Hide Others Players' Random Events",
+		description = "Configures whether or not other player random events are hidden"
 	)
 	default boolean hideRandomEvents()
 	{


### PR DESCRIPTION
The description for the "Hide Random Events" is not clear it only works for _other players'_ random events. This PR makes it a little bit clearer.