### PR TITLE
banktags: Fix potion storage's potions to have duplicate-item & remove-layout in an active layout

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/banktags/tabs/TabInterface.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/banktags/tabs/TabInterface.java
@@ -771,7 +771,7 @@ public class TabInterface
 	{
 		if ((activeOptions & BankTagsService.OPTION_ALLOW_MODIFICATIONS) != 0
 			&& event.getActionParam1() == InterfaceID.Bankmain.ITEMS
-			&& event.getOption().equals("Examine"))
+			&& event.getOption().equals("Withdraw-1"))
 		{
 			if (activeLayout != null)
 			{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/banktags/tabs/TabInterface.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/banktags/tabs/TabInterface.java
@@ -769,14 +769,15 @@ public class TabInterface
 	@Subscribe
 	private void onMenuEntryAdded(MenuEntryAdded event)
 	{
+		boolean potionStorage = false;
 		if ((activeOptions & BankTagsService.OPTION_ALLOW_MODIFICATIONS) != 0
 			&& event.getActionParam1() == InterfaceID.Bankmain.ITEMS
 			&& (event.getOption().equals("Examine")
-				|| (event.getOption().equals("Withdraw-All-but-1") && client.getItemContainer(InventoryID.BANK) != null && !Objects.requireNonNull(client.getItemContainer(InventoryID.BANK)).contains(event.getItemId()))))
+				|| (potionStorage = event.getOption().equals("Withdraw-All-but-1") && client.getItemContainer(InventoryID.BANK) != null && !Objects.requireNonNull(client.getItemContainer(InventoryID.BANK)).contains(event.getItemId()))))
 		{
 			if (activeLayout != null)
 			{
-				client.createMenuEntry(-1)
+				client.createMenuEntry(!potionStorage ? -1 : 1)
 					.setParam0(event.getActionParam0())
 					.setParam1(event.getActionParam1())
 					.setTarget(event.getTarget())
@@ -789,7 +790,7 @@ public class TabInterface
 
 			if (activeLayout != null && activeLayout.count(itemManager.canonicalize(event.getItemId())) > 1)
 			{
-				client.createMenuEntry(-1)
+				client.createMenuEntry(!potionStorage ? -1 : 2)
 					.setParam0(event.getActionParam0())
 					.setParam1(event.getActionParam1())
 					.setTarget(event.getTarget())

--- a/runelite-client/src/main/java/net/runelite/client/plugins/banktags/tabs/TabInterface.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/banktags/tabs/TabInterface.java
@@ -771,7 +771,8 @@ public class TabInterface
 	{
 		if ((activeOptions & BankTagsService.OPTION_ALLOW_MODIFICATIONS) != 0
 			&& event.getActionParam1() == InterfaceID.Bankmain.ITEMS
-			&& event.getOption().equals("Withdraw-1"))
+			&& (event.getOption().equals("Examine")
+				|| (event.getOption().equals("Withdraw-All-but-1") && client.getItemContainer(InventoryID.BANK) != null && !Objects.requireNonNull(client.getItemContainer(InventoryID.BANK)).contains(event.getItemId()))))
 		{
 			if (activeLayout != null)
 			{


### PR DESCRIPTION
Switching from Examine to Withdraw-1 & detect if an item is in potion storage allows Duplicate-Item and Remove-layout to be added, because Examine is not on a potion coming from potion storage. 

Fixes #18983