### PR TITLE
Player Indicators: Highlight true tile for party members

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsConfig.java
@@ -282,4 +282,15 @@ public interface PlayerIndicatorsConfig extends Config
 	{
 		return true;
 	}
+
+	@ConfigItem(
+		position = 16,
+		keyName = "partyDrawTrueTile",
+		name = "Draw true tile for party members",
+		description = "Configures whether or not true tiles for highlighted party members should be drawn."
+	)
+	default boolean partyDrawTrueTile()
+	{
+		return false;
+	}
 }


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/29716be2-8a49-4b64-b49c-277278e6ceec)

I have added an option to Player Indicators plugin to draw true tile for party members.
I was not sure if highlighting true tile would be considered as giving advantage to players in pvp scenarios, but if that is the case I think limiting it to party members can be ok (feel free to correct me)