### PR TITLE
Update mousehighlight core plugin with more options to hide tooltips.

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/mousehighlight/MouseHighlightConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/mousehighlight/MouseHighlightConfig.java
@@ -63,4 +63,37 @@ public interface MouseHighlightConfig extends Config
 	{
 		return false;
 	}
+
+	@ConfigItem(
+		position = 3,
+		keyName = "disablePrayertooltip",
+		name = "Disable prayer tooltips",
+		description = "Disable prayer tooltips."
+	)
+	default boolean disablePrayertooltip()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		position = 4,
+		keyName = "disableMenuStonesTooltip",
+		name = "Disable menu stones tooltips",
+		description = "Disable menu stones tooltips."
+	)
+	default boolean disableMenuStonesTooltip()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		position = 5,
+		keyName = "disableOrbsTooltip",
+		name = "Disable orbs tooltips",
+		description = "Disable orbs tooltips."
+	)
+	default boolean disableOrbsTooltip()
+	{
+		return false;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/mousehighlight/MouseHighlightOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/mousehighlight/MouseHighlightOverlay.java
@@ -30,6 +30,7 @@ import java.awt.Dimension;
 import java.awt.Graphics2D;
 import java.util.Set;
 import javax.inject.Inject;
+import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.MenuAction;
 import net.runelite.api.MenuEntry;
@@ -42,6 +43,7 @@ import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.tooltip.Tooltip;
 import net.runelite.client.ui.overlay.tooltip.TooltipManager;
 
+@Slf4j
 class MouseHighlightOverlay extends Overlay
 {
 	/**
@@ -137,12 +139,21 @@ class MouseHighlightOverlay extends Overlay
 				}
 		}
 
+
+
 		if (WIDGET_MENU_ACTIONS.contains(type))
 		{
 			final int widgetId = menuEntry.getParam1();
 			final int groupId = WidgetUtil.componentToInterface(widgetId);
 
+			log.debug(groupId + "");
+
 			if (!config.uiTooltip())
+			{
+				return null;
+			}
+
+			if (groupId == InterfaceID.WELCOME_SCREEN)
 			{
 				return null;
 			}
@@ -153,6 +164,21 @@ class MouseHighlightOverlay extends Overlay
 			}
 
 			if (config.disableSpellbooktooltip() && groupId == InterfaceID.MAGIC_SPELLBOOK)
+			{
+				return null;
+			}
+
+			if (config.disablePrayertooltip() && groupId == InterfaceID.PRAYERBOOK)
+			{
+				return null;
+			}
+
+			if (config.disableMenuStonesTooltip() && (groupId == InterfaceID.TOPLEVEL || groupId == InterfaceID.TOPLEVEL_PRE_EOC || groupId == InterfaceID.TOPLEVEL_OSRS_STRETCH))
+			{
+				return null;
+			}
+
+			if (config.disableOrbsTooltip() && (groupId == InterfaceID.ORBS || groupId == InterfaceID.ORBS_NOMAP))
 			{
 				return null;
 			}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/mousehighlight/MouseHighlightOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/mousehighlight/MouseHighlightOverlay.java
@@ -30,7 +30,6 @@ import java.awt.Dimension;
 import java.awt.Graphics2D;
 import java.util.Set;
 import javax.inject.Inject;
-import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.MenuAction;
 import net.runelite.api.MenuEntry;
@@ -43,7 +42,6 @@ import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.tooltip.Tooltip;
 import net.runelite.client.ui.overlay.tooltip.TooltipManager;
 
-@Slf4j
 class MouseHighlightOverlay extends Overlay
 {
 	/**
@@ -145,8 +143,6 @@ class MouseHighlightOverlay extends Overlay
 		{
 			final int widgetId = menuEntry.getParam1();
 			final int groupId = WidgetUtil.componentToInterface(widgetId);
-
-			log.debug(groupId + "");
 
 			if (!config.uiTooltip())
 			{


### PR DESCRIPTION
Update mousehighlight core plugin with options to hide prayer, menu stones and orbs tooltips.
<img width="227" height="228" alt="image" src="https://github.com/user-attachments/assets/19fcd76b-f9fb-4346-889d-41161eaedfcd" />

Also hide the welcome screen play button tooltip(no config option).
<img width="490" height="211" alt="image" src="https://github.com/user-attachments/assets/2d3d9181-755b-488e-866c-b9af7e714c08" />
