### PR TITLE
chatbox: run onClose handler before script entry

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/game/chatbox/ChatboxPanelManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/game/chatbox/ChatboxPanelManager.java
@@ -104,6 +104,11 @@ public class ChatboxPanelManager
 
 	private void unsafeOpenInput(ChatboxInput input)
 	{
+		if (currentInput != null)
+		{
+			killCurrentPanel();
+		}
+
 		client.runScript(ScriptID.MESSAGE_LAYER_OPEN, 0);
 
 		eventBus.register(input);


### PR DESCRIPTION
The onClose handler is called implicitly by the onScriptPreFired, but if that onClose handler needs to fire a script (such as the new bank tags plugin layouting), this can cause script reentrancy errors.

Calling the registered onClose handler early prevents that specific class of errors.