### PR TITLE
loottracker: Muddy Chest world metadata

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
@@ -172,6 +172,7 @@ public class LootTrackerPlugin extends Plugin
 	private static final String ANCIENT_CHEST_LOOTED_MESSAGE = "You open the chest and find";
 	private static final Pattern HAM_CHEST_LOOTED_PATTERN = Pattern.compile("Your (?<key>[a-z]+) key breaks in the lock.*");
 	private static final int HAM_STOREROOM_REGION = 10321;
+	private static final int LAVA_MAZE_NORTH_EAST_REGION = 12348;
 	private static final Map<Integer, String> CHEST_EVENT_TYPES = new ImmutableMap.Builder<Integer, String>().
 		put(5179, "Brimstone Chest").
 		put(11573, "Crystal Chest").
@@ -187,7 +188,7 @@ public class LootTrackerPlugin extends Plugin
 		put(7827, "Dark Chest").
 		put(13117, "Rogues' Chest").
 		put(13156, "Chest (Ancient Vault)").
-		put(12348, "Muddy Chest").
+		put(LAVA_MAZE_NORTH_EAST_REGION, "Muddy Chest").
 		put(5422, "Chest (Aldarin Villas)").
 		put(6550, "Chest (Moon key)").
 		build();
@@ -1011,6 +1012,13 @@ public class LootTrackerPlugin extends Plugin
 			log.debug("Chest loot matched '{}' region {}", message, regionID);
 			if (!CHEST_EVENT_TYPES.containsKey(regionID))
 			{
+				return;
+			}
+
+			if (regionID == LAVA_MAZE_NORTH_EAST_REGION) // Muddy Chest crowdsourcing needs F2P/P2P world
+			{
+				onInvChange(collectInvAndGroundItems(LootRecordType.EVENT, CHEST_EVENT_TYPES.get(regionID),
+					client.getWorld()));
 				return;
 			}
 


### PR DESCRIPTION
World metadata is necessary for the crowdsourcing to distinguish F2P and P2P worlds for finding unknown rare loot drop rates.

![image](https://github.com/user-attachments/assets/8f62e4f0-bc46-41f7-9370-753869a18f5a)
