### PR TITLE
fix null reference exception when trying to set an op listener on widget in SpellbookPlugin

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/spellbook/SpellbookPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/spellbook/SpellbookPlugin.java
@@ -390,10 +390,10 @@ public class SpellbookPlugin extends Plugin
 			ItemComposition spellObj = client.getItemDefinition(spellObjId);
 			int spellComponent = spellObj.getIntValue(ParamID.SPELL_BUTTON);
 			Widget w = client.getWidget(spellComponent);
-            if (w == null)
-            {
-                continue;
-            }
+			if (w == null)
+			{
+				continue;
+			}
 
 			// spells with no target mask have an existing op listener, capture it to
 			// call it later


### PR DESCRIPTION
Fixes #19396 

Btw some guidance on whether this is ok to `continue` would be nice, when I tested it, it seemed like the `MAGIC_SPELLBOOK_INITIALISESPELLS` script was fired after removing the greegree so it seems to still allow the initialization of the `SpellbookPlugin`.