### PR TITLE
Item Identification: Add New Farming Items to Item Identification Plugin

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemidentification/ItemIdentification.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemidentification/ItemIdentification.java
@@ -70,7 +70,6 @@ enum ItemIdentification
 	PILLAR_FRAG(Type.SEED_SPECIAL, "Pillar", "PIL", ItemID.CORAL_PILLAR_FRAG),
 	UMBRAL_FRAG(Type.SEED_SPECIAL, "Umbral", "UMB", ItemID.CORAL_UMBRAL_FRAG),
 
-
 	ACORN(Type.SEED_TREE, "Oak", "OAK", ItemID.ACORN),
 	WILLOW_SEED(Type.SEED_TREE, "Willow", "WIL", ItemID.WILLOW_SEED),
 	MAPLE_SEED(Type.SEED_TREE, "Maple", "MAP", ItemID.MAPLE_SEED),


### PR DESCRIPTION
Closes #19759
Adds the following items to item identification plugin:

1. Hop seeds
    - Flax (FLAX)
    - Hemp (HEMP)
    - Cotton (CTN)
2. Trees
    - Camphor (CAM)
    - Ironwood (IRON)
    - Rosewood (RSWD)
3. Special seeds
    - Elkhorn frag (ELK)
    - Pillar frag (PIL)
    - Umbral frag (UMB)

<img width="177" height="219" alt="item identification plugin screenshot2" src="https://github.com/user-attachments/assets/e2b8bc36-f15a-4dc3-af32-7919dd3e11b5" />

