### PR TITLE
fix client thread blocking from plugin hub interactions

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/util/Debouncer.java
+++ b/runelite-client/src/main/java/net/runelite/client/util/Debouncer.java
@@ -1,0 +1,30 @@
+package net.runelite.client.util;
+
+import java.util.concurrent.*;
+
+public class Debouncer
+{
+	private final ConcurrentHashMap<Object, Future<?>> delayedMap = new ConcurrentHashMap<>();
+
+	/**
+	 * Debounces {@code callable} by {@code delay}, i.e., schedules it to be executed after {@code delay},
+	 * or cancels its execution if the method is called with the same key within the {@code delay} again.
+	 */
+	public void debounce(final ScheduledExecutorService scheduler, final Object key, final Runnable runnable, long delay, TimeUnit unit)
+	{
+		final Future<?> prev = delayedMap.put(key, scheduler.schedule(() -> {
+			try
+			{
+				runnable.run();
+			}
+			finally
+			{
+				delayedMap.remove(key);
+			}
+		}, delay, unit));
+		if (prev != null)
+		{
+			prev.cancel(true);
+		}
+	}
+}


### PR DESCRIPTION
when opening the plugin hub on older computers the client stops taking any user input until the blocking operations are done, this is caused by invoking SwingUtilities.invokeLater, which even when called within a Runnable in an Executor will be executed differently. In addition every interaction with the search bar fired a seperate search, each blocking the client thread from taking any user input yet again for every key stroke, by introducing a debouncer this freeze can be optimized/minimized by firing less filter searches.

I checked for an existing debouncer within the project and could only find debounce logic within the WikiSearch, which I refactored to use the dedicated debouncer which is added as part of this PR