### PR TITLE
npcunaggroarea: Add minimap overlay

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/npcunaggroarea/NpcAggroAreaConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npcunaggroarea/NpcAggroAreaConfig.java
@@ -84,12 +84,23 @@ public interface NpcAggroAreaConfig extends Config
 		return false;
 	}
 
+	@ConfigItem(
+		keyName = "npcUnaggroShowMinimapAreaLines",
+		name = "Show minimap area lines",
+		description = "Display minimap lines, when walked past, the unaggressive timer resets.",
+		position = 5
+	)
+	default boolean showMinimapAreaLines()
+	{
+		return false;
+	}
+
 	@Alpha
 	@ConfigItem(
 		keyName = "npcAggroAreaColor",
 		name = "Aggressive color",
 		description = "Choose color to use for marking NPC unaggressive area when NPCs are aggressive.",
-		position = 5
+		position = 6
 	)
 	default Color aggroAreaColor()
 	{
@@ -101,7 +112,7 @@ public interface NpcAggroAreaConfig extends Config
 		keyName = "npcUnaggroAreaColor",
 		name = "Unaggressive color",
 		description = "Choose color to use for marking NPC unaggressive area after NPCs have lost aggression.",
-		position = 6
+		position = 7
 	)
 	default Color unaggroAreaColor()
 	{
@@ -112,7 +123,7 @@ public interface NpcAggroAreaConfig extends Config
 		keyName = "notifyExpire",
 		name = "Notify expiration",
 		description = "Send a notification when the unaggressive timer expires.",
-		position = 7
+		position = 8
 	)
 	default Notification notifyExpire()
 	{
@@ -123,7 +134,7 @@ public interface NpcAggroAreaConfig extends Config
 		keyName = "hideIfOutOfCombat",
 		name = "Hide when out of combat",
 		description = "Hides unaggressive area lines when out of combat.",
-		position = 8
+		position = 9
 	)
 	default boolean hideIfOutOfCombat()
 	{
@@ -134,7 +145,7 @@ public interface NpcAggroAreaConfig extends Config
 		keyName = "showOnSlayerTask",
 		name = "Show on slayer task",
 		description = "Enable for current slayer task NPCs.",
-		position = 9
+		position = 10
 	)
 	default boolean showOnSlayerTask()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/npcunaggroarea/NpcAggroAreaMinimapOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npcunaggroarea/NpcAggroAreaMinimapOverlay.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2018, Woox <https://github.com/wooxsolo>
+ * Copyright (c) 2025, Skretzo <https://github.com/skretzo>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.npcunaggroarea;
+
+import java.awt.BasicStroke;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Graphics2D;
+import java.awt.Rectangle;
+import java.awt.geom.GeneralPath;
+import java.time.Instant;
+import javax.inject.Inject;
+import net.runelite.api.Client;
+import net.runelite.api.Perspective;
+import net.runelite.api.Player;
+import net.runelite.api.Point;
+import net.runelite.api.coords.LocalPoint;
+import net.runelite.api.geometry.Geometry;
+import net.runelite.client.ui.overlay.Overlay;
+import net.runelite.client.ui.overlay.OverlayLayer;
+import net.runelite.client.ui.overlay.OverlayPosition;
+
+class NpcAggroAreaMinimapOverlay extends Overlay
+{
+	private static final int MAX_LOCAL_DRAW_LENGTH = 40 * Perspective.LOCAL_TILE_SIZE;
+
+	private final Client client;
+	private final NpcAggroAreaConfig config;
+	private final NpcAggroAreaPlugin plugin;
+
+	@Inject
+	private NpcAggroAreaMinimapOverlay(Client client, NpcAggroAreaConfig config, NpcAggroAreaPlugin plugin)
+	{
+		this.client = client;
+		this.config = config;
+		this.plugin = plugin;
+
+		setPosition(OverlayPosition.DYNAMIC);
+		setLayer(OverlayLayer.ABOVE_WIDGETS);
+	}
+
+	@Override
+	public Dimension render(Graphics2D graphics)
+	{
+		if (!plugin.isActive() || plugin.getSafeCenters()[1] == null)
+		{
+			return null;
+		}
+
+		final Player localPlayer = client.getLocalPlayer();
+		if (localPlayer.getHealthScale() == -1 && config.hideIfOutOfCombat())
+		{
+			return null;
+		}
+
+		GeneralPath lines = plugin.getLinesToDisplay()[client.getPlane()];
+		if (lines == null)
+		{
+			return null;
+		}
+
+		Color outlineColor = config.unaggroAreaColor();
+		if (outlineColor == null || (plugin.getEndTime() != null && Instant.now().isBefore(plugin.getEndTime())))
+		{
+			outlineColor = config.aggroAreaColor();
+		}
+
+		renderPath(graphics, lines, outlineColor);
+		return null;
+	}
+
+	private void renderPath(Graphics2D graphics, GeneralPath path, Color color)
+	{
+		LocalPoint playerLp = client.getLocalPlayer().getLocalLocation();
+		Rectangle viewArea = new Rectangle(
+			playerLp.getX() - MAX_LOCAL_DRAW_LENGTH,
+			playerLp.getY() - MAX_LOCAL_DRAW_LENGTH,
+			MAX_LOCAL_DRAW_LENGTH * 2,
+			MAX_LOCAL_DRAW_LENGTH * 2);
+
+		graphics.setColor(color);
+		graphics.setStroke(new BasicStroke(1));
+
+		path = Geometry.clipPath(path, viewArea);
+		path = Geometry.filterPath(path, (p1, p2) ->
+			Perspective.localToMinimap(client, new LocalPoint((int)p1[0], (int)p1[1])) != null &&
+			Perspective.localToMinimap(client, new LocalPoint((int)p2[0], (int)p2[1])) != null);
+		path = Geometry.transformPath(path, coords ->
+		{
+			Point point = Perspective.localToMinimap(client, new LocalPoint((int)coords[0], (int)coords[1]));
+			coords[0] = point.getX();
+			coords[1] = point.getY();
+		});
+
+		graphics.draw(path);
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/npcunaggroarea/NpcAggroAreaMinimapOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npcunaggroarea/NpcAggroAreaMinimapOverlay.java
@@ -77,7 +77,7 @@ class NpcAggroAreaMinimapOverlay extends Overlay
 		}
 
 		GeneralPath lines = plugin.getLinesToDisplay()[client.getPlane()];
-		if (lines == null)
+		if (lines == null || !config.showMinimapAreaLines())
 		{
 			return null;
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/npcunaggroarea/NpcAggroAreaOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npcunaggroarea/NpcAggroAreaOverlay.java
@@ -77,7 +77,7 @@ class NpcAggroAreaOverlay extends Overlay
 		}
 
 		GeneralPath lines = plugin.getLinesToDisplay()[client.getPlane()];
-		if (lines == null)
+		if (lines == null || !config.showAreaLines())
 		{
 			return null;
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/npcunaggroarea/NpcAggroAreaPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npcunaggroarea/NpcAggroAreaPlugin.java
@@ -209,7 +209,7 @@ public class NpcAggroAreaPlugin extends Plugin
 
 	private void calculateLinesToDisplay()
 	{
-		if (!active || !config.showAreaLines())
+		if (!active || !config.showAreaLines() && !config.showMinimapAreaLines())
 		{
 			Arrays.fill(linesToDisplay, null);
 			return;
@@ -414,6 +414,7 @@ public class NpcAggroAreaPlugin extends Plugin
 				break;
 			case "npcUnaggroCollisionDetection":
 			case "npcUnaggroShowAreaLines":
+			case "npcUnaggroShowMinimapLines":
 				calculateLinesToDisplay();
 				break;
 			case "npcUnaggroNames":

--- a/runelite-client/src/main/java/net/runelite/client/plugins/npcunaggroarea/NpcAggroAreaPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npcunaggroarea/NpcAggroAreaPlugin.java
@@ -106,6 +106,9 @@ public class NpcAggroAreaPlugin extends Plugin
 	private NpcAggroAreaOverlay overlay;
 
 	@Inject
+	private NpcAggroAreaMinimapOverlay minimapOverlay;
+
+	@Inject
 	private OverlayManager overlayManager;
 
 	@Inject
@@ -152,6 +155,7 @@ public class NpcAggroAreaPlugin extends Plugin
 	protected void startUp() throws Exception
 	{
 		overlayManager.add(overlay);
+		overlayManager.add(minimapOverlay);
 		npcNamePatterns = NAME_SPLITTER.splitToList(config.npcNamePatterns());
 		infoBoxManager.addInfoBox(new UncalibratedInfobox(itemManager.getImage(ItemID.ARCEUUS_CORPSE_DEMON_INITIAL), this));
 		clientThread.invokeLater(this::scanNpcs);
@@ -162,6 +166,7 @@ public class NpcAggroAreaPlugin extends Plugin
 	{
 		removeTimer();
 		overlayManager.remove(overlay);
+		overlayManager.remove(minimapOverlay);
 		infoBoxManager.removeIf(UncalibratedInfobox.class::isInstance);
 		Arrays.fill(safeCenters, null);
 		lastPlayerLocation = null;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/npcunaggroarea/NpcAggroAreaPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npcunaggroarea/NpcAggroAreaPlugin.java
@@ -414,7 +414,7 @@ public class NpcAggroAreaPlugin extends Plugin
 				break;
 			case "npcUnaggroCollisionDetection":
 			case "npcUnaggroShowAreaLines":
-			case "npcUnaggroShowMinimapLines":
+			case "npcUnaggroShowMinimapAreaLines":
 				calculateLinesToDisplay();
 				break;
 			case "npcUnaggroNames":


### PR DESCRIPTION
Minimap overlay for the NPC unaggro area lines
<img width="199" height="169" alt="image" src="https://github.com/user-attachments/assets/2904d026-5233-4180-818f-b6ee1c9377b3" />
Separate config option for the minimap lines
<img width="242" height="39" alt="image" src="https://github.com/user-attachments/assets/b68e78a8-c8e1-4182-9f10-67694072b92a" />

PS: a way to better clip the minimap, like e.g. #19271 , would make it look nicer!