### PR TITLE
overlay: Add custom font support

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/RuneLite.java
+++ b/runelite-client/src/main/java/net/runelite/client/RuneLite.java
@@ -110,6 +110,7 @@ public class RuneLite
 	public static final File LOGS_DIR = new File(RUNELITE_DIR, "logs");
 	public static final File DEFAULT_SESSION_FILE = new File(RUNELITE_DIR, "session");
 	public static final File NOTIFICATIONS_DIR = new File(RuneLite.RUNELITE_DIR, "notifications");
+	public static final File FONTS_DIR = new File(RuneLite.RUNELITE_DIR, "fonts");
 
 	private static final int MAX_OKHTTP_CACHE_SIZE = 20 * 1024 * 1024; // 20mb
 	public static String USER_AGENT = "RuneLite/" + RuneLiteProperties.getVersion() + "-" + RuneLiteProperties.getCommit() + (RuneLiteProperties.isDirty() ? "+" : "");

--- a/runelite-client/src/main/java/net/runelite/client/config/FontStyle.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/FontStyle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Tanner <https://github.com/Reasel>
+ * Copyright (c) 2025, Hamish <https://github.com/DustyRealm>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -24,45 +24,21 @@
  */
 package net.runelite.client.config;
 
-import lombok.RequiredArgsConstructor;
 import lombok.Getter;
-import net.runelite.client.ui.FontManager;
-import javax.swing.text.StyleContext;
+import lombok.RequiredArgsConstructor;
 import java.awt.Font;
 
-
 @RequiredArgsConstructor
-public enum FontType
+public enum FontStyle
 {
-	REGULAR("Regular", FontManager.getRunescapeFont()),
-	BOLD("Bold", FontManager.getRunescapeBoldFont()),
-	SMALL("Small", FontManager.getRunescapeSmallFont()),
-	CUSTOM("Custom", FontManager.getRunescapeSmallFont());
+	PLAIN("Plain", Font.PLAIN),
+	BOLD("Bold", Font.BOLD),
+	ITALIC("Italic", Font.ITALIC);
 
 	@Getter
 	private final String name;
 	@Getter
-	private final Font defaultFont;
-
-	/**
-	 * @deprecated This method is deprecated because handling CUSTOM font types requires a {@code RuneLiteConfig}.
-	 * Use {@link #getFont(RuneLiteConfig)} instead.
-	 */
-	@Deprecated
-	public Font getFont()
-	{
-		return getFont(null);
-	}
-
-	public Font getFont(final RuneLiteConfig config)
-	{
-		if (this == CUSTOM && config != null)
-		{
-			return StyleContext.getDefaultStyleContext()
-				.getFont(config.customFont(), config.customFontStyle().getStyle(), config.customFontSize());
-		}
-		return defaultFont;
-	}
+	private final int style;
 
 	@Override
 	public String toString()

--- a/runelite-client/src/main/java/net/runelite/client/config/RuneLiteConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/RuneLiteConfig.java
@@ -424,6 +424,43 @@ public interface RuneLiteConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "customFont",
+		name = "Custom font",
+		description = "Place TTF/OTF fonts in .runelite/fonts/ and enter the font family name here, e.g., Serif. All system fonts are also available.",
+		position = 45,
+		section = overlaySettings
+	)
+	default String customFont()
+	{
+		return FontType.CUSTOM.getDefaultFont().getFamily();
+	}
+
+	@ConfigItem(
+		keyName = "customFontStyle",
+		name = "Custom font Style",
+		description = "Configures the custom font style.",
+		position = 46,
+		section = overlaySettings
+	)
+	default FontStyle customFontStyle()
+	{
+		return FontStyle.PLAIN;
+	}
+
+	@Range
+	@ConfigItem(
+		keyName = "customFontSize",
+		name = "Custom font size",
+		description = "Configures the custom font size.",
+		position = 47,
+		section = overlaySettings
+	)
+	default int customFontSize()
+	{
+		return 12;
+	}
+
+	@ConfigItem(
 		keyName = "sidebarToggleKey",
 		name = "Sidebar toggle key",
 		description = "The key that will toggle the sidebar (accepts modifiers).",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsPlugin.java
@@ -811,7 +811,7 @@ public class RaidsPlugin extends Plugin
 		Rectangle overlayDimensions = overlay.getBounds();
 		BufferedImage overlayImage = new BufferedImage(overlayDimensions.width, overlayDimensions.height, BufferedImage.TYPE_INT_ARGB);
 		Graphics2D graphic = overlayImage.createGraphics();
-		graphic.setFont(runeLiteConfig.interfaceFontType().getFont());
+		graphic.setFont(runeLiteConfig.interfaceFontType().getFont(runeLiteConfig));
 		graphic.setColor(Color.BLACK);
 		graphic.fillRect(0, 0, overlayDimensions.width, overlayDimensions.height);
 		overlay.render(graphic);

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayRenderer.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayRenderer.java
@@ -714,15 +714,15 @@ public class OverlayRenderer extends MouseAdapter
 		// Set font based on configuration
 		if (position == OverlayPosition.DYNAMIC || position == OverlayPosition.DETACHED)
 		{
-			graphics.setFont(runeLiteConfig.fontType().getFont());
+			graphics.setFont(runeLiteConfig.fontType().getFont(runeLiteConfig));
 		}
 		else if (position == OverlayPosition.TOOLTIP)
 		{
-			graphics.setFont(runeLiteConfig.tooltipFontType().getFont());
+			graphics.setFont(runeLiteConfig.tooltipFontType().getFont(runeLiteConfig));
 		}
 		else
 		{
-			graphics.setFont(runeLiteConfig.interfaceFontType().getFont());
+			graphics.setFont(runeLiteConfig.interfaceFontType().getFont(runeLiteConfig));
 		}
 
 		graphics.translate(point.x, point.y);

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/infobox/InfoBoxOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/infobox/InfoBoxOverlay.java
@@ -123,7 +123,7 @@ public class InfoBoxOverlay extends OverlayPanel
 		panelComponent.setPreferredSize(new Dimension(DEFAULT_WRAP_COUNT * (config.infoBoxSize() + GAP), DEFAULT_WRAP_COUNT * (config.infoBoxSize() + GAP)));
 		panelComponent.setOrientation(orientation);
 
-		final Font font = config.infoboxFontType().getFont();
+		final Font font = config.infoboxFontType().getFont(config);
 		final boolean infoBoxTextOutline = config.infoBoxTextOutline();
 		final Color overlayBackgroundColor = config.overlayBackgroundColor();
 		final Dimension preferredSize = new Dimension(config.infoBoxSize(), config.infoBoxSize());


### PR DESCRIPTION
Introduce a custom FontType and configuration options to the Overlay settings. All .ttf and .otf files in .runelite/fonts/ will be automatically loaded. Additionally, all system fonts are available for use.

![image](https://github.com/user-attachments/assets/e0c25008-4da5-48eb-bdfd-90d8805ef2cf)
