### PR TITLE
Time Tracker: Show Falador patch protection with elite diary

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/farming/PaymentTracker.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/farming/PaymentTracker.java
@@ -125,14 +125,16 @@ public class PaymentTracker
 	}
 
 	@Subscribe
-	public void onChatMessage(ChatMessage event) {
+	public void onChatMessage(ChatMessage event)
+	{
 		if (event.getType() != ChatMessageType.GAMEMESSAGE || !event.getMessage().equals(FALADOR_DIARY_TEXT)) return;
 		FarmingPatch p = null;
 		for (FarmingRegion region : farmingWorld.getRegionsForLocation(client.getLocalPlayer().getWorldLocation()))
 		{
 			for (FarmingPatch patch : region.getPatches())
 			{
-				if (patch.getName().equals("Falador") && patch.getImplementation() == PatchImplementation.TREE) {
+				if (patch.getName().equals("Falador") && patch.getImplementation() == PatchImplementation.TREE)
+				{
 					p = patch;
 				}
 			}


### PR DESCRIPTION
Show the tree protection icon on the time tracking pane if the Falador diary message is in the chat