### PR TITLE
xptracker: save drag-and-drop order and compact view toggle to profile

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpInfoBox.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpInfoBox.java
@@ -252,7 +252,7 @@ class XpInfoBox extends JPanel
 			{
 				if (e.getButton() == MouseEvent.BUTTON1)
 				{
-					toggleCompactView();
+					xpTrackerPlugin.setSkillCompactViewState(skill, toggleCompactView());
 				}
 			}
 		};
@@ -275,10 +275,11 @@ class XpInfoBox extends JPanel
 		SwingUtilities.invokeLater(() -> rebuildAsync(updated, paused, xpSnapshotSingle));
 	}
 
-	private void toggleCompactView()
+	private boolean toggleCompactView()
 	{
 		final boolean isCompact = !headerPanel.isVisible();
 		setCompactView(!isCompact);
+		return !isCompact;
 	}
 
 	private void setCompactView(final boolean compact)
@@ -364,6 +365,8 @@ class XpInfoBox extends JPanel
 			}
 
 			progressBar.setDimmed(skillPaused);
+
+			setCompactView(xpSnapshotSingle.isCompactView());
 		}
 		else if (!paused && skillPaused)
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpPanel.java
@@ -32,7 +32,6 @@ import java.util.Map;
 import java.util.Set;
 import javax.swing.BoxLayout;
 import javax.swing.ImageIcon;
-import javax.swing.JComponent;
 import javax.swing.JLabel;
 import javax.swing.JMenuItem;
 import javax.swing.JPanel;
@@ -151,7 +150,12 @@ class XpPanel extends PluginPanel
 		overallPanel.add(overallIcon, BorderLayout.WEST);
 		overallPanel.add(overallInfo, BorderLayout.CENTER);
 
-		final JComponent infoBoxPanel = new DragAndDropReorderPane();
+		final DragAndDropReorderPane infoBoxPanel = new DragAndDropReorderPane();
+		infoBoxPanel.addDragListener(component ->
+		{
+			XpInfoBox c = (XpInfoBox) component;
+			xpTrackerPlugin.updateSkillOrderState(c.getSkill(), infoBoxPanel.getPosition(component));
+		});
 
 		layoutPanel.add(overallPanel);
 		layoutPanel.add(infoBoxPanel);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpSave.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpSave.java
@@ -27,8 +27,10 @@ package net.runelite.client.plugins.xptracker;
 import com.google.gson.Gson;
 import com.google.gson.annotations.SerializedName;
 import com.google.inject.Inject;
+import java.util.EnumSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Set;
 import net.runelite.api.Skill;
 import net.runelite.client.config.ConfigSerializer;
 import net.runelite.client.config.Serializer;
@@ -37,6 +39,7 @@ import net.runelite.client.config.Serializer;
 class XpSave
 {
 	Map<Skill, XpSaveSingle> skills = new LinkedHashMap<>();
+	Set<Skill> compactViewSkills = EnumSet.noneOf(Skill.class);
 	XpSaveSingle overall;
 }
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpSnapshotSingle.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpSnapshotSingle.java
@@ -45,4 +45,5 @@ class XpSnapshotSingle
 	private String timeTillGoal;
 	private String timeTillGoalHours;
 	private String timeTillGoalShort;
+	private boolean compactView;
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpState.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpState.java
@@ -217,6 +217,21 @@ class XpState
 		return overall.snapshot();
 	}
 
+	void setCompactView(Skill skill, boolean compactView)
+	{
+		xpSkills.get(skill).setCompactView(compactView);
+	}
+
+	void setOrder(Skill skill, int newPosition)
+	{
+		int oldPosition = order.indexOf(skill);
+		if (oldPosition != newPosition)
+		{
+			order.remove(oldPosition);
+			order.add(newPosition, skill);
+		}
+	}
+
 	private void updateOrder(Skill skill)
 	{
 		if (xpTrackerConfig.prioritizeRecentXpSkills())
@@ -252,6 +267,10 @@ class XpState
 			{
 				save.skills.put(skill, state.save());
 			}
+			if (state.isCompactView())
+			{
+				save.compactViewSkills.add(skill);
+			}
 		}
 		save.overall = overall.save();
 		return save;
@@ -269,6 +288,14 @@ class XpState
 			state.restore(s);
 			xpSkills.put(skill, state);
 			order.add(skill);
+		}
+		for (Skill skill : save.compactViewSkills)
+		{
+			XpStateSingle state = xpSkills.get(skill);
+			if (state != null)
+			{
+				state.setCompactView(true);
+			}
 		}
 		overall.restore(save.overall);
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpStateSingle.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpStateSingle.java
@@ -60,6 +60,10 @@ class XpStateSingle
 	private int startLevelExp = 0;
 	private int endLevelExp = 0;
 
+	@Getter
+	@Setter
+	private boolean compactView;
+
 	XpStateSingle(long startXp)
 	{
 		this.startXp = startXp;
@@ -305,6 +309,7 @@ class XpStateSingle
 			.timeTillGoalShort(getTimeTillLevel(XpGoalTimeType.SHORT))
 			.startGoalXp(startLevelExp)
 			.endGoalXp(endLevelExp)
+			.compactView(compactView)
 			.build();
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerPlugin.java
@@ -380,6 +380,28 @@ public class XpTrackerPlugin extends Plugin
 		xpState.resetOverallPerHour();
 	}
 
+	/**
+	 * Update the stored order of a skill, following a drag-and-drop operation that has moved it in the UI.
+	 *
+	 * @param skill       Skill that has been moved
+	 * @param newPosition New 0-indexed position of this skill
+	 */
+	void updateSkillOrderState(Skill skill, int newPosition)
+	{
+		xpState.setOrder(skill, newPosition);
+	}
+
+	/**
+	 * Update the stored 'compact view' state of a skill, following it being toggled via the UI.
+	 *
+	 * @param skill       Skill that has been toggled
+	 * @param compactView New 'compact view' flag
+	 */
+	void setSkillCompactViewState(Skill skill, boolean compactView)
+	{
+		xpState.setCompactView(skill, compactView);
+	}
+
 	@Subscribe
 	public void onStatChanged(StatChanged statChanged)
 	{


### PR DESCRIPTION
Currently the XP tracker allows you to manually reorder skills and to place them in compact view, but neither of these changes are saved to the profile.

This PR fixes this by adding code to synchronise manual reordering to the existing `XpState::order` field, and by adding a new set to `XpSave` that tracks which skills have been made compact.