### PR TITLE
Add an earlier null check to the Agility plugin's hint arrow handling

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/agility/AgilityPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/agility/AgilityPlugin.java
@@ -291,11 +291,15 @@ public class AgilityPlugin extends Plugin
 		{
 			// Hint arrow has no plane, and always returns the current plane
 			WorldPoint newTicketPosition = client.getHintArrowPoint();
+			if (newTicketPosition == null)
+			{
+				return;
+			}
 			WorldPoint oldTickPosition = lastArenaTicketPosition;
 
 			lastArenaTicketPosition = newTicketPosition;
 
-			if (oldTickPosition != null && newTicketPosition != null
+			if (oldTickPosition != null
 				&& (oldTickPosition.getX() != newTicketPosition.getX() || oldTickPosition.getY() != newTicketPosition.getY()))
 			{
 				log.debug("Ticked position moved from {} to {}", oldTickPosition, newTicketPosition);


### PR DESCRIPTION
This is in preparation for a planned change to the Brimhaven agility plugin, which is to clear the client's hint arrow when the current agility arena ticket is claimed, see https://github.com/kagof/rl-plugin-brimhaven-agility/compare/remove-hint.

I've noticed in testing that removing this hint breaks the Agility plugin's notifier & timer. This is because every game tick when in the Brimhaven arena, the Agility plugin checks the current hint arrow against the old one in order to see if the timer/notifier should be reset. If the new hint arrow is `null`, then it overrides the `lastArenaTicketPosition` variable with `null`, which then means that when the ticket _does_ change locations, it is treated as though the user just entered the arena so the timer does not appear and the notification does not go off.

Just moving this `null` check a bit earlier to prevent the `lastArenaTicketPosition = newTicketPosition;` line from running should be sufficient to prevent my planned change from breaking this behaviour, and (as far as I can tell) doesn't have any other side-effects.

Note I did very briefly discuss this in the Discord's `#development` channel