### PR TITLE
slayer: add new tasks introduced with sailing

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/Task.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/Task.java
@@ -41,6 +41,7 @@ enum Task
 	ABYSSAL_SIRE("The Abyssal Sire", ItemID.ABYSSALSIRE_PET),
 	ALCHEMICAL_HYDRA("The Alchemical Hydra", ItemID.HYDRAPET),
 	ANKOU("Ankou", ItemID.ANKOU_HEAD),
+	AQUANITES("Aquanite", ItemID.SLAYERGUIDE_AQUANITE),
 	ARAXXOR("Araxxor", ItemID.ARAXXORPET),
 	ARAXYTES("Araxytes", ItemID.POH_ARAXYTE_HEAD, "Araxxor"),
 	AVIANSIES("Aviansies", ItemID.ARCEUUS_CORPSE_AVIANSIE_INITIAL, "Kree'arra", "Flight Kilisa", "Flockleader Geerin", "Wingman Skree"),

--- a/runelite-client/src/test/java/net/runelite/client/plugins/slayer/SlayerPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/slayer/SlayerPluginTest.java
@@ -289,6 +289,8 @@ public class SlayerPluginTest
 		assertTrue(matches("Shellbane Gryphon", Task.SHELLBANE_GRYPHON));
 		assertTrue(matches("Lava Strykewyrm", Task.WYRMS));
 		assertTrue(matches("Magma strykewyrm", Task.WYRMS));
+		assertTrue(matches("Aquanite", Task.AQUANITES));
+		assertTrue(matches("Elder Aquanite", Task.AQUANITES));
 
 		assertFalse(matches("Rat", Task.PIRATES));
 		assertFalse(matches("Wolf", Task.WEREWOLVES));


### PR DESCRIPTION
- Adds new Gryphons and Shellbane Gryphon boss tasks [Wiki Slayer_task/Gryphons](https://oldschool.runescape.wiki/w/Slayer_task/Gryphons)
- Adds Aquanite task [Wiki Slayer_task/Aquanites](https://oldschool.runescape.wiki/w/Slayer_task/Aquanites)
- Adds Strykewyrms as an alternative to Wyrm tasks [Wiki Slayer_task/Wyrms](https://oldschool.runescape.wiki/w/Slayer_task/Wyrms)

[Sailing update](https://secure.runescape.com/m=news/sailing-is-out-today?oldschool=1)

Notes:
- tested ingame with gryphons and strykewyrms, relying on tests for the other ones based on wiki monster names
