### PR TITLE
StatusBars: add Boat health status bar with contextual swapping, and ItemStats for boat repair kits

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatChanges.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatChanges.java
@@ -390,14 +390,14 @@ public class ItemStatChanges
 		add(boost(STRENGTH, perc(.15, 4)), ItemID.BUTTERFLY_JAR_WARLOCK, ItemID.HUNTER_MIX_WARLOCK_1DOSE, ItemID.HUNTER_MIX_WARLOCK_2DOSE);
 		add(boost(DEFENCE, perc(.15, 4)), ItemID.BUTTERFLY_JAR_GLACIALIS, ItemID.HUNTER_MIX_GLACIALIS_1DOSE, ItemID.HUNTER_MIX_GLACIALIS_2DOSE);
 
-        // Ship health
-        add(heal(BOAT_HEALTH, 5), ItemID.BOAT_REPAIR_KIT);
-        add(heal(BOAT_HEALTH, 10), ItemID.BOAT_REPAIR_KIT_OAK);
-        add(heal(BOAT_HEALTH, 20), ItemID.BOAT_REPAIR_KIT_TEAK);
-        add(heal(BOAT_HEALTH, 30), ItemID.BOAT_REPAIR_KIT_MAHOGANY);
-        add(heal(BOAT_HEALTH, 40), ItemID.BOAT_REPAIR_KIT_CAMPHOR);
-        add(heal(BOAT_HEALTH, 45), ItemID.BOAT_REPAIR_KIT_IRONWOOD);
-        add(heal(BOAT_HEALTH, 50), ItemID.BOAT_REPAIR_KIT_ROSEWOOD);
+		// Ship health
+		add(heal(BOAT_HEALTH, 5), ItemID.BOAT_REPAIR_KIT);
+		add(heal(BOAT_HEALTH, 10), ItemID.BOAT_REPAIR_KIT_OAK);
+		add(heal(BOAT_HEALTH, 20), ItemID.BOAT_REPAIR_KIT_TEAK);
+		add(heal(BOAT_HEALTH, 30), ItemID.BOAT_REPAIR_KIT_MAHOGANY);
+		add(heal(BOAT_HEALTH, 40), ItemID.BOAT_REPAIR_KIT_CAMPHOR);
+		add(heal(BOAT_HEALTH, 45), ItemID.BOAT_REPAIR_KIT_IRONWOOD);
+		add(heal(BOAT_HEALTH, 50), ItemID.BOAT_REPAIR_KIT_ROSEWOOD);
 
 		log.debug("{} items; {} behaviours loaded", effects.size(), new HashSet<>(effects.values()).size());
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/stats/BoatHealthStat.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/stats/BoatHealthStat.java
@@ -29,20 +29,20 @@ import net.runelite.api.gameval.VarbitID;
 
 public class BoatHealthStat extends Stat
 {
-    BoatHealthStat()
-    {
-        super("Boat Health");
-    }
+	BoatHealthStat()
+	{
+		super("Boat Health");
+	}
 
-    @Override
-    public int getValue(Client client)
-    {
-        return client.getVarbitValue(VarbitID.SAILING_SIDEPANEL_BOAT_HP);
-    }
+	@Override
+	public int getValue(Client client)
+	{
+		return client.getVarbitValue(VarbitID.SAILING_SIDEPANEL_BOAT_HP);
+	}
 
-    @Override
-    public int getMaximum(Client client)
-    {
-        return client.getVarbitValue(VarbitID.SAILING_SIDEPANEL_BOAT_HP_MAX);
-    }
+	@Override
+	public int getMaximum(Client client)
+	{
+		return client.getVarbitValue(VarbitID.SAILING_SIDEPANEL_BOAT_HP_MAX);
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/stats/Stats.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/stats/Stats.java
@@ -53,5 +53,5 @@ public class Stats
 	public static final Stat CONSTRUCTION = new SkillStat(Skill.CONSTRUCTION);
 	public static final Stat SAILING = new SkillStat(Skill.SAILING);
 	public static final Stat RUN_ENERGY = new EnergyStat();
-    public static final Stat BOAT_HEALTH = new BoatHealthStat();
+	public static final Stat BOAT_HEALTH = new BoatHealthStat();
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/statusbars/StatusBarsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/statusbars/StatusBarsConfig.java
@@ -65,15 +65,15 @@ public interface StatusBarsConfig extends Config
 		return true;
 	}
 
-    @ConfigItem(
-            keyName = "contextualBoatHealth",
-            name = "Contextual boat health",
-            description = "Will swap player hitpoints bars with boat health when on a boat."
-    )
-    default boolean contextualBoatHealth()
-    {
-        return true;
-    }
+	@ConfigItem(
+			keyName = "contextualBoatHealth",
+			name = "Contextual boat health",
+			description = "Will swap player hitpoints bars with boat health when on a boat."
+	)
+	default boolean contextualBoatHealth()
+	{
+		return true;
+	}
 
 	enum BarMode
 	{
@@ -83,7 +83,7 @@ public interface StatusBarsConfig extends Config
 		RUN_ENERGY,
 		SPECIAL_ATTACK,
 		WARMTH,
-        BOAT_HEALTH
+		BOAT_HEALTH
 	}
 
 	@ConfigItem(

--- a/runelite-client/src/main/java/net/runelite/client/plugins/statusbars/StatusBarsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/statusbars/StatusBarsOverlay.java
@@ -74,10 +74,10 @@ class StatusBarsOverlay extends Overlay
 	private static final Color ENERGY_COLOR = new Color(199, 174, 0, 220);
 	private static final Color DISEASE_COLOR = new Color(255, 193, 75, 181);
 	private static final Color PARASITE_COLOR = new Color(196, 62, 109, 181);
-    private static final Color WARMTH_COLOR = new Color(244, 97, 0, 181);
-    private static final Color BOAT_HEALTH_COLOR = new Color(114, 69, 0, 181);
-    private static final Color BOAT_HEAL_COLOR = new Color(211, 167, 98, 181);
-    private static final int BOAT_HEALTH_ICON = SpriteID.IconSailingFacilities16x16._20;
+	private static final Color WARMTH_COLOR = new Color(244, 97, 0, 181);
+	private static final Color BOAT_HEALTH_COLOR = new Color(114, 69, 0, 181);
+	private static final Color BOAT_HEAL_COLOR = new Color(211, 167, 98, 181);
+	private static final int BOAT_HEALTH_ICON = SpriteID.IconSailingFacilities16x16._20;
 	private static final int HEIGHT = 252;
 	private static final int RESIZED_BOTTOM_HEIGHT = 272;
 	private static final int RESIZED_BOTTOM_OFFSET_Y = 12;
@@ -227,14 +227,14 @@ class StatusBarsOverlay extends Overlay
 			() -> null,
 			() -> skillIconManager.getSkillImage(Skill.FIREMAKING, true)
 		));
-        barRenderers.put(StatusBarsConfig.BarMode.BOAT_HEALTH, new BarRenderer(
-                () -> BOAT_HEALTH.getMaximum(client),
-                () -> BOAT_HEALTH.getValue(client),
-                () -> getRestoreValue(BOAT_HEALTH.getName()),
-                () -> BOAT_HEALTH_COLOR,
-                () -> BOAT_HEAL_COLOR,
-                () -> loadSprite(BOAT_HEALTH_ICON)
-        ));
+		barRenderers.put(StatusBarsConfig.BarMode.BOAT_HEALTH, new BarRenderer(
+				() -> BOAT_HEALTH.getMaximum(client),
+				() -> BOAT_HEALTH.getValue(client),
+				() -> getRestoreValue(BOAT_HEALTH.getName()),
+				() -> BOAT_HEALTH_COLOR,
+				() -> BOAT_HEAL_COLOR,
+				() -> loadSprite(BOAT_HEALTH_ICON)
+		));
 	}
 
 	@Override
@@ -289,8 +289,8 @@ class StatusBarsOverlay extends Overlay
 			offsetRightBarY = (location.getY() - offsetRight.getY());
 		}
 
-        StatusBarsConfig.BarMode leftBarMode = config.leftBarMode();
-        StatusBarsConfig.BarMode rightBarMode = config.rightBarMode();
+		StatusBarsConfig.BarMode leftBarMode = config.leftBarMode();
+		StatusBarsConfig.BarMode rightBarMode = config.rightBarMode();
 
 		BarRenderer left = getBarRenderer(leftBarMode, rightBarMode);
 		BarRenderer right = getBarRenderer(rightBarMode, leftBarMode);
@@ -352,28 +352,28 @@ class StatusBarsOverlay extends Overlay
 		return client.getWidget(InterfaceID.BrOverlay.CONTENT) != null;
 	}
 
-    public boolean isSailing()
-    {
-        return client.getVarbitValue(VarbitID.SAILING_PLAYER_IS_ON_PLAYER_BOAT) > 0;
-    }
+	public boolean isSailing()
+	{
+		return client.getVarbitValue(VarbitID.SAILING_PLAYER_IS_ON_PLAYER_BOAT) > 0;
+	}
 
-    private boolean validForContextSwapBoatHealth(StatusBarsConfig.BarMode barMode)
-    {
-        return barMode == StatusBarsConfig.BarMode.HITPOINTS && config.contextualBoatHealth() && isSailing();
-    }
+	private boolean validForContextSwapBoatHealth(StatusBarsConfig.BarMode barMode)
+	{
+		return barMode == StatusBarsConfig.BarMode.HITPOINTS && config.contextualBoatHealth() && isSailing();
+	}
 
-    private BarRenderer getBarRenderer(StatusBarsConfig.BarMode barMode, StatusBarsConfig.BarMode otherBarMode)
-    {
-        if (validForContextSwapBoatHealth(barMode) && otherBarMode != StatusBarsConfig.BarMode.BOAT_HEALTH)
-        {
-            return barRenderers.get(StatusBarsConfig.BarMode.BOAT_HEALTH);
-        }
+	private BarRenderer getBarRenderer(StatusBarsConfig.BarMode barMode, StatusBarsConfig.BarMode otherBarMode)
+	{
+		if (validForContextSwapBoatHealth(barMode) && otherBarMode != StatusBarsConfig.BarMode.BOAT_HEALTH)
+		{
+			return barRenderers.get(StatusBarsConfig.BarMode.BOAT_HEALTH);
+		}
 
-        if (barMode == StatusBarsConfig.BarMode.BOAT_HEALTH && BOAT_HEALTH.getMaximum(client) < 1)
-        {
-            return barRenderers.get(StatusBarsConfig.BarMode.DISABLED);
-        }
+		if (barMode == StatusBarsConfig.BarMode.BOAT_HEALTH && BOAT_HEALTH.getMaximum(client) < 1)
+		{
+			return barRenderers.get(StatusBarsConfig.BarMode.DISABLED);
+		}
 
-        return barRenderers.get(barMode);
-    }
+		return barRenderers.get(barMode);
+	}
 }


### PR DESCRIPTION
Add to the base status bars plugin so that it supports boat health.
Also added a configurable option to context switch player health status bars to boat health bars when on a boat. This will only happen if one of the status bars isn't already _explicitly_ set to `BOAT_HEALTH`.

Context switching enabled: (Hitpoints bar converts to boat health when on a boat)
<img width="607" height="395" alt="image" src="https://github.com/user-attachments/assets/6271c719-e7b0-4c22-945b-d7b487137f5b" />
<img width="625" height="384" alt="image" src="https://github.com/user-attachments/assets/eb4de5d4-5f27-4803-99f5-0be5717e4a7e" />

If one of the bars is manually set to `BOAT_HEALTH` (Hitpoints bar remains as is, disabling context switching toggle has the same effect)
<img width="572" height="477" alt="image" src="https://github.com/user-attachments/assets/4a8942f7-44df-4463-9e65-7f9cdcff28e4" />

On dry land there is no boat health, so manually configured `BOAT_HEALTH` bars are disabled:
<img width="604" height="510" alt="image" src="https://github.com/user-attachments/assets/14f5cf10-a705-4011-ad35-bc8677f13f51" />

Item Stats for repair kits:
<img width="492" height="336" alt="image" src="https://github.com/user-attachments/assets/300f1c63-cd76-44ae-8914-dd54669bd765" />

