### PR TITLE
Show warmth restore & auto-switch to warmth status bar in wintertodt

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatChanges.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatChanges.java
@@ -421,6 +421,9 @@ public class ItemStatChanges
 		add(boost(STRENGTH, perc(.15, 4)), ItemID.BUTTERFLY_JAR_WARLOCK, ItemID.HUNTER_MIX_WARLOCK_1DOSE, ItemID.HUNTER_MIX_WARLOCK_2DOSE);
 		add(boost(DEFENCE, perc(.15, 4)), ItemID.BUTTERFLY_JAR_GLACIALIS, ItemID.HUNTER_MIX_GLACIALIS_1DOSE, ItemID.HUNTER_MIX_GLACIALIS_2DOSE);
 
+		// Wintertodt
+		add(heal(WARMTH, 30), ItemID.WINT_POTION1, ItemID.WINT_POTION2, ItemID.WINT_POTION3, ItemID.WINT_POTION4);
+
 		log.debug("{} items; {} behaviours loaded", effects.size(), new HashSet<>(effects.values()).size());
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/stats/Stats.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/stats/Stats.java
@@ -53,4 +53,5 @@ public class Stats
 	public static final Stat CONSTRUCTION = new SkillStat(Skill.CONSTRUCTION);
 	public static final Stat SAILING = new SkillStat(Skill.SAILING);
 	public static final Stat RUN_ENERGY = new EnergyStat();
+	public static final Stat WARMTH = new WarmthStat();
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/stats/WarmthStat.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/stats/WarmthStat.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2025, Lake David <ldavid432@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.itemstats.stats;
+
+import net.runelite.api.Client;
+import net.runelite.api.gameval.VarbitID;
+
+public class WarmthStat extends Stat
+{
+	WarmthStat()
+	{
+		super("Warmth");
+	}
+
+	@Override
+	public int getValue(Client client)
+	{
+		return client.getVarbitValue(VarbitID.WINT_WARMTH) / 10;
+	}
+
+	@Override
+	public int getMaximum(Client client)
+	{
+		return 100;
+	}
+
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/statusbars/StatusBarsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/statusbars/StatusBarsConfig.java
@@ -106,6 +106,16 @@ public interface StatusBarsConfig extends Config
 		return 0;
 	}
 
+	@ConfigItem(
+		keyName = "replaceHpWithWarmth",
+		name = "Replace HP with Warmth",
+		description = "Automatically replace any HP status bars with Warmth while fighting the Wintertodt"
+	)
+	default boolean replaceHpWithWarmth()
+	{
+		return true;
+	}
+
 	@Range(
 		min = BarRenderer.MIN_WIDTH,
 		max = BarRenderer.MAX_WIDTH

--- a/runelite-client/src/main/java/net/runelite/client/plugins/statusbars/StatusBarsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/statusbars/StatusBarsOverlay.java
@@ -64,12 +64,14 @@ class StatusBarsOverlay extends Overlay
 	private static final Color VENOMED_COLOR = new Color(0, 65, 0, 150);
 	private static final Color HEAL_COLOR = new Color(255, 112, 6, 150);
 	private static final Color PRAYER_HEAL_COLOR = new Color(57, 255, 186, 75);
-	private static final Color ENERGY_HEAL_COLOR = new Color (199,  118, 0, 218);
+	private static final Color ENERGY_HEAL_COLOR = new Color(199, 118, 0, 218);
 	private static final Color RUN_STAMINA_COLOR = new Color(160, 124, 72, 255);
 	private static final Color SPECIAL_ATTACK_COLOR = new Color(3, 153, 0, 195);
 	private static final Color ENERGY_COLOR = new Color(199, 174, 0, 220);
 	private static final Color DISEASE_COLOR = new Color(255, 193, 75, 181);
 	private static final Color PARASITE_COLOR = new Color(196, 62, 109, 181);
+	private static final Color WARMTH_COLOR = new Color(244, 97, 0);
+	private static final Color WARMTH_HEAL_COLOR = new Color(244, 97, 0, 75);
 	private static final int HEIGHT = 252;
 	private static final int RESIZED_BOTTOM_HEIGHT = 272;
 	private static final int RESIZED_BOTTOM_OFFSET_Y = 12;
@@ -214,9 +216,26 @@ class StatusBarsOverlay extends Overlay
 		barRenderers.put(StatusBarsConfig.BarMode.WARMTH, new BarRenderer(
 			() -> 100,
 			() -> client.getVarbitValue(VarbitID.WINT_WARMTH) / 10,
-			() -> 0,
-			() -> new Color(244, 97, 0),
-			() -> null,
+			() ->
+			{
+				int warmthValue = getRestoreValue("Warmth");
+
+				if (warmthValue > 0)
+				{
+					return warmthValue;
+				}
+
+				int hitpointsValue = getRestoreValue(Skill.HITPOINTS.getName());
+
+				if (hitpointsValue >= 4)
+				{
+					return 35;
+				}
+
+				return 0;
+			},
+			() -> WARMTH_COLOR,
+			() -> WARMTH_HEAL_COLOR,
 			() -> skillIconManager.getSkillImage(Skill.FIREMAKING, true)
 		));
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/statusbars/StatusBarsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/statusbars/StatusBarsOverlay.java
@@ -292,8 +292,21 @@ class StatusBarsOverlay extends Overlay
 			offsetRightBarY = (location.getY() - offsetRight.getY());
 		}
 
-		BarRenderer left = barRenderers.get(config.leftBarMode());
-		BarRenderer right = barRenderers.get(config.rightBarMode());
+		StatusBarsConfig.BarMode leftBarMode = config.leftBarMode();
+		StatusBarsConfig.BarMode rightBarMode = config.rightBarMode();
+
+		if (leftBarMode == StatusBarsConfig.BarMode.HITPOINTS && plugin.isInWintertodtRegion() && config.replaceHpWithWarmth())
+		{
+			leftBarMode = StatusBarsConfig.BarMode.WARMTH;
+		}
+
+		if (rightBarMode == StatusBarsConfig.BarMode.HITPOINTS && plugin.isInWintertodtRegion() && config.replaceHpWithWarmth())
+		{
+			rightBarMode = StatusBarsConfig.BarMode.WARMTH;
+		}
+
+		BarRenderer left = barRenderers.get(leftBarMode);
+		BarRenderer right = barRenderers.get(rightBarMode);
 
 		if (left != null)
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/statusbars/StatusBarsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/statusbars/StatusBarsPlugin.java
@@ -24,8 +24,8 @@
  */
 package net.runelite.client.plugins.statusbars;
 
-import javax.inject.Inject;
 import com.google.inject.Provides;
+import javax.inject.Inject;
 import lombok.AccessLevel;
 import lombok.Getter;
 import net.runelite.api.Actor;
@@ -53,6 +53,8 @@ import org.apache.commons.lang3.ArrayUtils;
 @PluginDependency(ItemStatPlugin.class)
 public class StatusBarsPlugin extends Plugin
 {
+	private static final int WINTERTODT_REGION = 6462;
+
 	@Inject
 	private StatusBarsOverlay overlay;
 
@@ -118,7 +120,7 @@ public class StatusBarsPlugin extends Plugin
 
 		final Actor interacting = localPlayer.getInteracting();
 
-		if (config.hideAfterCombatDelay() == 0)
+		if (config.hideAfterCombatDelay() == 0 || isInWintertodtRegion())
 		{
 			barsDisplayed = true;
 		}
@@ -132,5 +134,15 @@ public class StatusBarsPlugin extends Plugin
 		{
 			barsDisplayed = false;
 		}
+	}
+
+	boolean isInWintertodtRegion()
+	{
+		if (client.getLocalPlayer() != null)
+		{
+			return client.getLocalPlayer().getWorldLocation().getRegionID() == WINTERTODT_REGION;
+		}
+
+		return false;
 	}
 }


### PR DESCRIPTION
- Item stats: Add Rejuvenation potion and the warmth stat
- Status bars: Add the ability to see warmth heal directly or via HP restore
- Status bars: Add the ability to auto-replace HP with Warmth while in Wintertodt

I'd love to add warmth to food in the item stats plugin but that seemed more involved, so for now the rejuvenation potions are the only ones that explicitly list warmth. Both the rejuvenation potions and anything that heals hitpoints display the warmth heal amount in the status bars plugin though.

![2025-01-31_14-37-38](https://github.com/user-attachments/assets/02c23810-6123-4121-bd99-a76a4430bfdd)
![2025-01-31_14-37-34](https://github.com/user-attachments/assets/2b1e685d-bbdd-4a74-b4d4-7154c2e0184f)

https://github.com/user-attachments/assets/f34c6044-b223-4e54-b0e5-cb9cfc47430e


