### PR TITLE
clues: add requirements to penguin clue

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java
@@ -1549,7 +1549,7 @@ public class CrypticClue extends ClueScroll implements NpcClueScroll, ObjectClue
 			.itemId(ItemID.TRAIL_CLUE_MASTER)
 			.text("2 musical birds. Dig in front of the spinning light.")
 			.location(new WorldPoint(2671, 10396, 0))
-			.solution("Dig in front of the spinning light in Ping and Pong's room inside the Iceberg")
+			.solution("Dig in front of the spinning light in Ping and Pong's room inside the Iceberg, A clockwork suit is required to enter the Penguin Outpost.")
 			.build(),
 		CrypticClue.builder()
 			.itemId(ItemID.TRAIL_EASY_SIMPLE_EXP9)


### PR DESCRIPTION
added some context to this clue step to include the clockwork suit that is required to access this area and [align with the wiki](https://oldschool.runescape.wiki/w/Treasure_Trails/Guide/Cryptic_clues#Master_Cryptic_clues)