### PR TITLE
itemcharges: fix ring of forging when varrock platebody is equipped

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemcharges/ItemChargePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemcharges/ItemChargePlugin.java
@@ -90,7 +90,7 @@ public class ItemChargePlugin extends Plugin
 		"You can smelt ([0-9]+|one) more pieces? of iron ore before a ring melts\\.");
 	private static final String RING_OF_FORGING_USED_TEXT = "You retrieve a bar of iron.";
 	private static final String RING_OF_FORGING_BREAK_TEXT = "Your Ring of Forging has melted.";
-	private static final String RING_OF_FORGING_VARROCK_PLATEBODY = "The Varrock platebody enabled you to smelt your next ore simultaneously.";
+	private static final String RING_OF_FORGING_VARROCK_PLATEBODY = "The Varrock platebody enabled you to smelt your next ore simultaneously\\.";
 	private static final Pattern AMULET_OF_CHEMISTRY_CHECK_PATTERN = Pattern.compile(
 		"Your amulet of chemistry has (\\d) charges? left\\."
 	);
@@ -155,7 +155,7 @@ public class ItemChargePlugin extends Plugin
 	private static final int MAX_BLOOD_ESSENCE_CHARGES = 1000;
 	private static final int MAX_BRACELET_OF_CLAY_CHARGES = 28;
 
-	private boolean varrockPlatebodySmeltTwo = false;
+	private boolean varrockPlatebodySmeltTwo;
 
 	@Inject
 	private Client client;
@@ -334,7 +334,7 @@ public class ItemChargePlugin extends Plugin
 			else if (bindingNecklaceUsedMatcher.find())
 			{
 				final ItemContainer equipment = client.getItemContainer(InventoryID.WORN);
-				if (equipment != null && equipment.contains(ItemID.MAGIC_EMERALD_NECKLACE))
+				if (equipment.contains(ItemID.MAGIC_EMERALD_NECKLACE))
 				{
 					updateBindingNecklaceCharges(getItemCharges(ItemChargeConfig.KEY_BINDING_NECKLACE) - 1);
 				}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemcharges/ItemChargePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemcharges/ItemChargePlugin.java
@@ -373,9 +373,9 @@ public class ItemChargePlugin extends Plugin
 					return;
 				}
 
-				if (equipment.contains(ItemID.RING_OF_FORGING) && (message.equals(RING_OF_FORGING_USED_TEXT)))
+				if (equipment.contains(ItemID.RING_OF_FORGING))
 				{
-					int charges = Ints.constrainToRange(getItemCharges(ItemChargeConfig.KEY_RING_OF_FORGING) - varrockPlatebodySmeltTwo ? 2 : 1, 0,
+					int charges = Ints.constrainToRange(getItemCharges(ItemChargeConfig.KEY_RING_OF_FORGING) - (varrockPlatebodySmeltTwo ? 2 : 1), 0,
 						MAX_RING_OF_FORGING_CHARGES);
 					updateRingOfForgingCharges(charges);
 				}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemcharges/ItemChargePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemcharges/ItemChargePlugin.java
@@ -155,6 +155,8 @@ public class ItemChargePlugin extends Plugin
 	private static final int MAX_BLOOD_ESSENCE_CHARGES = 1000;
 	private static final int MAX_BRACELET_OF_CLAY_CHARGES = 28;
 
+	private boolean varrockPlatebodySmeltTwo = false;
+
 	@Inject
 	private Client client;
 
@@ -360,7 +362,7 @@ public class ItemChargePlugin extends Plugin
 				}
 				updateRingOfForgingCharges(charges);
 			}
-			else if (message.equals(RING_OF_FORGING_USED_TEXT) || message.equals(RING_OF_FORGING_VARROCK_PLATEBODY))
+			else if (message.equals(RING_OF_FORGING_USED_TEXT))
 			{
 				final ItemContainer inventory = client.getItemContainer(InventoryID.INV);
 				final ItemContainer equipment = client.getItemContainer(InventoryID.WORN);
@@ -371,9 +373,10 @@ public class ItemChargePlugin extends Plugin
 					return;
 				}
 
-				if (equipment.contains(ItemID.RING_OF_FORGING) && (message.equals(RING_OF_FORGING_USED_TEXT) || inventory.count(ItemID.IRON_ORE) > 1))
+				if (equipment.contains(ItemID.RING_OF_FORGING) && (message.equals(RING_OF_FORGING_USED_TEXT)))
 				{
-					int charges = Ints.constrainToRange(getItemCharges(ItemChargeConfig.KEY_RING_OF_FORGING) - 1, 0, MAX_RING_OF_FORGING_CHARGES);
+					int charges = Ints.constrainToRange(getItemCharges(ItemChargeConfig.KEY_RING_OF_FORGING) - varrockPlatebodySmeltTwo ? 2 : 1, 0,
+						MAX_RING_OF_FORGING_CHARGES);
 					updateRingOfForgingCharges(charges);
 				}
 			}
@@ -489,6 +492,7 @@ public class ItemChargePlugin extends Plugin
 				notifier.notify(config.braceletOfClayNotification(), "Your bracelet of clay has crumbled to dust");
 				updateBraceletOfClayCharges(MAX_BRACELET_OF_CLAY_CHARGES);
 			}
+			varrockPlatebodySmeltTwo = message.matches(RING_OF_FORGING_VARROCK_PLATEBODY); //Set to true if the message matches and only survives one iteration (one chat message) before being set back to false
 		}
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemcharges/ItemChargePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemcharges/ItemChargePlugin.java
@@ -334,7 +334,7 @@ public class ItemChargePlugin extends Plugin
 			else if (bindingNecklaceUsedMatcher.find())
 			{
 				final ItemContainer equipment = client.getItemContainer(InventoryID.WORN);
-				if (equipment.contains(ItemID.MAGIC_EMERALD_NECKLACE))
+				if (equipment != null && equipment.contains(ItemID.MAGIC_EMERALD_NECKLACE))
 				{
 					updateBindingNecklaceCharges(getItemCharges(ItemChargeConfig.KEY_BINDING_NECKLACE) - 1);
 				}
@@ -364,7 +364,6 @@ public class ItemChargePlugin extends Plugin
 			}
 			else if (message.equals(RING_OF_FORGING_USED_TEXT))
 			{
-				final ItemContainer inventory = client.getItemContainer(InventoryID.INV);
 				final ItemContainer equipment = client.getItemContainer(InventoryID.WORN);
 
 				// Determine if the player smelted with a Ring of Forging equipped.

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemcharges/ItemChargePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemcharges/ItemChargePlugin.java
@@ -90,7 +90,7 @@ public class ItemChargePlugin extends Plugin
 		"You can smelt ([0-9]+|one) more pieces? of iron ore before a ring melts\\.");
 	private static final String RING_OF_FORGING_USED_TEXT = "You retrieve a bar of iron.";
 	private static final String RING_OF_FORGING_BREAK_TEXT = "Your Ring of Forging has melted.";
-	private static final String RING_OF_FORGING_VARROCK_PLATEBODY = "The Varrock platebody enabled you to smelt your next ore simultaneously\\.";
+	private static final String RING_OF_FORGING_VARROCK_PLATEBODY = "The Varrock platebody enabled you to smelt your next ore simultaneously.";
 	private static final Pattern AMULET_OF_CHEMISTRY_CHECK_PATTERN = Pattern.compile(
 		"Your amulet of chemistry has (\\d) charges? left\\."
 	);
@@ -491,7 +491,7 @@ public class ItemChargePlugin extends Plugin
 				notifier.notify(config.braceletOfClayNotification(), "Your bracelet of clay has crumbled to dust");
 				updateBraceletOfClayCharges(MAX_BRACELET_OF_CLAY_CHARGES);
 			}
-			varrockPlatebodySmeltTwo = message.matches(RING_OF_FORGING_VARROCK_PLATEBODY); //Set to true if the message matches and only survives one iteration (one chat message) before being set back to false
+			varrockPlatebodySmeltTwo = message.equals(RING_OF_FORGING_VARROCK_PLATEBODY); //Set to true if the message matches and only survives one iteration (one chat message) before being set back to false
 		}
 	}
 

--- a/runelite-client/src/test/java/net/runelite/client/plugins/itemcharges/ItemChargePluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/itemcharges/ItemChargePluginTest.java
@@ -62,6 +62,7 @@ public class ItemChargePluginTest
 	private static final String CHECK_RING_OF_FORGING_ONE = "You can smelt one more piece of iron ore before a ring melts.";
 	private static final String USED_RING_OF_FORGING = "You retrieve a bar of iron.";
 	private static final String BREAK_RING_OF_FORGING = "<col=7f007f>Your Ring of Forging has melted.</col>";
+	private static final String USED_RING_OF_FORGING_VARROCK_PLATEBODY = "The Varrock platebody enabled you to smelt your next ore simultaneously.";
 
 	private static final String CHECK_AMULET_OF_CHEMISTRY = "Your amulet of chemistry has 5 charges left.";
 	private static final String CHECK_AMULET_OF_CHEMISTRY_1 = "Your amulet of chemistry has 1 charge left.";
@@ -182,6 +183,29 @@ public class ItemChargePluginTest
 		ChatMessage chatMessage = new ChatMessage(null, ChatMessageType.GAMEMESSAGE, "", CHECK_RING_OF_FORGING_ONE, "", 0);
 		itemChargePlugin.onChatMessage(chatMessage);
 		verify(configManager).setRSProfileConfiguration(ItemChargeConfig.GROUP, ItemChargeConfig.KEY_RING_OF_FORGING, 1);
+	}
+
+	@Test
+	public void testRofTwo(){
+		when(configManager.getRSProfileConfiguration(ItemChargeConfig.GROUP, ItemChargeConfig.KEY_RING_OF_FORGING, Integer.class)).thenReturn(140);
+		// Create equipment inventory with ring of forging
+		ItemContainer equipmentItemContainer = mock(ItemContainer.class);
+		when(client.getItemContainer(InventoryID.WORN)).thenReturn(equipmentItemContainer);
+		when(equipmentItemContainer.contains(ItemID.RING_OF_FORGING)).thenReturn(true);
+		when(equipmentItemContainer.getItems()).thenReturn(new Item[0]);
+
+		//varrock platebody proc
+		ChatMessage chatMessageEffect = new ChatMessage(null, ChatMessageType.SPAM, "", USED_RING_OF_FORGING_VARROCK_PLATEBODY, "", 0);
+		//ring of forging proc
+		ChatMessage chatMessageUse = new ChatMessage(null, ChatMessageType.SPAM, "", USED_RING_OF_FORGING,"",0);
+
+		itemChargePlugin.onChatMessage(chatMessageEffect);
+		itemChargePlugin.onChatMessage(chatMessageUse);
+		verify(configManager).setRSProfileConfiguration(ItemChargeConfig.GROUP, ItemChargeConfig.KEY_RING_OF_FORGING, 138);
+
+		when(configManager.getRSProfileConfiguration(ItemChargeConfig.GROUP, ItemChargeConfig.KEY_RING_OF_FORGING, Integer.class)).thenReturn(138);
+		itemChargePlugin.onChatMessage(chatMessageUse);
+		verify(configManager).setRSProfileConfiguration(ItemChargeConfig.GROUP, ItemChargeConfig.KEY_RING_OF_FORGING, 137);
 	}
 
 	@Test

--- a/runelite-client/src/test/java/net/runelite/client/plugins/itemcharges/ItemChargePluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/itemcharges/ItemChargePluginTest.java
@@ -186,7 +186,8 @@ public class ItemChargePluginTest
 	}
 
 	@Test
-	public void testRofTwo(){
+	public void testRofTwo()
+	{
 		when(configManager.getRSProfileConfiguration(ItemChargeConfig.GROUP, ItemChargeConfig.KEY_RING_OF_FORGING, Integer.class)).thenReturn(140);
 		// Create equipment inventory with ring of forging
 		ItemContainer equipmentItemContainer = mock(ItemContainer.class);
@@ -197,7 +198,7 @@ public class ItemChargePluginTest
 		//varrock platebody proc
 		ChatMessage chatMessageEffect = new ChatMessage(null, ChatMessageType.SPAM, "", USED_RING_OF_FORGING_VARROCK_PLATEBODY, "", 0);
 		//ring of forging proc
-		ChatMessage chatMessageUse = new ChatMessage(null, ChatMessageType.SPAM, "", USED_RING_OF_FORGING,"",0);
+		ChatMessage chatMessageUse = new ChatMessage(null, ChatMessageType.SPAM, "", USED_RING_OF_FORGING, "", 0);
 
 		itemChargePlugin.onChatMessage(chatMessageEffect);
 		itemChargePlugin.onChatMessage(chatMessageUse);
@@ -531,6 +532,7 @@ public class ItemChargePluginTest
 		itemChargePlugin.onChatMessage(chatMessage);
 		verify(configManager).setRSProfileConfiguration(ItemChargeConfig.GROUP, ItemChargeConfig.KEY_BRACELET_OF_CLAY, 28);
 	}
+
 	@Test
 	public void testBraceletOfClayUseTrahaearn()
 	{


### PR DESCRIPTION
Changed the implementation of the varrock platebody proc when smelting with the ring of forging.
Previously, the plugin would only check if the inventory has 2 or more iron ore and could be accidentally triggered if smelting another ore with 2 iron ore somewhere in the inventory (i.e., smelting a full inventory of gold ore, but two slots are replaced with iron ore)

Now, an additional boolean variable has been implemented to save whether the varrock platebody has procced. If the next chat message is smelting iron ore, it will minus two from the current ring of forging charges. If the next message were to not be smelting iron ore, the saved variable would then be set back to false until the next time the varrock platebody effect procs.