### PR TITLE
clues: add fairy ring code to conch medium step

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java
@@ -279,7 +279,7 @@ public class CoordinateClue extends ClueScroll implements LocationClueScroll
 		CoordinateClue.builder()
 			.itemId(ItemID.TRAIL_MEDIUM_SEXTANT_SAIL)
 			.location(new WorldPoint(3183, 2453, 0))
-			.directions("Center of the Great Conch.")
+			.directions("Center of the Great Conch (CJQ).")
 			.build(),
 		// Hard
 		CoordinateClue.builder()


### PR DESCRIPTION
Adds the fairy ring code to the CoordinateClue directions for medium clue `TRAIL_MEDIUM_SEXTANT_SAIL` given that dig spot is about 10 tiles away