### PR TITLE
api: use spliterator with unknown size

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/IndexedObjectSet.java
+++ b/runelite-api/src/main/java/net/runelite/api/IndexedObjectSet.java
@@ -41,7 +41,7 @@ public interface IndexedObjectSet<T> extends Iterable<T>
 	@Override
 	default Spliterator<T> spliterator()
 	{
-		return Spliterators.spliterator(this.iterator(), 0,
+		return Spliterators.spliteratorUnknownSize(this.iterator(),
 			Spliterator.DISTINCT | Spliterator.ORDERED);
 	}
 }


### PR DESCRIPTION
Sorting with the current spliterator is broken due to initial size being 0.