### PR TITLE
Use grand exchange item search for ChatboxItemSearch

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/ScriptID.java
+++ b/runelite-api/src/main/java/net/runelite/api/ScriptID.java
@@ -229,6 +229,29 @@ public final class ScriptID
 	public static final int GE_ITEM_SEARCH = 752;
 
 	/**
+	 * Opens the grand exchange item search widget
+	 * <ul>
+	 * <li> string Search title </li>
+	 * <li> int (boolean) False searches deadman restricted items </li>
+	 * <li> int (EnumID) Item enum to search </li>
+	 * <li> int (boolean) Display last searched text </li>
+	 * </ul>
+	 */
+	@ScriptArguments(integer = 3, string = 1)
+	public static final int GE_OPEN_ITEM_SEARCH = 750;
+
+	/**
+	 * Selects the item from the grand exchange item search
+	 *
+	 * <ul>
+	 * <li> int (ItemID) Item selected </li>
+	 * <li> int must be 84 or the script returns </li>
+	 * </ul>
+	 */
+	@ScriptArguments(integer = 2)
+	public static final int GE_ITEM_SEARCH_SELECTED = 754;
+
+	/**
 	 * On load listener for building the quest list interface
 	 */
 	@ScriptArguments(integer = 8)

--- a/runelite-client/src/main/java/net/runelite/client/game/chatbox/ChatboxItemSearch.java
+++ b/runelite-client/src/main/java/net/runelite/client/game/chatbox/ChatboxItemSearch.java
@@ -25,310 +25,147 @@
 
 package net.runelite.client.game.chatbox;
 
-import com.google.common.primitives.Ints;
+import com.google.common.primitives.Shorts;
 import com.google.inject.Inject;
 import java.awt.event.KeyEvent;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.Map;
-import java.util.Set;
+import java.util.List;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import javax.inject.Singleton;
 import lombok.Getter;
-import lombok.Value;
+import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.ItemComposition;
-import net.runelite.api.widgets.ItemQuantityMode;
-import net.runelite.api.widgets.JavaScriptCallback;
+import static net.runelite.api.ScriptID.GE_ITEM_SEARCH;
+import static net.runelite.api.ScriptID.GE_ITEM_SEARCH_SELECTED;
+import static net.runelite.api.ScriptID.GE_OPEN_ITEM_SEARCH;
+import net.runelite.api.VarClientStr;
+import net.runelite.api.events.GrandExchangeSearched;
+import net.runelite.api.events.ScriptPostFired;
+import net.runelite.api.events.ScriptPreFired;
+import net.runelite.api.widgets.ComponentID;
 import net.runelite.api.widgets.Widget;
-import net.runelite.api.widgets.WidgetPositionMode;
-import net.runelite.api.widgets.WidgetSizeMode;
-import net.runelite.api.widgets.WidgetTextAlignment;
 import net.runelite.api.widgets.WidgetType;
-import net.runelite.client.callback.ClientThread;
+import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.game.ItemManager;
-import net.runelite.client.ui.JagexColors;
+import net.runelite.client.input.KeyListener;
 
 @Singleton
-public class ChatboxItemSearch extends ChatboxTextInput
+@Slf4j
+public class ChatboxItemSearch extends ChatboxInput  implements KeyListener
 {
-	private static final int ICON_HEIGHT = 32;
-	private static final int ICON_WIDTH = 36;
-	private static final int PADDING = 6;
-	private static final int MAX_RESULTS = 24;
-	private static final int FONT_SIZE = 16;
-	private static final int HOVERED_OPACITY = 128;
+	private static final int MAX_RESULTS = 250;
 
 	private final ChatboxPanelManager chatboxPanelManager;
 	private final ItemManager itemManager;
 	private final Client client;
 
-	private final Map<Integer, ItemComposition> results = new LinkedHashMap<>();
 	private String tooltipText;
-	private int index = -1;
 
 	@Getter
 	private Consumer<Integer> onItemSelected;
 
-	@Value
-	private static class ItemIcon
-	{
-		int modelId;
-		int ambient;
-		int contrast;
-		short[] colorsToReplace;
-		short[] texturesToReplace;
-	}
-
 	@Inject
-	private ChatboxItemSearch(ChatboxPanelManager chatboxPanelManager, ClientThread clientThread,
-		ItemManager itemManager, Client client)
+	private ChatboxItemSearch(ChatboxPanelManager chatboxPanelManager, ItemManager itemManager, Client client)
 	{
-		super(chatboxPanelManager, clientThread);
 		this.chatboxPanelManager = chatboxPanelManager;
 		this.itemManager = itemManager;
 		this.client = client;
+	}
 
-		lines(1);
-		prompt("Item Search");
-		onChanged(searchString ->
-			clientThread.invokeLater(() ->
-			{
-				filterResults();
-				update();
-			}));
+	public ChatboxItemSearch build()
+	{
+		chatboxPanelManager.openInput(this);
+
+		return this;
 	}
 
 	@Override
-	protected void update()
+	protected void open()
 	{
-		Widget container = chatboxPanelManager.getContainerWidget();
-		container.deleteAllChildren();
-
-		Widget promptWidget = container.createChild(-1, WidgetType.TEXT);
-		promptWidget.setText(getPrompt());
-		promptWidget.setTextColor(0x800000);
-		promptWidget.setFontId(getFontID());
-		promptWidget.setOriginalX(0);
-		promptWidget.setOriginalY(5);
-		promptWidget.setXPositionMode(WidgetPositionMode.ABSOLUTE_CENTER);
-		promptWidget.setYPositionMode(WidgetPositionMode.ABSOLUTE_TOP);
-		promptWidget.setOriginalHeight(FONT_SIZE);
-		promptWidget.setXTextAlignment(WidgetTextAlignment.CENTER);
-		promptWidget.setYTextAlignment(WidgetTextAlignment.CENTER);
-		promptWidget.setWidthMode(WidgetSizeMode.MINUS);
-		promptWidget.revalidate();
-
-		buildEdit(0, 5 + FONT_SIZE, container.getWidth(), FONT_SIZE);
-
-		Widget separator = container.createChild(-1, WidgetType.LINE);
-		separator.setOriginalX(0);
-		separator.setOriginalY(8 + (FONT_SIZE * 2));
-		separator.setXPositionMode(WidgetPositionMode.ABSOLUTE_CENTER);
-		separator.setYPositionMode(WidgetPositionMode.ABSOLUTE_TOP);
-		separator.setOriginalHeight(0);
-		separator.setOriginalWidth(16);
-		separator.setWidthMode(WidgetSizeMode.MINUS);
-		separator.setTextColor(0x666666);
-		separator.revalidate();
-
-		int x = PADDING;
-		int y = PADDING * 3;
-		int idx = 0;
-		for (ItemComposition itemComposition : results.values())
-		{
-			Widget item = container.createChild(-1, WidgetType.GRAPHIC);
-			item.setXPositionMode(WidgetPositionMode.ABSOLUTE_LEFT);
-			item.setYPositionMode(WidgetPositionMode.ABSOLUTE_TOP);
-			item.setOriginalX(x);
-			item.setOriginalY(y + FONT_SIZE * 2);
-			item.setOriginalHeight(ICON_HEIGHT);
-			item.setOriginalWidth(ICON_WIDTH);
-			item.setName(JagexColors.MENU_TARGET_TAG + itemComposition.getName());
-			item.setItemId(itemComposition.getId());
-			item.setItemQuantity(10000);
-			item.setItemQuantityMode(ItemQuantityMode.NEVER);
-			item.setBorderType(1);
-			item.setAction(0, tooltipText);
-			item.setHasListener(true);
-
-			if (index == idx)
-			{
-				item.setOpacity(HOVERED_OPACITY);
-			}
-			else
-			{
-				item.setOnMouseOverListener((JavaScriptCallback) ev -> item.setOpacity(HOVERED_OPACITY));
-				item.setOnMouseLeaveListener((JavaScriptCallback) ev -> item.setOpacity(0));
-			}
-
-			item.setOnOpListener((JavaScriptCallback) ev ->
-			{
-				if (onItemSelected != null)
-				{
-					onItemSelected.accept(itemComposition.getId());
-				}
-
-				chatboxPanelManager.close();
-			});
-
-			x += ICON_WIDTH + PADDING;
-			if (x + ICON_WIDTH >= container.getWidth())
-			{
-				y += ICON_HEIGHT + PADDING;
-				x = PADDING;
-			}
-
-			item.revalidate();
-			++idx;
-		}
-	}
-
-	@Override
-	public void keyPressed(KeyEvent ev)
-	{
-		if (!chatboxPanelManager.shouldTakeInput())
-		{
-			return;
-		}
-
-		switch (ev.getKeyCode())
-		{
-			case KeyEvent.VK_ENTER:
-				ev.consume();
-				if (index > -1)
-				{
-					if (onItemSelected != null)
-					{
-						onItemSelected.accept(results.keySet().toArray(new Integer[results.size()])[index]);
-					}
-
-					chatboxPanelManager.close();
-				}
-				break;
-			case KeyEvent.VK_TAB:
-			case KeyEvent.VK_RIGHT:
-				ev.consume();
-				if (!results.isEmpty())
-				{
-					index++;
-					if (index >= results.size())
-					{
-						index = 0;
-					}
-					clientThread.invokeLater(this::update);
-				}
-				break;
-			case KeyEvent.VK_LEFT:
-				ev.consume();
-				if (!results.isEmpty())
-				{
-					index--;
-					if (index < 0)
-					{
-						index = results.size() - 1;
-					}
-					clientThread.invokeLater(this::update);
-				}
-				break;
-			case KeyEvent.VK_UP:
-				ev.consume();
-				if (results.size() >= (MAX_RESULTS / 2))
-				{
-					index -= MAX_RESULTS / 2;
-					if (index < 0)
-					{
-						if (results.size() == MAX_RESULTS)
-						{
-							index += results.size();
-						}
-						else
-						{
-							index += MAX_RESULTS;
-						}
-						index = Ints.constrainToRange(index, 0, results.size() - 1);
-					}
-
-					clientThread.invokeLater(this::update);
-				}
-				break;
-			case KeyEvent.VK_DOWN:
-				ev.consume();
-				if (results.size() >= (MAX_RESULTS / 2))
-				{
-					index += MAX_RESULTS / 2;
-					if (index >= MAX_RESULTS)
-					{
-						if (results.size() == MAX_RESULTS)
-						{
-							index -= results.size();
-						}
-						else
-						{
-							index -= MAX_RESULTS;
-						}
-						index = Ints.constrainToRange(index, 0, results.size() - 1);
-					}
-
-					clientThread.invokeLater(this::update);
-				}
-				break;
-			default:
-				super.keyPressed(ev);
-		}
+		log.debug("opening item search");
+		this.client.runScript(GE_OPEN_ITEM_SEARCH, "Item Search", 1, -1, 0);
 	}
 
 	@Override
 	protected void close()
 	{
-		// Clear search string when closed
-		value("");
-		results.clear();
-		index = -1;
-		super.close();
+		log.debug("closing item search");
 	}
 
-	@Override
-	@Deprecated
-	public ChatboxTextInput onDone(Consumer<String> onDone)
+	@Subscribe
+	public void onScriptPreFired(ScriptPreFired event)
 	{
-		throw new UnsupportedOperationException();
-	}
-
-	private void filterResults()
-	{
-		results.clear();
-		index = -1;
-
-		String search = getValue().toLowerCase();
-		if (search.isEmpty())
+		if (event.getScriptId() != GE_ITEM_SEARCH_SELECTED)
 		{
 			return;
 		}
 
-		Set<ItemIcon> itemIcons = new HashSet<>();
-		for (int i = 0; i < client.getItemCount() && results.size() < MAX_RESULTS; i++)
+		var args = event.getScriptEvent().getArguments();
+		if ((int) args[2] != 84)
 		{
-			ItemComposition itemComposition = itemManager.getItemComposition(itemManager.canonicalize(i));
-			String name = itemComposition.getName().toLowerCase();
+			// items are only selected if 84 is passed as a parameter
+			return;
+		}
 
-			// The client assigns "null" to item names of items it doesn't know about
-			// and the item might already be in the results from canonicalize
-			if (!name.equals("null") && name.contains(search) && !results.containsKey(itemComposition.getId()))
+		final int resultId = (int) args[1];
+
+		log.debug("selecting item {}", resultId);
+		onItemSelected.accept(resultId);
+	}
+
+	@Subscribe
+	public void onScriptPostFired(ScriptPostFired event)
+	{
+		if (event.getScriptId() != GE_ITEM_SEARCH)
+		{
+			return;
+		}
+
+		Widget results = client.getWidget(ComponentID.CHATBOX_GE_SEARCH_RESULTS);
+		if (results == null || results.isSelfHidden())
+		{
+			return;
+		}
+
+		for (var w : results.getDynamicChildren())
+		{
+			// ops are defined on the highlight widgets surrounding the results
+			if (w.getType() == WidgetType.RECTANGLE)
 			{
-				// Check if the results already contain the same item image
-				ItemIcon itemIcon = new ItemIcon(itemComposition.getInventoryModel(),
-					itemComposition.getAmbient(), itemComposition.getContrast(),
-					itemComposition.getColorToReplaceWith(), itemComposition.getTextureToReplaceWith());
-				if (itemIcons.contains(itemIcon))
-				{
-					continue;
-				}
-
-				itemIcons.add(itemIcon);
-				results.put(itemComposition.getId(), itemComposition);
+				w.setAction(0, tooltipText);
 			}
 		}
+	}
+
+	@Subscribe(priority = 1)
+	public void onGrandExchangeSearched(GrandExchangeSearched event)
+	{
+		final String input = client.getVarcStrValue(VarClientStr.INPUT_TEXT);
+		client.setGeSearchResultIndex(0);
+
+		List<Integer> ids = IntStream.range(0, client.getItemCount())
+			.map(itemManager::canonicalize)
+			.distinct()
+			.mapToObj(itemManager::getItemComposition)
+			.filter(item -> item.getName().toLowerCase().contains(input))
+			.limit(MAX_RESULTS + 1)
+			.map(ItemComposition::getId)
+			.collect(Collectors.toList());
+
+		if (ids.size() > MAX_RESULTS)
+		{
+			client.setGeSearchResultCount(-1);
+			client.setGeSearchResultIds(null);
+		}
+		else
+		{
+			client.setGeSearchResultCount(ids.size());
+			client.setGeSearchResultIds(Shorts.toArray(ids));
+		}
+
+		event.consume();
 	}
 
 	public ChatboxItemSearch onItemSelected(Consumer<Integer> onItemSelected)
@@ -341,5 +178,31 @@ public class ChatboxItemSearch extends ChatboxTextInput
 	{
 		tooltipText = text;
 		return this;
+	}
+
+	@Override
+	public void keyTyped(KeyEvent ev)
+	{
+	}
+
+	@Override
+	public void keyPressed(KeyEvent ev)
+	{
+		if (!chatboxPanelManager.shouldTakeInput())
+		{
+			return;
+		}
+
+		int code = ev.getKeyCode();
+		if (code == KeyEvent.VK_ESCAPE)
+		{
+			ev.consume();
+			chatboxPanelManager.close();
+		}
+	}
+
+	@Override
+	public void keyReleased(KeyEvent e)
+	{
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/game/chatbox/ChatboxPanelManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/game/chatbox/ChatboxPanelManager.java
@@ -104,6 +104,11 @@ public class ChatboxPanelManager
 
 	private void unsafeOpenInput(ChatboxInput input)
 	{
+		if (currentInput != null)
+		{
+			killCurrentPanel();
+		}
+
 		client.runScript(ScriptID.MESSAGE_LAYER_OPEN, 0);
 
 		eventBus.register(input);
@@ -120,12 +125,6 @@ public class ChatboxPanelManager
 			mouseManager.registerMouseWheelListener((MouseWheelListener) input);
 		}
 
-		if (currentInput != null)
-		{
-			killCurrentPanel();
-		}
-
-		currentInput = input;
 		client.setVarcIntValue(VarClientID.MESLAYERMODE, InputType.RUNELITE_CHATBOX_PANEL.getType());
 		client.getWidget(InterfaceID.Chatbox.MES_TEXT).setHidden(true);
 		client.getWidget(InterfaceID.Chatbox.MES_TEXT2).setHidden(true);
@@ -134,6 +133,8 @@ public class ChatboxPanelManager
 		c.deleteAllChildren();
 		c.setOnDialogAbortListener((JavaScriptCallback) ev -> this.unsafeCloseInput());
 		input.open();
+
+		currentInput = input;
 	}
 
 	public void openInput(ChatboxInput input)


### PR DESCRIPTION
Originally, the suggestion was to add scrolling to our current ChatboxItemSearch. But that is hard to do as Jagex scrollbars would require a new layer component to attach to or would require us to  build widgets and write more listener code. Instead, let's just use Jagex's GE item search feature and it let's us delete a lot of code.

A notable  change might be to filter out models that are the same, like master currently does.

![java_rCgsCxxPYj](https://github.com/user-attachments/assets/4ce32f3b-e155-4168-b029-c8658195663f)

https://github.com/user-attachments/assets/513295a2-d6be-4313-aba0-6cb95a05a7c3

Closes https://github.com/runelite/runelite/issues/20217

