### PR TITLE
Add config option to disable spell tooltips

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/ScriptID.java
+++ b/runelite-api/src/main/java/net/runelite/api/ScriptID.java
@@ -491,4 +491,7 @@ public final class ScriptID
 
 	@ScriptArguments(integer = 1)
 	public static final int DOM_LOOT_CLAIM = 7928;
+
+	@ScriptArguments(integer = 6)
+	public static final int SPELLBOOK_TOOLTIP = 2622;
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/spellbook/SpellbookConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/spellbook/SpellbookConfig.java
@@ -26,9 +26,21 @@ package net.runelite.client.plugins.spellbook;
 
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
 
 @ConfigGroup(SpellbookConfig.GROUP)
 public interface SpellbookConfig extends Config
 {
 	String GROUP = "spellbook";
+
+	@ConfigItem(
+		keyName = "enableTooltips",
+		name = "Enable Tooltips",
+		description = "Configures whether or not to show tooltips",
+		position = 0
+	)
+	default boolean enableTooltips()
+	{
+		return true;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/spellbook/SpellbookPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/spellbook/SpellbookPlugin.java
@@ -36,6 +36,7 @@ import net.runelite.api.EnumComposition;
 import net.runelite.api.EnumID;
 import net.runelite.api.ItemComposition;
 import net.runelite.api.ParamID;
+import net.runelite.api.ScriptEvent;
 import net.runelite.api.ScriptID;
 import net.runelite.api.events.DraggingWidgetChanged;
 import net.runelite.api.events.ScriptCallbackEvent;
@@ -54,6 +55,7 @@ import net.runelite.client.chat.ChatMessageManager;
 import net.runelite.client.chat.QueuedMessage;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
+import net.runelite.client.events.ConfigChanged;
 import net.runelite.client.events.ProfileChanged;
 import net.runelite.client.menus.MenuManager;
 import net.runelite.client.menus.WidgetMenuOption;
@@ -92,6 +94,9 @@ public class SpellbookPlugin extends Plugin
 		"", InterfaceID.ToplevelPreEoc.STONE6);
 
 	@Inject
+	private SpellbookConfig config;
+
+	@Inject
 	private Client client;
 
 	@Inject
@@ -126,6 +131,18 @@ public class SpellbookPlugin extends Plugin
 	{
 		clearReoderMenus();
 		clientThread.invokeLater(this::reinitializeSpellbook);
+	}
+
+	@Subscribe
+	public void onConfigChanged(ConfigChanged event)
+	{
+		if (event.getGroup().equals(SpellbookConfig.GROUP))
+		{
+			if (event.getKey().equals("enableTooltips"))
+			{
+				clientThread.invokeLater(this::reinitializeSpellbook);
+			}
+		}
 	}
 
 	@Subscribe
@@ -205,6 +222,18 @@ public class SpellbookPlugin extends Plugin
 			int sz = client.getIntStackSize();
 			int spellBookEnum = stack[sz - 12]; // eg 1982, 5285, 1983, 1984, 1985
 			clientThread.invokeLater(() -> initializeSpells(spellBookEnum));
+		}
+
+		if (!config.enableTooltips() && event.getScriptId() == ScriptID.SPELLBOOK_TOOLTIP)
+		{
+			ScriptEvent tryReplace = event.getScriptEvent();
+			if ((int) tryReplace.getArguments()[1] == 0)
+			{
+				return;
+			}
+			tryReplace.getArguments()[1] = 0;
+			// index 1 is the boolean to show or hide the tool tip
+			event.setScriptEvent(tryReplace);
 		}
 	}
 


### PR DESCRIPTION
Cherry-picking @JZomDev's PR #18413 since it's been sitting with merge conflicts since October.

## Summary
Adds a config option to the Spellbook plugin to toggle spell tooltips (enabled by default). Note that **spell tooltips** (the large OSRS tooltips shown below) are distinct from the mouse hover tooltips that can already be disabled in RuneLite. Issue #9730 was incorrectly closed in 2021 with the understanding these were the same feature, but they are actually different systems.

## Background
- Original request: #9730 (August 2019) 
- Implementation by @JZomDev: #18413 (October 2024 - unreviewed)
- Renewed request: #18469 (October 2024)

<img width="766" height="1022" alt="spellbook tooltips enabled and disabled" src="https://github.com/user-attachments/assets/30d4f462-d525-439b-adee-7c58c922df5c" />
<br><br>
<img width="242" height="134" alt="spellbook config" src="https://github.com/user-attachments/assets/251c33a7-c398-4bc9-80a7-ef279eaef923" />

## Testing
- Tested with all spellbooks
- Config toggle works as expected
- No conflicts with existing mouse tooltip settings

All credit to @JZomDev for the implementation - I just resolved the conflicts.