### PR TITLE
overlays: add separate background colors for infoboxes and tooltips

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/config/RuneLiteConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/RuneLiteConfig.java
@@ -415,7 +415,7 @@ public interface RuneLiteConfig extends Config
 	@ConfigItem(
 		keyName = "overlayBackgroundColor",
 		name = "Overlay color",
-		description = "Configures the background color of infoboxes and overlays",
+		description = "Configures the background color of overlays",
 		position = 44,
 		section = overlaySettings
 	)
@@ -424,11 +424,37 @@ public interface RuneLiteConfig extends Config
 		return ComponentConstants.STANDARD_BACKGROUND_COLOR;
 	}
 
+	@Alpha
+	@ConfigItem(
+			keyName = "tooltipBackgroundColor",
+			name = "Tooltip color",
+			description = "Configures the background color of tooltips",
+			position = 45,
+			section = overlaySettings
+	)
+	default Color tooltipBackgroundColor()
+	{
+		return ComponentConstants.STANDARD_BACKGROUND_COLOR;
+	}
+
+	@Alpha
+	@ConfigItem(
+			keyName = "infoboxBackgroundColor",
+			name = "Infobox color",
+			description = "Configures the background color of infoboxes",
+			position = 46,
+			section = overlaySettings
+	)
+	default Color infoboxBackgroundColor()
+	{
+		return ComponentConstants.STANDARD_BACKGROUND_COLOR;
+	}
+
 	@ConfigItem(
 		keyName = "sidebarToggleKey",
 		name = "Sidebar toggle key",
 		description = "The key that will toggle the sidebar (accepts modifiers)",
-		position = 45,
+		position = 47,
 		section = windowSettings
 	)
 	default Keybind sidebarToggleKey()
@@ -440,7 +466,7 @@ public interface RuneLiteConfig extends Config
 		keyName = "panelToggleKey",
 		name = "Plugin panel toggle key",
 		description = "The key that will toggle the current or last opened plugin panel (accepts modifiers)",
-		position = 46,
+		position = 48,
 		section = windowSettings
 	)
 	default Keybind panelToggleKey()

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/infobox/InfoBoxOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/infobox/InfoBoxOverlay.java
@@ -125,7 +125,7 @@ public class InfoBoxOverlay extends OverlayPanel
 
 		final Font font = config.infoboxFontType().getFont();
 		final boolean infoBoxTextOutline = config.infoBoxTextOutline();
-		final Color overlayBackgroundColor = config.overlayBackgroundColor();
+		final Color overlayBackgroundColor = config.infoboxBackgroundColor();
 		final Dimension preferredSize = new Dimension(config.infoBoxSize(), config.infoBoxSize());
 		for (InfoBox box : infoBoxes)
 		{

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/tooltip/TooltipOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/tooltip/TooltipOverlay.java
@@ -107,7 +107,7 @@ public class TooltipOverlay extends Overlay
 				entity = tooltip.getComponent();
 				if (entity instanceof PanelComponent)
 				{
-					((PanelComponent) entity).setBackgroundColor(runeLiteConfig.overlayBackgroundColor());
+					((PanelComponent) entity).setBackgroundColor(runeLiteConfig.tooltipBackgroundColor());
 				}
 			}
 			else
@@ -115,7 +115,7 @@ public class TooltipOverlay extends Overlay
 				final TooltipComponent tooltipComponent = new TooltipComponent();
 				tooltipComponent.setModIcons(client.getModIcons());
 				tooltipComponent.setText(tooltip.getText());
-				tooltipComponent.setBackgroundColor(runeLiteConfig.overlayBackgroundColor());
+				tooltipComponent.setBackgroundColor(runeLiteConfig.tooltipBackgroundColor());
 				entity = tooltipComponent;
 			}
 


### PR DESCRIPTION
as we already have separate font sizes for them, further allow users to customize infoboxes and tooltips (i.e. users may want transparent infoboxes/overlays but backgrounds for tooltips)

![image](https://github.com/user-attachments/assets/7526a324-3363-4632-a033-8aff5fcff125)
