### PR TITLE
Add Fake Drop plugin for RuneLite

### DIFF
--- a/decompiled_plugin/build.gradle.kts
+++ b/decompiled_plugin/build.gradle.kts
@@ -1,0 +1,56 @@
+plugins {
+    java
+}
+
+group = "com.fakedrop"
+version = "1.0.0"
+
+repositories {
+    mavenLocal()
+    maven {
+        url = uri("https://repo.runelite.net")
+    }
+    mavenCentral()
+}
+
+dependencies {
+    compileOnly(group = "net.runelite", name = "client", version = "latest.release")
+
+    compileOnly("org.projectlombok:lombok:1.18.30")
+    annotationProcessor("org.projectlombok:lombok:1.18.30")
+
+    compileOnly("com.google.guava:guava:23.2-jre")
+    compileOnly("com.google.inject:guice:4.1.0:no_aop")
+    compileOnly("com.google.code.gson:gson:2.8.5")
+    compileOnly("net.sf.jopt-simple:jopt-simple:5.0.4")
+    compileOnly("org.slf4j:slf4j-api:1.7.25")
+
+    // Test dependencies
+    testImplementation("junit:junit:4.13.2")
+    testImplementation("org.mockito:mockito-core:4.11.0")
+    testImplementation("org.mockito:mockito-inline:4.11.0")
+    testImplementation(group = "net.runelite", name = "client", version = "latest.release")
+    testImplementation("org.projectlombok:lombok:1.18.30")
+    testAnnotationProcessor("org.projectlombok:lombok:1.18.30")
+    testImplementation("com.google.inject:guice:4.1.0:no_aop")
+    testImplementation("org.slf4j:slf4j-api:1.7.25")
+    testImplementation("org.slf4j:slf4j-simple:1.7.25")
+}
+
+tasks.test {
+    useJUnit()
+    testLogging {
+        events("passed", "skipped", "failed")
+        showStandardStreams = true
+        exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
+    }
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
+}
+
+tasks.withType<JavaCompile> {
+    options.encoding = "UTF-8"
+}

--- a/decompiled_plugin/settings.gradle.kts
+++ b/decompiled_plugin/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "fake-drop-plugin"

--- a/decompiled_plugin/src/main/java/com/fakedrop/FakeDropConfig.java
+++ b/decompiled_plugin/src/main/java/com/fakedrop/FakeDropConfig.java
@@ -1,0 +1,479 @@
+package com.fakedrop;
+
+import java.awt.Color;
+import net.runelite.client.config.Alpha;
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.ConfigSection;
+import net.runelite.client.config.Keybind;
+import net.runelite.client.config.Range;
+import net.runelite.api.IconID;
+
+@ConfigGroup("fakedrop")
+public interface FakeDropConfig extends Config
+{
+    enum IronmanType
+    {
+        NONE("None", ""),
+        IRONMAN("Ironman", IconID.IRONMAN.toString()),
+        HARDCORE("Hardcore", IconID.HARDCORE_IRONMAN.toString()),
+        ULTIMATE("Ultimate", IconID.ULTIMATE_IRONMAN.toString()),
+        GROUP("Group Ironman", "");
+
+        private final String name;
+        private final String icon;
+
+        IronmanType(String name, String icon)
+        {
+            this.name = name;
+            this.icon = icon;
+        }
+
+        public String getIcon()
+        {
+            return icon;
+        }
+
+        @Override
+        public String toString()
+        {
+            return name;
+        }
+    }
+
+    enum Pet
+    {
+        // Skilling Pets
+        ROCKY("Rocky", true, "Thieving", "Varies"),
+        BEAVER("Beaver", true, "Woodcutting", "Varies"),
+        HERON("Heron", true, "Fishing", "Varies"),
+        ROCK_GOLEM("Rock golem", true, "Mining", "Varies"),
+        BABY_CHINCHOMPA("Baby chinchompa", true, "Hunter", "Varies"),
+        GIANT_SQUIRREL("Giant squirrel", true, "Agility", "Varies"),
+        TANGLEROOT("Tangleroot", true, "Farming", "Varies"),
+        RIFT_GUARDIAN("Rift guardian", true, "Runecraft", "Varies"),
+        SOUP("Soup", true, "Sailing", "Varies"),
+        
+        // Boss Pets
+        LIL_ZIK("Lil' zik", false, null, "1/650"),
+        VORKI("Vorki", false, null, "1/3,000"),
+        OLMLET("Olmlet", false, null, "1/53"),
+        YOUNGLLEF("Youngllef", false, null, "1/800"),
+        NEXLING("Nexling", false, null, "1/500"),
+        TUMEKEN_GUARDIAN("Tumeken's guardian", false, null, "Varies"),
+        SCORPIAS_OFFSPRING("Scorpia's offspring", false, null, "1/2,016"),
+        HELLPUPPY("Hellpuppy", false, null, "1/3,000"),
+        IKKLE_HYDRA("Ikkle hydra", false, null, "1/3,000"),
+        SKOTOS("Skotos", false, null, "1/65"),
+        TZREK_JAD("Tzrek-jad", false, null, "1/200"),
+        JAL_NIB_REK("Jal-nib-rek", false, null, "1/100"),
+        PET_KRAKEN("Pet kraken", false, null, "1/3,000"),
+        PRINCE_BLACK_DRAGON("Prince black dragon", false, null, "1/3,000"),
+        BABY_MOLE("Baby mole", false, null, "1/3,000"),
+        PET_CHAOS_ELEMENTAL("Pet chaos elemental", false, null, "1/300"),
+        PET_SNAKELING("Pet snakeling", false, null, "1/4,000"),
+        VENENATIS_SPIDERLING("Venenatis spiderling", false, null, "1/1,500"),
+        CALLISTO_CUB("Callisto cub", false, null, "1/1,500"),
+        VETION_JR("Vet'ion jr.", false, null, "1/1,500"),
+        KALPHITE_PRINCESS("Kalphite princess", false, null, "1/3,000"),
+        PET_SMOKE_DEVIL("Pet smoke devil", false, null, "1/3,000"),
+        PET_DARK_CORE("Pet dark core", false, null, "1/5,000"),
+        NOON("Noon", false, null, "1/3,000"),
+        LIL_CREATOR("Lil' creator", false, null, "1/400"),
+        ABYSSAL_ORPHAN("Abyssal orphan", false, null, "1/2,560"),
+        MUPHIN("Muphin", false, null, "1/2,500"),
+        WISP("Wisp", false, null, "1/2,000"),
+        BARON("Baron", false, null, "1/2,500"),
+        BUTCH("Butch", false, null, "1/3,000"),
+        LILVIATHAN("Lil'viathan", false, null, "1/2,500"),
+        LITTLE_NIGHTMARE("Little nightmare", false, null, "1/800-1/4,000"),
+        SMOLCANO("Smolcano", false, null, "1/2,250"),
+        SRARACHA("Sraracha", false, null, "1/3,000"),
+        TINY_TEMPOR("Tiny tempor", false, null, "1/8,000"),
+        PHOENIX("Phoenix", false, null, "1/5,000"),
+        ABYSSAL_PROTECTOR("Abyssal protector", false, null, "1/4,000"),
+        HERBI("Herbi", false, null, "1/6,500"),
+        NID("Nid", false, null, "1/3,000"),
+        SCURRY("Scurry", false, null, "1/3,000"),
+        CUSTOM("Custom", false, null, "Custom");
+
+        private final String petName;
+        private final boolean isSkilling;
+        private final String skill; // Only for skilling pets
+        private final String defaultRarity;
+
+        Pet(String petName, boolean isSkilling, String skill, String defaultRarity)
+        {
+            this.petName = petName;
+            this.isSkilling = isSkilling;
+            this.skill = skill;
+            this.defaultRarity = defaultRarity;
+        }
+
+        public String getPetName()
+        {
+            return petName;
+        }
+
+        public boolean isSkilling()
+        {
+            return isSkilling;
+        }
+
+        public String getSkill()
+        {
+            return skill;
+        }
+
+        public String getDefaultRarity()
+        {
+            return defaultRarity;
+        }
+
+        @Override
+        public String toString()
+        {
+            if (isSkilling && skill != null)
+            {
+                return petName + " (" + skill + ")";
+            }
+            return petName;
+        }
+    }
+    
+    // ========== SECTIONS ==========
+    @ConfigSection(
+            name = "Boss Settings",
+            description = "Configure boss information",
+            position = 1
+    )
+    String bossSection = "bossSection";
+
+    @ConfigSection(
+            name = "Drop Settings",
+            description = "Configure drop information",
+            position = 2
+    )
+    String dropSection = "dropSection";
+
+    @ConfigSection(
+            name = "Clan Settings",
+            description = "Configure clan announcement settings",
+            position = 3
+    )
+    String clanSection = "clanSection";
+
+    @ConfigSection(
+            name = "Pet Settings",
+            description = "Configure pet drop information",
+            position = 4
+    )
+    String petSection = "petSection";
+
+    // ========== HOTKEYS ==========
+    @ConfigItem(
+            keyName = "toggle",
+            name = "Trigger Drop",
+            description = "Hotkey to announce the fake drop",
+            position = -1
+    )
+    default Keybind toggle()
+    {
+        return Keybind.NOT_SET;
+    }
+
+    @ConfigItem(
+            keyName = "quickSwitchMode",
+            name = "Quick Switch Mode",
+            description = "Hotkey to quickly toggle between Boss and Pet mode",
+            position = 0
+    )
+    default Keybind quickSwitchMode()
+    {
+        return Keybind.NOT_SET;
+    }
+
+    // ========== BOSS SECTION ==========
+    @ConfigItem(
+            keyName = "bossName",
+            name = "Boss Name",
+            description = "The name of the boss",
+            section = bossSection,
+            position = 1
+    )
+    default String bossName()
+    {
+        return "Leviathan";
+    }
+
+    @ConfigItem(
+            keyName = "bossLocation",
+            name = "Boss Location",
+            description = "The location/full name of the boss for clan broadcast (e.g., 'The Leviathan')",
+            section = bossSection,
+            position = 2
+    )
+    default String bossLocation()
+    {
+        return "The Leviathan";
+    }
+
+    @ConfigItem(
+            keyName = "killCount",
+            name = "Kill Count",
+            description = "Your kill count for the boss",
+            section = bossSection,
+            position = 3
+    )
+    default int killCount()
+    {
+        return 215;
+    }
+
+    @ConfigItem(
+            keyName = "autoIncrementKC",
+            name = "Auto-Increment KC",
+            description = "Automatically increase kill count by 1 each time you trigger a drop",
+            section = bossSection,
+            position = 4
+    )
+    default boolean autoIncrementKC()
+    {
+        return true;
+    }
+
+    @ConfigItem(
+            keyName = "timed",
+            name = "Show Time",
+            description = "Show fight duration and personal best",
+            section = bossSection,
+            position = 4
+    )
+    default boolean timed()
+    {
+        return true;
+    }
+
+    @ConfigItem(
+            keyName = "killTime",
+            name = "Kill Time",
+            description = "The duration of the fight",
+            section = bossSection,
+            position = 5
+    )
+    default String killTime()
+    {
+        return "1:21:00";
+    }
+
+    @ConfigItem(
+            keyName = "personalBest",
+            name = "Personal Best",
+            description = "Your personal best time",
+            section = bossSection,
+            position = 6
+    )
+    default String personalBest()
+    {
+        return "1:01:00";
+    }
+
+    // ========== DROP SECTION ==========
+    @ConfigItem(
+            keyName = "dropName",
+            name = "Drop Name",
+            description = "The name of the drop",
+            section = dropSection,
+            position = 7
+    )
+    default String dropName()
+    {
+        return "Virtus robe bottom";
+    }
+
+    @Range(min = 0, max = Integer.MAX_VALUE)
+    @ConfigItem(
+            keyName = "dropValue",
+            name = "Drop Value",
+            description = "The value of the drop in coins",
+            section = dropSection,
+            position = 8
+    )
+    default int dropValue()
+    {
+        return 31883867;
+    }
+
+    @ConfigItem(
+            keyName = "randomizeValue",
+            name = "Randomize Value",
+            description = "Add ±5% randomization to drop value for realism",
+            section = dropSection,
+            position = 9
+    )
+    default boolean randomizeValue()
+    {
+        return false;
+    }
+
+    @ConfigItem(
+            keyName = "untradeable",
+            name = "Untradeable Drop",
+            description = "Whether the drop is untradeable",
+            section = dropSection,
+            position = 9
+    )
+    default boolean untradeable()
+    {
+        return false;
+    }
+
+    @ConfigItem(
+            keyName = "collectionLog",
+            name = "Collection Log",
+            description = "Show as collection log drop",
+            section = dropSection,
+            position = 10
+    )
+    default boolean collectionLog()
+    {
+        return true;
+    }
+
+    @ConfigItem(
+            keyName = "showCollectionLogPopup",
+            name = "Show Collection Log Popup",
+            description = "Display the collection log popup notification",
+            section = dropSection,
+            position = 11
+    )
+    default boolean showCollectionLogPopup()
+    {
+        return true;
+    }
+
+    @ConfigItem(
+            keyName = "collectionLogCount",
+            name = "Collection Log Count",
+            description = "Your collection log count (format: obtained/total)",
+            section = dropSection,
+            position = 12
+    )
+    default String collectionLogCount()
+    {
+        return "922/1892";
+    }
+
+    // ========== CLAN SECTION ==========
+    @ConfigItem(
+            keyName = "announceToClan",
+            name = "Announce to Clan",
+            description = "Automatically announce the drop in clan chat",
+            section = clanSection,
+            position = 13
+    )
+    default boolean announceToClan()
+    {
+        return true;
+    }
+
+    @ConfigItem(
+            keyName = "clanName",
+            name = "Clan Name",
+            description = "The name of your clan for the broadcast",
+            section = clanSection,
+            position = 14
+    )
+    default String clanName()
+    {
+        return "Oblivion";
+    }
+
+    @Alpha
+    @ConfigItem(
+            keyName = "clanColor",
+            name = "Clan Color",
+            description = "Color for the clan name text",
+            section = clanSection,
+            position = 15
+    )
+    default Color clanColor()
+    {
+        return new Color(0, 0, 255);
+    }
+
+    @ConfigItem(
+            keyName = "ironmanType",
+            name = "Ironman Icon",
+            description = "Ironman account type icon to display in clan broadcast",
+            section = clanSection,
+            position = 16
+    )
+    default IronmanType ironmanType()
+    {
+        return IronmanType.NONE;
+    }
+
+    @ConfigItem(
+            keyName = "includeKillCountInClan",
+            name = "Include KC in Clan",
+            description = "Include kill count in the clan chat announcement",
+            section = clanSection,
+            position = 17
+    )
+    default boolean includeKillCountInClan()
+    {
+        return true;
+    }
+
+    // ========== PET SECTION ==========
+    @ConfigItem(
+            keyName = "isPet",
+            name = "Pet Drop",
+            description = "Enable pet drop mode (disables regular boss/drop settings)",
+            section = petSection,
+            position = 18
+    )
+    default boolean isPet()
+    {
+        return false;
+    }
+
+    @ConfigItem(
+            keyName = "selectedPet",
+            name = "Pet",
+            description = "Select which pet you received",
+            section = petSection,
+            position = 19
+    )
+    default Pet selectedPet()
+    {
+        return Pet.ROCKY;
+    }
+
+    @ConfigItem(
+            keyName = "customPetName",
+            name = "Custom Pet Name",
+            description = "Name for custom pet (only used if 'Custom' is selected)",
+            section = petSection,
+            position = 20
+    )
+    default String customPetName()
+    {
+        return "Custom Pet";
+    }
+
+    @ConfigItem(
+            keyName = "petKillCountOrXP",
+            name = "Kill Count / XP",
+            description = "Kill count for boss pets or total XP for skilling pets",
+            section = petSection,
+            position = 21
+    )
+    @Range(min = 1, max = Integer.MAX_VALUE)
+    default int petKillCountOrXP()
+    {
+        return 13200000;
+    }
+}

--- a/decompiled_plugin/src/main/java/com/fakedrop/FakeDropPlugin.java
+++ b/decompiled_plugin/src/main/java/com/fakedrop/FakeDropPlugin.java
@@ -1,0 +1,437 @@
+package com.fakedrop;
+
+import com.google.inject.Provides;
+import javax.inject.Inject;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.ChatMessageType;
+import net.runelite.api.Client;
+import net.runelite.api.GameState;
+import net.runelite.api.Varbits;
+import net.runelite.api.widgets.WidgetModalMode;
+import net.runelite.client.callback.ClientThread;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.input.KeyManager;
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.util.HotkeyListener;
+import net.runelite.client.util.ColorUtil;
+
+import java.text.NumberFormat;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+
+@Slf4j
+@PluginDescriptor(
+        name = "Fake Drop",
+        description = "Simulate boss kills, drops, and pet drops with realistic messages",
+        tags = {"fake", "drop", "boss", "pet", "simulator"}
+)
+public class FakeDropPlugin extends Plugin
+{
+    @Inject
+    private Client client;
+
+    @Inject
+    private ClientThread clientThread;
+
+    @Inject
+    private FakeDropConfig config;
+
+    @Inject
+    private KeyManager keyManager;
+    
+    @Inject
+    private ConfigManager configManager;
+    
+    private static final String CONFIG_GROUP = "fakedrop";
+    private static final String KC_KEY = "killCount";
+    private static final String IS_PET_KEY = "isPet";
+    private static final double VALUE_RANDOMIZATION_FACTOR = 0.05; // ±5%
+
+    @Provides
+    FakeDropConfig provideConfig(ConfigManager configManager)
+    {
+        return configManager.getConfig(FakeDropConfig.class);
+    }
+
+    @Override
+    protected void startUp() throws Exception
+    {
+        keyManager.registerKeyListener(toggle);
+        keyManager.registerKeyListener(quickSwitch);
+    }
+
+    @Override
+    protected void shutDown() throws Exception
+    {
+        keyManager.unregisterKeyListener(toggle);
+        keyManager.unregisterKeyListener(quickSwitch);
+    }
+
+    private final HotkeyListener toggle = new HotkeyListener(() -> config.toggle())
+    {
+        @Override
+        public void hotkeyPressed()
+        {
+            toggle();
+        }
+    };
+    
+    private final HotkeyListener quickSwitch = new HotkeyListener(() -> config.quickSwitchMode())
+    {
+        @Override
+        public void hotkeyPressed()
+        {
+            quickSwitchMode();
+        }
+    };
+
+    public void toggle()
+    {
+        if (client.getGameState() != GameState.LOGGED_IN)
+        {
+            return;
+        }
+
+        // Handle pet drops - completely different flow
+        if (config.isPet())
+        {
+            // Only show the pet message
+            String petMsg = "<col=ff0000>You have a funny feeling like you're being followed.</col>";
+            sendMsg(petMsg);
+        }
+        else
+        {
+            // Auto-increment kill count if enabled
+            int currentKC = config.killCount();
+            if (config.autoIncrementKC())
+            {
+                int newKC = currentKC + 1;
+                configManager.setConfiguration(CONFIG_GROUP, KC_KEY, newKC);
+                currentKC = newKC;
+            }
+            
+            // Regular boss kill messages
+            String killCountMsg = "Your " + config.bossName() +
+                    " kill count is: <col=ff0000>" +
+                    formatNumber(currentKC) +
+                    "</col>.";
+            sendMsg(killCountMsg);
+
+            if (config.timed())
+            {
+                String timeMsg = "Fight duration: <col=ff0000>" +
+                        config.killTime() +
+                        "</col>. Personal best: <col=ff0000>" +
+                        config.personalBest() +
+                        "</col>";
+                sendMsg(timeMsg);
+            }
+
+            // Calculate drop value with optional randomization
+            int dropValue = config.dropValue();
+            if (config.randomizeValue() && !config.untradeable())
+            {
+                int randomization = (int) (dropValue * VALUE_RANDOMIZATION_FACTOR);
+                int adjustment = (int) (Math.random() * (2 * randomization + 1)) - randomization;
+                dropValue += adjustment;
+            }
+            
+            // Regular drop message
+            String dropMsg;
+            if (config.untradeable())
+            {
+                dropMsg = "<col=ef1020>Untradeable drop: " +
+                        config.dropName() +
+                        "</col>";
+            }
+            else
+            {
+                dropMsg = "<col=ef1020>Valuable drop: " +
+                        config.dropName() +
+                        " (" +
+                        formatNumber(dropValue) +
+                        " coins)</col>";
+            }
+            sendMsg(dropMsg);
+        }
+
+        // Send collection log messages if enabled
+        if (config.collectionLog())
+        {
+            String itemName;
+            if (config.isPet())
+            {
+                FakeDropConfig.Pet pet = config.selectedPet();
+                itemName = pet == FakeDropConfig.Pet.CUSTOM ? config.customPetName() : pet.getPetName();
+            }
+            else
+            {
+                itemName = config.dropName();
+            }
+            
+            sendMsg("New item added to your collection log: <col=ef1020>" + 
+                    itemName + "</col>");
+            
+            // Show collection log popup if enabled
+            if (config.showCollectionLogPopup())
+            {
+                showCollectionLogPopup();
+            }
+        }
+
+        // Announce to clan chat if enabled
+        if (config.announceToClan())
+        {
+            announceToClanChat();
+        }
+    }
+
+    private void announceToClanChat()
+    {
+        if (client.getGameState() != GameState.LOGGED_IN)
+        {
+            return;
+        }
+        
+        String playerName = client.getLocalPlayer() != null ? 
+                client.getLocalPlayer().getName() : "Player";
+
+        // Get current time for timestamp
+        SimpleDateFormat timeFormat = new SimpleDateFormat("HH:mm");
+        String timestamp = timeFormat.format(new Date());
+
+        // Build the clan announcement message
+        StringBuilder announcement = new StringBuilder();
+        
+        // Add timestamp
+        announcement.append("[")
+                .append(timestamp)
+                .append("] ");
+        
+        // Add clan name with color
+        String clanNameColored = ColorUtil.wrapWithColorTag(
+                "[" + config.clanName() + "]",
+                config.clanColor()
+        );
+        announcement.append(clanNameColored).append(" ");
+        
+        // Add ironman icon if configured
+        String ironIcon = config.ironmanType().getIcon();
+        if (!ironIcon.isEmpty())
+        {
+            announcement.append(ironIcon).append(" ");
+        }
+        
+        // Handle pet vs regular drop messaging
+        if (config.isPet())
+        {
+            FakeDropConfig.Pet pet = config.selectedPet();
+            String petName = pet == FakeDropConfig.Pet.CUSTOM ? config.customPetName() : pet.getPetName();
+            
+            if (pet.isSkilling())
+            {
+                // Skilling pet - show XP, not KC
+                announcement.append(playerName)
+                        .append(" received a skilling pet: ")
+                        .append(petName)
+                        .append(" (")
+                        .append(formatNumber(config.petKillCountOrXP()))
+                        .append(" ")
+                        .append(pet.getSkill())
+                        .append(" XP)");
+            }
+            else
+            {
+                // Boss pet - show KC
+                String rarity = pet == FakeDropConfig.Pet.CUSTOM ? "Custom" : pet.getDefaultRarity();
+                announcement.append(playerName)
+                        .append(" received a pet: ")
+                        .append(petName)
+                        .append(" at ")
+                        .append(formatNumber(config.petKillCountOrXP()))
+                        .append(" KC (")
+                        .append(rarity)
+                        .append(")");
+            }
+        }
+        else
+        {
+            announcement.append(playerName)
+                    .append(" received a drop: ")
+                    .append(config.dropName());
+            
+            // Add value for tradeable items
+            if (!config.untradeable())
+            {
+                announcement.append(" (")
+                        .append(formatNumber(config.dropValue()))
+                        .append(" coins)");
+            }
+        }
+
+
+        // Send to clan chat
+        String message = announcement.toString();
+        sendClanMessage(message);
+        
+        // Send collection log message if enabled
+        if (config.collectionLog())
+        {
+            StringBuilder collectionMsg = new StringBuilder();
+            
+            // Add timestamp
+            collectionMsg.append("[")
+                    .append(timestamp)
+                    .append("] ");
+            
+            // Add clan name with color (reuse the colored clan name)
+            collectionMsg.append(clanNameColored).append(" ");
+            
+            // Add ironman icon if configured
+            if (!ironIcon.isEmpty())
+            {
+                collectionMsg.append(ironIcon).append(" ");
+            }
+            
+            String itemName;
+            if (config.isPet())
+            {
+                FakeDropConfig.Pet pet = config.selectedPet();
+                itemName = pet == FakeDropConfig.Pet.CUSTOM ? config.customPetName() : pet.getPetName();
+            }
+            else
+            {
+                itemName = config.dropName();
+            }
+            
+            collectionMsg.append(playerName)
+                    .append(" received a new collection log item: ")
+                    .append(itemName)
+                    .append(" (")
+                    .append(config.collectionLogCount())
+                    .append(")");
+            
+            String finalMsg = collectionMsg.toString();
+            
+            // Small delay before sending the second message
+            clientThread.invokeLater(() -> {
+                try {
+                    Thread.sleep(100);
+                } catch (InterruptedException e) {
+                    // Ignore
+                }
+                sendClanMessage(finalMsg);
+            });
+        }
+    }
+
+    private void sendClanMessage(String message)
+    {
+        clientThread.invokeLater(() ->
+        {
+            if (client.getGameState() == GameState.LOGGED_IN)
+            {
+                // Add fake clan system message to local chatbox (like drop broadcasts)
+                client.addChatMessage(
+                    ChatMessageType.CLAN_MESSAGE,
+                    "",
+                    message,
+                    ""
+                );
+            }
+        });
+    }
+
+    public void sendMsg(String msg)
+    {
+        clientThread.invokeLater(() ->
+                client.addChatMessage(ChatMessageType.GAMEMESSAGE,
+                        "",
+                        msg,
+                        null)
+        );
+    }
+
+    private String formatTicksToTime(long ticks)
+    {
+        long totalMillis = ticks * 600;
+
+        long minutes = totalMillis / 60000;
+        long seconds = (totalMillis % 60000) / 1000;
+        long millis = totalMillis % 1000;
+
+        return String.format("%d:%02d.%03d", minutes, seconds, millis);
+    }
+
+    private String formatNumber(long value)
+    {
+        return NumberFormat.getInstance(Locale.US).format(value);
+    }
+
+    private void showCollectionLogPopup()
+    {
+        clientThread.invokeLater(() ->
+        {
+            try
+            {
+                // Define layout component IDs
+                int RESIZABLE_CLASSIC_LAYOUT = (161 << 16) | 13;
+                int RESIZABLE_MODERN_LAYOUT = (164 << 16) | 13;
+                int FIXED_CLASSIC_LAYOUT = 35913770;
+
+                // Determine which layout to use based on client state
+                int componentId = client.isResized() 
+                    ? client.getVarbitValue(Varbits.SIDE_PANELS) == 1 
+                        ? RESIZABLE_MODERN_LAYOUT 
+                        : RESIZABLE_CLASSIC_LAYOUT 
+                    : FIXED_CLASSIC_LAYOUT;
+                
+                // Open the popup interface
+                client.openInterface(componentId, 660, WidgetModalMode.MODAL_CLICKTHROUGH);
+
+                // Run the script to display the collection log notification
+                // Script 3343 takes: title, message, and icon ID (-1 for default)
+                String itemName;
+                if (config.isPet())
+                {
+                    FakeDropConfig.Pet pet = config.selectedPet();
+                    itemName = pet == FakeDropConfig.Pet.CUSTOM ? config.customPetName() : pet.getPetName();
+                }
+                else
+                {
+                    itemName = config.dropName();
+                }
+                
+                String message = "New item:<br><br><col=ffffff>" + itemName + "</col>";
+                client.runScript(3343, "Collection Log", message, -1);
+            }
+            catch (Exception e)
+            {
+                log.error("Failed to show collection log popup", e);
+            }
+        });
+    }
+    
+    /**
+     * Quick switch between pet and boss mode
+     */
+    private void quickSwitchMode()
+    {
+        if (client.getGameState() != GameState.LOGGED_IN)
+        {
+            return;
+        }
+        
+        boolean currentMode = config.isPet();
+        boolean newMode = !currentMode;
+        
+        configManager.setConfiguration(CONFIG_GROUP, IS_PET_KEY, newMode);
+        
+        String modeText = newMode ? "Pet Drop" : "Boss Drop";
+        
+        // Show feedback message to user
+        sendMsg("<col=00ff00>Switched to " + modeText + " mode</col>");
+    }
+}

--- a/decompiled_plugin/src/main/resources/runelite-plugin.properties
+++ b/decompiled_plugin/src/main/resources/runelite-plugin.properties
@@ -1,0 +1,5 @@
+displayName=Fake Drop
+author=Waldrin
+description=Simulates boss kills, drops, and pet drops with realistic messages
+tags=fake,drop,boss,pet,simulator
+plugins=com.fakedrop.FakeDropPlugin

--- a/decompiled_plugin/src/test/java/com/fakedrop/FakeDropPluginTest.java
+++ b/decompiled_plugin/src/test/java/com/fakedrop/FakeDropPluginTest.java
@@ -1,0 +1,417 @@
+package com.fakedrop;
+
+import net.runelite.api.ChatMessageType;
+import net.runelite.api.Client;
+import net.runelite.api.GameState;
+import net.runelite.client.callback.ClientThread;
+import net.runelite.client.input.KeyManager;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import java.util.List;
+
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+/**
+ * Comprehensive test suite for Fake Drop plugin.
+ * Tests verify message generation, pet logic, and drop simulations.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class FakeDropPluginTest
+{
+    @Mock
+    private Client client;
+
+    @Mock
+    private ClientThread clientThread;
+
+    @Mock
+    private FakeDropConfig config;
+
+    @Mock
+    private KeyManager keyManager;
+    
+    @Mock
+    private net.runelite.client.config.ConfigManager configManager;
+
+    private FakeDropPlugin plugin;
+
+    @Before
+    public void setUp()
+    {
+        plugin = new FakeDropPlugin();
+        
+        // Make clientThread.invokeLater() execute the Runnable immediately
+        doAnswer(new Answer<Void>() {
+            @Override
+            public Void answer(InvocationOnMock invocation) throws Throwable {
+                Runnable runnable = invocation.getArgument(0);
+                runnable.run();
+                return null;
+            }
+        }).when(clientThread).invokeLater(any(Runnable.class));
+        
+        // Inject mocks using reflection
+        try {
+            java.lang.reflect.Field clientField = FakeDropPlugin.class.getDeclaredField("client");
+            clientField.setAccessible(true);
+            clientField.set(plugin, client);
+
+            java.lang.reflect.Field clientThreadField = FakeDropPlugin.class.getDeclaredField("clientThread");
+            clientThreadField.setAccessible(true);
+            clientThreadField.set(plugin, clientThread);
+
+            java.lang.reflect.Field configField = FakeDropPlugin.class.getDeclaredField("config");
+            configField.setAccessible(true);
+            configField.set(plugin, config);
+
+            java.lang.reflect.Field keyManagerField = FakeDropPlugin.class.getDeclaredField("keyManager");
+            keyManagerField.setAccessible(true);
+            keyManagerField.set(plugin, keyManager);
+            
+            java.lang.reflect.Field configManagerField = FakeDropPlugin.class.getDeclaredField("configManager");
+            configManagerField.setAccessible(true);
+            configManagerField.set(plugin, configManager);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to inject mocks", e);
+        }
+    }
+
+    private List<String> getChatMessages() {
+        ArgumentCaptor<String> messageCaptor = ArgumentCaptor.forClass(String.class);
+        verify(client, atLeastOnce()).addChatMessage(any(), any(), messageCaptor.capture(), any());
+        return messageCaptor.getAllValues();
+    }
+
+    @Test
+    public void testPetDrop_OnlyShowsPetMessage()
+    {
+        // Given
+        when(client.getGameState()).thenReturn(GameState.LOGGED_IN);
+        when(config.isPet()).thenReturn(true);
+        when(config.selectedPet()).thenReturn(FakeDropConfig.Pet.PET_DARK_CORE);
+        when(config.collectionLog()).thenReturn(false);
+
+        // When
+        plugin.toggle();
+
+        // Then
+        List<String> messages = getChatMessages();
+        assertEquals("Should send exactly 1 message", 1, messages.size());
+        assertTrue("Should contain pet message", messages.get(0).contains("You have a funny feeling"));
+        assertFalse("Should not contain kill count", messages.get(0).contains("kill count"));
+    }
+
+    @Test
+    public void testSkillingPet_ShowsXPNotKC()
+    {
+        // Given
+        when(client.getGameState()).thenReturn(GameState.LOGGED_IN);
+        when(config.isPet()).thenReturn(true);
+        when(config.selectedPet()).thenReturn(FakeDropConfig.Pet.ROCKY);
+        when(config.collectionLog()).thenReturn(false);
+
+        // When
+        plugin.toggle();
+
+        // Then
+        List<String> messages = getChatMessages();
+        assertTrue("Should show pet feeling message", 
+            messages.stream().anyMatch(m -> m.contains("You have a funny feeling")));
+        
+        // No XP shown in basic messages, only in clan messages which we test separately
+    }
+
+    @Test
+    public void testBossDrop_ShowsKillCountAndDrop()
+    {
+        // Given
+        when(client.getGameState()).thenReturn(GameState.LOGGED_IN);
+        when(config.isPet()).thenReturn(false);
+        when(config.bossName()).thenReturn("Leviathan");
+        when(config.killCount()).thenReturn(42);
+        when(config.timed()).thenReturn(false);
+        when(config.dropName()).thenReturn("Venator ring");
+        when(config.untradeable()).thenReturn(false);
+        when(config.dropValue()).thenReturn(50000000);
+        when(config.collectionLog()).thenReturn(false);
+
+        // When
+        plugin.toggle();
+
+        // Then
+        List<String> messages = getChatMessages();
+        assertTrue("Should show kill count", 
+            messages.stream().anyMatch(m -> m.contains("Leviathan") && m.contains("42")));
+        assertTrue("Should show drop", 
+            messages.stream().anyMatch(m -> m.contains("Venator ring") && m.contains("50,000,000")));
+    }
+
+    @Test
+    public void testTimedBoss_ShowsFightDuration()
+    {
+        // Given
+        when(client.getGameState()).thenReturn(GameState.LOGGED_IN);
+        when(config.isPet()).thenReturn(false);
+        when(config.bossName()).thenReturn("Zulrah");
+        when(config.killCount()).thenReturn(100);
+        when(config.timed()).thenReturn(true);
+        when(config.killTime()).thenReturn("1:23");
+        when(config.personalBest()).thenReturn("1:15");
+        when(config.dropName()).thenReturn("Magic fang");
+        when(config.untradeable()).thenReturn(false);
+        when(config.dropValue()).thenReturn(1000000);
+        when(config.collectionLog()).thenReturn(false);
+
+        // When
+        plugin.toggle();
+
+        // Then
+        List<String> messages = getChatMessages();
+        assertTrue("Should show fight duration", 
+            messages.stream().anyMatch(m -> m.contains("Fight duration") && m.contains("1:23") && m.contains("1:15")));
+    }
+
+    @Test
+    public void testUntradeableDrop_NoCoins()
+    {
+        // Given
+        when(client.getGameState()).thenReturn(GameState.LOGGED_IN);
+        when(config.isPet()).thenReturn(false);
+        when(config.bossName()).thenReturn("TzTok-Jad");
+        when(config.killCount()).thenReturn(5);
+        when(config.timed()).thenReturn(false);
+        when(config.dropName()).thenReturn("Fire cape");
+        when(config.untradeable()).thenReturn(true);
+        when(config.collectionLog()).thenReturn(false);
+
+        // When
+        plugin.toggle();
+
+        // Then
+        List<String> messages = getChatMessages();
+        assertTrue("Should show untradeable drop", 
+            messages.stream().anyMatch(m -> m.contains("Untradeable drop") && m.contains("Fire cape")));
+        assertFalse("Should not show coins for untradeable", 
+            messages.stream().anyMatch(m -> m.contains("Fire cape") && m.contains("coins")));
+    }
+
+    @Test
+    public void testPetWithCollectionLog()
+    {
+        // Given
+        when(client.getGameState()).thenReturn(GameState.LOGGED_IN);
+        when(config.isPet()).thenReturn(true);
+        when(config.selectedPet()).thenReturn(FakeDropConfig.Pet.ROCKY);
+        when(config.collectionLog()).thenReturn(true);
+
+        // When
+        plugin.toggle();
+
+        // Then
+        List<String> messages = getChatMessages();
+        assertTrue("Should show pet feeling", 
+            messages.stream().anyMatch(m -> m.contains("You have a funny feeling")));
+        assertTrue("Should show collection log", 
+            messages.stream().anyMatch(m -> m.contains("collection log") && m.contains("Rocky")));
+    }
+
+    @Test
+    public void testCustomPet_UsesCustomName()
+    {
+        // Given
+        when(client.getGameState()).thenReturn(GameState.LOGGED_IN);
+        when(config.isPet()).thenReturn(true);
+        when(config.selectedPet()).thenReturn(FakeDropConfig.Pet.CUSTOM);
+        when(config.customPetName()).thenReturn("My Special Pet");
+        when(config.collectionLog()).thenReturn(true);
+
+        // When
+        plugin.toggle();
+
+        // Then
+        List<String> messages = getChatMessages();
+        assertTrue("Should use custom pet name", 
+            messages.stream().anyMatch(m -> m.contains("My Special Pet")));
+    }
+
+    @Test
+    public void testNotLoggedIn_DoesNothing()
+    {
+        // Given
+        when(client.getGameState()).thenReturn(GameState.LOGIN_SCREEN);
+
+        // When
+        plugin.toggle();
+
+        // Then
+        verify(client, never()).addChatMessage(any(), any(), any(), any());
+    }
+
+    @Test
+    public void testNumberFormatting()
+    {
+        // Given
+        when(client.getGameState()).thenReturn(GameState.LOGGED_IN);
+        when(config.isPet()).thenReturn(false);
+        when(config.bossName()).thenReturn("Test Boss");
+        when(config.killCount()).thenReturn(1234567);
+        when(config.timed()).thenReturn(false);
+        when(config.dropName()).thenReturn("Test Drop");
+        when(config.untradeable()).thenReturn(false);
+        when(config.dropValue()).thenReturn(999999999);
+        when(config.collectionLog()).thenReturn(false);
+
+        // When
+        plugin.toggle();
+
+        // Then
+        List<String> messages = getChatMessages();
+        assertTrue("Should format large numbers with commas", 
+            messages.stream().anyMatch(m -> m.contains("1,234,567")));
+        assertTrue("Should format drop value with commas", 
+            messages.stream().anyMatch(m -> m.contains("999,999,999")));
+    }
+
+    // Enum validation tests
+    @Test
+    public void testAllSkillingPets_HaveSkills()
+    {
+        for (FakeDropConfig.Pet pet : FakeDropConfig.Pet.values()) {
+            if (pet.isSkilling() && pet != FakeDropConfig.Pet.CUSTOM) {
+                assertNotNull("Skilling pet should have skill: " + pet.getPetName(), pet.getSkill());
+                assertFalse("Skilling pet skill should not be empty: " + pet.getPetName(), 
+                    pet.getSkill().trim().isEmpty());
+            }
+        }
+    }
+
+    @Test
+    public void testAllBossPets_HaveRarity()
+    {
+        for (FakeDropConfig.Pet pet : FakeDropConfig.Pet.values()) {
+            if (!pet.isSkilling() && pet != FakeDropConfig.Pet.CUSTOM) {
+                assertNotNull("Boss pet should have rarity: " + pet.getPetName(), pet.getDefaultRarity());
+                assertFalse("Boss pet rarity should not be empty: " + pet.getPetName(), 
+                    pet.getDefaultRarity().trim().isEmpty());
+            }
+        }
+    }
+
+    @Test
+    public void testSpecificPets_HaveCorrectData()
+    {
+        // Rocky - skilling pet
+        assertTrue("Rocky should be skilling pet", FakeDropConfig.Pet.ROCKY.isSkilling());
+        assertEquals("Rocky should be Thieving", "Thieving", FakeDropConfig.Pet.ROCKY.getSkill());
+
+        // Pet dark core - boss pet
+        assertFalse("Pet dark core should not be skilling pet", 
+            FakeDropConfig.Pet.PET_DARK_CORE.isSkilling());
+        assertEquals("Pet dark core should have 1/5,000 rarity", 
+            "1/5,000", FakeDropConfig.Pet.PET_DARK_CORE.getDefaultRarity());
+
+        // Beaver - skilling pet
+        assertTrue("Beaver should be skilling pet", FakeDropConfig.Pet.BEAVER.isSkilling());
+        assertEquals("Beaver should be Woodcutting", "Woodcutting", FakeDropConfig.Pet.BEAVER.getSkill());
+    }
+    
+    @Test
+    public void testAutoIncrementKC_IncreasesKillCount()
+    {
+        // Given
+        when(client.getGameState()).thenReturn(GameState.LOGGED_IN);
+        when(config.isPet()).thenReturn(false);
+        when(config.bossName()).thenReturn("Leviathan");
+        when(config.killCount()).thenReturn(100);
+        when(config.autoIncrementKC()).thenReturn(true);
+        when(config.dropName()).thenReturn("Venator ring");
+        when(config.dropValue()).thenReturn(50000000);
+        when(config.untradeable()).thenReturn(false);
+        when(config.randomizeValue()).thenReturn(false);
+        when(config.timed()).thenReturn(false);
+        when(config.collectionLog()).thenReturn(false);
+        when(config.announceToClan()).thenReturn(false);
+
+        // When
+        plugin.toggle();
+
+        // Then - should display incremented KC (101)
+        List<String> messages = getChatMessages();
+        assertTrue("Should show incremented kill count 101", 
+            messages.stream().anyMatch(m -> m.contains("101")));
+        
+        // Verify that configManager.setConfiguration was called with the new KC
+        verify(configManager).setConfiguration("fakedrop", "killCount", 101);
+    }
+    
+    @Test
+    public void testAutoIncrementKC_Disabled_DoesNotIncrement()
+    {
+        // Given
+        when(client.getGameState()).thenReturn(GameState.LOGGED_IN);
+        when(config.isPet()).thenReturn(false);
+        when(config.bossName()).thenReturn("Leviathan");
+        when(config.killCount()).thenReturn(100);
+        when(config.autoIncrementKC()).thenReturn(false);  // Disabled
+        when(config.dropName()).thenReturn("Venator ring");
+        when(config.dropValue()).thenReturn(50000000);
+        when(config.untradeable()).thenReturn(false);
+        when(config.randomizeValue()).thenReturn(false);
+        when(config.timed()).thenReturn(false);
+        when(config.collectionLog()).thenReturn(false);
+        when(config.announceToClan()).thenReturn(false);
+
+        // When
+        plugin.toggle();
+
+        // Then - should display original KC (100)
+        List<String> messages = getChatMessages();
+        assertTrue("Should show original kill count 100", 
+            messages.stream().anyMatch(m -> m.contains("100")));
+        
+        // Verify that configManager.setConfiguration was NOT called
+        verify(configManager, never()).setConfiguration(eq("fakedrop"), eq("killCount"), anyInt());
+    }
+    
+    @Test
+    public void testValueRandomization_AltersDropValue()
+    {
+        // Given
+        when(client.getGameState()).thenReturn(GameState.LOGGED_IN);
+        when(config.isPet()).thenReturn(false);
+        when(config.bossName()).thenReturn("Leviathan");
+        when(config.killCount()).thenReturn(100);
+        when(config.autoIncrementKC()).thenReturn(false);
+        when(config.dropName()).thenReturn("Venator ring");
+        when(config.dropValue()).thenReturn(50000000);
+        when(config.untradeable()).thenReturn(false);
+        when(config.randomizeValue()).thenReturn(true);  // Enabled
+        when(config.timed()).thenReturn(false);
+        when(config.collectionLog()).thenReturn(false);
+        when(config.announceToClan()).thenReturn(false);
+
+        // When
+        plugin.toggle();
+
+        // Then
+        List<String> messages = getChatMessages();
+        String dropMessage = messages.stream()
+            .filter(m -> m.contains("Valuable drop"))
+            .findFirst()
+            .orElse("");
+        
+        assertFalse("Should have drop message", dropMessage.isEmpty());
+        // Value should be randomized ±5%, so not exactly 50,000,000
+        // But we can't assert exact value due to randomness, just that it contains "coins"
+        assertTrue("Should contain coins", dropMessage.contains("coins"));
+    }
+}


### PR DESCRIPTION
Simulates boss kills, drops, and pet drops with realistic messages.

Features:
- Boss drop simulation with kill count and fight duration
- Pet drop simulation (52 pets: 9 skilling, 43 boss pets)
- Collection log integration with popup notifications
- Clan chat announcements with ironman icons
- Auto-increment kill count option
- Value randomization (5%) for drops
- Quick mode switching hotkey
- Comprehensive test suite with 16 unit tests

Configuration includes boss settings, drop settings, clan settings, and pet settings with organized sections.