### PR TITLE
entity hider: fix hide others for attackers

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/entityhider/EntityHiderPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/entityhider/EntityHiderPlugin.java
@@ -204,9 +204,9 @@ public class EntityHiderPlugin extends Plugin
 				return !(drawingUI ? hideLocalPlayer2D : hideLocalPlayer);
 			}
 
-			if (hideAttackers && player.getInteracting() == local)
+			if (local != null && player.getInteracting() == local)
 			{
-				return false; // hide
+				return !hideAttackers;
 			}
 
 			if (partyService.isInParty() && partyService.getMemberByDisplayName(player.getName()) != null)

--- a/runelite-client/src/test/java/net/runelite/client/plugins/entityhider/EntityHiderPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/entityhider/EntityHiderPluginTest.java
@@ -285,4 +285,30 @@ public class EntityHiderPluginTest
 		assertTrue(plugin.shouldDraw(player, true));
 		assertTrue(plugin.shouldDraw(player, false));
 	}
+
+	// hide others except when they're attacking you
+	@Test
+	public void testHideOthersAttacker()
+	{
+		when(config.hideOthers()).thenReturn(true);
+		when(config.hideOthers2D()).thenReturn(true);
+
+		ConfigChanged configChanged = new ConfigChanged();
+		configChanged.setGroup(EntityHiderConfig.GROUP);
+		plugin.onConfigChanged(configChanged);
+
+		Player player = mock(Player.class);
+		when(client.getLocalPlayer()).thenReturn(player);
+
+		Player attacker = mock(Player.class);
+		when(attacker.getName()).thenReturn("Attacker");
+
+		assertFalse(plugin.shouldDraw(attacker, true));
+		assertFalse(plugin.shouldDraw(attacker, false));
+
+		when(attacker.getInteracting()).thenReturn(player);
+
+		assertTrue(plugin.shouldDraw(attacker, true));
+		assertTrue(plugin.shouldDraw(attacker, false));
+	}
 }


### PR DESCRIPTION
From the wiki for Entity Hider:
> 1. Hide Others
(Default On) Hides other players who are not on your friends/ignore list, in your friends/clan chat, or ***in combat with you***.

I believe this implies that "Hide Others" doesn't apply to players attacking you unless "Hide attackers" is enabled too.  
On the current version, attackers are still hidden when only "Hide Others" is selected. This fix should unhide players whenever they're attacking the local player.