### PR TITLE
chatcommands: Add sledding PB tracking to !pb command

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatcommands/ChatCommandsPlugin.java
@@ -125,6 +125,7 @@ public class ChatCommandsPlugin extends Plugin
 	private static final Pattern HUNTER_RUMOUR_KC_PATTERN = Pattern.compile("You have completed <col=[0-9a-f]{6}>([0-9,]+)</col> rumours? for the Hunter Guild\\.");
 	private static final Pattern BIRD_EGG_OFFERING_PATTERN = Pattern.compile("You have made <col=ff0000>(?<kc>[\\d,]+|one)</col> offerings?\\.");
 	private static final Pattern CHEST_OPENING_PATTERN = Pattern.compile("You have (?<never>never )?opened (the )?(?<chest>crystal chest|Larran's big chest|Larran's small chest|Brimstone chest)( (?<kc>[\\d,]+ times|once))?\\.");
+	private static final Pattern SLEDDING_PB_PATTERN = Pattern.compile("(?i)(?:You completed the race in: <col=[0-9a-f]{6}>[0-9:.]+</col>. |New )personal best: (?:<col=[0-9a-z]{6}>)?(?<pb>[0-9:]+(?:\\.[0-9]+)?)");
 
 	private static final String TOTAL_LEVEL_COMMAND_STRING = "!total";
 	private static final String PRICE_COMMAND_STRING = "!price";
@@ -663,6 +664,21 @@ public class ChatCommandsPlugin extends Plugin
 			String chest = matcher.group("chest");
 
 			setKc(chest, kc);
+		}
+
+		matcher = SLEDDING_PB_PATTERN.matcher(message);
+		if (matcher.find())
+		{
+			matchPb(matcher);
+			// Check if player is in sledding region
+			if (client.getLocalPlayer() != null)
+			{
+				int regionId = client.getLocalPlayer().getWorldLocation().getRegionID();
+				if (regionId == 52950)
+				{
+					setPb("Sledding", timeStringToSeconds(matcher.group("pb")));
+				}
+			}
 		}
 	}
 
@@ -2782,6 +2798,9 @@ public class ChatCommandsPlugin extends Plugin
 			case "dom":
 			case "doom":
 				return "Doom of Mokhaiotl";
+
+			case "sled":
+				return "Sledding";
 
 			default:
 				return WordUtils.capitalize(boss);


### PR DESCRIPTION
This change allows for players to broadcast their [Sled Racing](https://oldschool.runescape.wiki/w/Sled_Racing) PBs via the '!pb sled' and '!pb sledding' commands.

As the message for getting your new sledding PB is quite generic, it also checks for your region, to ensure that it doesn't accidentally trigger at other areas.