### PR TITLE
item stats: adjust blighted overload effect

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatChanges.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatChanges.java
@@ -280,7 +280,7 @@ public class ItemStatChanges
 		// Regular overload (NMZ)
 		add(combo(SUPER_ATTACK_POT, SUPER_STRENGTH_POT, SUPER_DEFENCE_POT, superRangingPot, superMagicPot, heal(HITPOINTS, -50)), ItemID.NZONE1DOSEOVERLOADPOTION, ItemID.NZONE2DOSEOVERLOADPOTION, ItemID.NZONE3DOSEOVERLOADPOTION, ItemID.NZONE4DOSEOVERLOADPOTION);
 		// Blighted overload (DMM)
-		add(combo(boost(ATTACK, perc(.15, 8)), boost(STRENGTH, perc(.15, 8)), new BoostedStatBoost(DEFENCE, false, perc(.1, -1)), boost(RANGED, perc(.1, 7)), boost(MAGIC, perc(.1, 1)), heal(HITPOINTS, -25)), ItemID.DEADMAN1DOSEOVERLOAD, ItemID.DEADMAN2DOSEOVERLOAD, ItemID.DEADMAN3DOSEOVERLOAD, ItemID.DEADMAN4DOSEOVERLOAD);
+		add(combo(boost(ATTACK, perc(.15, 8)), boost(STRENGTH, perc(.15, 8)), new BoostedStatBoost(DEFENCE, false, perc(.1, -1)), boost(RANGED, perc(.1, 7)), boost(MAGIC, perc(.1, 1)), heal(HITPOINTS, -5)), ItemID.DEADMAN1DOSEOVERLOAD, ItemID.DEADMAN2DOSEOVERLOAD, ItemID.DEADMAN3DOSEOVERLOAD, ItemID.DEADMAN4DOSEOVERLOAD);
 
 		// Bandages (Castle Wars)
 		add(new CastleWarsBandage(), ItemID.CASTLEWARS_BANDAGES);

--- a/runelite-client/src/test/java/net/runelite/client/plugins/itemstats/ItemStatEffectTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/itemstats/ItemStatEffectTest.java
@@ -521,9 +521,9 @@ public class ItemStatEffectTest
 	{
 		final Effect blightedOverload = new ItemStatChanges().get(ItemID.DEADMAN4DOSEOVERLOAD);
 
-		assertEquals(-25, skillChange(Skill.HITPOINTS, 49, 44, blightedOverload));
-		assertEquals(-25, skillChange(Skill.HITPOINTS, 64, 64, blightedOverload));
-		assertEquals(-25, skillChange(Skill.HITPOINTS, 99, 77, blightedOverload));
+		assertEquals(-5, skillChange(Skill.HITPOINTS, 49, 44, blightedOverload));
+		assertEquals(-5, skillChange(Skill.HITPOINTS, 64, 64, blightedOverload));
+		assertEquals(-5, skillChange(Skill.HITPOINTS, 99, 77, blightedOverload));
 
 		assertEquals(13, skillChange(Skill.STRENGTH, 36, 36, blightedOverload));
 		assertEquals(17, skillChange(Skill.STRENGTH, 66, 66, blightedOverload));


### PR DESCRIPTION
Hold for anticipated update on SDMM/blighted overload.

This amends the HP drain from overloads from -25 to -5.
Ref:
https://github.com/runelite/runelite/pull/19254#issuecomment-3765197795