### PR TITLE
runenergy: Update Run Energy Formulas

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/runenergy/RunEnergyPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/runenergy/RunEnergyPlugin.java
@@ -292,7 +292,7 @@ public class RunEnergyPlugin extends Plugin
 		final int effectiveWeight = Math.min(Math.max(client.getWeight(), 0), 64);
 
 		// 100% energy is 10000 energy units
-		int energyUnitsLost = (int) ((60 + (67 * effectiveWeight / 64)) * (1 - (double) client.getBoostedSkillLevel(Skill.AGILITY) / 300.0));
+		int energyUnitsLost = (int) ((60 + (67 * effectiveWeight / 64)) * (1 - client.getBoostedSkillLevel(Skill.AGILITY) / 300.0));
 
 		if (client.getVarbitValue(Varbits.RUN_SLOWED_DEPLETION_ACTIVE) != 0)
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/runenergy/RunEnergyPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/runenergy/RunEnergyPlugin.java
@@ -81,7 +81,7 @@ public class RunEnergyPlugin extends Plugin
 		GLOVES(EquipmentInventorySlot.GLOVES.getSlotIdx(), 3, GRACEFUL_GLOVES),
 		BOOTS(EquipmentInventorySlot.BOOTS.getSlotIdx(), 3, GRACEFUL_BOOTS),
 		// Agility skill capes and the non-cosmetic Max capes also count for the Graceful set effect
-		CAPE(EquipmentInventorySlot.CAPE.getSlotIdx(), 3, GRACEFUL_CAPE, AGILITY_CAPE, MAX_CAPE);
+		CAPE(EquipmentInventorySlot.CAPE.getSlotIdx(), 3, GRACEFUL_CAPE, AGILITY_CAPE, MAX_CAPE_13342);
 
 		private final int index;
 		private final int boost;
@@ -292,7 +292,7 @@ public class RunEnergyPlugin extends Plugin
 		final int effectiveWeight = Math.min(Math.max(client.getWeight(), 0), 64);
 
 		// 100% energy is 10000 energy units
-		int energyUnitsLost = effectiveWeight * 67 / 64 + 67;
+		int energyUnitsLost = (int) ((60 + (67 * effectiveWeight / 64)) * (1 - (double) client.getBoostedSkillLevel(Skill.AGILITY) / 300.0));
 
 		if (client.getVarbitValue(Varbits.RUN_SLOWED_DEPLETION_ACTIVE) != 0)
 		{
@@ -373,7 +373,7 @@ public class RunEnergyPlugin extends Plugin
 		}
 
 		// Calculate the amount of energy recovered every second
-		double recoverRate = (48 + client.getBoostedSkillLevel(Skill.AGILITY)) / 3.6;
+		double recoverRate = 25 + client.getBoostedSkillLevel(Skill.AGILITY) / 6.0;
 		recoverRate *= 1.0 + getGracefulRecoveryBoost() / 100.0;
 
 		// Calculate the number of seconds left

--- a/runelite-client/src/test/java/net/runelite/client/plugins/runenergy/RunEnergyPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/runenergy/RunEnergyPluginTest.java
@@ -30,6 +30,7 @@ import com.google.inject.testing.fieldbinder.BoundFieldModule;
 import javax.inject.Inject;
 import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
+import net.runelite.api.Skill;
 import net.runelite.api.InventoryID;
 import net.runelite.api.ItemContainer;
 import static net.runelite.api.ItemID.RING_OF_ENDURANCE;
@@ -149,10 +150,11 @@ public class RunEnergyPluginTest
 		when(equipment.count(RING_OF_ENDURANCE)).thenReturn(1);
 		when(client.getVarbitValue(Varbits.RUN_SLOWED_DEPLETION_ACTIVE)).thenReturn(1);
 		when(client.getEnergy()).thenReturn(10000);
-		assertEquals("300s", runEnergyPlugin.getEstimatedRunTimeRemaining(true));
+		when(client.getRealSkillLevel(Skill.AGILITY)).thenReturn(99);
+		assertEquals("333s", runEnergyPlugin.getEstimatedRunTimeRemaining(true));
 
 		when(client.getVarbitValue(Varbits.RUN_SLOWED_DEPLETION_ACTIVE)).thenReturn(0);
 		when(configManager.getRSProfileConfiguration(RunEnergyConfig.GROUP_NAME, "ringOfEnduranceCharges", Integer.class)).thenReturn(512);
-		assertEquals("1:47", runEnergyPlugin.getEstimatedRunTimeRemaining(false));
+		assertEquals("1:58", runEnergyPlugin.getEstimatedRunTimeRemaining(false));
 	}
 }

--- a/runelite-client/src/test/java/net/runelite/client/plugins/runenergy/RunEnergyPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/runenergy/RunEnergyPluginTest.java
@@ -151,10 +151,10 @@ public class RunEnergyPluginTest
 		when(client.getVarbitValue(Varbits.RUN_SLOWED_DEPLETION_ACTIVE)).thenReturn(1);
 		when(client.getEnergy()).thenReturn(10000);
 		when(client.getBoostedSkillLevel(Skill.AGILITY)).thenReturn(99);
-		assertEquals("333s", runEnergyPlugin.getEstimatedRunTimeRemaining(true));
+		assertEquals("500s", runEnergyPlugin.getEstimatedRunTimeRemaining(true));
 
 		when(client.getVarbitValue(Varbits.RUN_SLOWED_DEPLETION_ACTIVE)).thenReturn(0);
 		when(configManager.getRSProfileConfiguration(RunEnergyConfig.GROUP_NAME, "ringOfEnduranceCharges", Integer.class)).thenReturn(512);
-		assertEquals("1:58", runEnergyPlugin.getEstimatedRunTimeRemaining(false));
+		assertEquals("2:57", runEnergyPlugin.getEstimatedRunTimeRemaining(false));
 	}
 }

--- a/runelite-client/src/test/java/net/runelite/client/plugins/runenergy/RunEnergyPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/runenergy/RunEnergyPluginTest.java
@@ -150,7 +150,7 @@ public class RunEnergyPluginTest
 		when(equipment.count(RING_OF_ENDURANCE)).thenReturn(1);
 		when(client.getVarbitValue(Varbits.RUN_SLOWED_DEPLETION_ACTIVE)).thenReturn(1);
 		when(client.getEnergy()).thenReturn(10000);
-		when(client.getRealSkillLevel(Skill.AGILITY)).thenReturn(99);
+		when(client.getBoostedSkillLevel(Skill.AGILITY)).thenReturn(99);
 		assertEquals("333s", runEnergyPlugin.getEstimatedRunTimeRemaining(true));
 
 		when(client.getVarbitValue(Varbits.RUN_SLOWED_DEPLETION_ACTIVE)).thenReturn(0);


### PR DESCRIPTION
8 January 2025 Run Energy Changes
Energy Regeneration was changed from (Agility / 6) + 8 to (Agility / 10) + 15
Energy Drain was changed to include the agility level. (60 + (67 * Weight / 64)) * (1 - Agility/300)

The graceful boost check was looking for the inventory max-cape id rather than the worn max cape which is unrelated to the game update.