### PR TITLE
fix mark of darkness timer when purging staff equiped 

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/timersandbuffs/TimersAndBuffsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timersandbuffs/TimersAndBuffsPlugin.java
@@ -954,7 +954,8 @@ public class TimersAndBuffsPlugin extends Plugin
 			}
 			else if (message.endsWith(MARK_OF_DARKNESS_MESSAGE))
 			{
-				createGameTimer(MARK_OF_DARKNESS, Duration.of(magicLevel, RSTimeUnit.GAME_TICKS));
+				final int magicLevelMoD = getMagicLevelMoD(client.getRealSkillLevel(Skill.MAGIC));
+				createGameTimer(MARK_OF_DARKNESS_COOLDOWN, Duration.of(magicLevelMoD - 10, RSTimeUnit.GAME_TICKS));
 			}
 			else if (message.contains(RESURRECT_THRALL_MESSAGE_START) && message.endsWith(RESURRECT_THRALL_MESSAGE_END))
 			{
@@ -975,8 +976,8 @@ public class TimersAndBuffsPlugin extends Plugin
 
 		if (message.endsWith(MARK_OF_DARKNESS_MESSAGE) && config.showArceuusCooldown())
 		{
-			final int magicLevel = client.getRealSkillLevel(Skill.MAGIC);
-			createGameTimer(MARK_OF_DARKNESS_COOLDOWN, Duration.of(magicLevel - 10, RSTimeUnit.GAME_TICKS));
+			final int magicLevelMoD = getMagicLevelMoD(client.getRealSkillLevel(Skill.MAGIC));
+			createGameTimer(MARK_OF_DARKNESS_COOLDOWN, Duration.of(magicLevelMoD - 10, RSTimeUnit.GAME_TICKS));
 		}
 
 		if (TZHAAR_PAUSED_MESSAGE.matcher(message).find())
@@ -1110,6 +1111,21 @@ public class TimersAndBuffsPlugin extends Plugin
 		{
 			removeGameTimer(teleport);
 		}
+	}
+
+
+	private int getMagicLevelMoD(int magicLevel)
+	{
+		final ItemContainer container = client.getItemContainer(InventoryID.WORN);
+		if (container != null)
+		{
+			final Item weapon = container.getItem(EquipmentInventorySlot.WEAPON.getSlotIdx());
+			if (weapon != null && weapon.getId() == ItemID.PURGING_STAFF)
+			{
+				return magicLevel * 5;
+			}
+		}
+		return magicLevel;
 	}
 
 	@Subscribe


### PR DESCRIPTION
Fixes Mark of Darkness duration and cooldown timers when wearing the Purging Staff.
 - If the staff is equipped when casting, the duration will be 5x. It can be unequipped (even banked) while the mark is active. 

Took most of this code from stale PR here: https://github.com/runelite/runelite/pull/18343 and aims to only fix MoD issue rather than adding other timers for While Guthix Sleeps.

Fixes https://github.com/runelite/runelite/issues/18128
Discussion https://github.com/runelite/runelite/discussions/18123