### PR TITLE
keyremapping: Check for poll being open to prevent remaps

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/keyremapping/KeyRemappingListener.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/keyremapping/KeyRemappingListener.java
@@ -76,7 +76,7 @@ class KeyRemappingListener implements KeyListener
 		{
 			int mappedKeyCode = KeyEvent.VK_UNDEFINED;
 
-			if (config.cameraRemap())
+			if (config.cameraRemap() && !plugin.isPollWindowOpen())
 			{
 				if (config.up().matches(e))
 				{
@@ -99,7 +99,7 @@ class KeyRemappingListener implements KeyListener
 			// In addition to the above checks, the F-key remapping shouldn't
 			// activate when dialogs are open which listen for number keys
 			// to select options
-			if (config.fkeyRemap() && !plugin.isDialogOpen())
+			if (config.fkeyRemap() && !plugin.isDialogOpen() && !plugin.isPollWindowOpen())
 			{
 				if (config.f1().matches(e))
 				{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/keyremapping/KeyRemappingPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/keyremapping/KeyRemappingPlugin.java
@@ -162,6 +162,11 @@ public class KeyRemappingPlugin extends Plugin
 		return client.getWidget(InterfaceID.Chatmenu.OPTIONS) != null;
 	}
 
+	boolean isPollWindowOpen()
+	{
+		return client.getWidget(InterfaceID.Ballot.CONTENT) != null;
+	}
+
 	private boolean isHidden(int component)
 	{
 		Widget w = client.getWidget(component);


### PR DESCRIPTION
checks for poll window open to prevent remapper from activating, wasd remap moves on question 8 in test poll of new poll system