### PR TITLE
api: add DISEASE_BLOCKED to HitsplatID

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/HitsplatID.java
+++ b/runelite-api/src/main/java/net/runelite/api/HitsplatID.java
@@ -32,6 +32,7 @@ public final class HitsplatID
 	public static final int DAMAGE_OTHER = 17;
 	public static final int POISON = 65;
 	public static final int DISEASE = 4;
+	public static final int DISEASE_BLOCKED = 3;
 	public static final int VENOM = 5;
 	public static final int HEAL = 6;
 	public static final int CYAN_UP = 11;


### PR DESCRIPTION
While wearing an inoculation bracelet, the hitsplat type for disease damage is 3. (Without an inoculation bracelet, the hitsplat type is still 4)