### PR TITLE
skill calculator: add diabolic worms xp modifier

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/skills/FishingAction.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/skills/FishingAction.java
@@ -25,11 +25,13 @@
 package net.runelite.client.plugins.skillcalculator.skills;
 
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.Set;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import net.runelite.api.gameval.ItemID;
 import static net.runelite.client.plugins.skillcalculator.skills.FishingBonus.ANGLERS_OUTFIT;
+import static net.runelite.client.plugins.skillcalculator.skills.FishingBonus.DIABOLIC_WORMS;
 
 @AllArgsConstructor
 @Getter
@@ -95,10 +97,11 @@ public enum FishingAction implements ItemSkillAction
 			case RAW_HALIBUT:
 			case RAW_BLUEFIN:
 			case RAW_MARLIN:
-				return Set.of(ANGLERS_OUTFIT);
-			default:
+				return Set.of(ANGLERS_OUTFIT, DIABOLIC_WORMS);
+			case RAW_ANGLERFISH:
 				return Collections.emptySet();
+			default:
+				return EnumSet.of(DIABOLIC_WORMS);
 		}
 	}
-
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/skills/FishingBonus.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/skills/FishingBonus.java
@@ -24,6 +24,8 @@
  */
 package net.runelite.client.plugins.skillcalculator.skills;
 
+import java.util.EnumSet;
+import java.util.Set;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -32,8 +34,15 @@ import lombok.Getter;
 public enum FishingBonus implements SkillBonus
 {
 	ANGLERS_OUTFIT("Angler's Outfit", 1.025f),
+	DIABOLIC_WORMS("Diabolic Worms", 0.66f),
 	;
 
 	private final String name;
 	private final float value;
+
+	@Override
+	public Set<FishingBonus> getCanBeStackedWith()
+	{
+		return EnumSet.allOf(FishingBonus.class);
+	}
 }


### PR DESCRIPTION
This adds [diabolic worms](https://oldschool.runescape.wiki/w/Diabolic_worms) as a modifier to the skill calculator's fishing actions, as they give a different amount of experience compared to when anglerfish are caught with sandworms as bait.