### PR TITLE
Puzzle Solver plugin - Add options to increase number of moves as dots shown for puzzle solutions

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/puzzlesolver/PuzzleSolverConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/puzzlesolver/PuzzleSolverConfig.java
@@ -84,8 +84,8 @@ public interface PuzzleSolverConfig extends Config
 
 	@ConfigItem(
 		keyName = "dotColor",
-		name = "Dot color",
-		description = "Dot color for the dots.",
+		name = "Dot start color",
+		description = "Dot color for the first solution dot.",
 		position = 4
 	)
 	default Color dotColor()
@@ -94,12 +94,12 @@ public interface PuzzleSolverConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "gradientColor",
-		name = "Secondary gradient color",
-		description = "The color that the dots blend to from the Dot Color.",
-		position = 6
+		keyName = "dotEndColor",
+		name = "Dot end color",
+		description = "Dot color of the last solution dot that dots blend towards.",
+		position = 5
 	)
-	default Color gradientColor()
+	default Color dotEndColor()
 	{
 		return Color.RED;
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/puzzlesolver/PuzzleSolverOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/puzzlesolver/PuzzleSolverOverlay.java
@@ -249,7 +249,7 @@ public class PuzzleSolverOverlay extends Overlay
 									int y = puzzleBoxLocation.getY() + blankY * PUZZLE_TILE_SIZE
 											+ PUZZLE_TILE_SIZE / 2 - markerSize / 2;
 
-									Color color = ColorUtil.colorLerp(config.dotColor(), config.gradientColor(),
+									Color color = ColorUtil.colorLerp(config.dotColor(), config.dotEndColor(),
 										(double) (i - 1) / (movesToShow - 1));
 									graphics.setColor(color);
 									graphics.fillOval(x, y, markerSize, markerSize);


### PR DESCRIPTION
- Add option to increase number of dots shown up to 8
- Interpolate dot colors between a start and end color for easier visualization
- Outline dots with a black outline. 
- Add more size variation for dots.
- The color gradient, increased size variation, and outline make overlapping dots with > 4 moves shown much easier to comprehend.

For the image below:
1 - new default
2 - 6 moves
3 - 6 moves with identical end dot color
4 - 8 moves
<img width="553" height="553" alt="image" src="https://github.com/user-attachments/assets/a151f4cd-c355-4c7f-b6b9-66606eed5986" />

https://github.com/user-attachments/assets/590f79bb-2b7a-499d-a815-1a9f4cb00f40

This improvement has a lot of backing from clue solvers. From my experimenting this improves puzzle solving time by 50%, a 5 second time save per puzzle. 