### PR TITLE
fairyring: add CKQ

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/fairyring/FairyRings.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/fairyring/FairyRings.java
@@ -69,6 +69,7 @@ public enum FairyRings
 	CIS("North of the Arceuus Library"),
 	CJR("Sinclair Mansion", "falo bard"),
 	CKP("Cosmic entity's plane"),
+	CKQ("Aldarin"),
 	CKR("South of Tai Bwo Wannai Village"),
 	CKS("Canifis"),
 	CLP("(Island) South of Draynor Village"),

--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldmap/FairyRingLocation.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldmap/FairyRingLocation.java
@@ -65,6 +65,7 @@ enum FairyRingLocation
 	CIS("CIS", new WorldPoint(1636, 3869, 0)),
 	CJR("CJR", new WorldPoint(2704, 3578, 0)),
 	// CKP - Exists in game but not on World Map
+	CKQ("CKQ", new WorldPoint(1358, 2943, 0)),
 	CKR("CKR", new WorldPoint(2800, 3005, 0)),
 	CKS("CKS", new WorldPoint(3446, 3472, 0)),
 	CLP("CLP", new WorldPoint(3081, 3208, 0)),


### PR DESCRIPTION
This PR adds the new fairy ring location (CKQ) to the fairy ring plugin and the worldmap.