### PR TITLE
crowdsourcing: track *worn* max cape instead of inventory one

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/crowdsourcing/thieving/CrowdsourcingThieving.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/crowdsourcing/thieving/CrowdsourcingThieving.java
@@ -77,7 +77,7 @@ public class CrowdsourcingThieving
 
 		return equipmentContainer.contains(ItemID.THIEVING_CAPE) ||
 			equipmentContainer.contains(ItemID.THIEVING_CAPET) ||
-			equipmentContainer.contains(ItemID.MAX_CAPE);
+			equipmentContainer.contains(ItemID.MAX_CAPE_13342);
 	}
 
 	private int getArdougneDiary()


### PR DESCRIPTION
Fixes thieving crowdsourcing currently checking the equipment container for the inventory version of max cape. Currently we have to filter out a decent amount of pickpocket data.