### PR TITLE
Moons of Peril boss death status varbits

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/Varbits.java
+++ b/runelite-api/src/main/java/net/runelite/api/Varbits.java
@@ -944,9 +944,9 @@ public final class Varbits
 	 * Moons of Peril boss death status
 	 * 0=alive 1=dead
 	 */
-	public static final int MOON_BOSS_BLOOD_DEAD = 9858;
-	public static final int MOON_BOSS_BLUE_DEAD = 9859;
-	public static final int MOON_BOSS_ECLIPSE_DEAD = 9860;
+	public static final int BLOOD_MOON_DEAD = 9858;
+	public static final int BLUE_MOON_DEAD = 9859;
+	public static final int ECLIPSE_MOON_DEAD = 9860;
 
 	/**
 	 * The amount of Doom stacks received in the Fortis Colosseum.

--- a/runelite-api/src/main/java/net/runelite/api/Varbits.java
+++ b/runelite-api/src/main/java/net/runelite/api/Varbits.java
@@ -941,6 +941,14 @@ public final class Varbits
 	public static final int CURSE_OF_THE_MOONS = 9853;
 
 	/**
+	 * Moons of Peril boss death status
+	 * 0=alive 1=dead
+	 */
+	public static final int MOON_BOSS_BLOOD_DEAD = 9858;
+	public static final int MOON_BOSS_BLUE_DEAD = 9859;
+	public static final int MOON_BOSS_ECLIPSE_DEAD = 9860;
+
+	/**
 	 * The amount of Doom stacks received in the Fortis Colosseum.
 	 */
 	public static final int COLOSSEUM_DOOM = 9801;


### PR DESCRIPTION
I did a few rounds in different orders to verify that these Varbits correlate to these Moons of Peril bosses and they all reset to 0 when the chest is opened. I plan on using them in my combat-logger plugin, but I figured someone else might find them useful.

![image](https://github.com/user-attachments/assets/47c3f8e8-ab21-4002-be27-46bac437bbfb)
