### PR TITLE
Fix custom notification sound playing twice the first time after client launch

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/Notifier.java
+++ b/runelite-client/src/main/java/net/runelite/client/Notifier.java
@@ -525,7 +525,7 @@ public class Notifier
 		// Using loop instead of start + setFramePosition prevents the clip
 		// from not being played sometimes, presumably a race condition in the
 		// underlying line driver
-		clip.loop(1);
+		clip.loop(0);
 	}
 
 	private boolean tryLoadNotification()

--- a/runelite-client/src/main/java/net/runelite/client/Notifier.java
+++ b/runelite-client/src/main/java/net/runelite/client/Notifier.java
@@ -524,7 +524,9 @@ public class Notifier
 
 		// Using loop instead of start + setFramePosition prevents the clip
 		// from not being played sometimes, presumably a race condition in the
-		// underlying line driver
+		// underlying line driver. Setting the frame position first resets the loop,
+		// otherwise the clip would not pe played on subsequent calls.
+		clip.setFramePosition(0);
 		clip.loop(0);
 	}
 


### PR DESCRIPTION
Calling `clip.loop(1)` would cause the clip to be played twice the first time a notification sound should be played. This happens because after a loop finishes, the clips position is set to the last frame. When a new loop with count 1 (meaning repeat once) is started, the clip is instantly reset to the first frame, which counts as the first loop, causing the clip to audibly only be played once.

Setting the frame position to 0 and the loop count to 0 fixes this problem.

In my limited tests using `clip.start()` instead of `clip.loop(0)` worked just as well, but I don't know if the issue described in the comment above the changed lines is still relevant.

Closes #14914