### PR TITLE
item stats: update castle wars brew

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatChanges.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatChanges.java
@@ -36,6 +36,7 @@ import net.runelite.client.plugins.itemstats.delta.DeltaPercentage;
 import net.runelite.client.plugins.itemstats.food.Anglerfish;
 import net.runelite.client.plugins.itemstats.food.CookedBream;
 import net.runelite.client.plugins.itemstats.food.CookedMossLizard;
+import net.runelite.client.plugins.itemstats.potions.CastleWarsBrew;
 import net.runelite.client.plugins.itemstats.special.SunlightMoth;
 import net.runelite.client.plugins.itemstats.potions.Ambrosia;
 import net.runelite.client.plugins.itemstats.potions.AncientBrew;
@@ -66,6 +67,7 @@ public class ItemStatChanges
 	public static final SingleEffect SUPER_ATTACK_POT = boost(ATTACK, perc(.15, 5));
 	public static final SingleEffect SUPER_STRENGTH_POT = boost(STRENGTH, perc(.15, 5));
 	public static final SingleEffect SUPER_DEFENCE_POT = boost(DEFENCE, perc(.15, 5));
+	public static final Effect SUPER_RESTORE_POT = new SuperRestore(.25, 8);
 
 	private void init()
 	{
@@ -241,8 +243,7 @@ public class ItemStatChanges
 		add(combo(SUPER_ATTACK_POT, SUPER_STRENGTH_POT, SUPER_DEFENCE_POT, divinePot), DIVINE_SUPER_COMBAT_POTION1, DIVINE_SUPER_COMBAT_POTION2, DIVINE_SUPER_COMBAT_POTION3, DIVINE_SUPER_COMBAT_POTION4);
 		add(combo(rangingPot, SUPER_DEFENCE_POT, divinePot), DIVINE_BASTION_POTION1, DIVINE_BASTION_POTION2, DIVINE_BASTION_POTION3, DIVINE_BASTION_POTION4);
 		add(combo(magicPot, SUPER_DEFENCE_POT, divinePot), DIVINE_BATTLEMAGE_POTION1, DIVINE_BATTLEMAGE_POTION2, DIVINE_BATTLEMAGE_POTION3, DIVINE_BATTLEMAGE_POTION4);
-		add(combo(SUPER_ATTACK_POT, SUPER_STRENGTH_POT, SUPER_DEFENCE_POT, rangingPot, imbuedHeart),
-			CASTLEWARS_BREW4, CASTLEWARS_BREW3, CASTLEWARS_BREW2, CASTLEWARS_BREW1);
+		add(new CastleWarsBrew(), CASTLEWARS_BREW4, CASTLEWARS_BREW3, CASTLEWARS_BREW2, CASTLEWARS_BREW1);
 		add(combo(SUPER_ATTACK_POT, SUPER_STRENGTH_POT),
 			SUPER_COMBAT_POTION4_23543, SUPER_COMBAT_POTION3_23545, SUPER_COMBAT_POTION2_23547, SUPER_COMBAT_POTION1_23549 /* LMS */);
 		add(ancientBrew, ANCIENT_BREW1, ANCIENT_BREW2, ANCIENT_BREW3, ANCIENT_BREW4);
@@ -277,14 +278,13 @@ public class ItemStatChanges
 		final Effect energyPot = heal(RUN_ENERGY, 10);
 		final SingleEffect prayerPot = new PrayerPotion(7);
 		final Effect superEnergyPot = heal(RUN_ENERGY, 20);
-		final Effect superRestorePot = new SuperRestore(.25, 8);
 		final Effect staminaPot = new StaminaPotion();
 		final DeltaPercentage remedyHeal = perc(0.16, 6);
 		add(restorePot, RESTORE_POTION1, RESTORE_POTION2, RESTORE_POTION3, RESTORE_POTION4);
 		add(energyPot, ENERGY_POTION1, ENERGY_POTION2, ENERGY_POTION3, ENERGY_POTION4);
 		add(prayerPot, PRAYER_POTION1, PRAYER_POTION2, PRAYER_POTION3, PRAYER_POTION4);
 		add(superEnergyPot, SUPER_ENERGY1, SUPER_ENERGY2, SUPER_ENERGY3, SUPER_ENERGY4);
-		add(superRestorePot, SUPER_RESTORE1, SUPER_RESTORE2, SUPER_RESTORE3, SUPER_RESTORE4,
+		add(SUPER_RESTORE_POT, SUPER_RESTORE1, SUPER_RESTORE2, SUPER_RESTORE3, SUPER_RESTORE4,
 			BLIGHTED_SUPER_RESTORE1, BLIGHTED_SUPER_RESTORE2, BLIGHTED_SUPER_RESTORE3, BLIGHTED_SUPER_RESTORE4,
 			SUPER_RESTORE4_23567, SUPER_RESTORE3_23569, SUPER_RESTORE2_23571, SUPER_RESTORE1_23573 /* LMS */);
 		add(new SuperRestore(.30, 4), SANFEW_SERUM1, SANFEW_SERUM2, SANFEW_SERUM3, SANFEW_SERUM4,
@@ -297,7 +297,7 @@ public class ItemStatChanges
 		add(new MixedPotion(3, energyPot), ENERGY_MIX1, ENERGY_MIX2);
 		add(new MixedPotion(6, prayerPot), PRAYER_MIX1, PRAYER_MIX2);
 		add(new MixedPotion(6, superEnergyPot), SUPER_ENERGY_MIX1, SUPER_ENERGY_MIX2);
-		add(new MixedPotion(6, superRestorePot), SUPER_RESTORE_MIX1, SUPER_RESTORE_MIX2);
+		add(new MixedPotion(6, SUPER_RESTORE_POT), SUPER_RESTORE_MIX1, SUPER_RESTORE_MIX2);
 		add(new MixedPotion(6, staminaPot), STAMINA_MIX1, STAMINA_MIX2);
 
 		// Chambers of Xeric potions (+)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/potions/CastleWarsBrew.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/potions/CastleWarsBrew.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2025 Macweese
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.itemstats.potions;
+
+import java.util.Comparator;
+import java.util.stream.Stream;
+import lombok.RequiredArgsConstructor;
+import net.runelite.api.Client;
+import static net.runelite.client.plugins.itemstats.Builders.boost;
+import static net.runelite.client.plugins.itemstats.Builders.combo;
+import static net.runelite.client.plugins.itemstats.Builders.heal;
+import static net.runelite.client.plugins.itemstats.Builders.perc;
+import net.runelite.client.plugins.itemstats.Effect;
+import net.runelite.client.plugins.itemstats.ItemStatChanges;
+import net.runelite.client.plugins.itemstats.StatChange;
+import net.runelite.client.plugins.itemstats.StatsChanges;
+import static net.runelite.client.plugins.itemstats.stats.Stats.MAGIC;
+import static net.runelite.client.plugins.itemstats.stats.Stats.RANGED;
+import static net.runelite.client.plugins.itemstats.stats.Stats.RUN_ENERGY;
+
+@RequiredArgsConstructor
+public class CastleWarsBrew implements Effect
+{
+	@Override
+	public StatsChanges calculate(Client client)
+	{
+		final Effect superRestore = ItemStatChanges.SUPER_RESTORE_POT;
+		final Effect boosts = combo(
+			ItemStatChanges.SUPER_ATTACK_POT,
+			ItemStatChanges.SUPER_STRENGTH_POT,
+			ItemStatChanges.SUPER_DEFENCE_POT,
+			boost(MAGIC, perc(.10, 1)),
+			boost(RANGED, perc(.10, 4)),
+			heal(RUN_ENERGY, 20)
+		);
+
+		StatsChanges changes = new StatsChanges(0);
+		changes.setStatChanges(Stream.of(
+				Stream.of(superRestore.calculate(client).getStatChanges()),
+				Stream.of(boosts.calculate(client).getStatChanges()))
+			.reduce(Stream::concat)
+			.orElseGet(Stream::empty)
+			.toArray(StatChange[]::new));
+		changes.setPositivity(Stream.of(changes.getStatChanges())
+			.map(StatChange::getPositivity)
+			.max(Comparator.naturalOrder())
+			.get());
+		return changes;
+	}
+}

--- a/runelite-client/src/test/java/net/runelite/client/plugins/itemstats/ItemStatEffectTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/itemstats/ItemStatEffectTest.java
@@ -506,6 +506,26 @@ public class ItemStatEffectTest
 		assertEquals(35, skillChange(Skill.HITPOINTS, 99, 99, saradominBrew));
 	}
 
+	@Test
+	public void testCastleWarsBrew()
+	{
+		final Effect castleWarsBrew = new ItemStatChanges().get(ItemID.CASTLEWARS_BREW4);
+
+		assertEquals(9, skillChange(Skill.PRAYER, 99, 90, castleWarsBrew));
+		assertEquals(32, skillChange(Skill.PRAYER, 99, 0, castleWarsBrew));
+
+		assertEquals(3, skillChange(Skill.STRENGTH, 99, 115, castleWarsBrew));
+		assertEquals(19, skillChange(Skill.STRENGTH, 99, 99, castleWarsBrew));
+
+		assertEquals(1, skillChange(Skill.RANGED, 99, 111, castleWarsBrew));
+		assertEquals(13, skillChange(Skill.RANGED, 99, 99, castleWarsBrew));
+
+		assertEquals(3, skillChange(Skill.MAGIC, 99, 106, castleWarsBrew));
+		assertEquals(10, skillChange(Skill.MAGIC, 99, 99, castleWarsBrew));
+
+		assertEquals(10, skillChange(Skill.MAGIC, 99, 99, castleWarsBrew));
+	}
+
 	private int skillChange(Skill skill, int maxValue, int currentValue, Effect effect)
 	{
 		if (effect == null)


### PR DESCRIPTION
Since a recent update to the Castle Wars minigame, the stat changees for Castle Wars Brews are no longer accurate. This PR intends on making the necessary adjustments to provide accurate stat boost information for the potion.

Through testing ingame I was able to confirm (at level 99) that the potion behaves all at once as a:
- Super restore
and benefits from the holy wrench effect.
- Super strength
- Super attack
- Super defence
- Ranging potion
- Imbued heart
- Stamina potion

Tests were also added.