### PR TITLE
tileindicators: Option to only show true tile while moving

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/tileindicators/TileIndicatorsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/tileindicators/TileIndicatorsConfig.java
@@ -167,12 +167,24 @@ public interface TileIndicatorsConfig extends Config
 		return false;
 	}
 
+	@ConfigItem(
+		keyName = "highlightCurrentTileMoving",
+		name = "Only show true tile when moving",
+		description = "Whether to only highlight the true tile when the player is moving",
+		position = 2,
+		section = currentTile
+	)
+	default boolean highlightCurrentTileMoving()
+	{
+		return false;
+	}
+
 	@Alpha
 	@ConfigItem(
 		keyName = "highlightCurrentColor",
 		name = "Highlight color",
 		description = "Configures the highlight color of current true tile",
-		position = 2,
+		position = 3,
 		section = currentTile
 	)
 	default Color highlightCurrentColor()
@@ -185,7 +197,7 @@ public interface TileIndicatorsConfig extends Config
 		keyName = "currentTileFillColor",
 		name = "Fill color",
 		description = "Configures the fill color of current true tile",
-		position = 3,
+		position = 4,
 		section = currentTile
 	)
 	default Color currentTileFillColor()
@@ -197,7 +209,7 @@ public interface TileIndicatorsConfig extends Config
 		keyName = "currentTileBorderWidth",
 		name = "Border width",
 		description = "Width of the true tile marker border",
-		position = 4,
+		position = 5,
 		section = currentTile
 	)
 	default double currentTileBorderWidth()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/tileindicators/TileIndicatorsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/tileindicators/TileIndicatorsOverlay.java
@@ -80,7 +80,8 @@ public class TileIndicatorsOverlay extends Overlay
 			}
 
 			final LocalPoint playerPosLocal = LocalPoint.fromWorld(client, playerPos);
-			if (playerPosLocal == null)
+			if (playerPosLocal == null || (config.highlightCurrentTileMoving()
+				&& client.getLocalDestinationLocation() == null))
 			{
 				return null;
 			}


### PR DESCRIPTION
Adds a config option to only highlight the true tile while the player is moving. This means that no tile will be drawn under the player when the player is standing still, which can be a bit annoying when admiring your mole slippers.

Implements #14032 