### PR TITLE
loot tracker: record skill levels metadata for hunters' loot sacks

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
@@ -1302,13 +1302,18 @@ public class LootTrackerPlugin extends Plugin
 					case ItemID.HUNTERS_LOOT_SACK_EXPERT:
 					case ItemID.HUNTERS_LOOT_SACK_MASTER:
 						final int itemId = event.getItemId();
+						final Map<String, Integer> levels = new ImmutableMap.Builder<String, Integer>().
+							put("WOODCUTTING", client.getBoostedSkillLevel(Skill.WOODCUTTING)).
+							put("HERBLORE", client.getBoostedSkillLevel(Skill.HERBLORE)).
+							put("HUNTER", client.getBoostedSkillLevel(Skill.HUNTER)).
+							build();
 						onInvChange((((invItems, groundItems, removedItems) ->
 						{
 							int cnt = removedItems.count(itemId);
 							if (cnt > 0)
 							{
 								String name = itemManager.getItemComposition(itemId).getMembersName();
-								addLoot(name, -1, LootRecordType.EVENT, null, invItems, cnt);
+								addLoot(name, -1, LootRecordType.EVENT, levels, invItems, cnt);
 							}
 						})));
 						break;


### PR DESCRIPTION
It's known that hunters' loot sacks' drops scale depending on woodcutting and herblore levels, so I've added those as metadata for wiki crowdsourcing/drop rates purposes. I threw in hunter level too for good measure, since the wording on the wiki is a bit ambiguous as to whether it *only* depends on wc and herb levels. It could be the case that hunter level affects the meats you receive.

See: https://oldschool.runescape.wiki/w/Hunters%27_loot_sack_(expert)