### PR TITLE
profile panel: improve profile naming policy

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/ProfilePanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/ProfilePanel.java
@@ -391,7 +391,7 @@ class ProfilePanel extends PluginPanel
 				private String filter(String in)
 				{
 					// characters commonly forbidden in file names
-					return CharMatcher.noneOf("/\\<>:\"|?*\r\n\0")
+					return CharMatcher.noneOf("/\\<>:\"|?*\r\n\0$")
 						.retainFrom(in);
 				}
 			});

--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/ProfilePanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/ProfilePanel.java
@@ -392,7 +392,8 @@ class ProfilePanel extends PluginPanel
 				{
 					// characters commonly forbidden in file names
 					return CharMatcher.noneOf("/\\<>:\"|?*\r\n\0$")
-						.retainFrom(in);
+						.retainFrom(in)
+						.substring(0, 30);
 				}
 			});
 


### PR DESCRIPTION
This PR is intended to fix two issues with profiles where:
1. renaming a profile may mistakenly give an internal status to the profile.
2. excessively long names raise a `FileSystemException` (prilarily Windows)

Currently, the naming policy for profiles, primarily checking for reserved characters from file names, allows for '$'-characters to be included, this is fine if a '$'-character are not the first character in the name. Because profiles whose names begin with '$' are regarded as internal, they will be hidden from the profile list. Disallowing profiles from containing '$'-characters solves this.

An alternative solution would be to strip any leading '$' from the name, but I thought disallowing it altogether is better.

If a user gives a profile a long enough name so that the path is longer than 260 characters, it will cause an error in most Windows environments. Whilst there is an option to enable long paths on Windows versions newer than 10.1607, it is not enabled by default and requires editing registry files. By truncating the name to a certain length of the original input, the issue can largely be avoided. Other OS's also apply limits, but are far more generous (~255 chars for files/directories and ~1000 chars for paths on Linux, and MacOS being even more generous). The length limit of 20 character on names was chosen because it is about how many of the fonts widest characters can fit before the text overflows.

<details>
  <summary>FileSystemException</summary>
  
```log
2025-05-02 17:47:22 CEST [AWT-EventQueue-0] INFO  n.r.c.plugins.config.ProfilePanel - Renaming profile ConfigProfile(id=316606386978200, name=, sync=false, active=true, rev=-1, defaultForRsProfiles=[]) (316606386978200) to aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
2025-05-02 17:47:22 CEST [AWT-EventQueue-0] ERROR n.r.client.config.ProfileManager - error renaming profile
java.nio.file.FileSystemException: C:\Users\Administrator\.runelite\profiles2\-316606386978200.properties -> C:\Users\Administrator\.runelite\profiles2\aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-316606386978200.properties: The filename, directory name, or volume label syntax is incorrect.

	at java.base/sun.nio.fs.WindowsException.translateToIOException(WindowsException.java:92)
	at java.base/sun.nio.fs.WindowsException.rethrowAsIOException(WindowsException.java:103)
	at java.base/sun.nio.fs.WindowsFileCopy.move(WindowsFileCopy.java:395)
	at java.base/sun.nio.fs.WindowsFileSystemProvider.move(WindowsFileSystemProvider.java:292)
	at java.base/java.nio.file.Files.move(Files.java:1421)
	at net.runelite.client.config.ProfileManager$Lock.renameProfile(ProfileManager.java:211)
	at net.runelite.client.plugins.config.ProfilePanel.renameProfile(ProfilePanel.java:729)
	at net.runelite.client.plugins.config.ProfilePanel$ProfileCard.stopRenaming(ProfilePanel.java:672)
	at net.runelite.client.plugins.config.ProfilePanel$ProfileCard.lambda$new$0(ProfilePanel.java:365)
	at java.desktop/javax.swing.JTextField.fireActionPerformed(JTextField.java:508)
	at java.desktop/javax.swing.JTextField.postActionEvent(JTextField.java:723)
	at java.desktop/javax.swing.JTextField$NotifyAction.actionPerformed(JTextField.java:839)
	at java.desktop/javax.swing.SwingUtilities.notifyAction(SwingUtilities.java:1810)
	at java.desktop/javax.swing.JComponent.processKeyBinding(JComponent.java:2900)
	at java.desktop/javax.swing.JComponent.processKeyBindings(JComponent.java:2948)
	at java.desktop/javax.swing.JComponent.processKeyEvent(JComponent.java:2862)
	at java.desktop/java.awt.Component.processEvent(Component.java:6409)
	at java.desktop/java.awt.Container.processEvent(Container.java:2263)
	at java.desktop/java.awt.Component.dispatchEventImpl(Component.java:5008)
	at java.desktop/java.awt.Container.dispatchEventImpl(Container.java:2321)
	at java.desktop/java.awt.Component.dispatchEvent(Component.java:4840)
	at java.desktop/java.awt.KeyboardFocusManager.redispatchEvent(KeyboardFocusManager.java:1950)
	at java.desktop/java.awt.DefaultKeyboardFocusManager.dispatchKeyEvent(DefaultKeyboardFocusManager.java:870)
	at java.desktop/java.awt.DefaultKeyboardFocusManager.preDispatchKeyEvent(DefaultKeyboardFocusManager.java:1139)
	at java.desktop/java.awt.DefaultKeyboardFocusManager.typeAheadAssertions(DefaultKeyboardFocusManager.java:1009)
	at java.desktop/java.awt.DefaultKeyboardFocusManager.dispatchEvent(DefaultKeyboardFocusManager.java:835)
	at java.desktop/java.awt.Component.dispatchEventImpl(Component.java:4889)
	at java.desktop/java.awt.Container.dispatchEventImpl(Container.java:2321)
	at java.desktop/java.awt.Window.dispatchEventImpl(Window.java:2772)
	at java.desktop/java.awt.Component.dispatchEvent(Component.java:4840)
	at java.desktop/java.awt.EventQueue.dispatchEventImpl(EventQueue.java:772)
	at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:721)
	at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:715)
	at java.base/java.security.AccessController.doPrivileged(Native Method)
	at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:85)
	at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:95)
	at java.desktop/java.awt.EventQueue$5.run(EventQueue.java:745)
	at java.desktop/java.awt.EventQueue$5.run(EventQueue.java:743)
	at java.base/java.security.AccessController.doPrivileged(Native Method)
	at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:85)
	at java.desktop/java.awt.EventQueue.dispatchEvent(EventQueue.java:742)
	at java.desktop/java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:203)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:124)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:113)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:109)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:101)
	at java.desktop/java.awt.EventDispatchThread.run(EventDispatchThread.java:90)
2025-05-02 17:47:22 CEST [AWT-EventQueue-0] DEBUG n.r.client.config.ProfileManager - saving 26 profiles
```
  
</details>
