### PR TITLE
groundmarkers: Add custom tile fill colors in ground markers plugin

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/groundmarkers/GroundMarkerConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/groundmarkers/GroundMarkerConfig.java
@@ -79,16 +79,14 @@ public interface GroundMarkerConfig extends Config
 		return 2;
 	}
 
+	@Alpha
 	@ConfigItem(
-		keyName = "fillOpacity",
-		name = "Fill opacity",
-		description = "Opacity of the tile fill color."
+		keyName = "fillColor",
+		name = "Fill color",
+		description = "The default fill color for marked tiles."
 	)
-	@Range(
-		max = 255
-	)
-	default int fillOpacity()
+	default Color fillColor()
 	{
-		return 50;
+		return new Color(0, 0, 0, 50);
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/groundmarkers/GroundMarkerOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/groundmarkers/GroundMarkerOverlay.java
@@ -113,7 +113,7 @@ public class GroundMarkerOverlay extends Overlay
 		Polygon poly = Perspective.getCanvasTilePoly(client, lp);
 		if (poly != null)
 		{
-			OverlayUtil.renderPolygon(graphics, poly, color, new Color(0, 0, 0, config.fillOpacity()), borderStroke);
+			OverlayUtil.renderPolygon(graphics, poly, color, config.fillColor(), borderStroke);
 		}
 
 		if (!Strings.isNullOrEmpty(label))


### PR DESCRIPTION
Changed from bring able to only set opacity of the tile's fill color to being able to set the actual fill color too.