### PR TITLE
notifier: check taskbar support before using it

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
@@ -905,6 +905,12 @@ public class ClientUI
 	 */
 	public void flashTaskbar()
 	{
+		if (!Taskbar.isTaskbarSupported())
+		{
+			log.debug("Taskbar is not supported on this platform");
+			return;
+		}
+
 		Taskbar taskbar = Taskbar.getTaskbar();
 		if (taskbar.isSupported(Taskbar.Feature.USER_ATTENTION_WINDOW))
 		{


### PR DESCRIPTION
Without checking taskbar support first, [Taskbar.getTaskbar()](https://docs.oracle.com/en/java/javase/11/docs/api/java.desktop/java/awt/Taskbar.html#getTaskbar()) will throw `UnsupportedOperationException` on platforms that don't support it (Linux skill issue)

```
2025-03-11 19:55:49 EET [Client] WARN  n.runelite.client.eventbus.EventBus - Uncaught exception in event subscriber
java.lang.UnsupportedOperationException: Taskbar API is not supported on the current platform
    at java.desktop/java.awt.Taskbar.getTaskbar(Taskbar.java:217)
    at net.runelite.client.ui.ClientUI.flashTaskbar(ClientUI.java:908)
    at net.runelite.client.Notifier.notify(Notifier.java:197)
    at net.runelite.client.plugins.idlenotifier.IdleNotifierPlugin.onGameTick(IdleNotifierPlugin.java:561)
    at net.runelite.client.eventbus.EventBus$Subscriber.invoke(EventBus.java:70)
    at net.runelite.client.eventbus.EventBus.post(EventBus.java:223)
    at net.runelite.client.callback.Hooks.tick(Hooks.java:223)
    at client.zt(client.java:21803)
    at client.by(client.java)
    at bk.ap(bk.java:360)
    at bk.ao(bk.java)
    at bk.run(bk.java:24469)
    at java.base/java.lang.Thread.run(Thread.java:840)
```

This caused notifications with "Request focus" set to "Taskbar" to not fire at all.


Fix tested on Arch Linux with Sway
