### PR TITLE
fairyrings: Make fairy ring code search case-insensitive

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/fairyring/FairyRingPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/fairyring/FairyRingPlugin.java
@@ -193,7 +193,7 @@ public class FairyRingPlugin extends Plugin
 				tags = ring.getTags();
 			}
 
-			var filter = client.getVarcStrValue(VarClientID.MESLAYERINPUT);
+			var filter = client.getVarcStrValue(VarClientID.MESLAYERINPUT).toLowerCase();
 
 			if (code.toLowerCase().contains(filter)
 				|| tags != null && tags.contains(filter)


### PR DESCRIPTION
Previously, the fairy ring code search only worked when entering codes in lowercase (e.g., `aiq`), while input with uppercase (`AIQ`, `Aiq`, etc.) would not return any results.

This PR normalizes the input to lowercase, allowing both lowercase and uppercase codes to be found correctly.

---

## Before:
<img width="765" height="503" alt="before1" src="https://github.com/user-attachments/assets/0d87ebe6-0fb2-4ee4-820d-3162a9311566" />
<img width="765" height="503" alt="before2" src="https://github.com/user-attachments/assets/88f51bbf-659e-493d-99c1-f4fddb3a7a3f" />

## After:
<img width="765" height="503" alt="after" src="https://github.com/user-attachments/assets/deef22f6-011c-4f32-bda1-cb1d2ce91a8f" />
