### PR TITLE
combat level: exclude extraneous information from overlay

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/combatlevel/CombatLevelOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/combatlevel/CombatLevelOverlay.java
@@ -120,19 +120,39 @@ class CombatLevelOverlay extends Overlay
 
 		if ((attackLevel + strengthLevel) < Experience.MAX_REAL_LEVEL * 2)
 		{
-			sb.append(meleeNeed).append(" Attack/Strength</br>");
+			sb.append(meleeNeed);
+			if (attackLevel < Experience.MAX_REAL_LEVEL && strengthLevel < Experience.MAX_REAL_LEVEL)
+			{
+				sb.append(" Attack/Strength</br>");
+			}
+			else if (attackLevel < Experience.MAX_REAL_LEVEL)
+			{
+				sb.append(" Attack</br>");
+			}
+			else
+			{
+				sb.append(" Strength</br>");
+			}
 		}
 		if ((hitpointsLevel + defenceLevel) < Experience.MAX_REAL_LEVEL * 2)
 		{
-			sb.append(hpDefNeed).append(" Defence/Hitpoints</br>");
+			sb.append(hpDefNeed);
+			if (hitpointsLevel < Experience.MAX_REAL_LEVEL && defenceLevel < Experience.MAX_REAL_LEVEL)
+			{
+				sb.append(" Defence/Hitpoints</br>");
+			}
+			else if (defenceLevel < Experience.MAX_REAL_LEVEL)
+			{
+				sb.append(" Defence</br>");
+			}
+			else
+			{
+				sb.append(" Hitpoints</br>");
+			}
 		}
-		if (rangeLevel < Experience.MAX_REAL_LEVEL)
+		if (rangeLevel < Experience.MAX_REAL_LEVEL && magicLevel < Experience.MAX_REAL_LEVEL)
 		{
-			sb.append(rangeNeed).append(" Ranged</br>");
-		}
-		if (magicLevel < Experience.MAX_REAL_LEVEL)
-		{
-			sb.append(magicNeed).append(" Magic</br>");
+			sb.append(rangeNeed).append(" Ranged</br>").append(magicNeed).append(" Magic</br>");
 		}
 		if (prayerLevel < Experience.MAX_REAL_LEVEL)
 		{

--- a/runelite-client/src/test/java/net/runelite/client/plugins/combatlevel/CombatLevelOverlayTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/combatlevel/CombatLevelOverlayTest.java
@@ -67,13 +67,13 @@ public class CombatLevelOverlayTest
 	public void testGetLevelsUntilTooltip()
 	{
 		when(client.getRealSkillLevel(Skill.ATTACK)).thenReturn(99);
-		when(client.getRealSkillLevel(Skill.STRENGTH)).thenReturn(99);
+		when(client.getRealSkillLevel(Skill.STRENGTH)).thenReturn(94);
 		when(client.getRealSkillLevel(Skill.DEFENCE)).thenReturn(97);
-		when(client.getRealSkillLevel(Skill.HITPOINTS)).thenReturn(99);
+		when(client.getRealSkillLevel(Skill.HITPOINTS)).thenReturn(98);
 		when(client.getRealSkillLevel(Skill.MAGIC)).thenReturn(99);
-		when(client.getRealSkillLevel(Skill.RANGED)).thenReturn(99);
+		when(client.getRealSkillLevel(Skill.RANGED)).thenReturn(91);
 		when(client.getRealSkillLevel(Skill.PRAYER)).thenReturn(94);
 
-		assertEquals("<col=ff981f>Next combat level:</br></col>4 Defence/Hitpoints</br>8 Prayer", combatLevelOverlay.getLevelsUntilTooltip());
+		assertEquals("<col=ff981f>Next combat level:</br></col>3 Strength</br>4 Defence/Hitpoints</br>8 Prayer", combatLevelOverlay.getLevelsUntilTooltip());
 	}
 }


### PR DESCRIPTION
- If you have 99 Attack or Strength, the skill you have 99 in cannot contribute to combat level
- If you have 99 Hitpoints or Prayer, the skill you have 99 in cannot contribute to combat level
- If you have 99 Magic or Ranged, neither skill can contribute to combat level