### PR TITLE
World Map Plugin Expose

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldmap/AgilityCourseLocation.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldmap/AgilityCourseLocation.java
@@ -29,7 +29,7 @@ import lombok.Getter;
 import net.runelite.api.coords.WorldPoint;
 
 @Getter
-enum AgilityCourseLocation
+public enum AgilityCourseLocation
 {
 	AGILITY_PYRAMID("Agility Pyramid", new WorldPoint(3347, 2827, 0)),
 	AL_KHARID_ROOFTOP_COURSE("Al Kharid Rooftop Course", new WorldPoint(3272, 3195, 0)),

--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldmap/DungeonLocation.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldmap/DungeonLocation.java
@@ -29,7 +29,7 @@ import lombok.Getter;
 import net.runelite.api.coords.WorldPoint;
 
 @Getter
-enum DungeonLocation
+public enum DungeonLocation
 {
 	ABANDONED_MINE("Abandoned Mine", new WorldPoint(3439, 3232, 0)),
 	ABANDONED_MINE_SECRET("Abandoned Mine (secret entrance)", new WorldPoint(3452, 3244, 0)),

--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldmap/FairyRingLocation.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldmap/FairyRingLocation.java
@@ -29,7 +29,7 @@ import lombok.Getter;
 import net.runelite.api.coords.WorldPoint;
 
 @Getter
-enum FairyRingLocation
+public enum FairyRingLocation
 {
 	AIQ("AIQ", new WorldPoint(2995, 3112, 0)),
 	AIR("AIR", new WorldPoint(2699, 3249, 0)),

--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldmap/FarmingPatchLocation.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldmap/FarmingPatchLocation.java
@@ -29,7 +29,7 @@ import lombok.Getter;
 import net.runelite.api.coords.WorldPoint;
 
 @Getter
-enum FarmingPatchLocation
+public enum FarmingPatchLocation
 {
 	ALLOTMENT("Allotment",
 		new WorldPoint(3793, 2836, 0),

--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldmap/FishingSpotLocation.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldmap/FishingSpotLocation.java
@@ -32,7 +32,7 @@ import net.runelite.api.coords.WorldPoint;
 import net.runelite.client.game.FishingSpot;
 
 @Getter
-enum FishingSpotLocation
+public enum FishingSpotLocation
 {
 	ALDARIN_NORTH(FishingSpot.SHRIMP, new WorldPoint(1372, 2985, 0)),
 	ALDARIN_WEST(FishingSpot.SHRIMP, new WorldPoint(1313, 2963, 0)),

--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldmap/HunterAreaLocation.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldmap/HunterAreaLocation.java
@@ -31,7 +31,7 @@ import lombok.Getter;
 import net.runelite.api.coords.WorldPoint;
 
 @Getter
-enum HunterAreaLocation
+public enum HunterAreaLocation
 {
 	ALDARIN_NORTH(new WorldPoint(1357, 2977, 0), HunterCreature.COPPER_LONGTAIL),
 	ALDARIN_WEST(new WorldPoint(1342, 2934, 0), HunterCreature.RUBY_HARVEST),

--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldmap/MapPoint.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldmap/MapPoint.java
@@ -30,9 +30,9 @@ import lombok.experimental.SuperBuilder;
 import net.runelite.client.ui.overlay.worldmap.WorldMapPoint;
 
 @SuperBuilder
-class MapPoint extends WorldMapPoint
+public class MapPoint extends WorldMapPoint
 {
-	enum Type
+	public enum Type
 	{
 		TELEPORT,
 		RUNECRAFT_ALTAR,

--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldmap/MinigameLocation.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldmap/MinigameLocation.java
@@ -29,7 +29,7 @@ import lombok.Getter;
 import net.runelite.api.coords.WorldPoint;
 
 @Getter
-enum MinigameLocation
+public enum MinigameLocation
 {
 	ANIMATION_ROOM("Animation Room", new WorldPoint(2853, 3537, 0)),
 	BARBARIAN_ASSAULT("Barbarian Assault", new WorldPoint(2531, 3569, 0)),

--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldmap/MiningSiteLocation.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldmap/MiningSiteLocation.java
@@ -32,7 +32,7 @@ import lombok.Value;
 import net.runelite.api.coords.WorldPoint;
 
 @Getter
-enum MiningSiteLocation
+public enum MiningSiteLocation
 {
 	AGILITY_PYRAMID(new WorldPoint(3322, 2875, 0), new Rock(5, Ore.GOLD)),
 	// ABANDONED_MINE -- NOT AVAILABLE ON WORLDMAP

--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldmap/RareTreeLocation.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldmap/RareTreeLocation.java
@@ -29,7 +29,7 @@ import lombok.Getter;
 import net.runelite.api.coords.WorldPoint;
 
 @Getter
-enum RareTreeLocation
+public enum RareTreeLocation
 {
 	WILLOW("Willow tree", 30,
 		// Kandarin

--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldmap/RunecraftingAltarLocation.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldmap/RunecraftingAltarLocation.java
@@ -29,7 +29,7 @@ import lombok.Getter;
 import net.runelite.api.coords.WorldPoint;
 
 @Getter
-enum RunecraftingAltarLocation
+public enum RunecraftingAltarLocation
 {
 	AIR_ALTAR("Air Altar", 1, new WorldPoint(2985, 3293, 0), "air_altar_icon.png"),
 	MIND_ALTAR("Mind Altar", 2, new WorldPoint(2982, 3514, 0), "mind_altar_icon.png"),

--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldmap/TeleportLocationData.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldmap/TeleportLocationData.java
@@ -29,7 +29,7 @@ import lombok.Getter;
 import net.runelite.api.coords.WorldPoint;
 
 @Getter
-enum TeleportLocationData
+public enum TeleportLocationData
 {
 	VARROCK(TeleportType.NORMAL_MAGIC, "Varrock", 25, new WorldPoint(3213, 3424, 0), "varrock_teleport_icon.png"),
 	VARROCK_GE(TeleportType.NORMAL_MAGIC, "Varrock GE", 25, new WorldPoint(3164, 3478, 0), "varrock_teleport_icon.png"),

--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldmap/TransportationPointLocation.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldmap/TransportationPointLocation.java
@@ -34,7 +34,7 @@ import javax.annotation.Nullable;
 
 @Getter
 @AllArgsConstructor
-enum TransportationPointLocation
+public enum TransportationPointLocation
 {
 	//Ships
 	ALDARIN_TO_SUNSET_COAST("Ship to Sunset Coast", new WorldPoint(1443, 2976, 0), new WorldPoint(1492, 2985, 0)),

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/worldmap/WorldMapPointManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/worldmap/WorldMapPointManager.java
@@ -28,13 +28,12 @@ import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Predicate;
 import javax.inject.Singleton;
-import lombok.AccessLevel;
 import lombok.Getter;
 
 @Singleton
 public class WorldMapPointManager
 {
-	@Getter(AccessLevel.PACKAGE)
+	@Getter
 	private final List<WorldMapPoint> worldMapPoints = new CopyOnWriteArrayList<>();
 
 	public void add(WorldMapPoint worldMapPoint)


### PR DESCRIPTION
Expose relevant enums and getters so they can be reused by the minimap/worldmap plugin without duplicating code.