### PR TITLE
Add default minimap zoom level option to minimap plugin

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/minimap/MinimapConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/minimap/MinimapConfig.java
@@ -29,6 +29,8 @@ import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
 import net.runelite.client.config.ConfigSection;
+import net.runelite.client.config.Range;
+import net.runelite.client.config.Units;
 
 @ConfigGroup(MinimapConfig.GROUP)
 public interface MinimapConfig extends Config
@@ -38,14 +40,15 @@ public interface MinimapConfig extends Config
 	@ConfigSection(
 		name = "Minimap dot colors",
 		description = "The colors of dots on the minimap.",
-		position = 0
+		position = 4
 	)
 	String minimapDotSection = "minimapDotSection";
 
 	@ConfigItem(
 		keyName = "zoom",
 		name = "Zoom",
-		description = "Enables zooming on the minimap."
+		description = "Enables zooming on the minimap.",
+		position = 2
 	)
 	default boolean zoom()
 	{
@@ -53,9 +56,23 @@ public interface MinimapConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "defaultZoom",
+		name = "Default Zoom",
+		description = "Sets the default zoom level.",
+		position = 3
+	)
+	@Units(Units.PERCENT)
+	@Range(min = 0, max = 100)
+	default int defaultZoom()
+	{
+		return 50;
+	}
+
+	@ConfigItem(
 		keyName = "hideMinimap",
 		name = "Hide minimap",
-		description = "Do not show the minimap on screen (resizable only)."
+		description = "Do not show the minimap on screen (resizable only).",
+		position = 1
 	)
 	default boolean hideMinimap()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/minimap/MinimapPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/minimap/MinimapPlugin.java
@@ -78,6 +78,7 @@ public class MinimapPlugin extends Plugin
 		storeOriginalDots();
 		replaceMapDots();
 		client.setMinimapZoom(config.zoom());
+		client.setMinimapZoom(normalizeZoomPct(config.defaultZoom()));
 	}
 
 	@Override
@@ -111,15 +112,21 @@ public class MinimapPlugin extends Plugin
 			return;
 		}
 
-		if (event.getKey().equals("hideMinimap"))
+		switch (event.getKey())
 		{
-			updateMinimapWidgetVisibility(config.hideMinimap());
-			return;
-		}
-		else if (event.getKey().equals("zoom"))
-		{
-			client.setMinimapZoom(config.zoom());
-			return;
+			case "hideMinimap":
+				updateMinimapWidgetVisibility(config.hideMinimap());
+				return;
+			case "zoom":
+				client.setMinimapZoom(config.zoom());
+				if (config.zoom())
+				{
+					client.setMinimapZoom(normalizeZoomPct(config.defaultZoom()));
+				}
+				return;
+			case "defaultZoom":
+				client.setMinimapZoom(normalizeZoomPct(config.defaultZoom()));
+				return;
 		}
 
 		restoreOriginalDots();
@@ -207,5 +214,12 @@ public class MinimapPlugin extends Plugin
 		}
 
 		System.arraycopy(originalDotSprites, 0, mapDots, 0, mapDots.length);
+	}
+
+	private static double normalizeZoomPct(int zoomPct)
+	{
+		double minZoom = 2.0;
+		double maxZoom = 8.0;
+		return (zoomPct * (maxZoom - minZoom) / 100) + minZoom;
 	}
 }


### PR DESCRIPTION
As per title, I got tired of the zoom level on my minimap resetting every time I launched the client, so I decided to add a default configuration option to the minimap plugin.