### PR TITLE
Skill Calculator: Remove FORESTERS_CAMPFIRE from FiremakingBonus

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/skills/FiremakingBonus.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/skillcalculator/skills/FiremakingBonus.java
@@ -34,7 +34,6 @@ import lombok.Getter;
 public enum FiremakingBonus implements SkillBonus
 {
 	PYROMANCER_OUTFIT("Pyromancer Outfit", 1.025f),
-	FORESTERS_CAMPFIRE("Forester's Campfire", 0.33333333f),
 	MORYTANIA_ELITE_DIARY("Morytania Elite Diary", 1.5f)
 	;
 


### PR DESCRIPTION
- Remove FORESTERS_CAMPFIRE from Firemaking Bonus in line with [29/05/2025](https://secure.runescape.com/m=news/a=13/yama-cas--more?oldschool=1) game update.

> Burning logs at a bonfire now offers the same XP as traditional Firemaking, though they'll still be used at a slower rate than lighting them manually.

The XP modifier on the FORESTERS_CAMPFIRE is now redundant.