### PR TITLE
feat: item stats hotkey configuration

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatConfig.java
@@ -53,6 +53,28 @@ public interface ItemStatConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "useStatsHotkey",
+		name = "Require stats hotkey",
+		description = "Require holding the stats hotkey to show item stats. If disabled, stats always show.",
+		position = 16
+	)
+	default boolean useStatsHotkey()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		keyName = "statsHotkey",
+		name = "Stats Hotkey",
+		description = "Hold this key to show item stats.",
+		position = 15
+	)
+	default net.runelite.client.config.Keybind statsHotkey()
+	{
+		return net.runelite.client.config.Keybind.SHIFT;
+	}
+
+	@ConfigItem(
 		keyName = "geStats",
 		name = "Enable GE item information",
 		description = "Shows an item information panel when buying items in the GE."

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatOverlay.java
@@ -75,6 +75,13 @@ public class ItemStatOverlay extends Overlay
 	@Inject
 	private ItemStatConfig config;
 
+	private ItemStatsHotkeyListener hotkeyListener;
+
+	public void setHotkeyListener(ItemStatsHotkeyListener hotkeyListener)
+	{
+		this.hotkeyListener = hotkeyListener;
+	}
+
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
@@ -82,6 +89,12 @@ public class ItemStatOverlay extends Overlay
 		{
 			return null;
 		}
+
+	// Improved hotkey logic: only require hotkey if enabled
+	boolean hotkeyHeld = hotkeyListener != null && hotkeyListener.isHotkeyHeld();
+	boolean showStats = config.useStatsHotkey() ? hotkeyHeld : true;
+	boolean showEquipmentStats = config.equipmentStats() && showStats;
+	boolean showConsumableStats = config.consumableStats() && showStats;
 
 		final MenuEntry[] menu = client.getMenuEntries();
 		final int menuSize = menu.length;
@@ -125,7 +138,9 @@ public class ItemStatOverlay extends Overlay
 			return null;
 		}
 
-		if (config.consumableStats())
+	    boolean showConsumableStats = config.consumableStats() && hotkeyHeld;
+
+		if (showConsumableStats)
 		{
 			final Effect change = statChanges.get(itemId);
 			if (change != null)
@@ -185,7 +200,7 @@ public class ItemStatOverlay extends Overlay
 			}
 		}
 
-		if (config.equipmentStats())
+		if (showEquipmentStats)
 		{
 			final ItemStats stats = itemManager.getItemStats(itemId);
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatPlugin.java
@@ -65,6 +65,7 @@ import net.runelite.client.ui.FontManager;
 import net.runelite.client.ui.JagexColors;
 import net.runelite.client.ui.overlay.OverlayManager;
 import net.runelite.client.util.QuantityFormatter;
+import net.runelite.client.input.KeyManager;
 
 @PluginDescriptor(
 	name = "Item Stats",
@@ -82,6 +83,11 @@ public class ItemStatPlugin extends Plugin
 
 	@Inject
 	private ItemStatOverlay overlay;
+
+	@Inject
+	private KeyManager keyManager;
+
+	private ItemStatsHotkeyListener hotkeyListener;
 
 	@Inject
 	private Client client;
@@ -112,12 +118,17 @@ public class ItemStatPlugin extends Plugin
 	@Override
 	protected void startUp() throws Exception
 	{
+		hotkeyListener = new ItemStatsHotkeyListener(config);
+		keyManager.registerKeyListener(hotkeyListener);
+		overlay.setHotkeyListener(hotkeyListener);
 		overlayManager.add(overlay);
 	}
 
 	@Override
 	protected void shutDown() throws Exception
 	{
+		keyManager.unregisterKeyListener(hotkeyListener);
+		overlay.setHotkeyListener(null);
 		overlayManager.remove(overlay);
 		clientThread.invokeLater(this::resetGEInventory);
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatsHotkeyListener.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatsHotkeyListener.java
@@ -1,0 +1,34 @@
+package net.runelite.client.plugins.itemstats;
+
+import java.awt.event.KeyEvent;
+import net.runelite.client.config.Keybind;
+import net.runelite.client.input.KeyListener;
+
+public class ItemStatsHotkeyListener extends KeyListener {
+	private boolean hotkeyHeld = false;
+	private final ItemStatConfig config;
+
+	public ItemStatsHotkeyListener(ItemStatConfig config) {
+		this.config = config;
+	}
+
+	public boolean isHotkeyHeld() {
+		return hotkeyHeld;
+	}
+
+	@Override
+	public void keyPressed(KeyEvent e) {
+		Keybind keybind = config.statsHotkey();
+		if (keybind.matches(e)) {
+			hotkeyHeld = true;
+		}
+	}
+
+	@Override
+	public void keyReleased(KeyEvent e) {
+		Keybind keybind = config.statsHotkey();
+		if (keybind.matches(e)) {
+			hotkeyHeld = false;
+		}
+	}
+}


### PR DESCRIPTION
This pull request adds a configurable hotkey feature for displaying item stats in the plugin. Users can now choose to require holding a specific key to show item stats, improving usability and customization. The implementation introduces new configuration options, a hotkey listener, and updates the overlay logic to respect the hotkey setting.

**Hotkey Feature Implementation**

* Added new config options to `ItemStatConfig`: `useStatsHotkey` to enable/disable hotkey requirement, and `statsHotkey` to set the desired keybind (default: SHIFT).
* Created `ItemStatsHotkeyListener` to track hotkey state and expose `isHotkeyHeld()` for use in overlays.
* Registered and managed the hotkey listener in `ItemStatPlugin`, ensuring it is properly set up and cleaned up on plugin start/stop. [[1]](diffhunk://#diff-5aec44eae71e628a9990d44d64dcf8cf1d3c314289df96eb3085be644814b470R87-R91) [[2]](diffhunk://#diff-5aec44eae71e628a9990d44d64dcf8cf1d3c314289df96eb3085be644814b470R121-R131)

**Overlay Logic Updates**

* Updated `ItemStatOverlay` to use the hotkey listener and new config options, showing stats only when the hotkey is held if enabled. [[1]](diffhunk://#diff-df008b74192101d994eed12d6e6c9422eb8b441ee4ca8db8a20ab612f2d98372R78-R84) [[2]](diffhunk://#diff-df008b74192101d994eed12d6e6c9422eb8b441ee4ca8db8a20ab612f2d98372R93-R98)
* Refactored overlay rendering logic to conditionally display equipment and consumable stats based on hotkey state and configuration. [[1]](diffhunk://#diff-df008b74192101d994eed12d6e6c9422eb8b441ee4ca8db8a20ab612f2d98372L128-R143) [[2]](diffhunk://#diff-df008b74192101d994eed12d6e6c9422eb8b441ee4ca8db8a20ab612f2d98372L188-R203)

**Dependency Injection**

* Injected `KeyManager` into `ItemStatPlugin` to support hotkey listener registration.