### PR TITLE
add more display options for farming contract infobox

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/TimeTrackingConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/TimeTrackingConfig.java
@@ -29,6 +29,7 @@ import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
 import net.runelite.client.config.Notification;
 import net.runelite.client.config.Units;
+import net.runelite.client.plugins.timetracking.farming.FarmingContractInfoBoxDisplay;
 
 @ConfigGroup("timetracking")
 public interface TimeTrackingConfig extends Config
@@ -71,12 +72,12 @@ public interface TimeTrackingConfig extends Config
 	@ConfigItem(
 		keyName = "farmingContractInfoBox",
 		name = "Show farming contract infobox",
-		description = "Show an infobox of your current farming contract when inside the farming guild.",
+		description = "Show an infobox of your current farming contract",
 		position = 4
 	)
-	default boolean farmingContractInfoBox()
+	default FarmingContractInfoBoxDisplay farmingContractInfoBox()
 	{
-		return true;
+		return FarmingContractInfoBoxDisplay.IN_GUILD;
 	}
 
 	@ConfigItem(

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/farming/FarmingContractInfoBox.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/farming/FarmingContractInfoBox.java
@@ -125,6 +125,6 @@ class FarmingContractInfoBox extends InfoBox
 	@Override
 	public boolean render()
 	{
-		return config.farmingContractInfoBox();
+		return config.farmingContractInfoBox() != FarmingContractInfoBoxDisplay.NEVER;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/farming/FarmingContractInfoBoxDisplay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/farming/FarmingContractInfoBoxDisplay.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2020, MMagicala
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.timetracking.farming;
+
+public enum FarmingContractInfoBoxDisplay
+{
+	ALWAYS, NEVER, IN_GUILD
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/farming/FarmingContractManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timetracking/farming/FarmingContractManager.java
@@ -148,19 +148,24 @@ public class FarmingContractManager
 		SummaryState oldSummary = summary;
 
 		handleContractState();
-		if (loc.getRegionID() == FARMING_GUILD_REGION_ID)
+		boolean inFarmingGuild = loc.getRegionID() == FARMING_GUILD_REGION_ID;
+
+		if (inFarmingGuild)
 		{
 			handleGuildmasterJaneWidgetDialog();
+		}
+
+		if (config.farmingContractInfoBox() == FarmingContractInfoBoxDisplay.ALWAYS
+			|| (config.farmingContractInfoBox() == FarmingContractInfoBoxDisplay.IN_GUILD && inFarmingGuild))
+		{
 			handleInfoBox();
 		}
-		else
+		else if (infoBox != null)
 		{
-			if (infoBox != null)
-			{
-				infoBoxManager.removeInfoBox(infoBox);
-				infoBox = null;
-			}
+			infoBoxManager.removeInfoBox(infoBox);
+			infoBox = null;
 		}
+
 		return oldSummary != summary;
 	}
 


### PR DESCRIPTION
Closes #11935

Adds display options for the farming contract infobox, allowing users to choose when it appears:

- **Always** - Show the infobox everywhere (addresses the request for a "persistent farming contract indicator")
- **In Guild** - Only show when inside the Farming Guild (default, maintains current behavior)
- **Never** - Never show the infobox

This is a fresh implementation of #12055 with all review feedback addressed.
