### PR TITLE
worldhopper: add option to filter worlds by ping in the world switcher sidebar

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldHopperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldHopperConfig.java
@@ -150,10 +150,21 @@ public interface WorldHopperConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "pingFilter",
+		name = "Ping Filter",
+		description = "Only show worlds with ping less than or equal to this value (0 to disable)",
+		position = 11
+	)
+	default int pingFilter()
+	{
+		return 170;
+	}
+
+	@ConfigItem(
 		keyName = "displayPing",
 		name = "Display current ping",
 		description = "Displays ping to current game world.",
-		position = 11
+		position = 12
 	)
 	default boolean displayPing()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldHopperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldHopperPlugin.java
@@ -214,6 +214,7 @@ public class WorldHopperPlugin extends Plugin
 		panel.setSubscriptionFilterMode(config.subscriptionFilter());
 		panel.setRegionFilterMode(config.regionFilter());
 		panel.setWorldTypeFilters(config.worldTypeFilter());
+		panel.setPingFilterValue(config.pingFilter());
 
 		// The plugin has its own executor for pings, as it blocks for a long time
 		hopperExecutorService = new ExecutorServiceExceptionLogger(Executors.newSingleThreadScheduledExecutor());
@@ -284,6 +285,10 @@ public class WorldHopperPlugin extends Plugin
 					break;
 				case "worldTypeFilter":
 					panel.setWorldTypeFilters(config.worldTypeFilter());
+					updateList();
+					break;
+				case "pingFilter":
+					panel.setPingFilterValue(config.pingFilter());
 					updateList();
 					break;
 			}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldSwitcherPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldSwitcherPanel.java
@@ -42,6 +42,7 @@ import javax.swing.SwingUtilities;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.EnumComposition;
 import net.runelite.client.ui.ColorScheme;
 import net.runelite.client.ui.DynamicGridLayout;
@@ -49,6 +50,7 @@ import net.runelite.client.ui.PluginPanel;
 import net.runelite.http.api.worlds.World;
 import net.runelite.http.api.worlds.WorldType;
 
+@Slf4j
 class WorldSwitcherPanel extends PluginPanel
 {
 	private static final Color ODD_ROW = new Color(44, 44, 44);
@@ -78,6 +80,8 @@ class WorldSwitcherPanel extends PluginPanel
 	private Set<RegionFilterMode> regionFilterMode;
 	@Setter(AccessLevel.PACKAGE)
 	private Set<WorldTypeFilter> worldTypeFilters;
+	@Setter(AccessLevel.PACKAGE)
+	private int pingFilterValue;
 
 	WorldSwitcherPanel(WorldHopperPlugin plugin)
 	{
@@ -151,7 +155,7 @@ class WorldSwitcherPanel extends PluginPanel
 				worldTableRow.setPing(ping);
 
 				// If the panel is sorted by ping, re-sort it
-				if (orderIndex == WorldOrder.PING)
+				if (orderIndex == WorldOrder.PING || pingFilterValue > 0)
 				{
 					updateList();
 				}
@@ -217,6 +221,10 @@ class WorldSwitcherPanel extends PluginPanel
 		for (int i = 0; i < rows.size(); i++)
 		{
 			WorldTableRow row = rows.get(i);
+			if (pingFilterValue > 0 && row.getPing() > pingFilterValue)
+			{
+				continue;
+			}
 			row.setBackground(i % 2 == 0 ? ODD_ROW : ColorScheme.DARK_GRAY_COLOR);
 			listContainer.add(row);
 		}


### PR DESCRIPTION
Some worlds have different ping despite being in the same region (eg. US East/West). This addition allows more precise filtering of worlds.