### PR TITLE
Adding setState to force focus on MacOS when RuneLite is minimized

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
@@ -925,6 +925,7 @@ public class ClientUI
 		{
 			case MacOS:
 				OSXUtil.requestForeground();
+				frame.setState(Frame.NORMAL);
 				break;
 			case Windows:
 				WinUtil.requestForeground(frame);


### PR DESCRIPTION
Addressing the issue of the minimized RuneLite window not restoring despite the notification setting set to "force".

Checked if isVisible flipping is necessary, but the behavior is as expected without any additional changes, and only putting `setState()` in `forceFocus()` as suggested to fix #18381 