### PR TITLE
party: add option to display name on tile ping

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/party/PartyConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/party/PartyConfig.java
@@ -61,10 +61,21 @@ public interface PartyConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "nameOnPingedTile",
+		name = "Name on ping",
+		description = "Displays the name of the user who pinged on the tile.",
+		position = 3
+	)
+	default boolean nameOnPingedTile()
+	{
+		return false;
+	}
+
+	@ConfigItem(
 		keyName = "recolorNames",
 		name = "Recolor names",
 		description = "Recolor party members names based on unique color hash.",
-		position = 3
+		position = 4
 	)
 	default boolean recolorNames()
 	{
@@ -76,7 +87,7 @@ public interface PartyConfig extends Config
 		name = "Ping hotkey",
 		description = "Key to hold to send a tile ping.<br>"
 			+ "To ping, hold the ping hotkey down and click on the tile you want to ping.",
-		position = 4
+		position = 5
 	)
 	default Keybind pingHotkey()
 	{
@@ -87,7 +98,7 @@ public interface PartyConfig extends Config
 		keyName = "memberColor",
 		name = "Self-color",
 		description = "Which color you will appear as in the party panel and tile pings.",
-		position = 5
+		position = 6
 	)
 	Color memberColor();
 
@@ -95,7 +106,7 @@ public interface PartyConfig extends Config
 		keyName = "memberColor",
 		name = "",
 		description = "",
-		position = 5
+		position = 7
 	)
 	void setMemberColor(Color newMemberColor);
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/party/PartyPingOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/party/PartyPingOverlay.java
@@ -32,6 +32,7 @@ import java.util.Iterator;
 import javax.inject.Inject;
 import net.runelite.api.Client;
 import net.runelite.api.Perspective;
+import net.runelite.api.Point;
 import net.runelite.api.coords.LocalPoint;
 import net.runelite.client.plugins.party.data.PartyTilePingData;
 import net.runelite.client.ui.overlay.Overlay;
@@ -42,12 +43,16 @@ class PartyPingOverlay extends Overlay
 {
 	private final Client client;
 	private final PartyPlugin plugin;
+	private final PartyConfig config;
+
+	private boolean renderNameOnTile;
 
 	@Inject
-	private PartyPingOverlay(final Client client, final PartyPlugin plugin)
+	private PartyPingOverlay(final Client client, final PartyPlugin plugin, final PartyConfig config)
 	{
 		this.client = client;
 		this.plugin = plugin;
+		this.config = config;
 		setPosition(OverlayPosition.DYNAMIC);
 	}
 
@@ -106,5 +111,23 @@ class PartyPingOverlay extends Overlay
 			ping.getAlpha());
 
 		OverlayUtil.renderPolygon(graphics, poly, color);
+
+		if (renderNameOnTile)
+		{
+			final String tileText = ping.getDisplayName();
+			if (tileText != null)
+			{
+				Point canvasTextLocation = Perspective.getCanvasTextLocation(client, graphics, localPoint, tileText, 0);
+				if (canvasTextLocation != null)
+				{
+					OverlayUtil.renderTextLocation(graphics, canvasTextLocation, tileText, color);
+				}
+			}
+		}
+	}
+
+	void updateConfig()
+	{
+		this.renderNameOnTile = config.nameOnPingedTile();
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/party/PartyPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/party/PartyPlugin.java
@@ -253,6 +253,7 @@ public class PartyPlugin extends Plugin
 		if (event.getGroup().equals(PartyConfig.GROUP))
 		{
 			partyStatusOverlay.updateConfig();
+			partyPingOverlay.updateConfig();
 			// rebuild the panel in the event the "Recolor names" option changes
 			SwingUtilities.invokeLater(panel::updateAll);
 		}
@@ -315,7 +316,7 @@ public class PartyPlugin extends Plugin
 		{
 			final PartyData partyData = getPartyData(event.getMemberId());
 			final Color color = partyData != null ? partyData.getColor() : Color.RED;
-			pendingTilePings.add(new PartyTilePingData(event.getPoint(), color));
+			pendingTilePings.add(new PartyTilePingData(event.getPoint(), color, client.getLocalPlayer().getName()));
 		}
 
 		if (config.sounds())

--- a/runelite-client/src/main/java/net/runelite/client/plugins/party/data/PartyTilePingData.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/party/data/PartyTilePingData.java
@@ -37,6 +37,7 @@ public class PartyTilePingData
 {
 	private final WorldPoint point;
 	private final Color color;
+	private final String displayName;
 	private int alpha = 255;
 	private final long creationTime = System.nanoTime();
 }


### PR DESCRIPTION
Config option (defaulted to off) to display name of the gamer who pinged a tile

![image](https://github.com/user-attachments/assets/e7ffd4ed-4c92-45c1-bca4-1dc020929333)

Note:
`renderTextLocation` does not support fading out as `renderPolygon` does

Config view:

![image](https://github.com/user-attachments/assets/68a16976-791a-4cc6-8eeb-97c99b2a01c3)