### PR TITLE
Added username parsing for HighScorePlugin Lookup from menuTarget

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/hiscore/HiscorePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/hiscore/HiscorePlugin.java
@@ -185,14 +185,24 @@ public class HiscorePlugin extends Plugin
 		if (event.getMenuAction() == MenuAction.RUNELITE_PLAYER && event.getMenuOption().equals(LOOKUP))
 		{
 			Player player = event.getMenuEntry().getPlayer();
-			if (player == null)
-			{
-				return;
-			}
+            String target;
+            if (player != null)
+            {
+                target = player.getName();
+            }
+            else
+            {
+                //Fallback: Player is out of render distance try to parse username from MenuOptionClicked
+                String playerUserNameWithLevel = Text.removeFormattingTags(event.getMenuTarget());
+                target = playerUserNameWithLevel.replaceAll(" *\\(.+?\\)", "");
+                if(target.isEmpty())
+                {
+                    // Could not extract username
+                    return;
+                }
+            }
 
-			String target = player.getName();
 			HiscoreEndpoint endpoint = getWorldEndpoint();
-
 			lookupPlayer(target, endpoint);
 		}
 	}


### PR DESCRIPTION
In certain cases event.getMenuEntry().getPlayer() is null(such as player leaving render distance, TP'ing out, or going to a different floor), but the menu target still contains the username; this fallback ensures lookup via the menuOption works in those cases.

First PR, let me know if there are changes needed, thanks!

Fixes #19380
