### PR TITLE
clues: Fix incorrect z plane for "With drinks and dwarves I make my way"

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java
@@ -1985,7 +1985,7 @@ public class CrypticClue extends ClueScroll implements NpcClueScroll, ObjectClue
 		CrypticClue.builder()
 			.itemId(ItemID.TRAIL_ELITE_RIDDLE_VM01)
 			.text("With drinks and dwarves I make my way, upon my head a glass will stay.")
-			.location(new WorldPoint(1432, 9584, 0))
+			.location(new WorldPoint(1432, 9584, 1))
 			.npc("Funbo")
 			.solution("Speak to Funbo inside Cam Torum's pub.")
 			.build(),


### PR DESCRIPTION
The z plane is incorrectly set to 0 instead of 1 for the elite cryptic clue "With drinks and dwarves I make my way, upon my head a glass will stay.".
https://oldschool.runescape.wiki/w/Clue_scroll_(elite)_-_With_drinks_and_dwarves_I_make_my_way