### PR TITLE
Timers and buffs wealthy citizens pickpocketing

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/timersandbuffs/GameTimer.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timersandbuffs/GameTimer.java
@@ -100,6 +100,7 @@ enum GameTimer
 	SPELLBOOK_SWAP(SpriteID.SPELL_SPELLBOOK_SWAP, GameTimerImageType.SPRITE, "Spellbook Reset", 120, ChronoUnit.SECONDS, false),
 	GOADING(ItemID.GOADING_POTION4, GameTimerImageType.ITEM, "Goading potion", false),
 	PRAYER_REGENERATION(ItemID.PRAYER_REGENERATION_POTION4, GameTimerImageType.ITEM, "Prayer regeneration", false),
+	WEALTHY_TIMER(SpriteID.SKILL_THIEVING, GameTimerImageType.SPRITE, "Stunned", true),
 	;
 
 	@Nullable

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timersandbuffs/TimersAndBuffsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timersandbuffs/TimersAndBuffsConfig.java
@@ -75,7 +75,10 @@ public interface TimersAndBuffsConfig extends Config
 			section = thievingSection,
 			position = 1
 	)
-	default boolean showPickpocketStun() {return true;}
+	default boolean showPickpocketStun()
+	{
+		return true;
+	}
 
 	@ConfigItem(
 			keyName = "showWealthCitizensTimer",
@@ -84,7 +87,10 @@ public interface TimersAndBuffsConfig extends Config
 			section = thievingSection,
 			position = 2
 	)
-	default boolean showWealthyCitizensTimer() {return true;}
+	default boolean showWealthyCitizensTimer()
+	{
+		return true;
+	}
 
 	@ConfigItem(
 			keyName = "IgnoreWealthyAfter",
@@ -146,10 +152,7 @@ public interface TimersAndBuffsConfig extends Config
 		description = "Configures whether overload timer is displayed.",
 		section = consumablesSection
 	)
-	default boolean showOverload()
-	{
-		return true;
-	}
+	default boolean showOverload() { return true; }
 
 	@ConfigItem(
 		keyName = "showLiquidAdrenaline",
@@ -168,10 +171,7 @@ public interface TimersAndBuffsConfig extends Config
 		description = "Configures whether menaphite remedy timer is displayed.",
 		section = consumablesSection
 	)
-	default boolean showMenaphiteRemedy()
-	{
-		return true;
-	}
+	default boolean showMenaphiteRemedy() { return true; }
 
 	@ConfigItem(
 		keyName = "showSilkDressing",
@@ -190,10 +190,7 @@ public interface TimersAndBuffsConfig extends Config
 		description = "Configures whether blessed crystal scarab timer is displayed.",
 		section = consumablesSection
 	)
-	default boolean showBlessedCrystalScarab()
-	{
-		return true;
-	}
+	default boolean showBlessedCrystalScarab()  { return true; }
 
 	@ConfigItem(
 		keyName = "showPrayerEnhance",
@@ -201,10 +198,7 @@ public interface TimersAndBuffsConfig extends Config
 		description = "Configures whether prayer enhance timer is displayed.",
 		section = consumablesSection
 	)
-	default boolean showPrayerEnhance()
-	{
-		return true;
-	}
+	default boolean showPrayerEnhance()  { return true; }
 
 	@ConfigItem(
 		keyName = "showGoading",
@@ -212,10 +206,7 @@ public interface TimersAndBuffsConfig extends Config
 		description = "Configures whether goading potion timer is displayed.",
 		section = consumablesSection
 	)
-	default boolean showGoading()
-	{
-		return true;
-	}
+	default boolean showGoading()  { return true; }
 
 	@ConfigItem(
 		keyName = "showPrayerRegeneration",
@@ -223,10 +214,7 @@ public interface TimersAndBuffsConfig extends Config
 		description = "Configures whether prayer regeneration timer is displayed.",
 		section = consumablesSection
 	)
-	default boolean showPrayerRegneration()
-	{
-		return true;
-	}
+	default boolean showPrayerRegneration()  { return true; }
 
 	@ConfigItem(
 		keyName = "showDivine",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timersandbuffs/TimersAndBuffsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timersandbuffs/TimersAndBuffsConfig.java
@@ -24,10 +24,8 @@
  */
 package net.runelite.client.plugins.timersandbuffs;
 
-import net.runelite.client.config.Config;
-import net.runelite.client.config.ConfigGroup;
-import net.runelite.client.config.ConfigItem;
-import net.runelite.client.config.ConfigSection;
+import net.runelite.client.config.*;
+
 import java.time.Instant;
 
 @ConfigGroup(TimersAndBuffsConfig.GROUP)
@@ -57,11 +55,46 @@ public interface TimersAndBuffsConfig extends Config
 	String spellsSection = "spellsSection";
 
 	@ConfigSection(
+			name = "Thieving",
+			description = "Timers and buffs related to thieving.",
+			position = 3
+	)
+	String thievingSection = "thievingSection";
+
+	@ConfigSection(
 		name = "Miscellaneous",
 		description = "Timers and buffs related to miscellaneous items or activities.",
-		position = 3
+		position = 4
 	)
 	String miscellaneousSection = "miscellaneousSection";
+
+	@ConfigItem(
+			keyName = "showPickpocketStun",
+			name = "Pickpocket stun timer",
+			description = "Configures whether pickpocket stun timer is displayed.",
+			section = thievingSection,
+			position = 1
+	)
+	default boolean showPickpocketStun() {return true;}
+
+	@ConfigItem(
+			keyName = "showWealthCitizensTimer",
+			name = "Wealthy Citizens",
+			description = "Configures whether timers for wealthy citizens are displayed. During this time, wealthy citizens will not be distracted again.",
+			section = thievingSection,
+			position = 2
+	)
+	default boolean showWealthyCitizensTimer() {return true;}
+
+	@ConfigItem(
+			keyName = "IgnoreWealthyAfter",
+			name = "Disable Wealthy Citizens After",
+			description = "Time since the last pickpocket until the wealthy citizens timer is disabled",
+			section = thievingSection,
+			position = 3
+	)
+	@Units(Units.MINUTES)
+	default int ignoreWealthy() { return 20; }
 
 	@ConfigItem(
 		keyName = "showHomeMinigameTeleports",
@@ -410,17 +443,6 @@ public interface TimersAndBuffsConfig extends Config
 	default boolean showArceuusCooldown()
 	{
 		return false;
-	}
-
-	@ConfigItem(
-		keyName = "showPickpocketStun",
-		name = "Pickpocket stun timer",
-		description = "Configures whether pickpocket stun timer is displayed.",
-		section = miscellaneousSection
-	)
-	default boolean showPickpocketStun()
-	{
-		return true;
 	}
 
 	@ConfigItem(

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timersandbuffs/TimersAndBuffsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timersandbuffs/TimersAndBuffsPlugin.java
@@ -1063,21 +1063,25 @@ public class TimersAndBuffsPlugin extends Plugin
 	}
 
 	@Subscribe
-	public void onOverheadTextChanged(OverheadTextChanged event){
+	public void onOverheadTextChanged(OverheadTextChanged event)
+	{
 		final String actorName = event.getActor().getName();
 		final String message = event.getOverheadText();
 		boolean isSaidByLeo = Objects.equals(actorName, "Leo");
 		boolean isWealthyTriggerMessage = Arrays.asList(WealthyCitizensTriggers).contains(message);
-		if (isSaidByLeo && isWealthyTriggerMessage && config.showWealthyCitizensTimer()){
+		if (isSaidByLeo && isWealthyTriggerMessage && config.showWealthyCitizensTimer())
+		{
 			triggerWealthyTimer();
 		}
 	}
 
-	public void triggerWealthyTimer(){
+	public void triggerWealthyTimer()
+	 {
 		int timeNow = (int) (System.currentTimeMillis() / 1000);
 		boolean notAlreadyTriggered = ((timeNow - lastWealthyCitizensTriggerTime) >= wealthyTriggerLength);
 		boolean isNotDisabledByTimeout = config.ignoreWealthy() * 60 > (timeNow - lastPickpocketTime);
-		if (isNotDisabledByTimeout && notAlreadyTriggered) {
+		if (isNotDisabledByTimeout && notAlreadyTriggered)
+		{
 			createGameTimer(WEALTHY_TIMER, Duration.ofSeconds(wealthyTriggerLength));
 			lastWealthyCitizensTriggerTime = timeNow;
 		}


### PR DESCRIPTION
Updated the code for TimersAndBuffs to include wealthy citizens pickpocketing. The timer is triggered when a wealthy citizen begins to get distracted, and ends when it is possible for them to get distracted again. This allows the user to have a small section (top left) of the game window visible whilst doing other things on their PC, and still know when a wealthy citizen is about to or is being currently distracted.

This is my first time developing for Runelite, and the first time in 10 years to be using Java. Any feedback is welcomed.
