### PR TITLE
config: Combo box on new line for long config names

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
@@ -33,6 +33,7 @@ import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Component;
 import java.awt.Dimension;
+import java.awt.FontMetrics;
 import java.awt.event.FocusAdapter;
 import java.awt.event.FocusEvent;
 import java.awt.event.ItemEvent;
@@ -333,6 +334,8 @@ class ConfigPanel extends PluginPanel
 			topLevelPanels.put(csd, section);
 		}
 
+		FontMetrics fm = this.getFontMetrics(getFont());
+
 		for (ConfigItemDescriptor cid : cd.getItems())
 		{
 			if (cid.getItem().hidden())
@@ -346,6 +349,7 @@ class ConfigPanel extends PluginPanel
 			String name = cid.getItem().name();
 			JLabel configEntryName = new JLabel(name);
 			configEntryName.setForeground(Color.WHITE);
+			int nameWidth = fm.stringWidth(name);
 			String description = cid.getItem().description();
 			if (!"".equals(description))
 			{
@@ -380,7 +384,9 @@ class ConfigPanel extends PluginPanel
 			}
 			else if (cid.getType() instanceof Class && ((Class<?>) cid.getType()).isEnum())
 			{
-				item.add(createComboBox(cd, cid), BorderLayout.EAST);
+				item.add(createComboBox(cd, cid),
+					(nameWidth > 0.7 * (PANEL_WIDTH + SCROLLBAR_WIDTH))
+					? BorderLayout.SOUTH : BorderLayout.EAST);
 			}
 			else if (cid.getType() == Keybind.class || cid.getType() == ModifierlessKeybind.class)
 			{


### PR DESCRIPTION
Puts the combo box on a new line if the config name is over 70% of the config panel width.
With 70% as the width threshold this only affects 3 existing config entries in core RuneLite:
|Plugin|Before|After|
|-|-|-|
|Player Indicators|![before1](https://github.com/user-attachments/assets/d11dc817-6f14-4958-b102-aea880d3fffb)|![after1](https://github.com/user-attachments/assets/525a87b4-de24-4cff-90b9-f9e8ff070c69)|
|XP Tracker|![before2](https://github.com/user-attachments/assets/781d4c5f-998f-47ae-a80c-74168b5db2a9)|![after2](https://github.com/user-attachments/assets/559ed622-3326-49ad-bb63-ea9ed4b117af)|
|XP Tracker|![before3](https://github.com/user-attachments/assets/1f53bd9d-cb9c-42e8-b85f-ddc7c87d4269)|![after3](https://github.com/user-attachments/assets/014a6c19-046d-4e95-9710-3305a20bf51c)|