### PR TITLE
fix(loottracker): Track automated bird nest searching (#19975)

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
@@ -1172,6 +1172,11 @@ public class LootTrackerPlugin extends Plugin
 		{
 			countChangedItems(ItemID.DIRTY_ARROWTIPS, client.getBoostedSkillLevel(Skill.FLETCHING));
 		}
+
+		if (message.endsWith("out of the bird's nest."))
+		{
+			onInvChange(collectInvItems(LootRecordType.EVENT, BIRDNEST_EVENT));
+		}
 	}
 
 	private void countChangedItems(int itemId, Object metadata)

--- a/runelite-client/src/test/java/net/runelite/client/plugins/loottracker/LootTrackerPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/loottracker/LootTrackerPluginTest.java
@@ -585,7 +585,7 @@ public class LootTrackerPluginTest
 		when(client.getLocalPlayer()).thenReturn(player);
 		when(client.getBoostedSkillLevel(Skill.FIREMAKING)).thenReturn(99);
 
-		doNothing().when(lootTrackerPlugin).addLoot(any(), anyInt(), any(), any(), any(Collection.class));
+		doNothing().when(lootTrackerPlugin).addLoot(any(), anyInt(), any(), any(), anyCollection());
 
 		ItemContainer itemContainer = mock(ItemContainer.class);
 		when(itemContainer.getItems()).thenReturn(new Item[]{


### PR DESCRIPTION
### fix(loottracker): Track automated bird nest searching (#19975)

- Added support for tracking the loot received from the next searched bird nest that's automated by the game itself
	- Modified LootTrackerPlugin#onItemContainerChanged to see if a bird nest was searched by the game and whether or not to keep processing inventory changes while there are searchable bird nests remaining
- Added new test case LootTrackerPluginTest#testBirdNests

The following changes were made after noticing that when you `Search` -> `Bird nest`, the following searches that are automated by the game does not trigger `MenuOptionClicked`. It'll still fire `ItemContainerChanged` obviously because the inventory is changed. However, because we are calling `#resetEvent`, we end up setting `inventoryId` to `-1` and therefore early return out before the event handler could handle  `#onInvChange`. That's why I added a `ignoreReset` check in order to skip resetting the inventory and setting up the state to skip ItemContainerChanged.

---


**Note that while I was writing the tests, I realized there is a chat message being sent when you search a nest. I'm looking into relying on `ChatMessage` events instead of the _patch-work_ within `#onItemContainer`. Perhaps it'd also allow for multiple searches in the same tick too.**