### PR TITLE
npcunaggroarea: add setting to hide area lines until they have expired

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/npcunaggroarea/NpcAggroAreaConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npcunaggroarea/NpcAggroAreaConfig.java
@@ -140,4 +140,15 @@ public interface NpcAggroAreaConfig extends Config
 	{
 		return false;
 	}
+
+	@ConfigItem(
+			keyName = "hideUnlessExpired",
+			name = "Hide unless expired",
+			description = "Hides area lines until aggression has expired.",
+			position = 10
+	)
+	default boolean hideUnlessExpired()
+	{
+		return false;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/npcunaggroarea/NpcAggroAreaOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npcunaggroarea/NpcAggroAreaOverlay.java
@@ -85,6 +85,10 @@ class NpcAggroAreaOverlay extends Overlay
 		Color outlineColor = config.unaggroAreaColor();
 		if (outlineColor == null || (plugin.getEndTime() != null && Instant.now().isBefore(plugin.getEndTime())))
 		{
+			if (config.hideUnlessExpired())
+			{
+				return null;
+			}
 			outlineColor = config.aggroAreaColor();
 		}
 


### PR DESCRIPTION
Adds an additional config option for npc aggression plugin to hide lines unless aggression has expired.

Normally I have to open the plugin config, and toggle always active for times when I do afk combat. This setting will let me just leave the plugin on at all times, and only see it when I have to run and reset aggro.