### PR TITLE
slayer: add crabs task

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/Task.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/Task.java
@@ -72,6 +72,7 @@ enum Task
 	CHAOS_FANATIC("The Chaos Fanatic", ItemID.STAFF_OF_ZAROS),
 	COCKATRICE("Cockatrice", ItemID.SLAYERGUIDE_COCKATRICE, "Cockathrice"),
 	COWS("Cows", ItemID.COW_MASK),
+	CRABS("Crabs", ItemID.HUNDRED_PIRATE_CRAB_SHELL_CLAW, "Crab"),
 	CRAWLING_HANDS("Crawling hands", ItemID.SLAYERGUIDE_CRAWLINGHAND, "Crushing hand"),
 	CRAZY_ARCHAEOLOGIST("Crazy Archaeologists", ItemID.FEDORA),
 	CROCODILES("Crocodiles", ItemID.GREEN_SALAMANDER),


### PR DESCRIPTION
This PR adds crabs to tasks in for the slayer plugin, which was added with the [Poll 83 QoL Changes](https://secure.runescape.com/m=news/a=13/poll-83-qol-changes?oldschool=1) update.