### PR TITLE
cannon: Show cannonball count option

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonConfig.java
@@ -105,11 +105,11 @@ public interface CannonConfig extends Config
 		return true;
 	}
 
-	@ConfigItem (
-			keyName = "showAmmoCount",
-			name = "Show cannonball count",
-			description = "Configures whether to show the cannonballs above the cannon.",
-			position = 7
+	@ConfigItem(
+		keyName = "showAmmoCount",
+		name = "Show cannonball count",
+		description = "Configures whether to show the cannonballs above the cannon.",
+		position = 7
 	)
 	default boolean showAmmoCount()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonConfig.java
@@ -104,4 +104,15 @@ public interface CannonConfig extends Config
 	{
 		return true;
 	}
+
+	@ConfigItem (
+			keyName = "showAmmoCount",
+			name = "Show cannonball count",
+			description = "Configures whether to show the cannonballs above the cannon.",
+			position = 7
+	)
+	default boolean showAmmoCount()
+	{
+		return true;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonOverlay.java
@@ -79,19 +79,20 @@ class CannonOverlay extends Overlay
 
 		if (localLocation.distanceTo(cannonPoint) <= MAX_OVERLAY_DISTANCE)
 		{
-			Point cannonLoc = Perspective.getCanvasTextLocation(client,
-				graphics,
-				cannonPoint,
-				String.valueOf(plugin.getCballsLeft()), 150);
+			if (config.showAmmoCount()) {
+				Point cannonLoc = Perspective.getCanvasTextLocation(client,
+						graphics,
+						cannonPoint,
+						String.valueOf(plugin.getCballsLeft()), 150);
 
-			if (cannonLoc != null)
-			{
-				textComponent.setText(String.valueOf(plugin.getCballsLeft()));
-				textComponent.setPosition(new java.awt.Point(cannonLoc.getX(), cannonLoc.getY()));
-				textComponent.setColor(plugin.getStateColor());
-				textComponent.render(graphics);
+				if (cannonLoc != null)
+				{
+					textComponent.setText(String.valueOf(plugin.getCballsLeft()));
+					textComponent.setPosition(new java.awt.Point(cannonLoc.getX(), cannonLoc.getY()));
+					textComponent.setColor(plugin.getStateColor());
+					textComponent.render(graphics);
+				}
 			}
-
 			if (config.showDoubleHitSpot())
 			{
 				Color color = config.highlightDoubleHitColor();

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonOverlay.java
@@ -107,7 +107,6 @@ class CannonOverlay extends Overlay
 
 	/**
 	 * Draw the double hit spots on a 6 by 6 grid around the cannon
-	 *
 	 * @param startTile The position of the cannon
 	 */
 	private void drawDoubleHitSpots(Graphics2D graphics, LocalPoint startTile, Color color)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cannon/CannonOverlay.java
@@ -79,11 +79,12 @@ class CannonOverlay extends Overlay
 
 		if (localLocation.distanceTo(cannonPoint) <= MAX_OVERLAY_DISTANCE)
 		{
-			if (config.showAmmoCount()) {
+			if (config.showAmmoCount())
+			{
 				Point cannonLoc = Perspective.getCanvasTextLocation(client,
-						graphics,
-						cannonPoint,
-						String.valueOf(plugin.getCballsLeft()), 150);
+					graphics,
+					cannonPoint,
+					String.valueOf(plugin.getCballsLeft()), 150);
 
 				if (cannonLoc != null)
 				{
@@ -106,6 +107,7 @@ class CannonOverlay extends Overlay
 
 	/**
 	 * Draw the double hit spots on a 6 by 6 grid around the cannon
+	 *
 	 * @param startTile The position of the cannon
 	 */
 	private void drawDoubleHitSpots(Graphics2D graphics, LocalPoint startTile, Color color)


### PR DESCRIPTION
Based on suggestion #19124
Adds a config option to the Cannon plugin to toggle the ammo count text above the cannon.

![java_wuazHrlvWL](https://github.com/user-attachments/assets/0c64f6ee-cd29-4053-b215-9cb489bc2b48)

