### PR TITLE
(PoC) Config Submenus

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/config/ConfigInvocationHandler.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/ConfigInvocationHandler.java
@@ -97,6 +97,21 @@ class ConfigInvocationHandler implements InvocationHandler
 		{
 			log.trace("cache miss (size: {}, group: {}, key: {})", cache.size(), group.value(), item.keyName());
 
+			// If this item lives in a section gated by an opensSubmenu boolean, short-circuit to the
+			// type's zero value when the gating boolean is false. This makes feature flagging
+			// transparent: callers never have to AND against the toggle.
+			String gatingKey = findGatingKey(iface, item.section());
+			if (gatingKey != null && !gatingKey.equals(item.keyName()))
+			{
+				String gateValue = manager.getConfiguration(group.value(), gatingKey);
+				if (gateValue != null && !Boolean.parseBoolean(gateValue))
+				{
+					Object zero = zeroValue(method.getReturnType());
+					cache.put(method, zero == null ? NULL : zero);
+					return zero;
+				}
+			}
+
 			// Getting configuration item
 			String value = manager.getConfiguration(group.value(), item.keyName());
 
@@ -182,6 +197,49 @@ class ConfigInvocationHandler implements InvocationHandler
 			.unreflectSpecial(method, declaringClass)
 			.bindTo(proxy)
 			.invokeWithArguments(args);
+	}
+
+	/**
+	 * Returns the {@code keyName} of the boolean {@link ConfigItem} on {@code iface} whose
+	 * {@code opensSubmenu} equals {@code sectionName}, or {@code null} if the section isn't
+	 * gated by such an opener.
+	 */
+	private static String findGatingKey(Class<?> iface, String sectionName)
+	{
+		if (sectionName == null || sectionName.isEmpty())
+		{
+			return null;
+		}
+		for (Method m : iface.getMethods())
+		{
+			ConfigItem ann = m.getAnnotation(ConfigItem.class);
+			if (ann == null || ann.opensSubmenu().isEmpty())
+			{
+				continue;
+			}
+			if (sectionName.equals(ann.opensSubmenu()))
+			{
+				return ann.keyName();
+			}
+		}
+		return null;
+	}
+
+	private static Object zeroValue(Class<?> type)
+	{
+		if (!type.isPrimitive())
+		{
+			return null;
+		}
+		if (type == boolean.class) return Boolean.FALSE;
+		if (type == int.class) return 0;
+		if (type == long.class) return 0L;
+		if (type == double.class) return 0d;
+		if (type == float.class) return 0f;
+		if (type == short.class) return (short) 0;
+		if (type == byte.class) return (byte) 0;
+		if (type == char.class) return (char) 0;
+		return null;
 	}
 
 	void invalidate()

--- a/runelite-client/src/main/java/net/runelite/client/config/ConfigItem.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/ConfigItem.java
@@ -48,4 +48,24 @@ public @interface ConfigItem
 	boolean secret() default false;
 
 	String section() default "";
+
+	/**
+	 * Position of this item within a sub-panel opened by {@link #opensSubmenu()}.
+	 * Use this instead of {@link #position()} for items inside a submenu so the two
+	 * orderings are visually distinct in source — readers won't see {@code position}
+	 * appear to "reset" partway down the file. Falls back to {@link #position()} when
+	 * unset (default -1).
+	 */
+	int submenuPosition() default -1;
+
+	/**
+	 * If non-empty, marks this boolean item as the "opener" for a sibling {@link ConfigSection}.
+	 * The item renders as a regular checkbox, with a gear button next to it that opens a sub-panel
+	 * containing the section's items. While the checkbox is unchecked, the proxy reports the
+	 * type's zero value for every item in that section (transparent feature flagging).
+	 * <p>
+	 * Value is the section's key (the value of the {@code String} field annotated with
+	 * {@link ConfigSection}). Only meaningful for {@code boolean} items.
+	 */
+	String opensSubmenu() default "";
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
@@ -42,6 +42,7 @@ import java.awt.image.BufferedImage;
 import java.lang.reflect.ParameterizedType;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -143,6 +144,8 @@ class ConfigPanel extends PluginPanel
 	private final ColorPickerManager colorPickerManager;
 	private final Provider<NotificationPanel> notificationPanelProvider;
 	private final Provider<FontPanel> fontPanelProvider;
+	private final Provider<ConfigPanel> configPanelProvider;
+	private String sectionFilter = null;
 
 	private final TitleCaseListCellRenderer listCellRenderer = new TitleCaseListCellRenderer();
 
@@ -160,7 +163,8 @@ class ConfigPanel extends PluginPanel
 		ExternalPluginManager externalPluginManager,
 		ColorPickerManager colorPickerManager,
 		Provider<NotificationPanel> notificationPanelProvider,
-		Provider<FontPanel> fontPanelProvider
+		Provider<FontPanel> fontPanelProvider,
+		Provider<ConfigPanel> configPanelProvider
 	)
 	{
 		super(false);
@@ -172,6 +176,7 @@ class ConfigPanel extends PluginPanel
 		this.colorPickerManager = colorPickerManager;
 		this.notificationPanelProvider = notificationPanelProvider;
 		this.fontPanelProvider = fontPanelProvider;
+		this.configPanelProvider = configPanelProvider;
 
 		setLayout(new BorderLayout());
 		setBackground(ColorScheme.DARK_GRAY_COLOR);
@@ -254,6 +259,17 @@ class ConfigPanel extends PluginPanel
 		rebuild();
 	}
 
+	void init(PluginConfigurationDescriptor pluginConfig, String sectionKey, String sectionTitle)
+	{
+		assert this.pluginConfig == null;
+		this.pluginConfig = pluginConfig;
+		sectionFilter = sectionKey;
+		title.setText(sectionTitle);
+		title.setForeground(Color.WHITE);
+		pluginToggle.setVisible(false);
+		rebuild();
+	}
+
 	private void toggleSection(ConfigSectionDescriptor csd, JButton button, JPanel contents)
 	{
 		boolean newState = !contents.isVisible();
@@ -269,6 +285,21 @@ class ConfigPanel extends PluginPanel
 		mainPanel.removeAll();
 
 		ConfigDescriptor cd = pluginConfig.getConfigDescriptor();
+
+		if (sectionFilter != null)
+		{
+			cd.getItems().stream()
+				.filter(cid -> !cid.getItem().hidden() && sectionFilter.equals(cid.getItem().section()))
+				.sorted((a, b) -> ComparisonChain.start()
+					.compare(
+						a.getItem().submenuPosition() >= 0 ? a.getItem().submenuPosition() : a.getItem().position(),
+						b.getItem().submenuPosition() >= 0 ? b.getItem().submenuPosition() : b.getItem().position())
+					.compare(a.getItem().name(), b.getItem().name())
+					.result())
+				.forEach(cid -> mainPanel.add(buildItem(cd, cid)));
+			revalidate();
+			return;
+		}
 
 		final Map<String, JPanel> sectionWidgets = new HashMap<>();
 		final Map<ConfigObject, JPanel> topLevelPanels = new TreeMap<>((a, b) ->
@@ -337,6 +368,21 @@ class ConfigPanel extends PluginPanel
 			topLevelPanels.put(csd, section);
 		}
 
+		// Sections claimed by an opensSubmenu boolean render in a sub-panel, not inline.
+		final Set<String> submenuKeys = new HashSet<>();
+		for (ConfigItemDescriptor cid : cd.getItems())
+		{
+			String os = cid.getItem().opensSubmenu();
+			if (!os.isEmpty())
+			{
+				submenuKeys.add(os);
+			}
+		}
+		// Drop section panels (and their entries in topLevelPanels) for submenu sections
+		topLevelPanels.entrySet().removeIf(e -> e.getKey() instanceof ConfigSectionDescriptor
+			&& submenuKeys.contains(((ConfigSectionDescriptor) e.getKey()).getKey()));
+		submenuKeys.forEach(sectionWidgets::remove);
+
 		for (ConfigItemDescriptor cid : cd.getItems())
 		{
 			if (cid.getItem().hidden())
@@ -344,67 +390,39 @@ class ConfigPanel extends PluginPanel
 				continue;
 			}
 
-			JPanel item = new JPanel();
-			item.setLayout(new BorderLayout());
-			item.setMinimumSize(new Dimension(PANEL_WIDTH, 0));
-			String name = cid.getItem().name();
-			JLabel configEntryName = new JLabel(name);
-			configEntryName.setForeground(Color.WHITE);
-			String description = cid.getItem().description();
-			if (!"".equals(description))
+			// Items belonging to a submenu are rendered in the sub-panel, not here
+			if (submenuKeys.contains(cid.getItem().section()))
 			{
-				configEntryName.setToolTipText("<html>" + name + ":<br>" + description + "</html>");
+				continue;
 			}
-			PluginListItem.addLabelPopupMenu(configEntryName, createResetMenuItem(pluginConfig, cid));
-			item.add(configEntryName, BorderLayout.CENTER);
 
-			if (cid.getType() == boolean.class)
+			JPanel item = buildItem(cd, cid);
+
+			// If this is a boolean opener for a submenu, attach a gear button next to its checkbox.
+			String opensSubmenu = cid.getItem().opensSubmenu();
+			if (!opensSubmenu.isEmpty() && cid.getType() == boolean.class)
 			{
-				item.add(createCheckbox(cd, cid), BorderLayout.EAST);
-			}
-			else if (cid.getType() == int.class)
-			{
-				item.add(createIntSpinner(cd, cid), BorderLayout.EAST);
-			}
-			else if (cid.getType() == double.class)
-			{
-				item.add(createDoubleSpinner(cd, cid), BorderLayout.EAST);
-			}
-			else if (cid.getType() == String.class)
-			{
-				item.add(createTextField(cd, cid), BorderLayout.SOUTH);
-			}
-			else if (cid.getType() == Color.class)
-			{
-				item.add(createColorPicker(cd, cid), BorderLayout.EAST);
-			}
-			else if (cid.getType() == Dimension.class)
-			{
-				item.add(createDimension(cd, cid), BorderLayout.EAST);
-			}
-			else if (cid.getType() instanceof Class && ((Class<?>) cid.getType()).isEnum())
-			{
-				item.add(createComboBox(cd, cid), BorderLayout.EAST);
-			}
-			else if (cid.getType() == Keybind.class || cid.getType() == ModifierlessKeybind.class)
-			{
-				item.add(createKeybind(cd, cid), BorderLayout.EAST);
-			}
-			else if (cid.getType() == Notification.class)
-			{
-				item.add(createNotification(cd, cid), BorderLayout.EAST);
-			}
-			else if (cid.getType() == FontType.class)
-			{
-				item.add(createFont(cd, cid), BorderLayout.EAST);
-			}
-			else if (cid.getType() instanceof ParameterizedType)
-			{
-				ParameterizedType parameterizedType = (ParameterizedType) cid.getType();
-				if (parameterizedType.getRawType() == Set.class)
+				JCheckBox checkbox = (JCheckBox) ((BorderLayout) item.getLayout()).getLayoutComponent(BorderLayout.EAST);
+				item.remove(checkbox);
+
+				JButton openButton = new JButton(CONFIG_ICON);
+				SwingUtil.removeButtonDecorations(openButton);
+				openButton.setPreferredSize(new Dimension(25, 0));
+				openButton.setToolTipText("Configure " + cid.getItem().name());
+				openButton.addActionListener(l ->
 				{
-					item.add(createList(cd, cid), BorderLayout.EAST);
-				}
+					ConfigPanel sub = configPanelProvider.get();
+					sub.init(pluginConfig, opensSubmenu, cid.getItem().name());
+					pluginList.getMuxer().pushState(sub);
+				});
+				openButton.setVisible(checkbox.isSelected());
+				checkbox.addActionListener(l -> openButton.setVisible(checkbox.isSelected()));
+
+				JPanel controls = new JPanel(new BorderLayout());
+				controls.setOpaque(false);
+				controls.add(openButton, BorderLayout.WEST);
+				controls.add(checkbox, BorderLayout.EAST);
+				item.add(controls, BorderLayout.EAST);
 			}
 
 			JPanel section = sectionWidgets.get(cid.getItem().section());
@@ -448,6 +466,74 @@ class ConfigPanel extends PluginPanel
 		mainPanel.add(backButton);
 
 		revalidate();
+	}
+
+	private JPanel buildItem(ConfigDescriptor cd, ConfigItemDescriptor cid)
+	{
+		JPanel item = new JPanel();
+		item.setLayout(new BorderLayout());
+		item.setMinimumSize(new Dimension(PANEL_WIDTH, 0));
+		String name = cid.getItem().name();
+		JLabel configEntryName = new JLabel(name);
+		configEntryName.setForeground(Color.WHITE);
+		String description = cid.getItem().description();
+		if (!"".equals(description))
+		{
+			configEntryName.setToolTipText("<html>" + name + ":<br>" + description + "</html>");
+		}
+		PluginListItem.addLabelPopupMenu(configEntryName, createResetMenuItem(pluginConfig, cid));
+		item.add(configEntryName, BorderLayout.CENTER);
+
+		if (cid.getType() == boolean.class)
+		{
+			item.add(createCheckbox(cd, cid), BorderLayout.EAST);
+		}
+		else if (cid.getType() == int.class)
+		{
+			item.add(createIntSpinner(cd, cid), BorderLayout.EAST);
+		}
+		else if (cid.getType() == double.class)
+		{
+			item.add(createDoubleSpinner(cd, cid), BorderLayout.EAST);
+		}
+		else if (cid.getType() == String.class)
+		{
+			item.add(createTextField(cd, cid), BorderLayout.SOUTH);
+		}
+		else if (cid.getType() == Color.class)
+		{
+			item.add(createColorPicker(cd, cid), BorderLayout.EAST);
+		}
+		else if (cid.getType() == Dimension.class)
+		{
+			item.add(createDimension(cd, cid), BorderLayout.EAST);
+		}
+		else if (cid.getType() instanceof Class && ((Class<?>) cid.getType()).isEnum())
+		{
+			item.add(createComboBox(cd, cid), BorderLayout.EAST);
+		}
+		else if (cid.getType() == Keybind.class || cid.getType() == ModifierlessKeybind.class)
+		{
+			item.add(createKeybind(cd, cid), BorderLayout.EAST);
+		}
+		else if (cid.getType() == Notification.class)
+		{
+			item.add(createNotification(cd, cid), BorderLayout.EAST);
+		}
+		else if (cid.getType() == FontType.class)
+		{
+			item.add(createFont(cd, cid), BorderLayout.EAST);
+		}
+		else if (cid.getType() instanceof ParameterizedType)
+		{
+			ParameterizedType parameterizedType = (ParameterizedType) cid.getType();
+			if (parameterizedType.getRawType() == Set.class)
+			{
+				item.add(createList(cd, cid), BorderLayout.EAST);
+			}
+		}
+
+		return item;
 	}
 
 	private JCheckBox createCheckbox(ConfigDescriptor cd, ConfigItemDescriptor cid)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/configsubmenudemo/ConfigSubmenuDemoConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/configsubmenudemo/ConfigSubmenuDemoConfig.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2024, Adam <Adam@sigterm.info>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.configsubmenudemo;
+
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.ConfigSection;
+
+/**
+ * Config interface for the ConfigSubmenu PoC demo plugin.
+ * <p>
+ * Demonstrates all three kinds of top-level groupings:
+ * <ol>
+ *   <li>A plain boolean at the top level</li>
+ *   <li>A classic {@code @ConfigSection} (inline collapsible group)</li>
+ *   <li>A boolean {@code @ConfigItem} with {@link net.runelite.client.config.ConfigItem#opensSubmenu()} that opens a dedicated sub-panel</li>
+ * </ol>
+ */
+@ConfigGroup("configsubmenudemo")
+public interface ConfigSubmenuDemoConfig extends Config
+{
+	// ---- Top-level item (no section / submenu) --------------------------------
+
+	@ConfigItem(
+		keyName = "topLevelEnabled",
+		name = "Top-level toggle",
+		description = "A plain top-level boolean — not inside any section or submenu.",
+		position = 0
+	)
+	default boolean topLevelEnabled()
+	{
+		return true;
+	}
+
+	// ---- Classic inline section -----------------------------------------------
+
+	@ConfigSection(
+		name = "Classic Section",
+		description = "A regular inline section — unchanged behaviour.",
+		position = 1
+	)
+	String classicSection = "classicSection";
+
+	@ConfigItem(
+		keyName = "optionA",
+		name = "Option A",
+		description = "First item in the classic section.",
+		section = "classicSection",
+		position = 0
+	)
+	default boolean optionA()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		keyName = "optionB",
+		name = "Option B",
+		description = "Second item in the classic section.",
+		section = "classicSection",
+		position = 1
+	)
+	default boolean optionB()
+	{
+		return false;
+	}
+
+	// ---- Submenu (opens a dedicated sub-panel) --------------------------------
+	// The boolean opener doubles as a feature toggle: while it's off, the proxy
+	// reports zero values for every item in the sub-panel.
+
+	@ConfigSection(
+		name = "Subpanel Toggle",
+		description = "Grouped toggle for closely related settings.",
+		position = 2
+	)
+	String displayOptions = "displayOptions";
+
+	@ConfigItem(
+		keyName = "displayOptionsEnabled",
+		name = "Subpanel Toggle",
+		description = "Grouped toggle for closely related settings.",
+		position = 2,
+		opensSubmenu = "displayOptions"
+	)
+	default boolean displayOptionsEnabled()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		keyName = "optionC",
+		name = "Option C",
+		description = "First item in the submenu.",
+		section = "displayOptions",
+		submenuPosition = 0
+	)
+	default boolean optionC()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		keyName = "optionD",
+		name = "Option D",
+		description = "Second item in the submenu.",
+		section = "displayOptions",
+		submenuPosition = 1
+	)
+	default boolean optionD()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		keyName = "optionE",
+		name = "Option E",
+		description = "Third item in the submenu.",
+		section = "displayOptions",
+		submenuPosition = 2
+	)
+	default boolean optionE()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		keyName = "optionF",
+		name = "Option F",
+		description = "Fourth item in the submenu.",
+		section = "displayOptions",
+		submenuPosition = 3
+	)
+	default boolean optionF()
+	{
+		return false;
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/configsubmenudemo/ConfigSubmenuDemoOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/configsubmenudemo/ConfigSubmenuDemoOverlay.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2024, Adam <Adam@sigterm.info>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.configsubmenudemo;
+
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Graphics2D;
+import javax.inject.Inject;
+import net.runelite.client.ui.overlay.OverlayPanel;
+import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.components.LineComponent;
+import net.runelite.client.ui.overlay.components.TitleComponent;
+
+/**
+ * Renders the current state of every config value so you can see live that
+ * toggling items in the config panel (including the submenu sub-panel) takes
+ * effect immediately.
+ * <p>
+ * Note that the submenu items (Option C–F) are <em>automatically</em> gated by
+ * the submenu header's checkbox: callers don't AND against the toggle, the
+ * config proxy short-circuits to {@code false} when the submenu is off.
+ */
+class ConfigSubmenuDemoOverlay extends OverlayPanel
+{
+	private final ConfigSubmenuDemoConfig config;
+
+	@Inject
+	private ConfigSubmenuDemoOverlay(ConfigSubmenuDemoPlugin plugin, ConfigSubmenuDemoConfig config)
+	{
+		super(plugin);
+		setPosition(OverlayPosition.TOP_LEFT);
+		this.config = config;
+	}
+
+	@Override
+	public Dimension render(Graphics2D graphics)
+	{
+		if (!config.topLevelEnabled())
+		{
+			return null;
+		}
+
+		panelComponent.getChildren().add(TitleComponent.builder()
+			.text("Submenu Demo")
+			.build());
+
+		addRow("Option A", config.optionA());
+		addRow("Option B", config.optionB());
+		addRow("Option C", config.optionC());
+		addRow("Option D", config.optionD());
+		addRow("Option E", config.optionE());
+		addRow("Option F", config.optionF());
+
+		return super.render(graphics);
+	}
+
+	private void addRow(String label, boolean value)
+	{
+		panelComponent.getChildren().add(LineComponent.builder()
+			.left(label)
+			.right(value ? "on" : "off")
+			.rightColor(value ? Color.GREEN : Color.RED)
+			.build());
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/configsubmenudemo/ConfigSubmenuDemoPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/configsubmenudemo/ConfigSubmenuDemoPlugin.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2024, Adam <Adam@sigterm.info>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.configsubmenudemo;
+
+import com.google.inject.Provides;
+import javax.inject.Inject;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.ui.overlay.OverlayManager;
+
+/**
+ * Throwaway demo plugin for the {@code opensSubmenu} PoC — remove before merging.
+ * <p>
+ * Its only purpose is to give developers an in-game config panel that exercises
+ * the new {@link net.runelite.client.config.ConfigItem#opensSubmenu()} feature:
+ * <ul>
+ *   <li>A top-level boolean item</li>
+ *   <li>A classic {@code @ConfigSection} with two booleans (verifies existing behaviour unchanged)</li>
+ *   <li>A boolean opener with {@code opensSubmenu} pointing to a section with four booleans</li>
+ * </ul>
+ */
+@PluginDescriptor(
+	name = "Submenu Demo",
+	description = "PoC plugin for the opensSubmenu feature — remove before release",
+	tags = {"submenu", "demo", "poc"}
+)
+public class ConfigSubmenuDemoPlugin extends Plugin
+{
+	@Inject
+	private ConfigManager configManager;
+
+	@Inject
+	private OverlayManager overlayManager;
+
+	@Inject
+	private ConfigSubmenuDemoOverlay overlay;
+
+	@Override
+	protected void startUp()
+	{
+		overlayManager.add(overlay);
+	}
+
+	@Override
+	protected void shutDown()
+	{
+		overlayManager.remove(overlay);
+	}
+
+	@Provides
+	ConfigSubmenuDemoConfig provideConfig(ConfigManager configManager)
+	{
+		return configManager.getConfig(ConfigSubmenuDemoConfig.class);
+	}
+}


### PR DESCRIPTION
For Shortest Path, we were recently discussing reworking the config panel and adding some new options to better provide control for some of the teleport options, the POH in particular. We wanted to give the user more fine-grained control, but we couldn't settle on a way to do it in a way that wouldn't create a lot of visual noise in the config panel itself. We would either create a long list of boolean options, which would clog up certain sections or use a multi-select list, which groups the options but doesn't fix the problem of visual noise. In particular, individual options for each available portal (or nexus) teleport arose as a problem. Besides that, there was also no easy way to toggle those sections entirely, except for adding another config option that acts as a gate, which we would then need to add to each individual teleport condition.

I wanted to make a suggestion in the discussion section, but figured it would be easier just to show a proof of concept for the idea that came up during the discussion. 

Inspired by the (somewhat) recent rework of the notification settings, I followed the same example to introduce a config submenu. I slightly reworked the section header to add functionality to function as a submenu toggle. A gear icon gets added, and when clicked, the submenu opens to configure closely related settings. All the settings in the submenu are gated by the checkbox on the main submenu config item at the top level. I've added a small demo plugin that demonstrates its functionality in-game. It's just a panel that shows which config options are checked and shows the top-level toggle enabling/disabling everything.

I played around with introducing a new descriptor to distinguish it more from other config options, but I opted to extend `ConfigItem` instead to keep things simple for a PoC. I tried sticking close to the same logic used for the notification submenu.  I've added `submenuPosition` as a property to `ConfigItem` as well, to visually distinguish it from position, as when reading the config file, I found it to be potentially confusing if `position` goes 9 > 10 > 11 > 1 > 2 > 3 > 12 > 13 > 14. Positions are scoped to the submenu regardless, and the `submenuPosition` will fall back to `position` if not set.

I would love to know if this is something that you would consider. I'm open to any changes that need to be made to get it properly integrated. This is just a quick mock-up of the functionality that we aimed for. While it is of particular value for us, I'm sure there are plenty of plugins that might benefit from it.

Screenshots:
<img width="250" height="226" alt="image" src="https://github.com/user-attachments/assets/09f6f21c-1962-45b6-8e67-cf33978943b1" />

Top level toggle

<img width="255" height="179" alt="image" src="https://github.com/user-attachments/assets/872ca982-4ef0-44bc-a5d7-20251e03145b" />

Sub-menu