### PR TITLE
Re-add Color Banding toggle to GPU plugin

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuPlugin.java
@@ -254,6 +254,7 @@ public class GpuPlugin extends Plugin implements DrawCallbacks
 	private int uniFogDepth;
 	private int uniDrawDistance;
 	private int uniExpandedMapLoadingChunks;
+	private int uniSmoothBanding;
 	private int uniWorldProj;
 	private static int uniEntityProj;
 	static int uniEntityTint;
@@ -587,6 +588,7 @@ public class GpuPlugin extends Plugin implements DrawCallbacks
 		uniWorldProj = glGetUniformLocation(glProgram, "worldProj");
 		uniEntityProj = glGetUniformLocation(glProgram, "entityProj");
 		uniEntityTint = glGetUniformLocation(glProgram, "entityTint");
+		uniSmoothBanding = glGetUniformLocation(glProgram, "smoothBanding");
 		uniBrightness = glGetUniformLocation(glProgram, "brightness");
 		uniUseFog = glGetUniformLocation(glProgram, "useFog");
 		uniFogColor = glGetUniformLocation(glProgram, "fogColor");
@@ -939,6 +941,7 @@ public class GpuPlugin extends Plugin implements DrawCallbacks
 		// Brightness happens to also be stored in the texture provider, so we use that
 		TextureProvider textureProvider = client.getTextureProvider();
 		glUniform1f(uniBrightness, (float) textureProvider.getBrightness());
+		glUniform1f(uniSmoothBanding, config.smoothBanding() ? 0f : 1f);
 		glUniform1f(uniTextureLightMode, config.brightTextures() ? 1f : 0f);
 		if (client.getGameState() == GameState.LOGGED_IN)
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuPluginConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuPluginConfig.java
@@ -79,6 +79,17 @@ public interface GpuPluginConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "smoothBanding",
+		name = "Remove color banding",
+		description = "Smooths out the color banding that is present in the CPU renderer.",
+		position = 2
+	)
+	default boolean smoothBanding()
+	{
+		return true;
+	}
+
+	@ConfigItem(
 		keyName = "antiAliasingMode",
 		name = "Anti aliasing",
 		description = "Configures the anti-aliasing mode.",

--- a/runelite-client/src/main/resources/net/runelite/client/plugins/gpu/frag.glsl
+++ b/runelite-client/src/main/resources/net/runelite/client/plugins/gpu/frag.glsl
@@ -31,6 +31,7 @@
 
 uniform sampler2DArray textures;
 uniform float brightness;
+uniform float smoothBanding;
 uniform vec4 fogColor;
 uniform float textureLightMode;
 
@@ -80,7 +81,10 @@ void main() {
     vec3 mul = (1.f - textureLightMode) * vec3(light) + textureLightMode * fColor.rgb;
     c = textureColor * vec4(mul, fColor.a);
   } else {
-    c = fColor;
+    // pick interpolated hsl or rgb depending on smooth banding setting
+    vec3 hsl = vec3(int(fHsl) >> 10 & 63, int(fHsl) >> 7 & 7, int(fHsl) & 127);
+    vec3 rgb = mix(fColor.rgb, hslToRgb(hsl), smoothBanding);
+    c = vec4(rgb, fColor.a);
   }
 
 #if COLORBLIND_MODE > 0


### PR DESCRIPTION
Color banding is an iconic graphical style of OSRS. I think the new GPU plugin is a step in the right direction but it sucks to have lost this option. I've re-enabled it and tested the changes locally.

Here's what it looks like, just hanging out in Lumby:

With banding _disabled:_
<img width="1512" height="856" alt="Screenshot 2025-11-04 at 12 58 12 PM" src="https://github.com/user-attachments/assets/0d93f226-15a0-44c7-a3fe-684d19542071" />

With banding _enabled:_
<img width="1512" height="859" alt="Screenshot 2025-11-04 at 12 58 46 PM" src="https://github.com/user-attachments/assets/3ce01e38-a558-4af1-941c-77e6f856388d" />

Should be fairly straightforward and hopefully not have any negative downstream effects on the new renderer (it looked structured somewhat the same as the old plugin in the shader code.)

