### PR TITLE
banktags: On importing of a layout replace placeholderid items with their normal id

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/banktags/tabs/TabInterface.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/banktags/tabs/TabInterface.java
@@ -540,7 +540,15 @@ public class TabInterface
 			while (dataIter.hasNext())
 			{
 				final int idx = Integer.parseInt(dataIter.next());
-				final int itemId = Integer.parseInt(dataIter.next());
+				int itemId = Integer.parseInt(dataIter.next());
+
+				if (itemManager.getItemComposition(itemId).getPlaceholderTemplateId() == 14401)
+				{
+					int normalId = itemManager.getItemComposition(itemId).getPlaceholderId();
+					log.debug("Item {} is a place holder item, converting to normal id {}", itemId, normalId);
+					itemId = normalId;
+				}
+
 				l.setItemAtPos(itemId, idx);
 				tagManager.addTag(itemId, name, false);
 			}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/banktags/tabs/TabInterface.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/banktags/tabs/TabInterface.java
@@ -540,14 +540,7 @@ public class TabInterface
 			while (dataIter.hasNext())
 			{
 				final int idx = Integer.parseInt(dataIter.next());
-				int itemId = Integer.parseInt(dataIter.next());
-
-				if (itemManager.getItemComposition(itemId).getPlaceholderTemplateId() == 14401)
-				{
-					int normalId = itemManager.getItemComposition(itemId).getPlaceholderId();
-					log.debug("Item {} is a place holder item, converting to normal id {}", itemId, normalId);
-					itemId = normalId;
-				}
+				final int itemId = itemManager.canonicalize(Integer.parseInt(dataIter.next()));
 
 				l.setItemAtPos(itemId, idx);
 				tagManager.addTag(itemId, name, false);


### PR DESCRIPTION
Previously the following banktag tab:
`banktags,1,prayerpotions,952,layout,1,2434,2,15259`

Would get this:
<img width="660" height="455" alt="image" src="https://github.com/user-attachments/assets/aa27f73d-84a2-4eda-b0fe-eae5880f2427" />

With the fix, it will convert 15259 to 2434 so that it will look like this:

<img width="661" height="448" alt="image" src="https://github.com/user-attachments/assets/5db300fb-a3d3-4e43-909f-762adb5e02f0" />


I am sorta sure that this issue only exists for folks with potion storage

fixes #19020 