### PR TITLE
fix: Citric cellar clue location

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java
@@ -146,7 +146,7 @@ public class CrypticClue extends ClueScroll implements NpcClueScroll, ObjectClue
 		CrypticClue.builder()
 			.itemId(ItemID.TRAIL_CLUE_HARD_RIDDLE025)
 			.text("Citric cellar.")
-			.location(new WorldPoint(2490, 3488, 0))
+			.location(new WorldPoint(2490, 3488, 1))
 			.npc("Heckel Funch")
 			.solution("Speak to Heckel Funch on the first floor in the Grand Tree.")
 			.build(),


### PR DESCRIPTION
Was set to floor 0 when it should be 1. Related to https://github.com/KeiranY/clue-pathing-runelite-plugin/issues/14.