### PR TITLE
mes: correctly apply shift deposit swaps to deposit boxes and GIM storage

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -1396,7 +1396,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 		// Deposit- op 2 is the current withdraw amount 1/5/10/x for bank interface
 		if (shiftModifier() && config.bankDepositShiftClick() != ShiftDepositMode.OFF
 			&& type == MenuAction.CC_OP
-			&& ident == (isDepositBoxPlayerInventory || isGroupStoragePlayerInventory || isChambersOfXericStorageUnitPlayerInventory ? 1 : 2)
+			&& ident == (isGroupStoragePlayerInventory || isChambersOfXericStorageUnitPlayerInventory ? 1 : 2)
 			&& (menuEntry.getOption().startsWith("Deposit-") || menuEntry.getOption().startsWith("Store") || menuEntry.getOption().startsWith("Donate")))
 		{
 			ShiftDepositMode shiftDepositMode = config.bankDepositShiftClick();

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/ShiftDepositMode.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/ShiftDepositMode.java
@@ -31,11 +31,11 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum ShiftDepositMode
 {
-	DEPOSIT_1("Deposit-1", 3, 2, 1, 1),
+	DEPOSIT_1("Deposit-1", 3, 2, 2, 1),
 	DEPOSIT_5("Deposit-5", 4, 3, 3, 2),
 	DEPOSIT_10("Deposit-10", 5, 4, 4, 3),
-	DEPOSIT_X("Deposit-X", 6, 6, 5, 5),
-	DEPOSIT_ALL("Deposit-All", 8, 5, 7, 4),
+	DEPOSIT_X("Deposit-X", 6, 5, 5, 5),
+	DEPOSIT_ALL("Deposit-All", 8, 6, 7, 4),
 	EXTRA_OP("Eat/Wield/Etc.", 9, 9, 0, 0),
 	OFF("Off", 0, 0, 0, 0);
 


### PR DESCRIPTION
Currently, regardless of the in-game "Bank Item Options" setting being on or off, the MES setting "Bank deposit shift-click" is being applied incorrectly in the following cases:

For deposit boxes:
If the deposit box is set to deposit-1, the MES shift-deposit swap is never applied
If the deposit box is set to any other value and MES is set to deposit-all, the menu entry is swapped to deposit-x instead, and when MES is set to deposit-x, the entry is swapped to deposit-all.

For GIM group storage:
If the MES shift-deposit swap is set to deposit-1, the swap is not applied.

This PR resolves the above behavior.
I tested it with "Bank Item Options" both on and off, and checked at the MLM and Barbarian Assault deposit boxes. 
The group storage change was tested by Zoinkwiz as I don't have access to a GIM account.