### PR TITLE
chat message manager: apply color to clan name on broadcasts

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/chat/ChatMessageManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/chat/ChatMessageManager.java
@@ -205,6 +205,27 @@ public class ChatMessageManager
 		objectStack[osize - 2] = prefix + message;
 	}
 
+	void colorClanName(String callbackEvent)
+	{
+		final Object[] oStack = client.getObjectStack();
+		final int oSize = client.getObjectStackSize();
+
+		final Color clanNameColor = callbackEvent.equalsIgnoreCase("chatClanNameColor") ? chatColorConfig.transparentClanChannelName() : chatColorConfig.opaqueClanChannelName();
+		final Color clanGuestNameColor = callbackEvent.equalsIgnoreCase("chatClanNameColor") ? chatColorConfig.transparentClanChannelGuestName() : chatColorConfig.opaqueClanGuestChatChannelName();
+
+		String colorTag;
+		if (clanNameColor != null)
+		{
+			colorTag = ColorUtil.colorTag(clanNameColor);
+			oStack[oSize - 3] = colorTag;
+		}
+		if (clanGuestNameColor != null)
+		{
+			colorTag = ColorUtil.colorTag(clanGuestNameColor);
+			oStack[oSize - 1] = colorTag;
+		}
+	}
+
 	@Subscribe
 	public void onScriptCallbackEvent(ScriptCallbackEvent scriptCallbackEvent)
 	{
@@ -221,6 +242,10 @@ public class ChatMessageManager
 				break;
 			case "chatMessageBuilding":
 				colorChatMessage();
+				return;
+			case "chatClanNameColorDefault":
+			case "chatClanNameColor":
+				colorClanName(eventName);
 				return;
 			default:
 				return;

--- a/runelite-client/src/main/scripts/ChatBuilder.rs2asm
+++ b/runelite-client/src/main/scripts/ChatBuilder.rs2asm
@@ -42,11 +42,15 @@ LABEL30:
    iconst                 0
    istore                 5
    sconst                 "<col=004f00>"
-   ostore                 1
    sconst                 "<col=0000ff>"
-   ostore                 2
    sconst                 "<col=0000ff>"
+   sconst                 "<col=0000ff>"                ; Custom color added to guest clan name
+   sconst                 "chatClanNameColorDefault"    ; Callback set clan name colors opaque chat
+   runelite_callback
+   ostore                 26                            ; Store custom guest clan name color
    ostore                 3
+   ostore                 2
+   ostore                 1
    sconst                 ""
    ostore                 4
    sconst                 ""
@@ -89,6 +93,10 @@ LABEL74:
    sconst                 "<col=30ff30>"
    sconst                 "<col=9070ff>"
    sconst                 "<col=9070ff>"
+   sconst                 "<col=9070ff>"       ; Custom color added to guest clan name
+   sconst                 "chatClanNameColor"  ; Callback set clan name colors transparent chat
+   runelite_callback
+   ostore                 26                   ; Store custom guest clan name color
    ostore                 3
    ostore                 2
    ostore                 1
@@ -1089,7 +1097,7 @@ LABEL966:
 LABEL975:
    oload                  24
    sconst                 "["
-   oload                  2
+   oload                  26
    oload                  20
    sconst                 "</col>"
    sconst                 "]"
@@ -1123,7 +1131,7 @@ LABEL975:
 LABEL1008:
    oload                  24
    sconst                 "["
-   oload                  2
+   oload                  26
    oload                  20
    sconst                 "</col>"
    sconst                 "]"
@@ -1133,7 +1141,7 @@ LABEL1008:
    iconst                 -1
    iconst                 0
    iconst                 0
-   oload                  2
+   oload                  26
    oload                  23
    sconst                 "</col>"
    sconst                 " "
@@ -1166,7 +1174,7 @@ LABEL1045:
    ostore                 23
    oload                  24
    sconst                 "["
-   oload                  2
+   oload                  26
    oload                  20
    sconst                 "</col>"
    sconst                 "]"
@@ -1201,7 +1209,7 @@ LABEL1081:
 LABEL1082:
    oload                  24
    sconst                 "["
-   oload                  2
+   oload                  26
    oload                  20
    sconst                 "</col>"
    sconst                 "]"
@@ -1489,7 +1497,7 @@ LABEL1343:
 LABEL1347:
    oload                  24
    sconst                 "["
-   oload                  2
+   oload                  26
    activeclanchannel_getclanname
    sconst                 "</col>"
    sconst                 "]"


### PR DESCRIPTION
This PR fixes an discrepancy/bug regarding to the chat message manager's coloring of the clan name and guest clan name on broadcast type messages, currently the channel name is left uncolored, unlike for messages sent by players within these channels (see image 1 for reference).

The approach I opted for in solving this with was introducing a separate variable in the script to hold the guest channel name color. Though I don't know if this is ideal, it seemed like the most straightforward solution and it works as conceptualized. All feedback is welcome.

<details>
  <summary>Images</summary>
  
Image 1: Issue – The channel name is not colored for broadcast messages, as opposed to player sent messages.
![image](https://github.com/user-attachments/assets/9c52f5a2-2c34-449a-9275-3fd908e9d197)
  
Image 2: Post-fix result – The channel name is colored both at player-sent messages and broadcast messages.
![image](https://github.com/user-attachments/assets/91dcb6a0-1724-48e7-9401-e0f828327154)

</details>

I found that another PR for this issue exists #16523 but the author mentioned it to be incomplete, and I was unsure whether to 'build' on that or not given how different our solutions are, so this PR was made in its stead as a completed alternative.

Fixes #18768
Fixes #15933
Fixes #14061