### PR TITLE
droppartychest: add initial version as a core plugin

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/droppartychest/DropPartyChestConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/droppartychest/DropPartyChestConfig.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2025, Peter Grønbæk Andersen <peter@grnbk.io>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.droppartychest;
+
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+
+@ConfigGroup("droppartychest")
+public interface DropPartyChestConfig extends Config
+{
+	@ConfigItem(
+		keyName = "showExact",
+		name = "Show exact chest value",
+		description = "Show exact chest value."
+	)
+	default boolean showExact()
+	{
+		return false;
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/droppartychest/DropPartyChestPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/droppartychest/DropPartyChestPlugin.java
@@ -44,7 +44,9 @@ import javax.inject.Inject;
 
 @Slf4j
 @PluginDescriptor(
-	name = "Drop Party Chest"
+	name = "Drop Party Chest",
+	description = "Display value of the party room and clan hall chests.",
+	tags = {"party", "room", "clan", "hall", "chest", "value"}
 )
 public class DropPartyChestPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/droppartychest/DropPartyChestPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/droppartychest/DropPartyChestPlugin.java
@@ -25,7 +25,6 @@
  */
 package net.runelite.client.plugins.droppartychest;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.inject.Provides;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
@@ -118,8 +117,10 @@ public class DropPartyChestPlugin extends Plugin
 	{
 		long grandExchangeValue = 0;
 
-		for (Item item : items) {
-			if (item != null) {
+		for (Item item : items)
+		{
+			if (item != null)
+			{
 				grandExchangeValue += (long) itemManager.getItemPrice(item.getId()) * item.getQuantity();
 			}
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/droppartychest/DropPartyChestPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/droppartychest/DropPartyChestPlugin.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2025, Peter Grønbæk Andersen <peter@grnbk.io>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.droppartychest;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.inject.Provides;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.Client;
+import net.runelite.api.Item;
+import net.runelite.api.ItemContainer;
+import net.runelite.api.events.ItemContainerChanged;
+import net.runelite.api.widgets.Widget;
+import net.runelite.client.callback.ClientThread;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.eventbus.Subscribe;
+import net.runelite.client.game.ItemManager;
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.util.QuantityFormatter;
+import javax.inject.Inject;
+
+@Slf4j
+@PluginDescriptor(
+	name = "Drop Party Chest"
+)
+public class DropPartyChestPlugin extends Plugin
+{
+	private static final int CLANHALL_CHEST_ITEMS_CONTAINER_ID = 33684;
+	private static final int CLANHALL_CHEST_TITLE_WIDGET_ID = 51314689;
+	private static final String CLANHALL_CHEST_TITLE = "Clan Party Drop Chest";
+	private static final int PARTYROOM_CHEST_ITEMS_CONTAINER_ID = 91;
+	private static final int PARTYROOM_CHEST_TITLE_WIDGET_ID = 17367041;
+	private static final String PARTYROOM_CHEST_TITLE = "Party Drop Chest";
+
+	@Inject
+	private Client client;
+
+	@Inject
+	private ClientThread clientThread;
+
+	@Inject
+	private ItemManager itemManager;
+
+	@Inject
+	private DropPartyChestConfig config;
+
+	@Subscribe
+	public void onItemContainerChanged(ItemContainerChanged event)
+	{
+		int containerId = event.getContainerId();
+
+		if (containerId == PARTYROOM_CHEST_ITEMS_CONTAINER_ID)
+		{
+			updateChestItemsValue(containerId, PARTYROOM_CHEST_TITLE_WIDGET_ID, PARTYROOM_CHEST_TITLE);
+		}
+		else if (containerId == CLANHALL_CHEST_ITEMS_CONTAINER_ID)
+		{
+			updateChestItemsValue(containerId, CLANHALL_CHEST_TITLE_WIDGET_ID, CLANHALL_CHEST_TITLE);
+		}
+	}
+
+	private void updateChestItemsValue(int containerId, int widgetId, String title)
+	{
+		final Widget titleContainer = client.getWidget(widgetId);
+		if (titleContainer == null)
+		{
+			return;
+		}
+
+		final Widget titleWidget = titleContainer.getChild(1);
+		if (titleWidget == null)
+		{
+			return;
+		}
+
+		ItemContainer itemContainer = client.getItemContainer(containerId);
+		if (itemContainer != null)
+		{
+			final long totalChestItemsValue = getTotalGrandExchangeValue(itemContainer.getItems());
+			if (totalChestItemsValue > 0)
+			{
+				final String totalChestValueText = createValueText(totalChestItemsValue);
+				titleWidget.setText(title + totalChestValueText);
+			}
+			else
+			{
+				titleWidget.setText(title);
+			}
+		}
+	}
+
+	long getTotalGrandExchangeValue(Item[] items)
+	{
+		long grandExchangeValue = 0;
+
+        for (Item item : items) {
+            if (item != null) {
+                grandExchangeValue += (long) itemManager.getItemPrice(item.getId()) * item.getQuantity();
+            }
+        }
+
+		return grandExchangeValue;
+	}
+
+	private String createValueText(long grandExchangeValue)
+	{
+		StringBuilder stringBuilder = new StringBuilder();
+		if (grandExchangeValue != 0)
+		{
+			stringBuilder.append(" (");
+
+			if (config.showExact())
+			{
+				stringBuilder.append(QuantityFormatter.formatNumber(grandExchangeValue));
+			}
+			else
+			{
+				stringBuilder.append(QuantityFormatter.quantityToStackSize(grandExchangeValue));
+			}
+			stringBuilder.append(')');
+		}
+
+		return stringBuilder.toString();
+	}
+
+	@Provides
+	DropPartyChestConfig provideConfig(ConfigManager configManager)
+	{
+		return configManager.getConfig(DropPartyChestConfig.class);
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/droppartychest/DropPartyChestPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/droppartychest/DropPartyChestPlugin.java
@@ -116,11 +116,11 @@ public class DropPartyChestPlugin extends Plugin
 	{
 		long grandExchangeValue = 0;
 
-        for (Item item : items) {
-            if (item != null) {
-                grandExchangeValue += (long) itemManager.getItemPrice(item.getId()) * item.getQuantity();
-            }
-        }
+		for (Item item : items) {
+			if (item != null) {
+				grandExchangeValue += (long) itemManager.getItemPrice(item.getId()) * item.getQuantity();
+			}
+		}
 
 		return grandExchangeValue;
 	}

--- a/runelite-client/src/test/java/net/runelite/client/plugins/droppartychest/DropPartyChestPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/droppartychest/DropPartyChestPluginTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2025, Peter Grønbæk Andersen <peter@grnbk.io>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.droppartychest;
+
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Guice;
+import com.google.inject.testing.fieldbinder.Bind;
+import com.google.inject.testing.fieldbinder.BoundFieldModule;
+import net.runelite.api.*;
+import net.runelite.client.game.ItemManager;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import javax.inject.Inject;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DropPartyChestPluginTest
+{
+	@Mock
+	@Bind
+	private Client client;
+
+	@Mock
+	@Bind
+	private ItemManager itemManager;
+
+	@Mock
+	@Bind
+	private DropPartyChestConfig dropPartyChestConfig;
+
+	@Inject
+	private DropPartyChestPlugin dropPartyChestPlugin;
+
+	@Before
+	public void before()
+	{
+		Guice.createInjector(BoundFieldModule.of(this)).injectMembers(this);
+	}
+
+	@Test
+	public void testCalculateValue()
+	{
+		Item coins = new Item(ItemID.COINS_995, Integer.MAX_VALUE);
+
+		Item whip = new Item(ItemID.ABYSSAL_WHIP, 1_000_000_000);
+
+		Item[] items = ImmutableList.of(
+			coins,
+			whip
+		).toArray(new Item[0]);
+
+		when(itemManager.getItemPrice(ItemID.ABYSSAL_WHIP))
+			.thenReturn(3); // 1b * 3 overflows
+
+		final long totalValue = dropPartyChestPlugin.getTotalGrandExchangeValue(items);
+
+		assertTrue(totalValue > Integer.MAX_VALUE);
+	}
+}


### PR DESCRIPTION
This is a very simple plugin that adds total chest value to the title of the drop party chest interfaces in the party room and clan hall, like this:

![DropPartyChest](https://github.com/user-attachments/assets/166efe7e-73cf-448b-a51d-29a9b84b29e3)

It is quite similar to what the bank plugin does to the bank interface title. Just without HA value.

I originally submitted this is a [PR in the plugin-hub repo](https://github.com/runelite/plugin-hub/pull/7180), but YvesW suggested it would fit better as a core plugin. So here it is.

My reasoning for making this is that there is no easy way to see this otherwise in the standard UI.