### PR TITLE
twitch: Added filtering for 7TV ChatSpam module suffix

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/twitch/TwitchPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/twitch/TwitchPlugin.java
@@ -183,9 +183,9 @@ public class TwitchPlugin extends Plugin implements TwitchListener
 		String spamSuffix = Character.toString(0xE0000);
 		return message.endsWith(spamSuffix)
 				? message
-                	.substring(0, message.length() - spamSuffix.length())
-                	.stripTrailing()
-                : message;
+					.substring(0, message.length() - spamSuffix.length())
+					.stripTrailing()
+				: message;
 	}
 
 	@Override


### PR DESCRIPTION
7TV adds a suffix ` \u{E0000}` to messages when sent twice in order to bypass duplicate message detection on twitch. This is an extremely commonly used plugin and feature on Twitch, and renders in game as ??. It's a good idea to filter it.

Before:
![image](https://github.com/user-attachments/assets/1680a53f-9506-4cb1-87e6-fb9f48c07395)

After:
![image](https://github.com/user-attachments/assets/63c3b514-c915-4233-82a4-67d639fa1806)
