### PR TITLE
slayer: fix aquanite task name

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/Task.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/Task.java
@@ -41,7 +41,7 @@ enum Task
 	ABYSSAL_SIRE("The Abyssal Sire", ItemID.ABYSSALSIRE_PET),
 	ALCHEMICAL_HYDRA("The Alchemical Hydra", ItemID.HYDRAPET),
 	ANKOU("Ankou", ItemID.ANKOU_HEAD),
-	AQUANITES("Aquanite", ItemID.SLAYERGUIDE_AQUANITE),
+	AQUANITES("Aquanites", ItemID.SLAYERGUIDE_AQUANITE),
 	ARAXXOR("Araxxor", ItemID.ARAXXORPET),
 	ARAXYTES("Araxytes", ItemID.POH_ARAXYTE_HEAD, "Araxxor"),
 	AVIANSIES("Aviansies", ItemID.ARCEUUS_CORPSE_AVIANSIE_INITIAL, "Kree'arra", "Flight Kilisa", "Flockleader Geerin", "Wingman Skree"),


### PR DESCRIPTION
fixes
- Aquanite task name was wrong and still showed enchanted gem icon

checked the other tasks added with sailing and they should be ok, not 100% on the Shellbane Gryphon one since I can't find a source on the slayer task names like "the cave kraken boss" so I assume it's ok unless it's reported otherwise