### PR TITLE
loot tracker: add moon chest and aldarin villas chest

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
@@ -188,6 +188,8 @@ public class LootTrackerPlugin extends Plugin
 		put(13117, "Rogues' Chest").
 		put(13156, "Chest (Ancient Vault)").
 		put(12348, "Muddy Chest").
+		put(5422, "Chest (Aldarin Villas)").
+		put(6550, "Chest (Moon key)").
 		build();
 
 	// Chests opened with keys from slayer tasks


### PR DESCRIPTION
Adding two chests to loot tracker:
- <https://oldschool.runescape.wiki/w/Chest_(Aldarin_Villas)> uses `OTHER_CHEST_LOOTED_MESSAGE`
- <https://oldschool.runescape.wiki/w/Chest_(Moon_key)> uses `CHEST_LOOTED_MESSAGE`