### PR TITLE
fix(grounditems): make hidden items override wildcard highlights

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
@@ -34,7 +34,6 @@ import com.google.common.collect.Table;
 import com.google.inject.Provides;
 import java.awt.Color;
 import java.awt.Rectangle;
-import static java.lang.Boolean.FALSE;
 import static java.lang.Boolean.TRUE;
 import java.time.Duration;
 import java.time.Instant;


### PR DESCRIPTION
Issue #19972 is caused by the ground items plugin allowing the same item to match both the highlighted and hidden lists without applying hidden as the final override.

This change makes explicit hidden matches win over explicit wildcard highlight matches for the same item and applies that rule consistently to overlay coloring, notifications and lootbeams.