### PR TITLE
slayer: add custodian stalkers task and cows task alternative

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/Task.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/Task.java
@@ -74,6 +74,7 @@ enum Task
 	CRAWLING_HANDS("Crawling hands", ItemID.SLAYERGUIDE_CRAWLINGHAND, "Crushing hand"),
 	CRAZY_ARCHAEOLOGIST("Crazy Archaeologists", ItemID.FEDORA),
 	CROCODILES("Crocodiles", ItemID.GREEN_SALAMANDER),
+	CUSTODIAN_STALKERS("Custodian Stalkers", ItemID.SLAYERGUIDE_CUSTODIAN_STALKER_MATURE, "Ancient Custodian"),
 	DAGANNOTH("Dagannoth", ItemID.POH_DAGGANOTH),
 	DAGANNOTH_KINGS("Dagannoth Kings", ItemID.PRIMEPET),
 	DARK_BEASTS("Dark beasts", ItemID.SLAYERGUIDE_DARK_BEAST, "Night beast"),

--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/Task.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/Task.java
@@ -69,7 +69,7 @@ enum Task
 	CHAOS_ELEMENTAL("The Chaos Elemental", ItemID.CHAOSELEPET),
 	CHAOS_FANATIC("The Chaos Fanatic", ItemID.STAFF_OF_ZAROS),
 	COCKATRICE("Cockatrice", ItemID.SLAYERGUIDE_COCKATRICE, "Cockathrice"),
-	COWS("Cows", ItemID.COW_MASK),
+	COWS("Cows", ItemID.COW_MASK, "Buffalo"),
 	CRABS("Crabs", ItemID.HUNDRED_PIRATE_CRAB_SHELL_GAUNTLET, "Ammonite Crab", "Frost Crab", "King Sand Crab", "Rock Crab", "Giant Rock Crab", "Sand Crab", "Swamp Crab"),
 	CRAWLING_HANDS("Crawling hands", ItemID.SLAYERGUIDE_CRAWLINGHAND, "Crushing hand"),
 	CRAZY_ARCHAEOLOGIST("Crazy Archaeologists", ItemID.FEDORA),

--- a/runelite-client/src/test/java/net/runelite/client/plugins/slayer/SlayerPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/slayer/SlayerPluginTest.java
@@ -279,6 +279,10 @@ public class SlayerPluginTest
 		assertTrue(matches("Loar shade", Task.SHADES));
 		assertTrue(matches("Loar shadow", Task.SHADES));
 		assertTrue(matches("Urium shadow", Task.SHADES));
+		assertTrue(matches("Juvenile custodian stalker", Task.CUSTODIAN_STALKERS));
+		assertTrue(matches("Mature custodian stalker", Task.CUSTODIAN_STALKERS));
+		assertTrue(matches("Elder custodian stalker", Task.CUSTODIAN_STALKERS));
+		assertTrue(matches("Ancient Custodian", Task.CUSTODIAN_STALKERS));
 
 		assertFalse(matches("Rat", Task.PIRATES));
 		assertFalse(matches("Wolf", Task.WEREWOLVES));


### PR DESCRIPTION
This PR adds the Custodian Stalker task (with the “Custodian” target name alias because the 'normal' custodians are prefixed by their age, while the superior variant is suffixed), and add buffalo as a cow task alternative.

[Custodians – OSRS Wiki](https://oldschool.runescape.wiki/w/Custodian_stalker)
[OSRS Update — Varlamore: The Final Dawn Out Now](https://secure.runescape.com/m=news/varlamore-the-final-dawn-out-now?oldschool=1)