### PR TITLE
clues: add more sailing clues

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java
@@ -245,7 +245,8 @@ public class EmoteClue extends ClueScroll implements LocationClueScroll
 		new EmoteClue(ItemID.TRAIL_CLUE_BEGINNER, "Spin at Flynn's Mace Shop.", "Falador", null, new WorldPoint(2950, 3387, 0), SPIN),
 		new EmoteClue(ItemID.TRAIL_ELITE_EMOTE_EXP17, "Salute by the Charcoal Burners. Equip a Farmer's strawhat, Shayzien platebody (5) and Pyromancer robes.", "Charcoal Burners", CHARCOAL_BURNERS, new WorldPoint(1714, 3467, 0), SALUTE, any("Farmer's strawhat", item(ItemID.TITHE_REWARD_HAT_MALE), item(ItemID.TITHE_REWARD_HAT_FEMALE)), item(ItemID.SHAYZIEN_BODY_5), item(ItemID.PYROMANCER_BOTTOM)),
 		new EmoteClue(ItemID.TRAIL_EASY_EMOTE_SAIL, "Dance a jig behind the bar on the Pandemonium. Equip a right eye patch and a bronze scimitar.", "Pandemonium", PANDEMONIUM_BAR, new WorldPoint(3049, 2966, 0), JIG, item(ItemID.EYE_PATCH), item(ItemID.BRONZE_SCIMITAR)),
-		new EmoteClue(ItemID.TRAIL_ELITE_EMOTE_SAIL, "Do the crab dance by the monument on Wintumber Island. Equip a crab helmet and a crab claw.", "Wintumber Island", WINTUMBER_ISLAND, new WorldPoint(2069, 2608, 0), CRAB_DANCE, item(ItemID.HUNDRED_PIRATE_CRAB_SHELL_HELM), item(ItemID.HUNDRED_PIRATE_CRAB_SHELL_GAUNTLET)));
+		new EmoteClue(ItemID.TRAIL_ELITE_EMOTE_SAIL, "Do the crab dance by the monument on Wintumber Island. Equip a crab helmet and a crab claw.", "Wintumber Island", WINTUMBER_ISLAND, new WorldPoint(2069, 2608, 0), CRAB_DANCE, item(ItemID.HUNDRED_PIRATE_CRAB_SHELL_HELM), item(ItemID.HUNDRED_PIRATE_CRAB_SHELL_GAUNTLET)),
+		new EmoteClue(ItemID.TRAIL_CLUE_MASTER, "Bow in front of the cave on Brittle Isle. Beware of double agents! Equip a Medallion of the Deep and a rosewood blowpipe.", "Brittle Island", null, new WorldPoint(1952, 4074, 0), DOUBLE_AGENT_141, BOW, item(ItemID.MEDALLION_OF_THE_DEEP), item(ItemID.ROSEWOOD_BLOWPIPE)));
 
 	private static final String UNICODE_CHECK_MARK = "\u2713";
 	private static final String UNICODE_BALLOT_X = "\u2717";

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/FaloTheBardClue.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/FaloTheBardClue.java
@@ -72,7 +72,8 @@ public class FaloTheBardClue extends ClueScroll implements NpcClueScroll
 		new FaloTheBardClue("These gloves of white won't help you fight, but aid in cooking, they just might.", item(ItemID.GAUNTLETS_OF_COOKING)),
 		new FaloTheBardClue("They come from some time ago, from a land unto the east. Fossilised they have become, this small and gentle beast.", item(ItemID.FOSSIL_NUMULITE)),
 		new FaloTheBardClue("To slay a dragon you must first do, before this chest piece can be put on you.", item(ItemID.RUNE_PLATEBODY)),
-		new FaloTheBardClue("Vampyres are agile opponents, damaged best with a weapon of many components.", any("Rod of Ivandis or Ivandis/Blisterwood flail", range(ItemID.BURGH_ROD_COMMAND_FINAL_10, ItemID.BURGH_ROD_COMMAND_FINAL_1), item(ItemID.IVANDIS_FLAIL), item(ItemID.BLISTERWOOD_FLAIL)))
+		new FaloTheBardClue("Vampyres are agile opponents, damaged best with a weapon of many components.", any("Rod of Ivandis or Ivandis/Blisterwood flail", range(ItemID.BURGH_ROD_COMMAND_FINAL_10, ItemID.BURGH_ROD_COMMAND_FINAL_1), item(ItemID.IVANDIS_FLAIL), item(ItemID.BLISTERWOOD_FLAIL))),
+		new FaloTheBardClue("You won't bring me to heel, unless you have a bright red keel.", item(ItemID.SAILING_BOAT_KEEL_PART_DRAGON))
 	);
 
 	private static final WorldPoint LOCATION = new WorldPoint(2689, 3550, 0);


### PR DESCRIPTION
master clues are abex's enemy

there is a STASH unit in the game `HH_MASTER_SAIL` https://abextm.github.io/cache2/#/viewer/obj/58132 but I think I always checked stash locations manually, so I don't know how to find them in the cache, so i've only included the clue itself without the STASH