### PR TITLE
gpu: eliminate performance notification messages from interface buffer on Intel Linux

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuPlugin.java
@@ -1359,13 +1359,14 @@ public class GpuPlugin extends Plugin implements DrawCallbacks
 
 	private void prepareInterfaceTexture(int canvasWidth, int canvasHeight)
 	{
+		long bufferSize = canvasWidth * canvasHeight * 4L;
 		if (canvasWidth != lastCanvasWidth || canvasHeight != lastCanvasHeight)
 		{
 			lastCanvasWidth = canvasWidth;
 			lastCanvasHeight = canvasHeight;
 
 			glBindBuffer(GL_PIXEL_UNPACK_BUFFER, interfacePbo);
-			glBufferData(GL_PIXEL_UNPACK_BUFFER, canvasWidth * canvasHeight * 4L, GL_STREAM_DRAW);
+			glBufferData(GL_PIXEL_UNPACK_BUFFER, bufferSize, GL_STREAM_DRAW);
 			glBindBuffer(GL_PIXEL_UNPACK_BUFFER, 0);
 
 			glBindTexture(GL_TEXTURE_2D, interfaceTexture);
@@ -1379,7 +1380,7 @@ public class GpuPlugin extends Plugin implements DrawCallbacks
 		final int height = bufferProvider.getHeight();
 
 		glBindBuffer(GL_PIXEL_UNPACK_BUFFER, interfacePbo);
-		ByteBuffer interfaceBuf = glMapBuffer(GL_PIXEL_UNPACK_BUFFER, GL_WRITE_ONLY);
+		ByteBuffer interfaceBuf = glMapBufferRange(GL_PIXEL_UNPACK_BUFFER, 0, bufferSize, GL_MAP_WRITE_BIT | GL_MAP_INVALIDATE_BUFFER_BIT);
 		if (interfaceBuf != null)
 		{
 			interfaceBuf


### PR DESCRIPTION
Wanted to figure out the source of the LWJGL performance notification messages when run in debug mode.
```
[LWJGL] OpenGL debug message
	ID: 0x1
	Source: API
	Type: PERFORMANCE
	Severity: NOTIFICATION
	Message: memory mapping a busy "buffer" BO stalled and took 3.748 ms.
```
Tracked it down to the `interfaceBuf` usage of `glMapBuffer`. Modernizing it to use `glMapBufferRange` with the invalidate bit eliminates the messages and also increases performance and I saw no adverse effects with the interface or rest of the image in normal usage and while doing resizing of the Runelite window. Here's a not really scientific informal test at the GE of the performance with farthest view distance and max settings at ~4K looking directly overhead while being at the center.

Before: ~53-55 FPS
<img width="64" height="25" alt="before" src="https://github.com/user-attachments/assets/a0dd78ea-6c08-4675-98b8-a835c89020a6" />

After: ~61-63 FPS
<img width="70" height="25" alt="after" src="https://github.com/user-attachments/assets/e004733c-443e-46dc-840a-6bfc7be74c84" />

