### PR TITLE
spellbook: fix leftover state on shutdown and cooldown opacity in reo…

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/ScriptID.java
+++ b/runelite-api/src/main/java/net/runelite/api/ScriptID.java
@@ -462,6 +462,9 @@ public final class ScriptID
 	@ScriptArguments(integer = 12, string = 2)
 	public static final int MAGIC_SPELLBOOK_INITIALISESPELLS = 2616;
 
+	@ScriptArguments(integer = 11)
+	public static final int MAGIC_SPELLBOOK_REDRAW = 2611;
+
 	@ScriptArguments(integer = 2)
 	public static final int MOTHERLODE_HUD_UPDATE = 1634;
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/spellbook/SpellbookPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/spellbook/SpellbookPlugin.java
@@ -38,6 +38,7 @@ import net.runelite.api.ItemComposition;
 import net.runelite.api.ParamID;
 import net.runelite.api.ScriptID;
 import net.runelite.api.events.ScriptCallbackEvent;
+import net.runelite.api.events.ScriptPostFired;
 import net.runelite.api.events.ScriptPreFired;
 import net.runelite.api.events.WidgetDrag;
 import net.runelite.api.gameval.InterfaceID;
@@ -125,7 +126,43 @@ public class SpellbookPlugin extends Plugin
 	protected void shutDown()
 	{
 		clearReoderMenus();
-		clientThread.invokeLater(this::reinitializeSpellbook);
+		clientThread.invokeLater(() ->
+		{
+			resetSpellbookWidgets();
+			reinitializeSpellbook();
+		});
+	}
+
+	private void resetSpellbookWidgets()
+	{
+		reordering = false;
+
+		Widget universe = client.getWidget(InterfaceID.MagicSpellbook.UNIVERSE);
+		if (universe == null)
+		{
+			return;
+		}
+
+		// Remove the red reorder-mode overlay added by createWarning()
+		universe.deleteAllChildren();
+
+		int subSpellbookId = client.getEnum(EnumID.SPELLBOOKS_SUB).getIntValue(client.getVarbitValue(VarbitID.SPELLBOOK));
+		int spellbookId = client.getEnum(subSpellbookId).getIntValue(client.getVarbitValue(VarbitID.SPELLBOOK_SUBLIST));
+		EnumComposition spellbook = client.getEnum(spellbookId);
+		for (int i = 0; i < spellbook.size(); ++i)
+		{
+			ItemComposition spellObj = client.getItemDefinition(spellbook.getIntValue(i));
+			Widget w = client.getWidget(spellObj.getIntValue(ParamID.SPELL_BUTTON));
+			if (w == null)
+			{
+				continue;
+			}
+
+			w.setHidden(false);
+			w.setOpacity(0);
+			w.setAction(HIDE_UNHIDE_OP, null);
+			w.setClickMask(w.getClickMask() & ~(DRAG | DRAG_ON));
+		}
 	}
 
 	@Subscribe
@@ -315,17 +352,9 @@ public class SpellbookPlugin extends Plugin
 			int widgetConfig = w.getClickMask();
 			if (reordering)
 			{
-				if (hidden)
-				{
-					w.setOpacity(100);
-					w.setAction(HIDE_UNHIDE_OP, "Unhide");
-				}
-				else
-				{
-					w.setOpacity(0);
-					w.setAction(HIDE_UNHIDE_OP, "Hide");
-				}
-
+				// Opacity and the Hide/Unhide op are applied later, in onScriptPostFired,
+				// so that scripts which run after spellbookSort (e.g. cooldown rendering)
+				// can't overwrite them.
 				newSpells[numNewSpells++] = spells[i];
 				widgetConfig |= DRAG | DRAG_ON;
 			}
@@ -362,6 +391,34 @@ public class SpellbookPlugin extends Plugin
 
 		System.arraycopy(newSpells, 0, spells, 0, numNewSpells);
 		stack[size - 1] = numSpells = numNewSpells;
+	}
+
+	@Subscribe
+	public void onScriptPostFired(ScriptPostFired event)
+	{
+		if (event.getScriptId() != ScriptID.MAGIC_SPELLBOOK_REDRAW || !reordering)
+		{
+			return;
+		}
+
+		int subSpellbookId = client.getEnum(EnumID.SPELLBOOKS_SUB).getIntValue(client.getVarbitValue(VarbitID.SPELLBOOK));
+		int spellbookId = client.getEnum(subSpellbookId).getIntValue(client.getVarbitValue(VarbitID.SPELLBOOK_SUBLIST));
+
+		EnumComposition spellbook = client.getEnum(spellbookId);
+		for (int i = 0; i < spellbook.size(); ++i)
+		{
+			int spellObjId = spellbook.getIntValue(i);
+			ItemComposition spellObj = client.getItemDefinition(spellObjId);
+			Widget w = client.getWidget(spellObj.getIntValue(ParamID.SPELL_BUTTON));
+			if (w == null || w.isSelfHidden())
+			{
+				continue;
+			}
+
+			boolean hidden = isHidden(spellbookId, spellObjId);
+			w.setOpacity(hidden ? 100 : 0);
+			w.setAction(HIDE_UNHIDE_OP, hidden ? "Unhide" : "Hide");
+		}
 	}
 
 	private void createWarning(boolean unlocked)


### PR DESCRIPTION
…rder mode

Two bugs (#19572):

- shutDown() only triggered a vanilla reinitialise, which doesn't clear the per-widget state the plugin had applied (opacity, Hide/Unhide op, DRAG|DRAG_ON click mask) or the red reorder-mode warning rectangle added as a child of the spellbook universe widget. Add an explicit reset pass over every spell widget in the current spellbook before reinitialising.

- In reorder mode, opacity and the Hide/Unhide op were written from the spellbookSort callback, which fires mid-redraw. Subsequent scripts (cooldown rendering) could then overwrite the opacity, causing hidden-but-on-cooldown spells to render fully visible. Move the opacity/action writes to a ScriptPostFired handler keyed on MAGIC_SPELLBOOK_REDRAW so nothing in the redraw chain can clobber them.

Adds a MAGIC_SPELLBOOK_REDRAW (2611) constant to ScriptID for the new hook.