### PR TITLE
fix: hide walk here target name with condensed options

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/interfacestyles/InterfaceStylesPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/interfacestyles/InterfaceStylesPlugin.java
@@ -154,7 +154,6 @@ public class InterfaceStylesPlugin extends Plugin
 		Menu submenu = null;
 		Player prev = null;
 		boolean changed = false;
-		boolean walkFound = false;
 
 		for (MenuEntry menuEntry : menuEntries)
 		{
@@ -190,10 +189,9 @@ public class InterfaceStylesPlugin extends Plugin
 					.setDeprioritized(deprioritized);
 				changed = true;
 			}
-			else if (!walkFound && type == MenuAction.WALK)
+			else if (type == MenuAction.WALK)
 			{
 				newMenus[newIdx++] = menuEntry.setTarget("");
-				walkFound = true;
 			}
 			else
 			{


### PR DESCRIPTION
Removes the target from the "Walk here" option when condensing options.

<img width="434" height="348" alt="image" src="https://github.com/user-attachments/assets/c30fd8ab-d017-4591-ba9b-8d7b3d2e0e64" />


