### PR TITLE
[Accessibility] Customizable status bar hitpoint modifier colors

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/statusbars/StatusBarsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/statusbars/StatusBarsConfig.java
@@ -119,4 +119,44 @@ public interface StatusBarsConfig extends Config
 	{
 		return BarRenderer.DEFAULT_WIDTH;
 	}
+
+	@ConfigItem(
+		keyName = "poisonedColor",
+		name = "Poisoned color",
+		description = "Changes the color of the hitpoints bar when poisoned.",
+	)
+	default Color poisonedColor()
+	{
+		return new Color(0, 145, 0, 150);
+	}
+
+	@ConfigItem(
+		keyName = "venomedColor",
+		name = "Venomed color",
+		description = "Changes the color of the hitpoints bar when venomed.",
+	)
+	default Color venomedColor()
+	{
+		return new Color(0, 65, 0, 150);
+	}
+
+	@ConfigItem(
+		keyName = "diseaseColor",
+		name = "Disease color",
+		description = "Changes the color of the hitpoints bar when diseased.",
+	)
+	default Color diseaseColor()
+	{
+		return new Color(255, 193, 75, 181);
+	}
+
+	@ConfigItem(
+		keyName = "parasiteColor",
+		name = "Parasite color",
+		description = "Changes the color of the hitpoints bar when infected with parasites.",
+	)
+	default Color parasiteColor()
+	{
+		return new Color(196, 62, 109, 181);
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/statusbars/StatusBarsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/statusbars/StatusBarsConfig.java
@@ -120,6 +120,7 @@ public interface StatusBarsConfig extends Config
 		return BarRenderer.DEFAULT_WIDTH;
 	}
 
+	@Alpha
 	@ConfigItem(
 		keyName = "poisonedColor",
 		name = "Poisoned color",
@@ -130,6 +131,7 @@ public interface StatusBarsConfig extends Config
 		return new Color(0, 145, 0, 150);
 	}
 
+	@Alpha
 	@ConfigItem(
 		keyName = "venomedColor",
 		name = "Venomed color",
@@ -140,6 +142,7 @@ public interface StatusBarsConfig extends Config
 		return new Color(0, 65, 0, 150);
 	}
 
+	@Alpha
 	@ConfigItem(
 		keyName = "diseaseColor",
 		name = "Disease color",
@@ -150,6 +153,7 @@ public interface StatusBarsConfig extends Config
 		return new Color(255, 193, 75, 181);
 	}
 
+	@Alpha
 	@ConfigItem(
 		keyName = "parasiteColor",
 		name = "Parasite color",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/statusbars/StatusBarsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/statusbars/StatusBarsOverlay.java
@@ -60,16 +60,12 @@ class StatusBarsOverlay extends Overlay
 	private static final Color PRAYER_COLOR = new Color(50, 200, 200, 175);
 	private static final Color ACTIVE_PRAYER_COLOR = new Color(57, 255, 186, 225);
 	private static final Color HEALTH_COLOR = new Color(225, 35, 0, 125);
-	private static final Color POISONED_COLOR = new Color(0, 145, 0, 150);
-	private static final Color VENOMED_COLOR = new Color(0, 65, 0, 150);
 	private static final Color HEAL_COLOR = new Color(255, 112, 6, 150);
 	private static final Color PRAYER_HEAL_COLOR = new Color(57, 255, 186, 75);
 	private static final Color ENERGY_HEAL_COLOR = new Color (199,  118, 0, 218);
 	private static final Color RUN_STAMINA_COLOR = new Color(160, 124, 72, 255);
 	private static final Color SPECIAL_ATTACK_COLOR = new Color(3, 153, 0, 195);
 	private static final Color ENERGY_COLOR = new Color(199, 174, 0, 220);
-	private static final Color DISEASE_COLOR = new Color(255, 193, 75, 181);
-	private static final Color PARASITE_COLOR = new Color(196, 62, 109, 181);
 	private static final int HEIGHT = 252;
 	private static final int RESIZED_BOTTOM_HEIGHT = 272;
 	private static final int RESIZED_BOTTOM_OFFSET_Y = 12;
@@ -120,22 +116,22 @@ class StatusBarsOverlay extends Overlay
 
 				if (poisonState >= 1000000)
 				{
-					return VENOMED_COLOR;
+					return config.venomedColor();
 				}
 
 				if (poisonState > 0)
 				{
-					return POISONED_COLOR;
+					return config.poisonedColor();
 				}
 
 				if (client.getVarpValue(VarPlayerID.DISEASE) > 0)
 				{
-					return DISEASE_COLOR;
+					return config.diseaseColor();
 				}
 
 				if (client.getVarbitValue(VarbitID.PARASITE) >= 1)
 				{
-					return PARASITE_COLOR;
+					return config.parasiteColor();
 				}
 
 				return HEALTH_COLOR;


### PR DESCRIPTION
the poison, venom, disease, and parasite modifier colors can be very hard to read and differentiate for color blind users of the hitpoints bar in the status bar plugin. This PR adds color pickers to the config to allow customization for accessibility sake.