### PR TITLE
Status Bars: Add new status bar position and toggle option

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/statusbars/StatusBarsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/statusbars/StatusBarsConfig.java
@@ -119,4 +119,14 @@ public interface StatusBarsConfig extends Config
 	{
 		return BarRenderer.DEFAULT_WIDTH;
 	}
+
+    @ConfigItem(
+            keyName = "toggleResizableClassicSideview",
+            name = "Toggle sideview",
+            description = "Toggles statusbars' position in resizable classic layout."
+    )
+    default boolean toggleResizableClassicSideview()
+    {
+        return false;
+    }
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/statusbars/StatusBarsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/statusbars/StatusBarsOverlay.java
@@ -263,6 +263,17 @@ class StatusBarsOverlay extends Overlay
 			offsetRightBarX = (location.getX() + RESIZED_BOTTOM_OFFSET_X - offsetRight.getX() - barWidthOffset);
 			offsetRightBarY = (location.getY() - RESIZED_BOTTOM_OFFSET_Y - offsetRight.getY());
 		}
+
+        else if (curViewport == Viewport.RESIZED_BOX & config.toggleResizableClassicSideview())
+        {
+            width = config.barWidth();
+            height = HEIGHT;
+            offsetLeftBarX = (location.getX() + RESIZED_BOTTOM_OFFSET_X - 60 - offsetLeft.getX());
+            offsetLeftBarY = (location.getY() - RESIZED_BOTTOM_OFFSET_Y + 11 - offsetLeft.getY());
+            offsetRightBarX = (location.getX() + RESIZED_BOTTOM_OFFSET_X - 55  - offsetRight.getX());
+            offsetRightBarY = (location.getY() - RESIZED_BOTTOM_OFFSET_Y + 11 - offsetRight.getY());
+        }
+
 		else
 		{
 			width = BarRenderer.DEFAULT_WIDTH;


### PR DESCRIPTION
To the Status Bars plugin:

Add a new status bar position and a toggle option in resizable classic layout.
- The new status bar position is next to the inventory, similarly to how modern layout has it.
- The toggle option alters the status bars' position between 1) within inventory and 2) next to inventory.