### PR TITLE
Loot tracker plugin - track herb runs

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerConfig.java
@@ -138,4 +138,14 @@ public interface LootTrackerConfig extends Config
 	{
 		return true;
 	}
+
+	@ConfigItem(
+		keyName = "enableFarmingLootTracking",
+		name = "Enable Farming Loot Tracking",
+		description = "Track herbs obtained from Farming runs in loot tracker"
+	)
+	default boolean enableFarmingLootTracking()
+	{
+		return true;
+	}
 }


### PR DESCRIPTION
## Overview
This patch will add loot tracking for herb runs (for farming). This could be expanded later into all farming gains, but we should probably have this different section for herb runs and this is a good starting point for all farming gains. This addition should help address https://github.com/runelite/runelite/issues/4126