### PR TITLE
"Enhance tray notification tool tip message in the NotificationPanel"

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/NotificationPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/NotificationPanel.java
@@ -286,7 +286,7 @@ class NotificationPanel extends PluginPanel
 				var n = loadNotification();
 				saveNotification(n.withTray(checkboxTray.isSelected()));
 			});
-			item("Tray notification", "Enables tray notifications", checkboxTray);
+			item("Tray notification", "Enables tray notifications. Depending on your operating system settings, these can produce sound", checkboxTray);
 
 			var comboboxRequestFocus = combobox(RequestFocusType.class, notif.getRequestFocus());
 			comboboxRequestFocus.addItemListener(e ->


### PR DESCRIPTION
The current message does not indicate that your OS might cause notification sounds. This leads to confusing UX when notifications are producing sound and yet you have "notification sound: off" setting disabled. This adds a helpful message to indicate where the source of notification sounds might be coming from.