### PR TITLE
world hopper: toggle to hide unjoinable worlds, allow hiding specific worlds

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldHopperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldHopperConfig.java
@@ -159,4 +159,45 @@ public interface WorldHopperConfig extends Config
 	{
 		return false;
 	}
+
+	@ConfigItem(
+			keyName = "hideUnjoinableWorlds",
+			name = "Hide worlds you cannot join",
+			description = "Hides worlds you cannot join.",
+			position = 12
+			)
+	default boolean hideUnjoinableWorlds()
+	{
+		return false;
+	}
+	@ConfigItem(
+			keyName = "totalLevel",
+			name = "",
+			description = "",
+			hidden = true
+	)
+	default int getTotalLevel()
+	{
+		return 10000;
+	}
+
+	@ConfigItem(
+			keyName = "totalLevel",
+			name = "",
+			description = "",
+			hidden = true
+	)
+	void setTotalLevel(int totalLevel);
+
+	@ConfigItem(
+			keyName = "hiddenWorlds",
+			name = "Hidden Worlds",
+			description = "Comma separated IDs of worlds to hide.",
+			position = 13
+	)
+	default String hiddenWorlds()
+	{
+		return "";
+	}
+
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldSwitcherPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldSwitcherPanel.java
@@ -78,6 +78,10 @@ class WorldSwitcherPanel extends PluginPanel
 	private Set<RegionFilterMode> regionFilterMode;
 	@Setter(AccessLevel.PACKAGE)
 	private Set<WorldTypeFilter> worldTypeFilters;
+	@Setter(AccessLevel.PACKAGE)
+	private boolean hideUnjoinableWorlds;
+	@Setter(AccessLevel.PACKAGE)
+	private Set<Integer> hiddenWorlds;
 
 	WorldSwitcherPanel(WorldHopperPlugin plugin)
 	{
@@ -287,6 +291,22 @@ class WorldSwitcherPanel extends PluginPanel
 				{
 					continue;
 				}
+			}
+
+			if (hideUnjoinableWorlds)
+			{
+				if (world.getTypes().contains(WorldType.SKILL_TOTAL))
+				{
+					if (!this.plugin.isTotalLevelWorldJoinable(world.getActivity().substring(0, world.getActivity().indexOf(" "))))
+					{
+						continue;
+					}
+				}
+			}
+
+			if (!hiddenWorlds.isEmpty() && hiddenWorlds.contains(world.getId()))
+			{
+				continue;
 			}
 
 			rows.add(buildRow(world, i % 2 == 0,


### PR DESCRIPTION
Addressing the last two items in https://github.com/runelite/runelite/issues/435

Added a toggle to hide unjoinable worlds, defaulted to off. For now this is just for total level worlds but could be extended in the future as needed. Also added functionality to hide specific worlds in a comma separated config input, defaulting to empty

Updated config panel below

<img width="232" height="696" alt="Screenshot 2025-07-30 011506" src="https://github.com/user-attachments/assets/dd10e2f6-b0b8-42a8-bb48-28686ab36fbc" />
