### PR TITLE
Add "Set heading" to ignored mouse tooltips (as it's "Walk here" for boats)

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/mousehighlight/MouseHighlightOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/mousehighlight/MouseHighlightOverlay.java
@@ -127,6 +127,7 @@ class MouseHighlightOverlay extends Overlay
 			case "Walk here":
 			case "Cancel":
 			case "Continue":
+			case "Set heading":
 				return null;
 			case "Move":
 				// Hide overlay on sliding puzzle boxes


### PR DESCRIPTION
Tooltip is displayed 24/7 while sailing currently