### PR TITLE
menu swapper: add ferry option to travel swap

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -261,6 +261,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 		swap("talk-to", "miscellania", config::swapTravel);
 		swap("talk-to", "follow", config::swapTravel);
 		swap("talk-to", "transport", config::swapTravel);
+		swap("talk-to", "ferry", config::swapTravel);
 		swap("talk-to", "quick-travel", config::swapQuick);
 		swap("talk-to", ESSENCE_MINE_NPCS::contains, "teleport", config::swapEssenceMineTeleport);
 		swap("talk-to", "deposit-items", config::swapDepositItems);


### PR DESCRIPTION
This PR makes it so that the "Talk-to" menu option is swapped with "Ferry" when the _Travel_  config is enabled, under the NPC category.

The "Ferry" option is only available on two NPCs from what I could find; [Ferryman Sathwood](https://oldschool.runescape.wiki/w/Ferryman_Sathwood) and [Ferryman Nathwood](https://oldschool.runescape.wiki/w/Ferryman_Nathwood). These NPCs offer travel between [Al Kharid](https://oldschool.runescape.wiki/w/Al_Kharid) and the [Ruins of Unkah](https://oldschool.runescape.wiki/w/Ruins_of_Unkah).
<details>
  <summary>View NPC & their location</summary>

Ferryman Nathwood, in the Ruins of Unkah
![image](https://github.com/user-attachments/assets/778173bf-51ea-4e92-baa8-c8decd693d36)


Ferryman Sathwood, in Al Kharid
![image](https://github.com/user-attachments/assets/a571e51f-fd84-4b14-86da-03c0285600eb)
  
</details>