### PR TITLE
disable comma when renaming bank tags

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/banktags/tabs/TabInterface.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/banktags/tabs/TabInterface.java
@@ -97,7 +97,7 @@ import net.runelite.client.util.Text;
 @Slf4j
 public class TabInterface
 {
-	public static final IntPredicate FILTERED_CHARS = c -> "</>:".indexOf(c) == -1;
+	public static final IntPredicate FILTERED_CHARS = c -> "</>:,".indexOf(c) == -1;
 
 	private static final Color HILIGHT_COLOR = JagexColors.MENU_TARGET;
 	private static final String SCROLL_UP = "Scroll up";


### PR DESCRIPTION
fixes #19297 by adding a comma to the filtered characters which fully prevents entering a comma in the chat dialog that pops up