### PR TITLE
PluginItem name field truncation bugfix

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/PluginHubPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/PluginHubPanel.java
@@ -257,6 +257,7 @@ class PluginHubPanel extends PluginPanel
 			JLabel author = new JLabel(manifest.getAuthor());
 			author.setFont(FontManager.getRunescapeSmallFont());
 			author.setToolTipText(manifest.getAuthor());
+			author.setHorizontalAlignment(SwingConstants.RIGHT);
 
 			JLabel version = new JLabel(manifest.getVersion());
 			version.setFont(FontManager.getRunescapeSmallFont());
@@ -394,8 +395,6 @@ class PluginHubPanel extends PluginPanel
 			}
 			addrm.setBorder(new LineBorder(addrm.getBackground().darker()));
 			addrm.setFocusPainted(false);
-			pluginName.setHorizontalAlignment(SwingConstants.LEFT);
-			author.setHorizontalAlignment(SwingConstants.RIGHT);
 
 			layout.setHorizontalGroup(layout.createSequentialGroup()
 				.addGroup(layout.createParallelGroup()
@@ -406,7 +405,8 @@ class PluginHubPanel extends PluginPanel
 					.addGroup(layout.createSequentialGroup()
 						.addComponent(pluginName, 85, GroupLayout.PREFERRED_SIZE, Short.MAX_VALUE)
 						.addPreferredGap(LayoutStyle.ComponentPlacement.RELATED, GroupLayout.PREFERRED_SIZE, Short.MAX_VALUE)
-						.addComponent(author, 60, GroupLayout.PREFERRED_SIZE, Short.MAX_VALUE))
+						.addComponent(author, 60, GroupLayout.PREFERRED_SIZE, Short.MAX_VALUE)
+						.addGap(5))
 					.addComponent(description, 0, GroupLayout.PREFERRED_SIZE, Short.MAX_VALUE)
 					.addGroup(layout.createSequentialGroup()
 						.addComponent(version, 0, GroupLayout.PREFERRED_SIZE, Short.MAX_VALUE)


### PR DESCRIPTION
The name JLabel does not have a min width, so if a long string is entered in the author field, the author JLabel will force the name JLabel to truncate in order to make space. 

This change adds a min width to the name and author JLabels, currently set to 85 and 60 pixels respectively (tweak as needed), and respects the 200px fixed width of the PluginPanel - icon: 48px, 5px gap, plugin name 85px, preferred gap -2px?, author 60 px

The alignment is set to left for the plugin name JLabel so it grows right naturally until truncating.
The alignment is set to right for the plugin author JLabel so it grows left naturally until truncating.

NOTE: This change only will affect the PluginItem objects made from the PluginHubPanel, meaning the core PluginItems JLabels will not see this change. If the change is appropriate and accepted, I can make the change there as well. 

Before Image:
<img width="298" height="119" alt="image" src="https://github.com/user-attachments/assets/087e4014-fe1c-46c7-b1c3-5c7d67d67bac" />

After Image:
<img width="305" height="109" alt="image" src="https://github.com/user-attachments/assets/8ca6d34f-cb89-4626-a503-dd7d0fc96235" />
