### PR TITLE
Add configurable infobox overlay color

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/config/RuneLiteConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/RuneLiteConfig.java
@@ -414,7 +414,7 @@ public interface RuneLiteConfig extends Config
 	@ConfigItem(
 		keyName = "overlayBackgroundColor",
 		name = "Overlay color",
-		description = "Configures the background color of infoboxes and overlays.",
+		description = "Configures the background color of overlays.",
 		position = 44,
 		section = overlaySettings
 	)
@@ -423,11 +423,24 @@ public interface RuneLiteConfig extends Config
 		return ComponentConstants.STANDARD_BACKGROUND_COLOR;
 	}
 
+	@Alpha
+	@ConfigItem(
+			keyName = "infoBoxOverlayBackgroundColor",
+			name = "Infobox overlay color",
+			description = "Configures the background color of infobox overlays.",
+			position = 45,
+			section = overlaySettings
+	)
+	default Color infoBoxOverlayBackgroundColor()
+	{
+		return ComponentConstants.STANDARD_BACKGROUND_COLOR;
+	}
+
 	@ConfigItem(
 		keyName = "sidebarToggleKey",
 		name = "Sidebar toggle key",
 		description = "The key that will toggle the sidebar (accepts modifiers).",
-		position = 45,
+		position = 46,
 		section = windowSettings
 	)
 	default Keybind sidebarToggleKey()
@@ -439,7 +452,7 @@ public interface RuneLiteConfig extends Config
 		keyName = "panelToggleKey",
 		name = "Plugin panel toggle key",
 		description = "The key that will toggle the current or last opened plugin panel (accepts modifiers).",
-		position = 46,
+		position = 47,
 		section = windowSettings
 	)
 	default Keybind panelToggleKey()

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayManager.java
@@ -48,6 +48,7 @@ import net.runelite.client.config.RuneLiteConfig;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.events.ConfigChanged;
 import net.runelite.client.events.ProfileChanged;
+import net.runelite.client.ui.overlay.infobox.InfoBoxOverlay;
 
 /**
  * Manages state of all game overlays
@@ -350,7 +351,12 @@ public class OverlayManager
 
 	private void updateOverlayConfig(final Overlay overlay)
 	{
-		if (overlay instanceof OverlayPanel)
+		if (overlay instanceof InfoBoxOverlay)
+		{
+			// Update preferred color for infobox overlay panels based on configuration
+			((InfoBoxOverlay) overlay).setPreferredColor(runeLiteConfig.infoBoxOverlayBackgroundColor());
+		}
+		else if (overlay instanceof OverlayPanel)
 		{
 			// Update preferred color for overlay panels based on configuration
 			((OverlayPanel) overlay).setPreferredColor(runeLiteConfig.overlayBackgroundColor());

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/infobox/InfoBoxOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/infobox/InfoBoxOverlay.java
@@ -125,7 +125,7 @@ public class InfoBoxOverlay extends OverlayPanel
 
 		final Font font = config.infoboxFontType().getFont();
 		final boolean infoBoxTextOutline = config.infoBoxTextOutline();
-		final Color overlayBackgroundColor = config.overlayBackgroundColor();
+		final Color overlayBackgroundColor = config.infoBoxOverlayBackgroundColor();
 		final Dimension preferredSize = new Dimension(config.infoBoxSize(), config.infoBoxSize());
 		for (InfoBox box : infoBoxes)
 		{


### PR DESCRIPTION
Closes #13585.

This adds support for configuring the overlay color specifically for infoboxes, separately from other types of panels.