### PR TITLE
low detail: avoid npe before login

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/lowmemory/LowMemoryPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/lowmemory/LowMemoryPlugin.java
@@ -112,9 +112,14 @@ public class LowMemoryPlugin extends Plugin
 	@Subscribe
 	public void onBeforeRender(BeforeRender beforeRender)
 	{
+		var wv = client.getTopLevelWorldView();
+		if (wv == null)
+		{
+			return;
+		}
 		// This needs to be set to the current plane, but there is no event for plane change, so
 		// just set it each render.
-		client.getScene().
-			setMinLevel(config.hideLowerPlanes() ? client.getPlane() : 0);
+		wv.getScene().
+			setMinLevel(config.hideLowerPlanes() ? wv.getPlane() : 0);
 	}
 }


### PR DESCRIPTION
avoids deprecated `Client#getScene` and `Client#getPlane`

also fixes:
```
WARN  n.runelite.client.eventbus.EventBus - Uncaught exception in event subscriber
java.lang.NullPointerException: Cannot invoke "net.runelite.api.WorldView.getPlane()" because the return value of "net.runelite.api.Client.getTopLevelWorldView()" is null
        at net.runelite.api.Client.getPlane(Client.java:2241)
        at net.runelite.client.plugins.lowmemory.LowMemoryPlugin.onBeforeRender(LowMemoryPlugin.java:118)
        at net.runelite.client.eventbus.EventBus$Subscriber.invoke(EventBus.java:70)
        at net.runelite.client.eventbus.EventBus.post(EventBus.java:223)
        at net.runelite.client.callback.Hooks.frame(Hooks.java:268)
        at client.pm(client.java:29991)
        at client.bu(client.java)
        at bk.bl(bk.java:472)
        at bk.uq(bk.java)
        at bk.run(bk.java:41826)
        at java.base/java.lang.Thread.run(Thread.java:1583)
```