### PR TITLE
Add Brutus to Cows slayer task

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/Task.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/Task.java
@@ -70,7 +70,7 @@ enum Task
 	CHAOS_ELEMENTAL("The Chaos Elemental", ItemID.CHAOSELEPET),
 	CHAOS_FANATIC("The Chaos Fanatic", ItemID.STAFF_OF_ZAROS),
 	COCKATRICE("Cockatrice", ItemID.SLAYERGUIDE_COCKATRICE, "Cockathrice"),
-	COWS("Cows", ItemID.COW_MASK, "Buffalo"),
+	COWS("Cows", ItemID.COW_MASK, "Buffalo", "Brutus"),
 	CRABS("Crabs", ItemID.HUNDRED_PIRATE_CRAB_SHELL_GAUNTLET, "Ammonite Crab", "Frost Crab", "King Sand Crab", "Rock Crab", "Giant Rock Crab", "Sand Crab", "Swamp Crab"),
 	CRAWLING_HANDS("Crawling hands", ItemID.SLAYERGUIDE_CRAWLINGHAND, "Crushing hand"),
 	CRAZY_ARCHAEOLOGIST("Crazy Archaeologists", ItemID.FEDORA),


### PR DESCRIPTION
Brutus counts as a cow, so it should be recognized as a valid cow slayer target.