### PR TITLE
loot tracker: include metadata in published event

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootReceived.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootReceived.java
@@ -42,4 +42,5 @@ public class LootReceived
 	private LootRecordType type;
 	private Collection<ItemStack> items;
 	private int amount;
+	private Object metadata;
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
@@ -681,7 +681,7 @@ public class LootTrackerPlugin extends Plugin
 			queuedLoots.add(lootRecord);
 		}
 
-		eventBus.post(new LootReceived(name, combatLevel, type, items, amount));
+		eventBus.post(new LootReceived(name, combatLevel, type, items, amount, metadata));
 	}
 
 	private Integer getLootWorldId()


### PR DESCRIPTION
Working on adding to phub crowdsource plugin a thing that listens to loot tracker events and adds on a bunch more metadata. Would be very nice if it could see npc id.