### PR TITLE
timers buffs: fix moonlight potion issues

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/timersandbuffs/TimersAndBuffsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timersandbuffs/TimersAndBuffsPlugin.java
@@ -611,6 +611,12 @@ public class TimersAndBuffsPlugin extends Plugin
 			{
 				moonlightValue++;
 			}
+			// Varbits.DIVINE_SUPER_DEFENCE updates before Varbits.MOONLIGHT_POTION. Thus, the early return that
+			// prevents creation of the divine super defence timer does not work for the first game tick
+			if (client.getVarbitValue(Varbits.DIVINE_SUPER_DEFENCE) == moonlightValue)
+			{
+				removeVarTimer(DIVINE_SUPER_DEFENCE);
+			}
 
 			updateVarTimer(MOONLIGHT_POTION, moonlightValue, IntUnaryOperator.identity());
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timersandbuffs/TimersAndBuffsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timersandbuffs/TimersAndBuffsPlugin.java
@@ -479,13 +479,19 @@ public class TimersAndBuffsPlugin extends Plugin
 				|| client.getVarbitValue(Varbits.DIVINE_BATTLEMAGE) > event.getValue()
 				// When drinking a dose of moonlight potion while already under its effects, desync between
 				// Varbits.MOONLIGHT_POTION and Varbits.DIVINE_SUPER_DEFENCE can occur, with the latter being 1 tick
-				// greater
-				|| client.getVarbitValue(Varbits.MOONLIGHT_POTION) >= event.getValue())
+				// greater due to Varbits.MOONLIGHT_POTION ticking down twice in its first tick.
+
+				// When the user drinks a dose of moonlight potion at the exact tick the potion runs out, i.e. right
+				// after Varbits.MOONLIGHT_POTION == 0, the first tick behaves exactly as the above described desync.
+				// However, after the first tick, Varbits.MOONLIGHT_POTION is suddenly transmitted BEFORE
+				// Varbits.DIVINE_SUPER_DEFENCE every tick. Thus, when the latter is transmitted, the
+				// Varbits.MOONLIGHT_POTION value might be 1 less than the Varbits.DIVINE_SUPER_DEFENCE value.
+				|| client.getVarbitValue(Varbits.MOONLIGHT_POTION) + 1 >= event.getValue())
 			{
 				return;
 			}
 
-			if (client.getVarbitValue(Varbits.MOONLIGHT_POTION) < event.getValue())
+			if (client.getVarbitValue(Varbits.MOONLIGHT_POTION) + 1 < event.getValue())
 			{
 				removeVarTimer(MOONLIGHT_POTION);
 			}
@@ -607,12 +613,19 @@ public class TimersAndBuffsPlugin extends Plugin
 			int moonlightValue = event.getValue();
 			// Increase the timer by 1 tick in case of desync due to drinking a dose of moonlight potion while already
 			// under its effects. Otherwise, the timer would be 1 tick shorter than it is meant to be.
-			if (client.getVarbitValue(Varbits.DIVINE_SUPER_DEFENCE) == moonlightValue + 1)
+
+			// When the user drinks a dose of moonlight potion at the exact tick the potion runs out, i.e. right after
+			// Varbits.MOONLIGHT_POTION == 0, the first tick behaves exactly as 'normal' desync. However, after the
+			// first tick, Varbits.MOONLIGHT_POTION is suddenly transmitted BEFORE Varbits.DIVINE_SUPER_DEFENCE every
+			// tick. Thus, when the former is transmitted, there might be a difference of 2 between the varbit values.
+			final int divSupDefValue = client.getVarbitValue(Varbits.DIVINE_SUPER_DEFENCE);
+			if (divSupDefValue == moonlightValue + 1 || divSupDefValue == moonlightValue + 2)
 			{
 				moonlightValue++;
 			}
-			// Varbits.DIVINE_SUPER_DEFENCE updates before Varbits.MOONLIGHT_POTION. Thus, the early return that
-			// prevents creation of the divine super defence timer does not work for the first game tick
+			// Varbits.DIVINE_SUPER_DEFENCE updates before Varbits.MOONLIGHT_POTION (at least during its first tick).
+			// Thus, the early return that prevents creation of the divine super defence timer does not work for the
+			// first game tick.
 			if (client.getVarbitValue(Varbits.DIVINE_SUPER_DEFENCE) == moonlightValue)
 			{
 				removeVarTimer(DIVINE_SUPER_DEFENCE);


### PR DESCRIPTION
- Fixes the divine super defence timer showing up next to the moonlight timer, when drinking the first moonlight potion of the session
  - Re-introduces the full moonlightValue +1 hack in all its glory!
  - Video test: https://youtu.be/rIRFAuIrn-I
- Fixes the moonlight potion instantly being removed and a divine super defence being added, when you sip a moonlight potion on the exact tick it ran out (i.e. the moonlight varbit hits 0 and you click on the potion)
  - The problem occurs because in this very specific scenario, the varbit "desync" that we already knew about happens, but after the first tick, the transmission order of ``Varbits.DIVINE_SUPER_DEFENCE`` and ``Varbits.MOONLIGHT_POTION`` is also switched! See below for a more in-depth explanation.
  - Video test: https://youtu.be/ZoRTZ6MF6Dw
     - You can also tell when playing the end of the video back at slow speed that the moonlight buff is actually lost when ``Varbits.DIVINE_SUPER_DEFENCE`` hits 0.

Doesn't add any unit tests because I could not figure out how to use e.g. ``infoBoxManager.getInfoBoxes().size()`` properly in tests, as I have a lack of experience with unit tests due to my dislike for them. Jut adding ArgumentCaptors for InfoBoxes (``addInfoBox`` call) and Predicates (``removeIf`` call) felt pretty useless and brittle. Feel free to add useful unit tests.

Fixes https://github.com/runelite/runelite/issues/18379

## Problem description
### Double timers
- The double timers (moonlight & divine super defence) on a fresh client boot are caused by https://github.com/runelite/runelite/blob/3cc0c4c967360512b9c1ba849e4e8ff827a299ba/runelite-client/src/main/java/net/runelite/client/plugins/timersandbuffs/TimersAndBuffsPlugin.java#L483 being ``0 >= 500`` since ``Varbits.DIVINE_SUPER_DEFENCE`` updates before ``Varbits.MOONLIGHT_POTION``.
  - Other divine potions, such as the divine battlemage, remove the divine super defence timer for that reason. E.g. https://github.com/runelite/runelite/blob/3cc0c4c967360512b9c1ba849e4e8ff827a299ba/runelite-client/src/main/java/net/runelite/client/plugins/timersandbuffs/TimersAndBuffsPlugin.java#L554-L557
  - A divine super def timer does not pop up after the first moonlight potion of the session.
     - The first time the divine super def GameTimer is still null, and ``updateVarTimer(Varbits.DIVINE_SUPER_DEFENCE)`` will take the second branch, creating a new GameTimer https://github.com/runelite/runelite/blob/3cc0c4c967360512b9c1ba849e4e8ff827a299ba/runelite-client/src/main/java/net/runelite/client/plugins/timersandbuffs/TimersAndBuffsPlugin.java#L1306-L1311
     - After the first moonlight potion, it'll take the third branch, which does not create a new GameTimer https://github.com/runelite/runelite/blob/3cc0c4c967360512b9c1ba849e4e8ff827a299ba/runelite-client/src/main/java/net/runelite/client/plugins/timersandbuffs/TimersAndBuffsPlugin.java#L1312-L1316
     I assume when the divine super def runs out, ``InfoBoxManager::cull`` removes the infobox since ``Timer::cull`` is true at that point. The GameTimer does not get removed however, since ``updateVarTimer(DIVINE_SUPER_DEFENCE, 0)`` is never called. I've not looked into this further than this.


### Only the divine super defence showing up
I was able to recreate only the divine super defence showing up when drinking a moonlight potion after it just expired on master. This seems to be caused by how interesting the varbit behaves...

We were already aware of the "normal" desync that can happen when you drink a moonlight potion while already under its effect:
![Normal desync](https://github.com/user-attachments/assets/9028fef6-ead1-4dcf-af1e-5071dd93bec5)

As you can see in tick 1352, ``Varbit.DIVINE_SUPER_DEFENCE`` gets updated, then ``Varbits.MOONLIGHT_POTION`` twice. From tick 1353 onwards ``Varbit.DIVINE_SUPER_DEFENCE`` gets updated followed by ``Varbits.MOONLIGHT_POTION``. The former is 1 greater than the latter. This is the desync we already knew,



However, it turns out that in the edge case of drinking a moonlight potion right as the varbit hits 0 (probably while not already having the above "normal" desync), another type of desync can happen!
I was printing varbit changes in VarbitChanged at the time I reproduced the issue on master:
```
client.getTickCount() Varbit varbitId changed to varbitChanged.getValue()
163 Varbit 8431 (Varbits.DIVINE_SUPER_DEFENCE) changed to 2
163 Varbit 10029 (Varbits.MOONLIGHT_POTION) changed to 2

164 Varbit 8431 (Varbits.DIVINE_SUPER_DEFENCE) changed to 1
164 Varbit 10029 (Varbits.MOONLIGHT_POTION) changed to 1

165 Varbit 8431 (Varbits.DIVINE_SUPER_DEFENCE) changed to 0
165 Varbit 10029 (Varbits.MOONLIGHT_POTION) changed to 0

166 Varbit 8431 (Varbits.DIVINE_SUPER_DEFENCE) changed to 500
166 Varbit 10029 (Varbits.MOONLIGHT_POTION) changed to 500
166 Varbit 10029 (Varbits.MOONLIGHT_POTION) changed to 499

167 Varbit 10029 (Varbits.MOONLIGHT_POTION) changed to 498
167 Varbit 8431 (Varbits.DIVINE_SUPER_DEFENCE) changed to 499

168 Varbit 10029 (Varbits.MOONLIGHT_POTION) changed to 497
168 Varbit 8431 (Varbits.DIVINE_SUPER_DEFENCE) changed to 498

169 Varbit 10029 (Varbits.MOONLIGHT_POTION) changed to 496
169 Varbit 8431 (Varbits.DIVINE_SUPER_DEFENCE) changed to 497
```
As you can see, in tick 166 we get a divine super def and 2 moonlight updates, as expected with the known desync. However, afterwards we keep getting ``Varbits.MOONLIGHT_POTION`` updates before ``Varbits.DIVINE_SUPER_DEFENCE``!
This means that e.g. in tick 167:
- When VarbitChanged fires for Varbits.DIVINE_SUPER_DEFENCE https://github.com/runelite/runelite/blob/3cc0c4c967360512b9c1ba849e4e8ff827a299ba/runelite-client/src/main/java/net/runelite/client/plugins/timersandbuffs/TimersAndBuffsPlugin.java#L483-L491
  - The early return does not happen: 498 >= 499 -> false
  - The MOON_LIGHTPOTION vartimer gets removed: 498 < 499 -> true
- When VarbitChanged fires for Varbits.MOONLIGHT_POTION fires, the code in this PR that removes the divine super def vartimer does not fire for that tick.
  - ``moonlightValue++`` does not proc: 500 == 498 + 1 -> false
  - Since the first tick of varbit updates is still divine super def -> moonlight potion -> moonlight potion, this should not matter for fixing the first issue. However, this will cause the timer to be incorrect.

This sounded so insane to me that it sounded fake, so I managed to catch it on video later on: https://youtu.be/sjnJWn_APYQ
(this is my feature branch after ``timers buffs: correctly remove divine super defence timer when drinking moonlight potion`` but before writing any other code, i.e. no 2nd/3rd commit).