### PR TITLE
item prices: Only show GE price for tradeable items

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemprices/ItemPricesPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemprices/ItemPricesPlugin.java
@@ -233,7 +233,7 @@ public class ItemPricesPlugin extends Plugin
 		int haProfit = 0;
 		final int itemHaPrice = itemDef.getHaPrice();
 
-		if (config.showGEPrice())
+		if (config.showGEPrice() && itemDef.isTradeable())
 		{
 			gePrice = itemManager.getItemPrice(id);
 		}


### PR DESCRIPTION
Previously the GE price would be shown for untradeable items. This change ensures GE prices are only shown when the item is actually tradeable. Contributes #18654 