### PR TITLE
#14760 Fix Mouse Highlight Overlay Compilation Errors

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/mousehighlight/MouseHighlightOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/mousehighlight/MouseHighlightOverlay.java
@@ -112,13 +112,14 @@ public Dimension render(Graphics2D graphics)
 		Rectangle minimapBounds = new Rectangle(awtBounds.x, awtBounds.y, awtBounds.width, awtBounds.height);
 
 		// If the mouse is inside the minimap, don't display the highlight
-		if (mousePos.getX() >= minimapBounds.x1 &&
-			mousePos.getX() <= minimapBounds.x2 &&
-			mousePos.getY() >= minimapBounds.y1 &&
-			mousePos.getY() <= minimapBounds.y2)
+		if (mousePos.getX() >= minimapBounds.getX1() &&
+			mousePos.getX() <= minimapBounds.getX2() &&
+			mousePos.getY() >= minimapBounds.getY1() &&
+			mousePos.getY() <= minimapBounds.getY2())
 		{
 			return null;
 		}
+
 
 	}
 	MenuEntry[] menuEntries = client.getMenuEntries();

--- a/runelite-client/src/main/java/net/runelite/client/plugins/mousehighlight/MouseHighlightOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/mousehighlight/MouseHighlightOverlay.java
@@ -108,15 +108,18 @@ public Dimension render(Graphics2D graphics)
 
 	if (minimapWidget != null)
 	{
-		Rectangle minimapBounds = minimapWidget.getBounds();
-		
+		java.awt.Rectangle awtBounds = minimapWidget.getBounds();
+		Rectangle minimapBounds = new Rectangle(awtBounds.x, awtBounds.y, awtBounds.width, awtBounds.height);
+
 		// If the mouse is inside the minimap, don't display the highlight
-		if (minimapBounds.contains(mousePos.getX(), mousePos.getY()))
+		if (mousePos.getX() >= minimapBounds.getX() &&
+			mousePos.getX() <= minimapBounds.getX() + minimapBounds.getWidth() &&
+			mousePos.getY() >= minimapBounds.getY() &&
+			mousePos.getY() <= minimapBounds.getY() + minimapBounds.getHeight())
 		{
 			return null;
 		}
 	}
-
 	MenuEntry[] menuEntries = client.getMenuEntries();
 	int last = menuEntries.length - 1;
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/mousehighlight/MouseHighlightOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/mousehighlight/MouseHighlightOverlay.java
@@ -112,13 +112,14 @@ public Dimension render(Graphics2D graphics)
 		Rectangle minimapBounds = new Rectangle(awtBounds.x, awtBounds.y, awtBounds.width, awtBounds.height);
 
 		// If the mouse is inside the minimap, don't display the highlight
-		if (mousePos.getX() >= minimapBounds.getX() &&
-			mousePos.getX() <= minimapBounds.getX() + minimapBounds.getWidth() &&
-			mousePos.getY() >= minimapBounds.getY() &&
-			mousePos.getY() <= minimapBounds.getY() + minimapBounds.getHeight())
+		if (mousePos.getX() >= minimapBounds.x1 &&
+			mousePos.getX() <= minimapBounds.x2 &&
+			mousePos.getY() >= minimapBounds.y1 &&
+			mousePos.getY() <= minimapBounds.y2)
 		{
 			return null;
 		}
+
 	}
 	MenuEntry[] menuEntries = client.getMenuEntries();
 	int last = menuEntries.length - 1;


### PR DESCRIPTION
This PR resolves compilation issues in MouseHighlightOverlay.java related to:

1. Type Mismatch: Converted java.awt.Rectangle to net.runelite.api.geometry.RectangleUnion.Rectangle to match expected types.
2. Method Error: Replaced .contains(int, int) with a manual boundary check, ensuring compatibility with RectangleUnion.Rectangle.

- Changes Made:
- Updated minimap widget bounds conversion to use new Rectangle(x, y, width, height).
- Replaced contains() with manual boundary checking for mouse position.
- Ensured the highlight does not appear when the mouse is over the minimap.
- 

Testing:
- Successfully compiles without errors.
- Expected behavior: The overlay properly highlights elements except when inside the minimap.

Notes:
If further issues arise, we may need to check RectangleUnion.Rectangle for additional helper methods.
Open to any feedback on better handling of bounds conversion.