### PR TITLE
Drift Net: Add fill color options

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/driftnet/DriftNetConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/driftnet/DriftNetConfig.java
@@ -48,7 +48,33 @@ public interface DriftNetConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 2,
+			position = 2,
+			keyName = "netHighlightStyle",
+			name = "Use clickbox for nets",
+			description = "Use clickbox instead of hull to highlight drift nets."
+	)
+	default boolean useNetClickbox()
+	{
+		return false;
+	}
+
+	@Range(
+			min = 0,
+			max = 255
+	)
+	@ConfigItem(
+			position = 3,
+			keyName = "netFillOpacity",
+			name = "Net fill opacity",
+			description = "Opacity of drift net fill color (0 = transparent, 255 = solid)."
+	)
+	default int netFillOpacity()
+	{
+		return 0;
+	}
+
+	@ConfigItem(
+		position = 4,
 		keyName = "countColor",
 		name = "Fish count color",
 		description = "Color of the fish count text."
@@ -59,7 +85,7 @@ public interface DriftNetConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 3,
+		position = 5,
 		keyName = "highlightUntaggedFish",
 		name = "Highlight untagged fish",
 		description = "Highlight the untagged fish."
@@ -70,7 +96,7 @@ public interface DriftNetConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 4,
+		position = 6,
 		keyName = "timeoutDelay",
 		name = "Tagged timeout",
 		description = "Time required for a tag to expire."
@@ -90,18 +116,30 @@ public interface DriftNetConfig extends Config
 		keyName = "untaggedFishColor",
 		name = "Untagged fish color",
 		description = "Color of untagged fish.",
-		position = 5
+		position = 7
 	)
 	default Color untaggedFishColor()
 	{
 		return Color.CYAN;
 	}
 
+	@Alpha
+	@ConfigItem(
+			keyName = "untaggedFishFillColor",
+			name = "Untagged fish fill color",
+			description = "Fill color of untagged fish tile.",
+			position = 8
+	)
+	default Color untaggedFishFillColor()
+	{
+		return new Color(0, 255, 255, 50);
+	}
+
 	@ConfigItem(
 		keyName = "tagAnnette",
 		name = "Tag Annette",
 		description = "Tag Annette when no nets in inventory.",
-		position = 6
+		position = 9
 	)
 	default boolean tagAnnetteWhenNoNets()
 	{
@@ -113,7 +151,7 @@ public interface DriftNetConfig extends Config
 		keyName = "annetteTagColor",
 		name = "Annette tag color",
 		description = "Color of Annette tag.",
-		position = 7
+		position = 10
 	)
 	default Color annetteTagColor()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/driftnet/DriftNetOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/driftnet/DriftNetOverlay.java
@@ -7,6 +7,7 @@
  *
  * 1. Redistributions of source code must retain the above copyright notice, this
  *    list of conditions and the following disclaimer.
+ *
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
@@ -24,8 +25,10 @@
  */
 package net.runelite.client.plugins.driftnet;
 
+import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Graphics2D;
+import java.awt.Polygon;
 import java.awt.Shape;
 import javax.inject.Inject;
 import net.runelite.api.GameObject;
@@ -81,7 +84,14 @@ class DriftNetOverlay extends Overlay
 		{
 			if (!plugin.getTaggedFish().containsKey(fish))
 			{
-				OverlayUtil.renderActorOverlay(graphics, fish, "", config.untaggedFishColor());
+				Polygon tilePoly = fish.getCanvasTilePoly();
+				if (tilePoly != null)
+				{
+					graphics.setColor(config.untaggedFishFillColor());
+					graphics.fill(tilePoly);
+					graphics.setColor(config.untaggedFishColor());
+					graphics.draw(tilePoly);
+				}
 			}
 		}
 	}
@@ -90,11 +100,27 @@ class DriftNetOverlay extends Overlay
 	{
 		for (DriftNet net : plugin.getNETS())
 		{
-			final Shape polygon = net.getNet().getConvexHull();
+			final Shape polygon;
+			if (config.useNetClickbox())
+			{
+				polygon = net.getNet().getClickbox();
+			}
+			else
+			{
+				polygon = net.getNet().getConvexHull();
+			}
 
 			if (polygon != null)
 			{
-				OverlayUtil.renderPolygon(graphics, polygon, net.getStatus().getColor());
+				Color statusColor = net.getStatus().getColor();
+				if (config.netFillOpacity() > 0)
+				{
+					Color fillColor = new Color(statusColor.getRed(), statusColor.getGreen(), statusColor.getBlue(), config.netFillOpacity());
+					graphics.setColor(fillColor);
+					graphics.fill(polygon);
+				}
+				graphics.setColor(statusColor);
+				graphics.draw(polygon);
 			}
 
 			String text = net.getFormattedCountText();


### PR DESCRIPTION
Adds the following options to the Drift Net plugin:

- Net fill opacity: Adjustable fill opacity for drift nets (uses the existing status color)
- Use clickbox for nets: Option to highlight nets using clickbox instead of hull
- Untagged fish fill color: Fill color for untagged fish tiles