### PR TITLE
World Map: Don't render WorldMapPoints while world map is moving or resizing

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/worldmap/WorldMapOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/worldmap/WorldMapOverlay.java
@@ -95,7 +95,7 @@ public class WorldMapOverlay extends Overlay
 
 		Widget widget = client.getWidget(InterfaceID.Worldmap.MAP_CONTAINER);
 		Widget bottomBar = client.getWidget(InterfaceID.Worldmap.BOTTOM_GRAPHIC0);
-		if (widget == null || bottomBar == null)
+		if (widget == null || bottomBar == null || widget.isHidden())
 		{
 			return null;
 		}


### PR DESCRIPTION
Prevents `WorldMapPoint` from rendering while the world map is resizing or moving. This includes runelite world map icons and other `WorldMapPoint` added by plugins.

Client script `1747` sets `InterfaceID.Worldmap.MAP_CONTAINER` to be hidden during worldmap resizing. Client script `1745` sets it to be visible again once the resizing is finished.

**Before:**
![worl-map-before](https://github.com/user-attachments/assets/26fcf88d-435e-4079-ac1d-3d00e0782389)

**After:**
![worl-map-after](https://github.com/user-attachments/assets/5ce07d02-e61c-4aa9-8236-926d7e5db87b)
