### PR TITLE
Update CoordinateClue.java to fix master clue step

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java
@@ -967,7 +967,7 @@ public class CoordinateClue extends ClueScroll implements LocationClueScroll
 			.itemId(ItemID.TRAIL_CLUE_MASTER)
 			.location(new WorldPoint(2090, 3863, 0))
 			.directions("South of Lunar Isle, west of Astral altar.")
-			.enemy(ANCIENT_WIZARDS)
+			.enemy(BRASSICAN_MAGE)
 			.build(),
 		CoordinateClue.builder()
 			.itemId(ItemID.TRAIL_CLUE_MASTER)


### PR DESCRIPTION
Fix master clue step which is a brassican mage, incorrectly identified as ancient wizard trio. Didn't think to take a screenshot, sorry.