### PR TITLE
Add config option to disable the spell tooltips.

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/ScriptID.java
+++ b/runelite-api/src/main/java/net/runelite/api/ScriptID.java
@@ -467,4 +467,7 @@ public final class ScriptID
 
 	@ScriptArguments(integer = 1)
 	public static final int POTIONSTORE_WITHDRAW_DOSES = 4818;
+
+	@ScriptArguments(integer = 6)
+	public static final int SPELLBOOK_TOOLTIP = 2622;
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/spellbook/SpellbookConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/spellbook/SpellbookConfig.java
@@ -26,9 +26,21 @@ package net.runelite.client.plugins.spellbook;
 
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
 
 @ConfigGroup(SpellbookConfig.GROUP)
 public interface SpellbookConfig extends Config
 {
 	String GROUP = "spellbook";
+
+	@ConfigItem(
+		keyName = "enableTooltips",
+		name = "Enable Tooltips",
+		description = "Configures whether or not to show tooltips",
+		position = 0
+	)
+	default boolean enableTooltips()
+	{
+		return true;
+	}
 }


### PR DESCRIPTION
Not entirely confident this is the best route to get it done but it works. 

on client tick it fires the script that builds the tooltip [script link](https://github.com/RuneStar/cs2-scripts/blob/master/scripts/%5Bclientscript,magic_spellbook_settooltip%5D.cs2)
