### PR TITLE
chat message manager: fix line break unapplying message color

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/chat/ChatMessageManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/chat/ChatMessageManager.java
@@ -196,7 +196,8 @@ public class ChatMessageManager
 			// Replace </col> tags in the message with the new color so embedded </col> won't reset the color
 			final Color color = chatColor.getColor();
 			message = ColorUtil.wrapWithColorTag(
-				message.replace(ColorUtil.CLOSING_COLOR_TAG, ColorUtil.colorTag(color)),
+				message.replace(ColorUtil.CLOSING_COLOR_TAG, ColorUtil.colorTag(color))
+					.replaceAll("<br>", "<br>" + ColorUtil.colorTag(color)),
 				color);
 			break;
 		}


### PR DESCRIPTION
This PR aims to fix message colors being unapplied due to them containing line breaks.

Example
![image](https://github.com/user-attachments/assets/af7e67f9-28b3-4d78-a79e-60e1039a446e)
The message `You are now a guest of RuneLite.<br>To talk, start each line of chat with /// or /gc.` is only partially colored up to the line break.

Reapplying the color tag correctly colors the full message:
![image](https://github.com/user-attachments/assets/285d4041-4341-44c0-b234-b72ab87996cc)
