### PR TITLE
Fix: Expeditious bracelet notify message

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemcharges/ItemChargePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemcharges/ItemChargePlugin.java
@@ -131,7 +131,7 @@ public class ItemChargePlugin extends Plugin
 	private static final Pattern EXPEDITIOUS_BRACELET_CHECK_PATTERN = Pattern.compile(
 		"Your expeditious bracelet has (\\d{1,2}) charges? left\\."
 	);
-	private static final String EXPEDITIOUS_BRACELET_BREAK_TEXT = "Your Expeditious Bracelet has crumbled to dust.";
+	private static final String EXPEDITIOUS_BRACELET_BREAK_TEXT = "Your expeditious bracelet has crumbled to dust.";
 	private static final Pattern BLOOD_ESSENCE_CHECK_PATTERN = Pattern.compile(
 		"Your blood essence has (\\d{1,4}) charges? remaining"
 	);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemidentification/ItemIdentification.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemidentification/ItemIdentification.java
@@ -242,6 +242,8 @@ enum ItemIdentification
 	MITHRIL_BAR(Type.BAR, "Mithril", "MIT", ItemID.MITHRIL_BAR),
 	ADAMANTITE_BAR(Type.BAR, "Adaman", "ADA", ItemID.ADAMANTITE_BAR),
 	RUNITE_BAR(Type.BAR, "Runite", "RUN", ItemID.RUNITE_BAR),
+	
+	BLURITE_BAR(Type.BAR, "Blurite", "BLU", ItemID.BLURITE_BAR),
 
 	//Gems
 	SAPPHIRE(Type.GEM, "Sapphir", "S", ItemID.UNCUT_SAPPHIRE, ItemID.SAPPHIRE),

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemidentification/ItemIdentification.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemidentification/ItemIdentification.java
@@ -242,8 +242,9 @@ enum ItemIdentification
 	MITHRIL_BAR(Type.BAR, "Mithril", "MIT", ItemID.MITHRIL_BAR),
 	ADAMANTITE_BAR(Type.BAR, "Adaman", "ADA", ItemID.ADAMANTITE_BAR),
 	RUNITE_BAR(Type.BAR, "Runite", "RUN", ItemID.RUNITE_BAR),
+
 	BLURITE_BAR(Type.BAR, "Blurite", "BLU", ItemID.BLURITE_BAR),
-	ELEMENTAL_BAR(Type.BAR, "Elemental", "ELE", ItemID.ELEMENTAL_BAR),
+	ELEMENTAL_METAL(Type.BAR, "Elemental", "ELE", ItemID.ELEMENTAL_METAL),
 	LOVAKITE_BAR(Type.BAR, "Lovakite", "LOV", ItemID.LOVAKITE_BAR),
 	LUNAR_BAR(Type.BAR, "Lunar", "LUN", ItemID.LUNAR_BAR),
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemidentification/ItemIdentification.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemidentification/ItemIdentification.java
@@ -242,7 +242,6 @@ enum ItemIdentification
 	MITHRIL_BAR(Type.BAR, "Mithril", "MIT", ItemID.MITHRIL_BAR),
 	ADAMANTITE_BAR(Type.BAR, "Adaman", "ADA", ItemID.ADAMANTITE_BAR),
 	RUNITE_BAR(Type.BAR, "Runite", "RUN", ItemID.RUNITE_BAR),
-	
 	BLURITE_BAR(Type.BAR, "Blurite", "BLU", ItemID.BLURITE_BAR),
 
 	//Gems

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemidentification/ItemIdentification.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemidentification/ItemIdentification.java
@@ -243,6 +243,9 @@ enum ItemIdentification
 	ADAMANTITE_BAR(Type.BAR, "Adaman", "ADA", ItemID.ADAMANTITE_BAR),
 	RUNITE_BAR(Type.BAR, "Runite", "RUN", ItemID.RUNITE_BAR),
 	BLURITE_BAR(Type.BAR, "Blurite", "BLU", ItemID.BLURITE_BAR),
+	ELEMENTAL_BAR(Type.BAR, "Elemental", "ELE", ItemID.ELEMENTAL_BAR),
+	LOVAKITE_BAR(Type.BAR, "Lovakite", "LOV", ItemID.LOVAKITE_BAR),
+	LUNAR_BAR(Type.BAR, "Lunar", "LUN", ItemID.LUNAR_BAR),
 
 	//Gems
 	SAPPHIRE(Type.GEM, "Sapphir", "S", ItemID.UNCUT_SAPPHIRE, ItemID.SAPPHIRE),


### PR DESCRIPTION

this commit fixes the incorrect notify message for the expeditious bracelet when running out of charges. The expeditious bracelet notify message for running out of charges has two letters that are capitalized where they should not be.

![Screenshot 2024-09-22 153921](https://github.com/user-attachments/assets/b7406de4-9293-489b-9e0c-c0b890773161)
