### PR TITLE
bank tags: support vials in potion storage

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/VarPlayer.java
+++ b/runelite-api/src/main/java/net/runelite/api/VarPlayer.java
@@ -277,9 +277,4 @@ public final class VarPlayer
 	public static final int ESSENCE_POUCH_GIANT_DEGRADE = 490;
 
 	public static final int RAIDS_PERSONAL_POINTS = 4609;
-
-	/**
-	 * The amount of vials in the Potion Storage.
-	 */
-	public static final int POTION_STORAGE_VIALS_COUNT = 4286;
 }

--- a/runelite-api/src/main/java/net/runelite/api/VarPlayer.java
+++ b/runelite-api/src/main/java/net/runelite/api/VarPlayer.java
@@ -277,4 +277,9 @@ public final class VarPlayer
 	public static final int ESSENCE_POUCH_GIANT_DEGRADE = 490;
 
 	public static final int RAIDS_PERSONAL_POINTS = 4609;
+
+	/**
+	 * The amount of vials in the Potion Storage.
+	 */
+	public static final int POTION_STORAGE_VIALS_COUNT = 4286;
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/banktags/tabs/LayoutManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/banktags/tabs/LayoutManager.java
@@ -697,13 +697,13 @@ public class LayoutManager
 					return;
 				}
 
-				idx = potionStorage.find(w.getItemId());
+				idx = potionStorage.getIdx(w.getItemId());
 				if (idx > -1)
 				{
 					potionStorage.prepareWidgets();
 					menu.setIdentifier(mungeBankToPotionStore(menu.getIdentifier()));
 					menu.setParam1(InterfaceID.Bankmain.POTIONSTORE_ITEMS);
-					menu.setParam0(idx * PotionStorage.COMPONENTS_PER_POTION);
+					menu.setParam0(idx);
 				}
 			}
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/banktags/tabs/PotionStorage.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/banktags/tabs/PotionStorage.java
@@ -34,13 +34,13 @@ import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.EnumComposition;
 import net.runelite.api.EnumID;
-import net.runelite.api.ItemID;
 import net.runelite.api.ScriptID;
-import net.runelite.api.VarPlayer;
 import net.runelite.api.events.ClientTick;
 import net.runelite.api.events.VarbitChanged;
 import net.runelite.api.events.WidgetClosed;
 import net.runelite.api.gameval.InterfaceID;
+import net.runelite.api.gameval.ItemID;
+import net.runelite.api.gameval.VarPlayerID;
 import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetType;
 import net.runelite.client.eventbus.Subscribe;
@@ -166,11 +166,11 @@ class PotionStorage
 
 	int matches(Set<Integer> bank, int itemId)
 	{
-		if (itemId == ItemID.VIAL)
+		if (itemId == ItemID.VIAL_EMPTY)
 		{
 			if (hasVialsInPotionStorage())
 			{
-				return ItemID.VIAL;
+				return ItemID.VIAL_EMPTY;
 			}
 
 			return -1;
@@ -212,7 +212,7 @@ class PotionStorage
 
 	int count(int itemId)
 	{
-		if (itemId == ItemID.VIAL)
+		if (itemId == ItemID.VIAL_EMPTY)
 		{
 			return getVialsInPotionStorage();
 		}
@@ -239,7 +239,7 @@ class PotionStorage
 			return -1;
 		}
 
-		if (itemId == ItemID.VIAL)
+		if (itemId == ItemID.VIAL_EMPTY)
 		{
 			if (hasVialsInPotionStorage())
 			{
@@ -268,7 +268,7 @@ class PotionStorage
 
 	int getVialsInPotionStorage()
 	{
-		return client.getVarpValue(VarPlayer.POTION_STORAGE_VIALS_COUNT);
+		return client.getVarpValue(VarPlayerID.POTIONSTORE_VIALS);
 	}
 
 	void prepareWidgets()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/banktags/tabs/PotionStorage.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/banktags/tabs/PotionStorage.java
@@ -34,7 +34,9 @@ import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.EnumComposition;
 import net.runelite.api.EnumID;
+import net.runelite.api.ItemID;
 import net.runelite.api.ScriptID;
+import net.runelite.api.VarPlayer;
 import net.runelite.api.events.ClientTick;
 import net.runelite.api.events.VarbitChanged;
 import net.runelite.api.events.WidgetClosed;
@@ -164,6 +166,16 @@ class PotionStorage
 
 	int matches(Set<Integer> bank, int itemId)
 	{
+		if (itemId == ItemID.VIAL)
+		{
+			if (hasVialsInPotionStorage())
+			{
+				return ItemID.VIAL;
+			}
+
+			return -1;
+		}
+
 		if (potions == null)
 		{
 			return -1;
@@ -200,6 +212,11 @@ class PotionStorage
 
 	int count(int itemId)
 	{
+		if (itemId == ItemID.VIAL)
+		{
+			return getVialsInPotionStorage();
+		}
+
 		if (potions == null)
 		{
 			return 0;
@@ -215,10 +232,20 @@ class PotionStorage
 		return 0;
 	}
 
-	int find(int itemId)
+	int getIdx(int itemId)
 	{
 		if (potions == null)
 		{
+			return -1;
+		}
+
+		if (itemId == ItemID.VIAL)
+		{
+			if (hasVialsInPotionStorage())
+			{
+				return potions.length * COMPONENTS_PER_POTION + 4;
+			}
+
 			return -1;
 		}
 
@@ -228,10 +255,20 @@ class PotionStorage
 			++potionIdx;
 			if (potion != null && potion.itemId == itemId)
 			{
-				return potionIdx - 1;
+				return (potionIdx - 1) * COMPONENTS_PER_POTION;
 			}
 		}
 		return -1;
+	}
+
+	boolean hasVialsInPotionStorage()
+	{
+		return getVialsInPotionStorage() > 0;
+	}
+
+	int getVialsInPotionStorage()
+	{
+		return client.getVarpValue(VarPlayer.POTION_STORAGE_VIALS_COUNT);
 	}
 
 	void prepareWidgets()
@@ -249,6 +286,13 @@ class PotionStorage
 					potStoreContent.createChild(childIdx++, WidgetType.GRAPHIC);
 				}
 			}
+
+			// Add widgets so that we can also take out vials
+			potStoreContent.createChild(childIdx++, WidgetType.GRAPHIC);
+			potStoreContent.createChild(childIdx++, WidgetType.RECTANGLE);
+			potStoreContent.createChild(childIdx++, WidgetType.TEXT);
+			potStoreContent.createChild(childIdx++, WidgetType.RECTANGLE);
+			potStoreContent.createChild(childIdx++, WidgetType.TEXT);
 		}
 	}
 }


### PR DESCRIPTION
This PR is intended to make it so that empty vials can also be taken out from potion storage when in a bank tag. As empty vials seem to be unique in how they work in the potion storage, I've added unique methods for handling it.

I've made an assumption that the position for the vials widget in the potion storage children will always be the sum of all potions * 5 + 4, to try and make this more future-proofed. If there's a better way to determine where it'll be placed that'd be better, otherwise the main time this assumption will be challenged is when a new potion gets added to the game.

To allow for vials to be removed without having already opened the potion storage interface, I've added 5 new widgets to prepareWidgets. I've assumed I need to make the non-relevant widgets (line 292-295) be the correct WidgetType, but if they don't need to be then that can be simplified to a loop.