### PR TITLE
gpu: add colorblindness correction intensity value

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuPlugin.java
@@ -264,6 +264,8 @@ public class GpuPlugin extends Plugin implements DrawCallbacks
 	private int uniBlockMain;
 	private int uniTextureLightMode;
 	private int uniTick;
+	private int uniColorblindIntensity;
+	private int uniUiColorblindIntensity;
 	static int uniBase;
 
 	private static Projection lastProjection;
@@ -598,11 +600,13 @@ public class GpuPlugin extends Plugin implements DrawCallbacks
 		uniTextures = glGetUniformLocation(glProgram, "textures");
 		uniTextureAnimations = glGetUniformLocation(glProgram, "textureAnimations");
 		uniBase = glGetUniformLocation(glProgram, "base");
+		uniColorblindIntensity = glGetUniformLocation(glProgram, "colorblindIntensity");
 
 		uniTex = glGetUniformLocation(glUiProgram, "tex");
 		uniTexTargetDimensions = glGetUniformLocation(glUiProgram, "targetDimensions");
 		uniTexSourceDimensions = glGetUniformLocation(glUiProgram, "sourceDimensions");
 		uniUiAlphaOverlay = glGetUniformLocation(glUiProgram, "alphaOverlay");
+		uniUiColorblindIntensity = glGetUniformLocation(glUiProgram, "colorblindIntensity");
 	}
 
 	private void shutdownProgram()
@@ -947,6 +951,7 @@ public class GpuPlugin extends Plugin implements DrawCallbacks
 		glUniform1i(uniFogDepth, fogDepth);
 		glUniform1i(uniDrawDistance, drawDistance * Perspective.LOCAL_TILE_SIZE);
 		glUniform1i(uniExpandedMapLoadingChunks, client.getExpandedMapLoading());
+		glUniform1f(uniColorblindIntensity, config.colorBlindIntensity());
 
 		// Brightness happens to also be stored in the texture provider, so we use that
 		TextureProvider textureProvider = client.getTextureProvider();
@@ -1488,6 +1493,7 @@ public class GpuPlugin extends Plugin implements DrawCallbacks
 			(overlayColor & 0xFF) / 255f,
 			(overlayColor >>> 24) / 255f
 		);
+		glUniform1f(uniUiColorblindIntensity, config.colorBlindIntensity());
 
 		if (client.isStretchedEnabled())
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuPluginConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/gpu/GpuPluginConfig.java
@@ -151,11 +151,26 @@ public interface GpuPluginConfig extends Config
 		return ColorBlindMode.NONE;
 	}
 
+	@Range(
+		min = 0,
+		max = 100
+	)
+	@ConfigItem(
+		keyName = "colorBlindIntensity",
+		name = "Colorblindness intensity",
+		description = "Strength of the colorblindness correction effect.",
+		position = 9
+	)
+	default int colorBlindIntensity()
+	{
+		return 100;
+	}
+
 	@ConfigItem(
 		keyName = "brightTextures",
 		name = "Bright textures",
 		description = "Use old texture lighting method which results in brighter game textures.",
-		position = 9
+		position = 10
 	)
 	default boolean brightTextures()
 	{
@@ -166,7 +181,7 @@ public interface GpuPluginConfig extends Config
 		keyName = "unlockFps",
 		name = "Unlock FPS",
 		description = "Removes the 50 FPS cap for camera movement.",
-		position = 10
+		position = 11
 	)
 	default boolean unlockFps()
 	{
@@ -184,7 +199,7 @@ public interface GpuPluginConfig extends Config
 		keyName = "vsyncMode",
 		name = "Vsync mode",
 		description = "Method to synchronize frame rate with refresh rate.",
-		position = 11
+		position = 12
 	)
 	default SyncMode syncMode()
 	{
@@ -195,7 +210,7 @@ public interface GpuPluginConfig extends Config
 		keyName = "fpsTarget",
 		name = "FPS target",
 		description = "Target FPS when 'Unlock FPS' is enabled and 'Vsync mode' is off.",
-		position = 12
+		position = 13
 	)
 	@Range(
 		min = 1,
@@ -210,7 +225,7 @@ public interface GpuPluginConfig extends Config
 		keyName = "removeVertexSnapping",
 		name = "Remove vertex snapping",
 		description = "Removes vertex snapping from most animations.",
-		position = 13
+		position = 14
 	)
 	default boolean removeVertexSnapping()
 	{

--- a/runelite-client/src/main/resources/net/runelite/client/plugins/gpu/colorblind.glsl
+++ b/runelite-client/src/main/resources/net/runelite/client/plugins/gpu/colorblind.glsl
@@ -7,6 +7,9 @@
 #define DEUTERAN 2
 #define TRITAN 3
 
+// Blends between the original color (0.0) and the fully corrected color (1.0)
+uniform float colorblindIntensity;
+
 const mat3 rgb2lms = mat3(vec3(17.8824, 43.5161, 4.11935), vec3(3.45565, 27.1554, 3.86714), vec3(0.0299566, 0.184309, 1.46709));
 
 const mat3 lms2lmsp = mat3(vec3(0.0, 2.02344, -2.52581), vec3(0.0, 1.0, 0.0), vec3(0.0, 0.0, 1.0));
@@ -40,6 +43,7 @@ vec3 colorblind(vec3 color) {
 
   // Shift colors towards visible spectrum (apply error modifications)
   vec3 correction = error * corrections;
+  correction *= clamp(colorblindIntensity / 100.0, 0.0, 1.0);
 
   // Add compensation to original values
   correction = color + correction;


### PR DESCRIPTION
This adds continuous strength control to the GPU plugin’s colorblindness correction.

Changes:
- Add a new config item “Colorblindness intensity” (0–100, default 100).
- Add `uniform float colorblindIntensity` to `colorblind.glsl` and blend between the original and corrected color using `mix()`.
- Upload the uniform for both the scene and UI shader programs (only when the uniform exists, i.e. when colorblind mode is enabled).

Behavior:
- Intensity 100% matches current behavior (full correction).
- Intensity 0% disables the correction while keeping the selected mode, enabling smooth fade in/out.