### PR TITLE
fix npcidicators interaction with 'monstermenuhp' bug

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsPlugin.java
@@ -360,11 +360,15 @@ public class NpcIndicatorsPlugin extends Plugin
 		//<col=ffff00>Tool Leprechaun
 		//<col=ffff00>Ram<col=ff00>  (level-2)
 		String name, level;
-		if (target.contains("  (level-"))
+		int levelStartIndex = target.indexOf("(");
+		if (levelStartIndex > -1)
 		{
-			int c = target.lastIndexOf('<');
-			name = target.substring(0, c);
-			level = target.substring(c);
+			// in case other plugins (like monster menu hp) add tags in middle of level or name, or more than 2 tags total
+			int monsterEndIndex = target.substring(0, levelStartIndex).lastIndexOf('<');
+			monsterEndIndex = monsterEndIndex > -1 ? monsterEndIndex : levelStartIndex;
+
+			name = target.substring(0, monsterEndIndex);
+			level = target.substring(monsterEndIndex);
 		}
 		else
 		{

--- a/runelite-client/src/test/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsPluginTest.java
@@ -169,14 +169,14 @@ public class NpcIndicatorsPluginTest
 		npcIndicatorsPlugin.onNpcSpawned(new NpcSpawned(npc));
 
 		TestMenuEntry entry = new TestMenuEntry();
-		entry.setTarget("<col=ffff00>Ram<col=ff00>  (level-2)");
+		entry.setTarget("<col=ffff00>Ram<col=ff00>  (lev<col=00ff00>el-2)");
 		entry.setIdentifier(MenuAction.NPC_FIRST_OPTION.getId());
 		entry.setActor(npc);
 
 		MenuEntryAdded menuEntryAdded = new MenuEntryAdded(entry);
 		npcIndicatorsPlugin.onMenuEntryAdded(menuEntryAdded);
 
-		assertEquals("<col=0000ff>Ram<col=ff00>  (level-2)", entry.getTarget()); // blue name
+		assertEquals("<col=0000ff>Ram<col=ff00>  (lev<col=00ff00>el-2)", entry.getTarget()); // blue name
 	}
 
 	@Test


### PR DESCRIPTION
The current code makes assumptions about the structure of the 'target'. this means it is brittle and might not worth with other plugins, like some monstermenuhp settings. 

For example, if it is set to 'level' and npcindicators is set to 'name' the user reasonably expects that these two plugins could both work on different parts of the menu. But it doesn't, this code will make it so there is inconsistent behavior based upon the current hp % of the npc.

here is an example monstermenuhp target:
<col=ffff00>Ram<col=ff00>  (lev<col=00ff00>el-2)



note:
1) when monstermenuhp is set to name, and npcindicator is level, current code should work as expected.
2) if monstermenuhp is set to both then the hp colors will inconsistently partially work, this isn't unreasonable to the user since intended behavior based upon user settings is unclear.
3) if npcindicators is set to both, then it will reasonably override monstermenuhp. 