### PR TITLE
maven plugin: add javadoc for deprecated InterfaceID and ComponentID

### DIFF
--- a/runelite-maven-plugin/src/main/java/net/runelite/mvn/ComponentMojo.java
+++ b/runelite-maven-plugin/src/main/java/net/runelite/mvn/ComponentMojo.java
@@ -70,11 +70,13 @@ public class ComponentMojo extends AbstractMojo
 	{
 		TypeSpec.Builder interfaceType = TypeSpec.classBuilder("InterfaceID")
 			.addModifiers(Modifier.PUBLIC, Modifier.FINAL)
-			.addAnnotation(Deprecated.class);
+			.addAnnotation(Deprecated.class)
+			.addJavadoc("@deprecated Use {@link net.runelite.api.gameval.InterfaceID} instead");
 
 		TypeSpec.Builder componentType = TypeSpec.classBuilder("ComponentID")
 			.addModifiers(Modifier.PUBLIC, Modifier.FINAL)
-			.addAnnotation(Deprecated.class);
+			.addAnnotation(Deprecated.class)
+			.addJavadoc("@deprecated Use nested classes of {@link net.runelite.api.gameval.InterfaceID} instead");
 
 		for (File file : inputDirectory.listFiles((dir, name) -> name.endsWith(".toml")))
 		{


### PR DESCRIPTION
points devs to where the replacement is