### PR TITLE
timetracking: add aldarin farming patch

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/farming/FarmingWorld.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/farming/FarmingWorld.java
@@ -71,6 +71,10 @@ class FarmingWorld
 			new FarmingPatch("", Varbits.FARMING_4771, PatchImplementation.CACTUS, NpcID.AYESHA)
 		), 13362, 13105);
 
+		add(new FarmingRegion("Aldarin", 5421, false,
+			new FarmingPatch("", Varbits.FARMING_4771, PatchImplementation.HOPS, NpcID.ERCOS)
+		), 5165, 5166, 5422, 5677, 5678);
+
 		add(new FarmingRegion("Ardougne", 10290, false,
 			new FarmingPatch("", Varbits.FARMING_4771, PatchImplementation.BUSH, NpcID.TORRELL)
 		), 10546);


### PR DESCRIPTION
This PR adds the Aldarin hops farming patch to the time tracking plugin.
Closes #18344 