### PR TITLE
Loot tracker: Record last menu option as metadata for Royal Titans

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
@@ -379,6 +379,7 @@ public class LootTrackerPlugin extends Plugin
 	private boolean lastLoadingIntoInstance;
 	private String lastPickpocketTarget;
 	private int lastNpcTypeTarget;
+	private String lastMenuOption;
 
 	private List<String> ignoredItems = new ArrayList<>();
 	private List<String> ignoredEvents = new ArrayList<>();
@@ -1232,6 +1233,7 @@ public class LootTrackerPlugin extends Plugin
 			}
 
 			NPC npc = event.getMenuEntry().getNpc();
+			lastMenuOption = event.getMenuOption();
 			lastNpcTypeTarget = npc != null ? npc.getId() : -1;
 		}
 		else if (isObjectOp(event.getMenuAction()) && event.getMenuOption().equals("Open") && SHADE_CHEST_OBJECTS.containsKey(event.getId()))
@@ -1357,7 +1359,14 @@ public class LootTrackerPlugin extends Plugin
 		if (region == ARAXXOR_LAIR && lastNpcTypeTarget == NpcID.ARAXXOR_13669
 			|| region == ROYAL_TITANS_REGION && (lastNpcTypeTarget == NpcID.BRANDA_THE_FIRE_QUEEN_14148 || lastNpcTypeTarget == NpcID.ELDRIC_THE_ICE_KING_14149))
 		{
-			Object metadata = region == ROYAL_TITANS_REGION ? client.getPlayers().size() : null;
+			Object metadata = null;
+			if (region == ROYAL_TITANS_REGION)
+			{
+				metadata = new ImmutableMap.Builder<String, Object>().
+					put("PLAYERS", client.getPlayers().size()).
+					put("OPTION", lastMenuOption).
+					build();
+			}
 			NPCComposition type = client.getNpcDefinition(lastNpcTypeTarget);
 			onInvChange(InventoryID.INVENTORY, collectInvAndGroundItems(LootRecordType.NPC, type.getName(), metadata), 4);
 			log.debug("Harvesting {}", type.getName());


### PR DESCRIPTION
Distinguish between "Loot" and "Take pages" option in metadata to figure out desiccated pages drop rates. Both get lumped together currently.

![image](https://github.com/user-attachments/assets/ca6772a7-77dc-46b6-9534-3c9545ccb985)
