### PR TITLE
entityhider: draw2d controls for subgroups

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/entityhider/EntityHiderConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/entityhider/EntityHiderConfig.java
@@ -69,6 +69,17 @@ public interface EntityHiderConfig extends Config
 
 	@ConfigItem(
 		position = 4,
+		keyName = "hidePartyMembers2D",
+		name = "Hide party members 2D",
+		description = "Configures whether or not party members' 2D elements are hidden."
+	)
+	default boolean hidePartyMembers2D()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		position = 5,
 		keyName = "hideFriends",
 		name = "Hide friends",
 		description = "Configures whether or not friends are hidden."
@@ -79,7 +90,18 @@ public interface EntityHiderConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 5,
+		position = 6,
+		keyName = "hideFriends2D",
+		name = "Hide friends 2D",
+		description = "Configures whether or not friends' 2D elements are hidden."
+	)
+	default boolean hideFriends2D()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		position = 7,
 		keyName = "hideClanMates", // is actually friends chat
 		name = "Hide friends chat members",
 		description = "Configures whether or not friends chat members are hidden."
@@ -90,7 +112,18 @@ public interface EntityHiderConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 6,
+		position = 8,
+		keyName = "hideClanMates2D", // is actually friends chat
+		name = "Hide friends chat members 2D",
+		description = "Configures whether or not friends chat members' 2D elements are hidden."
+	)
+	default boolean hideFriendsChatMembers2D()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		position = 9,
 		keyName = "hideClanChatMembers",
 		name = "Hide clan chat members",
 		description = "Configures whether or not clan chat members are hidden."
@@ -101,7 +134,18 @@ public interface EntityHiderConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 7,
+		position = 10,
+		keyName = "hideClanChatMembers2D",
+		name = "Hide clan chat members 2D",
+		description = "Configures whether or not clan chat members' 2D elements are hidden."
+	)
+	default boolean hideClanChatMembers2D()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		position = 11,
 		keyName = "hideIgnores",
 		name = "Hide ignores",
 		description = "Configures whether or not ignored players are hidden."
@@ -112,7 +156,18 @@ public interface EntityHiderConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 8,
+		position = 12,
+		keyName = "hideIgnores2D",
+		name = "Hide ignores 2D",
+		description = "Configures whether or not ignored players' 2D elements are hidden."
+	)
+	default boolean hideIgnores2D()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		position = 13,
 		keyName = "hideLocalPlayer",
 		name = "Hide local player",
 		description = "Configures whether or not the local player is hidden."
@@ -123,7 +178,7 @@ public interface EntityHiderConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 9,
+		position = 14,
 		keyName = "hideLocalPlayer2D",
 		name = "Hide local player 2D",
 		description = "Configures whether or not the local player's 2D elements are hidden."
@@ -134,7 +189,7 @@ public interface EntityHiderConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 10,
+		position = 15,
 		keyName = "hideNPCs",
 		name = "Hide NPCs",
 		description = "Configures whether or not NPCs are hidden."
@@ -145,7 +200,7 @@ public interface EntityHiderConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 11,
+		position = 16,
 		keyName = "hideNPCs2D",
 		name = "Hide NPCs 2D",
 		description = "Configures whether or not NPCs 2D elements are hidden."
@@ -156,7 +211,7 @@ public interface EntityHiderConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 12,
+		position = 17,
 		keyName = "hidePets",
 		name = "Hide other players' pets",
 		description = "Configures whether or not other player pets are hidden."
@@ -167,7 +222,7 @@ public interface EntityHiderConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 13,
+		position = 18,
 		keyName = "hideAttackers",
 		name = "Hide attackers",
 		description = "Configures whether or not NPCs/players attacking you are hidden."
@@ -178,7 +233,18 @@ public interface EntityHiderConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 14,
+		position = 19,
+		keyName = "hideAttackers2D",
+		name = "Hide attackers 2D",
+		description = "Configures whether or not 2D elements of NPCs/players attacking you are hidden."
+	)
+	default boolean hideAttackers2D()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		position = 20,
 		keyName = "hideProjectiles",
 		name = "Hide projectiles",
 		description = "Configures whether or not projectiles are hidden."
@@ -189,7 +255,7 @@ public interface EntityHiderConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 15,
+		position = 21,
 		keyName = "hideDeadNpcs",
 		name = "Hide dead NPCs",
 		description = "Hides NPCs when their health reaches 0."
@@ -200,7 +266,7 @@ public interface EntityHiderConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 16,
+		position = 22,
 		keyName = "hideThralls",
 		name = "Hide thralls",
 		description = "Configures whether or not thralls are hidden."
@@ -211,7 +277,7 @@ public interface EntityHiderConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 17,
+		position = 23,
 		keyName = "hideRandomEvents",
 		name = "Hide random events",
 		description = "Configures whether or not random events are hidden."

--- a/runelite-client/src/main/java/net/runelite/client/plugins/entityhider/EntityHiderConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/entityhider/EntityHiderConfig.java
@@ -28,17 +28,33 @@ package net.runelite.client.plugins.entityhider;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.ConfigSection;
 
 @ConfigGroup(EntityHiderConfig.GROUP)
 public interface EntityHiderConfig extends Config
 {
 	String GROUP = "entityhider";
 
+	@ConfigSection(
+		name = "3D",
+		position = 1,
+		description = "Options to hide rendering of 3D scene elements (player models, NPC models)."
+	)
+	String draw3D = "draw3D";
+
+	@ConfigSection(
+		name = "2D",
+		position = 2,
+		description = "Options to hide rendering of 2D elements (overhead text, prayers, etc.)."
+	)
+	String draw2D = "draw2D";
+
 	@ConfigItem(
 		position = 1,
 		keyName = "hidePlayers",
 		name = "Hide others",
-		description = "Configures whether or not other players are hidden."
+		description = "Configures whether or not other players are hidden.",
+		section = draw3D
 	)
 	default boolean hideOthers()
 	{
@@ -49,7 +65,8 @@ public interface EntityHiderConfig extends Config
 		position = 2,
 		keyName = "hidePlayers2D",
 		name = "Hide others 2D",
-		description = "Configures whether or not other players 2D elements are hidden."
+		description = "Configures whether or not other players 2D elements are hidden.",
+		section = draw2D
 	)
 	default boolean hideOthers2D()
 	{
@@ -60,7 +77,8 @@ public interface EntityHiderConfig extends Config
 		position = 3,
 		keyName = "hidePartyMembers",
 		name = "Hide party members",
-		description = "Configures whether or not party members are hidden."
+		description = "Configures whether or not party members are hidden.",
+		section = draw3D
 	)
 	default boolean hidePartyMembers()
 	{
@@ -71,7 +89,8 @@ public interface EntityHiderConfig extends Config
 		position = 4,
 		keyName = "hidePartyMembers2D",
 		name = "Hide party members 2D",
-		description = "Configures whether or not party members' 2D elements are hidden."
+		description = "Configures whether or not party members' 2D elements are hidden.",
+		section = draw2D
 	)
 	default boolean hidePartyMembers2D()
 	{
@@ -82,7 +101,8 @@ public interface EntityHiderConfig extends Config
 		position = 5,
 		keyName = "hideFriends",
 		name = "Hide friends",
-		description = "Configures whether or not friends are hidden."
+		description = "Configures whether or not friends are hidden.",
+		section = draw3D
 	)
 	default boolean hideFriends()
 	{
@@ -93,7 +113,8 @@ public interface EntityHiderConfig extends Config
 		position = 6,
 		keyName = "hideFriends2D",
 		name = "Hide friends 2D",
-		description = "Configures whether or not friends' 2D elements are hidden."
+		description = "Configures whether or not friends' 2D elements are hidden.",
+		section = draw2D
 	)
 	default boolean hideFriends2D()
 	{
@@ -104,7 +125,8 @@ public interface EntityHiderConfig extends Config
 		position = 7,
 		keyName = "hideClanMates", // is actually friends chat
 		name = "Hide friends chat members",
-		description = "Configures whether or not friends chat members are hidden."
+		description = "Configures whether or not friends chat members are hidden.",
+		section = draw3D
 	)
 	default boolean hideFriendsChatMembers()
 	{
@@ -115,7 +137,8 @@ public interface EntityHiderConfig extends Config
 		position = 8,
 		keyName = "hideClanMates2D", // is actually friends chat
 		name = "Hide friends chat members 2D",
-		description = "Configures whether or not friends chat members' 2D elements are hidden."
+		description = "Configures whether or not friends chat members' 2D elements are hidden.",
+		section = draw2D
 	)
 	default boolean hideFriendsChatMembers2D()
 	{
@@ -126,7 +149,8 @@ public interface EntityHiderConfig extends Config
 		position = 9,
 		keyName = "hideClanChatMembers",
 		name = "Hide clan chat members",
-		description = "Configures whether or not clan chat members are hidden."
+		description = "Configures whether or not clan chat members are hidden.",
+		section = draw3D
 	)
 	default boolean hideClanChatMembers()
 	{
@@ -137,7 +161,8 @@ public interface EntityHiderConfig extends Config
 		position = 10,
 		keyName = "hideClanChatMembers2D",
 		name = "Hide clan chat members 2D",
-		description = "Configures whether or not clan chat members' 2D elements are hidden."
+		description = "Configures whether or not clan chat members' 2D elements are hidden.",
+		section = draw2D
 	)
 	default boolean hideClanChatMembers2D()
 	{
@@ -148,7 +173,8 @@ public interface EntityHiderConfig extends Config
 		position = 11,
 		keyName = "hideIgnores",
 		name = "Hide ignores",
-		description = "Configures whether or not ignored players are hidden."
+		description = "Configures whether or not ignored players are hidden.",
+		section = draw3D
 	)
 	default boolean hideIgnores()
 	{
@@ -159,7 +185,8 @@ public interface EntityHiderConfig extends Config
 		position = 12,
 		keyName = "hideIgnores2D",
 		name = "Hide ignores 2D",
-		description = "Configures whether or not ignored players' 2D elements are hidden."
+		description = "Configures whether or not ignored players' 2D elements are hidden.",
+		section = draw2D
 	)
 	default boolean hideIgnores2D()
 	{
@@ -170,7 +197,8 @@ public interface EntityHiderConfig extends Config
 		position = 13,
 		keyName = "hideLocalPlayer",
 		name = "Hide local player",
-		description = "Configures whether or not the local player is hidden."
+		description = "Configures whether or not the local player is hidden.",
+		section = draw3D
 	)
 	default boolean hideLocalPlayer()
 	{
@@ -181,7 +209,8 @@ public interface EntityHiderConfig extends Config
 		position = 14,
 		keyName = "hideLocalPlayer2D",
 		name = "Hide local player 2D",
-		description = "Configures whether or not the local player's 2D elements are hidden."
+		description = "Configures whether or not the local player's 2D elements are hidden.",
+		section = draw2D
 	)
 	default boolean hideLocalPlayer2D()
 	{
@@ -192,7 +221,8 @@ public interface EntityHiderConfig extends Config
 		position = 15,
 		keyName = "hideNPCs",
 		name = "Hide NPCs",
-		description = "Configures whether or not NPCs are hidden."
+		description = "Configures whether or not NPCs are hidden.",
+		section = draw3D
 	)
 	default boolean hideNPCs()
 	{
@@ -203,7 +233,8 @@ public interface EntityHiderConfig extends Config
 		position = 16,
 		keyName = "hideNPCs2D",
 		name = "Hide NPCs 2D",
-		description = "Configures whether or not NPCs 2D elements are hidden."
+		description = "Configures whether or not NPCs 2D elements are hidden.",
+		section = draw2D
 	)
 	default boolean hideNPCs2D()
 	{
@@ -214,7 +245,8 @@ public interface EntityHiderConfig extends Config
 		position = 17,
 		keyName = "hidePets",
 		name = "Hide other players' pets",
-		description = "Configures whether or not other player pets are hidden."
+		description = "Configures whether or not other player pets are hidden.",
+		section = draw3D
 	)
 	default boolean hidePets()
 	{
@@ -225,7 +257,8 @@ public interface EntityHiderConfig extends Config
 		position = 18,
 		keyName = "hideAttackers",
 		name = "Hide attackers",
-		description = "Configures whether or not NPCs/players attacking you are hidden."
+		description = "Configures whether or not NPCs/players attacking you are hidden.",
+		section = draw3D
 	)
 	default boolean hideAttackers()
 	{
@@ -236,7 +269,8 @@ public interface EntityHiderConfig extends Config
 		position = 19,
 		keyName = "hideAttackers2D",
 		name = "Hide attackers 2D",
-		description = "Configures whether or not 2D elements of NPCs/players attacking you are hidden."
+		description = "Configures whether or not 2D elements of NPCs/players attacking you are hidden.",
+		section = draw2D
 	)
 	default boolean hideAttackers2D()
 	{
@@ -247,7 +281,8 @@ public interface EntityHiderConfig extends Config
 		position = 20,
 		keyName = "hideProjectiles",
 		name = "Hide projectiles",
-		description = "Configures whether or not projectiles are hidden."
+		description = "Configures whether or not projectiles are hidden.",
+		section = draw3D
 	)
 	default boolean hideProjectiles()
 	{
@@ -258,7 +293,8 @@ public interface EntityHiderConfig extends Config
 		position = 21,
 		keyName = "hideDeadNpcs",
 		name = "Hide dead NPCs",
-		description = "Hides NPCs when their health reaches 0."
+		description = "Hides NPCs when their health reaches 0.",
+		section = draw3D
 	)
 	default boolean hideDeadNpcs()
 	{
@@ -269,7 +305,8 @@ public interface EntityHiderConfig extends Config
 		position = 22,
 		keyName = "hideThralls",
 		name = "Hide thralls",
-		description = "Configures whether or not thralls are hidden."
+		description = "Configures whether or not thralls are hidden.",
+		section = draw3D
 	)
 	default boolean hideThralls()
 	{
@@ -280,7 +317,8 @@ public interface EntityHiderConfig extends Config
 		position = 23,
 		keyName = "hideRandomEvents",
 		name = "Hide random events",
-		description = "Configures whether or not random events are hidden."
+		description = "Configures whether or not random events are hidden.",
+		section = draw3D
 	)
 	default boolean hideRandomEvents()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/entityhider/EntityHiderPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/entityhider/EntityHiderPlugin.java
@@ -105,10 +105,15 @@ public class EntityHiderPlugin extends Plugin
 	private boolean hideOthers;
 	private boolean hideOthers2D;
 	private boolean hidePartyMembers;
+	private boolean hidePartyMembers2D;
 	private boolean hideFriends;
+	private boolean hideFriends2D;
 	private boolean hideFriendsChatMembers;
+	private boolean hideFriendsChatMembers2D;
 	private boolean hideClanMembers;
+	private boolean hideClanMembers2D;
 	private boolean hideIgnoredPlayers;
+	private boolean hideIgnoredPlayers2D;
 	private boolean hideLocalPlayer;
 	private boolean hideLocalPlayer2D;
 	private boolean hideNPCs;
@@ -118,6 +123,7 @@ public class EntityHiderPlugin extends Plugin
 	private boolean hideThralls;
 	private boolean hideRandomEvents;
 	private boolean hideAttackers;
+	private boolean hideAttackers2D;
 	private boolean hideProjectiles;
 
 	private final Hooks.RenderableDrawListener drawListener = this::shouldDraw;
@@ -157,10 +163,19 @@ public class EntityHiderPlugin extends Plugin
 		hideOthers2D = config.hideOthers2D();
 
 		hidePartyMembers = config.hidePartyMembers();
+		hidePartyMembers2D = config.hidePartyMembers2D();
+
 		hideFriends = config.hideFriends();
+		hideFriends2D = config.hideFriends2D();
+
 		hideFriendsChatMembers = config.hideFriendsChatMembers();
+		hideFriendsChatMembers2D = config.hideFriendsChatMembers2D();
+
 		hideClanMembers = config.hideClanChatMembers();
+		hideClanMembers2D = config.hideClanChatMembers2D();
+
 		hideIgnoredPlayers = config.hideIgnores();
+		hideIgnoredPlayers2D = config.hideIgnores2D();
 
 		hideLocalPlayer = config.hideLocalPlayer();
 		hideLocalPlayer2D = config.hideLocalPlayer2D();
@@ -175,6 +190,7 @@ public class EntityHiderPlugin extends Plugin
 		hideRandomEvents = config.hideRandomEvents();
 
 		hideAttackers = config.hideAttackers();
+		hideAttackers2D = config.hideAttackers2D();
 
 		hideProjectiles = config.hideProjectiles();
 	}
@@ -200,30 +216,37 @@ public class EntityHiderPlugin extends Plugin
 				return !(drawingUI ? hideLocalPlayer2D : hideLocalPlayer);
 			}
 
-			if (hideAttackers && player.getInteracting() == local)
+			if (player.getInteracting() == local)
 			{
-				return false; // hide
+				if (!drawingUI && hideAttackers)
+				{
+					return false;
+				}
+				if (drawingUI && hideAttackers2D)
+				{
+					return false;
+				}
 			}
 
 			if (partyService.isInParty() && partyService.getMemberByDisplayName(player.getName()) != null)
 			{
-				return !hidePartyMembers;
+				return !(drawingUI ? hidePartyMembers2D : hidePartyMembers);
 			}
 			if (player.isFriend())
 			{
-				return !hideFriends;
+				return !(drawingUI ? hideFriends2D : hideFriends);
 			}
 			if (player.isFriendsChatMember())
 			{
-				return !hideFriendsChatMembers;
+				return !(drawingUI ? hideFriendsChatMembers2D : hideFriendsChatMembers);
 			}
 			if (player.isClanMember())
 			{
-				return !hideClanMembers;
+				return !(drawingUI ? hideClanMembers2D : hideClanMembers);
 			}
 			if (client.getIgnoreContainer().findByName(player.getName()) != null)
 			{
-				return !hideIgnoredPlayers;
+				return !(drawingUI ? hideIgnoredPlayers2D : hideIgnoredPlayers);
 			}
 
 			return !(drawingUI ? hideOthers2D : hideOthers);
@@ -245,14 +268,14 @@ public class EntityHiderPlugin extends Plugin
 
 			if (npc.getInteracting() == client.getLocalPlayer())
 			{
-				boolean b = hideAttackers;
-				// Kludge to make hide attackers only affect 2d or 3d if the 2d or 3d hide is on
-				// This allows hiding 2d for all npcs, including attackers.
-				if (hideNPCs2D || hideNPCs)
+				if (!drawingUI && hideAttackers)
 				{
-					b &= drawingUI ? hideNPCs2D : hideNPCs;
+					return false;
 				}
-				return !b;
+				if (drawingUI && hideAttackers2D)
+				{
+					return false;
+				}
 			}
 
 			if (THRALL_IDS.contains(npc.getId()))

--- a/runelite-client/src/test/java/net/runelite/client/plugins/entityhider/EntityHiderPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/entityhider/EntityHiderPluginTest.java
@@ -172,16 +172,35 @@ public class EntityHiderPluginTest
 		assertTrue(plugin.shouldDraw(player, false));
 	}
 
-	//	hidenpc hideattacker hidden?
-	//	t       t            t iif attacker would be hidden
-	//	t       f            f
-	//	f       t            t
-	//	f       f            f
 	@Test
-	public void testHideAndAttacker()
+	public void testHideNpcAttacker()
 	{
-		when(config.hideNPCs2D()).thenReturn(true);
 		when(config.hideAttackers()).thenReturn(true);
+		when(config.hideAttackers2D()).thenReturn(true);
+
+		ConfigChanged configChanged = new ConfigChanged();
+		configChanged.setGroup(EntityHiderConfig.GROUP);
+		plugin.onConfigChanged(configChanged);
+
+		NPCComposition composition = mock(NPCComposition.class);
+
+		NPC npc = mock(NPC.class);
+		when(npc.getComposition()).thenReturn(composition);
+
+		Player player = mock(Player.class);
+		when(client.getLocalPlayer()).thenReturn(player);
+
+		when(npc.getInteracting()).thenReturn(player);
+
+		assertFalse(plugin.shouldDraw(npc, true));
+		assertFalse(plugin.shouldDraw(npc, false));
+	}
+
+	@Test
+	public void testHideNpcWithoutHideAttackers()
+	{
+		when(config.hideAttackers2D()).thenReturn(false);
+		when(config.hideNPCs2D()).thenReturn(true);
 
 		ConfigChanged configChanged = new ConfigChanged();
 		configChanged.setGroup(EntityHiderConfig.GROUP);
@@ -202,32 +221,10 @@ public class EntityHiderPluginTest
 	}
 
 	@Test
-	public void testHideAndNoAttacker()
-	{
-		when(config.hideNPCs2D()).thenReturn(true);
-
-		ConfigChanged configChanged = new ConfigChanged();
-		configChanged.setGroup(EntityHiderConfig.GROUP);
-		plugin.onConfigChanged(configChanged);
-
-		NPCComposition composition = mock(NPCComposition.class);
-
-		NPC npc = mock(NPC.class);
-		when(npc.getComposition()).thenReturn(composition);
-
-		Player player = mock(Player.class);
-		when(client.getLocalPlayer()).thenReturn(player);
-
-		when(npc.getInteracting()).thenReturn(player);
-
-		assertTrue(plugin.shouldDraw(npc, true));
-		assertTrue(plugin.shouldDraw(npc, false));
-	}
-
-	@Test
-	public void testHideAttacker()
+	public void testHidePlayerAttacker()
 	{
 		when(config.hideAttackers()).thenReturn(true);
+		when(config.hideAttackers2D()).thenReturn(true);
 
 		ConfigChanged configChanged = new ConfigChanged();
 		configChanged.setGroup(EntityHiderConfig.GROUP);
@@ -263,7 +260,7 @@ public class EntityHiderPluginTest
 		when(partyService.isInParty()).thenReturn(true);
 		when(partyService.getMemberByDisplayName(eq("test player"))).thenReturn(partyMember);
 
-		assertFalse(plugin.shouldDraw(player, true));
+		assertTrue(plugin.shouldDraw(player, true));
 		assertFalse(plugin.shouldDraw(player, false));
 	}
 


### PR DESCRIPTION
Adds a number of switches to control the rendering of 2D extras for existing configuration options such as friends, friends chat members, and party members.

Optionally, 40a115d also splits these options into two separate sections for a bit of organization.

Closes #18300 