### PR TITLE
menu entry swapper: reprioritise swaps so that farmers have their 'pay' options above 'trade'

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -197,6 +197,9 @@ public class MenuEntrySwapperPlugin extends Plugin
 		swap("talk-to", "help", config::swapHelp);
 		// make sure assignment swap is higher priority than trade swap for slayer masters
 		swap("talk-to", "assignment", config::swapAssignment);
+		// make sure pay swaps are higher priority than trade swap for farmers
+		swap("talk-to", "pay", config::swapPay);
+		swapContains("talk-to", alwaysTrue(), "pay (", config::swapPay);
 		swap("talk-to", "trade", config::swapTrade);
 		swap("talk-to", "trade-with", config::swapTrade);
 		swap("talk-to", "shop", config::swapTrade);
@@ -215,8 +218,6 @@ public class MenuEntrySwapperPlugin extends Plugin
 		swap("talk-to", "miscellania", config::swapTravel);
 		swap("talk-to", "follow", config::swapTravel);
 		swap("talk-to", "transport", config::swapTravel);
-		swap("talk-to", "pay", config::swapPay);
-		swapContains("talk-to", alwaysTrue(), "pay (", config::swapPay);
 		swap("talk-to", "quick-travel", config::swapQuick);
 		swap("talk-to", ESSENCE_MINE_NPCS::contains, "teleport", config::swapEssenceMineTeleport);
 		swap("talk-to", "deposit-items", config::swapDepositItems);


### PR DESCRIPTION
Close [#18322](https://github.com/runelite/runelite/issues/18322)
Make "Pay" and "Pay (*" prioritise over "Trade" in the default menu entry swapper plugin (if/when both options are enabled). 

With the new Varlamore update, patch farmers now have both a "Trade" option and a "Pay" option. The menu entry swapper plugin currently prioritises "Trade" over "Pay", when for farmers this should likely be reversed (similar to Slayer masters prioritising "Assignment" over "Trade"). 

One side effect is that this also makes "Pay" the default option for Petrified Pete at the Volcanic Mine - but if users wish to change this, they can use the shift+right-click feature of the plugin to set a specific override for that NPC. The farmers are by far more common, and would require much more effort by users to prioritise the "Pay" option themselves. 

Both options enabled:
![Settings_Enabled](https://github.com/user-attachments/assets/a0653dfa-bef1-4887-bc71-a34433bc5652)
![Pay+Trade](https://github.com/user-attachments/assets/1adf5d40-aa24-423f-b830-f315c704367f) ![Pay(+Trade](https://github.com/user-attachments/assets/5985d94f-840f-458f-9770-5519574511bd) ![Multiple_Pay](https://github.com/user-attachments/assets/25aeb7d9-a8a9-4c77-92be-65207da317fb)
NPCs with only "Trade" are not treated any differently to previous version:
![Just_Trade](https://github.com/user-attachments/assets/1a9de7e0-74cd-4829-b72d-e3db66691834)
Effect on Petrified Pete:
![Pete](https://github.com/user-attachments/assets/857eedef-4fe0-4f03-b0dd-51de4c344e0c)
Effect if the user has only "Trade" swapper enabled
![Pay_Disabled](https://github.com/user-attachments/assets/c0b36e93-fab5-4c84-88bb-bf57940c6d25)
![Pay_Disabled2](https://github.com/user-attachments/assets/ba65ac04-0f3a-47f0-9d26-897943b41b63)
