### PR TITLE
Loot tracker: Cleaning dirty arrowtips

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
@@ -1129,6 +1129,20 @@ public class LootTrackerPlugin extends Plugin
 			{
 				onInvChange(collectInvItems(LootRecordType.EVENT, BIRDNEST_EVENT));
 			}
+			else if (event.getMenuOption().equals("Clean") && event.getItemId() == ItemID.DIRTY_ARROWTIPS)
+			{
+				// Entire stack gets cleaned at once, want to track how many
+				onInvChange((((invItems, groundItems, removedItems) ->
+				{
+					int itemId = event.getItemId();
+					int cnt = removedItems.count(itemId);
+					if (cnt > 0)
+					{
+						String name = itemManager.getItemComposition(itemId).getMembersName();
+						addLoot(name, -1, LootRecordType.EVENT, -1, invItems, cnt);
+					}
+				})));
+			}
 			else if (event.getMenuOption().equals("Open"))
 			{
 				switch (event.getItemId())


### PR DESCRIPTION
Cleaning [dirty arrowtips](https://oldschool.runescape.wiki/w/Dirty_arrowtips) processes the entire stack at once, always converting exactly one dirty arrowtip into one clean one. If you don't have enough inventory space it will process as many as it takes to fill your inventory. They never drop onto the floor.

I more or less copied the code from the hunters sacks bit where it calls `addLoot()` directly with an `amount`, since it's kind of similar in that we want to capture multiple events happening at the same time.

<img width="239" height="301" alt="image" src="https://github.com/user-attachments/assets/2b3e61e2-5ca8-4d1a-8e29-247662147abc" />