### PR TITLE
Added option to ignore bank rearrange made when using layouts

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/banktags/BankTagsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/banktags/BankTagsConfig.java
@@ -76,6 +76,17 @@ public interface BankTagsConfig extends Config
 	}
 
 	@ConfigItem(
+			keyName = "ignoreRearrangeMode",
+			name = "Use swap for bank layouts",
+			description = "When using bank layouts the bank rearrange made will always act as swap.",
+			position = 5
+	)
+	default boolean ignoreRearrangeMode()
+	{
+		return false;
+	}
+
+	@ConfigItem(
 		keyName = "position",
 		name = "",
 		description = "",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/banktags/tabs/LayoutManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/banktags/tabs/LayoutManager.java
@@ -75,6 +75,7 @@ import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.bank.BankSearch;
 import net.runelite.client.plugins.banktags.BankTag;
 import net.runelite.client.plugins.banktags.BankTagsPlugin;
+import net.runelite.client.plugins.banktags.BankTagsConfig;
 import static net.runelite.client.plugins.banktags.BankTagsPlugin.BANK_ITEMS_PER_ROW;
 import static net.runelite.client.plugins.banktags.BankTagsPlugin.BANK_ITEM_HEIGHT;
 import static net.runelite.client.plugins.banktags.BankTagsPlugin.BANK_ITEM_START_X;
@@ -101,13 +102,14 @@ public class LayoutManager
 	private final PotionStorage potionStorage;
 	private final EventBus eventBus;
 	private final ConfigManager configManager;
+	private final BankTagsConfig config;
 
 	private final List<PluginAutoLayout> autoLayouts = new ArrayList<>();
 
 	@Inject
 	LayoutManager(Client client, ItemManager itemManager, BankTagsPlugin plugin, ChatboxPanelManager chatboxPanelManager,
-		BankSearch bankSearch, ChatMessageManager chatMessageManager,
-		PotionStorage potionStorage, EventBus eventBus, ConfigManager configManager)
+                  BankSearch bankSearch, ChatMessageManager chatMessageManager,
+                  PotionStorage potionStorage, EventBus eventBus, ConfigManager configManager, BankTagsConfig config)
 	{
 		this.client = client;
 		this.itemManager = itemManager;
@@ -118,8 +120,9 @@ public class LayoutManager
 		this.potionStorage = potionStorage;
 		this.eventBus = eventBus;
 		this.configManager = configManager;
+        this.config = config;
 
-		registerAutoLayout(plugin, "Default", new DefaultLayout());
+        registerAutoLayout(plugin, "Default", new DefaultLayout());
 	}
 
 	public void register()
@@ -473,7 +476,7 @@ public class LayoutManager
 			l.resize(Math.max(sidx, tidx) + 1);
 		}
 
-		if (swap)
+		if (swap || config.ignoreRearrangeMode())
 		{
 			log.debug("Swap {} <-> {}", sidx, tidx);
 			l.swap(sidx, tidx);


### PR DESCRIPTION
Seen a few other people suggest this as well. Old bank layouts always acted as swap, so I think this would be a useful addition.