### PR TITLE
timers buffs: add WGS timers and buffs

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/SpriteID.java
+++ b/runelite-api/src/main/java/net/runelite/api/SpriteID.java
@@ -1726,7 +1726,8 @@ public final class SpriteID
 	public static final int HEALTHBAR_PURPLE_BACK_160PX = 4727;
 	/* Unmapped: 4728~4765 */
 	public static final int COLOSSEUM_DOOM = 4766;
-	/* Unmapped: 4767~4770 */
+	public static final int BURN_DAMAGE = 4767;
+	/* Unmapped: 4768~4770 */
 	public static final int HEALTHBAR_GREEN_FRONT_30PX = 4771;
 	public static final int HEALTHBAR_GREEN_BACK_30PX = 4772;
 	public static final int HEALTHBAR_GREEN_FRONT_40PX = 4773;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timersandbuffs/GameCounter.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timersandbuffs/GameCounter.java
@@ -36,6 +36,8 @@ import net.runelite.api.gameval.ItemID;
 @AllArgsConstructor
 enum GameCounter
 {
+	BURN_DAMAGE_ACCUMULATED(SpriteID.BURN_DAMAGE, GameTimerImageType.SPRITE, "Burn damage accumulated"),
+	BURN_DAMAGE_NEXT_HIT(ItemID.BONE_CLAW, GameTimerImageType.ITEM, "Burn damage next hit"),
 	COLOSSEUM_DOOM(SpriteID.COLOSSEUM_DOOM, GameTimerImageType.SPRITE, "Doom"),
 	CURSE_OF_THE_MOONS_BLUE(ItemID.FROST_MOON_HELM, GameTimerImageType.ITEM, "Curse of the Moons (Blue Moon)", ColorBoundaryType.GREATER_THAN_EQUAL_TO, 18, Color.RED),
 	CURSE_OF_THE_MOONS_ECLIPSE(ItemID.ECLIPSE_MOON_HELM, GameTimerImageType.ITEM, "Curse of the Moons (Eclipse Moon)"),

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timersandbuffs/GameCounter.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timersandbuffs/GameCounter.java
@@ -39,6 +39,7 @@ enum GameCounter
 	COLOSSEUM_DOOM(SpriteID.COLOSSEUM_DOOM, GameTimerImageType.SPRITE, "Doom"),
 	CURSE_OF_THE_MOONS_BLUE(ItemID.FROST_MOON_HELM, GameTimerImageType.ITEM, "Curse of the Moons (Blue Moon)", ColorBoundaryType.GREATER_THAN_EQUAL_TO, 18, Color.RED),
 	CURSE_OF_THE_MOONS_ECLIPSE(ItemID.ECLIPSE_MOON_HELM, GameTimerImageType.ITEM, "Curse of the Moons (Eclipse Moon)"),
+	STONE_OF_JAS_EMPOWERMENT(ItemID.WGS_STONE_OF_JAS_DUMMY_ITEM, GameTimerImageType.ITEM, "Stone of Jas empowerment", false),
 	VENGEANCE_ACTIVE(SpriteID.SPELL_VENGEANCE_OTHER, GameTimerImageType.SPRITE, "Vengeance active", false),
 	;
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timersandbuffs/GameTimer.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timersandbuffs/GameTimer.java
@@ -99,6 +99,7 @@ enum GameTimer
 	BLESSED_CRYSTAL_SCARAB(ItemID.TOA_SUPPLY_PRAYER_OVERTIME_2, GameTimerImageType.ITEM, "Blessed crystal scarab", 40, GAME_TICKS, true),
 	SPELLBOOK_SWAP(SpriteID.SPELL_SPELLBOOK_SWAP, GameTimerImageType.SPRITE, "Spellbook Reset", 120, ChronoUnit.SECONDS, false),
 	SMOULDERING_HEART(ItemID.SMOULDERING_HEART, GameTimerImageType.ITEM, "Smouldering heart", false),
+	SMOULDERING_GLAND(ItemID.SMOULDERING_GLAND, GameTimerImageType.ITEM, "Smouldering gland", false),
 	GOADING(ItemID._4DOSEGOADING, GameTimerImageType.ITEM, "Goading potion", false),
 	PRAYER_REGENERATION(ItemID._4DOSE1PRAYER_REGENERATION, GameTimerImageType.ITEM, "Prayer regeneration", false),
 	;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timersandbuffs/GameTimer.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timersandbuffs/GameTimer.java
@@ -98,6 +98,7 @@ enum GameTimer
 	SILK_DRESSING(ItemID.TOA_SUPPLY_HEAL_OVERTIME_2, GameTimerImageType.ITEM, "Silk dressing", 100, GAME_TICKS, true),
 	BLESSED_CRYSTAL_SCARAB(ItemID.TOA_SUPPLY_PRAYER_OVERTIME_2, GameTimerImageType.ITEM, "Blessed crystal scarab", 40, GAME_TICKS, true),
 	SPELLBOOK_SWAP(SpriteID.SPELL_SPELLBOOK_SWAP, GameTimerImageType.SPRITE, "Spellbook Reset", 120, ChronoUnit.SECONDS, false),
+	SMOULDERING_HEART(ItemID.SMOULDERING_HEART, GameTimerImageType.ITEM, "Smouldering heart", false),
 	GOADING(ItemID._4DOSEGOADING, GameTimerImageType.ITEM, "Goading potion", false),
 	PRAYER_REGENERATION(ItemID._4DOSE1PRAYER_REGENERATION, GameTimerImageType.ITEM, "Prayer regeneration", false),
 	;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timersandbuffs/TimersAndBuffsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timersandbuffs/TimersAndBuffsConfig.java
@@ -479,6 +479,28 @@ public interface TimersAndBuffsConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "showBurnDamageAccumulated",
+		name = "Burn damage accumulated",
+		description = "Configures whether the accumulated burn damage on the local player is displayed.",
+		section = miscellaneousSection
+	)
+	default boolean showBurnDamageAccumulated()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		keyName = "showBurnDamageNextHit",
+		name = "Burn damage next hit",
+		description = "Configures whether the next hit of burn damage on the local player is displayed.",
+		section = miscellaneousSection
+	)
+	default boolean showBurnDamageNextHit()
+	{
+		return false;
+	}
+
+	@ConfigItem(
 		keyName = "showScurriusFoodPile",
 		name = "Scurrius food pile",
 		description = "Configures whether the Scurrius food pile timer is displayed.",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timersandbuffs/TimersAndBuffsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timersandbuffs/TimersAndBuffsConfig.java
@@ -488,4 +488,15 @@ public interface TimersAndBuffsConfig extends Config
 	{
 		return true;
 	}
+
+	@ConfigItem(
+		keyName = "showTormentedDemonBuffs",
+		name = "Tormented demon buffs",
+		description = "Configures whether Tormented demon-related buffs are displayed.",
+		section = bossesSection
+	)
+	default boolean showTormentedDemonBuffs()
+	{
+		return true;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timersandbuffs/TimersAndBuffsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timersandbuffs/TimersAndBuffsPlugin.java
@@ -996,7 +996,7 @@ public class TimersAndBuffsPlugin extends Plugin
 			}
 			else if (message.endsWith(MARK_OF_DARKNESS_MESSAGE))
 			{
-				createGameTimer(MARK_OF_DARKNESS, Duration.of(magicLevel, RSTimeUnit.GAME_TICKS));
+				createGameTimer(MARK_OF_DARKNESS, Duration.of(getMagicLevelMoD(magicLevel), RSTimeUnit.GAME_TICKS));
 			}
 			else if (message.contains(RESURRECT_THRALL_MESSAGE_START) && message.endsWith(RESURRECT_THRALL_MESSAGE_END))
 			{
@@ -1017,8 +1017,8 @@ public class TimersAndBuffsPlugin extends Plugin
 
 		if (message.endsWith(MARK_OF_DARKNESS_MESSAGE) && config.showArceuusCooldown())
 		{
-			final int magicLevel = client.getRealSkillLevel(Skill.MAGIC);
-			createGameTimer(MARK_OF_DARKNESS_COOLDOWN, Duration.of(magicLevel - 10, RSTimeUnit.GAME_TICKS));
+			final int magicLevelMoD = getMagicLevelMoD(client.getRealSkillLevel(Skill.MAGIC));
+			createGameTimer(MARK_OF_DARKNESS_COOLDOWN, Duration.of(magicLevelMoD - 10, RSTimeUnit.GAME_TICKS));
 		}
 
 		if (TZHAAR_PAUSED_MESSAGE.matcher(message).find())
@@ -1088,6 +1088,20 @@ public class TimersAndBuffsPlugin extends Plugin
 		{
 			createGameTimer(LIQUID_ADRENALINE);
 		}
+	}
+
+	private int getMagicLevelMoD(int magicLevel)
+	{
+		final ItemContainer container = client.getItemContainer(InventoryID.WORN);
+		if (container != null)
+		{
+			final Item weapon = container.getItem(EquipmentInventorySlot.WEAPON.getSlotIdx());
+			if (weapon != null && weapon.getId() == ItemID.PURGING_STAFF)
+			{
+				return magicLevel * 5;
+			}
+		}
+		return magicLevel;
 	}
 
 	private boolean isInFightCaves()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timersandbuffs/TimersAndBuffsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timersandbuffs/TimersAndBuffsPlugin.java
@@ -618,6 +618,16 @@ public class TimersAndBuffsPlugin extends Plugin
 			updateVarCounter(STONE_OF_JAS_EMPOWERMENT, event.getValue());
 		}
 
+		if (event.getVarbitId() == VarbitID.PLAYER_OWN_BURN_DAMAGE_TOTAL && config.showBurnDamageAccumulated())
+		{
+			updateVarCounter(BURN_DAMAGE_ACCUMULATED, event.getValue());
+		}
+
+		if (event.getVarbitId() == VarbitID.PLAYER_OWN_BURN_DAMAGE_HITSPLAT_SIZE && config.showBurnDamageNextHit())
+		{
+			updateVarCounter(BURN_DAMAGE_NEXT_HIT, event.getValue());
+		}
+
 		if (event.getVarbitId() == VarbitID.GOADING_POTION_TIMER && config.showGoading())
 		{
 			updateVarTimer(GOADING, event.getValue(), i -> i * 6);
@@ -848,6 +858,16 @@ public class TimersAndBuffsPlugin extends Plugin
 		if (!config.showMoonlightPotion())
 		{
 			removeVarTimer(MOONLIGHT_POTION);
+		}
+
+		if (!config.showBurnDamageAccumulated())
+		{
+			removeVarCounter(BURN_DAMAGE_ACCUMULATED);
+		}
+
+		if (!config.showBurnDamageNextHit())
+		{
+			removeVarCounter(BURN_DAMAGE_NEXT_HIT);
 		}
 
 		if (!config.showGoading())

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timersandbuffs/TimersAndBuffsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timersandbuffs/TimersAndBuffsPlugin.java
@@ -633,6 +633,11 @@ public class TimersAndBuffsPlugin extends Plugin
 			updateVarTimer(SMOULDERING_HEART, event.getValue(), i -> i * 25);
 		}
 
+		if (event.getVarbitId() == VarbitID.WGS_SMOULDERING_GLAND_TIMER && config.showTormentedDemonBuffs())
+		{
+			updateVarTimer(SMOULDERING_GLAND, event.getValue(), i -> i * 4);
+		}
+
 		if (event.getVarbitId() == VarbitID.GOADING_POTION_TIMER && config.showGoading())
 		{
 			updateVarTimer(GOADING, event.getValue(), i -> i * 6);
@@ -690,6 +695,7 @@ public class TimersAndBuffsPlugin extends Plugin
 		{
 			removeVarCounter(STONE_OF_JAS_EMPOWERMENT);
 			removeGameTimer(SMOULDERING_HEART);
+			removeGameTimer(SMOULDERING_GLAND);
 		}
 
 		if (!config.showPrayerEnhance())

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timersandbuffs/TimersAndBuffsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timersandbuffs/TimersAndBuffsPlugin.java
@@ -628,6 +628,11 @@ public class TimersAndBuffsPlugin extends Plugin
 			updateVarCounter(BURN_DAMAGE_NEXT_HIT, event.getValue());
 		}
 
+		if (event.getVarbitId() == VarbitID.WGS_SMOULDERING_HEART_TIMER && config.showTormentedDemonBuffs())
+		{
+			updateVarTimer(SMOULDERING_HEART, event.getValue(), i -> i * 25);
+		}
+
 		if (event.getVarbitId() == VarbitID.GOADING_POTION_TIMER && config.showGoading())
 		{
 			updateVarTimer(GOADING, event.getValue(), i -> i * 6);
@@ -684,6 +689,7 @@ public class TimersAndBuffsPlugin extends Plugin
 		if (!config.showTormentedDemonBuffs())
 		{
 			removeVarCounter(STONE_OF_JAS_EMPOWERMENT);
+			removeGameTimer(SMOULDERING_HEART);
 		}
 
 		if (!config.showPrayerEnhance())

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timersandbuffs/TimersAndBuffsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timersandbuffs/TimersAndBuffsPlugin.java
@@ -613,6 +613,11 @@ public class TimersAndBuffsPlugin extends Plugin
 			updateVarTimer(MOONLIGHT_POTION, moonlightValue, IntUnaryOperator.identity());
 		}
 
+		if (event.getVarbitId() == VarbitID.WGS_STONE_OF_JAS_BOOST && config.showTormentedDemonBuffs())
+		{
+			updateVarCounter(STONE_OF_JAS_EMPOWERMENT, event.getValue());
+		}
+
 		if (event.getVarbitId() == VarbitID.GOADING_POTION_TIMER && config.showGoading())
 		{
 			updateVarTimer(GOADING, event.getValue(), i -> i * 6);
@@ -664,6 +669,11 @@ public class TimersAndBuffsPlugin extends Plugin
 			removeGameTimer(OVERLOAD);
 			removeGameTimer(OVERLOAD_RAID);
 			removeGameTimer(SMELLING_SALTS);
+		}
+
+		if (!config.showTormentedDemonBuffs())
+		{
+			removeVarCounter(STONE_OF_JAS_EMPOWERMENT);
 		}
 
 		if (!config.showPrayerEnhance())


### PR DESCRIPTION
Adds the WGS timers and buffs:
- Stone of Jas empowerment
  - Please DM me for Stone of Jas empowerment testing videos. Alternatively, if it's deemed too niche, the commit can be dropped. I assumed Jagex added it to the EHC buff bar with a reason though.
- Burn damage accumulated and next burn hit
  - EHC buff bar video: https://youtu.be/60e66gQ9Z5s
  - Test on RL: https://www.youtube.com/watch?v=dI0H-s5mYrE
- Adds smouldering heart & smouldering gland (TD consumables)
  - Unlike normally, I was not able to test the these, as they're relatively rare drops from TDs. The varbits are from script 5923, and 25 & 4 are from struct 965 and 966 respectively (param 1541, from script 5923).
  -  The wiki notes that teleporting away removes the effect from the smouldering gland -> ``removedOnDeath`` = false because  right now the timer is entirely controlled by var updates. I strongly suspect Jagex will set the varbit to 0 when teleporting away (like the Stone of Jas empowerment), among others based on the CS2 code, so EHC displays the buff correctly.
     - If this would not be the case, we'd have to check the regionIDs for the cave, as TDs are in >1 region, so just removing it on GameState.LOADING would not work.  
  - The wiki notes ``its effects carry over upon death`` for the smouldering heart ->  removedOnDeath = false.
- Fixes Mark of Darkness duration and cooldown timers when wearing the Purging Staff.
  - Tl;dr: If the staff is equipped when casting, the duration will be 5x. It can be unequipped (even banked) while the mark is active. Equipping it with a 1 minute mark active obviously does not prolong the duration.
  - Test: https://youtu.be/SQFkLgK8JTY and https://youtu.be/jAg2dU6IHog
  - Fixes https://github.com/runelite/runelite/issues/18128

Force pushes below are mostly to fix merge conflicts every time a new varbit, timer, or sprite gets added.