### PR TITLE
clue scroll: fix hot/cold steps on leagues

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/ClueScrollPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/ClueScrollPlugin.java
@@ -885,7 +885,7 @@ public class ClueScrollPlugin extends Plugin
 			return faloTheBardClue;
 		}
 
-		final HotColdClue hotColdClue = HotColdClue.forText(text, clueItemId);
+		final HotColdClue hotColdClue = HotColdClue.forText(text, clueItemId != null ? clueItemId : -1);
 
 		if (hotColdClue != null)
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/ClueScrollPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/ClueScrollPlugin.java
@@ -885,7 +885,7 @@ public class ClueScrollPlugin extends Plugin
 			return faloTheBardClue;
 		}
 
-		final HotColdClue hotColdClue = HotColdClue.forText(text);
+		final HotColdClue hotColdClue = HotColdClue.forText(text, clueItemId);
 
 		if (hotColdClue != null)
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/HotColdClue.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/HotColdClue.java
@@ -88,7 +88,7 @@ public class HotColdClue extends ClueScroll implements LocationClueScroll, Locat
 	private HotColdSolver hotColdSolver;
 	private WorldPoint location;
 
-	public static HotColdClue forText(String text, Integer clueItemId)
+	public static HotColdClue forText(String text, int clueItemId)
 	{
 		if (BEGINNER_CLUE.text.equalsIgnoreCase(text))
 		{
@@ -102,22 +102,17 @@ public class HotColdClue extends ClueScroll implements LocationClueScroll, Locat
 		}
 		else if (LEAGUE_TUTOR_CLUE_TEXT.equalsIgnoreCase(text))
 		{
-			if (clueItemId != null)
+			if (clueItemId == ItemID.TRAIL_CLUE_BEGINNER)
 			{
-				if (clueItemId == ItemID.TRAIL_CLUE_BEGINNER)
-				{
-					LEAGUE_TUTOR_BEGINNER_CLUE.reset();
-					return LEAGUE_TUTOR_BEGINNER_CLUE;
-				}
-
-				if (clueItemId == ItemID.TRAIL_CLUE_MASTER)
-				{
-					LEAGUE_TUTOR_MASTER_CLUE.reset();
-					return LEAGUE_TUTOR_MASTER_CLUE;
-				}
+				LEAGUE_TUTOR_BEGINNER_CLUE.reset();
+				return LEAGUE_TUTOR_BEGINNER_CLUE;
 			}
 
-			return null;
+			if (clueItemId == ItemID.TRAIL_CLUE_MASTER)
+			{
+				LEAGUE_TUTOR_MASTER_CLUE.reset();
+				return LEAGUE_TUTOR_MASTER_CLUE;
+			}
 		}
 
 		return null;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/HotColdClue.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/HotColdClue.java
@@ -88,11 +88,6 @@ public class HotColdClue extends ClueScroll implements LocationClueScroll, Locat
 	private HotColdSolver hotColdSolver;
 	private WorldPoint location;
 
-	public static HotColdClue forText(String text)
-	{
-		return forText(text, null);
-	}
-
 	public static HotColdClue forText(String text, Integer clueItemId)
 	{
 		if (BEGINNER_CLUE.text.equalsIgnoreCase(text))

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/HotColdClue.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/HotColdClue.java
@@ -39,6 +39,7 @@ import lombok.Getter;
 import net.runelite.api.NPC;
 import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.coords.WorldPoint;
+import net.runelite.api.gameval.ItemID;
 import static net.runelite.client.plugins.cluescrolls.ClueScrollOverlay.TITLED_CONTENT_COLOR;
 import net.runelite.client.plugins.cluescrolls.ClueScrollPlugin;
 import static net.runelite.client.plugins.cluescrolls.ClueScrollWorldOverlay.IMAGE_Z_OFFSET;
@@ -66,6 +67,17 @@ public class HotColdClue extends ClueScroll implements LocationClueScroll, Locat
 		"Speak to Jorral to receive a strange device.",
 		new WorldPoint(2436, 3347, 0),
 		false);
+	private static final String LEAGUE_TUTOR_CLUE_TEXT = "Buried beneath the ground, who knows where it's found. The League Tutor may have a strange device lying around.";
+	private static final HotColdClue LEAGUE_TUTOR_BEGINNER_CLUE = new HotColdClue(LEAGUE_TUTOR_CLUE_TEXT,
+		"Leagues Tutor",
+		"Speak to Leagues Tutor to receive a strange device.",
+		new WorldPoint(1500, 5596, 0),
+		true);
+	private static final HotColdClue LEAGUE_TUTOR_MASTER_CLUE = new HotColdClue(LEAGUE_TUTOR_CLUE_TEXT,
+		"Leagues Tutor",
+		"Speak to Leagues Tutor to receive a strange device.",
+		new WorldPoint(1500, 5596, 0),
+		false);
 
 	private final String text;
 	private final String npc;
@@ -78,6 +90,11 @@ public class HotColdClue extends ClueScroll implements LocationClueScroll, Locat
 
 	public static HotColdClue forText(String text)
 	{
+		return forText(text, null);
+	}
+
+	public static HotColdClue forText(String text, Integer clueItemId)
+	{
 		if (BEGINNER_CLUE.text.equalsIgnoreCase(text))
 		{
 			BEGINNER_CLUE.reset();
@@ -87,6 +104,25 @@ public class HotColdClue extends ClueScroll implements LocationClueScroll, Locat
 		{
 			MASTER_CLUE.reset();
 			return MASTER_CLUE;
+		}
+		else if (LEAGUE_TUTOR_CLUE_TEXT.equalsIgnoreCase(text))
+		{
+			if (clueItemId != null)
+			{
+				if (clueItemId == ItemID.TRAIL_CLUE_BEGINNER)
+				{
+					LEAGUE_TUTOR_BEGINNER_CLUE.reset();
+					return LEAGUE_TUTOR_BEGINNER_CLUE;
+				}
+
+				if (clueItemId == ItemID.TRAIL_CLUE_MASTER)
+				{
+					LEAGUE_TUTOR_MASTER_CLUE.reset();
+					return LEAGUE_TUTOR_MASTER_CLUE;
+				}
+			}
+
+			return null;
 		}
 
 		return null;

--- a/runelite-client/src/test/java/net/runelite/client/plugins/cluescrolls/clues/HotColdClueTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/cluescrolls/clues/HotColdClueTest.java
@@ -40,13 +40,13 @@ public class HotColdClueTest
 	@Test
 	public void forTextEmptyString()
 	{
-		assertNull(HotColdClue.forText("", null));
+		assertNull(HotColdClue.forText("", 0));
 	}
 
 	@Test
 	public void forTextBeginner()
 	{
-		HotColdClue clue = HotColdClue.forText(BEGINNER_CLUE_TEXT, null);
+		HotColdClue clue = HotColdClue.forText(BEGINNER_CLUE_TEXT, 0);
 		assertNotNull(clue);
 		assertTrue(clue.isBeginner());
 	}
@@ -54,7 +54,7 @@ public class HotColdClueTest
 	@Test
 	public void forTextMaster()
 	{
-		HotColdClue clue = HotColdClue.forText(MASTER_CLUE_TEXT, null);
+		HotColdClue clue = HotColdClue.forText(MASTER_CLUE_TEXT, 0);
 		assertNotNull(clue);
 		assertFalse(clue.isBeginner());
 	}
@@ -62,7 +62,7 @@ public class HotColdClueTest
 	@Test
 	public void forTextLeagueTutorWithoutItemId()
 	{
-		assertNull(HotColdClue.forText(LEAGUE_TUTOR_CLUE_TEXT, null));
+		assertNull(HotColdClue.forText(LEAGUE_TUTOR_CLUE_TEXT, 0));
 	}
 
 	@Test

--- a/runelite-client/src/test/java/net/runelite/client/plugins/cluescrolls/clues/HotColdClueTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/cluescrolls/clues/HotColdClueTest.java
@@ -40,13 +40,13 @@ public class HotColdClueTest
 	@Test
 	public void forTextEmptyString()
 	{
-		assertNull(HotColdClue.forText(""));
+		assertNull(HotColdClue.forText("", null));
 	}
 
 	@Test
 	public void forTextBeginner()
 	{
-		HotColdClue clue = HotColdClue.forText(BEGINNER_CLUE_TEXT);
+		HotColdClue clue = HotColdClue.forText(BEGINNER_CLUE_TEXT, null);
 		assertNotNull(clue);
 		assertTrue(clue.isBeginner());
 	}
@@ -54,7 +54,7 @@ public class HotColdClueTest
 	@Test
 	public void forTextMaster()
 	{
-		HotColdClue clue = HotColdClue.forText(MASTER_CLUE_TEXT);
+		HotColdClue clue = HotColdClue.forText(MASTER_CLUE_TEXT, null);
 		assertNotNull(clue);
 		assertFalse(clue.isBeginner());
 	}
@@ -62,7 +62,7 @@ public class HotColdClueTest
 	@Test
 	public void forTextLeagueTutorWithoutItemId()
 	{
-		assertNull(HotColdClue.forText(LEAGUE_TUTOR_CLUE_TEXT));
+		assertNull(HotColdClue.forText(LEAGUE_TUTOR_CLUE_TEXT, null));
 	}
 
 	@Test

--- a/runelite-client/src/test/java/net/runelite/client/plugins/cluescrolls/clues/HotColdClueTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/cluescrolls/clues/HotColdClueTest.java
@@ -24,14 +24,60 @@
  */
 package net.runelite.client.plugins.cluescrolls.clues;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import net.runelite.api.gameval.ItemID;
 import org.junit.Test;
 
 public class HotColdClueTest
 {
+	private static final String BEGINNER_CLUE_TEXT = "Buried beneath the ground, who knows where it's found. Lucky for you, A man called Reldo may have a clue.";
+	private static final String MASTER_CLUE_TEXT = "Buried beneath the ground, who knows where it's found. Lucky for you, A man called Jorral may have a clue.";
+	private static final String LEAGUE_TUTOR_CLUE_TEXT = "Buried beneath the ground, who knows where it's found. The League Tutor may have a strange device lying around.";
+
 	@Test
 	public void forTextEmptyString()
 	{
 		assertNull(HotColdClue.forText(""));
+	}
+
+	@Test
+	public void forTextBeginner()
+	{
+		HotColdClue clue = HotColdClue.forText(BEGINNER_CLUE_TEXT);
+		assertNotNull(clue);
+		assertTrue(clue.isBeginner());
+	}
+
+	@Test
+	public void forTextMaster()
+	{
+		HotColdClue clue = HotColdClue.forText(MASTER_CLUE_TEXT);
+		assertNotNull(clue);
+		assertFalse(clue.isBeginner());
+	}
+
+	@Test
+	public void forTextLeagueTutorWithoutItemId()
+	{
+		assertNull(HotColdClue.forText(LEAGUE_TUTOR_CLUE_TEXT));
+	}
+
+	@Test
+	public void forTextLeagueTutorBeginnerItemId()
+	{
+		HotColdClue clue = HotColdClue.forText(LEAGUE_TUTOR_CLUE_TEXT, ItemID.TRAIL_CLUE_BEGINNER);
+		assertNotNull(clue);
+		assertTrue(clue.isBeginner());
+	}
+
+	@Test
+	public void forTextLeagueTutorMasterItemId()
+	{
+		HotColdClue clue = HotColdClue.forText(LEAGUE_TUTOR_CLUE_TEXT, ItemID.TRAIL_CLUE_MASTER);
+		assertNotNull(clue);
+		assertFalse(clue.isBeginner());
 	}
 }


### PR DESCRIPTION
fixes #20073

Fixes the clue scroll plugin to work with hot/cold steps in leagues