### PR TITLE
Fix 2005 interface styles friends chat icon alignment

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/interfacestyles/WidgetOffset.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/interfacestyles/WidgetOffset.java
@@ -104,7 +104,7 @@ enum WidgetOffset
 	FIXED_2010_MUSIC_ICON(Skin.AROUND_2010, InterfaceID.Toplevel.ICON13, 209, 2, null, null),
 
 	RESIZABLE_2005_QUESTS_ICON(Skin.AROUND_2005, InterfaceID.ToplevelOsrsStretch.ICON2, 71, -1, null, null),
-	RESIZABLE_2005_FRIENDS_CHAT_ICON(Skin.AROUND_2005, InterfaceID.ToplevelOsrsStretch.ICON7, null, 2, null, null),
+	RESIZABLE_2005_FRIENDS_CHAT_ICON(Skin.AROUND_2005, InterfaceID.ToplevelOsrsStretch.ICON7, null, 1, null, null),
 	RESIZABLE_2005_LOGOUT_ICON(Skin.AROUND_2005, InterfaceID.ToplevelOsrsStretch.ICON10, null, null, null, null),
 	RESIZABLE_2005_OPTIONS_ICON(Skin.AROUND_2005, InterfaceID.ToplevelOsrsStretch.ICON11, 137, null, null, null),
 	RESIZABLE_2005_EMOTE_ICON(Skin.AROUND_2005, InterfaceID.ToplevelOsrsStretch.ICON12, 171, 2, null, null),
@@ -118,8 +118,7 @@ enum WidgetOffset
 	RESIZABLE_BOTTOM_2005_INVENTORY_ICON(Skin.AROUND_2005, InterfaceID.ToplevelPreEoc.ICON3, 98, 1, null, null),
 	RESIZABLE_BOTTOM_2005_QUESTS_ICON(Skin.AROUND_2005, InterfaceID.ToplevelPreEoc.ICON2, 66, -1, null, null),
 	RESIZABLE_BOTTOM_2005_EQUIPMENT_ICON(Skin.AROUND_2005, InterfaceID.ToplevelPreEoc.ICON4, 131, 3, null, null),
-	RESIZABLE_BOTTOM_2005_FRIENDS_CHAT_ICON(Skin.AROUND_2005, InterfaceID.ToplevelPreEoc.ICON7, null, 2, null, null),
-	RESIZABLE_BOTTOM_2005_FRIENDS_ICON(Skin.AROUND_2005, InterfaceID.ToplevelOsrsStretch.ICON9, 38, null, null, null),
+	RESIZABLE_BOTTOM_2005_FRIENDS_CHAT_ICON(Skin.AROUND_2005, InterfaceID.ToplevelPreEoc.ICON7, null, 1, null, null),
 	RESIZABLE_BOTTOM_2005_MUSIC_ICON(Skin.AROUND_2005, InterfaceID.ToplevelPreEoc.ICON13, null, 3, null, null),
 	RESIZABLE_BOTTOM_2005_EMOTE_ICON(Skin.AROUND_2005, InterfaceID.ToplevelPreEoc.ICON12, 133, 1, null, null),
 	RESIZABLE_BOTTOM_2005_STATS_ICON(Skin.AROUND_2005, InterfaceID.ToplevelPreEoc.ICON1, 32, null, null, null),


### PR DESCRIPTION
The alignment of the GIM/friends chat/grouping icons (and friend list in fixed mode) in the menu stones is off slightly in the 2005 interface style. It's more obvious when using 2005 Overhaul resource pack as it properly sizes the icons as well, particularly when the group icon is set to a equally-sized red quest icon override as you can see here. If you look carefully you will notice the red quest icon for groups is still 1 pixel placement above the friends and ignore list icons. This is due to the icon placement _without_ the 2005 resource pack being slightly different, so this is the best compromise. An example is in the next comment.

Comparison gifs below:

![fixed comparison](https://github.com/user-attachments/assets/7e25cccb-68b0-4610-91d6-0224f71d0fe9)

![classic resize comparison](https://github.com/user-attachments/assets/20120178-7246-4394-a871-e4aa8df666a5)

![modern resize comparison](https://github.com/user-attachments/assets/913d5790-5652-46d3-a546-2736485632ce)