### PR TITLE
LayoutManager: Fix variation matching when the layout's id is the base id.

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/banktags/tabs/LayoutManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/banktags/tabs/LayoutManager.java
@@ -516,9 +516,10 @@ public class LayoutManager
 	private int matchesVariant(Set<Integer> bank, int itemId)
 	{
 		int baseId = ItemVariationMapping.map(itemId);
-		if (baseId != itemId)
+		Collection<Integer> variations = ItemVariationMapping.getVariations(baseId);
+		if (variations.size() > 1)
 		{
-			for (int variationId : ItemVariationMapping.getVariations(baseId))
+			for (int variationId : variations)
 			{
 				if (bank.contains(variationId))
 				{


### PR DESCRIPTION
This is blocking an update to bank tag layouts so please add this soon.

Currently it assumes that if the base id is the same as the id in the layout then it is not a variation, which is plainly not true.

The exact id match does not catch this case because that checks the id of the item in the bank, not the id in the layout.