### PR TITLE
gpu: regions: add KBD lair

### DIFF
--- a/runelite-client/src/main/resources/net/runelite/client/plugins/gpu/regions/regions.txt
+++ b/runelite-client/src/main/resources/net/runelite/client/plugins/gpu/regions/regions.txt
@@ -369,3 +369,7 @@ r 43 146
 // tunnel of chaos (what lies below)
 n
 r 49 81
+
+// king black dragon lair
+n
+r 35 73


### PR DESCRIPTION
Reported by felanbird.


**Before:**
![kbd lair before](https://github.com/user-attachments/assets/0a589431-c22f-468f-a7b5-6be8293ee4d1)


**After:**
![kbd lair after](https://github.com/user-attachments/assets/82a7490d-2709-40ad-84c2-7e84fea487e2)

Getting there (probably not needed for this one but including for reference:
*Bring an antidote++, super antifire, and anti-dragon shield or dragonfire shield and use Protect From Magic*
- Burning Amulet to Lava Maze
- Open the gate to the north and climb down the ladder
- Pull the lever
From there, run right all the way to the corner. That's where the before and after screenshots were taken.
