### PR TITLE
NPC aggression timer: clear aggro lines when disengaging from flagged NPCs

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/npcunaggroarea/NpcAggroAreaPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npcunaggroarea/NpcAggroAreaPlugin.java
@@ -489,7 +489,7 @@ public class NpcAggroAreaPlugin extends Plugin
 					onLogin();
 				}
 
-				calculateLinesToDisplay();
+				scanNpcs();
 				break;
 
 			case LOGGING_IN:


### PR DESCRIPTION
Currently, once the area lines turn on they always stay active with this combination of settings:

![image](https://github.com/user-attachments/assets/3b732748-e07d-4736-949f-70f27dff4b82)

What I would expect with these settings is for the overlay to disappear when I am far away from any NPCs I've named + my current slayer task.

I've changed one line so that this now happens. Now upon teleporting away and stuff like that (game state > LOGGED_IN), it checks if it's supposed to continue showing lines.

It appears that Adam has gone back and forth on this line a handful of times (see commits around Feb 2024) so maybe he will have some thoughts on this.