### PR TITLE
loot tracker: capture unique wintertodt rewards

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
@@ -1164,7 +1164,7 @@ public class LootTrackerPlugin extends Plugin
 			return;
 		}
 
-		if (regionID == WINTERTODT_REGION && message.startsWith(WINTERTODT_LOOT_STRING))
+		if (regionID == WINTERTODT_REGION && message.contains(WINTERTODT_LOOT_STRING))
 		{
 			onInvChange(collectInvItems(LootRecordType.EVENT, WINTERTODT_REWARD_CART_EVENT, client.getBoostedSkillLevel(Skill.FIREMAKING)));
 			return;

--- a/runelite-client/src/test/java/net/runelite/client/plugins/loottracker/LootTrackerPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/loottracker/LootTrackerPluginTest.java
@@ -553,4 +553,54 @@ public class LootTrackerPluginTest
 
 		verify(lootTrackerPlugin).addLoot("Barbarian Assault high gamble", -1, LootRecordType.EVENT, null, items);
 	}
+
+	@Test
+	public void testWintertodtRewardCart()
+	{
+		Player player = mock(Player.class);
+		when(player.getWorldLocation()).thenReturn(new WorldPoint(1636, 3944, 0));
+		when(client.getLocalPlayer()).thenReturn(player);
+		when(client.getBoostedSkillLevel(Skill.FIREMAKING)).thenReturn(99);
+
+		doNothing().when(lootTrackerPlugin).addLoot(any(), anyInt(), any(), any(), anyCollection());
+
+		ItemContainer itemContainer = mock(ItemContainer.class);
+		when(itemContainer.getItems()).thenReturn(new Item[]{
+			new Item(ItemID.KNIFE, 1),
+			new Item(ItemID.BRUMA_TORCH, 1),
+			new Item(ItemID.HAMMER, 1)
+		});
+		when(client.getItemContainer(InventoryID.INVENTORY)).thenReturn(itemContainer);
+
+		ChatMessage chatMessage = new ChatMessage(null, ChatMessageType.SPAM, "", "<col=ef1020>You found some loot: 17 x Burnt page", "", 0);
+		lootTrackerPlugin.onChatMessage(chatMessage);
+
+		when(itemContainer.getItems()).thenReturn(new Item[]{
+			new Item(ItemID.BURNT_PAGE, 17),
+			new Item(ItemID.KNIFE, 1),
+			new Item(ItemID.BRUMA_TORCH, 1),
+			new Item(ItemID.HAMMER, 1)
+		});
+		lootTrackerPlugin.onItemContainerChanged(new ItemContainerChanged(InventoryID.INVENTORY.getId(), itemContainer));
+
+		verify(lootTrackerPlugin).addLoot("Reward cart (Wintertodt)", -1, LootRecordType.EVENT, 99, Collections.singletonList(
+			new ItemStack(ItemID.BURNT_PAGE, 17)
+		));
+
+		chatMessage = new ChatMessage(null, ChatMessageType.SPAM, "", "You found some loot: 4,694 x Coins", "", 0);
+		lootTrackerPlugin.onChatMessage(chatMessage);
+
+		when(itemContainer.getItems()).thenReturn(new Item[]{
+			new Item(ItemID.BURNT_PAGE, 17),
+			new Item(ItemID.COINS_995, 4694),
+			new Item(ItemID.KNIFE, 1),
+			new Item(ItemID.BRUMA_TORCH, 1),
+			new Item(ItemID.HAMMER, 1)
+		});
+		lootTrackerPlugin.onItemContainerChanged(new ItemContainerChanged(InventoryID.INVENTORY.getId(), itemContainer));
+
+		verify(lootTrackerPlugin).addLoot("Reward cart (Wintertodt)", -1, LootRecordType.EVENT, 99, Collections.singletonList(
+			new ItemStack(ItemID.COINS_995, 4694)
+		));
+	}
 }


### PR DESCRIPTION
This PR resolves an uncaught case within the loot tracker plugin, when collecting Wintertodt rewards.
A test for Wintertodt loot tracking was also added.

```
2025-02-23 15:40:07 CET [Client] DEBUG injected-client - Chat message type SPAM: <col=ef1020>You found some loot: 17 x Burnt page
2025-02-23 15:40:07 CET [Client] DEBUG n.r.c.p.l.LootTrackerPlugin - Inv change: [ItemStack(id=20718, quantity=17)] Ground items: []

2025-02-23 15:47:15 CET [Client] DEBUG injected-client - Chat message type SPAM: You found some loot: 4,694 x Coins
2025-02-23 15:47:15 CET [Client] DEBUG n.r.c.p.l.LootTrackerPlugin - Inv change: [ItemStack(id=995, quantity=4694)] Ground items: []
```

The reward message for rare loot is identical on both opaque and transparent chats.

<details>
  <summary>Spoiler</summary>
  
![image](https://github.com/user-attachments/assets/c5254d1b-1509-4ee4-bdbf-084009cabfab)
![image](https://github.com/user-attachments/assets/7684adb2-477e-42cc-b020-f2523099390c)

</details>

Fixes #18687 