### PR TITLE
item identification: add wines

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemidentification/ItemIdentification.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemidentification/ItemIdentification.java
@@ -577,7 +577,21 @@ enum ItemIdentification
 
 	OCCULT_NECKLACE(Type.JEWELLERY_ENCHANTED, "Occult", "OCC", ItemID.OCCULT_NECKLACE),
 	DRAGONBONE_NECKLACE(Type.JEWELLERY_ENCHANTED, "Dragon", "DRA", ItemID.DRAGONBONE_NECKLACE),
-	SLAYER_RING(Type.JEWELLERY_ENCHANTED, "Slayer", "SLA", ItemID.SLAYER_RING_1, ItemID.SLAYER_RING_2, ItemID.SLAYER_RING_3, ItemID.SLAYER_RING_4, ItemID.SLAYER_RING_5, ItemID.SLAYER_RING_6, ItemID.SLAYER_RING_7, ItemID.SLAYER_RING_8, ItemID.SLAYER_RING_ETERNAL);
+	SLAYER_RING(Type.JEWELLERY_ENCHANTED, "Slayer", "SLA", ItemID.SLAYER_RING_1, ItemID.SLAYER_RING_2, ItemID.SLAYER_RING_3, ItemID.SLAYER_RING_4, ItemID.SLAYER_RING_5, ItemID.SLAYER_RING_6, ItemID.SLAYER_RING_7, ItemID.SLAYER_RING_8, ItemID.SLAYER_RING_ETERNAL),
+
+	// Wines
+	JUG_OF_WATER(Type.WINES, "Water", "Wat", ItemID.JUG_WATER),
+	UNFERMENTED_WINE(Type.WINES, "Unf.", "U", ItemID.JUG_UNFERMENTED_WINE),
+	ZAMORAKS_UNFERMENTED_WINE(Type.WINES, "Unf. Z", "UZ", ItemID.JUG_UNFERMENTED_ZAMORAK_WINE),
+
+	JUG_OF_WINE(Type.WINES, "Wine", "W", ItemID.JUG_WINE),
+	WINE_OF_ZAMORAK(Type.WINES, "Zammy", "Z", ItemID.WINE_OF_ZAMORAK),
+	JUG_OF_BAD_WINE(Type.WINES, "Bad", "Bad", ItemID.JUG_BAD_WINE),
+	HALF_FULL_WINE_JUG(Type.WINES, "Half", "HF", ItemID.HALF_FULL_WINE_JUG),
+
+	JUG_OF_BLESSED_WINE(Type.WINES, "Blessed", "B", ItemID.JUG_WINE_BLESSED),
+	JUG_OF_SUNFIRE_WINE(Type.WINES, "Sunfire", "S", ItemID.JUG_SUNFIRE_WINE),
+	JUG_OF_BLESSED_SUNFIRE_WINE(Type.WINES, "B. Sun", "BS", ItemID.JUG_SUNFIRE_WINE_BLESSED);
 
 	final Type type;
 	final String medName;
@@ -641,7 +655,8 @@ enum ItemIdentification
 		TABLET(ItemIdentificationConfig::showTablets),
 		SCROLL(ItemIdentificationConfig::showTeleportScrolls),
 		JEWELLERY(ItemIdentificationConfig::showJewellery),
-		JEWELLERY_ENCHANTED(ItemIdentificationConfig::showEnchantedJewellery);
+		JEWELLERY_ENCHANTED(ItemIdentificationConfig::showEnchantedJewellery),
+		WINES(ItemIdentificationConfig::showWines);
 
 		final Predicate<ItemIdentificationConfig> enabled;
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemidentification/ItemIdentificationConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemidentification/ItemIdentificationConfig.java
@@ -336,4 +336,15 @@ public interface ItemIdentificationConfig extends Config
 	{
 		return false;
 	}
+
+	@ConfigItem(
+		keyName = "showWines",
+		name = "Wines",
+		description = "Show identification on jugs of wine.",
+		section = identificationSection
+	)
+	default boolean showWines()
+	{
+		return false;
+	}
 }


### PR DESCRIPTION
Add jugs of wine (+water) and related config options to the ItemIdentification plugin.

Jugs of wine all look similar, so they're a perfect candidate to be added to the ItemIdentification plugin. Very useful for Cooking training (water -> unfermented -> wine) or Varlamore Prayer training (wine -> sunfire wine -> blessed). 

New Config entry:
![Config](https://github.com/user-attachments/assets/8e9b4b34-58ad-41e4-9558-ebb1a9c24ef8)

Previous/Disabled: 
![Disabled](https://github.com/user-attachments/assets/6d4095d4-7abd-4d0c-8cf0-ace898462f35)

Medium names: 
![Med](https://github.com/user-attachments/assets/c00d8c07-67a8-4b6c-aada-2cdaeadc79b4)

Short names:
![Short](https://github.com/user-attachments/assets/b320fff4-7aa2-4656-82dd-2de99267e22b)
