### PR TITLE
Fix the bug in the Key Mappings plugin with dialog options

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/keyremapping/KeyRemappingListener.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/keyremapping/KeyRemappingListener.java
@@ -168,7 +168,7 @@ class KeyRemappingListener implements KeyListener
 			}
 
 			// Allow numeric keys to select dialog options, ignoring CTRL mapping
-			if (plugin.isDialogOpen() && plugin.isOptionsDialogOpen() && config.control().matches(e) && Character.isDigit(e.getKeyChar()))
+			if (plugin.isOptionsDialogOpen() && config.control().matches(e) && Character.isDigit(e.getKeyChar()))
 			{
 				mappedKeyCode = e.getKeyCode();
 			}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/keyremapping/KeyRemappingListener.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/keyremapping/KeyRemappingListener.java
@@ -162,15 +162,9 @@ class KeyRemappingListener implements KeyListener
 				mappedKeyCode = KeyEvent.VK_SPACE;
 			}
 
-			if (config.control().matches(e))
+			if (!plugin.isOptionsDialogOpen() && config.control().matches(e))
 			{
 				mappedKeyCode = KeyEvent.VK_CONTROL;
-			}
-
-			// Allow numeric keys to select dialog options, ignoring CTRL mapping
-			if (plugin.isOptionsDialogOpen() && config.control().matches(e))
-			{
-				mappedKeyCode = e.getKeyCode();
 			}
 
 			if (mappedKeyCode != KeyEvent.VK_UNDEFINED && mappedKeyCode != e.getKeyCode())

--- a/runelite-client/src/main/java/net/runelite/client/plugins/keyremapping/KeyRemappingListener.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/keyremapping/KeyRemappingListener.java
@@ -167,6 +167,12 @@ class KeyRemappingListener implements KeyListener
 				mappedKeyCode = KeyEvent.VK_CONTROL;
 			}
 
+			// Allow numeric keys to select dialog options, ignoring CTRL mapping
+			if (plugin.isDialogOpen() && plugin.isOptionsDialogOpen() && config.control().matches(e) && Character.isDigit(e.getKeyChar()))
+			{
+				mappedKeyCode = e.getKeyCode();
+			}
+
 			if (mappedKeyCode != KeyEvent.VK_UNDEFINED && mappedKeyCode != e.getKeyCode())
 			{
 				final char keyChar = e.getKeyChar();

--- a/runelite-client/src/main/java/net/runelite/client/plugins/keyremapping/KeyRemappingListener.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/keyremapping/KeyRemappingListener.java
@@ -168,7 +168,7 @@ class KeyRemappingListener implements KeyListener
 			}
 
 			// Allow numeric keys to select dialog options, ignoring CTRL mapping
-			if (plugin.isOptionsDialogOpen() && config.control().matches(e) && Character.isDigit(e.getKeyChar()))
+			if (plugin.isOptionsDialogOpen() && config.control().matches(e))
 			{
 				mappedKeyCode = e.getKeyCode();
 			}


### PR DESCRIPTION
Fix the bug in the Key Mappings plugin where if you are in a dialog with options to choose, then we ignore the ctrl mapping when it is mapped to a valid integer speech option

Original Issue: [https://github.com/runelite/runelite/issues/18135](https://github.com/runelite/runelite/issues/18135)

Smoke test passes:
![Screenshot 2025-05-14 at 10 16 18 PM](https://github.com/user-attachments/assets/2e2c2870-0970-4602-9bc8-7d539c91c630)

