### PR TITLE
Switch String.Format out for StringBuilder

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpStateSingle.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpStateSingle.java
@@ -41,6 +41,8 @@ class XpStateSingle
 	private final int[] actionExps = new int[10];
 	private int actionExpIndex = 0;
 
+	private final StringBuilder sb = new StringBuilder();
+
 	@Getter
 	@Setter
 	private long startXp;
@@ -77,6 +79,13 @@ class XpStateSingle
 	int getTotalXpGained()
 	{
 		return xpGainedBeforeReset + xpGainedSinceReset;
+	}
+
+	private StringBuilder appendTwoDigits(long v)
+	{
+		if (v < 10) sb.append('0');
+		sb.append(v);
+		return sb;
 	}
 
 	private int getActionsHr()
@@ -172,20 +181,33 @@ class XpStateSingle
 			case DAYS:
 				if (durationDays > 1)
 				{
-					return String.format("%d days %02d:%02d:%02d", durationDays, durationHours, durationMinutes, durationSeconds);
+					sb.setLength(0);
+					sb.append(durationDays).append(" days ");
+					appendTwoDigits(durationHours).append(':');
+					return appendTwoDigits(durationMinutes).append(':').toString();
 				}
 				else if (durationDays == 1)
 				{
-					return String.format("1 day %02d:%02d:%02d", durationHours, durationMinutes, durationSeconds);
+					sb.setLength(0);
+					sb.append("1 day ");
+					appendTwoDigits(durationHours).append(':');
+					appendTwoDigits(durationMinutes).append(':');
+					return appendTwoDigits(durationSeconds).toString();
 				}
 			case HOURS:
 				if (durationHoursTotal > 1)
 				{
-					return String.format("%d hours %02d:%02d", durationHoursTotal, durationMinutes, durationSeconds);
+					sb.setLength(0);
+					sb.append(durationHoursTotal).append(" hours ");
+					appendTwoDigits(durationMinutes).append(':');
+					return appendTwoDigits(durationSeconds).toString();
 				}
 				else if (durationHoursTotal == 1)
 				{
-					return String.format("1 hour %02d:%02d", durationMinutes, durationSeconds);
+					sb.setLength(0);
+					sb.append("1 hour ");
+					appendTwoDigits(durationMinutes).append(':');
+					return appendTwoDigits(durationSeconds).toString();
 				}
 			case SHORT:
 			default:
@@ -193,11 +215,16 @@ class XpStateSingle
 				// return time remaining in hh:mm:ss or mm:ss format where hh can be > 24
 				if (durationHoursTotal > 0)
 				{
-					return String.format("%d:%02d:%02d", durationHoursTotal, durationMinutes, durationSeconds);
+					sb.setLength(0);
+					sb.append(durationHoursTotal).append(':');
+					appendTwoDigits(durationMinutes).append(':');
+					return appendTwoDigits(durationSeconds).toString();
 				}
 
 				// Minutes and seconds will always be present
-				return String.format("%02d:%02d", durationMinutes, durationSeconds);
+				sb.setLength(0);
+				appendTwoDigits(durationMinutes).append(':');
+				return appendTwoDigits(durationSeconds).toString();
 		}
 	}
 


### PR DESCRIPTION
### Summary
`String.format` internally creates `new Formatter()`, which in turn create a new List & various other PODs to help the formatting.

Instead, the formatting has been expanded out using a String Builder to remove all allocations other than the built string, removing garbage generated between collections which was in the ballpark of 300 MB and sometimes more.

### Testing
To confirm the formatting is the same, I added asserts comparing the previous `String.format` to the new

### Profiling
Original117 Profile (This is what prompted this PR):
<img width="782" height="464" alt="image" src="https://github.com/user-attachments/assets/6a811046-b088-4dc5-93ab-9c022aea031e" />

Master Profile:
<img width="751" height="475" alt="image" src="https://github.com/user-attachments/assets/68e4a001-4567-40e6-a2d5-e98fe485607e" />

PR Profile:
<img width="727" height="448" alt="image" src="https://github.com/user-attachments/assets/e2c1b8ac-fd44-425f-98b1-482f7d7fe5ca" />
