### PR TITLE
mining: allow configuration of rock respawn timers

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/mining/MiningConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/mining/MiningConfig.java
@@ -28,6 +28,7 @@ package net.runelite.client.plugins.mining;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.ConfigSection;
 import net.runelite.client.config.Units;
 
 @ConfigGroup("mining")
@@ -50,6 +51,74 @@ public interface MiningConfig extends Config
 		description = "Configures whether to display mining session stats."
 	)
 	default boolean showMiningStats()
+	{
+		return true;
+	}
+
+	@ConfigSection(
+		name = "Respawn timers",
+		description = "Configures whether to display respawn timers for the given category.",
+		position = 0,
+		closedByDefault = true
+	)
+	String respawnTimersSection = "respawnTimersSection";
+
+	@ConfigItem(
+		position = 0,
+		keyName = "rock",
+		name = "Rocks",
+		description = "General rocks that aren't within a specific category",
+		section = respawnTimersSection
+	)
+	default boolean showRockRespawns()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		position = 1,
+		keyName = "motherlodeMine",
+		name = "Motherlode Mine",
+		description = "Ore veins within Motherlode Mine",
+		section = respawnTimersSection
+	)
+	default boolean showMotherlodeMineRespawns()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		position = 2,
+		keyName = "oreVeins",
+		name = "Ore veins",
+		description = "Ore veins such as gold veins or calcified rocks",
+		section = respawnTimersSection
+	)
+	default boolean showOreVeinRespawns()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		position = 3,
+		keyName = "amethyst",
+		name = "Amethyst",
+		description = "Amethyst crystals",
+		section = respawnTimersSection
+	)
+	default boolean showAmethystRespawns()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		position = 4,
+		keyName = "barronite",
+		name = "Barronite",
+		description = "Barronite rocks",
+		section = respawnTimersSection
+	)
+	default boolean showBarroniteRespawns()
 	{
 		return true;
 	}


### PR DESCRIPTION
I think there is value in exposing these configurations, e.g. when using a Motherlode Mine plugin that shows its own respawn timers.

<img width="178" height="210" alt="{14C7F4BC-1825-4A4D-88C1-8C6C8DB21B25}" src="https://github.com/user-attachments/assets/e1f512a7-3818-4cd5-97f5-c98d34089893" />
