### PR TITLE
account: correctly parent JOptionPane

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/account/AccountPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/account/AccountPlugin.java
@@ -38,6 +38,7 @@ import net.runelite.client.events.SessionOpen;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.ClientToolbar;
+import net.runelite.client.ui.ClientUI;
 import net.runelite.client.ui.NavigationButton;
 import net.runelite.client.util.ImageUtil;
 
@@ -60,6 +61,9 @@ public class AccountPlugin extends Plugin
 
 	@Inject
 	private ScheduledExecutorService executor;
+
+	@Inject
+	private ClientUI clientUI;
 
 	private NavigationButton loginButton;
 	private NavigationButton logoutButton;
@@ -113,9 +117,11 @@ public class AccountPlugin extends Plugin
 
 	private void logoutClick()
 	{
-		if (JOptionPane.YES_OPTION == JOptionPane.showConfirmDialog(null,
+		if (JOptionPane.YES_OPTION == JOptionPane.showConfirmDialog(
+			clientUI.getFrame(),
 			"Are you sure you want to sign out of RuneLite?", "Sign Out Confirmation",
-			JOptionPane.YES_NO_OPTION))
+			JOptionPane.YES_NO_OPTION
+		))
 		{
 			executor.execute(() ->
 			{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/ProfilePanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/ProfilePanel.java
@@ -837,7 +837,7 @@ class ProfilePanel extends PluginPanel
 			File source = ProfileManager.profileConfigFile(profile);
 			if (!source.exists())
 			{
-				SwingUtilities.invokeLater(() -> JOptionPane.showMessageDialog(null, "Profile '" + profile.getName() + "' can not be exported because it has no settings."));
+				SwingUtilities.invokeLater(() -> JOptionPane.showMessageDialog(this, "Profile '" + profile.getName() + "' can not be exported because it has no settings."));
 				return;
 			}
 

--- a/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
@@ -163,6 +163,7 @@ public class ClientUI
 	private ClientToolbarPanel toolbarPanel;
 	private boolean withTitleBar;
 
+	@Getter
 	private ContainableFrame frame;
 	private JPanel content;
 	private ClientPanel clientPanel;


### PR DESCRIPTION
Without a parent component, the JOptionPane may render underneath the client window if alwaysOnTop is set. This can make the JOptionPane uninteractable while also stealing focus from the frame.

Since the Account plugin doesn't have any owned components, we don't have other options for the parent. I've exposed the ContainableFrame instance from ClientUI, but if we don't want to do that then we'll need another way to provide a parent in non-Swing contexts.

I've also fixed one incorrect use in ProfilePanel, which has its own context available.

There is another instances of null-parenting in LinkBrowser, but since it is in a static context *and* is an extensively used API option, it needs a bit more consideration.

Closes #18933