### PR TITLE
Slayer: Fix boss tasks

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerPlugin.java
@@ -367,7 +367,7 @@ public class SlayerPlugin extends Plugin
 			{
 				var bossRows = client.getDBRowsByValue(
 					DBTableID.SlayerTaskSublist.ID,
-					DBTableID.SlayerTaskSublist.COL_SUBTABLE_ID,
+					DBTableID.SlayerTaskSublist.COL_TASK_SUBTABLE_ID,
 					0,
 					client.getVarbitValue(VarbitID.SLAYER_TARGET_BOSSID));
 


### PR DESCRIPTION
<img width="407" height="411" alt="image" src="https://github.com/user-attachments/assets/bd7826f1-a21a-41f6-b87c-98c1f28e74a9" />

Currently none of the overlays work for slayer plugin while on a boss task. Using `DBTableID.SlayerTaskSublist.COL_TASK_SUBTABLE_ID` instead of `DBTableID.SlayerTaskSublist.COL_SUBTABLE_ID` fixes this.