### PR TITLE
Fix boosts information text alignment

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/boosts/CompactBoostsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/boosts/CompactBoostsOverlay.java
@@ -81,7 +81,8 @@ class CompactBoostsOverlay extends Overlay
 		curY = maxX = 0;
 		maxIconWidth = Math.max(BUFFED.getWidth(), DEBUFFED.getWidth());
 
-		for (Skill skill : boostedSkills) {
+		for (Skill skill : boostedSkills)
+		{
 			BufferedImage img = skillIconManager.getSkillImage(skill, true);
 			maxIconWidth = Math.max(maxIconWidth, img.getWidth());
 		}


### PR DESCRIPTION
Skill icons with different widths would cause text alignment issues for Boosts Information's compact display.

| Before | After |
|---|---|
| <img width="128" height="201" alt="image" src="https://github.com/user-attachments/assets/0f14b120-43d4-468b-ac85-e9bd4ed2984a" /> | <img width="134" height="207" alt="image" src="https://github.com/user-attachments/assets/b1503395-fe28-4f91-afc7-6a94f6ae38ab" />|
