### PR TITLE
kc: remove color tag from boss name

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
@@ -107,7 +107,7 @@ import org.apache.commons.text.WordUtils;
 @Slf4j
 public class ChatCommandsPlugin extends Plugin
 {
-	private static final Pattern KILLCOUNT_PATTERN = Pattern.compile("Your (?<pre>completion count for |subdued |completed )?(?<boss>.+?) (?<post>(?:(?:kill|harvest|lap|completion) )?(?:count )?)is: <col=[0-9a-f]{6}>(?<kc>[0-9,]+)</col>");
+	private static final Pattern KILLCOUNT_PATTERN = Pattern.compile("Your (?<pre>completion count for |subdued |completed )?(?:<col=[0-9a-f]{6}>)?(?<boss>.+?)(?:</col>)? (?<post>(?:(?:kill|harvest|lap|completion) )?(?:count )?)is: ?<col=[0-9a-f]{6}>(?<kc>[0-9,]+)</col>");
 	private static final String TEAM_SIZES = "(?<teamsize>\\d+(?:\\+|-\\d+)? players?|Solo)";
 	private static final Pattern RAIDS_PB_PATTERN = Pattern.compile("<col=ef20ff>Congratulations - your raid is complete!</col><br>Team size: <col=ff0000>" + TEAM_SIZES + "</col> Duration:</col> <col=ff0000>(?<pb>[0-9:]+(?:\\.[0-9]+)?)</col> \\(new personal best\\)</col>");
 	private static final Pattern RAIDS_DURATION_PATTERN = Pattern.compile("<col=ef20ff>Congratulations - your raid is complete!</col><br>Team size: <col=ff0000>" + TEAM_SIZES + "</col> Duration:</col> <col=ff0000>[0-9:.]+</col> Personal best: </col><col=ff0000>(?<pb>[0-9:]+(?:\\.[0-9]+)?)</col>");

--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
@@ -955,7 +955,8 @@ public class ChatCommandsPlugin extends Plugin
 		return true;
 	}
 
-	private void killCountLookup(ChatMessage chatMessage, String message)
+	@VisibleForTesting
+	void killCountLookup(ChatMessage chatMessage, String message)
 	{
 		if (!config.killcount())
 		{
@@ -2121,7 +2122,14 @@ public class ChatCommandsPlugin extends Plugin
 
 	private static String longBossName(String boss)
 	{
-		switch (boss.toLowerCase())
+		String lowerBoss = boss.toLowerCase();
+		if (lowerBoss.endsWith(" (echo)"))
+		{
+			String actualBoss = lowerBoss.substring(0, lowerBoss.length() - " (echo)".length());
+			return longBossName(actualBoss) + " (Echo)";
+		}
+
+		switch (lowerBoss)
 		{
 			case "corp":
 				return "Corporeal Beast";

--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenshot/ScreenshotPlugin.java
@@ -96,7 +96,7 @@ public class ScreenshotPlugin extends Plugin
 	private static final Pattern NUMBER_PATTERN = Pattern.compile("([,0-9]+)");
 	private static final Pattern LEVEL_UP_PATTERN = Pattern.compile(".*Your ([a-zA-Z]+) (?:level is|are)? now (\\d+)\\.");
 	private static final Pattern LEVEL_UP_MESSAGE_PATTERN = Pattern.compile("Congratulations, you've (just advanced your (?<skill>[a-zA-Z]+) level\\. You are now level (?<level>\\d+)|reached the highest possible (?<skill99>[a-zA-Z]+) level of 99)\\.");
-	private static final Pattern BOSSKILL_MESSAGE_PATTERN = Pattern.compile("Your (.+) kill count is: <col=[0-9a-f]{6}>([0-9,]+)</col>");
+	private static final Pattern BOSSKILL_MESSAGE_PATTERN = Pattern.compile("Your (.+) kill count is: ?<col=[0-9a-f]{6}>([0-9,]+)</col>");
 	private static final Pattern VALUABLE_DROP_PATTERN = Pattern.compile(".*Valuable drop: ([^<>]+?\\(((?:\\d+,?)+) coins\\))(?:</col>)?");
 	private static final Pattern UNTRADEABLE_DROP_PATTERN = Pattern.compile(".*Untradeable drop: ([^<>]+)(?:</col>)?");
 	private static final Pattern DUEL_END_PATTERN = Pattern.compile("You have now (won|lost) ([0-9,]+) duels?\\.");
@@ -452,7 +452,7 @@ public class ScreenshotPlugin extends Plugin
 			Matcher m = BOSSKILL_MESSAGE_PATTERN.matcher(chatMessage);
 			if (m.find())
 			{
-				String bossName = m.group(1);
+				String bossName = Text.removeTags(m.group(1));
 				String bossKillcount = m.group(2).replace(",", "");
 				String fileName = bossName + "(" + bossKillcount + ")";
 				takeScreenshot(fileName, SD_BOSS_KILLS);

--- a/runelite-client/src/test/java/net/runelite/client/plugins/chatcommands/ChatCommandsPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/chatcommands/ChatCommandsPluginTest.java
@@ -676,6 +676,24 @@ public class ChatCommandsPluginTest
 	}
 
 	@Test
+	public void testKillCountLookup() throws IOException
+	{
+		when(chatCommandsConfig.killcount()).thenReturn(true);
+
+		when(chatClient.getKc(PLAYER_NAME, "Kalphite Queen (Echo)")).thenReturn(1);
+
+		MessageNode messageNode = mock(MessageNode.class);
+
+		ChatMessage chatMessage = new ChatMessage();
+		chatMessage.setType(ChatMessageType.PUBLICCHAT);
+		chatMessage.setName(PLAYER_NAME);
+		chatMessage.setMessageNode(messageNode);
+		chatCommandsPlugin.killCountLookup(chatMessage, "!kc kq (echo)");
+
+		verify(messageNode).setRuneLiteFormatMessage("<colHIGHLIGHT>Kalphite Queen (Echo)<colNORMAL> kill count: <colHIGHLIGHT>1");
+	}
+
+	@Test
 	public void testHsFloorNoPb()
 	{
 		ChatMessage chatMessage = new ChatMessage(null, GAMEMESSAGE, "", "Floor 1 time: <col=ff0000>1:19</col>. Personal best: 0:28", null, 0);

--- a/runelite-client/src/test/java/net/runelite/client/plugins/chatcommands/ChatCommandsPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/chatcommands/ChatCommandsPluginTest.java
@@ -318,6 +318,18 @@ public class ChatCommandsPluginTest
 	}
 
 	@Test
+	public void testHunllefEcho()
+	{
+		testKillCountChatMessage("corrupted hunllef (echo)", "Your <col=a53fff>Corrupted Hunllef (Echo)</col> kill count is: <col=ff3045>31</col>", 31);
+	}
+
+	@Test
+	public void testKalphiteEcho()
+	{
+		testKillCountChatMessage("kalphite queen (echo)", "Your <col=6800bf>Kalphite Queen (Echo)</col> kill count is:<col=e00a19>1</col>", 1);
+	}
+
+	@Test
 	public void testPersonalBest()
 	{
 		final String FIGHT_DURATION = "Fight duration: <col=ff0000>2:06</col>. Personal best: 1:19.";

--- a/runelite-client/src/test/java/net/runelite/client/plugins/screenshot/ScreenshotPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/screenshot/ScreenshotPluginTest.java
@@ -553,4 +553,25 @@ public class ScreenshotPluginTest
 
 		verify(screenshotPlugin).takeScreenshot("Nightmare(1130)", "Boss Kills");
 	}
+
+	@Test
+	public void testEchoBossKillCount()
+	{
+		when(screenshotConfig.screenshotBossKills()).thenReturn(true);
+
+		ChatMessage chatMessage = new ChatMessage(null, GAMEMESSAGE, "", "Your <col=6800bf>Kalphite Queen (Echo)</col> kill count is:<col=e00a19>1</col>", null, 1);
+		screenshotPlugin.onChatMessage(chatMessage);
+
+		verify(screenshotPlugin).takeScreenshot("Kalphite Queen (Echo)(1)", "Boss Kills");
+	}
+
+	@Test
+	public void testEchoGauntletKillCount()
+	{
+		when(screenshotConfig.screenshotBossKills()).thenReturn(true);
+		ChatMessage chatMessage = new ChatMessage(null, GAMEMESSAGE, "", "Your <col=a53fff>Corrupted Hunllef (Echo)</col> kill count is: <col=ff3045>31</col>", null, 0);
+		screenshotPlugin.onChatMessage(chatMessage);
+		verify(screenshotPlugin).takeScreenshot("Corrupted Hunllef (Echo)(31)", "Boss Kills");
+	}
+
 }


### PR DESCRIPTION
```
2024-11-29 05:06:24 CET [Client] DEBUG injected-client - Chat message type GAMEMESSAGE: Corrupted challenge duration: <col=ff0000>2:14.40</col>. Personal best: 1:57.00.
2024-11-29 05:06:24 CET [Client] DEBUG injected-client - Chat message type GAMEMESSAGE: Preparation time: <col=ff0000>0:03.60</col>. Hunllef kill time: <col=ff0000>2:10.80</col>.
2024-11-29 05:06:24 CET [Client] DEBUG injected-client - Chat message type GAMEMESSAGE: Your <col=a53fff>Corrupted Hunllef (Echo)</col> kill count is: <col=ff3045>31</col>
2024-11-29 05:06:24 CET [Client] DEBUG n.r.client.config.ConfigManager - Setting configuration value for killcount.rsprofile.uuGybRk_.<col=a53fff>corrupted hunllef (echo)</col> to 31
2024-11-29 05:06:24 CET [Client] DEBUG n.r.c.p.c.ChatCommandsPlugin - Got out-of-order personal best for <col=a53fff>Corrupted Hunllef (Echo)</col>: 117.0
2024-11-29 05:06:24 CET [Client] DEBUG n.r.c.p.c.ChatCommandsPlugin - Setting overall pb (old: 117.0)
2024-11-29 05:06:24 CET [Client] DEBUG injected-client - Chat message type GAMEMESSAGE: Duration: <col=ff3045>2:14.40</col>
2024-11-29 05:06:24 CET [pool-3-thread-1] ERROR n.runelite.client.util.ImageCapture - error writing screenshot
javax.imageio.IIOException: Can't create an ImageOutputStream!
	at java.desktop/javax.imageio.ImageIO.write(Unknown Source)
	at net.runelite.client.util.ImageCapture.saveScreenshot(ImageCapture.java:225)
	at net.runelite.client.plugins.screenshot.ScreenshotPlugin.saveScreenshot(ScreenshotPlugin.java:927)
	at net.runelite.client.plugins.screenshot.ScreenshotPlugin.lambda$takeScreenshot$3(ScreenshotPlugin.java:901)
	at net.runelite.client.util.RunnableExceptionLogger.run(RunnableExceptionLogger.java:41)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Unknown Source)
	at java.base/java.util.concurrent.FutureTask.run(Unknown Source)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
	at java.base/java.lang.Thread.run(Unknown Source)
```