### PR TITLE
xptracker: restore xp tracker state on rsprofile change

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerPlugin.java
@@ -236,6 +236,7 @@ public class XpTrackerPlugin extends Plugin
 		{
 			saveSaveState(event.getPreviousProfile(), save);
 		}
+		resetState();
 	}
 
 	@Subscribe


### PR DESCRIPTION
Resolves the behavior described in #19083 in which saved XP tracker sessions are wiped when hopping between world types which use separate RuneScapeProfile types