### PR TITLE
Config panel `@Units` fixes

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
@@ -475,7 +475,7 @@ class ConfigPanel extends PluginPanel
 		Units units = cid.getUnits();
 		if (units != null)
 		{
-			spinnerTextField.setFormatterFactory(new UnitFormatterFactory(units.value()));
+			spinnerTextField.setFormatterFactory(new UnitFormatterFactory(units.value(), min, max));
 		}
 
 		return spinner;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
@@ -96,6 +96,7 @@ import net.runelite.client.externalplugins.ExternalPluginManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginManager;
 import net.runelite.client.ui.ColorScheme;
+import net.runelite.client.ui.DoubleUnitFormatterFactory;
 import net.runelite.client.ui.DynamicGridLayout;
 import net.runelite.client.ui.FontManager;
 import net.runelite.client.ui.PluginPanel;
@@ -495,7 +496,7 @@ class ConfigPanel extends PluginPanel
 		Units units = cid.getUnits();
 		if (units != null)
 		{
-			spinnerTextField.setFormatterFactory(new UnitFormatterFactory(units.value()));
+			spinnerTextField.setFormatterFactory(new DoubleUnitFormatterFactory(units.value(), 0, Double.MAX_VALUE));
 		}
 
 		return spinner;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/NotificationPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/NotificationPanel.java
@@ -215,7 +215,7 @@ class NotificationPanel extends PluginPanel
 		Component editor = spinner.getEditor();
 		JFormattedTextField spinnerTextField = ((JSpinner.DefaultEditor) editor).getTextField();
 		spinnerTextField.setColumns(6);
-		spinnerTextField.setFormatterFactory(new UnitFormatterFactory(unit));
+		spinnerTextField.setFormatterFactory(new UnitFormatterFactory(unit, min, max));
 		return spinner;
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/ui/DoubleUnitFormatterFactory.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/DoubleUnitFormatterFactory.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2020, Hydrox6 <ikada@protonmail.ch>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.ui;
+
+import java.text.ParseException;
+import java.util.HashMap;
+import java.util.Map;
+import javax.swing.JFormattedTextField;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+final class DoubleUnitFormatter extends JFormattedTextField.AbstractFormatter
+{
+	private final String units;
+	private final double min;
+	private final double max;
+
+	@Override
+	public Object stringToValue(final String text) throws ParseException
+	{
+		final String trimmedText;
+
+		// Using the spinner controls causes the value to have the unit on the end, so remove it
+		if (text.endsWith(units))
+		{
+			trimmedText = text.substring(0, text.length() - units.length());
+		}
+		else
+		{
+			trimmedText = text;
+		}
+
+		try
+		{
+			double newValue = Double.parseDouble(trimmedText);
+
+			if (newValue < this.min || newValue > this.max)
+			{
+				throw new ParseException(trimmedText + " is out of range", 0);
+			}
+
+			return newValue;
+		}
+		catch (NumberFormatException e)
+		{
+			throw new ParseException(trimmedText + " is not a double.", 0); // NOPMD: PreserveStackTrace
+		}
+	}
+
+	@Override
+	public String valueToString(final Object value)
+	{
+		return value + units;
+	}
+}
+
+@RequiredArgsConstructor
+public final class DoubleUnitFormatterFactory extends JFormattedTextField.AbstractFormatterFactory
+{
+	private final String units;
+	private final double min;
+	private final double max;
+	private final Map<JFormattedTextField, JFormattedTextField.AbstractFormatter> formatters = new HashMap<>();
+
+	public DoubleUnitFormatterFactory(String units)
+	{
+		this(units, Double.MIN_VALUE, Double.MAX_VALUE);
+	}
+
+	@Override
+	public JFormattedTextField.AbstractFormatter getFormatter(final JFormattedTextField tf)
+	{
+		return formatters.computeIfAbsent(tf, (key) -> new DoubleUnitFormatter(units, min, max));
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/ui/UnitFormatterFactory.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/UnitFormatterFactory.java
@@ -30,14 +30,12 @@ import java.util.Map;
 import javax.swing.JFormattedTextField;
 import lombok.RequiredArgsConstructor;
 
+@RequiredArgsConstructor
 final class UnitFormatter extends JFormattedTextField.AbstractFormatter
 {
 	private final String units;
-
-	UnitFormatter(String units)
-	{
-		this.units = units;
-	}
+	private final int min;
+	private final int max;
 
 	@Override
 	public Object stringToValue(final String text) throws ParseException
@@ -56,7 +54,14 @@ final class UnitFormatter extends JFormattedTextField.AbstractFormatter
 
 		try
 		{
-			return Integer.valueOf(trimmedText);
+			int newValue = Integer.parseInt(trimmedText);
+
+			if (newValue < this.min || newValue > this.max)
+			{
+				throw new ParseException(trimmedText + " is out of range", 0);
+			}
+
+			return newValue;
 		}
 		catch (NumberFormatException e)
 		{
@@ -75,11 +80,18 @@ final class UnitFormatter extends JFormattedTextField.AbstractFormatter
 public final class UnitFormatterFactory extends JFormattedTextField.AbstractFormatterFactory
 {
 	private final String units;
+	private final int min;
+	private final int max;
 	private final Map<JFormattedTextField, JFormattedTextField.AbstractFormatter> formatters = new HashMap<>();
+
+	public UnitFormatterFactory(String units)
+	{
+		this(units, Integer.MIN_VALUE, Integer.MAX_VALUE);
+	}
 
 	@Override
 	public JFormattedTextField.AbstractFormatter getFormatter(final JFormattedTextField tf)
 	{
-		return formatters.computeIfAbsent(tf, (key) -> new UnitFormatter(units));
+		return formatters.computeIfAbsent(tf, (key) -> new UnitFormatter(units, min, max));
 	}
 }


### PR DESCRIPTION
there are a couple bugs going on here:
* for integer fields annotated with both `@Range` and `@Units`, the UnitFormatter does not validate that the value is within the allowed range and so allows a write to the config with an out of bounds value. If the config panel is refreshed, this is obfuscated from the user by a `constrainToRange` call in `ConfigPanel#createIntSpinner`
* for double fields annotated with `@Units`, only integer values can be saved since the present of a decimal point will throw an exception in `UnitFormatterFactory#stringToValue`.

To fix these, we can add a min and max to the UnitFormatter, and create a corresponding class for double values.