### PR TITLE
client: add support for col closing tag in TextComponent

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/components/TextComponent.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/components/TextComponent.java
@@ -40,11 +40,10 @@ import net.runelite.client.ui.overlay.RenderableEntity;
 public class TextComponent implements RenderableEntity
 {
 	private static final Pattern COL_TAG_PATTERN = Pattern.compile("(<col=(?<color>[0-9a-fA-F]{2,6})>)|(</col>)");
-	private static final Color DEFAULT_COLOR = Color.WHITE;
 
 	private String text;
 	private Point position = new Point();
-	private Color color = DEFAULT_COLOR;
+	private Color color = Color.WHITE;
 	private boolean outline;
 	/**
 	 * The text font.
@@ -55,6 +54,7 @@ public class TextComponent implements RenderableEntity
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
+		Color originalColor = color;
 		Font originalFont = null;
 		if (font != null)
 		{
@@ -77,7 +77,7 @@ public class TextComponent implements RenderableEntity
 			width += fontMetrics.stringWidth(s);
 
 			String color = matcher.group("color");
-			textColor = color != null ? Color.decode("#" + color) : DEFAULT_COLOR;
+			textColor = color != null ? Color.decode("#" + color) : originalColor;
 		}
 
 		{

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/components/TextComponent.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/components/TextComponent.java
@@ -39,11 +39,12 @@ import net.runelite.client.ui.overlay.RenderableEntity;
 @Setter
 public class TextComponent implements RenderableEntity
 {
-	private static final Pattern COL_TAG_PATTERN = Pattern.compile("<col=([0-9a-fA-F]{2,6})>");
+	private static final Pattern COL_TAG_PATTERN = Pattern.compile("(<col=(?<color>[0-9a-fA-F]{2,6})>)|(</col>)");
+	private static final Color DEFAULT_COLOR = Color.WHITE;
 
 	private String text;
 	private Point position = new Point();
-	private Color color = Color.WHITE;
+	private Color color = DEFAULT_COLOR;
 	private boolean outline;
 	/**
 	 * The text font.
@@ -69,14 +70,14 @@ public class TextComponent implements RenderableEntity
 		int width = 0;
 		while (matcher.find())
 		{
-			String color = matcher.group(1);
 			String s = text.substring(idx, matcher.start());
 			idx = matcher.end();
 
 			renderText(graphics, textColor, position.x + width, position.y, s);
 			width += fontMetrics.stringWidth(s);
 
-			textColor = Color.decode("#" + color);
+			String color = matcher.group("color");
+			textColor = color != null ? Color.decode("#" + color) : DEFAULT_COLOR;
 		}
 
 		{

--- a/runelite-client/src/test/java/net/runelite/client/ui/overlay/components/TextComponentTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/ui/overlay/components/TextComponentTest.java
@@ -104,4 +104,67 @@ public class TextComponentTest
 		g.verify(graphics).setColor(Color.BLUE);
 		g.verify(graphics).drawString(eq("test2"), anyInt(), anyInt());
 	}
+
+	@Test
+	public void testRenderWithUnclosedColorTags()
+	{
+		TextComponent textComponent = new TextComponent();
+		textComponent.setText("white<col=ff0000>red<col=00ff00>green<col=0000ff>blue");
+		textComponent.render(graphics);
+
+		InOrder g = inOrder(graphics);
+		g.verify(graphics).setColor(Color.BLACK);
+		g.verify(graphics).drawString(eq("white"), anyInt(), anyInt());
+		g.verify(graphics).setColor(Color.WHITE);
+		g.verify(graphics).drawString(eq("white"), anyInt(), anyInt());
+
+		g.verify(graphics).setColor(Color.BLACK);
+		g.verify(graphics).drawString(eq("red"), anyInt(), anyInt());
+		g.verify(graphics).setColor(Color.RED);
+		g.verify(graphics).drawString(eq("red"), anyInt(), anyInt());
+
+		g.verify(graphics).setColor(Color.BLACK);
+		g.verify(graphics).drawString(eq("green"), anyInt(), anyInt());
+		g.verify(graphics).setColor(Color.GREEN);
+		g.verify(graphics).drawString(eq("green"), anyInt(), anyInt());
+
+		g.verify(graphics).setColor(Color.BLACK);
+		g.verify(graphics).drawString(eq("blue"), anyInt(), anyInt());
+		g.verify(graphics).setColor(Color.BLUE);
+		g.verify(graphics).drawString(eq("blue"), anyInt(), anyInt());
+	}
+
+	@Test
+	public void testRenderResetsToDefaultColor()
+	{
+		TextComponent textComponent = new TextComponent();
+		textComponent.setText("<col=ff0000>red</col>white<col=00ff00>green");
+		textComponent.render(graphics);
+
+		InOrder g = inOrder(graphics);
+		g.verify(graphics).setColor(Color.BLACK);
+		g.verify(graphics).drawString(eq("red"), anyInt(), anyInt());
+		g.verify(graphics).setColor(Color.RED);
+		g.verify(graphics).drawString(eq("red"), anyInt(), anyInt());
+
+		g.verify(graphics).setColor(Color.BLACK);
+		g.verify(graphics).drawString(eq("white"), anyInt(), anyInt());
+		g.verify(graphics).setColor(Color.WHITE);
+		g.verify(graphics).drawString(eq("white"), anyInt(), anyInt());
+
+		g.verify(graphics).setColor(Color.BLACK);
+		g.verify(graphics).drawString(eq("green"), anyInt(), anyInt());
+		g.verify(graphics).setColor(Color.GREEN);
+		g.verify(graphics).drawString(eq("green"), anyInt(), anyInt());
+	}
+
+	@Test
+	public void testRenderWithIsolatedClosingTag()
+	{
+		TextComponent textComponent = new TextComponent();
+		textComponent.setText("test1</col>test2");
+		textComponent.render(graphics);
+		verify(graphics, times(2)).drawString(eq("test1"), anyInt(), anyInt());
+		verify(graphics, times(2)).drawString(eq("test2"), anyInt(), anyInt());
+	}
 }

--- a/runelite-client/src/test/java/net/runelite/client/ui/overlay/components/TextComponentTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/ui/overlay/components/TextComponentTest.java
@@ -138,7 +138,8 @@ public class TextComponentTest
 	public void testRenderResetsToDefaultColor()
 	{
 		TextComponent textComponent = new TextComponent();
-		textComponent.setText("<col=ff0000>red</col>white<col=00ff00>green");
+		textComponent.setText("<col=ff0000>red</col>original<col=00ff00>green");
+		textComponent.setColor(Color.BLUE);
 		textComponent.render(graphics);
 
 		InOrder g = inOrder(graphics);
@@ -148,9 +149,9 @@ public class TextComponentTest
 		g.verify(graphics).drawString(eq("red"), anyInt(), anyInt());
 
 		g.verify(graphics).setColor(Color.BLACK);
-		g.verify(graphics).drawString(eq("white"), anyInt(), anyInt());
-		g.verify(graphics).setColor(Color.WHITE);
-		g.verify(graphics).drawString(eq("white"), anyInt(), anyInt());
+		g.verify(graphics).drawString(eq("original"), anyInt(), anyInt());
+		g.verify(graphics).setColor(Color.BLUE);
+		g.verify(graphics).drawString(eq("original"), anyInt(), anyInt());
 
 		g.verify(graphics).setColor(Color.BLACK);
 		g.verify(graphics).drawString(eq("green"), anyInt(), anyInt());


### PR DESCRIPTION
Add support for the `</col>` tag in the `TextComponent` UI element.

The changes are backwards-compatible and so existing usages should continue to work as expected, unless they unintentionally included a `</col>` tag. If a `</col>` tag is included then the text color gets reset to the original color. So for example:

```
final TextComponent textComponent = new TextComponent();
textComponent.setColor(Color.Red);
textComponent.setText("foo <col=00ff00>bar</col> tee");
textComponent.render(graphics);
```

Will be rendered as $${\color{red}foo }{\color{green}bar}{\color{red} tee}$$

Related issue: #18626 