### PR TITLE
Examine: Change Pending Deque Management

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/examine/ExaminePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/examine/ExaminePlugin.java
@@ -128,7 +128,7 @@ public class ExaminePlugin extends Plugin
 			log.debug("Type mismatch for pending examine: {} != {}", pendingExamine.getResponseType(), event.getType());
 			return;
 		}
-		pending.poll();
+		pending.pop();
 
 		log.debug("Got examine type {} {}: {}", pendingExamine.getResponseType(), pendingExamine.getId(), event.getMessage());
 


### PR DESCRIPTION
Fixes #19762

Elements from the `pending` deque are no longer removed after a type mismatch. Previously `pending` would be entirely cleared upon mismatch; causing unrelated chat messages received after the user clicks examine and before the `ITEM_EXAMINE` chat message to clear `pending`. Now only the first element is removed after confirming correct chat message type. We can also use `pending.clear()` instead of `pending.poll()` if we should be clearing`pending`.

Before
<img width="1302" height="83" alt="pre change example GE" src="https://github.com/user-attachments/assets/fb226780-89ab-44a6-8e44-120d4311e9b9" />
The autotyper message has cleared `pending` so the plugin does nothing.

After
<img width="1304" height="135" alt="post change examine text in GE" src="https://github.com/user-attachments/assets/e7d36ad9-d834-4776-98c8-11c1f6f1e48a" />
Now only the corresponding `ITEM_EXAMINE` chat message can clear `pending`.

