### PR TITLE
properly escape commas in NPC names for config saving/loading

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsPlugin.java
@@ -719,8 +719,6 @@ public class NpcIndicatorsPlugin extends Plugin
 		return names.stream().map(s -> s.replace("\u0000", ",")).collect(Collectors.toList());
 	}
 
-
-
 	void rebuild()
 	{
 		highlights = getHighlights();


### PR DESCRIPTION
Closes #19437

Replaced CSV quote-based serialization with custom comma escaping (\\,) for NPC names in npcToHighlight. Updated save/load logic to escape on write and unescape on read, ensuring names containing commas are handled correctly by RuneLite’s simple CSV parser.

Output of stored config array: `Chaos Fanatic,Khorvak\, a dwarven engineer`

Recording of live test:
https://github.com/user-attachments/assets/e01cd54b-b4d4-46a9-a831-a65b5e803555

