### PR TITLE
chat commands: change !cmb to check local levels instead of hiscores

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
@@ -1687,13 +1687,13 @@ public class ChatCommandsPlugin extends Plugin
 			return;
 		}
 
-		int attack = levels[net.runelite.api.Skill.valueOf("ATTACK").ordinal()];
-		int strength = levels[net.runelite.api.Skill.valueOf("STRENGTH").ordinal()];
-		int defence = levels[net.runelite.api.Skill.valueOf("DEFENCE").ordinal()];
-		int hitpoints = levels[net.runelite.api.Skill.valueOf("HITPOINTS").ordinal()];
-		int ranged = levels[net.runelite.api.Skill.valueOf("RANGED").ordinal()];
-		int prayer = levels[net.runelite.api.Skill.valueOf("PRAYER").ordinal()];
-		int magic = levels[net.runelite.api.Skill.valueOf("MAGIC").ordinal()];
+		int attack = levels[net.runelite.api.Skill.ATTACK.ordinal()];
+		int strength = levels[net.runelite.api.Skill.STRENGTH.ordinal()];
+		int defence = levels[net.runelite.api.Skill.DEFENCE.ordinal()];
+		int hitpoints = levels[net.runelite.api.Skill.HITPOINTS.ordinal()];
+		int ranged = levels[net.runelite.api.Skill.RANGED.ordinal()];
+		int prayer = levels[net.runelite.api.Skill.PRAYER.ordinal()];
+		int magic = levels[net.runelite.api.Skill.MAGIC.ordinal()];
 		int combatLevel = Experience.getCombatLevel(attack, strength, defence, hitpoints, magic, ranged, prayer);
 
 		String response = new ChatMessageBuilder()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
@@ -1680,71 +1680,61 @@ public class ChatCommandsPlugin extends Plugin
 			return;
 		}
 
-		final HiscoreLookup lookup = getCorrectLookupFor(chatMessage);
-
-		try
+		var levels = client.getRealSkillLevels();
+		if (levels == null)
 		{
-			HiscoreResult playerStats = hiscoreClient.lookup(lookup.getName(), lookup.getEndpoint());
-
-			if (playerStats == null)
-			{
-				log.warn("Error fetching hiscore data: not found");
-				return;
-			}
-
-			int attack = playerStats.getSkill(HiscoreSkill.ATTACK).getLevel();
-			int strength = playerStats.getSkill(HiscoreSkill.STRENGTH).getLevel();
-			int defence = playerStats.getSkill(HiscoreSkill.DEFENCE).getLevel();
-			int hitpoints = playerStats.getSkill(HiscoreSkill.HITPOINTS).getLevel();
-			int ranged = playerStats.getSkill(HiscoreSkill.RANGED).getLevel();
-			int prayer = playerStats.getSkill(HiscoreSkill.PRAYER).getLevel();
-			int magic = playerStats.getSkill(HiscoreSkill.MAGIC).getLevel();
-			int combatLevel = Experience.getCombatLevel(attack, strength, defence, hitpoints, magic, ranged, prayer);
-
-			String response = new ChatMessageBuilder()
-				.append(ChatColorType.NORMAL)
-				.append("Combat Level: ")
-				.append(ChatColorType.HIGHLIGHT)
-				.append(String.valueOf(combatLevel))
-				.append(ChatColorType.NORMAL)
-				.append(" A: ")
-				.append(ChatColorType.HIGHLIGHT)
-				.append(String.valueOf(attack))
-				.append(ChatColorType.NORMAL)
-				.append(" S: ")
-				.append(ChatColorType.HIGHLIGHT)
-				.append(String.valueOf(strength))
-				.append(ChatColorType.NORMAL)
-				.append(" D: ")
-				.append(ChatColorType.HIGHLIGHT)
-				.append(String.valueOf(defence))
-				.append(ChatColorType.NORMAL)
-				.append(" H: ")
-				.append(ChatColorType.HIGHLIGHT)
-				.append(String.valueOf(hitpoints))
-				.append(ChatColorType.NORMAL)
-				.append(" R: ")
-				.append(ChatColorType.HIGHLIGHT)
-				.append(String.valueOf(ranged))
-				.append(ChatColorType.NORMAL)
-				.append(" P: ")
-				.append(ChatColorType.HIGHLIGHT)
-				.append(String.valueOf(prayer))
-				.append(ChatColorType.NORMAL)
-				.append(" M: ")
-				.append(ChatColorType.HIGHLIGHT)
-				.append(String.valueOf(magic))
-				.build();
-
-			log.debug("Setting response {}", response);
-			final MessageNode messageNode = chatMessage.getMessageNode();
-			messageNode.setRuneLiteFormatMessage(response);
-			client.refreshChat();
+			log.warn("Error fetching levels: not found");
+			return;
 		}
-		catch (IOException ex)
-		{
-			log.warn("Error fetching hiscore data", ex);
-		}
+
+		int attack = levels[net.runelite.api.Skill.valueOf("ATTACK").ordinal()];
+		int strength = levels[net.runelite.api.Skill.valueOf("STRENGTH").ordinal()];
+		int defence = levels[net.runelite.api.Skill.valueOf("DEFENCE").ordinal()];
+		int hitpoints = levels[net.runelite.api.Skill.valueOf("HITPOINTS").ordinal()];
+		int ranged = levels[net.runelite.api.Skill.valueOf("RANGED").ordinal()];
+		int prayer = levels[net.runelite.api.Skill.valueOf("PRAYER").ordinal()];
+		int magic = levels[net.runelite.api.Skill.valueOf("MAGIC").ordinal()];
+		int combatLevel = Experience.getCombatLevel(attack, strength, defence, hitpoints, magic, ranged, prayer);
+
+		String response = new ChatMessageBuilder()
+			.append(ChatColorType.NORMAL)
+			.append("Combat Level: ")
+			.append(ChatColorType.HIGHLIGHT)
+			.append(String.valueOf(combatLevel))
+			.append(ChatColorType.NORMAL)
+			.append(" A: ")
+			.append(ChatColorType.HIGHLIGHT)
+			.append(String.valueOf(attack))
+			.append(ChatColorType.NORMAL)
+			.append(" S: ")
+			.append(ChatColorType.HIGHLIGHT)
+			.append(String.valueOf(strength))
+			.append(ChatColorType.NORMAL)
+			.append(" D: ")
+			.append(ChatColorType.HIGHLIGHT)
+			.append(String.valueOf(defence))
+			.append(ChatColorType.NORMAL)
+			.append(" H: ")
+			.append(ChatColorType.HIGHLIGHT)
+			.append(String.valueOf(hitpoints))
+			.append(ChatColorType.NORMAL)
+			.append(" R: ")
+			.append(ChatColorType.HIGHLIGHT)
+			.append(String.valueOf(ranged))
+			.append(ChatColorType.NORMAL)
+			.append(" P: ")
+			.append(ChatColorType.HIGHLIGHT)
+			.append(String.valueOf(prayer))
+			.append(ChatColorType.NORMAL)
+			.append(" M: ")
+			.append(ChatColorType.HIGHLIGHT)
+			.append(String.valueOf(magic))
+			.build();
+
+		log.debug("Setting response {}", response);
+		final MessageNode messageNode = chatMessage.getMessageNode();
+		messageNode.setRuneLiteFormatMessage(response);
+		client.refreshChat();
 	}
 
 	private void leaguePointsLookup(ChatMessage chatMessage, String message)


### PR DESCRIPTION
Issue: !cmb command shows wrong values for combat skills that are relatively low (e.g. 45 def shows as 1) and computes the wrong combat level.

Cause:  net.runelite.client.plugins.chatcommands.ChatCommandsPlugin.combatLevelLookup queries the hi-scores for combat skill levels, which doesn't work when the combat skills are too low to show up on the hi-scores.

Fix: Get real skill levels from the local client instead of the hi-scores and use them to compute the combat level.

Fixes #18525 

Example with low cb (levelled str up to 2 to make sure):
![image](https://github.com/user-attachments/assets/1060f68c-148f-420f-a28d-ee42eaea80ce)

Example with high cb:
![image](https://github.com/user-attachments/assets/1ca16771-a970-4c70-b3b3-0d584c6d0654)


