### PR TITLE
Fixed potential NumberFormatException

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/components/TooltipComponent.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/components/TooltipComponent.java
@@ -120,7 +120,12 @@ public class TooltipComponent implements LayoutableRenderableEntity
 					if (subLine.startsWith("col="))
 					{
 						String argument = subLine.substring(4);
-						nextColor = Color.decode("#" + argument);
+
+						try {
+							nextColor = Color.decode("#" + argument);
+						} catch (NumberFormatException e) {
+							nextColor = Color.WHITE;
+						}
 					}
 					else if (subLine.equals("/col"))
 					{


### PR DESCRIPTION
My logs are getting spammed with NumberFormatException, this provides the following stack trace

 [Client] WARN net.runelite.client.ui.overlay.OverlayRenderer -  DEDUPLICATE Error during overlay rendering
java.lang.NumberFormatException: For input string: "0xffffff"
	at java.base/java.lang.NumberFormatException.forInputString(NumberFormatException.java:65)
	at java.base/java.lang.Integer.parseInt(Integer.java:652)
	at java.base/java.lang.Integer.valueOf(Integer.java:957)
	at java.base/java.lang.Integer.decode(Integer.java:1436)
	at java.desktop/java.awt.Color.decode(Color.java:729)
	at net.runelite.client.ui.overlay.components.TooltipComponent.render(TooltipComponent.java:123) <---
	at net.runelite.client.ui.overlay.tooltip.TooltipOverlay.renderTooltips(TooltipOverlay.java:123)
	at net.runelite.client.ui.overlay.tooltip.TooltipOverlay.render(TooltipOverlay.java:80)
	at net.runelite.client.ui.overlay.OverlayRenderer.safeRender(OverlayRenderer.java:742)
	at net.runelite.client.ui.overlay.OverlayRenderer.renderOverlays(OverlayRenderer.java:336)
	at net.runelite.client.ui.overlay.OverlayRenderer.renderAfterInterface(OverlayRenderer.java:245)
	at net.runelite.client.callback.Hooks.drawInterface(Hooks.java:546)
	at client.sm(client.java:30550)
	at by.me(by.java:9116)
	at fj.md(fj.java:8559)
	at client.qv(client.java:13633)
	at client.bn(client.java:11699)
	at bm.bs(bm.java:497)
	at bm.ec(bm.java)
	at bm.run(bm.java:42827)
