### PR TITLE
Add Welcome message type to ServerMessage recoloring.

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/chat/ChatMessageManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/chat/ChatMessageManager.java
@@ -546,6 +546,8 @@ public class ChatMessageManager
 				ChatMessageType.GAMEMESSAGE);
 			cacheColor(new ChatColor(ChatColorType.NORMAL, chatColorConfig.opaqueServerMessage(), false),
 				ChatMessageType.ENGINE);
+			cacheColor(new ChatColor(ChatColorType.NORMAL, chatColorConfig.opaqueServerMessage(), false),
+				ChatMessageType.WELCOME);
 		}
 		if (chatColorConfig.opaqueServerMessageHighlight() != null)
 		{
@@ -736,6 +738,8 @@ public class ChatMessageManager
 				ChatMessageType.GAMEMESSAGE);
 			cacheColor(new ChatColor(ChatColorType.NORMAL, chatColorConfig.transparentServerMessage(), true),
 				ChatMessageType.ENGINE);
+			cacheColor(new ChatColor(ChatColorType.NORMAL, chatColorConfig.transparentServerMessage(), true),
+				ChatMessageType.WELCOME);
 		}
 		if (chatColorConfig.transparentServerMessageHighlight() != null)
 		{


### PR DESCRIPTION
Add Welcome message type to ServerMessage recoloring.

The tooltip for the Server Message config says "Color of server messages (eg. 'Welcome to RuneScape').", but it doesn't actually include WELCOME chatMessageType. 

I assume it was part of game message and got changed into it's own chat type at some point.