### PR TITLE
Special Attack Counter: Filter out thrall and other non-player hitsplats

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/specialcounter/SpecialCounterPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/specialcounter/SpecialCounterPlugin.java
@@ -261,7 +261,7 @@ public class SpecialCounterPlugin extends Plugin
 				}
 
 				// The weapon hitsplat is always last, after other hitsplats which occur on the same tick such as from
-				// venge or thralls.
+				// venge. Thrall hitsplats are filtered out in onHitsplatApplied.
 				Hitsplat hitsplat = hitsplats.get(hitsplats.size() - 1);
 				specialAttackHit(specialWeapon, hitsplat.getAmount(), lastSpecTarget);
 			}
@@ -362,8 +362,8 @@ public class SpecialCounterPlugin extends Plugin
 	{
 		Actor target = hitsplatApplied.getActor();
 		Hitsplat hitsplat = hitsplatApplied.getHitsplat();
-		// Ignore all hitsplats other than mine
-		if (!hitsplat.isMine() || target == client.getLocalPlayer())
+		// Ignore all hitsplats other than mine, or hitsplats from other sources (e.g. thralls)
+		if (!hitsplat.isMine() || hitsplat.isOthers() || target == client.getLocalPlayer())
 		{
 			return;
 		}


### PR DESCRIPTION
Fixes #19722

When using special attacks with thralls active, the plugin was sometimes counting thrall damage as weapon damage when both hit on the same tick.

This occurred because thralls produce DAMAGE_OTHER hitsplats, which the previous isMine() check didn't filter out. The fix adds an isOthers() check to exclude hitsplats from thralls and other non-player sources.

Added test case to verify thrall hitsplats are correctly ignored.