### PR TITLE
Introduce caching to hiscore plugin

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/hiscore/HiscorePanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/hiscore/HiscorePanel.java
@@ -38,9 +38,11 @@ import java.awt.event.KeyListener;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.awt.image.BufferedImage;
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ScheduledExecutorService;
 import javax.inject.Inject;
 import javax.swing.BorderFactory;
 import javax.swing.ImageIcon;
@@ -62,7 +64,7 @@ import net.runelite.client.ui.components.materialtabs.MaterialTab;
 import net.runelite.client.ui.components.materialtabs.MaterialTabGroup;
 import net.runelite.client.util.ImageUtil;
 import net.runelite.client.util.QuantityFormatter;
-import net.runelite.client.hiscore.HiscoreClient;
+import net.runelite.client.hiscore.HiscoreManager;
 import net.runelite.client.hiscore.HiscoreEndpoint;
 import net.runelite.client.hiscore.HiscoreResult;
 import net.runelite.client.hiscore.HiscoreSkill;
@@ -128,8 +130,10 @@ public class HiscorePanel extends PluginPanel
 	private final HiscorePlugin plugin;
 	private final HiscoreConfig config;
 	private final NameAutocompleter nameAutocompleter;
-	private final HiscoreClient hiscoreClient;
+	private final HiscoreManager hiscoreManager;
 	private final SpriteManager spriteManager;
+
+	private final ScheduledExecutorService executor;
 
 	private final IconTextField searchBar;
 
@@ -147,13 +151,14 @@ public class HiscorePanel extends PluginPanel
 
 	@Inject
 	public HiscorePanel(Client client, HiscorePlugin plugin, HiscoreConfig config,
-		NameAutocompleter nameAutocompleter, HiscoreClient hiscoreClient, SpriteManager spriteManager)
+						NameAutocompleter nameAutocompleter, HiscoreManager hiscoreManager, SpriteManager spriteManager, ScheduledExecutorService executor)
 	{
 		this.plugin = plugin;
 		this.config = config;
 		this.nameAutocompleter = nameAutocompleter;
-		this.hiscoreClient = hiscoreClient;
+		this.hiscoreManager = hiscoreManager;
 		this.spriteManager = spriteManager;
+		this.executor = executor;
 
 		setBorder(BorderFactory.createEmptyBorder(10, 10, 0, 10));
 		setBackground(ColorScheme.DARK_GRAY_COLOR);
@@ -362,44 +367,58 @@ public class HiscorePanel extends PluginPanel
 
 	private void lookup()
 	{
-		final String lookup = sanitize(searchBar.getText());
+		executor.execute(() -> {
+			final String lookup = sanitize(searchBar.getText());
 
-		if (Strings.isNullOrEmpty(lookup))
-		{
-			return;
-		}
+			if (Strings.isNullOrEmpty(lookup))
+			{
+				return;
+			}
 
-		/* RuneScape usernames can't be longer than 12 characters long */
-		if (lookup.length() > MAX_USERNAME_LENGTH)
-		{
-			searchBar.setIcon(IconTextField.Icon.ERROR);
-			loading = false;
-			return;
-		}
+			/* RuneScape usernames can't be longer than 12 characters long */
+			if (lookup.length() > MAX_USERNAME_LENGTH)
+			{
+				searchBar.setIcon(IconTextField.Icon.ERROR);
+				loading = false;
+				return;
+			}
+			SwingUtilities.invokeLater(() -> {
+				repaint();
 
-		repaint();
+				searchBar.setEditable(false);
+				searchBar.setIcon(IconTextField.Icon.LOADING_DARKER);
+				loading = true;
 
-		searchBar.setEditable(false);
-		searchBar.setIcon(IconTextField.Icon.LOADING_DARKER);
-		loading = true;
+				for (Map.Entry<HiscoreSkill, JLabel> entry : skillLabels.entrySet())
+				{
+					HiscoreSkill skill = entry.getKey();
+					JLabel label = entry.getValue();
+					HiscoreSkillType skillType = skill == null ? HiscoreSkillType.SKILL : skill.getType();
 
-		for (Map.Entry<HiscoreSkill, JLabel> entry : skillLabels.entrySet())
-		{
-			HiscoreSkill skill = entry.getKey();
-			JLabel label = entry.getValue();
-			HiscoreSkillType skillType = skill == null ? HiscoreSkillType.SKILL : skill.getType();
+					label.setText(pad("--", skillType));
+					label.setToolTipText(skill == null ? "Combat" : skill.getName());
+				}
+			});
 
-			label.setText(pad("--", skillType));
-			label.setToolTipText(skill == null ? "Combat" : skill.getName());
-		}
 
-		// if for some reason no endpoint was selected, default to normal
-		if (selectedEndPoint == null)
-		{
-			selectedEndPoint = HiscoreEndpoint.NORMAL;
-		}
+			// if for some reason no endpoint was selected, default to normal
+			if (selectedEndPoint == null)
+			{
+				selectedEndPoint = HiscoreEndpoint.NORMAL;
+			}
 
-		hiscoreClient.lookupAsync(lookup, selectedEndPoint).whenCompleteAsync((result, ex) ->
+			HiscoreResult result = null;
+			try
+			{
+				result = hiscoreManager.lookup(lookup, selectedEndPoint);
+			}
+			catch (IOException e)
+			{
+				log.warn("Error fetching Hiscore data " + e.getMessage());
+			}
+
+			HiscoreResult finalResult = result;
+
 			SwingUtilities.invokeLater(() ->
 			{
 				if (!sanitize(searchBar.getText()).equals(lookup))
@@ -408,13 +427,8 @@ public class HiscorePanel extends PluginPanel
 					return;
 				}
 
-				if (result == null || ex != null)
+				if (finalResult == null)
 				{
-					if (ex != null)
-					{
-						log.warn("Error fetching Hiscore data " + ex.getMessage());
-					}
-
 					searchBar.setIcon(IconTextField.Icon.ERROR);
 					searchBar.setEditable(true);
 					loading = false;
@@ -426,8 +440,9 @@ public class HiscorePanel extends PluginPanel
 				searchBar.setEditable(true);
 				loading = false;
 
-				applyHiscoreResult(result);
-			}));
+				applyHiscoreResult(finalResult);
+			});
+		});
 	}
 
 	private void applyHiscoreResult(HiscoreResult result)

--- a/runelite-client/src/test/java/net/runelite/client/plugins/hiscore/HiscorePanelTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/hiscore/HiscorePanelTest.java
@@ -26,11 +26,15 @@ package net.runelite.client.plugins.hiscore;
 
 import net.runelite.api.Client;
 import net.runelite.client.game.SpriteManager;
-import net.runelite.client.hiscore.HiscoreClient;
 import static net.runelite.client.plugins.hiscore.HiscorePanel.formatLevel;
 import net.runelite.client.hiscore.HiscoreEndpoint;
 import static org.junit.Assert.assertEquals;
+
+import net.runelite.client.hiscore.HiscoreManager;
 import org.junit.Test;
+
+import java.util.concurrent.ScheduledExecutorService;
+
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -42,7 +46,7 @@ public class HiscorePanelTest
 		HiscorePlugin plugin = mock(HiscorePlugin.class);
 		when(plugin.getWorldEndpoint()).thenReturn(HiscoreEndpoint.NORMAL);
 		new HiscorePanel(mock(Client.class), plugin, mock(HiscoreConfig.class),
-			mock(NameAutocompleter.class), mock(HiscoreClient.class), mock(SpriteManager.class));
+			mock(NameAutocompleter.class), mock(HiscoreManager.class), mock(SpriteManager.class), mock(ScheduledExecutorService.class));
 	}
 
 	@Test


### PR DESCRIPTION
This PR changes the hiscore plugin to use the already created HiscoreManager instead of HiscoreClient, allowing hiscore lookups to be cached for an hour.

This is especially useful when switching between lookup endpoints (i.e seeing if someone is an ironman), and when looking up your own stats.

I personally don't think a way to have the user bypass the cache is necessary since hiscores are only updated on logout and the cache is only for an hour but if needed I can add any of these two ways:

* Clear cache when user logs out
* If a username is looked up while already being displayed then refresh the cache. 

This is my first PR here and I'm new to UI programming with Swing/Java suggestions greatly appreciated. 