### PR TITLE
gpu: fix wrong targetDimensions uniform value

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuPlugin.java
@@ -1464,7 +1464,9 @@ public class GpuPlugin extends Plugin implements DrawCallbacks
 		else
 		{
 			glDpiAwareViewport(0, 0, canvasWidth, canvasHeight);
-			glUniform2i(uniTexTargetDimensions, canvasWidth, canvasHeight);
+			final GraphicsConfiguration graphicsConfiguration = clientUI.getGraphicsConfiguration();
+			final AffineTransform t = graphicsConfiguration.getDefaultTransform();
+			glUniform2i(uniTexTargetDimensions, getScaledValue(t.getScaleX(), canvasWidth), getScaledValue(t.getScaleY(), canvasHeight));
 		}
 
 		// Set the sampling function used when stretching the UI.


### PR DESCRIPTION
The `targetDimensions` uniform is being set to the same value as `sourceDimensions` when stretched mode is not enabled. This is not correct when DPI scaling is active, and causes the "Hybrid" UI scaling mode which relies on it to effectively become the same as linear scaling.

Zoomed-in before/after picture (at 225% DPI scale):
<img width="1045" height="393" alt="image" src="https://github.com/user-attachments/assets/28406ebf-313a-4332-a923-98b7f5af394a" />

Note how the text below looks crisper. Only target pixels that land on multiple source pixels are interpolated, as intended by the hybrid scaling mode.