### PR TITLE
Combat Level Plugin: Include meleeNeed, hpDefNeed, rangeNeed, magicNeed, and prayerNeed in next level tooltip calculation

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/combatlevel/CombatLevelOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/combatlevel/CombatLevelOverlay.java
@@ -118,23 +118,23 @@ class CombatLevelOverlay extends Overlay
 		StringBuilder sb = new StringBuilder();
 		sb.append(ColorUtil.wrapWithColorTag("Next combat level:</br>", COMBAT_LEVEL_COLOUR));
 
-		if ((attackLevel + strengthLevel) < Experience.MAX_REAL_LEVEL * 2)
+		if ((attackLevel + strengthLevel) <= Experience.MAX_REAL_LEVEL * 2)
 		{
 			sb.append(meleeNeed).append(" Attack/Strength</br>");
 		}
-		if ((hitpointsLevel + defenceLevel) < Experience.MAX_REAL_LEVEL * 2)
+		if ((hitpointsLevel + defenceLevel) <= Experience.MAX_REAL_LEVEL * 2)
 		{
 			sb.append(hpDefNeed).append(" Defence/Hitpoints</br>");
 		}
-		if (rangeLevel < Experience.MAX_REAL_LEVEL)
+		if (rangeLevel + rangeNeed <= Experience.MAX_REAL_LEVEL)
 		{
 			sb.append(rangeNeed).append(" Ranged</br>");
 		}
-		if (magicLevel < Experience.MAX_REAL_LEVEL)
+		if (magicLevel + magicNeed <= Experience.MAX_REAL_LEVEL)
 		{
 			sb.append(magicNeed).append(" Magic</br>");
 		}
-		if (prayerLevel < Experience.MAX_REAL_LEVEL)
+		if (prayerLevel + prayerNeed <= Experience.MAX_REAL_LEVEL)
 		{
 			sb.append(prayerNeed).append(" Prayer");
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/combatlevel/CombatLevelOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/combatlevel/CombatLevelOverlay.java
@@ -118,11 +118,11 @@ class CombatLevelOverlay extends Overlay
 		StringBuilder sb = new StringBuilder();
 		sb.append(ColorUtil.wrapWithColorTag("Next combat level:</br>", COMBAT_LEVEL_COLOUR));
 
-		if ((attackLevel + strengthLevel) <= Experience.MAX_REAL_LEVEL * 2)
+		if ((attackLevel + strengthLevel) + meleeNeed <= Experience.MAX_REAL_LEVEL * 2)
 		{
 			sb.append(meleeNeed).append(" Attack/Strength</br>");
 		}
-		if ((hitpointsLevel + defenceLevel) <= Experience.MAX_REAL_LEVEL * 2)
+		if ((hitpointsLevel + defenceLevel) + hpDefNeed <= Experience.MAX_REAL_LEVEL * 2)
 		{
 			sb.append(hpDefNeed).append(" Defence/Hitpoints</br>");
 		}


### PR DESCRIPTION
Closes #19263

The Combat Level Plugin's next level hover tooltip currently displays impossible next level combinations.

This update adds the needed level to the current level when performing the tooltip string builder check, ensuring that only possible next level goals are shown. It also changes the comparison logic from < to <=, to include combinations that add up exactly to 99 (or 198 in cases of combinations like atk/str, hp/def).

Behavior before (75 Range + Required 33 = 108, 77 Magic + Required 31 = 108):
<div><img width="221" height="186" alt="Screenshot 2025-08-12 at 12 04 38 AM" src="https://github.com/user-attachments/assets/4f6b128d-c698-4112-b65e-1d02960912ee" /><img width="199" height="265" alt="Screenshot 2025-08-12 at 12 05 16 AM" src="https://github.com/user-attachments/assets/0ec6c230-9730-44d5-97a9-2122d60bd51f" />
<div>

Behavior after:
<img width="232" height="204" alt="Screenshot 2025-08-12 at 12 08 08 AM" src="https://github.com/user-attachments/assets/ccd697c1-62e8-4879-90ec-86c773cba6ea" />

