### PR TITLE
ground items: deprioritize menu options for items hidden by ownership filter

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
@@ -544,7 +544,7 @@ public class GroundItemsPlugin extends Plugin
 				lastEntry.setTarget(lastEntry.getTarget() + " (" + quantity + ")");
 			}
 
-			if (groundItem.hidden && !groundItem.highlighted && config.deprioritizeHiddenItems())
+			if ((groundItem.hidden || !shouldDisplayItem(config.ownershipFilterMode(), groundItem.getOwnership(), client.getVarbitValue(VarbitID.IRONMAN))) && !groundItem.highlighted && config.deprioritizeHiddenItems())
 			{
 				lastEntry.setDeprioritized(true);
 			}


### PR DESCRIPTION
fixes: https://github.com/runelite/runelite/issues/19188