### PR TITLE
entity hider: better attacker tracking

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/entityhider/EntityHiderPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/entityhider/EntityHiderPlugin.java
@@ -94,7 +94,7 @@ public class EntityHiderPlugin extends Plugin
 		NpcID.MACRO_COUNTCHECK_SURFACE, NpcID.MACRO_COUNTCHECK_UNDERWATER
 	);
 
-	private static final Duration WAIT = Duration.ofSeconds(5);
+	private static final Duration WAIT = Duration.ofMillis(9600);
 
 	@Inject
 	private Client client;


### PR DESCRIPTION
Adapted from [OpponentInfoPlugin](https://github.com/runelite/runelite/blob/master/runelite-client/src/main/java/net/runelite/client/plugins/opponentinfo/OpponentInfoPlugin.java).
This has a minor merge conflict with #19764, will fix if both are approved.
Currently, attackers are only hidden (with "Hide attackers" on) during the duration that they're interacting with the local player. If they stop interacting with the player temporarily like walking to another tile or eating food, they immediately stop counting as an attacker. This makes it so that they'll count as an attacker for at least 5 more seconds after their last interaction with the player.