### PR TITLE
mining: Add calcified rock IDs

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/mining/MiningPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/mining/MiningPlugin.java
@@ -309,6 +309,8 @@ public class MiningPlugin extends Plugin
 				case DEPLETED_VEIN: // Gold vein
 				case ROCKS_51486: // Calcified rock
 				case ROCKS_51488: // Calcified rock
+				case ROCKS_51490: // Calcified rock
+				case ROCKS_51492: // Calcified rock
 				{
 					addRockRespawn(Rock.ORE_VEIN, WorldPoint.fromCoord(locCoord), ticks);
 					break;


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/c4df5c1b-964a-45bb-b210-082464fea5d1)

Variants 3 and 4 of calcified rocks were missing from mining plugin, meaning despawn timer would not show up when depleted