### PR TITLE
emoji: fix :shortcode: parsing after emoticons

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/emojis/EmojiPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/emojis/EmojiPlugin.java
@@ -174,21 +174,6 @@ public class EmojiPlugin extends Plugin
 		{
 			char c = message.charAt(i);
 
-			if (Character.isWhitespace(c) || c == '\u00A0' || i + 1 == message.length())
-			{
-				int idxEndWs = i + 1 == message.length() ? message.length() : i;
-				String shortname = Text.removeFormattingTags(message.substring(idxStartWs + 1, idxEndWs));
-				idxStartWs = i;
-
-				final Emoji emoji = Emoji.getEmoji(shortname);
-				if (emoji != null)
-				{
-					String id = Integer.toHexString(emoji.codepoint);
-					int emojiId = getEmojiChatIconIndex(emoji.name(), id);
-					editedMessage = editedMessage.replace(shortname, "<img=" + chatIconManager.chatIconIndex(emojiId) + ">");
-				}
-			}
-
 			if (c == ':')
 			{
 				if (idxStart == -1)
@@ -206,6 +191,22 @@ public class EmojiPlugin extends Plugin
 						int emojiId = getEmojiChatIconIndex(emojiName, id);
 						editedMessage = editedMessage.replace(":" + emojiName + ":", "<img=" + chatIconManager.chatIconIndex(emojiId) + ">");
 					}
+				}
+			}
+
+			if (Character.isWhitespace(c) || c == '\u00A0' || i + 1 == message.length())
+			{
+				int idxEndWs = i + 1 == message.length() ? message.length() : i;
+				String shortname = Text.removeFormattingTags(message.substring(idxStartWs + 1, idxEndWs));
+				idxStart = -1;
+				idxStartWs = i;
+
+				final Emoji emoji = Emoji.getEmoji(shortname);
+				if (emoji != null)
+				{
+					String id = Integer.toHexString(emoji.codepoint);
+					int emojiId = getEmojiChatIconIndex(emoji.name(), id);
+					editedMessage = editedMessage.replace(shortname, "<img=" + chatIconManager.chatIconIndex(emojiId) + ">");
 				}
 			}
 		}

--- a/runelite-client/src/test/java/net/runelite/client/plugins/emojis/EmojiPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/emojis/EmojiPluginTest.java
@@ -147,4 +147,10 @@ public class EmojiPluginTest
 	{
 		assertEquals("test <img=0>", emojiPlugin.updateMessage("test :test:"));
 	}
+
+	@Test
+	public void testNamedAfterEmoji()
+	{
+		assertEquals("<img=0> <img=1>", emojiPlugin.updateMessage(":) :test:"));
+	}
 }


### PR DESCRIPTION
Reset idxStart on whitespace to prevent triggers with ':' from breaking subsequent :shortcode: emojis. Reordered blocks so if a line ends with  a :shortcode:, it is processed before the end-of-line check resets idxStart.

<img width="130" height="29" alt="image" src="https://github.com/user-attachments/assets/ff0a7d38-38ae-421b-9cb7-7090607f0b0b" />

<img width="118" height="27" alt="image" src="https://github.com/user-attachments/assets/0535a92a-dbce-499f-840a-bc0f6650f5f4" />
