### PR TITLE
Added Low Alchemy to Item Prices plugin

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemprices/ItemPricesConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemprices/ItemPricesConfig.java
@@ -32,10 +32,10 @@ import net.runelite.client.config.ConfigItem;
 public interface ItemPricesConfig extends Config
 {
 	@ConfigItem(
-			keyName = "showGEPrice",
-			name = "Show Grand Exchange prices",
-			description = "Grand Exchange prices should be shown on tooltips.",
-			position = 1
+		keyName = "showGEPrice",
+		name = "Show Grand Exchange prices",
+		description = "Grand Exchange prices should be shown on tooltips.",
+		position = 1
 	)
 	default boolean showGEPrice()
 	{
@@ -43,10 +43,10 @@ public interface ItemPricesConfig extends Config
 	}
 
 	@ConfigItem(
-			keyName = "showHAValue",
-			name = "Show high alchemy values",
-			description = "High alchemy values should be shown on tooltips.",
-			position = 2
+		keyName = "showHAValue",
+		name = "Show high alchemy values",
+		description = "High alchemy values should be shown on tooltips.",
+		position = 2
 	)
 	default boolean showHAValue()
 	{
@@ -55,10 +55,10 @@ public interface ItemPricesConfig extends Config
 
 
 	@ConfigItem(
-			keyName = "showLAValue",
-			name = "Show low alchemy values",
-			description = "Low alchemy values should be shown on tooltips.",
-			position = 3
+		keyName = "showLAValue",
+		name = "Show low alchemy values",
+		description = "Low alchemy values should be shown on tooltips.",
+		position = 3
 	)
 	default boolean showLAValue()
 	{
@@ -66,10 +66,10 @@ public interface ItemPricesConfig extends Config
 	}
 
 	@ConfigItem(
-			keyName = "showEA",
-			name = "Show price each on stacks",
-			description = "The price/value of each item should be shown on stacks.",
-			position = 4
+		keyName = "showEA",
+		name = "Show price each on stacks",
+		description = "The price/value of each item should be shown on stacks.",
+		position = 4
 	)
 	default boolean showEA()
 	{
@@ -77,10 +77,10 @@ public interface ItemPricesConfig extends Config
 	}
 
 	@ConfigItem(
-			keyName = "hideInventory",
-			name = "Hide tooltips on inventory items",
-			description = "Tooltips should be hidden on items in the inventory.",
-			position = 5
+		keyName = "hideInventory",
+		name = "Hide tooltips on inventory items",
+		description = "Tooltips should be hidden on items in the inventory.",
+		position = 5
 	)
 	default boolean hideInventory()
 	{
@@ -88,10 +88,10 @@ public interface ItemPricesConfig extends Config
 	}
 
 	@ConfigItem(
-			keyName = "showAlchProfit",
-			name = "Show high alchemy profit",
-			description = "Show the profit from casting high alchemy on items.",
-			position = 6
+		keyName = "showAlchProfit",
+		name = "Show high alchemy profit",
+		description = "Show the profit from casting high alchemy on items.",
+		position = 6
 	)
 	default boolean showAlchProfit()
 	{
@@ -99,10 +99,10 @@ public interface ItemPricesConfig extends Config
 	}
 
 	@ConfigItem(
-			keyName = "showWhileAlching",
-			name = "Show prices while alching",
-			description = "Show the price overlay while using high alchemy. Takes priority over 'Hide tooltips on inventory items'",
-			position = 7
+		keyName = "showWhileAlching",
+		name = "Show prices while alching",
+		description = "Show the price overlay while using high alchemy. Takes priority over 'Hide tooltips on inventory items'",
+		position = 7
 	)
 	default boolean showWhileAlching()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemprices/ItemPricesConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemprices/ItemPricesConfig.java
@@ -32,10 +32,10 @@ import net.runelite.client.config.ConfigItem;
 public interface ItemPricesConfig extends Config
 {
 	@ConfigItem(
-		keyName = "showGEPrice",
-		name = "Show Grand Exchange prices",
-		description = "Grand Exchange prices should be shown on tooltips.",
-		position = 1
+			keyName = "showGEPrice",
+			name = "Show Grand Exchange prices",
+			description = "Grand Exchange prices should be shown on tooltips.",
+			position = 1
 	)
 	default boolean showGEPrice()
 	{
@@ -43,21 +43,33 @@ public interface ItemPricesConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "showHAValue",
-		name = "Show high alchemy values",
-		description = "High alchemy values should be shown on tooltips.",
-		position = 2
+			keyName = "showHAValue",
+			name = "Show high alchemy values",
+			description = "High alchemy values should be shown on tooltips.",
+			position = 2
 	)
 	default boolean showHAValue()
 	{
 		return true;
 	}
 
+
 	@ConfigItem(
-		keyName = "showEA",
-		name = "Show price each on stacks",
-		description = "The price/value of each item should be shown on stacks.",
-		position = 3
+			keyName = "showLAValue",
+			name = "Show low alchemy values",
+			description = "Low alchemy values should be shown on tooltips.",
+			position = 3
+	)
+	default boolean showLAValue()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+			keyName = "showEA",
+			name = "Show price each on stacks",
+			description = "The price/value of each item should be shown on stacks.",
+			position = 4
 	)
 	default boolean showEA()
 	{
@@ -65,10 +77,10 @@ public interface ItemPricesConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "hideInventory",
-		name = "Hide tooltips on inventory items",
-		description = "Tooltips should be hidden on items in the inventory.",
-		position = 4
+			keyName = "hideInventory",
+			name = "Hide tooltips on inventory items",
+			description = "Tooltips should be hidden on items in the inventory.",
+			position = 5
 	)
 	default boolean hideInventory()
 	{
@@ -76,10 +88,10 @@ public interface ItemPricesConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "showAlchProfit",
-		name = "Show high alchemy profit",
-		description = "Show the profit from casting high alchemy on items.",
-		position = 5
+			keyName = "showAlchProfit",
+			name = "Show high alchemy profit",
+			description = "Show the profit from casting high alchemy on items.",
+			position = 6
 	)
 	default boolean showAlchProfit()
 	{
@@ -87,10 +99,10 @@ public interface ItemPricesConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "showWhileAlching",
-		name = "Show prices while alching",
-		description = "Show the price overlay while using high alchemy. Takes priority over 'Hide tooltips on inventory items'",
-		position = 6
+			keyName = "showWhileAlching",
+			name = "Show prices while alching",
+			description = "Show the price overlay while using high alchemy. Takes priority over 'Hide tooltips on inventory items'",
+			position = 7
 	)
 	default boolean showWhileAlching()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemprices/ItemPricesPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemprices/ItemPricesPlugin.java
@@ -48,10 +48,10 @@ import net.runelite.client.util.ColorUtil;
 import net.runelite.client.util.QuantityFormatter;
 
 @PluginDescriptor(
-		name = "Item Prices",
-		description = "Show prices on hover for items in your inventory and bank",
-		tags = {"bank", "inventory", "overlay", "high", "alchemy", "grand", "exchange", "tooltips"},
-		enabledByDefault = false
+	name = "Item Prices",
+	description = "Show prices on hover for items in your inventory and bank",
+	tags = {"bank", "inventory", "overlay", "high", "alchemy", "grand", "exchange", "tooltips"},
+	enabledByDefault = false
 )
 public class ItemPricesPlugin extends Plugin
 {
@@ -184,14 +184,14 @@ public class ItemPricesPlugin extends Plugin
 
 		// Inventory item
 		if (componentId == ComponentID.INVENTORY_CONTAINER ||
-				componentId == ComponentID.BANK_INVENTORY_ITEM_CONTAINER ||
-				componentId == ComponentID.EXPLORERS_RING_INVENTORY ||
-				componentId == ComponentID.SEED_VAULT_INVENTORY_ITEM_CONTAINER ||
-				componentId == ComponentID.POH_TREASURE_CHEST_INV_CONTAINER ||
-				// Bank item
-				componentId == ComponentID.BANK_ITEM_CONTAINER ||
-				// Seed vault item
-				componentId == ComponentID.SEED_VAULT_ITEM_CONTAINER
+			componentId == ComponentID.BANK_INVENTORY_ITEM_CONTAINER ||
+			componentId == ComponentID.EXPLORERS_RING_INVENTORY ||
+			componentId == ComponentID.SEED_VAULT_INVENTORY_ITEM_CONTAINER ||
+			componentId == ComponentID.POH_TREASURE_CHEST_INV_CONTAINER ||
+			// Bank item
+			componentId == ComponentID.BANK_ITEM_CONTAINER ||
+			// Seed vault item
+			componentId == ComponentID.SEED_VAULT_ITEM_CONTAINER
 		)
 		{
 			Widget w = menuEntry.getWidget();
@@ -267,13 +267,13 @@ public class ItemPricesPlugin extends Plugin
 		if (gePrice > 0)
 		{
 			itemStringBuilder.append("GE: ")
-					.append(QuantityFormatter.quantityToStackSize((long) gePrice * qty))
-					.append(" gp");
+				.append(QuantityFormatter.quantityToStackSize((long) gePrice * qty))
+				.append(" gp");
 			if (config.showEA() && qty > 1)
 			{
 				itemStringBuilder.append(" (")
-						.append(QuantityFormatter.quantityToStackSize(gePrice))
-						.append(" ea)");
+					.append(QuantityFormatter.quantityToStackSize(gePrice))
+					.append(" ea)");
 			}
 		}
 		if (haValue > 0)
@@ -284,13 +284,13 @@ public class ItemPricesPlugin extends Plugin
 			}
 
 			itemStringBuilder.append("HA: ")
-					.append(QuantityFormatter.quantityToStackSize((long) haValue * qty))
-					.append(" gp");
+				.append(QuantityFormatter.quantityToStackSize((long) haValue * qty))
+				.append(" gp");
 			if (config.showEA() && qty > 1)
 			{
 				itemStringBuilder.append(" (")
-						.append(QuantityFormatter.quantityToStackSize(haValue))
-						.append(" ea)");
+					.append(QuantityFormatter.quantityToStackSize(haValue))
+					.append(" ea)");
 			}
 		}
 		if (laValue > 0)
@@ -301,13 +301,13 @@ public class ItemPricesPlugin extends Plugin
 			}
 
 			itemStringBuilder.append("LA: ")
-					.append(QuantityFormatter.quantityToStackSize((long) laValue * qty))
-					.append(" gp");
+				.append(QuantityFormatter.quantityToStackSize((long) laValue * qty))
+				.append(" gp");
 			if (config.showEA() && qty > 1)
 			{
 				itemStringBuilder.append(" (")
-						.append(QuantityFormatter.quantityToStackSize(laValue))
-						.append(" ea)");
+					.append(QuantityFormatter.quantityToStackSize(laValue))
+					.append(" ea)");
 			}
 		}
 
@@ -317,13 +317,13 @@ public class ItemPricesPlugin extends Plugin
 
 			itemStringBuilder.append("</br>");
 			itemStringBuilder.append("HA Profit: ")
-					.append(ColorUtil.wrapWithColorTag(String.valueOf((long) haProfit * qty), haColor))
-					.append(" gp");
+				.append(ColorUtil.wrapWithColorTag(String.valueOf((long) haProfit * qty), haColor))
+				.append(" gp");
 			if (config.showEA() && qty > 1)
 			{
 				itemStringBuilder.append(" (")
-						.append(ColorUtil.wrapWithColorTag(String.valueOf(haProfit), haColor))
-						.append(" ea)");
+					.append(ColorUtil.wrapWithColorTag(String.valueOf(haProfit), haColor))
+					.append(" ea)");
 			}
 		}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemprices/ItemPricesPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemprices/ItemPricesPlugin.java
@@ -48,10 +48,10 @@ import net.runelite.client.util.ColorUtil;
 import net.runelite.client.util.QuantityFormatter;
 
 @PluginDescriptor(
-	name = "Item Prices",
-	description = "Show prices on hover for items in your inventory and bank",
-	tags = {"bank", "inventory", "overlay", "high", "alchemy", "grand", "exchange", "tooltips"},
-	enabledByDefault = false
+		name = "Item Prices",
+		description = "Show prices on hover for items in your inventory and bank",
+		tags = {"bank", "inventory", "overlay", "high", "alchemy", "grand", "exchange", "tooltips"},
+		enabledByDefault = false
 )
 public class ItemPricesPlugin extends Plugin
 {
@@ -174,8 +174,8 @@ public class ItemPricesPlugin extends Plugin
 
 	private String makeValueTooltip(MenuEntry menuEntry)
 	{
-		// Disabling both disables all value tooltips
-		if (!config.showGEPrice() && !config.showHAValue())
+		// Disabling all "show" options disables all value tooltips
+		if (!config.showGEPrice() && !config.showHAValue() && !config.showLAValue())
 		{
 			return null;
 		}
@@ -184,14 +184,14 @@ public class ItemPricesPlugin extends Plugin
 
 		// Inventory item
 		if (componentId == ComponentID.INVENTORY_CONTAINER ||
-			componentId == ComponentID.BANK_INVENTORY_ITEM_CONTAINER ||
-			componentId == ComponentID.EXPLORERS_RING_INVENTORY ||
-			componentId == ComponentID.SEED_VAULT_INVENTORY_ITEM_CONTAINER ||
-			componentId == ComponentID.POH_TREASURE_CHEST_INV_CONTAINER ||
-			// Bank item
-			componentId == ComponentID.BANK_ITEM_CONTAINER ||
-			// Seed vault item
-			componentId == ComponentID.SEED_VAULT_ITEM_CONTAINER
+				componentId == ComponentID.BANK_INVENTORY_ITEM_CONTAINER ||
+				componentId == ComponentID.EXPLORERS_RING_INVENTORY ||
+				componentId == ComponentID.SEED_VAULT_INVENTORY_ITEM_CONTAINER ||
+				componentId == ComponentID.POH_TREASURE_CHEST_INV_CONTAINER ||
+				// Bank item
+				componentId == ComponentID.BANK_ITEM_CONTAINER ||
+				// Seed vault item
+				componentId == ComponentID.SEED_VAULT_ITEM_CONTAINER
 		)
 		{
 			Widget w = menuEntry.getWidget();
@@ -230,8 +230,11 @@ public class ItemPricesPlugin extends Plugin
 
 		int gePrice = 0;
 		int haPrice = 0;
+		int laPrice = 0;
 		int haProfit = 0;
 		final int itemHaPrice = itemDef.getHaPrice();
+		final int itemLaPrice = (int) Math.ceil(itemHaPrice * 0.666666);
+
 
 		if (config.showGEPrice())
 		{
@@ -241,31 +244,36 @@ public class ItemPricesPlugin extends Plugin
 		{
 			haPrice = itemHaPrice;
 		}
+		if (config.showLAValue())
+		{
+			laPrice = itemLaPrice;
+		}
+
 		if (gePrice > 0 && itemHaPrice > 0 && config.showAlchProfit())
 		{
 			haProfit = calculateHAProfit(itemHaPrice, gePrice);
 		}
 
-		if (gePrice > 0 || haPrice > 0)
+		if (gePrice > 0 || haPrice > 0 || laPrice > 0)
 		{
-			return stackValueText(qty, gePrice, haPrice, haProfit);
+			return stackValueText(qty, gePrice, laPrice, haPrice, haProfit);
 		}
 
 		return null;
 	}
 
-	private String stackValueText(int qty, int gePrice, int haValue, int haProfit)
+	private String stackValueText(int qty, int gePrice, int laValue, int haValue, int haProfit)
 	{
 		if (gePrice > 0)
 		{
 			itemStringBuilder.append("GE: ")
-				.append(QuantityFormatter.quantityToStackSize((long) gePrice * qty))
-				.append(" gp");
+					.append(QuantityFormatter.quantityToStackSize((long) gePrice * qty))
+					.append(" gp");
 			if (config.showEA() && qty > 1)
 			{
 				itemStringBuilder.append(" (")
-					.append(QuantityFormatter.quantityToStackSize(gePrice))
-					.append(" ea)");
+						.append(QuantityFormatter.quantityToStackSize(gePrice))
+						.append(" ea)");
 			}
 		}
 		if (haValue > 0)
@@ -276,13 +284,30 @@ public class ItemPricesPlugin extends Plugin
 			}
 
 			itemStringBuilder.append("HA: ")
-				.append(QuantityFormatter.quantityToStackSize((long) haValue * qty))
-				.append(" gp");
+					.append(QuantityFormatter.quantityToStackSize((long) haValue * qty))
+					.append(" gp");
 			if (config.showEA() && qty > 1)
 			{
 				itemStringBuilder.append(" (")
-					.append(QuantityFormatter.quantityToStackSize(haValue))
-					.append(" ea)");
+						.append(QuantityFormatter.quantityToStackSize(haValue))
+						.append(" ea)");
+			}
+		}
+		if (laValue > 0)
+		{
+			if (gePrice > 0 || haValue > 0)
+			{
+				itemStringBuilder.append("</br>");
+			}
+
+			itemStringBuilder.append("LA: ")
+					.append(QuantityFormatter.quantityToStackSize((long) laValue * qty))
+					.append(" gp");
+			if (config.showEA() && qty > 1)
+			{
+				itemStringBuilder.append(" (")
+						.append(QuantityFormatter.quantityToStackSize(laValue))
+						.append(" ea)");
 			}
 		}
 
@@ -292,13 +317,13 @@ public class ItemPricesPlugin extends Plugin
 
 			itemStringBuilder.append("</br>");
 			itemStringBuilder.append("HA Profit: ")
-				.append(ColorUtil.wrapWithColorTag(String.valueOf((long) haProfit * qty), haColor))
-				.append(" gp");
+					.append(ColorUtil.wrapWithColorTag(String.valueOf((long) haProfit * qty), haColor))
+					.append(" gp");
 			if (config.showEA() && qty > 1)
 			{
 				itemStringBuilder.append(" (")
-					.append(ColorUtil.wrapWithColorTag(String.valueOf(haProfit), haColor))
-					.append(" ea)");
+						.append(ColorUtil.wrapWithColorTag(String.valueOf(haProfit), haColor))
+						.append(" ea)");
 			}
 		}
 


### PR DESCRIPTION
Tested and working as expected.
By default, low alchemy is set to disabled and must be enabled manually for those who wish to have it.
And this time around, removed the extra whitespace that was added.

![image](https://github.com/user-attachments/assets/c387343f-a844-4746-880c-dd382053c90c)
