### PR TITLE
chatcommands: fix gotr above 1000 & clean up the use of replaceAll

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/chat/ChatMessageManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/chat/ChatMessageManager.java
@@ -889,7 +889,7 @@ public class ChatMessageManager
 				}
 
 				// Replace custom formatting with actual colors
-				runeLiteFormatMessage = runeLiteFormatMessage.replaceAll(
+				runeLiteFormatMessage = runeLiteFormatMessage.replace(
 					"<col" + chatColor.getType().name() + ">",
 					colstr);
 			}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/DiaryRequirementsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/DiaryRequirementsPlugin.java
@@ -215,7 +215,7 @@ public class DiaryRequirementsPlugin extends Plugin
 	private GenericDiaryRequirement getRequirementsForTitle(String title)
 	{
 		String diaryName = Text.removeTags(title
-			.replaceAll(" ", "_")
+			.replace(" ", "_")
 			.toUpperCase());
 
 		GenericDiaryRequirement diaryRequirementContainer;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
@@ -578,21 +578,21 @@ public class ChatCommandsPlugin extends Plugin
 		if (matcher.find())
 		{
 			int floor = Integer.parseInt(matcher.group(1));
-			int kc = Integer.parseInt(matcher.group(2).replaceAll(",", ""));
+			int kc = Integer.parseInt(matcher.group(2).replace(",", ""));
 			setKc("Hallowed Sepulchre Floor " + floor, kc);
 		}
 
 		matcher = HS_KC_GHC_PATTERN.matcher(message);
 		if (matcher.find())
 		{
-			int kc = Integer.parseInt(matcher.group(1).replaceAll(",", ""));
+			int kc = Integer.parseInt(matcher.group(1).replace(",", ""));
 			setKc("Hallowed Sepulchre", kc);
 		}
 
 		matcher = HUNTER_RUMOUR_KC_PATTERN.matcher(message);
 		if (matcher.find())
 		{
-			int kc = Integer.parseInt(matcher.group(1).replaceAll(",", ""));
+			int kc = Integer.parseInt(matcher.group(1).replace(",", ""));
 			setKc("Hunter Rumours", kc);
 		}
 
@@ -623,7 +623,7 @@ public class ChatCommandsPlugin extends Plugin
 		matcher = GUARDIANS_OF_THE_RIFT_PATTERN.matcher(message);
 		if (matcher.find())
 		{
-			int kc = Integer.parseInt(matcher.group(1).replaceAll(",", ""));
+			int kc = Integer.parseInt(matcher.group(1).replace(",", ""));
 			setKc("Guardians of the Rift", kc);
 		}
 
@@ -633,7 +633,7 @@ public class ChatCommandsPlugin extends Plugin
 			String kcString = matcher.group("kc");
 			int kc = kcString.equals("one")
 				? 1
-				: Integer.parseInt(kcString.replaceAll(",", ""));
+				: Integer.parseInt(kcString.replace(",", ""));
 
 			setKc("Bird's egg offerings", kc);
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
@@ -623,7 +623,7 @@ public class ChatCommandsPlugin extends Plugin
 		matcher = GUARDIANS_OF_THE_RIFT_PATTERN.matcher(message);
 		if (matcher.find())
 		{
-			int kc = Integer.parseInt(matcher.group(1));
+			int kc = Integer.parseInt(matcher.group(1).replaceAll(",", ""));
 			setKc("Guardians of the Rift", kc);
 		}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatfilter/ChatFilterPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatfilter/ChatFilterPlugin.java
@@ -341,8 +341,8 @@ public class ChatFilterPlugin extends Plugin
 	{
 		String strippedMessage = jagexPrintableCharMatcher.retainFrom(message)
 			.replace('\u00A0', ' ')
-			.replaceAll("<lt>", "<")
-			.replaceAll("<gt>", ">");
+			.replace("<lt>", "<")
+			.replace("<gt>", ">");
 		String strippedAccents = stripAccents(strippedMessage);
 		assert strippedMessage.length() == strippedAccents.length();
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/crowdsourcing/dialogue/CrowdsourcingDialogue.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/crowdsourcing/dialogue/CrowdsourcingDialogue.java
@@ -54,7 +54,7 @@ public class CrowdsourcingDialogue
 	private String sanitize(String dialogue)
 	{
 		String username = client.getLocalPlayer().getName();
-		return dialogue.replaceAll(" ", " ").replaceAll(username, USERNAME_TOKEN);
+		return dialogue.replace(" ", " ").replace(username, USERNAME_TOKEN);
 	}
 
 	@Subscribe

--- a/runelite-client/src/main/java/net/runelite/client/plugins/fairyring/FairyRingPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/fairyring/FairyRingPlugin.java
@@ -300,7 +300,7 @@ public class FairyRingPlugin extends Plugin
 
 		for (CodeWidgets c : codes)
 		{
-			String code = Text.removeTags(c.getDescription().getName()).replaceAll(" ", "");
+			String code = Text.removeTags(c.getDescription().getName()).replace(" ", "");
 			String tags = null;
 
 			if (!code.isEmpty())

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grandexchange/GrandExchangePlugin.java
@@ -930,7 +930,7 @@ public class GrandExchangePlugin extends Plugin
 		final String url = runeLiteConfig.useWikiItemPrices() ?
 			"https://prices.runescape.wiki/" + (client.getWorldType().contains(net.runelite.api.WorldType.FRESH_START_WORLD) ? "fsw" : "osrs") + "/item/" + itemId :
 			"https://services.runescape.com/m=itemdb_oldschool/"
-				+ name.replaceAll(" ", "+")
+				+ name.replace(" ", "+")
 				+ "/viewitem?obj="
 				+ itemId;
 		LinkBrowser.browse(url);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/raids/solver/Layout.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/raids/solver/Layout.java
@@ -65,6 +65,6 @@ public class Layout
 
 	public String toCodeString()
 	{
-		return toCode().replaceAll("#", "").replaceAll("¤", "");
+		return toCode().replace("#", "").replace("¤", "");
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/runenergy/RunEnergyPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/runenergy/RunEnergyPlugin.java
@@ -243,7 +243,7 @@ public class RunEnergyPlugin extends Plugin
 			int charges = -1;
 			while (matcher.find())
 			{
-				charges = Integer.parseInt(matcher.group(1).replaceAll(",", ""));
+				charges = Integer.parseInt(matcher.group(1).replace(",", ""));
 			}
 
 			setRingOfEnduranceCharges(charges);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
@@ -472,7 +472,7 @@ public class ScreenshotPlugin extends Plugin
 			Matcher m = VALUABLE_DROP_PATTERN.matcher(chatMessage);
 			if (m.matches())
 			{
-				int valuableDropValue = Integer.parseInt(m.group(2).replaceAll(",", ""));
+				int valuableDropValue = Integer.parseInt(m.group(2).replace(",", ""));
 				if (valuableDropValue >= config.valuableDropThreshold())
 				{
 					String valuableDropName = m.group(1);

--- a/runelite-client/src/main/java/net/runelite/client/util/Text.java
+++ b/runelite-client/src/main/java/net/runelite/client/util/Text.java
@@ -143,8 +143,8 @@ public class Text
 	public static String sanitizeMultilineText(String str)
 	{
 		return removeTags(str
-			.replaceAll("-<br>", "-")
-			.replaceAll("<br>", " ")
+			.replace("-<br>", "-")
+			.replace("<br>", " ")
 			.replaceAll("[ ]+", " "));
 	}
 

--- a/runelite-client/src/test/java/net/runelite/client/plugins/chatcommands/ChatCommandsPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/chatcommands/ChatCommandsPluginTest.java
@@ -1266,10 +1266,10 @@ public class ChatCommandsPluginTest
 	@Test
 	public void testGuardiansOfTheRift()
 	{
-		ChatMessage chatMessage = new ChatMessage(null, GAMEMESSAGE, "", "Amount of rifts you have closed: <col=ff0000>167</col>.", null, 0);
+		ChatMessage chatMessage = new ChatMessage(null, GAMEMESSAGE, "", "Amount of rifts you have closed: <col=ff0000>1,627</col>.", null, 0);
 		chatCommandsPlugin.onChatMessage(chatMessage);
 
-		verify(configManager).setRSProfileConfiguration("killcount", "guardians of the rift", 167);
+		verify(configManager).setRSProfileConfiguration("killcount", "guardians of the rift", 1627);
 	}
 
 	@Test


### PR DESCRIPTION
Fixes the issue a user reported, their log shows that the value coming in was "1,841". 
[client (4).log](https://github.com/user-attachments/files/17106892/client.4.log)

This also removes the uses of replaceAll with replace for instances that regex is not used. 
