### PR TITLE
Player-owned House plugin: Added incense burner config section, timer color configurations, and burner notifications

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/poh/BurnerOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/poh/BurnerOverlay.java
@@ -24,7 +24,6 @@
  */
 package net.runelite.client.plugins.poh;
 
-import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Graphics2D;
 import java.time.Duration;
@@ -99,15 +98,15 @@ class BurnerOverlay extends Overlay
 			if (certainSec > 0)
 			{
 				pieComponent.setProgress(certainSec / burner.getCountdownTimer());
-				pieComponent.setFill(Color.GREEN);
-				pieComponent.setBorderColor(Color.GREEN);
+				pieComponent.setFill(config.burnerCertainTimerColor());
+				pieComponent.setBorderColor(config.burnerCertainTimerColor());
 				pieComponent.render(graphics);
 			}
 			else if (randomSec > 0)
 			{
 				pieComponent.setProgress(randomSec / burner.getRandomTimer());
-				pieComponent.setFill(Color.ORANGE);
-				pieComponent.setBorderColor(Color.ORANGE);
+				pieComponent.setFill(config.burnerRandomTimerColor());
+				pieComponent.setBorderColor(config.burnerRandomTimerColor());
 				pieComponent.render(graphics);
 			}
 		});

--- a/runelite-client/src/main/java/net/runelite/client/plugins/poh/IncenseBurner.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/poh/IncenseBurner.java
@@ -34,6 +34,7 @@ class IncenseBurner
 {
 	private Instant start;
 	private boolean lit;
+	private int litTick;
 	private double countdownTimer;
 	private double randomTimer;
 	private Instant end;
@@ -42,5 +43,6 @@ class IncenseBurner
 	{
 		countdownTimer = 0;
 		randomTimer = 0;
+		litTick = 0;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/poh/PohConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/poh/PohConfig.java
@@ -24,13 +24,26 @@
  */
 package net.runelite.client.plugins.poh;
 
+import java.awt.Color;
+import net.runelite.client.config.Alpha;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.ConfigSection;
+import net.runelite.client.config.Notification;
+import net.runelite.client.config.Range;
+import net.runelite.client.config.Units;
 
 @ConfigGroup("poh")
 public interface PohConfig extends Config
 {
+	@ConfigSection(
+		name = "Incense burners",
+		description = "All settings for incense burner overlays and notifications.",
+		position = 1
+	)
+	String burnerSection = "burners";
+
 	@ConfigItem(
 		keyName = "showPortals",
 		name = "Show portals",
@@ -87,16 +100,6 @@ public interface PohConfig extends Config
 		description = "Configures whether or not the exit portal is displayed."
 	)
 	default boolean showExitPortal()
-	{
-		return true;
-	}
-
-	@ConfigItem(
-		keyName = "showBurner",
-		name = "Show incense burner timers",
-		description = "Configures whether or not unlit/lit burners are displayed."
-	)
-	default boolean showBurner()
 	{
 		return true;
 	}
@@ -169,5 +172,83 @@ public interface PohConfig extends Config
 	default boolean showMythicalCape()
 	{
 		return true;
+	}
+
+	@ConfigItem(
+		keyName = "showBurner",
+		name = "Show incense burner timers",
+		description = "Configures whether or not unlit/lit burner timers are displayed.",
+		section = burnerSection,
+		position = 0
+	)
+	default boolean showBurner()
+	{
+		return true;
+	}
+
+	@Alpha
+	@ConfigItem(
+		keyName = "burnerCertainTimerColor",
+		name = "Certain timer color",
+		description = "Configures the color for the certain burner timer.",
+		section = burnerSection,
+		position = 1
+	)
+	default Color burnerCertainTimerColor()
+	{
+		return Color.GREEN;
+	}
+
+	@Alpha
+	@ConfigItem(
+		keyName = "burnerRandomTimerColor",
+		name = "Random timer color",
+		description = "Configures the color for the random burner timer.",
+		section = burnerSection,
+		position = 2
+	)
+	default Color burnerRandomTimerColor()
+	{
+		return Color.ORANGE;
+	}
+
+	@ConfigItem(
+		keyName = "burnerNotifyOnUnlit",
+		name = "Notify on unlit burner",
+		description = "Configures whether or not to notify you when lit burners become unlit.",
+		section = burnerSection,
+		position = 3
+	)
+	default Notification burnerNotifyOnUnlit()
+	{
+		return Notification.OFF;
+	}
+
+	@ConfigItem(
+		keyName = "burnerNotifyOnExpiring",
+		name = "Notify on expiring burner",
+		description = "Configures whether or not to notify you when lit burners enter their random expiring phase.",
+		section = burnerSection,
+		position = 4
+	)
+	default Notification burnerNotifyOnExpiring()
+	{
+		return Notification.OFF;
+	}
+
+	@ConfigItem(
+		keyName = "burnerNotificationLeadTime",
+		name = "Notification lead time",
+		description = "Configures how soon (in ticks) to preemptively send the expiring burner notification.",
+		section = burnerSection,
+		position = 5
+	)
+	@Range(
+		max = 200 // 201 is the minimum certain timer duration at 1 Firemaking. Capped to avoid negative lead times.
+	)
+	@Units(Units.TICKS)
+	default int burnerNotificationLeadTime()
+	{
+		return 0;
 	}
 }


### PR DESCRIPTION
Closes #11229
See #11652 for additional reference

Config panel with default settings:
![image](https://github.com/user-attachments/assets/f5d88f15-e466-430f-bc70-cc11e80b1155)

Tray notification example for expiring burners:
![image](https://github.com/user-attachments/assets/6d02165a-992a-48f8-be63-dd12162c40b1)

Should this get merged I'll open a separate PR for updating the plugin's config wiki as well.