### PR TITLE
Add Larupia heal stats to item stats

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatChanges.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemstats/ItemStatChanges.java
@@ -129,6 +129,7 @@ public class ItemStatChanges
 		add(range(food(5), food(8)), ItemID.SNAIL_CORPSE_COOKED2);
 		add(range(food(7), food(9)), ItemID.SNAIL_CORPSE_COOKED3);
 		add(range(food(7), food(10)), ItemID.TBW_SPIDER_ON_STICK_COOKED, ItemID.TBW_SPIDER_ON_SHAFT_COOKED);
+		add(combo(food(6), food(5)), ItemID.LARUPIA_COOKED);
 		add(combo(food(8), food(6)), ItemID.GRAAHK_COOKED);
 		add(combo(food(9), food(8)), ItemID.KYATT_COOKED);
 		add(combo(food(11), food(8)), ItemID.FENNECFOX_COOKED);


### PR DESCRIPTION
Adds a combo heal for [Cooked Larupia](https://oldschool.runescape.wiki/w/Cooked_larupia) to item stats

Instantly healing 6 hitpoints, then healing another 5 after a 7 tick delay (4.2s) for a total of 11 hitpoints.

I noticed this was the only hunter meat not listed in the itemstats