### PR TITLE
fix: properly bring client to front on Linux X11, skip on Wayland

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
@@ -892,18 +892,18 @@ public class ClientUI
 			case Windows:
 				WinUtil.requestForeground(frame);
 				break;
-            case Linux:
-                String sessionType = System.getenv("XDG_SESSION_TYPE");
-                if ("wayland".equalsIgnoreCase(sessionType))
-                {
-                    log.debug("Skipping forceFocus: Wayland session detected");
-                    break;
-                }
-                frame.setAlwaysOnTop(true);
-                frame.toFront();
-                frame.setAlwaysOnTop(false);
-                break;
-            default:
+			case Linux:
+				String sessionType = System.getenv("XDG_SESSION_TYPE");
+				if ("wayland".equalsIgnoreCase(sessionType))
+				{
+					log.debug("Skipping forceFocus: Wayland session detected");
+					break;
+				}
+				frame.setAlwaysOnTop(true);
+				frame.toFront();
+				frame.setAlwaysOnTop(false);
+				break;
+			default:
 				frame.requestFocus();
 				break;
 		}

--- a/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
@@ -892,7 +892,18 @@ public class ClientUI
 			case Windows:
 				WinUtil.requestForeground(frame);
 				break;
-			default:
+            case Linux:
+                String sessionType = System.getenv("XDG_SESSION_TYPE");
+                if ("wayland".equalsIgnoreCase(sessionType))
+                {
+                    log.debug("Skipping forceFocus: Wayland session detected");
+                    break;
+                }
+                frame.setAlwaysOnTop(true);
+                frame.toFront();
+                frame.setAlwaysOnTop(false);
+                break;
+            default:
 				frame.requestFocus();
 				break;
 		}


### PR DESCRIPTION
This PR updates `forceFocus()` to improve behavior on Linux:

- On **X11**, the RuneLite window is reliably brought to the front using the `setAlwaysOnTop` → `toFront` → reset trick.  
- On **Wayland**, focus-stealing is not supported, so the client skips the force focus attempt gracefully.  

### Rationale  
- Current Linux handling does not reliably raise the RuneLite window.  
- This approach ensures expected behavior for X11 users, while respecting Wayland’s limitations.  

### Related Issues/PRs  
- Fixes #19291  
- Supersedes #15207  

### Notes  
- Tested on Linux (X11): window reliably comes to front.  
- On Wayland: safely skipped, no errors.  
