### PR TITLE
Item Prices plugin: Show item prices for bank placeholders

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemprices/ItemPricesPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemprices/ItemPricesPlugin.java
@@ -124,6 +124,7 @@ public class ItemPricesPlugin extends Plugin
 				}
 				// FALLTHROUGH
 			case CC_OP:
+			case CC_OP_LOW_PRIORITY:
 			case ITEM_USE:
 			case ITEM_FIRST_OPTION:
 			case ITEM_SECOND_OPTION:
@@ -199,7 +200,7 @@ public class ItemPricesPlugin extends Plugin
 				return null;
 			}
 
-			return getItemStackValueText(w.getItemId(), w.getItemQuantity());
+			return getItemStackValueText(w.getItemId(), Math.max(w.getItemQuantity(), 1));
 		}
 
 		return null;


### PR DESCRIPTION
Add CC_OP_LOW_PRIORITY menu entry type to show on bank placeholders
Item quantity for placeholders is 0 so also set min item quantity to 1