### PR TITLE
timers: track prayer enhance effect using varbits

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/Varbits.java
+++ b/runelite-api/src/main/java/net/runelite/api/Varbits.java
@@ -897,6 +897,22 @@ public final class Varbits
 	 */
 	public static final int COX_OVERLOAD_REFRESHES_REMAINING = 5418;
 
+	/**
+	 * How many remaining prayer points the player will restore through the prayer enhance effect, in Chambers of Xeric.
+	 * <p>
+	 * This value is determined by the player's prayer level and will decrement
+	 * by 1 for every period of ticks set by {@link #COX_PRAYER_ENHANCE_PERIOD}.
+	 * Each period restores 1 prayer point.
+	 */
+	public static final int COX_PRAYER_ENHANCE_RESTORES_REMAINING = 5417;
+
+	/**
+	 * The interval, in ticks, for which {@link #COX_PRAYER_ENHANCE_RESTORES_REMAINING} is updated.
+	 * <p>
+	 * The value is determined by the player's prayer level.
+	 */
+	public static final int COX_PRAYER_ENHANCE_PERIOD = 5419;
+
 	public static final int SLAYER_POINTS = 4068;
 	public static final int SLAYER_TASK_STREAK = 4069;
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timersandbuffs/GameTimer.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timersandbuffs/GameTimer.java
@@ -58,7 +58,7 @@ enum GameTimer
 	VENGEANCE(SpriteID.SPELL_VENGEANCE, GameTimerImageType.SPRITE, "Vengeance", 30, ChronoUnit.SECONDS),
 	HEAL_GROUP(SpriteID.SPELL_HEAL_GROUP, GameTimerImageType.SPRITE, "Heal Group", 150, GAME_TICKS),
 	OVERLOAD_RAID(ItemID.RAIDS_VIAL_OVERLOAD_STRONG_4, GameTimerImageType.ITEM, "Overload", false),
-	PRAYER_ENHANCE(ItemID.RAIDS_VIAL_PRAYER_WEAK_4, GameTimerImageType.ITEM, "Prayer enhance", 290, ChronoUnit.SECONDS, true),
+	PRAYER_ENHANCE(ItemID.RAIDS_VIAL_PRAYER_WEAK_4, GameTimerImageType.ITEM, "Prayer enhance", false),
 	GOD_WARS_ALTAR(SpriteID.SKILL_PRAYER, GameTimerImageType.SPRITE, "God wars altar", false),
 	SCURRIUS_FOOD_PILE(ItemID.CHEESE, GameTimerImageType.ITEM, "Scurrius food pile", false),
 	CHARGE(SpriteID.SPELL_CHARGE, GameTimerImageType.SPRITE, "Charge", false),

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timersandbuffs/TimersAndBuffsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timersandbuffs/TimersAndBuffsPlugin.java
@@ -101,7 +101,6 @@ public class TimersAndBuffsPlugin extends Plugin
 	private static final String FROZEN_MESSAGE = "<col=ef1020>You have been frozen!</col>";
 	private static final String STAFF_OF_THE_DEAD_SPEC_EXPIRED_MESSAGE = "Your protection fades away";
 	private static final String STAFF_OF_THE_DEAD_SPEC_MESSAGE = "Spirits of deceased evildoers offer you their protection";
-	private static final String PRAYER_ENHANCE_EXPIRED = "<col=ff0000>Your prayer enhance effect has worn off.</col>";
 	private static final String SHADOW_VEIL_MESSAGE = ">Your thieving abilities have been enhanced.</col>";
 	private static final String RESURRECT_THRALL_MESSAGE_START = ">You resurrect a ";
 	private static final String RESURRECT_THRALL_MESSAGE_END = " thrall.</col>";
@@ -671,6 +670,12 @@ public class TimersAndBuffsPlugin extends Plugin
 		{
 			updateVarTimer(SURGE_POTION, event.getValue(), i -> i * 10);
 		}
+
+		if (event.getVarbitId() ==  VarbitID.RAIDS_PRAYERENHANCE_TIMER && config.showPrayerEnhance())
+		{
+			final int period = client.getVarbitValue(VarbitID.RAIDS_PRAYERENHANCE_RATE);
+			updateVarTimer(PRAYER_ENHANCE, event.getValue(), i -> i * period);
+		}
 	}
 
 	@Subscribe
@@ -979,16 +984,6 @@ public class TimersAndBuffsPlugin extends Plugin
 		{
 			removeGameTimer(CANNON);
 			removeGameTimer(CANNON_REPAIR);
-		}
-
-		if (message.startsWith("You drink some of your") && message.contains("prayer enhance") && config.showPrayerEnhance())
-		{
-			createGameTimer(PRAYER_ENHANCE);
-		}
-
-		if (message.equals(PRAYER_ENHANCE_EXPIRED) && config.showPrayerEnhance())
-		{
-			removeGameTimer(PRAYER_ENHANCE);
 		}
 
 		if (message.contains(STAFF_OF_THE_DEAD_SPEC_MESSAGE) && config.showStaffOfTheDead())


### PR DESCRIPTION
This PR migrates the tracking of the Prayer Enhance effect to rely on vars.

Very limited testing was done in game to see if this works. I only had the opportunity to use accounts with 99 prayer, but from what I was able to observe it worked as expected.

I did not add a test for this because the duration varies greatly depending on the effect/potion tier and the player's prayer level. And as the only accounts I had the ability to test this with, all had 99 prayer, I can only for certain know what a case with 99 prayer should produce. I am also not sure of the formula stated on the OSRS Wiki, since it doesn't 100% align with the results in game, so I refrained from relying on that. This [model](https://www.desmos.com/calculator/yqcnj7fjsy) is an approximation of the effect for the Prayer Enhance (+) potion, the other versions have different formulas when determining the periods and period lengths.

<details>
  <summary>Extra</summary>
  
Additional varbit which I didn't add but may be relevant/of interest for future reference:
```java
/**
 * The tier of prayer enhance potion the player was last affected by.
 *  0 = None
 *  1 = Prayer enhance (-)
 *  2 = Prayer enhance
 *  3 = Prayer enhance (+)
 */
 public static final int COX_PRAYER_ENHANCE_TIER = 12397;
```
</details>

Ref #16169 #18675 