### PR TITLE
chatcommands: Add longBossName for Obor and Bryophyta

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
@@ -2778,6 +2778,11 @@ public class ChatCommandsPlugin extends Plugin
 			case "doom":
 				return "Doom of Mokhaiotl";
 
+			case "bryophyta":
+				return "Bryophyta chests opened";
+			case "obor":
+				return "Obor chests opened";
+
 			default:
 				return WordUtils.capitalize(boss);
 		}

--- a/runelite-client/src/test/java/net/runelite/client/plugins/chatcommands/ChatCommandsPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/chatcommands/ChatCommandsPluginTest.java
@@ -329,6 +329,18 @@ public class ChatCommandsPluginTest
 	}
 
 	@Test
+	public void testBryophyta()
+	{
+		testKillCountChatMessage("bryophyta chests opened", "Your Bryophyta chests opened count is: <col=ff3045>67</col>", 67);
+	}
+
+	@Test
+	public void testObor()
+	{
+		testKillCountChatMessage("obor chests opened", "Your Obor chests opened count is: <col=ff3045>10</col>", 10);
+	}
+
+	@Test
 	public void testPersonalBest()
 	{
 		final String FIGHT_DURATION = "Fight duration: <col=ff0000>2:06</col>. Personal best: 1:19.";


### PR DESCRIPTION
Fixes #19294

The new KC includes "chests opened"

<img width="310" height="48" alt="image" src="https://github.com/user-attachments/assets/3a33de52-7937-44ed-bbc6-38adafdbffea" />


current behavior without this change (!kc obor vs !kc obor chests opened)

<img width="294" height="32" alt="image" src="https://github.com/user-attachments/assets/e72ef357-cdce-481d-aaa2-e144faeda9d8" />
