### PR TITLE
bank tags: add auto layouts

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/banktags/BankTagsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/banktags/BankTagsConfig.java
@@ -76,6 +76,17 @@ public interface BankTagsConfig extends Config
 	}
 
 	@ConfigItem(
+			keyName = "autoLayout",
+			name = "Enable layout by default",
+			description = "Enables layout on newly created tag tabs automatically",
+			position = 5
+	)
+	default boolean autoTabLayout()
+	{
+		return false;
+	}
+
+	@ConfigItem(
 		keyName = "position",
 		name = "",
 		description = "",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/banktags/tabs/TabManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/banktags/tabs/TabManager.java
@@ -65,6 +65,10 @@ public class TabManager
 			{
 				tagTab.getLayout().dirty = true;
 			}
+			else if (configManager.getConfiguration(CONFIG_GROUP, "autoLayout", Boolean.class))
+			{
+				tagTab.setLayout(new Layout());
+			}
 		}
 	}
 


### PR DESCRIPTION
Adds config option to enable layouts on newly created tag tabs automatically

I imagine a lot of people use layouts for every single tag tab, so this seems useful.