### PR TITLE
api: add animation IDs for trailblazer reloaded variants of dragon tools

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/AnimationID.java
+++ b/runelite-api/src/main/java/net/runelite/api/AnimationID.java
@@ -45,6 +45,7 @@ public final class AnimationID
 	public static final int WOODCUTTING_GILDED = 8303;
 	public static final int WOODCUTTING_DRAGON = 2846;
 	public static final int WOODCUTTING_DRAGON_OR = 24;
+	public static final int WOODCUTTING_DRAGON_OR_TRAILBLAZER_RELOADED = 11940;
 	public static final int WOODCUTTING_INFERNAL = 2117;
 	public static final int WOODCUTTING_3A_AXE = 7264;
 	public static final int WOODCUTTING_CRYSTAL = 8324;
@@ -239,6 +240,7 @@ public final class AnimationID
 	public final static int MINING_CRASHEDSTAR_DRAGON_UPGRADED = 643;
 	public final static int MINING_CRASHEDSTAR_DRAGON_OR = 8349;
 	public final static int MINING_CRASHEDSTAR_DRAGON_OR_TRAILBLAZER = 8888;
+	public final static int MINING_CRASHEDSTAR_DRAGON_OR_TRAILBLAZER_RELOADED = 11839;
 	public final static int MINING_CRASHEDSTAR_INFERNAL = 4483;
 	public final static int MINING_CRASHEDSTAR_3A = 7284;
 	public final static int MINING_CRASHEDSTAR_CRYSTAL = 8350;


### PR DESCRIPTION
I saw someone mining at MLM with this pickaxe https://oldschool.runescape.wiki/w/Dragon_pickaxe_(or)_(Trailblazer)#Trailblazer_Reloaded and noticed veins were not starting to deplete in the plugin. It looks like it is a separate animation id that I was able to grab with the creator's kit plugin.

After adding this to the animation id file I would update here to include it in Motherlode Mine Improved https://github.com/TicTac7x/runelite-plugins/blob/86916a10ae623c1356356b0c69144b12c880f935/src/main/java/tictac7x/motherlode/oreveins/OreVeins.java#L157

Where I grabbed the animation id from creator's kit:
<img width="151" height="169" alt="Screenshot 2026-03-18 182604" src="https://github.com/user-attachments/assets/efaf810b-bfa5-428d-8f9c-156cebc937bc" />

Video of the bug where this character's pickaxe doesn't start the vein depleting:

https://github.com/user-attachments/assets/b3b1c34a-b945-48f7-b1bb-2621b5fc4a04