### PR TITLE
slayer: use inital count VarPlayer

### DIFF
--- a/runelite-client/src/test/java/net/runelite/client/plugins/slayer/SlayerPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/slayer/SlayerPluginTest.java
@@ -317,9 +317,6 @@ public class SlayerPluginTest
 				return e;
 			});
 
-		// initial amount is fetched from config at sync
-		when(configManager.getRSProfileConfiguration("slayer", "initialAmount", int.class)).thenReturn(99);
-
 		slayerPlugin.setTaskName("mocked npc");
 		slayerPlugin.setAmount(42);
 		slayerPlugin.setInitialAmount(99);
@@ -351,6 +348,7 @@ public class SlayerPluginTest
 
 		when(client.getVarpValue(VarPlayerID.SLAYER_COUNT)).thenReturn(42);
 		when(client.getVarpValue(VarPlayerID.SLAYER_TARGET)).thenReturn(1);
+		when(client.getVarpValue(VarPlayerID.SLAYER_COUNT_ORIGINAL)).thenReturn(99);
 
 		slayerPlugin.onVarbitChanged(taskSizeChanged);
 		slayerPlugin.onVarbitChanged(taskCreatureChanged);


### PR DESCRIPTION
get the initial task amount from the varp instead of just storing it locally

The varp is always available, but does not reset after completing a task however, that's not really an issue as there is not overlay if you don't have a task.