### PR TITLE
Fix #19985 - spellbook: fix Minigame Teleport hide/unhide on non-Arceuus spellbooks

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/spellbook/SpellbookPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/spellbook/SpellbookPlugin.java
@@ -27,6 +27,8 @@ package net.runelite.client.plugins.spellbook;
 import com.google.inject.Provides;
 import java.util.Arrays;
 import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.stream.IntStream;
 import javax.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
@@ -107,6 +109,7 @@ public class SpellbookPlugin extends Plugin
 	private ConfigManager configManager;
 
 	private boolean reordering;
+	private final Map<Integer, Map<Integer, Integer>> spellIdsByWidgetAndSpellbook = new HashMap<>();
 
 	@Provides
 	SpellbookConfig getConfig(ConfigManager configManager)
@@ -389,6 +392,9 @@ public class SpellbookPlugin extends Plugin
 			int spellObjId = spellbook.getIntValue(i);
 			ItemComposition spellObj = client.getItemDefinition(spellObjId);
 			int spellComponent = spellObj.getIntValue(ParamID.SPELL_BUTTON);
+
+			spellIdsByWidgetAndSpellbook.computeIfAbsent(spellComponent, k -> new HashMap<>()).put(spellbookEnum, spellObjId);
+
 			Widget w = client.getWidget(spellComponent);
 			if (w == null)
 			{
@@ -409,11 +415,13 @@ public class SpellbookPlugin extends Plugin
 					int subSpellbookId = client.getEnum(EnumID.SPELLBOOKS_SUB).getIntValue(client.getVarbitValue(VarbitID.SPELLBOOK));
 					int spellbookId = client.getEnum(subSpellbookId).getIntValue(client.getVarbitValue(VarbitID.SPELLBOOK_SUBLIST));
 
-					boolean hidden = isHidden(spellbookId, spellObjId);
+					int spellIdFromCurrentSpellbook = spellIdsByWidgetAndSpellbook.get(s.getId()).get(spellbookId);
+
+					boolean hidden = isHidden(spellbookId, spellIdFromCurrentSpellbook);
 					hidden = !hidden;
 
 					log.debug("Changing {} to hidden: {}", s.getName(), hidden);
-					setHidden(spellbookId, spellObjId, hidden);
+					setHidden(spellbookId, spellIdFromCurrentSpellbook, hidden);
 
 					s.setOpacity(hidden ? 100 : 0);
 					s.setAction(HIDE_UNHIDE_OP, hidden ? "Unhide" : "Hide");


### PR DESCRIPTION
## Problem
The Minigame Teleport spell is unique - it appears on all spellbooks but uses different spell IDs (33138-33141) while sharing the same widget (14286856). When each spellbook initialized, the OpListener was overwritten, with Arceuus initializing last and capturing spell ID 33140. This caused hiding/unhiding to only work on Arceuus spellbook.

## Solution
Build a lookup map (`spellIdsByWidgetAndSpellbook`) during initialization to store spell IDs per widget per spellbook. The OpListener now looks up the spell ID from the current spellbook instead of using a stale captured value.

## Testing
- Verified hiding/unhiding Minigame Teleport works on all spellbooks (Standard, Ancient, Lunar, Arceuus)
- Hidden state is correctly persisted per spellbook
