### PR TITLE
XP Tracker: show Kills Left/Hour/Done for combat skills; update tooltips and on-screen labels

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpInfoBoxOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpInfoBoxOverlay.java
@@ -90,16 +90,18 @@ class XpInfoBoxOverlay extends OverlayPanel
 
 		final XpSnapshotSingle snapshot = plugin.getSkillSnapshot(skill);
 
-		final String leftStr = config.onScreenDisplayMode().getKey();
-		final String rightNum = config.onScreenDisplayMode().getValueFunc().apply(snapshot);
+		final XpPanelLabel topLabel = config.onScreenDisplayMode();
+		final String leftStr = formatKeyForSkill(topLabel, skill);
+		final String rightNum = topLabel.getValueFunc().apply(snapshot);
 
 		final LineComponent xpLine = LineComponent.builder()
 			.left(leftStr + ":")
 			.right(rightNum)
 			.build();
 
-		final String bottomLeftStr = config.onScreenDisplayModeBottom().getKey();
-		final String bottomRightNum = config.onScreenDisplayModeBottom().getValueFunc().apply(snapshot);
+		final XpPanelLabel bottomLabel = config.onScreenDisplayModeBottom();
+		final String bottomLeftStr = formatKeyForSkill(bottomLabel, skill);
+		final String bottomRightNum = bottomLabel.getValueFunc().apply(snapshot);
 
 		final LineComponent xpLineBottom = LineComponent.builder()
 				.left(bottomLeftStr + ":")
@@ -144,5 +146,39 @@ class XpInfoBoxOverlay extends OverlayPanel
 	public String getName()
 	{
 		return super.getName() + skill.getName();
+	}
+
+	private static boolean isActions(XpPanelLabel label)
+	{
+		return label == XpPanelLabel.ACTIONS_LEFT || label == XpPanelLabel.ACTIONS_HOUR || label == XpPanelLabel.ACTIONS_DONE;
+	}
+
+	private static boolean isCombatSkill(Skill skill)
+	{
+		return skill == Skill.ATTACK
+			|| skill == Skill.STRENGTH
+			|| skill == Skill.DEFENCE
+			|| skill == Skill.HITPOINTS
+			|| skill == Skill.RANGED
+			|| skill == Skill.MAGIC;
+	}
+
+	private static String formatKeyForSkill(XpPanelLabel label, Skill skill)
+	{
+		if (isCombatSkill(skill) && isActions(label))
+		{
+			switch (label)
+			{
+				case ACTIONS_LEFT:
+					return "Kills";
+				case ACTIONS_HOUR:
+					return "Kills/hr";
+				case ACTIONS_DONE:
+					return "Kills Done";
+				default:
+					break;
+			}
+		}
+		return label.getKey();
 	}
 }


### PR DESCRIPTION
Fixes runelite/runelite#19145

For combat skills (Attack, Strength, Defence, Hitpoints, Ranged, Magic), display action metrics as Kills:
- Actions Left -> Kills
- Actions/hr -> Kills/hr
- Actions Done -> Kills Done

Also:
- Progress bar tooltip uses Kills for combat skills; Actions for non-combat skills.
- On-screen overlay labels now relabel to Kills for combat skills when actions-based labels are selected.
- Non-combat behavior unchanged.

Implementation notes:
- Updated XpInfoBox to stop hiding actions for combat skills and relabel keys, and to adjust the tooltip wording dynamically.
- Updated XpInfoBoxOverlay to relabel on-screen keys similarly.
- Consideration: Magic included as a combat skill for this context (consistent XP per kill on tasks).