### PR TITLE
config: use same list selection background regardless of focus

### DIFF
--- a/runelite-client/src/main/resources/net/runelite/client/ui/laf/RuneLiteLAF.properties
+++ b/runelite-client/src/main/resources/net/runelite/client/ui/laf/RuneLiteLAF.properties
@@ -77,6 +77,8 @@ Component.borderColor=@BORDER
 
 CheckBox.arc=0
 
+List.selectionInactiveBackground=@selectionBackground
+
 MenuBar.background=@DARKER_GRAY
 MenuBar.border=0,0,0,0
 


### PR DESCRIPTION
https://www.formdev.com/flatlaf/components/list/

<details>
<summary>before (hard to distinguish on some screens)</summary>

![Screenshot_20250413_202929](https://github.com/user-attachments/assets/8b2e7671-ed8b-41da-8d1c-0f070cbfb6cb)
</details>

<details>
<summary>after (selection background color is the same whether or not the component is focused)</summary>

![Screenshot_20250413_202759](https://github.com/user-attachments/assets/9d561945-08ca-4bb3-97f6-cb8650bfbdd2)
</details>
