### PR TITLE
gpu: regions: add regions for areas from Shilo Village and What Lies Below

### DIFF
--- a/runelite-client/src/main/resources/net/runelite/client/plugins/gpu/regions/regions.txt
+++ b/runelite-client/src/main/resources/net/runelite/client/plugins/gpu/regions/regions.txt
@@ -357,3 +357,11 @@ r 51 150
 // desert mining camp (the tourist trap)
 n
 r 51 147
+
+// ah za rhoon (shilo village)
+n
+R 45 145 45 146
+
+// tomb of bervirius (shilo village)
+n
+r 43 146

--- a/runelite-client/src/main/resources/net/runelite/client/plugins/gpu/regions/regions.txt
+++ b/runelite-client/src/main/resources/net/runelite/client/plugins/gpu/regions/regions.txt
@@ -365,3 +365,7 @@ R 45 145 45 146
 // tomb of bervirius (shilo village)
 n
 r 43 146
+
+// tunnel of chaos (what lies below)
+n
+r 49 81


### PR DESCRIPTION
Adds GPU regions for the following areas:
- Ah Za Rhoon (Shilo Village):
- Tomb of Bervirius (Shilo Village)
- Tunnel of Chaos (What Lies Below)

Ah Za Rhoon (Shilo Village):
![Before](https://github.com/user-attachments/assets/df81f377-a7a1-4824-bed0-b3c3a7ad2049)

![After](https://github.com/user-attachments/assets/f771e1dd-1d5e-4639-adb7-17f3c66fea3e)

Tomb of Bervirius (Shilo Village):
![Before](https://github.com/user-attachments/assets/bcc16bac-9e1d-42ec-89a9-a9d75b91d56c)

![After](https://github.com/user-attachments/assets/046ff3a1-0d3e-4a2b-b484-3d6c1d1ea463)

Tunnel of Chaos (What Lies Below):
![Before](https://github.com/user-attachments/assets/e336d292-8c07-4a6e-88da-854e067018a2)

![After](https://github.com/user-attachments/assets/dff36a3f-5f24-48a5-b4f5-b1ee7ce17c86)
