### PR TITLE
Pixel-perfect ui scaler

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuPlugin.java
@@ -1439,8 +1439,8 @@ public class GpuPlugin extends Plugin implements DrawCallbacks
 		// Set the sampling function used when stretching the UI.
 		// This is probably better done with sampler objects instead of texture parameters, but this is easier and likely more portable.
 		// See https://www.khronos.org/opengl/wiki/Sampler_Object for details.
-		// GL_NEAREST makes sampling for bicubic/xBR simpler, so it should be used whenever linear isn't
-		final int function = uiScalingMode == UIScalingMode.LINEAR ? GL43C.GL_LINEAR : GL43C.GL_NEAREST;
+		// GL_NEAREST makes sampling for bicubic/xBR simpler, so it should be used whenever linear/pixel isn't
+		final int function = uiScalingMode == UIScalingMode.LINEAR  || uiScalingMode == UIScalingMode.PIXEL ? GL43C.GL_LINEAR : GL43C.GL_NEAREST;
 		GL43C.glTexParameteri(GL43C.GL_TEXTURE_2D, GL43C.GL_TEXTURE_MIN_FILTER, function);
 		GL43C.glTexParameteri(GL43C.GL_TEXTURE_2D, GL43C.GL_TEXTURE_MAG_FILTER, function);
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/gpu/config/UIScalingMode.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/gpu/config/UIScalingMode.java
@@ -35,7 +35,8 @@ public enum UIScalingMode
 	LINEAR("Bilinear", 0),
 	MITCHELL("Bicubic (Mitchell)", 1),
 	CATMULL_ROM("Bicubic (Catmull-Rom)", 2),
-	XBR("xBR", 3);
+	XBR("xBR", 3),
+	PIXEL("Pixel", 4);
 
 	private final String name;
 	private final int mode;

--- a/runelite-client/src/main/resources/net/runelite/client/plugins/gpu/fragui.glsl
+++ b/runelite-client/src/main/resources/net/runelite/client/plugins/gpu/fragui.glsl
@@ -27,6 +27,7 @@
 #define SAMPLING_MITCHELL 1
 #define SAMPLING_CATROM 2
 #define SAMPLING_XBR 3
+#define SAMPLING_PIXEL 4
 
 uniform sampler2D tex;
 
@@ -38,6 +39,7 @@ uniform vec4 alphaOverlay;
 
 #include "scale/bicubic.glsl"
 #include "scale/xbr_lv2_frag.glsl"
+#include "scale/pixel.glsl"
 #include "colorblind.glsl"
 
 in vec2 TexCoord;
@@ -56,6 +58,8 @@ void main() {
     c = textureCubic(tex, TexCoord, samplingMode);
   } else if (samplingMode == SAMPLING_XBR) {
     c = textureXBR(tex, TexCoord, xbrTable, ceil(1.0 * targetDimensions.x / sourceDimensions.x));
+  } else if (samplingMode == SAMPLING_PIXEL) {
+    c = texturePixel(tex, TexCoord);
   } else {  // NEAREST or LINEAR, which uses GL_TEXTURE_MIN_FILTER/GL_TEXTURE_MAG_FILTER to affect sampling
     c = texture(tex, TexCoord);
   }

--- a/runelite-client/src/main/resources/net/runelite/client/plugins/gpu/scale/pixel.glsl
+++ b/runelite-client/src/main/resources/net/runelite/client/plugins/gpu/scale/pixel.glsl
@@ -1,0 +1,11 @@
+// Anti-aliased UI scaling that respects pixel sharpness
+// Approach taken from https://colececil.dev/blog/2017/scaling-pixel-art-without-destroying-it/
+
+vec4 texturePixel(sampler2D sampler, vec2 texUV) {
+  vec2 textureCoords = texUV * vec2(sourceDimensions);
+  vec2 locationWithinTexel = fract(textureCoords);
+  vec2 pixelsPerTexel = vec2(targetDimensions) / vec2(sourceDimensions);
+  vec2 interpolationAmount = clamp(locationWithinTexel * pixelsPerTexel, 0, 0.5) + clamp((locationWithinTexel - vec2(1.0,1.0)) * pixelsPerTexel + vec2(0.5,0.5), 0, 0.5);
+  vec2 finalTextureCoords = (floor(textureCoords) + interpolationAmount) / vec2(sourceDimensions);
+  return texture(sampler, finalTextureCoords);
+}

--- a/runelite-client/src/main/resources/net/runelite/client/plugins/gpu/vertui.glsl
+++ b/runelite-client/src/main/resources/net/runelite/client/plugins/gpu/vertui.glsl
@@ -28,6 +28,7 @@
 #define SAMPLING_MITCHELL 1
 #define SAMPLING_CATROM 2
 #define SAMPLING_XBR 3
+#define SAMPLING_PIXEL 4
 
 uniform int samplingMode;
 uniform ivec2 sourceDimensions;


### PR DESCRIPTION
Adds new UI scaling mode "Pixel" which is almost as sharp as nearest-neighbor but does not suffer from aliasing at non-integer scaling values by using bilinear sampling at the edges of texels. Method from: https://colececil.dev/blog/2017/scaling-pixel-art-without-destroying-it/

Compare @ 1642x1080 (1080p black bars)

Nearest
<img width="528" height="361" alt="2025-09-01_22-43-47" src="https://github.com/user-attachments/assets/30a50cb7-feb2-43a2-b80e-e09b68bdc82a" />

Bilinear
<img width="531" height="360" alt="2025-09-01_22-43-52" src="https://github.com/user-attachments/assets/3e686215-234b-4b2a-a514-a746b19483c8" />

Catmull-Rom
<img width="529" height="362" alt="2025-09-01_22-43-58" src="https://github.com/user-attachments/assets/11b156f1-0875-4d2b-b511-dece8ed4f4ea" />

xBR
<img width="529" height="362" alt="2025-09-01_22-44-02" src="https://github.com/user-attachments/assets/b5e96e64-3182-4df3-b9b4-5bf33d9ac926" />

Pixel
<img width="521" height="357" alt="2025-09-01_22-44-09" src="https://github.com/user-attachments/assets/e936154a-1e5f-4216-9f8d-155d3375fec2" />


Difference is most noticeable with text

@ ~1440p

Nearest
<img width="581" height="152" alt="2025-09-02_15-28-12" src="https://github.com/user-attachments/assets/d0bb6b26-1630-43ef-a1d3-cc5268262e49" />

Pixel
<img width="582" height="154" alt="2025-09-02_15-28-50" src="https://github.com/user-attachments/assets/d7d52876-ac63-4055-a66b-2e3f8a1af628" />


Parity with https://github.com/117HD/RLHD/pull/706