### PR TITLE
timers: update death charge for yama changes

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/timersandbuffs/GameTimer.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timersandbuffs/GameTimer.java
@@ -82,7 +82,7 @@ enum GameTimer
 	SHADOW_VEIL(SpriteID.SPELL_SHADOW_VEIL, GameTimerImageType.SPRITE, "Shadow veil", true),
 	RESURRECT_THRALL(SpriteID.SPELL_RESURRECT_SUPERIOR_SKELETON, GameTimerImageType.SPRITE, "Resurrect thrall", false),
 	WARD_OF_ARCEUUS(SpriteID.SPELL_WARD_OF_ARCEUUS, GameTimerImageType.SPRITE, "Ward of Arceuus", true),
-	DEATH_CHARGE(SpriteID.SPELL_DEATH_CHARGE, GameTimerImageType.SPRITE, "Death charge", false),
+	DEATH_CHARGE(SpriteID.SPELL_DEATH_CHARGE, GameTimerImageType.SPRITE, "Death charge", 60, ChronoUnit.SECONDS, false),
 	MARK_OF_DARKNESS(SpriteID.SPELL_MARK_OF_DARKNESS, GameTimerImageType.SPRITE, "Mark of Darkness", true),
 	SHADOW_VEIL_COOLDOWN(SpriteID.SPELL_SHADOW_VEIL_DISABLED, GameTimerImageType.SPRITE, "Shadow veil cooldown", 30, ChronoUnit.SECONDS),
 	RESURRECT_THRALL_COOLDOWN(SpriteID.SPELL_RESURRECT_SUPERIOR_SKELETON_DISABLED, GameTimerImageType.SPRITE, "Resurrect thrall cooldown", 17, GAME_TICKS),

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timersandbuffs/TimersAndBuffsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timersandbuffs/TimersAndBuffsPlugin.java
@@ -143,6 +143,8 @@ public class TimersAndBuffsPlugin extends Plugin
 	private WorldPoint lastPoint;
 	private ElapsedTimer tzhaarTimer;
 
+	private int lastDeathChargeVarb;
+
 	private final Map<GameCounter, BuffCounter> varCounters = new EnumMap<>(GameCounter.class);
 	private static final int ECLIPSE_MOON_REGION_ID = 6038;
 
@@ -186,6 +188,7 @@ public class TimersAndBuffsPlugin extends Plugin
 		nextOverloadRefreshTick = 0;
 		nextAntifireTick = 0;
 		nextSuperAntifireTick = 0;
+		lastDeathChargeVarb = 0;
 		removeTzhaarTimer();
 		varTimers.clear();
 		infoBoxManager.removeIf(buffCounter -> buffCounter instanceof BuffCounter);
@@ -304,14 +307,25 @@ public class TimersAndBuffsPlugin extends Plugin
 
 		if (event.getVarbitId() == VarbitID.ARCEUUS_DEATH_CHARGE_ACTIVE && config.showArceuus())
 		{
-			if (event.getValue() == 1)
+			final int deathChargeVarb = event.getValue();
+
+			switch (deathChargeVarb)
 			{
-				createGameTimer(DEATH_CHARGE, Duration.of(client.getRealSkillLevel(Skill.MAGIC), RSTimeUnit.GAME_TICKS));
+				case 2:
+					createGameTimer(DEATH_CHARGE);
+					break;
+				case 1:
+					if (lastDeathChargeVarb == 0)
+					{
+						createGameTimer(DEATH_CHARGE);
+					}
+					break;
+				case 0:
+					removeGameTimer(DEATH_CHARGE);
+					break;
 			}
-			else
-			{
-				removeGameTimer(DEATH_CHARGE);
-			}
+
+			lastDeathChargeVarb = deathChargeVarb;
 		}
 
 		if (event.getVarbitId() == VarbitID.ARCEUUS_RESURRECTION_ACTIVE && event.getValue() == 0 && config.showArceuus())

--- a/runelite-client/src/test/java/net/runelite/client/plugins/timersandbuffs/TimersAndBuffsPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/timersandbuffs/TimersAndBuffsPluginTest.java
@@ -349,7 +349,6 @@ public class TimersAndBuffsPluginTest
 	public void testDeathChargeCast()
 	{
 		when(timersAndBuffsConfig.showArceuus()).thenReturn(true);
-		when(client.getRealSkillLevel(Skill.MAGIC)).thenReturn(50);
 		VarbitChanged varbitChanged = new VarbitChanged();
 		varbitChanged.setVarbitId(VarbitID.ARCEUUS_DEATH_CHARGE_ACTIVE);
 		varbitChanged.setValue(1);
@@ -359,7 +358,21 @@ public class TimersAndBuffsPluginTest
 		verify(infoBoxManager).addInfoBox(ibcaptor.capture());
 		TimerTimer infoBox = (TimerTimer) ibcaptor.getValue();
 		assertEquals(GameTimer.DEATH_CHARGE, infoBox.getTimer());
-		assertEquals(Duration.of(50, RSTimeUnit.GAME_TICKS), infoBox.getDuration());
+	}
+
+	@Test
+	public void testImprovedDeathChargeCast()
+	{
+		when(timersAndBuffsConfig.showArceuus()).thenReturn(true);
+		VarbitChanged varbitChanged = new VarbitChanged();
+		varbitChanged.setVarbitId(VarbitID.ARCEUUS_DEATH_CHARGE_ACTIVE);
+		varbitChanged.setValue(2);
+		timersAndBuffsPlugin.onVarbitChanged(varbitChanged);
+
+		ArgumentCaptor<InfoBox> ibcaptor = ArgumentCaptor.forClass(InfoBox.class);
+		verify(infoBoxManager).addInfoBox(ibcaptor.capture());
+		TimerTimer infoBox = (TimerTimer) ibcaptor.getValue();
+		assertEquals(GameTimer.DEATH_CHARGE, infoBox.getTimer());
 	}
 
 	@Test


### PR DESCRIPTION
Updated the death charge timer for the changes observed after Yama release.
- Death charge timer will now properly appear whether or not you've used the [Rite of vile transference](https://oldschool.runescape.wiki/w/Rite_of_vile_transference).
- Removed the variable death charge time as it was observed that death charge lasted a full minute on both an account with 99 mage as well as one with 81 mage.