### PR TITLE
loottracker: track Barbarian Assault high gamble rewards

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
@@ -148,6 +148,7 @@ public class LootTrackerPlugin extends Plugin
 	private static final int THEATRE_OF_BLOOD_LOBBY = 14642;
 	private static final int ARAXXOR_LAIR = 14489;
 	private static final int ROYAL_TITANS_REGION = 11669;
+	private static final int BA_LOBBY_REGION = 10039;
 
 	// Herbiboar loot handling
 	@VisibleForTesting
@@ -326,6 +327,8 @@ public class LootTrackerPlugin extends Plugin
 
 	private static final int FONT_OF_CONSUMPTION_REGION = 12106;
 	private static final String FONT_OF_CONSUMPTION_USE_MESSAGE = "You place the Unsired into the Font of Consumption...";
+
+	private static final String BA_HIGH_GAMBLE = "Barbarian Assault high gamble";
 
 	private static final Set<Character> VOWELS = ImmutableSet.of('a', 'e', 'i', 'o', 'u');
 
@@ -1175,6 +1178,14 @@ public class LootTrackerPlugin extends Plugin
 		if (regionID == FONT_OF_CONSUMPTION_REGION && message.equals(FONT_OF_CONSUMPTION_USE_MESSAGE))
 		{
 			onInvChange(collectInvItems(LootRecordType.EVENT, "Unsired"));
+		}
+
+		if (regionID == BA_LOBBY_REGION && chatType == ChatMessageType.MESBOX)
+		{
+			if (message.contains("High level gamble count:"))
+			{
+				onInvChange(collectInvAndGroundItems(LootRecordType.EVENT, BA_HIGH_GAMBLE));
+			}
 		}
 	}
 

--- a/runelite-client/src/test/java/net/runelite/client/plugins/loottracker/LootTrackerPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/loottracker/LootTrackerPluginTest.java
@@ -535,4 +535,22 @@ public class LootTrackerPluginTest
 			new ItemStack(ItemID.SANGUINESTI_STAFF_UNCHARGED, 1)
 		));
 	}
+
+	@Test
+	public void testBaHighGamble()
+	{
+		Player player = mock(Player.class);
+		when(player.getWorldLocation()).thenReturn(new WorldPoint(2534, 3572, 0));
+		when(client.getLocalPlayer()).thenReturn(player);
+
+		ChatMessage chatMessage = new ChatMessage(null, ChatMessageType.MESBOX, "", "Shark (x 114)! High level gamble count: <col=7f0000>3</col>.", "", 0);
+		lootTrackerPlugin.onChatMessage(chatMessage);
+
+		List<ItemStack> items = Collections.singletonList(
+			new ItemStack(ItemID.SHARK, 114)
+		);
+		sendInvChange(InventoryID.INVENTORY, items);
+
+		verify(lootTrackerPlugin).addLoot("Barbarian Assault high gamble", -1, LootRecordType.EVENT, null, items);
+	}
 }


### PR DESCRIPTION
Adds BA high gambles to the loot tracker.
Partially/mostly implements #11611 

Low and medium gambles aren't included here since there isn't an easy way to distinguish between the two, whereas high gambles have a unique message. As (to my knowledge) the significant majority of BA gambles are from people hunting the pet penance queen and are therefore high gambles, it seemed reasonable to not include low or medium gambles here.

Thanks to @samszotkowski and @coopermor for playing a fair amount of BA to test this.