### PR TITLE
Fix max length calculation in profile rename

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/ProfilePanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/ProfilePanel.java
@@ -376,24 +376,29 @@ class ProfilePanel extends PluginPanel
 			});
 			((AbstractDocument) name.getDocument()).setDocumentFilter(new DocumentFilter()
 			{
+				private final int MaxProfileNameLength = 30;
 				@Override
 				public void insertString(FilterBypass fb, int offset, String string, AttributeSet attr) throws BadLocationException
 				{
-					super.insertString(fb, offset, filter(string), attr);
+					if (fb.getDocument().getLength() + string.length() <= MaxProfileNameLength) {
+						super.insertString(fb, offset, filter(string), attr);
+					}
 				}
 
 				@Override
 				public void replace(FilterBypass fb, int offset, int length, String text, AttributeSet attrs) throws BadLocationException
 				{
-					super.replace(fb, offset, length, filter(text), attrs);
+					if ((fb.getDocument().getLength() + text.length() - length) <= MaxProfileNameLength) {
+						super.replace(fb, offset, length, filter(text), attrs);
+					}
 				}
 
 				private String filter(String in)
 				{
 					// characters commonly forbidden in file names
 					return CharMatcher.noneOf("/\\<>:\"|?*\r\n\0$")
-						.retainFrom(in)
-						.substring(0, 30);
+						.retainFrom(in);
+
 				}
 			});
 


### PR DESCRIPTION
Previous commit from #18959 removed the ability to edit profile names entirely. `.substring` throws an exception if `endIndex` is greater than the length of the string.

Additionally, the logic was faulty- `in` in `replace` is only the new characters added, usually one character at a time if typing. Filenames > 30 characters were still entirely possible if one typed them rather than pasting.

