### PR TITLE
item stats: add blighted overload

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatChanges.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatChanges.java
@@ -265,6 +265,8 @@ public class ItemStatChanges
 
 		// Regular overload (NMZ)
 		add(combo(SUPER_ATTACK_POT, SUPER_STRENGTH_POT, SUPER_DEFENCE_POT, superRangingPot, superMagicPot, heal(HITPOINTS, -50)), ItemID.NZONE1DOSEOVERLOADPOTION, ItemID.NZONE2DOSEOVERLOADPOTION, ItemID.NZONE3DOSEOVERLOADPOTION, ItemID.NZONE4DOSEOVERLOADPOTION);
+		// Blighted overload (DMM)
+		add(combo(boost(ATTACK, perc(.15, 8)), boost(STRENGTH, perc(.15, 8)), new BoostedStatBoost(DEFENCE, true, perc(.1, -1)), boost(RANGED, perc(.1, 7)), boost(MAGIC, perc(.1, 1)), heal(HITPOINTS, -25)), ItemID.DEADMAN1DOSEOVERLOAD, ItemID.DEADMAN2DOSEOVERLOAD, ItemID.DEADMAN3DOSEOVERLOAD, ItemID.DEADMAN4DOSEOVERLOAD);
 
 		// Bandages (Castle Wars)
 		add(new CastleWarsBandage(), ItemID.CASTLEWARS_BANDAGES);

--- a/runelite-client/src/test/java/net/runelite/client/plugins/itemstats/ItemStatEffectTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/itemstats/ItemStatEffectTest.java
@@ -506,6 +506,47 @@ public class ItemStatEffectTest
 		assertEquals(35, skillChange(Skill.HITPOINTS, 99, 99, saradominBrew));
 	}
 
+	@Test
+	public void testBlightedOverload()
+	{
+		final Effect blightedOverload = new ItemStatChanges().get(ItemID.DEADMAN4DOSEOVERLOAD);
+
+		assertEquals(-25, skillChange(Skill.HITPOINTS, 49, 44, blightedOverload));
+		assertEquals(-25, skillChange(Skill.HITPOINTS, 64, 64, blightedOverload));
+		assertEquals(-25, skillChange(Skill.HITPOINTS, 99, 77, blightedOverload));
+
+		assertEquals(13, skillChange(Skill.STRENGTH, 36, 36, blightedOverload));
+		assertEquals(17, skillChange(Skill.STRENGTH, 66, 66, blightedOverload));
+		assertEquals(19, skillChange(Skill.STRENGTH, 74, 74, blightedOverload));
+		assertEquals(20, skillChange(Skill.STRENGTH, 83, 83, blightedOverload));
+		assertEquals(22, skillChange(Skill.STRENGTH, 99, 99, blightedOverload));
+
+		assertEquals(0, skillChange(Skill.DEFENCE, 1, 0, blightedOverload));
+		assertEquals(-1, skillChange(Skill.DEFENCE, 1, 1, blightedOverload));
+		assertEquals(-3, skillChange(Skill.DEFENCE, 29, 29, blightedOverload));
+		assertEquals(-6, skillChange(Skill.DEFENCE, 54, 54, blightedOverload));
+		assertEquals(-8, skillChange(Skill.DEFENCE, 71, 71, blightedOverload));
+		assertEquals(-10, skillChange(Skill.DEFENCE, 90, 90, blightedOverload));
+		assertEquals(-9, skillChange(Skill.DEFENCE, 99, 89, blightedOverload));
+		assertEquals(-10, skillChange(Skill.DEFENCE, 99, 99, blightedOverload));
+		assertEquals(-11, skillChange(Skill.DEFENCE, 99, 101, blightedOverload));
+		assertEquals(-12, skillChange(Skill.DEFENCE, 99, 113, blightedOverload));
+
+		assertEquals(7, skillChange(Skill.RANGED, 3, 3, blightedOverload));
+		assertEquals(11, skillChange(Skill.RANGED, 49, 49, blightedOverload));
+		assertEquals(14, skillChange(Skill.RANGED, 72, 72, blightedOverload));
+		assertEquals(15, skillChange(Skill.RANGED, 87, 87, blightedOverload));
+		assertEquals(16, skillChange(Skill.RANGED, 99, 99, blightedOverload));
+
+		assertEquals(1, skillChange(Skill.MAGIC, 8, 8, blightedOverload));
+		assertEquals(3, skillChange(Skill.MAGIC, 28, 28, blightedOverload));
+		assertEquals(7, skillChange(Skill.MAGIC, 68, 68, blightedOverload));
+		assertEquals(9, skillChange(Skill.MAGIC, 80, 80, blightedOverload));
+		assertEquals(9, skillChange(Skill.MAGIC, 89, 89, blightedOverload));
+		assertEquals(10, skillChange(Skill.MAGIC, 99, 89, blightedOverload));
+		assertEquals(9, skillChange(Skill.MAGIC, 99, 100, blightedOverload));
+	}
+
 	private int skillChange(Skill skill, int maxValue, int currentValue, Effect effect)
 	{
 		if (effect == null)


### PR DESCRIPTION
This PR adds the blighted overloads to the Item Stats plugin, this potion is only available in DMM type worlds, and has different effects compared to overloads available in COX/NMZ.
Ref #19250 , #19047 (deleted)