### PR TITLE
Added Motherlode Mine Plugin Functionality

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/motherlode/MotherlodeConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/motherlode/MotherlodeConfig.java
@@ -81,4 +81,14 @@ public interface MotherlodeConfig extends Config
 	{
 		return true;
 	}
+
+	@ConfigItem(
+		keyName = "preventMiningWhenSackFull",
+		name = "Prevent mining when sack full",
+		description = "Highlights pay-dirt veins in red when your sack is full to prevent you from mining more."
+	)
+	default boolean preventMiningWhenSackFull()
+	{
+		return false;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/motherlode/MotherlodeSceneOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/motherlode/MotherlodeSceneOverlay.java
@@ -140,6 +140,16 @@ class MotherlodeSceneOverlay extends Overlay
 		if (canvasLoc != null)
 		{
 			graphics.drawImage(miningIcon, canvasLoc.getX(), canvasLoc.getY(), null);
+
+			// Show red highlight around veins when sack is full and option is enabled
+			if (config.preventMiningWhenSackFull() && plugin.isSackFull())
+			{
+				Polygon poly = Perspective.getCanvasTilePoly(client, vein.getLocalLocation());
+				if (poly != null)
+				{
+					OverlayUtil.renderPolygon(graphics, poly, Color.RED);
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
Configuration Option
Added a new toggle in MotherlodeConfig: "Prevent mining when sack full" Default setting is disabled (false)
Sack Fullness Calculation

Enhanced to account for:
Current paydirt in the sack
Paydirt in the player's inventory
Paydirt deposited in the hopper (not yet processed due to broken water wheels) Hopper Tracking System
Added pendingPaydirt counter to track unprocessed paydirt Increments when player deposits into the hopper
Decrements when sack amount increases
Resets on plugin start/shutdown (as the ore would update the varbit anyways once it reaches)

Mining Prevention
Monitors "Mine" action attempts on veins/ore
Cancels the action when sack would be full
Displays informative message about why mining is prevented Shows notification to the player
Veins are highlighted in red when sack is full