### PR TITLE
gpu: regions: add Lumbridge underground areas to Chasm of Tears region

### DIFF
--- a/runelite-client/src/main/resources/net/runelite/client/plugins/gpu/regions/regions.txt
+++ b/runelite-client/src/main/resources/net/runelite/client/plugins/gpu/regions/regions.txt
@@ -348,6 +348,8 @@ C 0 0 2 6
 n
 r 54 148
 
-// chasm of tears
+// lumbridge underground
 n
-r 50 148
+R 50 148 50 151
+r 49 149
+r 51 150

--- a/runelite-client/src/main/resources/net/runelite/client/plugins/gpu/regions/regions.txt
+++ b/runelite-client/src/main/resources/net/runelite/client/plugins/gpu/regions/regions.txt
@@ -353,3 +353,7 @@ n
 R 50 148 50 151
 r 49 149
 r 51 150
+
+// desert mining camp (the tourist trap)
+n
+r 51 147


### PR DESCRIPTION
Adds the following to the region for the Chasm of Tears:
- Lumbridge castle basement
- Watermill basement
- Dorgeshuun Mines
- Lumbridge swamp caves

Fixes #18265