### PR TITLE
Fix the chatbox anchors (snap points) to the chatbox

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayManager.java
@@ -426,6 +426,14 @@ public class OverlayManager
 	private OverlayPosition loadOverlayPosition(final Overlay overlay)
 	{
 		final String locationKey = overlay.getName() + OVERLAY_CONFIG_PREFERRED_POSITION;
-		return configManager.getConfiguration(RUNELITE_CONFIG_GROUP_NAME, locationKey, OverlayPosition.class);
+		OverlayPosition position = configManager.getConfiguration(RUNELITE_CONFIG_GROUP_NAME, locationKey, OverlayPosition.class);
+
+		boolean isChatbox = overlay.getName().equals("RESIZABLE_VIEWPORT_CHATBOX_PARENT") || overlay.getName().equals("RESIZABLE_VIEWPORT_BOTTOM_LINE_CHATBOX_PARENT");
+		if (isChatbox && (position == OverlayPosition.BOTTOM_LEFT || position == OverlayPosition.ABOVE_CHATBOX_RIGHT))
+		{
+			return null;
+		}
+
+		return position;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayManager.java
@@ -428,8 +428,7 @@ public class OverlayManager
 		final String locationKey = overlay.getName() + OVERLAY_CONFIG_PREFERRED_POSITION;
 		OverlayPosition position = configManager.getConfiguration(RUNELITE_CONFIG_GROUP_NAME, locationKey, OverlayPosition.class);
 
-		boolean isChatbox = overlay.getName().equals("RESIZABLE_VIEWPORT_CHATBOX_PARENT") || overlay.getName().equals("RESIZABLE_VIEWPORT_BOTTOM_LINE_CHATBOX_PARENT");
-		if (isChatbox && (position == OverlayPosition.BOTTOM_LEFT || position == OverlayPosition.ABOVE_CHATBOX_RIGHT))
+		if (position != null && position.isOverlayBlacklisted(overlay.getName()))
 		{
 			return null;
 		}

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayPosition.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayPosition.java
@@ -24,6 +24,9 @@
  */
 package net.runelite.client.ui.overlay;
 
+import java.util.Arrays;
+import java.util.List;
+
 public enum OverlayPosition
 {
 	/**
@@ -51,7 +54,7 @@ public enum OverlayPosition
 	/**
 	 * Place overlay in the bottom left viewport area
 	 */
-	BOTTOM_LEFT,
+	BOTTOM_LEFT(Arrays.asList("RESIZABLE_VIEWPORT_CHATBOX_PARENT", "RESIZABLE_VIEWPORT_BOTTOM_LINE_CHATBOX_PARENT")),
 	/**
 	 * Place overlay in the bottom right viewport area
 	 */
@@ -59,7 +62,7 @@ public enum OverlayPosition
 	/**
 	 * Place overlay directly above right side of chatbox
 	 */
-	ABOVE_CHATBOX_RIGHT,
+	ABOVE_CHATBOX_RIGHT(Arrays.asList("RESIZABLE_VIEWPORT_CHATBOX_PARENT", "RESIZABLE_VIEWPORT_BOTTOM_LINE_CHATBOX_PARENT")),
 	/**
 	 * Place overlay in the top right most area possible
 	 */
@@ -67,5 +70,26 @@ public enum OverlayPosition
 	/**
 	 * Tooltip overlay
 	 */
-	TOOLTIP
+	TOOLTIP;
+
+	/**
+	 * A list of overlays that must not be snapped to the OverlayPosition, used when an OverlayPosition is tied to the
+	 * location of an Overlay (chatbox, for example)
+	 */
+	private final List<String> componentNameBlacklist;
+
+	OverlayPosition()
+	{
+		this.componentNameBlacklist = null;
+	}
+
+	OverlayPosition(List<String> componentNameBlacklist)
+	{
+		this.componentNameBlacklist = componentNameBlacklist;
+	}
+
+	boolean isOverlayBlacklisted(String overlayName)
+	{
+		return componentNameBlacklist != null && componentNameBlacklist.contains(overlayName);
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayRenderer.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayRenderer.java
@@ -55,6 +55,7 @@ import net.runelite.api.events.ClientTick;
 import net.runelite.api.events.FocusChanged;
 import net.runelite.api.gameval.InterfaceID;
 import net.runelite.api.gameval.VarbitID;
+import net.runelite.api.widgets.ComponentID;
 import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetItem;
 import net.runelite.client.chat.ChatMessageManager;
@@ -113,6 +114,7 @@ public class OverlayRenderer extends MouseAdapter
 	private Overlay lastHoveredOverlay; // for off-thread access
 
 	private final SnapCorners snapCorners = new SnapCorners();
+	private Rectangle chatboxParentBounds;
 	private boolean dragWarn;
 
 	@Inject
@@ -652,6 +654,14 @@ public class OverlayRenderer extends MouseAdapter
 						// overlay moves back to default position
 						position = null;
 					}
+					else
+					{
+						boolean isChatbox = currentManagedOverlay.getName().equals("RESIZABLE_VIEWPORT_CHATBOX_PARENT") || currentManagedOverlay.getName().equals("RESIZABLE_VIEWPORT_BOTTOM_LINE_CHATBOX_PARENT");
+						if (isChatbox && (position == OverlayPosition.BOTTOM_LEFT || position == OverlayPosition.ABOVE_CHATBOX_RIGHT))
+						{
+							continue;
+						}
+					}
 
 					currentManagedOverlay.setPreferredPosition(position);
 					currentManagedOverlay.setPreferredLocation(null); // from dragging
@@ -797,6 +807,8 @@ public class OverlayRenderer extends MouseAdapter
 		final Widget chatbox = client.getWidget(InterfaceID.Chatbox.CHATAREA);
 		final boolean chatboxHidden = chatbox == null || chatbox.isHidden();
 		final Rectangle chatboxBounds = chatbox != null ? chatbox.getBounds() : new Rectangle();
+		final Widget chatboxParent = client.getWidget(ComponentID.CHATBOX_PARENT);
+		chatboxParentBounds = chatboxParent != null ? chatboxParent.getBounds() : new Rectangle();
 
 		snapCorners.topLeft.setPosition(
 			viewportBounds.x + BORDER,
@@ -811,8 +823,8 @@ public class OverlayRenderer extends MouseAdapter
 			viewportBounds.x + viewportBounds.width - BORDER,
 			viewportBounds.y + BORDER);
 
-		int bottomLeftX = viewportBounds.x + BORDER;
-		int bottomLeftY = viewportBounds.y + viewportBounds.height - BORDER;
+		int bottomLeftX = chatboxParentBounds.x + BORDER;
+		int bottomLeftY = chatboxParentBounds.y - BORDER;
 		// Check to see if chat box is minimized
 		if (isResizeable && chatboxHidden)
 		{
@@ -826,7 +838,7 @@ public class OverlayRenderer extends MouseAdapter
 
 		if (isResizeable)
 		{
-			snapCorners.aboveChatboxRight.setPosition(viewportBounds.x + chatboxBounds.width - BORDER, bottomLeftY);
+			snapCorners.aboveChatboxRight.setPosition(chatboxParentBounds.x + chatboxParentBounds.width - BORDER, bottomLeftY);
 			snapCorners.canvasTopRight.setPosition((int) client.getRealDimensions().getWidth(), 0);
 		}
 		else

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayRenderer.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayRenderer.java
@@ -654,13 +654,9 @@ public class OverlayRenderer extends MouseAdapter
 						// overlay moves back to default position
 						position = null;
 					}
-					else
+					else if (position != null && position.isOverlayBlacklisted(currentManagedOverlay.getName()))
 					{
-						boolean isChatbox = currentManagedOverlay.getName().equals("RESIZABLE_VIEWPORT_CHATBOX_PARENT") || currentManagedOverlay.getName().equals("RESIZABLE_VIEWPORT_BOTTOM_LINE_CHATBOX_PARENT");
-						if (isChatbox && (position == OverlayPosition.BOTTOM_LEFT || position == OverlayPosition.ABOVE_CHATBOX_RIGHT))
-						{
-							continue;
-						}
+						continue;
 					}
 
 					currentManagedOverlay.setPreferredPosition(position);


### PR DESCRIPTION
This fixes CI errors on @Thource\'s feature branch that make chatbox anchors (snap points) adjust correctly with changes to chatbox size and position.

Changes include:
- Replaced deprecated Widgets class constants with GameVal constants in OverlayRenderer
- All changes from #17522