### PR TITLE
Fix transformed NPCs not being tracked as slayer targets

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayer/SlayerPlugin.java
@@ -323,13 +323,9 @@ public class SlayerPlugin extends Plugin
 	public void onNpcChanged(NpcChanged npcChanged)
 	{
 		NPC npc = npcChanged.getNpc();
-		if (isTarget(npc))
+		if (isTarget(npc) && !targets.contains(npc))
 		{
 			targets.add(npc);
-		}
-		else
-		{
-			targets.remove(npc);
 		}
 	}
 


### PR DESCRIPTION
Rock Crabs and other NPCs that disguise themselves, like rocks for example were not being recognized as slayer targets because when they transformed into their attackable form, an NpcChanged event fires rather than NpcSpawned. Since there was no onNpcChanged handler, these NPCs were never added to the targets list, causing plugins that rely on getTargets() like the Slayer plugin to not recognize the slayer monster. This adds an onNpcChanged handler to handle this case.