### PR TITLE
gpu: regions: add asgarnia ice dungeon

### DIFF
--- a/runelite-client/src/main/resources/net/runelite/client/plugins/gpu/regions/regions.txt
+++ b/runelite-client/src/main/resources/net/runelite/client/plugins/gpu/regions/regions.txt
@@ -373,3 +373,13 @@ r 49 81
 // king black dragon lair
 n
 r 35 73
+
+// asgarnia ice dungeon
+n
+r 45 149
+r 46 149
+r 47 149
+m 48 149
+C 0 0 1 7
+m 47 150
+C 0 0 7 0


### PR DESCRIPTION
This PR concords the Asgarnia Ice Dungeon as GPU regions, for the GPU plugin.

<details>
  <summary>Before & after</summary>
  
![image](https://github.com/user-attachments/assets/2b35fc8c-5c5c-4d31-90f4-9a5ef92d94b5)
![image](https://github.com/user-attachments/assets/42b57d58-a011-4989-aaec-1e0782272557)
![image](https://github.com/user-attachments/assets/c71e3f66-0539-418b-9e4c-833977a20ee5)
![image](https://github.com/user-attachments/assets/cb099680-0f89-43e3-8009-0d72a9579dd2)
  
![image](https://github.com/user-attachments/assets/8aa0c8c3-6836-45a7-8e89-fddc2ac3146f)

</details>