### PR TITLE
Crowdsourcing: raw jubbly cooking success rates

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/cooking/CookingPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cooking/CookingPlugin.java
@@ -152,7 +152,7 @@ public class CookingPlugin extends Plugin
 	@Subscribe
 	public void onChatMessage(ChatMessage event)
 	{
-		if (event.getType() != ChatMessageType.SPAM)
+		if (event.getType() != ChatMessageType.SPAM && event.getType() != ChatMessageType.GAMEMESSAGE)
 		{
 			return;
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/crowdsourcing/cooking/CrowdsourcingCooking.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/crowdsourcing/cooking/CrowdsourcingCooking.java
@@ -67,7 +67,7 @@ public class CrowdsourcingCooking
 	@Subscribe
 	public void onChatMessage(ChatMessage event)
 	{
-		if (event.getType() != ChatMessageType.SPAM)
+		if (event.getType() != ChatMessageType.SPAM && event.getType() != ChatMessageType.GAMEMESSAGE)
 		{
 			return;
 		}


### PR DESCRIPTION
Crowdsource plugin was only tracking spam messages, but jubbly is not filtered.

![image](https://github.com/user-attachments/assets/8f13903c-ab0c-4bc4-aace-83032a168c71)
