### PR TITLE
Added home world hopper to world hopper

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldHopperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldHopperConfig.java
@@ -62,10 +62,21 @@ public interface WorldHopperConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "homeWorldKey",
+		name = "Quick-hop home world",
+		description = "When you press this key you'll hop to your set home world.",
+		position = 2
+	)	
+	default Keybind homeWorldKey()
+	{
+		return new Keybind(KeyEvent.VK_HOME, InputEvent.CTRL_DOWN_MASK | InputEvent.SHIFT_DOWN_MASK);
+	}
+
+	@ConfigItem(
 		keyName = "quickhopOutOfDanger",
 		name = "Quick-hop out of dangerous worlds",
 		description = "Don't hop to a PvP/high risk world when quick-hopping.",
-		position = 2
+		position = 3
 	)
 	default boolean quickhopOutOfDanger()
 	{
@@ -158,5 +169,16 @@ public interface WorldHopperConfig extends Config
 	default boolean displayPing()
 	{
 		return false;
+	}
+
+	@ConfigItem(
+		keyName = "setHomeWorld",
+		name = "Home world",
+		description = "Sets a home world to teleport to after world hopping.",
+		position = 12
+	)
+	default int setHomeWorld()
+	{
+		return 0;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldHopperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldHopperConfig.java
@@ -66,7 +66,7 @@ public interface WorldHopperConfig extends Config
 		name = "Quick-hop home world",
 		description = "When you press this key you'll hop to your set home world.",
 		position = 2
-	)	
+	)
 	default Keybind homeWorldKey()
 	{
 		return new Keybind(KeyEvent.VK_HOME, InputEvent.CTRL_DOWN_MASK | InputEvent.SHIFT_DOWN_MASK);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldHopperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldHopperPlugin.java
@@ -186,6 +186,14 @@ public class WorldHopperPlugin extends Plugin
 			clientThread.invoke(() -> hop(false));
 		}
 	};
+	private final HotkeyListener homeWorldKeyListener = new HotkeyListener(() -> config.homeWorldKey())
+	{
+		@Override
+		public void hotkeyPressed()
+		{
+			clientThread.invoke(() -> hop(config.setHomeWorld()));
+		}
+	};
 
 	@Provides
 	WorldHopperConfig getConfig(ConfigManager configManager)
@@ -200,6 +208,7 @@ public class WorldHopperPlugin extends Plugin
 
 		keyManager.registerKeyListener(previousKeyListener);
 		keyManager.registerKeyListener(nextKeyListener);
+		keyManager.registerKeyListener(homeWorldKeyListener);
 
 		panel = new WorldSwitcherPanel(this);
 


### PR DESCRIPTION
I get a lot of use out of this plugin but the one thing I have been missing is a quick way to return to my preferred world. To make this easier I have added an option to set a home world in the world hopper plugin and a keybind to be able to return quickly.

<img width="243" height="732" alt="Schermafbeelding 2026-04-03 205422" src="https://github.com/user-attachments/assets/4e0341f0-f5ee-49a3-8733-4a690042fde1" />
