### PR TITLE
widget: make mastering mixology overlay movable

### DIFF
--- a/runelite-api/src/main/interfaces/interfaces.toml
+++ b/runelite-api/src/main/interfaces/interfaces.toml
@@ -531,6 +531,10 @@ looting_bag_inventory=5
 [lunar_chest]
 id=868
 
+[mastering_mixology]
+id=882
+container=0
+
 [minimap]
 id=160
 container=0

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/WidgetOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/WidgetOverlay.java
@@ -107,7 +107,8 @@ public class WidgetOverlay extends Overlay
 			new WidgetOverlay(client, ComponentID.STRANGLER_OVERLAY, "STRANGLER_INFECTION_OVERLAY", OverlayPosition.TOP_LEFT),
 			new WidgetOverlay(client, ComponentID.SANITY_OVERLAY, "SANITY_OVERLAY", OverlayPosition.TOP_LEFT),
 			new WidgetOverlay(client, ComponentID.MOONS_OF_PERIL_LAYER, "MOONS_OF_PERIL", OverlayPosition.BOTTOM_RIGHT),
-			new WidgetOverlay(client, ComponentID.MLM_LAYER, "MLM_LAYER", OverlayPosition.TOP_LEFT)
+			new WidgetOverlay(client, ComponentID.MLM_LAYER, "MLM_LAYER", OverlayPosition.TOP_LEFT),
+			new WidgetOverlay(client, ComponentID.MASTERING_MIXOLOGY_CONTAINER, "MASTERING_MIXOLOGY", OverlayPosition.TOP_LEFT)
 		);
 	}
 


### PR DESCRIPTION
i don't know what the naming scheme actually is for `interfaces.toml`, i called it `container` because when I tried moving only the child widget, it was contained and couldn't be moved outside of that area.

![java_2025-02-02_23-01-08](https://github.com/user-attachments/assets/6b225b56-fa07-48ba-a5a2-8b88514c5f7c)
