### PR TITLE
fix(mouse-highlight): prevent tooltips from appearing over minimap

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/mousehighlight/MouseHighlightOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/mousehighlight/MouseHighlightOverlay.java
@@ -33,8 +33,11 @@ import javax.inject.Inject;
 import net.runelite.api.Client;
 import net.runelite.api.MenuAction;
 import net.runelite.api.MenuEntry;
+import net.runelite.api.Point;
 import net.runelite.api.VarClientInt;
+import net.runelite.api.geometry.RectangleUnion.Rectangle;
 import net.runelite.api.widgets.InterfaceID;
+import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetUtil;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
@@ -90,88 +93,105 @@ class MouseHighlightOverlay extends Overlay
 	}
 
 	@Override
-	public Dimension render(Graphics2D graphics)
+public Dimension render(Graphics2D graphics)
+{
+	if (client.isMenuOpen())
 	{
-		if (client.isMenuOpen())
-		{
-			return null;
-		}
-
-		MenuEntry[] menuEntries = client.getMenuEntries();
-		int last = menuEntries.length - 1;
-
-		if (last < 0)
-		{
-			return null;
-		}
-
-		MenuEntry menuEntry = menuEntries[last];
-		String target = menuEntry.getTarget();
-		String option = menuEntry.getOption();
-		MenuAction type = menuEntry.getType();
-
-		if (type == MenuAction.RUNELITE_OVERLAY || type == MenuAction.CC_OP_LOW_PRIORITY)
-		{
-			// These are always right click only
-			return null;
-		}
-
-		if (Strings.isNullOrEmpty(option))
-		{
-			return null;
-		}
-
-		// Trivial options that don't need to be highlighted, add more as they appear.
-		switch (option)
-		{
-			case "Walk here":
-			case "Cancel":
-			case "Continue":
-				return null;
-			case "Move":
-				// Hide overlay on sliding puzzle boxes
-				if (target.contains("Sliding piece"))
-				{
-					return null;
-				}
-		}
-
-		if (WIDGET_MENU_ACTIONS.contains(type))
-		{
-			final int widgetId = menuEntry.getParam1();
-			final int groupId = WidgetUtil.componentToInterface(widgetId);
-
-			if (!config.uiTooltip())
-			{
-				return null;
-			}
-
-			if (!config.chatboxTooltip() && groupId == InterfaceID.CHATBOX)
-			{
-				return null;
-			}
-
-			if (config.disableSpellbooktooltip() && groupId == InterfaceID.SPELLBOOK)
-			{
-				return null;
-			}
-		}
-
-		// If this varc is set, a tooltip will be displayed soon
-		int tooltipTimeout = client.getVarcIntValue(VarClientInt.TOOLTIP_TIMEOUT);
-		if (tooltipTimeout > client.getGameCycle())
-		{
-			return null;
-		}
-
-		// If this varc is set, a tooltip is already being displayed
-		int tooltipDisplayed = client.getVarcIntValue(VarClientInt.TOOLTIP_VISIBLE);
-		if (tooltipDisplayed == 1)
-		{
-			return null;
-		}
-
-		tooltipManager.addFront(new Tooltip(option + (Strings.isNullOrEmpty(target) ? "" : " " + target)));
 		return null;
 	}
+
+	// Get mouse position
+	Point mousePos = client.getMouseCanvasPosition();
+
+	// Get minimap widget bounds
+	Widget minimapWidget = client.getWidget(InterfaceID.MINIMAP);
+
+	if (minimapWidget != null)
+	{
+		Rectangle minimapBounds = minimapWidget.getBounds();
+		
+		// If the mouse is inside the minimap, don't display the highlight
+		if (minimapBounds.contains(mousePos.getX(), mousePos.getY()))
+		{
+			return null;
+		}
+	}
+
+	MenuEntry[] menuEntries = client.getMenuEntries();
+	int last = menuEntries.length - 1;
+
+	if (last < 0)
+	{
+		return null;
+	}
+
+	MenuEntry menuEntry = menuEntries[last];
+	String target = menuEntry.getTarget();
+	String option = menuEntry.getOption();
+	MenuAction type = menuEntry.getType();
+
+	if (type == MenuAction.RUNELITE_OVERLAY || type == MenuAction.CC_OP_LOW_PRIORITY)
+	{
+		// These are always right-click only
+		return null;
+	}
+
+	if (Strings.isNullOrEmpty(option))
+	{
+		return null;
+	}
+
+	// Trivial options that don't need to be highlighted
+	switch (option)
+	{
+		case "Walk here":
+		case "Cancel":
+		case "Continue":
+			return null;
+		case "Move":
+			// Hide overlay on sliding puzzle boxes
+			if (target.contains("Sliding piece"))
+			{
+				return null;
+			}
+	}
+
+	if (WIDGET_MENU_ACTIONS.contains(type))
+	{
+		final int widgetId = menuEntry.getParam1();
+		final int groupId = WidgetUtil.componentToInterface(widgetId);
+
+		if (!config.uiTooltip())
+		{
+			return null;
+		}
+
+		if (!config.chatboxTooltip() && groupId == InterfaceID.CHATBOX)
+		{
+			return null;
+		}
+
+		if (config.disableSpellbooktooltip() && groupId == InterfaceID.SPELLBOOK)
+		{
+			return null;
+		}
+	}
+
+	// If this varc is set, a tooltip will be displayed soon
+	int tooltipTimeout = client.getVarcIntValue(VarClientInt.TOOLTIP_TIMEOUT);
+	if (tooltipTimeout > client.getGameCycle())
+	{
+		return null;
+	}
+
+	// If this varc is set, a tooltip is already being displayed
+	int tooltipDisplayed = client.getVarcIntValue(VarClientInt.TOOLTIP_VISIBLE);
+	if (tooltipDisplayed == 1)
+	{
+		return null;
+	}
+
+	tooltipManager.addFront(new Tooltip(option + (Strings.isNullOrEmpty(target) ? "" : " " + target)));
+	return null;
+ }
 }


### PR DESCRIPTION
This PR modifies the `MouseHighlightOverlay` to prevent tooltips from appearing over the minimap.

- Added minimap boundary detection.
- Used `client.getWidget(InterfaceID.MINIMAP)` to get minimap bounds.
- Compared `client.getMouseCanvasPosition()` against minimap bounds.
- Tooltips are now prevented from appearing when the mouse is inside the minimap.

### How to Test:
1. Enable the **Mouse Highlight Plugin**.
2. Move the cursor **inside** the minimap – **no tooltip should appear**.
3. Move the cursor **outside** the minimap – tooltips should appear normally.

Closes #14760 