### PR TITLE
Skill Calculator: Add refresh current XP and level when clicked

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/SkillCalculator.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/SkillCalculator.java
@@ -92,7 +92,6 @@ class SkillCalculator extends JPanel
 	private final Map<SkillBonus, JCheckBox> bonusCheckBoxes = new HashMap<>();
 	private final IconTextField searchBar = new IconTextField();
 
-	private CalculatorType currentCalculator;
 	private int currentLevel = 1;
 	private int currentXP = Experience.getXpForLevel(currentLevel);
 	private int targetLevel = currentLevel + 1;
@@ -152,15 +151,12 @@ class SkillCalculator extends JPanel
 		uiInput.getUiFieldXPMultiplier().addFocusListener(buildFocusAdapter(e -> onFieldXPMultiplierUpdated()));
 	}
 
-	void openCalculator(CalculatorType calculatorType, boolean forceReload)
+	void openCalculator(CalculatorType calculatorType)
 	{
 		// Update internal skill/XP values.
 		currentXP = client.getSkillExperience(calculatorType.getSkill());
 		currentLevel = Experience.getLevelForXp(currentXP);
 
-		if (forceReload || currentCalculator != calculatorType)
-		{
-			currentCalculator = calculatorType;
 			currentBonuses.clear();
 
 			@Varp int endGoalVarp = endGoalVarpForSkill(calculatorType.getSkill());
@@ -188,7 +184,7 @@ class SkillCalculator extends JPanel
 			// Add in checkboxes for available skill bonuses if we're not on a F2P world.
 			if (client.getWorldType().contains(WorldType.MEMBERS))
 			{
-				renderBonusOptions();
+				renderBonusOptions(calculatorType);
 			}
 
 			// Add the combined action slot.
@@ -198,8 +194,8 @@ class SkillCalculator extends JPanel
 			add(searchBar);
 
 			// Create action slots for the skill actions.
-			renderActionSlots();
-		}
+			renderActionSlots(calculatorType);
+
 
 		// Update the input fields.
 		updateInputFields();
@@ -252,9 +248,9 @@ class SkillCalculator extends JPanel
 		combinedActionSlots.clear();
 	}
 
-	private void renderBonusOptions()
+	private void renderBonusOptions(CalculatorType calculatorType)
 	{
-		final SkillBonus[] skillBonuses = currentCalculator.getSkillBonuses();
+		final SkillBonus[] skillBonuses = calculatorType.getSkillBonuses();
 		if (skillBonuses == null)
 		{
 			return;
@@ -339,13 +335,13 @@ class SkillCalculator extends JPanel
 		calculate();
 	}
 
-	private void renderActionSlots()
+	private void renderActionSlots(CalculatorType calculatorType)
 	{
 		// Wipe the list of references to the slot components.
 		uiActionSlots.clear();
 
 		// Create new components for the action slots.
-		for (SkillAction action : currentCalculator.getSkillActions())
+		for (SkillAction action : calculatorType.getSkillActions())
 		{
 			JLabel uiIcon = new JLabel();
 
@@ -456,6 +452,14 @@ class SkillCalculator extends JPanel
 		int integer = xp / 10;
 		int frac = xp % 10;
 		return (frac != 0 ? (integer + "." + frac) : integer) + expExpression + NumberFormat.getIntegerInstance().format(actionCount) + (actionCount == 1 ? " action" : " actions");
+	}
+
+	public void refreshCurrentXP(CalculatorType calculatorType)
+	{
+		int xp = client.getSkillExperience(calculatorType.getSkill());
+		currentLevel = Experience.getLevelForXp(xp);
+		currentXP = xp;
+		updateInputFields();
 	}
 
 	private void updateInputFields()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/SkillCalculatorPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/SkillCalculatorPanel.java
@@ -99,9 +99,11 @@ class SkillCalculatorPanel extends PluginPanel
 				currentCalculator = calculatorType;
 				return true;
 			});
-			tab.addMouseListener(new MouseAdapter() {
+			tab.addMouseListener(new MouseAdapter()
+			{
 				@Override
-				public void mouseClicked(MouseEvent e) {
+				public void mouseClicked(MouseEvent e)
+				{
 					uiCalculator.refreshCurrentXP(calculatorType);
 				}
 			});

--- a/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/SkillCalculatorPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/SkillCalculatorPanel.java
@@ -25,15 +25,17 @@
  */
 package net.runelite.client.plugins.skillcalculator;
 
+import com.google.inject.Singleton;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.GridLayout;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
 import javax.inject.Inject;
 import javax.swing.ImageIcon;
 import javax.swing.JScrollPane;
 import javax.swing.SwingUtilities;
 import javax.swing.border.EmptyBorder;
-import com.google.inject.Singleton;
 import net.runelite.client.game.SkillIconManager;
 import net.runelite.client.ui.ColorScheme;
 import net.runelite.client.ui.PluginPanel;
@@ -47,8 +49,7 @@ class SkillCalculatorPanel extends PluginPanel
 	private final SkillIconManager iconManager;
 	private final MaterialTabGroup tabGroup;
 
-	private MaterialTab currentTab;
-	private boolean shouldForceReload;
+	private CalculatorType currentCalculator;
 
 	@Inject
 	SkillCalculatorPanel(SkillCalculator skillCalculator, SkillIconManager iconManager, UICalculatorInputArea uiInput)
@@ -94,10 +95,15 @@ class SkillCalculatorPanel extends PluginPanel
 			MaterialTab tab = new MaterialTab(icon, tabGroup, null);
 			tab.setOnSelectEvent(() ->
 			{
-				uiCalculator.openCalculator(calculatorType, shouldForceReload);
-				currentTab = tab;
-				shouldForceReload = false;
+				uiCalculator.openCalculator(calculatorType);
+				currentCalculator = calculatorType;
 				return true;
+			});
+			tab.addMouseListener(new MouseAdapter() {
+				@Override
+				public void mouseClicked(MouseEvent e) {
+					uiCalculator.refreshCurrentXP(calculatorType);
+				}
 			});
 
 			tabGroup.addTab(tab);
@@ -106,10 +112,9 @@ class SkillCalculatorPanel extends PluginPanel
 
 	void reloadCurrentCalculator()
 	{
-		if (currentTab != null)
+		if (currentCalculator != null)
 		{
-			shouldForceReload = true;
-			SwingUtilities.invokeLater(() -> tabGroup.select(currentTab));
+			SwingUtilities.invokeLater(() -> uiCalculator.openCalculator(currentCalculator));
 		}
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/SkillCalculatorPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/SkillCalculatorPlugin.java
@@ -38,9 +38,9 @@ import net.runelite.client.ui.NavigationButton;
 import net.runelite.client.util.ImageUtil;
 
 @PluginDescriptor(
-	name = "Skill Calculator",
-	description = "Enable the Skill Calculator panel",
-	tags = {"panel", "skilling"}
+		name = "Skill Calculator",
+		description = "Enable the Skill Calculator panel",
+		tags = {"panel", "skilling"}
 )
 public class SkillCalculatorPlugin extends Plugin
 {
@@ -62,11 +62,11 @@ public class SkillCalculatorPlugin extends Plugin
 		final BufferedImage icon = ImageUtil.loadImageResource(getClass(), "calc.png");
 
 		uiNavigationButton = NavigationButton.builder()
-			.tooltip("Skill Calculator")
-			.icon(icon)
-			.priority(6)
-			.panel(uiPanel.get())
-			.build();
+				.tooltip("Skill Calculator")
+				.icon(icon)
+				.priority(6)
+				.panel(uiPanel.get())
+				.build();
 
 		clientToolbar.addNavigation(uiNavigationButton);
 	}
@@ -85,7 +85,7 @@ public class SkillCalculatorPlugin extends Plugin
 		if (currentWorldIsMembers != lastWorldWasMembers)
 		{
 			uiPanel.get().reloadCurrentCalculator();
+			lastWorldWasMembers = currentWorldIsMembers;
 		}
-		lastWorldWasMembers = currentWorldIsMembers;
 	}
 }


### PR DESCRIPTION
When you click the tab again, it will refresh the current level and XP that the player has. Plus remove code from another author that did not work as intended.