### PR TITLE
timers: Added Nex, Glacies & Spiritual Mage freezes

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/timersandbuffs/TimersAndBuffsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timersandbuffs/TimersAndBuffsPlugin.java
@@ -1026,7 +1026,7 @@ public class TimersAndBuffsPlugin extends Plugin
 			int freezeDuration = 6;
 			// differentiate whether freeze is coming from Nex or Glacies/Spiritual Mage
 			// Nex can only freeze if at the time of her ice attack player didn't have 'Protect from Magic' activated
-			if (client.getVarbitValue(VarbitID.NEX_BARRIER) == 3 && caughtOffPrayByNex)
+			if (caughtOffPrayByNex && client.getVarbitValue(VarbitID.NEX_BARRIER) == 3)
 			{
 				// Nex's freeze length
 				freezeDuration = 15;


### PR DESCRIPTION
Upon being frozen by any of those 3, there is the same message sent in game chat.
These freeze timers exist in the mobile client, thus, should be Jagex-compliant.

Glacies' and Spiritual Mage's freezes always last 6 ticks.
Nex's freeze lasts 15 ticks AND can only occur if player isn't praying Protect from Magic upon Nex's casting ice spell. (verified by Mod Ash, see [cite note](https://oldschool.runescape.wiki/w/Nex/Strategies#cite_ref-ash_freeze_duration_6-0))

Because of the above, I assume that if player didn't have Protect from Magic active upon Nex's ice attack animation would mean that the freeze originates from Nex.
A check of [Varbit `NEX_BARRIER`](https://oldschool.runescape.wiki/w/RuneScape:Varbit/13184) is performed to see if we're in a fight (to differentiate from Spiritual Mage's freezes).

There might be a very rare scenario where player gets hit by Nex's & Glacies' casts at the same time and Glacies freezes them instead of Nex (it should never occur since Nex is very accurate, plus, players are not likely to be switching prayers after Glacies is called by Nex).

Additionally, being put into ice prison puts player out out combat which results in player's freeze being cancelled, for which I added message handling.