### PR TITLE
tileindicators: Minimap and world map rendering

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/tileindicators/TileIndicatorsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/tileindicators/TileIndicatorsConfig.java
@@ -204,4 +204,26 @@ public interface TileIndicatorsConfig extends Config
 	{
 		return 2;
 	}
+
+	@ConfigItem(
+		keyName = "showOnMinimap",
+		name = "Show on minimap",
+		description = "Whether to display tile indicators on the minimap",
+		position = 3
+	)
+	default boolean showOnMinimap()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		keyName = "showOnWorldMap",
+		name = "Show on world map",
+		description = "Whether to display tile indicators on the world map",
+		position = 4
+	)
+	default boolean showOnWorldMap()
+	{
+		return false;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/tileindicators/TileIndicatorsMapOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/tileindicators/TileIndicatorsMapOverlay.java
@@ -1,0 +1,114 @@
+package net.runelite.client.plugins.tileindicators;
+
+import java.awt.BasicStroke;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Graphics2D;
+import java.awt.Polygon;
+import java.awt.Rectangle;
+import java.awt.Stroke;
+import javax.inject.Inject;
+import net.runelite.api.Client;
+import net.runelite.api.Perspective;
+import net.runelite.api.Point;
+import net.runelite.api.coords.LocalPoint;
+import net.runelite.api.coords.WorldPoint;
+import net.runelite.api.widgets.ComponentID;
+import net.runelite.api.widgets.Widget;
+import net.runelite.client.ui.overlay.Overlay;
+import net.runelite.client.ui.overlay.OverlayLayer;
+import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.worldmap.WorldMapOverlay;
+
+public class TileIndicatorsMapOverlay extends Overlay
+{
+	private final Client client;
+	private final TileIndicatorsConfig config;
+
+	@Inject
+	private WorldMapOverlay worldMapOverlay;
+
+	@Inject
+	private TileIndicatorsMapOverlay(Client client, TileIndicatorsConfig config)
+	{
+		this.client = client;
+		this.config = config;
+		setPosition(OverlayPosition.DYNAMIC);
+		setLayer(OverlayLayer.MANUAL);
+		setPriority(PRIORITY_MED);
+		drawAfterLayer(ComponentID.WORLD_MAP_MAPVIEW);
+	}
+
+	@Override
+	public Dimension render(Graphics2D graphics)
+	{
+		if (!config.showOnWorldMap())
+		{
+			return null;
+		}
+
+		Widget worldMapView = client.getWidget(ComponentID.WORLD_MAP_MAPVIEW);
+		if (worldMapView == null)
+		{
+			return null;
+		}
+		Rectangle bounds = worldMapView.getBounds();
+		if (bounds == null)
+		{
+			return null;
+		}
+		graphics.setClip(worldMapOverlay.getWorldMapClipArea(bounds));
+
+		if (config.highlightDestinationTile())
+		{
+			renderTile(graphics, client.getLocalDestinationLocation(), config.highlightDestinationColor(), config.destinationTileFillColor());
+		}
+
+		if (config.highlightCurrentTile())
+		{
+			final WorldPoint playerPos = client.getLocalPlayer().getWorldLocation();
+			if (playerPos == null)
+			{
+				return null;
+			}
+
+			final LocalPoint playerPosLocal = LocalPoint.fromWorld(client, playerPos);
+			if (playerPosLocal == null)
+			{
+				return null;
+			}
+
+			renderTile(graphics, playerPosLocal, config.highlightCurrentColor(), config.currentTileFillColor());
+		}
+
+		return null;
+	}
+
+	private void renderTile(Graphics2D graphics, LocalPoint point, Color color, Color fillColor)
+	{
+		if (point == null)
+		{
+			return;
+		}
+
+		WorldPoint location = WorldPoint.fromLocal(client, point);
+
+		Point start = worldMapOverlay.mapWorldPointToGraphicsPoint(location);
+		Point end = worldMapOverlay.mapWorldPointToGraphicsPoint(location.dx(1).dy(1));
+
+		int offset = ((int) client.getWorldMap().getWorldMapZoom()) / 2;
+
+		Polygon poly = new Polygon();
+		poly.addPoint(start.getX() - offset, start.getY() + offset);
+		poly.addPoint(start.getX() - offset, end.getY() + offset);
+		poly.addPoint(end.getX() - offset, end.getY() + offset);
+		poly.addPoint(end.getX() - offset, start.getY() + offset);
+
+		Stroke stroke = new BasicStroke(1f);
+		graphics.setStroke(stroke);
+		graphics.setColor(color);
+		graphics.drawPolygon(poly);
+		graphics.setColor(fillColor);
+		graphics.fillPolygon(poly);
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/tileindicators/TileIndicatorsMinimapOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/tileindicators/TileIndicatorsMinimapOverlay.java
@@ -1,0 +1,100 @@
+package net.runelite.client.plugins.tileindicators;
+
+import java.awt.BasicStroke;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Graphics2D;
+import java.awt.Polygon;
+import java.awt.Stroke;
+import javax.inject.Inject;
+import net.runelite.api.Client;
+import net.runelite.api.Perspective;
+import net.runelite.api.Point;
+import net.runelite.api.coords.LocalPoint;
+import net.runelite.api.coords.WorldPoint;
+import net.runelite.client.ui.overlay.Overlay;
+import net.runelite.client.ui.overlay.OverlayLayer;
+import net.runelite.client.ui.overlay.OverlayPosition;
+
+public class TileIndicatorsMinimapOverlay extends Overlay
+{
+	private final Client client;
+	private final TileIndicatorsConfig config;
+
+	@Inject
+	private TileIndicatorsMinimapOverlay(Client client, TileIndicatorsConfig config)
+	{
+		this.client = client;
+		this.config = config;
+		setPosition(OverlayPosition.DYNAMIC);
+		setLayer(OverlayLayer.ABOVE_WIDGETS);
+		setPriority(PRIORITY_MED);
+	}
+
+	@Override
+	public Dimension render(Graphics2D graphics)
+	{
+		if (!config.showOnMinimap())
+		{
+			return null;
+		}
+
+		if (config.highlightDestinationTile())
+		{
+			renderTile(graphics, client.getLocalDestinationLocation(), config.highlightDestinationColor(), config.destinationTileFillColor());
+		}
+
+		if (config.highlightCurrentTile())
+		{
+			final WorldPoint playerPos = client.getLocalPlayer().getWorldLocation();
+			if (playerPos == null)
+			{
+				return null;
+			}
+
+			final LocalPoint playerPosLocal = LocalPoint.fromWorld(client, playerPos);
+			if (playerPosLocal == null)
+			{
+				return null;
+			}
+
+			renderTile(graphics, playerPosLocal, config.highlightCurrentColor(), config.currentTileFillColor());
+		}
+
+		return null;
+	}
+
+	private void renderTile(Graphics2D graphics, LocalPoint point, Color color, Color fillColor)
+	{
+		if (point == null)
+		{
+			return;
+		}
+
+		int offset = Perspective.LOCAL_HALF_TILE_SIZE;
+		point = point.dx(-offset).dy(-offset);
+
+		Point mp1 = Perspective.localToMinimap(client, point);
+		Point mp2 = Perspective.localToMinimap(client, point.dy(Perspective.LOCAL_TILE_SIZE));
+		Point mp3 = Perspective.localToMinimap(client, point.dx(Perspective.LOCAL_TILE_SIZE).dy(Perspective.LOCAL_TILE_SIZE));
+		Point mp4 = Perspective.localToMinimap(client, point.dx(Perspective.LOCAL_TILE_SIZE));
+
+		if (mp1 == null || mp2 == null || mp3 == null || mp4 == null)
+		{
+			return;
+		}
+
+		Polygon poly = new Polygon();
+		poly.addPoint(mp1.getX(), mp1.getY());
+		poly.addPoint(mp2.getX(), mp2.getY());
+		poly.addPoint(mp3.getX(), mp3.getY());
+		poly.addPoint(mp4.getX(), mp4.getY());
+
+		Stroke stroke = new BasicStroke(1f);
+		graphics.setStroke(stroke);
+		graphics.setColor(color);
+		graphics.drawPolygon(poly);
+		graphics.setColor(fillColor);
+		graphics.fillPolygon(poly);
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/tileindicators/TileIndicatorsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/tileindicators/TileIndicatorsPlugin.java
@@ -45,6 +45,12 @@ public class TileIndicatorsPlugin extends Plugin
 	@Inject
 	private TileIndicatorsOverlay overlay;
 
+	@Inject
+	private TileIndicatorsMapOverlay mapOverlay;
+
+	@Inject
+	private TileIndicatorsMinimapOverlay minimapOverlay;
+
 	@Provides
 	TileIndicatorsConfig provideConfig(ConfigManager configManager)
 	{
@@ -55,11 +61,15 @@ public class TileIndicatorsPlugin extends Plugin
 	protected void startUp() throws Exception
 	{
 		overlayManager.add(overlay);
+		overlayManager.add(mapOverlay);
+		overlayManager.add(minimapOverlay);
 	}
 
 	@Override
 	protected void shutDown() throws Exception
 	{
 		overlayManager.remove(overlay);
+		overlayManager.remove(mapOverlay);
+		overlayManager.remove(minimapOverlay);
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/worldmap/WorldMapOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/worldmap/WorldMapOverlay.java
@@ -297,7 +297,7 @@ public class WorldMapOverlay extends Overlay
 	 * @return              An {@link Area} representing <code>baseRectangle</code>, with the area
 	 *                      of visible widgets overlaying the world map clipped from it.
 	 */
-	private Shape getWorldMapClipArea(Rectangle baseRectangle)
+	public Shape getWorldMapClipArea(Rectangle baseRectangle)
 	{
 		final Widget overview = client.getWidget(ComponentID.WORLD_MAP_OVERVIEW_MAP);
 		final Widget surfaceSelector = client.getWidget(ComponentID.WORLD_MAP_SURFACE_SELECTOR);


### PR DESCRIPTION
Adds options to display tile indicators on the minimap and the world map for destination tile and true tile (I can also try to add hovered tile if wanted, but not sure if that is useful). The config options are set to false to not change the behaviour of the plugin for current users.

![image](https://github.com/user-attachments/assets/7555c277-fca0-4706-8a4d-a2c4bc9af4ab)