### PR TITLE
Smooth color interpolation between item value tiers and Stackable item value scaling for coloring

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
@@ -137,7 +137,7 @@ public interface GroundItemsConfig extends Config
 	@ConfigItem(
 		keyName = "deprioritizeHiddenItems",
 		name = "Deprioritize Menu Hidden Items",
-		description = "Depriotizies the menu options for items which are hidden, requiring a right click to pick up.",
+		description = "Deprioritizes the menu options for items which are hidden, requiring a right click to pick up.",
 		position = 5
 	)
 	default boolean deprioritizeHiddenItems()
@@ -189,6 +189,9 @@ public interface GroundItemsConfig extends Config
 		return PriceDisplayMode.BOTH;
 	}
 
+
+
+
 	@ConfigItem(
 		keyName = "itemHighlightMode",
 		name = "Item Highlight Mode",
@@ -233,12 +236,28 @@ public interface GroundItemsConfig extends Config
 		return 0;
 	}
 
+	@ConfigItem(
+		keyName = "scaleStackableColoringPrice",
+		name = "Adjust stackable item value",
+		description = "Adjusts the price value used to determine coloring for stackable items by a specified factor",
+		position = 14
+	)
+	default boolean scaleStackableColoringPrice() { return false; }
+
+	@ConfigItem(
+			keyName = "stackableColoringPriceScaleFactor",
+			name = "Stackable item value factor",
+			description = "Configures the factor by which stackable item price values are adjusted for coloring",
+			position = 15
+	)
+	default double stackableColoringPriceScaleFactor() { return 1.25; }
+
 	@Alpha
 	@ConfigItem(
 		keyName = "defaultColor",
 		name = "Default items",
 		description = "Configures the color for default, non-highlighted items",
-		position = 14
+		position = 16
 	)
 	default Color defaultColor()
 	{
@@ -250,7 +269,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "highlightedColor",
 		name = "Highlighted items",
 		description = "Configures the color for highlighted items",
-		position = 15
+		position = 17
 	)
 	default Color highlightedColor()
 	{
@@ -262,7 +281,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "hiddenColor",
 		name = "Hidden items",
 		description = "Configures the color for hidden items in right-click menu and when holding ALT",
-		position = 16
+		position = 18
 	)
 	default Color hiddenColor()
 	{
@@ -274,7 +293,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "lowValueColor",
 		name = "Low value items",
 		description = "Configures the color for low value items",
-		position = 17
+		position = 19
 	)
 	default Color lowValueColor()
 	{
@@ -285,7 +304,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "lowValuePrice",
 		name = "Low value price",
 		description = "Configures the start price for low value items",
-		position = 18
+		position = 20
 	)
 	default int lowValuePrice()
 	{
@@ -297,7 +316,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "mediumValueColor",
 		name = "Medium value items",
 		description = "Configures the color for medium value items",
-		position = 19
+		position = 21
 	)
 	default Color mediumValueColor()
 	{
@@ -308,7 +327,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "mediumValuePrice",
 		name = "Medium value price",
 		description = "Configures the start price for medium value items",
-		position = 20
+		position = 22
 	)
 	default int mediumValuePrice()
 	{
@@ -320,7 +339,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "highValueColor",
 		name = "High value items",
 		description = "Configures the color for high value items",
-		position = 21
+		position = 23
 	)
 	default Color highValueColor()
 	{
@@ -331,7 +350,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "highValuePrice",
 		name = "High value price",
 		description = "Configures the start price for high value items",
-		position = 22
+		position = 24
 	)
 	default int highValuePrice()
 	{
@@ -343,7 +362,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "insaneValueColor",
 		name = "Insane value items",
 		description = "Configures the color for insane value items",
-		position = 23
+		position = 25
 	)
 	default Color insaneValueColor()
 	{
@@ -354,7 +373,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "insaneValuePrice",
 		name = "Insane value price",
 		description = "Configures the start price for insane value items",
-		position = 24
+		position = 26
 	)
 	default int insaneValuePrice()
 	{
@@ -362,10 +381,18 @@ public interface GroundItemsConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "interpolateLootColors",
+		name = "Smoothed color tiers",
+		description = "Configures whether or not color is smoothly blended between tiers based on item value",
+		position = 27
+	)
+	default boolean interpolateLootColors() { return false; }
+
+	@ConfigItem(
 		keyName = "onlyShowLoot",
 		name = "Only show own items",
 		description = "Only shows items that are yours or you can pick up",
-		position = 25
+		position = 28
 	)
 	default boolean onlyShowOwnItems()
 	{
@@ -376,7 +403,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "doubleTapDelay",
 		name = "Double-tap delay",
 		description = "Delay for the double-tap ALT to hide ground items. 0 to disable.",
-		position = 26
+		position = 29
 	)
 	@Units(Units.MILLISECONDS)
 	default int doubleTapDelay()
@@ -388,7 +415,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "collapseEntries",
 		name = "Collapse ground item menu",
 		description = "Collapses ground item menu entries together and appends count",
-		position = 27
+		position = 30
 	)
 	default boolean collapseEntries()
 	{
@@ -399,7 +426,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "groundItemTimers",
 		name = "Despawn timer",
 		description = "Shows despawn timers for items you've dropped and received as loot",
-		position = 28
+		position = 31
 	)
 	default DespawnTimerMode groundItemTimers()
 	{
@@ -410,7 +437,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "textOutline",
 		name = "Text Outline",
 		description = "Use an outline around text instead of a text shadow",
-		position = 29
+		position = 32
 	)
 	default boolean textOutline()
 	{
@@ -421,7 +448,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "showLootbeamForHighlighted",
 		name = "Highlighted item lootbeams",
 		description = "Configures lootbeams to show for all highlighted items.",
-		position = 30
+		position = 33
 	)
 	default boolean showLootbeamForHighlighted()
 	{
@@ -432,7 +459,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "showLootbeamTier",
 		name = "Lootbeam tier",
 		description = "Configures which price tiers will trigger a lootbeam",
-		position = 31
+		position = 34
 	)
 	default HighlightTier showLootbeamTier()
 	{
@@ -443,7 +470,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "lootbeamStyle",
 		name = "Lootbeam Style",
 		description = "Style of lootbeam to use",
-		position = 32
+		position = 35
 	)
 	default Lootbeam.Style lootbeamStyle()
 	{
@@ -454,7 +481,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "hotkey",
 		name = "Hotkey",
 		description = "Configures the hotkey used by the Ground Items plugin",
-		position = 33
+		position = 36
 	)
 	default Keybind hotkey()
 	{


### PR DESCRIPTION
# Summary

Two QoL and eye-candy I thought would be nice and simple additions to the Ground Items plugin.
- Toggleable via plugin settings.
- Leaves existing behavior fully intact if not enabled.
- Little to no extra maintenance needed if implemented.

#### Disclaimer
I'm new to Runelite development and not the freshest on Java so there may be some syntactical oddities to iron out. I also erred on the side of verbose code to keep things readable but if code size is a concern I can slim things down. If this functionality is something that the maintainers think fits well into the Ground Items plugin then we can make whatever adjustments needed.

# Smooth Item Value Color Interpolation

Functionality enabled with default item price and color values.
![image](https://github.com/user-attachments/assets/dd45f927-6bb4-4b78-9e21-488ac97e9a1a)
<img src="https://github.com/user-attachments/assets/f6727ac8-2265-4ace-9109-3416e8579f97" width="700"/>

### Implementation Notes
* I added a small non-linearity in the color blending towards the high-end. Colors will blend until 70% of the higher-tier color and then snap to the new tier all at once when an item's value crosses the threshold. This is something subjective that I think helps maintain the meaning in setting your own price brackets. It also helps keep loot beams looking good without needing to implement the same behavior for them. 
    - If a tier is "green" then while the color will shift towards the next tier color as value increases, it'll still be a "greenish" color until that value crosses to the next tier entirely (and the loot beam with it).
    - The specifics of this can be adjusted or it can be removed entirely or made toggleable if desired.

## Why
I found myself pretty annoyed while doing some slayer tasks and wishing there was a visual distinction between the garbage items and the stackable/alchable items I actually want to pick up. I didn't want to mess with highlighting specific drops or changing my "Low value" price often so I thought something like this would be nice to have.

With the default value and color settings, see before and after:

<img src="https://github.com/user-attachments/assets/447d0759-4e52-4476-bf47-8e5f947a4940" width="300" height=250/>
<img src="https://github.com/user-attachments/assets/64dc703c-013f-4035-a381-54b6b397b716" width="300" height=250/>

This makes it a lot easier to pick out the stuff I want to pick up while still letting the higher value drops stand out by blending into the next color tier (like the dragon med).

<img src="https://github.com/user-attachments/assets/5394b6e0-a9bd-4702-ad74-81177da03eba" width="400" height=250/>
<img src="https://github.com/user-attachments/assets/08baa864-fc2e-47ad-8b89-e8786061a494" width="400" height=250/>

## Possible Issues
- Not integrated with loot beams currently. I think it's debateable whether it'd be better to keep discrete lootbeam color tiers or have them matched to text color.
- Might work better if the default item color was a bit darker than #FFFFFF but that's something the user can customize to their liking.

# Stackable Item Value Scaling
![image](https://github.com/user-attachments/assets/e859fe41-a81a-40ed-9d5d-d8d3a231dcfd)

## Why
For the same reason as above, I found myself wanting the smaller-but-valuable stackables (runes, coins, darts/javelin heads, etc.) to stand out more than the other garbage items. These drop in low-valued amounts but take up only one inventory slot so you often want to pick them up throughout a trip.

See before (no scaling+color smoothing) and after (2.0 scaling factor+color smoothing)

<img src="https://github.com/user-attachments/assets/6bac560d-717f-4df2-b859-e792ce07dda5" width="300"/>
<img src="https://github.com/user-attachments/assets/cf8e0fe8-b13e-41ea-b9d2-1429db0bfd9f" width="300"/>
 

## Possible Issues
- A bit more subjective in terms of utility. Some people wouldn't like this to be on or would like their own custom scaling factor tailored to their personal setup.
- Current implementation just scales the stack value linearly, so it'll have a more noticeable effect on higher value stacks than lower value ones (e.g. a 9m cash stack will be colored like a 13.5m cash stack if the scaling factor is 1.5). The implementation could be adjusted to use some form of logarithmic scaling instead.
- Not integrated with loot beams currently (should be simple to add though). A high value stackable drop might have a color tier that doesn't match its lootbeam tier.
- Not as useful on it's own without smooth color interpolation enabled

