### PR TITLE
feat(mta): add anti-epilepsy option to disable hint arrows

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/mta/MTAConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/mta/MTAConfig.java
@@ -28,9 +28,11 @@ import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
 
-@ConfigGroup("mta")
+@ConfigGroup(MTAConfig.GROUP)
 public interface MTAConfig extends Config
 {
+	String GROUP = "mta";
+
 	@ConfigItem(
 		keyName = "alchemy",
 		name = "Enable alchemy room",
@@ -73,5 +75,16 @@ public interface MTAConfig extends Config
 	default boolean enchantment()
 	{
 		return true;
+	}
+
+	@ConfigItem(
+		keyName = "disableFlashingArrows",
+		name = "Disable flashing arrows",
+		description = "Stops hint arrow flashing for players sensitive to it (anti-epilepsy mode).",
+		position = 4
+	)
+	default boolean disableFlashingArrows()
+	{
+		return false;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/mta/MTAPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/mta/MTAPlugin.java
@@ -28,8 +28,11 @@ import com.google.inject.Provides;
 import javax.inject.Inject;
 import lombok.AccessLevel;
 import lombok.Getter;
+import net.runelite.api.Client;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.EventBus;
+import net.runelite.client.eventbus.Subscribe;
+import net.runelite.client.events.ConfigChanged;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.plugins.mta.alchemy.AlchemyRoom;
@@ -64,6 +67,10 @@ public class MTAPlugin extends Plugin
 	private MTASceneOverlay sceneOverlay;
 	@Inject
 	private MTAItemOverlay itemOverlay;
+	@Inject
+	private Client client;
+	@Inject
+	private MTAConfig config;
 
 	@Getter(AccessLevel.PROTECTED)
 	private MTARoom[] rooms;
@@ -100,6 +107,20 @@ public class MTAPlugin extends Plugin
 		}
 
 		telekineticRoom.resetRoom();
+		client.clearHintArrow();
 	}
 
+	@Subscribe
+	private void onConfigChanged(ConfigChanged event)
+	{
+		if (!event.getGroup().equals(MTAConfig.GROUP))
+		{
+			return;
+		}
+
+		if (event.getKey().equals("disableFlashingArrows") && config.disableFlashingArrows())
+		{
+			client.clearHintArrow();
+		}
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/mta/alchemy/AlchemyRoom.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/mta/alchemy/AlchemyRoom.java
@@ -325,6 +325,8 @@ public class AlchemyRoom extends MTARoom
 		}
 
 		boolean found = false;
+		boolean arrowUpdated = false;
+		boolean showHintArrow = !getConfig().disableFlashingArrows();
 
 		for (Cupboard cupboard : cupboards)
 		{
@@ -343,9 +345,13 @@ public class AlchemyRoom extends MTARoom
 
 			if (alchemyItem == best)
 			{
-				client.setHintArrow(object.getWorldLocation());
 				found = true;
-				hintSet = true;
+				if (showHintArrow)
+				{
+					client.setHintArrow(object.getWorldLocation());
+					hintSet = true;
+					arrowUpdated = true;
+				}
 			}
 
 			BufferedImage image = itemManager.getImage(alchemyItem.getId());
@@ -357,10 +363,17 @@ public class AlchemyRoom extends MTARoom
 			}
 		}
 
-		if (!found && suggestion != null)
+		if (!found && suggestion != null && showHintArrow)
 		{
 			client.setHintArrow(suggestion.gameObject.getWorldLocation());
 			hintSet = true;
+			arrowUpdated = true;
+		}
+
+		if (!arrowUpdated && hintSet)
+		{
+			client.clearHintArrow();
+			hintSet = false;
 		}
 
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/mta/enchantment/EnchantmentRoom.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/mta/enchantment/EnchantmentRoom.java
@@ -82,12 +82,13 @@ public class EnchantmentRoom extends MTARoom
 		}
 
 		WorldPoint nearest = findNearestStone();
-		if (nearest != null)
+		boolean showHintArrow = !config.disableFlashingArrows();
+		if (nearest != null && showHintArrow)
 		{
 			client.setHintArrow(nearest);
 			hintSet = true;
 		}
-		else
+		else if (hintSet)
 		{
 			client.clearHintArrow();
 			hintSet = false;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/mta/telekinetic/TelekineticRoom.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/mta/telekinetic/TelekineticRoom.java
@@ -249,7 +249,10 @@ public class TelekineticRoom extends MTARoom
 
 				if (optimal != null)
 				{
-					client.setHintArrow(optimal);
+					if (!config.disableFlashingArrows())
+					{
+						client.setHintArrow(optimal);
+					}
 					renderWorldPoint(graphics2D, optimal);
 				}
 			}


### PR DESCRIPTION
Adds an anti-epilepsy toggle to the Mage Training Arena plugin. The new option (Disable flashing arrows) stops all arrow hint flashing across the three MTA overlays. Any existing hint arrow is cleared when the toggle is enabled or the plugin shuts down. 

Prompted by Reddit user /u/ZeroFyzix, who reported that the flashing arrow was triggering headaches due to photosensitive epilepsy ([link](https://www.reddit.com/r/2007scape/comments/1po4yzw/how_do_i_get_rid_of_this_flashing_arrow_in/))

I am open to suggestions, especially if there is a more obvious way to perhaps disable the arrows in the client scope instead of plugin-scoped.