### PR TITLE
animation smoothing: Make some more misc animations not interpolatable

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/AnimationID.java
+++ b/runelite-api/src/main/java/net/runelite/api/AnimationID.java
@@ -360,6 +360,7 @@ public final class AnimationID
 
 	// POH Animations
 	public static final int INCENSE_BURNER = 3687;
+	public static final int PORTAL_NEXUS_SPIN = 367;
 
 	// Wyrms
 	public static final int WYRM_IDLE_DORMANT = 8266;
@@ -382,4 +383,8 @@ public final class AnimationID
 	public static final int GIANTS_FOUNDRY_WATER_WHEEL_SPINNING = 9450;
 
 	public static final int HUEYCOATL_DEATH = 11679;
+
+	public static final int SLAYER_TOWER_WATER_BUCKET_DRIP = 3558;
+
+	public static final int KEY_MASTER_IDLE = 4519;
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/animsmoothing/AnimationSmoothingPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/animsmoothing/AnimationSmoothingPlugin.java
@@ -85,6 +85,12 @@ public class AnimationSmoothingPlugin extends Plugin
 			case AnimationID.GIANTS_FOUNDRY_WATER_WHEEL_SPINNING:
 
 			case AnimationID.MAGIC_ARCEUUS_DEMONBANE:
+
+			case AnimationID.PORTAL_NEXUS_SPIN:
+
+			case AnimationID.SLAYER_TOWER_WATER_BUCKET_DRIP:
+
+			case AnimationID.KEY_MASTER_IDLE:
 				return false;
 
 			default:


### PR DESCRIPTION
Fixing some misc animations that shouldn't be loopable

- Slayer tower water bucket drip
- Portal nexus spin
  - Not sure if this is the same animation for all the portal nexus levels, this is just the one I have built
- Key master idle animation


https://github.com/user-attachments/assets/f33f1b1e-c104-47a9-a4eb-ff9dfd0c2a65


https://github.com/user-attachments/assets/863d6568-0b9c-4718-8c5d-49747d11cdc3


https://github.com/user-attachments/assets/19fc11fc-ad32-4bb6-8050-26518cccbac1

