### PR TITLE
banktags: ability to hide/show tag tabs

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/banktags/BankTagsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/banktags/BankTagsPlugin.java
@@ -80,11 +80,13 @@ public class BankTagsPlugin extends Plugin implements BankTagsService
 	// banktags:item_<id>=tag,tag,tag,...
 	// banktags:icon_<tag>=id
 	// banktags:tagtabs=tab,tab,tab,...
+	// banktags:tagtabs.tagtabshidden_<item>=true
 	// banktags:layout_<tag>=item,item,item,...
 	// banktags:hidden_<tag>=true
 	public static final String CONFIG_GROUP = "banktags";
 	public static final String TAG_ICON_PREFIX = "icon_";
 	public static final String TAG_TABS_CONFIG = "tagtabs";
+	public static final String TAG_HIDDEN_CONFIG = "tagtabshidden";
 	public static final String TAG_LAYOUT_PREFIX = "layout_";
 	static final String ITEM_KEY_PREFIX = "item_";
 	static final String TAG_HIDDEN_PREFIX = "hidden_";

--- a/runelite-client/src/main/java/net/runelite/client/plugins/banktags/TagManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/banktags/TagManager.java
@@ -39,7 +39,9 @@ import net.runelite.client.game.ItemManager;
 import net.runelite.client.game.ItemVariationMapping;
 import static net.runelite.client.plugins.banktags.BankTagsPlugin.CONFIG_GROUP;
 import static net.runelite.client.plugins.banktags.BankTagsPlugin.ITEM_KEY_PREFIX;
+import static net.runelite.client.plugins.banktags.BankTagsPlugin.TAG_HIDDEN_CONFIG;
 import static net.runelite.client.plugins.banktags.BankTagsPlugin.TAG_HIDDEN_PREFIX;
+import static net.runelite.client.plugins.banktags.BankTagsPlugin.TAG_TABS_CONFIG;
 import net.runelite.client.util.Text;
 
 @Singleton
@@ -139,6 +141,7 @@ public class TagManager
 		});
 
 		setHidden(tag, false);
+		setTagTabHidden(tag, false);
 	}
 
 	public void removeTag(int itemId, String tag)
@@ -184,6 +187,23 @@ public class TagManager
 		else
 		{
 			configManager.unsetConfiguration(CONFIG_GROUP, TAG_HIDDEN_PREFIX + Text.standardize(tag));
+		}
+	}
+
+	public boolean isTagTabHidden(String tag)
+	{
+		return Boolean.TRUE.equals(configManager.getConfiguration(CONFIG_GROUP, TAG_TABS_CONFIG + "." + TAG_HIDDEN_CONFIG + "_" + tag, Boolean.class));
+	}
+
+	public void setTagTabHidden(String tag, boolean hidden)
+	{
+		if (hidden)
+		{
+			configManager.setConfiguration(CONFIG_GROUP, TAG_TABS_CONFIG + "." + TAG_HIDDEN_CONFIG + "_" + tag, true);
+		}
+		else
+		{
+			configManager.unsetConfiguration(CONFIG_GROUP, TAG_TABS_CONFIG + "." + TAG_HIDDEN_CONFIG + "_" + tag);
 		}
 	}
 


### PR DESCRIPTION
This PR aims to solve a problem for where a user may want to not see a bank tag tab but not delete it. If you delete it without removing tags you may be unable not remember the bank tab's name again. Without hunting down for a specific item's tags and recreating the banktag tab for name. 

Bank tags are not deleted when hidden, a config value of `banktags.tagtabs.tagtabshidden_<tagname>=true` is inserted, and these values would be continued over on a tag tab when building the side panel or the view all list. 

Hidden tabs can still be searched via that tab's name despite being hidden. 
This maybe should be hidden away as a config option to enable the feature so people aren't confused by it. 

Adds Hide/Show menu entry to the list where creating new or importing bank tags is at. 
<img width="667" height="443" alt="image" src="https://github.com/user-attachments/assets/3bef7fe9-6b04-456e-869d-1e64402904b6" />

When a tag tab is hidden, the icon is the placeholder icon
<img width="655" height="439" alt="image" src="https://github.com/user-attachments/assets/3eb23435-3f40-4a21-9b06-ef36118659af" />

When not viewing hidden items, the side bar tag hides the icons that should be hidden.
<img width="668" height="454" alt="image" src="https://github.com/user-attachments/assets/13b42c71-7acb-4f49-a89e-f1d8440dec4c" />

