### PR TITLE
worldmap: add spider cave teleport

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldmap/TeleportLocationData.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldmap/TeleportLocationData.java
@@ -200,6 +200,7 @@ enum TeleportLocationData
 	KEY_MASTER_SCROLL(TeleportType.SCROLL, "Key Master Teleport", new WorldPoint(2686, 9882, 0), "scroll_teleport_icon.png"),
 	REVENANT_CAVE_SCROLL(TeleportType.SCROLL, "Revenant Cave Teleport", new WorldPoint(3127, 3833, 0), "scroll_teleport_icon.png"),
 	WATSON_SCROLL(TeleportType.SCROLL, "Watson Teleport", new WorldPoint(1645, 3579, 0), "scroll_teleport_icon.png"),
+	SPIDER_CAVE_SCROLL(TeleportType.SCROLL, "Spider cave teleport", new WorldPoint(3658, 3403, 0), "scroll_teleport_icon.png"),
 
 	// Skillcapes
 	ACHIEVEMENT_CAPE_TWO_PINTS(TeleportType.OTHER, "Achievement Cape", "Two-pints", new WorldPoint(2574, 3324, 0), "achievement_cape_icon.png"),


### PR DESCRIPTION
Adds the spider cave teleport to the worldmap. Based on 50-60 teleports (thanks beta worlds!), it's a 3x3 this time.

![teleportlocations](https://github.com/user-attachments/assets/a105447a-40a2-4f6d-a46b-606645f3b984)

![worldmap](https://github.com/user-attachments/assets/f8b6cd4e-f070-4b10-b8db-b2878dd05ac6)
