### PR TITLE
wiki: Add wiki menu option for combat achievement tasks

### DIFF
--- a/runelite-api/src/main/interfaces/interfaces.toml
+++ b/runelite-api/src/main/interfaces/interfaces.toml
@@ -231,6 +231,12 @@ spell_icon=28
 spell_text=29
 auto_retaliate=30
 
+[combat_achievements_tasks]
+id=715
+progress_bar=3
+list=9
+filters=17
+
 [corp_damage]
 id=13
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/wiki/WikiPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/wiki/WikiPlugin.java
@@ -74,8 +74,8 @@ public class WikiPlugin extends Plugin
 {
 	static final HttpUrl WIKI_BASE = HttpUrl.get("https://oldschool.runescape.wiki");
 	static final HttpUrl WIKI_API = WIKI_BASE.newBuilder().addPathSegments("api.php").build();
-	static final String UTM_SORUCE_KEY = "utm_source";
-	static final String UTM_SORUCE_VALUE = "runelite";
+	static final String UTM_SOURCE_KEY = "utm_source";
+	static final String UTM_SOURCE_VALUE = "runelite";
 
 	private static final String MENUOP_WIKI = "Wiki";
 
@@ -346,7 +346,7 @@ public class WikiPlugin extends Plugin
 				.addQueryParameter("type", type)
 				.addQueryParameter("id", "" + id)
 				.addQueryParameter("name", name)
-				.addQueryParameter(UTM_SORUCE_KEY, UTM_SORUCE_VALUE);
+				.addQueryParameter(UTM_SOURCE_KEY, UTM_SOURCE_VALUE);
 
 			if (location != null)
 			{
@@ -419,7 +419,7 @@ public class WikiPlugin extends Plugin
 			}
 		}
 
-		if (WidgetUtil.componentToInterface(widgetID) == InterfaceID.SKILLS)
+		if (event.getType() == MenuAction.CC_OP.getId() && WidgetUtil.componentToInterface(widgetID) == InterfaceID.SKILLS)
 		{
 			Widget w = getWidget(widgetID, widgetIndex);
 			if (w.getActions() == null || w.getParentId() != ComponentID.SKILLS_CONTAINER)
@@ -442,7 +442,26 @@ public class WikiPlugin extends Plugin
 				.onClick(ev -> LinkBrowser.browse(WIKI_BASE.newBuilder()
 					.addPathSegment("w")
 					.addPathSegment(Text.removeTags(ev.getTarget()))
-					.addQueryParameter(UTM_SORUCE_KEY, UTM_SORUCE_VALUE)
+					.addQueryParameter(UTM_SOURCE_KEY, UTM_SOURCE_VALUE)
+					.build().toString()));
+		}
+
+		if (event.getType() == MenuAction.CC_OP.getId() && WidgetUtil.componentToInterface(widgetID) == InterfaceID.COMBAT_ACHIEVEMENTS_TASKS)
+		{
+			Widget w = getWidget(widgetID, widgetIndex);
+			if (w.getActions() == null || w.getParentId() != ComponentID.COMBAT_ACHIEVEMENTS_TASKS_LIST)
+			{
+				return;
+			}
+
+			client.getMenu().createMenuEntry(-1)
+				.setTarget(w.getName())
+				.setOption(MENUOP_WIKI)
+				.setType(MenuAction.RUNELITE)
+				.onClick(ev -> LinkBrowser.browse(WIKI_BASE.newBuilder()
+					.addPathSegment("w")
+					.addPathSegment(Text.removeTags(ev.getTarget()))
+					.addQueryParameter(UTM_SOURCE_KEY, UTM_SOURCE_VALUE)
 					.build().toString()));
 		}
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/wiki/WikiSearchChatboxTextInput.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/wiki/WikiSearchChatboxTextInput.java
@@ -300,7 +300,7 @@ public class WikiSearchChatboxTextInput extends ChatboxTextInput
 	{
 		LinkBrowser.browse(WikiPlugin.WIKI_BASE.newBuilder()
 			.addQueryParameter("search", search)
-			.addQueryParameter(WikiPlugin.UTM_SORUCE_KEY, WikiPlugin.UTM_SORUCE_VALUE)
+			.addQueryParameter(WikiPlugin.UTM_SOURCE_KEY, WikiPlugin.UTM_SOURCE_VALUE)
 			.build()
 			.toString());
 		chatboxPanelManager.close();


### PR DESCRIPTION
Adds a  menu option to combat achievements that opens the corresponding wiki page.

![image](https://github.com/user-attachments/assets/882f10d5-5930-4490-bc31-68b0b3d54ee6)
