### PR TITLE
Ground Items plugin: hide stacks of coins under amount

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItem.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItem.java
@@ -30,6 +30,7 @@ import java.time.Instant;
 import javax.annotation.Nullable;
 import lombok.Builder;
 import lombok.Data;
+import net.runelite.api.ItemID;
 import static net.runelite.api.TileItem.OWNERSHIP_GROUP;
 import static net.runelite.api.TileItem.OWNERSHIP_NONE;
 import static net.runelite.api.TileItem.OWNERSHIP_OTHER;
@@ -77,7 +78,7 @@ class GroundItem
 
 	int getCoinsAmount()
 	{
-		return name == "Coins" ? quantity : 0;
+		return itemId == ItemID.COINS_995 ? quantity : 0;
 	}
 
 	void reset()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItem.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItem.java
@@ -75,6 +75,11 @@ class GroundItem
 		return gePrice * quantity;
 	}
 
+	int getCoinsAmount()
+	{
+		return name == "Coins" ? quantity : 0;
+	}
+
 	void reset()
 	{
 		highlighted = hidden = false;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
@@ -235,12 +235,23 @@ public interface GroundItemsConfig extends Config
 		return 0;
 	}
 
+	@ConfigItem(
+	keyName = "hideCoinsUnderAmount",
+	name = "Hide coins under amount",
+	description = "Hides stacks of coins under the amount",
+	position = 14
+	)
+	default int getHideCoinsUnderAmount()
+	{
+		return 0;
+	}
+
 	@Alpha
 	@ConfigItem(
 		keyName = "defaultColor",
 		name = "Default items",
 		description = "Configures the color for default, non-highlighted items",
-		position = 14
+		position = 15
 	)
 	default Color defaultColor()
 	{
@@ -252,7 +263,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "highlightedColor",
 		name = "Highlighted items",
 		description = "Configures the color for highlighted items",
-		position = 15
+		position = 16
 	)
 	default Color highlightedColor()
 	{
@@ -264,7 +275,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "hiddenColor",
 		name = "Hidden items",
 		description = "Configures the color for hidden items in right-click menu and when holding ALT",
-		position = 16
+		position = 17
 	)
 	default Color hiddenColor()
 	{
@@ -276,7 +287,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "lowValueColor",
 		name = "Low value items",
 		description = "Configures the color for low value items",
-		position = 17
+		position = 18
 	)
 	default Color lowValueColor()
 	{
@@ -287,7 +298,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "lowValuePrice",
 		name = "Low value price",
 		description = "Configures the start price for low value items",
-		position = 18
+		position = 19
 	)
 	default int lowValuePrice()
 	{
@@ -299,7 +310,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "mediumValueColor",
 		name = "Medium value items",
 		description = "Configures the color for medium value items",
-		position = 19
+		position = 20
 	)
 	default Color mediumValueColor()
 	{
@@ -310,7 +321,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "mediumValuePrice",
 		name = "Medium value price",
 		description = "Configures the start price for medium value items",
-		position = 20
+		position = 21
 	)
 	default int mediumValuePrice()
 	{
@@ -322,7 +333,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "highValueColor",
 		name = "High value items",
 		description = "Configures the color for high value items",
-		position = 21
+		position = 22
 	)
 	default Color highValueColor()
 	{
@@ -333,7 +344,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "highValuePrice",
 		name = "High value price",
 		description = "Configures the start price for high value items",
-		position = 22
+		position = 23
 	)
 	default int highValuePrice()
 	{
@@ -345,7 +356,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "insaneValueColor",
 		name = "Insane value items",
 		description = "Configures the color for insane value items",
-		position = 23
+		position = 24
 	)
 	default Color insaneValueColor()
 	{
@@ -356,7 +367,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "insaneValuePrice",
 		name = "Insane value price",
 		description = "Configures the start price for insane value items",
-		position = 24
+		position = 25
 	)
 	default int insaneValuePrice()
 	{
@@ -367,7 +378,7 @@ public interface GroundItemsConfig extends Config
 		keyName = OWNERSHIP_FILTER_MODE,
 		name = "Ownership filter",
 		description = "Show all items, takeable items, or only your or your group's drops.",
-		position = 25
+		position = 26
 	)
 	default OwnershipFilterMode ownershipFilterMode()
 	{
@@ -378,7 +389,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "doubleTapDelay",
 		name = "Double-tap delay",
 		description = "Delay for the double-tap ALT to hide ground items. 0 to disable.",
-		position = 26
+		position = 27
 	)
 	@Units(Units.MILLISECONDS)
 	default int doubleTapDelay()
@@ -390,7 +401,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "collapseEntries",
 		name = "Collapse ground item menu",
 		description = "Collapses ground item menu entries together and appends count",
-		position = 27
+		position = 28
 	)
 	default boolean collapseEntries()
 	{
@@ -401,7 +412,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "groundItemTimers",
 		name = "Despawn timer",
 		description = "Shows despawn timers for items you've dropped and received as loot",
-		position = 28
+		position = 29
 	)
 	default DespawnTimerMode groundItemTimers()
 	{
@@ -412,7 +423,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "textOutline",
 		name = "Text Outline",
 		description = "Use an outline around text instead of a text shadow",
-		position = 29
+		position = 30
 	)
 	default boolean textOutline()
 	{
@@ -423,7 +434,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "showLootbeamForHighlighted",
 		name = "Highlighted item lootbeams",
 		description = "Configures lootbeams to show for all highlighted items.",
-		position = 30
+		position = 31
 	)
 	default boolean showLootbeamForHighlighted()
 	{
@@ -434,7 +445,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "showLootbeamTier",
 		name = "Lootbeam tier",
 		description = "Configures which price tiers will trigger a lootbeam",
-		position = 31
+		position = 32
 	)
 	default HighlightTier showLootbeamTier()
 	{
@@ -445,7 +456,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "lootbeamStyle",
 		name = "Lootbeam Style",
 		description = "Style of lootbeam to use",
-		position = 32
+		position = 33
 	)
 	default Lootbeam.Style lootbeamStyle()
 	{
@@ -456,7 +467,7 @@ public interface GroundItemsConfig extends Config
 		keyName = "hotkey",
 		name = "Hotkey",
 		description = "Configures the hotkey used by the Ground Items plugin",
-		position = 33
+		position = 34
 	)
 	default Keybind hotkey()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
@@ -666,9 +666,10 @@ public class GroundItemsPlugin extends Plugin
 		final boolean canBeHidden = groundItem.getGePrice() > 0 || groundItem.isTradeable() || !config.dontHideUntradeables();
 		final boolean underGe = groundItem.getGePrice() < config.getHideUnderValue();
 		final boolean underHa = groundItem.getHaPrice() < config.getHideUnderValue();
+		final boolean underCoins = groundItem.getCoinsAmount() < config.getHideCoinsUnderAmount();
 
 		// Explicit highlight takes priority over implicit hide
-		return isExplicitHidden || (!isExplicitHighlight && canBeHidden && underGe && underHa)
+		return isExplicitHidden || (!isExplicitHighlight && canBeHidden && underGe && underHa && underCoins)
 			? config.hiddenColor()
 			: null;
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
@@ -669,7 +669,7 @@ public class GroundItemsPlugin extends Plugin
 		final boolean underCoins = groundItem.getCoinsAmount() < config.getHideCoinsUnderAmount();
 
 		// Explicit highlight takes priority over implicit hide
-		return isExplicitHidden || (!isExplicitHighlight && canBeHidden && underGe && underHa && underCoins)
+		return isExplicitHidden || (!isExplicitHighlight && canBeHidden && ((underGe && underHa) || underCoins))
 			? config.hiddenColor()
 			: null;
 	}


### PR DESCRIPTION
I wanted a setting in the ground items plugin to hide stacks of coins under a given amount, but not all items under that amount.

I have added a new config for coin stack size and added an additional check to the hide logic for coins specifically.

I tested these changes in game after building the client.

I put the settings at `5` coins
![image](https://github.com/user-attachments/assets/4e07da41-4c9b-4577-aab8-b318dd273545)

And it can be seen that the coin stack of 4 is hidden, but the stack of 5 is not
![image](https://github.com/user-attachments/assets/792ca778-1724-46c3-9b7b-6ff5edf38102)
