### PR TITLE
implement feature request: auto-retaliate idle notification

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
@@ -492,6 +492,7 @@ public class IdleNotifierPlugin extends Plugin
 	public void onGameStateChanged(GameStateChanged gameStateChanged)
 	{
 		lastInteracting = null;
+		lastCombatStarted = null;
 
 		GameState state = gameStateChanged.getGameState();
 
@@ -913,7 +914,6 @@ public class IdleNotifierPlugin extends Plugin
 			{
 				lastInteract = null;
 				lastInteracting = null;
-				lastCombatStarted = null;
 
 				// prevent animation notifications from firing too
 				lastAnimation = -1;
@@ -1063,6 +1063,7 @@ public class IdleNotifierPlugin extends Plugin
 
 		// Reset interaction idle timer
 		lastInteracting = null;
+		lastCombatStarted = null;
 		if (gameState == GameState.LOGIN_SCREEN || local == null || local.getInteracting() != lastInteract)
 		{
 			lastInteract = null;


### PR DESCRIPTION
as requested in issue #17863 this PR adds a notification for when you stop auto retaliating

in addition to the feature I also went ahead and replaced the remaining deprecated calls in the class


a description of the logic to achieve this feature:

we use an Instant that references the time combat was entered, this is achieved by tracking clicked Menu Options to set or unset an instant based on the Option, in addition to this since combat can also be invoked by any agressive NPC and it can also be set by having an interacting NPC target when no Instant is set yet, we should not override this value as it is required to properly track that 20 minutes have elapsed. with this Instant as a reference and the current idle time we can dispatch a notification after combat has been engaged and 60_000 idle ticks (20 minutes) have passed in addition to atleast 20 minutes since combat has been invoked. we need a reference to the timer as when 20 minutes pass and auto-retaliation stops onInteractingChanged is continously called with the NPC that is attacking you, followed with the same event with a null since the client will not retaliate and we want to avoid continously sending the same notification whilst idle