### PR TITLE
loot tracker: hueycoatl

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/AnimationID.java
+++ b/runelite-api/src/main/java/net/runelite/api/AnimationID.java
@@ -368,4 +368,6 @@ public final class AnimationID
 	public static final int GWENITH_WINDMILL_SPINNING = 6495;
 	public static final int LITHKREN_GENERATOR_SPINNING = 7898;
 	public static final int GIANTS_FOUNDRY_WATER_WHEEL_SPINNING = 9450;
+
+	public static final int HUEYCOATL_DEATH = 11679;
 }

--- a/runelite-client/src/main/java/net/runelite/client/game/LootManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/game/LootManager.java
@@ -68,7 +68,8 @@ import net.runelite.client.events.PlayerLootReceived;
 public class LootManager
 {
 	private static final Map<Integer, Integer> NPC_DEATH_ANIMATIONS = ImmutableMap.of(
-		NpcID.CAVE_KRAKEN, AnimationID.CAVE_KRAKEN_DEATH
+		NpcID.CAVE_KRAKEN, AnimationID.CAVE_KRAKEN_DEATH,
+		NpcID.THE_HUEYCOATL_14012, AnimationID.HUEYCOATL_DEATH
 	);
 
 	private final EventBus eventBus;
@@ -437,6 +438,11 @@ public class LootManager
 			{
 				final WorldArea bossArea = npc.getWorldArea();
 				return List.of(new WorldArea(bossArea.getX() - 1, bossArea.getY() - 1, 3, 3, bossArea.getPlane()));
+			}
+			case NpcID.THE_HUEYCOATL_14012:
+			{
+				final WorldArea bossArea = npc.getWorldArea();
+				return List.of(new WorldArea(bossArea.getX() - 2, bossArea.getY() - 10, 10, 10, bossArea.getPlane()));
 			}
 		}
 


### PR DESCRIPTION
adds huey loot tracking via the death animation

special mentions:
* the boss changes id and plays the death animation at the same time, so either detection method could have worked
* the boss never actually despawns at all
* loot location doesn't seem to be tied to player location, either current or previous tick, so we just check a large area
* mvp gets bones! but that has no bearing on the code