### PR TITLE
timers: add scurrius food pile timer

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/Varbits.java
+++ b/runelite-api/src/main/java/net/runelite/api/Varbits.java
@@ -916,4 +916,9 @@ public final class Varbits
 	 * The amount of Doom stacks received in the Fortis Colosseum.
 	 */
 	public static final int COLOSSEUM_DOOM = 9801;
+
+	/**
+	 * How long is left on Scurrius's food pile's cooldown (in minutes).
+	 */
+	public static final int SCURRIUS_FOOD_PILE_COOLDOWN = 9581;
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timersandbuffs/GameTimer.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timersandbuffs/GameTimer.java
@@ -97,6 +97,7 @@ enum GameTimer
 	SILK_DRESSING(ItemID.SILK_DRESSING_2, GameTimerImageType.ITEM, "Silk dressing", 100, GAME_TICKS, true),
 	BLESSED_CRYSTAL_SCARAB(ItemID.BLESSED_CRYSTAL_SCARAB_2, GameTimerImageType.ITEM, "Blessed crystal scarab", 40, GAME_TICKS, true),
 	SPELLBOOK_SWAP(SpriteID.SPELL_SPELLBOOK_SWAP, GameTimerImageType.SPRITE, "Spellbook Reset", 120, ChronoUnit.SECONDS, false),
+	SCURRIUS_FOOD_PILE(ItemID.CHEESE, GameTimerImageType.ITEM, "Scurrius' food pile", false),
 	;
 
 	@Nullable

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timersandbuffs/TimersAndBuffsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timersandbuffs/TimersAndBuffsConfig.java
@@ -455,4 +455,15 @@ public interface TimersAndBuffsConfig extends Config
 	{
 		return true;
 	}
+
+	@ConfigItem(
+		keyName = "showScurriusFoodPile",
+		name = "Scurrius' Food Pile",
+		description = "Configures whether Scurrius' Food Pile timer is displayed",
+		section = bossesSection
+	)
+	default boolean showScurriusFoodPile()
+	{
+		return true;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timersandbuffs/TimersAndBuffsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timersandbuffs/TimersAndBuffsPlugin.java
@@ -614,6 +614,11 @@ public class TimersAndBuffsPlugin extends Plugin
 
 			updateVarTimer(MOONLIGHT_POTION, moonlightValue, IntUnaryOperator.identity());
 		}
+
+		if (event.getVarbitId() == Varbits.SCURRIUS_FOOD_PILE_COOLDOWN && config.showScurriusFoodPile())
+		{
+			updateVarTimer(SCURRIUS_FOOD_PILE, event.getValue(), i -> i * 100);
+		}
 	}
 
 	@Subscribe
@@ -825,6 +830,11 @@ public class TimersAndBuffsPlugin extends Plugin
 		if (!config.showMoonlightPotion())
 		{
 			removeVarTimer(MOONLIGHT_POTION);
+		}
+
+		if (!config.showScurriusFoodPile())
+		{
+			removeGameTimer(SCURRIUS_FOOD_PILE);
 		}
 	}
 


### PR DESCRIPTION
Re-submission of https://github.com/runelite/runelite/pull/17426 after some cleanup/git tomfoolery (sorry, not great at git at the best of times) - a timer for the food piles in Scurrius' lair using varbit 9581 (SCURRIUS_FOOD_PILE_COOLDOWN). Something mobile/steam client has so would be nice to get this in for feature parity's sake!