### PR TITLE
Loot tracker: add cave horror metadata to figure out GDT chaos talismans rectangle

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
@@ -808,6 +808,17 @@ public class LootTrackerPlugin extends Plugin
 			md.setR8(client.getVarbitValue(VarbitID.LEAGUE_RELIC_SELECTION_7));
 			return md;
 		}
+		else if (npc.getName() != null && npc.getName().equals("Cave horror"))
+		{
+			WorldPoint location = client.getLocalPlayer().getWorldLocation();
+			return Map.of(
+				"id", npc.getId(),
+				"x", location.getX(),
+				"y", location.getY(),
+				"plane", location.getPlane(),
+				"world", client.getWorld()
+			);
+		}
 		else
 		{
 			return npc.getId();


### PR DESCRIPTION
The wiki is sure about coordinates for the northern, eastern, and western edges of the the rectangle inside which the gem drop table drops chaos instead of nature talismans.

The southern edge is a bit weird though, because apparently it uses a local coordinate of 130 where the max should be 63, and nobody's quite sure whether the 130 is treated as 130 or 63 or 13 or something else. It seems almost certain that 130=130, though, in which case the SW/NE corners are (1920, 9474), (3903, 11263).

Cave horrors are found just south of (presumably) the southern edge of the chaos rectangle, so we'd expect them to drop 100% nature talismans, and yet we consistently see a small number of chaos talismans coming through. So at least temporarily we'd like to gather a bit of metadata for these guys and make sure we're accounting for everything.