### PR TITLE
Clamp Kingdom of Miscellania approval estimates to 25%

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/kingdomofmiscellania/KingdomPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/kingdomofmiscellania/KingdomPlugin.java
@@ -232,7 +232,8 @@ public class KingdomPlugin extends Plugin
 		float dailyPercentage = isRoyalTroubleCompleted() ? APPROVAL_DECREMENT_ROYAL_TROUBLE : APPROVAL_DECREMENT_BASE;
 
 		int newApproval = lastApproval;
-		if (newApproval > 25) {
+		if (newApproval > 25)
+		{
 			newApproval -= (int) (daysSince * dailyPercentage * MAX_APPROVAL);
 			newApproval = Math.max(newApproval, 25);
 		}


### PR DESCRIPTION
I did this in the web editor without testing! But you can see what I'm going for. Currently, the Kingdom of Miscellania estimates become wrong once your approval hits the 25% mark. This is because your approval will not decrease below 25% unless you take active measures to achieve this, such as killing civilians, but the plugin only had a minimum of 0 set. 