### PR TITLE
itemstats: update total heal for hunter meats

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatChanges.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatChanges.java
@@ -126,12 +126,15 @@ public class ItemStatChanges
 		add(range(food(5), food(8)), LEAN_SNAIL_MEAT);
 		add(range(food(7), food(9)), FAT_SNAIL_MEAT);
 		add(range(food(7), food(10)), SPIDER_ON_STICK_6297, SPIDER_ON_SHAFT_6299);
-		add(combo(food(8), food(6)), COOKED_GRAAHK);
-		add(combo(food(9), food(8)), COOKED_KYATT);
-		add(combo(food(11), food(8)), COOKED_PYRE_FOX);
-		add(combo(food(13), food(10), heal(RUN_ENERGY, 10)), COOKED_DASHING_KEBBIT);
-		add(combo(food(12), food(9)), COOKED_SUNLIGHT_ANTELOPE);
-		add(combo(food(14), food(12)), COOKED_MOONLIGHT_ANTELOPE);
+		add(combo(food(4), food(8)), COOKED_WILD_KEBBIT);
+		add(combo(food(6), food(11)), COOKED_LARUPIA);
+		add(combo(food(7), food(12)), COOKED_BARBTAILED_KEBBIT);
+		add(combo(food(8), food(14)), COOKED_GRAAHK);
+		add(combo(food(9), food(17)), COOKED_KYATT);
+		add(combo(food(11), food(19)), COOKED_PYRE_FOX);
+		add(combo(food(13), food(23), heal(RUN_ENERGY, 10)), COOKED_DASHING_KEBBIT);
+		add(combo(food(12), food(21)), COOKED_SUNLIGHT_ANTELOPE);
+		add(combo(food(14), food(26)), COOKED_MOONLIGHT_ANTELOPE);
 
 		// Dorgeshuun Cuisine
 		add(food(2), BAT_SHISH, COATED_FROGS_LEGS, FILLETS, FINGERS, FROGBURGER, FROGSPAWN_GUMBO, GREEN_GLOOP_SOUP,


### PR DESCRIPTION
fixes #18505 

Also noticed `COOKED_WILD_KEBBIT`, `COOKED_LARUPIA`, and `COOKED_BARBTAILED_KEBBIT` were missing
![image](https://github.com/user-attachments/assets/73e5f4f4-a1c7-4727-a672-cedc095fb5d4)
