### PR TITLE
cluescrolls: remove tags for emote clues before matching

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java
@@ -79,6 +79,7 @@ import net.runelite.client.ui.overlay.OverlayUtil;
 import net.runelite.client.ui.overlay.components.LineComponent;
 import net.runelite.client.ui.overlay.components.PanelComponent;
 import net.runelite.client.ui.overlay.components.TitleComponent;
+import net.runelite.client.util.Text;
 
 @Getter
 public class EmoteClue extends ClueScroll implements LocationClueScroll
@@ -412,7 +413,7 @@ public class EmoteClue extends ClueScroll implements LocationClueScroll
 	{
 		for (EmoteClue clue : CLUES)
 		{
-			if (clue.getText().equalsIgnoreCase(text))
+			if (clue.getText().equalsIgnoreCase(Text.removeTags(text)))
 			{
 				return clue;
 			}


### PR DESCRIPTION
Noticed at least two emote clue scrolls were no longer solving due to Jagex randomly adding <br> tags. Given that there are multiple clues and they may end up removing the tags at a later date (or adding new ones), I opted to remove the tags from the clue text rather than change the text we have stored.

Some example debug log lines indicating that the clues failed to resolve are:
`2024-10-04 17:52:44 EDT [Client] INFO  n.r.c.p.cluescrolls.ClueScrollPlugin - Unknown clue text: Salute in the centre of the mess hall.<br>Beware of double agents! Equip a rune halberd<br>rune platebody and an amulet of strength.`
`2024-10-04 14:20:44 EDT [Client] INFO  n.r.c.p.cluescrolls.ClueScrollPlugin - Unknown clue text: Cheer at the top of the agility pyramid.<br>Beware of double agents! Equip a blue mystic robe<br>top and any rune heraldic shield.`