### PR TITLE
idle notifier missing moonlight bolt animationid

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
@@ -266,6 +266,7 @@ public class IdleNotifierPlugin extends Plugin
 			case AnimationID.HUMAN_FLETCHING_ADD_BOLT_TIPS_ADAMANT:
 			case AnimationID.HUMAN_FLETCHING_ADD_BOLT_TIPS_RUNE:
 			case AnimationID.HUMAN_FLETCHING_ADD_BOLT_TIPS_DRAGON:
+			case AnimationID.HUMAN_FLETCHING_HUNTINGBOLTS:
 			/* Smithing(Anvil, Furnace, Cannonballs */
 			case AnimationID.HUMAN_SMITHING:
 			case AnimationID.HUMAN_SMITHING_IMCANDO_HAMMER:


### PR DESCRIPTION
Added a case for:

`case AnimationID.HUMAN_FLETCHING_HUNTINGBOLTS:`

Which is the animation ID tied to fletching moonlight antler bolts. 

Resolves #19713