### PR TITLE
ClientUI: Allow saved bounds to work with display overlap

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/ClientUI.java
@@ -797,6 +797,38 @@ public class ClientUI
 				bestGc = gc;
 			}
 		}
+		//overlap is partial, account for the situation where title bar is OOB and not contained within another display
+		if (bestGc != null)
+		{
+			Rectangle bestGcBounds = bestGc.getBounds();
+			Rectangle titleBounds = new Rectangle(bounds.x, bounds.y, bounds.width, content.getBounds().y);
+			for (GraphicsDevice gd : gds)
+			{
+				GraphicsConfiguration gc = gd.getDefaultConfiguration();
+				if (gc == bestGc)
+				{
+					continue;
+				}
+
+				final Rectangle displayBounds = gc.getBounds();
+				if (displayBounds.y > bestGcBounds.y)
+				{
+					continue;
+				}
+
+				Rectangle intersection = displayBounds.intersection(titleBounds);
+				//title bar not within display
+				if (intersection.isEmpty())
+				{
+					continue;
+				}
+
+				//title bar within a valid display no shift needed
+				return bestGc;
+			}
+			//no valid display found for title bar, cannot be interacted with and needs to be shifted to bestGcs top/y
+			frame.setLocation(frame.getX(), bestGcBounds.y);
+		}
 		return bestGc;
 	}
 


### PR DESCRIPTION
Issue this resolves : 
Saved bounds with any overlap onto a second display are currently considered invalid and send client to center of primary monitor.

How current issue occurs :
On client close the location is saved to config as clientBounds.
On launch, if the saved bounds are not entirely within one display no valid display is returned.
In said case the position is defaulted to the primary display's center location.

This PR attempts to find what display the client is overlapping with the most and returns that.
Given a valid display is returned, the clients location is properly restored.

Due to handling partial overlap, this feature needs to handle a [fringe case](https://github.com/1Defence/runelite/commit/df3b950de019f6e68392477b823b9285f26f236d) in which the title bar is off screen and not within a valid display, shifting it into bounds.

Feedback/better solutions on shifting the client would be appreciated as there is likely a better approach for this fringe case, it can only happen if user changed display configuration since their last launch or they used external software to move the client