### PR TITLE
Added Hunter's Mix support in Item Stats plugin

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatChanges.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatChanges.java
@@ -357,6 +357,16 @@ public class ItemStatChanges
 		// Soul Wars
 		add(combo(heal(HITPOINTS, perc(.15, 1)), heal(RUN_ENERGY, 100)), BANDAGES_25202);
 		add(combo(boost(ATTACK, perc(.15, 5)), boost(STRENGTH, perc(.15, 5)), boost(DEFENCE, perc(.15, 5)), boost(RANGED, perc(.15, 5)), boost(MAGIC, perc(.15, 5)), heal(PRAYER, perc(.25, 8))), POTION_OF_POWER1, POTION_OF_POWER2, POTION_OF_POWER3, POTION_OF_POWER4);
+		
+		
+		// Hunter's Mix
+		add(boost(ATTACK, perc(0.15, 4)), RUBY_HARVEST_MIX_1, RUBY_HARVEST_MIX_2);
+		add(boost(DEFENCE, perc(0.15, 4)), SAPPHIRE_GLACIALIS_MIX_1, SAPPHIRE_GLACIALIS_MIX_2);
+		add(food(8), SNOWY_KNIGHT_MIX_1, SNOWY_KNIGHT_MIX_2);
+		add(boost(STRENGTH, perc(0.15, 4)), BLACK_WARLOCK_MIX_1, BLACK_WARLOCK_MIX_2);
+		add(new StatRestoringEffect(0.20, 6, food(8)), SUNLIGHT_MOTH_MIX_1, SUNLIGHT_MOTH_MIX_2);
+		add(heal(PRAYER, 22), MOONLIGHT_MOTH_MIX_1, MOONLIGHT_MOTH_MIX_2);
+		
 
 		log.debug("{} items; {} behaviours loaded", effects.size(), new HashSet<>(effects.values()).size());
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/StatRestoringEffect.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/StatRestoringEffect.java
@@ -1,0 +1,48 @@
+package net.runelite.client.plugins.itemstats;
+
+import lombok.RequiredArgsConstructor;
+import net.runelite.api.Client;
+import net.runelite.client.plugins.itemstats.stats.Stat;
+import com.google.common.annotations.VisibleForTesting;
+
+import java.util.Comparator;
+import java.util.stream.Stream;
+
+import static net.runelite.client.plugins.itemstats.Builders.perc;
+import static net.runelite.client.plugins.itemstats.stats.Stats.*;
+
+@RequiredArgsConstructor
+public class StatRestoringEffect implements Effect {
+
+    private static final Stat[] superRestoreStats = {
+            ATTACK, DEFENCE, STRENGTH, RANGED, MAGIC, COOKING,
+            WOODCUTTING, FLETCHING, FISHING, FIREMAKING, CRAFTING, SMITHING, MINING,
+            HERBLORE, AGILITY, THIEVING, SLAYER, FARMING, RUNECRAFT, HUNTER,
+            CONSTRUCTION
+    };
+    
+    @VisibleForTesting
+    public final double percR; //percentage restored
+    private final int delta;
+    private final SingleEffect effect;
+    
+    @Override
+    public final StatsChanges calculate(Client client) {
+        StatsChanges changes = new StatsChanges(0);
+        SimpleStatBoost calc = new SimpleStatBoost(null, false, perc(percR, delta));
+        changes.setStatChanges(Stream.concat(
+                Stream.of(effect.effect(client)),
+                Stream.of(superRestoreStats)
+                        .filter(stat -> stat.getValue(client) < stat.getMaximum(client))
+                        .map(stat ->
+                        {
+                            calc.setStat(stat);
+                            return calc.effect(client);
+                        })
+                ).toArray(StatChange[]::new));
+        changes.setPositivity(Stream.of(changes.getStatChanges())
+                .map(sc -> sc.getPositivity())
+                .max(Comparator.naturalOrder()).get());
+        return changes;
+    }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/potions/SuperRestore.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/potions/SuperRestore.java
@@ -24,54 +24,13 @@
  */
 package net.runelite.client.plugins.itemstats.potions;
 
-import com.google.common.annotations.VisibleForTesting;
-import java.util.Comparator;
-import java.util.stream.Stream;
-import lombok.RequiredArgsConstructor;
-import net.runelite.api.Client;
-import static net.runelite.client.plugins.itemstats.Builders.perc;
-import net.runelite.client.plugins.itemstats.Effect;
-import net.runelite.client.plugins.itemstats.SimpleStatBoost;
-import net.runelite.client.plugins.itemstats.stats.Stat;
-import net.runelite.client.plugins.itemstats.StatChange;
-import static net.runelite.client.plugins.itemstats.stats.Stats.*;
-import net.runelite.client.plugins.itemstats.StatsChanges;
+import net.runelite.client.plugins.itemstats.StatRestoringEffect;
 
-@RequiredArgsConstructor
-public class SuperRestore implements Effect
+
+public class SuperRestore extends StatRestoringEffect
 {
-	private static final Stat[] superRestoreStats = {
-		ATTACK, DEFENCE, STRENGTH, RANGED, MAGIC, COOKING,
-		WOODCUTTING, FLETCHING, FISHING, FIREMAKING, CRAFTING, SMITHING, MINING,
-		HERBLORE, AGILITY, THIEVING, SLAYER, FARMING, RUNECRAFT, HUNTER,
-		CONSTRUCTION
-	};
-
-	@VisibleForTesting
-	public final double percR; //percentage restored
-	private final int delta;
-
-	@Override
-	public StatsChanges calculate(Client client)
+	public SuperRestore(double percR, int delta)
 	{
-		StatsChanges changes = new StatsChanges(0);
-
-		SimpleStatBoost calc = new SimpleStatBoost(null, false, perc(percR, delta));
-		PrayerPotion prayer = new PrayerPotion(delta, percR);
-		changes.setStatChanges(Stream.concat(
-			Stream.of(prayer.effect(client)),
-			Stream.of(superRestoreStats)
-				.filter(stat -> stat.getValue(client) < stat.getMaximum(client))
-				.map(stat ->
-				{
-					calc.setStat(stat);
-					return calc.effect(client);
-				})
-			).toArray(StatChange[]::new));
-		changes.setPositivity(Stream.of(changes.getStatChanges())
-			.map(sc -> sc.getPositivity())
-			.max(Comparator.naturalOrder()).get());
-		return changes;
+		super(percR, delta, new PrayerPotion(delta, percR));
 	}
-
 }


### PR DESCRIPTION
Created class StatRestoringEffect to allow stat restore to be used in conjunction with other effects.
Updated SuperRestore class to extend StatRestoringEffect using the prayer potion effect as it did previously.
Added the Hunter's mix section to the ItemStatChanges class with all the existing Hunter's Mix on the wiki.