### PR TITLE
loot tracker: fix price type config changes not immediately reflecting

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPanel.java
@@ -477,6 +477,14 @@ class LootTrackerPanel extends PluginPanel
 	}
 
 	/**
+	 * Rebuilds loot entries when one of the price type config options is changed
+	 */
+	void updatePriceTypeDisplay()
+	{
+		rebuild();
+	}
+
+	/**
 	 * Rebuilds all the boxes from scratch using existing listed records, depending on the grouping mode.
 	 */
 	private void rebuild()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
@@ -570,6 +570,10 @@ public class LootTrackerPlugin extends Plugin
 				ignoredEvents = Text.fromCSV(config.getIgnoredEvents());
 				SwingUtilities.invokeLater(panel::updateIgnoredRecords);
 			}
+			else if ("priceType".equals(event.getKey()) || "showPriceType".equals(event.getKey()))
+			{
+				SwingUtilities.invokeLater(panel::updatePriceTypeDisplay);
+			}
 		}
 	}
 


### PR DESCRIPTION
The price type displays are only updating when rebuilt through other means such as viewing loot details.
