### PR TITLE
skillcalculator: Add multiplier input

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/UnitFormatter.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/UnitFormatter.java
@@ -25,10 +25,7 @@
 package net.runelite.client.plugins.config;
 
 import java.text.ParseException;
-import java.util.HashMap;
-import java.util.Map;
 import javax.swing.JFormattedTextField;
-import lombok.RequiredArgsConstructor;
 
 final class UnitFormatter extends JFormattedTextField.AbstractFormatter
 {
@@ -68,18 +65,5 @@ final class UnitFormatter extends JFormattedTextField.AbstractFormatter
 	public String valueToString(final Object value)
 	{
 		return value + units;
-	}
-}
-
-@RequiredArgsConstructor
-final class UnitFormatterFactory extends JFormattedTextField.AbstractFormatterFactory
-{
-	private final String units;
-	private final Map<JFormattedTextField, JFormattedTextField.AbstractFormatter> formatters = new HashMap<>();
-
-	@Override
-	public JFormattedTextField.AbstractFormatter getFormatter(final JFormattedTextField tf)
-	{
-		return formatters.computeIfAbsent(tf, (key) -> new UnitFormatter(units));
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/UnitFormatterFactory.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/UnitFormatterFactory.java
@@ -1,0 +1,20 @@
+package net.runelite.client.plugins.config;
+
+import lombok.RequiredArgsConstructor;
+
+import javax.swing.JFormattedTextField;
+import java.util.HashMap;
+import java.util.Map;
+
+@RequiredArgsConstructor
+public final class UnitFormatterFactory extends JFormattedTextField.AbstractFormatterFactory
+{
+	private final String units;
+	private final Map<JFormattedTextField, JFormattedTextField.AbstractFormatter> formatters = new HashMap<>();
+
+	@Override
+	public JFormattedTextField.AbstractFormatter getFormatter(final JFormattedTextField tf)
+	{
+		return formatters.computeIfAbsent(tf, (key) -> new UnitFormatter(units));
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/SkillCalculator.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/SkillCalculator.java
@@ -73,6 +73,7 @@ import net.runelite.client.ui.components.IconTextField;
 class SkillCalculator extends JPanel
 {
 	private static final int MAX_XP = 200_000_000;
+	private static final int MAX_MULTIPLIER = 100;
 	private static final JLabel EMPTY_PANEL = new JLabel("No F2P actions to show.");
 
 	static
@@ -97,6 +98,7 @@ class SkillCalculator extends JPanel
 	private int currentXP = Experience.getXpForLevel(currentLevel);
 	private int targetLevel = currentLevel + 1;
 	private int targetXP = Experience.getXpForLevel(targetLevel);
+	private int xpMultiplier = 1;
 	private final Set<SkillBonus> currentBonuses = new HashSet<>();
 
 	@Inject
@@ -141,12 +143,14 @@ class SkillCalculator extends JPanel
 
 		uiInput.getUiFieldTargetLevel().addActionListener(e -> onFieldTargetLevelUpdated());
 		uiInput.getUiFieldTargetXP().addActionListener(e -> onFieldTargetXPUpdated());
+		uiInput.getUiFieldXPMultiplier().addActionListener(e -> onFieldXPMultiplierUpdated());
 
 		// Register focus listeners to calculate xp when exiting a text field
 		uiInput.getUiFieldCurrentLevel().addFocusListener(buildFocusAdapter(e -> onFieldCurrentLevelUpdated()));
 		uiInput.getUiFieldCurrentXP().addFocusListener(buildFocusAdapter(e -> onFieldCurrentXPUpdated()));
 		uiInput.getUiFieldTargetLevel().addFocusListener(buildFocusAdapter(e -> onFieldTargetLevelUpdated()));
 		uiInput.getUiFieldTargetXP().addFocusListener(buildFocusAdapter(e -> onFieldTargetXPUpdated()));
+		uiInput.getUiFieldXPMultiplier().addFocusListener(buildFocusAdapter(e -> onFieldXPMultiplierUpdated()));
 	}
 
 	void openCalculator(CalculatorType calculatorType, boolean forceReload)
@@ -431,7 +435,7 @@ class SkillCalculator extends JPanel
 					bonus *= skillBonus.getValue();
 				}
 			}
-			final int xp = (int) Math.floor(action.getXp() * 10f * bonus);
+			final int xp = (int) Math.floor(action.getXp() * 10f * bonus * xpMultiplier);
 
 			if (neededXP > 0)
 			{
@@ -471,6 +475,7 @@ class SkillCalculator extends JPanel
 		uiInput.setTargetLevelInput(targetLevel);
 		uiInput.setTargetXPInput(tXP);
 		uiInput.setNeededXP(nXP + " XP required to reach target XP");
+		uiInput.setXPMultiplier(xpMultiplier);
 		calculate();
 	}
 
@@ -478,6 +483,12 @@ class SkillCalculator extends JPanel
 	{
 		currentLevel = enforceSkillBounds(uiInput.getCurrentLevelInput());
 		currentXP = Experience.getXpForLevel(currentLevel);
+		updateInputFields();
+	}
+
+	private void onFieldXPMultiplierUpdated()
+	{
+		xpMultiplier = enforceMultiplierBounds(uiInput.getXPMultiplierInput());
 		updateInputFields();
 	}
 
@@ -510,6 +521,11 @@ class SkillCalculator extends JPanel
 	private static int enforceXPBounds(int input)
 	{
 		return Math.min(MAX_XP, Math.max(0, input));
+	}
+
+	private static int enforceMultiplierBounds(int input)
+	{
+		return Math.min(MAX_MULTIPLIER, Math.max(1, input));
 	}
 
 	private void onSearch()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/SkillCalculator.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/SkillCalculator.java
@@ -73,7 +73,7 @@ import net.runelite.client.ui.components.IconTextField;
 class SkillCalculator extends JPanel
 {
 	private static final int MAX_XP = 200_000_000;
-	private static final int MAX_MULTIPLIER = 100;
+	static final int MAX_MULTIPLIER = 32;
 	private static final JLabel EMPTY_PANEL = new JLabel("No F2P actions to show.");
 
 	static
@@ -143,7 +143,7 @@ class SkillCalculator extends JPanel
 
 		uiInput.getUiFieldTargetLevel().addActionListener(e -> onFieldTargetLevelUpdated());
 		uiInput.getUiFieldTargetXP().addActionListener(e -> onFieldTargetXPUpdated());
-		uiInput.getUiFieldXPMultiplier().addActionListener(e -> onFieldXPMultiplierUpdated());
+		uiInput.getUiFieldXPMultiplier().addChangeListener(e -> onFieldXPMultiplierUpdated());
 
 		// Register focus listeners to calculate xp when exiting a text field
 		uiInput.getUiFieldCurrentLevel().addFocusListener(buildFocusAdapter(e -> onFieldCurrentLevelUpdated()));

--- a/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/UICalculatorInputArea.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/UICalculatorInputArea.java
@@ -28,16 +28,24 @@ package net.runelite.client.plugins.skillcalculator;
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.GridLayout;
+import javax.swing.JFormattedTextField;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
+import javax.swing.JSpinner;
 import javax.swing.JTextField;
 import javax.swing.border.EmptyBorder;
+import javax.swing.SpinnerModel;
+import javax.swing.SpinnerNumberModel;
+
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import lombok.Getter;
+import net.runelite.client.plugins.config.UnitFormatterFactory;
 import net.runelite.client.ui.ColorScheme;
 import net.runelite.client.ui.FontManager;
 import net.runelite.client.ui.components.FlatTextField;
+
+import static net.runelite.client.plugins.skillcalculator.SkillCalculator.MAX_MULTIPLIER;
 
 @Getter
 @Singleton
@@ -47,7 +55,7 @@ class UICalculatorInputArea extends JPanel
 	private final JTextField uiFieldCurrentXP;
 	private final JTextField uiFieldTargetLevel;
 	private final JTextField uiFieldTargetXP;
-	private final JTextField uiFieldXPMultiplier;
+	private final JSpinner uiFieldXPMultiplier;
 
 	@Inject
 	UICalculatorInputArea()
@@ -57,7 +65,7 @@ class UICalculatorInputArea extends JPanel
 		uiFieldCurrentXP = addComponent("Current Experience");
 		uiFieldTargetLevel = addComponent("Target Level");
 		uiFieldTargetXP = addComponent("Target Experience");
-		uiFieldXPMultiplier = addComponent("XP Multiplier");
+		uiFieldXPMultiplier = addSpinnerComponent("XP Multiplier");
 	}
 
 	int getCurrentLevelInput()
@@ -115,6 +123,18 @@ class UICalculatorInputArea extends JPanel
 		uiFieldTargetXP.setToolTipText((String) value);
 	}
 
+	private int getInput(JSpinner field)
+	{
+		try
+		{
+			return Integer.parseInt(field.getModel().getValue().toString().replaceAll("\\D", ""));
+		}
+		catch (NumberFormatException e)
+		{
+			return 0;
+		}
+	}
+
 	private int getInput(JTextField field)
 	{
 		try
@@ -130,6 +150,39 @@ class UICalculatorInputArea extends JPanel
 	private void setInput(JTextField field, Object value)
 	{
 		field.setText(String.valueOf(value));
+	}
+
+	private void setInput(JSpinner field, Object value)
+	{
+		((JSpinner.DefaultEditor) field.getEditor()).getTextField().setValue(value);
+	}
+
+	private JSpinner addSpinnerComponent(String label)
+	{
+		final JPanel container = new JPanel();
+		container.setLayout(new BorderLayout());
+
+		final JLabel uiLabel = new JLabel(label);
+
+		SpinnerModel model = new SpinnerNumberModel(1, 1, MAX_MULTIPLIER, 1);
+		final JSpinner uiInput = new JSpinner(model);
+
+		JSpinner.DefaultEditor editor = (JSpinner.DefaultEditor) uiInput.getEditor();
+		JFormattedTextField spinnerTextField = editor.getTextField();
+		spinnerTextField.setFormatterFactory(new UnitFormatterFactory("x"));
+		uiInput.setBackground(ColorScheme.DARKER_GRAY_COLOR);
+		uiInput.setBorder(new EmptyBorder(5, 7, 5, 7));
+
+		uiLabel.setFont(FontManager.getRunescapeSmallFont());
+		uiLabel.setBorder(new EmptyBorder(0, 0, 4, 0));
+		uiLabel.setForeground(Color.WHITE);
+
+		container.add(uiLabel, BorderLayout.NORTH);
+		container.add(uiInput, BorderLayout.CENTER);
+
+		add(container);
+
+		return uiInput;
 	}
 
 	private JTextField addComponent(String label)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/UICalculatorInputArea.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/UICalculatorInputArea.java
@@ -47,15 +47,17 @@ class UICalculatorInputArea extends JPanel
 	private final JTextField uiFieldCurrentXP;
 	private final JTextField uiFieldTargetLevel;
 	private final JTextField uiFieldTargetXP;
+	private final JTextField uiFieldXPMultiplier;
 
 	@Inject
 	UICalculatorInputArea()
 	{
-		setLayout(new GridLayout(2, 2, 7, 7));
+		setLayout(new GridLayout(3, 2, 7, 7));
 		uiFieldCurrentLevel = addComponent("Current Level");
 		uiFieldCurrentXP = addComponent("Current Experience");
 		uiFieldTargetLevel = addComponent("Target Level");
 		uiFieldTargetXP = addComponent("Target Experience");
+		uiFieldXPMultiplier = addComponent("XP Multiplier");
 	}
 
 	int getCurrentLevelInput()
@@ -96,6 +98,16 @@ class UICalculatorInputArea extends JPanel
 	void setTargetXPInput(Object value)
 	{
 		setInput(uiFieldTargetXP, value);
+	}
+
+	int getXPMultiplierInput()
+	{
+		return getInput(uiFieldXPMultiplier);
+	}
+
+	void setXPMultiplier(Object value)
+	{
+		setInput(uiFieldXPMultiplier, value);
 	}
 
 	void setNeededXP(Object value)


### PR DESCRIPTION
Adds a multiplier input to the skill calculator, bound to [1,100].

No Multiplier:
![image](https://github.com/user-attachments/assets/2a953cfb-bb02-4ca3-9b44-fd219113feaa)

With Multiplier:
![image](https://github.com/user-attachments/assets/06f19139-c5da-4aaa-8a04-4def7220da39)

With Multiplier + Bonuses:
![image](https://github.com/user-attachments/assets/971fa707-2b0a-48eb-a898-724aba4ab204)

"Experience Multiplier" gets cut off in the label, so couldn't be consistent there with the label name