### PR TITLE
Fix canFilterPlayer to handle names with spaces.

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatfilter/ChatFilterPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatfilter/ChatFilterPlugin.java
@@ -310,7 +310,7 @@ public class ChatFilterPlugin extends Plugin
 
 	boolean canFilterPlayer(String playerName)
 	{
-		boolean isMessageFromSelf = playerName.equals(client.getLocalPlayer().getName());
+		boolean isMessageFromSelf = Text.sanitize(playerName).equals(Text.sanitize(Objects.requireNonNull(client.getLocalPlayer().getName())));
 		return !isMessageFromSelf &&
 			(config.filterFriends() || !client.isFriended(playerName, false)) &&
 			(config.filterFriendsChat() || !isFriendsChatMember(playerName)) &&

--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatfilter/ChatFilterPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatfilter/ChatFilterPlugin.java
@@ -310,7 +310,7 @@ public class ChatFilterPlugin extends Plugin
 
 	boolean canFilterPlayer(String playerName)
 	{
-		boolean isMessageFromSelf = Text.sanitize(playerName).equals(Text.sanitize(Objects.requireNonNull(client.getLocalPlayer().getName())));
+		boolean isMessageFromSelf = Text.sanitize(playerName).equals(Text.sanitize(client.getLocalPlayer().getName()));
 		return !isMessageFromSelf &&
 			(config.filterFriends() || !client.isFriended(playerName, false)) &&
 			(config.filterFriendsChat() || !isFriendsChatMember(playerName)) &&

--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatfilter/ChatFilterPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatfilter/ChatFilterPlugin.java
@@ -310,7 +310,7 @@ public class ChatFilterPlugin extends Plugin
 
 	boolean canFilterPlayer(String playerName)
 	{
-		boolean isMessageFromSelf = Text.sanitize(playerName).equals(Text.sanitize(client.getLocalPlayer().getName()));
+		boolean isMessageFromSelf = client.getLocalPlayer().getName() != null && Text.sanitize(playerName).equals(Text.sanitize(client.getLocalPlayer().getName()));
 		return !isMessageFromSelf &&
 			(config.filterFriends() || !client.isFriended(playerName, false)) &&
 			(config.filterFriendsChat() || !isFriendsChatMember(playerName)) &&


### PR DESCRIPTION
Added Text.sanitize to the playerName and the getLocalPlayer().getName so that names with spaces (\u00A0) are handled as expected.  