### PR TITLE
wiki dps: update wiki dps button position on client resize

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/wiki/WikiDpsManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/wiki/WikiDpsManager.java
@@ -291,6 +291,26 @@ class WikiDpsManager
 		text.setAction(0, "View DPS on OSRS Wiki");
 		text.setOnOpListener((JavaScriptCallback) ev -> onClick.run());
 
+		// listener which updates button height if window is resized
+		if (screen == Screen.BANK_EQUIPMENT)
+		{
+			text.setOnTimerListener((JavaScriptCallback) ev ->
+			{
+				int setBonusY = setBonus.getOriginalY() + parent.getHeight() / 2 - setBonus.getHeight() / 2;
+				if (setBonusY != text.getOriginalY())
+				{
+					int diff = setBonusY - text.getOriginalY();
+					for (int i = 0; i < 9; i++)
+					{
+						spriteWidgets[i].setOriginalY(diff + spriteWidgets[i].getOriginalY());
+						spriteWidgets[i].revalidate();
+					}
+					text.setOriginalY(diff + text.getOriginalY());
+					text.revalidate();
+				}
+			});
+		}
+
 		// recompute locations / sizes on parent
 		parent.revalidate();
 	}


### PR DESCRIPTION
Fixes a bug which causes the "View DPS" button on the bank equipment screen to be misaligned with the client is resized.

To replicate the bug, open the bank, toggle the equipment screen, and resize the client window.

### Before:
![DPS-button-before](https://github.com/user-attachments/assets/932bd8d6-ee41-408c-a61f-bf8c8d6e849a)
### After:
![DPS-button-after](https://github.com/user-attachments/assets/2c1cb7e1-0476-4d41-b497-6b9723a8c64a)

