### PR TITLE
Fix: Expeditious bracelet notify message

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemcharges/ItemChargePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemcharges/ItemChargePlugin.java
@@ -131,7 +131,7 @@ public class ItemChargePlugin extends Plugin
 	private static final Pattern EXPEDITIOUS_BRACELET_CHECK_PATTERN = Pattern.compile(
 		"Your expeditious bracelet has (\\d{1,2}) charges? left\\."
 	);
-	private static final String EXPEDITIOUS_BRACELET_BREAK_TEXT = "Your Expeditious Bracelet has crumbled to dust.";
+	private static final String EXPEDITIOUS_BRACELET_BREAK_TEXT = "Your expeditious bracelet has crumbled to dust.";
 	private static final Pattern BLOOD_ESSENCE_CHECK_PATTERN = Pattern.compile(
 		"Your blood essence has (\\d{1,4}) charges? remaining"
 	);


### PR DESCRIPTION
this commit fixes the incorrect notify message for the expeditious bracelet when running out of charges. The expeditious bracelet notify message for running out of charges has two letters that are capitalized where they should not be.
![Screenshot 2024-09-22 153921](https://github.com/user-attachments/assets/45209081-e956-4bf2-9be8-22900cba19c4)
