### PR TITLE
add config option to enable permanent inventory grid overlay, as well…

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/inventorygrid/InventoryGridConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/inventorygrid/InventoryGridConfig.java
@@ -33,6 +33,27 @@ import net.runelite.client.config.ConfigItem;
 @ConfigGroup("inventorygrid")
 public interface InventoryGridConfig extends Config
 {
+
+	@ConfigItem(
+			keyName = "hitboxColor",
+			name = "Hitbox Outline Color",
+			description = "Color of the hitbox grid outline"
+	)
+	default Color hitboxColor()
+	{
+		return new Color(255, 0, 0, 100);
+	}
+
+	@ConfigItem(
+			keyName = "showHitboxes",
+			name = "Show Hitbox Grid",
+			description = "Overlay each inventory slot with its hitbox"
+	)
+	default boolean showHitboxes()
+	{
+		return false;
+	}
+
 	@ConfigItem(
 		keyName = "showItem",
 		name = "Show item",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/inventorygrid/InventoryGridOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/inventorygrid/InventoryGridOverlay.java
@@ -26,15 +26,18 @@
 package net.runelite.client.plugins.inventorygrid;
 
 import com.google.inject.Inject;
-import java.awt.AlphaComposite;
+
+import java.awt.Point;
 import java.awt.Dimension;
 import java.awt.Graphics2D;
-import java.awt.Point;
 import java.awt.Rectangle;
+import java.awt.AlphaComposite;
+import java.awt.Color;
 import java.awt.image.BufferedImage;
 import net.runelite.api.Client;
 import net.runelite.api.gameval.InterfaceID;
 import net.runelite.api.widgets.Widget;
+import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.api.widgets.WidgetItem;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.ui.overlay.Overlay;
@@ -67,6 +70,11 @@ class InventoryGridOverlay extends Overlay
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
+		if (config.showHitboxes())
+		{
+			renderHitboxOverlay(graphics);
+		}
+
 		final Widget draggingWidget = client.getDraggedWidget();
 		if (draggingWidget == null)
 		{
@@ -155,5 +163,27 @@ class InventoryGridOverlay extends Overlay
 		graphics.setComposite(AlphaComposite.SrcOver.derive(0.3f));
 		graphics.drawImage(draggedItemImage, x, y, null);
 		graphics.setComposite(AlphaComposite.SrcOver);
+	}
+
+	private void renderHitboxOverlay(Graphics2D graphics)
+	{
+		Widget inventoryWidget = client.getWidget(WidgetInfo.INVENTORY);
+		if (inventoryWidget == null || inventoryWidget.isHidden())
+		{
+			return;
+		}
+
+		Widget[] items = inventoryWidget.getChildren();
+		if (items != null)
+		{
+			Color hitboxOutlineColor = config.hitboxColor();
+			graphics.setColor(hitboxOutlineColor);
+
+			for (Widget item : items)
+			{
+				Rectangle bounds = item.getBounds();
+				graphics.draw(bounds);
+			}
+		}
 	}
 }


### PR DESCRIPTION
… as a configurable outline color

**Summary**

Issue: https://github.com/runelite/runelite/issues/10656 Users would like the ability to have a inventory grid overlay that is always visible.

This PR enhances the Inventory Grid plugin by adding a configurable "always on" inventory grid. When enabled, users will be able to see the hitbox for each inventory slot at all times. They can also configure the color of the outline. Examples below.

<img width="184" height="264" alt="inventory-grid-invent" src="https://github.com/user-attachments/assets/53fd3813-a5d1-4448-bcea-ff7b2898c6f3" />

<img width="232" height="350" alt="inventory-grid-config" src="https://github.com/user-attachments/assets/2f2d9aad-62f2-4654-b4f3-0ab3d86b39f5" />

**Motivation**

This feature has been requested by users looking for better visual clarity, personalization, or accessibility improvements. Some common examples:

- https://github.com/runelite/runelite/discussions/18193
- https://github.com/runelite/runelite/discussions/15428
- https://github.com/runelite/runelite/discussions/16042